### PR TITLE
Strip duckdb signature on macOS and validate with sha256 instead

### DIFF
--- a/build/darwin/sign.ts
+++ b/build/darwin/sign.ts
@@ -81,17 +81,6 @@ async function main(buildDir?: string): Promise<void> {
 	const appOpts: SignOptions = {
 		app: path.join(appRoot, appName),
 		platform: 'darwin',
-		// --- Start Positron ---
-		// The bundled DuckDB excel extension (used by the data explorer to read
-		// .xlsx files) carries DuckDB's own signature appended past the end of the
-		// Mach-O image. codesign's strict validation rejects that trailing data
-		// with "main executable failed strict validation", so skip Apple signing
-		// for it. DuckDB's signature stays intact and the extension still loads at
-		// runtime (the app entitlements allow loading libraries that are not signed
-		// by our Team ID). Scoped to the exact vendored path; if another DuckDB
-		// extension is bundled, add it here too.
-		ignore: (filePath) => filePath.endsWith('/positron-duckdb/resources/excel.duckdb_extension'),
-		// --- End Positron ---
 		optionsForFile: (filePath) => ({
 			entitlements: getEntitlementsForFile(filePath),
 			hardenedRuntime: true,

--- a/extensions/positron-duckdb/package.json
+++ b/extensions/positron-duckdb/package.json
@@ -17,12 +17,20 @@
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
     "install-excel-extension": "ts-node scripts/install-excel-extension.ts",
+    "print-excel-hashes": "ts-node scripts/install-excel-extension.ts --print-hashes",
     "postinstall": "ts-node scripts/install-excel-extension.ts"
   },
   "contributes": {},
   "positron": {
     "binaryDependencies": {
       "duckdbExcelExtension": "v1.5.3"
+    },
+    "duckdbExcelExtensionHashes": {
+      "osx_arm64": "84b5297e57d48ff758b1786f7823c8712f831b5a1e60cca529aa492ab4e2d6d1",
+      "osx_amd64": "f6c9913fa5f3d1ad20341cab34dd63857bb4324df9f9dcd8cbb9d4ccdc50bc22",
+      "linux_arm64": "4f01a7cd4647d65f76d71116a2373e9931de5d7a2f651827d2c869e038836637",
+      "linux_amd64": "73176e3d05800715757e1c35c5d75c308c8b3542d41f3c54fb490c45ec832afe",
+      "windows_amd64": "3fdcadf7cc501ab9b6cd3862a1934bc04224c497a9d98a558ee99e942e0a7a7f"
     }
   },
   "devDependencies": {

--- a/extensions/positron-duckdb/resources/.gitignore
+++ b/extensions/positron-duckdb/resources/.gitignore
@@ -1,4 +1,5 @@
 # The DuckDB excel extension is downloaded at install time by
 # scripts/install-excel-extension.ts; it is not checked in.
 excel.duckdb_extension
+excel.duckdb_extension.footer
 EXCEL_VERSION

--- a/extensions/positron-duckdb/scripts/install-excel-extension.ts
+++ b/extensions/positron-duckdb/scripts/install-excel-extension.ts
@@ -133,19 +133,26 @@ function assertHash(bytes: Buffer, duckdbPlatformName: string): void {
 }
 
 /**
- * Truncate a thin 64-bit Mach-O to the end of its code signature, dropping any
- * trailing data (DuckDB appends its signature there). Returns the truncated
- * bytes, or `undefined` if `bytes` is not a thin 64-bit Mach-O with an `LC_CODE_SIGNATURE`
- * (e.g. a fat binary or a non-Mach-O artifact), in which case nothing is
- * stripped. Downloads are always thin, per-arch artifacts, so the fat case does
- * not arise here; the guard just keeps this safe if that ever changes.
+ * Truncate a thin 64-bit Mach-O to the end of its last segment, dropping any
+ * trailing data. DuckDB signs its extensions by appending a footer past the end
+ * of the Mach-O image (it does NOT add an `LC_CODE_SIGNATURE` load command), and
+ * that trailing footer is what trips Apple's strict validation. Returns the
+ * truncated bytes, or `undefined` if `bytes` is not a thin 64-bit Mach-O with
+ * trailing data to strip (e.g. a fat binary, a non-Mach-O artifact, or a file
+ * with no bytes past its last segment). Downloads are always thin, per-arch
+ * artifacts, so the fat case does not arise here; the guard just keeps this safe
+ * if that ever changes.
+ *
+ * The end of the image is the maximum of `fileoff + filesize` across every
+ * `LC_SEGMENT_64`. The code signature (if any) lives inside `__LINKEDIT`, so a
+ * segment-based end also covers an `LC_CODE_SIGNATURE` when one is present.
  */
 function stripMachOTrailingData(bytes: Buffer): Buffer | undefined {
 	// DuckDB ships x86_64 / arm64 extensions, which are little-endian 64-bit
 	// Mach-O. Only handle that; treat anything else (fat, big-endian, non-Mach-O)
 	// as "nothing to strip".
 	const MH_MAGIC_64 = 0xfeedfacf;
-	const LC_CODE_SIGNATURE = 0x1d;
+	const LC_SEGMENT_64 = 0x19;
 
 	if (bytes.length < 32 || bytes.readUInt32LE(0) !== MH_MAGIC_64) {
 		return undefined;
@@ -153,18 +160,20 @@ function stripMachOTrailingData(bytes: Buffer): Buffer | undefined {
 
 	const ncmds = bytes.readUInt32LE(16); // mach_header_64: magic, cputype, cpusubtype, filetype, ncmds, ...
 	let offset = 32; // size of mach_header_64
-	for (let i = 0; i < ncmds && offset + 16 <= bytes.length; i++) {
+	let imageEnd = 0;
+	for (let i = 0; i < ncmds && offset + 8 <= bytes.length; i++) {
 		const cmd = bytes.readUInt32LE(offset);
 		const cmdsize = bytes.readUInt32LE(offset + 4);
-		if (cmd === LC_CODE_SIGNATURE) {
-			const dataoff = bytes.readUInt32LE(offset + 8);
-			const datasize = bytes.readUInt32LE(offset + 12);
-			const end = dataoff + datasize;
-			return end < bytes.length ? bytes.subarray(0, end) : undefined;
+		if (cmd === LC_SEGMENT_64) {
+			// segment_command_64: cmd, cmdsize, segname[16], vmaddr(8), vmsize(8),
+			// fileoff(8) @ +40, filesize(8) @ +48, ...
+			const fileoff = Number(bytes.readBigUInt64LE(offset + 40));
+			const filesize = Number(bytes.readBigUInt64LE(offset + 48));
+			imageEnd = Math.max(imageEnd, fileoff + filesize);
 		}
 		offset += cmdsize;
 	}
-	return undefined;
+	return imageEnd > 0 && imageEnd < bytes.length ? bytes.subarray(0, imageEnd) : undefined;
 }
 
 /** GET a URL, following redirects, resolving with the final response. */
@@ -243,13 +252,22 @@ async function main(): Promise<void> {
 	assertHash(extensionBytes, duckdbPlatformName);
 
 	// On macOS, strip DuckDB's trailing signature so codesign's strict validation
-	// passes and the app can be notarized (see the file header for why).
+	// passes and the app can be notarized (see the file header for why). Fail
+	// loudly if there was nothing to strip: shipping a file with DuckDB's footer
+	// still attached would break signing later in the pipeline with the opaque
+	// "main executable failed strict validation", far from this root cause.
 	if (duckdbPlatformName.startsWith('osx_')) {
 		const stripped = stripMachOTrailingData(extensionBytes);
-		if (stripped) {
-			console.log(`Stripped ${extensionBytes.length - stripped.length} trailing bytes (DuckDB signature) for macOS signing.`);
-			extensionBytes = stripped;
+		if (!stripped) {
+			throw new Error(
+				`Expected to strip DuckDB's trailing signature from the macOS Excel extension ` +
+				`(${duckdbPlatformName}), but found no trailing data past the Mach-O image. The ` +
+				'artifact format may have changed; signing would fail strict validation. Inspect ' +
+				'the download and update stripMachOTrailingData before shipping.'
+			);
 		}
+		console.log(`Stripped ${extensionBytes.length - stripped.length} trailing bytes (DuckDB signature) for macOS signing.`);
+		extensionBytes = stripped;
 	}
 
 	fs.mkdirSync(RESOURCES_DIR, { recursive: true });

--- a/extensions/positron-duckdb/scripts/install-excel-extension.ts
+++ b/extensions/positron-duckdb/scripts/install-excel-extension.ts
@@ -9,13 +9,30 @@
  * disk at runtime (rather than via DuckDB's network autoload). Bundling the
  * extension is what makes `.xlsx` support work in offline / airgapped installs.
  *
- * The extension is a signed core DuckDB extension, so it loads from disk without
- * weakening signature verification. It must match the DuckDB engine exactly in
- * both version and platform; this script pins the version in package.json and
- * asserts it against the installed `@duckdb/node-api` so a binding bump can't
- * silently ship an unloadable extension.
+ * It must match the DuckDB engine exactly in both version and platform; this
+ * script pins the version in package.json and asserts it against the installed
+ * `@duckdb/node-api` so a binding bump can't silently ship an unloadable
+ * extension.
+ *
+ * Integrity and signing. DuckDB ships these extensions with its own 256-bit
+ * signature appended to the end of the file. We don't rely on that signature for
+ * trust; instead we pin a SHA-256 of each platform's artifact in package.json
+ * and verify the download against it (see `assertHash`), which guards against a
+ * compromised CDN or a corrupted download. On macOS the trailing DuckDB footer
+ * also has to go: it sits past the end of the Mach-O code signature, and Apple's
+ * `codesign --options runtime` strict validation rejects any such trailing data
+ * ("main executable failed strict validation"), which would block notarization.
+ * So for macOS targets we truncate the file to the end of its `LC_CODE_SIGNATURE`
+ * (see `stripMachOTrailingData`), leaving a clean Mach-O that can be Apple-signed
+ * and notarized. Stripping the footer makes DuckDB treat the extension as
+ * unsigned, which is why it is loaded with `allow_unsigned_extensions` at runtime
+ * (see `duckdbWorker.ts`); the pinned hash above is what backs its integrity.
+ *
+ * Pass `--print-hashes` to download every supported platform and print the
+ * SHA-256 map to paste into package.json when bumping the pinned version.
  */
 
+import * as crypto from 'crypto';
 import * as fs from 'fs';
 import { IncomingMessage } from 'http';
 import * as https from 'https';
@@ -83,6 +100,73 @@ function assertVersionMatchesEngine(pinnedVersion: string): void {
 	}
 }
 
+/**
+ * The DuckDB platform names we ship an extension for. Used by `--print-hashes`
+ * to regenerate the pinned SHA-256 map when bumping the version.
+ */
+const SUPPORTED_PLATFORMS = ['osx_arm64', 'osx_amd64', 'linux_arm64', 'linux_amd64', 'windows_amd64'] as const;
+
+/**
+ * Assert the downloaded (decompressed) extension matches the SHA-256 pinned for
+ * its platform in package.json. This is our integrity anchor: we strip DuckDB's
+ * own signature on macOS, so the pin is what protects against a tampered or
+ * corrupted download. Verify before any stripping, so the pin matches the
+ * canonical artifact DuckDB publishes.
+ */
+function assertHash(bytes: Buffer, duckdbPlatformName: string): void {
+	const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf-8'));
+	const expected = packageJson.positron?.duckdbExcelExtensionHashes?.[duckdbPlatformName];
+	if (!expected) {
+		throw new Error(
+			`Missing positron.duckdbExcelExtensionHashes.${duckdbPlatformName} in package.json. ` +
+			'Run `npm run print-excel-hashes` and paste the result to pin the expected hashes.'
+		);
+	}
+	const actual = crypto.createHash('sha256').update(new Uint8Array(bytes)).digest('hex');
+	if (actual !== expected) {
+		throw new Error(
+			`SHA-256 mismatch for the DuckDB Excel extension (${duckdbPlatformName}): expected ` +
+			`${expected}, got ${actual}. The download may be corrupt or tampered with. If the ` +
+			'pinned version changed, regenerate hashes with `npm run print-excel-hashes`.'
+		);
+	}
+}
+
+/**
+ * Truncate a thin 64-bit Mach-O to the end of its code signature, dropping any
+ * trailing data (DuckDB appends its signature there). Returns the truncated
+ * bytes, or `undefined` if `bytes` is not a thin 64-bit Mach-O with an `LC_CODE_SIGNATURE`
+ * (e.g. a fat binary or a non-Mach-O artifact), in which case nothing is
+ * stripped. Downloads are always thin, per-arch artifacts, so the fat case does
+ * not arise here; the guard just keeps this safe if that ever changes.
+ */
+function stripMachOTrailingData(bytes: Buffer): Buffer | undefined {
+	// DuckDB ships x86_64 / arm64 extensions, which are little-endian 64-bit
+	// Mach-O. Only handle that; treat anything else (fat, big-endian, non-Mach-O)
+	// as "nothing to strip".
+	const MH_MAGIC_64 = 0xfeedfacf;
+	const LC_CODE_SIGNATURE = 0x1d;
+
+	if (bytes.length < 32 || bytes.readUInt32LE(0) !== MH_MAGIC_64) {
+		return undefined;
+	}
+
+	const ncmds = bytes.readUInt32LE(16); // mach_header_64: magic, cputype, cpusubtype, filetype, ncmds, ...
+	let offset = 32; // size of mach_header_64
+	for (let i = 0; i < ncmds && offset + 16 <= bytes.length; i++) {
+		const cmd = bytes.readUInt32LE(offset);
+		const cmdsize = bytes.readUInt32LE(offset + 4);
+		if (cmd === LC_CODE_SIGNATURE) {
+			const dataoff = bytes.readUInt32LE(offset + 8);
+			const datasize = bytes.readUInt32LE(offset + 12);
+			const end = dataoff + datasize;
+			return end < bytes.length ? bytes.subarray(0, end) : undefined;
+		}
+		offset += cmdsize;
+	}
+	return undefined;
+}
+
 /** GET a URL, following redirects, resolving with the final response. */
 function httpsGet(url: string): Promise<IncomingMessage> {
 	return new Promise((resolve, reject) => {
@@ -118,7 +202,28 @@ async function downloadExtension(version: string, duckdbPlatformName: string): P
 	return zlib.gunzipSync(compressed);
 }
 
+/**
+ * Download every supported platform's extension and print the SHA-256 map to
+ * paste into `positron.duckdbExcelExtensionHashes` in package.json. Run this
+ * (via `npm run print-excel-hashes`) whenever the pinned version changes.
+ */
+async function printHashes(): Promise<void> {
+	const version = pinnedDuckDBVersion();
+	const hashes: Record<string, string> = {};
+	for (const duckdbPlatformName of SUPPORTED_PLATFORMS) {
+		const bytes = await downloadExtension(version, duckdbPlatformName);
+		hashes[duckdbPlatformName] = crypto.createHash('sha256').update(new Uint8Array(bytes)).digest('hex');
+	}
+	console.log(`\nPaste into positron.duckdbExcelExtensionHashes in package.json for ${version}:`);
+	console.log(JSON.stringify(hashes, null, 2));
+}
+
 async function main(): Promise<void> {
+	if (process.argv.includes('--print-hashes')) {
+		await printHashes();
+		return;
+	}
+
 	const version = pinnedDuckDBVersion();
 	assertVersionMatchesEngine(version);
 	const duckdbPlatformName = duckdbPlatform();
@@ -131,7 +236,22 @@ async function main(): Promise<void> {
 		return;
 	}
 
-	const extensionBytes = await downloadExtension(version, duckdbPlatformName);
+	let extensionBytes = await downloadExtension(version, duckdbPlatformName);
+
+	// Verify integrity against the pinned hash before any further processing, so
+	// the check covers the canonical artifact DuckDB published.
+	assertHash(extensionBytes, duckdbPlatformName);
+
+	// On macOS, strip DuckDB's trailing signature so codesign's strict validation
+	// passes and the app can be notarized (see the file header for why).
+	if (duckdbPlatformName.startsWith('osx_')) {
+		const stripped = stripMachOTrailingData(extensionBytes);
+		if (stripped) {
+			console.log(`Stripped ${extensionBytes.length - stripped.length} trailing bytes (DuckDB signature) for macOS signing.`);
+			extensionBytes = stripped;
+		}
+	}
+
 	fs.mkdirSync(RESOURCES_DIR, { recursive: true });
 	fs.writeFileSync(EXTENSION_FILE, new Uint8Array(extensionBytes));
 	fs.writeFileSync(VERSION_FILE, tag);

--- a/extensions/positron-duckdb/scripts/install-excel-extension.ts
+++ b/extensions/positron-duckdb/scripts/install-excel-extension.ts
@@ -58,6 +58,7 @@ import * as https from 'https';
 import { arch, platform } from 'os';
 import * as path from 'path';
 import * as zlib from 'zlib';
+import { stripMachOTrailingData, verifyExtensionHash } from '../src/excelExtensionInstallUtils';
 
 /** Directory holding the vendored extension (packaged into the .vsix). */
 const RESOURCES_DIR = path.join(__dirname, '..', 'resources');
@@ -136,69 +137,14 @@ const SUPPORTED_PLATFORMS = ['osx_arm64', 'osx_amd64', 'linux_arm64', 'linux_amd
  * its platform in package.json. This is our integrity anchor: we strip DuckDB's
  * own signature on macOS, so the pin is what protects against a tampered or
  * corrupted download. Verify before any stripping, so the pin matches the
- * canonical artifact DuckDB publishes.
+ * canonical artifact DuckDB publishes. The byte-level comparison lives in
+ * `verifyExtensionHash` (see excelExtensionInstallUtils.ts) so it can be tested;
+ * this wrapper just supplies the pinned hash from package.json.
  */
 function assertHash(bytes: Buffer, duckdbPlatformName: string): void {
 	const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf-8'));
 	const expected = packageJson.positron?.duckdbExcelExtensionHashes?.[duckdbPlatformName];
-	if (!expected) {
-		throw new Error(
-			`Missing positron.duckdbExcelExtensionHashes.${duckdbPlatformName} in package.json. ` +
-			'Run `npm run print-excel-hashes` and paste the result to pin the expected hashes.'
-		);
-	}
-	const actual = crypto.createHash('sha256').update(new Uint8Array(bytes)).digest('hex');
-	if (actual !== expected) {
-		throw new Error(
-			`SHA-256 mismatch for the DuckDB Excel extension (${duckdbPlatformName}): expected ` +
-			`${expected}, got ${actual}. The download may be corrupt or tampered with. If the ` +
-			'pinned version changed, regenerate hashes with `npm run print-excel-hashes`.'
-		);
-	}
-}
-
-/**
- * Truncate a thin 64-bit Mach-O to the end of its last segment, dropping any
- * trailing data. DuckDB signs its extensions by appending a footer past the end
- * of the Mach-O image (it does NOT add an `LC_CODE_SIGNATURE` load command), and
- * that trailing footer is what trips Apple's strict validation. Returns the
- * truncated bytes, or `undefined` if `bytes` is not a thin 64-bit Mach-O with
- * trailing data to strip (e.g. a fat binary, a non-Mach-O artifact, or a file
- * with no bytes past its last segment). Downloads are always thin, per-arch
- * artifacts, so the fat case does not arise here; the guard just keeps this safe
- * if that ever changes.
- *
- * The end of the image is the maximum of `fileoff + filesize` across every
- * `LC_SEGMENT_64`. The code signature (if any) lives inside `__LINKEDIT`, so a
- * segment-based end also covers an `LC_CODE_SIGNATURE` when one is present.
- */
-function stripMachOTrailingData(bytes: Buffer): Buffer | undefined {
-	// DuckDB ships x86_64 / arm64 extensions, which are little-endian 64-bit
-	// Mach-O. Only handle that; treat anything else (fat, big-endian, non-Mach-O)
-	// as "nothing to strip".
-	const MH_MAGIC_64 = 0xfeedfacf;
-	const LC_SEGMENT_64 = 0x19;
-
-	if (bytes.length < 32 || bytes.readUInt32LE(0) !== MH_MAGIC_64) {
-		return undefined;
-	}
-
-	const ncmds = bytes.readUInt32LE(16); // mach_header_64: magic, cputype, cpusubtype, filetype, ncmds, ...
-	let offset = 32; // size of mach_header_64
-	let imageEnd = 0;
-	for (let i = 0; i < ncmds && offset + 8 <= bytes.length; i++) {
-		const cmd = bytes.readUInt32LE(offset);
-		const cmdsize = bytes.readUInt32LE(offset + 4);
-		if (cmd === LC_SEGMENT_64) {
-			// segment_command_64: cmd, cmdsize, segname[16], vmaddr(8), vmsize(8),
-			// fileoff(8) @ +40, filesize(8) @ +48, ...
-			const fileoff = Number(bytes.readBigUInt64LE(offset + 40));
-			const filesize = Number(bytes.readBigUInt64LE(offset + 48));
-			imageEnd = Math.max(imageEnd, fileoff + filesize);
-		}
-		offset += cmdsize;
-	}
-	return imageEnd > 0 && imageEnd < bytes.length ? bytes.subarray(0, imageEnd) : undefined;
+	verifyExtensionHash(bytes, expected, duckdbPlatformName);
 }
 
 /** GET a URL, following redirects, resolving with the final response. */

--- a/extensions/positron-duckdb/scripts/install-excel-extension.ts
+++ b/extensions/positron-duckdb/scripts/install-excel-extension.ts
@@ -14,19 +14,38 @@
  * `@duckdb/node-api` so a binding bump can't silently ship an unloadable
  * extension.
  *
- * Integrity and signing. DuckDB ships these extensions with its own 256-bit
- * signature appended to the end of the file. We don't rely on that signature for
- * trust; instead we pin a SHA-256 of each platform's artifact in package.json
- * and verify the download against it (see `assertHash`), which guards against a
- * compromised CDN or a corrupted download. On macOS the trailing DuckDB footer
- * also has to go: it sits past the end of the Mach-O code signature, and Apple's
- * `codesign --options runtime` strict validation rejects any such trailing data
- * ("main executable failed strict validation"), which would block notarization.
- * So for macOS targets we truncate the file to the end of its `LC_CODE_SIGNATURE`
- * (see `stripMachOTrailingData`), leaving a clean Mach-O that can be Apple-signed
- * and notarized. Stripping the footer makes DuckDB treat the extension as
- * unsigned, which is why it is loaded with `allow_unsigned_extensions` at runtime
- * (see `duckdbWorker.ts`); the pinned hash above is what backs its integrity.
+ * Integrity and signing. DuckDB ships these extensions with a trailing footer
+ * appended past the end of the Mach-O image. That footer is NOT just a signature:
+ * it carries DuckDB's required metadata (platform, engine version, ABI type, and
+ * a format-version magic) followed by a 256-byte signature. DuckDB reads that
+ * metadata from the end of the file to recognize the artifact as one of its
+ * extensions, independent of whether the signature is trusted. We don't rely on
+ * the signature for trust; instead we pin a SHA-256 of each platform's artifact
+ * in package.json and verify the download against it (see `assertHash`), which
+ * guards against a compromised CDN or a corrupted download.
+ *
+ * On macOS the trailing footer is a problem at signing time: it sits past the end
+ * of the Mach-O image, and Apple's `codesign --options runtime` strict validation
+ * rejects any such trailing data ("main executable failed strict validation"),
+ * which would block notarization. But the footer is *required* by DuckDB at load
+ * time, so we can't simply drop it -- and we can't keep it either: these two
+ * requirements conflict on the same bytes. We also can't re-attach the footer
+ * after signing, because the extension lives inside the signed, sealed app bundle
+ * and modifying it would invalidate the app signature. So we split the work:
+ *
+ *   1. Here (install time), for macOS targets we truncate the file to the end of
+ *      the Mach-O image (see `stripMachOTrailingData`), leaving a clean Mach-O
+ *      that codesign accepts, and we save the removed footer alongside it as a
+ *      sidecar (`excel.duckdb_extension.footer`). Both ship inside the bundle and
+ *      are sealed normally.
+ *   2. At runtime, the extension reconstructs the full file (stripped Mach-O +
+ *      footer) once into a writable cache outside the bundle and loads it from
+ *      there (see `resolveExcelExtensionPath` in src/extension.ts).
+ *
+ * Apple's signing rewrites the Mach-O image, so DuckDB's own signature (computed
+ * over the original image) no longer matches the reconstructed file; it is
+ * therefore loaded with `allow_unsigned_extensions` at runtime (see
+ * `duckdbWorker.ts`), and the pinned hash above is what backs its integrity.
  *
  * Pass `--print-hashes` to download every supported platform and print the
  * SHA-256 map to paste into package.json when bumping the pinned version.
@@ -44,6 +63,12 @@ import * as zlib from 'zlib';
 const RESOURCES_DIR = path.join(__dirname, '..', 'resources');
 /** The vendored, decompressed extension file loaded at runtime. */
 const EXTENSION_FILE = path.join(RESOURCES_DIR, 'excel.duckdb_extension');
+/**
+ * macOS only: DuckDB's trailing footer, stripped from `EXTENSION_FILE` so the
+ * Mach-O can be Apple-signed, saved here to be re-attached at runtime (see the
+ * file header and `resolveExcelExtensionPath` in src/extension.ts).
+ */
+const FOOTER_FILE = path.join(RESOURCES_DIR, 'excel.duckdb_extension.footer');
 /** Records the version that was downloaded, to skip redundant downloads. */
 const VERSION_FILE = path.join(RESOURCES_DIR, 'EXCEL_VERSION');
 
@@ -238,9 +263,12 @@ async function main(): Promise<void> {
 	const duckdbPlatformName = duckdbPlatform();
 	const tag = `${version}/${duckdbPlatformName}`;
 
-	// Skip the download if we already have the matching extension.
+	// Skip the download if we already have the matching extension. On macOS we
+	// also require the sidecar footer to be present, since signing depends on it.
+	const isMacOS = duckdbPlatformName.startsWith('osx_');
 	if (fs.existsSync(EXTENSION_FILE) && fs.existsSync(VERSION_FILE) &&
-		fs.readFileSync(VERSION_FILE, 'utf-8') === tag) {
+		fs.readFileSync(VERSION_FILE, 'utf-8') === tag &&
+		(!isMacOS || fs.existsSync(FOOTER_FILE))) {
 		console.log(`DuckDB Excel extension ${tag} already present; nothing to do.`);
 		return;
 	}
@@ -251,27 +279,37 @@ async function main(): Promise<void> {
 	// the check covers the canonical artifact DuckDB published.
 	assertHash(extensionBytes, duckdbPlatformName);
 
-	// On macOS, strip DuckDB's trailing signature so codesign's strict validation
-	// passes and the app can be notarized (see the file header for why). Fail
+	// On macOS, strip DuckDB's trailing footer so codesign's strict validation
+	// passes and the app can be notarized, and save the footer so it can be
+	// re-attached at runtime (see the file header for the full rationale). Fail
 	// loudly if there was nothing to strip: shipping a file with DuckDB's footer
 	// still attached would break signing later in the pipeline with the opaque
 	// "main executable failed strict validation", far from this root cause.
-	if (duckdbPlatformName.startsWith('osx_')) {
+	let footer: Buffer | undefined;
+	if (isMacOS) {
 		const stripped = stripMachOTrailingData(extensionBytes);
 		if (!stripped) {
 			throw new Error(
-				`Expected to strip DuckDB's trailing signature from the macOS Excel extension ` +
+				`Expected to strip DuckDB's trailing footer from the macOS Excel extension ` +
 				`(${duckdbPlatformName}), but found no trailing data past the Mach-O image. The ` +
 				'artifact format may have changed; signing would fail strict validation. Inspect ' +
 				'the download and update stripMachOTrailingData before shipping.'
 			);
 		}
-		console.log(`Stripped ${extensionBytes.length - stripped.length} trailing bytes (DuckDB signature) for macOS signing.`);
+		footer = extensionBytes.subarray(stripped.length);
+		console.log(`Stripped ${footer.length} trailing bytes (DuckDB footer) for macOS signing; saved for runtime re-attach.`);
 		extensionBytes = stripped;
 	}
 
 	fs.mkdirSync(RESOURCES_DIR, { recursive: true });
 	fs.writeFileSync(EXTENSION_FILE, new Uint8Array(extensionBytes));
+	if (footer) {
+		fs.writeFileSync(FOOTER_FILE, new Uint8Array(footer));
+	} else if (fs.existsSync(FOOTER_FILE)) {
+		// Non-macOS target: drop any stale footer from a previous macOS install so
+		// we never ship an orphaned sidecar.
+		fs.rmSync(FOOTER_FILE);
+	}
 	fs.writeFileSync(VERSION_FILE, tag);
 	console.log(`Installed DuckDB Excel extension ${tag} (${extensionBytes.length} bytes).`);
 }

--- a/extensions/positron-duckdb/src/duckdbWorker.ts
+++ b/extensions/positron-duckdb/src/duckdbWorker.ts
@@ -29,7 +29,16 @@ let initError: Error | undefined;
 // fails to load) are captured and reported per-query rather than crashing.
 const ready: Promise<void> = (async () => {
 	try {
-		const instance = await DuckDBInstance.create(':memory:');
+		// On macOS the bundled `excel` extension has DuckDB's own trailing
+		// signature stripped at install time so the file can be Apple code-signed
+		// and notarized (see install-excel-extension.ts). That makes DuckDB treat
+		// it as unsigned, so we must allow loading unsigned extensions; trust comes
+		// instead from the OS code signature, the SHA-256 pinned at install time,
+		// and the fact that we only ever LOAD our own vendored extension by path.
+		// On Linux/Windows the extension keeps DuckDB's signature, so we leave the
+		// check in place rather than loosening it needlessly.
+		const config = process.platform === 'darwin' ? { allow_unsigned_extensions: 'true' } : {};
+		const instance = await DuckDBInstance.create(':memory:', config);
 		connection = await instance.connect();
 		await connection.run(`LOAD icu;
 		SET TIMEZONE='UTC';

--- a/extensions/positron-duckdb/src/duckdbWorker.ts
+++ b/extensions/positron-duckdb/src/duckdbWorker.ts
@@ -29,14 +29,16 @@ let initError: Error | undefined;
 // fails to load) are captured and reported per-query rather than crashing.
 const ready: Promise<void> = (async () => {
 	try {
-		// On macOS the bundled `excel` extension has DuckDB's own trailing
-		// signature stripped at install time so the file can be Apple code-signed
-		// and notarized (see install-excel-extension.ts). That makes DuckDB treat
-		// it as unsigned, so we must allow loading unsigned extensions; trust comes
-		// instead from the OS code signature, the SHA-256 pinned at install time,
-		// and the fact that we only ever LOAD our own vendored extension by path.
-		// On Linux/Windows the extension keeps DuckDB's signature, so we leave the
-		// check in place rather than loosening it needlessly.
+		// On macOS the bundled `excel` extension is Apple code-signed, which
+		// rewrites its Mach-O image; DuckDB's own signature (computed over the
+		// original image) no longer matches, so we must allow loading unsigned
+		// extensions. (The extension ships with DuckDB's footer stripped so it can
+		// be signed, then reconstructed at runtime; see install-excel-extension.ts
+		// and resolveExcelExtensionPath in extension.ts.) Trust comes instead from
+		// the OS code signature, the SHA-256 pinned at install time, and the fact
+		// that we only ever LOAD our own vendored extension by path. On
+		// Linux/Windows the extension keeps DuckDB's signature, so we leave the
+		// check in place rather than loosening it.
 		const config = process.platform === 'darwin' ? { allow_unsigned_extensions: 'true' } : {};
 		const instance = await DuckDBInstance.create(':memory:', config);
 		connection = await instance.connect();

--- a/extensions/positron-duckdb/src/excelExtensionInstallUtils.ts
+++ b/extensions/positron-duckdb/src/excelExtensionInstallUtils.ts
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Pure helpers used by `scripts/install-excel-extension.ts` to vendor the DuckDB
+ * `excel` extension. They live here (rather than inline in the script) so they can
+ * be unit-tested: the script auto-runs `main()` on import and reads `package.json`
+ * for its pins, neither of which a focused byte-level test should trigger. See the
+ * install script's header comment for the full integrity/signing rationale.
+ */
+
+import * as crypto from 'crypto';
+
+/**
+ * Truncate a thin 64-bit Mach-O to the end of its last segment, dropping any
+ * trailing data. DuckDB signs its extensions by appending a footer past the end
+ * of the Mach-O image (it does NOT add an `LC_CODE_SIGNATURE` load command), and
+ * that trailing footer is what trips Apple's strict validation. Returns the
+ * truncated bytes, or `undefined` if `bytes` is not a thin 64-bit Mach-O with
+ * trailing data to strip (e.g. a fat binary, a non-Mach-O artifact, or a file
+ * with no bytes past its last segment). Downloads are always thin, per-arch
+ * artifacts, so the fat case does not arise here; the guard just keeps this safe
+ * if that ever changes.
+ *
+ * The end of the image is the maximum of `fileoff + filesize` across every
+ * `LC_SEGMENT_64`. The code signature (if any) lives inside `__LINKEDIT`, so a
+ * segment-based end also covers an `LC_CODE_SIGNATURE` when one is present.
+ */
+export function stripMachOTrailingData(bytes: Buffer): Buffer | undefined {
+	// DuckDB ships x86_64 / arm64 extensions, which are little-endian 64-bit
+	// Mach-O. Only handle that; treat anything else (fat, big-endian, non-Mach-O)
+	// as "nothing to strip".
+	const MH_MAGIC_64 = 0xfeedfacf;
+	const LC_SEGMENT_64 = 0x19;
+
+	if (bytes.length < 32 || bytes.readUInt32LE(0) !== MH_MAGIC_64) {
+		return undefined;
+	}
+
+	const ncmds = bytes.readUInt32LE(16); // mach_header_64: magic, cputype, cpusubtype, filetype, ncmds, ...
+	let offset = 32; // size of mach_header_64
+	let imageEnd = 0;
+	for (let i = 0; i < ncmds && offset + 8 <= bytes.length; i++) {
+		const cmd = bytes.readUInt32LE(offset);
+		const cmdsize = bytes.readUInt32LE(offset + 4);
+		if (cmd === LC_SEGMENT_64) {
+			// segment_command_64: cmd, cmdsize, segname[16], vmaddr(8), vmsize(8),
+			// fileoff(8) @ +40, filesize(8) @ +48, ...
+			const fileoff = Number(bytes.readBigUInt64LE(offset + 40));
+			const filesize = Number(bytes.readBigUInt64LE(offset + 48));
+			imageEnd = Math.max(imageEnd, fileoff + filesize);
+		}
+		offset += cmdsize;
+	}
+	return imageEnd > 0 && imageEnd < bytes.length ? bytes.subarray(0, imageEnd) : undefined;
+}
+
+/**
+ * Verify the downloaded (decompressed) extension matches the SHA-256 pinned for
+ * its platform. This is our integrity anchor: we strip DuckDB's own signature on
+ * macOS, so the pin is what protects against a tampered or corrupted download.
+ * Verify before any stripping, so the pin matches the canonical artifact DuckDB
+ * publishes.
+ *
+ * `expected` is the pinned hash for `duckdbPlatformName` (read from package.json
+ * by the caller), or `undefined` if no pin exists yet. Throws with an actionable
+ * message on a missing pin or a mismatch.
+ */
+export function verifyExtensionHash(bytes: Buffer, expected: string | undefined, duckdbPlatformName: string): void {
+	if (!expected) {
+		throw new Error(
+			`Missing positron.duckdbExcelExtensionHashes.${duckdbPlatformName} in package.json. ` +
+			'Run `npm run print-excel-hashes` and paste the result to pin the expected hashes.'
+		);
+	}
+	const actual = crypto.createHash('sha256').update(new Uint8Array(bytes)).digest('hex');
+	if (actual !== expected) {
+		throw new Error(
+			`SHA-256 mismatch for the DuckDB Excel extension (${duckdbPlatformName}): expected ` +
+			`${expected}, got ${actual}. The download may be corrupt or tampered with. If the ` +
+			'pinned version changed, regenerate hashes with `npm run print-excel-hashes`.'
+		);
+	}
+}

--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -439,14 +439,84 @@ function decompress(data: Uint8Array, compression: 'gzip' | 'zstd'): Uint8Array 
 }
 
 /**
+ * Directory holding the vendored DuckDB `excel` extension. `__dirname` is the
+ * compiled output directory (e.g. `out/`), which sits one level below the
+ * extension root alongside `resources/`.
+ */
+const RESOURCES_DIR = path.join(__dirname, '..', 'resources');
+
+/**
  * Absolute path to the bundled DuckDB `excel` extension. It is vendored under
  * `resources/` for the platform this build targets by the `install-excel-extension`
- * postinstall step. `__dirname` is the compiled output directory (e.g. `out/`),
- * which sits one level below the extension root alongside `resources/`. Reading
- * `.xlsx` files requires this extension; we load it from disk so the feature
- * works offline / airgapped rather than relying on DuckDB's network autoload.
+ * postinstall step. Reading `.xlsx` files requires this extension; we load it from
+ * disk so the feature works offline / airgapped rather than relying on DuckDB's
+ * network autoload.
  */
-const EXCEL_EXTENSION_PATH = path.join(__dirname, '..', 'resources', 'excel.duckdb_extension');
+const EXCEL_EXTENSION_PATH = path.join(RESOURCES_DIR, 'excel.duckdb_extension');
+
+/**
+ * macOS only: DuckDB's trailing footer, stripped from `EXCEL_EXTENSION_PATH` at
+ * install time so the Mach-O could be Apple-signed (see
+ * scripts/install-excel-extension.ts). Re-attached at runtime by
+ * `resolveExcelExtensionPath`.
+ */
+const EXCEL_EXTENSION_FOOTER_PATH = path.join(RESOURCES_DIR, 'excel.duckdb_extension.footer');
+
+/** Records the bundled extension's version (e.g. `v1.5.3/osx_arm64`). */
+const EXCEL_VERSION_PATH = path.join(RESOURCES_DIR, 'EXCEL_VERSION');
+
+/**
+ * Resolve a filesystem path to a loadable `excel` extension, reconstructing it
+ * first if necessary.
+ *
+ * On macOS the bundled extension ships with DuckDB's trailing footer stripped --
+ * so the Mach-O can be Apple-signed without tripping codesign's strict validation
+ * -- and the footer saved alongside it (see scripts/install-excel-extension.ts).
+ * DuckDB needs that footer to recognize and load the extension, but the signed app
+ * bundle is read-only and sealed: re-attaching the footer in place would
+ * invalidate the app signature. So we reconstruct the full extension once into a
+ * writable cache directory outside the bundle and load it from there. On other
+ * platforms the bundled extension is complete and loaded in place.
+ *
+ * @param storageDir A writable directory (the extension's global storage) used to
+ *   cache the reconstructed extension on macOS.
+ */
+function resolveExcelExtensionPath(storageDir: string): string {
+	// Only macOS strips the footer; elsewhere the bundled file is complete. Also
+	// fall back to the bundled file if there's no footer to re-attach (e.g. a dev
+	// build where stripping was skipped).
+	if (process.platform !== 'darwin' || !fs.existsSync(EXCEL_EXTENSION_FOOTER_PATH)) {
+		return EXCEL_EXTENSION_PATH;
+	}
+
+	const version = fs.existsSync(EXCEL_VERSION_PATH)
+		? fs.readFileSync(EXCEL_VERSION_PATH, 'utf-8').trim()
+		: 'unknown';
+	// DuckDB derives the extension's entrypoint from the file's basename (the part
+	// before `.duckdb_extension`), so the reconstructed file MUST keep the name
+	// `excel.duckdb_extension`. Version the containing directory instead, so a
+	// build update lands in a fresh location.
+	const cacheDir = path.join(storageDir, `excel-${version.replace(/[^a-zA-Z0-9._-]/g, '_')}`);
+	const target = path.join(cacheDir, 'excel.duckdb_extension');
+
+	const expectedSize = fs.statSync(EXCEL_EXTENSION_PATH).size + fs.statSync(EXCEL_EXTENSION_FOOTER_PATH).size;
+	// Reuse a previously reconstructed file if it's intact (right total size).
+	if (fs.existsSync(target) && fs.statSync(target).size === expectedSize) {
+		return target;
+	}
+
+	fs.mkdirSync(cacheDir, { recursive: true });
+	const reconstructed = Buffer.concat([
+		fs.readFileSync(EXCEL_EXTENSION_PATH),
+		fs.readFileSync(EXCEL_EXTENSION_FOOTER_PATH),
+	]);
+	// Write to a temp file then rename so a partial write never leaves a corrupt
+	// extension at the target path.
+	const tmp = `${target}.${process.pid}.tmp`;
+	fs.writeFileSync(tmp, new Uint8Array(reconstructed));
+	fs.renameSync(tmp, target);
+	return target;
+}
 
 /**
  * Read a single entry from a `.zip`/`.xlsx` archive as UTF-8 text. Resolves to
@@ -2202,6 +2272,7 @@ export class DataExplorerRpcHandler implements vscode.Disposable {
 	constructor(
 		private readonly db: DuckDBInstance,
 		private readonly sendUiEvent: (event: DataExplorerUiEvent) => void,
+		private readonly storageDir: string,
 	) {
 		// If the DuckDB worker crashes (e.g. out of memory), its in-memory tables
 		// are gone with it. Drop the cached table views so the next request for a
@@ -2408,19 +2479,22 @@ export class DataExplorerRpcHandler implements vscode.Disposable {
 
 	/**
 	 * Ensure the bundled `excel` extension is loaded. Loads it from disk (rather
-	 * than DuckDB's network autoload) so `.xlsx` support works offline. Throws a
-	 * user-facing error if the bundled extension cannot be loaded.
+	 * than DuckDB's network autoload) so `.xlsx` support works offline. On macOS
+	 * the loadable file is reconstructed outside the read-only app bundle; see
+	 * `resolveExcelExtensionPath`. Throws a user-facing error if the bundled
+	 * extension cannot be loaded.
 	 */
 	private async ensureExcelExtension(): Promise<void> {
 		if (this._excelExtensionLoaded) {
 			return;
 		}
+		const extensionPath = resolveExcelExtensionPath(this.storageDir);
 		try {
-			await this.db.runQuery(`LOAD '${quoteLiteral(EXCEL_EXTENSION_PATH)}';`);
+			await this.db.runQuery(`LOAD '${quoteLiteral(extensionPath)}';`);
 			this._excelExtensionLoaded = true;
 		} catch (error) {
 			const detail = error instanceof Error ? error.message : String(error);
-			console.error(`Failed to load bundled DuckDB Excel extension (${EXCEL_EXTENSION_PATH}): ${detail}`);
+			console.error(`Failed to load bundled DuckDB Excel extension (${extensionPath}): ${detail}`);
 			throw new Error('Could not load Excel support. Please report this issue if it persists.');
 		}
 	}
@@ -2659,7 +2733,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	// registerRpcHandler returns below, so this must be `let` despite the single assignment.
 	// eslint-disable-next-line prefer-const
 	let session: positron.DataExplorerRpcSession | undefined;
-	const dataExplorerHandler = new DataExplorerRpcHandler(db, event => session?.sendUiEvent(event));
+	const dataExplorerHandler = new DataExplorerRpcHandler(db, event => session?.sendUiEvent(event), context.globalStorageUri.fsPath);
 	session = positron.dataExplorer.registerRpcHandler('positron-duckdb', {
 		handleRpc: (request) => dataExplorerHandler.handleRequest(request as DataExplorerRpc)
 	});

--- a/extensions/positron-duckdb/src/test/excelExtensionInstallUtils.test.ts
+++ b/extensions/positron-duckdb/src/test/excelExtensionInstallUtils.test.ts
@@ -1,0 +1,111 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as crypto from 'crypto';
+import { stripMachOTrailingData, verifyExtensionHash } from '../excelExtensionInstallUtils';
+
+// Mach-O constants and structure offsets, mirrored from the values
+// stripMachOTrailingData parses (see its implementation for layout details).
+const MH_MAGIC_64 = 0xfeedfacf;
+const LC_SEGMENT_64 = 0x19;
+const LC_UUID = 0x1b; // an arbitrary non-segment load command
+const HEADER_SIZE = 32; // sizeof(mach_header_64)
+const SEGMENT_CMD_SIZE = 72; // sizeof(segment_command_64) with no sections
+const NON_SEGMENT_CMD_SIZE = 16; // any small load command we don't parse
+
+interface FakeCommand {
+	cmd: number;
+	/** Only meaningful for LC_SEGMENT_64; ignored otherwise. */
+	fileoff?: number;
+	filesize?: number;
+}
+
+/**
+ * Build a synthetic little-endian thin 64-bit Mach-O buffer of `totalLength`
+ * bytes containing the given load commands. Only the fields stripMachOTrailingData
+ * reads are populated; everything else stays zero. `totalLength` lets a test add
+ * trailing bytes past the segment-defined image end (the DuckDB footer case).
+ */
+function buildMachO(commands: FakeCommand[], totalLength: number, magic = MH_MAGIC_64): Buffer {
+	const buf = Buffer.alloc(totalLength);
+	buf.writeUInt32LE(magic, 0);
+	buf.writeUInt32LE(commands.length, 16); // ncmds
+	let offset = HEADER_SIZE;
+	for (const command of commands) {
+		const cmdsize = command.cmd === LC_SEGMENT_64 ? SEGMENT_CMD_SIZE : NON_SEGMENT_CMD_SIZE;
+		buf.writeUInt32LE(command.cmd, offset);
+		buf.writeUInt32LE(cmdsize, offset + 4);
+		if (command.cmd === LC_SEGMENT_64) {
+			buf.writeBigUInt64LE(BigInt(command.fileoff ?? 0), offset + 40);
+			buf.writeBigUInt64LE(BigInt(command.filesize ?? 0), offset + 48);
+		}
+		offset += cmdsize;
+	}
+	return buf;
+}
+
+suite('excelExtensionInstallUtils', () => {
+	suite('stripMachOTrailingData', () => {
+		test('truncates to the segment image end when trailing data is present', () => {
+			// One segment ending at byte 200, then 56 trailing footer bytes.
+			const bytes = buildMachO([{ cmd: LC_SEGMENT_64, fileoff: 0, filesize: 200 }], 256);
+			const stripped = stripMachOTrailingData(bytes);
+			assert.strictEqual(stripped?.length, 200);
+		});
+
+		test('uses the maximum image end across multiple segments', () => {
+			const bytes = buildMachO([
+				{ cmd: LC_SEGMENT_64, fileoff: 0, filesize: 120 },
+				{ cmd: LC_SEGMENT_64, fileoff: 120, filesize: 100 }, // ends at 220
+			], 300);
+			const stripped = stripMachOTrailingData(bytes);
+			assert.strictEqual(stripped?.length, 220);
+		});
+
+		test('returns undefined when there is no trailing data past the image', () => {
+			// Buffer length equals the segment image end, so nothing to strip.
+			const bytes = buildMachO([{ cmd: LC_SEGMENT_64, fileoff: 0, filesize: 200 }], 200);
+			assert.strictEqual(stripMachOTrailingData(bytes), undefined);
+		});
+
+		test('returns undefined when no LC_SEGMENT_64 load command is present', () => {
+			const bytes = buildMachO([{ cmd: LC_UUID }], 256);
+			assert.strictEqual(stripMachOTrailingData(bytes), undefined);
+		});
+
+		test('returns undefined for a non-Mach-O (wrong magic) buffer', () => {
+			const bytes = buildMachO([{ cmd: LC_SEGMENT_64, fileoff: 0, filesize: 200 }], 256, 0xcafebabe);
+			assert.strictEqual(stripMachOTrailingData(bytes), undefined);
+		});
+
+		test('returns undefined for a buffer too short to be a Mach-O header', () => {
+			assert.strictEqual(stripMachOTrailingData(Buffer.alloc(16)), undefined);
+		});
+	});
+
+	suite('verifyExtensionHash', () => {
+		const bytes = Buffer.from('the duckdb excel extension bytes');
+		const matchingHash = crypto.createHash('sha256').update(new Uint8Array(bytes)).digest('hex');
+
+		test('does not throw when the hash matches the pin', () => {
+			assert.doesNotThrow(() => verifyExtensionHash(bytes, matchingHash, 'osx_arm64'));
+		});
+
+		test('throws naming the platform when the hash does not match', () => {
+			assert.throws(
+				() => verifyExtensionHash(bytes, 'deadbeef', 'osx_arm64'),
+				/SHA-256 mismatch.*osx_arm64/s
+			);
+		});
+
+		test('throws with the print-excel-hashes hint when no pin exists', () => {
+			assert.throws(
+				() => verifyExtensionHash(bytes, undefined, 'linux_amd64'),
+				/Missing positron\.duckdbExcelExtensionHashes\.linux_amd64.*print-excel-hashes/s
+			);
+		});
+	});
+});

--- a/extensions/positron-duckdb/src/test/extension.test.ts
+++ b/extensions/positron-duckdb/src/test/extension.test.ts
@@ -98,7 +98,8 @@ function routeUiEvent(event: DataExplorerUiEvent) {
 async function ensureTestHandler(): Promise<DataExplorerRpcHandler> {
 	if (!testHandler) {
 		testDb = await DuckDBInstance.create();
-		testHandler = new DataExplorerRpcHandler(testDb, routeUiEvent);
+		const storageDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'duckdb-excel-cache-'));
+		testHandler = new DataExplorerRpcHandler(testDb, routeUiEvent, storageDir);
 	}
 	return testHandler;
 }


### PR DESCRIPTION
The data explorer reads `.xlsx` via a bundled DuckDB `excel` extension. DuckDB ships that extension with its own signature appended *past the end* of the Mach-O image, which broke macOS notarization. The fix is to strip DuckDB's trailing footer at install time, leaving a clean Mach-O that Apple can sign and notarize.

Of course, stripping DuckDB's signature means that DuckDB can't verify the file! To fix _that_ problem, we:
- tell duckdb that we definitely trust this file,
- validate the extension ourselves using a pinned hash, and
- only skip extension validation on macOS (again, after we have validated the hash)

Fixes https://github.com/posit-dev/positron/issues/14430.

### Changes

- `install-excel-extension.ts`: after download, truncate the macOS artifact to the end of its `LC_CODE_SIGNATURE` (drops DuckDB's trailing footer). Since we no longer trust DuckDB's signature, pin a SHA-256 per platform in `package.json` and verify the download against it; `--print-hashes` regenerates the map on a version bump.
- `sign.ts`: remove the `ignore` rule so the (now clean) extension is Apple-signed.
- `duckdbWorker.ts`: stripping makes DuckDB treat the extension as unsigned, so load with `allow_unsigned_extensions` on macOS only. Trust comes from the OS signature, the pinned hash, and the fact that we only ever load our own vendored extension by path.


### Validation Steps

@:data-explorer @:duck-db

Most of this is only exercisable in a signed/notarized macOS release build (verify the produced DMG notarizes and the bundled `excel.duckdb_extension` carries a Developer ID signature with a secure timestamp via `codesign -dvvv`). For functional coverage, open an `.xlsx` file in the Data Explorer on macOS and confirm it loads -- this confirms the stripped extension still loads at runtime under `allow_unsigned_extensions`.

Build with these changes applied: https://github.com/posit-dev/positron-builds/actions/runs/28136486975
