### PR TITLE
ci: auto-inject @:ark tag when ark submodule is bumped

### DIFF
--- a/scripts/pr-tags-parse.sh
+++ b/scripts/pr-tags-parse.sh
@@ -119,6 +119,23 @@ else
 		fi
 	fi
 
+	# Auto-inject @:ark when the ark submodule is bumped.
+	# extensions/positron-r/ark is a gitlink (submodule pointer); it appears
+	# as a single filename entry in the PR files API when the pointer changes.
+	CHANGED_FILES=$(gh api repos/${REPO}/pulls/${PR_NUMBER}/files --paginate \
+		--header "Authorization: token $GITHUB_TOKEN" \
+		--jq '.[].filename' 2>/dev/null || true)
+	if [[ -z "$CHANGED_FILES" ]]; then
+		echo "Warning: could not fetch changed files; skipping @:ark injection."
+	elif echo "$CHANGED_FILES" | grep -qx "extensions/positron-r/ark"; then
+		echo "Ark submodule changed. Injecting @:ark tag."
+		if [[ -n "$TAGS" ]]; then
+			TAGS="$TAGS,@:ark"
+		else
+			TAGS="@:ark"
+		fi
+	fi
+
 	# Output the tags
 	echo "Extracted Tags: $TAGS"
 fi

--- a/scripts/pr-tags-parse.sh
+++ b/scripts/pr-tags-parse.sh
@@ -124,10 +124,10 @@ else
 	# as a single filename entry in the PR files API when the pointer changes.
 	CHANGED_FILES=$(gh api repos/${REPO}/pulls/${PR_NUMBER}/files --paginate \
 		--header "Authorization: token $GITHUB_TOKEN" \
-		--jq '.[].filename' 2>/dev/null || true)
+		--jq '.[].filename' || true)
 	if [[ -z "$CHANGED_FILES" ]]; then
 		echo "Warning: could not fetch changed files; skipping @:ark injection."
-	elif echo "$CHANGED_FILES" | grep -qx "extensions/positron-r/ark"; then
+	elif echo "$CHANGED_FILES" | grep -qxF "extensions/positron-r/ark"; then
 		echo "Ark submodule changed. Injecting @:ark tag."
 		if [[ -n "$TAGS" ]]; then
 			TAGS="$TAGS,@:ark"


### PR DESCRIPTION
### Summary
Closes #13690. Automatically adds `@:ark` to the e2e test tag set whenever a PR bumps the ark submodule, so authors don't have to remember to add it manually.

- Detects submodule change via `gh api /pulls/{n}/files` — no workflow YAML changes needed
- Injects `ark` tag only in the non-`all` tag branch; deduplication handled downstream by `pr-tags-transform.sh`
- Surfaces `gh api` errors in CI logs rather than swallowing them silently

### QA Notes
Spot-checked `scripts/pr-tags-parse.sh` locally against 5 real PRs:

| PR | Scenario | Result |
|----|----------|--------|
| #13513 | Ark bump, no ark tag in body | `critical,plots,ark` ✓ |
| #14254 | Ark bump, ark tag already in body | `critical,ark,ark` ✓ (deduped by `pr-tags-transform.sh`) |
| #14466 | No tags in body | `critical` ✓ |
| #14468 | Other tags, no ark change | `critical,interpreter,sessions` ✓ |
| #14462 | Other tags, no ark change | `critical,web,posit-assistant` ✓ |