### PR TITLE
ci(release-screenshots): resolve nightly to the dev pre-release, not stable

### DIFF
--- a/.github/workflows/release-screenshots.yml
+++ b/.github/workflows/release-screenshots.yml
@@ -82,8 +82,16 @@ jobs:
           fi
           case "$INPUT" in
             latest-prerelease)
+              # positron-builds flags EVERY tag as prerelease=true, including
+              # stable releases mirrored in from posit-dev/positron. A mirrored
+              # stable build can be the newest entry by created_at, so a plain
+              # ".[0]" would pick stable instead of the dev pre-release we want.
+              # Exclude any tag that exists as a release on posit-dev/positron
+              # (those are the stable ones) and take the newest dev build left.
+              STABLE_TAGS=$(gh api "repos/posit-dev/positron/releases?per_page=100" --jq '[.[].tag_name]')
               VERSION=$(gh api "repos/posit-dev/positron-builds/releases?per_page=100" \
-                --jq '[.[] | select(.prerelease == true)] | .[0].tag_name')
+                --jq '[.[] | select(.prerelease == true) | .tag_name]' \
+                | jq -r --argjson stable "$STABLE_TAGS" '(. - $stable) | .[0]')
               ;;
             latest-release)
               # Stable releases are flagged on posit-dev/positron; positron-builds

--- a/test/e2e/fixtures/settings.json
+++ b/test/e2e/fixtures/settings.json
@@ -21,5 +21,6 @@
 	"assistant.sidebarView": true,
 	"shiny.previewType": "internal",
 	"terminal.integrated.gpuAcceleration": "off",
-	"console.showNotebookConsoleActions": true
+	"console.showNotebookConsoleActions": true,
+	"positron.notebook.enabled": true
 }

--- a/test/e2e/fixtures/settings.json
+++ b/test/e2e/fixtures/settings.json
@@ -21,6 +21,5 @@
 	"assistant.sidebarView": true,
 	"shiny.previewType": "internal",
 	"terminal.integrated.gpuAcceleration": "off",
-	"console.showNotebookConsoleActions": true,
-	"positron.notebook.enabled": true
+	"console.showNotebookConsoleActions": true
 }

--- a/test/e2e/release-screenshots/notebooks/positron-notebook-assistant-modal.screenshot.ts
+++ b/test/e2e/release-screenshots/notebooks/positron-notebook-assistant-modal.screenshot.ts
@@ -8,15 +8,9 @@ import { captureFullWindow } from '../_helpers/screenshot-utils';
 import { overrideWorkspaceName, prepareForScreenshot, setScreenshotWindowSize } from '../_helpers/layout-utils';
 import { clearAnnotations } from '../_helpers/annotate-utils';
 
-const test = base.extend({
-	beforeApp: [
-		async ({ settingsFile }, use) => {
-			settingsFile.append({ 'positron.notebook.enabled': true });
-			await use();
-		},
-		{ scope: 'worker' }
-	],
-});
+// The Positron notebook editor is enabled by default in the pre-release builds
+// these screenshots run against, so no settings override is needed here.
+const test = base;
 
 test.use({
 	suiteId: __filename,

--- a/test/e2e/release-screenshots/notebooks/positron-notebook-assistant-modal.screenshot.ts
+++ b/test/e2e/release-screenshots/notebooks/positron-notebook-assistant-modal.screenshot.ts
@@ -3,15 +3,13 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test as base } from '../../tests/_test.setup';
+import { test } from '../../tests/_test.setup';
 import { captureFullWindow } from '../_helpers/screenshot-utils';
 import { overrideWorkspaceName, prepareForScreenshot, setScreenshotWindowSize } from '../_helpers/layout-utils';
 import { clearAnnotations } from '../_helpers/annotate-utils';
 
 // The Positron notebook editor is enabled by default in the pre-release builds
 // these screenshots run against, so no settings override is needed here.
-const test = base;
-
 test.use({
 	suiteId: __filename,
 });

--- a/test/e2e/release-screenshots/notebooks/positron-notebook.screenshot.ts
+++ b/test/e2e/release-screenshots/notebooks/positron-notebook.screenshot.ts
@@ -12,15 +12,9 @@ import { annotate, clearAnnotations } from '../_helpers/annotate-utils';
 
 const ANNOTATION_COLOR = '#dc2626';
 
-const test = base.extend({
-	beforeApp: [
-		async ({ settingsFile }, use) => {
-			settingsFile.append({ 'positron.notebook.enabled': true });
-			await use();
-		},
-		{ scope: 'worker' }
-	],
-});
+// The Positron notebook editor is enabled by default in the pre-release builds
+// these screenshots run against, so no settings override is needed here.
+const test = base;
 
 test.use({
 	suiteId: __filename,

--- a/test/e2e/release-screenshots/notebooks/positron-notebook.screenshot.ts
+++ b/test/e2e/release-screenshots/notebooks/positron-notebook.screenshot.ts
@@ -5,7 +5,7 @@
 
 import { expect } from '@playwright/test';
 import { join } from 'path';
-import { test as base } from '../../tests/_test.setup';
+import { test } from '../../tests/_test.setup';
 import { captureFullWindow } from '../_helpers/screenshot-utils';
 import { overrideWorkspaceName, prepareForScreenshot, setScreenshotWindowSize } from '../_helpers/layout-utils';
 import { annotate, clearAnnotations } from '../_helpers/annotate-utils';
@@ -14,8 +14,6 @@ const ANNOTATION_COLOR = '#dc2626';
 
 // The Positron notebook editor is enabled by default in the pre-release builds
 // these screenshots run against, so no settings override is needed here.
-const test = base;
-
 test.use({
 	suiteId: __filename,
 });


### PR DESCRIPTION
### Summary
Nightly screenshots now run against the latest dev pre-release instead of a stable build.

- `positron-builds` marks every tag `prerelease=true`, so the resolver could land on a stable build
- Resolver now skips tags that are stable releases on `posit-dev/positron` and picks the newest dev build
- Notebook screenshots rely on the dev build's defaults, so per-test `positron.notebook.enabled` setup is no longer needed

@:notebooks @:positron-notebooks