### PR TITLE
Wire copilot into build helper scripts

### DIFF
--- a/scripts/build-check.sh
+++ b/scripts/build-check.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Waits for all three build daemons (watch-client, watch-extensions, watch-e2e) to reach idle state.
+# Waits for all build daemons (watch-client, watch-extensions, watch-e2e, watch-copilot) to reach idle state.
 # Exits 0 if all daemons are idle, non-zero if any daemon fails.
 set -euo pipefail
 
@@ -30,10 +30,17 @@ node scripts/deemon-status.mts \
 	--command "npm run watch-client-transpile" &
 pid4=$!
 
-r1=0; r2=0; r3=0; r4=0
+node scripts/deemon-status.mts \
+	--begins '\[watch:tsc\s*\] \d+:\d+:\d+ [AP]M - (Starting compilation in watch mode|File change detected\. Starting incremental compilation)' \
+	--ends '\[watch:tsc\s*\] \d+:\d+:\d+ [AP]M - Found [0-9]+ errors?\. Watching for file changes' \
+	--command "npm run watch-copilot" &
+pid5=$!
+
+r1=0; r2=0; r3=0; r4=0; r5=0
 wait $pid1 || r1=$?
 wait $pid2 || r2=$?
 wait $pid3 || r3=$?
 wait $pid4 || r4=$?
+wait $pid5 || r5=$?
 
-exit $((r1 || r2 || r3 || r4))
+exit $((r1 || r2 || r3 || r4 || r5))

--- a/scripts/build-ps.mts
+++ b/scripts/build-ps.mts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { spawn } from 'node:child_process';
 
-const DAEMONS = ['watch-client-transpile', 'watch-client', 'watch-extensions', 'watch-e2e'];
+const DAEMONS = ['watch-client-transpile', 'watch-client', 'watch-extensions', 'watch-e2e', 'watch-copilot'];
 const DEEMON_MISSING = /\[deemon\] No daemon running/;
 
 /**

--- a/scripts/build-ps.sh
+++ b/scripts/build-ps.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# Shows the status of Positron build daemons (watch-clientd, watch-extensionsd, watch-e2ed)
+# Shows the status of Positron build daemons (watch-clientd, watch-extensionsd, watch-e2ed, watch-copilotd)
 set -euo pipefail
 exec node scripts/build-ps.mts

--- a/scripts/build-start.sh
+++ b/scripts/build-start.sh
@@ -20,10 +20,13 @@ run watch-extensions npx deemon -- --detach npm run watch-extensions &
 pid3=$!
 run watch-e2e npx deemon -- --detach npm run watch-e2e &
 pid4=$!
+run watch-copilot npx deemon -- --detach npm run watch-copilot &
+pid5=$!
 
 failed=0
 wait $pid1 || failed=1
 wait $pid2 || failed=1
 wait $pid3 || failed=1
 wait $pid4 || failed=1
+wait $pid5 || failed=1
 exit $failed

--- a/scripts/build-stop.sh
+++ b/scripts/build-stop.sh
@@ -20,10 +20,13 @@ run watch-extensions npx deemon -- --kill npm run watch-extensions &
 pid3=$!
 run watch-e2e npx deemon -- --kill npm run watch-e2e &
 pid4=$!
+run watch-copilot npx deemon -- --kill npm run watch-copilot &
+pid5=$!
 
 failed=0
 wait $pid1 || failed=1
 wait $pid2 || failed=1
 wait $pid3 || failed=1
 wait $pid4 || failed=1
+wait $pid5 || failed=1
 exit $failed


### PR DESCRIPTION
## Wire `watch-copilot` into the build-helper scripts

The copilot build daemon (`watch-copilot`, which compiles `extensions/copilot`) was added in the 1.118.0 upstream merge but never wired into the `build-*` helper scripts. Those scripts were last touched in the 1.111.0 merge, so they only manage four daemons (`watch-client-transpile`, `watch-client`, `watch-extensions`, `watch-e2e`). As a result, `npm run build-start` never starts the copilot watcher, `build-stop` never stops it, `build-ps` never reports it, and `build-check` never waits for it to go idle.

This PR adds `watch-copilot` to all four helpers so the daemon set stays consistent with the top-level `npm run watch` task.

### Changes

- **`scripts/build-start.sh`** — start `watch-copilot` (`deemon --detach`) as a 5th daemon.
- **`scripts/build-stop.sh`** — stop the matching `watch-copilot` daemon (`deemon --kill`) so stop mirrors start.
- **`scripts/build-ps.mts`** — add `watch-copilot` to the reported `DAEMONS` list (and update the `build-ps.sh` comment).
- **`scripts/build-check.sh`** — add a `deemon-status` block that waits for copilot to reach idle.

For `build-check`, the copilot watch runs `npm-run-all -lp watch:esbuild watch:tsc`. The `--begins`/`--ends` regexes track the `[watch:tsc]` sub-watcher (the type-check-relevant one), which emits standard tsc markers (`Starting compilation in watch mode...` / `File change detected...` → `Found N errors. Watching for file changes.`). The regexes were derived from captured live output, and `\s*` absorbs npm-run-all's label padding.

### Testing

- Verified `build-ps` detects a running copilot daemon.
- Verified `build-check` attaches to the copilot daemon, matches the compile cycle, and reaches idle.
- Syntax-checked all four scripts (`bash -n`).
