### PR TITLE
Theme ipywidgets to inherit Positron theme colors

### DIFF
--- a/build/filters.ts
+++ b/build/filters.ts
@@ -191,6 +191,9 @@ export const indentationFilter = Object.freeze<string[]>([
 	'!extensions/positron-r/resources/testing/**',
 	'!scripts/positron/**/*',
 	'!extensions/positron-r/src/test/snapshots/*.R',
+	// Vendored from JupyterLab (a fork of their labvariables.css); keeps JupyterLab's
+	// 2-space indentation to ease future diffs against the JupyterLab original.
+	'!extensions/positron-ipywidgets/renderer/src/css/jupyter-lab-variables.css',
 	// --- End Positron ---
 ]);
 

--- a/extensions/positron-ipywidgets/renderer/src/css/jupyter-lab-variables.css
+++ b/extensions/positron-ipywidgets/renderer/src/css/jupyter-lab-variables.css
@@ -1,0 +1,524 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* ----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|--------------------------------------------------------------------------- */
+
+/*
+This is a fork of JupyterLab's `labvariables.css` (vendored from the
+@jupyter-widgets/controls package, not from VS Code / code-oss). Every Jupyter
+`--jp-*` token has been re-pointed at the equivalent VS Code theme variable
+(`--vscode-*`) so that ipywidgets rendered inside a notebook output webview inherit
+the active Positron theme instead of Jupyter's hardcoded palette. Each mapping carries
+a comment naming the VS Code token and why it was chosen. It is imported from
+../index.ts in place of the bundled `labvariables.css`, alongside `widgets-base.css`.
+
+Note: many `--vscode-*` tokens are only injected into the webview when the active
+theme resolves a non-null color for them, so mappings that resolve to a null default
+on standard themes (e.g. anything routed through `contrastBorder`) carry a fallback.
+*/
+
+/*
+The following CSS variables define the main, public API for styling JupyterLab.
+These variables should be used by all plugins wherever possible. In other
+words, plugins should not define custom colors, sizes, etc unless absolutely
+necessary. This enables users to change the visual theme of JupyterLab
+by changing these variables.
+
+Many variables appear in an ordered sequence (0,1,2,3). These sequences
+are designed to work well together, so for example, `--jp-border-color1` should
+be used with `--jp-layout-color1`. The numbers have the following meanings:
+
+* 0: super-primary, reserved for special emphasis
+* 1: primary, most important under normal situations
+* 2: secondary, next most important under normal situations
+* 3: tertiary, next most important under normal situations
+
+Throughout JupyterLab, we are mostly following principles from Google's
+Material Design when selecting colors. We are not, however, following
+all of MD as it is not optimized for dense, information rich UIs.
+*/
+
+body.vscode-dark, body.vscode-high-contrast {
+  --jp-widgets-dropdown-arrow: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18'%3E%3Cpath fill='%23C8C8C8' d='M5.2,5.9L9,9.7l3.8-3.8l 1.2,1.2l-4.9,5l-4.9-5L5.2,5.9z'/%3E%3C/svg%3E");
+}
+
+:root {
+  /* Elevation
+   *
+   * We style box-shadows using Material Design's idea of elevation. These particular numbers are taken from here:
+   *
+   * https://github.com/material-components/material-components-web
+   * https://material-components-web.appspot.com/elevation.html
+   */
+
+  --jp-shadow-base-lightness: 0;
+  --jp-shadow-umbra-color: rgba(
+    var(--jp-shadow-base-lightness),
+    var(--jp-shadow-base-lightness),
+    var(--jp-shadow-base-lightness),
+    0.2
+  );
+  --jp-shadow-penumbra-color: rgba(
+    var(--jp-shadow-base-lightness),
+    var(--jp-shadow-base-lightness),
+    var(--jp-shadow-base-lightness),
+    0.14
+  );
+  --jp-shadow-ambient-color: rgba(
+    var(--jp-shadow-base-lightness),
+    var(--jp-shadow-base-lightness),
+    var(--jp-shadow-base-lightness),
+    0.12
+  );
+  --jp-elevation-z0: none;
+  --jp-elevation-z1: 0 2px 1px -1px var(--jp-shadow-umbra-color),
+    0 1px 1px 0 var(--jp-shadow-penumbra-color),
+    0 1px 3px 0 var(--jp-shadow-ambient-color);
+  --jp-elevation-z2: 0 3px 1px -2px var(--jp-shadow-umbra-color),
+    0 2px 2px 0 var(--jp-shadow-penumbra-color),
+    0 1px 5px 0 var(--jp-shadow-ambient-color);
+  --jp-elevation-z4: 0 2px 4px -1px var(--jp-shadow-umbra-color),
+    0 4px 5px 0 var(--jp-shadow-penumbra-color),
+    0 1px 10px 0 var(--jp-shadow-ambient-color);
+  --jp-elevation-z6: 0 3px 5px -1px var(--jp-shadow-umbra-color),
+    0 6px 10px 0 var(--jp-shadow-penumbra-color),
+    0 1px 18px 0 var(--jp-shadow-ambient-color);
+  --jp-elevation-z8: 0 5px 5px -3px var(--jp-shadow-umbra-color),
+    0 8px 10px 1px var(--jp-shadow-penumbra-color),
+    0 3px 14px 2px var(--jp-shadow-ambient-color);
+  --jp-elevation-z12: 0 7px 8px -4px var(--jp-shadow-umbra-color),
+    0 12px 17px 2px var(--jp-shadow-penumbra-color),
+    0 5px 22px 4px var(--jp-shadow-ambient-color);
+  --jp-elevation-z16: 0 8px 10px -5px var(--jp-shadow-umbra-color),
+    0 16px 24px 2px var(--jp-shadow-penumbra-color),
+    0 6px 30px 5px var(--jp-shadow-ambient-color);
+  --jp-elevation-z20: 0 10px 13px -6px var(--jp-shadow-umbra-color),
+    0 20px 31px 3px var(--jp-shadow-penumbra-color),
+    0 8px 38px 7px var(--jp-shadow-ambient-color);
+  --jp-elevation-z24: 0 11px 15px -7px var(--jp-shadow-umbra-color),
+    0 24px 38px 3px var(--jp-shadow-penumbra-color),
+    0 9px 46px 8px var(--jp-shadow-ambient-color);
+
+  /* Borders
+   *
+   * The following variables, specify the visual styling of borders in JupyterLab.
+   */
+
+  --jp-border-width: 1px;
+  /* Primary border used throughout JupyterLab UI chrome.
+   * widget.border: "Border color of widgets such as find/replace inside the editor."
+   * Null default on non-HC themes; fall back to panel.border so the border still renders.
+   */
+  --jp-border-color0: var(--vscode-widget-border, var(--vscode-panel-border));
+  /* Standard border between adjacent areas.
+   * panel.border: "Border color to separate two panels." */
+  --jp-border-color1: var(--vscode-panel-border);
+  /* Lighter secondary border for subdivisions within a panel.
+   * editorGroup.border: "Color to separate multiple editor groups from each other." */
+  --jp-border-color2: var(--vscode-editorGroup-border);
+  /* Subtle tertiary border for section separators.
+   * sideBarSectionHeader.border: "Side bar section header border color."
+   * Resolves via contrastBorder (null on non-HC themes); fall back to panel.border. */
+  --jp-border-color3: var(--vscode-sideBarSectionHeader-border, var(--vscode-panel-border));
+  /* cornerRadius-small: VS Code design token for small border radii. */
+  --jp-border-radius: var(--vscode-cornerRadius-small);
+
+  /* UI Fonts
+   *
+   * The UI font CSS variables are used for the typography all of the JupyterLab
+   * user interface elements that are not directly user generated content.
+   *
+   * The font sizing here is done assuming that the body font size of --jp-ui-font-size1
+   * is applied to a parent element. When children elements, such as headings, are sized
+   * in em all things will be computed relative to that body size.
+   */
+
+  --jp-ui-font-scale-factor: 1.2;
+  --jp-ui-font-size0: 0.8333em;
+  --jp-ui-font-size1: var(--notebook-cell-output-font-size, 13px);
+  --jp-ui-font-size2: 1.2em;
+  --jp-ui-font-size3: 1.44em;
+  --jp-ui-font-family: var(--vscode-font-family, -apple-system, blinkmacsystemfont, 'Segoe UI', helvetica,
+    arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol');
+
+  /*
+   * Use these font colors against the corresponding main layout colors.
+   * In a light theme, these go from dark to light.
+   */
+
+  /* foreground: "Overall foreground color" - full opacity primary text. */
+  --jp-ui-font-color0: var(--vscode-foreground);
+  /* editor.foreground: "Editor default foreground color" - standard text at slightly reduced emphasis. */
+  --jp-ui-font-color1: var(--vscode-editor-foreground);
+  /* descriptionForeground: "Foreground color for description text providing additional information."
+   * Secondary/muted text color. */
+  --jp-ui-font-color2: var(--vscode-descriptionForeground);
+  /* disabledForeground: "Overall foreground for disabled elements."
+   * Tertiary/disabled text color. */
+  --jp-ui-font-color3: var(--vscode-disabledForeground);
+
+  /*
+   * Use these against the brand/accent/warn/error colors.
+   * These will typically go from light to darker, in both a dark and light theme.
+   */
+
+  /* button.foreground: "Button foreground color" - white text on colored backgrounds. */
+  --jp-ui-inverse-font-color0: var(--vscode-button-foreground);
+  --jp-ui-inverse-font-color1: var(--vscode-button-foreground);
+  /* button.secondaryForeground: "Secondary button foreground" - slightly muted inverse text. */
+  --jp-ui-inverse-font-color2: var(--vscode-button-secondaryForeground);
+  --jp-ui-inverse-font-color3: var(--vscode-button-secondaryForeground);
+
+  /* Content Fonts
+   *
+   * Content font variables are used for typography of user generated content.
+   *
+   * The font sizing here is done assuming that the body font size of --jp-content-font-size1
+   * is applied to a parent element. When children elements, such as headings, are sized
+   * in em all things will be computed relative to that body size.
+   */
+
+  --jp-content-line-height: 1.6;
+  --jp-content-font-scale-factor: 1.2;
+  --jp-content-font-size0: 0.8333em;
+  --jp-content-font-size1: 14px; /* Base font size */
+  --jp-content-font-size2: 1.2em;
+  --jp-content-font-size3: 1.44em;
+  --jp-content-font-size4: 1.728em;
+  --jp-content-font-size5: 2.0736em;
+
+  /* This gives a magnification of about 125% in presentation mode over normal. */
+  --jp-content-presentation-font-size1: 17px;
+  --jp-content-heading-line-height: 1;
+  --jp-content-heading-margin-top: 1.2em;
+  --jp-content-heading-margin-bottom: 0.8em;
+  --jp-content-heading-font-weight: 500;
+
+  /* foreground: "Overall foreground color" - full opacity content text. */
+  --jp-content-font-color0: var(--vscode-foreground);
+  /* editor.foreground: "Editor default foreground color" - standard content text. */
+  --jp-content-font-color1: var(--vscode-editor-foreground);
+  /* descriptionForeground: "Foreground color for description text." - secondary content text. */
+  --jp-content-font-color2: var(--vscode-descriptionForeground);
+  /* disabledForeground: "Overall foreground for disabled elements." - tertiary content text. */
+  --jp-content-font-color3: var(--vscode-disabledForeground);
+  /* textLink.foreground: "Foreground color for links in text." */
+  --jp-content-link-color: var(--vscode-textLink-foreground);
+  --jp-content-font-family: var(--vscode-font-family, -apple-system, blinkmacsystemfont, 'Segoe UI',
+    helvetica, arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol');
+
+  /*
+   * Code Fonts
+   *
+   * Code font variables are used for typography of code and other monospaces content.
+   */
+
+  /* notebook-cell-output-font-size: the notebook output font size set by the back-layer webview.
+   * Falls back to vscode-editor-font-size (webview theme injection). */
+  --jp-code-font-size: var(--notebook-cell-output-font-size, var(--vscode-editor-font-size, 13px));
+  --jp-code-line-height: 1.3077; /* 17px for 13px base */
+  --jp-code-padding: 0.385em; /* 5px for 13px base */
+  /* notebook-cell-output-font-family: the notebook output font family set by the back-layer webview.
+   * Falls back to vscode-editor-font-family (webview theme injection). */
+  --jp-code-font-family-default: var(--notebook-cell-output-font-family, var(--vscode-editor-font-family, menlo, consolas, 'DejaVu Sans Mono', monospace));
+  --jp-code-font-family: var(--jp-code-font-family-default);
+
+  /* This gives a magnification of about 125% in presentation mode over normal. */
+  --jp-code-presentation-font-size: 16px;
+
+  /* may need to tweak cursor width if you change font size */
+  --jp-code-cursor-width0: 1.4px;
+  --jp-code-cursor-width1: 2px;
+  --jp-code-cursor-width2: 4px;
+
+  /* Layout
+   *
+   * The following are the main layout colors use in JupyterLab. In a light
+   * theme these would go from light to dark.
+   */
+
+  /* editor.background: "Editor background color" - primary content background. */
+  --jp-layout-color0: var(--vscode-editor-background);
+  /* notebook.editorBackground: "The top-level notebook editor background."
+   * Falls back to editor.background for non-notebook contexts. */
+  --jp-layout-color1: var(--vscode-editor-background);
+  /* sideBar.background: "Side bar background color" - secondary UI surface. */
+  --jp-layout-color2: var(--vscode-sideBar-background);
+  /* scrollbarSlider.background: "Scrollbar slider background color."
+   * Paints the unfilled slider trough (a 4px-thin track) and the momentary
+   * pressed-button/active-tag surface. editorWidget.background sits a hair off
+   * editor.background on dark/light, so a thin track over the cell surface
+   * washed out. scrollbarSlider.background is VS Code's purpose-built neutral
+   * for a thin element that must stay visible over arbitrary content: non-null
+   * on all four themes and contrast-tuned (40-60% of a saturated grey). It is
+   * translucent, but only ever sits over the solid editor surface, so it reads
+   * as a consistent visible grey; the filled portion stays opaque (brand-color1). */
+  --jp-layout-color3: var(--vscode-scrollbarSlider-background);
+  /* tab.inactiveBackground: "Inactive tab background" - darker UI chrome surface. */
+  --jp-layout-color4: var(--vscode-tab-inactiveBackground);
+
+  /* --jp-widgets-input-background-color is intentionally left unmapped here;
+   * widget inputs inherit their background from --jp-layout-color1 (see the
+   * input field styles below). */
+
+  /* Inverse Layout
+   *
+   * The following are the inverse layout colors use in JupyterLab. In a light
+   * theme these would go from dark to light.
+   */
+
+  /* titleBar.activeBackground: "Title bar background" - darkest inverse surface. */
+  --jp-inverse-layout-color0: var(--vscode-titleBar-activeBackground);
+  /* activityBar.background: "Activity bar background" - primary inverse surface. */
+  --jp-inverse-layout-color1: var(--vscode-activityBar-background);
+  /* statusBar.background: "Status bar background" - secondary inverse surface. */
+  --jp-inverse-layout-color2: var(--vscode-statusBar-background);
+  /* tab.activeBackground: "Active tab background" - lighter inverse surface. */
+  --jp-inverse-layout-color3: var(--vscode-tab-activeBackground);
+  /* editorGroupHeader.tabsBackground: "Editor group header tabs background" - lightest inverse. */
+  --jp-inverse-layout-color4: var(--vscode-editorGroupHeader-tabsBackground);
+
+  /* Brand/accent */
+
+  /* focusBorder: "Overall border color for focused elements" - used as the brand/accent color. */
+  --jp-brand-color0: var(--vscode-focusBorder);
+  /* button.background: "Button background color" - primary brand interaction color. */
+  --jp-brand-color1: var(--vscode-button-background);
+  /* button.hoverBackground: "Button background color when hovering." */
+  --jp-brand-color2: var(--vscode-button-hoverBackground);
+  --jp-brand-color3: var(--vscode-button-hoverBackground);
+  /* testing.iconPassed: "Color for the 'Passed' icon" - success/positive accent. */
+  --jp-accent-color0: var(--vscode-testing-iconPassed);
+  --jp-accent-color1: var(--vscode-testing-iconPassed);
+  --jp-accent-color2: var(--vscode-testing-iconPassed);
+  --jp-accent-color3: var(--vscode-testing-iconPassed);
+
+  /* State colors (warn, error, success, info) */
+
+  /* editorWarning.foreground: "Foreground color of warning squigglies." */
+  --jp-warn-color0: var(--vscode-editorWarning-foreground);
+  /* list.warningForeground: "Foreground color of list items containing warnings." */
+  --jp-warn-color1: var(--vscode-list-warningForeground);
+  --jp-warn-color2: var(--vscode-list-warningForeground);
+  --jp-warn-color3: var(--vscode-list-warningForeground);
+  /* editorError.foreground: "Foreground color of error squigglies." */
+  --jp-error-color0: var(--vscode-editorError-foreground);
+  /* list.errorForeground: "Foreground color of list items containing errors." */
+  --jp-error-color1: var(--vscode-list-errorForeground);
+  --jp-error-color2: var(--vscode-list-errorForeground);
+  --jp-error-color3: var(--vscode-list-errorForeground);
+  /* testing.iconPassed: "Color for the 'Passed' icon" - success state. */
+  --jp-success-color0: var(--vscode-testing-iconPassed);
+  --jp-success-color1: var(--vscode-testing-iconPassed);
+  --jp-success-color2: var(--vscode-testing-iconPassed);
+  --jp-success-color3: var(--vscode-testing-iconPassed);
+  /* editorInfo.foreground: "Foreground color of info squigglies in the editor." */
+  --jp-info-color0: var(--vscode-editorInfo-foreground);
+  --jp-info-color1: var(--vscode-editorInfo-foreground);
+  --jp-info-color2: var(--vscode-editorInfo-foreground);
+  --jp-info-color3: var(--vscode-editorInfo-foreground);
+
+  /* Cell specific styles */
+
+  --jp-cell-padding: 5px;
+  --jp-cell-collapser-width: 8px;
+  --jp-cell-collapser-min-height: 20px;
+  --jp-cell-collapser-not-active-hover-opacity: 0.6;
+  /* notebook.cellEditorBackground: "The color of the notebook cell editor background." */
+  --jp-cell-editor-background: var(--vscode-notebook-cellEditorBackground);
+  /* notebook.cellBorderColor: "The border color for notebook cells." */
+  --jp-cell-editor-border-color: var(--vscode-notebook-cellBorderColor);
+  /* focusBorder: "Overall border color for focused elements" - box shadow for focused editor. */
+  --jp-cell-editor-box-shadow: inset 0 0 2px var(--vscode-focusBorder);
+  /* editor.background: "Editor background color" - active cell editor background. */
+  --jp-cell-editor-active-background: var(--vscode-editor-background);
+  /* notebook.focusedEditorBorder: "The color of the notebook cell editor border." */
+  --jp-cell-editor-active-border-color: var(--vscode-notebook-focusedEditorBorder, var(--vscode-focusBorder));
+  --jp-cell-prompt-width: 64px;
+  --jp-cell-prompt-font-family: var(--jp-code-font-family-default);
+  --jp-cell-prompt-letter-spacing: 0;
+  --jp-cell-prompt-opacity: 1;
+  --jp-cell-prompt-not-active-opacity: 0.5;
+  /* descriptionForeground: "Foreground color for description text" - muted prompt text. */
+  --jp-cell-prompt-not-active-font-color: var(--vscode-descriptionForeground);
+
+  /* A custom blend of MD grey and blue 600
+   * See https://meyerweb.com/eric/tools/color-blend/#546E7A:1E88E5:5:hex */
+  /* editorLineNumber.activeForeground: "Color of editor active line number" - input prompt color. */
+  --jp-cell-inprompt-font-color: var(--vscode-editorLineNumber-activeForeground);
+
+  /* A custom blend of MD grey and orange 600
+   * https://meyerweb.com/eric/tools/color-blend/#546E7A:F4511E:5:hex */
+  /* debugConsole.warningForeground: "Foreground color for warning messages in debug console."
+   * Output prompts use a warm/orange tone similar to this. */
+  --jp-cell-outprompt-font-color: var(--vscode-debugConsole-warningForeground);
+
+  /* Notebook specific styles */
+
+  --jp-notebook-padding: 10px;
+  /* notebook.selectedCellBackground: "The selected cell background color."
+   * WHY layout-color1: notebook.selectedCellBackground is a highlight tint meant to
+   * sit on top of the editor background, not a standalone surface, so widgets read it
+   * as too strong; use the neutral primary surface instead. */
+  --jp-notebook-select-background: var(--jp-layout-color1);
+  /* notebook.focusedCellBackground: "The focused cell background color." */
+  --jp-notebook-multiselected-color: var(--vscode-notebook-focusedCellBackground, var(--vscode-editor-background));
+
+  /* The scroll padding is calculated to fill enough space at the bottom of the
+  notebook to show one single-line cell (with appropriate padding) at the top
+  when the notebook is scrolled all the way to the bottom. We also subtract one
+  pixel so that no scrollbar appears if we have just one single-line cell in the
+  notebook. This padding is to enable a 'scroll past end' feature in a notebook.
+  */
+  --jp-notebook-scroll-padding: calc(
+    100% - var(--jp-code-font-size) * var(--jp-code-line-height) -
+      var(--jp-code-padding) - var(--jp-cell-padding) - 1px
+  );
+
+  /* Rendermime styles */
+
+  /* inputValidation.errorBackground: "Input validation background color for error severity."
+   * Light reddish background for rendered error output. */
+  --jp-rendermime-error-background: var(--vscode-inputValidation-errorBackground);
+  /* tree.tableOddRowsBackground: "Background color for odd table rows."
+   * Alternating row background in rendered tables. */
+  --jp-rendermime-table-row-background: var(--vscode-tree-tableOddRowsBackground);
+  /* list.hoverBackground: "List/Tree background when hovering over items."
+   * Hover state for rendered table rows. */
+  --jp-rendermime-table-row-hover-background: var(--vscode-list-hoverBackground);
+
+  /* Dialog specific styles */
+
+  /* The VS Code backdrop for overlays. No exact variable but widget.shadow covers the shadow intent. */
+  --jp-dialog-background: rgba(0, 0, 0, 0.25);
+
+  /* Console specific styles */
+
+  --jp-console-padding: 10px;
+
+  /* Toolbar specific styles */
+
+  /* panel.border: "Border color to separate panels" - toolbar bottom border.
+   * Routed through border-color1 so all chrome borders share one source. */
+  --jp-toolbar-border-color: var(--jp-border-color1);
+  --jp-toolbar-micro-height: 8px;
+  /* editorGroupHeader.tabsBackground: "Background of the editor group title header when tabs are enabled."
+   * WHY layout-color1: keep the toolbar flush with the primary surface rather than the
+   * darker tabs-header tone, which looked detached inside widget output. */
+  --jp-toolbar-background: var(--jp-layout-color1);
+  /* widget.shadow: "Shadow color of widgets" - toolbar drop shadow. */
+  --jp-toolbar-box-shadow: 0 0 2px 0 var(--vscode-widget-shadow);
+  --jp-toolbar-header-margin: 4px 4px 0 4px;
+  /* toolbar.activeBackground: "Toolbar background when holding the mouse over actions." */
+  --jp-toolbar-active-background: var(--vscode-toolbar-activeBackground);
+
+  /* Statusbar specific styles */
+
+  --jp-statusbar-height: 24px;
+
+  /* Input field styles */
+
+  /* focusBorder: "Overall border color for focused elements" - input focus box shadow. */
+  --jp-input-box-shadow: inset 0 0 2px var(--vscode-focusBorder);
+  /* input.background: "Input box background" - active/hover input background.
+   * WHY layout-color1: input.background can differ from the surrounding surface and made
+   * widget inputs look boxed; match the primary surface for active/hover states instead. */
+  --jp-input-active-background: var(--jp-layout-color1);
+  --jp-input-hover-background: var(--jp-layout-color1);
+  --jp-input-background: var(--vscode-input-background);
+  /* input.border: "Input box border" - input field border. */
+  --jp-input-border-color: var(--vscode-input-border, var(--vscode-panel-border));
+  /* inputOption.activeBorder: "Border color of activated options in input fields." */
+  --jp-input-active-border-color: var(--vscode-inputOption-activeBorder);
+
+  /* General editor styles */
+
+  /* editor.selectionBackground: "Color of the editor selection." */
+  --jp-editor-selected-background: var(--vscode-editor-selectionBackground);
+  /* editor.inactiveSelectionBackground: "Color of the selection in an inactive editor." */
+  --jp-editor-selected-focused-background: var(--vscode-editor-inactiveSelectionBackground);
+  /* editorCursor.foreground: "Color of the editor cursor." */
+  --jp-editor-cursor-color: var(--vscode-editorCursor-foreground);
+
+  /* Code mirror specific styles */
+
+  /* debugTokenExpression.name: "Foreground color for token names in debug views." */
+  --jp-mirror-editor-keyword-color: var(--vscode-debugTokenExpression-name, #008000);
+  /* debugTokenExpression.boolean: "Foreground color for booleans in debug views." */
+  --jp-mirror-editor-atom-color: var(--vscode-debugTokenExpression-boolean, #88f);
+  /* debugTokenExpression.number: "Foreground color for numbers in debug views." */
+  --jp-mirror-editor-number-color: var(--vscode-debugTokenExpression-number, #080);
+  /* symbolIcon.functionForeground: "Foreground color for function symbols." */
+  --jp-mirror-editor-def-color: var(--vscode-symbolIcon-functionForeground, #00f);
+  --jp-mirror-editor-variable-color: var(--vscode-editor-foreground);
+  --jp-mirror-editor-variable-2-color: #05a;
+  --jp-mirror-editor-variable-3-color: #085;
+  --jp-mirror-editor-punctuation-color: #05a;
+  --jp-mirror-editor-property-color: #05a;
+  --jp-mirror-editor-operator-color: #a2f;
+  /* descriptionForeground: "Foreground color for description text." */
+  --jp-mirror-editor-comment-color: var(--vscode-descriptionForeground, #408080);
+  /* debugTokenExpression.string: "Foreground color for strings in debug views." */
+  --jp-mirror-editor-string-color: var(--vscode-debugTokenExpression-string, #ba2121);
+  --jp-mirror-editor-string-2-color: #708;
+  --jp-mirror-editor-meta-color: #a2f;
+  --jp-mirror-editor-qualifier-color: #555;
+  /* debugTokenExpression.name: "Foreground color for token names in debug views." */
+  --jp-mirror-editor-builtin-color: var(--vscode-debugTokenExpression-name, #008000);
+  --jp-mirror-editor-bracket-color: #997;
+  --jp-mirror-editor-tag-color: #170;
+  --jp-mirror-editor-attribute-color: #00c;
+  --jp-mirror-editor-header-color: blue;
+  --jp-mirror-editor-quote-color: #090;
+  /* textLink.foreground: "Foreground color for links in text." */
+  --jp-mirror-editor-link-color: var(--vscode-textLink-foreground);
+  /* editorError.foreground: "Foreground color of error squigglies." */
+  --jp-mirror-editor-error-color: var(--vscode-editorError-foreground);
+  --jp-mirror-editor-hr-color: #999;
+
+  /* User colors */
+
+  --jp-collaborator-color1: #ad4a00;
+  --jp-collaborator-color2: #7b6a00;
+  --jp-collaborator-color3: #007e00;
+  --jp-collaborator-color4: #008772;
+  --jp-collaborator-color5: #0079b9;
+  --jp-collaborator-color6: #8b45c6;
+  --jp-collaborator-color7: #be208b;
+
+  /* File or activity icons and switch semantic variables */
+
+  --jp-jupyter-icon-color: var(--vscode-icon-foreground);
+  --jp-notebook-icon-color: var(--vscode-icon-foreground);
+  --jp-json-icon-color: var(--vscode-icon-foreground);
+  --jp-console-icon-background-color: var(--vscode-button-background);
+  /* button.foreground: "Button foreground color" - icon on colored background. */
+  --jp-console-icon-color: var(--vscode-button-foreground);
+  /* sideBar.background: "Side bar background color" - neutral icon background. */
+  --jp-terminal-icon-background-color: var(--vscode-sideBar-background);
+  /* icon.foreground: "The default color for icons in the workbench." */
+  --jp-terminal-icon-color: var(--vscode-icon-foreground);
+  --jp-text-editor-icon-color: var(--vscode-icon-foreground);
+  --jp-inspector-icon-color: var(--vscode-icon-foreground);
+  /* disabledForeground: "Overall foreground for disabled elements" - muted switch track. */
+  --jp-switch-color: var(--vscode-disabledForeground);
+  /* inputOption.activeBorder: "Border color of activated options" - active switch indicator. */
+  --jp-switch-true-position-color: var(--vscode-inputOption-activeBorder);
+  /* foreground: "Overall foreground color" - switch cursor/thumb. */
+  --jp-switch-cursor-color: var(--vscode-foreground);
+
+  /* Vega extension styles */
+
+  /* editor.background: "Editor background color" - chart/visualization background. */
+  --jp-vega-background: var(--vscode-editor-background);
+
+  /* Sidebar-related styles */
+
+  --jp-sidebar-min-width: 180px;
+}

--- a/extensions/positron-ipywidgets/renderer/src/index.ts
+++ b/extensions/positron-ipywidgets/renderer/src/index.ts
@@ -13,8 +13,15 @@ import { Messaging } from './messaging';
 // Import CSS files required by the bundled widget packages.
 import '@fortawesome/fontawesome-free/css/all.min.css';
 import '@fortawesome/fontawesome-free/css/v4-shims.min.css';
+// Styles for disconnected and error widget states.
+// https://github.com/jupyter-widgets/ipywidgets/blob/main/packages/base/css/index.css
 import '@jupyter-widgets/base/css/index.css';
-import '@jupyter-widgets/controls/css/widgets.css';
+// Upstream `widgets.css` is just `@import labvariables.css` + `@import widgets-base.css`.
+// We import `widgets-base.css` (the widget styling) directly, but replace `labvariables.css`
+// with our fork that re-points Jupyter's `--jp-*` tokens at `--vscode-*` theme variables so
+// widgets inherit the active Positron theme. See ./css/jupyter-lab-variables.css.
+import '@jupyter-widgets/controls/css/widgets-base.css';
+import './css/jupyter-lab-variables.css';
 import '@lumino/widgets/style/index.css';
 import './reactable/reactable-py.esm.css';
 import './reactable/reactable-py.esm.js';


### PR DESCRIPTION
Fixes #12806

ipywidgets rendered in notebook outputs previously used JupyterLab's hardcoded color palette, so widgets and the tables/text they render stayed light against Positron's dark theme, failing contrast/accessibility requirements (see screenshots).

This re-points Jupyter's `--jp-*` design tokens at the equivalent `--vscode-*` theme variables so ipywidgets inherit the active Positron theme.

### Screenshots

| Before | After |
| --- | --- |
| <img width="847" height="1035" alt="Screenshot 2026-06-25 at 18 41 59" src="https://github.com/user-attachments/assets/e4e5e1f6-a446-4270-800a-60f33f22a443" /> | <img width="847" height="1035" alt="Screenshot 2026-06-25 at 18 42 21" src="https://github.com/user-attachments/assets/3f87914a-a034-452a-ba76-8c72e08b080e" /> |
| <img width="847" height="1035" alt="Screenshot 2026-06-25 at 18 42 11" src="https://github.com/user-attachments/assets/cd65cbee-2984-4eb6-b20c-56acbb49d0e1" /> | <img width="847" height="1035" alt="Screenshot 2026-06-25 at 18 42 30" src="https://github.com/user-attachments/assets/e78237c4-8339-4d6f-b5e9-37125931f6ba" /> |

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Themed ipywidgets in notebook outputs so they inherit the active Positron theme instead of JupyterLab's hardcoded palette (#12806)

### Validation Steps

@:positron-notebooks @:web

1. Switch Positron to a dark theme.
2. Open a notebook and run the sample from the issue:
    
    ```python
    import polars as pl
    import ipywidgets as widgets
    from datetime import date
    
    df = pl.DataFrame({
        "foo": [1, 2, 3],
        "bar": [6.0, 7.0, 8.0],
        "ham": [date(2020, 1, 2), date(2021, 3, 4), date(2022, 5, 6)],
        "a": [None, 2, 3],
        "b": [0.5, None, 2.5],
        "c": [True, None, False],
    })
    
    display(df)
    
    n_rows = widgets.IntSlider(value=len(df), min=1, max=len(df), step=1, description="Rows:")
    
    def show_head(n):
        display(df.head(n))
    
    widgets.interactive(show_head, n=n_rows)
    ```

3. Verify the slider, labels, and table output render with theme-appropriate (high-contrast) colors in dark mode.
4. Switch to a light theme and confirm widgets still render correctly.
