### PR TITLE
Trim Claude skill descriptions and make explicit-request skills user-only

### DIFF
--- a/.claude/commands/review-upstream-merge.md
+++ b/.claude/commands/review-upstream-merge.md
@@ -1,4 +1,4 @@
-# Skill: Review Upstream Merge
+# Review Upstream Merge
 
 Review changes from an upstream VS Code merge to ensure Posit Workbench integration remains intact.
 
@@ -12,7 +12,7 @@ If no branch name is provided, reviews the current branch against `main`.
 
 ## Instructions
 
-When this skill is invoked, perform a comprehensive code review of upstream merge changes with focus on Posit Workbench (PWB) integration safety.
+When this command is invoked, perform a comprehensive code review of upstream merge changes with focus on Posit Workbench (PWB) integration safety.
 
 ### Step 1: Identify the Merge
 

--- a/.claude/skills/author-e2e-tests/SKILL.md
+++ b/.claude/skills/author-e2e-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: author-e2e-tests
-description: This skill should be used when writing, debugging, or maintaining Playwright e2e tests for Positron. Load this skill when creating new test files, adding test cases, fixing flaky tests, or understanding the test infrastructure.
+description: Use when writing, debugging, or maintaining Playwright e2e tests for Positron -- new test files, test cases, flaky-test fixes, or test infrastructure.
 ---
 
 # Positron Playwright E2E Testing

--- a/.claude/skills/author-vitest-tests/SKILL.md
+++ b/.claude/skills/author-vitest-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: author-vitest-tests
-description: Use when writing, generating, or adding Vitest tests for Positron source code in src/vs/. Load this skill when analyzing a branch or PR for test coverage gaps, when the user asks to write tests using createTestContainer(), or when testing React components with RTL.
+description: Use when writing or adding Vitest tests for Positron source in src/vs/, checking a branch/PR for coverage gaps, using createTestContainer(), or testing React components with RTL.
 ---
 
 # Positron Vitest Test Authoring

--- a/.claude/skills/author-vitest-tests/SKILL.md
+++ b/.claude/skills/author-vitest-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: author-vitest-tests
-description: Use when writing or adding Vitest tests for Positron source in src/vs/, checking a branch/PR for coverage gaps, using createTestContainer(), or testing React components with RTL.
+description: Use when writing or adding Vitest tests for Positron src/vs/ code, checking a branch/PR for test-coverage gaps, or testing React components with RTL.
 ---
 
 # Positron Vitest Test Authoring

--- a/.claude/skills/pete-local/SKILL.md
+++ b/.claude/skills/pete-local/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: pete
+disable-model-invocation: true
 description: Preview the test-coverage verdict PETE will post, locally, before a PR exists. PETE is Positron's CI "PR Test Checker": it grades whether a PR adds adequate tests for its source changes and posts a verdict comment. This skill replays the same rubric and file classification against your working tree (committed + uncommitted + untracked changes vs the merge-base with the default branch) and renders the verdict in-session -- it posts nothing and needs no network or gh. Use when asked to "run PETE" / "run PETE locally", to preview or check test coverage before opening or pushing a PR, to see whether the current branch has adequate tests, or to anticipate what PETE / the PR Test Checker will say.
 ---
 

--- a/.claude/skills/pick-copilot-tag/SKILL.md
+++ b/.claude/skills/pick-copilot-tag/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: pick-copilot-tag
+disable-model-invocation: true
 description: Determine which vscode-copilot-chat release tag to use for a Positron build
 ---
 

--- a/.claude/skills/positron-abstract-svg/SKILL.md
+++ b/.claude/skills/positron-abstract-svg/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: positron-abstract-svg
+disable-model-invocation: true
 description: >
   Create or update abstract SVG illustrations for the Positron IDE -- for use in
   documentation, walkthrough steps, onboarding images, and feature previews.

--- a/.claude/skills/positron-data-grid-pattern/SKILL.md
+++ b/.claude/skills/positron-data-grid-pattern/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: positron-data-grid-pattern
-description: Use when building any list, table, grid, or virtualized scrolling UI in Positron, or whenever you encounter `DataGridInstance`, `PositronDataGrid`, or files importing them. Critical for avoiding a common architectural mistake (wrapping the grid in a React component that mediates props into the instance via useEffect).
+description: Use when building a list, table, grid, or virtualized scrolling UI in Positron, or touching `DataGridInstance` / `PositronDataGrid`. Avoids the common mistake of mediating props into the instance via useEffect.
 ---
 
 # Positron Data Grid Pattern

--- a/.claude/skills/positron-demo-video/SKILL.md
+++ b/.claude/skills/positron-demo-video/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: positron-demo-video
+disable-model-invocation: true
 description: Use when the user wants to create a demo video, record a feature walkthrough, or generate a video for a PR description. Triggers on "record a demo", "make a video", "demo video for PR", or "generate a walkthrough".
 ---
 

--- a/.claude/skills/positron-intake-rotation/SKILL.md
+++ b/.claude/skills/positron-intake-rotation/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: positron-intake-rotation
+disable-model-invocation: true
 description: This skill should be used when handling issue intake rotation duties for the Positron repository. It provides workflows for reviewing and organizing new issues, responding to discussions, handling support tickets, and searching for related content. Use this skill when on intake rotation duty, when helping someone with intake tasks, or when learning the intake rotation process.
 ---
 

--- a/.claude/skills/positron-issue-creator/SKILL.md
+++ b/.claude/skills/positron-issue-creator/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: positron-issue-creator
+disable-model-invocation: true
 description: This skill should be used when drafting GitHub issues for the Positron repository. It provides workflows for searching duplicates, selecting appropriate labels, gathering complete context through questioning, and writing terse, fluff-free issues that precisely describe what is needed or wrong. The skill prepares issues for manual submission by the user. Use this skill when the user asks to draft or prepare an issue for Positron.
 ---
 

--- a/.claude/skills/positron-pull-vscode-server/SKILL.md
+++ b/.claude/skills/positron-pull-vscode-server/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: positron-pull-vscode-server
+disable-model-invocation: true
 description: Use when pulling changes from rstudio/vscode-server into Positron — fetching upstream, triaging commits, and applying diffs
 ---
 

--- a/.claude/skills/positron-qa-verify/SKILL.md
+++ b/.claude/skills/positron-qa-verify/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: positron-qa-verify
+disable-model-invocation: true
 description: Generates clear, actionable verification guides for QA testing of Positron bug fixes and features
 ---
 

--- a/.claude/skills/review-vitest-tests/SKILL.md
+++ b/.claude/skills/review-vitest-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-vitest-tests
-description: Use when reviewing Vitest test files for quality, maintainability, and adherence to Positron's testing patterns. Load this skill when test files need a quality check against the builder pattern, RTL patterns, and project conventions. Not for e2e or Playwright tests.
+description: Use when reviewing Vitest test files (.vitest.ts/.tsx) for quality against Positron's builder pattern, RTL patterns, and conventions. Not for e2e or Playwright tests.
 ---
 
 # Positron Vitest Test Review


### PR DESCRIPTION
As we add more and more custom skills into the positron repo I think we should ocassionally do audits for context efficiency. Every skill in its default format loads the entirety of the description field into context for every session which can confuse the model and just generally waste tokens when those things are not being worked on. 

In this PR I looked over each skill and made some judgements about which ones should always be user-invoked (aka they don't get injected into the context at all) and which ones that have descriptions could have those descriptions trimmed (the description should tell the model only when it should invoke a skill, not about what that skill does etc.)


This is what I get when running `/context` on main:

 ```
 ...
  Project
 ├ pete: ~240 tokens
 ├ positron-abstract-svg: ~230 tokens
 ├ positron-issue-creator: ~150 tokens
 ├ positron-intake-rotation: ~140 tokens
 ├ positron-data-grid-pattern: ~120 tokens
 ├ author-vitest-tests: ~100 tokens
 ├ review-vitest-tests: ~100 tokens
 ├ author-e2e-tests: ~80 tokens
 ├ positron-demo-video: ~80 tokens
 ├ positron-pull-vscode-server: ~50 tokens
 ├ positron-qa-verify: ~40 tokens
 ├ pick-copilot-tag: ~30 tokens
 ├ positron-pr-helper: ~30 tokens
 └ launch-positron: < 20 tokens
 ...
 ```
 
 and on this branch:
 
 ```
 ...
 Project
 ├ positron-data-grid-pattern: ~80 tokens
 ├ review-vitest-tests: ~60 tokens
 ├ author-e2e-tests: ~60 tokens
 ├ author-vitest-tests: ~60 tokens
 ├ positron-pr-helper: ~30 tokens
 ├ launch-positron: < 20 tokens
 └ review-upstream-merge: < 20 tokens
 ...
 ```

_Agent generated notes 👇_

## What

Audit of this repo's `.claude/skills` for context efficiency. A skill's `description:` line is auto-injected into **every** session's context unless the skill sets `disable-model-invocation: true` (which removes it from context entirely while keeping it invocable via `/name`). This PR trims padded descriptions and flips explicit-request-only skills to user-only.

## Why

The auto-injected skill descriptions cost ~1,100 tokens of context in every session in this repo, much of it for skills that are only ever invoked deliberately by name (where auto-detection buys nothing).

## Changes

**Flipped to user-only** (`disable-model-invocation: true`) -- always invoked by explicit request, so they no longer load into session context:
- `pete`, `positron-abstract-svg`, `positron-issue-creator`, `positron-intake-rotation`, `positron-demo-video`, `positron-pull-vscode-server`, `pick-copilot-tag`, `positron-qa-verify`

**Trimmed** (kept auto-invocable -- these genuinely benefit from mid-task auto-detection):
- `author-e2e-tests`, `author-vitest-tests`, `positron-data-grid-pattern`, `review-vitest-tests` -- cut padding/implementation-detail noise while preserving trigger keywords.

**Fixed a broken file:**
- `review-upstream-merge.md` was a loose `.md` directly in `skills/` (no `<name>/SKILL.md` subdir, no frontmatter), so the loader never registered it -- it was neither loaded nor invocable. Moved to `.claude/commands/review-upstream-merge.md`, where its command-shaped body (`/review-upstream-merge [branch]`) belongs, and corrected its self-description from "skill" to "command".

## Impact

Auto-injected skill descriptions in this repo: **13 skills / ~1,121 tokens -> 5 skills / ~235 tokens** (~886 tokens saved per session). The 5 still auto-invocable (`author-e2e-tests`, `author-vitest-tests`, `positron-data-grid-pattern`, `positron-pr-helper`, `review-vitest-tests`) are the ones that benefit from firing mid-task without an explicit invocation.

All affected skills remain fully invocable via their `/name` slash command.

## Notes

- No skills warranted conversion to a hook or `CLAUDE.md` rule: every skill body is a judgment-bearing procedure, interactive approval flow, or script-backed workflow -- none is static always-on guidance, and `CLAUDE.md` would *add* per-session context cost.
- A parallel set of trims/flips for **global** skills (`~/.claude/skills`) was identified but is out of scope here since those files aren't tracked in this repo.
