### PR TITLE
E2E test: fix two flakes, enable a skipped test

### DIFF
--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -632,7 +632,10 @@ export class Sessions {
 	 */
 	async getCurrentSessionId(): Promise<string> {
 		return await test.step('Get current session ID', async () => {
-			const infoButton = this.page.getByTestId(/info-(python|r)-[a-z0-9]+/i);
+			// Notebook console sessions carry an extra `-notebook` segment
+			// (e.g. `info-r-notebook-f77090bb`), so allow it in addition to
+			// standalone sessions (`info-r-f77090bb`).
+			const infoButton = this.page.getByTestId(/info-(python|r)(-notebook)?-[a-z0-9]+/i);
 			const infoButtonCount = await infoButton.count();
 
 			if (infoButtonCount === 0) {
@@ -641,7 +644,7 @@ export class Sessions {
 
 			const testId = await infoButton.getAttribute('data-testid');
 
-			if (!testId || !/^info-((python|r)-[a-z0-9]+)$/i.test(testId)) {
+			if (!testId || !/^info-((python|r)(-notebook)?-[a-z0-9]+)$/i.test(testId)) {
 				throw new Error('No active session or unexpected session ID format');
 			}
 

--- a/test/e2e/tests/console/console-input.test.ts
+++ b/test/e2e/tests/console/console-input.test.ts
@@ -191,6 +191,10 @@ cat(sprintf('Hello %s!\n', val))`;
 		const activeConsole = app.workbench.console.activeConsole;
 		const inputLocator = activeConsole.locator('.console-input');
 
+		// Start from a clean input line so leftover text from a prior test
+		// (e.g. an uncleared `x = 42`) doesn't bleed into the assertions.
+		await app.workbench.console.clearInput();
+
 		await app.workbench.console.typeToConsole('abcDEF');
 		await app.workbench.console.waitForCurrentConsoleLineContents('abcDEF');
 

--- a/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
@@ -204,6 +204,10 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 	test('ensure closing a notebook removes its console session', { tag: [tags.CONSOLE, tags.EDITOR] }, async function ({ app, page, sessions, runCommand }) {
 		const { notebooksPositron } = app.workbench;
 
+		// clear any sessions left by prior tests (e.g. a terminated notebook
+		// console) so the Untitled-1.ipynb tab lookup is unambiguous
+		await sessions.deleteAll();
+
 		// start standalone sessions that should survive the notebook closing
 		const [, rSession] = await sessions.start(['python', 'r']);
 		await sessions.select(rSession.id);

--- a/test/e2e/tests/packages-pane/packages-pane.test.ts
+++ b/test/e2e/tests/packages-pane/packages-pane.test.ts
@@ -57,9 +57,8 @@ test.describe('Packages Pane', {
 			});
 	});
 
-	test.skip('R - Install, search, and uninstall package', {
-		tag: [tags.WIN],
-		annotation: { type: 'issue', description: 'https://github.com/posit-dev/positron/issues/14346' }
+	test('R - Install, search, and uninstall package', {
+		tag: [tags.WIN]
 	},
 		async function ({ app, r: _r }) {
 			const { packages } = app.workbench;


### PR DESCRIPTION
Enable previously broken packages test
Fix two flakes that were primarily due to previous case leaving something behind

@:packages
@:positron-notebooks
@:console