### PR TITLE
Actually delete the test node in explorer's tree if a test file gets deleted

### DIFF
--- a/extensions/positron-r/src/testing/loader.ts
+++ b/extensions/positron-r/src/testing/loader.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { LOGGER } from '../extension';
 import { parseTestsFromFile } from './parser';
-import { ItemType, TestingTools, encodeNodeId } from './util-testing';
+import { ItemType, TestingTools, uriToFileNodeId } from './util-testing';
 import { testthatTestFilePattern } from './watcher';
 
 export async function discoverTestFiles(testingTools: TestingTools) {
@@ -21,14 +21,14 @@ export async function discoverTestFiles(testingTools: TestingTools) {
 
 export function getOrCreateFileItem(testingTools: TestingTools, uri: vscode.Uri) {
 	const testFile = path.basename(uri.fsPath);
-	const existing = testingTools.controller.items.get(encodeNodeId(testFile));
+	const existing = testingTools.controller.items.get(uriToFileNodeId(uri));
 	if (existing) {
 		LOGGER.info(`Found a file node for ${testFile}`);
 		return existing;
 	}
 
 	LOGGER.info(`Creating a file node for ${testFile}`);
-	const item = testingTools.controller.createTestItem(encodeNodeId(testFile), testFile, uri);
+	const item = testingTools.controller.createTestItem(uriToFileNodeId(uri), testFile, uri);
 	testingTools.testItemData.set(item, ItemType.File);
 	item.canResolveChildren = true;
 	testingTools.controller.items.add(item);

--- a/extensions/positron-r/src/testing/util-testing.ts
+++ b/extensions/positron-r/src/testing/util-testing.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { LOGGER } from '../extension';
 
 export enum ItemType {
@@ -31,6 +32,10 @@ export function encodeNodeId(
 		: testLabel
 			? `${testFile}&${testLabel}`
 			: testFile;
+}
+
+export function uriToFileNodeId(uri: vscode.Uri): string {
+	return encodeNodeId(path.basename(uri.fsPath));
 }
 
 /**

--- a/extensions/positron-r/src/testing/watcher.ts
+++ b/extensions/positron-r/src/testing/watcher.ts
@@ -27,10 +27,10 @@ async function createWatchers(testingTools: TestingTools, packageRoot: vscode.Ur
 	const dotRPattern = new vscode.RelativePattern(packageRoot, testthatDotRPattern);
 	const dotRWatcher = vscode.workspace.createFileSystemWatcher(dotRPattern);
 
-	dotRWatcher.onDidCreate((uri) => {
+	dotRWatcher.onDidCreate(() => {
 		refreshTestthatStatus();
 	});
-	dotRWatcher.onDidDelete((uri) => {
+	dotRWatcher.onDidDelete(() => {
 		refreshTestthatStatus();
 	});
 
@@ -39,7 +39,7 @@ async function createWatchers(testingTools: TestingTools, packageRoot: vscode.Ur
 	const folderPattern = new vscode.RelativePattern(packageRoot, testsPattern);
 	const folderWatcher = vscode.workspace.createFileSystemWatcher(folderPattern);
 
-	folderWatcher.onDidDelete((uri) => {
+	folderWatcher.onDidDelete(() => {
 		refreshTestthatStatus();
 	});
 

--- a/extensions/positron-r/src/testing/watcher.ts
+++ b/extensions/positron-r/src/testing/watcher.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { TestingTools } from './util-testing';
+import { uriToFileNodeId, TestingTools } from './util-testing';
 import { getOrCreateFileItem } from './loader';
 import { parseTestsFromFile } from './parser';
 import { LOGGER } from '../extension';
@@ -54,7 +54,7 @@ async function createWatchers(testingTools: TestingTools, packageRoot: vscode.Ur
 	});
 	testFileWatcher.onDidChange((uri) => parseTestsFromFile(testingTools, getOrCreateFileItem(testingTools, uri)));
 	testFileWatcher.onDidDelete((uri) => {
-		testingTools.controller.items.delete(uri.path);
+		testingTools.controller.items.delete(uriToFileNodeId(uri));
 		// important to know if there are no test files left
 		refreshTestthatStatus();
 	});

--- a/test/e2e/pages/testExplorer.ts
+++ b/test/e2e/pages/testExplorer.ts
@@ -34,14 +34,14 @@ export class TestExplorer extends Explorer {
 		await this.quickaccess.runCommand('testing.clearTestResults');
 	}
 
-	async expectTestItems(labels: string[]): Promise<void> {
+	async expectTestItems(labels: string[], timeout?: number): Promise<void> {
 		const tree = this.code.driver.currentPage.locator('.test-explorer');
 		for (const label of labels) {
-			await expect(tree.getByLabel(label)).toBeVisible({ timeout: 3000 });
+			await expect(tree.getByLabel(label)).toBeVisible({ timeout });
 		}
 	}
 
-	async expectNoTestItem(label: string, timeout = 3000): Promise<void> {
+	async expectNoTestItem(label: string, timeout?: number): Promise<void> {
 		const tree = this.code.driver.currentPage.locator('.test-explorer');
 		await expect(tree.getByLabel(label)).toHaveCount(0, { timeout });
 	}

--- a/test/e2e/pages/testExplorer.ts
+++ b/test/e2e/pages/testExplorer.ts
@@ -41,6 +41,11 @@ export class TestExplorer extends Explorer {
 		}
 	}
 
+	async expectNoTestItem(label: string, timeout = 3000): Promise<void> {
+		const tree = this.code.driver.currentPage.locator('.test-explorer');
+		await expect(tree.getByLabel(label)).toHaveCount(0, { timeout });
+	}
+
 	async runAllTests(): Promise<void> {
 		await this.code.driver.currentPage.locator('.composite.title').getByLabel('Run Tests', { exact: true }).click();
 	}

--- a/test/e2e/tests/test-explorer/test-explorer.test.ts
+++ b/test/e2e/tests/test-explorer/test-explorer.test.ts
@@ -19,6 +19,8 @@ test.describe('R Test Explorer', { tag: [tags.TEST_EXPLORER, tags.R_PKG_DEVELOPM
 	const FIXTURE_NAME = 'r.pkg.test.explorer.fixture';
 	const FIXTURE_SOURCE = path.join(process.cwd(), 'extensions/positron-r/resources/testing', FIXTURE_NAME);
 
+	const WATCHER_TIMEOUT = 30000;
+
 	// Each test gets its own copy of the fixture.
 	// That's why the folder name includes the test title.
 	// The goal is to avoid flakiness due to one test failing to create or
@@ -86,10 +88,10 @@ test.describe('R Test Explorer', { tag: [tags.TEST_EXPLORER, tags.R_PKG_DEVELOPM
 		await testExplorer.expectTestItems(['test-test-that.R', 'test-describe-it.R']);
 
 		fs.rmSync(path.join(testthatDir, 'test-test-that.R'));
-		await testExplorer.expectNoTestItem('test-test-that.R');
+		await testExplorer.expectNoTestItem('test-test-that.R', WATCHER_TIMEOUT);
 
 		fs.renameSync(path.join(testthatDir, 'test-describe-it.R'), path.join(testthatDir, 'test-renamed.R'));
-		await testExplorer.expectTestItems(['test-renamed.R']);
-		await testExplorer.expectNoTestItem('test-describe-it.R');
+		await testExplorer.expectTestItems(['test-renamed.R'], WATCHER_TIMEOUT);
+		await testExplorer.expectNoTestItem('test-describe-it.R', WATCHER_TIMEOUT);
 	});
 });

--- a/test/e2e/tests/test-explorer/test-explorer.test.ts
+++ b/test/e2e/tests/test-explorer/test-explorer.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import path = require('path');
+import fs = require('fs');
 import { copyFixtureFolder } from '../../infra/test-runner';
 import { test, tags } from '../_test.setup';
 
@@ -16,20 +17,27 @@ test.describe('R Test Explorer', { tag: [tags.TEST_EXPLORER, tags.R_PKG_DEVELOPM
 	// resources) to avoid cross-repo coordination with qa-example-content while the
 	// test explorer e2e stabilizes.
 	const FIXTURE_NAME = 'r.pkg.test.explorer.fixture';
+	const FIXTURE_SOURCE = path.join(process.cwd(), 'extensions/positron-r/resources/testing', FIXTURE_NAME);
 
-	test.beforeAll(async function ({ app }) {
-		const source = path.join(process.cwd(), 'extensions/positron-r/resources/testing', FIXTURE_NAME);
-		const destination = path.join(path.dirname(app.workspacePathOrFolder), FIXTURE_NAME);
-		copyFixtureFolder(source, destination);
-	});
+	// Each test gets its own copy of the fixture.
+	// That's why the folder name includes the test title.
+	// The goal is to avoid flakiness due to one test failing to create or
+	// delete something, thereby causing spurious failure of other tests.
+	// The folder name also includes worker index, so it's possible to use
+	// `--repeat-each` during development to check for flakiness, without
+	// creating file system crosstalk between concurrent runs of a single test.
+	function fixtureFolderFor(title: string, workerIndex: number): string {
+		const slug = title.replace(/[^a-z0-9]+/gi, '-');
+		return `${FIXTURE_NAME}.${slug}.w${workerIndex}`;
+	}
 
-	test.beforeEach(async function ({ app, openFolder }) {
+	test.beforeEach(async function ({ app, openFolder }, testInfo) {
 		const { testExplorer, sessions } = app.workbench;
-		await openFolder(FIXTURE_NAME);
+		const fixtureFolder = fixtureFolderFor(testInfo.title, testInfo.workerIndex);
+		copyFixtureFolder(FIXTURE_SOURCE, path.join(path.dirname(app.workspacePathOrFolder), fixtureFolder));
+
+		await openFolder(fixtureFolder);
 		await testExplorer.openTestExplorer();
-		// Tests share one app instance; reset to a known state.
-		await testExplorer.collapseAllTests();
-		await testExplorer.clearAllTestResults();
 		await sessions.start('r');
 	});
 
@@ -68,5 +76,18 @@ test.describe('R Test Explorer', { tag: [tags.TEST_EXPLORER, tags.R_PKG_DEVELOPM
 
 		await testExplorer.runTest(MULTI_LINE_LABEL);
 		await testExplorer.expectTestStatus(MULTI_LINE_LABEL, 'Passed', 60000);
+	});
+
+	// https://github.com/posit-dev/positron/issues/2929
+	test('Deleting a test file removes it from the tree', async function ({ app }, testInfo) {
+		const { testExplorer } = app.workbench;
+		const TEST_FILE = 'test-test-that.R';
+
+		await testExplorer.expectTestItems([TEST_FILE]);
+
+		const fixtureRoot = path.join(path.dirname(app.workspacePathOrFolder), fixtureFolderFor(testInfo.title, testInfo.workerIndex));
+		fs.rmSync(path.join(fixtureRoot, 'tests', 'testthat', TEST_FILE));
+
+		await testExplorer.expectNoTestItem(TEST_FILE);
 	});
 });

--- a/test/e2e/tests/test-explorer/test-explorer.test.ts
+++ b/test/e2e/tests/test-explorer/test-explorer.test.ts
@@ -79,15 +79,17 @@ test.describe('R Test Explorer', { tag: [tags.TEST_EXPLORER, tags.R_PKG_DEVELOPM
 	});
 
 	// https://github.com/posit-dev/positron/issues/2929
-	test('Deleting a test file removes it from the tree', async function ({ app }, testInfo) {
+	test('Deleting or renaming a test file updates the tree', async function ({ app }, testInfo) {
 		const { testExplorer } = app.workbench;
-		const TEST_FILE = 'test-test-that.R';
+		const testthatDir = path.join(path.dirname(app.workspacePathOrFolder), fixtureFolderFor(testInfo.title, testInfo.workerIndex), 'tests', 'testthat');
 
-		await testExplorer.expectTestItems([TEST_FILE]);
+		await testExplorer.expectTestItems(['test-test-that.R', 'test-describe-it.R']);
 
-		const fixtureRoot = path.join(path.dirname(app.workspacePathOrFolder), fixtureFolderFor(testInfo.title, testInfo.workerIndex));
-		fs.rmSync(path.join(fixtureRoot, 'tests', 'testthat', TEST_FILE));
+		fs.rmSync(path.join(testthatDir, 'test-test-that.R'));
+		await testExplorer.expectNoTestItem('test-test-that.R');
 
-		await testExplorer.expectNoTestItem(TEST_FILE);
+		fs.renameSync(path.join(testthatDir, 'test-describe-it.R'), path.join(testthatDir, 'test-renamed.R'));
+		await testExplorer.expectTestItems(['test-renamed.R']);
+		await testExplorer.expectNoTestItem('test-describe-it.R');
 	});
 });


### PR DESCRIPTION
Fixes #2929

The problem was that file deletion or renaming (which is a paired create+delete) would not always be reflected by a corresponding change in the file-level nodes in R test explorer's tree of test items.

Root cause:

The test explorer stores each test file's node under an id derived from its file name. But when a file was deleted, the watcher tried to remove its node by the file's full path instead of that name-based id. So, the lookup never matched, the delete silently did nothing, and the stale node stayed in the tree. (A rename arrives as delete-old + create-new, so the new node appeared while the old one lingered.) This PR extracts the id logic into a shared helper `uriToFileNodeId()` used by both the loader and the watcher, so the add and delete sides can't drift apart again.

How could you bump into this? A git branch switch, where the two branches had a different list of test files, was the most common way I noticed this.

Added a new e2e test, which inspired some improvements in the testing utilities for the explorer.

(The related case where an existing file's *contents* change out of band, e.g. branch switch or edit by an external agent, is tracked separately in #14499.)

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- The R test explorer now live-updates its file nodes as test files are created, deleted, or renamed (#2929)

### Validation Steps

@:test-explorer @:win @:web

1. Open an R package with testthat tests and reveal the Test Explorer.
2. Delete a test file on disk and confirm its node disappears from the tree.
3. Rename a test file on disk and confirm the old node disappears and the new one appears.