### PR TITLE
Keep Python environments consistent when updating or installing packages

### DIFF
--- a/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
@@ -134,11 +134,20 @@ export class PipPackageManager implements IPackageManager {
             return;
         }
 
-        const packageNames = outdatedPackages.map((pkg) => pkg.name);
-        const flags = await this._getInstallFlags();
-        const args = ['install', '--upgrade', ...flags, ...packageNames];
-
-        await this._executePipInTerminal(args, token);
+        // All-or-nothing: pin every installed package and bump the outdated ones
+        // to latest in a single resolve. If the batch is inconsistent it fails
+        // and nothing changes.
+        const freezeLines = await this._getInstalledFreeze(token);
+        const targets = outdatedPackages.map((pkg) => ({ name: pkg.name, version: pkg.latest_version }));
+        const content = buildPinnedRequirements(freezeLines, targets);
+        const tempFile = await this._writeRequirementsTempFile(content);
+        try {
+            const flags = await this._getInstallFlags();
+            const args = ['install', '-r', tempFile.filePath, ...flags];
+            await this._executePipInTerminal(args, token);
+        } finally {
+            tempFile.dispose();
+        }
     }
 
     async searchPackages(query: string, token?: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {

--- a/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
@@ -256,14 +256,6 @@ export class PipPackageManager implements IPackageManager {
     }
 
     /**
-     * Format package install requests into pip package specifiers.
-     * e.g., { name: "requests", version: "2.28.0" } becomes "requests==2.28.0"
-     */
-    private _formatPackageSpecs(packages: positron.PackageSpec[]): string[] {
-        return packages.map((pkg) => (pkg.version ? `${pkg.name}==${pkg.version}` : pkg.name));
-    }
-
-    /**
      * Get proxy flags if a proxy is configured.
      */
     private _getProxyFlags(): string[] {

--- a/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
@@ -65,11 +65,19 @@ export class PipPackageManager implements IPackageManager {
 
         await this._ensurePip();
 
-        const packageSpecs = this._formatPackageSpecs(packages);
-        const flags = await this._getInstallFlags();
-        const args = ['install', ...flags, ...packageSpecs];
-
-        await this._executePipInTerminal(args, token);
+        // Re-resolve against the full installed set so the new package can't break
+        // the environment: name every installed package (bare) plus the new
+        // package(s); an inconsistent install fails atomically.
+        const freezeLines = await this._getInstalledFreeze(token);
+        const content = buildRequirementsFile(freezeLines, packages);
+        const tempFile = await this._writeRequirementsTempFile(content);
+        try {
+            const flags = await this._getInstallFlags();
+            const args = ['install', '-r', tempFile.filePath, ...flags];
+            await this._executePipInTerminal(args, token);
+        } finally {
+            tempFile.dispose();
+        }
     }
 
     async uninstallPackages(packages: string[], token?: vscode.CancellationToken): Promise<void> {

--- a/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
@@ -97,14 +97,20 @@ export class PipPackageManager implements IPackageManager {
             throw new vscode.CancellationError();
         }
 
+        const missing = packages.find((pkg) => !pkg.version);
+        if (missing) {
+            throw new Error(`A version is required to update '${missing.name}'.`);
+        }
+
         await this._ensurePip();
 
-        // Re-resolve against the full installed set so all constraints are
-        // honored: pin everything at its current version and move only the
-        // targets. An inconsistent update fails atomically instead of silently
-        // breaking the environment.
+        // Re-resolve against the full installed set: name every package so all
+        // constraints are honored, but only the target is pinned (others are bare
+        // and stay put unless the update forces a change). An inconsistent update
+        // fails atomically instead of silently breaking the environment.
+        const targets = packages.map((pkg) => ({ name: pkg.name, version: pkg.version! }));
         const freezeLines = await this._getInstalledFreeze(token);
-        const content = buildRequirementsFile(freezeLines, packages);
+        const content = buildRequirementsFile(freezeLines, targets);
         const tempFile = await this._writeRequirementsTempFile(content);
         try {
             const flags = await this._getInstallFlags();
@@ -134,16 +140,15 @@ export class PipPackageManager implements IPackageManager {
             return;
         }
 
-        // All-or-nothing: pin every installed package and bump the outdated ones
-        // to latest in a single resolve. If the batch is inconsistent it fails
-        // and nothing changes.
+        // Upgrade every installed package to its latest mutually-compatible
+        // version: name them all (bare) and let pip resolve. All constraints are
+        // honored; an impossible set fails atomically.
         const freezeLines = await this._getInstalledFreeze(token);
-        const targets = outdatedPackages.map((pkg) => ({ name: pkg.name, version: pkg.latest_version }));
-        const content = buildRequirementsFile(freezeLines, targets);
+        const content = buildRequirementsFile(freezeLines, []);
         const tempFile = await this._writeRequirementsTempFile(content);
         try {
             const flags = await this._getInstallFlags();
-            const args = ['install', '-r', tempFile.filePath, ...flags];
+            const args = ['install', '--upgrade', '-r', tempFile.filePath, ...flags];
             await this._executePipInTerminal(args, token);
         } finally {
             tempFile.dispose();

--- a/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
@@ -7,10 +7,12 @@ import { randomUUID } from 'crypto';
 import * as positron from 'positron';
 import * as vscode from 'vscode';
 import { IPythonExecutionFactory, IPythonExecutionService } from '../../common/process/types';
+import { IFileSystem } from '../../common/platform/types';
 import { ITerminalServiceFactory } from '../../common/terminal/types';
 import { IServiceContainer } from '../../ioc/types';
 import { fetchMetadataWithOutdated } from './packageMetadata';
 import { searchPyPI, searchPyPIVersions } from './pypiSearch';
+import { buildPinnedRequirements } from './requirementsFile';
 import { IPackageManager, MessageEmitter, PackageSession } from './types';
 
 /**
@@ -97,11 +99,20 @@ export class PipPackageManager implements IPackageManager {
 
         await this._ensurePip();
 
-        const packageSpecs = this._formatPackageSpecs(packages);
-        const flags = await this._getInstallFlags();
-        const args = ['install', '--upgrade', ...flags, ...packageSpecs];
-
-        await this._executePipInTerminal(args, token);
+        // Re-resolve against the full installed set so all constraints are
+        // honored: pin everything at its current version and move only the
+        // targets. An inconsistent update fails atomically instead of silently
+        // breaking the environment.
+        const freezeLines = await this._getInstalledFreeze(token);
+        const content = buildPinnedRequirements(freezeLines, packages);
+        const tempFile = await this._writeRequirementsTempFile(content);
+        try {
+            const flags = await this._getInstallFlags();
+            const args = ['install', '-r', tempFile.filePath, ...flags];
+            await this._executePipInTerminal(args, token);
+        } finally {
+            tempFile.dispose();
+        }
     }
 
     async updateAllPackages(token?: vscode.CancellationToken): Promise<void> {
@@ -185,6 +196,31 @@ export class PipPackageManager implements IPackageManager {
     }
 
     /**
+     * Capture the full installed set as pinned `pip freeze` lines. Origins
+     * (`@ file://`, `-e`, VCS URLs) are preserved so already-installed packages
+     * resolve as satisfied without an index lookup.
+     */
+    private async _getInstalledFreeze(token?: vscode.CancellationToken): Promise<string[]> {
+        const pythonService = await this._getPythonService();
+        const result = await pythonService.execModule('pip', ['freeze'], { token });
+        if (!result.stdout || result.stdout.trim() === '') {
+            throw new Error('Failed to read the installed package list (pip freeze returned no output).');
+        }
+        return result.stdout.split(/\r?\n/);
+    }
+
+    /**
+     * Write requirements content to a temporary file. Caller must `dispose()`
+     * the returned handle when the install completes.
+     */
+    private async _writeRequirementsTempFile(content: string): Promise<{ filePath: string; dispose: () => void }> {
+        const fs = this._serviceContainer.get<IFileSystem>(IFileSystem);
+        const tempFile = await fs.createTemporaryFile('.txt');
+        await fs.writeFile(tempFile.filePath, content);
+        return tempFile;
+    }
+
+    /**
      * Ensure pip is available, throwing an error if not.
      */
     private async _ensurePip(): Promise<void> {
@@ -209,7 +245,8 @@ export class PipPackageManager implements IPackageManager {
      * Get proxy flags if a proxy is configured.
      */
     private _getProxyFlags(): string[] {
-        const proxy = vscode.workspace.getConfiguration('http').get<string>('proxy', '');
+        const config = vscode.workspace.getConfiguration('http');
+        const proxy = config?.get<string>('proxy', '');
         if (proxy) {
             return ['--proxy', proxy];
         }

--- a/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
@@ -245,8 +245,7 @@ export class PipPackageManager implements IPackageManager {
      * Get proxy flags if a proxy is configured.
      */
     private _getProxyFlags(): string[] {
-        const config = vscode.workspace.getConfiguration('http');
-        const proxy = config?.get<string>('proxy', '');
+        const proxy = vscode.workspace.getConfiguration('http').get<string>('proxy', '');
         if (proxy) {
             return ['--proxy', proxy];
         }

--- a/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
@@ -10,6 +10,7 @@ import { IPythonExecutionFactory, IPythonExecutionService } from '../../common/p
 import { IFileSystem } from '../../common/platform/types';
 import { ITerminalServiceFactory } from '../../common/terminal/types';
 import { IServiceContainer } from '../../ioc/types';
+import { traceVerbose } from '../../logging';
 import { fetchMetadataWithOutdated } from './packageMetadata';
 import { searchPyPI, searchPyPIVersions } from './pypiSearch';
 import { buildRequirementsFile } from './requirementsFile';
@@ -239,6 +240,9 @@ export class PipPackageManager implements IPackageManager {
         const fs = this._serviceContainer.get<IFileSystem>(IFileSystem);
         const tempFile = await fs.createTemporaryFile('.txt');
         await fs.writeFile(tempFile.filePath, content);
+        // Log the generated requirements so the resolved set passed to pip can be
+        // inspected (the temp file itself is deleted after the command runs).
+        traceVerbose(`pip package requirements file ${tempFile.filePath}:\n${content}`);
         return tempFile;
     }
 

--- a/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
@@ -12,7 +12,7 @@ import { ITerminalServiceFactory } from '../../common/terminal/types';
 import { IServiceContainer } from '../../ioc/types';
 import { fetchMetadataWithOutdated } from './packageMetadata';
 import { searchPyPI, searchPyPIVersions } from './pypiSearch';
-import { buildPinnedRequirements } from './requirementsFile';
+import { buildRequirementsFile } from './requirementsFile';
 import { IPackageManager, MessageEmitter, PackageSession } from './types';
 
 /**
@@ -104,7 +104,7 @@ export class PipPackageManager implements IPackageManager {
         // targets. An inconsistent update fails atomically instead of silently
         // breaking the environment.
         const freezeLines = await this._getInstalledFreeze(token);
-        const content = buildPinnedRequirements(freezeLines, packages);
+        const content = buildRequirementsFile(freezeLines, packages);
         const tempFile = await this._writeRequirementsTempFile(content);
         try {
             const flags = await this._getInstallFlags();
@@ -139,7 +139,7 @@ export class PipPackageManager implements IPackageManager {
         // and nothing changes.
         const freezeLines = await this._getInstalledFreeze(token);
         const targets = outdatedPackages.map((pkg) => ({ name: pkg.name, version: pkg.latest_version }));
-        const content = buildPinnedRequirements(freezeLines, targets);
+        const content = buildRequirementsFile(freezeLines, targets);
         const tempFile = await this._writeRequirementsTempFile(content);
         try {
             const flags = await this._getInstallFlags();

--- a/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
@@ -215,7 +215,7 @@ export class PipPackageManager implements IPackageManager {
         if (!result.stdout || result.stdout.trim() === '') {
             throw new Error('Failed to read the installed package list (pip freeze returned no output).');
         }
-        return result.stdout.split(/\r?\n/);
+        return result.stdout.split(/\r?\n/).filter((line) => line.trim() !== '');
     }
 
     /**

--- a/extensions/positron-python/src/client/positron/packages/requirementsFile.ts
+++ b/extensions/positron-python/src/client/positron/packages/requirementsFile.ts
@@ -1,0 +1,84 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Pure helpers for building a pinned requirements file used by the pip and uv
+ * environment-workflow update flows. Naming every installed package in a single
+ * `install -r` forces the resolver to honor all constraints, so an update that
+ * would break the environment fails atomically instead of succeeding silently.
+ */
+
+/** Freeze lines that are emitted by some environments but are not installable. */
+const JUNK_LINES = new Set(['pkg-resources==0.0.0']);
+
+/**
+ * Normalize a package name per PEP 503: lowercase and collapse any run of
+ * `-`, `_`, or `.` into a single `-`. Used only for matching, not for output.
+ */
+export function normalizePackageName(name: string): string {
+    return name.toLowerCase().replace(/[-_.]+/g, '-');
+}
+
+/**
+ * Extract the package name from a single `pip freeze` line, or `undefined` if
+ * the line is not a plain requirement (blank, comment, option, or editable).
+ * Editables (`-e ...`) are intentionally not matched: they are preserved as-is.
+ */
+export function extractRequirementName(line: string): string | undefined {
+    const trimmed = line.trim();
+    if (trimmed === '' || trimmed.startsWith('#') || trimmed.startsWith('-')) {
+        return undefined;
+    }
+    // Leading PEP 508 name token, e.g. "Werkzeug==2.0.3" or "pkg @ file://...".
+    const match = trimmed.match(/^([A-Za-z0-9][A-Za-z0-9._-]*)/);
+    return match ? match[1] : undefined;
+}
+
+/**
+ * Build pinned requirements content from `freeze` output and the set of target
+ * packages being updated. Each target's existing line is replaced with
+ * `name==version` (or a bare `name` when no version is given); all other lines
+ * are preserved verbatim and in order; junk lines are dropped; targets absent
+ * from the freeze output are appended. The result ends with a trailing newline.
+ */
+export function buildPinnedRequirements(
+    freezeLines: string[],
+    targets: Array<{ name: string; version?: string }>,
+): string {
+    const targetSpecByNormName = new Map<string, string>();
+    for (const target of targets) {
+        const spec = target.version ? `${target.name}==${target.version}` : target.name;
+        targetSpecByNormName.set(normalizePackageName(target.name), spec);
+    }
+
+    const out: string[] = [];
+    const used = new Set<string>();
+
+    for (const raw of freezeLines) {
+        const line = raw.trimEnd();
+        if (line.trim() === '' || JUNK_LINES.has(line.trim())) {
+            continue;
+        }
+        const name = extractRequirementName(line);
+        if (name) {
+            const norm = normalizePackageName(name);
+            const spec = targetSpecByNormName.get(norm);
+            if (spec !== undefined) {
+                out.push(spec);
+                used.add(norm);
+                continue;
+            }
+        }
+        out.push(line);
+    }
+
+    for (const [norm, spec] of targetSpecByNormName) {
+        if (!used.has(norm)) {
+            out.push(spec);
+        }
+    }
+
+    return out.join('\n') + '\n';
+}

--- a/extensions/positron-python/src/client/positron/packages/requirementsFile.ts
+++ b/extensions/positron-python/src/client/positron/packages/requirementsFile.ts
@@ -49,11 +49,14 @@ export function extractRequirementName(line: string): string | undefined {
  */
 export function buildRequirementsFile(
     freezeLines: string[],
-    targets: Array<{ name: string; version: string }>,
+    targets: Array<{ name: string; version?: string }>,
 ): string {
     const targetSpecByNormName = new Map<string, string>();
     for (const target of targets) {
-        targetSpecByNormName.set(normalizePackageName(target.name), `${target.name}==${target.version}`);
+        targetSpecByNormName.set(
+            normalizePackageName(target.name),
+            target.version ? `${target.name}==${target.version}` : target.name,
+        );
     }
 
     const out: string[] = [];

--- a/extensions/positron-python/src/client/positron/packages/requirementsFile.ts
+++ b/extensions/positron-python/src/client/positron/packages/requirementsFile.ts
@@ -37,20 +37,23 @@ export function extractRequirementName(line: string): string | undefined {
 }
 
 /**
- * Build pinned requirements content from `freeze` output and the set of target
- * packages being updated. Each target's existing line is replaced with
- * `name==version` (or a bare `name` when no version is given); all other lines
- * are preserved verbatim and in order; junk lines are dropped; targets absent
- * from the freeze output are appended. The result ends with a trailing newline.
+ * Build requirements content from `freeze` output and the target packages being
+ * updated. Every installed package is named so the resolver honors all
+ * constraints, but plain PyPI pins are emitted as **bare names** (no version) so
+ * the resolver keeps an already-satisfied package put unless something forces it
+ * to move. Origin lines (direct references `name @ ...`, editables `-e ...`) and
+ * comments are kept verbatim so local/VCS packages resolve without an index
+ * lookup. Each target is pinned to `name==version`; targets absent from the
+ * freeze output are appended. Junk and blank lines are dropped. Pass an empty
+ * `targets` for Update All (the caller adds `--upgrade`). Ends with a newline.
  */
-export function buildPinnedRequirements(
+export function buildRequirementsFile(
     freezeLines: string[],
-    targets: Array<{ name: string; version?: string }>,
+    targets: Array<{ name: string; version: string }>,
 ): string {
     const targetSpecByNormName = new Map<string, string>();
     for (const target of targets) {
-        const spec = target.version ? `${target.name}==${target.version}` : target.name;
-        targetSpecByNormName.set(normalizePackageName(target.name), spec);
+        targetSpecByNormName.set(normalizePackageName(target.name), `${target.name}==${target.version}`);
     }
 
     const out: string[] = [];
@@ -58,16 +61,23 @@ export function buildPinnedRequirements(
 
     for (const raw of freezeLines) {
         const line = raw.trimEnd();
-        if (line.trim() === '' || JUNK_LINES.has(line.trim())) {
+        const trimmed = line.trim();
+        if (trimmed === '' || JUNK_LINES.has(trimmed)) {
             continue;
         }
         const name = extractRequirementName(line);
         if (name) {
             const norm = normalizePackageName(name);
-            const spec = targetSpecByNormName.get(norm);
-            if (spec !== undefined) {
-                out.push(spec);
+            const targetSpec = targetSpecByNormName.get(norm);
+            if (targetSpec !== undefined) {
+                out.push(targetSpec);
                 used.add(norm);
+                continue;
+            }
+            // Plain PyPI pin -> bare name. Origin lines (containing `@`) fall
+            // through to verbatim so a local/VCS package isn't sent to the index.
+            if (!line.includes('@')) {
+                out.push(name);
                 continue;
             }
         }

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -269,7 +269,7 @@ export class UvPackageManager implements IPackageManager {
         if (!result.stdout || result.stdout.trim() === '') {
             throw new Error('Failed to read the installed package list (uv pip freeze returned no output).');
         }
-        return result.stdout.split(/\r?\n/);
+        return result.stdout.split(/\r?\n/).filter((line) => line.trim() !== '');
     }
 
     /**

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -14,7 +14,7 @@ import { ITerminalServiceFactory } from '../../common/terminal/types';
 import { IServiceContainer } from '../../ioc/types';
 import { isUvInstalled } from '../../pythonEnvironments/common/environmentManagers/uv';
 import { fetchMetadataWithOutdated } from './packageMetadata';
-import { buildPinnedRequirements } from './requirementsFile';
+import { buildRequirementsFile } from './requirementsFile';
 import { searchPyPI, searchPyPIVersions } from './pypiSearch';
 import { IPackageManager, MessageEmitter, PackageSession } from './types';
 
@@ -128,7 +128,7 @@ export class UvPackageManager implements IPackageManager {
             // pinning everything and moving only the targets, so an inconsistent
             // update fails atomically instead of breaking the environment.
             const freezeLines = await this._getInstalledFreeze(token);
-            const content = buildPinnedRequirements(freezeLines, packages);
+            const content = buildRequirementsFile(freezeLines, packages);
             const tempFile = await this._writeRequirementsTempFile(content);
             try {
                 const args = ['pip', 'install', '-r', tempFile.filePath, '--python', this._pythonPath];
@@ -164,7 +164,7 @@ export class UvPackageManager implements IPackageManager {
 
             const freezeLines = await this._getInstalledFreeze(token);
             const targets = outdatedPackages.map((pkg) => ({ name: pkg.name, version: pkg.latest_version }));
-            const content = buildPinnedRequirements(freezeLines, targets);
+            const content = buildRequirementsFile(freezeLines, targets);
             const tempFile = await this._writeRequirementsTempFile(content);
             try {
                 const args = ['pip', 'install', '-r', tempFile.filePath, '--python', this._pythonPath];

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -75,9 +75,18 @@ export class UvPackageManager implements IPackageManager {
             const args = ['add', '--active', '--python', this._pythonPath, ...packageSpecs];
             await this._executeUvInTerminal(args, token);
         } else {
-            // Environment workflow: uv pip install --python <path> <packages>
-            const args = ['pip', 'install', '--python', this._pythonPath, ...packageSpecs];
-            await this._executeUvInTerminal(args, token);
+            // Re-resolve against the full installed set: name every installed
+            // package (bare) plus the new package(s) so an inconsistent install
+            // fails atomically instead of breaking the environment.
+            const freezeLines = await this._getInstalledFreeze(token);
+            const content = buildRequirementsFile(freezeLines, packages);
+            const tempFile = await this._writeRequirementsTempFile(content);
+            try {
+                const args = ['pip', 'install', '-r', tempFile.filePath, '--python', this._pythonPath];
+                await this._executeUvInTerminal(args, token);
+            } finally {
+                tempFile.dispose();
+            }
         }
     }
 

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -13,6 +13,7 @@ import { IProcessServiceFactory } from '../../common/process/types';
 import { ITerminalServiceFactory } from '../../common/terminal/types';
 import { IServiceContainer } from '../../ioc/types';
 import { isUvInstalled } from '../../pythonEnvironments/common/environmentManagers/uv';
+import { traceVerbose } from '../../logging';
 import { fetchMetadataWithOutdated } from './packageMetadata';
 import { buildRequirementsFile } from './requirementsFile';
 import { searchPyPI, searchPyPIVersions } from './pypiSearch';
@@ -292,6 +293,9 @@ export class UvPackageManager implements IPackageManager {
         const fs = this._serviceContainer.get<IFileSystem>(IFileSystem);
         const tempFile = await fs.createTemporaryFile('.txt');
         await fs.writeFile(tempFile.filePath, content);
+        // Log the generated requirements so the resolved set passed to uv can be
+        // inspected (the temp file itself is deleted after the command runs).
+        traceVerbose(`uv package requirements file ${tempFile.filePath}:\n${content}`);
         return tempFile;
     }
 

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -274,11 +274,10 @@ export class UvPackageManager implements IPackageManager {
         const processServiceFactory = this._serviceContainer.get<IProcessServiceFactory>(IProcessServiceFactory);
         const processService = await processServiceFactory.create();
         const proxyEnv = this._getProxyEnv();
-        const result = await processService.exec(
-            'uv',
-            ['pip', 'freeze', '--python', this._pythonPath],
-            { extraVariables: proxyEnv, token },
-        );
+        const result = await processService.exec('uv', ['pip', 'freeze', '--python', this._pythonPath], {
+            extraVariables: proxyEnv,
+            token,
+        });
         if (!result.stdout || result.stdout.trim() === '') {
             throw new Error('Failed to read the installed package list (uv pip freeze returned no output).');
         }

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -14,6 +14,7 @@ import { ITerminalServiceFactory } from '../../common/terminal/types';
 import { IServiceContainer } from '../../ioc/types';
 import { isUvInstalled } from '../../pythonEnvironments/common/environmentManagers/uv';
 import { fetchMetadataWithOutdated } from './packageMetadata';
+import { buildPinnedRequirements } from './requirementsFile';
 import { searchPyPI, searchPyPIVersions } from './pypiSearch';
 import { IPackageManager, MessageEmitter, PackageSession } from './types';
 
@@ -123,9 +124,18 @@ export class UvPackageManager implements IPackageManager {
             const args = ['add', '--upgrade', '--active', '--python', this._pythonPath, ...packageSpecs];
             await this._executeUvInTerminal(args, token);
         } else {
-            // Environment workflow: uv pip install --upgrade --python <path> <packages>
-            const args = ['pip', 'install', '--upgrade', '--python', this._pythonPath, ...packageSpecs];
-            await this._executeUvInTerminal(args, token);
+            // Environment workflow: re-resolve against the full installed set by
+            // pinning everything and moving only the targets, so an inconsistent
+            // update fails atomically instead of breaking the environment.
+            const freezeLines = await this._getInstalledFreeze(token);
+            const content = buildPinnedRequirements(freezeLines, packages);
+            const tempFile = await this._writeRequirementsTempFile(content);
+            try {
+                const args = ['pip', 'install', '-r', tempFile.filePath, '--python', this._pythonPath];
+                await this._executeUvInTerminal(args, token);
+            } finally {
+                tempFile.dispose();
+            }
         }
     }
 
@@ -143,7 +153,8 @@ export class UvPackageManager implements IPackageManager {
             const args = ['sync', '--upgrade', '--active', '--python', this._pythonPath];
             await this._executeUvInTerminal(args, token);
         } else {
-            // Environment workflow: get outdated packages and upgrade them
+            // Environment workflow: all-or-nothing re-resolve. Pin every installed
+            // package and bump the outdated ones to latest in a single resolve.
             const outdatedPackages = await this._getOutdatedPackages(token);
 
             if (outdatedPackages.length === 0) {
@@ -151,9 +162,16 @@ export class UvPackageManager implements IPackageManager {
                 return;
             }
 
-            const packageNames = outdatedPackages.map((pkg) => pkg.name);
-            const args = ['pip', 'install', '--upgrade', '--python', this._pythonPath, ...packageNames];
-            await this._executeUvInTerminal(args, token);
+            const freezeLines = await this._getInstalledFreeze(token);
+            const targets = outdatedPackages.map((pkg) => ({ name: pkg.name, version: pkg.latest_version }));
+            const content = buildPinnedRequirements(freezeLines, targets);
+            const tempFile = await this._writeRequirementsTempFile(content);
+            try {
+                const args = ['pip', 'install', '-r', tempFile.filePath, '--python', this._pythonPath];
+                await this._executeUvInTerminal(args, token);
+            } finally {
+                tempFile.dispose();
+            }
         }
     }
 
@@ -195,7 +213,7 @@ export class UvPackageManager implements IPackageManager {
         const fileSystem = this._serviceContainer.get<IFileSystem>(IFileSystem);
 
         // Get workspace folder
-        let workspaceFolder = workspaceService.workspaceFolders?.[0];
+        const workspaceFolder = workspaceService.workspaceFolders?.[0];
         if (!workspaceFolder) {
             return false;
         }
@@ -233,6 +251,36 @@ export class UvPackageManager implements IPackageManager {
         }
 
         return true;
+    }
+
+    /**
+     * Capture the full installed set as pinned `uv pip freeze` lines, preserving
+     * install origins so already-installed packages resolve as satisfied.
+     */
+    private async _getInstalledFreeze(token?: vscode.CancellationToken): Promise<string[]> {
+        const processServiceFactory = this._serviceContainer.get<IProcessServiceFactory>(IProcessServiceFactory);
+        const processService = await processServiceFactory.create();
+        const proxyEnv = this._getProxyEnv();
+        const result = await processService.exec(
+            'uv',
+            ['pip', 'freeze', '--python', this._pythonPath],
+            { extraVariables: proxyEnv, token },
+        );
+        if (!result.stdout || result.stdout.trim() === '') {
+            throw new Error('Failed to read the installed package list (uv pip freeze returned no output).');
+        }
+        return result.stdout.split(/\r?\n/);
+    }
+
+    /**
+     * Write requirements content to a temporary file. Caller must `dispose()`
+     * the returned handle when the install completes.
+     */
+    private async _writeRequirementsTempFile(content: string): Promise<{ filePath: string; dispose: () => void }> {
+        const fs = this._serviceContainer.get<IFileSystem>(IFileSystem);
+        const tempFile = await fs.createTemporaryFile('.txt');
+        await fs.writeFile(tempFile.filePath, content);
+        return tempFile;
     }
 
     /**

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -124,11 +124,15 @@ export class UvPackageManager implements IPackageManager {
             const args = ['add', '--upgrade', '--active', '--python', this._pythonPath, ...packageSpecs];
             await this._executeUvInTerminal(args, token);
         } else {
-            // Environment workflow: re-resolve against the full installed set by
-            // pinning everything and moving only the targets, so an inconsistent
-            // update fails atomically instead of breaking the environment.
+            const missing = packages.find((pkg) => !pkg.version);
+            if (missing) {
+                throw new Error(`A version is required to update '${missing.name}'.`);
+            }
+            // Re-resolve against the full installed set: name every package (bare),
+            // pin only the target, so an inconsistent update fails atomically.
+            const targets = packages.map((pkg) => ({ name: pkg.name, version: pkg.version! }));
             const freezeLines = await this._getInstalledFreeze(token);
-            const content = buildRequirementsFile(freezeLines, packages);
+            const content = buildRequirementsFile(freezeLines, targets);
             const tempFile = await this._writeRequirementsTempFile(content);
             try {
                 const args = ['pip', 'install', '-r', tempFile.filePath, '--python', this._pythonPath];
@@ -153,8 +157,6 @@ export class UvPackageManager implements IPackageManager {
             const args = ['sync', '--upgrade', '--active', '--python', this._pythonPath];
             await this._executeUvInTerminal(args, token);
         } else {
-            // Environment workflow: all-or-nothing re-resolve. Pin every installed
-            // package and bump the outdated ones to latest in a single resolve.
             const outdatedPackages = await this._getOutdatedPackages(token);
 
             if (outdatedPackages.length === 0) {
@@ -162,12 +164,13 @@ export class UvPackageManager implements IPackageManager {
                 return;
             }
 
+            // Upgrade every installed package to its latest mutually-compatible
+            // version: name them all (bare) and let uv resolve.
             const freezeLines = await this._getInstalledFreeze(token);
-            const targets = outdatedPackages.map((pkg) => ({ name: pkg.name, version: pkg.latest_version }));
-            const content = buildRequirementsFile(freezeLines, targets);
+            const content = buildRequirementsFile(freezeLines, []);
             const tempFile = await this._writeRequirementsTempFile(content);
             try {
-                const args = ['pip', 'install', '-r', tempFile.filePath, '--python', this._pythonPath];
+                const args = ['pip', 'install', '--upgrade', '-r', tempFile.filePath, '--python', this._pythonPath];
                 await this._executeUvInTerminal(args, token);
             } finally {
                 tempFile.dispose();

--- a/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
@@ -40,7 +40,10 @@ suite('PipPackageManager update Tests', () => {
         // Default freeze output; individual tests can override.
         pythonService.execModule
             .withArgs('pip', sinon.match.array.startsWith(['freeze']))
-            .resolves({ stdout: 'werkzeug==2.0.3\npositron-update-demo @ file:///tmp/demo\n', stderr: '' });
+            .resolves({
+                stdout: 'flask==2.2.0\nwerkzeug==2.0.3\npositron-update-demo @ file:///tmp/demo\n',
+                stderr: '',
+            });
 
         terminalService = {
             show: sinon.stub().resolves(),
@@ -86,19 +89,29 @@ suite('PipPackageManager update Tests', () => {
         vscode.workspace.getConfiguration = originalGetConfiguration;
     });
 
-    test('updatePackages installs a pinned requirements file naming all packages', async () => {
+    test('updatePackages writes a bare-names requirements file with the target pinned', async () => {
         await manager.updatePackages([{ name: 'werkzeug', version: '3.1.8' }]);
 
-        // The freeze line for the target is replaced; constraining package is kept.
-        expect(writtenContent).to.contain('werkzeug==3.1.8');
-        expect(writtenContent).to.contain('positron-update-demo @ file:///tmp/demo');
-        expect(writtenContent).to.not.contain('werkzeug==2.0.3');
+        expect(writtenContent).to.contain('werkzeug==3.1.8');        // target pinned
+        expect(writtenContent).to.contain('flask');                 // other PyPI -> bare
+        expect(writtenContent).to.not.contain('flask==2.2.0');      // not pinned
+        expect(writtenContent).to.contain('positron-update-demo @ file:///tmp/demo'); // origin verbatim
 
-        // The terminal runs `pip install -r <tempfile>`, not a bare --upgrade.
         const [pythonPath, args] = terminalService.sendCommand.firstCall.args;
         expect(pythonPath).to.equal('/path/to/python');
         expect(args).to.include.members(['-m', 'pip', 'install', '-r', '/tmp/reqs.txt']);
         expect(args).to.not.include('--upgrade');
+    });
+
+    test('updatePackages throws when a target has no version', async () => {
+        let threw = false;
+        try {
+            await manager.updatePackages([{ name: 'werkzeug' }]);
+        } catch {
+            threw = true;
+        }
+        expect(threw).to.equal(true);
+        expect(terminalService.sendCommand.called).to.equal(false);
     });
 
     test('updatePackages propagates a resolver failure (no silent success)', async () => {
@@ -113,21 +126,18 @@ suite('PipPackageManager update Tests', () => {
         expect(threw).to.equal(true);
     });
 
-    test('updateAllPackages pins outdated packages to latest in the requirements file', async () => {
+    test('updateAllPackages writes a bare requirements file and runs install --upgrade -r', async () => {
         pythonService.execModule
             .withArgs('pip', sinon.match.array.startsWith(['list', '--outdated']))
-            .resolves({
-                stdout: JSON.stringify([{ name: 'werkzeug', latest_version: '3.1.8' }]),
-                stderr: '',
-            });
+            .resolves({ stdout: JSON.stringify([{ name: 'werkzeug', latest_version: '3.1.8' }]), stderr: '' });
 
         await manager.updateAllPackages();
 
-        expect(writtenContent).to.contain('werkzeug==3.1.8');
+        expect(writtenContent).to.contain('werkzeug');                 // bare, no pin
+        expect(writtenContent).to.not.contain('werkzeug==');
         expect(writtenContent).to.contain('positron-update-demo @ file:///tmp/demo');
         const [, args] = terminalService.sendCommand.firstCall.args;
-        expect(args).to.include.members(['install', '-r', '/tmp/reqs.txt']);
-        expect(args).to.not.include('--upgrade');
+        expect(args).to.include.members(['install', '--upgrade', '-r', '/tmp/reqs.txt']);
     });
 
     test('updateAllPackages does nothing when no packages are outdated', async () => {

--- a/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
@@ -104,13 +104,14 @@ suite('PipPackageManager update Tests', () => {
     });
 
     test('updatePackages throws when a target has no version', async () => {
-        let threw = false;
+        let caughtError: unknown;
         try {
             await manager.updatePackages([{ name: 'werkzeug' }]);
-        } catch {
-            threw = true;
+        } catch (e) {
+            caughtError = e;
         }
-        expect(threw).to.equal(true);
+        expect(caughtError).to.be.instanceOf(Error);
+        expect((caughtError as Error).message).to.contain('werkzeug');
         expect(terminalService.sendCommand.called).to.equal(false);
     });
 

--- a/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
@@ -30,6 +30,7 @@ suite('PipPackageManager update Tests', () => {
     let writtenContent: string;
     let messageEmitter: MessageEmitter;
     let session: PackageSession;
+    let originalGetConfiguration: typeof vscode.workspace.getConfiguration;
 
     setup(() => {
         pythonService = {
@@ -58,6 +59,7 @@ suite('PipPackageManager update Tests', () => {
 
         // Assign getConfiguration so _getProxyFlags() gets a real WorkspaceConfiguration-like
         // object (vscode.workspace is a ts-mockito instance; sinon.stub won't work on it).
+        originalGetConfiguration = vscode.workspace.getConfiguration;
         vscode.workspace.getConfiguration = (_section?: string) =>
             ({ get: (_key: string, defaultValue?: unknown) => defaultValue } as any);
 
@@ -79,7 +81,10 @@ suite('PipPackageManager update Tests', () => {
         manager = new PipPackageManager('/path/to/python', messageEmitter, serviceContainer, session);
     });
 
-    teardown(() => sinon.restore());
+    teardown(() => {
+        sinon.restore();
+        vscode.workspace.getConfiguration = originalGetConfiguration;
+    });
 
     test('updatePackages installs a pinned requirements file naming all packages', async () => {
         await manager.updatePackages([{ name: 'werkzeug', version: '3.1.8' }]);

--- a/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
@@ -150,4 +150,21 @@ suite('PipPackageManager update Tests', () => {
 
         expect(terminalService.sendCommand.called).to.equal(false);
     });
+
+    test('installPackages names the full installed set and adds the new package', async () => {
+        await manager.installPackages([{ name: 'cowsay', version: '6.1' }]);
+
+        expect(writtenContent).to.contain('cowsay==6.1');                 // new package pinned
+        expect(writtenContent).to.contain('flask');                       // installed -> bare
+        expect(writtenContent).to.contain('positron-update-demo @ file:///tmp/demo'); // origin verbatim
+        const [, args] = terminalService.sendCommand.firstCall.args;
+        expect(args).to.include.members(['install', '-r', '/tmp/reqs.txt']);
+        expect(args).to.not.include('--upgrade');
+    });
+
+    test('installPackages adds a versionless new package as a bare name', async () => {
+        await manager.installPackages([{ name: 'cowsay' }]);
+        expect(writtenContent).to.contain('cowsay');
+        expect(writtenContent).to.not.contain('cowsay==');
+    });
 });

--- a/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
@@ -38,12 +38,10 @@ suite('PipPackageManager update Tests', () => {
             execModule: sinon.stub(),
         };
         // Default freeze output; individual tests can override.
-        pythonService.execModule
-            .withArgs('pip', sinon.match.array.startsWith(['freeze']))
-            .resolves({
-                stdout: 'flask==2.2.0\nwerkzeug==2.0.3\npositron-update-demo @ file:///tmp/demo\n',
-                stderr: '',
-            });
+        pythonService.execModule.withArgs('pip', sinon.match.array.startsWith(['freeze'])).resolves({
+            stdout: 'flask==2.2.0\nwerkzeug==2.0.3\npositron-update-demo @ file:///tmp/demo\n',
+            stderr: '',
+        });
 
         terminalService = {
             show: sinon.stub().resolves(),
@@ -92,9 +90,9 @@ suite('PipPackageManager update Tests', () => {
     test('updatePackages writes a bare-names requirements file with the target pinned', async () => {
         await manager.updatePackages([{ name: 'werkzeug', version: '3.1.8' }]);
 
-        expect(writtenContent).to.contain('werkzeug==3.1.8');        // target pinned
-        expect(writtenContent).to.contain('flask');                 // other PyPI -> bare
-        expect(writtenContent).to.not.contain('flask==2.2.0');      // not pinned
+        expect(writtenContent).to.contain('werkzeug==3.1.8'); // target pinned
+        expect(writtenContent).to.contain('flask'); // other PyPI -> bare
+        expect(writtenContent).to.not.contain('flask==2.2.0'); // not pinned
         expect(writtenContent).to.contain('positron-update-demo @ file:///tmp/demo'); // origin verbatim
 
         const [pythonPath, args] = terminalService.sendCommand.firstCall.args;
@@ -134,7 +132,7 @@ suite('PipPackageManager update Tests', () => {
 
         await manager.updateAllPackages();
 
-        expect(writtenContent).to.contain('werkzeug');                 // bare, no pin
+        expect(writtenContent).to.contain('werkzeug'); // bare, no pin
         expect(writtenContent).to.not.contain('werkzeug==');
         expect(writtenContent).to.contain('positron-update-demo @ file:///tmp/demo');
         const [, args] = terminalService.sendCommand.firstCall.args;
@@ -154,8 +152,8 @@ suite('PipPackageManager update Tests', () => {
     test('installPackages names the full installed set and adds the new package', async () => {
         await manager.installPackages([{ name: 'cowsay', version: '6.1' }]);
 
-        expect(writtenContent).to.contain('cowsay==6.1');                 // new package pinned
-        expect(writtenContent).to.contain('flask');                       // installed -> bare
+        expect(writtenContent).to.contain('cowsay==6.1'); // new package pinned
+        expect(writtenContent).to.contain('flask'); // installed -> bare
         expect(writtenContent).to.contain('positron-update-demo @ file:///tmp/demo'); // origin verbatim
         const [, args] = terminalService.sendCommand.firstCall.args;
         expect(args).to.include.members(['install', '-r', '/tmp/reqs.txt']);

--- a/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
@@ -1,0 +1,104 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+// eslint-disable-next-line import/no-unresolved
+import * as positron from 'positron';
+import { IPythonExecutionFactory } from '../../client/common/process/types';
+import { ITerminalServiceFactory } from '../../client/common/terminal/types';
+import { IFileSystem } from '../../client/common/platform/types';
+import { IServiceContainer } from '../../client/ioc/types';
+import { PipPackageManager } from '../../client/positron/packages/pipPackageManager';
+import { PackageSession } from '../../client/positron/packages/types';
+
+interface MessageEmitter {
+    fire(message: positron.LanguageRuntimeMessage): void;
+}
+
+suite('PipPackageManager update Tests', () => {
+    let manager: PipPackageManager;
+    let serviceContainer: IServiceContainer;
+    let pythonService: { isModuleInstalled: sinon.SinonStub; execModule: sinon.SinonStub };
+    let terminalService: { show: sinon.SinonStub; sendCommand: sinon.SinonStub; sendText: sinon.SinonStub };
+    let fileSystem: { createTemporaryFile: sinon.SinonStub; writeFile: sinon.SinonStub };
+    let writtenContent: string;
+    let messageEmitter: MessageEmitter;
+    let session: PackageSession;
+
+    setup(() => {
+        pythonService = {
+            isModuleInstalled: sinon.stub().resolves(true),
+            execModule: sinon.stub(),
+        };
+        // Default freeze output; individual tests can override.
+        pythonService.execModule
+            .withArgs('pip', sinon.match.array.startsWith(['freeze']))
+            .resolves({ stdout: 'werkzeug==2.0.3\npositron-update-demo @ file:///tmp/demo\n', stderr: '' });
+
+        terminalService = {
+            show: sinon.stub().resolves(),
+            sendCommand: sinon.stub().resolves(),
+            sendText: sinon.stub().resolves(),
+        };
+
+        writtenContent = '';
+        fileSystem = {
+            createTemporaryFile: sinon.stub().resolves({ filePath: '/tmp/reqs.txt', dispose: sinon.stub() }),
+            writeFile: sinon.stub().callsFake((_p: string, text: string) => {
+                writtenContent = text;
+                return Promise.resolve();
+            }),
+        };
+
+        serviceContainer = { get: sinon.stub() } as any;
+        const pythonFactory: IPythonExecutionFactory = { create: sinon.stub().resolves(pythonService) } as any;
+        const terminalFactory: ITerminalServiceFactory = {
+            getTerminalService: sinon.stub().returns(terminalService),
+        } as any;
+        (serviceContainer.get as sinon.SinonStub)
+            .withArgs(IPythonExecutionFactory)
+            .returns(pythonFactory)
+            .withArgs(ITerminalServiceFactory)
+            .returns(terminalFactory)
+            .withArgs(IFileSystem)
+            .returns(fileSystem);
+
+        messageEmitter = { fire: sinon.stub() };
+        session = { metadata: { sessionId: 'test' }, callMethod: sinon.stub().resolves([]) };
+        manager = new PipPackageManager('/path/to/python', messageEmitter, serviceContainer, session);
+    });
+
+    teardown(() => sinon.restore());
+
+    test('updatePackages installs a pinned requirements file naming all packages', async () => {
+        await manager.updatePackages([{ name: 'werkzeug', version: '3.1.8' }]);
+
+        // The freeze line for the target is replaced; constraining package is kept.
+        expect(writtenContent).to.contain('werkzeug==3.1.8');
+        expect(writtenContent).to.contain('positron-update-demo @ file:///tmp/demo');
+        expect(writtenContent).to.not.contain('werkzeug==2.0.3');
+
+        // The terminal runs `pip install -r <tempfile>`, not a bare --upgrade.
+        const [pythonPath, args] = terminalService.sendCommand.firstCall.args;
+        expect(pythonPath).to.equal('/path/to/python');
+        expect(args).to.include.members(['-m', 'pip', 'install', '-r', '/tmp/reqs.txt']);
+        expect(args).to.not.include('--upgrade');
+    });
+
+    test('updatePackages propagates a resolver failure (no silent success)', async () => {
+        terminalService.sendCommand.rejects(new Error('Command failed with errors'));
+
+        let threw = false;
+        try {
+            await manager.updatePackages([{ name: 'werkzeug', version: '3.1.8' }]);
+        } catch {
+            threw = true;
+        }
+        expect(threw).to.equal(true);
+    });
+});

--- a/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
@@ -112,4 +112,30 @@ suite('PipPackageManager update Tests', () => {
         }
         expect(threw).to.equal(true);
     });
+
+    test('updateAllPackages pins outdated packages to latest in the requirements file', async () => {
+        pythonService.execModule
+            .withArgs('pip', sinon.match.array.startsWith(['list', '--outdated']))
+            .resolves({
+                stdout: JSON.stringify([{ name: 'werkzeug', latest_version: '3.1.8' }]),
+                stderr: '',
+            });
+
+        await manager.updateAllPackages();
+
+        expect(writtenContent).to.contain('werkzeug==3.1.8');
+        expect(writtenContent).to.contain('positron-update-demo @ file:///tmp/demo');
+        const [, args] = terminalService.sendCommand.firstCall.args;
+        expect(args).to.include.members(['install', '-r', '/tmp/reqs.txt']);
+    });
+
+    test('updateAllPackages does nothing when no packages are outdated', async () => {
+        pythonService.execModule
+            .withArgs('pip', sinon.match.array.startsWith(['list', '--outdated']))
+            .resolves({ stdout: '[]', stderr: '' });
+
+        await manager.updateAllPackages();
+
+        expect(terminalService.sendCommand.called).to.equal(false);
+    });
 });

--- a/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
@@ -7,6 +7,7 @@
 
 import { expect } from 'chai';
 import * as sinon from 'sinon';
+import * as vscode from 'vscode';
 // eslint-disable-next-line import/no-unresolved
 import * as positron from 'positron';
 import { IPythonExecutionFactory } from '../../client/common/process/types';
@@ -54,6 +55,11 @@ suite('PipPackageManager update Tests', () => {
                 return Promise.resolve();
             }),
         };
+
+        // Assign getConfiguration so _getProxyFlags() gets a real WorkspaceConfiguration-like
+        // object (vscode.workspace is a ts-mockito instance; sinon.stub won't work on it).
+        vscode.workspace.getConfiguration = (_section?: string) =>
+            ({ get: (_key: string, defaultValue?: unknown) => defaultValue } as any);
 
         serviceContainer = { get: sinon.stub() } as any;
         const pythonFactory: IPythonExecutionFactory = { create: sinon.stub().resolves(pythonService) } as any;

--- a/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
@@ -127,6 +127,7 @@ suite('PipPackageManager update Tests', () => {
         expect(writtenContent).to.contain('positron-update-demo @ file:///tmp/demo');
         const [, args] = terminalService.sendCommand.firstCall.args;
         expect(args).to.include.members(['install', '-r', '/tmp/reqs.txt']);
+        expect(args).to.not.include('--upgrade');
     });
 
     test('updateAllPackages does nothing when no packages are outdated', async () => {

--- a/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
@@ -167,4 +167,16 @@ suite('PipPackageManager update Tests', () => {
         expect(writtenContent).to.contain('cowsay');
         expect(writtenContent).to.not.contain('cowsay==');
     });
+
+    test('installPackages propagates a resolver failure (no silent success)', async () => {
+        terminalService.sendCommand.rejects(new Error('Command failed with errors'));
+
+        let threw = false;
+        try {
+            await manager.installPackages([{ name: 'cowsay', version: '6.1' }]);
+        } catch {
+            threw = true;
+        }
+        expect(threw).to.equal(true);
+    });
 });

--- a/extensions/positron-python/src/test/positron/requirementsFile.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/requirementsFile.unit.test.ts
@@ -7,7 +7,7 @@
 
 import { expect } from 'chai';
 import {
-    buildPinnedRequirements,
+    buildRequirementsFile,
     extractRequirementName,
     normalizePackageName,
 } from '../../client/positron/packages/requirementsFile';
@@ -42,46 +42,52 @@ suite('requirementsFile Tests', () => {
         });
     });
 
-    suite('buildPinnedRequirements', () => {
-        test('replaces only the target line and preserves the rest in order', () => {
+    suite('buildRequirementsFile', () => {
+        test('bare-names plain PyPI pins and pins the target', () => {
             const lines = ['flask==2.2.0', 'Werkzeug==2.0.3', 'positron-update-demo @ file:///tmp/demo'];
-            const result = buildPinnedRequirements(lines, [{ name: 'werkzeug', version: '3.1.8' }]);
+            const result = buildRequirementsFile(lines, [{ name: 'werkzeug', version: '3.1.8' }]);
             expect(result).to.equal(
-                ['flask==2.2.0', 'werkzeug==3.1.8', 'positron-update-demo @ file:///tmp/demo'].join('\n') + '\n',
+                ['flask', 'werkzeug==3.1.8', 'positron-update-demo @ file:///tmp/demo'].join('\n') + '\n',
             );
+        });
+
+        test('keeps origin lines (direct reference and editable) verbatim', () => {
+            const lines = ['pkg @ file:///tmp/pkg', '-e /tmp/editable', 'requests==2.28.0'];
+            const result = buildRequirementsFile(lines, []);
+            expect(result).to.equal(['pkg @ file:///tmp/pkg', '-e /tmp/editable', 'requests'].join('\n') + '\n');
+        });
+
+        test('with no targets (Update All) leaves everything bare or verbatim', () => {
+            const lines = ['flask==2.2.0', 'werkzeug==2.0.3'];
+            const result = buildRequirementsFile(lines, []);
+            expect(result).to.equal(['flask', 'werkzeug'].join('\n') + '\n');
         });
 
         test('matches the target case-insensitively on the normalized name', () => {
             const lines = ['Typing_Extensions==4.0.0'];
-            const result = buildPinnedRequirements(lines, [{ name: 'typing-extensions', version: '4.9.0' }]);
+            const result = buildRequirementsFile(lines, [{ name: 'typing-extensions', version: '4.9.0' }]);
             expect(result).to.equal('typing-extensions==4.9.0\n');
         });
 
-        test('replaces multiple targets for update-all', () => {
+        test('pins multiple targets for a multi-package update', () => {
             const lines = ['flask==2.2.0', 'werkzeug==2.0.3', 'requests==2.28.0'];
-            const result = buildPinnedRequirements(lines, [
+            const result = buildRequirementsFile(lines, [
                 { name: 'flask', version: '3.0.0' },
                 { name: 'requests', version: '2.31.0' },
             ]);
-            expect(result).to.equal(['flask==3.0.0', 'werkzeug==2.0.3', 'requests==2.31.0'].join('\n') + '\n');
+            expect(result).to.equal(['flask==3.0.0', 'werkzeug', 'requests==2.31.0'].join('\n') + '\n');
         });
 
-        test('filters the pkg-resources==0.0.0 junk line', () => {
-            const lines = ['pkg-resources==0.0.0', 'flask==2.2.0'];
-            const result = buildPinnedRequirements(lines, [{ name: 'flask', version: '3.0.0' }]);
-            expect(result).to.equal('flask==3.0.0\n');
-        });
-
-        test('appends a target that is absent from the freeze output', () => {
-            const lines = ['flask==2.2.0'];
-            const result = buildPinnedRequirements(lines, [{ name: 'requests', version: '2.31.0' }]);
-            expect(result).to.equal(['flask==2.2.0', 'requests==2.31.0'].join('\n') + '\n');
-        });
-
-        test('uses a bare name when the target has no version', () => {
-            const lines = ['flask==2.2.0'];
-            const result = buildPinnedRequirements(lines, [{ name: 'flask' }]);
+        test('filters the pkg-resources==0.0.0 junk line and blank lines', () => {
+            const lines = ['pkg-resources==0.0.0', '', 'flask==2.2.0'];
+            const result = buildRequirementsFile(lines, []);
             expect(result).to.equal('flask\n');
+        });
+
+        test('appends a target absent from the freeze output', () => {
+            const lines = ['flask==2.2.0'];
+            const result = buildRequirementsFile(lines, [{ name: 'requests', version: '2.31.0' }]);
+            expect(result).to.equal(['flask', 'requests==2.31.0'].join('\n') + '\n');
         });
     });
 });

--- a/extensions/positron-python/src/test/positron/requirementsFile.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/requirementsFile.unit.test.ts
@@ -89,5 +89,10 @@ suite('requirementsFile Tests', () => {
             const result = buildRequirementsFile(lines, [{ name: 'requests', version: '2.31.0' }]);
             expect(result).to.equal(['flask', 'requests==2.31.0'].join('\n') + '\n');
         });
+
+        test('pins a target even when its freeze line is a direct reference', () => {
+            const result = buildRequirementsFile(['foo @ file:///x'], [{ name: 'foo', version: '2.0' }]);
+            expect(result).to.equal('foo==2.0\n');
+        });
     });
 });

--- a/extensions/positron-python/src/test/positron/requirementsFile.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/requirementsFile.unit.test.ts
@@ -1,0 +1,87 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import { expect } from 'chai';
+import {
+    buildPinnedRequirements,
+    extractRequirementName,
+    normalizePackageName,
+} from '../../client/positron/packages/requirementsFile';
+
+suite('requirementsFile Tests', () => {
+    suite('normalizePackageName', () => {
+        test('lowercases and collapses separators per PEP 503', () => {
+            expect(normalizePackageName('Flask')).to.equal('flask');
+            expect(normalizePackageName('typing_extensions')).to.equal('typing-extensions');
+            expect(normalizePackageName('zope.interface')).to.equal('zope-interface');
+            expect(normalizePackageName('Foo--_.Bar')).to.equal('foo-bar');
+        });
+    });
+
+    suite('extractRequirementName', () => {
+        test('reads the name from a pinned spec', () => {
+            expect(extractRequirementName('Werkzeug==2.0.3')).to.equal('Werkzeug');
+        });
+
+        test('reads the name from a direct-reference spec', () => {
+            expect(extractRequirementName('positron-update-demo @ file:///tmp/demo')).to.equal(
+                'positron-update-demo',
+            );
+        });
+
+        test('ignores comments, blanks, options, and editables', () => {
+            expect(extractRequirementName('')).to.equal(undefined);
+            expect(extractRequirementName('   ')).to.equal(undefined);
+            expect(extractRequirementName('# a comment')).to.equal(undefined);
+            expect(extractRequirementName('--index-url https://example.com')).to.equal(undefined);
+            expect(extractRequirementName('-e /path/to/pkg')).to.equal(undefined);
+        });
+    });
+
+    suite('buildPinnedRequirements', () => {
+        test('replaces only the target line and preserves the rest in order', () => {
+            const lines = ['flask==2.2.0', 'Werkzeug==2.0.3', 'positron-update-demo @ file:///tmp/demo'];
+            const result = buildPinnedRequirements(lines, [{ name: 'werkzeug', version: '3.1.8' }]);
+            expect(result).to.equal(
+                ['flask==2.2.0', 'werkzeug==3.1.8', 'positron-update-demo @ file:///tmp/demo'].join('\n') + '\n',
+            );
+        });
+
+        test('matches the target case-insensitively on the normalized name', () => {
+            const lines = ['Typing_Extensions==4.0.0'];
+            const result = buildPinnedRequirements(lines, [{ name: 'typing-extensions', version: '4.9.0' }]);
+            expect(result).to.equal('typing-extensions==4.9.0\n');
+        });
+
+        test('replaces multiple targets for update-all', () => {
+            const lines = ['flask==2.2.0', 'werkzeug==2.0.3', 'requests==2.28.0'];
+            const result = buildPinnedRequirements(lines, [
+                { name: 'flask', version: '3.0.0' },
+                { name: 'requests', version: '2.31.0' },
+            ]);
+            expect(result).to.equal(['flask==3.0.0', 'werkzeug==2.0.3', 'requests==2.31.0'].join('\n') + '\n');
+        });
+
+        test('filters the pkg-resources==0.0.0 junk line', () => {
+            const lines = ['pkg-resources==0.0.0', 'flask==2.2.0'];
+            const result = buildPinnedRequirements(lines, [{ name: 'flask', version: '3.0.0' }]);
+            expect(result).to.equal('flask==3.0.0\n');
+        });
+
+        test('appends a target that is absent from the freeze output', () => {
+            const lines = ['flask==2.2.0'];
+            const result = buildPinnedRequirements(lines, [{ name: 'requests', version: '2.31.0' }]);
+            expect(result).to.equal(['flask==2.2.0', 'requests==2.31.0'].join('\n') + '\n');
+        });
+
+        test('uses a bare name when the target has no version', () => {
+            const lines = ['flask==2.2.0'];
+            const result = buildPinnedRequirements(lines, [{ name: 'flask' }]);
+            expect(result).to.equal('flask\n');
+        });
+    });
+});

--- a/extensions/positron-python/src/test/positron/requirementsFile.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/requirementsFile.unit.test.ts
@@ -28,9 +28,7 @@ suite('requirementsFile Tests', () => {
         });
 
         test('reads the name from a direct-reference spec', () => {
-            expect(extractRequirementName('positron-update-demo @ file:///tmp/demo')).to.equal(
-                'positron-update-demo',
-            );
+            expect(extractRequirementName('positron-update-demo @ file:///tmp/demo')).to.equal('positron-update-demo');
         });
 
         test('ignores comments, blanks, options, and editables', () => {

--- a/extensions/positron-python/src/test/positron/requirementsFile.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/requirementsFile.unit.test.ts
@@ -94,5 +94,15 @@ suite('requirementsFile Tests', () => {
             const result = buildRequirementsFile(['foo @ file:///x'], [{ name: 'foo', version: '2.0' }]);
             expect(result).to.equal('foo==2.0\n');
         });
+
+        test('appends a versionless target as a bare name', () => {
+            const result = buildRequirementsFile(['flask==2.2.0'], [{ name: 'requests' }]);
+            expect(result).to.equal(['flask', 'requests'].join('\n') + '\n');
+        });
+
+        test('replaces a matching line with a bare name when the target has no version', () => {
+            const result = buildRequirementsFile(['requests==2.28.0'], [{ name: 'requests' }]);
+            expect(result).to.equal('requests\n');
+        });
     });
 });

--- a/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
@@ -320,6 +320,7 @@ version = "0.1.0"`;
             expect((fileSystem as any).getWritten()).to.contain('werkzeug==3.1.8');
             const [, args] = terminalService.sendCommand.firstCall.args;
             expect(args).to.include.members(['pip', 'install', '-r', '/tmp/reqs.txt']);
+            expect(args).to.not.include('--upgrade');
         });
     });
 });

--- a/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
@@ -342,5 +342,17 @@ version = "0.1.0"`;
             const [, args] = terminalService.sendCommand.firstCall.args;
             expect(args).to.include.members(['pip', 'install', '--upgrade', '-r', '/tmp/reqs.txt', '--python', '/path/to/python']);
         });
+
+        test('installPackages names the full installed set and adds the new package', async () => {
+            await uvPackageManager.installPackages([{ name: 'cowsay', version: '6.1' }]);
+
+            const written = (fileSystem as any).getWritten();
+            expect(written).to.contain('cowsay==6.1');
+            expect(written).to.contain('flask');
+            const [uvBin, args] = terminalService.sendCommand.firstCall.args;
+            expect(uvBin).to.equal('uv');
+            expect(args).to.include.members(['pip', 'install', '-r', '/tmp/reqs.txt', '--python', '/path/to/python']);
+            expect(args).to.not.include('--upgrade');
+        });
     });
 });

--- a/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
@@ -276,12 +276,10 @@ version = "0.1.0"`;
 
             processService = { exec: sinon.stub() };
             // uv pip freeze -- includes a plain PyPI package so bare-naming is observable
-            processService.exec
-                .withArgs('uv', sinon.match.array.startsWith(['pip', 'freeze']))
-                .resolves({
-                    stdout: 'flask==2.2.0\nwerkzeug==2.0.3\npositron-update-demo @ file:///tmp/demo\n',
-                    stderr: '',
-                });
+            processService.exec.withArgs('uv', sinon.match.array.startsWith(['pip', 'freeze'])).resolves({
+                stdout: 'flask==2.2.0\nwerkzeug==2.0.3\npositron-update-demo @ file:///tmp/demo\n',
+                stderr: '',
+            });
             const processFactory = { create: sinon.stub().resolves(processService) };
 
             terminalService = {
@@ -340,7 +338,15 @@ version = "0.1.0"`;
             expect(written).to.contain('werkzeug');
             expect(written).to.not.contain('werkzeug==');
             const [, args] = terminalService.sendCommand.firstCall.args;
-            expect(args).to.include.members(['pip', 'install', '--upgrade', '-r', '/tmp/reqs.txt', '--python', '/path/to/python']);
+            expect(args).to.include.members([
+                'pip',
+                'install',
+                '--upgrade',
+                '-r',
+                '/tmp/reqs.txt',
+                '--python',
+                '/path/to/python',
+            ]);
         });
 
         test('installPackages names the full installed set and adds the new package', async () => {

--- a/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
@@ -42,7 +42,7 @@ suite('UvPackageManager Tests', () => {
     let fileSystem: IFileSystem;
     let messageEmitter: MessageEmitter;
     let session: PackageSession;
-    let uvSandbox: sinon.SinonStub;
+    // let uvSandbox: sinon.SinonStub;
 
     setup(() => {
         // Capture requirements written to the temp file.
@@ -272,13 +272,16 @@ version = "0.1.0"`;
                 ({ get: (_key: string, defaultValue?: unknown) => defaultValue } as any);
 
             // uv available.
-            uvSandbox = sinon.stub(uvPackageManager, 'isUvAvailable').resolves(true);
+            sinon.stub(uvPackageManager, 'isUvAvailable').resolves(true);
 
             processService = { exec: sinon.stub() };
-            // uv pip freeze
+            // uv pip freeze -- includes a plain PyPI package so bare-naming is observable
             processService.exec
                 .withArgs('uv', sinon.match.array.startsWith(['pip', 'freeze']))
-                .resolves({ stdout: 'werkzeug==2.0.3\npositron-update-demo @ file:///tmp/demo\n', stderr: '' });
+                .resolves({
+                    stdout: 'flask==2.2.0\nwerkzeug==2.0.3\npositron-update-demo @ file:///tmp/demo\n',
+                    stderr: '',
+                });
             const processFactory = { create: sinon.stub().resolves(processService) };
 
             terminalService = {
@@ -299,28 +302,45 @@ version = "0.1.0"`;
             vscode.workspace.getConfiguration = originalGetConfiguration;
         });
 
-        test('updatePackages installs a pinned requirements file', async () => {
+        test('updatePackages writes a bare-names requirements file with the target pinned', async () => {
             await uvPackageManager.updatePackages([{ name: 'werkzeug', version: '3.1.8' }]);
 
-            expect((fileSystem as any).getWritten()).to.contain('werkzeug==3.1.8');
-            expect((fileSystem as any).getWritten()).to.contain('positron-update-demo @ file:///tmp/demo');
+            const written = (fileSystem as any).getWritten();
+            expect(written).to.contain('werkzeug==3.1.8');
+            expect(written).to.contain('flask');
+            expect(written).to.not.contain('flask==2.2.0');
+            expect(written).to.contain('positron-update-demo @ file:///tmp/demo');
+
             const [uvBin, args] = terminalService.sendCommand.firstCall.args;
             expect(uvBin).to.equal('uv');
             expect(args).to.include.members(['pip', 'install', '-r', '/tmp/reqs.txt', '--python', '/path/to/python']);
             expect(args).to.not.include('--upgrade');
         });
 
-        test('updateAllPackages pins outdated packages to latest', async () => {
+        test('updatePackages throws when a target has no version', async () => {
+            let caughtError: unknown;
+            try {
+                await uvPackageManager.updatePackages([{ name: 'werkzeug' }]);
+            } catch (e) {
+                caughtError = e;
+            }
+            expect(caughtError).to.be.instanceOf(Error);
+            expect((caughtError as Error).message).to.contain('werkzeug');
+            expect(terminalService.sendCommand.called).to.equal(false);
+        });
+
+        test('updateAllPackages writes a bare file and runs pip install --upgrade -r', async () => {
             processService.exec
                 .withArgs('uv', sinon.match.array.startsWith(['pip', 'list', '--outdated']))
                 .resolves({ stdout: JSON.stringify([{ name: 'werkzeug', latest_version: '3.1.8' }]), stderr: '' });
 
             await uvPackageManager.updateAllPackages();
 
-            expect((fileSystem as any).getWritten()).to.contain('werkzeug==3.1.8');
+            const written = (fileSystem as any).getWritten();
+            expect(written).to.contain('werkzeug');
+            expect(written).to.not.contain('werkzeug==');
             const [, args] = terminalService.sendCommand.firstCall.args;
-            expect(args).to.include.members(['pip', 'install', '-r', '/tmp/reqs.txt']);
-            expect(args).to.not.include('--upgrade');
+            expect(args).to.include.members(['pip', 'install', '--upgrade', '-r', '/tmp/reqs.txt']);
         });
     });
 });

--- a/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
@@ -10,9 +10,12 @@ import * as path from 'path';
 import * as sinon from 'sinon';
 // eslint-disable-next-line import/no-unresolved
 import * as positron from 'positron';
+import * as vscode from 'vscode';
 import { Uri } from 'vscode';
 import { IWorkspaceService } from '../../client/common/application/types';
 import { IFileSystem } from '../../client/common/platform/types';
+import { IProcessServiceFactory } from '../../client/common/process/types';
+import { ITerminalServiceFactory } from '../../client/common/terminal/types';
 import { IServiceContainer } from '../../client/ioc/types';
 import { UvPackageManager } from '../../client/positron/packages/uvPackageManager';
 import { PackageSession } from '../../client/positron/packages/types';
@@ -39,13 +42,21 @@ suite('UvPackageManager Tests', () => {
     let fileSystem: IFileSystem;
     let messageEmitter: MessageEmitter;
     let session: PackageSession;
+    let uvSandbox: sinon.SinonStub;
 
     setup(() => {
-        // Create mocks for services
+        // Capture requirements written to the temp file.
+        let writtenContent = '';
         fileSystem = {
             fileExists: sinon.stub().resolves(false),
             readFile: sinon.stub().resolves(''),
+            createTemporaryFile: sinon.stub().resolves({ filePath: '/tmp/reqs.txt', dispose: sinon.stub() }),
+            writeFile: sinon.stub().callsFake((_p: string, text: string) => {
+                writtenContent = text;
+                return Promise.resolve();
+            }),
         } as any;
+        (fileSystem as any).getWritten = () => writtenContent;
 
         workspaceService = {
             getWorkspaceFolder: sinon.stub().returns(undefined),
@@ -246,6 +257,69 @@ version = "0.1.0"`;
             const result = await uvPackageManager.shouldUseProjectWorkflow();
 
             expect(result).to.be.false;
+        });
+    });
+
+    suite('Environment-workflow updates', () => {
+        let processService: { exec: sinon.SinonStub };
+        let terminalService: { show: sinon.SinonStub; sendCommand: sinon.SinonStub; sendText: sinon.SinonStub };
+        let originalGetConfiguration: typeof vscode.workspace.getConfiguration;
+
+        setup(() => {
+            // Stub getConfiguration so _getProxyEnv() does not crash (vscode.workspace is a mock instance).
+            originalGetConfiguration = vscode.workspace.getConfiguration;
+            vscode.workspace.getConfiguration = (_section?: string) =>
+                ({ get: (_key: string, defaultValue?: unknown) => defaultValue } as any);
+
+            // uv available.
+            uvSandbox = sinon.stub(uvPackageManager, 'isUvAvailable').resolves(true);
+
+            processService = { exec: sinon.stub() };
+            // uv pip freeze
+            processService.exec
+                .withArgs('uv', sinon.match.array.startsWith(['pip', 'freeze']))
+                .resolves({ stdout: 'werkzeug==2.0.3\npositron-update-demo @ file:///tmp/demo\n', stderr: '' });
+            const processFactory = { create: sinon.stub().resolves(processService) };
+
+            terminalService = {
+                show: sinon.stub().resolves(),
+                sendCommand: sinon.stub().resolves(),
+                sendText: sinon.stub().resolves(),
+            };
+            const terminalFactory = { getTerminalService: sinon.stub().returns(terminalService) };
+
+            (serviceContainer.get as sinon.SinonStub)
+                .withArgs(IProcessServiceFactory)
+                .returns(processFactory)
+                .withArgs(ITerminalServiceFactory)
+                .returns(terminalFactory);
+        });
+
+        teardown(() => {
+            vscode.workspace.getConfiguration = originalGetConfiguration;
+        });
+
+        test('updatePackages installs a pinned requirements file', async () => {
+            await uvPackageManager.updatePackages([{ name: 'werkzeug', version: '3.1.8' }]);
+
+            expect((fileSystem as any).getWritten()).to.contain('werkzeug==3.1.8');
+            expect((fileSystem as any).getWritten()).to.contain('positron-update-demo @ file:///tmp/demo');
+            const [uvBin, args] = terminalService.sendCommand.firstCall.args;
+            expect(uvBin).to.equal('uv');
+            expect(args).to.include.members(['pip', 'install', '-r', '/tmp/reqs.txt', '--python', '/path/to/python']);
+            expect(args).to.not.include('--upgrade');
+        });
+
+        test('updateAllPackages pins outdated packages to latest', async () => {
+            processService.exec
+                .withArgs('uv', sinon.match.array.startsWith(['pip', 'list', '--outdated']))
+                .resolves({ stdout: JSON.stringify([{ name: 'werkzeug', latest_version: '3.1.8' }]), stderr: '' });
+
+            await uvPackageManager.updateAllPackages();
+
+            expect((fileSystem as any).getWritten()).to.contain('werkzeug==3.1.8');
+            const [, args] = terminalService.sendCommand.firstCall.args;
+            expect(args).to.include.members(['pip', 'install', '-r', '/tmp/reqs.txt']);
         });
     });
 });

--- a/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
@@ -340,7 +340,7 @@ version = "0.1.0"`;
             expect(written).to.contain('werkzeug');
             expect(written).to.not.contain('werkzeug==');
             const [, args] = terminalService.sendCommand.firstCall.args;
-            expect(args).to.include.members(['pip', 'install', '--upgrade', '-r', '/tmp/reqs.txt']);
+            expect(args).to.include.members(['pip', 'install', '--upgrade', '-r', '/tmp/reqs.txt', '--python', '/path/to/python']);
         });
     });
 });


### PR DESCRIPTION
Fixes #14328

### Summary

Updating a Python package from the Packages pane could silently break the
environment. pip and uv only honor the version constraints of packages **named**
on the install command, so `pip install --upgrade <name>==<version>` would
upgrade past another installed package's ceiling (e.g. a package that requires
`werkzeug<3`), exit 0, and leave the environment broken with no warning.

This makes the pip and uv *environment*-workflow operations re-resolve against
the full installed set. We capture `pip freeze` / `uv pip freeze` and build a
temporary requirements file naming every installed package, then run
`pip install -r <file>`:

- Installed packages are listed as **bare names** (no version), so the resolver
  keeps them where they are unless the operation forces a change -- honoring
  every package's constraints while still letting the target's own dependencies
  move.
- Direct-reference / editable / VCS lines (`@ file://`, `-e`, `@ git+`) are kept
  verbatim so local packages resolve without an index lookup.
- A single **update** pins the target to the chosen version (an explicit version
  is required). **Update All** names the full set with `--upgrade` (latest
  mutually-compatible). **Install** uses the same full-set re-resolution so a new
  package can't break the environment either.

A conflicting resolve now fails atomically (the resolver refuses inconsistent
installs) and surfaces as an error notification, instead of silently breaking the
environment. conda and uv's *project* workflow (`uv add` / `uv sync --upgrade`)
already resolve the full graph and are unchanged.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Updating or installing a Python package from the Packages pane no longer
  silently breaks the environment; an operation that would leave it inconsistent
  now fails with an error instead. (#14328)

### Validation Steps

@:environment-modules

> Note: full verification needs real pip/uv and is not covered by the automated
> unit tests. Reproduce the issue's setup, then verify the new behavior:

1. Create a workspace where a package caps a dependency:
   ```sh
   rm -rf ~/test_break && mkdir ~/test_break && cd ~/test_break
   uv venv
   mkdir -p demo/positron_update_demo
   cat > demo/setup.py <<'PYEOF'
   from setuptools import setup
   setup(name="positron-update-demo", version="1.0.0",
         packages=["positron_update_demo"], install_requires=["werkzeug<3"])
   PYEOF
   echo 'from werkzeug.urls import url_quote' > demo/positron_update_demo/__init__.py
   uv pip install ./demo werkzeug==2.0.3
   ```
2. Open `~/test_break` in Positron; confirm `import positron_update_demo` works.
3. Packages pane: **Update** `werkzeug` -> pick a 3.x version.
   - Expected: an error notification, no "Restart Session" prompt, and
     `import positron_update_demo` still works.
4. Update a package whose latest needs a newer dependency (nothing caps it).
   - Expected: succeeds, pulling the dependency up; unrelated packages stay put.
5. Repeat steps 3-4 with **Update All** and with **Install**.
