### PR TITLE
Unify notebook HTML output routing into a single function

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
@@ -13,8 +13,8 @@ import { PositronNotebookCellGeneral } from './PositronNotebookCell.js';
 import { PositronNotebookInstance } from '../PositronNotebookInstance.js';
 import { IPositronNotebookCodeCell, NotebookCellOutputs } from './IPositronNotebookCell.js';
 import { IPositronWebviewPreloadService } from '../../../../services/positronWebviewPreloads/browser/positronWebviewPreloadService.js';
-import { pickPreferredOutputItem } from './notebookOutputUtils.js';
-import { getWebviewMessageType, isComplexHtml } from '../../../../services/positronIPyWidgets/common/webviewPreloadUtils.js';
+import { htmlRenderMode, pickPreferredOutputItem } from './notebookOutputUtils.js';
+import { getWebviewMessageType } from '../../../../services/positronIPyWidgets/common/webviewPreloadUtils.js';
 import { INotebookExecutionStateService } from '../../../notebook/common/notebookExecutionStateService.js';
 import { IPositronCellOutputViewModel } from '../IPositronNotebookEditor.js';
 
@@ -163,7 +163,7 @@ export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implem
 				if (parsedOutput.preloadMessageResult === undefined) {
 					return;
 				}
-			} else if (preferredOutputItem.mime === 'text/html' && isComplexHtml(rawOutput)) {
+			} else if (preferredOutputItem.mime === 'text/html' && htmlRenderMode(rawOutput) === 'webview') {
 				// Route complex HTML (iframe, script) to a sandboxed webview. Inert full
 				// documents (e.g. Great Tables) fall through and render inline.
 				parsedOutput.preloadMessageResult = this._webviewPreloadService.addNotebookOutput({

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/notebookOutputUtils.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/notebookOutputUtils.ts
@@ -5,6 +5,7 @@
 
 import { NotebookCellOutputItem, NotebookCellOutputs } from './IPositronNotebookCell.js';
 import { isDataExplorerMimeType } from '../getOutputContents.js';
+import { isComplexHtml } from '../../../../services/positronIPyWidgets/common/webviewPreloadUtils.js';
 
 /**
  * Get the priority of a mime type for sorting purposes
@@ -87,4 +88,36 @@ export function pickPreferredOutputItem(outputItems: NotebookCellOutputItem[]): 
  */
 export function hasWebviewOutput(outputs: NotebookCellOutputs[]): boolean {
 	return outputs.some(output => output.preloadMessageResult !== undefined);
+}
+
+/**
+ * Where a piece of `text/html` output should be rendered:
+ * - `webview`: active content (scripts, iframes, embeds, `javascript:` URLs, or
+ *   inline event handlers) that must be isolated in a sandboxed webview overlay.
+ * - `shadowRoot`: an inert full HTML document (`<!doctype>`, `<html>`, `<body>`)
+ *   that renders inline in a shadow root so its document-level styles stay scoped.
+ * - `fragment`: an inert HTML fragment that renders inline via `renderHtml`.
+ */
+export type HtmlRenderMode = 'webview' | 'shadowRoot' | 'fragment';
+
+/**
+ * Decide how to render a piece of `text/html` output. This is the single source of
+ * truth for the routing both the model (webview vs inline) and the renderer
+ * (shadow root vs fragment) depend on.
+ *
+ * Uses substring matching rather than a parser intentionally: a false positive only
+ * routes to a webview (safe, still renders), while a false negative for active
+ * content would be a security gap, so we prefer conservative detection.
+ */
+export function htmlRenderMode(html: string): HtmlRenderMode {
+	if (isComplexHtml(html)) {
+		return 'webview';
+	}
+
+	const lower = html.toLowerCase();
+	const isFullDocument = lower.includes('<!doctype') ||
+		lower.includes('<html') ||
+		lower.includes('<body');
+
+	return isFullDocument ? 'shadowRoot' : 'fragment';
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -19,7 +19,7 @@ import { positronClassNames } from '../../../../../base/common/positronUtilities
 import { CellTextOutput } from './CellTextOutput.js';
 import { NotebookCellWrapper } from './NotebookCellWrapper.js';
 import { PositronNotebookCodeCell } from '../PositronNotebookCells/PositronNotebookCodeCell.js';
-import { hasWebviewOutput } from '../PositronNotebookCells/notebookOutputUtils.js';
+import { hasWebviewOutput, htmlRenderMode } from '../PositronNotebookCells/notebookOutputUtils.js';
 import { PreloadMessageOutput } from './PreloadMessageOutput.js';
 import { CellLeftActionMenu } from './CellLeftActionMenu.js';
 import { CellOutputCollapseButton } from './CellOutputCollapseButton.js';
@@ -343,16 +343,11 @@ const CellOutput = React.memo(function CellOutput(output: CellOutputProps) {
 			</div>;
 		case 'image':
 			return <img alt='output image' height={parsed.height} src={parsed.dataUrl} width={parsed.width} />;
-		case 'html': {
+		case 'html':
 			// Full HTML documents go in a shadow root; renderHtml only handles fragments.
-			const lower = parsed.content.toLowerCase();
-			const isFullDocument = lower.includes('<!doctype') ||
-				lower.includes('<html') ||
-				lower.includes('<body');
-			return isFullDocument
+			return htmlRenderMode(parsed.content) === 'shadowRoot'
 				? <ShadowDomContent content={parsed.content} trustedTypesPolicy={htmlOutputTTPolicy} />
 				: renderHtml(parsed.content);
-		}
 		case 'markdown':
 			return <Markdown content={parsed.content} />;
 		case 'latex':

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookOutputUtils.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookOutputUtils.vitest.ts
@@ -9,7 +9,7 @@ import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { DATA_EXPLORER_MIME_TYPE, parseOutputData } from '../../browser/getOutputContents.js';
 import { ParsedDataExplorerOutput } from '../../browser/PositronNotebookCells/IPositronNotebookCell.js';
-import { pickPreferredOutputItem } from '../../browser/PositronNotebookCells/notebookOutputUtils.js';
+import { HtmlRenderMode, htmlRenderMode, pickPreferredOutputItem } from '../../browser/PositronNotebookCells/notebookOutputUtils.js';
 import { parseVariablePath } from '../../../../services/positronDataExplorer/common/utils.js';
 
 function makeOutputItem(mime: string, text: string) {
@@ -214,6 +214,29 @@ describe('Notebook Output Utils', () => {
 			const result = parseOutputData(makeOutputItem(uppercaseMime, validPayload));
 			expect(result.type).toBe('dataExplorer');
 		});
+	});
+
+	describe('htmlRenderMode', () => {
+		const cases: [HtmlRenderMode, string, string][] = [
+			// Active content is isolated in a webview.
+			['webview', 'script', '<div><script>alert(1)</script></div>'],
+			['webview', 'iframe', '<iframe src="https://example.com"></iframe>'],
+			['webview', 'event handler', '<img src="x" onerror="alert(1)">'],
+			['webview', 'full document with a script', '<!DOCTYPE html><html><body><script>x()</script></body></html>'],
+			// Inert full documents render inline in a shadow root.
+			['shadowRoot', 'doctype', '<!DOCTYPE html><html></html>'],
+			['shadowRoot', 'html tag', '<html><p>Hello</p></html>'],
+			['shadowRoot', 'body tag', '<body><p>Hello</p></body>'],
+			// Inert fragments render inline via renderHtml.
+			['fragment', 'simple fragment', '<p>Hello world</p>'],
+			['fragment', 'data attribute with "on" prefix', '<div data-onclick="value">test</div>'],
+		];
+
+		for (const [mode, label, html] of cases) {
+			it(`routes ${label} to ${mode}`, () => {
+				expect(htmlRenderMode(html)).toBe(mode);
+			});
+		}
 	});
 
 	describe('parseVariablePath', () => {


### PR DESCRIPTION
Follow-up to #14375 addressing review feedback from @nstrayer.

Before this PR, two separate substring scans decided how `text/html` notebook output renders:
1. `isComplexHtml()` in `PositronNotebookCodeCell.ts` which checked if content was static or not and then rendered it inline vs a webview.
2. `isFullDocument` block in `NotebookCodeCell.tsx` which checked if content was a full document or not and then rendered it in a shadow root  fragment.

This unifies them into a single `htmlRenderMode` helper. The routing decision now lives in one place and no longer bleeds into different components!

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

@:positron-notebooks
@:web

Same testing steps as in #14375
