### PR TITLE
Update/databases config selector

### DIFF
--- a/extensions/positron-data-driver-duckdb/src/duckdbDriver.ts
+++ b/extensions/positron-data-driver-duckdb/src/duckdbDriver.ts
@@ -3,7 +3,8 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import * as positron from 'positron';
 import * as vscode from 'vscode';
@@ -18,6 +19,26 @@ function isNonEmptyString(value: unknown): value is string {
 }
 
 /**
+ * Resolves a user-entered database path to an absolute path.
+ */
+function resolveDatabasePath(filePath: string): string {
+	// A leading `~/` is the home directory. `~` is a Unix shell convention with no native meaning on
+	// Windows, so this only applies on macOS and Linux. The result is absolute, so return it directly.
+	if (process.platform !== 'win32' && filePath.startsWith('~/')) {
+		return path.join(os.homedir(), filePath.slice(2));
+	}
+
+	// Absolute paths are used as-is.
+	if (path.isAbsolute(filePath)) {
+		return filePath;
+	}
+
+	// Resolve a relative path against the workspace folders.
+	const candidatePaths = (vscode.workspace.workspaceFolders ?? []).map(folder => path.join(folder.uri.fsPath, filePath));
+	return candidatePaths.find(candidate => existsSync(candidate)) ?? candidatePaths[0] ?? filePath;
+}
+
+/**
  * Escapes a value for embedding in a double-quoted Python or R string literal. Both languages
  * treat backslash as an escape character in double-quoted strings, so Windows paths such as
  * `C:\db.duckdb` must have their separators doubled.
@@ -25,6 +46,12 @@ function isNonEmptyString(value: unknown): value is string {
 function escapeDoubleQuoted(value: string): string {
 	return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
+
+/**
+ * The id of the file-based connection mechanism. Used both in the driver's mechanism list and in
+ * the connect switch, so the two stay in sync.
+ */
+const FILE_MECHANISM_ID = 'file';
 
 /**
  * Creates the DuckDB DataConnectionDriver.
@@ -51,44 +78,61 @@ export function createDuckDBDriver(
 		description: vscode.l10n.t('Connect to a DuckDB database file'),
 		iconSvg,
 		supportedLanguageIds: ['python', 'r'],
-		parameters: [
+		mechanisms: [
 			{
-				id: 'databasePath',
+				id: FILE_MECHANISM_ID,
 				label: vscode.l10n.t('Database File'),
-				type: positron.DataConnectionParameterType.File,
-				required: true,
-				placeholder: databasePathPlaceholder,
-			},
-			{
-				id: 'readOnly',
-				label: vscode.l10n.t('Read Only'),
-				type: positron.DataConnectionParameterType.Boolean,
-				defaultValue: false,
+				description: vscode.l10n.t('Connect to a DuckDB database file on disk'),
+				parameters: [
+					{
+						id: 'databasePath',
+						label: vscode.l10n.t('Database File'),
+						type: positron.DataConnectionParameterType.File,
+						required: true,
+						placeholder: databasePathPlaceholder,
+					},
+					{
+						id: 'readOnly',
+						label: vscode.l10n.t('Read Only'),
+						type: positron.DataConnectionParameterType.Boolean,
+						defaultValue: false,
+					},
+				],
 			},
 		],
-		async connect(params: positron.DataConnectionParameterValues): Promise<positron.DataConnection> {
-			// Extract parameters.
-			const databasePath = params.databasePath;
-			const readOnly = params.readOnly as boolean ?? false;
+		async connect(mechanismId: string, params: positron.DataConnectionParameterValues): Promise<positron.DataConnection> {
+			// Connect to the database based on the mechanism. The driver is expected to throw on failure; let it propagate.
+			switch (mechanismId) {
+				case FILE_MECHANISM_ID: {
+					// Extract parameters.
+					const rawDatabasePath = params.databasePath;
+					const readOnly = params.readOnly as boolean ?? false;
 
-			// Validate parameters.
-			if (!isNonEmptyString(databasePath)) {
-				throw new Error(vscode.l10n.t('Database file path is required'));
+					// Validate parameters.
+					if (!isNonEmptyString(rawDatabasePath)) {
+						throw new Error(vscode.l10n.t('Database file path is required'));
+					}
+
+					// Resolve `~` and workspace-relative paths to an absolute path before opening the file.
+					const databasePath = resolveDatabasePath(rawDatabasePath);
+
+					// Create the connection and establish it.
+					const connection = new DuckDBConnection({
+						databasePath,
+						readOnly,
+					}, dataExplorerHandler);
+
+					// Connect.
+					await connection.connect();
+
+					// Return the live connection.
+					return connection;
+				}
+				default:
+					throw new Error(vscode.l10n.t("Unknown connection mechanism '{0}'.", mechanismId));
 			}
-
-			// Create the connection and establish it.
-			const connection = new DuckDBConnection({
-				databasePath,
-				readOnly,
-			}, dataExplorerHandler);
-
-			// Connect.
-			await connection.connect();
-
-			// Return the live connection.
-			return connection;
 		},
-		async generateConnectionCode(languageId: string, params: positron.DataConnectionParameterValues): Promise<positron.ConnectionCodeVariant[]> {
+		async generateConnectionCode(_mechanismId: string, languageId: string, params: positron.DataConnectionParameterValues): Promise<positron.ConnectionCodeVariant[]> {
 			// Extract parameters.
 			const databasePath = params.databasePath;
 			const readOnly = params.readOnly === true;
@@ -98,7 +142,10 @@ export function createDuckDBDriver(
 				return [];
 			}
 
-			const escapedPath = escapeDoubleQuoted(databasePath);
+			// Resolve `~` and workspace-relative paths so the generated code references a concrete,
+			// absolute path (Python and R do not expand `~`, and the console's working directory may
+			// differ from the workspace folder).
+			const escapedPath = escapeDoubleQuoted(resolveDatabasePath(databasePath));
 
 			// Generate code variants for supported languages. Return an empty array for
 			// unsupported languages or when code cannot be generated.

--- a/extensions/positron-data-driver-duckdb/src/test/dataConnectionIntegration.test.ts
+++ b/extensions/positron-data-driver-duckdb/src/test/dataConnectionIntegration.test.ts
@@ -78,21 +78,26 @@ suite('Data Connection Integration', () => {
 			assert.strictEqual(duckdb.name, 'DuckDB');
 		});
 
-		test('DuckDB driver has expected parameters', async () => {
+		test('DuckDB driver has expected mechanisms and parameters', async () => {
 			// Get the drivers and find the DuckDB driver.
 			const drivers = await positron.dataConnections.getDrivers();
 			const duckdb = drivers.find(d => d.id === 'positron-data-driver-duckdb')!;
 
+			// Test the single 'file' mechanism.
+			assert.strictEqual(duckdb.mechanisms.length, 1);
+			const mechanism = duckdb.mechanisms.find(m => m.id === 'file')!;
+			assert.ok(mechanism);
+
 			// Test the parameters length.
-			assert.strictEqual(duckdb.parameters.length, 2);
+			assert.strictEqual(mechanism.parameters.length, 2);
 
 			// Check the path parameter.
-			const pathParam = duckdb.parameters.find(p => p.id === 'databasePath');
+			const pathParam = mechanism.parameters.find(p => p.id === 'databasePath');
 			assert.ok(pathParam);
 			assert.strictEqual(pathParam.type, 'file');
 
 			// Check the read only parameter.
-			const readOnlyParam = duckdb.parameters.find(p => p.id === 'readOnly');
+			const readOnlyParam = mechanism.parameters.find(p => p.id === 'readOnly');
 			assert.ok(readOnlyParam);
 			assert.strictEqual(readOnlyParam.type, 'boolean');
 		});
@@ -105,7 +110,7 @@ suite('Data Connection Integration', () => {
 			const dbPath = await createTestDb('connect.duckdb', 'CREATE TABLE t (x INTEGER);');
 
 			// Connect to the test DB.
-			const conn = await positron.dataConnections.connect('positron-data-driver-duckdb', {
+			const conn = await positron.dataConnections.connect('positron-data-driver-duckdb', 'file', {
 				databasePath: dbPath,
 				readOnly: false,
 			});
@@ -124,7 +129,7 @@ suite('Data Connection Integration', () => {
 			const dbPath = await createTestDb('connect-ro.duckdb', 'CREATE TABLE t (x INTEGER);');
 
 			// Connect to the test DB.
-			const conn = await positron.dataConnections.connect('positron-data-driver-duckdb', {
+			const conn = await positron.dataConnections.connect('positron-data-driver-duckdb', 'file', {
 				databasePath: dbPath,
 				readOnly: true,
 			});
@@ -147,7 +152,7 @@ suite('Data Connection Integration', () => {
 			`);
 
 			// Connect to the test DB.
-			const conn = await positron.dataConnections.connect('positron-data-driver-duckdb', {
+			const conn = await positron.dataConnections.connect('positron-data-driver-duckdb', 'file', {
 				databasePath: dbPath,
 				readOnly: false,
 			});
@@ -175,7 +180,7 @@ suite('Data Connection Integration', () => {
 				'CREATE TABLE products (id INTEGER PRIMARY KEY, name VARCHAR NOT NULL, price DOUBLE, in_stock BOOLEAN);');
 
 			// Connect to the test DB.
-			const conn = await positron.dataConnections.connect('positron-data-driver-duckdb', {
+			const conn = await positron.dataConnections.connect('positron-data-driver-duckdb', 'file', {
 				databasePath: dbPath,
 				readOnly: true,
 			});
@@ -215,7 +220,7 @@ suite('Data Connection Integration', () => {
 			const dbPath = await createTestDb('lifecycle.duckdb', 'CREATE TABLE t (x INTEGER);');
 
 			// Connect to the test DB.
-			const conn = await positron.dataConnections.connect('positron-data-driver-duckdb', {
+			const conn = await positron.dataConnections.connect('positron-data-driver-duckdb', 'file', {
 				databasePath: dbPath,
 				readOnly: false,
 			});
@@ -235,7 +240,7 @@ suite('Data Connection Integration', () => {
 			const dbPath = await createTestDb('readwrite.duckdb', 'CREATE TABLE data (val VARCHAR);');
 
 			// Connect to the test DB.
-			const conn = await positron.dataConnections.connect('positron-data-driver-duckdb', {
+			const conn = await positron.dataConnections.connect('positron-data-driver-duckdb', 'file', {
 				databasePath: dbPath,
 				readOnly: false,
 			});
@@ -265,7 +270,7 @@ suite('Data Connection Integration', () => {
 			// 3. Connect through the full stack:
 			//    ext host -> main thread service -> main thread adapter
 			//    -> RPC -> ext host $driverConnect -> DuckDBConnection
-			const conn = await positron.dataConnections.connect('positron-data-driver-duckdb', {
+			const conn = await positron.dataConnections.connect('positron-data-driver-duckdb', 'file', {
 				databasePath: dbPath,
 				readOnly: false,
 			});

--- a/extensions/positron-data-driver-postgresql/src/postgresqlConnection.ts
+++ b/extensions/positron-data-driver-postgresql/src/postgresqlConnection.ts
@@ -12,15 +12,18 @@ import { IPostgresDataExplorerHost, POSTGRESQL_DATA_EXPLORER_PROVIDER_ID } from 
 let nextConnectionId = 1;
 
 /**
- * Connection configuration passed from the driver.
+ * Connection configuration passed from the driver. Only the database and user are always present;
+ * host, port, password, and SSL are omitted for peer authentication, which connects over a local
+ * Unix domain socket as the operating system account. When omitted, the pg client falls back to its
+ * defaults (local socket, port 5432, no password).
  */
 export interface PostgreSQLConnectionConfig {
-	host: string;
-	port: number;
+	host?: string;
+	port?: number;
 	database: string;
 	user: string;
-	password: string;
-	ssl: boolean;
+	password?: string;
+	ssl?: boolean;
 }
 
 /**
@@ -67,7 +70,12 @@ export class PostgreSQLConnection implements positron.DataConnection, IPostgresP
 			await this._client.connect();
 		} catch (err: any) {
 			this._client = null;
-			throw new Error(`Failed to connect to PostgreSQL at ${this._config.host}:${this._config.port}: ${err.message}`);
+			// A socket-directory host (or no host) means a local-socket/peer connection; otherwise
+			// report the host:port we tried.
+			const target = this._config.host && !this._config.host.startsWith('/')
+				? `${this._config.host}:${this._config.port ?? 5432}`
+				: 'the local socket';
+			throw new Error(`Failed to connect to PostgreSQL at ${target}: ${err.message}`);
 		}
 	}
 

--- a/extensions/positron-data-driver-postgresql/src/postgresqlConnection.ts
+++ b/extensions/positron-data-driver-postgresql/src/postgresqlConnection.ts
@@ -3,8 +3,10 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { readFileSync } from 'fs';
 import { Client } from 'pg';
 import * as positron from 'positron';
+import { ConnectionOptions } from 'tls';
 import { createSchemasGroupNode, IPostgresPreviewHost } from './postgresqlNodes.js';
 import { IPostgresDataExplorerHost, POSTGRESQL_DATA_EXPLORER_PROVIDER_ID } from './postgresqlDataExplorerRpcHandler.js';
 
@@ -12,18 +14,52 @@ import { IPostgresDataExplorerHost, POSTGRESQL_DATA_EXPLORER_PROVIDER_ID } from 
 let nextConnectionId = 1;
 
 /**
- * Connection configuration passed from the driver. Only the database and user are always present;
- * host, port, password, and SSL are omitted for peer authentication, which connects over a local
- * Unix domain socket as the operating system account. When omitted, the pg client falls back to its
- * defaults (local socket, port 5432, no password).
+ * The discrete connection fields, used when not connecting via a connection string. All are optional
+ * and mirror the pg client's own configuration: the local-server mechanism omits host, port, password,
+ * and SSL to connect over a local Unix domain socket, and the user/password mechanism may omit the
+ * user and password. When omitted, the pg client falls back to its defaults (local socket, port 5432,
+ * the operating system account via PGUSER, no password).
  */
-export interface PostgreSQLConnectionConfig {
+export interface PostgreSQLFieldConfig {
 	host?: string;
 	port?: number;
-	database: string;
-	user: string;
+	database?: string;
+	user?: string;
 	password?: string;
 	ssl?: boolean;
+	// Paths to the PEM files for client-certificate authentication. When any is set, SSL is enabled
+	// regardless of `ssl`, and the server certificate is verified only when `sslRootCert` is supplied.
+	sslRootCert?: string;
+	sslCert?: string;
+	sslKey?: string;
+}
+
+/**
+ * Connection configuration passed from the driver. Either a ready-made connection string or the
+ * discrete connection fields -- never both. The pg client is itself bimodal this way; the `kind`
+ * discriminant makes the two mutually exclusive by construction.
+ */
+export type PostgreSQLConnectionConfig =
+	// A libpq connection string (URL or key=value DSN), handed to the pg client as-is.
+	| { kind: 'connectionString'; connectionString: string }
+	| ({ kind: 'fields' } & PostgreSQLFieldConfig);
+
+/**
+ * Builds the `ssl` option for the pg Client from the discrete connection fields. Returns false when
+ * SSL is off, a permissive object when SSL is requested without certificates, and a full TLS option
+ * set (reading the certificate files into memory) for client-certificate authentication. The server
+ * certificate is verified only when a CA certificate is supplied.
+ */
+function buildSslConfig(config: PostgreSQLFieldConfig): boolean | ConnectionOptions {
+	if (config.sslRootCert || config.sslCert || config.sslKey) {
+		return {
+			rejectUnauthorized: Boolean(config.sslRootCert),
+			ca: config.sslRootCert ? readFileSync(config.sslRootCert) : undefined,
+			cert: config.sslCert ? readFileSync(config.sslCert) : undefined,
+			key: config.sslKey ? readFileSync(config.sslKey) : undefined,
+		};
+	}
+	return config.ssl ? { rejectUnauthorized: false } : false;
 }
 
 /**
@@ -49,14 +85,18 @@ export class PostgreSQLConnection implements positron.DataConnection, IPostgresP
 		private readonly _config: PostgreSQLConnectionConfig,
 		private readonly _dataExplorerHandler: IPostgresDataExplorerHost
 	) {
-		this._client = new Client({
-			host: _config.host,
-			port: _config.port,
-			database: _config.database,
-			user: _config.user,
-			password: _config.password,
-			ssl: _config.ssl ? { rejectUnauthorized: false } : false,
-		});
+		// A connection string is handed to the pg client verbatim (it parses and applies any SSL
+		// options itself); otherwise the connection is built from the individual fields.
+		this._client = _config.kind === 'connectionString'
+			? new Client({ connectionString: _config.connectionString })
+			: new Client({
+				host: _config.host,
+				port: _config.port,
+				database: _config.database,
+				user: _config.user,
+				password: _config.password,
+				ssl: buildSslConfig(_config),
+			});
 	}
 
 	/**
@@ -70,11 +110,16 @@ export class PostgreSQLConnection implements positron.DataConnection, IPostgresP
 			await this._client.connect();
 		} catch (err: any) {
 			this._client = null;
-			// A socket-directory host (or no host) means a local-socket/peer connection; otherwise
-			// report the host:port we tried.
-			const target = this._config.host && !this._config.host.startsWith('/')
-				? `${this._config.host}:${this._config.port ?? 5432}`
-				: 'the local socket';
+			// Report what we tried to connect to. A connection string hides the host; a socket-directory
+			// host (or no host) means a local-socket connection; otherwise report the host:port.
+			let target: string;
+			if (this._config.kind === 'connectionString') {
+				target = 'the server in the connection string';
+			} else if (this._config.host && !this._config.host.startsWith('/')) {
+				target = `${this._config.host}:${this._config.port ?? 5432}`;
+			} else {
+				target = 'the local socket';
+			}
 			throw new Error(`Failed to connect to PostgreSQL at ${target}: ${err.message}`);
 		}
 	}

--- a/extensions/positron-data-driver-postgresql/src/postgresqlDriver.ts
+++ b/extensions/positron-data-driver-postgresql/src/postgresqlDriver.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { readFileSync } from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import * as positron from 'positron';
 import * as vscode from 'vscode';
@@ -28,9 +29,158 @@ function escapeDoubleQuoted(value: string): string {
 
 /**
  * The id of the username/password connection mechanism. Used both in the driver's mechanism list
- * and in the connect switch, so the two stay in sync.
+ * and in the connect/generate switches, so they stay in sync.
  */
 const PASSWORD_MECHANISM_ID = 'password';
+
+/**
+ * The id of the peer connection mechanism. PostgreSQL peer authentication uses the operating system
+ * account over a local Unix domain socket, so no password is needed. Used both in the driver's
+ * mechanism list and in the connect/generate switches, so they stay in sync.
+ */
+const PEER_MECHANISM_ID = 'peer';
+
+/**
+ * Generates connection code for the username/password mechanism, using the host, port, database,
+ * user, password, and SSL parameters. Returns an empty array when a required value is missing.
+ */
+function generatePasswordConnectionCode(languageId: string, params: positron.DataConnectionParameterValues): positron.ConnectionCodeVariant[] {
+	// The host, database, and user are required to generate valid connection code.
+	const host = params.host;
+	const database = params.database;
+	const user = params.user;
+	if (!isNonEmptyString(host) || !isNonEmptyString(database) || !isNonEmptyString(user)) {
+		return [];
+	}
+
+	const port = typeof params.port === 'number' ? params.port : 5432;
+	const password = isNonEmptyString(params.password) ? params.password : '';
+	const ssl = params.ssl === true;
+
+	switch (languageId) {
+		case 'python': {
+			// The psycopg2 connect arguments.
+			const psycopg2Args = [
+				`host="${escapeDoubleQuoted(host)}"`,
+				`port=${port}`,
+				`dbname="${escapeDoubleQuoted(database)}"`,
+				`user="${escapeDoubleQuoted(user)}"`,
+				`password="${escapeDoubleQuoted(password)}"`,
+			];
+			if (ssl) {
+				psycopg2Args.push(`sslmode="require"`);
+			}
+
+			// The SQLAlchemy URL arguments. We build the engine from sa.URL.create(...)
+			// rather than a URL string so the credentials are escaped by SQLAlchemy
+			// instead of requiring manual percent-encoding of special characters.
+			const sqlalchemyArgs = [
+				`"postgresql+psycopg2"`,
+				`host="${escapeDoubleQuoted(host)}"`,
+				`port=${port}`,
+				`database="${escapeDoubleQuoted(database)}"`,
+				`username="${escapeDoubleQuoted(user)}"`,
+				`password="${escapeDoubleQuoted(password)}"`,
+			];
+			if (ssl) {
+				sqlalchemyArgs.push(`query={"sslmode": "require"}`);
+			}
+
+			return [
+				{
+					id: 'psycopg2',
+					label: 'psycopg2',
+					code: `import psycopg2\n\nconn = psycopg2.connect(\n${psycopg2Args.map(arg => `\t${arg},`).join('\n')}\n)\n`,
+				},
+				{
+					id: 'sqlalchemy',
+					label: 'SQLAlchemy',
+					code: `import sqlalchemy as sa\n\nengine = sa.create_engine(sa.URL.create(\n${sqlalchemyArgs.map(arg => `\t${arg},`).join('\n')}\n))\n`,
+				},
+			];
+		}
+		case 'r': {
+			const args = [
+				`RPostgres::Postgres()`,
+				`host = "${escapeDoubleQuoted(host)}"`,
+				`port = ${port}`,
+				`dbname = "${escapeDoubleQuoted(database)}"`,
+				`user = "${escapeDoubleQuoted(user)}"`,
+				`password = "${escapeDoubleQuoted(password)}"`,
+			];
+			if (ssl) {
+				args.push(`sslmode = "require"`);
+			}
+			return [
+				{
+					id: 'dbi',
+					label: 'DBI',
+					// R does not allow a trailing comma, so join the arguments with commas.
+					code: `library(DBI)\n\ncon <- dbConnect(\n${args.map(arg => `\t${arg}`).join(',\n')}\n)\n`,
+				},
+			];
+		}
+		default:
+			return [];
+	}
+}
+
+/**
+ * Generates connection code for the peer mechanism. Peer authentication connects over a local
+ * socket as the operating system account, so no host, port, or password is emitted; a user is
+ * included only when explicitly set (otherwise the client defaults to the OS account). Returns an
+ * empty array when the database is missing.
+ */
+function generatePeerConnectionCode(languageId: string, params: positron.DataConnectionParameterValues): positron.ConnectionCodeVariant[] {
+	const database = params.database;
+	if (!isNonEmptyString(database)) {
+		return [];
+	}
+	const user = isNonEmptyString(params.user) ? params.user : undefined;
+
+	switch (languageId) {
+		case 'python': {
+			const psycopg2Args = [`dbname="${escapeDoubleQuoted(database)}"`];
+			if (user) {
+				psycopg2Args.push(`user="${escapeDoubleQuoted(user)}"`);
+			}
+
+			const sqlalchemyArgs = [`"postgresql+psycopg2"`, `database="${escapeDoubleQuoted(database)}"`];
+			if (user) {
+				sqlalchemyArgs.push(`username="${escapeDoubleQuoted(user)}"`);
+			}
+
+			return [
+				{
+					id: 'psycopg2',
+					label: 'psycopg2',
+					code: `import psycopg2\n\nconn = psycopg2.connect(\n${psycopg2Args.map(arg => `\t${arg},`).join('\n')}\n)\n`,
+				},
+				{
+					id: 'sqlalchemy',
+					label: 'SQLAlchemy',
+					code: `import sqlalchemy as sa\n\nengine = sa.create_engine(sa.URL.create(\n${sqlalchemyArgs.map(arg => `\t${arg},`).join('\n')}\n))\n`,
+				},
+			];
+		}
+		case 'r': {
+			const args = [`RPostgres::Postgres()`, `dbname = "${escapeDoubleQuoted(database)}"`];
+			if (user) {
+				args.push(`user = "${escapeDoubleQuoted(user)}"`);
+			}
+			return [
+				{
+					id: 'dbi',
+					label: 'DBI',
+					// R does not allow a trailing comma, so join the arguments with commas.
+					code: `library(DBI)\n\ncon <- dbConnect(\n${args.map(arg => `\t${arg}`).join(',\n')}\n)\n`,
+				},
+			];
+		}
+		default:
+			return [];
+	}
+}
 
 /**
  * Creates the PostgreSQL DataConnectionDriver.
@@ -44,6 +194,88 @@ export function createPostgreSQLDriver(
 	const iconPath = path.join(context.extensionPath, 'media', 'logo', 'postgresql.svg');
 	const iconSvg = readFileSync(iconPath, 'utf-8');
 
+	// Username & password mechanism: a standard host/port/database/user/password connection.
+	const passwordMechanism: positron.DataConnectionMechanism = {
+		id: PASSWORD_MECHANISM_ID,
+		label: vscode.l10n.t('Username & Password'),
+		description: vscode.l10n.t('Connect using a host, database, and username/password'),
+		parameters: [
+			{
+				id: 'host',
+				label: vscode.l10n.t('Host'),
+				type: positron.DataConnectionParameterType.String,
+				required: true,
+				defaultValue: 'localhost',
+			},
+			{
+				id: 'port',
+				label: vscode.l10n.t('Port'),
+				type: positron.DataConnectionParameterType.Number,
+				required: true,
+				defaultValue: 5432,
+			},
+			{
+				id: 'database',
+				label: vscode.l10n.t('Database'),
+				type: positron.DataConnectionParameterType.String,
+				required: true,
+			},
+			{
+				id: 'user',
+				label: vscode.l10n.t('User'),
+				type: positron.DataConnectionParameterType.String,
+				required: true,
+			},
+			{
+				id: 'password',
+				label: vscode.l10n.t('Password'),
+				type: positron.DataConnectionParameterType.Password,
+				secret: true,
+				required: true,
+			},
+			{
+				id: 'ssl',
+				label: vscode.l10n.t('Use SSL'),
+				type: positron.DataConnectionParameterType.Boolean,
+				defaultValue: false,
+			},
+		],
+	};
+
+	// Peer mechanism: PostgreSQL peer authentication maps the operating system account to a database
+	// role over a local Unix domain socket, so no password is required.
+	const peerMechanism: positron.DataConnectionMechanism = {
+		id: PEER_MECHANISM_ID,
+		label: vscode.l10n.t('Peer (Local Socket)'),
+		description: vscode.l10n.t('Connect to a local server using your operating system account. No password required.'),
+		parameters: [
+			{
+				id: 'database',
+				label: vscode.l10n.t('Database'),
+				type: positron.DataConnectionParameterType.String,
+				required: true,
+			},
+			{
+				// Blank defaults to the operating system account; only needed when the role name differs.
+				id: 'user',
+				label: vscode.l10n.t('User'),
+				type: positron.DataConnectionParameterType.String,
+			},
+			{
+				// Blank uses the platform default socket location (e.g. /var/run/postgresql).
+				id: 'socketDirectory',
+				label: vscode.l10n.t('Socket Directory'),
+				type: positron.DataConnectionParameterType.File,
+			},
+		],
+	};
+
+	// Peer authentication is only available over Unix domain sockets; Windows has no equivalent (its
+	// analogue is SSPI), so only offer it on macOS and Linux.
+	const mechanisms = process.platform === 'win32'
+		? [passwordMechanism]
+		: [passwordMechanism, peerMechanism];
+
 	// Return the driver.
 	return {
 		id: 'positron-data-driver-postgresql',
@@ -51,54 +283,7 @@ export function createPostgreSQLDriver(
 		description: vscode.l10n.t('Connect to a PostgreSQL database server'),
 		iconSvg,
 		supportedLanguageIds: ['python', 'r'],
-		mechanisms: [
-			{
-				id: PASSWORD_MECHANISM_ID,
-				label: vscode.l10n.t('Username & Password'),
-				description: vscode.l10n.t('Connect using a host, database, and username/password'),
-				parameters: [
-					{
-						id: 'host',
-						label: vscode.l10n.t('Host'),
-						type: positron.DataConnectionParameterType.String,
-						required: true,
-						defaultValue: 'localhost',
-					},
-					{
-						id: 'port',
-						label: vscode.l10n.t('Port'),
-						type: positron.DataConnectionParameterType.Number,
-						required: true,
-						defaultValue: 5432,
-					},
-					{
-						id: 'database',
-						label: vscode.l10n.t('Database'),
-						type: positron.DataConnectionParameterType.String,
-						required: true,
-					},
-					{
-						id: 'user',
-						label: vscode.l10n.t('User'),
-						type: positron.DataConnectionParameterType.String,
-						required: true,
-					},
-					{
-						id: 'password',
-						label: vscode.l10n.t('Password'),
-						type: positron.DataConnectionParameterType.Password,
-						secret: true,
-						required: true,
-					},
-					{
-						id: 'ssl',
-						label: vscode.l10n.t('Use SSL'),
-						type: positron.DataConnectionParameterType.Boolean,
-						defaultValue: false,
-					},
-				],
-			},
-		],
+		mechanisms,
 		async connect(mechanismId: string, params: positron.DataConnectionParameterValues): Promise<positron.DataConnection> {
 			switch (mechanismId) {
 				case PASSWORD_MECHANISM_ID: {
@@ -143,86 +328,41 @@ export function createPostgreSQLDriver(
 					// Return the connection.
 					return connection;
 				}
+				case PEER_MECHANISM_ID: {
+					// Extract parameters.
+					const database = params.database;
+
+					// Validate parameters. Only the database is required: a blank user defaults to the
+					// operating system account, and a blank socket directory lets pg use its default.
+					if (!isNonEmptyString(database)) {
+						return Promise.reject(new Error(vscode.l10n.t('Database is required')));
+					}
+					const user = isNonEmptyString(params.user) ? params.user : os.userInfo().username;
+					const host = isNonEmptyString(params.socketDirectory) ? params.socketDirectory : undefined;
+
+					// Create the connection. No password, port, or SSL: peer auth is local-socket only.
+					const connection = new PostgreSQLConnection({
+						host,
+						database,
+						user,
+					}, dataExplorerHandler);
+
+					// Connect the connection.
+					await connection.connect();
+
+					// Return the connection.
+					return connection;
+				}
 				default:
 					return Promise.reject(new Error(vscode.l10n.t("Unknown connection mechanism '{0}'.", mechanismId)));
 			}
 		},
-		async generateConnectionCode(_mechanismId: string, languageId: string, params: positron.DataConnectionParameterValues): Promise<positron.ConnectionCodeVariant[]> {
-			// The host, database, and user are required to generate valid connection code.
-			const host = params.host;
-			const database = params.database;
-			const user = params.user;
-			if (!isNonEmptyString(host) || !isNonEmptyString(database) || !isNonEmptyString(user)) {
-				return [];
-			}
-
-			const port = typeof params.port === 'number' ? params.port : 5432;
-			const password = isNonEmptyString(params.password) ? params.password : '';
-			const ssl = params.ssl === true;
-
-			switch (languageId) {
-				case 'python': {
-					// The psycopg2 connect arguments.
-					const psycopg2Args = [
-						`host="${escapeDoubleQuoted(host)}"`,
-						`port=${port}`,
-						`dbname="${escapeDoubleQuoted(database)}"`,
-						`user="${escapeDoubleQuoted(user)}"`,
-						`password="${escapeDoubleQuoted(password)}"`,
-					];
-					if (ssl) {
-						psycopg2Args.push(`sslmode="require"`);
-					}
-
-					// The SQLAlchemy URL arguments. We build the engine from sa.URL.create(...)
-					// rather than a URL string so the credentials are escaped by SQLAlchemy
-					// instead of requiring manual percent-encoding of special characters.
-					const sqlalchemyArgs = [
-						`"postgresql+psycopg2"`,
-						`host="${escapeDoubleQuoted(host)}"`,
-						`port=${port}`,
-						`database="${escapeDoubleQuoted(database)}"`,
-						`username="${escapeDoubleQuoted(user)}"`,
-						`password="${escapeDoubleQuoted(password)}"`,
-					];
-					if (ssl) {
-						sqlalchemyArgs.push(`query={"sslmode": "require"}`);
-					}
-
-					return [
-						{
-							id: 'psycopg2',
-							label: 'psycopg2',
-							code: `import psycopg2\n\nconn = psycopg2.connect(\n${psycopg2Args.map(arg => `\t${arg},`).join('\n')}\n)\n`,
-						},
-						{
-							id: 'sqlalchemy',
-							label: 'SQLAlchemy',
-							code: `import sqlalchemy as sa\n\nengine = sa.create_engine(sa.URL.create(\n${sqlalchemyArgs.map(arg => `\t${arg},`).join('\n')}\n))\n`,
-						},
-					];
-				}
-				case 'r': {
-					const args = [
-						`RPostgres::Postgres()`,
-						`host = "${escapeDoubleQuoted(host)}"`,
-						`port = ${port}`,
-						`dbname = "${escapeDoubleQuoted(database)}"`,
-						`user = "${escapeDoubleQuoted(user)}"`,
-						`password = "${escapeDoubleQuoted(password)}"`,
-					];
-					if (ssl) {
-						args.push(`sslmode = "require"`);
-					}
-					return [
-						{
-							id: 'dbi',
-							label: 'DBI',
-							// R does not allow a trailing comma, so join the arguments with commas.
-							code: `library(DBI)\n\ncon <- dbConnect(\n${args.map(arg => `\t${arg}`).join(',\n')}\n)\n`,
-						},
-					];
-				}
+		async generateConnectionCode(mechanismId: string, languageId: string, params: positron.DataConnectionParameterValues): Promise<positron.ConnectionCodeVariant[]> {
+			switch (mechanismId) {
+				case PASSWORD_MECHANISM_ID:
+					return generatePasswordConnectionCode(languageId, params);
+				case PEER_MECHANISM_ID:
+					return generatePeerConnectionCode(languageId, params);
 				default:
 					return [];
 			}

--- a/extensions/positron-data-driver-postgresql/src/postgresqlDriver.ts
+++ b/extensions/positron-data-driver-postgresql/src/postgresqlDriver.ts
@@ -27,6 +27,12 @@ function escapeDoubleQuoted(value: string): string {
 }
 
 /**
+ * The id of the username/password connection mechanism. Used both in the driver's mechanism list
+ * and in the connect switch, so the two stay in sync.
+ */
+const PASSWORD_MECHANISM_ID = 'password';
+
+/**
  * Creates the PostgreSQL DataConnectionDriver.
  * @param context The extension context, used to locate the icon asset.
  */
@@ -45,90 +51,103 @@ export function createPostgreSQLDriver(
 		description: vscode.l10n.t('Connect to a PostgreSQL database server'),
 		iconSvg,
 		supportedLanguageIds: ['python', 'r'],
-		parameters: [
+		mechanisms: [
 			{
-				id: 'host',
-				label: vscode.l10n.t('Host'),
-				type: positron.DataConnectionParameterType.String,
-				required: true,
-				defaultValue: 'localhost',
-			},
-			{
-				id: 'port',
-				label: vscode.l10n.t('Port'),
-				type: positron.DataConnectionParameterType.Number,
-				required: true,
-				defaultValue: 5432,
-			},
-			{
-				id: 'database',
-				label: vscode.l10n.t('Database'),
-				type: positron.DataConnectionParameterType.String,
-				required: true,
-			},
-			{
-				id: 'user',
-				label: vscode.l10n.t('User'),
-				type: positron.DataConnectionParameterType.String,
-				required: true,
-			},
-			{
-				id: 'password',
-				label: vscode.l10n.t('Password'),
-				type: positron.DataConnectionParameterType.Password,
-				secret: true,
-				required: true,
-			},
-			{
-				id: 'ssl',
-				label: vscode.l10n.t('Use SSL'),
-				type: positron.DataConnectionParameterType.Boolean,
-				defaultValue: false,
+				id: PASSWORD_MECHANISM_ID,
+				label: vscode.l10n.t('Username & Password'),
+				description: vscode.l10n.t('Connect using a host, database, and username/password'),
+				parameters: [
+					{
+						id: 'host',
+						label: vscode.l10n.t('Host'),
+						type: positron.DataConnectionParameterType.String,
+						required: true,
+						defaultValue: 'localhost',
+					},
+					{
+						id: 'port',
+						label: vscode.l10n.t('Port'),
+						type: positron.DataConnectionParameterType.Number,
+						required: true,
+						defaultValue: 5432,
+					},
+					{
+						id: 'database',
+						label: vscode.l10n.t('Database'),
+						type: positron.DataConnectionParameterType.String,
+						required: true,
+					},
+					{
+						id: 'user',
+						label: vscode.l10n.t('User'),
+						type: positron.DataConnectionParameterType.String,
+						required: true,
+					},
+					{
+						id: 'password',
+						label: vscode.l10n.t('Password'),
+						type: positron.DataConnectionParameterType.Password,
+						secret: true,
+						required: true,
+					},
+					{
+						id: 'ssl',
+						label: vscode.l10n.t('Use SSL'),
+						type: positron.DataConnectionParameterType.Boolean,
+						defaultValue: false,
+					},
+				],
 			},
 		],
-		async connect(params: positron.DataConnectionParameterValues): Promise<positron.DataConnection> {
-			// Extract parameters.
-			const host = params.host;
-			const port = typeof params.port === 'number' ? params.port : undefined;
-			const database = params.database;
-			const user = params.user;
-			const password = params.password;
-			const ssl = params.ssl as boolean ?? false;
+		async connect(mechanismId: string, params: positron.DataConnectionParameterValues): Promise<positron.DataConnection> {
+			switch (mechanismId) {
+				case PASSWORD_MECHANISM_ID: {
+					// Extract parameters.
+					const host = params.host;
+					const port = typeof params.port === 'number' ? params.port : undefined;
+					const database = params.database;
+					const user = params.user;
+					const password = params.password;
+					const ssl = params.ssl as boolean ?? false;
 
-			// Validate parameters.
-			if (!isNonEmptyString(host)) {
-				return Promise.reject(new Error(vscode.l10n.t('Host is required')));
-			}
-			if (port === undefined) {
-				return Promise.reject(new Error(vscode.l10n.t('Port is required')));
-			}
-			if (!isNonEmptyString(database)) {
-				return Promise.reject(new Error(vscode.l10n.t('Database is required')));
-			}
-			if (!isNonEmptyString(user)) {
-				return Promise.reject(new Error(vscode.l10n.t('User is required')));
-			}
-			if (!isNonEmptyString(password)) {
-				return Promise.reject(new Error(vscode.l10n.t('Password is required')));
-			}
+					// Validate parameters.
+					if (!isNonEmptyString(host)) {
+						return Promise.reject(new Error(vscode.l10n.t('Host is required')));
+					}
+					if (port === undefined) {
+						return Promise.reject(new Error(vscode.l10n.t('Port is required')));
+					}
+					if (!isNonEmptyString(database)) {
+						return Promise.reject(new Error(vscode.l10n.t('Database is required')));
+					}
+					if (!isNonEmptyString(user)) {
+						return Promise.reject(new Error(vscode.l10n.t('User is required')));
+					}
+					if (!isNonEmptyString(password)) {
+						return Promise.reject(new Error(vscode.l10n.t('Password is required')));
+					}
 
-			// Create the connection.
-			const connection = new PostgreSQLConnection({
-				host,
-				port,
-				database,
-				user,
-				password,
-				ssl
-			}, dataExplorerHandler);
+					// Create the connection.
+					const connection = new PostgreSQLConnection({
+						host,
+						port,
+						database,
+						user,
+						password,
+						ssl
+					}, dataExplorerHandler);
 
-			// Connect the connection.
-			await connection.connect();
+					// Connect the connection.
+					await connection.connect();
 
-			// Return the connection.
-			return connection;
+					// Return the connection.
+					return connection;
+				}
+				default:
+					return Promise.reject(new Error(vscode.l10n.t("Unknown connection mechanism '{0}'.", mechanismId)));
+			}
 		},
-		async generateConnectionCode(languageId: string, params: positron.DataConnectionParameterValues): Promise<positron.ConnectionCodeVariant[]> {
+		async generateConnectionCode(_mechanismId: string, languageId: string, params: positron.DataConnectionParameterValues): Promise<positron.ConnectionCodeVariant[]> {
 			// The host, database, and user are required to generate valid connection code.
 			const host = params.host;
 			const database = params.database;

--- a/extensions/positron-data-driver-postgresql/src/postgresqlDriver.ts
+++ b/extensions/positron-data-driver-postgresql/src/postgresqlDriver.ts
@@ -28,158 +28,369 @@ function escapeDoubleQuoted(value: string): string {
 }
 
 /**
- * The id of the username/password connection mechanism. Used both in the driver's mechanism list
+ * The id of the user/password connection mechanism. Used both in the driver's mechanism list
  * and in the connect/generate switches, so they stay in sync.
  */
 const PASSWORD_MECHANISM_ID = 'password';
 
 /**
- * The id of the peer connection mechanism. PostgreSQL peer authentication uses the operating system
- * account over a local Unix domain socket, so no password is needed. Used both in the driver's
- * mechanism list and in the connect/generate switches, so they stay in sync.
+ * The id of the local-server connection mechanism. Connects over a local Unix domain socket as the
+ * operating system account with no password, relying on the server's local socket authentication
+ * (PostgreSQL peer or trust). Used both in the driver's mechanism list and in the connect/generate
+ * switches, so they stay in sync.
  */
-const PEER_MECHANISM_ID = 'peer';
+const LOCAL_SERVER_MECHANISM_ID = 'localServer';
 
 /**
- * Generates connection code for the username/password mechanism, using the host, port, database,
- * user, password, and SSL parameters. Returns an empty array when a required value is missing.
+ * The id of the client-certificate connection mechanism. The client authenticates over SSL by
+ * presenting a certificate and key rather than a password. Used both in the driver's mechanism list
+ * and in the connect/generate switches, so they stay in sync.
  */
-function generatePasswordConnectionCode(languageId: string, params: positron.DataConnectionParameterValues): positron.ConnectionCodeVariant[] {
-	// The host, database, and user are required to generate valid connection code.
-	const host = params.host;
-	const database = params.database;
-	const user = params.user;
-	if (!isNonEmptyString(host) || !isNonEmptyString(database) || !isNonEmptyString(user)) {
+const CERT_MECHANISM_ID = 'clientCert';
+
+/**
+ * The id of the connection-string mechanism. The user pastes a single libpq connection string (URL
+ * or key=value DSN), which is handed to the client verbatim. Used both in the driver's mechanism list
+ * and in the connect/generate switches, so they stay in sync.
+ */
+const CONNECTION_STRING_MECHANISM_ID = 'connectionString';
+
+// --- Parameter fragments ---
+//
+// Mechanisms are assembled from these shared fragments rather than repeating parameter definitions.
+// They are functions (not constants) because they call vscode.l10n.t, which must run after the l10n
+// bundle is initialized; each is invoked while building the driver inside createPostgreSQLDriver.
+
+/** The TCP endpoint parameters (host and port), shared by the password and client-cert mechanisms. */
+function hostPortParams(): positron.DataConnectionParameter[] {
+	return [
+		{
+			id: 'host',
+			label: vscode.l10n.t('Host'),
+			type: positron.DataConnectionParameterType.String,
+			required: true,
+			defaultValue: 'localhost',
+		},
+		{
+			id: 'port',
+			label: vscode.l10n.t('Port'),
+			type: positron.DataConnectionParameterType.Number,
+			required: true,
+			defaultValue: 5432,
+		},
+	];
+}
+
+/** The required database parameter, shared by every mechanism. */
+function databaseParam(): positron.DataConnectionParameter {
+	return {
+		id: 'database',
+		label: vscode.l10n.t('Database'),
+		type: positron.DataConnectionParameterType.String,
+		required: true,
+	};
+}
+
+/** The optional user parameter, shared by every mechanism. Blank defaults to the OS account. */
+function userParam(): positron.DataConnectionParameter {
+	return {
+		// Blank lets the pg client default to the operating system account (via PGUSER).
+		id: 'user',
+		label: vscode.l10n.t('User'),
+		description: vscode.l10n.t('Leave empty to use your operating system account.'),
+		type: positron.DataConnectionParameterType.String,
+	};
+}
+
+/** The optional password parameter, used by the user/password mechanism. */
+function passwordParam(): positron.DataConnectionParameter {
+	return {
+		// Blank connects without a password, which works when the server does not require one for this
+		// user (e.g. trust authentication, or credentials supplied via .pgpass or PGPASSWORD).
+		id: 'password',
+		label: vscode.l10n.t('Password'),
+		description: vscode.l10n.t('Leave empty if the server does not require a password for this user.'),
+		type: positron.DataConnectionParameterType.Password,
+		secret: true,
+	};
+}
+
+/** The optional "Use SSL" toggle, used by the user/password mechanism. */
+function sslParam(): positron.DataConnectionParameter {
+	return {
+		id: 'ssl',
+		label: vscode.l10n.t('Use SSL'),
+		type: positron.DataConnectionParameterType.Boolean,
+		defaultValue: false,
+	};
+}
+
+/** The client-certificate parameters (CA, client cert, client key), used by the cert mechanism. */
+function clientCertParams(): positron.DataConnectionParameter[] {
+	return [
+		{
+			// Blank skips server certificate verification; the connection is still encrypted.
+			id: 'sslrootcert',
+			label: vscode.l10n.t('CA Certificate'),
+			description: vscode.l10n.t('Leave empty to skip server certificate verification.'),
+			type: positron.DataConnectionParameterType.File,
+		},
+		{
+			id: 'sslcert',
+			label: vscode.l10n.t('Client Certificate'),
+			type: positron.DataConnectionParameterType.File,
+			required: true,
+		},
+		{
+			id: 'sslkey',
+			label: vscode.l10n.t('Client Key'),
+			type: positron.DataConnectionParameterType.File,
+			required: true,
+		},
+	];
+}
+
+/** The single connection-string parameter, used by the connection-string mechanism. */
+function connectionStringParam(): positron.DataConnectionParameter {
+	return {
+		// Secret: a connection string typically embeds a password, so it must go to secret storage
+		// rather than plain settings. This also masks the field in the dialog.
+		id: 'connectionString',
+		label: vscode.l10n.t('Connection String'),
+		description: vscode.l10n.t('The connection string (URL) from your database provider.'),
+		type: positron.DataConnectionParameterType.String,
+		secret: true,
+		required: true,
+		placeholder: 'postgresql://user:password@host:5432/database',
+	};
+}
+
+// --- Connection code generation ---
+//
+// Each mechanism maps its parameter values to a normalized PostgresConnectionFields, and the shared
+// renderers turn those fields into client-library code. Only fields that are set are emitted, so the
+// same renderers serve every mechanism; the renderers own the per-library argument-name differences
+// (e.g. dbname vs database, user vs username).
+
+/**
+ * Normalized PostgreSQL connection fields, independent of any client library. The renderers map
+ * these to each library's argument names. Optional fields are omitted from the generated code.
+ */
+interface PostgresConnectionFields {
+	host?: string;
+	port?: number;
+	database: string;
+	user?: string;
+	password?: string;
+	sslmode?: string;
+	sslrootcert?: string;
+	sslcert?: string;
+	sslkey?: string;
+}
+
+/** Renders psycopg2 connection code from normalized fields. */
+function renderPsycopg2Code(fields: PostgresConnectionFields): positron.ConnectionCodeVariant {
+	const args: string[] = [];
+	if (fields.host) { args.push(`host="${escapeDoubleQuoted(fields.host)}"`); }
+	if (fields.port !== undefined) { args.push(`port=${fields.port}`); }
+	args.push(`dbname="${escapeDoubleQuoted(fields.database)}"`);
+	if (fields.user) { args.push(`user="${escapeDoubleQuoted(fields.user)}"`); }
+	if (fields.password) { args.push(`password="${escapeDoubleQuoted(fields.password)}"`); }
+	if (fields.sslmode) { args.push(`sslmode="${escapeDoubleQuoted(fields.sslmode)}"`); }
+	if (fields.sslrootcert) { args.push(`sslrootcert="${escapeDoubleQuoted(fields.sslrootcert)}"`); }
+	if (fields.sslcert) { args.push(`sslcert="${escapeDoubleQuoted(fields.sslcert)}"`); }
+	if (fields.sslkey) { args.push(`sslkey="${escapeDoubleQuoted(fields.sslkey)}"`); }
+	return {
+		id: 'psycopg2',
+		label: 'psycopg2',
+		code: `import psycopg2\n\nconn = psycopg2.connect(\n${args.map(arg => `\t${arg},`).join('\n')}\n)\n`,
+	};
+}
+
+/**
+ * Renders SQLAlchemy connection code from normalized fields. We build the engine from
+ * sa.URL.create(...) rather than a URL string so the credentials are escaped by SQLAlchemy instead
+ * of requiring manual percent-encoding of special characters; SSL options go in the query dict.
+ */
+function renderSqlAlchemyCode(fields: PostgresConnectionFields): positron.ConnectionCodeVariant {
+	const args: string[] = [`"postgresql+psycopg2"`];
+	if (fields.host) { args.push(`host="${escapeDoubleQuoted(fields.host)}"`); }
+	if (fields.port !== undefined) { args.push(`port=${fields.port}`); }
+	args.push(`database="${escapeDoubleQuoted(fields.database)}"`);
+	if (fields.user) { args.push(`username="${escapeDoubleQuoted(fields.user)}"`); }
+	if (fields.password) { args.push(`password="${escapeDoubleQuoted(fields.password)}"`); }
+
+	const queryEntries: string[] = [];
+	if (fields.sslmode) { queryEntries.push(`"sslmode": "${escapeDoubleQuoted(fields.sslmode)}"`); }
+	if (fields.sslrootcert) { queryEntries.push(`"sslrootcert": "${escapeDoubleQuoted(fields.sslrootcert)}"`); }
+	if (fields.sslcert) { queryEntries.push(`"sslcert": "${escapeDoubleQuoted(fields.sslcert)}"`); }
+	if (fields.sslkey) { queryEntries.push(`"sslkey": "${escapeDoubleQuoted(fields.sslkey)}"`); }
+	if (queryEntries.length > 0) { args.push(`query={${queryEntries.join(', ')}}`); }
+
+	return {
+		id: 'sqlalchemy',
+		label: 'SQLAlchemy',
+		code: `import sqlalchemy as sa\n\nengine = sa.create_engine(sa.URL.create(\n${args.map(arg => `\t${arg},`).join('\n')}\n))\n`,
+	};
+}
+
+/** Renders DBI/RPostgres connection code from normalized fields. */
+function renderDbiCode(fields: PostgresConnectionFields): positron.ConnectionCodeVariant {
+	const args: string[] = [`RPostgres::Postgres()`];
+	if (fields.host) { args.push(`host = "${escapeDoubleQuoted(fields.host)}"`); }
+	if (fields.port !== undefined) { args.push(`port = ${fields.port}`); }
+	args.push(`dbname = "${escapeDoubleQuoted(fields.database)}"`);
+	if (fields.user) { args.push(`user = "${escapeDoubleQuoted(fields.user)}"`); }
+	if (fields.password) { args.push(`password = "${escapeDoubleQuoted(fields.password)}"`); }
+	if (fields.sslmode) { args.push(`sslmode = "${escapeDoubleQuoted(fields.sslmode)}"`); }
+	if (fields.sslrootcert) { args.push(`sslrootcert = "${escapeDoubleQuoted(fields.sslrootcert)}"`); }
+	if (fields.sslcert) { args.push(`sslcert = "${escapeDoubleQuoted(fields.sslcert)}"`); }
+	if (fields.sslkey) { args.push(`sslkey = "${escapeDoubleQuoted(fields.sslkey)}"`); }
+	return {
+		id: 'dbi',
+		label: 'DBI',
+		// R does not allow a trailing comma, so join the arguments with commas.
+		code: `library(DBI)\n\ncon <- dbConnect(\n${args.map(arg => `\t${arg}`).join(',\n')}\n)\n`,
+	};
+}
+
+/**
+ * Generates the connection code variants for the given language from normalized fields. Returns an
+ * empty array when the fields could not be built (a required parameter was missing) or the language
+ * is unsupported.
+ */
+function generateConnectionCodeForFields(languageId: string, fields: PostgresConnectionFields | undefined): positron.ConnectionCodeVariant[] {
+	if (!fields) {
 		return [];
 	}
-
-	const port = typeof params.port === 'number' ? params.port : 5432;
-	const password = isNonEmptyString(params.password) ? params.password : '';
-	const ssl = params.ssl === true;
-
 	switch (languageId) {
-		case 'python': {
-			// The psycopg2 connect arguments.
-			const psycopg2Args = [
-				`host="${escapeDoubleQuoted(host)}"`,
-				`port=${port}`,
-				`dbname="${escapeDoubleQuoted(database)}"`,
-				`user="${escapeDoubleQuoted(user)}"`,
-				`password="${escapeDoubleQuoted(password)}"`,
-			];
-			if (ssl) {
-				psycopg2Args.push(`sslmode="require"`);
-			}
-
-			// The SQLAlchemy URL arguments. We build the engine from sa.URL.create(...)
-			// rather than a URL string so the credentials are escaped by SQLAlchemy
-			// instead of requiring manual percent-encoding of special characters.
-			const sqlalchemyArgs = [
-				`"postgresql+psycopg2"`,
-				`host="${escapeDoubleQuoted(host)}"`,
-				`port=${port}`,
-				`database="${escapeDoubleQuoted(database)}"`,
-				`username="${escapeDoubleQuoted(user)}"`,
-				`password="${escapeDoubleQuoted(password)}"`,
-			];
-			if (ssl) {
-				sqlalchemyArgs.push(`query={"sslmode": "require"}`);
-			}
-
-			return [
-				{
-					id: 'psycopg2',
-					label: 'psycopg2',
-					code: `import psycopg2\n\nconn = psycopg2.connect(\n${psycopg2Args.map(arg => `\t${arg},`).join('\n')}\n)\n`,
-				},
-				{
-					id: 'sqlalchemy',
-					label: 'SQLAlchemy',
-					code: `import sqlalchemy as sa\n\nengine = sa.create_engine(sa.URL.create(\n${sqlalchemyArgs.map(arg => `\t${arg},`).join('\n')}\n))\n`,
-				},
-			];
-		}
-		case 'r': {
-			const args = [
-				`RPostgres::Postgres()`,
-				`host = "${escapeDoubleQuoted(host)}"`,
-				`port = ${port}`,
-				`dbname = "${escapeDoubleQuoted(database)}"`,
-				`user = "${escapeDoubleQuoted(user)}"`,
-				`password = "${escapeDoubleQuoted(password)}"`,
-			];
-			if (ssl) {
-				args.push(`sslmode = "require"`);
-			}
-			return [
-				{
-					id: 'dbi',
-					label: 'DBI',
-					// R does not allow a trailing comma, so join the arguments with commas.
-					code: `library(DBI)\n\ncon <- dbConnect(\n${args.map(arg => `\t${arg}`).join(',\n')}\n)\n`,
-				},
-			];
-		}
+		case 'python':
+			return [renderPsycopg2Code(fields), renderSqlAlchemyCode(fields)];
+		case 'r':
+			return [renderDbiCode(fields)];
 		default:
 			return [];
 	}
 }
 
 /**
- * Generates connection code for the peer mechanism. Peer authentication connects over a local
- * socket as the operating system account, so no host, port, or password is emitted; a user is
- * included only when explicitly set (otherwise the client defaults to the OS account). Returns an
- * empty array when the database is missing.
+ * Maps the usern/password mechanism's parameter values to normalized fields. The user and
+ * password are optional. Returns undefined when the host or database is missing.
  */
-function generatePeerConnectionCode(languageId: string, params: positron.DataConnectionParameterValues): positron.ConnectionCodeVariant[] {
+function passwordConnectionFields(params: positron.DataConnectionParameterValues): PostgresConnectionFields | undefined {
+	const host = isNonEmptyString(params.host) ? params.host : undefined;
+	const database = isNonEmptyString(params.database) ? params.database : undefined;
+	if (!host || !database) {
+		return undefined;
+	}
+	return {
+		host,
+		port: typeof params.port === 'number' ? params.port : 5432,
+		database,
+		user: isNonEmptyString(params.user) ? params.user : undefined,
+		password: isNonEmptyString(params.password) ? params.password : undefined,
+		sslmode: params.ssl === true ? 'require' : undefined,
+	};
+}
+
+/**
+ * Maps the local-server mechanism's parameter values to normalized fields. The connection is over a
+ * local socket, so no host, port, or password is emitted; the user is included only when set
+ * (otherwise the client defaults to the OS account). Returns undefined when the database is missing.
+ */
+function localServerConnectionFields(params: positron.DataConnectionParameterValues): PostgresConnectionFields | undefined {
+	const database = isNonEmptyString(params.database) ? params.database : undefined;
+	if (!database) {
+		return undefined;
+	}
+	return {
+		database,
+		user: isNonEmptyString(params.user) ? params.user : undefined,
+	};
+}
+
+/**
+ * Maps the client-certificate mechanism's parameter values to normalized fields. The server
+ * certificate is verified (sslmode "verify-full") only when a CA certificate is supplied; otherwise
+ * the connection is encrypted but unverified (sslmode "require"). Returns undefined when the host,
+ * database, client certificate, or client key is missing.
+ */
+function certConnectionFields(params: positron.DataConnectionParameterValues): PostgresConnectionFields | undefined {
+	const host = isNonEmptyString(params.host) ? params.host : undefined;
+	const database = isNonEmptyString(params.database) ? params.database : undefined;
+	const sslcert = isNonEmptyString(params.sslcert) ? params.sslcert : undefined;
+	const sslkey = isNonEmptyString(params.sslkey) ? params.sslkey : undefined;
+	if (!host || !database || !sslcert || !sslkey) {
+		return undefined;
+	}
+	const sslrootcert = isNonEmptyString(params.sslrootcert) ? params.sslrootcert : undefined;
+	return {
+		host,
+		port: typeof params.port === 'number' ? params.port : 5432,
+		database,
+		user: isNonEmptyString(params.user) ? params.user : undefined,
+		sslmode: sslrootcert ? 'verify-full' : 'require',
+		sslrootcert,
+		sslcert,
+		sslkey,
+	};
+}
+
+/**
+ * Parses a libpq URL connection string into normalized fields so the same renderers can generate
+ * code for it. Only the URL form (postgresql:// or postgres://) is understood; key=value DSN strings
+ * return undefined (they are still handed to the client verbatim at connect time, but cannot be
+ * turned into structured code). Returns undefined when the string does not parse or has no database.
+ */
+function parseConnectionString(connectionString: string): PostgresConnectionFields | undefined {
+	let url: URL;
+	try {
+		url = new URL(connectionString);
+	} catch {
+		return undefined;
+	}
+	if (url.protocol !== 'postgresql:' && url.protocol !== 'postgres:') {
+		return undefined;
+	}
+	const database = decodeURIComponent(url.pathname.replace(/^\//, ''));
+	if (!database) {
+		return undefined;
+	}
+	return {
+		host: url.hostname || undefined,
+		port: url.port ? Number(url.port) : undefined,
+		database,
+		user: url.username ? decodeURIComponent(url.username) : undefined,
+		password: url.password ? decodeURIComponent(url.password) : undefined,
+		sslmode: url.searchParams.get('sslmode') ?? undefined,
+		sslrootcert: url.searchParams.get('sslrootcert') ?? undefined,
+		sslcert: url.searchParams.get('sslcert') ?? undefined,
+		sslkey: url.searchParams.get('sslkey') ?? undefined,
+	};
+}
+
+// --- Connect-time validators ---
+
+/** Validates and returns the required TCP endpoint (host and port), throwing if either is missing. */
+function requireTcpEndpoint(params: positron.DataConnectionParameterValues): { host: string; port: number } {
+	const host = params.host;
+	if (!isNonEmptyString(host)) {
+		throw new Error(vscode.l10n.t('Host is required'));
+	}
+	const port = params.port;
+	if (typeof port !== 'number') {
+		throw new Error(vscode.l10n.t('Port is required'));
+	}
+	return { host, port };
+}
+
+/** Validates and returns the required database, throwing if it is missing. */
+function requireDatabase(params: positron.DataConnectionParameterValues): string {
 	const database = params.database;
 	if (!isNonEmptyString(database)) {
-		return [];
+		throw new Error(vscode.l10n.t('Database is required'));
 	}
-	const user = isNonEmptyString(params.user) ? params.user : undefined;
-
-	switch (languageId) {
-		case 'python': {
-			const psycopg2Args = [`dbname="${escapeDoubleQuoted(database)}"`];
-			if (user) {
-				psycopg2Args.push(`user="${escapeDoubleQuoted(user)}"`);
-			}
-
-			const sqlalchemyArgs = [`"postgresql+psycopg2"`, `database="${escapeDoubleQuoted(database)}"`];
-			if (user) {
-				sqlalchemyArgs.push(`username="${escapeDoubleQuoted(user)}"`);
-			}
-
-			return [
-				{
-					id: 'psycopg2',
-					label: 'psycopg2',
-					code: `import psycopg2\n\nconn = psycopg2.connect(\n${psycopg2Args.map(arg => `\t${arg},`).join('\n')}\n)\n`,
-				},
-				{
-					id: 'sqlalchemy',
-					label: 'SQLAlchemy',
-					code: `import sqlalchemy as sa\n\nengine = sa.create_engine(sa.URL.create(\n${sqlalchemyArgs.map(arg => `\t${arg},`).join('\n')}\n))\n`,
-				},
-			];
-		}
-		case 'r': {
-			const args = [`RPostgres::Postgres()`, `dbname = "${escapeDoubleQuoted(database)}"`];
-			if (user) {
-				args.push(`user = "${escapeDoubleQuoted(user)}"`);
-			}
-			return [
-				{
-					id: 'dbi',
-					label: 'DBI',
-					// R does not allow a trailing comma, so join the arguments with commas.
-					code: `library(DBI)\n\ncon <- dbConnect(\n${args.map(arg => `\t${arg}`).join(',\n')}\n)\n`,
-				},
-			];
-		}
-		default:
-			return [];
-	}
+	return database;
 }
 
 /**
@@ -194,87 +405,75 @@ export function createPostgreSQLDriver(
 	const iconPath = path.join(context.extensionPath, 'media', 'logo', 'postgresql.svg');
 	const iconSvg = readFileSync(iconPath, 'utf-8');
 
-	// Username & password mechanism: a standard host/port/database/user/password connection.
+	// User & password mechanism: a standard host/port/database/user/password connection.
 	const passwordMechanism: positron.DataConnectionMechanism = {
 		id: PASSWORD_MECHANISM_ID,
-		label: vscode.l10n.t('Username & Password'),
-		description: vscode.l10n.t('Connect using a host, database, and username/password'),
+		label: vscode.l10n.t('User & Password'),
+		description: vscode.l10n.t('Connect to a server over the network with a user and password.'),
 		parameters: [
-			{
-				id: 'host',
-				label: vscode.l10n.t('Host'),
-				type: positron.DataConnectionParameterType.String,
-				required: true,
-				defaultValue: 'localhost',
-			},
-			{
-				id: 'port',
-				label: vscode.l10n.t('Port'),
-				type: positron.DataConnectionParameterType.Number,
-				required: true,
-				defaultValue: 5432,
-			},
-			{
-				id: 'database',
-				label: vscode.l10n.t('Database'),
-				type: positron.DataConnectionParameterType.String,
-				required: true,
-			},
-			{
-				id: 'user',
-				label: vscode.l10n.t('User'),
-				type: positron.DataConnectionParameterType.String,
-				required: true,
-			},
-			{
-				id: 'password',
-				label: vscode.l10n.t('Password'),
-				type: positron.DataConnectionParameterType.Password,
-				secret: true,
-				required: true,
-			},
-			{
-				id: 'ssl',
-				label: vscode.l10n.t('Use SSL'),
-				type: positron.DataConnectionParameterType.Boolean,
-				defaultValue: false,
-			},
+			...hostPortParams(),
+			databaseParam(),
+			userParam(),
+			passwordParam(),
+			sslParam(),
 		],
 	};
 
-	// Peer mechanism: PostgreSQL peer authentication maps the operating system account to a database
-	// role over a local Unix domain socket, so no password is required.
-	const peerMechanism: positron.DataConnectionMechanism = {
-		id: PEER_MECHANISM_ID,
-		label: vscode.l10n.t('Peer (Local Socket)'),
-		description: vscode.l10n.t('Connect to a local server using your operating system account. No password required.'),
+	// Example socket directory shown as a placeholder. The default location is platform-specific:
+	// Debian/Ubuntu use /var/run/postgresql, while macOS (Homebrew, Postgres.app) and most other
+	// builds use /tmp. This is only an example; leaving the field blank uses libpq's compiled-in default.
+	const exampleSocketDirectory = process.platform === 'darwin' ? '/tmp' : '/var/run/postgresql';
+
+	// Local-server mechanism: connect over a local Unix domain socket as the operating system account,
+	// relying on the server's local socket authentication (PostgreSQL peer or trust), so no password
+	// is required.
+	const localServerMechanism: positron.DataConnectionMechanism = {
+		id: LOCAL_SERVER_MECHANISM_ID,
+		label: vscode.l10n.t('Local Server (No Password)'),
+		description: vscode.l10n.t('Connect to a PostgreSQL server running on this computer using your operating system account.'),
 		parameters: [
+			databaseParam(),
+			userParam(),
 			{
-				id: 'database',
-				label: vscode.l10n.t('Database'),
-				type: positron.DataConnectionParameterType.String,
-				required: true,
-			},
-			{
-				// Blank defaults to the operating system account; only needed when the role name differs.
-				id: 'user',
-				label: vscode.l10n.t('User'),
-				type: positron.DataConnectionParameterType.String,
-			},
-			{
-				// Blank uses the platform default socket location (e.g. /var/run/postgresql).
+				// Blank uses the platform default socket location (see exampleSocketDirectory above).
 				id: 'socketDirectory',
 				label: vscode.l10n.t('Socket Directory'),
+				description: vscode.l10n.t('Leave empty to use the default socket location.'),
+				placeholder: exampleSocketDirectory,
 				type: positron.DataConnectionParameterType.File,
 			},
 		],
 	};
 
-	// Peer authentication is only available over Unix domain sockets; Windows has no equivalent (its
-	// analogue is SSPI), so only offer it on macOS and Linux.
+	// Client-certificate mechanism: authenticate over SSL with a client certificate and key instead
+	// of a password. Available on all platforms, since it runs over TCP/TLS.
+	const certMechanism: positron.DataConnectionMechanism = {
+		id: CERT_MECHANISM_ID,
+		label: vscode.l10n.t('Client Certificate (SSL)'),
+		description: vscode.l10n.t('Connect over SSL and authenticate with a client certificate.'),
+		parameters: [
+			...hostPortParams(),
+			databaseParam(),
+			userParam(),
+			...clientCertParams(),
+		],
+	};
+
+	// Connection-string mechanism: paste a single libpq URL or DSN. Handed to the client verbatim, so
+	// it works over TCP or a local socket and is available on all platforms.
+	const connectionStringMechanism: positron.DataConnectionMechanism = {
+		id: CONNECTION_STRING_MECHANISM_ID,
+		label: vscode.l10n.t('Connection String'),
+		description: vscode.l10n.t('Connect by pasting a connection string (URL) from your database provider.'),
+		parameters: [connectionStringParam()],
+	};
+
+	// Local socket authentication is only available over Unix domain sockets; Windows has no
+	// equivalent (its analogue is SSPI), so only offer the local-server mechanism on macOS and Linux.
+	// The password, connection-string, and client-cert mechanisms are available everywhere.
 	const mechanisms = process.platform === 'win32'
-		? [passwordMechanism]
-		: [passwordMechanism, peerMechanism];
+		? [passwordMechanism, connectionStringMechanism, certMechanism]
+		: [passwordMechanism, connectionStringMechanism, localServerMechanism, certMechanism];
 
 	// Return the driver.
 	return {
@@ -287,39 +486,21 @@ export function createPostgreSQLDriver(
 		async connect(mechanismId: string, params: positron.DataConnectionParameterValues): Promise<positron.DataConnection> {
 			switch (mechanismId) {
 				case PASSWORD_MECHANISM_ID: {
-					// Extract parameters.
-					const host = params.host;
-					const port = typeof params.port === 'number' ? params.port : undefined;
-					const database = params.database;
-					const user = params.user;
-					const password = params.password;
-					const ssl = params.ssl as boolean ?? false;
-
-					// Validate parameters.
-					if (!isNonEmptyString(host)) {
-						return Promise.reject(new Error(vscode.l10n.t('Host is required')));
-					}
-					if (port === undefined) {
-						return Promise.reject(new Error(vscode.l10n.t('Port is required')));
-					}
-					if (!isNonEmptyString(database)) {
-						return Promise.reject(new Error(vscode.l10n.t('Database is required')));
-					}
-					if (!isNonEmptyString(user)) {
-						return Promise.reject(new Error(vscode.l10n.t('User is required')));
-					}
-					if (!isNonEmptyString(password)) {
-						return Promise.reject(new Error(vscode.l10n.t('Password is required')));
-					}
+					// Only the host, port, and database are required: a blank user defaults to the
+					// operating system account (via PGUSER), and a blank password connects without one,
+					// which works when the server does not require a password.
+					const { host, port } = requireTcpEndpoint(params);
+					const database = requireDatabase(params);
 
 					// Create the connection.
 					const connection = new PostgreSQLConnection({
+						kind: 'fields',
 						host,
 						port,
 						database,
-						user,
-						password,
-						ssl
+						user: isNonEmptyString(params.user) ? params.user : undefined,
+						password: isNonEmptyString(params.password) ? params.password : undefined,
+						ssl: params.ssl === true,
 					}, dataExplorerHandler);
 
 					// Connect the connection.
@@ -328,24 +509,67 @@ export function createPostgreSQLDriver(
 					// Return the connection.
 					return connection;
 				}
-				case PEER_MECHANISM_ID: {
-					// Extract parameters.
-					const database = params.database;
+				case LOCAL_SERVER_MECHANISM_ID: {
+					// Only the database is required: a blank user defaults to the operating system
+					// account, and a blank socket directory lets pg use its default.
+					const database = requireDatabase(params);
 
-					// Validate parameters. Only the database is required: a blank user defaults to the
-					// operating system account, and a blank socket directory lets pg use its default.
-					if (!isNonEmptyString(database)) {
-						return Promise.reject(new Error(vscode.l10n.t('Database is required')));
-					}
-					const user = isNonEmptyString(params.user) ? params.user : os.userInfo().username;
-					const host = isNonEmptyString(params.socketDirectory) ? params.socketDirectory : undefined;
-
-					// Create the connection. No password, port, or SSL: peer auth is local-socket only.
+					// Create the connection. No password, port, or SSL: this mechanism is local-socket only.
 					const connection = new PostgreSQLConnection({
-						host,
+						kind: 'fields',
+						host: isNonEmptyString(params.socketDirectory) ? params.socketDirectory : undefined,
 						database,
-						user,
+						user: isNonEmptyString(params.user) ? params.user : os.userInfo().username,
 					}, dataExplorerHandler);
+
+					// Connect the connection.
+					await connection.connect();
+
+					// Return the connection.
+					return connection;
+				}
+				case CERT_MECHANISM_ID: {
+					// The host, port, database, client certificate, and client key are required; the CA
+					// certificate is optional and, when omitted, the server certificate is not verified.
+					const { host, port } = requireTcpEndpoint(params);
+					const database = requireDatabase(params);
+					const sslCert = params.sslcert;
+					if (!isNonEmptyString(sslCert)) {
+						throw new Error(vscode.l10n.t('Client Certificate is required'));
+					}
+					const sslKey = params.sslkey;
+					if (!isNonEmptyString(sslKey)) {
+						throw new Error(vscode.l10n.t('Client Key is required'));
+					}
+
+					// Create the connection. SSL is implied by the client certificate.
+					const connection = new PostgreSQLConnection({
+						kind: 'fields',
+						host,
+						port,
+						database,
+						user: isNonEmptyString(params.user) ? params.user : undefined,
+						ssl: true,
+						sslRootCert: isNonEmptyString(params.sslrootcert) ? params.sslrootcert : undefined,
+						sslCert,
+						sslKey,
+					}, dataExplorerHandler);
+
+					// Connect the connection.
+					await connection.connect();
+
+					// Return the connection.
+					return connection;
+				}
+				case CONNECTION_STRING_MECHANISM_ID: {
+					// The connection string is the only parameter and is handed to the client verbatim.
+					const connectionString = params.connectionString;
+					if (!isNonEmptyString(connectionString)) {
+						throw new Error(vscode.l10n.t('Connection string is required'));
+					}
+
+					// Create the connection.
+					const connection = new PostgreSQLConnection({ kind: 'connectionString', connectionString }, dataExplorerHandler);
 
 					// Connect the connection.
 					await connection.connect();
@@ -360,9 +584,13 @@ export function createPostgreSQLDriver(
 		async generateConnectionCode(mechanismId: string, languageId: string, params: positron.DataConnectionParameterValues): Promise<positron.ConnectionCodeVariant[]> {
 			switch (mechanismId) {
 				case PASSWORD_MECHANISM_ID:
-					return generatePasswordConnectionCode(languageId, params);
-				case PEER_MECHANISM_ID:
-					return generatePeerConnectionCode(languageId, params);
+					return generateConnectionCodeForFields(languageId, passwordConnectionFields(params));
+				case LOCAL_SERVER_MECHANISM_ID:
+					return generateConnectionCodeForFields(languageId, localServerConnectionFields(params));
+				case CERT_MECHANISM_ID:
+					return generateConnectionCodeForFields(languageId, certConnectionFields(params));
+				case CONNECTION_STRING_MECHANISM_ID:
+					return generateConnectionCodeForFields(languageId, isNonEmptyString(params.connectionString) ? parseConnectionString(params.connectionString) : undefined);
 				default:
 					return [];
 			}

--- a/extensions/positron-data-driver-postgresql/src/postgresqlDriver.ts
+++ b/extensions/positron-data-driver-postgresql/src/postgresqlDriver.ts
@@ -154,12 +154,15 @@ function clientCertParams(): positron.DataConnectionParameter[] {
 function connectionStringParam(): positron.DataConnectionParameter {
 	return {
 		// Secret: a connection string typically embeds a password, so it must go to secret storage
-		// rather than plain settings. This also masks the field in the dialog.
+		// rather than plain settings.
 		id: 'connectionString',
 		label: vscode.l10n.t('Connection String'),
 		description: vscode.l10n.t('The connection string (URL) from your database provider.'),
 		type: positron.DataConnectionParameterType.String,
 		secret: true,
+		// Render in plaintext so the user can read back the string they paste. It still goes to
+		// secret storage because it typically embeds a password.
+		masked: false,
 		required: true,
 		placeholder: 'postgresql://user:password@host:5432/database',
 	};
@@ -367,6 +370,39 @@ function parseConnectionString(connectionString: string): PostgresConnectionFiel
 		sslcert: url.searchParams.get('sslcert') ?? undefined,
 		sslkey: url.searchParams.get('sslkey') ?? undefined,
 	};
+}
+
+/** The mask substituted for a password when redacting a connection string for display. */
+const REDACTED_PASSWORD = '****';
+
+/**
+ * Produces a display-safe form of a connection string by masking the embedded password, used as the
+ * field placeholder when editing an existing connection-string connection. Handles the URL form
+ * (postgresql://user:password@host/db) by parsing and re-serializing with the password masked, and
+ * the key=value DSN form (password=secret) by masking the password value in place. Returns the input
+ * unchanged when no password is present.
+ */
+function redactConnectionString(connectionString: string): string {
+	// URL form: mask the password component, then re-serialize. Re-encoding is acceptable here since
+	// the result is only ever shown as a read-only placeholder, never used to connect.
+	try {
+		const url = new URL(connectionString);
+		if (url.protocol === 'postgresql:' || url.protocol === 'postgres:') {
+			if (!url.password) {
+				return connectionString;
+			}
+			url.password = REDACTED_PASSWORD;
+			return url.toString();
+		}
+	} catch {
+		// Not a URL; fall through to DSN handling.
+	}
+
+	// key=value DSN form: mask the value of any password / pgpassword key, preserving the rest.
+	return connectionString.replace(
+		/\b(password|pgpassword)(\s*=\s*)('[^']*'|"[^"]*"|\S+)/gi,
+		`$1$2${REDACTED_PASSWORD}`
+	);
 }
 
 // --- Connect-time validators ---
@@ -594,6 +630,14 @@ export function createPostgreSQLDriver(
 				default:
 					return [];
 			}
+		},
+		redactParameterValue(mechanismId: string, parameterId: string, value: string): string | undefined {
+			// The connection string is the only parameter shown in plaintext while embedding a
+			// secret, so it is the only one with a meaningful redacted preview.
+			if (mechanismId === CONNECTION_STRING_MECHANISM_ID && parameterId === 'connectionString') {
+				return redactConnectionString(value);
+			}
+			return undefined;
 		},
 	};
 }

--- a/extensions/positron-data-driver-postgresql/src/test/dataConnectionIntegration.test.ts
+++ b/extensions/positron-data-driver-postgresql/src/test/dataConnectionIntegration.test.ts
@@ -92,7 +92,7 @@ suite('PostgreSQL Data Connection Integration', () => {
 
 	// Helper: connect to the test database via the Positron driver.
 	async function connectDriver(): Promise<positron.DataConnection> {
-		return positron.dataConnections.connect('positron-data-driver-postgresql', {
+		return positron.dataConnections.connect('positron-data-driver-postgresql', 'password', {
 			host: pgHost,
 			port: pgPort,
 			database: pgDatabase,
@@ -170,41 +170,46 @@ suite('PostgreSQL Data Connection Integration', () => {
 			assert.strictEqual(pg.name, 'PostgreSQL');
 		});
 
-		test('PostgreSQL driver has expected parameters', async () => {
+		test('PostgreSQL driver has expected mechanisms and parameters', async () => {
 			// Get the drivers and find the PostgreSQL driver.
 			const drivers = await positron.dataConnections.getDrivers();
 			const pg = drivers.find(d => d.id === 'positron-data-driver-postgresql')!;
 
+			// Test the single 'password' mechanism.
+			assert.strictEqual(pg.mechanisms.length, 1);
+			const mechanism = pg.mechanisms.find(m => m.id === 'password')!;
+			assert.ok(mechanism);
+
 			// Test the parameters length.
-			assert.strictEqual(pg.parameters.length, 6);
+			assert.strictEqual(mechanism.parameters.length, 6);
 
 			// Check the host parameter.
-			const hostParam = pg.parameters.find(p => p.id === 'host');
+			const hostParam = mechanism.parameters.find(p => p.id === 'host');
 			assert.ok(hostParam);
 			assert.strictEqual(hostParam.type, 'string');
 
 			// Check the port parameter.
-			const portParam = pg.parameters.find(p => p.id === 'port');
+			const portParam = mechanism.parameters.find(p => p.id === 'port');
 			assert.ok(portParam);
 			assert.strictEqual(portParam.type, 'number');
 
 			// Check the database parameter.
-			const dbParam = pg.parameters.find(p => p.id === 'database');
+			const dbParam = mechanism.parameters.find(p => p.id === 'database');
 			assert.ok(dbParam);
 			assert.strictEqual(dbParam.type, 'string');
 
 			// Check the user parameter.
-			const userParam = pg.parameters.find(p => p.id === 'user');
+			const userParam = mechanism.parameters.find(p => p.id === 'user');
 			assert.ok(userParam);
 			assert.strictEqual(userParam.type, 'string');
 
 			// Check the password parameter.
-			const pwParam = pg.parameters.find(p => p.id === 'password');
+			const pwParam = mechanism.parameters.find(p => p.id === 'password');
 			assert.ok(pwParam);
-			assert.strictEqual(pwParam.type, 'string');
+			assert.strictEqual(pwParam.type, 'password');
 
 			// Check the SSL parameter.
-			const sslParam = pg.parameters.find(p => p.id === 'ssl');
+			const sslParam = mechanism.parameters.find(p => p.id === 'ssl');
 			assert.ok(sslParam);
 			assert.strictEqual(sslParam.type, 'boolean');
 		});

--- a/extensions/positron-data-driver-postgresql/src/test/dataConnectionIntegration.test.ts
+++ b/extensions/positron-data-driver-postgresql/src/test/dataConnectionIntegration.test.ts
@@ -175,8 +175,7 @@ suite('PostgreSQL Data Connection Integration', () => {
 			const drivers = await positron.dataConnections.getDrivers();
 			const pg = drivers.find(d => d.id === 'positron-data-driver-postgresql')!;
 
-			// Test the single 'password' mechanism.
-			assert.strictEqual(pg.mechanisms.length, 1);
+			// Test the 'password' mechanism.
 			const mechanism = pg.mechanisms.find(m => m.id === 'password')!;
 			assert.ok(mechanism);
 
@@ -212,6 +211,16 @@ suite('PostgreSQL Data Connection Integration', () => {
 			const sslParam = mechanism.parameters.find(p => p.id === 'ssl');
 			assert.ok(sslParam);
 			assert.strictEqual(sslParam.type, 'boolean');
+
+			// The peer mechanism is offered only on Unix (it uses a local socket); Windows has no
+			// equivalent.
+			const peerMechanism = pg.mechanisms.find(m => m.id === 'peer');
+			if (process.platform === 'win32') {
+				assert.strictEqual(peerMechanism, undefined);
+			} else {
+				assert.ok(peerMechanism);
+				assert.deepStrictEqual(peerMechanism.parameters.map(p => p.id), ['database', 'user', 'socketDirectory']);
+			}
 		});
 	});
 

--- a/extensions/positron-data-driver-postgresql/src/test/dataConnectionIntegration.test.ts
+++ b/extensions/positron-data-driver-postgresql/src/test/dataConnectionIntegration.test.ts
@@ -212,15 +212,28 @@ suite('PostgreSQL Data Connection Integration', () => {
 			assert.ok(sslParam);
 			assert.strictEqual(sslParam.type, 'boolean');
 
-			// The peer mechanism is offered only on Unix (it uses a local socket); Windows has no
-			// equivalent.
-			const peerMechanism = pg.mechanisms.find(m => m.id === 'peer');
+			// The local-server mechanism is offered only on Unix (it uses a local socket); Windows has
+			// no equivalent.
+			const localServerMechanism = pg.mechanisms.find(m => m.id === 'localServer');
 			if (process.platform === 'win32') {
-				assert.strictEqual(peerMechanism, undefined);
+				assert.strictEqual(localServerMechanism, undefined);
 			} else {
-				assert.ok(peerMechanism);
-				assert.deepStrictEqual(peerMechanism.parameters.map(p => p.id), ['database', 'user', 'socketDirectory']);
+				assert.ok(localServerMechanism);
+				assert.deepStrictEqual(localServerMechanism.parameters.map(p => p.id), ['database', 'user', 'socketDirectory']);
 			}
+
+			// The connection-string mechanism takes a single secret parameter and is offered on all
+			// platforms.
+			const connectionStringMechanism = pg.mechanisms.find(m => m.id === 'connectionString');
+			assert.ok(connectionStringMechanism);
+			assert.deepStrictEqual(connectionStringMechanism.parameters.map(p => p.id), ['connectionString']);
+			const csParam = connectionStringMechanism.parameters[0];
+			assert.ok(csParam.type === 'string' && csParam.secret === true);
+
+			// The client-certificate mechanism is offered on all platforms (it runs over TCP/TLS).
+			const certMechanism = pg.mechanisms.find(m => m.id === 'clientCert');
+			assert.ok(certMechanism);
+			assert.deepStrictEqual(certMechanism.parameters.map(p => p.id), ['host', 'port', 'database', 'user', 'sslrootcert', 'sslcert', 'sslkey']);
 		});
 	});
 

--- a/extensions/positron-data-driver-postgresql/src/test/postgresqlDriver.test.ts
+++ b/extensions/positron-data-driver-postgresql/src/test/postgresqlDriver.test.ts
@@ -10,6 +10,7 @@ import { createSchemaNode } from '../postgresqlNodes.js';
 
 // Default config for tests -- not used to connect, just to construct.
 const TEST_CONFIG: PostgreSQLConnectionConfig = {
+	kind: 'fields',
 	host: 'localhost',
 	port: 5432,
 	database: 'testdb',

--- a/extensions/positron-data-driver-sqlite/src/sqliteDriver.ts
+++ b/extensions/positron-data-driver-sqlite/src/sqliteDriver.ts
@@ -3,7 +3,8 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import * as positron from 'positron';
 import * as vscode from 'vscode';
@@ -18,6 +19,26 @@ function isNonEmptyString(value: unknown): value is string {
 }
 
 /**
+ * Resolves a user-entered database path to an absolute path.
+ */
+function resolveDatabasePath(filePath: string): string {
+	// A leading `~/` is the home directory. `~` is a Unix shell convention with no native meaning on
+	// Windows, so this only applies on macOS and Linux. The result is absolute, so return it directly.
+	if (process.platform !== 'win32' && filePath.startsWith('~/')) {
+		return path.join(os.homedir(), filePath.slice(2));
+	}
+
+	// Absolute paths are used as-is.
+	if (path.isAbsolute(filePath)) {
+		return filePath;
+	}
+
+	// Resolve a relative path against the workspace folders.
+	const candidatePaths = (vscode.workspace.workspaceFolders ?? []).map(folder => path.join(folder.uri.fsPath, filePath));
+	return candidatePaths.find(candidate => existsSync(candidate)) ?? candidatePaths[0] ?? filePath;
+}
+
+/**
  * Escapes a value for embedding in a double-quoted Python or R string literal. Both languages
  * treat backslash as an escape character in double-quoted strings, so Windows paths such as
  * `C:\db.sqlite` must have their separators doubled.
@@ -25,6 +46,12 @@ function isNonEmptyString(value: unknown): value is string {
 function escapeDoubleQuoted(value: string): string {
 	return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
+
+/**
+ * The id of the file-based connection mechanism. Used both in the driver's mechanism list and in
+ * the connect switch, so the two stay in sync.
+ */
+const FILE_MECHANISM_ID = 'file';
 
 /**
  * Creates the SQLite DataConnectionDriver.
@@ -51,46 +78,65 @@ export function createSQLiteDriver(
 		description: vscode.l10n.t('Connect to a SQLite database file'),
 		iconSvg,
 		supportedLanguageIds: ['python', 'r'],
-		parameters: [
+		mechanisms: [
 			{
-				id: 'databasePath',
+				id: FILE_MECHANISM_ID,
 				label: vscode.l10n.t('Database File'),
-				type: positron.DataConnectionParameterType.File,
-				required: true,
-				placeholder: databasePathPlaceholder,
-			},
-			{
-				id: 'readOnly',
-				label: vscode.l10n.t('Read Only'),
-				type: positron.DataConnectionParameterType.Boolean,
-				defaultValue: false,
+				description: vscode.l10n.t('Connect to a SQLite database file on disk'),
+				parameters: [
+					{
+						id: 'databasePath',
+						label: vscode.l10n.t('Database File'),
+						type: positron.DataConnectionParameterType.File,
+						required: true,
+						placeholder: databasePathPlaceholder,
+					},
+					{
+						id: 'readOnly',
+						label: vscode.l10n.t('Read Only'),
+						type: positron.DataConnectionParameterType.Boolean,
+						defaultValue: false,
+					},
+				],
 			},
 		],
-		async connect(params: positron.DataConnectionParameterValues): Promise<positron.DataConnection> {
-			// Extract parameters.
-			const databasePath = params.databasePath;
-			const readOnly = params.readOnly as boolean ?? false;
+		async connect(mechanismId: string, params: positron.DataConnectionParameterValues): Promise<positron.DataConnection> {
+			// Connect to the database based on the mechanism. The driver is expected to throw on failure; let it propagate.
+			switch (mechanismId) {
+				case FILE_MECHANISM_ID: {
+					// Extract parameters.
+					const rawDatabasePath = params.databasePath;
+					const readOnly = params.readOnly as boolean ?? false;
 
-			// Validate parameters.
-			if (!isNonEmptyString(databasePath)) {
-				throw new Error(vscode.l10n.t('Database file path is required'));
+					// Validate parameters.
+					if (!isNonEmptyString(rawDatabasePath)) {
+						throw new Error(vscode.l10n.t('Database file path is required'));
+					}
+
+					// Resolve `~` and workspace-relative paths to an absolute path before opening the file.
+					const databasePath = resolveDatabasePath(rawDatabasePath);
+
+					// Create the connection and open the database in the worker process.
+					const connection = new SQLiteConnection(databasePath, readOnly, dataExplorerHandler);
+					await connection.connect();
+					return connection;
+				}
+				default:
+					throw new Error(vscode.l10n.t("Unknown connection mechanism '{0}'.", mechanismId));
 			}
-
-			// Create the connection and open the database in the worker process.
-			const connection = new SQLiteConnection(databasePath, readOnly, dataExplorerHandler);
-			await connection.connect();
-			return connection;
 		},
-		async generateConnectionCode(languageId: string, params: positron.DataConnectionParameterValues): Promise<positron.ConnectionCodeVariant[]> {
+		async generateConnectionCode(_mechanismId: string, languageId: string, params: positron.DataConnectionParameterValues): Promise<positron.ConnectionCodeVariant[]> {
 			// The database file path is required to generate valid connection code.
 			const databasePath = params.databasePath;
 			if (!isNonEmptyString(databasePath)) {
 				return [];
 			}
 
-			// Extract parameters.
+			// Extract parameters. Resolve `~` and workspace-relative paths so the generated code
+			// references a concrete, absolute path (Python and R do not expand `~`, and the console's
+			// working directory may differ from the workspace folder).
 			const readOnly = params.readOnly === true;
-			const escapedPath = escapeDoubleQuoted(databasePath);
+			const escapedPath = escapeDoubleQuoted(resolveDatabasePath(databasePath));
 
 			// Generate code variants for supported languages. Return an empty array for unsupported
 			// languages or when code cannot be generated.

--- a/extensions/positron-data-driver-sqlite/src/test/dataConnectionIntegration.test.ts
+++ b/extensions/positron-data-driver-sqlite/src/test/dataConnectionIntegration.test.ts
@@ -79,21 +79,26 @@ suite('Data Connection Integration', () => {
 			assert.strictEqual(sqlite.name, 'SQLite');
 		});
 
-		test('SQLite driver has expected parameters', async () => {
+		test('SQLite driver has expected mechanisms and parameters', async () => {
 			// Get the drivers and find the SQLite driver.
 			const drivers = await positron.dataConnections.getDrivers();
 			const sqlite = drivers.find(d => d.id === 'positron-data-driver-sqlite')!;
 
+			// Test the single 'file' mechanism.
+			assert.strictEqual(sqlite.mechanisms.length, 1);
+			const mechanism = sqlite.mechanisms.find(m => m.id === 'file')!;
+			assert.ok(mechanism);
+
 			// Test the parameters length.
-			assert.strictEqual(sqlite.parameters.length, 2);
+			assert.strictEqual(mechanism.parameters.length, 2);
 
 			// Check the path parameter.
-			const pathParam = sqlite.parameters.find(p => p.id === 'databasePath');
+			const pathParam = mechanism.parameters.find(p => p.id === 'databasePath');
 			assert.ok(pathParam);
 			assert.strictEqual(pathParam.type, 'file');
 
 			// Check the read only parameter.
-			const readOnlyParam = sqlite.parameters.find(p => p.id === 'readOnly');
+			const readOnlyParam = mechanism.parameters.find(p => p.id === 'readOnly');
 			assert.ok(readOnlyParam);
 			assert.strictEqual(readOnlyParam.type, 'boolean');
 		});
@@ -108,7 +113,7 @@ suite('Data Connection Integration', () => {
 			});
 
 			// Connect to the test DB.
-			const conn = await positron.dataConnections.connect('positron-data-driver-sqlite', {
+			const conn = await positron.dataConnections.connect('positron-data-driver-sqlite', 'file', {
 				databasePath: dbPath,
 				readOnly: false,
 			});
@@ -129,7 +134,7 @@ suite('Data Connection Integration', () => {
 			});
 
 			// Connect to the test DB.
-			const conn = await positron.dataConnections.connect('positron-data-driver-sqlite', {
+			const conn = await positron.dataConnections.connect('positron-data-driver-sqlite', 'file', {
 				databasePath: dbPath,
 				readOnly: true,
 			});
@@ -152,7 +157,7 @@ suite('Data Connection Integration', () => {
 			});
 
 			// Connect to the test DB.
-			const conn = await positron.dataConnections.connect('positron-data-driver-sqlite', {
+			const conn = await positron.dataConnections.connect('positron-data-driver-sqlite', 'file', {
 				databasePath: dbPath,
 				readOnly: false,
 			});
@@ -178,7 +183,7 @@ suite('Data Connection Integration', () => {
 			});
 
 			// Connect to the test DB.
-			const conn = await positron.dataConnections.connect('positron-data-driver-sqlite', {
+			const conn = await positron.dataConnections.connect('positron-data-driver-sqlite', 'file', {
 				databasePath: dbPath,
 				readOnly: true,
 			});
@@ -217,7 +222,7 @@ suite('Data Connection Integration', () => {
 			});
 
 			// Connect to the test DB.
-			const conn = await positron.dataConnections.connect('positron-data-driver-sqlite', {
+			const conn = await positron.dataConnections.connect('positron-data-driver-sqlite', 'file', {
 				databasePath: dbPath,
 				readOnly: false,
 			});
@@ -243,7 +248,7 @@ suite('Data Connection Integration', () => {
 			const dbPath = createTestDb('empty.db');
 
 			// Connect to the test DB.
-			const conn = await positron.dataConnections.connect('positron-data-driver-sqlite', {
+			const conn = await positron.dataConnections.connect('positron-data-driver-sqlite', 'file', {
 				databasePath: dbPath,
 				readOnly: false,
 			});
@@ -267,7 +272,7 @@ suite('Data Connection Integration', () => {
 			});
 
 			// Connect to the test DB.
-			const conn = await positron.dataConnections.connect('positron-data-driver-sqlite', {
+			const conn = await positron.dataConnections.connect('positron-data-driver-sqlite', 'file', {
 				databasePath: dbPath,
 				readOnly: false,
 			});
@@ -289,7 +294,7 @@ suite('Data Connection Integration', () => {
 			});
 
 			// Connect to the test DB.
-			const conn = await positron.dataConnections.connect('positron-data-driver-sqlite', {
+			const conn = await positron.dataConnections.connect('positron-data-driver-sqlite', 'file', {
 				databasePath: dbPath,
 				readOnly: true,
 			});
@@ -311,7 +316,7 @@ suite('Data Connection Integration', () => {
 			});
 
 			// Connect to the test DB.
-			const conn = await positron.dataConnections.connect('positron-data-driver-sqlite', {
+			const conn = await positron.dataConnections.connect('positron-data-driver-sqlite', 'file', {
 				databasePath: dbPath,
 				readOnly: false,
 			});
@@ -341,7 +346,7 @@ suite('Data Connection Integration', () => {
 			// 3. Connect through the full stack:
 			//    ext host -> main thread service -> main thread adapter
 			//    -> RPC -> ext host $driverConnect -> SQLiteConnection -> worker process
-			const conn = await positron.dataConnections.connect('positron-data-driver-sqlite', {
+			const conn = await positron.dataConnections.connect('positron-data-driver-sqlite', 'file', {
 				databasePath: dbPath,
 				readOnly: false,
 			});

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1911,6 +1911,34 @@ declare module 'positron' {
 	export type DataConnectionParameterValues = Record<string, string | number | boolean>;
 
 	/**
+	 * A configuration mechanism for a data connection driver. A driver exposes one or more
+	 * mechanisms, each describing a distinct way to configure a connection (for example, a
+	 * PostgreSQL driver may offer separate mechanisms for username/password and certificate-based
+	 * authentication). Each mechanism carries its own set of parameters.
+	 */
+	export interface DataConnectionMechanism {
+		/**
+		 * A stable identifier for the mechanism, unique within the driver.
+		 */
+		id: string;
+
+		/**
+		 * A short user-facing label for the mechanism (e.g. 'Username & Password').
+		 */
+		label: string;
+
+		/**
+		 * A user-facing description of the mechanism, shown as supporting text.
+		 */
+		description: string;
+
+		/**
+		 * The parameters required to configure a connection using this mechanism.
+		 */
+		parameters: DataConnectionParameter[];
+	}
+
+	/**
 	 * A driver that provides data connections through the 'New Database' dialog.
 	 */
 	/**
@@ -1958,9 +1986,11 @@ declare module 'positron' {
 		iconSvg: string;
 
 		/**
-		 * The driver parameters.
+		 * The configuration mechanisms this driver supports. Each mechanism describes a distinct
+		 * way to configure a connection and carries its own set of parameters. A driver must expose
+		 * at least one mechanism.
 		 */
-		parameters: DataConnectionParameter[];
+		mechanisms: DataConnectionMechanism[];
 
 		/**
 		 * The language identifiers this driver supports.
@@ -1968,23 +1998,30 @@ declare module 'positron' {
 		supportedLanguageIds: string[];
 
 		/**
-		 * Connects using the provided parameter values.
+		 * Connects using the selected mechanism and the provided parameter values.
+		 *
+		 * @param mechanismId The id of the mechanism the user selected. One of this driver's
+		 *   `mechanisms`.
+		 * @param parameters The current values of the parameters defined by the selected mechanism.
 		 */
-		connect(parameters: DataConnectionParameterValues): Thenable<DataConnection>;
+		connect(mechanismId: string, parameters: DataConnectionParameterValues): Thenable<DataConnection>;
 
 		/**
 		 * Generates one or more named code variants that connect to this data source in the given
-		 * language, using the provided parameter values. The language is one of the driver's
-		 * `supportedLanguageIds`; drivers that report no supported languages need not implement this
-		 * method. Variants are returned in preference order, so the first is treated as the default.
+		 * language, using the selected mechanism and the provided parameter values. The language is
+		 * one of the driver's `supportedLanguageIds`; drivers that report no supported languages need
+		 * not implement this method. Variants are returned in preference order, so the first is
+		 * treated as the default.
 		 *
+		 * @param mechanismId The id of the mechanism the user selected. One of this driver's
+		 *   `mechanisms`.
 		 * @param languageId The language to generate code for (e.g. 'python', 'r'). Always one of
 		 *   the driver's `supportedLanguageIds`.
-		 * @param parameters The current values of the connection parameters defined in `parameters`.
+		 * @param parameters The current values of the parameters defined by the selected mechanism.
 		 * @returns The available code variants, or an empty array if code cannot be generated from
 		 *   the given parameters (for example, when a required parameter is missing).
 		 */
-		generateConnectionCode?(languageId: string, parameters: DataConnectionParameterValues): Thenable<ConnectionCodeVariant[]>;
+		generateConnectionCode?(mechanismId: string, languageId: string, parameters: DataConnectionParameterValues): Thenable<ConnectionCodeVariant[]>;
 	}
 
 	/**
@@ -2076,8 +2113,8 @@ declare module 'positron' {
 		// The driver description.
 		description: string;
 
-		// The driver parameters.
-		parameters: DataConnectionParameter[];
+		// The configuration mechanisms this driver supports.
+		mechanisms: DataConnectionMechanism[];
 
 		// The language identifiers this driver supports.
 		supportedLanguageIds: string[];
@@ -2944,15 +2981,16 @@ declare module 'positron' {
 		export function getDrivers(): Thenable<DataConnectionDriverSummary[]>;
 
 		/**
-		 * Connects to a data connection driver with the given parameters.
+		 * Connects to a data connection driver using the selected mechanism and the given parameters.
 		 * The connection goes through the main thread service and exercises
 		 * the full RPC pipeline.
 		 *
 		 * @param driverId The driver identifier.
+		 * @param mechanismId The id of the mechanism to connect with. One of the driver's mechanisms.
 		 * @param parameters The connection parameters.
 		 * @returns A data connection.
 		 */
-		export function connect(driverId: string, parameters: DataConnectionParameterValues): Thenable<DataConnection>;
+		export function connect(driverId: string, mechanismId: string, parameters: DataConnectionParameterValues): Thenable<DataConnection>;
 	}
 
 	/**

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1909,6 +1909,14 @@ declare module 'positron' {
 			type: DataConnectionParameterType.String;
 			secret: true;
 			placeholder?: string;
+
+			/**
+			 * Whether the input is masked (rendered like a password field). Defaults to `true` for
+			 * secret strings. Set to `false` to render the value in plaintext while still storing it
+			 * in secret storage -- useful for values the user should be able to read back as they
+			 * type, such as a connection string.
+			 */
+			masked?: boolean;
 		}
 	);
 
@@ -2029,6 +2037,21 @@ declare module 'positron' {
 		 *   the given parameters (for example, when a required parameter is missing).
 		 */
 		generateConnectionCode?(mechanismId: string, languageId: string, parameters: DataConnectionParameterValues): Thenable<ConnectionCodeVariant[]>;
+
+		/**
+		 * Produces a display-safe, redacted form of a stored secret parameter value, shown in the
+		 * configuration dialog when editing an existing connection (for example, masking the password
+		 * embedded in a connection string). Only called for secret parameters that render in plaintext
+		 * (`masked: false`); the redacted string is used as the field's placeholder. The cleartext
+		 * value never leaves the extension host -- only the returned string is sent to the dialog.
+		 *
+		 * @param mechanismId The id of the mechanism the connection was configured with. One of this
+		 *   driver's `mechanisms`.
+		 * @param parameterId The id of the parameter to redact.
+		 * @param value The stored cleartext parameter value.
+		 * @returns The redacted string to display, or undefined to show no placeholder.
+		 */
+		redactParameterValue?(mechanismId: string, parameterId: string, value: string): ProviderResult<string>;
 	}
 
 	/**

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1854,6 +1854,13 @@ declare module 'positron' {
 		label: string;
 
 		/**
+		 * An optional, longer help text shown beneath the field to explain the parameter's purpose or
+		 * its behavior when left blank (e.g. "Defaults to your operating system account if empty").
+		 * Distinct from `placeholder`, which shows an example of the expected value.
+		 */
+		description?: string;
+
+		/**
 		 * Whether this parameter is required.
 		 */
 		required?: boolean;
@@ -1913,7 +1920,7 @@ declare module 'positron' {
 	/**
 	 * A configuration mechanism for a data connection driver. A driver exposes one or more
 	 * mechanisms, each describing a distinct way to configure a connection (for example, a
-	 * PostgreSQL driver may offer separate mechanisms for username/password and certificate-based
+	 * PostgreSQL driver may offer separate mechanisms for user/password and certificate-based
 	 * authentication). Each mechanism carries its own set of parameters.
 	 */
 	export interface DataConnectionMechanism {

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2051,7 +2051,7 @@ declare module 'positron' {
 		 * @param value The stored cleartext parameter value.
 		 * @returns The redacted string to display, or undefined to show no placeholder.
 		 */
-		redactParameterValue?(mechanismId: string, parameterId: string, value: string): ProviderResult<string>;
+		redactParameterValue?(mechanismId: string, parameterId: string, value: string): vscode.ProviderResult<string>;
 	}
 
 	/**

--- a/src/vs/workbench/api/browser/positron/mainThreadDataConnections.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadDataConnections.ts
@@ -15,7 +15,7 @@ import { ExtHostDataConnectionsShape, ExtHostPositronContext, MainPositronContex
  * IDataConnectionParameter discriminated union, picking up only the fields each variant carries.
  */
 function dtoToServiceParameter(dto: IDataConnectionParameterDTO): IDataConnectionParameter {
-	const base = { id: dto.id, label: dto.label, required: dto.required };
+	const base = { id: dto.id, label: dto.label, description: dto.description, required: dto.required };
 	switch (dto.type) {
 		case 'boolean':
 			return { ...base, type: 'boolean', defaultValue: dto.defaultValue as boolean | undefined };

--- a/src/vs/workbench/api/browser/positron/mainThreadDataConnections.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadDataConnections.ts
@@ -29,7 +29,7 @@ function dtoToServiceParameter(dto: IDataConnectionParameterDTO): IDataConnectio
 			return { ...base, type: 'password', secret: true, placeholder: dto.placeholder };
 		case 'string':
 			if (dto.secret) {
-				return { ...base, type: 'string', secret: true, placeholder: dto.placeholder };
+				return { ...base, type: 'string', secret: true, masked: dto.masked, placeholder: dto.placeholder };
 			}
 			return { ...base, type: 'string', secret: false, defaultValue: dto.defaultValue as string | undefined, placeholder: dto.placeholder };
 		default:
@@ -255,6 +255,17 @@ class MainThreadDataConnectionDriverAdapter implements IDataConnectionDriver {
 	async generateConnectionCode(mechanismId: string, languageId: string, params: DataConnectionParameterValues): Promise<IDataConnectionCodeVariant[]> {
 		const variants = await this._proxy.$generateConnectionCode(this.id, mechanismId, languageId, params);
 		return variants.map(variant => ({ id: variant.id, label: variant.label, code: variant.code }));
+	}
+
+	/**
+	 * Asks the ext host to run driver.redactParameterValue() via RPC, returning a display-safe form of
+	 * the stored secret value. Resolves to undefined when the driver does not implement redaction.
+	 * @param mechanismId The id of the mechanism the connection was configured with.
+	 * @param parameterId The id of the parameter to redact.
+	 * @param value The stored cleartext parameter value.
+	 */
+	async redactParameterValue(mechanismId: string, parameterId: string, value: string): Promise<string | undefined> {
+		return this._proxy.$redactParameterValue(this.id, mechanismId, parameterId, value);
 	}
 }
 

--- a/src/vs/workbench/api/browser/positron/mainThreadDataConnections.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadDataConnections.ts
@@ -6,8 +6,8 @@
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { extHostNamedCustomer, IExtHostContext } from '../../../services/extensions/common/extHostCustomers.js';
 import { IPositronDataConnectionsService } from '../../../services/positronDataConnections/common/interfaces/positronDataConnectionsService.js';
-import { DataConnectionParameterValues, IDataConnectionCodeVariant, IDataConnectionDriver, IDataConnectionDriverMetadata, IDataConnectionHandle, IDataConnectionParameter } from '../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
-import { IDataConnectionDriverMetadataDTO, IDataConnectionDriverSummaryDTO, IDataConnectionNodeDTO, IDataConnectionParameterDTO } from '../../../services/positronDataConnections/common/interfaces/dataConnectionDTOs.js';
+import { DataConnectionParameterValues, IDataConnectionCodeVariant, IDataConnectionDriver, IDataConnectionDriverMetadata, IDataConnectionHandle, IDataConnectionMechanism, IDataConnectionParameter } from '../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
+import { IDataConnectionDriverMetadataDTO, IDataConnectionDriverSummaryDTO, IDataConnectionMechanismDTO, IDataConnectionNodeDTO, IDataConnectionParameterDTO } from '../../../services/positronDataConnections/common/interfaces/dataConnectionDTOs.js';
 import { ExtHostDataConnectionsShape, ExtHostPositronContext, MainPositronContext, MainThreadDataConnectionsShape } from '../../common/positron/extHost.positron.protocol.js';
 
 /**
@@ -38,6 +38,18 @@ function dtoToServiceParameter(dto: IDataConnectionParameterDTO): IDataConnectio
 }
 
 /**
+ * Converts a wire-format mechanism DTO to the service-level shape, narrowing each of its parameters.
+ */
+function dtoToServiceMechanism(dto: IDataConnectionMechanismDTO): IDataConnectionMechanism {
+	return {
+		id: dto.id,
+		label: dto.label,
+		description: dto.description,
+		parameters: dto.parameters.map(dtoToServiceParameter),
+	};
+}
+
+/**
  * Converts a wire-format driver metadata DTO to the service-level shape.
  */
 function dtoToServiceMetadata(dto: IDataConnectionDriverMetadataDTO): IDataConnectionDriverMetadata {
@@ -46,7 +58,7 @@ function dtoToServiceMetadata(dto: IDataConnectionDriverMetadataDTO): IDataConne
 		name: dto.name,
 		description: dto.description,
 		iconSvg: dto.iconSvg,
-		parameters: dto.parameters.map(dtoToServiceParameter),
+		mechanisms: dto.mechanisms.map(dtoToServiceMechanism),
 		supportedLanguageIds: dto.supportedLanguageIds,
 	};
 }
@@ -113,7 +125,7 @@ export class MainThreadDataConnections implements MainThreadDataConnectionsShape
 			id: driver.id,
 			name: driver.metadata.name,
 			description: driver.metadata.description,
-			parameters: driver.metadata.parameters,
+			mechanisms: driver.metadata.mechanisms,
 			supportedLanguageIds: driver.metadata.supportedLanguageIds,
 		}));
 	}
@@ -124,13 +136,13 @@ export class MainThreadDataConnections implements MainThreadDataConnectionsShape
 	 * back into the ext host via $driverConnect, exercising the full RPC
 	 * round trip.
 	 */
-	async $connectToDataConnectionDriver(driverId: string, params: DataConnectionParameterValues): Promise<number> {
+	async $connectToDataConnectionDriver(driverId: string, mechanismId: string, params: DataConnectionParameterValues): Promise<number> {
 		const drivers = this._dataConnectionsService.driverManager.getDrivers();
 		const driver = drivers.find(d => d.id === driverId);
 		if (!driver) {
 			throw new Error(`Data connection driver '${driverId}' not found`);
 		}
-		const handle = await driver.connect(params);
+		const handle = await driver.connect(mechanismId, params);
 		this._connectionHandles.set(handle.handle, handle);
 		return handle.handle;
 	}
@@ -222,11 +234,12 @@ class MainThreadDataConnectionDriverAdapter implements IDataConnectionDriver {
 	/**
 	 * Calls the extension's driver.connect() via RPC and wraps the returned
 	 * connection handle in an adapter the service can operate on.
+	 * @param mechanismId The id of the mechanism the user selected.
 	 * @param params User-supplied parameter values from the connection dialog.
 	 */
-	async connect(params: DataConnectionParameterValues): Promise<IDataConnectionHandle> {
+	async connect(mechanismId: string, params: DataConnectionParameterValues): Promise<IDataConnectionHandle> {
 		// Ask the ext host to call driver.connect(); returns an integer handle.
-		const connectionHandle = await this._proxy.$driverConnect(this.id, params);
+		const connectionHandle = await this._proxy.$driverConnect(this.id, mechanismId, params);
 
 		// Wrap the handle so the service can call getChildren/disconnect/etc.
 		return new MainThreadDataConnectionHandleAdapter(connectionHandle, this._proxy);
@@ -235,11 +248,12 @@ class MainThreadDataConnectionDriverAdapter implements IDataConnectionDriver {
 	/**
 	 * Asks the ext host to run driver.generateConnectionCode() via RPC, returning the available
 	 * code variants. An empty array means code could not be generated from the given parameters.
+	 * @param mechanismId The id of the mechanism the user selected.
 	 * @param languageId One of the driver's supported language ids.
 	 * @param params User-supplied parameter values from the connection dialog.
 	 */
-	async generateConnectionCode(languageId: string, params: DataConnectionParameterValues): Promise<IDataConnectionCodeVariant[]> {
-		const variants = await this._proxy.$generateConnectionCode(this.id, languageId, params);
+	async generateConnectionCode(mechanismId: string, languageId: string, params: DataConnectionParameterValues): Promise<IDataConnectionCodeVariant[]> {
+		const variants = await this._proxy.$generateConnectionCode(this.id, mechanismId, languageId, params);
 		return variants.map(variant => ({ id: variant.id, label: variant.label, code: variant.code }));
 	}
 }

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -326,13 +326,14 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			},
 
 			/**
-			 * Connects to a data connection driver with the given parameters.
+			 * Connects to a data connection driver using the selected mechanism and the given parameters.
 			 * @param driverId The driver identifier.
+			 * @param mechanismId The id of the mechanism to connect with. One of the driver's mechanisms.
 			 * @param parameters The parameter values for the connection.
 			 * @returns A DataConnection that can be used to browse and interact with the data source.
 			 */
-			connect(driverId: string, parameters: positron.DataConnectionParameterValues): Thenable<positron.DataConnection> {
-				return extHostDataConnections.connect(driverId, parameters);
+			connect(driverId: string, mechanismId: string, parameters: positron.DataConnectionParameterValues): Thenable<positron.DataConnection> {
+				return extHostDataConnections.connect(driverId, mechanismId, parameters);
 			},
 		};
 

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -264,6 +264,7 @@ export interface MainThreadDataConnectionsShape extends IDisposable {
 export interface ExtHostDataConnectionsShape {
 	$driverConnect(driverId: string, mechanismId: string, params: DataConnectionParameterValuesDTO): Promise<number>;
 	$generateConnectionCode(driverId: string, mechanismId: string, languageId: string, params: DataConnectionParameterValuesDTO): Promise<IDataConnectionCodeVariantDTO[]>;
+	$redactParameterValue(driverId: string, mechanismId: string, parameterId: string, value: string): Promise<string | undefined>;
 	$connectionIsReadOnly(connectionHandle: number): Promise<boolean>;
 	$connectionGetChildren(connectionHandle: number): Promise<IDataConnectionNodeDTO[]>;
 	$connectionDisconnect(connectionHandle: number): Promise<void>;

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -218,7 +218,7 @@ export interface MainThreadDataConnectionsShape extends IDisposable {
 	 * adapter calls back into the ext host via $driverConnect, so the full
 	 * RPC round trip is exercised.
 	 */
-	$connectToDataConnectionDriver(driverId: string, params: DataConnectionParameterValuesDTO): Promise<number>;
+	$connectToDataConnectionDriver(driverId: string, mechanismId: string, params: DataConnectionParameterValuesDTO): Promise<number>;
 
 	/**
 	 * Checks whether a connection is read-only via the main thread service.
@@ -262,8 +262,8 @@ export interface MainThreadDataConnectionsShape extends IDisposable {
  * lifecycle of connections that live in the extension process.
  */
 export interface ExtHostDataConnectionsShape {
-	$driverConnect(driverId: string, params: DataConnectionParameterValuesDTO): Promise<number>;
-	$generateConnectionCode(driverId: string, languageId: string, params: DataConnectionParameterValuesDTO): Promise<IDataConnectionCodeVariantDTO[]>;
+	$driverConnect(driverId: string, mechanismId: string, params: DataConnectionParameterValuesDTO): Promise<number>;
+	$generateConnectionCode(driverId: string, mechanismId: string, languageId: string, params: DataConnectionParameterValuesDTO): Promise<IDataConnectionCodeVariantDTO[]>;
 	$connectionIsReadOnly(connectionHandle: number): Promise<boolean>;
 	$connectionGetChildren(connectionHandle: number): Promise<IDataConnectionNodeDTO[]>;
 	$connectionDisconnect(connectionHandle: number): Promise<void>;

--- a/src/vs/workbench/api/common/positron/extHostDataConnections.ts
+++ b/src/vs/workbench/api/common/positron/extHostDataConnections.ts
@@ -179,6 +179,24 @@ export class ExtHostDataConnections implements extHostProtocol.ExtHostDataConnec
 	}
 
 	/**
+	 * Calls the extension's driver.redactParameterValue() to produce a display-safe form of a stored
+	 * secret value. The cleartext value stays in the ext host; only the redacted result is returned to
+	 * the main thread. Returns undefined when the driver does not implement redaction.
+	 * @param driverId The unique identifier of the driver.
+	 * @param mechanismId The id of the mechanism the connection was configured with.
+	 * @param parameterId The id of the parameter to redact.
+	 * @param value The stored cleartext parameter value.
+	 */
+	async $redactParameterValue(driverId: string, mechanismId: string, parameterId: string, value: string): Promise<string | undefined> {
+		const driver = this._drivers.get(driverId);
+		if (!driver || !driver.redactParameterValue) {
+			return undefined;
+		}
+
+		return (await driver.redactParameterValue(mechanismId, parameterId, value)) ?? undefined;
+	}
+
+	/**
 	 * Returns whether the connection was opened in read-only mode.
 	 */
 	async $connectionIsReadOnly(connectionHandle: number): Promise<boolean> {
@@ -311,6 +329,7 @@ export class ExtHostDataConnections implements extHostProtocol.ExtHostDataConnec
 				dto.placeholder = p.placeholder;
 				if (p.secret) {
 					dto.secret = true;
+					dto.masked = p.masked;
 				} else {
 					dto.defaultValue = p.defaultValue;
 				}

--- a/src/vs/workbench/api/common/positron/extHostDataConnections.ts
+++ b/src/vs/workbench/api/common/positron/extHostDataConnections.ts
@@ -302,6 +302,7 @@ export class ExtHostDataConnections implements extHostProtocol.ExtHostDataConnec
 		const dto: IDataConnectionParameterDTO = {
 			id: p.id,
 			label: p.label,
+			description: p.description,
 			required: p.required,
 			type: p.type,
 		};

--- a/src/vs/workbench/api/common/positron/extHostDataConnections.ts
+++ b/src/vs/workbench/api/common/positron/extHostDataConnections.ts
@@ -74,7 +74,12 @@ export class ExtHostDataConnections implements extHostProtocol.ExtHostDataConnec
 			name: driver.name,
 			description: driver.description,
 			iconSvg: btoa(driver.iconSvg),
-			parameters: driver.parameters.map(p => this._convertParameter(p)),
+			mechanisms: driver.mechanisms.map(m => ({
+				id: m.id,
+				label: m.label,
+				description: m.description,
+				parameters: m.parameters.map(p => this._convertParameter(p)),
+			})),
 			supportedLanguageIds: driver.supportedLanguageIds,
 		};
 
@@ -106,7 +111,12 @@ export class ExtHostDataConnections implements extHostProtocol.ExtHostDataConnec
 			id: dto.id,
 			name: dto.name,
 			description: dto.description,
-			parameters: dto.parameters as positron.DataConnectionParameter[],
+			mechanisms: dto.mechanisms.map(m => ({
+				id: m.id,
+				label: m.label,
+				description: m.description,
+				parameters: m.parameters as positron.DataConnectionParameter[],
+			})),
 			supportedLanguageIds: dto.supportedLanguageIds,
 		}));
 	}
@@ -116,8 +126,8 @@ export class ExtHostDataConnections implements extHostProtocol.ExtHostDataConnec
 	 * ext host via $driverConnect (full round trip). Returns a DataConnection proxy that routes
 	 * all operations through the main thread.
 	 */
-	public async connect(driverId: string, params: positron.DataConnectionParameterValues): Promise<positron.DataConnection> {
-		const connectionHandle = await this._proxy.$connectToDataConnectionDriver(driverId, params);
+	public async connect(driverId: string, mechanismId: string, params: positron.DataConnectionParameterValues): Promise<positron.DataConnection> {
+		const connectionHandle = await this._proxy.$connectToDataConnectionDriver(driverId, mechanismId, params);
 		return new ExtHostDataConnectionProxy(connectionHandle, this._proxy);
 	}
 
@@ -127,15 +137,16 @@ export class ExtHostDataConnections implements extHostProtocol.ExtHostDataConnec
 	 * Calls the extension's driver.connect(), stores the resulting DataConnection, and returns a
 	 * handle the main thread can use to operate on it.
 	 * @param driverId The unique identifier of the driver to connect with.
+	 * @param mechanismId The id of the mechanism the user selected.
 	 * @param params User-supplied parameter values from the connection dialog.
 	 */
-	async $driverConnect(driverId: string, params: Record<string, string | number | boolean>): Promise<number> {
+	async $driverConnect(driverId: string, mechanismId: string, params: Record<string, string | number | boolean>): Promise<number> {
 		const driver = this._drivers.get(driverId);
 		if (!driver) {
 			throw new Error(`Data connection driver '${driverId}' not found`);
 		}
 
-		const connection = await driver.connect(params);
+		const connection = await driver.connect(mechanismId, params);
 		const handle = this._nextConnectionHandle++;
 		this._connections.set(handle, connection);
 		this._nodes.set(handle, new Map());
@@ -150,10 +161,11 @@ export class ExtHostDataConnections implements extHostProtocol.ExtHostDataConnec
 	 * Calls the extension's driver.generateConnectionCode() and maps its variants into DTOs for the
 	 * main thread.
 	 * @param driverId The unique identifier of the driver to generate code with.
+	 * @param mechanismId The id of the mechanism the user selected.
 	 * @param languageId One of the driver's supported language ids.
 	 * @param params User-supplied parameter values from the connection dialog.
 	 */
-	async $generateConnectionCode(driverId: string, languageId: string, params: Record<string, string | number | boolean>): Promise<IDataConnectionCodeVariantDTO[]> {
+	async $generateConnectionCode(driverId: string, mechanismId: string, languageId: string, params: Record<string, string | number | boolean>): Promise<IDataConnectionCodeVariantDTO[]> {
 		const driver = this._drivers.get(driverId);
 		if (!driver) {
 			throw new Error(`Data connection driver '${driverId}' not found`);
@@ -162,7 +174,7 @@ export class ExtHostDataConnections implements extHostProtocol.ExtHostDataConnec
 			throw new Error(`Data connection driver '${driverId}' does not support generating connection code`);
 		}
 
-		const variants = await driver.generateConnectionCode(languageId, params);
+		const variants = await driver.generateConnectionCode(mechanismId, languageId, params);
 		return variants.map(variant => ({ id: variant.id, label: variant.label, code: variant.code }));
 	}
 

--- a/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/components/threeButtonFooter.css
+++ b/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/components/threeButtonFooter.css
@@ -12,6 +12,13 @@
 	align-items: flex-start;
 }
 
+.positron-dynamic-modal-dialog-box .three-button-footer.top-border {
+	height: auto;
+	padding-top: 16px;
+	padding-bottom: 16px;
+	border-top: solid 1px var(--vscode-positronModalDialog-border);
+}
+
 .positron-dynamic-modal-dialog-box .three-button-footer .three-button-footer-right {
 	gap: 10px;
 	display: flex;

--- a/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/components/threeButtonFooter.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/components/threeButtonFooter.tsx
@@ -9,6 +9,7 @@ import './threeButtonFooter.css';
 // Other dependencies.
 import { FooterButton } from './footerButton.js';
 import * as platform from '../../../../../base/common/platform.js';
+import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
 
 /**
  * ThreeButtonFooterProps interface.
@@ -17,6 +18,7 @@ interface ThreeButtonFooterProps {
 	leftButtonTitle: string;
 	primaryButtonTitle: string;
 	secondaryButtonTitle: string;
+	topBorder?: boolean;
 	onLeftButton: () => void;
 	onPrimaryButton: () => void;
 	onSecondaryButton: () => void;
@@ -53,7 +55,7 @@ export const ThreeButtonFooter = (props: ThreeButtonFooterProps) => {
 
 	// Render.
 	return (
-		<div className='three-button-footer'>
+		<div className={positronClassNames('three-button-footer', { 'top-border': props.topBorder })}>
 			{leftButton}
 			<div className='three-button-footer-right'>
 				{/* On Windows, the primary button comes first; on macOS/Linux, the secondary button comes first. */}

--- a/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/components/titleBar.css
+++ b/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/components/titleBar.css
@@ -12,14 +12,63 @@
 	background: var(--vscode-positronModalDialog-titleBarBackground);
 }
 
+.positron-dynamic-modal-dialog-box .title-bar .title-bar-titles {
+	flex: 1 1 auto;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	gap: 2px;
+}
+
 .positron-dynamic-modal-dialog-box .title-bar .title-bar-title {
 	cursor: default;
 	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 	color: var(--vscode-positronModalDialog-titleBarForeground);
 }
 
+.positron-dynamic-modal-dialog-box .title-bar .title-bar-title-description {
+	cursor: default;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 13px;
+	color: var(--vscode-descriptionForeground);
+}
+
+.positron-dynamic-modal-dialog-box .title-bar .title-bar-close-button {
+	flex: 0 0 auto;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 22px;
+	height: 22px;
+	margin-left: 8px;
+	/*
+		Pull the icon back by the centering gap inside the 22px hover box so it sits the same 16px
+		from the right edge as the titles sit from the left edge (the title bar's 16px padding).
+	*/
+	margin-right: -3px;
+	border-radius: 5px;
+	color: var(--vscode-positronModalDialog-titleBarForeground);
+}
+
+.positron-dynamic-modal-dialog-box .title-bar .title-bar-close-button:hover {
+	background: var(--vscode-toolbar-hoverBackground);
+}
+
 .positron-dynamic-modal-dialog-box .title-bar.large {
-	flex-basis: 48px;
+	/*
+		Grow past the 48px single-line height when a title description adds a second line, keeping
+		symmetric vertical padding so two lines aren't crammed into the single-line space.
+	*/
+	flex: 0 0 auto;
+	min-height: 48px;
+	box-sizing: border-box;
+	padding-top: 10px;
+	padding-bottom: 10px;
 	background: var(--vscode-positronModalDialog-background);
 	border-bottom: solid 1px var(--vscode-positronModalDialog-border);
 }

--- a/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/components/titleBar.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/components/titleBar.tsx
@@ -11,18 +11,25 @@ import { MouseEvent } from 'react';
 
 // Other dependencies.
 import * as DOM from '../../../../../base/browser/dom.js';
+import { localize } from '../../../../../nls.js';
 import { useStateRef } from '../../../../../base/browser/ui/react/useStateRef.js';
 import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
+import { Button } from '../../../../../base/browser/ui/positronComponents/button/button.js';
 
 /**
  * TitleBarProps interface.
  */
 interface TitleBarProps {
 	title: string;
+	titleDescription?: string;
 	size?: 'normal' | 'large';
 	onStartDrag: () => void;
 	onDrag: (x: number, y: number) => void;
 	onStopDrag: (x: number, y: number) => void;
+
+	// When provided, a close (X) button is shown on the right of the title bar that invokes this
+	// handler. This is in addition to any cancel button the dialog renders in its footer.
+	onClose?: () => void;
 }
 
 /**
@@ -107,9 +114,25 @@ export const TitleBar = (props: TitleBarProps) => {
 		// Disable jsx-a11y/no-static-element-interactions.
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 		<div className={positronClassNames('title-bar', { 'large': props.size === 'large' })} onMouseDown={mouseDownHandler}>
-			<div className='title-bar-title'>
-				{props.title}
+			<div className='title-bar-titles'>
+				<div className='title-bar-title'>
+					{props.title}
+				</div>
+				{props.titleDescription &&
+					<div className='title-bar-title-description'>
+						{props.titleDescription}
+					</div>
+				}
 			</div>
+			{props.onClose &&
+				<Button
+					ariaLabel={localize('positron.dynamicModalDialog.close', "Close")}
+					className='title-bar-close-button'
+					onPressed={props.onClose}
+				>
+					<div className='codicon codicon-close' />
+				</Button>
+			}
 		</div>
 	);
 };

--- a/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/components/twoButtonFooter.css
+++ b/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/components/twoButtonFooter.css
@@ -12,3 +12,10 @@
 	justify-content: end;
 	align-items: flex-start;
 }
+
+.positron-dynamic-modal-dialog-box .two-button-footer.top-border {
+	height: auto;
+	padding-top: 16px;
+	padding-bottom: 16px;
+	border-top: solid 1px var(--vscode-positronModalDialog-border);
+}

--- a/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/components/twoButtonFooter.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/components/twoButtonFooter.tsx
@@ -9,6 +9,7 @@ import './twoButtonFooter.css';
 // Other dependencies.
 import { FooterButton } from './footerButton.js';
 import * as platform from '../../../../../base/common/platform.js';
+import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
 
 /**
  * TwoButtonFooterProps interface.
@@ -16,6 +17,7 @@ import * as platform from '../../../../../base/common/platform.js';
 interface TwoButtonFooterProps {
 	primaryButtonTitle: string;
 	secondaryButtonTitle: string;
+	topBorder?: boolean;
 	onPrimaryButton: () => void;
 	onSecondaryButton: () => void;
 }
@@ -42,7 +44,7 @@ export const TwoButtonFooter = (props: TwoButtonFooterProps) => {
 
 	// Render.
 	return (
-		<div className='two-button-footer'>
+		<div className={positronClassNames('two-button-footer', { 'top-border': props.topBorder })}>
 			{/* On Windows, the primary button comes first; on macOS/Linux, the secondary button comes first. */}
 			{platform.isWindows
 				? <>{primaryButton}{secondaryButton}</>

--- a/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.tsx
@@ -25,7 +25,8 @@ const kGutter = 40;
 export interface PositronDynamicModalDialogProps {
 	renderer: PositronModalDialogReactRenderer;
 	title: string;
-	titleBarSize?: 'normal' | 'large';
+	titleDescription?: string;
+	titleSize?: 'normal' | 'large';
 	width: number;
 	content: ReactNode;
 	contentMinHeight?: number;
@@ -229,7 +230,7 @@ export const PositronDynamicModalDialog = (props: PositronDynamicModalDialogProp
 				top: dialogBoxState.top,
 				width: props.width,
 			}}>
-				<TitleBar size={props.titleBarSize} title={props.title} onDrag={dragHandler} onStartDrag={startDragHandler} onStopDrag={stopDragHandler} />
+				<TitleBar size={props.titleSize} title={props.title} titleDescription={props.titleDescription} onClose={props.onCancel} onDrag={dragHandler} onStartDrag={startDragHandler} onStopDrag={stopDragHandler} />
 				{/*
 					The content area and footer are always wrapped in a <form>. Enter-key
 					implicit submission only activates when a submit target exists -- in this

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -1108,10 +1108,10 @@ export const POSITRON_MODAL_DIALOG_CONTRAST_BACKGROUND = registerColor('positron
 
 // Positron modal dialog border color.
 export const POSITRON_MODAL_DIALOG_BORDER = registerColor('positronModalDialog.border', {
-	dark: selectBorder,
-	light: selectBorder,
-	hcDark: selectBorder,
-	hcLight: selectBorder
+	dark: widgetBorder,
+	light: widgetBorder,
+	hcDark: widgetBorder,
+	hcLight: widgetBorder
 }, localize('positronModalDialog.border', "Positron modal dialog border color."));
 
 // Positron modal dialog separator color.

--- a/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionEntryRow.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionEntryRow.tsx
@@ -20,6 +20,7 @@ import { PYTHON_ICON_BASE64, R_ICON_BASE64 } from '../../../../services/positron
 import { CustomContextMenuItem } from '../../../../browser/positronComponents/customContextMenu/customContextMenuItem.js';
 import { CustomContextMenuSeparator } from '../../../../browser/positronComponents/customContextMenu/customContextMenuSeparator.js';
 import { CustomContextMenuEntry, showCustomContextMenu } from '../../../../browser/positronComponents/customContextMenu/customContextMenu.js';
+import { resolveDataConnectionMechanism } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
 
 /**
  * DataConnectionEntryRowProps interface.
@@ -74,11 +75,20 @@ export const DataConnectionEntryRow = ({ entry }: DataConnectionEntryRowProps) =
 			return;
 		}
 
+		// Resolve the mechanism the profile was configured with (falling back to the first for
+		// pre-mechanisms profiles); its parameters drive the form.
+		const mechanism = resolveDataConnectionMechanism(driver.metadata, profile.mechanismId);
+		if (!mechanism) {
+			reportDriverAccessError();
+			return;
+		}
+
 		// Render the ConfigureDataConnection dialog for this profile.
 		const renderer = new PositronModalDialogReactRenderer();
 		renderer.render(
 			<ConfigureDataConnection
 				driver={driver}
+				mechanism={mechanism}
 				profile={profile}
 				renderer={renderer}
 				onSave={updatedProfile => {
@@ -105,13 +115,17 @@ export const DataConnectionEntryRow = ({ entry }: DataConnectionEntryRowProps) =
 			return;
 		}
 
+		// Resolve the mechanism id (falling back to the first for pre-mechanisms profiles) once for
+		// all code generation calls below.
+		const mechanismId = resolveDataConnectionMechanism(driver.metadata, profile.mechanismId)?.id ?? profile.mechanismId;
+
 		// Generates the connection code variants for the given language and, if any are available,
 		// opens the Connect dialog to preview and run them.
 		const connectWith = async (languageId: string) => {
 			// The in-memory profile's parameterValues never contains secret values (those live in
 			// secret storage), so this is the default, secret-free preview. Secret values are only
 			// pulled in if the user explicitly opts in via the dialog's Include Secrets action.
-			const variants = await driver.generateConnectionCode(languageId, profile.parameterValues);
+			const variants = await driver.generateConnectionCode(mechanismId, languageId, profile.parameterValues);
 			if (variants.length === 0) {
 				notificationService.error(localize(
 					'positron.dataConnections.codeGenerationFailed',
@@ -125,6 +139,7 @@ export const DataConnectionEntryRow = ({ entry }: DataConnectionEntryRowProps) =
 				languageId,
 				connectionName: profile.connectionName,
 				driver,
+				mechanismId,
 				// Regenerates the code with secret values (e.g. passwords) pulled from secret storage.
 				// Invoked only after the user confirms the Include Secrets action in the dialog.
 				generateSecretVariants: async () => {
@@ -132,7 +147,7 @@ export const DataConnectionEntryRow = ({ entry }: DataConnectionEntryRowProps) =
 					if (!profileWithSecrets) {
 						return [];
 					}
-					return driver.generateConnectionCode(languageId, profileWithSecrets.parameterValues);
+					return driver.generateConnectionCode(mechanismId, languageId, profileWithSecrets.parameterValues);
 				},
 				variants,
 			});

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnection.css
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnection.css
@@ -59,6 +59,19 @@
 	color: var(--vscode-descriptionForeground);
 }
 
+.configure-data-connection .parameter-description {
+	font-size: 11px;
+	opacity: 0.8;
+	margin-top: 2px;
+	color: var(--vscode-descriptionForeground);
+}
+
+.configure-data-connection .parameter-optional {
+	margin-left: 4px;
+	opacity: 0.7;
+	font-style: italic;
+}
+
 .configure-data-connection .parameter-input {
 	width: 100%;
 	padding: 4px 6px;

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnection.css
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnection.css
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 .configure-data-connection-container {
-	padding: 16px;
-	border-radius: 6px;
-	border: 1px solid var(--vscode-widget-border);
+	/* padding: 16px; */
+	/* border-radius: 6px; */
+	/* border: 1px solid var(--vscode-widget-border); */
 }
 
 .configure-data-connection {

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnection.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnection.tsx
@@ -210,12 +210,12 @@ export const ConfigureDataConnection = (props: ConfigureDataConnectionProps) => 
 				<div className='configure-data-connection-container'>
 					<div className='configure-data-connection'>
 						{/* Driver Header. */}
-						<div className='driver-header'>
+						{/* <div className='driver-header'>
 							<div className='driver-header-badge'>
 								<img alt='' className='driver-header-icon' src={`data:image/svg+xml;base64,${props.driver.metadata.iconSvg}`} />
 							</div>
 							<div className='driver-header-name'>{props.driver.metadata.name}</div>
-						</div>
+						</div> */}
 
 						{/* Connection Name */}
 						<div className='parameter-field'>
@@ -253,6 +253,7 @@ export const ConfigureDataConnection = (props: ConfigureDataConnectionProps) => 
 						leftButtonTitle={localize('positron.configureDataConnection.back', "Back")}
 						primaryButtonTitle={localize('positron.configureDataConnection.save', "Save")}
 						secondaryButtonTitle={localize('positron.configureDataConnection.cancel', "Cancel")}
+						topBorder={true}
 						onLeftButton={props.onBack}
 						onPrimaryButton={saveHandler}
 						onSecondaryButton={cancelHandler}
@@ -260,6 +261,7 @@ export const ConfigureDataConnection = (props: ConfigureDataConnectionProps) => 
 					: <TwoButtonFooter
 						primaryButtonTitle={localize('positron.configureDataConnection.save', "Save")}
 						secondaryButtonTitle={localize('positron.configureDataConnection.cancel', "Cancel")}
+						topBorder={true}
 						onPrimaryButton={saveHandler}
 						onSecondaryButton={cancelHandler}
 					/>
@@ -267,10 +269,11 @@ export const ConfigureDataConnection = (props: ConfigureDataConnectionProps) => 
 			renderer={props.renderer}
 			title={localize(
 				'positron.configureDataConnection.title',
-				"Configure Data Connection"
+				"Configure Data Connection \u00B7 {0}",
+				props.driver.metadata.name
 			)}
-			titleBarSize='large'
-			width={492}
+			titleSize='large'
+			width={530}
 			onCancel={cancelHandler}
 			onSubmit={saveHandler}
 		/>

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnection.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnection.tsx
@@ -267,7 +267,7 @@ export const ConfigureDataConnection = (props: ConfigureDataConnectionProps) => 
 			renderer={props.renderer}
 			title={localize(
 				'positron.configureDataConnection.title',
-				"Configure Database"
+				"Configure Data Connection"
 			)}
 			titleBarSize='large'
 			width={492}

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnection.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnection.tsx
@@ -19,7 +19,7 @@ import { PositronModalDialogReactRenderer } from '../../../../../base/browser/po
 import { TwoButtonFooter } from '../../../../browser/positronComponents/positronDynamicModalDialog/components/twoButtonFooter.js';
 import { ThreeButtonFooter } from '../../../../browser/positronComponents/positronDynamicModalDialog/components/threeButtonFooter.js';
 import { PositronDynamicModalDialog } from '../../../../browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.js';
-import { DataConnectionParameterValues, IDataConnectionDriver, IDataConnectionProfile } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
+import { DataConnectionParameterValues, IDataConnectionDriver, IDataConnectionMechanism, IDataConnectionProfile } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
 
 /**
  * UI-side form state for a single parameter field, pairing the value with an error indicator.
@@ -48,6 +48,9 @@ interface ConfigureDataConnectionProps {
 
 	// The driver for the connection being configured.
 	driver: IDataConnectionDriver;
+
+	// The mechanism the connection is being configured with. Its parameters drive the form.
+	mechanism: IDataConnectionMechanism;
 
 	// The profile. Omit when creating a new profile.
 	profile?: IDataConnectionProfile;
@@ -92,7 +95,7 @@ export const ConfigureDataConnection = (props: ConfigureDataConnectionProps) => 
 	const [parameterFieldStates, setParameterFieldStates] = useState<ParameterFieldStates>(() => {
 		// Initialize parameter field states.
 		const initialParameterFieldStates: ParameterFieldStates = {};
-		for (const parameter of props.driver.metadata.parameters) {
+		for (const parameter of props.mechanism.parameters) {
 			// Get the default value for the parameter. Password parameters and secret string
 			// parameters do not have a default value in the type system.
 			const defaultValue = parameter.type === 'password' || (parameter.type === 'string' && parameter.secret)
@@ -147,7 +150,7 @@ export const ConfigureDataConnection = (props: ConfigureDataConnectionProps) => 
 
 		// Validate the parameters.
 		const updatedParameterFieldStates = { ...parameterFieldStates };
-		for (const parameter of props.driver.metadata.parameters) {
+		for (const parameter of props.mechanism.parameters) {
 			// Get the current value for this parameter field.
 			const value = parameterFieldStates[parameter.id].value;
 
@@ -194,6 +197,7 @@ export const ConfigureDataConnection = (props: ConfigureDataConnectionProps) => 
 					supportedLanguageIds: props.driver.metadata.supportedLanguageIds,
 				},
 				connectionName,
+				mechanismId: props.mechanism.id,
 				parameterValues,
 			});
 		}
@@ -235,7 +239,7 @@ export const ConfigureDataConnection = (props: ConfigureDataConnectionProps) => 
 						{/* Parameters */}
 						<ConfigureDataConnectionParameters
 							parameterFieldStates={parameterFieldStates}
-							parameters={props.driver.metadata.parameters}
+							parameters={props.mechanism.parameters}
 							storedSecretIds={storedSecretIds}
 							onParameterChanged={setParameterFieldState}
 						/>

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnection.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnection.tsx
@@ -89,6 +89,38 @@ export const ConfigureDataConnection = (props: ConfigureDataConnectionProps) => 
 		props.profile ? positronDataConnectionsService.getProfileSecretIds(props.profile.id) : []
 	));
 
+	// Redacted previews (parameter id -> redacted string) for unmasked secret parameters that have a
+	// stored value, shown as the field placeholder when editing (e.g. a connection string with its
+	// password masked). The cleartext is redacted by the driver and never loaded into this component.
+	const [redactedSecretValues, setRedactedSecretValues] = useState<Record<string, string>>({});
+
+	// On mount, fetch redacted previews for any unmasked secret parameters with a stored value.
+	useEffect(() => {
+		const profileId = props.profile?.id;
+		if (!profileId) {
+			return;
+		}
+
+		// Unmasked secret string parameters render in plaintext, so a "saved" dots placeholder would be
+		// misleading; show a driver-redacted preview of the stored value instead.
+		const unmaskedSecretIds = props.mechanism.parameters
+			.filter(parameter => parameter.type === 'string' && parameter.secret === true && parameter.masked === false && storedSecretIds.has(parameter.id))
+			.map(parameter => parameter.id);
+
+		let disposed = false;
+		Promise.all(unmaskedSecretIds.map(async parameterId => {
+			const redacted = await positronDataConnectionsService.getRedactedParameterValue(profileId, parameterId);
+			return [parameterId, redacted] as const;
+		})).then(entries => {
+			if (disposed) {
+				return;
+			}
+			setRedactedSecretValues(Object.fromEntries(entries.filter((entry): entry is [string, string] => entry[1] !== undefined)));
+		});
+
+		return () => { disposed = true; };
+	}, [positronDataConnectionsService, props.profile?.id, props.mechanism.parameters, storedSecretIds]);
+
 	// State.
 	const [connectionName, setConnectionName] = useState(props.profile?.connectionName ?? '');
 	const [connectionNameError, setConnectionNameError] = useState(false);
@@ -240,6 +272,7 @@ export const ConfigureDataConnection = (props: ConfigureDataConnectionProps) => 
 						<ConfigureDataConnectionParameters
 							parameterFieldStates={parameterFieldStates}
 							parameters={props.mechanism.parameters}
+							redactedSecretValues={redactedSecretValues}
 							storedSecretIds={storedSecretIds}
 							onParameterChanged={setParameterFieldState}
 						/>

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnectionParameters.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnectionParameters.tsx
@@ -25,6 +25,11 @@ interface ConfigureDataConnectionParametersProps {
 	// than clearing it.
 	storedSecretIds: ReadonlySet<string>;
 
+	// Driver-redacted previews (parameter id -> redacted string) for unmasked secret parameters with a
+	// stored value. When present for a field, the redacted preview is shown as the placeholder instead
+	// of the generic "saved" dots, so the user can see (a safe form of) what is stored.
+	redactedSecretValues?: Record<string, string>;
+
 	// The current value and error state of each parameter field, managed by the parent component.
 	parameterFieldStates: ParameterFieldStates;
 
@@ -63,6 +68,7 @@ const ParameterDescription = ({ text }: { text?: string }): JSX.Element | null =
 export const ConfigureDataConnectionParameters = ({
 	parameters,
 	storedSecretIds,
+	redactedSecretValues,
 	parameterFieldStates,
 	onParameterChanged,
 }: ConfigureDataConnectionParametersProps): JSX.Element => {
@@ -194,7 +200,17 @@ export const ConfigureDataConnectionParameters = ({
 					case 'string': {
 						// Secret-typed strings get the saved-secret placeholder treatment too.
 						const fieldValue = parameterFieldStates[parameter.id].value as string;
-						const showStoredPlaceholder = parameter.secret === true && storedSecretIds.has(parameter.id) && !fieldValue;
+						// Secret strings are masked unless the driver opts out (masked: false), which
+						// renders the value in plaintext while still storing it as a secret -- e.g. a
+						// connection string the user should be able to read back as they type.
+						const masked = parameter.secret === true && parameter.masked !== false;
+						// When editing, an unmasked secret with a stored value shows a driver-redacted
+						// preview of what is stored; a masked secret shows the generic dots. Either way,
+						// leaving the field blank keeps the stored secret.
+						const redactedValue = redactedSecretValues?.[parameter.id];
+						const placeholder = !fieldValue && parameter.secret === true && storedSecretIds.has(parameter.id)
+							? (redactedValue ?? STORED_SECRET_PLACEHOLDER)
+							: parameter.placeholder;
 						return (
 							<div key={parameter.id} className='parameter-field'>
 								<ParameterLabel htmlFor={fieldId} label={parameter.label} optional={!parameter.required} />
@@ -206,8 +222,8 @@ export const ConfigureDataConnectionParameters = ({
 										{ 'error': parameterFieldStates[parameter.id].error }
 									)}
 									id={fieldId}
-									placeholder={showStoredPlaceholder ? STORED_SECRET_PLACEHOLDER : parameter.placeholder}
-									type={parameter.secret === true ? 'password' : 'text'}
+									placeholder={placeholder}
+									type={masked ? 'password' : 'text'}
 									value={fieldValue}
 									onChange={e => onParameterChanged(parameter.id, e.target.value ?? undefined)}
 								/>

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnectionParameters.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnectionParameters.tsx
@@ -7,6 +7,7 @@
 import { JSX } from 'react';
 
 // Other dependencies.
+import { localize } from '../../../../../nls.js';
 import { ParameterFieldStates } from './configureDataConnection.js';
 import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
 import { Checkbox } from '../../../../../base/browser/ui/positronComponents/checkbox/checkbox.js';
@@ -36,6 +37,26 @@ interface ConfigureDataConnectionParametersProps {
 const STORED_SECRET_PLACEHOLDER = '••••••••';
 
 /**
+ * Renders a parameter's label, appending a muted "(optional)" marker when the parameter is not
+ * required. Marking optional fields (rather than required ones) needs no legend, matches the data
+ * model where parameters are optional unless explicitly flagged required, and is announced as
+ * meaningful text by screen readers.
+ */
+const ParameterLabel = ({ htmlFor, label, optional }: { htmlFor: string; label: string; optional: boolean }): JSX.Element => (
+	<label className='parameter-label' htmlFor={htmlFor}>
+		{label}
+		{optional && <span className='parameter-optional'>{localize('positron.dataConnections.parameterOptional', "(optional)")}</span>}
+	</label>
+);
+
+/**
+ * Renders a parameter's optional description as help text beneath its field. Returns nothing when the
+ * parameter has no description.
+ */
+const ParameterDescription = ({ text }: { text?: string }): JSX.Element | null =>
+	text ? <span className='parameter-description'>{text}</span> : null;
+
+/**
  * ConfigureDataConnectionParameters component. Renders the per-parameter form fields for the
  * selected driver, dispatching value changes back to the parent via onParameterChanged.
  */
@@ -48,6 +69,9 @@ export const ConfigureDataConnectionParameters = ({
 	return (
 		<>
 			{parameters.map(parameter => {
+				// Stable id linking each <label> to its control, so screen readers announce the label
+				// (including the "(optional)" marker) when the field is focused.
+				const fieldId = `data-connection-parameter-${parameter.id}`;
 				switch (parameter.type) {
 					// Boolean parameter.
 					case 'boolean': {
@@ -58,6 +82,7 @@ export const ConfigureDataConnectionParameters = ({
 									label={parameter.label}
 									onChanged={checked => onParameterChanged(parameter.id, checked)}
 								/>
+								<ParameterDescription text={parameter.description} />
 							</div>
 						);
 					}
@@ -66,17 +91,20 @@ export const ConfigureDataConnectionParameters = ({
 					case 'file': {
 						return (
 							<div key={parameter.id} className='parameter-field'>
-								<label className='parameter-label'>{parameter.label}</label>
+								<ParameterLabel htmlFor={fieldId} label={parameter.label} optional={!parameter.required} />
 								<input
+									aria-required={parameter.required || undefined}
 									className={positronClassNames(
 										'parameter-input', 'text-input',
 										{ 'error': parameterFieldStates[parameter.id].error }
 									)}
+									id={fieldId}
 									placeholder={parameter.placeholder}
 									type='text'
 									value={parameterFieldStates[parameter.id].value as string}
 									onChange={e => onParameterChanged(parameter.id, e.target.value)}
 								/>
+								<ParameterDescription text={parameter.description} />
 							</div>
 						);
 					}
@@ -85,12 +113,14 @@ export const ConfigureDataConnectionParameters = ({
 					case 'number': {
 						return (
 							<div key={parameter.id} className='parameter-field'>
-								<label className='parameter-label'>{parameter.label}</label>
+								<ParameterLabel htmlFor={fieldId} label={parameter.label} optional={!parameter.required} />
 								<input
+									aria-required={parameter.required || undefined}
 									className={positronClassNames(
 										'parameter-input', 'text-input',
 										{ 'error': parameterFieldStates[parameter.id].error }
 									)}
+									id={fieldId}
 									inputMode='numeric'
 									placeholder={parameter.placeholder}
 									type='text'
@@ -104,6 +134,7 @@ export const ConfigureDataConnectionParameters = ({
 										onParameterChanged(parameter.id, isNaN(numericValue) ? undefined : numericValue);
 									}}
 								/>
+								<ParameterDescription text={parameter.description} />
 							</div>
 						);
 					}
@@ -112,12 +143,14 @@ export const ConfigureDataConnectionParameters = ({
 					case 'option': {
 						return (
 							<div key={parameter.id} className='parameter-field'>
-								<label className='parameter-label'>{parameter.label}</label>
+								<ParameterLabel htmlFor={fieldId} label={parameter.label} optional={!parameter.required} />
 								<select
+									aria-required={parameter.required || undefined}
 									className={positronClassNames(
 										'parameter-input', 'parameter-select',
 										{ 'error': parameterFieldStates[parameter.id].error }
 									)}
+									id={fieldId}
 									value={parameterFieldStates[parameter.id].value as string}
 									onChange={e => onParameterChanged(parameter.id, e.target.value)}
 								>
@@ -125,6 +158,7 @@ export const ConfigureDataConnectionParameters = ({
 										<option key={option} value={option}>{option}</option>
 									))}
 								</select>
+								<ParameterDescription text={parameter.description} />
 							</div>
 						);
 					}
@@ -137,18 +171,21 @@ export const ConfigureDataConnectionParameters = ({
 						const showStoredPlaceholder = storedSecretIds.has(parameter.id) && !fieldValue;
 						return (
 							<div key={parameter.id} className='parameter-field'>
-								<label className='parameter-label'>{parameter.label}</label>
+								<ParameterLabel htmlFor={fieldId} label={parameter.label} optional={!parameter.required} />
 								<input
+									aria-required={parameter.required || undefined}
 									className={positronClassNames(
 										'parameter-input',
 										'text-input',
 										{ 'error': parameterFieldStates[parameter.id].error }
 									)}
+									id={fieldId}
 									placeholder={showStoredPlaceholder ? STORED_SECRET_PLACEHOLDER : parameter.placeholder}
 									type='password'
 									value={fieldValue}
 									onChange={e => onParameterChanged(parameter.id, e.target.value ?? undefined)}
 								/>
+								<ParameterDescription text={parameter.description} />
 							</div>
 						);
 					}
@@ -160,18 +197,21 @@ export const ConfigureDataConnectionParameters = ({
 						const showStoredPlaceholder = parameter.secret === true && storedSecretIds.has(parameter.id) && !fieldValue;
 						return (
 							<div key={parameter.id} className='parameter-field'>
-								<label className='parameter-label'>{parameter.label}</label>
+								<ParameterLabel htmlFor={fieldId} label={parameter.label} optional={!parameter.required} />
 								<input
+									aria-required={parameter.required || undefined}
 									className={positronClassNames(
 										'parameter-input',
 										'text-input',
 										{ 'error': parameterFieldStates[parameter.id].error }
 									)}
+									id={fieldId}
 									placeholder={showStoredPlaceholder ? STORED_SECRET_PLACEHOLDER : parameter.placeholder}
 									type={parameter.secret === true ? 'password' : 'text'}
 									value={fieldValue}
 									onChange={e => onParameterChanged(parameter.id, e.target.value ?? undefined)}
 								/>
+								<ParameterDescription text={parameter.description} />
 							</div>
 						);
 					}

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/connectDataConnectionWith.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/connectDataConnectionWith.tsx
@@ -23,7 +23,7 @@ import { CodeAttributionSource } from '../../../../services/positronConsole/comm
 import { DataConnectionCodeEditor, DataConnectionCodeEditorWidget } from '../components/dataConnectionCodeEditor.js';
 import { TwoButtonFooter } from '../../../../browser/positronComponents/positronDynamicModalDialog/components/twoButtonFooter.js';
 import { PositronDynamicModalDialog } from '../../../../browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.js';
-import { IDataConnectionCodeVariant, IDataConnectionDriver, isSecretParameter } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
+import { IDataConnectionCodeVariant, IDataConnectionDriver, isSecretParameter, resolveDataConnectionMechanism } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
 
 // The width of the Connect Data Connection With dialog.
 const CONNECT_DATA_CONNECTION_WITH_WIDTH = 800;
@@ -41,6 +41,10 @@ export interface ConnectDataConnectionWithOptions {
 	// The driver for this connection. Used for the title (driver name) and to detect whether the
 	// connection has any secret parameters (which surfaces the Include Secrets action).
 	readonly driver: IDataConnectionDriver;
+
+	// The id of the mechanism this connection was configured with. Determines which of the driver's
+	// parameters define the connection's secret schema.
+	readonly mechanismId: string;
 
 	// Regenerates the connection code variants with secret values (e.g. passwords) embedded. Invoked
 	// only after the user confirms the Include Secrets action; pulls secrets from secret storage.
@@ -67,6 +71,7 @@ export const showConnectDataConnectionWith = (options: ConnectDataConnectionWith
 			driver={options.driver}
 			generateSecretVariants={options.generateSecretVariants}
 			languageId={options.languageId}
+			mechanismId={options.mechanismId}
 			renderer={renderer}
 			variants={options.variants}
 		/>
@@ -81,6 +86,7 @@ interface ConnectDataConnectionWithProps {
 	readonly languageId: string;
 	readonly connectionName: string;
 	readonly driver: IDataConnectionDriver;
+	readonly mechanismId: string;
 	readonly generateSecretVariants: () => Promise<IDataConnectionCodeVariant[]>;
 	readonly variants: IDataConnectionCodeVariant[];
 }
@@ -95,9 +101,11 @@ const ConnectDataConnectionWith = (props: PropsWithChildren<ConnectDataConnectio
 
 	const editorRef = useRef<DataConnectionCodeEditorWidget>(undefined!);
 
-	// Whether the driver has any secret parameters (e.g. a password) whose values we keep out of the
-	// generated code unless the user opts in.
-	const hasSecrets = props.driver.metadata.parameters.some(isSecretParameter);
+	// Whether the connection's mechanism has any secret parameters (e.g. a password) whose values we
+	// keep out of the generated code unless the user opts in. Falls back to the first mechanism for
+	// pre-mechanisms profiles.
+	const mechanism = resolveDataConnectionMechanism(props.driver.metadata, props.mechanismId);
+	const hasSecrets = mechanism?.parameters.some(isSecretParameter) ?? false;
 
 	// Whether secret parameter values have been embedded in the generated code. Starts false; set
 	// once the user confirms the Include Secrets action. One-way: the dialog reopens secret-free.

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/connectDataConnectionWith.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/connectDataConnectionWith.tsx
@@ -289,7 +289,7 @@ const ConnectDataConnectionWith = (props: PropsWithChildren<ConnectDataConnectio
 			}
 			renderer={props.renderer}
 			title={localize('positron.connectDataConnectionWith.summary', "Connect {0} · {1} with {2}", props.connectionName, props.driver.metadata.name, languageName)}
-			titleBarSize='large'
+			titleSize='large'
 			width={CONNECT_DATA_CONNECTION_WITH_WIDTH}
 			onCancel={cancelHandler}
 		/>

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/includeSecretsConfirmation.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/includeSecretsConfirmation.tsx
@@ -79,7 +79,7 @@ const IncludeSecretsConfirmation = (props: IncludeSecretsConfirmationProps) => {
 			}
 			renderer={props.renderer}
 			title={localize('positron.includeSecretsConfirmation.title', "Include Secrets?")}
-			titleBarSize='large'
+			titleSize='large'
 			width={INCLUDE_SECRETS_CONFIRMATION_WIDTH}
 			onCancel={props.onCancel}
 		/>

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/newDataConnectionFlow.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/newDataConnectionFlow.tsx
@@ -12,9 +12,10 @@ import { useState } from 'react';
 // Other dependencies.
 import { ConfigureDataConnection } from './configureDataConnection.js';
 import { SelectDataConnectionProvider } from './selectDataConnectionProvider.js';
+import { SelectDataConnectionMechanism } from './selectDataConnectionMechanism.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { PositronModalDialogReactRenderer } from '../../../../../base/browser/positronModalDialogReactRenderer.js';
-import { IDataConnectionDriver } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
+import { IDataConnectionDriver, IDataConnectionMechanism } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
 
 /**
  * NewDataConnectionFlowStep enumeration.
@@ -26,7 +27,13 @@ enum NewDataConnectionFlowStep {
 	SelectProvider,
 
 	/**
-	 * The user is configuring the connection settings for the selected provider.
+	 * The user is selecting which configuration mechanism to use for the selected provider. Skipped
+	 * when the driver exposes only one mechanism.
+	 */
+	SelectMechanism,
+
+	/**
+	 * The user is configuring the connection settings for the selected provider and mechanism.
 	 */
 	Configure,
 }
@@ -53,6 +60,7 @@ export const NewDataConnectionFlow = (props: NewDataConnectionFlowProps) => {
 	// State.
 	const [step, setStep] = useState(NewDataConnectionFlowStep.SelectProvider);
 	const [driver, setDriver] = useState<IDataConnectionDriver | undefined>(undefined);
+	const [mechanism, setMechanism] = useState<IDataConnectionMechanism | undefined>(undefined);
 
 	// Render the current step.
 	switch (step) {
@@ -62,21 +70,50 @@ export const NewDataConnectionFlow = (props: NewDataConnectionFlowProps) => {
 				<SelectDataConnectionProvider
 					renderer={props.renderer}
 					onNext={selectedDriver => {
-						// Remember the selected driver and transition to the configure step. The
-						// profile itself is constructed by ConfigureDataConnection on save.
+						// Remember the selected driver. If it has a single mechanism, skip the
+						// mechanism step and select it implicitly; otherwise go to the mechanism step.
 						setDriver(selectedDriver);
+						const mechanisms = selectedDriver.metadata.mechanisms;
+						if (mechanisms.length === 1) {
+							setMechanism(mechanisms[0]);
+							setStep(NewDataConnectionFlowStep.Configure);
+						} else {
+							setStep(NewDataConnectionFlowStep.SelectMechanism);
+						}
+					}}
+				/>
+			);
+
+		// Step 2: Select mechanism (only reached when the driver has multiple mechanisms).
+		case NewDataConnectionFlowStep.SelectMechanism:
+			return (
+				<SelectDataConnectionMechanism
+					driver={driver!}
+					renderer={props.renderer}
+					onBack={() => setStep(NewDataConnectionFlowStep.SelectProvider)}
+					onNext={selectedMechanism => {
+						// Remember the selected mechanism and transition to the configure step. The
+						// profile itself is constructed by ConfigureDataConnection on save.
+						setMechanism(selectedMechanism);
 						setStep(NewDataConnectionFlowStep.Configure);
 					}}
 				/>
 			);
 
-		// Step 2: Configure connection.
+		// Step 3: Configure connection.
 		case NewDataConnectionFlowStep.Configure:
 			return (
 				<ConfigureDataConnection
 					driver={driver!}
+					mechanism={mechanism!}
 					renderer={props.renderer}
-					onBack={() => setStep(NewDataConnectionFlowStep.SelectProvider)}
+					onBack={() => {
+						// Return to the mechanism step, unless it was skipped (single mechanism), in
+						// which case return to the provider step.
+						setStep(driver!.metadata.mechanisms.length === 1
+							? NewDataConnectionFlowStep.SelectProvider
+							: NewDataConnectionFlowStep.SelectMechanism);
+					}}
 					onSave={profile => {
 						// Add the connection profile in the service.
 						positronDataConnectionsService.addUpdateProfile(profile);

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/selectDataConnectionMechanism.css
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/selectDataConnectionMechanism.css
@@ -3,12 +3,6 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.select-data-connection-mechanism .select-mechanism-label {
-	font-size: 13px;
-	margin-bottom: 6px;
-	color: var(--vscode-descriptionForeground);
-}
-
 .select-data-connection-mechanism .mechanism-list {
 	gap: 8px;
 	display: flex;

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/selectDataConnectionMechanism.css
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/selectDataConnectionMechanism.css
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.select-data-connection-mechanism .select-mechanism-label {
+	font-size: 13px;
+	margin-bottom: 6px;
+	color: var(--vscode-descriptionForeground);
+}
+
+.select-data-connection-mechanism .mechanism-list {
+	gap: 8px;
+	display: flex;
+	flex-direction: column;
+}
+
+.select-data-connection-mechanism .mechanism-card {
+	gap: 4px;
+	display: flex;
+	font: inherit;
+	color: inherit;
+	cursor: pointer;
+	padding: 12px;
+	border-radius: 6px;
+	flex-direction: column;
+	background: transparent;
+	border: 1px solid var(--vscode-widget-border);
+}
+
+.select-data-connection-mechanism .mechanism-card:hover {
+	background: var(--vscode-list-hoverBackground);
+}
+
+.select-data-connection-mechanism .mechanism-card.selected {
+	border-color: var(--vscode-focusBorder);
+	color: var(--vscode-list-activeSelectionForeground);
+	background: var(--vscode-list-activeSelectionBackground);
+}
+
+/*
+	Visually hide the radio input. The label is the visible click/focus surface; pulling the focus
+	ring up to the label keeps the visible focus indicator on the card.
+*/
+.select-data-connection-mechanism .mechanism-card-input {
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	position: absolute;
+	white-space: nowrap;
+	clip: rect(0, 0, 0, 0);
+	border: 0;
+}
+
+.select-data-connection-mechanism .mechanism-card:has(.mechanism-card-input:focus-visible) {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: 1px;
+}
+
+.select-data-connection-mechanism .mechanism-card-label {
+	font-weight: 600;
+}
+
+.select-data-connection-mechanism .mechanism-card-description {
+	font-size: 12px;
+	color: var(--vscode-descriptionForeground);
+}
+
+.select-data-connection-mechanism .mechanism-card.selected .mechanism-card-description {
+	color: inherit;
+}

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/selectDataConnectionMechanism.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/selectDataConnectionMechanism.tsx
@@ -78,12 +78,6 @@ export const SelectDataConnectionMechanism = (props: SelectDataConnectionMechani
 		<PositronDynamicModalDialog
 			content={
 				<div className='select-data-connection-mechanism'>
-					<div className='select-mechanism-label'>
-						{localize(
-							'positron.selectDataConnectionMechanism.selectMechanism',
-							"Select how to connect"
-						)}
-					</div>
 					<div className='mechanism-list' role='radiogroup'>
 						{driver.metadata.mechanisms.map(mechanism => {
 							const mechanismCardId = `data-connection-mechanism-card-${mechanism.id}`;
@@ -123,6 +117,7 @@ export const SelectDataConnectionMechanism = (props: SelectDataConnectionMechani
 					leftButtonTitle={localize('positron.selectDataConnectionMechanism.back', "Back")}
 					primaryButtonTitle={localize('positron.selectDataConnectionMechanism.next', "Next")}
 					secondaryButtonTitle={localize('positron.selectDataConnectionMechanism.cancel', "Cancel")}
+					topBorder={true}
 					onLeftButton={onBack}
 					onPrimaryButton={nextHandler}
 					onSecondaryButton={cancelHandler}
@@ -134,7 +129,11 @@ export const SelectDataConnectionMechanism = (props: SelectDataConnectionMechani
 				"Add Data Connection \u00B7 {0}",
 				driver.metadata.name
 			)}
-			titleBarSize='large'
+			titleDescription={localize(
+				'positron.selectDataConnectionMechanism.selectMechanism',
+				"Select how to connect"
+			)}
+			titleSize='large'
 			width={492}
 			onCancel={cancelHandler}
 			onSubmit={nextHandler}

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/selectDataConnectionMechanism.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/selectDataConnectionMechanism.tsx
@@ -54,18 +54,24 @@ export const SelectDataConnectionMechanism = (props: SelectDataConnectionMechani
 		renderer.dispose();
 	}, [renderer]);
 
-	// Next handler.
-	const nextHandler = useCallback(() => {
-		// Get the selected mechanism. This can't fail since the selection is always one of the
-		// driver's mechanisms.
-		const mechanism = driver.metadata.mechanisms.find(_ => _.id === selectedMechanismId);
+	// Resolves the given mechanism id and advances to the next step. Takes the id explicitly (rather
+	// than reading selectedMechanismId) so callers like double-click can advance in the same tick they
+	// select, without waiting for the selection state update to flush.
+	const proceedWithMechanism = useCallback((mechanismId: string) => {
+		// Get the mechanism. This can't fail since the id is always one of the driver's mechanisms.
+		const mechanism = driver.metadata.mechanisms.find(_ => _.id === mechanismId);
 		if (!mechanism) {
 			return;
 		}
 
 		// Proceed to the next step with the selected mechanism.
 		onNext(mechanism);
-	}, [driver.metadata.mechanisms, onNext, selectedMechanismId]);
+	}, [driver.metadata.mechanisms, onNext]);
+
+	// Next handler.
+	const nextHandler = useCallback(() => {
+		proceedWithMechanism(selectedMechanismId);
+	}, [proceedWithMechanism, selectedMechanismId]);
 
 	// Render.
 	return (
@@ -89,6 +95,11 @@ export const SelectDataConnectionMechanism = (props: SelectDataConnectionMechani
 										{ 'selected': selectedMechanismId === mechanism.id }
 									)}
 									htmlFor={mechanismCardId}
+									onDoubleClick={() => {
+										// Double-click selects the mechanism and advances, mirroring Next.
+										setSelectedMechanismId(mechanism.id);
+										proceedWithMechanism(mechanism.id);
+									}}
 								>
 									<input
 										checked={selectedMechanismId === mechanism.id}
@@ -120,7 +131,8 @@ export const SelectDataConnectionMechanism = (props: SelectDataConnectionMechani
 			renderer={props.renderer}
 			title={localize(
 				'positron.selectDataConnectionMechanism.title',
-				"Add Database"
+				"Add Data Connection \u00B7 {0}",
+				driver.metadata.name
 			)}
 			titleBarSize='large'
 			width={492}

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/selectDataConnectionMechanism.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/selectDataConnectionMechanism.tsx
@@ -1,0 +1,131 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import './selectDataConnectionMechanism.css';
+
+// React.
+import { useCallback, useState } from 'react';
+
+// Other dependencies.
+import { localize } from '../../../../../nls.js';
+import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
+import { PositronModalDialogReactRenderer } from '../../../../../base/browser/positronModalDialogReactRenderer.js';
+import { ThreeButtonFooter } from '../../../../browser/positronComponents/positronDynamicModalDialog/components/threeButtonFooter.js';
+import { PositronDynamicModalDialog } from '../../../../browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.js';
+import { IDataConnectionDriver, IDataConnectionMechanism } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
+
+/**
+ * SelectDataConnectionMechanismProps interface.
+ */
+interface SelectDataConnectionMechanismProps {
+	// The renderer.
+	renderer: PositronModalDialogReactRenderer;
+
+	// The driver whose mechanisms are being selected from.
+	driver: IDataConnectionDriver;
+
+	// Called when the user clicks the Back button to return to the provider selection step.
+	onBack: () => void;
+
+	// Called when the user selects a mechanism and clicks Next.
+	onNext: (mechanism: IDataConnectionMechanism) => void;
+}
+
+/**
+ * SelectDataConnectionMechanism component.
+ * Displays a dialog with a list of the driver's configuration mechanisms that the user can choose
+ * from. Only shown when the driver exposes more than one mechanism.
+ * @param props The component properties.
+ * @returns The rendered component.
+ */
+export const SelectDataConnectionMechanism = (props: SelectDataConnectionMechanismProps) => {
+	// Destructure props for use in hooks.
+	const { driver, onBack, onNext, renderer } = props;
+
+	// State. Pre-select the first mechanism so Next is always actionable.
+	const [selectedMechanismId, setSelectedMechanismId] = useState<string>(driver.metadata.mechanisms[0].id);
+
+	// Cancel handler.
+	const cancelHandler = useCallback(() => {
+		// Dispose the renderer, which will close the dialog.
+		renderer.dispose();
+	}, [renderer]);
+
+	// Next handler.
+	const nextHandler = useCallback(() => {
+		// Get the selected mechanism. This can't fail since the selection is always one of the
+		// driver's mechanisms.
+		const mechanism = driver.metadata.mechanisms.find(_ => _.id === selectedMechanismId);
+		if (!mechanism) {
+			return;
+		}
+
+		// Proceed to the next step with the selected mechanism.
+		onNext(mechanism);
+	}, [driver.metadata.mechanisms, onNext, selectedMechanismId]);
+
+	// Render.
+	return (
+		<PositronDynamicModalDialog
+			content={
+				<div className='select-data-connection-mechanism'>
+					<div className='select-mechanism-label'>
+						{localize(
+							'positron.selectDataConnectionMechanism.selectMechanism',
+							"Select how to connect"
+						)}
+					</div>
+					<div className='mechanism-list' role='radiogroup'>
+						{driver.metadata.mechanisms.map(mechanism => {
+							const mechanismCardId = `data-connection-mechanism-card-${mechanism.id}`;
+							return (
+								<label
+									key={mechanism.id}
+									className={positronClassNames(
+										'mechanism-card',
+										{ 'selected': selectedMechanismId === mechanism.id }
+									)}
+									htmlFor={mechanismCardId}
+								>
+									<input
+										checked={selectedMechanismId === mechanism.id}
+										className='mechanism-card-input'
+										id={mechanismCardId}
+										name='data-connection-mechanism'
+										type='radio'
+										value={mechanism.id}
+										onChange={() => setSelectedMechanismId(mechanism.id)}
+									/>
+									<div className='mechanism-card-label'>{mechanism.label}</div>
+									<div className='mechanism-card-description'>{mechanism.description}</div>
+								</label>
+							);
+						})}
+					</div>
+				</div>
+			}
+			footer={
+				<ThreeButtonFooter
+					leftButtonTitle={localize('positron.selectDataConnectionMechanism.back', "Back")}
+					primaryButtonTitle={localize('positron.selectDataConnectionMechanism.next', "Next")}
+					secondaryButtonTitle={localize('positron.selectDataConnectionMechanism.cancel', "Cancel")}
+					onLeftButton={onBack}
+					onPrimaryButton={nextHandler}
+					onSecondaryButton={cancelHandler}
+				/>
+			}
+			renderer={props.renderer}
+			title={localize(
+				'positron.selectDataConnectionMechanism.title',
+				"Add Database"
+			)}
+			titleBarSize='large'
+			width={492}
+			onCancel={cancelHandler}
+			onSubmit={nextHandler}
+		/>
+	);
+};

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/selectDataConnectionProvider.css
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/selectDataConnectionProvider.css
@@ -8,12 +8,6 @@
 	color: var(--vscode-descriptionForeground);
 }
 
-.select-data-connection-provider .select-provider-label {
-	font-size: 13px;
-	margin-bottom: 6px;
-	color: var(--vscode-descriptionForeground);
-}
-
 .select-data-connection-provider .driver-grid-clip {
 	overflow: hidden;
 	border-radius: 6px;

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/selectDataConnectionProvider.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/selectDataConnectionProvider.tsx
@@ -168,12 +168,6 @@ export const SelectDataConnectionProvider = (props: SelectDataConnectionProvider
 		<PositronDynamicModalDialog
 			content={
 				<div className='select-data-connection-provider'>
-					<div className='select-provider-label'>
-						{localize(
-							'positron.selectDataConnectionProvider.selectProvider',
-							"Select a provider"
-						)}
-					</div>
 					<div className={positronClassNames(
 						'driver-grid-clip',
 						{ 'error': showError }
@@ -253,7 +247,11 @@ export const SelectDataConnectionProvider = (props: SelectDataConnectionProvider
 				'positron.selectDataConnectionProvider.title',
 				"Add Data Connection"
 			)}
-			titleBarSize='large'
+			titleDescription={localize(
+				'positron.selectDataConnectionProvider.selectProvider',
+				"Select a provider"
+			)}
+			titleSize='large'
 			width={492}
 			onCancel={cancelHandler}
 			onSubmit={nextHandler}

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/selectDataConnectionProvider.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/selectDataConnectionProvider.tsx
@@ -136,6 +136,22 @@ export const SelectDataConnectionProvider = (props: SelectDataConnectionProvider
 		}
 	}, []);
 
+	// Resolves the given driver id and advances to the next step. Takes the id explicitly (rather than
+	// reading selectedDriverId) so callers like double-click can advance in the same tick they select,
+	// without waiting for the selection state update to flush.
+	const proceedWithDriver = useCallback((driverId: string) => {
+		// Get the driver. This can't fail. If it does, something is very wrong.
+		const driver = positronDataConnectionsService.driverManager.getDriver(driverId);
+		if (!driver) {
+			console.error(`Selected driver with id ${driverId} not found`);
+			setShowError(true);
+			return;
+		}
+
+		// Proceed to the next step with the selected driver.
+		onNext(driver);
+	}, [onNext, positronDataConnectionsService.driverManager]);
+
 	// Next handler.
 	const nextHandler = useCallback(() => {
 		// If no driver is selected, set the show error flag and do not proceed to the next step.
@@ -144,17 +160,8 @@ export const SelectDataConnectionProvider = (props: SelectDataConnectionProvider
 			return;
 		}
 
-		// Get the selected driver. This can't fail. If it does, something is very wrong.
-		const driver = positronDataConnectionsService.driverManager.getDriver(selectedDriverId);
-		if (!driver) {
-			console.error(`Selected driver with id ${selectedDriverId} not found`);
-			setShowError(true);
-			return;
-		}
-
-		// Proceed to the next step with the selected driver.
-		onNext(driver);
-	}, [selectedDriverId, onNext, positronDataConnectionsService.driverManager]);
+		proceedWithDriver(selectedDriverId);
+	}, [selectedDriverId, proceedWithDriver]);
 
 	// Render.
 	return (
@@ -200,6 +207,12 @@ export const SelectDataConnectionProvider = (props: SelectDataConnectionProvider
 													{ 'selected': selectedDriverId === driver.id }
 												)}
 												htmlFor={driverCardId}
+												onDoubleClick={() => {
+													// Double-click selects the driver and advances, mirroring Next.
+													setSelectedDriverId(driver.id);
+													setShowError(false);
+													proceedWithDriver(driver.id);
+												}}
 											>
 												<input
 													checked={selectedDriverId === driver.id}
@@ -238,7 +251,7 @@ export const SelectDataConnectionProvider = (props: SelectDataConnectionProvider
 			renderer={props.renderer}
 			title={localize(
 				'positron.selectDataConnectionProvider.title',
-				"Add Database"
+				"Add Data Connection"
 			)}
 			titleBarSize='large'
 			width={492}

--- a/src/vs/workbench/contrib/positronDataConnections/browser/positronDataConnections.contribution.ts
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/positronDataConnections.contribution.ts
@@ -19,7 +19,7 @@ import { ConfigurationScope, Extensions as ConfigurationExtensions, IConfigurati
 const POSITRON_DATA_CONNECTIONS_VIEW_ID = 'workbench.panel.positronDataConnections';
 
 // Configuration key that gates the Positron Data Connections feature.
-const POSITRON_DATA_CONNECTIONS_ENABLED_KEY = 'databases.enabled';
+const POSITRON_DATA_CONNECTIONS_ENABLED_KEY = 'dataConnections.enabled';
 
 // Register the configuration setting.
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
@@ -32,8 +32,8 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			type: 'boolean',
 			default: false,
 			markdownDescription: localize(
-				'databases.enabled',
-				'Enable the Databases panel. Requires a reload to take effect.'
+				'positron.dataConnections.enabled',
+				'Enable the Data Connections panel. Requires a reload to take effect.'
 			),
 			tags: ['preview'],
 			scope: ConfigurationScope.APPLICATION,

--- a/src/vs/workbench/contrib/positronDataConnections/browser/positronDataConnections.contribution.ts
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/positronDataConnections.contribution.ts
@@ -72,8 +72,8 @@ class PositronDataConnectionsContribution implements IWorkbenchContribution {
 			{
 				id: POSITRON_DATA_CONNECTIONS_VIEW_ID,
 				title: {
-					value: localize('positron.dataConnections', "Databases"),
-					original: 'Databases'
+					value: localize('positron.dataConnections', "Data Connections"),
+					original: 'Data Connections'
 				},
 				icon: positronDataConnectionsViewIcon,
 				order: 2,
@@ -92,8 +92,8 @@ class PositronDataConnectionsContribution implements IWorkbenchContribution {
 		Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews([{
 			id: POSITRON_DATA_CONNECTIONS_VIEW_ID,
 			name: {
-				value: localize('positron.dataConnections', "Databases"),
-				original: 'Databases'
+				value: localize('positron.dataConnections', "Data Connections"),
+				original: 'Data Connections'
 			},
 			containerIcon: positronDataConnectionsViewIcon,
 			canMoveView: true,

--- a/src/vs/workbench/services/positronDataConnections/browser/positronDataConnectionsService.ts
+++ b/src/vs/workbench/services/positronDataConnections/browser/positronDataConnectionsService.ts
@@ -14,7 +14,7 @@ import { IDataConnectionInstance } from '../common/interfaces/dataConnectionInst
 import { IPositronDataConnectionsService } from '../common/interfaces/positronDataConnectionsService.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
-import { IDataConnectionProfile } from '../common/interfaces/dataConnectionDriver.js';
+import { IDataConnectionProfile, resolveDataConnectionMechanism } from '../common/interfaces/dataConnectionDriver.js';
 import { IDataConnectionsDriverManager } from '../common/interfaces/dataConnectionsDriverManager.js';
 
 // Storage key prefix for persisted data connection profiles. Each data connection profile gets
@@ -247,8 +247,16 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 			throw new Error(`No data connection driver registered for '${profile.driverMetadata.id}'`);
 		}
 
+		// Resolve the mechanism (falling back to the first for pre-mechanisms profiles). Opening a
+		// profile that predates mechanisms is a good moment to persist the resolved id, so it is
+		// healed lazily without an eager migration pass.
+		const mechanism = resolveDataConnectionMechanism(driver.metadata, profile.mechanismId);
+		if (mechanism && !profile.mechanismId) {
+			this._backfillProfileMechanismId(profileId, mechanism.id);
+		}
+
 		// Open the connection. driver.connect throws on failure; let it propagate.
-		const handle = await driver.connect(profile.parameterValues);
+		const handle = await driver.connect(mechanism?.id ?? profile.mechanismId, profile.parameterValues);
 
 		// Build the live instance. Active starts true; an onDidChangeStatus emitter is wired so
 		// future status changes can fan out to listeners (currently nothing fires it).
@@ -353,6 +361,30 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 	}
 
 	/**
+	 * Sets the mechanism id on an in-memory profile that lacks one (persisted before mechanisms
+	 * existed) and persists the change, preserving the existing secret parameter ids. A no-op if the
+	 * profile is not found. Does not fire onDidChangeProfiles: the mechanism id is internal metadata
+	 * and changing it does not affect how the profile is displayed.
+	 * @param id The data connection profile id.
+	 * @param mechanismId The mechanism id to backfill.
+	 */
+	private _backfillProfileMechanismId(id: string, mechanismId: string): void {
+		const profile = this._profiles.find(_ => _.id === id);
+		if (!profile) {
+			return;
+		}
+		profile.mechanismId = mechanismId;
+		const secretParameterIds = this._readPersistedProfile(id)?.secretParameterIds ?? [];
+		this._storageService.store(
+			profileStorageKey(id),
+			JSON.stringify({ profile, secretParameterIds } satisfies IPersistedDataConnectionProfile),
+			StorageScope.PROFILE,
+			StorageTarget.USER,
+		);
+		this._logService.trace(`[DataConnections] Backfilled mechanism id '${mechanismId}' for profile ${id}`);
+	}
+
+	/**
 	 * Reads the persisted form of a single data connection profile from storage, or returns
 	 * undefined if not found or unparseable. Used to look up the secret parameter id list at the points
 	 * where we need it (save / remove / read with secrets).
@@ -387,10 +419,12 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 		const previouslyPersistedProfile = this._readPersistedProfile(profile.id);
 		const previousSecretParameterIds = new Set(previouslyPersistedProfile?.secretParameterIds ?? []);
 
-		// Identify the current secret parameter ids from the driver.
+		// Identify the current secret parameter ids from the profile's mechanism. A profile is tied to
+		// a single mechanism, so only that mechanism's parameters define its secret schema.
 		const driver = this.driverManager.getDriver(profile.driverMetadata.id);
+		const mechanism = driver ? resolveDataConnectionMechanism(driver.metadata, profile.mechanismId) : undefined;
 		const secretParamIdSet = new Set(
-			driver?.metadata.parameters
+			mechanism?.parameters
 				.filter(_ => (_.type === 'password' || _.type === 'string') && _.secret === true)
 				.map(_ => _.id) ?? []
 		);

--- a/src/vs/workbench/services/positronDataConnections/browser/positronDataConnectionsService.ts
+++ b/src/vs/workbench/services/positronDataConnections/browser/positronDataConnectionsService.ts
@@ -200,6 +200,47 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 	}
 
 	/**
+	 * Gets a display-safe, redacted form of a stored secret parameter value. Resolves the cleartext
+	 * from secret storage, hands it to the driver for format-specific redaction, and returns only the
+	 * redacted result. See {@link IPositronDataConnectionsService.getRedactedParameterValue}.
+	 * @param id The data connection profile id.
+	 * @param parameterId The id of the secret parameter to redact.
+	 */
+	async getRedactedParameterValue(id: string, parameterId: string): Promise<string | undefined> {
+		// Resolve the profile with its secret values pulled from secret storage.
+		const profile = await this.getProfileWithSecrets(id);
+		if (!profile) {
+			return undefined;
+		}
+
+		// Only string secret values can be redacted for display.
+		const value = profile.parameterValues[parameterId];
+		if (typeof value !== 'string') {
+			return undefined;
+		}
+
+		// Resolve the driver, and the mechanism the connection was configured with (falling back for
+		// profiles persisted before mechanisms existed).
+		const driver = this.driverManager.getDriver(profile.driverMetadata.id);
+		if (!driver) {
+			return undefined;
+		}
+		const mechanism = resolveDataConnectionMechanism(driver.metadata, profile.mechanismId);
+		if (!mechanism) {
+			return undefined;
+		}
+
+		// Ask the driver to redact the value. The cleartext stays within the service/driver; only the
+		// redacted string is returned to the caller.
+		try {
+			return await driver.redactParameterValue(mechanism.id, parameterId, value);
+		} catch (err) {
+			this._logService.error(`[DataConnections] Failed to redact ${id}/${parameterId}: ${err}`);
+			return undefined;
+		}
+	}
+
+	/**
 	 * Removes a data connection profile.
 	 * @param id The data connection profile id to remove.
 	 */

--- a/src/vs/workbench/services/positronDataConnections/common/interfaces/dataConnectionDTOs.ts
+++ b/src/vs/workbench/services/positronDataConnections/common/interfaces/dataConnectionDTOs.ts
@@ -19,6 +19,7 @@ export interface IDataConnectionParameterDTO {
 	label: string;
 	description?: string;
 	secret?: boolean;
+	masked?: boolean; // only for secret 'string' type; defaults to true when omitted
 	required?: boolean;
 	type: string; // 'boolean' | 'file' | 'number' | 'option' | 'password' | 'string'
 	defaultValue?: string | number | boolean;

--- a/src/vs/workbench/services/positronDataConnections/common/interfaces/dataConnectionDTOs.ts
+++ b/src/vs/workbench/services/positronDataConnections/common/interfaces/dataConnectionDTOs.ts
@@ -17,6 +17,7 @@
 export interface IDataConnectionParameterDTO {
 	id: string;
 	label: string;
+	description?: string;
 	secret?: boolean;
 	required?: boolean;
 	type: string; // 'boolean' | 'file' | 'number' | 'option' | 'password' | 'string'

--- a/src/vs/workbench/services/positronDataConnections/common/interfaces/dataConnectionDTOs.ts
+++ b/src/vs/workbench/services/positronDataConnections/common/interfaces/dataConnectionDTOs.ts
@@ -26,6 +26,17 @@ export interface IDataConnectionParameterDTO {
 }
 
 /**
+ * Serializable configuration mechanism definition. Carries the mechanism's identity and its own
+ * set of parameters.
+ */
+export interface IDataConnectionMechanismDTO {
+	id: string;
+	label: string;
+	description: string;
+	parameters: IDataConnectionParameterDTO[];
+}
+
+/**
  * Serializable driver metadata sent from the ext host to the main thread when a driver is
  * registered. Converted to the richer service-level IDataConnectionDriverMetadata at the
  * main-thread boundary.
@@ -35,7 +46,7 @@ export interface IDataConnectionDriverMetadataDTO {
 	name: string;
 	description: string;
 	iconSvg: string;
-	parameters: IDataConnectionParameterDTO[];
+	mechanisms: IDataConnectionMechanismDTO[];
 	supportedLanguageIds: string[];
 }
 
@@ -84,6 +95,6 @@ export interface IDataConnectionDriverSummaryDTO {
 	id: string;
 	name: string;
 	description: string;
-	parameters: IDataConnectionParameterDTO[];
+	mechanisms: IDataConnectionMechanismDTO[];
 	supportedLanguageIds: string[];
 }

--- a/src/vs/workbench/services/positronDataConnections/common/interfaces/dataConnectionDriver.ts
+++ b/src/vs/workbench/services/positronDataConnections/common/interfaces/dataConnectionDriver.ts
@@ -53,6 +53,7 @@ export interface IDataConnectionProfile {
 export interface IDataConnectionParameterBase {
 	id: string;
 	label: string;
+	description?: string;
 	required?: boolean;
 }
 

--- a/src/vs/workbench/services/positronDataConnections/common/interfaces/dataConnectionDriver.ts
+++ b/src/vs/workbench/services/positronDataConnections/common/interfaces/dataConnectionDriver.ts
@@ -70,7 +70,7 @@ export type IDataConnectionParameter = IDataConnectionParameterBase & (
 	| { type: 'option'; options: string[]; defaultValue?: string; placeholder?: string }
 	| { type: 'password'; secret: true; placeholder?: string }
 	| { type: 'string'; secret?: false; defaultValue?: string; placeholder?: string }
-	| { type: 'string'; secret: true; placeholder?: string }
+	| { type: 'string'; secret: true; masked?: boolean; placeholder?: string }
 );
 
 /**
@@ -155,6 +155,17 @@ export interface IDataConnectionDriver {
 	 * @param params The current connection parameter values.
 	 */
 	generateConnectionCode(mechanismId: string, languageId: string, params: DataConnectionParameterValues): Promise<IDataConnectionCodeVariant[]>;
+
+	/**
+	 * Produces a display-safe, redacted form of a stored secret parameter value (e.g. masking the
+	 * password embedded in a connection string) for display in the configuration dialog. The cleartext
+	 * value is passed to the driver in the ext host; only the redacted result returns. Resolves to
+	 * undefined when the driver does not implement redaction.
+	 * @param mechanismId The id of the mechanism the connection was configured with.
+	 * @param parameterId The id of the parameter to redact.
+	 * @param value The stored cleartext parameter value.
+	 */
+	redactParameterValue(mechanismId: string, parameterId: string, value: string): Promise<string | undefined>;
 }
 
 /**

--- a/src/vs/workbench/services/positronDataConnections/common/interfaces/dataConnectionDriver.ts
+++ b/src/vs/workbench/services/positronDataConnections/common/interfaces/dataConnectionDriver.ts
@@ -40,6 +40,9 @@ export interface IDataConnectionProfile {
 	// The user-chosen name for this connection.
 	connectionName: string;
 
+	// The id of the mechanism this connection was configured with. One of the driver's mechanisms.
+	mechanismId: string;
+
 	// The parameter values for this connection.
 	parameterValues: DataConnectionParameterValues;
 }
@@ -79,6 +82,17 @@ export function isSecretParameter(parameter: IDataConnectionParameter): boolean 
 }
 
 /**
+ * Service-level configuration mechanism. Same shape as IDataConnectionMechanismDTO but with the
+ * richer discriminated parameter type so consumers get narrowed `parameter.type`.
+ */
+export interface IDataConnectionMechanism {
+	id: string;
+	label: string;
+	description: string;
+	parameters: IDataConnectionParameter[];
+}
+
+/**
  * Service-level driver metadata. Same shape as IDataConnectionDriverMetadataDTO but with the
  * richer discriminated parameter type so consumers get narrowed `parameter.type`.
  */
@@ -87,8 +101,20 @@ export interface IDataConnectionDriverMetadata {
 	name: string;
 	description: string;
 	iconSvg: string;
-	parameters: IDataConnectionParameter[];
+	mechanisms: IDataConnectionMechanism[];
 	supportedLanguageIds: string[];
+}
+
+/**
+ * Resolves the mechanism a profile was configured with. Falls back to the driver's first mechanism
+ * when the id is missing or unknown: profiles persisted before mechanisms existed carry no
+ * mechanismId, and historically a driver had exactly one parameter set, which is now its first
+ * mechanism. Returns undefined only if the driver exposes no mechanisms.
+ * @param metadata The driver metadata to resolve against.
+ * @param mechanismId The profile's mechanism id, or undefined for a pre-mechanisms profile.
+ */
+export function resolveDataConnectionMechanism(metadata: IDataConnectionDriverMetadata, mechanismId: string | undefined): IDataConnectionMechanism | undefined {
+	return metadata.mechanisms.find(_ => _.id === mechanismId) ?? metadata.mechanisms[0];
 }
 
 /**
@@ -114,19 +140,20 @@ export interface IDataConnectionCodeVariant {
 export interface IDataConnectionDriver {
 	readonly id: string;
 	readonly metadata: IDataConnectionDriverMetadata;
-	connect(params: DataConnectionParameterValues): Promise<IDataConnectionHandle>;
+	connect(mechanismId: string, params: DataConnectionParameterValues): Promise<IDataConnectionHandle>;
 
 	/**
-	 * Generates the available connection code variants for the given language using the provided
-	 * parameter values. Callers should only invoke this for drivers that report at least one
-	 * supported language (see {@link IDataConnectionDriverMetadata.supportedLanguageIds}); the
-	 * underlying driver rejects the call when it does not implement code generation. Variants are
-	 * returned in preference order (first is the default); an empty array means code cannot be
-	 * generated from the given parameters.
+	 * Generates the available connection code variants for the given language using the selected
+	 * mechanism and the provided parameter values. Callers should only invoke this for drivers that
+	 * report at least one supported language (see
+	 * {@link IDataConnectionDriverMetadata.supportedLanguageIds}); the underlying driver rejects the
+	 * call when it does not implement code generation. Variants are returned in preference order
+	 * (first is the default); an empty array means code cannot be generated from the given parameters.
+	 * @param mechanismId The id of the mechanism the user selected.
 	 * @param languageId One of the driver's supported language ids.
 	 * @param params The current connection parameter values.
 	 */
-	generateConnectionCode(languageId: string, params: DataConnectionParameterValues): Promise<IDataConnectionCodeVariant[]>;
+	generateConnectionCode(mechanismId: string, languageId: string, params: DataConnectionParameterValues): Promise<IDataConnectionCodeVariant[]>;
 }
 
 /**

--- a/src/vs/workbench/services/positronDataConnections/common/interfaces/positronDataConnectionsService.ts
+++ b/src/vs/workbench/services/positronDataConnections/common/interfaces/positronDataConnectionsService.ts
@@ -71,6 +71,19 @@ export interface IPositronDataConnectionsService extends IDisposable {
 	getProfileSecretIds(id: string): readonly string[];
 
 	/**
+	 * Gets a display-safe, redacted form of a stored secret parameter value, for showing as a
+	 * placeholder when editing an existing connection (e.g. a connection string with its password
+	 * masked). The cleartext value is resolved from secret storage and passed to the driver, which
+	 * performs the format-specific redaction; only the redacted result is returned. The cleartext is
+	 * never exposed to callers.
+	 * @param id The data connection profile id.
+	 * @param parameterId The id of the secret parameter to redact.
+	 * @returns The redacted string, or undefined if there is no stored value or the driver does not
+	 * implement redaction.
+	 */
+	getRedactedParameterValue(id: string, parameterId: string): Promise<string | undefined>;
+
+	/**
 	 * Removes a data connection profile.
 	 * @param id The data connection profile id to remove.
 	 */

--- a/test/e2e/fixtures/test-setup/docker-utils.ts
+++ b/test/e2e/fixtures/test-setup/docker-utils.ts
@@ -81,7 +81,7 @@ export function dockerSettingsOverrides(opts: { useLegacyNotebookEditor?: boolea
 		overrides['positron.notebook.enabled'] = false;
 	}
 	if (opts.enableDataConnections) {
-		overrides['databases.enabled'] = true;
+		overrides['dataConnections.enabled'] = true;
 	}
 	if (opts.enableFoundryAssistant) {
 		Object.assign(overrides, FOUNDRY_ASSISTANT_SETTINGS);

--- a/test/e2e/pages/dataConnections.ts
+++ b/test/e2e/pages/dataConnections.ts
@@ -88,14 +88,17 @@ export class DataConnections {
 	}
 
 	/**
-	 * Fills the connection form fields in the "Configure Database" dialog. Keys are the field
-	 * labels (e.g. 'Connection Name', 'Host', 'Port', 'Database', 'User', 'Password') and values
-	 * are the text to enter.
-	 * @param fields A map of field label to value.
+	 * Fills the connection form fields in the "Configure Database" dialog. Labels (e.g. 'Connection
+	 * Name', 'Host', 'Port', 'Database', 'User', 'Password') map to the text to enter. Pass an object
+	 * for plain string labels, or an array of `[label, value]` entries when a label needs a RegExp
+	 * (e.g. `/^User/` to match a field rendered with an "(optional)" suffix). Note that `exact` is
+	 * ignored for RegExp matchers, so anchor the pattern yourself.
+	 * @param fields A map of field label to value, as an object or an array of entries.
 	 */
-	async fillConnectionInputs(fields: Record<string, string>): Promise<void> {
+	async fillConnectionInputs(fields: Record<string, string> | [string | RegExp, string][]): Promise<void> {
+		const entries = Array.isArray(fields) ? fields : Object.entries(fields);
 		await test.step('Fill connection inputs', async () => {
-			for (const [label, value] of Object.entries(fields)) {
+			for (const [label, value] of entries) {
 				const field = this.dialog.locator(PARAMETER_FIELD).filter({
 					has: this.code.driver.currentPage.getByText(label, { exact: true })
 				});

--- a/test/e2e/pages/dataConnections.ts
+++ b/test/e2e/pages/dataConnections.ts
@@ -7,7 +7,7 @@ import test, { expect, Locator } from '@playwright/test';
 import { Code } from '../infra/code';
 import { QuickAccess } from './quickaccess';
 
-// The focus command for the Data Connections view (gated behind `databases.enabled`).
+// The focus command for the Data Connections view (gated behind `dataConnections.enabled`).
 const DATA_CONNECTIONS_VIEW_FOCUS_COMMAND = 'workbench.panel.positronDataConnections.focus';
 
 // The "Add Data Connection" -> "Configure Data Connection" dialog and its surrounding modal.
@@ -27,7 +27,7 @@ const TREE_WAFFLE = '#data-connection-profiles-list .data-grid-waffle';
 /**
  * Reusable Positron Data Connections panel functionality for tests to leverage.
  *
- * Covers the panel gated behind the `databases.enabled` setting: opening the view, adding a
+ * Covers the panel gated behind the `dataConnections.enabled` setting: opening the view, adding a
  * connection through the new-connection flow (select provider -> configure -> save), and asserting
  * the resulting profile shows up in the tree.
  */
@@ -49,7 +49,7 @@ export class DataConnections {
 	}
 
 	/**
-	 * Focuses the Data Connections view. Requires `databases.enabled` to be true.
+	 * Focuses the Data Connections view. Requires `dataConnections.enabled` to be true.
 	 */
 	async openDataConnectionsView(): Promise<void> {
 		await this.quickaccess.runCommand(DATA_CONNECTIONS_VIEW_FOCUS_COMMAND);

--- a/test/e2e/pages/dataConnections.ts
+++ b/test/e2e/pages/dataConnections.ts
@@ -76,6 +76,18 @@ export class DataConnections {
 	}
 
 	/**
+	 * Selects a connection mechanism in the "Select how to connect" dialog and advances to the
+	 * configure step. This dialog only appears for providers that expose more than one mechanism.
+	 * @param mechanismLabel The label shown on the mechanism card, e.g. 'User & Password'.
+	 */
+	async selectConnectionMechanism(mechanismLabel: string): Promise<void> {
+		await test.step(`Select connection mechanism: ${mechanismLabel}`, async () => {
+			await this.dialog.locator('.mechanism-card').filter({ hasText: mechanismLabel }).click();
+			await this.nextButton.click();
+		});
+	}
+
+	/**
 	 * Fills the connection form fields in the "Configure Database" dialog. Keys are the field
 	 * labels (e.g. 'Connection Name', 'Host', 'Port', 'Database', 'User', 'Password') and values
 	 * are the text to enter.

--- a/test/e2e/pages/dataConnections.ts
+++ b/test/e2e/pages/dataConnections.ts
@@ -10,7 +10,7 @@ import { QuickAccess } from './quickaccess';
 // The focus command for the Data Connections view (gated behind `databases.enabled`).
 const DATA_CONNECTIONS_VIEW_FOCUS_COMMAND = 'workbench.panel.positronDataConnections.focus';
 
-// The "Add Database" / "Configure Database" dialog and its surrounding modal.
+// The "Add Data Connection" -> "Configure Data Connection" dialog and its surrounding modal.
 const MODAL_DIALOG = '.positron-modal-dialog';
 const PARAMETER_FIELD = '.parameter-field';
 const DATA_CONNECTION_ENTRY_ROW = '.data-connection-entry-row';
@@ -65,7 +65,7 @@ export class DataConnections {
 	}
 
 	/**
-	 * Selects a provider in the "Add Database" dialog and advances to the configure step.
+	 * Selects a provider in the "Add Data Connection" dialog and advances to the configure step.
 	 * @param providerName The driver name shown on the provider card, e.g. 'PostgreSQL'.
 	 */
 	async selectProvider(providerName: string): Promise<void> {

--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -120,7 +120,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 				// setting, which requires a reload to take effect. Enable it before the
 				// app starts so no reload is needed. Suites opt in with
 				// `test.use({ enableDataConnections: true })`.
-				await settingsFile.append({ 'databases.enabled': true });
+				await settingsFile.append({ 'dataConnections.enabled': true });
 			}
 
 			if (enableFoundryAssistant) {

--- a/test/e2e/tests/data-connections/postgres.test.ts
+++ b/test/e2e/tests/data-connections/postgres.test.ts
@@ -7,7 +7,7 @@ import { test, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename,
-	// The Data Connections panel is a preview feature gated behind `databases.enabled`. This
+	// The Data Connections panel is a preview feature gated behind `dataConnections.enabled`. This
 	// bakes the setting into the app (and the Workbench/Jupyter containers) at startup, since those
 	// read settings copied in at launch rather than the host settings file written at runtime.
 	enableDataConnections: true,

--- a/test/e2e/tests/data-connections/postgres.test.ts
+++ b/test/e2e/tests/data-connections/postgres.test.ts
@@ -54,7 +54,7 @@ test.describe('Data Connections - Postgres', {
 		await dataConnections.openDataConnectionsView();
 		await dataConnections.clickAddConnection();
 		await dataConnections.selectProvider('PostgreSQL');
-
+		await dataConnections.selectConnectionMechanism('User & Password');
 		await dataConnections.fillConnectionInputs({
 			'Connection Name': connectionName,
 			'Host': host,

--- a/test/e2e/tests/data-connections/postgres.test.ts
+++ b/test/e2e/tests/data-connections/postgres.test.ts
@@ -55,14 +55,14 @@ test.describe('Data Connections - Postgres', {
 		await dataConnections.clickAddConnection();
 		await dataConnections.selectProvider('PostgreSQL');
 		await dataConnections.selectConnectionMechanism('User & Password');
-		await dataConnections.fillConnectionInputs({
-			'Connection Name': connectionName,
-			'Host': host,
-			'Port': port,
-			'Database': database,
-			'User': user,
-			'Password': password,
-		});
+		await dataConnections.fillConnectionInputs([
+			['Connection Name', connectionName],
+			['Host', host],
+			['Port', port],
+			['Database', database],
+			[/^User/, user],
+			[/^Password/, password],
+		]);
 
 		await dataConnections.save();
 		await dataConnections.expectConnectionInTree(connectionName);


### PR DESCRIPTION
### Summary

Adds support for data connection drivers to expose multiple connection mechanisms, with a new dialog step that lets users choose how to connect before configuring parameters. Previously each driver offered a single fixed set of connection parameters; a driver can now declare several mechanisms, each with its own label, description, and parameters, and the new connection flow presents them as selectable cards. The mechanism selector step only appears when a driver exposes more than one mechanism, so single-mechanism drivers are unaffected, and the chosen mechanism is persisted with the connection profile.

The PostgreSQL driver uses this to offer four mechanisms: User & Password (host/port/database with optional credentials), Local Server (No Password) (connect over a local Unix socket as your operating system account, relying on the server's peer or trust authentication), Client Certificate (SSL) (authenticate with a client certificate and key), and Connection String (paste a libpq URL from a database provider). The DuckDB and SQLite drivers also declare their connections through the new mechanism API. Secret parameters such as passwords and connection strings continue to be stored in secret storage rather than plaintext, and the configuration dialog title now reads "Add Data Connection · <Driver>" to make the active driver clear.

This PR also renames the preview setting that gates the feature from `databases.enabled` to `dataConnections.enabled` and updates its description to "Enable the Data Connections panel." If you previously enabled the feature with `databases.enabled`, re-enable it with `dataConnections.enabled` (it remains a preview setting, defaulting to off).

### Screenshots

<!-- Add screenshots of the mechanism selector and the PostgreSQL mechanisms here -->

### Release Notes

#### New Features

- Data connection drivers can now offer multiple connection mechanisms, selectable when creating a connection.
- Added PostgreSQL connection mechanisms for user and password, local server, client certificate, and connection string.

#### Bug Fixes

- N/A

### Validation Steps

@:connections @:duck-db

1. Set `dataConnections.enabled` to `true` and reload, then open the New Data Connection flow and choose PostgreSQL; confirm the mechanism selector step appears with the four mechanisms and the dialog title reads "Add Data Connection · PostgreSQL".
2. Choose User & Password, connect to a local PostgreSQL server, and confirm schema browsing works in the Connections pane.
3. Choose Connection String, paste a `postgresql://user:password@host:5432/database` URL, and confirm the connection succeeds.
4. On macOS or Linux, choose Local Server (No Password) and confirm you can connect to a local server with no password.
5. Confirm DuckDB and SQLite connections still work and skip the selector step (each still exposes a single mechanism, where applicable).
