### PR TITLE
Add a Preview split button with format options to the Quarto editor action bar

### DIFF
--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -98,6 +98,7 @@ export class MenuId {
 	static readonly PositronNotebookKernelSubmenu = new MenuId('PositronNotebookKernelSubmenu');
 	static readonly PositronQuartoKernelSubmenu = new MenuId('PositronQuartoKernelSubmenu');
 	static readonly PositronQuartoEditorActionBarMenu = new MenuId('PositronQuartoEditorActionBarMenu');
+	static readonly PositronQuartoPreviewMenu = new MenuId('PositronQuartoPreviewMenu');
 	static readonly PositronNotebookCellActionBarLeft = new MenuId('PositronNotebookCellActionBarLeft');
 	static readonly PositronNotebookCellActionBarRight = new MenuId('PositronNotebookCellActionBarRight');
 	static readonly PositronNotebookCellActionBarSubmenu = new MenuId('PositronNotebookCellActionBarSubmenu');

--- a/src/vs/workbench/browser/parts/editor/test/browser/editorActionBarFactory.vitest.tsx
+++ b/src/vs/workbench/browser/parts/editor/test/browser/editorActionBarFactory.vitest.tsx
@@ -7,11 +7,15 @@
 
 import { Event } from '../../../../../../base/common/event.js';
 import { URI } from '../../../../../../base/common/uri.js';
+import { ModifierKeyEmitter } from '../../../../../../base/browser/dom.js';
+import { IAction } from '../../../../../../base/common/actions.js';
 import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { IKeybindingService } from '../../../../../../platform/keybinding/common/keybinding.js';
-import { IMenu, IMenuActionOptions, IMenuService } from '../../../../../../platform/actions/common/actions.js';
+import { IMenu, IMenuActionOptions, IMenuService, MenuId, MenuItemAction, SubmenuItemAction } from '../../../../../../platform/actions/common/actions.js';
 import { createTestContainer } from '../../../../../../test/vitest/positronTestContainer.js';
+import { setupRTLRenderer } from '../../../../../../test/vitest/reactTestingLibrary.js';
 import { stubInterface } from '../../../../../../test/vitest/stubInterface.js';
+import { PositronActionBarContextProvider } from '../../../../../../platform/positronActionBar/browser/positronActionBarContext.js';
 import { DiffEditorInput } from '../../../../../common/editor/diffEditorInput.js';
 import { TestEditorInput } from '../../../../../test/browser/workbenchTestServices.js';
 import { IEditorGroupView } from '../../editor.js';
@@ -64,5 +68,117 @@ describe('EditorActionBarFactory', () => {
 		// Every menu read forwards the modified-side URI, never undefined.
 		expect(capturedArgs.length).toBeGreaterThan(0);
 		expect(capturedArgs.every(arg => arg === modified.resource)).toBe(true);
+	});
+});
+
+describe('EditorActionBarFactory split-button dedup', () => {
+	const ctx = createTestContainer().withReactServices().build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
+
+	// ActionBarActionButton lazily creates the process-global ModifierKeyEmitter
+	// singleton on first render; dispose it so the leak tracker stays clean.
+	afterEach(() => ModifierKeyEmitter.disposeInstance());
+
+	// A MenuItemAction for a command id/title. No icon, so the factory renders a
+	// text label (matching how the Quarto Preview primary is registered).
+	const menuItem = (id: string, title: string) =>
+		ctx.instantiationService.createInstance(MenuItemAction, { id, title }, undefined, undefined, undefined, undefined);
+
+	// Render the factory output the way production does: inside the action bar
+	// context provider, with React services from the RTL renderer.
+	const renderActionBar = (actionsByMenu: Map<MenuId, [string, IAction[]][]>) => {
+		const menuService = stubInterface<IMenuService>({
+			createMenu: (id: MenuId) => stubInterface<IMenu>({
+				onDidChange: Event.None,
+				getActions: () => (actionsByMenu.get(id) ?? []) as ReturnType<IMenu['getActions']>,
+				dispose: () => { },
+			}),
+		});
+		const group = stubInterface<IEditorGroupView>({
+			activeEditor: ctx.disposables.add(new TestEditorInput(URI.file('/workspace/report.qmd'), 'test.qmd')),
+			activeEditorPane: undefined,
+			scopedContextKeyService: ctx.get(IContextKeyService),
+			onDidActiveEditorChange: Event.None,
+		});
+		const factory = ctx.disposables.add(new EditorActionBarFactory(
+			group, ctx.get(IContextKeyService), ctx.get(IKeybindingService), menuService,
+		));
+		return rtl.render(
+			<PositronActionBarContextProvider>
+				{factory.create()}
+			</PositronActionBarContextProvider>
+		);
+	};
+
+	// Project the Preview action-bar buttons the same way the DevTools diagnostic
+	// does in the running app: split buttons are a wrapping DIV with a primary +
+	// chevron; plain buttons are a single BUTTON. Filtered to Preview controls so
+	// unrelated buttons (e.g. the always-present "Move into new window") can't
+	// affect the assertion.
+	const previewButtons = (container: HTMLElement) =>
+		// eslint-disable-next-line no-restricted-syntax -- structural split-vs-plain shape has no role/testid; mirrors the app DevTools projection
+		[...container.querySelectorAll('.action-bar-button')].map(el => ({
+			kind: el.tagName === 'DIV' ? 'split' : 'plain',
+			// eslint-disable-next-line no-restricted-syntax -- see above
+			primary: (el.querySelector('.action-bar-button-action-button') ?? el).getAttribute('aria-label'),
+			// eslint-disable-next-line no-restricted-syntax -- see above
+			chevron: el.querySelector('.action-bar-button-drop-down-button')?.getAttribute('aria-label') ?? undefined,
+		})).filter(b => /preview/i.test(b.primary ?? '') || /preview/i.test(b.chevron ?? ''));
+
+	// The Quarto extension contributes `quarto.preview` to editor/title/run
+	// (MenuId.EditorTitleRun), where the factory renders it as a plain button.
+	const extensionPreview = () => new SubmenuItemAction(
+		{ submenu: MenuId.EditorTitleRun, title: 'Run or Debug...', isSplitButton: { togglePrimaryAction: true } },
+		undefined,
+		[menuItem('quarto.preview', 'Preview')],
+	);
+
+	// Positron core contributes a `quarto.preview` + `quarto.previewFormat` split
+	// button to EditorActionsLeft.
+	const corePreviewSplit = () => new SubmenuItemAction(
+		{ submenu: MenuId.PositronQuartoPreviewMenu, title: 'Preview', isSplitButton: true },
+		undefined,
+		[menuItem('quarto.preview', 'Preview'), menuItem('quarto.previewFormat', 'Preview Format...')],
+	);
+
+	it('renders the extension preview alone as a plain button', () => {
+		// Baseline (e.g. a markdown file, where core does not contribute): the
+		// extension's editor/title/run Preview renders as a single plain button.
+		// This is what the dedup below collapses away on a .qmd.
+		const { container } = renderActionBar(new Map<MenuId, [string, IAction[]][]>([
+			[MenuId.EditorTitle, [['navigation', [extensionPreview()]]]],
+		]));
+
+		expect(previewButtons(container)).toMatchInlineSnapshot(`
+			[
+			  {
+			    "chevron": undefined,
+			    "kind": "plain",
+			    "primary": "Preview",
+			  },
+			]
+		`);
+	});
+
+	it('collapses the extension and core quarto.preview into a single split button', () => {
+		// On a .qmd both contribute `quarto.preview`. The factory dedups by command
+		// id, so the result is one split button (the core one, with the format
+		// dropdown), not a duplicate plain "Preview" and not a standalone "Preview
+		// Format..." button. This is the behavior Positron relies on instead of a
+		// Quarto extension change to hide its own button.
+		const { container } = renderActionBar(new Map<MenuId, [string, IAction[]][]>([
+			[MenuId.EditorTitle, [['navigation', [extensionPreview()]]]],
+			[MenuId.EditorActionsLeft, [['navigation', [corePreviewSplit()]]]],
+		]));
+
+		expect(previewButtons(container)).toMatchInlineSnapshot(`
+			[
+			  {
+			    "chevron": "Preview",
+			    "kind": "split",
+			    "primary": "Preview",
+			  },
+			]
+		`);
 	});
 });

--- a/src/vs/workbench/browser/parts/editor/test/browser/editorActionBarFactory.vitest.tsx
+++ b/src/vs/workbench/browser/parts/editor/test/browser/editorActionBarFactory.vitest.tsx
@@ -142,9 +142,8 @@ describe('EditorActionBarFactory split-button dedup', () => {
 	);
 
 	it('renders the extension preview alone as a plain button', () => {
-		// Baseline (e.g. a markdown file, where core does not contribute): the
-		// extension's editor/title/run Preview renders as a single plain button.
-		// This is what the dedup below collapses away on a .qmd.
+		// Control: with only the extension's editor/title/run contribution and no
+		// core split button, the factory renders a single plain Preview button.
 		const { container } = renderActionBar(new Map<MenuId, [string, IAction[]][]>([
 			[MenuId.EditorTitle, [['navigation', [extensionPreview()]]]],
 		]));
@@ -161,11 +160,10 @@ describe('EditorActionBarFactory split-button dedup', () => {
 	});
 
 	it('collapses the extension and core quarto.preview into a single split button', () => {
-		// On a .qmd both contribute `quarto.preview`. The factory dedups by command
-		// id, so the result is one split button (the core one, with the format
-		// dropdown), not a duplicate plain "Preview" and not a standalone "Preview
-		// Format..." button. This is the behavior Positron relies on instead of a
-		// Quarto extension change to hide its own button.
+		// On a document where both contribute the factory dedups by command id,
+		// so the result is one split button (the core one, with the format dropdown),
+		// not a duplicate plain "Preview" and not a standalone "Preview Format..."
+		// button. This is the behavior Positron relies on.
 		const { container } = renderActionBar(new Map<MenuId, [string, IAction[]][]>([
 			[MenuId.EditorTitle, [['navigation', [extensionPreview()]]]],
 			[MenuId.EditorActionsLeft, [['navigation', [corePreviewSplit()]]]],

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoEditorActionBar.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoEditorActionBar.ts
@@ -165,3 +165,53 @@ registerWorkbenchContribution2(
 	QuartoRestartMenuItemController,
 	WorkbenchPhase.AfterRestored,
 );
+
+// --- Preview split button ---------------------------------------------------
+//
+// A dedicated split button for previewing the document. The primary action
+// previews the document's default format; the dropdown opens the extension's
+// "Preview Format..." picker, which lists the formats the document actually
+// supports (the extension enumerates them with `quarto inspect`).
+//
+// This replaces the Quarto extension's own Preview button in Positron. The
+// extension hides its `editor/title/run` button when the
+// `quartoCanUsePositronPreviewSplitButton` context key is set.
+//
+// `isSplitButton: true` (rather than `{ togglePrimaryAction: true }`) keeps
+// "Preview" as the fixed primary; using the dropdown does not change what the
+// button does. The primary menu item below intentionally has NO icon so the
+// editor action bar factory renders the "Preview" text label rather than an
+// icon-only button (see the split-button branch in editorActionBarFactory.tsx).
+
+// Outer submenu: the Preview split button on the editor action bar, just right
+// of the Run All button.
+MenuRegistry.appendMenuItem(MenuId.EditorActionsLeft, {
+	submenu: MenuId.PositronQuartoPreviewMenu,
+	title: localize2('quarto.editorActionBar.preview', "Preview"),
+	group: 'navigation',
+	order: 1,
+	when: QUARTO_LANG_WHEN,
+	isSplitButton: true,
+});
+
+// Primary action: preview the default format. Delegates to the extension's
+// `quarto.preview`. No icon, so the factory renders the "Preview" text label.
+MenuRegistry.appendMenuItem(MenuId.PositronQuartoPreviewMenu, {
+	command: {
+		id: 'quarto.preview',
+		title: localize2('quarto.editorActionBar.preview', "Preview"),
+	},
+	group: 'navigation',
+	order: 0,
+});
+
+// Dropdown: choose a format to preview. Delegates to the extension's
+// `quarto.previewFormat`, which prompts with the document's available formats.
+MenuRegistry.appendMenuItem(MenuId.PositronQuartoPreviewMenu, {
+	command: {
+		id: 'quarto.previewFormat',
+		title: localize2('quarto.editorActionBar.previewFormat', "Preview Format..."),
+	},
+	group: '1_formats',
+	order: 10,
+});

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoEditorActionBar.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoEditorActionBar.ts
@@ -22,6 +22,11 @@ const QUARTO_LANG_WHEN = ContextKeyExpr.or(
 	...QUARTO_LANGUAGE_IDS.map(id => ContextKeyExpr.equals(ResourceContextKey.LangId.key, id))
 );
 
+// Preview is offered more broadly than the other Quarto actions.
+const QUARTO_PREVIEW_LANG_WHEN = ContextKeyExpr.or(
+	...[...QUARTO_LANGUAGE_IDS, 'markdown'].map(id => ContextKeyExpr.equals(ResourceContextKey.LangId.key, id))
+);
+
 // Outer submenu attached to the editor action bar's leftmost slot.
 // Group `navigation` is special-cased to render before `0_preview` (Quarto
 // extension's Render button) and `1_save` (Save button), placing this entry
@@ -173,16 +178,13 @@ registerWorkbenchContribution2(
 // "Preview Format..." picker, which lists the formats the document actually
 // supports (the extension enumerates them with `quarto inspect`).
 //
-// This replaces the Quarto extension's own Preview button in Positron. The
-// extension hides its `editor/title/run` button when the
-// `quartoCanUsePositronPreviewSplitButton` context key is set.
+// The Quarto extension also contributes a `quarto.preview` button to
+// `editor/title/run`. Both reference the same command id, and the editor action
+// bar factory deduplicates by command id.
 //
-// `isSplitButton: true` (rather than `{ togglePrimaryAction: true }`) keeps
-// "Preview" as the fixed primary; using the dropdown does not change what the
-// button does. The primary menu item below intentionally has NO icon so the
-// editor action bar factory renders the "Preview" text label rather than an
-// icon-only button (see the split-button branch in editorActionBarFactory.tsx).
-
+// The primary menu item below intentionally has no icon so the editor action
+// bar factory renders the "Preview" text label rather than an icon-only button
+//
 // Outer submenu: the Preview split button on the editor action bar, just right
 // of the Run All button.
 MenuRegistry.appendMenuItem(MenuId.EditorActionsLeft, {
@@ -190,12 +192,11 @@ MenuRegistry.appendMenuItem(MenuId.EditorActionsLeft, {
 	title: localize2('quarto.editorActionBar.preview', "Preview"),
 	group: 'navigation',
 	order: 1,
-	when: QUARTO_LANG_WHEN,
+	when: QUARTO_PREVIEW_LANG_WHEN,
 	isSplitButton: true,
 });
 
-// Primary action: preview the default format. Delegates to the extension's
-// `quarto.preview`. No icon, so the factory renders the "Preview" text label.
+// Primary action: preview the default format.
 MenuRegistry.appendMenuItem(MenuId.PositronQuartoPreviewMenu, {
 	command: {
 		id: 'quarto.preview',

--- a/test/e2e/pages/editorActionBar.ts
+++ b/test/e2e/pages/editorActionBar.ts
@@ -37,7 +37,11 @@ export class EditorActionBar {
 	 * @param button - Name of the button to click in the editor action bar.
 	 */
 	async clickButton(button: EditorActionBarButton): Promise<void> {
-		const buttonLocator = this.page.getByLabel(button, { exact: true });
+		// Use `.first()` so split buttons resolve to their primary action: the
+		// primary renders before the dropdown chevron, and both carry the same
+		// aria-label (e.g. the Quarto "Preview" split button). For single-element
+		// buttons this is a no-op.
+		const buttonLocator = this.page.getByLabel(button, { exact: true }).first();
 
 		if (button === 'Split Editor Down') {
 			// Special case: "Split Editor Down" requires holding Alt key

--- a/test/e2e/tests/quarto/quarto-python.test.ts
+++ b/test/e2e/tests/quarto/quarto-python.test.ts
@@ -17,7 +17,7 @@ test.describe('Quarto - Python', { tag: [tags.WEB, tags.WIN, tags.QUARTO] }, () 
 
 		// This test verifies basic rendering of report in PDF after user clicks 'Preview'
 		await openFile(join('workspaces', 'quarto_python', 'report.qmd'));
-		await app.code.driver.currentPage.locator('.positron-action-bar').getByRole('button', { name: 'Preview' }).click();
+		await app.workbench.editorActionBar.clickButton('Preview');
 
 		// Viewer tab is targeted by corresponding iframe. It is assumed that the report fully loads once title 'Example Report' appears
 		const title = app.workbench.viewer.getViewerFrame().frameLocator('iframe').getByText('Example Report');

--- a/test/e2e/tests/quarto/quarto-r.test.ts
+++ b/test/e2e/tests/quarto/quarto-r.test.ts
@@ -46,7 +46,7 @@ test.describe('Quarto - R', { tag: [tags.WEB, tags.WIN, tags.QUARTO, tags.ARK] }
 	});
 
 	test('Verify Quarto can generate preview', async function ({ app }) {
-		await app.code.driver.currentPage.getByRole('button', { name: 'Preview' }).click();
+		await app.workbench.editorActionBar.clickButton('Preview');
 		const viewerFrame = app.workbench.viewer.getViewerFrame().frameLocator('iframe');
 
 		// verify preview displays
@@ -55,7 +55,7 @@ test.describe('Quarto - R', { tag: [tags.WEB, tags.WIN, tags.QUARTO, tags.ARK] }
 
 	test('Quarto Shiny App renders correctly', async ({ app, openFile }) => {
 		await openFile(join('workspaces', 'quarto_shiny', 'mini-app.qmd'));
-		await app.code.driver.currentPage.getByRole('button', { name: 'Preview' }).click();
+		await app.workbench.editorActionBar.clickButton('Preview');
 		await app.code.driver.currentPage
 			.frameLocator('iframe[name]')
 			.frameLocator('#active-frame')


### PR DESCRIPTION
Closes #12891

This PR adds a native "Preview" split button to the Quarto editor action bar for `.qmd`, `.Rmd`, and `.md` documents. The primary action previews the document's default format (the same behavior as today's Preview button); the dropdown chevron offers "Preview Format...", which lets you preview the document in a specific format (HTML, PDF, Word, Typst, etc.).

#### Why the format picker is two steps

RStudio's Render menu lists each output format inline, so picking a format is a single click. This new dropdown for Positron instead has one "Preview Format..." item that opens the Quarto extension's existing format picker (a QuickPick), so previewing a non-default format is two steps.

Open the dropdown:

<img width="767" height="434" alt="Screenshot 2026-06-25 at 5 26 09 PM" src="https://github.com/user-attachments/assets/150b8695-ce8f-4e98-82f5-0480a5621024" />

Then pick a format:

<img width="780" height="483" alt="Screenshot 2026-06-25 at 5 26 17 PM" src="https://github.com/user-attachments/assets/3ac24db6-42de-4a22-9c69-6eaa8e8b638a" />

I am advocating that this is the best option for us. Quarto's format space is open-ended and per-document. The set
of formats a document supports comes from its YAML plus Quarto's defaults, and only the extension can really enumerate it (it runs `quarto inspect`). Positron core cannot hold a sensible static format list and stay correct for every document, so I've chosen here to keep core completely format-agnostic and delegate to the command the extension already ships (`quarto.previewFormat`). The tradeoff we accept is the extra step versus RStudio's fixed inline list, in exchange for always offering exactly the formats the document actually supports and keeping all format knowledge in the extension.

The primary is intentionally registered without an icon so the action bar renders the "Preview" text label rather than an icon-only button.

#### Why no extension change

The Quarto extension also contributes a `quarto.preview` action to the editor action bar (via `editor/title/run`). Both that contribution and this PR's split button reference the same command id, and the editor action bar factory
deduplicates by command id. The two contributions collapse into this single split button, with no duplicate plain "Preview" and no standalone "Preview Format..." button. I verified this by inspecting the action bar DOM with the current marketplace extension (v1.133.0 and v1.134.0) installed.

An earlier version of this that I was trying gated the extension's button off in Positron, but that proved unnecessary. Relying on the dedup avoids that, plus the cross-repo release coordination a gate would require. The dedup is the one behavior this feature leans on that lives in shared factory code, so this PR adds a unit test for it to catch any future regression.

### Release Notes

#### New Features

- Added a Preview split button to the Quarto editor action bar, with a dropdown to preview a Quarto document in a specific format (#12891)

#### Bug Fixes

- N/A

### Validation Steps

@:quarto @:editor-action-bar

Unit test (`editorActionBarFactory.vitest.tsx`):

```
npx vitest run src/vs/workbench/browser/parts/editor/test/browser/editorActionBarFactory.vitest.tsx
```

It covers the dedup directly. The extension's `quarto.preview` alone renders a plain Preview button, and the extension plus core contributions collapse into a single split button.

Manual, with any recent version of the Quarto extension installed including the one we bundle:

1. Open a `.qmd` document (and/or `.Rmd` and/or `.md`).
2. Confirm the editor action bar shows a single "Preview" split button (a "Preview" label with a dropdown chevron, just right of "Run All"), with no second plain "Preview" button.
3. Click the primary "Preview" and confirm the document previews in its default format.
4. Click the chevron, choose "Preview Format...", pick a format from the picker, and confirm the document previews in that format.
