### PR TITLE
Filter the Packages pane version picker by Requires-Python and yank status

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
@@ -267,19 +267,19 @@ def test_best_package_url(headers: Dict[str, Any], expected_url: Any) -> None:
         ("not-a-real-spec", True),  # malformed -> conservative, do not hide
     ],
 )
-def test_check_requires_python(spec: str, expected: bool) -> None:  # noqa: FBT001
+def test_check_requires_python(kernel: PositronIPyKernel, spec: str, expected: bool) -> None:  # noqa: FBT001
     """Each spec is evaluated against the running interpreter (any Python 3.x)."""
     from positron.ui import _check_requires_python
 
-    result = _check_requires_python(None, [[spec]])
+    result = _check_requires_python(kernel, [[spec]])
 
     assert result == {spec: expected}
 
 
-def test_check_requires_python_multiple_specs() -> None:
+def test_check_requires_python_multiple_specs(kernel: PositronIPyKernel) -> None:
     from positron.ui import _check_requires_python
 
-    result = _check_requires_python(None, [[">=3.0", ">=99.0"]])
+    result = _check_requires_python(kernel, [[">=3.0", ">=99.0"]])
 
     assert result == {">=3.0": True, ">=99.0": False}
 

--- a/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
@@ -257,6 +257,33 @@ def test_best_package_url(headers: Dict[str, Any], expected_url: Any) -> None:
     assert _best_package_url(_StubDist(**headers)) == expected_url  # type: ignore[arg-type]
 
 
+@pytest.mark.parametrize(
+    ("spec", "expected"),
+    [
+        (">=3.0", True),
+        ("<3.0", False),
+        (">=99.0", False),
+        ("", True),  # empty specifier -> no constraint
+        ("not-a-real-spec", True),  # malformed -> conservative, do not hide
+    ],
+)
+def test_check_requires_python(spec: str, expected: bool) -> None:  # noqa: FBT001
+    """Each spec is evaluated against the running interpreter (any Python 3.x)."""
+    from positron.ui import _check_requires_python
+
+    result = _check_requires_python(None, [[spec]])
+
+    assert result == {spec: expected}
+
+
+def test_check_requires_python_multiple_specs() -> None:
+    from positron.ui import _check_requires_python
+
+    result = _check_requires_python(None, [[">=3.0", ">=99.0"]])
+
+    assert result == {">=3.0": True, ">=99.0": False}
+
+
 def test_is_module_loaded(ui_comm: DummyComm) -> None:
     """Test the `isModuleLoaded` RPC method called from Positron."""
     module = "fallingStars"

--- a/extensions/positron-python/python_files/posit/positron/ui.py
+++ b/extensions/positron-python/python_files/posit/positron/ui.py
@@ -8,6 +8,7 @@ import importlib.metadata
 import inspect
 import logging
 import os
+import platform
 import sys
 import types
 import webbrowser
@@ -16,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Unio
 from urllib.parse import urlparse
 
 from comm.base_comm import BaseComm
+from packaging.specifiers import SpecifierSet
 from packaging.utils import canonicalize_name
 
 from ._vendor.pydantic import BaseModel
@@ -245,11 +247,34 @@ def _get_packages_installed(kernel: "PositronIPyKernel", _params: List[JsonData]
     return sorted(packages_dict.values(), key=lambda p: p["displayName"])
 
 
+# Evaluate Requires-Python specifiers against this kernel's interpreter.
+def _check_requires_python(_kernel: "PositronIPyKernel", params: List[JsonData]) -> JsonData:
+    # params[0] is the list of distinct Requires-Python specifier strings the
+    # extension collected from a package's PyPI files. We answer, for each, whether
+    # this interpreter satisfies it, using the bundled `packaging` (the same PEP 440
+    # implementation pip relies on) against our own version. This keeps PEP 440
+    # semantics in the tool that owns them rather than re-implementing them in TS.
+    specs = params[0] if params else []
+    py_version = platform.python_version()
+    result: Dict[str, JsonData] = {}
+    if isinstance(specs, list):
+        for spec in specs:
+            if not isinstance(spec, str):
+                continue
+            try:
+                result[spec] = SpecifierSet(spec).contains(py_version, prereleases=True)
+            except Exception:
+                # Conservative: an unparseable specifier must not hide a version.
+                result[spec] = True
+    return result
+
+
 _RPC_METHODS: Dict[str, Callable[["PositronIPyKernel", List[JsonData]], Optional[JsonData]]] = {
     "setConsoleWidth": _set_console_width,
     "isModuleLoaded": _is_module_loaded,
     "getLoadedModules": _get_loaded_modules,
     "getPackagesInstalled": _get_packages_installed,
+    "checkRequiresPython": _check_requires_python,
 }
 
 

--- a/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
@@ -135,7 +135,11 @@ export class PipPackageManager implements IPackageManager {
     }
 
     async searchPackageVersions(name: string, token?: vscode.CancellationToken): Promise<string[]> {
-        return searchPyPIVersions(name, token);
+        return searchPyPIVersions(
+            name,
+            (specs) => this._callMethod<Record<string, boolean>>('checkRequiresPython', token, specs),
+            token,
+        );
     }
 
     // =========================================================================

--- a/extensions/positron-python/src/client/positron/packages/pypiSearch.ts
+++ b/extensions/positron-python/src/client/positron/packages/pypiSearch.ts
@@ -169,16 +169,140 @@ export async function searchPyPI(
 }
 
 /**
- * Search PyPI for available versions of a specific package.
+ * A single distribution file as reported by the PyPI simple API. Both
+ * `Requires-Python` and yank status live on the file, not the version.
  */
-export async function searchPyPIVersions(name: string, token?: vscode.CancellationToken): Promise<string[]> {
+interface PyPIFile {
+    filename: string;
+    'requires-python'?: string | null;
+    yanked?: boolean | string;
+}
+
+/** Per-version view aggregated from a package's files. */
+interface VersionFile {
+    /** The file's Requires-Python specifier, or null when unconstrained. */
+    spec: string | null;
+    /** Whether this file is yanked (true, or a string reason, both mean yanked). */
+    yanked: boolean;
+}
+
+/**
+ * Map each file to its version by matching against the authoritative `versions`
+ * list. We look for the version as a delimited token (`-{version}` followed by a
+ * separator or end) and prefer the longest match, so `pkg-1.0.1.tar.gz` maps to
+ * `1.0.1` rather than `1.0`. Files that match no known version are dropped (they
+ * cannot affect filtering, which keeps us conservative).
+ */
+function aggregateFilesByVersion(versions: string[], files: PyPIFile[]): Map<string, VersionFile[]> {
+    const longestFirst = [...versions].sort((a, b) => b.length - a.length);
+    const byVersion = new Map<string, VersionFile[]>();
+    for (const file of files) {
+        const lower = file.filename.toLowerCase();
+        let matched: string | undefined;
+        for (const version of longestFirst) {
+            const token = `-${version.toLowerCase()}`;
+            const idx = lower.indexOf(token);
+            if (idx === -1) {
+                continue;
+            }
+            // The character after the version must be a boundary so that, e.g.,
+            // `-1.0` does not match inside `-1.05`.
+            const after = lower[idx + token.length];
+            if (after === undefined || after === '-' || after === '.' || after === '+') {
+                matched = version;
+                break;
+            }
+        }
+        if (matched === undefined) {
+            continue;
+        }
+        const spec = file['requires-python'] || null;
+        const yanked = file.yanked !== undefined && file.yanked !== false;
+        const list = byVersion.get(matched) ?? [];
+        list.push({ spec, yanked });
+        byVersion.set(matched, list);
+    }
+    return byVersion;
+}
+
+/**
+ * Search PyPI for available versions of a specific package, filtered to those
+ * installable on the active interpreter.
+ *
+ * Versions are dropped when every file is yanked, or (when `resolveSpecs` is
+ * provided) when no non-yanked file's Requires-Python admits the interpreter.
+ * Filtering is conservative: any uncertainty (no file data, no resolver, a
+ * resolver failure, an unmatched filename) keeps the version visible. The
+ * returned list preserves PyPI's original ordering.
+ *
+ * @param name The package name.
+ * @param resolveSpecs Resolves distinct Requires-Python specifiers to whether
+ *   the active interpreter satisfies each. When omitted, Requires-Python is not
+ *   applied (yank filtering still is).
+ * @param token Optional cancellation token.
+ */
+export async function searchPyPIVersions(
+    name: string,
+    resolveSpecs?: (specs: string[]) => Promise<Record<string, boolean>>,
+    token?: vscode.CancellationToken,
+): Promise<string[]> {
     try {
         const response = await fetch(`https://pypi.org/simple/${name}/`, {
             headers: { Accept: 'application/vnd.pypi.simple.v1+json' },
             signal: createAbortSignal(token),
         });
-        const json = (await response.json()) as { versions: string[] };
-        return json.versions;
+        const json = (await response.json()) as { versions?: string[]; files?: PyPIFile[] };
+        const versions = json.versions ?? [];
+        const files = json.files ?? [];
+
+        // Without file data there is nothing to filter on; return as-is.
+        if (files.length === 0) {
+            return versions;
+        }
+
+        const byVersion = aggregateFilesByVersion(versions, files);
+
+        // Resolve Requires-Python for the distinct specifiers, best-effort. A
+        // resolver failure degrades to yank-only filtering rather than breaking
+        // the picker.
+        let specResults: Record<string, boolean> | undefined;
+        if (resolveSpecs) {
+            const distinctSpecs = [
+                ...new Set(
+                    [...byVersion.values()]
+                        .flat()
+                        .map((f) => f.spec)
+                        .filter((s): s is string => s !== null),
+                ),
+            ];
+            if (distinctSpecs.length === 0) {
+                specResults = {};
+            } else {
+                try {
+                    specResults = await resolveSpecs(distinctSpecs);
+                } catch {
+                    specResults = undefined;
+                }
+            }
+        }
+
+        return versions.filter((version) => {
+            const versionFiles = byVersion.get(version);
+            if (!versionFiles || versionFiles.length === 0) {
+                // No matched files -> keep (conservative).
+                return true;
+            }
+            return versionFiles.some((file) => {
+                if (file.yanked) {
+                    return false;
+                }
+                if (!specResults) {
+                    // Requires-Python not applied; a non-yanked file is enough.
+                    return true;
+                }
+                return file.spec === null || specResults[file.spec] === true;
+            });
+        });
     } catch (e) {
         if (e instanceof Error && e.name === 'AbortError') {
             throw new vscode.CancellationError();

--- a/extensions/positron-python/src/client/positron/packages/pypiSearch.ts
+++ b/extensions/positron-python/src/client/positron/packages/pypiSearch.ts
@@ -207,6 +207,10 @@ function aggregateFilesByVersion(versions: string[], files: PyPIFile[]): Map<str
             }
             // The character after the version must be a boundary so that, e.g.,
             // `-1.0` does not match inside `-1.05`.
+            // Only `-`, `.`, `+`, or end-of-string count as version boundaries; any
+            // other character (notably a digit) is not a boundary, so a short version
+            // like `1` cannot spuriously match inside a longer token like `-12.0`.
+            // Note: bare numeric-only versions (e.g. "1") are a known minor limitation.
             const after = lower[idx + token.length];
             if (after === undefined || after === '-' || after === '.' || after === '+') {
                 matched = version;

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -162,7 +162,11 @@ export class UvPackageManager implements IPackageManager {
     }
 
     async searchPackageVersions(name: string, token?: vscode.CancellationToken): Promise<string[]> {
-        return searchPyPIVersions(name, token);
+        return searchPyPIVersions(
+            name,
+            (specs) => this._callMethod<Record<string, boolean>>('checkRequiresPython', token, specs),
+            token,
+        );
     }
 
     // =========================================================================

--- a/extensions/positron-python/src/test/positron/pypiSearch.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/pypiSearch.unit.test.ts
@@ -6,7 +6,7 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
-import { resetPyPIIndexCacheForTests, searchPyPI } from '../../client/positron/packages/pypiSearch';
+import { resetPyPIIndexCacheForTests, searchPyPI, searchPyPIVersions } from '../../client/positron/packages/pypiSearch';
 
 function makeIndexResponse(names: string[]): Response {
     return {
@@ -118,5 +118,159 @@ suite('searchPyPI', () => {
             caught = e;
         }
         expect(caught).to.be.instanceOf(vscode.CancellationError);
+    });
+});
+
+interface FileEntry {
+    filename: string;
+    'requires-python'?: string | null;
+    yanked?: boolean | string;
+}
+
+function makeVersionsResponse(versions: string[], files: FileEntry[]): Response {
+    return {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ versions, files }),
+    } as Response;
+}
+
+suite('searchPyPIVersions', () => {
+    let fetchStub: sinon.SinonStub;
+
+    setup(() => {
+        fetchStub = sinon.stub(global, 'fetch');
+    });
+
+    teardown(() => {
+        sinon.restore();
+    });
+
+    test('excludes versions whose Requires-Python the interpreter does not satisfy', async () => {
+        fetchStub.resolves(
+            makeVersionsResponse(
+                ['1.0', '2.0'],
+                [
+                    { filename: 'pkg-1.0.tar.gz', 'requires-python': '>=3.7' },
+                    { filename: 'pkg-2.0.tar.gz', 'requires-python': '>=3.12' },
+                ],
+            ),
+        );
+
+        const result = await searchPyPIVersions('pkg', async () => ({ '>=3.7': true, '>=3.12': false }));
+
+        expect(result).to.deep.equal(['1.0']);
+    });
+
+    test('keeps a version whose file has no Requires-Python constraint', async () => {
+        fetchStub.resolves(makeVersionsResponse(['1.0'], [{ filename: 'pkg-1.0.tar.gz', 'requires-python': null }]));
+
+        const result = await searchPyPIVersions('pkg', async () => ({}));
+
+        expect(result).to.deep.equal(['1.0']);
+    });
+
+    test('drops a version whose every file is yanked', async () => {
+        fetchStub.resolves(
+            makeVersionsResponse(
+                ['1.0', '2.0'],
+                [
+                    { filename: 'pkg-1.0.tar.gz', yanked: true },
+                    { filename: 'pkg-2.0.tar.gz', yanked: false },
+                ],
+            ),
+        );
+
+        const result = await searchPyPIVersions('pkg', async () => ({}));
+
+        expect(result).to.deep.equal(['2.0']);
+    });
+
+    test('keeps a version when only some of its files are yanked', async () => {
+        fetchStub.resolves(
+            makeVersionsResponse(
+                ['1.0'],
+                [
+                    { filename: 'pkg-1.0-cp39-none-any.whl', yanked: true },
+                    { filename: 'pkg-1.0.tar.gz', yanked: false },
+                ],
+            ),
+        );
+
+        const result = await searchPyPIVersions('pkg', async () => ({}));
+
+        expect(result).to.deep.equal(['1.0']);
+    });
+
+    test('maps files to the longest matching version (1.0 vs 1.0.1)', async () => {
+        fetchStub.resolves(
+            makeVersionsResponse(
+                ['1.0', '1.0.1'],
+                [
+                    { filename: 'pkg-1.0.tar.gz', 'requires-python': '>=3.12' },
+                    { filename: 'pkg-1.0.1.tar.gz', 'requires-python': '>=3.7' },
+                ],
+            ),
+        );
+
+        const result = await searchPyPIVersions('pkg', async () => ({ '>=3.12': false, '>=3.7': true }));
+
+        // 1.0 is excluded by >=3.12; 1.0.1 kept. Proves pkg-1.0.tar.gz mapped to
+        // 1.0, not 1.0.1.
+        expect(result).to.deep.equal(['1.0.1']);
+    });
+
+    test('preserves the original PyPI version order', async () => {
+        fetchStub.resolves(
+            makeVersionsResponse(
+                ['2.0', '1.0'],
+                [
+                    { filename: 'pkg-2.0.tar.gz', 'requires-python': '>=3.7' },
+                    { filename: 'pkg-1.0.tar.gz', 'requires-python': '>=3.7' },
+                ],
+            ),
+        );
+
+        const result = await searchPyPIVersions('pkg', async () => ({ '>=3.7': true }));
+
+        expect(result).to.deep.equal(['2.0', '1.0']);
+    });
+
+    test('applies only yank filtering when no resolver is provided', async () => {
+        fetchStub.resolves(
+            makeVersionsResponse(['1.0'], [{ filename: 'pkg-1.0.tar.gz', 'requires-python': '>=3.99' }]),
+        );
+
+        const result = await searchPyPIVersions('pkg');
+
+        // No resolver -> Requires-Python is not applied; version stays.
+        expect(result).to.deep.equal(['1.0']);
+    });
+
+    test('degrades to yank-only filtering when the resolver rejects', async () => {
+        fetchStub.resolves(
+            makeVersionsResponse(
+                ['1.0', '2.0'],
+                [
+                    { filename: 'pkg-1.0.tar.gz', 'requires-python': '>=3.99' },
+                    { filename: 'pkg-2.0.tar.gz', yanked: true },
+                ],
+            ),
+        );
+
+        const result = await searchPyPIVersions('pkg', async () => {
+            throw new Error('kernel unavailable');
+        });
+
+        // Resolver failed: Requires-Python skipped (1.0 stays), yank still applied (2.0 dropped).
+        expect(result).to.deep.equal(['1.0']);
+    });
+
+    test('returns versions unfiltered when the response has no files', async () => {
+        fetchStub.resolves(makeVersionsResponse(['1.0', '2.0'], []));
+
+        const result = await searchPyPIVersions('pkg', async () => ({}));
+
+        expect(result).to.deep.equal(['1.0', '2.0']);
     });
 });

--- a/extensions/positron-python/src/test/positron/pypiSearch.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/pypiSearch.unit.test.ts
@@ -191,13 +191,13 @@ suite('searchPyPIVersions', () => {
             makeVersionsResponse(
                 ['1.0'],
                 [
-                    { filename: 'pkg-1.0-cp39-none-any.whl', yanked: true },
-                    { filename: 'pkg-1.0.tar.gz', yanked: false },
+                    { filename: 'pkg-1.0-cp39-none-any.whl', yanked: true, 'requires-python': '>=3.12' },
+                    { filename: 'pkg-1.0.tar.gz', yanked: false, 'requires-python': '>=3.7' },
                 ],
             ),
         );
 
-        const result = await searchPyPIVersions('pkg', async () => ({}));
+        const result = await searchPyPIVersions('pkg', async () => ({ '>=3.12': false, '>=3.7': true }));
 
         expect(result).to.deep.equal(['1.0']);
     });


### PR DESCRIPTION
Fixes #14344

The Packages pane version picker (shown when installing or updating a Python package) listed every PyPI version unfiltered, so a user on an older interpreter could pick a version that requires a newer Python and hit a guaranteed install failure (e.g. `numpy 2.4.6` on Python 3.9). This filters the picker to versions installable in the active environment.

### Summary

- A new `checkRequiresPython` kernel RPC (`positron/ui.py`) evaluates `Requires-Python` specifiers against the kernel's own interpreter using the bundled `packaging.specifiers.SpecifierSet` (the same PEP 440 implementation pip relies on). This keeps PEP 440 semantics in the tool that owns them rather than reimplementing them in TypeScript.
- `searchPyPIVersions` (`pypiSearch.ts`) fetches the PyPI simple API, maps files to versions, and drops versions excluded by `Requires-Python` or that are fully yanked. Filtering is conservative: any uncertainty (no file data, a kernel/resolver failure, an unparseable specifier or filename) keeps the version visible, so the picker never hides an installable version or breaks.
- Both the pip and uv version pickers are wired to the new RPC.

Platform/ABI (wheel-tag) filtering is intentionally out of scope and deferred per discussion on the issue.

### Screenshots

These examples demonstrate the validation steps.

Python 3.9.6, latest numpy is 2.0.2:
<img width="823" height="271" alt="Screenshot 2026-06-25 at 11 28 31 PM" src="https://github.com/user-attachments/assets/9416bfef-60a0-4878-875d-41e7f4db7da2" />

Python 3.14.3, latest numpy is 2.5.0:
<img width="761" height="319" alt="Screenshot 2026-06-25 at 11 28 45 PM" src="https://github.com/user-attachments/assets/a7258a0b-930b-4d07-961f-ff1996a0fb99" />

Python 3.9.6, requests==2.3.0 is known to be yanked so it doesn't show up
<img width="329" height="228" alt="Screenshot 2026-06-25 at 11 29 48 PM" src="https://github.com/user-attachments/assets/628f10fd-519b-4939-88ad-bb071b90fe90" />

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Packages pane: the Python version picker now lists only versions installable in the active environment, hiding versions excluded by Requires-Python or that have been yanked (#14344)

### Validation Steps

@:packages-pane

1. Open a Python 3.9 environment.
2. Packages pane > Install package > search `numpy` > open the version picker.
3. Verify versions that require a newer Python (e.g. 2.4.x) are absent, while 3.9-compatible versions remain.
4. Verify a known-yanked release is hidden: search `requests` and confirm version `2.32.0` (yanked on PyPI, but otherwise compatible with Python 3.9) does not appear, while neighboring versions such as `2.31.0` and `2.32.2` do.
5. Sanity check that `requests` still lists many versions (no over-filtering).
