### PR TITLE
Add `render_on_second_notebook` notebook e2e perf metric

### DIFF
--- a/test/e2e/fixtures/test-setup/metrics.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/metrics.fixtures.ts
@@ -8,6 +8,7 @@ import {
 	recordRunCell,
 	recordRenderOnOpen,
 	recordRenderOnNavBack,
+	recordRenderOnColdOpen,
 	type NotebookShortcutOptions,
 } from '../../utils/metrics/metric-notebooks.js';
 import { recordAssistantEval, type AssistantEvalInput } from '../../utils/metrics/metric-assistant.js';
@@ -89,6 +90,13 @@ export function MetricsFixture(app: Application, logger: MultiLogger): RecordMet
 				options?: NotebookShortcutOptions
 			): Promise<MetricResult<T>> => {
 				return recordRenderOnNavBack(operation, targetType, !app.web, logger, options);
+			},
+			renderOnColdOpen: async <T>(
+				operation: () => Promise<T>,
+				targetType: MetricTargetType,
+				options?: NotebookShortcutOptions
+			): Promise<MetricResult<T>> => {
+				return recordRenderOnColdOpen(operation, targetType, !app.web, logger, options);
 			},
 		},
 		sessions: {

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -259,7 +259,28 @@ export class PositronNotebooks extends Notebooks {
 	 * @param path - The path to the notebook to open.
 	 */
 	async openNotebook(path: string): Promise<void> {
+		await this.prepareOpenNotebook(path);
+		await this.confirmOpenNotebook();
+	}
+
+	/**
+	 * Action: Open Quick Access and surface the notebook so a subsequent
+	 * {@link confirmOpenNotebook} call only needs to confirm the selection.
+	 *
+	 * Splitting the open this way lets perf tests exclude Quick Access UI
+	 * latency (Cmd+P, clearEditorHistory, the result-polling retry loop)
+	 * from the measured open + parse + render time.
+	 * @param path - The path to the notebook to open.
+	 */
+	async prepareOpenNotebook(path: string): Promise<void> {
 		await this.quickaccess.openFileQuickAccessAndWait(basename(path), 1);
+	}
+
+	/**
+	 * Action: Confirm the Quick Access selection staged by
+	 * {@link prepareOpenNotebook} and wait for the notebook to render.
+	 */
+	async confirmOpenNotebook(): Promise<void> {
 		await this.quickinput.selectQuickInputElement(0);
 		await this.expectToBeVisible();
 	}

--- a/test/e2e/tests/notebooks-positron/performance/render.test.ts
+++ b/test/e2e/tests/notebooks-positron/performance/render.test.ts
@@ -18,14 +18,25 @@ test.describe('Positron Notebooks: Render', {
 	tag: [tags.WIN, tags.POSITRON_NOTEBOOKS, tags.PERFORMANCE]
 }, () => {
 
-	test.beforeEach(async function ({ app }) {
-		await app.workbench.notebooksPositron.openNotebook(NOTEBOOK_PATH);
+	test('render_on_cold_open: open notebook from disk', async function ({ app, metric }) {
+		const { notebooksPositron } = app.workbench;
+
+		// Open a notebook from disk for the first time.
+		const { duration_ms } = await metric.notebooks.renderOnColdOpen(async () => {
+			await notebooksPositron.openNotebook(NOTEBOOK_PATH);
+			await expect(notebooksPositron.cell.first()).toBeVisible();
+		}, 'file.ipynb', {
+			description: `Open ${NOTEBOOK_FILE} in Positron notebooks`,
+		});
+
+		if (!process.env.CI) { console.log(`[perf] render_on_cold_open: ${duration_ms} ms`); }
 	});
 
 	test('render_on_open: reopen notebook from disk', async function ({ app, hotKeys, runCommand, metric }) {
 		const { notebooksPositron } = app.workbench;
 
-		// Close the notebook tab so we can measure the reopen.
+		// Open and close the notebook tab so we can measure the reopen.
+		await notebooksPositron.openNotebook(NOTEBOOK_PATH);
 		await hotKeys.closeAllEditors();
 
 		// Use "Reopen Closed Editor" to avoid UI latency noise unrelated
@@ -43,7 +54,8 @@ test.describe('Positron Notebooks: Render', {
 	test('render_on_nav_back: switch back to notebook tab', async function ({ app, metric }) {
 		const { notebooksPositron, editors } = app.workbench;
 
-		// Background the notebook by opening a second tab
+		// Open and background the notebook by opening a second tab.
+		await notebooksPositron.openNotebook(NOTEBOOK_PATH);
 		await editors.newUntitledFile();
 
 		const { duration_ms } = await metric.notebooks.renderOnNavBack(async () => {

--- a/test/e2e/tests/notebooks-positron/performance/render.test.ts
+++ b/test/e2e/tests/notebooks-positron/performance/render.test.ts
@@ -21,9 +21,12 @@ test.describe('Positron Notebooks: Render', {
 	test('render_on_cold_open: open notebook from disk', async function ({ app, metric }) {
 		const { notebooksPositron } = app.workbench;
 
-		// Open a notebook from disk for the first time.
+		// Stage Quick Access (Cmd+P, type, wait for results) *outside* the
+		// timed block so the metric only captures the file open + parse + render.
+		await notebooksPositron.prepareOpenNotebook(NOTEBOOK_PATH);
+
 		const { duration_ms } = await metric.notebooks.renderOnColdOpen(async () => {
-			await notebooksPositron.openNotebook(NOTEBOOK_PATH);
+			await notebooksPositron.confirmOpenNotebook();
 			await expect(notebooksPositron.cell.first()).toBeVisible();
 		}, 'file.ipynb', {
 			description: `Open ${NOTEBOOK_FILE} in Positron notebooks`,

--- a/test/e2e/utils/metrics/metric-base.ts
+++ b/test/e2e/utils/metrics/metric-base.ts
@@ -86,6 +86,7 @@ export type RecordMetric = {
 	};
 	notebooks: {
 		runCell: <T>(operation: () => Promise<T>, targetType: MetricTargetType, language?: string, description?: string, context?: MetricContext | (() => Promise<MetricContext>)) => Promise<MetricResult<T>>;
+		renderOnColdOpen: <T>(operation: () => Promise<T>, targetType: MetricTargetType, options?: { description?: string; additionalContext?: MetricContext | (() => Promise<MetricContext>) }) => Promise<MetricResult<T>>;
 		renderOnOpen: <T>(operation: () => Promise<T>, targetType: MetricTargetType, options?: { description?: string; additionalContext?: MetricContext | (() => Promise<MetricContext>) }) => Promise<MetricResult<T>>;
 		renderOnNavBack: <T>(operation: () => Promise<T>, targetType: MetricTargetType, options?: { description?: string; additionalContext?: MetricContext | (() => Promise<MetricContext>) }) => Promise<MetricResult<T>>;
 	};

--- a/test/e2e/utils/metrics/metric-notebooks.ts
+++ b/test/e2e/utils/metrics/metric-notebooks.ts
@@ -15,6 +15,7 @@ export type NotebooksAction =
 	| 'run_cell'
 	| 'open_notebook'
 	| 'save_notebook'
+	| 'render_on_cold_open'
 	| 'render_on_open'
 	| 'render_on_nav_back';
 
@@ -107,6 +108,21 @@ export async function recordRunCell<T>(
 }
 
 /**
+ * Shortcut for recording the time to render a notebook after opening
+ * it from disk for the first time. Measures the notebook open + parse
+ * + render path.
+ */
+export async function recordRenderOnColdOpen<T>(
+	operation: () => Promise<T>,
+	targetType: MetricTargetType,
+	isElectronApp: boolean,
+	logger: MultiLogger,
+	options: NotebookShortcutOptions = {}
+): Promise<MetricResult<T>> {
+	return recordRender('render_on_cold_open', operation, targetType, isElectronApp, logger, options);
+}
+
+/**
  * Shortcut for recording the time to render a notebook after reopening
  * it from disk (tab closed, file reopened). Measures the notebook
  * open + parse + render path, isolated from app-startup noise.
@@ -137,7 +153,7 @@ export async function recordRenderOnNavBack<T>(
 }
 
 async function recordRender<T>(
-	action: 'render_on_open' | 'render_on_nav_back',
+	action: 'render_on_cold_open' | 'render_on_open' | 'render_on_nav_back',
 	operation: () => Promise<T>,
 	targetType: MetricTargetType,
 	isElectronApp: boolean,


### PR DESCRIPTION
Measure render time when opening a second notebook while the first notebook is still open. Establishes a baseline on the current architecture ahead of the cell-editor-reuse refactor (#14264).

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

@:win @:performance