### PR TITLE
PNE: Surface notebook commands via quick pick and Help modal

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/commands/NotebookCommandsAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/commands/NotebookCommandsAction.ts
@@ -99,7 +99,7 @@ function collectNotebookCommandIds(): string[] {
  * item, then emit them under their group's separator in `COMMAND_GROUPS` order,
  * sorted by label within each group, with any leftovers under "Other".
  */
-export function buildNotebookCommandPickItems(keybindingService: IKeybindingService): QuickPickInput<INotebookCommandPickItem>[] {
+function buildNotebookCommandPickItems(keybindingService: IKeybindingService): QuickPickInput<INotebookCommandPickItem>[] {
 	const itemsById = new Map<string, INotebookCommandPickItem>();
 	for (const commandId of collectNotebookCommandIds()) {
 		const command = MenuRegistry.getCommand(commandId);

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/commands/NotebookCommandsAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/commands/NotebookCommandsAction.ts
@@ -12,13 +12,66 @@ import { ContextKeyExpr } from '../../../../../../platform/contextkey/common/con
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
 import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IKeybindingService } from '../../../../../../platform/keybinding/common/keybinding.js';
-import { IQuickInputService, IQuickPickItem } from '../../../../../../platform/quickinput/common/quickInput.js';
+import { IQuickInputService, IQuickPickItem, QuickPickInput } from '../../../../../../platform/quickinput/common/quickInput.js';
 import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../../common/positronNotebookCommon.js';
 
 const SHOW_NOTEBOOK_COMMANDS_ACTION_ID = 'positronNotebook.showCommands';
 
 /** Command id prefix that identifies Positron Notebook commands. */
 const POSITRON_NOTEBOOK_COMMAND_PREFIX = 'positronNotebook.';
+
+/**
+ * Picker-only label overrides. A few commands carry a title tuned for another
+ * surface -- e.g. toolbar buttons sitting next to an icon ("Code", "Markdown")
+ * or a cell submenu ("Add Tag") where the context is implied. Flattened into
+ * this text-only list that context is gone, so we substitute a fuller label
+ * here without disturbing the command's registered title elsewhere.
+ */
+const LABEL_OVERRIDES: Record<string, string> = {
+	'positronNotebook.addCodeCell': localize('positron.notebookCommands.addCodeCell', "Add Code Cell"),
+	'positronNotebook.addMarkdownCell': localize('positron.notebookCommands.addMarkdownCell', "Add Markdown Cell"),
+	'positronNotebook.cell.addTag': localize('positron.notebookCommands.addCellTag', "Add Cell Tag"),
+};
+
+interface ICommandGroup {
+	readonly label: string;
+	readonly ids: readonly string[];
+}
+
+/**
+ * Ordered groups for the picker. A command lands in the first group that lists
+ * it; anything unlisted -- including extension-contributed commands (e.g.
+ * `positronNotebook.export`) and newly-added ones -- falls into a trailing
+ * "Other" group, so the picker never silently drops a command.
+ */
+const COMMAND_GROUPS: readonly ICommandGroup[] = [
+	{
+		label: localize('positron.notebookCommands.group.run', "Run"),
+		ids: ['positronNotebook.runAllCells', 'positronNotebook.stopAllCells', 'positronNotebook.cell.executeSelection', 'positronNotebook.executeSelectionInConsole'],
+	},
+	{
+		label: localize('positron.notebookCommands.group.cells', "Cells"),
+		ids: ['positronNotebook.addCodeCell', 'positronNotebook.addMarkdownCell', 'positronNotebook.cell.addTag', 'positronNotebook.removeAllCellTags', 'positronNotebook.toggleCellTags'],
+	},
+	{
+		label: localize('positron.notebookCommands.group.outputs', "Outputs"),
+		ids: ['positronNotebook.clearAllOutputs'],
+	},
+	{
+		label: localize('positron.notebookCommands.group.kernel', "Kernel"),
+		ids: ['positronNotebook.selectKernel'],
+	},
+	{
+		label: localize('positron.notebookCommands.group.view', "View"),
+		ids: ['positronNotebook.toggleOutline', 'positronNotebook.showConsole'],
+	},
+	{
+		label: localize('positron.notebookCommands.group.assistant', "Assistant"),
+		ids: ['positronNotebook.askAssistant', 'positronNotebook.enableGhostCellSuggestionsForNotebook', 'positronNotebook.showGhostCellInfo'],
+	},
+];
+
+const OTHER_GROUP_LABEL = localize('positron.notebookCommands.group.other', "Other");
 
 interface INotebookCommandPickItem extends IQuickPickItem {
 	readonly commandId: string;
@@ -42,6 +95,48 @@ function collectNotebookCommandIds(): string[] {
 }
 
 /**
+ * Build the grouped picker items: resolve each collected command to a pick
+ * item, then emit them under their group's separator in `COMMAND_GROUPS` order,
+ * sorted by label within each group, with any leftovers under "Other".
+ */
+export function buildNotebookCommandPickItems(keybindingService: IKeybindingService): QuickPickInput<INotebookCommandPickItem>[] {
+	const itemsById = new Map<string, INotebookCommandPickItem>();
+	for (const commandId of collectNotebookCommandIds()) {
+		const command = MenuRegistry.getCommand(commandId);
+		if (!command) {
+			continue;
+		}
+		const label = LABEL_OVERRIDES[commandId]
+			?? (typeof command.title === 'string' ? command.title : command.title.value);
+		itemsById.set(commandId, { commandId, label, keybinding: keybindingService.lookupKeybinding(commandId) });
+	}
+
+	const result: QuickPickInput<INotebookCommandPickItem>[] = [];
+	const emitGroup = (label: string, groupItems: INotebookCommandPickItem[]): void => {
+		if (!groupItems.length) {
+			return;
+		}
+		groupItems.sort((a, b) => a.label.localeCompare(b.label));
+		result.push({ type: 'separator', label });
+		result.push(...groupItems);
+	};
+
+	for (const group of COMMAND_GROUPS) {
+		const groupItems: INotebookCommandPickItem[] = [];
+		for (const id of group.ids) {
+			const item = itemsById.get(id);
+			if (item) {
+				groupItems.push(item);
+				itemsById.delete(id);
+			}
+		}
+		emitGroup(group.label, groupItems);
+	}
+	emitGroup(OTHER_GROUP_LABEL, [...itemsById.values()]);
+	return result;
+}
+
+/**
  * Show a quick pick of Positron Notebook commands and run the selected one.
  * Exported for testing.
  */
@@ -50,25 +145,12 @@ export function showNotebookCommandsQuickPick(
 	commandService: ICommandService,
 	keybindingService: IKeybindingService,
 ): void {
-	const items: INotebookCommandPickItem[] = [];
-	for (const commandId of collectNotebookCommandIds()) {
-		const command = MenuRegistry.getCommand(commandId);
-		if (!command) {
-			continue;
-		}
-		const label = typeof command.title === 'string' ? command.title : command.title.value;
-		items.push({
-			commandId,
-			label,
-			keybinding: keybindingService.lookupKeybinding(commandId),
-		});
-	}
-	items.sort((a, b) => a.label.localeCompare(b.label));
-
 	const store = new DisposableStore();
-	const quickPick = store.add(quickInputService.createQuickPick<INotebookCommandPickItem>());
+	const quickPick = store.add(quickInputService.createQuickPick<INotebookCommandPickItem>({ useSeparators: true }));
+	// Keep our group order; the picker otherwise re-sorts items alphabetically.
+	quickPick.sortByLabel = false;
 	quickPick.placeholder = localize('positron.notebookCommands.placeholder', "Select a notebook command to run");
-	quickPick.items = items;
+	quickPick.items = buildNotebookCommandPickItems(keybindingService);
 	store.add(quickPick.onDidAccept(() => {
 		const selected = quickPick.selectedItems[0];
 		if (selected) {

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/commands/NotebookCommandsAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/commands/NotebookCommandsAction.ts
@@ -5,17 +5,14 @@
 
 import { localize, localize2 } from '../../../../../../nls.js';
 import { Action2, isIMenuItem, MenuId, MenuRegistry, registerAction2 } from '../../../../../../platform/actions/common/actions.js';
-import { Codicon } from '../../../../../../base/common/codicons.js';
 import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
 import { onUnexpectedError } from '../../../../../../base/common/errors.js';
-import { ContextKeyExpr } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
 import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IKeybindingService } from '../../../../../../platform/keybinding/common/keybinding.js';
 import { IQuickInputService, IQuickPickItem, QuickPickInput } from '../../../../../../platform/quickinput/common/quickInput.js';
-import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../../common/positronNotebookCommon.js';
 
-const SHOW_NOTEBOOK_COMMANDS_ACTION_ID = 'positronNotebook.showCommands';
+export const SHOW_NOTEBOOK_COMMANDS_ACTION_ID = 'positronNotebook.showCommands';
 
 /** Command id prefix that identifies Positron Notebook commands. */
 const POSITRON_NOTEBOOK_COMMAND_PREFIX = 'positronNotebook.';
@@ -167,16 +164,10 @@ export class ShowNotebookCommandsAction extends Action2 {
 		super({
 			id: SHOW_NOTEBOOK_COMMANDS_ACTION_ID,
 			title: localize2('positron.notebookCommands.action', 'Show Notebook Commands'),
-			tooltip: localize2('positron.notebookCommands.tooltip', 'Show Notebook Commands'),
-			icon: Codicon.listFlat,
 			f1: true,
 			category: localize2('positronNotebook.category', 'Notebook'),
-			menu: {
-				id: MenuId.EditorActionsLeft,
-				group: 'navigation',
-				order: 56,
-				when: ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID)
-			}
+			// No toolbar menu: this is surfaced from the notebook Help modal
+			// ("See All Commands") and the command palette, not a toolbar button.
 		});
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/commands/NotebookCommandsAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/commands/NotebookCommandsAction.ts
@@ -159,7 +159,7 @@ export function showNotebookCommandsQuickPick(
 	quickPick.show();
 }
 
-export class ShowNotebookCommandsAction extends Action2 {
+class ShowNotebookCommandsAction extends Action2 {
 	constructor() {
 		super({
 			id: SHOW_NOTEBOOK_COMMANDS_ACTION_ID,

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/commands/NotebookCommandsAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/commands/NotebookCommandsAction.ts
@@ -12,7 +12,9 @@ import { ContextKeyExpr, IContextKeyService } from '../../../../../../platform/c
 import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IKeybindingService } from '../../../../../../platform/keybinding/common/keybinding.js';
 import { IQuickInputService, IQuickPickItem, QuickPickInput } from '../../../../../../platform/quickinput/common/quickInput.js';
+import { IEditorService } from '../../../../../services/editor/common/editorService.js';
 import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../../common/positronNotebookCommon.js';
+import { getNotebookInstanceFromActiveEditorPane } from '../../notebookUtils.js';
 
 export const SHOW_NOTEBOOK_COMMANDS_ACTION_ID = 'positronNotebook.showCommands';
 
@@ -167,7 +169,8 @@ export function showNotebookCommandsQuickPick(
 	quickPick.show();
 }
 
-class ShowNotebookCommandsAction extends Action2 {
+/** Exported for testing. */
+export class ShowNotebookCommandsAction extends Action2 {
 	constructor() {
 		super({
 			id: SHOW_NOTEBOOK_COMMANDS_ACTION_ID,
@@ -184,11 +187,19 @@ class ShowNotebookCommandsAction extends Action2 {
 	}
 
 	override run(accessor: ServicesAccessor): void {
+		// Evaluate command `when` clauses through the active notebook's scoped
+		// context key service, the same scope the F1 command palette uses. Editor-
+		// scoped keys -- notably NOTEBOOK_HAS_SOMETHING_RUNNING, which gates the
+		// runAllCells/stopAllCells toggle -- are only visible through that scope;
+		// the global service leaves them at their default, which wrongly hid
+		// "Stop Execution" while a cell ran (and showed it, running all cells, when
+		// idle).
+		const notebook = getNotebookInstanceFromActiveEditorPane(accessor.get(IEditorService));
 		showNotebookCommandsQuickPick(
 			accessor.get(IQuickInputService),
 			accessor.get(ICommandService),
 			accessor.get(IKeybindingService),
-			accessor.get(IContextKeyService),
+			notebook?.scopedContextKeyService ?? accessor.get(IContextKeyService),
 		);
 	}
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/commands/NotebookCommandsAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/commands/NotebookCommandsAction.ts
@@ -8,10 +8,11 @@ import { Action2, isIMenuItem, MenuId, MenuRegistry, registerAction2 } from '../
 import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
 import { onUnexpectedError } from '../../../../../../base/common/errors.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
-import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { ContextKeyExpr, IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IKeybindingService } from '../../../../../../platform/keybinding/common/keybinding.js';
 import { IQuickInputService, IQuickPickItem, QuickPickInput } from '../../../../../../platform/quickinput/common/quickInput.js';
+import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../../common/positronNotebookCommon.js';
 
 export const SHOW_NOTEBOOK_COMMANDS_ACTION_ID = 'positronNotebook.showCommands';
 
@@ -173,6 +174,10 @@ class ShowNotebookCommandsAction extends Action2 {
 			title: localize2('positron.notebookCommands.action', 'Show Notebook Commands'),
 			f1: true,
 			category: localize2('positronNotebook.category', 'Notebook'),
+			// Only meaningful with a notebook active, so gate the palette entry on
+			// it. The Help modal reaches the picker via executeCommand, which
+			// bypasses preconditions, so that path is unaffected.
+			precondition: ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
 			// No toolbar menu: this is surfaced from the notebook Help modal
 			// ("Browse All Notebook Commands...") and the command palette, not a toolbar button.
 		});

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/commands/NotebookCommandsAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/commands/NotebookCommandsAction.ts
@@ -7,6 +7,7 @@ import { localize, localize2 } from '../../../../../../nls.js';
 import { Action2, isIMenuItem, MenuId, MenuRegistry, registerAction2 } from '../../../../../../platform/actions/common/actions.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { onUnexpectedError } from '../../../../../../base/common/errors.js';
 import { ContextKeyExpr } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
 import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
@@ -34,19 +35,15 @@ function collectNotebookCommandIds(): string[] {
 			ids.add(item.command.id);
 		}
 	}
-	// To surface commands the prefix scan misses (e.g. keybinding-only commands
-	// absent from the command palette), add a greenlist of ids here before the
-	// self-exclusion below. Only greenlist commands that actually run from the
-	// Positron Notebook editor: upstream commands gated on `notebookEditorFocused`
-	// won't run, because the editor sets `positronNotebookEditorFocused` instead.
+	// Greenlist additional ids here (before this self-exclusion) if the prefix
+	// scan ever needs to surface palette-absent commands.
 	ids.delete(SHOW_NOTEBOOK_COMMANDS_ACTION_ID);
 	return [...ids];
 }
 
 /**
  * Show a quick pick of Positron Notebook commands and run the selected one.
- * Exported so other entry points (e.g. a future customizations dropdown) can
- * reuse it.
+ * Exported for testing.
  */
 export function showNotebookCommandsQuickPick(
 	quickInputService: IQuickInputService,
@@ -75,7 +72,7 @@ export function showNotebookCommandsQuickPick(
 	store.add(quickPick.onDidAccept(() => {
 		const selected = quickPick.selectedItems[0];
 		if (selected) {
-			commandService.executeCommand(selected.commandId);
+			commandService.executeCommand(selected.commandId).then(undefined, onUnexpectedError);
 		}
 		quickPick.hide();
 	}));

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/commands/NotebookCommandsAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/commands/NotebookCommandsAction.ts
@@ -8,6 +8,7 @@ import { Action2, isIMenuItem, MenuId, MenuRegistry, registerAction2 } from '../
 import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
 import { onUnexpectedError } from '../../../../../../base/common/errors.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
+import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IKeybindingService } from '../../../../../../platform/keybinding/common/keybinding.js';
 import { IQuickInputService, IQuickPickItem, QuickPickInput } from '../../../../../../platform/quickinput/common/quickInput.js';
@@ -76,12 +77,17 @@ interface INotebookCommandPickItem extends IQuickPickItem {
 
 /**
  * Collect the command ids to show: every `positronNotebook.` command in the
- * command palette, minus this picker's own command.
+ * command palette, minus this picker's own command. Commands are filtered by
+ * their palette `when` clause so the picker never surfaces (or runs) a command
+ * the palette itself would hide -- notably AI commands gated on `ai.enabled`,
+ * whose CommandPalette `when` is the action's precondition.
  */
-function collectNotebookCommandIds(): string[] {
+function collectNotebookCommandIds(contextKeyService: IContextKeyService): string[] {
 	const ids = new Set<string>();
 	for (const item of MenuRegistry.getMenuItems(MenuId.CommandPalette)) {
-		if (isIMenuItem(item) && item.command.id.startsWith(POSITRON_NOTEBOOK_COMMAND_PREFIX)) {
+		if (isIMenuItem(item)
+			&& item.command.id.startsWith(POSITRON_NOTEBOOK_COMMAND_PREFIX)
+			&& contextKeyService.contextMatchesRules(item.when)) {
 			ids.add(item.command.id);
 		}
 	}
@@ -96,9 +102,9 @@ function collectNotebookCommandIds(): string[] {
  * item, then emit them under their group's separator in `COMMAND_GROUPS` order,
  * sorted by label within each group, with any leftovers under "Other".
  */
-function buildNotebookCommandPickItems(keybindingService: IKeybindingService): QuickPickInput<INotebookCommandPickItem>[] {
+function buildNotebookCommandPickItems(keybindingService: IKeybindingService, contextKeyService: IContextKeyService): QuickPickInput<INotebookCommandPickItem>[] {
 	const itemsById = new Map<string, INotebookCommandPickItem>();
-	for (const commandId of collectNotebookCommandIds()) {
+	for (const commandId of collectNotebookCommandIds(contextKeyService)) {
 		const command = MenuRegistry.getCommand(commandId);
 		if (!command) {
 			continue;
@@ -141,13 +147,14 @@ export function showNotebookCommandsQuickPick(
 	quickInputService: IQuickInputService,
 	commandService: ICommandService,
 	keybindingService: IKeybindingService,
+	contextKeyService: IContextKeyService,
 ): void {
 	const store = new DisposableStore();
 	const quickPick = store.add(quickInputService.createQuickPick<INotebookCommandPickItem>({ useSeparators: true }));
 	// Keep our group order; the picker otherwise re-sorts items alphabetically.
 	quickPick.sortByLabel = false;
 	quickPick.placeholder = localize('positron.notebookCommands.placeholder', "Select a notebook command to run");
-	quickPick.items = buildNotebookCommandPickItems(keybindingService);
+	quickPick.items = buildNotebookCommandPickItems(keybindingService, contextKeyService);
 	store.add(quickPick.onDidAccept(() => {
 		const selected = quickPick.selectedItems[0];
 		if (selected) {
@@ -176,6 +183,7 @@ class ShowNotebookCommandsAction extends Action2 {
 			accessor.get(IQuickInputService),
 			accessor.get(ICommandService),
 			accessor.get(IKeybindingService),
+			accessor.get(IContextKeyService),
 		);
 	}
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/commands/NotebookCommandsAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/commands/NotebookCommandsAction.ts
@@ -19,29 +19,13 @@ const SHOW_NOTEBOOK_COMMANDS_ACTION_ID = 'positronNotebook.showCommands';
 /** Command id prefix that identifies Positron Notebook commands. */
 const POSITRON_NOTEBOOK_COMMAND_PREFIX = 'positronNotebook.';
 
-/**
- * Extra command ids to surface in the notebook commands picker that the
- * `positronNotebook.` prefix does not auto-include -- commands shared with
- * other editors, or commands that aren't registered in the command palette.
- *
- * Only greenlight commands that actually run from the Positron Notebook editor.
- * Upstream commands gated on the `notebookEditorFocused` context key will NOT
- * run here, because the Positron editor sets `positronNotebookEditorFocused`
- * instead -- prefer Positron's own commands or context-free toggles.
- */
-const GREENLIT_COMMAND_IDS: readonly string[] = [
-	// Positron's own line-numbers toggle: runs in our editor, but is
-	// keybinding-only (Shift+L) and otherwise absent from the command palette.
-	'positronNotebook.toggleLineNumbers',
-];
-
 interface INotebookCommandPickItem extends IQuickPickItem {
 	readonly commandId: string;
 }
 
 /**
  * Collect the command ids to show: every `positronNotebook.` command in the
- * command palette, plus the greenlit ids, minus this picker's own command.
+ * command palette, minus this picker's own command.
  */
 function collectNotebookCommandIds(): string[] {
 	const ids = new Set<string>();
@@ -50,9 +34,11 @@ function collectNotebookCommandIds(): string[] {
 			ids.add(item.command.id);
 		}
 	}
-	for (const id of GREENLIT_COMMAND_IDS) {
-		ids.add(id);
-	}
+	// To surface commands the prefix scan misses (e.g. keybinding-only commands
+	// absent from the command palette), add a greenlist of ids here before the
+	// self-exclusion below. Only greenlist commands that actually run from the
+	// Positron Notebook editor: upstream commands gated on `notebookEditorFocused`
+	// won't run, because the editor sets `positronNotebookEditorFocused` instead.
 	ids.delete(SHOW_NOTEBOOK_COMMANDS_ACTION_ID);
 	return [...ids];
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/commands/NotebookCommandsAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/commands/NotebookCommandsAction.ts
@@ -1,0 +1,126 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize, localize2 } from '../../../../../../nls.js';
+import { Action2, isIMenuItem, MenuId, MenuRegistry, registerAction2 } from '../../../../../../platform/actions/common/actions.js';
+import { Codicon } from '../../../../../../base/common/codicons.js';
+import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { ContextKeyExpr } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
+import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { IKeybindingService } from '../../../../../../platform/keybinding/common/keybinding.js';
+import { IQuickInputService, IQuickPickItem } from '../../../../../../platform/quickinput/common/quickInput.js';
+import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../../common/positronNotebookCommon.js';
+
+const SHOW_NOTEBOOK_COMMANDS_ACTION_ID = 'positronNotebook.showCommands';
+
+/** Command id prefix that identifies Positron Notebook commands. */
+const POSITRON_NOTEBOOK_COMMAND_PREFIX = 'positronNotebook.';
+
+/**
+ * Extra command ids to surface in the notebook commands picker that the
+ * `positronNotebook.` prefix does not auto-include -- commands shared with
+ * other editors, or commands that aren't registered in the command palette.
+ *
+ * Only greenlight commands that actually run from the Positron Notebook editor.
+ * Upstream commands gated on the `notebookEditorFocused` context key will NOT
+ * run here, because the Positron editor sets `positronNotebookEditorFocused`
+ * instead -- prefer Positron's own commands or context-free toggles.
+ */
+const GREENLIT_COMMAND_IDS: readonly string[] = [
+	// Positron's own line-numbers toggle: runs in our editor, but is
+	// keybinding-only (Shift+L) and otherwise absent from the command palette.
+	'positronNotebook.toggleLineNumbers',
+];
+
+interface INotebookCommandPickItem extends IQuickPickItem {
+	readonly commandId: string;
+}
+
+/**
+ * Collect the command ids to show: every `positronNotebook.` command in the
+ * command palette, plus the greenlit ids, minus this picker's own command.
+ */
+function collectNotebookCommandIds(): string[] {
+	const ids = new Set<string>();
+	for (const item of MenuRegistry.getMenuItems(MenuId.CommandPalette)) {
+		if (isIMenuItem(item) && item.command.id.startsWith(POSITRON_NOTEBOOK_COMMAND_PREFIX)) {
+			ids.add(item.command.id);
+		}
+	}
+	for (const id of GREENLIT_COMMAND_IDS) {
+		ids.add(id);
+	}
+	ids.delete(SHOW_NOTEBOOK_COMMANDS_ACTION_ID);
+	return [...ids];
+}
+
+/**
+ * Show a quick pick of Positron Notebook commands and run the selected one.
+ * Exported so other entry points (e.g. a future customizations dropdown) can
+ * reuse it.
+ */
+export function showNotebookCommandsQuickPick(
+	quickInputService: IQuickInputService,
+	commandService: ICommandService,
+	keybindingService: IKeybindingService,
+): void {
+	const items: INotebookCommandPickItem[] = [];
+	for (const commandId of collectNotebookCommandIds()) {
+		const command = MenuRegistry.getCommand(commandId);
+		if (!command) {
+			continue;
+		}
+		const label = typeof command.title === 'string' ? command.title : command.title.value;
+		items.push({
+			commandId,
+			label,
+			keybinding: keybindingService.lookupKeybinding(commandId),
+		});
+	}
+	items.sort((a, b) => a.label.localeCompare(b.label));
+
+	const store = new DisposableStore();
+	const quickPick = store.add(quickInputService.createQuickPick<INotebookCommandPickItem>());
+	quickPick.placeholder = localize('positron.notebookCommands.placeholder', "Select a notebook command to run");
+	quickPick.items = items;
+	store.add(quickPick.onDidAccept(() => {
+		const selected = quickPick.selectedItems[0];
+		if (selected) {
+			commandService.executeCommand(selected.commandId);
+		}
+		quickPick.hide();
+	}));
+	store.add(quickPick.onDidHide(() => store.dispose()));
+	quickPick.show();
+}
+
+export class ShowNotebookCommandsAction extends Action2 {
+	constructor() {
+		super({
+			id: SHOW_NOTEBOOK_COMMANDS_ACTION_ID,
+			title: localize2('positron.notebookCommands.action', 'Show Notebook Commands'),
+			tooltip: localize2('positron.notebookCommands.tooltip', 'Show Notebook Commands'),
+			icon: Codicon.listFlat,
+			f1: true,
+			category: localize2('positronNotebook.category', 'Notebook'),
+			menu: {
+				id: MenuId.EditorActionsLeft,
+				group: 'navigation',
+				order: 56,
+				when: ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID)
+			}
+		});
+	}
+
+	override run(accessor: ServicesAccessor): void {
+		showNotebookCommandsQuickPick(
+			accessor.get(IQuickInputService),
+			accessor.get(ICommandService),
+			accessor.get(IKeybindingService),
+		);
+	}
+}
+registerAction2(ShowNotebookCommandsAction);

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/commands/NotebookCommandsAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/commands/NotebookCommandsAction.ts
@@ -167,7 +167,7 @@ export class ShowNotebookCommandsAction extends Action2 {
 			f1: true,
 			category: localize2('positronNotebook.category', 'Notebook'),
 			// No toolbar menu: this is surfaced from the notebook Help modal
-			// ("See All Commands") and the command palette, not a toolbar button.
+			// ("Browse All Notebook Commands...") and the command palette, not a toolbar button.
 		});
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpAction.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpAction.tsx
@@ -17,6 +17,7 @@ import { PositronModalDialogReactRenderer } from '../../../../../../base/browser
 import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../../common/positronNotebookCommon.js';
 import { NotebookContextKeys } from '../../../common/notebookContextKeys.js';
 import { NotebookHelpPanel, resolveShortcutBindings } from './NotebookHelpPanel.js';
+import { SHOW_NOTEBOOK_COMMANDS_ACTION_ID } from '../commands/NotebookCommandsAction.js';
 
 const NOTEBOOK_HELP_ACTION_ID = 'positronNotebook.showKeyboardShortcuts';
 
@@ -24,9 +25,9 @@ registerAction2(class NotebookShowKeyboardShortcutsAction extends Action2 {
 	constructor() {
 		super({
 			id: NOTEBOOK_HELP_ACTION_ID,
-			title: localize2('positron.notebookHelp.action', 'Keyboard Shortcuts'),
-			tooltip: localize2('positron.notebookHelp.tooltip', 'Show Notebook Keyboard Shortcuts'),
-			icon: Codicon.keyboard,
+			title: localize2('positron.notebookHelp.action', 'Help'),
+			tooltip: localize2('positron.notebookHelp.tooltip', 'Show Notebook Help'),
+			icon: Codicon.question,
 			f1: true,
 			category: localize2('positronNotebook.category', 'Notebook'),
 			keybinding: {
@@ -62,6 +63,9 @@ registerAction2(class NotebookShowKeyboardShortcutsAction extends Action2 {
 				resolvedBindings={resolvedBindings}
 				onOpenAllShortcuts={() => {
 					commandService.executeCommand('workbench.action.openGlobalKeybindings', 'positronNotebook.');
+				}}
+				onSeeAllCommands={() => {
+					commandService.executeCommand(SHOW_NOTEBOOK_COMMANDS_ACTION_ID);
 				}}
 			/>
 		);

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpPanel.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpPanel.css
@@ -59,6 +59,23 @@
 	font-size: 11px;
 }
 
+.notebook-help-panel .notebook-help-command-row {
+	display: block;
+	width: 100%;
+	text-align: left;
+	background: none;
+	border: none;
+	color: var(--vscode-textLink-foreground);
+	font-size: 13px;
+	cursor: pointer;
+	padding: 4px 0;
+}
+
+.notebook-help-panel .notebook-help-command-row:hover {
+	color: var(--vscode-textLink-activeForeground);
+	text-decoration: underline;
+}
+
 .notebook-help-panel .notebook-help-all-shortcuts {
 	text-align: center;
 	padding-top: 4px;

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpPanel.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpPanel.css
@@ -13,6 +13,13 @@
 }
 
 .notebook-help-panel h2 {
+	font-size: 15px;
+	font-weight: 600;
+	color: var(--vscode-foreground);
+	margin: 0;
+}
+
+.notebook-help-panel h3 {
 	font-size: 12px;
 	font-weight: 600;
 	text-transform: uppercase;
@@ -21,6 +28,12 @@
 	margin: 0 0 8px 0;
 	padding-bottom: 4px;
 	border-bottom: 1px solid var(--vscode-widget-border);
+}
+
+.notebook-help-panel .notebook-help-shortcuts {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
 }
 
 .notebook-help-panel .shortcut-grid {
@@ -59,21 +72,10 @@
 	font-size: 11px;
 }
 
-.notebook-help-panel .notebook-help-command-row {
-	display: block;
-	width: 100%;
-	text-align: left;
-	background: none;
-	border: none;
-	color: var(--vscode-textLink-foreground);
-	font-size: 13px;
-	cursor: pointer;
-	padding: 4px 0;
-}
-
-.notebook-help-panel .notebook-help-command-row:hover {
-	color: var(--vscode-textLink-activeForeground);
-	text-decoration: underline;
+.notebook-help-panel .notebook-help-browse-commands {
+	text-align: center;
+	padding-bottom: 4px;
+	border-bottom: 1px solid var(--vscode-widget-border);
 }
 
 .notebook-help-panel .notebook-help-all-shortcuts {
@@ -82,7 +84,7 @@
 	border-top: 1px solid var(--vscode-widget-border);
 }
 
-.notebook-help-panel .all-shortcuts-link {
+.notebook-help-panel .notebook-help-link {
 	background: none;
 	border: none;
 	color: var(--vscode-textLink-foreground);
@@ -91,7 +93,7 @@
 	padding: 4px 8px;
 }
 
-.notebook-help-panel .all-shortcuts-link:hover {
+.notebook-help-panel .notebook-help-link:hover {
 	color: var(--vscode-textLink-activeForeground);
 	text-decoration: underline;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpPanel.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpPanel.tsx
@@ -100,6 +100,7 @@ interface NotebookHelpPanelProps {
 	renderer: PositronModalDialogReactRenderer;
 	resolvedBindings: ResolvedBindingsMap;
 	onOpenAllShortcuts: () => void;
+	onSeeAllCommands: () => void;
 }
 
 function getChordKeys(chord: ResolvedChord): string[] {
@@ -141,11 +142,17 @@ function KeybindingDisplay({ commandId, resolvedBindings }: { commandId: string;
 	return renderKeybinding(keybinding);
 }
 
-export function NotebookHelpPanel({ renderer, resolvedBindings, onOpenAllShortcuts }: NotebookHelpPanelProps): ReactElement {
+export function NotebookHelpPanel({ renderer, resolvedBindings, onOpenAllShortcuts, onSeeAllCommands }: NotebookHelpPanelProps): ReactElement {
 	return (
 		<PositronDynamicModalDialog
 			content={
 				<div className='notebook-help-panel'>
+					<div>
+						<h2>{localize('positron.notebookHelp.section.commands', 'See All Commands')}</h2>
+						<button className='notebook-help-command-row' onClick={() => { renderer.dispose(); onSeeAllCommands(); }}>
+							{localize('positron.notebookHelp.browseCommands', 'Browse all notebook commands...')}
+						</button>
+					</div>
 					{SHORTCUT_SECTIONS.map(section => (
 						<div key={section.title}>
 							<h2>{section.title}</h2>
@@ -173,7 +180,7 @@ export function NotebookHelpPanel({ renderer, resolvedBindings, onOpenAllShortcu
 				<OneButtonFooter buttonTitle={localize('positron.notebookHelp.close', 'Close')} onButton={() => renderer.dispose()} />
 			}
 			renderer={renderer}
-			title={localize('positron.notebookHelp.title', 'Notebook Keyboard Shortcuts')}
+			title={localize('positron.notebookHelp.title', 'Notebook Help')}
 			width={500}
 			onSubmit={() => renderer.dispose()}
 		/>

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpPanel.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpPanel.tsx
@@ -147,29 +147,31 @@ export function NotebookHelpPanel({ renderer, resolvedBindings, onOpenAllShortcu
 		<PositronDynamicModalDialog
 			content={
 				<div className='notebook-help-panel'>
-					<div>
-						<h2>{localize('positron.notebookHelp.section.commands', 'See All Commands')}</h2>
-						<button className='notebook-help-command-row' onClick={() => { renderer.dispose(); onSeeAllCommands(); }}>
-							{localize('positron.notebookHelp.browseCommands', 'Browse all notebook commands...')}
+					<div className='notebook-help-browse-commands'>
+						<button className='notebook-help-link' type='button' onClick={() => { renderer.dispose(); onSeeAllCommands(); }}>
+							{localize('positron.notebookHelp.browseCommands', 'Browse All Notebook Commands...')}
 						</button>
 					</div>
-					{SHORTCUT_SECTIONS.map(section => (
-						<div key={section.title}>
-							<h2>{section.title}</h2>
-							<div className='shortcut-grid'>
-								{section.shortcuts.map(shortcut => (
-									<div key={shortcut.commandId} className='shortcut-row'>
-										<span className='shortcut-label'>{shortcut.label}</span>
-										<span className='shortcut-keys'>
-											<KeybindingDisplay commandId={shortcut.commandId} resolvedBindings={resolvedBindings} />
-										</span>
-									</div>
-								))}
+					<div className='notebook-help-shortcuts'>
+						<h2>{localize('positron.notebookHelp.keyboardShortcuts', 'Keyboard Shortcuts')}</h2>
+						{SHORTCUT_SECTIONS.map(section => (
+							<div key={section.title}>
+								<h3>{section.title}</h3>
+								<div className='shortcut-grid'>
+									{section.shortcuts.map(shortcut => (
+										<div key={shortcut.commandId} className='shortcut-row'>
+											<span className='shortcut-label'>{shortcut.label}</span>
+											<span className='shortcut-keys'>
+												<KeybindingDisplay commandId={shortcut.commandId} resolvedBindings={resolvedBindings} />
+											</span>
+										</div>
+									))}
+								</div>
 							</div>
-						</div>
-					))}
+						))}
+					</div>
 					<div className='notebook-help-all-shortcuts'>
-						<button className='all-shortcuts-link' type='button' onClick={() => { renderer.dispose(); onOpenAllShortcuts(); }}>
+						<button className='notebook-help-link' type='button' onClick={() => { renderer.dispose(); onOpenAllShortcuts(); }}>
 							{localize('positron.notebookHelp.allShortcuts', 'View All Notebook Keyboard Shortcuts...')}
 						</button>
 					</div>

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -2192,7 +2192,7 @@ export class RunAllCellsAction extends NotebookAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.runAllCells',
-			title: localize2('runAllCells', 'Run All'),
+			title: localize2('runAllCells', 'Run All Cells'),
 			icon: ThemeIcon.fromId('notebook-execute-all'),
 			f1: true,
 			category: POSITRON_NOTEBOOK_CATEGORY,
@@ -2230,7 +2230,7 @@ registerAction2(class extends NotebookAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.stopAllCells',
-			title: localize2('stopAllCells', 'Stop'),
+			title: localize2('stopAllCells', 'Stop Execution'),
 			icon: ThemeIcon.fromId('primitive-square'),
 			f1: true,
 			category: POSITRON_NOTEBOOK_CATEGORY,
@@ -2271,7 +2271,7 @@ export class ClearAllOutputsAction extends NotebookAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.clearAllOutputs',
-			title: localize2('clearAllOutputs', 'Clear Outputs'),
+			title: localize2('clearAllOutputs', 'Clear All Outputs'),
 			icon: ThemeIcon.fromId('clear-all'),
 			f1: true,
 			category: POSITRON_NOTEBOOK_CATEGORY,

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -9,6 +9,7 @@ import './contrib/assistant/positronNotebookAssistant.contribution.js';
 import './contrib/ghostCell/positronNotebookGhostCell.contribution.js';
 import './contrib/outline/positronNotebookOutline.contribution.js';
 import './contrib/help/NotebookHelpAction.js';
+import './contrib/commands/NotebookCommandsAction.js';
 
 // Self-registering Action2 contributions
 import './notebookCells/InlineDataExplorerActions.js';

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -2196,6 +2196,13 @@ export class RunAllCellsAction extends NotebookAction2 {
 			icon: ThemeIcon.fromId('notebook-execute-all'),
 			f1: true,
 			category: POSITRON_NOTEBOOK_CATEGORY,
+			// Mirror the toolbar `when` so the command palette and the notebook
+			// command picker only surface this while nothing is running, matching
+			// the run/stop toolbar toggle (stopAllCells gates on the inverse).
+			precondition: ContextKeyExpr.and(
+				ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
+				NOTEBOOK_HAS_SOMETHING_RUNNING.toNegated()
+			),
 			positronActionBarOptions: {
 				controlType: 'button',
 				displayTitle: false
@@ -2234,6 +2241,15 @@ registerAction2(class extends NotebookAction2 {
 			icon: ThemeIcon.fromId('primitive-square'),
 			f1: true,
 			category: POSITRON_NOTEBOOK_CATEGORY,
+			// Mirror the toolbar `when` so the command palette and the notebook
+			// command picker only surface this while something is running. Without
+			// it the picker showed "Stop Execution" when idle, and selecting it ran
+			// all cells (runNotebookAction delegates to runAllCells, which only
+			// cancels when there are live executions to see).
+			precondition: ContextKeyExpr.and(
+				ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
+				NOTEBOOK_HAS_SOMETHING_RUNNING
+			),
 			positronActionBarOptions: {
 				controlType: 'button',
 				displayTitle: false

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCommandsQuickPick.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCommandsQuickPick.vitest.ts
@@ -8,6 +8,7 @@
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { MenuId, MenuRegistry } from '../../../../../platform/actions/common/actions.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { ContextKeyExpr, ContextKeyExpression, IContext, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
 import { IQuickInputService, IQuickPickItem } from '../../../../../platform/quickinput/common/quickInput.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
@@ -25,12 +26,23 @@ describe('showNotebookCommandsQuickPick', () => {
 	let pick: TestQuickPick<ICommandPickItem>;
 	const executeCommand = vi.fn(() => Promise.resolve(undefined));
 
+	// Drives the picker's palette-`when` filtering: contextMatchesRules evaluates
+	// each item's clause against these values, so a test can flip a key (e.g.
+	// ai.enabled) and assert a gated command appears or hides.
+	const contextValues = new Map<string, unknown>();
+	const testContext: IContext = {
+		getValue: <T,>(key: string): T | undefined => contextValues.get(key) as T | undefined,
+	};
+
 	const ctx = createTestContainer()
 		.stub(IQuickInputService, stubInterface<IQuickInputService>({
 			createQuickPick: (() => pick.asQuickPick()) as IQuickInputService['createQuickPick'],
 		}))
 		.stub(ICommandService, { executeCommand })
 		.stub(IKeybindingService, { lookupKeybinding: () => undefined })
+		.stub(IContextKeyService, stubInterface<IContextKeyService>({
+			contextMatchesRules: (rules?: ContextKeyExpression) => rules ? rules.evaluate(testContext) : true,
+		}))
 		.build();
 
 	let registrations: DisposableStore;
@@ -38,6 +50,7 @@ describe('showNotebookCommandsQuickPick', () => {
 	beforeEach(() => {
 		pick = ctx.disposables.add(new TestQuickPick<ICommandPickItem>());
 		registrations = new DisposableStore();
+		contextValues.clear();
 		// A palette command under the positronNotebook. prefix -> included.
 		register('positronNotebook.testAuto', 'Test Auto Command');
 		// A palette command without the prefix -> excluded.
@@ -53,13 +66,14 @@ describe('showNotebookCommandsQuickPick', () => {
 			ctx.get(IQuickInputService),
 			ctx.get(ICommandService),
 			ctx.get(IKeybindingService),
+			ctx.get(IContextKeyService),
 		);
 	}
 
-	/** Register a palette command under the test's lifecycle. */
-	function register(id: string, title: string): void {
+	/** Register a palette command under the test's lifecycle, optionally gated by a `when`. */
+	function register(id: string, title: string, when?: ContextKeyExpression): void {
 		registrations.add(MenuRegistry.addCommand({ id, title }));
-		registrations.add(MenuRegistry.appendMenuItem(MenuId.CommandPalette, { command: { id, title } }));
+		registrations.add(MenuRegistry.appendMenuItem(MenuId.CommandPalette, { command: { id, title }, when }));
 	}
 
 	function items(): ICommandPickItem[] {
@@ -87,6 +101,22 @@ describe('showNotebookCommandsQuickPick', () => {
 		expect(ids).toContain('positronNotebook.testAuto');
 		expect(ids).not.toContain('notebook.testOther');
 		pick.cancel(); // close the picker so its DisposableStore is released
+	});
+
+	it('hides a palette command whose `when` is unsatisfied (e.g. ai.enabled off)', () => {
+		register('positronNotebook.testGated', 'Gated Command', ContextKeyExpr.has('config.ai.enabled'));
+		contextValues.set('config.ai.enabled', false);
+		run();
+		expect(items().map(i => i.commandId)).not.toContain('positronNotebook.testGated');
+		pick.cancel();
+	});
+
+	it('shows the same command once its `when` is satisfied', () => {
+		register('positronNotebook.testGated', 'Gated Command', ContextKeyExpr.has('config.ai.enabled'));
+		contextValues.set('config.ai.enabled', true);
+		run();
+		expect(items().map(i => i.commandId)).toContain('positronNotebook.testGated');
+		pick.cancel();
 	});
 
 	it('excludes the picker\'s own command', () => {

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCommandsQuickPick.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCommandsQuickPick.vitest.ts
@@ -1,0 +1,80 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { MenuId, MenuRegistry } from '../../../../../platform/actions/common/actions.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
+import { IQuickInputService, IQuickPickItem } from '../../../../../platform/quickinput/common/quickInput.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { TestQuickPick } from '../../../../../test/vitest/testQuickPick.js';
+import { showNotebookCommandsQuickPick } from '../../browser/contrib/commands/NotebookCommandsAction.js';
+
+interface ICommandPickItem extends IQuickPickItem {
+	readonly commandId: string;
+}
+
+describe('showNotebookCommandsQuickPick', () => {
+	// Reassigned each test; the IQuickInputService stub captures it by closure
+	// so createQuickPick() returns the current double.
+	let pick: TestQuickPick<ICommandPickItem>;
+	const executeCommand = vi.fn();
+
+	const ctx = createTestContainer()
+		.stub(IQuickInputService, stubInterface<IQuickInputService>({
+			createQuickPick: (() => pick.asQuickPick()) as IQuickInputService['createQuickPick'],
+		}))
+		.stub(ICommandService, { executeCommand })
+		.stub(IKeybindingService, { lookupKeybinding: () => undefined })
+		.build();
+
+	let registrations: DisposableStore;
+
+	beforeEach(() => {
+		pick = ctx.disposables.add(new TestQuickPick<ICommandPickItem>());
+		registrations = new DisposableStore();
+		// A palette command under the positronNotebook. prefix -> auto-included.
+		registrations.add(MenuRegistry.addCommand({ id: 'positronNotebook.testAuto', title: 'Test Auto Command' }));
+		registrations.add(MenuRegistry.appendMenuItem(MenuId.CommandPalette, { command: { id: 'positronNotebook.testAuto', title: 'Test Auto Command' } }));
+		// The greenlit command: registered but NOT in the command palette, so it
+		// can only appear via the greenlist.
+		registrations.add(MenuRegistry.addCommand({ id: 'positronNotebook.toggleLineNumbers', title: 'Toggle Line Numbers' }));
+	});
+
+	afterEach(() => {
+		registrations.dispose();
+	});
+
+	function run(): void {
+		showNotebookCommandsQuickPick(
+			ctx.get(IQuickInputService),
+			ctx.get(ICommandService),
+			ctx.get(IKeybindingService),
+		);
+	}
+
+	function items(): ICommandPickItem[] {
+		return pick.items.filter((i): i is ICommandPickItem => i.type !== 'separator');
+	}
+
+	it('lists prefixed palette commands and greenlit commands', () => {
+		run();
+		const ids = items().map(i => i.commandId);
+		expect(ids).toContain('positronNotebook.testAuto');
+		expect(ids).toContain('positronNotebook.toggleLineNumbers');
+		pick.cancel(); // close the picker so its DisposableStore is released
+	});
+
+	it('runs the selected command on accept', () => {
+		run();
+		const item = items().find(i => i.commandId === 'positronNotebook.testAuto')!;
+		pick.accept(item);
+		expect(executeCommand).toHaveBeenCalledTimes(1);
+		expect(executeCommand).toHaveBeenCalledWith('positronNotebook.testAuto');
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCommandsQuickPick.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCommandsQuickPick.vitest.ts
@@ -11,10 +11,14 @@ import { ICommandService } from '../../../../../platform/commands/common/command
 import { ContextKeyExpr, ContextKeyExpression, IContext, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
 import { IQuickInputService, IQuickPickItem } from '../../../../../platform/quickinput/common/quickInput.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { TestQuickPick } from '../../../../../test/vitest/testQuickPick.js';
-import { showNotebookCommandsQuickPick } from '../../browser/contrib/commands/NotebookCommandsAction.js';
+import { ShowNotebookCommandsAction, showNotebookCommandsQuickPick } from '../../browser/contrib/commands/NotebookCommandsAction.js';
+import { IPositronNotebookInstance } from '../../browser/IPositronNotebookInstance.js';
+import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../common/positronNotebookCommon.js';
+import { IVisibleEditorPane } from '../../../../common/editor.js';
 
 interface ICommandPickItem extends IQuickPickItem {
 	readonly commandId: string;
@@ -208,6 +212,53 @@ describe('showNotebookCommandsQuickPick', () => {
 			.filter(i => i.commandId === 'positronNotebook.runAllCells' || i.commandId === 'positronNotebook.executeSelectionInConsole')
 			.map(i => i.label);
 		expect(runGroup).toEqual(['Execute Selection in Console', 'Run All Cells']);
+		pick.cancel();
+	});
+});
+
+describe('ShowNotebookCommandsAction', () => {
+	let pick: TestQuickPick<ICommandPickItem>;
+	let registrations: DisposableStore;
+
+	// run() must evaluate command `when` clauses through the active notebook's
+	// scoped context key service, not the global one -- editor-scoped keys like
+	// NOTEBOOK_HAS_SOMETHING_RUNNING are invisible globally. Sentinel: the global
+	// service rejects everything while the notebook's scoped service accepts
+	// everything, so a prefixed command appearing proves run() consulted the
+	// scoped service.
+	const scopedContextKeyService = stubInterface<IContextKeyService>({ contextMatchesRules: () => true });
+	const notebook = stubInterface<IPositronNotebookInstance>({ scopedContextKeyService });
+	// `notebookInstance` is not on the editor-pane interface; production code at
+	// notebookUtils.ts:80 widens via the same cast to read it off PositronNotebookEditor.
+	// eslint-disable-next-line local/code-no-dangerous-type-assertions -- modeling PositronNotebookEditor's `notebookInstance` field on a structurally-stubbed pane (production code casts the same way)
+	const paneOverrides = { getId: () => POSITRON_NOTEBOOK_EDITOR_ID, notebookInstance: notebook } as unknown as Partial<IVisibleEditorPane>;
+	const activeEditorPane = stubInterface<IVisibleEditorPane>(paneOverrides);
+
+	const ctx = createTestContainer()
+		.stub(IQuickInputService, stubInterface<IQuickInputService>({
+			createQuickPick: (() => pick.asQuickPick()) as IQuickInputService['createQuickPick'],
+		}))
+		.stub(ICommandService, { executeCommand: vi.fn(() => Promise.resolve(undefined)) })
+		.stub(IKeybindingService, { lookupKeybinding: () => undefined })
+		.stub(IContextKeyService, stubInterface<IContextKeyService>({ contextMatchesRules: () => false }))
+		.stub(IEditorService, stubInterface<IEditorService>({ activeEditorPane }))
+		.build();
+
+	beforeEach(() => {
+		pick = ctx.disposables.add(new TestQuickPick<ICommandPickItem>());
+		registrations = new DisposableStore();
+		registrations.add(MenuRegistry.addCommand({ id: 'positronNotebook.testScoped', title: 'Scoped Command' }));
+		registrations.add(MenuRegistry.appendMenuItem(MenuId.CommandPalette, { command: { id: 'positronNotebook.testScoped', title: 'Scoped Command' } }));
+	});
+
+	afterEach(() => {
+		registrations.dispose();
+	});
+
+	it('evaluates command visibility through the active notebook scoped context', () => {
+		ctx.instantiationService.invokeFunction(accessor => new ShowNotebookCommandsAction().run(accessor));
+		const ids = pick.items.filter((i): i is ICommandPickItem => i.type !== 'separator').map(i => i.commandId);
+		expect(ids).toContain('positronNotebook.testScoped');
 		pick.cancel();
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCommandsQuickPick.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCommandsQuickPick.vitest.ts
@@ -39,11 +39,9 @@ describe('showNotebookCommandsQuickPick', () => {
 		pick = ctx.disposables.add(new TestQuickPick<ICommandPickItem>());
 		registrations = new DisposableStore();
 		// A palette command under the positronNotebook. prefix -> included.
-		registrations.add(MenuRegistry.addCommand({ id: 'positronNotebook.testAuto', title: 'Test Auto Command' }));
-		registrations.add(MenuRegistry.appendMenuItem(MenuId.CommandPalette, { command: { id: 'positronNotebook.testAuto', title: 'Test Auto Command' } }));
+		register('positronNotebook.testAuto', 'Test Auto Command');
 		// A palette command without the prefix -> excluded.
-		registrations.add(MenuRegistry.addCommand({ id: 'notebook.testOther', title: 'Other Command' }));
-		registrations.add(MenuRegistry.appendMenuItem(MenuId.CommandPalette, { command: { id: 'notebook.testOther', title: 'Other Command' } }));
+		register('notebook.testOther', 'Other Command');
 	});
 
 	afterEach(() => {
@@ -95,8 +93,7 @@ describe('showNotebookCommandsQuickPick', () => {
 		// The picker action is registered in the palette under the
 		// positronNotebook. prefix, so it would be auto-included; it must not
 		// list itself.
-		registrations.add(MenuRegistry.addCommand({ id: 'positronNotebook.showCommands', title: 'Show Notebook Commands' }));
-		registrations.add(MenuRegistry.appendMenuItem(MenuId.CommandPalette, { command: { id: 'positronNotebook.showCommands', title: 'Show Notebook Commands' } }));
+		register('positronNotebook.showCommands', 'Show Notebook Commands');
 		run();
 		const ids = items().map(i => i.commandId);
 		expect(ids).not.toContain('positronNotebook.showCommands');
@@ -174,10 +171,8 @@ describe('showNotebookCommandsQuickPick', () => {
 		// executeSelectionInConsole, but the labels sort the other way ("E" <
 		// "R"), so without the within-group sort they would come out in the
 		// wrong order.
-		registrations.add(MenuRegistry.addCommand({ id: 'positronNotebook.runAllCells', title: 'Run All Cells' }));
-		registrations.add(MenuRegistry.appendMenuItem(MenuId.CommandPalette, { command: { id: 'positronNotebook.runAllCells', title: 'Run All Cells' } }));
-		registrations.add(MenuRegistry.addCommand({ id: 'positronNotebook.executeSelectionInConsole', title: 'Execute Selection in Console' }));
-		registrations.add(MenuRegistry.appendMenuItem(MenuId.CommandPalette, { command: { id: 'positronNotebook.executeSelectionInConsole', title: 'Execute Selection in Console' } }));
+		register('positronNotebook.runAllCells', 'Run All Cells');
+		register('positronNotebook.executeSelectionInConsole', 'Execute Selection in Console');
 		run();
 		const runGroup = items()
 			.filter(i => i.commandId === 'positronNotebook.runAllCells' || i.commandId === 'positronNotebook.executeSelectionInConsole')

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCommandsQuickPick.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCommandsQuickPick.vitest.ts
@@ -23,7 +23,7 @@ describe('showNotebookCommandsQuickPick', () => {
 	// Reassigned each test; the IQuickInputService stub captures it by closure
 	// so createQuickPick() returns the current double.
 	let pick: TestQuickPick<ICommandPickItem>;
-	const executeCommand = vi.fn();
+	const executeCommand = vi.fn(() => Promise.resolve(undefined));
 
 	const ctx = createTestContainer()
 		.stub(IQuickInputService, stubInterface<IQuickInputService>({

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCommandsQuickPick.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCommandsQuickPick.vitest.ts
@@ -13,7 +13,7 @@ import { IQuickInputService, IQuickPickItem } from '../../../../../platform/quic
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { TestQuickPick } from '../../../../../test/vitest/testQuickPick.js';
-import { showNotebookCommandsQuickPick } from '../../browser/contrib/commands/NotebookCommandsAction.js';
+import { buildNotebookCommandPickItems, showNotebookCommandsQuickPick } from '../../browser/contrib/commands/NotebookCommandsAction.js';
 
 interface ICommandPickItem extends IQuickPickItem {
 	readonly commandId: string;
@@ -88,5 +88,39 @@ describe('showNotebookCommandsQuickPick', () => {
 		pick.accept(item);
 		expect(executeCommand).toHaveBeenCalledTimes(1);
 		expect(executeCommand).toHaveBeenCalledWith('positronNotebook.testAuto');
+	});
+
+	describe('buildNotebookCommandPickItems', () => {
+		function build() {
+			return buildNotebookCommandPickItems(ctx.get(IKeybindingService));
+		}
+
+		it('substitutes the picker label for commands with an override', () => {
+			// addCodeCell registers as "Code" (a toolbar button label) but the
+			// picker must show the fuller "Add Code Cell".
+			registrations.add(MenuRegistry.addCommand({ id: 'positronNotebook.addCodeCell', title: 'Code' }));
+			registrations.add(MenuRegistry.appendMenuItem(MenuId.CommandPalette, { command: { id: 'positronNotebook.addCodeCell', title: 'Code' } }));
+			const item = build().find((i): i is ICommandPickItem => i.type !== 'separator' && i.commandId === 'positronNotebook.addCodeCell')!;
+			expect(item.label).toBe('Add Code Cell');
+		});
+
+		it('files each command under its group separator, unknown ones into Other', () => {
+			registrations.add(MenuRegistry.addCommand({ id: 'positronNotebook.runAllCells', title: 'Run All Cells' }));
+			registrations.add(MenuRegistry.appendMenuItem(MenuId.CommandPalette, { command: { id: 'positronNotebook.runAllCells', title: 'Run All Cells' } }));
+
+			// Map each command to the separator label it sits under. Robust to
+			// whatever other notebook commands the global registry carries.
+			const groupOf = new Map<string, string>();
+			let current = '';
+			for (const i of build()) {
+				if (i.type === 'separator') {
+					current = i.label ?? '';
+				} else {
+					groupOf.set((i as ICommandPickItem).commandId, current);
+				}
+			}
+			expect(groupOf.get('positronNotebook.runAllCells')).toBe('Run');
+			expect(groupOf.get('positronNotebook.testAuto')).toBe('Other'); // unmapped
+		});
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCommandsQuickPick.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCommandsQuickPick.vitest.ts
@@ -13,7 +13,7 @@ import { IQuickInputService, IQuickPickItem } from '../../../../../platform/quic
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { TestQuickPick } from '../../../../../test/vitest/testQuickPick.js';
-import { buildNotebookCommandPickItems, showNotebookCommandsQuickPick } from '../../browser/contrib/commands/NotebookCommandsAction.js';
+import { showNotebookCommandsQuickPick } from '../../browser/contrib/commands/NotebookCommandsAction.js';
 
 interface ICommandPickItem extends IQuickPickItem {
 	readonly commandId: string;
@@ -62,6 +62,21 @@ describe('showNotebookCommandsQuickPick', () => {
 		return pick.items.filter((i): i is ICommandPickItem => i.type !== 'separator');
 	}
 
+	/** Map each command id to the separator label it sits under. Robust to
+	 *  whatever other notebook commands the global registry carries. */
+	function groupByCommand(): Map<string, string> {
+		const groupOf = new Map<string, string>();
+		let current = '';
+		for (const i of pick.items) {
+			if (i.type === 'separator') {
+				current = i.label ?? '';
+			} else {
+				groupOf.set(i.commandId, current);
+			}
+		}
+		return groupOf;
+	}
+
 	it('lists positronNotebook.-prefixed palette commands and excludes others', () => {
 		run();
 		const ids = items().map(i => i.commandId);
@@ -90,37 +105,39 @@ describe('showNotebookCommandsQuickPick', () => {
 		expect(executeCommand).toHaveBeenCalledWith('positronNotebook.testAuto');
 	});
 
-	describe('buildNotebookCommandPickItems', () => {
-		function build() {
-			return buildNotebookCommandPickItems(ctx.get(IKeybindingService));
-		}
+	it('disables alphabetical sorting so the manual group order survives', () => {
+		run();
+		expect(pick.sortByLabel).toBe(false);
+		pick.cancel();
+	});
 
-		it('substitutes the picker label for commands with an override', () => {
-			// addCodeCell registers as "Code" (a toolbar button label) but the
-			// picker must show the fuller "Add Code Cell".
-			registrations.add(MenuRegistry.addCommand({ id: 'positronNotebook.addCodeCell', title: 'Code' }));
-			registrations.add(MenuRegistry.appendMenuItem(MenuId.CommandPalette, { command: { id: 'positronNotebook.addCodeCell', title: 'Code' } }));
-			const item = build().find((i): i is ICommandPickItem => i.type !== 'separator' && i.commandId === 'positronNotebook.addCodeCell')!;
-			expect(item.label).toBe('Add Code Cell');
-		});
+	it('substitutes the picker label for commands with an override', () => {
+		// addCodeCell registers as "Code" (a toolbar button label) but the
+		// picker must show the fuller "Add Code Cell".
+		registrations.add(MenuRegistry.addCommand({ id: 'positronNotebook.addCodeCell', title: 'Code' }));
+		registrations.add(MenuRegistry.appendMenuItem(MenuId.CommandPalette, { command: { id: 'positronNotebook.addCodeCell', title: 'Code' } }));
+		run();
+		const item = items().find(i => i.commandId === 'positronNotebook.addCodeCell')!;
+		expect(item.label).toBe('Add Code Cell');
+		pick.cancel();
+	});
 
-		it('files each command under its group separator, unknown ones into Other', () => {
-			registrations.add(MenuRegistry.addCommand({ id: 'positronNotebook.runAllCells', title: 'Run All Cells' }));
-			registrations.add(MenuRegistry.appendMenuItem(MenuId.CommandPalette, { command: { id: 'positronNotebook.runAllCells', title: 'Run All Cells' } }));
+	it('resolves the label from an object-typed (localized) command title', () => {
+		registrations.add(MenuRegistry.addCommand({ id: 'positronNotebook.testObjectTitle', title: { value: 'Localized Title', original: 'Localized Title' } }));
+		registrations.add(MenuRegistry.appendMenuItem(MenuId.CommandPalette, { command: { id: 'positronNotebook.testObjectTitle', title: { value: 'Localized Title', original: 'Localized Title' } } }));
+		run();
+		const item = items().find(i => i.commandId === 'positronNotebook.testObjectTitle')!;
+		expect(item.label).toBe('Localized Title');
+		pick.cancel();
+	});
 
-			// Map each command to the separator label it sits under. Robust to
-			// whatever other notebook commands the global registry carries.
-			const groupOf = new Map<string, string>();
-			let current = '';
-			for (const i of build()) {
-				if (i.type === 'separator') {
-					current = i.label ?? '';
-				} else {
-					groupOf.set((i as ICommandPickItem).commandId, current);
-				}
-			}
-			expect(groupOf.get('positronNotebook.runAllCells')).toBe('Run');
-			expect(groupOf.get('positronNotebook.testAuto')).toBe('Other'); // unmapped
-		});
+	it('files each command under its group separator, unknown ones into Other', () => {
+		registrations.add(MenuRegistry.addCommand({ id: 'positronNotebook.runAllCells', title: 'Run All Cells' }));
+		registrations.add(MenuRegistry.appendMenuItem(MenuId.CommandPalette, { command: { id: 'positronNotebook.runAllCells', title: 'Run All Cells' } }));
+		run();
+		const groupOf = groupByCommand();
+		expect(groupOf.get('positronNotebook.runAllCells')).toBe('Run');
+		expect(groupOf.get('positronNotebook.testAuto')).toBe('Other'); // unmapped
+		pick.cancel();
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCommandsQuickPick.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCommandsQuickPick.vitest.ts
@@ -38,12 +38,12 @@ describe('showNotebookCommandsQuickPick', () => {
 	beforeEach(() => {
 		pick = ctx.disposables.add(new TestQuickPick<ICommandPickItem>());
 		registrations = new DisposableStore();
-		// A palette command under the positronNotebook. prefix -> auto-included.
+		// A palette command under the positronNotebook. prefix -> included.
 		registrations.add(MenuRegistry.addCommand({ id: 'positronNotebook.testAuto', title: 'Test Auto Command' }));
 		registrations.add(MenuRegistry.appendMenuItem(MenuId.CommandPalette, { command: { id: 'positronNotebook.testAuto', title: 'Test Auto Command' } }));
-		// The greenlit command: registered but NOT in the command palette, so it
-		// can only appear via the greenlist.
-		registrations.add(MenuRegistry.addCommand({ id: 'positronNotebook.toggleLineNumbers', title: 'Toggle Line Numbers' }));
+		// A palette command without the prefix -> excluded.
+		registrations.add(MenuRegistry.addCommand({ id: 'notebook.testOther', title: 'Other Command' }));
+		registrations.add(MenuRegistry.appendMenuItem(MenuId.CommandPalette, { command: { id: 'notebook.testOther', title: 'Other Command' } }));
 	});
 
 	afterEach(() => {
@@ -62,11 +62,23 @@ describe('showNotebookCommandsQuickPick', () => {
 		return pick.items.filter((i): i is ICommandPickItem => i.type !== 'separator');
 	}
 
-	it('lists prefixed palette commands and greenlit commands', () => {
+	it('lists positronNotebook.-prefixed palette commands and excludes others', () => {
 		run();
 		const ids = items().map(i => i.commandId);
 		expect(ids).toContain('positronNotebook.testAuto');
-		expect(ids).toContain('positronNotebook.toggleLineNumbers');
+		expect(ids).not.toContain('notebook.testOther');
+		pick.cancel(); // close the picker so its DisposableStore is released
+	});
+
+	it('excludes the picker\'s own command', () => {
+		// The picker action is registered in the palette under the
+		// positronNotebook. prefix, so it would be auto-included; it must not
+		// list itself.
+		registrations.add(MenuRegistry.addCommand({ id: 'positronNotebook.showCommands', title: 'Show Notebook Commands' }));
+		registrations.add(MenuRegistry.appendMenuItem(MenuId.CommandPalette, { command: { id: 'positronNotebook.showCommands', title: 'Show Notebook Commands' } }));
+		run();
+		const ids = items().map(i => i.commandId);
+		expect(ids).not.toContain('positronNotebook.showCommands');
 		pick.cancel(); // close the picker so its DisposableStore is released
 	});
 

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCommandsQuickPick.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCommandsQuickPick.vitest.ts
@@ -140,4 +140,21 @@ describe('showNotebookCommandsQuickPick', () => {
 		expect(groupOf.get('positronNotebook.testAuto')).toBe('Other'); // unmapped
 		pick.cancel();
 	});
+
+	it('sorts commands alphabetically within a group', () => {
+		// Both land in the Run group. The group lists runAllCells before
+		// executeSelectionInConsole, but the labels sort the other way ("E" <
+		// "R"), so without the within-group sort they would come out in the
+		// wrong order.
+		registrations.add(MenuRegistry.addCommand({ id: 'positronNotebook.runAllCells', title: 'Run All Cells' }));
+		registrations.add(MenuRegistry.appendMenuItem(MenuId.CommandPalette, { command: { id: 'positronNotebook.runAllCells', title: 'Run All Cells' } }));
+		registrations.add(MenuRegistry.addCommand({ id: 'positronNotebook.executeSelectionInConsole', title: 'Execute Selection in Console' }));
+		registrations.add(MenuRegistry.appendMenuItem(MenuId.CommandPalette, { command: { id: 'positronNotebook.executeSelectionInConsole', title: 'Execute Selection in Console' } }));
+		run();
+		const runGroup = items()
+			.filter(i => i.commandId === 'positronNotebook.runAllCells' || i.commandId === 'positronNotebook.executeSelectionInConsole')
+			.map(i => i.label);
+		expect(runGroup).toEqual(['Execute Selection in Console', 'Run All Cells']);
+		pick.cancel();
+	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCommandsQuickPick.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCommandsQuickPick.vitest.ts
@@ -58,6 +58,12 @@ describe('showNotebookCommandsQuickPick', () => {
 		);
 	}
 
+	/** Register a palette command under the test's lifecycle. */
+	function register(id: string, title: string): void {
+		registrations.add(MenuRegistry.addCommand({ id, title }));
+		registrations.add(MenuRegistry.appendMenuItem(MenuId.CommandPalette, { command: { id, title } }));
+	}
+
 	function items(): ICommandPickItem[] {
 		return pick.items.filter((i): i is ICommandPickItem => i.type !== 'separator');
 	}
@@ -111,17 +117,6 @@ describe('showNotebookCommandsQuickPick', () => {
 		pick.cancel();
 	});
 
-	it('substitutes the picker label for commands with an override', () => {
-		// addCodeCell registers as "Code" (a toolbar button label) but the
-		// picker must show the fuller "Add Code Cell".
-		registrations.add(MenuRegistry.addCommand({ id: 'positronNotebook.addCodeCell', title: 'Code' }));
-		registrations.add(MenuRegistry.appendMenuItem(MenuId.CommandPalette, { command: { id: 'positronNotebook.addCodeCell', title: 'Code' } }));
-		run();
-		const item = items().find(i => i.commandId === 'positronNotebook.addCodeCell')!;
-		expect(item.label).toBe('Add Code Cell');
-		pick.cancel();
-	});
-
 	it('resolves the label from an object-typed (localized) command title', () => {
 		registrations.add(MenuRegistry.addCommand({ id: 'positronNotebook.testObjectTitle', title: { value: 'Localized Title', original: 'Localized Title' } }));
 		registrations.add(MenuRegistry.appendMenuItem(MenuId.CommandPalette, { command: { id: 'positronNotebook.testObjectTitle', title: { value: 'Localized Title', original: 'Localized Title' } } }));
@@ -131,13 +126,46 @@ describe('showNotebookCommandsQuickPick', () => {
 		pick.cancel();
 	});
 
-	it('files each command under its group separator, unknown ones into Other', () => {
-		registrations.add(MenuRegistry.addCommand({ id: 'positronNotebook.runAllCells', title: 'Run All Cells' }));
-		registrations.add(MenuRegistry.appendMenuItem(MenuId.CommandPalette, { command: { id: 'positronNotebook.runAllCells', title: 'Run All Cells' } }));
+	it('files a representative command from each group under the right separator', () => {
+		// One command per named group, so a broken group label or a broken
+		// id-match misfiles its command and fails here. A source-side typo in a
+		// COMMAND_GROUPS id is not catchable without loading the real command
+		// modules (deliberately not imported here); it surfaces as the command
+		// dropping into Other in the running app.
+		const expected: Record<string, string> = {
+			'positronNotebook.runAllCells': 'Run',
+			'positronNotebook.addCodeCell': 'Cells',
+			'positronNotebook.clearAllOutputs': 'Outputs',
+			'positronNotebook.selectKernel': 'Kernel',
+			'positronNotebook.toggleOutline': 'View',
+			'positronNotebook.askAssistant': 'Assistant',
+			'positronNotebook.testAuto': 'Other', // unmapped -> catch-all
+		};
+		for (const id of Object.keys(expected)) {
+			register(id, id);
+		}
 		run();
 		const groupOf = groupByCommand();
-		expect(groupOf.get('positronNotebook.runAllCells')).toBe('Run');
-		expect(groupOf.get('positronNotebook.testAuto')).toBe('Other'); // unmapped
+		const actual = Object.fromEntries(Object.keys(expected).map(id => [id, groupOf.get(id)]));
+		expect(actual).toEqual(expected);
+		pick.cancel();
+	});
+
+	it('substitutes the picker label for every LABEL_OVERRIDES entry', () => {
+		// Each registers under a title tuned for another surface; the picker
+		// must show the fuller override label instead.
+		const overrides: Record<string, string> = {
+			'positronNotebook.addCodeCell': 'Add Code Cell',
+			'positronNotebook.addMarkdownCell': 'Add Markdown Cell',
+			'positronNotebook.cell.addTag': 'Add Cell Tag',
+		};
+		for (const id of Object.keys(overrides)) {
+			register(id, 'Original Title'); // deliberately not the override text
+		}
+		run();
+		const byId = new Map(items().map(i => [i.commandId, i.label]));
+		const actual = Object.fromEntries(Object.keys(overrides).map(id => [id, byId.get(id)]));
+		expect(actual).toEqual(overrides);
 		pick.cancel();
 	});
 

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookHelpRegistration.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookHelpRegistration.vitest.ts
@@ -19,4 +19,11 @@ describe('Positron notebook contribution registration', () => {
 	it('registers the keyboard shortcuts help action', () => {
 		expect(CommandsRegistry.getCommand('positronNotebook.showKeyboardShortcuts')).toBeDefined();
 	});
+
+	it('registers the show-commands action', () => {
+		// showCommands has no toolbar button (it is reached from the Help modal
+		// and the command palette), so a dropped registration leaves no visual
+		// affordance to notice. Guard the command wiring.
+		expect(CommandsRegistry.getCommand('positronNotebook.showCommands')).toBeDefined();
+	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookHelpRegistration.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookHelpRegistration.vitest.ts
@@ -6,6 +6,7 @@
 /// <reference types="vitest/globals" />
 
 import { CommandsRegistry } from '../../../../../platform/commands/common/commands.js';
+import { IMenuItem, isIMenuItem, MenuId, MenuRegistry } from '../../../../../platform/actions/common/actions.js';
 
 // Importing the contribution barrel runs its side-effect imports, which is what
 // registers the notebook actions. The keyboard-shortcuts help action lives in
@@ -25,5 +26,28 @@ describe('Positron notebook contribution registration', () => {
 		// and the command palette), so a dropped registration leaves no visual
 		// affordance to notice. Guard the command wiring.
 		expect(CommandsRegistry.getCommand('positronNotebook.showCommands')).toBeDefined();
+	});
+
+	it('gates the run/stop all-cells palette entries on the running state', () => {
+		// The notebook command picker (and the F1 palette) filter commands by each
+		// command's CommandPalette `when`, which registerAction2 derives from the
+		// action precondition. runAllCells / stopAllCells share a toolbar slot and
+		// must flip with the running state; without a precondition they leaked into
+		// the palette/picker regardless of run state, and selecting an out-of-state
+		// "Stop Execution" ran all cells. Pin both palette `when`s.
+		const paletteWhen = (id: string) => MenuRegistry
+			.getMenuItems(MenuId.CommandPalette)
+			.find((item): item is IMenuItem => isIMenuItem(item) && item.command.id === id)
+			?.when?.serialize();
+
+		expect({
+			runAllCells: paletteWhen('positronNotebook.runAllCells'),
+			stopAllCells: paletteWhen('positronNotebook.stopAllCells'),
+		}).toMatchInlineSnapshot(`
+			{
+			  "runAllCells": "!notebookHasSomethingRunning && activeEditor == 'workbench.editor.positronNotebook'",
+			  "stopAllCells": "notebookHasSomethingRunning && activeEditor == 'workbench.editor.positronNotebook'",
+			}
+		`);
 	});
 });


### PR DESCRIPTION
## Summary

Makes Positron Notebook commands discoverable without sifting through the shared command palette, and turns the notebook keyboard-shortcuts modal into a general Help hub.

Fixes #13512.

We had to update descriptions to make the quickpick actually make sense. We probably should have done this a while ago as the command palette was always confusing. 

## Screenshots

### New button icon replacing the keyboard one before
<img width="283" height="189" alt="image" src="https://github.com/user-attachments/assets/b51938d6-2ca3-4b2c-b82e-ec149fdc40c6" />

### Top of the help modal is a link to notebook commands
<img width="515" height="631" alt="image" src="https://github.com/user-attachments/assets/921148c7-7978-4dcb-b1aa-0ce5fefc4d37" />

### Clicking the link opens a custom quickpick with commands grouped by area. 
<img width="669" height="543" alt="image" src="https://github.com/user-attachments/assets/ba983a2d-cfc6-4b90-a3af-880a6424fd6c" />

## What changed

- **Notebook Commands quick pick.** New `positronNotebook.showCommands` command opens a quick pick of Positron Notebook commands, scoped by the unique `positronNotebook.` command-id prefix (the visible "Notebook" category collides with upstream VS Code notebook commands).
- **Grouping + clearer labels.** Commands are grouped under fixed-order section separators (Run, Cells, Outputs, Kernel, View, Assistant); unmapped and extension-contributed commands fall into a trailing **Other** group so nothing is silently dropped. Palette titles for icon-only toolbar commands are clarified ("Run All" -> "Run All Cells", "Stop" -> "Stop Execution", "Clear Outputs" -> "Clear All Outputs"), with a picker-only `LABEL_OVERRIDES` map for commands whose title must stay short elsewhere.
- **Consolidated into the Help modal.** Moved the entry out of the toolbar and into the keyboard-shortcuts modal, turning it into a general help hub: swapped the keyboard icon for `Codicon.question`, retitled the toolbar button/modal to "Help" / "Notebook Help", and led the modal with a "See All Commands" section that opens the picker. Dropped the standalone `showCommands` toolbar button while keeping the command + F1 + palette entry so it stays runnable.

## Testing

- New `notebookCommandsQuickPick.vitest.ts`: drives the picker through its public path, asserts grouping (a representative command per group + the Other catch-all), within-group alphabetical sort, label overrides, and the prefix/own-id filter. Mutation-verified.
- `notebookHelpRegistration.vitest.ts`: guards `showCommands` registration now that it no longer has a toolbar affordance.
- eslint clean.
