### PR TITLE
Investigate #14328 e2e: uv --python before -r (arg-order hypothesis)

### DIFF
--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -83,7 +83,7 @@ export class UvPackageManager implements IPackageManager {
             const content = buildRequirementsFile(freezeLines, packages);
             const tempFile = await this._writeRequirementsTempFile(content);
             try {
-                const args = ['pip', 'install', '-r', tempFile.filePath, '--python', this._pythonPath];
+                const args = ['pip', 'install', '--python', this._pythonPath, '-r', tempFile.filePath];
                 await this._executeUvInTerminal(args, token);
             } finally {
                 tempFile.dispose();
@@ -145,7 +145,7 @@ export class UvPackageManager implements IPackageManager {
             const content = buildRequirementsFile(freezeLines, targets);
             const tempFile = await this._writeRequirementsTempFile(content);
             try {
-                const args = ['pip', 'install', '-r', tempFile.filePath, '--python', this._pythonPath];
+                const args = ['pip', 'install', '--python', this._pythonPath, '-r', tempFile.filePath];
                 await this._executeUvInTerminal(args, token);
             } finally {
                 tempFile.dispose();
@@ -180,7 +180,7 @@ export class UvPackageManager implements IPackageManager {
             const content = buildRequirementsFile(freezeLines, []);
             const tempFile = await this._writeRequirementsTempFile(content);
             try {
-                const args = ['pip', 'install', '--upgrade', '-r', tempFile.filePath, '--python', this._pythonPath];
+                const args = ['pip', 'install', '--upgrade', '--python', this._pythonPath, '-r', tempFile.filePath];
                 await this._executeUvInTerminal(args, token);
             } finally {
                 tempFile.dispose();


### PR DESCRIPTION
Investigating the e2e regression from #14495 (merged): the **Python - Install, search, and uninstall package (python)** test fails in CI (uv runtime) with `uv pip install -r <tempfile> --python /root/.venv/bin/python` returning a non-zero exit, and uv's output suggests it parsed the `--python` *value* as a requirements file.

This PR tests one hypothesis: that the failure is a uv **argument-order parsing** issue, not the content of the generated requirements file. It moves `--python <path>` to *before* `-r <file>` in the three uv environment-workflow commands (install / update / update-all), matching the ordering of the pre-#14495 command (`uv pip install --python <path> <pkgs>`) that worked.

Note: this exact command shape (`-r FILE --python PATH`) parses fine on uv 0.11.24 locally, so if CI still fails with this change, the cause is the freeze-file content instead (to be addressed by building the installed set from the kernel's package list rather than `pip freeze`).

Running the packages-pane e2e on this PR to get a CI signal: @:packages-pane @:web

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A (investigation PR; see #14328)

### Validation Steps

@:packages-pane @:web

The packages-pane e2e (Python install/uninstall on the uv runtime) must pass on both e2e-electron and e2e-chromium.
