### PR TITLE
Add e2e test for Microsoft Foundry API key sign-in (desktop)

### DIFF
--- a/.github/workflows/release-screenshots.yml
+++ b/.github/workflows/release-screenshots.yml
@@ -124,8 +124,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
-          MS_FOUNDRY_KEY: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/credential"
-          MS_FOUNDRY_BASE_URL: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/hostname"
+          MS_FOUNDRY_KEY: "op://Positron/MS-Foundry-East2TestAI/credential"
+          MS_FOUNDRY_BASE_URL: "op://Positron/MS-Foundry-East2TestAI/hostname"
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"

--- a/.github/workflows/release-screenshots.yml
+++ b/.github/workflows/release-screenshots.yml
@@ -124,6 +124,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
+          MS_FOUNDRY_KEY: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/credential"
+          MS_FOUNDRY_BASE_URL: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/hostname"
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"

--- a/.github/workflows/test-e2e-debian.yml
+++ b/.github/workflows/test-e2e-debian.yml
@@ -147,8 +147,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
-          MS_FOUNDRY_KEY: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/credential"
-          MS_FOUNDRY_BASE_URL: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/hostname"
+          MS_FOUNDRY_KEY: "op://Positron/MS-Foundry-East2TestAI/credential"
+          MS_FOUNDRY_BASE_URL: "op://Positron/MS-Foundry-East2TestAI/hostname"
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"

--- a/.github/workflows/test-e2e-debian.yml
+++ b/.github/workflows/test-e2e-debian.yml
@@ -147,6 +147,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
+          MS_FOUNDRY_KEY: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/credential"
+          MS_FOUNDRY_BASE_URL: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/hostname"
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"

--- a/.github/workflows/test-e2e-jupyter-ubuntu.yml
+++ b/.github/workflows/test-e2e-jupyter-ubuntu.yml
@@ -84,8 +84,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
-          MS_FOUNDRY_KEY: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/credential"
-          MS_FOUNDRY_BASE_URL: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/hostname"
+          MS_FOUNDRY_KEY: "op://Positron/MS-Foundry-East2TestAI/credential"
+          MS_FOUNDRY_BASE_URL: "op://Positron/MS-Foundry-East2TestAI/hostname"
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"

--- a/.github/workflows/test-e2e-jupyter-ubuntu.yml
+++ b/.github/workflows/test-e2e-jupyter-ubuntu.yml
@@ -84,6 +84,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
+          MS_FOUNDRY_KEY: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/credential"
+          MS_FOUNDRY_BASE_URL: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/hostname"
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"

--- a/.github/workflows/test-e2e-macos-run.yml
+++ b/.github/workflows/test-e2e-macos-run.yml
@@ -101,6 +101,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
+          MS_FOUNDRY_KEY: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/credential"
+          MS_FOUNDRY_BASE_URL: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/hostname"
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"

--- a/.github/workflows/test-e2e-macos-run.yml
+++ b/.github/workflows/test-e2e-macos-run.yml
@@ -101,8 +101,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
-          MS_FOUNDRY_KEY: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/credential"
-          MS_FOUNDRY_BASE_URL: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/hostname"
+          MS_FOUNDRY_KEY: "op://Positron/MS-Foundry-East2TestAI/credential"
+          MS_FOUNDRY_BASE_URL: "op://Positron/MS-Foundry-East2TestAI/hostname"
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"

--- a/.github/workflows/test-e2e-rhel.yml
+++ b/.github/workflows/test-e2e-rhel.yml
@@ -147,8 +147,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
-          MS_FOUNDRY_KEY: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/credential"
-          MS_FOUNDRY_BASE_URL: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/hostname"
+          MS_FOUNDRY_KEY: "op://Positron/MS-Foundry-East2TestAI/credential"
+          MS_FOUNDRY_BASE_URL: "op://Positron/MS-Foundry-East2TestAI/hostname"
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"

--- a/.github/workflows/test-e2e-rhel.yml
+++ b/.github/workflows/test-e2e-rhel.yml
@@ -147,6 +147,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
+          MS_FOUNDRY_KEY: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/credential"
+          MS_FOUNDRY_BASE_URL: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/hostname"
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"

--- a/.github/workflows/test-e2e-sles.yml
+++ b/.github/workflows/test-e2e-sles.yml
@@ -147,8 +147,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
-          MS_FOUNDRY_KEY: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/credential"
-          MS_FOUNDRY_BASE_URL: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/hostname"
+          MS_FOUNDRY_KEY: "op://Positron/MS-Foundry-East2TestAI/credential"
+          MS_FOUNDRY_BASE_URL: "op://Positron/MS-Foundry-East2TestAI/hostname"
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"

--- a/.github/workflows/test-e2e-sles.yml
+++ b/.github/workflows/test-e2e-sles.yml
@@ -147,6 +147,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
+          MS_FOUNDRY_KEY: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/credential"
+          MS_FOUNDRY_BASE_URL: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/hostname"
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"

--- a/.github/workflows/test-e2e-suse.yml
+++ b/.github/workflows/test-e2e-suse.yml
@@ -147,8 +147,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
-          MS_FOUNDRY_KEY: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/credential"
-          MS_FOUNDRY_BASE_URL: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/hostname"
+          MS_FOUNDRY_KEY: "op://Positron/MS-Foundry-East2TestAI/credential"
+          MS_FOUNDRY_BASE_URL: "op://Positron/MS-Foundry-East2TestAI/hostname"
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"

--- a/.github/workflows/test-e2e-suse.yml
+++ b/.github/workflows/test-e2e-suse.yml
@@ -147,6 +147,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
+          MS_FOUNDRY_KEY: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/credential"
+          MS_FOUNDRY_BASE_URL: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/hostname"
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"

--- a/.github/workflows/test-e2e-ubuntu-run.yml
+++ b/.github/workflows/test-e2e-ubuntu-run.yml
@@ -163,8 +163,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
-          MS_FOUNDRY_KEY: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/credential"
-          MS_FOUNDRY_BASE_URL: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/hostname"
+          MS_FOUNDRY_KEY: "op://Positron/MS-Foundry-East2TestAI/credential"
+          MS_FOUNDRY_BASE_URL: "op://Positron/MS-Foundry-East2TestAI/hostname"
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"

--- a/.github/workflows/test-e2e-ubuntu-run.yml
+++ b/.github/workflows/test-e2e-ubuntu-run.yml
@@ -163,6 +163,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
+          MS_FOUNDRY_KEY: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/credential"
+          MS_FOUNDRY_BASE_URL: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/hostname"
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -148,6 +148,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
+          MS_FOUNDRY_KEY: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/credential"
+          MS_FOUNDRY_BASE_URL: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/hostname"
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -148,8 +148,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
-          MS_FOUNDRY_KEY: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/credential"
-          MS_FOUNDRY_BASE_URL: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/hostname"
+          MS_FOUNDRY_KEY: "op://Positron/MS-Foundry-East2TestAI/credential"
+          MS_FOUNDRY_BASE_URL: "op://Positron/MS-Foundry-East2TestAI/hostname"
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"

--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -131,8 +131,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
-          MS_FOUNDRY_KEY: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/credential"
-          MS_FOUNDRY_BASE_URL: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/hostname"
+          MS_FOUNDRY_KEY: "op://Positron/MS-Foundry-East2TestAI/credential"
+          MS_FOUNDRY_BASE_URL: "op://Positron/MS-Foundry-East2TestAI/hostname"
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"

--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -131,6 +131,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
+          MS_FOUNDRY_KEY: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/credential"
+          MS_FOUNDRY_BASE_URL: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/hostname"
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"

--- a/.github/workflows/test-e2e-workbench-ubuntu.yml
+++ b/.github/workflows/test-e2e-workbench-ubuntu.yml
@@ -110,8 +110,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
-          MS_FOUNDRY_KEY: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/credential"
-          MS_FOUNDRY_BASE_URL: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/hostname"
+          MS_FOUNDRY_KEY: "op://Positron/MS-Foundry-East2TestAI/credential"
+          MS_FOUNDRY_BASE_URL: "op://Positron/MS-Foundry-East2TestAI/hostname"
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"

--- a/.github/workflows/test-e2e-workbench-ubuntu.yml
+++ b/.github/workflows/test-e2e-workbench-ubuntu.yml
@@ -110,6 +110,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
+          MS_FOUNDRY_KEY: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/credential"
+          MS_FOUNDRY_BASE_URL: "op://Positron/Microsoft Azure Foundry API Key (East2TestAI)/hostname"
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"

--- a/test/e2e/pages/modelProviderAuth.ts
+++ b/test/e2e/pages/modelProviderAuth.ts
@@ -38,6 +38,7 @@ const POSITRON_MODAL_DIALOG = '.positron-modal-dialog-box';
 
 // Configure Providers modal controls
 const APIKEY_INPUT = '#api-key-input input.text-input[type="password"]';
+const BASEURL_INPUT = '#base-url-input input.text-input[type="text"]';
 const CLOSE_BUTTON = 'button.positron-button.action-bar-button.default:has-text("Close")';
 const SIGN_IN_BUTTON = 'button.positron-button.language-model.button.sign-in:has-text("Sign in")';
 const SIGN_OUT_BUTTON = 'button.positron-button.language-model.button.sign-in:has-text("Sign out")';
@@ -49,6 +50,7 @@ const ANTHROPIC_BUTTON = 'button.positron-button.language-model.button:has(#anth
 const AWS_BEDROCK_BUTTON = 'button.positron-button.language-model.button:has(#amazon-bedrock-provider-button)';
 const ECHO_MODEL_BUTTON = 'button.positron-button.language-model.button:has(div.codicon-info)';
 const ERROR_MODEL_BUTTON = 'button.positron-button.language-model.button:has(div.codicon-error)';
+const MS_FOUNDRY_BUTTON = 'button.positron-button.language-model.button:has(#ms-foundry-provider-button)';
 const OPENAI_BUTTON = 'button.positron-button.language-model.button:has(#openai-api-provider-button)';
 const POSIT_AI_BUTTON = 'button.positron-button.language-model.button:has(#posit-ai-provider-button)';
 
@@ -66,6 +68,7 @@ export type ModelProvider =
 	| 'amazon-bedrock'
 	| 'echo'
 	| 'error'
+	| 'ms-foundry'
 	| 'openai-api'
 	| 'posit-ai';
 
@@ -103,6 +106,8 @@ export interface OAuthDeviceCodeConfig {
 export interface LoginModelProviderOptions {
 	/** API key for providers that support API key authentication */
 	apiKey?: string;
+	/** Base URL for providers that require one (e.g. ms-foundry); falls back to *_BASE_URL env var */
+	baseUrl?: string;
 	/** Timeout for verifying sign-in success (default: 15000ms) */
 	timeout?: number;
 	/** Whether to run the OAuth browser in headless mode (default: false) */
@@ -116,6 +121,7 @@ function getProviderAuthType(provider: ModelProvider): ProviderAuthType {
 			return 'none';
 		case 'anthropic-api':
 		case 'openai-api':
+		case 'ms-foundry':
 			return 'apiKey';
 		case 'amazon-bedrock':
 			return 'aws';
@@ -124,6 +130,19 @@ function getProviderAuthType(provider: ModelProvider): ProviderAuthType {
 		default:
 			throw new Error(`Unknown provider: ${provider}`);
 	}
+}
+
+/**
+ * Whether the provider requires a Base URL alongside its API key (e.g.
+ * Microsoft Foundry's Azure endpoint). These providers expose a "Base URL"
+ * field in the Configure Providers modal in addition to the API key field.
+ */
+function providerRequiresBaseUrl(provider: ModelProvider): boolean {
+	return provider.toLowerCase() === 'ms-foundry';
+}
+
+function getProviderBaseUrlEnvVarName(provider: ModelProvider): string {
+	return `${provider.toUpperCase().replace(/-/g, '_')}_BASE_URL`;
 }
 
 function getOAuthConfig(provider: ModelProvider): OAuthDeviceCodeConfig {
@@ -211,6 +230,9 @@ export class ModelProviderAuth {
 			case 'error':
 				await this.code.driver.currentPage.locator(ERROR_MODEL_BUTTON).click();
 				break;
+			case 'ms-foundry':
+				await this.code.driver.currentPage.locator(MS_FOUNDRY_BUTTON).click();
+				break;
 			case 'openai-api':
 				await this.code.driver.currentPage.locator(OPENAI_BUTTON).click();
 				break;
@@ -266,6 +288,20 @@ export class ModelProviderAuth {
 						);
 					}
 					await this.enterApiKey(apiKey);
+
+					// Some providers (e.g. ms-foundry) also require a Base URL.
+					if (providerRequiresBaseUrl(provider)) {
+						const baseUrlEnvVar = getProviderBaseUrlEnvVarName(provider);
+						const baseUrl = options.baseUrl ?? process.env[baseUrlEnvVar];
+						if (!baseUrl) {
+							throw new Error(
+								`No base URL provided for ${provider}. ` +
+								`Set the ${baseUrlEnvVar} environment variable or pass baseUrl in options.`
+							);
+						}
+						await this.enterBaseUrl(baseUrl);
+					}
+
 					await this.clickSignInButton();
 					break;
 				}
@@ -325,6 +361,13 @@ export class ModelProviderAuth {
 		await this.code.driver.currentPage.locator(APIKEY_RADIO).check();
 		const apiKeyInput = this.code.driver.currentPage.locator(APIKEY_INPUT);
 		await fillSecretValue(apiKeyInput, apiKey);
+	}
+
+	async enterBaseUrl(baseUrl: string) {
+		// Filled via the secret-value helper so the endpoint URL isn't recorded
+		// in Playwright traces.
+		const baseUrlInput = this.code.driver.currentPage.locator(BASEURL_INPUT);
+		await fillSecretValue(baseUrlInput, baseUrl);
 	}
 
 	async clickSignInButton() {

--- a/test/e2e/tests/posit-assistant/posit-assistant-signin.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant-signin.test.ts
@@ -15,6 +15,9 @@ const POSIT_ASSISTANT_SIGNIN_PROVIDERS: ModelProvider[] = [
 	'openai-api',
 	'amazon-bedrock',
 	'posit-ai',
+	// Microsoft Foundry (Azure) via API key + Base URL on desktop. The managed
+	// credentials path is covered separately in the workbench suite.
+	'ms-foundry',
 ];
 
 test.describe('Posit Assistant Sign-in', {
@@ -35,6 +38,13 @@ test.describe('Posit Assistant Sign-in', {
 					// explicitly. `newConversation: false` avoids starting a
 					// fresh chat after model selection, which would drop it.
 					await app.workbench.positAssistant.selectModel('GPT-5.4');
+					await app.workbench.positAssistant.sendMessage('Say hello', true, { newConversation: false });
+				} else if (provider === 'ms-foundry') {
+					// Foundry routes through its model router rather than a single
+					// named model. Select it explicitly (matching the workbench
+					// managed-credentials test); `newConversation: false` keeps the
+					// selection instead of resetting to a fresh chat.
+					await app.workbench.positAssistant.selectModel('Model Router');
 					await app.workbench.positAssistant.sendMessage('Say hello', true, { newConversation: false });
 				} else {
 					await app.workbench.positAssistant.sendMessage('Say hello', true, { newConversation: true });

--- a/test/e2e/tests/posit-assistant/posit-assistant-signin.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant-signin.test.ts
@@ -40,11 +40,11 @@ test.describe('Posit Assistant Sign-in', {
 					await app.workbench.positAssistant.selectModel('GPT-5.4');
 					await app.workbench.positAssistant.sendMessage('Say hello', true, { newConversation: false });
 				} else if (provider === 'ms-foundry') {
-					// Foundry routes through its model router rather than a single
-					// named model. Select it explicitly (matching the workbench
-					// managed-credentials test); `newConversation: false` keeps the
-					// selection instead of resetting to a fresh chat.
-					await app.workbench.positAssistant.selectModel('Model Router');
+					// Foundry doesn't auto-select a default model on desktop, so pick
+					// it explicitly. In the model picker the model is listed under its
+					// provider name, "Microsoft Foundry". `newConversation: false`
+					// keeps the selection instead of resetting to a fresh chat.
+					await app.workbench.positAssistant.selectModel('Microsoft Foundry');
 					await app.workbench.positAssistant.sendMessage('Say hello', true, { newConversation: false });
 				} else {
 					await app.workbench.positAssistant.sendMessage('Say hello', true, { newConversation: true });


### PR DESCRIPTION
Adds desktop e2e coverage for the Azure (`msFoundry`) provider's **API key + model router** auth path. Per [#14497](https://github.com/posit-dev/positron/issues/14497), the workbench managed-credentials path is already covered; this adds the first of the remaining auth methods needed before calling the provider GA.

### What changed

- **`modelProviderAuth` page object** (the shared "Configure Language Model Providers" component): added the `ms-foundry` provider -- provider tile, the **Base URL** field, and Base URL entry alongside the existing API key flow. The Base URL is read from `options.baseUrl` or the `MS_FOUNDRY_BASE_URL` env var; the API key resolves to `MS_FOUNDRY_KEY` via the existing convention.
- **`posit-assistant-signin.test.ts`**: added `ms-foundry` to the sign-in suite. It selects the **Model Router** model explicitly (mirroring the workbench Azure test) before sending a message, then signs out.
- **e2e workflows (11 files)**: load `MS_FOUNDRY_KEY` and `MS_FOUNDRY_BASE_URL` from 1Password (`Microsoft Azure Foundry API Key (East2TestAI)`) alongside the other provider credentials.

Still open in #14497 (separate follow-up): the `positron.assistant.models.overrides.msFoundry` setting path (workbench).

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

New test: `posit-assistant-signin.test.ts` -> `ms-foundry - Sign in, send hello, sign out`. Runs on desktop electron, web, and Windows.

@:posit-assistant @:assistant @:web @:win