### PR TITLE
Build package requirements from the kernel's installed list, not freeze

### DIFF
--- a/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
@@ -10,7 +10,7 @@ import { IPythonExecutionFactory, IPythonExecutionService } from '../../common/p
 import { IFileSystem } from '../../common/platform/types';
 import { ITerminalServiceFactory } from '../../common/terminal/types';
 import { IServiceContainer } from '../../ioc/types';
-import { traceVerbose } from '../../logging';
+import { traceInfo } from '../../logging';
 import { fetchMetadataWithOutdated } from './packageMetadata';
 import { searchPyPI, searchPyPIVersions } from './pypiSearch';
 import { buildRequirementsFile } from './requirementsFile';
@@ -223,17 +223,16 @@ export class PipPackageManager implements IPackageManager {
     }
 
     /**
-     * Capture the full installed set as pinned `pip freeze` lines. Origins
-     * (`@ file://`, `-e`, VCS URLs) are preserved so already-installed packages
-     * resolve as satisfied without an index lookup.
+     * Capture the full installed set as bare package names from the kernel's
+     * installed-package list (the same data the Packages pane shows). Using the
+     * kernel's clean names -- rather than `pip freeze` output -- avoids feeding
+     * `pip install -r` any line its parser can't handle (e.g. `@ file://`, `-e`,
+     * `--option`, or corrupt dist-info entries). The caller pins the update/install
+     * target; everything else stays a bare name and resolves as already-satisfied.
      */
     private async _getInstalledFreeze(token?: vscode.CancellationToken): Promise<string[]> {
-        const pythonService = await this._getPythonService();
-        const result = await pythonService.execModule('pip', ['freeze'], { token });
-        if (!result.stdout || result.stdout.trim() === '') {
-            throw new Error('Failed to read the installed package list (pip freeze returned no output).');
-        }
-        return result.stdout.split(/\r?\n/).filter((line) => line.trim() !== '');
+        const packages = await this.getPackages(token);
+        return packages.map((pkg) => pkg.name);
     }
 
     /**
@@ -246,7 +245,7 @@ export class PipPackageManager implements IPackageManager {
         await fs.writeFile(tempFile.filePath, content);
         // Log the generated requirements so the resolved set passed to pip can be
         // inspected (the temp file itself is deleted after the command runs).
-        traceVerbose(`pip package requirements file ${tempFile.filePath}:\n${content}`);
+        traceInfo(`pip package requirements file ${tempFile.filePath}:\n${content}`);
         return tempFile;
     }
 

--- a/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
@@ -10,7 +10,7 @@ import { IPythonExecutionFactory, IPythonExecutionService } from '../../common/p
 import { IFileSystem } from '../../common/platform/types';
 import { ITerminalServiceFactory } from '../../common/terminal/types';
 import { IServiceContainer } from '../../ioc/types';
-import { traceInfo } from '../../logging';
+import { traceVerbose } from '../../logging';
 import { fetchMetadataWithOutdated } from './packageMetadata';
 import { searchPyPI, searchPyPIVersions } from './pypiSearch';
 import { buildRequirementsFile } from './requirementsFile';
@@ -69,8 +69,8 @@ export class PipPackageManager implements IPackageManager {
         // Re-resolve against the full installed set so the new package can't break
         // the environment: name every installed package (bare) plus the new
         // package(s); an inconsistent install fails atomically.
-        const freezeLines = await this._getInstalledFreeze(token);
-        const content = buildRequirementsFile(freezeLines, packages);
+        const installedNames = await this._getInstalledPackageNames(token);
+        const content = buildRequirementsFile(installedNames, packages);
         const tempFile = await this._writeRequirementsTempFile(content);
         try {
             const flags = await this._getInstallFlags();
@@ -118,8 +118,8 @@ export class PipPackageManager implements IPackageManager {
         // and stay put unless the update forces a change). An inconsistent update
         // fails atomically instead of silently breaking the environment.
         const targets = packages.map((pkg) => ({ name: pkg.name, version: pkg.version! }));
-        const freezeLines = await this._getInstalledFreeze(token);
-        const content = buildRequirementsFile(freezeLines, targets);
+        const installedNames = await this._getInstalledPackageNames(token);
+        const content = buildRequirementsFile(installedNames, targets);
         const tempFile = await this._writeRequirementsTempFile(content);
         try {
             const flags = await this._getInstallFlags();
@@ -152,8 +152,8 @@ export class PipPackageManager implements IPackageManager {
         // Upgrade every installed package to its latest mutually-compatible
         // version: name them all (bare) and let pip resolve. All constraints are
         // honored; an impossible set fails atomically.
-        const freezeLines = await this._getInstalledFreeze(token);
-        const content = buildRequirementsFile(freezeLines, []);
+        const installedNames = await this._getInstalledPackageNames(token);
+        const content = buildRequirementsFile(installedNames, []);
         const tempFile = await this._writeRequirementsTempFile(content);
         try {
             const flags = await this._getInstallFlags();
@@ -230,7 +230,7 @@ export class PipPackageManager implements IPackageManager {
      * `--option`, or corrupt dist-info entries). The caller pins the update/install
      * target; everything else stays a bare name and resolves as already-satisfied.
      */
-    private async _getInstalledFreeze(token?: vscode.CancellationToken): Promise<string[]> {
+    private async _getInstalledPackageNames(token?: vscode.CancellationToken): Promise<string[]> {
         const packages = await this.getPackages(token);
         return packages.map((pkg) => pkg.name);
     }
@@ -245,7 +245,7 @@ export class PipPackageManager implements IPackageManager {
         await fs.writeFile(tempFile.filePath, content);
         // Log the generated requirements so the resolved set passed to pip can be
         // inspected (the temp file itself is deleted after the command runs).
-        traceInfo(`pip package requirements file ${tempFile.filePath}:\n${content}`);
+        traceVerbose(`pip package requirements file ${tempFile.filePath}:\n${content}`);
         return tempFile;
     }
 

--- a/extensions/positron-python/src/client/positron/packages/requirementsFile.ts
+++ b/extensions/positron-python/src/client/positron/packages/requirementsFile.ts
@@ -1,6 +1,6 @@
 /*---------------------------------------------------------------------------------------------
  *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
- *  Licensed under the Elastic License 2.0. See LICENSE.txt in the project root for license information.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
 /**

--- a/extensions/positron-python/src/client/positron/packages/requirementsFile.ts
+++ b/extensions/positron-python/src/client/positron/packages/requirementsFile.ts
@@ -37,18 +37,17 @@ export function extractRequirementName(line: string): string | undefined {
 }
 
 /**
- * Build requirements content from `freeze` output and the target packages being
- * updated. Every installed package is named so the resolver honors all
- * constraints, but plain PyPI pins are emitted as **bare names** (no version) so
- * the resolver keeps an already-satisfied package put unless something forces it
- * to move. Origin lines (direct references `name @ ...`, editables `-e ...`) and
- * comments are kept verbatim so local/VCS packages resolve without an index
- * lookup. Each target is pinned to `name==version`; targets absent from the
- * freeze output are appended. Junk and blank lines are dropped. Pass an empty
- * `targets` for Update All (the caller adds `--upgrade`). Ends with a newline.
+ * Build requirements content from the installed-package list and the target
+ * packages being updated. Every installed package is named so the resolver
+ * honors all constraints, but plain PyPI pins are emitted as **bare names**
+ * (no version) so the resolver keeps an already-satisfied package put unless
+ * something forces it to move. Each target is pinned to `name==version`;
+ * targets absent from the installed list are appended. Junk and blank lines
+ * are dropped. Pass an empty `targets` for Update All (the caller adds
+ * `--upgrade`). Ends with a newline.
  */
 export function buildRequirementsFile(
-    freezeLines: string[],
+    installedLines: string[],
     targets: Array<{ name: string; version?: string }>,
 ): string {
     const targetSpecByNormName = new Map<string, string>();
@@ -62,7 +61,7 @@ export function buildRequirementsFile(
     const out: string[] = [];
     const used = new Set<string>();
 
-    for (const raw of freezeLines) {
+    for (const raw of installedLines) {
         const line = raw.trimEnd();
         const trimmed = line.trim();
         if (trimmed === '' || JUNK_LINES.has(trimmed)) {

--- a/extensions/positron-python/src/client/positron/packages/requirementsFile.ts
+++ b/extensions/positron-python/src/client/positron/packages/requirementsFile.ts
@@ -1,6 +1,6 @@
 /*---------------------------------------------------------------------------------------------
  *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
- *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
 /**
@@ -9,9 +9,6 @@
  * `install -r` forces the resolver to honor all constraints, so an update that
  * would break the environment fails atomically instead of succeeding silently.
  */
-
-/** Freeze lines that are emitted by some environments but are not installable. */
-const JUNK_LINES = new Set(['pkg-resources==0.0.0']);
 
 /**
  * Normalize a package name per PEP 503: lowercase and collapse any run of
@@ -22,32 +19,24 @@ export function normalizePackageName(name: string): string {
 }
 
 /**
- * Extract the package name from a single `pip freeze` line, or `undefined` if
- * the line is not a plain requirement (blank, comment, option, or editable).
- * Editables (`-e ...`) are intentionally not matched: they are preserved as-is.
- */
-export function extractRequirementName(line: string): string | undefined {
-    const trimmed = line.trim();
-    if (trimmed === '' || trimmed.startsWith('#') || trimmed.startsWith('-')) {
-        return undefined;
-    }
-    // Leading PEP 508 name token, e.g. "Werkzeug==2.0.3" or "pkg @ file://...".
-    const match = trimmed.match(/^([A-Za-z0-9][A-Za-z0-9._-]*)/);
-    return match ? match[1] : undefined;
-}
-
-/**
- * Build requirements content from the installed-package list and the target
- * packages being updated. Every installed package is named so the resolver
- * honors all constraints, but plain PyPI pins are emitted as **bare names**
- * (no version) so the resolver keeps an already-satisfied package put unless
- * something forces it to move. Each target is pinned to `name==version`;
- * targets absent from the installed list are appended. Junk and blank lines
- * are dropped. Pass an empty `targets` for Update All (the caller adds
- * `--upgrade`). Ends with a newline.
+ * Build requirements content from installed package names and the target
+ * packages being updated.
+ *
+ * `installedNames` is a list of plain package names (e.g. from
+ * `getPackagesInstalled` via the kernel). Every installed package is emitted so
+ * the resolver honors all constraints:
+ * - If the package matches a target (compared via normalized PEP 503 name), it
+ *   is pinned to the target spec (`name==version`, or bare `name` if the target
+ *   has no version).
+ * - Otherwise it is emitted as a bare name so the resolver keeps it put unless
+ *   forced to move.
+ *
+ * Any target not present among the installed names is appended. Blank/whitespace
+ * entries are skipped defensively. Pass an empty `targets` for Update All (the
+ * caller adds `--upgrade`). Ends with a trailing newline.
  */
 export function buildRequirementsFile(
-    installedLines: string[],
+    installedNames: string[],
     targets: Array<{ name: string; version?: string }>,
 ): string {
     const targetSpecByNormName = new Map<string, string>();
@@ -61,29 +50,19 @@ export function buildRequirementsFile(
     const out: string[] = [];
     const used = new Set<string>();
 
-    for (const raw of installedLines) {
-        const line = raw.trimEnd();
-        const trimmed = line.trim();
-        if (trimmed === '' || JUNK_LINES.has(trimmed)) {
+    for (const raw of installedNames) {
+        const name = raw.trim();
+        if (name === '') {
             continue;
         }
-        const name = extractRequirementName(line);
-        if (name) {
-            const norm = normalizePackageName(name);
-            const targetSpec = targetSpecByNormName.get(norm);
-            if (targetSpec !== undefined) {
-                out.push(targetSpec);
-                used.add(norm);
-                continue;
-            }
-            // Plain PyPI pin -> bare name. Origin lines (containing `@`) fall
-            // through to verbatim so a local/VCS package isn't sent to the index.
-            if (!line.includes('@')) {
-                out.push(name);
-                continue;
-            }
+        const norm = normalizePackageName(name);
+        const targetSpec = targetSpecByNormName.get(norm);
+        if (targetSpec !== undefined) {
+            out.push(targetSpec);
+            used.add(norm);
+        } else {
+            out.push(name);
         }
-        out.push(line);
     }
 
     for (const [norm, spec] of targetSpecByNormName) {

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -13,7 +13,7 @@ import { IProcessServiceFactory } from '../../common/process/types';
 import { ITerminalServiceFactory } from '../../common/terminal/types';
 import { IServiceContainer } from '../../ioc/types';
 import { isUvInstalled } from '../../pythonEnvironments/common/environmentManagers/uv';
-import { traceVerbose } from '../../logging';
+import { traceInfo } from '../../logging';
 import { fetchMetadataWithOutdated } from './packageMetadata';
 import { buildRequirementsFile } from './requirementsFile';
 import { searchPyPI, searchPyPIVersions } from './pypiSearch';
@@ -275,17 +275,8 @@ export class UvPackageManager implements IPackageManager {
      * install origins so already-installed packages resolve as satisfied.
      */
     private async _getInstalledFreeze(token?: vscode.CancellationToken): Promise<string[]> {
-        const processServiceFactory = this._serviceContainer.get<IProcessServiceFactory>(IProcessServiceFactory);
-        const processService = await processServiceFactory.create();
-        const proxyEnv = this._getProxyEnv();
-        const result = await processService.exec('uv', ['pip', 'freeze', '--python', this._pythonPath], {
-            extraVariables: proxyEnv,
-            token,
-        });
-        if (!result.stdout || result.stdout.trim() === '') {
-            throw new Error('Failed to read the installed package list (uv pip freeze returned no output).');
-        }
-        return result.stdout.split(/\r?\n/).filter((line) => line.trim() !== '');
+        const packages = await this.getPackages(token);
+        return packages.map((pkg) => pkg.name);
     }
 
     /**
@@ -298,7 +289,7 @@ export class UvPackageManager implements IPackageManager {
         await fs.writeFile(tempFile.filePath, content);
         // Log the generated requirements so the resolved set passed to uv can be
         // inspected (the temp file itself is deleted after the command runs).
-        traceVerbose(`uv package requirements file ${tempFile.filePath}:\n${content}`);
+        traceInfo(`uv package requirements file ${tempFile.filePath}:\n${content}`);
         return tempFile;
     }
 

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -13,7 +13,7 @@ import { IProcessServiceFactory } from '../../common/process/types';
 import { ITerminalServiceFactory } from '../../common/terminal/types';
 import { IServiceContainer } from '../../ioc/types';
 import { isUvInstalled } from '../../pythonEnvironments/common/environmentManagers/uv';
-import { traceInfo } from '../../logging';
+import { traceVerbose } from '../../logging';
 import { fetchMetadataWithOutdated } from './packageMetadata';
 import { buildRequirementsFile } from './requirementsFile';
 import { searchPyPI, searchPyPIVersions } from './pypiSearch';
@@ -79,8 +79,8 @@ export class UvPackageManager implements IPackageManager {
             // Re-resolve against the full installed set: name every installed
             // package (bare) plus the new package(s) so an inconsistent install
             // fails atomically instead of breaking the environment.
-            const freezeLines = await this._getInstalledFreeze(token);
-            const content = buildRequirementsFile(freezeLines, packages);
+            const installedNames = await this._getInstalledPackageNames(token);
+            const content = buildRequirementsFile(installedNames, packages);
             const tempFile = await this._writeRequirementsTempFile(content);
             try {
                 const args = ['pip', 'install', '-r', tempFile.filePath, '--python', this._pythonPath];
@@ -141,8 +141,8 @@ export class UvPackageManager implements IPackageManager {
             // Re-resolve against the full installed set: name every package (bare),
             // pin only the target, so an inconsistent update fails atomically.
             const targets = packages.map((pkg) => ({ name: pkg.name, version: pkg.version! }));
-            const freezeLines = await this._getInstalledFreeze(token);
-            const content = buildRequirementsFile(freezeLines, targets);
+            const installedNames = await this._getInstalledPackageNames(token);
+            const content = buildRequirementsFile(installedNames, targets);
             const tempFile = await this._writeRequirementsTempFile(content);
             try {
                 const args = ['pip', 'install', '-r', tempFile.filePath, '--python', this._pythonPath];
@@ -176,8 +176,8 @@ export class UvPackageManager implements IPackageManager {
 
             // Upgrade every installed package to its latest mutually-compatible
             // version: name them all (bare) and let uv resolve.
-            const freezeLines = await this._getInstalledFreeze(token);
-            const content = buildRequirementsFile(freezeLines, []);
+            const installedNames = await this._getInstalledPackageNames(token);
+            const content = buildRequirementsFile(installedNames, []);
             const tempFile = await this._writeRequirementsTempFile(content);
             try {
                 const args = ['pip', 'install', '--upgrade', '-r', tempFile.filePath, '--python', this._pythonPath];
@@ -271,10 +271,14 @@ export class UvPackageManager implements IPackageManager {
     }
 
     /**
-     * Capture the full installed set as pinned `uv pip freeze` lines, preserving
-     * install origins so already-installed packages resolve as satisfied.
+     * Capture the full installed set as bare package names from the kernel's
+     * installed-package list (the same data the Packages pane shows). Using the
+     * kernel's clean names -- rather than `uv pip freeze` output -- avoids feeding
+     * `uv pip install -r` any line its parser can't handle (e.g. `@ file://`, `-e`,
+     * `--option`, or corrupt dist-info entries). The caller pins the update/install
+     * target; everything else stays a bare name and resolves as already-satisfied.
      */
-    private async _getInstalledFreeze(token?: vscode.CancellationToken): Promise<string[]> {
+    private async _getInstalledPackageNames(token?: vscode.CancellationToken): Promise<string[]> {
         const packages = await this.getPackages(token);
         return packages.map((pkg) => pkg.name);
     }
@@ -289,7 +293,7 @@ export class UvPackageManager implements IPackageManager {
         await fs.writeFile(tempFile.filePath, content);
         // Log the generated requirements so the resolved set passed to uv can be
         // inspected (the temp file itself is deleted after the command runs).
-        traceInfo(`uv package requirements file ${tempFile.filePath}:\n${content}`);
+        traceVerbose(`uv package requirements file ${tempFile.filePath}:\n${content}`);
         return tempFile;
     }
 

--- a/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
@@ -37,11 +37,6 @@ suite('PipPackageManager update Tests', () => {
             isModuleInstalled: sinon.stub().resolves(true),
             execModule: sinon.stub(),
         };
-        // Default freeze output; individual tests can override.
-        pythonService.execModule.withArgs('pip', sinon.match.array.startsWith(['freeze'])).resolves({
-            stdout: 'flask==2.2.0\nwerkzeug==2.0.3\npositron-update-demo @ file:///tmp/demo\n',
-            stderr: '',
-        });
 
         terminalService = {
             show: sinon.stub().resolves(),
@@ -78,7 +73,14 @@ suite('PipPackageManager update Tests', () => {
             .returns(fileSystem);
 
         messageEmitter = { fire: sinon.stub() };
-        session = { metadata: { sessionId: 'test' }, callMethod: sinon.stub().resolves([]) };
+        // getPackages() (used to build the installed set) calls the kernel's
+        // 'getPackagesInstalled' method; return clean names like the real kernel.
+        session = {
+            metadata: { sessionId: 'test' },
+            callMethod: sinon
+                .stub()
+                .resolves([{ name: 'flask' }, { name: 'werkzeug' }, { name: 'positron-update-demo' }]),
+        };
         manager = new PipPackageManager('/path/to/python', messageEmitter, serviceContainer, session);
     });
 
@@ -93,7 +95,7 @@ suite('PipPackageManager update Tests', () => {
         expect(writtenContent).to.contain('werkzeug==3.1.8'); // target pinned
         expect(writtenContent).to.contain('flask'); // other PyPI -> bare
         expect(writtenContent).to.not.contain('flask==2.2.0'); // not pinned
-        expect(writtenContent).to.contain('positron-update-demo @ file:///tmp/demo'); // origin verbatim
+        expect(writtenContent).to.contain('positron-update-demo'); // installed (local) -> bare name
 
         const [pythonPath, args] = terminalService.sendCommand.firstCall.args;
         expect(pythonPath).to.equal('/path/to/python');
@@ -134,7 +136,7 @@ suite('PipPackageManager update Tests', () => {
 
         expect(writtenContent).to.contain('werkzeug'); // bare, no pin
         expect(writtenContent).to.not.contain('werkzeug==');
-        expect(writtenContent).to.contain('positron-update-demo @ file:///tmp/demo');
+        expect(writtenContent).to.contain('positron-update-demo');
         const [, args] = terminalService.sendCommand.firstCall.args;
         expect(args).to.include.members(['install', '--upgrade', '-r', '/tmp/reqs.txt']);
     });
@@ -154,7 +156,7 @@ suite('PipPackageManager update Tests', () => {
 
         expect(writtenContent).to.contain('cowsay==6.1'); // new package pinned
         expect(writtenContent).to.contain('flask'); // installed -> bare
-        expect(writtenContent).to.contain('positron-update-demo @ file:///tmp/demo'); // origin verbatim
+        expect(writtenContent).to.contain('positron-update-demo'); // installed (local) -> bare name
         const [, args] = terminalService.sendCommand.firstCall.args;
         expect(args).to.include.members(['install', '-r', '/tmp/reqs.txt']);
         expect(args).to.not.include('--upgrade');

--- a/extensions/positron-python/src/test/positron/requirementsFile.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/requirementsFile.unit.test.ts
@@ -1,16 +1,12 @@
 /*---------------------------------------------------------------------------------------------
  *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
- *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
 'use strict';
 
 import { expect } from 'chai';
-import {
-    buildRequirementsFile,
-    extractRequirementName,
-    normalizePackageName,
-} from '../../client/positron/packages/requirementsFile';
+import { buildRequirementsFile, normalizePackageName } from '../../client/positron/packages/requirementsFile';
 
 suite('requirementsFile Tests', () => {
     suite('normalizePackageName', () => {
@@ -22,85 +18,53 @@ suite('requirementsFile Tests', () => {
         });
     });
 
-    suite('extractRequirementName', () => {
-        test('reads the name from a pinned spec', () => {
-            expect(extractRequirementName('Werkzeug==2.0.3')).to.equal('Werkzeug');
-        });
-
-        test('reads the name from a direct-reference spec', () => {
-            expect(extractRequirementName('positron-update-demo @ file:///tmp/demo')).to.equal('positron-update-demo');
-        });
-
-        test('ignores comments, blanks, options, and editables', () => {
-            expect(extractRequirementName('')).to.equal(undefined);
-            expect(extractRequirementName('   ')).to.equal(undefined);
-            expect(extractRequirementName('# a comment')).to.equal(undefined);
-            expect(extractRequirementName('--index-url https://example.com')).to.equal(undefined);
-            expect(extractRequirementName('-e /path/to/pkg')).to.equal(undefined);
-        });
-    });
-
     suite('buildRequirementsFile', () => {
-        test('bare-names plain PyPI pins and pins the target', () => {
-            const lines = ['flask==2.2.0', 'Werkzeug==2.0.3', 'positron-update-demo @ file:///tmp/demo'];
-            const result = buildRequirementsFile(lines, [{ name: 'werkzeug', version: '3.1.8' }]);
-            expect(result).to.equal(
-                ['flask', 'werkzeug==3.1.8', 'positron-update-demo @ file:///tmp/demo'].join('\n') + '\n',
-            );
+        test('pins the target and emits other names bare', () => {
+            const names = ['flask', 'werkzeug', 'positron-update-demo'];
+            const result = buildRequirementsFile(names, [{ name: 'werkzeug', version: '3.1.8' }]);
+            expect(result).to.equal(['flask', 'werkzeug==3.1.8', 'positron-update-demo'].join('\n') + '\n');
         });
 
-        test('keeps origin lines (direct reference and editable) verbatim', () => {
-            const lines = ['pkg @ file:///tmp/pkg', '-e /tmp/editable', 'requests==2.28.0'];
-            const result = buildRequirementsFile(lines, []);
-            expect(result).to.equal(['pkg @ file:///tmp/pkg', '-e /tmp/editable', 'requests'].join('\n') + '\n');
-        });
-
-        test('with no targets (Update All) leaves everything bare or verbatim', () => {
-            const lines = ['flask==2.2.0', 'werkzeug==2.0.3'];
-            const result = buildRequirementsFile(lines, []);
-            expect(result).to.equal(['flask', 'werkzeug'].join('\n') + '\n');
-        });
-
-        test('matches the target case-insensitively on the normalized name', () => {
-            const lines = ['Typing_Extensions==4.0.0'];
-            const result = buildRequirementsFile(lines, [{ name: 'typing-extensions', version: '4.9.0' }]);
+        test('matches target case-insensitively on normalized name', () => {
+            const names = ['Typing_Extensions'];
+            const result = buildRequirementsFile(names, [{ name: 'typing-extensions', version: '4.9.0' }]);
             expect(result).to.equal('typing-extensions==4.9.0\n');
         });
 
+        test('versionless target is emitted as a bare name when matched', () => {
+            const result = buildRequirementsFile(['requests'], [{ name: 'requests' }]);
+            expect(result).to.equal('requests\n');
+        });
+
         test('pins multiple targets for a multi-package update', () => {
-            const lines = ['flask==2.2.0', 'werkzeug==2.0.3', 'requests==2.28.0'];
-            const result = buildRequirementsFile(lines, [
+            const names = ['flask', 'werkzeug', 'requests'];
+            const result = buildRequirementsFile(names, [
                 { name: 'flask', version: '3.0.0' },
                 { name: 'requests', version: '2.31.0' },
             ]);
             expect(result).to.equal(['flask==3.0.0', 'werkzeug', 'requests==2.31.0'].join('\n') + '\n');
         });
 
-        test('filters the pkg-resources==0.0.0 junk line and blank lines', () => {
-            const lines = ['pkg-resources==0.0.0', '', 'flask==2.2.0'];
-            const result = buildRequirementsFile(lines, []);
-            expect(result).to.equal('flask\n');
+        test('with no targets (Update All) emits all names bare', () => {
+            const names = ['flask', 'werkzeug'];
+            const result = buildRequirementsFile(names, []);
+            expect(result).to.equal(['flask', 'werkzeug'].join('\n') + '\n');
         });
 
-        test('appends a target absent from the freeze output', () => {
-            const lines = ['flask==2.2.0'];
-            const result = buildRequirementsFile(lines, [{ name: 'requests', version: '2.31.0' }]);
+        test('appends a target absent from the installed names', () => {
+            const result = buildRequirementsFile(['flask'], [{ name: 'requests', version: '2.31.0' }]);
             expect(result).to.equal(['flask', 'requests==2.31.0'].join('\n') + '\n');
         });
 
-        test('pins a target even when its freeze line is a direct reference', () => {
-            const result = buildRequirementsFile(['foo @ file:///x'], [{ name: 'foo', version: '2.0' }]);
-            expect(result).to.equal('foo==2.0\n');
-        });
-
-        test('appends a versionless target as a bare name', () => {
-            const result = buildRequirementsFile(['flask==2.2.0'], [{ name: 'requests' }]);
+        test('appends a versionless target absent from the installed names as bare name', () => {
+            const result = buildRequirementsFile(['flask'], [{ name: 'requests' }]);
             expect(result).to.equal(['flask', 'requests'].join('\n') + '\n');
         });
 
-        test('replaces a matching line with a bare name when the target has no version', () => {
-            const result = buildRequirementsFile(['requests==2.28.0'], [{ name: 'requests' }]);
-            expect(result).to.equal('requests\n');
+        test('skips blank and whitespace-only entries defensively', () => {
+            const names = ['', '  ', 'flask'];
+            const result = buildRequirementsFile(names, []);
+            expect(result).to.equal('flask\n');
         });
     });
 });

--- a/extensions/positron-python/src/test/positron/requirementsFile.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/requirementsFile.unit.test.ts
@@ -1,6 +1,6 @@
 /*---------------------------------------------------------------------------------------------
  *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
- *  Licensed under the Elastic License 2.0. See LICENSE.txt in the project root for license information.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
 'use strict';

--- a/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
@@ -82,10 +82,13 @@ suite('UvPackageManager Tests', () => {
             fire: sinon.stub(),
         };
 
-        // Create session mock
+        // Create session mock. getPackages() (used to build the installed set)
+        // calls the kernel's 'getPackagesInstalled'; return clean names.
         session = {
             metadata: { sessionId: 'test-session-id' },
-            callMethod: sinon.stub().resolves([]),
+            callMethod: sinon
+                .stub()
+                .resolves([{ name: 'flask' }, { name: 'werkzeug' }, { name: 'positron-update-demo' }]),
         };
 
         // Create package manager instance
@@ -275,11 +278,6 @@ version = "0.1.0"`;
             sinon.stub(uvPackageManager, 'isUvAvailable').resolves(true);
 
             processService = { exec: sinon.stub() };
-            // uv pip freeze -- includes a plain PyPI package so bare-naming is observable
-            processService.exec.withArgs('uv', sinon.match.array.startsWith(['pip', 'freeze'])).resolves({
-                stdout: 'flask==2.2.0\nwerkzeug==2.0.3\npositron-update-demo @ file:///tmp/demo\n',
-                stderr: '',
-            });
             const processFactory = { create: sinon.stub().resolves(processService) };
 
             terminalService = {
@@ -307,7 +305,7 @@ version = "0.1.0"`;
             expect(written).to.contain('werkzeug==3.1.8');
             expect(written).to.contain('flask');
             expect(written).to.not.contain('flask==2.2.0');
-            expect(written).to.contain('positron-update-demo @ file:///tmp/demo');
+            expect(written).to.contain('positron-update-demo'); // installed (local) -> bare name
 
             const [uvBin, args] = terminalService.sendCommand.firstCall.args;
             expect(uvBin).to.equal('uv');


### PR DESCRIPTION
## Summary

The merged fix in #14495 built the `install -r` requirements file by running
`pip freeze` / `uv pip freeze` and passing that output directly to
`pip install -r` / `uv pip install -r`. Freeze output can contain lines the
requirements parser rejects:

- Direct-URL references: `package @ file:///path/to/dist`
- Editables: `-e git+https://...`
- Option directives (some tools emit these)
- Corrupt `~` dist-info entries in broken environments

These caused `uv pip install -r` to error on the first non-clean line, which
regressed the packages-pane Python (uv) install/update e2e.

This fix sources the installed set from the kernel's `getPackagesInstalled`
(the same data the Packages pane displays) instead of running freeze. The
generated requirements file contains only clean bare names plus the pinned
target, which both pip and uv parse without issue.

**Constraints are still honored.** Naming a package bare (without a version)
pulls its dependency metadata into the resolver's input set, so an update that
would break the environment still fails atomically. The env-safety guarantee
from #14495 is unchanged.

**Known limitation.** Bare names drop install origins, so for a *local or
non-PyPI* package the resolver may consult the index only when that package
must move (a conflict, or Update All's `--upgrade`). The worst realistic case
is a name collision with a same-named index package -- rare in practice, and
the previous freeze-based approach already broke entirely on such packages.

## Release Notes

### Bug Fixes

- Fix Python package install/update failing in environments where the package list isn't round-trippable through pip/uv freeze (#14328)

### New Features

N/A

See #14328

@:packages-pane @:web