### PR TITLE
Diagnostic: log package requirements at info level (#14328)

### DIFF
--- a/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
@@ -10,7 +10,7 @@ import { IPythonExecutionFactory, IPythonExecutionService } from '../../common/p
 import { IFileSystem } from '../../common/platform/types';
 import { ITerminalServiceFactory } from '../../common/terminal/types';
 import { IServiceContainer } from '../../ioc/types';
-import { traceVerbose } from '../../logging';
+import { traceInfo } from '../../logging';
 import { fetchMetadataWithOutdated } from './packageMetadata';
 import { searchPyPI, searchPyPIVersions } from './pypiSearch';
 import { buildRequirementsFile } from './requirementsFile';
@@ -246,7 +246,7 @@ export class PipPackageManager implements IPackageManager {
         await fs.writeFile(tempFile.filePath, content);
         // Log the generated requirements so the resolved set passed to pip can be
         // inspected (the temp file itself is deleted after the command runs).
-        traceVerbose(`pip package requirements file ${tempFile.filePath}:\n${content}`);
+        traceInfo(`pip package requirements file ${tempFile.filePath}:\n${content}`);
         return tempFile;
     }
 

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -13,7 +13,7 @@ import { IProcessServiceFactory } from '../../common/process/types';
 import { ITerminalServiceFactory } from '../../common/terminal/types';
 import { IServiceContainer } from '../../ioc/types';
 import { isUvInstalled } from '../../pythonEnvironments/common/environmentManagers/uv';
-import { traceVerbose } from '../../logging';
+import { traceInfo } from '../../logging';
 import { fetchMetadataWithOutdated } from './packageMetadata';
 import { buildRequirementsFile } from './requirementsFile';
 import { searchPyPI, searchPyPIVersions } from './pypiSearch';
@@ -298,7 +298,7 @@ export class UvPackageManager implements IPackageManager {
         await fs.writeFile(tempFile.filePath, content);
         // Log the generated requirements so the resolved set passed to uv can be
         // inspected (the temp file itself is deleted after the command runs).
-        traceVerbose(`uv package requirements file ${tempFile.filePath}:\n${content}`);
+        traceInfo(`uv package requirements file ${tempFile.filePath}:\n${content}`);
         return tempFile;
     }
 


### PR DESCRIPTION
Pure diagnostic for the merged install regression (#14495 -> #14328). This is **main + a log-level change only**: it keeps the current `pip freeze` / `uv pip freeze` behavior (so the e2e still reproduces the failure) but logs the generated requirements content at **info** instead of verbose.

Why info: the merged code already logs the content via `traceVerbose`, but that maps to `channel.debug()` on the "Python Language Pack" `LogOutputChannel`, which sits at **info** and does **not** honor the e2e harness's `--log=trace` (confirmed: the captured Python Language Pack logs contain `[info]`/`[warning]`/`[error]` lines but zero `[debug]`/`[trace]`). Logging at info guarantees the content is captured in the e2e log artifacts.

Goal: see the exact requirements file content handed to `uv pip install -r` in CI, to identify the precise line uv's parser rejects (`Unexpected '<token>', expected '-c', '-e', '-r' or the start of a requirement at <file>:1:1`).

After this runs, read the failing test's `server/exthostN/ms-python.python/Python Language Pack.log` (in the `e2e-*-logs` artifact) for the `package requirements file` line.

Running the packages-pane e2e: @:packages-pane @:web

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A (diagnostic PR; see #14328)

### Validation Steps

@:packages-pane @:web

This PR is expected to FAIL the Python install e2e (same as main) -- the value is the captured requirements content in the Python Language Pack log.
