### PR TITLE
uv: disable color on parsed freeze/list output (alt fix for #14328)

### DIFF
--- a/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
@@ -216,9 +216,13 @@ export class PipPackageManager implements IPackageManager {
     ): Promise<Array<{ name: string; latest_version: string }>> {
         const pythonService = await this._getPythonService();
         const proxyFlags = this._getProxyFlags();
-        const result = await pythonService.execModule('pip', ['list', '--outdated', '--format=json', ...proxyFlags], {
-            token,
-        });
+        const result = await pythonService.execModule(
+            'pip',
+            ['list', '--outdated', '--format=json', '--no-color', ...proxyFlags],
+            {
+                token,
+            },
+        );
         return JSON.parse(result.stdout) as Array<{ name: string; latest_version: string }>;
     }
 
@@ -229,7 +233,10 @@ export class PipPackageManager implements IPackageManager {
      */
     private async _getInstalledFreeze(token?: vscode.CancellationToken): Promise<string[]> {
         const pythonService = await this._getPythonService();
-        const result = await pythonService.execModule('pip', ['freeze'], { token });
+        // --no-color defensively: pip doesn't colorize `freeze` today, but
+        // FORCE_COLOR/CLICOLOR_FORCE could lead to ANSI codes that would corrupt
+        // the requirements file fed to `pip install -r` (as uv does -- see #14328).
+        const result = await pythonService.execModule('pip', ['freeze', '--no-color'], { token });
         if (!result.stdout || result.stdout.trim() === '') {
             throw new Error('Failed to read the installed package list (pip freeze returned no output).');
         }

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -278,10 +278,18 @@ export class UvPackageManager implements IPackageManager {
         const processServiceFactory = this._serviceContainer.get<IProcessServiceFactory>(IProcessServiceFactory);
         const processService = await processServiceFactory.create();
         const proxyEnv = this._getProxyEnv();
-        const result = await processService.exec('uv', ['pip', 'freeze', '--python', this._pythonPath], {
-            extraVariables: proxyEnv,
-            token,
-        });
+        // Force --color never: uv honors FORCE_COLOR/CLICOLOR_FORCE even when its
+        // output is piped, and `uv pip freeze` then wraps package names in ANSI
+        // codes (e.g. "\x1b[1mscipy\x1b[0m==1.15.3"). Feeding those to
+        // `uv pip install -r` makes uv's requirements parser reject the ESC byte.
+        const result = await processService.exec(
+            'uv',
+            ['pip', 'freeze', '--color', 'never', '--python', this._pythonPath],
+            {
+                extraVariables: proxyEnv,
+                token,
+            },
+        );
         if (!result.stdout || result.stdout.trim() === '') {
             throw new Error('Failed to read the installed package list (uv pip freeze returned no output).');
         }
@@ -327,7 +335,7 @@ export class UvPackageManager implements IPackageManager {
         try {
             const result = await processService.exec(
                 'uv',
-                ['pip', 'list', '--outdated', '--format=json', '--python', this._pythonPath],
+                ['pip', 'list', '--outdated', '--format=json', '--color', 'never', '--python', this._pythonPath],
                 { extraVariables: proxyEnv, token },
             );
 


### PR DESCRIPTION
Alternative fix to #14520 for the install regression from #14495 (see #14328).

### Root cause (confirmed)
`uv pip freeze` colorizes package names with ANSI codes (`\x1b[1mscipy\x1b[0m==1.15.3`) when `FORCE_COLOR` / `CLICOLOR_FORCE` is set -- which uv honors even when its output is piped (not a TTY), as in CI and in some users' shells. Those escape codes ended up in the temporary requirements file, and `uv pip install -r` then rejects the ESC byte: `Unexpected '<ESC>', expected '-c', '-e', '-r' or the start of a requirement at <file>:1:1`. (pip's `freeze` isn't colorized, which is why only the uv runtime broke.)

### This fix
Keep the freeze-based approach, but pass `--color never` on the uv subprocess calls whose stdout we parse (`uv pip freeze`, and defensively `uv pip list --outdated --format=json`). Verified locally that `--color never` overrides both `FORCE_COLOR` and `CLICOLOR_FORCE`.

### Relationship to #14520
#14520 fixes the same bug differently -- by sourcing the installed set from the kernel's `getPackagesInstalled` (plain names) instead of freeze. Trade-offs:
- **This PR (`--color never`)**: smaller change; keeps freeze, so it preserves install origins (`@ file://`, `-e`) for local/editable/VCS packages. Still relies on freeze output being otherwise parseable by uv.
- **#14520 (getPackages)**: more robust against any freeze-output quirk (always clean names), but drops origin info, so a local/editable package becomes a bare name (minor edge for Update All `--upgrade`).

Pick one. Running the packages-pane e2e here to confirm: @:packages-pane @:web

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix Python package install/update failing on the uv runtime when colorized `uv pip freeze` output is fed to `uv pip install -r` (#14328)

### Validation Steps

@:packages-pane @:web

The packages-pane Python install/uninstall e2e must pass on e2e-electron and e2e-chromium (it currently fails on main for the uv runtime).
