### PR TITLE
Gate Copilot Chat activation on `ai.enabled` instead of deprecated `positron.assistant.enable`

### DIFF
--- a/extensions/copilot/eslint.config.mjs
+++ b/extensions/copilot/eslint.config.mjs
@@ -535,4 +535,14 @@ export default tseslint.config(
 			'import/no-restricted-paths': 'off'
 		}
 	},
+	// --- Start Positron ---
+	// Positron-specific test files in the positron/ subdirectory are contributed
+	// by Posit and thus don't have the Microsoft header.
+	{
+		files: ['./src/extension/test/positron/**/*.test.ts', './src/extension/test/positron/**/*.test.tsx'],
+		rules: {
+			'header/header': 'off'
+		}
+	},
+	// --- End Positron ---
 );

--- a/extensions/copilot/src/extension/extension/vscode-node/extension.ts
+++ b/extensions/copilot/src/extension/extension/vscode-node/extension.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExtensionContext, workspace } from 'vscode';
+import { ExtensionContext } from 'vscode';
 import { resolve } from '../../../util/vs/base/common/path';
 import { baseActivate } from '../vscode/extension';
 import { vscodeNodeContributions } from './contributions';
@@ -33,15 +33,6 @@ function configureDevPackages() {
 //#endregion
 
 export function activate(context: ExtensionContext, forceActivation?: boolean) {
-	// --- Start Positron ---
-	// Don't enable the extension when Positron Assistant is disabled
-	const enabled = workspace.getConfiguration('positron.assistant').get('enable');
-	if (!enabled) {
-		console.log(`[Copilot Chat] Disabling since Positron Assistant is disabled`);
-		return;
-	}
-	// --- End Positron ---
-
 	return baseActivate({
 		context,
 		registerServices,

--- a/extensions/copilot/src/extension/extension/vscode/extension.ts
+++ b/extensions/copilot/src/extension/extension/vscode/extension.ts
@@ -41,9 +41,8 @@ export async function baseActivate(configuration: IExtensionActivationConfigurat
 	}
 
 	// --- Start Positron ---
-	// Don't enable the extension when Positron Assistant is disabled
-	const enabled = workspace.getConfiguration('positron.assistant').get('enable');
-	if (!enabled) {
+	// Don't activate when the AI switch is off.
+	if (workspace.getConfiguration().get('ai.enabled') === false) {
 		return context;
 	}
 	// --- End Positron ---

--- a/extensions/copilot/src/extension/test/positron/vscode-node/aiGating.test.ts
+++ b/extensions/copilot/src/extension/test/positron/vscode-node/aiGating.test.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ConfigurationTarget, ExtensionContext, ExtensionMode, workspace } from 'vscode';
+import { vscodeNodeContributions } from '../../../extension/vscode-node/contributions';
+import { registerServices } from '../../../extension/vscode-node/services';
+import { baseActivate } from '../../../extension/vscode/extension';
+
+suite('Positron AI gating', function () {
+
+	teardown(async () => {
+		await workspace.getConfiguration().update('ai.enabled', undefined, ConfigurationTarget.Global);
+	});
+
+	test('does not activate when ai.enabled is false', async function () {
+		await workspace.getConfiguration().update('ai.enabled', false, ConfigurationTarget.Global);
+
+		// `forceActivation` skips the `ExtensionMode.Test` early return, so the
+		// `ai.enabled` check is the only thing that can stop activation here.
+		// `isPreRelease` is left unset so the pre-release return isn't the reason.
+		const extensionContext = {
+			extensionMode: ExtensionMode.Test,
+			subscriptions: [] as { dispose(): void }[],
+			extension: {
+				packageJSON: { name: 'copilot' },
+			},
+		} as ExtensionContext;
+
+		const result = await baseActivate({
+			context: extensionContext,
+			contributions: vscodeNodeContributions,
+			registerServices,
+			forceActivation: true,
+		});
+
+		// When the check stops activation it returns the same context before creating
+		// any services or contributions, so nothing is added to `subscriptions`.
+		assert.strictEqual(result, extensionContext);
+		assert.strictEqual(extensionContext.subscriptions.length, 0);
+	});
+});


### PR DESCRIPTION
Fixes #14526.

Copilot Chat's activation was gated on `positron.assistant.enable`. When that setting was off, the extension never activated, so its `vscode.lm` model provider never registered, leaving Copilot invisible to Posit Assistant even for authenticated users.

This switches the activation gate to `ai.enabled` (the main AI switch), matching the other AI features, and drops the now-redundant duplicate check in the node entry point since `baseActivate` handles it.

`positron.assistant.enable` is deprecated and on its way out, so it shouldn't gate activation anymore.
