### PR TITLE
Fix leaked disposable when using a real context key service

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/test/browser/testPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/testPositronNotebookInstance.ts
@@ -155,7 +155,10 @@ export function instantiateTestNotebookInstance(
 	const overlayContainer = document.createElement('div');
 	editorContainer.appendChild(notebookContainer);
 	editorContainer.appendChild(overlayContainer);
-	const scopedContextKeyService = instantiationService.invokeFunction(accessor => accessor.get(IContextKeyService)).createScoped(editorContainer);
+	const scopedContextKeyService = disposables.add(
+		instantiationService.invokeFunction(accessor =>
+			accessor.get(IContextKeyService)).createScoped(editorContainer)
+	);
 	notebook.attachView(editorContainer, scopedContextKeyService, notebookContainer, overlayContainer);
 
 	// Auto-attach test editors to all cells (initial and dynamically added).


### PR DESCRIPTION
This has no effect atm because we use a non-disposable mock context key service. In my other work (#14264), I need to use a real context key service.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

Test change only.