### PR TITLE
fix(e2e-analyzer): skip Slack thread append when no e2e job failed

### DIFF
--- a/.github/actions/e2e-failure-analyzer/action.yml
+++ b/.github/actions/e2e-failure-analyzer/action.yml
@@ -257,7 +257,10 @@ runs:
         # thread exists, so an append would never match and the scheduler would
         # log a false "no Slack thread found" warning. Gate on run-info.json's
         # isE2e flag, which the gather step already sets per failed job.
-        E2E_FAILURES=$(jq '[.failedJobs[]? | select(.isE2e)] | length' "$WORK_DIR/run-info.json")
+        # 2>/dev/null || echo 0: fail closed (skip) on a missing/malformed
+        # run-info.json rather than letting a jq parse error abort this step
+        # under the default `bash -eo pipefail` — posting is best-effort.
+        E2E_FAILURES=$(jq '[.failedJobs[]? | select(.isE2e)] | length' "$WORK_DIR/run-info.json" 2>/dev/null || echo 0)
         if [ "${E2E_FAILURES:-0}" -eq 0 ]; then
           echo "No failed e2e jobs in this run; skipping Slack thread append (no thread registered)."
           exit 0

--- a/.github/actions/e2e-failure-analyzer/action.yml
+++ b/.github/actions/e2e-failure-analyzer/action.yml
@@ -251,6 +251,17 @@ runs:
           echo "No analysis-report.md produced; skipping Slack thread append."
           exit 0
         fi
+        # Only post when an actual e2e job failed. A Slack thread is registered
+        # only when e2e tests run and report results; on runs that fail before
+        # e2e (e.g. build/installer failures, where e2e jobs are skipped) no
+        # thread exists, so an append would never match and the scheduler would
+        # log a false "no Slack thread found" warning. Gate on run-info.json's
+        # isE2e flag, which the gather step already sets per failed job.
+        E2E_FAILURES=$(jq '[.failedJobs[]? | select(.isE2e)] | length' "$WORK_DIR/run-info.json")
+        if [ "${E2E_FAILURES:-0}" -eq 0 ]; then
+          echo "No failed e2e jobs in this run; skipping Slack thread append (no thread registered)."
+          exit 0
+        fi
 
         # The e2e-test-insights API uses a single "positron" repo ID for both
         # posit-dev/positron and posit-dev/positron-builds (same as the history


### PR DESCRIPTION
### Summary
The analyzer posts its report link to a run's Slack thread, but a thread only exists when e2e tests actually ran and reported results. On runs that fail *before* e2e (build/installer failures, where e2e jobs are skipped), no thread is registered — yet the analyzer still posted an append, producing a false "no Slack thread found" warning in the dashboard's Slack scheduler every time.

- Gate the "Post analysis link to Slack thread" step on an actual e2e job failure, using `run-info.json`'s `isE2e` flag (already set per failed job by the gather step)
- No behavior change for real e2e failures; the link still posts
- Bonus: avoids a needless webhook call on pure build failures

### QA Notes
Pairs with positron-builds reverting the `post_to_slack_thread: false` workaround (#1073). Deploy this first (submodule bump) so build-failure runs stop posting before build-release re-enables the append.