### PR TITLE
Respect workspace requirements.txt for Python package operations

### DIFF
--- a/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
@@ -8,12 +8,14 @@ import * as positron from 'positron';
 import * as vscode from 'vscode';
 import { IPythonExecutionFactory, IPythonExecutionService } from '../../common/process/types';
 import { IFileSystem } from '../../common/platform/types';
+import { IWorkspaceService } from '../../common/application/types';
 import { ITerminalServiceFactory } from '../../common/terminal/types';
 import { IServiceContainer } from '../../ioc/types';
 import { traceVerbose } from '../../logging';
 import { fetchMetadataWithOutdated } from './packageMetadata';
 import { searchPyPI, searchPyPIVersions } from './pypiSearch';
 import { buildRequirementsFile } from './requirementsFile';
+import { findWorkspaceRequirementsFile } from './workspaceRequirements';
 import { IPackageManager, MessageEmitter, PackageSession } from './types';
 
 /**
@@ -66,6 +68,18 @@ export class PipPackageManager implements IPackageManager {
 
         await this._ensurePip();
 
+        const requirementsPath = await this._getWorkspaceRequirementsPath();
+        if (requirementsPath) {
+            // requirements.txt is the source of truth: pass the target on the
+            // command line plus -r <file> (verbatim). The resolver intersects the
+            // target with the file; a conflict fails atomically.
+            const specs = this._formatPackageSpecs(packages);
+            const flags = await this._getInstallFlags();
+            const args = ['install', ...specs, '-r', requirementsPath, ...flags];
+            await this._executePipInTerminal(args, token);
+            return;
+        }
+
         // Re-resolve against the full installed set so the new package can't break
         // the environment: name every installed package (bare) plus the new
         // package(s); an inconsistent install fails atomically.
@@ -113,6 +127,17 @@ export class PipPackageManager implements IPackageManager {
 
         await this._ensurePip();
 
+        const requirementsPath = await this._getWorkspaceRequirementsPath();
+        if (requirementsPath) {
+            // Pin the target(s) on the command line plus -r <file> (verbatim). No
+            // --upgrade: an exact pin moves only the named target.
+            const specs = this._formatPackageSpecs(packages);
+            const flags = await this._getInstallFlags();
+            const args = ['install', ...specs, '-r', requirementsPath, ...flags];
+            await this._executePipInTerminal(args, token);
+            return;
+        }
+
         // Re-resolve against the full installed set: name every package so all
         // constraints are honored, but only the target is pinned (others are bare
         // and stay put unless the update forces a change). An inconsistent update
@@ -146,6 +171,16 @@ export class PipPackageManager implements IPackageManager {
 
         if (outdatedPackages.length === 0) {
             this._emitMessage('All packages are up to date.\n');
+            return;
+        }
+
+        const requirementsPath = await this._getWorkspaceRequirementsPath();
+        if (requirementsPath) {
+            // Upgrade everything DECLARED to latest compatible; the file is the
+            // source of truth (declared pins block their own upgrade).
+            const flags = await this._getInstallFlags();
+            const args = ['install', '--upgrade', '-r', requirementsPath, ...flags];
+            await this._executePipInTerminal(args, token);
             return;
         }
 
@@ -220,6 +255,23 @@ export class PipPackageManager implements IPackageManager {
             token,
         });
         return JSON.parse(result.stdout) as Array<{ name: string; latest_version: string }>;
+    }
+
+    /**
+     * Format package install requests into pip package specifiers.
+     * e.g., { name: "requests", version: "2.28.0" } becomes "requests==2.28.0".
+     */
+    private _formatPackageSpecs(packages: positron.PackageSpec[]): string[] {
+        return packages.map((pkg) => (pkg.version ? `${pkg.name}==${pkg.version}` : pkg.name));
+    }
+
+    /**
+     * Path to the workspace-root `requirements.txt` if present, else undefined.
+     */
+    private async _getWorkspaceRequirementsPath(): Promise<string | undefined> {
+        const workspaceService = this._serviceContainer.get<IWorkspaceService>(IWorkspaceService);
+        const fileSystem = this._serviceContainer.get<IFileSystem>(IFileSystem);
+        return findWorkspaceRequirementsFile(workspaceService, fileSystem);
     }
 
     /**

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -16,6 +16,7 @@ import { isUvInstalled } from '../../pythonEnvironments/common/environmentManage
 import { traceVerbose } from '../../logging';
 import { fetchMetadataWithOutdated } from './packageMetadata';
 import { buildRequirementsFile } from './requirementsFile';
+import { findWorkspaceRequirementsFile } from './workspaceRequirements';
 import { searchPyPI, searchPyPIVersions } from './pypiSearch';
 import { IPackageManager, MessageEmitter, PackageSession } from './types';
 
@@ -76,17 +77,26 @@ export class UvPackageManager implements IPackageManager {
             const args = ['add', '--active', '--python', this._pythonPath, ...packageSpecs];
             await this._executeUvInTerminal(args, token);
         } else {
-            // Re-resolve against the full installed set: name every installed
-            // package (bare) plus the new package(s) so an inconsistent install
-            // fails atomically instead of breaking the environment.
-            const freezeLines = await this._getInstalledFreeze(token);
-            const content = buildRequirementsFile(freezeLines, packages);
-            const tempFile = await this._writeRequirementsTempFile(content);
-            try {
-                const args = ['pip', 'install', '-r', tempFile.filePath, '--python', this._pythonPath];
+            const requirementsPath = await this._getWorkspaceRequirementsPath();
+            if (requirementsPath) {
+                // requirements.txt is the source of truth: pass the target on the
+                // command line plus -r <file> (verbatim). The resolver intersects
+                // the target with the file; a conflict fails atomically.
+                const args = ['pip', 'install', ...packageSpecs, '-r', requirementsPath, '--python', this._pythonPath];
                 await this._executeUvInTerminal(args, token);
-            } finally {
-                tempFile.dispose();
+            } else {
+                // Re-resolve against the full installed set: name every installed
+                // package (bare) plus the new package(s) so an inconsistent install
+                // fails atomically instead of breaking the environment.
+                const freezeLines = await this._getInstalledFreeze(token);
+                const content = buildRequirementsFile(freezeLines, packages);
+                const tempFile = await this._writeRequirementsTempFile(content);
+                try {
+                    const args = ['pip', 'install', '-r', tempFile.filePath, '--python', this._pythonPath];
+                    await this._executeUvInTerminal(args, token);
+                } finally {
+                    tempFile.dispose();
+                }
             }
         }
     }
@@ -138,17 +148,25 @@ export class UvPackageManager implements IPackageManager {
             if (missing) {
                 throw new Error(`A version is required to update '${missing.name}'.`);
             }
-            // Re-resolve against the full installed set: name every package (bare),
-            // pin only the target, so an inconsistent update fails atomically.
-            const targets = packages.map((pkg) => ({ name: pkg.name, version: pkg.version! }));
-            const freezeLines = await this._getInstalledFreeze(token);
-            const content = buildRequirementsFile(freezeLines, targets);
-            const tempFile = await this._writeRequirementsTempFile(content);
-            try {
-                const args = ['pip', 'install', '-r', tempFile.filePath, '--python', this._pythonPath];
+            const requirementsPath = await this._getWorkspaceRequirementsPath();
+            if (requirementsPath) {
+                // Pin the target(s) on the command line plus -r <file> (verbatim).
+                // No --upgrade: an exact pin moves only the named target.
+                const args = ['pip', 'install', ...packageSpecs, '-r', requirementsPath, '--python', this._pythonPath];
                 await this._executeUvInTerminal(args, token);
-            } finally {
-                tempFile.dispose();
+            } else {
+                // Re-resolve against the full installed set: name every package (bare),
+                // pin only the target, so an inconsistent update fails atomically.
+                const targets = packages.map((pkg) => ({ name: pkg.name, version: pkg.version! }));
+                const freezeLines = await this._getInstalledFreeze(token);
+                const content = buildRequirementsFile(freezeLines, targets);
+                const tempFile = await this._writeRequirementsTempFile(content);
+                try {
+                    const args = ['pip', 'install', '-r', tempFile.filePath, '--python', this._pythonPath];
+                    await this._executeUvInTerminal(args, token);
+                } finally {
+                    tempFile.dispose();
+                }
             }
         }
     }
@@ -174,16 +192,24 @@ export class UvPackageManager implements IPackageManager {
                 return;
             }
 
-            // Upgrade every installed package to its latest mutually-compatible
-            // version: name them all (bare) and let uv resolve.
-            const freezeLines = await this._getInstalledFreeze(token);
-            const content = buildRequirementsFile(freezeLines, []);
-            const tempFile = await this._writeRequirementsTempFile(content);
-            try {
-                const args = ['pip', 'install', '--upgrade', '-r', tempFile.filePath, '--python', this._pythonPath];
+            const requirementsPath = await this._getWorkspaceRequirementsPath();
+            if (requirementsPath) {
+                // Upgrade everything DECLARED to latest compatible; the file is the
+                // source of truth (declared pins block their own upgrade).
+                const args = ['pip', 'install', '--upgrade', '-r', requirementsPath, '--python', this._pythonPath];
                 await this._executeUvInTerminal(args, token);
-            } finally {
-                tempFile.dispose();
+            } else {
+                // Upgrade every installed package to its latest mutually-compatible
+                // version: name them all (bare) and let uv resolve.
+                const freezeLines = await this._getInstalledFreeze(token);
+                const content = buildRequirementsFile(freezeLines, []);
+                const tempFile = await this._writeRequirementsTempFile(content);
+                try {
+                    const args = ['pip', 'install', '--upgrade', '-r', tempFile.filePath, '--python', this._pythonPath];
+                    await this._executeUvInTerminal(args, token);
+                } finally {
+                    tempFile.dispose();
+                }
             }
         }
     }
@@ -215,6 +241,15 @@ export class UvPackageManager implements IPackageManager {
                     'Please install uv to use package management features: https://docs.astral.sh/uv/',
             );
         }
+    }
+
+    /**
+     * Path to the workspace-root `requirements.txt` if present, else undefined.
+     */
+    private async _getWorkspaceRequirementsPath(): Promise<string | undefined> {
+        const workspaceService = this._serviceContainer.get<IWorkspaceService>(IWorkspaceService);
+        const fileSystem = this._serviceContainer.get<IFileSystem>(IFileSystem);
+        return findWorkspaceRequirementsFile(workspaceService, fileSystem);
     }
 
     /**
@@ -261,9 +296,7 @@ export class UvPackageManager implements IPackageManager {
         }
 
         // Check if requirements.txt exists (if so, use pip workflow to avoid sync issues)
-        const requirementsPath = path.join(workspacePath, 'requirements.txt');
-        const requirementsExists = await fileSystem.fileExists(requirementsPath);
-        if (requirementsExists) {
+        if (await findWorkspaceRequirementsFile(workspaceService, fileSystem)) {
             return false;
         }
 

--- a/extensions/positron-python/src/client/positron/packages/workspaceRequirements.ts
+++ b/extensions/positron-python/src/client/positron/packages/workspaceRequirements.ts
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as path from 'path';
+import { IWorkspaceService } from '../../common/application/types';
+import { IFileSystem } from '../../common/platform/types';
+
+/**
+ * Locate the workspace-root `requirements.txt`, if present. When it exists,
+ * package operations treat it as the source of truth (passed verbatim via
+ * `-r`); when absent, callers fall back to the `pip freeze` path. Only the
+ * first workspace folder is considered (multi-root is out of scope).
+ */
+export async function findWorkspaceRequirementsFile(
+    workspaceService: IWorkspaceService,
+    fileSystem: IFileSystem,
+): Promise<string | undefined> {
+    const workspaceFolder = workspaceService.workspaceFolders?.[0];
+    if (!workspaceFolder) {
+        return undefined;
+    }
+    const requirementsPath = path.join(workspaceFolder.uri.fsPath, 'requirements.txt');
+    return (await fileSystem.fileExists(requirementsPath)) ? requirementsPath : undefined;
+}

--- a/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
@@ -5,14 +5,17 @@
 
 'use strict';
 
+import * as path from 'path';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
+import { Uri } from 'vscode';
 // eslint-disable-next-line import/no-unresolved
 import * as positron from 'positron';
 import { IPythonExecutionFactory } from '../../client/common/process/types';
 import { ITerminalServiceFactory } from '../../client/common/terminal/types';
 import { IFileSystem } from '../../client/common/platform/types';
+import { IWorkspaceService } from '../../client/common/application/types';
 import { IServiceContainer } from '../../client/ioc/types';
 import { PipPackageManager } from '../../client/positron/packages/pipPackageManager';
 import { PackageSession } from '../../client/positron/packages/types';
@@ -26,7 +29,8 @@ suite('PipPackageManager update Tests', () => {
     let serviceContainer: IServiceContainer;
     let pythonService: { isModuleInstalled: sinon.SinonStub; execModule: sinon.SinonStub };
     let terminalService: { show: sinon.SinonStub; sendCommand: sinon.SinonStub; sendText: sinon.SinonStub };
-    let fileSystem: { createTemporaryFile: sinon.SinonStub; writeFile: sinon.SinonStub };
+    let fileSystem: { createTemporaryFile: sinon.SinonStub; writeFile: sinon.SinonStub; fileExists: sinon.SinonStub };
+    let workspaceService: IWorkspaceService;
     let writtenContent: string;
     let messageEmitter: MessageEmitter;
     let session: PackageSession;
@@ -51,12 +55,18 @@ suite('PipPackageManager update Tests', () => {
 
         writtenContent = '';
         fileSystem = {
+            fileExists: sinon.stub().resolves(false),
             createTemporaryFile: sinon.stub().resolves({ filePath: '/tmp/reqs.txt', dispose: sinon.stub() }),
             writeFile: sinon.stub().callsFake((_p: string, text: string) => {
                 writtenContent = text;
                 return Promise.resolve();
             }),
         };
+        workspaceService = {
+            get workspaceFolders() {
+                return undefined;
+            },
+        } as any;
 
         // Assign getConfiguration so _getProxyFlags() gets a real WorkspaceConfiguration-like
         // object (vscode.workspace is a ts-mockito instance; sinon.stub won't work on it).
@@ -75,7 +85,9 @@ suite('PipPackageManager update Tests', () => {
             .withArgs(ITerminalServiceFactory)
             .returns(terminalFactory)
             .withArgs(IFileSystem)
-            .returns(fileSystem);
+            .returns(fileSystem)
+            .withArgs(IWorkspaceService)
+            .returns(workspaceService);
 
         messageEmitter = { fire: sinon.stub() };
         session = { metadata: { sessionId: 'test' }, callMethod: sinon.stub().resolves([]) };
@@ -176,5 +188,56 @@ suite('PipPackageManager update Tests', () => {
             threw = true;
         }
         expect(threw).to.equal(true);
+    });
+
+    suite('with workspace requirements.txt', () => {
+        let reqPath: string;
+
+        setup(() => {
+            const workspaceFolder = { uri: Uri.file('/workspace'), name: 'ws', index: 0 };
+            reqPath = path.join(workspaceFolder.uri.fsPath, 'requirements.txt');
+            sinon.stub(workspaceService, 'workspaceFolders').value([workspaceFolder]);
+            fileSystem.fileExists.withArgs(reqPath).resolves(true);
+        });
+
+        test('installPackages passes the target on the command line plus -r requirements.txt', async () => {
+            await manager.installPackages([{ name: 'cowsay', version: '6.1' }]);
+
+            const [, args] = terminalService.sendCommand.firstCall.args;
+            expect(args).to.include.members(['install', 'cowsay==6.1', '-r', reqPath]);
+            expect(args).to.not.include('--upgrade');
+            // No freeze temp file synthesized.
+            expect(fileSystem.createTemporaryFile.called).to.equal(false);
+            expect(pythonService.execModule.calledWithMatch('pip', sinon.match.array.startsWith(['freeze']))).to.equal(
+                false,
+            );
+        });
+
+        test('installPackages passes a versionless target as a bare name', async () => {
+            await manager.installPackages([{ name: 'cowsay' }]);
+
+            const [, args] = terminalService.sendCommand.firstCall.args;
+            expect(args).to.include.members(['install', 'cowsay', '-r', reqPath]);
+        });
+
+        test('updatePackages pins the target on the command line plus -r requirements.txt (no --upgrade)', async () => {
+            await manager.updatePackages([{ name: 'werkzeug', version: '3.1.8' }]);
+
+            const [, args] = terminalService.sendCommand.firstCall.args;
+            expect(args).to.include.members(['install', 'werkzeug==3.1.8', '-r', reqPath]);
+            expect(args).to.not.include('--upgrade');
+        });
+
+        test('updateAllPackages runs install --upgrade -r requirements.txt with no targets', async () => {
+            pythonService.execModule
+                .withArgs('pip', sinon.match.array.startsWith(['list', '--outdated']))
+                .resolves({ stdout: JSON.stringify([{ name: 'werkzeug', latest_version: '3.1.8' }]), stderr: '' });
+
+            await manager.updateAllPackages();
+
+            const [, args] = terminalService.sendCommand.firstCall.args;
+            expect(args).to.include.members(['install', '--upgrade', '-r', reqPath]);
+            expect(fileSystem.createTemporaryFile.called).to.equal(false);
+        });
     });
 });

--- a/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
@@ -361,4 +361,99 @@ version = "0.1.0"`;
             expect(args).to.not.include('--upgrade');
         });
     });
+
+    suite('Environment-workflow with requirements.txt', () => {
+        let processService: { exec: sinon.SinonStub };
+        let terminalService: { show: sinon.SinonStub; sendCommand: sinon.SinonStub; sendText: sinon.SinonStub };
+        let originalGetConfiguration: typeof vscode.workspace.getConfiguration;
+        let reqPath: string;
+
+        setup(() => {
+            originalGetConfiguration = vscode.workspace.getConfiguration;
+            vscode.workspace.getConfiguration = (_section?: string) =>
+                ({ get: (_key: string, defaultValue?: unknown) => defaultValue } as any);
+
+            sinon.stub(uvPackageManager, 'isUvAvailable').resolves(true);
+
+            // Workspace folder with a requirements.txt present (no pyproject -> env workflow).
+            const workspaceFolder = { uri: Uri.file('/workspace'), name: 'ws', index: 0 };
+            reqPath = path.join(workspaceFolder.uri.fsPath, 'requirements.txt');
+            sinon.stub(workspaceService, 'workspaceFolders').value([workspaceFolder]);
+            (fileSystem.fileExists as sinon.SinonStub).withArgs(reqPath).resolves(true);
+
+            processService = { exec: sinon.stub() };
+            const processFactory = { create: sinon.stub().resolves(processService) };
+            terminalService = {
+                show: sinon.stub().resolves(),
+                sendCommand: sinon.stub().resolves(),
+                sendText: sinon.stub().resolves(),
+            };
+            const terminalFactory = { getTerminalService: sinon.stub().returns(terminalService) };
+            (serviceContainer.get as sinon.SinonStub)
+                .withArgs(IProcessServiceFactory)
+                .returns(processFactory)
+                .withArgs(ITerminalServiceFactory)
+                .returns(terminalFactory);
+        });
+
+        teardown(() => {
+            vscode.workspace.getConfiguration = originalGetConfiguration;
+        });
+
+        test('installPackages passes the target on the command line plus -r requirements.txt', async () => {
+            await uvPackageManager.installPackages([{ name: 'cowsay', version: '6.1' }]);
+
+            const [uvBin, args] = terminalService.sendCommand.firstCall.args;
+            expect(uvBin).to.equal('uv');
+            expect(args).to.include.members([
+                'pip',
+                'install',
+                'cowsay==6.1',
+                '-r',
+                reqPath,
+                '--python',
+                '/path/to/python',
+            ]);
+            expect(args).to.not.include('--upgrade');
+            // Did not synthesize a freeze temp file.
+            expect(processService.exec.calledWithMatch('uv', sinon.match.array.startsWith(['pip', 'freeze']))).to.equal(
+                false,
+            );
+        });
+
+        test('updatePackages pins the target on the command line plus -r requirements.txt (no --upgrade)', async () => {
+            await uvPackageManager.updatePackages([{ name: 'werkzeug', version: '3.1.8' }]);
+
+            const [, args] = terminalService.sendCommand.firstCall.args;
+            expect(args).to.include.members([
+                'pip',
+                'install',
+                'werkzeug==3.1.8',
+                '-r',
+                reqPath,
+                '--python',
+                '/path/to/python',
+            ]);
+            expect(args).to.not.include('--upgrade');
+        });
+
+        test('updateAllPackages runs pip install --upgrade -r requirements.txt with no targets', async () => {
+            processService.exec
+                .withArgs('uv', sinon.match.array.startsWith(['pip', 'list', '--outdated']))
+                .resolves({ stdout: JSON.stringify([{ name: 'werkzeug', latest_version: '3.1.8' }]), stderr: '' });
+
+            await uvPackageManager.updateAllPackages();
+
+            const [, args] = terminalService.sendCommand.firstCall.args;
+            expect(args).to.include.members([
+                'pip',
+                'install',
+                '--upgrade',
+                '-r',
+                reqPath,
+                '--python',
+                '/path/to/python',
+            ]);
+        });
+    });
 });

--- a/extensions/positron-python/src/test/positron/workspaceRequirements.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/workspaceRequirements.unit.test.ts
@@ -1,0 +1,53 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import { expect } from 'chai';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import { Uri } from 'vscode';
+import { IWorkspaceService } from '../../client/common/application/types';
+import { IFileSystem } from '../../client/common/platform/types';
+import { findWorkspaceRequirementsFile } from '../../client/positron/packages/workspaceRequirements';
+
+suite('findWorkspaceRequirementsFile', () => {
+    let workspaceService: IWorkspaceService;
+    let fileSystem: IFileSystem;
+
+    setup(() => {
+        workspaceService = {
+            get workspaceFolders() {
+                return undefined;
+            },
+        } as any;
+        fileSystem = { fileExists: sinon.stub().resolves(false) } as any;
+    });
+
+    teardown(() => sinon.restore());
+
+    test('returns undefined when there is no workspace folder', async () => {
+        const result = await findWorkspaceRequirementsFile(workspaceService, fileSystem);
+        expect(result).to.equal(undefined);
+        expect((fileSystem.fileExists as sinon.SinonStub).called).to.equal(false);
+    });
+
+    test('returns undefined when requirements.txt does not exist', async () => {
+        const folder = { uri: Uri.file('/workspace'), name: 'ws', index: 0 };
+        sinon.stub(workspaceService, 'workspaceFolders').value([folder]);
+        const result = await findWorkspaceRequirementsFile(workspaceService, fileSystem);
+        expect(result).to.equal(undefined);
+    });
+
+    test('returns the path when requirements.txt exists in the first workspace folder', async () => {
+        const folder = { uri: Uri.file('/workspace'), name: 'ws', index: 0 };
+        const expected = path.join(folder.uri.fsPath, 'requirements.txt');
+        sinon.stub(workspaceService, 'workspaceFolders').value([folder]);
+        (fileSystem.fileExists as sinon.SinonStub).withArgs(expected).resolves(true);
+
+        const result = await findWorkspaceRequirementsFile(workspaceService, fileSystem);
+        expect(result).to.equal(expected);
+    });
+});


### PR DESCRIPTION
## Summary

When a workspace-root `requirements.txt` exists, pip and uv environment-workflow package operations now resolve against it by passing `-r requirements.txt` on the command line. The declared file becomes the source of truth: the target package(s) stay on the command line, and the resolver intersects them with the file's entries. When no `requirements.txt` is present, the existing `pip freeze`-based behavior (from #14495) is used unchanged.

This is a follow-up to #14328 / #14495, which prevented package operations from silently breaking the environment by re-resolving against the full installed set. That approach never read the project's actual `requirements.txt`. This PR makes the declared file authoritative when it exists.

## Behavior

With a workspace-root `requirements.txt` present:

| Operation | Command |
|---|---|
| Install `foo` / `foo==X` | `pip install foo[==X] -r requirements.txt` |
| Update `foo` -> X | `pip install foo==X -r requirements.txt` (no `--upgrade`) |
| Update All | `pip install -r requirements.txt --upgrade` |
| Uninstall `foo` | `pip uninstall -y foo` (file not involved) |

uv environment-workflow mirrors pip (`uv pip install ... -r requirements.txt --python <path>`). uv's project workflow (`uv add`/`uv sync`) is unchanged.

The file is passed verbatim and is **never read, parsed, copied, or mutated** by Positron. There is no write-back and no new setting; the file is user-maintained.

### Intentional, documented consequences

These follow from treating the file as the authoritative declared set:

- A package operation that conflicts with a declared exact pin (e.g. declared `flask==2.0`, update flask to 3.0) **fails loudly** with a resolver error rather than silently succeeding. The conflict surfaces through the existing non-zero-exit error path.
- A drifted environment is corrected toward declared versions on the next operation.
- Uninstalling a package that is still declared does not persist; the next operation reinstalls it from the file.

## Implementation

- New shared helper `findWorkspaceRequirementsFile()` detects the workspace-root `requirements.txt`.
- `PipPackageManager` and `UvPackageManager` (env-workflow branch) use the helper to choose the `-r requirements.txt` path or the freeze fallback.
- `UvPackageManager._shouldUseProjectWorkflow()` was refactored to reuse the same helper (behavior-preserving).

Scope is the workspace-root `requirements.txt` only; multi-file, multi-root, and `pyproject.toml`/`Pipfile`/`environment.yml` are out of scope.

## Testing

Unit tests (mocha) for the new helper and for the requirements-present branch of both managers, plus the existing freeze-path tests:

```
npm run test:unittests -- --grep "PackageManager|findWorkspaceRequirementsFile"
```

30/30 passing (3 helper + 3 uv + 4 pip new; remainder existing freeze-path coverage retained).
