### PR TITLE
chore: refine release screenshots: zoom, clean status bar, friendly recent path

### DIFF
--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -937,7 +937,7 @@ export class PositronNotebooks extends Notebooks {
 	async expectNotebookAssistantModalVisible(timeout = 10000): Promise<void> {
 		await expect(
 			this.code.driver.currentPage
-				.locator('.positron-modal-dialog-box')
+				.locator('.positron-dynamic-modal-dialog-box')
 				.filter({ hasText: 'Positron Notebook Assistant' })
 		).toBeVisible({ timeout });
 	}

--- a/test/e2e/release-screenshots/_helpers/layout-utils.ts
+++ b/test/e2e/release-screenshots/_helpers/layout-utils.ts
@@ -284,14 +284,29 @@ export async function overrideWorkspaceName(
 }
 
 /**
+ * Hide the debug launch-configuration status bar item. Starting a Python
+ * session activates the Python Debugger extension, which registers a
+ * "Python Debugger: Current File …" picker in the status bar. It's not
+ * meaningful in a release screenshot and should not be visible.
+ */
+export async function hideDebugStatusBar(page: Page): Promise<void> {
+	const items = page.locator('.statusbar-item').filter({ hasText: 'Python Debugger' });
+	const count = await items.count();
+	for (let i = 0; i < count; i++) {
+		await items.nth(i).evaluate((el: HTMLElement) => { el.style.display = 'none'; });
+	}
+}
+
+/**
  * Standard pre-screenshot cleanup. Composes the smaller helpers in the order
  * that produces a clean, deterministic frame:
  *   1. Hide notification toasts (they cover real UI)
  *   2. Hide activity-bar notification badges (e.g. "sign in to GitHub" red dot)
  *   3. Hide text-insertion caret (blinking cursor causes pixel noise)
- *   4. Unhover (no spurious hover states)
- *   5. Wait for layout to settle (and any in-flight progress bars to clear)
- *   6. Rewrite runtime labels (e.g. "(uv: positron)") to "(Venv: .venv)"
+ *   4. Hide debug launch-config status bar item (activated by Python sessions)
+ *   5. Unhover (no spurious hover states)
+ *   6. Wait for layout to settle (and any in-flight progress bars to clear)
+ *   7. Rewrite runtime labels (e.g. "(uv: positron)") to "(Venv: .venv)"
  *
  * The label rewrite goes last so React re-renders during the settle wait
  * don't undo it before the screenshot fires.
@@ -303,6 +318,7 @@ export async function prepareForScreenshot(app: Application, page: Page): Promis
 	await hideToasts(app);
 	await hideNotificationBadges(page);
 	await hideCaret(page);
+	await hideDebugStatusBar(page);
 	await unhoverAll(page);
 	await waitForStableUI(page);
 	await overrideRuntimeLabel(page);

--- a/test/e2e/release-screenshots/apps/run-app-button.screenshot.ts
+++ b/test/e2e/release-screenshots/apps/run-app-button.screenshot.ts
@@ -42,6 +42,7 @@ test.describe('Release Screenshots - Run App Button', () => {
 		await hotKeys.focusPreviewPanel();
 		await hotKeys.closePrimarySidebar();
 		await layouts.resizePanel({ y: -50 });
+		await page.getByRole('tab', { name: 'streamlit_example.py' }).click();
 
 		// capture screenshot
 		await prepareForScreenshot(app, page);

--- a/test/e2e/release-screenshots/apps/run-app-button.screenshot.ts
+++ b/test/e2e/release-screenshots/apps/run-app-button.screenshot.ts
@@ -46,7 +46,7 @@ test.describe('Release Screenshots - Run App Button', () => {
 		// capture screenshot
 		await prepareForScreenshot(app, page);
 		await annotate(page, [
-			{ selector: '.codicon-play', label: '', color: ANNOTATION_COLOR, padding: 4 },
+			{ selector: '.action-bar-button:has(.codicon-play)', label: '', color: ANNOTATION_COLOR, padding: 4 },
 		]);
 		await captureFullWindow(page, 'run-app-button.png');
 	});

--- a/test/e2e/release-screenshots/connections-pane/connections-pane-new-connection.screenshot.ts
+++ b/test/e2e/release-screenshots/connections-pane/connections-pane-new-connection.screenshot.ts
@@ -14,7 +14,7 @@ test.use({
 });
 
 test.beforeEach(async ({ app }) => {
-	await setScreenshotWindowSize(app);
+	await setScreenshotWindowSize(app, { width: 1024, height: 700 });
 });
 
 test.afterEach(async ({ page, hotKeys }) => {

--- a/test/e2e/release-screenshots/connections-pane/connections-pane-new-connection.screenshot.ts
+++ b/test/e2e/release-screenshots/connections-pane/connections-pane-new-connection.screenshot.ts
@@ -14,7 +14,7 @@ test.use({
 });
 
 test.beforeEach(async ({ app }) => {
-	await setScreenshotWindowSize(app, { width: 1024, height: 700 });
+	await setScreenshotWindowSize(app);
 });
 
 test.afterEach(async ({ page, hotKeys }) => {

--- a/test/e2e/release-screenshots/connections-pane/connections-pane-schema-explorer.screenshot.ts
+++ b/test/e2e/release-screenshots/connections-pane/connections-pane-schema-explorer.screenshot.ts
@@ -28,7 +28,7 @@ test.use({
 });
 
 test.beforeEach(async ({ app }) => {
-	await setScreenshotWindowSize(app);
+	await setScreenshotWindowSize(app, { width: 1024, height: 700 });
 });
 
 test.afterEach(async ({ app, page, hotKeys }) => {
@@ -46,7 +46,7 @@ test.describe('Release Screenshots - Connections Pane Schema Explorer', () => {
 	 * tree drilled into a table so the column types are visible.
 	 */
 	test('Release Screenshot - connections-pane-schema-explorer.png', async ({ app, page, openFile, executeCode, settings, r }) => {
-		const { sessions, console, connections, layouts } = app.workbench;
+		const { sessions, console, connections, layouts, hotKeys } = app.workbench;
 		await sessions.expectAllSessionsToBeReady();
 
 		// turn off occurrence highlighting so the editor doesn't box every
@@ -69,6 +69,7 @@ test.describe('Release Screenshots - Connections Pane Schema Explorer', () => {
 
 		// Expand SQLiteConnection > Default > {airlines, flights, planes} so
 		await connections.openConnectionsNodes(['SQLiteConnection', /^main$|^Default$/, 'airports', /^planes$/]);
+		await hotKeys.closePrimarySidebar();
 		await layouts.resizeAuxiliaryBar({ x: -300 });
 		await layouts.resizePanel({ y: -200 });
 		await console.focus();

--- a/test/e2e/release-screenshots/connections-pane/connections-pane-schema-explorer.screenshot.ts
+++ b/test/e2e/release-screenshots/connections-pane/connections-pane-schema-explorer.screenshot.ts
@@ -70,8 +70,8 @@ test.describe('Release Screenshots - Connections Pane Schema Explorer', () => {
 		// Expand SQLiteConnection > Default > {airlines, flights, planes} so
 		await connections.openConnectionsNodes(['SQLiteConnection', /^main$|^Default$/, 'airports', /^planes$/]);
 		await hotKeys.closePrimarySidebar();
-		await layouts.resizeAuxiliaryBar({ x: -300 });
-		await layouts.resizePanel({ y: -200 });
+		await layouts.resizeAuxiliaryBar({ x: -200 });
+		await layouts.resizePanel({ y: -120 });
 		await console.focus();
 
 		// capture screenshot

--- a/test/e2e/release-screenshots/notebooks/jupyter-notebooks.screenshot.ts
+++ b/test/e2e/release-screenshots/notebooks/jupyter-notebooks.screenshot.ts
@@ -47,7 +47,7 @@ test.describe('Release Screenshots - Jupyter Notebooks', () => {
 		await prepareForScreenshot(app, page);
 		await overrideWorkspaceName(page, 'qa-example-content', 'positron-demos-notebooks');
 		await annotate(page, [
-			{ selector: 'button[aria-label="Kernel Actions"]', label: '', color: ANNOTATION_COLOR, padding: 3 },
+			{ selector: '.positron-notebook-kernel-status-badge', label: '', color: ANNOTATION_COLOR, padding: 4 },
 		]);
 		await captureFullWindow(page, 'jupyter-notebooks-kernel-selector.png');
 	});

--- a/test/e2e/release-screenshots/ui/interpreter-session.screenshot.ts
+++ b/test/e2e/release-screenshots/ui/interpreter-session.screenshot.ts
@@ -107,7 +107,7 @@ test.describe('Release Screenshots - Interpreter Session', () => {
 	test('Release Screenshot - active-interpreter-session.png', async ({ app, page, openFile }) => {
 		const { sessions, hotKeys, layouts } = app.workbench;
 
-		await setScreenshotWindowSize(app, { width: 1280, height: 800 });
+		await setScreenshotWindowSize(app, { width: 1024, height: 700 });
 		const [, rSession] = await sessions.start(['python', 'r']);
 		await sessions.select(rSession.id);
 

--- a/test/e2e/release-screenshots/ui/interpreter-session.screenshot.ts
+++ b/test/e2e/release-screenshots/ui/interpreter-session.screenshot.ts
@@ -107,7 +107,7 @@ test.describe('Release Screenshots - Interpreter Session', () => {
 	test('Release Screenshot - active-interpreter-session.png', async ({ app, page, openFile }) => {
 		const { sessions, hotKeys, layouts } = app.workbench;
 
-		await setScreenshotWindowSize(app, { width: 800, height: 700 });
+		await setScreenshotWindowSize(app, { width: 900, height: 700 });
 		const [, rSession] = await sessions.start(['python', 'r']);
 		await sessions.select(rSession.id);
 

--- a/test/e2e/release-screenshots/ui/interpreter-session.screenshot.ts
+++ b/test/e2e/release-screenshots/ui/interpreter-session.screenshot.ts
@@ -107,7 +107,7 @@ test.describe('Release Screenshots - Interpreter Session', () => {
 	test('Release Screenshot - active-interpreter-session.png', async ({ app, page, openFile }) => {
 		const { sessions, hotKeys, layouts } = app.workbench;
 
-		await setScreenshotWindowSize(app, { width: 1024, height: 700 });
+		await setScreenshotWindowSize(app, { width: 800, height: 700 });
 		const [, rSession] = await sessions.start(['python', 'r']);
 		await sessions.select(rSession.id);
 
@@ -117,8 +117,8 @@ test.describe('Release Screenshots - Interpreter Session', () => {
 		// customize the layout
 		await hotKeys.closePrimarySidebar();
 		await hotKeys.closeSecondarySidebar();
-		await layouts.resizePanelToHeight(375);
-		await sessions.resizeSessionList({ x: -80 });
+		await layouts.resizePanelToHeight(320);
+		await sessions.resizeSessionList({ x: -180 });
 
 		// capture screenshot
 		await prepareForScreenshot(app, page);

--- a/test/e2e/release-screenshots/ui/open-folder.screenshot.ts
+++ b/test/e2e/release-screenshots/ui/open-folder.screenshot.ts
@@ -62,6 +62,20 @@ test.describe('Release Screenshots - Open Folder', () => {
 		const menu = page.locator('.positron-modal-popup');
 		await expect(menu).toBeVisible();
 
+		// Rewrite recent-path entries in the dropdown: keep only one, renamed to a
+		// friendly data-science project name. Hides the user's full global history.
+		await page.evaluate(() => {
+			const items = document.querySelectorAll<HTMLElement>('.custom-folder-recently-used-menu-item');
+			items.forEach((item, i) => {
+				if (i === 0) {
+					const title = item.querySelector<HTMLElement>('.title');
+					if (title) { title.textContent = '~/predict-customer-churn'; }
+				} else {
+					item.style.display = 'none';
+				}
+			});
+		});
+
 		await annotate(page, [
 			{ selector: '.top-action-bar-container [aria-label="Open"]', label: '', color: ANNOTATION_COLOR, padding: 3, borderWidth: 3 },
 			{ selector: '.top-action-bar-custom-folder-menu', label: '', color: ANNOTATION_COLOR, padding: 3, borderWidth: 3 },


### PR DESCRIPTION
### Summary
Refines several release screenshots and fixes two stale selectors.

- Add `hideDebugStatusBar()` to `prepareForScreenshot()` — hides the Python Debugger status bar entry globally
- Rewrite recent-folder entries in `open-folder.png` to `~/predict-customer-churn`
- Zoom and layout tweaks: `active-interpreter-session.png`, `connections-pane-schema-explorer.png`
- Fix `jupyter-notebooks-kernel-selector.png` annotation selector
- Fix `run-app-button.png` annotation to include the ▼ caret
- Fix `positron-notebook-assistant-panel.png` modal locator after #14470 renamed the class

### QA Notes
See run with updates: https://github.com/posit-dev/positron/actions/runs/28403800753