### PR TITLE
python: manually look for uv install if not on PATH

### DIFF
--- a/extensions/positron-python/src/client/common/utils/localize.ts
+++ b/extensions/positron-python/src/client/common/utils/localize.ts
@@ -292,6 +292,9 @@ export namespace InterpreterQuickPickList {
 
     export namespace UvInstall {
         export const noVersionsAvailable = l10n.t('No Python versions available for installation');
+        export const uvNotFoundAfterInstall = l10n.t(
+            'uv was installed but could not be found. Please restart Positron and try installing Python again.',
+        );
         export const alreadyInstalledSeparator = l10n.t('Already installed');
         export const selectVersion = l10n.t('Select a Python version to install');
         export const selectVersionTitle = l10n.t('Install Python via uv');

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
@@ -44,16 +44,47 @@ class UvUtils {
     }
 
     private static async locate(): Promise<UvUtils | undefined> {
-        const uvPath = 'uv';
-        traceVerbose(`Probing uv binary ${uvPath}`);
-        const uv = new UvUtils(uvPath);
-        const uvDir = await uv.getUvDir();
-        if (uvDir !== undefined) {
-            traceVerbose(`Found uv binary ${uvPath}`);
-            return uv;
+        // Probe `uv` on PATH first, then fall back to uv's known install locations.
+        // The official installer drops the binary at ~/.local/bin/uv (or ~/.cargo/bin/uv)
+        // and only updates shell rc files, so a freshly installed uv is not reachable on
+        // the already-running extension host's PATH. Probing the known locations lets us
+        // find it without waiting for a restart.
+        for (const candidate of ['uv', ...UvUtils.knownInstallLocations()]) {
+            // Absolute-path candidates come from known install locations; only probe ones
+            // that actually exist on disk to avoid spawning processes for missing paths.
+            if (path.isAbsolute(candidate) && !(await pathExists(candidate))) {
+                continue;
+            }
+            traceVerbose(`Probing uv binary ${candidate}`);
+            if (await UvUtils.canRun(candidate)) {
+                traceVerbose(`Found uv binary ${candidate}`);
+                return new UvUtils(candidate);
+            }
         }
         traceVerbose(`No uv binary found`);
         return undefined;
+    }
+
+    /** Default locations the official uv installer writes the binary to. */
+    private static knownInstallLocations(): string[] {
+        const home = os.homedir();
+        const binary = process.platform === 'win32' ? 'uv.exe' : 'uv';
+        return [path.join(home, '.local', 'bin', binary), path.join(home, '.cargo', 'bin', binary)];
+    }
+
+    /**
+     * Probes whether the given uv command is runnable. Runs `uv python dir` directly
+     * rather than through the cached `getUvDir()`, whose cache key ignores the command
+     * and would otherwise return a stale result across candidate probes.
+     */
+    private static async canRun(command: string): Promise<boolean> {
+        try {
+            const result = await exec(command, ['python', 'dir'], { throwOnStdErr: true });
+            return result?.stdout.trim() !== undefined;
+        } catch (ex) {
+            traceVerbose(ex);
+            return false;
+        }
     }
 
     @cache(-1)

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uvPythonInstaller.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uvPythonInstaller.ts
@@ -299,6 +299,14 @@ export async function installPythonViaUv(): Promise<InstallPythonResult> {
                         // User declined or installation failed - exit silently
                         return { success: false };
                     }
+                    // Verify uv is now reachable. The installer drops the binary at a known
+                    // location and updates shell rc files, but those PATH changes don't reach
+                    // the running extension host. isUvInstalled() also probes uv's known
+                    // install locations; if it still can't be found, surface an actionable
+                    // message instead of the misleading "no versions available" error later.
+                    if (!(await isUvInstalled())) {
+                        return { success: false, error: InterpreterQuickPickList.UvInstall.uvNotFoundAfterInstall };
+                    }
                 }
 
                 // Select and install Python version

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uvPythonInstaller.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uvPythonInstaller.ts
@@ -9,6 +9,7 @@ import * as vscode from 'vscode';
 import { traceError, traceInfo } from '../../../logging';
 import { exec } from '../externalDependencies';
 import { isUvInstalled, getAvailablePythonVersions, resetUvCache, isWindowsArm64 } from './uv';
+import { Commands } from '../../../common/constants';
 import { Common, InterpreterQuickPickList } from '../../../common/utils/localize';
 import { getWorkspaceFolders } from '../../../common/vscodeApis/workspaceApis';
 import { createUvVenv } from '../../creation/provider/uvCreationProvider';
@@ -16,6 +17,19 @@ import { ExistingVenvAction, deleteEnvironment, pickExistingVenvAction } from '.
 import { getVenvExecutable, hasVenv } from '../../creation/common/commonUtils';
 import { MultiStepAction } from '../../../common/vscodeApis/windowApis';
 import { refreshEnvironments } from '../../../envExt/api.internal';
+
+/**
+ * Shows an error notification for the uv Python install flow with a button that
+ * opens the Python Language Pack output channel, so users can inspect the logs to
+ * see what went wrong.
+ * @param message The error message to display.
+ */
+export async function showUvInstallError(message: string): Promise<void> {
+    const selection = await vscode.window.showErrorMessage(message, Common.showLogs);
+    if (selection === Common.showLogs) {
+        await vscode.commands.executeCommand(Commands.ViewOutput);
+    }
+}
 
 /**
  * Prompts the user for confirmation before installing uv.
@@ -208,7 +222,7 @@ async function selectPythonVersion(): Promise<
     const versions = await getAvailablePythonVersions();
 
     if (versions.length === 0) {
-        vscode.window.showErrorMessage(InterpreterQuickPickList.UvInstall.noVersionsAvailable);
+        await showUvInstallError(InterpreterQuickPickList.UvInstall.noVersionsAvailable);
         return undefined;
     }
 

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
@@ -37,7 +37,11 @@ import { Conda } from '../common/environmentManagers/conda';
 import { getUvPythonVersions } from './provider/uvUtils';
 import { isUvInstalled } from '../common/environmentManagers/uv';
 import { UvCreationProvider } from './provider/uvCreationProvider';
-import { installPythonViaUv, InstallPythonResult } from '../common/environmentManagers/uvPythonInstaller';
+import {
+    installPythonViaUv,
+    InstallPythonResult,
+    showUvInstallError,
+} from '../common/environmentManagers/uvPythonInstaller';
 import {
     createEnvironmentAndRegister,
     getCreateEnvironmentProviders,
@@ -46,7 +50,6 @@ import {
 } from '../../positron/createEnvApi';
 import { traceError, traceLog } from '../../logging';
 import { getConfiguration } from '../../common/vscodeApis/workspaceApis';
-import { showErrorMessage } from '../../common/vscodeApis/windowApis';
 import { InterpreterQuickPickList } from '../../common/utils/localize';
 // --- End Positron ---
 
@@ -126,7 +129,7 @@ async function handleInstallPythonResult(
         return { pythonPath: result.pythonPath, runtimeId: metadata?.runtimeId };
     }
     if (result.error && result.error !== 'Cancelled') {
-        showErrorMessage(result.error);
+        await showUvInstallError(result.error);
     }
     return undefined;
 }
@@ -237,7 +240,7 @@ export async function registerCreateEnvironmentFeatures(
                 return handled;
             } catch (error) {
                 traceError(`installPythonViaUv command failed: ${error}`);
-                showErrorMessage(InterpreterQuickPickList.UvInstall.installCommandFailed);
+                await showUvInstallError(InterpreterQuickPickList.UvInstall.installCommandFailed);
                 return undefined;
             }
         }),
@@ -296,7 +299,7 @@ export async function registerCreateEnvironmentFeatures(
                         return handled?.runtimeId;
                     } catch (error) {
                         traceError(`Install Python via uv failed: ${error}`);
-                        showErrorMessage(InterpreterQuickPickList.UvInstall.installCommandFailed);
+                        await showUvInstallError(InterpreterQuickPickList.UvInstall.installCommandFailed);
                     }
                 }
                 return undefined;

--- a/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uv.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uv.unit.test.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import * as os from 'os';
+import * as path from 'path';
 import * as sinon from 'sinon';
 import * as fileUtils from '../../../../client/pythonEnvironments/common/externalDependencies';
 import {
@@ -216,6 +218,21 @@ suite('uv Environment Tests', () => {
             const result = await isUvInstalled();
 
             assert.strictEqual(result, false);
+        });
+
+        test('Falls back to the default install location when uv is not on PATH', async () => {
+            // The uv installer drops the binary at ~/.local/bin/uv and only edits shell rc
+            // files, so a freshly installed uv is not reachable on the running process PATH.
+            const localBinUv = path.join(os.homedir(), '.local', 'bin', process.platform === 'win32' ? 'uv.exe' : 'uv');
+            // Bare `uv` is not on PATH.
+            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).rejects(new Error('command not found'));
+            // uv exists at its default install location and works there.
+            pathExistsStub.withArgs(localBinUv).resolves(true);
+            execStub.withArgs(localBinUv, ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
+
+            const result = await isUvInstalled();
+
+            assert.strictEqual(result, true);
         });
     });
 

--- a/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uvPythonInstaller.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uvPythonInstaller.unit.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert';
 import * as os from 'os';
 import * as path from 'path';
 import * as sinon from 'sinon';
-import { anything, when, reset } from 'ts-mockito';
+import { anything, when, reset, verify } from 'ts-mockito';
 import { MultiStepAction } from '../../../../client/common/vscodeApis/windowApis';
 import * as fileUtils from '../../../../client/pythonEnvironments/common/externalDependencies';
 import * as logging from '../../../../client/logging';
@@ -18,9 +18,13 @@ import * as commonCreationUtils from '../../../../client/pythonEnvironments/crea
 import * as venvUtils from '../../../../client/pythonEnvironments/creation/provider/venvUtils';
 import * as apiInternal from '../../../../client/envExt/api.internal';
 import { getAvailablePythonVersions } from '../../../../client/pythonEnvironments/common/environmentManagers/uv';
-import { installPythonViaUv } from '../../../../client/pythonEnvironments/common/environmentManagers/uvPythonInstaller';
+import {
+    installPythonViaUv,
+    showUvInstallError,
+} from '../../../../client/pythonEnvironments/common/environmentManagers/uvPythonInstaller';
 import { mockedVSCodeNamespaces } from '../../../vscode-mock';
-import { InterpreterQuickPickList } from '../../../../client/common/utils/localize';
+import { Common, InterpreterQuickPickList } from '../../../../client/common/utils/localize';
+import { Commands } from '../../../../client/common/constants';
 
 // Helper to get expected global venv path
 function getExpectedGlobalVenvPython(): string {
@@ -43,6 +47,32 @@ suite('UV Python Installer Tests', () => {
 
     teardown(() => {
         sinon.restore();
+    });
+
+    suite('showUvInstallError Tests', () => {
+        setup(() => {
+            reset(mockedVSCodeNamespaces.window!);
+            reset(mockedVSCodeNamespaces.commands!);
+            when(mockedVSCodeNamespaces.commands!.executeCommand(anything())).thenResolve(undefined);
+        });
+
+        test('Opens the Python Language Pack logs when the user clicks "Show logs"', async () => {
+            when(mockedVSCodeNamespaces.window!.showErrorMessage(anything(), anything())).thenResolve(
+                Common.showLogs as any,
+            );
+
+            await showUvInstallError('something went wrong');
+
+            verify(mockedVSCodeNamespaces.commands!.executeCommand(Commands.ViewOutput)).once();
+        });
+
+        test('Does not open the logs when the user dismisses the notification', async () => {
+            when(mockedVSCodeNamespaces.window!.showErrorMessage(anything(), anything())).thenResolve(undefined);
+
+            await showUvInstallError('something went wrong');
+
+            verify(mockedVSCodeNamespaces.commands!.executeCommand(Commands.ViewOutput)).never();
+        });
     });
 
     suite('getAvailablePythonVersions Tests', () => {

--- a/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uvPythonInstaller.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uvPythonInstaller.unit.test.ts
@@ -434,6 +434,8 @@ suite('UV Python Installer Tests', () => {
         test('Continues after uv installation even if PATH not updated in current process', async () => {
             // uv not installed initially
             isUvInstalledStub.onFirstCall().resolves(false);
+            // After install, uv is located (e.g. via its known install location)
+            isUvInstalledStub.resolves(true);
             // uv install succeeds
             execStub.onCall(0).resolves({ stdout: '' }); // uv install
             // After install, getAvailablePythonVersions returns versions
@@ -454,6 +456,20 @@ suite('UV Python Installer Tests', () => {
             const result = await installPythonViaUv();
 
             assert.strictEqual(result.success, true);
+        });
+
+        test('Returns actionable error when uv cannot be found after installation', async () => {
+            // uv not installed initially, install command succeeds...
+            isUvInstalledStub.onFirstCall().resolves(false);
+            execStub.resolves({ stdout: '' });
+            // ...but uv still cannot be located afterwards (e.g. installed outside any
+            // known location and not on the current process PATH).
+            isUvInstalledStub.resolves(false);
+
+            const result = await installPythonViaUv();
+
+            assert.strictEqual(result.success, false);
+            assert.strictEqual(result.error, InterpreterQuickPickList.UvInstall.uvNotFoundAfterInstall);
         });
 
         test('Returns error when Python installation fails', async () => {
@@ -890,6 +906,8 @@ suite('UV Python Installer Tests', () => {
         test('Installs uv when not present and continues', async () => {
             // uv not installed initially
             isUvInstalledStub.onFirstCall().resolves(false);
+            // After install, uv is located (e.g. via its known install location)
+            isUvInstalledStub.resolves(true);
             // uv install succeeds (sh command)
             execStub.onCall(0).resolves({ stdout: '' });
             // After install, getAvailablePythonVersions returns versions


### PR DESCRIPTION
Speculative fix for a "No Python versions found" post uv installation via the `+ Install Python via uv` in the interpreter dropdown. It's possible that `uv` wasn't loaded onto the PATH, so we should fallback to look in the usual locations for it. 

I also added a "Show logs" button to the uv install error notifications that opens the Python Language Pack output channel, so users can inspect what went wrong.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Find uv installed at its default location (`~/.local/bin`, `~/.cargo/bin`) when it isn't yet on `PATH`, so installing Python via uv works without restarting Positron


### Validation Steps

Be brave and remove all Python interpreters. You can cheat a little bit and hide via the interpreters exclude setting, and then just delete uv if you have lots of environment managers. That's what I do with conda 😄 to remove uv:

```
uv cache clean
rm -r "$(uv python dir)"
rm -r "$(uv tool dir)"
rm ~/.local/bin/uv ~/.local/bin/uvx
```

- Try out installing uv via the + in the interpreter dropdown
- Try out the command `install python with uv`