### PR TITLE
Add e2e test for Foundry model-overrides setting (workbench)

### DIFF
--- a/test/e2e/fixtures/test-setup/docker-utils.ts
+++ b/test/e2e/fixtures/test-setup/docker-utils.ts
@@ -57,11 +57,23 @@ export async function runDockerCommand(command: string, description: string): Pr
  * so no interactive sign-in is required. positAI is disabled so the Foundry
  * model is the one exercised. Shared by the host-side `beforeApp` fixture and
  * `dockerSettingsOverrides` so the two paths cannot drift.
+ *
+ * `positron.assistant.models.overrides.msFoundry` declares the models the
+ * provider exposes in the picker: `model-router` (the virtual routing model) and
+ * the concrete `claude-sonnet-4-6` model. The foundry workbench suite exercises
+ * both -- one test selects the router, the other the concrete model -- to cover
+ * the model-overrides auth path for GA.
+ *
+ * NOTE: the `positron.assistant.models.overrides.msFoundry` key is expected to
+ * change in the future; update this override (and the foundry suite) when it does.
  */
 export const FOUNDRY_ASSISTANT_SETTINGS = {
 	'positron.assistant.enable': true,
 	'positron.assistant.provider.positAI.enable': false,
-	'positron.assistant.models.overrides.msFoundry': [{ name: 'model-router', identifier: 'model-router' }],
+	'positron.assistant.models.overrides.msFoundry': [
+		{ name: 'model-router', identifier: 'model-router' },
+		{ name: 'claude-sonnet-4-6', identifier: 'claude-sonnet-4-6' },
+	],
 	'positron.assistant.provider.msFoundry.enable': true,
 	'posit.workbench.foundry.endpoint': 'https://east2testai.services.ai.azure.com/',
 	'authentication.foundry.baseUrl': 'https://east2testai.services.ai.azure.com/openai/v1',

--- a/test/e2e/tests/workbench/posit-assistant/posit-assistant-foundry.test.ts
+++ b/test/e2e/tests/workbench/posit-assistant/posit-assistant-foundry.test.ts
@@ -37,4 +37,26 @@ test.describe('Posit Assistant - Microsoft Foundry (Azure managed credentials)',
 		const responseText = await app.workbench.positAssistant.getLastResponseText();
 		expect(responseText.length).toBeGreaterThan(0);
 	});
+
+	test('Foundry model from the models-overrides setting responds (Azure managed credentials)', async function ({ app }) {
+		// The msFoundry provider exposes the models declared in
+		// `positron.assistant.models.overrides.msFoundry` (pushed by the fixture
+		// via `enableFoundryAssistant`). Alongside `model-router`, that override
+		// declares the concrete `claude-sonnet-4-6` model. Selecting it confirms a
+		// specific overridden model -- not just the router -- resolves and responds
+		// through the managed credential, covering the model-overrides auth path.
+		await app.workbench.positAssistant.open();
+		await app.workbench.positAssistant.waitForReady();
+		await app.workbench.positAssistant.startNewConversation();
+
+		// The concrete model is collapsed under the "More models" disclosure in the
+		// picker; selectModel expands it automatically. `newConversation: false`
+		// keeps the model we just picked instead of resetting to a fresh chat.
+		await app.workbench.positAssistant.selectModel('claude-sonnet-4-6');
+		await app.workbench.positAssistant.sendMessage('Say hello', true, { newConversation: false });
+		await app.workbench.positAssistant.expectResponseVisible();
+
+		const responseText = await app.workbench.positAssistant.getLastResponseText();
+		expect(responseText.length).toBeGreaterThan(0);
+	});
 });


### PR DESCRIPTION
Addresses the second task in #14497.

### Summary

Adds e2e coverage for the `positron.assistant.models.overrides.msFoundry` setting (the model-overrides auth path for the Microsoft Foundry / Azure provider), which the GA discussion called out as needed beyond the existing model-router coverage.

- The shared `FOUNDRY_ASSISTANT_SETTINGS` fixture override now declares a concrete `claude-sonnet-4-6` model alongside `model-router`, so the picker exposes both.
- A new test in the foundry workbench suite selects the concrete `claude-sonnet-4-6` model and confirms it resolves and responds through the Azure managed credential -- not just the router.

The test lives in the existing workbench foundry suite so it reuses the same worker-scoped Posit Workbench session (one container, one OIDC sign-in). Exposing the model through the provisioned fixture settings (rather than a runtime `settings.set`) avoids a window reload, which is fragile on the Azure JIT-user shard.

The first task in #14497 (API key + model router, desktop) shipped in #14519.

> Note: the `positron.assistant.models.overrides.msFoundry` key is expected to change in the future. A `NOTE:` comment on the fixture override flags that this test (and the override) will need updating when it does.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:workbench @:posit-assistant @:assistant

The new test runs on the Azure Workbench shard. It signs into Posit Workbench via Azure OIDC, opens Posit Assistant, selects the `claude-sonnet-4-6` model (exposed via the `positron.assistant.models.overrides.msFoundry` override and collapsed under the "More models" disclosure), sends "Say hello", and asserts a non-empty response is returned through the managed credential.
