### PR TITLE
E2E test: skip postgres tests on Mac runners

### DIFF
--- a/test/e2e/tests/connections/connections-postgres.test.ts
+++ b/test/e2e/tests/connections/connections-postgres.test.ts
@@ -18,6 +18,13 @@ test.describe('Postgres DB Connection', {
 	tag: [tags.WEB, tags.WIN, tags.CONNECTIONS, tags.WORKBENCH]
 }, () => {
 
+	// These tests require a running Postgres container, which is only available on the Windows
+	// and web CI rigs. The macOS CI project runs @:win-tagged tests too (see playwright.config.ts),
+	// but has no Postgres container, so skip the whole suite there.
+	test.beforeEach(function () {
+		test.skip(process.platform === 'darwin', 'No Postgres container available on macOS CI');
+	});
+
 	test('Python - Can establish a Postgres connection to a docker container', async function ({ app, hotKeys, python }) {
 
 		await app.workbench.connections.openConnectionPane();

--- a/test/e2e/tests/data-connections/postgres.test.ts
+++ b/test/e2e/tests/data-connections/postgres.test.ts
@@ -49,6 +49,11 @@ test.describe('Data Connections - Postgres', {
 	// every test in the suite. Create it and expand the tree to a known baseline once here. Per-test
 	// state that must not leak between tests (an open Data Explorer tab) is reset in afterEach.
 	test.beforeAll(async function ({ app }) {
+		// These tests require a running Postgres container, which is only available on the Windows
+		// and web CI rigs. The macOS CI project runs @:win-tagged tests too (see playwright.config.ts),
+		// but has no Postgres container, so skip the whole suite there.
+		test.skip(process.platform === 'darwin', 'No Postgres container available on macOS CI');
+
 		const { dataConnections } = app.workbench;
 
 		await dataConnections.openDataConnectionsView();


### PR DESCRIPTION
These tests require a postgres db but we do not have one for Mac because its not supported yet with the mac github runners.