### PR TITLE
Fix Copilot Chat auth

### DIFF
--- a/extensions/copilot/src/extension/prompts/node/base/positronAssistant.tsx
+++ b/extensions/copilot/src/extension/prompts/node/base/positronAssistant.tsx
@@ -25,10 +25,21 @@ export class PositronAssistant extends PromptElement<GenericBasePromptElementPro
 		progress?: vscode.Progress<ChatResponsePart>,
 		token?: vscode.CancellationToken): Promise<any> {
 
-		// Get the Positron API
-		const api = vscode.extensions.getExtension('positron.positron-assistant')?.exports;
+		// The Positron Assistant extension supplies the Positron-specific context
+		// for this prompt. When Copilot Chat is used on its own, that extension may
+		// be disabled or not installed; skip this element in that case rather than
+		// failing the whole chat request.
+		const extension = vscode.extensions.getExtension('positron.positron-assistant');
+		if (!extension) {
+			return undefined;
+		}
 
-		// Generate the content element
+		// Activate the extension if needed so its API is available, then generate
+		// the content element.
+		const api = await extension.activate();
+		if (typeof api?.generateAssistantPrompt !== 'function') {
+			return undefined;
+		}
 		return await api.generateAssistantPrompt(this.context.request);
 	}
 
@@ -42,6 +53,11 @@ export class PositronAssistant extends PromptElement<GenericBasePromptElementPro
 	 * @returns The rendered component.
 	 */
 	render(state: any, sizing: PromptSizing) {
+		// No Positron context available (e.g. the Positron Assistant extension is
+		// not installed or enabled); render nothing.
+		if (!state) {
+			return undefined;
+		}
 		return (
 			<SystemMessage>
 				<TextChunk>{state}</TextChunk>

--- a/extensions/copilot/src/extension/prompts/node/base/positronAssistant.tsx
+++ b/extensions/copilot/src/extension/prompts/node/base/positronAssistant.tsx
@@ -4,10 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { PromptElement, PromptSizing, SystemMessage, TextChunk } from '@vscode/prompt-tsx';
-import { ChatResponsePart } from '@vscode/prompt-tsx/dist/base/vscodeTypes.js';
+import type { ChatResponsePart } from '@vscode/prompt-tsx/dist/base/vscodeTypes.js';
 import * as vscode from 'vscode';
-import { GenericBasePromptElementProps } from '../../../context/node/resolvers/genericPanelIntentInvocation';
-import { IBuildPromptContext } from '../../../prompt/common/intents.js';
+import type { GenericBasePromptElementProps } from '../../../context/node/resolvers/genericPanelIntentInvocation';
+import type { IBuildPromptContext } from '../../../prompt/common/intents.js';
 
 /**
  * The Positron Assistant component; adds context from Positron as a prompt

--- a/extensions/copilot/src/extension/prompts/node/base/test/positronAssistant.spec.tsx
+++ b/extensions/copilot/src/extension/prompts/node/base/test/positronAssistant.spec.tsx
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect, suite, test, vi } from 'vitest';
+import { PositronAssistant } from '../positronAssistant';
+
+// `prepare()` resolves the Positron Assistant extension via
+// `vscode.extensions.getExtension`; that is the only `vscode` member used at
+// runtime, so mock just `extensions` and drive `getExtension` per-test.
+const { getExtension } = vi.hoisted(() => ({ getExtension: vi.fn() }));
+vi.mock('vscode', () => ({ extensions: { getExtension } }));
+
+suite('PositronAssistant', () => {
+	const request = { prompt: 'hello' };
+	const props = { promptContext: { request } } as any;
+	const element = new PositronAssistant(props);
+
+	test('prepare returns undefined when the Positron Assistant extension is not installed', async () => {
+		getExtension.mockReturnValue(undefined);
+
+		expect(await element.prepare({} as any)).toBeUndefined();
+	});
+
+	test('prepare returns undefined when the extension API lacks generateAssistantPrompt', async () => {
+		getExtension.mockReturnValue({ activate: async () => ({}) });
+
+		expect(await element.prepare({} as any)).toBeUndefined();
+	});
+
+	test('prepare activates the extension and returns its generated prompt', async () => {
+		const generateAssistantPrompt = vi.fn().mockResolvedValue('positron context');
+		getExtension.mockReturnValue({ activate: async () => ({ generateAssistantPrompt }) });
+
+		expect(await element.prepare({} as any)).toBe('positron context');
+		expect(generateAssistantPrompt).toHaveBeenCalledWith(request);
+	});
+
+	test('render returns nothing when there is no Positron context', () => {
+		expect(element.render(undefined, {} as any)).toBeUndefined();
+	});
+
+	test('render embeds the Positron context when it is available', () => {
+		const rendered = element.render('positron context', {} as any);
+
+		expect(JSON.stringify(rendered)).toContain('positron context');
+	});
+});

--- a/product.json
+++ b/product.json
@@ -338,24 +338,24 @@
 		"https://support.posit.co"
 	],
 	"defaultChatAgent": {
-		"extensionId": "positron.positron-assistant",
-		"chatExtensionId": "positron.positron-assistant",
+		"extensionId": "GitHub.copilot-chat",
+		"chatExtensionId": "GitHub.copilot-chat",
 		"provider": {
 			"default": {
-				"id": "positron.assistant",
-				"name": "Positron Assistant"
+				"id": "github",
+				"name": "GitHub"
 			},
 			"enterprise": {
-				"id": "positron.assistant",
-				"name": "Positron Assistant"
+				"id": "github-enterprise",
+				"name": "GHE"
 			},
 			"google": {
-				"id": "positron.assistant",
-				"name": "Positron Assistant"
+				"id": "google",
+				"name": "Google"
 			},
 			"apple": {
-				"id": "positron.assistant",
-				"name": "Positron Assistant"
+				"id": "apple",
+				"name": "Apple"
 			}
 		},
 		"providerExtensionId": "vscode.github-authentication",

--- a/src/vs/workbench/contrib/chat/common/participants/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/participants/chatAgents.ts
@@ -32,9 +32,6 @@ import { ChatPerfMark, markChat } from '../chatPerf.js';
 // --- Start Positron ---
 // eslint-disable-next-line no-duplicate-imports
 import { IChatTokenUsage } from '../model/chatModel.js';
-// eslint-disable-next-line no-duplicate-imports
-import { COPILOT_CHAT_EXTENSION_ID } from '../constants.js';
-import { IPositronAssistantConfigurationService } from '../../../positronAssistant/common/interfaces/positronAssistantService.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
 // --- End Positron ---
 
@@ -325,7 +322,6 @@ export class ChatAgentService extends Disposable implements IChatAgentService {
 		// --- Start Positron ---
 		@ILogService private readonly logService: ILogService,
 		@ILanguageModelsService private readonly languageModelsService: ILanguageModelsService,
-		@IPositronAssistantConfigurationService private readonly positronAssistantConfigurationService: IPositronAssistantConfigurationService,
 		// --- End Positron ---
 	) {
 		super();
@@ -426,15 +422,7 @@ export class ChatAgentService extends Disposable implements IChatAgentService {
 		let extensionAgentRegistered = false;
 		let defaultAgentRegistered = false;
 		let toolsAgentRegistered = false;
-		// --- Start Positron ---
-		let testAgentRegistered = false;
-		// --- End Positron ---
 		for (const agent of this.getAgents()) {
-			// --- Start Positron ---
-			if (agent.extensionId.value === 'vscode.vscode-api-tests') {
-				testAgentRegistered = true;
-			}
-			// --- End Positron ---
 			if (agent.isDefault) {
 				// --- Start Positron ---
 				defaultAgentRegistered = true;
@@ -451,14 +439,13 @@ export class ChatAgentService extends Disposable implements IChatAgentService {
 			}
 		}
 		// --- Start Positron ---
-		// Do not register default agents when Assistant is disabled, except for
-		// the API test agent from upstream. Also treat `chat.disableAIFeatures`
-		// as "no panel participant" so the chat UI hides while leaving the chat
-		// extension's `vscode.lm` model provider available for other consumers.
-		// this._defaultAgentRegistered.set(defaultAgentRegistered);
-		if (testAgentRegistered || this.configurationService.getValue('positron.assistant.enable')) {
-			this._defaultAgentRegistered.set(defaultAgentRegistered && !this._isAIDisabled());
-		}
+		// Treat `chat.disableAIFeatures` as "no panel participant" so the chat UI
+		// hides while leaving the chat extension's `vscode.lm` model provider
+		// available for other consumers. (Previously also gated on
+		// `positron.assistant.enable`, which made the chat panel depend on the
+		// Positron Assistant extension being enabled; removed so a default chat
+		// agent such as GitHub Copilot can register on its own.)
+		this._defaultAgentRegistered.set(defaultAgentRegistered && !this._isAIDisabled());
 		// Keep the `chatAiFeaturesEnabled` gate in sync with both AI switches.
 		this._aiFeaturesEnabled.set(!this._isAIDisabled());
 		// --- End Positron ---
@@ -616,33 +603,6 @@ export class ChatAgentService extends Disposable implements IChatAgentService {
 
 	private _agentIsEnabled(idOrAgent: string | IChatAgentEntry): boolean {
 		const entry = typeof idOrAgent === 'string' ? this._agents.get(idOrAgent) : idOrAgent;
-		// --- Start Positron ---
-		// Special handling for Copilot Chat participants
-		const isCopilotParticipant = ExtensionIdentifier.equals(entry?.data.extensionId, COPILOT_CHAT_EXTENSION_ID);
-		if (isCopilotParticipant) {
-			// Disable Copilot Chat agent if Copilot is not enabled
-			const isCopilotEnabled = this.positronAssistantConfigurationService.copilotEnabled;
-			if (!isCopilotEnabled) {
-				return false;
-			}
-
-			const currentProvider = this.languageModelsService.currentProvider;
-			const currentProviderExtensionId = currentProvider ?
-				this.languageModelsService.getExtensionIdentifierForProvider(currentProvider.id) :
-				undefined;
-			if (!currentProviderExtensionId) {
-				return false;
-			}
-			const isCurrentProviderCopilot = ExtensionIdentifier.equals(currentProviderExtensionId, COPILOT_CHAT_EXTENSION_ID);
-			if (!isCurrentProviderCopilot) {
-				// Disable Copilot Chat agent if the user has not opted into using Copilot participants for non-Copilot providers
-				const useCopilotParticipantsWithOtherProviders = this.configurationService.getValue<boolean>(ChatConfiguration.UseCopilotParticipantsWithOtherProviders);
-				if (!useCopilotParticipantsWithOtherProviders) {
-					return false;
-				}
-			}
-		}
-		// --- End Positron ---
 		return !entry?.data.when || this.contextKeyService.contextMatchesRules(ContextKeyExpr.deserialize(entry.data.when));
 	}
 

--- a/src/vs/workbench/contrib/chat/test/common/participants/chatAgents.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/participants/chatAgents.test.ts
@@ -15,7 +15,6 @@ import { ILanguageModelChatProvider, ILanguageModelsChangeEvent, ILanguageModels
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { NullLogService } from '../../../../../../platform/log/common/log.js';
 import { Disposable, IDisposable } from '../../../../../../base/common/lifecycle.js';
-import { TestPositronAssistantConfigurationService } from '../../../../../test/common/positronWorkbenchTestServices.js';
 import { observableValue } from '../../../../../../base/common/observable.js';
 import { ChatContextKeys } from '../../../common/actions/chatContextKeys.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind } from '../../../common/constants.js';
@@ -106,9 +105,7 @@ suite('ChatAgents', function () {
 		configurationService = new TestConfigurationService();
 		const logService = new NullLogService();
 		const languageModelsService = new TestLanguageModelsService();
-		const positronAssistantConfigurationService = new TestPositronAssistantConfigurationService();
-		configurationService.setUserConfiguration('positron.assistant.enable', true);
-		chatAgentService = store.add(new ChatAgentService(contextKeyService, configurationService, logService, languageModelsService, positronAssistantConfigurationService));
+		chatAgentService = store.add(new ChatAgentService(contextKeyService, configurationService, logService, languageModelsService));
 		// --- End Positron ---
 	});
 

--- a/src/vs/workbench/contrib/chat/test/common/participants/chatAgents.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/participants/chatAgents.test.ts
@@ -238,12 +238,13 @@ suite('ChatAgents', function () {
 			assert.deepStrictEqual(contextKeys(), { enabled: true, panelParticipantRegistered: true, aiFeaturesEnabled: true }, 'keys return when AI is re-enabled at runtime');
 		});
 
-		test('API test agent registers the panel participant regardless of positron.assistant.enable', () => {
+		test('a default agent registers the panel participant even when positron.assistant.enable is off', () => {
+			// The chat panel previously registered only when `positron.assistant.enable`
+			// was on (or the upstream API test agent was present). That gate has been
+			// removed, so any default agent (e.g. GitHub Copilot) now registers the
+			// panel participant on its own while AI features are not disabled.
 			configurationService.setUserConfiguration('positron.assistant.enable', false);
-			store.add(chatAgentService.registerAgent(defaultAgentId, {
-				...defaultAgentData,
-				extensionId: new ExtensionIdentifier('vscode.vscode-api-tests'),
-			}));
+			store.add(chatAgentService.registerAgent(defaultAgentId, defaultAgentData));
 
 			assert.strictEqual(ChatContextKeys.panelParticipantRegistered.getValue(contextKeyService), true);
 		});


### PR DESCRIPTION
#13222 

Fix issues with Copilot Chat auth and assistant name in chat view. The context injection for Positron protects the prompt if the API is unavailable. The chat agent names have been reverted to Copilot.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### Validation Steps

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information on how to validate the change, paying
  special attention to the level of risk, adjacent areas that could
  be affected by the change, and any important contextual information
  not present in the linked issues.
-->
