### PR TITLE
E2E test: capture more trace info

### DIFF
--- a/test/e2e/fixtures/test-setup/options.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/options.fixtures.ts
@@ -10,6 +10,7 @@ import * as playwright from '@playwright/test';
 import { ApplicationOptions, copyFixtureFile, Quality, getRandomUserDataDir, Browser, StorageFile } from '../../infra';
 import { ROOT_PATH, TEMP_DIR } from './constants';
 import { copyUserSettings } from './shared-utils.js';
+import { shouldUseCustomTracing } from './reporting.fixtures.js';
 
 export interface CustomTestOptions {
 	artifactDir: string;
@@ -64,6 +65,7 @@ export function OptionsFixture() {
 			headless: project.headless,
 			browser,
 			tracing: true,
+			customTracing: shouldUseCustomTracing(workerInfo.project),
 			snapshots,
 			quality: Quality.Dev,
 			version,

--- a/test/e2e/fixtures/test-setup/reporting.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/reporting.fixtures.ts
@@ -244,12 +244,16 @@ export function TracingFixture() {
 			return;
 		}
 
-		// The trace chunk we export below was opened *before* this test's per-test
-		// fixtures ran -- either by the `app` worker fixture (for the first test in
-		// the worker, which also captures `beforeAll`) or by the previous test's
-		// teardown in this same fixture. So failures in pre-test fixtures and
-		// `beforeEach` hooks are already inside the trace. The try/finally ensures
-		// we always export and re-open, even when `use()` rejects.
+		// Ensure a chunk is recording for this test. This fixture is an auto fixture,
+		// so it sets up before the test's request fixtures (`python`, `r`, ...) and
+		// `beforeEach` hooks -- their activity is captured. For the first test in the
+		// worker this is a no-op: the driver already opened the "startup" chunk at
+		// context creation, so that chunk (covering app startup and `beforeAll`) is
+		// reused and exported as the first test's trace. We deliberately open here at
+		// setup rather than re-opening in teardown: a test that leaves a blocking
+		// native dialog (e.g. the PDF print preview) would hang startTracing() in
+		// teardown. The try/finally still ensures we export even when `use()` rejects.
+		await app.startTracing(testInfo.titlePath.join(' › '));
 		try {
 			await use(app);
 		} finally {
@@ -257,12 +261,6 @@ export function TracingFixture() {
 			const title = path.basename(`_trace`); // do NOT use title of 'trace' - conflicts with the default trace
 			const tracePath = testInfo.outputPath(`${title}.zip`);
 			await app.stopTracing(title, true, tracePath);
-
-			// Immediately open a fresh chunk so the *next* test's pre-test fixtures
-			// and `beforeEach` hooks are captured from the very start. (For the last
-			// test in the worker this chunk is simply discarded when the context's
-			// tracing is stopped on close.)
-			await app.startTracing(testInfo.titlePath.join(' › '));
 
 			// attach the trace to the report if CI and test failed or not in CI
 			const isCI = process.env.CI === 'true';

--- a/test/e2e/fixtures/test-setup/reporting.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/reporting.fixtures.ts
@@ -221,29 +221,48 @@ async function attachDockerLogsToReport(logsPath: string, testInfo: playwright.T
 	}
 }
 
+/**
+ * Whether we manage Playwright tracing ourselves via per-test chunks (Positron
+ * desktop runs and all command-line runs), as opposed to letting Playwright's
+ * built-in tracing handle it (browser-based runs in UI mode or the VS Code
+ * extension). The continuous recording is started once per worker when the app
+ * context is created; we slice it into per-test chunks (see `TracingFixture`).
+ */
+export function shouldUseCustomTracing(project: playwright.FullProject): boolean {
+	const isCommandLineRun = !!process.env.npm_execpath && !(process.env.PW_UI_MODE === 'true');
+	// Use Playwright's built-in tracing only for browser-based runs (extension, UI mode).
+	return !(project.use.browserName && !isCommandLineRun);
+}
+
 export function TracingFixture() {
 	return async (options: TracingOptions, use: (arg0: Application) => Promise<void>) => {
 		const { app, testInfo } = options;
 
-		// Determine execution mode
-		const isCommandLineRun = process.env.npm_execpath && !(process.env.PW_UI_MODE === 'true');
-		// Use Playwright's built-in tracing only for browser-based runs (extension, UI mode).
-		// Use custom tracing for Positron desktop runs or CLI runs.
-		if (
-			testInfo.project.use.browserName &&
-			!isCommandLineRun
-		) {
+		if (!shouldUseCustomTracing(testInfo.project)) {
+			// Playwright's built-in tracing manages the trace for this run.
 			await use(app);
-		} else {
-			// start tracing
-			await app.startTracing(testInfo.titlePath.join(' › '));
+			return;
+		}
 
+		// The trace chunk we export below was opened *before* this test's per-test
+		// fixtures ran -- either by the `app` worker fixture (for the first test in
+		// the worker, which also captures `beforeAll`) or by the previous test's
+		// teardown in this same fixture. So failures in pre-test fixtures and
+		// `beforeEach` hooks are already inside the trace. The try/finally ensures
+		// we always export and re-open, even when `use()` rejects.
+		try {
 			await use(app);
-
-			// stop tracing
+		} finally {
+			// Export the chunk for this test.
 			const title = path.basename(`_trace`); // do NOT use title of 'trace' - conflicts with the default trace
 			const tracePath = testInfo.outputPath(`${title}.zip`);
 			await app.stopTracing(title, true, tracePath);
+
+			// Immediately open a fresh chunk so the *next* test's pre-test fixtures
+			// and `beforeEach` hooks are captured from the very start. (For the last
+			// test in the worker this chunk is simply discarded when the context's
+			// tracing is stopped on close.)
+			await app.startTracing(testInfo.titlePath.join(' › '));
 
 			// attach the trace to the report if CI and test failed or not in CI
 			const isCI = process.env.CI === 'true';

--- a/test/e2e/infra/code.ts
+++ b/test/e2e/infra/code.ts
@@ -45,6 +45,13 @@ export interface LaunchOptions {
 	readonly remote?: boolean;
 	readonly web?: boolean;
 	readonly tracing?: boolean;
+	/**
+	 * When true, we manage tracing ourselves via per-test chunks (Positron desktop
+	 * runs and all command-line runs) and open the first chunk at context creation
+	 * so early startup is captured. When false, Playwright's built-in tracing
+	 * handles it (browser-based runs in UI mode or the VS Code extension).
+	 */
+	readonly customTracing?: boolean;
 	snapshots?: boolean;
 	readonly headless?: boolean;
 	readonly browser?: 'chromium' | 'webkit' | 'firefox' | 'chromium-msedge' | 'chromium-chrome';

--- a/test/e2e/infra/playwrightBrowser.ts
+++ b/test/e2e/infra/playwrightBrowser.ts
@@ -143,7 +143,7 @@ async function startServer(
 }
 
 async function launchBrowser(options: LaunchOptions, endpoint: string) {
-	const { logger, workspacePath, tracing, snapshots, headless } = options;
+	const { logger, workspacePath, tracing, customTracing, snapshots, headless } = options;
 	const [browserType, browserChannel] = (options.browser ?? 'chromium').split('-');
 	// WebKit doesn't support --disable-popup-blocking, but Chromium/Firefox do
 	const args = browserType === 'webkit' ? [] : ['--disable-popup-blocking'];
@@ -167,6 +167,12 @@ async function launchBrowser(options: LaunchOptions, endpoint: string) {
 		try {
 			await measureAndLog(() => context.tracing.start({ screenshots: true, snapshots }), 'context.tracing.start()', logger);
 			// --- Start Positron ---
+			// Open the first chunk now so startup is captured. A failure during startup
+			// lands in the trace exported by the app fixture; otherwise the per-test
+			// tracing fixture re-slices from here.
+			if (customTracing) {
+				await context.tracing.startChunk({ title: 'startup' });
+			}
 			// Yes, this is hacky, but we are unable to disable default tracing in Playwright browser tests
 			// See related discussion: https://github.com/microsoft/playwright/issues/33303#issuecomment-2442096479
 			context.tracing.start = async (...args) => {

--- a/test/e2e/infra/playwrightDriver.ts
+++ b/test/e2e/infra/playwrightDriver.ts
@@ -71,7 +71,15 @@ export class PlaywrightDriver {
 		private readonly whenLoaded: Promise<unknown>,
 		private readonly options: LaunchOptions
 	) {
+		// When custom tracing is on, the launch code opens the first trace chunk
+		// (the "startup" chunk) right before constructing this driver, so a chunk
+		// is already recording. Tracking this lets startTracing() avoid clobbering
+		// that startup chunk (a duplicate startChunk silently discards the open one).
+		this._tracingChunkOpen = !!(options.tracing && options.customTracing);
 	}
+
+	// Whether a trace chunk is currently recording (see startTracing/stopTracing).
+	private _tracingChunkOpen = false;
 
 	get browserContext(): playwright.BrowserContext {
 		return this.context;
@@ -370,8 +378,16 @@ export class PlaywrightDriver {
 			return; // tracing disabled
 		}
 
+		// A chunk is already recording (e.g. the startup chunk, or the chunk from a
+		// test whose teardown hasn't run yet). Re-opening would silently discard it,
+		// so leave the current chunk in place.
+		if (this._tracingChunkOpen) {
+			return;
+		}
+
 		try {
 			await measureAndLog(() => this.context.tracing.startChunk({ title: name }), `startTracing${name ? ` for ${name}` : ''}`, this.options.logger);
+			this._tracingChunkOpen = true;
 		} catch (error) {
 			// Tracing may not have initialized successfully on some browsers - ignore
 		}
@@ -395,6 +411,10 @@ export class PlaywrightDriver {
 			await measureAndLog(() => this.context.tracing.stopChunk({ path: persistPath }), `stopTracing${name ? ` for ${name}` : ''}`, this.options.logger);
 		} catch (error) {
 			// Ignore
+		} finally {
+			// The chunk is closed (or failed to close); either way it is no longer the
+			// active chunk, so the next startTracing() should open a fresh one.
+			this._tracingChunkOpen = false;
 		}
 	}
 

--- a/test/e2e/infra/playwrightElectron.ts
+++ b/test/e2e/infra/playwrightElectron.ts
@@ -42,7 +42,7 @@ export async function launch(options: LaunchOptions): Promise<{ electronProcess:
 }
 
 async function launchElectron(configuration: IElectronConfiguration, options: LaunchOptions) {
-	const { logger, tracing, snapshots } = options;
+	const { logger, tracing, customTracing, snapshots } = options;
 
 	if (!fs.existsSync(configuration.electronPath || '')) {
 		throw new Error(`Cannot find Positron at ${configuration.electronPath}. Please run Positron once first (scripts/code.sh, scripts\\code.bat) and try again.`);
@@ -68,6 +68,12 @@ async function launchElectron(configuration: IElectronConfiguration, options: La
 	if (tracing) {
 		try {
 			await measureAndLog(() => context.tracing.start({ screenshots: true, snapshots }), 'context.tracing.start()', logger);
+			// Open the first chunk now so startup is captured. A failure during startup
+			// lands in the trace exported by the app fixture; otherwise the per-test
+			// tracing fixture re-slices from here.
+			if (customTracing) {
+				await context.tracing.startChunk({ title: 'startup' });
+			}
 		} catch (error) {
 			logger.log(`Playwright (Electron): Failed to start playwright tracing (${error})`); // do not fail the build when this fails
 		}

--- a/test/e2e/infra/playwrightExternalServer.ts
+++ b/test/e2e/infra/playwrightExternalServer.ts
@@ -22,7 +22,7 @@ export async function launch(options: LaunchOptions, serverUrl: string): Promise
 }
 
 async function launchBrowser(options: LaunchOptions, serverUrl: string) {
-	const { logger, workspacePath, tracing, snapshots, headless } = options;
+	const { logger, workspacePath, tracing, customTracing, snapshots, headless } = options;
 
 	const [browserType, browserChannel] = (options.browser ?? 'chromium').split('-');
 	// WebKit doesn't support --disable-popup-blocking, but Chromium/Firefox do
@@ -46,6 +46,12 @@ async function launchBrowser(options: LaunchOptions, serverUrl: string) {
 	if (tracing) {
 		try {
 			await measureAndLog(() => context.tracing.start({ screenshots: true, snapshots }), 'context.tracing.start()', logger);
+			// Open the first chunk now so startup (server connect, sign-in, opening the
+			// workspace) is captured. A failure here lands in the trace exported by the
+			// app fixture; otherwise the per-test tracing fixture re-slices from here.
+			if (customTracing) {
+				await context.tracing.startChunk({ title: 'startup' });
+			}
 			// Prevent duplicate tracing start calls
 			context.tracing.start = async (...args) => {
 				logger.log('Tracing is already managed, skipping default tracing start.');

--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -16,7 +16,7 @@ import { PackageManager } from '../pages/utils/packageManager';
 import {
 	FileOperationsFixture, SettingsFixture, Settings, MetricsFixture,
 	AttachScreenshotsToReportFixture, AttachLogsToReportFixture,
-	TracingFixture, AppFixture, UserDataDirFixture, OptionsFixture,
+	TracingFixture, shouldUseCustomTracing, AppFixture, UserDataDirFixture, OptionsFixture,
 	CustomTestOptions, TEMP_DIR, LOGS_ROOT_PATH, setSpecName, renameTempLogsDir
 } from '../fixtures/test-setup';
 import { loadEnvironmentVars, validateEnvironmentVars } from '../fixtures/load-environment-vars.js';
@@ -140,6 +140,14 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 
 		try {
 			await start();
+
+			// Open the first trace chunk now -- before `beforeAll` and the first
+			// test's per-test fixtures run -- so their activity is captured. Each
+			// test's tracing fixture then exports the current chunk and opens the
+			// next one (see TracingFixture).
+			if (shouldUseCustomTracing(workerInfo.project)) {
+				await app.startTracing('suite-start');
+			}
 
 			await use(app);
 		} catch (error) {

--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -26,7 +26,12 @@ import { runDockerCommand, RunResult, FOUNDRY_ASSISTANT_SETTINGS } from '../fixt
 // used specifically for app fixture error handling in test.afterAll
 let appFixtureFailed = false;
 let appFixtureScreenshot: Buffer | undefined;
+let appFixtureTracePath: string | undefined;
 let renamedLogsPath = 'not-set';
+
+// Basename of the trace exported when the app fixture's `start()` fails (see the
+// `app` fixture catch block); attached from the renamed logs dir in afterAll.
+const APP_START_FAILURE_TRACE = 'app-start-failure-trace.zip';
 
 // Test fixtures
 export const test = base.extend<TestFixtures, WorkerFixtures>({
@@ -139,15 +144,12 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 		const { app, start, stop } = await AppFixture({ options, logsPath, logger, workerInfo, managedCredentials, useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant });
 
 		try {
-			await start();
-
-			// Open the first trace chunk now -- before `beforeAll` and the first
-			// test's per-test fixtures run -- so their activity is captured. Each
+			// The first trace chunk is opened at context creation (see the driver's
+			// `context.tracing.start` + `startChunk`), so the whole of `start()` --
+			// server connect, sign-in, opening the workspace -- is recorded. Each
 			// test's tracing fixture then exports the current chunk and opens the
 			// next one (see TracingFixture).
-			if (shouldUseCustomTracing(workerInfo.project)) {
-				await app.startTracing('suite-start');
-			}
+			await start();
 
 			await use(app);
 		} catch (error) {
@@ -158,6 +160,19 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 				const page = app.code?.driver?.currentPage;
 				if (page) {
 					appFixtureScreenshot = await page.screenshot({ path: screenshotPath });
+				}
+			} catch {
+				// ignore
+			}
+
+			// The per-test tracing fixture never runs when `start()` fails, so export
+			// the startup chunk here. This is the trace of the failing startup itself.
+			// It is written under logsPath, which `renameTempLogsDir` (below) renames,
+			// so remember the basename and attach it from renamedLogsPath in afterAll.
+			try {
+				if (shouldUseCustomTracing(workerInfo.project)) {
+					await app.stopTracing('app-start-failure', true, join(logsPath, APP_START_FAILURE_TRACE));
+					appFixtureTracePath = APP_START_FAILURE_TRACE;
 				}
 			} catch {
 				// ignore
@@ -423,6 +438,18 @@ test.afterAll(async function ({ logger, suiteId, }, testInfo) {
 		}
 
 		try {
+			if (appFixtureTracePath) {
+				testInfo.attachments.push({
+					name: 'trace',
+					path: join(renamedLogsPath, appFixtureTracePath),
+					contentType: 'application/zip',
+				});
+			}
+		} catch (e) {
+			console.log(e);
+		}
+
+		try {
 			const attachLogs = AttachLogsToReportFixture();
 			await attachLogs({ suiteId, logsPath: renamedLogsPath, testInfo }, async () => { /* no-op */ });
 		} catch (e) {
@@ -431,6 +458,7 @@ test.afterAll(async function ({ logger, suiteId, }, testInfo) {
 
 		appFixtureFailed = false;
 		appFixtureScreenshot = undefined;
+		appFixtureTracePath = undefined;
 	}
 
 	// Dump active handles/requests to help debug worker teardown timeouts


### PR DESCRIPTION
## Summary

Playwright traces previously missed any failure that occurred before the per-test trace chunk was opened -- `beforeAll`, worker-scoped setup, and (most importantly) failures *during* app startup inside the `app` fixture's `start()`. This opens the trace chunk at context creation and exports it on app-start failure, so the trace now covers everything from app launch onward.

## Background

Tracing works in two layers:

1. **Continuous recording** -- `context.tracing.start()` is called once per worker when the app context is created. This records everything the worker does.
2. **Per-test slicing** -- the `tracing` fixture calls `startChunk`/`stopChunk` to carve the continuous recording into a trace file per test.

The slice-start (`startTracing`) lived inside the **test-scoped** `tracing` fixture, so the chunk only opened *after* worker setup, `beforeAll`, and the entire `app` fixture `start()` had already run. Any failure in those phases produced no usable trace -- even though the continuous recording was active the whole time.

A concrete example from CI ([failed workbench run](https://github.com/posit-dev/positron/actions/runs/28395930177/job/84138668351?pr=14562)): `Python - Create module environment` failed inside `start()` (`openSession('qa-example-content')` timed out while opening the workspace). The report shows an `app-start-failure` screenshot but no trace, because the chunk was never opened and the per-test tracing fixture never ran.

Isolated experiments (Playwright 1.59.1) also confirmed that pre-test *request* fixtures (`python`, `r`, `sessions`) and `beforeEach` hooks were already inside the chunk -- the `tracing` auto fixture sets up before them -- so the gaps were specifically `beforeAll`, worker setup, and app startup.

## Changes

- **Open the chunk at context creation, not after `start()`.** Each driver (`playwrightExternalServer.ts`, `playwrightBrowser.ts`, `playwrightElectron.ts`) now calls `context.tracing.startChunk({ title: 'startup' })` immediately after `context.tracing.start()`, so the chunk is open for the entire startup (connect, sign-in, open-folder) and for `beforeAll`.
- **`code.ts` / `options.fixtures.ts`** -- added a `customTracing` launch option, computed once via the existing `shouldUseCustomTracing(project)` helper, so the drivers gate the initial chunk the same way the fixture does. Browser UI-mode still defers to Playwright's built-in tracing; no infra-to-test-layer import.
- **`reporting.fixtures.ts`** -- the `tracing` fixture opens the chunk at **setup** (an auto fixture, so it runs before the test's request fixtures and `beforeEach`) and exports it in a `try/finally` teardown. It deliberately does **not** re-open a chunk in teardown: a test that ends with a blocking native dialog (e.g. the PDF print preview) would hang `startChunk` there. For the first test in a worker, setup is a no-op and reuses the driver's `startup` chunk, so its trace includes app startup + `beforeAll`.
- **`playwrightDriver.ts`** -- the driver tracks whether a chunk is recording. It is initialized open when custom tracing is on (the launch code opened the `startup` chunk), so `startTracing()` is a no-op when a chunk is already open. This matters because a duplicate `startChunk` silently discards the open chunk -- the guard is what preserves the startup chunk for the first test.
- **`_test.setup.ts`** -- when the `app` fixture's `start()` fails (the per-test tracing fixture never runs in that case), the `catch` block exports the startup chunk and `afterAll` attaches it as a `trace`, alongside the existing `app-start-failure` screenshot and logs.

## Validation

- Isolated Playwright experiments confirmed: auto-fixture ordering; that `use()` resolves (not rejects) on downstream fixture throw/timeout; that a duplicate `startChunk` silently rolls over (discarding the open chunk); and the full new lifecycle -- test 1 reuses the `startup` chunk (its trace includes startup content) while test 2 gets a body-only chunk, with `stopChunk` as the only tracing call in teardown.
- `tsc -p test/e2e/tsconfig.json` is clean; files formatted.

## Notes

- No `startChunk` runs in teardown, so a test that intentionally leaves a blocking native dialog open (e.g. `pdf.test.ts` "Can print PDF file") no longer hangs the `tracing` fixture teardown.
- The chunk for the last test in a worker is closed in its own teardown; nothing is re-opened, so there is no trailing chunk to discard. `afterAll` activity is not attributed to a test trace (unchanged from prior behavior).

## QA

- [x] Re-run the workbench job (or force a `start()` failure locally) and confirm a `trace` attachment now appears for a test that fails during app startup.
- [x] Re-run `pdf.test.ts` and confirm "Can print PDF file" passes (no `tracing` teardown timeout).
- [x] Confirm successful runs still produce per-test traces (the first test in each worker now also includes startup + `beforeAll`).

@:workbench
@:pyrefly
@:pdf
