### PR TITLE
Fix notebook Assistant panel actions; route all assistant chat entry points through a shared helper

### DIFF
--- a/src/vs/workbench/contrib/positronAssistant/browser/positAssistantChat.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/positAssistantChat.ts
@@ -49,7 +49,7 @@ export async function openPositAssistantChat(
 		notificationService.error(
 			localize(
 				'positron.assistant.chatUnavailable',
-				"Posit Assistant is not available. Make sure the Posit Assistant extension is installed and enabled."
+				"Posit Assistant could not be opened. Make sure the Posit Assistant extension is installed and enabled, and that the assistant sidebar view is turned on."
 			)
 		);
 	}

--- a/src/vs/workbench/contrib/positronAssistant/browser/positAssistantChat.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/positAssistantChat.ts
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../../nls.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { INotificationService } from '../../../../platform/notification/common/notification.js';
+
+// Command exposed by the Posit Assistant extension to start/continue a chat.
+// The key string is mirrored in the Posit Assistant extension (the two
+// repositories cannot share a module).
+export const POSIT_NEW_CHAT_COMMAND = 'posit-assistant.newChat';
+
+/** A file attachment passed to the Posit Assistant newChat command. */
+export interface NewChatFile {
+	uri: string;
+	name: string;
+}
+
+/** Payload for the posit-assistant.newChat command. */
+export interface NewChatOptions {
+	prompt: string;
+	/** 'new' starts a fresh conversation; 'auto' continues the current one. */
+	target: 'auto' | 'new';
+	/** 'submit' sends the prompt immediately; 'prefill' only populates the input. */
+	behavior: 'submit' | 'prefill';
+	files?: NewChatFile[];
+}
+
+/**
+ * Send a query to Posit Assistant via the standalone assistant's
+ * posit-assistant.newChat command. newChat opens the assistant in whichever
+ * surface the user configured (sidebar or editor panel), so callers do not
+ * branch on the surface themselves. Failures are logged and surfaced as a
+ * notification rather than thrown.
+ */
+export async function openPositAssistantChat(
+	commandService: ICommandService,
+	notificationService: INotificationService,
+	logService: ILogService,
+	options: NewChatOptions,
+): Promise<void> {
+	try {
+		await commandService.executeCommand(POSIT_NEW_CHAT_COMMAND, options);
+	} catch (error) {
+		logService.error('Failed to open Posit Assistant chat', error);
+		notificationService.error(
+			localize(
+				'positron.assistant.chatUnavailable',
+				"Posit Assistant is not available. Make sure the Posit Assistant extension is installed and enabled."
+			)
+		);
+	}
+}

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/positAssistantChat.vitest.ts
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/positAssistantChat.vitest.ts
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { openPositAssistantChat } from '../../browser/positAssistantChat.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+
+/**
+ * All three assistant entry points (notebook panel, notebook cell quick-fix, console
+ * quick-fix) route through this helper to the standalone Posit Assistant via
+ * posit-assistant.newChat (issue #14541). Pin the command id and payload so a regression
+ * to the inert built-in chat, or a dropped payload field, fails loudly.
+ */
+describe('openPositAssistantChat', () => {
+	it('forwards the options to the Posit Assistant newChat command', async () => {
+		const executeCommand = vi.fn().mockResolvedValue(undefined);
+		const commandService = stubInterface<ICommandService>({ executeCommand });
+		const notificationService = stubInterface<INotificationService>({ error: vi.fn() });
+
+		await openPositAssistantChat(commandService, notificationService, new NullLogService(), {
+			prompt: 'Explain this notebook',
+			target: 'new',
+			behavior: 'submit',
+		});
+
+		expect(executeCommand).toHaveBeenCalledWith('posit-assistant.newChat', {
+			prompt: 'Explain this notebook',
+			target: 'new',
+			behavior: 'submit',
+		});
+	});
+
+	it('notifies the user when the assistant command fails', async () => {
+		const executeCommand = vi.fn().mockRejectedValue(new Error('Posit Assistant is disabled.'));
+		const error = vi.fn();
+		const commandService = stubInterface<ICommandService>({ executeCommand });
+		const notificationService = stubInterface<INotificationService>({ error });
+
+		await openPositAssistantChat(commandService, notificationService, new NullLogService(), {
+			prompt: 'Explain this notebook',
+			target: 'new',
+			behavior: 'submit',
+		});
+
+		// The helper's job on this path is to surface the localized unavailable message,
+		// not just to call error() with anything -- pin the message so a regression to an
+		// empty or raw-error string fails.
+		expect(error).toHaveBeenCalledWith(expect.stringMatching(/Posit Assistant is not available/));
+	});
+});

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/positAssistantChat.vitest.ts
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/positAssistantChat.vitest.ts
@@ -51,6 +51,6 @@ describe('openPositAssistantChat', () => {
 		// The helper's job on this path is to surface the localized unavailable message,
 		// not just to call error() with anything -- pin the message so a regression to an
 		// empty or raw-error string fails.
-		expect(error).toHaveBeenCalledWith(expect.stringMatching(/Posit Assistant is not available/));
+		expect(error).toHaveBeenCalledWith(expect.stringMatching(/Posit Assistant could not be opened/));
 	});
 });

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityErrorQuickFix.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityErrorQuickFix.tsx
@@ -72,7 +72,7 @@ const buildAttachment = (text: string): NewChatFile | undefined => {
 export const ConsoleQuickFix = (props: ConsoleQuickFixProps) => {
 	const buttonRef = useRef<HTMLDivElement>(undefined!);
 	const services = usePositronReactServicesContext();
-	const { commandService, notificationService } = services;
+	const { commandService, logService, notificationService } = services;
 	// --- Start Quick Chat fallback ---
 	const { quickChatService } = services;
 	const sidebarViewEnabled = usePositronConfiguration<boolean>(SIDEBAR_VIEW_SETTING);
@@ -92,11 +92,12 @@ export const ConsoleQuickFix = (props: ConsoleQuickFixProps) => {
 		};
 		try {
 			await commandService.executeCommand(NEW_CHAT_COMMAND, options);
-		} catch {
+		} catch (error) {
+			logService.error('Failed to open Posit Assistant chat', error);
 			notificationService.error(
 				localize(
 					'positronConsoleAssistantUnavailable',
-					"Posit Assistant is not available. Install the Posit Assistant extension to use Fix and Explain."
+					"Posit Assistant is not available. Make sure the Posit Assistant extension is installed and enabled."
 				)
 			);
 		}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityErrorQuickFix.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityErrorQuickFix.tsx
@@ -16,37 +16,16 @@ import { Button } from '../../../../../base/browser/ui/positronComponents/button
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { ANSIOutputLine } from '../../../../../base/common/ansiOutput.js';
 import { encodeBase64, VSBuffer } from '../../../../../base/common/buffer.js';
-// --- Start Quick Chat fallback ---
-import { usePositronConfiguration } from '../../../../../base/browser/positronReactHooks.js';
-// --- End Quick Chat fallback ---
+import { NewChatFile, NewChatOptions, openPositAssistantChat } from '../../../positronAssistant/browser/positAssistantChat.js';
 
 const fixPrompt = localize('positronConsoleAssistantFixPrompt', "Fix this console error.");
 const explainPrompt = localize('positronConsoleAssistantExplainPrompt', "Explain this console error.");
 
-const NEW_CHAT_COMMAND = 'posit-assistant.newChat';
 const ATTACHMENT_NAME = 'console-error.txt';
-
-// --- Start Quick Chat fallback ---
-const quickChatFixPrompt = '/fix';
-const quickChatExplainPrompt = '/explain';
-const SIDEBAR_VIEW_SETTING = 'assistant.sidebarView';
-// --- End Quick Chat fallback ---
 
 interface ConsoleQuickFixProps {
 	outputLines: ANSIOutputLine[];
 	tracebackLines: ANSIOutputLine[];
-}
-
-interface NewChatFile {
-	uri: string;
-	name: string;
-}
-
-interface NewChatOptions {
-	prompt: string;
-	files?: NewChatFile[];
-	target: 'auto' | 'new';
-	behavior: 'submit' | 'prefill';
 }
 
 const formatOutput = (outputLines: ANSIOutputLine[], tracebackLines: ANSIOutputLine[]) => {
@@ -73,62 +52,25 @@ export const ConsoleQuickFix = (props: ConsoleQuickFixProps) => {
 	const buttonRef = useRef<HTMLDivElement>(undefined!);
 	const services = usePositronReactServicesContext();
 	const { commandService, logService, notificationService } = services;
-	// --- Start Quick Chat fallback ---
-	const { quickChatService } = services;
-	const sidebarViewEnabled = usePositronConfiguration<boolean>(SIDEBAR_VIEW_SETTING);
-	// --- End Quick Chat fallback ---
 
 	const attachment = useMemo(
 		() => buildAttachment(formatOutput(props.outputLines, props.tracebackLines)),
 		[props.outputLines, props.tracebackLines]
 	);
 
-	const runNewChat = async (prompt: string) => {
+	const runNewChat = (prompt: string) => {
 		const options: NewChatOptions = {
 			prompt,
 			target: 'auto',
 			behavior: 'submit',
 			...(attachment && { files: [attachment] }),
 		};
-		try {
-			await commandService.executeCommand(NEW_CHAT_COMMAND, options);
-		} catch (error) {
-			logService.error('Failed to open Posit Assistant chat', error);
-			notificationService.error(
-				localize(
-					'positronConsoleAssistantUnavailable',
-					"Posit Assistant is not available. Make sure the Posit Assistant extension is installed and enabled."
-				)
-			);
-		}
+		return openPositAssistantChat(commandService, notificationService, logService, options);
 	};
 
-	// --- Start Quick Chat fallback ---
-	const runQuickChat = (slashPrompt: string) => {
-		const formatted = formatOutput(props.outputLines, props.tracebackLines);
-		quickChatService.open({
-			query: formatted ? `${slashPrompt}\n\`\`\`${formatted}\`\`\`` : slashPrompt,
-		});
-	};
-	// --- End Quick Chat fallback ---
+	const pressedFixHandler = () => runNewChat(fixPrompt);
 
-	const pressedFixHandler = () => {
-		// --- Start Quick Chat fallback ---
-		if (!sidebarViewEnabled) {
-			return runQuickChat(quickChatFixPrompt);
-		}
-		// --- End Quick Chat fallback ---
-		return runNewChat(fixPrompt);
-	};
-
-	const pressedExplainHandler = () => {
-		// --- Start Quick Chat fallback ---
-		if (!sidebarViewEnabled) {
-			return runQuickChat(quickChatExplainPrompt);
-		}
-		// --- End Quick Chat fallback ---
-		return runNewChat(explainPrompt);
-	};
+	const pressedExplainHandler = () => runNewChat(explainPrompt);
 
 	// Render.
 	return (

--- a/src/vs/workbench/contrib/positronConsole/test/browser/activityErrorQuickFix.vitest.tsx
+++ b/src/vs/workbench/contrib/positronConsole/test/browser/activityErrorQuickFix.vitest.tsx
@@ -91,6 +91,6 @@ describe('ConsoleQuickFix', () => {
 		await user.click(screen.getByText('Fix'));
 
 		await waitFor(() => expect(notifyError).toHaveBeenCalledTimes(1));
-		expect(notifyError.mock.calls[0][0]).toMatch(/Posit Assistant is not available/);
+		expect(notifyError.mock.calls[0][0]).toMatch(/Posit Assistant could not be opened/);
 	});
 });

--- a/src/vs/workbench/contrib/positronConsole/test/browser/activityErrorQuickFix.vitest.tsx
+++ b/src/vs/workbench/contrib/positronConsole/test/browser/activityErrorQuickFix.vitest.tsx
@@ -15,11 +15,6 @@ import { decodeBase64, VSBuffer } from '../../../../../base/common/buffer.js';
 import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { ConsoleQuickFix } from '../../browser/components/activityErrorQuickFix.js';
-// --- Start Quick Chat fallback ---
-import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
-import { IQuickChatService } from '../../../../../workbench/contrib/chat/browser/chat.js';
-import { Event } from '../../../../../base/common/event.js';
-// --- End Quick Chat fallback ---
 
 const line = (id: string, text: string): ANSIOutputLine => ({
 	id,
@@ -40,30 +35,13 @@ const decodeDataUri = (uri: string): string => {
 describe('ConsoleQuickFix', () => {
 	const executeCommand = vi.fn().mockResolvedValue(undefined);
 	const notifyError = vi.fn();
-	// --- Start Quick Chat fallback ---
-	const openQuickChat = vi.fn();
-	let sidebarViewEnabled = true;
-	// --- End Quick Chat fallback ---
 
 	const ctx = createTestContainer()
 		.withReactServices()
 		.stub(ICommandService, { executeCommand })
 		.stub(INotificationService, { error: notifyError })
-		// --- Start Quick Chat fallback ---
-		.stub(IQuickChatService, { open: openQuickChat })
-		.stub(IConfigurationService, {
-			getValue: (key: string) => key === 'assistant.sidebarView' ? sidebarViewEnabled : undefined,
-			onDidChangeConfiguration: Event.None,
-		})
-		// --- End Quick Chat fallback ---
 		.build();
 	const rtl = setupRTLRenderer(() => ctx.reactServices);
-
-	// --- Start Quick Chat fallback ---
-	beforeEach(() => {
-		sidebarViewEnabled = true;
-	});
-	// --- End Quick Chat fallback ---
 
 	it('dispatches posit-assistant.newChat with a fix prompt and the error as a data URI attachment when Fix is clicked', async () => {
 		const user = userEvent.setup();
@@ -115,44 +93,4 @@ describe('ConsoleQuickFix', () => {
 		await waitFor(() => expect(notifyError).toHaveBeenCalledTimes(1));
 		expect(notifyError.mock.calls[0][0]).toMatch(/Posit Assistant is not available/);
 	});
-
-	// --- Start Quick Chat fallback ---
-	describe('with assistant.sidebarView disabled', () => {
-		beforeEach(() => {
-			sidebarViewEnabled = false;
-		});
-
-		it('opens the quick chat with the /fix slash command and fenced error block when Fix is clicked', async () => {
-			const user = userEvent.setup();
-			rtl.render(<ConsoleQuickFix outputLines={outputLines} tracebackLines={tracebackLines} />);
-			await user.click(screen.getByText('Fix'));
-
-			expect(openQuickChat).toHaveBeenCalledTimes(1);
-			const [options] = openQuickChat.mock.calls[0];
-			expect(options.query).toBe(`/fix\n\`\`\`${expectedAttachmentText}\`\`\``);
-			expect(executeCommand).not.toHaveBeenCalled();
-		});
-
-		it('opens the quick chat with the /explain slash command when Explain is clicked', async () => {
-			const user = userEvent.setup();
-			rtl.render(<ConsoleQuickFix outputLines={outputLines} tracebackLines={tracebackLines} />);
-			await user.click(screen.getByText('Explain'));
-
-			expect(openQuickChat).toHaveBeenCalledTimes(1);
-			const [options] = openQuickChat.mock.calls[0];
-			expect(options.query).toBe(`/explain\n\`\`\`${expectedAttachmentText}\`\`\``);
-			expect(executeCommand).not.toHaveBeenCalled();
-		});
-
-		it('opens the quick chat with just the slash command when there is no error output', async () => {
-			const user = userEvent.setup();
-			rtl.render(<ConsoleQuickFix outputLines={[]} tracebackLines={[]} />);
-			await user.click(screen.getByText('Fix'));
-
-			expect(openQuickChat).toHaveBeenCalledTimes(1);
-			const [options] = openQuickChat.mock.calls[0];
-			expect(options.query).toBe('/fix');
-		});
-	});
-	// --- End Quick Chat fallback ---
 });

--- a/src/vs/workbench/contrib/positronNotebook/browser/AskAssistantAction.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/AskAssistantAction.tsx
@@ -32,6 +32,37 @@ const ASK_ASSISTANT_ACTION_ID = 'positronNotebook.askAssistant';
 const POSIT_NEW_CHAT_COMMAND = 'posit-assistant.newChat';
 
 /**
+ * Send a query to Posit Assistant. Routes through the standalone assistant's
+ * posit-assistant.newChat command rather than the built-in chat, which has no
+ * Posit Assistant agent behind it and so does nothing. newChat opens the
+ * assistant in whichever surface the user configured (sidebar or editor panel).
+ *
+ * Exported so the command routing can be unit tested without the modal.
+ */
+export async function openAssistantChat(
+	commandService: ICommandService,
+	notificationService: INotificationService,
+	logService: ILogService,
+	query: string,
+): Promise<void> {
+	try {
+		await commandService.executeCommand(POSIT_NEW_CHAT_COMMAND, {
+			prompt: query,
+			target: 'new',
+			behavior: 'submit',
+		});
+	} catch (error) {
+		logService.error('Failed to open Posit Assistant chat', error);
+		notificationService.error(
+			localize(
+				'positronNotebook.assistant.unavailable',
+				"Posit Assistant is not available. Make sure the Posit Assistant extension is installed and enabled."
+			)
+		);
+	}
+}
+
+/**
  * Action that opens the assistant panel with predefined prompt options for the notebook.
  * Users can select a predefined prompt, type their own custom prompt, or generate AI suggestions.
  * The panel shows as a centered modal dialog.
@@ -96,28 +127,9 @@ export class AskAssistantAction extends Action2 {
 			}
 		});
 
-		// Handle action selection - send the query to Posit Assistant. Route through
-		// posit-assistant.newChat (the standalone assistant) rather than the built-in
-		// chat, which has no Posit Assistant agent behind it and so does nothing.
-		// newChat opens the assistant in whichever surface the user configured
-		// (sidebar or editor panel).
-		const handleActionSelected = async (query: string) => {
-			try {
-				await commandService.executeCommand(POSIT_NEW_CHAT_COMMAND, {
-					prompt: query,
-					target: 'new',
-					behavior: 'submit',
-				});
-			} catch (error) {
-				logService.error('Failed to open Posit Assistant chat', error);
-				notificationService.error(
-					localize(
-						'positronNotebook.assistant.unavailable',
-						"Posit Assistant is not available. Install the Posit Assistant extension to ask about this notebook."
-					)
-				);
-			}
-		};
+		// Handle action selection - send the query to Posit Assistant (see openAssistantChat).
+		const handleActionSelected = (query: string) =>
+			openAssistantChat(commandService, notificationService, logService, query);
 
 		// Render the assistant panel immediately (optimistic loading)
 		// Pass the notebook directly if available, otherwise pass the promise

--- a/src/vs/workbench/contrib/positronNotebook/browser/AskAssistantAction.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/AskAssistantAction.tsx
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize, localize2 } from '../../../../nls.js';
+import { localize2 } from '../../../../nls.js';
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
@@ -17,6 +17,7 @@ import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IHeadlessLanguageModelService } from '../../../services/positronHeadlessLanguageModel/common/headlessLanguageModelService.js';
 import { POSITRON_NOTEBOOK_EDITOR_ID } from '../common/positronNotebookCommon.js';
 import { AI_ENABLED_KEY } from '../../positronAssistant/common/positronAIConfiguration.js';
+import { openPositAssistantChat } from '../../positronAssistant/browser/positAssistantChat.js';
 import { PositronModalDialogReactRenderer } from '../../../../base/browser/positronModalDialogReactRenderer.js';
 import { AssistantPanel } from './AssistantPanel/AssistantPanel.js';
 import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
@@ -27,40 +28,6 @@ import { CancelablePromise } from '../../../../base/common/async.js';
 import { IPositronNotebookInstance } from './IPositronNotebookInstance.js';
 
 const ASK_ASSISTANT_ACTION_ID = 'positronNotebook.askAssistant';
-
-// Command exposed by the Posit Assistant extension to start/continue a chat.
-const POSIT_NEW_CHAT_COMMAND = 'posit-assistant.newChat';
-
-/**
- * Send a query to Posit Assistant. Routes through the standalone assistant's
- * posit-assistant.newChat command rather than the built-in chat, which has no
- * Posit Assistant agent behind it and so does nothing. newChat opens the
- * assistant in whichever surface the user configured (sidebar or editor panel).
- *
- * Exported so the command routing can be unit tested without the modal.
- */
-export async function openAssistantChat(
-	commandService: ICommandService,
-	notificationService: INotificationService,
-	logService: ILogService,
-	query: string,
-): Promise<void> {
-	try {
-		await commandService.executeCommand(POSIT_NEW_CHAT_COMMAND, {
-			prompt: query,
-			target: 'new',
-			behavior: 'submit',
-		});
-	} catch (error) {
-		logService.error('Failed to open Posit Assistant chat', error);
-		notificationService.error(
-			localize(
-				'positronNotebook.assistant.unavailable',
-				"Posit Assistant is not available. Make sure the Posit Assistant extension is installed and enabled."
-			)
-		);
-	}
-}
 
 /**
  * Action that opens the assistant panel with predefined prompt options for the notebook.
@@ -127,9 +94,14 @@ export class AskAssistantAction extends Action2 {
 			}
 		});
 
-		// Handle action selection - send the query to Posit Assistant (see openAssistantChat).
+		// Handle action selection - send the query to Posit Assistant. Always starts a
+		// fresh conversation, since the panel is a deliberate "ask about this notebook" entry.
 		const handleActionSelected = (query: string) =>
-			openAssistantChat(commandService, notificationService, logService, query);
+			openPositAssistantChat(commandService, notificationService, logService, {
+				prompt: query,
+				target: 'new',
+				behavior: 'submit',
+			});
 
 		// Render the assistant panel immediately (optimistic loading)
 		// Pass the notebook directly if available, otherwise pass the promise

--- a/src/vs/workbench/contrib/positronNotebook/browser/AskAssistantAction.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/AskAssistantAction.tsx
@@ -12,8 +12,6 @@ import { INotificationService } from '../../../../platform/notification/common/n
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
-import { CHAT_OPEN_ACTION_ID } from '../../chat/browser/actions/chatActions.js';
-import { ChatModeKind } from '../../chat/common/constants.js';
 import { IChatEditingService } from '../../chat/common/editing/chatEditingService.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IHeadlessLanguageModelService } from '../../../services/positronHeadlessLanguageModel/common/headlessLanguageModelService.js';
@@ -29,6 +27,9 @@ import { CancelablePromise } from '../../../../base/common/async.js';
 import { IPositronNotebookInstance } from './IPositronNotebookInstance.js';
 
 const ASK_ASSISTANT_ACTION_ID = 'positronNotebook.askAssistant';
+
+// Command exposed by the Posit Assistant extension to start/continue a chat.
+const POSIT_NEW_CHAT_COMMAND = 'posit-assistant.newChat';
 
 /**
  * Action that opens the assistant panel with predefined prompt options for the notebook.
@@ -95,19 +96,24 @@ export class AskAssistantAction extends Action2 {
 			}
 		});
 
-		// Handle action selection - open the chat with the selected query
-		const handleActionSelected = async (query: string, mode: ChatModeKind) => {
+		// Handle action selection - send the query to Posit Assistant. Route through
+		// posit-assistant.newChat (the standalone assistant) rather than the built-in
+		// chat, which has no Posit Assistant agent behind it and so does nothing.
+		// newChat opens the assistant in whichever surface the user configured
+		// (sidebar or editor panel).
+		const handleActionSelected = async (query: string) => {
 			try {
-				await commandService.executeCommand(CHAT_OPEN_ACTION_ID, {
-					query,
-					mode
+				await commandService.executeCommand(POSIT_NEW_CHAT_COMMAND, {
+					prompt: query,
+					target: 'new',
+					behavior: 'submit',
 				});
 			} catch (error) {
+				logService.error('Failed to open Posit Assistant chat', error);
 				notificationService.error(
 					localize(
-						'positronNotebook.assistant.error',
-						'Failed to open assistant chat: {0}',
-						error instanceof Error ? error.message : String(error)
+						'positronNotebook.assistant.unavailable',
+						"Posit Assistant is not available. Install the Posit Assistant extension to ask about this notebook."
 					)
 				);
 			}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx
@@ -45,7 +45,7 @@ interface NotebookCellQuickFixProps {
  */
 export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 	const services = usePositronReactServicesContext();
-	const { commandService, contextMenuService, notificationService } = services;
+	const { commandService, contextMenuService, logService, notificationService } = services;
 
 	// Configuration hooks to conditionally show the quick-fix buttons
 	const aiEnabled = usePositronConfiguration<boolean>(AI_ENABLED_KEY);
@@ -79,15 +79,16 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 				behavior: 'submit',
 				...(attachment && { files: [attachment] }),
 			});
-		} catch {
+		} catch (error) {
+			logService.error('Failed to open Posit Assistant chat', error);
 			notificationService.error(
 				localize(
 					'positronNotebookAssistantUnavailable',
-					"Posit Assistant is not available. Install the Posit Assistant extension to use Fix and Explain."
+					"Posit Assistant is not available. Make sure the Posit Assistant extension is installed and enabled."
 				)
 			);
 		}
-	}, [commandService, notificationService, attachment]);
+	}, [commandService, logService, notificationService, attachment]);
 
 	const runQuickChat = useCallback((prompt: string, isNew: boolean) => {
 		const query = cleanError

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx
@@ -50,7 +50,9 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 	// Configuration hooks to conditionally show the quick-fix buttons
 	const aiEnabled = usePositronConfiguration<boolean>(AI_ENABLED_KEY);
 	const enableNotebookMode = usePositronConfiguration<boolean>(POSITRON_NOTEBOOK_ENABLED_KEY);
-	const hasChatModels = useContextKeyFromString<boolean>('positron-assistant.hasChatModels');
+	// Set by the Posit Assistant extension when it has at least one usable model.
+	// The old positron-assistant.hasChatModels key is going away this milestone.
+	const hasChatModels = useContextKeyFromString<boolean>('posit-assistant.hasChatModels');
 	const sidebarViewEnabled = usePositronConfiguration<boolean>(SIDEBAR_VIEW_SETTING);
 
 	// Only show buttons if AI is enabled, notebook mode is enabled, and chat models are available

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx
@@ -16,18 +16,15 @@ import { usePositronConfiguration, useContextKeyFromString } from '../../../../.
 import { IAction } from '../../../../../base/common/actions.js';
 import { removeAnsiEscapeCodes } from '../../../../../base/common/strings.js';
 import { encodeBase64, VSBuffer } from '../../../../../base/common/buffer.js';
-import { CHAT_OPEN_ACTION_ID, ACTION_ID_NEW_CHAT } from '../../../chat/browser/actions/chatActions.js';
-import { ChatModeKind } from '../../../chat/common/constants.js';
 import { POSITRON_NOTEBOOK_ENABLED_KEY } from '../../common/positronNotebookConfig.js';
 import { AI_ENABLED_KEY } from '../../../positronAssistant/common/positronAIConfiguration.js';
+import { openPositAssistantChat } from '../../../positronAssistant/browser/positAssistantChat.js';
 import { SplitButton } from '../utilityComponents/SplitButton.js';
 
 const fixPrompt = localize('positronNotebookAssistantFixPrompt', "Fix this notebook cell error.");
 const explainPrompt = localize('positronNotebookAssistantExplainPrompt', "Explain this notebook cell error.");
 
-const NEW_CHAT_COMMAND = 'posit-assistant.newChat';
 const ATTACHMENT_NAME = 'notebook-cell-error.txt';
-const SIDEBAR_VIEW_SETTING = 'assistant.sidebarView';
 
 /**
  * Props for the NotebookCellQuickFix component.
@@ -39,8 +36,8 @@ interface NotebookCellQuickFixProps {
 
 /**
  * Quick fix component for notebook cell errors.
- * Displays "Fix" and "Explain" split buttons that send the error content to the assistant.
- * Uses posit-assistant.newChat when available, falling back to the built-in quick chat.
+ * Displays "Fix" and "Explain" split buttons that send the error content to the assistant
+ * via posit-assistant.newChat.
  * Primary click starts a fresh conversation; dropdown continues in the current conversation.
  */
 export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
@@ -53,7 +50,6 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 	// Set by the Posit Assistant extension when it has at least one usable model.
 	// The old positron-assistant.hasChatModels key is going away this milestone.
 	const hasChatModels = useContextKeyFromString<boolean>('posit-assistant.hasChatModels');
-	const sidebarViewEnabled = usePositronConfiguration<boolean>(SIDEBAR_VIEW_SETTING);
 
 	// Only show buttons if AI is enabled, notebook mode is enabled, and chat models are available
 	const showQuickFix = aiEnabled && enableNotebookMode && hasChatModels;
@@ -71,51 +67,18 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 		return { uri: `data:text/plain;base64,${base64}`, name: ATTACHMENT_NAME };
 	}, [cleanError]);
 
-	const runNewChat = useCallback(async (prompt: string, target: 'new' | 'auto') => {
-		try {
-			await commandService.executeCommand(NEW_CHAT_COMMAND, {
-				prompt,
-				target,
-				behavior: 'submit',
-				...(attachment && { files: [attachment] }),
-			});
-		} catch (error) {
-			logService.error('Failed to open Posit Assistant chat', error);
-			notificationService.error(
-				localize(
-					'positronNotebookAssistantUnavailable',
-					"Posit Assistant is not available. Make sure the Posit Assistant extension is installed and enabled."
-				)
-			);
-		}
-	}, [commandService, logService, notificationService, attachment]);
+	const runNewChat = useCallback((prompt: string, target: 'new' | 'auto') =>
+		openPositAssistantChat(commandService, notificationService, logService, {
+			prompt,
+			target,
+			behavior: 'submit',
+			...(attachment && { files: [attachment] }),
+		}),
+		[commandService, logService, notificationService, attachment]);
 
-	const runQuickChat = useCallback((prompt: string, isNew: boolean) => {
-		const query = cleanError
-			? `${prompt}\n\`\`\`\n${cleanError}\n\`\`\``
-			: prompt;
-		if (isNew) {
-			commandService.executeCommand(ACTION_ID_NEW_CHAT);
-		}
-		commandService.executeCommand(CHAT_OPEN_ACTION_ID, {
-			query,
-			mode: ChatModeKind.Agent
-		});
-	}, [commandService, cleanError]);
+	const pressedFixHandler = () => runNewChat(fixPrompt, 'new');
 
-	const pressedFixHandler = () => {
-		if (sidebarViewEnabled) {
-			return runNewChat(fixPrompt, 'new');
-		}
-		return runQuickChat(fixPrompt, true);
-	};
-
-	const pressedExplainHandler = () => {
-		if (sidebarViewEnabled) {
-			return runNewChat(explainPrompt, 'new');
-		}
-		return runQuickChat(explainPrompt, true);
-	};
+	const pressedExplainHandler = () => runNewChat(explainPrompt, 'new');
 
 	// Memoize dropdown actions for Fix button
 	const fixDropdownActions = useMemo((): IAction[] => [
@@ -125,14 +88,9 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 			tooltip: localize('positronNotebookAssistantFixInCurrentChatTooltip', "Opens in the current chat session to retain conversation context"),
 			class: undefined,
 			enabled: true,
-			run: () => {
-				if (sidebarViewEnabled) {
-					return runNewChat(fixPrompt, 'auto');
-				}
-				return runQuickChat(fixPrompt, false);
-			}
+			run: () => runNewChat(fixPrompt, 'auto')
 		}
-	], [sidebarViewEnabled, runNewChat, runQuickChat]);
+	], [runNewChat]);
 
 	// Memoize dropdown actions for Explain button
 	const explainDropdownActions = useMemo((): IAction[] => [
@@ -142,14 +100,9 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 			tooltip: localize('positronNotebookAssistantExplainInCurrentChatTooltip', "Opens in the current chat session to retain conversation context"),
 			class: undefined,
 			enabled: true,
-			run: () => {
-				if (sidebarViewEnabled) {
-					return runNewChat(explainPrompt, 'auto');
-				}
-				return runQuickChat(explainPrompt, false);
-			}
+			run: () => runNewChat(explainPrompt, 'auto')
 		}
-	], [sidebarViewEnabled, runNewChat, runQuickChat]);
+	], [runNewChat]);
 
 	// Don't render if assistant features are not enabled
 	if (!showQuickFix) {

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/askAssistantAction.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/askAssistantAction.vitest.ts
@@ -5,7 +5,11 @@
 
 /// <reference types="vitest/globals" />
 
-import { AskAssistantAction } from '../../browser/AskAssistantAction.js';
+import { AskAssistantAction, openAssistantChat } from '../../browser/AskAssistantAction.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 
 /**
  * The Ask Assistant action is gated on the AI main switch (`config.ai.enabled`).
@@ -24,5 +28,37 @@ describe('AskAssistantAction', () => {
 	it('gates the editor toolbar button via the menu when clause', () => {
 		const menu = Array.isArray(desc.menu) ? desc.menu[0] : desc.menu;
 		expect(menu?.when?.serialize()).toContain('config.ai.enabled');
+	});
+});
+
+/**
+ * The panel actions route to the standalone Posit Assistant via posit-assistant.newChat
+ * (issue #14541). Pin the command id and payload so a regression to the inert built-in
+ * chat, or a dropped payload field, fails loudly.
+ */
+describe('openAssistantChat', () => {
+	it('routes the query to the Posit Assistant newChat command', async () => {
+		const executeCommand = vi.fn().mockResolvedValue(undefined);
+		const commandService = stubInterface<ICommandService>({ executeCommand });
+		const notificationService = stubInterface<INotificationService>({ error: vi.fn() });
+
+		await openAssistantChat(commandService, notificationService, new NullLogService(), 'Explain this notebook');
+
+		expect(executeCommand).toHaveBeenCalledWith('posit-assistant.newChat', {
+			prompt: 'Explain this notebook',
+			target: 'new',
+			behavior: 'submit',
+		});
+	});
+
+	it('notifies the user when the assistant command fails', async () => {
+		const executeCommand = vi.fn().mockRejectedValue(new Error('Posit Assistant is disabled.'));
+		const error = vi.fn();
+		const commandService = stubInterface<ICommandService>({ executeCommand });
+		const notificationService = stubInterface<INotificationService>({ error });
+
+		await openAssistantChat(commandService, notificationService, new NullLogService(), 'Explain this notebook');
+
+		expect(error).toHaveBeenCalledOnce();
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/askAssistantAction.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/askAssistantAction.vitest.ts
@@ -5,11 +5,7 @@
 
 /// <reference types="vitest/globals" />
 
-import { AskAssistantAction, openAssistantChat } from '../../browser/AskAssistantAction.js';
-import { ICommandService } from '../../../../../platform/commands/common/commands.js';
-import { INotificationService } from '../../../../../platform/notification/common/notification.js';
-import { NullLogService } from '../../../../../platform/log/common/log.js';
-import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { AskAssistantAction } from '../../browser/AskAssistantAction.js';
 
 /**
  * The Ask Assistant action is gated on the AI main switch (`config.ai.enabled`).
@@ -28,37 +24,5 @@ describe('AskAssistantAction', () => {
 	it('gates the editor toolbar button via the menu when clause', () => {
 		const menu = Array.isArray(desc.menu) ? desc.menu[0] : desc.menu;
 		expect(menu?.when?.serialize()).toContain('config.ai.enabled');
-	});
-});
-
-/**
- * The panel actions route to the standalone Posit Assistant via posit-assistant.newChat
- * (issue #14541). Pin the command id and payload so a regression to the inert built-in
- * chat, or a dropped payload field, fails loudly.
- */
-describe('openAssistantChat', () => {
-	it('routes the query to the Posit Assistant newChat command', async () => {
-		const executeCommand = vi.fn().mockResolvedValue(undefined);
-		const commandService = stubInterface<ICommandService>({ executeCommand });
-		const notificationService = stubInterface<INotificationService>({ error: vi.fn() });
-
-		await openAssistantChat(commandService, notificationService, new NullLogService(), 'Explain this notebook');
-
-		expect(executeCommand).toHaveBeenCalledWith('posit-assistant.newChat', {
-			prompt: 'Explain this notebook',
-			target: 'new',
-			behavior: 'submit',
-		});
-	});
-
-	it('notifies the user when the assistant command fails', async () => {
-		const executeCommand = vi.fn().mockRejectedValue(new Error('Posit Assistant is disabled.'));
-		const error = vi.fn();
-		const commandService = stubInterface<ICommandService>({ executeCommand });
-		const notificationService = stubInterface<INotificationService>({ error });
-
-		await openAssistantChat(commandService, notificationService, new NullLogService(), 'Explain this notebook');
-
-		expect(error).toHaveBeenCalledOnce();
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTextOutput.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTextOutput.vitest.tsx
@@ -90,7 +90,7 @@ describe('CellTextOutput', () => {
 		const contextKeyService = ctx.get(IContextKeyService) as MockContextKeyService;
 		configurationService.setUserConfiguration('ai.enabled', true);
 		configurationService.setUserConfiguration('positron.notebook.enabled', true);
-		contextKeyService.createKey('positron-assistant.hasChatModels', true);
+		contextKeyService.createKey('posit-assistant.hasChatModels', true);
 
 		renderCellTextOutput({ content: 'NameError: name "x" is not defined', type: 'error' });
 


### PR DESCRIPTION
Fixes #14541. Follow-up to #14515.

The notebook "Ask Assistant" panel actions, custom prompt, and generated suggestions all did nothing: they routed through the built-in `CHAT_OPEN_ACTION_ID`, which is inert now that chat lives in the standalone Posit Assistant extension. They share one handler, so pointing it at `posit-assistant.newChat` fixes all of them.

While here, it folds the three assistant entry points (notebook panel, notebook cell quick-fix, console Fix/Explain) onto one shared `openPositAssistantChat` helper, drops a dead `assistant.sidebarView` fallback, and moves the cell quick-fix off the retiring `positron-assistant.hasChatModels` key.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix notebook Assistant panel actions and AI suggestions silently doing nothing instead of opening Posit Assistant chat (#14541)

### Validation Steps

@:assistant @:notebooks @:console

Covered by vitest; no e2e changes. Manual: with Posit Assistant enabled, open a notebook's Ask Assistant panel and confirm actions, the custom prompt, and suggestions all open chat with the query submitted; spot-check the cell and console Fix/Explain buttons too.
