### PR TITLE
assistant: remove preview tag from foundry

### DIFF
--- a/extensions/authentication/package.json
+++ b/extensions/authentication/package.json
@@ -152,10 +152,7 @@
 				"authentication.foundry.baseUrl": {
 					"type": "string",
 					"default": "",
-					"description": "%configuration.foundry.baseUrl.description%",
-					"tags": [
-						"preview"
-					]
+					"description": "%configuration.foundry.baseUrl.description%"
 				},
 				"authentication.foundry.customHeaders": {
 					"type": "object",
@@ -328,9 +325,6 @@
 					"type": "boolean",
 					"default": true,
 					"markdownDescription": "%configuration.provider.msFoundry.enable.description%",
-					"tags": [
-						"preview"
-					],
 					"order": 5
 				},
 				"positron.assistant.provider.openAI.enable": {
@@ -487,9 +481,6 @@
 					"type": "array",
 					"default": [],
 					"markdownDescription": "%configuration.models.overrides.msFoundry.description%",
-					"tags": [
-						"preview"
-					],
 					"items": {
 						"type": "object",
 						"properties": {

--- a/extensions/authentication/src/providerSources.ts
+++ b/extensions/authentication/src/providerSources.ts
@@ -57,8 +57,7 @@ export const PROVIDER_METADATA: Record<string, ProviderMetadata> = {
 	foundry: {
 		id: FOUNDRY_AUTH_PROVIDER_ID,
 		displayName: 'Microsoft Foundry',
-		settingName: 'msFoundry',
-		status: 'preview',
+		settingName: 'msFoundry'
 	},
 	snowflake: {
 		id: 'snowflake-cortex',


### PR DESCRIPTION
- addresses https://github.com/posit-dev/positron/issues/13810
- removes preview tag from foundry provider and relevant settings, now that https://github.com/posit-dev/positron/issues/14497 is in

<img width="606" height="506" alt="image" src="https://github.com/user-attachments/assets/e4966c9e-046c-4966-85f4-8c85b1d7ca09" />

<img width="1004" height="570" alt="image" src="https://github.com/user-attachments/assets/0d33feef-efe3-404e-8885-bc75ab420ac2" />

### Release Notes

#### New Features

- Foundry is generally available as an AI provider (#13810)

### Validation Steps

Provider modal and settings for foundry are no longer tagged as Preview. The exception is the customHeaders setting which is preview for all providers.