### PR TITLE
Fix terminal paste showing browser "Paste" popup in Firefox and Safari

### DIFF
--- a/.claude/skills/positron-pull-vscode-server/SKILL.md
+++ b/.claude/skills/positron-pull-vscode-server/SKILL.md
@@ -39,9 +39,31 @@ git rev-parse upstream/main
 
 If starting fresh with no recorded SHA, look at the `Brings in:` lines of the last upstream merge commit, find the earliest of those commits on `upstream/main`, and use its parent SHA as the baseline.
 
-The script assumes Positron and vscode-server are on the same Microsoft VSCode baseline. If Microsoft commits appear in the range it exits with an error — sync the Microsoft baseline first.
+This skill ports across a **shared** Microsoft VSCode baseline. Two independent signals indicate the baseline relationship:
+
+- **Version/distro parity (the reliable signal):** compare `version` and `distro` in `package.json` on `main` vs `upstream/main`. If both match, the repos share a baseline — proceed. A `Merge 1.NNN.0` / `Merge rel-*` commit in the range is then a *reconciliation* merge that brought vscode-server up to the baseline Positron already has; skip the merge itself but still port the feature/bugfix PRs interleaved around it. If `version` or `distro` differ, the repos have diverged — stop and sync the Microsoft baseline before porting anything.
+- **Microsoft-author commits (coarse backstop):** the enumerate script also errors out if Microsoft-authored commits appear in the range. This catches obvious divergence but is not authoritative — a baseline can differ without a Microsoft-authored commit landing in the exact range, which is why the version/distro check above is the one to trust.
 
 The script outputs all new commits on `upstream/main` since the baseline, with file stats per candidate.
+
+### Step 1b: Check the backlog when the user names a single PR/issue
+
+If the user asks to pull one specific PR or issue (rather than "pull everything new"), run the backlog check before porting it. The single requested PR is rarely the only thing waiting upstream, and silently porting just that one leaves the rest of the backlog undiscovered.
+
+```bash
+.claude/skills/positron-pull-vscode-server/scripts/check-backlog.sh
+```
+
+The script auto-derives the baseline from the most recent "upstream merge from vscode-server" commit (searching all refs, since that merge often lives on a dedicated `pull-vscode-server` branch, not `main`). Pass an explicit `<baseline-sha>` to override.
+
+It lists every merge on `upstream/main` since the last pull and prints triage guidance. Then:
+
+1. **Confirm the baseline is shared** using the version/distro parity check from Step 1. Matching means `Merge 1.NNN.0` / `Merge rel-*` commits are reconciliation merges (skip the merge, port the PRs around it); a mismatch means stop and sync the baseline first.
+2. **Triage the remaining merges.** `update-extension-*`, `version-bump`, and `.github/`/`Jenkinsfile`-only PRs are vscode-server tooling — skip. What's left is portable source changes.
+3. **Check direction before assuming a PR is missing.** Some vscode-server PRs originated in posit-dev/positron and were *back*ported upstream, so they already exist in Positron. Before listing a PR as portable, confirm Positron doesn't already have the change (grep for the touched symbol/file, or check the upstream PR description for a "ported from positron" note).
+4. **Surface the full portable list to the user** and ask whether to port just the requested PR or sweep the others in too. Don't decide for them.
+
+Keep a short record of every PR you triaged but did **not** port and the one-line reason (tooling-only, back-ported and already in Positron, baseline reconciliation merge, user scoped it out, etc.). This record feeds the PR body in Step 5 — readers should see what was considered and why it was left out, not just what was included.
 
 ### Step 2: Triage
 
@@ -62,14 +84,21 @@ git show <upstream-SHA>   # read the diff
 - **PWB markers** (`// --- Start PWB: ... ---` / `// --- End PWB ---`): copy exactly as they appear in the upstream diff. Do not rename them to Positron markers.
 - **Positron markers** (`// --- Start Positron ---` / `// --- End Positron ---`): use only when Positron needs to add or change something *on top of* the PWB change. Do not use them to wrap changes that came from vscode-server.
 
+`format.mts` (run in Step 4) may re-indent a marker comment to match its surrounding scope — e.g. an `// --- End PWB ---` placed just before an array element gets indented one level deeper than it sits in the upstream diff. That is correct: let the formatter win on indentation. "Copy exactly" governs the marker text and placement, not whitespace the formatter owns.
+
 ### Step 4: Verify and commit
 
 ```bash
-npm run build-check                                # zero TypeScript errors
+npm run build-ps                                   # check daemon status; if watch-client is stopped, run build-start first
+npm run build-check                                # TypeScript errors
 npm run precommit -- <file1> <file2> ...           # lint and formatting
 ```
 
-Fix precommit issues only in lines you touched. Do not fix pre-existing warnings in unrelated parts of the file — those belong in a separate commit.
+The TypeScript-checking daemon (`watch-client`) is often stopped; `build-check` only reports the latest cycle, so start the daemons with `npm run build-start` before relying on its output.
+
+`build-check` reports errors across the whole project, including pre-existing failures in extensions you didn't touch (e.g. `positron-data-driver-duckdb` "Cannot find module" errors from build ordering). Verify the **files you ported** compile clean; ignore pre-existing errors in untouched code.
+
+Fix precommit issues only in lines you touched. Do not fix pre-existing warnings in unrelated parts of the file — those belong in a separate commit. Before committing, run `git status` and exclude any unrelated churn a build daemon may have introduced (e.g. line-ending rewrites in a `package-lock.json` you never opened) — `git checkout -- <file>` to drop it.
 
 Bundle everything into one commit. Keep the message focused on what's being ported and why — do not include QA notes or e2e test tags (those belong in the PR body only):
 ```bash
@@ -87,6 +116,8 @@ After the commit lands and verification passes, ask the user whether to create a
 
 If they say yes, invoke `positron-pr-helper`. Always include `@:workbench @:web @:jupyter` in the QA tags. Then look at the ported diffs and add any other tags that match the affected areas — `positron-pr-helper` fetches the current list from `test/e2e/infra/test-runner/test-tags.ts` (or run `.claude/skills/positron-pr-helper/scripts/fetch-test-tags.sh list` directly). Pick tags conservatively — only add ones that genuinely match what changed. The mandatory three (`@:workbench @:web @:jupyter`) already cover the PWB surface area; additional tags are for routing extra coverage at the specific subsystem that was touched.
 
+The PR body must include a "Considered but not included" section listing the PRs from the Step 1b backlog that were triaged but left out, each with a one-line reason. If the backlog was empty (nothing portable beyond what was ported), state that explicitly rather than omitting the section. This makes the scope decision auditable — a reviewer can see the full delta was reviewed, not just the part that landed.
+
 ### Step 6: Ask for skill feedback
 
 After the PR is open (or after the user declines to create one), ask the user how the skill worked for them and whether anything about the workflow should be changed. If they suggest changes, edit `SKILL.md` directly so future runs incorporate the feedback.
@@ -98,3 +129,5 @@ After the PR is open (or after the user declines to create one), ask the user ho
 | Renaming `// --- Start PWB: ... ---` to `// --- Start Positron ---` | Keep PWB markers exactly as upstream. Positron markers are only for additions on top. |
 | Cherry-picking instead of applying diffs manually | No shared git ancestry — cherry-pick conflicts are worse than manual application |
 | Fixing pre-existing lint warnings in unrelated lines | Only fix issues in code you actually changed |
+| Porting only the one PR the user named, missing the backlog | Run `check-backlog.sh` (Step 1b) and surface the full portable list before deciding scope |
+| Treating `Merge 1.NNN.0` as out-of-scope divergence when baselines match | Compare `version`/`distro` in package.json — matching means it's a reconciliation merge, not a divergence; the PRs around it are still portable |

--- a/.claude/skills/positron-pull-vscode-server/SKILL.md
+++ b/.claude/skills/positron-pull-vscode-server/SKILL.md
@@ -56,14 +56,19 @@ If the user asks to pull one specific PR or issue (rather than "pull everything 
 
 The script auto-derives the baseline from the most recent "upstream merge from vscode-server" commit (searching all refs, since that merge often lives on a dedicated `pull-vscode-server` branch, not `main`). Pass an explicit `<baseline-sha>` to override.
 
-It lists every merge on `upstream/main` since the last pull and prints triage guidance. Then:
+The script already filters two classes of merge so they are never candidates:
 
-1. **Confirm the baseline is shared** using the version/distro parity check from Step 1. Matching means `Merge 1.NNN.0` / `Merge rel-*` commits are reconciliation merges (skip the merge, port the PRs around it); a mismatch means stop and sync the baseline first.
-2. **Triage the remaining merges.** `update-extension-*`, `version-bump`, and `.github/`/`Jenkinsfile`-only PRs are vscode-server tooling — skip. What's left is portable source changes.
+- **Microsoft baseline merges** (`Merge 1.NNN.0 from upstream`, `Merge rel-*`, `merge/1.NNN.0` branches). These are reconciliation merges that bring vscode-server up to a Microsoft VSCode baseline Positron tracks independently. They are not portable PRs, are never considered, and must not appear in the PR body's "Considered but not included" list.
+- **`update-extension-*` (rstudio.rstudio-workbench) bumps when Positron is not behind.** The script compares the `rstudio.rstudio-workbench` version in `product.json` on `main` vs `upstream/main`. If Positron's version is equal or newer, the bump is already covered and is dropped. Only when Positron is *behind* does the script keep `update-extension-*` as a candidate worth considering.
+
+It then lists the remaining candidate merges and prints triage guidance. For those:
+
+1. **Confirm the baseline is shared** using the version/distro parity check from Step 1. A mismatch means stop and sync the baseline first (the script's baseline-merge filter assumes a shared baseline).
+2. **Triage the remaining merges.** `version-bump` and `.github/`/`Jenkinsfile`-only PRs are vscode-server tooling — skip. What's left is portable source changes.
 3. **Check direction before assuming a PR is missing.** Some vscode-server PRs originated in posit-dev/positron and were *back*ported upstream, so they already exist in Positron. Before listing a PR as portable, confirm Positron doesn't already have the change (grep for the touched symbol/file, or check the upstream PR description for a "ported from positron" note).
 4. **Surface the full portable list to the user** and ask whether to port just the requested PR or sweep the others in too. Don't decide for them.
 
-Keep a short record of every PR you triaged but did **not** port and the one-line reason (tooling-only, back-ported and already in Positron, baseline reconciliation merge, user scoped it out, etc.). This record feeds the PR body in Step 5 — readers should see what was considered and why it was left out, not just what was included.
+Keep a short record of every *candidate* PR you triaged but did **not** port and the one-line reason (tooling-only, back-ported and already in Positron, user scoped it out, etc.). This record feeds the PR body in Step 5. Do **not** record the filtered-out baseline merges — they were never candidates.
 
 ### Step 2: Triage
 
@@ -116,7 +121,28 @@ After the commit lands and verification passes, ask the user whether to create a
 
 If they say yes, invoke `positron-pr-helper`. Always include `@:workbench @:web @:jupyter` in the QA tags. Then look at the ported diffs and add any other tags that match the affected areas — `positron-pr-helper` fetches the current list from `test/e2e/infra/test-runner/test-tags.ts` (or run `.claude/skills/positron-pr-helper/scripts/fetch-test-tags.sh list` directly). Pick tags conservatively — only add ones that genuinely match what changed. The mandatory three (`@:workbench @:web @:jupyter`) already cover the PWB surface area; additional tags are for routing extra coverage at the specific subsystem that was touched.
 
-The PR body must include a "Considered but not included" section listing the PRs from the Step 1b backlog that were triaged but left out, each with a one-line reason. If the backlog was empty (nothing portable beyond what was ported), state that explicitly rather than omitting the section. This makes the scope decision auditable — a reviewer can see the full delta was reviewed, not just the part that landed.
+Keep the PR body lean. Lead with `Fixes #<positron-issue>` and a one-line "Upstream merge from vscode-server, bringing in rstudio/vscode-server#N." Do **not** restate the problem and solution — the linked Positron issue already describes the problem and the upstream PR already describes the fix. Restating them just duplicates the issue.
+
+The PR body must include a "Considered but not included" section listing the candidate PRs from the Step 1b backlog that were triaged but left out. Format it as a two-column table: the **reason** in the first column, the vscode-server PRs as a `<ul><li>…</li></ul>` bullet list in the second (group PRs that share a reason into one row). GitHub-flavored markdown does not render native list syntax inside a table cell, so use inline `<ul>`/`<li>` tags.
+
+```markdown
+Other commits on `upstream/main` since the last pull (#<positron-merge-pr>) were triaged and left out:
+
+| Reason | Commits |
+| --- | --- |
+| Already implemented in Positron (#<positron-pr>) | <ul><li>rstudio/vscode-server#NNN (short description)</li></ul> |
+| rstudio.rstudio-workbench bumps; Positron's `product.json` already pins a newer version | <ul><li>rstudio/vscode-server#NNN</li><li>rstudio/vscode-server#NNN</li></ul> |
+| CI automation (`.github/` / `Jenkinsfile` only) | <ul><li>rstudio/vscode-server#NNN</li></ul> |
+```
+
+Reference rules for the table and the rest of the body:
+
+- Write **every** vscode-server reference fully qualified as `rstudio/vscode-server#NNN`, including each item in a bullet list — a bare `#NNN` on a posit-dev/positron PR auto-links to a Positron issue of that number, mislinking to something unrelated.
+- For a PR left out because it was back-ported from Positron, use the reason "Already implemented in Positron (#NNN)" and link the originating Positron PR. Find it in the vscode-server PR body (it usually says "Port of ... from posit-dev/positron#NNN").
+- The only bare `#NNN` that belong in the body are genuine Positron references: the issue being fixed, the prior upstream-merge PR, and any "already implemented in Positron" links.
+- When referring to "the last pull," link the prior *Positron* upstream-merge PR (e.g. `since the last pull (#13497)`), not a vscode-server PR number. Find it with `gh pr list --repo posit-dev/positron --state merged --search "upstream merge from vscode-server in:title" --limit 1`.
+
+If the backlog was empty (nothing portable beyond what was ported), state that explicitly rather than omitting the section. This makes the scope decision auditable — a reviewer can see the full delta was reviewed, not just the part that landed.
 
 ### Step 6: Ask for skill feedback
 

--- a/.claude/skills/positron-pull-vscode-server/scripts/check-backlog.sh
+++ b/.claude/skills/positron-pull-vscode-server/scripts/check-backlog.sh
@@ -52,28 +52,70 @@ if [ -z "$BASELINE" ]; then
 	echo "Last pulled PR appears to be #${LAST_PR} (merge ${BASELINE})."
 fi
 
-echo ""
-echo "Merge commits on upstream/main since ${BASELINE}:"
-echo "================================================="
-MERGES=$(git log upstream/main --first-parent --oneline "${BASELINE}..upstream/main" || true)
+ALL_MERGES=$(git log upstream/main --first-parent --no-color --oneline \
+	"${BASELINE}..upstream/main" || true)
 
-if [ -z "$MERGES" ]; then
-	echo "(none — nothing new upstream)"
+if [ -z "$ALL_MERGES" ]; then
+	echo ""
+	echo "Nothing new on upstream/main since ${BASELINE}."
 	exit 0
 fi
 
-echo "$MERGES"
+# Microsoft baseline merges (e.g. "Merge 1.118.0 from upstream",
+# "Merge rel-blue-plumbago", "merge/1.NNN.0" branches) are never portable PRs:
+# they are reconciliation merges that bring vscode-server up to a Microsoft
+# VSCode baseline. Positron tracks that baseline independently, so these must
+# never appear as candidates. Drop them before anything else.
+CANDIDATES=$(echo "$ALL_MERGES" \
+	| grep -viE 'Merge [0-9]+\.[0-9]+\.[0-9]+ from upstream' \
+	| grep -viE 'Merge rel-' \
+	| grep -viE 'merge/[0-9]+\.[0-9]+\.[0-9]+' || true)
 
 echo ""
-echo "Heads up: the merges above are waiting upstream beyond the single PR you"
-echo "named. Before triaging, confirm the baseline is shared: compare 'version'"
-echo "and 'distro' in package.json on main vs upstream/main."
-echo "  - If they MATCH, any 'Merge 1.NNN.0' / 'Merge rel-*' commits are"
-echo "    reconciliation merges that brought vscode-server up to Positron's"
-echo "    baseline (already in Positron); skip them but do NOT skip the feature/"
-echo "    bugfix PRs around them."
-echo "  - If they DIFFER, the repos have diverged — stop and sync the Microsoft"
-echo "    baseline first (this skill ports across a shared baseline only)."
-echo "update-extension-*, version-bump, and .github/Jenkins commits are"
-echo "vscode-server tooling and are normally skipped. Surface the remaining"
-echo "portable source PRs to the user before porting only the one they asked for."
+echo "Excluded Microsoft baseline merges (not portable):"
+echo "=================================================="
+echo "$ALL_MERGES" | grep --color=never -iE 'Merge [0-9]+\.[0-9]+\.[0-9]+ from upstream|Merge rel-|merge/[0-9]+\.[0-9]+\.[0-9]+' \
+	|| echo "(none)"
+
+# Decide whether an update-extension-* (rstudio.rstudio-workbench) bump is worth
+# considering: only if Positron is BEHIND upstream. If Positron's product.json
+# pins an equal-or-newer version, the bump is already covered — drop it.
+PWB_MAIN=$(git show main:product.json 2>/dev/null \
+	| grep -A1 '"rstudio.rstudio-workbench"' | grep -oE --color=never '[0-9]{4}\.[0-9]+\.[0-9]+' | head -1 || true)
+PWB_UPSTREAM=$(git show upstream/main:product.json 2>/dev/null \
+	| grep -A1 '"rstudio.rstudio-workbench"' | grep -oE --color=never '[0-9]{4}\.[0-9]+\.[0-9]+' | head -1 || true)
+
+PWB_BEHIND=false
+if [ -n "$PWB_MAIN" ] && [ -n "$PWB_UPSTREAM" ]; then
+	# Positron is behind only if the highest of the two versions is upstream's.
+	HIGHEST=$(printf '%s\n%s\n' "$PWB_MAIN" "$PWB_UPSTREAM" | sort -V | tail -1)
+	if [ "$HIGHEST" = "$PWB_UPSTREAM" ] && [ "$PWB_MAIN" != "$PWB_UPSTREAM" ]; then
+		PWB_BEHIND=true
+	fi
+fi
+
+echo ""
+echo "rstudio.rstudio-workbench: Positron=${PWB_MAIN:-?} upstream=${PWB_UPSTREAM:-?}"
+if [ "$PWB_BEHIND" = true ]; then
+	echo "Positron is BEHIND -- update-extension-* bumps ARE worth considering."
+else
+	echo "Positron is equal or ahead -- update-extension-* bumps are already covered; skip them."
+	CANDIDATES=$(echo "$CANDIDATES" | grep -viE 'update-extension-' || true)
+fi
+
+echo ""
+echo "Candidate merges to triage since ${BASELINE}:"
+echo "============================================="
+if [ -z "$CANDIDATES" ]; then
+	echo "(none -- only baseline/tooling merges, nothing portable)"
+	exit 0
+fi
+echo "$CANDIDATES"
+
+echo ""
+echo "Heads up: the candidates above are waiting upstream beyond the single PR"
+echo "you named. version-bump and .github/Jenkins-only commits are vscode-server"
+echo "tooling and are normally skipped. A PR may also already exist in Positron if"
+echo "it was back-ported upstream (check direction before porting). Surface the"
+echo "remaining portable source PRs to the user before porting only the one they"
+echo "asked for."

--- a/.claude/skills/positron-pull-vscode-server/scripts/check-backlog.sh
+++ b/.claude/skills/positron-pull-vscode-server/scripts/check-backlog.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Report the backlog of unpulled rstudio/vscode-server commits.
+#
+# Usage: ./check-backlog.sh [baseline-sha]
+#
+# Use this when the user asks to pull a SINGLE PR/issue, to surface any OTHER
+# portable commits that have accrued upstream since the last merge. The single
+# requested PR is rarely the only thing waiting — this check stops the rest of
+# the backlog from being silently skipped.
+#
+# <baseline-sha> is the upstream/main commit that corresponds to the last
+# "upstream merge from vscode-server" commit in Positron's history. If omitted,
+# the script derives it from the most recent "Brings in:" commit message.
+
+set -euo pipefail
+
+echo "Fetching upstream..."
+git fetch upstream >/dev/null 2>&1
+
+BASELINE="${1:-}"
+
+if [ -z "$BASELINE" ]; then
+	# Derive the baseline from the most recent "upstream merge from vscode-server"
+	# commit. Search --all: the merge often lands on a dedicated
+	# pull-vscode-server branch before it reaches main, so a main-only log misses
+	# it. Take the highest PR number its "Brings in:" list mentions, find that
+	# merge on upstream/main, and use it as the baseline (commits strictly after
+	# it are the backlog).
+	LAST_MERGE=$(git log --all --grep="upstream merge from vscode-server" \
+		--date-order --format="%H" | head -1 || true)
+	LAST_PR=$(git log -1 "$LAST_MERGE" --format="%B" 2>/dev/null \
+		| grep -oE --color=never 'vscode-server#[0-9]+' \
+		| grep -oE --color=never '[0-9]+' \
+		| sort -n | tail -1 || true)
+
+	if [ -z "$LAST_PR" ]; then
+		echo "ERROR: Could not derive a baseline. Pass <baseline-sha> explicitly."
+		echo "Recent upstream merges from vscode-server in Positron:"
+		git log --oneline --grep="upstream merge from vscode-server" -5
+		exit 1
+	fi
+
+	BASELINE=$(git log upstream/main --merges --no-color --oneline \
+		--grep="pull request #${LAST_PR} " | head -1 | cut -d' ' -f1 || true)
+
+	if [ -z "$BASELINE" ]; then
+		echo "ERROR: Found last pulled PR #${LAST_PR} but could not locate its merge"
+		echo "on upstream/main. Pass <baseline-sha> explicitly."
+		exit 1
+	fi
+
+	echo "Last pulled PR appears to be #${LAST_PR} (merge ${BASELINE})."
+fi
+
+echo ""
+echo "Merge commits on upstream/main since ${BASELINE}:"
+echo "================================================="
+MERGES=$(git log upstream/main --first-parent --oneline "${BASELINE}..upstream/main" || true)
+
+if [ -z "$MERGES" ]; then
+	echo "(none — nothing new upstream)"
+	exit 0
+fi
+
+echo "$MERGES"
+
+echo ""
+echo "Heads up: the merges above are waiting upstream beyond the single PR you"
+echo "named. Before triaging, confirm the baseline is shared: compare 'version'"
+echo "and 'distro' in package.json on main vs upstream/main."
+echo "  - If they MATCH, any 'Merge 1.NNN.0' / 'Merge rel-*' commits are"
+echo "    reconciliation merges that brought vscode-server up to Positron's"
+echo "    baseline (already in Positron); skip them but do NOT skip the feature/"
+echo "    bugfix PRs around them."
+echo "  - If they DIFFER, the repos have diverged — stop and sync the Microsoft"
+echo "    baseline first (this skill ports across a shared baseline only)."
+echo "update-extension-*, version-bump, and .github/Jenkins commits are"
+echo "vscode-server tooling and are normally skipped. Surface the remaining"
+echo "portable source PRs to the user before porting only the one they asked for."

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -3,7 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { isFirefox } from '../../../../base/browser/browser.js';
+// --- Start PWB: avoid Firefox/Safari clipboard "Paste" popup ---
+import { isFirefox, isSafari } from '../../../../base/browser/browser.js';
+// --- End PWB ---
 import { BrowserFeatures } from '../../../../base/browser/canIUse.js';
 import { DataTransfers } from '../../../../base/browser/dnd.js';
 import * as dom from '../../../../base/browser/dom.js';
@@ -1180,6 +1182,17 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			if (!BrowserFeatures.clipboard.readText && event.key === 'v' && event.ctrlKey) {
 				return false;
 			}
+
+			// --- Start PWB: avoid Firefox/Safari clipboard "Paste" popup ---
+			// In Firefox and Safari, navigator.clipboard.readText() shows a "Paste" permission
+			// affordance on every paste. The Cmd/Ctrl+V Paste keybinding is dropped on those
+			// browsers (see terminal.clipboard.contribution.ts), so let the keystroke fall
+			// through to the native paste event, which xterm handles without the popup. Without
+			// this, xterm would consume the keystroke and send a literal ^V to the shell instead.
+			if ((isFirefox || isSafari) && event.key === 'v' && (event.ctrlKey || (isMacintosh && event.metaKey))) {
+				return false;
+			}
+			// --- End PWB ---
 
 			return true;
 		});

--- a/src/vs/workbench/contrib/terminalContrib/clipboard/browser/terminal.clipboard.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/clipboard/browser/terminal.clipboard.contribution.ts
@@ -13,6 +13,9 @@ import { registerTerminalContribution, type IDetachedCompatibleTerminalContribut
 import { shouldPasteTerminalText } from './terminalClipboard.js';
 import { Emitter } from '../../../../../base/common/event.js';
 import { BrowserFeatures } from '../../../../../base/browser/canIUse.js';
+// --- Start PWB: avoid Firefox/Safari clipboard "Paste" popup ---
+import { isFirefox, isSafari } from '../../../../../base/browser/browser.js';
+// --- End PWB ---
 import { TerminalCapability, type ITerminalCommand } from '../../../../../platform/terminal/common/capabilities/capabilities.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { TerminalSettingId } from '../../../../../platform/terminal/common/terminal.js';
@@ -297,7 +300,15 @@ if (BrowserFeatures.clipboard.readText) {
 		id: TerminalCommandId.Paste,
 		title: localize2('workbench.action.terminal.paste', 'Paste into Active Terminal'),
 		precondition: terminalAvailableWhenClause,
-		keybinding: [{
+		// --- Start PWB: avoid Firefox/Safari clipboard "Paste" popup ---
+		// navigator.clipboard.readText() shows a "Paste" permission affordance on every call in
+		// Firefox and Safari. Drop the Cmd/Ctrl+V keybinding on those browsers so the native
+		// paste event flows through to xterm instead (see the key event handler in
+		// terminalInstance.ts), which pastes without the popup. The command stays available via
+		// the context menu and the command palette (those still use readText() and so still show
+		// the popup, which is unavoidable for a programmatic clipboard read in those browsers).
+		keybinding: (isFirefox || isSafari) ? [] : [{
+			// --- End PWB ---
 			primary: KeyMod.CtrlCmd | KeyCode.KeyV,
 			win: { primary: KeyMod.CtrlCmd | KeyCode.KeyV, secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyV] },
 			linux: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyV },


### PR DESCRIPTION
Fixes #9390

Upstream merge from vscode-server, bringing in rstudio/vscode-server#385.

### Considered but not included

Other commits on `upstream/main` since the last pull (#13497) were triaged and left out:

| Reason | Commits |
| --- | --- |
| Already implemented in Positron (#13649) | <ul><li>rstudio/vscode-server#366 (defend against extension host hangs)</li></ul> |
| rstudio.rstudio-workbench bumps; Positron's `product.json` already pins a newer version (2026.7.5 vs upstream 2026.7.4) | <ul><li>rstudio/vscode-server#363</li><li>rstudio/vscode-server#370</li><li>rstudio/vscode-server#381</li></ul> |
| vscode-server version tooling, no Positron equivalent | <ul><li>rstudio/vscode-server#365</li><li>rstudio/vscode-server#377</li></ul> |
| CI automation (`.github/` / `Jenkinsfile` only) | <ul><li>rstudio/vscode-server#369</li><li>rstudio/vscode-server#372</li></ul> |

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix terminal paste showing a browser "Paste" popup on every <kbd>Cmd/Ctrl+V</kbd> in Firefox and Safari web (#9390)

### Validation Steps

@:workbench @:web @:jupyter @:cross-browser

In Firefox and Safari on Workbench:

1. Open a terminal, copy some text, and press <kbd>Cmd/Ctrl+V</kbd>. The text pastes with no floating "Paste" popup.
2. Right-click "Paste" and the command palette "Paste into Active Terminal" still paste (they show the popup, as expected).
3. In Chrome, and in the desktop app, paste behavior is unchanged.
