### PR TITLE
Add an "Open in Data Explorer" code action

### DIFF
--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
@@ -17,18 +17,13 @@ import { EditorContextKeys } from '../../../../editor/common/editorContextKeys.j
 import { ILanguageService } from '../../../../editor/common/languages/language.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
-import { LanguageRuntimeSessionMode } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { viewVariableItem } from '../../../services/positronDataExplorer/browser/positronDataExplorerViewVariableItem.js';
 import { IPositronVariablesService } from '../../../services/positronVariables/common/interfaces/positronVariablesService.js';
-import { IPositronVariablesInstance } from '../../../services/positronVariables/common/interfaces/positronVariablesInstance.js';
-import { POSITRON_VARIABLES_VIEW_ID } from '../../positronVariables/browser/positronVariables.contribution.js';
 import { POSITRON_RUNTIME_LANGUAGE_IDS } from '../../languageRuntime/browser/languageRuntimeContextKeys.js';
-import { CellUri } from '../../notebook/common/notebookCommon.js';
 import { IViewsService } from '../../../services/views/common/viewsService.js';
-import { Event } from '../../../../base/common/event.js';
-import { raceTimeout } from '../../../../base/common/async.js';
+import { IDataFrameResolutionServices, resolveDataFrameAtPosition } from './positronDataExplorerResolveDataFrame.js';
 import { IPositronDataExplorerEditor } from './positronDataExplorerEditor.js';
 import { IPositronDataExplorerService, PositronDataExplorerLayout } from '../../../services/positronDataExplorer/browser/interfaces/positronDataExplorerService.js';
 import { PositronDataExplorerEditorInput } from './positronDataExplorerEditorInput.js';
@@ -82,6 +77,7 @@ export const enum PositronDataExplorerCommandId {
 	ShowRowContextMenuAction = 'workbench.action.positronDataExplorer.showRowContextMenu',
 	ShowCellContextMenuAction = 'workbench.action.positronDataExplorer.showCellContextMenu',
 	ViewDataFrameAtCursorAction = 'workbench.action.positronDataExplorer.viewDataFrameAtCursor',
+	ViewDataFrameByVariableAction = 'workbench.action.positronDataExplorer.viewDataFrameByVariable',
 }
 
 /**
@@ -1281,34 +1277,6 @@ class PositronDataExplorerShowCellContextMenuAction extends Action2 {
 }
 
 /**
- * How long to wait for a freshly-created variables instance to receive its
- * initial variable list from the runtime. Bounded because the runtime is an
- * external process: it may be slow, busy, or unresponsive.
- */
-const VARIABLES_LIST_READY_TIMEOUT_MS = 2000;
-
-/**
- * Waits for the given variables instance to have at least one known variable,
- * up to {@link VARIABLES_LIST_READY_TIMEOUT_MS}. A no-op if the instance
- * already has variables cached. Returns whether the wait timed out so callers
- * can distinguish "the variable really isn't there" from "we gave up waiting".
- */
-const waitForVariables = async (
-	instance: IPositronVariablesInstance,
-): Promise<{ timedOut: boolean }> => {
-	if (instance.variableItems.length > 0) {
-		return { timedOut: false };
-	}
-	let timedOut = false;
-	await raceTimeout(
-		Event.toPromise(Event.once(instance.onDidChangeEntries)),
-		VARIABLES_LIST_READY_TIMEOUT_MS,
-		() => { timedOut = true; },
-	);
-	return { timedOut };
-};
-
-/**
  * PositronDataExplorerViewDataFrameAtCursorAction opens the Data Explorer
  * for the identifier at the editor cursor, if that identifier names a
  * viewable variable in the console session for the editor's language.
@@ -1357,12 +1325,14 @@ export class PositronDataExplorerViewDataFrameAtCursorAction extends Action2 {
 
 	async run(accessor: ServicesAccessor): Promise<void> {
 		const editorService = accessor.get(IEditorService);
-		const languageService = accessor.get(ILanguageService);
-		const runtimeSessionService = accessor.get(IRuntimeSessionService);
-		const variablesService = accessor.get(IPositronVariablesService);
 		const dataExplorerService = accessor.get(IPositronDataExplorerService);
 		const notificationService = accessor.get(INotificationService);
-		const viewsService = accessor.get(IViewsService);
+		const services: IDataFrameResolutionServices = {
+			languageService: accessor.get(ILanguageService),
+			runtimeSessionService: accessor.get(IRuntimeSessionService),
+			variablesService: accessor.get(IPositronVariablesService),
+			viewsService: accessor.get(IViewsService),
+		};
 
 		const control = editorService.activeTextEditorControl;
 		if (!isCodeEditor(control)) {
@@ -1378,111 +1348,123 @@ export class PositronDataExplorerViewDataFrameAtCursorAction extends Action2 {
 			return;
 		}
 
-		const word = model.getWordAtPosition(position);
-		if (!word) {
-			notificationService.info(localize(
-				'positron.viewDataFrameAtCursor.noSymbol',
-				"No symbol at cursor."
-			));
+		// Interactive invocation: open the Variables pane if needed and wait for
+		// a freshly-created instance to report its variables.
+		const resolution = await resolveDataFrameAtPosition(model, position, services, {
+			wait: true,
+			openVariablesViewIfNeeded: true,
+		});
+
+		switch (resolution.kind) {
+			case 'no-symbol':
+				notificationService.info(localize(
+					'positron.viewDataFrameAtCursor.noSymbol',
+					"No symbol at cursor."
+				));
+				return;
+			case 'no-session':
+				notificationService.info(localize(
+					'positron.viewDataFrameAtCursor.noSession',
+					"No active {0} session.",
+					resolution.languageName,
+				));
+				return;
+			case 'variables-unavailable':
+				notificationService.info(localize(
+					'positron.viewDataFrameAtCursor.variablesUnavailable',
+					"Variables for the active {0} session are not available yet.",
+					resolution.languageName,
+				));
+				return;
+			case 'not-found':
+				// If we timed out waiting for the first variable update, the
+				// symbol might actually be defined but the runtime hasn't
+				// reported it yet (e.g. a long-running chunk that assigns the
+				// variable and then keeps running). Tell the user that rather
+				// than flatly claiming the variable doesn't exist.
+				if (resolution.timedOut) {
+					notificationService.info(localize(
+						'positron.viewDataFrameAtCursor.variablesTimeout',
+						"The active {0} session is still loading variables. Try again in a moment.",
+						resolution.languageName,
+					));
+				} else {
+					notificationService.info(localize(
+						'positron.viewDataFrameAtCursor.notDefined',
+						"'{0}' is not a data frame defined in the active session.",
+						resolution.symbol,
+					));
+				}
+				return;
+			case 'not-viewable':
+				notificationService.info(localize(
+					'positron.viewDataFrameAtCursor.notViewable',
+					"'{0}' is not viewable in the Data Explorer.",
+					resolution.symbol,
+				));
+				return;
+			case 'ok':
+				await viewVariableItem(
+					resolution.sessionId,
+					resolution.item,
+					dataExplorerService,
+					notificationService,
+				);
+				return;
+		}
+	}
+}
+
+/**
+ * Arguments for {@link PositronDataExplorerViewDataFrameByVariableAction}.
+ */
+export interface IViewDataFrameByVariableArgs {
+	readonly sessionId: string;
+	readonly variableId: string;
+}
+
+/**
+ * PositronDataExplorerViewDataFrameByVariableAction opens the Data Explorer for
+ * an already-resolved variable, identified by its session and variable id. It
+ * is the command that triggers (the code action, and later a click gesture)
+ * invoke once they have resolved the symbol, so the open/focus logic lives in
+ * one place and nothing has to re-resolve "the active editor cursor".
+ */
+export class PositronDataExplorerViewDataFrameByVariableAction extends Action2 {
+	constructor() {
+		super({
+			id: PositronDataExplorerCommandId.ViewDataFrameByVariableAction,
+			title: {
+				value: localize('positronDataExplorer.viewDataFrameByVariable', 'Open in Data Explorer'),
+				original: 'Open in Data Explorer'
+			},
+			category,
+			// Not a palette command: it requires arguments that only a caller
+			// (e.g. the code action) can supply.
+			f1: false,
+		});
+	}
+
+	async run(accessor: ServicesAccessor, args?: IViewDataFrameByVariableArgs): Promise<void> {
+		if (!args?.sessionId || !args?.variableId) {
 			return;
 		}
-		const symbol = word.word;
-		// Use the embedded language at the cursor position rather than the
-		// outer document's language, so this works inside R/Python chunks of
-		// language-embedded documents (e.g. Quarto).
-		const languageId = model.getLanguageIdAtPosition(
-			position.lineNumber,
-			position.column,
+		const variablesService = accessor.get(IPositronVariablesService);
+		const dataExplorerService = accessor.get(IPositronDataExplorerService);
+		const notificationService = accessor.get(INotificationService);
+
+		const instance = variablesService.positronVariablesInstances.find(
+			i => i.session.sessionId === args.sessionId,
 		);
-
-		// Notebook cells run in a per-notebook kernel session, which owns
-		// any variables defined by running the cells. Scripts use the
-		// language's console session instead.
-		//
-		// For scripts: getConsoleSessionForLanguage returns the foreground
-		// session (if it matches the language) or the last one brought to
-		// the foreground. A console can be running in the background
-		// without ever having been foregrounded -- fall back to scanning
-		// activeSessions in that case. Mirrors the lookup in
-		// PositronConsoleService.executeCode so "run code" and "view data
-		// frame" agree on which session to use.
-		const cellInfo = CellUri.parse(model.uri);
-		const session = cellInfo
-			? runtimeSessionService.getNotebookSessionForNotebookUri(cellInfo.notebook)
-			: runtimeSessionService.getConsoleSessionForLanguage(languageId)
-			?? runtimeSessionService.activeSessions.find(s =>
-				s.runtimeMetadata.languageId === languageId &&
-				s.metadata.sessionMode === LanguageRuntimeSessionMode.Console,
-			);
-		if (!session) {
-			notificationService.info(localize(
-				'positron.viewDataFrameAtCursor.noSession',
-				"No active {0} session.",
-				languageService.getLanguageName(languageId) ?? languageId,
-			));
-			return;
-		}
-
-		// Variables instances are created and populated lazily by the Variables
-		// pane. If the pane has never been shown, or is currently hidden, no
-		// instance will exist for this session. In that case open the pane
-		// (without stealing focus), which triggers instance creation, then
-		// retry the lookup.
-		const findInstance = (): IPositronVariablesInstance | undefined =>
-			variablesService.positronVariablesInstances.find(
-				instance => instance.session.sessionId === session.sessionId,
-			);
-		let variablesInstance = findInstance();
-		if (!variablesInstance) {
-			await viewsService.openView(POSITRON_VARIABLES_VIEW_ID, false);
-			variablesInstance = findInstance();
-		}
-		if (!variablesInstance) {
-			notificationService.info(localize(
-				'positron.viewDataFrameAtCursor.variablesUnavailable',
-				"Variables for the active {0} session are not available yet.",
-				languageService.getLanguageName(languageId) ?? languageId,
-			));
-			return;
-		}
-
-		// The variable list arrives asynchronously from the runtime, so a
-		// freshly-created instance may not yet have it.
-		const { timedOut } = await waitForVariables(variablesInstance);
-
-		const item = variablesInstance.variableItems.find(v => v.displayName === symbol);
+		const item = instance?.variableItems.find(v => v.id === args.variableId);
 		if (!item) {
-			// If we timed out waiting for the first variable update, the
-			// symbol might actually be defined but the runtime hasn't
-			// reported it yet (e.g. a long-running chunk that assigns the
-			// variable and then keeps running). Tell the user that rather
-			// than flatly claiming the variable doesn't exist.
-			if (timedOut) {
-				notificationService.info(localize(
-					'positron.viewDataFrameAtCursor.variablesTimeout',
-					"The active {0} session is still loading variables. Try again in a moment.",
-					languageService.getLanguageName(languageId) ?? languageId,
-				));
-			} else {
-				notificationService.info(localize(
-					'positron.viewDataFrameAtCursor.notDefined',
-					"'{0}' is not a data frame defined in the active session.",
-					symbol,
-				));
-			}
-			return;
-		}
-		if (!item.hasViewer) {
-			notificationService.info(localize(
-				'positron.viewDataFrameAtCursor.notViewable',
-				"'{0}' is not viewable in the Data Explorer.",
-				symbol,
-			));
+			// The variable went away between resolution and invocation (e.g. the
+			// session reset). Nothing to view.
 			return;
 		}
 
 		await viewVariableItem(
-			session.sessionId,
+			args.sessionId,
 			item,
 			dataExplorerService,
 			notificationService,
@@ -1510,4 +1492,5 @@ export function registerPositronDataExplorerActions() {
 	registerAction2(PositronDataExplorerShowRowContextMenuAction);
 	registerAction2(PositronDataExplorerShowCellContextMenuAction);
 	registerAction2(PositronDataExplorerViewDataFrameAtCursorAction);
+	registerAction2(PositronDataExplorerViewDataFrameByVariableAction);
 }

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerCodeActionProvider.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerCodeActionProvider.ts
@@ -1,0 +1,128 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../../nls.js';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { HierarchicalKind } from '../../../../base/common/hierarchicalKind.js';
+import { Range } from '../../../../editor/common/core/range.js';
+import { Selection } from '../../../../editor/common/core/selection.js';
+import { ITextModel } from '../../../../editor/common/model.js';
+import { CodeActionContext, CodeActionList, CodeActionProvider } from '../../../../editor/common/languages.js';
+import { ILanguageFeaturesService } from '../../../../editor/common/services/languageFeatures.js';
+import { CodeActionKind } from '../../../../editor/contrib/codeAction/common/types.js';
+import { ILanguageService } from '../../../../editor/common/languages/language.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
+import { IPositronVariablesService } from '../../../services/positronVariables/common/interfaces/positronVariablesService.js';
+import { IViewsService } from '../../../services/views/common/viewsService.js';
+import { IViewDataFrameByVariableArgs, PositronDataExplorerCommandId } from './positronDataExplorerActions.js';
+import { resolveDataFrameAtPosition } from './positronDataExplorerResolveDataFrame.js';
+
+/**
+ * The languages for which the "Open in Data Explorer" code action is offered.
+ * Quarto is included so the action works inside R/Python chunks of a .qmd file;
+ * the resolver keys off the embedded language at the cursor. Notebook cells are
+ * covered by the 'r'/'python' selectors, since a cell editor's model language
+ * is the cell's language.
+ */
+const CODE_ACTION_LANGUAGES = ['r', 'python', 'quarto'];
+
+/**
+ * Offers an "Open in Data Explorer" code action (lightbulb / Cmd+.) when the
+ * symbol at the cursor names a viewable data frame in the editor's runtime
+ * session.
+ *
+ * The action is a thin wrapper over the same resolution flow as the "View Data
+ * Frame at Cursor" command: it resolves the symbol to a variable and, on
+ * success, emits an action whose command opens that variable. Resolution runs
+ * with `wait: false` and `openVariablesViewIfNeeded: false` so feeding the
+ * lightbulb is instant and free of side effects -- if the variable isn't
+ * already known, no action is offered.
+ */
+export class PositronDataExplorerCodeActionProvider implements CodeActionProvider {
+
+	readonly providedCodeActionKinds = [CodeActionKind.Refactor.value];
+
+	constructor(
+		@ILanguageService private readonly _languageService: ILanguageService,
+		@IRuntimeSessionService private readonly _runtimeSessionService: IRuntimeSessionService,
+		@IPositronVariablesService private readonly _variablesService: IPositronVariablesService,
+		@IViewsService private readonly _viewsService: IViewsService,
+	) { }
+
+	async provideCodeActions(
+		model: ITextModel,
+		range: Range | Selection,
+		context: CodeActionContext,
+		_token: CancellationToken,
+	): Promise<CodeActionList | undefined> {
+		// Only do work when a refactor-kind action could actually be surfaced.
+		// This skips unrelated requests such as source.fixAll on save.
+		if (context.only && !CodeActionKind.Refactor.intersects(new HierarchicalKind(context.only))) {
+			return undefined;
+		}
+
+		const resolution = await resolveDataFrameAtPosition(
+			model,
+			range.getStartPosition(),
+			{
+				languageService: this._languageService,
+				runtimeSessionService: this._runtimeSessionService,
+				variablesService: this._variablesService,
+				viewsService: this._viewsService,
+			},
+			{ wait: false, openVariablesViewIfNeeded: false },
+		);
+		if (resolution.kind !== 'ok') {
+			return undefined;
+		}
+
+		const args: IViewDataFrameByVariableArgs = {
+			sessionId: resolution.sessionId,
+			variableId: resolution.item.id,
+		};
+		return {
+			actions: [
+				{
+					title: localize(
+						'positron.dataExplorer.openInDataExplorer',
+						"Open '{0}' in Data Explorer",
+						resolution.item.displayName,
+					),
+					kind: CodeActionKind.Refactor.value,
+					command: {
+						id: PositronDataExplorerCommandId.ViewDataFrameByVariableAction,
+						title: localize(
+							'positron.dataExplorer.openInDataExplorer.command',
+							"Open in Data Explorer",
+						),
+						arguments: [args],
+					},
+				},
+			],
+			dispose: () => { },
+		};
+	}
+}
+
+/**
+ * Registers the {@link PositronDataExplorerCodeActionProvider} for the runtime
+ * languages it supports.
+ */
+export class PositronDataExplorerCodeActionContribution extends Disposable {
+	static readonly ID = 'workbench.contrib.positronDataExplorerCodeActions';
+
+	constructor(
+		@ILanguageFeaturesService languageFeaturesService: ILanguageFeaturesService,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super();
+		this._register(languageFeaturesService.codeActionProvider.register(
+			CODE_ACTION_LANGUAGES,
+			instantiationService.createInstance(PositronDataExplorerCodeActionProvider),
+		));
+	}
+}

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts
@@ -17,6 +17,7 @@ import { EditorInputFactoryFunction, IEditorResolverService, RegisteredEditorPri
 import { PositronDataExplorerEditor } from './positronDataExplorerEditor.js';
 import { PositronDataExplorerEditorInput } from './positronDataExplorerEditorInput.js';
 import { registerPositronDataExplorerActions } from './positronDataExplorerActions.js';
+import { PositronDataExplorerCodeActionContribution } from './positronDataExplorerCodeActionProvider.js';
 import { PositronDataExplorerSheetSelector } from './positronDataExplorerSheetSelector.js';
 import { POSITRON_DATA_EXPLORER_IS_ACTIVE_EDITOR, POSITRON_DATA_EXPLORER_IS_XLSX } from './positronDataExplorerContextKeys.js';
 import { extname } from '../../../../base/common/resources.js';
@@ -146,6 +147,14 @@ registerWorkbenchContribution2(
 
 // Register actions.
 registerPositronDataExplorerActions();
+
+// Register the "Open in Data Explorer" code action provider for runtime
+// languages.
+registerWorkbenchContribution2(
+	PositronDataExplorerCodeActionContribution.ID,
+	PositronDataExplorerCodeActionContribution,
+	WorkbenchPhase.AfterRestored
+);
 
 // Register the worksheet selector widget in the editor action bar. It appears
 // on the right side of the action bar, only for Excel workbooks with more than

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerResolveDataFrame.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerResolveDataFrame.ts
@@ -1,0 +1,191 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Event } from '../../../../base/common/event.js';
+import { raceTimeout } from '../../../../base/common/async.js';
+import { IPosition } from '../../../../editor/common/core/position.js';
+import { ITextModel } from '../../../../editor/common/model.js';
+import { ILanguageService } from '../../../../editor/common/languages/language.js';
+import { CellUri } from '../../notebook/common/notebookCommon.js';
+import { POSITRON_VARIABLES_VIEW_ID } from '../../positronVariables/browser/positronVariables.contribution.js';
+import { IViewsService } from '../../../services/views/common/viewsService.js';
+import { IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
+import { LanguageRuntimeSessionMode } from '../../../services/languageRuntime/common/languageRuntimeService.js';
+import { IPositronVariablesService } from '../../../services/positronVariables/common/interfaces/positronVariablesService.js';
+import { IPositronVariablesInstance } from '../../../services/positronVariables/common/interfaces/positronVariablesInstance.js';
+import { IVariableItem } from '../../../services/positronVariables/common/interfaces/variableItem.js';
+
+/**
+ * How long to wait for a freshly-created variables instance to receive its
+ * initial variable list from the runtime. Bounded because the runtime is an
+ * external process: it may be slow, busy, or unresponsive.
+ */
+const VARIABLES_LIST_READY_TIMEOUT_MS = 2000;
+
+/**
+ * Waits for the given variables instance to have at least one known variable,
+ * up to {@link VARIABLES_LIST_READY_TIMEOUT_MS}. A no-op if the instance
+ * already has variables cached. Returns whether the wait timed out so callers
+ * can distinguish "the variable really isn't there" from "we gave up waiting".
+ */
+const waitForVariables = async (
+	instance: IPositronVariablesInstance,
+): Promise<{ timedOut: boolean }> => {
+	if (instance.variableItems.length > 0) {
+		return { timedOut: false };
+	}
+	let timedOut = false;
+	await raceTimeout(
+		Event.toPromise(Event.once(instance.onDidChangeEntries)),
+		VARIABLES_LIST_READY_TIMEOUT_MS,
+		() => { timedOut = true; },
+	);
+	return { timedOut };
+};
+
+/**
+ * The services needed to resolve the data frame at an editor position. Passed
+ * explicitly (rather than via a ServicesAccessor) so both command handlers and
+ * a code action provider can call {@link resolveDataFrameAtPosition}.
+ */
+export interface IDataFrameResolutionServices {
+	readonly languageService: ILanguageService;
+	readonly runtimeSessionService: IRuntimeSessionService;
+	readonly variablesService: IPositronVariablesService;
+	readonly viewsService: IViewsService;
+}
+
+/**
+ * Options controlling the side effects and patience of
+ * {@link resolveDataFrameAtPosition}.
+ */
+export interface IDataFrameResolutionOptions {
+	/**
+	 * Whether to wait up to {@link VARIABLES_LIST_READY_TIMEOUT_MS} for a
+	 * freshly-created variables instance to report its first variable list.
+	 * Interactive callers (a command the user invoked) should wait; background
+	 * callers (a code action provider feeding the lightbulb) should not, so the
+	 * computation stays instant.
+	 */
+	readonly wait: boolean;
+
+	/**
+	 * Whether to open the Variables view (without stealing focus) when no
+	 * variables instance exists yet for the session. Interactive callers should
+	 * do this so a never-shown pane still resolves; background callers must not,
+	 * since computing a code action should have no visible side effects.
+	 */
+	readonly openVariablesViewIfNeeded: boolean;
+}
+
+/**
+ * The outcome of resolving the identifier at an editor position to a viewable
+ * data frame. Discriminated by `kind` so callers can map each case to the
+ * appropriate notification (interactive command) or simply check for `'ok'`
+ * (code action provider).
+ */
+export type DataFrameResolution =
+	| { readonly kind: 'ok'; readonly sessionId: string; readonly item: IVariableItem }
+	| { readonly kind: 'no-symbol' }
+	| { readonly kind: 'no-session'; readonly languageName: string }
+	| { readonly kind: 'variables-unavailable'; readonly languageName: string }
+	| { readonly kind: 'not-found'; readonly symbol: string; readonly languageName: string; readonly timedOut: boolean }
+	| { readonly kind: 'not-viewable'; readonly symbol: string };
+
+/**
+ * Resolves the identifier at the given editor position to a viewable variable
+ * in the runtime session for the position's (embedded) language.
+ *
+ * This is the shared resolution flow behind both the "View Data Frame at
+ * Cursor" command and the "Open in Data Explorer" code action. It does not
+ * surface any notifications; callers map the returned {@link DataFrameResolution}
+ * to user-facing messages as appropriate.
+ *
+ * @param model The text model under the cursor.
+ * @param position The position to resolve.
+ * @param services The services needed for resolution.
+ * @param options Side-effect and patience options.
+ */
+export async function resolveDataFrameAtPosition(
+	model: ITextModel,
+	position: IPosition,
+	services: IDataFrameResolutionServices,
+	options: IDataFrameResolutionOptions,
+): Promise<DataFrameResolution> {
+	const { languageService, runtimeSessionService, variablesService, viewsService } = services;
+
+	const word = model.getWordAtPosition(position);
+	if (!word) {
+		return { kind: 'no-symbol' };
+	}
+	const symbol = word.word;
+
+	// Use the embedded language at the cursor position rather than the outer
+	// document's language, so this works inside R/Python chunks of
+	// language-embedded documents (e.g. Quarto).
+	const languageId = model.getLanguageIdAtPosition(position.lineNumber, position.column);
+	const languageName = languageService.getLanguageName(languageId) ?? languageId;
+
+	// Notebook cells run in a per-notebook kernel session, which owns any
+	// variables defined by running the cells. Scripts use the language's console
+	// session instead.
+	//
+	// For scripts: getConsoleSessionForLanguage returns the foreground session
+	// (if it matches the language) or the last one brought to the foreground. A
+	// console can be running in the background without ever having been
+	// foregrounded -- fall back to scanning activeSessions in that case. Mirrors
+	// the lookup in PositronConsoleService.executeCode so "run code" and "view
+	// data frame" agree on which session to use.
+	const cellInfo = CellUri.parse(model.uri);
+	const session = cellInfo
+		? runtimeSessionService.getNotebookSessionForNotebookUri(cellInfo.notebook)
+		: runtimeSessionService.getConsoleSessionForLanguage(languageId)
+		?? runtimeSessionService.activeSessions.find(s =>
+			s.runtimeMetadata.languageId === languageId &&
+			s.metadata.sessionMode === LanguageRuntimeSessionMode.Console,
+		);
+	if (!session) {
+		return { kind: 'no-session', languageName };
+	}
+
+	// Variables instances are created and populated lazily by the Variables
+	// pane. If the pane has never been shown, or is currently hidden, no
+	// instance will exist for this session. In interactive mode, open the pane
+	// (without stealing focus), which triggers instance creation, then retry the
+	// lookup.
+	const findInstance = (): IPositronVariablesInstance | undefined =>
+		variablesService.positronVariablesInstances.find(
+			instance => instance.session.sessionId === session.sessionId,
+		);
+	let variablesInstance = findInstance();
+	if (!variablesInstance && options.openVariablesViewIfNeeded) {
+		await viewsService.openView(POSITRON_VARIABLES_VIEW_ID, false);
+		variablesInstance = findInstance();
+	}
+	if (!variablesInstance) {
+		return { kind: 'variables-unavailable', languageName };
+	}
+
+	// The variable list arrives asynchronously from the runtime, so a
+	// freshly-created instance may not yet have it.
+	const timedOut = options.wait
+		? (await waitForVariables(variablesInstance)).timedOut
+		: false;
+
+	const item = variablesInstance.variableItems.find(v => v.displayName === symbol);
+	if (!item) {
+		// If we timed out waiting for the first variable update, the symbol
+		// might actually be defined but the runtime hasn't reported it yet (e.g.
+		// a long-running chunk that assigns the variable and then keeps
+		// running). The caller can tell the user that rather than flatly
+		// claiming the variable doesn't exist.
+		return { kind: 'not-found', symbol, languageName, timedOut };
+	}
+	if (!item.hasViewer) {
+		return { kind: 'not-viewable', symbol };
+	}
+
+	return { kind: 'ok', sessionId: session.sessionId, item };
+}

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/test/browser/positronDataExplorerCodeActionProvider.vitest.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/test/browser/positronDataExplorerCodeActionProvider.vitest.ts
@@ -1,0 +1,150 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { URI } from '../../../../../base/common/uri.js';
+import { Range } from '../../../../../editor/common/core/range.js';
+import { ITextModel } from '../../../../../editor/common/model.js';
+import { CodeActionContext, CodeActionTriggerType } from '../../../../../editor/common/languages.js';
+import { CodeActionKind } from '../../../../../editor/contrib/codeAction/common/types.js';
+import { ILanguageService } from '../../../../../editor/common/languages/language.js';
+import { LanguageRuntimeSessionMode } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
+import { ILanguageRuntimeSession, IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
+import { IPositronVariablesInstance } from '../../../../services/positronVariables/common/interfaces/positronVariablesInstance.js';
+import { IPositronVariablesService } from '../../../../services/positronVariables/common/interfaces/positronVariablesService.js';
+import { IVariableItem } from '../../../../services/positronVariables/common/interfaces/variableItem.js';
+import { IViewsService } from '../../../../services/views/common/viewsService.js';
+import { Event } from '../../../../../base/common/event.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { PositronDataExplorerCommandId } from '../../browser/positronDataExplorerActions.js';
+import { PositronDataExplorerCodeActionProvider } from '../../browser/positronDataExplorerCodeActionProvider.js';
+
+const SESSION_ID = 'test-session-id';
+
+// Test doubles below use `as unknown as <Service>` because the services have
+// large surface areas we don't exercise. Disabling the rule locally keeps the
+// helpers readable; the trade-off is that a real missing field won't be caught
+// by the compiler -- acceptable for tightly scoped unit tests.
+/* eslint-disable local/code-no-dangerous-type-assertions */
+const makeSession = (languageId: string, sessionId = SESSION_ID): ILanguageRuntimeSession =>
+({
+	sessionId,
+	runtimeMetadata: { languageId },
+	metadata: { sessionMode: LanguageRuntimeSessionMode.Console },
+} as unknown as ILanguageRuntimeSession);
+
+const makeModel = (options: { word?: string; languageIdAtPosition?: string; uri?: URI } = {}): ITextModel => {
+	const { word, languageIdAtPosition = 'r', uri = URI.parse('file:///test.R') } = options;
+	return {
+		uri,
+		getWordAtPosition: vi.fn().mockReturnValue(word ? { word, startColumn: 1, endColumn: word.length + 1 } : null),
+		getLanguageIdAtPosition: () => languageIdAtPosition,
+	} as unknown as ITextModel;
+};
+
+const makeVariableItem = (overrides: Partial<IVariableItem> = {}): IVariableItem =>
+({
+	id: 'item-id',
+	path: [],
+	hasViewer: true,
+	displayName: 'df',
+	view: vi.fn().mockResolvedValue(undefined),
+	...overrides,
+} as unknown as IVariableItem);
+
+const makeVariablesInstance = (items: IVariableItem[], sessionId = SESSION_ID): IPositronVariablesInstance =>
+({
+	session: { sessionId },
+	variableItems: items,
+	onDidChangeEntries: Event.None,
+} as unknown as IPositronVariablesInstance);
+/* eslint-enable local/code-no-dangerous-type-assertions */
+
+describe('PositronDataExplorerCodeActionProvider', () => {
+	let session: ILanguageRuntimeSession | undefined;
+	let variablesInstances: IPositronVariablesInstance[];
+	let openViewStub: ReturnType<typeof vi.fn<(...args: unknown[]) => Promise<unknown>>>;
+
+	const ctx = createTestContainer()
+		.stub(ILanguageService, {
+			getLanguageName: (id: string) => id === 'r' ? 'R' : id === 'python' ? 'Python' : null,
+		})
+		.stub(IRuntimeSessionService, {
+			getConsoleSessionForLanguage: () => session,
+			getNotebookSessionForNotebookUri: () => undefined,
+			get activeSessions() { return []; },
+		})
+		.stub(IPositronVariablesService, {
+			get positronVariablesInstances() { return variablesInstances; },
+		})
+		.stub(IViewsService, {
+			openView: (...args: unknown[]) => openViewStub(...args),
+		})
+		.build();
+
+	beforeEach(() => {
+		session = makeSession('r');
+		variablesInstances = [makeVariablesInstance([makeVariableItem({ displayName: 'df' })])];
+		openViewStub = vi.fn().mockResolvedValue(null);
+	});
+
+	const provide = (model: ITextModel, context?: Partial<CodeActionContext>) => {
+		const provider = ctx.instantiationService.createInstance(PositronDataExplorerCodeActionProvider);
+		return provider.provideCodeActions(
+			model,
+			new Range(1, 1, 1, 1),
+			{ trigger: CodeActionTriggerType.Auto, ...context },
+			// eslint-disable-next-line local/code-no-dangerous-type-assertions -- minimal cancellation token stub
+			{ isCancellationRequested: false, onCancellationRequested: Event.None } as unknown as Parameters<PositronDataExplorerCodeActionProvider['provideCodeActions']>[3],
+		);
+	};
+
+	it('offers "Open in Data Explorer" with the resolved variable command when the symbol is a viewable data frame', async () => {
+		const result = await provide(makeModel({ word: 'df' }));
+
+		expect(result?.actions).toMatchObject([
+			{
+				title: `Open 'df' in Data Explorer`,
+				kind: CodeActionKind.Refactor.value,
+				command: {
+					id: PositronDataExplorerCommandId.ViewDataFrameByVariableAction,
+					arguments: [{ sessionId: SESSION_ID, variableId: 'item-id' }],
+				},
+			},
+		]);
+	});
+
+	it('offers nothing when the symbol is not a known variable', async () => {
+		const result = await provide(makeModel({ word: 'missing' }));
+
+		expect(result).toBeUndefined();
+	});
+
+	it('offers nothing when the symbol exists but is not viewable', async () => {
+		variablesInstances = [makeVariablesInstance([makeVariableItem({ displayName: 'df', hasViewer: false })])];
+
+		const result = await provide(makeModel({ word: 'df' }));
+
+		expect(result).toBeUndefined();
+	});
+
+	it('offers nothing when the request is scoped to an unrelated kind', async () => {
+		const result = await provide(makeModel({ word: 'df' }), { only: CodeActionKind.SourceFixAll.value });
+
+		expect(result).toBeUndefined();
+	});
+
+	it('does not open the Variables view or wait when computing actions (no side effects, no hang)', async () => {
+		// An instance exists but has no variables yet, and its change event never
+		// fires. A waiting resolver would hang; the provider must return promptly.
+		variablesInstances = [makeVariablesInstance([])];
+
+		const result = await provide(makeModel({ word: 'df' }));
+
+		expect(result).toBeUndefined();
+		expect(openViewStub).not.toHaveBeenCalled();
+	});
+});

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/test/browser/viewDataFrameAtCursorAction.vitest.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/test/browser/viewDataFrameAtCursorAction.vitest.ts
@@ -26,6 +26,7 @@ import { createTestContainer } from '../../../../../test/vitest/positronTestCont
 import {
 	PositronDataExplorerCommandId,
 	PositronDataExplorerViewDataFrameAtCursorAction,
+	PositronDataExplorerViewDataFrameByVariableAction,
 } from '../../browser/positronDataExplorerActions.js';
 
 const SESSION_ID = 'test-session-id';
@@ -328,5 +329,52 @@ describe('PositronDataExplorerViewDataFrameAtCursorAction', () => {
 			expect(viewStub).toHaveBeenCalledTimes(1);
 			expect(notificationInfo).not.toHaveBeenCalled();
 		});
+	});
+});
+
+describe('PositronDataExplorerViewDataFrameByVariableAction', () => {
+	let variablesInstances: IPositronVariablesInstance[];
+
+	const ctx = createTestContainer()
+		.stub(IPositronVariablesService, {
+			get positronVariablesInstances() { return variablesInstances; },
+		})
+		.stub(IPositronDataExplorerService, {
+			getInstanceForVar: () => undefined,
+			getInstanceForVariablePath: () => undefined,
+			setInstanceForVar: vi.fn(),
+		})
+		.stub(INotificationService, {
+			info: vi.fn(),
+			error: vi.fn(),
+		})
+		.build();
+
+	beforeEach(() => {
+		variablesInstances = [];
+	});
+
+	const runAction = (args?: { sessionId: string; variableId: string }) => {
+		const action = new PositronDataExplorerViewDataFrameByVariableAction();
+		return ctx.instantiationService.invokeFunction(accessor => action.run(accessor, args));
+	};
+
+	it('opens the viewer for the resolved variable', async () => {
+		const viewStub = vi.fn().mockResolvedValue(undefined);
+		const item = makeVariableItem({ id: 'item-id', view: viewStub as unknown as IVariableItem['view'] });
+		variablesInstances = [makeVariablesInstance([item])];
+
+		await runAction({ sessionId: SESSION_ID, variableId: 'item-id' });
+
+		expect(viewStub).toHaveBeenCalledTimes(1);
+	});
+
+	it('does nothing when the variable no longer exists in the session', async () => {
+		const viewStub = vi.fn().mockResolvedValue(undefined);
+		variablesInstances = [makeVariablesInstance([makeVariableItem({ id: 'other-id', view: viewStub as unknown as IVariableItem['view'] })])];
+
+		await runAction({ sessionId: SESSION_ID, variableId: 'item-id' });
+
+		expect(viewStub).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
Addresses #2974

This PR dds an "Open in Data Explorer" code action (the editor lightbulb / <kbd>Cmd+.</kbd>) that opens the Data Explorer for the data frame under the cursor in R, Python, and Quarto editors. It is the assist-menu counterpart to the "View Data Frame at Cursor" command added in #13098, and a step toward the broader cursor-driven exploration gestures discussed in the issue:

<img width="1454" height="1029" alt="Screenshot_2026-06-29_at_6_10_53 PM" src="https://github.com/user-attachments/assets/6250b8ee-d98a-4bd5-b29a-f1548e390a10" />

The code action is a pretty thin wrapper over the same resolution flow as the command from #13098. This PR extracts that flow (resolving the symbol at the cursor to a viewable variable in the editor's runtime session) into a shared `resolveDataFrameAtPosition` helper, so the command and the code action use the same logic. The provider runs the resolver without waiting on the runtime and without opening the Variables pane, so computing the lightbulb is instant and free of side effects. If the symbol does not already resolve to a viewable data frame, no action is offered. A new argument-taking command (`viewDataFrameByVariable`) opens an already-resolved variable, so the action never has to re-resolve "the active editor cursor".

Quarto works because the resolver keys off the embedded language at the cursor, so the action appears inside R and Python chunks of a `.qmd` file. Notebook cells are covered too, since a cell editor's model language is the cell's language.

<kbd>Cmd+Click</kbd> is intentionally left to a follow-up PR. It conflicts with go-to-definition (both fire independently on <kbd>Cmd+Click</kbd> with no precedence between them), so doing it properly means coordinating with the go-to-definition gesture rather than registering a separate provider. Or maybe we decide to skip it and lean on the code action/assist?

### Release Notes

#### New Features

- Added an "Open in Data Explorer" code action that opens the Data Explorer for the data frame at the editor cursor, available from the editor lightbulb (<kbd>Cmd+.</kbd>) in R, Python, and Quarto files (#2974).

#### Bug Fixes

- N/A

### Validation Steps

@:critical @:data-explorer @:editor @:variables @:quarto

1. In an R file, type `df <- mtcars` and run it so the variable appears in the Variables pane. Place the cursor on `df`, press Cmd+. (or click the lightbulb), and choose "Open 'df' in Data Explorer". The Data Explorer opens for `df`.
2. Run the code action again with the Data Explorer still open. It focuses the existing viewer rather than opening a duplicate.
3. Place the cursor on an identifier that is not a viewable data frame (an undefined symbol, or a function name). No "Open in Data Explorer" action is offered.
4. Repeat step 1 in a Python file with a pandas DataFrame:

   ```python
   import pandas as pd
   df = pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})
   ```

5. Create a `.qmd` file with an R chunk or a Python chunk, run it, then place the cursor on the variable in each chunk and trigger the code action. The Data Explorer opens for the correct variable in each case.
6. Confirm the action does not appear on non-runtime files (e.g. a Markdown or JSON file).
