### PR TITLE
Make package detail view text-selectable

### DIFF
--- a/src/vs/workbench/contrib/positronPackages/browser/components/packageDetail.css
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/packageDetail.css
@@ -8,6 +8,11 @@
 	overflow: auto;
 	height: 100%;
 	box-sizing: border-box;
+	/* The workbench root sets user-select: none (browser/media/style.css). */
+	/* Opt back in so package metadata (version, license, repository URL, */
+	/* etc.) can be selected and copied, matching the extension editor. */
+	user-select: text;
+	-webkit-user-select: text;
 }
 
 .package-detail-header {
@@ -29,6 +34,9 @@
 	font-size: 24px;
 	color: var(--vscode-button-foreground);
 	background: var(--vscode-button-background);
+	/* Decorative, aria-hidden glyph -- keep it out of copied selections. */
+	user-select: none;
+	-webkit-user-select: none;
 }
 
 .package-detail-header-main { flex: 1; min-width: 0; }
@@ -37,7 +45,15 @@
 .package-detail-version { color: var(--vscode-descriptionForeground); font-size: 0.9em; }
 .package-detail-author { color: var(--vscode-descriptionForeground); margin: 2px 0; }
 .package-detail-description { color: var(--vscode-foreground); margin: 2px 0 10px; }
-.package-detail-actions { display: flex; gap: 6px; flex-wrap: wrap; align-items: center; }
+.package-detail-actions {
+	display: flex;
+	gap: 6px;
+	flex-wrap: wrap;
+	align-items: center;
+	/* Buttons are not text content -- don't select their labels on drag. */
+	user-select: none;
+	-webkit-user-select: none;
+}
 
 .package-detail-attached-pill {
 	font-size: 0.8em;


### PR DESCRIPTION
Part of #12926.

Makes the package detail editor's content selectable, so users can highlight and copy package metadata (name, version, license, source repository URL, published date, description). The workbench root disables text selection globally (`user-select: none`); this opts the detail view back in, matching the extension detail editor. The decorative language badge and the action buttons are excluded so copied text stays clean.

CSS-only change.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Allow selecting and copying text in the package detail view (#12926)

### Validation Steps

`@:packages-pane` `@:win`

1. Open a package's detail view (click a package in the Packages pane).
2. Drag-select the description, version, and source repository URL; copy and paste elsewhere to confirm the text is on the clipboard.
3. Confirm the language badge letter ("R" / "Py") and the action button labels are not highlighted when dragging across them.
