### PR TITLE
Pre-install requirements.txt for the alternate Python in e2e CI

### DIFF
--- a/.github/workflows/test-e2e-macos-run.yml
+++ b/.github/workflows/test-e2e-macos-run.yml
@@ -257,7 +257,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
-      - name: Install ipykernel for 3.11.0
+      # Pre-install requirements.txt so in-test installs that resolve against it don't time out.
+      - name: Install requirements and ipykernel for 3.11.0
         run: |
           export PYENV_ROOT="$HOME/.pyenv"
           export PATH="$PYENV_ROOT/bin:$PATH"
@@ -265,6 +266,7 @@ jobs:
           eval "$(pyenv init -)"
           pyenv global 3.11.0
           python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
           python -m pip install ipykernel
           pyenv global 3.10.10
 

--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -335,11 +335,13 @@ jobs:
           python-version: "3.13.0"
 
       # Ensure Python 3.13.0 is used and only install ipykernel
-      - name: Install ipykernel for Python 3.13.0
+      # Pre-install requirements.txt so in-test installs that resolve against it don't time out.
+      - name: Install requirements and ipykernel for Python 3.13.0
         env:
           UV_CACHE_DIR: ${{ runner.temp }}\uv-cache
         run: |
           python --version  # Verify it's 3.13.0
+          uv pip install --system -r requirements.txt
           uv pip install --system ipykernel
 
       # Install rig (R Installation Manager)


### PR DESCRIPTION
Follow-up to #14550.

### Summary

Since #14550, Python package operations resolve against the workspace `requirements.txt` (`pip install <pkg> -r requirements.txt`), which installs every declared package. The Windows and macOS e2e workflows provisioned the **alternate** Python interpreter with only `ipykernel`, while the primary interpreter is provisioned with the full `requirements.txt`. As a result, the `pythonAlt` variant of the packages-pane install/uninstall test triggered a full `requirements.txt` install on a fresh interpreter and hung/timed out (deterministic on Windows; the primary `python`/uv variant passed because its environment was already satisfied).

This provisions the alternate interpreter with `requirements.txt` too (as the primary already is), so the in-test install is a fast no-op.

Note: the Ubuntu e2e job provisions its interpreters from the `positron-ubuntu24-amd64` container image rather than the workflow YAML, so the equivalent change there would need an image rebuild (out of scope here); on Linux this surfaced only as a flake.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:packages-pane @:win

In both a primary and an alternate Python session, open the Packages pane, install a package (e.g. `cowsay`), confirm it appears in the list, then uninstall it and confirm it is removed -- without the alternate-session install timing out.
