### PR TITLE
Don't dispose inline data explorer comm when closing a separate editor tab

### DIFF
--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditorInput.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditorInput.ts
@@ -50,11 +50,18 @@ export class PositronDataExplorerEditorInput extends EditorInput {
 	 * dispose override method.
 	 */
 	override dispose(): void {
-		// Dispose the client when this editor tab closes (sole owner)
+		// Dispose the client when this editor tab closes, but only for explorers
+		// this tab exclusively owns. Inline/embedded explorers (e.g. notebook cell
+		// outputs) share their comm with the embedding view, whose lifetime
+		// outlives this tab; the runtime owns that comm's lifecycle (closed on
+		// cell re-execution or session end). Disposing it here would break the
+		// embedded view -- see issue #13283.
 		const identifier = PositronDataExplorerUri.parse(this.resource);
 		if (identifier) {
 			const instance = this._positronDataExplorerService.getInstance(identifier);
-			instance?.dataExplorerClientInstance.dispose();
+			if (instance && !instance.isInline) {
+				instance.dataExplorerClientInstance.dispose();
+			}
 		} else {
 			this._logService.warn(`PositronDataExplorerEditorInput: failed to parse URI on dispose, client instance may leak: ${this.resource.toString()}`);
 		}

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/test/browser/positronDataExplorerEditorInput.vitest.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/test/browser/positronDataExplorerEditorInput.vitest.ts
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { DataExplorerClientInstance } from '../../../../services/languageRuntime/common/languageRuntimeDataExplorerClient.js';
+import { IPositronDataExplorerInstance } from '../../../../services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance.js';
+import { IPositronDataExplorerService } from '../../../../services/positronDataExplorer/browser/interfaces/positronDataExplorerService.js';
+import { PositronDataExplorerUri } from '../../../../services/positronDataExplorer/common/positronDataExplorerUri.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { PositronDataExplorerEditorInput } from '../../browser/positronDataExplorerEditorInput.js';
+
+describe('PositronDataExplorerEditorInput', () => {
+	// A valid runtime comm id (UUID) so PositronDataExplorerUri.parse round-trips.
+	const commId = '12345678-1234-1234-1234-1234567890ab';
+
+	function makeInput(instance: IPositronDataExplorerInstance | undefined) {
+		const service = stubInterface<IPositronDataExplorerService>({
+			getInstance: () => instance,
+		});
+		return new PositronDataExplorerEditorInput(
+			PositronDataExplorerUri.generate(commId),
+			service,
+			new NullLogService(),
+		);
+	}
+
+	function makeInstance(isInline: boolean) {
+		const dispose = vi.fn();
+		const instance = stubInterface<IPositronDataExplorerInstance>({
+			isInline,
+			dataExplorerClientInstance: stubInterface<DataExplorerClientInstance>({ dispose }),
+		});
+		return { instance, dispose };
+	}
+
+	it('disposes the client when closing an editor-owned (non-inline) explorer', () => {
+		const { instance, dispose } = makeInstance(false);
+
+		makeInput(instance).dispose();
+
+		expect(dispose).toHaveBeenCalledTimes(1);
+	});
+
+	it('does NOT dispose the client when closing an inline/embedded explorer (issue #13283)', () => {
+		const { instance, dispose } = makeInstance(true);
+
+		makeInput(instance).dispose();
+
+		expect(dispose).not.toHaveBeenCalled();
+	});
+
+	it('is a no-op when no instance is registered for the resource', () => {
+		// Disposing with no backing instance must not throw.
+		expect(() => makeInput(undefined).dispose()).not.toThrow();
+	});
+});

--- a/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance.ts
@@ -26,6 +26,13 @@ export interface IPositronDataExplorerInstance extends IDisposable {
 	readonly dataExplorerClientInstance: DataExplorerClientInstance;
 
 	/**
+	 * Gets whether this instance backs an inline/embedded view (e.g. a notebook
+	 * cell output) whose comm is shared and runtime-owned. An editor tab opened
+	 * against such a comm must not dispose it on close.
+	 */
+	readonly isInline: boolean;
+
+	/**
 	 * Gets or sets the layout.
 	 */
 	layout: PositronDataExplorerLayout;

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -149,10 +149,13 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 	 * @param _languageName The language name.
 	 * @param _dataExplorerClientInstance The DataExplorerClientInstance. The data explorer takes
 	 * ownership of the client instance and will dispose it when it is disposed.
+	 * @param _isInline Whether this instance backs an inline/embedded view (e.g. a notebook
+	 * cell output) whose comm is shared and runtime-owned.
 	 */
 	constructor(
 		private readonly _languageName: string,
-		private readonly _dataExplorerClientInstance: DataExplorerClientInstance
+		private readonly _dataExplorerClientInstance: DataExplorerClientInstance,
+		private readonly _isInline: boolean = false
 	) {
 		// Call the base class's constructor.
 		super();
@@ -251,6 +254,17 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 	 */
 	get dataExplorerClientInstance() {
 		return this._dataExplorerClientInstance;
+	}
+
+	/**
+	 * Gets whether this instance backs an inline/embedded view (e.g. a notebook
+	 * cell output). Inline comms are shared with the embedding view, whose
+	 * lifetime outlives any editor tab opened against the same comm; their
+	 * lifecycle is owned by the runtime (closed on cell re-execution or session
+	 * end). An editor tab must not dispose the client for an inline instance.
+	 */
+	get isInline() {
+		return this._isInline;
 	}
 
 	/**

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
@@ -524,8 +524,11 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 		this._register(
 			dataExplorerRuntime.onDidOpenDataExplorerClient(event => {
 				if (event.inlineOnly) {
-					// For inline-only data explorers, register without opening editor
-					this.registerDataExplorerClient(session.runtimeMetadata.languageName, event.client);
+					// For inline-only data explorers, register without opening editor.
+					// Mark as inline so an editor tab later opened against this shared
+					// comm (e.g. via the Variables pane or "Open in Data Explorer") does
+					// not dispose it on close -- see issue #13283.
+					this.registerDataExplorerClient(session.runtimeMetadata.languageName, event.client, true);
 				} else {
 					// Normal behavior: register and open editor
 					this.openEditor(session.runtimeMetadata.languageName, event.client);
@@ -587,10 +590,11 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 	 * Registers a DataExplorerClientInstance so that it is available when the
 	 * PositronDataExplorerEditor is instantiated.
 	 */
-	private registerDataExplorerClient(languageName: string, client: DataExplorerClientInstance) {
+	private registerDataExplorerClient(languageName: string, client: DataExplorerClientInstance, inline: boolean = false) {
 		const instance = this._register(new PositronDataExplorerInstance(
 			languageName,
-			client
+			client,
+			inline
 		));
 
 		// Set the Positron data explorer client instance.

--- a/test/e2e/tests/notebooks-positron/notebook-inline-data-explorer.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-inline-data-explorer.test.ts
@@ -113,13 +113,15 @@ test.describe('Positron Notebooks: Inline Data Explorer', {
 			await editors.verifyTab(/Untitled.*\.ipynb/, { isVisible: true, isSelected: true });
 		});
 
-		await test.step('Verify inline data explorer still visible after returning', async () => {
+		await test.step('Verify inline data explorer still shows data after returning (issue #13283)', async () => {
 			await inlineDataExplorer.expectToBeVisible();
-			// The inline view may show the grid (if the comm survived) or a
-			// disconnected/stale state (if the comm was disposed while the
-			// notebook tab was inactive). Either is acceptable -- the key
-			// assertion is that no error is shown and the container is intact.
+			// Closing the shared full Data Explorer tab must NOT tear down the
+			// embedded view's comm. The grid should reconnect and show data --
+			// not the "Data unavailable" disconnected state.
 			await inlineDataExplorer.expectNoError();
+			await expect(inlineDataExplorer.disconnectedState).not.toBeVisible();
+			await inlineDataExplorer.expectGridToBeReady();
+			await inlineDataExplorer.expectCellValue('Name', 0, 'Alice');
 		});
 	});
 


### PR DESCRIPTION
## Summary

Embedded/inline data explorers in notebook cell outputs share their runtime comm with the embedding view. When a separate Data Explorer **editor tab** was opened against that same comm (via the Variables pane or the inline "Open in Data Explorer" button, both of which reuse the existing instance), **closing that tab disposed the shared client**, breaking the still-open embedded view with a "Data unavailable. Re-run cell to view." message.

## Root cause

`PositronDataExplorerEditorInput.dispose()` unconditionally disposed the underlying `DataExplorerClientInstance` on tab close, assuming the tab was the sole owner. For inline-only explorers that comm is shared and is owned by the runtime (closed on cell re-execution or session end), so tearing it down on tab close orphaned the embedded view.

## Fix

- Tag instances created for inline display with a new `isInline` flag on `IPositronDataExplorerInstance` / `PositronDataExplorerInstance`.
- `registerDataExplorerClient` marks inline-only registrations as inline.
- `PositronDataExplorerEditorInput.dispose()` skips client disposal for inline instances; the runtime owns that comm's lifecycle. Standalone, DuckDB, and extension-backend explorers still dispose their client on tab close as before.

## Tests

- New unit test `positronDataExplorerEditorInput.vitest.ts`: disposes the client for editor-owned (non-inline) explorers, does NOT dispose for inline/embedded explorers, and is a no-op when no instance is registered.
- Tightened the e2e test `notebook-inline-data-explorer.test.ts` ("open full Data Explorer and return to inline view") to assert the embedded view still shows data (no disconnected/"Data unavailable" state) after the separate tab is closed.

## Notes

This issue was originally filed as an investigation; the root cause was proven and the fix is small and self-contained, so it is included here. The full e2e suite runs in CI.

Fixes #13283
