### PR TITLE
feat(wb-local): full-history pwb logs + Connect license mount guard

### DIFF
--- a/dockerfiles/workbench-local.sh
+++ b/dockerfiles/workbench-local.sh
@@ -492,9 +492,16 @@ cmd_status() {
 
 cmd_logs() {
 	wb_require_stack
-	case "${1:-rserver}" in
-		rserver|workbench) docker exec test bash -c 'tail -n 100 -f /var/log/rstudio/rstudio-server/rserver.log' ;;
-		connect)           docker logs -f connect ;;
+	# Default to the full interleaved history of every service and follow live
+	# (parity with the old `docker compose up` foreground view): Ctrl-C to stop,
+	# then scroll back over the whole run. Name a service for just that one.
+	# rserver logs to a file inside the test container (the container's own
+	# docker log is only the keepalive loop), so tail that file from the top
+	# (-n +1) for its full history rather than docker logs.
+	case "${1:-all}" in
+		all)               wb_compose logs -f ;;
+		rserver|workbench) docker exec test bash -c 'tail -n +1 -f /var/log/rstudio/rstudio-server/rserver.log' ;;
+		connect|postgres)  wb_compose logs -f "${1}" ;;
 		*)                 docker logs -f "${1}" ;;
 	esac
 }
@@ -521,7 +528,8 @@ USAGE
                              or azure (set the provider's vars in .env first).
   npm run pwb -- --ttl N      Set the auto-stop to N minutes (--no-ttl to disable).
   npm run pwb -- status       Containers, installed Positron + Workbench versions, URLs.
-  npm run pwb -- logs [svc]   Tail logs: rserver (default), connect, or a container name.
+  npm run pwb -- logs [svc]   Follow full history of all services (default), or one:
+                             rserver, connect, postgres. Ctrl-C to stop, then scroll back.
   npm run pwb -- shell [svc]  Open a shell in the container: test (default), postgres, connect.
   npm run pwb -- stop         Pause the stack (containers stopped, volumes kept).
   npm run pwb -- down         Tear the stack down (removes containers and volumes).

--- a/dockerfiles/workbench-local.sh
+++ b/dockerfiles/workbench-local.sh
@@ -385,6 +385,15 @@ cmd_up() {
 		printf '\nCONNECT_BOOTSTRAP_SECRETKEY="%s"\n' "$CONNECT_BOOTSTRAP_SECRETKEY" >> "${SCRIPT_DIR}/.env"
 	fi
 	mkdir -p "${SCRIPT_DIR}/connect"
+	# A prior run without a license lets Compose's bind-mount auto-create
+	# connect/connect.lic as a *directory* on the host. That then makes connect
+	# fail to start ("cannot mount directory onto file") and makes the cp below
+	# land the license file *inside* the directory -- a confusing crash that
+	# persists even after the license is added. Clear that stale mount artifact
+	# so the copy creates a real file.
+	if [ -d "${SCRIPT_DIR}/connect/connect.lic" ]; then
+		rm -rf "${SCRIPT_DIR}/connect/connect.lic"
+	fi
 	if [ -f "${SCRIPT_DIR}/connect.lic" ]; then
 		cp "${SCRIPT_DIR}/connect.lic" "${SCRIPT_DIR}/connect/connect.lic"
 	fi


### PR DESCRIPTION
### Summary
Two pwb robustness fixes in `workbench-local.sh`.

Full-history logs:
- `logs` (no arg) now follows the full interleaved history of all services (`docker compose logs -f`) instead of `tail -n 100` of rserver only, matching the old `docker compose up` foreground experience
- Drops the 100-line cap, so `logs rserver` shows the entire rserver.log
- Adds `postgres` as a named target

Connect license mount guard:
- A run without a license let Compose auto-create `connect/connect.lic` as a directory, which then crashed connect ("cannot mount directory onto file") on every later run, even after the license was added
- Now clears that stale directory before the license copy so it is recreated as a real file (self-heals)

### QA Notes
<img width="572" height="513" alt="Screenshot 2026-06-30 at 10 37 00 AM" src="https://github.com/user-attachments/assets/8acdd8f1-50bf-4826-ba7d-a539a9973b13" />
