### PR TITLE
e2e: fix locators for renamed notebook action bar buttons

### DIFF
--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -23,7 +23,7 @@ const DRAG_ACTIVATION_DISTANCE_PX = 10;
 const MARKDOWN_ARIA_LABEL = 'Markdown cell - Press Enter to edit';
 
 type MoreActionsMenuItems = 'Copy cell' | 'Cut cell' | 'Paste Cell Above' | 'Paste cell below' | 'Move cell down' | 'Move cell up' | 'Insert code cell above' | 'Insert code cell below';
-type EditorActionBarButtons = 'Markdown' | 'Code' | 'Clear Outputs' | 'Run All';
+type EditorActionBarButtons = 'Markdown' | 'Code' | 'Clear All Outputs' | 'Run All Cells';
 type OutputActionBarButtons = 'Collapse Output' | 'Expand Output' | 'Clear Output' | 'Show Full Output' | 'Truncate Output' | 'Copy Image';
 
 /**
@@ -2211,10 +2211,10 @@ export class ScopedNotebook {
 		this.kernel = new ScopedKernel(statusBadge, this.editorActionBar, contextMenu);
 
 		// Action bar buttons
-		this.runAllButton = this.editorActionBar.getByRole('button', { name: 'Run All' });
+		this.runAllButton = this.editorActionBar.getByRole('button', { name: 'Run All Cells' });
 		this.addCodeButton = this.editorActionBar.getByRole('button', { name: 'Code' });
 		this.addMarkdownButton = this.editorActionBar.getByRole('button', { name: 'Markdown' });
-		this.clearOutputsButton = this.editorActionBar.getByRole('button', { name: 'Clear Outputs' });
+		this.clearOutputsButton = this.editorActionBar.getByRole('button', { name: 'Clear All Outputs' });
 	}
 
 	/** Get a specific cell by index */

--- a/test/e2e/tests/plots/matplotlib-interact.test.ts
+++ b/test/e2e/tests/plots/matplotlib-interact.test.ts
@@ -23,7 +23,7 @@ test.describe('Matplotlib Interact', { tag: [tags.PLOTS, tags.POSITRON_NOTEBOOKS
 
 		await hotKeys.closeSecondarySidebar();
 
-		await notebooksPositron.clickActionBarButtton('Run All');
+		await notebooksPositron.clickActionBarButtton('Run All Cells');
 		await notebooksPositron.expectNoActiveSpinners(30000);
 		await hotKeys.toggleBottomPanel();
 


### PR DESCRIPTION
### Summary
Updates Positron notebook e2e locators after #14509 renamed the editor action bar buttons which caused 2 test failures on `main`: `matplotlib-interact` and `notebook-side-by-side`. Updated notebook POM:

- `Run All` -> `Run All Cells`
- `Clear Outputs` -> `Clear All Outputs`

### QA Notes
@:plots @positron-notebooks