### PR TITLE
Treat empty pip/uv freeze output as an empty environment

### DIFF
--- a/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
@@ -296,8 +296,13 @@ export class PipPackageManager implements IPackageManager {
         // FORCE_COLOR/CLICOLOR_FORCE could lead to ANSI codes that would corrupt
         // the requirements file fed to `pip install -r` (as uv does -- see #14328).
         const result = await pythonService.execModule('pip', ['freeze', '--no-color'], { token });
-        if (!result.stdout || result.stdout.trim() === '') {
-            throw new Error('Failed to read the installed package list (pip freeze returned no output).');
+        // Empty output is a valid empty environment, not a failure: `pip freeze`
+        // excludes pip/setuptools/wheel by default, so a fresh env with no
+        // user-installed packages prints nothing. Real failures (missing pip,
+        // spawn errors) throw upstream in execModule, and a broken resolver
+        // surfaces at the actual `install` step.
+        if (!result.stdout) {
+            return [];
         }
         return result.stdout.split(/\r?\n/).filter((line) => line.trim() !== '');
     }

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -330,8 +330,13 @@ export class UvPackageManager implements IPackageManager {
                 token,
             },
         );
-        if (!result.stdout || result.stdout.trim() === '') {
-            throw new Error('Failed to read the installed package list (uv pip freeze returned no output).');
+        // Empty output is a valid empty environment, not a failure: `uv pip
+        // freeze` excludes pip/setuptools/wheel by default, so a fresh env with
+        // no user-installed packages prints nothing. Real failures (spawn
+        // errors) reject upstream, and a broken resolver surfaces at the actual
+        // `install` step.
+        if (!result.stdout) {
+            return [];
         }
         return result.stdout.split(/\r?\n/).filter((line) => line.trim() !== '');
     }

--- a/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
@@ -178,6 +178,21 @@ suite('PipPackageManager update Tests', () => {
         expect(writtenContent).to.not.contain('cowsay==');
     });
 
+    test('installPackages proceeds on an empty environment (freeze returns nothing)', async () => {
+        // A fresh env (e.g. newly created via pyenv) has no user packages, so
+        // `pip freeze` prints nothing. The install must still proceed with only
+        // the target, not fail with "returned no output".
+        pythonService.execModule
+            .withArgs('pip', sinon.match.array.startsWith(['freeze']))
+            .resolves({ stdout: '', stderr: '' });
+
+        await manager.installPackages([{ name: 'cowsay', version: '6.1' }]);
+
+        expect(writtenContent).to.equal('cowsay==6.1\n');
+        const [, args] = terminalService.sendCommand.firstCall.args;
+        expect(args).to.include.members(['install', '-r', '/tmp/reqs.txt']);
+    });
+
     test('installPackages propagates a resolver failure (no silent success)', async () => {
         terminalService.sendCommand.rejects(new Error('Command failed with errors'));
 

--- a/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
@@ -360,6 +360,21 @@ version = "0.1.0"`;
             expect(args).to.include.members(['pip', 'install', '-r', '/tmp/reqs.txt', '--python', '/path/to/python']);
             expect(args).to.not.include('--upgrade');
         });
+
+        test('installPackages proceeds on an empty environment (freeze returns nothing)', async () => {
+            // A fresh env (e.g. newly created via pyenv) has no user packages, so
+            // `uv pip freeze` prints nothing. The install must still proceed with
+            // only the target, not fail with "returned no output".
+            processService.exec
+                .withArgs('uv', sinon.match.array.startsWith(['pip', 'freeze']))
+                .resolves({ stdout: '', stderr: '' });
+
+            await uvPackageManager.installPackages([{ name: 'cowsay', version: '6.1' }]);
+
+            expect((fileSystem as any).getWritten()).to.equal('cowsay==6.1\n');
+            const [, args] = terminalService.sendCommand.firstCall.args;
+            expect(args).to.include.members(['pip', 'install', '-r', '/tmp/reqs.txt', '--python', '/path/to/python']);
+        });
     });
 
     suite('Environment-workflow with requirements.txt', () => {


### PR DESCRIPTION
`pip freeze` and `uv pip freeze` exclude `pip`/`setuptools`/`wheel` by default, so a fresh Python environment with no user-installed packages prints empty output (with exit code 0). The pre-install freeze step added in #14328 treated this empty-but-successful result as a fatal error and showed the notification "Failed to read the installed package list (pip freeze returned no output)", which blocked installing the very first package into a clean environment (e.g. a newly created pyenv Python).

This changes `_getInstalledFreeze()` in both the pip and uv package managers to return an empty set instead of throwing. The install then proceeds with only the target package, routed through the same constraint pipeline (`buildRequirementsFile([], [target])` -> `cowsay`). Real failures are unaffected: a missing pip still throws `ModuleNotInstalledError`, spawn errors still reject, and a broken resolver surfaces its real message at the actual `install` step.

Regression introduced by #14328 / #14550

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed installing the first package into a fresh Python environment failing with "Failed to read the installed package list (pip freeze returned no output)".

### Validation Steps

@:packages-pane

I was able to reproduce the original issue locally after doing `pyenv install 3.12.12`

1. Create a fresh Python environment with no user packages (e.g. `pyenv install 3.12.12`). Confirm `pip freeze` prints nothing.
2. Open the Packages pane and install a package (e.g. `cowsay`).
3. Verify the install succeeds instead of showing the "Failed to read the installed package list" notification.
4. Repeat with a `uv`-managed environment to cover the uv package manager path.