### PR TITLE
Notebooks: single notebook.ai.enabled switch for all notebook AI features

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/AskAssistantAction.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/AskAssistantAction.tsx
@@ -18,6 +18,7 @@ import { IHeadlessLanguageModelService } from '../../../services/positronHeadles
 import { POSITRON_NOTEBOOK_EDITOR_ID } from '../common/positronNotebookCommon.js';
 import { AI_ENABLED_KEY } from '../../positronAssistant/common/positronAIConfiguration.js';
 import { openPositAssistantChat } from '../../positronAssistant/browser/positAssistantChat.js';
+import { NOTEBOOK_AI_ENABLED_KEY } from '../common/positronNotebookConfig.js';
 import { PositronModalDialogReactRenderer } from '../../../../base/browser/positronModalDialogReactRenderer.js';
 import { AssistantPanel } from './AssistantPanel/AssistantPanel.js';
 import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
@@ -42,9 +43,13 @@ export class AskAssistantAction extends Action2 {
 			tooltip: localize2('askAssistant.tooltip', 'Ask the assistant about this notebook'),
 			icon: ThemeIcon.fromId('positron-assistant'),
 			f1: true,
-			// Gate the command palette entry and command execution on the AI main switch.
+			// Gate the command palette entry and command execution on the AI switches:
+			// the global `ai.enabled` and the notebooks-only `notebook.ai.enabled`.
 			// The menu `when` below hides the toolbar button; precondition covers the rest.
-			precondition: ContextKeyExpr.has(`config.${AI_ENABLED_KEY}`),
+			precondition: ContextKeyExpr.and(
+				ContextKeyExpr.has(`config.${AI_ENABLED_KEY}`),
+				ContextKeyExpr.has(`config.${NOTEBOOK_AI_ENABLED_KEY}`),
+			),
 			category: localize2('positronNotebook.category', 'Notebook'),
 			positronActionBarOptions: {
 				controlType: 'button',
@@ -57,6 +62,7 @@ export class AskAssistantAction extends Action2 {
 				when: ContextKeyExpr.and(
 					ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
 					ContextKeyExpr.has(`config.${AI_ENABLED_KEY}`),
+					ContextKeyExpr.has(`config.${NOTEBOOK_AI_ENABLED_KEY}`),
 				)
 			}
 		});

--- a/src/vs/workbench/contrib/positronNotebook/browser/AskAssistantAction.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/AskAssistantAction.tsx
@@ -16,9 +16,8 @@ import { IChatEditingService } from '../../chat/common/editing/chatEditingServic
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IHeadlessLanguageModelService } from '../../../services/positronHeadlessLanguageModel/common/headlessLanguageModelService.js';
 import { POSITRON_NOTEBOOK_EDITOR_ID } from '../common/positronNotebookCommon.js';
-import { AI_ENABLED_KEY } from '../../positronAssistant/common/positronAIConfiguration.js';
 import { openPositAssistantChat } from '../../positronAssistant/browser/positAssistantChat.js';
-import { NOTEBOOK_AI_ENABLED_KEY } from '../common/positronNotebookConfig.js';
+import { NotebookContextKeys } from '../common/notebookContextKeys.js';
 import { PositronModalDialogReactRenderer } from '../../../../base/browser/positronModalDialogReactRenderer.js';
 import { AssistantPanel } from './AssistantPanel/AssistantPanel.js';
 import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
@@ -43,13 +42,11 @@ export class AskAssistantAction extends Action2 {
 			tooltip: localize2('askAssistant.tooltip', 'Ask the assistant about this notebook'),
 			icon: ThemeIcon.fromId('positron-assistant'),
 			f1: true,
-			// Gate the command palette entry and command execution on the AI switches:
-			// the global `ai.enabled` and the notebooks-only `notebook.ai.enabled`.
+			// Gate the command palette entry and command execution on the composite
+			// notebook AI switch (global `ai.enabled` AND notebooks-only
+			// `notebook.ai.enabled`, kept in sync by bindNotebookAIEnabledContextKey).
 			// The menu `when` below hides the toolbar button; precondition covers the rest.
-			precondition: ContextKeyExpr.and(
-				ContextKeyExpr.has(`config.${AI_ENABLED_KEY}`),
-				ContextKeyExpr.has(`config.${NOTEBOOK_AI_ENABLED_KEY}`),
-			),
+			precondition: NotebookContextKeys.aiEnabled,
 			category: localize2('positronNotebook.category', 'Notebook'),
 			positronActionBarOptions: {
 				controlType: 'button',
@@ -61,8 +58,7 @@ export class AskAssistantAction extends Action2 {
 				order: 50,
 				when: ContextKeyExpr.and(
 					ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
-					ContextKeyExpr.has(`config.${AI_ENABLED_KEY}`),
-					ContextKeyExpr.has(`config.${NOTEBOOK_AI_ENABLED_KEY}`),
+					NotebookContextKeys.aiEnabled,
 				)
 			}
 		});

--- a/src/vs/workbench/contrib/positronNotebook/browser/AssistantPanel/AssistantPanelActions.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/AssistantPanel/AssistantPanelActions.tsx
@@ -17,6 +17,7 @@ import { isCancellationError } from '../../../../../base/common/errors.js';
 import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
 import { isFileExcludedFromAI } from '../../../chat/browser/tools/utils.js';
 import { AI_ENABLED_KEY } from '../../../positronAssistant/common/positronAIConfiguration.js';
+import { NOTEBOOK_AI_ENABLED_KEY } from '../../common/positronNotebookConfig.js';
 import { IHeadlessLanguageModelService } from '../../../../services/positronHeadlessLanguageModel/common/headlessLanguageModelService.js';
 import { INotebookContextDTO } from '../../../../common/positron/notebookAssistant.js';
 import { generateNotebookSuggestions, INotebookSuggestion } from './notebookSuggestions.js';
@@ -144,7 +145,9 @@ export const AssistantPanelActions = (props: AssistantPanelActionsProps) => {
 		// configured: never send a notebook to a model when AI is disabled or
 		// the file is excluded. Read live, since `ai.enabled` toggles without a
 		// window reload.
-		const aiEnabled = configurationService.getValue<boolean>(AI_ENABLED_KEY) === true;
+		// notebook.ai.enabled defaults to true, so only an explicit `false` disables.
+		const aiEnabled = configurationService.getValue<boolean>(AI_ENABLED_KEY) === true
+			&& configurationService.getValue<boolean>(NOTEBOOK_AI_ENABLED_KEY) !== false;
 		if (!notebookContext || !aiEnabled || isFileExcludedFromAI(configurationService, notebook.uri.path)) {
 			notifyNoSuggestions();
 			return;

--- a/src/vs/workbench/contrib/positronNotebook/browser/AssistantPanel/AssistantPanelActions.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/AssistantPanel/AssistantPanelActions.tsx
@@ -15,9 +15,9 @@ import { ChatModeKind } from '../../../chat/common/constants.js';
 import { CancellationTokenSource } from '../../../../../base/common/cancellation.js';
 import { isCancellationError } from '../../../../../base/common/errors.js';
 import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
+import { useContextKey } from '../../../../../base/browser/positronReactHooks.js';
 import { isFileExcludedFromAI } from '../../../chat/browser/tools/utils.js';
-import { AI_ENABLED_KEY } from '../../../positronAssistant/common/positronAIConfiguration.js';
-import { NOTEBOOK_AI_ENABLED_KEY } from '../../common/positronNotebookConfig.js';
+import { NotebookContextKeys } from '../../common/notebookContextKeys.js';
 import { IHeadlessLanguageModelService } from '../../../../services/positronHeadlessLanguageModel/common/headlessLanguageModelService.js';
 import { INotebookContextDTO } from '../../../../common/positron/notebookAssistant.js';
 import { generateNotebookSuggestions, INotebookSuggestion } from './notebookSuggestions.js';
@@ -95,6 +95,11 @@ export interface AssistantPanelActionsProps {
 export const AssistantPanelActions = (props: AssistantPanelActionsProps) => {
 	const { notebook, configurationService, headlessLmService, notebookContext, notificationService, onActionSelected } = props;
 
+	// Composite notebook AI gate (global ai.enabled AND notebook.ai.enabled), kept
+	// in sync by bindNotebookAIEnabledContextKey. Read reactively so toggling it
+	// without a window reload updates the gate. undefined reads as enabled.
+	const notebookAiEnabled = useContextKey<boolean>(NotebookContextKeys.aiEnabled);
+
 	const [customPrompt, setCustomPrompt] = useState('');
 	const [isGenerating, setIsGenerating] = useState(false);
 	const [aiSuggestions, setAiSuggestions] = useState<INotebookSuggestion[]>([]);
@@ -141,13 +146,11 @@ export const AssistantPanelActions = (props: AssistantPanelActionsProps) => {
 			)
 		);
 
-		// Honor the AI main switch and the per-file exclusion the user
-		// configured: never send a notebook to a model when AI is disabled or
-		// the file is excluded. Read live, since `ai.enabled` toggles without a
-		// window reload.
-		// notebook.ai.enabled defaults to true, so only an explicit `false` disables.
-		const aiEnabled = configurationService.getValue<boolean>(AI_ENABLED_KEY) === true
-			&& configurationService.getValue<boolean>(NOTEBOOK_AI_ENABLED_KEY) !== false;
+		// Honor the composite notebook AI gate and the per-file exclusion the user
+		// configured: never send a notebook to a model when AI is disabled or the
+		// file is excluded. notebookAiEnabled defaults to enabled, so only an
+		// explicit disable (either AI switch off) blocks generation.
+		const aiEnabled = notebookAiEnabled !== false;
 		if (!notebookContext || !aiEnabled || isFileExcludedFromAI(configurationService, notebook.uri.path)) {
 			notifyNoSuggestions();
 			return;
@@ -208,7 +211,7 @@ export const AssistantPanelActions = (props: AssistantPanelActionsProps) => {
 			setIsGenerating(false);
 			cancellationTokenSourceRef.current = null;
 		}
-	}, [isGenerating, notebook, notebookContext, configurationService, headlessLmService, notificationService]);
+	}, [isGenerating, notebook, notebookContext, notebookAiEnabled, configurationService, headlessLmService, notificationService]);
 
 	const handleActionClick = useCallback((action: PredefinedAction) => {
 		onActionSelected(action.query, action.mode);

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/ghostCell/controller.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/ghostCell/controller.ts
@@ -18,6 +18,7 @@ import { CellEditType } from '../../../../notebook/common/notebookCommon.js';
 import { CellKind as PositronCellKind } from '../../PositronNotebookCells/IPositronNotebookCell.js';
 import { getAssistantSettings, setAssistantSettings } from '../../../common/notebookAssistantMetadata.js';
 import { AI_ENABLED_KEY } from '../../../../positronAssistant/common/positronAIConfiguration.js';
+import { NOTEBOOK_AI_ENABLED_KEY } from '../../../common/positronNotebookConfig.js';
 import {
 	POSITRON_NOTEBOOK_GHOST_CELL_SUGGESTIONS_KEY,
 	POSITRON_NOTEBOOK_GHOST_CELL_DELAY_KEY,
@@ -670,19 +671,22 @@ export class GhostCellController extends Disposable implements IPositronNotebook
 	// ===== Private Helpers =====
 
 	/**
-	 * Main switch for Positron's AI features. Ghost cell suggestions only work
-	 * when AI is enabled.
+	 * Whether AI is enabled for notebooks. Both switches must be on: the global
+	 * `ai.enabled` and the notebooks-only `notebook.ai.enabled`. The latter
+	 * defaults to true, so only an explicit `false` disables notebook AI.
+	 * Ghost cell suggestions only work when notebook AI is enabled.
 	 */
-	private _isAIEnabled(): boolean {
-		return this._configurationService.getValue<boolean>(AI_ENABLED_KEY) === true;
+	private _isNotebookAIEnabled(): boolean {
+		return this._configurationService.getValue<boolean>(AI_ENABLED_KEY) === true
+			&& this._configurationService.getValue<boolean>(NOTEBOOK_AI_ENABLED_KEY) !== false;
 	}
 
 	/**
 	 * Check if ghost cell suggestions are enabled for this notebook.
 	 */
 	private _isGhostCellEnabled(): boolean {
-		// Gated on the AI main switch.
-		if (!this._isAIEnabled()) {
+		// Gated on the AI switches (global + notebooks).
+		if (!this._isNotebookAIEnabled()) {
 			return false;
 		}
 
@@ -723,8 +727,8 @@ export class GhostCellController extends Disposable implements IPositronNotebook
 	 * Returns true if: user hasn't explicitly set enabled, no per-notebook override, and not dismissed this open.
 	 */
 	private _shouldShowOptInPrompt(): boolean {
-		// Don't prompt to opt in when AI is disabled.
-		if (!this._isAIEnabled()) {
+		// Don't prompt to opt in when AI is disabled (global or notebooks).
+		if (!this._isNotebookAIEnabled()) {
 			return false;
 		}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/ghostCell/controller.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/ghostCell/controller.ts
@@ -9,7 +9,7 @@ import { CancellationTokenSource } from '../../../../../../base/common/cancellat
 import { ConfigurationTarget, IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { ILogService } from '../../../../../../platform/log/common/log.js';
 import { INotificationService, Severity } from '../../../../../../platform/notification/common/notification.js';
-import { RawContextKey, IContextKey } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { RawContextKey, IContextKey, IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { localize } from '../../../../../../nls.js';
 import { IPositronNotebookContribution } from '../../positronNotebookExtensions.js';
 import { IPositronNotebookInstance } from '../../IPositronNotebookInstance.js';
@@ -17,8 +17,7 @@ import { INotebookExecutionStateService, NotebookExecutionType } from '../../../
 import { CellEditType } from '../../../../notebook/common/notebookCommon.js';
 import { CellKind as PositronCellKind } from '../../PositronNotebookCells/IPositronNotebookCell.js';
 import { getAssistantSettings, setAssistantSettings } from '../../../common/notebookAssistantMetadata.js';
-import { AI_ENABLED_KEY } from '../../../../positronAssistant/common/positronAIConfiguration.js';
-import { NOTEBOOK_AI_ENABLED_KEY } from '../../../common/positronNotebookConfig.js';
+import { NotebookContextKeys } from '../../../common/notebookContextKeys.js';
 import {
 	POSITRON_NOTEBOOK_GHOST_CELL_SUGGESTIONS_KEY,
 	POSITRON_NOTEBOOK_GHOST_CELL_DELAY_KEY,
@@ -91,6 +90,7 @@ export class GhostCellController extends Disposable implements IPositronNotebook
 		@ILogService private readonly _logService: ILogService,
 		@IHeadlessLanguageModelService private readonly _headlessLmService: IHeadlessLanguageModelService,
 		@IPositronVariablesService private readonly _variablesService: IPositronVariablesService,
+		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
 	) {
 		super();
 
@@ -671,14 +671,14 @@ export class GhostCellController extends Disposable implements IPositronNotebook
 	// ===== Private Helpers =====
 
 	/**
-	 * Whether AI is enabled for notebooks. Both switches must be on: the global
-	 * `ai.enabled` and the notebooks-only `notebook.ai.enabled`. The latter
-	 * defaults to true, so only an explicit `false` disables notebook AI.
-	 * Ghost cell suggestions only work when notebook AI is enabled.
+	 * Whether AI is enabled for notebooks, read from the composite
+	 * `positronNotebook.aiEnabled` context key (the global `ai.enabled` AND the
+	 * notebooks-only `notebook.ai.enabled`, kept in sync by
+	 * bindNotebookAIEnabledContextKey). Defaults to enabled when unset, so only an
+	 * explicit disable blocks ghost cell suggestions.
 	 */
 	private _isNotebookAIEnabled(): boolean {
-		return this._configurationService.getValue<boolean>(AI_ENABLED_KEY) === true
-			&& this._configurationService.getValue<boolean>(NOTEBOOK_AI_ENABLED_KEY) !== false;
+		return NotebookContextKeys.aiEnabled.getValue(this._contextKeyService) !== false;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/ghostCell/test/controller.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/ghostCell/test/controller.vitest.ts
@@ -17,6 +17,7 @@ import { stubInterface } from '../../../../../../../test/vitest/stubInterface.js
 import { INotebookExecutionStateService } from '../../../../../notebook/common/notebookExecutionStateService.js';
 import { NotebookTextModel } from '../../../../../notebook/common/model/notebookTextModel.js';
 import { AI_ENABLED_KEY } from '../../../../../positronAssistant/common/positronAIConfiguration.js';
+import { NOTEBOOK_AI_ENABLED_KEY } from '../../../../common/positronNotebookConfig.js';
 import { IPositronNotebookCell, IPositronNotebookCodeCell } from '../../../PositronNotebookCells/IPositronNotebookCell.js';
 import { IPositronNotebookInstance } from '../../../IPositronNotebookInstance.js';
 import { GhostCellController } from '../controller.js';
@@ -69,6 +70,84 @@ describe('GhostCellController ai.enabled gate', () => {
 		controller.triggerGhostCellSuggestion(0);
 
 		expect(controller.ghostCellState.get().status).toBe('loading');
+		controller.dispose();
+	});
+});
+
+describe('GhostCellController notebook.ai.enabled gate', () => {
+	const config = new TestConfigurationService();
+	const ctx = createTestContainer()
+		.stub(IConfigurationService, config)
+		.stub(INotebookExecutionStateService, stubInterface<INotebookExecutionStateService>({ onDidChangeExecution: Event.None }))
+		.stub(INotificationService, stubInterface<INotificationService>())
+		.stub(ILogService, new NullLogService())
+		.build();
+
+	// The per-notebook override turns ghost cells ON, so the two AI switches are
+	// the only variables. notebook.ai.enabled (default true) sits below ai.enabled
+	// and above the feature's own gates: a suggestion goes through only when BOTH
+	// switches are on. Disabling either keeps the controller hidden.
+	function createController(): GhostCellController {
+		const mockCell = stubInterface<IPositronNotebookCell>({
+			isCodeCell: function (this: IPositronNotebookCell): this is IPositronNotebookCodeCell { return true; },
+			getContent: () => '',
+			outputs: observableValue('outputs', []),
+		});
+		const notebook = stubInterface<IPositronNotebookInstance>({
+			uri: URI.parse('file:///test.ipynb'),
+			cells: observableValue('cells', [mockCell]),
+			container: observableValue<HTMLElement | undefined>('container', undefined),
+			runtimeSession: observableValue('runtimeSession', undefined),
+			textModel: stubInterface<NotebookTextModel>({
+				metadata: { metadata: { positron: { assistant: { ghostCellSuggestions: 'enabled' } } } },
+				cells: undefined,
+			}),
+		});
+		return ctx.instantiationService.createInstance(GhostCellController, notebook);
+	}
+
+	it('stays hidden when notebook.ai.enabled is false, even with ai.enabled on and the per-notebook override on', () => {
+		config.setUserConfiguration(AI_ENABLED_KEY, true);
+		config.setUserConfiguration(NOTEBOOK_AI_ENABLED_KEY, false);
+		const controller = createController();
+
+		controller.triggerGhostCellSuggestion(0);
+
+		expect(controller.ghostCellState.get().status).toBe('hidden');
+		controller.dispose();
+	});
+
+	it('lets the suggestion through when ai.enabled and notebook.ai.enabled are both true', () => {
+		config.setUserConfiguration(AI_ENABLED_KEY, true);
+		config.setUserConfiguration(NOTEBOOK_AI_ENABLED_KEY, true);
+		const controller = createController();
+
+		controller.triggerGhostCellSuggestion(0);
+
+		expect(controller.ghostCellState.get().status).toBe('loading');
+		controller.dispose();
+	});
+
+	it('lets the suggestion through when ai.enabled is true and notebook.ai.enabled is unset (defaults to enabled)', () => {
+		// notebook.ai.enabled defaults to true, so an unset value must not disable
+		// notebook AI; only an explicit `false` does.
+		config.setUserConfiguration(AI_ENABLED_KEY, true);
+		const controller = createController();
+
+		controller.triggerGhostCellSuggestion(0);
+
+		expect(controller.ghostCellState.get().status).toBe('loading');
+		controller.dispose();
+	});
+
+	it('stays hidden when ai.enabled is false even if notebook.ai.enabled is true (global switch wins)', () => {
+		config.setUserConfiguration(AI_ENABLED_KEY, false);
+		config.setUserConfiguration(NOTEBOOK_AI_ENABLED_KEY, true);
+		const controller = createController();
+
+		controller.triggerGhostCellSuggestion(0);
+
+		expect(controller.ghostCellState.get().status).toBe('hidden');
 		controller.dispose();
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/ghostCell/test/controller.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/ghostCell/test/controller.vitest.ts
@@ -10,30 +10,36 @@ import { observableValue } from '../../../../../../../base/common/observable.js'
 import { URI } from '../../../../../../../base/common/uri.js';
 import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IContextKeyService } from '../../../../../../../platform/contextkey/common/contextkey.js';
+import { MockContextKeyService } from '../../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
 import { ILogService, NullLogService } from '../../../../../../../platform/log/common/log.js';
 import { INotificationService } from '../../../../../../../platform/notification/common/notification.js';
 import { createTestContainer } from '../../../../../../../test/vitest/positronTestContainer.js';
 import { stubInterface } from '../../../../../../../test/vitest/stubInterface.js';
 import { INotebookExecutionStateService } from '../../../../../notebook/common/notebookExecutionStateService.js';
 import { NotebookTextModel } from '../../../../../notebook/common/model/notebookTextModel.js';
-import { AI_ENABLED_KEY } from '../../../../../positronAssistant/common/positronAIConfiguration.js';
-import { NOTEBOOK_AI_ENABLED_KEY } from '../../../../common/positronNotebookConfig.js';
+import { NotebookContextKeys } from '../../../../common/notebookContextKeys.js';
 import { IPositronNotebookCell, IPositronNotebookCodeCell } from '../../../PositronNotebookCells/IPositronNotebookCell.js';
 import { IPositronNotebookInstance } from '../../../IPositronNotebookInstance.js';
 import { GhostCellController } from '../controller.js';
 
-describe('GhostCellController ai.enabled gate', () => {
+describe('GhostCellController notebook AI gate', () => {
 	const config = new TestConfigurationService();
+	const contextKeyService = new MockContextKeyService();
 	const ctx = createTestContainer()
 		.stub(IConfigurationService, config)
+		.stub(IContextKeyService, contextKeyService)
 		.stub(INotebookExecutionStateService, stubInterface<INotebookExecutionStateService>({ onDidChangeExecution: Event.None }))
 		.stub(INotificationService, stubInterface<INotificationService>())
 		.stub(ILogService, new NullLogService())
 		.build();
 
-	// The per-notebook override turns ghost cells ON, so `ai.enabled` is the only
-	// variable across the two tests: with it off the controller must still stay
-	// hidden; with it on the gate lets the suggestion through.
+	// The per-notebook override turns ghost cells ON, so the composite notebook AI
+	// context key is the only variable: with it off the controller stays hidden,
+	// with it on the gate lets the suggestion through. (The ai.enabled vs
+	// notebook.ai.enabled composition that drives this key lives in
+	// notebookAIEnabledContextKey.vitest.ts.) Each test sets the key explicitly,
+	// so order doesn't matter.
 	function createController(): GhostCellController {
 		const mockCell = stubInterface<IPositronNotebookCell>({
 			isCodeCell: function (this: IPositronNotebookCell): this is IPositronNotebookCodeCell { return true; },
@@ -53,8 +59,8 @@ describe('GhostCellController ai.enabled gate', () => {
 		return ctx.instantiationService.createInstance(GhostCellController, notebook);
 	}
 
-	it('stays hidden when ai.enabled is false, even with the per-notebook override on', () => {
-		config.setUserConfiguration(AI_ENABLED_KEY, false);
+	it('stays hidden when the notebook AI gate is off, even with the per-notebook override on', () => {
+		contextKeyService.createKey(NotebookContextKeys.aiEnabled.key, false);
 		const controller = createController();
 
 		controller.triggerGhostCellSuggestion(0);
@@ -63,91 +69,13 @@ describe('GhostCellController ai.enabled gate', () => {
 		controller.dispose();
 	});
 
-	it('lets the suggestion through when ai.enabled is true', () => {
-		config.setUserConfiguration(AI_ENABLED_KEY, true);
+	it('lets the suggestion through when the notebook AI gate is on', () => {
+		contextKeyService.createKey(NotebookContextKeys.aiEnabled.key, true);
 		const controller = createController();
 
 		controller.triggerGhostCellSuggestion(0);
 
 		expect(controller.ghostCellState.get().status).toBe('loading');
-		controller.dispose();
-	});
-});
-
-describe('GhostCellController notebook.ai.enabled gate', () => {
-	const config = new TestConfigurationService();
-	const ctx = createTestContainer()
-		.stub(IConfigurationService, config)
-		.stub(INotebookExecutionStateService, stubInterface<INotebookExecutionStateService>({ onDidChangeExecution: Event.None }))
-		.stub(INotificationService, stubInterface<INotificationService>())
-		.stub(ILogService, new NullLogService())
-		.build();
-
-	// The per-notebook override turns ghost cells ON, so the two AI switches are
-	// the only variables. notebook.ai.enabled (default true) sits below ai.enabled
-	// and above the feature's own gates: a suggestion goes through only when BOTH
-	// switches are on. Disabling either keeps the controller hidden.
-	function createController(): GhostCellController {
-		const mockCell = stubInterface<IPositronNotebookCell>({
-			isCodeCell: function (this: IPositronNotebookCell): this is IPositronNotebookCodeCell { return true; },
-			getContent: () => '',
-			outputs: observableValue('outputs', []),
-		});
-		const notebook = stubInterface<IPositronNotebookInstance>({
-			uri: URI.parse('file:///test.ipynb'),
-			cells: observableValue('cells', [mockCell]),
-			container: observableValue<HTMLElement | undefined>('container', undefined),
-			runtimeSession: observableValue('runtimeSession', undefined),
-			textModel: stubInterface<NotebookTextModel>({
-				metadata: { metadata: { positron: { assistant: { ghostCellSuggestions: 'enabled' } } } },
-				cells: undefined,
-			}),
-		});
-		return ctx.instantiationService.createInstance(GhostCellController, notebook);
-	}
-
-	it('stays hidden when notebook.ai.enabled is false, even with ai.enabled on and the per-notebook override on', () => {
-		config.setUserConfiguration(AI_ENABLED_KEY, true);
-		config.setUserConfiguration(NOTEBOOK_AI_ENABLED_KEY, false);
-		const controller = createController();
-
-		controller.triggerGhostCellSuggestion(0);
-
-		expect(controller.ghostCellState.get().status).toBe('hidden');
-		controller.dispose();
-	});
-
-	it('lets the suggestion through when ai.enabled and notebook.ai.enabled are both true', () => {
-		config.setUserConfiguration(AI_ENABLED_KEY, true);
-		config.setUserConfiguration(NOTEBOOK_AI_ENABLED_KEY, true);
-		const controller = createController();
-
-		controller.triggerGhostCellSuggestion(0);
-
-		expect(controller.ghostCellState.get().status).toBe('loading');
-		controller.dispose();
-	});
-
-	it('lets the suggestion through when ai.enabled is true and notebook.ai.enabled is unset (defaults to enabled)', () => {
-		// notebook.ai.enabled defaults to true, so an unset value must not disable
-		// notebook AI; only an explicit `false` does.
-		config.setUserConfiguration(AI_ENABLED_KEY, true);
-		const controller = createController();
-
-		controller.triggerGhostCellSuggestion(0);
-
-		expect(controller.ghostCellState.get().status).toBe('loading');
-		controller.dispose();
-	});
-
-	it('stays hidden when ai.enabled is false even if notebook.ai.enabled is true (global switch wins)', () => {
-		config.setUserConfiguration(AI_ENABLED_KEY, false);
-		config.setUserConfiguration(NOTEBOOK_AI_ENABLED_KEY, true);
-		const controller = createController();
-
-		controller.triggerGhostCellSuggestion(0);
-
-		expect(controller.ghostCellState.get().status).toBe('hidden');
 		controller.dispose();
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/VisualizeAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/VisualizeAction.ts
@@ -4,15 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CancellationTokenSource } from '../../../../../../base/common/cancellation.js';
-import { ContextKeyExpr } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { ContextKeyExpr, IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { localize } from '../../../../../../nls.js';
 import { Action2, MenuId, registerAction2 } from '../../../../../../platform/actions/common/actions.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { INotificationService, Severity } from '../../../../../../platform/notification/common/notification.js';
 import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { isFileExcludedFromAI } from '../../../../chat/browser/tools/utils.js';
-import { AI_ENABLED_KEY } from '../../../../positronAssistant/common/positronAIConfiguration.js';
-import { NOTEBOOK_AI_ENABLED_KEY } from '../../../common/positronNotebookConfig.js';
+import { NotebookContextKeys } from '../../../common/notebookContextKeys.js';
 import { IHeadlessLanguageModelService } from '../../../../../services/positronHeadlessLanguageModel/common/headlessLanguageModelService.js';
 import type { PositronNotebookCodeCell } from '../../PositronNotebookCells/PositronNotebookCodeCell.js';
 import type { IInlineDataExplorerActionContext } from '../../notebookCells/InlineDataExplorerActions.js';
@@ -79,6 +78,7 @@ export class VisualizeDataFrameAction extends Action2 {
 
 		const headlessLmService = accessor.get(IHeadlessLanguageModelService);
 		const configurationService = accessor.get(IConfigurationService);
+		const contextKeyService = accessor.get(IContextKeyService);
 		const notificationService = accessor.get(INotificationService);
 
 		const columns: DataFrameColumn[] = [];
@@ -112,11 +112,10 @@ export class VisualizeDataFrameAction extends Action2 {
 		// closes before the request resolves.
 		const suggestionCts = new CancellationTokenSource();
 		try {
-			// Honor the AI switches (global + notebooks) and the per-file exclusion:
-			// skip the model when AI is disabled or the notebook is excluded. The
-			// wizard still opens for manual selection (null prefill).
-			const aiEnabled = configurationService.getValue<boolean>(AI_ENABLED_KEY) === true
-				&& configurationService.getValue<boolean>(NOTEBOOK_AI_ENABLED_KEY) !== false;
+			// Honor the composite notebook AI gate (global + notebooks) and the
+			// per-file exclusion: skip the model when AI is disabled or the notebook
+			// is excluded. The wizard still opens for manual selection (null prefill).
+			const aiEnabled = NotebookContextKeys.aiEnabled.getValue(contextKeyService) !== false;
 			const suggestionPromise = (!aiEnabled || isFileExcludedFromAI(configurationService, ctx.documentUri.path))
 				? Promise.resolve(null)
 				: generateVisualizationSuggestion(

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/VisualizeAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/VisualizeAction.ts
@@ -12,6 +12,7 @@ import { INotificationService, Severity } from '../../../../../../platform/notif
 import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { isFileExcludedFromAI } from '../../../../chat/browser/tools/utils.js';
 import { AI_ENABLED_KEY } from '../../../../positronAssistant/common/positronAIConfiguration.js';
+import { NOTEBOOK_AI_ENABLED_KEY } from '../../../common/positronNotebookConfig.js';
 import { IHeadlessLanguageModelService } from '../../../../../services/positronHeadlessLanguageModel/common/headlessLanguageModelService.js';
 import type { PositronNotebookCodeCell } from '../../PositronNotebookCells/PositronNotebookCodeCell.js';
 import type { IInlineDataExplorerActionContext } from '../../notebookCells/InlineDataExplorerActions.js';
@@ -111,10 +112,11 @@ export class VisualizeDataFrameAction extends Action2 {
 		// closes before the request resolves.
 		const suggestionCts = new CancellationTokenSource();
 		try {
-			// Honor the AI main switch and the per-file exclusion: skip the model
-			// when AI is disabled or the notebook is excluded. The wizard still
-			// opens for manual selection (null prefill).
-			const aiEnabled = configurationService.getValue<boolean>(AI_ENABLED_KEY) === true;
+			// Honor the AI switches (global + notebooks) and the per-file exclusion:
+			// skip the model when AI is disabled or the notebook is excluded. The
+			// wizard still opens for manual selection (null prefill).
+			const aiEnabled = configurationService.getValue<boolean>(AI_ENABLED_KEY) === true
+				&& configurationService.getValue<boolean>(NOTEBOOK_AI_ENABLED_KEY) !== false;
 			const suggestionPromise = (!aiEnabled || isFileExcludedFromAI(configurationService, ctx.documentUri.path))
 				? Promise.resolve(null)
 				: generateVisualizationSuggestion(

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookAIEnabledContextKey.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookAIEnabledContextKey.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IDisposable } from '../../../../base/common/lifecycle.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { bindContextKey, observableConfigValue } from '../../../../platform/observable/common/platformObservableUtils.js';
+import { AI_ENABLED_KEY } from '../../positronAssistant/common/positronAIConfiguration.js';
+import { NOTEBOOK_AI_ENABLED_KEY } from '../common/positronNotebookConfig.js';
+import { NotebookContextKeys } from '../common/notebookContextKeys.js';
+
+/**
+ * Derive the {@link NotebookContextKeys.aiEnabled} context key from the two AI
+ * switches and keep it in sync. This is the single place the composite gate is
+ * computed: notebook AI is on only when the global `ai.enabled` is on AND the
+ * notebooks-only `notebook.ai.enabled` is on. Both default to true, so an unset
+ * value reads as enabled and only an explicit `false` disables.
+ *
+ * Every notebook AI feature reads the resulting context key rather than the two
+ * settings, so the cascade can't drift between call sites.
+ *
+ * @returns a disposable that stops syncing the context key.
+ */
+export function bindNotebookAIEnabledContextKey(
+	contextKeyService: IContextKeyService,
+	configurationService: IConfigurationService,
+): IDisposable {
+	const aiEnabled = observableConfigValue<boolean>(AI_ENABLED_KEY, true, configurationService);
+	const notebookAiEnabled = observableConfigValue<boolean>(NOTEBOOK_AI_ENABLED_KEY, true, configurationService);
+	return bindContextKey(
+		NotebookContextKeys.aiEnabled,
+		contextKeyService,
+		reader => aiEnabled.read(reader) === true && notebookAiEnabled.read(reader) !== false,
+	);
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx
@@ -16,7 +16,7 @@ import { usePositronConfiguration, useContextKeyFromString } from '../../../../.
 import { IAction } from '../../../../../base/common/actions.js';
 import { removeAnsiEscapeCodes } from '../../../../../base/common/strings.js';
 import { encodeBase64, VSBuffer } from '../../../../../base/common/buffer.js';
-import { POSITRON_NOTEBOOK_ENABLED_KEY } from '../../common/positronNotebookConfig.js';
+import { NOTEBOOK_AI_ENABLED_KEY, POSITRON_NOTEBOOK_ENABLED_KEY } from '../../common/positronNotebookConfig.js';
 import { AI_ENABLED_KEY } from '../../../positronAssistant/common/positronAIConfiguration.js';
 import { openPositAssistantChat } from '../../../positronAssistant/browser/positAssistantChat.js';
 import { SplitButton } from '../utilityComponents/SplitButton.js';
@@ -46,13 +46,16 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 
 	// Configuration hooks to conditionally show the quick-fix buttons
 	const aiEnabled = usePositronConfiguration<boolean>(AI_ENABLED_KEY);
+	// notebook.ai.enabled defaults to true, so only an explicit `false` hides the buttons.
+	const notebookAiEnabled = usePositronConfiguration<boolean>(NOTEBOOK_AI_ENABLED_KEY);
 	const enableNotebookMode = usePositronConfiguration<boolean>(POSITRON_NOTEBOOK_ENABLED_KEY);
 	// Set by the Posit Assistant extension when it has at least one usable model.
 	// The old positron-assistant.hasChatModels key is going away this milestone.
 	const hasChatModels = useContextKeyFromString<boolean>('posit-assistant.hasChatModels');
 
-	// Only show buttons if AI is enabled, notebook mode is enabled, and chat models are available
-	const showQuickFix = aiEnabled && enableNotebookMode && hasChatModels;
+	// Only show buttons if AI is enabled (global + notebooks), notebook mode is
+	// enabled, and chat models are available
+	const showQuickFix = aiEnabled && notebookAiEnabled !== false && enableNotebookMode && hasChatModels;
 
 	const cleanError = useMemo(
 		() => removeAnsiEscapeCodes(props.errorContent).trim(),

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx
@@ -12,12 +12,12 @@ import { useCallback, useMemo } from 'react';
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
-import { usePositronConfiguration, useContextKeyFromString } from '../../../../../base/browser/positronReactHooks.js';
+import { usePositronConfiguration, useContextKey, useContextKeyFromString } from '../../../../../base/browser/positronReactHooks.js';
 import { IAction } from '../../../../../base/common/actions.js';
 import { removeAnsiEscapeCodes } from '../../../../../base/common/strings.js';
 import { encodeBase64, VSBuffer } from '../../../../../base/common/buffer.js';
-import { NOTEBOOK_AI_ENABLED_KEY, POSITRON_NOTEBOOK_ENABLED_KEY } from '../../common/positronNotebookConfig.js';
-import { AI_ENABLED_KEY } from '../../../positronAssistant/common/positronAIConfiguration.js';
+import { POSITRON_NOTEBOOK_ENABLED_KEY } from '../../common/positronNotebookConfig.js';
+import { NotebookContextKeys } from '../../common/notebookContextKeys.js';
 import { openPositAssistantChat } from '../../../positronAssistant/browser/positAssistantChat.js';
 import { SplitButton } from '../utilityComponents/SplitButton.js';
 
@@ -44,18 +44,20 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 	const services = usePositronReactServicesContext();
 	const { commandService, contextMenuService, logService, notificationService } = services;
 
-	// Configuration hooks to conditionally show the quick-fix buttons
-	const aiEnabled = usePositronConfiguration<boolean>(AI_ENABLED_KEY);
-	// notebook.ai.enabled defaults to true, so only an explicit `false` hides the buttons.
-	const notebookAiEnabled = usePositronConfiguration<boolean>(NOTEBOOK_AI_ENABLED_KEY);
+	// Configuration hooks to conditionally show the quick-fix buttons.
+	// notebookAiEnabled is the composite gate (global ai.enabled AND
+	// notebook.ai.enabled), kept in sync by bindNotebookAIEnabledContextKey.
+	// undefined (before the key is bound) reads as enabled, matching the
+	// settings' default of true.
+	const notebookAiEnabled = useContextKey<boolean>(NotebookContextKeys.aiEnabled);
 	const enableNotebookMode = usePositronConfiguration<boolean>(POSITRON_NOTEBOOK_ENABLED_KEY);
 	// Set by the Posit Assistant extension when it has at least one usable model.
 	// The old positron-assistant.hasChatModels key is going away this milestone.
 	const hasChatModels = useContextKeyFromString<boolean>('posit-assistant.hasChatModels');
 
-	// Only show buttons if AI is enabled (global + notebooks), notebook mode is
-	// enabled, and chat models are available
-	const showQuickFix = aiEnabled && notebookAiEnabled !== false && enableNotebookMode && hasChatModels;
+	// Only show buttons if notebook AI is enabled, notebook mode is enabled, and
+	// chat models are available
+	const showQuickFix = notebookAiEnabled !== false && enableNotebookMode && hasChatModels;
 
 	const cleanError = useMemo(
 		() => removeAnsiEscapeCodes(props.errorContent).trim(),

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -62,6 +62,7 @@ import { POSITRON_EXECUTE_CELL_COMMAND_ID, POSITRON_NOTEBOOK_CATEGORY, POSITRON_
 import { getActiveCell, getSelectedCells, SelectionState } from './selectionMachine.js';
 import { CellContextKeys } from '../common/cellContextKeys.js';
 import { NotebookContextKeys } from '../common/notebookContextKeys.js';
+import { bindNotebookAIEnabledContextKey } from './notebookAIEnabledContextKey.js';
 import './contrib/undoRedo/positronNotebookUndoRedo.js';
 import { Action2, registerAction2, MenuId, MenuRegistry } from '../../../../platform/actions/common/actions.js';
 import { ExecuteSelectionInCellAction } from './ExecuteSelectionInCellAction.js';
@@ -136,6 +137,10 @@ class PositronNotebookContribution extends Disposable {
 			contextKeyService,
 			reader => positronNotebookService.experimentsEnabled.read(reader),
 		));
+
+		// Keep the composite notebook AI gate (ai.enabled AND notebook.ai.enabled)
+		// in sync so every notebook AI feature can read the single context key.
+		this._register(bindNotebookAIEnabledContextKey(contextKeyService, this.configurationService));
 
 		this.registerEditor();
 	}

--- a/src/vs/workbench/contrib/positronNotebook/common/notebookContextKeys.ts
+++ b/src/vs/workbench/contrib/positronNotebook/common/notebookContextKeys.ts
@@ -14,4 +14,6 @@ export namespace NotebookContextKeys {
 	export const cellEditorFocused = new RawContextKey<boolean>('positronNotebookCellEditorFocused', false, { type: 'boolean', description: localize('positronNotebookCellEditorFocused', "Whether a code editor within a Positron notebook cell is focused") });
 	/** Mirrors the `positron.notebook.experimental` configuration. */
 	export const experimental = new RawContextKey<boolean>('positronNotebook.experimental', false, { type: 'boolean', description: localize('positronNotebookExperimental', "Whether experimental Positron Notebook features are enabled") });
+	/** Composite notebook AI gate: true only when both `ai.enabled` and `notebook.ai.enabled` are on. Derived from configuration; see `bindNotebookAIEnabledContextKey`. */
+	export const aiEnabled = new RawContextKey<boolean>('positronNotebook.aiEnabled', true, { type: 'boolean', description: localize('positronNotebookAiEnabled', "Whether AI features are enabled for Positron notebooks (both the global ai.enabled switch and the notebook.ai.enabled switch are on)") });
 }

--- a/src/vs/workbench/contrib/positronNotebook/common/notebookContextKeys.ts
+++ b/src/vs/workbench/contrib/positronNotebook/common/notebookContextKeys.ts
@@ -14,6 +14,6 @@ export namespace NotebookContextKeys {
 	export const cellEditorFocused = new RawContextKey<boolean>('positronNotebookCellEditorFocused', false, { type: 'boolean', description: localize('positronNotebookCellEditorFocused', "Whether a code editor within a Positron notebook cell is focused") });
 	/** Mirrors the `positron.notebook.experimental` configuration. */
 	export const experimental = new RawContextKey<boolean>('positronNotebook.experimental', false, { type: 'boolean', description: localize('positronNotebookExperimental', "Whether experimental Positron Notebook features are enabled") });
-	/** Composite notebook AI gate: true only when both `ai.enabled` and `notebook.ai.enabled` are on. Derived from configuration; see `bindNotebookAIEnabledContextKey`. */
+	/** Composite notebook AI gate: true only when both `ai.enabled` and `notebook.ai.enabled` are on. Derived from configuration; see `bindNotebookAIEnabledContextKey`. Bound (default `true`) before any notebook editor opens, so it's never read unbound in practice; if it were, the expression form (`precondition`/`when`) reads unset as `false` (fail-closed) while `getValue`/`useContextKey` consumers use `!== false` (default-enabled). */
 	export const aiEnabled = new RawContextKey<boolean>('positronNotebook.aiEnabled', true, { type: 'boolean', description: localize('positronNotebookAiEnabled', "Whether AI features are enabled for Positron notebooks (both the global ai.enabled switch and the notebook.ai.enabled switch are on)") });
 }

--- a/src/vs/workbench/contrib/positronNotebook/common/positronNotebookConfig.ts
+++ b/src/vs/workbench/contrib/positronNotebook/common/positronNotebookConfig.ts
@@ -64,7 +64,8 @@ configurationRegistry.registerConfiguration({
 			default: true,
 			markdownDescription: localize(
 				'positron.notebook.ai.enabled',
-				'Enable AI features in notebooks, such as ghost cell suggestions, the notebook assistant, and Fix and Explain on cell errors. When disabled, all AI features in notebooks are turned off. The main AI features setting (`#ai.enabled#`) must also be enabled.'
+				'Enable AI features in notebooks, such as ghost cell suggestions, the notebook assistant, and Fix and Explain on cell errors. When disabled, all AI features in notebooks are turned off. The main AI features setting ({0}) must also be enabled.',
+				'`#ai.enabled#`'
 			),
 			tags: ['positronNotebook'],
 			scope: ConfigurationScope.WINDOW,

--- a/src/vs/workbench/contrib/positronNotebook/common/positronNotebookConfig.ts
+++ b/src/vs/workbench/contrib/positronNotebook/common/positronNotebookConfig.ts
@@ -14,6 +14,10 @@ import { Registry } from '../../../../platform/registry/common/platform.js';
 // Configuration key for the Positron notebook setting
 export const POSITRON_NOTEBOOK_ENABLED_KEY = 'positron.notebook.enabled';
 
+// Single switch that gates all AI features in Positron notebooks. Sits below the
+// global `ai.enabled` switch and above each feature's own settings.
+export const NOTEBOOK_AI_ENABLED_KEY = 'notebook.ai.enabled';
+
 // Configuration key for assistant auto-follow setting
 export const POSITRON_NOTEBOOK_ASSISTANT_AUTO_FOLLOW_KEY = 'positron.assistant.notebook.autoFollow';
 
@@ -51,6 +55,16 @@ configurationRegistry.registerConfiguration({
 			markdownDescription: localize(
 				'positron.enablePositronNotebook',
 				'Use the Positron Notebook Editor for `.ipynb` files. When disabled, Positron uses the legacy notebook editor.'
+			),
+			tags: ['positronNotebook'],
+			scope: ConfigurationScope.WINDOW,
+		},
+		[NOTEBOOK_AI_ENABLED_KEY]: {
+			type: 'boolean',
+			default: true,
+			markdownDescription: localize(
+				'positron.notebook.ai.enabled',
+				'Enable AI features in notebooks, such as ghost cell suggestions, the notebook assistant, and Fix and Explain on cell errors. When disabled, all AI features in notebooks are turned off. The main AI features setting (`#ai.enabled#`) must also be enabled.'
 			),
 			tags: ['positronNotebook'],
 			scope: ConfigurationScope.WINDOW,

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/AssistantPanel/assistantPanelActions.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/AssistantPanel/assistantPanelActions.vitest.tsx
@@ -5,7 +5,6 @@
 
 /// <reference types="vitest/globals" />
 
-import React from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/AssistantPanel/assistantPanelActions.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/AssistantPanel/assistantPanelActions.vitest.tsx
@@ -17,6 +17,7 @@ import { createTestContainer } from '../../../../../../test/vitest/positronTestC
 import { setupRTLRenderer } from '../../../../../../test/vitest/reactTestingLibrary.js';
 import { stubInterface } from '../../../../../../test/vitest/stubInterface.js';
 import { AI_ENABLED_KEY } from '../../../../positronAssistant/common/positronAIConfiguration.js';
+import { NOTEBOOK_AI_ENABLED_KEY } from '../../../common/positronNotebookConfig.js';
 import { INotebookContextDTO } from '../../../../../common/positron/notebookAssistant.js';
 import { IHeadlessLanguageModelService } from '../../../../../services/positronHeadlessLanguageModel/common/headlessLanguageModelService.js';
 import { IPositronNotebookInstance } from '../../../browser/IPositronNotebookInstance.js';
@@ -43,8 +44,9 @@ describe('AssistantPanelActions AI gate', () => {
 		configurationService = ctx.get(IConfigurationService) as TestConfigurationService;
 		notificationService = stubInterface<INotificationService>({ info: vi.fn(), error: vi.fn() });
 		mockGenerateNotebookSuggestions.mockReset().mockResolvedValue([]);
-		// Default to AI on (matching the registered default) and nothing excluded.
+		// Default both AI switches on (matching the registered defaults) and nothing excluded.
 		configurationService.setUserConfiguration(AI_ENABLED_KEY, true);
+		configurationService.setUserConfiguration(NOTEBOOK_AI_ENABLED_KEY, true);
 		configurationService.setUserConfiguration('positron.assistant.aiExcludes', []);
 	});
 
@@ -82,6 +84,17 @@ describe('AssistantPanelActions AI gate', () => {
 
 	it('does not request suggestions when AI is disabled, and notifies instead', async () => {
 		configurationService.setUserConfiguration(AI_ENABLED_KEY, false);
+		renderActions();
+		await clickGenerate();
+		expect(mockGenerateNotebookSuggestions).not.toHaveBeenCalled();
+		expect(notificationService.info).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not request suggestions when notebook.ai.enabled is false (ai.enabled on), and notifies instead', async () => {
+		// The notebooks-only switch gates suggestion generation independently of
+		// the global switch.
+		configurationService.setUserConfiguration(AI_ENABLED_KEY, true);
+		configurationService.setUserConfiguration(NOTEBOOK_AI_ENABLED_KEY, false);
 		renderActions();
 		await clickGenerate();
 		expect(mockGenerateNotebookSuggestions).not.toHaveBeenCalled();

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/AssistantPanel/assistantPanelActions.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/AssistantPanel/assistantPanelActions.vitest.tsx
@@ -12,12 +12,12 @@ import { CancellationToken } from '../../../../../../base/common/cancellation.js
 import { URI } from '../../../../../../base/common/uri.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { INotificationService } from '../../../../../../platform/notification/common/notification.js';
 import { createTestContainer } from '../../../../../../test/vitest/positronTestContainer.js';
 import { setupRTLRenderer } from '../../../../../../test/vitest/reactTestingLibrary.js';
 import { stubInterface } from '../../../../../../test/vitest/stubInterface.js';
-import { AI_ENABLED_KEY } from '../../../../positronAssistant/common/positronAIConfiguration.js';
-import { NOTEBOOK_AI_ENABLED_KEY } from '../../../common/positronNotebookConfig.js';
+import { NotebookContextKeys } from '../../../common/notebookContextKeys.js';
 import { INotebookContextDTO } from '../../../../../common/positron/notebookAssistant.js';
 import { IHeadlessLanguageModelService } from '../../../../../services/positronHeadlessLanguageModel/common/headlessLanguageModelService.js';
 import { IPositronNotebookInstance } from '../../../browser/IPositronNotebookInstance.js';
@@ -38,15 +38,17 @@ describe('AssistantPanelActions AI gate', () => {
 	const rtl = setupRTLRenderer(() => ctx.reactServices);
 
 	let configurationService: TestConfigurationService;
+	let contextKeyService: IContextKeyService;
 	let notificationService: INotificationService;
 
 	beforeEach(() => {
 		configurationService = ctx.get(IConfigurationService) as TestConfigurationService;
+		contextKeyService = ctx.get(IContextKeyService);
 		notificationService = stubInterface<INotificationService>({ info: vi.fn(), error: vi.fn() });
 		mockGenerateNotebookSuggestions.mockReset().mockResolvedValue([]);
-		// Default both AI switches on (matching the registered defaults) and nothing excluded.
-		configurationService.setUserConfiguration(AI_ENABLED_KEY, true);
-		configurationService.setUserConfiguration(NOTEBOOK_AI_ENABLED_KEY, true);
+		// Default the composite notebook AI gate on (matching the default) and
+		// nothing excluded.
+		contextKeyService.createKey(NotebookContextKeys.aiEnabled.key, true);
 		configurationService.setUserConfiguration('positron.assistant.aiExcludes', []);
 	});
 
@@ -82,19 +84,11 @@ describe('AssistantPanelActions AI gate', () => {
 		await waitFor(() => expect(mockGenerateNotebookSuggestions).toHaveBeenCalledTimes(1));
 	});
 
-	it('does not request suggestions when AI is disabled, and notifies instead', async () => {
-		configurationService.setUserConfiguration(AI_ENABLED_KEY, false);
-		renderActions();
-		await clickGenerate();
-		expect(mockGenerateNotebookSuggestions).not.toHaveBeenCalled();
-		expect(notificationService.info).toHaveBeenCalledTimes(1);
-	});
-
-	it('does not request suggestions when notebook.ai.enabled is false (ai.enabled on), and notifies instead', async () => {
-		// The notebooks-only switch gates suggestion generation independently of
-		// the global switch.
-		configurationService.setUserConfiguration(AI_ENABLED_KEY, true);
-		configurationService.setUserConfiguration(NOTEBOOK_AI_ENABLED_KEY, false);
+	it('does not request suggestions when the notebook AI gate is off, and notifies instead', async () => {
+		// The composite notebook AI gate (ai.enabled AND notebook.ai.enabled, whose
+		// composition is covered in notebookAIEnabledContextKey.vitest.ts) gates
+		// suggestion generation.
+		contextKeyService.createKey(NotebookContextKeys.aiEnabled.key, false);
 		renderActions();
 		await clickGenerate();
 		expect(mockGenerateNotebookSuggestions).not.toHaveBeenCalled();

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/askAssistantAction.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/askAssistantAction.vitest.ts
@@ -5,29 +5,62 @@
 
 /// <reference types="vitest/globals" />
 
+import { ContextKeyExpression, IContext } from '../../../../../platform/contextkey/common/contextkey.js';
+import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../common/positronNotebookCommon.js';
 import { AskAssistantAction } from '../../browser/AskAssistantAction.js';
 
 /**
  * The Ask Assistant action is gated on both AI switches: the global
- * `config.ai.enabled` and the notebooks-only `config.notebook.ai.enabled`.
- * The menu `when` clause hides the editor toolbar button, but the action also
- * sets `f1: true`, so it gets a command palette entry whose visibility is driven
- * by the action's `precondition`. Without a precondition the command stayed in
- * the palette (and runnable) even with AI disabled, so assert both gates.
+ * `config.ai.enabled` and the notebooks-only `config.notebook.ai.enabled`,
+ * combined with AND. The menu `when` clause hides the editor toolbar button,
+ * but the action also sets `f1: true`, so it gets a command palette entry whose
+ * visibility is driven by the action's `precondition`. Without a precondition
+ * the command stayed in the palette (and runnable) even with AI disabled.
+ *
+ * These tests evaluate the real expressions against contexts rather than
+ * string-matching the serialized form, so an inverted (`not`) or OR-ed gate
+ * (which would still contain the key substring) is caught.
  */
 describe('AskAssistantAction', () => {
 	const desc = new AskAssistantAction().desc;
 
-	it('gates the command palette entry and execution via precondition', () => {
-		const serialized = desc.precondition?.serialize();
-		expect(serialized).toContain('config.ai.enabled');
-		expect(serialized).toContain('config.notebook.ai.enabled');
+	// Minimal IContext backed by a plain map of context-key -> value.
+	function evaluate(expr: ContextKeyExpression | undefined, values: Record<string, unknown>): boolean {
+		expect(expr).toBeDefined();
+		const context: IContext = {
+			getValue: (key: string) => values[key] as never,
+		};
+		return expr!.evaluate(context);
+	}
+
+	describe('precondition (command palette entry + execution)', () => {
+		it('is enabled only when both AI switches are on', () => {
+			expect(evaluate(desc.precondition, { 'config.ai.enabled': true, 'config.notebook.ai.enabled': true })).toBe(true);
+		});
+
+		it('is disabled when ai.enabled is off (notebook.ai.enabled on)', () => {
+			expect(evaluate(desc.precondition, { 'config.ai.enabled': false, 'config.notebook.ai.enabled': true })).toBe(false);
+		});
+
+		it('is disabled when notebook.ai.enabled is off (ai.enabled on)', () => {
+			expect(evaluate(desc.precondition, { 'config.ai.enabled': true, 'config.notebook.ai.enabled': false })).toBe(false);
+		});
 	});
 
-	it('gates the editor toolbar button via the menu when clause', () => {
+	describe('menu when clause (editor toolbar button)', () => {
 		const menu = Array.isArray(desc.menu) ? desc.menu[0] : desc.menu;
-		const serialized = menu?.when?.serialize();
-		expect(serialized).toContain('config.ai.enabled');
-		expect(serialized).toContain('config.notebook.ai.enabled');
+		const activeNotebook = { 'activeEditor': POSITRON_NOTEBOOK_EDITOR_ID };
+
+		it('is shown only when both AI switches are on in the notebook editor', () => {
+			expect(evaluate(menu?.when, { ...activeNotebook, 'config.ai.enabled': true, 'config.notebook.ai.enabled': true })).toBe(true);
+		});
+
+		it('is hidden when ai.enabled is off', () => {
+			expect(evaluate(menu?.when, { ...activeNotebook, 'config.ai.enabled': false, 'config.notebook.ai.enabled': true })).toBe(false);
+		});
+
+		it('is hidden when notebook.ai.enabled is off', () => {
+			expect(evaluate(menu?.when, { ...activeNotebook, 'config.ai.enabled': true, 'config.notebook.ai.enabled': false })).toBe(false);
+		});
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/askAssistantAction.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/askAssistantAction.vitest.ts
@@ -8,7 +8,8 @@
 import { AskAssistantAction } from '../../browser/AskAssistantAction.js';
 
 /**
- * The Ask Assistant action is gated on the AI main switch (`config.ai.enabled`).
+ * The Ask Assistant action is gated on both AI switches: the global
+ * `config.ai.enabled` and the notebooks-only `config.notebook.ai.enabled`.
  * The menu `when` clause hides the editor toolbar button, but the action also
  * sets `f1: true`, so it gets a command palette entry whose visibility is driven
  * by the action's `precondition`. Without a precondition the command stayed in
@@ -18,11 +19,15 @@ describe('AskAssistantAction', () => {
 	const desc = new AskAssistantAction().desc;
 
 	it('gates the command palette entry and execution via precondition', () => {
-		expect(desc.precondition?.serialize()).toBe('config.ai.enabled');
+		const serialized = desc.precondition?.serialize();
+		expect(serialized).toContain('config.ai.enabled');
+		expect(serialized).toContain('config.notebook.ai.enabled');
 	});
 
 	it('gates the editor toolbar button via the menu when clause', () => {
 		const menu = Array.isArray(desc.menu) ? desc.menu[0] : desc.menu;
-		expect(menu?.when?.serialize()).toContain('config.ai.enabled');
+		const serialized = menu?.when?.serialize();
+		expect(serialized).toContain('config.ai.enabled');
+		expect(serialized).toContain('config.notebook.ai.enabled');
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/askAssistantAction.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/askAssistantAction.vitest.ts
@@ -7,22 +7,25 @@
 
 import { ContextKeyExpression, IContext } from '../../../../../platform/contextkey/common/contextkey.js';
 import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../common/positronNotebookCommon.js';
+import { NotebookContextKeys } from '../../common/notebookContextKeys.js';
 import { AskAssistantAction } from '../../browser/AskAssistantAction.js';
 
 /**
- * The Ask Assistant action is gated on both AI switches: the global
- * `config.ai.enabled` and the notebooks-only `config.notebook.ai.enabled`,
- * combined with AND. The menu `when` clause hides the editor toolbar button,
- * but the action also sets `f1: true`, so it gets a command palette entry whose
- * visibility is driven by the action's `precondition`. Without a precondition
- * the command stayed in the palette (and runnable) even with AI disabled.
+ * The Ask Assistant action is gated on the composite notebook AI context key
+ * (`positronNotebook.aiEnabled`), which is on only when both the global
+ * `ai.enabled` and the notebooks-only `notebook.ai.enabled` are on. That
+ * config->key composition is verified in `notebookAIEnabledContextKey.vitest.ts`;
+ * here we assert the action reads the key. The menu `when` clause hides the
+ * editor toolbar button, but the action also sets `f1: true`, so it gets a
+ * command palette entry whose visibility is driven by the `precondition`.
  *
  * These tests evaluate the real expressions against contexts rather than
- * string-matching the serialized form, so an inverted (`not`) or OR-ed gate
- * (which would still contain the key substring) is caught.
+ * string-matching the serialized form, so an inverted (`not`) gate (which would
+ * still contain the key substring) is caught.
  */
 describe('AskAssistantAction', () => {
 	const desc = new AskAssistantAction().desc;
+	const AI_ENABLED = NotebookContextKeys.aiEnabled.key;
 
 	// Minimal IContext backed by a plain map of context-key -> value.
 	function evaluate(expr: ContextKeyExpression | undefined, values: Record<string, unknown>): boolean {
@@ -34,16 +37,12 @@ describe('AskAssistantAction', () => {
 	}
 
 	describe('precondition (command palette entry + execution)', () => {
-		it('is enabled only when both AI switches are on', () => {
-			expect(evaluate(desc.precondition, { 'config.ai.enabled': true, 'config.notebook.ai.enabled': true })).toBe(true);
+		it('is enabled when the notebook AI gate is on', () => {
+			expect(evaluate(desc.precondition, { [AI_ENABLED]: true })).toBe(true);
 		});
 
-		it('is disabled when ai.enabled is off (notebook.ai.enabled on)', () => {
-			expect(evaluate(desc.precondition, { 'config.ai.enabled': false, 'config.notebook.ai.enabled': true })).toBe(false);
-		});
-
-		it('is disabled when notebook.ai.enabled is off (ai.enabled on)', () => {
-			expect(evaluate(desc.precondition, { 'config.ai.enabled': true, 'config.notebook.ai.enabled': false })).toBe(false);
+		it('is disabled when the notebook AI gate is off', () => {
+			expect(evaluate(desc.precondition, { [AI_ENABLED]: false })).toBe(false);
 		});
 	});
 
@@ -51,16 +50,16 @@ describe('AskAssistantAction', () => {
 		const menu = Array.isArray(desc.menu) ? desc.menu[0] : desc.menu;
 		const activeNotebook = { 'activeEditor': POSITRON_NOTEBOOK_EDITOR_ID };
 
-		it('is shown only when both AI switches are on in the notebook editor', () => {
-			expect(evaluate(menu?.when, { ...activeNotebook, 'config.ai.enabled': true, 'config.notebook.ai.enabled': true })).toBe(true);
+		it('is shown when the notebook AI gate is on in the notebook editor', () => {
+			expect(evaluate(menu?.when, { ...activeNotebook, [AI_ENABLED]: true })).toBe(true);
 		});
 
-		it('is hidden when ai.enabled is off', () => {
-			expect(evaluate(menu?.when, { ...activeNotebook, 'config.ai.enabled': false, 'config.notebook.ai.enabled': true })).toBe(false);
+		it('is hidden when the notebook AI gate is off', () => {
+			expect(evaluate(menu?.when, { ...activeNotebook, [AI_ENABLED]: false })).toBe(false);
 		});
 
-		it('is hidden when notebook.ai.enabled is off', () => {
-			expect(evaluate(menu?.when, { ...activeNotebook, 'config.ai.enabled': true, 'config.notebook.ai.enabled': false })).toBe(false);
+		it('is hidden outside the notebook editor even when the gate is on', () => {
+			expect(evaluate(menu?.when, { 'activeEditor': 'other.editor', [AI_ENABLED]: true })).toBe(false);
 		});
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/visualize/visualizeAction.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/visualize/visualizeAction.vitest.ts
@@ -13,6 +13,7 @@ import { createTestContainer } from '../../../../../../../test/vitest/positronTe
 import { stubInterface } from '../../../../../../../test/vitest/stubInterface.js';
 import { IHeadlessLanguageModelService } from '../../../../../../services/positronHeadlessLanguageModel/common/headlessLanguageModelService.js';
 import { AI_ENABLED_KEY } from '../../../../../positronAssistant/common/positronAIConfiguration.js';
+import { NOTEBOOK_AI_ENABLED_KEY } from '../../../../common/positronNotebookConfig.js';
 import { VisualizeDataFrameAction } from '../../../../browser/contrib/visualize/VisualizeAction.js';
 import type { IInlineDataExplorerActionContext } from '../../../../browser/notebookCells/InlineDataExplorerActions.js';
 import type { InlineTableDataGridInstance } from '../../../../../../services/positronDataExplorer/browser/inlineTableDataGridInstance.js';
@@ -56,9 +57,10 @@ describe('VisualizeDataFrameAction', () => {
 		mockShowVisualizeModalDialog.mockReset();
 		mockApplyVisualizeResult.mockReset();
 		mockGenerateVisualizationSuggestion.mockReset().mockResolvedValue(null);
-		// Reset the AI state the shared describe-scope container carries: AI on
-		// (matching the registered default) and nothing excluded.
+		// Reset the AI state the shared describe-scope container carries: both AI
+		// switches on (matching the registered defaults) and nothing excluded.
 		configurationService.setUserConfiguration(AI_ENABLED_KEY, true);
+		configurationService.setUserConfiguration(NOTEBOOK_AI_ENABLED_KEY, true);
 		configurationService.setUserConfiguration('positron.assistant.aiExcludes', []);
 	});
 
@@ -184,6 +186,19 @@ describe('VisualizeDataFrameAction', () => {
 
 	it('does not request a suggestion when AI is disabled, but still opens the dialog', async () => {
 		configurationService.setUserConfiguration(AI_ENABLED_KEY, false);
+		mockShowVisualizeModalDialog.mockResolvedValue(undefined);
+
+		await run(buildContext());
+
+		expect(mockGenerateVisualizationSuggestion).not.toHaveBeenCalled();
+		expect(mockShowVisualizeModalDialog).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not request a suggestion when notebook.ai.enabled is false (ai.enabled on), but still opens the dialog', async () => {
+		// The notebooks-only switch gates the AI suggestion independently of the
+		// global switch: with it off, no model call, but the manual wizard opens.
+		configurationService.setUserConfiguration(AI_ENABLED_KEY, true);
+		configurationService.setUserConfiguration(NOTEBOOK_AI_ENABLED_KEY, false);
 		mockShowVisualizeModalDialog.mockResolvedValue(undefined);
 
 		await run(buildContext());

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/visualize/visualizeAction.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/visualize/visualizeAction.vitest.ts
@@ -9,11 +9,11 @@ import { URI } from '../../../../../../../base/common/uri.js';
 import { observableValue } from '../../../../../../../base/common/observable.js';
 import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IContextKeyService } from '../../../../../../../platform/contextkey/common/contextkey.js';
 import { createTestContainer } from '../../../../../../../test/vitest/positronTestContainer.js';
 import { stubInterface } from '../../../../../../../test/vitest/stubInterface.js';
 import { IHeadlessLanguageModelService } from '../../../../../../services/positronHeadlessLanguageModel/common/headlessLanguageModelService.js';
-import { AI_ENABLED_KEY } from '../../../../../positronAssistant/common/positronAIConfiguration.js';
-import { NOTEBOOK_AI_ENABLED_KEY } from '../../../../common/positronNotebookConfig.js';
+import { NotebookContextKeys } from '../../../../common/notebookContextKeys.js';
 import { VisualizeDataFrameAction } from '../../../../browser/contrib/visualize/VisualizeAction.js';
 import type { IInlineDataExplorerActionContext } from '../../../../browser/notebookCells/InlineDataExplorerActions.js';
 import type { InlineTableDataGridInstance } from '../../../../../../services/positronDataExplorer/browser/inlineTableDataGridInstance.js';
@@ -51,16 +51,17 @@ describe('VisualizeDataFrameAction', () => {
 		.build();
 
 	let configurationService: TestConfigurationService;
+	let contextKeyService: IContextKeyService;
 
 	beforeEach(() => {
 		configurationService = ctx.get(IConfigurationService) as TestConfigurationService;
+		contextKeyService = ctx.get(IContextKeyService);
 		mockShowVisualizeModalDialog.mockReset();
 		mockApplyVisualizeResult.mockReset();
 		mockGenerateVisualizationSuggestion.mockReset().mockResolvedValue(null);
-		// Reset the AI state the shared describe-scope container carries: both AI
-		// switches on (matching the registered defaults) and nothing excluded.
-		configurationService.setUserConfiguration(AI_ENABLED_KEY, true);
-		configurationService.setUserConfiguration(NOTEBOOK_AI_ENABLED_KEY, true);
+		// Reset the AI state the shared describe-scope container carries: the
+		// composite notebook AI gate on (matching the default) and nothing excluded.
+		contextKeyService.createKey(NotebookContextKeys.aiEnabled.key, true);
 		configurationService.setUserConfiguration('positron.assistant.aiExcludes', []);
 	});
 
@@ -184,21 +185,11 @@ describe('VisualizeDataFrameAction', () => {
 		expect(mockShowVisualizeModalDialog).toHaveBeenCalledTimes(1);
 	});
 
-	it('does not request a suggestion when AI is disabled, but still opens the dialog', async () => {
-		configurationService.setUserConfiguration(AI_ENABLED_KEY, false);
-		mockShowVisualizeModalDialog.mockResolvedValue(undefined);
-
-		await run(buildContext());
-
-		expect(mockGenerateVisualizationSuggestion).not.toHaveBeenCalled();
-		expect(mockShowVisualizeModalDialog).toHaveBeenCalledTimes(1);
-	});
-
-	it('does not request a suggestion when notebook.ai.enabled is false (ai.enabled on), but still opens the dialog', async () => {
-		// The notebooks-only switch gates the AI suggestion independently of the
-		// global switch: with it off, no model call, but the manual wizard opens.
-		configurationService.setUserConfiguration(AI_ENABLED_KEY, true);
-		configurationService.setUserConfiguration(NOTEBOOK_AI_ENABLED_KEY, false);
+	it('does not request a suggestion when the notebook AI gate is off, but still opens the dialog', async () => {
+		// The composite notebook AI gate (ai.enabled AND notebook.ai.enabled, whose
+		// composition is covered in notebookAIEnabledContextKey.vitest.ts) gates the
+		// model call; the manual wizard still opens.
+		contextKeyService.createKey(NotebookContextKeys.aiEnabled.key, false);
 		mockShowVisualizeModalDialog.mockResolvedValue(undefined);
 
 		await run(buildContext());

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookAIEnabledContextKey.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookAIEnabledContextKey.vitest.ts
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { ensureNoLeakedDisposables } from '../../../../../test/vitest/vitestUtils.js';
+import { AI_ENABLED_KEY } from '../../../positronAssistant/common/positronAIConfiguration.js';
+import { NOTEBOOK_AI_ENABLED_KEY } from '../../common/positronNotebookConfig.js';
+import { NotebookContextKeys } from '../../common/notebookContextKeys.js';
+import { bindNotebookAIEnabledContextKey } from '../../browser/notebookAIEnabledContextKey.js';
+
+/**
+ * The composite gate is the single source of truth for notebook AI: the context
+ * key is on only when the global `ai.enabled` AND the notebooks-only
+ * `notebook.ai.enabled` are both on. Both settings default to true, so an unset
+ * value reads as enabled and only an explicit `false` disables. This is the one
+ * place the cascade is computed; every feature reads the resulting key.
+ */
+describe('bindNotebookAIEnabledContextKey', () => {
+	beforeEach(() => ensureNoLeakedDisposables());
+
+	// Bind the context key against a config with the given values (undefined =
+	// unset) and return what the gate resolves to immediately after binding.
+	function gate(aiEnabled: boolean | undefined, notebookAiEnabled: boolean | undefined): boolean | undefined {
+		const config = new TestConfigurationService();
+		if (aiEnabled !== undefined) {
+			config.setUserConfiguration(AI_ENABLED_KEY, aiEnabled);
+		}
+		if (notebookAiEnabled !== undefined) {
+			config.setUserConfiguration(NOTEBOOK_AI_ENABLED_KEY, notebookAiEnabled);
+		}
+		const contextKeyService = new MockContextKeyService();
+		const binding = bindNotebookAIEnabledContextKey(contextKeyService, config);
+		const value = NotebookContextKeys.aiEnabled.getValue(contextKeyService);
+		binding.dispose();
+		return value;
+	}
+
+	it('is enabled only when both switches allow it, with unset reading as enabled', () => {
+		expect({
+			bothUnset: gate(undefined, undefined),
+			bothOn: gate(true, true),
+			notebookUnsetGlobalOn: gate(true, undefined),
+			notebookOffGlobalOn: gate(true, false),
+			globalOffNotebookOn: gate(false, true),
+			globalOffNotebookUnset: gate(false, undefined),
+		}).toMatchInlineSnapshot(`
+			{
+			  "bothOn": true,
+			  "bothUnset": true,
+			  "globalOffNotebookOn": false,
+			  "globalOffNotebookUnset": false,
+			  "notebookOffGlobalOn": false,
+			  "notebookUnsetGlobalOn": true,
+			}
+		`);
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTextOutput.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTextOutput.vitest.tsx
@@ -105,6 +105,22 @@ describe('CellTextOutput', () => {
 		expect(screen.queryByRole('group', { name: /quick fix/i })).not.toBeInTheDocument();
 	});
 
+	it('does not render quick-fix for errors when notebook.ai.enabled is false', () => {
+		// Everything else that would show the quick-fix is on; only the
+		// notebooks-only AI switch is off, isolating that gate.
+		const configurationService = ctx.get(IConfigurationService) as TestConfigurationService;
+		const contextKeyService = ctx.get(IContextKeyService) as MockContextKeyService;
+		configurationService.setUserConfiguration('ai.enabled', true);
+		configurationService.setUserConfiguration('notebook.ai.enabled', false);
+		configurationService.setUserConfiguration('positron.notebook.enabled', true);
+		contextKeyService.createKey('positron-assistant.hasChatModels', true);
+
+		renderCellTextOutput({ content: 'NameError: name "x" is not defined', type: 'error' });
+
+		expect(screen.getByTestId('cell-text-output')).toHaveClass('notebook-error');
+		expect(screen.queryByRole('group', { name: /quick fix/i })).not.toBeInTheDocument();
+	});
+
 	it('renders multiline content within limit', () => {
 		renderCellTextOutput({ content: '1\n2\n3', type: 'stdout' });
 

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTextOutput.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTextOutput.vitest.tsx
@@ -85,11 +85,13 @@ describe('CellTextOutput', () => {
 	it('renders error output with quick-fix', () => {
 		// The workbench preset creates a fresh TestConfigurationService and
 		// MockContextKeyService per test, so pulling them out of the container
-		// here gives isolated state without any manual reset.
+		// here gives isolated state without any manual reset. The composite
+		// notebook AI gate is a context key (positronNotebook.aiEnabled), not a
+		// config value.
 		const configurationService = ctx.get(IConfigurationService) as TestConfigurationService;
 		const contextKeyService = ctx.get(IContextKeyService) as MockContextKeyService;
-		configurationService.setUserConfiguration('ai.enabled', true);
 		configurationService.setUserConfiguration('positron.notebook.enabled', true);
+		contextKeyService.createKey('positronNotebook.aiEnabled', true);
 		contextKeyService.createKey('posit-assistant.hasChatModels', true);
 
 		renderCellTextOutput({ content: 'NameError: name "x" is not defined', type: 'error' });
@@ -105,15 +107,16 @@ describe('CellTextOutput', () => {
 		expect(screen.queryByRole('group', { name: /quick fix/i })).not.toBeInTheDocument();
 	});
 
-	it('does not render quick-fix for errors when notebook.ai.enabled is false', () => {
-		// Everything else that would show the quick-fix is on; only the
-		// notebooks-only AI switch is off, isolating that gate.
+	it('does not render quick-fix for errors when the notebook AI gate is off', () => {
+		// Everything else that would show the quick-fix is on; only the composite
+		// notebook AI context key is off, isolating that gate. (The ai.enabled vs
+		// notebook.ai.enabled composition is covered in
+		// notebookAIEnabledContextKey.vitest.ts.)
 		const configurationService = ctx.get(IConfigurationService) as TestConfigurationService;
 		const contextKeyService = ctx.get(IContextKeyService) as MockContextKeyService;
-		configurationService.setUserConfiguration('ai.enabled', true);
-		configurationService.setUserConfiguration('notebook.ai.enabled', false);
 		configurationService.setUserConfiguration('positron.notebook.enabled', true);
-		contextKeyService.createKey('positron-assistant.hasChatModels', true);
+		contextKeyService.createKey('positronNotebook.aiEnabled', false);
+		contextKeyService.createKey('posit-assistant.hasChatModels', true);
 
 		renderCellTextOutput({ content: 'NameError: name "x" is not defined', type: 'error' });
 

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTextOutput.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTextOutput.vitest.tsx
@@ -16,6 +16,7 @@ import { IConfigurationService } from '../../../../../../platform/configuration/
 import { MockContextKeyService } from '../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { NotebookDisplayOptions, NotebookLayoutConfiguration, NotebookOptions, NotebookOptionsChangeEvent } from '../../../../notebook/browser/notebookOptions.js';
+import { NotebookContextKeys } from '../../../common/notebookContextKeys.js';
 import { IPositronNotebookInstance } from '../../../browser/IPositronNotebookInstance.js';
 import { NotebookInstanceProvider } from '../../../browser/NotebookInstanceProvider.js';
 import { CellTextOutput } from '../../../browser/notebookCells/CellTextOutput.js';
@@ -91,7 +92,7 @@ describe('CellTextOutput', () => {
 		const configurationService = ctx.get(IConfigurationService) as TestConfigurationService;
 		const contextKeyService = ctx.get(IContextKeyService) as MockContextKeyService;
 		configurationService.setUserConfiguration('positron.notebook.enabled', true);
-		contextKeyService.createKey('positronNotebook.aiEnabled', true);
+		contextKeyService.createKey(NotebookContextKeys.aiEnabled.key, true);
 		contextKeyService.createKey('posit-assistant.hasChatModels', true);
 
 		renderCellTextOutput({ content: 'NameError: name "x" is not defined', type: 'error' });
@@ -115,7 +116,7 @@ describe('CellTextOutput', () => {
 		const configurationService = ctx.get(IConfigurationService) as TestConfigurationService;
 		const contextKeyService = ctx.get(IContextKeyService) as MockContextKeyService;
 		configurationService.setUserConfiguration('positron.notebook.enabled', true);
-		contextKeyService.createKey('positronNotebook.aiEnabled', false);
+		contextKeyService.createKey(NotebookContextKeys.aiEnabled.key, false);
 		contextKeyService.createKey('posit-assistant.hasChatModels', true);
 
 		renderCellTextOutput({ content: 'NameError: name "x" is not defined', type: 'error' });


### PR DESCRIPTION
Closes #14542

### Summary

Adds a single `notebook.ai.enabled` setting (default `true`) that gates every AI feature in Positron Notebooks, replacing the need to juggle several keys (`positron.notebook.experimental`, the `ghostCellSuggestions.*` family, etc.). Users now reason about just two switches:

- `ai.enabled` -- all Positron AI features (global)
- `notebook.ai.enabled` -- notebook AI features only

Notebook AI is on only when both are on (`ai.enabled AND notebook.ai.enabled`). The composite is computed once and exposed as the derived context key `positronNotebook.aiEnabled` (via `bindNotebookAIEnabledContextKey`), which every feature reads instead of re-deriving the cascade, so the gate can't drift between call sites. The new switch sits *above* each feature's own settings rather than replacing them, and is read live so toggling takes effect without a window reload.

### Features gated by `notebook.ai.enabled`

- Ghost cell suggestions (inline AI cell completions)
- Notebook assistant ("Ask Assistant" button + its suggestion panel)
- "Visualize..." action
- "Fix" / "Explain" quick fixes on cell errors

### Release Notes

#### New Features

- Add a single `notebook.ai.enabled` setting to enable or disable all AI features in Positron Notebooks (#14542)

#### Bug Fixes

- N/A

### Validation Steps

@:notebooks @:positron-notebooks @:assistant

1. With both `ai.enabled` and `notebook.ai.enabled` at their defaults (`true`), confirm the gated features above are available in a notebook.
2. Set `notebook.ai.enabled` to `false` (no reload) and confirm all of them are hidden/disabled while the rest of Positron AI is unaffected.
3. Restore it to `true`, then set `ai.enabled` to `false` and confirm notebook AI is disabled again (the global switch overrides).
