### PR TITLE
Stop the package detail view from jumping while loading

### DIFF
--- a/src/vs/workbench/contrib/positronPackages/browser/components/packageDetail.css
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/packageDetail.css
@@ -194,3 +194,7 @@
 	background: var(--vscode-editorWidget-background);
 	opacity: 0.6;
 }
+
+/* Header placeholders read as a name / one-line summary, so size them wider. */
+.package-detail-author .package-detail-skeleton { width: 140px; }
+.package-detail-description .package-detail-skeleton { width: 240px; }

--- a/src/vs/workbench/contrib/positronPackages/browser/components/packageDetail.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/packageDetail.tsx
@@ -48,40 +48,36 @@ function formatPublishedDate(raw: string): string {
 
 /**
  * A single stat in the Overview's top stat strip: an uppercase label above a
- * prominent value. Shows a skeleton while a detail-sourced value is pending,
- * and renders nothing once resolved if there is still no value.
+ * prominent value. Renders nothing if there is no value. The Overview is hidden
+ * until the detail fetch resolves, so this never sees a pending value.
  */
-const Stat = (props: { label: string; value: string | number | undefined; loading?: boolean }) => {
+const Stat = (props: { label: string; value: string | number | undefined }) => {
 	const hasValue = props.value !== undefined && props.value !== '';
-	if (!hasValue && !props.loading) {
+	if (!hasValue) {
 		return null;
 	}
 	return (
 		<div className='package-detail-stat'>
 			<div className='package-detail-stat-label'>{props.label}</div>
-			<div className='package-detail-stat-value'>
-				{hasValue ? props.value : <span className='package-detail-skeleton' data-testid='package-detail-loading' />}
-			</div>
+			<div className='package-detail-stat-value'>{props.value}</div>
 		</div>
 	);
 };
 
 /**
- * A label/value row in the Metadata section. Shows a skeleton while a
- * detail-sourced value is pending, and renders nothing once resolved if there
- * is still no value.
+ * A label/value row in the Metadata section. Renders nothing if there is no
+ * value. The Overview is hidden until the detail fetch resolves, so this never
+ * sees a pending value.
  */
-const MetaRow = (props: { label: string; value: string | number | undefined; loading?: boolean }) => {
+const MetaRow = (props: { label: string; value: string | number | undefined }) => {
 	const hasValue = props.value !== undefined && props.value !== '';
-	if (!hasValue && !props.loading) {
+	if (!hasValue) {
 		return null;
 	}
 	return (
 		<>
 			<div className='package-detail-meta-label'>{props.label}</div>
-			<div className='package-detail-meta-value'>
-				{hasValue ? props.value : <span className='package-detail-skeleton' data-testid='package-detail-loading' />}
-			</div>
+			<div className='package-detail-meta-value'>{props.value}</div>
 		</>
 	);
 };
@@ -120,8 +116,12 @@ export const PackageDetail = (props: PackageDetailProps) => {
 	}, [packagesService, sessionId]);
 
 	// Detail fetch: call getPackageDetail when the package/session changes.
+	// Initialize `detailLoading` to true when a live session exists so the very
+	// first paint already reflects the pending fetch -- otherwise the Overview
+	// would flash in (with no detail) for one frame before the effect runs.
 	const [detail, setDetail] = useState<Partial<ILanguageRuntimePackage> | undefined>(undefined);
-	const [detailLoading, setDetailLoading] = useState(false);
+	const [detailLoading, setDetailLoading] = useState<boolean>(() =>
+		!!packagesService.getInstances().find(i => i.session.metadata.sessionId === sessionId));
 	useEffect(() => {
 		const inst = packagesService.getInstances().find(i => i.session.metadata.sessionId === sessionId);
 		if (!inst) {
@@ -287,8 +287,12 @@ export const PackageDetail = (props: PackageDetailProps) => {
 						{pkg?.version && <span className='package-detail-version'>{pkg.version}</span>}
 						{pkg?.attached && <span className='package-detail-attached-pill'>{localize('positron.packages.detail.attached', "Attached")}</span>}
 					</div>
-					{merged.author && <div className='package-detail-author'>{merged.author}</div>}
-					{subtitle && <div className='package-detail-description'>{subtitle}</div>}
+					{detailLoading
+						? <div className='package-detail-author'><span className='package-detail-skeleton' data-testid='package-detail-loading' /></div>
+						: merged.author && <div className='package-detail-author'>{merged.author}</div>}
+					{detailLoading
+						? <div className='package-detail-description'><span className='package-detail-skeleton' data-testid='package-detail-loading' /></div>
+						: subtitle && <div className='package-detail-description'>{subtitle}</div>}
 					<div className='package-detail-actions'>
 						{view.actions.map(renderActionButton)}
 					</div>
@@ -311,21 +315,28 @@ export const PackageDetail = (props: PackageDetailProps) => {
 				<div className='package-detail-tab active'>{localize('positron.packages.detail.overview', "Overview")}</div>
 			</div>
 
-			<div className='package-detail-overview'>
-				<div className='package-detail-stats'>
-					<Stat label={localize('positron.packages.detail.version', "Version")} value={installedVersionText} />
-					<Stat label={localize('positron.packages.detail.license', "License")} loading={detailLoading} value={merged.license} />
-				</div>
+			{/*
+			 * Hold the Overview back until the detail fetch resolves, then render
+			 * it all at once. Half-rendering it with the list entry and filling in
+			 * detail-only fields afterwards made the panel jump.
+			 */}
+			{!detailLoading &&
+				<div className='package-detail-overview'>
+					<div className='package-detail-stats'>
+						<Stat label={localize('positron.packages.detail.version', "Version")} value={installedVersionText} />
+						<Stat label={localize('positron.packages.detail.license', "License")} value={merged.license} />
+					</div>
 
-				<div className='package-detail-section'>
-					<div className='package-detail-section-title'>{localize('positron.packages.detail.metadata', "Metadata")}</div>
-					<div className='package-detail-meta-grid'>
-						<MetaRow label={localize('positron.packages.detail.repository', "Source repository")} loading={detailLoading} value={merged.sourceRepository} />
-						<MetaRow label={localize('positron.packages.detail.published', "Date published")} loading={detailLoading} value={merged.publishedDate ? formatPublishedDate(merged.publishedDate) : undefined} />
-						<MetaRow label={localize('positron.packages.detail.interpreter', "Interpreter")} value={interpreter} />
+					<div className='package-detail-section'>
+						<div className='package-detail-section-title'>{localize('positron.packages.detail.metadata', "Metadata")}</div>
+						<div className='package-detail-meta-grid'>
+							<MetaRow label={localize('positron.packages.detail.repository', "Source repository")} value={merged.sourceRepository} />
+							<MetaRow label={localize('positron.packages.detail.published', "Date published")} value={merged.publishedDate ? formatPublishedDate(merged.publishedDate) : undefined} />
+							<MetaRow label={localize('positron.packages.detail.interpreter', "Interpreter")} value={interpreter} />
+						</div>
 					</div>
 				</div>
-			</div>
+			}
 		</div>
 	);
 };

--- a/src/vs/workbench/contrib/positronPackages/test/browser/packageDetail.vitest.tsx
+++ b/src/vs/workbench/contrib/positronPackages/test/browser/packageDetail.vitest.tsx
@@ -75,10 +75,13 @@ describe('PackageDetail', () => {
 		);
 	}
 
-	it('renders the package name and description', () => {
+	it('renders the package name immediately and the description once the fetch resolves', async () => {
 		render();
+		// The name is list-derived, so it paints right away.
 		expect(screen.getByRole('heading', { name: 'dplyr' })).toBeInTheDocument();
-		expect(screen.getByText('A grammar of data manipulation')).toBeInTheDocument();
+		// The subtitle is held behind a skeleton until the detail fetch resolves
+		// (here to no detail), then falls back to the list description.
+		expect(await screen.findByText('A grammar of data manipulation')).toBeInTheDocument();
 	});
 
 	it('shows an Update button for an outdated package and runs the update command', async () => {
@@ -90,11 +93,13 @@ describe('PackageDetail', () => {
 		expect(executeCommand).toHaveBeenCalledWith('positronPackages.updatePackage', 'dplyr', '1.1.4');
 	});
 
-	it('shows the Overview stat strip', () => {
+	it('shows the Overview stat strip once the fetch resolves', async () => {
 		render();
+		// The Overview is held back until the detail fetch resolves; the LICENSE
+		// stat ("MIT") is the last piece to appear.
+		expect(await screen.findByText('MIT')).toBeInTheDocument();     // LICENSE stat
 		// The version appears twice: faded next to the name and as the VERSION stat.
 		expect(screen.getAllByText('1.1.2')).toHaveLength(2);
-		expect(screen.getByText('MIT')).toBeInTheDocument();     // LICENSE stat
 	});
 });
 
@@ -131,13 +136,13 @@ describe('PackageDetail when the package is current', () => {
 	const ctx = createTestContainer().withReactServices().stub(ICommandService, { executeCommand: vi.fn() }).build();
 	const rtl = setupRTLRenderer(() => ctx.reactServices);
 
-	it('appends "(latest)" to the installed version and omits a Latest version row', () => {
+	it('appends "(latest)" to the installed version and omits a Latest version row', async () => {
 		rtl.render(
 			<PackageDetail languageId='r' packageName='dplyr' packagesService={packagesService} sessionId={SESSION_ID} />
 		);
-		// Installed-version Overview row reads "1.1.4 (latest)"; the faded header
-		// version is the bare "1.1.4".
-		expect(screen.getByText('1.1.4 (latest)')).toBeInTheDocument();
+		// Installed-version Overview row reads "1.1.4 (latest)" (appears once the
+		// fetch resolves); the faded header version is the bare "1.1.4".
+		expect(await screen.findByText('1.1.4 (latest)')).toBeInTheDocument();
 		expect(screen.getByText('1.1.4')).toBeInTheDocument();
 	});
 });
@@ -203,11 +208,14 @@ describe('PackageDetail while detail fetch is pending', () => {
 	const ctx = createTestContainer().withReactServices().stub(ICommandService, { executeCommand: vi.fn() }).build();
 	const rtl = setupRTLRenderer(() => ctx.reactServices);
 
-	it('shows loading skeletons for detail-only rows while the fetch is pending', () => {
+	it('shows header skeletons and hides the Overview while the fetch is pending', () => {
 		rtl.render(
 			<PackageDetail languageId='r' packageName='dplyr' packagesService={packagesService} sessionId={SESSION_ID} />
 		);
-		const skeletons = screen.getAllByTestId('package-detail-loading');
-		expect(skeletons.length).toBeGreaterThan(0);
+		// Author and subtitle render as fixed-height skeletons so the header
+		// doesn't jump when the detail fetch resolves.
+		expect(screen.getAllByTestId('package-detail-loading')).toHaveLength(2);
+		// The Overview (and its detail-only rows) stays hidden until the fetch resolves.
+		expect(screen.queryByText('MIT')).not.toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
Polishes the package detail view so it no longer jumps while loading. The view painted once with the list-entry data and then re-rendered as `getPackageDetail` resolved -- inserting the author line, swapping the subtitle (long list `description` for the short detail `title`), and popping in the metadata rows, which shoved the action buttons and content around.

The header now stays put: the author and subtitle render fixed-height skeletons while the detail fetch is pending, and the Overview (stats + metadata) is held back until the fetch resolves so it renders all at once below the stable header. `detailLoading` is initialized from whether a live session exists, so the very first paint already reflects the pending fetch instead of flashing the empty Overview for a frame.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Stop the package detail view from jumping while it loads package metadata.

### Validation Steps

@:packages-pane

1. Open the Packages pane with an active R or Python session.
2. Click a package to open its detail view.
3. Verify the header (name, version, author, subtitle) does not shift, and the Overview/metadata section appears all at once when loading finishes -- no jump.
