### PR TITLE
Allow select all Cmd/Ctrl-A

### DIFF
--- a/src/vs/workbench/contrib/positronPackages/browser/components/packageDetail.css
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/packageDetail.css
@@ -8,6 +8,11 @@
 	overflow: auto;
 	height: 100%;
 	box-sizing: border-box;
+	/* The workbench root sets user-select: none (browser/media/style.css). */
+	/* Opt back in so package metadata (version, license, repository URL, */
+	/* etc.) can be selected and copied, matching the extension editor. */
+	user-select: text;
+	-webkit-user-select: text;
 }
 
 .package-detail-header {
@@ -29,6 +34,9 @@
 	font-size: 24px;
 	color: var(--vscode-button-foreground);
 	background: var(--vscode-button-background);
+	/* Decorative, aria-hidden glyph -- keep it out of copied selections. */
+	user-select: none;
+	-webkit-user-select: none;
 }
 
 .package-detail-header-main { flex: 1; min-width: 0; }
@@ -37,7 +45,15 @@
 .package-detail-version { color: var(--vscode-descriptionForeground); font-size: 0.9em; }
 .package-detail-author { color: var(--vscode-descriptionForeground); margin: 2px 0; }
 .package-detail-description { color: var(--vscode-foreground); margin: 2px 0 10px; }
-.package-detail-actions { display: flex; gap: 6px; flex-wrap: wrap; align-items: center; }
+.package-detail-actions {
+	display: flex;
+	gap: 6px;
+	flex-wrap: wrap;
+	align-items: center;
+	/* Buttons are not text content -- don't select their labels on drag. */
+	user-select: none;
+	-webkit-user-select: none;
+}
 
 .package-detail-attached-pill {
 	font-size: 0.8em;

--- a/src/vs/workbench/contrib/positronPackages/browser/packageEditor.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/packageEditor.tsx
@@ -72,6 +72,17 @@ export class PackageEditor extends EditorPane {
 		DOM.size(this._container, dimension.width, dimension.height);
 	}
 
+	/**
+	 * Selects all selectable text in the detail view. Bound to Ctrl/Cmd+A via a
+	 * keybinding rule scoped to this editor; the per-element user-select: none
+	 * rules (language badge, actions row) keep decorative content out of the
+	 * selection.
+	 */
+	selectAll(): void {
+		const selection = DOM.getActiveWindow().document.getSelection();
+		selection?.selectAllChildren(this._container);
+	}
+
 	override dispose(): void {
 		this.disposeRenderer();
 		super.dispose();

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
@@ -12,6 +12,7 @@ import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/c
 import { CommandsRegistry, ICommandService } from '../../../../platform/commands/common/commands.js';
 import { Extensions as ConfigurationExtensions, ConfigurationScope, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
+import { KeybindingsRegistry, KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { SyncDescriptor } from '../../../../platform/instantiation/common/descriptors.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
@@ -20,6 +21,7 @@ import { INotificationService, Severity } from '../../../../platform/notificatio
 import { IProgressService, ProgressLocation } from '../../../../platform/progress/common/progress.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { EditorExtensions } from '../../../common/editor.js';
+import { ActiveEditorContext } from '../../../common/contextkeys.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { EditorPaneDescriptor, IEditorPaneRegistry } from '../../../browser/editor.js';
 import { ViewPaneContainer } from '../../../browser/parts/views/viewPaneContainer.js';
@@ -728,6 +730,23 @@ Registry.as<IEditorPaneRegistry>(EditorExtensions.EditorPane).registerEditorPane
 		new SyncDescriptor(PackageEditorInput)
 	]
 );
+
+// Register Ctrl/Cmd+A to select all text in the package detail editor. The
+// workbench root disables text selection and intercepts the keystroke, so we
+// scope a keybinding to the active package editor and select its contents
+// programmatically (matching the Console pane's select-all).
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: 'positronPackages.detail.selectAll',
+	weight: KeybindingWeight.WorkbenchContrib,
+	primary: KeyMod.CtrlCmd | KeyCode.KeyA,
+	when: ActiveEditorContext.isEqualTo(PackageEditor.ID),
+	handler: accessor => {
+		const pane = accessor.get(IEditorService).activeEditorPane;
+		if (pane instanceof PackageEditor) {
+			pane.selectAll();
+		}
+	}
+});
 
 // Opens a package detail editor for the given package name.
 // `pinned` is false for preview (single-click) and true for a pinned tab (double-click).


### PR DESCRIPTION
Allows select all in package editor via Cmd/Ctrl-A.