### PR TITLE
Extract `PositronCellEditorOptions`

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -14,12 +14,11 @@ import { localize } from '../../../../../nls.js';
 
 import { EditorExtensionsRegistry, IEditorContributionDescription } from '../../../../../editor/browser/editorExtensions.js';
 import { CodeEditorWidget } from '../../../../../editor/browser/widget/codeEditor/codeEditorWidget.js';
-import { IEditorOptions } from '../../../../../editor/common/config/editorOptions.js';
 
 import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
 import { IEditorProgressService } from '../../../../../platform/progress/common/progress.js';
 import { FloatingEditorClickMenu } from '../../../../browser/codeeditor.js';
-import { CellEditorOptions } from '../../../notebook/browser/view/cellParts/cellEditorOptions.js';
+import { PositronCellEditorOptions } from './PositronCellEditorOptions.js';
 import { useNotebookInstance } from '../NotebookInstanceProvider.js';
 import { addDisposableListener, getWindow } from '../../../../../base/browser/dom.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
@@ -145,40 +144,27 @@ export function useCellEditorWidget(cell: PositronNotebookCellGeneral) {
 		);
 
 		const editorInstaService = instance.scopedInstantiationService.createChild(serviceCollection);
-		const editorOptions = disposables.add(new CellEditorOptions(instance.getBaseCellEditorOptions(language), instance.notebookOptions, services.configurationService));
+		const editorOptions = disposables.add(new PositronCellEditorOptions(instance, language, services.configurationService));
 
-		// Build the final editor options from the cell editor defaults merged with
-		// the Positron Notebook editor overrides. Used for both initial creation
-		// and live updates so the overrides are never lost on update.
-		const buildEditorOptions = () => {
-			const defaultOptions = editorOptions.getDefaultValue();
-			return {
-				...defaultOptions,
-				// Override padding for Positron notebooks to add breathing room between action bar and editor content
-				padding: { top: 16, bottom: 16 },
-				scrollbar: {
-					...defaultOptions.scrollbar,
-					// Smaller scrollbars since we embed many editor widgets
-					verticalScrollbarSize: 8,
-					horizontalScrollbarSize: 8
-				},
-				tabIndex: -1, // Remove editor from tab order - use Enter to focus
+		const editor = disposables.add(editorInstaService.createInstance(
+			CodeEditorWidget,
+			editorPartRef.current,
+			{
+				...editorOptions.getValue(),
+				// Initially set the editor size to 0x0.
 				dimension: {
 					width: 0,
 					height: 0,
-				},
-			};
-		};
-
-		const editor = disposables.add(editorInstaService.createInstance(CodeEditorWidget, editorPartRef.current, buildEditorOptions(), {
-			contributions: getNotebookEditorContributions()
-		}));
+				}
+			},
+			{ contributions: getNotebookEditorContributions() }
+		));
 		cell.attachEditor(editor);
 
 		// Re-apply options when they change so the open notebook
 		// updates without requiring a reload.
 		disposables.add(editorOptions.onDidChange(() => {
-			editor.updateOptions(buildEditorOptions() as IEditorOptions);
+			editor.updateOptions(editorOptions.getValue());
 		}));
 
 		// Request model for cell and pass to editor.

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/PositronCellEditorOptions.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/PositronCellEditorOptions.ts
@@ -1,0 +1,59 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Event } from '../../../../../base/common/event.js';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { IEditorOptions } from '../../../../../editor/common/config/editorOptions.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { CellEditorOptions } from '../../../notebook/browser/view/cellParts/cellEditorOptions.js';
+import { IPositronNotebookInstance } from '../IPositronNotebookInstance.js';
+
+/**
+ * Provides options for a notebook cell's `CodeEditorWidget`.
+ * Wraps {@link CellEditorOptions} with Positron-specific overrides.
+ */
+export class PositronCellEditorOptions extends Disposable {
+	/** The wrapped cell editor options */
+	private readonly _options: CellEditorOptions;
+
+	/** Event that fires when the editor options change */
+	public readonly onDidChange: Event<void>;
+
+	constructor(
+		public readonly notebook: IPositronNotebookInstance,
+		public readonly language: string,
+		@IConfigurationService configurationService: IConfigurationService,
+	) {
+		super();
+
+		this._options = this._register(new CellEditorOptions(
+			notebook.getBaseCellEditorOptions(language),
+			notebook.notebookOptions,
+			configurationService,
+		));
+
+		this.onDidChange = this._options.onDidChange;
+	}
+
+	/** Get the current editor options. */
+	getValue(): IEditorOptions {
+		// Build the final editor options from the cell editor defaults merged with
+		// the Positron Notebook editor overrides. Used for both initial creation
+		// and live updates so the overrides are never lost on update.
+		const defaultOptions = this._options.getDefaultValue();
+		return {
+			...defaultOptions,
+			// Override padding for Positron notebooks to add breathing room between action bar and editor content
+			padding: { top: 16, bottom: 16 },
+			scrollbar: {
+				...defaultOptions.scrollbar,
+				// Smaller scrollbars since we embed many editor widgets
+				verticalScrollbarSize: 8,
+				horizontalScrollbarSize: 8
+			},
+			tabIndex: -1, // Remove editor from tab order - use Enter to focus
+		};
+	}
+}


### PR DESCRIPTION
Another refactor to simplify #14264, and generally doesn't seem like a bad idea.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

@:positron-notebooks @:web