### PR TITLE
Extract `createCellEditor` function

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -21,7 +21,7 @@ import { FloatingEditorClickMenu } from '../../../../browser/codeeditor.js';
 import { PositronCellEditorOptions } from './PositronCellEditorOptions.js';
 import { useNotebookInstance } from '../NotebookInstanceProvider.js';
 import { addDisposableListener, getWindow } from '../../../../../base/browser/dom.js';
-import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { DisposableStore, IDisposable } from '../../../../../base/common/lifecycle.js';
 import { PositronNotebookCellGeneral } from '../PositronNotebookCells/PositronNotebookCell.js';
 import { useObservedValue } from '../useObservedValue.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
@@ -33,6 +33,9 @@ import { EditorContextKeys } from '../../../../../editor/common/editorContextKey
 import { CTX_INLINE_CHAT_FOCUSED } from '../../../../contrib/inlineChat/common/inlineChat.js';
 import { CONTEXT_FIND_INPUT_FOCUSED, CONTEXT_REPLACE_INPUT_FOCUSED } from '../../../../../editor/contrib/find/browser/findModel.js';
 import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { IPositronNotebookInstance } from '../IPositronNotebookInstance.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
 
 /**
  *
@@ -88,6 +91,214 @@ export function CellEditorMonacoWidget({ cell }: { cell: PositronNotebookCellGen
 	</>;
 }
 
+function createCellEditor(
+	editorPartRef: React.RefObject<HTMLDivElement | null>,
+	cell: PositronNotebookCellGeneral,
+	instance: IPositronNotebookInstance,
+	configurationService: IConfigurationService,
+	contextKeyService: IContextKeyService,
+	logService: ILogService,
+): IDisposable | undefined {
+	if (!editorPartRef.current || !cell.scopedContextKeyService) { return; }
+
+	const disposables = new DisposableStore();
+
+	const language = cell.model.language;
+
+	// Create a scoped context key service for this editor as a child of the cell's scope.
+	// This ensures cell-level context keys (e.g. positronNotebookCellIsFirst) are visible
+	// to menus evaluated inside the editor. CodeEditorWidget will create its own child scope
+	// from this one for editor-specific keys.
+	const editorContextKeyService = cell.scopedContextKeyService.createScoped(editorPartRef.current);
+	disposables.add(editorContextKeyService);
+
+	// CRITICAL: Set the inCompositeEditor flag to change editor behavior
+	// This tells Monaco it's part of a composite (notebook) and not a standalone editor
+	// Without this flag, certain standalone editor keybindings would still fire
+	EditorContextKeys.inCompositeEditor.bindTo(editorContextKeyService).set(true);
+
+	// We need to ensure the EditorProgressService (or a fake) is available
+	// in the service collection because monaco editors will try and access
+	// it even though it's not available in the notebook context. This feels
+	// hacky but VSCode notebooks do the same thing so I guess it's easier
+	// than fixing it at the monaco level.
+	const serviceCollection = new ServiceCollection(
+		[
+			IEditorProgressService,
+			// Create a simple no-op IEditorProgressService for editor contributions
+			// Based on pattern from codeBlockPart.ts in chat contrib
+			new class implements IEditorProgressService {
+				_serviceBrand: undefined;
+				show() {
+					// No-op progress indicator for notebook cell editors
+					return { done: () => { }, total: () => { }, worked: () => { } };
+				}
+				async showWhile(promise: Promise<any>): Promise<void> {
+					await promise;
+				}
+			}],
+		[IContextKeyService, editorContextKeyService]
+	);
+
+	const editorInstaService = instance.scopedInstantiationService.createChild(serviceCollection);
+	const editorOptions = disposables.add(new PositronCellEditorOptions(instance, language, configurationService));
+
+	const editor = disposables.add(editorInstaService.createInstance(
+		CodeEditorWidget,
+		editorPartRef.current,
+		{
+			...editorOptions.getValue(),
+			// Initially set the editor size to 0x0.
+			dimension: {
+				width: 0,
+				height: 0,
+			}
+		},
+		{ contributions: getNotebookEditorContributions() }
+	));
+	cell.attachEditor(editor);
+
+	// Re-apply options when they change so the open notebook
+	// updates without requiring a reload.
+	disposables.add(editorOptions.onDidChange(() => {
+		editor.updateOptions(editorOptions.getValue());
+	}));
+
+	// Request model for cell and pass to editor.
+	cell.getTextEditorModel().then(model => {
+		editor.setModel(model);
+	});
+
+	// Bind the cell editor focused context key to the editor's internal scoped service
+	// (CodeEditorWidget creates this synchronously in its constructor)
+	const cellEditorFocusedKey = NotebookContextKeys.cellEditorFocused.bindTo(editor.contextKeyService);
+
+	// Track whether the most recent mousedown had modifier keys held.
+	// Monaco's _onMouseDown calls focus() BEFORE emitting onMouseDown,
+	// so editor.onMouseDown fires AFTER onDidFocusEditorWidget. We use a
+	// native DOM capture-phase listener which fires before Monaco's
+	// handler to detect modifier keys early enough.
+	let hadModifierMouseDown = false;
+	const editorContainer = editor.getContainerDomNode();
+	const nativeMouseDownHandler = (e: MouseEvent) => {
+		hadModifierMouseDown = e.shiftKey || e.ctrlKey || e.metaKey;
+	};
+	disposables.add(addDisposableListener(editorContainer, 'mousedown', nativeMouseDownHandler, true));
+
+	// Also handle multi-selection from editor.onMouseDown (fires after
+	// focus) as a secondary path for cases where the focus handler
+	// couldn't prevent enterEditor in time.
+	disposables.add(editor.onMouseDown((e) => {
+		if (e.event.shiftKey || e.event.ctrlKey || e.event.metaKey) {
+			instance.selectionStateMachine.selectCell(cell, CellSelectionType.Add);
+		}
+	}));
+
+	disposables.add(editor.onDidFocusEditorWidget(() => {
+		// Consume and reset the modifier flag so it doesn't affect
+		// subsequent programmatic focus calls.
+		const wasModifierClick = hadModifierMouseDown;
+		hadModifierMouseDown = false;
+
+		// If the user shift/ctrl/cmd-clicked, the wrapper's onClick handler
+		// will handle multi-selection. Don't override that by entering edit mode.
+		if (wasModifierClick) {
+			cellEditorFocusedKey.set(true);
+			return;
+		}
+
+		// enterEditor() automatically detects that editor has focus and skips focus management.
+		// This also handles plain clicks during MultiSelection, collapsing the selection
+		// into EditingSelection for this cell.
+		instance.selectionStateMachine.enterEditor(cell);
+		cellEditorFocusedKey.set(true);
+	}));
+
+	disposables.add(editor.onDidBlurEditorWidget(() => {
+		// Clear any stale modifier flag so it doesn't incorrectly suppress
+		// enterEditor() on a later keyboard/programmatic focus.
+		hadModifierMouseDown = false;
+		cellEditorFocusedKey.set(false);
+
+		// Check where focus moved to - don't exit edit mode if focus moved to VS Code overlays
+		// or is still within the notebook editor scope.
+		// This prevents the command palette, quick open, find widget, etc. from closing
+		// immediately when opened from a cell in edit mode.
+		const activeElement = editor.getContainerDomNode().ownerDocument.activeElement;
+		if (!activeElement) {
+			// No active element - focus has truly left, exit edit mode
+			instance.selectionStateMachine.exitEditor(cell);
+			return;
+		}
+
+		const contextKeyContext = contextKeyService.getContext(activeElement);
+
+		// Context keys that indicate focus is still within VS Code overlays or related UI
+		const shouldKeepEditModeContextKeys = [
+			// VS Code overlays (command palette, quick open, etc.)
+			InQuickPickContextKey.key,
+			// Other editor inputs (find widget, etc.)
+			EditorContextKeys.textInputFocus.key,
+			// Find input box
+			CONTEXT_FIND_INPUT_FOCUSED.key,
+			// Replace input box
+			CONTEXT_REPLACE_INPUT_FOCUSED.key,
+			// Chat-related contexts (assistant inline or panel chat)
+			CTX_INLINE_CHAT_FOCUSED.key,
+			// Other editors like find widget etc..
+			EditorContextKeys.textInputFocus.key,
+			// Action widget menus (model switcher, etc.)
+			// Not exported anywhere but set in src/vs/platform/actionWidget/browser/actionWidget.ts
+			'codeActionMenuVisible',
+		];
+
+		const shouldKeepEditMode = shouldKeepEditModeContextKeys.some(contextKey => contextKeyContext.getValue(contextKey));
+		if (shouldKeepEditMode) {
+			return;
+		}
+
+		// Check if focus is still within the notebook editor container
+		// This covers both internal focus changes (cell to cell) and focus on notebook UI elements
+		if (instance.currentContainer?.contains(activeElement)) {
+			return;
+		}
+
+		// Focus has truly left the notebook editor - exit edit mode
+		// Pass the cell so we only exit if THIS specific cell is being edited (not a different one)
+		// This handles the race condition where a user clicks from one cell editor into another.
+		instance.selectionStateMachine.exitEditor(cell);
+	}));
+
+	/**
+	 * Resize the editor widget to fill the width of its container and the height of its
+	 * content.
+	 * @param height Height to set. Defaults to checking content height.
+	 */
+	function resizeEditor(height: number = editor.getContentHeight()) {
+		if (!editorPartRef.current) { return; }
+		editor.layout({
+			height,
+			width: editorPartRef.current.offsetWidth,
+		});
+	}
+
+	// Resize the editor when its content size changes
+	disposables.add(editor.onDidContentSizeChange(e => {
+		if (!(e.contentHeightChanged || e.contentWidthChanged)) { return; }
+		resizeEditor(e.contentHeight);
+	}));
+
+	// Resize the editor as the window resizes.
+	disposables.add(autorun(reader => {
+		instance.size.read(reader);
+		resizeEditor();
+	}));
+
+	logService.debug('Positron Notebook | useCellEditorWidget() | Setting up editor widget');
+
+	return disposables;
+}
+
 /**
  * Create a cell editor widget for a cell.
  * @param cell Cell whose editor is to be created
@@ -102,209 +313,24 @@ export function useCellEditorWidget(cell: PositronNotebookCellGeneral) {
 
 	// Create the editor
 	React.useEffect(() => {
-		if (!editorPartRef.current || !cell.scopedContextKeyService) { return; }
-
-		const disposables = new DisposableStore();
-
-		const language = cell.model.language;
-
-		// Create a scoped context key service for this editor as a child of the cell's scope.
-		// This ensures cell-level context keys (e.g. positronNotebookCellIsFirst) are visible
-		// to menus evaluated inside the editor. CodeEditorWidget will create its own child scope
-		// from this one for editor-specific keys.
-		const editorContextKeyService = cell.scopedContextKeyService.createScoped(editorPartRef.current);
-		disposables.add(editorContextKeyService);
-
-		// CRITICAL: Set the inCompositeEditor flag to change editor behavior
-		// This tells Monaco it's part of a composite (notebook) and not a standalone editor
-		// Without this flag, certain standalone editor keybindings would still fire
-		EditorContextKeys.inCompositeEditor.bindTo(editorContextKeyService).set(true);
-
-		// We need to ensure the EditorProgressService (or a fake) is available
-		// in the service collection because monaco editors will try and access
-		// it even though it's not available in the notebook context. This feels
-		// hacky but VSCode notebooks do the same thing so I guess it's easier
-		// than fixing it at the monaco level.
-		const serviceCollection = new ServiceCollection(
-			[
-				IEditorProgressService,
-				// Create a simple no-op IEditorProgressService for editor contributions
-				// Based on pattern from codeBlockPart.ts in chat contrib
-				new class implements IEditorProgressService {
-					_serviceBrand: undefined;
-					show() {
-						// No-op progress indicator for notebook cell editors
-						return { done: () => { }, total: () => { }, worked: () => { } };
-					}
-					async showWhile(promise: Promise<any>): Promise<void> {
-						await promise;
-					}
-				}],
-			[IContextKeyService, editorContextKeyService]
+		const disposables = createCellEditor(
+			editorPartRef,
+			cell,
+			instance,
+			services.configurationService,
+			services.contextKeyService,
+			services.logService
 		);
-
-		const editorInstaService = instance.scopedInstantiationService.createChild(serviceCollection);
-		const editorOptions = disposables.add(new PositronCellEditorOptions(instance, language, services.configurationService));
-
-		const editor = disposables.add(editorInstaService.createInstance(
-			CodeEditorWidget,
-			editorPartRef.current,
-			{
-				...editorOptions.getValue(),
-				// Initially set the editor size to 0x0.
-				dimension: {
-					width: 0,
-					height: 0,
-				}
-			},
-			{ contributions: getNotebookEditorContributions() }
-		));
-		cell.attachEditor(editor);
-
-		// Re-apply options when they change so the open notebook
-		// updates without requiring a reload.
-		disposables.add(editorOptions.onDidChange(() => {
-			editor.updateOptions(editorOptions.getValue());
-		}));
-
-		// Request model for cell and pass to editor.
-		cell.getTextEditorModel().then(model => {
-			editor.setModel(model);
-		});
-
-		// Bind the cell editor focused context key to the editor's internal scoped service
-		// (CodeEditorWidget creates this synchronously in its constructor)
-		const cellEditorFocusedKey = NotebookContextKeys.cellEditorFocused.bindTo(editor.contextKeyService);
-
-		// Track whether the most recent mousedown had modifier keys held.
-		// Monaco's _onMouseDown calls focus() BEFORE emitting onMouseDown,
-		// so editor.onMouseDown fires AFTER onDidFocusEditorWidget. We use a
-		// native DOM capture-phase listener which fires before Monaco's
-		// handler to detect modifier keys early enough.
-		let hadModifierMouseDown = false;
-		const editorContainer = editor.getContainerDomNode();
-		const nativeMouseDownHandler = (e: MouseEvent) => {
-			hadModifierMouseDown = e.shiftKey || e.ctrlKey || e.metaKey;
-		};
-		disposables.add(addDisposableListener(editorContainer, 'mousedown', nativeMouseDownHandler, true));
-
-		// Also handle multi-selection from editor.onMouseDown (fires after
-		// focus) as a secondary path for cases where the focus handler
-		// couldn't prevent enterEditor in time.
-		disposables.add(editor.onMouseDown((e) => {
-			if (e.event.shiftKey || e.event.ctrlKey || e.event.metaKey) {
-				instance.selectionStateMachine.selectCell(cell, CellSelectionType.Add);
-			}
-		}));
-
-		disposables.add(editor.onDidFocusEditorWidget(() => {
-			// Consume and reset the modifier flag so it doesn't affect
-			// subsequent programmatic focus calls.
-			const wasModifierClick = hadModifierMouseDown;
-			hadModifierMouseDown = false;
-
-			// If the user shift/ctrl/cmd-clicked, the wrapper's onClick handler
-			// will handle multi-selection. Don't override that by entering edit mode.
-			if (wasModifierClick) {
-				cellEditorFocusedKey.set(true);
-				return;
-			}
-
-			// enterEditor() automatically detects that editor has focus and skips focus management.
-			// This also handles plain clicks during MultiSelection, collapsing the selection
-			// into EditingSelection for this cell.
-			instance.selectionStateMachine.enterEditor(cell);
-			cellEditorFocusedKey.set(true);
-		}));
-
-		disposables.add(editor.onDidBlurEditorWidget(() => {
-			// Clear any stale modifier flag so it doesn't incorrectly suppress
-			// enterEditor() on a later keyboard/programmatic focus.
-			hadModifierMouseDown = false;
-			cellEditorFocusedKey.set(false);
-
-			// Check where focus moved to - don't exit edit mode if focus moved to VS Code overlays
-			// or is still within the notebook editor scope.
-			// This prevents the command palette, quick open, find widget, etc. from closing
-			// immediately when opened from a cell in edit mode.
-			const activeElement = editor.getContainerDomNode().ownerDocument.activeElement;
-			if (!activeElement) {
-				// No active element - focus has truly left, exit edit mode
-				instance.selectionStateMachine.exitEditor(cell);
-				return;
-			}
-
-			const contextKeyContext = services.contextKeyService.getContext(activeElement);
-
-			// Context keys that indicate focus is still within VS Code overlays or related UI
-			const shouldKeepEditModeContextKeys = [
-				// VS Code overlays (command palette, quick open, etc.)
-				InQuickPickContextKey.key,
-				// Other editor inputs (find widget, etc.)
-				EditorContextKeys.textInputFocus.key,
-				// Find input box
-				CONTEXT_FIND_INPUT_FOCUSED.key,
-				// Replace input box
-				CONTEXT_REPLACE_INPUT_FOCUSED.key,
-				// Chat-related contexts (assistant inline or panel chat)
-				CTX_INLINE_CHAT_FOCUSED.key,
-				// Other editors like find widget etc..
-				EditorContextKeys.textInputFocus.key,
-				// Action widget menus (model switcher, etc.)
-				// Not exported anywhere but set in src/vs/platform/actionWidget/browser/actionWidget.ts
-				'codeActionMenuVisible',
-			];
-
-			const shouldKeepEditMode = shouldKeepEditModeContextKeys.some(contextKey => contextKeyContext.getValue(contextKey));
-			if (shouldKeepEditMode) {
-				return;
-			}
-
-			// Check if focus is still within the notebook editor container
-			// This covers both internal focus changes (cell to cell) and focus on notebook UI elements
-			if (instance.currentContainer?.contains(activeElement)) {
-				return;
-			}
-
-			// Focus has truly left the notebook editor - exit edit mode
-			// Pass the cell so we only exit if THIS specific cell is being edited (not a different one)
-			// This handles the race condition where a user clicks from one cell editor into another.
-			instance.selectionStateMachine.exitEditor(cell);
-		}));
-
-		/**
-		 * Resize the editor widget to fill the width of its container and the height of its
-		 * content.
-		 * @param height Height to set. Defaults to checking content height.
-		 */
-		function resizeEditor(height: number = editor.getContentHeight()) {
-			if (!editorPartRef.current) { return; }
-			editor.layout({
-				height,
-				width: editorPartRef.current.offsetWidth,
-			});
+		if (!disposables) {
+			return;
 		}
-
-		// Resize the editor when its content size changes
-		disposables.add(editor.onDidContentSizeChange(e => {
-			if (!(e.contentHeightChanged || e.contentWidthChanged)) { return; }
-			resizeEditor(e.contentHeight);
-		}));
-
-		// Resize the editor as the window resizes.
-		disposables.add(autorun(reader => {
-			instance.size.read(reader);
-			resizeEditor();
-		}));
-
-		services.logService.debug('Positron Notebook | useCellEditorWidget() | Setting up editor widget');
 
 		return () => {
 			services.logService.debug('Positron Notebook | useCellEditorWidget() | Disposing editor widget');
 			disposables.dispose();
 			cell.detachEditor();
 		};
-	}, [cell, instance, services.configurationService, services.contextKeyService, services.instantiationService, services.logService]);
+	}, [cell, instance, services.configurationService, services.contextKeyService, services.logService]);
 
 	// Watch for editor focus requests from the cell
 	React.useLayoutEffect(() => {


### PR DESCRIPTION
Another step to simplify #14264, and maybe also a generally useful step.

The diff looks huge but it is just a cut and paste into a new function. Diff might look better if you hide whitespace changes.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

@:positron-notebooks @:web.