### PR TITLE
Fix extensions/positron-assistant/package-lock.json

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -1,960 +1,960 @@
 {
-	"name": "positron-assistant",
-	"displayName": "%displayName%",
-	"description": "%description%",
-	"version": "0.0.1",
-	"publisher": "positron",
-	"private": true,
-	"engines": {
-		"vscode": "^1.108.0"
-	},
-	"categories": [
-		"Other"
-	],
-	"activationEvents": [
-		"onStartupFinished"
-	],
-	"main": "./out/extension.js",
-	"enabledApiProposals": [
-		"chatProvider",
-		"codeActionAI",
-		"defaultChatParticipant",
-		"findFiles2",
-		"inlineCompletionsAdditions",
-		"languageModelSystem"
-	],
-	"contributes": {
-		"authentication": [
-			{
-				"label": "Posit AI",
-				"id": "posit-ai",
-				"authorizationServerGlobs": [
-					"https://*.posit.co/*",
-					"https://*.posit.ai/*",
-					"https://*.posit.cloud/*"
-				]
-			}
-		],
-		"chatParticipants": [
-			{
-				"id": "positron.assistant.chat",
-				"name": "assistant",
-				"fullName": "%chatParticipants.fullName%",
-				"description": "%chatParticipants.ask.description%",
-				"isSticky": false,
-				"isDefault": true,
-				"commands": [
-					{
-						"name": "exportQuarto",
-						"description": "%chatParticipants.commands.exportQuarto.description%"
-					},
-					{
-						"name": "fix",
-						"description": "%chatParticipants.commands.fix.description%"
-					},
-					{
-						"name": "explain",
-						"description": "%chatParticipants.commands.explain.description%"
-					}
-				],
-				"locations": [
-					"panel"
-				],
-				"modes": [
-					"ask"
-				]
-			},
-			{
-				"id": "positron.assistant.agent",
-				"name": "assistant",
-				"fullName": "%chatParticipants.fullName%",
-				"description": "%chatParticipants.agent.description%",
-				"isDefault": true,
-				"locations": [
-					"panel"
-				],
-				"modes": [
-					"agent"
-				]
-			},
-			{
-				"id": "positron.assistant.terminal",
-				"name": "assistant",
-				"fullName": "%chatParticipants.fullName%",
-				"description": "%chatParticipants.ask.description%",
-				"isSticky": false,
-				"isDefault": true,
-				"locations": [
-					"terminal"
-				]
-			},
-			{
-				"id": "positron.assistant.editor",
-				"name": "assistant",
-				"fullName": "%chatParticipants.fullName%",
-				"description": "%chatParticipants.ask.description%",
-				"isSticky": false,
-				"isDefault": true,
-				"locations": [
-					"editor"
-				],
-				"commands": [
-					{
-						"name": "fix",
-						"description": "%chatParticipants.commands.fix.description%"
-					},
-					{
-						"name": "explain",
-						"description": "%chatParticipants.commands.explain.description%"
-					},
-					{
-						"name": "doc",
-						"description": "%chatParticipants.commands.doc.description%"
-					}
-				]
-			},
-			{
-				"id": "positron.assistant.notebook",
-				"name": "assistant",
-				"fullName": "%chatParticipants.fullName%",
-				"description": "%chatParticipants.ask.description%",
-				"isSticky": false,
-				"isDefault": true,
-				"locations": [
-					"notebook"
-				]
-			},
-			{
-				"id": "positron.assistant.editingSessionEditor",
-				"name": "assistant",
-				"fullName": "%chatParticipants.fullName%",
-				"description": "%chatParticipants.edit.description%",
-				"isSticky": false,
-				"isDefault": true,
-				"locations": [
-					"panel"
-				],
-				"modes": [
-					"edit"
-				]
-			}
-		],
-		"menus": {
-			"scm/inputBox": [
-				{
-					"command": "positron-assistant.generateCommitMessage",
-					"group": "navigation",
-					"when": "!positron-assistant.generatingCommitMessage && config.positron.assistant.gitIntegration.enable"
-				},
-				{
-					"command": "positron-assistant.cancelGenerateCommitMessage",
-					"group": "navigation",
-					"when": "positron-assistant.generatingCommitMessage && config.positron.assistant.gitIntegration.enable"
-				}
-			],
-			"commandPalette": [
-				{
-					"command": "positron-assistant.configureProviders",
-					"when": "false"
-				}
-			]
-		},
-		"commands": [
-			{
-				"command": "positron-assistant.enableAssistantSetting",
-				"title": "%commands.enableAssistant.title%",
-				"category": "%commands.category%",
-				"enablement": "!config.positron.assistant.enable"
-			},
-			{
-				"command": "positron-assistant.exportChatToFileInWorkspace",
-				"title": "%commands.exportChatToFileInWorkspace.title%",
-				"category": "%commands.category%",
-				"enablement": "config.positron.assistant.enable && workspaceFolderCount != 0"
-			},
-			{
-				"command": "positron-assistant.exportChatTo",
-				"title": "%commands.exportChatTo.title%",
-				"category": "%commands.category%",
-				"enablement": "config.positron.assistant.enable"
-			},
-			{
-				"command": "positron-assistant.configureProviders",
-				"title": "%commands.configureProviders.title%",
-				"category": "%commands.category%",
-				"enablement": "config.positron.assistant.enable"
-			},
-			{
-				"command": "positron-assistant.logStoredModels",
-				"title": "%commands.logStoredModels.title%",
-				"category": "%commands.category%",
-				"enablement": "config.positron.assistant.enable"
-			},
-			{
-				"command": "positron-assistant.generateCommitMessage",
-				"title": "%commands.generateCommitMessage.title%",
-				"category": "%commands.category%",
-				"enablement": "config.positron.assistant.enable && config.positron.assistant.gitIntegration.enable",
-				"icon": "$(sparkle)"
-			},
-			{
-				"command": "positron-assistant.cancelGenerateCommitMessage",
-				"title": "%commands.cancelGenerateCommitMessage.title%",
-				"category": "%commands.category%",
-				"enablement": "config.positron.assistant.enable && config.positron.assistant.gitIntegration.enable",
-				"icon": "$(stop)"
-			},
-			{
-				"command": "positron-assistant.managePromptFiles",
-				"title": "%commands.managePromptFiles.title%",
-				"category": "%commands.category%",
-				"enablement": "config.positron.assistant.enable && isDevelopment"
-			},
-			{
-				"command": "positron-assistant.collectDiagnostics",
-				"title": "%commands.collectDiagnostics.title%",
-				"category": "%commands.category%",
-				"enablement": "config.positron.assistant.enable"
-			}
-		],
-		"configuration": [
-			{
-				"type": "object",
-				"title": "%configuration.title%",
-				"properties": {
-					"positron.assistant.enable": {
-						"type": "boolean",
-						"default": false,
-						"markdownDescription": "%configuration.enable.markdownDescription%",
-						"markdownDeprecationMessage": "%configuration.enable.markdownDeprecationMessage%",
-						"tags": [
-							"preview"
-						]
-					},
-					"positron.assistant.toolDetails.enable": {
-						"type": "boolean",
-						"default": false,
-						"description": "%configuration.toolDetails.enable%"
-					},
-					"positron.assistant.useAnthropicSdk": {
-						"type": "boolean",
-						"default": false,
-						"description": "%configuration.useAnthropicSdk.description%",
-						"tags": [
-							"advanced"
-						]
-					},
-					"positron.assistant.streamingEdits.enable": {
-						"type": "boolean",
-						"default": true,
-						"description": "%configuration.streamingEdits.enable%"
-					},
-					"positron.assistant.gitIntegration.enable": {
-						"type": "boolean",
-						"default": true,
-						"description": "%configuration.gitIntegration.description%"
-					},
-					"positron.assistant.showTokenUsage.enable": {
-						"type": "boolean",
-						"default": false,
-						"description": "%configuration.showTokenUsage.description%"
-					},
-					"positron.assistant.maxInputTokens": {
-						"type": "object",
-						"default": {},
-						"description": "%configuration.maxInputTokens.description%",
-						"additionalProperties": {
-							"type": "number",
-							"minimum": 512
-						}
-					},
-					"positron.assistant.maxOutputTokens": {
-						"type": "object",
-						"default": {},
-						"description": "%configuration.maxOutputTokens.description%",
-						"additionalProperties": {
-							"type": "number",
-							"minimum": 512
-						}
-					},
-					"positron.assistant.toolErrors.propagate": {
-						"type": "boolean",
-						"default": false,
-						"markdownDescription": "%configuration.toolErrors.propagate.description%"
-					},
-					"positron.assistant.alwaysIncludeCopilotTools": {
-						"type": "boolean",
-						"default": false,
-						"markdownDescription": "%configuration.alwaysIncludeCopilotTools.description%"
-					},
-					"positron.assistant.providerTimeout": {
-						"type": "number",
-						"default": 60,
-						"markdownDescription": "%configuration.providerTimeout.description%",
-						"minimum": 1
-					},
-					"positron.assistant.models.preference.global": {
-						"type": "string",
-						"default": "",
-						"markdownDescription": "%configuration.models.preference.global.description%",
-						"examples": [
-							"Claude Sonnet 4.5",
-							"GPT-5"
-						]
-					},
-					"positron.assistant.providerVariables.bedrock": {
-						"type": "object",
-						"default": {},
-						"markdownDescription": "%configuration.providerVariables.bedrock.description%",
-						"markdownDeprecationMessage": "This setting has been moved to the Authentication extension. Use `#authentication.aws.credentials#` instead.",
-						"properties": {
-							"AWS_PROFILE": {
-								"type": "string",
-								"default": null
-							},
-							"AWS_REGION": {
-								"type": "string",
-								"default": null
-							}
-						},
-						"additionalProperties": false
-					},
-					"positron.assistant.bedrock.inferenceProfileRegion": {
-						"type": "string",
-						"default": null,
-						"markdownDescription": "%configuration.bedrock.inferenceProfileRegion.description%",
-						"markdownDeprecationMessage": "This setting has been moved to the Authentication extension. Use `#authentication.aws.inferenceProfileRegion#` instead."
-					},
-					"positron.assistant.providerVariables.snowflake": {
-						"type": "object",
-						"default": {},
-						"markdownDescription": "%configuration.providerVariables.snowflake.description%",
-						"markdownDeprecationMessage": "This setting has been moved to the Authentication extension. Use `#authentication.snowflake.credentials#` instead.",
-						"properties": {
-							"SNOWFLAKE_ACCOUNT": {
-								"type": "string",
-								"default": null
-							},
-							"SNOWFLAKE_HOME": {
-								"type": "string",
-								"default": null
-							}
-						},
-						"additionalProperties": false
-					},
-					"positron.assistant.alwaysEnableApplyInEditorAction": {
-						"type": "boolean",
-						"default": false,
-						"description": "%configuration.alwaysEnableApplyInEditorAction.description%"
-					}
-				}
-			},
-			{
-				"type": "object",
-				"title": "%configuration.modelPreferences.title%",
-				"properties": {
-					"positron.assistant.models.preference.byProvider": {
-						"type": "object",
-						"markdownDeprecationMessage": "%configuration.models.preference.byProvider.deprecated.markdownDeprecationMessage%",
-						"description": "%configuration.models.preference.byProvider.deprecated.description%"
-					},
-					"positron.assistant.models.preference.anthropic": {
-						"type": "string",
-						"default": "",
-						"markdownDescription": "%configuration.models.preference.anthropic.description%"
-					},
-					"positron.assistant.models.preference.githubCopilot": {
-						"type": "string",
-						"default": "",
-						"markdownDescription": "%configuration.models.preference.githubCopilot.description%",
-						"tags": [
-							"preview"
-						]
-					},
-					"positron.assistant.models.preference.amazonBedrock": {
-						"type": "string",
-						"default": "",
-						"markdownDescription": "%configuration.models.preference.amazonBedrock.description%"
-					},
-					"positron.assistant.models.preference.snowflakeCortex": {
-						"type": "string",
-						"default": "",
-						"markdownDescription": "%configuration.models.preference.snowflakeCortex.description%"
-					},
-					"positron.assistant.models.preference.msFoundry": {
-						"type": "string",
-						"default": "",
-						"markdownDescription": "%configuration.models.preference.msFoundry.description%",
-						"tags": [
-							"preview"
-						]
-					},
-					"positron.assistant.models.preference.openAI": {
-						"type": "string",
-						"default": "",
-						"markdownDescription": "%configuration.models.preference.openAI.description%"
-					},
-					"positron.assistant.models.preference.customProvider": {
-						"type": "string",
-						"default": "",
-						"markdownDescription": "%configuration.models.preference.customProvider.description%",
-						"tags": [
-							"experimental"
-						]
-					},
-					"positron.assistant.models.preference.positAI": {
-						"type": "string",
-						"default": "",
-						"markdownDescription": "%configuration.models.preference.positAI.description%"
-					},
-					"positron.assistant.models.preference.google": {
-						"type": "string",
-						"default": "",
-						"markdownDescription": "%configuration.models.preference.google.description%",
-						"tags": [
-							"experimental",
-							"advanced"
-						]
-					},
-					"positron.assistant.models.preference.echo": {
-						"type": "string",
-						"default": "",
-						"markdownDescription": "%configuration.models.preference.echo.description%",
-						"tags": [
-							"advanced"
-						]
-					},
-					"positron.assistant.models.preference.error": {
-						"type": "string",
-						"default": "",
-						"markdownDescription": "%configuration.models.preference.error.description%",
-						"tags": [
-							"advanced"
-						]
-					}
-				}
-			}
-		],
-		"languageModelChatProviders": [
-			{
-				"vendor": "echo",
-				"displayName": "Echo",
-				"managementCommand": "positron-assistant.configureProviders"
-			},
-			{
-				"vendor": "amazon-bedrock",
-				"displayName": "Amazon Bedrock",
-				"managementCommand": "positron-assistant.configureProviders"
-			},
-			{
-				"vendor": "ms-foundry",
-				"displayName": "Microsoft Foundry",
-				"managementCommand": "positron-assistant.configureProviders"
-			},
-			{
-				"vendor": "anthropic-api",
-				"displayName": "Anthropic",
-				"managementCommand": "positron-assistant.configureProviders"
-			},
-			{
-				"vendor": "openai-api",
-				"displayName": "OpenAI",
-				"managementCommand": "positron-assistant.configureProviders"
-			},
-			{
-				"vendor": "openai-compatible",
-				"displayName": "Custom Provider",
-				"managementCommand": "positron-assistant.configureProviders"
-			},
-			{
-				"vendor": "posit-ai",
-				"displayName": "Posit AI",
-				"managementCommand": "positron-assistant.configureProviders"
-			},
-			{
-				"vendor": "snowflake-cortex",
-				"displayName": "Snowflake Cortex",
-				"managementCommand": "positron-assistant.configureProviders"
-			},
-			{
-				"vendor": "google",
-				"displayName": "Gemini Code Assist",
-				"managementCommand": "positron-assistant.configureProviders"
-			}
-		],
-		"languageModelTools": [
-			{
-				"name": "documentEdit",
-				"displayName": "Edit Document",
-				"modelDescription": "Output an edited version of the document.",
-				"canBeReferencedInPrompt": false,
-				"tags": [
-					"positron-assistant"
-				],
-				"inputSchema": {
-					"type": "object",
-					"properties": {
-						"deltas": {
-							"type": "array",
-							"description": "The array of changes to apply.",
-							"items": {
-								"type": "object",
-								"properties": {
-									"delete": {
-										"type": "string",
-										"description": "Text to delete from the document."
-									},
-									"replace": {
-										"type": "string",
-										"description": "Text to replace the deleted text with."
-									}
-								}
-							}
-						}
-					}
-				}
-			},
-			{
-				"name": "documentCreate",
-				"displayName": "Create Document",
-				"modelDescription": "Create a new document in the workspace.",
-				"canBeReferencedInPrompt": false,
-				"tags": [
-					"positron-assistant",
-					"requires-workspace"
-				],
-				"inputSchema": {
-					"type": "object",
-					"properties": {
-						"filePath": {
-							"type": "string",
-							"description": "The path to the document to create, including the file name and extension. This path must be relative to the workspace folder."
-						},
-						"workspaceFolder": {
-							"type": "string",
-							"description": "The workspace folder to create the document in. If not specified, the document will be created in the first workspace folder."
-						},
-						"content": {
-							"type": "string",
-							"description": "The initial content of the document. If not specified, the document will be created empty."
-						},
-						"errorIfExists": {
-							"type": "boolean",
-							"description": "Whether to throw an error if the document already exists. If false, the existing document will be opened instead.",
-							"default": true
-						}
-					}
-				}
-			},
-			{
-				"name": "selectionEdit",
-				"displayName": "Edit Selection",
-				"modelDescription": "Output an edited version of the selected text.",
-				"canBeReferencedInPrompt": false,
-				"tags": [
-					"positron-assistant"
-				],
-				"inputSchema": {
-					"type": "object",
-					"properties": {
-						"code": {
-							"type": "string",
-							"description": "The entire edited code selection."
-						}
-					}
-				}
-			},
-			{
-				"name": "executeCode",
-				"displayName": "Execute Code",
-				"modelDescription": "Execute a piece of code in the specified programming language and return the result. You prefer to show code over running it unless given an imperative. You prefer this tool to the terminal and other ways of running code when there is a session available with the correct language.",
-				"icon": "$(play)",
-				"toolReferenceName": "executeCode",
-				"userDescription": "Execute code in the console",
-				"canBeReferencedInPrompt": true,
-				"inputSchema": {
-					"type": "object",
-					"properties": {
-						"sessionIdentifier": {
-							"type": "string",
-							"description": "The identifier of the session to execute the code in."
-						},
-						"code": {
-							"type": "string",
-							"description": "The code to execute."
-						},
-						"language": {
-							"type": "string",
-							"description": "The programming language of the code."
-						},
-						"summary": {
-							"type": "string",
-							"description": "A very short summary of the task the code is performing, beginning with a verb and not to exceed 7 words. Shown to the user to help them understand what the code will do."
-						}
-					}
-				},
-				"tags": [
-					"positron-assistant",
-					"requires-session"
-				]
-			},
-			{
-				"name": "inspectVariables",
-				"displayName": "Inspect Variables",
-				"modelDescription": "List the children of an array of variables in a session. For example, the columns in a dataframe, items in a column or array, or elements of a list. If `variableNames` is empty, lists all root-level variables in the session.",
-				"icon": "$(positron-variables-view)",
-				"toolReferenceName": "inspectVariables",
-				"userDescription": "Inspect data and variables in the current session",
-				"canBeReferencedInPrompt": true,
-				"inputSchema": {
-					"type": "object",
-					"properties": {
-						"sessionIdentifier": {
-							"type": "string",
-							"description": "The identifier of the session to inspect."
-						},
-						"variableNames": {
-							"type": "array",
-							"description": "An array of variable names to inspect.",
-							"items": {
-								"type": "string",
-								"description": "The name of a variable to inspect."
-							}
-						}
-					},
-					"required": [
-						"sessionIdentifier",
-						"variableNames"
-					]
-				},
-				"tags": [
-					"positron-assistant",
-					"requires-session"
-				]
-			},
-			{
-				"name": "getPlot",
-				"displayName": "View active plot",
-				"modelDescription": "View the current active plot if one exists. Don't invoke this tool if there are no plots in the session.",
-				"icon": "$(graph)",
-				"toolReferenceName": "getPlot",
-				"userDescription": "View the current active plot.",
-				"canBeReferencedInPrompt": true,
-				"tags": [
-					"positron-assistant",
-					"requires-session"
-				]
-			},
-			{
-				"name": "getTableSummary",
-				"displayName": "Get Table Summary",
-				"modelDescription": "Retrieve summary statistics and structure of tabular data variables (DataFrames, tibbles, arrays) in the current session. Use when the user asks to summarize, describe, or inspect their data.",
-				"canBeReferencedInPrompt": true,
-				"toolReferenceName": "getTableSummary",
-				"userDescription": "Get a summary of a table's data and structure.",
-				"icon": "$(table)",
-				"inputSchema": {
-					"type": "object",
-					"properties": {
-						"sessionIdentifier": {
-							"type": "string",
-							"description": "The identifier of the session that contains the tables."
-						},
-						"variableNames": {
-							"type": "array",
-							"description": "An array of table variable names to summarize.",
-							"items": {
-								"type": "string",
-								"description": "The name of a table variable to summarize."
-							}
-						}
-					},
-					"required": [
-						"sessionIdentifier",
-						"variableNames"
-					]
-				},
-				"tags": [
-					"positron-assistant",
-					"requires-session"
-				]
-			},
-			{
-				"name": "getProjectTree",
-				"displayName": "Get Project Tree",
-				"modelDescription": "Get the project tree of the current workspace as a JSON object. This is useful for understanding the structure of the project and finding files. Empty folders are not included in the tree unless `directoriesOnly` is true. Set `directoriesOnly` to true to return only directories without listing files within them; this is more efficient for discovering directories.",
-				"icon": "$(file-directory)",
-				"toolReferenceName": "projectTree",
-				"userDescription": "Get the project tree of the current workspace.",
-				"canBeReferencedInPrompt": true,
-				"tags": [
-					"positron-assistant",
-					"requires-workspace"
-				],
-				"inputSchema": {
-					"type": "object",
-					"properties": {
-						"include": {
-							"type": "array",
-							"items": {
-								"type": "string",
-								"description": "A Glob pattern to include in the project tree. Only the files and folders matching these patterns will be considered. If files are also matched by the `excludes` patterns, they will be filtered out."
-							},
-							"description": "Glob patterns to include in the project tree. This parameter is required. Use specific patterns to target relevant files (e.g., ['src/**/*.ts'], ['*.py', 'tests/**'])."
-						},
-						"exclude": {
-							"type": "array",
-							"items": {
-								"type": "string",
-								"description": "A Glob pattern to exclude from the project tree. Files and folders matching these patterns will be filtered out, even if they match an included Glob."
-							},
-							"description": "Glob patterns to exclude from the project tree. These patterns will be applied _in addition to_ the default excludes unless `skipDefaultExcludes` is true."
-						},
-						"skipDefaultExcludes": {
-							"type": "boolean",
-							"description": "Whether to skip all automatic exclusions (.gitignore rules, VS Code exclude settings, and default exclusions for dependencies, build artifacts, and other commonly ignored files/directories). When true, only the explicit `exclude` patterns will be applied.",
-							"default": false
-						},
-						"maxItems": {
-							"type": "number",
-							"description": "The maximum number of items (files or directories) to include in the project tree (<=50). If this limit is reached, a compressed description of the project will be provided instead.",
-							"default": 50
-						},
-						"directoriesOnly": {
-							"type": "boolean",
-							"description": "When true, returns only directories without listing files within them. Empty directories are included. This is more efficient for directory queries. Prefer this over running code in the terminal for finding directories.",
-							"default": false
-						}
-					},
-					"required": [
-						"include"
-					]
-				}
-			},
-			{
-				"name": "getChangedFiles",
-				"displayName": "Get changed files",
-				"modelDescription": "Get summaries and git diffs for current changes to files in this workspace.",
-				"canBeReferencedInPrompt": true,
-				"userDescription": "Get changed files",
-				"toolReferenceName": "changes",
-				"when": "config.positron.assistant.gitIntegration.enable",
-				"icon": "$(diff)",
-				"tags": [
-					"positron-assistant"
-				]
-			},
-			{
-				"name": "executeNotebook",
-				"displayName": "Execute Notebook",
-				"modelDescription": "Manage notebook execution lifecycle. Use operation='run' to execute specific cells by index and return their outputs. Use operation='runAll' to execute all cells in order. Use operation='interrupt' to cancel a running execution. Use operation='restartKernel' to restart the kernel (optionally with runAll=true to run all cells after restart).",
-				"toolReferenceName": "executeNotebook",
-				"canBeReferencedInPrompt": true,
-				"tags": [
-					"positron-assistant",
-					"requires-notebook"
-				],
-				"inputSchema": {
-					"type": "object",
-					"properties": {
-						"operation": {
-							"type": "string",
-							"enum": [
-								"run",
-								"runAll",
-								"interrupt",
-								"restartKernel"
-							],
-							"description": "Type of execution operation. 'run' executes specific cells by index, 'runAll' executes all cells in order, 'interrupt' cancels running execution, 'restartKernel' restarts the kernel."
-						},
-						"cellIndices": {
-							"type": "array",
-							"description": "Array of cell indices to execute (0-based). Required when operation is 'run'.",
-							"items": {
-								"type": "number"
-							}
-						},
-						"runAll": {
-							"type": "boolean",
-							"description": "When true with operation='restartKernel', run all cells after the kernel restarts. Defaults to false."
-						}
-					},
-					"required": [
-						"operation"
-					]
-				}
-			},
-			{
-				"name": "editNotebook",
-				"displayName": "Edit Notebook",
-				"modelDescription": "Perform edit operations on notebook cells. Use operation='add' to create new cells (requires cellType, index, and content). Code cells are executed by default after adding (set run=false to skip execution). Use operation='update' to modify existing cells (requires cellIndex and content), operation='delete' to remove cells (requires cellIndices array, e.g., [0] for single cell or [0,1,2] for multiple), operation='reorder' to reorganize cells, or operation='clearOutputs' to clear cell outputs (optionally pass cellIndices to clear specific cells, or omit to clear all). For reorder, either use fromIndex and toIndex to move a single cell, or provide newOrder array (a permutation where newOrder[i] is the original index of the cell that should be at position i) to reorder all cells at once. Use index=-1 to append cells at the end when adding.",
-				"toolReferenceName": "editNotebook",
-				"canBeReferencedInPrompt": true,
-				"tags": [
-					"positron-assistant"
-				],
-				"inputSchema": {
-					"type": "object",
-					"properties": {
-						"operation": {
-							"type": "string",
-							"enum": [
-								"add",
-								"update",
-								"delete",
-								"reorder",
-								"clearOutputs"
-							],
-							"description": "Type of edit operation to perform. 'add' creates a new cell, 'update' modifies existing cell content, 'delete' removes a cell, 'reorder' moves cells to new positions, 'clearOutputs' clears cell outputs (optionally for specific cells via cellIndices)."
-						},
-						"cellType": {
-							"type": "string",
-							"enum": [
-								"code",
-								"markdown"
-							],
-							"description": "Type of cell to create. Required when operation is 'add'. Use 'code' for executable cells, 'markdown' for documentation."
-						},
-						"index": {
-							"type": "number",
-							"description": "Position to insert the cell (0-based). Required when operation is 'add'. Use -1 to append at the end."
-						},
-						"content": {
-							"type": "string",
-							"description": "Cell content. Required when operation is 'add' or 'update'."
-						},
-						"cellIndex": {
-							"type": "number",
-							"description": "Index of the cell to modify (0-based). Required when operation is 'update'."
-						},
-						"cellIndices": {
-							"type": "array",
-							"items": {
-								"type": "number"
-							},
-							"description": "Array of cell indices (0-based). Required for 'delete'. Optional for 'clearOutputs' (omit to clear all). Use [0] for single cell or [0,1,2] for multiple."
-						},
-						"run": {
-							"type": "boolean",
-							"description": "Whether to execute the cell after adding it. Defaults to true for code cells. Ignored for markdown cells."
-						},
-						"fromIndex": {
-							"type": "number",
-							"description": "Current index of the cell to move (0-based). Required when operation is 'reorder' and not using newOrder."
-						},
-						"toIndex": {
-							"type": "number",
-							"description": "Target index to move the cell to (0-based). Required when operation is 'reorder' and not using newOrder."
-						},
-						"newOrder": {
-							"type": "array",
-							"items": {
-								"type": "number"
-							},
-							"description": "Array specifying new cell order. newOrder[i] is the original index of the cell that should be at position i. Must be a valid permutation containing each index 0 to cellCount-1 exactly once. Use this for full notebook reordering. Alternative to fromIndex/toIndex for operation='reorder'."
-						}
-					},
-					"required": [
-						"operation"
-					]
-				}
-			},
-			{
-				"name": "getNotebookInfo",
-				"displayName": "Get Notebook Info",
-				"modelDescription": "Retrieve information about notebook cells and kernel status. Use operation='get' to fetch specific cells by index or all cells if cellIndices is omitted, operation='getSelected' to get only selected cells, operation='getOutputs' to retrieve cell execution outputs (requires cellIndices), operation='getMetadata' to get only cell status information without content, or operation='getKernelStatus' to get kernel state and session metadata.",
-				"toolReferenceName": "getNotebookInfo",
-				"canBeReferencedInPrompt": true,
-				"tags": [
-					"positron-assistant"
-				],
-				"inputSchema": {
-					"type": "object",
-					"properties": {
-						"operation": {
-							"type": "string",
-							"enum": [
-								"get",
-								"getSelected",
-								"getOutputs",
-								"getMetadata",
-								"getKernelStatus"
-							],
-							"description": "Type of read operation. 'get' retrieves cell info, 'getSelected' gets only selected cells, 'getOutputs' retrieves cell execution outputs, 'getMetadata' gets only status/execution info without content, 'getKernelStatus' gets kernel state and session metadata."
-						},
-						"cellIndices": {
-							"type": "array",
-							"description": "Optional array of cell indices to retrieve (0-based). Required for 'getOutputs'. For 'get', returns all cells if omitted. Ignored for 'getSelected' and 'getMetadata'.",
-							"items": {
-								"type": "number"
-							}
-						}
-					},
-					"required": [
-						"operation"
-					]
-				}
-			},
-			{
-				"name": "createNotebook",
-				"displayName": "Create Notebook",
-				"modelDescription": "Create a new Jupyter notebook with the specified language kernel (Python or R). Use when the user wants to start a new notebook. After creation, use editNotebook to add content.",
-				"toolReferenceName": "createNotebook",
-				"canBeReferencedInPrompt": true,
-				"tags": [
-					"positron-assistant"
-				],
-				"inputSchema": {
-					"type": "object",
-					"properties": {
-						"language": {
-							"type": "string",
-							"enum": ["python", "r"],
-							"description": "The kernel language for the notebook"
-						}
-					},
-					"required": ["language"]
-				}
-			}
-		]
-	},
-	"scripts": {
-		"compile": "gulp compile-extension:positron-assistant",
-		"vscode:prepublish": "npm run compile",
-		"pretest": "npm run compile"
-	},
-	"devDependencies": {
-		"@ai-sdk/amazon-bedrock": "^3.0.93",
-		"@ai-sdk/anthropic": "^2.0.53",
-		"@ai-sdk/azure": "^2.0.78",
-		"@ai-sdk/google": "^2.0.44",
-		"@ai-sdk/openai": "^2.0.76",
-		"@aws-sdk/credential-providers": "^3.734.0",
-		"@eslint/js": "^9.13.0",
-		"@stylistic/eslint-plugin": "^2.9.0",
-		"@types/mocha": "^9.1.0",
-		"@types/node": "^20",
-		"@types/sinon": "^17.0.3",
-		"ai": "^5.0.106",
-		"eslint": "^9.13.0",
-		"google-auth-library": "^9.15.1",
-		"mocha": "^9.2.1",
-		"openai": "^6.10.0",
-		"sinon": "^17.0.1",
-		"ts-node": "^10.9.2",
-		"typescript": "^5.6.2",
-		"typescript-eslint": "^8.11.0",
-		"zod": "^3.24.1"
-	},
-	"dependencies": {
-		"@ai-sdk/provider-utils": "^2.1.3",
-		"@anthropic-ai/sdk": "^0.57.0",
-		"@vscode/prompt-tsx": "^0.4.0-alpha.5",
-		"yaml": "^2.8.1"
-	},
-	"extensionDependencies": [
-		"positron.positron-supervisor",
-		"positron.positron-environment",
-		"positron.authentication"
-	]
+  "name": "positron-assistant",
+  "displayName": "%displayName%",
+  "description": "%description%",
+  "version": "0.0.1",
+  "publisher": "positron",
+  "private": true,
+  "engines": {
+    "vscode": "^1.108.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onStartupFinished"
+  ],
+  "main": "./out/extension.js",
+  "enabledApiProposals": [
+    "chatProvider",
+    "codeActionAI",
+    "defaultChatParticipant",
+    "findFiles2",
+    "inlineCompletionsAdditions",
+    "languageModelSystem"
+  ],
+  "contributes": {
+    "authentication": [
+      {
+        "label": "Posit AI",
+        "id": "posit-ai",
+        "authorizationServerGlobs": [
+          "https://*.posit.co/*",
+          "https://*.posit.ai/*",
+          "https://*.posit.cloud/*"
+        ]
+      }
+    ],
+    "chatParticipants": [
+      {
+        "id": "positron.assistant.chat",
+        "name": "assistant",
+        "fullName": "%chatParticipants.fullName%",
+        "description": "%chatParticipants.ask.description%",
+        "isSticky": false,
+        "isDefault": true,
+        "commands": [
+          {
+            "name": "exportQuarto",
+            "description": "%chatParticipants.commands.exportQuarto.description%"
+          },
+          {
+            "name": "fix",
+            "description": "%chatParticipants.commands.fix.description%"
+          },
+          {
+            "name": "explain",
+            "description": "%chatParticipants.commands.explain.description%"
+          }
+        ],
+        "locations": [
+          "panel"
+        ],
+        "modes": [
+          "ask"
+        ]
+      },
+      {
+        "id": "positron.assistant.agent",
+        "name": "assistant",
+        "fullName": "%chatParticipants.fullName%",
+        "description": "%chatParticipants.agent.description%",
+        "isDefault": true,
+        "locations": [
+          "panel"
+        ],
+        "modes": [
+          "agent"
+        ]
+      },
+      {
+        "id": "positron.assistant.terminal",
+        "name": "assistant",
+        "fullName": "%chatParticipants.fullName%",
+        "description": "%chatParticipants.ask.description%",
+        "isSticky": false,
+        "isDefault": true,
+        "locations": [
+          "terminal"
+        ]
+      },
+      {
+        "id": "positron.assistant.editor",
+        "name": "assistant",
+        "fullName": "%chatParticipants.fullName%",
+        "description": "%chatParticipants.ask.description%",
+        "isSticky": false,
+        "isDefault": true,
+        "locations": [
+          "editor"
+        ],
+        "commands": [
+          {
+            "name": "fix",
+            "description": "%chatParticipants.commands.fix.description%"
+          },
+          {
+            "name": "explain",
+            "description": "%chatParticipants.commands.explain.description%"
+          },
+          {
+            "name": "doc",
+            "description": "%chatParticipants.commands.doc.description%"
+          }
+        ]
+      },
+      {
+        "id": "positron.assistant.notebook",
+        "name": "assistant",
+        "fullName": "%chatParticipants.fullName%",
+        "description": "%chatParticipants.ask.description%",
+        "isSticky": false,
+        "isDefault": true,
+        "locations": [
+          "notebook"
+        ]
+      },
+      {
+        "id": "positron.assistant.editingSessionEditor",
+        "name": "assistant",
+        "fullName": "%chatParticipants.fullName%",
+        "description": "%chatParticipants.edit.description%",
+        "isSticky": false,
+        "isDefault": true,
+        "locations": [
+          "panel"
+        ],
+        "modes": [
+          "edit"
+        ]
+      }
+    ],
+    "menus": {
+      "scm/inputBox": [
+        {
+          "command": "positron-assistant.generateCommitMessage",
+          "group": "navigation",
+          "when": "!positron-assistant.generatingCommitMessage && config.positron.assistant.gitIntegration.enable"
+        },
+        {
+          "command": "positron-assistant.cancelGenerateCommitMessage",
+          "group": "navigation",
+          "when": "positron-assistant.generatingCommitMessage && config.positron.assistant.gitIntegration.enable"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "positron-assistant.configureProviders",
+          "when": "false"
+        }
+      ]
+    },
+    "commands": [
+      {
+        "command": "positron-assistant.enableAssistantSetting",
+        "title": "%commands.enableAssistant.title%",
+        "category": "%commands.category%",
+        "enablement": "!config.positron.assistant.enable"
+      },
+      {
+        "command": "positron-assistant.exportChatToFileInWorkspace",
+        "title": "%commands.exportChatToFileInWorkspace.title%",
+        "category": "%commands.category%",
+        "enablement": "config.positron.assistant.enable && workspaceFolderCount != 0"
+      },
+      {
+        "command": "positron-assistant.exportChatTo",
+        "title": "%commands.exportChatTo.title%",
+        "category": "%commands.category%",
+        "enablement": "config.positron.assistant.enable"
+      },
+      {
+        "command": "positron-assistant.configureProviders",
+        "title": "%commands.configureProviders.title%",
+        "category": "%commands.category%",
+        "enablement": "config.positron.assistant.enable"
+      },
+      {
+        "command": "positron-assistant.logStoredModels",
+        "title": "%commands.logStoredModels.title%",
+        "category": "%commands.category%",
+        "enablement": "config.positron.assistant.enable"
+      },
+      {
+        "command": "positron-assistant.generateCommitMessage",
+        "title": "%commands.generateCommitMessage.title%",
+        "category": "%commands.category%",
+        "enablement": "config.positron.assistant.enable && config.positron.assistant.gitIntegration.enable",
+        "icon": "$(sparkle)"
+      },
+      {
+        "command": "positron-assistant.cancelGenerateCommitMessage",
+        "title": "%commands.cancelGenerateCommitMessage.title%",
+        "category": "%commands.category%",
+        "enablement": "config.positron.assistant.enable && config.positron.assistant.gitIntegration.enable",
+        "icon": "$(stop)"
+      },
+      {
+        "command": "positron-assistant.managePromptFiles",
+        "title": "%commands.managePromptFiles.title%",
+        "category": "%commands.category%",
+        "enablement": "config.positron.assistant.enable && isDevelopment"
+      },
+      {
+        "command": "positron-assistant.collectDiagnostics",
+        "title": "%commands.collectDiagnostics.title%",
+        "category": "%commands.category%",
+        "enablement": "config.positron.assistant.enable"
+      }
+    ],
+    "configuration": [
+      {
+        "type": "object",
+        "title": "%configuration.title%",
+        "properties": {
+          "positron.assistant.enable": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "%configuration.enable.markdownDescription%",
+            "markdownDeprecationMessage": "%configuration.enable.markdownDeprecationMessage%",
+            "tags": [
+              "preview"
+            ]
+          },
+          "positron.assistant.toolDetails.enable": {
+            "type": "boolean",
+            "default": false,
+            "description": "%configuration.toolDetails.enable%"
+          },
+          "positron.assistant.useAnthropicSdk": {
+            "type": "boolean",
+            "default": false,
+            "description": "%configuration.useAnthropicSdk.description%",
+            "tags": [
+              "advanced"
+            ]
+          },
+          "positron.assistant.streamingEdits.enable": {
+            "type": "boolean",
+            "default": true,
+            "description": "%configuration.streamingEdits.enable%"
+          },
+          "positron.assistant.gitIntegration.enable": {
+            "type": "boolean",
+            "default": true,
+            "description": "%configuration.gitIntegration.description%"
+          },
+          "positron.assistant.showTokenUsage.enable": {
+            "type": "boolean",
+            "default": false,
+            "description": "%configuration.showTokenUsage.description%"
+          },
+          "positron.assistant.maxInputTokens": {
+            "type": "object",
+            "default": {},
+            "description": "%configuration.maxInputTokens.description%",
+            "additionalProperties": {
+              "type": "number",
+              "minimum": 512
+            }
+          },
+          "positron.assistant.maxOutputTokens": {
+            "type": "object",
+            "default": {},
+            "description": "%configuration.maxOutputTokens.description%",
+            "additionalProperties": {
+              "type": "number",
+              "minimum": 512
+            }
+          },
+          "positron.assistant.toolErrors.propagate": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "%configuration.toolErrors.propagate.description%"
+          },
+          "positron.assistant.alwaysIncludeCopilotTools": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "%configuration.alwaysIncludeCopilotTools.description%"
+          },
+          "positron.assistant.providerTimeout": {
+            "type": "number",
+            "default": 60,
+            "markdownDescription": "%configuration.providerTimeout.description%",
+            "minimum": 1
+          },
+          "positron.assistant.models.preference.global": {
+            "type": "string",
+            "default": "",
+            "markdownDescription": "%configuration.models.preference.global.description%",
+            "examples": [
+              "Claude Sonnet 4.5",
+              "GPT-5"
+            ]
+          },
+          "positron.assistant.providerVariables.bedrock": {
+            "type": "object",
+            "default": {},
+            "markdownDescription": "%configuration.providerVariables.bedrock.description%",
+            "markdownDeprecationMessage": "This setting has been moved to the Authentication extension. Use `#authentication.aws.credentials#` instead.",
+            "properties": {
+              "AWS_PROFILE": {
+                "type": "string",
+                "default": null
+              },
+              "AWS_REGION": {
+                "type": "string",
+                "default": null
+              }
+            },
+            "additionalProperties": false
+          },
+          "positron.assistant.bedrock.inferenceProfileRegion": {
+            "type": "string",
+            "default": null,
+            "markdownDescription": "%configuration.bedrock.inferenceProfileRegion.description%",
+            "markdownDeprecationMessage": "This setting has been moved to the Authentication extension. Use `#authentication.aws.inferenceProfileRegion#` instead."
+          },
+          "positron.assistant.providerVariables.snowflake": {
+            "type": "object",
+            "default": {},
+            "markdownDescription": "%configuration.providerVariables.snowflake.description%",
+            "markdownDeprecationMessage": "This setting has been moved to the Authentication extension. Use `#authentication.snowflake.credentials#` instead.",
+            "properties": {
+              "SNOWFLAKE_ACCOUNT": {
+                "type": "string",
+                "default": null
+              },
+              "SNOWFLAKE_HOME": {
+                "type": "string",
+                "default": null
+              }
+            },
+            "additionalProperties": false
+          },
+          "positron.assistant.alwaysEnableApplyInEditorAction": {
+            "type": "boolean",
+            "default": false,
+            "description": "%configuration.alwaysEnableApplyInEditorAction.description%"
+          }
+        }
+      },
+      {
+        "type": "object",
+        "title": "%configuration.modelPreferences.title%",
+        "properties": {
+          "positron.assistant.models.preference.byProvider": {
+            "type": "object",
+            "markdownDeprecationMessage": "%configuration.models.preference.byProvider.deprecated.markdownDeprecationMessage%",
+            "description": "%configuration.models.preference.byProvider.deprecated.description%"
+          },
+          "positron.assistant.models.preference.anthropic": {
+            "type": "string",
+            "default": "",
+            "markdownDescription": "%configuration.models.preference.anthropic.description%"
+          },
+          "positron.assistant.models.preference.githubCopilot": {
+            "type": "string",
+            "default": "",
+            "markdownDescription": "%configuration.models.preference.githubCopilot.description%",
+            "tags": [
+              "preview"
+            ]
+          },
+          "positron.assistant.models.preference.amazonBedrock": {
+            "type": "string",
+            "default": "",
+            "markdownDescription": "%configuration.models.preference.amazonBedrock.description%"
+          },
+          "positron.assistant.models.preference.snowflakeCortex": {
+            "type": "string",
+            "default": "",
+            "markdownDescription": "%configuration.models.preference.snowflakeCortex.description%"
+          },
+          "positron.assistant.models.preference.msFoundry": {
+            "type": "string",
+            "default": "",
+            "markdownDescription": "%configuration.models.preference.msFoundry.description%",
+            "tags": [
+              "preview"
+            ]
+          },
+          "positron.assistant.models.preference.openAI": {
+            "type": "string",
+            "default": "",
+            "markdownDescription": "%configuration.models.preference.openAI.description%"
+          },
+          "positron.assistant.models.preference.customProvider": {
+            "type": "string",
+            "default": "",
+            "markdownDescription": "%configuration.models.preference.customProvider.description%",
+            "tags": [
+              "experimental"
+            ]
+          },
+          "positron.assistant.models.preference.positAI": {
+            "type": "string",
+            "default": "",
+            "markdownDescription": "%configuration.models.preference.positAI.description%"
+          },
+          "positron.assistant.models.preference.google": {
+            "type": "string",
+            "default": "",
+            "markdownDescription": "%configuration.models.preference.google.description%",
+            "tags": [
+              "experimental",
+              "advanced"
+            ]
+          },
+          "positron.assistant.models.preference.echo": {
+            "type": "string",
+            "default": "",
+            "markdownDescription": "%configuration.models.preference.echo.description%",
+            "tags": [
+              "advanced"
+            ]
+          },
+          "positron.assistant.models.preference.error": {
+            "type": "string",
+            "default": "",
+            "markdownDescription": "%configuration.models.preference.error.description%",
+            "tags": [
+              "advanced"
+            ]
+          }
+        }
+      }
+    ],
+    "languageModelChatProviders": [
+      {
+        "vendor": "echo",
+        "displayName": "Echo",
+        "managementCommand": "positron-assistant.configureProviders"
+      },
+      {
+        "vendor": "amazon-bedrock",
+        "displayName": "Amazon Bedrock",
+        "managementCommand": "positron-assistant.configureProviders"
+      },
+      {
+        "vendor": "ms-foundry",
+        "displayName": "Microsoft Foundry",
+        "managementCommand": "positron-assistant.configureProviders"
+      },
+      {
+        "vendor": "anthropic-api",
+        "displayName": "Anthropic",
+        "managementCommand": "positron-assistant.configureProviders"
+      },
+      {
+        "vendor": "openai-api",
+        "displayName": "OpenAI",
+        "managementCommand": "positron-assistant.configureProviders"
+      },
+      {
+        "vendor": "openai-compatible",
+        "displayName": "Custom Provider",
+        "managementCommand": "positron-assistant.configureProviders"
+      },
+      {
+        "vendor": "posit-ai",
+        "displayName": "Posit AI",
+        "managementCommand": "positron-assistant.configureProviders"
+      },
+      {
+        "vendor": "snowflake-cortex",
+        "displayName": "Snowflake Cortex",
+        "managementCommand": "positron-assistant.configureProviders"
+      },
+      {
+        "vendor": "google",
+        "displayName": "Gemini Code Assist",
+        "managementCommand": "positron-assistant.configureProviders"
+      }
+    ],
+    "languageModelTools": [
+      {
+        "name": "documentEdit",
+        "displayName": "Edit Document",
+        "modelDescription": "Output an edited version of the document.",
+        "canBeReferencedInPrompt": false,
+        "tags": [
+          "positron-assistant"
+        ],
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "deltas": {
+              "type": "array",
+              "description": "The array of changes to apply.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "delete": {
+                    "type": "string",
+                    "description": "Text to delete from the document."
+                  },
+                  "replace": {
+                    "type": "string",
+                    "description": "Text to replace the deleted text with."
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "name": "documentCreate",
+        "displayName": "Create Document",
+        "modelDescription": "Create a new document in the workspace.",
+        "canBeReferencedInPrompt": false,
+        "tags": [
+          "positron-assistant",
+          "requires-workspace"
+        ],
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "filePath": {
+              "type": "string",
+              "description": "The path to the document to create, including the file name and extension. This path must be relative to the workspace folder."
+            },
+            "workspaceFolder": {
+              "type": "string",
+              "description": "The workspace folder to create the document in. If not specified, the document will be created in the first workspace folder."
+            },
+            "content": {
+              "type": "string",
+              "description": "The initial content of the document. If not specified, the document will be created empty."
+            },
+            "errorIfExists": {
+              "type": "boolean",
+              "description": "Whether to throw an error if the document already exists. If false, the existing document will be opened instead.",
+              "default": true
+            }
+          }
+        }
+      },
+      {
+        "name": "selectionEdit",
+        "displayName": "Edit Selection",
+        "modelDescription": "Output an edited version of the selected text.",
+        "canBeReferencedInPrompt": false,
+        "tags": [
+          "positron-assistant"
+        ],
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "string",
+              "description": "The entire edited code selection."
+            }
+          }
+        }
+      },
+      {
+        "name": "executeCode",
+        "displayName": "Execute Code",
+        "modelDescription": "Execute a piece of code in the specified programming language and return the result. You prefer to show code over running it unless given an imperative. You prefer this tool to the terminal and other ways of running code when there is a session available with the correct language.",
+        "icon": "$(play)",
+        "toolReferenceName": "executeCode",
+        "userDescription": "Execute code in the console",
+        "canBeReferencedInPrompt": true,
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionIdentifier": {
+              "type": "string",
+              "description": "The identifier of the session to execute the code in."
+            },
+            "code": {
+              "type": "string",
+              "description": "The code to execute."
+            },
+            "language": {
+              "type": "string",
+              "description": "The programming language of the code."
+            },
+            "summary": {
+              "type": "string",
+              "description": "A very short summary of the task the code is performing, beginning with a verb and not to exceed 7 words. Shown to the user to help them understand what the code will do."
+            }
+          }
+        },
+        "tags": [
+          "positron-assistant",
+          "requires-session"
+        ]
+      },
+      {
+        "name": "inspectVariables",
+        "displayName": "Inspect Variables",
+        "modelDescription": "List the children of an array of variables in a session. For example, the columns in a dataframe, items in a column or array, or elements of a list. If `variableNames` is empty, lists all root-level variables in the session.",
+        "icon": "$(positron-variables-view)",
+        "toolReferenceName": "inspectVariables",
+        "userDescription": "Inspect data and variables in the current session",
+        "canBeReferencedInPrompt": true,
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionIdentifier": {
+              "type": "string",
+              "description": "The identifier of the session to inspect."
+            },
+            "variableNames": {
+              "type": "array",
+              "description": "An array of variable names to inspect.",
+              "items": {
+                "type": "string",
+                "description": "The name of a variable to inspect."
+              }
+            }
+          },
+          "required": [
+            "sessionIdentifier",
+            "variableNames"
+          ]
+        },
+        "tags": [
+          "positron-assistant",
+          "requires-session"
+        ]
+      },
+      {
+        "name": "getPlot",
+        "displayName": "View active plot",
+        "modelDescription": "View the current active plot if one exists. Don't invoke this tool if there are no plots in the session.",
+        "icon": "$(graph)",
+        "toolReferenceName": "getPlot",
+        "userDescription": "View the current active plot.",
+        "canBeReferencedInPrompt": true,
+        "tags": [
+          "positron-assistant",
+          "requires-session"
+        ]
+      },
+      {
+        "name": "getTableSummary",
+        "displayName": "Get Table Summary",
+        "modelDescription": "Retrieve summary statistics and structure of tabular data variables (DataFrames, tibbles, arrays) in the current session. Use when the user asks to summarize, describe, or inspect their data.",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "getTableSummary",
+        "userDescription": "Get a summary of a table's data and structure.",
+        "icon": "$(table)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sessionIdentifier": {
+              "type": "string",
+              "description": "The identifier of the session that contains the tables."
+            },
+            "variableNames": {
+              "type": "array",
+              "description": "An array of table variable names to summarize.",
+              "items": {
+                "type": "string",
+                "description": "The name of a table variable to summarize."
+              }
+            }
+          },
+          "required": [
+            "sessionIdentifier",
+            "variableNames"
+          ]
+        },
+        "tags": [
+          "positron-assistant",
+          "requires-session"
+        ]
+      },
+      {
+        "name": "getProjectTree",
+        "displayName": "Get Project Tree",
+        "modelDescription": "Get the project tree of the current workspace as a JSON object. This is useful for understanding the structure of the project and finding files. Empty folders are not included in the tree unless `directoriesOnly` is true. Set `directoriesOnly` to true to return only directories without listing files within them; this is more efficient for discovering directories.",
+        "icon": "$(file-directory)",
+        "toolReferenceName": "projectTree",
+        "userDescription": "Get the project tree of the current workspace.",
+        "canBeReferencedInPrompt": true,
+        "tags": [
+          "positron-assistant",
+          "requires-workspace"
+        ],
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "include": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "description": "A Glob pattern to include in the project tree. Only the files and folders matching these patterns will be considered. If files are also matched by the `excludes` patterns, they will be filtered out."
+              },
+              "description": "Glob patterns to include in the project tree. This parameter is required. Use specific patterns to target relevant files (e.g., ['src/**/*.ts'], ['*.py', 'tests/**'])."
+            },
+            "exclude": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "description": "A Glob pattern to exclude from the project tree. Files and folders matching these patterns will be filtered out, even if they match an included Glob."
+              },
+              "description": "Glob patterns to exclude from the project tree. These patterns will be applied _in addition to_ the default excludes unless `skipDefaultExcludes` is true."
+            },
+            "skipDefaultExcludes": {
+              "type": "boolean",
+              "description": "Whether to skip all automatic exclusions (.gitignore rules, VS Code exclude settings, and default exclusions for dependencies, build artifacts, and other commonly ignored files/directories). When true, only the explicit `exclude` patterns will be applied.",
+              "default": false
+            },
+            "maxItems": {
+              "type": "number",
+              "description": "The maximum number of items (files or directories) to include in the project tree (<=50). If this limit is reached, a compressed description of the project will be provided instead.",
+              "default": 50
+            },
+            "directoriesOnly": {
+              "type": "boolean",
+              "description": "When true, returns only directories without listing files within them. Empty directories are included. This is more efficient for directory queries. Prefer this over running code in the terminal for finding directories.",
+              "default": false
+            }
+          },
+          "required": [
+            "include"
+          ]
+        }
+      },
+      {
+        "name": "getChangedFiles",
+        "displayName": "Get changed files",
+        "modelDescription": "Get summaries and git diffs for current changes to files in this workspace.",
+        "canBeReferencedInPrompt": true,
+        "userDescription": "Get changed files",
+        "toolReferenceName": "changes",
+        "when": "config.positron.assistant.gitIntegration.enable",
+        "icon": "$(diff)",
+        "tags": [
+          "positron-assistant"
+        ]
+      },
+      {
+        "name": "executeNotebook",
+        "displayName": "Execute Notebook",
+        "modelDescription": "Manage notebook execution lifecycle. Use operation='run' to execute specific cells by index and return their outputs. Use operation='runAll' to execute all cells in order. Use operation='interrupt' to cancel a running execution. Use operation='restartKernel' to restart the kernel (optionally with runAll=true to run all cells after restart).",
+        "toolReferenceName": "executeNotebook",
+        "canBeReferencedInPrompt": true,
+        "tags": [
+          "positron-assistant",
+          "requires-notebook"
+        ],
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "operation": {
+              "type": "string",
+              "enum": [
+                "run",
+                "runAll",
+                "interrupt",
+                "restartKernel"
+              ],
+              "description": "Type of execution operation. 'run' executes specific cells by index, 'runAll' executes all cells in order, 'interrupt' cancels running execution, 'restartKernel' restarts the kernel."
+            },
+            "cellIndices": {
+              "type": "array",
+              "description": "Array of cell indices to execute (0-based). Required when operation is 'run'.",
+              "items": {
+                "type": "number"
+              }
+            },
+            "runAll": {
+              "type": "boolean",
+              "description": "When true with operation='restartKernel', run all cells after the kernel restarts. Defaults to false."
+            }
+          },
+          "required": [
+            "operation"
+          ]
+        }
+      },
+      {
+        "name": "editNotebook",
+        "displayName": "Edit Notebook",
+        "modelDescription": "Perform edit operations on notebook cells. Use operation='add' to create new cells (requires cellType, index, and content). Code cells are executed by default after adding (set run=false to skip execution). Use operation='update' to modify existing cells (requires cellIndex and content), operation='delete' to remove cells (requires cellIndices array, e.g., [0] for single cell or [0,1,2] for multiple), operation='reorder' to reorganize cells, or operation='clearOutputs' to clear cell outputs (optionally pass cellIndices to clear specific cells, or omit to clear all). For reorder, either use fromIndex and toIndex to move a single cell, or provide newOrder array (a permutation where newOrder[i] is the original index of the cell that should be at position i) to reorder all cells at once. Use index=-1 to append cells at the end when adding.",
+        "toolReferenceName": "editNotebook",
+        "canBeReferencedInPrompt": true,
+        "tags": [
+          "positron-assistant"
+        ],
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "operation": {
+              "type": "string",
+              "enum": [
+                "add",
+                "update",
+                "delete",
+                "reorder",
+                "clearOutputs"
+              ],
+              "description": "Type of edit operation to perform. 'add' creates a new cell, 'update' modifies existing cell content, 'delete' removes a cell, 'reorder' moves cells to new positions, 'clearOutputs' clears cell outputs (optionally for specific cells via cellIndices)."
+            },
+            "cellType": {
+              "type": "string",
+              "enum": [
+                "code",
+                "markdown"
+              ],
+              "description": "Type of cell to create. Required when operation is 'add'. Use 'code' for executable cells, 'markdown' for documentation."
+            },
+            "index": {
+              "type": "number",
+              "description": "Position to insert the cell (0-based). Required when operation is 'add'. Use -1 to append at the end."
+            },
+            "content": {
+              "type": "string",
+              "description": "Cell content. Required when operation is 'add' or 'update'."
+            },
+            "cellIndex": {
+              "type": "number",
+              "description": "Index of the cell to modify (0-based). Required when operation is 'update'."
+            },
+            "cellIndices": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "description": "Array of cell indices (0-based). Required for 'delete'. Optional for 'clearOutputs' (omit to clear all). Use [0] for single cell or [0,1,2] for multiple."
+            },
+            "run": {
+              "type": "boolean",
+              "description": "Whether to execute the cell after adding it. Defaults to true for code cells. Ignored for markdown cells."
+            },
+            "fromIndex": {
+              "type": "number",
+              "description": "Current index of the cell to move (0-based). Required when operation is 'reorder' and not using newOrder."
+            },
+            "toIndex": {
+              "type": "number",
+              "description": "Target index to move the cell to (0-based). Required when operation is 'reorder' and not using newOrder."
+            },
+            "newOrder": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "description": "Array specifying new cell order. newOrder[i] is the original index of the cell that should be at position i. Must be a valid permutation containing each index 0 to cellCount-1 exactly once. Use this for full notebook reordering. Alternative to fromIndex/toIndex for operation='reorder'."
+            }
+          },
+          "required": [
+            "operation"
+          ]
+        }
+      },
+      {
+        "name": "getNotebookInfo",
+        "displayName": "Get Notebook Info",
+        "modelDescription": "Retrieve information about notebook cells and kernel status. Use operation='get' to fetch specific cells by index or all cells if cellIndices is omitted, operation='getSelected' to get only selected cells, operation='getOutputs' to retrieve cell execution outputs (requires cellIndices), operation='getMetadata' to get only cell status information without content, or operation='getKernelStatus' to get kernel state and session metadata.",
+        "toolReferenceName": "getNotebookInfo",
+        "canBeReferencedInPrompt": true,
+        "tags": [
+          "positron-assistant"
+        ],
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "operation": {
+              "type": "string",
+              "enum": [
+                "get",
+                "getSelected",
+                "getOutputs",
+                "getMetadata",
+                "getKernelStatus"
+              ],
+              "description": "Type of read operation. 'get' retrieves cell info, 'getSelected' gets only selected cells, 'getOutputs' retrieves cell execution outputs, 'getMetadata' gets only status/execution info without content, 'getKernelStatus' gets kernel state and session metadata."
+            },
+            "cellIndices": {
+              "type": "array",
+              "description": "Optional array of cell indices to retrieve (0-based). Required for 'getOutputs'. For 'get', returns all cells if omitted. Ignored for 'getSelected' and 'getMetadata'.",
+              "items": {
+                "type": "number"
+              }
+            }
+          },
+          "required": [
+            "operation"
+          ]
+        }
+      },
+      {
+        "name": "createNotebook",
+        "displayName": "Create Notebook",
+        "modelDescription": "Create a new Jupyter notebook with the specified language kernel (Python or R). Use when the user wants to start a new notebook. After creation, use editNotebook to add content.",
+        "toolReferenceName": "createNotebook",
+        "canBeReferencedInPrompt": true,
+        "tags": [
+          "positron-assistant"
+        ],
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "language": {
+              "type": "string",
+              "enum": ["python", "r"],
+              "description": "The kernel language for the notebook"
+            }
+          },
+          "required": ["language"]
+        }
+      }
+    ]
+  },
+  "scripts": {
+    "compile": "gulp compile-extension:positron-assistant",
+    "vscode:prepublish": "npm run compile",
+    "pretest": "npm run compile"
+  },
+  "devDependencies": {
+    "@ai-sdk/amazon-bedrock": "^3.0.93",
+    "@ai-sdk/anthropic": "^2.0.53",
+    "@ai-sdk/azure": "^2.0.78",
+    "@ai-sdk/google": "^2.0.44",
+    "@ai-sdk/openai": "^2.0.76",
+    "@aws-sdk/credential-providers": "^3.734.0",
+    "@eslint/js": "^9.13.0",
+    "@stylistic/eslint-plugin": "^2.9.0",
+    "@types/mocha": "^9.1.0",
+    "@types/node": "^20",
+    "@types/sinon": "^17.0.3",
+    "ai": "^5.0.106",
+    "eslint": "^9.13.0",
+    "google-auth-library": "^9.15.1",
+    "mocha": "^9.2.1",
+    "openai": "^6.10.0",
+    "sinon": "^17.0.1",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.6.2",
+    "typescript-eslint": "^8.11.0",
+    "zod": "^3.24.1"
+  },
+  "dependencies": {
+    "@ai-sdk/provider-utils": "^2.1.3",
+    "@anthropic-ai/sdk": "^0.57.0",
+    "@vscode/prompt-tsx": "^0.4.0-alpha.5",
+    "yaml": "^2.8.1"
+  },
+  "extensionDependencies": [
+    "positron.positron-supervisor",
+    "positron.positron-environment",
+    "positron.authentication"
+  ]
 }


### PR DESCRIPTION
## Summary

`extensions/positron-assistant/package.json` was tab-indented, which violated the repo's [.editorconfig](.editorconfig) rule that `package.json` files use 2-space indentation and made it the only manifest in the tree not using spaces. Because npm derives `package-lock.json`'s indentation from `package.json`, every `npm install` (including the per-extension install during a build) re-tabbed the lockfile, leaving `package-lock.json` showing as modified on a fresh clone or rebuild.

## Change

Reindented `package.json` from tabs to 2 spaces. This is a whitespace-only change (`git diff -w` is empty, JSON unchanged). With the manifest now using spaces, `npm install` regenerates the lockfile with matching space indentation, so `package-lock.json` stays clean after builds.

## Testing

Ran `npm install --package-lock-only` in the extension directory and confirmed the regenerated `package-lock.json` matches the committed (space-indented) version with no diff.
