### PR TITLE
E2E test: workaround bad kernels (uv managed)

### DIFF
--- a/test/e2e/fixtures/settings.json
+++ b/test/e2e/fixtures/settings.json
@@ -21,5 +21,11 @@
 	"assistant.sidebarView": true,
 	"shiny.previewType": "internal",
 	"terminal.integrated.gpuAcceleration": "off",
-	"console.showNotebookConsoleActions": true
+	"console.showNotebookConsoleActions": true,
+	"jupyter.kernels.excludePythonEnvironments": [
+        "~/.local"
+    ],
+	"python.interpreters.exclude": [
+        "~/.local"
+    ]
 }


### PR DESCRIPTION
Need to skip interpreters that tests must not use.

@:positron-notebooks
@:package-pane