### PR TITLE
Allow "duplication" of notebook consoles

### DIFF
--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -770,7 +770,6 @@ export class DuplicateActiveConsoleSessionAction extends Action2 {
 		// Access services
 		const commandService = accessor.get(ICommandService);
 		const runtimeSessionService = accessor.get(IRuntimeSessionService);
-		const notificationService = accessor.get(INotificationService);
 
 		// Get the current foreground session.
 		const currentSession = runtimeSessionService.foregroundSession;
@@ -778,24 +777,35 @@ export class DuplicateActiveConsoleSessionAction extends Action2 {
 			return;
 		}
 
-		if (currentSession.metadata.sessionMode !== LanguageRuntimeSessionMode.Console) {
-			notificationService.error(localize('positron.languageRuntime.duplicate.notConsole', 'Cannot duplicate session. The current session is not a console session.'));
-			return;
-		}
-
 		// Drive focus into the Positron console.
 		commandService.executeCommand('workbench.panel.positronConsole.focus');
 
-		// Duplicate the current session with the `startNewRuntimeSession` method.
-		await runtimeSessionService.startNewRuntimeSession(
-			currentSession.runtimeMetadata.runtimeId,
-			currentSession.dynState.sessionName,
-			currentSession.metadata.sessionMode,
-			undefined,
-			`Duplicated session: ${currentSession.dynState.sessionName}`,
-			RuntimeStartMode.Starting,
-			true
-		);
+		// Start a new console session using the current session's runtime
+		// information. When the current session is itself a console session,
+		// this duplicates it. When it's a non-console session (e.g. a notebook
+		// console), this starts a fresh console session in the same environment
+		// rather than treating it as an error.
+		if (currentSession.metadata.sessionMode === LanguageRuntimeSessionMode.Console) {
+			await runtimeSessionService.startNewRuntimeSession(
+				currentSession.runtimeMetadata.runtimeId,
+				currentSession.dynState.sessionName,
+				LanguageRuntimeSessionMode.Console,
+				undefined,
+				`Duplicated session: ${currentSession.dynState.sessionName}`,
+				RuntimeStartMode.Starting,
+				true
+			);
+		} else {
+			await runtimeSessionService.startNewRuntimeSession(
+				currentSession.runtimeMetadata.runtimeId,
+				currentSession.runtimeMetadata.runtimeName,
+				LanguageRuntimeSessionMode.Console,
+				undefined,
+				`Started console session from notebook session: ${currentSession.dynState.sessionName}`,
+				RuntimeStartMode.Starting,
+				true
+			);
+		}
 	}
 }
 

--- a/src/vs/workbench/contrib/languageRuntime/test/browser/languageRuntimeActions.vitest.ts
+++ b/src/vs/workbench/contrib/languageRuntime/test/browser/languageRuntimeActions.vitest.ts
@@ -672,6 +672,10 @@ describe('DuplicateActiveConsoleSessionAction', () => {
 
 	function makeNotebookForegroundSession(): ILanguageRuntimeSession {
 		return stubInterface<ILanguageRuntimeSession>({
+			runtimeMetadata: stubInterface<ILanguageRuntimeMetadata>({
+				runtimeId: 'python-runtime-1',
+				runtimeName: 'Python 3.12',
+			}),
 			dynState: stubInterface<ILanguageRuntimeSession['dynState']>({ sessionName: 'My Notebook Session' }),
 			metadata: {
 				sessionId: 'notebook-session-1',
@@ -705,10 +709,19 @@ describe('DuplicateActiveConsoleSessionAction', () => {
 		);
 	});
 
-	it('shows an error notification and skips startNewRuntimeSession when the foreground session is not a Console session', async () => {
+	it('starts a new Console session using the notebook session runtime info when the foreground session is a notebook session', async () => {
 		foregroundSession = makeNotebookForegroundSession();
 		await runAction();
-		expect(notifyError).toHaveBeenCalledOnce();
-		expect(startNewRuntimeSession).not.toHaveBeenCalled();
+		expect(notifyError).not.toHaveBeenCalled();
+		expect(executeCommand).toHaveBeenCalledWith('workbench.panel.positronConsole.focus');
+		expect(startNewRuntimeSession).toHaveBeenCalledWith(
+			'python-runtime-1',
+			'Python 3.12',
+			LanguageRuntimeSessionMode.Console,
+			undefined,
+			'Started console session from notebook session: My Notebook Session',
+			RuntimeStartMode.Starting,
+			true
+		);
 	});
 });


### PR DESCRIPTION
When a notebook/Quarto console is the foreground session, clicking the "+" button in the Console view previously raised an error: "Cannot duplicate session. The current session is not a console session." This PR removes that error condition. Instead, the action now starts a new console session using the runtime information from the notebook session, creating a console in the same environment.

For an actual console session, the behavior is unchanged (it duplicates the session by display name). For a non-console session (e.g. a notebook console), it starts a fresh console session using the runtime's name.

Fixes #14267


### Release Notes

#### New Features
- N/A

#### Bug Fixes

- Start a new console session (instead of showing an error) when adding a console while a notebook console is the active session (#14267)

### Validation Steps

@:console @:sessions

1. Enable inline output and notebook consoles
2. Open a Quarto document
3. Run a cell
4. Open the Console view (the Quarto console is selected)
5. Click the "+" button to open a new console
6. Verify a new console session starts in the same interpreter/environment, with no error popup
