### PR TITLE
Fix race on runtime manager registration

### DIFF
--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -1659,14 +1659,19 @@ export class MainThreadLanguageRuntime
 	}
 
 	/**
-	 * Tell the extension host that initial discovery is over without asking
-	 * it to enumerate. Used by the warm-start fast path in
+	 * Tell the extension host that initial discovery is over on the warm-start
+	 * fast path. The ext host enumerates any managers whose language isn't in
+	 * `skipLanguageIds` (the cache-satisfied set), so late-registered managers
+	 * aren't stranded, but skips the cache-backed languages the main thread
+	 * already served. Used by the warm-start fast path in
 	 * `RuntimeStartupService.discoverAllRuntimes`.
 	 *
 	 * (part of implementation of IRuntimeManager)
+	 *
+	 * @param skipLanguageIds The cache-satisfied languages to skip enumerating.
 	 */
-	markDiscoveryComplete(): void {
-		this._proxy.$markRuntimeDiscoveryComplete();
+	markDiscoveryComplete(skipLanguageIds?: string[]): void {
+		this._proxy.$markRuntimeDiscoveryComplete(skipLanguageIds);
 	}
 
 	/**

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -120,7 +120,7 @@ export interface ExtHostLanguageRuntimeShape {
 	$showProfileLanguageRuntime(handle: number): void;
 	$getLaunchInfo(handle: number): Promise<ILanguageRuntimeLaunchInfo | undefined>;
 	$discoverLanguageRuntimes(disabledLanguageIds: string[], skipLanguageIds?: string[]): void;
-	$markRuntimeDiscoveryComplete(): void;
+	$markRuntimeDiscoveryComplete(skipLanguageIds?: string[]): void;
 	$recommendWorkspaceRuntimes(disabledLanguageIds: string[]): Promise<ILanguageRuntimeMetadata[]>;
 	$getDiscoveryRootSignature(extensionId: string, languageId: string): Promise<IRuntimeRootSignature | undefined>;
 	$getHostedLanguageContributions(): Promise<IHostedLanguageContribution[]>;

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -1090,15 +1090,23 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 	}
 
 	/**
-	 * Set the discovery-complete flag without running an enumeration. Called
-	 * by the main thread on the warm-start fast path, where the discovery
-	 * cache has satisfied every manager and no real enumeration is needed.
-	 * Without this, late-registered runtime managers (those registered via
-	 * `registerLanguageRuntimeManager` after initial discovery) would never
-	 * see the flag flip and so would never self-discover.
+	 * Mark discovery complete on the warm-start fast path, where the main thread
+	 * served every cache-satisfied language from its discovery cache.
+	 *
+	 * This still runs a normal discovery pass, but with the cache-satisfied
+	 * languages in the skip set so they aren't needlessly re-walked. The point
+	 * is to catch a runtime manager registered via the public
+	 * `registerLanguageRuntimeManager` API *before* this signal arrived: its
+	 * language isn't cache-backed, so it was parked in `_runtimeManagers`
+	 * awaiting an enumeration pass that the warm start would otherwise skip,
+	 * stranding it forever. (Managers registered *after* the flag flips
+	 * self-discover via their own IIFE, so they were never at risk.)
+	 *
+	 * @param skipLanguageIds The cache-satisfied (and disabled) languages to
+	 * skip; supplied by the main thread.
 	 */
-	public $markRuntimeDiscoveryComplete(): void {
-		this._runtimeDiscoveryComplete = true;
+	public $markRuntimeDiscoveryComplete(skipLanguageIds?: string[]): Promise<void> {
+		return this.$discoverLanguageRuntimes([], skipLanguageIds);
 	}
 
 	/**

--- a/src/vs/workbench/api/test/common/positron/extHostLanguageRuntime.vitest.ts
+++ b/src/vs/workbench/api/test/common/positron/extHostLanguageRuntime.vitest.ts
@@ -51,6 +51,9 @@ function createMockShape() {
 		override $emitPerfMark(_extensionId: string, _name: string): void {
 			// no-op
 		}
+		override $completeLanguageRuntimeDiscovery(): void {
+			// no-op
+		}
 	};
 }
 
@@ -128,6 +131,61 @@ describe('ExtHostLanguageRuntime - onDidRegisterRuntime', function () {
 		expect(shape.registrations[0].runtimeId).toBe(meta.runtimeId);
 		// ...but the public event has not fired yet (it would on broadcast back).
 		expect(seen).toEqual([]);
+	});
+});
+
+/**
+ * A manager whose `discoverAllRuntimes` yields a fixed set of runtimes. Used to
+ * exercise the discovery-completion enumeration paths.
+ */
+class DiscoveringManager extends mock<positron.LanguageRuntimeManager>() {
+	constructor(private readonly _runtimes: positron.LanguageRuntimeMetadata[]) { super(); }
+	override async *discoverAllRuntimes(): AsyncGenerator<positron.LanguageRuntimeMetadata> {
+		for (const runtime of this._runtimes) {
+			yield runtime;
+		}
+	}
+}
+
+describe('ExtHostLanguageRuntime - discovery completion', function () {
+
+	const disposables = ensureNoLeakedDisposables();
+
+	let shape: ReturnType<typeof createMockShape>;
+	let runtime: ExtHostLanguageRuntime;
+
+	beforeEach(() => {
+		shape = createMockShape();
+		runtime = new ExtHostLanguageRuntime(SingleProxyRPCProtocol(shape), new NullLogService());
+	});
+
+	it('enumerates a manager registered before warm-start completion', async () => {
+		// The race this guards: a runtime manager registered via the public API
+		// before discovery completed is parked in `_runtimeManagers`, waiting
+		// for an enumeration pass. On the warm-start fast path the main thread
+		// served every cached language from cache and signals completion via
+		// `$markRuntimeDiscoveryComplete` -- without enumerating here, the parked
+		// manager (whose language isn't cache-backed) would be stranded forever.
+		const testRuntime = fakeMetadata({ runtimeId: 'test-1', languageId: 'test' }) as unknown as positron.LanguageRuntimeMetadata;
+		const manager = new DiscoveringManager([testRuntime]);
+		disposables.add(runtime.registerLanguageRuntimeManager(fakeExtension, 'test', manager));
+
+		// Warm start completes; cached languages (r) are supplied in the skip set.
+		await runtime.$markRuntimeDiscoveryComplete(['r']);
+
+		expect(shape.registrations.map(r => r.runtimeId)).toEqual(['test-1']);
+	});
+
+	it('does not re-enumerate cache-satisfied managers on warm-start completion', async () => {
+		// A manager whose language was served from cache must not be re-walked:
+		// that is the whole point of the warm-start optimization.
+		const rRuntime = fakeMetadata({ runtimeId: 'r-1', languageId: 'r' }) as unknown as positron.LanguageRuntimeMetadata;
+		const manager = new DiscoveringManager([rRuntime]);
+		disposables.add(runtime.registerLanguageRuntimeManager(fakeExtension, 'r', manager));
+
+		await runtime.$markRuntimeDiscoveryComplete(['r']);
+
+		expect(shape.registrations).toEqual([]);
 	});
 });
 

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -1002,14 +1002,18 @@ export interface IRuntimeManager {
 	discoverAllRuntimes(disabledLanguageIds: string[], skipLanguageIds?: string[]): Promise<void>;
 
 	/**
-	 * Mark the manager's discovery-complete flag without running a real
-	 * enumeration. Used by the warm-start fast path: the discovery cache
-	 * already satisfied every bucket, so no manager needs to enumerate, but
-	 * the ext host still needs to know that initial discovery is over so
-	 * runtime managers registered later (via `registerLanguageRuntimeManager`)
-	 * self-trigger their own discovery.
+	 * Mark the manager's discovery-complete flag on the warm-start fast path:
+	 * the discovery cache already satisfied every cache-backed bucket, so those
+	 * languages don't need to enumerate. The ext host still enumerates any
+	 * managers whose language is *not* in `skipLanguageIds` -- this catches
+	 * runtime managers registered via `registerLanguageRuntimeManager` before
+	 * the warm-start completion signal, whose languages aren't cache-backed and
+	 * would otherwise be stranded -- and records that initial discovery is over
+	 * so managers registered later self-trigger their own discovery.
+	 *
+	 * @param skipLanguageIds The cache-satisfied languages to skip enumerating.
 	 */
-	markDiscoveryComplete(): void;
+	markDiscoveryComplete(skipLanguageIds?: string[]): void;
 
 	/**
 	 * Recommend runtimes for this specific workspace.

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -1039,9 +1039,20 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 			// `registerLanguageRuntimeManager` API) self-triggers its own
 			// discovery -- the IIFE inside the ext host is gated on a flag
 			// that, without this signal, would never flip on a warm start.
+			//
+			// Pass the cache-satisfied (and disabled) languages as the skip set.
+			// The ext host enumerates any manager whose language isn't in this
+			// set, so a manager registered via the public API *before* this
+			// signal arrived (its language isn't cache-backed) is still
+			// discovered rather than stranded, while the cache-backed languages
+			// we already served aren't needlessly re-enumerated.
+			const skipLanguageIds = Array.from(new Set([
+				...this._discoveryCache.getAllBuckets().map(bucket => bucket.languageId),
+				...disabledLanguages,
+			]));
 			for (const manager of this._runtimeManagers) {
 				this._discoveryCompleteByExtHostId.set(manager.id, true);
-				manager.markDiscoveryComplete();
+				manager.markDiscoveryComplete(skipLanguageIds);
 			}
 			this.setStartupPhase(RuntimeStartupPhase.Complete);
 		} else {


### PR DESCRIPTION
Fixes #14206

Fixes a startup race that could strand a language runtime manager registered via the public `registerLanguageRuntimeManager` API.

On the warm-start fast path (every contribution served from the discovery cache), the extension host was told discovery was complete via `$markRuntimeDiscoveryComplete`, which set the completion flag *without* running an enumeration pass.

A manager registered before that signal arrived sat waiting for an enumeration that never came, so its runtimes were never registered. This is what made the `positron API - runtime > register a runtime manager` ext-host test flake: depending on activation/startup timing, the test manager would sometimes be registered before warm-start completion and then stranded, timing out after 20s.

The fix routes the warm-start completion through the existing discovery path with a skip set: the main thread passes the cache-satisfied (and disabled) languages, and the extension host runs a normal discovery pass that skips those languages while still enumerating any manager whose language isn't cache-backed. This preserves the warm-start optimization (cached languages aren't re-walked) while eliminating the race.

### Validation Steps

@:interpreter @:console

This is primarily covered by the existing extension-host test that previously flaked:

```
npm run test-extension -- -l vscode-api-tests --grep "register a runtime manager"
```

New unit coverage is in `extHostLanguageRuntime.vitest.ts` (run with `npx vitest run src/vs/workbench/api/test/common/positron/extHostLanguageRuntime.vitest.ts`), which verifies that a manager registered before warm-start completion is still enumerated, and that cache-satisfied managers are not re-walked.

Manually: start Positron normally (warm start, with cached interpreters) and confirm Python and R interpreters appear in the interpreter picker and a console starts, with no regression in discovery timing.
