### PR TITLE
Revert "python: update PET categories for uv"

### DIFF
--- a/extensions/positron-python/src/client/pythonEnvironments/base/locators/common/nativePythonUtils.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/locators/common/nativePythonUtils.ts
@@ -14,6 +14,10 @@ export enum NativePythonEnvironmentKind {
     PyenvVirtualEnv = 'PyenvVirtualEnv',
     Pipenv = 'Pipenv',
     Poetry = 'Poetry',
+    // --- Start Positron ---
+    Uv = 'uv',
+    Custom = 'Custom',
+    // --- End Positron ---
     MacPythonOrg = 'MacPythonOrg',
     MacCommandLineTools = 'MacCommandLineTools',
     LinuxGlobal = 'LinuxGlobal',
@@ -24,14 +28,10 @@ export enum NativePythonEnvironmentKind {
     WindowsStore = 'WindowsStore',
     WindowsRegistry = 'WindowsRegistry',
     // --- Start Positron ---
-    // PET emits these category strings verbatim for uv-managed environments:
-    // `Uv` for uv-managed base Pythons and non-workspace uv venvs, `UvWorkspace`
-    // for uv venvs inside a uv workspace. Both map to PythonEnvKind.Uv below.
-    //
+    // Disabling UvVenv since PET does not have a release that uses it yet.
+    // We currently have our own implementation of `Uv`, that we may want to
+    // swap out once PET can handle this.
     // VenvUv = 'Uv',
-    Uv = 'Uv',
-    UvWorkspace = 'UvWorkspace',
-    Custom = 'Custom',
     // --- End Positron ---
 }
 
@@ -43,14 +43,17 @@ const mapping = new Map<NativePythonEnvironmentKind, PythonEnvKind>([
     [NativePythonEnvironmentKind.PyenvVirtualEnv, PythonEnvKind.Pyenv],
     [NativePythonEnvironmentKind.Pipenv, PythonEnvKind.Pipenv],
     [NativePythonEnvironmentKind.Poetry, PythonEnvKind.Poetry],
+    // --- Start Positron ---
+    [NativePythonEnvironmentKind.Uv, PythonEnvKind.Uv],
+    // --- End Positron ---
     [NativePythonEnvironmentKind.VirtualEnv, PythonEnvKind.VirtualEnv],
     [NativePythonEnvironmentKind.VirtualEnvWrapper, PythonEnvKind.VirtualEnvWrapper],
     [NativePythonEnvironmentKind.Venv, PythonEnvKind.Venv],
     // --- Start Positron ---
+    // Disabling UvVenv since PET does not have a release that uses it yet.
+    // We currently have our own implementation of `Uv`, that we may want to
+    // swap out once PET can handle this.
     // [NativePythonEnvironmentKind.VenvUv, PythonEnvKind.Venv],
-    [NativePythonEnvironmentKind.Uv, PythonEnvKind.Uv],
-    [NativePythonEnvironmentKind.UvWorkspace, PythonEnvKind.Uv],
-    [NativePythonEnvironmentKind.Custom, PythonEnvKind.Custom],
     // --- End Positron ---
     [NativePythonEnvironmentKind.WindowsRegistry, PythonEnvKind.System],
     [NativePythonEnvironmentKind.WindowsStore, PythonEnvKind.MicrosoftStore],
@@ -59,6 +62,9 @@ const mapping = new Map<NativePythonEnvironmentKind, PythonEnvKind>([
     [NativePythonEnvironmentKind.MacCommandLineTools, PythonEnvKind.System],
     [NativePythonEnvironmentKind.MacPythonOrg, PythonEnvKind.System],
     [NativePythonEnvironmentKind.MacXCode, PythonEnvKind.System],
+    // --- Start Positron ---
+    [NativePythonEnvironmentKind.Custom, PythonEnvKind.Custom],
+    // --- End Positron ---
 ]);
 
 export function categoryToKind(category?: NativePythonEnvironmentKind, logger?: LogOutputChannel): PythonEnvKind {


### PR DESCRIPTION
This reverts commit f6db710ebf796eb400e082008790e63a59200558. (#14588)

To unblock e2e tests. I'll have a better fix up later today.

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Reference the associated issue with a closing keyword such as
  "Fixes #123" so GitHub automatically closes the issue when this PR
  is merged. If there are any details about your approach that are
  unintuitive or you want to draw attention to, please describe them
  here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### Validation Steps

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information on how to validate the change, paying
  special attention to the level of risk, adjacent areas that could
  be affected by the change, and any important contextual information
  not present in the linked issues.
-->
