### PR TITLE
python: un-revert PET changes and tell uv not to use color

### DIFF
--- a/extensions/positron-python/src/client/pythonEnvironments/base/locators/common/nativePythonUtils.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/locators/common/nativePythonUtils.ts
@@ -14,10 +14,6 @@ export enum NativePythonEnvironmentKind {
     PyenvVirtualEnv = 'PyenvVirtualEnv',
     Pipenv = 'Pipenv',
     Poetry = 'Poetry',
-    // --- Start Positron ---
-    Uv = 'uv',
-    Custom = 'Custom',
-    // --- End Positron ---
     MacPythonOrg = 'MacPythonOrg',
     MacCommandLineTools = 'MacCommandLineTools',
     LinuxGlobal = 'LinuxGlobal',
@@ -28,10 +24,14 @@ export enum NativePythonEnvironmentKind {
     WindowsStore = 'WindowsStore',
     WindowsRegistry = 'WindowsRegistry',
     // --- Start Positron ---
-    // Disabling UvVenv since PET does not have a release that uses it yet.
-    // We currently have our own implementation of `Uv`, that we may want to
-    // swap out once PET can handle this.
+    // PET emits these category strings verbatim for uv-managed environments:
+    // `Uv` for uv-managed base Pythons and non-workspace uv venvs, `UvWorkspace`
+    // for uv venvs inside a uv workspace. Both map to PythonEnvKind.Uv below.
+    //
     // VenvUv = 'Uv',
+    Uv = 'Uv',
+    UvWorkspace = 'UvWorkspace',
+    Custom = 'Custom',
     // --- End Positron ---
 }
 
@@ -43,17 +43,14 @@ const mapping = new Map<NativePythonEnvironmentKind, PythonEnvKind>([
     [NativePythonEnvironmentKind.PyenvVirtualEnv, PythonEnvKind.Pyenv],
     [NativePythonEnvironmentKind.Pipenv, PythonEnvKind.Pipenv],
     [NativePythonEnvironmentKind.Poetry, PythonEnvKind.Poetry],
-    // --- Start Positron ---
-    [NativePythonEnvironmentKind.Uv, PythonEnvKind.Uv],
-    // --- End Positron ---
     [NativePythonEnvironmentKind.VirtualEnv, PythonEnvKind.VirtualEnv],
     [NativePythonEnvironmentKind.VirtualEnvWrapper, PythonEnvKind.VirtualEnvWrapper],
     [NativePythonEnvironmentKind.Venv, PythonEnvKind.Venv],
     // --- Start Positron ---
-    // Disabling UvVenv since PET does not have a release that uses it yet.
-    // We currently have our own implementation of `Uv`, that we may want to
-    // swap out once PET can handle this.
     // [NativePythonEnvironmentKind.VenvUv, PythonEnvKind.Venv],
+    [NativePythonEnvironmentKind.Uv, PythonEnvKind.Uv],
+    [NativePythonEnvironmentKind.UvWorkspace, PythonEnvKind.Uv],
+    [NativePythonEnvironmentKind.Custom, PythonEnvKind.Custom],
     // --- End Positron ---
     [NativePythonEnvironmentKind.WindowsRegistry, PythonEnvKind.System],
     [NativePythonEnvironmentKind.WindowsStore, PythonEnvKind.MicrosoftStore],
@@ -62,9 +59,6 @@ const mapping = new Map<NativePythonEnvironmentKind, PythonEnvKind>([
     [NativePythonEnvironmentKind.MacCommandLineTools, PythonEnvKind.System],
     [NativePythonEnvironmentKind.MacPythonOrg, PythonEnvKind.System],
     [NativePythonEnvironmentKind.MacXCode, PythonEnvKind.System],
-    // --- Start Positron ---
-    [NativePythonEnvironmentKind.Custom, PythonEnvKind.Custom],
-    // --- End Positron ---
 ]);
 
 export function categoryToKind(category?: NativePythonEnvironmentKind, logger?: LogOutputChannel): PythonEnvKind {

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
@@ -26,6 +26,20 @@ export function isVersionPrerelease(version: string): boolean {
     return PRERELEASE_REGEX.test(version);
 }
 
+/**
+ * Runs a uv subcommand with color output disabled. uv honors FORCE_COLOR/CLICOLOR_FORCE
+ * even when its stdout is piped (both are commonly set in CI), which wraps the paths and
+ * tokens we parse in ANSI escape codes and corrupts them. `--color never` overrides
+ * those env vars. See uvPackageManager, which passes the same flag to `uv pip` commands.
+ */
+export function execUv(
+    command: string,
+    args: string[],
+    options: Parameters<typeof exec>[2] = {},
+): ReturnType<typeof exec> {
+    return exec(command, ['--color', 'never', ...args], options);
+}
+
 /** Wraps the "uv" utility, and exposes its functionality. */
 class UvUtils {
     private static uvPromise: Promise<UvUtils | undefined>;
@@ -79,7 +93,7 @@ class UvUtils {
      */
     private static async canRun(command: string): Promise<boolean> {
         try {
-            const result = await exec(command, ['python', 'dir'], { throwOnStdErr: true });
+            const result = await execUv(command, ['python', 'dir'], { throwOnStdErr: true });
             return result?.stdout.trim() !== undefined;
         } catch (ex) {
             traceVerbose(ex);
@@ -90,7 +104,7 @@ class UvUtils {
     @cache(-1)
     public async getUvDir(): Promise<string | undefined> {
         try {
-            const result = await exec(this.command, ['python', 'dir'], { throwOnStdErr: true });
+            const result = await execUv(this.command, ['python', 'dir'], { throwOnStdErr: true });
             return result?.stdout.trim();
         } catch (ex) {
             traceVerbose(ex);
@@ -101,7 +115,7 @@ class UvUtils {
     @cache(-1)
     public async getUvBinDir(): Promise<string | undefined> {
         try {
-            const result = await exec(this.command, ['python', 'dir', '--bin'], { throwOnStdErr: true });
+            const result = await execUv(this.command, ['python', 'dir', '--bin'], { throwOnStdErr: true });
             return result?.stdout.trim();
         } catch (ex) {
             traceVerbose(ex);
@@ -261,7 +275,7 @@ export async function getUvPythonVersionInfo(
         // Output format:
         //   cpython-3.15.0a6-macos-aarch64-none    <download available>
         //   cpython-3.13.7-macos-aarch64-none     /usr/local/bin/python3.13 -> ...
-        const result = await exec(uvUtils.command, ['python', 'list', requestedVersion], { throwOnStdErr: false });
+        const result = await execUv(uvUtils.command, ['python', 'list', requestedVersion], { throwOnStdErr: false });
         const output = result?.stdout.trim();
 
         if (!output) {
@@ -336,7 +350,7 @@ export async function updateUv(): Promise<boolean> {
 
     try {
         traceVerbose('Running uv self update...');
-        await exec(uvUtils.command, ['self', 'update'], { throwOnStdErr: false });
+        await execUv(uvUtils.command, ['self', 'update'], { throwOnStdErr: false });
         traceVerbose('uv self update completed successfully');
         return true;
     } catch (ex) {
@@ -358,7 +372,7 @@ export async function installUvPython(version: string): Promise<boolean> {
 
     try {
         traceVerbose(`Running uv python install ${version}...`);
-        await exec(uvUtils.command, ['python', 'install', version], { throwOnStdErr: false });
+        await execUv(uvUtils.command, ['python', 'install', version], { throwOnStdErr: false });
         traceVerbose(`uv python install ${version} completed successfully`);
         return true;
     } catch (ex) {
@@ -467,7 +481,7 @@ export async function getAvailablePythonVersions(): Promise<UvAvailablePython[]>
         const args = isWindowsArm64()
             ? ['python', 'list', '--managed-python', '--all-arches']
             : ['python', 'list', '--managed-python'];
-        const result = await exec(uvUtils.command, args, { throwOnStdErr: false });
+        const result = await execUv(uvUtils.command, args, { throwOnStdErr: false });
         const output = result?.stdout.trim();
 
         if (!output) {

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uvPythonInstaller.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uvPythonInstaller.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { traceError, traceInfo } from '../../../logging';
 import { exec } from '../externalDependencies';
-import { isUvInstalled, getAvailablePythonVersions, resetUvCache, isWindowsArm64 } from './uv';
+import { isUvInstalled, getAvailablePythonVersions, resetUvCache, isWindowsArm64, execUv } from './uv';
 import { Commands } from '../../../common/constants';
 import { Common, InterpreterQuickPickList } from '../../../common/utils/localize';
 import { getWorkspaceFolders } from '../../../common/vscodeApis/workspaceApis';
@@ -106,10 +106,10 @@ async function installPythonVersionAndGetPath(version: string, identifier?: stri
         // On Windows ARM64, use the full identifier to ensure we get ARM64 builds.
         // See: https://github.com/astral-sh/uv/issues/12906
         const installTarget = identifier ?? version;
-        await exec('uv', ['python', 'install', installTarget], { throwOnStdErr: false });
+        await execUv('uv', ['python', 'install', installTarget], { throwOnStdErr: false });
 
         // Get the path to the installed Python
-        const result = await exec('uv', ['python', 'find', version], { throwOnStdErr: false });
+        const result = await execUv('uv', ['python', 'find', version], { throwOnStdErr: false });
         const pythonPath = result?.stdout.trim();
 
         if (pythonPath) {
@@ -153,7 +153,7 @@ async function createGlobalVenv(
         // Create the venv using uv
         // --seed installs pip/setuptools for compatibility
         const args = ['venv', venvPath, '--seed', '-p', version];
-        await exec('uv', args, { throwOnStdErr: false });
+        await execUv('uv', args, { throwOnStdErr: false });
 
         // Return the path to the Python executable
         const pythonPath =

--- a/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uv.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uv.unit.test.ts
@@ -56,7 +56,7 @@ suite('uv Environment Tests', () => {
         test('exec is called with correct arguments', async () => {
             await isUvEnvironment(exampleUvPython);
 
-            assert.ok(execStub.calledWith('uv', ['python', 'dir'], { throwOnStdErr: true }));
+            assert.ok(execStub.calledWith('uv', ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true }));
         });
 
         test('getUvDir returns undefined when command fails', async () => {
@@ -225,10 +225,14 @@ suite('uv Environment Tests', () => {
             // files, so a freshly installed uv is not reachable on the running process PATH.
             const localBinUv = path.join(os.homedir(), '.local', 'bin', process.platform === 'win32' ? 'uv.exe' : 'uv');
             // Bare `uv` is not on PATH.
-            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).rejects(new Error('command not found'));
+            execStub
+                .withArgs('uv', ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true })
+                .rejects(new Error('command not found'));
             // uv exists at its default install location and works there.
             pathExistsStub.withArgs(localBinUv).resolves(true);
-            execStub.withArgs(localBinUv, ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
+            execStub
+                .withArgs(localBinUv, ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true })
+                .resolves({ stdout: customDir });
 
             const result = await isUvInstalled();
 
@@ -240,8 +244,12 @@ suite('uv Environment Tests', () => {
         test('Returns both uv dir and bin dir when both are available', async () => {
             const uvDir = '/path/to/uv/python';
             const uvBinDir = '/path/to/uv/bin';
-            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: uvDir });
-            execStub.withArgs('uv', ['python', 'dir', '--bin'], { throwOnStdErr: true }).resolves({ stdout: uvBinDir });
+            execStub
+                .withArgs('uv', ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true })
+                .resolves({ stdout: uvDir });
+            execStub
+                .withArgs('uv', ['--color', 'never', 'python', 'dir', '--bin'], { throwOnStdErr: true })
+                .resolves({ stdout: uvBinDir });
 
             const result = await getUvDirs();
 
@@ -261,9 +269,11 @@ suite('uv Environment Tests', () => {
         test('Trims whitespace from command output', async () => {
             const uvDir = '/path/to/uv/python';
             const uvBinDir = '/path/to/uv/bin';
-            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: `  ${uvDir}  \n` });
             execStub
-                .withArgs('uv', ['python', 'dir', '--bin'], { throwOnStdErr: true })
+                .withArgs('uv', ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true })
+                .resolves({ stdout: `  ${uvDir}  \n` });
+            execStub
+                .withArgs('uv', ['--color', 'never', 'python', 'dir', '--bin'], { throwOnStdErr: true })
                 .resolves({ stdout: `\t${uvBinDir}\r\n` });
 
             const result = await getUvDirs();
@@ -271,6 +281,17 @@ suite('uv Environment Tests', () => {
             assert.strictEqual(result.size, 2);
             assert.ok(result.has(uvDir));
             assert.ok(result.has(uvBinDir));
+        });
+
+        test('Passes --color never so paths are not wrapped in ANSI codes', async () => {
+            // uv honors FORCE_COLOR/CLICOLOR_FORCE even when piped (both common in CI);
+            // the flag keeps `uv python dir` output free of the escape codes we parse.
+            await getUvDirs();
+
+            assert.ok(execStub.calledWith('uv', ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true }));
+            assert.ok(
+                execStub.calledWith('uv', ['--color', 'never', 'python', 'dir', '--bin'], { throwOnStdErr: true }),
+            );
         });
     });
 
@@ -284,8 +305,12 @@ suite('uv Environment Tests', () => {
         });
 
         test('Returns undefined when uv python list returns empty output', async () => {
-            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
-            execStub.withArgs('uv', ['python', 'list', '3.13'], { throwOnStdErr: false }).resolves({ stdout: '' });
+            execStub
+                .withArgs('uv', ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true })
+                .resolves({ stdout: customDir });
+            execStub
+                .withArgs('uv', ['--color', 'never', 'python', 'list', '3.13'], { throwOnStdErr: false })
+                .resolves({ stdout: '' });
 
             const result = await getUvPythonVersionInfo('3.13');
 
@@ -293,8 +318,10 @@ suite('uv Environment Tests', () => {
         });
 
         test('Detects pre-release alpha version from download-only output', async () => {
-            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
-            execStub.withArgs('uv', ['python', 'list', '3.15'], { throwOnStdErr: false }).resolves({
+            execStub
+                .withArgs('uv', ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true })
+                .resolves({ stdout: customDir });
+            execStub.withArgs('uv', ['--color', 'never', 'python', 'list', '3.15'], { throwOnStdErr: false }).resolves({
                 stdout: 'cpython-3.15.0a6-macos-aarch64-none    <download available>',
             });
 
@@ -307,8 +334,10 @@ suite('uv Environment Tests', () => {
         });
 
         test('Detects pre-release beta version', async () => {
-            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
-            execStub.withArgs('uv', ['python', 'list', '3.14'], { throwOnStdErr: false }).resolves({
+            execStub
+                .withArgs('uv', ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true })
+                .resolves({ stdout: customDir });
+            execStub.withArgs('uv', ['--color', 'never', 'python', 'list', '3.14'], { throwOnStdErr: false }).resolves({
                 stdout: 'cpython-3.14.0b2-linux-x86_64-gnu    <download available>',
             });
 
@@ -320,8 +349,10 @@ suite('uv Environment Tests', () => {
         });
 
         test('Detects pre-release candidate version', async () => {
-            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
-            execStub.withArgs('uv', ['python', 'list', '3.13'], { throwOnStdErr: false }).resolves({
+            execStub
+                .withArgs('uv', ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true })
+                .resolves({ stdout: customDir });
+            execStub.withArgs('uv', ['--color', 'never', 'python', 'list', '3.13'], { throwOnStdErr: false }).resolves({
                 stdout: 'cpython-3.13.0rc1-macos-aarch64-none    <download available>',
             });
 
@@ -333,8 +364,10 @@ suite('uv Environment Tests', () => {
         });
 
         test('Detects stable version as non-prerelease', async () => {
-            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
-            execStub.withArgs('uv', ['python', 'list', '3.12'], { throwOnStdErr: false }).resolves({
+            execStub
+                .withArgs('uv', ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true })
+                .resolves({ stdout: customDir });
+            execStub.withArgs('uv', ['--color', 'never', 'python', 'list', '3.12'], { throwOnStdErr: false }).resolves({
                 stdout: 'cpython-3.12.5-macos-aarch64-none    <download available>',
             });
 
@@ -346,8 +379,10 @@ suite('uv Environment Tests', () => {
         });
 
         test('Returns local install info including path when version is pre-release', async () => {
-            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
-            execStub.withArgs('uv', ['python', 'list', '3.14'], { throwOnStdErr: false }).resolves({
+            execStub
+                .withArgs('uv', ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true })
+                .resolves({ stdout: customDir });
+            execStub.withArgs('uv', ['--color', 'never', 'python', 'list', '3.14'], { throwOnStdErr: false }).resolves({
                 stdout: 'cpython-3.14.0a5-macos-aarch64-none    /usr/local/bin/python3.14',
             });
 
@@ -360,8 +395,10 @@ suite('uv Environment Tests', () => {
         });
 
         test('Returns local install info for stable version', async () => {
-            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
-            execStub.withArgs('uv', ['python', 'list', '3.13'], { throwOnStdErr: false }).resolves({
+            execStub
+                .withArgs('uv', ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true })
+                .resolves({ stdout: customDir });
+            execStub.withArgs('uv', ['--color', 'never', 'python', 'list', '3.13'], { throwOnStdErr: false }).resolves({
                 stdout: 'cpython-3.13.7-macos-aarch64-none     /usr/local/bin/python3.13 -> python3.13.real',
             });
 
@@ -374,8 +411,10 @@ suite('uv Environment Tests', () => {
         });
 
         test('Extracts Windows path correctly', async () => {
-            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
-            execStub.withArgs('uv', ['python', 'list', '3.12'], { throwOnStdErr: false }).resolves({
+            execStub
+                .withArgs('uv', ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true })
+                .resolves({ stdout: customDir });
+            execStub.withArgs('uv', ['--color', 'never', 'python', 'list', '3.12'], { throwOnStdErr: false }).resolves({
                 stdout: 'cpython-3.12.5-windows-x86_64-none    C:\\Users\\test\\AppData\\Local\\uv\\python\\python.exe',
             });
 
@@ -388,8 +427,10 @@ suite('uv Environment Tests', () => {
         });
 
         test('Extracts Windows path with spaces correctly', async () => {
-            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
-            execStub.withArgs('uv', ['python', 'list', '3.12'], { throwOnStdErr: false }).resolves({
+            execStub
+                .withArgs('uv', ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true })
+                .resolves({ stdout: customDir });
+            execStub.withArgs('uv', ['--color', 'never', 'python', 'list', '3.12'], { throwOnStdErr: false }).resolves({
                 stdout: 'cpython-3.12.5-windows-x86_64-none    C:\\Program Files\\Python312\\python.exe',
             });
 
@@ -402,8 +443,10 @@ suite('uv Environment Tests', () => {
         });
 
         test('Prefers local install over download when both available', async () => {
-            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
-            execStub.withArgs('uv', ['python', 'list', '3.13'], { throwOnStdErr: false }).resolves({
+            execStub
+                .withArgs('uv', ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true })
+                .resolves({ stdout: customDir });
+            execStub.withArgs('uv', ['--color', 'never', 'python', 'list', '3.13'], { throwOnStdErr: false }).resolves({
                 stdout: [
                     'cpython-3.13.8-macos-aarch64-none    <download available>',
                     'cpython-3.13.7-macos-aarch64-none    /usr/local/bin/python3.13',
@@ -419,8 +462,10 @@ suite('uv Environment Tests', () => {
         });
 
         test('Returns undefined when version cannot be parsed from output', async () => {
-            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
-            execStub.withArgs('uv', ['python', 'list', '3.13'], { throwOnStdErr: false }).resolves({
+            execStub
+                .withArgs('uv', ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true })
+                .resolves({ stdout: customDir });
+            execStub.withArgs('uv', ['--color', 'never', 'python', 'list', '3.13'], { throwOnStdErr: false }).resolves({
                 stdout: 'unexpected format that does not match',
             });
 
@@ -431,8 +476,10 @@ suite('uv Environment Tests', () => {
         });
 
         test('Handles multiple lines of output', async () => {
-            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
-            execStub.withArgs('uv', ['python', 'list', '3.12'], { throwOnStdErr: false }).resolves({
+            execStub
+                .withArgs('uv', ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true })
+                .resolves({ stdout: customDir });
+            execStub.withArgs('uv', ['--color', 'never', 'python', 'list', '3.12'], { throwOnStdErr: false }).resolves({
                 stdout: [
                     'cpython-3.12.9-macos-aarch64-none    <download available>',
                     'cpython-3.12.8-macos-aarch64-none    <download available>',
@@ -448,15 +495,31 @@ suite('uv Environment Tests', () => {
             assert.strictEqual(result.isPrerelease, false);
         });
 
+        test('Passes --color never so the interpreter path is not wrapped in ANSI codes', async () => {
+            execStub.withArgs('uv', ['--color', 'never', 'python', 'list', '3.13'], { throwOnStdErr: false }).resolves({
+                stdout: 'cpython-3.13.7-macos-aarch64-none    /usr/local/bin/python3.13',
+            });
+
+            await getUvPythonVersionInfo('3.13');
+
+            assert.ok(
+                execStub.calledWith('uv', ['--color', 'never', 'python', 'list', '3.13'], { throwOnStdErr: false }),
+            );
+        });
+
         suite('skipLocalPrereleases option', () => {
             test('Skips local pre-release and returns downloadable stable version', async () => {
-                execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
-                execStub.withArgs('uv', ['python', 'list', '3.14'], { throwOnStdErr: false }).resolves({
-                    stdout: [
-                        'cpython-3.14.0a5-macos-aarch64-none    /usr/local/bin/python3.14',
-                        'cpython-3.14.0-macos-aarch64-none    <download available>',
-                    ].join('\n'),
-                });
+                execStub
+                    .withArgs('uv', ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true })
+                    .resolves({ stdout: customDir });
+                execStub
+                    .withArgs('uv', ['--color', 'never', 'python', 'list', '3.14'], { throwOnStdErr: false })
+                    .resolves({
+                        stdout: [
+                            'cpython-3.14.0a5-macos-aarch64-none    /usr/local/bin/python3.14',
+                            'cpython-3.14.0-macos-aarch64-none    <download available>',
+                        ].join('\n'),
+                    });
 
                 const result = await getUvPythonVersionInfo('3.14', { skipLocalPrereleases: true });
 
@@ -468,13 +531,17 @@ suite('uv Environment Tests', () => {
             });
 
             test('Returns local stable version when available', async () => {
-                execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
-                execStub.withArgs('uv', ['python', 'list', '3.13'], { throwOnStdErr: false }).resolves({
-                    stdout: [
-                        'cpython-3.13.8-macos-aarch64-none    <download available>',
-                        'cpython-3.13.7-macos-aarch64-none    /usr/local/bin/python3.13',
-                    ].join('\n'),
-                });
+                execStub
+                    .withArgs('uv', ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true })
+                    .resolves({ stdout: customDir });
+                execStub
+                    .withArgs('uv', ['--color', 'never', 'python', 'list', '3.13'], { throwOnStdErr: false })
+                    .resolves({
+                        stdout: [
+                            'cpython-3.13.8-macos-aarch64-none    <download available>',
+                            'cpython-3.13.7-macos-aarch64-none    /usr/local/bin/python3.13',
+                        ].join('\n'),
+                    });
 
                 const result = await getUvPythonVersionInfo('3.13', { skipLocalPrereleases: true });
 
@@ -486,13 +553,17 @@ suite('uv Environment Tests', () => {
             });
 
             test('Falls back to pre-release when no stable version available', async () => {
-                execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
-                execStub.withArgs('uv', ['python', 'list', '3.15'], { throwOnStdErr: false }).resolves({
-                    stdout: [
-                        'cpython-3.15.0a6-macos-aarch64-none    /usr/local/bin/python3.15',
-                        'cpython-3.15.0a5-macos-aarch64-none    <download available>',
-                    ].join('\n'),
-                });
+                execStub
+                    .withArgs('uv', ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true })
+                    .resolves({ stdout: customDir });
+                execStub
+                    .withArgs('uv', ['--color', 'never', 'python', 'list', '3.15'], { throwOnStdErr: false })
+                    .resolves({
+                        stdout: [
+                            'cpython-3.15.0a6-macos-aarch64-none    /usr/local/bin/python3.15',
+                            'cpython-3.15.0a5-macos-aarch64-none    <download available>',
+                        ].join('\n'),
+                    });
 
                 const result = await getUvPythonVersionInfo('3.15', { skipLocalPrereleases: true });
 
@@ -503,14 +574,18 @@ suite('uv Environment Tests', () => {
             });
 
             test('Prefers local stable over downloadable stable', async () => {
-                execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
-                execStub.withArgs('uv', ['python', 'list', '3.13'], { throwOnStdErr: false }).resolves({
-                    stdout: [
-                        'cpython-3.13.0a5-macos-aarch64-none    /usr/local/bin/python3.13a',
-                        'cpython-3.13.8-macos-aarch64-none    <download available>',
-                        'cpython-3.13.7-macos-aarch64-none    /usr/local/bin/python3.13',
-                    ].join('\n'),
-                });
+                execStub
+                    .withArgs('uv', ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true })
+                    .resolves({ stdout: customDir });
+                execStub
+                    .withArgs('uv', ['--color', 'never', 'python', 'list', '3.13'], { throwOnStdErr: false })
+                    .resolves({
+                        stdout: [
+                            'cpython-3.13.0a5-macos-aarch64-none    /usr/local/bin/python3.13a',
+                            'cpython-3.13.8-macos-aarch64-none    <download available>',
+                            'cpython-3.13.7-macos-aarch64-none    /usr/local/bin/python3.13',
+                        ].join('\n'),
+                    });
 
                 const result = await getUvPythonVersionInfo('3.13', { skipLocalPrereleases: true });
 
@@ -522,13 +597,17 @@ suite('uv Environment Tests', () => {
             });
 
             test('Default behavior (no option) prefers local pre-release', async () => {
-                execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
-                execStub.withArgs('uv', ['python', 'list', '3.14'], { throwOnStdErr: false }).resolves({
-                    stdout: [
-                        'cpython-3.14.0a5-macos-aarch64-none    /usr/local/bin/python3.14',
-                        'cpython-3.14.0-macos-aarch64-none    <download available>',
-                    ].join('\n'),
-                });
+                execStub
+                    .withArgs('uv', ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true })
+                    .resolves({ stdout: customDir });
+                execStub
+                    .withArgs('uv', ['--color', 'never', 'python', 'list', '3.14'], { throwOnStdErr: false })
+                    .resolves({
+                        stdout: [
+                            'cpython-3.14.0a5-macos-aarch64-none    /usr/local/bin/python3.14',
+                            'cpython-3.14.0-macos-aarch64-none    <download available>',
+                        ].join('\n'),
+                    });
 
                 const result = await getUvPythonVersionInfo('3.14');
 
@@ -551,18 +630,26 @@ suite('uv Environment Tests', () => {
         });
 
         test('Returns true when uv self update succeeds', async () => {
-            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
-            execStub.withArgs('uv', ['self', 'update'], { throwOnStdErr: false }).resolves({ stdout: 'Updated' });
+            execStub
+                .withArgs('uv', ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true })
+                .resolves({ stdout: customDir });
+            execStub
+                .withArgs('uv', ['--color', 'never', 'self', 'update'], { throwOnStdErr: false })
+                .resolves({ stdout: 'Updated' });
 
             const result = await updateUv();
 
             assert.strictEqual(result, true);
-            assert.ok(execStub.calledWith('uv', ['self', 'update'], { throwOnStdErr: false }));
+            assert.ok(execStub.calledWith('uv', ['--color', 'never', 'self', 'update'], { throwOnStdErr: false }));
         });
 
         test('Returns false when uv self update fails', async () => {
-            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
-            execStub.withArgs('uv', ['self', 'update'], { throwOnStdErr: false }).rejects(new Error('Update failed'));
+            execStub
+                .withArgs('uv', ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true })
+                .resolves({ stdout: customDir });
+            execStub
+                .withArgs('uv', ['--color', 'never', 'self', 'update'], { throwOnStdErr: false })
+                .rejects(new Error('Update failed'));
 
             const result = await updateUv();
 
@@ -571,8 +658,12 @@ suite('uv Environment Tests', () => {
         });
 
         test('Logs success message on successful update', async () => {
-            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
-            execStub.withArgs('uv', ['self', 'update'], { throwOnStdErr: false }).resolves({ stdout: 'Updated' });
+            execStub
+                .withArgs('uv', ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true })
+                .resolves({ stdout: customDir });
+            execStub
+                .withArgs('uv', ['--color', 'never', 'self', 'update'], { throwOnStdErr: false })
+                .resolves({ stdout: 'Updated' });
 
             await updateUv();
 
@@ -591,21 +682,29 @@ suite('uv Environment Tests', () => {
         });
 
         test('Returns true when uv python install succeeds', async () => {
-            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
             execStub
-                .withArgs('uv', ['python', 'install', '3.13.7'], { throwOnStdErr: false })
+                .withArgs('uv', ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true })
+                .resolves({ stdout: customDir });
+            execStub
+                .withArgs('uv', ['--color', 'never', 'python', 'install', '3.13.7'], { throwOnStdErr: false })
                 .resolves({ stdout: 'Installed' });
 
             const result = await installUvPython('3.13.7');
 
             assert.strictEqual(result, true);
-            assert.ok(execStub.calledWith('uv', ['python', 'install', '3.13.7'], { throwOnStdErr: false }));
+            assert.ok(
+                execStub.calledWith('uv', ['--color', 'never', 'python', 'install', '3.13.7'], {
+                    throwOnStdErr: false,
+                }),
+            );
         });
 
         test('Returns false when uv python install fails', async () => {
-            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
             execStub
-                .withArgs('uv', ['python', 'install', '3.13.7'], { throwOnStdErr: false })
+                .withArgs('uv', ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true })
+                .resolves({ stdout: customDir });
+            execStub
+                .withArgs('uv', ['--color', 'never', 'python', 'install', '3.13.7'], { throwOnStdErr: false })
                 .rejects(new Error('Install failed'));
 
             const result = await installUvPython('3.13.7');
@@ -615,9 +714,11 @@ suite('uv Environment Tests', () => {
         });
 
         test('Logs success message on successful install', async () => {
-            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
             execStub
-                .withArgs('uv', ['python', 'install', '3.14.0'], { throwOnStdErr: false })
+                .withArgs('uv', ['--color', 'never', 'python', 'dir'], { throwOnStdErr: true })
+                .resolves({ stdout: customDir });
+            execStub
+                .withArgs('uv', ['--color', 'never', 'python', 'install', '3.14.0'], { throwOnStdErr: false })
                 .resolves({ stdout: 'Installed' });
 
             await installUvPython('3.14.0');

--- a/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uvPythonInstaller.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uvPythonInstaller.unit.test.ts
@@ -962,6 +962,31 @@ suite('UV Python Installer Tests', () => {
             assert.strictEqual(result.pythonPath, getExpectedGlobalVenvPython());
         });
 
+        test('Passes --color never to uv install and find so the parsed path is not ANSI-wrapped', async () => {
+            // uv honors FORCE_COLOR/CLICOLOR_FORCE even when piped (both common in CI); the flag
+            // keeps `uv python find` output free of the escape codes we parse as the interpreter path.
+            isUvInstalledStub.resolves(true);
+            getAvailablePythonVersionsStub.resolves([
+                { version: '3.13', isInstalled: false, identifier: 'cpython-3.13.1-macos-aarch64-none' },
+            ]);
+            quickPickResponses = [{ version: '3.13', label: 'Python 3.13' }];
+            execStub.onFirstCall().resolves({ stdout: '' }); // uv python install
+            execStub.onSecondCall().resolves({ stdout: '/usr/local/bin/python3.13' }); // uv python find
+            execStub.onThirdCall().resolves({ stdout: '' }); // uv venv (global)
+            getWorkspaceFoldersStub.returns(undefined);
+
+            await installPythonViaUv();
+
+            assert.ok(
+                execStub.calledWith('uv', ['--color', 'never', 'python', 'install', '3.13'], { throwOnStdErr: false }),
+                'uv python install should be invoked with --color never',
+            );
+            assert.ok(
+                execStub.calledWith('uv', ['--color', 'never', 'python', 'find', '3.13'], { throwOnStdErr: false }),
+                'uv python find should be invoked with --color never',
+            );
+        });
+
         test('Falls back to base Python when global venv creation fails', async () => {
             isUvInstalledStub.resolves(true);
             // Return available versions via stub

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -94,13 +94,11 @@ export class Sessions {
 		options?: {
 			triggerMode?: SessionTrigger;
 			reuse?: boolean;
-			interpreterSource?: string; // source label to require in the selected row (e.g. '.venv')
 		}
 	): Promise<T extends SessionRuntimes ? SessionMetaData : { [K in keyof T]: SessionMetaData }> {
 		const {
 			triggerMode = 'hotkey',
 			reuse = true,
-			interpreterSource,
 		} = options || {};
 
 		// convert input to array for unified processing
@@ -115,7 +113,6 @@ export class Sessions {
 				...sessionTemplate,
 				waitForReady: true,
 				triggerMode,
-				interpreterSource,
 				// Ensure we get fresh environment values
 				name: sessionTemplate.name, // This will call the getter again
 				version: sessionTemplate.version, // This will call the getter again
@@ -435,7 +432,6 @@ export class Sessions {
 		language: 'Python' | 'R';
 		version?: string;
 		disambiguator?: string; // additional string to differentiate in picker
-		interpreterSource?: string; // source label to require in the selected row (e.g. '.venv')
 		triggerMode?: 'session-picker' | 'quickaccess' | 'hotkey';
 		waitForReady?: boolean;
 	}): Promise<string> {
@@ -451,7 +447,6 @@ export class Sessions {
 		const {
 			language,
 			version = language === 'Python' ? getDesiredPython() : getDesiredR(),
-			interpreterSource,
 			waitForReady = true,
 			triggerMode = 'hotkey',
 		} = options;
@@ -497,22 +492,10 @@ export class Sessions {
 				// Wait until the desired runtime appears in the list and select it.
 				// We need to click instead of using 'enter' because the Python select interpreter command
 				// may include additional items above the desired interpreter string.
-				//
-				// When `interpreterSource` is set, target that specific interpreter
-				// (e.g. a project `.venv`) by matching its source in the row label,
-				// rather than relying on the deprioritize heuristic. A slower
-				// discovery source (a project venv on web/remote, which surfaces
-				// after the fast-discovered base interpreter) is simply absent on the
-				// first attempt: selection throws and the enclosing `toPass` retries,
-				// re-opening the picker until discovery lists it -- instead of
-				// falling back to a base interpreter that may be an invalid target.
-				const selectionText = interpreterSource
-					? `${language} ${version} (${interpreterSource})`
-					: `${language} ${version}`;
 				try {
-					await this.quickinput.selectQuickInputElementContaining(selectionText, {
+					await this.quickinput.selectQuickInputElementContaining(`${language} ${version}`, {
 						timeout: 2000,
-						deprioritize: (language === 'Python' && !interpreterSource) ? DEPRIORITIZED_PYTHON_SOURCES : undefined,
+						deprioritize: language === 'Python' ? DEPRIORITIZED_PYTHON_SOURCES : undefined,
 					});
 				} catch (e) {
 					// Auto-discovery is intermittent: POSITRON_PY_VER_SEL's interpreter
@@ -1347,7 +1330,6 @@ export type SessionInfo = {
 	language: 'Python' | 'R';
 	version: string; // e.g. '3.10.15'
 	disambiguator?: string; // additional string to differentiate in picker
-	interpreterSource?: string; // source label to require in the selected row (e.g. '.venv')
 	id: string;
 	triggerMode?: SessionTrigger;
 	waitForReady?: boolean;

--- a/test/e2e/tests/packages-pane/packages-pane.test.ts
+++ b/test/e2e/tests/packages-pane/packages-pane.test.ts
@@ -47,22 +47,7 @@ test.describe('Packages Pane', {
 				async function ({ app, sessions }) {
 					const { packages, toasts } = app.workbench;
 
-					// The `python` (uv) runtime resolves to two 3.10.12 interpreters: the
-					// project venv (`.venv`) and the uv-managed base standalone. The
-					// new-session (hotkey) picker only offers the preferred one, which is the
-					// base standalone -- an invalid install target (externally-managed; even
-					// `uv pip install` refuses it). Use `python.setInterpreter`, which lists
-					// all interpreters, and require the `.venv` source so the project venv is
-					// selected and package installs succeed. On web/remote the venv is
-					// discovered a beat later than the base interpreter, so requiring its
-					// source (rather than taking the first match) lets the picker retry until
-					// the venv appears instead of falling back to the standalone. Windows CI
-					// has no venv (system Python via actions/setup-python), so require the
-					// `.venv` source only elsewhere.
-					const pythonOptions = process.platform === 'win32'
-						? { triggerMode: 'quickaccess' as const }
-						: { triggerMode: 'quickaccess' as const, interpreterSource: '.venv' };
-					await sessions.start(runtime, runtime === 'python' ? pythonOptions : undefined);
+					await sessions.start(runtime);
 
 					await packages.verifyPackagesList();
 


### PR DESCRIPTION
This PR includes 3 changes that all need to be shipped together for CI to remain green:

1. Un-revert #14588. This slurps up the new PET 2026.12 categories so that uv environments aren't labeled "Unknown" in some cases, and silences a false positive error log message.
2. Tell the uv CLI not to use ANSI color codes, because we often parse the return values. When we don't have this fix but we do have the above fix, certain e2e tests would fail because they'd start to label base uv envs as `uv (python)` instead of `uv`, as if they were venvs, because of the parse failure. (This is why the above fix was reverted.)
3. Revert a change made to "fix" the packages pane e2e test in #14738. That wasn't the correct fix; the correct fix was https://github.com/posit-dev/positron/pull/14618, and the wrong fix ended up deterministically failing the test on Windows/Mac.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about  the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- uv environments are labeled "Unknown" less often https://github.com/posit-dev/positron/issues/14556


### Validation Steps

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information on how to validate the change, paying
  special attention to the level of risk, adjacent areas that could
  be affected by the change, and any important contextual information
  not present in the linked issues.
-->

I'll kick off a full e2e workflow separately instead of tagging this PR because that works better.

See validation steps in #14588. Also make sure uv environments look labeled correctly to you. (Right now, the base ones should just be `(uv)` and venvs should be `(uv: your_folder)`.