### PR TITLE
CI: pin PPM to a dated snapshot to avoid latest 404 race

### DIFF
--- a/.github/workflows/test-e2e-macos-run.yml
+++ b/.github/workflows/test-e2e-macos-run.yml
@@ -217,9 +217,16 @@ jobs:
           rig add "$R_ALTERNATE_VERSION"
 
       - name: Install R packages for 4.5.2
+        env:
+          # Pin to a frozen PPM snapshot instead of `latest`. `latest` is a rolling
+          # target: pak resolves a version from the metadata, but by the time it
+          # downloads the binary PPM may have published a newer release and rotated
+          # the old binary out, yielding intermittent 404s. A dated snapshot keeps
+          # metadata and binaries consistent.
+          PPM_REPO: https://packagemanager.posit.co/cran/2026-06-30
         run: |
           curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/DESCRIPTION --output DESCRIPTION
-          Rscript -e "options(pak.install_binary = TRUE, repos = c(CRAN = 'https://packagemanager.posit.co/cran/latest')); pak::local_install_dev_deps(ask = FALSE)"
+          Rscript -e "options(pak.install_binary = TRUE, repos = c(CRAN = Sys.getenv('PPM_REPO'))); pak::local_install_dev_deps(ask = FALSE)"
 
       - name: Install pyenv and Python
         run: |

--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -376,12 +376,19 @@ jobs:
             ${{ runner.os }}-r-4.4.0-
 
       - name: Install R packages for 4.4.0
+        env:
+          # Pin to a frozen PPM snapshot instead of `latest`. `latest` is a rolling
+          # target: pak resolves a version from the metadata, but by the time it
+          # downloads the binary PPM may have published a newer release and rotated
+          # the old binary out, yielding intermittent 404s (e.g. performance,
+          # RSQLite). A dated snapshot keeps metadata and binaries consistent.
+          PPM_REPO: https://packagemanager.posit.co/cran/2026-06-30
         run: |
-          Rscript -e "install.packages('pak')"
+          Rscript -e "options(repos = c(CRAN = Sys.getenv('PPM_REPO'))); install.packages('pak')"
           # openssl 2.4.1 Windows binary was never published to the package manager; pin to 2.4.2
           # so pak doesn't attempt to download the missing binary.
-          Rscript -e "pak::pak('openssl@2.4.2')"
-          Rscript -e "pak::local_install_dev_deps(ask = FALSE, upgrade = FALSE)"
+          Rscript -e "options(repos = c(CRAN = Sys.getenv('PPM_REPO'))); pak::pak('openssl@2.4.2')"
+          Rscript -e "options(repos = c(CRAN = Sys.getenv('PPM_REPO'))); pak::local_install_dev_deps(ask = FALSE, upgrade = FALSE)"
 
       - name: Save R packages cache
         if: ${{ matrix.shard == 1 && steps.cache-r.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
## Problem

The Windows and macOS e2e workflows install R packages from PPM's rolling `latest` channel. During a publish window, pak resolves a package version from the `PACKAGES` metadata but the matching binary can already have been rotated out of `latest`, producing intermittent `404` download failures. This surfaced as CI failures on Windows R 4.4:

```
Failed to download performance from .../cran/latest/bin/windows/contrib/4.4/performance_0.17.0.zip
Failed to download RSQLite  from .../cran/latest/bin/windows/contrib/4.4/RSQLite_3.53.2.zip
```

At the time, `latest` had already moved to `performance 0.17.1` / `RSQLite 3.53.3` and dropped the older binaries.

## Fix

Pin `PPM_REPO` to a frozen dated snapshot (`.../cran/2026-06-30`) in both workflows. A dated snapshot is internally consistent: the version pak resolves from `PACKAGES` always has a downloadable binary, so the race can't occur.

Changed files:
- `.github/workflows/test-e2e-windows-run.yml` (R 4.4.0 install step)
- `.github/workflows/test-e2e-macos-run.yml` (R 4.5.2 install step)

## Keeping it current

A monthly cloud routine bumps this date and opens a follow-up PR, so the pin doesn't drift stale while still avoiding the `latest` race.

Also reported to the PPM team as a likely server-side metadata/binary atomicity issue on `latest`.

CC @jonvanausdeln @midleman

🤖 Generated with [Claude Code](https://claude.com/claude-code)