### PR TITLE
Fix/12887 dispose orphaned webviews

### DIFF
--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadService.vitest.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadService.vitest.ts
@@ -22,7 +22,15 @@ import { IEditorService } from '../../../services/editor/common/editorService.js
 
 /** Minimal stub for IPositronNotebookInstance */
 function stubNotebookInstance(id: string, uri = URI.file('/workspace/notebook.ipynb')): IPositronNotebookInstance {
-	return stubInterface<IPositronNotebookInstance>({ getId: () => id, uri });
+	// attachNotebookInstance reconciles overlay webviews against the notebook
+	// model, so it reads textModel + subscribes to onDidChangeModel. These PDF
+	// tests don't exercise reconciliation, so a model-less instance is enough.
+	return stubInterface<IPositronNotebookInstance>({
+		getId: () => id,
+		uri,
+		textModel: undefined,
+		onDidChangeModel: Event.None,
+	});
 }
 
 /** Counts raw HTML webview creations */

--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadService.vitest.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadService.vitest.ts
@@ -22,9 +22,8 @@ import { IEditorService } from '../../../services/editor/common/editorService.js
 
 /** Minimal stub for IPositronNotebookInstance */
 function stubNotebookInstance(id: string, uri = URI.file('/workspace/notebook.ipynb')): IPositronNotebookInstance {
-	// attachNotebookInstance reconciles overlay webviews against the notebook
-	// model, so it reads textModel + subscribes to onDidChangeModel. These PDF
-	// tests don't exercise reconciliation, so a model-less instance is enough.
+	// attachNotebookInstance now reads textModel + onDidChangeModel; these PDF
+	// tests don't exercise reconciliation, so a model-less stub is enough.
 	return stubInterface<IPositronNotebookInstance>({
 		getId: () => id,
 		uri,

--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
@@ -275,27 +275,49 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 	}
 
 	/**
-	 * Track and return an overlay webview (display plot or raw HTML) so it can
-	 * be reconciled against the notebook model and disposed when orphaned.
+	 * Get the tracked overlay webview for an output, creating and tracking one
+	 * if none exists or the content changed under the same output ID.
+	 *
+	 * Concentrates the overlay reuse/rebuild invariant in one place: reuse the
+	 * cached webview on an exact content match (parseCellOutputs() re-runs on
+	 * every output change, so recreating would churn and orphan the webview);
+	 * otherwise dispose any stale webview and create a fresh one. The created
+	 * webview is tracked so it is reconciled against the notebook model and
+	 * disposed when its output disappears, and dropped from the cache if
+	 * creation fails (guarding against a newer create that replaced it).
+	 *
+	 * @param create Builds the webview; called only when a (re)build is needed.
 	 */
-	private _trackOverlayWebview(instance: IPositronNotebookInstance, outputId: string, contentKey: string, webview: Promise<INotebookOutputWebview>): Promise<INotebookOutputWebview> {
-		this._overlayWebviewsByOutputId.set(outputId, webview);
+	private _getOrCreateOverlayWebview(
+		instance: IPositronNotebookInstance,
+		outputId: string,
+		contentKey: string,
+		create: () => Promise<INotebookOutputWebview>,
+	): Promise<INotebookOutputWebview> {
+		const existingOverlay = this._overlayWebviewsByOutputId.get(outputId);
+		if (existingOverlay && this._overlayContentByOutputId.get(outputId) === contentKey) {
+			return existingOverlay;
+		}
+		if (existingOverlay) {
+			this._disposeOverlayWebview(outputId);
+		}
+
+		const webviewPromise = create().catch(err => {
+			// Drop from the cache on failure, but only if still the current entry
+			// -- a newer create for the same output ID may have replaced it while
+			// this one was pending.
+			if (this._overlayWebviewsByOutputId.get(outputId) === webviewPromise) {
+				this._overlayWebviewsByOutputId.delete(outputId);
+				this._overlayContentByOutputId.delete(outputId);
+				this._overlayOutputIdsByNotebookId.get(instance.getId())?.delete(outputId);
+			}
+			throw err;
+		});
+
+		this._overlayWebviewsByOutputId.set(outputId, webviewPromise);
 		this._overlayContentByOutputId.set(outputId, contentKey);
 		this._overlayOutputIdsByNotebookId.get(instance.getId())?.add(outputId);
-		return webview;
-	}
-
-	/**
-	 * Drop a tracked overlay webview from the caches after creation fails, but
-	 * only if it is still the current entry -- a newer create for the same
-	 * output ID may have replaced it while this one was pending.
-	 */
-	private _untrackOverlayWebview(instance: IPositronNotebookInstance, outputId: string, webview: Promise<INotebookOutputWebview>): void {
-		if (this._overlayWebviewsByOutputId.get(outputId) === webview) {
-			this._overlayWebviewsByOutputId.delete(outputId);
-			this._overlayContentByOutputId.delete(outputId);
-			this._overlayOutputIdsByNotebookId.get(instance.getId())?.delete(outputId);
-		}
+		return webviewPromise;
 	}
 
 	static notebookMessageToRuntimeOutput(message: NotebookOutput, kind: RuntimeOutputKind): ILanguageRuntimeMessageWebOutput {
@@ -372,29 +394,13 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 				return { preloadMessageType: 'display', webview: webviewPromise };
 			}
 
-			// Reuse a tracked overlay if one already exists for this output with
-			// the same content: parseCellOutputs() re-runs on every output
-			// change, so recreating here would churn (and orphan) the webview.
-			// If the HTML changed under the same output ID (e.g. an in-place
-			// update), dispose the stale webview and rebuild. The tracked webview
-			// is reconciled against the model and disposed when its output is gone.
-			const contentKey = rawHtml;
-			const existingOverlay = this._overlayWebviewsByOutputId.get(outputId);
-			if (existingOverlay && this._overlayContentByOutputId.get(outputId) === contentKey) {
-				return { preloadMessageType: 'display', webview: existingOverlay };
-			}
-			if (existingOverlay) {
-				this._disposeOverlayWebview(outputId);
-			}
-
-			const webviewPromise = this._notebookOutputWebviewService.createRawHtmlOutputWebview(outputId, rawHtml, rawHtmlBaseUri)
-				.catch(err => {
-					this._untrackOverlayWebview(instance, outputId, webviewPromise);
-					throw err;
-				});
+			// Track the raw HTML overlay (keyed by its HTML content) so it is
+			// reconciled against the model and rebuilt if the HTML changes under
+			// the same output ID. See _getOrCreateOverlayWebview.
 			return {
 				preloadMessageType: 'display',
-				webview: this._trackOverlayWebview(instance, outputId, contentKey, webviewPromise),
+				webview: this._getOrCreateOverlayWebview(instance, outputId, rawHtml, () =>
+					this._notebookOutputWebviewService.createRawHtmlOutputWebview(outputId, rawHtml, rawHtmlBaseUri)),
 			};
 		}
 
@@ -450,30 +456,14 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 		}
 
 		// Display messages (e.g., interactive plots) need their own overlay
-		// webview. Reuse a tracked one if it already exists with the same content
-		// -- parseCellOutputs() re-runs on every output change, so recreating
-		// here would churn (and orphan) the webview. If the output content
-		// changed under the same output ID (e.g. an in-place update), dispose the
-		// stale webview and rebuild. The tracked webview is reconciled against
-		// the model and disposed when its output disappears.
+		// webview. Track it (keyed by output content) so it is reconciled against
+		// the model and rebuilt if the content changes under the same output ID.
+		// See _getOrCreateOverlayWebview.
 		if (messageType === 'display') {
-			const contentKey = this._fingerprintOutputs(outputs);
-			const existingOverlay = this._overlayWebviewsByOutputId.get(runtimeOutput.id);
-			if (existingOverlay && this._overlayContentByOutputId.get(runtimeOutput.id) === contentKey) {
-				return { preloadMessageType: messageType, webview: existingOverlay };
-			}
-			if (existingOverlay) {
-				this._disposeOverlayWebview(runtimeOutput.id);
-			}
-
-			const webviewPromise = this._createNotebookPlotWebview(instance, runtimeOutput)
-				.catch(err => {
-					this._untrackOverlayWebview(instance, runtimeOutput.id, webviewPromise);
-					throw err;
-				});
 			return {
 				preloadMessageType: messageType,
-				webview: this._trackOverlayWebview(instance, runtimeOutput.id, contentKey, webviewPromise),
+				webview: this._getOrCreateOverlayWebview(instance, runtimeOutput.id, this._fingerprintOutputs(outputs), () =>
+					this._createNotebookPlotWebview(instance, runtimeOutput)),
 			};
 		}
 

--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
@@ -56,17 +56,9 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 	private readonly _pdfWebviewsByOutputId = new Map<string, Promise<INotebookOutputWebview>>();
 
 	/**
-	 * Map of created overlay webviews (interactive display plots and raw HTML)
-	 * keyed by output ID. Unlike widgets, these have no comm channel of their
-	 * own, so the service owns their lifecycle: they are reconciled against the
-	 * notebook model and disposed when their output disappears. Widget and PDF
-	 * webviews are deliberately excluded -- they manage their own lifecycle.
-	 *
-	 * Each entry carries the content fingerprint it was built from (to detect a
-	 * content change under the same output ID, e.g. a Jupyter
-	 * update_display_data, so the stale webview is rebuilt rather than reused)
-	 * and its owning notebook ID (so disposal can drop the output from the
-	 * per-notebook set without the caller having to).
+	 * Overlay webviews (display plots + raw HTML) keyed by output ID. Unlike
+	 * comm-backed widgets, the service owns their lifecycle: it reconciles them
+	 * against the model and disposes them when their output disappears.
 	 */
 	private readonly _overlayWebviewsByOutputId = new Map<string, OverlayWebviewEntry>();
 
@@ -177,10 +169,9 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 		this._outputIdsByNotebookId.set(notebookId, new Set());
 		this._overlayOutputIdsByNotebookId.set(notebookId, new Set());
 
-		// Listen for notebook model changes so overlay webviews whose outputs
-		// disappear (cleared, cell deleted, output type changed) are disposed
-		// rather than left orphaned in memory. The text model can be swapped
-		// out (onDidChangeModel), so re-attach the content listener each time.
+		// Dispose overlay webviews whose outputs disappear (cleared, cell deleted,
+		// re-run). The text model can be swapped, so re-attach the listener on
+		// each model change.
 		const modelDisposables = disposables.add(new MutableDisposable<DisposableStore>());
 		const attachModel = () => {
 			modelDisposables.clear();
@@ -221,11 +212,7 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 		}));
 	}
 
-	/**
-	 * Whether a model-content change touched cell outputs in a way that could
-	 * orphan an overlay webview: outputs replaced (clear / re-run), output items
-	 * changed, or cells added/removed.
-	 */
+	/** Whether a content change touched outputs (replace, item change, or add/remove cell) and so could orphan an overlay. */
 	private _affectsNotebookOutputs(event: NotebookTextModelChangedEvent): boolean {
 		return event.rawEvents.some(rawEvent =>
 			rawEvent.kind === NotebookCellsChangeType.Output ||
@@ -235,10 +222,8 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 	}
 
 	/**
-	 * Dispose any tracked overlay webview whose output ID is no longer present
-	 * in the notebook model. Only overlay webviews (display plots + raw HTML)
-	 * are reconciled here; widget webviews own their own lifecycle via the
-	 * ipywidgets comm channels and are never disposed by reconciliation.
+	 * Dispose overlay webviews whose output ID is no longer in the model. Widgets
+	 * are comm-backed and tracked separately, so they are never reconciled here.
 	 */
 	private _reconcileOverlayWebviews(instance: IPositronNotebookInstance): void {
 		const overlayOutputIds = this._overlayOutputIdsByNotebookId.get(instance.getId());
@@ -258,10 +243,8 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 	}
 
 	/**
-	 * Dispose a tracked overlay webview and remove it from all overlay tracking
-	 * (the webview cache and its notebook's output-ID set). Disposal is chained
-	 * off the cached Promise so a webview still being created is torn down once
-	 * it resolves.
+	 * Dispose an overlay webview and drop it from both overlay maps. Disposal is
+	 * chained off the Promise so an in-flight webview is torn down once it resolves.
 	 */
 	private _disposeOverlayWebview(outputId: string): void {
 		const entry = this._overlayWebviewsByOutputId.get(outputId);
@@ -273,28 +256,16 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 		this._overlayOutputIdsByNotebookId.get(entry.notebookId)?.delete(outputId);
 	}
 
-	/**
-	 * Stable fingerprint of an output's items (mime + data), used to detect when
-	 * a display output's content changed under the same output ID so a stale
-	 * webview is rebuilt rather than reused.
-	 */
+	/** Fingerprint of an output's items (mime + data) to detect in-place content changes under a stable output ID. */
 	private _fingerprintOutputs(outputs: NotebookOutput['outputs']): string {
 		return outputs.map(o => `${o.mime}:${o.data.toString()}`).join('\0');
 	}
 
 	/**
-	 * Get the tracked overlay webview for an output, creating and tracking one
-	 * if none exists or the content changed under the same output ID.
-	 *
-	 * Concentrates the overlay reuse/rebuild invariant in one place: reuse the
-	 * cached webview on an exact content match (parseCellOutputs() re-runs on
-	 * every output change, so recreating would churn and orphan the webview);
-	 * otherwise dispose any stale webview and create a fresh one. The created
-	 * webview is tracked so it is reconciled against the notebook model and
-	 * disposed when its output disappears, and dropped from the cache if
-	 * creation fails (guarding against a newer create that replaced it).
-	 *
-	 * @param create Builds the webview; called only when a (re)build is needed.
+	 * Reuse the tracked overlay webview on an exact content match; otherwise
+	 * dispose the stale one and build a fresh one via `create`. Reuse matters
+	 * because parseCellOutputs() re-runs on every output change, so rebuilding
+	 * unconditionally would churn and orphan webviews.
 	 */
 	private _getOrCreateOverlayWebview(
 		instance: IPositronNotebookInstance,
@@ -311,9 +282,7 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 		}
 
 		const webviewPromise = create().catch(err => {
-			// Drop from the cache on failure, but only if still the current entry
-			// -- a newer create for the same output ID may have replaced it while
-			// this one was pending.
+			// Untrack on failure, unless a newer create already replaced this entry.
 			if (this._overlayWebviewsByOutputId.get(outputId)?.webview === webviewPromise) {
 				this._disposeOverlayWebview(outputId);
 			}
@@ -374,11 +343,9 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 				? undefined
 				: dirname(instance.uri);
 
-			// Check if this HTML contains an iframe pointing to a PDF file.
-			// If so, route through the PDF server for proper rendering. PDF
-			// webviews keep their own cache and notebook-close cleanup (they
-			// also unregister from the PDF HTTP server on dispose), so they are
-			// not tracked for output reconciliation here.
+			// Route HTML with an embedded PDF iframe through the PDF server. PDF
+			// webviews have their own cache and self-register with that server,
+			// so they are not reconciled here.
 			const pdfIframeInfo = extractPdfIframeInfo(rawHtml);
 			if (pdfIframeInfo) {
 				const existingWebview = this._pdfWebviewsByOutputId.get(outputId);
@@ -399,9 +366,7 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 				return { preloadMessageType: 'display', webview: webviewPromise };
 			}
 
-			// Track the raw HTML overlay (keyed by its HTML content) so it is
-			// reconciled against the model and rebuilt if the HTML changes under
-			// the same output ID. See _getOrCreateOverlayWebview.
+			// Track the raw HTML overlay, keyed by its HTML so it rebuilds on change.
 			return {
 				preloadMessageType: 'display',
 				webview: this._getOrCreateOverlayWebview(instance, outputId, rawHtml, () =>
@@ -460,10 +425,8 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 			};
 		}
 
-		// Display messages (e.g., interactive plots) need their own overlay
-		// webview. Track it (keyed by output content) so it is reconciled against
-		// the model and rebuilt if the content changes under the same output ID.
-		// See _getOrCreateOverlayWebview.
+		// Display messages (e.g. interactive plots) get a tracked overlay webview,
+		// keyed by output content so it rebuilds on change.
 		if (messageType === 'display') {
 			return {
 				preloadMessageType: messageType,

--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
@@ -29,6 +29,15 @@ import { URI } from '../../../../base/common/uri.js';
  * Format of output from a notebook cell
  */
 type NotebookOutput = { outputId: string; outputs: { mime: string; data: VSBuffer }[] };
+
+/** A tracked overlay webview together with the state needed to reconcile and dispose it. */
+interface OverlayWebviewEntry {
+	readonly webview: Promise<INotebookOutputWebview>;
+	/** Fingerprint of the content the webview was built from. */
+	readonly contentKey: string;
+	/** ID of the notebook that owns this overlay. */
+	readonly notebookId: string;
+}
 export class PositronWebviewPreloadService extends Disposable implements IPositronWebviewPreloadService {
 	/** Needed for service branding in dependency injector. */
 	_serviceBrand: undefined;
@@ -52,19 +61,17 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 	 * own, so the service owns their lifecycle: they are reconciled against the
 	 * notebook model and disposed when their output disappears. Widget and PDF
 	 * webviews are deliberately excluded -- they manage their own lifecycle.
+	 *
+	 * Each entry carries the content fingerprint it was built from (to detect a
+	 * content change under the same output ID, e.g. a Jupyter
+	 * update_display_data, so the stale webview is rebuilt rather than reused)
+	 * and its owning notebook ID (so disposal can drop the output from the
+	 * per-notebook set without the caller having to).
 	 */
-	private readonly _overlayWebviewsByOutputId = new Map<string, Promise<INotebookOutputWebview>>();
+	private readonly _overlayWebviewsByOutputId = new Map<string, OverlayWebviewEntry>();
 
 	/** Map tracking which overlay output IDs belong to which notebook for reconciliation. */
 	private readonly _overlayOutputIdsByNotebookId = new Map<string, Set<string>>();
-
-	/**
-	 * Fingerprint of the content each tracked overlay webview was created from,
-	 * keyed by output ID. Used to detect when an output's content changes under
-	 * the same output ID (e.g. a Jupyter update_display_data) so the stale
-	 * webview is rebuilt rather than reused.
-	 */
-	private readonly _overlayContentByOutputId = new Map<string, string>();
 
 	/** Map tracking which output IDs belong to which notebook for cache cleanup. */
 	private readonly _outputIdsByNotebookId = new Map<string, Set<string>>();
@@ -246,23 +253,24 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 		for (const outputId of Array.from(overlayOutputIds)) {
 			if (!liveOutputIds.has(outputId)) {
 				this._disposeOverlayWebview(outputId);
-				overlayOutputIds.delete(outputId);
 			}
 		}
 	}
 
 	/**
-	 * Dispose a tracked overlay webview and drop it from the cache. Disposal is
-	 * chained off the cached Promise so a webview still being created is torn
-	 * down once it resolves.
+	 * Dispose a tracked overlay webview and remove it from all overlay tracking
+	 * (the webview cache and its notebook's output-ID set). Disposal is chained
+	 * off the cached Promise so a webview still being created is torn down once
+	 * it resolves.
 	 */
 	private _disposeOverlayWebview(outputId: string): void {
-		const webviewPromise = this._overlayWebviewsByOutputId.get(outputId);
-		if (webviewPromise) {
-			webviewPromise.then(webview => webview.dispose(), () => { /* creation failed; nothing to dispose */ });
+		const entry = this._overlayWebviewsByOutputId.get(outputId);
+		if (!entry) {
+			return;
 		}
+		entry.webview.then(webview => webview.dispose(), () => { /* creation failed; nothing to dispose */ });
 		this._overlayWebviewsByOutputId.delete(outputId);
-		this._overlayContentByOutputId.delete(outputId);
+		this._overlayOutputIdsByNotebookId.get(entry.notebookId)?.delete(outputId);
 	}
 
 	/**
@@ -295,8 +303,8 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 		create: () => Promise<INotebookOutputWebview>,
 	): Promise<INotebookOutputWebview> {
 		const existingOverlay = this._overlayWebviewsByOutputId.get(outputId);
-		if (existingOverlay && this._overlayContentByOutputId.get(outputId) === contentKey) {
-			return existingOverlay;
+		if (existingOverlay && existingOverlay.contentKey === contentKey) {
+			return existingOverlay.webview;
 		}
 		if (existingOverlay) {
 			this._disposeOverlayWebview(outputId);
@@ -306,16 +314,13 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 			// Drop from the cache on failure, but only if still the current entry
 			// -- a newer create for the same output ID may have replaced it while
 			// this one was pending.
-			if (this._overlayWebviewsByOutputId.get(outputId) === webviewPromise) {
-				this._overlayWebviewsByOutputId.delete(outputId);
-				this._overlayContentByOutputId.delete(outputId);
-				this._overlayOutputIdsByNotebookId.get(instance.getId())?.delete(outputId);
+			if (this._overlayWebviewsByOutputId.get(outputId)?.webview === webviewPromise) {
+				this._disposeOverlayWebview(outputId);
 			}
 			throw err;
 		});
 
-		this._overlayWebviewsByOutputId.set(outputId, webviewPromise);
-		this._overlayContentByOutputId.set(outputId, contentKey);
+		this._overlayWebviewsByOutputId.set(outputId, { webview: webviewPromise, contentKey, notebookId: instance.getId() });
 		this._overlayOutputIdsByNotebookId.get(instance.getId())?.add(outputId);
 		return webviewPromise;
 	}

--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable, DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { ILanguageRuntimeMessageOutput, ILanguageRuntimeMessageWebOutput, LanguageRuntimeMessageType, LanguageRuntimeSessionMode, RuntimeOutputKind } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { IPositronWebviewPreloadService, NotebookPreloadOutputResults } from '../../../services/positronWebviewPreloads/browser/positronWebviewPreloadService.js';
@@ -15,6 +15,7 @@ import { UiFrontendEvent } from '../../../services/languageRuntime/common/positr
 import { VSBuffer } from '../../../../base/common/buffer.js';
 import { isWebviewDisplayMessage, getWebviewMessageType } from '../../../services/positronIPyWidgets/common/webviewPreloadUtils.js';
 import { IPositronNotebookInstance } from '../../positronNotebook/browser/IPositronNotebookInstance.js';
+import { NotebookCellsChangeType, NotebookTextModelChangedEvent } from '../../notebook/common/notebookCommon.js';
 import { IPositronIPyWidgetsService } from '../../../services/positronIPyWidgets/common/positronIPyWidgetsService.js';
 import { dirname } from '../../../../base/common/resources.js';
 import { Schemas } from '../../../../base/common/network.js';
@@ -44,6 +45,18 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 
 	/** Map of created PDF webviews keyed by output ID for Positron notebooks. */
 	private readonly _pdfWebviewsByOutputId = new Map<string, Promise<INotebookOutputWebview>>();
+
+	/**
+	 * Map of created overlay webviews (interactive display plots and raw HTML)
+	 * keyed by output ID. Unlike widgets, these have no comm channel of their
+	 * own, so the service owns their lifecycle: they are reconciled against the
+	 * notebook model and disposed when their output disappears. Widget and PDF
+	 * webviews are deliberately excluded -- they manage their own lifecycle.
+	 */
+	private readonly _overlayWebviewsByOutputId = new Map<string, Promise<INotebookOutputWebview>>();
+
+	/** Map tracking which overlay output IDs belong to which notebook for reconciliation. */
+	private readonly _overlayOutputIdsByNotebookId = new Map<string, Set<string>>();
 
 	/** Map tracking which output IDs belong to which notebook for cache cleanup. */
 	private readonly _outputIdsByNotebookId = new Map<string, Set<string>>();
@@ -147,6 +160,31 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 
 		// Initialize output ID tracking for this notebook
 		this._outputIdsByNotebookId.set(notebookId, new Set());
+		this._overlayOutputIdsByNotebookId.set(notebookId, new Set());
+
+		// Listen for notebook model changes so overlay webviews whose outputs
+		// disappear (cleared, cell deleted, output type changed) are disposed
+		// rather than left orphaned in memory. The text model can be swapped
+		// out (onDidChangeModel), so re-attach the content listener each time.
+		const modelDisposables = disposables.add(new MutableDisposable<DisposableStore>());
+		const attachModel = () => {
+			modelDisposables.clear();
+
+			const textModel = instance.textModel;
+			if (textModel) {
+				const contentDisposables = new DisposableStore();
+				contentDisposables.add(textModel.onDidChangeContent(event => {
+					if (this._affectsNotebookOutputs(event)) {
+						this._reconcileOverlayWebviews(instance);
+					}
+				}));
+				modelDisposables.value = contentDisposables;
+			}
+
+			this._reconcileOverlayWebviews(instance);
+		};
+		attachModel();
+		disposables.add(instance.onDidChangeModel(() => attachModel()));
 
 		// Clean up webview cache entries when notebook is disposed
 		disposables.add(toDisposable(() => {
@@ -158,9 +196,86 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 				});
 				this._outputIdsByNotebookId.delete(notebookId);
 			}
+			const overlayOutputIds = this._overlayOutputIdsByNotebookId.get(notebookId);
+			if (overlayOutputIds) {
+				overlayOutputIds.forEach(outputId => this._disposeOverlayWebview(outputId));
+				this._overlayOutputIdsByNotebookId.delete(notebookId);
+			}
 			this._messagesByNotebookId.delete(notebookId);
 			this._notebookToDisposablesMap.delete(notebookId);
 		}));
+	}
+
+	/**
+	 * Whether a model-content change touched cell outputs in a way that could
+	 * orphan an overlay webview: outputs replaced (clear / re-run), output items
+	 * changed, or cells added/removed.
+	 */
+	private _affectsNotebookOutputs(event: NotebookTextModelChangedEvent): boolean {
+		return event.rawEvents.some(rawEvent =>
+			rawEvent.kind === NotebookCellsChangeType.Output ||
+			rawEvent.kind === NotebookCellsChangeType.OutputItem ||
+			rawEvent.kind === NotebookCellsChangeType.ModelChange
+		);
+	}
+
+	/**
+	 * Dispose any tracked overlay webview whose output ID is no longer present
+	 * in the notebook model. Only overlay webviews (display plots + raw HTML)
+	 * are reconciled here; widget webviews own their own lifecycle via the
+	 * ipywidgets comm channels and are never disposed by reconciliation.
+	 */
+	private _reconcileOverlayWebviews(instance: IPositronNotebookInstance): void {
+		const overlayOutputIds = this._overlayOutputIdsByNotebookId.get(instance.getId());
+		if (!overlayOutputIds?.size) {
+			return;
+		}
+
+		const liveOutputIds = new Set(
+			instance.textModel?.cells.flatMap(cell => cell.outputs.map(output => output.outputId)) ?? []
+		);
+
+		for (const outputId of Array.from(overlayOutputIds)) {
+			if (!liveOutputIds.has(outputId)) {
+				this._disposeOverlayWebview(outputId);
+				overlayOutputIds.delete(outputId);
+			}
+		}
+	}
+
+	/**
+	 * Dispose a tracked overlay webview and drop it from the cache. Disposal is
+	 * chained off the cached Promise so a webview still being created is torn
+	 * down once it resolves.
+	 */
+	private _disposeOverlayWebview(outputId: string): void {
+		const webviewPromise = this._overlayWebviewsByOutputId.get(outputId);
+		if (webviewPromise) {
+			webviewPromise.then(webview => webview.dispose(), () => { /* creation failed; nothing to dispose */ });
+		}
+		this._overlayWebviewsByOutputId.delete(outputId);
+	}
+
+	/**
+	 * Track and return an overlay webview (display plot or raw HTML) so it can
+	 * be reconciled against the notebook model and disposed when orphaned.
+	 */
+	private _trackOverlayWebview(instance: IPositronNotebookInstance, outputId: string, webview: Promise<INotebookOutputWebview>): Promise<INotebookOutputWebview> {
+		this._overlayWebviewsByOutputId.set(outputId, webview);
+		this._overlayOutputIdsByNotebookId.get(instance.getId())?.add(outputId);
+		return webview;
+	}
+
+	/**
+	 * Drop a tracked overlay webview from the caches after creation fails, but
+	 * only if it is still the current entry -- a newer create for the same
+	 * output ID may have replaced it while this one was pending.
+	 */
+	private _untrackOverlayWebview(instance: IPositronNotebookInstance, outputId: string, webview: Promise<INotebookOutputWebview>): void {
+		if (this._overlayWebviewsByOutputId.get(outputId) === webview) {
+			this._overlayWebviewsByOutputId.delete(outputId);
+			this._overlayOutputIdsByNotebookId.get(instance.getId())?.delete(outputId);
+		}
 	}
 
 	static notebookMessageToRuntimeOutput(message: NotebookOutput, kind: RuntimeOutputKind): ILanguageRuntimeMessageWebOutput {
@@ -212,15 +327,11 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 				? undefined
 				: dirname(instance.uri);
 
-			// TODO: Overlay webviews (display AND raw HTML) are not disposed when
-			// outputs are cleared, cells are deleted, or output types change. A
-			// follow-up PR should add model-change reconciliation for all webview
-			// types. This is also a virtualization prerequisite: when cells are
-			// virtualized, the service will need to hold webviews across
-			// component mount/unmount cycles.
-
 			// Check if this HTML contains an iframe pointing to a PDF file.
-			// If so, route through the PDF server for proper rendering.
+			// If so, route through the PDF server for proper rendering. PDF
+			// webviews keep their own cache and notebook-close cleanup (they
+			// also unregister from the PDF HTTP server on dispose), so they are
+			// not tracked for output reconciliation here.
 			const pdfIframeInfo = extractPdfIframeInfo(rawHtml);
 			if (pdfIframeInfo) {
 				const existingWebview = this._pdfWebviewsByOutputId.get(outputId);
@@ -241,9 +352,23 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 				return { preloadMessageType: 'display', webview: webviewPromise };
 			}
 
+			// Reuse a tracked overlay if one already exists for this output:
+			// parseCellOutputs() re-runs on every output change, so recreating
+			// here would churn (and orphan) the webview. The tracked webview is
+			// reconciled against the model and disposed when its output is gone.
+			const existingOverlay = this._overlayWebviewsByOutputId.get(outputId);
+			if (existingOverlay) {
+				return { preloadMessageType: 'display', webview: existingOverlay };
+			}
+
+			const webviewPromise = this._notebookOutputWebviewService.createRawHtmlOutputWebview(outputId, rawHtml, rawHtmlBaseUri)
+				.catch(err => {
+					this._untrackOverlayWebview(instance, outputId, webviewPromise);
+					throw err;
+				});
 			return {
 				preloadMessageType: 'display',
-				webview: this._notebookOutputWebviewService.createRawHtmlOutputWebview(outputId, rawHtml, rawHtmlBaseUri),
+				webview: this._trackOverlayWebview(instance, outputId, webviewPromise),
 			};
 		}
 
@@ -298,12 +423,25 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 			};
 		}
 
-		// Display messages (e.g., interactive plots) need to create a new webview immediately
-		// and return it for rendering
+		// Display messages (e.g., interactive plots) need their own overlay
+		// webview. Reuse a tracked one if it already exists -- parseCellOutputs()
+		// re-runs on every output change, so recreating here would churn (and
+		// orphan) the webview. The tracked webview is reconciled against the
+		// model and disposed when its output disappears.
 		if (messageType === 'display') {
+			const existingOverlay = this._overlayWebviewsByOutputId.get(runtimeOutput.id);
+			if (existingOverlay) {
+				return { preloadMessageType: messageType, webview: existingOverlay };
+			}
+
+			const webviewPromise = this._createNotebookPlotWebview(instance, runtimeOutput)
+				.catch(err => {
+					this._untrackOverlayWebview(instance, runtimeOutput.id, webviewPromise);
+					throw err;
+				});
 			return {
 				preloadMessageType: messageType,
-				webview: this._createNotebookPlotWebview(instance, runtimeOutput)
+				webview: this._trackOverlayWebview(instance, runtimeOutput.id, webviewPromise),
 			};
 		}
 

--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
@@ -58,6 +58,14 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 	/** Map tracking which overlay output IDs belong to which notebook for reconciliation. */
 	private readonly _overlayOutputIdsByNotebookId = new Map<string, Set<string>>();
 
+	/**
+	 * Fingerprint of the content each tracked overlay webview was created from,
+	 * keyed by output ID. Used to detect when an output's content changes under
+	 * the same output ID (e.g. a Jupyter update_display_data) so the stale
+	 * webview is rebuilt rather than reused.
+	 */
+	private readonly _overlayContentByOutputId = new Map<string, string>();
+
 	/** Map tracking which output IDs belong to which notebook for cache cleanup. */
 	private readonly _outputIdsByNotebookId = new Map<string, Set<string>>();
 
@@ -254,14 +262,25 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 			webviewPromise.then(webview => webview.dispose(), () => { /* creation failed; nothing to dispose */ });
 		}
 		this._overlayWebviewsByOutputId.delete(outputId);
+		this._overlayContentByOutputId.delete(outputId);
+	}
+
+	/**
+	 * Stable fingerprint of an output's items (mime + data), used to detect when
+	 * a display output's content changed under the same output ID so a stale
+	 * webview is rebuilt rather than reused.
+	 */
+	private _fingerprintOutputs(outputs: NotebookOutput['outputs']): string {
+		return outputs.map(o => `${o.mime}:${o.data.toString()}`).join('\0');
 	}
 
 	/**
 	 * Track and return an overlay webview (display plot or raw HTML) so it can
 	 * be reconciled against the notebook model and disposed when orphaned.
 	 */
-	private _trackOverlayWebview(instance: IPositronNotebookInstance, outputId: string, webview: Promise<INotebookOutputWebview>): Promise<INotebookOutputWebview> {
+	private _trackOverlayWebview(instance: IPositronNotebookInstance, outputId: string, contentKey: string, webview: Promise<INotebookOutputWebview>): Promise<INotebookOutputWebview> {
 		this._overlayWebviewsByOutputId.set(outputId, webview);
+		this._overlayContentByOutputId.set(outputId, contentKey);
 		this._overlayOutputIdsByNotebookId.get(instance.getId())?.add(outputId);
 		return webview;
 	}
@@ -274,6 +293,7 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 	private _untrackOverlayWebview(instance: IPositronNotebookInstance, outputId: string, webview: Promise<INotebookOutputWebview>): void {
 		if (this._overlayWebviewsByOutputId.get(outputId) === webview) {
 			this._overlayWebviewsByOutputId.delete(outputId);
+			this._overlayContentByOutputId.delete(outputId);
 			this._overlayOutputIdsByNotebookId.get(instance.getId())?.delete(outputId);
 		}
 	}
@@ -352,13 +372,19 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 				return { preloadMessageType: 'display', webview: webviewPromise };
 			}
 
-			// Reuse a tracked overlay if one already exists for this output:
-			// parseCellOutputs() re-runs on every output change, so recreating
-			// here would churn (and orphan) the webview. The tracked webview is
-			// reconciled against the model and disposed when its output is gone.
+			// Reuse a tracked overlay if one already exists for this output with
+			// the same content: parseCellOutputs() re-runs on every output
+			// change, so recreating here would churn (and orphan) the webview.
+			// If the HTML changed under the same output ID (e.g. an in-place
+			// update), dispose the stale webview and rebuild. The tracked webview
+			// is reconciled against the model and disposed when its output is gone.
+			const contentKey = rawHtml;
 			const existingOverlay = this._overlayWebviewsByOutputId.get(outputId);
-			if (existingOverlay) {
+			if (existingOverlay && this._overlayContentByOutputId.get(outputId) === contentKey) {
 				return { preloadMessageType: 'display', webview: existingOverlay };
+			}
+			if (existingOverlay) {
+				this._disposeOverlayWebview(outputId);
 			}
 
 			const webviewPromise = this._notebookOutputWebviewService.createRawHtmlOutputWebview(outputId, rawHtml, rawHtmlBaseUri)
@@ -368,7 +394,7 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 				});
 			return {
 				preloadMessageType: 'display',
-				webview: this._trackOverlayWebview(instance, outputId, webviewPromise),
+				webview: this._trackOverlayWebview(instance, outputId, contentKey, webviewPromise),
 			};
 		}
 
@@ -424,14 +450,20 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 		}
 
 		// Display messages (e.g., interactive plots) need their own overlay
-		// webview. Reuse a tracked one if it already exists -- parseCellOutputs()
-		// re-runs on every output change, so recreating here would churn (and
-		// orphan) the webview. The tracked webview is reconciled against the
-		// model and disposed when its output disappears.
+		// webview. Reuse a tracked one if it already exists with the same content
+		// -- parseCellOutputs() re-runs on every output change, so recreating
+		// here would churn (and orphan) the webview. If the output content
+		// changed under the same output ID (e.g. an in-place update), dispose the
+		// stale webview and rebuild. The tracked webview is reconciled against
+		// the model and disposed when its output disappears.
 		if (messageType === 'display') {
+			const contentKey = this._fingerprintOutputs(outputs);
 			const existingOverlay = this._overlayWebviewsByOutputId.get(runtimeOutput.id);
-			if (existingOverlay) {
+			if (existingOverlay && this._overlayContentByOutputId.get(runtimeOutput.id) === contentKey) {
 				return { preloadMessageType: messageType, webview: existingOverlay };
+			}
+			if (existingOverlay) {
+				this._disposeOverlayWebview(runtimeOutput.id);
 			}
 
 			const webviewPromise = this._createNotebookPlotWebview(instance, runtimeOutput)
@@ -441,7 +473,7 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 				});
 			return {
 				preloadMessageType: messageType,
-				webview: this._trackOverlayWebview(instance, runtimeOutput.id, webviewPromise),
+				webview: this._trackOverlayWebview(instance, runtimeOutput.id, contentKey, webviewPromise),
 			};
 		}
 

--- a/src/vs/workbench/contrib/positronWebviewPreloads/test/browser/positronWebviewPreloadReconciliation.vitest.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/test/browser/positronWebviewPreloadReconciliation.vitest.ts
@@ -35,21 +35,31 @@ import { waitForRuntimeState } from '../../../../services/runtimeSession/test/co
  * can assert disposal against.
  */
 describe('Positron - PositronWebviewPreloadService output reconciliation (#12887)', () => {
-	// Track every fake webview the stubbed output-webview service hands out,
-	// keyed by output ID, plus whether dispose() has been called on it.
+	// Track every fake webview the stubbed output-webview service hands out.
+	// `disposedById` collapses to the latest webview per output ID (enough for
+	// the leak/exclusion assertions); `created` keeps every instance so tests
+	// that rebuild under the same output ID can distinguish old from new.
 	const disposedById = new Map<string, boolean>();
+	interface FakeWebview extends INotebookOutputWebview { disposed: boolean }
+	const created: FakeWebview[] = [];
 
-	function makeFakeWebview(id: string): INotebookOutputWebview {
+	function makeFakeWebview(id: string): FakeWebview {
 		disposedById.set(id, false);
-		return {
+		const fake: FakeWebview = {
 			id,
 			sessionId: 'test-session',
+			disposed: false,
 			// The reconciliation path never touches the underlying overlay; a
 			// minimal stub is enough and keeps the fake free of real disposables.
 			webview: stubInterface<IOverlayWebview>(),
 			onDidRender: Event.None,
-			dispose: () => disposedById.set(id, true),
+			dispose: () => {
+				fake.disposed = true;
+				disposedById.set(id, true);
+			},
 		};
+		created.push(fake);
+		return fake;
 	}
 
 	const ctx = createTestContainer()
@@ -68,6 +78,7 @@ describe('Positron - PositronWebviewPreloadService output reconciliation (#12887
 
 	beforeEach(() => {
 		disposedById.clear();
+		created.length = 0;
 		// Construct the service AFTER stubs are applied so it captures our
 		// stubbed output-webview service.
 		service = ctx.disposables.add(
@@ -192,6 +203,27 @@ describe('Positron - PositronWebviewPreloadService output reconciliation (#12887
 		await flushReconciliation();
 
 		expect(disposedById.get('display-1'), 'a changed output type must dispose the stale overlay webview').toBe(true);
+	});
+
+	it('rebuilds a display webview when its content changes under the same output ID', async () => {
+		const { instance } = setupNotebook([plotlyOutput]);
+
+		await awaitWebview(service.addNotebookOutput({ instance, outputId: 'display-1', outputs: plotlyOutput.outputs }));
+		expect(created.length, 'first render creates one webview').toBe(1);
+
+		// A Jupyter update_display_data keeps the same output ID but swaps the
+		// content. parseCellOutputs() re-runs and calls addNotebookOutput again
+		// with the new bytes -- the cached webview is stale and must be rebuilt.
+		const updatedOutputs = [{ mime: 'application/vnd.plotly.v1+json', data: VSBuffer.fromString('{"updated":true}') }];
+		await awaitWebview(service.addNotebookOutput({ instance, outputId: 'display-1', outputs: updatedOutputs }));
+
+		expect(created.length, 'a content change must build a second, distinct webview').toBe(2);
+		expect(created[0].disposed, 'the stale webview must be disposed').toBe(true);
+		expect(created[1].disposed, 'the fresh webview stays alive').toBe(false);
+
+		// The re-parse that does NOT change content must reuse, not churn.
+		await awaitWebview(service.addNotebookOutput({ instance, outputId: 'display-1', outputs: updatedOutputs }));
+		expect(created.length, 'unchanged content reuses the live webview -- no rebuild').toBe(2);
 	});
 
 	it('disposes an orphaned raw HTML webview when its cell is deleted', async () => {

--- a/src/vs/workbench/contrib/positronWebviewPreloads/test/browser/positronWebviewPreloadReconciliation.vitest.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/test/browser/positronWebviewPreloadReconciliation.vitest.ts
@@ -24,21 +24,15 @@ import { createTestLanguageRuntimeMetadata, startTestLanguageRuntimeSession } fr
 import { waitForRuntimeState } from '../../../../services/runtimeSession/test/common/testLanguageRuntimeSession.js';
 
 /**
- * Regression coverage for #12887: overlay webviews (interactive display plots
- * and raw HTML) must be disposed when their backing output disappears from the
- * notebook model -- cleared, the cell deleted, or the output replaced. Widget
- * webviews are explicitly excluded; they manage their own lifecycle via the
- * ipywidgets comm channels, so reconciliation must never dispose them.
- *
- * These tests drive the service directly against a real NotebookTextModel and
- * stub the output-webview service so each created webview is a tracked fake we
- * can assert disposal against.
+ * Regression coverage for #12887: overlay webviews (display plots + raw HTML)
+ * must be disposed when their output leaves the model (cleared, cell deleted,
+ * replaced), while comm-backed widgets must be left alone. Drives the service
+ * against a real NotebookTextModel with a stubbed output-webview service whose
+ * fakes track disposal.
  */
 describe('Positron - PositronWebviewPreloadService output reconciliation (#12887)', () => {
-	// Track every fake webview the stubbed output-webview service hands out.
-	// `disposedById` collapses to the latest webview per output ID (enough for
-	// the leak/exclusion assertions); `created` keeps every instance so tests
-	// that rebuild under the same output ID can distinguish old from new.
+	// Track fakes the stub hands out: `disposedById` keyed by latest output ID
+	// (leak/exclusion checks); `created` keeps every instance (rebuild checks).
 	const disposedById = new Map<string, boolean>();
 	interface FakeWebview extends INotebookOutputWebview { disposed: boolean }
 	const created: FakeWebview[] = [];
@@ -49,8 +43,7 @@ describe('Positron - PositronWebviewPreloadService output reconciliation (#12887
 			id,
 			sessionId: 'test-session',
 			disposed: false,
-			// The reconciliation path never touches the underlying overlay; a
-			// minimal stub is enough and keeps the fake free of real disposables.
+			// Reconciliation never touches the underlying overlay; a minimal stub suffices.
 			webview: stubInterface<IOverlayWebview>(),
 			onDidRender: Event.None,
 			dispose: () => {
@@ -79,8 +72,7 @@ describe('Positron - PositronWebviewPreloadService output reconciliation (#12887
 	beforeEach(() => {
 		disposedById.clear();
 		created.length = 0;
-		// Construct the service AFTER stubs are applied so it captures our
-		// stubbed output-webview service.
+		// Construct after stubs so the service captures the stubbed output-webview service.
 		service = ctx.disposables.add(
 			ctx.instantiationService.createInstance(PositronWebviewPreloadService)
 		);
@@ -97,11 +89,7 @@ describe('Positron - PositronWebviewPreloadService output reconciliation (#12887
 		outputs: [{ mime: 'application/vnd.jupyter.widget-view+json', data: VSBuffer.fromString('{}') }],
 	};
 
-	/**
-	 * Build a real single-cell NotebookTextModel seeded with the given outputs
-	 * and a minimal IPositronNotebookInstance exposing only what the service
-	 * reads (id, uri, textModel, onDidChangeModel).
-	 */
+	/** Real single-cell NotebookTextModel + a minimal instance exposing what the service reads. */
 	function setupNotebook(outputs: IOutputDto[]) {
 		const textModel = ctx.disposables.add(ctx.instantiationService.createInstance(
 			NotebookTextModel,
@@ -132,10 +120,7 @@ describe('Positron - PositronWebviewPreloadService output reconciliation (#12887
 		return { textModel, instance };
 	}
 
-	/**
-	 * Wait for the webview a 'display'/'widget' result carries. Narrows the
-	 * NotebookPreloadOutputResults union (the 'preload' member has no webview).
-	 */
+	/** Await the webview a display/widget result carries (narrows out the webview-less 'preload' member). */
 	async function awaitWebview(result: NotebookPreloadOutputResults | undefined) {
 		if (!result || result.preloadMessageType === 'preload') {
 			throw new Error(`expected a webview-bearing result, got ${result?.preloadMessageType}`);
@@ -152,11 +137,8 @@ describe('Positron - PositronWebviewPreloadService output reconciliation (#12887
 	}
 
 	/**
-	 * Let reconciliation run to completion. The listener fires synchronously on
-	 * the model-change event, but disposal is chained off an already-resolved
-	 * webview Promise, so it lands on a later microtask. A macrotask hop drains
-	 * all pending microtasks; a few extra hops keep a correct multi-await fix
-	 * from producing a false negative.
+	 * Drain reconciliation. Disposal is chained off a resolved Promise, so it
+	 * lands a microtask later; a few macrotask hops flush it.
 	 */
 	async function flushReconciliation() {
 		for (let i = 0; i < 3; i++) {
@@ -260,12 +242,9 @@ describe('Positron - PositronWebviewPreloadService output reconciliation (#12887
 		await waitForRuntimeState(session, RuntimeState.Ready);
 		expect(ctx.get(IRuntimeSessionService).getNotebookSessionForNotebookUri(NOTEBOOK_URI)).toBeDefined();
 
-		// One cell holding both a display overlay and a widget. Clearing the cell
-		// removes both outputs, so a single reconciliation pass sees both gone.
-		// The overlay must be disposed (proving the pass actually ran and is not a
-		// no-op); the widget must survive (it owns its own lifecycle). If a change
-		// wrongly lumped widgets into the reconciled set, the widget would be
-		// disposed in this very pass and the final assertion would flip.
+		// One cell with both an overlay and a widget. Clearing removes both
+		// outputs, so one reconciliation pass sees both gone: the overlay must be
+		// disposed (proving the pass ran) and the widget must survive.
 		const { textModel, instance } = setupNotebook([plotlyOutput, widgetOutput]);
 
 		const display = service.addNotebookOutput({ instance, outputId: 'display-1', outputs: plotlyOutput.outputs });

--- a/src/vs/workbench/contrib/positronWebviewPreloads/test/browser/positronWebviewPreloadReconciliation.vitest.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/test/browser/positronWebviewPreloadReconciliation.vitest.ts
@@ -17,6 +17,7 @@ import { NotebookTextModel } from '../../../notebook/common/model/notebookTextMo
 import { INotebookOutputWebview, IPositronNotebookOutputWebviewService } from '../../../positronOutputWebview/browser/notebookOutputWebviewService.js';
 import { IPositronNotebookInstance } from '../../../positronNotebook/browser/IPositronNotebookInstance.js';
 import { PositronWebviewPreloadService } from '../../browser/positronWebviewPreloadsService.js';
+import { NotebookPreloadOutputResults } from '../../../../services/positronWebviewPreloads/browser/positronWebviewPreloadService.js';
 import { LanguageRuntimeSessionMode, RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { createTestLanguageRuntimeMetadata, startTestLanguageRuntimeSession } from '../../../../services/runtimeSession/test/common/testRuntimeSessionService.js';
@@ -120,6 +121,17 @@ describe('Positron - PositronWebviewPreloadService output reconciliation (#12887
 		return { textModel, instance };
 	}
 
+	/**
+	 * Wait for the webview a 'display'/'widget' result carries. Narrows the
+	 * NotebookPreloadOutputResults union (the 'preload' member has no webview).
+	 */
+	async function awaitWebview(result: NotebookPreloadOutputResults | undefined) {
+		if (!result || result.preloadMessageType === 'preload') {
+			throw new Error(`expected a webview-bearing result, got ${result?.preloadMessageType}`);
+		}
+		return result.webview;
+	}
+
 	/** Clear the (only) cell's outputs, the way the Clear Output action does. */
 	function clearOutputs(textModel: NotebookTextModel) {
 		textModel.applyEdits(
@@ -146,7 +158,7 @@ describe('Positron - PositronWebviewPreloadService output reconciliation (#12887
 
 		const result = service.addNotebookOutput({ instance, outputId: 'display-1', outputs: plotlyOutput.outputs });
 		expect(result?.preloadMessageType).toBe('display');
-		await result!.webview;
+		await awaitWebview(result);
 		expect(disposedById.get('display-1'), 'webview is alive while the output exists').toBe(false);
 
 		clearOutputs(textModel);
@@ -160,7 +172,7 @@ describe('Positron - PositronWebviewPreloadService output reconciliation (#12887
 
 		const result = service.addNotebookOutput({ instance, outputId: 'display-1', outputs: plotlyOutput.outputs });
 		expect(result?.preloadMessageType).toBe('display');
-		await result!.webview;
+		await awaitWebview(result);
 		expect(disposedById.get('display-1')).toBe(false);
 
 		// Re-running the cell replaces the plot output with a plain-text output
@@ -192,7 +204,7 @@ describe('Positron - PositronWebviewPreloadService output reconciliation (#12887
 
 		const result = service.addNotebookOutput({ instance, outputId: 'html-1', outputs: htmlOutput.outputs, rawHtml });
 		expect(result?.preloadMessageType).toBe('display');
-		await result!.webview;
+		await awaitWebview(result);
 		expect(disposedById.get('html-1'), 'webview is alive while the cell exists').toBe(false);
 
 		// Delete the whole cell, the way the Delete Cell action does.
@@ -220,7 +232,7 @@ describe('Positron - PositronWebviewPreloadService output reconciliation (#12887
 
 		const result = service.addNotebookOutput({ instance, outputId: 'widget-1', outputs: widgetOutput.outputs });
 		expect(result?.preloadMessageType).toBe('widget');
-		await result!.webview;
+		await awaitWebview(result);
 		expect(disposedById.get('widget-1')).toBe(false);
 
 		// Removing the widget's output triggers reconciliation. The widget owns

--- a/src/vs/workbench/contrib/positronWebviewPreloads/test/browser/positronWebviewPreloadReconciliation.vitest.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/test/browser/positronWebviewPreloadReconciliation.vitest.ts
@@ -1,0 +1,193 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { timeout } from '../../../../../base/common/async.js';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { IOverlayWebview } from '../../../webview/browser/webview.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { CellEditType, CellKind, IOutputDto } from '../../../notebook/common/notebookCommon.js';
+import { NotebookTextModel } from '../../../notebook/common/model/notebookTextModel.js';
+import { INotebookOutputWebview, IPositronNotebookOutputWebviewService } from '../../../positronOutputWebview/browser/notebookOutputWebviewService.js';
+import { IPositronNotebookInstance } from '../../../positronNotebook/browser/IPositronNotebookInstance.js';
+import { PositronWebviewPreloadService } from '../../browser/positronWebviewPreloadsService.js';
+import { LanguageRuntimeSessionMode, RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
+import { IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
+import { createTestLanguageRuntimeMetadata, startTestLanguageRuntimeSession } from '../../../../services/runtimeSession/test/common/testRuntimeSessionService.js';
+import { waitForRuntimeState } from '../../../../services/runtimeSession/test/common/testLanguageRuntimeSession.js';
+
+/**
+ * Regression coverage for #12887: overlay webviews (interactive display plots
+ * and raw HTML) must be disposed when their backing output disappears from the
+ * notebook model -- cleared, the cell deleted, or the output replaced. Widget
+ * webviews are explicitly excluded; they manage their own lifecycle via the
+ * ipywidgets comm channels, so reconciliation must never dispose them.
+ *
+ * These tests drive the service directly against a real NotebookTextModel and
+ * stub the output-webview service so each created webview is a tracked fake we
+ * can assert disposal against.
+ */
+describe('Positron - PositronWebviewPreloadService output reconciliation (#12887)', () => {
+	// Track every fake webview the stubbed output-webview service hands out,
+	// keyed by output ID, plus whether dispose() has been called on it.
+	const disposedById = new Map<string, boolean>();
+
+	function makeFakeWebview(id: string): INotebookOutputWebview {
+		disposedById.set(id, false);
+		return {
+			id,
+			sessionId: 'test-session',
+			// The reconciliation path never touches the underlying overlay; a
+			// minimal stub is enough and keeps the fake free of real disposables.
+			webview: stubInterface<IOverlayWebview>(),
+			onDidRender: Event.None,
+			dispose: () => disposedById.set(id, true),
+		};
+	}
+
+	const ctx = createTestContainer()
+		.withWorkbenchServices()
+		.stub(IPositronNotebookOutputWebviewService, {
+			createMultiMessageWebview: ({ displayMessage }: { displayMessage: { id: string } }) =>
+				Promise.resolve(makeFakeWebview(displayMessage.id)),
+			createNotebookOutputWebview: ({ id }: { id: string }) =>
+				Promise.resolve(makeFakeWebview(id)),
+			createRawHtmlOutputWebview: (id: string) =>
+				Promise.resolve(makeFakeWebview(id)),
+		})
+		.build();
+
+	let service: PositronWebviewPreloadService;
+
+	beforeEach(() => {
+		disposedById.clear();
+		// Construct the service AFTER stubs are applied so it captures our
+		// stubbed output-webview service.
+		service = ctx.disposables.add(
+			ctx.instantiationService.createInstance(PositronWebviewPreloadService)
+		);
+	});
+
+	const NOTEBOOK_URI = URI.parse('test:///reconcile/notebook.ipynb');
+
+	const plotlyOutput: IOutputDto = {
+		outputId: 'display-1',
+		outputs: [{ mime: 'application/vnd.plotly.v1+json', data: VSBuffer.fromString('{}') }],
+	};
+	const widgetOutput: IOutputDto = {
+		outputId: 'widget-1',
+		outputs: [{ mime: 'application/vnd.jupyter.widget-view+json', data: VSBuffer.fromString('{}') }],
+	};
+
+	/**
+	 * Build a real single-cell NotebookTextModel seeded with the given outputs
+	 * and a minimal IPositronNotebookInstance exposing only what the service
+	 * reads (id, uri, textModel, onDidChangeModel).
+	 */
+	function setupNotebook(outputs: IOutputDto[]) {
+		const textModel = ctx.disposables.add(ctx.instantiationService.createInstance(
+			NotebookTextModel,
+			'jupyter-notebook',
+			NOTEBOOK_URI,
+			[{
+				source: 'plot()',
+				language: 'python',
+				mime: undefined,
+				cellKind: CellKind.Code,
+				outputs,
+				metadata: {},
+				internalMetadata: {},
+			}],
+			{},
+			{ transientCellMetadata: {}, transientDocumentMetadata: {}, cellContentMetadata: {}, transientOutputs: false },
+		));
+
+		const onDidChangeModel = ctx.disposables.add(new Emitter<NotebookTextModel | undefined>());
+		const instance = stubInterface<IPositronNotebookInstance>({
+			getId: () => 'reconcile-notebook',
+			uri: NOTEBOOK_URI,
+			textModel,
+			onDidChangeModel: onDidChangeModel.event,
+		});
+
+		service.attachNotebookInstance(instance);
+		return { textModel, instance };
+	}
+
+	/** Clear the (only) cell's outputs, the way the Clear Output action does. */
+	function clearOutputs(textModel: NotebookTextModel) {
+		textModel.applyEdits(
+			[{ editType: CellEditType.Output, index: 0, outputs: [], append: false }],
+			true, undefined, () => undefined, undefined, false,
+		);
+	}
+
+	it('disposes an orphaned display webview when its output is cleared', async () => {
+		const { textModel, instance } = setupNotebook([plotlyOutput]);
+
+		const result = service.addNotebookOutput({ instance, outputId: 'display-1', outputs: plotlyOutput.outputs });
+		expect(result?.preloadMessageType).toBe('display');
+		await result!.webview;
+		expect(disposedById.get('display-1'), 'webview is alive while the output exists').toBe(false);
+
+		clearOutputs(textModel);
+		await timeout(0);
+
+		expect(disposedById.get('display-1'), 'cleared output must dispose its overlay webview').toBe(true);
+	});
+
+	it('disposes an orphaned raw HTML webview when its cell is deleted', async () => {
+		const rawHtml = '<iframe src="https://example.com/map"></iframe>';
+		const htmlOutput: IOutputDto = {
+			outputId: 'html-1',
+			outputs: [{ mime: 'text/html', data: VSBuffer.fromString(rawHtml) }],
+		};
+		const { textModel, instance } = setupNotebook([htmlOutput]);
+
+		const result = service.addNotebookOutput({ instance, outputId: 'html-1', outputs: htmlOutput.outputs, rawHtml });
+		expect(result?.preloadMessageType).toBe('display');
+		await result!.webview;
+		expect(disposedById.get('html-1'), 'webview is alive while the cell exists').toBe(false);
+
+		// Delete the whole cell, the way the Delete Cell action does.
+		textModel.applyEdits(
+			[{ editType: CellEditType.Replace, index: 0, count: 1, cells: [] }],
+			true, undefined, () => undefined, undefined, false,
+		);
+		await timeout(0);
+
+		expect(disposedById.get('html-1'), 'deleting the cell must dispose its overlay webview').toBe(true);
+	});
+
+	it('does NOT dispose a widget webview during reconciliation', async () => {
+		// Widgets need a live notebook session to be created.
+		const runtime = createTestLanguageRuntimeMetadata(ctx.instantiationService, ctx.disposables);
+		const session = await startTestLanguageRuntimeSession(ctx.instantiationService, ctx.disposables, {
+			runtime,
+			notebookUri: NOTEBOOK_URI,
+			sessionMode: LanguageRuntimeSessionMode.Notebook,
+		});
+		await waitForRuntimeState(session, RuntimeState.Ready);
+		expect(ctx.get(IRuntimeSessionService).getNotebookSessionForNotebookUri(NOTEBOOK_URI)).toBeDefined();
+
+		const { textModel, instance } = setupNotebook([widgetOutput]);
+
+		const result = service.addNotebookOutput({ instance, outputId: 'widget-1', outputs: widgetOutput.outputs });
+		expect(result?.preloadMessageType).toBe('widget');
+		await result!.webview;
+		expect(disposedById.get('widget-1')).toBe(false);
+
+		// Removing the widget's output triggers reconciliation. The widget owns
+		// its own lifecycle, so reconciliation must leave it alone.
+		clearOutputs(textModel);
+		await timeout(0);
+
+		expect(disposedById.get('widget-1'), 'reconciliation must not dispose widget webviews').toBe(false);
+	});
+});

--- a/src/vs/workbench/contrib/positronWebviewPreloads/test/browser/positronWebviewPreloadReconciliation.vitest.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/test/browser/positronWebviewPreloadReconciliation.vitest.ts
@@ -128,6 +128,19 @@ describe('Positron - PositronWebviewPreloadService output reconciliation (#12887
 		);
 	}
 
+	/**
+	 * Let reconciliation run to completion. The listener fires synchronously on
+	 * the model-change event, but disposal is chained off an already-resolved
+	 * webview Promise, so it lands on a later microtask. A macrotask hop drains
+	 * all pending microtasks; a few extra hops keep a correct multi-await fix
+	 * from producing a false negative.
+	 */
+	async function flushReconciliation() {
+		for (let i = 0; i < 3; i++) {
+			await timeout(0);
+		}
+	}
+
 	it('disposes an orphaned display webview when its output is cleared', async () => {
 		const { textModel, instance } = setupNotebook([plotlyOutput]);
 
@@ -137,9 +150,36 @@ describe('Positron - PositronWebviewPreloadService output reconciliation (#12887
 		expect(disposedById.get('display-1'), 'webview is alive while the output exists').toBe(false);
 
 		clearOutputs(textModel);
-		await timeout(0);
+		await flushReconciliation();
 
 		expect(disposedById.get('display-1'), 'cleared output must dispose its overlay webview').toBe(true);
+	});
+
+	it('disposes an orphaned display webview when the output type changes (re-run)', async () => {
+		const { textModel, instance } = setupNotebook([plotlyOutput]);
+
+		const result = service.addNotebookOutput({ instance, outputId: 'display-1', outputs: plotlyOutput.outputs });
+		expect(result?.preloadMessageType).toBe('display');
+		await result!.webview;
+		expect(disposedById.get('display-1')).toBe(false);
+
+		// Re-running the cell replaces the plot output with a plain-text output
+		// under a new output ID -- the original overlay is now orphaned.
+		textModel.applyEdits(
+			[{
+				editType: CellEditType.Output,
+				index: 0,
+				outputs: [{
+					outputId: 'text-2',
+					outputs: [{ mime: 'application/vnd.code.notebook.stdout', data: VSBuffer.fromString('done') }],
+				}],
+				append: false,
+			}],
+			true, undefined, () => undefined, undefined, false,
+		);
+		await flushReconciliation();
+
+		expect(disposedById.get('display-1'), 'a changed output type must dispose the stale overlay webview').toBe(true);
 	});
 
 	it('disposes an orphaned raw HTML webview when its cell is deleted', async () => {
@@ -160,7 +200,7 @@ describe('Positron - PositronWebviewPreloadService output reconciliation (#12887
 			[{ editType: CellEditType.Replace, index: 0, count: 1, cells: [] }],
 			true, undefined, () => undefined, undefined, false,
 		);
-		await timeout(0);
+		await flushReconciliation();
 
 		expect(disposedById.get('html-1'), 'deleting the cell must dispose its overlay webview').toBe(true);
 	});
@@ -186,7 +226,7 @@ describe('Positron - PositronWebviewPreloadService output reconciliation (#12887
 		// Removing the widget's output triggers reconciliation. The widget owns
 		// its own lifecycle, so reconciliation must leave it alone.
 		clearOutputs(textModel);
-		await timeout(0);
+		await flushReconciliation();
 
 		expect(disposedById.get('widget-1'), 'reconciliation must not dispose widget webviews').toBe(false);
 	});

--- a/src/vs/workbench/contrib/positronWebviewPreloads/test/browser/positronWebviewPreloadReconciliation.vitest.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/test/browser/positronWebviewPreloadReconciliation.vitest.ts
@@ -249,7 +249,7 @@ describe('Positron - PositronWebviewPreloadService output reconciliation (#12887
 		expect(disposedById.get('html-1'), 'deleting the cell must dispose its overlay webview').toBe(true);
 	});
 
-	it('does NOT dispose a widget webview during reconciliation', async () => {
+	it('reconciliation disposes an overlay but spares a widget sharing the cell', async () => {
 		// Widgets need a live notebook session to be created.
 		const runtime = createTestLanguageRuntimeMetadata(ctx.instantiationService, ctx.disposables);
 		const session = await startTestLanguageRuntimeSession(ctx.instantiationService, ctx.disposables, {
@@ -260,18 +260,29 @@ describe('Positron - PositronWebviewPreloadService output reconciliation (#12887
 		await waitForRuntimeState(session, RuntimeState.Ready);
 		expect(ctx.get(IRuntimeSessionService).getNotebookSessionForNotebookUri(NOTEBOOK_URI)).toBeDefined();
 
-		const { textModel, instance } = setupNotebook([widgetOutput]);
+		// One cell holding both a display overlay and a widget. Clearing the cell
+		// removes both outputs, so a single reconciliation pass sees both gone.
+		// The overlay must be disposed (proving the pass actually ran and is not a
+		// no-op); the widget must survive (it owns its own lifecycle). If a change
+		// wrongly lumped widgets into the reconciled set, the widget would be
+		// disposed in this very pass and the final assertion would flip.
+		const { textModel, instance } = setupNotebook([plotlyOutput, widgetOutput]);
 
-		const result = service.addNotebookOutput({ instance, outputId: 'widget-1', outputs: widgetOutput.outputs });
-		expect(result?.preloadMessageType).toBe('widget');
-		await awaitWebview(result);
+		const display = service.addNotebookOutput({ instance, outputId: 'display-1', outputs: plotlyOutput.outputs });
+		expect(display?.preloadMessageType).toBe('display');
+		await awaitWebview(display);
+
+		const widget = service.addNotebookOutput({ instance, outputId: 'widget-1', outputs: widgetOutput.outputs });
+		expect(widget?.preloadMessageType).toBe('widget');
+		await awaitWebview(widget);
+
+		expect(disposedById.get('display-1')).toBe(false);
 		expect(disposedById.get('widget-1')).toBe(false);
 
-		// Removing the widget's output triggers reconciliation. The widget owns
-		// its own lifecycle, so reconciliation must leave it alone.
 		clearOutputs(textModel);
 		await flushReconciliation();
 
-		expect(disposedById.get('widget-1'), 'reconciliation must not dispose widget webviews').toBe(false);
+		expect(disposedById.get('display-1'), 'reconciliation ran and disposed the orphaned overlay').toBe(true);
+		expect(disposedById.get('widget-1'), 'the same reconciliation pass must spare the widget webview').toBe(false);
 	});
 });


### PR DESCRIPTION
Fixes #12887

Previously we never actually disposed of overlay webviews for interactive plots or complex html outputs in notebooks. This resulted in invisible webviews/iframes persisting in memory until the notebook closed. Most of the time this is fine but if you had a notebook where you had lots of webviews-based outputs and it stayed open for a long time with lots of rerunning and tweaking of cells these webviews could add up. This PR fixes that by linking each webview to the unique output ID of the execution that caused it, so it can dispose when it goes away and update in place when the output updates. 


__ai generated description 👇__


Overlay webviews (interactive display plots and raw HTML) were never disposed when their backing output left the notebook model, so clearing outputs, deleting a cell, or re-running a cell that changed output type left an invisible iframe alive in memory. This adds a notebook model-change listener to `PositronWebviewPreloadService` that reconciles tracked overlay webviews against the live output IDs and disposes any orphans. It also rebuilds an overlay when its content changes in place under the same output ID (e.g. a Jupyter `update_display_data`), which previously left stale content on screen.

Widget and PDF webviews are deliberately excluded from reconciliation: widgets are comm-backed and manage their own lifecycle via the ipywidgets channels, and PDF webviews keep their own cache and self-register with the PDF server.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Dispose orphaned notebook overlay webviews (interactive plots and raw HTML) when their outputs are cleared, their cell is deleted, or the cell is re-run (#12887)

### Validation Steps

@:positron-notebooks @:plots

Covered by unit tests in `positronWebviewPreloadReconciliation.vitest.ts` (`npx vitest run src/vs/workbench/contrib/positronWebviewPreloads/`). To verify manually in a Positron notebook:

1. Run a cell that produces an interactive plot (e.g. Plotly) or a raw HTML output.
2. Clear the cell's output (or delete the cell) and confirm the webview is disposed rather than lingering.
3. Re-run a cell so `update_display_data` swaps the plot content under the same output ID; confirm the new plot renders (not the stale one).
4. Confirm ipywidgets outputs in the same notebook continue to work and are not disposed by the above.
