### PR TITLE
e2e: close source file editor before Save assertion in data-files test

### DIFF
--- a/test/e2e/tests/editor-action-bar/editor-action-bar-data-files.test.ts
+++ b/test/e2e/tests/editor-action-bar/editor-action-bar-data-files.test.ts
@@ -78,7 +78,8 @@ test.describe('Editor Action Bar: Data Files', {
 
 			// Open data explorer via variable pane
 			if (testCase.variable) {
-				await openDataExplorerViaVariablePane(app, testCase.variable, testCase.tabName);
+				const sourceFileTab = testCase.openFile!.split('/').pop()!;
+				await openDataExplorerViaVariablePane(app, testCase.variable, testCase.tabName, sourceFileTab);
 			}
 
 			// Ensure the summary panel is visible
@@ -120,12 +121,20 @@ test.describe('Editor Action Bar: Data Files', {
 });
 
 
-async function openDataExplorerViaVariablePane(app: Application, variable: string, tabName: string) {
+async function openDataExplorerViaVariablePane(app: Application, variable: string, tabName: string, sourceFileTab: string) {
 	await test.step('Open data explorer via variable pane', async () => {
+		const page = app.code.driver.currentPage;
+		// Run the source file so the data frame appears in the Variables pane.
 		await app.workbench.editor.playButton.click();
+		// Open the data frame in the Data Explorer.
 		await app.workbench.variables.doubleClickVariableRow(variable);
-		await app.code.driver.currentPage.getByRole('tablist').locator('.tab').first().click();
-		await app.code.driver.currentPage.getByLabel('Close').first().click();
-		await expect(app.code.driver.currentPage.getByText(tabName, { exact: true })).toBeVisible();
+		// Close the source file editor so only the Data Explorer remains. Scope the
+		// close to the source file's own tab: a page-wide `getByLabel('Close')` can
+		// match an unrelated control and leave the file editor open, whose (disabled)
+		// Save button would then trip the "Save not visible" assertion in the test.
+		const sourceTab = page.getByRole('tab', { name: sourceFileTab });
+		await sourceTab.hover();
+		await sourceTab.getByLabel('Close').click();
+		await expect(page.getByText(tabName, { exact: true })).toBeVisible();
 	});
 }


### PR DESCRIPTION
Fixes flaky failures in `editor-action-bar-data-files.test.ts` for the "R / Python - Can load data frame via variables pane" cases (seen in [this run](https://github.com/posit-dev/positron/actions/runs/28528820922)).

### Summary

Only the R and Python cases failed; the parquet and CSV cases in the same file passed. All four share the same `verifyButtonVisible('Save', false)` assertion, so the passing parquet/CSV cases prove the Data Explorer itself renders **no** Save button (its `positronDataExplorer` URI has no file-system provider, so the `when: ResourceContextKey.IsFileSystemResource` gate from #13373 is false).

The R/Python cases differ in that they open and run a `.py`/`.r` file before opening the Data Explorer. Since #13373 gave file-backed editors a Save button (disabled when clean), that source editor now shows a disabled Save button. The helper's cleanup used a page-wide `getByLabel('Close').first()`, which on web can match an unrelated "Close" control and leave the file editor open. Its disabled Save button then trips the assertion meant for the Data Explorer.

The fix scopes the tab close to the source file's own tab, so only the Data Explorer remains before the assertion runs. This is a test-only change; no product behavior is affected.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:editor-action-bar @:data-explorer @:web @:win

Run the editor action bar data files suite and confirm all four cases pass on web (chromium) and Windows:

```
npx playwright test test/e2e/tests/editor-action-bar/editor-action-bar-data-files.test.ts --project e2e-browser
```

Confirm the "R / Python - Can load data frame via variables pane" cases pass, and that the parquet/CSV cases continue to pass.
