### PR TITLE
Add setting to opt out of requirements.txt as package source of truth

### DIFF
--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -821,6 +821,12 @@
                     "scope": "resource",
                     "type": "string"
                 },
+                "python.packageManager.useRequirementsFile": {
+                    "default": true,
+                    "markdownDescription": "%python.packageManager.useRequirementsFile.description%",
+                    "scope": "resource",
+                    "type": "boolean"
+                },
                 "python.locator": {
                     "default": "native",
                     "markdownDescription": "%python.locator.description%",

--- a/extensions/positron-python/package.nls.json
+++ b/extensions/positron-python/package.nls.json
@@ -86,6 +86,7 @@
     "python.logging.level.description": "The logging level the extension logs at, defaults to 'error'",
     "python.logging.level.deprecation": "This setting is deprecated. Please use command `Developer: Set Log Level...` to set logging level.",
     "python.missingPackage.severity.description": "Set severity of missing packages in requirements.txt or pyproject.toml",
+    "python.packageManager.useRequirementsFile.description": "Use the workspace root requirements.txt file (when present) as the source of truth for package install and update operations from the Packages pane. When enabled, changes are resolved against requirements.txt; when disabled, they resolve against the currently installed packages instead.",
     "python.locator.description": "Choose how to discover Python interpreters. Native uses [Python Environment Tools](https://github.com/microsoft/python-environment-tools) a faster, Rust-based locator, while JS uses a JavaScript implementation.",
     "python.pipenvPath.description": "Path to the pipenv executable to use for activation.",
     "python.poetryPath.description": "Path to the poetry executable.",

--- a/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
@@ -15,7 +15,7 @@ import { traceVerbose } from '../../logging';
 import { fetchMetadataWithOutdated } from './packageMetadata';
 import { searchPyPI, searchPyPIVersions } from './pypiSearch';
 import { buildRequirementsFile } from './requirementsFile';
-import { findWorkspaceRequirementsFile } from './workspaceRequirements';
+import { findWorkspaceRequirementsFile, USE_REQUIREMENTS_FILE_SETTING } from './workspaceRequirements';
 import { IPackageManager, MessageEmitter, PackageSession } from './types';
 
 /**
@@ -280,6 +280,11 @@ export class PipPackageManager implements IPackageManager {
      * Path to the workspace-root `requirements.txt` if present, else undefined.
      */
     private async _getWorkspaceRequirementsPath(): Promise<string | undefined> {
+        // Opt-out: when the setting is disabled, ignore requirements.txt so all
+        // operations fall back to the pip freeze re-resolve path.
+        if (!vscode.workspace.getConfiguration('python').get<boolean>(USE_REQUIREMENTS_FILE_SETTING, true)) {
+            return undefined;
+        }
         const workspaceService = this._serviceContainer.get<IWorkspaceService>(IWorkspaceService);
         const fileSystem = this._serviceContainer.get<IFileSystem>(IFileSystem);
         return findWorkspaceRequirementsFile(workspaceService, fileSystem);

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -16,7 +16,7 @@ import { isUvInstalled } from '../../pythonEnvironments/common/environmentManage
 import { traceVerbose } from '../../logging';
 import { fetchMetadataWithOutdated } from './packageMetadata';
 import { buildRequirementsFile } from './requirementsFile';
-import { findWorkspaceRequirementsFile } from './workspaceRequirements';
+import { findWorkspaceRequirementsFile, USE_REQUIREMENTS_FILE_SETTING } from './workspaceRequirements';
 import { searchPyPI, searchPyPIVersions } from './pypiSearch';
 import { IPackageManager, MessageEmitter, PackageSession } from './types';
 
@@ -254,6 +254,12 @@ export class UvPackageManager implements IPackageManager {
      * Path to the workspace-root `requirements.txt` if present, else undefined.
      */
     private async _getWorkspaceRequirementsPath(): Promise<string | undefined> {
+        // Opt-out: when the setting is disabled, ignore requirements.txt so the
+        // env workflow falls back to the uv pip freeze re-resolve path. This does
+        // not affect the project (uv add) workflow, which is selected separately.
+        if (!vscode.workspace.getConfiguration('python').get<boolean>(USE_REQUIREMENTS_FILE_SETTING, true)) {
+            return undefined;
+        }
         const workspaceService = this._serviceContainer.get<IWorkspaceService>(IWorkspaceService);
         const fileSystem = this._serviceContainer.get<IFileSystem>(IFileSystem);
         return findWorkspaceRequirementsFile(workspaceService, fileSystem);

--- a/extensions/positron-python/src/client/positron/packages/workspaceRequirements.ts
+++ b/extensions/positron-python/src/client/positron/packages/workspaceRequirements.ts
@@ -8,6 +8,14 @@ import { IWorkspaceService } from '../../common/application/types';
 import { IFileSystem } from '../../common/platform/types';
 
 /**
+ * Setting key (relative to the `python` configuration section) that controls
+ * whether package operations treat a workspace-root `requirements.txt` as the
+ * source of truth. When `false`, the managers ignore `requirements.txt` and
+ * fall back to the `pip freeze` re-resolve path. Defaults to `true`.
+ */
+export const USE_REQUIREMENTS_FILE_SETTING = 'packageManager.useRequirementsFile';
+
+/**
  * Locate the workspace-root `requirements.txt`, if present. When it exists,
  * package operations treat it as the source of truth (passed verbatim via
  * `-r`); when absent, callers fall back to the `pip freeze` path. Only the

--- a/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
@@ -263,9 +263,7 @@ suite('PipPackageManager update Tests', () => {
                 vscode.workspace.getConfiguration = (section?: string) =>
                     ({
                         get: (key: string, defaultValue?: unknown) =>
-                            section === 'python' && key === 'packageManager.useRequirementsFile'
-                                ? false
-                                : defaultValue,
+                            section === 'python' && key === 'packageManager.useRequirementsFile' ? false : defaultValue,
                     } as any);
             });
 

--- a/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
@@ -254,5 +254,51 @@ suite('PipPackageManager update Tests', () => {
             expect(args).to.include.members(['install', '--upgrade', '-r', reqPath]);
             expect(fileSystem.createTemporaryFile.called).to.equal(false);
         });
+
+        suite('with python.packageManager.useRequirementsFile disabled', () => {
+            setup(() => {
+                // Force the opt-out setting to false so requirements.txt is ignored
+                // and operations fall back to the pip freeze re-resolve path, even
+                // though a requirements.txt is present.
+                vscode.workspace.getConfiguration = (section?: string) =>
+                    ({
+                        get: (key: string, defaultValue?: unknown) =>
+                            section === 'python' && key === 'packageManager.useRequirementsFile'
+                                ? false
+                                : defaultValue,
+                    } as any);
+            });
+
+            test('installPackages falls back to the freeze temp file, ignoring requirements.txt', async () => {
+                await manager.installPackages([{ name: 'cowsay', version: '6.1' }]);
+
+                const [, args] = terminalService.sendCommand.firstCall.args;
+                expect(args).to.include.members(['install', '-r', '/tmp/reqs.txt']);
+                expect(args).to.not.include(reqPath);
+                expect(fileSystem.createTemporaryFile.called).to.equal(true);
+            });
+
+            test('updatePackages falls back to the freeze temp file, ignoring requirements.txt', async () => {
+                await manager.updatePackages([{ name: 'werkzeug', version: '3.1.8' }]);
+
+                const [, args] = terminalService.sendCommand.firstCall.args;
+                expect(args).to.include.members(['install', '-r', '/tmp/reqs.txt']);
+                expect(args).to.not.include(reqPath);
+                expect(fileSystem.createTemporaryFile.called).to.equal(true);
+            });
+
+            test('updateAllPackages falls back to the freeze temp file, ignoring requirements.txt', async () => {
+                pythonService.execModule
+                    .withArgs('pip', sinon.match.array.startsWith(['list', '--outdated']))
+                    .resolves({ stdout: JSON.stringify([{ name: 'werkzeug', latest_version: '3.1.8' }]), stderr: '' });
+
+                await manager.updateAllPackages();
+
+                const [, args] = terminalService.sendCommand.firstCall.args;
+                expect(args).to.include.members(['install', '--upgrade', '-r', '/tmp/reqs.txt']);
+                expect(args).to.not.include(reqPath);
+                expect(fileSystem.createTemporaryFile.called).to.equal(true);
+            });
+        });
     });
 });

--- a/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
@@ -471,4 +471,79 @@ version = "0.1.0"`;
             ]);
         });
     });
+
+    suite('with python.packageManager.useRequirementsFile disabled', () => {
+        let processService: { exec: sinon.SinonStub };
+        let terminalService: { show: sinon.SinonStub; sendCommand: sinon.SinonStub; sendText: sinon.SinonStub };
+        let originalGetConfiguration: typeof vscode.workspace.getConfiguration;
+
+        setup(() => {
+            // Force the opt-out setting to false: requirements.txt is ignored and
+            // the env workflow falls back to the uv pip freeze re-resolve path.
+            originalGetConfiguration = vscode.workspace.getConfiguration;
+            vscode.workspace.getConfiguration = (section?: string) =>
+                ({
+                    get: (key: string, defaultValue?: unknown) =>
+                        section === 'python' && key === 'packageManager.useRequirementsFile' ? false : defaultValue,
+                } as any);
+
+            sinon.stub(uvPackageManager, 'isUvAvailable').resolves(true);
+
+            processService = { exec: sinon.stub() };
+            processService.exec.withArgs('uv', sinon.match.array.startsWith(['pip', 'freeze'])).resolves({
+                stdout: 'flask==2.2.0\nwerkzeug==2.0.3\n',
+                stderr: '',
+            });
+            const processFactory = { create: sinon.stub().resolves(processService) };
+            terminalService = {
+                show: sinon.stub().resolves(),
+                sendCommand: sinon.stub().resolves(),
+                sendText: sinon.stub().resolves(),
+            };
+            const terminalFactory = { getTerminalService: sinon.stub().returns(terminalService) };
+            (serviceContainer.get as sinon.SinonStub)
+                .withArgs(IProcessServiceFactory)
+                .returns(processFactory)
+                .withArgs(ITerminalServiceFactory)
+                .returns(terminalFactory);
+        });
+
+        teardown(() => {
+            vscode.workspace.getConfiguration = originalGetConfiguration;
+        });
+
+        test('env workflow falls back to the freeze temp file, ignoring requirements.txt', async () => {
+            // requirements.txt present, no pyproject.toml -> env workflow.
+            const workspaceFolder = { uri: Uri.file('/workspace'), name: 'ws', index: 0 };
+            const reqPath = path.join(workspaceFolder.uri.fsPath, 'requirements.txt');
+            sinon.stub(workspaceService, 'workspaceFolders').value([workspaceFolder]);
+            (fileSystem.fileExists as sinon.SinonStub).withArgs(reqPath).resolves(true);
+
+            await uvPackageManager.installPackages([{ name: 'cowsay', version: '6.1' }]);
+
+            const [, args] = terminalService.sendCommand.firstCall.args;
+            expect(args).to.include.members(['pip', 'install', '-r', '/tmp/reqs.txt', '--python', '/path/to/python']);
+            expect(args).to.not.include(reqPath);
+        });
+
+        test('project workflow is unaffected: uv add still runs when pyproject is valid', async () => {
+            // pyproject valid + no requirements.txt -> uv add project workflow. The
+            // setting must not flip this into the env workflow.
+            const workspaceFolder = { uri: Uri.file('/workspace'), name: 'ws', index: 0 };
+            const pyprojectPath = path.join(workspaceFolder.uri.fsPath, 'pyproject.toml');
+            const reqPath = path.join(workspaceFolder.uri.fsPath, 'requirements.txt');
+            sinon.stub(workspaceService, 'workspaceFolders').value([workspaceFolder]);
+            (fileSystem.fileExists as sinon.SinonStub).withArgs(pyprojectPath).resolves(true);
+            (fileSystem.fileExists as sinon.SinonStub).withArgs(reqPath).resolves(false);
+            (fileSystem.readFile as sinon.SinonStub).withArgs(pyprojectPath).resolves(`[project]
+name = "test-project"
+version = "0.1.0"`);
+
+            await uvPackageManager.installPackages([{ name: 'cowsay', version: '6.1' }]);
+
+            const [uvBin, args] = terminalService.sendCommand.firstCall.args;
+            expect(uvBin).to.equal('uv');
+            expect(args).to.include.members(['add', '--active', '--python', '/path/to/python', 'cowsay==6.1']);
+        });
+    });
 });


### PR DESCRIPTION
### Summary

Adds a new setting, `python.packageManager.useRequirementsFile` (boolean, default `true`), that lets users opt out of the requirements.txt-driven package behavior introduced in #14328.

When a workspace-root `requirements.txt` is present, the pip and uv package managers treat it as the source of truth and pass `-r requirements.txt` on the command line for install/update/update-all operations. Some users prefer the previous behavior, where operations resolve against the currently installed set (via a `pip freeze` / `uv pip freeze` re-resolve). Setting `python.packageManager.useRequirementsFile` to `false` restores that path even when a `requirements.txt` exists.

The setting only gates each manager's `_getWorkspaceRequirementsPath()` (the env/pip source-of-truth path). uv's project-vs-env workflow selection is deliberately untouched: a `uv add` project (valid `pyproject.toml`, no `requirements.txt`) still uses `uv add` regardless of the setting.

Related to #14328 (the original requirements.txt-as-source-of-truth work).

### Release Notes

#### New Features

- Added the `python.packageManager.useRequirementsFile` setting to control whether package install and update operations use a workspace `requirements.txt` as the source of truth (#14328)

#### Bug Fixes

- N/A

### Validation Steps

@:packages-pane

1. In a Python project with a workspace-root `requirements.txt`, open the Packages pane and install a package. With the default (`python.packageManager.useRequirementsFile` = `true`), the pip/uv command in the terminal includes `-r requirements.txt`.
2. Set `python.packageManager.useRequirementsFile` to `false` in Settings.
3. Install or update a package again. The command no longer references `requirements.txt`; it resolves against the installed set via a generated (temporary) requirements file instead.
4. Update All behaves the same way (freeze-based `--upgrade` rather than `--upgrade -r requirements.txt`).
5. For a uv project with a valid `pyproject.toml` and no `requirements.txt`, confirm install still runs `uv add` regardless of the setting value.
