### PR TITLE
E2E test: waitForInterpreterDiscoveryToComplete to fix packages flake

### DIFF
--- a/test/e2e/pages/quickInput.ts
+++ b/test/e2e/pages/quickInput.ts
@@ -91,6 +91,22 @@ export class QuickInput {
 		).toBeVisible({ timeout });
 	}
 
+	/**
+	 * Wait for the runtime quick pick to finish interpreter discovery before
+	 * interacting with the list. While discovery is in progress the picker sets
+	 * its input placeholder to "Discovering interpreters..." (see
+	 * languageRuntimeActions.ts) and lists only the interpreters found so far.
+	 * Selecting during this window races discovery: a version-string match can
+	 * land on a fast-discovered source (e.g. a uv base install) instead of the
+	 * intended interpreter. The placeholder is set synchronously before the
+	 * picker is shown, so this assertion cannot pass vacuously mid-discovery.
+	 */
+	async waitForInterpreterDiscoveryToComplete({ timeout = 30000 }: { timeout?: number } = {}): Promise<void> {
+		await expect(
+			this.code.driver.currentPage.locator(QuickInput.QUICK_INPUT_INPUT),
+		).not.toHaveAttribute('placeholder', /Discovering interpreters/i, { timeout });
+	}
+
 	async type(value: string): Promise<void> {
 		await this.code.driver.currentPage
 			.locator(QuickInput.QUICK_INPUT_INPUT)

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -472,6 +472,13 @@ export class Sessions {
 					await this.page.keyboard.press('Control+Shift+/');
 				}
 
+				// Wait for interpreter discovery to finish before filtering/selecting.
+				// Opening the picker right after a workspace load (e.g. openFolder)
+				// lands mid-discovery, when only fast-discovered sources are listed;
+				// a bare version-string match can then pick the wrong source (e.g. a
+				// uv base install) over the intended interpreter of the same version.
+				await this.quickinput.waitForInterpreterDiscoveryToComplete();
+
 				let input = language;
 				if (version) {
 					input += ` ${version}`;

--- a/test/e2e/tests/packages-pane/packages-pane.test.ts
+++ b/test/e2e/tests/packages-pane/packages-pane.test.ts
@@ -45,7 +45,7 @@ test.describe('Packages Pane', {
 		pythonRuntimes.forEach((runtime) => {
 			test(`Python - Install, search, and uninstall package (${runtime})`, { tag: [tags.WIN] },
 				async function ({ app, sessions }) {
-					const { packages } = app.workbench;
+					const { packages, toasts } = app.workbench;
 
 					await sessions.start(runtime);
 
@@ -59,6 +59,8 @@ test.describe('Packages Pane', {
 					// uninstall package and verify it is removed from the list
 					await packages.uninstallPackage('cowsay');
 					await packages.expectPackageNotInList('cowsay');
+
+					await toasts.closeAll();
 				});
 		});
 	});


### PR DESCRIPTION
<img width="2088" height="596" alt="image" src="https://github.com/user-attachments/assets/4374e04e-7614-498f-b021-30bacbeaf53d" />

waiting for this to clear before typing filter text for an interpreter.

@:packages-pane @:web