### PR TITLE
Anchor webviews in Quarto inline output

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
@@ -2108,7 +2108,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 	 */
 	private _anchorWebview(webview: INotebookOutputWebview, container: HTMLElement): void {
 		const overlay = webview.webview.container;
-		if (isWebviewOverlayShown(this.domNode, container)) {
+		if (!this._isCollapsed && isWebviewOverlayShown(this.domNode, container)) {
 			overlay.style.visibility = 'visible';
 			webview.webview.setAnchorElement(container, this._clippingContainer);
 		} else {

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
@@ -115,24 +115,37 @@ export interface QuartoOutputViewZoneOptions {
 }
 
 /**
- * Mark a webview overlay so it is hidden whenever its anchor element is not
- * visible.
+ * Whether an inline-output webview's overlay should be shown for a view zone in
+ * its current scroll state.
  *
- * Inline output webviews are absolutely positioned (via CSS anchor
- * positioning) over a placeholder element inside the editor's view zone, but
- * the webview itself is mounted at the workbench root so it can't be clipped by
- * normal editor scrolling. When the view zone scrolls out of Monaco's rendered
- * range its placeholder (the anchor) is removed from the DOM, at which point the
- * fixed-position webview falls back to its static position and "sticks" in the
- * corner of the editor. `position-visibility: anchors-visible` strongly hides
- * the overlay whenever its anchor is scrolled out of view or removed, which
- * fixes the sticking. See posit-dev/positron#13978.
+ * Inline output webviews are absolutely positioned (via CSS anchor positioning)
+ * over a placeholder element inside the editor's view zone, but the webview
+ * itself is mounted at the workbench root so it can't be clipped by normal
+ * editor scrolling. When the placeholder is not actually on-screen the
+ * fixed-position overlay falls back to a static position and "sticks" in the
+ * corner of the editor (see posit-dev/positron#13978).
  *
- * This is deliberately scoped to Quarto inline output webviews rather than
- * applied to the shared overlay layout element.
+ * The reliable signal for "the placeholder is on-screen" is Monaco's own
+ * `monaco-visible-view-zone` attribute: Monaco adds it to (and removes it from)
+ * the view zone's DOM node in its render pass, based on whether the zone's
+ * whitespace intersects the viewport. Crucially it is updated BEFORE Monaco
+ * calls `onDomNodeTop` and BEFORE it applies the zone's new `display`/position,
+ * so reading it during a scroll handler is fresh.
+ *
+ * A geometry probe such as `getClientRects().length > 0` is not a substitute: it
+ * is one frame stale during scroll, and it stays truthy for a zone that has
+ * merely scrolled out of the editor viewport while Monaco still renders it -- in
+ * which case anchor positioning has already fallen back to the corner. An
+ * interactive widget tends to emit follow-up layout events that incidentally
+ * re-hide the overlay, but a static output such as a flextable table does not,
+ * so it stays stuck.
+ *
+ * @param zoneDomNode the view zone's outer DOM node (carries the attribute).
+ * @param anchor the placeholder element the overlay is anchored to.
+ * @returns true when the zone is on-screen and the anchor is still attached.
  */
-export function hideWebviewOverlayWhenAnchorHidden(overlayContent: HTMLElement): void {
-	overlayContent.style.setProperty('position-visibility', 'anchors-visible');
+export function isWebviewOverlayShown(zoneDomNode: HTMLElement, anchor: HTMLElement): boolean {
+	return zoneDomNode.hasAttribute('monaco-visible-view-zone') && anchor.isConnected;
 }
 
 /**
@@ -154,6 +167,10 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 	 */
 	public readonly onDomNodeTop = (_top: number): void => {
 		this._layoutAllWebviews();
+		// Monaco updates the zone's visibility attribute before this callback but
+		// applies its position afterward; re-check next frame to catch the
+		// settled state (matters for static outputs with no follow-up event).
+		this._scheduleWebviewLayout();
 		this._layoutCollapseButton();
 	};
 
@@ -170,6 +187,9 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 	private readonly _webviewsByOutputId = new Map<string, INotebookOutputWebview>();
 	// Map from output ID to the container element for re-layout during scrolling
 	private readonly _webviewContainersByOutputId = new Map<string, HTMLElement>();
+	// Pending animation-frame handle for a deferred webview re-layout, used to
+	// re-read overlay visibility after Monaco has applied a layout change.
+	private _webviewLayoutFrame: number | undefined;
 	// Cached clipping container for the editor
 	private _clippingContainer: HTMLElement | undefined;
 
@@ -1175,6 +1195,10 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		this._stopTimer();
 		this._stopTimestampRefresh();
 		this._stopSparkline(true);
+		if (this._webviewLayoutFrame !== undefined) {
+			dom.getWindow(this.domNode).cancelAnimationFrame(this._webviewLayoutFrame);
+			this._webviewLayoutFrame = undefined;
+		}
 		this._disposeResizeObserver();
 		this._disposeAllWebviews();
 		this._disposeAllReactRenderers();
@@ -2075,12 +2099,45 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 
 	/**
 	 * Anchor an output webview over its placeholder container and clip it to the
-	 * editor, then ensure the overlay hides itself when its anchor is no longer
-	 * visible (see {@link hideWebviewOverlayWhenAnchorHidden}).
+	 * editor.
+	 *
+	 * When the view zone is not on-screen, anchoring to its placeholder would
+	 * leave the overlay "stuck" in the editor corner (see
+	 * {@link isWebviewOverlayShown}). In that case we hide the overlay instead,
+	 * and show + re-anchor it once the zone is on-screen again.
 	 */
 	private _anchorWebview(webview: INotebookOutputWebview, container: HTMLElement): void {
-		webview.webview.setAnchorElement(container, this._clippingContainer);
-		hideWebviewOverlayWhenAnchorHidden(webview.webview.container);
+		const overlay = webview.webview.container;
+		if (isWebviewOverlayShown(this.domNode, container)) {
+			overlay.style.visibility = 'visible';
+			webview.webview.setAnchorElement(container, this._clippingContainer);
+		} else {
+			overlay.style.visibility = 'hidden';
+		}
+	}
+
+	/**
+	 * Re-evaluate overlay visibility on the next animation frame.
+	 *
+	 * A layout change (scroll, height update, first render) updates the view
+	 * zone's `monaco-visible-view-zone` attribute in Monaco's own render pass,
+	 * which runs asynchronously after the triggering event. Reading the attribute
+	 * synchronously in the event handler can therefore be stale, and a static
+	 * output (e.g. a flextable table) emits no follow-up event to correct it.
+	 * Re-checking next frame reads the settled attribute. Unlike a deferred
+	 * geometry read, a deferred attribute read stays correct: the attribute is
+	 * stable once Monaco settles, so this does not fight the immediate updates
+	 * done during scrolling.
+	 */
+	private _scheduleWebviewLayout(): void {
+		if (this._webviewLayoutFrame !== undefined) {
+			return;
+		}
+		const win = dom.getWindow(this.domNode);
+		this._webviewLayoutFrame = win.requestAnimationFrame(() => {
+			this._webviewLayoutFrame = undefined;
+			this._layoutAllWebviews();
+		});
 	}
 
 	private _renderAllOutputs(): void {
@@ -2596,12 +2653,17 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 					// Update the view zone height and re-layout the webview
 					this._updateHeight();
 					this._anchorWebview(webview, webviewContainer);
+					// The height change re-lays out the zone asynchronously; re-check
+					// visibility once Monaco settles so the overlay shows on load.
+					this._scheduleWebviewLayout();
 				}
 			}));
 
 			// Update height when webview renders
 			this._webviewDisposables.add(webview.onDidRender(() => {
 				this._updateHeight();
+				this._anchorWebview(webview, webviewContainer);
+				this._scheduleWebviewLayout();
 			}));
 
 			// Handle scroll events - update webview position
@@ -2610,6 +2672,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 			this._webviewDisposables.add(this._editor.onDidScrollChange(() => {
 				if (this._zoneId) {
 					this._anchorWebview(webview, webviewContainer);
+					this._scheduleWebviewLayout();
 				}
 			}));
 
@@ -2681,12 +2744,17 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 					container.style.height = `${boundedHeight}px`;
 					this._updateHeight();
 					this._anchorWebview(webview, container);
+					// The height change re-lays out the zone asynchronously; re-check
+					// visibility once Monaco settles so the overlay shows on load.
+					this._scheduleWebviewLayout();
 				}
 			}));
 
 			// Update height when webview renders
 			this._webviewDisposables.add(webview.onDidRender(() => {
 				this._updateHeight();
+				this._anchorWebview(webview, container);
+				this._scheduleWebviewLayout();
 			}));
 
 			// Handle scroll events
@@ -2695,6 +2763,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 			this._webviewDisposables.add(this._editor.onDidScrollChange(() => {
 				if (this._zoneId) {
 					this._anchorWebview(webview, container);
+					this._scheduleWebviewLayout();
 				}
 			}));
 

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
@@ -115,6 +115,27 @@ export interface QuartoOutputViewZoneOptions {
 }
 
 /**
+ * Mark a webview overlay so it is hidden whenever its anchor element is not
+ * visible.
+ *
+ * Inline output webviews are absolutely positioned (via CSS anchor
+ * positioning) over a placeholder element inside the editor's view zone, but
+ * the webview itself is mounted at the workbench root so it can't be clipped by
+ * normal editor scrolling. When the view zone scrolls out of Monaco's rendered
+ * range its placeholder (the anchor) is removed from the DOM, at which point the
+ * fixed-position webview falls back to its static position and "sticks" in the
+ * corner of the editor. `position-visibility: anchors-visible` strongly hides
+ * the overlay whenever its anchor is scrolled out of view or removed, which
+ * fixes the sticking. See posit-dev/positron#13978.
+ *
+ * This is deliberately scoped to Quarto inline output webviews rather than
+ * applied to the shared overlay layout element.
+ */
+export function hideWebviewOverlayWhenAnchorHidden(overlayContent: HTMLElement): void {
+	overlayContent.style.setProperty('position-visibility', 'anchors-visible');
+}
+
+/**
  * View zone for displaying Quarto cell output inline in the editor.
  * Supports text, images, error output, and complex webview-based outputs.
  */
@@ -2047,9 +2068,19 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		for (const [outputId, webview] of this._webviewsByOutputId) {
 			const container = this._webviewContainersByOutputId.get(outputId);
 			if (container) {
-				webview.webview.setAnchorElement(container, this._clippingContainer);
+				this._anchorWebview(webview, container);
 			}
 		}
+	}
+
+	/**
+	 * Anchor an output webview over its placeholder container and clip it to the
+	 * editor, then ensure the overlay hides itself when its anchor is no longer
+	 * visible (see {@link hideWebviewOverlayWhenAnchorHidden}).
+	 */
+	private _anchorWebview(webview: INotebookOutputWebview, container: HTMLElement): void {
+		webview.webview.setAnchorElement(container, this._clippingContainer);
+		hideWebviewOverlayWhenAnchorHidden(webview.webview.container);
 	}
 
 	private _renderAllOutputs(): void {
@@ -2551,7 +2582,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 			// Claim and position the webview
 			const editorWindow = dom.getWindow(this.domNode);
 			webview.webview.claim(this, editorWindow, undefined);
-			webview.webview.setAnchorElement(webviewContainer, this._clippingContainer);
+			this._anchorWebview(webview, webviewContainer);
 
 			// Listen for webview messages to get the actual content height
 			// The webview sends webviewMetrics messages with bodyScrollHeight when content loads/resizes
@@ -2564,7 +2595,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 					webviewContainer.style.height = `${boundedHeight}px`;
 					// Update the view zone height and re-layout the webview
 					this._updateHeight();
-					webview.webview.setAnchorElement(webviewContainer, this._clippingContainer);
+					this._anchorWebview(webview, webviewContainer);
 				}
 			}));
 
@@ -2578,7 +2609,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 			// but we keep this as a backup for any scroll events that might be missed
 			this._webviewDisposables.add(this._editor.onDidScrollChange(() => {
 				if (this._zoneId) {
-					webview.webview.setAnchorElement(webviewContainer, this._clippingContainer);
+					this._anchorWebview(webview, webviewContainer);
 				}
 			}));
 
@@ -2640,7 +2671,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 			// Claim and position the webview
 			const editorWindow = dom.getWindow(this.domNode);
 			webview.webview.claim(this, editorWindow, undefined);
-			webview.webview.setAnchorElement(container, this._clippingContainer);
+			this._anchorWebview(webview, container);
 
 			// Listen for webview messages to get the actual content height
 			this._webviewDisposables.add(webview.webview.onMessage(({ message }) => {
@@ -2649,7 +2680,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 					const boundedHeight = Math.min(message.bodyScrollHeight, maxHeight);
 					container.style.height = `${boundedHeight}px`;
 					this._updateHeight();
-					webview.webview.setAnchorElement(container, this._clippingContainer);
+					this._anchorWebview(webview, container);
 				}
 			}));
 
@@ -2663,7 +2694,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 			// but we keep this as a backup for any scroll events that might be missed
 			this._webviewDisposables.add(this._editor.onDidScrollChange(() => {
 				if (this._zoneId) {
-					webview.webview.setAnchorElement(container, this._clippingContainer);
+					this._anchorWebview(webview, container);
 				}
 			}));
 

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputViewZone.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputViewZone.vitest.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { hideWebviewOverlayWhenAnchorHidden } from '../../browser/quartoOutputViewZone.js';
+
+describe('hideWebviewOverlayWhenAnchorHidden', () => {
+	it('hides the overlay when its anchor is no longer visible', () => {
+		// The inline output webview is a fixed-position overlay anchored to a
+		// placeholder inside the editor view zone. When the placeholder scrolls
+		// out of the rendered range and is removed, the overlay must be hidden
+		// rather than falling back to (and "sticking" in) the editor corner.
+		// See posit-dev/positron#13978.
+		const overlayContent = document.createElement('div');
+
+		hideWebviewOverlayWhenAnchorHidden(overlayContent);
+
+		expect(overlayContent.style.getPropertyValue('position-visibility')).toBe('anchors-visible');
+	});
+});

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputViewZone.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputViewZone.vitest.ts
@@ -5,19 +5,48 @@
 
 /// <reference types="vitest/globals" />
 
-import { hideWebviewOverlayWhenAnchorHidden } from '../../browser/quartoOutputViewZone.js';
+import { isWebviewOverlayShown } from '../../browser/quartoOutputViewZone.js';
 
-describe('hideWebviewOverlayWhenAnchorHidden', () => {
-	it('hides the overlay when its anchor is no longer visible', () => {
-		// The inline output webview is a fixed-position overlay anchored to a
-		// placeholder inside the editor view zone. When the placeholder scrolls
-		// out of the rendered range and is removed, the overlay must be hidden
-		// rather than falling back to (and "sticking" in) the editor corner.
-		// See posit-dev/positron#13978.
-		const overlayContent = document.createElement('div');
+// The inline-output webview is a fixed-position overlay anchored to a
+// placeholder inside the editor view zone. It must be shown only while its view
+// zone is on-screen; otherwise CSS anchor positioning falls back to a static
+// position and the overlay "sticks" in the editor corner (see
+// posit-dev/positron#13978).
+//
+// The predicate keys off Monaco's own `monaco-visible-view-zone` attribute
+// rather than a geometry probe. Monaco sets/removes it in its render pass before
+// calling `onDomNodeTop`, so it is fresh during scroll; a `getClientRects()`
+// probe is one frame stale and, worse, stays truthy for a zone that has scrolled
+// out of the viewport while Monaco still renders it -- exactly the flextable
+// sticking case.
+describe('isWebviewOverlayShown', () => {
+	function zone(visible: boolean): HTMLElement {
+		const el = document.createElement('div');
+		if (visible) {
+			el.setAttribute('monaco-visible-view-zone', 'true');
+		}
+		return el;
+	}
 
-		hideWebviewOverlayWhenAnchorHidden(overlayContent);
+	function anchor(connected: boolean): HTMLElement {
+		const el = document.createElement('div');
+		if (connected) {
+			document.body.appendChild(el);
+		}
+		return el;
+	}
 
-		expect(overlayContent.style.getPropertyValue('position-visibility')).toBe('anchors-visible');
+	it('shows the overlay when the zone is on-screen and the anchor is attached', () => {
+		expect(isWebviewOverlayShown(zone(true), anchor(true))).toBe(true);
+	});
+
+	it('hides the overlay when the zone has scrolled off-screen', () => {
+		// Monaco removes the attribute for an off-screen zone even while the
+		// placeholder is still in the DOM: this is the flextable sticking case.
+		expect(isWebviewOverlayShown(zone(false), anchor(true))).toBe(false);
+	});
+
+	it('hides the overlay when the anchor is detached from the DOM', () => {
+		expect(isWebviewOverlayShown(zone(true), anchor(false))).toBe(false);
 	});
 });

--- a/test/e2e/tests/quarto/quarto-inline-output-rawhtml-scroll.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-rawhtml-scroll.test.ts
@@ -1,0 +1,88 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { join } from 'path';
+import { promises as fs } from 'fs';
+import { test, tags, expect } from './_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+const FIXTURE_REL_PATH = join('workspaces', 'quarto_inline_output', 'rawhtml_scroll.qmd');
+
+// Line of the code cell that renders the widget, and a line far below it.
+const CELL_LINE = 6;
+const FAR_BELOW_LINE = 210;
+
+// A Quarto document whose first cell renders an R htmlwidget (highcharter).
+// htmlwidget output is self-contained HTML that Positron routes through the
+// raw-HTML overlay webview -- the same rendering path as R's flextable output
+// from the bug report -- as opposed to the widget/plot path used by Plotly. The
+// filler paragraphs below let the output scroll far out of Monaco's rendered
+// range. See the Plotly variant in quarto-inline-output-webview-scroll.test.ts
+// for the widget-path counterpart.
+function fixtureContent(): string {
+	const filler = Array.from(
+		{ length: 200 },
+		(_, i) => `Line ${i + 1}: The quick brown fox jumps over the lazy dog while the webview stays anchored.`
+	).join('\n');
+	return `---
+title: "Raw HTML Scroll Test"
+engine: knitr
+---
+
+\`\`\`{r}
+library(highcharter)
+hchart(data.frame(x = 1:5, y = c(1, 4, 9, 16, 25)), "scatter", hcaes(x, y))
+\`\`\`
+
+## Filler section
+
+${filler}
+`;
+}
+
+test.describe('Quarto - Inline Output: Raw HTML scroll', {
+	tag: [tags.QUARTO]
+}, () => {
+
+	test.beforeEach(async function ({ app }) {
+		await fs.writeFile(join(app.workspacePathOrFolder, FIXTURE_REL_PATH), fixtureContent(), 'utf8');
+	});
+
+	test.afterEach(async function ({ app, hotKeys }) {
+		await hotKeys.closeAllEditors();
+		await fs.rm(join(app.workspacePathOrFolder, FIXTURE_REL_PATH), { force: true });
+	});
+
+	// Regression test for posit-dev/positron#13978, raw-HTML overlay path. The
+	// overlay must hide while its view zone is scrolled off-screen and reappear
+	// when scrolled back, rather than "sticking" in the editor's top-left corner.
+	test('R - Verify raw HTML output does not stick when scrolled out of view', async function ({ r, app, openFile, page }) {
+		const { editors, inlineQuarto } = app.workbench;
+
+		await openFile(FIXTURE_REL_PATH);
+		await editors.waitForActiveTab('rawhtml_scroll.qmd');
+		await inlineQuarto.expectKernelStatusVisible();
+
+		await editors.clickTab('rawhtml_scroll.qmd');
+		await inlineQuarto.gotoLine(CELL_LINE);
+		await inlineQuarto.runCurrentCell();
+
+		// The overlay webview appears once the htmlwidget renders.
+		const webview = page.locator('iframe.webview');
+		await expect(webview.first()).toBeVisible({ timeout: 120000 });
+
+		// Scroll far past the output so its view zone leaves the rendered range.
+		// The overlay must not remain visible (it used to stick in the corner).
+		await inlineQuarto.gotoLine(FAR_BELOW_LINE);
+		await expect(webview.first()).not.toBeVisible();
+
+		// Scrolling back to the cell must bring the overlay back.
+		await inlineQuarto.gotoLine(CELL_LINE);
+		await expect(webview.first()).toBeVisible();
+	});
+});

--- a/test/e2e/tests/quarto/quarto-inline-output-webview-scroll.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-webview-scroll.test.ts
@@ -1,0 +1,95 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { join } from 'path';
+import { promises as fs } from 'fs';
+import { test, tags, expect } from './_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+// Relative path (from the workspace root) of the fixture we generate at runtime.
+const FIXTURE_REL_PATH = join('workspaces', 'quarto_inline_output', 'webview_scroll.qmd');
+
+// Line of the code cell that renders the webview, and a line far below it.
+const CELL_LINE = 11;
+const FAR_BELOW_LINE = 210;
+
+// A Quarto document whose first cell renders an interactive Plotly figure (an
+// overlay webview) followed by enough filler text that the output can be
+// scrolled far out of Monaco's rendered range. Plotly is used (rather than the
+// R packages from the bug report) because the sticking is a property of the
+// webview-overlay anchoring and is language-agnostic, and Python/ipykernel runs
+// reliably in local dev and CI.
+function fixtureContent(): string {
+	const filler = Array.from(
+		{ length: 200 },
+		(_, i) => `Line ${i + 1}: The quick brown fox jumps over the lazy dog while the webview stays anchored.`
+	).join('\n');
+	return `---
+title: "Webview Scroll Test"
+jupyter: python3
+---
+
+An interactive Plotly figure is rendered inline as a webview overlay. The
+paragraphs below exist so the output can be scrolled far out of view.
+
+\`\`\`{python}
+import plotly.express as px
+fig = px.scatter(x=[0, 1, 2, 3, 4], y=[0, 1, 4, 9, 16])
+fig.show()
+\`\`\`
+
+## Filler section
+
+${filler}
+`;
+}
+
+test.describe('Quarto - Inline Output: Webview scroll', {
+	tag: [tags.WEB, tags.WIN, tags.QUARTO]
+}, () => {
+
+	test.beforeEach(async function ({ app }) {
+		await fs.writeFile(join(app.workspacePathOrFolder, FIXTURE_REL_PATH), fixtureContent(), 'utf8');
+	});
+
+	test.afterEach(async function ({ app, hotKeys }) {
+		await hotKeys.closeAllEditors();
+		await fs.rm(join(app.workspacePathOrFolder, FIXTURE_REL_PATH), { force: true });
+	});
+
+	// Regression test for posit-dev/positron#13978: an inline-output webview is a
+	// fixed-position overlay anchored to a placeholder inside the editor view
+	// zone. When the placeholder scrolls out of Monaco's rendered range it
+	// collapses to zero layout boxes, and the overlay used to fall back to a
+	// static position and "stick" in the editor's top-left corner. It must hide
+	// while its anchor is off-screen and reappear when scrolled back.
+	test('Python - Verify webview output does not stick when scrolled out of view', async function ({ python, app, openFile, page }) {
+		const { editors, inlineQuarto } = app.workbench;
+
+		await openFile(FIXTURE_REL_PATH);
+		await editors.waitForActiveTab('webview_scroll.qmd');
+		await inlineQuarto.expectKernelStatusVisible();
+
+		await editors.clickTab('webview_scroll.qmd');
+		await inlineQuarto.gotoLine(CELL_LINE);
+		await inlineQuarto.runCurrentCell();
+
+		// The overlay webview appears once the Plotly figure renders.
+		const webview = page.locator('iframe.webview');
+		await expect(webview.first()).toBeVisible({ timeout: 120000 });
+
+		// Scroll far past the output so its view zone leaves the rendered range.
+		// The overlay must not remain visible (it used to stick in the corner).
+		await inlineQuarto.gotoLine(FAR_BELOW_LINE);
+		await expect(webview.first()).not.toBeVisible();
+
+		// Scrolling back to the cell must bring the overlay back.
+		await inlineQuarto.gotoLine(CELL_LINE);
+		await expect(webview.first()).toBeVisible();
+	});
+});


### PR DESCRIPTION
Quarto inline-output webviews (flextable, htmlwidgets, etc.) are fixed-position overlays anchored via CSS anchor positioning to a placeholder inside the editor view zone, while the webview itself is mounted at the workbench root. When the placeholder is not on-screen, anchor positioning falls back to a static position and the overlay "sticks" in the editor's top-left corner.

<img width="986" height="484" alt="image" src="https://github.com/user-attachments/assets/a79852ab-9fb6-4400-957b-8f06f009b351" />

The previous approach drove overlay visibility from signals that don't reliably report whether the anchor is on-screen: `position-visibility: anchors-visible` doesn't hide the overlay when the anchor "still exists", and a `getClientRects().length > 0` probe is one frame stale during scroll (scroll handlers fire before Monaco applies the zone's new `display`/position) and stays truthy for a zone that has scrolled out of the viewport while Monaco still renders it. Interactive widgets (highcharter, Plotly) emit follow-up resize/render events that incidentally re-run the layout and correct a stale decision, but a static output like a flextable table emits nothing, so it stays stuck.

This drives overlay visibility off Monaco's own `monaco-visible-view-zone` attribute, which Monaco sets/removes in its render pass *before* calling `onDomNodeTop` and *before* applying the zone's position (so it's fresh during scroll), plus a deferred animation-frame re-check so static outputs converge after asynchronous layout.

Fixes #13978

### Release Notes

#### New Features
- N/A

#### Bug Fixes

- Fix Quarto inline-output webviews (e.g. flextable) sticking in the editor corner when scrolled past the output (#13978)

### Validation Steps

@:quarto

1. Open a `.qmd` or `.rmd` file and add an R cell that renders a static HTML output, e.g.:

   ```r
   library(flextable)
   flextable(head(iris, 10))
   ```

2. Run the cell so the table renders inline.
3. Scroll far past the output (add filler paragraphs below the cell if needed) and confirm the table does **not** stick in the top-left corner of the editor -- it should disappear cleanly.
4. Scroll back to the cell and confirm the table reappears in the correct position.
5. Repeat with an interactive widget (e.g. `highcharter`, or a Python Plotly figure) to confirm no regression on the widget path.

Automated coverage: `test/e2e/tests/quarto/quarto-inline-output-rawhtml-scroll.test.ts` (raw-HTML overlay path, R) and `quarto-inline-output-webview-scroll.test.ts` (widget path, Python), plus a unit test for the visibility predicate in `quartoOutputViewZone.vitest.ts`.
