### PR TITLE
python: suggest ibis-framework for 'import ibis'

### DIFF
--- a/extensions/positron-python/src/client/positron/pythonImportAliases.ts
+++ b/extensions/positron-python/src/client/positron/pythonImportAliases.ts
@@ -38,6 +38,7 @@ export const IMPORT_TO_DISTRIBUTION: Readonly<Record<string, string>> = {
     gdal: 'GDAL',
     mpl_toolkits: 'matplotlib',
     faiss: 'faiss-cpu',
+    ibis: 'ibis-framework',
 
     // Serialization / config / data formats.
     yaml: 'PyYAML',


### PR DESCRIPTION
I noticed `ibis -> ibis-framework` was missing from our list of package aliases.

Note from their [docs](https://ibis-project.org/install):

<img width="682" height="119" alt="image" src="https://github.com/user-attachments/assets/2a72f0b2-83b9-4d09-997a-3b916e074cab" />

I think it's safe to recommend `ibis-framework` given that it's much more data-science-focused and we have other custom handling for its objects in positron-python.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### Validation Steps

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information on how to validate the change, paying
  special attention to the level of risk, adjacent areas that could
  be affected by the change, and any important contextual information
  not present in the linked issues.
-->
`import ibis`