### PR TITLE
Add settings for custom gallery extension URLs

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionGalleryManifest.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryManifest.ts
@@ -101,4 +101,5 @@ export const ExtensionGalleryServiceUrlConfigKey = 'extensions.gallery.serviceUr
 
 // --- Start Positron ---
 export const PositronGallerySourceConfigKey = 'positron.extensions.gallerySource';
+export const PositronCustomGalleryUrlConfigKey = 'positron.extensions.customGalleryUrl';
 // --- End Positron ---

--- a/src/vs/platform/extensionManagement/common/extensionGalleryManifestService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryManifestService.ts
@@ -22,41 +22,95 @@ export type ExtensionGalleryConfig = {
 };
 
 // --- Start Positron ---
-export const POSITRON_GALLERY_PRESETS: Record<string, ExtensionGalleryConfig> = {
-	'posit-p3m': {
-		serviceUrl: 'https://p3m.dev/openvsx/latest/vscode/gallery',
-		itemUrl: 'https://p3m.dev/openvsx/latest/vscode/item',
-		resourceUrlTemplate: 'https://p3m.dev/openvsx/latest/vscode/asset/{publisher}/{name}/{version}/Microsoft.VisualStudio.Code.WebResources/{path}',
-		controlUrl: '',
-		extensionUrlTemplate: 'https://p3m.dev/openvsx/latest/vscode/gallery/{publisher}/{name}/latest',
-		nlsBaseUrl: '',
-		publisherUrl: '',
-	},
-	'open-vsx': {
-		serviceUrl: 'https://open-vsx.org/vscode/gallery',
-		itemUrl: 'https://open-vsx.org/vscode/item',
-		resourceUrlTemplate: 'https://open-vsx.org/vscode/asset/{publisher}/{name}/{version}/Microsoft.VisualStudio.Code.WebResources/{path}',
-		controlUrl: '',
-		extensionUrlTemplate: 'https://open-vsx.org/vscode/gallery/{publisher}/{name}/latest',
-		nlsBaseUrl: '',
-		publisherUrl: '',
-	},
+
+/**
+ * Base URLs for the built-in gallery presets. Every gallery (preset or custom)
+ * is a single base URL run through deriveGalleryConfig, so the Open VSX URL
+ * scheme lives in exactly one place and presets and custom URLs cannot drift.
+ */
+export const POSITRON_GALLERY_PRESET_BASES: Record<string, string> = {
+	'posit-p3m': 'https://p3m.dev/openvsx/latest/vscode',
+	'open-vsx': 'https://open-vsx.org/vscode',
 };
+
+/**
+ * Derives a full gallery config from a base URL using the Open VSX URL scheme.
+ * Returns undefined (and warns) when the base fails canonicalization, so a
+ * malformed or unsafe value falls back to the product default rather than
+ * producing broken or secret-bearing gallery URLs. A blank/whitespace-only
+ * value returns undefined silently (it means "no custom URL", not an error).
+ */
+export function deriveGalleryConfig(
+	base: string,
+	warn: (message: string) => void = msg => console.warn(msg),
+): ExtensionGalleryConfig | undefined {
+	const trimmed = base.trim();
+	if (!trimmed) {
+		return undefined;
+	}
+	let url: URL;
+	try {
+		url = new URL(trimmed);
+	} catch {
+		// Do not echo the raw value: a programmatic or settings.json value could
+		// carry credentials past the settings-editor pattern.
+		warn('Ignoring custom gallery URL: not a valid URL.');
+		return undefined;
+	}
+	if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+		warn('Ignoring custom gallery URL: must use http or https.');
+		return undefined;
+	}
+	if (url.username || url.password || url.search || url.hash) {
+		warn('Ignoring custom gallery URL: credentials, query, and fragment are not allowed.');
+		return undefined;
+	}
+	// Canonical base: origin + pathname, trailing slashes stripped. By
+	// construction this carries no credentials/query/fragment, so it is safe
+	// to log and to show in notifications.
+	const b = `${url.origin}${url.pathname}`.replace(/\/+$/, '');
+	return {
+		serviceUrl: `${b}/gallery`,
+		itemUrl: `${b}/item`,
+		resourceUrlTemplate: `${b}/asset/{publisher}/{name}/{version}/Microsoft.VisualStudio.Code.WebResources/{path}`,
+		extensionUrlTemplate: `${b}/gallery/{publisher}/{name}/latest`,
+		controlUrl: '',
+		nlsBaseUrl: '',
+		publisherUrl: '',
+	};
+}
+
+/**
+ * The built-in presets, derived from their base URLs. Kept as a named export
+ * so existing consumers and tests continue to reference presets by config.
+ */
+export const POSITRON_GALLERY_PRESETS: Record<string, ExtensionGalleryConfig> =
+	Object.fromEntries(
+		Object.entries(POSITRON_GALLERY_PRESET_BASES).map(
+			([name, base]) => [name, deriveGalleryConfig(base)!]
+		)
+	);
 
 /**
  * Resolves the gallery config to use, applying the Positron precedence:
  * a successfully-parsed EXTENSIONS_GALLERY env var wins over the
  * `positron.extensions.gallerySource` setting, which wins over the default
- * product gallery. An env var that failed to parse should be passed as
- * undefined so the caller falls through to the preset.
+ * product gallery. When gallerySource is 'custom', the config is derived from
+ * customGalleryUrl, falling back to the product gallery when that URL is blank
+ * or fails canonicalization. An env var that failed to parse should be passed
+ * as undefined so the caller falls through to the preset/custom path.
  */
 export function resolvePositronGalleryConfig(
 	envGallery: ExtensionGalleryConfig | undefined,
 	gallerySource: string | undefined,
+	customGalleryUrl: string | undefined,
 	productGallery: ExtensionGalleryConfig | undefined,
 ): ExtensionGalleryConfig | undefined {
 	if (envGallery) {
 		return envGallery;
+	}
+	if (gallerySource === 'custom') {
+		return deriveGalleryConfig(customGalleryUrl ?? '') ?? productGallery;
 	}
 	const preset = gallerySource ? POSITRON_GALLERY_PRESETS[gallerySource] : undefined;
 	return preset ?? productGallery;

--- a/src/vs/platform/extensionManagement/common/extensionGalleryManifestService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryManifestService.ts
@@ -116,6 +116,24 @@ export function resolvePositronGalleryConfig(
 	return preset ?? productGallery;
 }
 
+/**
+ * Whether two gallery resource URLs (or templates) target the same gallery host.
+ * Used to decide whether the product-default resource API is a safe fallback for
+ * the resolved gallery: it is only safe within the same host, so a non-default
+ * gallery never silently leaks to the default one. Returns false when either
+ * value is missing or not a parseable URL.
+ */
+export function sameGalleryHost(a: string | undefined, b: string | undefined): boolean {
+	if (!a || !b) {
+		return false;
+	}
+	try {
+		return new URL(a).origin === new URL(b).origin;
+	} catch {
+		return false;
+	}
+}
+
 // --- End Positron ---
 
 export class ExtensionGalleryManifestService extends Disposable implements IExtensionGalleryManifestService {

--- a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
@@ -30,6 +30,9 @@ import { ITelemetryService } from '../../telemetry/common/telemetry.js';
 import { StopWatch } from '../../../base/common/stopwatch.js';
 import { format2 } from '../../../base/common/strings.js';
 import { ExtensionGalleryResourceType, Flag, getExtensionGalleryManifestResourceUri, IExtensionGalleryManifest, IExtensionGalleryManifestService, ExtensionGalleryManifestStatus } from './extensionGalleryManifest.js';
+// --- Start Positron ---
+import { sameGalleryHost } from './extensionGalleryManifestService.js';
+// --- End Positron ---
 import { TelemetryTrustedValue } from '../../telemetry/common/telemetryUtils.js';
 // --- Start Positron ---
 import { appendPositronGalleryParams, formatPositronVersion, GalleryUsageDataConfigKey, getPositronSessionType, PositronCheckTrigger } from './positronGalleryTelemetry.js';
@@ -704,7 +707,16 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 		if (latestVersionResource) {
 			return {
 				uri: latestVersionResource,
-				fallback: this.unpkgResourceApi
+				// --- Start Positron ---
+				// `unpkgResourceApi` comes from the product's default gallery
+				// (`product.json`), so only use it as a fallback when it targets the
+				// same gallery host as the resolved resource. Otherwise a request that
+				// fails against a non-default gallery (a custom or Open VSX gallery
+				// selected via `positron.extensions.gallerySource`) would silently leak
+				// to the default gallery -- e.g. a custom gallery returning 5xx must not
+				// fall back to p3m.dev and serve its extensions instead.
+				fallback: sameGalleryHost(latestVersionResource, this.unpkgResourceApi) ? this.unpkgResourceApi : undefined
+				// --- End Positron ---
 			};
 		}
 		return undefined;

--- a/src/vs/platform/extensionManagement/test/common/positronGalleryManifestService.vitest.ts
+++ b/src/vs/platform/extensionManagement/test/common/positronGalleryManifestService.vitest.ts
@@ -5,7 +5,7 @@
 
 /// <reference types="vitest/globals" />
 
-import { ExtensionGalleryManifestService, ExtensionGalleryConfig, POSITRON_GALLERY_PRESETS, resolvePositronGalleryConfig } from '../../common/extensionGalleryManifestService.js';
+import { ExtensionGalleryManifestService, ExtensionGalleryConfig, POSITRON_GALLERY_PRESETS, POSITRON_GALLERY_PRESET_BASES, deriveGalleryConfig, resolvePositronGalleryConfig } from '../../common/extensionGalleryManifestService.js';
 import { parseExtensionsGalleryEnv } from '../../common/extensionsGalleryEnv.js';
 import { ExtensionGalleryResourceType, getExtensionGalleryManifestResourceUri } from '../../common/extensionGalleryManifest.js';
 import { IProductService } from '../../../product/common/productService.js';
@@ -44,6 +44,65 @@ describe('POSITRON_GALLERY_PRESETS', () => {
 			}
 			expect(preset.serviceUrl).toBeTruthy();
 			expect(preset.itemUrl).toBeTruthy();
+		}
+	});
+});
+
+describe('deriveGalleryConfig', () => {
+	it('derives the four URLs from a base using the Open VSX scheme', () => {
+		const config = deriveGalleryConfig('https://my-ppm.example.com/openvsx/latest/vscode');
+		expect(config).toEqual({
+			serviceUrl: 'https://my-ppm.example.com/openvsx/latest/vscode/gallery',
+			itemUrl: 'https://my-ppm.example.com/openvsx/latest/vscode/item',
+			resourceUrlTemplate: 'https://my-ppm.example.com/openvsx/latest/vscode/asset/{publisher}/{name}/{version}/Microsoft.VisualStudio.Code.WebResources/{path}',
+			extensionUrlTemplate: 'https://my-ppm.example.com/openvsx/latest/vscode/gallery/{publisher}/{name}/latest',
+			controlUrl: '',
+			nlsBaseUrl: '',
+			publisherUrl: '',
+		});
+	});
+
+	it('normalizes one or more trailing slashes', () => {
+		const a = deriveGalleryConfig('https://host.example.com/vscode/');
+		const b = deriveGalleryConfig('https://host.example.com/vscode');
+		expect(a).toEqual(b);
+		expect(a?.serviceUrl).toBe('https://host.example.com/vscode/gallery');
+	});
+
+	it('trims surrounding whitespace', () => {
+		const config = deriveGalleryConfig('  https://host.example.com/vscode  ');
+		expect(config?.serviceUrl).toBe('https://host.example.com/vscode/gallery');
+	});
+
+	it('returns undefined for blank or whitespace-only input', () => {
+		const warn = vi.fn();
+		expect(deriveGalleryConfig('', warn)).toBeUndefined();
+		expect(deriveGalleryConfig('   ', warn)).toBeUndefined();
+		expect(warn).not.toHaveBeenCalled();
+	});
+
+	it('returns undefined for non-http(s) or unparseable input', () => {
+		expect(deriveGalleryConfig('not a url')).toBeUndefined();
+		expect(deriveGalleryConfig('ftp://host.example.com/vscode')).toBeUndefined();
+	});
+
+	it('rejects credentials, query, and fragment', () => {
+		expect(deriveGalleryConfig('https://user:pass@host.example.com/vscode')).toBeUndefined();
+		expect(deriveGalleryConfig('https://host.example.com/vscode?x=1')).toBeUndefined();
+		expect(deriveGalleryConfig('https://host.example.com/vscode#frag')).toBeUndefined();
+	});
+
+	it('warns via the supplied callback on rejection', () => {
+		const warn = vi.fn();
+		expect(deriveGalleryConfig('https://user:pass@host/vscode', warn)).toBeUndefined();
+		expect(deriveGalleryConfig('not a url', warn)).toBeUndefined();
+		expect(deriveGalleryConfig('ftp://host.example.com/vscode', warn)).toBeUndefined();
+		expect(warn).toHaveBeenCalledTimes(3);
+	});
+
+	it('preset bases derive to the same configs as POSITRON_GALLERY_PRESETS', () => {
+		for (const [name, base] of Object.entries(POSITRON_GALLERY_PRESET_BASES)) {
+			expect(deriveGalleryConfig(base)).toEqual(POSITRON_GALLERY_PRESETS[name]);
 		}
 	});
 });
@@ -167,7 +226,7 @@ describe('resolvePositronGalleryConfig', () => {
 			...productGallery,
 			serviceUrl: 'https://override.example.com/gallery',
 		};
-		const result = resolvePositronGalleryConfig(envGallery, 'open-vsx', productGallery);
+		const result = resolvePositronGalleryConfig(envGallery, 'open-vsx', undefined, productGallery);
 		expect(result).toBe(envGallery);
 		expect(result?.serviceUrl).toBe('https://override.example.com/gallery');
 		expect(result?.serviceUrl).not.toBe(POSITRON_GALLERY_PRESETS['open-vsx'].serviceUrl);
@@ -178,7 +237,7 @@ describe('resolvePositronGalleryConfig', () => {
 			...productGallery,
 			serviceUrl: 'https://override.example.com/gallery',
 		};
-		const result = resolvePositronGalleryConfig(envGallery, undefined, productGallery);
+		const result = resolvePositronGalleryConfig(envGallery, undefined, undefined, productGallery);
 		expect(result).toBe(envGallery);
 	});
 
@@ -186,18 +245,53 @@ describe('resolvePositronGalleryConfig', () => {
 		// Passing undefined is how the caller signals "env was not usable" — either
 		// it wasn't set, or it was set but parseExtensionsGalleryEnv returned undefined
 		// because the value was not valid JSON. In both cases the preset wins.
-		expect(resolvePositronGalleryConfig(undefined, 'open-vsx', productGallery)).toBe(POSITRON_GALLERY_PRESETS['open-vsx']);
-		expect(resolvePositronGalleryConfig(undefined, 'posit-p3m', productGallery)).toBe(POSITRON_GALLERY_PRESETS['posit-p3m']);
+		expect(resolvePositronGalleryConfig(undefined, 'open-vsx', undefined, productGallery)).toBe(POSITRON_GALLERY_PRESETS['open-vsx']);
+		expect(resolvePositronGalleryConfig(undefined, 'posit-p3m', undefined, productGallery)).toBe(POSITRON_GALLERY_PRESETS['posit-p3m']);
 	});
 
 	it('returns the product gallery when env is undefined and gallerySource is unset or unknown', () => {
-		expect(resolvePositronGalleryConfig(undefined, undefined, productGallery)).toBe(productGallery);
-		expect(resolvePositronGalleryConfig(undefined, '', productGallery)).toBe(productGallery);
-		expect(resolvePositronGalleryConfig(undefined, 'not-a-preset', productGallery)).toBe(productGallery);
+		expect(resolvePositronGalleryConfig(undefined, undefined, undefined, productGallery)).toBe(productGallery);
+		expect(resolvePositronGalleryConfig(undefined, '', undefined, productGallery)).toBe(productGallery);
+		expect(resolvePositronGalleryConfig(undefined, 'not-a-preset', undefined, productGallery)).toBe(productGallery);
 	});
 
 	it('returns undefined when env is undefined and the product gallery is unset', () => {
-		expect(resolvePositronGalleryConfig(undefined, undefined, undefined)).toBeUndefined();
+		expect(resolvePositronGalleryConfig(undefined, undefined, undefined, undefined)).toBeUndefined();
+	});
+
+	it('derives a custom config when gallerySource is custom and the URL is valid', () => {
+		const result = resolvePositronGalleryConfig(undefined, 'custom', 'https://my-ppm.example.com/vscode', productGallery);
+		expect(result).toEqual(deriveGalleryConfig('https://my-ppm.example.com/vscode'));
+	});
+
+	it('falls back to product gallery when gallerySource is custom but the URL is blank', () => {
+		expect(resolvePositronGalleryConfig(undefined, 'custom', '', productGallery)).toBe(productGallery);
+		expect(resolvePositronGalleryConfig(undefined, 'custom', undefined, productGallery)).toBe(productGallery);
+	});
+
+	it('falls back to product gallery when gallerySource is custom but the URL is invalid', () => {
+		expect(resolvePositronGalleryConfig(undefined, 'custom', 'https://user:pass@host/vscode', productGallery)).toBe(productGallery);
+		expect(resolvePositronGalleryConfig(undefined, 'custom', 'not a url', productGallery)).toBe(productGallery);
+	});
+
+	it('env gallery still wins even when gallerySource is custom', () => {
+		const envGallery: ExtensionGalleryConfig = { ...productGallery, serviceUrl: 'https://override.example.com/gallery' };
+		expect(resolvePositronGalleryConfig(envGallery, 'custom', 'https://my-ppm.example.com/vscode', productGallery)).toBe(envGallery);
+	});
+
+	// The electron-browser service only prompts for a restart when the resolved
+	// serviceUrl changes. These pin the resolution property that gating relies on,
+	// so editing the two settings in sequence never triggers a no-op restart.
+	it('setting a custom URL while the source is a preset does not change the resolved gallery', () => {
+		const before = resolvePositronGalleryConfig(undefined, 'posit-p3m', '', productGallery);
+		const after = resolvePositronGalleryConfig(undefined, 'posit-p3m', 'https://my-ppm.example.com/vscode', productGallery);
+		expect(after?.serviceUrl).toBe(before?.serviceUrl);
+	});
+
+	it('changing the custom URL while the source is custom does change the resolved gallery', () => {
+		const before = resolvePositronGalleryConfig(undefined, 'custom', 'https://a.example.com/vscode', productGallery);
+		const after = resolvePositronGalleryConfig(undefined, 'custom', 'https://b.example.com/vscode', productGallery);
+		expect(after?.serviceUrl).not.toBe(before?.serviceUrl);
 	});
 });
 

--- a/src/vs/platform/extensionManagement/test/common/positronGalleryManifestService.vitest.ts
+++ b/src/vs/platform/extensionManagement/test/common/positronGalleryManifestService.vitest.ts
@@ -5,7 +5,7 @@
 
 /// <reference types="vitest/globals" />
 
-import { ExtensionGalleryManifestService, ExtensionGalleryConfig, POSITRON_GALLERY_PRESETS, POSITRON_GALLERY_PRESET_BASES, deriveGalleryConfig, resolvePositronGalleryConfig } from '../../common/extensionGalleryManifestService.js';
+import { ExtensionGalleryManifestService, ExtensionGalleryConfig, POSITRON_GALLERY_PRESETS, POSITRON_GALLERY_PRESET_BASES, deriveGalleryConfig, resolvePositronGalleryConfig, sameGalleryHost } from '../../common/extensionGalleryManifestService.js';
 import { parseExtensionsGalleryEnv } from '../../common/extensionsGalleryEnv.js';
 import { ExtensionGalleryResourceType, getExtensionGalleryManifestResourceUri } from '../../common/extensionGalleryManifest.js';
 import { IProductService } from '../../../product/common/productService.js';
@@ -292,6 +292,25 @@ describe('resolvePositronGalleryConfig', () => {
 		const before = resolvePositronGalleryConfig(undefined, 'custom', 'https://a.example.com/vscode', productGallery);
 		const after = resolvePositronGalleryConfig(undefined, 'custom', 'https://b.example.com/vscode', productGallery);
 		expect(after?.serviceUrl).not.toBe(before?.serviceUrl);
+	});
+});
+
+describe('sameGalleryHost', () => {
+	const p3m = 'https://p3m.dev/openvsx/latest/vscode/gallery/{publisher}/{name}/latest';
+
+	it('is true for templates on the same host', () => {
+		expect(sameGalleryHost(p3m, p3m)).toBe(true);
+	});
+
+	it('is false for a custom gallery vs the default host (no cross-gallery fallback)', () => {
+		const custom = 'https://solo.packagemanager.posit.co/openvsx/latest/vscode/gallery/{publisher}/{name}/latest';
+		expect(sameGalleryHost(custom, p3m)).toBe(false);
+	});
+
+	it('is false when either value is missing or unparseable', () => {
+		expect(sameGalleryHost(undefined, p3m)).toBe(false);
+		expect(sameGalleryHost(p3m, undefined)).toBe(false);
+		expect(sameGalleryHost('not a url', p3m)).toBe(false);
 	});
 });
 

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -28,7 +28,7 @@ import { IDialogService, IFileDialogService } from '../../../../platform/dialogs
 import { ExtensionGalleryManifestStatus, ExtensionGalleryResourceType, ExtensionGalleryServiceUrlConfigKey, getExtensionGalleryManifestResourceUri, IExtensionGalleryManifest, IExtensionGalleryManifestService } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
 // --- Start Positron ---
 // eslint-disable-next-line no-duplicate-imports
-import { PositronGallerySourceConfigKey } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
+import { PositronGallerySourceConfigKey, PositronCustomGalleryUrlConfigKey } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
 // --- End Positron ---
 import { EXTENSION_INSTALL_SOURCE_CONTEXT, ExtensionInstallSource, ExtensionRequestsTimeoutConfigKey, ExtensionsLocalizedLabel, FilterType, IExtensionGalleryService, IExtensionManagementService, PreferencesLocalizedLabel, SortBy, VerifyExtensionSignatureConfigKey } from '../../../../platform/extensionManagement/common/extensionManagement.js';
 import { areSameExtensions, getIdAndVersion } from '../../../../platform/extensionManagement/common/extensionManagementUtil.js';
@@ -335,17 +335,28 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 			// --- Start Positron ---
 			[PositronGallerySourceConfigKey]: {
 				type: 'string',
-				enum: ['posit-p3m', 'open-vsx'],
+				enum: ['posit-p3m', 'open-vsx', 'custom'],
 				enumDescriptions: [
 					localize('positron.extensions.gallerySource.positP3m', "Posit Public Package Manager (p3m.dev) - Posit's curated extension registry (default)"),
 					localize('positron.extensions.gallerySource.openVsx', "Open VSX Registry (open-vsx.org) - the upstream open-source extension registry"),
+					localize('positron.extensions.gallerySource.custom', "A custom Open VSX-compatible gallery, such as a self-hosted Posit Package Manager. Set its base URL in the Custom Gallery Url setting"),
 				],
 				enumItemLabels: [
 					localize('positron.extensions.gallerySource.positP3m.label', "Posit Public Package Manager"),
 					localize('positron.extensions.gallerySource.openVsx.label', "Open VSX Registry"),
+					localize('positron.extensions.gallerySource.custom.label', "Custom"),
 				],
 				markdownDescription: localize('positron.extensions.gallerySource', "Choose which extension gallery (marketplace) to use for browsing and installing extensions. Changes require a restart.\n\nNote: when the `EXTENSIONS_GALLERY` environment variable is set to a valid value, it overrides this setting."),
 				default: 'posit-p3m',
+				scope: ConfigurationScope.APPLICATION,
+				tags: ['usesOnlineServices'],
+			},
+			[PositronCustomGalleryUrlConfigKey]: {
+				type: 'string',
+				default: '',
+				pattern: '^$|^https?://.+',
+				patternErrorMessage: localize('positron.extensions.customGalleryUrl.pattern', "Enter an absolute http(s) URL, or leave blank."),
+				markdownDescription: localize('positron.extensions.customGalleryUrl', "Base URL of a custom Open VSX-compatible extension gallery. Only used when Extension Gallery Source is set to Custom. Provide the root URL of the Open VSX endpoint, for example `https://my-ppm.example.com/openvsx/latest/vscode`; the `/gallery` and asset paths are appended automatically. For galleries that do not follow the standard Open VSX URL scheme, use the `EXTENSIONS_GALLERY` environment variable instead. Changes require a restart."),
 				scope: ConfigurationScope.APPLICATION,
 				tags: ['usesOnlineServices'],
 			},

--- a/src/vs/workbench/contrib/extensions/common/positronCustomGalleryProbe.ts
+++ b/src/vs/workbench/contrib/extensions/common/positronCustomGalleryProbe.ts
@@ -1,0 +1,98 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Pure, DI-free decision logic for the custom-gallery reachability probe.
+ * Kept separate from the electron-browser contribution so it is unit-testable
+ * without DI services or a live network.
+ */
+
+/** Raw outcome of a probe attempt, before it is turned into a user-facing decision. */
+export type ProbeOutcome =
+	| { kind: 'invalid-url' }
+	| { kind: 'http'; status: number; hasResultsArray: boolean }
+	| { kind: 'error'; reason: string };
+
+/** Whether to surface a warning, and (if so) a short sanitized reason. */
+export type ProbeDecision =
+	| { notify: false }
+	| { notify: true; reason: string };
+
+/**
+ * Maps a raw probe outcome to a user-facing decision. The reason is always a
+ * short, normalized string (never a raw transport/stack message), so
+ * notifications stay clean and leak no internals.
+ */
+export function interpretProbeResult(outcome: ProbeOutcome): ProbeDecision {
+	switch (outcome.kind) {
+		case 'invalid-url':
+			return { notify: true, reason: 'not a valid URL' };
+		case 'http':
+			if (outcome.status >= 200 && outcome.status < 300) {
+				return outcome.hasResultsArray
+					? { notify: false }
+					: { notify: true, reason: 'the server did not return a gallery response' };
+			}
+			return { notify: true, reason: `HTTP ${outcome.status}` };
+		case 'error':
+			return { notify: true, reason: outcome.reason };
+	}
+}
+
+/**
+ * Tracks the last value that produced a warning so the probe warns at most once
+ * per distinct value -- no notification spam while the user edits the setting.
+ */
+export class WarnOnceCache {
+	private lastWarnedValue: string | undefined;
+
+	/** Returns true if a warning should be shown for this value now. */
+	shouldWarn(value: string): boolean {
+		if (this.lastWarnedValue === value) {
+			return false;
+		}
+		this.lastWarnedValue = value;
+		return true;
+	}
+
+	/** Forget the last-warned value (e.g. after a success), so it can warn again later. */
+	clear(): void {
+		this.lastWarnedValue = undefined;
+	}
+}
+
+/**
+ * Returns a credential-free display form of a URL, for use in user-facing
+ * messages. A custom gallery URL can be rejected for carrying credentials, a
+ * query, or a fragment -- any of which may hold secrets/tokens -- so all of
+ * those are stripped before display. Input that does not parse as a URL cannot
+ * contain URL credentials and is returned trimmed as-is.
+ */
+export function redactUrlForDisplay(raw: string): string {
+	try {
+		const url = new URL(raw.trim());
+		url.username = '';
+		url.password = '';
+		url.search = '';
+		url.hash = '';
+		return url.href.replace(/\/+$/, '');
+	} catch {
+		return raw.trim();
+	}
+}
+
+/** Shape of a gallery extensionquery request body. */
+export interface ProbeQueryBody {
+	readonly filters: { criteria: unknown[]; pageNumber: number; pageSize: number; sortBy: number; sortOrder: number }[];
+	readonly flags: number;
+}
+
+/** Minimal extension-query body: ask for a single result to confirm the gallery responds. */
+export function buildProbeQueryBody(): ProbeQueryBody {
+	return {
+		filters: [{ criteria: [], pageNumber: 1, pageSize: 1, sortBy: 0, sortOrder: 0 }],
+		flags: 0,
+	};
+}

--- a/src/vs/workbench/contrib/extensions/electron-browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/extensions.contribution.ts
@@ -25,6 +25,9 @@ import { CleanUpExtensionsFolderAction, OpenExtensionsFolderAction } from './ext
 import { ExtensionsAutoProfiler } from './extensionsAutoProfiler.js';
 import { InstallRemoteExtensionsContribution, RemoteExtensionsInitializerContribution } from './remoteExtensionsInit.js';
 import { IExtensionHostProfileService, OpenExtensionHostProfileACtion, RuntimeExtensionsEditor, SaveExtensionHostProfileAction, StartExtensionHostProfileAction, StopExtensionHostProfileAction } from './runtimeExtensionsEditor.js';
+// --- Start Positron ---
+import { PositronCustomGalleryValidation } from './positronCustomGalleryValidation.js';
+// --- End Positron ---
 
 // Singletons
 registerSingleton(IExtensionHostProfileService, ExtensionHostProfileService, InstantiationType.Delayed);
@@ -73,6 +76,12 @@ workbenchRegistry.registerWorkbenchContribution(ExtensionsAutoProfiler, Lifecycl
 workbenchRegistry.registerWorkbenchContribution(RemoteExtensionsInitializerContribution, LifecyclePhase.Restored);
 workbenchRegistry.registerWorkbenchContribution(InstallRemoteExtensionsContribution, LifecyclePhase.Restored);
 workbenchRegistry.registerWorkbenchContribution(DebugExtensionsContribution, LifecyclePhase.Restored);
+// --- Start Positron ---
+// Advisory probe that warns when a configured custom extension gallery is
+// unreachable or malformed. Restored phase: after the workbench is ready but
+// not on the critical startup path.
+workbenchRegistry.registerWorkbenchContribution(PositronCustomGalleryValidation, LifecyclePhase.Restored);
+// --- End Positron ---
 
 // Register Commands
 

--- a/src/vs/workbench/contrib/extensions/electron-browser/positronCustomGalleryValidation.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/positronCustomGalleryValidation.ts
@@ -1,0 +1,132 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { RunOnceScheduler } from '../../../../base/common/async.js';
+import { CancellationTokenSource } from '../../../../base/common/cancellation.js';
+import { localize } from '../../../../nls.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { INotificationService } from '../../../../platform/notification/common/notification.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { asJson, IRequestService } from '../../../../platform/request/common/request.js';
+import { IWorkbenchContribution } from '../../../common/contributions.js';
+import { PositronGallerySourceConfigKey, PositronCustomGalleryUrlConfigKey } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
+import { deriveGalleryConfig } from '../../../../platform/extensionManagement/common/extensionGalleryManifestService.js';
+import { interpretProbeResult, WarnOnceCache, buildProbeQueryBody, ProbeOutcome, redactUrlForDisplay } from '../common/positronCustomGalleryProbe.js';
+
+const PROBE_DEBOUNCE_MS = 750;
+const PROBE_TIMEOUT_MS = 5000;
+
+/**
+ * Advisory, desktop-only check that warns when the configured custom extension
+ * gallery is malformed or unreachable. Runs once at startup (so a persisted bad
+ * config is surfaced without re-editing) and on each relevant config change,
+ * debounced and warn-once'd so editing the setting does not spam notifications.
+ * Never blocks: the value still saves and the gallery only switches on restart.
+ */
+export class PositronCustomGalleryValidation extends Disposable implements IWorkbenchContribution {
+
+	private readonly warnOnce = new WarnOnceCache();
+	private readonly scheduler: RunOnceScheduler;
+	private cts: CancellationTokenSource | undefined;
+
+	constructor(
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IRequestService private readonly requestService: IRequestService,
+		@INotificationService private readonly notificationService: INotificationService,
+		@ILogService private readonly logService: ILogService,
+	) {
+		super();
+
+		this.scheduler = this._register(new RunOnceScheduler(() => this.probe(), PROBE_DEBOUNCE_MS));
+
+		this._register(this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(PositronGallerySourceConfigKey) || e.affectsConfiguration(PositronCustomGalleryUrlConfigKey)) {
+				this.cancelInFlight();
+				this.scheduler.schedule();
+			}
+		}));
+
+		// Startup advisory: probe once if the user is already on a custom gallery.
+		if (this.isCustom()) {
+			this.scheduler.schedule();
+		}
+	}
+
+	override dispose(): void {
+		// Cancel any in-flight probe so it cannot notify after disposal.
+		this.cancelInFlight();
+		super.dispose();
+	}
+
+	private isCustom(): boolean {
+		return this.configurationService.getValue<string>(PositronGallerySourceConfigKey) === 'custom';
+	}
+
+	private cancelInFlight(): void {
+		this.cts?.cancel();
+		this.cts?.dispose();
+		this.cts = undefined;
+	}
+
+	private async probe(): Promise<void> {
+		if (!this.isCustom()) {
+			return;
+		}
+		const rawUrl = (this.configurationService.getValue<string>(PositronCustomGalleryUrlConfigKey) ?? '').trim();
+		const config = deriveGalleryConfig(rawUrl, msg => this.logService.warn(`[CustomGallery] ${msg}`));
+		// Credential-free display value. For a valid config use the canonical
+		// serviceUrl (minus /gallery); otherwise redact the raw input so a
+		// credential-bearing URL (which is exactly why derivation failed) never
+		// reaches the notification.
+		const displayUrl = config ? config.serviceUrl.replace(/\/gallery$/, '') : redactUrlForDisplay(rawUrl);
+
+		const outcome: ProbeOutcome = config
+			? await this.requestQuery(`${config.serviceUrl}/extensionquery`)
+			: { kind: 'invalid-url' };
+
+		const decision = interpretProbeResult(outcome);
+		if (decision.notify) {
+			if (this.warnOnce.shouldWarn(rawUrl)) {
+				this.notificationService.warn(localize(
+					'positron.extensions.customGallery.unreachable',
+					"Couldn't reach the custom extension gallery at {0}: {1}.", displayUrl, decision.reason
+				));
+			}
+		} else {
+			this.warnOnce.clear();
+		}
+	}
+
+	private async requestQuery(url: string): Promise<ProbeOutcome> {
+		// Defensive: supersede any probe still in flight before starting a new one.
+		this.cancelInFlight();
+		this.cts = new CancellationTokenSource();
+		try {
+			const context = await this.requestService.request({
+				type: 'POST',
+				url,
+				data: JSON.stringify(buildProbeQueryBody()),
+				headers: { 'Content-Type': 'application/json', 'Accept': 'application/json;api-version=3.0-preview.1' },
+				timeout: PROBE_TIMEOUT_MS,
+				callSite: 'positronCustomGalleryValidation.probe',
+			}, this.cts.token);
+
+			const status = context.res.statusCode ?? 0;
+			let hasResultsArray = false;
+			try {
+				const body = await asJson<{ results?: unknown[] }>(context);
+				hasResultsArray = Array.isArray(body?.results);
+			} catch {
+				hasResultsArray = false;
+			}
+			return { kind: 'http', status, hasResultsArray };
+		} catch (error) {
+			const reason = error instanceof Error ? error.message : String(error);
+			this.logService.warn(`[CustomGallery] probe failed for ${url}: ${reason}`);
+			return { kind: 'error', reason: 'connection failed' };
+		}
+	}
+}

--- a/src/vs/workbench/contrib/extensions/test/common/positronCustomGalleryProbe.vitest.ts
+++ b/src/vs/workbench/contrib/extensions/test/common/positronCustomGalleryProbe.vitest.ts
@@ -1,0 +1,93 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { interpretProbeResult, WarnOnceCache, buildProbeQueryBody, redactUrlForDisplay } from '../../common/positronCustomGalleryProbe.js';
+
+describe('interpretProbeResult', () => {
+	it('notifies for an invalid URL', () => {
+		expect(interpretProbeResult({ kind: 'invalid-url' }).notify).toBe(true);
+	});
+
+	it('does not notify on 2xx with a results array', () => {
+		expect(interpretProbeResult({ kind: 'http', status: 200, hasResultsArray: true }).notify).toBe(false);
+	});
+
+	it('notifies on 2xx without a results array', () => {
+		expect(interpretProbeResult({ kind: 'http', status: 200, hasResultsArray: false }).notify).toBe(true);
+	});
+
+	it('notifies on a non-2xx status, including the status', () => {
+		const result = interpretProbeResult({ kind: 'http', status: 404, hasResultsArray: false });
+		expect(result.notify).toBe(true);
+		expect(result.notify && result.reason).toContain('404');
+	});
+
+	it('notifies on a network error with the reason', () => {
+		const result = interpretProbeResult({ kind: 'error', reason: 'timed out' });
+		expect(result.notify).toBe(true);
+		expect(result.notify && result.reason).toBe('timed out');
+	});
+
+	it('does not notify at the 2xx boundary (299) with a results array', () => {
+		expect(interpretProbeResult({ kind: 'http', status: 299, hasResultsArray: true }).notify).toBe(false);
+	});
+
+	it('notifies for a status just below 2xx (199)', () => {
+		expect(interpretProbeResult({ kind: 'http', status: 199, hasResultsArray: true }).notify).toBe(true);
+	});
+});
+
+describe('WarnOnceCache', () => {
+	it('warns the first time a failing value is seen, then suppresses repeats', () => {
+		const cache = new WarnOnceCache();
+		expect(cache.shouldWarn('https://a.example.com')).toBe(true);
+		expect(cache.shouldWarn('https://a.example.com')).toBe(false);
+	});
+
+	it('warns again when the value changes', () => {
+		const cache = new WarnOnceCache();
+		expect(cache.shouldWarn('https://a.example.com')).toBe(true);
+		expect(cache.shouldWarn('https://b.example.com')).toBe(true);
+	});
+
+	it('clears the cache so a previously-warned value warns again', () => {
+		const cache = new WarnOnceCache();
+		expect(cache.shouldWarn('https://a.example.com')).toBe(true);
+		cache.clear();
+		expect(cache.shouldWarn('https://a.example.com')).toBe(true);
+	});
+});
+
+describe('buildProbeQueryBody', () => {
+	it('builds a minimal single-result extension query', () => {
+		const body = buildProbeQueryBody();
+		expect(Array.isArray(body.filters)).toBe(true);
+		expect(body.filters[0].pageSize).toBe(1);
+	});
+});
+
+describe('redactUrlForDisplay', () => {
+	it('strips credentials from a URL', () => {
+		expect(redactUrlForDisplay('https://user:pass@host.example.com/vscode')).toBe('https://host.example.com/vscode');
+	});
+
+	it('leaves a credential-free URL unchanged (trailing slash stripped)', () => {
+		expect(redactUrlForDisplay('https://host.example.com/vscode')).toBe('https://host.example.com/vscode');
+	});
+
+	it('returns unparseable input trimmed as-is (cannot contain URL credentials)', () => {
+		expect(redactUrlForDisplay('  not a url  ')).toBe('not a url');
+	});
+
+	it('strips a trailing slash on the root path', () => {
+		expect(redactUrlForDisplay('https://host.example.com/')).toBe('https://host.example.com');
+	});
+
+	it('strips query and fragment, which may carry tokens', () => {
+		expect(redactUrlForDisplay('https://host.example.com/vscode?token=secret#frag')).toBe('https://host.example.com/vscode');
+	});
+});

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/positronCustomGalleryValidation.vitest.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/positronCustomGalleryValidation.vitest.ts
@@ -1,0 +1,81 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { IRequestContext, IRequestOptions } from '../../../../../base/parts/request/common/request.js';
+import { IConfigurationChangeEvent } from '../../../../../platform/configuration/common/configuration.js';
+import { PositronGallerySourceConfigKey, PositronCustomGalleryUrlConfigKey } from '../../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
+import { IRequestService } from '../../../../../platform/request/common/request.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { PositronCustomGalleryValidation } from '../../electron-browser/positronCustomGalleryValidation.js';
+
+type RequestFn = (options: IRequestOptions, token: CancellationToken) => Promise<IRequestContext>;
+
+describe('PositronCustomGalleryValidation', () => {
+
+	function makeRequest(impl?: RequestFn): ReturnType<typeof vi.fn<RequestFn>> {
+		return vi.fn<RequestFn>(impl);
+	}
+
+	function makeContribution(values: Record<string, string>, request: ReturnType<typeof makeRequest>) {
+		const configService = new TestConfigurationService(values);
+		const requestService = stubInterface<IRequestService>({ request });
+		const notification = stubInterface<INotificationService>({ warn: vi.fn() });
+		const log = stubInterface<ILogService>({ warn: vi.fn(), error: vi.fn() });
+		return new PositronCustomGalleryValidation(configService, requestService, notification, log);
+	}
+
+	beforeEach(() => vi.useFakeTimers());
+	afterEach(() => vi.useRealTimers());
+
+	it('debounces rapid changes into a single probe', async () => {
+		// Minimal IRequestContext stub: the contribution only reads res.statusCode
+		// and passes the context to asJson (which will throw on a stub stream,
+		// caught internally). The cast is a narrowing cast -- the value is
+		// structurally compatible with what the contribution consumes.
+		// eslint-disable-next-line local/code-no-dangerous-type-assertions -- narrowing cast: only res.statusCode is read by contribution
+		const fakeContext = { res: { statusCode: 200, headers: {} }, stream: null } as unknown as IRequestContext;
+		const request = makeRequest(() => Promise.resolve(fakeContext));
+		const configService = new TestConfigurationService({
+			[PositronGallerySourceConfigKey]: 'custom',
+			[PositronCustomGalleryUrlConfigKey]: 'https://a.example.com/vscode',
+		});
+		const requestService = stubInterface<IRequestService>({ request });
+		const notification = stubInterface<INotificationService>({ warn: vi.fn() });
+		const log = stubInterface<ILogService>({ warn: vi.fn(), error: vi.fn() });
+		const contribution = new PositronCustomGalleryValidation(configService, requestService, notification, log);
+
+		// Minimal IConfigurationChangeEvent that only supplies affectsConfiguration.
+		const evt = stubInterface<IConfigurationChangeEvent>({ affectsConfiguration: () => true });
+
+		// Fire multiple rapid changes - they should collapse into one probe.
+		configService.onDidChangeConfigurationEmitter.fire(evt);
+		configService.onDidChangeConfigurationEmitter.fire(evt);
+		configService.onDidChangeConfigurationEmitter.fire(evt);
+
+		// Advance past debounce. The startup probe + 3 fired changes all collapse.
+		await vi.advanceTimersByTimeAsync(800);
+
+		// All the scheduling collapses: only 1 request call total.
+		expect(request).toHaveBeenCalledTimes(1);
+		contribution.dispose();
+	});
+
+	it('does not probe when the source is not custom', async () => {
+		const request = makeRequest();
+		const contribution = makeContribution(
+			{ [PositronGallerySourceConfigKey]: 'posit-p3m', [PositronCustomGalleryUrlConfigKey]: '' },
+			request,
+		);
+		await vi.advanceTimersByTimeAsync(800);
+		expect(request).not.toHaveBeenCalled();
+		contribution.dispose();
+	});
+});

--- a/src/vs/workbench/services/extensionManagement/browser/extensionGalleryManifestService.ts
+++ b/src/vs/workbench/services/extensionManagement/browser/extensionGalleryManifestService.ts
@@ -14,7 +14,7 @@ import { localize } from '../../../../nls.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 // eslint-disable-next-line no-duplicate-imports
-import { IExtensionGalleryManifest, PositronGallerySourceConfigKey } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
+import { IExtensionGalleryManifest, PositronGallerySourceConfigKey, PositronCustomGalleryUrlConfigKey } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
 // eslint-disable-next-line no-duplicate-imports
 import { ExtensionGalleryConfig, resolvePositronGalleryConfig } from '../../../../platform/extensionManagement/common/extensionGalleryManifestService.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
@@ -55,19 +55,37 @@ export class WebExtensionGalleryManifestService extends ExtensionGalleryManifest
 		}
 		// --- Start Positron ---
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
-			if (!e.affectsConfiguration(PositronGallerySourceConfigKey)) {
+			if (!e.affectsConfiguration(PositronGallerySourceConfigKey) && !e.affectsConfiguration(PositronCustomGalleryUrlConfigKey)) {
 				return;
 			}
 			// Re-parse and report so the user is told again if the env var is
 			// malformed; only a valid env var actually overrides the setting.
 			const envGallery = this.reportEnv();
-			handleGallerySourceSettingChange(envGallery, this.notificationService, () => this.requestRestart());
+			// When a valid env var is overriding, handleGallerySourceSettingChange
+			// notifies without restarting. Otherwise restart only when the change
+			// resolves to a different gallery (e.g. setting the custom URL before
+			// selecting Custom is a no-op).
+			handleGallerySourceSettingChange(envGallery, this.notificationService, () => {
+				const resolved = resolvePositronGalleryConfig(
+					envGallery,
+					this.configurationService.getValue<string>(PositronGallerySourceConfigKey),
+					this.configurationService.getValue<string>(PositronCustomGalleryUrlConfigKey),
+					super.getGalleryConfig(),
+				);
+				if (resolved?.serviceUrl !== this.activeGalleryServiceUrl) {
+					this.requestRestart();
+				}
+			});
 		}));
 		// --- End Positron ---
 	}
 
 	// --- Start Positron ---
 	private extensionGalleryManifestPromise: Promise<IExtensionGalleryManifest | null> | undefined;
+	// The resolved gallery serviceUrl in effect at startup; used to restart only
+	// when a setting change resolves to a different gallery (see desktop service).
+	private activeGalleryServiceUrl: string | undefined;
+	private activeGalleryCaptured = false;
 
 	/**
 	 * Cache the manifest so getGalleryConfig() -- which reports the
@@ -81,11 +99,19 @@ export class WebExtensionGalleryManifestService extends ExtensionGalleryManifest
 	}
 
 	protected override getGalleryConfig(): ExtensionGalleryConfig | undefined {
-		return resolvePositronGalleryConfig(
+		const resolved = resolvePositronGalleryConfig(
 			this.reportEnv(),
 			this.configurationService.getValue<string>(PositronGallerySourceConfigKey),
+			this.configurationService.getValue<string>(PositronCustomGalleryUrlConfigKey),
 			super.getGalleryConfig(),
 		);
+		// Capture the gallery in effect this session on first resolution, so a later
+		// settings change can tell whether it resolves to a different gallery.
+		if (!this.activeGalleryCaptured) {
+			this.activeGalleryCaptured = true;
+			this.activeGalleryServiceUrl = resolved?.serviceUrl;
+		}
+		return resolved;
 	}
 
 	/**

--- a/src/vs/workbench/services/extensionManagement/electron-browser/extensionGalleryManifestService.ts
+++ b/src/vs/workbench/services/extensionManagement/electron-browser/extensionGalleryManifestService.ts
@@ -31,7 +31,7 @@ import { env } from '../../../../base/common/process.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 // eslint-disable-next-line no-duplicate-imports
-import { PositronGallerySourceConfigKey } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
+import { PositronGallerySourceConfigKey, PositronCustomGalleryUrlConfigKey } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
 // eslint-disable-next-line no-duplicate-imports
 import { ExtensionGalleryConfig, resolvePositronGalleryConfig } from '../../../../platform/extensionManagement/common/extensionGalleryManifestService.js';
 import { handleGallerySourceSettingChange, reportExtensionsGalleryEnv, showWindowLog } from '../common/extensionGalleryManifestEnvReporting.js';
@@ -97,15 +97,31 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 			this.notificationService,
 			() => showWindowLog(this.instantiationService),
 		);
-		return resolvePositronGalleryConfig(
+		const resolved = resolvePositronGalleryConfig(
 			envGallery,
 			gallerySource,
+			this.configurationService.getValue<string>(PositronCustomGalleryUrlConfigKey),
 			super.getGalleryConfig(),
 		);
+		// Capture the gallery in effect this session on first resolution, so a later
+		// settings change can tell whether it resolves to a different gallery (and
+		// thus needs a restart) without prompting for no-op edits.
+		if (!this.activeGalleryCaptured) {
+			this.activeGalleryCaptured = true;
+			this.activeGalleryServiceUrl = resolved?.serviceUrl;
+		}
+		return resolved;
 	}
 	// --- End Positron ---
 
 	private extensionGalleryManifestPromise: Promise<void> | undefined;
+	// --- Start Positron ---
+	// The resolved gallery serviceUrl in effect at startup. A gallery-setting
+	// change only needs a restart if it resolves to a *different* serviceUrl, so
+	// we compare against this rather than prompting on every edit.
+	private activeGalleryServiceUrl: string | undefined;
+	private activeGalleryCaptured = false;
+	// --- End Positron ---
 	override async getExtensionGalleryManifest(): Promise<IExtensionGalleryManifest | null> {
 		if (!this.extensionGalleryManifestPromise) {
 			this.extensionGalleryManifestPromise = this.doGetExtensionGalleryManifest();
@@ -131,17 +147,36 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
 			// --- Start Positron ---
-			if (e.affectsConfiguration(PositronGallerySourceConfigKey)) {
+			// The gallery source and the custom URL resolve together (see
+			// resolvePositronGalleryConfig), so a change to either may affect the
+			// active gallery.
+			if (e.affectsConfiguration(PositronGallerySourceConfigKey) || e.affectsConfiguration(PositronCustomGalleryUrlConfigKey)) {
+				const gallerySource = this.configurationService.getValue<string>(PositronGallerySourceConfigKey);
 				// Re-parse and report so the user is told again if the env var is
 				// malformed; only a valid env var actually overrides the setting.
 				const envGallery = reportExtensionsGalleryEnv(
 					env['EXTENSIONS_GALLERY'],
-					this.configurationService.getValue<string>(PositronGallerySourceConfigKey),
+					gallerySource,
 					this.logService,
 					this.notificationService,
 					() => showWindowLog(this.instantiationService),
 				);
-				handleGallerySourceSettingChange(envGallery, this.notificationService, () => this.requestRestart());
+				// When a valid env var is overriding, handleGallerySourceSettingChange
+				// notifies without restarting. Otherwise it invokes our callback, which
+				// only restarts when the change resolves to a *different* gallery --
+				// setting the custom URL before selecting Custom (or selecting Custom
+				// with an empty URL) is a no-op and must not prompt.
+				handleGallerySourceSettingChange(envGallery, this.notificationService, () => {
+					const resolved = resolvePositronGalleryConfig(
+						envGallery,
+						gallerySource,
+						this.configurationService.getValue<string>(PositronCustomGalleryUrlConfigKey),
+						super.getGalleryConfig(),
+					);
+					if (resolved?.serviceUrl !== this.activeGalleryServiceUrl) {
+						this.requestRestart();
+					}
+				});
 				return;
 			}
 			// --- End Positron ---


### PR DESCRIPTION
This PR does two things:

- Adds support for pointing the extension gallery at a custom Open VSX-compatible server (for example a self-hosted Posit Package Manager), which previously was only possible via the undiscoverable `EXTENSIONS_GALLERY` environment variable (see #13415)
  - A new `Custom` option activates a new `Custom Gallery Url` setting. Both the built-in presets and the custom URL now derive their full gallery endpoints from a single base URL through one `deriveGalleryConfig()` helper, so the Open VSX URL scheme lives in one place and presets and custom URLs cannot drift.
- The second part fixes a pre-existing cross-gallery fallback: the resource ("unpkg") API in `extensionGalleryService` used the product-default gallery as a hard-coded fallback, so a request that failed against a non-default gallery would silently leak to the default gallery.


Here are some screenshots of the configuration and a request going through:
<img width="786" height="411" alt="image" src="https://github.com/user-attachments/assets/8eab3b7f-9306-4b9d-8e39-0de973912d54" />
<img width="640" height="136" alt="image" src="https://github.com/user-attachments/assets/f1fc9735-5414-4aab-b805-b5c031ed1113" />


### Release Notes

#### New Features

- Add support for configuring a custom Open VSX-compatible extension gallery, such as a self-hosted Posit Package Manager, via the Extension Gallery Source and Custom Gallery Url settings.

#### Bug Fixes

- Stop a non-default extension gallery (custom or Open VSX) from silently falling back to the default gallery when a resource request fails.

### Validation Steps

1. Open Settings and search for "Extension Gallery Source"; set it to **Custom**
2. Set **Custom Gallery Url** to a valid Open VSX-compatible base URL, e.g. `https://open-vsx.org/vscode`. Restart, open the Extensions view, and confirm extensions load from the configured gallery
3. **Restart-prompt timing:** with Source = Custom, edit the URL before selecting Custom (or select Custom with an empty URL) and confirm no premature restart prompt; the prompt appears only once the change resolves to a different gallery.
4. Enter an unreachable URL (e.g. `https://nope.invalid/vscode`) and confirm a single warning notification (no spam while typing); enter `https://user:pass@host/vscode` and confirm it is rejected with no credentials shown.
5. **No cross-gallery leak:** with Source = Custom pointed at an unreachable/erroring host, confirm requests do **not** fall back to `p3m.dev` (check the Network tab / Dev Tools); the failure stays within the configured gallery.
6. If `EXTENSIONS_GALLERY` is set to a valid value, confirm changing the settings shows the "environment variable is overriding" notification and does not restart.
7. Switch back to **Posit Public Package Manager** and confirm extensions still load.