### PR TITLE
Add configurable shared Quarto execution sessions

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoKernelManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoKernelManager.ts
@@ -7,7 +7,7 @@ import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
-import { ResourceMap } from '../../../../base/common/map.js';
+import { ResourceMap, ResourceSet } from '../../../../base/common/map.js';
 import { Action } from '../../../../base/common/actions.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
@@ -26,7 +26,7 @@ import { IEditorService } from '../../../services/editor/common/editorService.js
 import { ITextModel } from '../../../../editor/common/model.js';
 import { timeout } from '../../../../base/common/async.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { POSITRON_QUARTO_INLINE_OUTPUT_KEY, isQuartoOrRmdFile } from '../common/positronQuartoConfig.js';
+import { POSITRON_QUARTO_EXECUTION_USE_SHARED_SESSION_KEY, POSITRON_QUARTO_INLINE_OUTPUT_KEY, isQuartoOrRmdFile, usingQuartoSharedExecutionSession } from '../common/positronQuartoConfig.js';
 import { IQuartoOutputCacheService } from '../common/quartoExecutionTypes.js';
 
 export const IQuartoKernelManager = createDecorator<IQuartoKernelManager>('quartoKernelManager');
@@ -125,6 +125,15 @@ interface DocumentKernelInfo {
 	language: string | undefined;
 	disposables: DisposableStore;
 	startupCancellation: CancellationTokenSource | undefined;
+	sharedKey: string | undefined;
+}
+
+/**
+ * Runtime session shared by compatible Quarto documents.
+ */
+interface SharedKernelInfo {
+	session: ILanguageRuntimeSession;
+	documents: ResourceSet;
 }
 
 /** Storage key for persisted kernel selections. */
@@ -138,6 +147,12 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 	declare readonly _serviceBrand: undefined;
 
 	private readonly _documentKernels = new ResourceMap<DocumentKernelInfo>();
+
+	/** Shared Quarto sessions keyed by compatible runtime identity. */
+	private readonly _sharedKernels = new Map<string, SharedKernelInfo>();
+
+	/** Shared Quarto sessions currently starting, keyed by compatible runtime identity. */
+	private readonly _startingSharedKernels = new Map<string, Promise<ILanguageRuntimeSession | undefined>>();
 
 	/** Persisted runtime selections keyed by document URI string. */
 	private readonly _kernelBindings = new Map<string, string>();
@@ -190,7 +205,7 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 					const stillOpen = this._editorService.findEditors(uri).length > 0;
 					if (!stillOpen) {
 						this._logService.debug(`[QuartoKernelManager] Document closed, cleaning up: ${uri.toString()}`);
-						await this.shutdownKernelForDocument(uri);
+						await this._releaseKernelForDocument(uri);
 					}
 				}, 100);
 				this._pendingCleanupTimeouts.add(handle);
@@ -204,6 +219,11 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 				if (!enabled) {
 					this._shutdownAllKernels();
 				}
+			}
+			if (e.affectsConfiguration(POSITRON_QUARTO_EXECUTION_USE_SHARED_SESSION_KEY) &&
+				!usingQuartoSharedExecutionSession(this._configurationService)
+			) {
+				this._shutdownAllKernels();
 			}
 		}));
 
@@ -235,11 +255,109 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 		this._logService.debug('[QuartoKernelManager] Shutting down all kernels (feature disabled)');
 
 		const shutdownPromises: Promise<void>[] = [];
-		for (const [uri] of this._documentKernels) {
+		const seenSharedKeys = new Set<string>();
+		for (const [uri, info] of this._documentKernels) {
+			if (info.sharedKey) {
+				if (seenSharedKeys.has(info.sharedKey)) {
+					continue;
+				}
+				seenSharedKeys.add(info.sharedKey);
+			}
 			shutdownPromises.push(this.shutdownKernelForDocument(uri));
 		}
 
 		await Promise.allSettled(shutdownPromises);
+	}
+
+	/**
+	 * Release a document from its kernel session.
+	 *
+	 * For isolated sessions this preserves the current behavior and shuts down
+	 * the document session. For shared sessions it only detaches the released
+	 * document while other open documents still own the session.
+	 */
+	private async _releaseKernelForDocument(
+		documentUri: URI,
+		options?: { throwOnShutdownError?: boolean }
+	): Promise<void> {
+		const info = this._documentKernels.get(documentUri);
+		if (!info) {
+			return;
+		}
+
+		if (info.sharedKey) {
+			const sharedInfo = this._sharedKernels.get(info.sharedKey);
+			if (sharedInfo && sharedInfo.documents.size > 1) {
+				if (info.startupCancellation) {
+					info.startupCancellation.cancel();
+					info.startupCancellation.dispose();
+					info.startupCancellation = undefined;
+				}
+
+				this._unregisterSharedDocument(documentUri, info);
+				info.disposables.dispose();
+				this._setKernelState(documentUri, QuartoKernelState.None);
+				this._documentKernels.delete(documentUri);
+				return;
+			}
+		}
+
+		if (options?.throwOnShutdownError) {
+			await this.tryShutdownKernelForDocument(documentUri);
+		} else {
+			await this.shutdownKernelForDocument(documentUri);
+		}
+	}
+
+	/**
+	 * Shut down a shared session and clear every document attached to it.
+	 */
+	private async _shutdownSharedKernel(
+		sharedKey: string,
+		exitReason: RuntimeExitReason,
+		source: string
+	): Promise<void> {
+		const sharedInfo = this._sharedKernels.get(sharedKey);
+		if (!sharedInfo) {
+			return;
+		}
+
+		const documentUris = Array.from(sharedInfo.documents);
+		for (const uri of documentUris) {
+			this._setKernelState(uri, QuartoKernelState.ShuttingDown);
+		}
+
+		try {
+			const notebookUri = sharedInfo.session.metadata.notebookUri;
+			if (notebookUri) {
+				await this._runtimeSessionService.shutdownNotebookSession(
+					notebookUri,
+					exitReason,
+					source,
+				);
+			} else {
+				await sharedInfo.session.shutdown(exitReason);
+			}
+		} finally {
+			for (const uri of documentUris) {
+				const info = this._documentKernels.get(uri);
+				if (!info) {
+					continue;
+				}
+
+				if (info.startupCancellation) {
+					info.startupCancellation.cancel();
+					info.startupCancellation.dispose();
+					info.startupCancellation = undefined;
+				}
+
+				info.disposables.dispose();
+				info.sharedKey = undefined;
+				this._setKernelState(uri, QuartoKernelState.None);
+				this._documentKernels.delete(uri);
+			}
+			this._sharedKernels.delete(sharedKey);
+		}
 	}
 
 	/**
@@ -262,9 +380,19 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 			language: session.runtimeMetadata.languageId,
 			disposables: new DisposableStore(),
 			startupCancellation: undefined,
+			sharedKey: undefined,
 		};
 
 		this._documentKernels.set(documentUri, info);
+
+		if (usingQuartoSharedExecutionSession(this._configurationService)) {
+			this._registerSharedDocument(
+				this._getSharedKernelKey(session.runtimeMetadata),
+				documentUri,
+				session,
+				info,
+			);
+		}
 
 		// Set up session event listeners
 		this._setupSessionListeners(documentUri, session, info);
@@ -349,6 +477,156 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 			default:
 				return QuartoKernelState.None;
 		}
+	}
+
+	/**
+	 * Whether a runtime session can be used for Quarto execution.
+	 */
+	private _isUsableSession(session: ILanguageRuntimeSession): boolean {
+		const state = session.getRuntimeState();
+		return state !== RuntimeState.Exited && state !== RuntimeState.Uninitialized;
+	}
+
+	/**
+	 * Key used to find compatible shared Quarto sessions.
+	 *
+	 * Runtime IDs already include the interpreter/runtime identity selected by
+	 * the runtime infrastructure, so this stays language-agnostic while keeping
+	 * unrelated runtimes isolated.
+	 */
+	private _getSharedKernelKey(runtime: ILanguageRuntimeMetadata): string {
+		return runtime.runtimeId;
+	}
+
+	/**
+	 * Track a document as an owner of a shared session.
+	 */
+	private _registerSharedDocument(
+		sharedKey: string,
+		documentUri: URI,
+		session: ILanguageRuntimeSession,
+		info: DocumentKernelInfo
+	): void {
+		let sharedInfo = this._sharedKernels.get(sharedKey);
+		if (!sharedInfo ||
+			sharedInfo.session.sessionId !== session.sessionId ||
+			!this._isUsableSession(sharedInfo.session)
+		) {
+			sharedInfo = {
+				session,
+				documents: new ResourceSet(),
+			};
+			this._sharedKernels.set(sharedKey, sharedInfo);
+		}
+
+		sharedInfo.documents.add(documentUri);
+		info.sharedKey = sharedKey;
+	}
+
+	/**
+	 * Remove a document from its shared session owner set.
+	 */
+	private _unregisterSharedDocument(documentUri: URI, info: DocumentKernelInfo): SharedKernelInfo | undefined {
+		const sharedKey = info.sharedKey;
+		if (!sharedKey) {
+			return undefined;
+		}
+
+		const sharedInfo = this._sharedKernels.get(sharedKey);
+		sharedInfo?.documents.delete(documentUri);
+		info.sharedKey = undefined;
+
+		if (sharedInfo && sharedInfo.documents.size === 0) {
+			this._sharedKernels.delete(sharedKey);
+		}
+
+		return sharedInfo;
+	}
+
+	/**
+	 * Find an existing Quarto-owned session that can be shared by the requested runtime.
+	 */
+	private _findReusableSharedSession(runtime: ILanguageRuntimeMetadata): ILanguageRuntimeSession | undefined {
+		const sharedKey = this._getSharedKernelKey(runtime);
+		const sharedInfo = this._sharedKernels.get(sharedKey);
+		if (sharedInfo) {
+			if (this._isUsableSession(sharedInfo.session)) {
+				return sharedInfo.session;
+			}
+			this._sharedKernels.delete(sharedKey);
+		}
+
+		for (const [documentUri, info] of this._documentKernels) {
+			const session = info.session;
+			if (!session ||
+				session.runtimeMetadata.runtimeId !== runtime.runtimeId ||
+				!this._isUsableSession(session)
+			) {
+				continue;
+			}
+
+			this._registerSharedDocument(sharedKey, documentUri, session, info);
+			return session;
+		}
+
+		return undefined;
+	}
+
+	/**
+	 * Attach a document to an existing shared session.
+	 */
+	private async _useSharedSession(
+		documentUri: URI,
+		info: DocumentKernelInfo,
+		runtime: ILanguageRuntimeMetadata,
+		session: ILanguageRuntimeSession,
+		token: CancellationToken
+	): Promise<ILanguageRuntimeSession | undefined> {
+		if (!this._isUsableSession(session)) {
+			return undefined;
+		}
+		if (token.isCancellationRequested) {
+			return undefined;
+		}
+
+		const cleanupAttachment = () => {
+			this._unregisterSharedDocument(documentUri, info);
+			info.disposables.dispose();
+			info.disposables = new DisposableStore();
+			info.session = undefined;
+			this._setKernelState(documentUri, QuartoKernelState.None);
+		};
+
+		info.session = session;
+		info.language = session.runtimeMetadata.languageId;
+		this._registerSharedDocument(this._getSharedKernelKey(runtime), documentUri, session, info);
+		this._setupSessionListeners(documentUri, session, info);
+		this._setKernelState(documentUri, this._runtimeStateToKernelState(session.getRuntimeState()));
+
+		const state = session.getRuntimeState();
+		if (state !== RuntimeState.Ready && state !== RuntimeState.Idle) {
+			try {
+				await this._waitForSessionReady(session, token);
+			} catch (error) {
+				cleanupAttachment();
+				throw error;
+			}
+			if (token.isCancellationRequested) {
+				cleanupAttachment();
+				return undefined;
+			}
+			this._setKernelState(documentUri, QuartoKernelState.Ready);
+		}
+		if (token.isCancellationRequested) {
+			cleanupAttachment();
+			return undefined;
+		}
+
+		this._logService.debug(
+			`[QuartoKernelManager] Reusing shared ${runtime.languageId} kernel ` +
+			`${session.sessionId} for ${documentUri.toString()}`
+		);
+		return session;
 	}
 
 	/**
@@ -621,6 +899,15 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 			return;
 		}
 
+		if (info.sharedKey) {
+			await this._shutdownSharedKernel(
+				info.sharedKey,
+				RuntimeExitReason.Shutdown,
+				'Quarto shared kernel shutdown',
+			);
+			return;
+		}
+
 		// Cancel any pending startup
 		if (info.startupCancellation) {
 			info.startupCancellation.cancel();
@@ -693,7 +980,7 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 		// so that the user can still switch to the new kernel.
 		const oldRuntimeName = this._documentKernels.get(documentUri)?.session?.runtimeMetadata.runtimeName;
 		try {
-			await this.tryShutdownKernelForDocument(documentUri);
+			await this._releaseKernelForDocument(documentUri, { throwOnShutdownError: true });
 		} catch (error) {
 			this._logService.error(`[QuartoKernelManager] Failed to shut down existing kernel for ${documentUri.toString()}:`, error);
 			this._notificationService.warn(
@@ -791,6 +1078,7 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 				language: undefined,
 				disposables: new DisposableStore(),
 				startupCancellation: undefined,
+				sharedKey: undefined,
 			};
 			this._documentKernels.set(documentUri, info);
 		}
@@ -801,6 +1089,11 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 
 		// Update state to starting
 		this._setKernelState(documentUri, QuartoKernelState.Starting);
+
+		let sharedKey: string | undefined;
+		let resolveSharedStart: ((session: ILanguageRuntimeSession | undefined) => void) | undefined;
+		let rejectSharedStart: ((error: unknown) => void) | undefined;
+		let sharedStartPromise: Promise<ILanguageRuntimeSession | undefined> | undefined;
 
 		try {
 			// Get the document's language from the Quarto document model
@@ -861,13 +1154,49 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 				return undefined;
 			}
 
+			sharedKey = usingQuartoSharedExecutionSession(this._configurationService)
+				? this._getSharedKernelKey(runtime)
+				: undefined;
+			if (sharedKey) {
+				const reusableSession = this._findReusableSharedSession(runtime);
+				if (reusableSession) {
+					return this._useSharedSession(documentUri, info, runtime, reusableSession, cts.token);
+				}
+
+				const startingSharedSession = this._startingSharedKernels.get(sharedKey);
+				if (startingSharedSession) {
+					try {
+						const session = await startingSharedSession;
+						if (session && !cts.token.isCancellationRequested) {
+							return this._useSharedSession(documentUri, info, runtime, session, cts.token);
+						}
+					} catch (error) {
+						this._logService.debug(
+							`[QuartoKernelManager] Shared kernel startup failed for ${runtime.runtimeId}; starting a new session`,
+							error
+						);
+					}
+				}
+			}
+
 			// Use the filename (with extension) as the session name. Untitled
 			// Quarto URIs don't include the .qmd extension, so append it here.
 			let fileName = documentUri.path.split('/').pop() ?? '';
 			if (!isQuartoOrRmdFile(fileName)) {
 				fileName = `${fileName}.qmd`;
 			}
-			const sessionName = fileName;
+			const sessionName = sharedKey
+				? localize('quartoKernel.sharedSessionName', "Quarto: {0}", runtime.runtimeName)
+				: fileName;
+
+			if (sharedKey) {
+				sharedStartPromise = new Promise((resolve, reject) => {
+					resolveSharedStart = resolve;
+					rejectSharedStart = reject;
+				});
+				this._startingSharedKernels.set(sharedKey, sharedStartPromise);
+			}
+
 			const sessionId = await this._runtimeSessionService.startNewRuntimeSession(
 				runtime.runtimeId,
 				sessionName,
@@ -884,6 +1213,7 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 				if (session) {
 					await session.shutdown();
 				}
+				resolveSharedStart?.(undefined);
 				return undefined;
 			}
 
@@ -893,6 +1223,9 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 			}
 
 			info.session = session;
+			if (sharedKey) {
+				this._registerSharedDocument(sharedKey, documentUri, session, info);
+			}
 
 			// Set up session event listeners
 			this._setupSessionListeners(documentUri, session, info);
@@ -902,19 +1235,28 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 
 			if (cts.token.isCancellationRequested) {
 				await session.shutdown();
+				this._unregisterSharedDocument(documentUri, info);
+				resolveSharedStart?.(undefined);
 				return undefined;
 			}
 
 			this._setKernelState(documentUri, QuartoKernelState.Ready);
 			this._logService.debug(`[QuartoKernelManager] Kernel ready for ${documentUri.toString()}`);
+			resolveSharedStart?.(session);
 
 			return session;
 		} catch (error) {
 			if (cts.token.isCancellationRequested) {
+				resolveSharedStart?.(undefined);
 				return undefined;
 			}
+			rejectSharedStart?.(error);
 			throw error;
 		} finally {
+			if (sharedKey && sharedStartPromise && this._startingSharedKernels.get(sharedKey) === sharedStartPromise) {
+				this._startingSharedKernels.delete(sharedKey);
+			}
+
 			// Only clear the cancellation source if it's still the current one
 			if (info.startupCancellation === cts) {
 				info.startupCancellation = undefined;
@@ -939,6 +1281,7 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 		// Listen for session end
 		info.disposables.add(session.onDidEndSession(() => {
 			this._logService.debug(`[QuartoKernelManager] Session ended for ${documentUri.toString()}`);
+			this._unregisterSharedDocument(documentUri, info);
 			info.session = undefined;
 			this._setKernelState(documentUri, QuartoKernelState.None);
 		}));
@@ -1177,17 +1520,21 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 		this._pendingCleanupTimeouts.clear();
 
 		// Shutdown all sessions
+		const shuttingDownSessionIds = new Set<string>();
 		for (const [, info] of this._documentKernels) {
 			info.startupCancellation?.cancel();
 			info.startupCancellation?.dispose();
 			info.disposables.dispose();
-			if (info.session) {
+			if (info.session && !shuttingDownSessionIds.has(info.session.sessionId)) {
+				shuttingDownSessionIds.add(info.session.sessionId);
 				Promise.resolve(info.session.shutdown()).catch((e: unknown) => {
 					this._logService.warn(`[QuartoKernelManager] Error during disposal: ${e}`);
 				});
 			}
 		}
 		this._documentKernels.clear();
+		this._sharedKernels.clear();
+		this._startingSharedKernels.clear();
 		super.dispose();
 	}
 }

--- a/src/vs/workbench/contrib/positronQuarto/common/positronQuartoConfig.ts
+++ b/src/vs/workbench/contrib/positronQuarto/common/positronQuartoConfig.ts
@@ -25,6 +25,11 @@ export const POSITRON_QUARTO_INLINE_OUTPUT_KEY = 'positron.quarto.inlineOutput.e
 export const POSITRON_QUARTO_INLINE_OUTPUT_MAX_LINES_KEY = 'positron.quarto.inlineOutput.maxLines';
 
 /**
+ * Configuration key for sharing one execution session across compatible Quarto documents.
+ */
+export const POSITRON_QUARTO_EXECUTION_USE_SHARED_SESSION_KEY = 'positron.quarto.execution.useSharedSession';
+
+/**
  * Context key for whether Quarto inline output is enabled.
  * Used for conditionally showing commands and menus.
  */
@@ -94,6 +99,15 @@ configurationRegistry.registerConfiguration({
 			),
 			scope: ConfigurationScope.WINDOW,
 		},
+		[POSITRON_QUARTO_EXECUTION_USE_SHARED_SESSION_KEY]: {
+			type: 'boolean',
+			default: false,
+			markdownDescription: localize(
+				'positron.quarto.execution.useSharedSession',
+				'Reuse a compatible execution session across Quarto documents when inline output is enabled. When disabled, each Quarto document uses an isolated execution session.'
+			),
+			scope: ConfigurationScope.WINDOW,
+		},
 	},
 });
 
@@ -104,6 +118,15 @@ configurationRegistry.registerConfiguration({
  */
 export function usingQuartoInlineOutput(configurationService: IConfigurationService): boolean {
 	return configurationService.getValue<boolean>(POSITRON_QUARTO_INLINE_OUTPUT_KEY) ?? false;
+}
+
+/**
+ * Helper function to check if Quarto documents should reuse compatible sessions.
+ * @param configurationService The configuration service instance
+ * @returns true if shared Quarto execution sessions are enabled
+ */
+export function usingQuartoSharedExecutionSession(configurationService: IConfigurationService): boolean {
+	return configurationService.getValue<boolean>(POSITRON_QUARTO_EXECUTION_USE_SHARED_SESSION_KEY) ?? false;
 }
 
 /**

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoKernelManager.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoKernelManager.vitest.ts
@@ -24,6 +24,7 @@ import { IEditorIdentifier, IEditorCloseEvent } from '../../../../common/editor.
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { EditorInput } from '../../../../common/editor/editorInput.js';
 import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
+import { POSITRON_QUARTO_EXECUTION_USE_SHARED_SESSION_KEY } from '../../common/positronQuartoConfig.js';
 
 function makeRuntime(id: string, languageId: string, name: string): ILanguageRuntimeMetadata {
 	return {
@@ -49,6 +50,8 @@ const pythonRuntime2 = makeRuntime('python-3.12', 'python', 'Python 3.12');
 const rRuntime1 = makeRuntime('r-4.4', 'r', 'R 4.4');
 
 const docUri = URI.file('/test/doc.qmd');
+const docUri2 = URI.file('/test/doc-two.qmd');
+const docUri3 = URI.file('/test/doc-three.qmd');
 
 describe('QuartoKernelManager', () => {
 	const disposables = ensureNoLeakedDisposables();
@@ -56,11 +59,15 @@ describe('QuartoKernelManager', () => {
 	let kernelManager: QuartoKernelManager;
 	let runtimeStartupService: TestRuntimeStartupService;
 	let storageService: InMemoryStorageService;
+	let configurationService: TestConfigurationService;
 
 	// Track calls to startNewRuntimeSession
 	let startedRuntimeIds: string[];
+	let sessionNames: string[];
 	let shutdownUris: URI[];
 	let nextSessionId: number;
+	let sessionsById: Map<string, ILanguageRuntimeSession>;
+	let notebookSessionsByUri: Map<string, ILanguageRuntimeSession>;
 
 	// Mutable state for mocks that tests can override
 	let primaryLanguage: string;
@@ -78,37 +85,69 @@ describe('QuartoKernelManager', () => {
 		runtimeStartupService.setPreferredRuntime('r', rRuntime1);
 
 		storageService = disposables.add(new InMemoryStorageService());
+		configurationService = new TestConfigurationService();
 
 		startedRuntimeIds = [];
+		sessionNames = [];
 		shutdownUris = [];
 		nextSessionId = 0;
+		sessionsById = new Map();
+		notebookSessionsByUri = new Map();
 		primaryLanguage = 'python';
 		registeredRuntimes = [pythonRuntime1, pythonRuntime2, rRuntime1];
 
 		const mockRuntimeSessionService = stubInterface<IRuntimeSessionService>({
-			async startNewRuntimeSession(runtimeId: string, _name: string, _mode: LanguageRuntimeSessionMode, _notebookUri?: URI) {
+			async startNewRuntimeSession(runtimeId: string, name: string, mode: LanguageRuntimeSessionMode, notebookUri?: URI) {
 				startedRuntimeIds.push(runtimeId);
-				return `session-${nextSessionId++}`;
-			},
-			getSession(_id: string) {
-				// Return a minimal session that passes the _waitForSessionReady check
-				// by being already idle, and supports shutdown/state queries.
-				return stubInterface<ILanguageRuntimeSession>({
-					sessionId: `session-${nextSessionId - 1}`,
-					runtimeMetadata: startedRuntimeIds.length > 0
-						? findRuntimeById(startedRuntimeIds[startedRuntimeIds.length - 1])
-						: pythonRuntime1,
+				sessionNames.push(name);
+
+				const sessionId = `session-${nextSessionId++}`;
+				const metadata = {
+					sessionId,
+					sessionMode: mode,
+					notebookUri,
+					createdTimestamp: Date.now(),
+					startReason: 'test',
+				};
+				const runtime = findRuntimeById(runtimeId);
+				const session = stubInterface<ILanguageRuntimeSession>({
+					sessionId,
+					metadata,
+					runtimeMetadata: runtime,
 					getRuntimeState() { return RuntimeState.Idle; },
 					onDidChangeRuntimeState: Event.None,
 					onDidCompleteStartup: Event.None,
 					onDidEncounterStartupFailure: Event.None,
 					onDidEndSession: Event.None,
-					async shutdown(_reason: RuntimeExitReason) { /* no-op */ },
+					async shutdown(_reason?: RuntimeExitReason) {
+						sessionsById.delete(sessionId);
+						if (notebookUri) {
+							notebookSessionsByUri.delete(notebookUri.toString());
+						}
+					},
+					interrupt() { /* no-op */ },
 				});
+				sessionsById.set(sessionId, session);
+				if (notebookUri) {
+					notebookSessionsByUri.set(notebookUri.toString(), session);
+				}
+				return sessionId;
 			},
-			getNotebookSessionForNotebookUri(_uri: URI) { return undefined; },
+			getSession(id: string) {
+				return sessionsById.get(id);
+			},
+			getNotebookSessionForNotebookUri(uri: URI) {
+				return notebookSessionsByUri.get(uri.toString());
+			},
 			getActiveSessions() { return []; },
-			async shutdownNotebookSession(uri: URI) { shutdownUris.push(uri); },
+			async shutdownNotebookSession(uri: URI) {
+				shutdownUris.push(uri);
+				const session = notebookSessionsByUri.get(uri.toString());
+				if (session) {
+					sessionsById.delete(session.sessionId);
+					notebookSessionsByUri.delete(uri.toString());
+				}
+			},
 			onDidStartRuntime: Event.None,
 		});
 
@@ -129,7 +168,7 @@ describe('QuartoKernelManager', () => {
 				return [stubInterface<IEditorIdentifier>({
 					editor: stubInterface<EditorInput>({
 						resolve: async () => ({
-							textEditorModel: { uri: docUri, getLanguageId: () => 'quarto' },
+							textEditorModel: { uri: _uri, getLanguageId: () => 'quarto' },
 							dispose() { },
 						}),
 					}),
@@ -148,7 +187,7 @@ describe('QuartoKernelManager', () => {
 			mockEditorService,
 			new NullLogService(),
 			stubInterface<INotificationService>({ warn: vi.fn(), info: vi.fn(), notify: vi.fn() }),
-			new TestConfigurationService(),
+			configurationService,
 			storageService,
 			mockCacheService,
 		));
@@ -157,6 +196,65 @@ describe('QuartoKernelManager', () => {
 	it('ensureKernelForDocument uses preferred runtime by default', async () => {
 		await kernelManager.ensureKernelForDocument(docUri);
 		expect(startedRuntimeIds).toEqual(['python-3.11']);
+	});
+
+	it('keeps separate sessions for separate documents by default', async () => {
+		const session1 = await kernelManager.ensureKernelForDocument(docUri);
+		const session2 = await kernelManager.ensureKernelForDocument(docUri2);
+
+		expect(session1?.sessionId).not.toBe(session2?.sessionId);
+		expect(startedRuntimeIds).toEqual(['python-3.11', 'python-3.11']);
+	});
+
+	it('reuses a compatible session when shared sessions are enabled', async () => {
+		await configurationService.setUserConfiguration(POSITRON_QUARTO_EXECUTION_USE_SHARED_SESSION_KEY, true);
+
+		const session1 = await kernelManager.ensureKernelForDocument(docUri);
+		const session2 = await kernelManager.ensureKernelForDocument(docUri2);
+
+		expect(session2?.sessionId).toBe(session1?.sessionId);
+		expect(startedRuntimeIds).toEqual(['python-3.11']);
+		expect(sessionNames).toEqual(['Quarto: Python 3.11']);
+	});
+
+	it('does not share sessions across different runtimes', async () => {
+		await configurationService.setUserConfiguration(POSITRON_QUARTO_EXECUTION_USE_SHARED_SESSION_KEY, true);
+
+		const pythonSession = await kernelManager.ensureKernelForDocument(docUri);
+		primaryLanguage = 'r';
+		const rSession = await kernelManager.ensureKernelForDocument(docUri3);
+
+		expect(rSession?.sessionId).not.toBe(pythonSession?.sessionId);
+		expect(startedRuntimeIds).toEqual(['python-3.11', 'r-4.4']);
+	});
+
+	it('changing one shared document kernel does not shut down a session still used by another document', async () => {
+		await configurationService.setUserConfiguration(POSITRON_QUARTO_EXECUTION_USE_SHARED_SESSION_KEY, true);
+
+		const originalSession = await kernelManager.ensureKernelForDocument(docUri);
+		const sharedSession = await kernelManager.ensureKernelForDocument(docUri2);
+		expect(sharedSession?.sessionId).toBe(originalSession?.sessionId);
+
+		await kernelManager.changeKernelForDocument(docUri2, pythonRuntime2.runtimeId);
+
+		expect(shutdownUris).toEqual([]);
+		expect(kernelManager.getSessionForDocument(docUri)?.sessionId).toBe(originalSession?.sessionId);
+		expect(kernelManager.getSessionForDocument(docUri2)?.sessionId).not.toBe(originalSession?.sessionId);
+		expect(startedRuntimeIds).toEqual(['python-3.11', 'python-3.12']);
+	});
+
+	it('shutdown of a shared kernel clears all attached documents', async () => {
+		await configurationService.setUserConfiguration(POSITRON_QUARTO_EXECUTION_USE_SHARED_SESSION_KEY, true);
+
+		const session1 = await kernelManager.ensureKernelForDocument(docUri);
+		const session2 = await kernelManager.ensureKernelForDocument(docUri2);
+		expect(session2?.sessionId).toBe(session1?.sessionId);
+
+		await kernelManager.shutdownKernelForDocument(docUri2);
+
+		expect(shutdownUris.map(uri => uri.toString())).toEqual([docUri.toString()]);
+		expect(kernelManager.getKernelState(docUri)).toBe(QuartoKernelState.None);
+		expect(kernelManager.getKernelState(docUri2)).toBe(QuartoKernelState.None);
 	});
 
 	it('changeKernelForDocument shuts down old session and starts new runtime', async () => {


### PR DESCRIPTION
Fixes #12732

Adds an optional Quarto execution mode that lets compatible Quarto documents reuse the same inline execution session. The new setting is disabled by default, so existing per-document session isolation remains unchanged unless users explicitly opt in.

Implementation notes:

- Adds `positron.quarto.execution.useSharedSession`, default `false`.
- Keeps the existing isolated notebook-session startup path when the setting is disabled.
- Adds Quarto-level shared session tracking keyed by `runtimeMetadata.runtimeId`, avoiding language-specific assumptions.
- Reuses existing compatible sessions, including in-progress shared startups.
- Detaches a closed or kernel-switched document from a shared session while other attached documents keep using it.
- Treats explicit shared-kernel shutdown as shutdown for all attached documents.

### Release Notes

#### New Features

- Added `positron.quarto.execution.useSharedSession` to optionally reuse compatible Quarto inline execution sessions across documents.

#### Bug Fixes

- N/A


### Validation Steps

Automated validation:

- `npm run compile-check-ts-native`
- `npx vitest run src/vs/workbench/contrib/positronQuarto/test/browser/quartoKernelManager.vitest.ts`
- `npx vitest run src/vs/workbench/contrib/positronQuarto/test/browser`

Manual validation to perform before merge:

1. Leave `positron.quarto.execution.useSharedSession` disabled.
2. Open two Quarto documents with the same compatible runtime.
3. Execute a variable assignment in document A.
4. Execute a reference to that variable in document B.
5. Verify document B does not see document A's variable.
6. Enable `positron.quarto.execution.useSharedSession`.
7. Repeat the same execution flow.
8. Verify document B can see document A's variable when both documents use the same compatible runtime.
9. Switch one document to a different runtime and verify it does not reuse the original shared session.
10. Close or switch one attached document and verify the remaining attached document can continue using the shared session.
