### PR TITLE
Add Cmd/Ctrl+Click to open a data frame in the Data Explorer, gated on the RStudio keymap

### DIFF
--- a/src/vs/editor/contrib/gotoSymbol/browser/link/clickToViewProvider.ts
+++ b/src/vs/editor/contrib/gotoSymbol/browser/link/clickToViewProvider.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { Position } from '../../../../common/core/position.js';
+import { ITextModel } from '../../../../common/model.js';
+
+/**
+ * A provider that can handle a modifier+click (Cmd/Ctrl+Click) on an identifier
+ * in the editor before go-to-definition runs.
+ *
+ * This is the editor-layer seam that lets the workbench redirect a click on,
+ * say, a data frame to the Data Explorer instead of navigating to its
+ * definition. It lives here (rather than as an injected service) because there
+ * is no `@optional` DI decorator in this codebase and go-to-definition must keep
+ * working in the standalone editor, where nothing registers a provider.
+ */
+export interface IClickToViewProvider {
+	/**
+	 * Attempt to handle a modifier+click at the given position.
+	 *
+	 * @returns `true` if the click was handled and go-to-definition should be
+	 * skipped; `false` to fall through to the normal go-to-definition behavior.
+	 * Implementations must not throw: a rejected promise is treated as unhandled.
+	 */
+	handleClick(model: ITextModel, position: Position): Promise<boolean>;
+}
+
+/**
+ * The single registered click-to-view provider, or `undefined` when none is
+ * registered (e.g. the standalone editor). A single slot is sufficient: only
+ * one workbench contribution registers a provider.
+ */
+let provider: IClickToViewProvider | undefined;
+
+/**
+ * Registers the click-to-view provider consulted by go-to-definition on
+ * modifier+click. Registering replaces any previous provider; disposing the
+ * returned {@link IDisposable} clears it (only if it is still the current one).
+ */
+export function registerClickToViewProvider(newProvider: IClickToViewProvider): IDisposable {
+	provider = newProvider;
+	return toDisposable(() => {
+		if (provider === newProvider) {
+			provider = undefined;
+		}
+	});
+}
+
+/**
+ * Returns the registered click-to-view provider, or `undefined` if none.
+ */
+export function getClickToViewProvider(): IClickToViewProvider | undefined {
+	return provider;
+}

--- a/src/vs/editor/contrib/gotoSymbol/browser/link/goToDefinitionAtPosition.ts
+++ b/src/vs/editor/contrib/gotoSymbol/browser/link/goToDefinitionAtPosition.ts
@@ -22,6 +22,9 @@ import { LocationLink } from '../../../../common/languages.js';
 import { ILanguageService } from '../../../../common/languages/language.js';
 import { ITextModelService } from '../../../../common/services/resolverService.js';
 import { ClickLinkGesture, ClickLinkKeyboardEvent, ClickLinkMouseEvent } from './clickLinkGesture.js';
+// --- Start Positron ---
+import { getClickToViewProvider } from './clickToViewProvider.js';
+// --- End Positron ---
 import { PeekContext } from '../../../peekView/browser/peekView.js';
 import * as nls from '../../../../../nls.js';
 import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
@@ -60,7 +63,29 @@ export class GotoDefinitionAtPositionEditorContribution implements IEditorContri
 			this.startFindDefinitionFromMouse(mouseEvent, keyboardEvent ?? undefined);
 		}));
 
-		this.toUnhook.add(linkGesture.onExecute((mouseEvent: ClickLinkMouseEvent) => {
+		// --- Start Positron ---
+		// this.toUnhook.add(linkGesture.onExecute((mouseEvent: ClickLinkMouseEvent) => {
+		//
+		// Give a registered click-to-view provider (e.g. a data frame -> Data
+		// Explorer gesture) the first chance to handle a modifier+click, before
+		// go-to-definition. This is deliberately gated on isClickCandidate rather
+		// than isEnabled, so it does not require a definition provider for the
+		// model: language features in Quarto chunks and some runtimes (e.g.
+		// R/Python via vdocs) are not registered against the visible document's
+		// model. If the provider handles the click, skip go-to-definition so the
+		// two gestures don't both fire. The listener is made async to await the
+		// provider.
+
+		this.toUnhook.add(linkGesture.onExecute(async (mouseEvent: ClickLinkMouseEvent) => {
+			if (this.isClickCandidate(mouseEvent)) {
+				const provider = getClickToViewProvider();
+				const model = this.editor.getModel();
+				if (provider && model && await provider.handleClick(model, mouseEvent.target.position!)) {
+					this.removeLinkDecorations();
+					return;
+				}
+			}
+			// --- End Positron ---
 			if (this.isEnabled(mouseEvent)) {
 				this.gotoDefinition(mouseEvent.target.position!, mouseEvent.hasSideBySideModifier)
 					.catch((error: Error) => {
@@ -280,6 +305,23 @@ export class GotoDefinitionAtPositionEditorContribution implements IEditorContri
 	private removeLinkDecorations(): void {
 		this.linkDecorations.clear();
 	}
+
+	// --- Start Positron ---
+	// A modifier+click on real editor text: isEnabled without the
+	// definitionProvider.has(...) requirement. Duplicated (rather than factored
+	// out of isEnabled) to keep the upstream isEnabled untouched for easier
+	// merges. Lets a click-to-view provider handle a click even when no
+	// definition provider is registered for the model (e.g. Quarto chunks, or
+	// R/Python served via vdocs).
+	private isClickCandidate(mouseEvent: ClickLinkMouseEvent, withKey?: ClickLinkKeyboardEvent): boolean {
+		return this.editor.hasModel()
+			&& mouseEvent.isLeftClick
+			&& mouseEvent.isNoneOrSingleMouseDown
+			&& mouseEvent.target.type === MouseTargetType.CONTENT_TEXT
+			&& !(mouseEvent.target.detail.injectedText?.options instanceof ModelDecorationInjectedTextOptions)
+			&& (mouseEvent.hasTriggerModifier || (withKey ? withKey.keyCodeIsTriggerKey : false));
+	}
+	// --- End Positron ---
 
 	private isEnabled(mouseEvent: ClickLinkMouseEvent, withKey?: ClickLinkKeyboardEvent): boolean {
 		return this.editor.hasModel()

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerClickToViewProvider.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerClickToViewProvider.ts
@@ -1,0 +1,98 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { IPosition } from '../../../../editor/common/core/position.js';
+import { ITextModel } from '../../../../editor/common/model.js';
+import { ILanguageService } from '../../../../editor/common/languages/language.js';
+import { IClickToViewProvider, registerClickToViewProvider } from '../../../../editor/contrib/gotoSymbol/browser/link/clickToViewProvider.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
+import { IPositronVariablesService } from '../../../services/positronVariables/common/interfaces/positronVariablesService.js';
+import { IViewsService } from '../../../services/views/common/viewsService.js';
+import { IViewDataFrameByVariableArgs, PositronDataExplorerCommandId } from './positronDataExplorerActions.js';
+import { resolveDataFrameAtPosition } from './positronDataExplorerResolveDataFrame.js';
+
+/**
+ * The RStudio keybindings setting, declared in
+ * positronKeybindings.contribution.ts. Referenced by string here because that
+ * contribution does not export a constant for it; keep in sync if it moves.
+ */
+const RSTUDIO_KEYBINDINGS_SETTING = 'workbench.keybindings.rstudioKeybindings';
+
+/**
+ * Redirects a modifier+click (Cmd/Ctrl+Click) on a data frame identifier to the
+ * Data Explorer, before go-to-definition runs.
+ *
+ * This is the RStudio "Ctrl+Click to view" gesture. It is gated on the RStudio
+ * keymap setting so it only overrides go-to-definition for the cohort that
+ * expects it; default / VS Code users keep plain go-to-definition on
+ * Cmd+Click. The gesture itself is delivered by the editor's go-to-definition
+ * contribution (a mouse modifier gesture, which the keybindings registry cannot
+ * bind), so this provider does the gating live via the configuration service.
+ *
+ * Resolution runs with `wait: false` and `openVariablesViewIfNeeded: false` so
+ * the click is instant and free of side effects, and go-to-definition (which
+ * awaits this provider) is never delayed on a cold Variables pane: if the symbol
+ * is not an already-known viewable data frame, the click falls through to
+ * go-to-definition.
+ */
+export class PositronDataExplorerClickToViewContribution extends Disposable implements IClickToViewProvider {
+
+	static readonly ID = 'workbench.contrib.positronDataExplorerClickToView';
+
+	constructor(
+		@ICommandService private readonly _commandService: ICommandService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@ILanguageService private readonly _languageService: ILanguageService,
+		@IRuntimeSessionService private readonly _runtimeSessionService: IRuntimeSessionService,
+		@IPositronVariablesService private readonly _variablesService: IPositronVariablesService,
+		@IViewsService private readonly _viewsService: IViewsService,
+	) {
+		super();
+		this._register(registerClickToViewProvider(this));
+	}
+
+	async handleClick(model: ITextModel, position: IPosition): Promise<boolean> {
+		try {
+			// Gated on the RStudio keymap. Read live: the setting can change
+			// without a click contribution restart. Compare against `true` so an
+			// unset (undefined) value can't slip through.
+			if (this._configurationService.getValue<boolean>(RSTUDIO_KEYBINDINGS_SETTING) !== true) {
+				return false;
+			}
+
+			const resolution = await resolveDataFrameAtPosition(
+				model,
+				position,
+				{
+					languageService: this._languageService,
+					runtimeSessionService: this._runtimeSessionService,
+					variablesService: this._variablesService,
+					viewsService: this._viewsService,
+				},
+				{ wait: false, openVariablesViewIfNeeded: false },
+			);
+			if (resolution.kind !== 'ok') {
+				return false;
+			}
+
+			const args: IViewDataFrameByVariableArgs = {
+				sessionId: resolution.sessionId,
+				variableId: resolution.item.id,
+			};
+			await this._commandService.executeCommand(
+				PositronDataExplorerCommandId.ViewDataFrameByVariableAction,
+				args,
+			);
+			return true;
+		} catch {
+			// Never let a resolution or open error break go-to-definition; treat
+			// it as unhandled so the click falls through.
+			return false;
+		}
+	}
+}

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts
@@ -18,6 +18,7 @@ import { PositronDataExplorerEditor } from './positronDataExplorerEditor.js';
 import { PositronDataExplorerEditorInput } from './positronDataExplorerEditorInput.js';
 import { registerPositronDataExplorerActions } from './positronDataExplorerActions.js';
 import { PositronDataExplorerCodeActionContribution } from './positronDataExplorerCodeActionProvider.js';
+import { PositronDataExplorerClickToViewContribution } from './positronDataExplorerClickToViewProvider.js';
 import { PositronDataExplorerSheetSelector } from './positronDataExplorerSheetSelector.js';
 import { POSITRON_DATA_EXPLORER_IS_ACTIVE_EDITOR, POSITRON_DATA_EXPLORER_IS_XLSX } from './positronDataExplorerContextKeys.js';
 import { extname } from '../../../../base/common/resources.js';
@@ -153,6 +154,15 @@ registerPositronDataExplorerActions();
 registerWorkbenchContribution2(
 	PositronDataExplorerCodeActionContribution.ID,
 	PositronDataExplorerCodeActionContribution,
+	WorkbenchPhase.AfterRestored
+);
+
+// Register the "Cmd/Ctrl+Click to open a data frame in the Data Explorer"
+// gesture. Gated on the RStudio keymap; takes precedence over go-to-definition
+// only for that cohort.
+registerWorkbenchContribution2(
+	PositronDataExplorerClickToViewContribution.ID,
+	PositronDataExplorerClickToViewContribution,
 	WorkbenchPhase.AfterRestored
 );
 

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/test/browser/positronDataExplorerClickToViewProvider.vitest.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/test/browser/positronDataExplorerClickToViewProvider.vitest.ts
@@ -1,0 +1,155 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { URI } from '../../../../../base/common/uri.js';
+import { Position } from '../../../../../editor/common/core/position.js';
+import { ITextModel } from '../../../../../editor/common/model.js';
+import { ILanguageService } from '../../../../../editor/common/languages/language.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { LanguageRuntimeSessionMode } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
+import { ILanguageRuntimeSession, IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
+import { IPositronVariablesInstance } from '../../../../services/positronVariables/common/interfaces/positronVariablesInstance.js';
+import { IPositronVariablesService } from '../../../../services/positronVariables/common/interfaces/positronVariablesService.js';
+import { IVariableItem } from '../../../../services/positronVariables/common/interfaces/variableItem.js';
+import { IViewsService } from '../../../../services/views/common/viewsService.js';
+import { Event } from '../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { PositronDataExplorerCommandId } from '../../browser/positronDataExplorerActions.js';
+import { PositronDataExplorerClickToViewContribution } from '../../browser/positronDataExplorerClickToViewProvider.js';
+
+const SESSION_ID = 'test-session-id';
+const RSTUDIO_KEYBINDINGS_SETTING = 'workbench.keybindings.rstudioKeybindings';
+
+// Test doubles below use `as unknown as <Service>` because the services have
+// large surface areas we don't exercise. Disabling the rule locally keeps the
+// helpers readable; the trade-off is that a real missing field won't be caught
+// by the compiler -- acceptable for tightly scoped unit tests.
+/* eslint-disable local/code-no-dangerous-type-assertions */
+const makeSession = (languageId: string, sessionId = SESSION_ID): ILanguageRuntimeSession =>
+({
+	sessionId,
+	runtimeMetadata: { languageId },
+	metadata: { sessionMode: LanguageRuntimeSessionMode.Console },
+} as unknown as ILanguageRuntimeSession);
+
+const makeModel = (options: { word?: string; languageIdAtPosition?: string; uri?: URI } = {}): ITextModel => {
+	const { word, languageIdAtPosition = 'r', uri = URI.parse('file:///test.R') } = options;
+	return {
+		uri,
+		getWordAtPosition: vi.fn().mockReturnValue(word ? { word, startColumn: 1, endColumn: word.length + 1 } : null),
+		getLanguageIdAtPosition: () => languageIdAtPosition,
+	} as unknown as ITextModel;
+};
+
+const makeVariableItem = (overrides: Partial<IVariableItem> = {}): IVariableItem =>
+({
+	id: 'item-id',
+	path: [],
+	hasViewer: true,
+	displayName: 'df',
+	view: vi.fn().mockResolvedValue(undefined),
+	...overrides,
+} as unknown as IVariableItem);
+
+const makeVariablesInstance = (items: IVariableItem[], sessionId = SESSION_ID): IPositronVariablesInstance =>
+({
+	session: { sessionId },
+	variableItems: items,
+	onDidChangeEntries: Event.None,
+} as unknown as IPositronVariablesInstance);
+/* eslint-enable local/code-no-dangerous-type-assertions */
+
+describe('PositronDataExplorerClickToViewContribution', () => {
+	let session: ILanguageRuntimeSession | undefined;
+	let variablesInstances: IPositronVariablesInstance[];
+	let rstudioKeybindingsEnabled: boolean;
+	let openViewStub: ReturnType<typeof vi.fn<(...args: unknown[]) => Promise<unknown>>>;
+	let executeCommandStub: ReturnType<typeof vi.fn<(...args: unknown[]) => Promise<unknown>>>;
+	const disposables = new DisposableStore();
+
+	const ctx = createTestContainer()
+		.stub(ICommandService, {
+			executeCommand: (...args: unknown[]) => executeCommandStub(...args),
+		})
+		.stub(IConfigurationService, {
+			getValue: (key: string) => key === RSTUDIO_KEYBINDINGS_SETTING ? rstudioKeybindingsEnabled : undefined,
+		})
+		.stub(ILanguageService, {
+			getLanguageName: (id: string) => id === 'r' ? 'R' : id === 'python' ? 'Python' : null,
+		})
+		.stub(IRuntimeSessionService, {
+			getConsoleSessionForLanguage: () => session,
+			getNotebookSessionForNotebookUri: () => undefined,
+			get activeSessions() { return []; },
+		})
+		.stub(IPositronVariablesService, {
+			get positronVariablesInstances() { return variablesInstances; },
+		})
+		.stub(IViewsService, {
+			openView: (...args: unknown[]) => openViewStub(...args),
+		})
+		.build();
+
+	beforeEach(() => {
+		session = makeSession('r');
+		variablesInstances = [makeVariablesInstance([makeVariableItem({ displayName: 'df' })])];
+		rstudioKeybindingsEnabled = true;
+		openViewStub = vi.fn().mockResolvedValue(null);
+		executeCommandStub = vi.fn().mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		disposables.clear();
+	});
+
+	const handleClick = (model: ITextModel) => {
+		const provider = disposables.add(ctx.instantiationService.createInstance(PositronDataExplorerClickToViewContribution));
+		return provider.handleClick(model, new Position(1, 1));
+	};
+
+	it('opens the data frame and skips go-to-definition when the symbol is a viewable data frame', async () => {
+		const handled = await handleClick(makeModel({ word: 'df' }));
+
+		expect(handled).toBe(true);
+		expect(executeCommandStub).toHaveBeenCalledWith(
+			PositronDataExplorerCommandId.ViewDataFrameByVariableAction,
+			{ sessionId: SESSION_ID, variableId: 'item-id' },
+		);
+	});
+
+	it('falls through to go-to-definition when the RStudio keymap is off', async () => {
+		rstudioKeybindingsEnabled = false;
+
+		const handled = await handleClick(makeModel({ word: 'df' }));
+
+		expect(handled).toBe(false);
+		expect(executeCommandStub).not.toHaveBeenCalled();
+	});
+
+	it('falls through without running the command when the symbol is not a viewable data frame', async () => {
+		const handled = await handleClick(makeModel({ word: 'missing' }));
+
+		expect(handled).toBe(false);
+		expect(executeCommandStub).not.toHaveBeenCalled();
+	});
+
+	it('falls through when resolution throws, so a failure never breaks go-to-definition', async () => {
+		// eslint-disable-next-line local/code-no-dangerous-type-assertions -- model whose word lookup throws
+		const throwingModel = {
+			uri: URI.parse('file:///test.R'),
+			getWordAtPosition: () => { throw new Error('boom'); },
+			getLanguageIdAtPosition: () => 'r',
+		} as unknown as ITextModel;
+
+		const handled = await handleClick(throwingModel);
+
+		expect(handled).toBe(false);
+		expect(executeCommandStub).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Relates to #2974

> [!IMPORTANT]
> **This is a proposal for discussion.** It works and is tested, but it takes on a new core change to how clicks in the editor are handled. I am honestly not sure if we want to own that, or whether we would rather close this and point people at the code action instead.

This PR adds RStudio-style <kbd>Ctrl/Cmd+Click</kbd> on a data frame in the editor to open it in the Data Explorer. Confirmed working in `.R`, `.py`, and `.qmd` (R and Python chunks).

It is gated on the RStudio keymap setting (`workbench.keybindings.rstudioKeybindings`), so it is opt-in and users are unaffected by default. In those cases, <kbd>Ctrl/Cmd+Click</kbd> keeps going to definition. For users who have the RStudio keymap on, clicking a viewable data frame opens the Data Explorer, and every other symbol still goes to definition (or to references at the definition site, exactly as today). <kbd>F2</kbd> stays pure go-to-definition. This matches RStudio's behavior and is pretty much the request in #2974.

### The decision to make

**Do we want to take on a core go-to-definition change to deliver this gesture, or not?**

<kbd>Ctrl/Cmd+Click</kbd> is owned by the editor's go-to-definition contribution. There is no free modifier and no coordination between click gestures, so the only clean way to let data frames override navigation (rather than double-fire) is to have go-to-definition consult us first. That requires one small, fenced edit to an upstream file (`editor/contrib/gotoSymbol/browser/link/goToDefinitionAtPosition.ts`); everything else is new Positron files. The upstream touch is pretty minimal, but it is still a fundamental change to how clicks are handled.

We already shipped, in this same area, the *View Data Frame at Cursor* command (command palette + editor context menu) and the *Open in Data Explorer* code action (<kbd>Cmd+.</kbd>). Both are universal, need no upstream changes, and cover the same intent. If we would rather not own a core go-to-definition change, we can close this and tell people to use those instead. I would be very comfortable with that! 😅 

### How it is built

- **Editor-layer seam:** a new `clickToViewProvider.ts` holds a single-provider registry. Go-to-definition consults it on a modifier+click before navigating and skips navigation only if the provider handled the click. It is a registry rather than an injected service because this codebase has no `@optional` DI decorator, and this way the standalone Monaco editor simply no-ops.
- **Upstream edit:** `goToDefinitionAtPosition.ts` gains that one guarded consult, wrapped in `// --- Start/End Positron ---`, with the original listener line kept commented out.
- **Workbench provider:** `positronDataExplorerClickToViewProvider.ts` reads the RStudio keymap setting live and reuses the existing `resolveDataFrameAtPosition` resolver and `viewDataFrameByVariable` command. It resolves with `wait: false` and no side effects, so go-to-definition (which awaits the provider) is never delayed and the click never opens the Variables pane as a side effect.

### Release Notes

#### New Features

- <kbd>Ctrl/Cmd+Click</kbd> a data frame in the editor to open it in the Data Explorer, when the RStudio keymap is enabled (#2974)

#### Bug Fixes

- N/A

### Validation Steps

@:data-explorer @:editor @:variables

1. Enable **Settings > Keybindings: RStudio Keybindings** (`workbench.keybindings.rstudioKeybindings`) and restart.
2. Open an `.R`, a `.py`, and a `.qmd` file, and start an R and a Python session.
3. Define a data frame, for example `df <- data.frame(x = 1:3)` (R) or `df = pd.DataFrame({"x": [1, 2, 3]})` (Python), and run it so it appears in the Variables pane.
4. <kbd>Ctrl/Cmd+Click</kbd> the data frame's name in the editor and confirm the Data Explorer opens on it (including inside R and Python chunks of the `.qmd`).
5. <kbd>Ctrl/Cmd+Click</kbd> a function or a non-data-frame symbol and confirm it still goes to definition.
6. Turn the RStudio keymap off, restart, and confirm <kbd>Ctrl/Cmd+Click</kbd> always goes to definition.
