### PR TITLE
Auth: prefer user setting over env var for provider base url

### DIFF
--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -20,7 +20,7 @@ import {
 } from './constants';
 import { AuthProvider } from './authProvider';
 import { registerAuthProvider, providerAction, updateProviderFromSessions, authProviders } from './configDialog';
-import { getProviderSources } from './providerSources';
+import { getEffectiveBaseUrl, getProviderSources } from './providerSources';
 import {
 	normalizeToV1Url,
 	validateAnthropicApiKey,
@@ -148,20 +148,6 @@ async function registerAnthropicProvider(
 ): Promise<void> {
 	const logger = new AuthProviderLogger('Anthropic');
 
-	// Sync ANTHROPIC_BASE_URL env var to the config setting before
-	// chain resolution so validation uses the correct endpoint.
-	const envBaseUrl = process.env.ANTHROPIC_BASE_URL;
-	if (envBaseUrl) {
-		await vscode.workspace
-			.getConfiguration('authentication.anthropic')
-			.update(
-				'baseUrl', envBaseUrl,
-				vscode.ConfigurationTarget.Global
-			).then(undefined, err =>
-				logger.logOperationError('sync Anthropic base URL', err)
-			);
-	}
-
 	const provider = new AuthProvider(
 		ANTHROPIC_AUTH_PROVIDER_ID, 'Anthropic', context,
 		undefined,
@@ -171,9 +157,7 @@ async function registerAnthropicProvider(
 				if (!apiKey) {
 					throw new Error('ANTHROPIC_API_KEY not set');
 				}
-				const baseUrl = vscode.workspace
-					.getConfiguration('authentication.anthropic')
-					.get<string>('baseUrl') || undefined;
+				const baseUrl = getEffectiveBaseUrl('anthropic');
 				await validateAnthropicApiKey(apiKey, { baseUrl });
 				return apiKey;
 			},
@@ -455,18 +439,6 @@ async function registerSnowflakeProvider(context: vscode.ExtensionContext): Prom
 async function registerOpenaiProvider(
 	context: vscode.ExtensionContext
 ): Promise<void> {
-	const envBaseUrl = process.env.OPENAI_BASE_URL;
-	if (envBaseUrl) {
-		await vscode.workspace
-			.getConfiguration(`authentication.${OPENAI_AUTH_PROVIDER_ID}`)
-			.update(
-				'baseUrl', envBaseUrl,
-				vscode.ConfigurationTarget.Global
-			).then(undefined, err =>
-				log.error(`Failed to sync OpenAI base URL: ${err}`)
-			);
-	}
-
 	const provider = new AuthProvider(
 		OPENAI_AUTH_PROVIDER_ID, 'OpenAI', context,
 		undefined,
@@ -476,9 +448,7 @@ async function registerOpenaiProvider(
 				if (!apiKey) {
 					throw new Error('OPENAI_API_KEY not set');
 				}
-				const baseUrl = vscode.workspace
-					.getConfiguration(`authentication.${OPENAI_AUTH_PROVIDER_ID}`)
-					.get<string>('baseUrl') || undefined;
+				const baseUrl = getEffectiveBaseUrl(OPENAI_AUTH_PROVIDER_ID);
 				await validateOpenaiApiKey(apiKey, { baseUrl });
 				return apiKey;
 			},
@@ -516,18 +486,6 @@ async function registerOpenaiProvider(
 async function registerGeminiProvider(
 	context: vscode.ExtensionContext
 ): Promise<void> {
-	const envBaseUrl = process.env.GEMINI_BASE_URL;
-	if (envBaseUrl) {
-		await vscode.workspace
-			.getConfiguration(`authentication.${GEMINI_AUTH_PROVIDER_ID}`)
-			.update(
-				'baseUrl', envBaseUrl,
-				vscode.ConfigurationTarget.Global
-			).then(undefined, err =>
-				log.error(`Failed to sync Gemini base URL: ${err}`)
-			);
-	}
-
 	const provider = new AuthProvider(
 		GEMINI_AUTH_PROVIDER_ID, 'Google Gemini', context,
 		undefined,
@@ -540,9 +498,7 @@ async function registerGeminiProvider(
 						'GEMINI_API_KEY or GOOGLE_API_KEY not set'
 					);
 				}
-				const baseUrl = vscode.workspace
-					.getConfiguration(`authentication.${GEMINI_AUTH_PROVIDER_ID}`)
-					.get<string>('baseUrl') || undefined;
+				const baseUrl = getEffectiveBaseUrl(GEMINI_AUTH_PROVIDER_ID);
 				await validateGeminiApiKey(apiKey, { baseUrl });
 				return apiKey;
 			},
@@ -581,17 +537,6 @@ async function registerGoogleVertexProvider(
 	context: vscode.ExtensionContext,
 ): Promise<void> {
 	const logger = new AuthProviderLogger('Google Vertex AI');
-	const envBaseUrl = process.env.GOOGLE_VERTEX_BASE_URL;
-	if (envBaseUrl) {
-		await vscode.workspace
-			.getConfiguration('authentication.googleVertex')
-			.update(
-				'baseUrl', envBaseUrl,
-				vscode.ConfigurationTarget.Global,
-			).then(undefined, err =>
-				log.error(`Failed to sync Vertex base URL: ${err}`)
-			);
-	}
 
 	const provider = new AuthProvider(
 		GOOGLE_CLOUD_AUTH_PROVIDER_ID, 'Gemini Enterprise Agent Platform', context,
@@ -631,18 +576,6 @@ async function registerGoogleVertexProvider(
 async function registerDeepSeekProvider(
 	context: vscode.ExtensionContext
 ): Promise<void> {
-	const envBaseUrl = process.env.DEEPSEEK_BASE_URL;
-	if (envBaseUrl) {
-		await vscode.workspace
-			.getConfiguration(`authentication.${DEEPSEEK_AUTH_PROVIDER_ID}`)
-			.update(
-				'baseUrl', envBaseUrl,
-				vscode.ConfigurationTarget.Global
-			).then(undefined, err =>
-				log.error(`Failed to sync DeepSeek base URL: ${err}`)
-			);
-	}
-
 	const provider = new AuthProvider(
 		DEEPSEEK_AUTH_PROVIDER_ID, 'DeepSeek', context,
 		undefined,
@@ -652,9 +585,7 @@ async function registerDeepSeekProvider(
 				if (!apiKey) {
 					throw new Error('DEEPSEEK_API_KEY not set');
 				}
-				const baseUrl = vscode.workspace
-					.getConfiguration(`authentication.${DEEPSEEK_AUTH_PROVIDER_ID}`)
-					.get<string>('baseUrl') || undefined;
+				const baseUrl = getEffectiveBaseUrl(DEEPSEEK_AUTH_PROVIDER_ID);
 				await validateDeepSeekApiKey(apiKey, { baseUrl });
 				return apiKey;
 			},

--- a/extensions/authentication/src/providerSources.ts
+++ b/extensions/authentication/src/providerSources.ts
@@ -18,10 +18,35 @@ import {
 } from './constants';
 import { getConfiguredSnowflakeAccount } from './snowflakeCredentials';
 
-function getSavedBaseUrl(configSection: string, fallback?: string): string | undefined {
-	return vscode.workspace
+/**
+ * Config section -> `*_BASE_URL` env var, for providers whose base URL can come
+ * from the environment. A provider missing here has no env-var source.
+ */
+const BASE_URL_ENV_VARS: Record<string, string> = {
+	'anthropic': 'ANTHROPIC_BASE_URL',
+	'openai-api': 'OPENAI_BASE_URL',
+	'google': 'GEMINI_BASE_URL',
+	'googleVertex': 'GOOGLE_VERTEX_BASE_URL',
+	'deepseek-api': 'DEEPSEEK_BASE_URL',
+};
+
+/**
+ * Effective base URL for a provider, with the precedence user setting > env var
+ * > fallback. A value the user set in settings (at any scope) wins; otherwise
+ * the provider's `*_BASE_URL` env var is read live; otherwise the fallback. The
+ * env var is never written to settings, so removing it reverts cleanly to the
+ * user's setting or the fallback (#12894).
+ */
+export function getEffectiveBaseUrl(configSection: string, fallback?: string): string | undefined {
+	const inspected = vscode.workspace
 		.getConfiguration(`authentication.${configSection}`)
-		.get<string>('baseUrl') || fallback;
+		.inspect<string>('baseUrl');
+	const userValue = inspected?.workspaceFolderValue
+		?? inspected?.workspaceValue
+		?? inspected?.globalValue;
+	const envVar = BASE_URL_ENV_VARS[configSection];
+	const envValue = envVar ? process.env[envVar] : undefined;
+	return userValue || envValue || fallback;
 }
 
 export interface ProviderMetadata {
@@ -115,7 +140,7 @@ export function getProviderSources(): positron.ai.LanguageModelSource[] {
 			supportedOptions: ['apiKey', 'baseUrl', 'autoconfigure'],
 			defaults: {
 				model: 'claude-sonnet-4-latest',
-				baseUrl: getSavedBaseUrl('anthropic', 'https://api.anthropic.com'),
+				baseUrl: getEffectiveBaseUrl('anthropic', 'https://api.anthropic.com'),
 				toolCalls: true,
 				autoconfigure: {
 					type: positron.ai.LanguageModelAutoconfigureType.EnvVariable,
@@ -149,7 +174,7 @@ export function getProviderSources(): positron.ai.LanguageModelSource[] {
 			supportedOptions: ['apiKey', 'baseUrl', 'toolCalls'],
 			defaults: {
 				model: 'model-router',
-				baseUrl: getSavedBaseUrl('foundry'),
+				baseUrl: getEffectiveBaseUrl('foundry'),
 				toolCalls: true,
 			},
 		},
@@ -176,7 +201,7 @@ export function getProviderSources(): positron.ai.LanguageModelSource[] {
 			supportedOptions: ['apiKey', 'baseUrl', 'toolCalls'],
 			defaults: {
 				model: 'openai',
-				baseUrl: getSavedBaseUrl('openai-api', 'https://api.openai.com/v1'),
+				baseUrl: getEffectiveBaseUrl('openai-api', 'https://api.openai.com/v1'),
 				toolCalls: true,
 			},
 		},
@@ -186,7 +211,7 @@ export function getProviderSources(): positron.ai.LanguageModelSource[] {
 			supportedOptions: ['baseUrl', 'apiKey'],
 			defaults: {
 				model: 'gemini-2.5-flash',
-				baseUrl: getSavedBaseUrl('google', 'https://generativelanguage.googleapis.com/v1beta'),
+				baseUrl: getEffectiveBaseUrl('google', 'https://generativelanguage.googleapis.com/v1beta'),
 				apiKey: undefined,
 				toolCalls: true,
 			},
@@ -203,7 +228,7 @@ export function getProviderSources(): positron.ai.LanguageModelSource[] {
 				: ['baseUrl', 'toolCalls'],
 			defaults: {
 				model: 'gemini-2.5-flash',
-				baseUrl: getSavedBaseUrl('googleVertex', 'https://aiplatform.googleapis.com'),
+				baseUrl: getEffectiveBaseUrl('googleVertex', 'https://aiplatform.googleapis.com'),
 				toolCalls: true,
 				...(vertexFromEnv && {
 					autoconfigure: {
@@ -233,7 +258,7 @@ export function getProviderSources(): positron.ai.LanguageModelSource[] {
 			supportedOptions: ['apiKey', 'baseUrl', 'toolCalls'],
 			defaults: {
 				model: 'openai-compatible',
-				baseUrl: getSavedBaseUrl('openai-compatible', 'https://localhost:1337/v1'),
+				baseUrl: getEffectiveBaseUrl('openai-compatible', 'https://localhost:1337/v1'),
 				toolCalls: true,
 			},
 		},
@@ -243,7 +268,7 @@ export function getProviderSources(): positron.ai.LanguageModelSource[] {
 			supportedOptions: ['apiKey', 'baseUrl', 'autoconfigure'],
 			defaults: {
 				model: 'deepseek-chat',
-				baseUrl: getSavedBaseUrl('deepseek-api', 'https://api.deepseek.com'),
+				baseUrl: getEffectiveBaseUrl('deepseek-api', 'https://api.deepseek.com'),
 				toolCalls: true,
 				autoconfigure: {
 					type: positron.ai.LanguageModelAutoconfigureType.EnvVariable,

--- a/extensions/authentication/src/test/baseUrl.test.ts
+++ b/extensions/authentication/src/test/baseUrl.test.ts
@@ -8,16 +8,30 @@ import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import { getEffectiveBaseUrl } from '../providerSources';
 
-suite('getEffectiveBaseUrl', () => {
-	// `anthropic` is backed by ANTHROPIC_BASE_URL; `foundry` has no env var.
-	const ENV_VAR = 'ANTHROPIC_BASE_URL';
+/**
+ * The section -> env var contract each provider relies on. Hardcoded here
+ * independently of the implementation's map so a typo in either the section key
+ * or the env var name is caught.
+ */
+const PROVIDER_ENV_VARS: ReadonlyArray<{ section: string; envVar: string }> = [
+	{ section: 'anthropic', envVar: 'ANTHROPIC_BASE_URL' },
+	{ section: 'openai-api', envVar: 'OPENAI_BASE_URL' },
+	{ section: 'google', envVar: 'GEMINI_BASE_URL' },
+	{ section: 'googleVertex', envVar: 'GOOGLE_VERTEX_BASE_URL' },
+	{ section: 'deepseek-api', envVar: 'DEEPSEEK_BASE_URL' },
+];
 
+suite('getEffectiveBaseUrl', () => {
 	let mockInspect: sinon.SinonStub;
-	let originalEnvValue: string | undefined;
+	const savedEnv = new Map<string, string | undefined>();
 
 	setup(() => {
-		originalEnvValue = process.env[ENV_VAR];
-		delete process.env[ENV_VAR];
+		// Snapshot and clear every mapped env var so the host environment can't
+		// leak into a test.
+		for (const { envVar } of PROVIDER_ENV_VARS) {
+			savedEnv.set(envVar, process.env[envVar]);
+			delete process.env[envVar];
+		}
 
 		mockInspect = sinon.stub();
 		const mockConfig = {
@@ -31,11 +45,14 @@ suite('getEffectiveBaseUrl', () => {
 
 	teardown(() => {
 		sinon.restore();
-		if (originalEnvValue === undefined) {
-			delete process.env[ENV_VAR];
-		} else {
-			process.env[ENV_VAR] = originalEnvValue;
+		for (const [envVar, value] of savedEnv) {
+			if (value === undefined) {
+				delete process.env[envVar];
+			} else {
+				process.env[envVar] = value;
+			}
 		}
+		savedEnv.clear();
 	});
 
 	function stubInspect(values: {
@@ -46,62 +63,76 @@ suite('getEffectiveBaseUrl', () => {
 		mockInspect.returns({ key: 'baseUrl', ...values });
 	}
 
-	test('user setting wins over the env var', () => {
-		stubInspect({ globalValue: 'https://user.example.com' });
-		process.env[ENV_VAR] = 'https://env.example.com';
+	suite('precedence', () => {
+		test('user setting wins over the env var', () => {
+			stubInspect({ globalValue: 'https://user.example.com' });
+			process.env.ANTHROPIC_BASE_URL = 'https://env.example.com';
 
-		assert.strictEqual(
-			getEffectiveBaseUrl('anthropic', 'https://fallback.example.com'),
-			'https://user.example.com'
-		);
-	});
-
-	test('env var is used when the user has no setting', () => {
-		stubInspect({});
-		process.env[ENV_VAR] = 'https://env.example.com';
-
-		assert.strictEqual(
-			getEffectiveBaseUrl('anthropic', 'https://fallback.example.com'),
-			'https://env.example.com'
-		);
-	});
-
-	test('workspace value takes precedence over the global value', () => {
-		stubInspect({
-			globalValue: 'https://global.example.com',
-			workspaceValue: 'https://workspace.example.com',
+			assert.strictEqual(
+				getEffectiveBaseUrl('anthropic', 'https://fallback.example.com'),
+				'https://user.example.com'
+			);
 		});
 
-		assert.strictEqual(
-			getEffectiveBaseUrl('anthropic'),
-			'https://workspace.example.com'
-		);
+		test('env var is used when the user has no setting', () => {
+			stubInspect({});
+			process.env.ANTHROPIC_BASE_URL = 'https://env.example.com';
+
+			assert.strictEqual(
+				getEffectiveBaseUrl('anthropic', 'https://fallback.example.com'),
+				'https://env.example.com'
+			);
+		});
+
+		test('workspace value takes precedence over the global value', () => {
+			stubInspect({
+				globalValue: 'https://global.example.com',
+				workspaceValue: 'https://workspace.example.com',
+			});
+
+			assert.strictEqual(
+				getEffectiveBaseUrl('anthropic'),
+				'https://workspace.example.com'
+			);
+		});
+
+		test('falls back when neither user setting nor env var is set', () => {
+			stubInspect({});
+
+			assert.strictEqual(
+				getEffectiveBaseUrl('anthropic', 'https://fallback.example.com'),
+				'https://fallback.example.com'
+			);
+		});
+
+		test('returns undefined when nothing is set and no fallback is given', () => {
+			stubInspect({});
+
+			assert.strictEqual(getEffectiveBaseUrl('anthropic'), undefined);
+		});
 	});
 
-	test('falls back when neither user setting nor env var is set', () => {
-		stubInspect({});
+	suite('per-provider env var mapping', () => {
+		for (const { section, envVar } of PROVIDER_ENV_VARS) {
+			test(`${section} reads ${envVar}`, () => {
+				stubInspect({});
+				const expected = `https://${section}.example.com`;
+				process.env[envVar] = expected;
 
-		assert.strictEqual(
-			getEffectiveBaseUrl('anthropic', 'https://fallback.example.com'),
-			'https://fallback.example.com'
-		);
-	});
+				assert.strictEqual(getEffectiveBaseUrl(section), expected);
+			});
+		}
 
-	test('returns undefined when nothing is set and no fallback is given', () => {
-		stubInspect({});
+		test('ignores env vars for a section that has no mapping', () => {
+			stubInspect({});
+			// Even with a base-URL env var present, foundry has no mapping, so
+			// nothing from the environment must leak in.
+			process.env.ANTHROPIC_BASE_URL = 'https://env.example.com';
 
-		assert.strictEqual(getEffectiveBaseUrl('anthropic'), undefined);
-	});
-
-	test('ignores env vars for a section that has no mapping', () => {
-		stubInspect({});
-		// Even if an unrelated base-URL env var is present, foundry has no
-		// mapping, so it must not leak in.
-		process.env[ENV_VAR] = 'https://env.example.com';
-
-		assert.strictEqual(
-			getEffectiveBaseUrl('foundry', 'https://fallback.example.com'),
-			'https://fallback.example.com'
-		);
+			assert.strictEqual(
+				getEffectiveBaseUrl('foundry', 'https://fallback.example.com'),
+				'https://fallback.example.com'
+			);
+		});
 	});
 });

--- a/extensions/authentication/src/test/baseUrl.test.ts
+++ b/extensions/authentication/src/test/baseUrl.test.ts
@@ -1,0 +1,107 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { getEffectiveBaseUrl } from '../providerSources';
+
+suite('getEffectiveBaseUrl', () => {
+	// `anthropic` is backed by ANTHROPIC_BASE_URL; `foundry` has no env var.
+	const ENV_VAR = 'ANTHROPIC_BASE_URL';
+
+	let mockInspect: sinon.SinonStub;
+	let originalEnvValue: string | undefined;
+
+	setup(() => {
+		originalEnvValue = process.env[ENV_VAR];
+		delete process.env[ENV_VAR];
+
+		mockInspect = sinon.stub();
+		const mockConfig = {
+			get: sinon.stub(),
+			has: sinon.stub(),
+			inspect: mockInspect,
+			update: sinon.stub(),
+		} as unknown as vscode.WorkspaceConfiguration;
+		sinon.stub(vscode.workspace, 'getConfiguration').returns(mockConfig);
+	});
+
+	teardown(() => {
+		sinon.restore();
+		if (originalEnvValue === undefined) {
+			delete process.env[ENV_VAR];
+		} else {
+			process.env[ENV_VAR] = originalEnvValue;
+		}
+	});
+
+	function stubInspect(values: {
+		globalValue?: string;
+		workspaceValue?: string;
+		workspaceFolderValue?: string;
+	}): void {
+		mockInspect.returns({ key: 'baseUrl', ...values });
+	}
+
+	test('user setting wins over the env var', () => {
+		stubInspect({ globalValue: 'https://user.example.com' });
+		process.env[ENV_VAR] = 'https://env.example.com';
+
+		assert.strictEqual(
+			getEffectiveBaseUrl('anthropic', 'https://fallback.example.com'),
+			'https://user.example.com'
+		);
+	});
+
+	test('env var is used when the user has no setting', () => {
+		stubInspect({});
+		process.env[ENV_VAR] = 'https://env.example.com';
+
+		assert.strictEqual(
+			getEffectiveBaseUrl('anthropic', 'https://fallback.example.com'),
+			'https://env.example.com'
+		);
+	});
+
+	test('workspace value takes precedence over the global value', () => {
+		stubInspect({
+			globalValue: 'https://global.example.com',
+			workspaceValue: 'https://workspace.example.com',
+		});
+
+		assert.strictEqual(
+			getEffectiveBaseUrl('anthropic'),
+			'https://workspace.example.com'
+		);
+	});
+
+	test('falls back when neither user setting nor env var is set', () => {
+		stubInspect({});
+
+		assert.strictEqual(
+			getEffectiveBaseUrl('anthropic', 'https://fallback.example.com'),
+			'https://fallback.example.com'
+		);
+	});
+
+	test('returns undefined when nothing is set and no fallback is given', () => {
+		stubInspect({});
+
+		assert.strictEqual(getEffectiveBaseUrl('anthropic'), undefined);
+	});
+
+	test('ignores env vars for a section that has no mapping', () => {
+		stubInspect({});
+		// Even if an unrelated base-URL env var is present, foundry has no
+		// mapping, so it must not leak in.
+		process.env[ENV_VAR] = 'https://env.example.com';
+
+		assert.strictEqual(
+			getEffectiveBaseUrl('foundry', 'https://fallback.example.com'),
+			'https://fallback.example.com'
+		);
+	});
+});


### PR DESCRIPTION
- fixes https://github.com/posit-dev/positron/issues/12894

Note that due to the existing behaviour, users will have had their env var base urls written to their user settings already. This means that if they change the env var, their user setting will take precedence once the changes in this PR are merged. It seems reasonable to accept this, as it would just involve clearing the user settings for their base urls, versus adding logic to clear out the user setting, which I think could be complex.

### Release Notes

#### Bug Fixes

- Auth: user setting now takes precedence instead of being overwritten by environment variables (#12894)

### Validation Steps

All of these providers with env var-specifiable base urls should now have the user setting take precedence over the env var, if both are specified.

```js
const BASE_URL_ENV_VARS: Record<string, string> = {
	'anthropic': 'ANTHROPIC_BASE_URL',
	'openai-api': 'OPENAI_BASE_URL',
	'google': 'GEMINI_BASE_URL',
	'googleVertex': 'GOOGLE_VERTEX_BASE_URL',
	'deepseek-api': 'DEEPSEEK_BASE_URL',
};
```

Example test steps:

1. Launch positron with a base url env var set, e.g. `ANTHROPIC_BASE_URL=https://example.com`
2. Confirm that the provider modal shows this base url for anthropic
3. In user settings, set `authentication.anthropic.baseUrl` to a different value, e.g. `another url`
4. Reload/restart positron
5. Confirm that the modal now shows the same value as the user setting, instead of the env var
6. The user setting is never overwritten with the env var url automatically