### PR TITLE
Add `bump-ark` script and skill

### DIFF
--- a/.claude/skills/bump-ark/README.md
+++ b/.claude/skills/bump-ark/README.md
@@ -10,7 +10,7 @@ The script creates a Positron-side PR that bumps the submodule ref, and fills th
 
 - A "Closes #XXX" line for every issue mentioned in the release notes, and every "Addresses #XXX" mention in the Ark PRs.
 
-- A commit section listing every commit since the last bump.
+- A commit section listing every commit since the last bump. The commits are gathered with a `--first-parent` walk, so that only squash merges, merge commits, and commits directly pushed to main are included.
 
 
 #### Usage

--- a/.claude/skills/bump-ark/README.md
+++ b/.claude/skills/bump-ark/README.md
@@ -1,0 +1,48 @@
+# bump-ark
+
+`bump-ark` is a script and a thin skill wrapper around it. The script can be run with just `python3` (no deps) and assumes the `gh` CLI is properly configured.
+
+The script creates a Positron-side PR that bumps the submodule ref, and fills the PR description automatically. If called again, the script updates the PR with a new submodule bump (if needed) and a refreshed description. The automated PR description includes:
+
+- The set of E2E tags requested by the caller (`@:ark` is always included).
+
+- The relevant release notes from the Ark PRs covered by the submodule bump
+
+- A "Closes #XXX" line for every issue mentioned in the release notes, and every "Addresses #XXX" mention in the Ark PRs.
+
+- A commit section listing every commit since the last bump.
+
+
+#### Usage
+
+The script (and skill) takes the following arguments:
+
+- A source: This can be an Ark PR number, or "main". When set to an Ark PR, the script tracks changes from the current submodule ref to the PR branch tip (or its merge commit once the PR is merged). When set to main, it tracks changes up to Ark's remote main tip.
+
+- A list of E2E tags to include in the Positron PR to expand the active set of tests on CI.
+
+- `--dry-run` to generate a PR description without pushing anything on github.
+
+- `--confirm` to bypass the author protection in case of a "bump to latest main" PR (see below).
+
+
+#### Bump to PR branch mode
+
+You call the script with the PR number to open a Positron PR and run CI tests. If needed, you then iterate on your branch and reinvoke the script to update the Positron PR and refresh CI tests.
+
+Make sure to include the relevant release notes in your Ark PR so the script can generate up-to-date release notes in the Positron PR.
+
+When ready, merge your branch to main and invoke the script one last time. The Positron side PR will now point to the merge commit on main. This works no matter the merge type (squash or branch merge).
+
+If there is other work committed to main, the script will find the release notes of the corresponding PRs. That's on purpose: If your submodule bump includes other people's work, the entire set of changes should be documented here. That's often the sign that a concurrent bump is going on and you might want to coordinate in that case. If the other work gets merged in, call the script/skill again to update the release notes accordingly.
+
+
+#### Bump to latest main mode
+
+The main reason you'd merge work to Ark without a parallel Positron-side bump PR is when the work doesn't have user-visible changes and shouldn't affect the frontend. It's still a good idea to update the frontend-side submodule regularly, which you can do by supplying "main" instead of an Ark PR number.
+
+In this mode, the Positron bump PR isn't tethered to an Ark PR or branch, it tracks the latest Ark commit on main. There can be only one "Bump to latest main" PR opened at any time. When you invoke the script again and a PR is already open, it checks the Ark repo for an update, and bumps the submodule commit in the open bump PR if needed.
+
+If two colleagues try to bump to latest concurrently, the second bump will alert you that another PR is already open and ask you to confirm whether you want to refresh the bump even though it's not your PR.
+
+The script scans all commits and linked PRs to generate a description that includes the Closes section, commits section, as well as release notes. There shouldn't be any release notes in this mode (the preferred workflow is to generate them with a tracked PR bump), but they are checked and included just in case.

--- a/.claude/skills/bump-ark/SKILL.md
+++ b/.claude/skills/bump-ark/SKILL.md
@@ -12,7 +12,7 @@ it never force-pushes.
 
 ## Usage
 
-`/bump-ark <pr-number | main> [@:tag ...] [--confirm]`
+`/bump-ark <pr-number | main> [@:tag ...] [--confirm] [--dry-run]`
 
 - `<pr-number>` tracks one Ark PR across its whole life on a single branch
   `bump-ark/pr-<N>`. While the PR is open the bump points at its head commit, so
@@ -26,6 +26,10 @@ it never force-pushes.
   supplied tags are added and deduped.
 - `--confirm` advances the open `main` bump even when a colleague owns it (see
   below). Never pass it proactively.
+- `--dry-run` prints the assembled PR body to stdout and exits, touching no
+  branch, ref, or PR. Only read-only `gh` calls run. Use it to preview the
+  `Closes`/tags/release-notes/commits body for a target before deciding to open
+  or update anything, e.g. if the user wants to see it first.
 
 The merge-commit finalize works for squash, merge-commit, and rebase merges
 alike, since GitHub records `merge_commit_sha` for all three.
@@ -70,3 +74,8 @@ re-run the same command with `--confirm` appended.
 The script prints the Positron PR URL to stdout (progress goes to stderr).
 Relay that URL. If it reports that the submodule is already at the target,
 relay that as-is instead.
+
+With `--dry-run`, stdout is the PR body instead of a URL, and nothing is
+created or modified: not the tracked branch, not its ref, not the PR. Use it
+only when asked to preview a bump; the default `/bump-ark <args>` invocation
+should not pass it.

--- a/.claude/skills/bump-ark/SKILL.md
+++ b/.claude/skills/bump-ark/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: bump-ark
+description: Open or advance a Positron PR that bumps the Ark submodule to a given Ark PR (its head while open, its merge commit once merged) or to latest Ark main, with Positron e2e test tags. Use when the user runs /bump-ark with a PR number or "main" and optional @:tags.
+---
+
+# bump-ark
+
+Opens a PR against `posit-dev/positron` that bumps the Ark submodule
+(`extensions/positron-r/ark`) to a target commit. Everything goes through the
+GitHub API via `gh`, so no local clone or working tree is read or touched, and
+it never force-pushes.
+
+## Usage
+
+`/bump-ark <pr-number | main> [@:tag ...] [--confirm]`
+
+- `<pr-number>` tracks one Ark PR across its whole life on a single branch
+  `bump-ark/pr-<N>`. While the PR is open the bump points at its head commit, so
+  you can run Positron e2e against the dev branch. Once the Ark PR is merged,
+  re-running `/bump-ark <N>` finalizes the same Positron PR to the merge commit
+  on Ark main, turning the testing PR into the mergeable bump. Title:
+  `Bump Ark to posit-dev/ark#<N>`.
+- `main` bumps to the latest `posit-dev/ark@main` on a single branch
+  `bump-ark/main`, advancing it in place on re-run. Title: `Bump Ark to latest main`.
+- `@:tag` arguments are Positron e2e test tags. `@:ark` is always included; the
+  supplied tags are added and deduped.
+- `--confirm` advances the open `main` bump even when a colleague owns it (see
+  below). Never pass it proactively.
+
+The merge-commit finalize works for squash, merge-commit, and rebase merges
+alike, since GitHub records `merge_commit_sha` for all three.
+
+When the bumped PRs close Positron issues, the body opens with `Closes #<N>`
+lines. Then the tag line, a `### Release Notes` section aggregated from the
+bumped Ark PRs, and a `### Commits` first-parent list of the Ark commits between
+the current submodule pointer and the target.
+
+Release notes are scraped from each bumped Ark PR's `#### New Features` /
+`#### Bug Fixes` bullets. `parse_description.py` is a vendored copy of
+`posit-dev/positron-release-notes`'s parser, so extraction matches the
+release-notes collector; `bump_notes.py` is the skill-local glue on top of it
+(section rendering, `Closes` collection).
+
+## How to run
+
+Run the bundled script, forwarding the arguments verbatim. It needs `python3`
+and an authenticated `gh`:
+
+```bash
+python3 .claude/skills/bump-ark/bump_ark.py <args>
+```
+
+Re-running is always safe. Both bump kinds track one fixed branch and advance it
+by stacking a fast-forward commit onto its current tip (so the ref only ever
+moves forward, never a force-push), then refresh the title and description from
+scratch (commit list, release notes, `Closes` lines).
+
+A PR bump has no author check: its content is fully determined by the Ark PR, so
+collaborators converge on the same PR rather than clobber each other. A main bump
+is author-guarded: you can freely advance your own open `Bump Ark to latest main`
+PR, but if the open one belongs to a colleague the script refuses (it never
+touches their branch) and exits 3.
+
+When the script exits reporting that the main bump belongs to someone else,
+**do not re-run with `--confirm` on your own initiative.** Relay who owns it and
+its URL, and ask the user to confirm, for example: "The 'Bump Ark to latest main'
+PR belongs to @foo (<url>). Advance it anyway?" Only if they explicitly confirm,
+re-run the same command with `--confirm` appended.
+
+The script prints the Positron PR URL to stdout (progress goes to stderr).
+Relay that URL. If it reports that the submodule is already at the target,
+relay that as-is instead.

--- a/.claude/skills/bump-ark/bump_ark.py
+++ b/.claude/skills/bump-ark/bump_ark.py
@@ -112,7 +112,7 @@ def build_bump(
     walk = first_parent_commits(
         compare.merge_base, resolution.sha, compare.commit_map, compare.total_commits
     )
-    commit_lines = "\n".join(f"- {subject}" for _, subject in walk)
+    commit_lines = "\n".join(commit_line(sha, subject) for sha, subject in walk)
 
     notes = collect_release_notes(walk, resolution.open_pr_number)
     closes = "\n".join(f"Closes #{n}" for n in notes["closes"])
@@ -434,6 +434,16 @@ def tag_line(tags: list[str]) -> str:
         if normalized not in result:
             result.append(normalized)
     return " ".join(result)
+
+
+# Render a walked commit as a markdown link to the Ark commit. The link does
+# double duty: it points at the Ark side, and it stops GitHub from autolinking the
+# `(#NNNN)` Ark PR reference in the subject to a Positron issue of the same number,
+# since autolinking doesn't fire inside link text. Brackets in the subject are
+# escaped so a stray `[`/`]` (e.g. `[skip ci]`) can't break the link syntax.
+def commit_line(sha: str, subject: str) -> str:
+    text = subject.replace("[", r"\[").replace("]", r"\]")
+    return f"- [{text}](https://github.com/{ARK_REPO}/commit/{sha})"
 
 
 # Assemble the PR body. `Closes` lines go first (GitHub reads closing keywords

--- a/.claude/skills/bump-ark/bump_ark.py
+++ b/.claude/skills/bump-ark/bump_ark.py
@@ -22,13 +22,14 @@ from typing import Callable, Optional
 from bump_notes import build_notes
 
 USAGE = """\
-Usage: bump_ark.py <pr-number | main> [@:tag ...] [--confirm]
+Usage: bump_ark.py <pr-number | main> [@:tag ...] [--confirm] [--dry-run]
 
 Opens a PR against posit-dev/positron bumping the Ark submodule.
   <pr-number>  bump to the head commit of that Ark PR (its merge commit once merged)
   main         bump to latest posit-dev/ark@main
   @:tag        Positron e2e test tags (@:ark is always included)
-  --confirm    advance the open main bump even if a colleague owns it"""
+  --confirm    advance the open main bump even if a colleague owns it
+  --dry-run    print the PR body to stdout; no branch, ref, or PR is touched"""
 
 ARK_REPO = "posit-dev/ark"
 POSITRON_REPO = "posit-dev/positron"
@@ -61,14 +62,40 @@ def main():
 
 
 def run(argv: list[str]) -> int:
-    target_arg, tag_args, confirm = parse_args(argv)
+    target_arg, tag_args, confirm, dry_run = parse_args(argv)
     check_gh()
 
-    resolution = resolve_target(target_arg)
+    bump = build_bump(target_arg, tag_args)
+    if bump is None:
+        return 0
+    resolution, body = bump
+
+    if dry_run:
+        print(body)
+        return 0
 
     # Only main bumps are author-guarded; a PR bump is keyed on the Ark PR, so
     # collaborators converge on the same PR rather than clobber each other.
     enforce_author = not resolution.is_pr_bump
+
+    open_or_update_tracked_bump(
+        resolution.sha,
+        resolution.title,
+        resolution.branch,
+        body,
+        enforce_author,
+        confirm,
+    )
+    return 0
+
+
+# Resolve the target and assemble its PR body, using only read-only `gh` calls, no
+# branch, ref, or PR is created or modified. Returns None when the submodule is
+# already at the target, the one outcome that has no body to hand back.
+def build_bump(
+    target_arg: str, tag_args: list[str]
+) -> Optional[tuple[Resolution, str]]:
+    resolution = resolve_target(target_arg)
 
     current_sha = gh_json(
         "api", f"repos/{POSITRON_REPO}/contents/{SUBMODULE_PATH}?ref={BASE_BRANCH}"
@@ -77,7 +104,7 @@ def run(argv: list[str]) -> int:
         eprint(
             f"Submodule is already at {resolution.sha} on {POSITRON_REPO}@{BASE_BRANCH}. Nothing to bump."
         )
-        return 0
+        return None
 
     compare = check_ancestry(current_sha, resolution.sha)
     eprint(f"Bumping {SUBMODULE_PATH}: {current_sha} -> {resolution.sha}")
@@ -91,31 +118,26 @@ def run(argv: list[str]) -> int:
     closes = "\n".join(f"Closes #{n}" for n in notes["closes"])
     body = build_body(closes, tag_line(tag_args), notes["notes"], commit_lines)
 
-    open_or_update_tracked_bump(
-        resolution.sha,
-        resolution.title,
-        resolution.branch,
-        body,
-        enforce_author,
-        confirm,
-    )
-    return 0
+    return resolution, body
 
 
-# Pull `--confirm` out from anywhere in the args; what's left is the target (first
-# positional) and the e2e tags. Returns (target, tags, confirm).
-def parse_args(argv: list[str]) -> tuple[str, list[str], bool]:
+# Pull `--confirm`/`--dry-run` out from anywhere in the args; what's left is the
+# target (first positional) and the e2e tags. Returns (target, tags, confirm, dry_run).
+def parse_args(argv: list[str]) -> tuple[str, list[str], bool, bool]:
     confirm = False
+    dry_run = False
     rest = []
     for arg in argv:
         if arg == "--confirm":
             confirm = True
+        elif arg == "--dry-run":
+            dry_run = True
         else:
             rest.append(arg)
     if not rest:
         eprint(USAGE)
         sys.exit(1)
-    return rest[0], rest[1:], confirm
+    return rest[0], rest[1:], confirm, dry_run
 
 
 def check_gh():

--- a/.claude/skills/bump-ark/bump_ark.py
+++ b/.claude/skills/bump-ark/bump_ark.py
@@ -1,0 +1,678 @@
+#!/usr/bin/env python3
+#
+# Open a PR against posit-dev/positron that bumps the Ark submodule
+# (extensions/positron-r/ark) to a target commit.
+#
+# Fully API-driven via `gh`: no local clone or working tree is read or mutated,
+# so it is safe to run from anywhere and never force-pushes.
+
+# Turns annotations into unevaluated strings, so `build_bump`'s reference to
+# `Resolution` below (defined later in the file) doesn't raise `NameError` on
+# import.
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+from bump_notes import build_notes
+
+USAGE = """\
+Usage: bump_ark.py <pr-number | main> [@:tag ...] [--confirm]
+
+Opens a PR against posit-dev/positron bumping the Ark submodule.
+  <pr-number>  bump to the head commit of that Ark PR (its merge commit once merged)
+  main         bump to latest posit-dev/ark@main
+  @:tag        Positron e2e test tags (@:ark is always included)
+  --confirm    advance the open main bump even if a colleague owns it"""
+
+ARK_REPO = "posit-dev/ark"
+POSITRON_REPO = "posit-dev/positron"
+SUBMODULE_PATH = "extensions/positron-r/ark"
+BASE_BRANCH = "main"
+
+# Fallback cap for `walk_first_parents` when no tighter bound is supplied. In
+# practice `first_parent_commits` always passes the compare's `total_commits`,
+# which bounds the walk exactly, so this only backstops direct callers (the unit
+# tests) against an unterminated walk.
+MAX_WALK = 1000
+
+# `gh` honors these force-color vars even when its output is a pipe, which injects
+# ANSI codes into the JSON we capture and breaks parsing. Drop them so `gh` falls
+# back to its normal "no color when not a terminal" behavior.
+GH_ENV = {
+    k: v for k, v in os.environ.items() if k not in ("CLICOLOR_FORCE", "FORCE_COLOR")
+}
+
+
+# --- entrypoint ---------------------------------------------------------
+
+
+def main():
+    try:
+        sys.exit(run(sys.argv[1:]))
+    except BumpError as error:
+        eprint(error.message)
+        sys.exit(error.code)
+
+
+def run(argv: list[str]) -> int:
+    target_arg, tag_args, confirm = parse_args(argv)
+    check_gh()
+
+    resolution = resolve_target(target_arg)
+
+    # Only main bumps are author-guarded; a PR bump is keyed on the Ark PR, so
+    # collaborators converge on the same PR rather than clobber each other.
+    enforce_author = not resolution.is_pr_bump
+
+    current_sha = gh_json(
+        "api", f"repos/{POSITRON_REPO}/contents/{SUBMODULE_PATH}?ref={BASE_BRANCH}"
+    )["sha"]
+    if current_sha == resolution.sha:
+        eprint(
+            f"Submodule is already at {resolution.sha} on {POSITRON_REPO}@{BASE_BRANCH}. Nothing to bump."
+        )
+        return 0
+
+    compare = check_ancestry(current_sha, resolution.sha)
+    eprint(f"Bumping {SUBMODULE_PATH}: {current_sha} -> {resolution.sha}")
+
+    walk = first_parent_commits(
+        compare.merge_base, resolution.sha, compare.commit_map, compare.total_commits
+    )
+    commit_lines = "\n".join(f"- {subject}" for _, subject in walk)
+
+    notes = collect_release_notes(walk, resolution.open_pr_number)
+    closes = "\n".join(f"Closes #{n}" for n in notes["closes"])
+    body = build_body(closes, tag_line(tag_args), notes["notes"], commit_lines)
+
+    open_or_update_tracked_bump(
+        resolution.sha,
+        resolution.title,
+        resolution.branch,
+        body,
+        enforce_author,
+        confirm,
+    )
+    return 0
+
+
+# Pull `--confirm` out from anywhere in the args; what's left is the target (first
+# positional) and the e2e tags. Returns (target, tags, confirm).
+def parse_args(argv: list[str]) -> tuple[str, list[str], bool]:
+    confirm = False
+    rest = []
+    for arg in argv:
+        if arg == "--confirm":
+            confirm = True
+        else:
+            rest.append(arg)
+    if not rest:
+        eprint(USAGE)
+        sys.exit(1)
+    return rest[0], rest[1:], confirm
+
+
+def check_gh():
+    if shutil.which("gh") is None:
+        raise BumpError("Error: gh CLI not found.")
+    if (
+        subprocess.run(
+            ["gh", "auth", "status"], capture_output=True, env=GH_ENV
+        ).returncode
+        != 0
+    ):
+        raise BumpError("Error: gh is not authenticated (run 'gh auth login').")
+
+
+# --- target resolution ------------------------------------------------------
+
+
+@dataclass
+class Resolution:
+    sha: str
+    title: str
+    branch: str
+    # Set only on an open PR bump: its head commit belongs to the still-open PR,
+    # which the walk's merged-only filter drops, so its notes are added by number
+    # instead. None on a merged PR bump and a main bump, whose notes ride the walk.
+    open_pr_number: Optional[str]
+    is_pr_bump: bool
+
+
+# Each logical bump gets a single fixed branch it advances in place. A PR bump
+# uses `bump-ark/pr-<N>` and tracks one Ark PR across its whole life: while the
+# PR is open it targets the PR head, once merged it targets the merge commit. A
+# main bump uses `bump-ark/main` and tracks the latest Ark main.
+def resolve_target(arg: str) -> Resolution:
+    if arg == "main":
+        sha = gh_json("api", f"repos/{ARK_REPO}/commits/main")["sha"]
+        return Resolution(sha, "Bump Ark to latest main", "bump-ark/main", None, False)
+
+    if not arg.isdigit():
+        raise BumpError(
+            f"Error: first argument must be a PR number or 'main' (got '{arg}')."
+        )
+
+    pr = gh_json("api", f"repos/{ARK_REPO}/pulls/{arg}")
+    resolution, messages = pr_resolution(arg, pr)
+
+    for message in messages:
+        eprint(message)
+
+    return resolution
+
+
+# Pure decision for a PR bump: map the fetched PR JSON to a Resolution plus the
+# stderr messages the caller should emit. Fatal cases raise BumpError.
+def pr_resolution(pr_number: str, pr: dict) -> tuple[Resolution, list[str]]:
+    messages: list[str] = []
+    title = f"Bump Ark to posit-dev/ark#{pr_number}"
+    branch = f"bump-ark/pr-{pr_number}"
+
+    if pr.get("merged_at"):
+        # Finalize: point the bump at the merge commit on Ark main. This works for
+        # squash, merge-commit, and rebase merges alike, since GitHub sets
+        # `merge_commit_sha` for all three and each lands reachable from main via
+        # first parents.
+        merge_commit = pr.get("merge_commit_sha")
+        if not merge_commit:
+            raise BumpError(
+                f"Error: PR #{pr_number} is merged but has no merge commit sha; can't finalize the bump."
+            )
+        messages.append(
+            f"PR #{pr_number} is merged. Finalizing the bump to its merge commit {merge_commit}."
+        )
+        return Resolution(merge_commit, title, branch, None, True), messages
+
+    if pr.get("state") == "closed":
+        messages.append(
+            f"Warning: PR #{pr_number} is closed (not merged). Bumping to its last head commit anyway."
+        )
+
+    head = pr.get("head") or {}
+    head_repo = (head.get("repo") or {}).get("full_name") or ""
+    if head_repo != ARK_REPO:
+        where = head_repo or "deleted fork"
+        raise BumpError(
+            f"Error: PR #{pr_number} head lives in '{where}', not '{ARK_REPO}'.\n"
+            "       The submodule can't resolve to a fork commit, so refusing to bump."
+        )
+
+    return Resolution(head["sha"], title, branch, pr_number, True), messages
+
+
+# --- ancestry ---------------------------------------------------------------
+
+
+@dataclass
+class Ancestry:
+    merge_base: str
+    messages: list[str] = field(default_factory=list)
+    # None: continue. 0: nothing to do. 1: refuse. Set when the caller must exit.
+    exit_code: Optional[int] = None
+
+
+@dataclass
+class CompareResult:
+    # The commit the first-parent walk stops at (the current pointer for a clean
+    # fast-forward, the fork point for diverged history).
+    merge_base: str
+    # Commits in the range, which is the tight upper bound on the first-parent
+    # walk length (the first-parent chain is a subset of all commits).
+    total_commits: int
+    # sha -> (subject, first-parent sha) for every commit `compare` returned
+    # (capped at 250). The walk reads these instead of refetching each commit.
+    commit_map: dict[str, tuple[str, Optional[str]]]
+
+
+# Diagnose how the target relates to the current pointer, so a backward or diverged
+# bump is caught upfront rather than surfacing as a runaway first-parent walk.
+# `status` is relative to the current pointer. Hands back the compare payload the
+# first-parent walk then reads (merge base, commit count, and the per-commit
+# summaries) so the walk needs no further API calls in the common case.
+def check_ancestry(current: str, target: str) -> CompareResult:
+    info = gh_json("api", f"repos/{ARK_REPO}/compare/{current}...{target}")
+    result = classify_ancestry(
+        info["status"],
+        info["ahead_by"],
+        info["behind_by"],
+        info["merge_base_commit"]["sha"],
+    )
+
+    for message in result.messages:
+        eprint(message)
+    if result.exit_code is not None:
+        sys.exit(result.exit_code)
+
+    commit_map = {c["sha"]: commit_summary(c) for c in info.get("commits") or []}
+    return CompareResult(result.merge_base, info.get("total_commits", 0), commit_map)
+
+
+# Pure classification of a `compare` result.
+def classify_ancestry(
+    status: str, ahead: int, behind: int, merge_base: str
+) -> Ancestry:
+    if status == "ahead":
+        return Ancestry(
+            merge_base, [f"Target is {ahead} commit(s) ahead of the current pointer."]
+        )
+    if status == "identical":
+        return Ancestry(
+            merge_base,
+            ["Submodule is already at the target. Nothing to bump."],
+            exit_code=0,
+        )
+    if status == "behind":
+        return Ancestry(
+            merge_base,
+            [
+                "Error: the current submodule pointer already contains the target",
+                f"       (target is {behind} commit(s) behind it). Refusing to bump backward.",
+            ],
+            exit_code=1,
+        )
+    if status == "diverged":
+        return Ancestry(
+            merge_base,
+            [
+                "Warning: the target is not based on the current Ark main pointer",
+                f"         ({ahead} ahead, {behind} behind). The commit list will include",
+                "         divergent commits and the resulting PR may be stale.",
+            ],
+        )
+
+    # Unreachable: GitHub's compare API documents exactly the four statuses above.
+    return Ancestry(
+        merge_base,
+        [f"Error: unexpected compare status '{status}'. Refusing to bump."],
+        exit_code=1,
+    )
+
+
+# Reduce a commit JSON object to the (subject, first-parent sha) pair the walk
+# needs. Works for both the single-commit and the `compare` endpoints, which
+# return commits in the same shape.
+def commit_summary(commit: dict) -> tuple[str, Optional[str]]:
+    subject = commit["commit"]["message"].split("\n", 1)[0]
+    parents = commit.get("parents") or []
+    parent = parents[0]["sha"] if parents else None
+    return subject, parent
+
+
+# --- first-parent walk ------------------------------------------------------
+
+
+# List the commits in the range `from_sha..to_sha` (newest first, walking parents
+# back from the `to_sha` end), reading the commit summaries `compare` already
+# returned and only fetching a commit one-off when it
+# falls outside that payload (a bump spanning more than the 250 commits `compare`
+# caps at). `total_commits` bounds the walk exactly: the first-parent chain can't
+# be longer than the range's commit count, so a walk that overruns it has left the
+# first-parent line and is caught after a handful of steps rather than fetching up
+# to MAX_WALK commits.
+def first_parent_commits(
+    from_sha: str,
+    to_sha: str,
+    commit_map: dict[str, tuple[str, Optional[str]]],
+    total_commits: int,
+) -> list[tuple[str, str]]:
+    def get_commit(sha: str) -> tuple[str, Optional[str]]:
+        cached = commit_map.get(sha)
+        return cached if cached is not None else gh_get_commit(sha)
+
+    return walk_first_parents(from_sha, to_sha, get_commit, max_walk=total_commits)
+
+
+def gh_get_commit(sha: str) -> tuple[str, Optional[str]]:
+    return commit_summary(gh_json("api", f"repos/{ARK_REPO}/commits/{sha}"))
+
+
+# List the commits in git's range `from_sha..to_sha`, newest first. The parameter
+# names follow that range syntax: `from_sha` is the older, excluded end (the current
+# pointer) and `to_sha` is the newer, included end (the target). The walk runs
+# backward, from `to_sha` down to `from_sha`, because a git commit records only its
+# parents, not its children, so newest-first is the only direction we can follow.
+# `get_commit(sha)` yields (subject, first_parent_sha_or_None). Same result as
+# `git log --first-parent <from>..<to>` without a local clone, as long as `from_sha`
+# sits on that chain. Bails if the walk hits a root commit or `max_walk` without
+# reaching `from_sha`, since the commit list would otherwise be wrong (a partial
+# history, or the whole repo up to the cap).
+def walk_first_parents(
+    from_sha: str,
+    to_sha: str,
+    get_commit: Callable[[str], tuple[str, Optional[str]]],
+    max_walk: int = MAX_WALK,
+) -> list[tuple[str, str]]:
+    walk: list[tuple[str, str]] = []
+    sha = to_sha
+    count = 0
+
+    while sha != from_sha and count < max_walk:
+        subject, parent = get_commit(sha)
+        walk.append((sha, subject))
+        count += 1
+        if not parent:
+            break
+        sha = parent
+
+    if sha != from_sha:
+        raise BumpError(
+            f"Error: walked {count} first-parent commit(s) back from the target without\n"
+            f"       reaching the current pointer {from_sha}.\n"
+            "       It is reachable from the target only through a merge commit's second\n"
+            "       parent, so a first-parent commit list can't span the gap. This is\n"
+            "       unexpected for Ark's squash-merge history."
+        )
+    return walk
+
+
+# --- release notes ----------------------------------------------------------
+
+
+# Gather the merged Ark PRs behind the walked commits, plus the target PR itself
+# on an open PR bump, and hand their bodies to the vendored release-notes parser.
+#
+# On an open PR bump the target PR is added explicitly: its head commit is
+# associated only with the still-open PR, which the `merged_at` filter drops, yet
+# its notes are the point of the bump. On a merged PR bump `open_pr_number` is
+# empty, because the merge commit already surfaces the PR through the walk. The
+# dict keeps the first body seen per PR number, collapsing a PR that spans several
+# walked commits (or the target reappearing among a commit's associated PRs).
+def collect_release_notes(
+    walk: list[tuple[str, str]], open_pr_number: Optional[str]
+) -> dict:
+    bodies: dict[int, str] = {}
+    for sha, _ in walk:
+        for pr in gh_json("api", f"repos/{ARK_REPO}/commits/{sha}/pulls") or []:
+            if pr.get("merged_at"):
+                bodies.setdefault(pr["number"], pr.get("body") or "")
+
+    if open_pr_number:
+        pr = gh_json("api", f"repos/{ARK_REPO}/pulls/{open_pr_number}")
+        bodies.setdefault(pr["number"], pr.get("body") or "")
+
+    return build_notes([{"number": n, "body": b} for n, b in bodies.items()])
+
+
+# --- body assembly ----------------------------------------------------------
+
+
+# The space-separated tag line: `@:ark` first, then the caller's tags, each
+# normalized to an `@:` prefix, deduped while preserving order.
+def tag_line(tags: list[str]) -> str:
+    result = ["@:ark"]
+    for raw in tags:
+        normalized = raw if raw.startswith("@:") else f"@:{raw}"
+        if normalized not in result:
+            result.append(normalized)
+    return " ".join(result)
+
+
+# Assemble the PR body. `Closes` lines go first (GitHub reads closing keywords
+# anywhere, and keeping them above the release-notes headers stops the collector
+# from parsing them as items). Omitted entirely when there are no issues.
+def build_body(closes: str, tags: str, notes: str, commit_lines: str) -> str:
+    parts = []
+    if closes:
+        parts.append(closes)
+    parts += [tags, notes, f"### Commits\n\n{commit_lines}"]
+    return "\n\n".join(parts)
+
+
+# --- branch and PR mutation -------------------------------------------------
+
+
+# Make this bump's branch and its PR point at `target_sha`, no matter their
+# current state (branch missing, behind, or already there, and PR open or not).
+# When the branch needs to move we push a fast-forward commit that retriggers
+# tests on CI. The resulting PR URL is printed to stdout as the machine-readable
+# result whereas progress streams to stderr.
+#
+# `enforce_author` is True only for main bumps. When it is set and the open PR
+# belongs to someone else, refuse unless `confirm` is given, and exit with code 3.
+def open_or_update_tracked_bump(
+    target_sha: str,
+    title: str,
+    branch: str,
+    body: str,
+    enforce_author: bool,
+    confirm: bool,
+):
+    prs = gh_json(
+        "pr",
+        "list",
+        "--repo",
+        POSITRON_REPO,
+        "--head",
+        branch,
+        "--state",
+        "open",
+        "--json",
+        "number,url,author",
+    )
+    pr = prs[0] if prs else None
+
+    # Author-gate before touching the branch, so a refusal never stacks a commit
+    # onto a colleague's PR.
+    me = (
+        gh_json("api", "user")["login"]
+        if (enforce_author and pr and not confirm)
+        else None
+    )
+    pr_author = pr["author"]["login"] if pr else None
+    if pr is not None and blocked_by_pr_owner(
+        enforce_author, True, pr_author, me, confirm
+    ):
+        raise BumpError(
+            f"Refusing: the '{title}' PR belongs to @{pr_author} ({pr['url']}).\n"
+            f"         Ask the user to confirm advancing @{pr_author}'s PR before re-running with --confirm.",
+            code=3,
+        )
+
+    tip = branch_head_sha(branch)
+    if tip is None:
+        ensure_branch(target_sha, title, branch)
+    elif branch_submodule_sha(branch) != target_sha:
+        eprint(f"Advancing {branch} to {target_sha}")
+        stack_submodule_commit(branch, target_sha, title, tip)
+
+    if pr:
+        gh(
+            "api",
+            "-X",
+            "PATCH",
+            f"repos/{POSITRON_REPO}/pulls/{pr['number']}",
+            "--input",
+            "-",
+            input_obj={"title": title, "body": body},
+        )
+        eprint(f"Updated {pr['url']}")
+        print(pr["url"])
+        return
+
+    url = gh_json(
+        "api",
+        "-X",
+        "POST",
+        f"repos/{POSITRON_REPO}/pulls",
+        "--input",
+        "-",
+        input_obj={"title": title, "head": branch, "base": BASE_BRANCH, "body": body},
+    )["html_url"]
+    eprint(f"Opened {url}")
+    print(url)
+
+
+# True when we must refuse: a main bump (`enforce_author`) with an open PR that
+# belongs to someone else and no `--confirm`. `me` may be None when the cheap
+# conditions already rule refusal out.
+def blocked_by_pr_owner(
+    enforce_author: bool,
+    has_pr: bool,
+    pr_author: Optional[str],
+    me: Optional[str],
+    confirm: bool,
+) -> bool:
+    if not (enforce_author and has_pr and not confirm):
+        return False
+    return pr_author != me
+
+
+def branch_head_sha(branch: str) -> Optional[str]:
+    """Branch tip commit sha, or None if the branch doesn't exist."""
+    proc = gh("api", f"repos/{POSITRON_REPO}/git/ref/heads/{branch}", allow_fail=True)
+    if proc.returncode != 0:
+        return None
+    return json.loads(proc.stdout)["object"]["sha"]
+
+
+# Create the bump branch off main if it doesn't already exist. Never force-pushes:
+# an existing branch is left untouched.
+def ensure_branch(target_sha: str, title: str, branch: str):
+    if (
+        gh(
+            "api", f"repos/{POSITRON_REPO}/git/ref/heads/{branch}", allow_fail=True
+        ).returncode
+        == 0
+    ):
+        return
+
+    base_commit = gh_json("api", f"repos/{POSITRON_REPO}/git/ref/heads/{BASE_BRANCH}")[
+        "object"
+    ]["sha"]
+    new_commit = make_bump_commit(target_sha, title, base_commit)
+    gh(
+        "api",
+        "-X",
+        "POST",
+        f"repos/{POSITRON_REPO}/git/refs",
+        "--input",
+        "-",
+        input_obj={"ref": f"refs/heads/{branch}", "sha": new_commit},
+    )
+
+
+# Create a commit that sets the submodule gitlink (mode 160000, type commit) to
+# `target_sha`, parented on `parent`. The tree is `parent`'s own tree with only the
+# gitlink swapped, so the commit is a pure one-file change. Returns the new commit
+# sha.
+#
+# Why parent's tree and not current main's tree: a PR's diff is measured from its
+# merge base, the commit the branch was cut from, which stacking never moves. If we
+# rebuilt the tree from current main, every file main touched since the fork would
+# land in the bump PR's diff, and a later main edit to one of them would conflict on
+# merge. A pure gitlink delta keeps the PR touching only the submodule, however far
+# main has drifted.
+def make_bump_commit(target_sha: str, title: str, parent: str) -> str:
+    base_tree = gh_json("api", f"repos/{POSITRON_REPO}/git/commits/{parent}")["tree"][
+        "sha"
+    ]
+    new_tree = gh_json(
+        "api",
+        "-X",
+        "POST",
+        f"repos/{POSITRON_REPO}/git/trees",
+        "--input",
+        "-",
+        input_obj={
+            "base_tree": base_tree,
+            "tree": [
+                {
+                    "path": SUBMODULE_PATH,
+                    "mode": "160000",
+                    "type": "commit",
+                    "sha": target_sha,
+                }
+            ],
+        },
+    )["sha"]
+    return gh_json(
+        "api",
+        "-X",
+        "POST",
+        f"repos/{POSITRON_REPO}/git/commits",
+        "--input",
+        "-",
+        input_obj={"message": title, "tree": new_tree, "parents": [parent]},
+    )["sha"]
+
+
+def branch_submodule_sha(branch: str) -> Optional[str]:
+    """Submodule gitlink sha recorded on the given branch, or None if unavailable."""
+    proc = gh(
+        "api",
+        f"repos/{POSITRON_REPO}/contents/{SUBMODULE_PATH}?ref={branch}",
+        allow_fail=True,
+    )
+    if proc.returncode != 0:
+        return None
+    return json.loads(proc.stdout)["sha"]
+
+
+# Advance an existing branch to a new commit that sets the submodule to
+# `target_sha`, stacked on the current tip so the ref move is a fast-forward. The
+# ref PATCH omits `force`, so a non-fast-forward (someone advanced the branch since
+# `tip` was read) is rejected rather than clobbering their work.
+def stack_submodule_commit(branch: str, target_sha: str, title: str, tip: str):
+    new_commit = make_bump_commit(target_sha, title, tip)
+    gh(
+        "api",
+        "-X",
+        "PATCH",
+        f"repos/{POSITRON_REPO}/git/refs/heads/{branch}",
+        "--input",
+        "-",
+        input_obj={"sha": new_commit},
+    )
+
+
+# --- gh transport (shared by everything above) -------------------------
+
+
+class BumpError(Exception):
+    """A fatal condition whose `message` is printed verbatim to stderr, exiting
+    with `code`. The message carries its own prefix ("Error: ", "Refusing: ")."""
+
+    def __init__(self, message: str, code: int = 1):
+        super().__init__(message)
+        self.message = message
+        self.code = code
+
+
+def eprint(*args):
+    print(*args, file=sys.stderr)
+
+
+def gh(
+    *args: str, input_obj=None, allow_fail: bool = False
+) -> subprocess.CompletedProcess:
+    """Run `gh <args>`, returning the completed process. `input_obj` is JSON-encoded
+    onto stdin (pair it with `--input -`). A nonzero exit raises BumpError with gh's
+    stderr, unless `allow_fail` is set (used to probe for a missing branch)."""
+    input_str = json.dumps(input_obj) if input_obj is not None else None
+    proc = subprocess.run(
+        ["gh", *args],
+        input=input_str,
+        capture_output=True,
+        encoding="utf-8",
+        env=GH_ENV,
+    )
+    if proc.returncode != 0 and not allow_fail:
+        raise BumpError(f"Error: `gh {' '.join(args)}` failed:\n{proc.stderr.rstrip()}")
+    return proc
+
+
+def gh_json(*args: str, input_obj=None):
+    """`gh` call whose stdout is parsed as JSON. Empty output yields None."""
+    out = gh(*args, input_obj=input_obj).stdout
+    return json.loads(out) if out.strip() else None
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/bump-ark/bump_notes.py
+++ b/.claude/skills/bump-ark/bump_notes.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+#
+# Turn a set of Ark PR descriptions into the `### Release Notes` block and the
+# `Closes` issue list for the Positron bump PR body.
+#
+# The parsing lives in the vendored `parse_description.py` (a copy of
+# posit-dev/positron-release-notes). This file is the skill-local glue on top of
+# it: it renders the parsed items back into bullets, aggregates the release-notes
+# block, and collects the issues to close. Keeping it separate keeps the vendored
+# file a clean mirror of upstream.
+#
+# Input: a JSON array of {number, body} objects (the merged Ark PRs) on stdin.
+# Output: JSON {"closes": [issue numbers], "notes": "<block>"} on stdout. The
+# `notes` block uses `- N/A` for a category that has none. `closes` unions the
+# Positron issues linked inside the emitted release notes with every issue
+# referenced by an "Addresses ..." line in the PR bodies.
+
+import json
+import re
+import sys
+
+from parse_description import Item, ReleaseNotes
+
+
+def main():
+    prs = json.load(sys.stdin)
+    json.dump(build_notes(prs), sys.stdout)
+
+
+# Build the `{closes, notes}` payload for a set of Ark PRs. `prs` is a list of
+# {number, body} dicts. `notes` is the `### Release Notes` block; `closes` unions
+# the issues linked inside the release notes with the "Addresses ..." references.
+def build_notes(prs):
+    notes = ReleaseNotes()
+    for pr in prs:
+        notes.parse_description(pr.get("body") or "", pr_number=pr.get("number"))
+
+    block = "### Release Notes\n\n"
+    block += format_section("New Features", notes.features())
+    block += "\n\n"
+    block += format_section("Bug Fixes", notes.bugfixes())
+
+    closes = linked_issues(notes)
+    for pr in prs:
+        for issue in addresses_issues(pr.get("body") or ""):
+            if issue not in closes:
+                closes.append(issue)
+
+    return {"closes": sorted(int(n) for n in closes), "notes": block}
+
+
+def format_section(title: str, items: list[Item]) -> str:
+    body = "\n\n".join(render_item(item) for item in items) if items else "- N/A"
+    return f"#### {title}\n\n{body}"
+
+
+# Render one parsed item back into the bullet form the collector expects when
+# it re-parses this bump PR: a `- ` first line and 2-space-indented
+# continuation lines. Deliberately without the collector's tag/link/full-stop
+# rendering, so the collector applies that once, downstream.
+def render_item(item: Item) -> str:
+    lines = item.item_text.splitlines()
+    if not lines:
+        return ""
+
+    lines[0] = "- " + lines[0]
+    lines = [
+        "  " + line if line and not line.startswith(("-", " ")) else line
+        for line in lines
+    ]
+    lines = [line if line.strip() else "" for line in lines]
+
+    return "\n".join(lines).rstrip()
+
+
+# Positron issues linked inside the parsed items, deduped preserving first-seen
+# order. Lives here rather than on the vendored `ReleaseNotes` so that class stays
+# a faithful mirror of upstream.
+def linked_issues(notes: ReleaseNotes) -> list[str]:
+    issues: list[str] = []
+    for item in notes.items:
+        for issue in item.linked_issues:
+            if issue not in issues:
+                issues.append(issue)
+    return issues
+
+
+# Issue references the collector recognizes, all pointing at Positron: a bare
+# `#123`, `posit-dev/positron#123`, or the full issues URL.
+_ISSUE_REF = r"(?:posit-dev/positron)?#\d+|https://github\.com/posit-dev/positron/issues/\d+"
+
+# "Addresses" followed by one or more of those refs (comma/"and" separated). The
+# run stops at the first token that isn't a ref, so a `#N` elsewhere in the same
+# sentence isn't swept in.
+_ADDRESSES_RE = re.compile(
+    r"(?i)\baddresses\b[:\s]+((?:" + _ISSUE_REF + r")(?:\s*(?:,|and)\s*)?)+"
+)
+_ISSUE_NUM_RE = re.compile(r"#(\d+)|/issues/(\d+)")
+
+
+def addresses_issues(body: str) -> list[str]:
+    body = re.sub(r"<!--.*?-->", "", body, flags=re.DOTALL)
+    issues = []
+    for match in _ADDRESSES_RE.finditer(body):
+        for num in _ISSUE_NUM_RE.finditer(match.group(0)):
+            issues.append(num.group(1) or num.group(2))
+    return issues
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/bump-ark/parse_description.py
+++ b/.claude/skills/bump-ark/parse_description.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+#
+# Parse `#### New Features` / `#### Bug Fixes` bullets out of a PR description.
+#
+# Vendored from posit-dev/positron-release-notes (`parse_description.py`) so
+# extraction matches the release-notes collector exactly. Keep this file a clean
+# mirror of upstream: the `ghapi` dependency and the release-doc rendering
+# (`Item.text`, `ReleaseNotes.print`, language-label fetching) are the only
+# things dropped, since here we only extract the raw bullets. The skill-local
+# rendering and aggregation lives in `bump_notes.py`, not here.
+
+import re
+from typing import Optional
+
+
+class Item:
+    item_text: str
+    type: str
+    pr_number: Optional[int]
+
+    def __init__(self, item: str, item_type: str, pr_number: Optional[int] = None):
+        if item_type not in ["feature", "bugfix"]:
+            raise ValueError(
+                f"Item type must be 'feature' or 'bugfix', not '{item_type}'"
+            )
+        self.type = item_type
+
+        item = item.lstrip("- ")
+        self.item_text = item
+
+        self.pr_number = pr_number
+
+        self._parse_linked_issues()
+
+    def _parse_linked_issues(self):
+        # Normalise links to issues
+        self.item_text = re.sub(
+            r"posit-dev/positron#(\d+)",
+            r"https://github.com/posit-dev/positron/issues/\1",
+            self.item_text,
+        )
+        self.item_text = re.sub(
+            r"#(\d+)",
+            r"https://github.com/posit-dev/positron/issues/\1",
+            self.item_text,
+        )
+
+        linked_issues = re.findall(
+            r"https://github.com/posit-dev/positron/issues/(\d+)", self.item_text
+        )
+        self.linked_issues = list(set(linked_issues))
+
+
+class ReleaseNotes:
+    items: list[Item]
+
+    def __init__(self):
+        self.items = []
+
+    def features(self) -> list[Item]:
+        return [item for item in self.items if item.type == "feature"]
+
+    def bugfixes(self) -> list[Item]:
+        return [item for item in self.items if item.type == "bugfix"]
+
+    def parse_description(self, desc: str, pr_number: Optional[int] = None):
+        parser = DescriptionParser(pr_number=pr_number)
+        parser.parse(desc)
+        self.items.extend(parser.items)
+
+
+class DescriptionParser:
+    items: list[Item]
+
+    _current_item: list[str]
+    _current_section: Optional[str]
+    _in_comment: bool
+    _pr_number: Optional[int]
+
+    def __init__(self, pr_number: Optional[int] = None):
+        self.items = []
+        self._current_item = []
+        self._current_section = None
+        self._in_comment = False
+        self._pr_number = pr_number
+
+    def parse(self, desc: str):
+        lines = desc.splitlines()
+        for line in lines:
+            self._parse_line(line)
+        self._flush()
+
+    def _flush(self):
+        lines = trim_empty_lines(self._current_item)
+        text = "\n".join(lines)
+        self._current_item = []
+
+        if self._current_section is not None and len(text) > 0:
+            self.items.append(Item(text, self._current_section, self._pr_number))
+
+    def _parse_line(self, line: str):
+        if "<!--" in line:
+            self._in_comment = True
+            return
+
+        if "-->" in line:
+            self._in_comment = False
+            return
+
+        # Skip lines within comments
+        if self._in_comment:
+            return
+
+        # Enter known sections. For simplicity we don't check that we're within
+        # the `### Release Notes` header.
+        if re.match(r"^####\ New\ Features", line):
+            self._flush()
+            self._current_section = "feature"
+            return
+
+        if re.match(r"^####\ Bug\ Fixes", line):
+            self._flush()
+            self._current_section = "bugfix"
+            return
+
+        # Reset section for any other headers, e.g. `QA Notes`
+        if re.match(r"^#", line):
+            self._flush()
+            self._current_section = None
+            return
+
+        # We're not in a relevant section, ignore the line
+        if self._current_section == "":
+            return
+
+        # Normalize `*` bullets to `-`
+        if re.match(r"^\*", line):
+            line = "- " + line[2:]
+
+        # Ignore unindented lines - they are not part of an item
+        if line.strip() and not re.match(r"^(  |- )", line):
+            return
+
+        # Start new line
+        if re.match(r"^-\ ", line):
+            self._flush()
+
+            # Ignore N/A line
+            if re.match(r"^-\ N/A", line):
+                # Ignore N/A line
+                return
+
+        self._current_item.append(line)
+
+
+def trim_empty_lines(lines):
+    # Trim leading lines
+    while len(lines) > 0:
+        if re.match(r"^\s*$", lines[0]):
+            lines.pop(0)
+        else:
+            break
+
+    # Trim trailing lines
+    while len(lines) > 0:
+        if re.match(r"^\s*$", lines[-1]):
+            lines.pop()
+        else:
+            break
+
+    return lines

--- a/.claude/skills/bump-ark/test_bump_ark.py
+++ b/.claude/skills/bump-ark/test_bump_ark.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+#
+# Unit tests for the pure decision logic in bump_ark.py. Run offline, no `gh`:
+#
+#   python3 -m unittest test_bump_ark
+#
+# The `gh`-driven orchestration (branch/ref/PR mutation) is not covered here; it
+# is side-effecting against GitHub and not unit-testable without a sandbox repo.
+
+import contextlib
+import io
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from bump_ark import (  # noqa: E402
+    ARK_REPO,
+    BumpError,
+    blocked_by_pr_owner,
+    build_body,
+    classify_ancestry,
+    commit_summary,
+    first_parent_commits,
+    parse_args,
+    pr_resolution,
+    tag_line,
+    walk_first_parents,
+)
+
+
+class DecidePrResolutionTest(unittest.TestCase):
+    def open_pr(self, **overrides):
+        pr = {
+            "head": {"sha": "headsha", "repo": {"full_name": ARK_REPO}},
+            "state": "open",
+            "merged_at": None,
+            "merge_commit_sha": None,
+        }
+        pr.update(overrides)
+        return pr
+
+    def test_open_pr_targets_head_and_sets_open_pr_number(self):
+        resolution, messages = pr_resolution("42", self.open_pr())
+        self.assertEqual(resolution.sha, "headsha")
+        self.assertEqual(resolution.title, "Bump Ark to posit-dev/ark#42")
+        self.assertEqual(resolution.branch, "bump-ark/pr-42")
+        self.assertEqual(resolution.open_pr_number, "42")
+        self.assertTrue(resolution.is_pr_bump)
+        self.assertEqual(messages, [])
+
+    def test_merged_pr_targets_merge_commit_and_clears_open_pr_number(self):
+        pr = self.open_pr(
+            merged_at="2026-01-01T00:00:00Z",
+            merge_commit_sha="mergesha",
+            state="closed",
+        )
+        resolution, messages = pr_resolution("42", pr)
+        self.assertEqual(resolution.sha, "mergesha")
+        self.assertIsNone(resolution.open_pr_number)
+        self.assertTrue(resolution.is_pr_bump)
+        self.assertEqual(
+            messages,
+            ["PR #42 is merged. Finalizing the bump to its merge commit mergesha."],
+        )
+
+    def test_merged_pr_ignores_closed_and_fork_warnings(self):
+        # A merged PR is always closed and its fork may be gone; those warnings
+        # belong to the open path only, so finalize stays quiet about them.
+        pr = self.open_pr(
+            merged_at="2026-01-01T00:00:00Z",
+            merge_commit_sha="mergesha",
+            state="closed",
+            head={"sha": "headsha", "repo": None},
+        )
+        _, messages = pr_resolution("42", pr)
+        self.assertEqual(len(messages), 1)
+        self.assertIn("Finalizing", messages[0])
+
+    def test_merged_pr_without_merge_commit_is_fatal(self):
+        pr = self.open_pr(merged_at="2026-01-01T00:00:00Z", merge_commit_sha=None)
+        with self.assertRaises(BumpError) as ctx:
+            pr_resolution("42", pr)
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("no merge commit sha", ctx.exception.message)
+
+    def test_closed_unmerged_pr_warns_but_targets_head(self):
+        resolution, messages = pr_resolution("42", self.open_pr(state="closed"))
+        self.assertEqual(resolution.sha, "headsha")
+        self.assertEqual(resolution.open_pr_number, "42")
+        self.assertEqual(len(messages), 1)
+        self.assertIn("is closed (not merged)", messages[0])
+
+    def test_fork_head_is_fatal(self):
+        pr = self.open_pr(head={"sha": "headsha", "repo": {"full_name": "someone/ark"}})
+        with self.assertRaises(BumpError) as ctx:
+            pr_resolution("42", pr)
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("head lives in 'someone/ark'", ctx.exception.message)
+
+    def test_deleted_fork_head_is_fatal(self):
+        pr = self.open_pr(head={"sha": "headsha", "repo": None})
+        with self.assertRaises(BumpError) as ctx:
+            pr_resolution("42", pr)
+        self.assertIn("head lives in 'deleted fork'", ctx.exception.message)
+
+    def test_closed_fork_head_is_fatal(self):
+        # The fork head is unbumpable regardless of the closed state, so the fork
+        # check raises before the closed warning can matter.
+        pr = self.open_pr(
+            state="closed",
+            head={"sha": "headsha", "repo": {"full_name": "someone/ark"}},
+        )
+        with self.assertRaises(BumpError) as ctx:
+            pr_resolution("42", pr)
+        self.assertIn("head lives in", ctx.exception.message)
+
+
+class ClassifyAncestryTest(unittest.TestCase):
+    def test_ahead_continues(self):
+        result = classify_ancestry("ahead", 3, 0, "base")
+        self.assertEqual(result.merge_base, "base")
+        self.assertIsNone(result.exit_code)
+        self.assertIn("3 commit(s) ahead", result.messages[0])
+
+    def test_identical_exits_zero(self):
+        result = classify_ancestry("identical", 0, 0, "base")
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("already at the target", result.messages[0])
+
+    def test_behind_refuses(self):
+        result = classify_ancestry("behind", 0, 2, "base")
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("already contains the target", result.messages[0])
+        self.assertIn("2 commit(s) behind", result.messages[1])
+
+    def test_diverged_warns_but_continues(self):
+        result = classify_ancestry("diverged", 1, 4, "base")
+        self.assertIsNone(result.exit_code)
+        self.assertIn("not based on the current Ark main pointer", result.messages[0])
+        self.assertIn("1 ahead, 4 behind", result.messages[1])
+
+    def test_unexpected_status_refuses(self):
+        result = classify_ancestry("weird", 0, 0, "base")
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("unexpected compare status 'weird'", result.messages[0])
+
+
+class WalkFirstParentsTest(unittest.TestCase):
+    # Linear graph C -> B -> A, plus a root R below A.
+    GRAPH = {
+        "C": ("subject C", "B"),
+        "B": ("subject B", "A"),
+        "A": ("subject A", "R"),
+        "R": ("subject R", None),
+    }
+
+    def get_commit(self, sha):
+        return self.GRAPH[sha]
+
+    def test_walks_back_to_but_excludes_from(self):
+        walk = walk_first_parents("A", "C", self.get_commit)
+        self.assertEqual(walk, [("C", "subject C"), ("B", "subject B")])
+
+    def test_target_equals_from_yields_empty(self):
+        self.assertEqual(walk_first_parents("C", "C", self.get_commit), [])
+
+    def test_hitting_root_before_from_is_fatal(self):
+        with self.assertRaises(BumpError) as ctx:
+            walk_first_parents("Z", "C", self.get_commit)
+        self.assertIn("without", ctx.exception.message)
+        self.assertIn("reaching the current pointer Z", ctx.exception.message)
+
+    def test_exceeding_max_walk_is_fatal(self):
+        with self.assertRaises(BumpError):
+            walk_first_parents("A", "C", self.get_commit, max_walk=1)
+
+    def test_max_walk_boundary_reaches_from(self):
+        # Two steps (C, B) are exactly enough to reach A.
+        walk = walk_first_parents("A", "C", self.get_commit, max_walk=2)
+        self.assertEqual([sha for sha, _ in walk], ["C", "B"])
+
+
+class CommitSummaryTest(unittest.TestCase):
+    def test_takes_subject_line_and_first_parent(self):
+        commit = {
+            "commit": {"message": "Fix the thing\n\nlong body"},
+            "parents": [{"sha": "p1"}, {"sha": "p2"}],
+        }
+        self.assertEqual(commit_summary(commit), ("Fix the thing", "p1"))
+
+    def test_root_commit_has_no_parent(self):
+        commit = {"commit": {"message": "Initial"}, "parents": []}
+        self.assertEqual(commit_summary(commit), ("Initial", None))
+
+
+class FirstParentCommitsTest(unittest.TestCase):
+    # A complete map means the walk never falls back to `gh_get_commit`, so these
+    # run offline. C -> B -> A, with A the merge base.
+    COMMIT_MAP = {
+        "C": ("subject C", "B"),
+        "B": ("subject B", "A"),
+    }
+
+    def test_reads_commit_map_without_fetching(self):
+        walk = first_parent_commits("A", "C", self.COMMIT_MAP, total_commits=2)
+        self.assertEqual(walk, [("C", "subject C"), ("B", "subject B")])
+
+    def test_total_commits_bounds_the_walk(self):
+        # A too-small bound trips before the walk can run away fetching commits.
+        with self.assertRaises(BumpError):
+            first_parent_commits("A", "C", self.COMMIT_MAP, total_commits=1)
+
+
+class TagLineTest(unittest.TestCase):
+    def test_default_is_ark_only(self):
+        self.assertEqual(tag_line([]), "@:ark")
+
+    def test_normalizes_bare_tags(self):
+        self.assertEqual(tag_line(["win", "console"]), "@:ark @:win @:console")
+
+    def test_keeps_already_prefixed_tags(self):
+        self.assertEqual(tag_line(["@:win"]), "@:ark @:win")
+
+    def test_dedupes_preserving_order(self):
+        self.assertEqual(tag_line(["win", "@:win", "console"]), "@:ark @:win @:console")
+
+    def test_dedupes_explicit_ark(self):
+        self.assertEqual(tag_line(["ark", "@:ark", "win"]), "@:ark @:win")
+
+
+class AuthorGateTest(unittest.TestCase):
+    def test_pr_bump_never_refuses(self):
+        self.assertFalse(blocked_by_pr_owner(False, True, "someone", "me", False))
+
+    def test_no_pr_never_refuses(self):
+        self.assertFalse(blocked_by_pr_owner(True, False, None, "me", False))
+
+    def test_confirm_overrides(self):
+        self.assertFalse(blocked_by_pr_owner(True, True, "someone", "me", True))
+
+    def test_own_pr_is_allowed(self):
+        self.assertFalse(blocked_by_pr_owner(True, True, "me", "me", False))
+
+    def test_foreign_pr_refuses(self):
+        self.assertTrue(blocked_by_pr_owner(True, True, "someone", "me", False))
+
+
+class BuildBodyTest(unittest.TestCase):
+    def test_omits_closes_block_when_empty(self):
+        body = build_body("", "@:ark", "### Release Notes\n\n- x", "- commit")
+        self.assertEqual(
+            body, "@:ark\n\n### Release Notes\n\n- x\n\n### Commits\n\n- commit"
+        )
+
+    def test_leads_with_closes_when_present(self):
+        body = build_body("Closes #1", "@:ark", "NOTES", "- commit")
+        self.assertTrue(body.startswith("Closes #1\n\n@:ark\n\n"))
+        self.assertTrue(body.endswith("### Commits\n\n- commit"))
+
+
+class ParseArgsTest(unittest.TestCase):
+    def test_target_only(self):
+        self.assertEqual(parse_args(["main"]), ("main", [], False))
+
+    def test_target_and_tags(self):
+        self.assertEqual(
+            parse_args(["123", "@:win", "@:console"]),
+            ("123", ["@:win", "@:console"], False),
+        )
+
+    def test_confirm_pulled_from_anywhere(self):
+        self.assertEqual(
+            parse_args(["main", "--confirm", "@:win"]), ("main", ["@:win"], True)
+        )
+
+    def test_no_target_exits(self):
+        with (
+            contextlib.redirect_stderr(io.StringIO()),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            parse_args(["--confirm"])
+        self.assertEqual(ctx.exception.code, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/bump-ark/test_bump_ark.py
+++ b/.claude/skills/bump-ark/test_bump_ark.py
@@ -21,6 +21,7 @@ from bump_ark import (  # noqa: E402
     blocked_by_pr_owner,
     build_body,
     classify_ancestry,
+    commit_line,
     commit_summary,
     first_parent_commits,
     parse_args,
@@ -258,6 +259,26 @@ class BuildBodyTest(unittest.TestCase):
         body = build_body("Closes #1", "@:ark", "NOTES", "- commit")
         self.assertTrue(body.startswith("Closes #1\n\n@:ark\n\n"))
         self.assertTrue(body.endswith("### Commits\n\n- commit"))
+
+
+class CommitLineTest(unittest.TestCase):
+    def test_links_subject_to_the_ark_commit(self):
+        line = commit_line("abc123", "Fix the thing")
+        self.assertEqual(
+            line, f"- [Fix the thing](https://github.com/{ARK_REPO}/commit/abc123)"
+        )
+
+    def test_pr_reference_stays_inside_the_link_text(self):
+        # The `(#1308)` must land inside the link text, not trail after it, so
+        # GitHub renders it as literal text instead of autolinking a Positron issue.
+        line = commit_line("abc123", "Prevent forking (#1308)")
+        self.assertIn("[Prevent forking (#1308)]", line)
+
+    def test_escapes_brackets_in_subject(self):
+        line = commit_line("abc123", "Tweak CI [skip ci]")
+        self.assertEqual(
+            line, r"- [Tweak CI \[skip ci\]](https://github.com/" + ARK_REPO + "/commit/abc123)"
+        )
 
 
 class ParseArgsTest(unittest.TestCase):

--- a/.claude/skills/bump-ark/test_bump_ark.py
+++ b/.claude/skills/bump-ark/test_bump_ark.py
@@ -262,17 +262,24 @@ class BuildBodyTest(unittest.TestCase):
 
 class ParseArgsTest(unittest.TestCase):
     def test_target_only(self):
-        self.assertEqual(parse_args(["main"]), ("main", [], False))
+        self.assertEqual(parse_args(["main"]), ("main", [], False, False))
 
     def test_target_and_tags(self):
         self.assertEqual(
             parse_args(["123", "@:win", "@:console"]),
-            ("123", ["@:win", "@:console"], False),
+            ("123", ["@:win", "@:console"], False, False),
         )
 
     def test_confirm_pulled_from_anywhere(self):
         self.assertEqual(
-            parse_args(["main", "--confirm", "@:win"]), ("main", ["@:win"], True)
+            parse_args(["main", "--confirm", "@:win"]),
+            ("main", ["@:win"], True, False),
+        )
+
+    def test_dry_run_pulled_from_anywhere(self):
+        self.assertEqual(
+            parse_args(["main", "--dry-run", "@:win"]),
+            ("main", ["@:win"], False, True),
         )
 
     def test_no_target_exits(self):

--- a/.claude/skills/bump-ark/test_bump_notes.py
+++ b/.claude/skills/bump-ark/test_bump_notes.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+#
+# Unit tests for the skill-local release-notes glue in bump_notes.py: the section
+# rendering and the `Closes` collection wrapped around the vendored parser. Run
+# offline:
+#
+#   python3 -m unittest test_bump_notes
+#
+# The vendored parser (`parse_description.py`: `Item`, `DescriptionParser`,
+# `trim_empty_lines`) is tested upstream in posit-dev/positron-release-notes; the
+# tests here cover the parts written for this skill (`linked_issues`,
+# `render_item`, `format_section`, `addresses_issues`, `build_notes`).
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from bump_notes import (  # noqa: E402
+    addresses_issues,
+    build_notes,
+    format_section,
+    linked_issues,
+    render_item,
+)
+from parse_description import Item, ReleaseNotes  # noqa: E402
+
+
+class RenderItemTest(unittest.TestCase):
+    def test_single_line_gets_bullet_prefix(self):
+        self.assertEqual(render_item(Item("Fix the crash", "bugfix")), "- Fix the crash")
+
+    def test_continuation_lines_are_indented(self):
+        item = Item("First line\nsecond line", "feature")
+        self.assertEqual(render_item(item), "- First line\n  second line")
+
+    def test_already_indented_continuation_is_left_alone(self):
+        item = Item("First line\n  - nested bullet", "feature")
+        self.assertEqual(render_item(item), "- First line\n  - nested bullet")
+
+
+class FormatSectionTest(unittest.TestCase):
+    def test_empty_section_renders_na(self):
+        self.assertEqual(format_section("New Features", []), "#### New Features\n\n- N/A")
+
+    def test_single_item(self):
+        items = [Item("Did a thing", "feature")]
+        self.assertEqual(format_section("New Features", items), "#### New Features\n\n- Did a thing")
+
+    def test_items_separated_by_blank_line(self):
+        items = [Item("One", "feature"), Item("Two", "feature")]
+        self.assertEqual(
+            format_section("New Features", items),
+            "#### New Features\n\n- One\n\n- Two",
+        )
+
+
+class LinkedIssuesTest(unittest.TestCase):
+    def test_dedupes_across_items_preserving_order(self):
+        notes = ReleaseNotes()
+        notes.items = [
+            Item("Fixes #10", "bugfix"),
+            Item("Also touches #20", "feature"),
+            Item("Again #10", "bugfix"),
+        ]
+        self.assertEqual(linked_issues(notes), ["10", "20"])
+
+
+class AddressesIssuesTest(unittest.TestCase):
+    def test_bare_hash_reference(self):
+        self.assertEqual(addresses_issues("Addresses #123"), ["123"])
+
+    def test_comma_and_and_separated_run(self):
+        self.assertEqual(addresses_issues("Addresses #1, #2 and #3"), ["1", "2", "3"])
+
+    def test_qualified_and_url_references(self):
+        self.assertEqual(
+            addresses_issues("Addresses posit-dev/positron#42"), ["42"]
+        )
+        self.assertEqual(
+            addresses_issues("Addresses https://github.com/posit-dev/positron/issues/50"),
+            ["50"],
+        )
+
+    def test_references_inside_comments_are_ignored(self):
+        self.assertEqual(addresses_issues("<!-- Addresses #9 -->"), [])
+
+    def test_no_addresses_keyword_yields_nothing(self):
+        self.assertEqual(addresses_issues("See #7 for details"), [])
+
+    def test_matches_keyword_mid_sentence_case_insensitively(self):
+        # The regex is not anchored to a leading "Addresses" line, so any
+        # "addresses <ref>" is swept in; this pins that behavior.
+        self.assertEqual(addresses_issues("This addresses #5 fully."), ["5"])
+
+
+class BuildNotesTest(unittest.TestCase):
+    def test_aggregates_sections_and_unions_closes(self):
+        body = (
+            "### Release Notes\n\n"
+            "#### New Features\n\n"
+            "- Added a shiny thing (#100).\n\n"
+            "#### Bug Fixes\n\n"
+            "- Fixed a crash (posit-dev/positron#200).\n\n"
+            "### QA Notes\n\n"
+            "Addresses #300 and #301.\n"
+        )
+        result = build_notes([{"number": 1, "body": body}])
+
+        self.assertEqual(
+            result["notes"],
+            "### Release Notes\n\n"
+            "#### New Features\n\n"
+            "- Added a shiny thing (https://github.com/posit-dev/positron/issues/100).\n\n"
+            "#### Bug Fixes\n\n"
+            "- Fixed a crash (https://github.com/posit-dev/positron/issues/200).",
+        )
+        # Union of bullet-linked issues (100, 200) and "Addresses" refs (300, 301).
+        self.assertEqual(result["closes"], [100, 200, 300, 301])
+
+    def test_empty_category_renders_na(self):
+        body = "#### Bug Fixes\n\n- Fixed something.\n"
+        result = build_notes([{"number": 1, "body": body}])
+        self.assertIn("#### New Features\n\n- N/A", result["notes"])
+        self.assertEqual(result["closes"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The script manages the opening and updating of a submodule bump PR, including the description and release notes. It is invoked via this skill command:

```
# Bump to an Ark-side PR #XXX (open or closed)
/bump-ark #XXX [@:e2e...]

# Bump to latest Ark main
/bump-ark main [@:e2e...]
```

Here are examples of PRs that the script generated:

- Bump to latest main: https://github.com/posit-dev/positron/pull/14669
- Bump to PR: https://github.com/posit-dev/positron/pull/14678

One workflow change that is intended with this script is that we write down release notes in the Ark PRs: https://github.com/posit-dev/ark/pull/1318. This allows the script to compile release notes from multiple PRs if needed.

See `README.md` for a full description of the workflow and usage.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### Validation Steps

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information on how to validate the change, paying
  special attention to the level of risk, adjacent areas that could
  be affected by the change, and any important contextual information
  not present in the linked issues.
-->
