### PR TITLE
test(e2e/perf): emit typed variant for console execute_code metrics

### DIFF
--- a/test/e2e/tests/console/performance/console-code-execution.test.ts
+++ b/test/e2e/tests/console/performance/console-code-execution.test.ts
@@ -14,6 +14,9 @@ const LANGUAGES = [
 	{ lang: 'R', runtime: 'r', target: 'console.r', prompt: '>' },
 ] as const;
 
+// `variant` is the stable, snake_case key the e2e-test-insights dashboard groups
+// the Duration Distribution box plot by. Keep it stable even if `name` (the
+// human-readable label) changes — they're intentionally decoupled.
 const SCENARIOS = [
 	{
 		name: 'simple expression',

--- a/test/e2e/tests/console/performance/console-code-execution.test.ts
+++ b/test/e2e/tests/console/performance/console-code-execution.test.ts
@@ -17,6 +17,7 @@ const LANGUAGES = [
 const SCENARIOS = [
 	{
 		name: 'simple expression',
+		variant: 'simple_expression',
 		python: '2 ** 32',
 		r: '2 ^ 32',
 		// Both expressions evaluate to 4294967296
@@ -29,6 +30,7 @@ const SCENARIOS = [
 		// (posit-dev/positron#9852). Running below the default 10,000-line cap would never
 		// trigger trimming and would leave the regression undetected.
 		name: 'scrollback trim',
+		variant: 'scrollback_trim',
 		python: 'print("\\n".join(str(i) for i in range(1, 3001)))',
 		r: 'cat(paste(seq_len(3000), collapse = "\\n"), "\\n")',
 		// '2999' appears in both outputs but not in either code string
@@ -80,6 +82,7 @@ test.describe('Console Performance: Code Execution', {
 					}, target, {
 						language: lang,
 						description: `${lang}: ${scenario.name}`,
+						additionalContext: { variant: scenario.variant },
 					});
 
 					expect(duration_ms).toBeGreaterThan(0);

--- a/test/e2e/tests/console/performance/console-code-execution.test.ts
+++ b/test/e2e/tests/console/performance/console-code-execution.test.ts
@@ -14,9 +14,8 @@ const LANGUAGES = [
 	{ lang: 'R', runtime: 'r', target: 'console.r', prompt: '>' },
 ] as const;
 
-// `variant` is the stable, snake_case key the e2e-test-insights dashboard groups
-// the Duration Distribution box plot by. Keep it stable even if `name` (the
-// human-readable label) changes — they're intentionally decoupled.
+// `variant` is the stable grouping key; `name` is the display label. Keep them
+// decoupled. See utils/metrics/README.md for choosing dimensions.
 const SCENARIOS = [
 	{
 		name: 'simple expression',

--- a/test/e2e/tests/console/performance/console-code-execution.test.ts
+++ b/test/e2e/tests/console/performance/console-code-execution.test.ts
@@ -85,7 +85,7 @@ test.describe('Console Performance: Code Execution', {
 					}, target, {
 						language: lang,
 						description: `${lang}: ${scenario.name}`,
-						additionalContext: { variant: scenario.variant },
+						variant: scenario.variant,
 					});
 
 					expect(duration_ms).toBeGreaterThan(0);

--- a/test/e2e/utils/metrics/README.md
+++ b/test/e2e/utils/metrics/README.md
@@ -145,24 +145,17 @@ Metrics are logged in the background without affecting test performance.
 
 ## Choosing the right dimension
 
-When a test varies something, use this to decide where it goes:
+Answer these in order and stop at the first "yes" — that's where your value goes.
 
-| What varies | Where it goes | Example |
-|---|---|---|
-| What you act on (structure, file format, session kind) | `target_type` (the `MetricTargetType` union) | `console.python`, `file.csv` |
-| A size or count that duration scales with | a numeric `context_json` field | `data_rows`, `input_rows` |
-| A named case you benchmark that shares the same action + target_type with nothing else to tell it apart | `variant` | `simple_expression` vs `scrollback_trim` |
-| A flag or property you occasionally slice by | its own `context_json` field | `filter_applied`, `preview_enabled` |
-| A human-readable row label | `target_description` (display only) | `"Python: scrollback trim"` |
+1. **A distinct thing you act on** (data structure, file type, session kind)? → `target_type`, e.g. `console.python`, `file.csv`. (Add a member to `MetricTargetType` for a genuinely new one.)
+2. **A number** (size or count)? → a numeric `context_json` field named for the quantity: `data_rows`, `input_rows`. Keep it numeric so duration can be plotted against it.
+3. **A true/false condition**? → a boolean `context_json` field: `filter_applied`, `sort_applied`, `preview_enabled`.
+4. **One of a few named scenarios of the *same* operation** — same `action` + `target_type`, nothing else to tell them apart? → `variant`, e.g. `simple_expression` vs `scrollback_trim`. Declare it as a typed union in the reporter (`ConsoleExecuteVariant`) so a typo won't compile.
+5. **Just a label to read** on the row? → `target_description` (display only).
 
-The dashboard groups the Duration Distribution box plot by `variant` (alongside action and target_type). Two distinctions trip people up:
+The dashboard splits the Duration Distribution box plot by **`variant`** (with `action` + `target_type`). Numbers and booleans are for filtering in queries, not the default split — so `filter_applied` is step 3, never a variant.
 
-- **Number vs. variant:** keep a magnitude numeric (`data_rows`) so duration can be plotted against it. Reach for `variant` only when the cases are discrete and named. Don't bucket a number into a label.
-- **Variant vs. attribute:** a variant is a scenario with no other home. An attribute like `filter_applied` already has its own field, so it is never a variant, and the dashboard does not group by attributes.
-
-`variant` values are short, stable, snake_case, low-cardinality, and declared as a typed union in the reporter (e.g. `ConsoleExecuteVariant`) so a typo won't compile. Don't put free-form or timestamped strings there, and don't hide a grouping distinction in `target_description` to force it onto the dashboard.
-
-For numeric field names, make the quantity obvious: countable nouns (`*_rows`, `*_cols`, `*_lines`) or an explicit unit (`*_ms`, `*_bytes`). Never a bare `size` or `length`.
+Keep `variant` values short, stable, and snake_case; never put a free-form or timestamped string there.
 
 ## Files
 

--- a/test/e2e/utils/metrics/README.md
+++ b/test/e2e/utils/metrics/README.md
@@ -145,27 +145,32 @@ Metrics are logged in the background without affecting test performance.
 
 ## Choosing the right dimension
 
-When a performance metric varies, put that variation in the right field so the
-dashboard can group and analyze it:
+Your test varies something — "where does it go?" Walk this in order:
 
-- **`target_type`** — *what* is being acted upon (a data structure, file format,
-  session kind). Use the `MetricTargetType` union; add a member for a genuinely
-  different target.
-- **`variant`** (in `context_json`) — a *named scenario* that shares the same
-  `(action, target_type)` but exercises a different code path or condition
-  (e.g. `simple_expression` vs `scrollback_trim`). Use when one target has 2+
-  meaningful scenarios you want compared side by side. Keep values short,
-  stable, `snake_case`, low-cardinality. Do **not** put unique/free-form/
-  timestamped strings here.
-- **Numeric context (`data_rows`, `input_rows`, …)** — workload *magnitude* you
-  expect duration to scale with. Use when the variation is a number you'd want
-  on an axis, not a named case.
-- **`target_description`** — a human-readable label for display only. Never rely
-  on it for grouping or aggregation; it is optional free text.
+1. Is it **what you're acting on** (a data structure, file format, session
+   kind)? → **`target_type`** (the `MetricTargetType` union; add a member for a
+   genuinely new target).
+2. Is it a **number** — a size/count you'd expect duration to scale with? →
+   a **numeric context field** (`data_rows`, `data_cols`, `input_rows`, …).
+   Keep it a number so the dashboard can plot duration against it.
+3. Is it a **label** — a named case or on/off condition you want to compare
+   side by side? → a **variant** (categorical). Use `variant` (in
+   `context_json`) for a named scenario like `simple_expression` vs
+   `scrollback_trim`; use a boolean like `filter_applied` / `sort_applied` for
+   an on/off condition. (Those booleans are just pre-named variants.)
+4. Is it **only a human-readable label** for the row? → **`target_description`**
+   (display only — never grouped or aggregated on).
 
-Rule of thumb: if you're tempted to encode a distinction in `target_description`
-so it shows up separately in the dashboard, that distinction belongs in
-`variant` (categorical) or a numeric context field (magnitude).
+The one call that trips people up is #2 vs #3: **number or label?** A number
+(`1_000_000` rows) keeps its magnitude — you can scatter, order, and fit a
+scaling curve. A label (`scrollback_trim`) is a discrete case with no
+in-between. Collapsing a number into a label is lossy and one-way, so keep
+numbers numeric; everything categorical is a variant.
+
+`variant` values should be short, stable, `snake_case`, low-cardinality. Never
+put unique/free-form/timestamped strings there, and don't smuggle a grouping
+distinction into `target_description` to make it show up in the dashboard — that
+belongs in `variant` (label) or a numeric field (number).
 
 ## Files
 

--- a/test/e2e/utils/metrics/README.md
+++ b/test/e2e/utils/metrics/README.md
@@ -143,6 +143,30 @@ The factory automatically captures success/error status and re-throws errors to 
 
 Metrics are logged in the background without affecting test performance.
 
+## Choosing the right dimension
+
+When a performance metric varies, put that variation in the right field so the
+dashboard can group and analyze it:
+
+- **`target_type`** — *what* is being acted upon (a data structure, file format,
+  session kind). Use the `MetricTargetType` union; add a member for a genuinely
+  different target.
+- **`variant`** (in `context_json`) — a *named scenario* that shares the same
+  `(action, target_type)` but exercises a different code path or condition
+  (e.g. `simple_expression` vs `scrollback_trim`). Use when one target has 2+
+  meaningful scenarios you want compared side by side. Keep values short,
+  stable, `snake_case`, low-cardinality. Do **not** put unique/free-form/
+  timestamped strings here.
+- **Numeric context (`data_rows`, `input_rows`, …)** — workload *magnitude* you
+  expect duration to scale with. Use when the variation is a number you'd want
+  on an axis, not a named case.
+- **`target_description`** — a human-readable label for display only. Never rely
+  on it for grouping or aggregation; it is optional free text.
+
+Rule of thumb: if you're tempted to encode a distinction in `target_description`
+so it shows up separately in the dashboard, that distinction belongs in
+`variant` (categorical) or a numeric context field (magnitude).
+
 ## Files
 
 - `metric-factory.ts` - The main factory that eliminates boilerplate

--- a/test/e2e/utils/metrics/README.md
+++ b/test/e2e/utils/metrics/README.md
@@ -172,6 +172,11 @@ put unique/free-form/timestamped strings there, and don't smuggle a grouping
 distinction into `target_description` to make it show up in the dashboard — that
 belongs in `variant` (label) or a numeric field (number).
 
+**Naming convention:** make a numeric field's quantity obvious in its name —
+counts as countable nouns (`*_rows`, `*_cols`, `*_lines`), other magnitudes with
+an explicit unit (`*_ms`, `*_bytes`). Never a bare `size`/`length`. Categorical
+(variant) fields get plain names.
+
 ## Files
 
 - `metric-factory.ts` - The main factory that eliminates boilerplate

--- a/test/e2e/utils/metrics/README.md
+++ b/test/e2e/utils/metrics/README.md
@@ -145,13 +145,14 @@ Metrics are logged in the background without affecting test performance.
 
 ## Choosing the right dimension
 
-Answer these in order and stop at the first "yes" — that's where your value goes.
+For the thing your test varies, walk these in order and stop at the first "yes" — that's the field it belongs in.
 
 1. **A distinct thing you act on** (data structure, file type, session kind)? → `target_type`, e.g. `console.python`, `file.csv`. (Add a member to `MetricTargetType` for a genuinely new one.)
 2. **A number** (size or count)? → a numeric `context_json` field named for the quantity: `data_rows`, `input_rows`. Keep it numeric so duration can be plotted against it.
 3. **A true/false condition**? → a boolean `context_json` field: `filter_applied`, `sort_applied`, `preview_enabled`.
 4. **One of a few named scenarios of the *same* operation** — same `action` + `target_type`, nothing else to tell them apart? → `variant`, e.g. `simple_expression` vs `scrollback_trim`. Declare it as a typed union in the reporter (`ConsoleExecuteVariant`) so a typo won't compile.
-5. **Just a label to read** on the row? → `target_description` (display only).
+
+Always set **`target_description`** as well — a short human-readable label for the row (e.g. `"Python: scrollback trim"`). It's display-only and never grouped, so it's independent of the choice above.
 
 The dashboard splits the Duration Distribution box plot by **`variant`** (with `action` + `target_type`). Numbers and booleans are for filtering in queries, not the default split — so `filter_applied` is step 3, never a variant.
 

--- a/test/e2e/utils/metrics/README.md
+++ b/test/e2e/utils/metrics/README.md
@@ -145,54 +145,24 @@ Metrics are logged in the background without affecting test performance.
 
 ## Choosing the right dimension
 
-Your test varies something — "where does it go?" Walk this in order:
+When a test varies something, use this to decide where it goes:
 
-1. Is it **what you're acting on** (a data structure, file format, session
-   kind)? → **`target_type`** (the `MetricTargetType` union; add a member for a
-   genuinely new target).
-2. Is it a **number** — a size/count you'd expect duration to scale with? →
-   a **numeric context field** (`data_rows`, `data_cols`, `input_rows`, …).
-   Keep it a number so the dashboard can plot duration against it.
-3. Is it a **named case** you deliberately benchmark and want as its own
-   box-plot group — one that shares the same `action`+`target_type` but has no
-   other field to distinguish it? → a **variant**. Use `variant` (in
-   `context_json`) for `simple_expression` vs `scrollback_trim`. The dashboard
-   groups the Duration Distribution box plot by it.
-4. Is it a **property/flag of the run** you might slice by occasionally, but not
-   the identity of the scenario? → an **attribute** — its own field in
-   `context_json` (`filter_applied`, `sort_applied`, `preview_enabled`, …).
-   Attributes are *not* a variant: the dashboard doesn't group by them by
-   default, and each is recoverable from its own field, so it never belongs in
-   `variant`.
-5. Is it **only a human-readable label** for the row? → **`target_description`**
-   (display only — never grouped or aggregated on).
+| What varies | Where it goes | Example |
+|---|---|---|
+| What you act on (structure, file format, session kind) | `target_type` (the `MetricTargetType` union) | `console.python`, `file.csv` |
+| A size or count that duration scales with | a numeric `context_json` field | `data_rows`, `input_rows` |
+| A named case you benchmark that shares the same action + target_type with nothing else to tell it apart | `variant` | `simple_expression` vs `scrollback_trim` |
+| A flag or property you occasionally slice by | its own `context_json` field | `filter_applied`, `preview_enabled` |
+| A human-readable row label | `target_description` (display only) | `"Python: scrollback trim"` |
 
-The calls that trip people up:
+The dashboard groups the Duration Distribution box plot by `variant` (alongside action and target_type). Two distinctions trip people up:
 
-- **#2 vs #3 — number or label?** A number (`1_000_000` rows) keeps its
-  magnitude — you can scatter, order, and fit a scaling curve. A label
-  (`scrollback_trim`) is a discrete case with no in-between. Collapsing a number
-  into a label is lossy and one-way, so keep numbers numeric.
-- **#3 vs #4 — variant or attribute?** A variant is the *identity* of a named
-  scenario that has nowhere else to live; an attribute is a flag/property that
-  already has (or could have) its own field. `filter_applied` is an attribute,
-  not a variant — nobody benchmarks "filter applied" vs "not applied" as
-  deliberately-compared box-plot groups, and the value is already in its own
-  field. If you truly wanted to compare, say, filter cost by dataset size,
-  that's a *number* (`data_rows`), bucketed at analysis time — still not a
-  variant.
+- **Number vs. variant:** keep a magnitude numeric (`data_rows`) so duration can be plotted against it. Reach for `variant` only when the cases are discrete and named. Don't bucket a number into a label.
+- **Variant vs. attribute:** a variant is a scenario with no other home. An attribute like `filter_applied` already has its own field, so it is never a variant, and the dashboard does not group by attributes.
 
-`variant` values should be short, stable, `snake_case`, low-cardinality, and
-declared as a typed union in the reporter (e.g. `ConsoleExecuteVariant`) so a
-typo won't compile. Never put unique/free-form/timestamped strings there, and
-don't smuggle a grouping distinction into `target_description` to make it show
-up in the dashboard — that belongs in `variant` (named case) or a numeric field
-(number).
+`variant` values are short, stable, snake_case, low-cardinality, and declared as a typed union in the reporter (e.g. `ConsoleExecuteVariant`) so a typo won't compile. Don't put free-form or timestamped strings there, and don't hide a grouping distinction in `target_description` to force it onto the dashboard.
 
-**Naming convention:** make a numeric field's quantity obvious in its name —
-counts as countable nouns (`*_rows`, `*_cols`, `*_lines`), other magnitudes with
-an explicit unit (`*_ms`, `*_bytes`). Never a bare `size`/`length`. Categorical
-(variant) fields get plain names.
+For numeric field names, make the quantity obvious: countable nouns (`*_rows`, `*_cols`, `*_lines`) or an explicit unit (`*_ms`, `*_bytes`). Never a bare `size` or `length`.
 
 ## Files
 

--- a/test/e2e/utils/metrics/README.md
+++ b/test/e2e/utils/metrics/README.md
@@ -153,24 +153,41 @@ Your test varies something — "where does it go?" Walk this in order:
 2. Is it a **number** — a size/count you'd expect duration to scale with? →
    a **numeric context field** (`data_rows`, `data_cols`, `input_rows`, …).
    Keep it a number so the dashboard can plot duration against it.
-3. Is it a **label** — a named case or on/off condition you want to compare
-   side by side? → a **variant** (categorical). Use `variant` (in
-   `context_json`) for a named scenario like `simple_expression` vs
-   `scrollback_trim`; use a boolean like `filter_applied` / `sort_applied` for
-   an on/off condition. (Those booleans are just pre-named variants.)
-4. Is it **only a human-readable label** for the row? → **`target_description`**
+3. Is it a **named case** you deliberately benchmark and want as its own
+   box-plot group — one that shares the same `action`+`target_type` but has no
+   other field to distinguish it? → a **variant**. Use `variant` (in
+   `context_json`) for `simple_expression` vs `scrollback_trim`. The dashboard
+   groups the Duration Distribution box plot by it.
+4. Is it a **property/flag of the run** you might slice by occasionally, but not
+   the identity of the scenario? → an **attribute** — its own field in
+   `context_json` (`filter_applied`, `sort_applied`, `preview_enabled`, …).
+   Attributes are *not* a variant: the dashboard doesn't group by them by
+   default, and each is recoverable from its own field, so it never belongs in
+   `variant`.
+5. Is it **only a human-readable label** for the row? → **`target_description`**
    (display only — never grouped or aggregated on).
 
-The one call that trips people up is #2 vs #3: **number or label?** A number
-(`1_000_000` rows) keeps its magnitude — you can scatter, order, and fit a
-scaling curve. A label (`scrollback_trim`) is a discrete case with no
-in-between. Collapsing a number into a label is lossy and one-way, so keep
-numbers numeric; everything categorical is a variant.
+The calls that trip people up:
 
-`variant` values should be short, stable, `snake_case`, low-cardinality. Never
-put unique/free-form/timestamped strings there, and don't smuggle a grouping
-distinction into `target_description` to make it show up in the dashboard — that
-belongs in `variant` (label) or a numeric field (number).
+- **#2 vs #3 — number or label?** A number (`1_000_000` rows) keeps its
+  magnitude — you can scatter, order, and fit a scaling curve. A label
+  (`scrollback_trim`) is a discrete case with no in-between. Collapsing a number
+  into a label is lossy and one-way, so keep numbers numeric.
+- **#3 vs #4 — variant or attribute?** A variant is the *identity* of a named
+  scenario that has nowhere else to live; an attribute is a flag/property that
+  already has (or could have) its own field. `filter_applied` is an attribute,
+  not a variant — nobody benchmarks "filter applied" vs "not applied" as
+  deliberately-compared box-plot groups, and the value is already in its own
+  field. If you truly wanted to compare, say, filter cost by dataset size,
+  that's a *number* (`data_rows`), bucketed at analysis time — still not a
+  variant.
+
+`variant` values should be short, stable, `snake_case`, low-cardinality, and
+declared as a typed union in the reporter (e.g. `ConsoleExecuteVariant`) so a
+typo won't compile. Never put unique/free-form/timestamped strings there, and
+don't smuggle a grouping distinction into `target_description` to make it show
+up in the dashboard — that belongs in `variant` (named case) or a numeric field
+(number).
 
 **Naming convention:** make a numeric field's quantity obvious in its name —
 counts as countable nouns (`*_rows`, `*_cols`, `*_lines`), other magnitudes with

--- a/test/e2e/utils/metrics/api.ts
+++ b/test/e2e/utils/metrics/api.ts
@@ -29,6 +29,7 @@ export type PerfMetric = {
 	action: string;
 	target_type: string;
 	target_description?: string;
+	variant?: string;
 	duration_ms: number;
 	status?: 'success' | 'error';
 	context_json?: AnyMetricContext;
@@ -49,6 +50,7 @@ export type MetricPayload = {
 	duration_ms: number;
 	status: string;
 	target_description?: string;
+	variant?: string;
 	spec_name: string;
 	context: string;
 };
@@ -103,7 +105,8 @@ function createMetricPayload(metric: PerfMetric, isElectronApp: boolean): Metric
 		duration_ms,
 		status = 'success',
 		context_json = {},
-		spec_name
+		spec_name,
+		variant
 	} = metric;
 
 	return {
@@ -120,6 +123,7 @@ function createMetricPayload(metric: PerfMetric, isElectronApp: boolean): Metric
 		duration_ms,
 		status,
 		target_description,
+		variant,
 		spec_name: spec_name || SPEC_NAME,
 		context: JSON.stringify(context_json)
 	};

--- a/test/e2e/utils/metrics/metric-base.ts
+++ b/test/e2e/utils/metrics/metric-base.ts
@@ -46,6 +46,12 @@ export type MetricContext = {
 	filter_applied?: boolean;
 	preview_enabled?: boolean;
 
+	// General: a named sub-scenario that shares one (action, target_type) but
+	// exercises a different code path. Rides in context_json; the
+	// e2e-test-insights dashboard groups the Duration Distribution box plot by
+	// it. Keep values short, stable, snake_case, low-cardinality.
+	variant?: string;
+
 	// Language runtime session fields
 	runtime_version?: string;
 	interpreter_kind?: 'system' | 'venv' | 'conda' | 'uv' | 'renv' | 'other';

--- a/test/e2e/utils/metrics/metric-console.ts
+++ b/test/e2e/utils/metrics/metric-console.ts
@@ -18,6 +18,17 @@ export type ConsoleMetric = BaseMetric & {
 	action: ConsoleAction;
 };
 
+/**
+ * Declared variants for console `execute_code` — a named sub-scenario that
+ * shares one (action, target_type) but exercises a different code path. This
+ * union is the contract: the e2e-test-insights dashboard groups the Duration
+ * Distribution box plot by `variant`, and a typo here won't compile, so the
+ * dashboard can trust the value without an allowlist. Add a member only for a
+ * genuinely new, deliberately-benchmarked scenario; keep values short, stable,
+ * and snake_case.
+ */
+export type ConsoleExecuteVariant = 'simple_expression' | 'scrollback_trim';
+
 //-----------------------
 // Create Feature Factory
 //-----------------------
@@ -44,6 +55,8 @@ export { recordConsoleMetric };
 export interface ConsoleShortcutOptions {
 	description?: string;
 	language?: string;
+	/** Declared sub-scenario for grouping in the dashboard. Typed so a typo won't compile. */
+	variant?: ConsoleExecuteVariant;
 	additionalContext?: MetricContext | (() => Promise<MetricContext>);
 }
 
@@ -58,11 +71,12 @@ export async function recordExecuteCode<T>(
 	logger: MultiLogger,
 	options: ConsoleShortcutOptions = {}
 ): Promise<MetricResult<T>> {
-	const { description, language, additionalContext } = options;
+	const { description, language, variant, additionalContext } = options;
 
-	const context_json = language !== undefined || additionalContext ? async (): Promise<MetricContext> => {
+	const context_json = language !== undefined || variant !== undefined || additionalContext ? async (): Promise<MetricContext> => {
 		const base: MetricContext = {};
 		if (language !== undefined) { base.language = language; }
+		if (variant !== undefined) { base.variant = variant; }
 
 		if (!additionalContext) {
 			return base;

--- a/test/e2e/utils/metrics/metric-console.ts
+++ b/test/e2e/utils/metrics/metric-console.ts
@@ -73,6 +73,10 @@ export async function recordExecuteCode<T>(
 ): Promise<MetricResult<T>> {
 	const { description, language, variant, additionalContext } = options;
 
+	// Dual-write during rollout: `variant` is sent as a top-level field (below)
+	// AND still written into context_json here, so the metric persists correctly
+	// whether or not the API's top-level `variant` param is deployed yet. Once the
+	// API is confirmed live, drop the context_json write (the `base.variant` line).
 	const context_json = language !== undefined || variant !== undefined || additionalContext ? async (): Promise<MetricContext> => {
 		const base: MetricContext = {};
 		if (language !== undefined) { base.language = language; }
@@ -90,6 +94,7 @@ export async function recordExecuteCode<T>(
 		action: 'execute_code',
 		target_type: targetType,
 		target_description: description || `Execute code: ${targetType}`,
+		variant,
 		context_json,
 	}, isElectronApp, logger);
 }

--- a/test/e2e/utils/metrics/metric-console.ts
+++ b/test/e2e/utils/metrics/metric-console.ts
@@ -73,10 +73,6 @@ export async function recordExecuteCode<T>(
 ): Promise<MetricResult<T>> {
 	const { description, language, variant, additionalContext } = options;
 
-	// Dual-write during rollout: `variant` is sent as a top-level field (below)
-	// AND still written into context_json here, so the metric persists correctly
-	// whether or not the API's top-level `variant` param is deployed yet. Once the
-	// API is confirmed live, drop the context_json write (the `base.variant` line).
 	const context_json = language !== undefined || variant !== undefined || additionalContext ? async (): Promise<MetricContext> => {
 		const base: MetricContext = {};
 		if (language !== undefined) { base.language = language; }

--- a/test/e2e/utils/metrics/metric-factory.ts
+++ b/test/e2e/utils/metrics/metric-factory.ts
@@ -17,6 +17,8 @@ import { logMetric } from './api.js';
 export interface FeatureMetric<TAction extends string> extends BaseMetric {
 	feature_area: string;
 	action: TAction;
+	/** Optional top-level sub-scenario dimension (see api.ts PerfMetric.variant). */
+	variant?: string;
 }
 
 /**
@@ -26,6 +28,7 @@ export interface RecordMetricParams<TAction extends string> {
 	action: TAction;
 	target_type: MetricTargetType;
 	target_description?: string;
+	variant?: string;
 	context_json?: MetricContext | (() => Promise<MetricContext>);
 	status?: MetricStatus;
 }
@@ -85,6 +88,7 @@ export function createMetricRecorder<TAction extends string>(featureArea: string
 				action: params.action,
 				target_type: params.target_type,
 				target_description: params.target_description,
+				variant: params.variant,
 				duration_ms: duration,
 				status: params.status || operationStatus,
 				context_json: resolvedContext


### PR DESCRIPTION
### Summary
Emits a typed `variant` dimension on console `execute_code` perf metrics so the e2e-test-insights dashboard can split the Duration Distribution box plot by scenario (`simple_expression` vs `scrollback_trim`).

### QA Notes
n/a