### PR TITLE
e2e: fix python-module-loading test issue

### DIFF
--- a/test/e2e/tests/debug/python-module-loading.test.ts
+++ b/test/e2e/tests/debug/python-module-loading.test.ts
@@ -12,8 +12,16 @@ test.use({
 });
 
 test.describe('Python Debugging', {
-	tag: [tags.DEBUG, tags.WEB, tags.WIN]
+	tag: [tags.DEBUG, tags.WEB, tags.WIN, tags.CONSOLE]
 }, () => {
+
+	test.beforeEach(async function ({ settings }) {
+		// Disable the missing-packages preflight so the Run gesture doesn't open a
+		// blocking install modal (app.py's local `helper` import is flagged as a
+		// missing package once its cache warms). This test is about module auto
+		// reload, not package installation.
+		await settings.set({ 'packages.confirmMissingOnRun': false }, { keepOpen: false });
+	});
 
 	test.afterAll(async function ({ cleanup }) {
 


### PR DESCRIPTION
### Summary
The `Python - Verify Module Auto Reload` e2e started failing after #14573. The Run gesture now awaits the missing-packages preflight, which opens a blocking install modal on a warm cache when the file references a missing package.

- `app.py`'s local `helper` import is flagged as missing once the cache warms, so the second run hangs on the modal and never prints "Goodbye World"
- Disable `packages.confirmMissingOnRun` for this test, which is about module auto-reload, not package installation
- Add the `@:console` tag

### QA Notes
@:console