### PR TITLE
test: add missing feature tags to e2e tests

### DIFF
--- a/test/e2e/tests/data-connections/duckdb.test.ts
+++ b/test/e2e/tests/data-connections/duckdb.test.ts
@@ -39,7 +39,7 @@ const detailColumns = [
 const detailIndexes = ['idx_customers_country'];
 
 test.describe('Data Connections - DuckDB', {
-	tag: [tags.WEB, tags.WIN, tags.CONNECTIONS, tags.WORKBENCH]
+	tag: [tags.WEB, tags.WIN, tags.CONNECTIONS, tags.WORKBENCH, tags.DATA_EXPLORER]
 }, () => {
 
 	// Configuring the connection is a one-time, stateful action. The connection and its expanded

--- a/test/e2e/tests/data-connections/duckdb.test.ts
+++ b/test/e2e/tests/data-connections/duckdb.test.ts
@@ -39,7 +39,7 @@ const detailColumns = [
 const detailIndexes = ['idx_customers_country'];
 
 test.describe('Data Connections - DuckDB', {
-	tag: [tags.WEB, tags.WIN, tags.CONNECTIONS, tags.WORKBENCH, tags.DATA_EXPLORER]
+	tag: [tags.WEB, tags.WIN, tags.CONNECTIONS, tags.WORKBENCH]
 }, () => {
 
 	// Configuring the connection is a one-time, stateful action. The connection and its expanded
@@ -101,7 +101,7 @@ test.describe('Data Connections - DuckDB', {
 		});
 	});
 
-	test('Opens a table in the Data Explorer on double-click', async function ({ app }) {
+	test('Opens a table in the Data Explorer on double-click', { tag: [tags.DATA_EXPLORER] }, async function ({ app }) {
 		const { dataConnections, dataExplorer } = app.workbench;
 
 		await dataConnections.doubleClickNode(detailTable);
@@ -110,7 +110,7 @@ test.describe('Data Connections - DuckDB', {
 		await dataExplorer.grid.expectColumnHeadersToBe(detailColumns.map(({ name }) => name));
 	});
 
-	test('Opens a column in the Data Explorer on double-click', async function ({ app }) {
+	test('Opens a column in the Data Explorer on double-click', { tag: [tags.DATA_EXPLORER] }, async function ({ app }) {
 		const { dataConnections, dataExplorer } = app.workbench;
 
 		await dataConnections.expandNode(detailTable);

--- a/test/e2e/tests/data-connections/postgres.test.ts
+++ b/test/e2e/tests/data-connections/postgres.test.ts
@@ -41,7 +41,7 @@ const actorColumns = [
 const actorIndexes = ['actor_pkey', 'idx_actor_last_name'];
 
 test.describe('Data Connections - Postgres', {
-	tag: [tags.WEB, tags.WIN, tags.CONNECTIONS, tags.WORKBENCH, tags.DATA_EXPLORER]
+	tag: [tags.WEB, tags.WIN, tags.CONNECTIONS, tags.WORKBENCH]
 }, () => {
 
 	// Configuring the connection is a one-time, stateful action (re-running the new-connection flow
@@ -115,7 +115,7 @@ test.describe('Data Connections - Postgres', {
 		});
 	});
 
-	test('Opens a table in the Data Explorer on double-click', async function ({ app }) {
+	test('Opens a table in the Data Explorer on double-click', { tag: [tags.DATA_EXPLORER] }, async function ({ app }) {
 		const { dataConnections, dataExplorer } = app.workbench;
 
 		await dataConnections.doubleClickNode('actor');
@@ -124,7 +124,7 @@ test.describe('Data Connections - Postgres', {
 		await dataExplorer.grid.expectColumnHeadersToBe(actorColumns.map(({ name }) => name));
 	});
 
-	test('Opens a column in the Data Explorer on double-click', async function ({ app }) {
+	test('Opens a column in the Data Explorer on double-click', { tag: [tags.DATA_EXPLORER] }, async function ({ app }) {
 		const { dataConnections, dataExplorer } = app.workbench;
 
 		await dataConnections.expandNode('actor');

--- a/test/e2e/tests/data-connections/postgres.test.ts
+++ b/test/e2e/tests/data-connections/postgres.test.ts
@@ -41,7 +41,7 @@ const actorColumns = [
 const actorIndexes = ['actor_pkey', 'idx_actor_last_name'];
 
 test.describe('Data Connections - Postgres', {
-	tag: [tags.WEB, tags.WIN, tags.CONNECTIONS, tags.WORKBENCH]
+	tag: [tags.WEB, tags.WIN, tags.CONNECTIONS, tags.WORKBENCH, tags.DATA_EXPLORER]
 }, () => {
 
 	// Configuring the connection is a one-time, stateful action (re-running the new-connection flow

--- a/test/e2e/tests/data-connections/sqlite.test.ts
+++ b/test/e2e/tests/data-connections/sqlite.test.ts
@@ -42,7 +42,7 @@ const detailColumns = [
 const detailIndexes = ['idx_customers_country'];
 
 test.describe('Data Connections - SQLite', {
-	tag: [tags.WEB, tags.WIN, tags.CONNECTIONS, tags.WORKBENCH, tags.DATA_EXPLORER]
+	tag: [tags.WEB, tags.WIN, tags.CONNECTIONS, tags.WORKBENCH]
 }, () => {
 
 	// SQLite connections are file-backed and stateful. Configure once and reuse across the
@@ -101,7 +101,7 @@ test.describe('Data Connections - SQLite', {
 		});
 	});
 
-	test('Opens a table in the Data Explorer on double-click', async function ({ app }) {
+	test('Opens a table in the Data Explorer on double-click', { tag: [tags.DATA_EXPLORER] }, async function ({ app }) {
 		const { dataConnections, dataExplorer } = app.workbench;
 
 		await dataConnections.doubleClickNode(detailTable);
@@ -110,7 +110,7 @@ test.describe('Data Connections - SQLite', {
 		await dataExplorer.grid.expectColumnHeadersToBe(detailColumns.map(({ name }) => name));
 	});
 
-	test('Opens a column in the Data Explorer on double-click', async function ({ app }) {
+	test('Opens a column in the Data Explorer on double-click', { tag: [tags.DATA_EXPLORER] }, async function ({ app }) {
 		const { dataConnections, dataExplorer } = app.workbench;
 
 		await dataConnections.expandNode(detailTable);

--- a/test/e2e/tests/data-connections/sqlite.test.ts
+++ b/test/e2e/tests/data-connections/sqlite.test.ts
@@ -42,7 +42,7 @@ const detailColumns = [
 const detailIndexes = ['idx_customers_country'];
 
 test.describe('Data Connections - SQLite', {
-	tag: [tags.WEB, tags.WIN, tags.CONNECTIONS, tags.WORKBENCH]
+	tag: [tags.WEB, tags.WIN, tags.CONNECTIONS, tags.WORKBENCH, tags.DATA_EXPLORER]
 }, () => {
 
 	// SQLite connections are file-backed and stateful. Configure once and reuse across the

--- a/test/e2e/tests/data-explorer/data-explorer-clipboard.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-clipboard.test.ts
@@ -24,7 +24,7 @@ const testCases: {
 	tags: string[];
 }[] = [
 		{ env: 'R', rowIndexOffset: 1, data: 'df <- read.csv("data-files/small_file.csv")', tags: [tags.WIN] },
-		{ env: 'DuckDB', rowIndexOffset: 0, data: 'data-files/small_file.csv', tags: [tags.WIN] },
+		{ env: 'DuckDB', rowIndexOffset: 0, data: 'data-files/small_file.csv', tags: [tags.WIN, tags.DUCK_DB] },
 		{ env: 'Polars', rowIndexOffset: 0, data: 'import polars as pl; df = pl.read_csv("data-files/small_file.csv")', tags: [tags.WIN] },
 		// Note: Pandas test is problematic on Windows in CI and the clipboard content is incorrect. Jon confirmed manually on his Windows machine that it works.
 		{ env: 'Pandas', rowIndexOffset: 0, data: 'import pandas as pd; df = pd.read_csv("data-files/small_file.csv")', tags: [] }

--- a/test/e2e/tests/data-explorer/data-explorer-pins.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-pins.test.ts
@@ -39,15 +39,16 @@ const testCases: {
 	env: 'Polars' | 'Pandas' | 'R' | 'DuckDB';
 	rowIndexOffset: number;
 	data: string;
+	tags?: string[];
 }[] = [
 		{ env: 'R', rowIndexOffset: 1, data: 'df <- read.csv("data-files/small_file.csv")' },
-		{ env: 'DuckDB', rowIndexOffset: 0, data: 'data-files/small_file.csv' },
+		{ env: 'DuckDB', rowIndexOffset: 0, data: 'data-files/small_file.csv', tags: [tags.DUCK_DB] },
 		{ env: 'Polars', rowIndexOffset: 0, data: 'import polars as pl; df = pl.read_csv("data-files/small_file.csv")' },
 		{ env: 'Pandas', rowIndexOffset: 0, data: 'import pandas as pd; df = pd.read_csv("data-files/small_file.csv")' }
 	];
 
-for (const { env, data, rowIndexOffset: indexOffset } of testCases) {
-	test.describe('Data Explorer: Pins', { tag: [tags.WIN, tags.WEB, tags.DATA_EXPLORER] }, () => {
+for (const { env, data, rowIndexOffset: indexOffset, tags: testTags = [] } of testCases) {
+	test.describe('Data Explorer: Pins', { tag: [tags.WIN, tags.WEB, tags.DATA_EXPLORER, ...testTags] }, () => {
 
 		test.beforeEach(async function ({ app, openDataFile, hotKeys }) {
 			const { dataExplorer, console, sessions, variables } = app.workbench;

--- a/test/e2e/tests/data-explorer/performance/convert-to-code.test.ts
+++ b/test/e2e/tests/data-explorer/performance/convert-to-code.test.ts
@@ -87,7 +87,7 @@ test.describe('Data Explorer: Convert to Code', { tag: [tags.WIN, tags.DATA_EXPL
 
 	testCases.forEach(({ environment, data: dataScript, expectedCodeStyle, dataObjectType, expectedGeneratedCode }) => {
 
-		test(`${environment} - ${expectedCodeStyle} (${dataObjectType}) - Verify copy code behavior with basic filters`, async function ({ app, sessions, hotKeys, metric, openDataFile }) {
+		test(`${environment} - ${expectedCodeStyle} (${dataObjectType}) - Verify copy code behavior with basic filters`, { tag: environment === 'DuckDB' ? [tags.DUCK_DB] : [] }, async function ({ app, sessions, hotKeys, metric, openDataFile }) {
 			const { dataExplorer, variables, modals, console, clipboard, toasts } = app.workbench;
 
 			if (environment === 'DuckDB') {

--- a/test/e2e/tests/notebook/notebook-create.test.ts
+++ b/test/e2e/tests/notebook/notebook-create.test.ts
@@ -14,7 +14,7 @@ test.use({
 let newFileName: string;
 
 test.describe('Notebooks', {
-	tag: [tags.CRITICAL, tags.WEB, tags.WIN, tags.NOTEBOOKS]
+	tag: [tags.CRITICAL, tags.WEB, tags.WIN, tags.NOTEBOOKS, tags.VARIABLES]
 }, () => {
 	test.describe('Python Notebooks', () => {
 		test.beforeAll(async function ({ app, settings }) {

--- a/test/e2e/tests/notebook/notebook-large-python.test.ts
+++ b/test/e2e/tests/notebook/notebook-large-python.test.ts
@@ -13,7 +13,7 @@ test.use({
 
 // test is too heavy for web
 test.describe('Large Python Notebook', {
-	tag: [tags.NOTEBOOKS]
+	tag: [tags.NOTEBOOKS, tags.PLOTS]
 }, () => {
 
 	test.afterAll(async function ({ hotKeys }) {

--- a/test/e2e/tests/notebook/notebook-large-r.test.ts
+++ b/test/e2e/tests/notebook/notebook-large-r.test.ts
@@ -18,7 +18,7 @@ test.describe('Large R Notebook', {
 }, () => {
 
 	test('R - Large notebook execution', {
-		tag: [tags.ARK]
+		tag: [tags.ARK, tags.PLOTS]
 	}, async function ({ app, openDataFile, runCommand, r }) {
 		test.slow();
 		const { notebooks, layouts } = app.workbench;

--- a/test/e2e/tests/notebooks-positron/notebook-edit-mode.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-edit-mode.test.ts
@@ -11,7 +11,7 @@ test.use({
 });
 
 test.describe('Notebook Edit Mode', {
-	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS, tags.CROSS_BROWSER]
+	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS, tags.CROSS_BROWSER, tags.DEBUG]
 }, () => {
 
 	test.beforeAll(async function ({ hotKeys }) {

--- a/test/e2e/tests/notebooks-positron/notebook-ghost-cell-keyboard-shortcut.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-ghost-cell-keyboard-shortcut.test.ts
@@ -16,7 +16,7 @@ test.use({
 });
 
 test.describe('Notebook: Ghost Cell Keyboard Shortcut', {
-	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS]
+	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS, tags.ASSISTANT]
 }, () => {
 	test('Cmd+Shift+G triggers ghost cell suggestion', async function ({ app, hotKeys, page, python }) {
 		const { notebooksPositron } = app.workbench;

--- a/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
@@ -12,7 +12,7 @@ test.use({
 });
 
 test.describe('Positron Notebooks: Kernel Behavior', {
-	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS, tags.SOFT_FAIL] // soft fail due to https://github.com/posit-dev/positron/issues/10546
+	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS, tags.SOFT_FAIL, tags.SESSIONS] // soft fail due to https://github.com/posit-dev/positron/issues/10546
 }, () => {
 
 	test('ensure notebook session states update correctly during start, restart, and shutdown', async function ({ app }) {

--- a/test/e2e/tests/notebooks-positron/notebook-search.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-search.test.ts
@@ -12,7 +12,7 @@ test.use({
 });
 
 test.describe('Positron Notebooks: Search & Replace', {
-	tag: [tags.POSITRON_NOTEBOOKS, tags.WEB, tags.WIN]
+	tag: [tags.POSITRON_NOTEBOOKS, tags.WEB, tags.WIN, tags.SEARCH]
 }, () => {
 
 	test('Verify Basic Search', async function ({ app }) {

--- a/test/e2e/tests/notebooks-positron/notebook-side-by-side.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-side-by-side.test.ts
@@ -20,7 +20,7 @@ test.use({
 });
 
 test.describe('Notebook Side-by-Side Isolation', {
-	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS]
+	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS, tags.SESSIONS]
 }, () => {
 
 	test.beforeAll(async function ({ hotKeys }) {

--- a/test/e2e/tests/posit-assistant/posit-assistant.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant.test.ts
@@ -13,7 +13,7 @@ test.use({
 const POSIT_ASSISTANT_PROVIDERS: ModelProvider[] = ['anthropic-api'];
 
 test.describe('Posit Assistant', {
-	tag: [tags.POSIT_ASSISTANT, tags.ASSISTANT, tags.WEB, tags.WIN],
+	tag: [tags.POSIT_ASSISTANT, tags.ASSISTANT, tags.WEB, tags.WIN, tags.PLOTS],
 }, () => {
 
 	for (const provider of POSIT_ASSISTANT_PROVIDERS) {

--- a/test/e2e/tests/viewer/viewer.test.ts
+++ b/test/e2e/tests/viewer/viewer.test.ts
@@ -9,7 +9,7 @@ test.use({
 	suiteId: __filename
 });
 
-test.describe('Viewer', { tag: [tags.VIEWER] }, () => {
+test.describe('Viewer', { tag: [tags.VIEWER, tags.CONSOLE] }, () => {
 
 	test.afterEach(async function ({ app }) {
 		await app.workbench.viewer.clearViewer();


### PR DESCRIPTION
### Summary
Tag-content sweep of the e2e suite: several tests exercise a feature area whose tag they lack, so a source change to that area would not select them when auto-tagging is setup. This adds the missing feature tag(s).

### QA Notes
n/a