### PR TITLE
Fix Data Connections DuckDB driver to share one worker per file so the same database can be opened more than once

### DIFF
--- a/extensions/positron-data-driver-duckdb/src/duckdbConnection.ts
+++ b/extensions/positron-data-driver-duckdb/src/duckdbConnection.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as positron from 'positron';
-import { DuckDBWorkerClient } from './duckdbWorkerClient.js';
+import { duckDBWorkerPool, IDuckDBWorkerLease } from './duckdbWorkerPool.js';
 import { createSchemasGroupNode, IDuckDBPreviewHost } from './duckdbNodes.js';
 import { DUCKDB_DATA_EXPLORER_PROVIDER_ID, IDuckDBDataExplorerHost } from './duckdbDataExplorerRpcHandler.js';
 
@@ -32,8 +32,10 @@ export interface DuckDBConnectionConfig {
  * getChildren().
  */
 export class DuckDBConnection implements positron.DataConnection, IDuckDBPreviewHost {
-	// The worker client, or undefined before connect()/after disconnect().
-	private _client: DuckDBWorkerClient | undefined;
+	// The pooled worker lease, or undefined before connect()/after disconnect(). Connections to the
+	// same database file share one worker via the pool, so releasing this lease closes the worker
+	// only when it is the last one for that file.
+	private _lease: IDuckDBWorkerLease | undefined;
 
 	// Unique id for this connection, used to key its previewed datasets.
 	private readonly _connectionId = `duckdb-${nextConnectionId++}`;
@@ -62,15 +64,19 @@ export class DuckDBConnection implements positron.DataConnection, IDuckDBPreview
 			throw new Error('Database file path is required');
 		}
 
-		const client = new DuckDBWorkerClient({ databasePath, readOnly: this._config.readOnly });
+		// Borrow a worker from the pool: connections to the same file + mode share one worker (and
+		// therefore one file lock), so opening the same database twice reuses the existing worker
+		// instead of spawning a second one that would fail to acquire the lock.
+		const lease = duckDBWorkerPool.acquire({ databasePath, readOnly: this._config.readOnly });
 
 		try {
 			// Probe the connection so an open failure surfaces here rather than on
 			// the first schema query. The worker reports open errors per-query.
-			await client.runQuery('SELECT 1');
-			this._client = client;
+			await lease.client.runQuery('SELECT 1');
+			this._lease = lease;
 		} catch (err: any) {
-			client.dispose();
+			// Release the lease so the worker is torn down if we were the only one holding it.
+			lease.release();
 			throw new Error(`Failed to open DuckDB database: ${databasePath}. ${err?.message ?? err}`);
 		}
 	}
@@ -81,7 +87,7 @@ export class DuckDBConnection implements positron.DataConnection, IDuckDBPreview
 	 */
 	async getChildren(): Promise<positron.DataConnectionNode[]> {
 		this._ensureConnected();
-		return [createSchemasGroupNode(this._client!, this)];
+		return [createSchemasGroupNode(this._lease!.client, this)];
 	}
 
 	/**
@@ -92,7 +98,7 @@ export class DuckDBConnection implements positron.DataConnection, IDuckDBPreview
 	async previewObject(schemaName: string, tableName: string, kind: 'table' | 'view'): Promise<void> {
 		this._ensureConnected();
 		const datasetId = `duckdbconn:${this._connectionId}:${kind}:${schemaName}.${tableName}`;
-		await this._dataExplorerHandler.openTableView(datasetId, this._client!, schemaName, tableName, kind);
+		await this._dataExplorerHandler.openTableView(datasetId, this._lease!.client, schemaName, tableName, kind);
 		this._openedDatasets.add(datasetId);
 		await positron.dataExplorer.open({
 			providerId: DUCKDB_DATA_EXPLORER_PROVIDER_ID,
@@ -108,7 +114,7 @@ export class DuckDBConnection implements positron.DataConnection, IDuckDBPreview
 	async previewColumn(schemaName: string, tableName: string, kind: 'table' | 'view', columnName: string): Promise<void> {
 		this._ensureConnected();
 		const datasetId = `duckdbconn:${this._connectionId}:column:${schemaName}.${tableName}.${columnName}`;
-		await this._dataExplorerHandler.openColumnView(datasetId, this._client!, schemaName, tableName, kind, columnName);
+		await this._dataExplorerHandler.openColumnView(datasetId, this._lease!.client, schemaName, tableName, kind, columnName);
 		this._openedDatasets.add(datasetId);
 		await positron.dataExplorer.open({
 			providerId: DUCKDB_DATA_EXPLORER_PROVIDER_ID,
@@ -128,19 +134,21 @@ export class DuckDBConnection implements positron.DataConnection, IDuckDBPreview
 			this._dataExplorerHandler.closeTableView(datasetId);
 		}
 		this._openedDatasets.clear();
-		this._client?.dispose();
-		this._client = undefined;
+		// Release our lease rather than disposing directly: the pool closes the shared worker only
+		// when the last connection to this file releases.
+		this._lease?.release();
+		this._lease = undefined;
 	}
 
 	/** Checks whether the connection is still open and operational. */
 	async isConnected(): Promise<boolean> {
 		// A crashed worker leaves the client present but not alive; don't respawn
 		// just to answer this.
-		if (!this._client || !this._client.isAlive) {
+		if (!this._lease || !this._lease.client.isAlive) {
 			return false;
 		}
 		try {
-			await this._client.runQuery('SELECT 1');
+			await this._lease.client.runQuery('SELECT 1');
 			return true;
 		} catch {
 			return false;
@@ -149,7 +157,7 @@ export class DuckDBConnection implements positron.DataConnection, IDuckDBPreview
 
 	// Throws if the database has been disconnected.
 	private _ensureConnected(): void {
-		if (!this._client) {
+		if (!this._lease) {
 			throw new Error('Database connection is closed');
 		}
 	}

--- a/extensions/positron-data-driver-duckdb/src/duckdbWorkerPool.ts
+++ b/extensions/positron-data-driver-duckdb/src/duckdbWorkerPool.ts
@@ -1,0 +1,81 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DuckDBWorkerClient } from './duckdbWorkerClient.js';
+import { WorkerOpenConfig } from './duckdbWorkerProtocol.js';
+
+/**
+ * A borrowed reference to a shared DuckDBWorkerClient. Call {@link release} exactly once when the
+ * borrowing connection is done with it; the pool disposes the underlying worker (killing its
+ * process and releasing the database file lock) once the last lease for a file is released.
+ */
+export interface IDuckDBWorkerLease {
+	/** The shared worker client. Do not dispose it directly -- call {@link release} instead. */
+	readonly client: DuckDBWorkerClient;
+
+	/** Releases this lease. Idempotent; only the first call counts against the refcount. */
+	release(): void;
+}
+
+/**
+ * Shares one DuckDBWorkerClient -- and therefore one worker process, one native DuckDBInstance, and
+ * one database file lock -- across every connection that opens the same database file in the same
+ * mode.
+ *
+ * DuckDB takes an exclusive OS-level lock on a database file opened read-write, so two separate
+ * worker processes cannot open the same file at once: the second `DuckDBInstance.create` fails with
+ * a conflicting-lock error. Two saved profiles that resolve to the same absolute path (e.g. a `~/`
+ * path and a workspace-relative `../` path pointing at one file) would otherwise hit exactly that,
+ * so the first opened connection wins and the second always fails. Pooling by resolved path + mode
+ * lets same-file connections reuse one worker (DuckDB's own one-instance-many-connections model),
+ * while connections to different files keep their own isolated worker.
+ *
+ * Read-only and read-write opens of the same file are keyed separately, since a single native
+ * instance cannot serve both access modes; that combination remains a genuine lock conflict.
+ */
+export class DuckDBWorkerPool {
+	/** Live entries keyed by {@link poolKey}, each tracking a shared client and its lease count. */
+	private readonly _entries = new Map<string, { readonly client: DuckDBWorkerClient; refCount: number }>();
+
+	/**
+	 * Borrows the shared worker for the given open configuration, spawning one if this is the first
+	 * lease for that file + mode. The returned lease must be released exactly once.
+	 */
+	acquire(config: WorkerOpenConfig): IDuckDBWorkerLease {
+		const key = poolKey(config);
+		let entry = this._entries.get(key);
+		if (!entry) {
+			entry = { client: new DuckDBWorkerClient(config), refCount: 0 };
+			this._entries.set(key, entry);
+		}
+		entry.refCount++;
+
+		let released = false;
+		return {
+			client: entry.client,
+			release: () => {
+				if (released) {
+					return;
+				}
+				released = true;
+				if (--entry.refCount === 0) {
+					entry.client.dispose();
+					this._entries.delete(key);
+				}
+			},
+		};
+	}
+}
+
+/**
+ * Keys a pool entry by access mode and resolved database path. The NUL separator cannot appear in a
+ * filesystem path, so it cannot let a path collide with the mode prefix.
+ */
+function poolKey(config: WorkerOpenConfig): string {
+	return `${config.readOnly ? 'ro' : 'rw'}\0${config.databasePath}`;
+}
+
+/** The process-wide pool shared by every DuckDB connection in this extension host. */
+export const duckDBWorkerPool = new DuckDBWorkerPool();

--- a/extensions/positron-data-driver-duckdb/src/test/duckdbDriver.test.ts
+++ b/extensions/positron-data-driver-duckdb/src/test/duckdbDriver.test.ts
@@ -88,6 +88,30 @@ suite('DuckDB Driver Tests', () => {
 		assert.strictEqual(await conn.isConnected(), false);
 	});
 
+	// Opening the same database file twice used to fail: each connection forked its own worker, and
+	// DuckDB's exclusive read-write file lock meant the second worker could not open the file. Two
+	// profiles that resolve to the same absolute path (e.g. a `~/` path and a `../` path) hit this.
+	// Connections to the same file + mode now share one pooled worker, so both succeed.
+	test('opening the same database twice shares one worker and both stay usable', async () => {
+		const dbPath = await createTestDb('shared.duckdb', 'CREATE TABLE t (x INTEGER);');
+
+		const first = await connect({ databasePath: dbPath, readOnly: false });
+		const second = await connect({ databasePath: dbPath, readOnly: false });
+
+		// Both connections are live and can browse independently.
+		assert.strictEqual(await first.isConnected(), true);
+		assert.strictEqual(await second.isConnected(), true);
+		assert.ok(await getGroup(await getSchemaNode(second), 'Tables'));
+
+		// Disconnecting one leaves the shared worker alive for the other.
+		await first.disconnect();
+		assert.strictEqual(await first.isConnected(), false);
+		assert.strictEqual(await second.isConnected(), true);
+		assert.ok(await getGroup(await getSchemaNode(second), 'Tables'));
+
+		await second.disconnect();
+	});
+
 	test('connect to non-existent file in read-only mode throws', async () => {
 		await assert.rejects(
 			() => connect({ databasePath: path.join(tmpDir, 'nonexistent.duckdb'), readOnly: true }),


### PR DESCRIPTION
## Summary

Opening the same DuckDB database file from more than one saved connection used to fail: the first connection opened fine, but every additional connection to that file failed to open, regardless of order. This fixes that by sharing one worker process per database file so a file can be opened by any number of connections at once.

## Background

Each `DuckDBConnection` forks its own worker process, and each worker opens the file with `DuckDBInstance.create(path)`. In the default read-write mode, DuckDB takes an exclusive OS-level lock on the database file, so no additional worker process can open the same file: its `create()` fails with a conflicting-lock error, which surfaces to the user as `Failed to open DuckDB database`.

This bit users whose separate connections actually resolved to the same file. `resolveDatabasePath` expands `~/db.duckdb` to `$HOME/db.duckdb` and resolves `../db.duckdb` against the workspace folder, and in a common layout both land on the same absolute path. The result is one physical database opened by multiple connections: whichever connection opened first held the lock and worked, and every other one failed. Because it is a shared exclusive resource rather than per-order state, the failure was reversible (changing which one you open first changes which one wins).

## Change

Adds a reference-counted worker pool (`duckdbWorkerPool.ts`) keyed by resolved path plus access mode. Connections to the same file and mode now share one worker process, one native `DuckDBInstance`, and one file lock, which matches DuckDB's own one-instance-many-connections model. Connections to different files keep their own isolated worker as before. `DuckDBConnection` acquires a lease in `connect()` and releases it in `disconnect()`; the shared worker is torn down only when the last connection to that file releases.

## Notes and trade-offs

Read-only and read-write opens of the same file are keyed separately, since a single native instance cannot serve both access modes; that combination remains a genuine lock conflict, but it is a rare and contradictory configuration. The default (all read-write) case now shares cleanly. Sharing a process across a file's connections means a crash (e.g. an out-of-memory abort) takes down every connection to that file; different-file crash isolation is unchanged. The SQLite driver is unaffected, since SQLite permits multiple opens of one file.

## Testing

Adds a regression test, `opening the same database twice shares one worker and both stay usable`, that opens one file from multiple connections, confirms each browses independently, and confirms disconnecting one leaves the others usable. All 26 `positron-data-driver-duckdb` extension tests pass with 0 compilation errors.

Tests:
@:connections
