### PR TITLE
Preserve ancestor scroll positions when focusing the native edit context

### DIFF
--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContextUtils.ts
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContextUtils.ts
@@ -5,6 +5,7 @@
 
 // --- Start Positron ---
 // Also import saveParentsScrollTop/restoreParentsScrollTop for the focus() fix below.
+// import { addDisposableListener, getActiveElement, getShadowRoot } from '../../../../../base/browser/dom.js';
 import { addDisposableListener, getActiveElement, getShadowRoot, restoreParentsScrollTop, saveParentsScrollTop } from '../../../../../base/browser/dom.js';
 // --- End Positron ---
 import { IDisposable, Disposable } from '../../../../../base/common/lifecycle.js';

--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContextUtils.ts
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContextUtils.ts
@@ -3,7 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { addDisposableListener, getActiveElement, getShadowRoot } from '../../../../../base/browser/dom.js';
+// --- Start Positron ---
+// Also import saveParentsScrollTop/restoreParentsScrollTop for the focus() fix below.
+import { addDisposableListener, getActiveElement, getShadowRoot, restoreParentsScrollTop, saveParentsScrollTop } from '../../../../../base/browser/dom.js';
+// --- End Positron ---
 import { IDisposable, Disposable } from '../../../../../base/common/lifecycle.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
 
@@ -61,7 +64,20 @@ export class FocusTracker extends Disposable {
 	}
 
 	public focus(): void {
+		// --- Start Positron ---
+		// If focus is outside the edit context node, browsers will try really hard
+		// to reveal it by scrolling every scrollable ancestor. The node is parked at
+		// the editor's last cursor position, so in an embedded editor whose ancestors
+		// scroll natively (e.g. a Positron notebook cell taller than the viewport)
+		// that reveal shifts the layout between Monaco's mouse-down hit tests and the
+		// click lands the cursor on the wrong line (posit-dev/positron#14085).
+		// Mirror the guard the textarea input uses (see writeNativeTextAreaContent in
+		// textAreaEditContextInput.ts): save ancestor scroll positions, focus, restore.
+		// this._domNode.focus();
+		const scrollState = saveParentsScrollTop(this._domNode);
 		this._domNode.focus();
+		restoreParentsScrollTop(this._domNode, scrollState);
+		// --- End Positron ---
 		this.refreshFocusState();
 	}
 

--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContextUtils.ts
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContextUtils.ts
@@ -66,14 +66,10 @@ export class FocusTracker extends Disposable {
 
 	public focus(): void {
 		// --- Start Positron ---
-		// If focus is outside the edit context node, browsers will try really hard
-		// to reveal it by scrolling every scrollable ancestor. The node is parked at
-		// the editor's last cursor position, so in an embedded editor whose ancestors
-		// scroll natively (e.g. a Positron notebook cell taller than the viewport)
-		// that reveal shifts the layout between Monaco's mouse-down hit tests and the
-		// click lands the cursor on the wrong line (posit-dev/positron#14085).
-		// Mirror the guard the textarea input uses (see writeNativeTextAreaContent in
-		// textAreaEditContextInput.ts): save ancestor scroll positions, focus, restore.
+		// Focusing the hidden edit context node makes the browser scroll any natively
+		// scrolling ancestor to reveal it, shifting layout mid-click and misplacing
+		// the cursor in e.g. tall Positron notebook cells (posit-dev/positron#14085).
+		// Mirror the textarea path's guard (see writeNativeTextAreaContent).
 		// this._domNode.focus();
 		const scrollState = saveParentsScrollTop(this._domNode);
 		this._domNode.focus();

--- a/test/e2e/tests/notebooks-positron/notebook-click-cursor-position.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-click-cursor-position.test.ts
@@ -84,4 +84,86 @@ test.describe('Notebook Click-to-Cursor Position', {
 			`expected the "${TARGET}" line to contain "${MARKER}". Cell lines: ${JSON.stringify(content)}`
 		).toContain(MARKER);
 	});
+
+	// Regression test for https://github.com/posit-dev/positron/issues/14085.
+	//
+	// The long-cell variant of the scenario above, following the repro from the
+	// issue: a cell taller than the viewport, exit edit mode with Esc, scroll
+	// within the cell, then click a line. The cursor must land on the clicked
+	// line.
+	//
+	// The scroll step matters: after typing, Monaco leaves the cursor (and its
+	// hidden input element) on the LAST line of the cell. Scrolling back to the
+	// top puts that hidden input far outside the notebook's scroll viewport,
+	// which is the state in which clicking a visible line placed the cursor on
+	// the wrong line.
+	test('Clicking a line in a long scrolled cell places the cursor on that line', async function ({ app }) {
+		const { notebooksPositron, toasts } = app.workbench;
+		const keyboard = app.code.driver.currentPage.keyboard;
+
+		// 60 unique filler lines make the cell taller than the viewport. The
+		// target token appears on exactly one line, near the top of the cell.
+		const lines = Array.from({ length: 60 }, (_, i) => `filler_${String(i + 1).padStart(2, '0')} = ${i + 1}`);
+		lines[4] = 'print("clicked")';
+		const TARGET = 'print';
+		const MARKER = 'ZZZ';
+
+		await notebooksPositron.newNotebook({ codeCells: 1 });
+		await notebooksPositron.addCodeToCell(0, lines.join('\n'), { fast: true });
+
+		// Repro step: press Esc to exit edit mode. Close any toasts first so a
+		// transient notification cannot swallow the keypress (see #14139), and
+		// retry the keypress in case a late toast or editor widget consumes it.
+		await toasts.closeAll();
+		await expect(async () => {
+			await keyboard.press('Escape');
+			await notebooksPositron.expectCellIndexToBeSelected(0, { inEditMode: false, timeout: 2000 });
+		}).toPass({ timeout: 15000 });
+
+		// Repro step: scroll back to the top of the cell so the target line is
+		// visible and the editor's hidden input (left on the last line) is not.
+		const targetLine = notebooksPositron
+			.editorWidgetAtIndex(0)
+			.locator('.view-line', { hasText: TARGET });
+		await targetLine.scrollIntoViewIfNeeded();
+
+		// Precondition: the hidden editor input must be outside the notebook's
+		// scroll viewport, otherwise this test degenerates into the short-cell
+		// case above and cannot catch the bug.
+		const containerBox = await notebooksPositron.cellsContainer.boundingBox();
+		const inputBox = await notebooksPositron.editorAtIndex(0).boundingBox();
+		expect(containerBox, 'notebook scroll container should be visible').toBeTruthy();
+		expect(inputBox, 'cell editor hidden input should be rendered').toBeTruthy();
+		// Require a clear margin (several text lines) so the geometry cannot be
+		// borderline: the focus-driven reveal must produce a scroll shift much
+		// larger than one line for the misplacement to be unambiguous.
+		expect(
+			inputBox!.y,
+			'hidden editor input must be well below the scroll viewport for this repro'
+		).toBeGreaterThan(containerBox!.y + containerBox!.height + 100);
+
+		// Repro step: click directly ON THE TEXT of the target line (near its
+		// start, like a user clicking the beginning of a line). This is
+		// load-bearing: a click past the end of the text resolves through a
+		// geometry-only code path in Monaco that is immune to the bug, while a
+		// click on the text resolves via a client-coordinate hit test that is
+		// not.
+		await targetLine.click({ position: { x: 5, y: 5 } });
+
+		// Wait until the click has put us back in edit mode before typing.
+		await notebooksPositron.expectCellIndexToBeSelected(0, { inEditMode: true });
+
+		// Normalize to the start of whatever line the cursor actually landed on,
+		// then insert a unique marker there.
+		await keyboard.press('Home');
+		await keyboard.type(MARKER);
+
+		// The marker must be on the line we clicked.
+		const content = await notebooksPositron.getCellContent(0);
+		const targetLineText = content.find(l => l.includes(TARGET));
+		expect(
+			targetLineText,
+			`expected the "${TARGET}" line to contain "${MARKER}". Cell lines: ${JSON.stringify(content)}`
+		).toContain(MARKER);
+	});
 });


### PR DESCRIPTION
Fixes #14085
Fixes #14656

When a Positron notebook cell is taller than the viewport, clicking a line could place the cursor on the wrong line (#14085) and/or yank the scroll position to the top of the cell (#14656). Both symptoms share one root cause: when Monaco focuses its hidden edit-context node during click handling, the browser tries to reveal that node by scrolling every scrollable ancestor. The node is parked at the editor's last cursor position, so in a long cell that reveal shifts the notebook's scroll container mid-click, desyncing Monaco's hit test from what is on screen.

The fix mirrors the guard the textarea input path has carried for years (`writeNativeTextAreaContent` in `textAreaEditContextInput.ts`): save ancestor scroll positions, focus, restore. Three lines in `FocusTracker.focus()`, fenced per upstream-compatibility conventions.

### Why this is safe outside notebooks

- The guard only writes back a `scrollTop` that actually changed during `focus()`. In stock VS Code surfaces (editors, VS Code notebooks, lists) scrolling is synthetic -- `listView.ts` even actively resets browser-initiated scrolls -- so the guard is a no-op there.
- The two input modes are switchable via `editor.editContext`, and the textarea mode has applied this exact guard globally for ~a decade. Any surface depending on the browser reveal would already be broken in textarea mode.
- Upstream's native EditContext implementation (Sept 2024) simply never got the guard; the bug only manifests in hosts with natively scrolling ancestors, which VS Code itself doesn't have. Positron notebooks are the first such host here. A follow-up PR offering the same fix to microsoft/vscode is planned, which would let this fork patch dissolve at a future upstream merge (related upstream report: microsoft/monaco-editor#4042).

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix clicks in a notebook cell taller than the viewport placing the cursor on the wrong line (#14085)
- Fix clicks in a notebook cell taller than the viewport jumping the scroll position to the top of the cell (#14656)

### Validation Steps

@:positron-notebooks

A new e2e regression test covers the long-cell scenario (`notebook-click-cursor-position.test.ts`): it verifies the precondition that the hidden edit-context node is far outside the scroll viewport, clicks a line near the top of a 60-line cell, and asserts the cursor landed on that exact line. It fails without the fix and passes with it.

Manual check:

1. Open a notebook and create a code cell with 60+ lines (taller than the viewport).
2. Press Esc to exit edit mode, scroll back to the top of the cell.
3. Click directly on the text of a visible line.
4. The cursor lands on the clicked line and the scroll position does not jump.
