### PR TITLE
doc: add reference to CI dev container README

### DIFF
--- a/test/e2e/CLAUDE.md
+++ b/test/e2e/CLAUDE.md
@@ -46,3 +46,5 @@ If the `BUILD` environment variable is set, unset it before running tests:
 ```bash
 unset BUILD
 ```
+
+To reproduce and debug a CI failure locally using the actual CI image, see [`.devcontainer/ci-arm/README.md`](../../.devcontainer/ci-arm/README.md).

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -263,6 +263,9 @@ New tests are not complete until they run successfully across operating systems 
 
 When a run is complete, you can debug any test failures that occurred using the HTML report. This report will contain everything you need: error info, test steps, screenshot(s), trace, and logs. Note that the trace files are only present for failed cases.
 
+> [!TIP]
+> To reproduce and debug a CI failure locally using the actual CI image, see [`.devcontainer/ci-arm/README.md`](../../.devcontainer/ci-arm/README.md).
+
 ## Notes About Updating Specific Tests
 
 ### Plot Tests That Use Resemblejs


### PR DESCRIPTION
### Summary
Adds a pointer from the e2e test README.md and CLAUDE.md to the CI dev container README for debugging test/CI failures against the actual CI image.

### QA Notes
n/a