### PR TITLE
Register hover delegate before eager React services init so header tooltips show

### DIFF
--- a/src/vs/workbench/browser/workbench.ts
+++ b/src/vs/workbench/browser/workbench.ts
@@ -216,11 +216,16 @@ export class Workbench extends Layout {
 		const instantiationService = new InstantiationService(serviceCollection, true);
 
 		// --- Start Positron ---
-		// The hover delegate factory must be registered before any workbench/layout
-		// components are constructed, otherwise they capture a no-op hover delegate and
-		// never show tooltips (e.g. view/sidebar header action buttons). Upstream registers
-		// this later in `startup()`, but Positron eagerly initializes React services below,
-		// which transitively constructs UI, so we must register it here first. See #13854.
+		// Register the hover delegate factory before initializing React services.
+		//
+		// Upstream registers this in `startup()` (see the identical call there),
+		// but Positron eagerly instantiates PositronReactServices just below, which
+		// pulls in ~50 services whose constructors build UI (view/sidebar header
+		// action buttons, top action bar) that captures the hover delegate at
+		// construction time. Registering here ensures they capture the real delegate
+		// instead of the no-op default. The upstream `startup()` call re-runs this
+		// harmlessly (idempotent overwrite); do not remove it because keeping it
+		// minimizes upstream merge conflicts. See #13854.
 		instantiationService.invokeFunction(accessor => {
 			setHoverDelegateFactory((placement, enableInstantHover) => instantiationService.createInstance(WorkbenchHoverDelegate, placement, { instantHover: enableInstantHover }, {}));
 			setBaseLayerHoverDelegate(accessor.get(IHoverService));

--- a/src/vs/workbench/browser/workbench.ts
+++ b/src/vs/workbench/browser/workbench.ts
@@ -216,6 +216,16 @@ export class Workbench extends Layout {
 		const instantiationService = new InstantiationService(serviceCollection, true);
 
 		// --- Start Positron ---
+		// The hover delegate factory must be registered before any workbench/layout
+		// components are constructed, otherwise they capture a no-op hover delegate and
+		// never show tooltips (e.g. view/sidebar header action buttons). Upstream registers
+		// this later in `startup()`, but Positron eagerly initializes React services below,
+		// which transitively constructs UI, so we must register it here first. See #13854.
+		instantiationService.invokeFunction(accessor => {
+			setHoverDelegateFactory((placement, enableInstantHover) => instantiationService.createInstance(WorkbenchHoverDelegate, placement, { instantHover: enableInstantHover }, {}));
+			setBaseLayerHoverDelegate(accessor.get(IHoverService));
+		});
+
 		// Initialize Positron React Services. This is done once and reused by all components.
 		PositronReactServices.initialize(instantiationService);
 		// --- End Positron ---


### PR DESCRIPTION
Fixes #13854

Tooltips never appeared for action buttons in view and sidebar headers (for example the Refresh button in the Extensions view, the Test Explorer actions, and others). This is a Positron-specific startup-ordering issue, not a change to the hover/tooltip code (that code is identical to upstream).

The header action buttons use a `WorkbenchToolBar`, which captures its hover delegate eagerly via `createInstantHoverDelegate()` when the header is built. That factory returns a no-op delegate until `setHoverDelegateFactory()` runs. Upstream registers the factory early in `startup()`, but Positron eagerly initializes React services in `initServices()` (which transitively constructs UI) before that registration happens, so any header built during that window permanently captures the no-op delegate and never shows a tooltip. Headers built later (for example a view opened after launch) worked fine, which matched the reports.

The fix registers the hover delegate factory inside `initServices()`, before `PositronReactServices.initialize()`, so it is in place before any UI is constructed.

> [!IMPORTANT]
> I left the upstream registration in `startup()` untouched, so it now runs a _second time_. IIUC the re-registration is idempotent and harmless (it overwrites the module global with an equivalent factory and passes the same singleton hover service). Leaving the upstream lines as-is means future upstream merges of that block will not conflict. Do we prefer this, or would you rather I comment out the upstream registration with a Positron marker so it is only registered once?

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed tooltips not appearing for action buttons in view and sidebar headers (#13854)

### Validation Steps

@:accessibility @:extensions

1. Launch Positron.
2. Open the Extensions view and hover the Refresh button in its header. A tooltip should appear.
3. Hover action buttons in other view/sidebar headers that are open at launch (for example the Explorer or Test Explorer header actions) and confirm tooltips appear.
