### PR TITLE
Rehydrate R HTML widgets on reopen

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
@@ -149,6 +149,57 @@ export function isWebviewOverlayShown(zoneDomNode: HTMLElement, anchor: HTMLElem
 }
 
 /**
+ * Whether a `text/html` output is inert -- free of active content (scripts,
+ * iframes, objects, embeds, `javascript:` URLs, inline event handlers) -- and
+ * therefore safe to inject directly into the DOM rather than sandboxing it in a
+ * webview.
+ *
+ * Uses substring/pattern matching rather than a parser: a false negative (inert
+ * markup treated as active) merely routes to a webview, which still renders,
+ * while a false positive would be a security gap, so we err toward "active".
+ */
+export function isInertHtml(html: string): boolean {
+	const activePatterns = [
+		/<script/i,
+		/javascript:/i,
+		/on\w+\s*=/i, // onclick, onerror, etc.
+		/<iframe/i,
+		/<object/i,
+		/<embed/i,
+	];
+	return !activePatterns.some(pattern => pattern.test(html));
+}
+
+/**
+ * How a `text/html` output item should be rendered inline in a Quarto output
+ * view zone.
+ */
+export type HtmlRenderMode = 'inline' | 'webview' | 'warning';
+
+/**
+ * Decide how to render a `text/html` output item.
+ *
+ * - `inline`: the HTML is inert, so it is injected directly into the DOM.
+ * - `webview`: the HTML has active content and must be sandboxed. The raw-HTML
+ *   webview is built from the static HTML alone via `createRawHtmlOutputWebview`
+ *   and needs no runtime session. This is what lets cached R HTML widgets (e.g.
+ *   highcharter, leaflet) restore as interactive webviews after a reload or
+ *   reopen, before any kernel session reattaches (posit-dev/positron#14559).
+ * - `warning`: no webview service is available at all, so fall back to escaped
+ *   text with a "requires webview" notice.
+ *
+ * @param html the raw HTML content of the output item.
+ * @param hasWebviewService whether a webview service is available to sandbox
+ *   active HTML.
+ */
+export function chooseHtmlRenderMode(html: string, hasWebviewService: boolean): HtmlRenderMode {
+	if (isInertHtml(html)) {
+		return 'inline';
+	}
+	return hasWebviewService ? 'webview' : 'warning';
+}
+
+/**
  * View zone for displaying Quarto cell output inline in the editor.
  * Supports text, images, error output, and complex webview-based outputs.
  */
@@ -2544,43 +2595,34 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		const container = document.createElement('div');
 		container.className = 'quarto-output-html';
 
-		// For security, only render safe HTML (no scripts)
-		if (this._isSafeHtml(content)) {
-			safeSetInnerHtml(container, content);
-		} else if (this._webviewService && this._session) {
-			// Use webview for unsafe HTML content
-			container.className = 'quarto-output-webview-container';
-			this._renderHtmlInWebview(content, output, container);
-		} else {
-			// If HTML contains scripts and no webview service available,
-			// render as escaped text with a warning
-			const warning = document.createElement('div');
-			warning.className = 'quarto-output-warning';
-			warning.textContent = localize('unsafeHtml', 'Interactive HTML output (requires webview)');
-			container.appendChild(warning);
+		// Active HTML is sandboxed in a raw-HTML webview, which is built from the
+		// static content alone and needs no runtime session -- so cached R HTML
+		// widgets restore as webviews after a reload before any kernel reattaches
+		// (posit-dev/positron#14559).
+		switch (chooseHtmlRenderMode(content, !!this._webviewService)) {
+			case 'inline':
+				safeSetInnerHtml(container, content);
+				break;
+			case 'webview':
+				container.className = 'quarto-output-webview-container';
+				this._renderHtmlInWebview(content, output, container);
+				break;
+			case 'warning': {
+				// No webview service available: render as escaped text with a warning.
+				const warning = document.createElement('div');
+				warning.className = 'quarto-output-warning';
+				warning.textContent = localize('unsafeHtml', 'Interactive HTML output (requires webview)');
+				container.appendChild(warning);
 
-			const pre = document.createElement('pre');
-			pre.className = 'quarto-output-html-escaped';
-			pre.textContent = content.substring(0, 500) + (content.length > 500 ? '...' : '');
-			container.appendChild(pre);
+				const pre = document.createElement('pre');
+				pre.className = 'quarto-output-html-escaped';
+				pre.textContent = content.substring(0, 500) + (content.length > 500 ? '...' : '');
+				container.appendChild(pre);
+				break;
+			}
 		}
 
 		return container;
-	}
-
-	private _isSafeHtml(html: string): boolean {
-		// Simple check for potentially unsafe content
-		// Rich/interactive content will be handled by webview
-		const unsafePatterns = [
-			/<script/i,
-			/javascript:/i,
-			/on\w+\s*=/i, // onclick, onerror, etc.
-			/<iframe/i,
-			/<object/i,
-			/<embed/i,
-		];
-
-		return !unsafePatterns.some(pattern => pattern.test(html));
 	}
 
 	/**
@@ -2691,7 +2733,10 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 	 * Used for unsafe HTML that requires sandboxed rendering.
 	 */
 	private async _renderHtmlInWebview(content: string, output: ICellOutput, container: HTMLElement): Promise<void> {
-		if (!this._webviewService || !this._session) {
+		// A raw-HTML webview renders static content and needs no runtime session,
+		// so it can be built when restoring cached output before a kernel
+		// reattaches (posit-dev/positron#14559).
+		if (!this._webviewService) {
 			return;
 		}
 

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputViewZone.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputViewZone.vitest.ts
@@ -5,7 +5,7 @@
 
 /// <reference types="vitest/globals" />
 
-import { isWebviewOverlayShown } from '../../browser/quartoOutputViewZone.js';
+import { chooseHtmlRenderMode, isInertHtml, isWebviewOverlayShown } from '../../browser/quartoOutputViewZone.js';
 
 // The inline-output webview is a fixed-position overlay anchored to a
 // placeholder inside the editor view zone. It must be shown only while its view
@@ -48,5 +48,47 @@ describe('isWebviewOverlayShown', () => {
 
 	it('hides the overlay when the anchor is detached from the DOM', () => {
 		expect(isWebviewOverlayShown(zone(true), anchor(false))).toBe(false);
+	});
+});
+
+describe('isInertHtml', () => {
+	it('treats plain markup as inert', () => {
+		expect(isInertHtml('<table><tr><td>1</td></tr></table>')).toBe(true);
+	});
+
+	it('treats a full inert document as inert', () => {
+		expect(isInertHtml('<!doctype html><html><body><p>hi</p></body></html>')).toBe(true);
+	});
+
+	it('flags scripts, iframes, and inline handlers as active', () => {
+		expect(isInertHtml('<div><script>run()</script></div>')).toBe(false);
+		expect(isInertHtml('<iframe src="x"></iframe>')).toBe(false);
+		expect(isInertHtml('<a href="javascript:go()">x</a>')).toBe(false);
+		expect(isInertHtml('<button onclick="go()">x</button>')).toBe(false);
+	});
+});
+
+// R HTML widgets (e.g. highcharter, leaflet) emit self-contained `text/html`
+// with <script> tags. When such an output is restored from cache after a
+// reload/reopen, no kernel session has reattached yet -- but the raw-HTML
+// webview is built from the static HTML alone and needs no session, so it must
+// still render as a webview rather than the escaped-text warning
+// (posit-dev/positron#14559).
+describe('chooseHtmlRenderMode', () => {
+	const activeHtml = '<div><script>run()</script></div>';
+	const inertHtml = '<table><tr><td>1</td></tr></table>';
+
+	it('renders inert HTML inline regardless of webview service', () => {
+		expect(chooseHtmlRenderMode(inertHtml, true)).toBe('inline');
+		expect(chooseHtmlRenderMode(inertHtml, false)).toBe('inline');
+	});
+
+	it('routes active HTML through a webview whenever the service is available', () => {
+		// This is the reload case: no session, but the service is present.
+		expect(chooseHtmlRenderMode(activeHtml, true)).toBe('webview');
+	});
+
+	it('falls back to the warning only when no webview service exists', () => {
+		expect(chooseHtmlRenderMode(activeHtml, false)).toBe('warning');
 	});
 });

--- a/test/e2e/tests/quarto/quarto-inline-output-rawhtml-persistence.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-rawhtml-persistence.test.ts
@@ -1,0 +1,115 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { join } from 'path';
+import { promises as fs } from 'fs';
+import { test, tags, expect } from './_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+const FIXTURE_REL_PATH = join('workspaces', 'quarto_inline_output', 'rawhtml_persistence.qmd');
+
+// Line of the code cell that renders the widget.
+const CELL_LINE = 6;
+
+// The escaped-text fallback shown when active HTML can't be routed to a webview.
+// This is exactly what a restored htmlwidget regressed to before the fix, so its
+// absence is the regression signal (posit-dev/positron#14559).
+const WARNING_TEXT = 'Interactive HTML output (requires webview)';
+
+// A Quarto document whose only cell renders an R htmlwidget (highcharter).
+// htmlwidget output is self-contained HTML with <script> tags that Positron
+// routes through the raw-HTML overlay webview -- the same path as the R HTML
+// widgets in the bug report. This webview is built from the static HTML alone
+// and needs no runtime session, so it must survive a close/reopen or window
+// reload even before any kernel session reattaches.
+function fixtureContent(): string {
+	return `---
+title: "Raw HTML Persistence Test"
+engine: knitr
+---
+
+\`\`\`{r}
+library(highcharter)
+hchart(data.frame(x = 1:5, y = c(1, 4, 9, 16, 25)), "scatter", hcaes(x, y))
+\`\`\`
+`;
+}
+
+test.describe('Quarto - Inline Output: Raw HTML persistence', {
+	tag: [tags.QUARTO]
+}, () => {
+
+	test.beforeEach(async function ({ app }) {
+		await fs.writeFile(join(app.workspacePathOrFolder, FIXTURE_REL_PATH), fixtureContent(), 'utf8');
+	});
+
+	test.afterEach(async function ({ app, hotKeys }) {
+		await hotKeys.closeAllEditors();
+		await fs.rm(join(app.workspacePathOrFolder, FIXTURE_REL_PATH), { force: true });
+	});
+
+	// Regression test for posit-dev/positron#14559. An R htmlwidget rendered as a
+	// raw-HTML overlay webview must restore as a webview -- not the escaped-text
+	// warning -- when the document is closed and reopened, since the cached output
+	// is rehydrated before any kernel session reattaches.
+	test('R - Verify raw HTML output restores as a webview after close and reopen', async function ({ r, app, openFile, page, hotKeys }) {
+		const { editors, inlineQuarto } = app.workbench;
+		const webview = page.locator('iframe.webview');
+
+		await openFile(FIXTURE_REL_PATH);
+		await editors.waitForActiveTab('rawhtml_persistence.qmd');
+		await inlineQuarto.expectKernelStatusVisible();
+
+		// Run the cell; the overlay webview appears once the htmlwidget renders.
+		await editors.clickTab('rawhtml_persistence.qmd');
+		await inlineQuarto.gotoLine(CELL_LINE);
+		await inlineQuarto.runCurrentCell();
+		await expect(webview.first()).toBeVisible({ timeout: 120000 });
+
+		// Close and reopen the document. The cached output rehydrates without a
+		// session; it must come back as a webview, not the raw-HTML warning.
+		await hotKeys.closeAllEditors();
+		await openFile(FIXTURE_REL_PATH);
+		await editors.waitForActiveTab('rawhtml_persistence.qmd');
+
+		await inlineQuarto.gotoLine(CELL_LINE);
+		await expect(webview.first()).toBeVisible({ timeout: 60000 });
+		await expect(page.getByText(WARNING_TEXT)).not.toBeVisible();
+	});
+
+	// Same regression, exercised via a full window reload rather than an editor
+	// close/reopen. Moved after the close/reopen case since a reload can destabilize
+	// subsequent tests.
+	test('R - Verify raw HTML output restores as a webview after window reload', async function ({ r, app, openFile, page, hotKeys }) {
+		const { editors, inlineQuarto } = app.workbench;
+		const webview = page.locator('iframe.webview');
+
+		await openFile(FIXTURE_REL_PATH);
+		await editors.waitForActiveTab('rawhtml_persistence.qmd');
+		await inlineQuarto.expectKernelStatusVisible();
+
+		await editors.clickTab('rawhtml_persistence.qmd');
+		await inlineQuarto.gotoLine(CELL_LINE);
+		await inlineQuarto.runCurrentCell();
+		await expect(webview.first()).toBeVisible({ timeout: 120000 });
+
+		// The output cache is written to disk on a 1s debounce and there is no
+		// shutdown flush, so a reload fired immediately would race the write and
+		// leave nothing to rehydrate. Wait out the debounce before reloading; a
+		// close/reopen (the other test) doesn't need this since it isn't a race.
+		await page.waitForTimeout(2000);
+
+		// Reload the window; the cached output rehydrates as the editor restores.
+		await hotKeys.reloadWindow(true);
+		await editors.waitForActiveTab('rawhtml_persistence.qmd');
+
+		await inlineQuarto.gotoLine(CELL_LINE);
+		await expect(webview.first()).toBeVisible({ timeout: 60000 });
+		await expect(page.getByText(WARNING_TEXT)).not.toBeVisible();
+	});
+});

--- a/test/e2e/tests/quarto/quarto-inline-output-rawhtml-persistence.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-rawhtml-persistence.test.ts
@@ -98,12 +98,9 @@ test.describe('Quarto - Inline Output: Raw HTML persistence', {
 		await inlineQuarto.runCurrentCell();
 		await expect(webview.first()).toBeVisible({ timeout: 120000 });
 
-		// The output cache is written to disk on a 1s debounce and there is no
-		// shutdown flush, so a reload fired immediately would race the write and
-		// leave nothing to rehydrate. Wait out the debounce before reloading; a
-		// close/reopen (the other test) doesn't need this since it isn't a race.
-		await page.waitForTimeout(2000);
-
+		// Reloading the window triggers a graceful shutdown, which flushes the
+		// output cache to disk (the service joins flushAll() on onWillShutdown),
+		// so the debounced write can't race the reload -- no wait is needed.
 		// Reload the window; the cached output rehydrates as the editor restores.
 		await hotKeys.reloadWindow(true);
 		await editors.waitForActiveTab('rawhtml_persistence.qmd');


### PR DESCRIPTION
Fixes #14559

R HTML widgets in Quarto inline output (highcharter, leaflet, etc.) rendered as raw escaped HTML with an "Interactive HTML output (requires webview)" warning after a window reload or a close/reopen of the document. These widgets emit self-contained `text/html` with `<script>` tags and carry no `webviewMetadata`, so they render through the raw-HTML path, which sandboxes active HTML in a webview.

That path gated the webview on a live kernel session, but the sandboxed webview is built from the static HTML alone (`createRawHtmlOutputWebview`) and needs no session. When cached output rehydrates on reopen/reload, no session has reattached yet, so it fell back to the escaped-text warning instead of the webview. The session requirement is removed from the raw-HTML render decision so cached widgets restore as interactive webviews, matching `.ipynb` behavior.

<img width="831" height="791" alt="image" src="https://github.com/user-attachments/assets/fc4e3e74-28be-4453-b04b-d977a99804e8" />


### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix R HTML widgets in Quarto inline output rendering as raw HTML after a reload or reopen (#14559)

### Validation Steps

@:quarto

1. Open a `.qmd` or `.rmd` file and add an R cell that renders an HTML widget:

   ```r
   library(highcharter)
   hchart(mtcars, "scatter", hcaes(wt, mpg, z = drat, color = hp)) |>
     hc_title(text = "Scatter chart with size and color")
   ```

2. Run the cell so the widget renders inline as an interactive chart.
3. Reload the window (or close and reopen the document).
4. Confirm the widget restores as the interactive chart, **not** raw HTML with a "requires webview" warning.

Automated coverage: `test/e2e/tests/quarto/quarto-inline-output-rawhtml-persistence.test.ts` (close/reopen and window-reload cases) plus unit tests for the render-mode decision in `quartoOutputViewZone.vitest.ts`.
