### PR TITLE
ci: auto-trigger release screenshots on release branch creation

### DIFF
--- a/.github/workflows/release-screenshots.yml
+++ b/.github/workflows/release-screenshots.yml
@@ -47,12 +47,6 @@ on:
     branches:
       - 'release/*'
 
-concurrency:
-  # Separate groups per mode so a publish run doesn't cancel an in-flight nightly.
-  # Kept in sync with env.MODE below (concurrency can't reference env context).
-  group: release-screenshots-${{ inputs.mode || (github.event_name == 'push' && 'publish') || 'nightly' }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
   id-token: write  # for AWS OIDC role-assumption in upload-report-to-s3
@@ -73,6 +67,13 @@ jobs:
     # this narrows to the branch's first push (creation) via the all-zero
     # "before" SHA, so subsequent commits to the branch don't rerun this.
     if: github.event_name != 'push' || github.event.before == '0000000000000000000000000000000000000000'
+    concurrency:
+      # Separate groups per mode so a publish run doesn't cancel an in-flight
+      # nightly. Job-level (not workflow-level): a run skipped by the `if`
+      # above (e.g. a non-initial push to a release branch) then never enters
+      # the group, so it can't cancel an in-flight real publish run.
+      group: release-screenshots-${{ inputs.mode || (github.event_name == 'push' && 'publish') || 'nightly' }}
+      cancel-in-progress: true
     steps:
       - name: Checkout positron
         uses: actions/checkout@v7

--- a/.github/workflows/release-screenshots.yml
+++ b/.github/workflows/release-screenshots.yml
@@ -2,9 +2,12 @@ name: "Release Screenshots"
 
 # Cron triggers nightly mode automatically (compare-only). Manual dispatch
 # can pick publish mode to open a PR in posit-dev/positron-website with
-# changed images.
+# changed images. Creating a release/* branch (branching-for-release.html,
+# step 1) also triggers publish mode automatically, against the latest
+# prerelease/daily build -- the real release build doesn't exist yet at
+# that point, so we don't wait for it (see job-level `if` below).
 
-run-name: "${{ inputs.build_from_source == true && '[source] ' || '' }}${{ inputs.mode == 'publish' && 'Publish' || 'Nightly' }}: Release Screenshots"
+run-name: "${{ inputs.build_from_source == true && '[source] ' || '' }}${{ (inputs.mode || (github.event_name == 'create' && 'publish') || 'nightly') == 'publish' && 'Publish' || 'Nightly' }}: Release Screenshots"
 
 on:
   workflow_dispatch:
@@ -34,28 +37,36 @@ on:
         default: false
   schedule:
     - cron: '0 9 * * 1-5'  # 09:00 UTC, Mon-Fri (resolves to mode=nightly, version=latest-prerelease via 'auto')
+  create:
+    # Fires for every new branch and tag; filtered to release/* branches by
+    # the job-level `if` below since `create` has no ref filter of its own.
+    # Patch releases (branching-for-release.html tip) reuse the existing
+    # release/* branch instead of creating a new one, so they don't retrigger this.
 
 concurrency:
   # Separate groups per mode so a publish run doesn't cancel an in-flight nightly.
-  group: release-screenshots-${{ inputs.mode || 'nightly' }}
+  # Kept in sync with env.MODE below (concurrency can't reference env context).
+  group: release-screenshots-${{ inputs.mode || (github.event_name == 'create' && 'publish') || 'nightly' }}
   cancel-in-progress: true
 
 permissions:
   contents: read
   id-token: write  # for AWS OIDC role-assumption in upload-report-to-s3
 
-# Normalize inputs once. Scheduled (cron) events do not populate inputs.*,
-# so we fall back to nightly defaults here and use env.MODE / env.VERSION_INPUT
-# everywhere downstream.
+# Normalize inputs once. Scheduled (cron) and create (branch) events do not
+# populate inputs.*, so we fall back to defaults here and use env.MODE /
+# env.VERSION_INPUT everywhere downstream.
 env:
-  MODE: ${{ inputs.mode || 'nightly' }}
-  VERSION_INPUT: ${{ inputs.version || 'auto' }}
+  MODE: ${{ inputs.mode || (github.event_name == 'create' && 'publish') || 'nightly' }}
+  VERSION_INPUT: ${{ inputs.version || (github.event_name == 'create' && 'latest-prerelease') || 'auto' }}
   BUILD_FROM_SOURCE: ${{ inputs.build_from_source || false }}
 
 jobs:
   release-screenshots:
-    name: screenshots-${{ inputs.mode || 'nightly' }}
+    name: screenshots-${{ inputs.mode || (github.event_name == 'create' && 'publish') || 'nightly' }}
     runs-on: macos-latest-xlarge
+    # create fires for any branch/tag; only act on new release/* branches.
+    if: github.event_name != 'create' || (github.event.ref_type == 'branch' && startsWith(github.event.ref, 'release/'))
     steps:
       - name: Checkout positron
         uses: actions/checkout@v7
@@ -422,13 +433,13 @@ jobs:
               }')"
 
   slack-notify:
-    # Notify on cron failures always; manual runs only when the box is checked.
-    # Use github.event_name instead of comparing inputs.slack_notify to a string
+    # Notify on failures from unattended triggers (cron, release/* branch
+    # creation) always; manual runs only when the box is checked. Use
+    # github.event_name instead of comparing inputs.slack_notify to a string
     # literal -- boolean inputs don't reliably coerce to strings in expressions.
     if: >-
       ${{ failure() &&
-          (inputs.mode || 'nightly') == 'nightly' &&
-          (github.event_name == 'schedule' || inputs.slack_notify == true) }}
+          (github.event_name == 'schedule' || github.event_name == 'create' || inputs.slack_notify == true) }}
     needs: [release-screenshots]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-screenshots.yml
+++ b/.github/workflows/release-screenshots.yml
@@ -2,10 +2,7 @@ name: "Release Screenshots"
 
 # Cron triggers nightly mode automatically (compare-only). Manual dispatch
 # can pick publish mode to open a PR in posit-dev/positron-website with
-# changed images. Creating a release/* branch (branching-for-release.html,
-# step 1) also triggers publish mode automatically, against the latest
-# prerelease/daily build -- the real release build doesn't exist yet at
-# that point, so we don't wait for it (see job-level `if` below).
+# changed images. Creating a release/* branch also triggers publish mode automatically, against the latest prerelease/daily build.
 
 run-name: "${{ inputs.build_from_source == true && '[source] ' || '' }}${{ (inputs.mode || (github.event_name == 'push' && 'publish') || 'nightly') == 'publish' && 'Publish' || 'Nightly' }}: Release Screenshots"
 
@@ -28,22 +25,16 @@ on:
         type: boolean
         default: false
       open_pr:
-        description: "Publish mode: open a PR if there are changes. No-op for nightly."
+        description: "Publish mode only (no-op for nightly): open a PR if there are changes."
         type: boolean
         default: true
       slack_notify:
-        description: "Notify #positron-test-results on nightly failure. Always on for scheduled runs; opt-in for manual triggers."
+        description: "Notify #positron-test-results on failure. Always on for unattended triggers (nightly cron, release branch push); opt-in for manual dispatch."
         type: boolean
         default: false
   schedule:
     - cron: '0 9 * * 1-5'  # 09:00 UTC, Mon-Fri (resolves to mode=nightly, version=latest-prerelease via 'auto')
   push:
-    # GitHub only creates a run here for branches actually matching this
-    # filter, so non-release branches never show up in this workflow's
-    # history. Job-level `if` below narrows further to the initial push
-    # (branch creation) so later commits to the branch don't retrigger this.
-    # Patch releases (branching-for-release.html tip) reuse the existing
-    # release/* branch instead of creating a new one, so they won't match either.
     branches:
       - 'release/*'
 
@@ -68,10 +59,7 @@ jobs:
     # "before" SHA, so subsequent commits to the branch don't rerun this.
     if: github.event_name != 'push' || github.event.before == '0000000000000000000000000000000000000000'
     concurrency:
-      # Separate groups per mode so a publish run doesn't cancel an in-flight
-      # nightly. Job-level (not workflow-level): a run skipped by the `if`
-      # above (e.g. a non-initial push to a release branch) then never enters
-      # the group, so it can't cancel an in-flight real publish run.
+      # Separate groups per mode so a publish run doesn't cancel nightly
       group: release-screenshots-${{ inputs.mode || (github.event_name == 'push' && 'publish') || 'nightly' }}
       cancel-in-progress: true
     steps:

--- a/.github/workflows/release-screenshots.yml
+++ b/.github/workflows/release-screenshots.yml
@@ -7,7 +7,7 @@ name: "Release Screenshots"
 # prerelease/daily build -- the real release build doesn't exist yet at
 # that point, so we don't wait for it (see job-level `if` below).
 
-run-name: "${{ inputs.build_from_source == true && '[source] ' || '' }}${{ (inputs.mode || (github.event_name == 'create' && 'publish') || 'nightly') == 'publish' && 'Publish' || 'Nightly' }}: Release Screenshots"
+run-name: "${{ inputs.build_from_source == true && '[source] ' || '' }}${{ (inputs.mode || (github.event_name == 'push' && 'publish') || 'nightly') == 'publish' && 'Publish' || 'Nightly' }}: Release Screenshots"
 
 on:
   workflow_dispatch:
@@ -37,36 +37,42 @@ on:
         default: false
   schedule:
     - cron: '0 9 * * 1-5'  # 09:00 UTC, Mon-Fri (resolves to mode=nightly, version=latest-prerelease via 'auto')
-  create:
-    # Fires for every new branch and tag; filtered to release/* branches by
-    # the job-level `if` below since `create` has no ref filter of its own.
+  push:
+    # GitHub only creates a run here for branches actually matching this
+    # filter, so non-release branches never show up in this workflow's
+    # history. Job-level `if` below narrows further to the initial push
+    # (branch creation) so later commits to the branch don't retrigger this.
     # Patch releases (branching-for-release.html tip) reuse the existing
-    # release/* branch instead of creating a new one, so they don't retrigger this.
+    # release/* branch instead of creating a new one, so they won't match either.
+    branches:
+      - 'release/*'
 
 concurrency:
   # Separate groups per mode so a publish run doesn't cancel an in-flight nightly.
   # Kept in sync with env.MODE below (concurrency can't reference env context).
-  group: release-screenshots-${{ inputs.mode || (github.event_name == 'create' && 'publish') || 'nightly' }}
+  group: release-screenshots-${{ inputs.mode || (github.event_name == 'push' && 'publish') || 'nightly' }}
   cancel-in-progress: true
 
 permissions:
   contents: read
   id-token: write  # for AWS OIDC role-assumption in upload-report-to-s3
 
-# Normalize inputs once. Scheduled (cron) and create (branch) events do not
-# populate inputs.*, so we fall back to defaults here and use env.MODE /
-# env.VERSION_INPUT everywhere downstream.
+# Normalize inputs once. Scheduled (cron) and push (release branch creation)
+# events do not populate inputs.*, so we fall back to defaults here and use
+# env.MODE / env.VERSION_INPUT everywhere downstream.
 env:
-  MODE: ${{ inputs.mode || (github.event_name == 'create' && 'publish') || 'nightly' }}
-  VERSION_INPUT: ${{ inputs.version || (github.event_name == 'create' && 'latest-prerelease') || 'auto' }}
+  MODE: ${{ inputs.mode || (github.event_name == 'push' && 'publish') || 'nightly' }}
+  VERSION_INPUT: ${{ inputs.version || (github.event_name == 'push' && 'latest-prerelease') || 'auto' }}
   BUILD_FROM_SOURCE: ${{ inputs.build_from_source || false }}
 
 jobs:
   release-screenshots:
-    name: screenshots-${{ inputs.mode || (github.event_name == 'create' && 'publish') || 'nightly' }}
+    name: screenshots-${{ inputs.mode || (github.event_name == 'push' && 'publish') || 'nightly' }}
     runs-on: macos-latest-xlarge
-    # create fires for any branch/tag; only act on new release/* branches.
-    if: github.event_name != 'create' || (github.event.ref_type == 'branch' && startsWith(github.event.ref, 'release/'))
+    # The branches filter above already scopes push events to release/*;
+    # this narrows to the branch's first push (creation) via the all-zero
+    # "before" SHA, so subsequent commits to the branch don't rerun this.
+    if: github.event_name != 'push' || github.event.before == '0000000000000000000000000000000000000000'
     steps:
       - name: Checkout positron
         uses: actions/checkout@v7
@@ -439,7 +445,7 @@ jobs:
     # literal -- boolean inputs don't reliably coerce to strings in expressions.
     if: >-
       ${{ failure() &&
-          (github.event_name == 'schedule' || github.event_name == 'create' || inputs.slack_notify == true) }}
+          (github.event_name == 'schedule' || github.event_name == 'push' || inputs.slack_notify == true) }}
     needs: [release-screenshots]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Summary
Release screenshots publish mode now triggers automatically on the initial push of a `release/*` branch, instead of requiring a manual dispatch.
- Adds a `push` trigger scoped to `release/*` via GitHub's native branch filter, so non-matching branches never create a run at all
- A job-level check on the all-zero `before` SHA narrows it to the branch's first push (creation), so later commits to the branch don't rerun this
- Resolves mode to `publish` and version to `latest-prerelease` for this trigger, since the final release build doesn't exist yet at branch-cut time
- Extends failure Slack notifications to cover this trigger, since it's unattended like the nightly cron
- Patch releases reuse the existing branch, so they won't retrigger this

### QA Notes
n/a