### PR TITLE
Add server-mode PostgreSQL connections to browse all databases when n…

### DIFF
--- a/extensions/positron-data-driver-postgresql/src/postgresqlConnection.ts
+++ b/extensions/positron-data-driver-postgresql/src/postgresqlConnection.ts
@@ -7,11 +7,19 @@ import { readFileSync } from 'fs';
 import { Client } from 'pg';
 import * as positron from 'positron';
 import { ConnectionOptions } from 'tls';
-import { createSchemasGroupNode, IPostgresPreviewHost } from './postgresqlNodes.js';
+import { createDatabasesGroupNode, createSchemasGroupNode, IPostgresConnectionHost } from './postgresqlNodes.js';
 import { IPostgresDataExplorerHost, POSTGRESQL_DATA_EXPLORER_PROVIDER_ID } from './postgresqlDataExplorerRpcHandler.js';
 
 /** Monotonically increasing id so each connection's previewed datasets get a unique key. */
 let nextConnectionId = 1;
+
+/**
+ * The conventional PostgreSQL maintenance database. In server mode (no database specified) the base
+ * client connects here to enumerate the databases on the server, matching what tools like pgAdmin do.
+ * It exists on virtually every server; when it doesn't (or the role can't connect to it), the base
+ * client falls back to the pg client's default database (the user name).
+ */
+const MAINTENANCE_DATABASE = 'postgres';
 
 /**
  * The discrete connection fields, used when not connecting via a connection string. All are optional
@@ -23,9 +31,9 @@ let nextConnectionId = 1;
 export interface PostgreSQLFieldConfig {
 	host?: string;
 	port?: number;
-	database?: string;
 	user?: string;
 	password?: string;
+	database?: string;
 	ssl?: boolean;
 	// Paths to the PEM files for client-certificate authentication. When any is set, SSL is enabled
 	// regardless of `ssl`, and the server certificate is verified only when `sslRootCert` is supplied.
@@ -63,12 +71,65 @@ function buildSslConfig(config: PostgreSQLFieldConfig): boolean | ConnectionOpti
 }
 
 /**
+ * Determines whether a libpq connection string names a database. The URL form
+ * (postgresql://host/dbname) carries the database in the path; the key=value DSN form carries it in a
+ * `dbname` or `database` key. When neither is present the connection targets the whole server, so
+ * databases are browsable as the top-level nodes.
+ */
+function connectionStringHasDatabase(connectionString: string): boolean {
+	try {
+		const url = new URL(connectionString);
+		if (url.protocol === 'postgresql:' || url.protocol === 'postgres:') {
+			return url.pathname.replace(/^\//, '').length > 0;
+		}
+	} catch {
+		// Not a URL; fall through to DSN handling.
+	}
+	// key=value DSN form: look for a non-empty dbname / database value.
+	return /\b(?:dbname|database)\s*=\s*(?:'[^']+'|"[^"]+"|\S+)/i.test(connectionString);
+}
+
+/**
+ * Returns a copy of a libpq connection string scoped to the given database, used to build a
+ * per-database client in server mode. Rewrites the path of a URL-form string, or replaces/appends the
+ * `dbname` key of a key=value DSN string.
+ */
+function withConnectionStringDatabase(connectionString: string, database: string): string {
+	try {
+		const url = new URL(connectionString);
+		if (url.protocol === 'postgresql:' || url.protocol === 'postgres:') {
+			url.pathname = `/${encodeURIComponent(database)}`;
+			return url.toString();
+		}
+	} catch {
+		// Not a URL; fall through to DSN handling.
+	}
+	// key=value DSN form: replace an existing dbname/database key, or append one if none is present.
+	if (/\b(?:dbname|database)\s*=/i.test(connectionString)) {
+		return connectionString.replace(
+			/\b(?:dbname|database)(\s*=\s*)(?:'[^']*'|"[^"]*"|\S+)/i,
+			`dbname$1'${database.replace(/'/g, '\\\'')}'`
+		);
+	}
+	return `${connectionString} dbname='${database.replace(/'/g, '\\\'')}'`;
+}
+
+/**
  * A live PostgreSQL connection implementing the DataConnection interface.
  * Connects via the pg Client and provides schema browsing via getChildren().
  */
-export class PostgreSQLConnection implements positron.DataConnection, IPostgresPreviewHost {
-	// The pg client, or null after disconnect.
+export class PostgreSQLConnection implements positron.DataConnection, IPostgresConnectionHost {
+	// The pg client, or null after disconnect. In server mode this is the base client used to list
+	// databases; per-database browsing uses the clients cached in _databaseClients.
 	private _client: Client | null;
+
+	// Whether the connection targets the whole server (no database specified). In server mode the
+	// top-level nodes are the databases; otherwise they are the schemas of the single database.
+	private readonly _serverMode: boolean;
+
+	// Per-database clients created lazily in server mode, keyed by database name. Cached as promises so
+	// concurrent expansions of the same database node share a single client, and closed on disconnect.
+	private readonly _databaseClients = new Map<string, Promise<Client>>();
 
 	// Unique id for this connection, used to key its previewed datasets.
 	private readonly _connectionId = `postgresql-${nextConnectionId++}`;
@@ -85,18 +146,37 @@ export class PostgreSQLConnection implements positron.DataConnection, IPostgresP
 		private readonly _config: PostgreSQLConnectionConfig,
 		private readonly _dataExplorerHandler: IPostgresDataExplorerHost
 	) {
-		// A connection string is handed to the pg client verbatim (it parses and applies any SSL
-		// options itself); otherwise the connection is built from the individual fields.
-		this._client = _config.kind === 'connectionString'
-			? new Client({ connectionString: _config.connectionString })
-			: new Client({
-				host: _config.host,
-				port: _config.port,
-				database: _config.database,
-				user: _config.user,
-				password: _config.password,
-				ssl: buildSslConfig(_config),
-			});
+		// Server mode when no database is specified: for fields, a blank database; for a connection
+		// string, one that names no database.
+		this._serverMode = _config.kind === 'connectionString'
+			? !connectionStringHasDatabase(_config.connectionString)
+			: !_config.database;
+
+		// The base client. In server mode it connects to the maintenance database to enumerate the
+		// databases on the server; otherwise it connects to the single configured database.
+		this._client = this._serverMode ? this._buildClient(MAINTENANCE_DATABASE) : this._buildClient();
+	}
+
+	/**
+	 * Builds a pg client from the connection config, optionally scoped to a specific database (used to
+	 * create per-database clients in server mode). A connection string is parsed and applied by the pg
+	 * client itself (including SSL); otherwise the client is built from the individual fields.
+	 */
+	private _buildClient(database?: string): Client {
+		if (this._config.kind === 'connectionString') {
+			const connectionString = database !== undefined
+				? withConnectionStringDatabase(this._config.connectionString, database)
+				: this._config.connectionString;
+			return new Client({ connectionString });
+		}
+		return new Client({
+			host: this._config.host,
+			port: this._config.port,
+			user: this._config.user,
+			password: this._config.password,
+			database: database ?? this._config.database,
+			ssl: buildSslConfig(this._config),
+		});
 	}
 
 	/**
@@ -109,19 +189,40 @@ export class PostgreSQLConnection implements positron.DataConnection, IPostgresP
 		try {
 			await this._client.connect();
 		} catch (err: any) {
-			this._client = null;
-			// Report what we tried to connect to. A connection string hides the host; a socket-directory
-			// host (or no host) means a local-socket connection; otherwise report the host:port.
-			let target: string;
-			if (this._config.kind === 'connectionString') {
-				target = 'the server in the connection string';
-			} else if (this._config.host && !this._config.host.startsWith('/')) {
-				target = `${this._config.host}:${this._config.port ?? 5432}`;
-			} else {
-				target = 'the local socket';
+			// In server mode the base client targets the maintenance database; if that is unavailable
+			// (it doesn't exist, or the role can't connect to it), fall back to the pg client's default
+			// database (the user name) so enumeration still works. Any other failure is terminal.
+			if (this._serverMode) {
+				try { await this._client.end(); } catch { /* the client never connected; nothing to close */ }
+				this._client = this._buildClient();
+				try {
+					await this._client.connect();
+					return;
+				} catch (fallbackErr: any) {
+					this._client = null;
+					throw this._connectError(fallbackErr);
+				}
 			}
-			throw new Error(`Failed to connect to PostgreSQL at ${target}: ${err.message}`);
+			this._client = null;
+			throw this._connectError(err);
 		}
+	}
+
+	/**
+	 * Builds the error thrown when the base client fails to connect, naming what we tried to connect
+	 * to. A connection string hides the host; a socket-directory host (or no host) means a local-socket
+	 * connection; otherwise the host:port is reported.
+	 */
+	private _connectError(err: any): Error {
+		let target: string;
+		if (this._config.kind === 'connectionString') {
+			target = 'the server in the connection string';
+		} else if (this._config.host && !this._config.host.startsWith('/')) {
+			target = `${this._config.host}:${this._config.port ?? 5432}`;
+		} else {
+			target = 'the local socket';
+		}
+		return new Error(`Failed to connect to PostgreSQL at ${target}: ${err.message}`);
 	}
 
 	/**
@@ -133,23 +234,68 @@ export class PostgreSQLConnection implements positron.DataConnection, IPostgresP
 	}
 
 	/**
-	 * Returns top-level children: a single "Schemas" group node that lists every non-system
-	 * schema. Each schema node can be expanded to show its Tables and Views groups.
+	 * Returns top-level children. In server mode (no database specified) this is a single "Databases"
+	 * group that lists the databases on the server, each expanding to its schemas. Otherwise it is a
+	 * single "Schemas" group that lists every non-system schema in the connected database.
 	 */
 	async getChildren(): Promise<positron.DataConnectionNode[]> {
 		this._ensureConnected();
-		return [createSchemasGroupNode(this._client!, this)];
+		if (this._serverMode) {
+			return [createDatabasesGroupNode(this)];
+		}
+		return [createSchemasGroupNode(this._client!, this, undefined)];
+	}
+
+	/**
+	 * Lists the browsable databases on the server (excluding templates and databases that don't allow
+	 * connections). Used by the "Databases" group in server mode.
+	 */
+	async listDatabases(): Promise<string[]> {
+		this._ensureConnected();
+		const result = await this._client!.query(
+			`SELECT datname FROM pg_database WHERE datistemplate = false AND datallowconn = true ORDER BY datname`
+		);
+		return result.rows.map(row => row.datname);
+	}
+
+	/**
+	 * Returns a pg client connected to the given database, creating and caching it on first use so a
+	 * database node's schemas can be browsed with a client scoped to that database. The cached clients
+	 * are closed on disconnect.
+	 */
+	async getDatabaseClient(database: string): Promise<Client> {
+		this._ensureConnected();
+		let clientPromise = this._databaseClients.get(database);
+		if (!clientPromise) {
+			clientPromise = (async () => {
+				const client = this._buildClient(database);
+				await client.connect();
+				return client;
+			})();
+			// Cache the promise before awaiting so concurrent calls share it. If the connection fails,
+			// drop it from the cache so a later expansion can retry.
+			this._databaseClients.set(database, clientPromise);
+			try {
+				await clientPromise;
+			} catch (err) {
+				this._databaseClients.delete(database);
+				throw err;
+			}
+		}
+		return clientPromise;
 	}
 
 	/**
 	 * Opens the given table or view in the Data Explorer. Registers a table view with the RPC
 	 * handler under a stable per-connection dataset id, then asks Positron to open (or focus) the
-	 * explorer backed by this extension's provider.
+	 * explorer backed by this extension's provider. `client` is the client the object's node was built
+	 * against and `database` is the database it lives in (undefined in single-database mode), so the
+	 * dataset id and query client match the right database.
 	 */
-	async previewObject(schemaName: string, tableName: string, kind: 'table' | 'view'): Promise<void> {
+	async previewObject(client: Client, database: string | undefined, schemaName: string, tableName: string, kind: 'table' | 'view'): Promise<void> {
 		this._ensureConnected();
-		const datasetId = `postgresql:${this._connectionId}:${kind}:${schemaName}.${tableName}`;
-		await this._dataExplorerHandler.openTableView(datasetId, this._queryClient(), schemaName, tableName, kind);
+		const datasetId = `postgresql:${this._connectionId}:${database ?? ''}:${kind}:${schemaName}.${tableName}`;
+		await this._dataExplorerHandler.openTableView(datasetId, this._queryClient(client), schemaName, tableName, kind);
 		this._openedDatasets.add(datasetId);
 		await positron.dataExplorer.open({
 			providerId: POSTGRESQL_DATA_EXPLORER_PROVIDER_ID,
@@ -162,10 +308,10 @@ export class PostgreSQLConnection implements positron.DataConnection, IPostgresP
 	 * Opens a single column of the given table or view in the Data Explorer as a one-column grid.
 	 * Uses a dataset id distinct from the table's so both can be open at once.
 	 */
-	async previewColumn(schemaName: string, tableName: string, kind: 'table' | 'view', columnName: string): Promise<void> {
+	async previewColumn(client: Client, database: string | undefined, schemaName: string, tableName: string, kind: 'table' | 'view', columnName: string): Promise<void> {
 		this._ensureConnected();
-		const datasetId = `postgresql:${this._connectionId}:column:${schemaName}.${tableName}.${columnName}`;
-		await this._dataExplorerHandler.openColumnView(datasetId, this._queryClient(), schemaName, tableName, kind, columnName);
+		const datasetId = `postgresql:${this._connectionId}:${database ?? ''}:column:${schemaName}.${tableName}.${columnName}`;
+		await this._dataExplorerHandler.openColumnView(datasetId, this._queryClient(client), schemaName, tableName, kind, columnName);
 		this._openedDatasets.add(datasetId);
 		await positron.dataExplorer.open({
 			providerId: POSTGRESQL_DATA_EXPLORER_PROVIDER_ID,
@@ -174,9 +320,8 @@ export class PostgreSQLConnection implements positron.DataConnection, IPostgresP
 		});
 	}
 
-	/** A query client over this connection's pg client, for the Data Explorer table views. */
-	private _queryClient() {
-		const client = this._client!;
+	/** A query client over the given pg client, for the Data Explorer table views. */
+	private _queryClient(client: Client) {
 		return { runQuery: async (sql: string) => (await client.query(sql)).rows };
 	}
 
@@ -186,6 +331,17 @@ export class PostgreSQLConnection implements positron.DataConnection, IPostgresP
 			this._dataExplorerHandler.closeTableView(datasetId);
 		}
 		this._openedDatasets.clear();
+		// Close any per-database clients created in server mode. Await each settled promise so a client
+		// that connected is ended; ignore failures from clients that never connected.
+		const databaseClients = [...this._databaseClients.values()];
+		this._databaseClients.clear();
+		await Promise.all(databaseClients.map(async clientPromise => {
+			try {
+				await (await clientPromise).end();
+			} catch {
+				// The client failed to connect or has already ended; nothing to close.
+			}
+		}));
 		if (this._client) {
 			await this._client.end();
 			this._client = null;

--- a/extensions/positron-data-driver-postgresql/src/postgresqlDriver.ts
+++ b/extensions/positron-data-driver-postgresql/src/postgresqlDriver.ts
@@ -81,13 +81,13 @@ function hostPortParams(): positron.DataConnectionParameter[] {
 	];
 }
 
-/** The required database parameter, shared by every mechanism. */
+/** The optional database parameter, shared by every mechanism. Blank connects to the whole server. */
 function databaseParam(): positron.DataConnectionParameter {
 	return {
 		id: 'database',
 		label: vscode.l10n.t('Database'),
+		description: vscode.l10n.t('Leave empty to connect to the server and browse all databases.'),
 		type: positron.DataConnectionParameterType.String,
-		required: true,
 	};
 }
 
@@ -182,9 +182,11 @@ function connectionStringParam(): positron.DataConnectionParameter {
 interface PostgresConnectionFields {
 	host?: string;
 	port?: number;
-	database: string;
 	user?: string;
 	password?: string;
+	// Optional: when blank, the connection targets the whole server and databases are browsable as
+	// the top-level nodes. When set, the connection is scoped to that single database.
+	database?: string;
 	sslmode?: string;
 	sslrootcert?: string;
 	sslcert?: string;
@@ -196,9 +198,9 @@ function renderPsycopg2Code(fields: PostgresConnectionFields): positron.Connecti
 	const args: string[] = [];
 	if (fields.host) { args.push(`host="${escapeDoubleQuoted(fields.host)}"`); }
 	if (fields.port !== undefined) { args.push(`port=${fields.port}`); }
-	args.push(`dbname="${escapeDoubleQuoted(fields.database)}"`);
 	if (fields.user) { args.push(`user="${escapeDoubleQuoted(fields.user)}"`); }
 	if (fields.password) { args.push(`password="${escapeDoubleQuoted(fields.password)}"`); }
+	if (fields.database) { args.push(`dbname="${escapeDoubleQuoted(fields.database)}"`); }
 	if (fields.sslmode) { args.push(`sslmode="${escapeDoubleQuoted(fields.sslmode)}"`); }
 	if (fields.sslrootcert) { args.push(`sslrootcert="${escapeDoubleQuoted(fields.sslrootcert)}"`); }
 	if (fields.sslcert) { args.push(`sslcert="${escapeDoubleQuoted(fields.sslcert)}"`); }
@@ -219,9 +221,9 @@ function renderSqlAlchemyCode(fields: PostgresConnectionFields): positron.Connec
 	const args: string[] = [`"postgresql+psycopg2"`];
 	if (fields.host) { args.push(`host="${escapeDoubleQuoted(fields.host)}"`); }
 	if (fields.port !== undefined) { args.push(`port=${fields.port}`); }
-	args.push(`database="${escapeDoubleQuoted(fields.database)}"`);
 	if (fields.user) { args.push(`username="${escapeDoubleQuoted(fields.user)}"`); }
 	if (fields.password) { args.push(`password="${escapeDoubleQuoted(fields.password)}"`); }
+	if (fields.database) { args.push(`database="${escapeDoubleQuoted(fields.database)}"`); }
 
 	const queryEntries: string[] = [];
 	if (fields.sslmode) { queryEntries.push(`"sslmode": "${escapeDoubleQuoted(fields.sslmode)}"`); }
@@ -242,9 +244,9 @@ function renderDbiCode(fields: PostgresConnectionFields): positron.ConnectionCod
 	const args: string[] = [`RPostgres::Postgres()`];
 	if (fields.host) { args.push(`host = "${escapeDoubleQuoted(fields.host)}"`); }
 	if (fields.port !== undefined) { args.push(`port = ${fields.port}`); }
-	args.push(`dbname = "${escapeDoubleQuoted(fields.database)}"`);
 	if (fields.user) { args.push(`user = "${escapeDoubleQuoted(fields.user)}"`); }
 	if (fields.password) { args.push(`password = "${escapeDoubleQuoted(fields.password)}"`); }
+	if (fields.database) { args.push(`dbname = "${escapeDoubleQuoted(fields.database)}"`); }
 	if (fields.sslmode) { args.push(`sslmode = "${escapeDoubleQuoted(fields.sslmode)}"`); }
 	if (fields.sslrootcert) { args.push(`sslrootcert = "${escapeDoubleQuoted(fields.sslrootcert)}"`); }
 	if (fields.sslcert) { args.push(`sslcert = "${escapeDoubleQuoted(fields.sslcert)}"`); }
@@ -277,21 +279,21 @@ function generateConnectionCodeForFields(languageId: string, fields: PostgresCon
 }
 
 /**
- * Maps the usern/password mechanism's parameter values to normalized fields. The user and
- * password are optional. Returns undefined when the host or database is missing.
+ * Maps the usern/password mechanism's parameter values to normalized fields. The database, user, and
+ * password are optional; a blank database targets the whole server. Returns undefined when the host
+ * is missing.
  */
 function passwordConnectionFields(params: positron.DataConnectionParameterValues): PostgresConnectionFields | undefined {
 	const host = isNonEmptyString(params.host) ? params.host : undefined;
-	const database = isNonEmptyString(params.database) ? params.database : undefined;
-	if (!host || !database) {
+	if (!host) {
 		return undefined;
 	}
 	return {
 		host,
 		port: typeof params.port === 'number' ? params.port : 5432,
-		database,
 		user: isNonEmptyString(params.user) ? params.user : undefined,
 		password: isNonEmptyString(params.password) ? params.password : undefined,
+		database: isNonEmptyString(params.database) ? params.database : undefined,
 		sslmode: params.ssl === true ? 'require' : undefined,
 	};
 }
@@ -299,39 +301,36 @@ function passwordConnectionFields(params: positron.DataConnectionParameterValues
 /**
  * Maps the local-server mechanism's parameter values to normalized fields. The connection is over a
  * local socket, so no host, port, or password is emitted; the user is included only when set
- * (otherwise the client defaults to the OS account). Returns undefined when the database is missing.
+ * (otherwise the client defaults to the OS account). The database is optional; a blank database
+ * targets the whole server.
  */
 function localServerConnectionFields(params: positron.DataConnectionParameterValues): PostgresConnectionFields | undefined {
-	const database = isNonEmptyString(params.database) ? params.database : undefined;
-	if (!database) {
-		return undefined;
-	}
 	return {
-		database,
 		user: isNonEmptyString(params.user) ? params.user : undefined,
+		database: isNonEmptyString(params.database) ? params.database : undefined,
 	};
 }
 
 /**
  * Maps the client-certificate mechanism's parameter values to normalized fields. The server
  * certificate is verified (sslmode "verify-full") only when a CA certificate is supplied; otherwise
- * the connection is encrypted but unverified (sslmode "require"). Returns undefined when the host,
- * database, client certificate, or client key is missing.
+ * the connection is encrypted but unverified (sslmode "require"). The database is optional; a blank
+ * database targets the whole server. Returns undefined when the host, client certificate, or client
+ * key is missing.
  */
 function certConnectionFields(params: positron.DataConnectionParameterValues): PostgresConnectionFields | undefined {
 	const host = isNonEmptyString(params.host) ? params.host : undefined;
-	const database = isNonEmptyString(params.database) ? params.database : undefined;
 	const sslcert = isNonEmptyString(params.sslcert) ? params.sslcert : undefined;
 	const sslkey = isNonEmptyString(params.sslkey) ? params.sslkey : undefined;
-	if (!host || !database || !sslcert || !sslkey) {
+	if (!host || !sslcert || !sslkey) {
 		return undefined;
 	}
 	const sslrootcert = isNonEmptyString(params.sslrootcert) ? params.sslrootcert : undefined;
 	return {
 		host,
 		port: typeof params.port === 'number' ? params.port : 5432,
-		database,
 		user: isNonEmptyString(params.user) ? params.user : undefined,
+		database: isNonEmptyString(params.database) ? params.database : undefined,
 		sslmode: sslrootcert ? 'verify-full' : 'require',
 		sslrootcert,
 		sslcert,
@@ -343,7 +342,8 @@ function certConnectionFields(params: positron.DataConnectionParameterValues): P
  * Parses a libpq URL connection string into normalized fields so the same renderers can generate
  * code for it. Only the URL form (postgresql:// or postgres://) is understood; key=value DSN strings
  * return undefined (they are still handed to the client verbatim at connect time, but cannot be
- * turned into structured code). Returns undefined when the string does not parse or has no database.
+ * turned into structured code). A missing database is allowed (the connection targets the whole
+ * server). Returns undefined when the string does not parse or is not a PostgreSQL URL.
  */
 function parseConnectionString(connectionString: string): PostgresConnectionFields | undefined {
 	let url: URL;
@@ -356,15 +356,12 @@ function parseConnectionString(connectionString: string): PostgresConnectionFiel
 		return undefined;
 	}
 	const database = decodeURIComponent(url.pathname.replace(/^\//, ''));
-	if (!database) {
-		return undefined;
-	}
 	return {
 		host: url.hostname || undefined,
 		port: url.port ? Number(url.port) : undefined,
-		database,
 		user: url.username ? decodeURIComponent(url.username) : undefined,
 		password: url.password ? decodeURIComponent(url.password) : undefined,
+		database: database || undefined,
 		sslmode: url.searchParams.get('sslmode') ?? undefined,
 		sslrootcert: url.searchParams.get('sslrootcert') ?? undefined,
 		sslcert: url.searchParams.get('sslcert') ?? undefined,
@@ -420,15 +417,6 @@ function requireTcpEndpoint(params: positron.DataConnectionParameterValues): { h
 	return { host, port };
 }
 
-/** Validates and returns the required database, throwing if it is missing. */
-function requireDatabase(params: positron.DataConnectionParameterValues): string {
-	const database = params.database;
-	if (!isNonEmptyString(database)) {
-		throw new Error(vscode.l10n.t('Database is required'));
-	}
-	return database;
-}
-
 /**
  * Creates the PostgreSQL DataConnectionDriver.
  * @param context The extension context, used to locate the icon asset.
@@ -448,9 +436,9 @@ export function createPostgreSQLDriver(
 		description: vscode.l10n.t('Connect to a server over the network with a user and password.'),
 		parameters: [
 			...hostPortParams(),
-			databaseParam(),
 			userParam(),
 			passwordParam(),
+			databaseParam(),
 			sslParam(),
 		],
 	};
@@ -468,8 +456,8 @@ export function createPostgreSQLDriver(
 		label: vscode.l10n.t('Local Server (No Password)'),
 		description: vscode.l10n.t('Connect to a PostgreSQL server running on this computer using your operating system account.'),
 		parameters: [
-			databaseParam(),
 			userParam(),
+			databaseParam(),
 			{
 				// Blank uses the platform default socket location (see exampleSocketDirectory above).
 				id: 'socketDirectory',
@@ -489,8 +477,8 @@ export function createPostgreSQLDriver(
 		description: vscode.l10n.t('Connect over SSL and authenticate with a client certificate.'),
 		parameters: [
 			...hostPortParams(),
-			databaseParam(),
 			userParam(),
+			databaseParam(),
 			...clientCertParams(),
 		],
 	};
@@ -522,20 +510,20 @@ export function createPostgreSQLDriver(
 		async connect(mechanismId: string, params: positron.DataConnectionParameterValues): Promise<positron.DataConnection> {
 			switch (mechanismId) {
 				case PASSWORD_MECHANISM_ID: {
-					// Only the host, port, and database are required: a blank user defaults to the
-					// operating system account (via PGUSER), and a blank password connects without one,
-					// which works when the server does not require a password.
+					// Only the host and port are required: a blank database targets the whole server (so
+					// databases become the top-level nodes), a blank user defaults to the operating system
+					// account (via PGUSER), and a blank password connects without one, which works when the
+					// server does not require a password.
 					const { host, port } = requireTcpEndpoint(params);
-					const database = requireDatabase(params);
 
 					// Create the connection.
 					const connection = new PostgreSQLConnection({
 						kind: 'fields',
 						host,
 						port,
-						database,
 						user: isNonEmptyString(params.user) ? params.user : undefined,
 						password: isNonEmptyString(params.password) ? params.password : undefined,
+						database: isNonEmptyString(params.database) ? params.database : undefined,
 						ssl: params.ssl === true,
 					}, dataExplorerHandler);
 
@@ -546,16 +534,16 @@ export function createPostgreSQLDriver(
 					return connection;
 				}
 				case LOCAL_SERVER_MECHANISM_ID: {
-					// Only the database is required: a blank user defaults to the operating system
-					// account, and a blank socket directory lets pg use its default.
-					const database = requireDatabase(params);
+					// Nothing is required: a blank database targets the whole server (so databases become
+					// the top-level nodes), a blank user defaults to the operating system account, and a
+					// blank socket directory lets pg use its default.
 
 					// Create the connection. No password, port, or SSL: this mechanism is local-socket only.
 					const connection = new PostgreSQLConnection({
 						kind: 'fields',
 						host: isNonEmptyString(params.socketDirectory) ? params.socketDirectory : undefined,
-						database,
 						user: isNonEmptyString(params.user) ? params.user : os.userInfo().username,
+						database: isNonEmptyString(params.database) ? params.database : undefined,
 					}, dataExplorerHandler);
 
 					// Connect the connection.
@@ -565,10 +553,10 @@ export function createPostgreSQLDriver(
 					return connection;
 				}
 				case CERT_MECHANISM_ID: {
-					// The host, port, database, client certificate, and client key are required; the CA
+					// The host, port, client certificate, and client key are required; a blank database
+					// targets the whole server (so databases become the top-level nodes), and the CA
 					// certificate is optional and, when omitted, the server certificate is not verified.
 					const { host, port } = requireTcpEndpoint(params);
-					const database = requireDatabase(params);
 					const sslCert = params.sslcert;
 					if (!isNonEmptyString(sslCert)) {
 						throw new Error(vscode.l10n.t('Client Certificate is required'));
@@ -583,8 +571,8 @@ export function createPostgreSQLDriver(
 						kind: 'fields',
 						host,
 						port,
-						database,
 						user: isNonEmptyString(params.user) ? params.user : undefined,
+						database: isNonEmptyString(params.database) ? params.database : undefined,
 						ssl: true,
 						sslRootCert: isNonEmptyString(params.sslrootcert) ? params.sslrootcert : undefined,
 						sslCert,

--- a/extensions/positron-data-driver-postgresql/src/postgresqlNodes.ts
+++ b/extensions/positron-data-driver-postgresql/src/postgresqlNodes.ts
@@ -8,19 +8,67 @@ import * as positron from 'positron';
 
 /**
  * The capability a table/view/column node needs to open itself in the Data Explorer. Implemented by
- * PostgreSQLConnection, which owns the pg client and the dataset registration.
+ * PostgreSQLConnection, which owns the dataset registration. The `client` is the pg client the node
+ * was built against (the connection's own client in single-database mode, or a per-database client in
+ * server mode) and `database` is the database the object lives in (undefined in single-database mode),
+ * so previewed datasets stay unique across databases.
  */
 export interface IPostgresPreviewHost {
 	/** Opens the given table or view in the Data Explorer. */
-	previewObject(schemaName: string, tableName: string, kind: 'table' | 'view'): Promise<void>;
+	previewObject(client: Client, database: string | undefined, schemaName: string, tableName: string, kind: 'table' | 'view'): Promise<void>;
 	/** Opens a single column of the given table or view in the Data Explorer. */
-	previewColumn(schemaName: string, tableName: string, kind: 'table' | 'view', columnName: string): Promise<void>;
+	previewColumn(client: Client, database: string | undefined, schemaName: string, tableName: string, kind: 'table' | 'view', columnName: string): Promise<void>;
+}
+
+/**
+ * The capability the "Databases" group and database nodes need in server mode: listing the databases
+ * on the server and obtaining a pg client scoped to a particular database. Implemented by
+ * PostgreSQLConnection, which owns the base client and the per-database client cache.
+ */
+export interface IPostgresConnectionHost extends IPostgresPreviewHost {
+	/** Lists the names of the browsable (non-template) databases on the server. */
+	listDatabases(): Promise<string[]>;
+	/** Returns a pg client connected to the given database, creating and caching it on first use. */
+	getDatabaseClient(database: string): Promise<Client>;
+}
+
+/**
+ * Creates the root "Databases" group node, used in server mode (no database specified). Lists every
+ * browsable database as a child database node. Each database node expands to the same "Schemas" group
+ * shown in single-database mode, scoped to a per-database client.
+ */
+export function createDatabasesGroupNode(host: IPostgresConnectionHost): positron.DataConnectionNode {
+	return {
+		name: 'Databases',
+		kind: positron.DataConnectionNodeKind.GroupDatabases,
+		async getChildren() {
+			const databases = await host.listDatabases();
+			return databases.map(database => createDatabaseNode(host, database));
+		},
+	};
+}
+
+/**
+ * Creates a database node that expands to a single "Schemas" group, backed by a per-database client.
+ * Exported so unit tests can construct a database node directly against a mocked host.
+ */
+export function createDatabaseNode(host: IPostgresConnectionHost, database: string): positron.DataConnectionNode {
+	return {
+		name: database,
+		kind: positron.DataConnectionNodeKind.Database,
+		async getChildren() {
+			const client = await host.getDatabaseClient(database);
+			return [createSchemasGroupNode(client, host, database)];
+		},
+	};
 }
 
 /**
  * Creates the root "Schemas" group node. Lists every non-system schema as a child schema node.
+ * `database` is the database the schemas live in (undefined in single-database mode), threaded down
+ * to previews so their datasets stay unique across databases.
  */
-export function createSchemasGroupNode(client: Client, host: IPostgresPreviewHost): positron.DataConnectionNode {
+export function createSchemasGroupNode(client: Client, host: IPostgresPreviewHost, database: string | undefined): positron.DataConnectionNode {
 	return {
 		name: 'Schemas',
 		kind: positron.DataConnectionNodeKind.GroupSchemas,
@@ -28,7 +76,7 @@ export function createSchemasGroupNode(client: Client, host: IPostgresPreviewHos
 			const result = await client.query(
 				`SELECT schema_name FROM information_schema.schemata WHERE schema_name NOT IN ('pg_catalog', 'information_schema', 'pg_toast') ORDER BY schema_name`
 			);
-			return result.rows.map(row => createSchemaNode(client, host, row.schema_name));
+			return result.rows.map(row => createSchemaNode(client, host, database, row.schema_name));
 		},
 	};
 }
@@ -38,14 +86,14 @@ export function createSchemasGroupNode(client: Client, host: IPostgresPreviewHos
  * unit tests can construct a schema node directly against a mocked client without having to
  * walk through the root Schemas group.
  */
-export function createSchemaNode(client: Client, host: IPostgresPreviewHost, schemaName: string): positron.DataConnectionNode {
+export function createSchemaNode(client: Client, host: IPostgresPreviewHost, database: string | undefined, schemaName: string): positron.DataConnectionNode {
 	return {
 		name: schemaName,
 		kind: positron.DataConnectionNodeKind.Schema,
 		async getChildren() {
 			return [
-				createTablesGroupNode(client, host, schemaName),
-				createViewsGroupNode(client, host, schemaName),
+				createTablesGroupNode(client, host, database, schemaName),
+				createViewsGroupNode(client, host, database, schemaName),
 			];
 		},
 	};
@@ -54,7 +102,7 @@ export function createSchemaNode(client: Client, host: IPostgresPreviewHost, sch
 /**
  * Creates the "Tables" group inside a schema. Lists base tables in the schema.
  */
-function createTablesGroupNode(client: Client, host: IPostgresPreviewHost, schemaName: string): positron.DataConnectionNode {
+function createTablesGroupNode(client: Client, host: IPostgresPreviewHost, database: string | undefined, schemaName: string): positron.DataConnectionNode {
 	return {
 		name: 'Tables',
 		kind: positron.DataConnectionNodeKind.GroupTables,
@@ -63,7 +111,7 @@ function createTablesGroupNode(client: Client, host: IPostgresPreviewHost, schem
 				`SELECT table_name FROM information_schema.tables WHERE table_schema = $1 AND table_type = 'BASE TABLE' ORDER BY table_name`,
 				[schemaName]
 			);
-			return result.rows.map(row => createTableNode(client, host, schemaName, row.table_name));
+			return result.rows.map(row => createTableNode(client, host, database, schemaName, row.table_name));
 		},
 	};
 }
@@ -71,7 +119,7 @@ function createTablesGroupNode(client: Client, host: IPostgresPreviewHost, schem
 /**
  * Creates the "Views" group inside a schema. Lists views in the schema.
  */
-function createViewsGroupNode(client: Client, host: IPostgresPreviewHost, schemaName: string): positron.DataConnectionNode {
+function createViewsGroupNode(client: Client, host: IPostgresPreviewHost, database: string | undefined, schemaName: string): positron.DataConnectionNode {
 	return {
 		name: 'Views',
 		kind: positron.DataConnectionNodeKind.GroupViews,
@@ -80,7 +128,7 @@ function createViewsGroupNode(client: Client, host: IPostgresPreviewHost, schema
 				`SELECT table_name FROM information_schema.tables WHERE table_schema = $1 AND table_type = 'VIEW' ORDER BY table_name`,
 				[schemaName]
 			);
-			return result.rows.map(row => createViewNode(client, host, schemaName, row.table_name));
+			return result.rows.map(row => createViewNode(client, host, database, schemaName, row.table_name));
 		},
 	};
 }
@@ -91,6 +139,7 @@ function createViewsGroupNode(client: Client, host: IPostgresPreviewHost, schema
 function createTableNode(
 	client: Client,
 	host: IPostgresPreviewHost,
+	database: string | undefined,
 	schemaName: string,
 	tableName: string
 ): positron.DataConnectionNode {
@@ -99,12 +148,12 @@ function createTableNode(
 		kind: positron.DataConnectionNodeKind.Table,
 		async getChildren() {
 			return [
-				createColumnsGroupNode(client, host, schemaName, tableName, 'table'),
+				createColumnsGroupNode(client, host, database, schemaName, tableName, 'table'),
 				createIndexesGroupNode(client, schemaName, tableName),
 			];
 		},
 		preview() {
-			return host.previewObject(schemaName, tableName, 'table');
+			return host.previewObject(client, database, schemaName, tableName, 'table');
 		},
 	};
 }
@@ -116,6 +165,7 @@ function createTableNode(
 function createViewNode(
 	client: Client,
 	host: IPostgresPreviewHost,
+	database: string | undefined,
 	schemaName: string,
 	viewName: string
 ): positron.DataConnectionNode {
@@ -123,10 +173,10 @@ function createViewNode(
 		name: viewName,
 		kind: positron.DataConnectionNodeKind.View,
 		async getChildren() {
-			return [createColumnsGroupNode(client, host, schemaName, viewName, 'view')];
+			return [createColumnsGroupNode(client, host, database, schemaName, viewName, 'view')];
 		},
 		preview() {
-			return host.previewObject(schemaName, viewName, 'view');
+			return host.previewObject(client, database, schemaName, viewName, 'view');
 		},
 	};
 }
@@ -138,6 +188,7 @@ function createViewNode(
 function createColumnsGroupNode(
 	client: Client,
 	host: IPostgresPreviewHost,
+	database: string | undefined,
 	schemaName: string,
 	relationName: string,
 	kind: 'table' | 'view'
@@ -163,7 +214,7 @@ function createColumnsGroupNode(
 					dataType: formatDataType(row),
 					isPrimaryKey: primaryKeyColumns.has(columnName),
 					preview() {
-						return host.previewColumn(schemaName, relationName, kind, columnName);
+						return host.previewColumn(client, database, schemaName, relationName, kind, columnName);
 					},
 				};
 			});

--- a/extensions/positron-data-driver-postgresql/src/test/dataConnectionIntegration.test.ts
+++ b/extensions/positron-data-driver-postgresql/src/test/dataConnectionIntegration.test.ts
@@ -54,9 +54,9 @@ suite('PostgreSQL Data Connection Integration', () => {
 		setupClient = new Client({
 			host: pgHost,
 			port: pgPort,
-			database: pgDatabase,
 			user: pgUser,
 			password: pgPassword,
+			database: pgDatabase,
 		});
 
 		try {
@@ -95,9 +95,9 @@ suite('PostgreSQL Data Connection Integration', () => {
 		return positron.dataConnections.connect('positron-data-driver-postgresql', 'password', {
 			host: pgHost,
 			port: pgPort,
-			database: pgDatabase,
 			user: pgUser,
 			password: pgPassword,
+			database: pgDatabase,
 			ssl: false,
 		});
 	}
@@ -219,7 +219,7 @@ suite('PostgreSQL Data Connection Integration', () => {
 				assert.strictEqual(localServerMechanism, undefined);
 			} else {
 				assert.ok(localServerMechanism);
-				assert.deepStrictEqual(localServerMechanism.parameters.map(p => p.id), ['database', 'user', 'socketDirectory']);
+				assert.deepStrictEqual(localServerMechanism.parameters.map(p => p.id), ['user', 'database', 'socketDirectory']);
 			}
 
 			// The connection-string mechanism takes a single secret parameter and is offered on all
@@ -233,7 +233,7 @@ suite('PostgreSQL Data Connection Integration', () => {
 			// The client-certificate mechanism is offered on all platforms (it runs over TCP/TLS).
 			const certMechanism = pg.mechanisms.find(m => m.id === 'clientCert');
 			assert.ok(certMechanism);
-			assert.deepStrictEqual(certMechanism.parameters.map(p => p.id), ['host', 'port', 'database', 'user', 'sslrootcert', 'sslcert', 'sslkey']);
+			assert.deepStrictEqual(certMechanism.parameters.map(p => p.id), ['host', 'port', 'user', 'database', 'sslrootcert', 'sslcert', 'sslkey']);
 		});
 	});
 

--- a/extensions/positron-data-driver-postgresql/src/test/postgresqlDriver.test.ts
+++ b/extensions/positron-data-driver-postgresql/src/test/postgresqlDriver.test.ts
@@ -13,9 +13,9 @@ const TEST_CONFIG: PostgreSQLConnectionConfig = {
 	kind: 'fields',
 	host: 'localhost',
 	port: 5432,
-	database: 'testdb',
 	user: 'testuser',
 	password: 'testpass',
+	database: 'testdb',
 	ssl: false
 };
 
@@ -215,7 +215,7 @@ suite('PostgreSQL Driver Tests', () => {
 			return { rows: [] };
 		});
 
-		const schemaNode = createSchemaNode(mock, noopHost, 'public');
+		const schemaNode = createSchemaNode(mock, noopHost, undefined, 'public');
 		const groups = await schemaNode.getChildren!();
 		assert.strictEqual(groups.length, 2);
 		assert.strictEqual(groups[0].kind, positron.DataConnectionNodeKind.GroupTables);
@@ -296,7 +296,7 @@ suite('PostgreSQL Driver Tests', () => {
 			return { rows: [] };
 		});
 
-		const schemaNode = createSchemaNode(mock, noopHost, 'public');
+		const schemaNode = createSchemaNode(mock, noopHost, undefined, 'public');
 		const tables = await tablesOf(schemaNode);
 		const productsNode = tables.find(c => c.name === 'products')!;
 
@@ -344,7 +344,7 @@ suite('PostgreSQL Driver Tests', () => {
 			return { rows: [] };
 		});
 
-		const schemaNode = createSchemaNode(mock, noopHost, 'public');
+		const schemaNode = createSchemaNode(mock, noopHost, undefined, 'public');
 		const tables = await tablesOf(schemaNode);
 		const productsNode = tables.find(c => c.name === 'products')!;
 
@@ -382,7 +382,7 @@ suite('PostgreSQL Driver Tests', () => {
 			return { rows: [] };
 		});
 
-		const schema = createSchemaNode(mock, noopHost, 'public');
+		const schema = createSchemaNode(mock, noopHost, undefined, 'public');
 		const tables = await tablesOf(schema);
 		const fields = await columnsOf(tables[0]);
 		assert.strictEqual(fields[0].dataType, 'text[]');
@@ -409,7 +409,7 @@ suite('PostgreSQL Driver Tests', () => {
 			return { rows: [] };
 		});
 
-		const schema = createSchemaNode(mock, noopHost, 'public');
+		const schema = createSchemaNode(mock, noopHost, undefined, 'public');
 		const tables = await tablesOf(schema);
 		const fields = await columnsOf(tables[0]);
 		assert.strictEqual(fields[0].dataType, 'order_status');
@@ -436,7 +436,7 @@ suite('PostgreSQL Driver Tests', () => {
 			return { rows: [] };
 		});
 
-		const schema = createSchemaNode(mock, noopHost, 'public');
+		const schema = createSchemaNode(mock, noopHost, undefined, 'public');
 		const tables = await tablesOf(schema);
 		const fields = await columnsOf(tables[0]);
 		assert.strictEqual(fields[0].dataType, 'numeric(18)');
@@ -465,9 +465,130 @@ suite('PostgreSQL Driver Tests', () => {
 			return { rows: [] };
 		});
 
-		const schema = createSchemaNode(mock, noopHost, 'public');
+		const schema = createSchemaNode(mock, noopHost, undefined, 'public');
 		const tables = await tablesOf(schema);
 		assert.ok(tables[0].preview);
 		await tables[0].preview!();
+	});
+});
+
+suite('PostgreSQL Server Mode Tests', () => {
+
+	// Fields config with no database: the connection targets the whole server, so databases are the
+	// top-level nodes.
+	const SERVER_CONFIG: PostgreSQLConnectionConfig = {
+		kind: 'fields',
+		host: 'localhost',
+		port: 5432,
+		user: 'testuser',
+		password: 'testpass',
+		ssl: false,
+	};
+
+	// Builds a server-mode connection with a base client (used to list databases) and a per-database
+	// client (returned for any database node's schema browsing). Stubbing _buildClient bypasses the
+	// real pg Client, so getDatabaseClient hands back the mock instead of dialing a server.
+	function createServerConnection(baseClient: any, databaseClient: any): PostgreSQLConnection {
+		const conn = new PostgreSQLConnection(SERVER_CONFIG, noopHost);
+		// eslint-disable-next-line local/code-no-any-casts
+		(conn as any)._client = baseClient;
+		// eslint-disable-next-line local/code-no-any-casts
+		(conn as any)._buildClient = () => databaseClient;
+		return conn;
+	}
+
+	test('getChildren returns a single Databases group node', async () => {
+		const mock = createMockClient();
+		const conn = createServerConnection(mock, mock);
+
+		const roots = await conn.getChildren();
+		assert.strictEqual(roots.length, 1);
+		assert.strictEqual(roots[0].kind, positron.DataConnectionNodeKind.GroupDatabases);
+		assert.strictEqual(roots[0].name, 'Databases');
+
+		await conn.disconnect();
+	});
+
+	test('Databases group lists databases, each expanding to its schemas', async () => {
+		const baseClient = createMockClient((sql) => {
+			if (sql.includes('pg_database')) {
+				return { rows: [{ datname: 'analytics' }, { datname: 'app' }] };
+			}
+			return { rows: [] };
+		});
+		const databaseClient = createMockClient((sql) => {
+			if (sql.includes('information_schema.schemata')) {
+				return { rows: [{ schema_name: 'public' }] };
+			}
+			return { rows: [] };
+		});
+		const conn = createServerConnection(baseClient, databaseClient);
+
+		const [databasesGroup] = await conn.getChildren();
+		const databases = await databasesGroup.getChildren!();
+		assert.deepStrictEqual(databases.map(d => d.name), ['analytics', 'app']);
+		databases.forEach(d => assert.strictEqual(d.kind, positron.DataConnectionNodeKind.Database));
+
+		// Expanding a database yields a Schemas group backed by the per-database client.
+		const [schemasGroup] = await databases[0].getChildren!();
+		assert.strictEqual(schemasGroup.kind, positron.DataConnectionNodeKind.GroupSchemas);
+		const schemas = await schemasGroup.getChildren!();
+		assert.deepStrictEqual(schemas.map(s => s.name), ['public']);
+
+		await conn.disconnect();
+	});
+
+	test('server mode falls back from the maintenance database to the default database', async () => {
+		const fallbackClient = createMockClient((sql) => {
+			if (sql.includes('pg_database')) {
+				return { rows: [{ datname: 'app' }] };
+			}
+			return { rows: [] };
+		});
+		const conn = new PostgreSQLConnection(SERVER_CONFIG, noopHost);
+		// The primary (maintenance-database) client rejects, as it would when 'postgres' is unavailable;
+		// the fallback client (the pg default database) connects instead.
+		// eslint-disable-next-line local/code-no-any-casts
+		(conn as any)._client = { connect: async () => { throw new Error('database "postgres" does not exist'); }, end: async () => { } };
+		// eslint-disable-next-line local/code-no-any-casts
+		(conn as any)._buildClient = () => fallbackClient;
+
+		await conn.connect();
+		assert.strictEqual(await conn.isConnected(), true);
+
+		// Enumeration proceeds against the fallback client.
+		const [databasesGroup] = await conn.getChildren();
+		const databases = await databasesGroup.getChildren!();
+		assert.deepStrictEqual(databases.map(d => d.name), ['app']);
+
+		await conn.disconnect();
+	});
+
+	test('connection string with a database is single-database mode', async () => {
+		const conn = new PostgreSQLConnection(
+			{ kind: 'connectionString', connectionString: 'postgresql://user@localhost:5432/mydb' },
+			noopHost
+		);
+		// eslint-disable-next-line local/code-no-any-casts
+		(conn as any)._client = createMockClient();
+
+		const roots = await conn.getChildren();
+		assert.strictEqual(roots[0].kind, positron.DataConnectionNodeKind.GroupSchemas);
+
+		await conn.disconnect();
+	});
+
+	test('connection string without a database is server mode', async () => {
+		const conn = new PostgreSQLConnection(
+			{ kind: 'connectionString', connectionString: 'postgresql://user@localhost:5432/' },
+			noopHost
+		);
+		// eslint-disable-next-line local/code-no-any-casts
+		(conn as any)._client = createMockClient();
+
+		const roots = await conn.getChildren();
+		assert.strictEqual(roots[0].kind, positron.DataConnectionNodeKind.GroupDatabases);
+
+		await conn.disconnect();
 	});
 });

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2173,6 +2173,7 @@ declare module 'positron' {
 		View = 'view',
 		Field = 'field',
 		// Category containers that group sibling nodes (e.g. "Tables", "Views").
+		GroupDatabases = 'group-databases',
 		GroupSchemas = 'group-schemas',
 		GroupTables = 'group-tables',
 		GroupViews = 'group-views',

--- a/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
+++ b/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
@@ -484,6 +484,7 @@ export enum DataConnectionNodeKind {
 	Table = 'table',
 	View = 'view',
 	Field = 'field',
+	GroupDatabases = 'group-databases',
 	GroupSchemas = 'group-schemas',
 	GroupTables = 'group-tables',
 	GroupViews = 'group-views',

--- a/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionNodeRow.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionNodeRow.tsx
@@ -29,6 +29,10 @@ const kindIcon = (dto: IDataConnectionNodeDTO): string => {
 		case 'database':
 			return 'positron-db-database';
 
+		// No dedicated plural glyph exists, so the "Databases" group reuses the database icon.
+		case 'group-databases':
+			return 'positron-db-database';
+
 		case 'group-schemas':
 			return 'positron-db-schemas';
 

--- a/test/e2e/tests/data-connections/postgres.test.ts
+++ b/test/e2e/tests/data-connections/postgres.test.ts
@@ -64,7 +64,7 @@ test.describe('Data Connections - Postgres', {
 			['Connection Name', connectionName],
 			['Host', host],
 			['Port', port],
-			['Database', database],
+			[/^Database/, database],
 			[/^User/, user],
 			[/^Password/, password],
 		]);


### PR DESCRIPTION
### Summary

Addresses https://github.com/posit-dev/positron/issues/14728.

Adds a server-mode for PostgreSQL connections. The `Database` parameter is now optional across every connection mechanism (password, local server, client certificate, and connection string). When it is left blank, the connection targets the whole server instead of a single database, and the top-level nodes in the Connections pane become the browsable databases on the server (a new "Databases" group), each expanding to its own schemas, tables, views, and columns, just as pgAdmin does.

In server mode the base client connects to the conventional `postgres` maintenance database to enumerate the server's databases (falling back to the pg client's default database when the maintenance database is unavailable or the role can't connect to it). Per-database pg clients are created lazily and cached the first time a database node is expanded, shared across concurrent expansions, and closed on disconnect. Previewed datasets are now keyed by database as well, so tables of the same name in different databases stay distinct in the Data Explorer, and each preview queries through the client scoped to its own database.

A new `GroupDatabases` node kind is added to the Positron API (`positron.d.ts` and `extHostTypes.positron.ts`); the "Databases" group reuses the existing database icon since there is no dedicated plural glyph.

### Release Notes

#### New Features

- PostgreSQL connections can now omit the database to connect in server mode and browse all databases on the server from the Connections pane.

#### Bug Fixes

- N/A

### Validation Steps

@:connections @:data-explorer

1. Open the Connections pane and create a new PostgreSQL connection using any mechanism (password, local server, client certificate, or connection string).
2. Leave the `Database` field blank (or omit the database from the connection string).
3. Verify the connection expands to a top-level "Databases" group listing every non-template database on the server.
4. Expand a database and confirm its schemas, tables, views, and columns browse correctly.

<p>
<img width="568" height="316" alt="image" src="https://github.com/user-attachments/assets/de4b5990-3946-4266-8c33-0e77605ef6e6" />
</p>

<p>
<img width="2682" height="1786" alt="image" src="https://github.com/user-attachments/assets/84ad294d-2bd8-40c7-8dca-f3d1432590da" />
</p>

5. Preview a table (and a single column) from two different databases and confirm both open in the Data Explorer as distinct datasets querying the correct database.
6. As a regression check, create a connection with the `Database` field set and confirm it still opens directly to a top-level "Schemas" group for that single database.

### Tests

Tests:
@:connections