### PR TITLE
Run PETE test-checker on demand only, add /pete command (#14494)

### DIFF
--- a/.claude/skills/positron-pr-helper/SKILL.md
+++ b/.claude/skills/positron-pr-helper/SKILL.md
@@ -14,6 +14,7 @@ Use this skill when:
 - Updating an existing PR body with the correct format
 - You need the current list of e2e test tags for validation steps
 - You want to ensure your PR body follows Positron conventions
+- You want a test-coverage check (PETE) before opening the PR
 
 ## Prerequisites
 
@@ -44,7 +45,16 @@ I'll dynamically fetch the current e2e test tags from `test/e2e/infra/test-runne
 - Performance tags
 - Special tags (critical, soft-fail)
 
-### Step 3: Generate PR Body
+### Step 3: Evaluate Test Coverage (PETE)
+
+Before drafting Validation Steps, I'll run the local PETE preview (the `pete` skill, sharing its rubric with `.claude/skills/pr-test-checker/SKILL.md` -- the same one CI's PR Test Checker uses) against your working tree. This checks test coverage for the change the same way I already check test tags:
+- Flags substantive source changes with no unit/e2e coverage (verdict: Insufficient)
+- Surfaces existing e2e tests that already cover the change but whose `@:` tag is missing from the PR body -- these fold into the tag list from Step 2
+- Notes Windows/web deployment gaps worth calling out in Validation Steps
+
+If PETE reports **Insufficient**, I'll say so and suggest concrete additions (file path, runner, what to test) before we finalize the PR body -- I won't silently paper over a coverage gap with a generic "Validation Steps" section. This is a local preview only; it doesn't replace the official check, which now runs on demand in CI -- comment `/pete` (or `/recheck-tests`, `/rePETE`, `/re-pete`) on the PR once it's open to get the authoritative verdict.
+
+### Step 4: Generate PR Body
 
 Based on the PR type and context, I'll create a structured PR body with:
 
@@ -69,8 +79,9 @@ Based on the PR type and context, I'll create a structured PR body with:
    - Relevant e2e test tags based on affected areas
    - Testing instructions
    - Code examples if helpful
+   - A note on PETE's verdict from Step 3 if it was Insufficient
 
-### Step 4: Output Options
+### Step 5: Output Options
 
 Once the PR body is ready, you can choose:
 1. **Copy to clipboard** (Mac only) - I'll use `pbcopy`

--- a/.claude/skills/pr-test-checker/SKILL.md
+++ b/.claude/skills/pr-test-checker/SKILL.md
@@ -188,7 +188,7 @@ Only suggest **feature** tags from `test/e2e/infra/test-runner/test-tags.ts`. Do
 Omit entirely if not applicable.>
 
 ---
-<small>PETE (Positron Extreme Test Experiment) - LLM-based test-coverage advisor, in pilot. Triggers on PR open and on `/recheck-tests` comments. Wrong verdict? Comment `/recheck-tests` (or `/rePETE`) on this PR to re-run. Please share feedback on how PETE performed [here](https://docs.google.com/spreadsheets/d/1MIBYC-ItKaeH7Pup1VHoGw8sTkwxIbbDnDMn_vRSrGg/edit?usp=sharing).</small>
+<small>PETE (Positron Extreme Test Experiment) - LLM-based test-coverage advisor, in pilot. Runs only on demand -- comment `/pete` (or `/recheck-tests`, `/rePETE`, `/re-pete`) on this PR to run (or re-run) it. Please share feedback on how PETE performed [here](https://docs.google.com/spreadsheets/d/1MIBYC-ItKaeH7Pup1VHoGw8sTkwxIbbDnDMn_vRSrGg/edit?usp=sharing).</small>
 ```
 
 ## Constraints

--- a/.claude/skills/pr-test-checker/scripts/context-core.mjs
+++ b/.claude/skills/pr-test-checker/scripts/context-core.mjs
@@ -160,6 +160,6 @@ export function renderSkipComment(context) {
 		`${context.stats.fileCount} file(s), categorized as: ${formatCategoryCounts(context.stats.categoryCounts)}.`,
 		'',
 		'---',
-		`<sub>PETE (Positron Extreme Test Experiment): an LLM-based test-coverage advisor, currently in pilot. Nothing to test here! A pre-filter handled this PR, so we skipped the LLM check. Comment \`/recheck-tests\` if that's wrong.</sub>`,
+		`<sub>PETE (Positron Extreme Test Experiment): an LLM-based test-coverage advisor, currently in pilot. Nothing to test here! A pre-filter handled this PR, so we skipped the LLM check. Comment \`/pete\` if that's wrong.</sub>`,
 	].join('\n');
 }

--- a/.github/actions/pr-test-checker/action.yml
+++ b/.github/actions/pr-test-checker/action.yml
@@ -10,10 +10,6 @@ inputs:
   repo-root:
     description: "Absolute path to the PR-head checkout the agent reads source from. The action itself runs from a trusted base-branch checkout; this input lets the workflow point the agent at a separate, untrusted checkout for source-reading only. Must be set for any flow that handles secrets."
     required: true
-  force-regrade:
-    description: "When 'true', always run the analyzer even if a PETE comment already exists. Set by the /recheck-tests flow so a manual re-grade is never short-circuited. Default 'false' so `pull_request` events (opened / synchronize / ready_for_review) skip when a verdict has already been posted -- this lets `synchronize` recover a missed `opened` delivery without re-grading every subsequent push."
-    required: false
-    default: "false"
   model:
     description: "Anthropic model identifier (a tier alias like 'opus' always resolves to the latest)"
     required: false
@@ -25,42 +21,12 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Check for prior grade (idempotency guard)
-      # When called from a `pull_request` event, skip if a PETE comment
-      # already exists on the PR. This lets `synchronize` / `ready_for_review`
-      # act purely as recovery channels for a dropped `opened` delivery
-      # (see #13664) without re-grading on every subsequent push. The
-      # /recheck-tests flow sets force-regrade=true to bypass this.
-      id: idempotency
-      if: inputs.force-regrade != 'true'
-      shell: bash
-      env:
-        GH_TOKEN: ${{ github.token }}
-        GITHUB_REPOSITORY: ${{ github.repository }}
-        PR_NUMBER: ${{ inputs.pr-number }}
-      run: |
-        MARKER="<!-- pr-test-checker -->"
-        # Match on BOTH the marker AND the bot author -- a non-bot commenter
-        # could otherwise paste the marker to suppress future auto-grading
-        # until someone manually runs /recheck-tests.
-        EXISTING_ID=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
-          --jq "[.[] | select(.body | contains(\"$MARKER\")) | select(.user.login == \"github-actions[bot]\")][0].id // empty")
-        if [ -n "$EXISTING_ID" ]; then
-          echo "PETE comment already exists (id=${EXISTING_ID}); skipping. Use /recheck-tests to force a re-grade."
-          echo "skip=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "No PETE comment yet; proceeding."
-          echo "skip=false" >> "$GITHUB_OUTPUT"
-        fi
-
     - name: Set up Node
-      if: steps.idempotency.outputs.skip != 'true'
       uses: actions/setup-node@v6
       with:
         node-version: "20"
 
     - name: Install action dependencies
-      if: steps.idempotency.outputs.skip != 'true'
       shell: bash
       working-directory: ${{ github.action_path }}
       run: npm ci --no-audit --no-fund
@@ -70,7 +36,6 @@ runs:
       # the musl variant over glibc on Linux runners. Installing globally and
       # passing the resolved path via pathToClaudeCodeExecutable sidesteps it.
       # See claude-agent-sdk-typescript#296.
-      if: steps.idempotency.outputs.skip != 'true'
       shell: bash
       run: |
         npm install -g @anthropic-ai/claude-code
@@ -79,7 +44,6 @@ runs:
 
     - name: Prepare working directory
       id: prep
-      if: steps.idempotency.outputs.skip != 'true'
       shell: bash
       run: |
         WORK_DIR="${RUNNER_TEMP}/pr-test-checker"
@@ -91,7 +55,6 @@ runs:
       # Runs the gather script from the action's own directory (i.e. the
       # trusted base-branch checkout), not from the PR head. PR-head code
       # must never execute with secrets in scope.
-      if: steps.idempotency.outputs.skip != 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
@@ -109,7 +72,6 @@ runs:
       # so they are read from the trusted base-branch checkout. Only
       # REPO_ROOT (where the agent's Read/Grep/Glob tools operate) points
       # at the untrusted PR-head checkout.
-      if: steps.idempotency.outputs.skip != 'true'
       shell: bash
       working-directory: ${{ github.action_path }}
       env:
@@ -122,7 +84,6 @@ runs:
       run: node analyze.mjs
 
     - name: Upsert PR comment
-      if: steps.idempotency.outputs.skip != 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
@@ -156,7 +117,7 @@ runs:
         fi
 
     - name: Upload analyzer artifacts
-      if: always() && steps.idempotency.outputs.skip != 'true'
+      if: always()
       uses: actions/upload-artifact@v7
       with:
         name: pr-test-checker-${{ inputs.pr-number }}

--- a/.github/actions/pr-test-checker/analyze.mjs
+++ b/.github/actions/pr-test-checker/analyze.mjs
@@ -326,7 +326,7 @@ async function main() {
 			'**Verdict:** ⚪ _Unknown_ -- the analyzer produced no markdown report. Check action logs.',
 			'',
 			'---',
-			'<sub>PETE (Positron Extreme Test Experiment): an LLM-based test-coverage advisor, currently in pilot. Run `/recheck-tests` to retry.</sub>',
+			'<sub>PETE (Positron Extreme Test Experiment): an LLM-based test-coverage advisor, currently in pilot. Comment `/pete` to retry.</sub>',
 		].join('\n');
 		writeFileSync(join(WORK_DIR, 'comment.md'), wrapWithMarker(fallback));
 		console.error('[analyzer] no markdown report produced; wrote fallback comment');

--- a/.github/workflows/pr-test-checker.yml
+++ b/.github/workflows/pr-test-checker.yml
@@ -1,6 +1,12 @@
 name: "PR Test Checker"
 
-# Grades whether the PR has adequate test coverage and posts a verdict comment.
+# Grades whether a PR has adequate test coverage and posts a verdict comment.
+# Runs only on demand: comment `/pete` (or `/recheck-tests`, `/rePETE`,
+# `/re-pete`) on a PR to trigger it. It does NOT run automatically on PR
+# open/push (see #14494) -- authors get the same rubric locally via the `pete`
+# skill before opening a PR, so the automatic CI pass was redundant with that
+# plus the on-demand comment trigger below.
+#
 # Scope: runs only for PR authors / commenters in the posit-dev `positron-dev`
 # team. GitHub Actions `if:` has no team-membership predicate, and the default
 # GITHUB_TOKEN cannot read org membership, so a dedicated `gate` job resolves
@@ -8,25 +14,13 @@ name: "PR Test Checker"
 # the "Positron Projects" GitHub App (secrets POSITRON_PROJECTS_CLIENT_ID +
 # POSITRON_PROJECTS_PEM, shared with release-generate-sbom.yml) scoped to the
 # posit-dev org, which carries the App's `Members: read` permission, and
-# exposes an `ok` output the grading jobs depend on via `needs`. The gate
+# exposes an `ok` output the grading job depends on via `needs`. The gate
 # FAILS CLOSED: if the token can't be minted or any API call fails (e.g. the
 # App is missing `Members: read`), `ok=false` and nothing is graded. Membership
 # is always live -- there is no allowlist to maintain. To change who PETE runs
 # for, edit the `positron-dev` team on GitHub, not this file.
 #
-# Trigger recovery: we listen for `opened`, `synchronize`, AND `ready_for_review`
-# on `pull_request`, not just `opened`. GitHub occasionally drops `opened`
-# deliveries (see #13664, where the `pull_request_target` CLA event fired but
-# `pull_request: opened` didn't, leaving PETE with no verdict), so the extra
-# types give us a recovery path on the next push or draft->ready transition.
-# Observable behavior: PETE grades on PR creation, and only re-grades on
-# explicit `/recheck-tests`. To avoid re-grading on every push, the action
-# short-circuits any `pull_request`-triggered run when a PETE comment already
-# exists on the PR -- `synchronize` and `ready_for_review` therefore only do
-# work in the rare case where the initial `opened` was missed. `/recheck-tests`
-# (an `issue_comment` event) sets `force-regrade=true` and bypasses the guard.
-#
-# Security model: each job checks out two trees -- the BASE branch (trusted
+# Security model: the job checks out two trees -- the BASE branch (trusted
 # action + skill code, used to run the analyzer with secrets) and the PR HEAD
 # (untrusted source code, mounted as read-only data for the agent's
 # Read/Grep/Glob tools). The analyzer is invoked from the base checkout via
@@ -37,11 +31,6 @@ name: "PR Test Checker"
 # full secrets, unlike `pull_request` events which strip secrets for forks).
 
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - ready_for_review
   issue_comment:
     types:
       - created
@@ -49,28 +38,29 @@ on:
 jobs:
   # Resolve positron-dev team membership at runtime. This is a pure GitHub API
   # read with a short-lived App token; it checks out no PR code, so it is safe
-  # to run in base context. Emits `ok=true` only when the relevant user(s) are
-  # *active* team members, and FAILS CLOSED (`ok=false`) on a token/API error.
-  # The grading jobs depend on this via `needs: gate`.
+  # to run in base context. Emits `ok=true` only when BOTH the commenter and
+  # the PR author are *active* team members, and FAILS CLOSED (`ok=false`) on
+  # a token/API error.
   gate:
     name: Check positron-dev membership
-    # Cheap event-shape pre-filter so we don't spin up a runner (or hit the API)
-    # for every PR comment -- only PR events and recheck-command comments on PRs
-    # reach the membership check below. Recognized recheck commands: /recheck-tests,
-    # /rePETE, /re-pete (contains() is case-insensitive, so casing doesn't matter).
-    # NOTE: keep this command list in sync with the on-recheck job's `if` below.
+    # Cheap event-shape pre-filter so we don't spin up a runner (or hit the
+    # API) for every PR comment -- only trigger-command comments on PRs reach
+    # the membership check below. Recognized commands: /pete, /recheck-tests,
+    # /rePETE, /re-pete (contains() is case-insensitive, so casing doesn't
+    # matter; the /pete substring check does not match /repete or /re-pete,
+    # since neither contains a "/pete" substring). NOTE: keep this command
+    # list in sync with the `run` job's `if` below.
     if: |
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request != null &&
-        (contains(github.event.comment.body, '/recheck-tests') ||
-          contains(github.event.comment.body, '/repete') ||
-          contains(github.event.comment.body, '/re-pete')))
+      github.event.issue.pull_request != null &&
+      (contains(github.event.comment.body, '/pete') ||
+        contains(github.event.comment.body, '/recheck-tests') ||
+        contains(github.event.comment.body, '/repete') ||
+        contains(github.event.comment.body, '/re-pete'))
     runs-on: ubuntu-latest
     # No GITHUB_TOKEN scopes needed: the check uses the App token in GH_TOKEN.
     permissions: {}
     concurrency:
-      group: pr-test-checker-gate-${{ github.event.pull_request.number || github.event.issue.number }}
+      group: pr-test-checker-gate-${{ github.event.issue.number }}
       cancel-in-progress: true
     outputs:
       ok: ${{ steps.check.outputs.ok }}
@@ -91,8 +81,6 @@ jobs:
           # `Members: read` permission; without it the gh calls 404 and the gate
           # stays ok=false -- fail closed.
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          EVENT_NAME: ${{ github.event_name }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           COMMENTER: ${{ github.event.comment.user.login }}
           ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
         run: |
@@ -106,92 +94,35 @@ jobs:
             [ "$state" = "active" ]
           }
 
+          # BOTH the commenter and the PR author must be members, so an
+          # attacker can't bait a run by commenting the trigger phrase on a
+          # PR whose author is outside the team.
           ok=false
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            # on-open: the PR author must be a team member.
-            if is_member "$PR_AUTHOR"; then
-              ok=true
-            fi
-          else
-            # on-recheck: BOTH the commenter and the PR author must be members,
-            # so an attacker can't bait /recheck-tests by commenting on a PR
-            # whose author is outside the team.
-            if is_member "$COMMENTER" && is_member "$ISSUE_AUTHOR"; then
-              ok=true
-            fi
+          if is_member "$COMMENTER" && is_member "$ISSUE_AUTHOR"; then
+            ok=true
           fi
 
           echo "Membership gate result: ok=$ok"
           echo "ok=$ok" >> "$GITHUB_OUTPUT"
 
-  on-open:
-    name: Grade on PR change
+  run:
+    name: Grade on command
     needs: gate
-    if: |
-      github.event_name == 'pull_request' &&
-      needs.gate.outputs.ok == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-    concurrency:
-      group: pr-test-checker-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
-    steps:
-      - name: Checkout BASE (trusted action + skill code)
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.repository.default_branch }}
-          path: base
-          sparse-checkout: |
-            .claude/skills/pr-test-checker
-            .claude/rules
-            .github/actions/pr-test-checker
-
-      - name: Checkout PR HEAD (untrusted source data)
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          path: pr-head
-          sparse-checkout: |
-            CLAUDE.md
-            src
-            extensions
-            test/e2e
-
-      - name: Load Anthropic API key
-        uses: 1password/load-secrets-action@v4
-        with:
-          export-env: true
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
-
-      - name: Run pr-test-checker (from base, source from PR head)
-        uses: ./base/.github/actions/pr-test-checker
-        with:
-          pr-number: ${{ github.event.pull_request.number }}
-          anthropic-api-key: ${{ env.ANTHROPIC_KEY }}
-          repo-root: ${{ github.workspace }}/pr-head
-
-  on-recheck:
-    name: Re-grade on recheck command
-    needs: gate
-    # Fires when a positron-dev member comments a recheck command (/recheck-tests,
-    # /rePETE, /re-pete) on a PR. The issue_comment event runs in base-repo context
-    # with full secrets even when the PR is from a fork, so two layers of defense:
+    # Fires when a positron-dev member comments a trigger command
+    # (/pete, /recheck-tests, /rePETE, /re-pete) on a PR. The issue_comment
+    # event runs in base-repo context with full secrets even when the PR is
+    # from a fork, so two layers of defense:
     #   1. The `gate` job requires BOTH the commenter AND the PR author to be
     #      positron-dev members (the PR-author check blocks comments on fork
-    #      PRs by non-members -- attackers can't bait a recheck on a PR
-    #      whose author is outside the team).
+    #      PRs by non-members -- attackers can't bait a run on a PR whose
+    #      author is outside the team).
     #   2. The job checks out the base branch to RUN the action and the
     #      PR head only as READ-ONLY DATA -- PR-head code never executes.
-    # NOTE: keep the recheck-command list in sync with the gate job's `if` above.
+    # NOTE: keep the command list in sync with the gate job's `if` above.
     if: |
-      github.event_name == 'issue_comment' &&
       github.event.issue.pull_request != null &&
-      (contains(github.event.comment.body, '/recheck-tests') ||
+      (contains(github.event.comment.body, '/pete') ||
+        contains(github.event.comment.body, '/recheck-tests') ||
         contains(github.event.comment.body, '/repete') ||
         contains(github.event.comment.body, '/re-pete')) &&
       needs.gate.outputs.ok == 'true'
@@ -204,11 +135,12 @@ jobs:
       group: pr-test-checker-${{ github.event.issue.number }}
       cancel-in-progress: true
     steps:
-      # Acknowledge the recheck command with an "eyes" reaction so the commenter
-      # gets immediate visual confirmation that PETE picked it up and is running.
-      # First step so it lands before the slower checkout/analysis steps. Capture
-      # the reaction id so the finalize step can remove it once PETE is done.
-      - name: Acknowledge recheck command
+      # Acknowledge the command with an "eyes" reaction so the commenter gets
+      # immediate visual confirmation that PETE picked it up and is running.
+      # First step so it lands before the slower checkout/analysis steps.
+      # Capture the reaction id so the finalize step can remove it once PETE
+      # is done.
+      - name: Acknowledge command
         id: ack
         env:
           GH_TOKEN: ${{ github.token }}
@@ -265,13 +197,13 @@ jobs:
           pr-number: ${{ github.event.issue.number }}
           anthropic-api-key: ${{ env.ANTHROPIC_KEY }}
           repo-root: ${{ github.workspace }}/pr-head
-          force-regrade: "true"
 
       # Replace the "eyes" acknowledgement with a terminal reaction once PETE
-      # finishes: rocket on success, confused on failure. Runs on always() so the
-      # comment never gets stuck showing "running". Skipped if the ack step never
-      # recorded a reaction id (e.g. the initial reaction POST failed).
-      - name: Finalize recheck reaction
+      # finishes: rocket on success, confused on failure. Runs on always() so
+      # the comment never gets stuck showing "running". Skipped if the ack
+      # step never recorded a reaction id (e.g. the initial reaction POST
+      # failed).
+      - name: Finalize reaction
         if: always() && steps.ack.outputs.reaction_id != ''
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Fixes #14494

### Summary

Makes the PETE PR Test Checker run **only on demand** via a slash-command comment, instead of automatically on every PR open/push. 

Authors still get the same rubric locally through the `pete` skill before opening a PR, so the automatic CI pass was redundant with that plus the on-demand trigger.

Changes:
- **Workflow** ([pr-test-checker.yml](.github/workflows/pr-test-checker.yml)): drop the `pull_request` triggers (`opened`/`synchronize`/`ready_for_review`) and the `on-open` job; keep only the `issue_comment` command path. The membership `gate` now always checks both the commenter and the PR author (no more event-type branching). Added `/pete` as a trigger alongside the existing `/recheck-tests`, `/rePETE`, `/re-pete`.
- **Action** ([action.yml](.github/actions/pr-test-checker/action.yml)): remove the now-dead `force-regrade` input and the idempotency-guard step, since every remaining caller always grades. The upsert step still creates the comment on the first run and updates it on later runs.
- **positron-pr-helper skill**: add a PETE test-coverage-check step so we evaluate coverage before opening a PR, the same way we already check e2e test tags.
- Refresh user-facing footer strings (skill docs, `analyze.mjs`, `context-core.mjs`) to mention `/pete`.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

No e2e/unit coverage applies -- this changes CI workflow/action config and skill docs only, with no `src/` or `extensions/` behavior. (Local PETE preview verdict: 🟡 Not applicable.)

To validate the workflow itself once merged:
1. On a PR authored by a `positron-dev` member, comment `/pete` -- PETE should react with 👀, grade, and post/update its verdict comment.
2. Open a fresh PR without commenting -- PETE should **not** run automatically.
3. Re-comment `/pete` (or `/recheck-tests`) -- PETE should update the existing comment rather than create a duplicate.