### PR TITLE
Add right padding to the Data Connections datatype label so it clears…

### DIFF
--- a/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionNodeRow.css
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionNodeRow.css
@@ -32,4 +32,5 @@
 	flex: 0 0 auto;
 	color: var(--vscode-descriptionForeground);
 	font-size: 0.9em;
+	padding-right: 4px;
 }


### PR DESCRIPTION
Fixes #14631

In the Connections pane, the datatype label shown to the right of a column (INTEGER, TEXT, etc.) sat flush against the panel's right edge and scrollbar. This adds a little right padding to the label so it has some breathing room.

<p>
<img width="584" height="992" alt="image" src="https://github.com/user-attachments/assets/a02ab38b-7b75-4f2c-a452-bed2712820d0" />
</p>

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Add padding to the datatype label in the Connections pane so it no longer sits against the panel's right edge and scrollbar (#14631).

### Validation Steps

@:connections

1. Open the Connections pane and connect to a database.
2. Expand a table or view down to its Columns.
3. Confirm the datatype label on the right of each column has a small gap from the panel edge / scrollbar rather than being jammed against it.
