### PR TITLE
e2e: consolidate @:posit-assistant into @:assistant

### DIFF
--- a/.github/workflows/extensions-tag-map.json
+++ b/.github/workflows/extensions-tag-map.json
@@ -9,7 +9,7 @@
   "ms-toolsai.vscode-jupyter-cell-tags":        { "tags": ["@:positron-notebooks"] },
   "ms-toolsai.vscode-jupyter-slideshow":        { "tags": ["@:positron-notebooks"] },
   "posit.air-vscode":                           { "tags": ["@:ark"] },
-  "posit.assistant":                            { "tags": ["@:assistant", "@:posit-assistant"] },
+  "posit.assistant":                            { "tags": ["@:assistant"] },
   "posit.publisher":                            { "tags": ["@:workbench"] },
   "posit.shiny":                                { "tags": ["@:apps"] },
   "quarto.quarto":                              { "tags": ["@:quarto"] }

--- a/test/e2e/infra/test-runner/test-tags.ts
+++ b/test/e2e/infra/test-runner/test-tags.ts
@@ -35,7 +35,6 @@ export enum TestTags {
 	CONNECTIONS = '@:connections',
 	CONSOLE = '@:console',
 	CRITICAL = '@:critical',
-	POSIT_ASSISTANT = '@:posit-assistant',
 	DATA_EXPLORER = '@:data-explorer',
 	DEBUG = '@:debug',
 	DUCK_DB = '@:duck-db',

--- a/test/e2e/tests/assistant/chat-command-palette-gating.test.ts
+++ b/test/e2e/tests/assistant/chat-command-palette-gating.test.ts
@@ -29,7 +29,7 @@ test.use({
  *
  * @see https://github.com/posit-dev/positron/pull/14054 (single-command gating this extends)
  */
-test.describe('Chat Command Palette Gating', { tag: [tags.ASSISTANT, tags.POSIT_ASSISTANT] }, () => {
+test.describe('Chat Command Palette Gating', { tag: [tags.ASSISTANT] }, () => {
 	// Command palette rows in the "Chat" category render as "Chat: <title>".
 	// Anchor at the start so other categories (e.g. "GitHub Copilot Chat: ...") are excluded.
 	const CHAT_CATEGORY_ROW = /^Chat: /;

--- a/test/e2e/tests/layouts/layouts.test.ts
+++ b/test/e2e/tests/layouts/layouts.test.ts
@@ -143,7 +143,7 @@ test.describe('Layouts', { tag: [tags.LAYOUTS, tags.WIN] }, () => {
 	});
 
 	test.describe.skip('Assistant Layout', {
-		tag: [tags.ASSISTANT, tags.POSIT_ASSISTANT],
+		tag: [tags.ASSISTANT],
 		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/14037' }]
 	}, () => {
 		test.afterEach('Reset Layout', async function ({ app }) {

--- a/test/e2e/tests/posit-assistant/posit-assistant-mcp.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant-mcp.test.ts
@@ -18,7 +18,7 @@ const POSIT_ASSISTANT_PROVIDERS: ModelProvider[] = ['anthropic-api'];
 // ignored — see posit-dev/assistant#1289 (fixed in #1293). Uses the `echo`
 // tool from @modelcontextprotocol/server-everything as a stable reference.
 test.describe.skip('Posit Assistant MCP', { // skipping while investigating failures
-	tag: [tags.POSIT_ASSISTANT, tags.ASSISTANT, tags.WEB, tags.WIN],
+	tag: [tags.ASSISTANT, tags.WEB, tags.WIN],
 }, () => {
 
 	for (const provider of POSIT_ASSISTANT_PROVIDERS) {

--- a/test/e2e/tests/posit-assistant/posit-assistant-signin.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant-signin.test.ts
@@ -21,7 +21,7 @@ const POSIT_ASSISTANT_SIGNIN_PROVIDERS: ModelProvider[] = [
 ];
 
 test.describe('Posit Assistant Sign-in', {
-	tag: [tags.POSIT_ASSISTANT, tags.ASSISTANT, tags.WEB, tags.WIN],
+	tag: [tags.ASSISTANT, tags.WEB, tags.WIN],
 }, () => {
 
 	for (const provider of POSIT_ASSISTANT_SIGNIN_PROVIDERS) {

--- a/test/e2e/tests/posit-assistant/posit-assistant.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant.test.ts
@@ -13,7 +13,7 @@ test.use({
 const POSIT_ASSISTANT_PROVIDERS: ModelProvider[] = ['anthropic-api'];
 
 test.describe('Posit Assistant', {
-	tag: [tags.POSIT_ASSISTANT, tags.ASSISTANT, tags.WEB, tags.WIN, tags.PLOTS],
+	tag: [tags.ASSISTANT, tags.WEB, tags.WIN, tags.PLOTS],
 }, () => {
 
 	for (const provider of POSIT_ASSISTANT_PROVIDERS) {
@@ -159,7 +159,7 @@ test.describe('Posit Assistant', {
  * visibility; this test exercises that gate in both directions.
  * @see https://github.com/posit-dev/positron/pull/14054
  */
-test.describe('Language Model Access Gating', { tag: [tags.POSIT_ASSISTANT, tags.ASSISTANT] }, () => {
+test.describe('Language Model Access Gating', { tag: [tags.ASSISTANT] }, () => {
 	const COMMAND_TITLE = 'Manage Language Model Access';
 
 	test.afterEach('Reset chat.disableAIFeatures', async function ({ settings }) {

--- a/test/e2e/tests/workbench/posit-assistant/posit-assistant-foundry.test.ts
+++ b/test/e2e/tests/workbench/posit-assistant/posit-assistant-foundry.test.ts
@@ -12,7 +12,7 @@ test.use({
 });
 
 test.describe('Posit Assistant - Microsoft Foundry (Azure managed credentials)', {
-	tag: [tags.WORKBENCH_AZURE, tags.POSIT_ASSISTANT, tags.ASSISTANT],
+	tag: [tags.WORKBENCH_AZURE, tags.ASSISTANT],
 }, () => {
 	test('Foundry model responds when authenticated via Azure managed credentials', async function ({ app }) {
 		// No interactive sign-in: the msFoundry provider obtains its token via


### PR DESCRIPTION
### Summary
tags.ASSISTANT and tags.POSIT_ASSISTANT both still exist from Positron Assistant migration and it's quite confusing. Going forward only tags.ASSISTANT is to be used.

- Removed `POSIT_ASSISTANT` from test-tags and tests
- Updated `extensions-tag-map.json`'s `posit.assistant` entry to just `assistant`

### QA Notes
`scripts/check-test-tag-map.sh --tags-only` and `scripts/test/pr-tags-lib-test.sh` pass.