### PR TITLE
ci: fix false-positive WIN/WEB auto-tag detection on same-line edits

### DIFF
--- a/scripts/lib/pr-tags-lib.sh
+++ b/scripts/lib/pr-tags-lib.sh
@@ -55,21 +55,11 @@ derive_map_tags() {
 	printf '%s\n' "${out[@]}" | awk 'NF && !seen[$0]++' | paste -sd, -
 }
 
-# scan_added_platform_tags <patch_text>
-#   patch_text: unified-diff text for a SINGLE file's patch. Do not pass in
-#   multiple files' patches concatenated together -- see
-#   scan_added_platform_tags_across_files, which exists specifically to avoid
-#   that.
-# Echoes "<win> <web>" (each true/false), true iff the tag enum reference is
-# GENUINELY new: present on an added line and absent from every removed line.
-# The "absent from removed" half matters because a tag array usually lives on
-# one line -- editing any entry (e.g. dropping an unrelated tag) reprints the
-# whole line as one removed + one added line. Checking added lines alone would
-# then treat an already-present tags.WIN/tags.WEB as newly added on every such
-# edit (see #14731, which only removed tags.POSIT_ASSISTANT from a line that
-# already carried tags.WIN/tags.WEB and still tripped this check). Test source
-# uses `tags.WIN` / `tags.WEB`, not the literal `@:win` / `@:web`, so match the
-# enum members.
+# scan_added_platform_tags <patch_text for ONE file>
+# Echoes "<win> <web>" (true/false): true only if tags.WIN/tags.WEB is on an
+# added line AND not on a removed one -- a same-line edit that reprints an
+# already-present tag (#14731) doesn't count. Multiple files? Use
+# scan_added_platform_tags_across_files instead of concatenating patches.
 scan_added_platform_tags() {
 	local patch="$1" added removed win=false web=false
 	added="$(printf '%s\n' "$patch" | grep '^+' | grep -v '^+++' || true)"
@@ -84,17 +74,9 @@ scan_added_platform_tags() {
 }
 
 # scan_added_platform_tags_across_files <patch1> [<patch2> ...]
-#   Each argument is one file's full patch text (as scan_added_platform_tags
-#   expects).
-# Echoes "<win> <web>", OR-ed across all files passed in.
-#
-# This is NOT equivalent to concatenating every file's patch into one string
-# and calling scan_added_platform_tags once: the "absent from every removed
-# line" check has to be scoped PER FILE, or one file's incidental removed-line
-# mention of tags.WIN can mask a genuinely new tags.WIN added in a different
-# file in the same PR (e.g. a tag-cleanup PR touching many test files
-# alongside someone else's new Windows test). Callers with multiple e2e test
-# files in a PR must call this, not scan_added_platform_tags directly.
+# Runs scan_added_platform_tags per file and ORs the results. Keep files
+# separate here, don't concatenate them first: one file's stale tag mention
+# could otherwise mask a genuinely new tag added in a different file.
 scan_added_platform_tags_across_files() {
 	local patch file_win file_web win=false web=false
 	for patch in "$@"; do

--- a/scripts/lib/pr-tags-lib.sh
+++ b/scripts/lib/pr-tags-lib.sh
@@ -56,21 +56,25 @@ derive_map_tags() {
 }
 
 # scan_added_platform_tags <patch_text for ONE file>
-# Echoes "<win> <web>" (true/false): true only if tags.WIN/tags.WEB is on an
-# added line AND not on a removed one -- a same-line edit that reprints an
-# already-present tag (#14731) doesn't count. Multiple files? Use
-# scan_added_platform_tags_across_files instead of concatenating patches.
+# Echoes "<win> <web>" (true/false): true only if a hunk has tags.WIN/tags.WEB
+# on an added line but not on a removed line IN THAT SAME HUNK -- so a same-line
+# edit that reprints an already-present tag (#14731) doesn't count, but an
+# unrelated hunk elsewhere in the file can't mask a real addition either.
+# Multiple files? Use scan_added_platform_tags_across_files, don't concatenate.
 scan_added_platform_tags() {
-	local patch="$1" added removed win=false web=false
-	added="$(printf '%s\n' "$patch" | grep '^+' | grep -v '^+++' || true)"
-	removed="$(printf '%s\n' "$patch" | grep '^-' | grep -v '^---' || true)"
-	if printf '%s\n' "$added" | grep -q "tags\.WIN" && ! printf '%s\n' "$removed" | grep -q "tags\.WIN"; then
-		win=true
-	fi
-	if printf '%s\n' "$added" | grep -q "tags\.WEB" && ! printf '%s\n' "$removed" | grep -q "tags\.WEB"; then
-		web=true
-	fi
-	echo "$win $web"
+	local patch="$1"
+	printf '%s\n' "$patch" | awk '
+		function flush() {
+			if (a_win && !r_win) win = 1
+			if (a_web && !r_web) web = 1
+			a_win = 0; r_win = 0; a_web = 0; r_web = 0
+		}
+		/^@@/ { flush() }
+		/^\+\+\+/ || /^---/ { next }
+		/^\+/ { if ($0 ~ /tags\.WIN/) a_win = 1; if ($0 ~ /tags\.WEB/) a_web = 1 }
+		/^-/ { if ($0 ~ /tags\.WIN/) r_win = 1; if ($0 ~ /tags\.WEB/) r_web = 1 }
+		END { flush(); print (win ? "true" : "false"), (web ? "true" : "false") }
+	'
 }
 
 # scan_added_platform_tags_across_files <patch1> [<patch2> ...]

--- a/scripts/lib/pr-tags-lib.sh
+++ b/scripts/lib/pr-tags-lib.sh
@@ -56,7 +56,10 @@ derive_map_tags() {
 }
 
 # scan_added_platform_tags <patch_text>
-#   patch_text: unified-diff text (concatenated patches of e2e test files)
+#   patch_text: unified-diff text for a SINGLE file's patch. Do not pass in
+#   multiple files' patches concatenated together -- see
+#   scan_added_platform_tags_across_files, which exists specifically to avoid
+#   that.
 # Echoes "<win> <web>" (each true/false), true iff the tag enum reference is
 # GENUINELY new: present on an added line and absent from every removed line.
 # The "absent from removed" half matters because a tag array usually lives on
@@ -77,6 +80,28 @@ scan_added_platform_tags() {
 	if printf '%s\n' "$added" | grep -q "tags\.WEB" && ! printf '%s\n' "$removed" | grep -q "tags\.WEB"; then
 		web=true
 	fi
+	echo "$win $web"
+}
+
+# scan_added_platform_tags_across_files <patch1> [<patch2> ...]
+#   Each argument is one file's full patch text (as scan_added_platform_tags
+#   expects).
+# Echoes "<win> <web>", OR-ed across all files passed in.
+#
+# This is NOT equivalent to concatenating every file's patch into one string
+# and calling scan_added_platform_tags once: the "absent from every removed
+# line" check has to be scoped PER FILE, or one file's incidental removed-line
+# mention of tags.WIN can mask a genuinely new tags.WIN added in a different
+# file in the same PR (e.g. a tag-cleanup PR touching many test files
+# alongside someone else's new Windows test). Callers with multiple e2e test
+# files in a PR must call this, not scan_added_platform_tags directly.
+scan_added_platform_tags_across_files() {
+	local patch file_win file_web win=false web=false
+	for patch in "$@"; do
+		read -r file_win file_web <<< "$(scan_added_platform_tags "$patch")"
+		[[ "$file_win" == "true" ]] && win=true
+		[[ "$file_web" == "true" ]] && web=true
+	done
 	echo "$win $web"
 }
 

--- a/scripts/lib/pr-tags-lib.sh
+++ b/scripts/lib/pr-tags-lib.sh
@@ -57,14 +57,26 @@ derive_map_tags() {
 
 # scan_added_platform_tags <patch_text>
 #   patch_text: unified-diff text (concatenated patches of e2e test files)
-# Echoes "<win> <web>" (each true/false), true iff the tag enum reference
-# appears on an ADDED line. Test source uses `tags.WIN` / `tags.WEB`, not the
-# literal `@:win` / `@:web`, so match the enum members.
+# Echoes "<win> <web>" (each true/false), true iff the tag enum reference is
+# GENUINELY new: present on an added line and absent from every removed line.
+# The "absent from removed" half matters because a tag array usually lives on
+# one line -- editing any entry (e.g. dropping an unrelated tag) reprints the
+# whole line as one removed + one added line. Checking added lines alone would
+# then treat an already-present tags.WIN/tags.WEB as newly added on every such
+# edit (see #14731, which only removed tags.POSIT_ASSISTANT from a line that
+# already carried tags.WIN/tags.WEB and still tripped this check). Test source
+# uses `tags.WIN` / `tags.WEB`, not the literal `@:win` / `@:web`, so match the
+# enum members.
 scan_added_platform_tags() {
-	local patch="$1" added win=false web=false
+	local patch="$1" added removed win=false web=false
 	added="$(printf '%s\n' "$patch" | grep '^+' | grep -v '^+++' || true)"
-	printf '%s\n' "$added" | grep -q "tags\.WIN" && win=true
-	printf '%s\n' "$added" | grep -q "tags\.WEB" && web=true
+	removed="$(printf '%s\n' "$patch" | grep '^-' | grep -v '^---' || true)"
+	if printf '%s\n' "$added" | grep -q "tags\.WIN" && ! printf '%s\n' "$removed" | grep -q "tags\.WIN"; then
+		win=true
+	fi
+	if printf '%s\n' "$added" | grep -q "tags\.WEB" && ! printf '%s\n' "$removed" | grep -q "tags\.WEB"; then
+		web=true
+	fi
 	echo "$win $web"
 }
 

--- a/scripts/pr-tags-parse.sh
+++ b/scripts/pr-tags-parse.sh
@@ -180,18 +180,11 @@ else
 		fi
 	fi
 
-	# Enable Windows/web jobs when a NEWLY ADDED e2e test carries tags.WIN /
-	# tags.WEB (read from added diff lines only, so small edits to an existing
-	# tagged test don't opt in). Runs regardless of @:no-auto-tags. Also fold
-	# @:win/@:web into TAGS so the PR comment shows why those jobs are running --
-	# otherwise the comment lists the tags used for --grep filtering but not the
-	# ones that silently gated the whole Windows/web job on.
-	#
-	# Fetched and scanned per file (not concatenated into one blob): each
-	# element is @json-encoded so a patch's embedded newlines survive as a
-	# literal `\n` on one line, keeping file boundaries intact for `read`.
-	# scan_added_platform_tags_across_files then needs per-file boundaries to
-	# avoid one file's removed-line tag masking another file's genuinely new one.
+	# Enable Windows/web jobs when a test genuinely adds tags.WIN/tags.WEB.
+	# Runs regardless of @:no-auto-tags. Also add @:win/@:web to TAGS so the PR
+	# comment explains why those jobs ran.
+	# @json-encode each file's patch so embedded newlines don't merge files
+	# together when read line by line -- see scan_added_platform_tags_across_files.
 	declare -a TEST_FILE_PATCHES=()
 	while IFS= read -r ENCODED_PATCH || [[ -n "$ENCODED_PATCH" ]]; do
 		[[ -z "$ENCODED_PATCH" ]] && continue

--- a/scripts/pr-tags-parse.sh
+++ b/scripts/pr-tags-parse.sh
@@ -182,7 +182,10 @@ else
 
 	# Enable Windows/web jobs when a NEWLY ADDED e2e test carries tags.WIN /
 	# tags.WEB (read from added diff lines only, so small edits to an existing
-	# tagged test don't opt in). Runs regardless of @:no-auto-tags.
+	# tagged test don't opt in). Runs regardless of @:no-auto-tags. Also fold
+	# @:win/@:web into TAGS so the PR comment shows why those jobs are running --
+	# otherwise the comment lists the tags used for --grep filtering but not the
+	# ones that silently gated the whole Windows/web job on.
 	TEST_PATCHES="$(gh api repos/${REPO}/pulls/${PR_NUMBER}/files --paginate \
 		--header "Authorization: token $GITHUB_TOKEN" \
 		--jq '.[] | select(.filename | startswith("test/e2e/tests/")) | .patch' || true)"
@@ -190,10 +193,12 @@ else
 	if [[ "$ADDED_WIN" == "true" ]]; then
 		echo "Newly added e2e test carries tags.WIN. Enabling Windows tests."
 		echo "win_tag_found=true" >> "$GITHUB_OUTPUT"
+		TAGS="$(union_csv_tags "$TAGS" "@:win")"
 	fi
 	if [[ "$ADDED_WEB" == "true" ]]; then
 		echo "Newly added e2e test carries tags.WEB. Enabling web tests."
 		echo "web_tag_found=true" >> "$GITHUB_OUTPUT"
+		TAGS="$(union_csv_tags "$TAGS" "@:web")"
 	fi
 
 	# Output the tags

--- a/scripts/pr-tags-parse.sh
+++ b/scripts/pr-tags-parse.sh
@@ -186,10 +186,20 @@ else
 	# @:win/@:web into TAGS so the PR comment shows why those jobs are running --
 	# otherwise the comment lists the tags used for --grep filtering but not the
 	# ones that silently gated the whole Windows/web job on.
-	TEST_PATCHES="$(gh api repos/${REPO}/pulls/${PR_NUMBER}/files --paginate \
+	#
+	# Fetched and scanned per file (not concatenated into one blob): each
+	# element is @json-encoded so a patch's embedded newlines survive as a
+	# literal `\n` on one line, keeping file boundaries intact for `read`.
+	# scan_added_platform_tags_across_files then needs per-file boundaries to
+	# avoid one file's removed-line tag masking another file's genuinely new one.
+	declare -a TEST_FILE_PATCHES=()
+	while IFS= read -r ENCODED_PATCH || [[ -n "$ENCODED_PATCH" ]]; do
+		[[ -z "$ENCODED_PATCH" ]] && continue
+		TEST_FILE_PATCHES+=("$(jq -r '.' <<< "$ENCODED_PATCH")")
+	done < <(gh api repos/${REPO}/pulls/${PR_NUMBER}/files --paginate \
 		--header "Authorization: token $GITHUB_TOKEN" \
-		--jq '.[] | select(.filename | startswith("test/e2e/tests/")) | .patch' || true)"
-	read -r ADDED_WIN ADDED_WEB <<< "$(scan_added_platform_tags "$TEST_PATCHES")"
+		--jq '.[] | select(.filename | startswith("test/e2e/tests/")) | (.patch // "") | @json' || true)
+	read -r ADDED_WIN ADDED_WEB <<< "$(scan_added_platform_tags_across_files "${TEST_FILE_PATCHES[@]}")"
 	if [[ "$ADDED_WIN" == "true" ]]; then
 		echo "Newly added e2e test carries tags.WIN. Enabling Windows tests."
 		echo "win_tag_found=true" >> "$GITHUB_OUTPUT"

--- a/scripts/test/pr-tags-lib-test.sh
+++ b/scripts/test/pr-tags-lib-test.sh
@@ -125,45 +125,33 @@ PATCH_REMOVED=$'@@ -1 +0,0 @@\n-test.describe("x", { tag: [tags.WEB] }, () => {}
 assert_eq "removed line not counted" "false false" "$(scan_added_platform_tags "$PATCH_REMOVED")"
 PATCH_BOTH=$'@@ -0 +1,2 @@\n+const a = tags.WIN;\n+const b = tags.WEB;'
 assert_eq "added win and web" "true true" "$(scan_added_platform_tags "$PATCH_BOTH")"
-# Regression for #14731: editing a tag array on one line (dropping an unrelated
-# tag) reprints tags.WIN/tags.WEB as both removed and added -- not genuinely new.
+# Regression for #14731: an unrelated same-line edit reprints tags.WIN/tags.WEB.
 PATCH_SAME_LINE_EDIT=$'@@ -1 +1 @@\n-\ttag: [tags.POSIT_ASSISTANT, tags.ASSISTANT, tags.WEB, tags.WIN],\n+\ttag: [tags.ASSISTANT, tags.WEB, tags.WIN],'
 assert_eq "same-line edit keeping win/web is not newly added" "false false" \
 	"$(scan_added_platform_tags "$PATCH_SAME_LINE_EDIT")"
-# But a tag genuinely newly added alongside an untouched one should still count.
 PATCH_WIN_ADDED_TO_EXISTING=$'@@ -1 +1 @@\n-\ttag: [tags.ASSISTANT],\n+\ttag: [tags.ASSISTANT, tags.WIN],'
 assert_eq "win added to existing tag array is newly added" "true false" \
 	"$(scan_added_platform_tags "$PATCH_WIN_ADDED_TO_EXISTING")"
-# WEB-only mirror of the #14731 same-line-edit case -- the WIN and WEB checks
-# are independent, so exercise WEB alone rather than only ever pairing it with WIN.
+# WEB-only mirror -- WIN and WEB are scored independently.
 PATCH_SAME_LINE_EDIT_WEB_ONLY=$'@@ -1 +1 @@\n-\ttag: [tags.OLD, tags.ASSISTANT, tags.WEB],\n+\ttag: [tags.ASSISTANT, tags.WEB],'
 assert_eq "same-line edit keeping web-only is not newly added" "false false" \
 	"$(scan_added_platform_tags "$PATCH_SAME_LINE_EDIT_WEB_ONLY")"
-# A same-line "swap" -- WIN dropped, WEB newly added -- should score each tag
-# independently rather than coupling them (e.g. both flipping true, or a stale
-# WIN counting as evidence WEB isn't new).
+# Same-line swap: WIN dropped, WEB added -- must not couple the two checks.
 PATCH_SAME_LINE_SWAP=$'@@ -1 +1 @@\n-\ttag: [tags.ASSISTANT, tags.WIN],\n+\ttag: [tags.ASSISTANT, tags.WEB],'
 assert_eq "same-line swap: web newly added, win newly removed (not added)" "false true" \
 	"$(scan_added_platform_tags "$PATCH_SAME_LINE_SWAP")"
 
 # --- scan_added_platform_tags_across_files ---
-# Single-file passthrough behaves the same as the underlying function.
 assert_eq "across_files: single genuine add" "true false" \
 	"$(scan_added_platform_tags_across_files "$PATCH_WIN")"
-# No files touched (e.g. a PR with no e2e test changes) is a no-op, not an error.
 assert_eq "across_files: no files" "false false" \
 	"$(scan_added_platform_tags_across_files)"
-# The critical case this function exists for: a PR that both (a) genuinely adds
-# tags.WIN in one file and (b) does an unrelated same-line edit in another file
-# that incidentally still carries tags.WIN. Concatenating both files' patches
-# into one blob before scanning would see tags.WIN on a removed line (from file
-# b) and wrongly suppress the genuine addition in file a. Scoping per file must
-# keep file a's true positive intact.
+# Why this function exists: concatenating both files' patches before scanning
+# would see tags.WIN on file b's removed line and wrongly suppress file a's add.
 FILE_A_GENUINE_WIN=$'@@ -0 +1 @@\n+test.describe("new win test", { tag: [tags.WIN] }, () => {})'
 FILE_B_UNRELATED_EDIT_MENTIONS_WIN=$'@@ -1 +1 @@\n-\ttag: [tags.OLD, tags.ASSISTANT, tags.WIN],\n+\ttag: [tags.ASSISTANT, tags.WIN],'
 assert_eq "across_files: genuine add in one file survives unrelated edit in another" "true false" \
 	"$(scan_added_platform_tags_across_files "$FILE_A_GENUINE_WIN" "$FILE_B_UNRELATED_EDIT_MENTIONS_WIN")"
-# Symmetric sanity check: two files, neither with a genuine addition, stays false.
 assert_eq "across_files: no genuine addition anywhere stays false" "false false" \
 	"$(scan_added_platform_tags_across_files "$PATCH_SAME_LINE_EDIT" "$FILE_B_UNRELATED_EDIT_MENTIONS_WIN")"
 

--- a/scripts/test/pr-tags-lib-test.sh
+++ b/scripts/test/pr-tags-lib-test.sh
@@ -125,6 +125,15 @@ PATCH_REMOVED=$'@@ -1 +0,0 @@\n-test.describe("x", { tag: [tags.WEB] }, () => {}
 assert_eq "removed line not counted" "false false" "$(scan_added_platform_tags "$PATCH_REMOVED")"
 PATCH_BOTH=$'@@ -0 +1,2 @@\n+const a = tags.WIN;\n+const b = tags.WEB;'
 assert_eq "added win and web" "true true" "$(scan_added_platform_tags "$PATCH_BOTH")"
+# Regression for #14731: editing a tag array on one line (dropping an unrelated
+# tag) reprints tags.WIN/tags.WEB as both removed and added -- not genuinely new.
+PATCH_SAME_LINE_EDIT=$'@@ -1 +1 @@\n-\ttag: [tags.POSIT_ASSISTANT, tags.ASSISTANT, tags.WEB, tags.WIN],\n+\ttag: [tags.ASSISTANT, tags.WEB, tags.WIN],'
+assert_eq "same-line edit keeping win/web is not newly added" "false false" \
+	"$(scan_added_platform_tags "$PATCH_SAME_LINE_EDIT")"
+# But a tag genuinely newly added alongside an untouched one should still count.
+PATCH_WIN_ADDED_TO_EXISTING=$'@@ -1 +1 @@\n-\ttag: [tags.ASSISTANT],\n+\ttag: [tags.ASSISTANT, tags.WIN],'
+assert_eq "win added to existing tag array is newly added" "true false" \
+	"$(scan_added_platform_tags "$PATCH_WIN_ADDED_TO_EXISTING")"
 
 # --- is_infra_only ---
 assert_eq "infra only" "true" "$(is_infra_only "$(printf '.github/workflows/x.yml\ndocs/y.md')")"

--- a/scripts/test/pr-tags-lib-test.sh
+++ b/scripts/test/pr-tags-lib-test.sh
@@ -140,6 +140,12 @@ assert_eq "same-line edit keeping web-only is not newly added" "false false" \
 PATCH_SAME_LINE_SWAP=$'@@ -1 +1 @@\n-\ttag: [tags.ASSISTANT, tags.WIN],\n+\ttag: [tags.ASSISTANT, tags.WEB],'
 assert_eq "same-line swap: web newly added, win newly removed (not added)" "false true" \
 	"$(scan_added_platform_tags "$PATCH_SAME_LINE_SWAP")"
+# Two hunks in the SAME file: one edits an existing tag array (unrelated
+# removal keeps tags.WIN), the other genuinely adds a new tags.WIN test. The
+# unrelated hunk must not mask the real addition in the other hunk.
+PATCH_TWO_HUNKS=$'@@ -1 +1 @@\n-\ttag: [tags.OLD, tags.ASSISTANT, tags.WIN],\n+\ttag: [tags.ASSISTANT, tags.WIN],\n@@ -20 +20,2 @@\n+test.describe("new win test", { tag: [tags.WIN] }, () => {})'
+assert_eq "genuine add in one hunk survives unrelated edit in another hunk, same file" "true false" \
+	"$(scan_added_platform_tags "$PATCH_TWO_HUNKS")"
 
 # --- scan_added_platform_tags_across_files ---
 assert_eq "across_files: single genuine add" "true false" \

--- a/scripts/test/pr-tags-lib-test.sh
+++ b/scripts/test/pr-tags-lib-test.sh
@@ -134,6 +134,38 @@ assert_eq "same-line edit keeping win/web is not newly added" "false false" \
 PATCH_WIN_ADDED_TO_EXISTING=$'@@ -1 +1 @@\n-\ttag: [tags.ASSISTANT],\n+\ttag: [tags.ASSISTANT, tags.WIN],'
 assert_eq "win added to existing tag array is newly added" "true false" \
 	"$(scan_added_platform_tags "$PATCH_WIN_ADDED_TO_EXISTING")"
+# WEB-only mirror of the #14731 same-line-edit case -- the WIN and WEB checks
+# are independent, so exercise WEB alone rather than only ever pairing it with WIN.
+PATCH_SAME_LINE_EDIT_WEB_ONLY=$'@@ -1 +1 @@\n-\ttag: [tags.OLD, tags.ASSISTANT, tags.WEB],\n+\ttag: [tags.ASSISTANT, tags.WEB],'
+assert_eq "same-line edit keeping web-only is not newly added" "false false" \
+	"$(scan_added_platform_tags "$PATCH_SAME_LINE_EDIT_WEB_ONLY")"
+# A same-line "swap" -- WIN dropped, WEB newly added -- should score each tag
+# independently rather than coupling them (e.g. both flipping true, or a stale
+# WIN counting as evidence WEB isn't new).
+PATCH_SAME_LINE_SWAP=$'@@ -1 +1 @@\n-\ttag: [tags.ASSISTANT, tags.WIN],\n+\ttag: [tags.ASSISTANT, tags.WEB],'
+assert_eq "same-line swap: web newly added, win newly removed (not added)" "false true" \
+	"$(scan_added_platform_tags "$PATCH_SAME_LINE_SWAP")"
+
+# --- scan_added_platform_tags_across_files ---
+# Single-file passthrough behaves the same as the underlying function.
+assert_eq "across_files: single genuine add" "true false" \
+	"$(scan_added_platform_tags_across_files "$PATCH_WIN")"
+# No files touched (e.g. a PR with no e2e test changes) is a no-op, not an error.
+assert_eq "across_files: no files" "false false" \
+	"$(scan_added_platform_tags_across_files)"
+# The critical case this function exists for: a PR that both (a) genuinely adds
+# tags.WIN in one file and (b) does an unrelated same-line edit in another file
+# that incidentally still carries tags.WIN. Concatenating both files' patches
+# into one blob before scanning would see tags.WIN on a removed line (from file
+# b) and wrongly suppress the genuine addition in file a. Scoping per file must
+# keep file a's true positive intact.
+FILE_A_GENUINE_WIN=$'@@ -0 +1 @@\n+test.describe("new win test", { tag: [tags.WIN] }, () => {})'
+FILE_B_UNRELATED_EDIT_MENTIONS_WIN=$'@@ -1 +1 @@\n-\ttag: [tags.OLD, tags.ASSISTANT, tags.WIN],\n+\ttag: [tags.ASSISTANT, tags.WIN],'
+assert_eq "across_files: genuine add in one file survives unrelated edit in another" "true false" \
+	"$(scan_added_platform_tags_across_files "$FILE_A_GENUINE_WIN" "$FILE_B_UNRELATED_EDIT_MENTIONS_WIN")"
+# Symmetric sanity check: two files, neither with a genuine addition, stays false.
+assert_eq "across_files: no genuine addition anywhere stays false" "false false" \
+	"$(scan_added_platform_tags_across_files "$PATCH_SAME_LINE_EDIT" "$FILE_B_UNRELATED_EDIT_MENTIONS_WIN")"
 
 # --- is_infra_only ---
 assert_eq "infra only" "true" "$(is_infra_only "$(printf '.github/workflows/x.yml\ndocs/y.md')")"


### PR DESCRIPTION
### Summary
#14602's WIN/web platform-tag auto-detection false-triggered on #14731, which only reordered an unrelated tag on the same line -- it never touched WIN/web itself.
- Only count a tag as newly added if it's on an added line and absent from removed lines in the same diff hunk, not just present anywhere on an added line
- Scope per file, then per hunk within a file, so one unrelated mention can't mask a genuine addition elsewhere in the PR or the same file
- Surface the matched platform tag in the PR comment when this path fires
- Add regression tests for the false positive, a genuine addition, and the cross-file/cross-hunk masking cases

### QA Notes
`scripts/test/pr-tags-lib-test.sh` and `scripts/check-test-tag-map.sh --tags-only` pass. Reviewed via roborev (2 fix iterations); one residual edge case (two unrelated platform-tag edits landing in the exact same diff hunk with no separating context) is a known, accepted limitation -- fixing it needs real line-level diff alignment, disproportionate for that narrow a shape.