### PR TITLE
Add Fix/Explain buttons to Quarto inline output errors

### DIFF
--- a/build/lib/i18n.resources.json
+++ b/build/lib/i18n.resources.json
@@ -279,6 +279,10 @@
 			"project": "vscode-workbench"
 		},
 		{
+			"name": "vs/workbench/contrib/positronQuarto",
+			"project": "vscode-workbench"
+		},
+		{
 			"name": "vs/workbench/contrib/repl",
 			"project": "vscode-workbench"
 		},

--- a/src/vs/workbench/contrib/positronAssistant/browser/positAssistantChat.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/positAssistantChat.ts
@@ -13,6 +13,11 @@ import { INotificationService } from '../../../../platform/notification/common/n
 // repositories cannot share a module).
 export const POSIT_NEW_CHAT_COMMAND = 'posit-assistant.newChat';
 
+// Context key set by the Posit Assistant extension when it has at least one
+// usable chat model. Like the command ID, the string is mirrored in the
+// extension.
+export const POSIT_HAS_CHAT_MODELS_KEY = 'posit-assistant.hasChatModels';
+
 /** A file attachment passed to the Posit Assistant newChat command. */
 export interface NewChatFile {
 	uri: string;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/AssistantErrorQuickFix.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/AssistantErrorQuickFix.css
@@ -1,10 +1,10 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
 /* Container for all quick-fix buttons */
-.notebook-cell-quick-fix {
+.assistant-error-quick-fix {
 	display: flex;
 	flex-direction: row;
 	justify-content: flex-start;
@@ -13,20 +13,20 @@
 }
 
 /* Override split button styling for quick-fix buttons */
-.notebook-cell-quick-fix .notebook-cell-quick-fix-split-button {
+.assistant-error-quick-fix .assistant-error-quick-fix-split-button {
 	border-color: var(--vscode-positronActionBar-selectBorder);
 }
 
 /* Main action button styling */
-.notebook-cell-quick-fix .split-button-main {
+.assistant-error-quick-fix .split-button-main {
 	border-radius: 3px 0 0 3px;
 }
 
-.notebook-cell-quick-fix .split-button-main:hover {
+.assistant-error-quick-fix .split-button-main:hover {
 	background: var(--vscode-positronActionBar-hoverBackground);
 }
 
-.notebook-cell-quick-fix .split-button-main .link-text {
+.assistant-error-quick-fix .split-button-main .link-text {
 	display: flex;
 	align-items: center;
 	gap: 4px;
@@ -37,7 +37,7 @@
 	user-select: none;
 }
 
-.notebook-cell-quick-fix .split-button-main .link-text .codicon {
+.assistant-error-quick-fix .split-button-main .link-text .codicon {
 	color: var(--vscode-textLink-foreground);
 	font-size: 12px;
 	cursor: pointer;
@@ -45,16 +45,15 @@
 }
 
 /* Dropdown button styling */
-.notebook-cell-quick-fix .split-button-dropdown {
+.assistant-error-quick-fix .split-button-dropdown {
 	border-left-color: var(--vscode-positronActionBar-selectBorder);
 }
 
-.notebook-cell-quick-fix .split-button-dropdown:hover {
+.assistant-error-quick-fix .split-button-dropdown:hover {
 	background: var(--vscode-positronActionBar-hoverBackground);
 }
 
-.notebook-cell-quick-fix .split-button-dropdown .codicon {
+.assistant-error-quick-fix .split-button-dropdown .codicon {
 	color: var(--vscode-textLink-foreground);
 	font-size: 14px;
 }
-

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/AssistantErrorQuickFix.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/AssistantErrorQuickFix.tsx
@@ -1,0 +1,165 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import './AssistantErrorQuickFix.css';
+
+// React.
+import { useCallback, useMemo } from 'react';
+
+// Other dependencies.
+import { localize } from '../../../../../nls.js';
+import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
+import { IAction } from '../../../../../base/common/actions.js';
+import { removeAnsiEscapeCodes } from '../../../../../base/common/strings.js';
+import { encodeBase64, VSBuffer } from '../../../../../base/common/buffer.js';
+import { openPositAssistantChat } from '../../../positronAssistant/browser/positAssistantChat.js';
+import { SplitButton } from '../utilityComponents/SplitButton.js';
+
+// Appended to every Explain prompt. Without it, an agentic assistant treats
+// "Explain this error" plus an attached traceback as license to fix it too.
+const explainOnlyConstraint = localize('positronAssistantExplainOnlyConstraint', "Do not make changes or edit any files; just explain the error.");
+
+/**
+ * A prompt/attachment payload resolved when a quick-fix button is pressed.
+ */
+export interface AssistantErrorPayload {
+	/** Prompt sent when the user presses Fix. */
+	fixPrompt: string;
+	/**
+	 * Prompt sent when the user presses Explain; the component appends the
+	 * explain-only constraint to it.
+	 */
+	explainPrompt: string;
+	/** Attachment body describing the error. */
+	attachmentContent: string;
+}
+
+/**
+ * Props for the AssistantErrorQuickFix component.
+ */
+interface AssistantErrorQuickFixProps {
+	/**
+	 * Resolves the prompts and attachment when a button is pressed (not at
+	 * render time), so the payload can reflect the error source's current
+	 * location. Each caller owns its own fallback for an error source that
+	 * can no longer be found.
+	 */
+	getPayload: () => AssistantErrorPayload;
+	/** File name for the error attachment (e.g. 'notebook-cell-error.txt'). */
+	attachmentName: string;
+	/** Accessible label for the button group. */
+	groupAriaLabel: string;
+}
+
+/**
+ * Presentational "Fix" and "Explain" split buttons for an error output. Sends
+ * the error content to Posit Assistant via posit-assistant.newChat: the primary
+ * click starts a fresh conversation, the dropdown continues the current one.
+ *
+ * This component does no gating; each caller decides whether to render it (see
+ * NotebookCellQuickFix and QuartoOutputQuickFix, which apply their surface's
+ * assistant-availability checks first).
+ */
+export const AssistantErrorQuickFix = (props: AssistantErrorQuickFixProps) => {
+	const services = usePositronReactServicesContext();
+	const { commandService, contextMenuService, logService, notificationService } = services;
+
+	const { attachmentName, getPayload } = props;
+
+	// Resolve the payload when a button is pressed (not at render time) so the
+	// provider can report the error source's current location.
+	const runNewChat = useCallback((action: 'fix' | 'explain', target: 'new' | 'auto') => {
+		const payload = getPayload();
+		const prompt = action === 'fix'
+			? payload.fixPrompt
+			: `${payload.explainPrompt} ${explainOnlyConstraint}`;
+		const content = removeAnsiEscapeCodes(payload.attachmentContent).trim();
+		const attachment = content
+			? { uri: `data:text/plain;base64,${encodeBase64(VSBuffer.fromString(content))}`, name: attachmentName }
+			: undefined;
+		return openPositAssistantChat(commandService, notificationService, logService, {
+			prompt,
+			target,
+			behavior: 'submit',
+			...(attachment && { files: [attachment] }),
+		});
+	}, [commandService, logService, notificationService, getPayload, attachmentName]);
+
+	const pressedFixHandler = () => runNewChat('fix', 'new');
+
+	const pressedExplainHandler = () => runNewChat('explain', 'new');
+
+	// Memoize dropdown actions for Fix button
+	const fixDropdownActions = useMemo((): IAction[] => [
+		{
+			id: 'continue-in-existing-chat',
+			label: localize('positronAssistantFixInCurrentChat', "Ask assistant to fix in current chat"),
+			tooltip: localize('positronAssistantFixInCurrentChatTooltip', "Opens in the current chat session to retain conversation context"),
+			class: undefined,
+			enabled: true,
+			run: () => runNewChat('fix', 'auto')
+		}
+	], [runNewChat]);
+
+	// Memoize dropdown actions for Explain button
+	const explainDropdownActions = useMemo((): IAction[] => [
+		{
+			id: 'continue-in-existing-chat',
+			label: localize('positronAssistantExplainInCurrentChat', "Ask assistant to explain in current chat"),
+			tooltip: localize('positronAssistantExplainInCurrentChatTooltip', "Opens in the current chat session to retain conversation context"),
+			class: undefined,
+			enabled: true,
+			run: () => runNewChat('explain', 'auto')
+		}
+	], [runNewChat]);
+
+	// Tooltip strings
+	const fixTooltip = localize('positronAssistantFixTooltip', "Ask assistant to fix in new chat");
+	const fixDropdownTooltip = localize('positronAssistantFixDropdownTooltip', "More fix options");
+	const explainTooltip = localize('positronAssistantExplainTooltip', "Ask assistant to explain in new chat");
+	const explainDropdownTooltip = localize('positronAssistantExplainDropdownTooltip', "More explain options");
+
+	// Render.
+	return (
+		<div
+			aria-label={props.groupAriaLabel}
+			className='assistant-error-quick-fix'
+			role='group'
+		>
+			{/* Fix button with split dropdown */}
+			<SplitButton
+				ariaLabel={fixTooltip}
+				className='assistant-error-quick-fix-split-button'
+				contextMenuService={contextMenuService}
+				dropdownActions={fixDropdownActions}
+				dropdownIconClass='codicon-positron-drop-down-arrow'
+				dropdownTooltip={fixDropdownTooltip}
+				onMainAction={pressedFixHandler}
+			>
+				<div className='link-text' title={fixTooltip}>
+					<span className='codicon codicon-sparkle' />
+					{localize('positronAssistantFix', "Fix")}
+				</div>
+			</SplitButton>
+
+			{/* Explain button with split dropdown */}
+			<SplitButton
+				ariaLabel={explainTooltip}
+				className='assistant-error-quick-fix-split-button'
+				contextMenuService={contextMenuService}
+				dropdownActions={explainDropdownActions}
+				dropdownIconClass='codicon-positron-drop-down-arrow'
+				dropdownTooltip={explainDropdownTooltip}
+				onMainAction={pressedExplainHandler}
+			>
+				<div className='link-text' title={explainTooltip}>
+					<span className='codicon codicon-sparkle' />
+					{localize('positronAssistantExplain', "Explain")}
+				</div>
+			</SplitButton>
+		</div>
+	);
+};

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx
@@ -3,23 +3,16 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// CSS.
-import './NotebookCellQuickFix.css';
-
 // React.
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
-import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { usePositronConfiguration, useContextKey, useContextKeyFromString } from '../../../../../base/browser/positronReactHooks.js';
-import { IAction } from '../../../../../base/common/actions.js';
-import { removeAnsiEscapeCodes } from '../../../../../base/common/strings.js';
-import { encodeBase64, VSBuffer } from '../../../../../base/common/buffer.js';
 import { POSITRON_NOTEBOOK_ENABLED_KEY } from '../../common/positronNotebookConfig.js';
 import { NotebookContextKeys } from '../../common/notebookContextKeys.js';
-import { openPositAssistantChat } from '../../../positronAssistant/browser/positAssistantChat.js';
-import { SplitButton } from '../utilityComponents/SplitButton.js';
+import { POSIT_HAS_CHAT_MODELS_KEY } from '../../../positronAssistant/browser/positAssistantChat.js';
+import { AssistantErrorQuickFix } from './AssistantErrorQuickFix.js';
 
 const fixPrompt = localize('positronNotebookAssistantFixPrompt', "Fix this notebook cell error.");
 const explainPrompt = localize('positronNotebookAssistantExplainPrompt', "Explain this notebook cell error.");
@@ -35,14 +28,12 @@ interface NotebookCellQuickFixProps {
 }
 
 /**
- * Quick fix component for notebook cell errors.
- * Displays "Fix" and "Explain" split buttons that send the error content to the assistant
- * via posit-assistant.newChat.
- * Primary click starts a fresh conversation; dropdown continues in the current conversation.
+ * Quick fix buttons for notebook cell errors. Gates on the notebook's AI
+ * switches and, when enabled, delegates the buttons and assistant wiring to
+ * {@link AssistantErrorQuickFix}.
  */
 export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
-	const services = usePositronReactServicesContext();
-	const { commandService, contextMenuService, logService, notificationService } = services;
+	const { errorContent } = props;
 
 	// Configuration hooks to conditionally show the quick-fix buttons.
 	// notebookAiEnabled is the composite gate (global ai.enabled AND
@@ -52,113 +43,29 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 	const notebookAiEnabled = useContextKey<boolean>(NotebookContextKeys.aiEnabled);
 	const enableNotebookMode = usePositronConfiguration<boolean>(POSITRON_NOTEBOOK_ENABLED_KEY);
 	// Set by the Posit Assistant extension when it has at least one usable model.
-	// The old positron-assistant.hasChatModels key is going away this milestone.
-	const hasChatModels = useContextKeyFromString<boolean>('posit-assistant.hasChatModels');
+	const hasChatModels = useContextKeyFromString<boolean>(POSIT_HAS_CHAT_MODELS_KEY);
+
+	// Stable identity so AssistantErrorQuickFix's click handler and dropdown
+	// actions aren't recreated on every render.
+	const getPayload = useCallback(
+		() => ({ fixPrompt, explainPrompt, attachmentContent: errorContent }),
+		[errorContent]
+	);
 
 	// Only show buttons if notebook AI is enabled, notebook mode is enabled, and
 	// chat models are available
 	const showQuickFix = notebookAiEnabled !== false && enableNotebookMode && hasChatModels;
-
-	const cleanError = useMemo(
-		() => removeAnsiEscapeCodes(props.errorContent).trim(),
-		[props.errorContent]
-	);
-
-	const attachment = useMemo(() => {
-		if (!cleanError) {
-			return undefined;
-		}
-		const base64 = encodeBase64(VSBuffer.fromString(cleanError));
-		return { uri: `data:text/plain;base64,${base64}`, name: ATTACHMENT_NAME };
-	}, [cleanError]);
-
-	const runNewChat = useCallback((prompt: string, target: 'new' | 'auto') =>
-		openPositAssistantChat(commandService, notificationService, logService, {
-			prompt,
-			target,
-			behavior: 'submit',
-			...(attachment && { files: [attachment] }),
-		}),
-		[commandService, logService, notificationService, attachment]);
-
-	const pressedFixHandler = () => runNewChat(fixPrompt, 'new');
-
-	const pressedExplainHandler = () => runNewChat(explainPrompt, 'new');
-
-	// Memoize dropdown actions for Fix button
-	const fixDropdownActions = useMemo((): IAction[] => [
-		{
-			id: 'continue-in-existing-chat',
-			label: localize('positronNotebookAssistantFixInCurrentChat', "Ask assistant to fix in current chat"),
-			tooltip: localize('positronNotebookAssistantFixInCurrentChatTooltip', "Opens in the current chat session to retain conversation context"),
-			class: undefined,
-			enabled: true,
-			run: () => runNewChat(fixPrompt, 'auto')
-		}
-	], [runNewChat]);
-
-	// Memoize dropdown actions for Explain button
-	const explainDropdownActions = useMemo((): IAction[] => [
-		{
-			id: 'continue-in-existing-chat',
-			label: localize('positronNotebookAssistantExplainInCurrentChat', "Ask assistant to explain in current chat"),
-			tooltip: localize('positronNotebookAssistantExplainInCurrentChatTooltip', "Opens in the current chat session to retain conversation context"),
-			class: undefined,
-			enabled: true,
-			run: () => runNewChat(explainPrompt, 'auto')
-		}
-	], [runNewChat]);
 
 	// Don't render if assistant features are not enabled
 	if (!showQuickFix) {
 		return null;
 	}
 
-	// Tooltip strings
-	const fixTooltip = localize('positronNotebookAssistantFixTooltip', "Ask assistant to fix in new chat");
-	const fixDropdownTooltip = localize('positronNotebookAssistantFixDropdownTooltip', "More fix options");
-	const explainTooltip = localize('positronNotebookAssistantExplainTooltip', "Ask assistant to explain in new chat");
-	const explainDropdownTooltip = localize('positronNotebookAssistantExplainDropdownTooltip', "More explain options");
-
-	// Render.
 	return (
-		<div
-			aria-label={localize('positron.notebook.quickFixGroup', "Cell output quick fix actions")}
-			className='notebook-cell-quick-fix'
-			role='group'
-		>
-			{/* Fix button with split dropdown */}
-			<SplitButton
-				ariaLabel={fixTooltip}
-				className='notebook-cell-quick-fix-split-button'
-				contextMenuService={contextMenuService}
-				dropdownActions={fixDropdownActions}
-				dropdownIconClass='codicon-positron-drop-down-arrow'
-				dropdownTooltip={fixDropdownTooltip}
-				onMainAction={pressedFixHandler}
-			>
-				<div className='link-text' title={fixTooltip}>
-					<span className='codicon codicon-sparkle' />
-					{localize('positronNotebookAssistantFix', "Fix")}
-				</div>
-			</SplitButton>
-
-			{/* Explain button with split dropdown */}
-			<SplitButton
-				ariaLabel={explainTooltip}
-				className='notebook-cell-quick-fix-split-button'
-				contextMenuService={contextMenuService}
-				dropdownActions={explainDropdownActions}
-				dropdownIconClass='codicon-positron-drop-down-arrow'
-				dropdownTooltip={explainDropdownTooltip}
-				onMainAction={pressedExplainHandler}
-			>
-				<div className='link-text' title={explainTooltip}>
-					<span className='codicon codicon-sparkle' />
-					{localize('positronNotebookAssistantExplain', "Explain")}
-				</div>
-			</SplitButton>
-		</div>
+		<AssistantErrorQuickFix
+			attachmentName={ATTACHMENT_NAME}
+			getPayload={getPayload}
+			groupAriaLabel={localize('positron.notebook.quickFixGroup', "Cell output quick fix actions")}
+		/>
 	);
 };
-

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/AssistantErrorQuickFix.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/AssistantErrorQuickFix.vitest.tsx
@@ -1,0 +1,143 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { ComponentProps } from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IContextMenuService } from '../../../../../platform/contextview/browser/contextView.js';
+import { IContextMenuDelegate } from '../../../../../base/browser/contextmenu.js';
+import { IAction } from '../../../../../base/common/actions.js';
+import { decodeBase64 } from '../../../../../base/common/buffer.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
+import { POSIT_NEW_CHAT_COMMAND, NewChatOptions } from '../../../positronAssistant/browser/positAssistantChat.js';
+import { AssistantErrorQuickFix } from '../../browser/notebookCells/AssistantErrorQuickFix.js';
+
+describe('AssistantErrorQuickFix', () => {
+	const ctx = createTestContainer()
+		.withReactServices()
+		.stub(ICommandService, { executeCommand: vi.fn().mockResolvedValue(undefined) })
+		.stub(IContextMenuService, { showContextMenu: vi.fn() })
+		.build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
+
+	const defaultPayload = {
+		fixPrompt: 'Fix this test error.',
+		explainPrompt: 'Explain this test error.',
+		attachmentContent: 'NameError: name "x" is not defined',
+	};
+
+	const defaultProps = {
+		getPayload: () => defaultPayload,
+		attachmentName: 'test-error.txt',
+		groupAriaLabel: 'Error quick fix actions',
+	};
+
+	function renderQuickFix(overrides: Partial<ComponentProps<typeof AssistantErrorQuickFix>> = {}) {
+		return rtl.render(<AssistantErrorQuickFix {...defaultProps} {...overrides} />);
+	}
+
+	/** The newChat payload from the most recent executeCommand call. */
+	function lastNewChatOptions(): NewChatOptions {
+		const executeCommand = vi.mocked(ctx.get(ICommandService).executeCommand);
+		const lastCall = executeCommand.mock.calls.at(-1);
+		expect(lastCall?.[0]).toBe(POSIT_NEW_CHAT_COMMAND);
+		return lastCall?.[1] as NewChatOptions;
+	}
+
+	function decodeAttachment(uri: string): string {
+		return decodeBase64(uri.replace('data:text/plain;base64,', '')).toString();
+	}
+
+	it('sends the fix prompt and error attachment to a new chat', async () => {
+		const user = userEvent.setup();
+		renderQuickFix();
+		await user.click(screen.getByRole('button', { name: 'Ask assistant to fix in new chat' }));
+
+		const options = lastNewChatOptions();
+		expect({
+			...options,
+			files: options.files?.map(file => ({ name: file.name, content: decodeAttachment(file.uri) })),
+		}).toEqual({
+			prompt: 'Fix this test error.',
+			target: 'new',
+			behavior: 'submit',
+			files: [{ name: 'test-error.txt', content: 'NameError: name "x" is not defined' }],
+		});
+	});
+
+	it('appends the explain-only constraint to the explain prompt', async () => {
+		const user = userEvent.setup();
+		renderQuickFix();
+		await user.click(screen.getByRole('button', { name: 'Ask assistant to explain in new chat' }));
+
+		expect(lastNewChatOptions().prompt).toBe(
+			'Explain this test error. Do not make changes or edit any files; just explain the error.'
+		);
+	});
+
+	it('strips ANSI escape codes from the attachment', async () => {
+		const user = userEvent.setup();
+		renderQuickFix({ getPayload: () => ({ ...defaultPayload, attachmentContent: '\u001b[31mboom\u001b[0m' }) });
+		await user.click(screen.getByRole('button', { name: 'Ask assistant to fix in new chat' }));
+
+		const files = lastNewChatOptions().files;
+		expect(files && decodeAttachment(files[0].uri)).toBe('boom');
+	});
+
+	it('omits the attachment when the error content is blank', async () => {
+		const user = userEvent.setup();
+		renderQuickFix({ getPayload: () => ({ ...defaultPayload, attachmentContent: '   ' }) });
+		await user.click(screen.getByRole('button', { name: 'Ask assistant to fix in new chat' }));
+
+		expect(lastNewChatOptions().files).toBeUndefined();
+	});
+
+	it('resolves the payload at click time, not render time', async () => {
+		const user = userEvent.setup();
+		let attachmentContent = 'stale location';
+		renderQuickFix({ getPayload: () => ({ ...defaultPayload, attachmentContent }) });
+		attachmentContent = 'fresh location';
+		await user.click(screen.getByRole('button', { name: 'Ask assistant to fix in new chat' }));
+
+		const files = lastNewChatOptions().files;
+		expect(files && decodeAttachment(files[0].uri)).toBe('fresh location');
+	});
+
+	it('continues in the current chat via the fix dropdown action', async () => {
+		const user = userEvent.setup();
+		renderQuickFix();
+		await user.click(screen.getByRole('button', { name: 'More fix options' }));
+
+		const showContextMenu = vi.mocked(ctx.get(IContextMenuService).showContextMenu);
+		const delegate = showContextMenu.mock.calls.at(-1)?.[0] as IContextMenuDelegate;
+		const actions = delegate.getActions() as IAction[];
+		await actions[0].run();
+
+		const options = lastNewChatOptions();
+		expect(options.target).toBe('auto');
+		expect(options.prompt).toBe('Fix this test error.');
+	});
+
+	it('continues in the current chat via the explain dropdown action', async () => {
+		const user = userEvent.setup();
+		renderQuickFix();
+		await user.click(screen.getByRole('button', { name: 'More explain options' }));
+
+		const showContextMenu = vi.mocked(ctx.get(IContextMenuService).showContextMenu);
+		const delegate = showContextMenu.mock.calls.at(-1)?.[0] as IContextMenuDelegate;
+		const actions = delegate.getActions() as IAction[];
+		await actions[0].run();
+
+		const options = lastNewChatOptions();
+		expect(options.target).toBe('auto');
+		expect(options.prompt).toBe(
+			'Explain this test error. Do not make changes or edit any files; just explain the error.'
+		);
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/AssistantErrorQuickFix.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/AssistantErrorQuickFix.vitest.tsx
@@ -124,20 +124,4 @@ describe('AssistantErrorQuickFix', () => {
 		expect(options.prompt).toBe('Fix this test error.');
 	});
 
-	it('continues in the current chat via the explain dropdown action', async () => {
-		const user = userEvent.setup();
-		renderQuickFix();
-		await user.click(screen.getByRole('button', { name: 'More explain options' }));
-
-		const showContextMenu = vi.mocked(ctx.get(IContextMenuService).showContextMenu);
-		const delegate = showContextMenu.mock.calls.at(-1)?.[0] as IContextMenuDelegate;
-		const actions = delegate.getActions() as IAction[];
-		await actions[0].run();
-
-		const options = lastNewChatOptions();
-		expect(options.target).toBe('auto');
-		expect(options.prompt).toBe(
-			'Explain this test error. Do not make changes or edit any files; just explain the error.'
-		);
-	});
 });

--- a/src/vs/workbench/contrib/positronQuarto/browser/QuartoOutputQuickFix.tsx
+++ b/src/vs/workbench/contrib/positronQuarto/browser/QuartoOutputQuickFix.tsx
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// React.
+import { useCallback } from 'react';
+
+// Other dependencies.
+import { localize } from '../../../../nls.js';
+import { usePositronConfiguration, useContextKeyFromString } from '../../../../base/browser/positronReactHooks.js';
+import { AI_ENABLED_KEY } from '../../positronAssistant/common/positronAIConfiguration.js';
+import { POSIT_HAS_CHAT_MODELS_KEY } from '../../positronAssistant/browser/positAssistantChat.js';
+import { AssistantErrorQuickFix, AssistantErrorPayload } from '../../positronNotebook/browser/notebookCells/AssistantErrorQuickFix.js';
+import { QuartoCellErrorContext } from '../common/quartoExecutionTypes.js';
+
+const fixPrompt = localize('positronQuartoAssistantFixPrompt', "Fix this Quarto inline output error.");
+const explainPrompt = localize('positronQuartoAssistantExplainPrompt', "Explain this Quarto inline output error.");
+
+const ATTACHMENT_NAME = 'quarto-output-error.txt';
+
+interface QuartoOutputQuickFixProps {
+	/** The error output content from the Quarto cell execution. */
+	errorContent: string;
+	/** Cell context resolved at render time. */
+	cellContext?: QuartoCellErrorContext;
+}
+
+/**
+ * Quick fix buttons for Quarto inline output errors. Gated on ai.enabled +
+ * posit-assistant.hasChatModels; renders nothing when either is off.
+ */
+export const QuartoOutputQuickFix = (props: QuartoOutputQuickFixProps) => {
+	const aiEnabled = usePositronConfiguration<boolean>(AI_ENABLED_KEY);
+	const hasChatModels = useContextKeyFromString<boolean>(POSIT_HAS_CHAT_MODELS_KEY);
+
+	const { errorContent, cellContext } = props;
+
+	const buildPayload = useCallback((): AssistantErrorPayload => {
+		if (!cellContext) {
+			return { fixPrompt, explainPrompt, attachmentContent: errorContent };
+		}
+		const header = cellContext.label
+			? localize('positronQuartoErrorContextHeaderLabeled', "Error from the {0} code chunk in {1}, lines {2}-{3} (label: {4}):", cellContext.language, cellContext.path, cellContext.codeStartLine, cellContext.codeEndLine, cellContext.label)
+			: localize('positronQuartoErrorContextHeader', "Error from the {0} code chunk in {1}, lines {2}-{3}:", cellContext.language, cellContext.path, cellContext.codeStartLine, cellContext.codeEndLine);
+		const codeHeader = localize('positronQuartoErrorContextCodeHeader', "--- Failing code ---");
+		const errorHeader = localize('positronQuartoErrorContextErrorHeader', "--- Error output ---");
+		return {
+			fixPrompt: localize('positronQuartoAssistantFixPromptWithContext', "Fix the error from the {0} code chunk at lines {1}-{2} of {3}. The failing code and its error output are attached; fix only this error.", cellContext.language, cellContext.codeStartLine, cellContext.codeEndLine, cellContext.path),
+			explainPrompt: localize('positronQuartoAssistantExplainPromptWithContext', "Explain the error from the {0} code chunk at lines {1}-{2} of {3}. The failing code and its error output are attached.", cellContext.language, cellContext.codeStartLine, cellContext.codeEndLine, cellContext.path),
+			attachmentContent: `${header}\n\n${codeHeader}\n${cellContext.code}\n\n${errorHeader}\n${errorContent}`,
+		};
+	}, [cellContext, errorContent]);
+
+	if (aiEnabled === false || !hasChatModels) {
+		return null;
+	}
+
+	return (
+		<AssistantErrorQuickFix
+			attachmentName={ATTACHMENT_NAME}
+			getPayload={buildPayload}
+			groupAriaLabel={localize('positron.quarto.quickFixGroup', "Output quick fix actions")}
+		/>
+	);
+};

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoDocumentModel.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoDocumentModel.ts
@@ -142,12 +142,6 @@ export class QuartoDocumentModel extends Disposable implements IQuartoDocumentMo
 		return matches[0];
 	}
 
-	findCellByPreviousId(previousCellId: string, contentHash: string): QuartoCodeCell | undefined {
-		// Cell IDs are "{index}-{hashPrefix}-{label}" (see generateCellId), so
-		// the old index disambiguates duplicate chunks with the same hash.
-		const oldIndex = parseInt(previousCellId, 10);
-		return this.findCellByContentHash(contentHash, isNaN(oldIndex) ? undefined : oldIndex);
-	}
 
 	getCellCode(cell: QuartoCodeCell): string {
 		const lines: string[] = [];

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoDocumentModel.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoDocumentModel.ts
@@ -142,6 +142,13 @@ export class QuartoDocumentModel extends Disposable implements IQuartoDocumentMo
 		return matches[0];
 	}
 
+	findCellByPreviousId(previousCellId: string, contentHash: string): QuartoCodeCell | undefined {
+		// Cell IDs are "{index}-{hashPrefix}-{label}" (see generateCellId), so
+		// the old index disambiguates duplicate chunks with the same hash.
+		const oldIndex = parseInt(previousCellId, 10);
+		return this.findCellByContentHash(contentHash, isNaN(oldIndex) ? undefined : oldIndex);
+	}
+
 	getCellCode(cell: QuartoCodeCell): string {
 		const lines: string[] = [];
 		for (let i = cell.codeStartLine; i <= cell.codeEndLine; i++) {
@@ -149,6 +156,7 @@ export class QuartoDocumentModel extends Disposable implements IQuartoDocumentMo
 		}
 		return lines.join('\n');
 	}
+
 
 	private _parseDocument(): void {
 		const content = this._textModel.getValue();

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
@@ -24,7 +24,7 @@ import { dirname, basename, extname } from '../../../../base/common/resources.js
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { IPositronPreviewService } from '../../positronPreview/browser/positronPreviewSevice.js';
 import { IQuartoDocumentModelService } from './quartoDocumentModelService.js';
-import { IQuartoExecutionManager, ICellOutput, ICellOutputItem, CellExecutionState, IQuartoOutputCacheService } from '../common/quartoExecutionTypes.js';
+import { IQuartoExecutionManager, ICellOutput, ICellOutputItem, CellExecutionState, IQuartoOutputCacheService, QuartoCellErrorContext } from '../common/quartoExecutionTypes.js';
 import { QUARTO_INLINE_OUTPUT_ENABLED, POSITRON_QUARTO_INLINE_OUTPUT_MAX_LINES_KEY, isQuartoDocument } from '../common/positronQuartoConfig.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IPositronNotebookOutputWebviewService } from '../../positronOutputWebview/browser/notebookOutputWebviewService.js';
@@ -33,6 +33,7 @@ import { ILanguageRuntimeMessageWebOutput, LanguageRuntimeMessageType, RuntimeOu
 import { IResourceUsageHistoryService } from '../../../services/positronConsole/browser/resourceUsageHistoryService.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { ILabelService } from '../../../../platform/label/common/label.js';
 
 // Workspace storage key for collapsed inline outputs. Value is JSON:
 // `{ [documentUri]: string[] }` - each entry is the list of cell IDs whose
@@ -219,6 +220,7 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 		@IResourceUsageHistoryService private readonly _resourceUsageHistoryService: IResourceUsageHistoryService,
 		@IHoverService private readonly _hoverService: IHoverService,
 		@IStorageService private readonly _storageService: IStorageService,
+		@ILabelService private readonly _labelService: ILabelService,
 	) {
 		super();
 
@@ -856,6 +858,9 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 					if (!viewZone) {
 						viewZone = this._createViewZone(cell.id);
 						if (viewZone) {
+							// Cache-restored outputs are from a previous
+							// session; suppress Fix/Explain buttons.
+							viewZone.setFromCurrentSession(false);
 							this._viewZones.set(cell.id, viewZone);
 						}
 					}
@@ -902,6 +907,9 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 				if (!viewZone) {
 					viewZone = this._createViewZone(cellId);
 					if (viewZone) {
+						// Stash is same session; resolve cell context for
+						// quick-fix buttons.
+						viewZone.setCellContext(this._resolveCellContext(cellId));
 						this._viewZones.set(cellId, viewZone);
 					}
 				}
@@ -931,6 +939,32 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 		this._logService.debug('[QuartoOutputContribution] Restored outputs from stash for', restoredCount, 'cells');
 	}
 
+	/**
+	 * Resolve the cell context (code, language, location) for quick-fix buttons.
+	 */
+	private _resolveCellContext(cellId: string): QuartoCellErrorContext | undefined {
+		if (!this._documentUri) {
+			return undefined;
+		}
+		const model = this._editor.getModel();
+		if (!model) {
+			return undefined;
+		}
+		const quartoModel = this._documentModelService.getModel(model);
+		const cell = quartoModel.getCellById(cellId);
+		if (!cell) {
+			return undefined;
+		}
+		return {
+			code: quartoModel.getCellCode(cell),
+			language: cell.language,
+			label: cell.label,
+			path: this._labelService.getUriLabel(this._documentUri, { relative: true }),
+			codeStartLine: cell.codeStartLine,
+			codeEndLine: cell.codeEndLine,
+		};
+	}
+
 	private _handleOutput(cellId: string, output: ICellOutput): void {
 		this._logService.debug('[QuartoOutputContribution] Received output for cell', cellId);
 
@@ -948,6 +982,9 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 			}
 			this._viewZones.set(cellId, viewZone);
 		}
+
+		// Provide cell context for quick-fix buttons (code, language, location)
+		viewZone.setCellContext(this._resolveCellContext(cellId));
 
 		// Add output to view zone
 		viewZone.addOutput(output);

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
@@ -907,9 +907,9 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 				if (!viewZone) {
 					viewZone = this._createViewZone(cellId);
 					if (viewZone) {
-						// Stash is same session; resolve cell context for
-						// quick-fix buttons.
-						viewZone.setCellContext(this._resolveCellContext(cellId));
+						// Suppress Fix/Explain on restored outputs; buttons
+						// should only appear on freshly-executed errors.
+						viewZone.setFromCurrentSession(false);
 						this._viewZones.set(cellId, viewZone);
 					}
 				}

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
@@ -858,9 +858,6 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 					if (!viewZone) {
 						viewZone = this._createViewZone(cell.id);
 						if (viewZone) {
-							// Cache-restored outputs are from a previous
-							// session; suppress Fix/Explain buttons.
-							viewZone.setFromCurrentSession(false);
 							this._viewZones.set(cell.id, viewZone);
 						}
 					}
@@ -907,9 +904,6 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 				if (!viewZone) {
 					viewZone = this._createViewZone(cellId);
 					if (viewZone) {
-						// Suppress Fix/Explain on restored outputs; buttons
-						// should only appear on freshly-executed errors.
-						viewZone.setFromCurrentSession(false);
 						this._viewZones.set(cellId, viewZone);
 					}
 				}
@@ -983,8 +977,8 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 			this._viewZones.set(cellId, viewZone);
 		}
 
-		// Provide cell context for quick-fix buttons (code, language, location)
-		viewZone.setCellContext(this._resolveCellContext(cellId));
+		// Enable quick-fix buttons with cell context (code, language, location)
+		viewZone.enableQuickFix(this._resolveCellContext(cellId));
 
 		// Add output to view zone
 		viewZone.addOutput(output);

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
@@ -354,9 +354,10 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 	private readonly _onDidChangeCollapsed = this._register(new Emitter<boolean>());
 	readonly onDidChangeCollapsed: VSEvent<boolean> = this._onDidChangeCollapsed.event;
 
-	// Quick-fix support for error outputs
+	// Quick-fix support for error outputs (suppressed by default; the live
+	// execution path calls enableQuickFix() to opt in).
+	private _quickFixEnabled = false;
 	private _cellContext: QuartoCellErrorContext | undefined;
-	private _fromCurrentSession = true;
 	private _quickFixRenderer: PositronReactRenderer | undefined;
 
 	constructor(
@@ -1032,18 +1033,13 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 	}
 
 	/**
-	 * Set cell context for quick-fix buttons (code, language, location).
+	 * Enable Fix/Explain quick-fix buttons for error outputs in this view
+	 * zone. Only the live execution path calls this; restore paths leave
+	 * the default (suppressed) so stale errors don't show buttons.
 	 */
-	setCellContext(context: QuartoCellErrorContext | undefined): void {
+	enableQuickFix(context?: QuartoCellErrorContext): void {
+		this._quickFixEnabled = true;
 		this._cellContext = context;
-	}
-
-	/**
-	 * Set whether outputs in this view zone are from the current window
-	 * session. Quick-fix buttons are suppressed on cache-restored errors.
-	 */
-	setFromCurrentSession(value: boolean): void {
-		this._fromCurrentSession = value;
 	}
 
 	/**
@@ -2588,7 +2584,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		// Mount Fix/Explain quick-fix buttons for current-session errors.
 		// QuartoOutputQuickFix self-gates on assistant availability and
 		// renders nothing when the assistant is unavailable.
-		if (this._fromCurrentSession) {
+		if (this._quickFixEnabled) {
 			const quickFixContainer = document.createElement('div');
 			quickFixContainer.setAttribute('aria-live', 'off');
 			container.appendChild(quickFixContainer);

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
@@ -11,7 +11,7 @@ import { status as ariaStatus } from '../../../../base/browser/ui/aria/aria.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { ICodeEditor, IViewZone, MouseTargetType } from '../../../../editor/browser/editorBrowser.js';
 import { localize } from '../../../../nls.js';
-import { ICellOutput, ICellOutputItem, DATA_EXPLORER_MIME_TYPE, CellExecutionState } from '../common/quartoExecutionTypes.js';
+import { ICellOutput, ICellOutputItem, DATA_EXPLORER_MIME_TYPE, CellExecutionState, QuartoCellErrorContext } from '../common/quartoExecutionTypes.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { formatCellDuration, getRelativeTime } from '../../positronNotebook/browser/notebookCells/cellExecutionUtils.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
@@ -38,6 +38,7 @@ import { IResourceUsageHistoryService } from '../../../services/positronConsole/
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { getDefaultHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { IManagedHover } from '../../../../base/browser/ui/hover/hover.js';
+import { QuartoOutputQuickFix } from './QuartoOutputQuickFix.js';
 
 /**
  * Minimum height for a view zone in pixels.
@@ -352,6 +353,11 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 	// to persist the state to workspace storage.
 	private readonly _onDidChangeCollapsed = this._register(new Emitter<boolean>());
 	readonly onDidChangeCollapsed: VSEvent<boolean> = this._onDidChangeCollapsed.event;
+
+	// Quick-fix support for error outputs
+	private _cellContext: QuartoCellErrorContext | undefined;
+	private _fromCurrentSession = true;
+	private _quickFixRenderer: PositronReactRenderer | undefined;
 
 	constructor(
 		private readonly _editor: ICodeEditor,
@@ -1026,6 +1032,21 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 	}
 
 	/**
+	 * Set cell context for quick-fix buttons (code, language, location).
+	 */
+	setCellContext(context: QuartoCellErrorContext | undefined): void {
+		this._cellContext = context;
+	}
+
+	/**
+	 * Set whether outputs in this view zone are from the current window
+	 * session. Quick-fix buttons are suppressed on cache-restored errors.
+	 */
+	setFromCurrentSession(value: boolean): void {
+		this._fromCurrentSession = value;
+	}
+
+	/**
 	 * Add an output to the view zone.
 	 */
 	addOutput(output: ICellOutput): void {
@@ -1100,6 +1121,8 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		// Dispose all webviews and React renderers
 		this._disposeAllWebviews();
 		this._disposeAllReactRenderers();
+		this._quickFixRenderer?.dispose();
+		this._quickFixRenderer = undefined;
 
 		// Reset recomputing state
 		this._isRecomputing = false;
@@ -1253,6 +1276,8 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		this._disposeResizeObserver();
 		this._disposeAllWebviews();
 		this._disposeAllReactRenderers();
+		this._quickFixRenderer?.dispose();
+		this._quickFixRenderer = undefined;
 		if (this._copyButtonTimeout) {
 			clearTimeout(this._copyButtonTimeout);
 		}
@@ -2194,6 +2219,8 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 	private _renderAllOutputs(): void {
 		this._disposeAllWebviews();
 		this._disposeAllReactRenderers();
+		this._quickFixRenderer?.dispose();
+		this._quickFixRenderer = undefined;
 		dom.clearNode(this._outputContainer);
 
 		for (const output of this._outputs) {
@@ -2527,7 +2554,6 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 	private _renderError(data: string): HTMLElement {
 		const container = document.createElement('div');
 		container.className = 'quarto-output-error';
-		container.setAttribute('role', 'alert');
 
 		let errorText: string;
 		try {
@@ -2550,11 +2576,32 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 			errorText = data;
 		}
 
-		// Process ANSI escape sequences in error output
+		// Process ANSI escape sequences in error output. The alert role lives
+		// on the error text, not the container, so the interactive quick-fix
+		// buttons mounted below stay outside the assertive live region.
 		const pre = document.createElement('pre');
+		pre.setAttribute('role', 'alert');
 		const outputLines = ANSIOutput.processOutput(errorText);
 		this._renderAnsiOutputLines(outputLines, pre);
 		container.appendChild(pre);
+
+		// Mount Fix/Explain quick-fix buttons for current-session errors.
+		// QuartoOutputQuickFix self-gates on assistant availability and
+		// renders nothing when the assistant is unavailable.
+		if (this._fromCurrentSession) {
+			const quickFixContainer = document.createElement('div');
+			quickFixContainer.setAttribute('aria-live', 'off');
+			container.appendChild(quickFixContainer);
+
+			this._quickFixRenderer?.dispose();
+			this._quickFixRenderer = new PositronReactRenderer(quickFixContainer);
+			this._quickFixRenderer.render(
+				React.createElement(QuartoOutputQuickFix, {
+					errorContent: errorText,
+					cellContext: this._cellContext,
+				})
+			);
+		}
 
 		return container;
 	}

--- a/src/vs/workbench/contrib/positronQuarto/common/quartoExecutionTypes.ts
+++ b/src/vs/workbench/contrib/positronQuarto/common/quartoExecutionTypes.ts
@@ -97,6 +97,25 @@ export interface ICellOutput {
 }
 
 /**
+ * The code chunk that produced an error output, used to point the assistant
+ * at the failing code instead of letting it hunt through the whole document.
+ */
+export interface QuartoCellErrorContext {
+	/** Workspace-relative path of the Quarto document. */
+	path: string;
+	/** Language of the code chunk (e.g. 'python', 'r'). */
+	language: string;
+	/** Optional chunk label from the chunk options. */
+	label?: string;
+	/** Source code of the chunk (without the fences). */
+	code: string;
+	/** First line of the chunk's code (1-based). */
+	codeStartLine: number;
+	/** Last line of the chunk's code (1-based). */
+	codeEndLine: number;
+}
+
+/**
  * Event emitted when execution state changes.
  */
 export interface ExecutionStateChangeEvent {

--- a/src/vs/workbench/contrib/positronQuarto/common/quartoTypes.ts
+++ b/src/vs/workbench/contrib/positronQuarto/common/quartoTypes.ts
@@ -243,13 +243,6 @@ export interface IQuartoDocumentModel extends IDisposable {
 	 */
 	findCellByContentHash(hash: string, preferIndex?: number): QuartoCodeCell | undefined;
 
-	/**
-	 * Find the current cell behind a cell ID from an earlier parse. Cell IDs
-	 * embed the cell's index, so a cell added or removed above changes the ID
-	 * without changing the chunk; this matches by content hash, preferring
-	 * the instance at the old index when duplicate chunks share a hash.
-	 */
-	findCellByPreviousId(previousCellId: string, contentHash: string): QuartoCodeCell | undefined;
 
 	/**
 	 * Get code content for a cell.

--- a/src/vs/workbench/contrib/positronQuarto/common/quartoTypes.ts
+++ b/src/vs/workbench/contrib/positronQuarto/common/quartoTypes.ts
@@ -244,6 +244,14 @@ export interface IQuartoDocumentModel extends IDisposable {
 	findCellByContentHash(hash: string, preferIndex?: number): QuartoCodeCell | undefined;
 
 	/**
+	 * Find the current cell behind a cell ID from an earlier parse. Cell IDs
+	 * embed the cell's index, so a cell added or removed above changes the ID
+	 * without changing the chunk; this matches by content hash, preferring
+	 * the instance at the old index when duplicate chunks share a hash.
+	 */
+	findCellByPreviousId(previousCellId: string, contentHash: string): QuartoCodeCell | undefined;
+
+	/**
 	 * Get code content for a cell.
 	 */
 	getCellCode(cell: QuartoCodeCell): string;

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/QuartoOutputQuickFix.vitest.tsx
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/QuartoOutputQuickFix.vitest.tsx
@@ -1,0 +1,145 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { decodeBase64 } from '../../../../../base/common/buffer.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
+import { POSIT_NEW_CHAT_COMMAND, NewChatOptions } from '../../../positronAssistant/browser/positAssistantChat.js';
+import { QuartoOutputQuickFix } from '../../browser/QuartoOutputQuickFix.js';
+import { QuartoCellErrorContext } from '../../common/quartoExecutionTypes.js';
+
+describe('QuartoOutputQuickFix', () => {
+	const ctx = createTestContainer()
+		.withReactServices()
+		.stub(ICommandService, { executeCommand: vi.fn().mockResolvedValue(undefined) })
+		.build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
+
+	function setGates(aiEnabled: boolean | undefined, hasChatModels: boolean | undefined) {
+		const configurationService = ctx.get(IConfigurationService) as TestConfigurationService;
+		const contextKeyService = ctx.get(IContextKeyService) as MockContextKeyService;
+		if (aiEnabled !== undefined) {
+			configurationService.setUserConfiguration('ai.enabled', aiEnabled);
+		}
+		if (hasChatModels !== undefined) {
+			contextKeyService.createKey('posit-assistant.hasChatModels', hasChatModels);
+		}
+	}
+
+	function renderQuickFix(cellContext?: QuartoCellErrorContext) {
+		return rtl.render(
+			<QuartoOutputQuickFix
+				errorContent='NameError: name "x" is not defined'
+				cellContext={cellContext}
+			/>
+		);
+	}
+
+	function lastNewChatOptions(): NewChatOptions {
+		const executeCommand = vi.mocked(ctx.get(ICommandService).executeCommand);
+		const lastCall = executeCommand.mock.calls.at(-1);
+		expect(lastCall?.[0]).toBe(POSIT_NEW_CHAT_COMMAND);
+		return lastCall?.[1] as NewChatOptions;
+	}
+
+	function decodeAttachment(uri: string): string {
+		return decodeBase64(uri.replace('data:text/plain;base64,', '')).toString();
+	}
+
+	it('renders Fix/Explain buttons when AI is enabled and chat models are available', () => {
+		setGates(true, true);
+		renderQuickFix();
+		expect(screen.getByRole('group', { name: /quick fix/i })).toBeInTheDocument();
+	});
+
+	it('renders the buttons when ai.enabled is unset (defaults to enabled)', () => {
+		setGates(undefined, true);
+		renderQuickFix();
+		expect(screen.getByRole('group', { name: /quick fix/i })).toBeInTheDocument();
+	});
+
+	it('does not render the buttons when AI features are disabled', () => {
+		setGates(false, true);
+		renderQuickFix();
+		expect(screen.queryByRole('group', { name: /quick fix/i })).not.toBeInTheDocument();
+	});
+
+	it('does not render the buttons when no chat models are available', () => {
+		setGates(true, false);
+		renderQuickFix();
+		expect(screen.queryByRole('group', { name: /quick fix/i })).not.toBeInTheDocument();
+	});
+
+	describe('payload with cell context', () => {
+		const cellContext: QuartoCellErrorContext = {
+			path: 'report.qmd',
+			language: 'python',
+			label: 'setup',
+			code: 'raise RuntimeError("boom")',
+			codeStartLine: 8,
+			codeEndLine: 8,
+		};
+
+		it('sends the failing code and its location alongside the error', async () => {
+			const user = userEvent.setup();
+			setGates(true, true);
+			renderQuickFix(cellContext);
+			await user.click(screen.getByRole('button', { name: 'Ask assistant to fix in new chat' }));
+
+			const options = lastNewChatOptions();
+			expect({
+				prompt: options.prompt,
+				attachment: options.files && decodeAttachment(options.files[0].uri),
+			}).toEqual({
+				prompt: 'Fix the error from the python code chunk at lines 8-8 of report.qmd. The failing code and its error output are attached; fix only this error.',
+				attachment: [
+					'Error from the python code chunk in report.qmd, lines 8-8 (label: setup):',
+					'',
+					'--- Failing code ---',
+					'raise RuntimeError("boom")',
+					'',
+					'--- Error output ---',
+					'NameError: name "x" is not defined',
+				].join('\n'),
+			});
+		});
+
+		it('keeps the explain-only constraint on the contextual explain prompt', async () => {
+			const user = userEvent.setup();
+			setGates(true, true);
+			renderQuickFix(cellContext);
+			await user.click(screen.getByRole('button', { name: 'Ask assistant to explain in new chat' }));
+
+			expect(lastNewChatOptions().prompt).toBe(
+				'Explain the error from the python code chunk at lines 8-8 of report.qmd. The failing code and its error output are attached. Do not make changes or edit any files; just explain the error.'
+			);
+		});
+
+		it('falls back to the error-only payload when no cell context is provided', async () => {
+			const user = userEvent.setup();
+			setGates(true, true);
+			renderQuickFix(undefined);
+			await user.click(screen.getByRole('button', { name: 'Ask assistant to fix in new chat' }));
+
+			const options = lastNewChatOptions();
+			expect({
+				prompt: options.prompt,
+				attachment: options.files && decodeAttachment(options.files[0].uri),
+			}).toEqual({
+				prompt: 'Fix this Quarto inline output error.',
+				attachment: 'NameError: name "x" is not defined',
+			});
+		});
+	});
+});

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/QuartoOutputQuickFix.vitest.tsx
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/QuartoOutputQuickFix.vitest.tsx
@@ -40,8 +40,8 @@ describe('QuartoOutputQuickFix', () => {
 	function renderQuickFix(cellContext?: QuartoCellErrorContext) {
 		return rtl.render(
 			<QuartoOutputQuickFix
-				errorContent='NameError: name "x" is not defined'
 				cellContext={cellContext}
+				errorContent='NameError: name "x" is not defined'
 			/>
 		);
 	}

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoDocumentModel.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoDocumentModel.vitest.ts
@@ -626,27 +626,4 @@ x = 1
 	});
 
 
-	describe('findCellByPreviousId', () => {
-		// Two identical chunks: same content hash, different indices.
-		const content = `\`\`\`{python}
-x = 1
-\`\`\`
-
-\`\`\`{python}
-x = 1
-\`\`\`
-`;
-
-		it('prefers the instance at the old index for duplicate chunks', () => {
-			const model = createModel(content);
-			const second = model.cells[1];
-			expect(model.findCellByPreviousId(second.id, second.contentHash)?.index).toBe(1);
-		});
-
-		it('falls back to the first hash match when the ID has no index', () => {
-			const model = createModel(content);
-			const hash = model.cells[0].contentHash;
-			expect(model.findCellByPreviousId('bogus-id', hash)?.index).toBe(0);
-		});
-	});
 });

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoDocumentModel.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoDocumentModel.vitest.ts
@@ -624,4 +624,29 @@ x = 1
 			expect(model.primaryLanguage).toBe('r');
 		});
 	});
+
+
+	describe('findCellByPreviousId', () => {
+		// Two identical chunks: same content hash, different indices.
+		const content = `\`\`\`{python}
+x = 1
+\`\`\`
+
+\`\`\`{python}
+x = 1
+\`\`\`
+`;
+
+		it('prefers the instance at the old index for duplicate chunks', () => {
+			const model = createModel(content);
+			const second = model.cells[1];
+			expect(model.findCellByPreviousId(second.id, second.contentHash)?.index).toBe(1);
+		});
+
+		it('falls back to the first hash match when the ID has no index', () => {
+			const model = createModel(content);
+			const hash = model.cells[0].contentHash;
+			expect(model.findCellByPreviousId('bogus-id', hash)?.index).toBe(0);
+		});
+	});
 });


### PR DESCRIPTION
Closes #13228

This PR adds the same Fix/Explain buttons that the Positron Notebook Editor gets for cell errors to Quarto inline outputs. The buttons were extracted from the notebook quick-fix into a shared `AssistantErrorQuickFix` component, so both surfaces can share one implementation. This also let us fix a latent problem (Explain was fixing errors too) in one place for both.


__Agent generated notes 👇__

### Summary

The notebook's Fix/Explain implementation was tangled with notebook-only gating, so this PR splits it in two:

- **`AssistantErrorQuickFix`** (shared, presentational): the split buttons, ANSI cleanup, error attachment, and `posit-assistant.newChat` wiring. No gating -- callers decide whether to render it.
- **Per-surface wrappers** own their gating and prompt wording: `NotebookCellQuickFix` (unchanged gates) and the new `QuartoOutputQuickFix`.

Key decisions:

- **Quarto gating**: gates on the global `ai.enabled` setting (read live; unset counts as enabled) plus the `posit-assistant.hasChatModels` context key. It deliberately drops the notebook-only gates (`positron.notebook.enabled`, `notebook.ai.enabled`) -- Quarto inline output works regardless of whether the Positron notebook editor is enabled.
- **Explain is explanation-only**: while testing, Explain would often go ahead and fix the error too. The shared component now appends "Do not make changes or edit any files; just explain the error." to every Explain prompt -- the notebook inherits this for free via the shared component. (A true read-only "ask mode" in the assistant was investigated and tabled; `posit-assistant.newChat` has no mode argument today.)
- **Component home**: `AssistantErrorQuickFix` stays in `positronNotebook` even though `positronQuarto` imports it. The tidy home would be the `positronAssistant` contrib, but that's on a deprecation path; a shared home can be created when the assistant migration needs one.
- **Renderer lifecycle**: the quick-fix mounts via the view zone's existing per-output React renderer registry (keyed `` `${outputId}::quick-fix` ``), so the existing disposal sweep tears it down on clear/re-execute/dispose.

The console's error quick-fix still hand-rolls its own version (different UX: plain buttons, always continues the current chat); unifying it is deliberately out of scope.

### In-Action

https://github.com/user-attachments/assets/9a3d1893-30c7-476b-8b9c-4277619fdb88


### Release Notes

#### New Features

- Quarto inline output errors now show Fix/Explain buttons that send the error to Posit Assistant, matching Positron notebooks (#13228)

#### Bug Fixes

- The Explain button on notebook and Quarto error outputs now asks the assistant to explain the error without also attempting to fix it

### Validation Steps

@:quarto @:positron-notebooks @:posit-assistant

1. Open a `.qmd` with an erroring chunk (e.g. `test/e2e/test-files/workspaces/quarto_inline_output/r_errors.qmd`) and run the chunk.
2. Verify Fix/Explain buttons appear below the error output; Fix opens a new Posit Assistant chat with the error attached; Explain does the same but the assistant only explains -- it should not edit files.
3. Each button's dropdown ("continue in current chat") should reuse the current conversation instead of starting a new one.
4. Set `ai.enabled: false` (or quit the assistant so no chat models are available) and re-run: no buttons should render.
5. Run an erroring cell in a Positron notebook and confirm the buttons still behave as before (only change: Explain no longer fixes).

Unit coverage: `AssistantErrorQuickFix.vitest.tsx` (chat payload contract) and `QuartoOutputQuickFix.vitest.tsx` (gate matrix).
