### PR TITLE
Use code fences as fallback language determinants

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoDocumentModel.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoDocumentModel.ts
@@ -259,11 +259,15 @@ export class QuartoDocumentModel extends Disposable implements IQuartoDocumentMo
 			cellIndex++;
 		}
 
-		// Determine primary language from frontmatter or first cell
+		// Determine primary language from frontmatter, falling back to the first
+		// cell's fence language. A custom Jupyter kernelspec name (e.g.
+		// `spectral-comparison-3.14`) can't be mapped to a known language, so the
+		// cell fence language is used as a fallback rather than leaving the primary
+		// language undefined (which would disable the kernel picker and Run Cell).
 		const jupyterKernel = doc.frontmatter?.jupyterKernel;
-		const primaryLanguage = jupyterKernel ?
-			kernelToLanguageId(jupyterKernel) :
-			cells.at(0)?.language;
+		const primaryLanguage =
+			(jupyterKernel ? kernelToLanguageId(jupyterKernel) : undefined)
+			?? cells.at(0)?.language;
 
 		return { cells, primaryLanguage, jupyterKernel };
 	}

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoDocumentModel.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoDocumentModel.vitest.ts
@@ -172,6 +172,24 @@ x = 1
 			expect(model.primaryLanguage).toBe('r');
 		});
 
+		it('falls back to first cell language when jupyter kernel name is unrecognized', () => {
+			// A custom kernelspec name (e.g. created via `ipykernel install --name ...`)
+			// isn't mappable to a known language, so the primary language should fall
+			// back to the cell fence language rather than being left undefined.
+			const content = `---
+jupyter: spectral-comparison-3.14
+---
+
+\`\`\`{python}
+x = 1
+\`\`\`
+`;
+			const model = createModel(content);
+
+			expect(model.jupyterKernel).toBe('spectral-comparison-3.14');
+			expect(model.primaryLanguage).toBe('python');
+		});
+
 		it('uses first cell language when no jupyter kernel', () => {
 			const content = `---
 title: "Test"


### PR DESCRIPTION
Fixes #13613

With `positron.quarto.inlineOutput.enabled: true`, opening a `.qmd` whose YAML header declares a custom Jupyter kernelspec name (e.g. `jupyter: spectral-comparison-3.14`) left the kernel picker disabled and "Run Cell" broken with a "Could not determine language for Quarto document" toast.

The document model determined the primary language *exclusively* from the `jupyter:` kernel name when present. Custom kernelspec names aren't in the known-kernel mapping table, so `primaryLanguage` became `undefined`, which disables the picker and Run Cell. The fix makes the cell-fence language a fallback rather than an alternative, so an unrecognized kernel name falls through to the cell's declared language (Quarto fences always specify one, e.g. `{python}`).

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed running code in Quarto documents with inline output enabled and a custom Jupyter kernelspec name in the YAML header (#13613)

### Validation Steps

@:quarto

1. Enable inline output: set `positron.quarto.inlineOutput.enabled: true`.
2. Register a custom kernel: `python -m ipykernel install --user --name spectral-comparison-3.14`
3. Create a `test.qmd`:

    ```qmd
    ---
    title: "Python Test"
    format: html
    jupyter: spectral-comparison-3.14
    ---

    ```{python}
    x = 1
    print(x)
    ```
    ```

4. Open in Positron and verify the kernel picker is enabled and Run Cell executes the cell (produces output, no error toast).
