### PR TITLE
test: pin provider+model in posit-assistant e2e message tests

### DIFF
--- a/test/e2e/pages/positAssistant.ts
+++ b/test/e2e/pages/positAssistant.ts
@@ -441,21 +441,39 @@ export class PositAssistant {
 	 * click the provider's top model. The radio group is flat, so the provider's
 	 * top model is the header div's immediately-following radio item (adjacent
 	 * sibling combinator scopes the choice to that provider).
+	 *
+	 * The open→select→close cycle is retried because the inline picker is not
+	 * stable to drive one-shot:
+	 *  - On open it auto-scrolls the selected item into view and runs refocus
+	 *    logic, which can transiently close the menu out from under a pending
+	 *    click.
+	 *  - Base UI radio items do NOT close the menu on selection (unlike the
+	 *    regular menu items used in menu mode), so the menu must be dismissed
+	 *    explicitly with Escape afterwards, or the overlay blocks the chat input.
 	 */
 	private async selectProviderModelInlineMode(providerName: string): Promise<void> {
-		await this.frame.locator(INLINE_MODEL_TRIGGER).last().click();
-
+		const trigger = this.frame.locator(INLINE_MODEL_TRIGGER).last();
 		const radioGroup = this.frame.locator(MODEL_RADIO_GROUP);
-		await expect(radioGroup).toBeVisible();
-
 		const topModel = radioGroup.locator(
 			`div:has(> span:text-is("${providerName}")) + [role="menuitemradio"]`,
 		);
-		await topModel.click();
+		const page = this.code.driver.currentPage;
 
-		// Selection closes the dropdown; wait for it to detach so subsequent
-		// actions (e.g. Send) don't race an open overlay.
-		await expect(radioGroup).toBeHidden();
+		await expect(async () => {
+			// Open the picker if it isn't already open (e.g. a prior iteration
+			// selected the model but Escape didn't land).
+			if (!(await radioGroup.isVisible().catch(() => false))) {
+				await trigger.click();
+				await expect(radioGroup).toBeVisible({ timeout: 5000 });
+			}
+			// Short click timeout so a menu that closed mid-open fails fast and we
+			// reopen on the next iteration rather than hanging.
+			await topModel.click({ timeout: 5000 });
+			// Radio selection leaves the menu open; dismiss it so it can't obscure
+			// the chat input, and confirm it detached.
+			await page.keyboard.press('Escape');
+			await expect(radioGroup).toBeHidden({ timeout: 5000 });
+		}).toPass({ timeout: 30000 });
 	}
 
 	// --- Chat messages ---

--- a/test/e2e/pages/positAssistant.ts
+++ b/test/e2e/pages/positAssistant.ts
@@ -424,12 +424,20 @@ export class PositAssistant {
 		await this.frame.locator('[role="menuitem"][aria-haspopup="menu"]:has(span:text-is("Model"))').click();
 
 		// Scope to the provider's group (label + its model items live in one
-		// container), then take its first model item.
+		// container).
 		const group = this.frame.locator(
 			`${MODEL_MENU_GROUP}:has([data-slot="dropdown-menu-label"] span:text-is("${providerName}"))`,
 		);
 		await expect(group).toBeVisible();
-		await group.locator('[role="menuitem"]').first().click();
+
+		// Some providers (e.g. Microsoft Foundry) list every model under the
+		// "More models" disclosure with none shown directly, so the group has no
+		// model item until it's expanded.
+		const models = group.locator('[role="menuitem"]');
+		if (await models.count() === 0) {
+			await group.locator('button:has-text("More models")').click();
+		}
+		await models.first().click();
 
 		// Menu closes on selection; wait for the trigger to collapse so subsequent
 		// actions (e.g. Send) don't race an open overlay.
@@ -454,9 +462,16 @@ export class PositAssistant {
 	private async selectProviderModelInlineMode(providerName: string): Promise<void> {
 		const trigger = this.frame.locator(INLINE_MODEL_TRIGGER).last();
 		const radioGroup = this.frame.locator(MODEL_RADIO_GROUP);
-		const topModel = radioGroup.locator(
-			`div:has(> span:text-is("${providerName}")) + [role="menuitemradio"]`,
-		);
+		const headerSelector = `div:has(> span:text-is("${providerName}"))`;
+		const header = radioGroup.locator(headerSelector);
+		// A model shown directly under the provider header (adjacent sibling).
+		const directTopModel = radioGroup.locator(`${headerSelector} + [role="menuitemradio"]`);
+		// The provider's "More models" disclosure, present as the header's adjacent
+		// sibling only when the provider has no model shown directly.
+		const moreModels = radioGroup.locator(`${headerSelector} + button:has-text("More models")`);
+		// The provider's top model, whether shown directly or revealed by expanding
+		// "More models": the first radio item following this provider's header.
+		const topModel = header.locator('xpath=./following-sibling::*[@role="menuitemradio"][1]');
 		const page = this.code.driver.currentPage;
 
 		await expect(async () => {
@@ -465,6 +480,12 @@ export class PositAssistant {
 			if (!(await radioGroup.isVisible().catch(() => false))) {
 				await trigger.click();
 				await expect(radioGroup).toBeVisible({ timeout: 5000 });
+			}
+			// Some providers (e.g. Microsoft Foundry) list every model under the
+			// "More models" disclosure with none shown directly; expand it so the
+			// provider has a selectable model.
+			if (await directTopModel.count() === 0 && await moreModels.isVisible().catch(() => false)) {
+				await moreModels.click();
 			}
 			// Short click timeout so a menu that closed mid-open fails fast and we
 			// reopen on the next iteration rather than hanging.

--- a/test/e2e/pages/positAssistant.ts
+++ b/test/e2e/pages/positAssistant.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect, FrameLocator } from '@playwright/test';
+import { expect, FrameLocator, Locator } from '@playwright/test';
 import { Code } from '../infra/code';
 import { Toasts } from './dialog-toasts';
 
@@ -39,6 +39,30 @@ const STOP_BUTTON = 'button:has(svg.lucide-square)';
 // Chat-form overflow (...) menu — hosts the model picker for providers
 // (like OpenAI) that do not auto-select a default model.
 const CHAT_FORM_OVERFLOW_BUTTON = '.chat-form button[aria-haspopup="menu"]:has(svg.lucide-ellipsis)';
+
+// Model picker containers. The picker renders in two width-dependent modes
+// (see selectProviderModel): a flat radio group when inline, and per-provider
+// group containers when collapsed into the overflow (...) menu.
+const MODEL_RADIO_GROUP = '[data-slot="dropdown-menu-radio-group"]';
+const MODEL_MENU_GROUP = '[data-slot="dropdown-menu-group"]';
+// The inline model-picker trigger. ModeSelector (left) uses plain buttons and
+// the only other status-bar dropdown trigger with a chevron (the persona
+// selector) precedes the model selector in the DOM, so the model trigger is the
+// last chevron dropdown trigger in the chat form.
+const INLINE_MODEL_TRIGGER = '[data-slot="dropdown-menu-trigger"]:has(svg.lucide-chevron-down)';
+
+/**
+ * Maps an e2e provider id to the provider's display name as shown in the model
+ * picker's group headers. Sourced from the assistant's provider registry
+ * (packages/core/src/platform/provider-registry.ts).
+ */
+const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
+	'anthropic-api': 'Anthropic',
+	'amazon-bedrock': 'AWS Bedrock',
+	'openai-api': 'OpenAI',
+	'ms-foundry': 'Microsoft Foundry',
+	'posit-ai': 'Posit AI',
+};
 
 // Chat message elements
 const CHAT_MESSAGE_USER = '.chat-message-user';
@@ -345,6 +369,93 @@ export class PositAssistant {
 		// Menu closes on selection; wait for the trigger to collapse so
 		// subsequent actions (e.g. Send) don't race an open overlay.
 		await expect(this.frame.locator(CHAT_FORM_OVERFLOW_BUTTON)).toHaveAttribute('aria-expanded', 'false');
+	}
+
+	/**
+	 * Selects the top (first / default) model belonging to a specific provider,
+	 * scoping the choice to that provider's group in the model picker.
+	 *
+	 * WHY: More than one provider can be signed in at once. In particular AWS
+	 * Bedrock auto-signs-in whenever AWS credentials are present in the
+	 * environment, independent of whatever provider a test logged in with. The
+	 * picker then shows multiple provider groups, and model display names repeat
+	 * across them ("Claude Sonnet 5" appears under both Anthropic and AWS
+	 * Bedrock). Selecting by model name alone is provider-ambiguous and can
+	 * silently exercise the wrong provider (e.g. an auto-selected Bedrock
+	 * default). Scoping to the provider group guarantees the intended
+	 * provider+model combination. Picking the group's top model keeps this robust
+	 * to the frequent churn in the model list.
+	 *
+	 * Must be called on a fresh conversation (after `startNewConversation()`),
+	 * and the message that follows should be sent with `newConversation: false`,
+	 * because starting a new conversation drops the model selection.
+	 *
+	 * Handles both picker render modes (width-dependent):
+	 *  - menu mode (narrow status bar): the overflow (...) menu hosts a "Model"
+	 *    submenu where each provider is a `dropdown-menu-group` container.
+	 *  - inline mode (wide status bar, e.g. a maximized sidebar): the model
+	 *    trigger opens a flat radio group whose provider headers are sibling divs.
+	 *
+	 * @param provider e2e provider id (e.g. 'anthropic-api', 'amazon-bedrock').
+	 */
+	async selectProviderModel(provider: string): Promise<void> {
+		const providerName = PROVIDER_DISPLAY_NAMES[provider];
+		if (!providerName) {
+			throw new Error(`No model-picker display name mapped for provider "${provider}"`);
+		}
+
+		const overflow = this.frame.locator(CHAT_FORM_OVERFLOW_BUTTON);
+		const menuMode = await overflow.isVisible().catch(() => false);
+		if (menuMode) {
+			await this.selectProviderModelMenuMode(overflow, providerName);
+		} else {
+			await this.selectProviderModelInlineMode(providerName);
+		}
+	}
+
+	/**
+	 * Menu-mode path for {@link selectProviderModel}: open the overflow (...)
+	 * menu and its "Model" submenu, then click the first model in the provider's
+	 * group container.
+	 */
+	private async selectProviderModelMenuMode(overflow: Locator, providerName: string): Promise<void> {
+		await overflow.click();
+		// Open the "Model" submenu (SubTrigger carries the stable "Model" label).
+		await this.frame.locator('[role="menuitem"][aria-haspopup="menu"]:has(span:text-is("Model"))').click();
+
+		// Scope to the provider's group (label + its model items live in one
+		// container), then take its first model item.
+		const group = this.frame.locator(
+			`${MODEL_MENU_GROUP}:has([data-slot="dropdown-menu-label"] span:text-is("${providerName}"))`,
+		);
+		await expect(group).toBeVisible();
+		await group.locator('[role="menuitem"]').first().click();
+
+		// Menu closes on selection; wait for the trigger to collapse so subsequent
+		// actions (e.g. Send) don't race an open overlay.
+		await expect(overflow).toHaveAttribute('aria-expanded', 'false');
+	}
+
+	/**
+	 * Inline-mode path for {@link selectProviderModel}: open the model trigger and
+	 * click the provider's top model. The radio group is flat, so the provider's
+	 * top model is the header div's immediately-following radio item (adjacent
+	 * sibling combinator scopes the choice to that provider).
+	 */
+	private async selectProviderModelInlineMode(providerName: string): Promise<void> {
+		await this.frame.locator(INLINE_MODEL_TRIGGER).last().click();
+
+		const radioGroup = this.frame.locator(MODEL_RADIO_GROUP);
+		await expect(radioGroup).toBeVisible();
+
+		const topModel = radioGroup.locator(
+			`div:has(> span:text-is("${providerName}")) + [role="menuitemradio"]`,
+		);
+		await topModel.click();
+
+		// Selection closes the dropdown; wait for it to detach so subsequent
+		// actions (e.g. Send) don't race an open overlay.
+		await expect(radioGroup).toBeHidden();
 	}
 
 	// --- Chat messages ---

--- a/test/e2e/tests/posit-assistant/posit-assistant-mcp.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant-mcp.test.ts
@@ -55,6 +55,8 @@ test.describe.skip('Posit Assistant MCP', { // skipping while investigating fail
 			test(`${provider} - Use echo tool from MCP server configured in .positai/settings.json`, async function ({ app }) {
 				await app.workbench.positAssistant.open();
 				await app.workbench.positAssistant.waitForReady();
+				await app.workbench.positAssistant.startNewConversation();
+				await app.workbench.positAssistant.selectProviderModel(provider);
 
 				// Unique marker so any positive match has to come from this run.
 				const marker = 'positron-mcp-echo-marker-7f31b9c4';
@@ -62,7 +64,7 @@ test.describe.skip('Posit Assistant MCP', { // skipping while investigating fail
 				await app.workbench.positAssistant.sendMessage(
 					`Call the "echo" tool from the "everything" MCP server with this exact message: ${marker}. Then reply with only the echoed text.`,
 					false,
-					{ newConversation: true },
+					{ newConversation: false },
 				);
 
 				await app.workbench.positAssistant.expectMcpToolConfirmVisible('everything', 'echo');

--- a/test/e2e/tests/posit-assistant/posit-assistant-signin.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant-signin.test.ts
@@ -33,22 +33,15 @@ test.describe('Posit Assistant Sign-in', {
 				await app.workbench.positAssistant.waitForReady();
 				await app.workbench.positAssistant.startNewConversation();
 
-				if (provider === 'openai-api') {
-					// OpenAI does not auto-select a default model, so pick one
-					// explicitly. `newConversation: false` avoids starting a
-					// fresh chat after model selection, which would drop it.
-					await app.workbench.positAssistant.selectModel('GPT-5.4');
-					await app.workbench.positAssistant.sendMessage('Say hello', true, { newConversation: false });
-				} else if (provider === 'ms-foundry') {
-					// Foundry doesn't auto-select a default model on desktop, so pick
-					// it explicitly. In the model picker the model is listed under its
-					// provider name, "Microsoft Foundry". `newConversation: false`
-					// keeps the selection instead of resetting to a fresh chat.
-					await app.workbench.positAssistant.selectModel('Microsoft Foundry');
-					await app.workbench.positAssistant.sendMessage('Say hello', true, { newConversation: false });
-				} else {
-					await app.workbench.positAssistant.sendMessage('Say hello', true, { newConversation: true });
-				}
+				// Explicitly select the just-signed-in provider's model rather than
+				// relying on an auto-selected default. Other providers can be signed
+				// in simultaneously (notably AWS Bedrock, which auto-signs-in when AWS
+				// credentials are present in the environment), and model names repeat
+				// across providers, so an auto-selected default may belong to the wrong
+				// provider. `newConversation: false` keeps the selection instead of
+				// resetting to a fresh chat.
+				await app.workbench.positAssistant.selectProviderModel(provider);
+				await app.workbench.positAssistant.sendMessage('Say hello', true, { newConversation: false });
 				await app.workbench.positAssistant.expectResponseVisible();
 
 				const responseText = await app.workbench.positAssistant.getLastResponseText();

--- a/test/e2e/tests/posit-assistant/posit-assistant.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant.test.ts
@@ -38,8 +38,10 @@ test.describe('Posit Assistant', {
 			test(`${provider} - Send a chat message and receive a response`, async function ({ app }) {
 				await app.workbench.positAssistant.open();
 				await app.workbench.positAssistant.waitForReady();
+				await app.workbench.positAssistant.startNewConversation();
+				await app.workbench.positAssistant.selectProviderModel(provider);
 
-				await app.workbench.positAssistant.sendMessage('Say hello', true, { newConversation: true });
+				await app.workbench.positAssistant.sendMessage('Say hello', true, { newConversation: false });
 				await app.workbench.positAssistant.expectResponseVisible();
 
 				const responseText = await app.workbench.positAssistant.getLastResponseText();
@@ -50,8 +52,10 @@ test.describe('Posit Assistant', {
 				const session = await sessions.start('python', { reuse: false });
 				await app.workbench.positAssistant.open();
 				await app.workbench.positAssistant.waitForReady();
+				await app.workbench.positAssistant.startNewConversation();
+				await app.workbench.positAssistant.selectProviderModel(provider);
 
-				await app.workbench.positAssistant.sendMessage('Print "hello world" in python', false);
+				await app.workbench.positAssistant.sendMessage('Print "hello world" in python', false, { newConversation: false });
 				await app.workbench.positAssistant.expectToolConfirmVisible();
 				await app.workbench.positAssistant.allowToolOnce();
 				await app.workbench.positAssistant.waitForResponseComplete();
@@ -63,8 +67,10 @@ test.describe('Posit Assistant', {
 				const session = await sessions.start('r', { reuse: false });
 				await app.workbench.positAssistant.open();
 				await app.workbench.positAssistant.waitForReady();
+				await app.workbench.positAssistant.startNewConversation();
+				await app.workbench.positAssistant.selectProviderModel(provider);
 
-				await app.workbench.positAssistant.sendMessage('Print "hello world" in R', false);
+				await app.workbench.positAssistant.sendMessage('Print "hello world" in R', false, { newConversation: false });
 				await app.workbench.positAssistant.expectToolConfirmVisible();
 				await app.workbench.positAssistant.allowToolOnce();
 				await app.workbench.positAssistant.waitForResponseComplete();
@@ -76,9 +82,11 @@ test.describe('Posit Assistant', {
 				const session = await sessions.start('python', { reuse: false });
 				await app.workbench.positAssistant.open();
 				await app.workbench.positAssistant.waitForReady();
+				await app.workbench.positAssistant.startNewConversation();
+				await app.workbench.positAssistant.selectProviderModel(provider);
 
 				// First tool call - allow once
-				await app.workbench.positAssistant.sendMessage('Print "first" in python', false);
+				await app.workbench.positAssistant.sendMessage('Print "first" in python', false, { newConversation: false });
 				await app.workbench.positAssistant.expectToolConfirmVisible();
 				await app.workbench.positAssistant.allowToolOnce();
 				await app.workbench.positAssistant.waitForResponseComplete();
@@ -96,9 +104,11 @@ test.describe('Posit Assistant', {
 				const session = await sessions.start('python', { reuse: false });
 				await app.workbench.positAssistant.open();
 				await app.workbench.positAssistant.waitForReady();
+				await app.workbench.positAssistant.startNewConversation();
+				await app.workbench.positAssistant.selectProviderModel(provider);
 
 				// First tool call - allow for session
-				await app.workbench.positAssistant.sendMessage('Print "first" in python', false);
+				await app.workbench.positAssistant.sendMessage('Print "first" in python', false, { newConversation: false });
 				await app.workbench.positAssistant.expectToolConfirmVisible();
 				await app.workbench.positAssistant.allowToolForSession();
 				await app.workbench.positAssistant.waitForResponseComplete();
@@ -114,8 +124,10 @@ test.describe('Posit Assistant', {
 				await app.workbench.plots.clearPlots();
 				await app.workbench.positAssistant.open();
 				await app.workbench.positAssistant.waitForReady();
+				await app.workbench.positAssistant.startNewConversation();
+				await app.workbench.positAssistant.selectProviderModel(provider);
 
-				await app.workbench.positAssistant.sendMessage('Create a simple data visualization using base R plot()', false);
+				await app.workbench.positAssistant.sendMessage('Create a simple data visualization using base R plot()', false, { newConversation: false });
 				await app.workbench.positAssistant.expectToolConfirmVisible();
 				await app.workbench.positAssistant.allowToolForSession();
 				await app.workbench.positAssistant.waitForResponseComplete();
@@ -134,8 +146,10 @@ test.describe('Posit Assistant', {
 				await app.workbench.plots.clearPlots();
 				await app.workbench.positAssistant.open();
 				await app.workbench.positAssistant.waitForReady();
+				await app.workbench.positAssistant.startNewConversation();
+				await app.workbench.positAssistant.selectProviderModel(provider);
 
-				await app.workbench.positAssistant.sendMessage('Create a simple data visualization using matplotlib', false);
+				await app.workbench.positAssistant.sendMessage('Create a simple data visualization using matplotlib', false, { newConversation: false });
 				await app.workbench.positAssistant.expectToolConfirmVisible();
 				await app.workbench.positAssistant.allowToolForSession();
 				await app.workbench.positAssistant.waitForResponseComplete();


### PR DESCRIPTION
### Summary

The AWS Bedrock provider auto-signs-in whenever AWS credentials are present in the environment, independent of whichever provider a test logged in with. When that happens the Posit Assistant model picker shows multiple provider groups, and model display names repeat across them (e.g. "Claude Sonnet 5" appears under both **Anthropic** and **AWS Bedrock**). The auto-selected default could silently land on the wrong provider, so `posit-assistant` e2e tests that only asserted "got a response" were passing while exercising Bedrock instead of the intended provider.

This PR adds a generic, provider-scoped `selectProviderModel(provider)` to the `PositAssistant` page object and calls it before every message-send:

- Maps the e2e provider id to the picker's stable display name (`Anthropic`, `AWS Bedrock`, `OpenAI`, `Microsoft Foundry`, `Posit AI`), sourced from the assistant's provider registry.
- Scopes the selection to the intended provider's group and picks that group's **top/default model** -- robust to the frequent churn in the model list (new Claude/GPT versions land constantly), while still guaranteeing a specific provider+model combination.
- Handles both width-dependent picker render modes: the inline radio group (wide/maximized sidebar) and the overflow (`...`) menu groups (narrow sidebar).
- Replaces the ad-hoc OpenAI/Foundry model-selection special-casing in the sign-in test with the single generic call for all providers.

The existing name-only `selectModel` is left intact (still used by the Microsoft Foundry workbench test).

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A (e2e test infrastructure only)

### Validation Steps

@:assistant

Run the Posit Assistant e2e suite against an environment where AWS credentials are present (so Bedrock auto-signs-in alongside the target provider) and confirm each provider's message-sending test exercises the intended provider's model rather than an auto-selected Bedrock default:

```
npx playwright test test/e2e/tests/posit-assistant/ --project e2e-electron
```
