### PR TITLE
[DO NOT MERGE] Try out on-demand PETE

### DIFF
--- a/src/vs/base/common/peteTryout.ts
+++ b/src/vs/base/common/peteTryout.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Throwaway sample used to try out the on-demand PETE test-checker on a real PR.
+ * Safe to delete -- this PR is not intended to be merged.
+ *
+ * Clamps a number into the inclusive range [min, max].
+ */
+export function clampToRange(value: number, min: number, max: number): number {
+	if (min > max) {
+		throw new Error(`Invalid range: min (${min}) is greater than max (${max}).`);
+	}
+	if (value < min) {
+		return min;
+	}
+	if (value > max) {
+		return max;
+	}
+	return value;
+}


### PR DESCRIPTION
**Throwaway PR -- do not merge, safe to close.**

This exists only to exercise the on-demand PETE test-checker on a real PR now that #14494 has merged. It adds a single small, intentionally untested pure function so PETE has something substantive to grade.

### How to try it
1. Confirm PETE did **not** post a verdict automatically when this PR opened (on-demand only now).
2. Comment `/pete` on this PR. PETE should react with 👀, then post a verdict comment (expected: 🔴 Insufficient, suggesting a Vitest for `clampToRange`).
3. Comment `/pete` again -- it should **update** the existing comment rather than create a duplicate.
4. (Optional) Push a Vitest for the function and comment `/pete` once more to see it flip to 🟢 Adequate.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A