### PR TITLE
Handle forwarded scroll events in Quarto view zones

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/hooks/useWebviewMount.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/hooks/useWebviewMount.ts
@@ -6,7 +6,7 @@
 import * as React from 'react';
 import { getWindow, addDisposableListener } from '../../../../../../base/browser/dom.js';
 import { INotebookOutputWebview } from '../../../../positronOutputWebview/browser/notebookOutputWebviewService.js';
-import { isDoubleClickMessage, isHTMLOutputWebviewMessage, isWheelForwardMessage } from '../../../../positronWebviewPreloads/browser/notebookOutputUtils.js';
+import { isDoubleClickMessage, isHTMLOutputWebviewMessage, isWheelForwardMessage, normalizeWheelDeltaY } from '../../../../positronWebviewPreloads/browser/notebookOutputUtils.js';
 import { useNotebookInstance } from '../../NotebookInstanceProvider.js';
 import { IOverlayWebview } from '../../../../webview/browser/webview.js';
 import { DisposableStore, toDisposable } from '../../../../../../base/common/lifecycle.js';
@@ -18,11 +18,6 @@ import { autorun } from '../../../../../../base/common/observable.js';
 // Constants
 const MAX_OUTPUT_HEIGHT = 1000;
 const EMPTY_OUTPUT_HEIGHT = 150;
-// Approximate line height used when a wheel event reports DOM_DELTA_LINE.
-// Matches the divisor in StandardWheelEvent (base/browser/mouseEvent.ts,
-// the `/ 40` in its pixel-to-line conversion), which is not exported.
-// Keep this in sync if that constant moves.
-const WHEEL_LINE_HEIGHT_PX = 40;
 
 /**
  * Computes the webview container height from the body scroll height reported by
@@ -35,22 +30,6 @@ export function computeBoundedHeight(bodyScrollHeight: number, outputScrolling: 
 	const cap = outputScrolling ? MAX_OUTPUT_HEIGHT : Infinity;
 	const boundedHeight = Math.min(bodyScrollHeight, cap);
 	return boundedHeight === EMPTY_OUTPUT_HEIGHT ? 0 : boundedHeight;
-}
-
-/**
- * Convert a forwarded wheel event's vertical delta into pixels so raw
- * DOM_DELTA_LINE / DOM_DELTA_PAGE values (e.g. Firefox) don't scroll by
- * a single pixel per tick.
- */
-function normalizeWheelDeltaY(deltaMode: number, deltaY: number, container: HTMLElement): number {
-	switch (deltaMode) {
-		case WheelEvent.DOM_DELTA_LINE:
-			return deltaY * WHEEL_LINE_HEIGHT_PX;
-		case WheelEvent.DOM_DELTA_PAGE:
-			return deltaY * container.clientHeight;
-		default: // DOM_DELTA_PIXEL
-			return deltaY;
-	}
 }
 
 /**
@@ -119,7 +98,7 @@ export function useWebviewMount(webview: Promise<INotebookOutputWebview>, option
 		if (isWheelForwardMessage(message)) {
 			const container = notebookInstance.cellsContainer;
 			if (container) {
-				container.scrollTop += normalizeWheelDeltaY(message.deltaMode, message.deltaY, container);
+				container.scrollTop += normalizeWheelDeltaY(message.deltaMode, message.deltaY, container.clientHeight);
 			}
 		}
 

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
@@ -20,7 +20,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { dirname } from '../../../../base/common/resources.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { INotebookOutputWebview, IPositronNotebookOutputWebviewService } from '../../positronOutputWebview/browser/notebookOutputWebviewService.js';
-import { isHTMLOutputWebviewMessage } from '../../positronWebviewPreloads/browser/notebookOutputUtils.js';
+import { isHTMLOutputWebviewMessage, isWheelForwardMessage, normalizeWheelDeltaY } from '../../positronWebviewPreloads/browser/notebookOutputUtils.js';
 import { ILanguageRuntimeSession } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { RuntimeOutputKind, ILanguageRuntimeMessageWebOutput, PositronOutputLocation, LanguageRuntimeMessageType, ILanguageRuntimeResourceUsage } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { EditorLayoutInfo, EditorOption } from '../../../../editor/common/config/editorOptions.js';
@@ -2584,6 +2584,23 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 	}
 
 	/**
+	 * Scroll the editor in response to a wheel event forwarded out of an
+	 * inline-output webview. An overlay webview iframe captures wheel events, so
+	 * without this the widget is a scroll trap: the surrounding document stops
+	 * scrolling once the pointer enters the widget (posit-dev/positron#14620).
+	 * The webview preload only forwards wheel events that nothing inside the
+	 * output can consume, so applying the delta to the editor's scroll position
+	 * lets the document scroll without fighting an inner scroller.
+	 */
+	private _handleWebviewWheel(message: unknown): void {
+		if (!isWheelForwardMessage(message)) {
+			return;
+		}
+		const delta = normalizeWheelDeltaY(message.deltaMode, message.deltaY, this._editor.getLayoutInfo().height);
+		this._editor.setScrollTop(this._editor.getScrollTop() + delta);
+	}
+
+	/**
 	 * Render an output using a webview.
 	 * Used for interactive plots, widgets, and complex HTML.
 	 */
@@ -2656,7 +2673,9 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 					// The height change re-lays out the zone asynchronously; re-check
 					// visibility once Monaco settles so the overlay shows on load.
 					this._scheduleWebviewLayout();
+					return;
 				}
+				this._handleWebviewWheel(message);
 			}));
 
 			// Update height when webview renders
@@ -2747,7 +2766,9 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 					// The height change re-lays out the zone asynchronously; re-check
 					// visibility once Monaco settles so the overlay shows on load.
 					this._scheduleWebviewLayout();
+					return;
 				}
+				this._handleWebviewWheel(message);
 			}));
 
 			// Update height when webview renders

--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/notebookOutputUtils.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/notebookOutputUtils.ts
@@ -73,6 +73,29 @@ export function isDoubleClickMessage(message: unknown): message is DoubleClickMe
 	return (message as DoubleClickMessage | undefined)?.type === 'doubleClick';
 }
 
+// Approximate line height used when a forwarded wheel event reports
+// DOM_DELTA_LINE. Matches the divisor in StandardWheelEvent (the `/ 40` in its
+// pixel-to-line conversion in base/browser/mouseEvent.ts), which is not
+// exported. Keep this in sync if that constant moves.
+const WHEEL_LINE_HEIGHT_PX = 40;
+
+/**
+ * Convert a forwarded wheel event's vertical delta into pixels so raw
+ * DOM_DELTA_LINE / DOM_DELTA_PAGE values (e.g. Firefox) don't scroll by a
+ * single pixel per tick. {@link pageHeight} is used to size a page-mode delta
+ * (the height of the surface being scrolled).
+ */
+export function normalizeWheelDeltaY(deltaMode: number, deltaY: number, pageHeight: number): number {
+	switch (deltaMode) {
+		case WheelEvent.DOM_DELTA_LINE:
+			return deltaY * WHEEL_LINE_HEIGHT_PX;
+		case WheelEvent.DOM_DELTA_PAGE:
+			return deltaY * pageHeight;
+		default: // DOM_DELTA_PIXEL
+			return deltaY;
+	}
+}
+
 
 function webviewMessageCode() {
 	// acquireVsCodeApi is a global injected by the webview host. Access it

--- a/test/e2e/tests/quarto/quarto-inline-output-widget-scroll-trap.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-widget-scroll-trap.test.ts
@@ -1,0 +1,124 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { join } from 'path';
+import { promises as fs } from 'fs';
+import { test, tags, expect } from './_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+const FIXTURE_REL_PATH = join('workspaces', 'quarto_inline_output', 'widget_scroll_trap.qmd');
+
+// Line of the code cell that renders the widget.
+const CELL_LINE = 9;
+
+// A Quarto document whose first cell renders an R htmlwidget (highcharter).
+// htmlwidget output routes through the raw-HTML overlay webview -- the same
+// rendering path as R's flextable output from the bug report. A short intro
+// above the cell keeps the widget off the very top of the editor (so it has
+// room to move up while staying on screen), and the filler paragraphs below
+// give the document somewhere to scroll to.
+function fixtureContent(): string {
+	const filler = Array.from(
+		{ length: 200 },
+		(_, i) => `Line ${i + 1}: The quick brown fox jumps over the lazy dog while the widget is wheeled.`
+	).join('\n');
+	return `---
+title: "Widget Scroll Trap Test"
+engine: knitr
+---
+
+Intro paragraph so the widget is not pinned to the top of the editor and has
+room to scroll upward while remaining on screen.
+
+\`\`\`{r}
+library(highcharter)
+hchart(data.frame(x = 1:5, y = c(1, 4, 9, 16, 25)), "scatter", hcaes(x, y))
+\`\`\`
+
+## Filler section
+
+${filler}
+`;
+}
+
+test.describe('Quarto - Inline Output: Widget scroll trap', {
+	tag: [tags.QUARTO]
+}, () => {
+
+	test.beforeEach(async function ({ app }) {
+		await fs.writeFile(join(app.workspacePathOrFolder, FIXTURE_REL_PATH), fixtureContent(), 'utf8');
+	});
+
+	test.afterEach(async function ({ app, hotKeys }) {
+		await hotKeys.closeAllEditors();
+		await fs.rm(join(app.workspacePathOrFolder, FIXTURE_REL_PATH), { force: true });
+	});
+
+	// Regression test for posit-dev/positron#14620: R HTML widgets rendered as
+	// inline-output overlay webviews used to be scroll traps -- once the pointer
+	// entered the widget, wheel events were captured by the webview iframe and
+	// never reached the outer Quarto document. Wheeling over a widget that has no
+	// scrollable content of its own must scroll the surrounding document.
+	test('R - Verify wheeling over a widget scrolls the outer document', async function ({ r, app, openFile, page }) {
+		const { editors, inlineQuarto } = app.workbench;
+
+		await openFile(FIXTURE_REL_PATH);
+		await editors.waitForActiveTab('widget_scroll_trap.qmd');
+		await inlineQuarto.expectKernelStatusVisible();
+
+		await editors.clickTab('widget_scroll_trap.qmd');
+		await inlineQuarto.gotoLine(CELL_LINE);
+		await inlineQuarto.runCurrentCell();
+
+		// The overlay webview appears once the htmlwidget renders.
+		const webview = page.locator('iframe.webview').first();
+		await expect(webview).toBeVisible({ timeout: 120000 });
+
+		// Reveal the cell so the widget sits mid-editor with room to scroll.
+		await inlineQuarto.gotoLine(CELL_LINE);
+		await expect(webview).toBeVisible();
+
+		const boxBefore = await webview.boundingBox();
+		expect(boxBefore).not.toBeNull();
+
+		// Wheel downward over the center of the widget. We dispatch a real
+		// WheelEvent inside the widget's rendered content frame rather than using
+		// page.mouse.wheel: Playwright's synthetic mouse wheel is not delivered
+		// into the webview's out-of-process iframe, so it cannot reach the widget
+		// at all. Dispatching into the content document exercises the true fix
+		// path -- the injected preload's wheel listener runs its inner-scroll
+		// heuristic, posts a `wheelForward` message across the iframe boundary,
+		// and the view zone applies it to the editor's scroll position. The
+		// scatter plot has no inner vertical scroller, so the scroll must
+		// propagate out to the Quarto document rather than being trapped.
+		const WHEEL_DELTA_Y = 300;
+		const contentFrame = page.frameLocator('iframe.webview').frameLocator('#active-frame');
+		await expect(contentFrame.locator('body')).toBeVisible();
+		await contentFrame.locator('body').evaluate((body, deltaY) => {
+			const view = body.ownerDocument.defaultView!;
+			const target = body.ownerDocument.elementFromPoint(
+				view.innerWidth / 2,
+				view.innerHeight / 2
+			) ?? body;
+			target.dispatchEvent(new WheelEvent('wheel', {
+				deltaY,
+				deltaMode: 0, // DOM_DELTA_PIXEL
+				bubbles: true,
+				cancelable: true,
+			}));
+		}, WHEEL_DELTA_Y);
+
+		// The document scrolled: the widget's view zone moved up by roughly the
+		// wheel delta. Before the fix the widget trapped the scroll and its top y
+		// did not move at all.
+		await expect.poll(async () => {
+			const box = await webview.boundingBox();
+			return box === null ? -Infinity : box.y;
+		}, { timeout: 10000 }).toBeLessThan(boxBefore!.y - (WHEEL_DELTA_Y / 2));
+	});
+});


### PR DESCRIPTION
Fixes #14620

R HTML widgets rendered as Quarto inline output (flextable, highcharter, leaflet, and other htmlwidgets) were scroll traps: because the widget renders inside an overlay webview iframe, wheel events were captured by the iframe and never reached the surrounding Quarto document, so scrolling stopped once the pointer entered the widget.

Positron already had the plumbing for this. The webview preload script runs an inner-scroll heuristic and, when nothing inside the widget can consume the scroll, posts a `wheelForward` message across the iframe boundary. The Positron notebook consumes this message, but the Quarto inline-output view zone never listened for it.

This PR wires the Quarto view zone up to the same message: when a `wheelForward` arrives, it applies the delta to the editor's scroll position so the document scrolls instead of the widget trapping the wheel. The shared `normalizeWheelDeltaY` helper is lifted into `notebookOutputUtils.ts` so both the notebook and Quarto consumers use one implementation.

### Release Notes

#### New Features
- N/A

#### Bug Fixes

- Fixed Quarto inline-output HTML widgets (flextable, htmlwidgets) trapping scroll instead of letting the document scroll (#14620)

### Validation Steps

@:quarto @:positron-notebooks

1. Open a `.qmd` file with the `knitr` engine and run a cell that renders an htmlwidget:
   ```r
   library(highcharter)
   hchart(data.frame(x = 1:5, y = c(1, 4, 9, 16, 25)), "scatter", hcaes(x, y))
   ```
   (or the `flextable` example from the issue)
2. Add enough text below the cell that the document can scroll.
3. Place the cursor over the rendered widget and scroll with the trackpad/mouse wheel.
4. Verify the outer document scrolls (before the fix it stopped once the pointer entered the widget).
5. Confirm a widget with its own scrollable content (e.g. a tall scrollable table) still scrolls internally first, and only forwards to the document once it reaches its edge.
