### PR TITLE
Surface actionable error when notebook is in the built-in editor

### DIFF
--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -3782,8 +3782,15 @@ declare module 'positron' {
 		}
 
 		/**
-		 * Get context about the active notebook
-		 * @returns The notebook context or undefined if no notebook is active
+		 * Get context about the active notebook.
+		 *
+		 * Resolves with `undefined` when no notebook is open. Rejects with an
+		 * actionable error when a notebook is open but in an editor other than
+		 * the Positron Notebook Editor (e.g. the built-in/Jupyter notebook
+		 * editor), since the notebook API only operates on Positron Notebook
+		 * Editor instances; the error message explains how to switch editors.
+		 *
+		 * @returns The notebook context, or undefined if no notebook is active
 		 */
 		export function getContext(): Thenable<NotebookContext | undefined>;
 

--- a/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
@@ -10,7 +10,7 @@ import { IPositronNotebookService } from '../../../contrib/positronNotebook/brow
 import { IPositronNotebookInstance, NotebookOperationType } from '../../../contrib/positronNotebook/browser/IPositronNotebookInstance.js';
 import { IPositronNotebookCell, CellSelectionStatus, IPositronNotebookCodeCell } from '../../../contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
-import { getNotebookInstanceFromActiveEditorPane } from '../../../contrib/positronNotebook/browser/notebookUtils.js';
+import { getNotebookInstanceFromActiveEditorPane, getUnsupportedNotebookEditorMessage } from '../../../contrib/positronNotebook/browser/notebookUtils.js';
 import { CellSelectionType, getSelectedCells } from '../../../contrib/positronNotebook/browser/selectionMachine.js';
 import { URI } from '../../../../base/common/uri.js';
 import { CellKind, CellEditType, ICellDto2 } from '../../../contrib/notebook/common/notebookCommon.js';
@@ -96,6 +96,15 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 		// Use existing helper function instead of service method
 		const instance = getNotebookInstanceFromActiveEditorPane(this._editorService);
 		if (!instance) {
+			// A notebook may be open, but in the built-in editor rather than the
+			// Positron Notebook Editor that this API operates on. Surface an
+			// actionable error telling the user how to switch editors, instead of
+			// a bare "no notebook is open" that callers cannot distinguish from
+			// having nothing open at all.
+			const unsupportedEditorMessage = getUnsupportedNotebookEditorMessage(this._editorService);
+			if (unsupportedEditorMessage) {
+				throw new Error(unsupportedEditorMessage);
+			}
 			return undefined;
 		}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookUtils.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookUtils.ts
@@ -3,12 +3,14 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { localize } from '../../../../nls.js';
 import { CancelablePromise, createCancelablePromise, timeout } from '../../../../base/common/async.js';
 import { CancellationError } from '../../../../base/common/errors.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { IPositronNotebookInstance } from './IPositronNotebookInstance.js';
 import { PositronNotebookEditor } from './PositronNotebookEditor.js';
 import { POSITRON_NOTEBOOK_EDITOR_ID } from '../common/positronNotebookCommon.js';
+import { NOTEBOOK_EDITOR_ID } from '../../notebook/common/notebookCommon.js';
 import { IEditorPane } from '../../../common/editor.js';
 
 /** Default timeout for waiting for notebook instance (5 seconds) */
@@ -61,6 +63,29 @@ export function waitForNotebook(
  */
 export function getNotebookInstanceFromActiveEditorPane(editorService: IEditorService): IPositronNotebookInstance | undefined {
 	return getNotebookInstanceFromEditorPane(editorService.activeEditorPane);
+}
+
+/**
+ * Actionable message shown when a notebook is open, but in the built-in
+ * (Jupyter) notebook editor rather than the Positron Notebook Editor. The
+ * Positron notebook API only operates on Positron Notebook Editor instances, so
+ * this tells the user how to switch editors.
+ */
+export const UNSUPPORTED_NOTEBOOK_EDITOR_MESSAGE = localize('positronNotebook.unsupportedEditor', "The active notebook is open in the default notebook editor, which does not support this operation. Reopen it in the Positron Notebook Editor (run the \"View: Reopen Editor With...\" command and choose \"Positron Notebook\", or set \"positron.notebook.enabled\" to true and reopen the notebook), then try again.");
+
+/**
+ * When the active editor holds a notebook that the Positron notebook API cannot
+ * operate on because it is open in the built-in notebook editor rather than the
+ * Positron Notebook Editor, returns an actionable message explaining how to
+ * switch editors. Returns undefined when the active editor is a Positron
+ * notebook or is not a notebook at all.
+ *
+ * @param editorService The editor service
+ */
+export function getUnsupportedNotebookEditorMessage(editorService: IEditorService): string | undefined {
+	return editorService.activeEditorPane?.getId() === NOTEBOOK_EDITOR_ID
+		? UNSUPPORTED_NOTEBOOK_EDITOR_MESSAGE
+		: undefined;
 }
 
 /**

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookUtils.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookUtils.vitest.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { IVisibleEditorPane } from '../../../../common/editor.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { NOTEBOOK_EDITOR_ID } from '../../../notebook/common/notebookCommon.js';
+import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../common/positronNotebookCommon.js';
+import {
+	UNSUPPORTED_NOTEBOOK_EDITOR_MESSAGE,
+	getUnsupportedNotebookEditorMessage,
+} from '../../browser/notebookUtils.js';
+
+function editorServiceWithActivePane(editorId: string | undefined): IEditorService {
+	const activeEditorPane = editorId === undefined
+		? undefined
+		: stubInterface<IVisibleEditorPane>({ getId: () => editorId });
+	return stubInterface<IEditorService>({ activeEditorPane });
+}
+
+describe('getUnsupportedNotebookEditorMessage', () => {
+	it('returns the actionable message when a notebook is open in the built-in editor', () => {
+		const editorService = editorServiceWithActivePane(NOTEBOOK_EDITOR_ID);
+
+		const message = getUnsupportedNotebookEditorMessage(editorService);
+
+		expect(message).toBe(UNSUPPORTED_NOTEBOOK_EDITOR_MESSAGE);
+		expect(message).toContain('Positron Notebook Editor');
+	});
+
+	it('returns undefined when the active editor is a Positron notebook', () => {
+		const editorService = editorServiceWithActivePane(POSITRON_NOTEBOOK_EDITOR_ID);
+
+		expect(getUnsupportedNotebookEditorMessage(editorService)).toBeUndefined();
+	});
+
+	it('returns undefined when no editor is active', () => {
+		const editorService = editorServiceWithActivePane(undefined);
+
+		expect(getUnsupportedNotebookEditorMessage(editorService)).toBeUndefined();
+	});
+
+	it('returns undefined for an unrelated (non-notebook) editor', () => {
+		const editorService = editorServiceWithActivePane('workbench.editors.files.textFileEditor');
+
+		expect(getUnsupportedNotebookEditorMessage(editorService)).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Closes #14250 


<img width="1143" height="344" alt="image" src="https://github.com/user-attachments/assets/88bba7ba-5acd-47ba-81f7-9a80190be953" />


`positron.notebooks.getContext()` only resolves Positron Notebook Editor instances. When a `.ipynb` is open in the built-in notebook editor (e.g. `positron.notebook.enabled` set to `false`), it resolved `undefined`, so assistant notebook tools (`notebookRead`, `notebookEdit`, `notebookRunCells`) failed with a bare "No notebook is open in the editor" even though a notebook was visibly open with a live kernel.

This PR makes the `getContext()` main-thread path detect that case and reject with a localized, actionable message telling the user how to reopen the notebook in the Positron Notebook Editor (via "View: Reopen Editor With..." or `positron.notebook.enabled`). When no notebook is open at all, `getContext()` still resolves `undefined`. The `positron.d.ts` JSDoc documents the rejection.

Both Posit Assistant and positron-assistant funnel through this API, so both get the improved error. A companion PR in posit-dev/assistant hardens its `normalizeParams` path so the new rejection surfaces as a per-tool error rather than escaping the tool pipeline.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Assistant notebook tools now explain how to reopen a notebook in the Positron Notebook Editor when it is open in the built-in notebook editor, instead of failing with "no notebook is open" (#14250)

### Validation Steps

@:notebooks @:positron-notebooks

1. Set `positron.notebook.enabled` to `false` and reload.
2. Open a `.ipynb` file; it opens in the built-in notebook editor.
3. Ask Posit Assistant to read or edit the notebook.
4. The tool error now explains how to reopen the notebook in the Positron Notebook Editor (previously: "No notebook is open in the editor").
5. With no notebook open at all, the tools still report the plain "no notebook is open" error (unchanged).

Unit coverage: `npx vitest run src/vs/workbench/contrib/positronNotebook/test/browser/notebookUtils.vitest.ts`
