### PR TITLE
e2e: don't require .venv interpreter source on Windows in packages-pane test

### DIFF
--- a/test/e2e/tests/packages-pane/packages-pane.test.ts
+++ b/test/e2e/tests/packages-pane/packages-pane.test.ts
@@ -56,8 +56,13 @@ test.describe('Packages Pane', {
 					// selected and package installs succeed. On web/remote the venv is
 					// discovered a beat later than the base interpreter, so requiring its
 					// source (rather than taking the first match) lets the picker retry until
-					// the venv appears instead of falling back to the standalone.
-					await sessions.start(runtime, runtime === 'python' ? { triggerMode: 'quickaccess', interpreterSource: '.venv' } : undefined);
+					// the venv appears instead of falling back to the standalone. Windows CI
+					// has no venv (system Python via actions/setup-python), so require the
+					// `.venv` source only elsewhere.
+					const pythonOptions = process.platform === 'win32'
+						? { triggerMode: 'quickaccess' as const }
+						: { triggerMode: 'quickaccess' as const, interpreterSource: '.venv' };
+					await sessions.start(runtime, runtime === 'python' ? pythonOptions : undefined);
 
 					await packages.verifyPackagesList();
 


### PR DESCRIPTION
### Summary
The packages-pane `python` (uv) test requires the project `.venv` as the pip install target, but that venv only exists on Linux/web CI. Windows CI installs Python system-wide via `actions/setup-python` with no venv, so requiring the `.venv` source made the interpreter picker time out (30s) and the test failed only on Windows.

- Gate the `interpreterSource: '.venv'` requirement on non-Windows
- On Windows the default deprioritize heuristic selects the sole system interpreter, a valid pip target
- Linux/web behavior (added in #14738) is unchanged

### QA Notes
@:win @:web @:packages-pane