### PR TITLE
AI: Show baseURL config for providers with authmethod none (#14677)

### DIFF
--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -168,7 +168,7 @@ export const LanguageModelConfigComponent = (props: LanguageModelConfigComponent
 	const hasAutoconfigure = !!source.defaults.autoconfigure && source.defaults.autoconfigure.signedIn && authStatus === AuthStatus.SIGNED_IN;
 	const showApiKeyInput = authMethod === AuthMethod.API_KEY && authStatus !== AuthStatus.SIGNED_IN && !hasAutoconfigure;
 	const showCancelButton = authMethod === AuthMethod.OAUTH && authStatus === AuthStatus.SIGNING_IN && !hasAutoconfigure;
-	const showBaseUrl = authMethod === AuthMethod.API_KEY && source.supportedOptions?.includes('baseUrl') && !hasAutoconfigure;
+	const showBaseUrl = (authMethod === AuthMethod.API_KEY || authMethod === AuthMethod.NONE) && source.supportedOptions?.includes('baseUrl') && !hasAutoconfigure;
 
 	// This currently only updates the API key for the provider, but in the future it may be extended to support
 	// additional configuration options for language models.

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/languageModelConfigComponent.vitest.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/languageModelConfigComponent.vitest.tsx
@@ -12,24 +12,28 @@ import { LanguageModelConfigComponent } from '../../browser/components/languageM
 import { AuthMethod, AuthStatus } from '../../browser/types.js';
 import { IPositronLanguageModelSource, PositronLanguageModelType } from '../../common/interfaces/positronAssistantService.js';
 
+function makeSource(overrides?: Partial<Pick<IPositronLanguageModelSource, 'supportedOptions' | 'defaults'>> & { provider?: { id: string; displayName: string } }): IPositronLanguageModelSource {
+	const provider = overrides?.provider ?? { id: 'anthropic-api', displayName: 'Anthropic' };
+	return {
+		type: PositronLanguageModelType.Chat,
+		provider: { ...provider, settingName: provider.id },
+		supportedOptions: overrides?.supportedOptions ?? [],
+		defaults: overrides?.defaults ?? { model: '' },
+	};
+}
+
 describe('LanguageModelConfigComponent ProviderNotice', () => {
 	const ctx = createTestContainer().withReactServices().build();
 	const rtl = setupRTLRenderer(() => ctx.reactServices);
 
 	function renderNotice(provider: { id: string; displayName: string }): HTMLElement {
-		const source: IPositronLanguageModelSource = {
-			type: PositronLanguageModelType.Chat,
-			provider: { ...provider, settingName: provider.id },
-			supportedOptions: [],
-			defaults: { model: '' },
-		};
 		rtl.render(
 			<LanguageModelConfigComponent
 				authMethod={AuthMethod.NONE}
 				authStatus={AuthStatus.SIGNED_OUT}
 				closeDialog={() => { }}
 				config={{ model: '' }}
-				source={source}
+				source={makeSource({ provider, supportedOptions: [] })}
 				onCancel={() => { }}
 				onChange={() => { }}
 				onSignIn={() => { }}
@@ -91,5 +95,37 @@ describe('LanguageModelConfigComponent ProviderNotice', () => {
 		expect(linkHrefs(notice)).toEqual({
 			'Posit EULA': 'https://posit.co/about/eula/',
 		});
+	});
+});
+
+describe('LanguageModelConfigComponent base-URL input', () => {
+	const ctx = createTestContainer().withReactServices().build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
+
+	function renderConfig(supportedOptions: string[]) {
+		rtl.render(
+			<LanguageModelConfigComponent
+				authMethod={AuthMethod.NONE}
+				authStatus={AuthStatus.SIGNED_OUT}
+				closeDialog={() => { }}
+				config={{ model: '' }}
+				source={makeSource({ supportedOptions })}
+				onCancel={() => { }}
+				onChange={() => { }}
+				onSignIn={() => { }}
+			/>
+		);
+	}
+
+	it('renders the base-URL input when supportedOptions includes baseUrl', () => {
+		renderConfig(['baseUrl']);
+
+		expect(screen.getByLabelText('Base URL')).toBeInTheDocument();
+	});
+
+	it('does not render the base-URL input when supportedOptions is empty', () => {
+		renderConfig([]);
+
+		expect(screen.queryByLabelText('Base URL')).not.toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
Cherry-picks https://github.com/posit-dev/positron/pull/14677 to the 2026.07 branch, to ship in the 2026.07.1 patch release

Description from https://github.com/posit-dev/positron/pull/14677:
> This is a tiny follow-up to #14126 that allows model providers registered with no authentication method to show a base URL input box in the configuration modal.
> 
> Before:
> <img width="624" height="527" alt="Screenshot 2026-07-06 at 11 34 46" src="https://github.com/user-attachments/assets/f4542b89-5aaf-4a1a-8bc0-f19d5bfbec30" />
> 
> After:
> <img width="611" height="508" alt="Screenshot 2026-07-06 at 11 32 03" src="https://github.com/user-attachments/assets/dfbcba83-573c-4190-ba34-2921b98d616a" />