### PR TITLE
cherry-pick #14618 into 2026.07.1

### DIFF
--- a/extensions/positron-python/src/client/common/platform/fs-paths.ts
+++ b/extensions/positron-python/src/client/common/platform/fs-paths.ts
@@ -23,7 +23,7 @@ export class FileSystemPaths implements IFileSystemPaths {
         private readonly isCaseInsensitive: boolean,
         // (effectively) the node "path" module to use
         private readonly raw: INodePath,
-    ) {}
+    ) { }
     // Create a new object using common-case default values.
     // We do not use an alternate constructor because defaults in the
     // constructor runs counter to our typical approach.
@@ -73,7 +73,7 @@ export class Executables {
         public readonly delimiter: string,
         // the OS type to target
         private readonly osType: OSType,
-    ) {}
+    ) { }
     // Create a new object using common-case default values.
     // We do not use an alternate constructor because defaults in the
     // constructor runs counter to our typical approach.
@@ -106,7 +106,7 @@ export class FileSystemPathUtils implements IFileSystemPathUtils {
         public readonly executables: IExecutables,
         // other low-level FS path operations to use
         private readonly raw: IRawPaths,
-    ) {}
+    ) { }
     // Create a new object using common-case default values.
     // We do not use an alternate constructor because defaults in the
     // constructor runs counter to our typical approach.
@@ -236,6 +236,12 @@ export function readdirSync(
 export function readlink(path: string): Promise<string> {
     return fs.readlink(path);
 }
+
+// --- Start Positron ---
+export function realpath(path: string): Promise<string> {
+    return fs.realpath(path);
+}
+// --- End Positron ---
 
 export function unlink(path: string): Promise<void> {
     return fs.unlink(path);

--- a/extensions/positron-python/src/client/positron/manager.ts
+++ b/extensions/positron-python/src/client/positron/manager.ts
@@ -15,7 +15,7 @@ import { inject, injectable } from 'inversify';
 import * as fs from '../common/platform/fs-paths';
 import { IServiceContainer } from '../ioc/types';
 import { pythonRuntimeDiscoverer } from './discoverer';
-import { IInterpreterService } from '../interpreter/contracts';
+import { IInterpreterService, PythonEnvironmentsChangedEvent } from '../interpreter/contracts';
 import { traceError, traceInfo } from '../logging';
 import { IConfigurationService, IDisposable, IDisposableRegistry } from '../common/types';
 import { getActivePythonSessions, PythonRuntimeSession } from './session';
@@ -43,9 +43,22 @@ export interface IPythonRuntimeManager extends positron.LanguageRuntimeManager {
      */
     onDidCreateSession: Event<PythonRuntimeSession>;
 
+    /**
+     * Register a Python language runtime for the given interpreter path.
+     *
+     * @param pythonPath The interpreter path.
+     * @param recreateRuntime Shut down any sessions on an existing runtime for
+     *        this path and re-register it.
+     * @param forceRefresh Re-resolve the interpreter even if a runtime is
+     *        already registered for this path, and supersede it if the resolved
+     *        metadata differs (e.g. a version that a cached discovery pass got
+     *        wrong). Without this, an already-registered path returns early
+     *        without re-resolving.
+     */
     registerLanguageRuntimeFromPath(
         pythonPath: string,
         recreateRuntime?: boolean,
+        forceRefresh?: boolean,
     ): Promise<positron.LanguageRuntimeMetadata | undefined>;
     selectLanguageRuntimeFromPath(pythonPath: string, recreateRuntime?: boolean): Promise<string | undefined>;
     triggerInterpreterRefresh(): Promise<void>;
@@ -66,6 +79,8 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
 
     private readonly _onDidDiscoverRuntime = new EventEmitter<positron.LanguageRuntimeMetadata>();
 
+    private readonly _onDidRemoveRuntime = new EventEmitter<string>();
+
     private readonly _onDidCreateSession = new EventEmitter<PythonRuntimeSession>();
 
     /**
@@ -73,7 +88,23 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
      */
     public readonly onDidDiscoverRuntime = this._onDidDiscoverRuntime.event;
 
+    /**
+     * An event that fires when a previously registered Python runtime should be
+     * retracted from Positron, carrying the runtimeId to remove. Used to drop a
+     * runtime whose interpreter was deleted, or a symlink alias that
+     * de-duplication has collapsed into another path.
+     */
+    public readonly onDidRemoveRuntime = this._onDidRemoveRuntime.event;
+
     public readonly onDidCreateSession = this._onDidCreateSession.event;
+
+    /**
+     * Serializes handling of `onDidChangeInterpreters` events. The handler is
+     * async (it resolves interpreter details before registering), so without a
+     * queue a `Created` and a follow-up `Changed`/`Deleted` for the same path
+     * could interleave and leave the registry out of sync with the picker.
+     */
+    private _interpreterChangeQueue: Promise<void> = Promise.resolve();
 
     constructor(
         @inject(IServiceContainer) private readonly serviceContainer: IServiceContainer,
@@ -89,38 +120,19 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
                 new CondaPythonPickerContribution(this.serviceContainer),
             ),
 
-            // When an interpreter is added or removed, update our registry and (on removal)
-            // shut down any sessions still backed by the deleted environment.
-            interpreterService.onDidChangeInterpreters(async (event) => {
-                if (!event.old && event.new) {
-                    // An interpreter was added.
-                    const interpreterPath = event.new.path;
-                    await this.registerLanguageRuntimeFromPath(interpreterPath);
-                } else if (event.old && !event.new) {
-                    // An interpreter was removed externally (e.g. `.venv` directory deleted). Clear
-                    // stored metadata so we don't hand out stale runtimes, and shut down any live
-                    // sessions using the deleted path.
-                    const deletedPath = event.old.path;
-                    this.registeredPythonRuntimes.delete(deletedPath);
-                    try {
-                        // Only Python sessions; other languages' sessions may not even have
-                        // extraRuntimeData (e.g. restored from a serialized state).
-                        const sessions = await getActivePythonSessions();
-                        const toShutdown = sessions.filter(
-                            (s) =>
-                                (s.runtimeMetadata.extraRuntimeData as PythonRuntimeExtraData).pythonPath ===
-                                deletedPath,
-                        );
-                        if (toShutdown.length > 0) {
-                            traceInfo(
-                                `Shutting down ${toShutdown.length} session(s) for deleted interpreter ${deletedPath}`,
-                            );
-                            await Promise.all(toShutdown.map((s) => s.shutdown(positron.RuntimeExitReason.Shutdown)));
-                        }
-                    } catch (error) {
-                        traceError(`Failed to clean up sessions for deleted interpreter ${deletedPath}: ${error}`);
-                    }
-                }
+            // When an interpreter is added, removed, or replaced, keep our
+            // registry (and the Positron picker) in sync. Serialized so a
+            // Created and a follow-up Changed/Deleted for the same path can't
+            // interleave. Each event's failure is caught and logged so one
+            // transient error can't reject the queue and stop every later event
+            // from being handled until reload.
+            interpreterService.onDidChangeInterpreters((event) => {
+                this._interpreterChangeQueue = this._interpreterChangeQueue
+                    .then(() => this.handleInterpreterChange(event))
+                    .catch((error) => {
+                        const changedPath = event.new?.path ?? event.old?.path;
+                        traceError(`Failed to handle interpreter change for ${changedPath}: ${error}`);
+                    });
             }),
 
             interpreterService.onDidChangeInterpreter(async (event) => {
@@ -154,6 +166,69 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
 
     dispose(): void {
         this.disposables.forEach((d) => d.dispose());
+    }
+
+    /**
+     * Handles an interpreter add/remove/replace event, keeping the registry and
+     * the Positron picker in sync. Invoked serially via `_interpreterChangeQueue`.
+     *
+     * - Added (`new` only): register a runtime for the new path. Uses
+     *   forceRefresh so that if a cached discovery pass already registered this
+     *   path with a stale version, we re-resolve and supersede it.
+     * - Removed (`old` only): retract the removed path's runtime and shut down
+     *   any sessions still backed by it.
+     * - Replaced (`old` and `new` with different paths): de-duplication collapsed
+     *   one interpreter alias into another (e.g. a symlink resolved to a shorter
+     *   path). Retract the old alias's runtime -- which may already be in the
+     *   picker from its own earlier Created event -- and register the survivor
+     *   with forceRefresh so a stale cached version for the survivor path is
+     *   re-resolved and superseded rather than returned as is.
+     *   Same-path changes are metadata refreshes and leave the registration as is.
+     */
+    private async handleInterpreterChange(event: PythonEnvironmentsChangedEvent): Promise<void> {
+        if (!event.old && event.new) {
+            await this.registerLanguageRuntimeFromPath(
+                event.new.path,
+                /* recreateRuntime */ false,
+                /* forceRefresh */ true,
+            );
+        } else if (event.old && !event.new) {
+            const deletedPath = event.old.path;
+            this.unregisterRuntimeForPath(deletedPath);
+            try {
+                // Only Python sessions; other languages' sessions may not even have
+                // extraRuntimeData (e.g. restored from a serialized state).
+                const sessions = await getActivePythonSessions();
+                const toShutdown = sessions.filter(
+                    (s) => (s.runtimeMetadata.extraRuntimeData as PythonRuntimeExtraData).pythonPath === deletedPath,
+                );
+                if (toShutdown.length > 0) {
+                    traceInfo(`Shutting down ${toShutdown.length} session(s) for deleted interpreter ${deletedPath}`);
+                    await Promise.all(toShutdown.map((s) => s.shutdown(positron.RuntimeExitReason.Shutdown)));
+                }
+            } catch (error) {
+                traceError(`Failed to clean up sessions for deleted interpreter ${deletedPath}: ${error}`);
+            }
+        } else if (event.old && event.new && event.old.path !== event.new.path) {
+            this.unregisterRuntimeForPath(event.old.path);
+            await this.registerLanguageRuntimeFromPath(
+                event.new.path,
+                /* recreateRuntime */ false,
+                /* forceRefresh */ true,
+            );
+        }
+    }
+
+    /**
+     * Retract the runtime registered for a given interpreter path, if any, so it
+     * is removed from the Positron picker. No-op if the path isn't registered.
+     */
+    private unregisterRuntimeForPath(pythonPath: string): void {
+        const existing = this.registeredPythonRuntimes.get(pythonPath);
+        if (existing) {
+            this.registeredPythonRuntimes.delete(pythonPath);
+            this._onDidRemoveRuntime.fire(existing.runtimeId);
+        }
     }
 
     /**
@@ -265,6 +340,15 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
         const extraData = runtime.extraRuntimeData as PythonRuntimeExtraData;
 
         if (shouldIncludeInterpreter(extraData.pythonPath)) {
+            // If this path is already registered under a different runtime id
+            // (e.g. a stale version -- the same venv reported as 3.14.4 by the
+            // cached discovery pass and 3.14.6 once resolved), retract the old
+            // one first so the picker shows a single entry per interpreter path.
+            const existing = this.registeredPythonRuntimes.get(extraData.pythonPath);
+            if (existing && existing.runtimeId !== runtime.runtimeId) {
+                this._onDidRemoveRuntime.fire(existing.runtimeId);
+            }
+
             // Save the runtime for later use
             this.registeredPythonRuntimes.set(extraData.pythonPath, runtime);
             this._onDidDiscoverRuntime.fire(runtime);
@@ -524,8 +608,22 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
 
         // As each runtime metadata element is returned, cache and return it
         for await (const runtime of discoverer) {
-            // Save a copy of the metadata for later use
             const extraData = runtime.extraRuntimeData as PythonRuntimeExtraData;
+
+            // If the live `onDidChangeInterpreters` handler already registered
+            // this path during discovery, it resolved the interpreter and may
+            // hold a more accurate version than this (cached) discovery pass --
+            // e.g. a venv whose base was upgraded in place, reported here as the
+            // stale `pyvenv.cfg` version but resolved live to the real one.
+            // Yield the existing registration so the same path can't produce two
+            // picker entries with different versions.
+            const existing = this.registeredPythonRuntimes.get(extraData.pythonPath);
+            if (existing && existing.runtimeId !== runtime.runtimeId) {
+                yield existing;
+                continue;
+            }
+
+            // Save a copy of the metadata for later use
             this.registeredPythonRuntimes.set(extraData.pythonPath, runtime);
 
             // Return the runtime to Positron
@@ -542,13 +640,16 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
     async registerLanguageRuntimeFromPath(
         pythonPath: string,
         recreateRuntime?: boolean,
+        forceRefresh?: boolean,
     ): Promise<positron.LanguageRuntimeMetadata | undefined> {
         const alreadyRegisteredRuntime = this.registeredPythonRuntimes.get(pythonPath);
-        if (alreadyRegisteredRuntime) {
-            if (!recreateRuntime) {
-                return alreadyRegisteredRuntime;
-            }
-
+        if (alreadyRegisteredRuntime && !recreateRuntime && !forceRefresh) {
+            // Fast path: a runtime is already registered for this path and the
+            // caller hasn't asked us to recreate it or re-check its metadata, so
+            // avoid re-resolving the interpreter.
+            return alreadyRegisteredRuntime;
+        }
+        if (alreadyRegisteredRuntime && recreateRuntime) {
             const sessions = await getActivePythonSessions();
             // Find any active sessions using this runtime
             const sessionsToShutdown = sessions.filter((session) => {
@@ -569,13 +670,28 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
             this.registeredPythonRuntimes.delete(pythonPath);
         }
 
-        // Get the interpreter corresponding to the new runtime.
+        // Get the interpreter corresponding to the new runtime. This resolves the
+        // interpreter (running it when needed), so the version reflects what the
+        // interpreter actually reports rather than a stale `pyvenv.cfg` version a
+        // cached discovery pass may have registered for this path.
         const interpreter = await this.interpreterService.getInterpreterDetails(pythonPath);
         // Create the runtime and register it with Positron.
         if (interpreter) {
             // Set recommendedForWorkspace to false, since we change the active runtime
             // in the onDidChangeActiveEnvironmentPath listener.
             const newRuntime = await createPythonRuntimeMetadata(interpreter, this.serviceContainer, false);
+            // On a forceRefresh, if the resolved runtime matches what's already
+            // registered for this path, there's nothing to do. If it differs (e.g.
+            // the real version supersedes a stale one from discovery),
+            // registerLanguageRuntime retracts the stale entry so the picker shows
+            // the correct version.
+            if (
+                alreadyRegisteredRuntime &&
+                !recreateRuntime &&
+                alreadyRegisteredRuntime.runtimeId === newRuntime.runtimeId
+            ) {
+                return alreadyRegisteredRuntime;
+            }
             // Register the runtime with Positron.
             this.registerLanguageRuntime(newRuntime);
             return newRuntime;

--- a/extensions/positron-python/src/client/pythonEnvironments/base/info/index.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/info/index.ts
@@ -224,6 +224,14 @@ export type PythonEnvInfo = _PythonEnvInfo & {
      */
     pythonRunCommand?: string[];
     identifiedUsingNativeLocator?: boolean;
+    // --- Start Positron ---
+    /**
+     * Other paths the native locator (PET) reports as equivalent to `executable`,
+     * e.g. the real interpreter a launcher-style shim (uv's Windows trampolines)
+     * spawns. Used to de-duplicate environments; not user-facing.
+     */
+    symlinks?: string[];
+    // --- End Positron ---
 };
 
 /**

--- a/extensions/positron-python/src/client/pythonEnvironments/common/externalDependencies.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/externalDependencies.ts
@@ -120,6 +120,35 @@ export function arePathsSame(path1: string, path2: string): boolean {
     return normCasePath(path1) === normCasePath(path2);
 }
 
+// --- Start Positron ---
+/**
+ * Canonicalize a path by resolving every symlink in it -- including symlinked
+ * intermediate directories -- to the underlying real path.
+ *
+ * Unlike `resolveSymbolicLink`, which only follows a symlink when the leaf
+ * itself is one, this resolves directory symlinks too. uv, for example, installs
+ * a real `cpython-3.14.6-<platform>` directory and a `cpython-3.14-<platform>`
+ * symlink pointing at it; an executable reached through the symlinked directory
+ * is not itself a symlink, so leaf-only resolution leaves the two paths looking
+ * distinct even though they are the same file. Full canonicalization collapses
+ * them, which is what interpreter de-duplication needs.
+ *
+ * The result is used only as a comparison key, never as a displayed path. On any
+ * failure (missing path, permission denied, an unsupported/networked filesystem
+ * that does not implement realpath) we fall back to the normalized input path so
+ * that the worst case is a conservative "treat as distinct" rather than a thrown
+ * error or a dropped environment.
+ */
+export async function canonicalizePath(absPath: string): Promise<string> {
+    try {
+        return await fsapi.realpath(absPath);
+    } catch (ex) {
+        traceVerbose(`Failed to canonicalize path ${absPath}, falling back to normalized path: ${ex}`);
+        return normalizePath(absPath);
+    }
+}
+// --- End Positron ---
+
 export async function resolveSymbolicLink(absPath: string, stats?: fsapi.Stats, count?: number): Promise<string> {
     stats = stats ?? (await fsapi.lstat(absPath));
     if (stats.isSymbolicLink()) {

--- a/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
@@ -47,7 +47,7 @@ import { isAdditionalGlobalBinPath } from './common/environmentManagers/globalIn
 // eslint-disable-next-line import/no-duplicates
 import { PythonEnvSource } from './base/info';
 import { getShortestString } from '../common/stringUtils';
-import { arePathsSame, isParentPath, resolveSymbolicLink } from './common/externalDependencies';
+import { arePathsSame, canonicalizePath, isParentPath, normCasePath } from './common/externalDependencies';
 import {
     ModuleEnvironmentLocator,
     moduleMetadataMap,
@@ -304,6 +304,11 @@ async function toPythonEnvInfo(nativeEnv: NativeEnvInfo, condaEnvDirs: string[])
         },
         // --- Start Positron ---
         source: nativeEnv.source ?? [],
+        // Carry PET's equivalent-path list through so getEnvIdentity() can
+        // recognize launcher-style shims (e.g. uv's Windows trampolines) whose
+        // realpath is not the interpreter they run. Omitted (not undefined) when
+        // absent so deep-equality comparisons of envs are unaffected.
+        ...(nativeEnv.symlinks && { symlinks: nativeEnv.symlinks }),
         // --- End Positron ---
         detailedDisplayName: displayName,
         display: displayName,
@@ -376,11 +381,12 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
     private _condaEnvDirs: string[] = [];
 
     // --- Start Positron ---
-    // Cache of resolved symlink paths, keyed by executable filename.
-    // Maintained incrementally in addEnv()/removeEnv() so checkForExistingEnv()
-    // can do O(1) lookups instead of re-resolving all existing envs on every
-    // new env addition (which was O(N^2) total).
-    private _resolvedSymlinks = new Map<string, string>();
+    // Cache of environment identities (canonical executable + canonical prefix),
+    // keyed by executable filename. Maintained incrementally in
+    // addEnv()/removeEnv() so checkForExistingEnv() can do O(1) lookups instead
+    // of re-canonicalizing all existing envs on every new env addition (which was
+    // O(N^2) total).
+    private _envIdentities = new Map<string, string>();
 
     // Cache of resolved environments, keyed by the executable path passed to
     // resolveEnv(). Only successful resolutions are cached. Entries are
@@ -584,7 +590,7 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
             if (!old) {
                 // If the 'info' env is not already in the list, check if it is one of the additional env directories,
                 // and if so, check if we have an equivalent env already and determine if we should add the 'info' env.
-                const { reason, existingEnv } = await checkForExistingEnv(this._envs, info, this._resolvedSymlinks);
+                const { reason, existingEnv } = await checkForExistingEnv(this._envs, info, this._envIdentities);
                 switch (reason) {
                     case ExistingEnvAction.KeepExistingEnv:
                         // We found an 'old' equivalent env, but it has a shorter path than the equivalent new 'info' env.
@@ -613,13 +619,13 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
                 }
             }
             if (old) {
-                // Remove the replaced env's symlink cache entry. In the
+                // Remove the replaced env's identity cache entry. In the
                 // ReplaceExistingEnv case, old's filename differs from info's,
                 // so we also need to filter _envs by old's filename to
                 // actually remove it (not just info's filename, which isn't
                 // in _envs yet).
                 const oldFilename = old.executable.filename;
-                this._resolvedSymlinks.delete(oldFilename);
+                this._envIdentities.delete(oldFilename);
                 // Drop any stale resolveEnv cache entry for the replaced path
                 // so late callers don't see the superseded env.
                 this._resolveEnvCache.delete(oldFilename);
@@ -655,7 +661,7 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
             const old = this._envs.find((item) => item.executable.filename === env);
             this._envs = this._envs.filter((item) => item.executable.filename !== env);
             // --- Start Positron ---
-            this._resolvedSymlinks.delete(env);
+            this._envIdentities.delete(env);
             this._resolveEnvCache.delete(env);
             // --- End Positron ---
             this._onChanged.fire({ type: FileChangeType.Deleted, old });
@@ -663,7 +669,7 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
         }
         this._envs = this._envs.filter((item) => item.executable.filename !== env.executable.filename);
         // --- Start Positron ---
-        this._resolvedSymlinks.delete(env.executable.filename);
+        this._envIdentities.delete(env.executable.filename);
         this._resolveEnvCache.delete(env.executable.filename);
         // --- End Positron ---
         this._onChanged.fire({ type: FileChangeType.Deleted, old: env });
@@ -944,7 +950,7 @@ class NativeWithModulesApi implements IDiscoveryAPI, Disposable {
         const { uniqueModuleEnvs, reKeys } = await partitionModuleEnvsByNative(
             moduleEnvs,
             this.nativeApi.getEnvs(),
-            (p) => resolveSymbolicLink(p),
+            (p) => canonicalizePath(p),
         );
 
         // Apply the re-keys: move each duplicate's module metadata and pending
@@ -1044,6 +1050,77 @@ class NativeWithModulesApi implements IDiscoveryAPI, Disposable {
 }
 
 /**
+ * Compute a stable identity for an environment, used to recognize when two
+ * interpreter executables are really the same environment reached through
+ * different paths.
+ *
+ * The identity combines the fully canonicalized executable path with the
+ * canonicalized environment prefix:
+ * - Canonicalizing (rather than following only leaf symlinks) collapses
+ *   symlinked *directories*. uv, for example, installs a real
+ *   `cpython-3.14.6-<platform>` directory alongside a `cpython-3.14-<platform>`
+ *   symlink to it; an executable reached through the symlinked directory is not
+ *   itself a symlink, so leaf-only resolution would leave the two paths looking
+ *   distinct. Canonicalization makes such aliases of one interpreter match.
+ * - Including the prefix keeps genuinely distinct environments apart. Two
+ *   virtual environments whose `python` resolves to the same base interpreter
+ *   have different prefixes, so they are not collapsed into one another (issue
+ *   #14493); neither is a venv collapsed into its base interpreter.
+ *
+ * Module-discovered envs arrive without a `sysPrefix` (the environment-modules
+ * API doesn't report one), so we fall back to the *resolved* executable's
+ * install directory (the `<prefix>/bin/python` layout). Resolving first is what
+ * matters: a module interpreter is often reached through a shim or symlink --
+ * e.g. `~/.local/bin/python3` pointing into a uv install -- whose own
+ * grandparent (`~/.local`) is not the interpreter's prefix. Deriving from the
+ * resolved path instead lands on the real install dir, matching the prefix PET
+ * reports for the native twin so the two collapse instead of showing twice.
+ * Module discovery is Linux-only, where this layout holds.
+ *
+ * On Windows, uv installs `~/.local/bin/python*.exe` as *trampolines*: small
+ * regular executables (not symlinks) that spawn the real interpreter, so
+ * canonicalizing the executable is a no-op and the exe component alone would
+ * leave the trampoline and its target looking distinct. PET spawns such
+ * launchers and reports the interpreter's own `sys.executable` in `symlinks`,
+ * so when the canonical executable falls outside the environment's canonical
+ * prefix (the launcher signature -- a real interpreter or resolved symlink
+ * always lives inside its prefix), we substitute the canonicalized `symlinks`
+ * entry that lives inside the prefix. That collapses the trampoline into its
+ * target while leaving in-prefix executables -- everything on mac/Linux --
+ * on the exact same code path as before.
+ *
+ * The result is a comparison key only -- it is never used as a displayed path.
+ *
+ * @param env The environment to identify.
+ * @param canonicalize Resolves a path to its canonical real path. Injected so
+ *        callers/tests can supply a real or fake resolver.
+ */
+async function getEnvIdentity(
+    env: PythonEnvInfo,
+    canonicalize: (p: string) => Promise<string> = canonicalizePath,
+): Promise<string> {
+    const { filename, sysPrefix } = env.executable;
+    let canonicalExe = await canonicalize(filename);
+    const prefix = sysPrefix || path.dirname(path.dirname(canonicalExe));
+    const canonicalPrefix = await canonicalize(prefix);
+    if (!isParentPath(canonicalExe, canonicalPrefix)) {
+        // Launcher-style shim (see the trampoline note above): identify it by
+        // the real, in-prefix interpreter PET reports instead.
+        for (const link of env.symlinks ?? []) {
+            const canonicalLink = await canonicalize(link);
+            if (!arePathsSame(canonicalLink, canonicalExe) && isParentPath(canonicalLink, canonicalPrefix)) {
+                canonicalExe = canonicalLink;
+                break;
+            }
+        }
+    }
+    // NUL can't appear in a path, so it's a safe separator between the two
+    // components. normCasePath makes the comparison case-insensitive where the
+    // platform's filesystem is (Windows, macOS).
+    return `${normCasePath(canonicalExe)}\0${normCasePath(canonicalPrefix)}`;
+}
+
+/**
  * Partition module-discovered environments into those that duplicate a native
  * environment and those that are standalone.
  *
@@ -1052,12 +1129,13 @@ class NativeWithModulesApi implements IDiscoveryAPI, Disposable {
  * symlinked siblings to the shortest path (e.g. `.../bin/python`), while the
  * module locator resolves `python3` first (e.g. `.../bin/python3`). Comparing
  * raw filenames treats these as distinct, so the interpreter shows up twice.
- * Resolving symlinks reveals that they point at the same target.
+ * Comparing environment identities (see {@link getEnvIdentity}) reveals that they
+ * are the same environment, while keeping genuinely distinct environments apart.
  *
  * @param moduleEnvs The freshly discovered module environments.
  * @param nativeEnvs The environments found by the native locator.
- * @param resolveSymlink Resolves an executable path to its canonical (symlink)
- *        target. Injected so callers/tests can supply a real or fake resolver.
+ * @param canonicalize Resolves a path to its canonical real path. Injected so
+ *        callers/tests can supply a real or fake resolver.
  * @returns `uniqueModuleEnvs` (module envs with no native equivalent, kept as
  *          their own entries) and `reKeys` (module-path -> native-path moves the
  *          caller should apply to the module metadata maps so the surviving
@@ -1068,22 +1146,22 @@ class NativeWithModulesApi implements IDiscoveryAPI, Disposable {
 export async function partitionModuleEnvsByNative(
     moduleEnvs: PythonEnvInfo[],
     nativeEnvs: PythonEnvInfo[],
-    resolveSymlink: (executablePath: string) => Promise<string>,
+    canonicalize: (executablePath: string) => Promise<string>,
 ): Promise<{ uniqueModuleEnvs: PythonEnvInfo[]; reKeys: { from: string; to: string }[] }> {
     const reKeys: { from: string; to: string }[] = [];
     if (moduleEnvs.length === 0 || nativeEnvs.length === 0) {
         return { uniqueModuleEnvs: moduleEnvs, reKeys };
     }
 
-    // Map each native interpreter's canonical (symlink-resolved) target to the
-    // path Positron registers it under. Native discovery already collapses
-    // equivalents to the shortest path, so the first match per target wins.
-    const nativePathByResolved = new Map<string, string>();
+    // Map each native interpreter's environment identity to the path Positron
+    // registers it under. Native discovery already collapses equivalents to the
+    // shortest path, so the first match per identity wins.
+    const nativePathByIdentity = new Map<string, string>();
     await Promise.all(
         nativeEnvs.map(async (e) => {
-            const resolved = await resolveSymlink(e.executable.filename);
-            if (!nativePathByResolved.has(resolved)) {
-                nativePathByResolved.set(resolved, e.executable.filename);
+            const identity = await getEnvIdentity(e, canonicalize);
+            if (!nativePathByIdentity.has(identity)) {
+                nativePathByIdentity.set(identity, e.executable.filename);
             }
         }),
     );
@@ -1091,8 +1169,8 @@ export async function partitionModuleEnvsByNative(
     const uniqueModuleEnvs: PythonEnvInfo[] = [];
     for (const moduleEnv of moduleEnvs) {
         const modulePath = moduleEnv.executable.filename;
-        const resolved = await resolveSymlink(modulePath);
-        const nativePath = nativePathByResolved.get(resolved);
+        const identity = await getEnvIdentity(moduleEnv, canonicalize);
+        const nativePath = nativePathByIdentity.get(identity);
         if (!nativePath) {
             // No native equivalent: keep the module env as its own entry.
             uniqueModuleEnvs.push(moduleEnv);
@@ -1126,15 +1204,23 @@ export async function partitionModuleEnvsByNative(
  * case, we only want to add one of them to the list of environments -- in particular,
  * the one with the shortest path: `/opt/python/3.10.4/bin/python`.
  *
+ * Equivalence is decided by environment identity (see {@link getEnvIdentity}), not by
+ * the symlink target alone: two interpreters are equivalent only when they canonicalize
+ * to the same executable *and* share an environment prefix. This collapses aliases of a
+ * single interpreter -- including ones reached through a symlinked directory (issue
+ * #14489) -- without merging distinct virtual environments that happen to share a base
+ * interpreter (issue #14493).
+ *
  * @param envs The current list of environments
  * @param newEnv The new environment to be added
+ * @param envIdentities Cache of environment identities keyed by executable filename.
  * @return The result of the check -- how to proceed with the new environment and if found,
  *         the equivalent existing environment.
  */
 async function checkForExistingEnv(
     envs: PythonEnvInfo[],
     newEnv: PythonEnvInfo,
-    resolvedSymlinks: Map<string, string>,
+    envIdentities: Map<string, string>,
 ): Promise<ExistingEnvResult> {
     const additionalEnvDirs = await getAdditionalEnvDirs();
     const isAdditionalEnv = additionalEnvDirs.find((dir) => isParentPath(newEnv.executable.filename, dir));
@@ -1145,18 +1231,18 @@ async function checkForExistingEnv(
         return { reason: ExistingEnvAction.AddNewEnv, existingEnv: undefined };
     }
 
-    // Look for an existing environment in the same additional environment directory
-    // as the new env. Use the cached resolved symlinks to avoid an O(N) pass of
-    // resolveSymbolicLink() calls on every invocation.
-    const resolvedEnv = await resolveSymbolicLink(newEnv.executable.filename);
+    // Look for an existing environment with the same identity as the new env. Use
+    // the cached identities to avoid an O(N) pass of canonicalizePath() calls on
+    // every invocation.
+    const newIdentity = await getEnvIdentity(newEnv);
     let existingEnv: PythonEnvInfo | undefined;
     for (const item of envs) {
-        let resolvedItem = resolvedSymlinks.get(item.executable.filename);
-        if (resolvedItem === undefined) {
-            resolvedItem = await resolveSymbolicLink(item.executable.filename);
-            resolvedSymlinks.set(item.executable.filename, resolvedItem);
+        let itemIdentity = envIdentities.get(item.executable.filename);
+        if (itemIdentity === undefined) {
+            itemIdentity = await getEnvIdentity(item);
+            envIdentities.set(item.executable.filename, itemIdentity);
         }
-        if (arePathsSame(resolvedEnv, resolvedItem)) {
+        if (newIdentity === itemIdentity) {
             existingEnv = item;
             break;
         }

--- a/extensions/positron-python/src/test/positron/manager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/manager.unit.test.ts
@@ -186,6 +186,10 @@ suite('Python runtime manager', () => {
     });
 
     test('selectLanguageRuntimeFromPath: calls positron.runtime.selectLanguageRuntime with the corresponding runtime ID', async () => {
+        // An already-registered path is re-resolved (createPythonRuntimeMetadata)
+        // to catch stale versions; the cached runtime is kept when the resolved
+        // runtimeId matches.
+        sinon.stub(runtime, 'createPythonRuntimeMetadata').resolves(runtimeMetadata.object);
         pythonRuntimeManager.registeredPythonRuntimes.set(pythonPath, runtimeMetadata.object);
 
         await pythonRuntimeManager.selectLanguageRuntimeFromPath(pythonPath);
@@ -707,5 +711,49 @@ suite('Python runtime manager - onDidChangeInterpreter filter', () => {
         sinon.assert.notCalled(otherShutdown);
         sinon.assert.notCalled(nonPythonShutdown);
         sinon.assert.notCalled(selectSpy);
+    });
+
+    test('interpreter replacement: retracts old alias and re-registers survivor with forceRefresh', async () => {
+        // De-duplication collapsed a symlink alias into a shorter survivor path.
+        // The survivor must be re-registered with forceRefresh so a stale cached
+        // version for its path is re-resolved and superseded, not returned as is.
+        const oldPath = '/path/to/long/symlink/python';
+        const newPath = '/path/to/python';
+        pythonRuntimeManager.registeredPythonRuntimes.set(oldPath, {
+            runtimeId: 'old',
+            extraRuntimeData: { pythonPath: oldPath },
+        } as any);
+        const registerStub = sinon.stub(pythonRuntimeManager, 'registerLanguageRuntimeFromPath').resolves(undefined);
+
+        onDidChangeInterpretersEmitter.fire({ old: { path: oldPath } as any, new: { path: newPath } as any });
+        await new Promise((r) => setTimeout(r, 0));
+
+        assert.strictEqual(pythonRuntimeManager.registeredPythonRuntimes.has(oldPath), false);
+        sinon.assert.calledOnceWithExactly(registerStub, newPath, false, true);
+    });
+
+    test('a rejected change handler does not poison the queue for later events', async () => {
+        // If handling one event rejects (e.g. registration throws), the serialized
+        // queue must stay resolved so later events are still handled -- otherwise a
+        // single transient failure freezes interpreter syncing until reload.
+        const registerStub = sinon
+            .stub(pythonRuntimeManager, 'registerLanguageRuntimeFromPath')
+            .rejects(new Error('transient failure'));
+
+        const laterDeletedPath = '/path/to/later/python';
+        pythonRuntimeManager.registeredPythonRuntimes.set(laterDeletedPath, {
+            runtimeId: 'r',
+            extraRuntimeData: { pythonPath: laterDeletedPath },
+        } as any);
+
+        // First event rejects while being handled; the second must still run.
+        onDidChangeInterpretersEmitter.fire({ old: undefined, new: { path: '/path/to/added/python' } as any });
+        onDidChangeInterpretersEmitter.fire({ old: { path: laterDeletedPath } as any, new: undefined });
+
+        // Let the serialized queue drain.
+        await new Promise((r) => setTimeout(r, 0));
+
+        sinon.assert.called(registerStub);
+        assert.strictEqual(pythonRuntimeManager.registeredPythonRuntimes.has(laterDeletedPath), false);
     });
 });

--- a/extensions/positron-python/src/test/pythonEnvironments/common/externalDependencies.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/common/externalDependencies.unit.test.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -7,7 +7,7 @@ import * as assert from 'assert';
 import * as path from 'path';
 import * as sinon from 'sinon';
 import * as fsapi from '../../../client/common/platform/fs-paths';
-import { checkParentDirs } from '../../../client/pythonEnvironments/common/externalDependencies';
+import { canonicalizePath, checkParentDirs } from '../../../client/pythonEnvironments/common/externalDependencies';
 
 suite('checkParentDirs tests', () => {
     let pathExistsSyncStub: sinon.SinonStub;
@@ -39,5 +39,36 @@ suite('checkParentDirs tests', () => {
         const expected = undefined;
         const actual = checkParentDirs(root, filename);
         assert.strictEqual(actual, expected);
+    });
+});
+
+suite('canonicalizePath tests', () => {
+    let realpathStub: sinon.SinonStub;
+
+    setup(() => {
+        realpathStub = sinon.stub(fsapi, 'realpath');
+    });
+
+    teardown(() => {
+        sinon.restore();
+    });
+
+    test('returns the fully resolved real path', async () => {
+        const input = path.join('home', 'cpython-3.14', 'bin', 'python3.14');
+        const resolved = path.join('home', 'cpython-3.14.6', 'bin', 'python3.14');
+        realpathStub.withArgs(input).resolves(resolved);
+
+        const actual = await canonicalizePath(input);
+
+        assert.strictEqual(actual, resolved);
+    });
+
+    test('falls back to the normalized input path when realpath throws', async () => {
+        const input = path.join('home', '..', 'home', 'project', 'bin', 'python');
+        realpathStub.withArgs(input).rejects(new Error('ENOENT'));
+
+        const actual = await canonicalizePath(input);
+
+        assert.strictEqual(actual, path.normalize(input));
     });
 });

--- a/extensions/positron-python/src/test/pythonEnvironments/nativeAPI.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/nativeAPI.unit.test.ts
@@ -472,13 +472,11 @@ suite('Native Python API', () => {
         const symlinkTarget = '/opt/python/3.10/bin/python3.10';
 
         sinon.stub(nativeFinder, 'getAdditionalEnvDirs').resolves([additionalDir]);
-        sinon.stub(externalDeps, 'resolveSymbolicLink').callsFake(async (p: string) => {
-            // Both paths resolve to the same underlying binary.
-            if (p === longerPath || p === shorterPath) {
-                return symlinkTarget;
-            }
-            return p;
-        });
+        // Both executables canonicalize to the same underlying binary, and both
+        // report the same install prefix, so they are the same environment.
+        const resolveToTarget = async (p: string) => (p === longerPath || p === shorterPath ? symlinkTarget : p);
+        sinon.stub(externalDeps, 'resolveSymbolicLink').callsFake(resolveToTarget);
+        sinon.stub(externalDeps, 'canonicalizePath').callsFake(resolveToTarget);
 
         const longerEnv: NativeEnvInfo = {
             displayName: 'Python 3.10',
@@ -514,6 +512,195 @@ suite('Native Python API', () => {
         const envs = api.getEnvs();
         assert.equal(envs.length, 1, 'expected exactly one env (longer path should be replaced)');
         assert.equal(envs[0].executable.filename, shorterPath);
+    });
+
+    test('Issue #14489: a uv interpreter reached through a symlinked version directory is de-duplicated', async () => {
+        // uv installs a real `cpython-3.14.6-*` directory alongside a
+        // `cpython-3.14-*` symlink pointing at it. The ~/.local/bin shim reaches
+        // the interpreter THROUGH the symlinked directory, so the executable file
+        // itself is not a symlink and leaf-only resolution leaves the two paths
+        // looking distinct. Full canonicalization resolves the directory symlink
+        // and collapses them to the same real file.
+        const realDir = '/home/user/.local/share/uv/python/cpython-3.14.6-linux-x86_64-gnu';
+        const linkDir = '/home/user/.local/share/uv/python/cpython-3.14-linux-x86_64-gnu';
+        const realExe = `${realDir}/bin/python`;
+        const shimExe = '/home/user/.local/bin/python3.14';
+        const canonicalExe = `${realDir}/bin/python3.14`;
+
+        sinon
+            .stub(nativeFinder, 'getAdditionalEnvDirs')
+            .resolves(['/home/user/.local/share/uv/python', '/home/user/.local/bin']);
+        // Leaf-only resolution (what the buggy code used) leaves the two distinct
+        // because the shim's executable is not itself a symlink.
+        sinon.stub(externalDeps, 'resolveSymbolicLink').callsFake(async (p: string) => {
+            if (p === realExe) {
+                return canonicalExe;
+            }
+            if (p === shimExe) {
+                return `${linkDir}/bin/python3.14`;
+            }
+            return p;
+        });
+        // Full canonicalization resolves the directory symlink: both the executable
+        // and the reported prefix collapse onto the real cpython-3.14.6 paths.
+        sinon.stub(externalDeps, 'canonicalizePath').callsFake(async (p: string) => {
+            if (p === realExe || p === shimExe) {
+                return canonicalExe;
+            }
+            if (p === realDir || p === linkDir) {
+                return realDir;
+            }
+            return p;
+        });
+
+        const realEnv: NativeEnvInfo = {
+            displayName: 'Python 3.14.6',
+            name: 'python',
+            executable: realExe,
+            kind: NativePythonEnvironmentKind.Uv,
+            version: '3.14.6',
+            prefix: realDir,
+        };
+        const shimEnv: NativeEnvInfo = {
+            displayName: 'Python 3.14.6',
+            name: 'python3.14',
+            executable: shimExe,
+            kind: NativePythonEnvironmentKind.Uv,
+            version: '3.14.6',
+            prefix: linkDir,
+        };
+
+        mockFinder
+            .setup((f) => f.refresh())
+            .returns(() => {
+                async function* generator() {
+                    yield* [realEnv, shimEnv];
+                }
+                return generator();
+            });
+
+        await api.triggerRefresh();
+
+        const envs = api.getEnvs();
+        assert.equal(envs.length, 1, 'the shim and the real interpreter should collapse to a single entry');
+        // The shorter path (the ~/.local/bin shim) is the one kept.
+        assert.equal(envs[0].executable.filename, shimExe);
+    });
+
+    test('Windows uv trampolines: a launcher that is not a symlink is de-duplicated via PET symlinks', async () => {
+        // On Windows, uv installs `~/.local/bin/python.exe` as a trampoline: a
+        // small regular executable (not a symlink) that spawns the real
+        // interpreter, so canonicalizing it is a no-op. PET spawns the launcher
+        // and reports the interpreter's real executable in `symlinks`, and its
+        // prefix through uv's minor-version alias directory (a real directory
+        // symlink). The identity must follow the in-prefix symlink so the
+        // trampoline collapses into the real interpreter.
+        const realDir = '/home/user/.local/share/uv/python/cpython-3.14.6-linux-x86_64-gnu';
+        const linkDir = '/home/user/.local/share/uv/python/cpython-3.14-linux-x86_64-gnu';
+        const realExe = `${realDir}/bin/python`;
+        const aliasExe = `${linkDir}/bin/python`;
+        const trampolineExe = '/home/user/.local/bin/python';
+
+        sinon
+            .stub(nativeFinder, 'getAdditionalEnvDirs')
+            .resolves(['/home/user/.local/share/uv/python', '/home/user/.local/bin']);
+        // The trampoline is a regular file: canonicalization leaves it as is.
+        // Only the alias directory (and paths through it) resolve to the real dir.
+        sinon.stub(externalDeps, 'canonicalizePath').callsFake(async (p: string) => {
+            if (p === aliasExe) {
+                return realExe;
+            }
+            if (p === linkDir) {
+                return realDir;
+            }
+            return p;
+        });
+
+        const realEnv: NativeEnvInfo = {
+            displayName: 'Python 3.14.6',
+            name: 'python',
+            executable: realExe,
+            kind: NativePythonEnvironmentKind.Uv,
+            version: '3.14.6',
+            prefix: realDir,
+        };
+        const trampolineEnv: NativeEnvInfo = {
+            displayName: 'Python 3.14.6',
+            name: 'python',
+            executable: trampolineExe,
+            kind: NativePythonEnvironmentKind.GlobalPaths,
+            version: '3.14.6',
+            prefix: linkDir,
+            symlinks: [trampolineExe, aliasExe],
+        };
+
+        mockFinder
+            .setup((f) => f.refresh())
+            .returns(() => {
+                async function* generator() {
+                    yield* [realEnv, trampolineEnv];
+                }
+                return generator();
+            });
+
+        await api.triggerRefresh();
+
+        const envs = api.getEnvs();
+        assert.equal(envs.length, 1, 'the trampoline and the real interpreter should collapse to a single entry');
+        // The shorter path (the ~/.local/bin trampoline) is the one kept.
+        assert.equal(envs[0].executable.filename, trampolineExe);
+    });
+
+    test('Issue #14493: distinct virtual environments sharing a base interpreter are both kept', async () => {
+        // Two uv venvs whose `python` symlinks both resolve to the SAME base
+        // interpreter, but which are genuinely different environments (different
+        // prefixes). They must not be de-duplicated against each other.
+        const base = '/home/user/.local/share/uv/python/cpython-3.12.0-linux-x86_64-gnu/bin/python3.12';
+        const venvA = '/home/user/venvs/a/.venv';
+        const venvB = '/home/user/venvs/bbb/.venv';
+        const exeA = `${venvA}/bin/python`;
+        const exeB = `${venvB}/bin/python`;
+
+        sinon.stub(nativeFinder, 'getAdditionalEnvDirs').resolves(['/home/user/venvs']);
+        // Both venv executables resolve/canonicalize to the same base interpreter;
+        // every other path (notably each venv's distinct prefix) maps to itself.
+        const resolveBoth = async (p: string) => (p === exeA || p === exeB ? base : p);
+        sinon.stub(externalDeps, 'resolveSymbolicLink').callsFake(resolveBoth);
+        sinon.stub(externalDeps, 'canonicalizePath').callsFake(resolveBoth);
+
+        const envA: NativeEnvInfo = {
+            displayName: 'Python 3.12.0',
+            name: 'a',
+            executable: exeA,
+            kind: NativePythonEnvironmentKind.Venv,
+            version: '3.12.0',
+            prefix: venvA,
+        };
+        const envB: NativeEnvInfo = {
+            displayName: 'Python 3.12.0',
+            name: 'bbb',
+            executable: exeB,
+            kind: NativePythonEnvironmentKind.Venv,
+            version: '3.12.0',
+            prefix: venvB,
+        };
+
+        mockFinder
+            .setup((f) => f.refresh())
+            .returns(() => {
+                async function* generator() {
+                    yield* [envA, envB];
+                }
+                return generator();
+            });
+
+        await api.triggerRefresh();
+
+        const envs = api
+            .getEnvs()
+            .map((e) => e.executable.filename)
+            .sort();
+        assert.deepEqual(envs, [exeA, exeB], 'both venvs should appear despite sharing a base interpreter');
     });
 
     // Regression tests for issue #12500: `resolveEnv` must not pin an
@@ -738,6 +925,77 @@ suite('partitionModuleEnvsByNative', () => {
         assert.deepEqual(
             { uniqueModuleEnvs: result.uniqueModuleEnvs.map((e) => e.executable.filename), reKeys: result.reKeys },
             { uniqueModuleEnvs: ['/opt/mod/bin/python3'], reKeys: [] },
+        );
+    });
+
+    test('Issue #14493: distinct venvs sharing a base interpreter are not merged', async () => {
+        // The module and native locators each surface a *different* venv, but both
+        // venvs' `python` resolves to the same base interpreter. They are distinct
+        // environments (different prefixes), so the module env must be kept, not
+        // re-keyed onto the native one.
+        const base = '/uv/cpython-3.12.0/bin/python3.12';
+        const venvA = '/home/user/venvs/a/.venv';
+        const venvB = '/home/user/venvs/bbb/.venv';
+        const envWithPrefix = (filename: string, sysPrefix: string): PythonEnvInfo => ({
+            ...envWith(filename),
+            executable: { filename, sysPrefix, ctime: -1, mtime: -1 },
+        });
+
+        const result = await nativeAPI.partitionModuleEnvsByNative(
+            [envWithPrefix(`${venvB}/bin/python`, venvB)],
+            [envWithPrefix(`${venvA}/bin/python`, venvA)],
+            (p) => Promise.resolve(p === `${venvA}/bin/python` || p === `${venvB}/bin/python` ? base : p),
+        );
+        assert.deepEqual(
+            { uniqueModuleEnvs: result.uniqueModuleEnvs.map((e) => e.executable.filename), reKeys: result.reKeys },
+            { uniqueModuleEnvs: [`${venvB}/bin/python`], reKeys: [] },
+        );
+    });
+
+    test('a module env with no prefix still de-dups against its native twin', async () => {
+        // In production the native locator fills in a real prefix (via PET) while
+        // a module-discovered env has none (envWith leaves sysPrefix ''). The two
+        // must still collapse to one entry: getEnvIdentity derives the missing
+        // module prefix from the resolved executable's grandparent
+        // (`<prefix>/bin/python`), which matches the native prefix.
+        const prefix = '/opt/python/3.11';
+        const nativeExe = `${prefix}/bin/python`;
+        const moduleExe = `${prefix}/bin/python3`;
+        const target = `${prefix}/bin/python3.11`;
+        const nativeEnv: PythonEnvInfo = {
+            ...envWith(nativeExe),
+            executable: { filename: nativeExe, sysPrefix: prefix, ctime: -1, mtime: -1 },
+        };
+
+        const result = await nativeAPI.partitionModuleEnvsByNative([envWith(moduleExe)], [nativeEnv], (p) =>
+            Promise.resolve(p === nativeExe || p === moduleExe ? target : p),
+        );
+        assert.deepEqual(
+            { uniqueModuleEnvs: result.uniqueModuleEnvs.map((e) => e.executable.filename), reKeys: result.reKeys },
+            { uniqueModuleEnvs: [], reKeys: [{ from: moduleExe, to: nativeExe }] },
+        );
+    });
+
+    test('a module env reached through a ~/.local/bin shim de-dups against its native twin', async () => {
+        // Module envs commonly resolve to a shim like ~/.local/bin/python3 that
+        // points into the real install. Its own grandparent (~/.local/bin ->
+        // ~/.local) is not the interpreter's prefix, so the identity must be
+        // built from the RESOLVED executable's install dir -- which is the prefix
+        // PET reports for the native env it discovered at the real location.
+        const realPrefix = '/home/user/.local/share/uv/python/cpython-3.14.6-linux';
+        const realExe = `${realPrefix}/bin/python3.14`;
+        const shimExe = '/home/user/.local/bin/python3.14';
+        const nativeEnv: PythonEnvInfo = {
+            ...envWith(realExe),
+            executable: { filename: realExe, sysPrefix: realPrefix, ctime: -1, mtime: -1 },
+        };
+        // realpath resolves both the shim and the real path to the same file.
+        const canonicalize = (p: string) => Promise.resolve(p === shimExe || p === realExe ? realExe : p);
+
+        const result = await nativeAPI.partitionModuleEnvsByNative([envWith(shimExe)], [nativeEnv], canonicalize);
+        assert.deepEqual(
+            { uniqueModuleEnvs: result.uniqueModuleEnvs.map((e) => e.executable.filename), reKeys: result.reKeys },
+            { uniqueModuleEnvs: [], reKeys: [{ from: shimExe, to: realExe }] },
         );
     });
 });

--- a/product.json
+++ b/product.json
@@ -98,7 +98,7 @@
 			"version": "2026.7.5",
 			"positUrl": "https://cdn.posit.co/pwb-components/extension",
 			"type": "reh-web-pwb",
-			"sha256": "4653f543e2eb5aa933320b99937a7fcb600ad22a5d7bbbe21cc05a94311b0a0c",
+			"sha256": "68fd34383f485992ae5348ebd5dff0d7d5c3ab79f463d19933df7219dbb11f57",
 			"metadata": {
 				"publisherDisplayName": "Posit PBC"
 			}

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1116,6 +1116,20 @@ declare module 'positron' {
 		onDidDiscoverRuntime?: vscode.Event<LanguageRuntimeMetadata>;
 
 		/**
+		 * An optional event that fires when a previously registered runtime
+		 * should be removed, carrying the `runtimeId` of the runtime to remove.
+		 *
+		 * Used to retract a runtime that a manager previously surfaced (via
+		 * `discoverAllRuntimes()` or `onDidDiscoverRuntime`) but that no longer
+		 * exists or has been superseded -- for example when the underlying
+		 * environment is deleted, or when de-duplication collapses several
+		 * aliases of one interpreter and the alias already registered is not the
+		 * survivor. Without this, such stale runtimes linger in the picker until
+		 * the window is reloaded.
+		 */
+		onDidRemoveRuntime?: vscode.Event<string>;
+
+		/**
 		 * An optional metadata validation function. If provided, Positron will
 		 * validate any stored metadata before attempting to use it to create a
 		 * new session. This happens when a workspace is re-opened, for example.

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -1398,6 +1398,17 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 			}));
 		}
 
+		// Attach an event handler to the onDidRemoveRuntime event, if present.
+		// This event notifies us when a previously registered runtime should be
+		// retracted (e.g. its environment was deleted, or de-duplication
+		// collapsed an alias that had already been registered).
+		if (manager.onDidRemoveRuntime) {
+			disposables.add(manager.onDidRemoveRuntime(runtimeId => {
+				this._proxy.$unregisterLanguageRuntime(runtimeId);
+				this._runtimeManagersByRuntimeId.delete(runtimeId);
+			}));
+		}
+
 		this._runtimeManagers.push({ manager, languageId, extension });
 
 		return new Disposable(() => {

--- a/src/vs/workbench/api/test/common/positron/extHostLanguageRuntime.vitest.ts
+++ b/src/vs/workbench/api/test/common/positron/extHostLanguageRuntime.vitest.ts
@@ -42,11 +42,12 @@ function fakeMetadata(overrides: Partial<ILanguageRuntimeMetadata> = {}): ILangu
 function createMockShape() {
 	return new class extends mock<MainThreadLanguageRuntimeShape>() {
 		registrations: ILanguageRuntimeMetadata[] = [];
+		unregistrations: string[] = [];
 		override $registerLanguageRuntime(metadata: ILanguageRuntimeMetadata): void {
 			this.registrations.push(metadata);
 		}
-		override $unregisterLanguageRuntime(_runtimeId: string): void {
-			// no-op
+		override $unregisterLanguageRuntime(runtimeId: string): void {
+			this.unregistrations.push(runtimeId);
 		}
 		override $emitPerfMark(_extensionId: string, _name: string): void {
 			// no-op
@@ -128,6 +129,55 @@ describe('ExtHostLanguageRuntime - onDidRegisterRuntime', function () {
 		expect(shape.registrations[0].runtimeId).toBe(meta.runtimeId);
 		// ...but the public event has not fired yet (it would on broadcast back).
 		expect(seen).toEqual([]);
+	});
+});
+
+/** A manager that exposes an `onDidRemoveRuntime` event for retraction tests. */
+class RemovableManager extends mock<positron.LanguageRuntimeManager>() {
+	readonly removeEmitter = new Emitter<string>();
+	override readonly onDidRemoveRuntime = this.removeEmitter.event;
+}
+
+describe('ExtHostLanguageRuntime - onDidRemoveRuntime', function () {
+
+	const disposables = ensureNoLeakedDisposables();
+
+	let shape: ReturnType<typeof createMockShape>;
+	let runtime: ExtHostLanguageRuntime;
+
+	beforeEach(() => {
+		shape = createMockShape();
+		runtime = new ExtHostLanguageRuntime(SingleProxyRPCProtocol(shape), new NullLogService());
+	});
+
+	function registerRemovableRuntime(): RemovableManager {
+		const manager = new RemovableManager();
+		disposables.add(manager.removeEmitter);
+		disposables.add(runtime.registerLanguageRuntimeManager(fakeExtension, 'r', manager));
+		disposables.add(runtime.registerLanguageRuntime(fakeExtension, manager, fakeMetadata({ runtimeId: 'r-1' })));
+		return manager;
+	}
+
+	it('retracts the runtime on the main thread when the manager fires onDidRemoveRuntime', () => {
+		const manager = registerRemovableRuntime();
+
+		manager.removeEmitter.fire('r-1');
+
+		expect(shape.unregistrations).toEqual(['r-1']);
+	});
+
+	it('does not retract the runtime again when the manager is later disposed', () => {
+		const manager = new RemovableManager();
+		disposables.add(manager.removeEmitter);
+		const managerRegistration = runtime.registerLanguageRuntimeManager(fakeExtension, 'r', manager);
+		disposables.add(runtime.registerLanguageRuntime(fakeExtension, manager, fakeMetadata({ runtimeId: 'r-1' })));
+
+		// The runtime is dropped from the manager map on retraction, so disposing
+		// the manager afterwards must not unregister the same id a second time.
+		manager.removeEmitter.fire('r-1');
+		managerRegistration.dispose();
+
+		expect(shape.unregistrations).toEqual(['r-1']);
 	});
 });
 

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -637,6 +637,12 @@ export const selectNewLanguageRuntime = async (
 		rebuildItems();
 	}));
 
+	// Rebuild when a runtime is unregistered - covers de-duplication collapsing
+	// a symlink alias or a deleted interpreter while the picker is open.
+	disposables.add(languageRuntimeService.onDidUnregisterRuntime(() => {
+		rebuildItems();
+	}));
+
 	// If startup completes while the picker is open, re-fetch contributions
 	// (which we previously skipped) and rebuild.
 	disposables.add(languageRuntimeService.onDidChangeRuntimeStartupPhase(async phase => {

--- a/src/vs/workbench/contrib/languageRuntime/test/browser/languageRuntimeActions.vitest.ts
+++ b/src/vs/workbench/contrib/languageRuntime/test/browser/languageRuntimeActions.vitest.ts
@@ -243,6 +243,23 @@ describe('selectNewLanguageRuntime', () => {
 			await promise;
 		});
 
+		it('rebuilds when onDidUnregisterRuntime fires mid-pick', async () => {
+			registerRuntime(makeRuntime({ runtimeId: 'py-1' }));
+			registerRuntime(makeRuntime({ runtimeId: 'py-2', languageVersion: '3.10.0' }));
+			const promise = runPicker();
+			await waitUntilOpened();
+			expect(pickItemById('py-1')).toBeDefined();
+			expect(pickItemById('py-2')).toBeDefined();
+
+			// De-duplication collapsing an alias retracts a runtime while the
+			// picker is open; the removed runtime must drop out of the rebuilt list.
+			ctx.get(ILanguageRuntimeService).unregisterRuntime('py-2');
+			expect(pickItemById('py-2')).toBeUndefined();
+			expect(pickItemById('py-1')).toBeDefined();
+			pick.cancel(QuickInputHideReason.Gesture);
+			await promise;
+		});
+
 		it('preserves the previously focused item across rebuilds', async () => {
 			registerRuntime(makeRuntime({ runtimeId: 'py-1' }));
 			registerRuntime(makeRuntime({ runtimeId: 'py-2', languageVersion: '3.10.0' }));

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -27,6 +27,10 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 	// The event emitter for the onDidRegisterRuntime event.
 	private readonly _onDidRegisterRuntimeEmitter =
 		this._register(new Emitter<ILanguageRuntimeMetadata>);
+
+	// The event emitter for the onDidUnregisterRuntime event.
+	private readonly _onDidUnregisterRuntimeEmitter =
+		this._register(new Emitter<string>);
 
 	// The current startup phase; an observeable value.
 	private _startupPhase: ISettableObservable<RuntimeStartupPhase>;
@@ -74,6 +78,9 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 
 	// An event that fires when a new runtime is registered.
 	readonly onDidRegisterRuntime = this._onDidRegisterRuntimeEmitter.event;
+
+	// An event that fires when a runtime is unregistered, carrying its runtimeId.
+	readonly onDidUnregisterRuntime = this._onDidUnregisterRuntimeEmitter.event;
 
 	/**
 	 * Event tracking the current startup phase.
@@ -134,7 +141,7 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 		this._logService.trace(`Language runtime ${formatLanguageRuntimeMetadata(metadata)} successfully registered.`);
 
 		return this._register(toDisposable(() => {
-			this._registeredRuntimesByRuntimeId.delete(metadata.runtimeId);
+			this.unregisterRuntime(metadata.runtimeId);
 		}));
 	}
 
@@ -144,7 +151,9 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 	 * @param runtimeId The runtime identifier of the runtime to unregister
 	 */
 	unregisterRuntime(runtimeId: string): void {
-		this._registeredRuntimesByRuntimeId.delete(runtimeId);
+		if (this._registeredRuntimesByRuntimeId.delete(runtimeId)) {
+			this._onDidUnregisterRuntimeEmitter.fire(runtimeId);
+		}
 	}
 
 	/**

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -1154,6 +1154,12 @@ export interface ILanguageRuntimeService {
 	 * An event that fires when a new runtime is registered.
 	 */
 	readonly onDidRegisterRuntime: Event<ILanguageRuntimeMetadata>;
+
+	/**
+	 * An event that fires when a runtime is unregistered, carrying the
+	 * runtimeId of the removed runtime.
+	 */
+	readonly onDidUnregisterRuntime: Event<string>;
 
 	/**
 	 * Event tracking the current startup phase.

--- a/src/vs/workbench/services/languageRuntime/test/common/languageRuntime.vitest.ts
+++ b/src/vs/workbench/services/languageRuntime/test/common/languageRuntime.vitest.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -8,6 +8,7 @@
 import { raceTimeout } from '../../../../../base/common/async.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
 import { ILogService, NullLogger } from '../../../../../platform/log/common/log.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
@@ -32,7 +33,7 @@ function makeTestMetadata(overrides: Partial<ILanguageRuntimeMetadata>): ILangua
 		runtimeSource: 'test',
 		startupBehavior: LanguageRuntimeStartupBehavior.Explicit,
 		sessionLocation: LanguageRuntimeSessionLocation.Workspace,
-		extensionId: { value: 'test' },
+		extensionId: new ExtensionIdentifier('test'),
 		extraRuntimeData: {},
 		...overrides,
 	});
@@ -87,6 +88,53 @@ describe('Positron - LanguageRuntimeService', () => {
 
 			// No-op since we already unregistered the runtime.
 			runtimeDisposable.dispose();
+		});
+	});
+
+	describe('onDidUnregisterRuntime', () => {
+		const ctx = createTestContainer()
+			.withRuntimeServices()
+			.stub(ILogService, new NullLogger())
+			.stub(IConfigurationService, new TestConfigurationService())
+			.build();
+
+		it('fires with the runtimeId and removes the runtime when unregistered', () => {
+			const languageRuntimeService = ctx.disposables.add(ctx.instantiationService.createInstance(LanguageRuntimeService));
+			languageRuntimeService.registerRuntime(makeTestMetadata({ runtimeId: 'py-1' }));
+
+			const unregistered: string[] = [];
+			ctx.disposables.add(languageRuntimeService.onDidUnregisterRuntime(id => unregistered.push(id)));
+
+			languageRuntimeService.unregisterRuntime('py-1');
+
+			expect(unregistered).toEqual(['py-1']);
+			expect(languageRuntimeService.registeredRuntimes.length).toBe(0);
+		});
+
+		it('does not fire when unregistering an id that was never registered', () => {
+			const languageRuntimeService = ctx.disposables.add(ctx.instantiationService.createInstance(LanguageRuntimeService));
+
+			const unregistered: string[] = [];
+			ctx.disposables.add(languageRuntimeService.onDidUnregisterRuntime(id => unregistered.push(id)));
+
+			languageRuntimeService.unregisterRuntime('never-registered');
+
+			expect(unregistered).toEqual([]);
+		});
+
+		it('fires when the registration disposable is disposed', () => {
+			const languageRuntimeService = ctx.disposables.add(ctx.instantiationService.createInstance(LanguageRuntimeService));
+			const registration = languageRuntimeService.registerRuntime(makeTestMetadata({ runtimeId: 'py-1' }));
+
+			const unregistered: string[] = [];
+			ctx.disposables.add(languageRuntimeService.onDidUnregisterRuntime(id => unregistered.push(id)));
+
+			// Disposing the registration removes the runtime through the same path
+			// as unregisterRuntime, so the event fires exactly like an explicit call.
+			registration.dispose();
+
+			expect(unregistered).toEqual(['py-1']);
+			expect(languageRuntimeService.registeredRuntimes.length).toBe(0);
 		});
 	});
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Reference the associated issue with a closing keyword such as
  "Fixes #123" so GitHub automatically closes the issue when this PR
  is merged. If there are any details about your approach that are
  unintuitive or you want to draw attention to, please describe them
  here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix distinct Python virtual environments that share a base interpreter being collapsed into one entry in the interpreter list (https://github.com/posit-dev/positron/issues/14493)
- Fix the same uv-managed Python interpreter appearing multiple times when reached through a symlinked version directory

@:interpreter @:console @:environment-modules @:positron-notebooks @:packages-pane @:win @:web @:remote-ssh