### PR TITLE
cherry-pick #14759 into 2026.07.1

### DIFF
--- a/product.json
+++ b/product.json
@@ -98,7 +98,7 @@
 			"version": "2026.7.5",
 			"positUrl": "https://cdn.posit.co/pwb-components/extension",
 			"type": "reh-web-pwb",
-			"sha256": "4653f543e2eb5aa933320b99937a7fcb600ad22a5d7bbbe21cc05a94311b0a0c",
+			"sha256": "68fd34383f485992ae5348ebd5dff0d7d5c3ab79f463d19933df7219dbb11f57",
 			"metadata": {
 				"publisherDisplayName": "Posit PBC"
 			}


### PR DESCRIPTION
Cherry-pick #14759 into 2026.07.1. This is the Workbench extension hash fix. This should get things a-buildin' again.