### PR TITLE
ci: specify why each tag was selected in the e2e pr comment

### DIFF
--- a/.github/workflows/pr-e2e-comment.yml
+++ b/.github/workflows/pr-e2e-comment.yml
@@ -23,7 +23,7 @@ jobs:
           GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
 
       - name: Update PR Comment with Tags
-        run: bash ./scripts/pr-e2e-comment.sh "<!-- PR Tags -->" "${{ env.tags }}" "${{ steps.pr-tags.outputs.no_matches }}" "${{ steps.pr-tags.outputs.unmapped_dirs }}" "${{ steps.pr-tags.outputs.invalid_tags }}"
+        run: bash ./scripts/pr-e2e-comment.sh "<!-- PR Tags -->" "${{ env.tags }}" "${{ steps.pr-tags.outputs.no_matches }}" "${{ steps.pr-tags.outputs.unmapped_dirs }}" "${{ steps.pr-tags.outputs.invalid_tags }}" "${{ steps.pr-tags.outputs.tag_reasons }}"
         env:
           tags: ${{ steps.pr-tags.outputs.tags }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/lib/pr-tags-lib.sh
+++ b/scripts/lib/pr-tags-lib.sh
@@ -294,3 +294,43 @@ build_tag_reasons() {
 	[[ ${#out[@]} -eq 0 ]] && return 0
 	printf '%s\n' "${out[@]}" | paste -sd, -
 }
+
+# render_why_these_tags <encoded>
+# <encoded>: build_tag_reasons output (or the literal "@:all|body"). Echoes a
+# collapsed "Why these tags?" <details> block annotating each tag with a human
+# label, or NOTHING when there's nothing to explain (empty input, or the sole
+# entry is the always-injected @:critical). Pure presentation: maps the source
+# codes to labels. The README link that used to live in the comment footer now
+# lives here.
+render_why_these_tags() {
+	local encoded="$1"
+	[[ -z "$encoded" ]] && return 0
+	# Not informative when the only entry is the required @:critical floor.
+	[[ "$encoded" == "@:critical|required" ]] && return 0
+	local pair tag code label rows=""
+	while IFS= read -r pair; do
+		[[ -z "$pair" ]] && continue
+		tag="${pair%%|*}"
+		code="${pair##*|}"
+		case "$code" in
+			required) label="Always runs (required)" ;;
+			body)     label="PR description" ;;
+			files)    label="Changed files" ;;
+			ark)      label="Ark submodule bump" ;;
+			test-win) label="New test (tags.WIN)" ;;
+			test-web) label="New test (tags.WEB)" ;;
+			*)        label="Auto-selected" ;;
+		esac
+		rows="${rows}| \`${tag}\` | ${label} |"$'\n'
+	done < <(printf '%s\n' "${encoded//,/$'\n'}")
+	cat <<EOF
+<details>
+<summary>Why these tags?</summary>
+
+| Tag | Source |
+| --- | --- |
+${rows}
+More on [automatic tags from changed files](https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#automatic-tags-from-changed-files).
+</details>
+EOF
+}

--- a/scripts/lib/pr-tags-lib.sh
+++ b/scripts/lib/pr-tags-lib.sh
@@ -259,3 +259,38 @@ find_unmapped_positron_dirs() {
 	[[ ${#out[@]} -eq 0 ]] && return 0
 	printf '%s\n' "${out[@]}" | awk 'NF && !seen[$0]++'
 }
+
+# build_tag_reasons <final_csv> <author_csv> <map_csv> <ark> <added_win> <added_web>
+# Assigns each tag in <final_csv> (comma-separated, order-stable) a single source
+# code by precedence: required -> body -> files -> ark -> test-win -> test-web ->
+# auto. Booleans are the strings "true"/"false". Echoes comma-separated
+# "<tag>|<code>" pairs in <final_csv> order; empty final list echoes nothing.
+# Pure: presentation of an already-decided tag set, no gh / $GITHUB_OUTPUT.
+build_tag_reasons() {
+	local final="$1" author="$2" map="$3" ark="$4" added_win="$5" added_web="$6"
+	local tag code author_nl map_nl
+	local -a out=()
+	author_nl="${author//,/$'\n'}"
+	map_nl="${map//,/$'\n'}"
+	while IFS= read -r tag; do
+		[[ -z "$tag" ]] && continue
+		if [[ "$tag" == "@:critical" ]]; then
+			code="required"
+		elif printf '%s\n' "$author_nl" | grep -qxF "$tag"; then
+			code="body"
+		elif printf '%s\n' "$map_nl" | grep -qxF "$tag"; then
+			code="files"
+		elif [[ "$tag" == "@:ark" && "$ark" == "true" ]]; then
+			code="ark"
+		elif [[ "$tag" == "@:win" && "$added_win" == "true" ]]; then
+			code="test-win"
+		elif [[ "$tag" == "@:web" && "$added_web" == "true" ]]; then
+			code="test-web"
+		else
+			code="auto"
+		fi
+		out+=("$tag|$code")
+	done < <(printf '%s\n' "${final//,/$'\n'}")
+	[[ ${#out[@]} -eq 0 ]] && return 0
+	printf '%s\n' "${out[@]}" | paste -sd, -
+}

--- a/scripts/pr-e2e-comment.sh
+++ b/scripts/pr-e2e-comment.sh
@@ -3,7 +3,7 @@
 # Script to update or create the single E2E PR comment: the tags that will run,
 # plus advisory warnings (no feature tags auto-selected, and/or touched Positron
 # dirs missing from the tag map) folded into the same comment.
-# Usage: bash ./scripts/pr-e2e-comment.sh "<comment_marker>" "<tags>" [<no_matches>] [<unmapped_dirs>] [<invalid_tags>]
+# Usage: bash ./scripts/pr-e2e-comment.sh "<comment_marker>" "<tags>" [<no_matches>] [<unmapped_dirs>] [<invalid_tags>] [<tag_reasons>]
 # Example: bash ./scripts/pr-e2e-comment.sh "<!-- PR Tags -->" "@:critical,@:quarto" "false" "" ""
 
 set -e
@@ -14,6 +14,7 @@ TAGS="$2"                  # e.g., "@:critical,@:quarto"
 NO_MATCHES="${3:-false}"   # "true" when only @:critical resolved (no feature tags)
 UNMAPPED_DIRS="${4:-}"     # comma-joined Positron dirs with no entry in the tag map
 INVALID_TAGS="${5:-}"      # comma-joined author-typed tags not in the TestTags enum
+TAG_REASONS="${6:-}"       # build_tag_reasons encoding: "<tag>|<code>,..." (or "@:all|body")
 
 # Pure helpers (is_infra_only, union_csv_tags) used below.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -100,10 +101,18 @@ if [ "$(is_infra_only "$CHANGED_FILES")" != "true" ]; then
   fi
 fi
 
+# "Why these tags?" collapse (empty when there's nothing to explain). Prefix two
+# newlines only when present so it separates cleanly from the tags line and
+# collapses to nothing otherwise. Real newlines -> rendered with %s below.
+WHY_BLOCK="$(render_why_these_tags "$TAG_REASONS")"
+if [[ -n "$WHY_BLOCK" ]]; then
+	WHY_BLOCK=$'\n\n'"$WHY_BLOCK"
+fi
+
 # Build the new comment body with proper newlines (%s = tags, %b = warnings).
 # Layout: tags -> advisory block (if any) -> footer links last, so the links
 # always sit at the bottom rather than wedged between the tags and the note.
-NEW_COMMENT=$(printf "${COMMENT_MARKER}\n${RED_ALERT_NOTE}\n\n**E2E Tests** 🚀\nThis PR will run tests tagged with: %s%b\n\n<sup>[readme](https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags)</sup>&nbsp;&nbsp;<sup>[valid tags](https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts)</sup>&nbsp;&nbsp;<sup>[why these tags?](https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#automatic-tags-from-changed-files)</sup>" "$FORMATTED_TAGS" "$WARN_FMT")
+NEW_COMMENT=$(printf "${COMMENT_MARKER}\n${RED_ALERT_NOTE}\n\n**E2E Tests** 🚀\nThis PR will run tests tagged with: %s%s%b\n\n<sup>[readme](https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags)</sup>&nbsp;&nbsp;<sup>[valid tags](https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts)</sup>" "$FORMATTED_TAGS" "$WHY_BLOCK" "$WARN_FMT")
 
 if [ -n "$COMMENT_ID" ]; then
   # Update the existing comment

--- a/scripts/pr-e2e-comment.sh
+++ b/scripts/pr-e2e-comment.sh
@@ -105,8 +105,8 @@ fi
 # newlines only when present so it separates cleanly from the tags line and
 # collapses to nothing otherwise. Real newlines -> rendered with %s below.
 WHY_BLOCK="$(render_why_these_tags "$TAG_REASONS")"
-if [[ -n "$WHY_BLOCK" ]]; then
-	WHY_BLOCK=$'\n\n'"$WHY_BLOCK"
+if [ -n "$WHY_BLOCK" ]; then
+  WHY_BLOCK=$'\n\n'"$WHY_BLOCK"
 fi
 
 # Build the new comment body with proper newlines (%s = tags, %b = warnings).

--- a/scripts/pr-tags-parse.sh
+++ b/scripts/pr-tags-parse.sh
@@ -105,6 +105,14 @@ if echo "$PR_BODY" | grep -q "@:remote-ssh"; then
 	echo "remote_ssh_tag_found=true" >> "$GITHUB_OUTPUT"
 fi
 
+# Provenance inputs for build_tag_reasons, defaulted so the @:all branch (which
+# skips the else block that sets them) and any skipped derivation still resolve.
+AUTHOR_TAGS=""
+MAP_TAGS=""
+ARK_INJECTED="false"
+ADDED_WIN="false"
+ADDED_WEB="false"
+
 # Check if @:all is present in the PR body
 if echo "$PR_BODY" | grep -q "@:all"; then
 	echo "Found @:all tag in PR body. Setting tags to run all tests."
@@ -132,6 +140,10 @@ else
 	fi
 	echo "invalid_tags=$INVALID_TAGS" >> "$GITHUB_OUTPUT"
 
+	# Snapshot the author-typed valid tags (post-validation, pre-injection) so
+	# build_tag_reasons can label them "PR description".
+	AUTHOR_TAGS="$TAGS"
+
 	# Always add @:critical if not already included
 	if [[ ! "$TAGS" =~ "@:critical" ]]; then
 		if [[ -n "$TAGS" ]]; then
@@ -151,6 +163,7 @@ else
 		echo "Warning: could not fetch changed files; skipping @:ark injection."
 	elif echo "$CHANGED_FILES" | grep -qxF "extensions/positron-r/ark"; then
 		echo "Ark submodule changed. Injecting @:ark tag."
+		ARK_INJECTED="true"
 		if [[ -n "$TAGS" ]]; then
 			TAGS="$TAGS,@:ark"
 		else
@@ -247,6 +260,15 @@ echo "unmapped_dirs=$(printf '%s' "$UNMAPPED_DIRS" | paste -sd, -)" >> "$GITHUB_
 # empty list collapses any repeats so neither the --grep nor the PR comment shows
 # a tag twice.
 TAGS="$(union_csv_tags "$TAGS" "")"
+
+# Per-tag provenance for the PR comment's "Why these tags?" collapse. An empty
+# TAGS means the author wrote @:all (run everything) -- label it as a body tag.
+if [[ -z "$TAGS" ]]; then
+	TAG_REASONS="@:all|body"
+else
+	TAG_REASONS="$(build_tag_reasons "$TAGS" "$AUTHOR_TAGS" "$MAP_TAGS" "$ARK_INJECTED" "$ADDED_WIN" "$ADDED_WEB")"
+fi
+echo "tag_reasons=$TAG_REASONS" >> "$GITHUB_OUTPUT"
 
 # Save tags to GITHUB_OUTPUT for use in GitHub Actions
 if [[ -n "$GITHUB_OUTPUT" ]]; then

--- a/scripts/test/pr-tags-lib-test.sh
+++ b/scripts/test/pr-tags-lib-test.sh
@@ -673,6 +673,26 @@ if printf '%s' "$ALL_OUT" | grep -qF '| `@:all` | PR description |'; then
 else
 	echo "FAIL: render should annotate @:all as PR description"; fail=1
 fi
+# The ark / test-win / test-web label arms: one assertion each so a typo or
+# label change in those arms is caught (they aren't exercised by the cases above).
+ARK_OUT="$(render_why_these_tags "@:critical|required,@:ark|ark")"
+if printf '%s' "$ARK_OUT" | grep -qF '| `@:ark` | Ark submodule bump |'; then
+	echo "PASS: render labels the ark arm"
+else
+	echo "FAIL: render should label @:ark as Ark submodule bump"; fail=1
+fi
+WIN_OUT="$(render_why_these_tags "@:critical|required,@:win|test-win")"
+if printf '%s' "$WIN_OUT" | grep -qF '| `@:win` | New test (tags.WIN) |'; then
+	echo "PASS: render labels the test-win arm"
+else
+	echo "FAIL: render should label @:win as New test (tags.WIN)"; fail=1
+fi
+WEB_OUT="$(render_why_these_tags "@:critical|required,@:web|test-web")"
+if printf '%s' "$WEB_OUT" | grep -qF '| `@:web` | New test (tags.WEB) |'; then
+	echo "PASS: render labels the test-web arm"
+else
+	echo "FAIL: render should label @:web as New test (tags.WEB)"; fail=1
+fi
 
 [[ $fail -eq 0 ]] && echo "ALL PASS"
 exit $fail

--- a/scripts/test/pr-tags-lib-test.sh
+++ b/scripts/test/pr-tags-lib-test.sh
@@ -633,5 +633,43 @@ assert_eq "reasons: scan-added web is test-web" "@:critical|required,@:web|test-
 assert_eq "reasons: empty final yields nothing" "" \
 	"$(build_tag_reasons "" "" "" "false" "false" "false")"
 
+# --- render_why_these_tags ---
+assert_eq "render: critical-only is not informative (empty)" "" \
+	"$(render_why_these_tags "@:critical|required")"
+assert_eq "render: empty input yields nothing" "" \
+	"$(render_why_these_tags "")"
+RENDER_OUT="$(render_why_these_tags "@:critical|required,@:quarto|body,@:console|files")"
+if printf '%s' "$RENDER_OUT" | grep -qF "<summary>Why these tags?</summary>"; then
+	echo "PASS: render includes the collapse summary"
+else
+	echo "FAIL: render should include the collapse summary"; fail=1
+fi
+if printf '%s' "$RENDER_OUT" | grep -qF '| `@:critical` | Always runs (required) |'; then
+	echo "PASS: render annotates critical as required"
+else
+	echo "FAIL: render should annotate critical as required"; fail=1
+fi
+if printf '%s' "$RENDER_OUT" | grep -qF '| `@:quarto` | PR description |'; then
+	echo "PASS: render annotates an author tag as PR description"
+else
+	echo "FAIL: render should annotate the author tag"; fail=1
+fi
+if printf '%s' "$RENDER_OUT" | grep -qF '| `@:console` | Changed files |'; then
+	echo "PASS: render annotates a map tag as Changed files"
+else
+	echo "FAIL: render should annotate the map tag"; fail=1
+fi
+if printf '%s' "$RENDER_OUT" | grep -qF "#automatic-tags-from-changed-files"; then
+	echo "PASS: render moves the why-these-tags link into the collapse"
+else
+	echo "FAIL: render should include the README link inside the collapse"; fail=1
+fi
+ALL_OUT="$(render_why_these_tags "@:all|body")"
+if printf '%s' "$ALL_OUT" | grep -qF '| `@:all` | PR description |'; then
+	echo "PASS: render handles the @:all case"
+else
+	echo "FAIL: render should annotate @:all as PR description"; fail=1
+fi
+
 [[ $fail -eq 0 ]] && echo "ALL PASS"
 exit $fail

--- a/scripts/test/pr-tags-lib-test.sh
+++ b/scripts/test/pr-tags-lib-test.sh
@@ -632,6 +632,9 @@ assert_eq "reasons: scan-added web is test-web" "@:critical|required,@:web|test-
 	"$(build_tag_reasons "@:critical,@:web" "" "" "false" "false" "true")"
 assert_eq "reasons: empty final yields nothing" "" \
 	"$(build_tag_reasons "" "" "" "false" "false" "false")"
+# A tag matching no source falls through to the defensive "auto" fallback.
+assert_eq "reasons: unattributed tag falls back to auto" "@:critical|required,@:mystery|auto" \
+	"$(build_tag_reasons "@:critical,@:mystery" "" "" "false" "false" "false")"
 
 # --- render_why_these_tags ---
 assert_eq "render: critical-only is not informative (empty)" "" \

--- a/scripts/test/pr-tags-lib-test.sh
+++ b/scripts/test/pr-tags-lib-test.sh
@@ -610,5 +610,28 @@ else
 fi
 rm -rf "$APPLY_DIR"
 
+# --- build_tag_reasons ---
+assert_eq "reasons: critical is required" "@:critical|required" \
+	"$(build_tag_reasons "@:critical" "" "" "false" "false" "false")"
+assert_eq "reasons: author tag is body" "@:critical|required,@:quarto|body" \
+	"$(build_tag_reasons "@:critical,@:quarto" "@:quarto" "" "false" "false" "false")"
+assert_eq "reasons: map tag is files" "@:critical|required,@:console|files" \
+	"$(build_tag_reasons "@:critical,@:console" "" "@:console" "false" "false" "false")"
+# Author + map overlap: explicit author intent (body) wins over files.
+assert_eq "reasons: author+map overlap prefers body" "@:critical|required,@:console|body" \
+	"$(build_tag_reasons "@:critical,@:console" "@:console" "@:console" "false" "false" "false")"
+assert_eq "reasons: ark injection" "@:critical|required,@:ark|ark" \
+	"$(build_tag_reasons "@:critical,@:ark" "" "" "true" "false" "false")"
+# @:win typed in the body reads as body, not test-win.
+assert_eq "reasons: author-typed win is body" "@:critical|required,@:win|body" \
+	"$(build_tag_reasons "@:critical,@:win" "@:win" "" "false" "true" "false")"
+# @:win added only by the test scan reads as test-win.
+assert_eq "reasons: scan-added win is test-win" "@:critical|required,@:win|test-win" \
+	"$(build_tag_reasons "@:critical,@:win" "" "" "false" "true" "false")"
+assert_eq "reasons: scan-added web is test-web" "@:critical|required,@:web|test-web" \
+	"$(build_tag_reasons "@:critical,@:web" "" "" "false" "false" "true")"
+assert_eq "reasons: empty final yields nothing" "" \
+	"$(build_tag_reasons "" "" "" "false" "false" "false")"
+
 [[ $fail -eq 0 ]] && echo "ALL PASS"
 exit $fail


### PR DESCRIPTION
### Summary
Adds a collapsible "Why these tags?" section to the E2E PR comment showing the source (**required**, **pr description**, **src file change**) of each auto-selected tag, so reviewers can easily understand the derivation without having to dig through the job logs.

### QA Notes
<img width="910" height="264" alt="Screenshot 2026-07-08 at 3 44 01 PM" src="https://github.com/user-attachments/assets/cd5e5ec3-e59f-4536-bba0-908bcfae4b76" />
<img width="928" height="421" alt="Screenshot 2026-07-08 at 3 43 53 PM" src="https://github.com/user-attachments/assets/53d91082-9b57-4691-a96c-f23943b2f4b4" />

