### PR TITLE
E2E test: make wb path selection more robust (again)

### DIFF
--- a/test/e2e/pages/workbench/dashboard.page.ts
+++ b/test/e2e/pages/workbench/dashboard.page.ts
@@ -86,13 +86,37 @@ export class DashboardPage {
 		await this.code.driver.currentPage.getByRole('button', { name: 'Open Folder', exact: true }).click();
 		await this.quickInput.waitForQuickInputOpened();
 
-		// When the picker opens already pointed at the target folder, its path is prefilled
-		// in the input box and the list shows the folder's *contents* (no row matches the
-		// folder name), so selectQuickInputElementContaining would fail. In that case just
-		// confirm with OK; otherwise navigate to the folder first.
+		// The Open Folder picker can open in one of two states depending on the Workbench
+		// build and timing:
+		//   - prefilled *inside* the target folder: the input path ends with the folder name
+		//     and the list shows the folder's *contents* (no row matches the folder name);
+		//     confirming with OK opens it.
+		//   - opened at the *parent*: the list shows a row for the folder that must be
+		//     selected first.
+		// Reading the input value immediately after the picker opens races the (slower) stable
+		// Workbench build still prefilling the path -- it returns '' or the parent path, so we
+		// wrongly try to select a folder row that never appears and time out. Wait for the
+		// picker to settle into either recognizable state before deciding what to do. Reading
+		// the actual prefilled path (rather than hard-coding a home dir) keeps this correct for
+		// both the user1 dashboard flow and the Azure JIT user's differing home directory.
 		const input = this.code.driver.currentPage.locator('.quick-input-widget .quick-input-box input');
-		const currentPath = (await input.inputValue().catch(() => '')).replace(/\/$/, '');
-		if (!currentPath.endsWith(`/${folderToOpen}`)) {
+		// Match how selectQuickInputElementContaining targets the row (aria-label *contains* the
+		// folder name), so "parent" detection agrees with the row we would go on to select.
+		const folderRow = this.code.driver.currentPage
+			.locator(`.quick-input-widget .quick-input-list .monaco-list-row[aria-label*="${folderToOpen}"]`)
+			.first();
+
+		let prefilledInsideFolder = false;
+		await expect(async () => {
+			const currentPath = (await input.inputValue().catch(() => '')).replace(/\/$/, '');
+			if (currentPath.endsWith(`/${folderToOpen}`)) {
+				prefilledInsideFolder = true;
+				return;
+			}
+			await expect(folderRow).toBeVisible({ timeout: 250 });
+		}).toPass({ timeout: 10000 });
+
+		if (!prefilledInsideFolder) {
 			await this.quickInput.selectQuickInputElementContaining(folderToOpen);
 		}
 		await this.quickInput.clickOkButton();


### PR DESCRIPTION
## Summary

Fixes four flaky `@:workbench-stable` e2e tests that time out opening the workspace
folder in the nightly "workbench ubuntu stable" run. All four fail identically:

    TimeoutError: locator.textContent: Timeout 30000ms exceeded.
    waiting for locator('... .monaco-list-row[aria-label*="test-files"]')
    at pages/quickInput.ts:206 (selectQuickInputElementContaining)
    called from pages/workbench/dashboard.page.ts (openWorkspaceFolder)

The same tests pass in the non-stable ("daily") workbench run. Both runs use the
same Positron binary and the same test code; they differ only in the Posit
Workbench server version. So this is a Workbench timing difference, not a Positron
or test-code bug. It began surfacing after `qa-example-content` was merged and the
opened workspace folder was renamed from `qa-example-content` to `test-files`.

## Root cause

`DashboardPage.openWorkspaceFolder()` read `input.inputValue()` immediately after
`waitForQuickInputOpened()` and branched on it:

- If the input path already ended with the folder name -> click OK (picker opened
  prefilled *inside* the folder, showing its contents).
- Otherwise -> select a row named after the folder (picker opened at the *parent*).

On the stable Workbench build the picker takes longer to prefill its path, so the
value read races the prefill and comes back `''` (or the parent path). The guard is
then false, the code tries to select a `test-files` row that never exists in the
contents view, and it times out.

## Fix

Wait for the picker to settle into one of its two recognizable states before
deciding what to do, using an `expect(...).toPass()` poll:

- Input path ends with the target folder -> confirm with OK.
- A row for the folder becomes visible -> select it, then OK.

The row-detection selector mirrors what `selectQuickInputElementContaining` targets
(`aria-label*="<folder>"`), so the "parent" detection agrees with the row that would
actually be selected.

### Why not "fill an absolute path"

An alternative was to skip the heuristic and `input.fill('/home/user1/<folder>')`.
That hard-codes `user1`'s home, but `openWorkspaceFolder()` has two callers with
different home directories:

- the standard dashboard flow (`/home/user1/test-files`)
- the Azure JIT user `rstudio-ide-test` (`/home/rstudio-ide-test/test-files`)

Reading the picker's actual prefilled path keeps the fix correct for both, and for
either picker-initial-state, without hard-coding a home dir.

## Testing

- ESLint and `tsc --noEmit -p test/e2e/tsconfig.json`: clean.
- Reasoned through all cases (stable-prefilled, daily-parent, daily-already-inside,
  Azure JIT user); each opens the folder rather than merely suppressing the timeout.
- Will validate against the stable Workbench build in CI.

## E2E test tags

@:workbench-stable
@:workbench