### PR TITLE
Patch release repair

### DIFF
--- a/src/tsconfig.monaco.json
+++ b/src/tsconfig.monaco.json
@@ -37,6 +37,8 @@
 		"vs/platform/telemetry/*",
 		"vs/platform/assignment/*",
 		"vs/platform/terminal/*",
-		"vs/platform/externalTerminal/*"
+		"vs/platform/externalTerminal/*",
+		"vs/base/browser/*.tsx", // <-- add
+		"vs/platform/*/browser/*.tsx" // <-- add (covers platform-level React helpers too)
 	]
 }

--- a/src/vs/platform/environment/common/environmentService.ts
+++ b/src/vs/platform/environment/common/environmentService.ts
@@ -75,7 +75,7 @@ export abstract class AbstractNativeEnvironmentService implements INativeEnviron
 			const key = toLocalISOString(new Date()).replace(/-|:|\.\d+Z$/g, '');
 			// --- Start PWB ---
 			// Change this.args.logsPath from userDataPath to XDG_STATE_HOME if available, otherwise use ~/.local/state for logs
-			const userStatePath = process.env['XDG_STATE_HOME'];
+			const userStatePath = env['XDG_STATE_HOME'];
 			const productName = this.productService.applicationName;
 			if (userStatePath) {
 				this.args.logsPath = join(userStatePath, productName, 'logs', key);


### PR DESCRIPTION
## Fix monaco-compile-check failures

`monaco-compile-check` (type-checks the standalone, React-free Monaco editor via `src/tsconfig.monaco.json`, which has no `jsx`) was failing on two unrelated issues.

### 1. React `.tsx` pulled into the Monaco type-check (TS6142)
`tsconfig.monaco.json`'s `include` (`vs/base/browser/*`, `vs/platform/*/browser/*`) swept in Positron's React helpers that live under those folders (e.g. `positronReactServices.tsx`, `positronReactRendererContext.tsx`, `positronModalDialogReactRenderer.tsx`). With no `jsx` set, resolving these `.tsx` imports produced `TS6142: ... but '--jsx' is not set`.

Fix: exclude `.tsx` from the Monaco compile by adding `vs/base/browser/*.tsx` and `vs/platform/*/browser/*.tsx` to `exclude` in `src/tsconfig.monaco.json`. Only other React `.tsx` files import these, so no Monaco-core `.ts` dependency is affected.

### 2. Node `process` global in a Monaco-included common file (TS2591)
**This might or might not be necessary. It was necessary locally on my machine.**
A PWB patch in `src/vs/platform/environment/common/environmentService.ts` used `process.env['XDG_STATE_HOME']`. That file is in Monaco's include (`vs/platform/*/common/*`), and the Monaco compile has no `@types/node`, so `process` was undefined (`TS2591: Cannot find name 'process'`).

Fix: use the already-imported browser-safe `env` shim from `vs/base/common/process.js` (`env['XDG_STATE_HOME']`). Same runtime behavior in the native context; no Node types required.

### Verification

`npm run monaco-compile-check` (from `/positron` root folder) passes (exit 0, no errors).
