### PR TITLE
don't run copilot e2e tests on web

### DIFF
--- a/test/e2e/tests/assistant/copilot-provider-disabled-status.test.ts
+++ b/test/e2e/tests/assistant/copilot-provider-disabled-status.test.ts
@@ -26,7 +26,7 @@ const STATUS_ITEM = '.statusbar-item[id="chat.statusBarEntry"]';
 // The disabled state renders the copilot-unavailable codicon; a stable, state-specific marker.
 const DISABLED_ICON = `${STATUS_ITEM} .codicon-copilot-unavailable`;
 
-test.describe('Assistant: Copilot status reflects the provider setting', { tag: [tags.ASSISTANT, tags.WEB] }, () => {
+test.describe('Assistant: Copilot status reflects the provider setting', { tag: [tags.ASSISTANT] }, () => {
 
 	test.afterEach(async ({ settings }) => {
 		// Restore the fixture default (the provider is enabled by default).

--- a/test/e2e/tests/assistant/copilot-signin-suppressed.test.ts
+++ b/test/e2e/tests/assistant/copilot-signin-suppressed.test.ts
@@ -39,7 +39,7 @@ const EDITOR_PRESETUP_ITEMS = ['Explain', 'Fix', 'Code Review'];
 const HIDE_AI_COMMAND = 'Learn How to Hide AI Features';
 const USE_AI_FEATURES_COMMAND = 'Use AI Features with Copilot for free';
 
-test.describe('Assistant: Copilot setup on-ramp suppressed', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB] }, () => {
+test.describe('Assistant: Copilot setup on-ramp suppressed', { tag: [tags.WIN, tags.ASSISTANT] }, () => {
 
 	test('Command palette does not list the Copilot "Use AI Features with Copilot for free..." command', async function ({ app }) {
 		const { hotKeys, quickInput } = app.workbench;
@@ -65,7 +65,7 @@ test.describe('Assistant: Copilot setup on-ramp suppressed', { tag: [tags.WIN, t
 // already hidden by that gate. We turn AI features on so the gate passes and the dropped menu /
 // f1 entries are the only thing keeping them out of view; otherwise the assertions would pass
 // trivially. The default is restored afterward.
-test.describe('Assistant: Copilot sign-in surfaces suppressed with AI features on', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB] }, () => {
+test.describe('Assistant: Copilot sign-in surfaces suppressed with AI features on', { tag: [tags.WIN, tags.ASSISTANT] }, () => {
 
 	test.beforeAll(async ({ settings }) => {
 		await settings.set({ 'chat.disableAIFeatures': false }, { reload: true });


### PR DESCRIPTION
test/e2e/tests/assistant/copilot-provider-disabled-status.test.ts is new as of https://github.com/posit-dev/positron/pull/14764 but it is flaking on web

the copilot extension flakily doesn't activate in our web tests, so let's just not run the copilot e2e tests on web

@:assistant

also made this change to https://github.com/posit-dev/positron/pull/14794