### PR TITLE
E2E test: cleanup refs to qa-example-content from merged positron-ci-images

### DIFF
--- a/docker/images/README.md
+++ b/docker/images/README.md
@@ -19,7 +19,7 @@ This repository contains Docker images used for Positron continuous integration 
 These Docker images provide consistent testing environments for Positron across different architectures. They include:
 
 - Build dependencies
-- Required installations or R and Python, including packages from qa-example-content
+- Required installations of R and Python, including packages used by the e2e test content (`test/e2e/test-files`)
 - Runtime test dependencies such as Quarto
 - The positron license server
 - Fluxbox and x11vnc for locally viewing running tests

--- a/docker/images/SLES15_6/Dockerfile.SLES15_6
+++ b/docker/images/SLES15_6/Dockerfile.SLES15_6
@@ -211,8 +211,8 @@ ENV PATH="/root/.local/bin:$PATH"
 RUN uv venv --python=3.10.12 /root/.venv && \
     curl -sS https://bootstrap.pypa.io/get-pip.py | /root/.venv/bin/python
 
-# Install qa-example-content deps into that Python 3.10.12 env
-RUN curl -O https://raw.githubusercontent.com/posit-dev/qa-example-content/main/requirements.txt && \
+# Install the e2e test-content Python deps into that Python 3.10.12 env
+RUN curl -O https://raw.githubusercontent.com/posit-dev/positron/main/test/e2e/test-files/requirements.txt && \
     uv pip install --python /root/.venv/bin/python --break-system-packages -r requirements.txt && \
     /root/.venv/bin/python -m pip list
 
@@ -249,8 +249,8 @@ RUN ARCH_NAME=$(uname -m) && \
         R_REPO="https://packagemanager.posit.co/cran/__linux__/opensuse156/${PPM_SNAPSHOT}"; \
     fi && \
     export MAKEFLAGS="-j$(nproc)" && \
-    git clone --depth 1 https://github.com/posit-dev/qa-example-content.git /tmp/qa-example-content && \
-    cd /tmp/qa-example-content && \
+    mkdir -p /tmp/test-content && cd /tmp/test-content && \
+    curl -O https://raw.githubusercontent.com/posit-dev/positron/main/test/e2e/test-files/DESCRIPTION && \
     Rscript -e "options(repos=c(CRAN='${R_REPO}'), pak.no_build_vignettes=TRUE, pkg.sysreqs=FALSE, pkg.install.extra=c('--no-multiarch'), pkgType='${PKG_TYPE}'); \
     pak::local_install_dev_deps(ask=FALSE, dependencies=TRUE, lib=Sys.getenv('R_LIBS_SITE'))"
 

--- a/docker/images/debian/Dockerfile.debian12
+++ b/docker/images/debian/Dockerfile.debian12
@@ -147,8 +147,8 @@ ENV PATH="/root/.local/bin:$PATH"
 RUN uv venv --python=3.10.12 /root/.venv && \
     curl -sS https://bootstrap.pypa.io/get-pip.py | /root/.venv/bin/python
 
-# Install qa-example-content deps into that Python 3.10.12 env
-RUN curl -O https://raw.githubusercontent.com/posit-dev/qa-example-content/main/requirements.txt && \
+# Install the e2e test-content Python deps into that Python 3.10.12 env
+RUN curl -O https://raw.githubusercontent.com/posit-dev/positron/main/test/e2e/test-files/requirements.txt && \
     uv pip install --python /root/.venv/bin/python --break-system-packages -r requirements.txt && \
     /root/.venv/bin/python -m pip list
 
@@ -189,8 +189,8 @@ RUN ARCH_NAME=$(uname -m) && \
         PKG_TYPE="both"; \
         R_REPO="https://packagemanager.posit.co/cran/__linux__/bookworm/${PPM_SNAPSHOT}"; \
     fi && \
-    git clone --depth 1 https://github.com/posit-dev/qa-example-content.git /tmp/qa-example-content && \
-    cd /tmp/qa-example-content && \
+    mkdir -p /tmp/test-content && cd /tmp/test-content && \
+    curl -O https://raw.githubusercontent.com/posit-dev/positron/main/test/e2e/test-files/DESCRIPTION && \
     Rscript -e "options(repos=c(CRAN='${R_REPO}'), pak.no_build_vignettes=TRUE, pkg.sysreqs=FALSE, pkg.install.extra=c('--no-multiarch'), pkgType='${PKG_TYPE}'); \
     pak::local_install_dev_deps(ask=FALSE, dependencies=TRUE, lib=Sys.getenv('R_LIBS_SITE'))"
 

--- a/docker/images/debian/README.md
+++ b/docker/images/debian/README.md
@@ -18,4 +18,4 @@ The PostgreSQL database image is built from the shared [`../postgres/`](../postg
 This docker image is used in GitHub Actions workflows for testing Positron. This includes the PR, Merge, Full Suite, Release, and Extension Verification workflows.
 
 ## Local Development
-See the [Debian 12 Local ARM](https://github.com/posit-dev/qa-example-content/tree/main/dockerfiles/arm-local) for details.
+See the [Debian 12 Local ARM](../../environments/arm-local/) for details.

--- a/docker/images/openSUSE15_6/Dockerfile.openSUSE15_6
+++ b/docker/images/openSUSE15_6/Dockerfile.openSUSE15_6
@@ -185,8 +185,8 @@ ENV PATH="/root/.local/bin:$PATH"
 RUN uv venv --python=3.10.12 /root/.venv && \
     curl -sS https://bootstrap.pypa.io/get-pip.py | /root/.venv/bin/python
 
-# Install qa-example-content deps into that Python 3.10.12 env
-RUN curl -O https://raw.githubusercontent.com/posit-dev/qa-example-content/main/requirements.txt && \
+# Install the e2e test-content Python deps into that Python 3.10.12 env
+RUN curl -O https://raw.githubusercontent.com/posit-dev/positron/main/test/e2e/test-files/requirements.txt && \
     uv pip install --python /root/.venv/bin/python --break-system-packages -r requirements.txt && \
     /root/.venv/bin/python -m pip list
 
@@ -223,8 +223,8 @@ RUN ARCH_NAME=$(uname -m) && \
         R_REPO="https://packagemanager.posit.co/cran/__linux__/opensuse156/${PPM_SNAPSHOT}"; \
     fi && \
     export MAKEFLAGS="-j$(nproc)" && \
-    git clone --depth 1 https://github.com/posit-dev/qa-example-content.git /tmp/qa-example-content && \
-    cd /tmp/qa-example-content && \
+    mkdir -p /tmp/test-content && cd /tmp/test-content && \
+    curl -O https://raw.githubusercontent.com/posit-dev/positron/main/test/e2e/test-files/DESCRIPTION && \
     Rscript -e "options(repos=c(CRAN='${R_REPO}'), pak.no_build_vignettes=TRUE, pkg.sysreqs=FALSE, pkg.install.extra=c('--no-multiarch'), pkgType='${PKG_TYPE}'); \
     pak::local_install_dev_deps(ask=FALSE, dependencies=TRUE, lib=Sys.getenv('R_LIBS_SITE'))"
 

--- a/docker/images/rocky_8/Dockerfile.rocky_8
+++ b/docker/images/rocky_8/Dockerfile.rocky_8
@@ -250,8 +250,8 @@ ENV PATH="/root/.local/bin:${PATH}"
 RUN uv venv --python=3.10.12 /root/.venv && \
     curl -sS https://bootstrap.pypa.io/get-pip.py | /root/.venv/bin/python
 
-# Install qa-example-content deps into that Python 3.10 env
-RUN curl -fsSL https://raw.githubusercontent.com/posit-dev/qa-example-content/main/requirements.txt -o /tmp/requirements.txt && \
+# Install the e2e test-content Python deps into that Python 3.10 env
+RUN curl -fsSL https://raw.githubusercontent.com/posit-dev/positron/main/test/e2e/test-files/requirements.txt -o /tmp/requirements.txt && \
     grep -v '^bokeh' /tmp/requirements.txt > /tmp/requirements-filtered.txt && \
     uv pip install --python /root/.venv/bin/python \
       -r /tmp/requirements-filtered.txt \
@@ -350,8 +350,8 @@ RUN GEOS_PREFIX=/opt/geos \
     Rscript -e 'pak::pkg_install("sf@1.0-20", lib = Sys.getenv("R_LIBS_SITE"))'
 
 # Install the project dev deps to the same site library via pak
-RUN git clone --depth 1 https://github.com/posit-dev/qa-example-content.git /tmp/qa-example-content && \
-    cd /tmp/qa-example-content && \
+RUN mkdir -p /tmp/test-content && cd /tmp/test-content && \
+    curl -O https://raw.githubusercontent.com/posit-dev/positron/main/test/e2e/test-files/DESCRIPTION && \
     GEOS_PREFIX=/opt/geos \
     GDAL_PREFIX=/opt/gdal \
     LIBGIT2_PREFIX=/opt/libgit2 \

--- a/docker/images/ubuntu24_04/Dockerfile.ubuntu24_04
+++ b/docker/images/ubuntu24_04/Dockerfile.ubuntu24_04
@@ -146,8 +146,8 @@ ENV PATH="/root/.local/bin:$PATH"
 RUN uv venv --python=3.10.12 /root/.venv && \
     curl -sS https://bootstrap.pypa.io/get-pip.py | /root/.venv/bin/python
 
-# Install qa-example-content deps into that Python 3.10.12 env
-RUN curl -O https://raw.githubusercontent.com/posit-dev/qa-example-content/main/requirements.txt && \
+# Install the e2e test-content Python deps into that Python 3.10.12 env
+RUN curl -O https://raw.githubusercontent.com/posit-dev/positron/main/test/e2e/test-files/requirements.txt && \
     uv pip install --python /root/.venv/bin/python --break-system-packages -r requirements.txt && \
     /root/.venv/bin/python -m pip list
 
@@ -179,8 +179,8 @@ RUN rig add 4.5.2 && rig default 4.5.2 && \
 # noble's PPM repo serves arm64 binaries as well as amd64, so both arches use it
 # and nothing has to compile from source. The image's runtime .Rprofile/RSPM
 # stays on `latest`.
-RUN git clone --depth 1 https://github.com/posit-dev/qa-example-content.git /tmp/qa-example-content && \
-    cd /tmp/qa-example-content && \
+RUN mkdir -p /tmp/test-content && cd /tmp/test-content && \
+    curl -O https://raw.githubusercontent.com/posit-dev/positron/main/test/e2e/test-files/DESCRIPTION && \
     Rscript -e "options(repos=c(RSPM='https://packagemanager.posit.co/cran/__linux__/noble/${PPM_SNAPSHOT}'), pak.no_build_vignettes=TRUE, pkg.sysreqs=FALSE, pkg.install.extra=c('--no-multiarch')); \
     pak::local_install_dev_deps(ask=FALSE, dependencies=TRUE, lib=Sys.getenv('R_LIBS_SITE'))"
 

--- a/docker/images/ubuntu24_04/README.md
+++ b/docker/images/ubuntu24_04/README.md
@@ -18,4 +18,4 @@ The PostgreSQL database image is built from the shared [`../postgres/`](../postg
 This docker image is used in GitHub Actions workflows for testing Positron. This includes the PR, Merge, Full Suite, Release, and Extension Verification workflows.
 
 ## Local Development
-See the [Ubuntu 24.04 Local ARM](https://github.com/posit-dev/qa-example-content/tree/main/dockerfiles/arm-local) for details.
+See the [Ubuntu 24.04 Local ARM](../../environments/arm-local/) for details.

--- a/test/e2e/test-files/workspaces/assistant/README.md
+++ b/test/e2e/test-files/workspaces/assistant/README.md
@@ -2,7 +2,7 @@
 
 A home for various scripts, file and configurations to test the behaviour and affordances of Positron Assistant.
 
-In order to leverage the custom agents/prompts/instructions, this workspace must be opened directly, not just as part of the qa-example-content workspace.
+In order to leverage the custom agents/prompts/instructions, this workspace must be opened directly, not just as part of the larger e2e test-files workspace.
 
 ## Key Files
 

--- a/test/e2e/tests/test-explorer/test-explorer.test.ts
+++ b/test/e2e/tests/test-explorer/test-explorer.test.ts
@@ -14,8 +14,8 @@ test.use({
 
 test.describe('R Test Explorer', { tag: [tags.TEST_EXPLORER, tags.R_PKG_DEVELOPMENT, tags.ARK, tags.WEB, tags.WIN] }, () => {
 	// A toy R package fixture, incubated inside positron-r (beside the vscodereporter
-	// resources) to avoid cross-repo coordination with qa-example-content while the
-	// test explorer e2e stabilizes.
+	// resources) rather than in the shared e2e test-files, while the test explorer
+	// e2e stabilizes.
 	const FIXTURE_NAME = 'r.pkg.test.explorer.fixture';
 	const FIXTURE_SOURCE = path.join(process.cwd(), 'extensions/positron-r/resources/testing', FIXTURE_NAME);
 


### PR DESCRIPTION
## Summary

Finishes cleaning up references to the standalone `posit-dev/qa-example-content`
repo, which has been merged into Positron at `test/e2e/test-files/`. The prior
cleanup (#14791) covered `docker/environments`; when `positron-ci-images` was
merged in, its `docker/images` Dockerfiles/READMEs still pointed at the old repo.
This PR repoints those, plus two stale comments elsewhere in the tree.

## Changes

### `docker/images` Dockerfiles (ubuntu24_04, debian, SLES15_6, openSUSE15_6, rocky_8)

Each image installs the e2e test-content Python and R dependencies. Both sources
were repointed from `posit-dev/qa-example-content` to the in-repo path in
`posit-dev/positron`:

- **`requirements.txt`** now fetched from
  `raw.githubusercontent.com/posit-dev/positron/main/test/e2e/test-files/requirements.txt`.
- **R dev deps** previously did a full `git clone` of `qa-example-content` just to
  read its `DESCRIPTION`. Since `pak::local_install_dev_deps` only needs the
  `DESCRIPTION` in the working directory, the clone is replaced with a lightweight
  `curl` of `test/e2e/test-files/DESCRIPTION` (avoids cloning the entire, much
  larger `positron` repo).
- Comments updated accordingly.

### `docker/images` READMEs

- `README.md`: reworded the dependencies line to reference the e2e test content
  (also fixed an "or R" -> "of R" typo).
- `ubuntu24_04/README.md`, `debian/README.md`: "Local ARM" links now point at the
  in-repo `../../environments/arm-local/` (where the arm-local content landed after
  the merge) instead of the dead `qa-example-content/dockerfiles/arm-local` path.

### Stale comments

- `test/e2e/test-files/workspaces/assistant/README.md`: no longer refers to the
  defunct "qa-example-content workspace."
- `test/e2e/tests/test-explorer/test-explorer.test.ts`: dropped the now-obsolete
  "avoid cross-repo coordination with qa-example-content" rationale (it's the same
  repo now); kept the fact that the fixture lives in `positron-r/resources`.

## Notes

- The remaining `qa-example-content` mentions in the tree (`.gitignore`,
  `test-runner/utils.ts`, `test-files/README.md`, `build/filters.ts`) are
  intentional provenance notes documenting the merge and are left in place. One
  stale personal path survives in a pokemon notebook's saved output cell
  (`ds-workflow2.ipynb`); it's captured fixture output, not a live reference, so
  it's left as-is.
- `posit-dev/qa-example-content` is still a live public repo, so nothing was broken
  before this change; the point is to make the source of truth Positron.

## QA notes

Docker image changes can't be exercised by the standard e2e suite; they take
effect the next time the CI OS images are rebuilt via the
**CI Images: Build OS test images** workflow. The `test/e2e/test-files/requirements.txt`
and `DESCRIPTION` paths referenced by the new URLs are confirmed present on `main`.
