### PR TITLE
Add file browse to data connections dialog

### DIFF
--- a/extensions/positron-data-driver-duckdb/src/duckdbDriver.ts
+++ b/extensions/positron-data-driver-duckdb/src/duckdbDriver.ts
@@ -90,6 +90,7 @@ export function createDuckDBDriver(
 						type: positron.DataConnectionParameterType.File,
 						required: true,
 						placeholder: databasePathPlaceholder,
+						filters: { [vscode.l10n.t('DuckDB Files')]: ['duckdb', 'ddb'] },
 					},
 					{
 						id: 'readOnly',

--- a/extensions/positron-data-driver-sqlite/src/sqliteDriver.ts
+++ b/extensions/positron-data-driver-sqlite/src/sqliteDriver.ts
@@ -90,6 +90,7 @@ export function createSQLiteDriver(
 						type: positron.DataConnectionParameterType.File,
 						required: true,
 						placeholder: databasePathPlaceholder,
+						filters: { [vscode.l10n.t('SQLite Files')]: ['sqlite', 'sqlite3', 'db'] },
 					},
 					{
 						id: 'readOnly',

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2002,6 +2002,19 @@ declare module 'positron' {
 			type: DataConnectionParameterType.File;
 			defaultValue?: string;
 			placeholder?: string;
+
+			/**
+			 * File-type filters for the file picker opened by the field's Browse button, in the
+			 * same format as {@link vscode.OpenDialogOptions.filters}: each key is a human-readable
+			 * label and each value is a list of extensions without dots, for example:
+			 * ```ts
+			 * { 'SQLite Files': ['sqlite', 'sqlite3', 'db'] }
+			 * ```
+			 * Filters are shown in declaration order and the first one is the picker's default
+			 * selection. An "All Files" option is always appended, so drivers should not declare
+			 * one. When omitted, the picker shows "All Files" only.
+			 */
+			filters?: { [name: string]: string[] };
 		}
 		| {
 			type: DataConnectionParameterType.Number;

--- a/src/vs/platform/quickinput/browser/quickInputController.ts
+++ b/src/vs/platform/quickinput/browser/quickInputController.ts
@@ -152,9 +152,8 @@ export class QuickInputController extends Disposable {
 	 * with the quick input, so the reparent itself is gated on the parent already being correct.
 	 */
 	private handlePositronModal(applyInert = false) {
-		const modal = this.layoutService.activeContainer.getElementsByClassName('positron-modal-dialog-box');
-		if (modal.length && dom.isHTMLElement(modal.item(0)) && this.ui) {
-			const modalContainer = modal.item(0) as HTMLElement;
+		const modalContainer = this.getPositronModalContainer();
+		if (modalContainer && this.ui) {
 			if (!modalContainer.isSameNode(this.ui.container.parentNode)) {
 				// a Positron modal is open, the quick pick will need to set its parent to it
 				dom.append(modalContainer, this.ui.container);
@@ -181,6 +180,34 @@ export class QuickInputController extends Disposable {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Finds the open Positron modal (if any) that the quick input should render inside so it paints
+	 * above the dialog and participates in its focus scope. Two modal renderers exist:
+	 *
+	 * - The native <dialog> renderer calls showModal(), which places the dialog in the browser top
+	 *   layer. A top-layer element beats any z-index, so the quick input can only appear above it (and
+	 *   be focusable past the dialog's focus trap) by being a DOM descendant of the <dialog>. Preferred
+	 *   when present; the <dialog> is styled with overflow: visible so the quick input is not clipped.
+	 * - The older div-overlay renderer (.positron-modal-dialog-box) is an ordinary z-indexed element;
+	 *   reparenting into it works the same way and is kept as a fallback.
+	 *
+	 * @returns The element to host the quick input, or undefined when no Positron modal is open.
+	 */
+	private getPositronModalContainer(): HTMLElement | undefined {
+		// Prefer the top-most native <dialog>. showModal() sets the `open` attribute; when dialogs are
+		// nested the last one in DOM order is the top-most in the browser top layer.
+		// eslint-disable-next-line no-restricted-syntax -- the modal DOM is built by a separate renderer, so it must be located by selector rather than dom.ts h()
+		const dialogs = this.layoutService.activeContainer.querySelectorAll('dialog.positron-modal-dialog[open]');
+		const topDialog = dialogs.length ? dialogs[dialogs.length - 1] : undefined;
+		if (dom.isHTMLElement(topDialog)) {
+			return topDialog;
+		}
+		// Fall back to the older div-overlay modal.
+		// eslint-disable-next-line no-restricted-syntax -- the modal DOM is built by a separate renderer, so it must be located by selector rather than dom.ts h()
+		const overlayModal = this.layoutService.activeContainer.getElementsByClassName('positron-modal-dialog-box').item(0);
+		return dom.isHTMLElement(overlayModal) ? overlayModal : undefined;
 	}
 
 	private applyPositronModalInert(modalContainer: HTMLElement) {

--- a/src/vs/platform/quickinput/test/browser/quickinput.test.ts
+++ b/src/vs/platform/quickinput/test/browser/quickinput.test.ts
@@ -136,6 +136,27 @@ suite('QuickInput', () => { // https://github.com/microsoft/vscode/issues/147543
 		quickpick.hide();
 		assert.strictEqual(modalContent.inert, false);
 	});
+
+	test('quick input reparents into a native <dialog> modal so it renders above the top layer', () => {
+		// The native <dialog> renderer uses showModal(), placing the dialog in the browser top layer;
+		// the quick input must become a descendant of it to appear above and be focusable.
+		const dialog = document.createElement('dialog');
+		dialog.className = 'positron-modal-dialog';
+		dialog.setAttribute('open', '');
+		const modalContent = document.createElement('button');
+		dialog.appendChild(modalContent);
+		controller.container.appendChild(dialog);
+		store.add(toDisposable(() => dialog.remove()));
+
+		const quickpick = store.add(controller.createQuickPick());
+
+		quickpick.show();
+		assert.ok(dialog.querySelector('.quick-input-widget'), 'quick input should be reparented into the dialog');
+		assert.strictEqual(modalContent.inert, true);
+
+		quickpick.hide();
+		assert.strictEqual(modalContent.inert, false);
+	});
 	// --- End Positron ---
 
 	test('pick - basecase', async () => {

--- a/src/vs/workbench/api/browser/positron/mainThreadDataConnections.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadDataConnections.ts
@@ -20,7 +20,13 @@ function dtoToServiceParameter(dto: IDataConnectionParameterDTO): IDataConnectio
 		case 'boolean':
 			return { ...base, type: 'boolean', defaultValue: dto.defaultValue as boolean | undefined };
 		case 'file':
-			return { ...base, type: 'file', defaultValue: dto.defaultValue as string | undefined, placeholder: dto.placeholder };
+			return {
+				...base, type: 'file', defaultValue: dto.defaultValue as string | undefined, placeholder: dto.placeholder,
+				// Convert the wire-format filters dictionary (label -> extensions) to the ordered
+				// FileFilter array the file dialog service consumes. Insertion order is preserved,
+				// so the driver's first filter remains the picker's default selection.
+				filters: dto.filters && Object.entries(dto.filters).map(([name, extensions]) => ({ name, extensions })),
+			};
 		case 'number':
 			return { ...base, type: 'number', defaultValue: dto.defaultValue as number | undefined, placeholder: dto.placeholder };
 		case 'option':
@@ -46,6 +52,28 @@ function dtoToServiceMechanism(dto: IDataConnectionMechanismDTO): IDataConnectio
 		label: dto.label,
 		description: dto.description,
 		parameters: dto.parameters.map(dtoToServiceParameter),
+	};
+}
+
+/**
+ * Converts a service-level mechanism back to the wire DTO shape for driver summaries returned to
+ * the ext host. The service-level parameter variants are structurally assignable to the flat DTO
+ * except for the file variant's filters, which flatten from the ordered FileFilter array back to
+ * the wire's label -> extensions dictionary.
+ */
+function serviceMechanismToDto(mechanism: IDataConnectionMechanism): IDataConnectionMechanismDTO {
+	return {
+		...mechanism,
+		parameters: mechanism.parameters.map((parameter): IDataConnectionParameterDTO => {
+			if (parameter.type !== 'file') {
+				return parameter;
+			}
+			const { filters, ...rest } = parameter;
+			return {
+				...rest,
+				filters: filters && Object.fromEntries(filters.map(filter => [filter.name, filter.extensions])),
+			};
+		}),
 	};
 }
 
@@ -125,7 +153,7 @@ export class MainThreadDataConnections implements MainThreadDataConnectionsShape
 			id: driver.id,
 			name: driver.metadata.name,
 			description: driver.metadata.description,
-			mechanisms: driver.metadata.mechanisms,
+			mechanisms: driver.metadata.mechanisms.map(serviceMechanismToDto),
 			supportedLanguageIds: driver.metadata.supportedLanguageIds,
 		}));
 	}

--- a/src/vs/workbench/api/common/positron/extHostDataConnections.ts
+++ b/src/vs/workbench/api/common/positron/extHostDataConnections.ts
@@ -335,9 +335,13 @@ export class ExtHostDataConnections implements extHostProtocol.ExtHostDataConnec
 				}
 				break;
 			case 'number':
+				dto.defaultValue = p.defaultValue;
+				dto.placeholder = p.placeholder;
+				break;
 			case 'file':
 				dto.defaultValue = p.defaultValue;
 				dto.placeholder = p.placeholder;
+				dto.filters = p.filters;
 				break;
 			case 'boolean':
 				dto.defaultValue = p.defaultValue;

--- a/src/vs/workbench/api/test/browser/positron/mainThreadDataConnections.vitest.ts
+++ b/src/vs/workbench/api/test/browser/positron/mainThreadDataConnections.vitest.ts
@@ -1,0 +1,121 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { ensureNoLeakedDisposables } from '../../../../../test/vitest/vitestUtils.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { IExtHostContext } from '../../../../services/extensions/common/extHostCustomers.js';
+import { IPositronDataConnectionsService } from '../../../../services/positronDataConnections/common/interfaces/positronDataConnectionsService.js';
+import { IDataConnectionsDriverManager } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionsDriverManager.js';
+import { IDataConnectionDriver } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
+import { IDataConnectionDriverMetadataDTO } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDTOs.js';
+import { ExtHostDataConnectionsShape } from '../../../common/positron/extHost.positron.protocol.js';
+import { MainThreadDataConnections } from '../../../browser/positron/mainThreadDataConnections.js';
+
+describe('MainThreadDataConnections', () => {
+	const disposables = ensureNoLeakedDisposables();
+
+	// Driver metadata as an extension would declare it, with a file parameter carrying two
+	// file-picker filters (order matters: the first is the picker's default selection).
+	const metadataDto: IDataConnectionDriverMetadataDTO = {
+		id: 'duckdb',
+		name: 'DuckDB',
+		description: 'Connect to DuckDB databases',
+		iconSvg: '<svg/>',
+		supportedLanguageIds: ['python', 'r'],
+		mechanisms: [{
+			id: 'file',
+			label: 'Database File',
+			description: 'Connect to a database file',
+			parameters: [
+				{
+					id: 'databasePath',
+					label: 'Database File',
+					type: 'file',
+					required: true,
+					filters: { 'DuckDB Files': ['duckdb', 'ddb'], 'Backups': ['bak'] },
+				},
+				{ id: 'readOnly', label: 'Read Only', type: 'boolean', defaultValue: false },
+			],
+		}],
+	};
+
+	let registeredDrivers: IDataConnectionDriver[];
+	let mainThread: MainThreadDataConnections;
+
+	beforeEach(() => {
+		registeredDrivers = [];
+		const driverManager = stubInterface<IDataConnectionsDriverManager>({
+			registerDriver: driver => { registeredDrivers.push(driver); },
+			getDrivers: () => registeredDrivers,
+		});
+		const dataConnectionsService = stubInterface<IPositronDataConnectionsService>({ driverManager });
+		const extHostContext = stubInterface<IExtHostContext>({
+			getProxy: (<T>() => stubInterface<ExtHostDataConnectionsShape>({}) as T) as IExtHostContext['getProxy'],
+		});
+		mainThread = disposables.add(new MainThreadDataConnections(extHostContext, dataConnectionsService));
+	});
+
+	/**
+	 * Returns the file parameter of the single registered driver, narrowed to the file variant so
+	 * its filters are accessible.
+	 */
+	function registeredFileParameter() {
+		const parameter = registeredDrivers[0].metadata.mechanisms[0].parameters.find(p => p.type === 'file');
+		if (parameter?.type !== 'file') {
+			throw new Error('expected the registered driver to have a file parameter');
+		}
+		return parameter;
+	}
+
+	it('converts the file parameter filters dictionary to an ordered FileFilter array', () => {
+		mainThread.$registerDataConnectionDriver('duckdb', metadataDto);
+
+		expect(registeredFileParameter().filters).toMatchInlineSnapshot(`
+			[
+			  {
+			    "extensions": [
+			      "duckdb",
+			      "ddb",
+			    ],
+			    "name": "DuckDB Files",
+			  },
+			  {
+			    "extensions": [
+			      "bak",
+			    ],
+			    "name": "Backups",
+			  },
+			]
+		`);
+	});
+
+	it('round-trips driver mechanisms back to the wire shape in driver summaries', async () => {
+		mainThread.$registerDataConnectionDriver('duckdb', metadataDto);
+
+		const summaries = await mainThread.$getDataConnectionDrivers();
+
+		// The summary must equal what the extension declared: the FileFilter array flattens back
+		// to the label -> extensions dictionary and non-file parameters pass through untouched.
+		expect(summaries[0].mechanisms).toEqual(metadataDto.mechanisms);
+	});
+
+	it('leaves filters undefined across the boundary when the file parameter declares none', async () => {
+		const withoutFilters: IDataConnectionDriverMetadataDTO = {
+			...metadataDto,
+			mechanisms: [{
+				...metadataDto.mechanisms[0],
+				parameters: [{ id: 'databasePath', label: 'Database File', type: 'file', required: true }],
+			}],
+		};
+		mainThread.$registerDataConnectionDriver('duckdb', withoutFilters);
+
+		expect(registeredFileParameter().filters).toBeUndefined();
+
+		const summaries = await mainThread.$getDataConnectionDrivers();
+		expect(summaries[0].mechanisms[0].parameters[0].filters).toBeUndefined();
+	});
+});

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnection.css
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnection.css
@@ -100,6 +100,36 @@
 	outline-offset: 2px;
 }
 
+/* File parameter: text input paired with a Browse button on one row. */
+.configure-data-connection .parameter-file-input {
+	gap: 6px;
+	display: flex;
+	align-items: stretch;
+}
+
+.configure-data-connection .parameter-file-input .parameter-input {
+	flex: 1;
+	min-width: 0;
+}
+
+.configure-data-connection .parameter-file-input .browse-button {
+	padding: 0 8px;
+	white-space: nowrap;
+	border-radius: 4px;
+	color: var(--vscode-positronModalDialog-buttonForeground);
+	background: var(--vscode-positronModalDialog-buttonBackground);
+	border: 1px solid var(--vscode-button-border);
+}
+
+.configure-data-connection .parameter-file-input .browse-button:focus {
+	outline: none !important;
+}
+
+.configure-data-connection .parameter-file-input .browse-button:focus-visible {
+	outline-offset: 2px;
+	outline: 1px solid var(--vscode-focusBorder) !important;
+}
+
 .configure-data-connection .parameter-select {
 	height: 26px;
 }

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnection.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnection.tsx
@@ -205,6 +205,11 @@ export const ConfigureDataConnection = (props: ConfigureDataConnectionProps) => 
 			canSelectFolders: false,
 			canSelectMany: false,
 			filters: getFileDialogFilters(parameter?.type === 'file' ? parameter.filters : undefined),
+			// The chosen path is passed to the driver as a plain string and opened on the extension
+			// host's file system, so restrict the picker to that file system. Without this, the
+			// web/remote quick-pick dialog offers a "Show Local" button whose browser-local files
+			// the driver could never open.
+			availableFileSystems: [defaultFilePath.scheme],
 		});
 
 		// If the user made a selection, set the field to the chosen path, formatted for the platform

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnection.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnection.tsx
@@ -13,6 +13,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { localize } from '../../../../../nls.js';
 import { generateUuid } from '../../../../../base/common/uuid.js';
 import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
+import { FileFilter } from '../../../../../platform/dialogs/common/dialogs.js';
 import { combineLabelWithPathUri, pathUriToLabel } from '../../../../browser/utils/path.js';
 import { ConfigureDataConnectionParameters } from './configureDataConnectionParameters.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
@@ -39,6 +40,24 @@ export interface ParameterFieldState {
  * UI-side form state for all parameter fields.
  */
 export type ParameterFieldStates = Record<string, ParameterFieldState>;
+
+/**
+ * Builds the "Browse..." file-picker filters for a file parameter. The filters the driver declared
+ * on the parameter are listed first so the driver's file type is the default selection in the
+ * picker, followed by an "All Files" option for databases stored with a non-standard extension.
+ * Parameters that declare no filters get "All Files" only.
+ * @param declaredFilters The filters declared on the file parameter, if any.
+ * @returns The ordered list of file filters for the open dialog.
+ */
+export function getFileDialogFilters(declaredFilters: FileFilter[] | undefined): FileFilter[] {
+	return [
+		...declaredFilters ?? [],
+		{
+			name: localize('positron.configureDataConnection.allFiles', "All Files"),
+			extensions: ['*'],
+		},
+	];
+}
 
 /**
  * ConfigureDataConnectionProps interface.
@@ -175,7 +194,9 @@ export const ConfigureDataConnection = (props: ConfigureDataConnectionProps) => 
 			? await combineLabelWithPathUri(currentValue, defaultFilePath, pathService)
 			: defaultFilePath;
 
-		// Show the open dialog.
+		// Show the open dialog. The filters default to the file type the driver declared on the
+		// parameter (e.g. DuckDB files for the DuckDB driver), while still offering "All Files".
+		const parameter = props.mechanism.parameters.find(parameter => parameter.id === parameterId);
 		const uris = await fileDialogService.showOpenDialog({
 			title: localize('positron.configureDataConnection.selectFile', "Select File"),
 			defaultUri,
@@ -183,6 +204,7 @@ export const ConfigureDataConnection = (props: ConfigureDataConnectionProps) => 
 			canSelectFiles: true,
 			canSelectFolders: false,
 			canSelectMany: false,
+			filters: getFileDialogFilters(parameter?.type === 'file' ? parameter.filters : undefined),
 		});
 
 		// If the user made a selection, set the field to the chosen path, formatted for the platform
@@ -190,7 +212,7 @@ export const ConfigureDataConnection = (props: ConfigureDataConnectionProps) => 
 		if (uris?.length) {
 			setParameterFieldState(parameterId, pathUriToLabel(uris[0], labelService));
 		}
-	}, [fileDialogService, labelService, parameterFieldStates, pathService, setParameterFieldState]);
+	}, [fileDialogService, labelService, parameterFieldStates, pathService, props.mechanism.parameters, setParameterFieldState]);
 
 	// Cancel handler.
 	const cancelHandler = useCallback(() => {

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnection.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnection.tsx
@@ -13,6 +13,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { localize } from '../../../../../nls.js';
 import { generateUuid } from '../../../../../base/common/uuid.js';
 import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
+import { combineLabelWithPathUri, pathUriToLabel } from '../../../../browser/utils/path.js';
 import { ConfigureDataConnectionParameters } from './configureDataConnectionParameters.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { PositronModalDialogReactRenderer } from '../../../../../base/browser/positronModalDialogReactRenderer.js';
@@ -71,7 +72,7 @@ interface ConfigureDataConnectionProps {
  */
 export const ConfigureDataConnection = (props: ConfigureDataConnectionProps) => {
 	// Services.
-	const { positronDataConnectionsService } = usePositronReactServicesContext();
+	const { fileDialogService, labelService, pathService, positronDataConnectionsService } = usePositronReactServicesContext();
 
 	// Ref to the Connection Name input so we can drive initial focus to it (overriding the
 	// primary button's autoFocus, which fires during React commit before this effect runs).
@@ -161,6 +162,35 @@ export const ConfigureDataConnection = (props: ConfigureDataConnectionProps) => 
 			}
 		}));
 	}, []);
+
+	// Browse handler for file parameters. Opens a file picker (native on desktop, quick-picker on
+	// web/remote via IFileDialogService) and fills the field with the chosen path on selection.
+	const browseFileHandler = useCallback(async (parameterId: string) => {
+		// Seed the dialog's starting location from the current value when present, otherwise the
+		// default file path. defaultFilePath() yields a URI with the correct scheme/authority for
+		// local vs remote; combineLabelWithPathUri re-homes the typed path onto the server platform.
+		const currentValue = parameterFieldStates[parameterId]?.value;
+		const defaultFilePath = await fileDialogService.defaultFilePath();
+		const defaultUri = typeof currentValue === 'string' && currentValue.length > 0
+			? await combineLabelWithPathUri(currentValue, defaultFilePath, pathService)
+			: defaultFilePath;
+
+		// Show the open dialog.
+		const uris = await fileDialogService.showOpenDialog({
+			title: localize('positron.configureDataConnection.selectFile', "Select File"),
+			defaultUri,
+			openLabel: localize('positron.configureDataConnection.select', "Select"),
+			canSelectFiles: true,
+			canSelectFolders: false,
+			canSelectMany: false,
+		});
+
+		// If the user made a selection, set the field to the chosen path, formatted for the platform
+		// the server is running on.
+		if (uris?.length) {
+			setParameterFieldState(parameterId, pathUriToLabel(uris[0], labelService));
+		}
+	}, [fileDialogService, labelService, parameterFieldStates, pathService, setParameterFieldState]);
 
 	// Cancel handler.
 	const cancelHandler = useCallback(() => {
@@ -274,6 +304,7 @@ export const ConfigureDataConnection = (props: ConfigureDataConnectionProps) => 
 							parameters={props.mechanism.parameters}
 							redactedSecretValues={redactedSecretValues}
 							storedSecretIds={storedSecretIds}
+							onBrowseFile={browseFileHandler}
 							onParameterChanged={setParameterFieldState}
 						/>
 

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnectionParameters.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnectionParameters.tsx
@@ -114,7 +114,7 @@ export const ConfigureDataConnectionParameters = ({
 										id={fieldId}
 										placeholder={parameter.placeholder}
 										type='text'
-										value={parameterFieldStates[parameter.id].value as string}
+										value={(parameterFieldStates[parameter.id].value as string) ?? ''}
 										onChange={e => onParameterChanged(parameter.id, e.target.value)}
 									/>
 									<Button className='browse-button' onPressed={() => onBrowseFile(parameter.id)}>

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnectionParameters.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnectionParameters.tsx
@@ -10,6 +10,7 @@ import { JSX } from 'react';
 import { localize } from '../../../../../nls.js';
 import { ParameterFieldStates } from './configureDataConnection.js';
 import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
+import { Button } from '../../../../../base/browser/ui/positronComponents/button/button.js';
 import { Checkbox } from '../../../../../base/browser/ui/positronComponents/checkbox/checkbox.js';
 import { IDataConnectionParameter } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
 
@@ -32,6 +33,10 @@ interface ConfigureDataConnectionParametersProps {
 
 	// The current value and error state of each parameter field, managed by the parent component.
 	parameterFieldStates: ParameterFieldStates;
+
+	// Callback to open a file picker for a file parameter. The parent owns the dialog interaction
+	// and updates the field with the chosen path.
+	onBrowseFile: (parameterId: string) => void;
 
 	// Callback to notify the parent component of changes to any parameter field.
 	onParameterChanged: (parameterId: string, value: boolean | number | string | undefined) => void;
@@ -70,6 +75,7 @@ export const ConfigureDataConnectionParameters = ({
 	storedSecretIds,
 	redactedSecretValues,
 	parameterFieldStates,
+	onBrowseFile,
 	onParameterChanged,
 }: ConfigureDataConnectionParametersProps): JSX.Element => {
 	return (
@@ -98,18 +104,23 @@ export const ConfigureDataConnectionParameters = ({
 						return (
 							<div key={parameter.id} className='parameter-field'>
 								<ParameterLabel htmlFor={fieldId} label={parameter.label} optional={!parameter.required} />
-								<input
-									aria-required={parameter.required || undefined}
-									className={positronClassNames(
-										'parameter-input', 'text-input',
-										{ 'error': parameterFieldStates[parameter.id].error }
-									)}
-									id={fieldId}
-									placeholder={parameter.placeholder}
-									type='text'
-									value={parameterFieldStates[parameter.id].value as string}
-									onChange={e => onParameterChanged(parameter.id, e.target.value)}
-								/>
+								<div className='parameter-file-input'>
+									<input
+										aria-required={parameter.required || undefined}
+										className={positronClassNames(
+											'parameter-input', 'text-input',
+											{ 'error': parameterFieldStates[parameter.id].error }
+										)}
+										id={fieldId}
+										placeholder={parameter.placeholder}
+										type='text'
+										value={parameterFieldStates[parameter.id].value as string}
+										onChange={e => onParameterChanged(parameter.id, e.target.value)}
+									/>
+									<Button className='browse-button' onPressed={() => onBrowseFile(parameter.id)}>
+										{localize('positron.configureDataConnection.browse', "Browse...")}
+									</Button>
+								</div>
 								<ParameterDescription text={parameter.description} />
 							</div>
 						);

--- a/src/vs/workbench/contrib/positronDataConnections/test/browser/configureDataConnection.vitest.ts
+++ b/src/vs/workbench/contrib/positronDataConnections/test/browser/configureDataConnection.vitest.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { getFileDialogFilters } from '../../browser/dialogs/configureDataConnection.js';
+
+describe('getFileDialogFilters', () => {
+	it('lists the declared filters first, then All Files', () => {
+		expect(getFileDialogFilters([
+			{ name: 'DuckDB Files', extensions: ['duckdb', 'ddb'] },
+		])).toMatchInlineSnapshot(`
+			[
+			  {
+			    "extensions": [
+			      "duckdb",
+			      "ddb",
+			    ],
+			    "name": "DuckDB Files",
+			  },
+			  {
+			    "extensions": [
+			      "*",
+			    ],
+			    "name": "All Files",
+			  },
+			]
+		`);
+	});
+
+	it('offers only All Files when the parameter declares no filters', () => {
+		expect(getFileDialogFilters(undefined)).toMatchInlineSnapshot(`
+			[
+			  {
+			    "extensions": [
+			      "*",
+			    ],
+			    "name": "All Files",
+			  },
+			]
+		`);
+	});
+});

--- a/src/vs/workbench/contrib/positronDataConnections/test/browser/configureDataConnection.vitest.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/test/browser/configureDataConnection.vitest.tsx
@@ -1,0 +1,121 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { URI } from '../../../../../base/common/uri.js';
+import { Event } from '../../../../../base/common/event.js';
+import { posix } from '../../../../../base/common/path.js';
+import { ILabelService } from '../../../../../platform/label/common/label.js';
+import { IFileDialogService, IOpenDialogOptions } from '../../../../../platform/dialogs/common/dialogs.js';
+import { IPathService } from '../../../../services/path/common/pathService.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { PositronModalDialogReactRenderer } from '../../../../../base/browser/positronModalDialogReactRenderer.js';
+import { IDataConnectionDriver, IDataConnectionMechanism } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
+import { ConfigureDataConnection } from '../../browser/dialogs/configureDataConnection.js';
+
+describe('ConfigureDataConnection', () => {
+	// File dialog seams under test. The implementations persist across tests (clearMocks only
+	// clears call history); showOpenDialog resolves undefined (= user cancelled) unless a test
+	// queues a selection with mockResolvedValueOnce.
+	const defaultFilePath = vi.fn(async (_schemeFilter?: string) => URI.file('/home/user'));
+	const showOpenDialog = vi.fn(async (_options: IOpenDialogOptions): Promise<URI[] | undefined> => undefined);
+
+	const ctx = createTestContainer()
+		.withReactServices()
+		.stub(IFileDialogService, { defaultFilePath, showOpenDialog })
+		// Format chosen URIs back to a plain path so the write-back is assertable.
+		.stub(ILabelService, { getUriLabel: (uri: URI) => uri.path })
+		// The browse handler re-homes a typed path via the server platform's path lib.
+		.stub(IPathService, { path: Promise.resolve(posix) })
+		.build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
+
+	// The dialog only subscribes to the renderer's resize event during render.
+	const renderer = stubInterface<PositronModalDialogReactRenderer>({ onResize: Event.None });
+
+	const driver = stubInterface<IDataConnectionDriver>({
+		id: 'duckdb',
+		metadata: {
+			id: 'duckdb',
+			name: 'DuckDB',
+			description: 'Connect to DuckDB databases',
+			iconSvg: '',
+			mechanisms: [],
+			supportedLanguageIds: ['python'],
+		},
+	});
+
+	// Builds a mechanism with a single file parameter carrying a driver-declared filter,
+	// optionally pre-filled with a current value.
+	const mechanismWithFileParameter = (defaultValue?: string): IDataConnectionMechanism => ({
+		id: 'file',
+		label: 'Database File',
+		description: 'Connect to a database file',
+		parameters: [{
+			id: 'databasePath',
+			label: 'Database File',
+			type: 'file',
+			required: true,
+			defaultValue,
+			filters: [{ name: 'DuckDB Files', extensions: ['duckdb', 'ddb'] }],
+		}],
+	});
+
+	const renderDialog = (mechanism: IDataConnectionMechanism) => {
+		rtl.render(
+			<ConfigureDataConnection
+				driver={driver}
+				mechanism={mechanism}
+				renderer={renderer}
+				onSave={() => { }}
+			/>
+		);
+	};
+
+	it('opens the picker with the driver filters plus All Files and writes the chosen path into the field', async () => {
+		const user = userEvent.setup();
+		showOpenDialog.mockResolvedValueOnce([URI.file('/data/chosen.duckdb')]);
+		renderDialog(mechanismWithFileParameter());
+		const input = screen.getByLabelText('Database File');
+
+		await user.click(screen.getByRole('button', { name: 'Browse...' }));
+
+		await waitFor(() => expect(input).toHaveValue('/data/chosen.duckdb'));
+		expect(showOpenDialog).toHaveBeenCalledWith(expect.objectContaining({
+			// The field is empty, so the picker starts at the default file path.
+			defaultUri: expect.objectContaining({ path: '/home/user' }),
+			filters: [
+				{ name: 'DuckDB Files', extensions: ['duckdb', 'ddb'] },
+				{ name: 'All Files', extensions: ['*'] },
+			],
+		}));
+	});
+
+	it('seeds the picker starting location from the field current value', async () => {
+		const user = userEvent.setup();
+		renderDialog(mechanismWithFileParameter('/existing/data.duckdb'));
+
+		await user.click(screen.getByRole('button', { name: 'Browse...' }));
+
+		await waitFor(() => expect(showOpenDialog).toHaveBeenCalledWith(expect.objectContaining({
+			defaultUri: expect.objectContaining({ path: '/existing/data.duckdb' }),
+		})));
+	});
+
+	it('leaves the field unchanged when the picker is cancelled', async () => {
+		const user = userEvent.setup();
+		renderDialog(mechanismWithFileParameter('/existing/data.duckdb'));
+
+		await user.click(screen.getByRole('button', { name: 'Browse...' }));
+
+		await waitFor(() => expect(showOpenDialog).toHaveBeenCalled());
+		expect(screen.getByLabelText('Database File')).toHaveValue('/existing/data.duckdb');
+	});
+});

--- a/src/vs/workbench/contrib/positronDataConnections/test/browser/configureDataConnection.vitest.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/test/browser/configureDataConnection.vitest.tsx
@@ -95,6 +95,9 @@ describe('ConfigureDataConnection', () => {
 				{ name: 'DuckDB Files', extensions: ['duckdb', 'ddb'] },
 				{ name: 'All Files', extensions: ['*'] },
 			],
+			// Restricted to the extension host's file system (the default file path's scheme) so
+			// the web/remote picker never offers browser-local files the driver cannot open.
+			availableFileSystems: ['file'],
 		}));
 	});
 

--- a/src/vs/workbench/contrib/positronDataConnections/test/browser/configureDataConnectionParameters.vitest.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/test/browser/configureDataConnectionParameters.vitest.tsx
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+/// <reference types="@testing-library/jest-dom/vitest" />
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ConfigureDataConnectionParameters } from '../../browser/dialogs/configureDataConnectionParameters.js';
+import { IDataConnectionParameter } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
+import type { ParameterFieldStates } from '../../browser/dialogs/configureDataConnection.js';
+
+describe('ConfigureDataConnectionParameters', () => {
+	const fileParameter: IDataConnectionParameter = {
+		id: 'databasePath',
+		label: 'Database File',
+		type: 'file',
+		required: true,
+	};
+	const stringParameter: IDataConnectionParameter = {
+		id: 'host',
+		label: 'Host',
+		type: 'string',
+	};
+
+	// Renders the component with default field states and returns the callback spies.
+	const renderParameters = (parameters: IDataConnectionParameter[]) => {
+		const parameterFieldStates: ParameterFieldStates = Object.fromEntries(
+			parameters.map(parameter => [parameter.id, { value: '', error: false }])
+		);
+		const onBrowseFile = vi.fn();
+		const onParameterChanged = vi.fn();
+		render(
+			<ConfigureDataConnectionParameters
+				parameterFieldStates={parameterFieldStates}
+				parameters={parameters}
+				storedSecretIds={new Set()}
+				onBrowseFile={onBrowseFile}
+				onParameterChanged={onParameterChanged}
+			/>
+		);
+		return { onBrowseFile, onParameterChanged };
+	};
+
+	it('renders a Browse button for a file parameter and invokes onBrowseFile when clicked', async () => {
+		const user = userEvent.setup();
+		const { onBrowseFile } = renderParameters([fileParameter]);
+
+		await user.click(screen.getByRole('button', { name: 'Browse...' }));
+
+		expect(onBrowseFile).toHaveBeenCalledWith('databasePath');
+	});
+
+	it('does not render a Browse button for non-file parameters', () => {
+		renderParameters([stringParameter]);
+
+		expect(screen.queryByRole('button', { name: 'Browse...' })).not.toBeInTheDocument();
+	});
+});

--- a/src/vs/workbench/contrib/positronDataConnections/test/browser/configureDataConnectionParameters.vitest.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/test/browser/configureDataConnectionParameters.vitest.tsx
@@ -7,7 +7,7 @@
 /// <reference types="@testing-library/jest-dom/vitest" />
 
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { userEvent } from '@testing-library/user-event';
 import { ConfigureDataConnectionParameters } from '../../browser/dialogs/configureDataConnectionParameters.js';
 import { IDataConnectionParameter } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
 import type { ParameterFieldStates } from '../../browser/dialogs/configureDataConnection.js';

--- a/src/vs/workbench/services/positronDataConnections/common/interfaces/dataConnectionDTOs.ts
+++ b/src/vs/workbench/services/positronDataConnections/common/interfaces/dataConnectionDTOs.ts
@@ -25,6 +25,7 @@ export interface IDataConnectionParameterDTO {
 	defaultValue?: string | number | boolean;
 	placeholder?: string;
 	options?: string[]; // only for 'option' type
+	filters?: Record<string, string[]>; // only for 'file' type; file-picker filters, label -> extensions
 }
 
 /**

--- a/src/vs/workbench/services/positronDataConnections/common/interfaces/dataConnectionDriver.ts
+++ b/src/vs/workbench/services/positronDataConnections/common/interfaces/dataConnectionDriver.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { FileFilter } from '../../../../../platform/dialogs/common/dialogs.js';
 import { IDataConnectionNodeDTO } from './dataConnectionDTOs.js';
 
 // --- Service-level interfaces ---
@@ -61,11 +62,13 @@ export interface IDataConnectionParameterBase {
  * Service-level data connection parameter. Mirrors the public API's DataConnectionParameter
  * discriminated union: `secret` lives only on `password` and `string` variants, and a `string`
  * marked `secret: true` cannot carry a `defaultValue`. The RPC layer converts
- * IDataConnectionParameterDTO → IDataConnectionParameter at the main-thread boundary.
+ * IDataConnectionParameterDTO → IDataConnectionParameter at the main-thread boundary; the `file`
+ * variant's filters dictionary becomes an ordered FileFilter array there so UI consumers can pass
+ * it straight to the file dialog service.
  */
 export type IDataConnectionParameter = IDataConnectionParameterBase & (
 	| { type: 'boolean'; defaultValue?: boolean }
-	| { type: 'file'; defaultValue?: string; placeholder?: string }
+	| { type: 'file'; defaultValue?: string; placeholder?: string; filters?: FileFilter[] }
 	| { type: 'number'; defaultValue?: number; placeholder?: string }
 	| { type: 'option'; options: string[]; defaultValue?: string; placeholder?: string }
 	| { type: 'password'; secret: true; placeholder?: string }


### PR DESCRIPTION
Fixes #14599

### Summary

Adds a Browse... button to file parameter fields in the Configure Data Connection dialog so users can pick local files (e.g. DuckDB/SQLite databases) with a file picker instead of typing a path. The picker is the native OS dialog on desktop and the quick-pick file browser on web/remote, via `IFileDialogService`.

- New optional `filters` field on the `positron` API's `File` connection parameter lets drivers declare file-type filters (label -> extensions). The DuckDB and SQLite drivers now declare theirs, and an "All Files" option is always appended. PostgreSQL has generic file pickers for file fields.
- On web/remote, the picker is restricted to the extension host's file system (`availableFileSystems`) since the chosen path is opened by the driver on the server -- browser-local files are not offered.
- The quick input now reparents into the native `<dialog>` modal renderer (browser top layer) so the web file browser renders above the Data Connections modal and participates in its focus scope; the older div-overlay renderer remains as a fallback.

### Screenshots

<img width="538" height="275" alt="image" src="https://github.com/user-attachments/assets/fb898f45-482f-43db-b12c-9ae612eaab96" />

<img width="539" height="270" alt="image" src="https://github.com/user-attachments/assets/e7d2c826-0ade-4aad-bed0-25a41bcc7b39" />

<img width="535" height="634" alt="image" src="https://github.com/user-attachments/assets/34e0b3cc-1afd-4e6c-bd79-fbdbda95e443" />


### Release Notes

#### New Features
- Added a Browse button to file fields in the Data Connections dialog for selecting local database files (e.g. DuckDB, SQLite), with driver-declared file-type filters (#14599)

#### Bug Fixes
- N/A

### Validation Steps

@:connections @:modal @:win @:web

1. Connections pane -> New Connection -> DuckDB -> Database File
2. Click Browse... and verify the native picker defaults to a "DuckDB Files" filter (`duckdb`, `ddb`) with "All Files" also available
3. Select a file and verify the field fills with the chosen path, then connect
4. Repeat for SQLite ("SQLite Files": `sqlite`, `sqlite3`, `db`)
5. On web (e.g. `npm run web`), verify Browse opens the quick-pick file browser rendered above the modal with working focus, and that no "Show Local" button is offered
