### PR TITLE
fix: make gcc/g++ default to C++20 compiler on openSUSE and SLES images

### DIFF
--- a/docker/images/SLES15_6/Dockerfile.SLES15_6
+++ b/docker/images/SLES15_6/Dockerfile.SLES15_6
@@ -109,9 +109,18 @@ RUN curl -fsSL https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-li
 # Verify Node.js
 RUN node -v && npm -v
 
-# Configure node-gyp to use GCC 13 for C++20 support
+# Configure node-gyp to use GCC 13 for C++20 support.
+# CC/CXX cover tools that read them, but node-gyp's make targets fall back to a
+# bare "g++" when the env is not inherited by the spawned subprocess (as happens
+# for the positron/remote native rebuild). Point the default gcc/g++ at GCC 13 so
+# even bare invocations get C++20 support.
 ENV CC=gcc-13
 ENV CXX=g++-13
+RUN ln -sf /usr/bin/gcc-13 /usr/bin/gcc && \
+    ln -sf /usr/bin/g++-13 /usr/bin/g++
+
+# Sanity check: fail the build here if bare g++ cannot compile C++20.
+RUN echo 'int main(){}' | g++ -std=gnu++20 -x c++ - -o /dev/null && g++ --version
 
 # Global npm deps
 RUN npm install -g node-gyp npm-run-all yarn

--- a/docker/images/openSUSE15_6/Dockerfile.openSUSE15_6
+++ b/docker/images/openSUSE15_6/Dockerfile.openSUSE15_6
@@ -76,9 +76,18 @@ RUN curl -fsSL https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-li
 # Verify Node.js
 RUN node -v && npm -v
 
-# Configure node-gyp to use GCC 12 for C++20 support
+# Configure node-gyp to use GCC 12 for C++20 support.
+# CC/CXX cover tools that read them, but node-gyp's make targets fall back to a
+# bare "g++" when the env is not inherited by the spawned subprocess (as happens
+# for the positron/remote native rebuild). Point the default gcc/g++ at GCC 12 so
+# even bare invocations get C++20 support.
 ENV CC=gcc-12
 ENV CXX=g++-12
+RUN ln -sf /usr/bin/gcc-12 /usr/bin/gcc && \
+    ln -sf /usr/bin/g++-12 /usr/bin/g++
+
+# Sanity check: fail the build here if bare g++ cannot compile C++20.
+RUN echo 'int main(){}' | g++ -std=gnu++20 -x c++ - -o /dev/null && g++ --version
 
 # Global npm deps
 RUN npm install -g node-gyp npm-run-all yarn


### PR DESCRIPTION
The remote server native rebuild (node-gyp) fell back to a bare `g++`, which on these images is the old distro default that predates C++20, so @parcel/watcher and @vscode/native-watchdog failed to compile with "unrecognized command line option '-std=gnu++20'". The ENV CC/CXX were set but did not propagate into the make subprocess spawned by postinstall.ts.

Symlink gcc/g++ to the installed modern compiler (GCC 12 / GCC 13) so even bare invocations get C++20, and add the same build-time -std=gnu++20 sanity check the rocky_8 image already has so a future regression fails at image-build time.

@:rhel-web @:suse-web @:sles-web