### PR TITLE
Collapse empty icon column in custom context menus when no items have icons

### DIFF
--- a/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.css
+++ b/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.css
@@ -43,6 +43,18 @@
 	grid-template-columns: [check] 22px [icon] 24px [title] 1fr [shortcut] min-content [end];
 }
 
+/*
+ * When no entry in the menu has an icon, collapse the icon column to 0px so labels aren't
+ * pushed right by an empty icon gutter. The check column (if any) is preserved.
+ */
+.custom-context-menu-items.no-icons .custom-context-menu-item {
+	grid-template-columns: [icon] 0px [title] 1fr [shortcut] min-content [end];
+}
+
+.custom-context-menu-items.no-icons .custom-context-menu-item.checkable {
+	grid-template-columns: [check] 22px [icon] 0px [title] 1fr [shortcut] min-content [end];
+}
+
 .custom-context-menu-item.destructive {
 	color: var(--vscode-errorForeground);
 }

--- a/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
+++ b/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
@@ -519,6 +519,14 @@ const CustomContextMenuModalPopup = (props: CustomContextMenuModalPopupProps) =>
 		}
 	};
 
+	// Determine whether any entry in this menu has an icon. If none do, the icon column is
+	// collapsed (see the 'no-icons' class in the CSS) so labels aren't pushed right by an
+	// empty icon gutter.
+	const menuHasIcons = props.entries.some(entry =>
+		(entry instanceof CustomContextMenuItem || entry instanceof CustomContextMenuSubmenu) &&
+		(!!entry.options.icon || !!entry.options.iconSrc)
+	);
+
 	// Render.
 	return (
 		<PositronModalPopup
@@ -533,7 +541,14 @@ const CustomContextMenuModalPopup = (props: CustomContextMenuModalPopupProps) =>
 			renderer={props.renderer}
 			width={props.width}
 		>
-			<div className='custom-context-menu-items' role='menu' onKeyDown={handleKeyDown}>
+			<div
+				className={positronClassNames(
+					'custom-context-menu-items',
+					{ 'no-icons': !menuHasIcons }
+				)}
+				role='menu'
+				onKeyDown={handleKeyDown}
+			>
 				{props.entries.map((entry, index) => {
 					if (entry instanceof CustomContextMenuItem) {
 						return <MenuItem key={index} {...entry.options} />;


### PR DESCRIPTION
## Summary

Fixes #13764

Custom context menus reserve a fixed 24px icon column for every item. When a menu's items are checkable but none of them have an icon (for example the Packages pane's Filter/Sort submenus), that column renders as an empty gutter that pushes the checkmark and label to the right, leaving awkward whitespace.

Before:
<p>
<img width="731" height="409" alt="C =" src="https://github.com/user-attachments/assets/5aeec94f-5bde-44cb-b54b-589806b0ced6" />
</p>

This change collapses the icon column to 0px when no item in the menu has an icon. The check column is preserved, so checkable-but-icon-less menus now align cleanly.

After:
<p>
<img width="838" height="433" alt="image" src="https://github.com/user-attachments/assets/5c8a5aaa-7e32-4efd-aeff-2ea8d36473ae" />
</p>

## Changes

- `customContextMenu.tsx`: Compute a `menuHasIcons` flag from the menu's entries (covering both `CustomContextMenuItem` and `CustomContextMenuSubmenu`, and both `icon` and `iconSrc`) and apply a `no-icons` class to the menu container when none have an icon. This is computed at the container level because whether the column should collapse depends on all sibling items, not any single one.
- `customContextMenu.css`: Under `.no-icons`, override `grid-template-columns` to set the `[icon]` track to 0px for both the standard and `.checkable` variants.

## Testing

- Manually verified in the Packages pane: the Filter and Sort submenus (checkmarks, no icons) no longer show the empty icon gutter, and menus that do have icons are unaffected.

@:packages-pane

