### PR TITLE
Fix accessor use after await in Execute Code in Console action

### DIFF
--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -1391,6 +1391,7 @@ export function registerLanguageRuntimeActions() {
 			const consoleService = accessor.get(IPositronConsoleService);
 			const notificationService = accessor.get(INotificationService);
 			const quickInputService = accessor.get(IQuickInputService);
+			const runtimeSessionService = accessor.get(IRuntimeSessionService);
 			let fromPrompt = false;
 
 			// TODO: Should this be a "Developer: " command?
@@ -1427,7 +1428,7 @@ export function registerLanguageRuntimeActions() {
 			// If no language ID is provided, try to get the language ID from
 			// the active session.
 			if (!args.langId) {
-				const foreground = accessor.get(IRuntimeSessionService).foregroundSession;
+				const foreground = runtimeSessionService.foregroundSession;
 				if (foreground) {
 					args.langId = foreground.runtimeMetadata.languageId;
 				} else {


### PR DESCRIPTION
Fixes a `local/code-no-accessor-after-await` eslint warning in the Execute Code in Console action. `accessor.get(IRuntimeSessionService)` was called after the quick input prompts were awaited, but a `ServicesAccessor` is only valid synchronously. The service is now extracted at the top of `run()` alongside the other services.

<img width="1696" height="965" alt="Screenshot 2026-07-09 at 5 00 31 PM" src="https://github.com/user-attachments/assets/489dd496-df9e-46a1-8125-e8539bcf485a" />


### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

@:console @:sessions

With an active console session, run "Execute Code in Console" from the command palette and verify the prompted code executes in the console. Verify `npx eslint src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts` reports no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
