### PR TITLE
Add positronWelcome to i18n.resources.json

### DIFF
--- a/build/lib/i18n.resources.json
+++ b/build/lib/i18n.resources.json
@@ -275,6 +275,10 @@
 			"project": "vscode-workbench"
 		},
 		{
+			"name": "vs/workbench/contrib/positronWelcome",
+			"project": "vscode-workbench"
+		},
+		{
 			"name": "vs/workbench/contrib/repl",
 			"project": "vscode-workbench"
 		},


### PR DESCRIPTION
This registers the `vs/workbench/contrib/positronWelcome` folder in `build/lib/i18n.resources.json`. The folder has used `localize()` since it was created, but it was never added to the resources file, so ESLint's `code-translation-remind` rule shows a warning whenever `positronWelcome.contribution.ts` is open in the editor:

```
src/vs/workbench/contrib/positronWelcome/browser/positronWelcome.contribution.ts
  19:26  warning  Please add 'vs/workbench/contrib/positronWelcome' to ./build/lib/i18n.resources.json file to use translations here  local/code-translation-remind
```

<img width="1696" height="965" alt="Screenshot 2026-07-09 at 5 20 45 PM" src="https://github.com/user-attachments/assets/bb1dc21e-5b10-427a-8af2-0283792e72dc" />

Registering the folder also means its localized strings get picked up for translation like the other positron contrib folders. This is needed for upcoming onboarding wizard work (#14691).

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

This is a build metadata change with no runtime behavior, so no e2e test tags apply.

1. Run `npx eslint src/vs/workbench/contrib/positronWelcome/browser/positronWelcome.contribution.ts`
2. Verify the `code-translation-remind` warning is gone (it fires on this file when run against main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)