### PR TITLE
CI: retry ext-host remote tests on Electron startup segfault

### DIFF
--- a/.github/workflows/test-ext-host.yml
+++ b/.github/workflows/test-ext-host.yml
@@ -166,7 +166,21 @@ jobs:
         id: electron-remote-integration-tests
         env:
           PLAYWRIGHT_BROWSERS_PATH: .playwright-browsers
-        run: DISPLAY=:10 ./scripts/test-remote-integration.sh
+        # Since the Electron 42 bump (upstream 1.124.0, #14673), Electron
+        # intermittently segfaults (exit 139) at startup in the system
+        # libfontconfig/libexpat on the ubuntu24 CI image, killing whichever
+        # suite happens to be launching. Retry only on that exit code so real
+        # test failures still fail fast.
+        run: |
+          for attempt in 1 2 3; do
+            code=0
+            DISPLAY=:10 ./scripts/test-remote-integration.sh || code=$?
+            if [ "$code" -ne 139 ]; then
+              exit "$code"
+            fi
+            echo "Electron segfaulted at startup (exit 139) on attempt $attempt/3"
+          done
+          exit 139
 
       - name: 🧪 Run Extension Host Tests (Chromium)
         if: ${{ job.status != 'cancelled' && (success() || failure()) }}


### PR DESCRIPTION
## Summary

Since the Electron 42 bump (upstream 1.124.0 merge, #14673, landed July 8), the `test / ext-host` job's **Run Extension Host Tests (Remote)** step intermittently fails with exit code 139. Electron segfaults **at startup**, before any test runs, inside the system `libfontconfig` / `libexpat` on the ubuntu24 CI image:

```
Received signal 11 SI_KERNEL
#3 libexpat.so.1.9.1
#6-#11 libfontconfig.so.1.12.1
#12 libpangoft2-1.0.so
#13 libglib-2.0.so (worker thread)
./scripts/test-remote-integration.sh: line 91: Segmentation fault (core dumped) "$INTEGRATION_TEST_ELECTRON_PATH" ...
```

The crash strikes whichever suite happens to be launching Electron at the time - observed against the TypeScript, ipynb, and configuration-editing suites on unrelated branches (runs [29043333717](https://github.com/posit-dev/positron/actions/runs/29043333717), [29094973481](https://github.com/posit-dev/positron/actions/runs/29094973481), [29060813983](https://github.com/posit-dev/positron/actions/runs/29060813983), [29066567774](https://github.com/posit-dev/positron/actions/runs/29066567774), [29094468926](https://github.com/posit-dev/positron/actions/runs/29094468926)). No ext-host failures with this signature exist before July 9; since then it has killed the majority of ext-host runs.

## Fix

Retry the remote integration step up to 3 times, but **only when the exit code is 139**, so genuine test failures still fail fast on the first attempt. `scripts/test-remote-integration.sh` is upstream-owned, so the retry lives in the Positron-owned workflow instead.

This is a mitigation. The real fix is likely in the CI image (fontconfig/expat packages in `positron-ci-images` ubuntu24) or a future Electron release; the retry can be removed once startup is stable again.

## QA Notes

CI-only change. Verify the `test / ext-host` job passes; on a segfault the step log will show `Electron segfaulted at startup (exit 139) on attempt N/3` before retrying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)