### PR TITLE
Fix links on the help welcome page

### DIFF
--- a/src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -12,7 +12,7 @@ import { Emitter, Event } from '../../../../base/common/event.js';
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
 import { PositronHelpFocused } from '../../../common/contextkeys.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
-import { isLocalhost } from './utils.js';
+import { isLocalhost, tryParseUrl } from './utils.js';
 import { ExtensionIdentifier } from '../../../../platform/extensions/common/extensions.js';
 import { KeyEvent } from '../../webview/browser/webviewMessages.js';
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
@@ -49,11 +49,15 @@ function generateNonce() {
 }
 
 /**
- * Shortens a URL.
+ * Shortens a URL by stripping its origin. Non-absolute URLs (e.g. the welcome
+ * page's 'welcome.html') have no origin and are returned unchanged.
  * @param url The URL.
  * @returns The shortened URL.
  */
-const shortenUrl = (url: string) => url.replace(new URL(url).origin, '');
+const shortenUrl = (url: string) => {
+	const origin = tryParseUrl(url)?.origin;
+	return origin ? url.replace(origin, '') : url;
+};
 
 /**
  * KeyboardMessage type.
@@ -516,10 +520,20 @@ export class HelpEntry extends Disposable implements IHelpEntry, WebviewFindDele
 						// nor on the same origin as the help proxy hosting this entry. The
 						// same-origin check is what lets relative help links resolve internally
 						// when Positron Server is hosted at a non-localhost authority.
-						const url = new URL(message.url);
-						const sourceUrl = new URL(this.sourceUrl);
+						const url = tryParseUrl(message.url);
+						if (!url) {
+							// The navigation target isn't a valid absolute URL, so there's
+							// nothing to open. Log it rather than throwing out of the message
+							// handler. See issue #14810.
+							this._logService.error(`Positron Help received an invalid navigation URL: ${message.url}`);
+							break;
+						}
+						// The source URL isn't always an absolute URL (e.g. the welcome page's
+						// 'welcome.html'), so parse it defensively. When it has no origin,
+						// treat the target as cross-origin so external links open externally.
+						const sourceOrigin = tryParseUrl(this.sourceUrl)?.origin;
 						if (url.pathname.toLowerCase().endsWith('.pdf') ||
-							(!isLocalhost(url.hostname) && url.origin !== sourceUrl.origin)) {
+							(!isLocalhost(url.hostname) && url.origin !== sourceOrigin)) {
 							try {
 								await this._openerService.open(message.url, {
 									openExternal: true

--- a/src/vs/workbench/contrib/positronHelp/browser/utils.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/utils.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -10,3 +10,18 @@
  */
 export const isLocalhost = (hostname?: string) =>
 	!!(hostname && ['localhost', '127.0.0.1', '::1'].indexOf(hostname.toLowerCase()) > -1);
+
+/**
+ * Parses a string into a URL, returning undefined instead of throwing when the
+ * string is not a valid absolute URL. Useful for source URLs that aren't always
+ * absolute (e.g. the help welcome page's 'welcome.html').
+ * @param value The string to parse.
+ * @returns The parsed URL, or undefined if the string is not a valid absolute URL.
+ */
+export const tryParseUrl = (value: string): URL | undefined => {
+	try {
+		return new URL(value);
+	} catch {
+		return undefined;
+	}
+};

--- a/src/vs/workbench/contrib/positronHelp/test/browser/helpEntry.vitest.ts
+++ b/src/vs/workbench/contrib/positronHelp/test/browser/helpEntry.vitest.ts
@@ -5,11 +5,12 @@
 
 /// <reference types="vitest/globals" />
 
-import { Event } from '../../../../../base/common/event.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
 import { URI } from '../../../../../base/common/uri.js';
+import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
-import { IOverlayWebview, IWebviewService } from '../../../webview/browser/webview.js';
+import { IOverlayWebview, IWebviewService, WebviewMessageReceivedEvent } from '../../../webview/browser/webview.js';
 import { HelpEntry } from '../../browser/helpEntry.js';
 
 type HelpMessage = {
@@ -17,9 +18,17 @@ type HelpMessage = {
 	readonly findValue?: string;
 };
 
+const LOCALHOST_HELP_URL = 'http://localhost/help/library/graphics/html/plot.html';
+
 describe('HelpEntry', () => {
 	let messages: HelpMessage[];
 	let helpEntry: HelpEntry;
+
+	// Emitter used to simulate messages posted from the help webview (e.g. a
+	// link click). Created at describe scope so the webview stub can hand out
+	// its `.event` reference; fired from individual tests.
+	const onMessageEmitter = new Emitter<WebviewMessageReceivedEvent>();
+	const open = vi.fn(async () => true);
 
 	const overlayWebview = (): IOverlayWebview => stubInterface<IOverlayWebview>({
 		container: document.createElement('div'),
@@ -34,7 +43,7 @@ describe('HelpEntry', () => {
 		onDidUpdateState: Event.None,
 		onFatalError: Event.None,
 		onMissingCsp: Event.None,
-		onMessage: Event.None,
+		onMessage: onMessageEmitter.event,
 		onDidNavigate: Event.None,
 		onDidLoad: Event.None,
 		intrinsicContentSize: undefined,
@@ -54,9 +63,10 @@ describe('HelpEntry', () => {
 		.stub(IWebviewService, {
 			createWebviewOverlay: () => overlayWebview(),
 		})
+		.stub(IOpenerService, { open })
 		.build();
 
-	function createHelpEntry(): void {
+	function createHelpEntry(sourceUrl: string = LOCALHOST_HELP_URL): void {
 		messages = [];
 
 		helpEntry = ctx.disposables.add(ctx.instantiationService.createInstance(
@@ -65,8 +75,8 @@ describe('HelpEntry', () => {
 			'r',
 			'test-session',
 			'R',
-			'http://localhost/help/library/graphics/html/plot.html',
-			URI.parse('http://localhost/help/library/graphics/html/plot.html').toString(),
+			sourceUrl,
+			URI.parse(LOCALHOST_HELP_URL).toString(),
 		));
 
 		const anchor = document.createElement('div');
@@ -91,6 +101,44 @@ describe('HelpEntry', () => {
 			await vi.runAllTimersAsync();
 
 			expect(messages).toEqual([{ id: 'positron-help-find-next', findValue: 'title' }]);
+		});
+	});
+
+	describe('Link navigation', () => {
+		it('opens external links from the welcome page whose source URL is relative', async () => {
+			vi.useFakeTimers();
+			// The welcome page uses a relative source URL ('welcome.html'), which
+			// is not a valid absolute URL. See issue #14810.
+			createHelpEntry('welcome.html');
+
+			onMessageEmitter.fire({
+				message: {
+					id: 'positron-help-navigate',
+					url: 'https://github.com/posit-dev/positron/discussions',
+				},
+			});
+			await vi.runAllTimersAsync();
+
+			expect(open).toHaveBeenCalledWith(
+				'https://github.com/posit-dev/positron/discussions',
+				{ openExternal: true },
+			);
+		});
+
+		it('navigates internally for same-origin help links', async () => {
+			vi.useFakeTimers();
+			createHelpEntry();
+			const navigated: string[] = [];
+			ctx.disposables.add(helpEntry.onDidNavigate(url => navigated.push(url.toString())));
+
+			const sameOriginUrl = 'http://localhost/help/library/graphics/html/hist.html';
+			onMessageEmitter.fire({
+				message: { id: 'positron-help-navigate', url: sameOriginUrl },
+			});
+			await vi.runAllTimersAsync();
+
+			expect(navigated).toEqual([sameOriginUrl]);
+			expect(open).not.toHaveBeenCalled();
 		});
 	});
 });


### PR DESCRIPTION
Fixes #14810, where clicking any link on the Help pane's welcome page did nothing. This was a regression from #13626, which added the same-origin check without accounting for the welcome page's relative source URL.

The fix adds a `tryParseUrl` helper that returns `undefined` instead of throwing on a non-absolute URL. The navigate handler now parses the source URL defensively, and `shortenUrl` degrades gracefully on relative URLs.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix links on the Help pane welcome page not opening when clicked (#14810)

### Validation Steps

@:help @:web

1. Open the Help pane so the welcome page is shown (no help topic loaded).
2. Click "Positron Documentation", "Positron Community Forum", and "Sign Up for Positron Updates" -- each should open in your external browser.
3. Click "Report a Bug in Positron" -- it should open the in-app issue reporter.
4. Open the developer tools console and confirm no `Failed to construct 'URL': Invalid URL` error is logged when clicking links.

Covered by new unit tests in `helpEntry.vitest.ts` (external welcome-page link opens externally; same-origin help link navigates internally). Note: the existing `@:help` e2e test verifies the welcome links' `href`s but does not click them, which is why this regression was not caught. It wouldn't be a good idea to actually click them in e2e tests because it would spawn a browser in CI that Playwright couldn't track.