### PR TITLE
Fix e2e failure analyzer history matching for suite-prefixed titles

### DIFF
--- a/.github/actions/e2e-failure-analyzer/analyze.mjs
+++ b/.github/actions/e2e-failure-analyzer/analyze.mjs
@@ -239,13 +239,19 @@ function findHistoryFor(historyMap, title, file) {
 	// the leaf title -- or ending in "> <leaf title>" -- is the same test. This
 	// keeps history matching working regardless of whether either side prefixes
 	// the suite chain.
+	//
+	// Fail closed on ambiguity: two tests in the same file can share a leaf title
+	// under different suites, and the leaf-only blob title can't tell them apart.
+	// Returning the first hit could attach the wrong history, so require exactly
+	// one candidate; otherwise return null and let the caller show "no entry".
 	const suffix = `> ${title}`;
+	const candidates = [];
 	for (const entry of historyMap.values()) {
 		if (normalizeSpecPath(entry.specPath) !== specPath) { continue; }
 		const name = entry.testName || '';
-		if (name === title || name.endsWith(suffix)) { return entry; }
+		if (name === title || name.endsWith(suffix)) { candidates.push(entry); }
 	}
-	return null;
+	return candidates.length === 1 ? candidates[0] : null;
 }
 
 function renderHistoryForTest(entry) {

--- a/.github/actions/e2e-failure-analyzer/analyze.mjs
+++ b/.github/actions/e2e-failure-analyzer/analyze.mjs
@@ -223,8 +223,29 @@ function buildHistoryByKey(history) {
 
 function findHistoryFor(historyMap, title, file) {
 	if (!historyMap || historyMap.size === 0) { return null; }
-	const key = `${title}|||${normalizeSpecPath(file)}`;
-	return historyMap.get(key) || null;
+	const specPath = normalizeSpecPath(file);
+
+	// Fast path: the composed key matches an entry outright. Works when the blob
+	// title is already the full Playwright title path, or when the API keys tests
+	// by their leaf title.
+	const exact = historyMap.get(`${title}|||${specPath}`);
+	if (exact) { return exact; }
+
+	// Fall back to spec-path + leaf-title-suffix matching. The e2e-test-insights
+	// API keys tests by their FULL Playwright title path (suite ancestors joined
+	// with " > "), e.g. "Console Pane: Python > Python - Verify ...", while the
+	// blob report yields only the leaf title "Python - Verify ...". The normalized
+	// spec path uniquely narrows the file, so within that file a testName equal to
+	// the leaf title -- or ending in "> <leaf title>" -- is the same test. This
+	// keeps history matching working regardless of whether either side prefixes
+	// the suite chain.
+	const suffix = `> ${title}`;
+	for (const entry of historyMap.values()) {
+		if (normalizeSpecPath(entry.specPath) !== specPath) { continue; }
+		const name = entry.testName || '';
+		if (name === title || name.endsWith(suffix)) { return entry; }
+	}
+	return null;
 }
 
 function renderHistoryForTest(entry) {


### PR DESCRIPTION
## Summary

The e2e failure analyzer was reporting **"no entry for this test"** for failing tests even when the e2e-test-insights dashboard returned rich history for them (e.g. [run #29037134118](https://github.com/posit-dev/positron/actions/runs/29037134118)). The dashboard API is healthy -- this was a client-side key-matching bug.

The analyzer matched failing tests to history by `` `${title}|||${specPath}` ``, where `title` is the **leaf** test title extracted from the Playwright blob report. The `test-health` API keys tests by their **full Playwright title path** (suite ancestors joined with `" > "`):

| Source | Value |
|---|---|
| Analyzer failure `title` | `Python - Verify console commands are queued during execution` |
| API `test_key` / `testName` | `Console Pane: Python > Python - Verify console commands are queued during execution` |

The path side matched after normalization; the title side never did. Since virtually every Positron e2e test lives inside a `test.describe(...)` block, essentially every test failed to match history.

## Fix

`findHistoryFor` now falls back to spec-path + leaf-title-**suffix** matching: within the same normalized spec file, a history `testName` equal to the leaf title -- or ending in `> <leaf title>` -- is the same test. The exact-key fast path is preserved, so this is robust regardless of whether either side prefixes the suite chain.

## Verification

Replayed against run #29037134118's real artifacts (`history.json` + `result.json`):

- Both failing tests (`Python - Verify console commands are queued during execution`, `ms-foundry - Sign in, send hello, sign out`) now **match** their history (previously both `NO MATCH`).
- Negative cases correctly do **not** match: wrong file, a title that is only a substring (not a suite-suffix), and a bogus title.

## E2E test tags

None -- this touches CI tooling (`.github/actions/e2e-failure-analyzer`) only, with no Positron product surface to exercise.
