### PR TITLE
Add a command to move an editor into a dedicated window

### DIFF
--- a/src/vs/workbench/browser/parts/editor/auxiliaryEditorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/auxiliaryEditorPart.ts
@@ -379,6 +379,16 @@ class AuxiliaryEditorPartImpl extends EditorPart implements IAuxiliaryEditorPart
 	updateOptions(options: { compact: boolean }): void {
 		this.isCompact = options.compact;
 
+		// --- Start Positron ---
+		// Mirror the compact state into a context key so features gated on
+		// IsCompactTitleBarContext (notably suppressing the editor action bar in
+		// compact windows) work even when there is no custom title bar to set it,
+		// e.g. auxiliary windows opened with a native title bar. This runs before
+		// the window is used: AuxiliaryEditorPart.create() always calls
+		// updateOptions() right after constructing this part.
+		IsCompactTitleBarContext.bindTo(this.scopedContextKeyService).set(options.compact);
+		// --- End Positron ---
+
 		if (options.compact) {
 			if (!this.optionsDisposable.value) {
 				this.optionsDisposable.value = this.enforcePartOptions({

--- a/src/vs/workbench/browser/parts/editor/auxiliaryEditorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/auxiliaryEditorPart.ts
@@ -208,7 +208,13 @@ export class AuxiliaryEditorPart {
 		// Titlebar
 		let titlebarPart: IAuxiliaryTitlebarPart | undefined = undefined;
 		let titlebarVisible = false;
-		const useCustomTitle = isNative && hasCustomTitlebar(this.configurationService); // custom title in aux windows only enabled in native
+		// --- Start Positron ---
+		// When the window is opened with a native OS title bar, skip the custom
+		// title bar so we do not draw two bars. `hasCustomTitlebar` is hardcoded
+		// to true upstream, so the `nativeTitlebar` option is the only signal.
+		// const useCustomTitle = isNative && hasCustomTitlebar(this.configurationService); // custom title in aux windows only enabled in native
+		const useCustomTitle = isNative && hasCustomTitlebar(this.configurationService) && options?.nativeTitlebar !== true; // custom title in aux windows only enabled in native
+		// --- End Positron ---
 		if (useCustomTitle) {
 			titlebarPart = disposables.add(this.titleService.createAuxiliaryTitlebarPart(auxiliaryWindow.container, editorPart, scopedEditorPartInstantiationService));
 			titlebarPart.updateOptions({ compact });

--- a/src/vs/workbench/contrib/positronEditorActions/browser/positronDedicatedWindow.ts
+++ b/src/vs/workbench/contrib/positronEditorActions/browser/positronDedicatedWindow.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { getActiveWindow } from '../../../../base/browser/dom.js';
+import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
+import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { prepareMoveCopyEditors } from '../../../browser/parts/editor/editor.js';
+import { IAuxiliaryWindowOpenOptions } from '../../../services/auxiliaryWindow/browser/auxiliaryWindowService.js';
+import { IEditorGroupsService } from '../../../services/editor/common/editorGroupsService.js';
+
+/**
+ * Moves the active editor into a "dedicated window": an auxiliary window with
+ * a native OS title bar and compact chrome (no editor tabs, no status bar),
+ * sized to match the window the editor moves out of.
+ *
+ * The command is intent-level on purpose: what a dedicated window looks like
+ * is policy owned here, so callers never learn about auxiliary window options.
+ * It is not exposed in the command palette; callers invoke it by id after
+ * making the editor to move the active one -- the same contract as
+ * `workbench.action.moveEditorToNewWindow`.
+ */
+CommandsRegistry.registerCommand('positron.editor.moveIntoDedicatedWindow', async (accessor: ServicesAccessor) => {
+	const editorGroupsService = accessor.get(IEditorGroupsService);
+
+	const sourceGroup = editorGroupsService.activeGroup;
+	const editor = sourceGroup.activeEditor;
+	if (!editor) {
+		return; // nothing to move; do not open an empty window
+	}
+
+	// Size the dedicated window like the source window, which is still the
+	// active window at this point; it intentionally opens exactly over it.
+	const sourceWindow = getActiveWindow();
+	const options: IAuxiliaryWindowOpenOptions = {
+		compact: true,
+		nativeTitlebar: true,
+		bounds: { width: sourceWindow.outerWidth, height: sourceWindow.outerHeight }
+	};
+
+	const auxiliaryEditorPart = await editorGroupsService.createAuxiliaryEditorPart(options);
+	sourceGroup.moveEditors(prepareMoveCopyEditors(sourceGroup, [editor]), auxiliaryEditorPart.activeGroup);
+	auxiliaryEditorPart.activeGroup.focus();
+});

--- a/src/vs/workbench/contrib/positronEditorActions/browser/positronEditorActions.contribution.ts
+++ b/src/vs/workbench/contrib/positronEditorActions/browser/positronEditorActions.contribution.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import './positronDedicatedWindow.js';
 import { localize } from '../../../../nls.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { Event } from '../../../../base/common/event.js';


### PR DESCRIPTION
This is progress towards #14771.

There are methods of opening fullscreen editors from exposed workbench commands but they feel a bit clunky and non-native. Ultimately they're the same as dragging an editor tab out to the new window and have controls in the header that can be distracting. 

https://github.com/user-attachments/assets/e8b89c90-fd60-4dfd-93cd-dabe9b260a14

_Demo of using a command added to positron assistant to trigger this mode._


Upstream added the concept of a native-looking new window for their new issue creator feature but didnt open it up to third parties. This effectively does that. I attempted to make the diff as upstream merge friendly as possible to avoid future headaches. 

_Agent summary 👇_

---

Adds `positron.editor.moveIntoDedicatedWindow`, a secret command (no palette
entry) that moves the active editor into a "dedicated window": an auxiliary
window with a native OS title bar and compact chrome (no tabs, no status bar),
sized to match the source window. 




The command owns the whole policy internally, so callers only ever learn one
command id -- no auxiliary-window options cross the boundary, and core learns
nothing about callers. Posit Assistant is the first consumer, but nothing in
this PR references it.

Three commits, each standalone:

1. **Skip the custom title bar in auxiliary windows opened with a native title
   bar.** `nativeTitlebar` is an existing upstream option (the issue reporter
   window uses it), but upstream hardcodes `hasCustomTitlebar` to `true`, so
   such windows drew two title bars.
2. **Set `IsCompactTitleBarContext` from auxiliary editor parts.** The key was
   only bound by the custom title bar part, so anything gated on it (the
   Positron editor action bar suppression in compact windows) broke in windows
   without one, leaving an empty 28px bar above the editor.
3. **The new command**, in a new fork-owned file under
   `positronEditorActions`; registration is a one-line import in an existing
   fork-owned file, so no new upstream-file edits.

The plots special-case in `getAuxiliaryWindowOptionsForEditors` and both
`editorActions.ts` call sites are untouched.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

1. With any editor active, run
   `vscode.commands.executeCommand('positron.editor.moveIntoDedicatedWindow')`
   (e.g. from an extension or the debug console). The editor opens in a new
   window with a native OS title bar, no custom title bar beneath it, no tabs,
   no status bar, no empty editor action bar, sized like the source window.
2. Regression: right-click a plot editor tab > "Move Editor into New Window"
   still opens the compact 900x700 plots window, unchanged.
3. Regression: "Move Editor into New Window" on a regular editor still opens a
   normal auxiliary window (custom title bar, status bar), unchanged.
