### PR TITLE
CI: dedicated electron-only e2e-connect workflow (PR2)

### DIFF
--- a/.github/workflows/build-connect-linux.yml
+++ b/.github/workflows/build-connect-linux.yml
@@ -1,0 +1,112 @@
+name: "Build: Connect (Linux x64)"
+
+# Builds a plain Positron desktop DEB for the electron-only connect/publisher
+# e2e lane (test-e2e-connect.yml). Mirrors build-remote-ssh-linux.yml's DEB job
+# but drops the REH build -- e2e-connect drives a local electron app, no remote
+# extension host.
+
+on:
+  workflow_call:
+    outputs:
+      artifact-name:
+        description: "Name of the deb artifact uploaded"
+        value: ${{ jobs.build-deb.outputs.artifact-name }}
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  build-deb:
+    name: Build Positron DEB for Connect Tests
+    runs-on: ubuntu-latest-8x
+    timeout-minutes: 180
+    outputs:
+      artifact-name: positron-deb-connect-x64
+    container:
+      image: ghcr.io/posit-dev/positron-builds-rocky8:3
+      credentials:
+        username: ${{ secrets.POSITRON_GITHUB_RO_USER }}
+        password: ${{ secrets.POSITRON_GITHUB_RO_PAT }}
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      POSITRON_BUILD_NUMBER: 0
+      BUILD_SOURCEVERSION: ${{ github.sha }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Configure Git safe directory
+        run: |
+          git config --global --add safe.directory '*'
+          git rev-parse --show-toplevel
+
+      - name: Install build dependencies
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+          ELECTRON_SKIP_BINARY_DOWNLOAD: 1
+          npm_config_arch: x64
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: scl enable gcc-toolset-14 -- bash -eo pipefail {0}
+        run: |
+          # Check versions
+          g++ --version
+          python3 --version
+          pip --version
+
+          # Install build dependencies
+          npm install --prefix build --fetch-timeout 120000
+
+          # Install main dependencies
+          npm ci --fetch-timeout 120000
+
+      - name: Build Positron Client
+        env:
+          npm_config_arch: x64
+          MANGLER_WORKER_POOL_SIZE: 1
+        run: |
+          echo "Building Positron Client with commit SHA: ${{ env.BUILD_SOURCEVERSION }}"
+          npm run gulp vscode-linux-x64
+
+      - name: Correct Permissions
+        run: |
+          pushd ../VSCode-linux-x64/resources/app/extensions
+          find . -type f -name "*.ts" -exec chmod -x {} +
+          sed -i 's|#!/usr/bin/env python\b|#!/usr/bin/env python3|g' positron-python/python_files/lib/ipykernel/py3/jupyter_core/troubleshoot.py
+          popd
+
+      - name: Prepare Linux packages
+        env:
+          STRIP: /usr/bin/true
+          PERL5LIB: /root/.cpan/build:$PERL5LIB
+        run: |
+          npm run gulp vscode-linux-x64-prepare-deb
+
+      - name: Build DEB package
+        env:
+          STRIP: /usr/bin/true
+        run: |
+          echo "Building Positron DEB with commit SHA: ${{ env.BUILD_SOURCEVERSION }}"
+          npm run gulp vscode-linux-x64-build-deb
+          DEB_FILENAME="Positron-connect-x64.deb"
+          mv .build/linux/deb/*/deb/*.deb "$DEB_FILENAME"
+
+      - name: Upload DEB artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: positron-deb-connect-x64
+          path: Positron-connect-x64.deb
+          retention-days: 1

--- a/.github/workflows/test-e2e-connect.yml
+++ b/.github/workflows/test-e2e-connect.yml
@@ -42,9 +42,12 @@ jobs:
     env:
       AWS_S3_BUCKET: positron-test-reports
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      R_LIBS_SITE: /usr/local/lib/R/site-library
-      R_LIBS_USER: /usr/local/lib/R/site-library
       GH_SUMMARY_REPORT: true
+      # NOTE: do NOT set R_LIBS_SITE/R_LIBS_USER here. R is installed via rig on the
+      # host (see below) and pak lands in rig's managed library; forcing a custom
+      # lib path hides it ("there is no package called 'pak'"). The macOS run (also
+      # rig-based) sets neither. remote-ssh sets them only because its R runs in the
+      # remote container, not on the host.
       # Connect's image is linux/amd64 -- native on the amd64 runner (no emulation).
 
     steps:
@@ -110,7 +113,9 @@ jobs:
       - name: Install R packages
         env:
           # Pin to a frozen PPM snapshot (see test-e2e-macos-run.yml for rationale).
-          PPM_REPO: https://packagemanager.posit.co/cran/__linux__/jammy/2026-06-30
+          # Use the noble (24.04) binary repo -- the runner and rig's R deb are both
+          # ubuntu-2404, so jammy binaries would be the wrong distro.
+          PPM_REPO: https://packagemanager.posit.co/cran/__linux__/noble/2026-06-30
         run: |
           cp test/e2e/test-files/DESCRIPTION DESCRIPTION
           Rscript -e "options(pak.install_binary = TRUE, repos = c(CRAN = Sys.getenv('PPM_REPO'))); pak::local_install_dev_deps(ask = FALSE)"

--- a/.github/workflows/test-e2e-connect.yml
+++ b/.github/workflows/test-e2e-connect.yml
@@ -1,0 +1,207 @@
+name: "Test: E2E Connect (Ubuntu)"
+
+# Electron-only connect/publisher e2e lane. Drives a plain local Positron desktop
+# (installed from the DEB built by build-connect-linux.yml) against a standalone
+# Posit Connect container brought up via the connect-local compose -- no Workbench.
+# Complementary to the e2e-workbench lane, which provides the web/chromium coverage
+# for the same tests. See docker/environments/connect-local/PLAN.md.
+#
+# NOTE: new and intentionally NON-BLOCKING first (not wired into
+# test-merge.yml / test-full-suite.yml). Runs only when a PR is tagged @:connect.
+
+on:
+  workflow_call:
+    inputs:
+      display_name:
+        required: false
+        description: "The name of the job as it will appear in the GitHub Actions UI."
+        default: "connect"
+        type: string
+      upload_logs:
+        required: false
+        description: "Whether or not to upload e2e test logs."
+        type: boolean
+        default: true
+      allow_soft_fail:
+        required: false
+        description: "Whether to allow tests marked with :soft-fail to fail without failing the job."
+        type: boolean
+        default: false
+
+permissions:
+  id-token: write
+  contents: read
+  packages: read
+
+jobs:
+  e2e-connect-ubuntu:
+    name: ${{ inputs.display_name || 'connect' }}
+    runs-on: ubuntu-latest-8x
+    timeout-minutes: 80
+
+    env:
+      AWS_S3_BUCKET: positron-test-reports
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      R_LIBS_SITE: /usr/local/lib/R/site-library
+      R_LIBS_USER: /usr/local/lib/R/site-library
+      GH_SUMMARY_REPORT: true
+      # Connect's image is linux/amd64 -- native on the amd64 runner (no emulation).
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Docker login (GHCR)
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.POSITRON_GITHUB_RO_USER }}
+          password: ${{ secrets.POSITRON_GITHUB_RO_PAT }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.QA_AWS_RO_ROLE }}
+          aws-region: ${{ secrets.QA_AWS_REGION }}
+          role-duration-seconds: 21600
+
+      - name: Load secret
+        uses: 1password/load-secrets-action@v4
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          CONNECT_LICENSE: "op://Positron/Connect-lic-WB-Auto/notesPlain"
+
+      - name: Write Connect license
+        run: |
+          mkdir -p docker/environments/connect-local/connect
+          echo "$CONNECT_LICENSE" > docker/environments/connect-local/connect/connect.lic
+
+      - name: Setup test dependencies and compile tests
+        uses: ./.github/actions/setup-e2e-test-dependencies
+
+      - name: Download DEB artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: "positron-deb-connect-x64"
+          path: /tmp/artifacts
+
+      - name: Install Positron from DEB
+        run: |
+          sudo apt-get update && sudo apt-get install -y xdg-utils
+          sudo dpkg -i /tmp/artifacts/Positron-connect-x64.deb
+
+      # --- Interpreters (electron runs on the host, so R/Python/Quarto must be
+      # available on the host -- mirrors test-e2e-macos-run.yml). ---
+      - name: Install system libraries for R packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgdal-dev libudunits2-dev libcurl4-openssl-dev libssl-dev libxml2-dev
+
+      - name: Install rig and R
+        run: |
+          curl -Ls https://github.com/r-lib/rig/releases/download/latest/rig-linux-$(uname -m)-latest.tar.gz | sudo tar xz -C /usr/local
+          rig add 4.5.2
+          rig default 4.5.2
+
+      - name: Install R packages
+        env:
+          # Pin to a frozen PPM snapshot (see test-e2e-macos-run.yml for rationale).
+          PPM_REPO: https://packagemanager.posit.co/cran/__linux__/jammy/2026-06-30
+        run: |
+          cp test/e2e/test-files/DESCRIPTION DESCRIPTION
+          Rscript -e "options(pak.install_binary = TRUE, repos = c(CRAN = Sys.getenv('PPM_REPO'))); pak::local_install_dev_deps(ask = FALSE)"
+
+      - name: Install Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10.12"
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r test/e2e/test-files/requirements.txt
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tinytex: true
+
+      # --- Bring up standalone Posit Connect + bootstrap the publisher token.
+      # Uses the SAME connect-local compose + run.sh the local flow uses, so CI
+      # and local exercise one code path. run.sh brings connect up, waits for it
+      # to be healthy, and runs the one-shot token bootstrap, writing the token to
+      # docker/environments/connect-local/.tokens/connect_bootstrap_token. ---
+      - name: Start Connect and bootstrap token
+        run: |
+          cd docker/environments/connect-local
+          ./run.sh
+
+      - name: Export Connect publisher API key
+        run: |
+          TOKEN_FILE="docker/environments/connect-local/.tokens/connect_bootstrap_token"
+          # The one-shot token container runs as root, so the bootstrapped file is
+          # root-owned (mode 600) on the host -- read it with sudo.
+          if ! sudo test -s "$TOKEN_FILE"; then
+            echo "::error::Connect token was not bootstrapped at $TOKEN_FILE"
+            docker compose -f docker/environments/connect-local/docker-compose.yml logs connect || true
+            exit 1
+          fi
+          echo "CONNECT_PUBLISHER_API_KEY=$(sudo cat "$TOKEN_FILE")" >> "$GITHUB_ENV"
+
+      - name: Resolve Connect hostname
+        run: |
+          # The electron app publishes to the stored credential URL http://connect:3939;
+          # map that hostname to the published port on the host (see PLAN.md / README).
+          echo "127.0.0.1 connect" | sudo tee -a /etc/hosts
+
+      - name: Configure xvfb and dbus
+        uses: ./.github/actions/setup-xvfb
+
+      - name: Generate Report Directory
+        uses: ./.github/actions/gen-report-dir
+        with:
+          identifier: e2e-connect
+
+      - name: 🧪 Run Playwright Tests (Electron)
+        env:
+          POSITRON_PY_VER_SEL: "3.10.12"
+          POSITRON_R_VER_SEL: 4.5.2
+          POSITRON_PY_ALT_VER_SEL: "3.13.0"
+          POSITRON_R_ALT_VER_SEL: 4.4.2
+          PWTEST_BLOB_DO_NOT_REMOVE: 1
+          REPORTER_REPO_NAME: positron
+          PW_PROJECT_NAME: e2e-connect
+        run: |
+          export DISPLAY=:10
+          # The e2e-connect project already scopes to @:connect via its grep; no
+          # --grep needed. Serial to keep the single Connect server unambiguous.
+          BUILD=/usr/share/positron npx playwright test --project e2e-connect --retries=1 --workers=1
+
+      - name: Upload Playwright Report to S3
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/upload-report-to-s3
+        with:
+          role-to-assume: ${{ secrets.AWS_TEST_REPORTS_ROLE }}
+          report-dir: ${{ env.REPORT_DIR }}
+
+      - name: Upload Test Logs
+        if: ${{ always() && inputs.upload_logs }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-connect-ubuntu-logs
+          path: test-logs
+          retention-days: 3
+          if-no-files-found: ignore
+
+      - name: Teardown
+        if: always()
+        run: |
+          cd docker/environments/connect-local
+          ./stop-containers.sh --wipe || true

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -32,6 +32,7 @@ jobs:
       workbench_stable_tag_found: ${{ steps.pr-tags.outputs.workbench_stable_tag_found }}
       jupyter_tag_found: ${{ steps.pr-tags.outputs.jupyter_tag_found }}
       remote_ssh_tag_found: ${{ steps.pr-tags.outputs.remote_ssh_tag_found }}
+      connect_tag_found: ${{ steps.pr-tags.outputs.connect_tag_found }}
 
     steps:
       - uses: actions/checkout@v7
@@ -294,6 +295,24 @@ jobs:
     with:
       grep: ${{ needs.pr-tags.outputs.tags }}
       display_name: "remote-ssh"
+      upload_logs: false
+      allow_soft_fail: false
+    secrets: inherit
+
+  build-connect:
+    needs: pr-tags
+    if: ${{ needs.pr-tags.outputs.connect_tag_found == 'true' }}
+    name: build
+    uses: ./.github/workflows/build-connect-linux.yml
+    secrets: inherit
+
+  e2e-connect:
+    needs: [pr-tags, build-connect]
+    if: ${{ needs.pr-tags.outputs.connect_tag_found == 'true' }}
+    name: e2e
+    uses: ./.github/workflows/test-e2e-connect.yml
+    with:
+      display_name: "connect"
       upload_logs: false
       allow_soft_fail: false
     secrets: inherit

--- a/docker/environments/connect-local/PLAN.md
+++ b/docker/environments/connect-local/PLAN.md
@@ -205,6 +205,29 @@ naming nuance: `wb:connect` means "attach to the Workbench container", whereas
 - Tag a PR `@:connect` -> `build-connect` + `e2e-connect` run; iterate until green
   several times unattended; then optionally add it as a job to merge/full-suite.
 
+### PR 2 CI bring-up -- first green (run 29126155881, 2026-07-10)
+`build-connect` + `e2e-connect` both green; only the two publisher tests ran:
+`publisher-quarto-r` (2.5m) and `publisher-shiny` (1.0m), 2 passed / 0 failed.
+Three fixes were needed after the first attempts (all in this PR):
+1. Dropped job-level `R_LIBS_SITE`/`R_LIBS_USER` -- they overrode rig-managed R's
+   library path so the freshly-installed `pak` was invisible. (rig-based macOS run
+   sets neither; remote-ssh sets them only because its R runs in the container.)
+2. `PPM_REPO` -> noble (24.04) binary repo (was jammy); matches the runner and
+   rig's ubuntu-2404 R.
+3. `playwright.config.ts` e2e-connect project `grep: /@:connect/` -> `/@:connect(?![\w-])/`.
+   The bare regex substring-matched `@:connections`, dragging the Postgres/Snowflake
+   connections suite into the Connect-only lane. (Locally masked because the README
+   command passes a `test/e2e/tests/connect/` path; CI runs the project without a path.)
+
+Known non-fatal noise: the run logs `API failed after 3 attempts: HTTP 401` from the
+metrics/insights reporter (this lane sets no `CONNECT_API_KEY`/reporter creds); it does
+not affect pass/fail. Clean up later if desired.
+
+Watch-outs when writing the PR description: the PR-tag parser (pr-tags-parse.sh) and
+the Playwright project grep BOTH scan for tag literals as substrings, so writing
+`@:workbench`/`@:connections` in prose triggers those lanes / suites. Keep tag
+literals out of prose (or the body will spin up the Workbench build).
+
 ---
 
 ## Locked decisions

--- a/docker/environments/connect-local/PLAN.md
+++ b/docker/environments/connect-local/PLAN.md
@@ -146,31 +146,64 @@ naming nuance: `wb:connect` means "attach to the Workbench container", whereas
 
 ---
 
-## PR 2 -- Dedicated CI workflow (electron only)
+## PR 2 -- Dedicated CI workflow (electron only)  [IMPLEMENTED]
 
-### Changes
-- New `.github/workflows/test-e2e-connect.yml`, `ubuntu-latest` runner, modeled on
-  `test-e2e-ubuntu-run.yml`:
-  - Depends on the Positron electron BUILD artifact (download-artifact) -- `e2e-connect`
-    runs a real electron app; this is not optional boilerplate.
-  - Bring connect up via the PR-1 connect-only compose in a step AFTER checkout
-    (NOT GitHub Actions `services:` -- services start before checkout and cannot
-    bind-mount the gcfg/license files).
-  - Write `connect.lic` from the `CONNECT_LICENSE` 1Password secret (mirror the
-    Workbench workflow's license step); add the 1Password load step.
-  - Run the extracted bootstrap; export `CONNECT_PUBLISHER_API_KEY` (or point the
-    resolver at the token file).
-  - xvfb + playwright browsers, then `npx playwright test --project e2e-connect`.
+### Changes (as built)
+- New `.github/workflows/test-e2e-connect.yml`, `ubuntu-latest-8x` runner.
+  - **Structural model: `test-e2e-remote-ssh-ubuntu.yml`, not `test-e2e-ubuntu-run.yml`.**
+    Reason: `e2e-connect` must run docker compose on the host to stand up Connect
+    with bind-mounted gcfg/license (the `services:` limitation the plan called out),
+    and it needs the electron app + interpreters on that same host so
+    `localhost:3939` / the `connect` hostname resolve for both the app and the
+    published port. remote-ssh already does exactly this (plain host + `docker` +
+    a DEB-installed electron Positron); ubuntu-run runs inside the
+    `positron-ubuntu24` container where host docker/networking is not available.
+  - Depends on a Positron electron BUILD artifact: new
+    `.github/workflows/build-connect-linux.yml` builds a plain Positron DEB
+    (`positron-deb-connect-x64`, a trimmed copy of build-remote-ssh's DEB job --
+    no REH). The run workflow installs it with `dpkg -i` and runs electron with
+    `BUILD=/usr/share/positron`.
+  - Brings Connect up via the PR-1 connect-local compose in a step AFTER checkout
+    by calling `docker/environments/connect-local/run.sh` (same path as local),
+    then exports `CONNECT_PUBLISHER_API_KEY` from the bootstrapped token file
+    (read with `sudo` -- the one-shot token container writes it root-owned 0600).
+  - Writes `connect/connect.lic` from the `CONNECT_LICENSE` 1Password secret
+    (mirrors the Workbench workflow's license step) before `run.sh`.
+  - Installs interpreters on the host (R via rig, Python via setup-python, Quarto
+    via quarto-actions) -- mirrors `test-e2e-macos-run.yml`, since the electron
+    app runs on the host. **This is the most likely area to need iteration.**
+  - Adds `127.0.0.1 connect` to `/etc/hosts`, xvfb, then
+    `npx playwright test --project e2e-connect` (the project's own `grep`
+    scopes to `@:connect`).
+- Wired into `test-pull-request.yml`: `build-connect` + `e2e-connect` jobs gated
+  on `connect_tag_found` (build -> e2e via `needs`), mirroring the
+  build-remote-ssh -> e2e-remote-ssh pair.
+- `scripts/pr-tags-parse.sh` now sets `connect_tag_found=true` when the PR body
+  contains `@:connect` (word-boundary match so it does NOT fire on
+  `@:connections`); `pr-tags` job exposes it as an output.
+
+### Deviations from the original plan text
+- Runner is `ubuntu-latest-8x` (plain host) modeled on remote-ssh, not the
+  container-based `test-e2e-ubuntu-run.yml` -- see reason above. The plan's intent
+  (host + docker compose + downloaded electron build, NOT `services:`) is honored.
+- Single job (2 tests), no sharding / merge-reports -- unnecessary here and
+  keeps the non-blocking lane simple.
 
 ### Gotchas
-- Connect image is `linux/amd64` -- fine on amd64 runners (no emulation), but
-  bootstrap/reachability timing still needs generous waits.
+- Connect image is `linux/amd64` -- native on the amd64 runner (no emulation), but
+  bootstrap/reachability timing still needs generous waits (run.sh already waits).
+- Host interpreter install (R packages via PPM snapshot, system libs like
+  libgdal/libudunits) is the fragile part; expect to tune versions/deps.
+- `@:connect` lives in FeatureTags, so it is also auto-added to the default
+  electron lane's grep, but the `e2e-electron` project ignores `**/connect/**`,
+  so the connect tests do not double-run there. Only an explicit `@:connect` in
+  the PR body triggers this dedicated lane.
 - DO NOT wire this into `test-merge.yml` / `test-full-suite.yml` as a gate until it
   has had several green runs. New, non-blocking first.
 
 ### PR 2 verification
-- Workflow green several times unattended; then optionally add it as a job to
-  merge/full-suite.
+- Tag a PR `@:connect` -> `build-connect` + `e2e-connect` run; iterate until green
+  several times unattended; then optionally add it as a job to merge/full-suite.
 
 ---
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -210,7 +210,10 @@ export default defineConfig<CustomTestOptions>({
 				headless: false,
 				useExternalServer: false,
 			},
-			grep: /@:connect/
+			// Word-boundary guard: a bare /@:connect/ regex substring-matches
+			// '@:connections', pulling the connections suite (Postgres/Snowflake)
+			// into this Connect-only lane. Require a non-tag char (or end) after.
+			grep: /@:connect(?![\w-])/
 		},
 		{
 			name: 'e2e-remote-ssh',

--- a/scripts/pr-tags-parse.sh
+++ b/scripts/pr-tags-parse.sh
@@ -104,6 +104,13 @@ if echo "$PR_BODY" | grep -q "@:remote-ssh"; then
 	echo "Found remote-ssh tag in PR body. Setting to run remote-ssh tests."
 	echo "remote_ssh_tag_found=true" >> "$GITHUB_OUTPUT"
 fi
+# Match a bare '@:connect' tag but not '@:connections' (which shares the prefix).
+# The tag must be followed by a non-tag character (anything outside
+# [a-zA-Z0-9_-]) or the end of the string.
+if echo "$PR_BODY" | grep -qE "@:connect([^a-zA-Z0-9_-]|\$)"; then
+	echo "Found connect tag in PR body. Setting to run connect (electron) tests."
+	echo "connect_tag_found=true" >> "$GITHUB_OUTPUT"
+fi
 
 # Provenance inputs for build_tag_reasons, defaulted so the @:all branch (which
 # skips the else block that sets them) and any skipped derivation still resolve.


### PR DESCRIPTION
PR 2 of the "run connect/publisher e2e tests without Workbench" plan (`docker/environments/connect-local/PLAN.md`). PR 1 (#14824) moved the tests to `test/e2e/tests/connect/`, added the `e2e-connect` Playwright project, and made the suite locally runnable against a standalone Posit Connect container. This PR adds the dedicated, electron-only CI lane for it.

> Note: this description deliberately avoids writing other tag literals (the Workbench/connections tags) in prose, because the PR-tag parser scans the whole body and would otherwise spin up those lanes.

### Summary

A new CI lane drives a plain local Positron desktop (electron) against a standalone Posit Connect container -- no Workbench. It is complementary to the existing Workbench web lane, which continues to provide the web/chromium coverage for the same tests.

- **`.github/workflows/build-connect-linux.yml`** -- builds a plain Positron DEB (`positron-deb-connect-x64`), a trimmed copy of the remote-ssh DEB build (no REH).
- **`.github/workflows/test-e2e-connect.yml`** -- installs the DEB, stands up Connect via the PR-1 `connect-local` compose (`run.sh`), bootstraps the publisher token, installs host interpreters (rig/R, Python, Quarto), and runs `npx playwright test --project e2e-connect`.
- **`.github/workflows/test-pull-request.yml`** -- `build-connect` -> `e2e-connect` jobs, gated on `connect_tag_found`.
- **`scripts/pr-tags-parse.sh`** -- sets `connect_tag_found=true` on a bare connect tag (word-boundary match so it does not fire on the longer `connections` tag).

**Why remote-ssh, not `test-e2e-ubuntu-run.yml`:** the run workflow is modeled on `test-e2e-remote-ssh-ubuntu.yml` (plain `ubuntu-latest-8x` host + `docker` + DEB-installed electron) rather than the container-based `test-e2e-ubuntu-run.yml`, because Connect must come up via `docker compose` (bind-mounted gcfg/license) on the same host the electron app runs on, so `localhost:3939` and the `connect` hostname resolve for both. Interpreter setup mirrors `test-e2e-macos-run.yml`.

**Non-blocking first:** intentionally NOT wired into `test-merge.yml` / `test-full-suite.yml`. It runs only when a PR carries the connect tag, and should get several green runs before being promoted to a gate. Expect the host interpreter setup (rig/R packages, PPM snapshot, `libgdal`/`libudunits`, Quarto) to need a few iterations.

### Release Notes

#### New Features
- N/A (CI-only change)

#### Bug Fixes
- N/A

### Validation Steps

@:connect

This PR body carries the connect tag above, so `build-connect` + `e2e-connect` run on this PR. Confirm both jobs appear and that `e2e-connect` brings up Connect, bootstraps a token, and runs the two `test/e2e/tests/connect/` publisher tests (quarto-r, shiny) under the electron `e2e-connect` project. The Workbench web coverage is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
