### PR TITLE
Fix language params rarely appearing on update checks

### DIFF
--- a/.github/workflows/test-tag-paths-map.json
+++ b/.github/workflows/test-tag-paths-map.json
@@ -117,6 +117,7 @@
   "src/vs/platform/positronHeadlessLanguageModel/": ["@:positron-notebooks"],
   "src/vs/platform/positronIdleTracking/": [],
   "src/vs/platform/positronMemoryUsage/": ["@:variables"],
+  "src/vs/platform/update/": [],
   "src/vs/workbench/browser/parts/positronTopActionBar/": ["@:top-action-bar"],
   "src/vs/workbench/browser/positronAnsiRenderer/": ["@:console"],
   "src/vs/workbench/browser/positronDataExplorer/": ["@:data-explorer"],

--- a/src/vs/platform/update/common/positronUpdateUtils.ts
+++ b/src/vs/platform/update/common/positronUpdateUtils.ts
@@ -26,3 +26,99 @@ export function buildUpdateUrl(
 	}
 	return urlParams.length > 0 ? `${baseUrl}?${urlParams.join('&')}` : baseUrl;
 }
+
+/**
+ * A persisted record of the languages the user ran code in on a given UTC day.
+ * Reported on the next update check so usage survives short sessions and cold
+ * starts (the check often fires before any code has run in the current session).
+ */
+export interface IActiveLanguageRecord {
+	/** The UTC day the languages were used, as 'YYYY-MM-DD'. */
+	day: string;
+	/** The language ids used that day, e.g. ['python', 'r']. */
+	languages: string[];
+}
+
+/**
+ * Formats a timestamp as its UTC day string ('YYYY-MM-DD').
+ * @param timestamp Milliseconds since the epoch.
+ * @returns The UTC day, e.g. '2026-07-11'.
+ */
+export function toUtcDay(timestamp: number): string {
+	return new Date(timestamp).toISOString().slice(0, 10);
+}
+
+/**
+ * Determines which languages to report on an update check from a persisted
+ * record. The record's languages are reported only if its day is within
+ * `maxAgeDays` of today (UTC); a missing, malformed, or stale record reports
+ * nothing.
+ * @param record The persisted record, or undefined if none is stored.
+ * @param now The current time in milliseconds since the epoch.
+ * @param maxAgeDays The oldest a record's day may be and still be reported.
+ * @returns The languages to report, or an empty array.
+ */
+export function reportableLanguages(
+	record: IActiveLanguageRecord | undefined,
+	now: number,
+	maxAgeDays: number
+): string[] {
+	if (!record?.languages?.length) {
+		return [];
+	}
+	const recordDayMs = Date.parse(`${record.day}T00:00:00Z`);
+	if (Number.isNaN(recordDayMs)) {
+		return [];
+	}
+	const todayMs = new Date(now).setUTCHours(0, 0, 0, 0);
+	const ageDays = Math.round((todayMs - recordDayMs) / (24 * 60 * 60 * 1000));
+	return ageDays < 0 || ageDays > maxAgeDays ? [] : record.languages;
+}
+
+/**
+ * Serializes the languages used today into a storable record, for persisting
+ * across launches. Returns undefined for an empty set so a day with no usage
+ * yet never overwrites (clobbers) a previously stored day's languages.
+ * @param languages The languages used today, or an empty array.
+ * @param now The current time in milliseconds since the epoch.
+ * @returns The JSON string to store, or undefined if there is nothing to store.
+ */
+export function serializeActiveLanguageRecord(languages: string[], now: number): string | undefined {
+	if (languages.length === 0) {
+		return undefined;
+	}
+	const record: IActiveLanguageRecord = { day: toUtcDay(now), languages };
+	return JSON.stringify(record);
+}
+
+/**
+ * Resolves the languages to report on an update check: the current session's
+ * usage if any code has run today, otherwise the most recent stored day within
+ * the retention window. This lets the check carry a faithful signal even at cold
+ * start, when it typically fires before any code has run this session.
+ * @param activeLanguages The languages used so far in the current session today.
+ * @param stored The raw stored record JSON, or undefined if none is stored.
+ * @param now The current time in milliseconds since the epoch.
+ * @param maxAgeDays The oldest a stored day may be and still be reported.
+ * @returns The languages to report, or an empty array.
+ */
+export function resolveReportableLanguages(
+	activeLanguages: string[],
+	stored: string | undefined,
+	now: number,
+	maxAgeDays: number
+): string[] {
+	if (activeLanguages.length > 0) {
+		return activeLanguages;
+	}
+	if (!stored) {
+		return [];
+	}
+	let record: IActiveLanguageRecord;
+	try {
+		record = JSON.parse(stored) as IActiveLanguageRecord;
+	} catch {
+		return [];
+	}
+	return reportableLanguages(record, now, maxAgeDays);
+}

--- a/src/vs/platform/update/common/positronUpdateUtils.ts
+++ b/src/vs/platform/update/common/positronUpdateUtils.ts
@@ -76,49 +76,55 @@ export function reportableLanguages(
 }
 
 /**
- * Serializes the languages used today into a storable record, for persisting
- * across launches. Returns undefined for an empty set so a day with no usage
- * yet never overwrites (clobbers) a previously stored day's languages.
- * @param languages The languages used today, or an empty array.
- * @param now The current time in milliseconds since the epoch.
- * @returns The JSON string to store, or undefined if there is nothing to store.
+ * Parses a stored record's JSON back into a record. Returns undefined for a
+ * missing, corrupt, or structurally invalid value so callers can treat "nothing
+ * usable stored" uniformly.
+ * @param stored The raw stored record JSON, or undefined if none is stored.
+ * @returns The parsed record, or undefined.
  */
-export function serializeActiveLanguageRecord(languages: string[], now: number): string | undefined {
-	if (languages.length === 0) {
+export function parseActiveLanguageRecord(stored: string | undefined): IActiveLanguageRecord | undefined {
+	if (!stored) {
 		return undefined;
 	}
-	const record: IActiveLanguageRecord = { day: toUtcDay(now), languages };
-	return JSON.stringify(record);
+	try {
+		const record = JSON.parse(stored) as IActiveLanguageRecord;
+		if (typeof record?.day === 'string' && Array.isArray(record?.languages)) {
+			return record;
+		}
+		return undefined;
+	} catch {
+		return undefined;
+	}
 }
 
 /**
- * Resolves the languages to report on an update check: the current session's
- * usage if any code has run today, otherwise the most recent stored day within
- * the retention window. This lets the check carry a faithful signal even at cold
- * start, when it typically fires before any code has run this session.
- * @param activeLanguages The languages used so far in the current session today.
+ * Merges the languages used into the stored record for today, returning the JSON
+ * to persist. Multiple windows share one main-process update service and each
+ * pushes only its own languages, so this unions with the existing same-day
+ * record rather than overwriting (e.g. R in one window and Python in another
+ * both count toward today). A stored record from an earlier day is reset rather
+ * than extended, so today's report reflects only today's usage. Returns
+ * undefined when the merged set is empty, so a usage-free push never overwrites
+ * (clobbers) a previously stored day's languages.
  * @param stored The raw stored record JSON, or undefined if none is stored.
+ * @param languages The languages to merge in, or an empty array.
  * @param now The current time in milliseconds since the epoch.
- * @param maxAgeDays The oldest a stored day may be and still be reported.
- * @returns The languages to report, or an empty array.
+ * @returns The JSON string to store, or undefined if there is nothing to store.
  */
-export function resolveReportableLanguages(
-	activeLanguages: string[],
+export function mergeActiveLanguageRecord(
 	stored: string | undefined,
-	now: number,
-	maxAgeDays: number
-): string[] {
-	if (activeLanguages.length > 0) {
-		return activeLanguages;
+	languages: string[],
+	now: number
+): string | undefined {
+	const today = toUtcDay(now);
+	const existing = parseActiveLanguageRecord(stored);
+	const merged = new Set<string>(existing?.day === today ? existing.languages : []);
+	for (const language of languages) {
+		merged.add(language);
 	}
-	if (!stored) {
-		return [];
+	if (merged.size === 0) {
+		return undefined;
 	}
-	let record: IActiveLanguageRecord;
-	try {
-		record = JSON.parse(stored) as IActiveLanguageRecord;
-	} catch {
-		return [];
-	}
-	return reportableLanguages(record, now, maxAgeDays);
+	const record: IActiveLanguageRecord = { day: today, languages: [...merged].sort() };
+	return JSON.stringify(record);
 }

--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -37,7 +37,7 @@ import { IUpdate } from '../common/update.js';
 import { hasUpdate } from '../common/positronVersion.js';
 import { INativeHostMainService } from '../../native/electron-main/nativeHostMainService.js';
 import { IStateService } from '../../state/node/state.js';
-import { buildUpdateUrl } from '../common/positronUpdateUtils.js';
+import { buildUpdateUrl, resolveReportableLanguages, serializeActiveLanguageRecord } from '../common/positronUpdateUtils.js';
 
 // This was modfied from the original createUpdateURL as our update URL structure is much simpler
 export function createUpdateURL(platform: string, channel: string, productService: IProductService): string {
@@ -93,6 +93,8 @@ export abstract class AbstractUpdateService implements IUpdateService {
 	// enable the service to download and apply updates automatically
 	protected enableAutoUpdate = false;
 	private static readonly TELEMETRY_ID_KEY = 'telemetry.anonymousId';
+	private static readonly ACTIVE_LANGUAGES_KEY = 'update.activeLanguages';
+	private static readonly ACTIVE_LANGUAGES_MAX_AGE_DAYS = 7;
 	// --- End Positron ---
 
 	private _state: State = State.Uninitialized;
@@ -357,7 +359,8 @@ export abstract class AbstractUpdateService implements IUpdateService {
 		this.logService.debug('update#checkForUpdates, includeAnonymousUsage =', includeAnonymousId);
 		this.logService.trace('update#checkForUpdates, state = ', this.state.type);
 
-		this.logService.debug('update#checkForUpdates, languages =', this._activeLanguages.join(', '));
+		const languages = this.getReportableLanguages();
+		this.logService.debug('update#checkForUpdates, languages =', languages.join(', '));
 
 
 		if (this.state.type !== StateType.Idle) {
@@ -368,7 +371,7 @@ export abstract class AbstractUpdateService implements IUpdateService {
 
 		// Build URL with optional parameters
 		const anonymousId = includeAnonymousId ? this.getOrCreateTelemetryId() : undefined;
-		const releaseMetadataUrl = buildUpdateUrl(this.url!, this._activeLanguages, includeLanguages, anonymousId);
+		const releaseMetadataUrl = buildUpdateUrl(this.url!, languages, includeLanguages, anonymousId);
 
 		this.logService.debug('update#checkForUpdates, url =', releaseMetadataUrl);
 
@@ -629,6 +632,21 @@ export abstract class AbstractUpdateService implements IUpdateService {
 	}
 	updateActiveLanguages(languages: string[]): void {
 		this._activeLanguages = languages;
+		// Persist the day's usage so it can be reported on a later launch, even
+		// if this session ends before an update check fires.
+		const record = serializeActiveLanguageRecord(languages, Date.now());
+		if (record !== undefined) {
+			this.stateService.setItem(AbstractUpdateService.ACTIVE_LANGUAGES_KEY, record);
+		}
+	}
+
+	private getReportableLanguages(): string[] {
+		return resolveReportableLanguages(
+			this._activeLanguages,
+			this.stateService.getItem<string>(AbstractUpdateService.ACTIVE_LANGUAGES_KEY),
+			Date.now(),
+			AbstractUpdateService.ACTIVE_LANGUAGES_MAX_AGE_DAYS
+		);
 	}
 
 	private getOrCreateTelemetryId(): string {

--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -37,7 +37,7 @@ import { IUpdate } from '../common/update.js';
 import { hasUpdate } from '../common/positronVersion.js';
 import { INativeHostMainService } from '../../native/electron-main/nativeHostMainService.js';
 import { IStateService } from '../../state/node/state.js';
-import { buildUpdateUrl, resolveReportableLanguages, serializeActiveLanguageRecord } from '../common/positronUpdateUtils.js';
+import { buildUpdateUrl, mergeActiveLanguageRecord, parseActiveLanguageRecord, reportableLanguages } from '../common/positronUpdateUtils.js';
 
 // This was modfied from the original createUpdateURL as our update URL structure is much simpler
 export function createUpdateURL(platform: string, channel: string, productService: IProductService): string {
@@ -89,7 +89,6 @@ export abstract class AbstractUpdateService implements IUpdateService {
 	// --- Start Positron ---
 	// protected quality: string | undefined;
 	protected url: string | undefined;
-	private _activeLanguages: string[];
 	// enable the service to download and apply updates automatically
 	protected enableAutoUpdate = false;
 	private static readonly TELEMETRY_ID_KEY = 'telemetry.anonymousId';
@@ -156,10 +155,6 @@ export abstract class AbstractUpdateService implements IUpdateService {
 		// --- End Positron ---
 		protected readonly supportsUpdateOverwrite: boolean,
 	) {
-		// --- Start Positron ---
-		this._activeLanguages = [];
-		// --- End Positron ---
-
 		lifecycleMainService.when(LifecycleMainPhase.AfterWindowOpen)
 			.finally(() => this.initialize());
 	}
@@ -631,19 +626,25 @@ export abstract class AbstractUpdateService implements IUpdateService {
 		this.setState(State.AvailableForDownload(context));
 	}
 	updateActiveLanguages(languages: string[]): void {
-		this._activeLanguages = languages;
-		// Persist the day's usage so it can be reported on a later launch, even
-		// if this session ends before an update check fires.
-		const record = serializeActiveLanguageRecord(languages, Date.now());
+		// Persist the day's usage so it can be reported on a later launch, even if
+		// this session ends before an update check fires. Every window pushes into
+		// this single main-process service, each reporting only its own languages,
+		// so union with the stored same-day record rather than overwriting it (so
+		// R in one window and Python in another are both reported).
+		const stored = this.stateService.getItem<string>(AbstractUpdateService.ACTIVE_LANGUAGES_KEY);
+		const record = mergeActiveLanguageRecord(stored, languages, Date.now());
 		if (record !== undefined) {
 			this.stateService.setItem(AbstractUpdateService.ACTIVE_LANGUAGES_KEY, record);
 		}
 	}
 
 	private getReportableLanguages(): string[] {
-		return resolveReportableLanguages(
-			this._activeLanguages,
-			this.stateService.getItem<string>(AbstractUpdateService.ACTIVE_LANGUAGES_KEY),
+		// The stored record is the source of truth: it holds today's union across
+		// all windows, and at cold start (before any code has run this session) it
+		// holds the most recent day's usage within the retention window.
+		const stored = this.stateService.getItem<string>(AbstractUpdateService.ACTIVE_LANGUAGES_KEY);
+		return reportableLanguages(
+			parseActiveLanguageRecord(stored),
 			Date.now(),
 			AbstractUpdateService.ACTIVE_LANGUAGES_MAX_AGE_DAYS
 		);

--- a/src/vs/platform/update/test/common/positronUpdateUtils.vitest.ts
+++ b/src/vs/platform/update/test/common/positronUpdateUtils.vitest.ts
@@ -5,7 +5,7 @@
 
 /// <reference types="vitest/globals" />
 
-import { buildUpdateUrl } from '../../common/positronUpdateUtils.js';
+import { buildUpdateUrl, IActiveLanguageRecord, reportableLanguages, resolveReportableLanguages, serializeActiveLanguageRecord } from '../../common/positronUpdateUtils.js';
 
 describe('buildUpdateUrl', function () {
 	const baseUrl = 'https://updates.example.com/releases/darwin/arm64/releases.json';
@@ -64,5 +64,83 @@ describe('buildUpdateUrl', function () {
 			const result = buildUpdateUrl(baseUrl, ['python'], true, anonymousId);
 			expect(result.indexOf('python=1'), 'language should come before uuid').toBeLessThan(result.indexOf('uuid='));
 		});
+	});
+});
+
+describe('reportableLanguages', function () {
+	const maxAgeDays = 7;
+	// A fixed "now" so age math is deterministic.
+	const now = Date.parse('2026-07-11T09:00:00Z');
+
+	it('returns the languages when the record is from yesterday', () => {
+		// The core design intent: report the last active day at cold start.
+		const record: IActiveLanguageRecord = { day: '2026-07-10', languages: ['python'] };
+		expect(reportableLanguages(record, now, maxAgeDays)).toEqual(['python']);
+	});
+
+	it('returns the languages at exactly the max age boundary', () => {
+		const record: IActiveLanguageRecord = { day: '2026-07-04', languages: ['r'] };
+		expect(reportableLanguages(record, now, maxAgeDays)).toEqual(['r']);
+	});
+
+	it('returns empty when the record is older than the max age', () => {
+		const record: IActiveLanguageRecord = { day: '2026-07-03', languages: ['python'] };
+		expect(reportableLanguages(record, now, maxAgeDays)).toEqual([]);
+	});
+
+	it('returns empty when the record is undefined', () => {
+		expect(reportableLanguages(undefined, now, maxAgeDays)).toEqual([]);
+	});
+
+	it('returns empty when the record day is malformed', () => {
+		const record: IActiveLanguageRecord = { day: 'not-a-date', languages: ['python'] };
+		expect(reportableLanguages(record, now, maxAgeDays)).toEqual([]);
+	});
+});
+
+// The read/write decision the update service delegates to. These exercise the
+// same logic getReportableLanguages / updateActiveLanguages run, without the
+// electron-main service's dependency graph and constructor side effects.
+describe('active-language reporting (service logic)', function () {
+	const maxAgeDays = 7;
+	const now = Date.parse('2026-07-11T09:00:00Z');
+
+	describe('serializeActiveLanguageRecord', function () {
+		it('does not store an empty set, so a usage-free day cannot clobber a stored day', () => {
+			expect(serializeActiveLanguageRecord([], now)).toBeUndefined();
+		});
+
+		it('stores the day and languages for a non-empty set', () => {
+			const stored = serializeActiveLanguageRecord(['python', 'r'], now);
+			expect(JSON.parse(stored!)).toEqual({ day: '2026-07-11', languages: ['python', 'r'] });
+		});
+	});
+
+	describe('resolveReportableLanguages', function () {
+		it('prefers the live session set over the stored record', () => {
+			const stored = serializeActiveLanguageRecord(['r'], now);
+			expect(resolveReportableLanguages(['python'], stored, now, maxAgeDays)).toEqual(['python']);
+		});
+
+		it('falls back to the stored record when the live set is empty', () => {
+			const stored = serializeActiveLanguageRecord(['python'], now);
+			expect(resolveReportableLanguages([], stored, now, maxAgeDays)).toEqual(['python']);
+		});
+
+		it('returns empty when the live set is empty and nothing is stored', () => {
+			expect(resolveReportableLanguages([], undefined, now, maxAgeDays)).toEqual([]);
+		});
+
+		it('returns empty when the stored record is corrupt JSON', () => {
+			expect(resolveReportableLanguages([], '{not valid json', now, maxAgeDays)).toEqual([]);
+		});
+	});
+
+	it('round-trips a stored day into the next launch report', () => {
+		// Session 1 persists today's usage; session 2 launches the next day with
+		// no live usage yet and reports what was stored.
+		const stored = serializeActiveLanguageRecord(['python', 'r'], now);
+		const nextDay = Date.parse('2026-07-12T09:00:00Z');
+		expect(resolveReportableLanguages([], stored, nextDay, maxAgeDays)).toEqual(['python', 'r']);
 	});
 });

--- a/src/vs/platform/update/test/common/positronUpdateUtils.vitest.ts
+++ b/src/vs/platform/update/test/common/positronUpdateUtils.vitest.ts
@@ -96,6 +96,11 @@ describe('reportableLanguages', function () {
 		const record: IActiveLanguageRecord = { day: 'not-a-date', languages: ['python'] };
 		expect(reportableLanguages(record, now, maxAgeDays)).toEqual([]);
 	});
+
+	it('returns empty when the record is dated in the future (clock skew)', () => {
+		const record: IActiveLanguageRecord = { day: '2026-07-12', languages: ['python'] };
+		expect(reportableLanguages(record, now, maxAgeDays)).toEqual([]);
+	});
 });
 
 // The read/write decision the update service delegates to. These exercise the
@@ -132,6 +137,15 @@ describe('active-language reporting (service logic)', function () {
 			const nextDay = Date.parse('2026-07-12T09:00:00Z');
 			const today = mergeActiveLanguageRecord(yesterday, ['python'], nextDay);
 			expect(JSON.parse(today!)).toEqual({ day: '2026-07-12', languages: ['python'] });
+		});
+
+		it('does not clobber an earlier stored day when the new day has no usage yet', () => {
+			// A new UTC day dawns before any code runs: the empty push must leave
+			// yesterday's stored languages intact (returns undefined, so the caller
+			// skips the write) rather than resetting them to nothing.
+			const yesterday = mergeActiveLanguageRecord(undefined, ['r'], now);
+			const nextDay = Date.parse('2026-07-12T09:00:00Z');
+			expect(mergeActiveLanguageRecord(yesterday, [], nextDay)).toBeUndefined();
 		});
 	});
 

--- a/src/vs/platform/update/test/common/positronUpdateUtils.vitest.ts
+++ b/src/vs/platform/update/test/common/positronUpdateUtils.vitest.ts
@@ -5,7 +5,7 @@
 
 /// <reference types="vitest/globals" />
 
-import { buildUpdateUrl, IActiveLanguageRecord, reportableLanguages, resolveReportableLanguages, serializeActiveLanguageRecord } from '../../common/positronUpdateUtils.js';
+import { buildUpdateUrl, IActiveLanguageRecord, mergeActiveLanguageRecord, parseActiveLanguageRecord, reportableLanguages } from '../../common/positronUpdateUtils.js';
 
 describe('buildUpdateUrl', function () {
 	const baseUrl = 'https://updates.example.com/releases/darwin/arm64/releases.json';
@@ -105,42 +105,55 @@ describe('active-language reporting (service logic)', function () {
 	const maxAgeDays = 7;
 	const now = Date.parse('2026-07-11T09:00:00Z');
 
-	describe('serializeActiveLanguageRecord', function () {
-		it('does not store an empty set, so a usage-free day cannot clobber a stored day', () => {
-			expect(serializeActiveLanguageRecord([], now)).toBeUndefined();
+	describe('mergeActiveLanguageRecord', function () {
+		it('stores the day and languages for a non-empty set', () => {
+			const stored = mergeActiveLanguageRecord(undefined, ['python', 'r'], now);
+			expect(JSON.parse(stored!)).toEqual({ day: '2026-07-11', languages: ['python', 'r'] });
 		});
 
-		it('stores the day and languages for a non-empty set', () => {
-			const stored = serializeActiveLanguageRecord(['python', 'r'], now);
-			expect(JSON.parse(stored!)).toEqual({ day: '2026-07-11', languages: ['python', 'r'] });
+		it('does not store an empty set, so a usage-free day cannot clobber a stored day', () => {
+			expect(mergeActiveLanguageRecord(undefined, [], now)).toBeUndefined();
+		});
+
+		it('unions a new language into the same day (e.g. R and Python in separate windows)', () => {
+			// One window reports R, another reports Python on the same day; both count.
+			const afterR = mergeActiveLanguageRecord(undefined, ['r'], now);
+			const afterPython = mergeActiveLanguageRecord(afterR, ['python'], now);
+			expect(JSON.parse(afterPython!)).toEqual({ day: '2026-07-11', languages: ['python', 'r'] });
+		});
+
+		it('preserves the stored day when a window reports nothing', () => {
+			const afterR = mergeActiveLanguageRecord(undefined, ['r'], now);
+			expect(mergeActiveLanguageRecord(afterR, [], now)).toEqual(afterR);
+		});
+
+		it('resets to only the new day when the stored record is from an earlier day', () => {
+			const yesterday = mergeActiveLanguageRecord(undefined, ['r'], now);
+			const nextDay = Date.parse('2026-07-12T09:00:00Z');
+			const today = mergeActiveLanguageRecord(yesterday, ['python'], nextDay);
+			expect(JSON.parse(today!)).toEqual({ day: '2026-07-12', languages: ['python'] });
 		});
 	});
 
-	describe('resolveReportableLanguages', function () {
-		it('prefers the live session set over the stored record', () => {
-			const stored = serializeActiveLanguageRecord(['r'], now);
-			expect(resolveReportableLanguages(['python'], stored, now, maxAgeDays)).toEqual(['python']);
+	describe('parseActiveLanguageRecord', function () {
+		it('returns undefined when nothing is stored', () => {
+			expect(parseActiveLanguageRecord(undefined)).toBeUndefined();
 		});
 
-		it('falls back to the stored record when the live set is empty', () => {
-			const stored = serializeActiveLanguageRecord(['python'], now);
-			expect(resolveReportableLanguages([], stored, now, maxAgeDays)).toEqual(['python']);
+		it('returns undefined when the stored record is corrupt JSON', () => {
+			expect(parseActiveLanguageRecord('{not valid json')).toBeUndefined();
 		});
 
-		it('returns empty when the live set is empty and nothing is stored', () => {
-			expect(resolveReportableLanguages([], undefined, now, maxAgeDays)).toEqual([]);
-		});
-
-		it('returns empty when the stored record is corrupt JSON', () => {
-			expect(resolveReportableLanguages([], '{not valid json', now, maxAgeDays)).toEqual([]);
+		it('returns undefined when the stored record is missing required fields', () => {
+			expect(parseActiveLanguageRecord('{"day":"2026-07-11"}')).toBeUndefined();
 		});
 	});
 
 	it('round-trips a stored day into the next launch report', () => {
-		// Session 1 persists today's usage; session 2 launches the next day with
-		// no live usage yet and reports what was stored.
-		const stored = serializeActiveLanguageRecord(['python', 'r'], now);
+		// Session 1 persists today's usage; session 2 launches the next day with no
+		// live usage yet and reports what was stored.
+		const stored = mergeActiveLanguageRecord(undefined, ['python', 'r'], now);
 		const nextDay = Date.parse('2026-07-12T09:00:00Z');
-		expect(resolveReportableLanguages([], stored, nextDay, maxAgeDays)).toEqual(['python', 'r']);
+		expect(reportableLanguages(parseActiveLanguageRecord(stored), nextDay, maxAgeDays)).toEqual(['python', 'r']);
 	});
 });

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -23,6 +23,7 @@ import { IExtensionService } from '../../extensions/common/extensions.js';
 import { IStorageService, StorageScope } from '../../../../platform/storage/common/storage.js';
 import { ActiveRuntimeSession } from './activeRuntimeSession.js';
 import { IUpdateService } from '../../../../platform/update/common/update.js';
+import { toUtcDay } from '../../../../platform/update/common/positronUpdateUtils.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { localize } from '../../../../nls.js';
 import { UiClientInstance } from '../../languageRuntime/common/languageRuntimeUiClient.js';
@@ -121,6 +122,11 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	// from sessionId to session. We keep these around so we can reconnect them when
 	// the extension host comes back online.
 	private readonly _disconnectedSessions = new Map<string, ActiveRuntimeSession>();
+
+	// The last active-language set pushed to the update service, keyed by UTC day
+	// and sorted language ids, so repeated execution events don't re-push an
+	// unchanged set (and a session spanning UTC midnight re-pushes for the new day).
+	private _lastReportedLanguagesKey = '';
 
 	// The event emitter for the onWillStartRuntime event.
 	private readonly _onWillStartRuntimeEmitter =
@@ -2032,6 +2038,14 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 				case RuntimeState.Exited:
 					this.updateSessionMapsAfterExit(session);
 					break;
+
+				case RuntimeState.Busy:
+					// The session is running code, so refresh the active language
+					// usage reported on update checks. This is the earliest reliable
+					// "code ran" signal; by now execute() has set the session's
+					// lastUsed timestamp.
+					this.updateActiveLanguages();
+					break;
 			}
 
 			// Let listeners know that the runtime state has changed.
@@ -2467,7 +2481,15 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 				languages.add(activeSession.session.runtimeMetadata.languageId);
 			}
 		});
-		this._updateService.updateActiveLanguages([...languages]);
+		const sorted = [...languages].sort();
+		// Skip the push if nothing changed since last time. The key includes the
+		// UTC day so a long-running session re-reports after crossing midnight.
+		const key = `${toUtcDay(Date.now())}|${sorted.join(',')}`;
+		if (key === this._lastReportedLanguagesKey) {
+			return;
+		}
+		this._lastReportedLanguagesKey = key;
+		this._updateService.updateActiveLanguages(sorted);
 	}
 
 	/**

--- a/src/vs/workbench/services/runtimeSession/test/common/testRuntimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/testRuntimeSessionService.ts
@@ -31,6 +31,7 @@ import { TestLanguageRuntimeSession } from './testLanguageRuntimeSession.js';
 import { TestOpenerService, TestPositronModalDialogService, TestCommandService, TestRuntimeSessionManager, TestConfigurationResolverService, TestDirectoryFileService, TestPathService } from '../../../../test/common/positronWorkbenchTestServices.js';
 import { TestExtensionService, TestStorageService, TestWorkspaceTrustManagementService, TestContextService } from '../../../../test/common/workbenchTestServices.js';
 import { INotificationService } from '../../../../../platform/notification/common/notification.js';
+import { IUpdateService } from '../../../../../platform/update/common/update.js';
 import { TestNotificationService } from '../../../../../platform/notification/test/common/testNotificationService.js';
 import { IConfigurationResolverService } from '../../../configurationResolver/common/configurationResolver.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
@@ -58,6 +59,7 @@ export function createRuntimeServices(
 	instantiationService.stub(ICommandService, new TestCommandService(instantiationService));
 	instantiationService.stub(IKeybindingService, new MockKeybindingService());
 	instantiationService.stub(INotificationService, new TestNotificationService());
+	instantiationService.stub(IUpdateService, { updateActiveLanguages: () => { } });
 	instantiationService.stub(IRuntimeSessionService, disposables.add(instantiationService.createInstance(RuntimeSessionService)));
 	return instantiationService;
 }


### PR DESCRIPTION
Fixes posit-dev/positron-builds#1087

Update checks were meant to carry the user's primary-language usage (`python=1`/`r=1`), but our logs showed the language params almost _never_ appeared. Two things caused this: 

- The update check fires about 30s after launch, before the active-language set has been populated (a cross-process timing race between the main-process check and the renderer's language refresh).
- Even once populated the set only reflected code run in the current live session, so a short (like less than 6 hours) session that ended before a check fired reported nothing.

This changes the reporting model to persist the languages used per UTC day and report the most recent active day at startup. At cold start the check reads the last active day's usage directly from storage, with no dependency on the in-session refresh timer, which removes the race. A session's usage is persisted as soon as code runs (on the session's `Busy` transition), so short sessions are captured on the next launch. A stored day is reported only if it is within the last 7 days, and a usage-free day never overwrites a previously stored day. The read/write decision logic lives in pure functions in `positronUpdateUtils.ts` so it is unit tested directly (prefer live set, fall back to stored, staleness boundary, corrupt storage, and a write-then-read round-trip) rather than through the electron-main service's dependency graph.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Report primary-language usage reliably on update checks by persisting daily usage across launches (posit-dev/positron-builds#1087)

### Validation Steps

Unit tests cover the reporting logic:

```
npx vitest run src/vs/platform/update/test/common/positronUpdateUtils.vitest.ts
```

The update-check query string has no practical e2e surface (it depends on the update server and telemetry). To confirm manually in a _release_ build:

1. Run code in a Python or R console so the session records usage, then quit.
2. Relaunch (the next UTC day even? probably not realistic for reviewing) and let the update check fire (about 30s after launch, or trigger _Check for Updates_).
3. In the update service debug logs, confirm the check logs the stored languages (`update#checkForUpdates, languages = python`) and the request URL carries `python=1`/`r=1`.
