### PR TITLE
Declare fs-extra as an e2e test dependency

### DIFF
--- a/test/e2e/package-lock.json
+++ b/test/e2e/package-lock.json
@@ -12,6 +12,7 @@
         "@anthropic-ai/sdk": "^0.52.0",
         "@aws-sdk/client-s3": "^3.722.0",
         "canvas": "^3.2.0",
+        "fs-extra": "^11.3.6",
         "mkdirp": "^1.0.4",
         "ncp": "^2.0.0",
         "node-fetch": "^2.6.7",
@@ -2491,6 +2492,20 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "license": "MIT"
     },
+    "node_modules/fs-extra": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
+      "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
       "license": "ISC",
@@ -2698,7 +2713,6 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-bigints": {
@@ -3201,6 +3215,18 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "node_modules/lazystream": {
       "version": "1.0.1",
@@ -4691,6 +4717,15 @@
       "version": "6.19.8",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -11,6 +11,7 @@
     "@anthropic-ai/sdk": "^0.52.0",
     "@aws-sdk/client-s3": "^3.722.0",
     "canvas": "^3.2.0",
+    "fs-extra": "^11.3.6",
     "mkdirp": "^1.0.4",
     "ncp": "^2.0.0",
     "node-fetch": "^2.6.7",


### PR DESCRIPTION
Declares `fs-extra` as a dependency of the e2e test package so it resolves deterministically in the against-a-build test path.

### Summary

`test/e2e/tests/quarto/quarto-r.test.ts` does a top-level `require('fs-extra')`, but `fs-extra` was not declared in `test/e2e/package.json`. In normal dev CI it resolves transitively via the root `npm ci`, but the against-a-build e2e path (used by the daily release build in `posit-dev/positron-builds`) installs dependencies piecemeal via the `setup-e2e-test-dependencies` action -- a stubbed root `package.json` plus a hand-maintained `npm install` list. That path is non-deterministic on Windows and can leave `fs-extra` unresolvable in the root `node_modules`.

Because Playwright loads every test file during collection, one unresolvable top-level `require` aborts the entire run (0 passed / 0 failed). This is what sank the `remote-wsl (windows)` job in [positron-builds run 29234289296](https://github.com/posit-dev/positron-builds/actions/runs/29234289296) while `electron (windows)` passed against the same build.

Declaring `fs-extra` in `test/e2e`'s own `package.json` guarantees `npm --prefix test/e2e install` provides it, removing the reliance on the fragile root install list. The lockfile change also promotes `graceful-fs` from dev-only to production scope (it's a transitive of `fs-extra`) and adds `jsonfile`/`universalify`.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:quarto @:remote-wsl

1. Run the Quarto e2e suite and confirm collection succeeds with no `Cannot find module 'fs-extra'` error: `npx playwright test test/e2e/tests/quarto --project e2e-electron`
2. From `test/e2e/tests/quarto`, confirm resolution after a scoped install: `npm --prefix test/e2e install` then `node -e "require('fs-extra')"`.