### PR TITLE
Fall back to open Positron notebooks in notebooks.getContext when none is the active editor pane

### DIFF
--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -3786,8 +3786,9 @@ declare module 'positron' {
 		 * Get context about the active notebook.
 		 *
 		 * When no Positron notebook is the active editor pane (e.g. focus is
-		 * in another editor or view), falls back to the most recently active
-		 * Positron notebook that is still open.
+		 * in another editor or view), falls back to the open notebook attached
+		 * to the foreground session, then to the most recently active Positron
+		 * notebook that is still open.
 		 *
 		 * Resolves with `undefined` when no notebook is open. Rejects with an
 		 * actionable error when the active editor holds a notebook in an

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -3785,13 +3785,18 @@ declare module 'positron' {
 		/**
 		 * Get context about the active notebook.
 		 *
-		 * Resolves with `undefined` when no notebook is open. Rejects with an
-		 * actionable error when a notebook is open but in an editor other than
-		 * the Positron Notebook Editor (e.g. the built-in/Jupyter notebook
-		 * editor), since the notebook API only operates on Positron Notebook
-		 * Editor instances; the error message explains how to switch editors.
+		 * When no Positron notebook is the active editor pane (e.g. focus is
+		 * in another editor or view), falls back to the most recently active
+		 * Positron notebook that is still open.
 		 *
-		 * @returns The notebook context, or undefined if no notebook is active
+		 * Resolves with `undefined` when no notebook is open. Rejects with an
+		 * actionable error when the active editor holds a notebook in an
+		 * editor other than the Positron Notebook Editor (e.g. the
+		 * built-in/Jupyter notebook editor), since the notebook API only
+		 * operates on Positron Notebook Editor instances; the error message
+		 * explains how to switch editors.
+		 *
+		 * @returns The notebook context, or undefined if no notebook is open
 		 */
 		export function getContext(): Thenable<NotebookContext | undefined>;
 

--- a/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
@@ -93,8 +93,9 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 
 	/**
 	 * Gets the context information for the currently active notebook. When no
-	 * Positron notebook is the active editor pane, falls back to the most
-	 * recently active Positron notebook that is still open.
+	 * Positron notebook is the active editor pane, falls back to the open
+	 * notebook attached to the foreground session, then to the most recently
+	 * active Positron notebook that is still open.
 	 * @returns The notebook context DTO, or undefined if no notebook is open.
 	 */
 	async $getActiveNotebookContext(): Promise<INotebookContextDTO | undefined> {
@@ -111,10 +112,10 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 				throw new Error(unsupportedEditorMessage);
 			}
 			// A Positron notebook can be open without being the active editor
-			// pane (focus in a chat editor, a split group, or another tab).
-			// Fall back to the most recently active open notebook so assistant
-			// tools can still find it (#14762).
-			instance = this._getMostRecentlyActiveNotebookInstance();
+			// pane (a Data Explorer or plot editor took the pane, focus moved
+			// to another tab mid-turn). Fall back to an open notebook so
+			// assistant tools can still find it (#14762).
+			instance = this._getFallbackNotebookInstance();
 			if (!instance) {
 				return undefined;
 			}
@@ -715,12 +716,21 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 	}
 
 	/**
-	 * Finds the open Positron notebook instance whose editor was most
-	 * recently active, regardless of which editor pane currently has focus.
+	 * Finds an open Positron notebook instance when none is the active editor
+	 * pane. Prefers the notebook attached to the foreground session (what the
+	 * interpreter picker shows, and what assistant notebook mode is keyed on),
+	 * then falls back to the notebook whose editor was most recently active.
 	 * @returns The notebook instance, or undefined if no Positron notebook
 	 * editor is open.
 	 */
-	private _getMostRecentlyActiveNotebookInstance(): IPositronNotebookInstance | undefined {
+	private _getFallbackNotebookInstance(): IPositronNotebookInstance | undefined {
+		const foregroundNotebookUri = this._runtimeSessionService.foregroundSession?.metadata.notebookUri;
+		if (foregroundNotebookUri) {
+			const instances = this._positronNotebookService.listInstances(foregroundNotebookUri);
+			if (instances.length > 0) {
+				return instances[0];
+			}
+		}
 		for (const { editor } of this._editorService.getEditors(EditorsOrder.MOST_RECENTLY_ACTIVE)) {
 			if (editor.typeId !== POSITRON_NOTEBOOK_EDITOR_INPUT_ID || !editor.resource) {
 				continue;

--- a/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
@@ -23,6 +23,8 @@ import { rasterizeSvgToPng } from '../../../contrib/positronNotebook/browser/svg
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { POSITRON_NOTEBOOK_ASSISTANT_AUTO_FOLLOW_KEY } from '../../../contrib/positronNotebook/common/positronNotebookConfig.js';
 import { IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
+import { EditorsOrder } from '../../../common/editor.js';
+import { POSITRON_NOTEBOOK_EDITOR_INPUT_ID } from '../../../contrib/positronNotebook/common/positronNotebookCommon.js';
 
 /**
  * Main thread implementation of notebook features for extension host communication.
@@ -90,12 +92,14 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 	}
 
 	/**
-	 * Gets the context information for the currently active notebook.
-	 * @returns The notebook context DTO, or undefined if no notebook is active.
+	 * Gets the context information for the currently active notebook. When no
+	 * Positron notebook is the active editor pane, falls back to the most
+	 * recently active Positron notebook that is still open.
+	 * @returns The notebook context DTO, or undefined if no notebook is open.
 	 */
 	async $getActiveNotebookContext(): Promise<INotebookContextDTO | undefined> {
 		// Use existing helper function instead of service method
-		const instance = getNotebookInstanceFromActiveEditorPane(this._editorService);
+		let instance = getNotebookInstanceFromActiveEditorPane(this._editorService);
 		if (!instance) {
 			// A notebook may be open, but in the built-in editor rather than the
 			// Positron Notebook Editor that this API operates on. Surface an
@@ -106,7 +110,14 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 			if (unsupportedEditorMessage) {
 				throw new Error(unsupportedEditorMessage);
 			}
-			return undefined;
+			// A Positron notebook can be open without being the active editor
+			// pane (focus in a chat editor, a split group, or another tab).
+			// Fall back to the most recently active open notebook so assistant
+			// tools can still find it (#14762).
+			instance = this._getMostRecentlyActiveNotebookInstance();
+			if (!instance) {
+				return undefined;
+			}
 		}
 
 		// Get current state from observables
@@ -701,6 +712,25 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 			throw new Error(`No text model found for notebook: ${notebookUri}`);
 		}
 		return instance.textModel;
+	}
+
+	/**
+	 * Finds the open Positron notebook instance whose editor was most
+	 * recently active, regardless of which editor pane currently has focus.
+	 * @returns The notebook instance, or undefined if no Positron notebook
+	 * editor is open.
+	 */
+	private _getMostRecentlyActiveNotebookInstance(): IPositronNotebookInstance | undefined {
+		for (const { editor } of this._editorService.getEditors(EditorsOrder.MOST_RECENTLY_ACTIVE)) {
+			if (editor.typeId !== POSITRON_NOTEBOOK_EDITOR_INPUT_ID || !editor.resource) {
+				continue;
+			}
+			const instances = this._positronNotebookService.listInstances(editor.resource);
+			if (instances.length > 0) {
+				return instances[0];
+			}
+		}
+		return undefined;
 	}
 
 	/**

--- a/src/vs/workbench/api/test/browser/positron/mainThreadNotebookFeatures.vitest.ts
+++ b/src/vs/workbench/api/test/browser/positron/mainThreadNotebookFeatures.vitest.ts
@@ -9,14 +9,20 @@ import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { encodeBase64, VSBuffer } from '../../../../../base/common/buffer.js';
 import { constObservable } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { isEqual } from '../../../../../base/common/resources.js';
 import { IExtHostContext } from '../../../../services/extensions/common/extHostCustomers.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
+import { IVisibleEditorPane } from '../../../../common/editor.js';
+import { EditorInput } from '../../../../common/editor/editorInput.js';
 import { IPositronNotebookService } from '../../../../contrib/positronNotebook/browser/positronNotebookService.js';
 import { IPositronNotebookInstance } from '../../../../contrib/positronNotebook/browser/IPositronNotebookInstance.js';
 import { IPositronNotebookCodeCell, NotebookCellOutputs } from '../../../../contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.js';
+import { SelectionState, SelectionStateMachine } from '../../../../contrib/positronNotebook/browser/selectionMachine.js';
+import { POSITRON_NOTEBOOK_EDITOR_INPUT_ID } from '../../../../contrib/positronNotebook/common/positronNotebookCommon.js';
 import { MainThreadNotebookFeatures } from '../../../browser/positron/mainThreadNotebookFeatures.js';
 
 const { mockRasterizeSvgToPng } = vi.hoisted(() => ({ mockRasterizeSvgToPng: vi.fn() }));
@@ -107,6 +113,114 @@ describe('MainThreadNotebookFeatures $getCellOutputs SVG handling', () => {
 		const outputs = await features.$getCellOutputs(NOTEBOOK_URI, 0);
 
 		expect(outputs).toEqual([{ mimeType: 'image/svg+xml', data: SVG_TEXT }]);
+		features.dispose();
+	});
+});
+
+describe('MainThreadNotebookFeatures $getActiveNotebookContext', () => {
+	createTestContainer().build();
+
+	const TEXT_FILE_EDITOR_PANE_ID = 'workbench.editors.files.textFileEditor';
+	const TEXT_FILE_EDITOR_INPUT_ID = 'workbench.editors.files.fileEditorInput';
+
+	/** A notebook instance stub with no cells, no kernel, and no selection. */
+	function createNotebookInstance(uriString: string): IPositronNotebookInstance {
+		return stubInterface<IPositronNotebookInstance>({
+			uri: URI.parse(uriString),
+			cells: constObservable([]),
+			kernel: constObservable(undefined),
+			selectionStateMachine: stubInterface<SelectionStateMachine>({
+				state: constObservable({ type: SelectionState.NoCells }),
+			}),
+		});
+	}
+
+	/** An editor input stub as it appears in the editor service's MRU list. */
+	function createEditorInput(typeId: string, uriString: string): EditorInput {
+		return stubInterface<EditorInput>({
+			typeId,
+			resource: URI.parse(uriString),
+		});
+	}
+
+	/**
+	 * Builds a MainThreadNotebookFeatures against a stubbed editor state: the
+	 * given active pane, editors in most-recently-active order, and the open
+	 * Positron notebook instances.
+	 */
+	function createContextFeatures(options: {
+		activeEditorPane: IVisibleEditorPane | undefined;
+		mruEditors: EditorInput[];
+		instances: IPositronNotebookInstance[];
+	}): MainThreadNotebookFeatures {
+		const editorService = stubInterface<IEditorService>({
+			activeEditorPane: options.activeEditorPane,
+			getEditors: () => options.mruEditors.map((editor, groupId) => ({ groupId, editor })),
+		});
+		const notebookService = stubInterface<IPositronNotebookService>({
+			listInstances: (uri?: URI) => options.instances.filter(instance => !uri || isEqual(instance.uri, uri)),
+		});
+		return new MainThreadNotebookFeatures(
+			stubInterface<IExtHostContext>(),
+			editorService,
+			notebookService,
+			stubInterface<ILogService>(),
+			stubInterface<IConfigurationService>(),
+			stubInterface<IRuntimeSessionService>({ getNotebookSessionForNotebookUri: () => undefined }),
+		);
+	}
+
+	it('resolves an open Positron notebook when it is not the active editor pane (#14762)', async () => {
+		const notebookUri = 'file:///test/notebook.ipynb';
+		const notebook = createNotebookInstance(notebookUri);
+		// Focus is elsewhere: the user is typing in another editor (chat
+		// editor, split group, another file tab) while the notebook stays
+		// open in its own tab.
+		const features = createContextFeatures({
+			activeEditorPane: stubInterface<IVisibleEditorPane>({ getId: () => TEXT_FILE_EDITOR_PANE_ID }),
+			mruEditors: [
+				createEditorInput(TEXT_FILE_EDITOR_INPUT_ID, 'file:///test/script.py'),
+				createEditorInput(POSITRON_NOTEBOOK_EDITOR_INPUT_ID, notebookUri),
+			],
+			instances: [notebook],
+		});
+
+		const context = await features.$getActiveNotebookContext();
+
+		expect(context?.uri).toBe(notebookUri);
+		features.dispose();
+	});
+
+	it('resolves the most recently active notebook when multiple are open and none is active', async () => {
+		const olderUri = 'file:///test/older.ipynb';
+		const recentUri = 'file:///test/recent.ipynb';
+		// Registration order (older first) deliberately differs from MRU
+		// order (recent first): the fallback must follow the editor
+		// service's most-recently-active order, not instance registration.
+		const features = createContextFeatures({
+			activeEditorPane: stubInterface<IVisibleEditorPane>({ getId: () => TEXT_FILE_EDITOR_PANE_ID }),
+			mruEditors: [
+				createEditorInput(TEXT_FILE_EDITOR_INPUT_ID, 'file:///test/script.py'),
+				createEditorInput(POSITRON_NOTEBOOK_EDITOR_INPUT_ID, recentUri),
+				createEditorInput(POSITRON_NOTEBOOK_EDITOR_INPUT_ID, olderUri),
+			],
+			instances: [createNotebookInstance(olderUri), createNotebookInstance(recentUri)],
+		});
+
+		const context = await features.$getActiveNotebookContext();
+
+		expect(context?.uri).toBe(recentUri);
+		features.dispose();
+	});
+
+	it('resolves undefined when no Positron notebook is open anywhere', async () => {
+		const features = createContextFeatures({
+			activeEditorPane: stubInterface<IVisibleEditorPane>({ getId: () => TEXT_FILE_EDITOR_PANE_ID }),
+			mruEditors: [createEditorInput(TEXT_FILE_EDITOR_INPUT_ID, 'file:///test/script.py')],
+			instances: [],
+		});
+
+		expect(await features.$getActiveNotebookContext()).toBeUndefined();
 		features.dispose();
 	});
 });

--- a/src/vs/workbench/api/test/browser/positron/mainThreadNotebookFeatures.vitest.ts
+++ b/src/vs/workbench/api/test/browser/positron/mainThreadNotebookFeatures.vitest.ts
@@ -145,11 +145,6 @@ describe('MainThreadNotebookFeatures $getActiveNotebookContext', () => {
 		});
 	}
 
-	/**
-	 * Builds a MainThreadNotebookFeatures against a stubbed editor state: the
-	 * given active pane, editors in most-recently-active order, and the open
-	 * Positron notebook instances.
-	 */
 	/** A foreground session stub attached to the given notebook. */
 	function createForegroundNotebookSession(uriString: string): ILanguageRuntimeSession {
 		return stubInterface<ILanguageRuntimeSession>({
@@ -159,6 +154,11 @@ describe('MainThreadNotebookFeatures $getActiveNotebookContext', () => {
 		});
 	}
 
+	/**
+	 * Builds a MainThreadNotebookFeatures against a stubbed editor state: the
+	 * given active pane, editors in most-recently-active order, the open
+	 * Positron notebook instances, and optionally the foreground session.
+	 */
 	function createContextFeatures(options: {
 		activeEditorPane: IVisibleEditorPane | undefined;
 		mruEditors: EditorInput[];

--- a/src/vs/workbench/api/test/browser/positron/mainThreadNotebookFeatures.vitest.ts
+++ b/src/vs/workbench/api/test/browser/positron/mainThreadNotebookFeatures.vitest.ts
@@ -16,7 +16,7 @@ import { IEditorService } from '../../../../services/editor/common/editorService
 import { IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
-import { IVisibleEditorPane } from '../../../../common/editor.js';
+import { EditorsOrder, IVisibleEditorPane } from '../../../../common/editor.js';
 import { EditorInput } from '../../../../common/editor/editorInput.js';
 import { IPositronNotebookService } from '../../../../contrib/positronNotebook/browser/positronNotebookService.js';
 import { IPositronNotebookInstance } from '../../../../contrib/positronNotebook/browser/IPositronNotebookInstance.js';
@@ -157,7 +157,11 @@ describe('MainThreadNotebookFeatures $getActiveNotebookContext', () => {
 	}): MainThreadNotebookFeatures {
 		const editorService = stubInterface<IEditorService>({
 			activeEditorPane: options.activeEditorPane,
-			getEditors: () => options.mruEditors.map((editor, groupId) => ({ groupId, editor })),
+			// Order-sensitive: only the most-recently-active query sees the
+			// editors, so a regression to another EditorsOrder fails here.
+			getEditors: (order: EditorsOrder) => order === EditorsOrder.MOST_RECENTLY_ACTIVE
+				? options.mruEditors.map((editor, groupId) => ({ groupId, editor }))
+				: [],
 		});
 		const notebookService = stubInterface<IPositronNotebookService>({
 			listInstances: (uri?: URI) => options.instances.filter(instance => !uri || isEqual(instance.uri, uri)),

--- a/src/vs/workbench/api/test/browser/positron/mainThreadNotebookFeatures.vitest.ts
+++ b/src/vs/workbench/api/test/browser/positron/mainThreadNotebookFeatures.vitest.ts
@@ -22,7 +22,9 @@ import { IPositronNotebookService } from '../../../../contrib/positronNotebook/b
 import { IPositronNotebookInstance } from '../../../../contrib/positronNotebook/browser/IPositronNotebookInstance.js';
 import { IPositronNotebookCodeCell, NotebookCellOutputs } from '../../../../contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.js';
 import { SelectionState, SelectionStateMachine } from '../../../../contrib/positronNotebook/browser/selectionMachine.js';
+import { UNSUPPORTED_NOTEBOOK_EDITOR_MESSAGE } from '../../../../contrib/positronNotebook/browser/notebookUtils.js';
 import { POSITRON_NOTEBOOK_EDITOR_INPUT_ID } from '../../../../contrib/positronNotebook/common/positronNotebookCommon.js';
+import { NOTEBOOK_EDITOR_ID } from '../../../../contrib/notebook/common/notebookCommon.js';
 import { MainThreadNotebookFeatures } from '../../../browser/positron/mainThreadNotebookFeatures.js';
 
 const { mockRasterizeSvgToPng } = vi.hoisted(() => ({ mockRasterizeSvgToPng: vi.fn() }));
@@ -221,6 +223,21 @@ describe('MainThreadNotebookFeatures $getActiveNotebookContext', () => {
 		});
 
 		expect(await features.$getActiveNotebookContext()).toBeUndefined();
+		features.dispose();
+	});
+
+	it('surfaces the unsupported-editor error when the built-in notebook editor is active, even if a Positron notebook is open elsewhere', async () => {
+		// The user is looking at a notebook in the built-in editor; falling
+		// back to a different open Positron notebook would make assistant
+		// tools operate on the wrong notebook.
+		const notebookUri = 'file:///test/notebook.ipynb';
+		const features = createContextFeatures({
+			activeEditorPane: stubInterface<IVisibleEditorPane>({ getId: () => NOTEBOOK_EDITOR_ID }),
+			mruEditors: [createEditorInput(POSITRON_NOTEBOOK_EDITOR_INPUT_ID, notebookUri)],
+			instances: [createNotebookInstance(notebookUri)],
+		});
+
+		await expect(features.$getActiveNotebookContext()).rejects.toThrow(UNSUPPORTED_NOTEBOOK_EDITOR_MESSAGE);
 		features.dispose();
 	});
 });

--- a/src/vs/workbench/api/test/browser/positron/mainThreadNotebookFeatures.vitest.ts
+++ b/src/vs/workbench/api/test/browser/positron/mainThreadNotebookFeatures.vitest.ts
@@ -13,7 +13,7 @@ import { URI } from '../../../../../base/common/uri.js';
 import { isEqual } from '../../../../../base/common/resources.js';
 import { IExtHostContext } from '../../../../services/extensions/common/extHostCustomers.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
-import { IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
+import { ILanguageRuntimeSession, IRuntimeSessionMetadata, IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { EditorsOrder, IVisibleEditorPane } from '../../../../common/editor.js';
@@ -150,10 +150,20 @@ describe('MainThreadNotebookFeatures $getActiveNotebookContext', () => {
 	 * given active pane, editors in most-recently-active order, and the open
 	 * Positron notebook instances.
 	 */
+	/** A foreground session stub attached to the given notebook. */
+	function createForegroundNotebookSession(uriString: string): ILanguageRuntimeSession {
+		return stubInterface<ILanguageRuntimeSession>({
+			metadata: stubInterface<IRuntimeSessionMetadata>({
+				notebookUri: URI.parse(uriString),
+			}),
+		});
+	}
+
 	function createContextFeatures(options: {
 		activeEditorPane: IVisibleEditorPane | undefined;
 		mruEditors: EditorInput[];
 		instances: IPositronNotebookInstance[];
+		foregroundSession?: ILanguageRuntimeSession;
 	}): MainThreadNotebookFeatures {
 		const editorService = stubInterface<IEditorService>({
 			activeEditorPane: options.activeEditorPane,
@@ -172,7 +182,10 @@ describe('MainThreadNotebookFeatures $getActiveNotebookContext', () => {
 			notebookService,
 			stubInterface<ILogService>(),
 			stubInterface<IConfigurationService>(),
-			stubInterface<IRuntimeSessionService>({ getNotebookSessionForNotebookUri: () => undefined }),
+			stubInterface<IRuntimeSessionService>({
+				getNotebookSessionForNotebookUri: () => undefined,
+				foregroundSession: options.foregroundSession,
+			}),
 		);
 	}
 
@@ -216,6 +229,47 @@ describe('MainThreadNotebookFeatures $getActiveNotebookContext', () => {
 		const context = await features.$getActiveNotebookContext();
 
 		expect(context?.uri).toBe(recentUri);
+		features.dispose();
+	});
+
+	it('prefers the foreground session\'s notebook over a more recently active notebook editor', async () => {
+		const attachedUri = 'file:///test/attached.ipynb';
+		const recentUri = 'file:///test/recent.ipynb';
+		// The user's session (what the interpreter picker shows, and what the
+		// assistant's notebook mode is keyed on) is attached to one notebook
+		// while another notebook's editor was touched more recently: the
+		// attached notebook wins.
+		const features = createContextFeatures({
+			activeEditorPane: stubInterface<IVisibleEditorPane>({ getId: () => TEXT_FILE_EDITOR_PANE_ID }),
+			mruEditors: [
+				createEditorInput(POSITRON_NOTEBOOK_EDITOR_INPUT_ID, recentUri),
+				createEditorInput(POSITRON_NOTEBOOK_EDITOR_INPUT_ID, attachedUri),
+			],
+			instances: [createNotebookInstance(attachedUri), createNotebookInstance(recentUri)],
+			foregroundSession: createForegroundNotebookSession(attachedUri),
+		});
+
+		const context = await features.$getActiveNotebookContext();
+
+		expect(context?.uri).toBe(attachedUri);
+		features.dispose();
+	});
+
+	it('falls back to the most recently active notebook editor when the foreground notebook is closed', async () => {
+		const closedUri = 'file:///test/closed.ipynb';
+		const openUri = 'file:///test/open.ipynb';
+		// The foreground session's notebook editor was closed (its session may
+		// still be running); resolution must not target a closed notebook.
+		const features = createContextFeatures({
+			activeEditorPane: stubInterface<IVisibleEditorPane>({ getId: () => TEXT_FILE_EDITOR_PANE_ID }),
+			mruEditors: [createEditorInput(POSITRON_NOTEBOOK_EDITOR_INPUT_ID, openUri)],
+			instances: [createNotebookInstance(openUri)],
+			foregroundSession: createForegroundNotebookSession(closedUri),
+		});
+
+		const context = await features.$getActiveNotebookContext();
+
+		expect(context?.uri).toBe(openUri);
 		features.dispose();
 	});
 


### PR DESCRIPTION
Fixes #14762

There was a confusing state you could get into where when you navigate off of a positron notebook into a non-editor-type context like a data explorer etc we never triggered the event that caused the assistant chat to think it had left the notebook. This meant that the notebook was still "active" in the chat pane (e.g. the active runtime was the notebook) but when the assistant went to query the notebook the thing we gate on is the notebook being the active editor which if focus is on something like the data explorer then it is _not._ The result was a confused agent and user because the agent didnt have access to the notebook context it expected. This fixes that by letting the notebook tools search open but not focused editors for the correct notebook. 

_Agent generated notes 👇_
--- 

`positron.notebooks.getContext` resolved the notebook only from the active editor pane, so assistant tools reported "no notebook is open in the editor" whenever focus was anywhere else (a Data Explorer or plot editor opened from the notebook, the chat editor, a split group, another tab) even though a Positron notebook was open. This PR adds a fallback: when no Positron notebook is the active pane, `getContext` resolves the open notebook attached to the foreground session (what the interpreter picker shows, and what assistant notebook mode is keyed on), then the most recently active open Positron notebook.

Two edge behaviors are deliberate:
- When the active editor is a notebook in the built-in (Jupyter) editor, `getContext` still rejects with the actionable "reopen in the Positron Notebook Editor" error rather than falling back to a different open notebook.
- When the foreground session's notebook editor has been closed, resolution falls back to the most recently active open notebook rather than targeting a closed one. (Assistant tool calls that pass an explicit notebook path verify it against the resolved notebook and error on mismatch, so a stale session can't silently redirect a path-addressed edit.)

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix Assistant failing to find an open Positron Notebook when the notebook is not the active editor pane, e.g. after opening a Data Explorer or moving focus to another editor (#14762)

### Validation Steps

@:positron-notebooks @:assistant

Regression tests: `src/vs/workbench/api/test/browser/positron/mainThreadNotebookFeatures.vitest.ts` covers the fallback (open-but-inactive notebook, MRU order across multiple notebooks, foreground-session preference, closed foreground notebook, nothing open, and the built-in-editor error).

Manual check:
1. Open a Positron Notebook (`positron.notebook.enabled` on) and run a cell so it has a session.
2. Open a Data Explorer from the notebook (e.g. `View` a dataframe) so the notebook is no longer the active editor pane.
3. Ask Posit Assistant something that reads the notebook (or invoke a notebook tool). It should find the notebook instead of replying "no notebook is open in the editor".
4. With a second notebook also open, verify the assistant still targets the notebook attached to the current session, not the more recently touched one.
5. Open a notebook in the built-in Jupyter editor as the active tab; notebook tools should still return the "reopen in the Positron Notebook Editor" guidance.
