### PR TITLE
Fix test flake for R HTML widgets

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
@@ -177,6 +177,13 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 	// This prevents infinite loops when listening for model changes.
 	private _cachedOutputsLoaded = false;
 
+	// Cells whose re-execution has started but not yet produced a replacement
+	// output. The previously cached output is kept until the first new output
+	// arrives (mirroring the view zone's "recomputing" behavior), so an
+	// execution that is interrupted before producing output -- e.g. cancelled by
+	// a window reload -- does not destroy the still-valid persisted cache.
+	private readonly _cellsAwaitingRecomputeOutput = new Set<string>();
+
 	// Stash outputs per document URI across model changes (tab switches).
 	// Unlike the disk cache, stashed outputs preserve data explorer MIME items
 	// so the inline data explorer can reconnect to a live comm when switching back.
@@ -281,6 +288,7 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 			this._outputsByCell.clear();
 			this._contentHashByCellId.clear();
 			this._executionInfoByCell.clear();
+			this._cellsAwaitingRecomputeOutput.clear();
 
 			// Clear previous output handling subscriptions to prevent duplicates
 			this._outputHandlingDisposables.clear();
@@ -397,10 +405,14 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 					// Clear our internal output tracking since new outputs will replace
 					this._outputsByCell.delete(cellId);
 					this._contentHashByCellId.delete(cellId);
-					// Clear from cache
-					if (this._documentUri) {
-						this._cacheService.clearCellOutputs(this._documentUri, cellId);
-					}
+					// Defer clearing the persisted cache until the first new output
+					// actually arrives (see _handleOutput). Clearing it here would
+					// destroy the still-valid cached output if the execution is
+					// interrupted before producing anything -- for example when a
+					// window reload cancels an in-flight execution during shutdown,
+					// which otherwise leaves an empty entry that the shutdown flush
+					// writes out as a deletion.
+					this._cellsAwaitingRecomputeOutput.add(cellId);
 				}
 
 				// When execution finishes (Idle, Completed, or Error), if still in
@@ -420,6 +432,17 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 					});
 				}
 
+				// A re-execution finished without producing a replacement output.
+				// Only drop the previously cached output if the run completed
+				// cleanly (the cell genuinely produces nothing now). If it ended in
+				// error -- which includes cancellation, e.g. by a window reload --
+				// keep the cache so the last good output survives the reload.
+				if (executionFinished && this._cellsAwaitingRecomputeOutput.delete(cellId)) {
+					if (currentState === CellExecutionState.Completed && this._documentUri) {
+						this._cacheService.clearCellOutputs(this._documentUri, cellId);
+					}
+				}
+
 				// When execution finishes and there is no view zone yet,
 				// create one to show the status bar
 				if (executionFinished && !viewZone) {
@@ -435,16 +458,21 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 				}
 
 				// When state goes to Idle (e.g. after cancellation), hide
-				// status-only view zones since there's nothing meaningful to show
-				if (currentState === CellExecutionState.Idle && viewZone?.isRecomputing) {
-					viewZone.clearOutputs();
-					this._viewZones.delete(cellId);
-					this._executionInfoByCell.delete(cellId);
-					this._onDidChangeOutputs.fire({
-						cellId,
-						documentUri: this._documentUri!,
-						outputs: [],
-					});
+				// status-only view zones since there's nothing meaningful to show.
+				// The execution was interrupted rather than completed, so leave the
+				// persisted cache alone.
+				if (currentState === CellExecutionState.Idle) {
+					this._cellsAwaitingRecomputeOutput.delete(cellId);
+					if (viewZone?.isRecomputing) {
+						viewZone.clearOutputs();
+						this._viewZones.delete(cellId);
+						this._executionInfoByCell.delete(cellId);
+						this._onDidChangeOutputs.fire({
+							cellId,
+							documentUri: this._documentUri!,
+							outputs: [],
+						});
+					}
 				}
 			}
 		}));
@@ -532,6 +560,7 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 		this._disposeAllViewZones();
 		this._outputsByCell.clear();
 		this._executionInfoByCell.clear();
+		this._cellsAwaitingRecomputeOutput.clear();
 	}
 
 	/**
@@ -961,6 +990,14 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 
 	private _handleOutput(cellId: string, output: ICellOutput): void {
 		this._logService.debug('[QuartoOutputContribution] Received output for cell', cellId);
+
+		// First replacement output of a re-execution: now that new output is
+		// actually arriving, drop the previously cached output for this cell so
+		// the new run replaces it instead of appending. This is deferred from
+		// execution start so an interrupted run never destroys the old cache.
+		if (this._cellsAwaitingRecomputeOutput.delete(cellId) && this._documentUri) {
+			this._cacheService.clearCellOutputs(this._documentUri, cellId);
+		}
 
 		// Store output
 		const outputs = this._outputsByCell.get(cellId) ?? [];


### PR DESCRIPTION
Follow-up to #14559.

The R HTML widget persistence fix (#14715) added an e2e regression test whose window-reload case failed 100% in CI. Reproducing it in the CI image surfaced a separate output-cache bug that the reload path exposes.

When a cell re-execution starts, we cleared the cell's cached output immediately, in anticipation of new output replacing it.

If that execution is interrupted before producing anything -- which is exactly what a window reload does when it cancels the in-flight execution during shutdown -- the in-memory cache entry is left empty but dirty, and the `onWillShutdown` flush then deletes the still-valid cache file on disk (the "no cells, delete the file" branch). After the reload there is no cache to restore, so the widget does not come back.

The cache clear is now deferred from execution start to the arrival of the first replacement output, mirroring the view zone's existing "recomputing" behavior where old output stays visible until new output replaces it. An interrupted or cancelled run no longer destroys the previously cached output, so cached widgets survive a window reload. A clean re-execution that genuinely produces no output still clears the cache as before.

### Validation Steps

@:quarto

Covered by `test/e2e/tests/quarto/quarto-inline-output-rawhtml-persistence.test.ts` -- its "restores as a webview after window reload" case previously failed 100% in CI and now passes (verified 10/10 runs in the CI docker image).

1. Open a `.qmd` with an R cell that renders an HTML widget:
   ```r
   library(highcharter)
   hchart(data.frame(x = 1:5, y = c(1, 4, 9, 16, 25)), "scatter", hcaes(x, y))
   ```
2. Run the cell so the widget renders inline as an interactive chart.
3. Reload the window.
4. Confirm the widget restores as the interactive chart (a webview), not raw HTML with an "Interactive HTML output (requires webview)" warning.
