### PR TITLE
E2E test: infra for pins connector test

### DIFF
--- a/docker/environments/connect-local/docker-compose.yml
+++ b/docker/environments/connect-local/docker-compose.yml
@@ -18,10 +18,12 @@ services:
       - CONNECT_TENSORFLOW_ENABLED=false
     privileged: true
     volumes:
-      # Persistent data volume: the bootstrap key stays valid across runs, so a
-      # saved publisher keychain credential keeps working (see PLAN.md section 6).
+      # Connect's data dir. Treated as ephemeral: run.sh wipes this volume on
+      # every start, so state never carries over between runs.
+      # NOTE: do NOT add a bare `- /var/lib/rstudio-connect` entry here -- an
+      # anonymous volume at the same target shadows connect-data, giving each
+      # container two competing data dirs.
       - connect-data:/var/lib/rstudio-connect
-      - /var/lib/rstudio-connect
       - ./connect/rstudio-connect.gcfg:/etc/rstudio-connect/rstudio-connect.gcfg:ro
       - ./connect/connect.lic:/var/lib/rstudio-connect/connect.lic:ro
     healthcheck:

--- a/docker/environments/connect-local/run.sh
+++ b/docker/environments/connect-local/run.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
-# run.sh -- bring up standalone Posit Connect and bootstrap a publisher token.
+# run.sh -- bring up a clean standalone Posit Connect and bootstrap a token.
 #
-# 1. Starts the `connect` service (persistent connect-data volume).
-# 2. Runs the one-shot `token` service to bootstrap/reuse the Connect API token,
+# Connect is treated as an ephemeral test dependency: every start begins from a
+# clean slate. This avoids the stale-state failure modes that persistence
+# invites (a saved token outliving the data it belonged to).
+#
+# 1. Tears down any prior stack + connect-data volume + saved token.
+# 2. Starts a fresh `connect` service.
+# 3. Runs the one-shot `token` service to bootstrap a fresh Connect API token,
 #    writing it to ./.tokens/connect_bootstrap_token (read by the test resolver).
+#
+# The `.tokens/.last_publisher_key` marker is deliberately preserved so the
+# publisher tests' keychain self-heal can detect that the (fresh) key rotated
+# and re-enter their saved credential.
 #
 # See README.md for prerequisites (/etc/hosts entry, connect.lic, ghcr login).
 
@@ -23,8 +32,8 @@ if [ -f .env ]; then
 fi
 
 # Connect requires a valid base64 Bootstrap.SecretKey. Mint one the first time
-# and persist it to .env so it stays stable across runs (rebootstrapping is a
-# no-op once the token file exists, so a stable key avoids churn).
+# and persist it to .env so it stays stable across runs. (The secret key stays
+# stable; the API key it bootstraps is minted fresh on every start.)
 if [ -z "${CONNECT_BOOTSTRAP_SECRETKEY:-}" ]; then
   CONNECT_BOOTSTRAP_SECRETKEY="$(openssl rand -base64 32)"
   export CONNECT_BOOTSTRAP_SECRETKEY
@@ -53,6 +62,13 @@ if [ ! -f "connect/connect.lic" ]; then
   echo "         healthy. Add connect/connect.lic (see README.md)." >&2
 fi
 
+# Clean slate: remove any prior stack, its connect-data volume, and the saved
+# token so this start is fully reproducible. The .last_publisher_key marker is
+# intentionally NOT removed (see header).
+echo "Removing any prior Connect stack for a clean start..."
+docker compose -f "$COMPOSE_FILE" --profile token down -v --remove-orphans
+rm -f "${SCRIPT_DIR}/.tokens/connect_bootstrap_token"
+
 echo "Starting Posit Connect..."
 docker compose -f "$COMPOSE_FILE" up -d --remove-orphans connect
 
@@ -68,15 +84,27 @@ until curl -fsS "http://localhost:3939/__ping__" >/dev/null 2>&1 || curl -fsS "h
   sleep 1
 done
 
+TOKEN_FILE="${SCRIPT_DIR}/.tokens/connect_bootstrap_token"
+
+# Whether the token file holds a key that authenticates against Connect.
+token_authenticates() {
+  [ -s "$TOKEN_FILE" ] && curl -fsS -o /dev/null \
+    -H "Authorization: Key $(cat "$TOKEN_FILE")" \
+    "http://localhost:3939/__api__/v1/users?page_size=1"
+}
+
 echo "Bootstrapping Connect API token (one-shot)..."
 docker compose -f "$COMPOSE_FILE" run --rm token
 
-TOKEN_FILE="${SCRIPT_DIR}/.tokens/connect_bootstrap_token"
 echo ""
-if [ -s "$TOKEN_FILE" ]; then
+# The data dir was just wiped, so bootstrap runs against a fresh instance and
+# should always mint a working key. Validate to fail fast if something is off.
+if token_authenticates; then
   echo "Connect is up. Token written to: ${TOKEN_FILE}"
 else
-  echo "WARNING: token file missing/empty at ${TOKEN_FILE}." >&2
+  echo "ERROR: bootstrapped token at ${TOKEN_FILE} does not authenticate." >&2
+  echo "       Check the connect logs: docker compose -f ${COMPOSE_FILE} logs connect" >&2
+  exit 1
 fi
 echo ""
 echo "Reminder: add '127.0.0.1 connect' to /etc/hosts so the publisher's stored"

--- a/docker/environments/connect-local/run.sh
+++ b/docker/environments/connect-local/run.sh
@@ -86,23 +86,20 @@ done
 
 TOKEN_FILE="${SCRIPT_DIR}/.tokens/connect_bootstrap_token"
 
-# Whether the token file holds a key that authenticates against Connect.
-token_authenticates() {
-  [ -s "$TOKEN_FILE" ] && curl -fsS -o /dev/null \
-    -H "Authorization: Key $(cat "$TOKEN_FILE")" \
-    "http://localhost:3939/__api__/v1/users?page_size=1"
-}
-
 echo "Bootstrapping Connect API token (one-shot)..."
 docker compose -f "$COMPOSE_FILE" run --rm token
 
 echo ""
-# The data dir was just wiped, so bootstrap runs against a fresh instance and
-# should always mint a working key. Validate to fail fast if something is off.
-if token_authenticates; then
+# Presence check only: the one-shot token container runs as root, so the token
+# file is root-owned (mode 600) on Linux/CI and this script (non-root) can't read
+# its contents -- but `test -s` only stats the file, so it works regardless of
+# ownership. Callers that need the value read it with sudo (see the CI workflow).
+# Since the data dir was just wiped, bootstrap runs against a fresh instance and
+# should always produce a token; auth itself is validated by the tests.
+if [ -s "$TOKEN_FILE" ]; then
   echo "Connect is up. Token written to: ${TOKEN_FILE}"
 else
-  echo "ERROR: bootstrapped token at ${TOKEN_FILE} does not authenticate." >&2
+  echo "ERROR: token was not bootstrapped at ${TOKEN_FILE}." >&2
   echo "       Check the connect logs: docker compose -f ${COMPOSE_FILE} logs connect" >&2
   exit 1
 fi

--- a/docker/environments/connect-local/stop-containers.sh
+++ b/docker/environments/connect-local/stop-containers.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
-# stop-containers.sh -- stop the standalone Connect stack.
+# stop-containers.sh -- tear down the standalone Connect stack.
 #
-# By default the persistent connect-data volume is KEPT (so the bootstrap key --
-# and any saved publisher keychain credential -- stays valid on the next run).
-# Pass --wipe to remove the volume and the local token file for a clean slate;
-# the next run.sh will re-bootstrap a fresh token (the test's local self-heal
-# then clears the stale keychain credential automatically).
+# Connect is an ephemeral test dependency (see run.sh): there is no state worth
+# keeping between runs, so stopping removes the container, the connect-data
+# volume, and the saved bootstrap token. The next `run.sh` bootstraps a fresh
+# token against a fresh instance.
+#
+# The `.tokens/.last_publisher_key` marker is deliberately preserved so the
+# publisher tests' keychain self-heal can still detect that the key rotated on
+# the next run and re-enter their saved credential.
 
 set -eu
 
@@ -13,21 +16,14 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
 COMPOSE_FILE="docker-compose.yml"
 
-WIPE=false
-if [ "${1:-}" = "--wipe" ] || [ "${1:-}" = "-v" ]; then
-  WIPE=true
-elif [ -n "${1:-}" ]; then
+# Accept (and ignore) the historical --wipe/-v flag: a full wipe is now the
+# default, so these are no-ops kept for backward compatibility.
+if [ -n "${1:-}" ] && [ "${1:-}" != "--wipe" ] && [ "${1:-}" != "-v" ]; then
   echo "Usage: $0 [--wipe]"
   exit 1
 fi
 
-if [ "$WIPE" = true ]; then
-  echo "Stopping Connect and removing the connect-data volume..."
-  docker compose -f "$COMPOSE_FILE" --profile token down -v --remove-orphans
-  rm -f "${SCRIPT_DIR}/.tokens/connect_bootstrap_token" "${SCRIPT_DIR}/.tokens/.last_publisher_key"
-  echo "Wiped. Next run.sh will re-bootstrap a fresh token."
-else
-  echo "Stopping Connect (volumes preserved)..."
-  docker compose -f "$COMPOSE_FILE" --profile token down --remove-orphans
-  echo "Stopped. Data preserved; resume with: npm run connect:start"
-fi
+echo "Stopping Connect and removing the connect-data volume..."
+docker compose -f "$COMPOSE_FILE" --profile token down -v --remove-orphans
+rm -f "${SCRIPT_DIR}/.tokens/connect_bootstrap_token"
+echo "Stopped. Start a fresh instance with: npm run connect:start"

--- a/test/e2e/pages/workbench/dashboard.page.ts
+++ b/test/e2e/pages/workbench/dashboard.page.ts
@@ -371,8 +371,21 @@ export class DashboardPage {
 	 * @param projectName The project name to quit
 	 */
 	async quitSession(projectName = 'test-files'): Promise<void> {
-		await this.projectCheckbox(projectName).check();
-		await this.quitButton.click();
+		// A prior teardown that failed to quit can leave a session behind, so more
+		// than one row for the same project may be present. Selecting by the shared
+		// "select <project>" checkbox name then matches multiple elements, which is
+		// a strict-mode violation for `.check()` -- so nothing gets quit and the
+		// leaked sessions accumulate until new sessions can no longer launch. The
+		// workbench lane runs serially (workers=1), so it's safe to check every
+		// matching row and quit them all, which also sweeps up any leaked session.
+		const checkboxes = this.projectCheckbox(projectName);
+		const count = await checkboxes.count();
+		for (let i = 0; i < count; i++) {
+			await checkboxes.nth(i).check();
+		}
+		if (count > 0) {
+			await this.quitButton.click();
+		}
 	}
 
 	// #endregion

--- a/test/e2e/test-files/workspaces/README.md
+++ b/test/e2e/test-files/workspaces/README.md
@@ -14,6 +14,9 @@ A collection of Projects for testing and demos.  Please keep these organized and
 * chinook-db-py : Simple python project to view data in SQLite db chinook.db
 * chinook-db-r : Simple R project to view data in SQLite db chinook.db
    - requires `connections` package
+* connect-pins-r : Simple R project that publishes a couple of pins with dummy data to a Posit Connect server, then reads them back and prints their contents.
+   - requires `pins` package
+   - reads CONNECT_SERVER and CONNECT_API_KEY from the environment (set by the connect e2e test)
 * generate-data-frames-py : Simple project for generating large data frames with Python
 * generate-data-frames-r : Simple project for generating large data frames with R
 * quarto_basic : Simple quarto project for integration testing

--- a/test/e2e/test-files/workspaces/connect-pins-r/connect-pins-r.Rproj
+++ b/test/e2e/test-files/workspaces/connect-pins-r/connect-pins-r.Rproj
@@ -1,0 +1,13 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: No
+NumSpacesForTab: 4
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX

--- a/test/e2e/test-files/workspaces/connect-pins-r/publish-pins.R
+++ b/test/e2e/test-files/workspaces/connect-pins-r/publish-pins.R
@@ -1,0 +1,55 @@
+# Publishes a couple of pins with dummy data to a Posit Connect server using the
+# pins package, then reads them back and prints their contents (the "tables") to
+# the console.
+#
+# Credentials are read from the CONNECT_SERVER and CONNECT_API_KEY environment
+# variables, which the e2e test sets on the R session before sourcing this file.
+# board_connect() picks these up automatically via its default "auto" auth.
+#
+# The script is idempotent: it deletes any pins left over from a previous run
+# before publishing, so a flaky re-run always starts from a clean slate.
+
+if (!requireNamespace("pins", quietly = TRUE)) {
+	install.packages("pins")
+}
+
+library(pins)
+
+# The pins we publish. Small slices of the built-in datasets are plenty for
+# exercising the publish -> query round trip.
+pins_to_publish <- list(
+	list(name = "e2e-mtcars", data = head(mtcars, 5)),
+	list(name = "e2e-iris", data = head(iris, 5))
+)
+
+board <- board_connect()
+
+# --- Cleanup ---------------------------------------------------------------
+# Remove any pins from a previous (possibly failed) run. Wrapped in tryCatch so
+# a pin that does not exist -- or a transient lookup error -- never aborts the
+# publish that follows.
+for (pin in pins_to_publish) {
+	tryCatch({
+		if (pin_exists(board, pin$name)) {
+			pin_delete(board, pin$name)
+			cat("Deleted existing pin:", pin$name, "\n")
+		}
+	}, error = function(e) {
+		cat("Cleanup skipped for", pin$name, ":", conditionMessage(e), "\n")
+	})
+}
+
+# --- Publish ---------------------------------------------------------------
+for (pin in pins_to_publish) {
+	pin_write(board, pin$data, name = pin$name, type = "rds")
+	cat("Published pin:", pin$name, "\n")
+}
+
+# --- Query -----------------------------------------------------------------
+# Read each pin back and log its table contents to the console.
+for (pin in pins_to_publish) {
+	cat("\n==== Pin contents:", pin$name, "====\n")
+	print(pin_read(board, pin$name))
+}
+
+cat("\nPINS PUBLISH COMPLETE\n")

--- a/test/e2e/tests/connect/pins-r.test.ts
+++ b/test/e2e/tests/connect/pins-r.test.ts
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { join } from 'path';
+import { test, tags } from '../_test.setup.js';
+
+test.use({
+	suiteId: __filename
+});
+
+// The Connect API key resolved in beforeAll and injected into the R session so
+// the pins board can authenticate.
+let connectApiKey: string;
+// Connect's URL as seen from the R session. The service name resolves in both
+// runs: in the Workbench web run R runs in a container on the compose network,
+// and the local electron run relies on an /etc/hosts entry mapping `connect` to
+// 127.0.0.1 (the same mapping the publisher already depends on locally).
+const connectServer = 'http://connect:3939';
+
+test.describe('Pins - R', { tag: [tags.WORKBENCH, tags.CONNECT] }, () => {
+
+	test.beforeAll('Get connect API key', async function ({ app, runDockerCommand }) {
+
+		// Local electron run (connect-local stack) vs the Workbench web run.
+		const isLocal = test.info().project.name === 'e2e-connect';
+
+		// Skip the suite when Connect isn't up (e.g. the full local suite is run
+		// without the connect-local stack started).
+		test.skip(!(await app.workbench.positConnect.isReachable()), 'Posit Connect is not reachable at http://localhost:3939');
+
+		// Resolve the publisher API key: env -> local token file -> Workbench volume.
+		connectApiKey = await app.workbench.positConnect.resolveApiKey(isLocal ? undefined : runDockerCommand);
+		app.workbench.positConnect.setConnectApiKey(connectApiKey);
+
+		if (!(await app.workbench.positConnect.isApiKeyValid())) {
+			throw new Error('Connect API key did not authenticate against http://localhost:3939');
+		}
+	});
+
+	test('Publish pins with dummy data and query their contents', async function ({ app, r, executeCode }) {
+
+		test.slow();
+
+		const { console } = app.workbench;
+
+		await test.step('Point the R session at Connect', async () => {
+			// Set the env vars that pins::board_connect() reads by default. Passing
+			// them via the session (rather than baking the key into the script) keeps
+			// the credential out of the workspace file.
+			await executeCode(
+				'R',
+				`Sys.setenv(CONNECT_SERVER = ${JSON.stringify(connectServer)}, CONNECT_API_KEY = ${JSON.stringify(connectApiKey)})`
+			);
+		});
+
+		await test.step('Run the publish script', async () => {
+			// Source with chdir so relative paths inside the script resolve, and use
+			// an absolute path so the working directory of the session doesn't matter.
+			const scriptPath = join(app.workspacePathOrFolder, 'workspaces', 'connect-pins-r', 'publish-pins.R');
+			await executeCode('R', `source(${JSON.stringify(scriptPath)}, chdir = TRUE)`, { timeout: 120000 });
+		});
+
+		await test.step('Verify both pins were published', async () => {
+			await console.waitForConsoleContents('Published pin: e2e-mtcars', { timeout: 60000 });
+			await console.waitForConsoleContents('Published pin: e2e-iris', { timeout: 60000 });
+		});
+
+		await test.step('Verify the queried pin tables were logged to the console', async () => {
+			// Column headers printed by print(pin_read(...)) prove the round trip
+			// returned the dummy data frames we published.
+			await console.waitForConsoleContents('mpg', { timeout: 60000 });
+			await console.waitForConsoleContents('Sepal.Length', { timeout: 60000 });
+			await console.waitForConsoleContents('PINS PUBLISH COMPLETE', { timeout: 60000 });
+		});
+	});
+});


### PR DESCRIPTION
### Summary

Sets up the e2e test infrastructure for a future Positron pins connector. Adds an R workspace that publishes pins to Posit Connect and a `connect` e2e test that drives it. No product code changes -- this is test infra plus a fix to the local Connect dev dependency.

### What's included

- **New R workspace** `test/e2e/test-files/workspaces/connect-pins-r/` -- publishes two pins with dummy data (`head(mtcars)`, `head(iris)`) to Connect via `pins::board_connect()`, then reads them back and prints their contents. Credentials come from `CONNECT_SERVER` / `CONNECT_API_KEY` env vars. The script deletes any pins from a prior run first, so a flaky re-run always starts clean.
- **New e2e test** `test/e2e/tests/connect/pins-r.test.ts` -- resolves the Connect API key (same flow as the existing publisher tests), injects it into an R session, runs the publish script, and asserts both the publish and the queried table contents appear in the Positron console.

### Connect dev-dependency cleanup

While validating locally, the saved bootstrap token kept going stale after a container restart. Root cause: a redundant anonymous volume in `docker-compose.yml` shadowed the named `connect-data` volume, so "persisted" state silently didn't persist. Rather than patch persistence, the local Connect stack is now treated as an ephemeral test dependency:

- `npm run connect:start` wipes the volume + token and bootstraps a fresh instance every time.
- `npm run connect:stop` tears down the container, volume, and token.
- The `.last_publisher_key` marker is preserved so the publisher tests' keychain self-heal still detects the rotated key.

### QA Notes

@:connect @:workbench

Verified locally against the connect-local stack: the pins test publishes, queries, and logs the table contents; publisher tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
