### PR TITLE
Pin Quarto documents when running code

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
@@ -2221,9 +2221,6 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 	}
 
 	/**
-	 * Get the text model for a document URI.
-	 */
-	/**
 	 * Pin any editor showing the given document.
 	 *
 	 * Quarto documents open as preview tabs, which are silently replaced when
@@ -2239,6 +2236,9 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 		}
 	}
 
+	/**
+	 * Get the text model for a document URI.
+	 */
 	private async _getTextModel(documentUri: URI): Promise<ITextModel | undefined> {
 		const editors = this._editorService.findEditors(documentUri);
 		if (editors.length === 0) {

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
@@ -16,6 +16,7 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { IEphemeralStateService } from '../../../../platform/ephemeralState/common/ephemeralState.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { IEditorGroupsService } from '../../../services/editor/common/editorGroupsService.js';
 import { ITextModel } from '../../../../editor/common/model.js';
 import { IModelService } from '../../../../editor/common/services/model.js';
 import { ILanguageFeaturesService } from '../../../../editor/common/services/languageFeatures.js';
@@ -180,6 +181,7 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 		@IQuartoKernelManager private readonly _kernelManager: IQuartoKernelManager,
 		@IQuartoDocumentModelService private readonly _documentModelService: IQuartoDocumentModelService,
 		@IEditorService private readonly _editorService: IEditorService,
+		@IEditorGroupsService private readonly _editorGroupsService: IEditorGroupsService,
 		@IEphemeralStateService private readonly _ephemeralStateService: IEphemeralStateService,
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
@@ -217,6 +219,10 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 		if (cells.length === 0) {
 			return;
 		}
+
+		// Running code pins the document tab so its preview editor (and any
+		// backing runtime session) isn't silently closed.
+		this._pinEditorForDocument(documentUri);
 
 		this._logService.debug(`[QuartoExecutionManager] Queueing ${cells.length} cells for execution`);
 
@@ -377,6 +383,10 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 		if (codeRanges.length === 0) {
 			return;
 		}
+
+		// Running code pins the document tab so its preview editor (and any
+		// backing runtime session) isn't silently closed. See #14736.
+		this._pinEditorForDocument(documentUri);
 
 		this._logService.debug(`[QuartoExecutionManager] Queueing ${codeRanges.length} inline code ranges for execution`);
 
@@ -2213,6 +2223,22 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 	/**
 	 * Get the text model for a document URI.
 	 */
+	/**
+	 * Pin any editor showing the given document.
+	 *
+	 * Quarto documents open as preview tabs, which are silently replaced when
+	 * the user opens another file. Running code signals the user intends to
+	 * work with the document, not just preview it -- and in inline output mode
+	 * it creates a backing runtime session -- so we pin the tab to prevent it
+	 * from being closed out from under a live session. This mirrors the
+	 * notebook behavior where running a cell pins the editor.
+	 */
+	private _pinEditorForDocument(documentUri: URI): void {
+		for (const { groupId, editor } of this._editorService.findEditors(documentUri)) {
+			this._editorGroupsService.getGroup(groupId)?.pinEditor(editor);
+		}
+	}
+
 	private async _getTextModel(documentUri: URI): Promise<ITextModel | undefined> {
 		const editors = this._editorService.findEditors(documentUri);
 		if (editors.length === 0) {

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoExecutionManager.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoExecutionManager.vitest.ts
@@ -26,6 +26,7 @@ import { IQuartoKernelManager } from '../../browser/quartoKernelManager.js';
 import { IQuartoDocumentModelService } from '../../browser/quartoDocumentModelService.js';
 import { QuartoCodeCell } from '../../common/quartoTypes.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
+import { IEditorGroupsService } from '../../../../services/editor/common/editorGroupsService.js';
 import { IEphemeralStateService } from '../../../../../platform/ephemeralState/common/ephemeralState.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
@@ -80,6 +81,7 @@ describe('QuartoExecutionManager', () => {
 	let mockKernelManager: MockKernelManager;
 	let mockDocumentModelService: MockDocumentModelService;
 	let mockEditorService: MockEditorService;
+	let mockEditorGroupsService: MockEditorGroupsService;
 	let mockConsoleService: RecordingConsoleService;
 	let mockRuntimeSessionService: MockRuntimeSessionService;
 	let configurationService: TestConfigurationService;
@@ -101,6 +103,7 @@ describe('QuartoExecutionManager', () => {
 		mockKernelManager = ctx.disposables.add(new MockKernelManager(mockSession));
 		mockDocumentModelService = new MockDocumentModelService();
 		mockEditorService = new MockEditorService();
+		mockEditorGroupsService = new MockEditorGroupsService();
 		const mockEphemeralStateService = new MockEphemeralStateService();
 		const mockWorkspaceContextService = new MockWorkspaceContextService();
 		mockConsoleService = new RecordingConsoleService();
@@ -120,6 +123,7 @@ describe('QuartoExecutionManager', () => {
 			asKernelManager(mockKernelManager),
 			asDocumentModelService(mockDocumentModelService),
 			asEditorService(mockEditorService),
+			asEditorGroupsService(mockEditorGroupsService),
 			asEphemeralStateService(mockEphemeralStateService),
 			asWorkspaceContextService(mockWorkspaceContextService),
 			configurationService,
@@ -1234,6 +1238,7 @@ describe('QuartoExecutionManager', () => {
 				asKernelManager(mockKernelManager),
 				asDocumentModelService(mockDocumentModelService),
 				asEditorService(trackingEditorService),
+				asEditorGroupsService(new MockEditorGroupsService()),
 				asEphemeralStateService(new MockEphemeralStateService()),
 				asWorkspaceContextService(new MockWorkspaceContextService()),
 				configurationService,
@@ -1333,6 +1338,7 @@ describe('QuartoExecutionManager', () => {
 				asKernelManager(mockKernelManager),
 				asDocumentModelService(localMockDocumentModelService),
 				asEditorService(localMockEditorService),
+				asEditorGroupsService(new MockEditorGroupsService()),
 				asEphemeralStateService(new MockEphemeralStateService()),
 				asWorkspaceContextService(new MockWorkspaceContextService()),
 				configurationService,
@@ -1504,6 +1510,67 @@ describe('QuartoExecutionManager', () => {
 			expect(metadata).toBeDefined();
 			expect(metadata!['fig-width'], 'cell value should win').toBe(4);
 			expect(metadata!['output_pixel_ratio'], 'external-only key should pass through').toBe(2);
+		});
+	});
+
+	describe('Editor Pinning', () => {
+		it('pins the document tab when a cell is executed (#14736)', async () => {
+			const documentUri = URI.file('/test-pin-cell.qmd');
+			const cell: QuartoCodeCell = {
+				id: 'test-pin-cell',
+				index: 0,
+				language: 'python',
+				startLine: 1,
+				endLine: 4,
+				codeStartLine: 2,
+				codeEndLine: 3,
+				label: undefined,
+				options: '',
+				contentHash: 'pin-cell',
+			};
+
+			const executionPromise = executionManager.executeCell(documentUri, cell);
+			const executionId = await mockKernelManager.waitForExecution();
+			mockSession.receiveStateMessage({
+				parent_id: executionId,
+				state: RuntimeOnlineState.Idle,
+			});
+			await executionPromise;
+
+			expect(mockEditorGroupsService.pinnedEditors.length).toBe(1);
+		});
+
+		it('pins the document tab when inline cells are executed (#14736)', async () => {
+			const documentUri = URI.file('/test-pin-inline.qmd');
+			const cell: QuartoCodeCell = {
+				id: 'test-pin-inline',
+				index: 0,
+				language: 'python',
+				startLine: 1,
+				endLine: 3,
+				codeStartLine: 2,
+				codeEndLine: 2,
+				label: undefined,
+				options: '',
+				contentHash: 'pin-inline',
+			};
+			const documentLines = ['```{python}', 'x = 1', '```'];
+			const mockModel = new MockQuartoDocumentModel([cell], documentLines);
+			mockDocumentModelService.setMockModel(mockModel);
+			mockEditorService.getValueInRangeCallback = (range: unknown) => {
+				const r = range as { startLineNumber: number; endLineNumber: number };
+				return documentLines.slice(r.startLineNumber - 1, r.endLineNumber).join('\n');
+			};
+
+			const executionPromise = executionManager.executeInlineCells(documentUri, [new Range(2, 1, 2, 100)]);
+			const executionId = await mockKernelManager.waitForExecution();
+			mockSession.receiveStateMessage({
+				parent_id: executionId,
+				state: RuntimeOnlineState.Idle,
+			});
+			await executionPromise;
+
+			expect(mockEditorGroupsService.pinnedEditors.length).toBe(1);
 		});
 	});
 });
@@ -1696,6 +1763,7 @@ class MockEditorService {
 	findEditors(_resource: unknown): unknown[] {
 		const self = this;
 		return [{
+			groupId: MOCK_EDITOR_GROUP_ID,
 			editor: {
 				resolve: async () => ({
 					textEditorModel: {
@@ -1724,6 +1792,35 @@ function asEditorService(mock: MockEditorService): IEditorService {
 		// reads it to derive layout metadata when an editor is active. The
 		// existing tests don't activate an editor, so undefined is correct.
 		activeTextEditorControl: undefined,
+	});
+}
+
+/** Group id reported by MockEditorService.findEditors, resolved by MockEditorGroupsService.getGroup. */
+const MOCK_EDITOR_GROUP_ID = 1;
+
+/**
+ * Mock editor groups service that records every editor pinned via its group's
+ * pinEditor. Lets tests assert that running a cell pins the document's tab.
+ */
+class MockEditorGroupsService {
+	readonly pinnedEditors: unknown[] = [];
+
+	private readonly _group = {
+		pinEditor: (editor: unknown) => {
+			this.pinnedEditors.push(editor);
+		},
+	};
+
+	getGroup(groupId: number): unknown {
+		return groupId === MOCK_EDITOR_GROUP_ID ? this._group : undefined;
+	}
+}
+
+function asEditorGroupsService(mock: MockEditorGroupsService): IEditorGroupsService {
+	return stubInterface<IEditorGroupsService>({
+		// Cast: the mock's group only implements pinEditor, which is all the
+		// execution manager calls; we narrow at the boundary.
+		getGroup: mock.getGroup.bind(mock) as IEditorGroupsService['getGroup'],
 	});
 }
 


### PR DESCRIPTION
Closes #14736

Quarto documents open as preview editor tabs. Editing the prose in a `.qmd` already pins the tab, but running code did not -- so after running a cell (which, in inline output mode, also spins up a backing R or Python session), clicking another file in the Explorer would silently close the Quarto document and end its session. Running code now pins the document tab, just like editing prose does.

The `QuartoExecutionManager` pins the editor for the document at the start of both `executeCells` and `executeInlineCells` (which every run gesture routes through -- the cell toolbar, keyboard shortcuts, and the Quarto extension's inline-execution command). This mirrors the notebook behavior where running a cell pins the editor.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Running code in a Quarto document now pins its editor tab, so the document (and its runtime session) isn't silently closed when opening another file (#14736)

### Validation Steps

@:quarto

1. Enable Quarto inline output.
2. Open a `.qmd` file with a single click in the Explorer (opens as a preview tab, shown in italics).
3. Run a cell in the file.
4. Verify the editor tab is now pinned (no longer italic).
5. Click a different file in the Explorer and confirm the Quarto document stays open and its R/Python session keeps running.
