### PR TITLE
Show runtime name in Quarto docs; add 'start kernel' affordance

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/QuartoKernelStatusBadge.tsx
+++ b/src/vs/workbench/contrib/positronQuarto/browser/QuartoKernelStatusBadge.tsx
@@ -21,6 +21,7 @@ import { RuntimeStatusIcon } from '../../positronConsole/browser/components/runt
 import { runtimeStateToRuntimeStatus, RuntimeStatus } from '../../positronConsole/common/sessionDisplayUtils.js';
 import { useSessionRuntimeState } from '../../positronConsole/browser/components/useSessionRuntimeState.js';
 import { type ILanguageRuntimeSession } from '../../../services/runtimeSession/common/runtimeSessionService.js';
+import { ILanguageRuntimeService } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
@@ -89,6 +90,7 @@ export function QuartoKernelStatusBadge({ accessor }: QuartoKernelStatusBadgePro
 	const quartoKernelManager = accessor.get(IQuartoKernelManager);
 	const menuService = accessor.get(IMenuService);
 	const contextKeyService = accessor.get(IContextKeyService);
+	const languageRuntimeService = accessor.get(ILanguageRuntimeService);
 
 	// State
 	const [documentUri, setDocumentUri] = React.useState<URI | undefined>(() =>
@@ -97,6 +99,10 @@ export function QuartoKernelStatusBadge({ accessor }: QuartoKernelStatusBadgePro
 		documentUri ? quartoKernelManager.getKernelState(documentUri) : QuartoKernelState.None);
 	const [session, setSession] = React.useState<ILanguageRuntimeSession | undefined>(() =>
 		documentUri ? quartoKernelManager.getSessionForDocument(documentUri) : undefined);
+	// Name of the interpreter that would start if code were run, shown when no
+	// kernel is running yet (e.g. in a Quarto preview editor).
+	const [preferredRuntimeName, setPreferredRuntimeName] = React.useState<string | undefined>(() =>
+		documentUri ? quartoKernelManager.getPreferredRuntimeForDocument(documentUri)?.runtimeName : undefined);
 
 	// Subscribe to the session's runtime state via the shared hook.
 	const runtimeState = useSessionRuntimeState(session);
@@ -104,6 +110,13 @@ export function QuartoKernelStatusBadge({ accessor }: QuartoKernelStatusBadgePro
 	// Set up event listeners
 	React.useEffect(() => {
 		const disposables = new DisposableStore();
+
+		// Recompute the prospective interpreter name for the current document.
+		const refreshPreferredRuntime = () => {
+			setPreferredRuntimeName(documentUri
+				? quartoKernelManager.getPreferredRuntimeForDocument(documentUri)?.runtimeName
+				: undefined);
+		};
 
 		// Listen for active editor changes
 		disposables.add(editorService.onDidActiveEditorChange(() => {
@@ -124,18 +137,34 @@ export function QuartoKernelStatusBadge({ accessor }: QuartoKernelStatusBadgePro
 			if (documentUri && e.documentUri.toString() === documentUri.toString()) {
 				setKernelState(e.newState);
 				setSession(e.session);
+				refreshPreferredRuntime();
 			}
 		}));
 
+		// The preferred interpreter can change as runtimes are discovered or
+		// registered (which may finish after the editor opens), so recompute
+		// the prospective name when that happens.
+		disposables.add(languageRuntimeService.onDidRegisterRuntime(refreshPreferredRuntime));
+		disposables.add(languageRuntimeService.onDidChangeRuntimeStartupPhase(refreshPreferredRuntime));
+
+		// Compute once for the current document.
+		refreshPreferredRuntime();
+
 		return () => disposables.dispose();
-	}, [editorService, quartoKernelManager, documentUri]);
+	}, [editorService, quartoKernelManager, languageRuntimeService, documentUri]);
 
 	// Prefer the session's runtime state. Fall back to the manager's
 	// pre-session kernel state (None / Error) when no session exists.
 	const runtimeStatus = runtimeState !== undefined
 		? runtimeStateToRuntimeStatus[runtimeState]
 		: quartoStateToRuntimeStatus[kernelState] ?? RuntimeStatus.Disconnected;
+	// Label priority:
+	// 1. A running session's runtime name.
+	// 2. When no kernel has started, the interpreter that would start if code
+	//    were run (so the badge names it instead of a bare "No Kernel").
+	// 3. The state label ("No Kernel", "Kernel Error", etc.) as a fallback.
 	const label = session?.runtimeMetadata.runtimeName
+		?? (kernelState === QuartoKernelState.None ? preferredRuntimeName : undefined)
 		?? quartoStateToLabel[kernelState]
 		?? '';
 

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoCommands.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoCommands.ts
@@ -31,6 +31,7 @@ export const enum QuartoCommandId {
 	ClearAllOutputs = 'positronQuarto.clearAllOutputs',
 	ClearOutputCache = 'positronQuarto.clearOutputCache',
 	ShowOutputCache = 'positronQuarto.showOutputCache',
+	StartKernel = 'positronQuarto.startKernel',
 	RestartKernel = 'positronQuarto.restartKernel',
 	InterruptKernel = 'positronQuarto.interruptKernel',
 	ShutdownKernel = 'positronQuarto.shutdownKernel',
@@ -213,6 +214,43 @@ registerAction2(class RestartAndClearAllOutputsAction extends Action2 {
 });
 
 /**
+ * Start the kernel for the current document explicitly. Shown when no kernel
+ * is running so the user can start one directly (e.g. from a Quarto preview
+ * editor) instead of having to run a cell or pin the tab.
+ */
+registerAction2(class StartKernelAction extends Action2 {
+	constructor() {
+		super({
+			id: QuartoCommandId.StartKernel,
+			title: localize2('quarto.startKernel', "Start Kernel"),
+			category: QUARTO_CATEGORY,
+			f1: true,
+			precondition: ContextKeyExpr.and(QUARTO_PRECONDITION, QUARTO_KERNEL_RUNNING.negate()),
+			menu: {
+				id: MenuId.PositronQuartoKernelSubmenu,
+				order: -10,
+				when: QUARTO_KERNEL_RUNNING.negate(),
+			},
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		// Extract all services synchronously before any async operations
+		const editorService = accessor.get(IEditorService);
+		const kernelManager = accessor.get(IQuartoKernelManager);
+
+		const context = getQuartoContext(editorService);
+		if (!context) {
+			return;
+		}
+
+		const { documentUri } = context;
+
+		await kernelManager.ensureKernelForDocument(documentUri);
+	}
+});
+
+/**
  * Restart the kernel for the current document.
  */
 registerAction2(class RestartKernelAction extends Action2 {
@@ -229,6 +267,9 @@ registerAction2(class RestartKernelAction extends Action2 {
 			menu: {
 				id: MenuId.PositronQuartoKernelSubmenu,
 				order: 10,
+				// Only show for a running kernel; when nothing is running the
+				// "Start Kernel" item covers starting one.
+				when: QUARTO_KERNEL_RUNNING,
 			},
 		});
 	}

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoCommands.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoCommands.ts
@@ -309,6 +309,7 @@ registerAction2(class InterruptKernelAction extends Action2 {
 			menu: {
 				id: MenuId.PositronQuartoKernelSubmenu,
 				order: 20,
+				when: QUARTO_KERNEL_RUNNING,
 			},
 		});
 	}

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoKernelManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoKernelManager.ts
@@ -111,6 +111,16 @@ export interface IQuartoKernelManager {
 	changeKernelForDocument(documentUri: URI, runtimeId: string): Promise<ILanguageRuntimeSession | undefined>;
 
 	/**
+	 * Get the runtime that would be used to start a kernel for the document,
+	 * without starting one. Returns the persisted per-document binding when it
+	 * still matches the document's language, otherwise the preferred runtime
+	 * for that language. Synchronous and best-effort: relies on the document's
+	 * text model being loaded in a visible editor, and returns undefined when
+	 * the language or a matching runtime can't yet be determined.
+	 */
+	getPreferredRuntimeForDocument(documentUri: URI): ILanguageRuntimeMetadata | undefined;
+
+	/**
 	 * Get the primary language for a document.
 	 */
 	getDocumentLanguage(documentUri: URI): Promise<string | undefined>;
@@ -711,8 +721,42 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 		return this._startKernelWithRetry(documentUri, undefined, runtime);
 	}
 
+	getPreferredRuntimeForDocument(documentUri: URI): ILanguageRuntimeMetadata | undefined {
+		// If a kernel is already running for the document, that runtime is what
+		// would be used, so report it directly.
+		const runningRuntime = this._documentKernels.get(documentUri)?.session?.runtimeMetadata;
+		if (runningRuntime) {
+			return runningRuntime;
+		}
+
+		const language = this._getDocumentLanguageSync(documentUri);
+		if (!language) {
+			return undefined;
+		}
+
+		return this._resolveRuntimeForLanguage(documentUri, language);
+	}
+
 	async getDocumentLanguage(documentUri: URI): Promise<string | undefined> {
 		return this._getDocumentLanguage(documentUri);
+	}
+
+	/**
+	 * Resolve which runtime should be used for a document with the given primary
+	 * language: the persisted per-document binding when it still matches the
+	 * language, otherwise the preferred runtime for that language. Does not
+	 * mutate any state.
+	 */
+	private _resolveRuntimeForLanguage(documentUri: URI, language: string): ILanguageRuntimeMetadata | undefined {
+		const persistedRuntimeId = this._kernelBindings.get(documentUri.toString());
+		if (persistedRuntimeId) {
+			const persisted = this._languageRuntimeService.registeredRuntimes
+				.find(r => r.runtimeId === persistedRuntimeId && r.languageId === language);
+			if (persisted) {
+				return persisted;
+			}
+		}
+		return this._runtimeStartupService.getPreferredRuntime(language);
 	}
 
 	/**
@@ -834,19 +878,16 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 			// 3. Preferred runtime for the language
 			let runtime: ILanguageRuntimeMetadata | undefined = runtimeOverride;
 			if (!runtime) {
+				// Clear a stale persisted binding that no longer matches the
+				// current language so we don't keep it around; resolution then
+				// falls back to the preferred runtime.
 				const persistedRuntimeId = this._kernelBindings.get(documentUri.toString());
-				if (persistedRuntimeId) {
-					runtime = this._languageRuntimeService.registeredRuntimes
-						.find(r => r.runtimeId === persistedRuntimeId && r.languageId === language);
-					if (!runtime) {
-						// Persisted binding doesn't match the current language; clear it
-						this._kernelBindings.delete(documentUri.toString());
-						this._persistKernelBindings();
-					}
+				if (persistedRuntimeId && !this._languageRuntimeService.registeredRuntimes
+					.some(r => r.runtimeId === persistedRuntimeId && r.languageId === language)) {
+					this._kernelBindings.delete(documentUri.toString());
+					this._persistKernelBindings();
 				}
-			}
-			if (!runtime) {
-				runtime = this._runtimeStartupService.getPreferredRuntime(language);
+				runtime = this._resolveRuntimeForLanguage(documentUri, language);
 			}
 			if (!runtime) {
 				this._logService.warn(`[QuartoKernelManager] No runtime found for language: ${language}`);

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/QuartoKernelStatusBadge.vitest.tsx
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/QuartoKernelStatusBadge.vitest.tsx
@@ -7,8 +7,8 @@
 
 import { act, screen } from '@testing-library/react';
 import { URI } from '../../../../../base/common/uri.js';
-import { Emitter, Event } from '../../../../../base/common/event.js';
-import { ILanguageRuntimeMetadata, ILanguageRuntimeService, RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
+import { Emitter } from '../../../../../base/common/event.js';
+import { ILanguageRuntimeMetadata, ILanguageRuntimeService, RuntimeStartupPhase, RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { IQuartoKernelManager, QuartoKernelState, QuartoKernelStateChangeEvent } from '../../browser/quartoKernelManager.js';
@@ -21,6 +21,8 @@ describe('QuartoKernelStatusBadge', () => {
 	const stateChange = new Emitter<QuartoKernelStateChangeEvent>();
 	const editorChange = new Emitter<void>();
 	const displayStateEmitter = new Emitter<{ sessionId: string; state: RuntimeState }>();
+	const registerRuntimeEmitter = new Emitter<ILanguageRuntimeMetadata>();
+	const startupPhaseEmitter = new Emitter<RuntimeStartupPhase>();
 	let displayState: RuntimeState | undefined;
 
 	const editorServiceStub = {
@@ -45,8 +47,8 @@ describe('QuartoKernelStatusBadge', () => {
 			getDisplayRuntimeState: () => displayState,
 		})
 		.stub(ILanguageRuntimeService, {
-			onDidRegisterRuntime: Event.None,
-			onDidChangeRuntimeStartupPhase: Event.None,
+			onDidRegisterRuntime: registerRuntimeEmitter.event,
+			onDidChangeRuntimeStartupPhase: startupPhaseEmitter.event,
 		})
 		.build();
 	const rtl = setupRTLRenderer(() => ctx.reactServices);
@@ -83,6 +85,34 @@ describe('QuartoKernelStatusBadge', () => {
 			stubInterface<ILanguageRuntimeMetadata>({ runtimeName: 'Python 3.12' });
 		rtl.render(<QuartoKernelStatusBadge accessor={ctx.instantiationService} />);
 		expect(screen.getByTestId('runtime-status-disconnected')).toBeInTheDocument();
+		expect(screen.getByText('Python 3.12')).toBeInTheDocument();
+	});
+
+	it('names a preferred runtime discovered after the initial render', () => {
+		// Interpreter discovery can finish after the editor opens: the badge
+		// starts with "No Kernel" and should adopt the interpreter name once a
+		// preferred runtime becomes available and a registration event fires.
+		rtl.render(<QuartoKernelStatusBadge accessor={ctx.instantiationService} />);
+		expect(screen.getByText('No Kernel')).toBeInTheDocument();
+
+		kernelManagerStub.getPreferredRuntimeForDocument = () =>
+			stubInterface<ILanguageRuntimeMetadata>({ runtimeName: 'Python 3.12' });
+		act(() => registerRuntimeEmitter.fire(
+			stubInterface<ILanguageRuntimeMetadata>({ runtimeName: 'Python 3.12' })));
+
+		expect(screen.getByText('Python 3.12')).toBeInTheDocument();
+	});
+
+	it('recomputes the preferred runtime when the startup phase changes', () => {
+		// The preferred runtime can resolve as the runtime startup sequence
+		// advances, so a startup-phase change should also refresh the label.
+		rtl.render(<QuartoKernelStatusBadge accessor={ctx.instantiationService} />);
+		expect(screen.getByText('No Kernel')).toBeInTheDocument();
+
+		kernelManagerStub.getPreferredRuntimeForDocument = () =>
+			stubInterface<ILanguageRuntimeMetadata>({ runtimeName: 'Python 3.12' });
+		act(() => startupPhaseEmitter.fire(RuntimeStartupPhase.Complete));
+
 		expect(screen.getByText('Python 3.12')).toBeInTheDocument();
 	});
 

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/QuartoKernelStatusBadge.vitest.tsx
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/QuartoKernelStatusBadge.vitest.tsx
@@ -7,8 +7,8 @@
 
 import { act, screen } from '@testing-library/react';
 import { URI } from '../../../../../base/common/uri.js';
-import { Emitter } from '../../../../../base/common/event.js';
-import { ILanguageRuntimeMetadata, RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { ILanguageRuntimeMetadata, ILanguageRuntimeService, RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { IQuartoKernelManager, QuartoKernelState, QuartoKernelStateChangeEvent } from '../../browser/quartoKernelManager.js';
@@ -33,6 +33,7 @@ describe('QuartoKernelStatusBadge', () => {
 		onDidChangeKernelState: stateChange.event,
 		getKernelState: () => QuartoKernelState.None as QuartoKernelState,
 		getSessionForDocument: () => undefined as ILanguageRuntimeSession | undefined,
+		getPreferredRuntimeForDocument: () => undefined as ILanguageRuntimeMetadata | undefined,
 	};
 
 	const ctx = createTestContainer()
@@ -42,6 +43,10 @@ describe('QuartoKernelStatusBadge', () => {
 		.stub(IRuntimeSessionService, {
 			onDidChangeDisplayRuntimeState: displayStateEmitter.event,
 			getDisplayRuntimeState: () => displayState,
+		})
+		.stub(ILanguageRuntimeService, {
+			onDidRegisterRuntime: Event.None,
+			onDidChangeRuntimeStartupPhase: Event.None,
 		})
 		.build();
 	const rtl = setupRTLRenderer(() => ctx.reactServices);
@@ -62,12 +67,33 @@ describe('QuartoKernelStatusBadge', () => {
 		editorServiceStub.activeEditor = { resource: URI.file('/tmp/notebook.qmd') };
 		kernelManagerStub.getKernelState = () => QuartoKernelState.None;
 		kernelManagerStub.getSessionForDocument = () => undefined;
+		kernelManagerStub.getPreferredRuntimeForDocument = () => undefined;
 	});
 
-	it('shows disconnected icon and "No Kernel" label when no session and state is None', () => {
+	it('shows disconnected icon and "No Kernel" label when no session, no preferred runtime, and state is None', () => {
 		rtl.render(<QuartoKernelStatusBadge accessor={ctx.instantiationService} />);
 		expect(screen.getByTestId('runtime-status-disconnected')).toBeInTheDocument();
 		expect(screen.getByText('No Kernel')).toBeInTheDocument();
+	});
+
+	it('names the interpreter that would start when no kernel is running', () => {
+		// No session yet, but a preferred runtime is available: the badge should
+		// name it instead of showing "No Kernel".
+		kernelManagerStub.getPreferredRuntimeForDocument = () =>
+			stubInterface<ILanguageRuntimeMetadata>({ runtimeName: 'Python 3.12' });
+		rtl.render(<QuartoKernelStatusBadge accessor={ctx.instantiationService} />);
+		expect(screen.getByTestId('runtime-status-disconnected')).toBeInTheDocument();
+		expect(screen.getByText('Python 3.12')).toBeInTheDocument();
+	});
+
+	it('shows the state label over the preferred runtime when not in the None state', () => {
+		// An Error state should still surface the error label rather than the
+		// prospective interpreter name.
+		kernelManagerStub.getKernelState = () => QuartoKernelState.Error;
+		kernelManagerStub.getPreferredRuntimeForDocument = () =>
+			stubInterface<ILanguageRuntimeMetadata>({ runtimeName: 'Python 3.12' });
+		rtl.render(<QuartoKernelStatusBadge accessor={ctx.instantiationService} />);
+		expect(screen.getByText('Kernel Error')).toBeInTheDocument();
 	});
 
 	it('shows disconnected icon when manager reports an Error state', () => {

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoKernelManager.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoKernelManager.vitest.ts
@@ -135,6 +135,14 @@ describe('QuartoKernelManager', () => {
 					}),
 				})];
 			},
+			// Backs the synchronous language lookup used by
+			// getPreferredRuntimeForDocument: a single visible editor whose
+			// model resolves to the tracked document URI.
+			get visibleTextEditorControls() {
+				return [{
+					getModel() { return { uri: docUri }; },
+				}] as unknown as IEditorService['visibleTextEditorControls'];
+			},
 			onDidCloseEditor: Event.None as Event<IEditorCloseEvent>,
 		});
 
@@ -258,6 +266,25 @@ describe('QuartoKernelManager', () => {
 
 		// Should start the R runtime, not the stale Python binding
 		expect(startedRuntimeIds).toEqual(['r-4.4']);
+	});
+
+	it('getPreferredRuntimeForDocument returns the preferred runtime when nothing has started', () => {
+		// No session, no persisted binding: the interpreter that would start is
+		// the preferred runtime for the document's language.
+		expect(kernelManager.getPreferredRuntimeForDocument(docUri)).toBe(pythonRuntime1);
+	});
+
+	it('getPreferredRuntimeForDocument reports the running runtime once a kernel is started', async () => {
+		await kernelManager.changeKernelForDocument(docUri, pythonRuntime2.runtimeId);
+		// A kernel is running, so the badge should name that runtime rather than
+		// the default preferred one.
+		expect(kernelManager.getPreferredRuntimeForDocument(docUri)).toBe(pythonRuntime2);
+	});
+
+	it('getPreferredRuntimeForDocument returns undefined when the language cannot be determined', () => {
+		// A URI with no matching visible editor yields no language, so there is
+		// no interpreter to name.
+		expect(kernelManager.getPreferredRuntimeForDocument(URI.file('/test/other.qmd'))).toBeUndefined();
 	});
 
 	it('changeKernelForDocument fires state change events', async () => {


### PR DESCRIPTION
Fixes #14558

### Summary

In a Quarto (`.qmd`) preview editor with inline output enabled, there was previously no way to start the kernel explicitly -- you had to run a cell or promote the preview tab to a real editor. The "No Kernel" indicator also offered options that didn't make sense before a kernel existed.

This PR makes the Quarto kernel status badge behave more like the notebook
kernel status.

<img width="326" height="144" alt="image" src="https://github.com/user-attachments/assets/da9b4217-4f5e-4719-aa23-7153e9941304" />


- **Names the interpreter that would start.** When no kernel is running, the badge shows the interpreter that would start if you ran code (e.g. "Python 3.12") instead of a bare "No Kernel". It resolves the prospective runtime the same way startup does (a running session, a persisted per-document kernel choice, then the preferred runtime for the document's language) and updates as interpreters are discovered.
- **Adds an explicit "Start Kernel" action.** The badge drop list now includes  "Start Kernel" when no kernel is running, so you can start one directly. The menu is also tidied so "Restart Kernel" only appears once a kernel is running: no kernel -> Start Kernel / Change Kernel; running -> Change /  Restart / Interrupt / Shutdown.

### Release Notes

#### New Features

- Quarto inline output: the kernel status now names the interpreter that would start and offers an explicit "Start Kernel" action (#14558)

#### Bug Fixes

- N/A

### Validation Steps

@:quarto

1. Enable the `quarto.inlineOutput.enabled` setting.
2. In the Explorer, single-click a `.qmd` file to open it as a preview editor (single click, not double click).
3. Confirm the kernel status badge in the editor toolbar names the interpreter that would start (e.g. "Python 3.12") rather than "No Kernel".
4. Click the badge, choose **Start Kernel**, and confirm the kernel starts and the badge shows the running interpreter.
5. With a kernel running, open the drop list again and confirm it shows Change / Restart / Interrupt / Shutdown and no longer shows "Start Kernel".
