### PR TITLE
Download the detected build on Linux updates instead of pointing to the website

### DIFF
--- a/src/vs/platform/update/electron-main/updateService.linux.ts
+++ b/src/vs/platform/update/electron-main/updateService.linux.ts
@@ -81,12 +81,16 @@ export class LinuxUpdateService extends AbstractUpdateService {
 	}
 
 	protected override async doDownloadUpdate(state: AvailableForDownload): Promise<void> {
-		// Use the download URL if available as we don't currently detect the package type that was
-		// installed and the website download page is more useful than the tarball generally.
-		if (this.productService.downloadUrl && this.productService.downloadUrl.length > 0) {
-			this.nativeHostMainService.openExternal(undefined, this.productService.downloadUrl);
-		} else if (state.update.url) {
+		// Send the user directly to the artifact advertised by the update feed. The feed URL is keyed
+		// to the installed package type (productService.packageType), so state.update.url already points
+		// at the correct .deb/.rpm/tarball for the version we detected. This is the version the check
+		// found, which matters for both channels: the website download page only serves `releases`, so
+		// dailies users have nowhere to land there, and even release users can be handed a build the page
+		// is not yet serving. Fall back to the generic download page only when the feed omits a URL.
+		if (state.update.url) {
 			this.nativeHostMainService.openExternal(undefined, state.update.url);
+		} else if (this.productService.downloadUrl && this.productService.downloadUrl.length > 0) {
+			this.nativeHostMainService.openExternal(undefined, this.productService.downloadUrl);
 		}
 
 		this.setState(State.Idle(UpdateType.Archive));


### PR DESCRIPTION
I was digging into some update problems people were having after the latest release, and I think we have a straightforward path to fixing https://github.com/posit-dev/positron/issues/8306 now! 🎉 

Before, on Linux, "Download Update" sent the user to the generic website download page (`productService.downloadUrl`) rather than the specific artifact advertised by the update feed. That page only serves the `releases` channel, so users on `"update.positron.channel": "dailies"` had nowhere to land, and even release users could be handed whatever build the page happened to be serving rather than the one the update check actually detected.

This changes `doDownloadUpdate` in the Linux update service to prefer `state.update.url`, the artifact from the update feed, falling back to the website download page only if the feed omits a URL. The feed URL is already keyed to the installed package type (`productService.packageType`), so `state.update.url` points at the correct `.deb`/`.rpm` for the version we detected. The stale code comment claiming we "don't currently detect the package type" no longer holds, since `packageType` is what builds the feed URL in the first place.

**This change applies to both the `releases` and `dailies` channels,** but it's an improvement in both cases. Daily users can now update from the CDN feed, and release users are handed the exact build the check found instead of whatever the download page is serving.

Known limitation (pre-existing, not changed by this PR): a user who installed via a `.tar.gz` but whose `product.json` defaults `packageType` to `deb` would be offered a `.deb`. We do not currently detect the installed package format.

Fixes #8306. Also might address the Linux report in https://github.com/posit-dev/positron/issues/8284#issuecomment-4924910679 where a user on `releases` was repeatedly sent to re-download a build that looked like the one they already had.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed Linux updates so "Download Update" fetches the specific build detected by the update check, including on the `dailies` channel, instead of opening the website download page (#8306).

### Validation Steps

Auto e2e tags are not meaningful for this change, so validation is manual on Linux (`.deb` or `.rpm` install) after I kick off some release builds:

1. Set `"update.positron.channel": "dailies"` in Settings and restart Positron.
2. When an update is available, choose "Download Update" and confirm the browser is sent directly to the daily artifact on the CDN (e.g. `https://cdn.posit.co/positron/dailies/deb/x86_64/Positron-<version>-x64.deb`), not to `https://positron.posit.co/download`.
3. Repeat with `"update.positron.channel": "releases"` and confirm the download goes to the specific release artifact for the detected version.
4. Confirm the update state returns to idle after the download is initiated.
