### PR TITLE
Show default message instead of duplicate load prompts when diffing `.rds`/`.RData` files

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -14,6 +14,9 @@
     "Debuggers"
   ],
   "main": "./out/extension.js",
+  "enabledApiProposals": [
+    "customEditorPriority"
+  ],
   "capabilities": {
     "untrustedWorkspaces": {
       "supported": "limited",
@@ -840,7 +843,11 @@
       {
         "viewType": "positron-r.rdataLoader",
         "displayName": "%r.customEditor.rdataLoader.displayName%",
-        "priority": "default",
+        "priority": {
+          "editor": "default",
+          "diff": "option",
+          "merge": "option"
+        },
         "selector": [
           {
             "filenamePattern": "*.RData"
@@ -859,7 +866,11 @@
       {
         "viewType": "positron-r.rdsLoader",
         "displayName": "%r.customEditor.rdsLoader.displayName%",
-        "priority": "default",
+        "priority": {
+          "editor": "default",
+          "diff": "option",
+          "merge": "option"
+        },
         "selector": [
           {
             "filenamePattern": "*.rds"


### PR DESCRIPTION
Fixes #14426

Before, clicking a modified `.rds` file in the Git pane opened the diff as two identical "Load R Object" prompts, one per side. The `.rds` (and `.RData`/`.rda`) custom editors are more like action prompts, not viewers, so rendering one per diff side produced two useless, identical loaders. The "old" side would have loaded the current working-tree content anyway.

The custom editor now declines to be the automatic editor for diffs and merges, so those fall back to VS Code's built-in binary diff view:

<img width="1483" height="1004" alt="Screenshot 2026-07-13 at 9 16 17 PM" src="https://github.com/user-attachments/assets/a61cf4f1-c073-4aa7-832e-571521a8351e" />

This is the exact same thing you see in VS Code for the same situation/gesture. A normal double-click from the Explorer still opens the loader as before.

This specific approach uses the existing per-context editor priority mechanism rather than any new core code. The `customEditors` contribution point already supports separate `editor` / `diff` / `merge` priorities, and the editor resolver already honors them. The change enables the `customEditorPriority` proposed API and sets `diff` and `merge` to `option` (below the auto-select threshold) while keeping `editor` at `default`. It is scoped entirely to the `positron-r` editors; image, PDF, and Markdown diffs are unaffected.

Do note that this takes a dependency on the `customEditorPriority` proposed API (microsoft/vscode#292379), following the same pattern `positron-python` and `positron-assistant` use to enable proposals in a built-in extension. If the proposal changes upstream before finalizing, it would surface at a future merge.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed duplicate "Load R Object" prompts when viewing the diff of a modified `.rds` file (#14426).

### Validation Steps

1. Create an `.rds` file (e.g. `saveRDS(mtcars, "example.rds")`) and commit it.
2. Modify its contents but keep the same filename, then re-save so it shows as "Modified" in the Git pane.
3. Click the modified file to open the diff. Confirm it shows the native/default binary diff ("The file is not displayed... binary") on each side, not two "Load R Object" prompts.
4. Double-click the `.rds` file in the Explorer and confirm the "Load R Object" prompt still appears and loads the object into the R session.
5. Repeat with a modified `.RData`/`.rda` file to confirm the same behavior for the workspace loader.
