### PR TITLE
Add hidden feature switch for the new Configure LLM Providers modal

### DIFF
--- a/src/vs/workbench/contrib/positronAssistant/browser/configureLLMProvidersModal.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/configureLLMProvidersModal.tsx
@@ -1,0 +1,77 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Other dependencies.
+import { localize } from '../../../../nls.js';
+import { IPositronLanguageModelConfig, IPositronLanguageModelSource, IShowLanguageModelConfigOptions } from '../common/interfaces/positronAssistantService.js';
+import { OKModalDialog } from '../../../browser/positronComponents/positronModalDialog/positronOKModalDialog.js';
+import { PositronModalReactRenderer } from '../../../../base/browser/positronModalReactRenderer.js';
+import { VerticalStack } from '../../../browser/positronComponents/positronModalDialog/components/verticalStack.js';
+
+/**
+ * Hidden feature switch that selects the new "Configure LLM Providers" modal
+ * over the legacy language model provider dialog.
+ *
+ * This key is intentionally NOT contributed to the configuration registry, so
+ * it does not appear in the Settings editor. Set it manually in `settings.json`
+ * to opt in to the in-progress modal. It defaults to `false` (legacy dialog).
+ */
+export const NEW_PROVIDER_MODAL_KEY = 'assistant.newProviderModal';
+
+/**
+ * Opens the new "Configure LLM Providers" modal.
+ *
+ * This is a minimal shell: it renders the dialog chrome so the feature switch
+ * has something to open, while the header/footer controls and provider
+ * configuration flows are built out in follow-up work (see
+ * https://github.com/posit-dev/positron/issues/14815).
+ *
+ * The signature mirrors {@link showLanguageModelModalDialog} so the two modals
+ * are interchangeable at the single call site that reads the feature switch.
+ */
+export const showConfigureLLMProvidersModal = (
+	_sources: IPositronLanguageModelSource[],
+	_onAction: (source: IPositronLanguageModelSource, config: IPositronLanguageModelConfig, action: string) => Promise<void>,
+	onClose: () => void,
+	_options?: IShowLanguageModelConfigOptions,
+) => {
+	const renderer = new PositronModalReactRenderer();
+
+	renderer.render(
+		<div className='configure-llm-providers-modal'>
+			<ConfigureLLMProviders renderer={renderer} onClose={onClose} />
+		</div>
+	);
+};
+
+interface ConfigureLLMProvidersProps {
+	renderer: PositronModalReactRenderer;
+	onClose: () => void;
+}
+
+const ConfigureLLMProviders = (props: ConfigureLLMProvidersProps) => {
+	// Notify the caller and tear down the modal DOM. Both are required: the
+	// renderer must be disposed or the dialog stays mounted after Close.
+	const onClose = () => {
+		props.onClose();
+		props.renderer.dispose();
+	};
+
+	return <OKModalDialog
+		height={500}
+		okButtonTitle={localize('positron.configureLLMProvidersModal.close', "Close")}
+		renderer={props.renderer}
+		title={localize('positron.configureLLMProvidersModal.title', "Configure LLM Providers")}
+		width={600}
+		onAccept={onClose}
+		onCancel={onClose}
+	>
+		<VerticalStack>
+			<p>
+				{localize('positron.configureLLMProvidersModal.placeholder', "This is the new provider configuration experience. It's still being built.")}
+			</p>
+		</VerticalStack>
+	</OKModalDialog>;
+};

--- a/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
@@ -10,6 +10,7 @@ import { IPositronPlotsService } from '../../../services/positronPlots/common/po
 import { ITerminalService } from '../../terminal/browser/terminal.js';
 import { IChatRequestData, IPositronAssistantService, IPositronAssistantConfigurationService, IPositronChatContext, IPositronLanguageModelConfig, IPositronLanguageModelSource, IShowLanguageModelConfigOptions } from '../common/interfaces/positronAssistantService.js';
 import { showLanguageModelModalDialog } from './languageModelModalDialog.js';
+import { NEW_PROVIDER_MODAL_KEY, showConfigureLLMProvidersModal } from './configureLLMProvidersModal.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
@@ -326,7 +327,10 @@ export class PositronAssistantService extends Disposable implements IPositronAss
 			onClose();
 			return;
 		}
-		showLanguageModelModalDialog(
+		// Feature switch: the new "Configure LLM Providers" modal
+		const useNewModal = this._configurationService.getValue<boolean>(NEW_PROVIDER_MODAL_KEY) === true;
+		const showModal = useNewModal ? showConfigureLLMProvidersModal : showLanguageModelModalDialog;
+		showModal(
 			sources,
 			onAction,
 			onClose,

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/positronAssistantService.vitest.ts
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/positronAssistantService.vitest.ts
@@ -28,6 +28,12 @@ import { createTestContainer } from '../../../../../test/vitest/positronTestCont
 const { mockShowDialog } = vi.hoisted(() => ({ mockShowDialog: vi.fn() }));
 vi.mock('../../browser/languageModelModalDialog.js', () => ({ showLanguageModelModalDialog: mockShowDialog }));
 
+const { mockShowNewModal } = vi.hoisted(() => ({ mockShowNewModal: vi.fn() }));
+vi.mock('../../browser/configureLLMProvidersModal.js', () => ({
+	NEW_PROVIDER_MODAL_KEY: 'assistant.newProviderModal',
+	showConfigureLLMProvidersModal: mockShowNewModal,
+}));
+
 // `areCompletionsEnabled` reads the completions enablement setting name from
 // product configuration. The vitest web fallback leaves that name empty, so
 // override only this one field (preserving the rest of the product config) to
@@ -195,6 +201,19 @@ describe('PositronAssistantService showLanguageModelModalDialog', () => {
 		expect(prompt).not.toHaveBeenCalled();
 		expect(mockShowDialog).toHaveBeenCalledTimes(1);
 		expect(mockShowDialog.mock.calls[0][0]).toBe(sources);
+		expect(mockShowNewModal).not.toHaveBeenCalled();
+	});
+
+	it('renders the new provider modal when the feature switch is enabled', () => {
+		const sources = [makeSource('prov-a')];
+		getRegisteredSources.mockReturnValue(sources);
+		(ctx.get(IConfigurationService) as TestConfigurationService).setUserConfiguration('assistant.newProviderModal', true);
+
+		service.showLanguageModelModalDialog(vi.fn(), vi.fn());
+
+		expect(mockShowNewModal).toHaveBeenCalledTimes(1);
+		expect(mockShowNewModal.mock.calls[0][0]).toBe(sources);
+		expect(mockShowDialog).not.toHaveBeenCalled();
 	});
 });
 


### PR DESCRIPTION
Fixes #14814

### Summary
Adds a hidden feature switch that selects a new "Configure LLM Providers" modal over the legacy language model provider dialog. This is the first step of a larger effort; the new modal's chrome and provider flows land in follow-ups (#14815, #14818, #14819).

The switch (`assistant.newProviderModal`) is intentionally **not** contributed to the configuration registry, so it stays hidden from the Settings editor and defaults to the legacy dialog. All provider-configuration entry points (the `Configure Language Model Providers` command, the Accounts menu item, and the "Configure" notification action) funnel through `PositronAssistantService.showLanguageModelModalDialog`, so the switch is read live in that single place. This PR also adds a minimal shell so the switch has something to open.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:assistant

1. Run the **Configure Language Model Providers** command (or the Accounts menu item) and verify the existing provider dialog opens (unchanged behavior).
2. Add `"assistant.newProviderModal": true` to `settings.json` (hidden setting, won't autocomplete).
3. Re-run the command and verify the new "Configure LLM Providers" modal opens instead.
4. Click **Close** and verify the modal dismisses.
5. Remove the setting and confirm the legacy dialog returns.
