### PR TITLE
e2e: fix flaky plots image-comparison tests

### DIFF
--- a/test/e2e/pages/plots.ts
+++ b/test/e2e/pages/plots.ts
@@ -150,6 +150,19 @@ export class Plots {
 		await expect(this.code.driver.currentPage.locator(CURRENT_PLOT)).not.toBeVisible({ timeout });
 	}
 
+	// Clears every plot (all sessions) via the action-bar button and asserts the pane is empty.
+	// The "Clear All Plots" button works headlessly where the Cmd+L C keybinding does not, so this
+	// guarantees an empty history (no filmstrip) that image-comparison tests rely on. Requires the
+	// Plots view to be visible (e.g. after stackedLayout()) so the button is actionable.
+	async clearAllPlots({ timeout = 15000 }: { timeout?: number } = {}) {
+		await expect(async () => {
+			if (await this.clearPlotsButton.isVisible() && await this.clearPlotsButton.isEnabled()) {
+				await this.clearPlotsButton.click();
+			}
+			await this.waitForNoPlots({ timeout: 3000 });
+		}).toPass({ timeout });
+	}
+
 	async getCurrentPlotAsBuffer(): Promise<Buffer> {
 		return this.currentPlot.screenshot();
 	}

--- a/test/e2e/tests/plots/plots.test.ts
+++ b/test/e2e/tests/plots/plots.test.ts
@@ -25,8 +25,12 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 			await sessions.start('python');
 		});
 
-		test.beforeEach(async function ({ hotKeys, sessions }) {
+		test.beforeEach(async function ({ app, hotKeys, sessions }) {
 			await hotKeys.stackedLayout();
+			// Clear plots left over from earlier tests so the history filmstrip is absent and a
+			// single plot renders at full height, matching the image-comparison baselines. Uses
+			// the action-bar button because the Cmd+L C keybinding does not clear headlessly.
+			await app.workbench.plots.clearAllPlots();
 		});
 
 		test.afterEach(async function ({ app, hotKeys }) {
@@ -51,9 +55,6 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 			await app.workbench.plots.waitForCurrentPlot();
 
 			await app.workbench.toasts.closeAll();
-
-			// attempt to workaround a flake by letting plot settle
-			await app.code.driver.currentPage.waitForTimeout(1000);
 
 			const buffer = await app.workbench.plots.getCurrentPlotAsBuffer();
 			await compareImages({
@@ -95,9 +96,6 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 			await app.workbench.plots.waitForCurrentStaticPlot();
 
 			await app.workbench.toasts.closeAll();
-
-			// attempt to workaround a flake by letting plot settle
-			await app.code.driver.currentPage.waitForTimeout(1000);
 
 			const buffer = await app.workbench.plots.getCurrentStaticPlotAsBuffer();
 			await compareImages({
@@ -392,8 +390,12 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 			await sessions.start('r');
 		});
 
-		test.beforeEach(async function ({ sessions, hotKeys }) {
+		test.beforeEach(async function ({ app, sessions, hotKeys }) {
 			await hotKeys.stackedLayout();
+			// Clear plots left over from earlier tests so the history filmstrip is absent and a
+			// single plot renders at full height, matching the image-comparison baselines. Uses
+			// the action-bar button because the Cmd+L C keybinding does not clear headlessly.
+			await app.workbench.plots.clearAllPlots();
 		});
 
 		test.afterEach(async function ({ app, hotKeys }) {
@@ -417,9 +419,6 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 			await app.workbench.plots.waitForCurrentPlot();
 
 			await app.workbench.toasts.closeAll();
-
-			// attempt to workaround a flake by letting plot settle
-			await app.code.driver.currentPage.waitForTimeout(1000);
 
 			const buffer = await app.workbench.plots.getCurrentPlotAsBuffer();
 			await compareImages({


### PR DESCRIPTION
The `Cmd+L C` clearPlots hotkey is a no-op headlessly, so plots leaked across tests and the history filmstrip shrank the plot render area, causing a deterministic image-comparison mismatch (the test only passed on retry).

- Clear plot history via the action-bar button in `beforeEach`
- Drop the redundant plot-settle `waitForTimeout` waits

Validated on the ci-arm CI image: full plots spec 25 passed.
