### PR TITLE
e2e(ci-arm): add headless helper scripts

### DIFF
--- a/.devcontainer/ci-arm/README.md
+++ b/.devcontainer/ci-arm/README.md
@@ -158,9 +158,17 @@ docker compose exec -T test bash -lc \
   "cd \$POSITRON_WORKSPACE_PATH && ./.devcontainer/ci-arm/run-e2e.sh test/e2e/tests/<area>/<file>.test.ts --workers=1"
 ```
 
-The numbered steps document what `ci-lab-up.sh` does and are the fallback when a phase fails; you
-don't run them by hand on the happy path. All `docker compose` commands run from
-`<worktree>/.devcontainer/ci-arm` so Compose finds the right project's `docker-compose.yml` and `.env`.
+All `docker compose` commands run from `<worktree>/.devcontainer/ci-arm` so Compose finds the right
+project's `docker-compose.yml` and `.env`.
+
+**Reproducing a CI-only flake? Run the *whole* spec at `--workers=1`** (as the command above does).
+Positron doesn't split a single spec file across workers, so its tests run in order and share app
+state. A test that only fails in CI often passes in isolation (a single `--grep`) yet fails because an
+earlier test in the same file left state behind -- don't conclude "can't reproduce" from an isolated
+run.
+
+<details>
+<summary><strong>Manual step-by-step</strong> -- what <code>ci-lab-up.sh</code> automates, and the fallback when a phase fails</summary>
 
 1. **Set the workspace env vars** (normally run by the `initializeCommand` hook):
 
@@ -292,16 +300,8 @@ Gotchas specific to this path:
   `ci-lab-up.sh` does this check for you -- prefer it over running the build step by hand.
 - **No `devcontainer` CLI required** -- this is plain `docker compose`, useful since the CLI isn't
   installed by default on the host.
-- **Reproducing a CI-only flake? Run the *whole* spec at `--workers=1`.** Positron doesn't split a
-  single spec file across workers, so its tests run in order and share app state. A test that only
-  fails in CI often passes in isolation (a single `--grep`) yet fails because an earlier test in the
-  same file left state behind. Don't conclude "can't reproduce" from the isolated run -- run the
-  entire spec file in order before deciding:
 
-  ```bash
-  docker compose exec test bash -lc \
-    "cd \$POSITRON_WORKSPACE_PATH && ./.devcontainer/ci-arm/run-e2e.sh test/e2e/tests/<area>/<file>.test.ts --workers=1"
-  ```
+</details>
 
 ## Reference
 

--- a/.devcontainer/ci-arm/README.md
+++ b/.devcontainer/ci-arm/README.md
@@ -148,10 +148,10 @@ cd <worktree>/.devcontainer/ci-arm
 ./ci-lab-up.sh [<branch>]   # idempotent: initialize, compose up, build if cold, per-start setup
 ```
 
-`ci-lab-up.sh` collapses the numbered steps below into one command that can't be run half-way or out
-of order -- it detects cold/warm/hot itself, and with a `<branch>` it also checks out that branch and
-reconciles deps + `out/`. A cold build is ~10 min, so run it in the background and wait for it to
-exit (clean exit = ready). Then run a spec inside the container:
+`ci-lab-up.sh` is one command that can't be run half-way or out of order -- it detects cold/warm/hot
+itself, and with a `<branch>` it also checks out that branch and reconciles deps + `out/`. A cold
+build is ~10 min, so run it in the background and wait for it to exit (clean exit = ready). Then run a
+spec inside the container:
 
 ```bash
 docker compose exec -T test bash -lc \
@@ -167,141 +167,25 @@ state. A test that only fails in CI often passes in isolation (a single `--grep`
 earlier test in the same file left state behind -- don't conclude "can't reproduce" from an isolated
 run.
 
-<details>
-<summary><strong>Manual step-by-step</strong> -- what <code>ci-lab-up.sh</code> automates, and the fallback when a phase fails</summary>
+**How it works, and when it breaks.** `ci-lab-up.sh` chains `initialize.sh` -> `docker compose up -d`
+-> cold-or-ready detection -> `post-create.sh` if cold (~10 min) -> the idempotent `post-start.sh`
+(display, VNC, postgres). A `<branch>` argument also checks out that branch and reconciles deps +
+`out/`. When a phase fails, read its log (`/tmp/post-create.log`, `/tmp/compile.log`) and the script's
+`=== ci-lab-up: <phase> ===` echoes, then rerun that phase. Three non-obvious things it handles:
 
-1. **Set the workspace env vars** (normally run by the `initializeCommand` hook):
-
-   ```bash
-   cd <worktree>/.devcontainer/ci-arm
-   ./initialize.sh   # writes POSITRON_WORKSPACE_PATH / POSITRON_GIT_COMMON_DIR into .env
-   ```
-
-2. **Point the worktree at the target branch** (skip this on a fresh worktree; it matters once the lab
-   is long-lived and reused across sessions). Don't assume the checked-out source matches whatever
-   you're currently investigating -- fetch and check out explicitly:
-
-   ```bash
-   cd <worktree>
-   git fetch origin <branch>
-   git checkout <branch>
-   ```
-
-   Switching branches can leave two things stale, both of which the Doctor's Build row already checks:
-
-   - **Dependencies.** Compare `package-lock.json`'s hash against the one recorded at the last install:
-
-     ```bash
-     docker compose exec test bash -lc \
-       "cd \$POSITRON_WORKSPACE_PATH && [ \"\$(sha256sum package-lock.json | awk '{print \$1}')\" = \"\$(cat .build/.ci-arm-state/deps.sha 2>/dev/null)\" ] && echo OK || echo DRIFTED"
-     ```
-
-     A `DRIFTED` result means reinstall, via the same `reinstall-deps.sh` script the **Positron CI:
-     Reinstall deps** task calls:
-
-     ```bash
-     docker compose exec test bash -lc \
-       "cd \$POSITRON_WORKSPACE_PATH && ./.devcontainer/ci-arm/reinstall-deps.sh root"
-     ```
-
-     Repeat with `e2e` instead of `root` (**Positron CI: Reinstall e2e deps**) against
-     `test/e2e/package-lock.json` / `e2e-deps.sha` if the target branch also touched e2e's own deps.
-
-   - **Compiled output.** `out/` is bind-mounted and reflects whichever branch was last built here, so
-     recompile after switching:
-
-     ```bash
-     docker compose exec -d test bash -lc \
-       "cd \$POSITRON_WORKSPACE_PATH && npm exec -- npm-run-all --max_old_space_size=4095 -lp compile > /tmp/compile.log 2>&1"
-     ```
-
-     This is incremental -- the same thing the **Watch** task does -- so it's much faster than the
-     first-time build in step 5 below.
-
-3. **Bring up the stack.** `initialize.sh` (step 1) pins `COMPOSE_PROJECT_NAME` to this checkout's own
-   directory name, so its containers/volumes never collide with another checkout's -- the remaining
-   steps use `docker compose exec <service>` instead of a hardcoded container name, so they resolve
-   correctly regardless of what that project name is:
-
-   ```bash
-   docker compose up -d
-   ```
-
-4. **Check whether the build is cold, warm, or hot** before doing anything else -- don't assume:
-
-   ```bash
-   docker compose exec test bash -lc \
-     "test -f \$POSITRON_WORKSPACE_PATH/.build/.ci-arm-state/complete && echo WARM_OR_HOT || echo COLD"
-   ```
-
-   - **COLD** (fresh worktree, or after `reset.sh`): no `node_modules`/`.build` yet -> run the
-     first-time build (step 5) before anything else.
-   - **WARM** (built before, containers just recreated by step 3): skip straight to step 6.
-   - **HOT** (containers were already running, e.g. from an earlier session): skip both step 5 and 6's
-     `post-start.sh` call and go straight to step 7.
-
-   If step 7 fails with a `Cannot find module` or missing `out/main.js` error despite a "warm"
-   reading, treat it as effectively cold: rerun step 2's dependency-drift check and compile command,
-   or fall back to step 5.
-
-5. **First-time build only.** This mirrors `post-create.sh`'s dep install / compile / Electron build /
-   Playwright install / license setup -- the same script Dev Containers runs, just invoked directly.
-   It takes roughly 10 minutes and is not something to block a foreground shell on:
-
-   ```bash
-   docker compose exec -d test bash -lc \
-     "cd \$POSITRON_WORKSPACE_PATH && ./.devcontainer/ci-arm/post-create.sh > /tmp/post-create.log 2>&1"
-   ```
-
-   `-d` detaches immediately, so this returns right away instead of holding the shell for
-   10 minutes. Poll for completion instead of guessing at a fixed sleep -- check every minute or two,
-   not continuously, and read the log on failure:
-
-   ```bash
-   docker compose exec test bash -lc \
-     "test -f \$POSITRON_WORKSPACE_PATH/.build/.ci-arm-state/complete && echo DONE || tail -5 /tmp/post-create.log"
-   ```
-
-   The marker file (`.build/.ci-arm-state/complete`, written by `mark-build-state.sh`) is the same
-   completion signal step 4 checks -- once it's there, move on to step 6.
-
-6. **Per-start setup** (display, VNC, postgres reachability -- idempotent, safe to always run except
-   on an already-HOT container):
-
-   ```bash
-   docker compose exec test bash -lc "cd \$POSITRON_WORKSPACE_PATH && ./.devcontainer/ci-arm/post-start.sh"
-   ```
-
-7. **Run an e2e spec.** Unlike the UI, `docker compose exec` doesn't inject `containerEnv`, so the
-   helper re-supplies it: use `run-e2e.sh` rather than calling `npx playwright test` by hand -- it sets
-   the four interpreter version vars (read from `devcontainer.json`), `DISPLAY`, a default
-   `--project e2e-electron`, and `GITHUB_ACTIONS=true` (harmless for the tests that don't read it; it's
-   what makes image-comparison tests actually compare). Everything else passes straight through to Playwright:
-
-   ```bash
-   docker compose exec test bash -lc \
-     "cd \$POSITRON_WORKSPACE_PATH && ./.devcontainer/ci-arm/run-e2e.sh test/e2e/tests/search/search.test.ts"
-   ```
-
-   All `docker compose` commands above must run from `<worktree>/.devcontainer/ci-arm` (step 1's
-   directory) so Compose finds the right project's `docker-compose.yml` and `.env`.
-
-Gotchas specific to this path:
-
-- **No `containerEnv` injection.** `devcontainer.json`'s `containerEnv` block (the four interpreter
-  version selectors, etc.) is applied by the Dev Containers extension, not by plain `docker compose`,
-  and the e2e suite's `test/e2e/tests/_test.setup.ts` *throws* unless all four are set --
-  `POSITRON_PY_VER_SEL`, `POSITRON_R_VER_SEL`, `POSITRON_PY_ALT_VER_SEL`, `POSITRON_R_ALT_VER_SEL`.
-  `run-e2e.sh` (step 7) reads them from `devcontainer.json` and exports them for you, so prefer it
-  over exporting by hand: the canonical values live in one place and stay correct if the pins change.
-- **Don't skip the cold/warm/hot check.** Running `post-create.sh` on an already-built container just
-  wastes ~10 minutes (it's idempotent-safe but not idempotent-fast); skipping it on a truly cold
-  container fails every later step with confusing missing-module errors instead of one clear one.
-  `ci-lab-up.sh` does this check for you -- prefer it over running the build step by hand.
-- **No `devcontainer` CLI required** -- this is plain `docker compose`, useful since the CLI isn't
-  installed by default on the host.
-
-</details>
+- **"Ready" checks artifacts, not just the marker.** Detection keys off `.build/.ci-arm-state/complete`
+  *and* `out/main.js` + a populated `node_modules` -- a container can read built yet still fail a run
+  with `Cannot find module`. That case is treated as cold; reinstall + recompile (or rerun
+  `ci-lab-up.sh <branch>`).
+- **No `containerEnv` over plain `docker compose`.** The four interpreter version selectors in
+  `devcontainer.json`'s `containerEnv` are injected by the Dev Containers extension, not by
+  `docker compose exec`, and the e2e suite throws without them. That's why runs go through
+  `run-e2e.sh`, which reads the pins and exports them (plus `DISPLAY`, `--project e2e-electron`,
+  `GITHUB_ACTIONS=true`, which is what makes image-comparison tests actually compare).
+- **Branch switches stale deps and `out/`.** `out/` is bind-mounted and reflects whichever branch was
+  last built here. Passing `<branch>` to `ci-lab-up.sh` reconciles both (sha-compare against
+  `.build/.ci-arm-state/*.sha`, then `reinstall-deps.sh` / incremental compile as needed) -- prefer it
+  over a bare `git checkout`.
 
 ## Reference
 
@@ -436,8 +320,8 @@ It removes this project's dev container, its data volumes (root + e2e + remote `
   - **Mid-session (messier).** `git checkout` in the open container, then reload the window and let
     **Watch** recompile (restart any running Positron/debug). Note Watch recompiles but does *not*
     check dependency drift -- rely on the Doctor's **Build** row to flag stale deps.
-  - **Headless.** [Claude Workflows](#claude-workflows-cli-only-headless)'s step 2 does the same
-    thing over the CLI, including the dependency-drift check Watch doesn't handle.
+  - **Headless.** `ci-lab-up.sh <branch>` (see [Claude Workflows](#claude-workflows-cli-only-headless))
+    does the same thing over the CLI, including the dependency-drift check Watch doesn't handle.
 
   Whichever path you take, keep the **Doctor** open: its Build and Interpreters rows tell you what
   went stale and which task fixes it.
@@ -445,7 +329,7 @@ It removes this project's dev container, its data volumes (root + e2e + remote `
   it.** Compose's project name defaults to the directory *basename* holding `docker-compose.yml`,
   which is `ci-arm` for every checkout of this repo (they all have the same `.devcontainer/ci-arm`
   layout); without a fix, two checkouts would silently share one set of containers and volumes
-  instead of erroring. `initialize.sh` (Setup step 3 / CLI-only step 1) closes this by pinning
+  instead of erroring. `initialize.sh` (Setup step 3, and the first thing `ci-lab-up.sh` runs) closes this by pinning
   `COMPOSE_PROJECT_NAME` to the checkout's own directory name, so `docker compose up -d` always
   creates that checkout's own containers. The one sharp edge: a checkout whose `.env` predates this
   fix (no `COMPOSE_PROJECT_NAME` line) still defaults to the shared `ci-arm` name until

--- a/.devcontainer/ci-arm/README.md
+++ b/.devcontainer/ci-arm/README.md
@@ -136,30 +136,25 @@ Debug **e2e tests** straight from the test files via the gutter run/debug icons,
 
 ### Claude Workflows (CLI-only, headless)
 
-Everything in [User Workflows](#user-workflows-vs-code-ui) assumes VS Code's Dev Containers UI. An
-agent (or any terminal-only workflow) can drive the same stack directly with `docker compose` +
-`docker exec`, once [Setup](#setup)'s steps 1-2 are done (worktree created, secrets added) -- the
-build itself can happen through this path too, no Dev Containers UI required.
+No Dev Containers UI -- drive the stack from the host with `docker compose`, once [Setup](#setup)'s
+steps 1-2 are done (worktree created, secrets added). The build runs through this path too.
 
-**Happy path -- two commands.** On the host, from the worktree:
+**Two commands.** From the worktree:
 
 ```bash
 cd <worktree>/.devcontainer/ci-arm
 ./ci-lab-up.sh [<branch>]   # idempotent: initialize, compose up, build if cold, per-start setup
 ```
 
-`ci-lab-up.sh` is one command that can't be run half-way or out of order -- it detects cold/warm/hot
-itself, and with a `<branch>` it also checks out that branch and reconciles deps + `out/`. A cold
-build is ~10 min, so run it in the background and wait for it to exit (clean exit = ready). Then run a
-spec inside the container:
+`ci-lab-up.sh` detects cold/warm/hot itself; with a `<branch>` it also checks out that branch and
+reconciles deps + `out/`. A cold build is ~10 min -- run it in the background; clean exit = ready.
+Then run a spec in the container (from the same `.devcontainer/ci-arm` dir, so Compose finds this
+project's `docker-compose.yml` and `.env`):
 
 ```bash
 docker compose exec -T test bash -lc \
   "cd \$POSITRON_WORKSPACE_PATH && ./.devcontainer/ci-arm/run-e2e.sh test/e2e/tests/<area>/<file>.test.ts --workers=1"
 ```
-
-All `docker compose` commands run from `<worktree>/.devcontainer/ci-arm` so Compose finds the right
-project's `docker-compose.yml` and `.env`.
 
 **Reproducing a CI-only flake? Run the *whole* spec at `--workers=1`** (as the command above does).
 Positron doesn't split a single spec file across workers, so its tests run in order and share app

--- a/.devcontainer/ci-arm/README.md
+++ b/.devcontainer/ci-arm/README.md
@@ -141,6 +141,27 @@ agent (or any terminal-only workflow) can drive the same stack directly with `do
 `docker exec`, once [Setup](#setup)'s steps 1-2 are done (worktree created, secrets added) -- the
 build itself can happen through this path too, no Dev Containers UI required.
 
+**Happy path -- two commands.** On the host, from the worktree:
+
+```bash
+cd <worktree>/.devcontainer/ci-arm
+./ci-lab-up.sh [<branch>]   # idempotent: initialize, compose up, build if cold, per-start setup
+```
+
+`ci-lab-up.sh` collapses the numbered steps below into one command that can't be run half-way or out
+of order -- it detects cold/warm/hot itself, and with a `<branch>` it also checks out that branch and
+reconciles deps + `out/`. A cold build is ~10 min, so run it in the background and wait for it to
+exit (clean exit = ready). Then run a spec inside the container:
+
+```bash
+docker compose exec -T test bash -lc \
+  "cd \$POSITRON_WORKSPACE_PATH && ./.devcontainer/ci-arm/run-e2e.sh test/e2e/tests/<area>/<file>.test.ts --workers=1"
+```
+
+The numbered steps document what `ci-lab-up.sh` does and are the fallback when a phase fails; you
+don't run them by hand on the happy path. All `docker compose` commands run from
+`<worktree>/.devcontainer/ci-arm` so Compose finds the right project's `docker-compose.yml` and `.env`.
+
 1. **Set the workspace env vars** (normally run by the `initializeCommand` hook):
 
    ```bash
@@ -268,6 +289,7 @@ Gotchas specific to this path:
 - **Don't skip the cold/warm/hot check.** Running `post-create.sh` on an already-built container just
   wastes ~10 minutes (it's idempotent-safe but not idempotent-fast); skipping it on a truly cold
   container fails every later step with confusing missing-module errors instead of one clear one.
+  `ci-lab-up.sh` does this check for you -- prefer it over running the build step by hand.
 - **No `devcontainer` CLI required** -- this is plain `docker compose`, useful since the CLI isn't
   installed by default on the host.
 - **Reproducing a CI-only flake? Run the *whole* spec at `--workers=1`.** Positron doesn't split a

--- a/.devcontainer/ci-arm/README.md
+++ b/.devcontainer/ci-arm/README.md
@@ -243,11 +243,14 @@ build itself can happen through this path too, no Dev Containers UI required.
    docker compose exec test bash -lc "cd \$POSITRON_WORKSPACE_PATH && ./.devcontainer/ci-arm/post-start.sh"
    ```
 
-7. **Run a test directly**, e.g. a single e2e spec:
+7. **Run an e2e spec.** Use the `run-e2e.sh` helper rather than calling `npx playwright test` by
+   hand -- it sets everything a headless run needs (the four interpreter version vars read from
+   `devcontainer.json`, `GITHUB_ACTIONS=true` so image-comparison tests actually compare, `DISPLAY`,
+   and a default `--project e2e-electron`) and passes the rest straight through to Playwright:
 
    ```bash
-   docker compose exec -e DISPLAY=:10 test bash -lc \
-     "cd \$POSITRON_WORKSPACE_PATH && npx playwright test test/e2e/tests/search/search.test.ts --project e2e-electron"
+   docker compose exec test bash -lc \
+     "cd \$POSITRON_WORKSPACE_PATH && ./.devcontainer/ci-arm/run-e2e.sh test/e2e/tests/search/search.test.ts"
    ```
 
    All `docker compose` commands above must run from `<worktree>/.devcontainer/ci-arm` (step 1's
@@ -255,20 +258,12 @@ build itself can happen through this path too, no Dev Containers UI required.
 
 Gotchas specific to this path:
 
-- **No `containerEnv` injection -- export all four interpreter versions.** Values from
-  `devcontainer.json`'s `containerEnv` block are applied by the Dev Containers extension, not by plain
-  `docker compose`. The e2e suite's `test/e2e/tests/_test.setup.ts` *throws* unless all four are set,
-  so every headless test run must export them explicitly -- not just the one interpreter under test:
+- **No `containerEnv` injection.** `devcontainer.json`'s `containerEnv` block (the four interpreter
+  version selectors, etc.) is applied by the Dev Containers extension, not by plain `docker compose`,
+  and the e2e suite's `test/e2e/tests/_test.setup.ts` *throws* unless all four are set --
   `POSITRON_PY_VER_SEL`, `POSITRON_R_VER_SEL`, `POSITRON_PY_ALT_VER_SEL`, `POSITRON_R_ALT_VER_SEL`.
-  Discover the installed versions first (`pyenv versions` for Python; `ls /opt/R` for R), then pass
-  each one:
-
-  ```bash
-  docker compose exec \
-    -e POSITRON_PY_VER_SEL=3.13.0 -e POSITRON_R_VER_SEL=4.5.2 \
-    -e POSITRON_PY_ALT_VER_SEL=3.10.12 -e POSITRON_R_ALT_VER_SEL=4.4.2 \
-    -e DISPLAY=:10 test bash -lc "cd \$POSITRON_WORKSPACE_PATH && npx playwright test ..."
-  ```
+  `run-e2e.sh` (step 7) reads them from `devcontainer.json` and exports them for you, so prefer it
+  over exporting by hand: the canonical values live in one place and stay correct if the pins change.
 - **Don't skip the cold/warm/hot check.** Running `post-create.sh` on an already-built container just
   wastes ~10 minutes (it's idempotent-safe but not idempotent-fast); skipping it on a truly cold
   container fails every later step with confusing missing-module errors instead of one clear one.
@@ -281,8 +276,8 @@ Gotchas specific to this path:
   entire spec file in order before deciding:
 
   ```bash
-  docker compose exec -e DISPLAY=:10 test bash -lc \
-    "cd \$POSITRON_WORKSPACE_PATH && npx playwright test test/e2e/tests/<area>/<file>.test.ts --project e2e-electron --workers=1"
+  docker compose exec test bash -lc \
+    "cd \$POSITRON_WORKSPACE_PATH && ./.devcontainer/ci-arm/run-e2e.sh test/e2e/tests/<area>/<file>.test.ts --workers=1"
   ```
 
 ## Reference
@@ -379,6 +374,7 @@ already mixed, see [Gotchas](#gotchas) for the fix.
 | **Positron CI: Reinstall interpreters** | restore the Linux `pet`/`ark`/`kcserver` binaries after a native build clobbered them (Python/R fail to start; the Doctor flags it) |
 | **Positron CI: Rebuild** | re-runs the whole cold build (idempotent) |
 | **Positron CI: Get QA content** | provision test-files for manual repro; linked at `~/test-files` |
+| **Positron CI: e2e (current spec)** | runs the open spec via `run-e2e.sh` (interpreter vars + `GITHUB_ACTIONS` set, whole file at `--workers=1`) - the CI-faithful path for reproducing flakes |
 | **Positron CI: Watch (src)** | incremental compiler for the edit-debug loop; reload the window after "Finished compilation" |
 | *Run and Debug ->* **Positron CI: Debug (Electron)** / **(Web)** | debug Positron source - desktop app / browser build (see Debug above) |
 

--- a/.devcontainer/ci-arm/README.md
+++ b/.devcontainer/ci-arm/README.md
@@ -139,22 +139,25 @@ Debug **e2e tests** straight from the test files via the gutter run/debug icons,
 No Dev Containers UI -- drive the stack from the host with `docker compose`, once [Setup](#setup)'s
 steps 1-2 are done (worktree created, secrets added). The build runs through this path too.
 
-**Two commands.** From the worktree:
+**Two commands:**
 
-```bash
-cd <worktree>/.devcontainer/ci-arm
-./ci-lab-up.sh [<branch>]   # idempotent: initialize, compose up, build if cold, per-start setup
-```
+1. **Bring the lab up** (idempotent: initialize, compose up, build if cold, per-start setup):
 
-`ci-lab-up.sh` detects cold/warm/hot itself; with a `<branch>` it also checks out that branch and
-reconciles deps + `out/`. A cold build is ~10 min -- run it in the background; clean exit = ready.
-Then run a spec in the container (from the same `.devcontainer/ci-arm` dir, so Compose finds this
-project's `docker-compose.yml` and `.env`):
+   ```bash
+   cd <worktree>/.devcontainer/ci-arm
+   ./ci-lab-up.sh [<branch>]
+   ```
 
-```bash
-docker compose exec -T test bash -lc \
-  "cd \$POSITRON_WORKSPACE_PATH && ./.devcontainer/ci-arm/run-e2e.sh test/e2e/tests/<area>/<file>.test.ts --workers=1"
-```
+   `ci-lab-up.sh` detects cold/warm/hot itself; with a `<branch>` it also checks out that branch and
+   reconciles deps + `out/`. A cold build is ~10 min -- run it in the background; clean exit = ready.
+
+2. **Run a spec** in the container (from the same `.devcontainer/ci-arm` dir, so Compose finds this
+   project's `docker-compose.yml` and `.env`):
+
+   ```bash
+   docker compose exec -T test bash -lc \
+     "cd \$POSITRON_WORKSPACE_PATH && ./.devcontainer/ci-arm/run-e2e.sh test/e2e/tests/<area>/<file>.test.ts --workers=1"
+   ```
 
 **Reproducing a CI-only flake? Run the *whole* spec at `--workers=1`** (as the command above does).
 Positron doesn't split a single spec file across workers, so its tests run in order and share app

--- a/.devcontainer/ci-arm/README.md
+++ b/.devcontainer/ci-arm/README.md
@@ -112,7 +112,13 @@ down (and the report), leaving core services up.
 #### Run tests
 
 Click the run icon in the gutter on any spec (if it's missing, check the selected Playwright project), or
-from the terminal: `npx playwright test --project e2e-electron --grep @:search`.
+from the terminal: `npx playwright test --project e2e-electron --grep @:search`. Nothing extra to set up
+here -- the interpreter version vars and `DISPLAY` come from `devcontainer.json`'s `containerEnv`, so the
+gutter button and a plain `npx playwright test` just work.
+
+One gotcha: image-comparison tests (e.g. `plots.test.ts`) only compare when `GITHUB_ACTIONS=true` and
+silently skip the assertion otherwise. Most tests don't read it, so it's off by default; export it for
+those runs: `GITHUB_ACTIONS=true npx playwright test --project e2e-electron --grep @:plots`.
 
 Headed runs (`e2e-electron` and `e2e-chromium`) render on the headless display. Open the noVNC link in the **Doctor** to view it live. Use the **Report** task to serve the report at any time.
 
@@ -243,10 +249,11 @@ build itself can happen through this path too, no Dev Containers UI required.
    docker compose exec test bash -lc "cd \$POSITRON_WORKSPACE_PATH && ./.devcontainer/ci-arm/post-start.sh"
    ```
 
-7. **Run an e2e spec.** Use the `run-e2e.sh` helper rather than calling `npx playwright test` by
-   hand -- it sets everything a headless run needs (the four interpreter version vars read from
-   `devcontainer.json`, `GITHUB_ACTIONS=true` so image-comparison tests actually compare, `DISPLAY`,
-   and a default `--project e2e-electron`) and passes the rest straight through to Playwright:
+7. **Run an e2e spec.** Unlike the UI, `docker compose exec` doesn't inject `containerEnv`, so the
+   helper re-supplies it: use `run-e2e.sh` rather than calling `npx playwright test` by hand -- it sets
+   the four interpreter version vars (read from `devcontainer.json`), `DISPLAY`, a default
+   `--project e2e-electron`, and `GITHUB_ACTIONS=true` (harmless for the tests that don't read it; it's
+   what makes image-comparison tests actually compare). Everything else passes straight through to Playwright:
 
    ```bash
    docker compose exec test bash -lc \

--- a/.devcontainer/ci-arm/README.md
+++ b/.devcontainer/ci-arm/README.md
@@ -255,15 +255,35 @@ build itself can happen through this path too, no Dev Containers UI required.
 
 Gotchas specific to this path:
 
-- **No `containerEnv` injection.** Values from `devcontainer.json`'s `containerEnv` block (interpreter
-  versions like `POSITRON_PY_VER_SEL`) are applied by the Dev Containers extension, not by plain
-  `docker compose`. Tests that depend on a specific interpreter version need those exported
-  explicitly (`docker compose exec -e POSITRON_PY_VER_SEL=... ...`).
+- **No `containerEnv` injection -- export all four interpreter versions.** Values from
+  `devcontainer.json`'s `containerEnv` block are applied by the Dev Containers extension, not by plain
+  `docker compose`. The e2e suite's `test/e2e/tests/_test.setup.ts` *throws* unless all four are set,
+  so every headless test run must export them explicitly -- not just the one interpreter under test:
+  `POSITRON_PY_VER_SEL`, `POSITRON_R_VER_SEL`, `POSITRON_PY_ALT_VER_SEL`, `POSITRON_R_ALT_VER_SEL`.
+  Discover the installed versions first (`pyenv versions` for Python; `ls /opt/R` for R), then pass
+  each one:
+
+  ```bash
+  docker compose exec \
+    -e POSITRON_PY_VER_SEL=3.13.0 -e POSITRON_R_VER_SEL=4.5.2 \
+    -e POSITRON_PY_ALT_VER_SEL=3.10.12 -e POSITRON_R_ALT_VER_SEL=4.4.2 \
+    -e DISPLAY=:10 test bash -lc "cd \$POSITRON_WORKSPACE_PATH && npx playwright test ..."
+  ```
 - **Don't skip the cold/warm/hot check.** Running `post-create.sh` on an already-built container just
   wastes ~10 minutes (it's idempotent-safe but not idempotent-fast); skipping it on a truly cold
   container fails every later step with confusing missing-module errors instead of one clear one.
 - **No `devcontainer` CLI required** -- this is plain `docker compose`, useful since the CLI isn't
   installed by default on the host.
+- **Reproducing a CI-only flake? Run the *whole* spec at `--workers=1`.** Positron doesn't split a
+  single spec file across workers, so its tests run in order and share app state. A test that only
+  fails in CI often passes in isolation (a single `--grep`) yet fails because an earlier test in the
+  same file left state behind. Don't conclude "can't reproduce" from the isolated run -- run the
+  entire spec file in order before deciding:
+
+  ```bash
+  docker compose exec -e DISPLAY=:10 test bash -lc \
+    "cd \$POSITRON_WORKSPACE_PATH && npx playwright test test/e2e/tests/<area>/<file>.test.ts --project e2e-electron --workers=1"
+  ```
 
 ## Reference
 

--- a/.devcontainer/ci-arm/README.md
+++ b/.devcontainer/ci-arm/README.md
@@ -112,13 +112,7 @@ down (and the report), leaving core services up.
 #### Run tests
 
 Click the run icon in the gutter on any spec (if it's missing, check the selected Playwright project), or
-from the terminal: `npx playwright test --project e2e-electron --grep @:search`. Nothing extra to set up
-here -- the interpreter version vars and `DISPLAY` come from `devcontainer.json`'s `containerEnv`, so the
-gutter button and a plain `npx playwright test` just work.
-
-One gotcha: image-comparison tests (e.g. `plots.test.ts`) only compare when `GITHUB_ACTIONS=true` and
-silently skip the assertion otherwise. Most tests don't read it, so it's off by default; export it for
-those runs: `GITHUB_ACTIONS=true npx playwright test --project e2e-electron --grep @:plots`.
+from the terminal: `npx playwright test --project e2e-electron --grep @:search`.
 
 Headed runs (`e2e-electron` and `e2e-chromium`) render on the headless display. Open the noVNC link in the **Doctor** to view it live. Use the **Report** task to serve the report at any time.
 

--- a/.devcontainer/ci-arm/ci-lab-up.sh
+++ b/.devcontainer/ci-arm/ci-lab-up.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Get the ci-arm CI lab ready to run tests, from any starting state, in one command.
+#
+# Runs on the HOST (it drives `docker compose`), from anywhere -- it cd's to its own directory so
+# Compose finds this checkout's docker-compose.yml + .env. It collapses the manual runbook
+# (initialize -> compose up -> detect cold/warm/hot -> build-if-needed -> per-start setup) into one
+# idempotent step, so no phase can be skipped or run out of order. Pair it with run-e2e.sh:
+#
+#   ./.devcontainer/ci-arm/ci-lab-up.sh [<branch>]
+#   docker compose exec -T test bash -lc \
+#     "cd \$POSITRON_WORKSPACE_PATH && ./.devcontainer/ci-arm/run-e2e.sh test/e2e/tests/<area>/<f>.test.ts --workers=1"
+#
+# With <branch> it points the worktree at that branch first (fetch + checkout), then reconciles
+# dependencies and recompiles out/ so the build matches the new source. Without it, the current
+# checkout is assumed already built. A cold build takes ~10 minutes -- run this in the background
+# and wait for it to exit; a clean exit means ready. Re-running is safe and fast when nothing changed.
+set -euo pipefail
+
+BRANCH=""
+case "${1:-}" in
+	-h | --help) echo "usage: ci-lab-up.sh [<branch>]  (see header comment for details)"; exit 0 ;;
+	-*) echo "ci-lab-up: unknown option '$1'" >&2; exit 2 ;;
+	"") : ;;
+	*) BRANCH="$1" ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"   # .devcontainer/ci-arm
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$SCRIPT_DIR"                                             # so `docker compose` finds this checkout
+
+step() { printf '\n=== ci-lab-up: %s ===\n' "$1"; }
+
+# Run a command inside the test container from the workspace root, failing loudly (a masked failure
+# inside a pipe or an && / || list is the whole reason this wrapper sets -e and pipefail).
+in_ctr() { docker compose exec -T test bash -lc "set -eo pipefail; cd \"\$POSITRON_WORKSPACE_PATH\" && $1"; }
+
+# 1. Optional branch switch (host-side git). Refuse on a dirty tree so we never half-switch or
+#    silently carry uncommitted changes onto another branch.
+if [ -n "$BRANCH" ]; then
+	step "checkout $BRANCH"
+	if [ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]; then
+		echo "ci-lab-up: ERROR: working tree is dirty; commit or stash before switching branches" >&2
+		git -C "$REPO_ROOT" status --short >&2
+		exit 1
+	fi
+	git -C "$REPO_ROOT" fetch origin "$BRANCH"
+	git -C "$REPO_ROOT" checkout "$BRANCH"
+fi
+
+# 2. Workspace env (.env: bind-mount paths + a per-checkout COMPOSE_PROJECT_NAME). Idempotent.
+step "initialize"
+./initialize.sh
+
+# 3. Bring up the stack (waits for the postgres healthcheck). Idempotent.
+step "docker compose up -d"
+docker compose up -d
+
+# 4. Is a usable build present? The marker file alone isn't enough -- a switched branch or an
+#    interrupted build can leave the marker while out/main.js or node_modules are gone, which is
+#    exactly the "warm but Cannot find module" trap. Check the artifacts too.
+step "build state"
+# $() below is meant to run inside the container, not expand on the host, hence single quotes:
+# shellcheck disable=SC2016
+STATE="$(in_ctr '{ [ -f .build/.ci-arm-state/complete ] && [ -f out/main.js ] && [ -n "$(ls -A node_modules 2>/dev/null)" ]; } && echo READY || echo COLD' | tail -n1)"
+echo "ci-lab-up: build is $STATE"
+
+if [ "$STATE" = COLD ]; then
+	# 5. First-time (or recovery) build: ~10 min. Blocks until done; log kept for failures.
+	step "cold build (post-create.sh, ~10 min)"
+	in_ctr './.devcontainer/ci-arm/post-create.sh 2>&1 | tee /tmp/post-create.log'
+elif [ -n "$BRANCH" ]; then
+	# Build present but we just switched branches: reconcile deps and recompile out/ so both match
+	# the new source. (Without a branch switch the current checkout is assumed already built.)
+	step "reconcile dependencies"
+	# $() below is meant to run inside the container, not expand on the host, hence single quotes:
+	# shellcheck disable=SC2016
+	in_ctr '
+		[ "$(sha256sum package-lock.json | cut -d" " -f1)" = "$(cat .build/.ci-arm-state/deps.sha 2>/dev/null)" ] || ./.devcontainer/ci-arm/reinstall-deps.sh root
+		[ "$(sha256sum test/e2e/package-lock.json | cut -d" " -f1)" = "$(cat .build/.ci-arm-state/e2e-deps.sha 2>/dev/null)" ] || ./.devcontainer/ci-arm/reinstall-deps.sh e2e
+	'
+	step "recompile out/ (incremental)"
+	in_ctr 'npm exec -- npm-run-all --max_old_space_size=4095 -lp compile 2>&1 | tee /tmp/compile.log'
+fi
+
+# 6. Per-start setup (display/VNC, license symlink, postgres check). Idempotent, always safe.
+step "per-start setup (post-start.sh)"
+in_ctr './.devcontainer/ci-arm/post-start.sh'
+
+step "ready"
+cat <<'MSG'
+ci-lab-up: the lab is ready. Run a spec with:
+  docker compose exec -T test bash -lc \
+    "cd \$POSITRON_WORKSPACE_PATH && ./.devcontainer/ci-arm/run-e2e.sh test/e2e/tests/<area>/<file>.test.ts --workers=1"
+MSG

--- a/.devcontainer/ci-arm/run-e2e.sh
+++ b/.devcontainer/ci-arm/run-e2e.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Run Positron e2e specs headlessly with the full environment the tests require, so a CLI/agent run
+# (docker compose exec) matches what the Dev Containers UI -- and CI -- would give you. It sets up,
+# in one place, the things that are easy to forget and that fail confusingly (or silently) when
+# missing:
+#
+#   - The four interpreter version selectors the e2e setup demands. test/e2e/tests/_test.setup.ts
+#     throws unless all four are set. Already-exported values win (Dev Containers injects them from
+#     devcontainer.json's containerEnv); anything unset is read straight from devcontainer.json, so
+#     both paths use identical, canonical values with no guessing.
+#   - DISPLAY (the headless Xvnc display) so the app can render.
+#   - GITHUB_ACTIONS=true, so image-comparison tests actually compare instead of silently skipping
+#     (compareImages() is gated on it -- without it those tests pass without asserting anything).
+#   - --project e2e-electron, unless the caller already passed a --project.
+#
+# Usage (inside the container, or via `docker compose exec test bash -lc`):
+#   ./.devcontainer/ci-arm/run-e2e.sh test/e2e/tests/plots/plots.test.ts --workers=1
+#   ./.devcontainer/ci-arm/run-e2e.sh test/e2e/tests/search/search.test.ts --grep @:search
+# Every argument passes straight through to `npx playwright test`.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${POSITRON_WORKSPACE_PATH:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+DEVCONTAINER_JSON="$SCRIPT_DIR/devcontainer.json"
+
+# Resolve the four interpreter selectors: keep any already exported, fill the rest from
+# devcontainer.json (one source of truth) so the CLI path and the Dev Containers path agree.
+for key in POSITRON_PY_VER_SEL POSITRON_R_VER_SEL POSITRON_PY_ALT_VER_SEL POSITRON_R_ALT_VER_SEL; do
+	if [ -z "${!key:-}" ]; then
+		val="$(grep -oE "\"$key\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" "$DEVCONTAINER_JSON" 2>/dev/null | head -1 | sed -E 's/.*"([^"]*)"$/\1/')"
+		if [ -z "$val" ]; then
+			echo "run-e2e: ERROR: $key is unset and not found in $DEVCONTAINER_JSON" >&2
+			exit 1
+		fi
+		export "$key=$val"
+	fi
+done
+
+# Headless display + the flag that makes image-comparison tests run (they no-op without it).
+export DISPLAY="${DISPLAY:-:10}"
+export GITHUB_ACTIONS="${GITHUB_ACTIONS:-true}"
+
+# Default the Playwright project unless the caller chose one.
+args=("$@")
+has_project=false
+for a in "$@"; do
+	case "$a" in
+		--project | --project=*) has_project=true ;;
+	esac
+done
+if ! $has_project; then
+	args+=(--project e2e-electron)
+fi
+
+echo "run-e2e: PY=$POSITRON_PY_VER_SEL R=$POSITRON_R_VER_SEL PY_ALT=$POSITRON_PY_ALT_VER_SEL R_ALT=$POSITRON_R_ALT_VER_SEL DISPLAY=$DISPLAY GITHUB_ACTIONS=$GITHUB_ACTIONS"
+echo "run-e2e: npx playwright test ${args[*]}"
+
+cd "$REPO_ROOT"
+exec npx playwright test "${args[@]}"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "private": true,
   "scripts": {
     "ci-lab-reset": "./.devcontainer/ci-arm/reset.sh",
+    "ci-lab-up": "./.devcontainer/ci-arm/ci-lab-up.sh",
     "test": "echo Please run any of the test scripts from the scripts folder.",
     "test-browser": "npx playwright install && node test/unit/browser/index.js",
     "test-browser-no-install": "node test/unit/browser/index.js",

--- a/positron-ci-lab.code-workspace
+++ b/positron-ci-lab.code-workspace
@@ -137,6 +137,19 @@
 				"problemMatcher": []
 			},
 			{
+				// Runs the currently open spec via run-e2e.sh, which sets everything a headless e2e run
+				// needs (all four interpreter version vars, GITHUB_ACTIONS so image-comparison tests
+				// actually compare, DISPLAY, --project e2e-electron). --workers=1 runs the whole file
+				// in order -- Positron doesn't split a spec across workers -- which is how CI-only flakes
+				// reproduce. Open the .test.ts first (${relativeFile} is the active editor).
+				"label": "Positron CI: e2e (current spec)",
+				"detail": "Run the open .test.ts CI-faithfully: interpreter vars + GITHUB_ACTIONS set, whole file in order at --workers=1. The setup for reproducing CI-only flakes. Open the spec first.",
+				"type": "shell",
+				"command": "./.devcontainer/ci-arm/run-e2e.sh \"${relativeFile}\" --workers=1",
+				"presentation": { "panel": "dedicated", "reveal": "always", "focus": true, "clear": true },
+				"problemMatcher": []
+			},
+			{
 				// Prelaunch step for the "Positron CI: Debug (Electron)" compound. Same as the repo's
 				// "Ensure Prelaunch Dependencies" task (node build/lib/preLaunch.ts), but defined here
 				// under a unique name so the workspace-level launch compound can resolve it — a


### PR DESCRIPTION
### Summary
Two helper scripts so the headless ci-arm path (CLI / agent, no Dev Containers UI) is hard to get wrong.

- **`ci-lab-up.sh`** - one idempotent command to get the lab ready: initialize, `compose up`, build if cold, per-start setup. Optional `<branch>` also checks out and reconciles deps + `out/`.
- **`run-e2e.sh`** - runs a spec in the container with the right env (interpreter selectors, `DISPLAY`, `GITHUB_ACTIONS=true`, default `--project e2e-electron`).
- README Claude Workflows section rewritten around the two-command happy path.
- Adds a `ci-lab-up` npm script and a `Positron CI: e2e (current spec)` task.

### QA Notes
Posit-internal (ci-arm lab). Both scripts validated live, including a full cold build end-to-end.