### PR TITLE
Add "Show Help at Cursor" to the editor context menu

### DIFF
--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelpActions.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelpActions.ts
@@ -10,7 +10,7 @@ import { IEditor } from '../../../../editor/common/editorCommon.js';
 import { ITextModel } from '../../../../editor/common/model.js';
 import { ILanguageFeaturesService } from '../../../../editor/common/services/languageFeatures.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
-import { Action2 } from '../../../../platform/actions/common/actions.js';
+import { Action2, MenuId } from '../../../../platform/actions/common/actions.js';
 import { KeyChord, KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IPositronHelpService } from './positronHelpService.js';
@@ -23,6 +23,7 @@ import { PositronConsoleFocused } from '../../../common/contextkeys.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { IPositronConsoleService } from '../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
 import { IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
+import { POSITRON_RUNTIME_LANGUAGE_IDS } from '../../languageRuntime/browser/languageRuntimeContextKeys.js';
 
 export class ShowHelpAtCursor extends Action2 {
 	constructor() {
@@ -41,7 +42,39 @@ export class ShowHelpAtCursor extends Action2 {
 				when: ContextKeyExpr.or(EditorContextKeys.focus, PositronConsoleFocused)
 			},
 			category: Categories.Help,
-			f1: true
+			f1: true,
+			menu: [
+				{
+					id: MenuId.EditorContext,
+					// Show on editors whose language has a registered Positron
+					// runtime. The list is maintained dynamically by
+					// PositronRuntimeLanguagesContextKeyContribution so new
+					// runtimes are picked up without code changes here.
+					//
+					// Quarto is added explicitly: a .qmd document's outer
+					// language is 'quarto', but the command still works
+					// because it resolves the embedded language at the
+					// cursor via getLanguageIdAtPosition.
+					when: ContextKeyExpr.and(
+						EditorContextKeys.editorTextFocus,
+						ContextKeyExpr.or(
+							ContextKeyExpr.in(
+								EditorContextKeys.languageId.key,
+								POSITRON_RUNTIME_LANGUAGE_IDS.key,
+							),
+							ContextKeyExpr.equals(
+								EditorContextKeys.languageId.key,
+								'quarto',
+							),
+						),
+					),
+					// Sit just below "Go to References" (order 1.45) and just
+					// above "View Data Frame at Cursor" (order 1.5) in the
+					// editor context menu's navigation group.
+					group: 'navigation',
+					order: 1.47,
+				},
+			],
 		});
 	}
 


### PR DESCRIPTION
Fixes #14570

This PR adds "Show Help at Cursor" to the editor right-click context menu. The command already existed with keybindings (<kbd>F1</kbd>, <kbd>Cmd+K Cmd+H</kbd>) and a command palette entry; this PR just surfaces it in the context menu where users might look for it, as requested in the issue.

This is purely declarative metadata. A `menu` entry added to the existing `ShowHelpAtCursor` action registration. There is no new runtime logic, and the action's `run()` method is unchanged.

The `when` clause reuses the `POSITRON_RUNTIME_LANGUAGE_IDS` context key I added in #13098 (for "View Data Frame at Cursor"), so the item shows on editors whose language has a registered Positron runtime, plus `.qmd` explicitly (the embedded language is resolved at the cursor). The entry is ordered to sit just below "Go to References" and just above "View Data Frame at Cursor" in the navigation group:

<img width="1478" height="1026" alt="Screenshot_2026-07-14_at_1_21_33 PM" src="https://github.com/user-attachments/assets/0d16daee-d124-4cea-9dfd-44f3acb3c745" />


### Release Notes

#### New Features

- Added "Show Help at Cursor" to the editor context menu (#14570).

#### Bug Fixes

- N/A

### QA Notes

@:help @:editor @:quarto

There are no automated tests here because the change is declarative menu registration with no new logic to exercise. We can verify manually during review:

1. In an R file, right-click on a function name (e.g. `library`). Confirm "Show Help at Cursor" appears in the context menu, directly below "Go to References" and above "View Data Frame at Cursor". Choosing it opens the help topic.
2. Repeat in a Python file (e.g. right-click on `print`).
3. In a `.qmd` file with an R chunk or a Python chunk, place the cursor inside each chunk on a symbol and confirm the item appears and opens help for the correct language (this exercises the embedded-language path).
4. In a plaintext or Markdown file with no runtime language, confirm the item does NOT appear.
