### PR TITLE
Add bottom padding to terminal so the prompt is not squished

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/terminal.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/terminal.css
@@ -92,6 +92,15 @@
 	bottom: 0;
 	left: 0;
 	right: 0;
+
+	/* --- Start Positron ---
+	Add bottom padding so the prompt does not feel squished against the edge of
+	the pane (see posit-dev/positron#998, mirrors the console padding). Scoped to
+	the bottom-aligned layouts only. The terminal dimension calculation reads
+	paddingBottom off this element's computed style, so the reserved space is
+	honored rather than clipping rows. */
+	padding-bottom: 10px;
+	/* --- End Positron --- */
 }
 
 .terminal-side-view .terminal.xterm {


### PR DESCRIPTION
Fixes #998

This is still bothering me, even several years later! Adds 10px of bottom padding to terminal instances so the prompt no longer feels squished against the bottom edge of the pane. This mirrors the console bottom padding added in #971. The padding is scoped to the bottom-aligned layouts (panel and editor-area terminals); the top-aligned side-view terminal is left as-is since it already has natural space below the prompt. The terminal's row/column calculation reads `paddingBottom` off the element's computed style, so the reserved space is honored rather than clipping rows:

<img width="1478" height="1026" alt="Screenshot_2026-07-14_at_1_40_51 PM" src="https://github.com/user-attachments/assets/246ea8e6-7f37-4fd9-86e1-8dffec4bad0c" />


### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

I'm not adding any E2E tags because this is a CSS-only change, to be verified visually.

1. Open a terminal in the bottom panel, type at the prompt, and confirm there is comfortable space below the prompt instead of it sitting flush against the edge.
2. Run "Terminal: Create New Terminal in Editor Area" and confirm the same padding applies to an editor-tab terminal.
3. Switch to the Side-by-Side Layout (side-view terminal) and confirm it looks right as well.
