### PR TITLE
Remove "Copy vscode.dev Link" from editor context menus

### DIFF
--- a/extensions/github/package.json
+++ b/extensions/github/package.json
@@ -132,40 +132,40 @@
       "file/share": [
         {
           "command": "github.copyVscodeDevLinkFile",
-          "when": "github.hasGitHubRepo && remoteName != 'codespaces'",
+          "when": "false",
           "group": "0_vscode@0"
         }
       ],
       "editor/context/share": [
         {
           "command": "github.copyVscodeDevLink",
-          "when": "github.hasGitHubRepo && resourceScheme != untitled && !isInEmbeddedEditor && remoteName != 'codespaces'",
+          "when": "false",
           "group": "0_vscode@0"
         }
       ],
       "explorer/context/share": [
         {
           "command": "github.copyVscodeDevLinkWithoutRange",
-          "when": "github.hasGitHubRepo && resourceScheme != untitled && !isInEmbeddedEditor && remoteName != 'codespaces'",
+          "when": "false",
           "group": "0_vscode@0"
         }
       ],
       "editor/lineNumber/context": [
         {
           "command": "github.copyVscodeDevLink",
-          "when": "github.hasGitHubRepo && resourceScheme != untitled && activeEditor == workbench.editors.files.textFileEditor && config.editor.lineNumbers == on && remoteName != 'codespaces'",
+          "when": "false",
           "group": "1_cutcopypaste@2"
         },
         {
           "command": "github.copyVscodeDevLink",
-          "when": "github.hasGitHubRepo && resourceScheme != untitled && activeEditor == workbench.editor.notebook && remoteName != 'codespaces'",
+          "when": "false",
           "group": "1_cutcopypaste@2"
         }
       ],
       "editor/title/context/share": [
         {
           "command": "github.copyVscodeDevLinkWithoutRange",
-          "when": "github.hasGitHubRepo && resourceScheme != untitled && remoteName != 'codespaces'",
+          "when": "false",
           "group": "0_vscode@0"
         }
       ],


### PR DESCRIPTION
Fixes #1366

Positron's built-in GitHub extension currently contributes a "Copy vscode.dev Link" item to several right-click "Share" menus. vscode.dev is a Microsoft proprietary service that Positron shouldn't advertise, so this disables those menu contributions by setting their `when` clauses to `false` (the same pattern the extension already uses to hide its `commandPalette` entries).

This covers every right-click surface the item appeared in: the editor context menu (`editor/context/share`), the explorer (`explorer/context/share`), the editor tab (`editor/title/context/share`), the file share menu (`file/share`), and the line-number gutter (`editor/lineNumber/context`). The `copyVscodeDevLink*` commands themselves are left registered but unreachable, keeping the diff minimal but still fixing what folks see:

<img width="1451" height="999" alt="Screenshot_2026-07-14_at_2_01_29 PM" src="https://github.com/user-attachments/assets/a19d0f2f-aea4-4ba6-a610-e9edecca0bb2" />

The experimental "Share..." command (gated behind `workbench.experimental.share.enabled`, off by default) is intentionally untouched.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:editor

This is a menu-contribution change with no automated coverage which we should just validate manually:

1. Open a folder backed by a GitHub remote (so `github.hasGitHubRepo` is true) and open a file.
2. Right-click in the editor text area. Confirm the "Share" submenu no longer offers "Copy vscode.dev Link" (with no other items, the "Share" submenu no longer appears).
3. Confirm the same in the explorer right-click menu, the editor tab right-click menu, and the line-number gutter right-click menu.
