### PR TITLE
e2e: fix scm.test.ts flake from leftover R Markdown/Quarto render artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,8 +64,6 @@ product.json.backup
 test/e2e/release-screenshots/output/
 # Log file written to cwd by the snowflake-sdk dependency (positron-catalog-explorer)
 snowflake.log
-# Downloaded from S3 at e2e runtime (very-large-data-frame.test.ts); keep `git clean -fd` from wiping it mid-suite
-/test/e2e/test-files/data-files/largeParquet.parquet
 # --- End Positron ---
 test-output.json
 test/componentFixtures/.screenshots/*

--- a/.gitignore
+++ b/.gitignore
@@ -65,18 +65,9 @@ test/e2e/release-screenshots/output/
 # Log file written to cwd by the snowflake-sdk dependency (positron-catalog-explorer)
 snowflake.log
 # Generated artifacts from qa-example-content test files (merged into test/e2e/test-files)
-test/e2e/test-files/workspaces/quarto_basic/.quarto/*
-test/e2e/test-files/workspaces/quarto_basic/quarto_basic_files/*
-test/e2e/test-files/workspaces/quarto_basic/quarto_basic.html
-test/e2e/test-files/workspaces/basic-rmd-file/basicRmd_cache/*
-test/e2e/test-files/workspaces/basic-rmd-file/basicRmd_files/*
-test/e2e/test-files/workspaces/basic-rmd-file/basicRmd.html
-test/e2e/test-files/workspaces/basic-rmd-file/.gitignore
-test/e2e/test-files/workspaces/quarto_interactive/.quarto/*
-test/e2e/test-files/workspaces/quarto_interactive/quarto_interactive_files/*
-test/e2e/test-files/workspaces/quarto_interactive/quarto_interactive.html
-test/e2e/test-files/workspaces/quarto_shiny/mini-app_files/*
-test/e2e/test-files/workspaces/quarto_shiny/mini-app.html
+# handled by a .gitignore in each workspace folder instead of here: the e2e test
+# runner copies only the contents of test/e2e/test-files into an ephemeral
+# workspace and re-inits git there, so entries in this root .gitignore never apply
 # Downloaded from S3 at e2e runtime (very-large-data-frame.test.ts); keep `git clean -fd` from wiping it mid-suite
 /test/e2e/test-files/data-files/largeParquet.parquet
 # --- End Positron ---

--- a/.gitignore
+++ b/.gitignore
@@ -64,10 +64,6 @@ product.json.backup
 test/e2e/release-screenshots/output/
 # Log file written to cwd by the snowflake-sdk dependency (positron-catalog-explorer)
 snowflake.log
-# Generated artifacts from qa-example-content test files (merged into test/e2e/test-files)
-# handled by a .gitignore in each workspace folder instead of here: the e2e test
-# runner copies only the contents of test/e2e/test-files into an ephemeral
-# workspace and re-inits git there, so entries in this root .gitignore never apply
 # Downloaded from S3 at e2e runtime (very-large-data-frame.test.ts); keep `git clean -fd` from wiping it mid-suite
 /test/e2e/test-files/data-files/largeParquet.parquet
 # --- End Positron ---

--- a/test/e2e/test-files/data-files/.gitignore
+++ b/test/e2e/test-files/data-files/.gitignore
@@ -1,0 +1,1 @@
+largeParquet.parquet

--- a/test/e2e/test-files/workspaces/basic-rmd-file/.gitignore
+++ b/test/e2e/test-files/workspaces/basic-rmd-file/.gitignore
@@ -1,0 +1,3 @@
+basicRmd_cache/
+basicRmd_files/
+basicRmd.html

--- a/test/e2e/test-files/workspaces/quarto_basic/.gitignore
+++ b/test/e2e/test-files/workspaces/quarto_basic/.gitignore
@@ -1,0 +1,3 @@
+.quarto/
+quarto_basic_files/
+quarto_basic.html

--- a/test/e2e/test-files/workspaces/quarto_interactive/.gitignore
+++ b/test/e2e/test-files/workspaces/quarto_interactive/.gitignore
@@ -1,0 +1,3 @@
+.quarto/
+quarto_interactive_files/
+quarto_interactive.html

--- a/test/e2e/test-files/workspaces/quarto_shiny/.gitignore
+++ b/test/e2e/test-files/workspaces/quarto_shiny/.gitignore
@@ -1,0 +1,2 @@
+mini-app_files/
+mini-app.html

--- a/test/e2e/tests/r-markdown/r-markdown.test.ts
+++ b/test/e2e/tests/r-markdown/r-markdown.test.ts
@@ -13,18 +13,6 @@ test.use({
 test.describe('R Markdown', { tag: [tags.WEB, tags.R_MARKDOWN, tags.ARK] }, () => {
 	test.describe.configure({ mode: 'serial' }); // 2nd test depends on 1st test
 
-	test.afterAll(async function ({ cleanup }) {
-		// rendering leaves behind basicRmd.html, basicRmd_cache/, and basicRmd_files/
-		// in the shared test-files workspace; remove them so they don't pollute SCM
-		// status for later tests
-		const rmdDir = join('workspaces', 'basic-rmd-file');
-		await cleanup.removeTestFiles([
-			join(rmdDir, 'basicRmd.html'),
-			join(rmdDir, 'basicRmd_cache'),
-			join(rmdDir, 'basicRmd_files'),
-		]);
-	});
-
 	test('Verify can render R Markdown', async function ({ app, r }) {
 		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'basic-rmd-file', 'basicRmd.rmd'));
 		await app.workbench.quickaccess.runCommand('r.rmarkdownRender');

--- a/test/e2e/tests/r-markdown/r-markdown.test.ts
+++ b/test/e2e/tests/r-markdown/r-markdown.test.ts
@@ -13,6 +13,18 @@ test.use({
 test.describe('R Markdown', { tag: [tags.WEB, tags.R_MARKDOWN, tags.ARK] }, () => {
 	test.describe.configure({ mode: 'serial' }); // 2nd test depends on 1st test
 
+	test.afterAll(async function ({ cleanup }) {
+		// rendering leaves behind basicRmd.html, basicRmd_cache/, and basicRmd_files/
+		// in the shared test-files workspace; remove them so they don't pollute SCM
+		// status for later tests
+		const rmdDir = join('workspaces', 'basic-rmd-file');
+		await cleanup.removeTestFiles([
+			join(rmdDir, 'basicRmd.html'),
+			join(rmdDir, 'basicRmd_cache'),
+			join(rmdDir, 'basicRmd_files'),
+		]);
+	});
+
 	test('Verify can render R Markdown', async function ({ app, r }) {
 		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'basic-rmd-file', 'basicRmd.rmd'));
 		await app.workbench.quickaccess.runCommand('r.rmarkdownRender');


### PR DESCRIPTION
### Summary
Render artifacts from r-markdown.test.ts leaked into the shared test-files git workspace and inflated SCM status, causing scm.test.ts to flake.
- Moved dead qa-example-content render-artifact ignores out of the root .gitignore into a .gitignore per workspace folder (basic-rmd-file, quarto_basic, quarto_interactive, quarto_shiny)
- The root entries never actually applied: the e2e runner copies only the contents of test/e2e/test-files into an ephemeral workspace and re-inits git there, so root .gitignore rules don't travel with it -- a .gitignore inside the workspace folder does
- Fixed the same dead-ignore issue for largeParquet.parquet

### QA Notes
n/a