### PR TITLE
fix(copilot): resolve build-check watcher hang

### DIFF
--- a/scripts/build-check.sh
+++ b/scripts/build-check.sh
@@ -31,8 +31,8 @@ node scripts/deemon-status.mts \
 pid4=$!
 
 node scripts/deemon-status.mts \
-	--begins '\[watch:tsc\s*\] \d+:\d+:\d+ [AP]M - (Starting compilation in watch mode|File change detected\. Starting incremental compilation)' \
-	--ends '\[watch:tsc\s*\] \d+:\d+:\d+ [AP]M - Found [0-9]+ errors?\. Watching for file changes' \
+	--begins '\[watch:typecheck\s*\] \d+:\d+:\d+ [AP]M - (Starting compilation in watch mode|File change detected\. Starting incremental compilation)' \
+	--ends '\[watch:typecheck\s*\] \d+:\d+:\d+ [AP]M - Found [0-9]+ errors?\. Watching for file changes' \
 	--command "npm run watch-copilot" &
 pid5=$!
 


### PR DESCRIPTION
### Summary
`npm run build-check` hung forever on the copilot watcher, requiring Ctrl+C to unblock any script that calls it.
- Fixed a log regex mismatch (`watch:tsc` vs. actual `watch:typecheck` prefix) that kept the daemon from ever reporting idle

### QA Notes
Verified `npm run build-check` completes in seconds instead of hanging.