### PR TITLE
fix(extensions): skip prereleases when resolving latest bootstrap version

### DIFF
--- a/scripts/update-extensions.sh
+++ b/scripts/update-extensions.sh
@@ -111,10 +111,19 @@ get_extension_info() {
 	EXTENSION_TARGET_PLATFORM=""
 
 	if command -v jq >/dev/null 2>&1; then
-		# Sort by published_at descending to get the actual latest version
-		# (P3M does not guarantee versions are returned in sorted order)
-		EXTENSION_VERSION=$(echo "$response" | jq -r '.versions | sort_by(.published_at) | reverse | .[0].version // empty')
-		EXTENSION_TARGET_PLATFORM=$(echo "$response" | jq -r '.versions | sort_by(.published_at) | reverse | .[0].target_platform // empty')
+		# Pick the most recently published *stable* release. Open VSX marks
+		# prerelease builds with "pre_release": true (e.g. pyrefly's 1.1.900x dev
+		# builds), and those must not be bootstrapped as if they were releases.
+		# Fall back to all versions if the extension only publishes prereleases.
+		# Select a single entry so version and target_platform stay consistent.
+		# (P3M does not guarantee versions are returned in sorted order.)
+		local selected
+		selected=$(echo "$response" | jq -c '
+			(.versions | map(select(.pre_release != true))) as $stable
+			| (if ($stable | length) > 0 then $stable else .versions end)
+			| sort_by(.published_at) | reverse | .[0] // {}')
+		EXTENSION_VERSION=$(echo "$selected" | jq -r '.version // empty')
+		EXTENSION_TARGET_PLATFORM=$(echo "$selected" | jq -r '.target_platform // empty')
 
 	else
 		# Fallback parsing without jq


### PR DESCRIPTION
## Summary

The nightly bootstrap-extensions check kept opening PRs that bumped `meta.pyrefly` from the stable `1.1.1` to a prerelease dev build (e.g. `1.1.9002`). This was originally suspected to be a Linux-specific marketplace bug, but investigation showed the bump comes from `scripts/update-extensions.sh`, which the `auto-update` job runs every night.

`get_extension_info()` resolved the "latest" version by sorting all Open VSX versions by `published_at` and taking the newest -- which for pyrefly is a prerelease build flagged `pre_release: true`. This is a plain registry API query, so it was never platform-dependent (running the check on macOS would not have changed it).

## Fix

Filter out versions flagged `pre_release: true` and pick the newest remaining stable release, falling back to all versions only if an extension publishes nothing but prereleases. Version and `target_platform` are now read from the same selected entry so they stay consistent.

Verified against the live registry with the exact jq logic:
- `meta.pyrefly` -> `1.1.1` (stable) instead of `1.1.9002` (prerelease)
- `charliermarsh.ruff` -> `2026.60.0` (unchanged; normal extension with no prereleases)

## QA Notes

No e2e test impact. Change is scoped to the version-resolution logic in `update-extensions.sh`, which is exercised by the nightly bootstrap-extensions workflow's `auto-update` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)