### PR TITLE
E2E test: update full suite

### DIFF
--- a/.github/workflows/build-connect-linux.yml
+++ b/.github/workflows/build-connect-linux.yml
@@ -7,6 +7,12 @@ name: "Build: Connect (Linux x64)"
 
 on:
   workflow_call:
+    inputs:
+      commit:
+        description: "Commit SHA to test"
+        required: false
+        default: ""
+        type: string
     outputs:
       artifact-name:
         description: "Name of the deb artifact uploaded"
@@ -32,7 +38,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       POSITRON_BUILD_NUMBER: 0
-      BUILD_SOURCEVERSION: ${{ github.sha }}
+      BUILD_SOURCEVERSION: ${{ inputs.commit || github.sha }}
 
     steps:
       - name: Checkout repository
@@ -53,6 +59,10 @@ jobs:
         run: |
           git config --global --add safe.directory '*'
           git rev-parse --show-toplevel
+
+      - name: Checkout specific commit
+        if: ${{ inputs.commit != '' }}
+        run: git checkout ${{ inputs.commit }}
 
       - name: Install build dependencies
         env:

--- a/.github/workflows/build-jupyter-linux.yml
+++ b/.github/workflows/build-jupyter-linux.yml
@@ -2,6 +2,12 @@ name: "Build: Positron Server (Linux x64)"
 
 on:
   workflow_call:
+    inputs:
+      commit:
+        description: "Commit SHA to test"
+        required: false
+        default: ""
+        type: string
     outputs:
       artifact-name:
         description: "Name of the server artifact uploaded"
@@ -43,6 +49,10 @@ jobs:
         run: |
           git config --global --add safe.directory '*'
           git rev-parse --show-toplevel
+
+      - name: Checkout specific commit
+        if: ${{ inputs.commit != '' }}
+        run: git checkout ${{ inputs.commit }}
 
       - name: Install build dependencies
         env:

--- a/.github/workflows/build-remote-ssh-linux.yml
+++ b/.github/workflows/build-remote-ssh-linux.yml
@@ -2,6 +2,12 @@ name: "Build: Remote SSH (Linux x64)"
 
 on:
   workflow_call:
+    inputs:
+      commit:
+        description: "Commit SHA to test"
+        required: false
+        default: ""
+        type: string
     outputs:
       artifact-name:
         description: "Name of the deb artifact uploaded"
@@ -30,7 +36,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       POSITRON_BUILD_NUMBER: 0
-      BUILD_SOURCEVERSION: ${{ github.sha }}
+      BUILD_SOURCEVERSION: ${{ inputs.commit || github.sha }}
 
     steps:
       - name: Checkout repository
@@ -51,6 +57,10 @@ jobs:
         run: |
           git config --global --add safe.directory '*'
           git rev-parse --show-toplevel
+
+      - name: Checkout specific commit
+        if: ${{ inputs.commit != '' }}
+        run: git checkout ${{ inputs.commit }}
 
       - name: Install build dependencies
         env:
@@ -124,7 +134,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       POSITRON_BUILD_NUMBER: 0
-      BUILD_SOURCEVERSION: ${{ github.sha }}
+      BUILD_SOURCEVERSION: ${{ inputs.commit || github.sha }}
 
     steps:
       - name: Checkout repository
@@ -145,6 +155,10 @@ jobs:
         run: |
           git config --global --add safe.directory '*'
           git rev-parse --show-toplevel
+
+      - name: Checkout specific commit
+        if: ${{ inputs.commit != '' }}
+        run: git checkout ${{ inputs.commit }}
 
       - name: Install build dependencies
         env:

--- a/.github/workflows/build-workbench-linux.yml
+++ b/.github/workflows/build-workbench-linux.yml
@@ -2,6 +2,12 @@ name: "Build: Positron Workbench (Linux x64)"
 
 on:
   workflow_call:
+    inputs:
+      commit:
+        description: "Commit SHA to test"
+        required: false
+        default: ""
+        type: string
     outputs:
       artifact-name:
         description: "Name of the workbench artifact uploaded"
@@ -43,6 +49,10 @@ jobs:
         run: |
           git config --global --add safe.directory '*'
           git rev-parse --show-toplevel
+
+      - name: Checkout specific commit
+        if: ${{ inputs.commit != '' }}
+        run: git checkout ${{ inputs.commit }}
 
       - name: Install build dependencies
         env:

--- a/.github/workflows/test-e2e-connect.yml
+++ b/.github/workflows/test-e2e-connect.yml
@@ -27,6 +27,16 @@ on:
         description: "Whether to allow tests marked with :soft-fail to fail without failing the job."
         type: boolean
         default: false
+      commit:
+        description: "Commit SHA to test"
+        required: false
+        default: ""
+        type: string
+      enable_diagnostic_logging:
+        required: false
+        description: "Enable diagnostic logging (free memory, process list, CPU usage) at the end of each test."
+        type: boolean
+        default: false
 
 permissions:
   id-token: write
@@ -55,6 +65,10 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+
+      - name: Checkout specific commit
+        if: ${{ inputs.commit != '' }}
+        run: git checkout ${{ inputs.commit }}
 
       - name: Docker login (GHCR)
         uses: docker/login-action@v4
@@ -179,6 +193,7 @@ jobs:
           PWTEST_BLOB_DO_NOT_REMOVE: 1
           REPORTER_REPO_NAME: positron
           PW_PROJECT_NAME: e2e-connect
+          ENABLE_DIAGNOSTIC_LOGGING: ${{ inputs.enable_diagnostic_logging }}
         run: |
           export DISPLAY=:10
           # The e2e-connect project already scopes to @:connect via its grep; no

--- a/.github/workflows/test-e2e-jupyter-ubuntu.yml
+++ b/.github/workflows/test-e2e-jupyter-ubuntu.yml
@@ -28,6 +28,16 @@ on:
         description: "Whether to allow tests marked with :soft-fail to fail without failing the job."
         type: boolean
         default: false
+      commit:
+        description: "Commit SHA to test"
+        required: false
+        default: ""
+        type: string
+      enable_diagnostic_logging:
+        required: false
+        description: "Enable diagnostic logging (free memory, process list, CPU usage) at the end of each test."
+        type: boolean
+        default: false
 
 permissions:
   id-token: write
@@ -57,6 +67,10 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+
+      - name: Checkout specific commit
+        if: ${{ inputs.commit != '' }}
+        run: git checkout ${{ inputs.commit }}
 
       - name: Generate access token for private repos
         id: access-token
@@ -151,6 +165,7 @@ jobs:
           USE_KEY: true
           PW_PROJECT_NAME: e2e-jupyter
           REPORTER_REPO_NAME: positron
+          ENABLE_DIAGNOSTIC_LOGGING: ${{ inputs.enable_diagnostic_logging }}
         run: |
           export DISPLAY=:10
           npx playwright test --project e2e-jupyter --retries=1 --workers=1

--- a/.github/workflows/test-e2e-pyrefly.yml
+++ b/.github/workflows/test-e2e-pyrefly.yml
@@ -3,6 +3,22 @@ name: "Test: E2E Pyrefly (Ubuntu)"
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      commit:
+        description: "Commit SHA to test"
+        required: false
+        default: ""
+        type: string
+      skip_cache:
+        description: "Skip restoring caches (use when testing a specific commit)"
+        required: false
+        default: false
+        type: boolean
+      enable_diagnostic_logging:
+        required: false
+        description: "Enable diagnostic logging (free memory, process list, CPU usage) at the end of each test."
+        type: boolean
+        default: false
 
 permissions:
   id-token: write
@@ -39,12 +55,17 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
+      - name: Checkout specific commit
+        if: ${{ inputs.commit != '' }}
+        run: git checkout ${{ inputs.commit }}
+
       - name: Setup build environment
         uses: ./.github/actions/setup-build-env
         with:
           distro: ubuntu
           install-playwright: 'true'
           github-token: ${{ github.token }}
+          skip-cache: ${{ inputs.skip_cache }}
 
       - name: Setup E2E Test Environment
         uses: ./.github/actions/setup-test-env
@@ -75,6 +96,7 @@ jobs:
           SHARD_NAME: electron-pyrefly
           USE_KEY: true
           GH_SUMMARY_REPORT: true
+          ENABLE_DIAGNOSTIC_LOGGING: ${{ inputs.enable_diagnostic_logging }}
         run: |
           ALLOW_PYREFLY=true npx playwright test test/e2e/tests/lsp --project=e2e-electron --workers=1
 

--- a/.github/workflows/test-e2e-remote-ssh-ubuntu.yml
+++ b/.github/workflows/test-e2e-remote-ssh-ubuntu.yml
@@ -23,6 +23,16 @@ on:
         description: "Whether to allow tests marked with :soft-fail to fail without failing the job."
         type: boolean
         default: false
+      commit:
+        description: "Commit SHA to test"
+        required: false
+        default: ""
+        type: string
+      enable_diagnostic_logging:
+        required: false
+        description: "Enable diagnostic logging (free memory, process list, CPU usage) at the end of each test."
+        type: boolean
+        default: false
 
 permissions:
   id-token: write
@@ -47,6 +57,10 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+
+      - name: Checkout specific commit
+        if: ${{ inputs.commit != '' }}
+        run: git checkout ${{ inputs.commit }}
 
       - uses: docker/login-action@v4
         with:
@@ -100,8 +114,10 @@ jobs:
 
       - name: Setup Positron REH in container
         run: |
-          # Get the commit SHA to create the versioned directory structure
-          COMMIT_SHA="${{ github.sha }}"
+          # Get the commit SHA to create the versioned directory structure.
+          # Must match BUILD_SOURCEVERSION baked into the desktop build (see
+          # build-remote-ssh-linux.yml) so the extension resolves the REH here.
+          COMMIT_SHA="${{ inputs.commit || github.sha }}"
 
           # Copy REH tarball into container
           docker cp /tmp/artifacts/positron-reh-remote-ssh-x64.tar.gz test:/tmp/positron-reh-remote-ssh-x64.tar.gz
@@ -186,6 +202,7 @@ jobs:
           REPORTER_REPO_NAME: positron
           CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
           PW_PROJECT_NAME: e2e-remote-ssh
+          ENABLE_DIAGNOSTIC_LOGGING: ${{ inputs.enable_diagnostic_logging }}
         run: |
           export DISPLAY=:10
           BUILD=/usr/share/positron npx playwright test --project e2e-remote-ssh --retries=1 --workers=1

--- a/.github/workflows/test-e2e-workbench-ubuntu.yml
+++ b/.github/workflows/test-e2e-workbench-ubuntu.yml
@@ -33,6 +33,16 @@ on:
         description: "Workbench install mode: 'ci' for latest daily, 'ci-stable' for the last stable release."
         type: string
         default: "ci"
+      commit:
+        description: "Commit SHA to test"
+        required: false
+        default: ""
+        type: string
+      enable_diagnostic_logging:
+        required: false
+        description: "Enable diagnostic logging (free memory, process list, CPU usage) at the end of each test."
+        type: boolean
+        default: false
 
 permissions:
   id-token: write
@@ -83,6 +93,10 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+
+      - name: Checkout specific commit
+        if: ${{ inputs.commit != '' }}
+        run: git checkout ${{ inputs.commit }}
 
       - name: Generate access token for private repos
         id: access-token
@@ -195,6 +209,7 @@ jobs:
           USE_KEY: true
           PW_PROJECT_NAME: e2e-workbench
           REPORTER_REPO_NAME: positron
+          ENABLE_DIAGNOSTIC_LOGGING: ${{ inputs.enable_diagnostic_logging }}
         run: |
           export DISPLAY=:10
           GREP_INVERT_ARG=""

--- a/.github/workflows/test-full-suite.yml
+++ b/.github/workflows/test-full-suite.yml
@@ -14,26 +14,6 @@ on:
         required: false
         default: true
         type: boolean
-      run_e2e_rhel:
-        description: "E2E Tests / Electron (RHEL)"
-        required: false
-        default: false
-        type: boolean
-      run_e2e_suse:
-        description: "E2E Tests / Electron (SUSE)"
-        required: false
-        default: false
-        type: boolean
-      run_e2e_sles:
-        description: "E2E Tests / Electron (SLES)"
-        required: false
-        default: false
-        type: boolean
-      run_e2e_debian:
-        description: "E2E Tests / Electron (Debian)"
-        required: false
-        default: false
-        type: boolean
       run_e2e_windows:
         description: "E2E Tests / Electron (Windows)"
         required: false
@@ -71,6 +51,36 @@ on:
         type: boolean
       run_e2e_browser_debian:
         description: "E2E Tests / Chromium (Debian)"
+        required: false
+        default: false
+        type: boolean
+      run_e2e_workbench:
+        description: "E2E Tests / Workbench (Ubuntu)"
+        required: false
+        default: false
+        type: boolean
+      run_e2e_workbench_stable:
+        description: "E2E Tests / Workbench Stable (Ubuntu)"
+        required: false
+        default: false
+        type: boolean
+      run_e2e_pyrefly:
+        description: "E2E Tests / Pyrefly (Ubuntu)"
+        required: false
+        default: false
+        type: boolean
+      run_e2e_connect:
+        description: "E2E Tests / Connect (Ubuntu)"
+        required: false
+        default: false
+        type: boolean
+      run_e2e_jupyter:
+        description: "E2E Tests / Jupyter (Ubuntu)"
+        required: false
+        default: false
+        type: boolean
+      run_e2e_remote_ssh:
+        description: "E2E Tests / Remote SSH (Ubuntu)"
         required: false
         default: false
         type: boolean
@@ -255,23 +265,6 @@ jobs:
       max_failures: 6  # 20 max failures / 4 shards = 5, rounded to 6 to avoid premature failure of the entire suite
       enable_diagnostic_logging: ${{ inputs.enable_diagnostic_logging }}
 
-  e2e-rhel:
-    name: e2e
-    needs: [validate-commit]
-    if: ${{ !failure() && !cancelled() && (github.event_name == 'schedule' || inputs.run_e2e_rhel) }}
-    uses: ./.github/workflows/test-e2e-rhel.yml
-    secrets: inherit
-    with:
-      commit: ${{ inputs.commit != 'latest' && inputs.commit || '' }}
-      skip_cache: ${{ inputs.commit != 'latest' }}
-      grep: ${{ inputs.grep || '' }}
-      project: "e2e-electron"
-      display_name: "electron (rhel)"
-      install_undetectable_interpreters: true
-      install_license: false
-      allow_soft_fail: false
-      enable_diagnostic_logging: ${{ inputs.enable_diagnostic_logging }}
-
   e2e-chromium-rhel:
     name: e2e
     needs: [validate-commit]
@@ -286,23 +279,6 @@ jobs:
       display_name: "chromium (rhel)"
       install_undetectable_interpreters: true
       install_license: true
-      allow_soft_fail: false
-      enable_diagnostic_logging: ${{ inputs.enable_diagnostic_logging }}
-
-  e2e-suse:
-    name: e2e
-    needs: [validate-commit]
-    if: ${{ !failure() && !cancelled() && (github.event_name == 'schedule' || inputs.run_e2e_suse) }}
-    uses: ./.github/workflows/test-e2e-suse.yml
-    secrets: inherit
-    with:
-      commit: ${{ inputs.commit != 'latest' && inputs.commit || '' }}
-      skip_cache: ${{ inputs.commit != 'latest' }}
-      grep: ${{ inputs.grep || '' }}
-      project: "e2e-electron"
-      display_name: "electron (suse)"
-      install_undetectable_interpreters: true
-      install_license: false
       allow_soft_fail: false
       enable_diagnostic_logging: ${{ inputs.enable_diagnostic_logging }}
 
@@ -323,23 +299,6 @@ jobs:
       allow_soft_fail: false
       enable_diagnostic_logging: ${{ inputs.enable_diagnostic_logging }}
 
-  e2e-sles:
-    name: e2e
-    needs: [validate-commit]
-    if: ${{ !failure() && !cancelled() && (github.event_name == 'schedule' || inputs.run_e2e_sles) }}
-    uses: ./.github/workflows/test-e2e-sles.yml
-    secrets: inherit
-    with:
-      commit: ${{ inputs.commit != 'latest' && inputs.commit || '' }}
-      skip_cache: ${{ inputs.commit != 'latest' }}
-      grep: ${{ inputs.grep || '' }}
-      project: "e2e-electron"
-      display_name: "electron (sles)"
-      install_undetectable_interpreters: true
-      install_license: false
-      allow_soft_fail: false
-      enable_diagnostic_logging: ${{ inputs.enable_diagnostic_logging }}
-
   e2e-chromium-sles:
     name: e2e
     needs: [validate-commit]
@@ -357,23 +316,6 @@ jobs:
       allow_soft_fail: false
       enable_diagnostic_logging: ${{ inputs.enable_diagnostic_logging }}
 
-  e2e-debian:
-    name: e2e
-    needs: [validate-commit]
-    if: ${{ !failure() && !cancelled() && (github.event_name == 'schedule' || inputs.run_e2e_debian) }}
-    uses: ./.github/workflows/test-e2e-debian.yml
-    secrets: inherit
-    with:
-      commit: ${{ inputs.commit != 'latest' && inputs.commit || '' }}
-      skip_cache: ${{ inputs.commit != 'latest' }}
-      grep: ${{ inputs.grep || '' }}
-      project: "e2e-electron"
-      display_name: "electron (debian)"
-      install_undetectable_interpreters: true
-      install_license: false
-      allow_soft_fail: false
-      enable_diagnostic_logging: ${{ inputs.enable_diagnostic_logging }}
-
   e2e-chromium-debian:
     name: e2e
     needs: [validate-commit]
@@ -388,6 +330,126 @@ jobs:
       display_name: "chromium (debian)"
       install_undetectable_interpreters: true
       install_license: true
+      allow_soft_fail: false
+      enable_diagnostic_logging: ${{ inputs.enable_diagnostic_logging }}
+
+  build-workbench:
+    name: build
+    needs: [validate-commit]
+    if: ${{ !failure() && !cancelled() && (github.event_name == 'schedule' || inputs.run_e2e_workbench || inputs.run_e2e_workbench_stable) }}
+    uses: ./.github/workflows/build-workbench-linux.yml
+    secrets: inherit
+    with:
+      commit: ${{ inputs.commit != 'latest' && inputs.commit || '' }}
+
+  e2e-workbench:
+    name: e2e
+    needs: [build-workbench]
+    if: ${{ !failure() && !cancelled() && (github.event_name == 'schedule' || inputs.run_e2e_workbench) }}
+    uses: ./.github/workflows/test-e2e-workbench-ubuntu.yml
+    secrets: inherit
+    with:
+      commit: ${{ inputs.commit != 'latest' && inputs.commit || '' }}
+      grep: ${{ inputs.grep || '@:workbench' }}
+      display_name: "workbench"
+      install_license: false
+      upload_logs: false
+      allow_soft_fail: false
+      enable_diagnostic_logging: ${{ inputs.enable_diagnostic_logging }}
+
+  e2e-workbench-stable:
+    name: e2e
+    needs: [build-workbench]
+    if: ${{ !failure() && !cancelled() && (github.event_name == 'schedule' || inputs.run_e2e_workbench_stable) }}
+    uses: ./.github/workflows/test-e2e-workbench-ubuntu.yml
+    secrets: inherit
+    with:
+      commit: ${{ inputs.commit != 'latest' && inputs.commit || '' }}
+      grep: "@:workbench"
+      display_name: "workbench-stable"
+      install_license: false
+      upload_logs: false
+      allow_soft_fail: false
+      install_mode: "ci-stable"
+      enable_diagnostic_logging: ${{ inputs.enable_diagnostic_logging }}
+
+  e2e-pyrefly:
+    name: e2e
+    needs: [validate-commit]
+    if: ${{ !failure() && !cancelled() && (github.event_name == 'schedule' || inputs.run_e2e_pyrefly) }}
+    uses: ./.github/workflows/test-e2e-pyrefly.yml
+    secrets: inherit
+    with:
+      commit: ${{ inputs.commit != 'latest' && inputs.commit || '' }}
+      skip_cache: ${{ inputs.commit != 'latest' }}
+      enable_diagnostic_logging: ${{ inputs.enable_diagnostic_logging }}
+
+  build-connect:
+    name: build
+    needs: [validate-commit]
+    if: ${{ !failure() && !cancelled() && (github.event_name == 'schedule' || inputs.run_e2e_connect) }}
+    uses: ./.github/workflows/build-connect-linux.yml
+    secrets: inherit
+    with:
+      commit: ${{ inputs.commit != 'latest' && inputs.commit || '' }}
+
+  e2e-connect:
+    name: e2e
+    needs: [build-connect]
+    if: ${{ !failure() && !cancelled() && (github.event_name == 'schedule' || inputs.run_e2e_connect) }}
+    uses: ./.github/workflows/test-e2e-connect.yml
+    secrets: inherit
+    with:
+      commit: ${{ inputs.commit != 'latest' && inputs.commit || '' }}
+      display_name: "connect"
+      upload_logs: false
+      allow_soft_fail: false
+      enable_diagnostic_logging: ${{ inputs.enable_diagnostic_logging }}
+
+  build-jupyter:
+    name: build
+    needs: [validate-commit]
+    if: ${{ !failure() && !cancelled() && (github.event_name == 'schedule' || inputs.run_e2e_jupyter) }}
+    uses: ./.github/workflows/build-jupyter-linux.yml
+    secrets: inherit
+    with:
+      commit: ${{ inputs.commit != 'latest' && inputs.commit || '' }}
+
+  e2e-jupyter:
+    name: e2e
+    needs: [build-jupyter]
+    if: ${{ !failure() && !cancelled() && (github.event_name == 'schedule' || inputs.run_e2e_jupyter) }}
+    uses: ./.github/workflows/test-e2e-jupyter-ubuntu.yml
+    secrets: inherit
+    with:
+      commit: ${{ inputs.commit != 'latest' && inputs.commit || '' }}
+      grep: ${{ inputs.grep || '@:jupyter' }}
+      display_name: "jupyter"
+      install_license: true
+      upload_logs: false
+      allow_soft_fail: false
+      enable_diagnostic_logging: ${{ inputs.enable_diagnostic_logging }}
+
+  build-remote-ssh:
+    name: build
+    needs: [validate-commit]
+    if: ${{ !failure() && !cancelled() && (github.event_name == 'schedule' || inputs.run_e2e_remote_ssh) }}
+    uses: ./.github/workflows/build-remote-ssh-linux.yml
+    secrets: inherit
+    with:
+      commit: ${{ inputs.commit != 'latest' && inputs.commit || '' }}
+
+  e2e-remote-ssh:
+    name: e2e
+    needs: [build-remote-ssh]
+    if: ${{ !failure() && !cancelled() && (github.event_name == 'schedule' || inputs.run_e2e_remote_ssh) }}
+    uses: ./.github/workflows/test-e2e-remote-ssh-ubuntu.yml
+    secrets: inherit
+    with:
+      commit: ${{ inputs.commit != 'latest' && inputs.commit || '' }}
+      grep: ${{ inputs.grep || '@:remote-ssh' }}
+      display_name: "remote-ssh"
+      upload_logs: false
       allow_soft_fail: false
       enable_diagnostic_logging: ${{ inputs.enable_diagnostic_logging }}
 
@@ -413,7 +475,7 @@ jobs:
   slack-notify:
     if: always()
     needs:
-      [validate-commit, e2e-electron, e2e-windows, e2e-macos-arm64, e2e-macos-x64, e2e-chromium, e2e-rhel, e2e-chromium-rhel, e2e-suse, e2e-chromium-suse, e2e-sles, e2e-chromium-sles, e2e-debian, e2e-chromium-debian, unit-tests, ext-host-tests]
+      [validate-commit, e2e-electron, e2e-windows, e2e-macos-arm64, e2e-macos-x64, e2e-chromium, e2e-chromium-rhel, e2e-chromium-suse, e2e-chromium-sles, e2e-chromium-debian, e2e-workbench, e2e-workbench-stable, e2e-pyrefly, e2e-connect, e2e-jupyter, e2e-remote-ssh, unit-tests, ext-host-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Updates the "Test: Full Suite" dispatch workflow so it can kick off every test
lane from one place, and removes lanes we no longer use.

**Removed** the four Electron distro lanes (RHEL, SUSE, SLES, Debian) and their
input toggles -- these went unused. The Chromium distro lanes are unchanged.

**Added** six lanes that were previously only reachable from the PR workflow, each
with its own opt-in toggle (default off): Workbench, Workbench Stable, Pyrefly,
Connect, Jupyter, and Remote SSH.

**Wired the "Commit SHA to test" and "Diagnostic logging" inputs through the new
lanes.** Their reusable build/run workflows didn't previously accept these, so:
- Added a `commit` input + conditional `git checkout <commit>` to the four build
  workflows and the five run workflows.
- Threaded `enable_diagnostic_logging` into the five run workflows.
- For Connect and Remote SSH, `BUILD_SOURCEVERSION` now tracks the tested commit;
  Remote SSH's REH server directory (`bin/<commit>`) matches it so the extension
  still resolves the server.
- Pyrefly (self-contained, uses `setup-build-env`) also gained `skip_cache`, wired
  the same way as the existing RHEL lane, so a specific-commit run doesn't restore
  a stale cache.

Every added path is a no-op at its default (`commit: ''`,
`enable_diagnostic_logging: false`, `skip_cache: false`), so routine and scheduled
runs are byte-identical to before -- the new behavior only activates when a commit
SHA or diagnostic logging is explicitly requested.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

1. Dispatch **Test: Full Suite** from a branch with no changes to inputs -> the
   default lanes (Ubuntu Electron, Windows, Chromium Ubuntu) run as before; the new
   lanes stay skipped.
2. Dispatch with the new toggles checked -> Workbench, Workbench Stable, Pyrefly,
   Connect, Jupyter, and Remote SSH each build and run.
3. Dispatch with a specific commit SHA and one of the new lanes (Remote SSH is the
   highest-signal one, given the `BUILD_SOURCEVERSION` / REH-dir coupling) ->
   confirm it builds and tests that commit and the remote server resolves.
