### PR TITLE
e2e: fix scm.test.ts flake from leaked interpreter-test venvs

### DIFF
--- a/test/e2e/test-files/.gitignore
+++ b/test/e2e/test-files/.gitignore
@@ -1,0 +1,8 @@
+# Runtime venv/project folders created at the workspace root by interpreter
+# tests. The e2e runner copies this dir into an ephemeral workspace and re-inits
+# git there, so only a .gitignore inside the workspace travels with it (the root
+# repo .gitignore does not). Without these, a leaked venv inflates SCM status and
+# flakes scm.test.ts.
+venv-creation-test/
+proj/
+.venv/


### PR DESCRIPTION
### Summary
`scm.test.ts` still flakes: leaked `.venv` folders inflate SCM status with 100+ untracked files, so the target file cannot be found in the virtualized change list.
- The `python-venv-creation` and `new-uv-project` tests create `venv-creation-test/` and `proj/` at the shared workspace root and rely on best-effort teardown that loses to timeouts
- Ignore both folders (and `.venv/`) via a workspace-root `.gitignore`
- Only a `.gitignore` inside the copied `test-files` dir travels with the ephemeral git repo the runner re-inits; the root repo `.gitignore` does not (same mechanism as #14877)

### QA Notes
@:scm @:interpreter