### PR TITLE
e2e: fix reticulate multi-session race by explicitly selecting session

### DIFF
--- a/test/e2e/tests/reticulate/helpers/verifyReticulateFunction.ts
+++ b/test/e2e/tests/reticulate/helpers/verifyReticulateFunction.ts
@@ -17,6 +17,11 @@ export async function verifyReticulateFunctionality(
 	zValue = '6'): Promise<void> {
 	const { console, sessions, variables } = app.workbench;
 
+	// Explicitly select the Python session before running code -- with multiple concurrent
+	// sessions of the same language, `console.executeCode` targets whichever session happens
+	// to be foreground, which races with session startup/rename.
+	await sessions.select(pythonSessionId);
+
 	// Create a variable x in Python session
 	await expect(async () => {
 		await console.executeCode('Python', `x = ${xValue}`);
@@ -25,6 +30,7 @@ export async function verifyReticulateFunctionality(
 
 	// Switch to the R session and create an R variable `y` by accessing the Python
 	// variable `x` through reticulate.
+	await sessions.select(rSessionId);
 	await expect(async () => {
 		await console.executeCode('R', 'y<-reticulate::py$x');
 		await variables.expectVariableToBe('y', xValue, 2000);


### PR DESCRIPTION
### Summary
Fixes an intermittent race in the reticulate multi-session e2e test where code could execute against the wrong Python session.
- `console.executeCode()` resolves its target by foreground/MRU session per language, not by session id
- With two concurrent reticulate Python sessions, code could silently land in the non-visible session, failing the Variables pane check
- Explicitly select the intended session (`sessions.select()`) before executing code in `verifyReticulateFunctionality`
- Restores a step dropped in the #10887 stability refactor
- Root-caused via `/triage-e2e-test`; repro'd locally by running both reticulate specs concurrently (2/4 failures unfixed, 8/8 passing fixed)

### QA Notes
@:reticulate @:web @:ark