### PR TITLE
e2e: verify session tab click landed before reading metadata

### DIFF
--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -683,8 +683,15 @@ export class Sessions {
 			const isSingleSession = (await this.getSessionCount()) === 1;
 
 			if (!isSingleSession && sessionId) {
-				// Use force to bypass notification toasts that may overlay the tab
-				await this.page.getByTestId(`console-tab-${sessionId}`).click({ force: true });
+				const targetTab = this.getSessionTab(sessionId);
+				await expect(async () => {
+					// Use force to bypass notification toasts that may overlay the tab. A
+					// toast can also swallow the click outright (it's on top, so the real
+					// tab never receives it) -- verify the tab actually went active instead
+					// of assuming the click landed, and retry if it didn't.
+					await targetTab.click({ force: true });
+					await expect(targetTab).toHaveClass(/tab-button--active/);
+				}, `Select session tab: ${sessionId}`).toPass({ timeout: 10000 });
 			}
 
 			const metadata = await this.extractMetadataFromDialog();


### PR DESCRIPTION
### Summary
Fixes a flaky session-reuse path in e2e tests (noticed in `Quarto - Inline Output: DataFrame and Interactive HTML > Python - Verify interactive HTML widget persists correctly after close and reopen`) where a notification toast could swallow a force-click on a console tab, leaving the metadata dialog stuck closed.
- `Sessions.getMetadata()` now retries the tab click until the tab actually reports active (`tab-button--active`), instead of assuming a force-click landed.
- Root-caused via `/triage-e2e-test`: CI history showed this hitting the Quarto inline-output interactive-HTML-widget test almost exclusively on win/electron, correlating with concurrent notification toasts in sibling failures from the same runs.

### QA Notes
@:sessions @:win