### PR TITLE
fix(supervisor): quote space-containing args in PowerShell Start-Process on Windows

### DIFF
--- a/extensions/positron-supervisor/resources/supervisor-wrapper.bat
+++ b/extensions/positron-supervisor/resources/supervisor-wrapper.bat
@@ -18,7 +18,7 @@ if "%~2"=="" (
 )
 
 REM The first argument is the output file; consume it.
-set output_file=%1
+set "output_file=%~1"
 shift
 
 REM `shift` doesn't affect `%*`, so we have to manually remove the first argument

--- a/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
+++ b/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
@@ -578,7 +578,14 @@ export class KCApi implements PositronSupervisorApi {
 				wrapperPath = 'powershell.exe';
 				// Build the arguments for the wrapper script
 				const escapedWrapper = kernelWrapper.replace(/'/g, "''");
-				const escapedArgs = shellArgs.map(arg => `'${arg.replace(/'/g, "''")}'`).join(', ');
+				const escapedArgs = shellArgs.map(arg => {
+					const escapedArg = arg.replace(/'/g, "''");
+					// Start-Process joins -ArgumentList elements with spaces when
+					// building the cmd.exe command line for .bat invocation. Wrap
+					// args that contain spaces in double-quotes so cmd.exe treats
+					// them as single tokens.
+					return arg.includes(' ') ? `'"${escapedArg}"'` : `'${escapedArg}'`;
+				}).join(', ');
 				shellArgs = [
 					'-WindowStyle', 'Hidden',
 					'-Command',


### PR DESCRIPTION
Fixes #14671

When `kernelSupervisor.shutdownTimeout` is changed from the default (`immediately`) on Windows, Positron launches the Kallichore server via PowerShell's `Start-Process`. PowerShell joins `-ArgumentList` array elements with spaces when building the `cmd.exe` command line, so a path like `c:\Program Files\...\kcserver.exe` is split at the space and `cmd.exe` tries to run `c:\Program` — producing the *'c:\Program' is not recognized* error.

The fix wraps arguments that contain spaces in double-quotes within the PowerShell array so `cmd.exe` treats each path as a single token. The batch wrapper is also updated to use `%~1` (strips surrounding double-quotes) when assigning the output file path, for defensive correctness.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix supervisor failing to start when `kernelSupervisor.shutdownTimeout` is non-default on Windows installations with spaces in the path (#14671)

### Validation Steps

@:win @:sessions

This fix is Windows-only and requires an installation in a path containing spaces (e.g. `C:\Program Files\Positron\`):

1. Install Positron to a path with spaces
2. Set `kernelSupervisor.shutdownTimeout` to `when idle` (or any non-`immediately` value)
3. Restart Positron
4. Start an R or Python console session — it should start without error