### PR TITLE
ci-arm: detect dependency drift from extension-only changes

### DIFF
--- a/.devcontainer/ci-arm/build-doctor.sh
+++ b/.devcontainer/ci-arm/build-doctor.sh
@@ -26,6 +26,12 @@ SERVER_ERR=/tmp/positron-server.err     # written by start-server.sh on a failed
 DESKTOP_ERR=/tmp/positron-electron.err  # written by launch-electron.sh on a failed launch
 
 sha() { [ -f "$1" ] && sha256sum "$1" | awk '{print $1}' || echo "missing"; }
+# Root deps check: a root-lockfile-only sha (like the e2e check below) misses drift from an
+# extension's own package.json/package-lock.json, since each dir in build/npm/dirs.ts is installed
+# separately and doesn't touch the root package-lock.json. installStateHash.ts's isUpToDate() is the
+# same read-only check npm's own postinstall hook trusts, hashing every dir in dirs.ts - reuse it
+# here instead of re-deriving (and getting wrong) that logic in bash. ~200ms; fine for a 3s poll.
+root_deps_ok() { node -e "import('$WS/build/npm/installStateHash.ts').then(m => process.exit(m.isUpToDate() ? 0 : 1))" 2>/dev/null; }
 tcp() { (exec 3<>"/dev/tcp/$1/$2") 2>/dev/null; }
 human_dur() { # seconds -> compact "3d 4h" / "2h 5m" / "12m" / "9s"
   local s=$1
@@ -140,7 +146,7 @@ render() {
     [ -f "$STATE/complete" ] || { build_ok=0; actions+=("Cold build never completed → run 'Positron CI: Rebuild'."); }
     [ -d "$WS/out" ]        || { build_ok=0; actions+=("No compiled output (out/) → start the watcher ('npm run watch') or run 'Positron CI: Rebuild'."); }
     [ -e "$WS/.build/electron" ] || { build_ok=0; actions+=("Electron not set up → run 'Positron CI: Rebuild'."); }
-    [ "$(sha "$WS/package-lock.json")" = "$(cat "$STATE/deps.sha" 2>/dev/null)" ] || { build_ok=0; actions+=("Root deps changed → run 'Positron CI: Reinstall deps'."); }
+    root_deps_ok || { build_ok=0; actions+=("Root deps changed → run 'Positron CI: Reinstall deps'."); }
     [ "$(sha "$WS/test/e2e/package-lock.json")" = "$(cat "$STATE/e2e-deps.sha" 2>/dev/null)" ] || { build_ok=0; actions+=("test/e2e deps changed → run 'Positron CI: Reinstall e2e deps'."); }
     if [ "$build_ok" -eq 1 ]; then
       printf '  %s✓%s %-*s%s%s%s\n' "$G" "$RST" "$NAMEW" "Build" "$DIM" "$last_build" "$RST"
@@ -244,7 +250,7 @@ sig() {
   # marker, so without these bits the Build row stayed stale until a manual refresh.
   [ -d "$WS/out" ] && s+=O || s+=o
   [ -e "$WS/.build/electron" ] && s+=L || s+=l
-  [ "$(sha "$WS/package-lock.json")" = "$(cat "$STATE/deps.sha" 2>/dev/null)" ] && s+=M || s+=m
+  root_deps_ok && s+=M || s+=m
   [ "$(sha "$WS/test/e2e/package-lock.json")" = "$(cat "$STATE/e2e-deps.sha" 2>/dev/null)" ] && s+=2 || s+=z
   # Build-marker mtime: Reinstall deps / Rebuild rewrite it (mark-build-state.sh), so the Build
   # card redraws when they finish — Reinstall never runs post-create.sh, so the B bit alone misses it.

--- a/.devcontainer/ci-arm/ci-lab-up.sh
+++ b/.devcontainer/ci-arm/ci-lab-up.sh
@@ -72,10 +72,15 @@ elif [ -n "$BRANCH" ]; then
 	# Build present but we just switched branches: reconcile deps and recompile out/ so both match
 	# the new source. (Without a branch switch the current checkout is assumed already built.)
 	step "reconcile dependencies"
+	# Root deps go through fast-install.ts, not a root-lockfile-only sha compare: it hashes every
+	# dir in build/npm/dirs.ts (root plus each extension), so a branch that only changes an
+	# extension's own package.json (no root package-lock.json change) still triggers a reinstall
+	# instead of silently keeping a stale node_modules from the branch we switched off of.
 	# $() below is meant to run inside the container, not expand on the host, hence single quotes:
 	# shellcheck disable=SC2016
 	in_ctr '
-		[ "$(sha256sum package-lock.json | cut -d" " -f1)" = "$(cat .build/.ci-arm-state/deps.sha 2>/dev/null)" ] || ./.devcontainer/ci-arm/reinstall-deps.sh root
+		node build/npm/fast-install.ts
+		./.devcontainer/ci-arm/mark-build-state.sh root
 		[ "$(sha256sum test/e2e/package-lock.json | cut -d" " -f1)" = "$(cat .build/.ci-arm-state/e2e-deps.sha 2>/dev/null)" ] || ./.devcontainer/ci-arm/reinstall-deps.sh e2e
 	'
 	step "recompile out/ (incremental)"

--- a/.devcontainer/ci-arm/post-create.sh
+++ b/.devcontainer/ci-arm/post-create.sh
@@ -6,11 +6,16 @@ set -euo pipefail
 
 cd "${WORKSPACE_FOLDER:-$(cd "$(dirname "$0")/../.." && pwd)}"
 
-echo "==> [1/8] root npm ci"
-[ -d node_modules ] && [ -n "$(ls -A node_modules 2>/dev/null)" ] || npm ci --fetch-timeout 120000
+echo "==> [1/8] root deps"
+# fast-install.ts hashes package.json/package-lock.json/.npmrc across every dir in
+# build/npm/dirs.ts (root plus each extension), so it catches a new/changed extension
+# package.json even when the root package-lock.json itself didn't change -- unlike a plain
+# non-empty check or a root-lockfile-only sha compare, both of which would skip the install
+# and leave a stale node_modules a volume carried over from before that extension existed.
+node build/npm/fast-install.ts
 
 echo "==> [2/8] test/e2e npm ci"
-[ -d test/e2e/node_modules ] && [ -n "$(ls -A test/e2e/node_modules 2>/dev/null)" ] || npm --prefix test/e2e ci
+[ "$(sha256sum test/e2e/package-lock.json | cut -d' ' -f1)" = "$(cat .build/.ci-arm-state/e2e-deps.sha 2>/dev/null)" ] || npm --prefix test/e2e ci
 
 echo "==> [3/8] compile + electron (${POSITRON_CI_IMAGE_ARCH:-arm64})"
 ELECTRON_ARCH="${POSITRON_CI_IMAGE_ARCH:-arm64}"


### PR DESCRIPTION
### Summary
Fixes a dependency-drift blind spot in the ci-arm dev container scripts: they only hashed the root `package-lock.json`, so an extension-only `package.json` change (installed separately per `build/npm/dirs.ts`, never touching the root lockfile) went undetected and left stale `node_modules` after a cold build or branch switch.
- `post-create.sh`'s root-deps step now runs `fast-install.ts` instead of a plain non-empty check
- `ci-lab-up.sh`'s branch-reconcile step uses the same check instead of a root-lockfile-only sha compare
- `build-doctor.sh`'s Build status row/signature use the same read-only `isUpToDate()` check instead of hashing only `package-lock.json`

### QA Notes
Dev-tooling only (`.devcontainer/ci-arm`), no e2e tags. Reproduced the original failure (`positron-data-driver-pins` missing `@types` after a stale cold build), confirmed `fast-install.ts` detects and fixes the drift, and re-ran `compile-extensions` clean afterward.