### PR TITLE
e2e: fix flaky Console information dialog click in selectMetadataOption

### DIFF
--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -236,7 +236,10 @@ export class Sessions {
 	 */
 	async selectMetadataOption(menuItem: 'Show Kernel Output Channel' | 'Show Supervisor Output Channel' | 'Show LSP Output Channel') {
 		await this.console.focus();
-		await this.metadataButton.click();
+		// Use openMetadataDialog() instead of a raw button click: the button's
+		// click handler reads the active console session from React context,
+		// which can lag a just-fired focus change and silently no-op.
+		await this.openMetadataDialog();
 		await this.metadataDialog.getByText(menuItem).click();
 
 		await expect(this.page.getByRole('tab', { name: 'Output' })).toHaveClass(/.*checked.*/);


### PR DESCRIPTION
### Summary
Fixes flakiness in `Sessions: State > Validate metadata between sessions`.
- `selectMetadataOption()` clicked the Console information button directly; the button's click handler silently no-ops when the active console session in React context hasn't caught up to a just-fired focus change, so the dialog never opens and the next click hangs for 30s.
- Reuses the existing `openMetadataDialog()` retry helper (already used elsewhere in `sessions.ts` for the same race) instead of a bare button click.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A (test-only change)

### QA Notes

@:web @:console @:sessions