### PR TITLE
e2e: fix default-python-interpreter session-not-ready race

### DIFF
--- a/test/e2e/tests/interpreters/default-python-interpreter.test.ts
+++ b/test/e2e/tests/interpreters/default-python-interpreter.test.ts
@@ -53,6 +53,14 @@ test.describe('Default Interpreters - Python', {
 			? /python-env\/bin\/python/
 			: new RegExp(`~?\\.pyenv/versions/${pythonVersion.replace(/\./g, '\\.')}/bin/python`);
 
+		// The beforeAll reload's waitForReady only asserts the loading banner is gone -- it
+		// doesn't confirm the auto-started session (interpreters.startupBehavior: 'always') has
+		// actually appeared. Extension host reactivation and the kernel-supervisor round trip can
+		// still be in flight once that banner clears, so wait for the session to actually exist
+		// before querying its metadata; otherwise getMetadata() can hang retrying a click on a
+		// Console-information button that doesn't exist yet.
+		await sessions.expectSessionCountToBe(1);
+
 		// Verify interpreter metadata. No extra reload here: the beforeAll reload above already
 		// starts the interpreter. A second reload used to run at this point, but it raced a
 		// window reload against that still-in-flight session-creation call, canceling it and


### PR DESCRIPTION
### Summary
The beforeAll reload's waitForReady only asserts the loading banner is gone, not that the auto-started session actually exists yet -- so getMetadata() can hang retrying a click on a Console-information button that doesn't exist.
- Confirmed via CI trace/logs: metadataButton.click() looped on "waiting for getByRole(...)" for 7+ seconds with zero sessions present (screenshot: "There is no session running")
- Kernel Supervisor log showed the extension host reactivating and language runtimes finishing activation well after waitForReady had already returned
- Fixes it by waiting on `sessions.expectSessionCountToBe(1)` (existing POM verification, polls for the metadata button) before reading metadata
- Distinct from and additional to #14901 (removed a redundant second reload) -- that fix didn't address this race

### Known limitation
This assumes the auto-started session is just slow, not silently skipped. Evidence leans that way (low ~10.5% historical failure rate, healthy Kernel Supervisor in the failing traces, unresponsive-extension-host events pointing at CI load), but I never directly observed a session appear after a failing run timed out. The earlier fix's author noted `startupBehavior: always` only picks up `defaultInterpreterPath` once initial interpreter discovery has already run -- so there's a real alternative where the setting is missed entirely on some runs, and no amount of waiting would help. If this test keeps flaking after this PR, that's the next thing to check (likely in `runtimeStartup.ts`'s auto-start logic), not a longer wait.

### QA Notes
@:interpreter