### PR TITLE
e2e: capture failure screenshot before afterEach/afterAll teardown

### DIFF
--- a/test/e2e/fixtures/test-setup/reporting.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/reporting.fixtures.ts
@@ -38,16 +38,33 @@ export function AttachScreenshotsToReportFixture() {
 			screenshots.push(screenshotPath);
 		};
 
-		await use();
-
-		// if test failed, take and attach screenshot
-		if (testInfo.status !== testInfo.expectedStatus) {
+		const attachFailureScreenshot = async () => {
+			if (testInfo.status === testInfo.expectedStatus) { return; }
 			try {
 				const screenshot = await page.screenshot();
-				await testInfo.attach('on-test-end', { body: screenshot, contentType: 'image/png' });
+				await testInfo.attach('on-test-fail', { body: screenshot, contentType: 'image/png' });
 			} catch {
 				// Page may not be available if app failed to start
 			}
+		};
+
+		// Capture the failure screenshot the instant the test function throws, via the
+		// same private callback hook Playwright's own built-in `screenshot:
+		// 'only-on-failure'` uses internally. This fires before afterEach/afterAll hooks
+		// and before fixture teardown, so it shows the state that caused the failure
+		// rather than whatever teardown left behind. There's no public API for this
+		// timing; if a future Playwright release removes the hook, fall back to
+		// capturing at fixture teardown (the old, later timing) so failure screenshots
+		// don't silently disappear.
+		const onDidFinishTestFunctionCallbacks = (testInfo as unknown as {
+			_onDidFinishTestFunctionCallbacks?: Set<() => unknown>;
+		})._onDidFinishTestFunctionCallbacks;
+		onDidFinishTestFunctionCallbacks?.add(attachFailureScreenshot);
+
+		await use();
+
+		if (!onDidFinishTestFunctionCallbacks) {
+			await attachFailureScreenshot();
 		}
 
 		for (const screenshotPath of screenshots) {


### PR DESCRIPTION
### Summary
Moves the e2e failure screenshot from fixture teardown (after all `afterEach`/`afterAll` hooks) to the instant the failing test function throws, so it reflects the state that caused the failure instead of whatever teardown left behind.
- Hooks into Playwright's internal test-function-finish callback, the same one its built-in `screenshot: 'only-on-failure'` uses
- Renames the attachment from `on-test-end` to `on-test-fail`
- Falls back to the old teardown-time capture if that internal hook is ever removed in a future Playwright release

### QA Notes
Manually verified with a throwaway failing test that printed distinct pre/post-teardown console markers; the `on-test-fail` screenshot showed only the pre-teardown marker.