### PR TITLE
fix(ci): stop libexpat/fontconfig segfault crashing ext-host Remote tests

### DIFF
--- a/docker/images/ubuntu24_04/Dockerfile.ubuntu24_04
+++ b/docker/images/ubuntu24_04/Dockerfile.ubuntu24_04
@@ -136,6 +136,26 @@ RUN set -eu; \
     "$TT_BIN/mktexlsr"; \
     fc-cache -f
 
+# --- Font stack hardening for headless Electron/Chromium test runs ---
+# The ext-host "Remote" suite cold-starts Electron once per test workspace.
+# Each cold start runs fontconfig's FcInit (config XML parse via libexpat plus a
+# font-dir scan) from multiple threads, and on a thin headless image this
+# intermittently GP-faults deep in libexpat while loading the fontconfig config
+# (crash stack: libexpat <- libfontconfig <- libpangoft2). It is the dominant
+# ext-host CI flake (amd64). We can't remove the race at the image layer, but we
+# shrink its window to near-zero and rule out the known memory-corruption bug:
+#   1. Pull the security-patched libexpat1 / libfontconfig1 (noble's base
+#      2.6.1-2build1 shipped with the CVE-2024-45490 negative-length memory
+#      corruption bug; 2.6.1-2ubuntu0.1 fixes it).
+#   2. Install a complete font set and fully rebuild the cache as the last
+#      font-affecting step so FcInit is a fast cache-hit that never regenerates
+#      the cache at runtime.
+RUN apt-get update && \
+    apt-get install -y --only-upgrade libexpat1 libfontconfig1 && \
+    apt-get install -y fontconfig fonts-dejavu-core fonts-noto-core && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    fc-cache -f -v
+
 # Install uv (latest)
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 

--- a/scripts/test-remote-integration.sh
+++ b/scripts/test-remote-integration.sh
@@ -67,6 +67,16 @@ fi
 
 API_TESTS_EXTRA_ARGS="--no-sandbox --disable-telemetry --disable-experiments --skip-welcome --skip-release-notes --crash-reporter-directory=$VSCODECRASHDIR --logsPath=$VSCODELOGSDIR --no-cached-data --disable-updates --use-inmemory-secretstorage --disable-workspace-trust --user-data-dir=$VSCODEUSERDATADIR"
 
+# --- Start Positron ---
+# Each test workspace below cold-starts a fresh Electron. On the headless CI
+# image the GPU process's multithreaded fontconfig init intermittently
+# GP-faults in libexpat during font config load (stack: libexpat <-
+# libfontconfig <- libpangoft2), crashing the whole run with exit 139. This is
+# the dominant ext-host CI flake. Disabling the GPU process removes that font
+# init path; these tests are headless and don't exercise GPU rendering.
+API_TESTS_EXTRA_ARGS="$API_TESTS_EXTRA_ARGS --disable-gpu"
+# --- End Positron ---
+
 echo "Storing crash reports into '$VSCODECRASHDIR'."
 echo "Storing log files into '$VSCODELOGSDIR'."
 


### PR DESCRIPTION
## Problem

The `test / ext-host` job intermittently fails with **exit 139 (SIGSEGV)** during the **Run Extension Host Tests (Remote)** step. The crash happens on Electron startup, before any test runs, and the stack is entirely in system font libraries:

```
Received signal 11  (Possibly a General Protection Fault / non-canonical address deref)
#3  libexpat.so.1.9.1        <- XML config parse
#6  libfontconfig.so.1.12.1  <- FcConfigParseAndLoad
#21 libpangoft2-1.0.so       <- FcInit during font setup
```

It is the **dominant ext-host flake on amd64**: ~5 of 6 recent ext-host failures on `main` were this exact crash. The suite that dies moves around (markdown-language-features one run, vscode-api-tests the next), which rules out test code.

## Root cause

A fontconfig cold-start race. The Remote suite cold-starts a fresh Electron **once per test workspace**, and each cold start runs `FcInit` (config XML parse via libexpat + font-dir scan) from multiple threads (note the `InitializeSandbox() called with multiple threads` line right before the crash). A malformed config would fail every time; this is intermittent, so it's a data race in the shared fontconfig/parser state. The Remote run has by far the most independent Electron cold starts, which is why it - and only it - hits this.

## Fix

Two complementary changes, attacking the same race from both sides:

- **`docker/images/ubuntu24_04/Dockerfile.ubuntu24_04`** - pull the security-patched `libexpat1`/`libfontconfig1` (noble's base `2.6.1-2build1` shipped with the CVE-2024-45490 memory-corruption bug, fixed in `2.6.1-2ubuntu0.1`), install a fuller font set, and rebuild the fontconfig cache as the last font-affecting step so `FcInit` is a fast cache-hit that never regenerates the cache at runtime. Shrinks the cold-start race window to near-zero.
- **`scripts/test-remote-integration.sh`** - run the test Electron with `--disable-gpu`, removing the GPU process whose multithreaded font init is where the crash actually occurs. Scoped to the Remote script (the only suite affected); these tests are headless and don't exercise GPU rendering.

A race can't be provably eliminated at these layers, but this is the standard, effective remedy and addresses the known memory-corruption bug outright.

## Image / tag note

The `ubuntu24_04` image tag encodes the embedded Node version (`24.15.0`), so it is rebuilt in place at the **same tag** rather than bumped. No workflow tag references change.

## Testing

- Dockerfile build validated via the `CI Images: Build OS test images` workflow (`os=ubuntu24_04`, `tag=24.15.0`) against this branch, both arches.
- After merge, watch the ext-host `libexpat` crash rate on `main` against the ~5-in-6 baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)