### PR TITLE
e2e: fix metadata dialog race 

### DIFF
--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -697,7 +697,7 @@ export class Sessions {
 				}, `Select session tab: ${sessionId}`).toPass({ timeout: 10000 });
 			}
 
-			const metadata = await this.extractMetadataFromDialog();
+			const metadata = await this.extractMetadataFromDialog(sessionId);
 
 			// Close the metadata dialog
 			await this.page.keyboard.press('Escape');
@@ -708,13 +708,15 @@ export class Sessions {
 
 	/**
 	 * Helper: Extract metadata from the metadata dialog
+	 *
+	 * @param sessionId the session ID the dialog should reflect, if known
 	 */
-	private async extractMetadataFromDialog(): Promise<SessionMetaData> {
+	private async extractMetadataFromDialog(sessionId?: string): Promise<SessionMetaData> {
 		let metadata: SessionMetaData | undefined;
 
 		await test.step('Extract metadata from dialog', async () => {
 			await expect(async () => {
-				await this.openMetadataDialog();
+				await this.openMetadataDialog(sessionId);
 				const [name, id, state, path, source] = await Promise.all([
 					this.metadataDialog.getByTestId('session-name').textContent(),
 					this.metadataDialog.getByTestId('session-id').textContent(),
@@ -866,13 +868,22 @@ export class Sessions {
 
 	/**
 	* Action: Open the metadata dialog for the current session
+	*
+	* @param sessionId the session the dialog should reflect, if known -- click via the
+	* button's testid (`info-unknown` until a real session lands in it) rather than its
+	* role/label, so we wait for the click handler's React context to be ready, not just visible
 	*/
-	async openMetadataDialog() {
+	async openMetadataDialog(sessionId?: string) {
+		const button = sessionId
+			? this.page.getByTestId(`info-${sessionId}`)
+			: this.page.getByTestId(/^info-(python|r)(-notebook)?-[a-z0-9]+$/i);
+
 		await expect(async () => {
 			const isMetadataDialogVisible = await this.metadataDialog.isVisible();
 
 			if (!isMetadataDialogVisible) {
-				await this.metadataButton.click();
+				await expect(button).toBeVisible();
+				await button.click();
 				await this.page.mouse.move(0, 0);
 				await this.page.waitForTimeout(500);
 			}


### PR DESCRIPTION
### Summary
The metadata dialog's info button can silently no-op if clicked before its React state catches up to a session switch, causing test flakes.
- Wait for the button's testid to reflect the target session before clicking, instead of clicking blind
- Fixes the dominant failure mode in the quarto interactive-widget persistence flake

### QA Notes
@:sessions