### PR TITLE
Top align table cells in hover docs

### DIFF
--- a/src/vs/base/browser/ui/hover/hoverWidget.css
+++ b/src/vs/base/browser/ui/hover/hoverWidget.css
@@ -169,13 +169,19 @@
 
 /* --- Start Positron --- */
 /*
- * Top-align table cells in hover markdown. Browsers default table cells to
- * vertical-align: middle, which leaves an argument name floating in the middle
- * of a multi-line description in function hover docs (e.g. R argument tables).
- * The Help pane top-aligns these, so match that here for consistency.
+ * Top-align table cells in editor hover markdown. Browsers default table cells
+ * to vertical-align: middle, which leaves an argument name floating in the
+ * middle of a multi-line description in function hover docs (e.g. R argument
+ * tables). The Help pane top-aligns these, so match that here for consistency.
+ *
+ * Scoped to `.monaco-editor` so this only affects editor hovers, not other
+ * hovers/tooltips across the workbench. This mirrors upstream's own hover
+ * theming convention (see hoverContribution.ts, which scopes with
+ * `.monaco-editor .monaco-hover`), and the extra class raises specificity so
+ * the rule wins regardless of stylesheet load order.
  */
-.monaco-hover .hover-contents table td,
-.monaco-hover .hover-contents table th {
+.monaco-editor .monaco-hover .hover-contents table td,
+.monaco-editor .monaco-hover .hover-contents table th {
 	vertical-align: top;
 }
 /* --- End Positron --- */

--- a/src/vs/base/browser/ui/hover/hoverWidget.css
+++ b/src/vs/base/browser/ui/hover/hoverWidget.css
@@ -167,6 +167,19 @@
 	content: '(';
 }
 
+/* --- Start Positron --- */
+/*
+ * Top-align table cells in hover markdown. Browsers default table cells to
+ * vertical-align: middle, which leaves an argument name floating in the middle
+ * of a multi-line description in function hover docs (e.g. R argument tables).
+ * The Help pane top-aligns these, so match that here for consistency.
+ */
+.monaco-hover .hover-contents table td,
+.monaco-hover .hover-contents table th {
+	vertical-align: top;
+}
+/* --- End Positron --- */
+
 .monaco-hover .hover-contents a.code-link:after {
 	content: ')';
 }


### PR DESCRIPTION
- Fixes #14851
- Fixes #3599

When hovering over a function, the Arguments section is rendered as a markdown table with the argument name on the left and its description on the right. Table cells default to `vertical-align: middle`, so when a description spans several lines the name floats in the middle of the paragraph, making the argument list hard to scan. The Help pane already top-aligns these.

This adds a single CSS rule in `hoverWidget.css` to top-align `td`/`th` in hover contents tables. It is most visible in R function hovers (e.g. `readr::read_csv`), but the fix is language-agnostic and applies to any markdown hover table:

<img width="1451" height="999" alt="Screenshot_2026-07-16_at_5_45_45 PM" src="https://github.com/user-attachments/assets/e6f0826b-26a2-4e67-9e64-4a3df60928ce" />

This supersedes the approach floated in #3599 (enabling `supportHtml`, allowlisting `<style>` through the markdown scrubber, and injecting a `<style>` block from Ark's help converter). The CSS approach (suggested by @gkaramanis; thank you!) touches one file, avoids widening the markdown scrubber's HTML surface, and fixes all languages at once rather than just R. Both issues are closed by this PR.

The change lives in an upstream file (`hoverWidget.css`), wrapped in Positron markers. It is generic enough that we could consider contributing it upstream to `microsoft/vscode` later but I say let's just fix it here now.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Argument names in function hover docs are now top-aligned with the first line of their description, matching the Help pane (#14851, #3599).

### Validation Steps

@:help

1. In an R script, hover over a function with long, multi-line argument descriptions, e.g. `readr::read_csv` or `ggplot::ggplot`.
2. Scroll down to the Arguments section of the hover.
3. Confirm each argument name lines up with the first line of its description (not the vertical center), matching how the Help pane renders the same content.
4. Sanity check a hover that renders a single-line table row to confirm those still look correct. For example, in the same `read_csv` hover, confirm the arguments with short single-line descriptions (e.g. `skip`, `n_max`) still render correctly, so single-row cells aren't affected.
