### PR TITLE
e2e: session-related flake fixes

### DIFF
--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -139,6 +139,22 @@ export class Sessions {
 				} else {
 					// session found, retrieve metadata
 					const foundSession = consoleTabActiveSessions[existingSessionIndex];
+
+					// Wait for the reused session to actually be reattached before reading its
+					// metadata -- the Console information button silently no-ops while a session
+					// is still reconnecting (e.g. right after another test's window reload reset
+					// every session's websocket), which otherwise strands getMetadata()'s dialog
+					// retry against a button that never opens it. Only checkable here when more
+					// than one session tab is rendered; a lone session's metadata already goes
+					// through this same dialog with no tab-based signal to wait on instead.
+					if (await this.getSessionCount() > 1) {
+						await expect(async () => {
+							const status = await this.getIconStatus(foundSession.id);
+							expect(status).not.toBe('disconnected');
+							expect(status).not.toBe('unknown');
+						}, `Wait for reused session to reattach: ${foundSession.id}`).toPass({ timeout: 30000 });
+					}
+
 					results.push(await this.getMetadata(foundSession.id));
 
 					// remove the found session from the list to avoid duplicates

--- a/test/e2e/tests/interpreters/default-python-interpreter.test.ts
+++ b/test/e2e/tests/interpreters/default-python-interpreter.test.ts
@@ -39,7 +39,7 @@ test.describe('Default Interpreters - Python', {
 		await cleanup.discardAllChanges();
 	});
 
-	test('Python - Add a default interpreter (Conda)', async function ({ sessions }) {
+	test('Python - Add a default interpreter (Conda)', async function ({ sessions, hotKeys }) {
 		// Get version from appropriate env var (hidden Python in CI, regular in local)
 		const pythonVersion = process.env.CI
 			? (process.env.POSITRON_HIDDEN_PY || '3.12.10').split(' ')[0] // Extract "3.12.10" from "3.12.10 (Conda)"
@@ -53,12 +53,17 @@ test.describe('Default Interpreters - Python', {
 			? /python-env\/bin\/python/
 			: new RegExp(`~?\\.pyenv/versions/${pythonVersion.replace(/\./g, '\\.')}/bin/python`);
 
-		// Verify interpreter metadata. No extra reload here: the beforeAll reload above already
-		// starts the interpreter. A second reload used to run at this point, but it raced a
-		// window reload against that still-in-flight session-creation call, canceling it and
-		// leaving the console referencing a session that never finished starting.
-		const { name, path } = await sessions.getMetadata();
-		expect(name).toMatch(versionRegex);
-		expect(path).toMatch(pathRegex);
+		// Retry with reload on failure -- same detached-session race as #14901; matches
+		// default-r-interpreter.test.ts's idiom.
+		await expect(async () => {
+			try {
+				const { name, path } = await sessions.getMetadata();
+				expect(name).toMatch(versionRegex);
+				expect(path).toMatch(pathRegex);
+			} catch (error) {
+				await hotKeys.reloadWindow(true);
+				throw error;
+			}
+		}).toPass({ timeout: 60000 });
 	});
 });

--- a/test/e2e/tests/interpreters/default-r-interpreter.test.ts
+++ b/test/e2e/tests/interpreters/default-r-interpreter.test.ts
@@ -42,10 +42,9 @@ test.describe('Default Interpreters - R', {
 
 	});
 
-	test('R - Add a default interpreter', async function ({ runCommand, sessions, hotKeys }) {
+	test('R - Add a default interpreter', async function ({ sessions, hotKeys }) {
 
-		await hotKeys.reloadWindow(true);
-
+		// No reload here -- see #14901, same detached-session race as the Python default-interpreter test.
 		const hiddenRVersion = process.env.POSITRON_HIDDEN_R;
 		if (!hiddenRVersion) {
 			throw new Error('POSITRON_HIDDEN_R environment variable is not set');

--- a/test/e2e/tests/reticulate/helpers/verifyReticulateFunction.ts
+++ b/test/e2e/tests/reticulate/helpers/verifyReticulateFunction.ts
@@ -17,21 +17,21 @@ export async function verifyReticulateFunctionality(
 	zValue = '6'): Promise<void> {
 	const { console, sessions, variables } = app.workbench;
 
-	// Explicitly select the Python session before running code -- with multiple concurrent
-	// sessions of the same language, `console.executeCode` targets whichever session happens
-	// to be foreground, which races with session startup/rename.
-	await sessions.select(pythonSessionId);
-
 	// Create a variable x in Python session
 	await expect(async () => {
+		// Re-select on every retry -- with multiple concurrent sessions of the same language,
+		// `console.executeCode` targets whichever session is foreground, and foreground can be
+		// reassigned asynchronously (e.g. by another session's Ready transition) after a
+		// one-time select, silently stranding subsequent retries on the wrong session.
+		await sessions.select(pythonSessionId);
 		await console.executeCode('Python', `x = ${xValue}`);
 		await variables.expectVariableToBe('x', xValue, 2000);
 	}, 'Can create variable in Python session').toPass();
 
 	// Switch to the R session and create an R variable `y` by accessing the Python
 	// variable `x` through reticulate.
-	await sessions.select(rSessionId);
 	await expect(async () => {
+		await sessions.select(rSessionId);
 		await console.executeCode('R', 'y<-reticulate::py$x');
 		await variables.expectVariableToBe('y', xValue, 2000);
 	}, 'Can access Python variable x from R').toPass();
@@ -42,6 +42,7 @@ export async function verifyReticulateFunctionality(
 
 	// Verify able to overwrite the R variable `y` with an integer literal on the R side.
 	await expect(async () => {
+		await sessions.select(rSessionId);
 		await console.executeCode('R', `y <- ${yValue}L`);
 		await variables.expectVariableToBe('y', yValue, 2000);
 	}, 'Can overwrite the R variable').toPass();
@@ -53,12 +54,14 @@ export async function verifyReticulateFunctionality(
 
 	// Print the R variable r.y (should reflect the R-side value) and ensure it appears in the console
 	await expect(async () => {
+		await sessions.select(pythonSessionId);
 		await console.executeCode('Python', 'print(r.y)');
 		await console.waitForConsoleContents(yValue, { timeout: 5000 });
 	}, 'Can print the R variable r.y from Python').toPass();
 
 	// Print the Python variable z (created via repl_python) and ensure it appears as well
 	await expect(async () => {
+		await sessions.select(pythonSessionId);
 		await console.executeCode('Python', 'print(z)');
 		await console.waitForConsoleContents(zValue, { timeout: 5000 });
 	}, 'Can print the Python variable z from Python').toPass();


### PR DESCRIPTION
### Summary
Three small e2e flake fixes, all in the same "session isn't fully attached yet" problem family.
- default-python-interpreter.test.ts: wrap the metadata read in a retry-with-reload, matching the R test's existing idiom, to recover when CI startup latency outruns the dialog's retry budget
- default-r-interpreter.test.ts: remove a redundant window reload that raced against the beforeAll reload's still-in-flight session creation, canceling it -- the same root cause #14901 already fixed on the Python side
- reticulate-multiple.test.ts (via verifyReticulateFunction.ts helper): re-select the target session inside each toPass() retry block instead of once before it, so a retry can't get stranded on the wrong session if foreground is reassigned asynchronously mid-test
- sessions.ts: sessions.start({ reuse: true }) could hand back a session whose websocket hadn't finished reconnecting after a prior test in the same file reloaded the window; wait for the session's icon status to leave disconnected/unknown before reading its metadata

### QA Notes
@:interpreter @:reticulate @:web @:win @:sessions