### PR TITLE
fix(ci): retry ext-host Remote invocations that die with a startup segfault

### DIFF
--- a/scripts/test-remote-integration.sh
+++ b/scripts/test-remote-integration.sh
@@ -80,55 +80,82 @@ API_TESTS_EXTRA_ARGS="$API_TESTS_EXTRA_ARGS --disable-gpu"
 echo "Storing crash reports into '$VSCODECRASHDIR'."
 echo "Storing log files into '$VSCODELOGSDIR'."
 
+# --- Start Positron ---
+# Headless Electron intermittently GP-faults on startup in libexpat while
+# fontconfig initializes fonts on a glib worker thread (a thread-safety race in
+# the system font libraries; crash stack: libexpat <- libfontconfig <-
+# libpangoft2). It happens before any test runs, exits 139 (SIGSEGV), and takes
+# the whole Remote suite down with it. The race lives in system libraries we
+# can't patch, so retry an invocation that dies with a startup segfault: a fresh
+# process is a new roll of the dice and succeeds nearly every time. Only exit
+# 139 is retried -- any other non-zero exit is a real test failure and is
+# returned immediately so it is never masked.
+run_integration_test() {
+	local attempt=1 max_attempts=3 status
+	while true; do
+		set +e
+		"$@"
+		status=$?
+		set -e
+		if [ "$status" -ne 139 ] || [ "$attempt" -ge "$max_attempts" ]; then
+			return "$status"
+		fi
+		echo "Electron exited 139 (startup segfault, likely fontconfig race); retrying (attempt $((attempt + 1))/$max_attempts)..."
+		kill_app
+		attempt=$((attempt + 1))
+	done
+}
+# --- End Positron ---
+
 
 # Tests in the extension host
 
 echo
 echo "### API tests (folder)"
 echo
-"$INTEGRATION_TEST_ELECTRON_PATH" --folder-uri=$REMOTE_VSCODE/vscode-api-tests/testWorkspace --extensionDevelopmentPath=$REMOTE_VSCODE/vscode-api-tests --extensionTestsPath=$REMOTE_VSCODE/vscode-api-tests/out/singlefolder-tests $API_TESTS_EXTRA_ARGS $EXTRA_INTEGRATION_TEST_ARGUMENTS
+run_integration_test "$INTEGRATION_TEST_ELECTRON_PATH" --folder-uri=$REMOTE_VSCODE/vscode-api-tests/testWorkspace --extensionDevelopmentPath=$REMOTE_VSCODE/vscode-api-tests --extensionTestsPath=$REMOTE_VSCODE/vscode-api-tests/out/singlefolder-tests $API_TESTS_EXTRA_ARGS $EXTRA_INTEGRATION_TEST_ARGUMENTS
 kill_app
 
 echo
 echo "### API tests (workspace)"
 echo
-"$INTEGRATION_TEST_ELECTRON_PATH" --file-uri=$REMOTE_VSCODE/vscode-api-tests/testworkspace.code-workspace --extensionDevelopmentPath=$REMOTE_VSCODE/vscode-api-tests --extensionTestsPath=$REMOTE_VSCODE/vscode-api-tests/out/workspace-tests $API_TESTS_EXTRA_ARGS $EXTRA_INTEGRATION_TEST_ARGUMENTS
+run_integration_test "$INTEGRATION_TEST_ELECTRON_PATH" --file-uri=$REMOTE_VSCODE/vscode-api-tests/testworkspace.code-workspace --extensionDevelopmentPath=$REMOTE_VSCODE/vscode-api-tests --extensionTestsPath=$REMOTE_VSCODE/vscode-api-tests/out/workspace-tests $API_TESTS_EXTRA_ARGS $EXTRA_INTEGRATION_TEST_ARGUMENTS
 kill_app
 
 echo
 echo "### TypeScript tests"
 echo
-"$INTEGRATION_TEST_ELECTRON_PATH" --folder-uri=$REMOTE_VSCODE/typescript-language-features/test-workspace --extensionDevelopmentPath=$REMOTE_VSCODE/typescript-language-features --extensionTestsPath=$REMOTE_VSCODE/typescript-language-features/out/test/unit $API_TESTS_EXTRA_ARGS $EXTRA_INTEGRATION_TEST_ARGUMENTS
+run_integration_test "$INTEGRATION_TEST_ELECTRON_PATH" --folder-uri=$REMOTE_VSCODE/typescript-language-features/test-workspace --extensionDevelopmentPath=$REMOTE_VSCODE/typescript-language-features --extensionTestsPath=$REMOTE_VSCODE/typescript-language-features/out/test/unit $API_TESTS_EXTRA_ARGS $EXTRA_INTEGRATION_TEST_ARGUMENTS
 kill_app
 
 echo
 echo "### Markdown tests"
 echo
-"$INTEGRATION_TEST_ELECTRON_PATH" --folder-uri=$REMOTE_VSCODE/markdown-language-features/test-workspace --extensionDevelopmentPath=$REMOTE_VSCODE/markdown-language-features --extensionTestsPath=$REMOTE_VSCODE/markdown-language-features/out/test $API_TESTS_EXTRA_ARGS $EXTRA_INTEGRATION_TEST_ARGUMENTS
+run_integration_test "$INTEGRATION_TEST_ELECTRON_PATH" --folder-uri=$REMOTE_VSCODE/markdown-language-features/test-workspace --extensionDevelopmentPath=$REMOTE_VSCODE/markdown-language-features --extensionTestsPath=$REMOTE_VSCODE/markdown-language-features/out/test $API_TESTS_EXTRA_ARGS $EXTRA_INTEGRATION_TEST_ARGUMENTS
 kill_app
 
 echo
 echo "### Emmet tests"
 echo
-"$INTEGRATION_TEST_ELECTRON_PATH" --folder-uri=$REMOTE_VSCODE/emmet/test-workspace --extensionDevelopmentPath=$REMOTE_VSCODE/emmet --extensionTestsPath=$REMOTE_VSCODE/emmet/out/test $API_TESTS_EXTRA_ARGS $EXTRA_INTEGRATION_TEST_ARGUMENTS
+run_integration_test "$INTEGRATION_TEST_ELECTRON_PATH" --folder-uri=$REMOTE_VSCODE/emmet/test-workspace --extensionDevelopmentPath=$REMOTE_VSCODE/emmet --extensionTestsPath=$REMOTE_VSCODE/emmet/out/test $API_TESTS_EXTRA_ARGS $EXTRA_INTEGRATION_TEST_ARGUMENTS
 kill_app
 
 echo
 echo "### Git tests"
 echo
-"$INTEGRATION_TEST_ELECTRON_PATH" --folder-uri=$AUTHORITY$(mktemp -d 2>/dev/null) --extensionDevelopmentPath=$REMOTE_VSCODE/git --extensionTestsPath=$REMOTE_VSCODE/git/out/test $API_TESTS_EXTRA_ARGS $EXTRA_INTEGRATION_TEST_ARGUMENTS
+run_integration_test "$INTEGRATION_TEST_ELECTRON_PATH" --folder-uri=$AUTHORITY$(mktemp -d 2>/dev/null) --extensionDevelopmentPath=$REMOTE_VSCODE/git --extensionTestsPath=$REMOTE_VSCODE/git/out/test $API_TESTS_EXTRA_ARGS $EXTRA_INTEGRATION_TEST_ARGUMENTS
 kill_app
 
 echo
 echo "### Ipynb tests"
 echo
-"$INTEGRATION_TEST_ELECTRON_PATH" --folder-uri=$AUTHORITY$(mktemp -d 2>/dev/null) --extensionDevelopmentPath=$REMOTE_VSCODE/ipynb --extensionTestsPath=$REMOTE_VSCODE/ipynb/out/test $API_TESTS_EXTRA_ARGS $EXTRA_INTEGRATION_TEST_ARGUMENTS
+run_integration_test "$INTEGRATION_TEST_ELECTRON_PATH" --folder-uri=$AUTHORITY$(mktemp -d 2>/dev/null) --extensionDevelopmentPath=$REMOTE_VSCODE/ipynb --extensionTestsPath=$REMOTE_VSCODE/ipynb/out/test $API_TESTS_EXTRA_ARGS $EXTRA_INTEGRATION_TEST_ARGUMENTS
 kill_app
 
 echo
 echo "### Configuration editing tests"
 echo
-"$INTEGRATION_TEST_ELECTRON_PATH" --folder-uri=$AUTHORITY$(mktemp -d 2>/dev/null) --extensionDevelopmentPath=$REMOTE_VSCODE/configuration-editing --extensionTestsPath=$REMOTE_VSCODE/configuration-editing/out/test $API_TESTS_EXTRA_ARGS $EXTRA_INTEGRATION_TEST_ARGUMENTS
+run_integration_test "$INTEGRATION_TEST_ELECTRON_PATH" --folder-uri=$AUTHORITY$(mktemp -d 2>/dev/null) --extensionDevelopmentPath=$REMOTE_VSCODE/configuration-editing --extensionTestsPath=$REMOTE_VSCODE/configuration-editing/out/test $API_TESTS_EXTRA_ARGS $EXTRA_INTEGRATION_TEST_ARGUMENTS
 kill_app
 
 # Cleanup

--- a/scripts/test-remote-integration.sh
+++ b/scripts/test-remote-integration.sh
@@ -68,13 +68,17 @@ fi
 API_TESTS_EXTRA_ARGS="--no-sandbox --disable-telemetry --disable-experiments --skip-welcome --skip-release-notes --crash-reporter-directory=$VSCODECRASHDIR --logsPath=$VSCODELOGSDIR --no-cached-data --disable-updates --use-inmemory-secretstorage --disable-workspace-trust --user-data-dir=$VSCODEUSERDATADIR"
 
 # --- Start Positron ---
-# Each test workspace below cold-starts a fresh Electron. On the headless CI
-# image the GPU process's multithreaded fontconfig init intermittently
-# GP-faults in libexpat during font config load (stack: libexpat <-
-# libfontconfig <- libpangoft2), crashing the whole run with exit 139. This is
-# the dominant ext-host CI flake. Disabling the GPU process removes that font
-# init path; these tests are headless and don't exercise GPU rendering.
-API_TESTS_EXTRA_ARGS="$API_TESTS_EXTRA_ARGS --disable-gpu"
+# Match the headless software-GL flags the e2e harness passes in docker (see
+# test/e2e/infra/playwrightElectron.ts). Each test workspace below cold-starts a
+# fresh Electron, and on the headless CI image the render/GPU stack's startup
+# intermittently trips a thread-safety race in fontconfig, GP-faulting in
+# libexpat (stack: libexpat <- libfontconfig <- libpangoft2) and crashing the
+# run with exit 139. Forcing software GL via swiftshader makes the ext-host
+# Electron start up the same way e2e's does (which does not hit this), shrinking
+# the race window. Passed unconditionally rather than gated on docker: almost
+# nobody runs the ext-host tests locally, and forcing software GL for a headless
+# test run is harmless. The retry below is the actual safety net.
+API_TESTS_EXTRA_ARGS="$API_TESTS_EXTRA_ARGS --disable-dev-shm-usage --use-gl=swiftshader --enable-unsafe-swiftshader --disable-gpu-compositing"
 # --- End Positron ---
 
 echo "Storing crash reports into '$VSCODECRASHDIR'."


### PR DESCRIPTION
## Background

Follow-up to #14931 (font-stack hardening + GPU flag). That cut the ext-host `libexpat`/fontconfig crash rate substantially - from ~5-of-6 ext-host failures to occasional - but did **not** eliminate it (e.g. PR #14945's ext-host run still crashed on the hardened image).

## Root cause (refined)

The crashing PID is the **main Electron process**, dying on a **glib worker thread** during fontconfig init:

```
#21 libpangoft2   <- pango font init
#22 libglib-2.0   <- glib worker thread
#23/#24 libc      <- thread start
```

A **thread-safety race in the system font libraries** (fontconfig/pango), not the GPU process. It fires on Electron cold start, **before any test runs**, exits 139, and takes the whole Remote suite down.

## Why e2e never hits this (and ext-host did)

Two differences, both addressed here:

1. **e2e retries once in CI (`retries: process.env.CI ? 1 : 0`), ext-host retried zero times.** When e2e's Electron hits the same crash, Playwright retries and it passes - the flake is invisible. ext-host had no retry, so one segfault killed everything.
2. **e2e launches Electron in docker with a fuller software-GL flag set** (`test/e2e/infra/playwrightElectron.ts`) that ext-host's Remote launch lacked.

## Changes (both in `scripts/test-remote-integration.sh`)

1. **Retry wrapper** - each Electron invocation is retried **only on exit 139 (SIGSEGV)**, up to 3 attempts. A fresh process is a new roll of the dice and succeeds nearly every time. Any other non-zero exit is a genuine test failure and returns immediately, so real regressions are never masked. Brings ext-host in line with the retry resilience e2e already has.
2. **Flag alignment** - replace the earlier `--disable-gpu` with e2e's docker set: `--disable-dev-shm-usage --use-gl=swiftshader --enable-unsafe-swiftshader --disable-gpu-compositing`, so both Electron paths start up identically. Reduces how often the retry has to fire. Passed unconditionally (not gated on docker) since ext-host tests are essentially never run locally.

## Testing

Script-only change; no image rebuild needed. Validated by dispatching the ext-host workflow multiple times on this branch. The retry log line (`Electron exited 139 ... retrying`) confirms the wrapper engages when the race fires, and the run then completes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
