### PR TITLE
fix(e2e): make verifyGitStatus robust to terminal viewport scrolling

### DIFF
--- a/test/e2e/tests/new-folder-flow/helpers/new-folder-flow.ts
+++ b/test/e2e/tests/new-folder-flow/helpers/new-folder-flow.ts
@@ -42,10 +42,15 @@ export async function verifyGitFilesArePresent(app: Application) {
 
 export async function verifyGitStatus(app: Application) {
 	await test.step('Verify git status', async () => {
-		// Git status should show that we're on the main branch
+		// Verify the repo is on the main branch. Use `git branch --show-current`
+		// (prints just "main") rather than `git status`: the multi-line status
+		// header pushes "On branch main" out of the visible xterm viewport on
+		// short terminals, and waitForTerminalText only reads the rendered
+		// viewport rows, so the assertion flakes (seen on debian web). A single
+		// line of output can't scroll off.
 		await app.workbench.terminal.createTerminal();
-		await app.workbench.terminal.runCommandInTerminal('git status');
-		await app.workbench.terminal.waitForTerminalText('On branch main');
+		await app.workbench.terminal.runCommandInTerminal('git branch --show-current');
+		await app.workbench.terminal.waitForTerminalText('main');
 	});
 }
 


### PR DESCRIPTION
The new-folder-flow git-init tests flaked on the debian-web CI lane. `verifyGitStatus` asserted on "On branch main" from `git status`, but that header line scrolled one row above the visible xterm viewport on short terminals. `waitForTerminalText` only reads the rendered viewport rows via `textContent()`, so the match timed out (`received undefined`).

The trace confirmed the branch was always `main` and git printed the line correctly -- it was purely a viewport-clipping artifact, not a git-default-branch difference or a folder-flow regression. This asserts on `git branch --show-current` instead, which emits a single `main` line that cannot scroll out of view.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A (test-only change)

### Validation Steps

@:new-folder-flow @:debian-web

Run the new-folder-flow suite (Python git-init test and empty-folder git test both exercise `verifyGitStatus`). Confirm the git-status verification passes on the debian-web lane, where it previously flaked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)