### PR TITLE
Add support for versions for Posit Connect pins

### DIFF
--- a/extensions/positron-data-driver-pins/src/connectClient.ts
+++ b/extensions/positron-data-driver-pins/src/connectClient.ts
@@ -34,6 +34,21 @@ export interface PinInfo {
 	activeBundleId: string;
 }
 
+/**
+ * A single version (bundle) of a pin, as returned by the bundles endpoint. The `id` doubles as the
+ * `_rev<id>` segment used to read a specific version's files.
+ */
+export interface BundleInfo {
+	/** The bundle id, as a string. Also the `_rev<id>` segment in the version's file URLs. */
+	id: string;
+	/** The bundle creation timestamp, as an ISO 8601 string (e.g. "2024-01-15T09:30:00Z"). */
+	createdTime: string;
+	/** Whether this bundle is the pin's active (currently served) version. */
+	active: boolean;
+	/** The bundle size in bytes, when recorded. */
+	size?: number;
+}
+
 /** The subset of the server settings response this driver reads. */
 export interface ServerSettings {
 	/** The Connect server version, e.g. "2024.01.0". */
@@ -59,6 +74,14 @@ interface RawApplication {
 /** The applications endpoint response envelope. */
 interface RawApplicationsResponse {
 	applications?: RawApplication[];
+}
+
+/** The shape of a single item in the content bundles endpoint response. */
+interface RawBundle {
+	id?: string | number;
+	created_time?: string;
+	active?: boolean;
+	size?: number;
 }
 
 /**
@@ -159,6 +182,29 @@ export class ConnectClient {
 				description: app.description ?? '',
 				activeBundleId: app.bundle_id !== undefined ? String(app.bundle_id) : '',
 			}));
+	}
+
+	/**
+	 * Lists a pin's versions (bundles) via the documented content bundles endpoint, newest first.
+	 * Each version's `id` is also the `_rev<id>` segment used to read that version's files.
+	 *
+	 * @param guid The pin's content GUID.
+	 */
+	async listBundles(guid: string): Promise<BundleInfo[]> {
+		const json = await this._getJson<RawBundle[]>(this._apiUrl(`v1/content/${encodeURIComponent(guid)}/bundles`));
+		const bundles = Array.isArray(json) ? json : [];
+		this._logger.info(`Found ${bundles.length} version(s) for pin ${guid}`);
+		return bundles
+			.filter((bundle): bundle is RawBundle & { id: string | number } => bundle.id !== undefined)
+			.map(bundle => ({
+				id: String(bundle.id),
+				createdTime: typeof bundle.created_time === 'string' ? bundle.created_time : '',
+				active: bundle.active === true,
+				size: typeof bundle.size === 'number' ? bundle.size : undefined,
+			}))
+			// Newest first. ISO 8601 timestamps sort lexicographically in chronological order; ties
+			// (or missing timestamps) fall back to the numerically larger (newer) bundle id.
+			.sort((a, b) => b.createdTime.localeCompare(a.createdTime) || Number(b.id) - Number(a.id));
 	}
 
 	/**

--- a/extensions/positron-data-driver-pins/src/connectClient.ts
+++ b/extensions/positron-data-driver-pins/src/connectClient.ts
@@ -195,7 +195,7 @@ export class ConnectClient {
 		const bundles = Array.isArray(json) ? json : [];
 		this._logger.info(`Found ${bundles.length} version(s) for pin ${guid}`);
 		return bundles
-			.filter((bundle): bundle is RawBundle & { id: string | number } => bundle.id !== undefined)
+			.filter((bundle): bundle is RawBundle & { id: string | number } => bundle.id !== undefined && bundle.id !== null)
 			.map(bundle => ({
 				id: String(bundle.id),
 				createdTime: typeof bundle.created_time === 'string' ? bundle.created_time : '',

--- a/extensions/positron-data-driver-pins/src/pinsConnection.ts
+++ b/extensions/positron-data-driver-pins/src/pinsConnection.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as positron from 'positron';
-import { ConnectClient, PinInfo } from './connectClient.js';
+import { BundleInfo, ConnectClient, PinInfo } from './connectClient.js';
 import { Logger, NULL_LOGGER } from './logging.js';
 import { createOwnerNode, IPinsBrowseHost } from './pinsNodes.js';
 
@@ -82,6 +82,15 @@ export class PinsConnection implements positron.DataConnection, IPinsBrowseHost 
 			this._typeCache.delete(pin.guid);
 			return undefined;
 		}
+	}
+
+	/**
+	 * Lists a pin's versions (bundles), newest first, when a pin node is expanded. Fetched fresh each
+	 * time (not cached): it is a single request, and a live fetch surfaces newly published versions.
+	 */
+	async getBundles(pin: PinInfo): Promise<BundleInfo[]> {
+		this._ensureConnected();
+		return this._client.listBundles(pin.guid);
 	}
 
 	/** Marks the connection disconnected and drops cached state. No socket to close. */

--- a/extensions/positron-data-driver-pins/src/pinsDriver.ts
+++ b/extensions/positron-data-driver-pins/src/pinsDriver.ts
@@ -33,7 +33,9 @@ function escapeDoubleQuoted(value: string): string {
 }
 
 /**
- * Generates the R connection code variants. The default variant relies on the CONNECT_SERVER and
+ * Generates the R connection code variants. The generated code operates at the connection (board)
+ * level, listing the board's pins; reading an individual pin is a per-pin operation, not something
+ * this connection-level code represents. The default variant relies on the CONNECT_SERVER and
  * CONNECT_API_KEY environment variables (matching `board_connect()` defaults). The explicit-server
  * variant names the server from the profile and reads the key from the environment, unless the key
  * was included via the Include Secrets flow, in which case it is embedded inline.
@@ -43,7 +45,7 @@ function generateRCode(serverUrl: string | undefined, apiKey: string | undefined
 		{
 			id: 'envvar',
 			label: vscode.l10n.t('Environment Variables'),
-			code: `library(pins)\nboard <- board_connect()\npin_list(board)\n# pin_read(board, "owner/name")\n`,
+			code: `library(pins)\nboard <- board_connect()\npin_list(board)\n`,
 		},
 	];
 	if (serverUrl) {
@@ -53,23 +55,25 @@ function generateRCode(serverUrl: string | undefined, apiKey: string | undefined
 		variants.push({
 			id: 'explicitServer',
 			label: vscode.l10n.t('Explicit Server'),
-			code: `library(pins)\nboard <- board_connect(\n\tserver = "${escapeDoubleQuoted(serverUrl)}",\n\t${keyArg}\n)\npin_list(board)\n# pin_read(board, "owner/name")\n`,
+			code: `library(pins)\nboard <- board_connect(\n\tserver = "${escapeDoubleQuoted(serverUrl)}",\n\t${keyArg}\n)\npin_list(board)\n`,
 		});
 	}
 	return variants;
 }
 
 /**
- * Generates the Python connection code variants, mirroring {@link generateRCode}. The default
- * variant relies on the CONNECT_SERVER and CONNECT_API_KEY environment variables; the
- * explicit-server variant names the server and, when secrets are included, embeds the key.
+ * Generates the Python connection code variants, mirroring {@link generateRCode}. The generated
+ * code lists the board's pins (a connection-level operation); reading an individual pin is per-pin
+ * and not represented here. The default variant relies on the CONNECT_SERVER and CONNECT_API_KEY
+ * environment variables; the explicit-server variant names the server and, when secrets are
+ * included, embeds the key.
  */
 function generatePythonCode(serverUrl: string | undefined, apiKey: string | undefined): positron.ConnectionCodeVariant[] {
 	const variants: positron.ConnectionCodeVariant[] = [
 		{
 			id: 'envvar',
 			label: vscode.l10n.t('Environment Variables'),
-			code: `import pins\nboard = pins.board_connect()\nboard.pin_list()\n# board.pin_read("owner/name")\n`,
+			code: `import pins\nboard = pins.board_connect()\nboard.pin_list()\n`,
 		},
 	];
 	if (serverUrl) {
@@ -79,7 +83,7 @@ function generatePythonCode(serverUrl: string | undefined, apiKey: string | unde
 		variants.push({
 			id: 'explicitServer',
 			label: vscode.l10n.t('Explicit Server'),
-			code: `import pins\nboard = pins.board_connect(server_url="${escapeDoubleQuoted(serverUrl)}"${keyArg})\nboard.pin_list()\n# board.pin_read("owner/name")\n`,
+			code: `import pins\nboard = pins.board_connect(server_url="${escapeDoubleQuoted(serverUrl)}"${keyArg})\nboard.pin_list()\n`,
 		});
 	}
 	return variants;

--- a/extensions/positron-data-driver-pins/src/pinsNodes.ts
+++ b/extensions/positron-data-driver-pins/src/pinsNodes.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as positron from 'positron';
-import { PinInfo } from './connectClient.js';
+import { BundleInfo, PinInfo } from './connectClient.js';
 
 /**
  * The maximum number of `data.txt` requests made in parallel when resolving the type badges for an
@@ -24,6 +24,9 @@ export interface IPinsBrowseHost {
 	 * than failing the whole owner expansion.
 	 */
 	getPinType(pin: PinInfo): Promise<string | undefined>;
+
+	/** Lists a pin's versions (bundles), newest first, when the pin node is expanded. */
+	getBundles(pin: PinInfo): Promise<BundleInfo[]>;
 }
 
 /**
@@ -61,23 +64,58 @@ export function createOwnerNode(host: IPinsBrowseHost, ownerUsername: string, pi
 		async getChildren() {
 			const sorted = [...pins].sort((a, b) => a.name.localeCompare(b.name));
 			const types = await mapWithConcurrency(sorted, MAX_METADATA_CONCURRENCY, pin => host.getPinType(pin));
-			return sorted.map((pin, index) => createPinNode(pin, types[index]));
+			return sorted.map((pin, index) => createPinNode(host, pin, types[index]));
 		},
 	};
 }
 
 /**
- * Creates a pin node. In PR 1 pins are leaves: no children and no preview (previewing tabular pins
- * in the Data Explorer comes in a later PR). The type badge shows the pin's storage format when
- * known.
+ * Creates a pin node. Expanding it lists the pin's versions (bundles), newest first; previewing a
+ * version's data in the Data Explorer comes in a later PR. The type badge shows the pin's storage
+ * format when known.
  *
+ * @param host The browse host used to list the pin's versions on expansion.
  * @param pin The pin.
  * @param type The pin's storage type for the badge, or undefined when unknown.
  */
-export function createPinNode(pin: PinInfo, type: string | undefined): positron.DataConnectionNode {
+export function createPinNode(host: IPinsBrowseHost, pin: PinInfo, type: string | undefined): positron.DataConnectionNode {
 	return {
 		name: pin.name,
 		kind: positron.DataConnectionNodeKind.Pin,
 		dataType: type,
+		async getChildren() {
+			const bundles = await host.getBundles(pin);
+			return bundles.map(createVersionNode);
+		},
 	};
+}
+
+/**
+ * Creates a version node: one bundle of a pin. Versions are leaves for now (previewing a version's
+ * data comes in a later PR). The active (currently served) version is flagged with an "active"
+ * badge; the name pairs the creation time with the bundle id, e.g. "2024-01-15 09:30 (#421)".
+ *
+ * @param bundle The bundle (version).
+ */
+export function createVersionNode(bundle: BundleInfo): positron.DataConnectionNode {
+	const timestamp = formatBundleTimestamp(bundle.createdTime);
+	return {
+		name: timestamp ? `${timestamp} (#${bundle.id})` : `#${bundle.id}`,
+		kind: positron.DataConnectionNodeKind.Version,
+		dataType: bundle.active ? 'active' : undefined,
+	};
+}
+
+/**
+ * Formats a bundle's ISO 8601 creation timestamp as "YYYY-MM-DD HH:MM" in UTC, for stable,
+ * timezone-unambiguous version labels. Returns an empty string when the timestamp is missing or
+ * unparseable, so the caller can fall back to a bare bundle id.
+ */
+function formatBundleTimestamp(iso: string): string {
+	const date = new Date(iso);
+	if (iso === '' || isNaN(date.getTime())) {
+		return '';
+	}
+	const pad = (n: number) => String(n).padStart(2, '0');
+	return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())} ${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}`;
 }

--- a/extensions/positron-data-driver-pins/src/test/connectClient.test.ts
+++ b/extensions/positron-data-driver-pins/src/test/connectClient.test.ts
@@ -88,6 +88,22 @@ suite('ConnectClient', () => {
 		assert.ok(calls[0].url.includes('filter=content_type:pin'), calls[0].url);
 	});
 
+	test('listBundles parses the bundles response into BundleInfo, newest first', async () => {
+		const { fetch, calls } = recordingFetch(() => ({
+			// Returned out of order to confirm the client sorts newest first.
+			body: JSON.stringify([
+				{ id: 1, created_time: '2024-01-15T09:30:00Z', active: false, size: 100 },
+				{ id: 5, created_time: '2024-03-02T14:00:00Z', active: true, size: 200 },
+			]),
+		}));
+		const bundles = await new ConnectClient(SERVER, KEY, fetch).listBundles('g1');
+		assert.deepStrictEqual(bundles, [
+			{ id: '5', createdTime: '2024-03-02T14:00:00Z', active: true, size: 200 },
+			{ id: '1', createdTime: '2024-01-15T09:30:00Z', active: false, size: 100 },
+		]);
+		assert.strictEqual(calls[0].url, `${SERVER}/__api__/v1/content/g1/bundles`);
+	});
+
 	test('getPinMeta fetches data.txt from the content _rev path and parses it', async () => {
 		const { fetch, calls } = recordingFetch(() => ({
 			body: 'file: data.parquet\ntype: parquet\ntitle: Cars\napi_version: 1\n',

--- a/extensions/positron-data-driver-pins/src/test/pinsDriver.test.ts
+++ b/extensions/positron-data-driver-pins/src/test/pinsDriver.test.ts
@@ -95,8 +95,16 @@ suite('Pins Connection tree', () => {
 			{ guid: 'g-model', name: 'model', owner_username: 'tim', bundle_id: 9 },
 		],
 	});
+	// cars has two versions, returned out of order to confirm they are surfaced newest first.
+	const carsBundles = JSON.stringify([
+		{ id: 1, created_time: '2024-01-15T09:30:00Z', active: false, size: 100 },
+		{ id: 5, created_time: '2024-03-02T14:00:00Z', active: true, size: 200 },
+	]);
 	const routes = [
 		{ match: '/__api__/applications', body: applications },
+		// Bundles routes precede the data.txt routes: a bundles URL also contains the "/content/<guid>/"
+		// substring the data.txt routes match on, so the more specific bundles match must be found first.
+		{ match: '/v1/content/g-cars/bundles', body: carsBundles },
 		{ match: '/content/g-sales/', body: 'file: sales.csv\ntype: csv\napi_version: 1\n' },
 		{ match: '/content/g-cars/', body: 'file: cars.parquet\ntype: parquet\napi_version: 1\n' },
 		{ match: '/content/g-model/', body: 'file: model.joblib\ntype: joblib\napi_version: 1\n' },
@@ -112,7 +120,7 @@ suite('Pins Connection tree', () => {
 		owners.forEach(o => assert.strictEqual(o.kind, positron.DataConnectionNodeKind.Owner));
 	});
 
-	test('owner expands to pins sorted by name, badged with type, as leaves', async () => {
+	test('owner expands to pins sorted by name, badged with type, expandable but not previewable', async () => {
 		const [julia] = await connection().getChildren();
 		const pins = await julia.getChildren!();
 
@@ -120,10 +128,26 @@ suite('Pins Connection tree', () => {
 			{ name: 'cars', kind: positron.DataConnectionNodeKind.Pin, dataType: 'parquet' },
 			{ name: 'sales', kind: positron.DataConnectionNodeKind.Pin, dataType: 'csv' },
 		]);
-		// Pins are leaves in PR 1: no children, not previewable.
+		// Pins expand to versions but are not previewable (Data Explorer preview comes in a later PR).
 		pins.forEach(p => {
-			assert.strictEqual(p.getChildren, undefined);
+			assert.notStrictEqual(p.getChildren, undefined);
 			assert.strictEqual(p.preview, undefined);
+		});
+	});
+
+	test('pin expands to versions, newest first, with the active version badged, as leaves', async () => {
+		const [julia] = await connection().getChildren();
+		const cars = (await julia.getChildren!()).find(p => p.name === 'cars')!;
+		const versions = await cars.getChildren!();
+
+		assert.deepStrictEqual(versions.map(v => ({ name: v.name, kind: v.kind, dataType: v.dataType })), [
+			{ name: '2024-03-02 14:00 (#5)', kind: positron.DataConnectionNodeKind.Version, dataType: 'active' },
+			{ name: '2024-01-15 09:30 (#1)', kind: positron.DataConnectionNodeKind.Version, dataType: undefined },
+		]);
+		// Versions are leaves for now: no children, not previewable.
+		versions.forEach(v => {
+			assert.strictEqual(v.getChildren, undefined);
+			assert.strictEqual(v.preview, undefined);
 		});
 	});
 

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2274,6 +2274,8 @@ declare module 'positron' {
 		Owner = 'owner',
 		// A pin on a Posit Connect server (positron-data-driver-pins).
 		Pin = 'pin',
+		// A version (bundle) of a pin on a Posit Connect server (positron-data-driver-pins).
+		Version = 'version',
 	}
 
 	export interface DataConnectionNode {

--- a/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
+++ b/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
@@ -507,6 +507,8 @@ export enum DataConnectionNodeKind {
 	Owner = 'owner',
 	// A pin on a Posit Connect server (positron-data-driver-pins).
 	Pin = 'pin',
+	// A version (bundle) of a pin on a Posit Connect server (positron-data-driver-pins).
+	Version = 'version',
 }
 
 /**

--- a/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionNodeRow.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionNodeRow.tsx
@@ -66,6 +66,9 @@ const kindIcon = (dto: IDataConnectionNodeDTO): string => {
 		case 'pin':
 			return 'pinned';
 
+		case 'version':
+			return 'history';
+
 		case 'column':
 		case 'field':
 			return dto.isPrimaryKey ? 'positron-db-column-key' : 'positron-db-column';

--- a/test/e2e/pages/dataConnections.ts
+++ b/test/e2e/pages/dataConnections.ts
@@ -20,9 +20,17 @@ const DATA_CONNECTION_ENTRY_ROW = '.data-connection-entry-row';
 const TREE_ROW = '.positron-tree-row';
 const TREE_TWISTY_COLLAPSED = '.positron-tree-twisty-collapsed';
 
-// The virtualized grid that hosts the tree. It renders only the rows that fit in the viewport (no
-// overscan), so rows below the fold are absent from the DOM until scrolled into view.
-const TREE_WAFFLE = '#data-connection-profiles-list .data-grid-waffle';
+// The container that hosts the connection tree, and the virtualized grid inside it. The grid renders
+// only the rows that fit in the viewport (no overscan), so rows below the fold are absent from the
+// DOM until scrolled into view.
+const TREE_CONTAINER = '#data-connection-profiles-list';
+const TREE_WAFFLE = `${TREE_CONTAINER} .data-grid-waffle`;
+
+// Version (pin bundle) nodes render with the history codicon; the active bundle carries an "active"
+// type badge. Scoped to the tree container so the icon can't collide with history icons elsewhere in
+// the workbench.
+const VERSION_ROW = `${TREE_CONTAINER} ${TREE_ROW}:has(.codicon-history)`;
+const NODE_TYPE_BADGE = '.data-connection-node-type';
 
 /**
  * Reusable Positron Data Connections panel functionality for tests to leverage.
@@ -149,11 +157,11 @@ export class DataConnections {
 	 */
 	private async expandRow(row: Locator, label: string): Promise<void> {
 		await test.step(`Expand node: ${label}`, async () => {
-			// Every node expanded by this test lives near the top of the tree, so scrolling to the
-			// top guarantees the target is within the (overscan-free) rendered range, even if a
-			// prior verification step scrolled the grid down. toBeVisible then waits for the row to
-			// finish loading after its parent expanded.
-			await this.scrollToTop();
+			// Reveal the row so it is rendered before interacting with it: the grid renders no
+			// overscan, so a row below the fold is absent from the DOM (and a prior step may have
+			// scrolled the grid). revealNode scrolls it into the rendered range; toBeVisible then
+			// waits for the row to finish loading after its parent expanded.
+			await this.revealNode(row);
 			await expect(row).toBeVisible();
 
 			const collapsedTwisty = row.locator(TREE_TWISTY_COLLAPSED);
@@ -245,6 +253,30 @@ export class DataConnections {
 		const row = this.treeRow(name);
 		await this.revealNode(row);
 		await expect(row).toBeVisible();
-		await expect(row.locator('.data-connection-node-type')).toHaveText(dataType);
+		await expect(row.locator(NODE_TYPE_BADGE)).toHaveText(dataType);
+	}
+
+	/**
+	 * Asserts the number of version (pin bundle) nodes currently shown in the tree. Use after
+	 * expanding a single pin so the count reflects that pin's versions. Version node labels are
+	 * dynamic (creation time + bundle id), so tests key off the count and the active badge rather
+	 * than exact names.
+	 * @param count The expected number of version nodes.
+	 */
+	async expectVersionCount(count: number): Promise<void> {
+		await expect(this.code.driver.currentPage.locator(VERSION_ROW)).toHaveCount(count);
+	}
+
+	/**
+	 * Asserts that a version node badged "active" is visible: the pin's currently served bundle. This
+	 * is the deterministic anchor on version nodes (their names carry a dynamic timestamp/bundle id),
+	 * so it works against a real server where the version count is unknown. Reveals the row first, as
+	 * an expanded pin's versions can sit below the fold.
+	 */
+	async expectActiveVersionVisible(): Promise<void> {
+		const activeVersion = this.code.driver.currentPage.locator(VERSION_ROW)
+			.filter({ has: this.code.driver.currentPage.locator(NODE_TYPE_BADGE, { hasText: 'active' }) });
+		await this.revealNode(activeVersion);
+		await expect(activeVersion).toBeVisible();
 	}
 }

--- a/test/e2e/pages/dataConnections.ts
+++ b/test/e2e/pages/dataConnections.ts
@@ -260,11 +260,14 @@ export class DataConnections {
 	 * Asserts the number of version (pin bundle) nodes currently shown in the tree. Use after
 	 * expanding a single pin so the count reflects that pin's versions. Version node labels are
 	 * dynamic (creation time + bundle id), so tests key off the count and the active badge rather
-	 * than exact names.
+	 * than exact names. Reveals a version row first so the count isn't taken while the expanded
+	 * pin's versions are still below the virtualized fold.
 	 * @param count The expected number of version nodes.
 	 */
 	async expectVersionCount(count: number): Promise<void> {
-		await expect(this.code.driver.currentPage.locator(VERSION_ROW)).toHaveCount(count);
+		const versionRows = this.code.driver.currentPage.locator(VERSION_ROW);
+		await this.revealNode(versionRows.first());
+		await expect(versionRows).toHaveCount(count);
 	}
 
 	/**

--- a/test/e2e/test-files/workspaces/connect-pins-r/publish-pins.R
+++ b/test/e2e/test-files/workspaces/connect-pins-r/publish-pins.R
@@ -45,6 +45,11 @@ for (pin in pins_to_publish) {
 	cat("Published pin:", pin$name, "\n")
 }
 
+# Publish a second version of one pin (board_connect() is versioned by default), so the
+# tree shows multiple version nodes and the newest write becomes the active version.
+pin_write(board, head(mtcars, 8), name = "e2e-mtcars", type = "rds")
+cat("Published second version of pin: e2e-mtcars\n")
+
 # --- Query -----------------------------------------------------------------
 # Read each pin back and log its table contents to the console.
 for (pin in pins_to_publish) {

--- a/test/e2e/tests/connect/pins-data-connection.test.ts
+++ b/test/e2e/tests/connect/pins-data-connection.test.ts
@@ -17,6 +17,10 @@ const connectionName = 'e2e Connect Pins';
 // their pins alphabetically).
 const seededPins = ['e2e-iris', 'e2e-mtcars'];
 
+// The seed script publishes this pin twice, so it has two version nodes (the newest is the active
+// bundle). e2e-iris is published once and is left collapsed.
+const versionedPin = 'e2e-mtcars';
+
 // The Connect API key resolved in beforeAll and used both to seed pins (via the R session) and to
 // configure the Data Connections driver.
 let connectApiKey: string;
@@ -78,6 +82,13 @@ test.describe('Data Connections - Posit Connect Pins', { tag: [tags.WORKBENCH, t
 			for (const pin of seededPins) {
 				await dataConnections.expectNodeVisible(pin);
 			}
+		});
+
+		await test.step('Expand a pin and verify its version nodes, with the active bundle badged', async () => {
+			await dataConnections.expandNode(versionedPin);
+			// The pin was published twice, so it has two versions; the newest is the active bundle.
+			await dataConnections.expectVersionCount(2);
+			await dataConnections.expectActiveVersionVisible();
 		});
 	});
 });

--- a/test/e2e/tests/data-connections/pins-remote.test.ts
+++ b/test/e2e/tests/data-connections/pins-remote.test.ts
@@ -55,5 +55,12 @@ test.describe('Data Connections - Posit Connect Pins (remote)', { tag: [tags.CON
 			await dataConnections.expandNode(ownerUsername);
 			await dataConnections.expectNodeVisible(pinName);
 		});
+
+		await test.step(`Expand ${pinName} and verify its active version`, async () => {
+			// Any real pin has exactly one active bundle, so the "active" version node is the stable
+			// anchor here (the real version count is unknown and each version's label is dynamic).
+			await dataConnections.expandNode(pinName);
+			await dataConnections.expectActiveVersionVisible();
+		});
 	});
 });


### PR DESCRIPTION
This is the second PR in the Posit Connect pins data connection driver series, following #14874. It adds a third level to the connection tree so each pin now expands to its **versions** (Connect bundles), listed newest first, with the currently served bundle marked "active":

<img width="1451" height="999" alt="Screenshot_2026-07-17_at_10_57_08 AM" src="https://github.com/user-attachments/assets/974cb71d-7d72-40eb-bdf8-0853512205eb" />

Version nodes are leaves for now; previewing a version's data in the Data Explorer comes in a later PR.

Details:

- `ConnectClient.listBundles(guid)` calls the documented `GET /__api__/v1/content/<guid>/bundles` endpoint (fields `id`, `created_time`, `active`, `size`), matching what the pins R package's `pin_versions()` reads. Results are sorted newest first and fetched fresh on each expand (not cached), so newly published versions show up.
- A new `DataConnectionNodeKind.Version` (mirrored in `positron.d.ts` and the extension-host types) renders with the `history` icon. Version labels pair the creation time with the bundle id, e.g. `2024-01-15 09:30 (#5)`.
- I also decided to change the connection-level generated code to now emit only `pin_list` (R `pin_list(board)`, Python `board.pin_list()`). The previous `# pin_read("owner/name")` hint was removed. I think reading a specific pin is a per-pin operation, and connection-level code generation has no per-node context to fill in.

Addresses part of #14663.

### Release Notes

#### New Features

- Posit Connect pins data connections now show each pin's versions in the tree, with the active version marked (#14663)

#### Bug Fixes

- N/A

### Validation Steps

Automated e2e coverage: `@:connect` `@:connections` `@:workbench`

Manual verification (which anyone here at Posit can do against <https://pub.demo.posit.team/> with a real API key):

1. Ensure a Connect server has at least one pin. Anyone at Posit can use <https://pub.demo.posit.team/> and see pins that are shared with everyone there.
2. Create an API key in Connect (profile menu, "Manage Your API Keys", "New API Key").
3. In Positron, set `dataConnections.enabled: true` and reload. Open the Data Connections pane, click Add Connection, choose "Posit Connect Pins".
4. Enter the server URL (a bare host such as `pub.demo.posit.team` works; it defaults to https) and the API key, then Save.
3. Expand the connection, then an owner, then a pin. Confirm the pin expands to one node per version, newest first, with the active version showing an "active" badge.
