### PR TITLE
fix: Import Settings preview race that clobbers conflict markers

### DIFF
--- a/src/vs/workbench/contrib/positronWelcome/browser/actions.ts
+++ b/src/vs/workbench/contrib/positronWelcome/browser/actions.ts
@@ -6,6 +6,7 @@
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { isWeb } from '../../../../base/common/platform.js';
 import { ServicesAccessor } from '../../../../editor/browser/editorExtensions.js';
+import { ITextModelService } from '../../../../editor/common/services/resolverService.js';
 import { localize } from '../../../../nls.js';
 import { Action2 } from '../../../../platform/actions/common/actions.js';
 import { ConfigurationTarget } from '../../../../platform/configuration/common/configuration.js';
@@ -52,6 +53,7 @@ export class PositronImportSettings extends Action2 {
 		const prefService = accessor.get(IPreferencesService);
 		const fileService = accessor.get(IFileService);
 		const editorService = accessor.get(IEditorService);
+		const textModelService = accessor.get(ITextModelService);
 		const notificationService = accessor.get(INotificationService);
 		const loggingService = accessor.get(ILogService);
 		const terminalService = accessor.get(ITerminalService);
@@ -90,17 +92,23 @@ export class PositronImportSettings extends Action2 {
 		});
 
 		const editor = editorService.activeEditor;
-		const model = editorService.activeTextEditorControl?.getModel();
 		if (editor) {
 			disposables.add(
 				fileConfigurationService.disableAutoSave(editor)
 			);
 		}
 
-		if (model && 'setValue' in model) {
-			model.setLanguage('jsonl');
-			model.setValue('// Settings imported from Visual Studio Code\n' + mergedSettings);
-		}
+		// Resolve the settings model fully before writing the imported preview.
+		// openEditor() returns once the editor is shown, but the file-backed model
+		// resolves its on-disk contents asynchronously; writing before that settles
+		// lets the late resolve overwrite the preview (the conflict markers flash in,
+		// then get clobbered). Awaiting the model reference guarantees the initial
+		// resolve is done, and setValue then dirties the model so no reload follows.
+		const modelRef = await textModelService.createModelReference(positronSettingsPath);
+		disposables.add(modelRef);
+		const model = modelRef.object.textEditorModel;
+		model.setLanguage('jsonl');
+		model.setValue('// Settings imported from Visual Studio Code\n' + mergedSettings);
 
 		const notification = notificationService.prompt(
 			Severity.Info,


### PR DESCRIPTION
Fixes a race in the Import VS Code Settings command where the imported conflict-marker preview could be overwritten by the settings file model finishing its async on-disk resolve, leaving a marker-free file. This surfaced as a flaky e2e (the diff assertion saw `<<<<<<< Existing` appear, then vanish before it ran). Latent race in existing feature code; no behavior change.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed an intermittent issue where the Import VS Code Settings preview could lose its conflict markers before they could be reviewed.

### Validation Steps

@:vscode-settings @:web @:win

1. Create a VS Code `settings.json` with a value that conflicts with your Positron settings.
2. Run "Import VS Code Settings" and verify the diff preview reliably shows `<<<<<<<`/`>>>>>>>` conflict markers.
3. Accept the changes and confirm the imported settings are saved correctly.

### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- async race in the settings model likely caused the failure.</summary>

- **Spec:** `test/e2e/tests/import-vs-code-settings/import-vscode-settings.test.ts`
  - **Test:** `Verify diff displays and accepted settings are saved`
- **Signal:** trace shows the `<<<<<<<` conflict markers render immediately after import, then disappear before the assertion's `toBeVisible()` check runs -- appear-then-vanish, not a render failure
- **Frequency:** 5/313 runs (1.6%), ubuntu/electron
- **Hypothesis:** async on-disk settings-model resolve overwrote the freshly-written conflict-marker preview before the assertion ran

</details>