### PR TITLE
e2e: restore selectMetadataOption fix accidentally reverted in #14896

### DIFF
--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -252,7 +252,10 @@ export class Sessions {
 	 */
 	async selectMetadataOption(menuItem: 'Show Kernel Output Channel' | 'Show Supervisor Output Channel' | 'Show LSP Output Channel') {
 		await this.console.focus();
-		await this.metadataButton.click();
+		// Use openMetadataDialog() instead of a raw button click: the button's
+		// click handler reads the active console session from React context,
+		// which can lag a just-fired focus change and silently no-op.
+		await this.openMetadataDialog();
 		await this.metadataDialog.getByText(menuItem).click();
 
 		await expect(this.page.getByRole('tab', { name: 'Output' })).toHaveClass(/.*checked.*/);


### PR DESCRIPTION
### Summary
A stale revert commit carried over during a rebase of #14896 and undid the flaky-click fix in `selectMetadataOption`, regressing `sessions.ts`.
- Restores `openMetadataDialog()` call (was reverted back to a raw `metadataButton.click()`)
- No other changes

### QA Notes
No test tags needed; restores prior fixed behavior exactly.