### PR TITLE
Add schema-summarization helper for Data Connections

### DIFF
--- a/src/vs/workbench/contrib/positronDataConnections/browser/positronDataConnections.contribution.ts
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/positronDataConnections.contribution.ts
@@ -6,6 +6,7 @@
 import { localize } from '../../../../nls.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { PositronDataViewPane } from './positronDataConnectionsView.js';
+import './positronDataConnectionsDebugActions.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { registerIcon } from '../../../../platform/theme/common/iconRegistry.js';
 import { ViewPaneContainer } from '../../../browser/parts/views/viewPaneContainer.js';

--- a/src/vs/workbench/contrib/positronDataConnections/browser/positronDataConnectionsDebugActions.ts
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/positronDataConnectionsDebugActions.ts
@@ -1,0 +1,82 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize, localize2 } from '../../../../nls.js';
+import { IUntitledTextResourceEditorInput } from '../../../common/editor.js';
+import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';
+import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { IsDevelopmentContext } from '../../../../platform/contextkey/common/contextkeys.js';
+import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { INotificationService } from '../../../../platform/notification/common/notification.js';
+import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
+import { IDataConnectionInstance } from '../../../services/positronDataConnections/common/interfaces/dataConnectionInstance.js';
+import { summarizeDataConnectionSchema } from '../../../services/positronDataConnections/common/dataConnectionSchemaSummary.js';
+import { IPositronDataConnectionsService } from '../../../services/positronDataConnections/common/interfaces/positronDataConnectionsService.js';
+
+interface IDataConnectionInstancePickItem extends IQuickPickItem {
+	instance: IDataConnectionInstance;
+}
+
+/**
+ * Developer-only Command Palette entry that runs summarizeDataConnectionSchema() against a live
+ * data connection instance and opens the resulting JSON in a new untitled editor. Manual testing
+ * aid for the schema-summarization helper (see #14926) while no product feature calls it yet;
+ * not consumed by Assistant or any other production code path.
+ */
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'positronDataConnections.debugSummarizeSchema',
+			title: localize2('positron.dataConnections.debugSummarizeSchema', 'Summarize Data Connection Schema (Debug)'),
+			category: Categories.Developer,
+			f1: true,
+			precondition: IsDevelopmentContext, // hide this from release builds -- manual testing aid only
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const dataConnectionsService = accessor.get(IPositronDataConnectionsService);
+		const quickInputService = accessor.get(IQuickInputService);
+		const notificationService = accessor.get(INotificationService);
+		const editorService = accessor.get(IEditorService);
+
+		const instances = dataConnectionsService.getInstances();
+		if (instances.length === 0) {
+			notificationService.info(localize(
+				'positron.dataConnections.debugSummarizeSchema.noInstances',
+				"No active data connections. Connect to one from the Data Connections panel first."
+			));
+			return;
+		}
+
+		let instance: IDataConnectionInstance;
+		if (instances.length === 1) {
+			instance = instances[0];
+		} else {
+			const picks: IDataConnectionInstancePickItem[] = instances.map(candidate => ({
+				label: dataConnectionsService.getProfile(candidate.profileId)?.connectionName ?? candidate.profileId,
+				description: candidate.driverName,
+				instance: candidate,
+			}));
+			const pick = await quickInputService.pick(picks, {
+				placeHolder: localize('positron.dataConnections.debugSummarizeSchema.pick', "Select a data connection to summarize"),
+			});
+			if (!pick) {
+				return;
+			}
+			instance = pick.instance;
+		}
+
+		const summary = await summarizeDataConnectionSchema(instance.connectionHandle);
+
+		await editorService.openEditor({
+			resource: undefined,
+			contents: JSON.stringify(summary, null, 2),
+			languageId: 'json',
+			options: { pinned: true },
+		} satisfies IUntitledTextResourceEditorInput);
+	}
+});

--- a/src/vs/workbench/services/positronDataConnections/common/dataConnectionSchemaSummary.ts
+++ b/src/vs/workbench/services/positronDataConnections/common/dataConnectionSchemaSummary.ts
@@ -1,0 +1,189 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IDataConnectionNodeDTO } from './interfaces/dataConnectionDTOs.js';
+import { IDataConnectionHandle } from './interfaces/dataConnectionDriver.js';
+
+// Defaults keep a single summarization call cheap for both the driver (bounded number of
+// nodeGetChildren round-trips) and the consumer (bounded JSON payload size).
+const DEFAULT_MAX_DEPTH = 4;
+const DEFAULT_MAX_NODES_PER_LEVEL = 50;
+const DEFAULT_MAX_TOTAL_NODES = 500;
+
+// DataConnectionNodeKind values (positron.d.ts) that only group sibling nodes for display (e.g.
+// "Tables", "Views") and carry no schema information of their own. IDataConnectionNodeDTO.kind
+// crosses the RPC wire as a plain string (see dataConnectionDTOs.ts), so these are compared as
+// string literals rather than imported from the ext-host-only DataConnectionNodeKind enum.
+const CONTAINER_ONLY_KINDS = new Set([
+	'group-databases',
+	'group-schemas',
+	'group-tables',
+	'group-views',
+	'group-columns',
+	'group-indexes',
+]);
+
+/**
+ * Bounds for a {@link summarizeDataConnectionSchema} call. All fields default when omitted; see
+ * DEFAULT_MAX_DEPTH, DEFAULT_MAX_NODES_PER_LEVEL, DEFAULT_MAX_TOTAL_NODES.
+ */
+export interface IDataConnectionSchemaSummaryOptions {
+	// Maximum depth of real (non-container) nodes in the returned tree. Root-level nodes are
+	// depth 1. Container nodes (see CONTAINER_ONLY_KINDS) are flattened and don't consume a depth
+	// level.
+	maxDepth?: number;
+
+	// Maximum number of nodes returned under any single parent (or at the root), after container
+	// flattening. Extra siblings are counted into that parent's truncatedChildCount rather than
+	// dropped without a trace.
+	maxNodesPerLevel?: number;
+
+	// Maximum number of nodes in the entire summary, across all levels combined. Once reached, no
+	// further nodes are added anywhere in the tree.
+	maxTotalNodes?: number;
+}
+
+/**
+ * A single node in a summarized data connection schema tree. Plain JSON -- safe to send to
+ * Assistant or serialize for storage.
+ */
+export interface IDataConnectionSchemaNode {
+	name: string;
+	kind: string; // DataConnectionNodeKind value (positron.d.ts)
+	dataType?: string;
+	isPrimaryKey?: boolean;
+
+	// Present only when this node has at least one included child.
+	children?: IDataConnectionSchemaNode[];
+
+	// Number of this node's children left out of the summary by a maxDepth, maxNodesPerLevel, or
+	// maxTotalNodes cap. Present only when at least one child was left out.
+	truncatedChildCount?: number;
+}
+
+/**
+ * A bounded, JSON-serializable summary of a data connection's schema tree, produced by
+ * {@link summarizeDataConnectionSchema}.
+ */
+export interface IDataConnectionSchemaSummary {
+	// Identifies the connection instance the schema was read from (the handle's RPC connection
+	// handle, stringified).
+	instanceId: string;
+
+	nodes: IDataConnectionSchemaNode[];
+
+	// True if any cap (maxDepth, maxNodesPerLevel, maxTotalNodes) truncated the output.
+	truncated: boolean;
+}
+
+// Mutable counters threaded through the recursive walk. summarizeDataConnectionSchema allocates
+// one of these per call; sharing it across recursive calls is what makes maxTotalNodes a global
+// (not per-branch) budget.
+interface IWalkState {
+	totalNodes: number;
+	truncated: boolean;
+}
+
+/**
+ * Recursively walks a data connection's schema tree via {@link IDataConnectionHandle.getChildren}
+ * and {@link IDataConnectionHandle.nodeGetChildren}, producing a bounded, plain JSON-serializable
+ * summary suitable for handing to Assistant. Container-only node kinds (see
+ * CONTAINER_ONLY_KINDS) are flattened into their parent since they add no schema information of
+ * their own. Output is bounded by maxDepth, maxNodesPerLevel, and maxTotalNodes; whenever a cap
+ * leaves children out, the parent node is annotated with truncatedChildCount rather than the
+ * data being dropped silently.
+ * @param handle The live data connection handle to summarize.
+ * @param options Bounds for the walk; see {@link IDataConnectionSchemaSummaryOptions}.
+ */
+export async function summarizeDataConnectionSchema(
+	handle: IDataConnectionHandle,
+	options?: IDataConnectionSchemaSummaryOptions,
+): Promise<IDataConnectionSchemaSummary> {
+	const maxDepth = options?.maxDepth ?? DEFAULT_MAX_DEPTH;
+	const maxNodesPerLevel = options?.maxNodesPerLevel ?? DEFAULT_MAX_NODES_PER_LEVEL;
+	const maxTotalNodes = options?.maxTotalNodes ?? DEFAULT_MAX_TOTAL_NODES;
+
+	const state: IWalkState = { totalNodes: 0, truncated: false };
+
+	const fetchChildren = (dto: IDataConnectionNodeDTO): Promise<IDataConnectionNodeDTO[]> =>
+		dto.hasGetChildren ? handle.nodeGetChildren(dto.nodeHandle) : Promise.resolve([]);
+
+	// Expands container-only kinds (e.g. "Tables", "Columns" group nodes) in place, replacing each
+	// with its own children -- recursively, in case a driver nests containers -- so the caller sees
+	// a flat list of only the real, schema-bearing nodes at this level. Done as its own pass (rather
+	// than inline while budgeting) so every real node is counted against maxNodesPerLevel/
+	// maxTotalNodes exactly once, regardless of how many container levels it was nested under.
+	async function flattenContainers(dtos: IDataConnectionNodeDTO[]): Promise<IDataConnectionNodeDTO[]> {
+		const flattened: IDataConnectionNodeDTO[] = [];
+		for (const dto of dtos) {
+			if (CONTAINER_ONLY_KINDS.has(dto.kind)) {
+				flattened.push(...await flattenContainers(await fetchChildren(dto)));
+			} else {
+				flattened.push(dto);
+			}
+		}
+		return flattened;
+	}
+
+	/**
+	 * Summarizes one sibling list -- the children of a single node, or the root list -- after
+	 * flattening container-only kinds directly into it. `depth` is the depth these (real) nodes
+	 * occupy; container nodes are transparent and don't consume a depth level, so their flattened
+	 * contents share the depth of the list they were flattened into. Returns the accepted nodes
+	 * plus a count of siblings left out by the maxNodesPerLevel/maxTotalNodes budgets.
+	 */
+	async function summarizeSiblings(dtos: IDataConnectionNodeDTO[], depth: number): Promise<{ nodes: IDataConnectionSchemaNode[]; omitted: number }> {
+		const nodes: IDataConnectionSchemaNode[] = [];
+		let omitted = 0;
+
+		for (const dto of await flattenContainers(dtos)) {
+			if (nodes.length >= maxNodesPerLevel || state.totalNodes >= maxTotalNodes) {
+				omitted++;
+				state.truncated = true;
+				continue;
+			}
+			state.totalNodes++;
+
+			const node: IDataConnectionSchemaNode = { name: dto.name, kind: dto.kind };
+			if (dto.dataType !== undefined) {
+				node.dataType = dto.dataType;
+			}
+			if (dto.isPrimaryKey !== undefined) {
+				node.isPrimaryKey = dto.isPrimaryKey;
+			}
+			nodes.push(node);
+
+			if (dto.hasGetChildren) {
+				if (depth < maxDepth) {
+					const result = await summarizeSiblings(await fetchChildren(dto), depth + 1);
+					if (result.nodes.length > 0) {
+						node.children = result.nodes;
+					}
+					if (result.omitted > 0) {
+						node.truncatedChildCount = result.omitted;
+						state.truncated = true;
+					}
+				} else {
+					// At the depth limit: report that (real) children exist without descending into them.
+					const children = await flattenContainers(await fetchChildren(dto));
+					if (children.length > 0) {
+						node.truncatedChildCount = children.length;
+						state.truncated = true;
+					}
+				}
+			}
+		}
+
+		return { nodes, omitted };
+	}
+
+	const { nodes } = await summarizeSiblings(await handle.getChildren(), 1);
+
+	return {
+		instanceId: String(handle.handle),
+		nodes,
+		truncated: state.truncated,
+	};
+}

--- a/src/vs/workbench/services/positronDataConnections/test/common/dataConnectionSchemaSummary.vitest.ts
+++ b/src/vs/workbench/services/positronDataConnections/test/common/dataConnectionSchemaSummary.vitest.ts
@@ -1,0 +1,263 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { summarizeDataConnectionSchema } from '../../common/dataConnectionSchemaSummary.js';
+import { IDataConnectionNodeDTO } from '../../common/interfaces/dataConnectionDTOs.js';
+import { IDataConnectionHandle } from '../../common/interfaces/dataConnectionDriver.js';
+
+// A lightweight description of a schema tree used to build a fake IDataConnectionHandle. Mirrors
+// the shape drivers hand to getChildren()/nodeGetChildren(), minus the wire-format bookkeeping
+// (nodeHandle, hasGetChildren) that createFakeHandle assigns automatically.
+interface IFakeSchemaNode {
+	name: string;
+	kind: string;
+	dataType?: string;
+	isPrimaryKey?: boolean;
+	children?: IFakeSchemaNode[];
+}
+
+// Builds a fake IDataConnectionHandle backed by an in-memory tree, assigning each node a
+// nodeHandle the first time it is serialized to a DTO (mirroring how the real ext host assigns
+// handles lazily as nodes are expanded).
+function createFakeHandle(roots: IFakeSchemaNode[], connectionHandle = 1): IDataConnectionHandle {
+	let nextNodeHandle = 1;
+	const childrenByNodeHandle = new Map<number, IFakeSchemaNode[]>();
+
+	const toDto = (node: IFakeSchemaNode): IDataConnectionNodeDTO => {
+		const nodeHandle = nextNodeHandle++;
+		if (node.children) {
+			childrenByNodeHandle.set(nodeHandle, node.children);
+		}
+		return {
+			nodeHandle,
+			name: node.name,
+			kind: node.kind,
+			dataType: node.dataType,
+			isPrimaryKey: node.isPrimaryKey,
+			hasGetChildren: node.children !== undefined,
+			hasPreview: false,
+		};
+	};
+
+	return stubInterface<IDataConnectionHandle>({
+		handle: connectionHandle,
+		getChildren: async () => roots.map(toDto),
+		nodeGetChildren: async (nodeHandle: number) => (childrenByNodeHandle.get(nodeHandle) ?? []).map(toDto),
+	});
+}
+
+// Builds a chain of `depth` nested nodes, each the sole child of the previous one, all sharing
+// `kind`. Used to exercise the maxDepth cap independent of any particular node kind's real-world
+// shape (e.g. field nodes are normally leaves; this keeps every level "expandable").
+function createChain(depth: number, kind = 'database'): IFakeSchemaNode {
+	let node: IFakeSchemaNode = { name: `level${depth}`, kind };
+	for (let level = depth - 1; level >= 1; level--) {
+		node = { name: `level${level}`, kind, children: [node] };
+	}
+	return node;
+}
+
+describe('summarizeDataConnectionSchema', () => {
+	it('returns an empty summary for a connection with no schema', async () => {
+		const handle = createFakeHandle([], 42);
+
+		const summary = await summarizeDataConnectionSchema(handle);
+
+		expect(summary).toEqual({ instanceId: '42', nodes: [], truncated: false });
+	});
+
+	it('flattens container-only kinds into their parent', async () => {
+		const handle = createFakeHandle([
+			{
+				name: 'Tables', kind: 'group-tables', children: [
+					{
+						name: 'employees', kind: 'table', children: [
+							{
+								name: 'Columns', kind: 'group-columns', children: [
+									{ name: 'id', kind: 'field', dataType: 'integer', isPrimaryKey: true },
+									{ name: 'name', kind: 'field', dataType: 'text' },
+								]
+							},
+						]
+					},
+				]
+			},
+		]);
+
+		const summary = await summarizeDataConnectionSchema(handle);
+
+		expect(summary).toMatchInlineSnapshot(`
+			{
+			  "instanceId": "1",
+			  "nodes": [
+			    {
+			      "children": [
+			        {
+			          "dataType": "integer",
+			          "isPrimaryKey": true,
+			          "kind": "field",
+			          "name": "id",
+			        },
+			        {
+			          "dataType": "text",
+			          "kind": "field",
+			          "name": "name",
+			        },
+			      ],
+			      "kind": "table",
+			      "name": "employees",
+			    },
+			  ],
+			  "truncated": false,
+			}
+		`);
+	});
+
+	it('caps recursion at maxDepth, marking truncatedChildCount instead of descending further', async () => {
+		// level1 -> level2 -> level3 -> level4: 4 real levels, one child each.
+		const handle = createFakeHandle([createChain(4)]);
+
+		const summary = await summarizeDataConnectionSchema(handle, { maxDepth: 2 });
+
+		expect(summary).toEqual({
+			instanceId: '1',
+			truncated: true,
+			nodes: [
+				{
+					name: 'level1', kind: 'database', children: [
+						{ name: 'level2', kind: 'database', truncatedChildCount: 1 },
+					]
+				},
+			],
+		});
+	});
+
+	it('does not truncate a tree that fits entirely within maxDepth', async () => {
+		const handle = createFakeHandle([createChain(4)]);
+
+		const summary = await summarizeDataConnectionSchema(handle, { maxDepth: 4 });
+
+		expect(summary.truncated).toBe(false);
+		// level4 is a leaf (no children), so nothing is left dangling at the boundary.
+		expect(summary.nodes[0].children![0].children![0].children).toEqual([{ name: 'level4', kind: 'database' }]);
+	});
+
+	it('caps children per parent at maxNodesPerLevel, marking truncatedChildCount on the parent', async () => {
+		const handle = createFakeHandle([
+			{
+				name: 'schema', kind: 'schema', children: [
+					{ name: 't1', kind: 'table' },
+					{ name: 't2', kind: 'table' },
+					{ name: 't3', kind: 'table' },
+					{ name: 't4', kind: 'table' },
+					{ name: 't5', kind: 'table' },
+				]
+			},
+		]);
+
+		const summary = await summarizeDataConnectionSchema(handle, { maxNodesPerLevel: 3 });
+
+		expect(summary).toEqual({
+			instanceId: '1',
+			truncated: true,
+			nodes: [
+				{
+					name: 'schema', kind: 'schema', truncatedChildCount: 2, children: [
+						{ name: 't1', kind: 'table' },
+						{ name: 't2', kind: 'table' },
+						{ name: 't3', kind: 'table' },
+					]
+				},
+			],
+		});
+	});
+
+	it('applies maxNodesPerLevel independently to each parent, not as a shared per-depth budget', async () => {
+		const makeTables = (prefix: string) => Array.from({ length: 4 }, (_, i) => ({ name: `${prefix}${i + 1}`, kind: 'table' }));
+		const handle = createFakeHandle([
+			{ name: 'schemaA', kind: 'schema', children: makeTables('a') },
+			{ name: 'schemaB', kind: 'schema', children: makeTables('b') },
+		]);
+
+		const summary = await summarizeDataConnectionSchema(handle, { maxNodesPerLevel: 2 });
+
+		expect(summary.nodes.map(n => ({ name: n.name, truncatedChildCount: n.truncatedChildCount, children: n.children?.map(c => c.name) }))).toEqual([
+			{ name: 'schemaA', truncatedChildCount: 2, children: ['a1', 'a2'] },
+			{ name: 'schemaB', truncatedChildCount: 2, children: ['b1', 'b2'] },
+		]);
+	});
+
+	it('caps the total number of nodes across the whole tree at maxTotalNodes', async () => {
+		const handle = createFakeHandle([
+			{ name: 'tableA', kind: 'table', children: [{ name: 'f1', kind: 'field' }, { name: 'f2', kind: 'field' }, { name: 'f3', kind: 'field' }] },
+			{ name: 'tableB', kind: 'table', children: [{ name: 'g1', kind: 'field' }, { name: 'g2', kind: 'field' }, { name: 'g3', kind: 'field' }] },
+		]);
+
+		const summary = await summarizeDataConnectionSchema(handle, { maxTotalNodes: 4 });
+
+		// The global budget is exhausted inside tableA's own children; tableB never gets a node at
+		// all (there's no root-level parent to annotate with a count), but `truncated` still flags it.
+		expect(summary).toEqual({
+			instanceId: '1',
+			truncated: true,
+			nodes: [
+				{
+					name: 'tableA', kind: 'table', children: [
+						{ name: 'f1', kind: 'field' },
+						{ name: 'f2', kind: 'field' },
+						{ name: 'f3', kind: 'field' },
+					]
+				},
+			],
+		});
+	});
+
+	it('counts nodes flattened out of a container only once against maxTotalNodes', async () => {
+		// Regression test: nodes nested under a container kind must not be charged against the
+		// budget once per container hop they were flattened through -- only once each, same as a
+		// node with no container ancestors at all.
+		const handle = createFakeHandle([
+			{
+				name: 'Tables', kind: 'group-tables', children: [
+					{ name: 't1', kind: 'table' },
+					{ name: 't2', kind: 'table' },
+					{ name: 't3', kind: 'table' },
+				]
+			},
+		]);
+
+		const summary = await summarizeDataConnectionSchema(handle, { maxTotalNodes: 2 });
+
+		expect(summary).toEqual({
+			instanceId: '1',
+			truncated: true,
+			nodes: [
+				{ name: 't1', kind: 'table' },
+				{ name: 't2', kind: 'table' },
+			],
+		});
+	});
+
+	it('produces a payload that survives a JSON round-trip', async () => {
+		const handle = createFakeHandle([
+			{
+				name: 'Tables', kind: 'group-tables', children: [
+					{
+						name: 'employees', kind: 'table', children: [
+							{ name: 'id', kind: 'field', dataType: 'integer', isPrimaryKey: true },
+						]
+					},
+				]
+			},
+		]);
+
+		const summary = await summarizeDataConnectionSchema(handle);
+
+		expect(JSON.parse(JSON.stringify(summary))).toEqual(summary);
+	});
+});


### PR DESCRIPTION
Fixes #14926

### Summary

Adds `summarizeDataConnectionSchema()`, a bounded, recursive helper that walks a data connection's schema tree via `IDataConnectionHandle.getChildren()`/`nodeGetChildren()` and produces a plain, JSON-serializable summary suitable for handing to Assistant. Output is capped by `maxDepth` (default 4), `maxNodesPerLevel` (default 50), and `maxTotalNodes` (default 500); whenever a cap trims a node's children, the parent is annotated with `truncatedChildCount` instead of the data being dropped silently. Container-only `DataConnectionNodeKind` values (e.g. the "Tables"/"Columns" group nodes) are flattened into their parent since they carry no schema information of their own.

This is issue 1 of 2 in the schema-aware Assistant plan (#14658); issue 2 (the `getSchema` command that will call this helper) is a follow-up and not part of this PR.

Also adds a development-only Command Palette entry (`positronDataConnections.debugSummarizeSchema`, gated on `IsDevelopmentContext`) as a manual-testing aid: it runs the helper against a live connection and opens the result as JSON in a new editor. It's not wired into any product code path and won't appear in release builds.


<details>
<summary>This is what the command returns for the flights data:</summary>

```json
{
  "instanceId": "4",
  "nodes": [
    {
      "name": "dev",
      "kind": "database",
      "children": [
        {
          "name": "public",
          "kind": "schema",
          "children": [
            {
              "name": "category",
              "kind": "table",
              "children": [
                {
                  "name": "catid",
                  "kind": "field",
                  "dataType": "smallint",
                  "isPrimaryKey": false
                },
                {
                  "name": "catgroup",
                  "kind": "field",
                  "dataType": "character varying(10)",
                  "isPrimaryKey": false
                },
                {
                  "name": "catname",
                  "kind": "field",
                  "dataType": "character varying(10)",
                  "isPrimaryKey": false
                },
                {
                  "name": "catdesc",
                  "kind": "field",
                  "dataType": "character varying(50)",
                  "isPrimaryKey": false
                }
              ]
            },
            {
              "name": "date",
              "kind": "table",
              "children": [
                {
                  "name": "dateid",
                  "kind": "field",
                  "dataType": "smallint",
                  "isPrimaryKey": false
                },
                {
                  "name": "caldate",
                  "kind": "field",
                  "dataType": "date",
                  "isPrimaryKey": false
                },
                {
                  "name": "day",
                  "kind": "field",
                  "dataType": "character(3)",
                  "isPrimaryKey": false
                },
                {
                  "name": "week",
                  "kind": "field",
                  "dataType": "smallint",
                  "isPrimaryKey": false
                },
                {
                  "name": "month",
                  "kind": "field",
                  "dataType": "character(5)",
                  "isPrimaryKey": false
                },
                {
                  "name": "qtr",
                  "kind": "field",
                  "dataType": "character(5)",
                  "isPrimaryKey": false
                },
                {
                  "name": "year",
                  "kind": "field",
                  "dataType": "smallint",
                  "isPrimaryKey": false
                },
                {
                  "name": "holiday",
                  "kind": "field",
                  "dataType": "boolean",
                  "isPrimaryKey": false
                }
              ]
            },
            {
              "name": "event",
              "kind": "table",
              "children": [
                {
                  "name": "eventid",
                  "kind": "field",
                  "dataType": "integer",
                  "isPrimaryKey": false
                },
                {
                  "name": "venueid",
                  "kind": "field",
                  "dataType": "smallint",
                  "isPrimaryKey": false
                },
                {
                  "name": "catid",
                  "kind": "field",
                  "dataType": "smallint",
                  "isPrimaryKey": false
                },
                {
                  "name": "dateid",
                  "kind": "field",
                  "dataType": "smallint",
                  "isPrimaryKey": false
                },
                {
                  "name": "eventname",
                  "kind": "field",
                  "dataType": "character varying(200)",
                  "isPrimaryKey": false
                },
                {
                  "name": "starttime",
                  "kind": "field",
                  "dataType": "timestamp without time zone",
                  "isPrimaryKey": false
                }
              ]
            },
            {
              "name": "listing",
              "kind": "table",
              "children": [
                {
                  "name": "listid",
                  "kind": "field",
                  "dataType": "integer",
                  "isPrimaryKey": false
                },
                {
                  "name": "sellerid",
                  "kind": "field",
                  "dataType": "integer",
                  "isPrimaryKey": false
                },
                {
                  "name": "eventid",
                  "kind": "field",
                  "dataType": "integer",
                  "isPrimaryKey": false
                },
                {
                  "name": "dateid",
                  "kind": "field",
                  "dataType": "smallint",
                  "isPrimaryKey": false
                },
                {
                  "name": "numtickets",
                  "kind": "field",
                  "dataType": "smallint",
                  "isPrimaryKey": false
                },
                {
                  "name": "priceperticket",
                  "kind": "field",
                  "dataType": "numeric(8,2)",
                  "isPrimaryKey": false
                },
                {
                  "name": "totalprice",
                  "kind": "field",
                  "dataType": "numeric(8,2)",
                  "isPrimaryKey": false
                },
                {
                  "name": "listtime",
                  "kind": "field",
                  "dataType": "timestamp without time zone",
                  "isPrimaryKey": false
                }
              ]
            },
            {
              "name": "sales",
              "kind": "table",
              "children": [
                {
                  "name": "salesid",
                  "kind": "field",
                  "dataType": "integer",
                  "isPrimaryKey": false
                },
                {
                  "name": "listid",
                  "kind": "field",
                  "dataType": "integer",
                  "isPrimaryKey": false
                },
                {
                  "name": "sellerid",
                  "kind": "field",
                  "dataType": "integer",
                  "isPrimaryKey": false
                },
                {
                  "name": "buyerid",
                  "kind": "field",
                  "dataType": "integer",
                  "isPrimaryKey": false
                },
                {
                  "name": "eventid",
                  "kind": "field",
                  "dataType": "integer",
                  "isPrimaryKey": false
                },
                {
                  "name": "dateid",
                  "kind": "field",
                  "dataType": "smallint",
                  "isPrimaryKey": false
                },
                {
                  "name": "qtysold",
                  "kind": "field",
                  "dataType": "smallint",
                  "isPrimaryKey": false
                },
                {
                  "name": "pricepaid",
                  "kind": "field",
                  "dataType": "numeric(8,2)",
                  "isPrimaryKey": false
                },
                {
                  "name": "commission",
                  "kind": "field",
                  "dataType": "numeric(8,2)",
                  "isPrimaryKey": false
                },
                {
                  "name": "saletime",
                  "kind": "field",
                  "dataType": "timestamp without time zone",
                  "isPrimaryKey": false
                }
              ]
            },
            {
              "name": "users",
              "kind": "table",
              "children": [
                {
                  "name": "userid",
                  "kind": "field",
                  "dataType": "integer",
                  "isPrimaryKey": false
                },
                {
                  "name": "username",
                  "kind": "field",
                  "dataType": "character(8)",
                  "isPrimaryKey": false
                },
                {
                  "name": "firstname",
                  "kind": "field",
                  "dataType": "character varying(30)",
                  "isPrimaryKey": false
                },
                {
                  "name": "lastname",
                  "kind": "field",
                  "dataType": "character varying(30)",
                  "isPrimaryKey": false
                },
                {
                  "name": "city",
                  "kind": "field",
                  "dataType": "character varying(30)",
                  "isPrimaryKey": false
                },
                {
                  "name": "state",
                  "kind": "field",
                  "dataType": "character(2)",
                  "isPrimaryKey": false
                },
                {
                  "name": "email",
                  "kind": "field",
                  "dataType": "character varying(100)",
                  "isPrimaryKey": false
                },
                {
                  "name": "phone",
                  "kind": "field",
                  "dataType": "character(14)",
                  "isPrimaryKey": false
                },
                {
                  "name": "likesports",
                  "kind": "field",
                  "dataType": "boolean",
                  "isPrimaryKey": false
                },
                {
                  "name": "liketheatre",
                  "kind": "field",
                  "dataType": "boolean",
                  "isPrimaryKey": false
                },
                {
                  "name": "likeconcerts",
                  "kind": "field",
                  "dataType": "boolean",
                  "isPrimaryKey": false
                },
                {
                  "name": "likejazz",
                  "kind": "field",
                  "dataType": "boolean",
                  "isPrimaryKey": false
                },
                {
                  "name": "likeclassical",
                  "kind": "field",
                  "dataType": "boolean",
                  "isPrimaryKey": false
                },
                {
                  "name": "likeopera",
                  "kind": "field",
                  "dataType": "boolean",
                  "isPrimaryKey": false
                },
                {
                  "name": "likerock",
                  "kind": "field",
                  "dataType": "boolean",
                  "isPrimaryKey": false
                },
                {
                  "name": "likevegas",
                  "kind": "field",
                  "dataType": "boolean",
                  "isPrimaryKey": false
                },
                {
                  "name": "likebroadway",
                  "kind": "field",
                  "dataType": "boolean",
                  "isPrimaryKey": false
                },
                {
                  "name": "likemusicals",
                  "kind": "field",
                  "dataType": "boolean",
                  "isPrimaryKey": false
                }
              ]
            },
            {
              "name": "venue",
              "kind": "table",
              "children": [
                {
                  "name": "venueid",
                  "kind": "field",
                  "dataType": "smallint",
                  "isPrimaryKey": false
                },
                {
                  "name": "venuename",
                  "kind": "field",
                  "dataType": "character varying(100)",
                  "isPrimaryKey": false
                },
                {
                  "name": "venuecity",
                  "kind": "field",
                  "dataType": "character varying(30)",
                  "isPrimaryKey": false
                },
                {
                  "name": "venuestate",
                  "kind": "field",
                  "dataType": "character(2)",
                  "isPrimaryKey": false
                },
                {
                  "name": "venueseats",
                  "kind": "field",
                  "dataType": "integer",
                  "isPrimaryKey": false
                }
              ]
            }
          ]
        }
      ]
    },
    {
      "name": "flights",
      "kind": "database",
      "children": [
        {
          "name": "public",
          "kind": "schema",
          "children": [
            {
              "name": "flights",
              "kind": "table",
              "children": [
                {
                  "name": "year",
                  "kind": "field",
                  "dataType": "smallint",
                  "isPrimaryKey": false
                },
                {
                  "name": "month",
                  "kind": "field",
                  "dataType": "smallint",
                  "isPrimaryKey": false
                },
                {
                  "name": "day",
                  "kind": "field",
                  "dataType": "smallint",
                  "isPrimaryKey": false
                },
                {
                  "name": "dep_time",
                  "kind": "field",
                  "dataType": "smallint",
                  "isPrimaryKey": false
                },
                {
                  "name": "sched_dep_time",
                  "kind": "field",
                  "dataType": "smallint",
                  "isPrimaryKey": false
                },
                {
                  "name": "dep_delay",
                  "kind": "field",
                  "dataType": "smallint",
                  "isPrimaryKey": false
                },
                {
                  "name": "arr_time",
                  "kind": "field",
                  "dataType": "smallint",
                  "isPrimaryKey": false
                },
                {
                  "name": "sched_arr_time",
                  "kind": "field",
                  "dataType": "smallint",
                  "isPrimaryKey": false
                },
                {
                  "name": "arr_delay",
                  "kind": "field",
                  "dataType": "smallint",
                  "isPrimaryKey": false
                },
                {
                  "name": "carrier",
                  "kind": "field",
                  "dataType": "character varying(256)",
                  "isPrimaryKey": false
                },
                {
                  "name": "flight",
                  "kind": "field",
                  "dataType": "smallint",
                  "isPrimaryKey": false
                },
                {
                  "name": "tailnum",
                  "kind": "field",
                  "dataType": "character varying(256)",
                  "isPrimaryKey": false
                },
                {
                  "name": "origin",
                  "kind": "field",
                  "dataType": "character varying(256)",
                  "isPrimaryKey": false
                },
                {
                  "name": "dest",
                  "kind": "field",
                  "dataType": "character varying(256)",
                  "isPrimaryKey": false
                },
                {
                  "name": "air_time",
                  "kind": "field",
                  "dataType": "smallint",
                  "isPrimaryKey": false
                },
                {
                  "name": "distance",
                  "kind": "field",
                  "dataType": "smallint",
                  "isPrimaryKey": false
                },
                {
                  "name": "hour",
                  "kind": "field",
                  "dataType": "smallint",
                  "isPrimaryKey": false
                },
                {
                  "name": "minute",
                  "kind": "field",
                  "dataType": "smallint",
                  "isPrimaryKey": false
                },
                {
                  "name": "time_hour",
                  "kind": "field",
                  "dataType": "timestamp without time zone",
                  "isPrimaryKey": false
                }
              ]
            }
          ]
        }
      ]
    }
  ],
  "truncated": false
}
```
</details>

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

@:connections

This PR has no user-facing surface yet -- validate via the unit tests and the dev-only debug command:

1. `npx vitest run src/vs/workbench/services/positronDataConnections/test/common/dataConnectionSchemaSummary.vitest.ts`
2. In a dev build, connect to a data connection from the Connections pane, then run "Developer: Summarize Data Connection Schema (Debug)" from the Command Palette and confirm the JSON opened in a new editor matches the connection's schema, with `truncatedChildCount` populated for any node whose children exceed the caps.