### PR TITLE
ci: always run win and web e2e lanes on ark submodule bumps

### DIFF
--- a/scripts/lib/pr-tags-lib.sh
+++ b/scripts/lib/pr-tags-lib.sh
@@ -429,7 +429,11 @@ build_tag_reasons() {
 			code="body"
 		elif printf '%s\n' "$map_nl" | grep -qxF "$tag"; then
 			code="files"
-		elif [[ "$tag" == "@:ark" && "$ark" == "true" ]]; then
+		elif [[ ( "$tag" == "@:ark" || "$tag" == "@:win" || "$tag" == "@:web" ) && "$ark" == "true" ]]; then
+			# An ark bump injects @:ark plus @:win/@:web together (see
+			# pr-tags-parse.sh); attribute all three to the bump. This sits above
+			# the test-win/test-web branches, so a bump wins over a coincidental
+			# tags.WIN/WEB add in the same PR.
 			code="ark"
 		elif [[ "$tag" == "@:win" && "$added_win" == "true" ]]; then
 			code="test-win"

--- a/scripts/pr-tags-parse.sh
+++ b/scripts/pr-tags-parse.sh
@@ -169,11 +169,11 @@ else
 	if [[ -z "$CHANGED_FILES" ]]; then
 		echo "Warning: could not fetch changed files; skipping @:ark injection."
 	elif echo "$CHANGED_FILES" | grep -qxF "extensions/positron-r/ark"; then
-		# An ark bump can regress R behavior on any platform, so run the
-		# Windows and web lanes too -- not just the default electron lane.
-		# @:win/@:web only add the tags to the grep list; the win/web CI jobs
-		# gate on the *_tag_found outputs, so set those as well or the jobs
-		# never launch.
+		# @:ark is also derivable from the path map (extensions/positron-r/),
+		# but @:win/@:web can't be: the map only feeds the --grep string, while
+		# the win/web CI jobs launch off the *_tag_found outputs, not the tags.
+		# An ark bump can regress R behavior on any platform, so run those lanes
+		# too -- which means setting the outputs here, imperatively.
 		echo "Ark submodule changed. Injecting @:ark, @:win, and @:web tags."
 		ARK_INJECTED="true"
 		TAGS="$(union_csv_tags "$TAGS" "@:ark,@:win,@:web")"

--- a/scripts/pr-tags-parse.sh
+++ b/scripts/pr-tags-parse.sh
@@ -169,13 +169,16 @@ else
 	if [[ -z "$CHANGED_FILES" ]]; then
 		echo "Warning: could not fetch changed files; skipping @:ark injection."
 	elif echo "$CHANGED_FILES" | grep -qxF "extensions/positron-r/ark"; then
-		echo "Ark submodule changed. Injecting @:ark tag."
+		# An ark bump can regress R behavior on any platform, so run the
+		# Windows and web lanes too -- not just the default electron lane.
+		# @:win/@:web only add the tags to the grep list; the win/web CI jobs
+		# gate on the *_tag_found outputs, so set those as well or the jobs
+		# never launch.
+		echo "Ark submodule changed. Injecting @:ark, @:win, and @:web tags."
 		ARK_INJECTED="true"
-		if [[ -n "$TAGS" ]]; then
-			TAGS="$TAGS,@:ark"
-		else
-			TAGS="@:ark"
-		fi
+		TAGS="$(union_csv_tags "$TAGS" "@:ark,@:win,@:web")"
+		echo "win_tag_found=true" >> "$GITHUB_OUTPUT"
+		echo "web_tag_found=true" >> "$GITHUB_OUTPUT"
 	fi
 
 	# Resolve the path to the map (this script lives in scripts/).

--- a/scripts/test/pr-tags-lib-test.sh
+++ b/scripts/test/pr-tags-lib-test.sh
@@ -838,6 +838,9 @@ assert_eq "reasons: ark injection" "@:critical|required,@:ark|ark" \
 assert_eq "reasons: ark bump labels win/web as ark" \
 	"@:critical|required,@:ark|ark,@:win|ark,@:web|ark" \
 	"$(build_tag_reasons "@:critical,@:ark,@:win,@:web" "" "" "true" "false" "false")"
+# @:win typed in the body beats the ark-injection attribution even when ark=true.
+assert_eq "reasons: author-typed win beats ark" "@:critical|required,@:win|body" \
+	"$(build_tag_reasons "@:critical,@:win" "@:win" "" "true" "false" "false")"
 # @:win typed in the body reads as body, not test-win.
 assert_eq "reasons: author-typed win is body" "@:critical|required,@:win|body" \
 	"$(build_tag_reasons "@:critical,@:win" "@:win" "" "false" "true" "false")"

--- a/scripts/test/pr-tags-lib-test.sh
+++ b/scripts/test/pr-tags-lib-test.sh
@@ -834,6 +834,10 @@ assert_eq "reasons: author+map overlap prefers body" "@:critical|required,@:cons
 	"$(build_tag_reasons "@:critical,@:console" "@:console" "@:console" "false" "false" "false")"
 assert_eq "reasons: ark injection" "@:critical|required,@:ark|ark" \
 	"$(build_tag_reasons "@:critical,@:ark" "" "" "true" "false" "false")"
+# An ark bump injects @:ark + @:win + @:web together; all three read as ark.
+assert_eq "reasons: ark bump labels win/web as ark" \
+	"@:critical|required,@:ark|ark,@:win|ark,@:web|ark" \
+	"$(build_tag_reasons "@:critical,@:ark,@:win,@:web" "" "" "true" "false" "false")"
 # @:win typed in the body reads as body, not test-win.
 assert_eq "reasons: author-typed win is body" "@:critical|required,@:win|body" \
 	"$(build_tag_reasons "@:critical,@:win" "@:win" "" "false" "true" "false")"

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -256,6 +256,7 @@ In addition to scanning your PR description, the `pr-tags` job derives tags from
 
 - **Source / extension changes** map to feature tags via [`.github/workflows/test-tag-paths-map.json`](https://github.com/posit-dev/positron/blob/main/.github/workflows/test-tag-paths-map.json) (for example, a change under `contrib/positronConsole/` adds `@:console`).
 - **E2E test-file changes** map to the minimal tag(s) needed to guarantee the touched/added tests actually run, chosen to add as few additional sibling tests as possible -- see [`scripts/derive-test-change-tags.mjs`](https://github.com/posit-dev/positron/blob/main/scripts/derive-test-change-tags.mjs). A test file with no declared tags gets a warning in the job log instead of a guessed tag.
+- **Ark submodule bumps** (a change to the `extensions/positron-r/ark` pointer) add `@:ark` plus `@:win` and `@:web`, so the ark-tagged suites run on Linux, Windows, and the browser -- an ark update can regress R behavior on any platform.
 - **Opt out:** add `@:no-auto-tags` to the PR description to disable this derivation for the PR (the `@:critical` floor still applies).
 - **Unmapped dirs:** if your PR touches a Positron dir with no entry in the map, the E2E Tests comment will note it so you (or a maintainer) can add a mapping.
 - **Typo'd tags:** any `@:tag` in your description that isn't declared in [`test-tags.ts`](https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts) is dropped and called out in the E2E Tests comment instead of silently matching nothing.


### PR DESCRIPTION
### Summary
Ark bumps already auto-inject `tags.ARK`; this also enables the Windows and web e2e lanes on those PRs, since an ark update can regress R behavior on any platform.

- On an `extensions/positron-r/ark` submodule bump, inject `tags.WIN`/`tags.WEB` alongside `tags.ARK`
- Set `win_tag_found`/`web_tag_found` outputs so the Windows/web lane jobs actually launch (they gate on those outputs, not on the tag string)
- Label the injected `tags.WIN`/`tags.WEB` as "Ark submodule bump" in the PR comment's provenance table

<sub>(Tag names written as `tags.X` rather than `@:x` so this CI-tooling PR doesn't trigger those lanes on itself.)</sub>

### QA Notes
Covered by `scripts/test/pr-tags-lib-test.sh`. No test tags needed (CI-tooling change).