### PR TITLE
e2e: fix flaky default-interpreter tests (session start + metadata dialog races)

### DIFF
--- a/.claude/skills/triage-e2e-test/SKILL.md
+++ b/.claude/skills/triage-e2e-test/SKILL.md
@@ -357,6 +357,61 @@ Don't claim a flaky test is "fixed" on the strength of a single green run,
 local or in CI -- for a race, evidence is a trend across enough runs, not one
 data point.
 
+### 7. Record the diagnosis on the PR
+
+This skill is manual and doesn't open PRs itself, so this step fires whenever
+the triage does lead to a PR (fix-the-test or a product-bug fix). Append an
+`### E2E Triage Diagnosis` block to the end of the PR body -- after whatever
+body template the change itself calls for (plain Summary/QA Notes for a
+test-only change; the product PR template for a source fix). The block is an
+immutable snapshot of the skill's root-cause prediction at authoring time, so
+its accuracy can be scored later against what actually fixed the flake.
+
+```
+### E2E Triage Diagnosis
+
+<details>
+<summary>🟢 <b>High confidence</b> -- <one-line hypothesis summary></summary>
+
+- **Spec:** `<spec path>`
+  - **Test:** `<full hierarchical test title>`
+- **Signal:** <trace-timeline mechanism observation, not the bare assertion string>
+- **Frequency:** <count/percentage + environment, e.g. "5/313 runs (1.6%), ubuntu/electron">
+- **Hypothesis:** <root-cause mechanism -- race / isolation / contention / infra / product-bug>
+
+</details>
+```
+
+Field notes:
+
+- **Confidence emoji:** 🟢 high, 🟡 medium, 🔴 low. Keep the word "confidence"
+  in plain text next to the emoji so the block stays greppable for later
+  scoring.
+- **Signal is the highest-leverage field, and the easiest to get lazy on.**
+  Pull the timeline shape from the step 4-5 evidence -- what the trace or
+  snapshot actually showed (e.g. "markers render right after import, then
+  disappear before the assertion runs") -- not the step-3 failure-pattern
+  string ("`toBeVisible()` timed out"), which can't tell "never rendered" from
+  "rendered then clobbered": two unrelated root causes.
+- **Frequency** is its own bullet -- it's a different kind of evidence (how
+  often / where) than the Signal mechanism observation.
+- `<details>` collapsing is rendering-only: `gh api` / `gh pr view --json body`
+  still return the full text, so nothing is lost for later scoring.
+
+Do NOT edit the block after merge to record whether the hypothesis turned out
+right -- that would rewrite a merged PR description as ground truth arrives
+late. Outcome scoring lives in a separate log keyed by PR number. To find every
+PR carrying a diagnosis, full-text search the heading (no label needed):
+
+```bash
+gh search prs --repo posit-dev/positron --match body "E2E Triage Diagnosis" \
+  --json number,title,url
+```
+
+When appending the block to an existing PR, edit the body with `gh api
+repos/<owner>/<repo>/pulls/<n> -X PATCH -F body=@<file>` -- `gh pr edit` fails
+on the Projects-classic GraphQL deprecation.
+
 ## Non-goals
 
 - No new S3 uploads or API changes -- consumes the existing `test-health`

--- a/.claude/skills/triage-e2e-test/SKILL.md
+++ b/.claude/skills/triage-e2e-test/SKILL.md
@@ -384,6 +384,16 @@ its accuracy can be scored later against what actually fixed the flake.
 
 Field notes:
 
+- **Spec and Test lead every block -- never drop them.** Each block names the
+  spec path and the **full hierarchical test title** (every enclosing
+  `test.describe()` joined with `" > "`, same key as step 1) -- they're the
+  block's identity, what makes it findable and scoreable per-test later. A
+  product-bug block whose fix lives in source still gets them: the diagnosis is
+  keyed to the test that surfaced it, not to the file being changed (this is
+  the field easiest to forget precisely on those blocks). When one block covers
+  more than one test, give each its own `Spec` + `Test` pair rather than
+  collapsing them into a prose "`pathA` and `pathB`" that a later per-test
+  search won't match.
 - **Confidence emoji:** 🟢 high, 🟡 medium, 🔴 low. Keep the word "confidence"
   in plain text next to the emoji so the block stays greppable for later
   scoring.

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -894,16 +894,19 @@ export class Sessions {
 			? this.page.getByTestId(`info-${sessionId}`)
 			: this.page.getByTestId(/^info-(python|r)(-notebook)?-[a-z0-9]+$/i);
 
+		// The info button's press handler no-ops while the button's testid is still `info-unknown`
+		// -- the active console session isn't wired into React context yet. Wait for the real
+		// `info-<id>` testid before clicking; once it's real a single click reliably opens the
+		// dialog. Return early when the dialog is already open: clicking the button again dismisses
+		// the popup, so the retry must never re-click an open dialog.
+		await expect(button).toBeVisible();
+
 		await expect(async () => {
-			const isMetadataDialogVisible = await this.metadataDialog.isVisible();
-
-			if (!isMetadataDialogVisible) {
-				await expect(button).toBeVisible();
-				await button.click();
-				await this.page.mouse.move(0, 0);
-				await this.page.waitForTimeout(500);
+			if (await this.metadataDialog.isVisible()) {
+				return;
 			}
-
+			await button.click();
+			await this.page.mouse.move(0, 0);
 			await expect(this.metadataDialog).toBeVisible();
 		}, 'Open the Metadata Dialog').toPass({ timeout: 3000 });
 	}

--- a/test/e2e/tests/interpreters/default-python-interpreter.test.ts
+++ b/test/e2e/tests/interpreters/default-python-interpreter.test.ts
@@ -53,17 +53,22 @@ test.describe('Default Interpreters - Python', {
 			? /python-env\/bin\/python/
 			: new RegExp(`~?\\.pyenv/versions/${pythonVersion.replace(/\./g, '\\.')}/bin/python`);
 
-		// Retry with reload on failure -- same detached-session race as #14901; matches
-		// default-r-interpreter.test.ts's idiom.
-		await expect(async () => {
-			try {
-				const { name, path } = await sessions.getMetadata();
-				expect(name).toMatch(versionRegex);
-				expect(path).toMatch(pathRegex);
-			} catch (error) {
-				await hotKeys.reloadWindow(true);
-				throw error;
-			}
-		}).toPass({ timeout: 60000 });
+		// The beforeAll set python.defaultInterpreterPath and reloaded in one call. That reload
+		// cancels the in-flight (extension-requested) session creation, and the affiliated Python
+		// runtime does not reliably auto-start afterward. Wait for a session to actually appear
+		// before reading metadata rather than racing a still-empty console (which is what surfaced
+		// the misleading "Extract session metadata" timeout). If affiliation never fired, reload
+		// once to re-trigger it -- but only after the wait, so we never reload a session mid-start
+		// (a reload cancels in-flight session creation; see #14901).
+		try {
+			await sessions.expectSessionCountToBe(1);
+		} catch {
+			await hotKeys.reloadWindow(true);
+			await sessions.expectSessionCountToBe(1);
+		}
+
+		const { name, path } = await sessions.getMetadata();
+		expect(name).toMatch(versionRegex);
+		expect(path).toMatch(pathRegex);
 	});
 });

--- a/test/e2e/tests/interpreters/default-r-interpreter.test.ts
+++ b/test/e2e/tests/interpreters/default-r-interpreter.test.ts
@@ -44,7 +44,6 @@ test.describe('Default Interpreters - R', {
 
 	test('R - Add a default interpreter', async function ({ sessions, hotKeys }) {
 
-		// No reload here -- see #14901, same detached-session race as the Python default-interpreter test.
 		const hiddenRVersion = process.env.POSITRON_HIDDEN_R;
 		if (!hiddenRVersion) {
 			throw new Error('POSITRON_HIDDEN_R environment variable is not set');
@@ -53,24 +52,28 @@ test.describe('Default Interpreters - R', {
 		// Escape dots for regex matching
 		const escapedVersion = hiddenRVersion.replace(/\./g, '\\.');
 
-		await expect(async () => {
+		// The beforeAll set the default interpreter and reloaded in one call. That reload cancels
+		// the in-flight (extension-requested) session creation, and the affiliated runtime does not
+		// reliably auto-start afterward. Wait for a session to actually appear before reading
+		// metadata rather than racing a still-empty console (which is what surfaced the misleading
+		// "Extract session metadata" timeout). If affiliation never fired, reload once to re-trigger
+		// it -- but only after the wait, so we never reload a session mid-start (a reload cancels
+		// in-flight session creation; see #14901).
+		try {
+			await sessions.expectSessionCountToBe(1);
+		} catch {
+			await hotKeys.reloadWindow(true);
+			await sessions.expectSessionCountToBe(1);
+		}
 
-			try {
-				const { name, path } = await sessions.getMetadata();
+		const { name, path } = await sessions.getMetadata();
 
-				// Local debugging sample:
-				// expect(name).toContain('R 4.3.3');
-				// expect(path).toContain('R.framework/Versions/4.3-arm64/Resources/R');
+		// Local debugging sample:
+		// expect(name).toContain('R 4.3.3');
+		// expect(path).toContain('R.framework/Versions/4.3-arm64/Resources/R');
 
-				// hidden CI interpreter:
-				expect(name).toMatch(new RegExp(`R ${escapedVersion}`));
-				expect(path).toMatch(new RegExp(`R-${escapedVersion}\\/bin\\/R`));
-
-			} catch (error) {
-				await hotKeys.reloadWindow(true);
-				throw error;
-			}
-
-		}).toPass({ timeout: 60000 });
+		// hidden CI interpreter:
+		expect(name).toMatch(new RegExp(`R ${escapedVersion}`));
+		expect(path).toMatch(new RegExp(`R-${escapedVersion}\\/bin\\/R`));
 	});
 });


### PR DESCRIPTION
Two e2e reliability fixes for the flaky `Default Interpreters` tests, both cases of reading session metadata before the session is ready, plus a `triage-e2e-test` skill step.

### Summary
- **default-interpreter tests** (Python + R): wait for the affiliated session to actually start (`expectSessionCountToBe`) before reading metadata; reload once only to re-nudge affiliation if none appeared, so a session mid-start is never reloaded away
- **`openMetadataDialog()`** (`sessions.ts`): wait for the real `info-<id>` testid before clicking and return early if the dialog is already open, so the click lands on a session wired into React context (was clicking while the testid could still be `info-unknown`, a silent no-op)
- **`triage-e2e-test`**: add SKILL.md step 7 (record the diagnosis block on the PR)

### QA Notes
@:interpreter @:sessions
The Python/Conda race needs CI-image contention (hidden Conda startup) and can't be proven with one local run; ci-arm showed R 4/4 clean at `--workers=2`.

### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> (test mitigation) -- tests read session metadata before the session was ready</summary>

- **Spec:** `test/e2e/tests/interpreters/default-python-interpreter.test.ts`
  - **Test:** `Default Interpreters - Python > Python - Add a default interpreter (Conda)`
- **Spec:** `test/e2e/tests/interpreters/default-r-interpreter.test.ts`
  - **Test:** `Default Interpreters - R > R - Add a default interpreter`
- **Signal (Python, kernel-log confirmed):** trace loops on an `info-<id>` button that never renders; failure screenshot shows an empty console ("There is no session running"). On the failing attempt no session is ever created (empty `Python Supervisor.log`); the passing retry starts the affiliated session ~16s after its reload.
- **Signal (R):** the info-button press no-ops while its testid is still `info-unknown` (active session not yet wired into React context), so the popup never opens -- 25/26 clicks on a real `info-<id>` open first try.
- **Frequency:** Python 17/148 (11.5%), R ~7/143 (~5%), ubuntu/electron.
- **Fix:** wait for a session (`expectSessionCountToBe(1)`) before `getMetadata()`, reloading once only to re-nudge affiliation if none appears (never reload a session mid-start -- a reload cancels in-flight creation, #14901); and harden `openMetadataDialog()` against clicking an unwired `info-unknown` button.

</details>

<details>
<summary>🟢 <b>High confidence</b> (product bug -- filed #14991, fixed in #14994) -- the workspace default is dropped on a cold interpreter resolve and never re-driven</summary>

- **Spec:** `test/e2e/tests/interpreters/default-python-interpreter.test.ts`
  - **Test:** `Default Interpreters - Python > Python - Add a default interpreter (Conda)`
- **Signal:** on both failing Python occurrences, `beforeAll`'s `settings.set({ defaultInterpreterPath }, { reload: true })` cancels the extension-requested session (`Creating session ...Python (Conda)... failed. Reason: Canceled`), then the supervisor reconnects with "0 sessions" and no affiliated runtime is ever re-requested (~26-28s to test-fail). Passing retries get the affiliated session ~16s after their reload.
- **Root cause (narrowed by controlled experiment, 2026-07-20):** the recommend query `recommendedWorkspaceRuntime()` -> `getInterpreterDetails` -> `resolveEnv` returns `undefined` when discovery has not resolved the default's path yet (a cold resolve). It runs once, before `discoverAllRuntimes()`, and is never re-driven, so the default is never recommended that window and no affiliation is saved for the reload to re-fire. Proven by instrumenting startup and discarding the recommend result: baseline started Python and passed; injected (recommend dropped, same `count=1 langs=[python]`) started nothing and failed while discovery still registered the runtimes.
- **Fix:** #14994 -- trigger an interpreter refresh and retry the resolve once in `recommendedWorkspaceRuntime()`, so the default is recommended reliably; the affiliation is then saved and the reload starts it. The reload nudge itself is load-bearing by design (an implicit default only starts on a subsequent boot) and stays. positron-r has the same shape and needs the same retry (follow-up).
- **Status:** filed as #14991, fixed in #14994.

</details>
