### PR TITLE
New settings modal should not get all our editor action bar stuff

### DIFF
--- a/.github/workflows/test-tag-paths-map.json
+++ b/.github/workflows/test-tag-paths-map.json
@@ -122,6 +122,7 @@
   "src/vs/platform/positronIdleTracking/": [],
   "src/vs/platform/positronMemoryUsage/": ["@:variables"],
   "src/vs/platform/update/": [],
+  "src/vs/workbench/browser/parts/editor/editorActionBar": ["@:editor-action-bar"],
   "src/vs/workbench/browser/parts/positronTopActionBar/": ["@:top-action-bar"],
   "src/vs/workbench/browser/positronAnsiRenderer/": ["@:console"],
   "src/vs/workbench/browser/positronDataExplorer/": ["@:data-explorer"],

--- a/src/vs/workbench/browser/parts/editor/editorActionBarControl.tsx
+++ b/src/vs/workbench/browser/parts/editor/editorActionBarControl.tsx
@@ -24,7 +24,7 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { SettingsEditor2Input } from '../../../services/preferences/common/preferencesEditorInput.js';
 import { NotebookOutputEditorInput } from '../../../contrib/notebook/browser/outputEditor/notebookOutputEditorInput.js';
-import { IsAuxiliaryWindowContext, IsCompactTitleBarContext } from '../../../common/contextkeys.js';
+import { EditorPartModalContext, IsAuxiliaryWindowContext, IsCompactTitleBarContext } from '../../../common/contextkeys.js';
 
 /**
  * Constants.
@@ -227,6 +227,16 @@ export class EditorActionBarControlFactory {
 	private updateEnablementForEditorInput(editorInput: EditorInput | undefined | null) {
 		// If there isn't an active editor, disable the editor action bar and return.
 		if (!editorInput) {
+			this.updateEnablement(false);
+			return;
+		}
+
+		// Modal editor parts (e.g. the Settings dialog overlay) always disable the
+		// editor action bar. The modal part renders its own header chrome, so the
+		// Positron action bar would appear as a spurious extra row of icons on top of
+		// the dialog. This gate also keeps any action bar widgets (e.g. the Quarto
+		// kernel status badge) from leaking into the modal header.
+		if (EditorPartModalContext.getValue(this._contextKeyService)) {
 			this.updateEnablement(false);
 			return;
 		}

--- a/src/vs/workbench/browser/parts/editor/test/browser/editorActionBarControl.vitest.tsx
+++ b/src/vs/workbench/browser/parts/editor/test/browser/editorActionBarControl.vitest.tsx
@@ -1,0 +1,69 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { Event } from '../../../../../../base/common/event.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { IDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { createTestContainer } from '../../../../../../test/vitest/positronTestContainer.js';
+import { stubInterface } from '../../../../../../test/vitest/stubInterface.js';
+import { EditorPartModalContext } from '../../../../../common/contextkeys.js';
+import { SettingsEditor2Input } from '../../../../../services/preferences/common/preferencesEditorInput.js';
+import { TestEditorInput } from '../../../../../test/browser/workbenchTestServices.js';
+import { IEditorGroupView } from '../../editor.js';
+import { EditorActionBarControlFactory } from '../../editorActionBarControl.js';
+
+describe('EditorActionBarControlFactory enablement', () => {
+	const ctx = createTestContainer().withWorkbenchServices().build();
+
+	// Stub the instantiation service so creating the control yields a sentinel
+	// disposable instead of rendering the real React control. This lets us observe
+	// only the enablement DECISION: `factory.control` is defined when the factory
+	// decides to show the action bar, undefined when it suppresses it.
+	const controlInstantiationService = () => stubInterface<IInstantiationService>({
+		// The factory only ever calls createInstance(EditorActionBarControl, ...);
+		// cast past the overloaded signature to return a lightweight disposable.
+		createInstance: (() => toDisposable(() => { })) as unknown as IInstantiationService['createInstance'],
+	});
+
+	it('suppresses the action bar when the editor group is in a modal part', () => {
+		// Regression: Settings opens in the modal editor part, whose header already
+		// renders its own toolbar. Without the modal gate, the "Settings always
+		// enables" branch would add the Positron action bar as a spurious second row
+		// of icons on the dialog and leak action bar widgets (e.g. the Quarto kernel
+		// status badge) into it. See posit-dev/positron#14781 and #14826.
+		//
+		// A Settings input is used deliberately: it is the case that force-enables the
+		// action bar, so the assertion only holds if the modal gate runs *before* that
+		// branch. Removing the gate falls through to the enable path, `createInstance`
+		// runs, and `factory.control` becomes defined, failing this test.
+		const contextKeyService = ctx.disposables.add(
+			ctx.get(IContextKeyService).createScoped(document.createElement('div'))
+		);
+		EditorPartModalContext.bindTo(contextKeyService).set(true);
+
+		const settingsInput = ctx.disposables.add(
+			new TestEditorInput(URI.file('/settings'), SettingsEditor2Input.ID)
+		) as TestEditorInput & IDisposable;
+		const group = stubInterface<IEditorGroupView>({
+			activeEditor: settingsInput,
+			onDidActiveEditorChange: Event.None,
+		});
+
+		const factory = ctx.disposables.add(new EditorActionBarControlFactory(
+			document.createElement('div'),
+			group,
+			ctx.get(IConfigurationService),
+			controlInstantiationService(),
+			contextKeyService,
+		));
+
+		expect(factory.control).toBeUndefined();
+	});
+});

--- a/src/vs/workbench/contrib/positronQuarto/browser/QuartoKernelStatusBadge.tsx
+++ b/src/vs/workbench/contrib/positronQuarto/browser/QuartoKernelStatusBadge.tsx
@@ -13,7 +13,8 @@ import React from 'react';
 import { localize } from '../../../../nls.js';
 import { IMenuService, MenuId, MenuItemAction, SubmenuItemAction } from '../../../../platform/actions/common/actions.js';
 import { ActionBarMenuButton } from '../../../../platform/positronActionBar/browser/components/actionBarMenuButton.js';
-import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { IEditorGroup } from '../../../services/editor/common/editorGroupsService.js';
+import { useEditorGroup } from '../../../browser/parts/editor/editorGroupContext.js';
 import { IQuartoKernelManager, QuartoKernelState } from './quartoKernelManager.js';
 import { isQuartoDocument } from '../common/positronQuartoConfig.js';
 import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
@@ -59,17 +60,22 @@ interface QuartoKernelStatusBadgeProps {
 }
 
 /**
- * Helper function to get URI and language ID from the active editor.
- * Returns undefined if the active editor is not a Quarto document.
+ * Helper function to get URI and language ID from the given editor group's
+ * active editor. Returns undefined if that editor is not a Quarto document.
+ *
+ * Binds to the group's own active editor rather than the globally active
+ * editor, so the badge keeps reflecting its document's kernel even when another
+ * editor -- such as the Settings modal overlay -- becomes the globally active
+ * editor. See posit-dev/positron#14826.
  */
-function getQuartoDocumentFromEditor(editorService: IEditorService): URI | undefined {
-	const uri = editorService.activeEditor?.resource;
-	const activeEditor = editorService.activeTextEditorControl;
+function getQuartoDocumentFromGroup(editorGroup: IEditorGroup | undefined): URI | undefined {
+	const uri = editorGroup?.activeEditor?.resource;
+	const control = editorGroup?.activeEditorPane?.getControl();
 
 	// Get language ID from the editor model if available
 	let languageId: string | undefined;
-	if (activeEditor && 'getModel' in activeEditor) {
-		const model = (activeEditor as ICodeEditor).getModel();
+	if (control && 'getModel' in control) {
+		const model = (control as ICodeEditor).getModel();
 		languageId = model?.getLanguageId();
 	}
 
@@ -86,15 +92,19 @@ function getQuartoDocumentFromEditor(editorService: IEditorService): URI | undef
  */
 export function QuartoKernelStatusBadge({ accessor }: QuartoKernelStatusBadgeProps) {
 	// Get services
-	const editorService = accessor.get(IEditorService);
 	const quartoKernelManager = accessor.get(IQuartoKernelManager);
 	const menuService = accessor.get(IMenuService);
 	const contextKeyService = accessor.get(IContextKeyService);
 	const languageRuntimeService = accessor.get(ILanguageRuntimeService);
 
+	// The editor group this badge is rendered in. State is resolved from this
+	// group's active editor, not the globally active editor (see
+	// getQuartoDocumentFromGroup).
+	const editorGroup = useEditorGroup();
+
 	// State
 	const [documentUri, setDocumentUri] = React.useState<URI | undefined>(() =>
-		getQuartoDocumentFromEditor(editorService));
+		getQuartoDocumentFromGroup(editorGroup));
 	const [kernelState, setKernelState] = React.useState<QuartoKernelState>(() =>
 		documentUri ? quartoKernelManager.getKernelState(documentUri) : QuartoKernelState.None);
 	const [session, setSession] = React.useState<ILanguageRuntimeSession | undefined>(() =>
@@ -118,19 +128,23 @@ export function QuartoKernelStatusBadge({ accessor }: QuartoKernelStatusBadgePro
 				: undefined);
 		};
 
-		// Listen for active editor changes
-		disposables.add(editorService.onDidActiveEditorChange(() => {
-			const quartoUri = getQuartoDocumentFromEditor(editorService);
-			if (quartoUri) {
-				setDocumentUri(quartoUri);
-				setKernelState(quartoKernelManager.getKernelState(quartoUri));
-				setSession(quartoKernelManager.getSessionForDocument(quartoUri));
-			} else {
-				setDocumentUri(undefined);
-				setKernelState(QuartoKernelState.None);
-				setSession(undefined);
-			}
-		}));
+		// Listen for active editor changes within this editor group (not the
+		// globally active editor), so opening another editor -- e.g. the Settings
+		// modal -- doesn't reset this document's kernel badge.
+		if (editorGroup) {
+			disposables.add(editorGroup.onDidActiveEditorChange(() => {
+				const quartoUri = getQuartoDocumentFromGroup(editorGroup);
+				if (quartoUri) {
+					setDocumentUri(quartoUri);
+					setKernelState(quartoKernelManager.getKernelState(quartoUri));
+					setSession(quartoKernelManager.getSessionForDocument(quartoUri));
+				} else {
+					setDocumentUri(undefined);
+					setKernelState(QuartoKernelState.None);
+					setSession(undefined);
+				}
+			}));
+		}
 
 		// Listen for kernel state changes
 		disposables.add(quartoKernelManager.onDidChangeKernelState(e => {
@@ -151,7 +165,7 @@ export function QuartoKernelStatusBadge({ accessor }: QuartoKernelStatusBadgePro
 		refreshPreferredRuntime();
 
 		return () => disposables.dispose();
-	}, [editorService, quartoKernelManager, languageRuntimeService, documentUri]);
+	}, [editorGroup, quartoKernelManager, languageRuntimeService, documentUri]);
 
 	// Prefer the session's runtime state. Fall back to the manager's
 	// pre-session kernel state (None / Error) when no session exists.

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/QuartoKernelStatusBadge.vitest.tsx
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/QuartoKernelStatusBadge.vitest.tsx
@@ -7,10 +7,12 @@
 
 import { act, screen } from '@testing-library/react';
 import { URI } from '../../../../../base/common/uri.js';
-import { Emitter } from '../../../../../base/common/event.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
 import { ILanguageRuntimeMetadata, ILanguageRuntimeService, RuntimeStartupPhase, RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
-import { IEditorService } from '../../../../services/editor/common/editorService.js';
+import { IEditorGroup } from '../../../../services/editor/common/editorGroupsService.js';
+import { EditorGroupContext } from '../../../../browser/parts/editor/editorGroupContext.js';
+import { EditorInput } from '../../../../common/editor/editorInput.js';
 import { IQuartoKernelManager, QuartoKernelState, QuartoKernelStateChangeEvent } from '../../browser/quartoKernelManager.js';
 import { QuartoKernelStatusBadge } from '../../browser/QuartoKernelStatusBadge.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
@@ -19,17 +21,23 @@ import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary
 
 describe('QuartoKernelStatusBadge', () => {
 	const stateChange = new Emitter<QuartoKernelStateChangeEvent>();
-	const editorChange = new Emitter<void>();
 	const displayStateEmitter = new Emitter<{ sessionId: string; state: RuntimeState }>();
 	const registerRuntimeEmitter = new Emitter<ILanguageRuntimeMetadata>();
 	const startupPhaseEmitter = new Emitter<RuntimeStartupPhase>();
 	let displayState: RuntimeState | undefined;
 
-	const editorServiceStub = {
-		activeEditor: { resource: URI.file('/tmp/notebook.qmd') },
-		activeTextEditorControl: undefined as unknown,
-		onDidActiveEditorChange: editorChange.event,
-	};
+	const quartoUri = URI.file('/tmp/notebook.qmd');
+
+	// The badge binds to its own editor group, not the globally active editor
+	// (posit-dev/positron#14826). Rendering inside this group -- whose active
+	// editor is the .qmd -- is what drives the badge; the ambient IEditorService
+	// deliberately has no Quarto editor active, so a regression to reading the
+	// global active editor would surface as "No Kernel" and fail these tests.
+	const editorGroupStub = stubInterface<IEditorGroup>({
+		activeEditor: stubInterface<EditorInput>({ resource: quartoUri }),
+		activeEditorPane: undefined,
+		onDidActiveEditorChange: Event.None,
+	});
 
 	const kernelManagerStub = {
 		onDidChangeKernelState: stateChange.event,
@@ -40,7 +48,6 @@ describe('QuartoKernelStatusBadge', () => {
 
 	const ctx = createTestContainer()
 		.withReactServices()
-		.stub(IEditorService, editorServiceStub)
 		.stub(IQuartoKernelManager, kernelManagerStub)
 		.stub(IRuntimeSessionService, {
 			onDidChangeDisplayRuntimeState: displayStateEmitter.event,
@@ -52,6 +59,13 @@ describe('QuartoKernelStatusBadge', () => {
 		})
 		.build();
 	const rtl = setupRTLRenderer(() => ctx.reactServices);
+
+	// Render the badge inside its editor group, the way the action bar does.
+	const renderBadge = () => rtl.render(
+		<EditorGroupContext.Provider value={editorGroupStub}>
+			<QuartoKernelStatusBadge accessor={ctx.instantiationService} />
+		</EditorGroupContext.Provider>
+	);
 
 	function makeSession(initial: RuntimeState, sessionId = 's1') {
 		const emitter = new Emitter<RuntimeState>();
@@ -66,14 +80,13 @@ describe('QuartoKernelStatusBadge', () => {
 
 	beforeEach(() => {
 		displayState = undefined;
-		editorServiceStub.activeEditor = { resource: URI.file('/tmp/notebook.qmd') };
 		kernelManagerStub.getKernelState = () => QuartoKernelState.None;
 		kernelManagerStub.getSessionForDocument = () => undefined;
 		kernelManagerStub.getPreferredRuntimeForDocument = () => undefined;
 	});
 
 	it('shows disconnected icon and "No Kernel" label when no session, no preferred runtime, and state is None', () => {
-		rtl.render(<QuartoKernelStatusBadge accessor={ctx.instantiationService} />);
+		renderBadge();
 		expect(screen.getByTestId('runtime-status-disconnected')).toBeInTheDocument();
 		expect(screen.getByText('No Kernel')).toBeInTheDocument();
 	});
@@ -83,7 +96,7 @@ describe('QuartoKernelStatusBadge', () => {
 		// name it instead of showing "No Kernel".
 		kernelManagerStub.getPreferredRuntimeForDocument = () =>
 			stubInterface<ILanguageRuntimeMetadata>({ runtimeName: 'Python 3.12' });
-		rtl.render(<QuartoKernelStatusBadge accessor={ctx.instantiationService} />);
+		renderBadge();
 		expect(screen.getByTestId('runtime-status-disconnected')).toBeInTheDocument();
 		expect(screen.getByText('Python 3.12')).toBeInTheDocument();
 	});
@@ -92,7 +105,7 @@ describe('QuartoKernelStatusBadge', () => {
 		// Interpreter discovery can finish after the editor opens: the badge
 		// starts with "No Kernel" and should adopt the interpreter name once a
 		// preferred runtime becomes available and a registration event fires.
-		rtl.render(<QuartoKernelStatusBadge accessor={ctx.instantiationService} />);
+		renderBadge();
 		expect(screen.getByText('No Kernel')).toBeInTheDocument();
 
 		kernelManagerStub.getPreferredRuntimeForDocument = () =>
@@ -106,7 +119,7 @@ describe('QuartoKernelStatusBadge', () => {
 	it('recomputes the preferred runtime when the startup phase changes', () => {
 		// The preferred runtime can resolve as the runtime startup sequence
 		// advances, so a startup-phase change should also refresh the label.
-		rtl.render(<QuartoKernelStatusBadge accessor={ctx.instantiationService} />);
+		renderBadge();
 		expect(screen.getByText('No Kernel')).toBeInTheDocument();
 
 		kernelManagerStub.getPreferredRuntimeForDocument = () =>
@@ -122,13 +135,13 @@ describe('QuartoKernelStatusBadge', () => {
 		kernelManagerStub.getKernelState = () => QuartoKernelState.Error;
 		kernelManagerStub.getPreferredRuntimeForDocument = () =>
 			stubInterface<ILanguageRuntimeMetadata>({ runtimeName: 'Python 3.12' });
-		rtl.render(<QuartoKernelStatusBadge accessor={ctx.instantiationService} />);
+		renderBadge();
 		expect(screen.getByText('Kernel Error')).toBeInTheDocument();
 	});
 
 	it('shows disconnected icon when manager reports an Error state', () => {
 		kernelManagerStub.getKernelState = () => QuartoKernelState.Error;
-		rtl.render(<QuartoKernelStatusBadge accessor={ctx.instantiationService} />);
+		renderBadge();
 		expect(screen.getByTestId('runtime-status-disconnected')).toBeInTheDocument();
 		expect(screen.getByText('Kernel Error')).toBeInTheDocument();
 	});
@@ -138,7 +151,7 @@ describe('QuartoKernelStatusBadge', () => {
 		kernelManagerStub.getSessionForDocument = () => session;
 		kernelManagerStub.getKernelState = () => QuartoKernelState.Ready;
 		displayState = RuntimeState.Idle;
-		rtl.render(<QuartoKernelStatusBadge accessor={ctx.instantiationService} />);
+		renderBadge();
 		expect(screen.getByTestId('runtime-status-idle')).toBeInTheDocument();
 		expect(screen.getByText('Python 3.12')).toBeInTheDocument();
 	});
@@ -148,7 +161,7 @@ describe('QuartoKernelStatusBadge', () => {
 		kernelManagerStub.getSessionForDocument = () => session;
 		kernelManagerStub.getKernelState = () => QuartoKernelState.Ready;
 		displayState = RuntimeState.Idle;
-		rtl.render(<QuartoKernelStatusBadge accessor={ctx.instantiationService} />);
+		renderBadge();
 		act(() => displayStateEmitter.fire({ sessionId: 's1', state: RuntimeState.Busy }));
 		expect(screen.getByTestId('runtime-status-active')).toBeInTheDocument();
 	});
@@ -158,17 +171,35 @@ describe('QuartoKernelStatusBadge', () => {
 		kernelManagerStub.getSessionForDocument = () => a.session;
 		kernelManagerStub.getKernelState = () => QuartoKernelState.Ready;
 		displayState = RuntimeState.Idle;
-		rtl.render(<QuartoKernelStatusBadge accessor={ctx.instantiationService} />);
+		renderBadge();
 
 		const b = makeSession(RuntimeState.Starting, 'sB');
 		displayState = RuntimeState.Starting;
 		act(() => stateChange.fire({
-			documentUri: URI.file('/tmp/notebook.qmd'),
+			documentUri: quartoUri,
 			oldState: QuartoKernelState.Ready,
 			newState: QuartoKernelState.Starting,
 			session: b.session,
 		}));
 
 		expect(screen.getByTestId('runtime-status-active')).toBeInTheDocument();
+	});
+
+	it('keeps its running kernel visible when another editor is globally active (#14826)', () => {
+		// The Settings dialog opens in a modal overlay that becomes the globally
+		// active editor. Previously the badge read the global active editor, so a
+		// running .qmd kernel reset to "No Kernel" while the modal was in front and
+		// recovered on dismiss. The badge now reads its own group (the .qmd, with a
+		// live session), so its kernel stays visible regardless of what is globally
+		// active -- represented here by the container's ambient IEditorService,
+		// which has no Quarto editor active.
+		const { session } = makeSession(RuntimeState.Idle);
+		kernelManagerStub.getSessionForDocument = () => session;
+		kernelManagerStub.getKernelState = () => QuartoKernelState.Ready;
+		displayState = RuntimeState.Idle;
+		renderBadge();
+
+		expect(screen.getByText('Python 3.12')).toBeInTheDocument();
+		expect(screen.queryByText('No Kernel')).not.toBeInTheDocument();
 	});
 });

--- a/test/e2e/tests/editor-action-bar/settings-modal.test.ts
+++ b/test/e2e/tests/editor-action-bar/settings-modal.test.ts
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Editor Action Bar: Modal Editor Overlay
+ *
+ * Regression guard for the upstream modal editor overlay (the dialog that Settings,
+ * Keyboard Shortcuts, etc. open in). The modal renders its own header toolbar, so the
+ * Positron editor action bar must not also render inside it. Previously it did,
+ * producing a spurious second row of icons and leaking action bar widgets such as the
+ * Quarto kernel status badge into the dialog.
+ *
+ * See posit-dev/positron#14781 and #14826.
+ *
+ * The modal is driven here via `workbench.editor.useModal: 'all'`, which routes every
+ * editor into the overlay. Settings itself is deliberately NOT routed to the modal under
+ * the smoke-test driver (see preferencesService.getEditorGroupFromOptions), and Workspace
+ * Trust is disabled in e2e (--disable-workspace-trust), so neither can be used to reach
+ * the modal here. `editor.actionBar.enabled` is turned on so the action bar *would* render
+ * inside the modal if the suppression gate were missing, which is what makes the absence
+ * assertion meaningful rather than vacuous.
+ */
+
+import { test, expect, tags } from '../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Editor Action Bar: Modal Editor Overlay', {
+	tag: [tags.WEB, tags.MODAL, tags.EDITOR_ACTION_BAR, tags.VSCODE_SETTINGS]
+}, () => {
+
+	test.afterEach(async function ({ runCommand }) {
+		await runCommand('workbench.action.closeModalEditor');
+	});
+
+	test('does not render the Positron editor action bar inside the modal editor overlay', async function ({ page, settings, runCommand }) {
+		// keepOpen: false forces the settings reload to settle before we open an editor,
+		// so `useModal: 'all'` is in effect by the time the editor is routed.
+		await settings.set(
+			{ 'editor.actionBar.enabled': true, 'workbench.editor.useModal': 'all' },
+			{ keepOpen: false }
+		);
+
+		await runCommand('workbench.action.files.newUntitledFile');
+
+		const modal = page.locator('.monaco-modal-editor-block');
+		await expect(modal).toBeVisible();
+
+		// Wait for the editor content to render inside the modal before the negative
+		// assertion. The action bar (if enabled) is prepended to the editor group as it
+		// is created, so once the editor is present the enablement decision has already
+		// been made -- this closes the race where an empty modal frame would let
+		// `toHaveCount(0)` pass before a leaked action bar had a chance to appear.
+		await expect(modal.locator('.monaco-editor').first()).toBeVisible();
+
+		await expect(modal.locator('.editor-action-bar-container')).toHaveCount(0);
+	});
+});


### PR DESCRIPTION
- Fixes #14781
- Fixes #14826

The 1.124 upstream merge added the new modal editor overlay (the dialog that Settings and similar editors open in front of the app). Two pieces of Positron-specific UI were leaking into or misbehaving around that overlay.

### Editor action bar on the modal (#14782)
 
Positron's editor action bar was rendering inside the modal editor, adding a spurious second row of icons on top of the dialog's own header and pulling in action bar widgets (such as the Quarto kernel status badge). `EditorActionBarControlFactory` now suppresses the action bar whenever its editor group belongs to a modal editor part, gated on the `editorPartModal` context key, alongside the existing auxiliary-window and notebook gates. This handles every current and future action bar widget in one place:

<img width="1406" height="1055" alt="Screenshot 2026-07-17 at 5 58 07 PM" src="https://github.com/user-attachments/assets/73f69ffc-216e-4b0c-8021-ba0192c15e7f" />

### Quarto kernel badge flipping to "No Kernel" (#14826)

On a real `.qmd` with inline output enabled and a running kernel, opening the Settings modal flipped the document's kernel badge to "No Kernel", and then it recovered when the modal was dismissed. The badge derived its state from the globally active editor, so when the modal became active it recomputed against the wrong editor. It now binds to its own editor group via `useEditorGroup()` (the same group-scoped pattern the notebook kernel badge already uses), so it keeps reporting its document's kernel regardless of what is globally active:

<img width="1406" height="1055" alt="Screenshot 2026-07-17 at 5 57 52 PM" src="https://github.com/user-attachments/assets/22adb19a-44cd-4960-83f0-0730e057743d" />

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

@:modal @:editor-action-bar @:vscode-settings @:quarto

An automated e2e test (`test/e2e/tests/editor-action-bar/settings-modal.test.ts`) covers the action bar suppression in the modal. To validate manually:

1. Run "Preferences: Open Settings (UI)". Confirm the dialog shows a single header toolbar, with no extra Positron action bar row of icons.
2. Enable Quarto inline output, open a `.qmd`, and run a cell so the kernel status badge shows the running interpreter.
3. Open Settings while the `.qmd` is still open. Confirm the `.qmd` kernel badge still shows the running interpreter (not "No Kernel"), and that no kernel badge appears on the Settings dialog itself.
4. Dismiss the Settings dialog and confirm the badge remains correct.

Test coverage: the action bar fix has unit (`editorActionBarControl.vitest.tsx`) and e2e coverage; the Quarto badge fix has unit coverage (`QuartoKernelStatusBadge.vitest.tsx`). An e2e test for the badge is impractical because it requires a live kernel with inline output enabled.
