### PR TITLE
Make Positron view focus commands agent-invocable

### DIFF
--- a/.claude/skills/agent-compatible-command/SKILL.md
+++ b/.claude/skills/agent-compatible-command/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: agent-compatible-command
+description: Use when making a Positron command invocable by Posit Assistant (agent-compatible) - reviews the command, decides whether it can be made agent-invocable in place, lists the exact edits, and applies them. Triggers on "make this command agent-compatible", "agentCompatible", "let the assistant run this command".
+---
+
+# Making a Positron command agent-invocable
+
+Posit Assistant runs Positron commands through its `positronCommand` tool. It embeds
+the curated list from `positron.ai.getAgentAllowedCommands()` in its system prompt and
+executes a chosen command via `positron.ai.validateAndExecuteCommand(id, args)`, so a
+command is only usable by the assistant if it is advertised by that endpoint and can run
+without prompting. This skill makes one command agent-invocable using the project
+pattern (see `docs/superpowers/specs/2026-07-17-agent-invocable-commands-design.md`).
+
+## The pattern
+
+One command, one code path. The command prompts only for what it was not given:
+no arguments -> the existing picker/input box (a user); arguments supplied -> run
+headless (an agent). You annotate the command and, if it takes new arguments, add
+them as optional parameters that skip the prompt when present.
+
+## Steps
+
+1. **Locate the command.** Find its registration (`registerAction2`/`Action2` or
+   `CommandsRegistry.registerCommand`). Note its id and its `run()` signature. Palette
+   exposure (`f1: true`) is NOT required: the endpoint advertises any `agentCompatible`
+   command whose precondition currently holds, palette or not.
+
+2. **List non-test call sites.** Search for `executeCommand('<id>')` and menu
+   contributions. Record what each caller passes.
+
+3. **Apply the decision rule.**
+   - If no caller passes the argument an agent would supply (the usual case: the
+     command is argless and opens a picker), add an OPTIONAL typed parameter and only
+     prompt when it is missing.
+   - If a caller passes the SAME argument an agent would (so argument-presence cannot
+     tell a user from an agent - for example a destructive command whose UI also
+     passes the item id), STOP and ask the user how to proceed. Do not silently change
+     the shared behavior. (This is why `uninstallPackage` was dropped from scope.)
+
+4. **Report the exact edits before applying:**
+   - `agentCompatible: true` and a `description` in the command's `metadata`.
+   - `args`: one entry per positional argument, each with a `name`, a `description`,
+     a JSON `schema` (for example `{ type: 'string' }`), and `isOptional: true` for
+     optional ones.
+   - **Never set `constraint`** on these args. `constraint` is enforced at runtime on
+     every invocation and would reject existing callers (for example menu callers that
+     pass a context object). `schema` is documentation for the model and is not
+     enforced.
+   - Optionally a `returns` string when the command returns something useful.
+   - The `run()` change: accept the new optional parameter(s) and prompt only when a
+     parameter is missing (`const x = arg ?? await prompt()`).
+
+   The `description`, each arg's `description`/`schema`, and `returns` are shown to the
+   model verbatim in the assistant's system prompt, so write them for that reader. An
+   arg is treated as required unless you set `isOptional: true`.
+
+5. **Apply the edits with the user, then verify:**
+   - `npm run build-check` is clean.
+   - In the running app, "Developer: Show All Agent-Compatible Commands" lists the
+     command with the expected `args`.
+   - Calling the command with arguments runs without a prompt; calling it with none
+     still prompts (unchanged for users).
+
+## Worked references
+
+- In place, argless -> optional arg: `positron.help.lookupHelpTopic` (a `topic?` param).
+- Already argument-driven, add a documented value: `positronPackages.updatePackage`
+  (agent passes `version`, using `'latest'` for the newest; name-only still prompts).

--- a/.claude/skills/agent-compatible-command/SKILL.md
+++ b/.claude/skills/agent-compatible-command/SKILL.md
@@ -9,8 +9,7 @@ Posit Assistant runs Positron commands through its `positronCommand` tool. It em
 the curated list from `positron.ai.getAgentAllowedCommands()` in its system prompt and
 executes a chosen command via `positron.ai.validateAndExecuteCommand(id, args)`, so a
 command is only usable by the assistant if it is advertised by that endpoint and can run
-without prompting. This skill makes one command agent-invocable using the project
-pattern (see `docs/superpowers/specs/2026-07-17-agent-invocable-commands-design.md`).
+without prompting. This skill makes one command agent-invocable using the pattern below.
 
 ## The pattern
 
@@ -36,7 +35,7 @@ them as optional parameters that skip the prompt when present.
    - If a caller passes the SAME argument an agent would (so argument-presence cannot
      tell a user from an agent - for example a destructive command whose UI also
      passes the item id), STOP and ask the user how to proceed. Do not silently change
-     the shared behavior. (This is why `uninstallPackage` was dropped from scope.)
+     the shared behavior.
 
 4. **Report the exact edits before applying:**
    - `agentCompatible: true` and a `description` in the command's `metadata`.

--- a/.claude/skills/agent-compatible-command/SKILL.md
+++ b/.claude/skills/agent-compatible-command/SKILL.md
@@ -48,7 +48,22 @@ them as optional parameters that skip the prompt when present.
      enforced.
    - Optionally a `returns` string when the command returns something useful.
    - The `run()` change: accept the new optional parameter(s) and prompt only when a
-     parameter is missing (`const x = arg ?? await prompt()`).
+     usable value is missing. Treat only a non-empty string as supplied - menu items
+     can forward a context object as the first argument, so a bare truthiness or `??`
+     check misreads them:
+
+     ```ts
+     const suppliedX = typeof x === 'string' && x.length > 0 ? x : undefined;
+     const value = suppliedX ?? await prompt();
+     ```
+
+     Use `suppliedX` (not `x`) everywhere downstream, including any "was it
+     supplied?" branching.
+   - Fail loud on the agent path: when a supplied value cannot be resolved (an
+     unknown id, or a later lookup that depends on it finds nothing), notify the
+     user AND throw. A silent return reads as success through
+     `validateAndExecuteCommand`; a throw comes back as `{ok: false}` with the
+     message. The no-argument interactive path keeps its existing behavior.
 
    The `description`, each arg's `description`/`schema`, and `returns` are shown to the
    model verbatim in the assistant's system prompt, so write them for that reader. An

--- a/.claude/skills/agent-compatible-command/SKILL.md
+++ b/.claude/skills/agent-compatible-command/SKILL.md
@@ -58,8 +58,10 @@ them as optional parameters that skip the prompt when present.
    - `npm run build-check` is clean.
    - In the running app, "Developer: Show All Agent-Compatible Commands" lists the
      command with the expected `args`.
-   - Calling the command with arguments runs without a prompt; calling it with none
-     still prompts (unchanged for users).
+   - Both code paths still work. Agent path: invoke the command with its argument
+     supplied (easiest way: ask the assistant) and it completes with no picker or
+     input box. User path: run it from the Command Palette, which passes no
+     arguments, and it prompts exactly as it did before the change.
 
 ## Worked references
 

--- a/src/vs/workbench/common/views.ts
+++ b/src/vs/workbench/common/views.ts
@@ -318,6 +318,11 @@ export interface IViewDescriptor {
 
 	readonly focusCommand?: { id: string; keybindings?: IKeybindings };
 
+	// --- Start Positron ---
+	/** When true, the auto-generated `<id>.focus` command is exposed to AI agents via `getAgentAllowedCommands()`. */
+	readonly agentCompatible?: boolean;
+	// --- End Positron ---
+
 	// For contributed remote explorer views
 	readonly group?: string;
 

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsole.contribution.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsole.contribution.ts
@@ -55,6 +55,7 @@ const VIEW_CONTAINER: ViewContainer = Registry.as<IViewContainersRegistry>(ViewC
 
 Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews([{
 	id: POSITRON_CONSOLE_VIEW_ID,
+	agentCompatible: true,
 	name: {
 		value: nls.localize('positron.console', "Console"),
 		original: 'Console'

--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelp.contribution.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelp.contribution.ts
@@ -50,6 +50,7 @@ const VIEW_CONTAINER: ViewContainer = Registry.as<IViewContainersRegistry>(
 
 Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews([{
 	id: POSITRON_HELP_VIEW_ID,
+	agentCompatible: true,
 	name: {
 		value: nls.localize('positron.help', "Help"),
 		original: 'Help'

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
@@ -64,6 +64,7 @@ Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews
 	[
 		{
 			id: POSITRON_PACKAGES_VIEW_ID,
+			agentCompatible: true,
 			name: {
 				value: nls.localize('positron.packages', 'Packages'),
 				original: 'Packages'

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
@@ -37,6 +37,7 @@ Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews
 	[
 		{
 			id: POSITRON_PLOTS_VIEW_ID,
+			agentCompatible: true,
 			name: {
 				value: nls.localize('positron.plots', "Plots"),
 				original: 'Plots'

--- a/src/vs/workbench/contrib/positronVariables/browser/positronVariables.contribution.ts
+++ b/src/vs/workbench/contrib/positronVariables/browser/positronVariables.contribution.ts
@@ -29,6 +29,7 @@ Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews
 	[
 		{
 			id: POSITRON_VARIABLES_VIEW_ID,
+			agentCompatible: true,
 			name: {
 				value: nls.localize('positron.variables', "Variables"),
 				original: 'Variables'

--- a/src/vs/workbench/services/views/browser/viewsService.ts
+++ b/src/vs/workbench/services/views/browser/viewsService.ts
@@ -598,21 +598,26 @@ export class ViewsService extends Disposable implements IViewsService {
 					},
 					metadata: {
 						description: title.value,
+						// --- Start Positron ---
+						agentCompatible: viewDescriptor.agentCompatible,
+						// Describe the focus option so agents (getAgentAllowedCommands) can use it.
 						args: [
 							{
 								name: 'focusOptions',
-								description: 'Focus Options',
+								description: 'Options for focusing the view.',
 								schema: {
 									type: 'object',
 									properties: {
 										'preserveFocus': {
 											type: 'boolean',
-											default: false
+											default: false,
+											description: 'When true, reveal the view without moving keyboard focus to it - use when the user should not be interrupted (e.g. actively typing). Omit or false to focus the view (the usual case).'
 										}
 									},
 								}
 							}
 						]
+						// --- End Positron ---
 					}
 				});
 			}


### PR DESCRIPTION
Partially addresses #15063 

Builds on #14913, which added the `getAgentAllowedCommands()` API. This PR makes the first set of Positron commands available through it: the focus commands for the Console, Variables, Plots, Help, and Packages views.

Every view already auto-generates a `<id>.focus` command. This adds an `agentCompatible` flag to `IViewDescriptor`, and when a view sets it, `ViewsService` marks that generated focus command as agent-compatible so it shows up in `getAgentAllowedCommands()`. The five views above opt in. I also filled in the focus command's argument metadata so an agent can use it well: the `preserveFocus` option now has a real description explaining when to reveal a view without moving keyboard focus to it.

Also adds an `agent-compatible-command` skill that documents how to make a command agent-compatible, so the pattern is easy to follow for future commands.

### Screenshots

**Console**

https://github.com/user-attachments/assets/6632793c-0ed6-4595-a0bb-b3725011aceb

**Help**

https://github.com/user-attachments/assets/da8f8a8f-9053-48d8-ae92-6611a12b84b5

**Packages**

https://github.com/user-attachments/assets/4471d9e5-6061-4e7a-81cb-f6dcdd384ad7

**Plots**

https://github.com/user-attachments/assets/be64b39d-994c-4b3a-99ff-15b2c2bbb657

**Variables**

https://github.com/user-attachments/assets/835d656b-51e5-4146-bc8c-991d5be9a0bf

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

@:assistant

1. Run "Developer: Show Agent-Allowed Commands" from the command palette.
2. Verify the Console, Variables, Plots, Help, and Packages `.focus` commands appear in the output, each with a `focusOptions` argument and a `preserveFocus` description.
3. With Posit Assistant set up (posit-dev/assistant#1810) and `assistant.positronCommandIntegration` on, ask the assistant to focus one of these views and confirm it runs the matching command.
