### PR TITLE
Defer Catalog Explorer (and especially Snowflake SDK) load until needed

### DIFF
--- a/extensions/positron-catalog-explorer/.vscodeignore
+++ b/extensions/positron-catalog-explorer/.vscodeignore
@@ -4,10 +4,11 @@ src/**
 .gitignore
 .prettierignore
 .yarnrc
-esbuild.js
 vsc-extension-quickstart.md
 **/tsconfig.json
+**/tsconfig.tsbuildinfo
 **/eslint.config.mjs
 **/*.map
 **/*.ts
+**/*.mts
 **/.vscode-test.*

--- a/extensions/positron-catalog-explorer/package.json
+++ b/extensions/positron-catalog-explorer/package.json
@@ -13,7 +13,10 @@
     "Data Science"
   ],
   "activationEvents": [
-    "onStartupFinished"
+    "onView:catalog-explorer",
+    "onCommand:posit.catalog-explorer.addCatalogProvider",
+    "onCommand:posit.catalog-explorer.removeCatalogProvider",
+    "onCommand:posit.catalog-explorer.refresh"
   ],
   "main": "./out/extension.js",
   "extensionDependencies": [
@@ -26,7 +29,7 @@
         "catalogExplorer.enabled": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Enable or disable the experimental Catalog Explorer extension. When disabled, the extension will not activate. Requires a restart of Positron to take effect.",
+          "markdownDescription": "Enable or disable the experimental Catalog Explorer extension. When disabled, the Catalog Explorer view is hidden and the extension is not loaded.",
           "tags": [
             "experimental"
           ]

--- a/extensions/positron-catalog-explorer/src/catalogs/snowflake.ts
+++ b/extensions/positron-catalog-explorer/src/catalogs/snowflake.ts
@@ -5,7 +5,11 @@
 
 import * as vscode from 'vscode';
 import * as path from 'path';
-import * as snowflake from 'snowflake-sdk';
+// Import the Snowflake SDK for its types only. The runtime module is large and
+// pulls in a sizable dependency tree, so it is loaded lazily via
+// loadSnowflakeSdk() rather than at extension activation. See that function for
+// details.
+import type * as snowflake from 'snowflake-sdk';
 import {
 	CatalogNode,
 	CatalogProvider,
@@ -19,6 +23,31 @@ import { getSnowflakeConnectionOptions, SnowflakeConnectionOptions } from '../cr
 import { l10n } from 'vscode';
 
 export type SnowflakeLogLevel = 'ERROR' | 'WARN' | 'INFO' | 'DEBUG' | 'TRACE';
+
+/**
+ * Cached Snowflake SDK module, populated on first use by {@link loadSnowflakeSdk}.
+ */
+let snowflakeSdk: typeof import('snowflake-sdk') | undefined;
+
+/**
+ * Lazily load the Snowflake SDK.
+ *
+ * The SDK and its dependency tree are only needed once the user actually
+ * connects to Snowflake, so the module is imported on demand instead of at
+ * extension activation. This keeps it (and its many transitive dependencies)
+ * out of the extension host's memory for users who never use Snowflake.
+ *
+ * The SDK logger is configured on first load, before any connection is
+ * established (connecting is what triggers the SDK's first log writes).
+ */
+async function loadSnowflakeSdk(context: vscode.ExtensionContext): Promise<typeof import('snowflake-sdk')> {
+	if (!snowflakeSdk) {
+		const sdk = await import('snowflake-sdk');
+		await configureSnowflakeLogging(context, sdk);
+		snowflakeSdk = sdk;
+	}
+	return snowflakeSdk;
+}
 
 export const registration: CatalogProviderRegistration = {
 	label: l10n.t('Snowflake'),
@@ -95,17 +124,21 @@ export async function ensureSnowflakeLogDirectory(context: vscode.ExtensionConte
  * there. Point the log file at the extension's log directory instead so it stays
  * out of the user's home directory.
  *
- * This is configured once at activation so the log path is set before any
- * Snowflake connection is established (connecting is what triggers the SDK's
- * first log writes).
+ * This is configured once when the SDK is first loaded (see
+ * {@link loadSnowflakeSdk}) so the log path is set before any Snowflake
+ * connection is established (connecting is what triggers the SDK's first log
+ * writes).
  */
-export async function configureSnowflakeLogging(context: vscode.ExtensionContext): Promise<void> {
+async function configureSnowflakeLogging(
+	context: vscode.ExtensionContext,
+	sdk: typeof import('snowflake-sdk'),
+): Promise<void> {
 	const config = vscode.workspace.getConfiguration('catalogExplorer');
 	const logLevelStr = config.get<string>('logLevel', 'INFO') as SnowflakeLogLevel;
 
 	await ensureSnowflakeLogDirectory(context);
 
-	snowflake.configure({
+	sdk.configure({
 		logLevel: logLevelStr,
 		logFilePath: getSnowflakeLogFilePath(context),
 	});
@@ -201,7 +234,8 @@ export async function registerSnowflakeCatalog(
 		});
 	}
 
-	const connection = snowflake.createConnection(connectionOptions);
+	const sdk = await loadSnowflakeSdk(context);
+	const connection = sdk.createConnection(connectionOptions);
 
 	return await vscode.window.withProgress(
 		{

--- a/extensions/positron-catalog-explorer/src/extension.ts
+++ b/extensions/positron-catalog-explorer/src/extension.ts
@@ -13,23 +13,27 @@ import { DefaultDatabricksCredentialProvider } from './credentials';
 import { registerDatabricksProvider } from './catalogs/databricks';
 import { registerMockProvider } from './catalogs/mock';
 import { registerDbfsProvider } from './fs/dbfs';
-import { configureSnowflakeLogging, registerSnowflakeProvider } from './catalogs/snowflake';
+import { registerSnowflakeProvider } from './catalogs/snowflake';
 import { setExtensionUri } from './resources';
-import { initializeLogging, traceInfo, traceWarn } from './logging';
+import { initializeLogging, traceInfo } from './logging';
 
-let catalogExplorerEnabled = false;
-
-async function initializeCatalogExplorer(context: vscode.ExtensionContext): Promise<void> {
-	if (catalogExplorerEnabled) {
-		return;
-	}
+/**
+ * Activate the Catalog Explorer extension.
+ *
+ * Activation is driven on demand by the declarative activation events in
+ * package.json (the `catalog-explorer` view and the palette commands), all of
+ * which are gated on `config.catalogExplorer.enabled`. As a result the
+ * extension - and its module graph - is only loaded once the feature is
+ * actually enabled and used, rather than on every Positron startup.
+ */
+export async function activate(context: vscode.ExtensionContext) {
+	initializeLogging();
+	traceInfo('Catalog Explorer extension activating');
 
 	const config = vscode.workspace.getConfiguration('catalogExplorer');
 	const viewTestCatalog = config.get<boolean>('viewTestCatalog', false);
 
 	setExtensionUri(context);
-
-	await configureSnowflakeLogging(context);
 
 	const registry = new CatalogProviderRegistry();
 
@@ -46,37 +50,7 @@ async function initializeCatalogExplorer(context: vscode.ExtensionContext): Prom
 	);
 	registerCatalogCommands(context, registry);
 
-	catalogExplorerEnabled = true;
 	traceInfo('Catalog Explorer extension initialized');
-}
-
-export async function activate(context: vscode.ExtensionContext) {
-	initializeLogging();
-	traceInfo('Catalog Explorer extension activating');
-
-	// Check if the extension is enabled via configuration
-	const config = vscode.workspace.getConfiguration('catalogExplorer');
-	const isEnabled = config.get<boolean>('enabled', true);
-
-	// If the extension is disabled, set up a listener to initialize when enabled
-	if (!isEnabled) {
-		traceWarn('Catalog Explorer extension is disabled via configuration');
-		context.subscriptions.push(
-			vscode.workspace.onDidChangeConfiguration(async (e) => {
-				if (e.affectsConfiguration('catalogExplorer.enabled')) {
-					const newConfig = vscode.workspace.getConfiguration('catalogExplorer');
-					const newEnabled = newConfig.get<boolean>('enabled', false);
-					if (newEnabled && !catalogExplorerEnabled) {
-						traceInfo('Catalog Explorer enabled via configuration change');
-						await initializeCatalogExplorer(context);
-					}
-				}
-			})
-		);
-		return;
-	}
-
-	await initializeCatalogExplorer(context);
 }
 
 export function deactivate() { }


### PR DESCRIPTION
The Catalog Explorer extension activated on every Positron startup (`onStartupFinished`) even though it is experimental and disabled by default, and it statically imported `snowflake-sdk` -- a large module with a sizable dependency tree -- pulling the whole SDK into the extension host's memory at activation regardless of whether the user ever used Snowflake.

This PR makes the extension load on demand and shrinks its resident footprint:

- **On-demand activation.** `activationEvents` changes from `onStartupFinished` to `onView:catalog-explorer` plus `onCommand:` for the palette commands. All of these are gated on `config.catalogExplorer.enabled`, so the extension (and its module graph) only loads once the feature is actually enabled and used. Enabling now takes effect live without a restart, since flipping the setting reveals the view and triggers activation.
- **Lazy `snowflake-sdk` load.** The SDK is now imported via a cached dynamic `import()` inside a loader that runs only when the user connects to Snowflake. The type-only import is retained for compile-time types. The Databricks path uses plain `fetch` and pulls in nothing heavy, so users who never touch Snowflake never pay for the SDK.


### Release Notes

#### New Features

- N/A

#### Bug Fixes

- The experimental Catalog Explorer extension no longer loads on startup when disabled, and its Snowflake SDK is loaded only when connecting to Snowflake, reducing startup cost and memory footprint.

### QA Notes

@:catalog-explorer

- With `catalogExplorer.enabled` off (default), confirm the extension does not activate on startup and the Catalog Explorer view is hidden.
- Enable `catalogExplorer.enabled` and confirm the Catalog Explorer view appears and the extension activates without a restart.
- Exercise the Databricks catalog flow (browse catalogs/schemas/tables, copy path, generate Python/R code) and confirm behavior is unchanged.
- Add and authenticate a Snowflake connection and confirm it still works (this is the path that now lazily loads `snowflake-sdk`).
