### PR TITLE
fix: open console session info popup without awaiting listOutputChannels()

### DIFF
--- a/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
@@ -418,18 +418,6 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 		updatePopupLayout();
 	}, [updatePopupLayout]);
 
-	// Re-layout when the popup's content changes size. Content can load
-	// asynchronously (e.g. buttons that appear once an RPC resolves); without
-	// re-measuring, the popup keeps its initial placement and can overflow
-	// off-screen instead of repositioning to fit.
-	useEffect(() => {
-		const resizeObserver = new (DOM.getWindow(popupChildrenRef.current).ResizeObserver)(() => {
-			updatePopupLayout();
-		});
-		resizeObserver.observe(popupChildrenRef.current);
-		return () => resizeObserver.disconnect();
-	}, [updatePopupLayout]);
-
 	// Event handlers.
 	useEffect(() => {
 		// Set this popup's bounds provider with the renderer so that we can check click containment.

--- a/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
@@ -418,6 +418,18 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 		updatePopupLayout();
 	}, [updatePopupLayout]);
 
+	// Re-layout when the popup's content changes size. Content can load
+	// asynchronously (e.g. buttons that appear once an RPC resolves); without
+	// re-measuring, the popup keeps its initial placement and can overflow
+	// off-screen instead of repositioning to fit.
+	useEffect(() => {
+		const resizeObserver = new (DOM.getWindow(popupChildrenRef.current).ResizeObserver)(() => {
+			updatePopupLayout();
+		});
+		resizeObserver.observe(popupChildrenRef.current);
+		return () => resizeObserver.disconnect();
+	}, [updatePopupLayout]);
+
 	// Event handlers.
 	useEffect(() => {
 		// Set this popup's bounds provider with the renderer so that we can check click containment.

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
@@ -111,7 +111,7 @@ const ConsoleInstanceInfoModalPopup = (props: ConsoleInstanceInfoModalPopupProps
 		}));
 
 		return () => disposableStore.dispose();
-	}, [props.session, props.renderer]);
+	}, [props.session]);
 
 	// Load the session's output channels asynchronously so the popup opens
 	// immediately; the channel buttons appear once listOutputChannels() resolves.

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
@@ -45,7 +45,7 @@ export const ConsoleInstanceInfoButton = () => {
 	// Reference hooks.
 	const ref = useRef<HTMLButtonElement>(undefined!);
 
-	const handlePressed = async () => {
+	const handlePressed = () => {
 		// Get the session ID and the session. Note that we don't ask the
 		// console instance for the session directly since we want this to work
 		// even with a detached session.
@@ -59,16 +59,11 @@ export const ConsoleInstanceInfoButton = () => {
 			return;
 		}
 
-		// Get the channels from the session.
-		let channels: LanguageRuntimeSessionChannel[] = [];
-		try {
-			channels = intersectionOutputChannels(await session.listOutputChannels());
-		} catch (err) {
-			// If we fail to get the channels we can just ignore it
-			console.warn('Failed to get output channels', err);
-		}
-
-		// Create the renderer.
+		// Open the popup immediately. The popup loads its output channels
+		// asynchronously (see ConsoleInstanceInfoModalPopup) so opening it never
+		// waits on the listOutputChannels() ext-host RPC, which can be slow under
+		// load or early in session startup and would otherwise delay (or drop) the
+		// popup entirely.
 		const renderer = new PositronModalReactRenderer({
 			container: services.workbenchLayoutService.getContainer(DOM.getWindow(ref.current)),
 			parent: ref.current
@@ -77,7 +72,6 @@ export const ConsoleInstanceInfoButton = () => {
 		renderer.render(
 			<ConsoleInstanceInfoModalPopup
 				anchorElement={ref.current}
-				channels={channels}
 				renderer={renderer}
 				session={session}
 			/>
@@ -102,11 +96,11 @@ interface ConsoleInstanceInfoModalPopupProps {
 	anchorElement: HTMLElement;
 	renderer: PositronModalReactRenderer;
 	session: ILanguageRuntimeSession;
-	channels: LanguageRuntimeSessionChannel[];
 }
 
 const ConsoleInstanceInfoModalPopup = (props: ConsoleInstanceInfoModalPopupProps) => {
 	const [sessionState, setSessionState] = useState(() => props.session.getRuntimeState());
+	const [channels, setChannels] = useState<LanguageRuntimeSessionChannel[]>([]);
 
 	// Main useEffect hook.
 	useEffect(() => {
@@ -118,6 +112,23 @@ const ConsoleInstanceInfoModalPopup = (props: ConsoleInstanceInfoModalPopupProps
 
 		return () => disposableStore.dispose();
 	}, [props.session, props.renderer]);
+
+	// Load the session's output channels asynchronously so the popup opens
+	// immediately; the channel buttons appear once listOutputChannels() resolves.
+	useEffect(() => {
+		let active = true;
+		props.session.listOutputChannels().then(
+			available => {
+				if (active) {
+					setChannels(intersectionOutputChannels(available));
+				}
+			},
+			err => {
+				// If we fail to get the channels we can just ignore it
+				console.warn('Failed to get output channels', err);
+			});
+		return () => { active = false; };
+	}, [props.session]);
 
 	const showKernelOutputChannelClickHandler = (channel: LanguageRuntimeSessionChannel) => {
 		props.session.showOutput(channel);
@@ -163,7 +174,7 @@ const ConsoleInstanceInfoModalPopup = (props: ConsoleInstanceInfoModalPopupProps
 					</div>
 				</div>
 				<div className='top-separator actions'>
-					{props.channels.map((channel, index) => (
+					{channels.map((channel, index) => (
 						<Button
 							key={`channel-${index}`}
 							className='link'

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
@@ -117,16 +117,23 @@ const ConsoleInstanceInfoModalPopup = (props: ConsoleInstanceInfoModalPopupProps
 	// immediately; the channel buttons appear once listOutputChannels() resolves.
 	useEffect(() => {
 		let active = true;
-		props.session.listOutputChannels().then(
-			available => {
-				if (active) {
-					setChannels(intersectionOutputChannels(available));
-				}
-			},
-			err => {
+
+		const loadOutputChannels = async () => {
+			let available: string[];
+			try {
+				available = await props.session.listOutputChannels();
+			} catch (err) {
 				// If we fail to get the channels we can just ignore it
 				console.warn('Failed to get output channels', err);
-			});
+				return;
+			}
+			if (active) {
+				setChannels(intersectionOutputChannels(available));
+			}
+		};
+
+		loadOutputChannels();
+
 		return () => { active = false; };
 	}, [props.session]);
 
@@ -173,17 +180,19 @@ const ConsoleInstanceInfoModalPopup = (props: ConsoleInstanceInfoModalPopupProps
 						</p>
 					</div>
 				</div>
-				<div className='top-separator actions'>
-					{channels.map((channel, index) => (
-						<Button
-							key={`channel-${index}`}
-							className='link'
-							onPressed={() => showKernelOutputChannelClickHandler(channel)}
-						>
-							{localizeShowKernelOutputChannel(OutputChannelNames[channel])}
-						</Button>
-					))}
-				</div>
+				{channels.length > 0 &&
+					<div className='top-separator actions'>
+						{channels.map((channel, index) => (
+							<Button
+								key={`channel-${index}`}
+								className='link'
+								onPressed={() => showKernelOutputChannelClickHandler(channel)}
+							>
+								{localizeShowKernelOutputChannel(OutputChannelNames[channel])}
+							</Button>
+						))}
+					</div>
+				}
 			</div>
 		</PositronModalPopup>
 	);


### PR DESCRIPTION
Fixes #14983

The Console session info button awaited `session.listOutputChannels()` (an ext-host RPC) before rendering the metadata popup, so under load or early in session startup the popup opened late or not at all. This renders the popup immediately and loads its output channels asynchronously in a `useEffect` (mirroring the existing session-state effect); the channel buttons appear once the RPC resolves. The race was R-biased because R's output channels come through the Ark supervisor, which is slower to respond under load.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Open the console session information popup immediately instead of waiting on the output-channels lookup, so it no longer fails to open under load (#14983)

### Validation Steps

@:sessions @:interpreter @:web @:win

Start an R (or Python) console session, then click the session info button in the console action bar. The metadata popup should open immediately, with the "Show ... Output Channel" buttons appearing a moment later once the channel lookup resolves. Covered by the existing `default-{python,r}-interpreter` e2e tests, which read session metadata through this popup; ci-arm 3-worker over-stress went from 4 R flaky (before) to 0 flaky / 16 passed with this change.

### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> (product bug) -- session info popup render is gated on the listOutputChannels() RPC, so it opens late under load</summary>

- **Spec:** `test/e2e/tests/interpreters/default-r-interpreter.test.ts`
  - **Test:** `Default Interpreters - R > R - Add a default interpreter`
- **Signal:** trace shows the info button click landing on a real `info-r-<id>` button, but the `.console-instance-info` popup not appearing within `getMetadata`'s window; earlier CI evidence showed the popup eventually opening with correct metadata, just after the assertion had already timed out. `handlePressed` awaits `session.listOutputChannels()` (a MainThread->ExtHost RPC) before `renderer.render(...)`, so a slow RPC delays or drops the popup.
- **Frequency:** R ~7/147 (~5%) on main, ubuntu/electron; reproduced on ci-arm 3-worker over-stress as 4/16 flaky with the #14979 test mitigation alone.
- **Hypothesis:** Product bug. The popup render waits on an ext-host RPC; R's output channels come through the Ark/kallichore supervisor, slower to service the call early in startup, which widens the window under contention. Rendering the popup immediately and loading channels asynchronously removes the gate (this PR: 0/16 flaky under the same over-stress).

</details>
