### PR TITLE
fix: recommend workspace default interpreter on a cold resolve

### DIFF
--- a/extensions/positron-python/src/client/positron/manager.ts
+++ b/extensions/positron-python/src/client/positron/manager.ts
@@ -329,7 +329,7 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
             // Mirrors the retry in selectLanguageRuntimeFromPath.
             if (!interpreter) {
                 traceInfo(`Recommended interpreter ${interpreterPath} not resolved yet, triggering refresh...`);
-                await this.triggerInterpreterRefresh();
+                await this.interpreterService.triggerRefresh().ignoreErrors();
                 interpreter = await this.interpreterService.getInterpreterDetails(interpreterPath, workspaceUri);
             }
 

--- a/extensions/positron-python/src/client/positron/manager.ts
+++ b/extensions/positron-python/src/client/positron/manager.ts
@@ -320,7 +320,19 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
 
         if (interpreterPath) {
             interpreterPath = untildify(interpreterPath);
-            const interpreter = await this.interpreterService.getInterpreterDetails(interpreterPath, workspaceUri);
+            let interpreter = await this.interpreterService.getInterpreterDetails(interpreterPath, workspaceUri);
+
+            // This runs during startup, before interpreter discovery has necessarily
+            // resolved this path. A cold resolve returns undefined, which would drop the
+            // workspace default entirely, since it is never re-queried after discovery.
+            // Trigger a refresh and retry once so the default is recommended reliably.
+            // Mirrors the retry in selectLanguageRuntimeFromPath.
+            if (!interpreter) {
+                traceInfo(`Recommended interpreter ${interpreterPath} not resolved yet, triggering refresh...`);
+                await this.triggerInterpreterRefresh();
+                interpreter = await this.interpreterService.getInterpreterDetails(interpreterPath, workspaceUri);
+            }
+
             if (interpreter) {
                 const metadata = await createPythonRuntimeMetadata(interpreter, this.serviceContainer, isImmediate);
                 traceInfo(`Recommended runtime for workspace: ${interpreter.path}`);

--- a/extensions/positron-python/src/test/positron/manager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/manager.unit.test.ts
@@ -583,6 +583,66 @@ suite('Python runtime manager - recommendedWorkspaceRuntime', () => {
         assert.strictEqual(createPythonRuntimeMetadataStub.firstCall.args[2], false);
         assert.strictEqual(result?.extraRuntimeData?.pythonPath, venvPythonPath);
     });
+
+    test('triggers a refresh and retries when the interpreter is not resolved yet (cold resolve)', async () => {
+        Object.defineProperty(vscode.workspace, 'workspaceFolders', {
+            value: [],
+            configurable: true,
+        });
+        const globalInterpreterPath = '/path/to/global/python';
+        getUserDefaultInterpreterStub.returns({
+            globalValue: globalInterpreterPath,
+            workspaceValue: undefined,
+            workspaceFolderValue: undefined,
+        } as InspectInterpreterSettingType);
+
+        // First resolve is cold (undefined), the refresh warms it, the retry succeeds.
+        interpreter.setup((i) => i.path).returns(() => globalInterpreterPath);
+        let resolveCount = 0;
+        interpreterService
+            .setup((i) =>
+                i.getInterpreterDetails(TypeMoq.It.isValue(globalInterpreterPath), TypeMoq.It.isValue(undefined)),
+            )
+            .returns(() => {
+                resolveCount += 1;
+                return Promise.resolve(resolveCount === 1 ? undefined : interpreter.object);
+            });
+        interpreterService.setup((i) => i.triggerRefresh()).returns(() => Promise.resolve());
+
+        const result = await pythonRuntimeManager.recommendedWorkspaceRuntime();
+
+        assert.strictEqual(resolveCount, 2);
+        interpreterService.verify((i) => i.triggerRefresh(), TypeMoq.Times.once());
+        sinon.assert.calledOnce(createPythonRuntimeMetadataStub);
+        assert.strictEqual(result?.extraRuntimeData?.pythonPath, globalInterpreterPath);
+    });
+
+    test('returns undefined when the interpreter stays unresolved after a refresh', async () => {
+        Object.defineProperty(vscode.workspace, 'workspaceFolders', {
+            value: [],
+            configurable: true,
+        });
+        const globalInterpreterPath = '/path/to/global/python';
+        getUserDefaultInterpreterStub.returns({
+            globalValue: globalInterpreterPath,
+            workspaceValue: undefined,
+            workspaceFolderValue: undefined,
+        } as InspectInterpreterSettingType);
+
+        // Resolve stays cold even after the refresh: recommend gives up, does not loop.
+        interpreterService
+            .setup((i) =>
+                i.getInterpreterDetails(TypeMoq.It.isValue(globalInterpreterPath), TypeMoq.It.isValue(undefined)),
+            )
+            .returns(() => Promise.resolve(undefined));
+        interpreterService.setup((i) => i.triggerRefresh()).returns(() => Promise.resolve());
+
+        const result = await pythonRuntimeManager.recommendedWorkspaceRuntime();
+
+        assert.strictEqual(result, undefined);
+        interpreterService.verify((i) => i.triggerRefresh(), TypeMoq.Times.once());
+        sinon.assert.notCalled(createPythonRuntimeMetadataStub);
+    });
 });
 
 suite('Python runtime manager - onDidChangeInterpreter filter', () => {


### PR DESCRIPTION
Addresses #14991 (Python side; positron-r follow-up tracked separately).

`recommendedWorkspaceRuntime()` resolves the workspace default interpreter's details during startup, before interpreter discovery has necessarily resolved the path. A cold `resolveEnv` returned `undefined`, which dropped the recommendation entirely -- and it is never re-queried after discovery, so the default never started that window and only recovered on a later reload. This triggers an interpreter refresh and retries the resolve once (mirroring the retry in `selectLanguageRuntimeFromPath`), so the workspace default is recommended reliably.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Start the workspace default interpreter reliably when its environment is slow to resolve at startup (#14991)

### Validation Steps

@:interpreter @:web @:win

In a workspace with `python.defaultInterpreterPath` set and `interpreters.startupBehavior: always`, launch Positron and confirm the default Python interpreter starts. Covered end-to-end by `default-python-interpreter` / `default-r-interpreter`.

### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> (product bug, fixed here) -- the recommend query drops the workspace default on a cold resolve and is never re-driven</summary>

- **Spec:** `test/e2e/tests/interpreters/default-python-interpreter.test.ts`
  - **Test:** `Default Interpreters - Python > Python - Add a default interpreter (Conda)`
- **Spec:** `test/e2e/tests/interpreters/default-r-interpreter.test.ts`
  - **Test:** `Default Interpreters - R > R - Add a default interpreter`
- **Signal:** the freshly-defaulted interpreter never starts on the failing window; the session is absent or belongs to the other language (#14979 kernel logs showed the runtime never re-requested after a reload cancelled the initial creation).
- **Mechanism:** `recommendedWorkspaceRuntime()` -> `getInterpreterDetails` -> `resolveEnv` returns `undefined` when discovery has not resolved the path yet. The recommend query runs once, before `discoverAllRuntimes()`, and is never re-driven, so the default is dropped for that window.
- **Confirmed by experiment (local, 2026-07-20):** instrumented startup and ran the Python test twice against an installed interpreter; the only difference was whether the recommend result was discarded.

  | Run | Recommend result (warm window) | Python starts? | Verdict |
  |---|---|---|---|
  | Baseline | count=1 langs=[python] | yes, then becomes affiliated | PASS |
  | Injected (return []) | same count=1 langs=[python], discarded | no | FAIL |

  Discovery still registered the runtimes in the injected run, and the logs caught the natural cold-to-warm transition (count=0 then count=1), so the cold resolve is real, not hypothetical.
- **Frequency:** Python ~11.5%, R ~5% (ubuntu/electron, per #14979).
- **Fix:** trigger an interpreter refresh and retry the resolve once in `recommendedWorkspaceRuntime()`; the existing startup fallback then starts the recommended default. positron-r has the same shape and needs the same retry (follow-up).

</details>

Related: #14979 (test mitigation + original triage), #14983 / #14984 (R info-popup race, a separate residual cause of the R flake).
