### PR TITLE
Fix trailing slash in test-tag-paths-map.json Copilot entry

### DIFF
--- a/.github/workflows/test-tag-paths-map.json
+++ b/.github/workflows/test-tag-paths-map.json
@@ -35,7 +35,7 @@
 
   "extensions/authentication/": ["@:assistant"],
   "extensions/copilot/": ["@:assistant"],
-  "extensions/copilot/src/extension/prompts/node/base/positronAssistant.tsx/": ["@:assistant"],
+  "extensions/copilot/src/extension/prompts/node/base/positronAssistant.tsx": ["@:assistant"],
   "extensions/positron-connections/": ["@:connections"],
   "extensions/positron-notebooks/": ["@:positron-notebooks"],
   "extensions/positron-reticulate/": ["@:reticulate"],


### PR DESCRIPTION
The `positronAssistant.tsx` entry in `test-tag-paths-map.json` had a trailing slash, but it's a file path, not a directory. The map's staleness check globs each key as `"${key}*"` against `git ls-files` -- with the trailing slash, that glob became `positronAssistant.tsx/*`, which never matches the tracked file itself, so the weekly guardrail (`test-tag-map-check-weekly.yml`) flagged this entry as stale even though the file exists and is correctly tagged `@:assistant`.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A (internal CI tooling fix, no user-facing behavior change)

### Validation Steps

No e2e tag applies -- this only touches `.github/workflows/test-tag-paths-map.json`, which the map itself doesn't cover, and doesn't change app behavior.

Confirmed locally that the entry is no longer flagged as stale:

```bash
bash scripts/check-test-tag-map.sh --warn-only --json | jq '.stale'
# [] on this branch; previously included
# "extensions/copilot/src/extension/prompts/node/base/positronAssistant.tsx/"
```

Also ran the existing shell test suites, which pass unaffected:
- `bash scripts/test/pr-tags-lib-test.sh`
- `bash scripts/check-test-tag-map.sh --tags-only` (the check CI runs on PRs)