### PR TITLE
Add Redshift data-connection e2e test

### DIFF
--- a/.env.e2e.example
+++ b/.env.e2e.example
@@ -15,3 +15,9 @@ E2E_POSTGRES_PASSWORD=your_postgres_password_here
 # triage-e2e-test to query historical test-health data. In CI this is read
 # from 1Password (op://Positron/E2E_dashboard_api_key/credential).
 E2E_INSIGHTS_API_KEY=your_e2e_insights_api_key_here
+
+# Redshift data connection used by data-connections e2e tests. In CI these are
+# read from 1Password (op://Positron/Redshift_Test_Environment/*).
+REDSHIFT_TEST_HOST=your_host_here
+REDSHIFT_TEST_USERNAME=your_username_here
+REDSHIFT_TEST_PASSWORD=your_password_here

--- a/.github/workflows/test-e2e-macos-run.yml
+++ b/.github/workflows/test-e2e-macos-run.yml
@@ -106,6 +106,21 @@ jobs:
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"
+          REDSHIFT_TEST_HOST: "op://Positron/Redshift_Test_Environment/hostname"
+          REDSHIFT_TEST_USERNAME: "op://Positron/Redshift_Test_Environment/username"
+          REDSHIFT_TEST_PASSWORD: "op://Positron/Redshift_Test_Environment/password"
+          TS_OAUTH_CLIENT_ID: "op://Positron/Tailscale_OAuth/client_id"
+          TS_OAUTH_SECRET: "op://Positron/Tailscale_OAuth/client_secret"
+
+      # Bring up Tailscale so tests can reach private test infrastructure (e.g. the serverless
+      # Redshift workgroup used by the data-connections e2e tests). OAuth creds are loaded from
+      # 1Password in the previous step.
+      - name: Tailscale
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: ${{ env.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ env.TS_OAUTH_SECRET }}
+          tags: tag:positron-gha
 
       - name: Configure display resolution
         run: |

--- a/.github/workflows/test-e2e-ubuntu-run.yml
+++ b/.github/workflows/test-e2e-ubuntu-run.yml
@@ -99,7 +99,9 @@ jobs:
       matrix: ${{ fromJson(inputs.matrix) }}
     container:
       image: ghcr.io/posit-dev/positron-ubuntu24:24.15.0
-      options: --user 0:0 --init
+      # --device/--cap-add give the container a TUN device so the Tailscale step can bring up
+      # kernel-mode networking (transparent routing to the tailnet, needed by the Redshift test).
+      options: --user 0:0 --init --device /dev/net/tun --cap-add=NET_ADMIN
       credentials:
         username: ${{ secrets.POSITRON_GITHUB_RO_USER }}
         password: ${{ secrets.POSITRON_GITHUB_RO_PAT }}
@@ -168,6 +170,21 @@ jobs:
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"
+          REDSHIFT_TEST_HOST: "op://Positron/Redshift_Test_Environment/hostname"
+          REDSHIFT_TEST_USERNAME: "op://Positron/Redshift_Test_Environment/username"
+          REDSHIFT_TEST_PASSWORD: "op://Positron/Redshift_Test_Environment/password"
+          TS_OAUTH_CLIENT_ID: "op://Positron/Tailscale_OAuth/client_id"
+          TS_OAUTH_SECRET: "op://Positron/Tailscale_OAuth/client_secret"
+
+      # Bring up Tailscale so tests can reach private test infrastructure (e.g. the serverless
+      # Redshift workgroup used by the data-connections e2e tests). OAuth creds are loaded from
+      # 1Password in the previous step.
+      - name: Tailscale
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: ${{ env.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ env.TS_OAUTH_SECRET }}
+          tags: tag:positron-gha
 
       - name: Transform to Playwright tags $PW_TAGS
         run: bash scripts/pr-tags-transform.sh ${{ inputs.project}} "${{ inputs.grep }}"

--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -136,6 +136,21 @@ jobs:
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"
+          REDSHIFT_TEST_HOST: "op://Positron/Redshift_Test_Environment/hostname"
+          REDSHIFT_TEST_USERNAME: "op://Positron/Redshift_Test_Environment/username"
+          REDSHIFT_TEST_PASSWORD: "op://Positron/Redshift_Test_Environment/password"
+          TS_OAUTH_CLIENT_ID: "op://Positron/Tailscale_OAuth/client_id"
+          TS_OAUTH_SECRET: "op://Positron/Tailscale_OAuth/client_secret"
+
+      # Bring up Tailscale so tests can reach private test infrastructure (e.g. the serverless
+      # Redshift workgroup used by the data-connections e2e tests). OAuth creds are loaded from
+      # 1Password in the previous step.
+      - name: Tailscale
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: ${{ env.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ env.TS_OAUTH_SECRET }}
+          tags: tag:positron-gha
 
       - name: Set screen resolution
         shell: pwsh

--- a/.github/workflows/test-e2e-workbench-ubuntu.yml
+++ b/.github/workflows/test-e2e-workbench-ubuntu.yml
@@ -142,6 +142,21 @@ jobs:
           AZURE_SERVICE_PRINCIPAL_CLIENT_SECRET: "op://Positron/RStudioIDE_Service_Account/azure-service-principal-client-secret"
           WORKBENCH_LICENSE: "op://Positron/Workbench-lic-WB-Auto/notesPlain"
           CONNECT_LICENSE: "op://Positron/Connect-lic-WB-Auto/notesPlain"
+          REDSHIFT_TEST_HOST: "op://Positron/Redshift_Test_Environment/hostname"
+          REDSHIFT_TEST_USERNAME: "op://Positron/Redshift_Test_Environment/username"
+          REDSHIFT_TEST_PASSWORD: "op://Positron/Redshift_Test_Environment/password"
+          TS_OAUTH_CLIENT_ID: "op://Positron/Tailscale_OAuth/client_id"
+          TS_OAUTH_SECRET: "op://Positron/Tailscale_OAuth/client_secret"
+
+      # Bring up Tailscale so tests can reach private test infrastructure (e.g. the serverless
+      # Redshift workgroup used by the data-connections e2e tests). OAuth creds are loaded from
+      # 1Password in the previous step.
+      - name: Tailscale
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: ${{ env.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ env.TS_OAUTH_SECRET }}
+          tags: tag:positron-gha
 
       - name: Write license files
         run: |

--- a/test/e2e/pages/dataConnections.ts
+++ b/test/e2e/pages/dataConnections.ts
@@ -33,6 +33,20 @@ const VERSION_ROW = `${TREE_CONTAINER} ${TREE_ROW}:has(.codicon-history)`;
 const NODE_TYPE_BADGE = '.data-connection-node-type';
 
 /**
+ * The subset of node kinds a caller can disambiguate on, mapped to the codicon class the row renders
+ * for that kind (see `dataConnectionNodeRow.tsx`). Two nodes can share a label across levels (e.g. a
+ * Redshift database and a table both named `flights`); passing a kind narrows the exact-text match to
+ * the row with the matching icon.
+ */
+export type DataConnectionNodeKind = 'database' | 'schema' | 'table' | 'view';
+const NODE_KIND_ICON: Record<DataConnectionNodeKind, string> = {
+	database: 'codicon-positron-db-database',
+	schema: 'codicon-positron-db-schema',
+	table: 'codicon-positron-db-table',
+	view: 'codicon-positron-db-view',
+};
+
+/**
  * Reusable Positron Data Connections panel functionality for tests to leverage.
  *
  * Covers the panel gated behind the `dataConnections.enabled` setting: opening the view, adding a
@@ -46,6 +60,15 @@ export class DataConnections {
 	saveButton: Locator;
 	nextButton: Locator;
 	connectionEntries: Locator;
+
+	/**
+	 * Optional override (in ms) for the built-in waits in this page object. Slow backends need more
+	 * than the global 15s expect timeout: a serverless Redshift workgroup can cold-start on the first
+	 * connect, and each tree expansion issues a metadata query that may be slow to return. Set this
+	 * once (e.g. in `beforeAll`) to widen every wait for connecting, expanding, and node assertions.
+	 * Leave undefined to use Playwright's default expect timeout.
+	 */
+	actionTimeout?: number;
 
 	constructor(private code: Code, private quickaccess: QuickAccess) {
 		const page = code.driver.currentPage;
@@ -120,7 +143,9 @@ export class DataConnections {
 	 */
 	async save(): Promise<void> {
 		await this.saveButton.click();
-		await expect(this.dialog).toBeHidden();
+		// Saving opens the live connection, so this wait spans the backend connect (a cold-starting
+		// serverless workgroup can take a while); honor actionTimeout when set.
+		await expect(this.dialog).toBeHidden({ timeout: this.actionTimeout });
 	}
 
 	/**
@@ -130,18 +155,24 @@ export class DataConnections {
 	async expectConnectionInTree(connectionName: string): Promise<void> {
 		await expect(
 			this.connectionEntries.filter({ hasText: connectionName })
-		).toBeVisible();
+		).toBeVisible({ timeout: this.actionTimeout });
 	}
 
 	/**
 	 * Returns the tree row whose node label exactly matches the given text. Exact matching avoids
-	 * false matches between names that share a substring (e.g. 'actor' vs 'actor_info').
+	 * false matches between names that share a substring (e.g. 'actor' vs 'actor_info'). Pass a
+	 * `kind` to further narrow the match by node icon when the same label appears at more than one
+	 * level (e.g. a Redshift database and a table both named 'flights').
 	 * @param label The node label, e.g. 'Schemas', 'public', 'Tables', 'actor'.
+	 * @param kind Optional node kind to disambiguate rows that share a label.
 	 */
-	private treeRow(label: string): Locator {
-		return this.code.driver.currentPage.locator(TREE_ROW).filter({
-			has: this.code.driver.currentPage.getByText(label, { exact: true })
-		});
+	private treeRow(label: string, kind?: DataConnectionNodeKind): Locator {
+		const page = this.code.driver.currentPage;
+		let row = page.locator(TREE_ROW).filter({ has: page.getByText(label, { exact: true }) });
+		if (kind) {
+			row = row.filter({ has: page.locator(`.${NODE_KIND_ICON[kind]}`) });
+		}
+		return row;
 	}
 
 	/**
@@ -157,17 +188,21 @@ export class DataConnections {
 	 */
 	private async expandRow(row: Locator, label: string): Promise<void> {
 		await test.step(`Expand node: ${label}`, async () => {
-			// Reveal the row so it is rendered before interacting with it: the grid renders no
-			// overscan, so a row below the fold is absent from the DOM (and a prior step may have
-			// scrolled the grid). revealNode scrolls it into the rendered range; toBeVisible then
-			// waits for the row to finish loading after its parent expanded.
+			// Reveal the row before acting on it. The grid renders no overscan, so a row below the
+			// fold is absent from the DOM entirely -- which happens for a deep node in a short panel
+			// (e.g. a Redshift table, one level below Postgres's because of the extra Databases node).
+			// revealNode scrolls it into the rendered range (or back to the top if it is a child still
+			// loading after its parent expanded); toBeVisible then waits for that load to finish before
+			// we click its twisty.
 			await this.revealNode(row);
-			await expect(row).toBeVisible();
+			await expect(row).toBeVisible({ timeout: this.actionTimeout });
 
 			const collapsedTwisty = row.locator(TREE_TWISTY_COLLAPSED);
 			if (await collapsedTwisty.count() > 0) {
 				await collapsedTwisty.first().dispatchEvent('click');
-				await expect(row.locator(TREE_TWISTY_COLLAPSED)).toHaveCount(0);
+				// Children load asynchronously (a metadata query) after the twisty is clicked, so this
+				// wait can span a slow backend response; honor actionTimeout when set.
+				await expect(row.locator(TREE_TWISTY_COLLAPSED)).toHaveCount(0, { timeout: this.actionTimeout });
 			}
 		});
 	}
@@ -185,9 +220,10 @@ export class DataConnections {
 	/**
 	 * Expands a tree node by its label.
 	 * @param label The node label to expand, e.g. 'Schemas', 'public', 'Tables', 'Views'.
+	 * @param kind Optional node kind to disambiguate rows that share a label (see {@link treeRow}).
 	 */
-	async expandNode(label: string): Promise<void> {
-		await this.expandRow(this.treeRow(label), label);
+	async expandNode(label: string, kind?: DataConnectionNodeKind): Promise<void> {
+		await this.expandRow(this.treeRow(label, kind), label);
 	}
 
 	/**
@@ -196,12 +232,13 @@ export class DataConnections {
 	 * node row. Like {@link expandRow}, this uses `dispatchEvent` rather than a coordinate-based
 	 * click because the tree is a virtualized grid with absolutely-positioned rows.
 	 * @param label The node label, e.g. 'actor' or 'first_name'.
+	 * @param kind Optional node kind to disambiguate rows that share a label (see {@link treeRow}).
 	 */
-	async doubleClickNode(label: string): Promise<void> {
+	async doubleClickNode(label: string, kind?: DataConnectionNodeKind): Promise<void> {
 		await test.step(`Double-click node: ${label}`, async () => {
-			const row = this.treeRow(label);
+			const row = this.treeRow(label, kind);
 			await this.revealNode(row);
-			await expect(row).toBeVisible();
+			await expect(row).toBeVisible({ timeout: this.actionTimeout });
 			await row.locator('.data-connection-node-row').dispatchEvent('dblclick');
 		});
 	}
@@ -232,16 +269,25 @@ export class DataConnections {
 		for (let i = 0; i < 60 && await row.count() === 0; i++) {
 			await page.mouse.wheel(0, 200);
 		}
+
+		// If the scan reached the end without rendering the row, it is not below the fold -- it is a
+		// child still loading after its parent expanded. Return to the top so it renders in the visible
+		// range once the load completes (the nodes this drives all live near the top of the tree),
+		// rather than being stranded off-screen where the scan left the grid scrolled to the bottom.
+		if (await row.count() === 0) {
+			await this.scrollToTop();
+		}
 	}
 
 	/**
 	 * Asserts that a tree node with the given label is visible, scrolling it into view if needed.
 	 * @param label The node label.
+	 * @param kind Optional node kind to disambiguate rows that share a label (see {@link treeRow}).
 	 */
-	async expectNodeVisible(label: string): Promise<void> {
-		const row = this.treeRow(label);
+	async expectNodeVisible(label: string, kind?: DataConnectionNodeKind): Promise<void> {
+		const row = this.treeRow(label, kind);
 		await this.revealNode(row);
-		await expect(row).toBeVisible();
+		await expect(row).toBeVisible({ timeout: this.actionTimeout });
 	}
 
 	/**
@@ -252,8 +298,8 @@ export class DataConnections {
 	async expectColumn(name: string, dataType: string): Promise<void> {
 		const row = this.treeRow(name);
 		await this.revealNode(row);
-		await expect(row).toBeVisible();
-		await expect(row.locator(NODE_TYPE_BADGE)).toHaveText(dataType);
+		await expect(row).toBeVisible({ timeout: this.actionTimeout });
+		await expect(row.locator(NODE_TYPE_BADGE)).toHaveText(dataType, { timeout: this.actionTimeout });
 	}
 
 	/**

--- a/test/e2e/tests/data-connections/redshift.test.ts
+++ b/test/e2e/tests/data-connections/redshift.test.ts
@@ -1,0 +1,158 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test, tags } from '../_test.setup';
+
+test.use({
+	suiteId: __filename,
+	// The Data Connections panel is a preview feature gated behind `dataConnections.enabled`. This
+	// bakes the setting into the app (and the Workbench/Jupyter containers) at startup, since those
+	// read settings copied in at launch rather than the host settings file written at runtime.
+	enableDataConnections: true,
+});
+
+// Redshift connection details. Host/user/password come from the environment (the project's .env
+// file locally, 1Password in CI); port and database are fixed for the test cluster. The endpoint is
+// a private serverless Redshift workgroup reachable only over Tailscale, so both local runs and CI
+// need network access to it -- see redshift.test.ts docs / the CI workflow's Tailscale step.
+//
+// The env-backed values are read at runtime inside beforeAll, not here: `.env.e2e` is applied by the
+// auto `envVars` worker fixture, which runs after this file is evaluated during test collection, so a
+// top-level `process.env` read would always be empty (and the suite would skip).
+const connectionName = 'redshift';
+const port = '5439';
+const database = 'dev';
+
+// The test cluster has a `flights` database (alongside the connection's own `dev` database) holding a
+// single `public.flights` table -- the nycflights13 dataset loaded into Redshift. Note the database
+// and the table share the name `flights`, so tree lookups for the table pass an explicit node kind
+// to disambiguate them (see DataConnections.expandNode / doubleClickNode).
+const detailDatabase = 'flights';
+const detailTable = 'flights';
+
+// Columns of the flights table, in the order the tree renders them, with their Redshift data types.
+const flightsColumns = [
+	{ name: 'year', dataType: 'smallint' },
+	{ name: 'month', dataType: 'smallint' },
+	{ name: 'day', dataType: 'smallint' },
+	{ name: 'dep_time', dataType: 'smallint' },
+	{ name: 'sched_dep_time', dataType: 'smallint' },
+	{ name: 'dep_delay', dataType: 'smallint' },
+	{ name: 'arr_time', dataType: 'smallint' },
+	{ name: 'sched_arr_time', dataType: 'smallint' },
+	{ name: 'arr_delay', dataType: 'smallint' },
+	{ name: 'carrier', dataType: 'character varying(256)' },
+	{ name: 'flight', dataType: 'smallint' },
+	{ name: 'tailnum', dataType: 'character varying(256)' },
+	{ name: 'origin', dataType: 'character varying(256)' },
+	{ name: 'dest', dataType: 'character varying(256)' },
+	{ name: 'air_time', dataType: 'smallint' },
+	{ name: 'distance', dataType: 'smallint' },
+	{ name: 'hour', dataType: 'smallint' },
+	{ name: 'minute', dataType: 'smallint' },
+	{ name: 'time_hour', dataType: 'timestamp without time zone' },
+];
+
+test.describe('Data Connections - Redshift', {
+	tag: [tags.WEB, tags.WIN, tags.CONNECTIONS, tags.WORKBENCH]
+}, () => {
+
+	// Configuring the connection is a one-time, stateful action (re-running the new-connection flow
+	// would add a duplicate profile), and the app is worker-scoped, so the connection persists across
+	// every test in the suite. Create it and expand the tree to a known baseline once here. Per-test
+	// state that must not leak between tests (an open Data Explorer tab) is reset in afterEach.
+	test.beforeAll(async function ({ app }) {
+		// Read the env-backed connection details now (not at module scope): `.env.e2e` is applied by
+		// the auto `envVars` worker fixture, which has run by the time this hook executes.
+		const host = process.env.REDSHIFT_TEST_HOST || '';
+		const user = process.env.REDSHIFT_TEST_USERNAME || '';
+		const password = process.env.REDSHIFT_TEST_PASSWORD || '';
+
+		// The test workgroup is a private serverless Redshift reached over Tailscale, and its host /
+		// credentials are secrets. Where those aren't provisioned (no .env locally, no secrets +
+		// Tailscale in a given CI rig) the connection can't be made, so skip the whole suite rather
+		// than fail. Runs anywhere REDSHIFT_TEST_HOST is set.
+		test.skip(!host, 'Redshift test credentials not configured (REDSHIFT_TEST_HOST unset)');
+
+		// A serverless workgroup can cold-start on first connect and its metadata queries are slow, so
+		// give this hook and every DataConnections wait a generous budget.
+		test.setTimeout(180_000);
+
+		const { dataConnections } = app.workbench;
+		dataConnections.actionTimeout = 60_000;
+
+		await dataConnections.openDataConnectionsView();
+		await dataConnections.clickAddConnection();
+		await dataConnections.selectProvider('Redshift');
+		// Redshift exposes a single connection mechanism (User & Password), so the flow advances
+		// straight to the configure step without a mechanism-selection dialog. SSL is left on (the
+		// default), which the serverless endpoint requires.
+		await dataConnections.fillConnectionInputs({
+			'Connection Name': connectionName,
+			'Host': host,
+			'Port': port,
+			'Database': database,
+			'User': user,
+			'Password': password,
+		});
+
+		await dataConnections.save();
+		await dataConnections.expectConnectionInTree(connectionName);
+
+		await test.step('Expand the tree down to tables and views', async () => {
+			await dataConnections.expandConnection(connectionName);
+			await dataConnections.expandNode('Databases');
+			await dataConnections.expandNode(detailDatabase, 'database');
+			await dataConnections.expandNode('Schemas');
+			await dataConnections.expandNode('public');
+			await dataConnections.expandNode('Tables');
+			await dataConnections.expandNode('Views');
+		});
+	});
+
+	// Each preview test opens a Data Explorer tab. Close it so the next test starts from a clean
+	// editor state rather than depending on what the previous test left open. The connection and its
+	// expanded tree remain in the worker-scoped app.
+	test.afterEach(async function ({ app }) {
+		await app.workbench.hotKeys.closeAllEditors();
+	});
+
+	test('Displays the table, columns, and their types in the tree', async function ({ app }) {
+		const { dataConnections } = app.workbench;
+
+		await test.step('Verify the flights table is visible', async () => {
+			await dataConnections.expectNodeVisible(detailTable, 'table');
+		});
+
+		await test.step('Verify columns and types for the flights table', async () => {
+			await dataConnections.expandNode(detailTable, 'table');
+			await dataConnections.expandNode('Columns');
+			for (const { name, dataType } of flightsColumns) {
+				await dataConnections.expectColumn(name, dataType);
+			}
+		});
+	});
+
+	test('Opens a table in the Data Explorer on double-click', { tag: [tags.DATA_EXPLORER] }, async function ({ app }) {
+		const { dataConnections, dataExplorer } = app.workbench;
+
+		await dataConnections.doubleClickNode(detailTable, 'table');
+
+		await dataExplorer.waitForIdle();
+		await dataExplorer.grid.expectColumnHeadersToBe(flightsColumns.map(({ name }) => name));
+	});
+
+	test('Opens a column in the Data Explorer on double-click', { tag: [tags.DATA_EXPLORER] }, async function ({ app }) {
+		const { dataConnections, dataExplorer } = app.workbench;
+
+		await dataConnections.expandNode(detailTable, 'table');
+		await dataConnections.expandNode('Columns');
+
+		await dataConnections.doubleClickNode('year');
+
+		await dataExplorer.waitForIdle();
+		await dataExplorer.grid.expectColumnHeadersToBe(['year']);
+	});
+});


### PR DESCRIPTION
Adds an e2e test for the Redshift data connection (`test/e2e/tests/data-connections/redshift.test.ts`), following the existing Postgres/DuckDB pattern: create the connection, verify the tree (table, columns, and their types), and open a table and a column in the Data Explorer.

The test connects to a private serverless Redshift workgroup that is reachable only over the Posit tailnet, so CI needs both Tailscale and the connection credentials.

### Changes

- **Test** -- `redshift.test.ts`, tagged `@:web @:win @:connections @:workbench`. Credentials come from `REDSHIFT_TEST_HOST` / `REDSHIFT_TEST_USERNAME` / `REDSHIFT_TEST_PASSWORD` (`.env.e2e` locally, 1Password in CI); port `5439` and database `dev` are fixed. The suite skips when `REDSHIFT_TEST_HOST` is unset. Env vars are read at runtime (in `beforeAll`), since `.env.e2e` is applied by a worker fixture after test-file collection.
- **Page object** (`dataConnections.ts`) -- `expandRow` now reveals its target (scrolls it into the virtualized grid's rendered range) instead of assuming it sits near the top, and `revealNode` gained a return-to-top fallback for children still loading. This makes tree navigation robust for Redshift's deeper tree (extra `Databases` level) and small panels. Also adds an optional node-`kind` filter to disambiguate same-named nodes (the test cluster has a `flights` table inside a `flights` database).
- **CI** -- Adds a Tailscale step + Redshift credentials (via 1Password `op://`) to the four rigs that run the test: ubuntu-run, workbench-ubuntu, macos-run, windows-run. The one containerized rig among them (ubuntu-run) also gets `--device /dev/net/tun --cap-add=NET_ADMIN` so kernel-mode Tailscale can start. Other rigs (rhel/sles/suse/debian) are untouched -- the test skips there without credentials, so they get no Tailscale overhead.
- **`.env.e2e.example`** -- documents the new Redshift vars.

### Notes / follow-ups

- Tailscale OAuth creds are loaded from 1Password (`op://Positron/Tailscale_OAuth/...`); no GitHub repo-secret setup required.
- First CI run may reveal that the tailnet route to Redshift needs `--accept-routes` or an exit node on the Tailscale step -- a one-line follow-up if so.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

New data-connections e2e test; remaining platforms will be run manually via the full suite.

@:web @:win @:connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)
