### PR TITLE
e2e: re-accept Quick Open row until picker closes

### DIFF
--- a/test/e2e/pages/quickInput.ts
+++ b/test/e2e/pages/quickInput.ts
@@ -162,13 +162,24 @@ export class QuickInput {
 		keepOpen?: boolean,
 	): Promise<void> {
 		await this.waitForQuickInputOpened();
-		await this.code.driver.currentPage
+
+		const row = this.code.driver.currentPage
 			.locator(QuickInput.QUICK_INPUT_RESULT)
-			.nth(index)
-			.click();
+			.nth(index);
+		const input = this.code.driver.currentPage.locator(QuickInput.QUICK_INPUT_INPUT);
+		await row.click();
 
 		if (!keepOpen) {
-			await this.waitForQuickInputClosed();
+			// The accept-click occasionally fails to register under parallel-load
+			// focus contention (something steals focus from the picker), leaving it
+			// open. Re-click the row until the picker closes rather than waiting out
+			// a single click; re-accepting the same row is idempotent.
+			await expect(async () => {
+				if (await input.isVisible()) {
+					await row.click();
+				}
+				await expect(input).not.toBeVisible({ timeout: 2000 });
+			}).toPass({ timeout: 15000 });
 		}
 	}
 


### PR DESCRIPTION
### Summary
Fixes a shared-infra e2e flake in the Quick Open helper. `selectQuickInputElement` clicked a result row then waited once for the picker to close, so an accept-click that lost focus under parallel-worker contention left the picker open and failed `waitForQuickInputClosed` (surfaced as a ~2.5% flake on the Quarto webview-scroll test, entirely in setup).
- Re-accept the same row (idempotent) in a `toPass` loop until the picker closes, instead of a single click + fixed wait
- No timeout bump; targets the missed-accept mechanism
- Fix lives in `openFile`/`selectQuickInputElement`, used by ~66 test files

### QA Notes
@:web @:win @:quarto

### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- accept-click on the Quick Open row occasionally never registers under parallel-worker focus contention, leaving the picker open</summary>

- **Spec:** `test/e2e/tests/quarto/quarto-inline-output-webview-scroll.test.ts`
  - **Test:** `Quarto - Inline Output: Webview scroll > Python - Verify webview output does not stick when scrolled out of view`
- **Signal:** Fails in setup at the first line (`openFile`), not the webview assertions. Across 2 independent SHAs the trace shows the same shape: after the click on `monaco-list-row` nth=0, the Quick Open input resolved *visible* 14x across the full 5s window and never closed; the error-context snapshot shows the input still holding the full fixture path with row 0 highlighted (`aria-activedescendant=list_id_N_0`). The accept-click landed but never registered as an accept -- not a slow close.
- **Frequency:** 10/435 runs (2.5%, all flaky, 0 hard failures) over 14 days; clusters on ubuntu/chromium (7), also ubuntu/electron (2) and win/electron (2) -- tracks worker count / parallelism.
- **Hypothesis:** Shared test-infra focus-contention race. `selectQuickInputElement` clicked once then did a bare 5s `waitForQuickInputClosed` with no re-accept; under parallel-worker load something momentarily steals focus from the picker (POM already comments this at quickaccess.ts:122) so the accept is dropped. Not a product regression and not a defect in the webview-scroll feature or the test's own assertions.

</details>
