### PR TITLE
fix: notebook kernel status badge binds to wrong session after group move

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/registerNotebookWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/registerNotebookWidget.tsx
@@ -128,8 +128,15 @@ export function registerNotebookWidget(options: INotebookWidgetOptions): IDispos
 					? getNotebookInstanceFromEditorPane(editorGroup.activeEditorPane)
 					: undefined;
 
-				// Fall back to the global active editor (e.g. command palette context)
-				if (!notebook) {
+				// Fall back to the global active editor only when there is no
+				// editor-group context (e.g. command palette). Inside a group we
+				// must NOT borrow the globally-focused notebook: when a notebook is
+				// moved to another group, its badge can re-render before the new
+				// pane's notebookInstance is populated, and a global fallback would
+				// bind this group's badge to whichever notebook is focused. Render
+				// nothing instead and let the next re-render resolve this group's
+				// own notebook.
+				if (!notebook && !editorGroup) {
 					const editorService = accessor.get(IEditorService);
 					notebook = getNotebookInstanceFromActiveEditorPane(editorService);
 				}

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -307,6 +307,17 @@ export class Sessions {
 			// behind on server/workbench (see delete() workaround) stays visible,
 			// so it does not block this wait.
 			await expect(this.sessions.filter({ visible: false })).toHaveCount(0, { timeout: 15000 });
+
+			// The detach wait above only tracks hidden instances; it can pass while a
+			// session is still visibly tearing down, letting the next test's fresh
+			// kernel start race that teardown (session comes up "not active"). On
+			// desktop, also wait for the console to reach its empty state (no tabs, no
+			// metadata button). Server/workbench intentionally leaves a session behind
+			// (see delete() workaround), so skip this stricter wait there.
+			const isServedSession = /(8080|8787)/.test(this.code.driver.currentPage.url());
+			if (!isServedSession) {
+				await this.expectSessionCountToBe(0);
+			}
 		});
 	}
 


### PR DESCRIPTION
Fixes #15006

The notebook kernel status badge showed the wrong kernel status after a notebook was moved to another editor group (split side-by-side). When the badge re-rendered after the move -- before the moved pane's notebook instance was populated -- per-group resolution returned nothing and the resolver fell back to the globally-active editor, binding the badge to the focused notebook instead of its own. This gates that fallback on the absence of an editor-group context, so a split badge resolves its own notebook. It also hardens `Sessions.deleteAll()` on desktop to wait for the console's empty state, closing a teardown race that flaked the e2e coverage.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix notebook kernel status showing the wrong kernel after a notebook is moved to another editor group (#15006)

### Validation Steps

@:positron-notebooks @:web @:win

1. Open a Python notebook, select a kernel, wait for idle.
2. Open a second Python notebook, wait for its kernel to autostart to idle.
3. Move one notebook to a second editor group (drag to split side-by-side, or run `workbench.action.moveEditorToNextGroup`).
4. Verify each notebook's kernel status icon reflects its own kernel, and that shutting down one notebook's kernel leaves the other's status unchanged.

Note: `deleteAll()` is a shared POM helper; its new wait is desktop-only. The served-session (web) teardown race is tracked separately and not fully closed here.

### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- product bug: badge global-fallback binds a split notebook's badge to the focused notebook</summary>

- **Spec:** `test/e2e/tests/notebooks-positron/notebook-side-by-side.test.ts`
  - **Test:** `Notebook Side-by-Side Isolation > Kernel selection and actions are independent per notebook`
- **Signal:** After `moveEditorToNextGroup`, the moved group's kernel-status badge re-renders before its pane's `notebookInstance` is populated. Per-group resolution returns undefined and the resolver falls back to the globally-active editor, binding the badge to whichever notebook is focused rather than its own. The idle-status codicon for the wrong group then never appears.
- **Frequency:** ~74% of this test's recent failures; ~6% overall on main, concentrated on ubuntu/chromium. Reproduces 100% deterministically on local e2e-chromium in isolation.
- **Hypothesis:** Product bug (#15006). Gating the global fallback on the absence of an editor-group context flipped the 100%-deterministic local chromium failure to 5/5 green.

</details>

<details>
<summary>🟡 <b>Medium confidence</b> -- teardown race: fresh kernel starts before the prior test's session finishes tearing down</summary>

- **Spec:** `test/e2e/tests/notebooks-positron/notebook-side-by-side.test.ts`
  - **Test:** `Notebook Side-by-Side Isolation > Kernel selection and actions are independent per notebook`
- **Signal:** `deleteAll()`'s detach wait only tracks hidden instances and can return while a session is still visibly tearing down; the next test's fresh kernel starts into that teardown and comes up not-active. In the full-spec chromium sequence the right notebook's idle codicon is absent (present in isolation).
- **Frequency:** ~26% of this test's recent failures; ubuntu/chromium.
- **Hypothesis:** Cross-test teardown race. Desktop empty-state wait in `deleteAll()` closes it (2/2 full spec on electron). Served sessions (server/workbench) intentionally keep a session behind and skip the wait, so the web sequence is not fully closed here; local-machine load also confounds the chromium repro.

</details>
