### PR TITLE
Show Copilot usage in status bar popup even when chat UI is hidden

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
@@ -318,10 +318,7 @@ export class ChatStatusDashboard extends DomWidget {
 			}
 
 			let chatQuotaIndicator: ((quota: IQuotaSnapshot | string) => void) | undefined;
-			// --- Start Positron ---
-			// Hide the "Chat messages" quota row in completions-only mode (chat is hidden).
-			if (!this.options?.disableChatSections && chatQuota && !chatQuota.unlimited && (!this.chatEntitlementService.quotas.usageBasedBilling || this.chatEntitlementService.entitlement === ChatEntitlement.Free)) {
-				// --- End Positron ---
+			if (chatQuota && !chatQuota.unlimited && (!this.chatEntitlementService.quotas.usageBasedBilling || this.chatEntitlementService.entitlement === ChatEntitlement.Free)) {
 				const chatLabel = this.chatEntitlementService.quotas.usageBasedBilling && this.chatEntitlementService.entitlement === ChatEntitlement.Free
 					? localize('creditsLabel', "Credits")
 					: localize('chatsLabel', "Chat messages");
@@ -329,10 +326,7 @@ export class ChatStatusDashboard extends DomWidget {
 			}
 
 			let premiumChatQuotaIndicator: ((quota: IQuotaSnapshot | string) => void) | undefined;
-			// --- Start Positron ---
-			// Hide the "Premium requests" quota row in completions-only mode (chat is hidden).
-			if (!this.options?.disableChatSections && premiumChatQuota && !premiumChatQuota.unlimited && premiumChatQuota.percentRemaining >= 0) {
-				// --- End Positron ---
+			if (premiumChatQuota && !premiumChatQuota.unlimited && premiumChatQuota.percentRemaining >= 0) {
 				const isUBB = this.chatEntitlementService.quotas.usageBasedBilling;
 				const premiumChatLabel = isUBB
 					? localize('creditsLabel', "Credits")
@@ -385,10 +379,7 @@ export class ChatStatusDashboard extends DomWidget {
 		}
 
 		// Anonymous Indicator
-		// --- Start Positron ---
-		// Hide the anonymous "Chat messages" quota row in completions-only mode (chat is hidden).
-		else if (!this.options?.disableChatSections && this.chatEntitlementService.anonymous && this.chatEntitlementService.sentiment.completed) {
-			// --- End Positron ---
+		else if (this.chatEntitlementService.anonymous && this.chatEntitlementService.sentiment.completed) {
 			this.createQuotaIndicator(container, localize('quotaLimited', "Limited"), localize('chatsLabel', "Chat messages"));
 		}
 	}

--- a/src/vs/workbench/contrib/chat/test/browser/chatStatusDashboard.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatStatusDashboard.test.ts
@@ -115,7 +115,11 @@ const dashboardOptions: IChatStatusDashboardOptions = {
 suite('ChatStatusDashboard', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
 
-	function createDashboard(entitlementService: IChatEntitlementService): ChatStatusDashboard {
+	// --- Start Positron ---
+	// `options` param added (defaulting to the original hardcoded `dashboardOptions`) so
+	// tests can exercise `disableChatSections` (completions-only mode) below.
+	function createDashboard(entitlementService: IChatEntitlementService, options: IChatStatusDashboardOptions = dashboardOptions): ChatStatusDashboard {
+		// --- End Positron ---
 		const instantiationService = workbenchInstantiationService(undefined, store);
 
 		instantiationService.stub(IChatEntitlementService, entitlementService);
@@ -137,7 +141,10 @@ suite('ChatStatusDashboard', () => {
 			_serviceBrand: undefined,
 		});
 
-		const dashboard = store.add(instantiationService.createInstance(ChatStatusDashboard, dashboardOptions));
+		// --- Start Positron ---
+		// Was: instantiationService.createInstance(ChatStatusDashboard, dashboardOptions)
+		const dashboard = store.add(instantiationService.createInstance(ChatStatusDashboard, options));
+		// --- End Positron ---
 
 		mainWindow.document.body.appendChild(dashboard.element);
 		store.add({ dispose: () => dashboard.element.remove() });
@@ -633,6 +640,24 @@ suite('ChatStatusDashboard', () => {
 
 		assert.strictEqual(getCalloutText(dashboard.element), 'You\'ve used your included credits. Your organization covers additional usage, so you can keep working.');
 	});
+
+	// --- Start Positron ---
+	// --- COMPLETIONS-ONLY MODE ---
+	// Regression test for https://github.com/posit-dev/positron/issues/14989: Copilot's
+	// usage rows must stay visible even when `disableChatSections` hides the chat-specific
+	// setup / contributed sections, since Copilot's quota still applies when it's used as a
+	// chat provider in Posit Assistant.
+	test('Completions-only mode: still shows Chat messages and Premium requests quota rows', () => {
+		const dashboard = createDashboard(createEntitlementService({
+			chat: { percentRemaining: 80, unlimited: false },
+			premiumChat: { percentRemaining: 60, unlimited: false },
+			completions: { percentRemaining: 90, unlimited: false },
+			entitlement: ChatEntitlement.Pro,
+		}), { ...dashboardOptions, disableChatSections: true });
+
+		assert.deepStrictEqual(getQuotaLabels(dashboard.element), ['Chat messages', 'Premium requests', 'Inline Suggestions']);
+	});
+	// --- End Positron ---
 
 	// --- LIVE UPDATES ---
 


### PR DESCRIPTION
Fixes #14989

Positron defaults `chat.disableAIFeatures` to `true`, which puts the Copilot status bar entry into "completions-only mode" so the built-in Copilot chat UI stays hidden. As a side effect, this also hid the chat and premium request quota rows in the usage popup, even though Copilot's usage still applies when it's used as a model provider in Posit Assistant. This reverts the added gating on those rows back to upstream behaviour, so the usage popup shows quota info regardless of whether the chat UI is hidden.

### Release Notes

#### Bug Fixes
- Show Copilot usage (chat and premium request quotas) in the status bar popup even when the built-in Copilot chat UI is hidden (#14989)

### Validation Steps

@:assistant

1. Sign in to GitHub Copilot with an account that has quota data (Free, Pro, Business, or Enterprise).
2. Leave `chat.disableAIFeatures` at its default (`true`).
3. Click the Copilot status bar icon to open the usage popup.
4. Verify the "Chat messages" / "Premium requests" quota rows are visible alongside "Inline Suggestions", matching what you'd see in stock VS Code.

free tier:

<img width="357" height="392" alt="image" src="https://github.com/user-attachments/assets/11965b28-a0a1-4acd-8cc7-51e607d44a0a" />

business tier:

<img width="359" height="254" alt="image" src="https://github.com/user-attachments/assets/0922ffa3-fb24-48c7-8973-dd0c36e4c5df" />
