### PR TITLE
Clear stale results in R test explorer at start of run

### DIFF
--- a/extensions/positron-r/resources/testing/r.pkg.test.explorer.fixture/tests/testthat/test-early-stop.R
+++ b/extensions/positron-r/resources/testing/r.pkg.test.explorer.fixture/tests/testthat/test-early-stop.R
@@ -1,0 +1,13 @@
+test_that("runs before the stop", {
+  expect_true(TRUE)
+})
+
+# The e2e test drops a "STOP" sentinel in tests/testthat/ so this top-level
+# stop() ends the file early, leaving the test below unrun.
+if (file.exists("STOP")) {
+  stop("stopping before the rest of the file")
+}
+
+test_that("runs after the stop", {
+  expect_true(TRUE)
+})

--- a/extensions/positron-r/src/testing/runner-testthat.ts
+++ b/extensions/positron-r/src/testing/runner-testthat.ts
@@ -12,7 +12,6 @@ import { checkInstalled, getLocale } from '../session';
 import { EXTENSION_ROOT_DIR } from '../constants';
 import { ItemType, TestingTools, encodeNodeId, escapeLabelForRDesc } from './util-testing';
 import { TestResult } from './reporter';
-import { parseTestsFromFile } from './parser';
 import { RSessionManager } from '../session-manager';
 
 const testReporterPath = path
@@ -69,16 +68,9 @@ export async function runThatTest(
 			return Promise.resolve('Individual it() call: can\'t be run individually.');
 		case ItemType.File:
 			LOGGER.info('Test type is file');
-			if (test!.children.size === 0) {
-				LOGGER.info('Children are not yet available. Parsing children.');
-				await parseTestsFromFile(testingTools, test!);
-			}
 			break;
 		case ItemType.Directory:
 			LOGGER.info('Test type is directory');
-			testingTools.controller.items.forEach(async (test) => {
-				await parseTestsFromFile(testingTools, test);
-			});
 			break;
 	}
 
@@ -120,6 +112,7 @@ export async function runThatTest(
 			}
 		});
 		let stdout = '';
+		let sawEndReporter = false;
 		const testStartDates = new WeakMap<vscode.TestItem, number>();
 		childProcess.stdout!
 			.pipe(split2((line: string) => {
@@ -220,14 +213,31 @@ export async function runThatTest(
 							}
 						}
 						break;
+					case 'end_reporter':
+						sawEndReporter = true;
+						break;
 				}
 			});
-		childProcess.once('exit', () => {
-			stdout += childProcess.stderr.read();
-			if (stdout.includes('Execution halted')) {
-				reject(Error(stdout));
+		childProcess.once('exit', (code, signal) => {
+			const stderr = String(childProcess.stderr.read() ?? '');
+			stdout += stderr;
+			if (sawEndReporter) {
+				resolve(stdout);
+				return;
 			}
-			resolve(stdout);
+			// If we haven't seen end_reporter, that means R died before testthat
+			// finished its work cleanly (e.g. a failed load_all(), an error in a
+			// setup or helper file, or an R crash). Surface what we know in TEST
+			// RESULTS.
+			const how = signal ? `signal ${signal}` : `exit code ${code}`;
+			run.appendOutput(
+				`\r\nThe R test run ended before completing (${how}).\r\n`
+			);
+			const detail = stderr.trim();
+			if (detail) {
+				run.appendOutput(detail.replace(/\r?\n/g, '\r\n') + '\r\n');
+			}
+			reject(new Error(detail || `R exited with ${how} before completing.`));
 		});
 		childProcess.once('error', (err) => {
 			reject(err);

--- a/extensions/positron-r/src/testing/runner.ts
+++ b/extensions/positron-r/src/testing/runner.ts
@@ -5,16 +5,24 @@
 
 import * as vscode from 'vscode';
 import { runThatTest } from './runner-testthat';
-import { TestingTools } from './util-testing';
+import { ItemType, TestingTools } from './util-testing';
+import { parseTestsFromFile } from './parser';
 import { LOGGER } from '../extension';
 
-function maybeEnqueue(
-	test: vscode.TestItem,
-	queue: vscode.TestItem[],
-	excludeSet: readonly vscode.TestItem[] | undefined
+// Paint the UI state of every leaf test under `item` as "queued", recursing through containers.
+function markLeafTestsQueued(
+	testingTools: TestingTools,
+	item: vscode.TestItem,
+	run: vscode.TestRun
 ) {
-	if (!excludeSet?.includes(test)) {
-		queue.push(test);
+	if (item.children.size > 0) {
+		item.children.forEach((child) => markLeafTestsQueued(testingTools, child, run));
+	} else {
+		const type = testingTools.testItemData.get(item);
+		if (type === ItemType.TestThat || type === ItemType.It) {
+			// Only mark a true leaf, not an empty container
+			run.enqueued(item);
+		}
 	}
 }
 
@@ -41,20 +49,41 @@ export async function runHandler(
 		});
 	}
 
-	// We only enqueue tests if we are running something smaller than the whole suite.
-	if (!runAllTests) {
+	// The items to run: every file for a run-all, otherwise the requested (or broken-up) items.
+	const toRun: vscode.TestItem[] = [];
+	if (runAllTests) {
+		testingTools.controller.items.forEach((file) => toRun.push(file));
+	} else {
 		const eligibleTests = explicitInclude ? request.include! : testingTools.controller.items;
-		eligibleTests.forEach((test) => {
+		eligibleTests.forEach((test: vscode.TestItem) => {
 			if (toBreakUp.includes(test)) {
-				test.children.forEach((childTest) => {
-					maybeEnqueue(childTest, queue, request.exclude);
-				});
+				test.children.forEach((child) => toRun.push(child));
 			} else {
-				maybeEnqueue(test, queue, request.exclude);
+				toRun.push(test);
 			}
 		});
-		LOGGER.info(`${queue.length} tests are enqueued`);
 	}
+
+	// Parse files whose children aren't materialized yet, so their leaves exist to mark.
+	const parses: Promise<void>[] = [];
+	toRun.forEach((item) => {
+		if (testingTools.testItemData.get(item) === ItemType.File && item.children.size === 0) {
+			parses.push(parseTestsFromFile(testingTools, item));
+		}
+	});
+	await Promise.all(parses);
+
+	// Mark each leaf "queued" so a run that stops early shows no stale/fresh mix. For a partial
+	// run, also queue the item for the loop below; a run-all is one invocation over the directory.
+	toRun.forEach((item) => {
+		if (request.exclude?.includes(item)) {
+			return;
+		}
+		markLeafTestsQueued(testingTools, item, run);
+		if (!runAllTests) {
+			queue.push(item);
+		}
+	});
 
 	while (!token.isCancellationRequested && (queue.length > 0 || runAllTests)) {
 		let test: vscode.TestItem | undefined;

--- a/test/e2e/tests/test-explorer/test-explorer.test.ts
+++ b/test/e2e/tests/test-explorer/test-explorer.test.ts
@@ -124,4 +124,27 @@ test.describe('R Test Explorer', { tag: [tags.TEST_EXPLORER, tags.R_PKG_DEVELOPM
 		await testExplorer.expectTestItems(['added out of band'], WATCHER_TIMEOUT);
 		await testExplorer.expectNoTestItem('test_that number 2 fails', WATCHER_TIMEOUT);
 	});
+
+	// Clear-on-run: a run that stops partway must clear stale results, not leave them behind.
+	test('A run that stops partway clears stale results', async function ({ app }, testInfo) {
+		const { testExplorer } = app.workbench;
+		const testthatDir = path.join(path.dirname(app.workspacePathOrFolder), fixtureFolderFor(testInfo.title, testInfo.workerIndex), 'tests', 'testthat');
+		const BEFORE = 'runs before the stop';
+		const AFTER = 'runs after the stop';
+
+		// First run: no STOP sentinel, so the whole file runs and both tests pass.
+		await testExplorer.runAllTests();
+		await testExplorer.expectTestStatus('test-early-stop.R', 'Passed', 60000);
+		await testExplorer.expandAllTests();
+		await testExplorer.expectTestStatus(BEFORE, 'Passed');
+		await testExplorer.expectTestStatus(AFTER, 'Passed');
+
+		// Drop the sentinel so a top-level stop() ends the file after the first test.
+		fs.writeFileSync(path.join(testthatDir, 'STOP'), '');
+
+		// Second run: the file stops after BEFORE, so AFTER never runs. Its prior
+		// 'Passed' must be cleared to 'Skipped', not left stale.
+		await testExplorer.runAllTests();
+		await testExplorer.expectTestStatus(AFTER, 'Skipped', 60000);
+	});
 });


### PR DESCRIPTION
Closes #15019
Partial progress on #14668

This PR rationalizes what happens at the start of a test run and when a test run doesn't complete cleanly. This is not about tests passing or failing, but about the test machinery being stale or fouled up.

First, before running tests, we now mark every leaf test that's about to run as "queued", eagerly clearing any result from a previous run up front. Here's how a large test suite looks now at the start of "run all tests". Notice how everything immediately switches to this yellow "Queued" status. This is the main improved behaviour every user will notice!

<img width="333" height="478" alt="Screenshot 2026-07-20 at 12 00 59 PM" src="https://github.com/user-attachments/assets/3bf174ce-7fca-47f9-9279-f8c1fdbb14ac" />

If the run ends early, un-run tests show as "Skipped" instead of retaining their out-of-date pass/fail status from before. (I think "Not yet run" would be a more appropriate status than "Skipped", but this behaviour comes from the VS Code core, not in positron-r, so I'm living with it for now.) This requires doing more work eagerly (parsing, changing test status, enqueing), but we're not doing any *new* work. Just doing the same old work in a more useful order. I attach before/after screenshots of this in a comment below.

There's a new e2e test of the clear-on-run behaviour and I verified that it fails before the changes and passes after.

Second, another fix motivated by my manual experimentation. Now we explicitly look for testthat's `end_reporter` event. If the R process exits without that, we know it's an unclean exit and reveal more detail in the TEST RESULTS area. This output can be sort of verbose and ugly, but it's a vast improvement over "The test run did not record any output." and it's *actionable*.

This can happen via some edge cases (failed `load_all()` or even a segfault). This replaces a brittle "Execution halted" match on stdout with a more structured approach based on `end_reporter`. No formal test of this yet, because putting more useful info in TEST RESULTS is the next work item and that's when I will add the infrastructure to inspect it. I attach a screenshot of the new behaviour below.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- The R test explorer proactively clears existing test statuses at the start of a partial or full run, to avoid displaying a mix of current and stale results. Runs that finish uncleanly reveal more actionable information in the TEST RESULTS panel.

#### Bug Fixes

- N/A


### Validation Steps

Run a whole, large test suite and behold how all tests snap to "Queued" at the very start.

Break `load_all()` and run tests. Notice that no pre-existing passing/failing test statuses persist. Everything is marked as "Skipped". You can break `load_all()` by putting `stop("breaking load_all()")` somewhere like the start of `tests/testthat/setup.R` or `test/testthat/helper.R`. Notice the new info surfaced in TEST RESULTS.

<img width="540" height="239" alt="Screenshot 2026-07-20 at 12 10 23 PM" src="https://github.com/user-attachments/assets/c45f83c2-930e-4d42-9278-5604930411c5" />

If you want to play with a partial test run, drop this into a test file in an existing R package:

```
test_that("passing test before the quit", {
  expect_true(TRUE)
})

test_that("test that crashes R", {
  skip("not really interested in studying a crash")
  rlang::node_car(1L)
})

test_that("test with uncaught error", {
  stop("oops")
})

stop("stop testing in middle of file")

test_that("failing test after the quit", {
  expect_true(FALSE)
})
```

Run just this test file by clicking its "Run test" play button in the explorer. Comment / uncomment the `stop()` in order to witness what happens with the status of the `test_that()` *after* the `stop()`.

@:test-explorer @:web @:win