### PR TITLE
ci: remove @:no-auto-tags reference from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -45,7 +45,7 @@ main branch by either pulling or rebasing.
 <!--
   Positron team members: e2e feature tags are auto-added based on your changed
   files, so tests run automatically when you open this pull request. Add tags
-  here yourself to run more, or use `@:no-auto-tags` to opt out.
+  here yourself to run more.
 
   - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
   - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts


### PR DESCRIPTION
### Summary
The e2e tag parser greps the whole PR body for `@:no-auto-tags`, so the mention in the template's boilerplate comment silently opts every PR out of auto-tagging.

- Removed the `@:no-auto-tags` sentence from the Validation Steps comment in `.github/pull_request_template.md`
- The opt-out itself is unchanged and still documented in `test/e2e/README.md`

### QA Notes
Docs-only; no test tags needed.