### PR TITLE
[SCRATCH - do not merge] docs-only skip demo

### DIFF
--- a/scratch-ci-demo.md
+++ b/scratch-ci-demo.md
@@ -1,0 +1,3 @@
+# Scratch CI demo
+
+Throwaway file to exercise the docs-only skip. Safe to delete.


### PR DESCRIPTION
Throwaway PR to demonstrate the docs-only CI skip end-to-end. Base carries the detector; diff is a single markdown file. Expect test / unit, test / ext-host, e2e / electron to go green in seconds with real steps skipped. Delete after verifying.