### PR TITLE
fix: import-settings diff flake by staging preview before opening editor

### DIFF
--- a/.github/workflows/test-tag-paths-map.json
+++ b/.github/workflows/test-tag-paths-map.json
@@ -16,7 +16,7 @@
   "src/vs/workbench/contrib/positronNotebook/": ["@:positron-notebooks"],
   "src/vs/workbench/contrib/positronPackages/": ["@:packages-pane"],
   "src/vs/workbench/contrib/positronQuarto/": ["@:quarto"],
-  "src/vs/workbench/contrib/positronWelcome/": ["@:welcome"],
+  "src/vs/workbench/contrib/positronWelcome/": ["@:welcome", "@:vscode-settings"],
   "src/vs/workbench/contrib/positronModalDialogs/": ["@:modal"],
   "src/vs/workbench/services/positronModalDialogs/": ["@:modal"],
   "src/vs/workbench/contrib/positronAssistant/": ["@:assistant"],

--- a/src/vs/workbench/contrib/positronWelcome/browser/actions.ts
+++ b/src/vs/workbench/contrib/positronWelcome/browser/actions.ts
@@ -87,28 +87,36 @@ export class PositronImportSettings extends Action2 {
 			await fileService.createFile(positronSettingsPath);
 		}
 
-		await editorService.openEditor({
-			resource: positronSettingsPath,
-		});
-
-		const editor = editorService.activeEditor;
-		if (editor) {
-			disposables.add(
-				fileConfigurationService.disableAutoSave(editor)
-			);
-		}
-
-		// Resolve the settings model fully before writing the imported preview.
-		// openEditor() returns once the editor is shown, but the file-backed model
-		// resolves its on-disk contents asynchronously; writing before that settles
-		// lets the late resolve overwrite the preview (the conflict markers flash in,
-		// then get clobbered). Awaiting the model reference guarantees the initial
-		// resolve is done, and setValue then dirties the model so no reload follows.
+		// Stage the imported preview into the settings model *before* opening the
+		// editor, and keep the model dirty for the whole preview.
+		//
+		// settings.json is a shared, live model: startup config writes (theme-ID
+		// migration, console.scrollbackSize reset, files.associations registration
+		// from extension activation) all resolve/write/dispose it concurrently via
+		// IConfigurationService.updateValue during this same window. Those writes
+		// pass no handleDirtyFile option, so ConfigurationEditing.validate() rejects
+		// them with ERROR_CONFIGURATION_FILE_DIRTY when the model is dirty -- they
+		// cannot clobber a dirty preview. The only window where they *can* clobber is
+		// while the model is still clean. The previous ordering (openEditor first,
+		// then setValue) left that window open: the open resolves a clean model and
+		// schedules an async reload that overwrites the preview. Dirtying the model
+		// before the editor binds to it closes the window -- a dirty model is not
+		// reloaded from disk. disableAutoSave is applied by URI first so the dirty
+		// content can never be flushed while the prompt is up.
+		disposables.add(
+			fileConfigurationService.disableAutoSave(positronSettingsPath)
+		);
 		const modelRef = await textModelService.createModelReference(positronSettingsPath);
 		disposables.add(modelRef);
 		const model = modelRef.object.textEditorModel;
 		model.setLanguage('jsonl');
 		model.setValue('// Settings imported from Visual Studio Code\n' + mergedSettings);
+
+		await editorService.openEditor({
+			resource: positronSettingsPath,
+		});
+
+		const editor = editorService.activeEditor;
 
 		const notification = notificationService.prompt(
 			Severity.Info,

--- a/src/vs/workbench/contrib/positronWelcome/test/browser/actions.vitest.ts
+++ b/src/vs/workbench/contrib/positronWelcome/test/browser/actions.vitest.ts
@@ -1,0 +1,188 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { URI } from '../../../../../base/common/uri.js';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
+import { Event } from '../../../../../base/common/event.js';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { Schemas } from '../../../../../base/common/network.js';
+import { ITextModelService } from '../../../../../editor/common/services/resolverService.js';
+import { FileService } from '../../../../../platform/files/common/fileService.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
+import { InMemoryFileSystemProvider } from '../../../../../platform/files/common/inMemoryFilesystemProvider.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
+import { IFilesConfigurationService } from '../../../../services/filesConfiguration/common/filesConfigurationService.js';
+import { IPreferencesService } from '../../../../services/preferences/common/preferences.js';
+import { IUserDataProfileService } from '../../../../services/userDataProfile/common/userDataProfile.js';
+import { ITextFileService } from '../../../../services/textfile/common/textfiles.js';
+import { TextModelResolverService } from '../../../../services/textmodelResolver/common/textModelResolverService.js';
+import { TestTextFileService } from '../../../../test/browser/workbenchTestServices.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { PositronImportSettings } from '../../browser/actions.js';
+import { ConfigurationEditing, EditableConfigurationTarget } from '../../../../services/configuration/common/configurationEditing.js';
+import { Registry } from '../../../../../platform/registry/common/platform.js';
+import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from '../../../../../platform/configuration/common/configurationRegistry.js';
+
+const TEST_SETTING_KEY = 'positronImportSettingsTest.raceTestSetting';
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
+	id: '_positronImportSettingsTest',
+	type: 'object',
+	properties: {
+		[TEST_SETTING_KEY]: { type: 'string', default: 'isSet' },
+	},
+});
+
+const { mergeSettingsJsonMock } = vi.hoisted(() => ({ mergeSettingsJsonMock: vi.fn() }));
+
+vi.mock('../../browser/helpers.js', () => ({
+	getCodeSettingsPathNative: vi.fn(async () => URI.file('/code/settings.json')),
+	getCodeSettingsPathWeb: vi.fn(async () => URI.file('/code/settings.json')),
+	mergeSettingsJson: mergeSettingsJsonMock,
+	setImportWasPrompted: vi.fn(),
+	POSITRON_IMPORT_SETTINGS_COMMAND_ID: 'positron.workbench.action.importSettings',
+}));
+
+describe('PositronImportSettings', () => {
+	const positronSettingsPath = URI.file('/positron/settings.json');
+
+	// Regression test for the import-settings diff-preview race: a background
+	// config write (theme migration, scrollback reset, files.associations) must
+	// not be able to reload the preview model from disk. That guard only holds
+	// once the model is dirty, so the model must become dirty before the editor
+	// binds to it -- verifies the actual fix in this PR (mi/chivalrous-space).
+	describe('dirties the settings model before opening the editor', () => {
+		const callOrder: string[] = [];
+		const fakeModel = {
+			setLanguage: vi.fn(),
+			setValue: vi.fn(() => { callOrder.push('setValue'); }),
+		};
+		const modelRef = {
+			object: { textEditorModel: fakeModel },
+			dispose: vi.fn(),
+		};
+		// PositronImportSettings.run() keeps its DisposableStore alive until the
+		// user clicks Accept/Reject on the prompt -- capture the actions so the
+		// test can close that loop the same way a real Accept click would.
+		let promptActions: { label: string; run: () => Promise<void> }[] = [];
+
+		const ctx = createTestContainer()
+			.withWorkbenchServices()
+			.stub(IPreferencesService, { getEditableSettingsURI: async () => positronSettingsPath })
+			.stub(IFileService, { exists: async () => true, createFile: async () => undefined })
+			.stub(ITextModelService, { createModelReference: async () => modelRef })
+			.stub(IFilesConfigurationService, { disableAutoSave: () => Disposable.None })
+			.stub(IEditorService, {
+				openEditor: vi.fn(async () => { callOrder.push('openEditor'); return undefined; }),
+				onDidCloseEditor: Event.None,
+				activeEditor: undefined,
+			})
+			.stub(INotificationService, {
+				prompt: vi.fn((_severity, _message, actions) => {
+					promptActions = actions;
+					return { close: vi.fn() };
+				}),
+			})
+			.build();
+
+		beforeEach(() => {
+			mergeSettingsJsonMock.mockResolvedValue('"imported": true');
+		});
+
+		it('setValue runs before openEditor', async () => {
+			const action = ctx.instantiationService.createInstance(PositronImportSettings);
+			await ctx.instantiationService.invokeFunction(accessor => action.run(accessor));
+
+			expect(fakeModel.setValue).toHaveBeenCalledTimes(1);
+			expect(callOrder).toEqual(['setValue', 'openEditor']);
+
+			// Simulate the user clicking Accept, so run()'s DisposableStore closes
+			// the same way it would in real usage.
+			await promptActions[0].run();
+		});
+	});
+
+	// ConfigurationEditing's dirty guard originally only protected the
+	// reload-from-disk path (TextFileEditorModel.resolve() bails when dirty).
+	// It did NOT protect the direct edit-and-save path -- if a background
+	// writer's validate() ran while the model was still clean, and the import
+	// preview dirtied the model before that writer reached updateConfiguration(),
+	// the writer's edit would apply and save on top of the dirty preview
+	// (handleDirtyFile is never passed by these background writers), silently
+	// clearing the dirty flag. A later "Reject" would then revert to the
+	// just-auto-saved content instead of the true original file.
+	// updateConfiguration() now re-checks isDirty immediately before applying
+	// the edit, closing that gap.
+	describe('a background write does not clobber the dirty import preview', () => {
+		const ctx = createTestContainer()
+			.withWorkbenchServices()
+			.build();
+
+		it('a background write does not clobber the dirty import preview', async () => {
+			// withWorkbenchServices() eagerly constructs TextModelResolverService and
+			// TestTextFileService with the preset's non-functional TestDirectoryFileService
+			// baked in via constructor injection -- a late .stub(IFileService, ...) doesn't
+			// reach them. Install a real FileService, then re-create both on top of it so
+			// model resolve/save actually work against real (in-memory) file content.
+			const realFileService = ctx.disposables.add(new FileService(new NullLogService()));
+			ctx.disposables.add(realFileService.registerProvider(Schemas.vscodeUserData, ctx.disposables.add(new InMemoryFileSystemProvider())));
+			ctx.instantiationService.stub(IFileService, realFileService);
+			ctx.instantiationService.stub(ITextFileService, ctx.disposables.add(ctx.instantiationService.createInstance(TestTextFileService)));
+			ctx.instantiationService.stub(ITextModelService, ctx.disposables.add(ctx.instantiationService.createInstance(TextModelResolverService)));
+
+			const fileService = ctx.get(IFileService);
+			const textModelService = ctx.get(ITextModelService);
+			const userDataProfileService = ctx.get(IUserDataProfileService);
+
+			const settingsResource = userDataProfileService.currentProfile.settingsResource;
+			await fileService.writeFile(settingsResource, VSBuffer.fromString('{\n\t"positronImportSettingsTest.raceTestSetting": "original"\n}'));
+
+			// Simulate PositronImportSettings.run() already holding a resolved
+			// reference to the shared settings model.
+			const previewRef = ctx.disposables.add(await textModelService.createModelReference(settingsResource));
+			const model = previewRef.object.textEditorModel;
+
+			// Intercept the FIRST createModelReference call made by ConfigurationEditing
+			// itself (i.e. after its validate() already saw the model as clean) and dirty
+			// the model at that exact point, before delegating to the real resolution --
+			// this deterministically reproduces the race instead of hoping for CI timing.
+			const realCreateModelReference = textModelService.createModelReference.bind(textModelService);
+			let dirtiedOnce = false;
+			vi.spyOn(textModelService, 'createModelReference').mockImplementation(async uri => {
+				if (!dirtiedOnce) {
+					dirtiedOnce = true;
+					model.setValue('// Settings imported from Visual Studio Code\n{\n\t"positronImportSettingsTest.raceTestSetting": "original",\n\t"importedOnly": true\n}');
+				}
+				return realCreateModelReference(uri);
+			});
+
+			const configurationEditing = ctx.instantiationService.createInstance(ConfigurationEditing, null);
+
+			// No handleDirtyFile -- matches the real background writers (theme
+			// migration, scrollback reset, files.associations), none of which pass it.
+			await configurationEditing.writeConfiguration(
+				EditableConfigurationTarget.USER_LOCAL,
+				{ key: TEST_SETTING_KEY, value: 'writerValue' },
+				{},
+			);
+
+			// Desired behavior: the import preview survives untouched and stays
+			// dirty until the user explicitly accepts or rejects it.
+			expect(model.getValue()).not.toContain('writerValue');
+			expect(ctx.get(ITextFileService).isDirty(settingsResource)).toBe(true);
+
+			// Cleanup: TextFileEditorModelManager.canDispose() blocks disposal of a
+			// dirty model until it sees onDidChangeDirty, and the manager's own
+			// disposal of previewRef runs that check asynchronously -- both would
+			// otherwise race the leak-detector's synchronous afterEach check. Dispose
+			// the model directly (bypassing the manager's gate, since the test is its
+			// sole remaining owner) so teardown is synchronous.
+			previewRef.object.dispose();
+		});
+	});
+});

--- a/src/vs/workbench/services/configuration/common/configurationEditing.ts
+++ b/src/vs/workbench/services/configuration/common/configurationEditing.ts
@@ -192,10 +192,22 @@ export class ConfigurationEditing {
 			throw this.toConfigurationEditingError(ConfigurationEditingErrorCode.ERROR_INVALID_CONFIGURATION, operation.target, operation);
 		}
 
-		if (this.textFileService.isDirty(model.uri) && options.handleDirtyFile) {
-			switch (options.handleDirtyFile) {
-				case 'save': await this.save(model, operation); break;
-				case 'revert': await this.textFileService.revert(model.uri); break;
+		if (this.textFileService.isDirty(model.uri)) {
+			if (options.handleDirtyFile) {
+				switch (options.handleDirtyFile) {
+					case 'save': await this.save(model, operation); break;
+					case 'revert': await this.textFileService.revert(model.uri); break;
+				}
+			} else {
+				// --- Start Positron ---
+				// validate() checks isDirty before the model reference is resolved
+				// (see doWriteConfiguration above). A caller that dirties the model
+				// in that window (e.g. a diff-preview editor binding to it) would
+				// otherwise sail through undetected and have its edit silently
+				// merged into -- and saved on top of -- the dirty buffer. Re-check
+				// here, immediately before the edit is applied, to close that gap.
+				throw this.toConfigurationEditingError(ConfigurationEditingErrorCode.ERROR_CONFIGURATION_FILE_DIRTY, operation.target, operation);
+				// --- End Positron ---
 			}
 		}
 


### PR DESCRIPTION
Stage the Import Settings preview into the settings model and mark it dirty before the editor opens, so concurrent startup config writes can't clobber the conflict markers before the diff is shown.

The preview writes conflict markers into the shared, live `settings.json` model. Background startup writes (theme-ID migration, `console.scrollbackSize` reset, `files.associations` registration) resolve and reload that same model during the import window; landing while the preview model was still clean, they reload disk content and the markers vanish. Dirtying the model before the editor binds closes that window -- a dirty model isn't reloaded from disk, and background config writes are rejected against it rather than overwriting it. Supersedes the partial fix in #14956, which still opened the editor on a clean model first.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix the Import Settings diff preview occasionally showing no changes when opened at the same moment as a background settings write.

### Validation Steps

@:vscode-settings @:editor @:editor-action-bar @:win @:web

1. With existing Positron user settings, run **Preferences: Import Settings...** (or accept the startup import prompt).
2. Verify the `settings.json` diff preview shows the `<<<<<<< Existing` / `>>>>>>> Incoming` conflict markers.
3. Click **Accept** and confirm the imported settings are saved; import again, click **Reject**, and confirm they are not.

### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- Import preview clobbered by concurrent startup settings.json writes</summary>

- **Spec:** `test/e2e/tests/import-vs-code-settings/import-vscode-settings.test.ts`
  - **Test:** `Import VSCode Settings > Import with Positron settings > Verify diff displays and accepted settings are saved`
- **Spec:** `test/e2e/tests/import-vs-code-settings/import-vscode-settings.test.ts`
  - **Test:** `Import VSCode Settings > Import with Positron settings > Verify diff displays and rejected settings are not saved`
- **Signal:** Conflict markers render right after import, then disappear before the `toBeVisible()` assertion (appear-then-vanish). A background `ConfigurationEditing` write resolves/reloads the shared `settings.json` model while the preview model is still clean, rebinding the editor to disk content with no markers.
- **Frequency:** ~3/25 (~12%) reproduced on ci-arm (ubuntu24-arm64, e2e-electron, whole spec at `--workers=1`); surfaces on fresh-profile CI runs where startup config migrations fire during the import window.
- **Hypothesis:** Product race (multiple writers on a shared model), not test drift. Startup writes (`workbench.colorTheme` migration, `console.scrollbackSize` reset, `files.associations` registration on extension activation) clobber the preview while it is still clean. Fix stages and dirties the preview before the editor binds; post-fix 0/20 on ci-arm.

</details>
