### PR TITLE
Add Data Explorer preview for tabular pins on Connect

### DIFF
--- a/extensions/positron-data-driver-duckdb/src/test/duckdbTableView.test.ts
+++ b/extensions/positron-data-driver-duckdb/src/test/duckdbTableView.test.ts
@@ -218,11 +218,48 @@ suite('DuckDB Data Explorer Tests', () => {
 			try {
 				// The physical table ('pin_g_cars_5', a synthetic name over a downloaded file) and the
 				// display name ('julia/cars', what the tab should show) deliberately differ.
-				await handler.openTableView('ds1', client, 'main', 'pin_g_cars_5', 'table', 'julia/cars');
+				await handler.openTableView('ds1', client, 'main', 'pin_g_cars_5', 'table', { displayName: 'julia/cars' });
 				const response = await handler.handleRequest({
 					method: DataExplorerBackendRequest.GetState, uri: 'ds1', params: {},
 				} as DataExplorerRpc) as DataExplorerResponse & { result: BackendState };
 				assert.strictEqual(response.result.display_name, 'julia/cars');
+			} finally {
+				handler.dispose();
+			}
+		});
+	});
+
+	suite('dataset close', () => {
+		// A client that answers buildDuckDBSchema (information_schema) and getState (count(*)).
+		const makeClient = () => new FakeQueryClient(sql =>
+			sql.includes('information_schema') ? [{ column_name: 'id', data_type: 'INTEGER' }] : [{ n: 0 }]);
+
+		test('closeDataset drops the view and invokes the onClose hook', async () => {
+			const handler = new DuckDBDataExplorerRpcHandler('test-provider');
+			let closed = false;
+			try {
+				await handler.openTableView('ds1', makeClient(), 'main', 't', 'table', { onClose: () => { closed = true; } });
+				handler.closeDataset('ds1');
+				assert.strictEqual(closed, true);
+				// The view is gone, so a later RPC for the dataset comes back as an error.
+				const response = await handler.handleRequest({
+					method: DataExplorerBackendRequest.GetState, uri: 'ds1', params: {},
+				} as DataExplorerRpc) as { error_message?: string };
+				assert.ok(response.error_message);
+			} finally {
+				handler.dispose();
+			}
+		});
+
+		test('closeTableView drops the view without invoking the onClose hook', async () => {
+			// Disconnect uses closeTableView and tears down its own worker, so the per-dataset hook must
+			// not fire (it would double up on that cleanup).
+			const handler = new DuckDBDataExplorerRpcHandler('test-provider');
+			let closed = false;
+			try {
+				await handler.openTableView('ds1', makeClient(), 'main', 't', 'table', { onClose: () => { closed = true; } });
+				handler.closeTableView('ds1');
+				assert.strictEqual(closed, false);
 			} finally {
 				handler.dispose();
 			}

--- a/extensions/positron-data-driver-duckdb/src/test/duckdbTableView.test.ts
+++ b/extensions/positron-data-driver-duckdb/src/test/duckdbTableView.test.ts
@@ -4,10 +4,21 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { DuckDBRow, DuckDBSchemaEntry, DuckDBTableView, duckdbDisplayType, makeWhereExpr } from 'positron-data-explorer-duckdb';
 import {
+	DuckDBDataExplorerRpcHandler,
+	DuckDBRow,
+	DuckDBSchemaEntry,
+	DuckDBTableView,
+	duckdbDisplayType,
+	makeWhereExpr
+} from 'positron-data-explorer-duckdb';
+import {
+	BackendState,
 	ColumnDisplayType,
 	ColumnValue,
+	DataExplorerBackendRequest,
+	DataExplorerResponse,
+	DataExplorerRpc,
 	FilterComparisonOp,
 	FormatOptions,
 	RowFilter,
@@ -158,6 +169,63 @@ suite('DuckDB Data Explorer Tests', () => {
 				{ numColumns: state.table_shape.num_columns, columns: data.columns },
 				{ numColumns: 1, columns: [['1.50', '2.50']] }
 			);
+		});
+	});
+
+	suite('convert to code', () => {
+		const schema: DuckDBSchemaEntry[] = [
+			{ column_name: 'id', column_type: 'INTEGER', type_display: ColumnDisplayType.Integer },
+		];
+		// A view that never queries: the code-gen paths don't touch the client, and the row counts
+		// resolve lazily.
+		const idleClient = new FakeQueryClient(() => [{ n: 0 }]);
+
+		test('without a generator, advertises SQL and emits a SELECT over the table', async () => {
+			const view = new DuckDBTableView(idleClient, '"main"."people"', 'people', 'table', schema);
+			const state = await view.getState();
+			assert.deepStrictEqual(state.supported_features.convert_to_code.code_syntaxes, [{ code_syntax_name: 'SQL' }]);
+			assert.deepStrictEqual(await view.suggestCodeSyntax(), { code_syntax_name: 'SQL' });
+			const code = await view.convertToCode({ column_filters: [], row_filters: [], sort_keys: [], code_syntax_name: { code_syntax_name: 'SQL' } });
+			assert.deepStrictEqual(code.converted_code, ['SELECT *', 'FROM "main"."people"']);
+		});
+
+		test('with a generator, advertises its syntaxes and delegates the emitted code', async () => {
+			const generator = {
+				syntaxNames: ['R', 'Python'],
+				defaultSyntaxName: 'R',
+				generate: (syntax: string) => [`# ${syntax} code`],
+			};
+			const view = new DuckDBTableView(idleClient, '"main"."people"', 'people', 'table', schema, generator);
+
+			const state = await view.getState();
+			assert.deepStrictEqual(state.supported_features.convert_to_code.code_syntaxes, [
+				{ code_syntax_name: 'R' }, { code_syntax_name: 'Python' },
+			]);
+			assert.deepStrictEqual(await view.suggestCodeSyntax(), { code_syntax_name: 'R' });
+			const code = await view.convertToCode({ column_filters: [], row_filters: [], sort_keys: [], code_syntax_name: { code_syntax_name: 'Python' } });
+			assert.deepStrictEqual(code.converted_code, ['# Python code']);
+		});
+	});
+
+	suite('openTableView display name', () => {
+		test('reports the given display name, not the physical table name, in the view state', async () => {
+			// buildDuckDBSchema queries information_schema; getState queries count(*).
+			const client = new FakeQueryClient(sql =>
+				sql.includes('information_schema')
+					? [{ column_name: 'id', data_type: 'INTEGER' }]
+					: [{ n: 0 }]);
+			const handler = new DuckDBDataExplorerRpcHandler('test-provider');
+			try {
+				// The physical table ('pin_g_cars_5', a synthetic name over a downloaded file) and the
+				// display name ('julia/cars', what the tab should show) deliberately differ.
+				await handler.openTableView('ds1', client, 'main', 'pin_g_cars_5', 'table', 'julia/cars');
+				const response = await handler.handleRequest({
+					method: DataExplorerBackendRequest.GetState, uri: 'ds1', params: {},
+				} as DataExplorerRpc) as DataExplorerResponse & { result: BackendState };
+				assert.strictEqual(response.result.display_name, 'julia/cars');
+			} finally {
+				handler.dispose();
+			}
 		});
 	});
 });

--- a/extensions/positron-data-driver-pins/esbuild.mts
+++ b/extensions/positron-data-driver-pins/esbuild.mts
@@ -12,10 +12,19 @@ run({
 	platform: 'node',
 	entryPoints: {
 		'extension': path.join(srcDir, 'extension.ts'),
+		// The DuckDB native instance that backs the Data Explorer preview runs in this child process
+		// (forked by the shared DuckDBWorkerClient) so a native abort cannot take down the extension
+		// host. It re-exports the worker from positron-data-explorer-duckdb; esbuild bundles it next
+		// to extension.js so the runtime __dirname lookup resolves.
+		'duckdbWorker': path.join(srcDir, 'duckdbWorker.ts'),
 	},
 	srcDir,
 	outdir: outDir,
 	additionalOptions: {
-		external: ['vscode', 'positron'],
+		// @duckdb/node-api loads a native N-API addon (@duckdb/node-bindings) plus a prebuilt
+		// libduckdb; externalize so it's loaded from node_modules at runtime (this extension is
+		// registered in extensionsWithNpmDeps so its dependencies are packaged). Only duckdbWorker.ts
+		// imports these; the extension host bundle never loads the native binding.
+		external: ['vscode', 'positron', '@duckdb/node-api', '@duckdb/node-bindings'],
 	},
 }, process.argv);

--- a/extensions/positron-data-driver-pins/package-lock.json
+++ b/extensions/positron-data-driver-pins/package-lock.json
@@ -8,6 +8,7 @@
       "name": "positron-data-driver-pins",
       "version": "0.0.1",
       "dependencies": {
+        "@duckdb/node-api": "^1.5.3-r.3",
         "js-yaml": "^4.1.0"
       },
       "devDependencies": {
@@ -20,11 +21,24 @@
         "@vscode/vsce": "^3.3.2",
         "eslint": "^8.9.0",
         "mocha": "^9.2.1",
+        "positron-data-explorer-duckdb": "file:../positron-data-explorer-duckdb",
         "ts-node": "^10.9.1",
         "typescript": "^4.5.5"
       },
       "engines": {
         "vscode": "^1.65.0"
+      }
+    },
+    "../positron-data-explorer-duckdb": {
+      "version": "0.0.1",
+      "dev": true,
+      "dependencies": {
+        "@duckdb/node-api": "^1.5.3-r.3"
+      },
+      "devDependencies": {
+        "@types/node": "14.x",
+        "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
+        "typescript": "^4.5.5"
       }
     },
     "node_modules/@azu/format-text": {
@@ -249,6 +263,150 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@duckdb/node-api": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-1.5.3-r.3.tgz",
+      "integrity": "sha512-FzuL6sevuFfEFwkgiUMRMUAj4TaVqV//L0oo2FVZ9s9oYpLpALF9qZyQv2ucclTNQZwDCkm8+e6yLMc6t8IjlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@duckdb/node-bindings": "1.5.3-r.3"
+      }
+    },
+    "node_modules/@duckdb/node-bindings": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings/-/node-bindings-1.5.3-r.3.tgz",
+      "integrity": "sha512-Dphw1a9kKXZnCiWX1YCEAJsQ7WJQO2Ikgxy7m8jy0QVXqAwB9esr5NGsuEL3vMKL7velZHeZCjGOMnHZEcIsdg==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.1.2"
+      },
+      "optionalDependencies": {
+        "@duckdb/node-bindings-darwin-arm64": "1.5.3-r.3",
+        "@duckdb/node-bindings-darwin-x64": "1.5.3-r.3",
+        "@duckdb/node-bindings-linux-arm64": "1.5.3-r.3",
+        "@duckdb/node-bindings-linux-arm64-musl": "1.5.3-r.3",
+        "@duckdb/node-bindings-linux-x64": "1.5.3-r.3",
+        "@duckdb/node-bindings-linux-x64-musl": "1.5.3-r.3",
+        "@duckdb/node-bindings-win32-arm64": "1.5.3-r.3",
+        "@duckdb/node-bindings-win32-x64": "1.5.3-r.3"
+      }
+    },
+    "node_modules/@duckdb/node-bindings-darwin-arm64": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.5.3-r.3.tgz",
+      "integrity": "sha512-ttD8QBesgzHu7Sc4qouuIGLM7PWedLW8GvFbnZEyMqk24mQz1HWFgaT0ivw6nDRaDPUQLB9QnAOq8MZUh1zWHQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-darwin-x64": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.5.3-r.3.tgz",
+      "integrity": "sha512-Vp9MYtoYf6zUWHdCmHXwUcJlHq3YaaIeULWeSiPUM1hsDflLiZKXtz5i250Ulz03VsfWBjpO4wdM99sjjrYKkg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-linux-arm64": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.5.3-r.3.tgz",
+      "integrity": "sha512-3HLcrzQE83947JS51UVR7C9qnXQMltCOk4Dnhiz1CD+9u32DGLMgPTIIxclk7O+Q7EwfqzD8JV86Ud+LT1crcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-linux-arm64-musl": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64-musl/-/node-bindings-linux-arm64-musl-1.5.3-r.3.tgz",
+      "integrity": "sha512-IadRyx+98FEynKLXAk2MzReinFgduiDXgNd5Z8c5VKch+8FgBfqkEUYGOnBMMUPT8kuheKdLj23vpWXaCzOgoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-linux-x64": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.5.3-r.3.tgz",
+      "integrity": "sha512-TXndAL0ZoETq17Df6wB+SUZjLGDmOsKuDSySxB+wy6sHfpRtbDgQibyXRlajVeUkRDwSzBFC5ymy16YG0Fl4iw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-linux-x64-musl": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64-musl/-/node-bindings-linux-x64-musl-1.5.3-r.3.tgz",
+      "integrity": "sha512-5bulS16YhftXcarki4tvCufVslntpQDLOEF6RZ+FSMOGiv5d7SDXqklmVRy4DKW3C5ekgN7S2oYzuGL/ss9BuA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-win32-arm64": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-arm64/-/node-bindings-win32-arm64-1.5.3-r.3.tgz",
+      "integrity": "sha512-55Vu13S0jUudiAGlNWJd7UvlW1iKjwWehD8s93jBCNm0AdE/EJN4nz5rQ0IuWzPWXpMjAYuKu00yE7NdtbTyug==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-win32-x64": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.5.3-r.3.tgz",
+      "integrity": "sha512-rlOc9ltWQNHuDq99Ah8XaD80nN1ucrSK5AcH/7ibSp9ogX/jswPYlRVE7ODFJAjnQNf8bVvs++Mp+wyGvuG7ag==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -2137,9 +2295,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -4814,6 +4970,10 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/positron-data-explorer-duckdb": {
+      "resolved": "../positron-data-explorer-duckdb",
+      "link": true
     },
     "node_modules/prebuild-install": {
       "version": "7.1.3",

--- a/extensions/positron-data-driver-pins/package.json
+++ b/extensions/positron-data-driver-pins/package.json
@@ -19,9 +19,11 @@
   },
   "contributes": {},
   "dependencies": {
+    "@duckdb/node-api": "^1.5.3-r.3",
     "js-yaml": "^4.1.0"
   },
   "devDependencies": {
+    "positron-data-explorer-duckdb": "file:../positron-data-explorer-duckdb",
     "@types/js-yaml": "^4.0.5",
     "@types/mocha": "^9.1.0",
     "@types/node": "22.x",

--- a/extensions/positron-data-driver-pins/src/connectClient.ts
+++ b/extensions/positron-data-driver-pins/src/connectClient.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { randomUUID } from 'crypto';
 import { createWriteStream } from 'fs';
 import { mkdir, rename, unlink } from 'fs/promises';
 import { dirname } from 'path';
@@ -230,9 +231,12 @@ export class ConnectClient {
 	/**
 	 * Downloads a single data file from a pin version to `destPath`, streamed to disk so a large pin
 	 * never materializes in memory. Served from the content's own URL (under `/content/`, matching
-	 * {@link getPinMeta}), which works with viewer access. The body is written to a temporary sibling
-	 * and renamed into place only on success, so a failed or interrupted download never leaves a
-	 * partial file that a later immutable-skip would mistake for a complete one.
+	 * {@link getPinMeta}), which works with viewer access. The body is written to a per-call unique
+	 * temporary sibling and atomically renamed into place only on success. The unique name means two
+	 * concurrent downloads of the same file (e.g. previewing a pin and its active version at once)
+	 * each write their own temp rather than corrupting a shared one, and the atomic rename means
+	 * `destPath` is only ever absent or a complete file, so a failed/interrupted download never leaves
+	 * a partial file that a later immutable-skip would mistake for a complete one.
 	 *
 	 * No request timeout is applied: a pin's data file can be large and take longer than the API
 	 * timeout to transfer, and the fixed abort would kill an otherwise-healthy download.
@@ -251,7 +255,9 @@ export class ConnectClient {
 			throw new Error(`The Connect server returned an empty response body for ${filename}.`);
 		}
 		await mkdir(dirname(destPath), { recursive: true });
-		const tempPath = `${destPath}.download`;
+		// A per-call unique temp (a sibling, so the rename stays on the same filesystem and is atomic)
+		// keeps concurrent downloads of the same file from clobbering each other's in-progress writes.
+		const tempPath = `${destPath}.${randomUUID()}.download`;
 		try {
 			await pipeline(Readable.fromWeb(response.body), createWriteStream(tempPath));
 			await rename(tempPath, destPath);

--- a/extensions/positron-data-driver-pins/src/connectClient.ts
+++ b/extensions/positron-data-driver-pins/src/connectClient.ts
@@ -3,6 +3,11 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { createWriteStream } from 'fs';
+import { mkdir, rename, unlink } from 'fs/promises';
+import { dirname } from 'path';
+import { Readable } from 'stream';
+import { pipeline } from 'stream/promises';
 import { Logger, NULL_LOGGER } from './logging.js';
 import { parsePinMeta, PinMeta } from './meta.js';
 
@@ -222,6 +227,41 @@ export class ConnectClient {
 		return parsePinMeta(text);
 	}
 
+	/**
+	 * Downloads a single data file from a pin version to `destPath`, streamed to disk so a large pin
+	 * never materializes in memory. Served from the content's own URL (under `/content/`, matching
+	 * {@link getPinMeta}), which works with viewer access. The body is written to a temporary sibling
+	 * and renamed into place only on success, so a failed or interrupted download never leaves a
+	 * partial file that a later immutable-skip would mistake for a complete one.
+	 *
+	 * No request timeout is applied: a pin's data file can be large and take longer than the API
+	 * timeout to transfer, and the fixed abort would kill an otherwise-healthy download.
+	 *
+	 * @param guid The pin's content GUID.
+	 * @param bundleId The bundle (version) id to read.
+	 * @param filename The data file name within the bundle (from the pin's `data.txt`).
+	 * @param destPath The absolute path to write the file to.
+	 */
+	async downloadPinFile(guid: string, bundleId: string, filename: string, destPath: string): Promise<void> {
+		const url = `${this._serverUrl}/content/${encodeURIComponent(guid)}/_rev${encodeURIComponent(bundleId)}/${encodeURIComponent(filename)}`;
+		this._logger.info(`Downloading ${filename} (${destPath}) for pin ${guid} version ${bundleId}`);
+		// GET with no abort timeout; the body may be large.
+		const response = await this._get(url, '*/*', 0);
+		if (!response.body) {
+			throw new Error(`The Connect server returned an empty response body for ${filename}.`);
+		}
+		await mkdir(dirname(destPath), { recursive: true });
+		const tempPath = `${destPath}.download`;
+		try {
+			await pipeline(Readable.fromWeb(response.body), createWriteStream(tempPath));
+			await rename(tempPath, destPath);
+		} catch (err) {
+			// Best-effort cleanup of the partial file; the original error is what matters.
+			await unlink(tempPath).catch(() => { });
+			throw err;
+		}
+	}
+
 	/** Builds a URL under the server's `/__api__/` prefix. */
 	private _apiUrl(path: string): string {
 		return `${this._serverUrl}/__api__/${path}`;
@@ -246,11 +286,14 @@ export class ConnectClient {
 	/**
 	 * Performs a GET request with the auth header and a timeout, returning the response only when it
 	 * is successful. Maps transport failures, timeouts, and non-2xx statuses to clear errors.
+	 *
+	 * @param timeoutMs The abort timeout in milliseconds; pass 0 to disable it (for large downloads
+	 * whose transfer can legitimately exceed the API timeout).
 	 */
-	private async _get(url: string, accept: string): Promise<Response> {
+	private async _get(url: string, accept: string, timeoutMs: number = DEFAULT_TIMEOUT_MS): Promise<Response> {
 		this._logger.trace(`GET ${url}`);
 		const controller = new AbortController();
-		const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+		const timeout = timeoutMs > 0 ? setTimeout(() => controller.abort(), timeoutMs) : undefined;
 		let response: Response;
 		try {
 			response = await this._fetch(url, {

--- a/extensions/positron-data-driver-pins/src/duckdbWorker.ts
+++ b/extensions/positron-data-driver-pins/src/duckdbWorker.ts
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Entry point for the forked DuckDB child process that backs the Data Explorer preview. The actual
+// worker lives in the shared positron-data-explorer-duckdb package; this thin re-export is the
+// esbuild entry point so the worker is bundled into this extension's own dist/ (next to
+// extension.js) and located at runtime via __dirname by the shared DuckDBWorkerClient. Importing
+// the module runs it (it reads its config from process.argv and installs the IPC message handler).
+import 'positron-data-explorer-duckdb/worker';

--- a/extensions/positron-data-driver-pins/src/extension.ts
+++ b/extensions/positron-data-driver-pins/src/extension.ts
@@ -5,8 +5,11 @@
 
 import * as positron from 'positron';
 import * as vscode from 'vscode';
+import { DuckDBDataExplorerRpcHandler } from 'positron-data-explorer-duckdb';
 import { Logger } from './logging.js';
+import { PinsCache } from './pinsCache.js';
 import { createPinsDriver } from './pinsDriver.js';
+import { PINS_DATA_EXPLORER_PROVIDER_ID } from './pinsConnection.js';
 
 /**
  * Builds a {@link Logger} backed by an output channel that is created on first use. Deferring
@@ -46,7 +49,17 @@ export function activate(context: vscode.ExtensionContext) {
 	// its gear menu) to see individual requests.
 	const logger = createLazyChannelLogger('Data Connections: Posit Connect Pins', context);
 
-	const driver = createPinsDriver(context, logger);
+	// Services Data Explorer RPCs for tabular pins previewed from a connection. Uses the shared DuckDB
+	// backend under this extension's own provider id.
+	const dataExplorerHandler = new DuckDBDataExplorerRpcHandler(PINS_DATA_EXPLORER_PROVIDER_ID);
+	context.subscriptions.push(dataExplorerHandler);
+
+	// Downloaded pin data files are cached under the extension's global storage. Prune stale entries
+	// once per session (best-effort; never blocks activation).
+	const cache = new PinsCache(context.globalStorageUri.fsPath);
+	void cache.prune();
+
+	const driver = createPinsDriver(context, dataExplorerHandler, cache, logger);
 	context.subscriptions.push(positron.dataConnections.registerDriver(driver));
 }
 

--- a/extensions/positron-data-driver-pins/src/pinTypes.ts
+++ b/extensions/positron-data-driver-pins/src/pinTypes.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * The pin storage types that can be previewed in the Data Explorer, mapped to the DuckDB table
+ * function that reads them. The Data Explorer preview downloads the pin's data file and queries it
+ * with DuckDB, so only formats DuckDB reads natively are previewable. Arrow is intentionally absent:
+ * the bundled DuckDB has no `read_arrow`. Other pin types (rds, qs2, joblib, json, file) are not
+ * tabular files DuckDB can scan, so they stay non-previewable and are reached via generated code.
+ */
+const DUCKDB_READERS: Readonly<Record<string, string>> = {
+	parquet: 'read_parquet',
+	csv: 'read_csv_auto',
+};
+
+/**
+ * Returns the DuckDB table function that reads a pin of the given storage type, or undefined when
+ * the type is not previewable.
+ */
+export function duckdbReaderForPinType(type: string | undefined): string | undefined {
+	return type === undefined ? undefined : DUCKDB_READERS[type];
+}
+
+/** Whether a pin of the given storage type can be previewed in the Data Explorer. */
+export function isPreviewablePinType(type: string | undefined): boolean {
+	return duckdbReaderForPinType(type) !== undefined;
+}

--- a/extensions/positron-data-driver-pins/src/pinsCache.ts
+++ b/extensions/positron-data-driver-pins/src/pinsCache.ts
@@ -1,0 +1,92 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createHash } from 'crypto';
+import { existsSync } from 'fs';
+import { readdir, rmdir, stat, unlink } from 'fs/promises';
+import { basename, join } from 'path';
+
+/** The subdirectory of the extension's global storage that holds downloaded pin data files. */
+const CACHE_DIR_NAME = 'pins-cache';
+
+/** Pin data files not touched in this many days are removed by {@link PinsCache.prune}. */
+const CACHE_MAX_AGE_DAYS = 30;
+
+/**
+ * An extension-local cache of downloaded pin data files, laid out under the extension's global
+ * storage directory as `<globalStorage>/pins-cache/<serverHash>/<guid>/<bundleId>/<file>`.
+ *
+ * This is deliberately the driver's own cache, not a shared cache with the pins R or Python
+ * packages: those two do not share a cache with each other (different root directories, board-dir
+ * hashes, and internal layouts), so no single directory could serve both, and reimplementing either
+ * package's exact scheme in TypeScript would be fragile across pins releases. The pins hygiene rules
+ * that are useful regardless of location are kept: an immutable-skip on download (a bundle is
+ * content-addressed by its version, so a present file is never re-fetched) and a prune of files
+ * unused for ~30 days.
+ */
+export class PinsCache {
+	/**
+	 * @param _baseDir The extension's global storage path (the fsPath of `globalStorageUri`).
+	 */
+	constructor(private readonly _baseDir: string) { }
+
+	/**
+	 * Returns the absolute path a pin version's data file is (or would be) cached at. The server URL
+	 * is hashed to keep the path short and to separate servers; the file name is reduced to its base
+	 * name so a server-supplied name with path separators cannot escape the cache directory.
+	 *
+	 * @param serverUrl The normalized Connect server URL.
+	 * @param guid The pin's content GUID.
+	 * @param bundleId The bundle (version) id.
+	 * @param filename The data file name within the bundle.
+	 */
+	filePath(serverUrl: string, guid: string, bundleId: string, filename: string): string {
+		const serverHash = createHash('sha256').update(serverUrl).digest('hex').slice(0, 16);
+		return join(this._baseDir, CACHE_DIR_NAME, serverHash, guid, bundleId, basename(filename));
+	}
+
+	/** Whether a file is already present at `path` (the immutable-skip check). */
+	has(path: string): boolean {
+		return existsSync(path);
+	}
+
+	/**
+	 * Best-effort removal of cached files not modified in the last {@link CACHE_MAX_AGE_DAYS} days,
+	 * plus any directories left empty by the removals. Errors are swallowed: cache hygiene must never
+	 * fail a connection. Intended to run once when a connection opens, so it never removes a file
+	 * downloaded during the current session.
+	 */
+	async prune(): Promise<void> {
+		const cutoff = Date.now() - CACHE_MAX_AGE_DAYS * 24 * 60 * 60 * 1000;
+		await this._pruneDir(join(this._baseDir, CACHE_DIR_NAME), cutoff);
+	}
+
+	// Recursively removes stale files under `dir`, then removes `dir`'s now-empty subdirectories.
+	private async _pruneDir(dir: string, cutoff: number): Promise<void> {
+		let entries;
+		try {
+			entries = await readdir(dir, { withFileTypes: true });
+		} catch {
+			// The directory doesn't exist yet (nothing cached) or is unreadable: nothing to prune.
+			return;
+		}
+		for (const entry of entries) {
+			const full = join(dir, entry.name);
+			try {
+				if (entry.isDirectory()) {
+					await this._pruneDir(full, cutoff);
+					// Remove the directory if pruning emptied it.
+					if ((await readdir(full)).length === 0) {
+						await rmdir(full);
+					}
+				} else if ((await stat(full)).mtimeMs < cutoff) {
+					await unlink(full);
+				}
+			} catch {
+				// Skip anything we can't stat or remove.
+			}
+		}
+	}
+}

--- a/extensions/positron-data-driver-pins/src/pinsCache.ts
+++ b/extensions/positron-data-driver-pins/src/pinsCache.ts
@@ -15,6 +15,28 @@ const CACHE_DIR_NAME = 'pins-cache';
 const CACHE_MAX_AGE_DAYS = 30;
 
 /**
+ * Reduces a server-supplied id (guid, bundle id) to a single safe path segment. Everything outside a
+ * conservative charset -- including `/`, `\`, and `.` -- is replaced, so a crafted value from a
+ * malicious or compromised server (e.g. `../../etc`) cannot act as a path separator or dot-segment
+ * and escape the cache directory. Real ids (UUIDs, integers) pass through unchanged. An all-stripped
+ * value falls back to a placeholder so the segment is never empty.
+ */
+function safeSegment(value: string): string {
+	return value.replace(/[^A-Za-z0-9_-]/g, '_') || '_';
+}
+
+/**
+ * Reduces a server-supplied file name to a safe leaf. `basename` strips any directory components, and
+ * the dot-segment / empty cases (which `basename` leaves as `.`/`..`/`''`, all traversal risks) fall
+ * back to a fixed name. The real extension is preserved, so legitimate names like `data.parquet` are
+ * kept intact.
+ */
+function safeFileName(filename: string): string {
+	const name = basename(filename);
+	return name === '' || name === '.' || name === '..' ? 'data' : name;
+}
+
+/**
  * An extension-local cache of downloaded pin data files, laid out under the extension's global
  * storage directory as `<globalStorage>/pins-cache/<serverHash>/<guid>/<bundleId>/<file>`.
  *
@@ -33,9 +55,10 @@ export class PinsCache {
 	constructor(private readonly _baseDir: string) { }
 
 	/**
-	 * Returns the absolute path a pin version's data file is (or would be) cached at. The server URL
-	 * is hashed to keep the path short and to separate servers; the file name is reduced to its base
-	 * name so a server-supplied name with path separators cannot escape the cache directory.
+	 * Returns the absolute path a pin version's data file is (or would be) cached at. The server URL is
+	 * hashed to keep the path short and to separate servers. Every server-supplied segment (guid,
+	 * bundle id, file name) is sanitized so none can act as a path separator or dot-segment and escape
+	 * the cache directory, even if the server is malicious or compromised.
 	 *
 	 * @param serverUrl The normalized Connect server URL.
 	 * @param guid The pin's content GUID.
@@ -44,7 +67,7 @@ export class PinsCache {
 	 */
 	filePath(serverUrl: string, guid: string, bundleId: string, filename: string): string {
 		const serverHash = createHash('sha256').update(serverUrl).digest('hex').slice(0, 16);
-		return join(this._baseDir, CACHE_DIR_NAME, serverHash, guid, bundleId, basename(filename));
+		return join(this._baseDir, CACHE_DIR_NAME, serverHash, safeSegment(guid), safeSegment(bundleId), safeFileName(filename));
 	}
 
 	/** Whether a file is already present at `path` (the immutable-skip check). */

--- a/extensions/positron-data-driver-pins/src/pinsCode.ts
+++ b/extensions/positron-data-driver-pins/src/pinsCode.ts
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IDuckDBTableCodeGenerator } from 'positron-data-explorer-duckdb';
+
+/** The Convert-to-Code syntax names offered for a previewed pin. */
+const R_SYNTAX = 'R';
+const PYTHON_SYNTAX = 'Python';
+
+/**
+ * Escapes a value for embedding in a double-quoted Python or R string literal. Both languages treat
+ * backslash as an escape character in double-quoted strings, so values containing backslashes or
+ * quotes must be escaped.
+ */
+export function escapeDoubleQuoted(value: string): string {
+	return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+/** Identifies a pin version for `pin_read` code generation. */
+export interface PinReadTarget {
+	/** The normalized Connect server URL. */
+	serverUrl: string;
+	/** The full pin name, `owner/name`. */
+	fullName: string;
+	/** The bundle id to read as an explicit version; omitted to read the latest (active) version. */
+	version?: string;
+}
+
+/**
+ * Builds a Data Explorer Convert-to-Code generator that emits `pins` code reading the previewed pin.
+ * Both R and Python are offered (the user picks in the Convert-to-Code dialog), matching the
+ * driver's connection-level code generation; R is the default. This replaces the DuckDB backend's
+ * default SQL output, which would otherwise reference the throwaway in-memory table the preview
+ * loads the downloaded file into, code the user could not run.
+ */
+export function createPinReadCodeGenerator(target: PinReadTarget): IDuckDBTableCodeGenerator {
+	return {
+		syntaxNames: [R_SYNTAX, PYTHON_SYNTAX],
+		defaultSyntaxName: R_SYNTAX,
+		generate(syntaxName: string): string[] {
+			return syntaxName === PYTHON_SYNTAX ? generatePython(target) : generateR(target);
+		},
+	};
+}
+
+/** Generates the R `pin_read` snippet: connect to the board, then read the pin (by version if given). */
+function generateR(target: PinReadTarget): string[] {
+	const args = ['board', `"${escapeDoubleQuoted(target.fullName)}"`];
+	if (target.version) {
+		args.push(`version = "${escapeDoubleQuoted(target.version)}"`);
+	}
+	return [
+		'library(pins)',
+		`board <- board_connect(server = "${escapeDoubleQuoted(target.serverUrl)}")`,
+		`pin_read(${args.join(', ')})`,
+	];
+}
+
+/** Generates the Python `pin_read` snippet, mirroring {@link generateR}. */
+function generatePython(target: PinReadTarget): string[] {
+	const args = [`"${escapeDoubleQuoted(target.fullName)}"`];
+	if (target.version) {
+		args.push(`version="${escapeDoubleQuoted(target.version)}"`);
+	}
+	return [
+		'import pins',
+		`board = pins.board_connect(server_url="${escapeDoubleQuoted(target.serverUrl)}")`,
+		`board.pin_read(${args.join(', ')})`,
+	];
+}

--- a/extensions/positron-data-driver-pins/src/pinsConnection.ts
+++ b/extensions/positron-data-driver-pins/src/pinsConnection.ts
@@ -206,7 +206,13 @@ export class PinsConnection implements positron.DataConnection, IPinsBrowseHost 
 			// The active version reads as the latest; only pin an explicit version for the others.
 			version: isActiveVersion ? undefined : bundleId,
 		});
-		await this._dataExplorerHandler.openTableView(datasetId, worker, 'main', tableName, 'table', displayName, codeGenerator);
+		await this._dataExplorerHandler.openTableView(datasetId, worker, 'main', tableName, 'table', {
+			displayName,
+			codeGenerator,
+			// When the user closes this preview's tab, reclaim its memory instead of waiting for the
+			// whole connection to disconnect.
+			onClose: () => this._releasePreview(datasetId, tableName),
+		});
 		this._openedDatasets.add(datasetId);
 
 		// Re-check after the async view build: a disconnect in that window already tore down the worker
@@ -247,6 +253,24 @@ export class PinsConnection implements positron.DataConnection, IPinsBrowseHost 
 			{ location: vscode.ProgressLocation.Notification, title: vscode.l10n.t('Downloading {0}...', displayName) },
 			() => download()
 		);
+	}
+
+	// Releases a previewed dataset when its Data Explorer tab is closed: drops the materialized table
+	// to reclaim its memory, and disposes the worker once no previews remain (it respawns lazily on the
+	// next preview). A no-op if the dataset was already released (e.g. the connection disconnected
+	// first), so a late tab-close after disconnect can't touch a torn-down worker.
+	private _releasePreview(datasetId: string, tableName: string): void {
+		if (!this._openedDatasets.delete(datasetId)) {
+			return;
+		}
+		if (this._openedDatasets.size === 0) {
+			// Last preview closed: drop the whole in-memory database by disposing the worker.
+			this._worker?.dispose();
+			this._worker = undefined;
+		} else {
+			// Other previews still share the worker; drop just this table.
+			void this._worker?.runQuery(`DROP TABLE IF EXISTS "${tableName}"`).catch(() => { });
+		}
 	}
 
 	// Lazily creates the in-memory DuckDB worker that backs this connection's previews. The worker

--- a/extensions/positron-data-driver-pins/src/pinsConnection.ts
+++ b/extensions/positron-data-driver-pins/src/pinsConnection.ts
@@ -55,7 +55,11 @@ export class PinsConnection implements positron.DataConnection, IPinsBrowseHost 
 	/** Set once disconnected, so browsing after disconnect fails cleanly. */
 	private _disconnected = false;
 
-	/** Per-pin type lookups, keyed by GUID, so a pin's `data.txt` is fetched at most once on success. */
+	/**
+	 * Per-version type lookups, keyed by `guid:bundleId`, so a version's `data.txt` is fetched at most
+	 * once on success. Keyed per version (not per pin) because a pin's storage type can differ across
+	 * versions, which determines each version's preview availability.
+	 */
 	private readonly _typeCache = new Map<string, Promise<string | undefined>>();
 
 	/** The in-memory DuckDB worker backing previews, created lazily on the first preview. */
@@ -116,17 +120,28 @@ export class PinsConnection implements positron.DataConnection, IPinsBrowseHost 
 	 * whole owner expansion.
 	 */
 	async getPinType(pin: PinInfo): Promise<string | undefined> {
-		let typePromise = this._typeCache.get(pin.guid);
+		// The badge reflects the active (currently served) version's type.
+		return this.getVersionType(pin, pin.activeBundleId);
+	}
+
+	/**
+	 * Resolves a specific version's storage type, used to gate that version's preview (and, for the
+	 * active version, the pin's type badge). A successful lookup is memoized per (guid, bundle); a
+	 * failed one is dropped so a later re-expand retries, offering no preview in the meantime rather
+	 * than failing the whole expansion.
+	 */
+	async getVersionType(pin: PinInfo, bundleId: string): Promise<string | undefined> {
+		const key = `${pin.guid}:${bundleId}`;
+		let typePromise = this._typeCache.get(key);
 		if (!typePromise) {
-			typePromise = this._client.getPinMeta(pin.guid, pin.activeBundleId)
-				.then(meta => meta.type || undefined);
-			this._typeCache.set(pin.guid, typePromise);
+			typePromise = this._client.getPinMeta(pin.guid, bundleId).then(meta => meta.type || undefined);
+			this._typeCache.set(key, typePromise);
 		}
 		try {
 			return await typePromise;
 		} catch {
-			// The lookup failed: drop it so a later re-expand retries, and show no badge this time.
-			this._typeCache.delete(pin.guid);
+			// The lookup failed: drop it so a later re-expand retries, and show no badge/preview this time.
+			this._typeCache.delete(key);
 			return undefined;
 		}
 	}
@@ -170,6 +185,14 @@ export class PinsConnection implements positron.DataConnection, IPinsBrowseHost 
 			await this._downloadToCache(pin.guid, bundleId, meta.file, meta.fileSize, destPath, displayName);
 		}
 
+		// The metadata and download above are awaited, so a disconnect may have completed in the
+		// meantime. Bail before spinning up a worker or opening an explorer: disconnect's cleanup has
+		// already run and will not run again, so anything created past this point would leak. The
+		// download stays cached (harmless). Aborting quietly, since the user chose to disconnect.
+		if (this._disconnected) {
+			return;
+		}
+
 		// Load the file into the in-memory database as a table (materialized for fast repeated
 		// queries and a stable row order), then register and open the Data Explorer view.
 		const worker = this._ensureWorker();
@@ -185,6 +208,15 @@ export class PinsConnection implements positron.DataConnection, IPinsBrowseHost 
 		});
 		await this._dataExplorerHandler.openTableView(datasetId, worker, 'main', tableName, 'table', displayName, codeGenerator);
 		this._openedDatasets.add(datasetId);
+
+		// Re-check after the async view build: a disconnect in that window already tore down the worker
+		// and any views it knew about, but not this dataset (registered just above). Undo the
+		// registration and bail rather than opening an explorer backed by a disposed worker.
+		if (this._disconnected) {
+			this._dataExplorerHandler.closeTableView(datasetId);
+			this._openedDatasets.delete(datasetId);
+			return;
+		}
 
 		this._logger.info(`Opening ${displayName} in the Data Explorer`);
 		await positron.dataExplorer.open({ providerId: PINS_DATA_EXPLORER_PROVIDER_ID, datasetId, displayName });

--- a/extensions/positron-data-driver-pins/src/pinsConnection.ts
+++ b/extensions/positron-data-driver-pins/src/pinsConnection.ts
@@ -4,9 +4,38 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as positron from 'positron';
+import * as vscode from 'vscode';
+import { DuckDBWorkerClient, IDuckDBDataExplorerHost } from 'positron-data-explorer-duckdb';
 import { BundleInfo, ConnectClient, PinInfo } from './connectClient.js';
 import { Logger, NULL_LOGGER } from './logging.js';
+import { PinsCache } from './pinsCache.js';
+import { createPinReadCodeGenerator } from './pinsCode.js';
+import { duckdbReaderForPinType } from './pinTypes.js';
 import { createOwnerNode, IPinsBrowseHost } from './pinsNodes.js';
+
+/** The Data Explorer provider id this connection opens previewed pins under. */
+export const PINS_DATA_EXPLORER_PROVIDER_ID = 'positron-data-driver-pins';
+
+/**
+ * Data files at or above this size get a progress notification while downloading; smaller ones rely
+ * on the tree row's spinner alone, to avoid a toast for downloads that finish in a moment. A
+ * heuristic, not a hard rule: the pin's recorded `file_size` drives the choice, and an unrecorded
+ * size falls through to the quiet path.
+ */
+const DOWNLOAD_PROGRESS_MIN_BYTES = 10 * 1024 * 1024;
+
+/** Monotonically increasing id so each connection's previewed datasets get a unique key. */
+let nextConnectionId = 1;
+
+/** Escapes a value for a single-quoted SQL string literal (DuckDB doubles the quote to escape it). */
+function quoteSqlLiteral(value: string): string {
+	return value.replace(/'/g, '\'\'');
+}
+
+/** A DuckDB-safe, deterministic table name for a previewed pin version (so re-previews reuse it). */
+function previewTableName(guid: string, bundleId: string): string {
+	return `pin_${guid}_${bundleId}`.replace(/[^a-zA-Z0-9_]/g, '_');
+}
 
 /**
  * A live connection to a Posit Connect server's pins, implementing the DataConnection interface.
@@ -16,6 +45,11 @@ import { createOwnerNode, IPinsBrowseHost } from './pinsNodes.js';
  * its tree entry is collapsed and re-expanded, so there is nothing to cache across); a successful
  * per-pin type lookup is memoized because an owner node can be collapsed and re-expanded without
  * disconnecting, while a failed one is retried on the next re-expand.
+ *
+ * Previewing a tabular pin downloads its data file (cached on disk) and queries it with a DuckDB
+ * instance that runs in a child process (via DuckDBWorkerClient) so a native failure takes down only
+ * that child, not the extension host. The database is in-memory: each previewed version becomes a
+ * table in it, so no worker pool is needed (there is no database file to lock).
  */
 export class PinsConnection implements positron.DataConnection, IPinsBrowseHost {
 	/** Set once disconnected, so browsing after disconnect fails cleanly. */
@@ -24,12 +58,25 @@ export class PinsConnection implements positron.DataConnection, IPinsBrowseHost 
 	/** Per-pin type lookups, keyed by GUID, so a pin's `data.txt` is fetched at most once on success. */
 	private readonly _typeCache = new Map<string, Promise<string | undefined>>();
 
+	/** The in-memory DuckDB worker backing previews, created lazily on the first preview. */
+	private _worker: DuckDBWorkerClient | undefined;
+
+	/** Unique id for this connection, used to key its previewed datasets. */
+	private readonly _connectionId = `pins-${nextConnectionId++}`;
+
+	/** Dataset ids opened via preview, so their table views can be released on disconnect. */
+	private readonly _openedDatasets = new Set<string>();
+
 	/**
 	 * @param _client The Connect client, already validated by the driver's connect().
+	 * @param _dataExplorerHandler Hosts the table views previewed pins are shown in.
+	 * @param _cache The on-disk cache downloaded pin data files are stored in.
 	 * @param _logger Logs browse activity; defaults to a no-op logger.
 	 */
 	constructor(
 		private readonly _client: ConnectClient,
+		private readonly _dataExplorerHandler: IDuckDBDataExplorerHost,
+		private readonly _cache: PinsCache,
 		private readonly _logger: Logger = NULL_LOGGER
 	) { }
 
@@ -93,10 +140,104 @@ export class PinsConnection implements positron.DataConnection, IPinsBrowseHost 
 		return this._client.listBundles(pin.guid);
 	}
 
-	/** Marks the connection disconnected and drops cached state. No socket to close. */
+	/**
+	 * Opens a pin version's tabular data in the Data Explorer. Reads the version's metadata to find
+	 * its data file, downloads that file (reusing the cached copy when present), loads it into the
+	 * DuckDB worker as a table, and opens the explorer over it. Convert-to-Code in the resulting
+	 * explorer emits `pin_read` code rather than SQL against the throwaway table.
+	 */
+	async previewPin(pin: PinInfo, bundleId: string, isActiveVersion: boolean): Promise<void> {
+		this._ensureConnected();
+
+		// Resolve the version's data file and confirm it is a previewable, single-file tabular type.
+		const meta = await this._client.getPinMeta(pin.guid, bundleId);
+		const reader = duckdbReaderForPinType(meta.type);
+		if (!reader) {
+			throw new Error(`Pins of type '${meta.type}' cannot be previewed in the Data Explorer.`);
+		}
+		if (Array.isArray(meta.file)) {
+			throw new Error('Previewing pins that store multiple files is not supported.');
+		}
+
+		const fullName = `${pin.ownerUsername}/${pin.name}`;
+		// The Data Explorer tab shows the backend's display_name, so it must be the human-readable pin
+		// name, not the synthetic DuckDB table name. Distinguish a specific version from the latest.
+		const displayName = isActiveVersion ? fullName : `${fullName} (#${bundleId})`;
+
+		// Download the data file into the cache (immutable-skip if already present).
+		const destPath = this._cache.filePath(this._client.serverUrl, pin.guid, bundleId, meta.file);
+		if (!this._cache.has(destPath)) {
+			await this._downloadToCache(pin.guid, bundleId, meta.file, meta.fileSize, destPath, displayName);
+		}
+
+		// Load the file into the in-memory database as a table (materialized for fast repeated
+		// queries and a stable row order), then register and open the Data Explorer view.
+		const worker = this._ensureWorker();
+		const tableName = previewTableName(pin.guid, bundleId);
+		await worker.runQuery(`CREATE OR REPLACE TABLE "${tableName}" AS SELECT * FROM ${reader}('${quoteSqlLiteral(destPath)}')`);
+
+		const datasetId = `pinsconn:${this._connectionId}:${pin.guid}:${bundleId}`;
+		const codeGenerator = createPinReadCodeGenerator({
+			serverUrl: this._client.serverUrl,
+			fullName,
+			// The active version reads as the latest; only pin an explicit version for the others.
+			version: isActiveVersion ? undefined : bundleId,
+		});
+		await this._dataExplorerHandler.openTableView(datasetId, worker, 'main', tableName, 'table', displayName, codeGenerator);
+		this._openedDatasets.add(datasetId);
+
+		this._logger.info(`Opening ${displayName} in the Data Explorer`);
+		await positron.dataExplorer.open({ providerId: PINS_DATA_EXPLORER_PROVIDER_ID, datasetId, displayName });
+	}
+
+	/** Marks the connection disconnected, releases previewed views, and closes the DuckDB worker. */
 	async disconnect(): Promise<void> {
 		this._disconnected = true;
 		this._typeCache.clear();
+		for (const datasetId of this._openedDatasets) {
+			this._dataExplorerHandler.closeTableView(datasetId);
+		}
+		this._openedDatasets.clear();
+		this._worker?.dispose();
+		this._worker = undefined;
+	}
+
+	// Downloads a pin's data file into the cache, showing a progress notification only when the file
+	// is large enough that the download is likely to take a noticeable moment. Smaller downloads stay
+	// quiet and rely on the tree row's spinner.
+	private async _downloadToCache(guid: string, bundleId: string, filename: string, fileSize: number | undefined, destPath: string, displayName: string): Promise<void> {
+		const download = () => this._client.downloadPinFile(guid, bundleId, filename, destPath);
+		if (fileSize === undefined || fileSize < DOWNLOAD_PROGRESS_MIN_BYTES) {
+			await download();
+			return;
+		}
+		await vscode.window.withProgress(
+			{ location: vscode.ProgressLocation.Notification, title: vscode.l10n.t('Downloading {0}...', displayName) },
+			() => download()
+		);
+	}
+
+	// Lazily creates the in-memory DuckDB worker that backs this connection's previews. The worker
+	// process is spawned by the client on its first query, so nothing is forked until a pin is
+	// actually previewed.
+	private _ensureWorker(): DuckDBWorkerClient {
+		if (!this._worker) {
+			// Each connection gets its OWN worker, deliberately NOT the shared duckDBWorkerPool. The
+			// pool keys workers by database path to share one worker per file (DuckDB's exclusive file
+			// lock); every connection here opens ':memory:', so pooling would key them all to the same
+			// entry and pile every connection's previewed tables into one shared in-memory database.
+			// A private worker per connection keeps each connection's tables isolated.
+			//
+			// Tradeoff of an in-memory database: if the worker crashes (e.g. a query exhausts memory),
+			// the client respawns it on the next query but the respawn is empty, so tables loaded before
+			// the crash are gone and any open previews for this connection error until re-opened. This is
+			// accepted for a preview feature: unlike the file-backed DuckDB driver (which reopens its
+			// file on respawn), a pin preview has no durable database to reopen, and the crash trigger --
+			// a pin too large to fit in memory -- could not have been previewed anyway. Re-preview
+			// reloads the data.
+			this._worker = new DuckDBWorkerClient({ databasePath: ':memory:', readOnly: false });
+		}
+		return this._worker;
 	}
 
 	/** Whether the connection is still usable. */

--- a/extensions/positron-data-driver-pins/src/pinsDriver.ts
+++ b/extensions/positron-data-driver-pins/src/pinsDriver.ts
@@ -7,8 +7,11 @@ import { readFileSync } from 'fs';
 import * as path from 'path';
 import * as positron from 'positron';
 import * as vscode from 'vscode';
+import { IDuckDBDataExplorerHost } from 'positron-data-explorer-duckdb';
 import { ConnectClient } from './connectClient.js';
+import { escapeDoubleQuoted } from './pinsCode.js';
 import { Logger, NULL_LOGGER } from './logging.js';
+import { PinsCache } from './pinsCache.js';
 import { PinsConnection } from './pinsConnection.js';
 
 /**
@@ -21,15 +24,6 @@ const API_KEY_MECHANISM_ID = 'apiKey';
 /** Type guard for a non-empty string. */
 function isNonEmptyString(value: unknown): value is string {
 	return typeof value === 'string' && value.length > 0;
-}
-
-/**
- * Escapes a value for embedding in a double-quoted Python or R string literal. Both languages treat
- * backslash as an escape character in double-quoted strings, so values containing backslashes or
- * quotes must be escaped.
- */
-function escapeDoubleQuoted(value: string): string {
-	return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
 
 /**
@@ -92,9 +86,16 @@ function generatePythonCode(serverUrl: string | undefined, apiKey: string | unde
 /**
  * Creates the Posit Connect pins DataConnectionDriver.
  * @param context The extension context, used to locate the icon asset.
+ * @param dataExplorerHandler Hosts the table views previewed pins are shown in.
+ * @param cache The on-disk cache downloaded pin data files are stored in.
  * @param logger Logs connect and browse activity; defaults to a no-op logger.
  */
-export function createPinsDriver(context: vscode.ExtensionContext, logger: Logger = NULL_LOGGER): positron.DataConnectionDriver {
+export function createPinsDriver(
+	context: vscode.ExtensionContext,
+	dataExplorerHandler: IDuckDBDataExplorerHost,
+	cache: PinsCache,
+	logger: Logger = NULL_LOGGER
+): positron.DataConnectionDriver {
 	// Load the SVG icon once at registration time.
 	const iconPath = path.join(context.extensionPath, 'media', 'logo', 'connect.svg');
 	const iconSvg = readFileSync(iconPath, 'utf-8');
@@ -148,7 +149,7 @@ export function createPinsDriver(context: vscode.ExtensionContext, logger: Logge
 			const settings = await client.getServerSettings();
 			const user = await client.getCurrentUser();
 			logger.info(`Connected as ${user.username || '(unknown user)'}${settings.version ? ` (Connect ${settings.version})` : ''}`);
-			return new PinsConnection(client, logger);
+			return new PinsConnection(client, dataExplorerHandler, cache, logger);
 		},
 		async generateConnectionCode(mechanismId: string, languageId: string, params: positron.DataConnectionParameterValues): Promise<positron.ConnectionCodeVariant[]> {
 			if (mechanismId !== API_KEY_MECHANISM_ID) {

--- a/extensions/positron-data-driver-pins/src/pinsNodes.ts
+++ b/extensions/positron-data-driver-pins/src/pinsNodes.ts
@@ -5,6 +5,7 @@
 
 import * as positron from 'positron';
 import { BundleInfo, PinInfo } from './connectClient.js';
+import { isPreviewablePinType } from './pinTypes.js';
 
 /**
  * The maximum number of `data.txt` requests made in parallel when resolving the type badges for an
@@ -27,6 +28,18 @@ export interface IPinsBrowseHost {
 
 	/** Lists a pin's versions (bundles), newest first, when the pin node is expanded. */
 	getBundles(pin: PinInfo): Promise<BundleInfo[]>;
+
+	/**
+	 * Opens a pin version's tabular data in the Data Explorer: downloads the version's data file
+	 * (cached), loads it into DuckDB, and opens the explorer over it. Only invoked for previewable pin
+	 * types (see {@link isPreviewablePinType}).
+	 *
+	 * @param pin The pin.
+	 * @param bundleId The bundle (version) id whose data to preview.
+	 * @param isActiveVersion Whether `bundleId` is the pin's active version; the active version reads
+	 * as the latest, so its generated code omits the explicit `version` argument.
+	 */
+	previewPin(pin: PinInfo, bundleId: string, isActiveVersion: boolean): Promise<void>;
 }
 
 /**
@@ -70,11 +83,11 @@ export function createOwnerNode(host: IPinsBrowseHost, ownerUsername: string, pi
 }
 
 /**
- * Creates a pin node. Expanding it lists the pin's versions (bundles), newest first; previewing a
- * version's data in the Data Explorer comes in a later PR. The type badge shows the pin's storage
- * format when known.
+ * Creates a pin node. Expanding it lists the pin's versions (bundles), newest first. A previewable
+ * pin (a tabular type; see {@link isPreviewablePinType}) can be opened in the Data Explorer, which
+ * previews its active version. The type badge shows the pin's storage format when known.
  *
- * @param host The browse host used to list the pin's versions on expansion.
+ * @param host The browse host used to list versions and open the preview.
  * @param pin The pin.
  * @param type The pin's storage type for the badge, or undefined when unknown.
  */
@@ -85,24 +98,35 @@ export function createPinNode(host: IPinsBrowseHost, pin: PinInfo, type: string 
 		dataType: type,
 		async getChildren() {
 			const bundles = await host.getBundles(pin);
-			return bundles.map(createVersionNode);
+			return bundles.map(bundle => createVersionNode(host, pin, type, bundle));
 		},
+		// A previewable pin opens its active version in the Data Explorer.
+		preview: isPreviewablePinType(type)
+			? () => host.previewPin(pin, pin.activeBundleId, true)
+			: undefined,
 	};
 }
 
 /**
- * Creates a version node: one bundle of a pin. Versions are leaves for now (previewing a version's
- * data comes in a later PR). The active (currently served) version is flagged with an "active"
- * badge; the name pairs the creation time with the bundle id, e.g. "2024-01-15 09:30 (#421)".
+ * Creates a version node: one bundle of a pin. A version of a previewable pin can be opened in the
+ * Data Explorer (that specific version's data); other versions are leaves. The active (currently
+ * served) version is flagged with an "active" badge; the name pairs the creation time with the
+ * bundle id, e.g. "2024-01-15 09:30 (#421)".
  *
+ * @param host The browse host used to open the preview.
+ * @param pin The pin this version belongs to.
+ * @param type The pin's storage type, used to decide whether the version is previewable.
  * @param bundle The bundle (version).
  */
-export function createVersionNode(bundle: BundleInfo): positron.DataConnectionNode {
+export function createVersionNode(host: IPinsBrowseHost, pin: PinInfo, type: string | undefined, bundle: BundleInfo): positron.DataConnectionNode {
 	const timestamp = formatBundleTimestamp(bundle.createdTime);
 	return {
 		name: timestamp ? `${timestamp} (#${bundle.id})` : `#${bundle.id}`,
 		kind: positron.DataConnectionNodeKind.Version,
 		dataType: bundle.active ? 'active' : undefined,
+		preview: isPreviewablePinType(type)
+			? () => host.previewPin(pin, bundle.id, bundle.active)
+			: undefined,
 	};
 }
 

--- a/extensions/positron-data-driver-pins/src/pinsNodes.ts
+++ b/extensions/positron-data-driver-pins/src/pinsNodes.ts
@@ -26,6 +26,12 @@ export interface IPinsBrowseHost {
 	 */
 	getPinType(pin: PinInfo): Promise<string | undefined>;
 
+	/**
+	 * Resolves a specific version's storage type, or undefined when it can't be determined. Used to
+	 * gate each version's preview on its own format, since a pin's type can differ across versions.
+	 */
+	getVersionType(pin: PinInfo, bundleId: string): Promise<string | undefined>;
+
 	/** Lists a pin's versions (bundles), newest first, when the pin node is expanded. */
 	getBundles(pin: PinInfo): Promise<BundleInfo[]>;
 
@@ -98,7 +104,10 @@ export function createPinNode(host: IPinsBrowseHost, pin: PinInfo, type: string 
 		dataType: type,
 		async getChildren() {
 			const bundles = await host.getBundles(pin);
-			return bundles.map(bundle => createVersionNode(host, pin, type, bundle));
+			// A pin's storage type can differ across versions, so resolve each version's own type
+			// (bounded concurrency, like the per-owner badge fetch) to gate its preview correctly.
+			const versionTypes = await mapWithConcurrency(bundles, MAX_METADATA_CONCURRENCY, bundle => host.getVersionType(pin, bundle.id));
+			return bundles.map((bundle, index) => createVersionNode(host, pin, versionTypes[index], bundle));
 		},
 		// A previewable pin opens its active version in the Data Explorer.
 		preview: isPreviewablePinType(type)
@@ -108,23 +117,24 @@ export function createPinNode(host: IPinsBrowseHost, pin: PinInfo, type: string 
 }
 
 /**
- * Creates a version node: one bundle of a pin. A version of a previewable pin can be opened in the
- * Data Explorer (that specific version's data); other versions are leaves. The active (currently
- * served) version is flagged with an "active" badge; the name pairs the creation time with the
- * bundle id, e.g. "2024-01-15 09:30 (#421)".
+ * Creates a version node: one bundle of a pin. A version stored in a previewable (tabular) format
+ * can be opened in the Data Explorer (that specific version's data); others are leaves. Preview is
+ * gated on this version's own storage type, since a pin's type can differ across versions. The
+ * active (currently served) version is flagged with an "active" badge; the name pairs the creation
+ * time with the bundle id, e.g. "2024-01-15 09:30 (#421)".
  *
  * @param host The browse host used to open the preview.
  * @param pin The pin this version belongs to.
- * @param type The pin's storage type, used to decide whether the version is previewable.
+ * @param versionType This version's own storage type, used to decide whether it is previewable.
  * @param bundle The bundle (version).
  */
-export function createVersionNode(host: IPinsBrowseHost, pin: PinInfo, type: string | undefined, bundle: BundleInfo): positron.DataConnectionNode {
+export function createVersionNode(host: IPinsBrowseHost, pin: PinInfo, versionType: string | undefined, bundle: BundleInfo): positron.DataConnectionNode {
 	const timestamp = formatBundleTimestamp(bundle.createdTime);
 	return {
 		name: timestamp ? `${timestamp} (#${bundle.id})` : `#${bundle.id}`,
 		kind: positron.DataConnectionNodeKind.Version,
 		dataType: bundle.active ? 'active' : undefined,
-		preview: isPreviewablePinType(type)
+		preview: isPreviewablePinType(versionType)
 			? () => host.previewPin(pin, bundle.id, bundle.active)
 			: undefined,
 	};

--- a/extensions/positron-data-driver-pins/src/test/connectClient.test.ts
+++ b/extensions/positron-data-driver-pins/src/test/connectClient.test.ts
@@ -4,6 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { ConnectClient, normalizeServerUrl } from '../connectClient.js';
 
 /** Records the requests made and returns responses from a route handler, standing in for fetch. */
@@ -127,5 +130,34 @@ suite('ConnectClient', () => {
 	test('maps other non-2xx to a failure with the body summary', async () => {
 		const { fetch } = recordingFetch(() => ({ status: 500, body: 'boom' }));
 		await assert.rejects(() => new ConnectClient(SERVER, KEY, fetch).getServerSettings(), /HTTP 500.*boom/);
+	});
+});
+
+suite('ConnectClient.downloadPinFile', () => {
+	const SERVER = 'https://connect.example.com';
+	const KEY = 'secret-key';
+	let dir: string;
+
+	setup(() => { dir = mkdtempSync(join(tmpdir(), 'pins-download-')); });
+	teardown(() => { rmSync(dir, { recursive: true, force: true }); });
+
+	test('streams the data file from the content _rev path to destPath', async () => {
+		const { fetch, calls } = recordingFetch(() => ({ body: 'PARQUET-BYTES' }));
+		const destPath = join(dir, 'nested', 'data.parquet');
+		await new ConnectClient(SERVER, KEY, fetch).downloadPinFile('g1', '42', 'data.parquet', destPath);
+
+		// Fetched from the content-served _rev path (not /__api__/), with the auth header, and written
+		// to destPath (parent directory created as needed).
+		assert.strictEqual(calls[0].url, `${SERVER}/content/g1/_rev42/data.parquet`);
+		assert.strictEqual(authHeaderOf(calls[0].init), `Key ${KEY}`);
+		assert.strictEqual(readFileSync(destPath, 'utf-8'), 'PARQUET-BYTES');
+	});
+
+	test('leaves no file behind when the request fails', async () => {
+		const { fetch } = recordingFetch(() => ({ status: 404, body: 'nope' }));
+		const destPath = join(dir, 'data.parquet');
+		await assert.rejects(() => new ConnectClient(SERVER, KEY, fetch).downloadPinFile('g1', '42', 'data.parquet', destPath), /Not Found/);
+		assert.strictEqual(existsSync(destPath), false);
+		assert.strictEqual(existsSync(`${destPath}.download`), false);
 	});
 });

--- a/extensions/positron-data-driver-pins/src/test/connectClient.test.ts
+++ b/extensions/positron-data-driver-pins/src/test/connectClient.test.ts
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { ConnectClient, normalizeServerUrl } from '../connectClient.js';
 
 /** Records the requests made and returns responses from a route handler, standing in for fetch. */
@@ -158,6 +158,25 @@ suite('ConnectClient.downloadPinFile', () => {
 		const destPath = join(dir, 'data.parquet');
 		await assert.rejects(() => new ConnectClient(SERVER, KEY, fetch).downloadPinFile('g1', '42', 'data.parquet', destPath), /Not Found/);
 		assert.strictEqual(existsSync(destPath), false);
-		assert.strictEqual(existsSync(`${destPath}.download`), false);
+		assert.strictEqual(readdirSync(dir).filter(f => f.includes('.download')).length, 0);
+	});
+
+	test('concurrent downloads of the same file populate the cache without corruption', async () => {
+		// A body large enough that two writes interleaved into one shared temp would not match it.
+		const body = 'X'.repeat(200_000);
+		const { fetch } = recordingFetch(() => ({ body }));
+		const client = new ConnectClient(SERVER, KEY, fetch);
+		const destPath = join(dir, 'nested', 'data.parquet');
+
+		// Two previews of the same uncached version race to download it (each writes its own unique
+		// temp and atomically publishes a complete file).
+		await Promise.all([
+			client.downloadPinFile('g1', '5', 'data.parquet', destPath),
+			client.downloadPinFile('g1', '5', 'data.parquet', destPath),
+		]);
+
+		assert.strictEqual(readFileSync(destPath, 'utf-8'), body);
+		// No temporary files are left behind by either download.
+		assert.strictEqual(readdirSync(dirname(destPath)).filter(f => f.includes('.download')).length, 0);
 	});
 });

--- a/extensions/positron-data-driver-pins/src/test/pinsCache.test.ts
+++ b/extensions/positron-data-driver-pins/src/test/pinsCache.test.ts
@@ -1,0 +1,59 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+import { PinsCache } from '../pinsCache.js';
+
+suite('PinsCache', () => {
+	let base: string;
+	setup(() => { base = mkdtempSync(join(tmpdir(), 'pins-cache-')); });
+	teardown(() => { rmSync(base, { recursive: true, force: true }); });
+
+	test('filePath is under pins-cache/<serverHash>/<guid>/<bundle>/<file> and separates servers', () => {
+		const cache = new PinsCache(base);
+		const a = cache.filePath('https://a.example.com', 'g1', '5', 'data.parquet');
+		const b = cache.filePath('https://b.example.com', 'g1', '5', 'data.parquet');
+
+		assert.ok(a.startsWith(join(base, 'pins-cache')), a);
+		assert.ok(a.endsWith(join('g1', '5', 'data.parquet')), a);
+		// Different servers hash to different directories.
+		assert.notStrictEqual(dirname(a), dirname(b));
+	});
+
+	test('filePath reduces the file name to its base name so it cannot escape the cache', () => {
+		const cache = new PinsCache(base);
+		const p = cache.filePath('https://a.example.com', 'g1', '5', '../../etc/passwd');
+		assert.ok(p.startsWith(join(base, 'pins-cache')), p);
+		assert.ok(p.endsWith('passwd'), p);
+		assert.ok(!p.includes('..'), p);
+	});
+
+	test('prune removes files older than 30 days and keeps recent ones', async () => {
+		const cache = new PinsCache(base);
+		const stale = cache.filePath('https://a.example.com', 'old', '1', 'data.parquet');
+		const fresh = cache.filePath('https://a.example.com', 'new', '1', 'data.parquet');
+		for (const p of [stale, fresh]) {
+			mkdirSync(dirname(p), { recursive: true });
+			writeFileSync(p, 'x');
+		}
+		// Backdate the stale file well past the 30-day cutoff.
+		const longAgo = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000);
+		utimesSync(stale, longAgo, longAgo);
+
+		await cache.prune();
+
+		assert.strictEqual(existsSync(stale), false, 'stale file should be pruned');
+		assert.strictEqual(existsSync(fresh), true, 'fresh file should be kept');
+		// The stale file's now-empty directories are cleaned up too.
+		assert.strictEqual(existsSync(dirname(stale)), false, 'empty directory should be removed');
+	});
+
+	test('prune is a no-op (does not throw) when nothing is cached', async () => {
+		await assert.doesNotReject(() => new PinsCache(base).prune());
+	});
+});

--- a/extensions/positron-data-driver-pins/src/test/pinsCache.test.ts
+++ b/extensions/positron-data-driver-pins/src/test/pinsCache.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import { existsSync, mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
-import { dirname, join } from 'path';
+import { dirname, join, sep } from 'path';
 import { PinsCache } from '../pinsCache.js';
 
 suite('PinsCache', () => {
@@ -25,12 +25,26 @@ suite('PinsCache', () => {
 		assert.notStrictEqual(dirname(a), dirname(b));
 	});
 
-	test('filePath reduces the file name to its base name so it cannot escape the cache', () => {
+	test('no server-supplied segment (guid, bundle, file) can escape the cache directory', () => {
 		const cache = new PinsCache(base);
-		const p = cache.filePath('https://a.example.com', 'g1', '5', '../../etc/passwd');
-		assert.ok(p.startsWith(join(base, 'pins-cache')), p);
-		assert.ok(p.endsWith('passwd'), p);
-		assert.ok(!p.includes('..'), p);
+		const root = join(base, 'pins-cache');
+		// A crafted guid, bundle id, or file name from a malicious server must not traverse out of the
+		// cache root. Each stays within root and leaves no `..` in the resolved path.
+		const crafted = [
+			cache.filePath('https://a.example.com', '../../../../etc', '5', 'data.parquet'),
+			cache.filePath('https://a.example.com', 'g1', '../../../../etc', 'data.parquet'),
+			cache.filePath('https://a.example.com', 'g1', '5', '../../etc/passwd'),
+			cache.filePath('https://a.example.com', 'g1', '5', '..'),
+		];
+		for (const p of crafted) {
+			assert.ok(p.startsWith(root + sep), p);
+			assert.ok(!p.includes('..'), p);
+		}
+	});
+
+	test('a legitimate file name keeps its extension', () => {
+		const cache = new PinsCache(base);
+		assert.ok(cache.filePath('https://a.example.com', 'g1', '5', 'data.parquet').endsWith('data.parquet'));
 	});
 
 	test('prune removes files older than 30 days and keeps recent ones', async () => {

--- a/extensions/positron-data-driver-pins/src/test/pinsCode.test.ts
+++ b/extensions/positron-data-driver-pins/src/test/pinsCode.test.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { createPinReadCodeGenerator } from '../pinsCode.js';
+
+suite('createPinReadCodeGenerator', () => {
+	const target = { serverUrl: 'https://connect.example.com', fullName: 'julia/cars' };
+
+	test('the default syntax is one of the offered syntaxes', () => {
+		// The Convert-to-Code dialog pre-selects defaultSyntaxName from the offered list; a default
+		// that isn't in the list would open the dialog on a selection the dropdown can't display.
+		const gen = createPinReadCodeGenerator(target);
+		assert.ok(gen.syntaxNames.includes(gen.defaultSyntaxName));
+	});
+
+	test('R reads the latest version when none is given', () => {
+		const gen = createPinReadCodeGenerator(target);
+		assert.deepStrictEqual(gen.generate('R'), [
+			'library(pins)',
+			'board <- board_connect(server = "https://connect.example.com")',
+			'pin_read(board, "julia/cars")',
+		]);
+	});
+
+	test('Python reads the latest version when none is given', () => {
+		const gen = createPinReadCodeGenerator(target);
+		assert.deepStrictEqual(gen.generate('Python'), [
+			'import pins',
+			'board = pins.board_connect(server_url="https://connect.example.com")',
+			'board.pin_read("julia/cars")',
+		]);
+	});
+
+	test('a specific version adds the version argument in each language', () => {
+		const gen = createPinReadCodeGenerator({ ...target, version: '41' });
+		assert.strictEqual(gen.generate('R').at(-1), 'pin_read(board, "julia/cars", version = "41")');
+		assert.strictEqual(gen.generate('Python').at(-1), 'board.pin_read("julia/cars", version="41")');
+	});
+
+	test('an unknown syntax falls back to R', () => {
+		const gen = createPinReadCodeGenerator(target);
+		assert.deepStrictEqual(gen.generate('SQL'), gen.generate('R'));
+	});
+});

--- a/extensions/positron-data-driver-pins/src/test/pinsDriver.test.ts
+++ b/extensions/positron-data-driver-pins/src/test/pinsDriver.test.ts
@@ -4,11 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import * as os from 'os';
 import * as path from 'path';
 import * as positron from 'positron';
 import * as vscode from 'vscode';
+import { IDuckDBDataExplorerHost } from 'positron-data-explorer-duckdb';
 import { ConnectClient } from '../connectClient.js';
 import { createPinsDriver } from '../pinsDriver.js';
+import { PinsCache } from '../pinsCache.js';
 import { PinsConnection } from '../pinsConnection.js';
 
 /** A minimal ExtensionContext exposing only extensionPath, which is all the driver factory reads. */
@@ -17,6 +20,20 @@ function fakeContext(): vscode.ExtensionContext {
 	const extensionPath = path.join(__dirname, '..', '..');
 	// eslint-disable-next-line local/code-no-any-casts
 	return { extensionPath, subscriptions: [] } as any as vscode.ExtensionContext;
+}
+
+/** A no-op Data Explorer host: the tree tests browse and inspect nodes, they never open a preview. */
+function fakeDataExplorerHandler(): IDuckDBDataExplorerHost {
+	return {
+		openTableView: async () => { },
+		openColumnView: async () => { },
+		closeTableView: () => { },
+	};
+}
+
+/** A cache pointed at the temp dir; the tree tests never download, so nothing is written. */
+function fakeCache(): PinsCache {
+	return new PinsCache(os.tmpdir());
 }
 
 /** A fetch stand-in that routes by URL substring, for driving a real ConnectClient in tests. */
@@ -29,7 +46,7 @@ function routingFetch(routes: { match: string; body: string }[]): typeof fetch {
 }
 
 suite('Pins Driver', () => {
-	const driver = createPinsDriver(fakeContext());
+	const driver = createPinsDriver(fakeContext(), fakeDataExplorerHandler(), fakeCache());
 
 	test('marks the server URL and API key parameters required, with the key a secret', () => {
 		const [mechanism] = driver.mechanisms;
@@ -111,7 +128,11 @@ suite('Pins Connection tree', () => {
 	];
 
 	function connection(): PinsConnection {
-		return new PinsConnection(new ConnectClient('https://c.example.com', 'key', routingFetch(routes)));
+		return new PinsConnection(
+			new ConnectClient('https://c.example.com', 'key', routingFetch(routes)),
+			fakeDataExplorerHandler(),
+			fakeCache(),
+		);
 	}
 
 	test('groups pins by owner, sorted, rendered as owner nodes', async () => {
@@ -120,7 +141,7 @@ suite('Pins Connection tree', () => {
 		owners.forEach(o => assert.strictEqual(o.kind, positron.DataConnectionNodeKind.Owner));
 	});
 
-	test('owner expands to pins sorted by name, badged with type, expandable but not previewable', async () => {
+	test('owner expands to pins sorted by name, badged with type; tabular pins are previewable', async () => {
 		const [julia] = await connection().getChildren();
 		const pins = await julia.getChildren!();
 
@@ -128,14 +149,22 @@ suite('Pins Connection tree', () => {
 			{ name: 'cars', kind: positron.DataConnectionNodeKind.Pin, dataType: 'parquet' },
 			{ name: 'sales', kind: positron.DataConnectionNodeKind.Pin, dataType: 'csv' },
 		]);
-		// Pins expand to versions but are not previewable (Data Explorer preview comes in a later PR).
+		// Pins expand to versions, and tabular pins (parquet, csv) can be opened in the Data Explorer.
 		pins.forEach(p => {
 			assert.notStrictEqual(p.getChildren, undefined);
-			assert.strictEqual(p.preview, undefined);
+			assert.notStrictEqual(p.preview, undefined);
 		});
 	});
 
-	test('pin expands to versions, newest first, with the active version badged, as leaves', async () => {
+	test('a non-tabular pin is not previewable', async () => {
+		const [, tim] = await connection().getChildren();
+		const [model] = await tim.getChildren!();
+		// model is a joblib pin: DuckDB cannot read it, so it stays non-previewable.
+		assert.strictEqual(model.dataType, 'joblib');
+		assert.strictEqual(model.preview, undefined);
+	});
+
+	test('a tabular pin expands to versions, newest first, active badged, previewable leaves', async () => {
 		const [julia] = await connection().getChildren();
 		const cars = (await julia.getChildren!()).find(p => p.name === 'cars')!;
 		const versions = await cars.getChildren!();
@@ -144,10 +173,10 @@ suite('Pins Connection tree', () => {
 			{ name: '2024-03-02 14:00 (#5)', kind: positron.DataConnectionNodeKind.Version, dataType: 'active' },
 			{ name: '2024-01-15 09:30 (#1)', kind: positron.DataConnectionNodeKind.Version, dataType: undefined },
 		]);
-		// Versions are leaves for now: no children, not previewable.
+		// Versions are leaves (no children); each version of a tabular pin is previewable.
 		versions.forEach(v => {
 			assert.strictEqual(v.getChildren, undefined);
-			assert.strictEqual(v.preview, undefined);
+			assert.notStrictEqual(v.preview, undefined);
 		});
 	});
 
@@ -166,7 +195,7 @@ suite('Pins Connection tree', () => {
 			return new Response('', { status: 404 });
 		}) as typeof fetch;
 
-		const conn = new PinsConnection(new ConnectClient('https://c.example.com', 'key', failFirstFetch));
+		const conn = new PinsConnection(new ConnectClient('https://c.example.com', 'key', failFirstFetch), fakeDataExplorerHandler(), fakeCache());
 
 		// First browse fails...
 		await assert.rejects(() => conn.getChildren(), /network blip/);
@@ -190,7 +219,7 @@ suite('Pins Connection tree', () => {
 			return new Response(route ? route.body : '', { status: route ? 200 : 404 });
 		}) as typeof fetch;
 
-		const conn = new PinsConnection(new ConnectClient('https://c.example.com', 'key', failFirstMeta));
+		const conn = new PinsConnection(new ConnectClient('https://c.example.com', 'key', failFirstMeta), fakeDataExplorerHandler(), fakeCache());
 
 		// First expansion: the cars badge is missing because its metadata read failed.
 		const [julia1] = await conn.getChildren();

--- a/extensions/positron-data-driver-pins/src/test/pinsDriver.test.ts
+++ b/extensions/positron-data-driver-pins/src/test/pinsDriver.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import { mkdtempSync, rmSync } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as positron from 'positron';
@@ -180,6 +181,39 @@ suite('Pins Connection tree', () => {
 		});
 	});
 
+	test('version preview is gated on each version\'s own type, not the active version\'s', async () => {
+		// A pin whose active version (#5) is parquet but whose older version (#1) is rds. Each version
+		// node must reflect its own format, so only the parquet version is previewable.
+		const mixedApps = JSON.stringify({ applications: [{ guid: 'g-mixed', name: 'mixed', owner_username: 'julia', bundle_id: 5 }] });
+		const mixedBundles = JSON.stringify([
+			{ id: 1, created_time: '2024-01-01T00:00:00Z', active: false },
+			{ id: 5, created_time: '2024-02-01T00:00:00Z', active: true },
+		]);
+		// Per-version data.txt routes (more specific than a whole-pin route; matched by _rev segment).
+		const mixedRoutes = [
+			{ match: '/__api__/applications', body: mixedApps },
+			{ match: '/v1/content/g-mixed/bundles', body: mixedBundles },
+			{ match: '/content/g-mixed/_rev1/', body: 'file: old.rds\ntype: rds\napi_version: 1\n' },
+			{ match: '/content/g-mixed/_rev5/', body: 'file: new.parquet\ntype: parquet\napi_version: 1\n' },
+		];
+		const conn = new PinsConnection(
+			new ConnectClient('https://c.example.com', 'key', routingFetch(mixedRoutes)),
+			fakeDataExplorerHandler(),
+			fakeCache(),
+		);
+
+		const [julia] = await conn.getChildren();
+		const [mixed] = await julia.getChildren!();
+		// The pin badge + the pin node's preview follow the active (parquet) version.
+		assert.strictEqual(mixed.dataType, 'parquet');
+		assert.notStrictEqual(mixed.preview, undefined);
+
+		// Versions are newest-first: [#5 parquet (active), #1 rds]. Only the parquet one is previewable.
+		const [v5, v1] = await mixed.getChildren!();
+		assert.notStrictEqual(v5.preview, undefined);
+		assert.strictEqual(v1.preview, undefined);
+	});
+
 	test('a failed enumeration does not stick; the next browse re-fetches', async () => {
 		let applicationsAttempts = 0;
 		const failFirstFetch = (async (input: string | URL): Promise<Response> => {
@@ -237,5 +271,47 @@ suite('Pins Connection tree', () => {
 		await conn.disconnect();
 		assert.strictEqual(await conn.isConnected(), false);
 		await assert.rejects(() => conn.getChildren(), /closed/);
+	});
+
+	test('previewPin aborts without registering a view if disconnected during the download', async () => {
+		// Fake handler that records whether a view was ever registered.
+		let openTableViewCalls = 0;
+		const handler: IDuckDBDataExplorerHost = {
+			openTableView: async () => { openTableViewCalls++; },
+			openColumnView: async () => { },
+			closeTableView: () => { },
+		};
+		// A fresh cache dir guarantees a cache miss (so the download actually runs).
+		const cacheDir = mkdtempSync(path.join(os.tmpdir(), 'pins-preview-'));
+		// Holder so the fetch stub can close over the connection it will disconnect (the connection is
+		// built with that stub, hence the forward reference).
+		const ref: { conn?: PinsConnection } = {};
+		const disconnectDuringDownload = (async (input: string | URL): Promise<Response> => {
+			const url = typeof input === 'string' ? input : input.toString();
+			if (url.endsWith('/data.txt')) {
+				return new Response('file: data.parquet\ntype: parquet\napi_version: 1\n', { status: 200 });
+			}
+			if (url.includes('/data.parquet')) {
+				// The user collapses the connection mid-download.
+				await ref.conn!.disconnect();
+				return new Response('PARQUET-BYTES', { status: 200 });
+			}
+			return new Response('', { status: 404 });
+		}) as typeof fetch;
+
+		ref.conn = new PinsConnection(
+			new ConnectClient('https://c.example.com', 'key', disconnectDuringDownload),
+			handler,
+			new PinsCache(cacheDir),
+		);
+		try {
+			const pin = { guid: 'g', name: 'p', ownerUsername: 'julia', title: '', description: '', activeBundleId: '1' };
+			await ref.conn.previewPin(pin, '1', true);
+			// Disconnected before the view was built, so nothing should have been registered (it would
+			// leak, since disconnect's cleanup has already run).
+			assert.strictEqual(openTableViewCalls, 0);
+		} finally {
+			rmSync(cacheDir, { recursive: true, force: true });
+		}
 	});
 });

--- a/extensions/positron-data-explorer-duckdb/src/duckdbDataExplorerRpcHandler.ts
+++ b/extensions/positron-data-explorer-duckdb/src/duckdbDataExplorerRpcHandler.ts
@@ -9,7 +9,7 @@
 import * as positron from 'positron';
 import * as vscode from 'vscode';
 import { IDuckDBQueryClient } from './duckdbWorkerClient.js';
-import { DuckDBSchemaEntry, DuckDBTableView, duckdbDisplayType } from './duckdbTableView.js';
+import { DuckDBSchemaEntry, DuckDBTableView, duckdbDisplayType, IDuckDBTableCodeGenerator } from './duckdbTableView.js';
 import {
 	ConvertToCodeParams,
 	DataExplorerBackendRequest,
@@ -31,8 +31,14 @@ import {
  * connection can be tested without registering the real Data Explorer provider.
  */
 export interface IDuckDBDataExplorerHost {
-	/** Builds and registers a table view for a table or view under the given dataset id. */
-	openTableView(datasetId: string, client: IDuckDBQueryClient, schemaName: string, tableName: string, kind: 'table' | 'view'): Promise<void>;
+	/**
+	 * Builds and registers a table view for a table or view under the given dataset id. `displayName`
+	 * is the human-readable name shown in the Data Explorer tab (defaults to `tableName`); pass it when
+	 * the physical table name is not what the user should see (e.g. a synthetic name over a downloaded
+	 * file). An optional code generator overrides the view's Convert-to-Code output (see
+	 * {@link IDuckDBTableCodeGenerator}).
+	 */
+	openTableView(datasetId: string, client: IDuckDBQueryClient, schemaName: string, tableName: string, kind: 'table' | 'view', displayName?: string, codeGenerator?: IDuckDBTableCodeGenerator): Promise<void>;
 	/** Builds and registers a single-column view of a table or view under the given dataset id. */
 	openColumnView(datasetId: string, client: IDuckDBQueryClient, schemaName: string, tableName: string, kind: 'table' | 'view', columnName: string): Promise<void>;
 	/** Drops a dataset's view. */
@@ -79,9 +85,11 @@ export class DuckDBDataExplorerRpcHandler implements vscode.Disposable, IDuckDBD
 		schemaName: string,
 		tableName: string,
 		kind: 'table' | 'view',
+		displayName: string = tableName,
+		codeGenerator?: IDuckDBTableCodeGenerator,
 	): Promise<void> {
 		const schema = await buildDuckDBSchema(client, schemaName, tableName);
-		this._views.set(datasetId, new DuckDBTableView(client, tableRef(schemaName, tableName), tableName, kind, schema));
+		this._views.set(datasetId, new DuckDBTableView(client, tableRef(schemaName, tableName), displayName, kind, schema, codeGenerator));
 	}
 
 	/**

--- a/extensions/positron-data-explorer-duckdb/src/duckdbDataExplorerRpcHandler.ts
+++ b/extensions/positron-data-explorer-duckdb/src/duckdbDataExplorerRpcHandler.ts
@@ -26,22 +26,37 @@ import {
 	SetSortColumnsParams,
 } from 'positron-data-explorer-protocol';
 
+/** Options for {@link IDuckDBDataExplorerHost.openTableView}. */
+export interface OpenTableViewOptions {
+	/**
+	 * The human-readable name shown in the Data Explorer tab (defaults to the table name); pass it
+	 * when the physical table name is not what the user should see (e.g. a synthetic name over a
+	 * downloaded file).
+	 */
+	displayName?: string;
+	/** Overrides the view's Convert-to-Code output (see {@link IDuckDBTableCodeGenerator}). */
+	codeGenerator?: IDuckDBTableCodeGenerator;
+	/**
+	 * Called when the Data Explorer for this dataset is closed by the user (its tab closed), so the
+	 * consumer can release the dataset's resources (e.g. drop a materialized table, shut down an idle
+	 * worker). Not called when the view is removed via {@link IDuckDBDataExplorerHost.closeTableView}.
+	 */
+	onClose?: () => void;
+}
+
 /**
  * The slice of the RPC handler a connection needs to preview its tables. Kept as an interface so a
  * connection can be tested without registering the real Data Explorer provider.
  */
 export interface IDuckDBDataExplorerHost {
 	/**
-	 * Builds and registers a table view for a table or view under the given dataset id. `displayName`
-	 * is the human-readable name shown in the Data Explorer tab (defaults to `tableName`); pass it when
-	 * the physical table name is not what the user should see (e.g. a synthetic name over a downloaded
-	 * file). An optional code generator overrides the view's Convert-to-Code output (see
-	 * {@link IDuckDBTableCodeGenerator}).
+	 * Builds and registers a table view for a table or view under the given dataset id. See
+	 * {@link OpenTableViewOptions} for the display name, Convert-to-Code override, and close hook.
 	 */
-	openTableView(datasetId: string, client: IDuckDBQueryClient, schemaName: string, tableName: string, kind: 'table' | 'view', displayName?: string, codeGenerator?: IDuckDBTableCodeGenerator): Promise<void>;
+	openTableView(datasetId: string, client: IDuckDBQueryClient, schemaName: string, tableName: string, kind: 'table' | 'view', options?: OpenTableViewOptions): Promise<void>;
 	/** Builds and registers a single-column view of a table or view under the given dataset id. */
 	openColumnView(datasetId: string, client: IDuckDBQueryClient, schemaName: string, tableName: string, kind: 'table' | 'view', columnName: string): Promise<void>;
-	/** Drops a dataset's view. */
+	/** Drops a dataset's view (without invoking its close hook), e.g. when its connection disconnects. */
 	closeTableView(datasetId: string): void;
 }
 
@@ -58,6 +73,8 @@ export interface IDuckDBDataExplorerHost {
  */
 export class DuckDBDataExplorerRpcHandler implements vscode.Disposable, IDuckDBDataExplorerHost {
 	private readonly _views = new Map<string, DuckDBTableView>();
+	/** Per-dataset close hooks, invoked when the user closes a dataset's Data Explorer tab. */
+	private readonly _onClose = new Map<string, () => void>();
 	private readonly _session: positron.DataExplorerRpcSession;
 
 	/**
@@ -66,13 +83,15 @@ export class DuckDBDataExplorerRpcHandler implements vscode.Disposable, IDuckDBD
 	 */
 	constructor(providerId: string) {
 		this._session = positron.dataExplorer.registerRpcHandler(providerId, {
-			handleRpc: (request) => this.handleRequest(request as DataExplorerRpc)
+			handleRpc: (request) => this.handleRequest(request as DataExplorerRpc),
+			closeDataset: (datasetId) => this.closeDataset(datasetId),
 		});
 	}
 
 	dispose(): void {
 		this._session.dispose();
 		this._views.clear();
+		this._onClose.clear();
 	}
 
 	/**
@@ -85,11 +104,15 @@ export class DuckDBDataExplorerRpcHandler implements vscode.Disposable, IDuckDBD
 		schemaName: string,
 		tableName: string,
 		kind: 'table' | 'view',
-		displayName: string = tableName,
-		codeGenerator?: IDuckDBTableCodeGenerator,
+		options: OpenTableViewOptions = {},
 	): Promise<void> {
 		const schema = await buildDuckDBSchema(client, schemaName, tableName);
-		this._views.set(datasetId, new DuckDBTableView(client, tableRef(schemaName, tableName), displayName, kind, schema, codeGenerator));
+		this._views.set(datasetId, new DuckDBTableView(client, tableRef(schemaName, tableName), options.displayName ?? tableName, kind, schema, options.codeGenerator));
+		if (options.onClose) {
+			this._onClose.set(datasetId, options.onClose);
+		} else {
+			this._onClose.delete(datasetId);
+		}
 	}
 
 	/**
@@ -112,9 +135,26 @@ export class DuckDBDataExplorerRpcHandler implements vscode.Disposable, IDuckDBD
 		this._views.set(datasetId, new DuckDBTableView(client, tableRef(schemaName, tableName), tableName, kind, [column]));
 	}
 
-	/** Drops a dataset's view, e.g. when its connection is disconnected. */
+	/**
+	 * Drops a dataset's view and forgets its close hook, without invoking it. Used when the connection
+	 * tears everything down itself (disconnect), where invoking the per-dataset hook would double up on
+	 * that wholesale cleanup.
+	 */
 	closeTableView(datasetId: string): void {
 		this._views.delete(datasetId);
+		this._onClose.delete(datasetId);
+	}
+
+	/**
+	 * Handles the user closing a dataset's Data Explorer tab (invoked by Positron via the registered
+	 * handler's `closeDataset`): drops the view and invokes the consumer's close hook (if any) so it can
+	 * release that dataset's resources.
+	 */
+	closeDataset(datasetId: string): void {
+		this._views.delete(datasetId);
+		const onClose = this._onClose.get(datasetId);
+		this._onClose.delete(datasetId);
+		onClose?.();
 	}
 
 	async handleRequest(rpc: DataExplorerRpc): Promise<DataExplorerResponse> {

--- a/extensions/positron-data-explorer-duckdb/src/duckdbTableView.ts
+++ b/extensions/positron-data-explorer-duckdb/src/duckdbTableView.ts
@@ -77,6 +77,26 @@ export interface DuckDBSchemaEntry {
 }
 
 /**
+ * Optional override for the Data Explorer's Convert-to-Code feature. A table view built with a
+ * generator advertises these syntaxes in the Convert-to-Code dialog, pre-selects
+ * {@link defaultSyntaxName}, and emits {@link generate} instead of the built-in DuckDB SQL.
+ *
+ * A consumer whose data is not a durable SQL table -- e.g. a pin previewed from a file downloaded
+ * into an ephemeral in-memory database -- uses this to emit code that reads the real source (a
+ * `pin_read(...)` call) rather than a `SELECT` against a throwaway local table the user cannot run.
+ * Kept string-based (no protocol types) so consumers don't need a `positron-data-explorer-protocol`
+ * dependency to implement it.
+ */
+export interface IDuckDBTableCodeGenerator {
+	/** The syntax names offered in the Convert-to-Code dropdown (e.g. 'R', 'Python'). */
+	readonly syntaxNames: readonly string[];
+	/** The syntax pre-selected when the dialog opens; must be one of {@link syntaxNames}. */
+	readonly defaultSyntaxName: string;
+	/** Emits the code lines for the chosen syntax. Data Explorer filters/sorts are not represented. */
+	generate(syntaxName: string): string[];
+}
+
+/**
  * Maps a DuckDB column type name (from information_schema.columns.data_type) to a Data Explorer
  * display type. Matches by substring so parameterized types (e.g. DECIMAL(18,3)) resolve correctly.
  */
@@ -230,6 +250,8 @@ export class DuckDBTableView {
 	 * @param displayName The unqualified table/view name for display.
 	 * @param objectKind Whether this is a table (has a stable rowid) or a view.
 	 * @param schema The resolved column schema.
+	 * @param codeGenerator Optional Convert-to-Code override; when omitted, Convert-to-Code emits
+	 * DuckDB SQL over the table reference.
 	 */
 	constructor(
 		private readonly client: IDuckDBQueryClient,
@@ -237,6 +259,7 @@ export class DuckDBTableView {
 		private readonly displayName: string,
 		private readonly objectKind: 'table' | 'view',
 		private readonly schema: Array<DuckDBSchemaEntry>,
+		private readonly codeGenerator?: IDuckDBTableCodeGenerator,
 	) {
 		this._unfilteredRows = this._countRows('');
 		this._filteredRows = this._unfilteredRows;
@@ -500,13 +523,24 @@ export class DuckDBTableView {
 				},
 				convert_to_code: {
 					support_status: SupportStatus.Supported,
-					code_syntaxes: [{ code_syntax_name: 'SQL' }],
+					code_syntaxes: this.codeGenerator
+						? this.codeGenerator.syntaxNames.map(name => ({ code_syntax_name: name }))
+						: [{ code_syntax_name: 'SQL' }],
 				},
 			},
 		};
 	}
 
-	async convertToCode(_params: ConvertToCodeParams): Promise<ConvertedCode> {
+	async convertToCode(params: ConvertToCodeParams): Promise<ConvertedCode> {
+		// When a code generator is supplied, it fully owns the output (e.g. a pin_read snippet); the
+		// Data Explorer's current filters/sorts do not map onto that source and are intentionally
+		// dropped.
+		if (this.codeGenerator) {
+			// Read the syntax defensively: fall back to the generator's default if it is absent, so a
+			// missing/renamed parameter degrades to sensible output instead of throwing.
+			const syntaxName = params.code_syntax_name?.code_syntax_name ?? this.codeGenerator.defaultSyntaxName;
+			return { converted_code: this.codeGenerator.generate(syntaxName) };
+		}
 		const result = ['SELECT *', `FROM ${this._quotedTable}`];
 		if (this._whereClause) {
 			result.push(this._whereClause.replace(/\n/g, ' ').trim());
@@ -519,7 +553,7 @@ export class DuckDBTableView {
 	}
 
 	async suggestCodeSyntax(): Promise<CodeSyntaxName> {
-		return { code_syntax_name: 'SQL' };
+		return { code_syntax_name: this.codeGenerator?.defaultSyntaxName ?? 'SQL' };
 	}
 
 	async exportDataSelection(params: ExportDataSelectionParams): Promise<ExportedData> {

--- a/extensions/positron-data-explorer-duckdb/src/index.ts
+++ b/extensions/positron-data-explorer-duckdb/src/index.ts
@@ -8,7 +8,7 @@
 // separate side-effecting entry point exposed as 'positron-data-explorer-duckdb/worker' (bundled by
 // the consumer's esbuild into its own dist so the runtime __dirname lookup resolves).
 
-export { DuckDBTableView, DuckDBSchemaEntry, duckdbDisplayType, makeWhereExpr } from './duckdbTableView.js';
+export { DuckDBTableView, DuckDBSchemaEntry, IDuckDBTableCodeGenerator, duckdbDisplayType, makeWhereExpr } from './duckdbTableView.js';
 export { DuckDBDataExplorerRpcHandler, IDuckDBDataExplorerHost, buildDuckDBSchema } from './duckdbDataExplorerRpcHandler.js';
 export { DuckDBWorkerClient, IDuckDBQueryClient, DuckDBRow } from './duckdbWorkerClient.js';
 export { DuckDBWorkerPool, duckDBWorkerPool, IDuckDBWorkerLease } from './duckdbWorkerPool.js';

--- a/extensions/positron-data-explorer-duckdb/src/index.ts
+++ b/extensions/positron-data-explorer-duckdb/src/index.ts
@@ -9,7 +9,7 @@
 // the consumer's esbuild into its own dist so the runtime __dirname lookup resolves).
 
 export { DuckDBTableView, DuckDBSchemaEntry, IDuckDBTableCodeGenerator, duckdbDisplayType, makeWhereExpr } from './duckdbTableView.js';
-export { DuckDBDataExplorerRpcHandler, IDuckDBDataExplorerHost, buildDuckDBSchema } from './duckdbDataExplorerRpcHandler.js';
+export { DuckDBDataExplorerRpcHandler, IDuckDBDataExplorerHost, OpenTableViewOptions, buildDuckDBSchema } from './duckdbDataExplorerRpcHandler.js';
 export { DuckDBWorkerClient, IDuckDBQueryClient, DuckDBRow } from './duckdbWorkerClient.js';
 export { DuckDBWorkerPool, duckDBWorkerPool, IDuckDBWorkerLease } from './duckdbWorkerPool.js';
 export { WorkerOpenConfig } from './duckdbWorkerProtocol.js';

--- a/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionNodeRow.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionNodeRow.tsx
@@ -7,7 +7,7 @@
 import './dataConnectionNodeRow.css';
 
 // React.
-import { MouseEvent as ReactMouseEvent, useRef } from 'react';
+import { MouseEvent as ReactMouseEvent, useRef, useState } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
@@ -79,11 +79,12 @@ const kindIcon = (dto: IDataConnectionNodeDTO): string => {
 };
 
 /**
- * Whether a node can be opened in the Data Explorer: a previewable table, view, or column. The
- * `hasPreview` gate excludes nodes the driver didn't make previewable (e.g. index-column fields).
+ * Whether a node can be opened in the Data Explorer: a previewable table, view, column, pin, or pin
+ * version. The `hasPreview` gate excludes nodes the driver didn't make previewable (e.g. index-column
+ * fields, or pins whose storage type isn't tabular).
  */
 const canPreview = (dto: IDataConnectionNodeDTO): boolean =>
-	dto.hasPreview && (dto.kind === 'table' || dto.kind === 'view' || dto.kind === 'field');
+	dto.hasPreview && (dto.kind === 'table' || dto.kind === 'view' || dto.kind === 'field' || dto.kind === 'pin' || dto.kind === 'version');
 
 interface DataConnectionNodeRowProps {
 	dto: IDataConnectionNodeDTO;
@@ -98,16 +99,28 @@ interface DataConnectionNodeRowProps {
 export const DataConnectionNodeRow = ({ dto, handle }: DataConnectionNodeRowProps) => {
 	const { notificationService } = usePositronReactServicesContext();
 	const rowRef = useRef<HTMLDivElement>(null);
+	// Opening a preview can take a moment (a driver may download data first). Track it so the row can
+	// show a spinner for the duration, matching the tree's busy treatment on expansion.
+	const [opening, setOpening] = useState(false);
 
-	const openInDataExplorer = () => {
-		handle.nodePreview(dto.nodeHandle).catch(error => {
+	const openInDataExplorer = async () => {
+		// Ignore a repeat trigger (double-click or context menu) while a preview is already opening.
+		if (opening) {
+			return;
+		}
+		setOpening(true);
+		try {
+			await handle.nodePreview(dto.nodeHandle);
+		} catch (error) {
 			notificationService.error(localize(
 				'positron.dataConnections.openInDataExplorerFailed',
 				"Could not open '{0}' in the Data Explorer: {1}",
 				dto.name,
 				error instanceof Error ? error.message : String(error)
 			));
-		});
+		} finally {
+			setOpening(false);
+		}
 	};
 
 	const onDoubleClick = () => {
@@ -148,7 +161,7 @@ export const DataConnectionNodeRow = ({ dto, handle }: DataConnectionNodeRowProp
 			onContextMenu={onContextMenu}
 			onDoubleClick={onDoubleClick}
 		>
-			<div className={`codicon codicon-${kindIcon(dto)} data-connection-node-icon`} />
+			<div className={`codicon ${opening ? 'codicon-loading codicon-modifier-spin' : `codicon-${kindIcon(dto)}`} data-connection-node-icon`} />
 			<div className='data-connection-node-text'>{dto.name}</div>
 			{dto.dataType && (
 				<div className='data-connection-node-type'>{dto.dataType}</div>

--- a/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerExtensionBackend.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerExtensionBackend.ts
@@ -15,6 +15,7 @@ import {
 	ColumnSelection,
 	ColumnSortKey,
 	ConvertedCode,
+	ConvertToCodeParams,
 	DataExplorerBackendRequest,
 	DataExplorerFrontendEvent,
 	DataUpdateEvent,
@@ -206,8 +207,10 @@ export class PositronDataExplorerExtensionBackend extends Disposable implements 
 				column_filters: columnFilters,
 				row_filters: rowFilters,
 				sort_keys: sortKeys,
-				code_syntax: codeSyntax
-			}
+				// The protocol (and the generated runtime comm) name this parameter `code_syntax_name`;
+				// sending it under any other key leaves it undefined for the backend handler.
+				code_syntax_name: codeSyntax
+			} satisfies ConvertToCodeParams
 		});
 	}
 

--- a/src/vs/workbench/services/positronDataExplorer/test/common/positronDataExplorerExtensionBackend.vitest.ts
+++ b/src/vs/workbench/services/positronDataExplorer/test/common/positronDataExplorerExtensionBackend.vitest.ts
@@ -60,6 +60,20 @@ describe('PositronDataExplorerExtensionBackend', () => {
 		});
 	});
 
+	it('sends the code syntax under the protocol parameter name for convertToCode', async () => {
+		const { backend, calls } = createBackend(() => ({ result: { converted_code: ['code'] } }));
+
+		await backend.convertToCode([], [], [], { code_syntax_name: 'R' });
+
+		// The backend handler reads `code_syntax_name` (the protocol/OpenRPC name); sending it under any
+		// other key leaves the selected syntax undefined for the handler.
+		expect(calls[0].rpc).toEqual({
+			method: DataExplorerBackendRequest.ConvertToCode,
+			uri: IDENTIFIER,
+			params: { column_filters: [], row_filters: [], sort_keys: [], code_syntax_name: { code_syntax_name: 'R' } },
+		});
+	});
+
 	it('rejects when the transport returns an error message', async () => {
 		const { backend } = createBackend(() => ({ error_message: 'boom' }));
 		await expect(backend.getState()).rejects.toThrow('boom');

--- a/test/e2e/test-files/workspaces/connect-pins-r/publish-pins.R
+++ b/test/e2e/test-files/workspaces/connect-pins-r/publish-pins.R
@@ -17,9 +17,14 @@ library(pins)
 
 # The pins we publish. Small slices of the built-in datasets are plenty for
 # exercising the publish -> query round trip.
+# Each pin carries its storage type. The rds pins exercise the tree; the csv pin is a tabular type
+# DuckDB can read, so it exercises the Data Explorer preview. csv is used (not parquet) because it
+# needs no extra R package, and pins writes it with row.names = FALSE so its columns are exactly the
+# data frame's.
 pins_to_publish <- list(
-	list(name = "e2e-mtcars", data = head(mtcars, 5)),
-	list(name = "e2e-iris", data = head(iris, 5))
+	list(name = "e2e-mtcars", data = head(mtcars, 5), type = "rds"),
+	list(name = "e2e-iris", data = head(iris, 5), type = "rds"),
+	list(name = "e2e-csv", data = data.frame(id = 1:5, group = letters[1:5], value = c(1.5, 2.5, 3.5, 4.5, 5.5)), type = "csv")
 )
 
 board <- board_connect()
@@ -41,8 +46,8 @@ for (pin in pins_to_publish) {
 
 # --- Publish ---------------------------------------------------------------
 for (pin in pins_to_publish) {
-	pin_write(board, pin$data, name = pin$name, type = "rds")
-	cat("Published pin:", pin$name, "\n")
+	pin_write(board, pin$data, name = pin$name, type = pin$type)
+	cat("Published pin:", pin$name, "(", pin$type, ")\n")
 }
 
 # Publish a second version of one pin (board_connect() is versioned by default), so the

--- a/test/e2e/tests/connect/pins-data-connection.test.ts
+++ b/test/e2e/tests/connect/pins-data-connection.test.ts
@@ -13,13 +13,19 @@ test.use({
 
 const connectionName = 'e2e Connect Pins';
 
-// The pins the seed script publishes, both stored as rds, listed sorted by name (owner nodes list
-// their pins alphabetically).
+// Two of the pins the seed script publishes as rds, verified in the tree (owner nodes list their
+// pins sorted by name). The seed also publishes a csv pin (previewedPin below); rds pins are not
+// previewable, so they stay tree-only.
 const seededPins = ['e2e-iris', 'e2e-mtcars'];
 
 // The seed script publishes this pin twice, so it has two version nodes (the newest is the active
 // bundle). e2e-iris is published once and is left collapsed.
 const versionedPin = 'e2e-mtcars';
+
+// The seeded csv pin and its columns. csv is a tabular type DuckDB can read, so this pin is
+// previewable in the Data Explorer; its columns come straight from the seed data frame.
+const previewedPin = 'e2e-csv';
+const previewedColumns = ['id', 'group', 'value'];
 
 // The Connect API key resolved in beforeAll and used both to seed pins (via the R session) and to
 // configure the Data Connections driver.
@@ -49,7 +55,7 @@ test.describe('Data Connections - Posit Connect Pins', { tag: [tags.WORKBENCH, t
 
 	test('Add a Connect server and browse its pins in the tree', async function ({ app, r, executeCode }) {
 		test.slow();
-		const { console, dataConnections } = app.workbench;
+		const { console, dataConnections, dataExplorer } = app.workbench;
 
 		await test.step('Seed pins by publishing dummy data with the R pins package', async () => {
 			// board_connect() reads these env vars; set them on the session rather than baking the key
@@ -89,6 +95,14 @@ test.describe('Data Connections - Posit Connect Pins', { tag: [tags.WORKBENCH, t
 			// The pin was published twice, so it has two versions; the newest is the active bundle.
 			await dataConnections.expectVersionCount(2);
 			await dataConnections.expectActiveVersionVisible();
+		});
+
+		await test.step('Open a tabular pin in the Data Explorer and verify its columns', async () => {
+			// Double-clicking a csv pin downloads its data file, loads it into DuckDB, and opens the
+			// Data Explorer over it; the grid shows the seed data frame's columns.
+			await dataConnections.doubleClickNode(previewedPin);
+			await dataExplorer.waitForIdle();
+			await dataExplorer.grid.expectColumnHeadersToBe(previewedColumns);
 		});
 	});
 });

--- a/test/e2e/tests/data-connections/pins-remote.test.ts
+++ b/test/e2e/tests/data-connections/pins-remote.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, tags } from '../_test.setup.js';
+import { expect, test, tags } from '../_test.setup.js';
 
 test.use({
 	suiteId: __filename,
@@ -24,9 +24,10 @@ const CONNECT_API_KEY = process.env.CONNECT_API_KEY;
 
 const connectionName = 'Remote Connect';
 // A pin known to exist on the target server, addressed as owner/name. Owners are the top-level
-// grouping in the tree; the pin is a leaf beneath its owner.
+// grouping in the tree; the pin is a leaf beneath its owner. This pin is stored in a tabular format
+// (parquet or csv), so it can also be opened in the Data Explorer.
 const ownerUsername = 'julia.silge';
-const pinName = 'what-numbers-are-these';
+const pinName = 'mtcars';
 
 test.describe('Data Connections - Posit Connect Pins (remote)', { tag: [tags.CONNECTIONS] }, () => {
 
@@ -34,7 +35,7 @@ test.describe('Data Connections - Posit Connect Pins (remote)', { tag: [tags.CON
 		test.skip(!CONNECT_SERVER || !CONNECT_API_KEY, 'Set CONNECT_SERVER and CONNECT_API_KEY to run this remote smoke test');
 		test.slow();
 
-		const { dataConnections } = app.workbench;
+		const { dataConnections, dataExplorer } = app.workbench;
 
 		await test.step('Add the Posit Connect Pins connection', async () => {
 			await dataConnections.openDataConnectionsView();
@@ -61,6 +62,15 @@ test.describe('Data Connections - Posit Connect Pins (remote)', { tag: [tags.CON
 			// anchor here (the real version count is unknown and each version's label is dynamic).
 			await dataConnections.expandNode(pinName);
 			await dataConnections.expectActiveVersionVisible();
+		});
+
+		await test.step(`Open ${pinName} in the Data Explorer`, async () => {
+			// Double-clicking the pin downloads its data file, loads it into DuckDB, and opens the Data
+			// Explorer. The pin's schema isn't asserted (a live server's data can change); reaching idle
+			// with at least one column is enough to confirm the download + open path worked.
+			await dataConnections.doubleClickNode(pinName);
+			await dataExplorer.waitForIdle();
+			await expect.poll(() => dataExplorer.grid.getColumnCount()).toBeGreaterThan(0);
 		});
 	});
 });


### PR DESCRIPTION
Addresses part of #14663

This PR adds a Data Explorer preview for tabular Posit Connect pins in the Data Connections pane. A parquet or CSV pin (or a specific version of one) can be opened in the Data Explorer directly from the tree:

<img width="1568" height="1012" alt="Screenshot 2026-07-20 at 7 30 02 PM" src="https://github.com/user-attachments/assets/69745d87-f1bd-40e6-92d8-6f23ffadfbd8" />

### Summary

This is PR 3 of the Connect Pins driver, building on the scaffold + owner/pin tree (#14874), version nodes (#14952), and the shared DuckDB backend extraction (#15010).

Previewing a pin reads the version's metadata, downloads its data file into an extension-local cache (immutable-skip, matching `pin_read()` semantics from the R and Python packages), loads it into an in-memory DuckDB instance running in a child process, and opens the core Data Explorer over it through the shared `positron-data-explorer-duckdb` backend. Only parquet and CSV pins are previewable; the bundled DuckDB has no `read_arrow`, and the other pin types are not tabular files DuckDB can scan, so non-tabular pins stay tree-only and are reached through the generated connection code.

Some thing to note about the approach I've taken: 

- Whole-file download, no remote predicate pushdown: the authenticated file is cached locally and then queried, which matches how `pin_read()` works and avoids pushing the API key into DuckDB's httpfs.
- Convert-to-Code in a previewed pin emits `pins` code (`board_connect()` + `pin_read()`, R or Python, chosen in the dialog) rather than SQL against the throwaway in-memory table. This adds a small, backward-compatible code-generator hook to the shared DuckDB `TableView`; the DuckDB driver is unchanged and still emits SQL.
- Preview availability is gated per version on that version's own storage type, since a pin's format can change across versions.
- A busy spinner on the tree row covers the click-to-open gap, and a progress notification is shown for downloads large enough to take a moment.

While wiring up Convert-to-Code I found and fixed a core bug where the extension-backed Data Explorer sent the selected syntax over the wire under `code_syntax` instead of the protocol's `code_syntax_name`, so Convert-to-Code threw for any extension backend that reads the parameter (the DuckDB driver never hit it because it ignores the parameter and emits SQL).

### Release Notes

#### New Features

- Preview tabular (parquet, CSV) Posit Connect pins in the Data Explorer from the Data Connections pane (#14663)

#### Bug Fixes

- N/A

### Validation Steps

@:connect @:connections @:workbench

The hermetic e2e test (`test/e2e/tests/connect/pins-data-connection.test.ts`) publishes `.rds` and CSV pins to a dockerized Connect, browses them, and opens the csv pin in the Data Explorer. To exercise it manually:

1. Enable the Data Connections pane: set `dataConnections.enabled: true` and reload.
2. Add a "Posit Connect Pins" connection (server URL + API key).
3. Expand an owner, then a pin, to see its versions.
4. Double-click a parquet or CSV pin (or one of its versions) to open it in the Data Explorer; confirm the grid loads and the tab reads `Data: owner/name`.
5. In the Data Explorer, run Convert to Code and confirm it emits `pin_read(...)` for either R and Python.
6. Confirm a non-tabular pin (e.g. an rds pin) is not previewable.

An opt-in remote smoke test runs the same flow against a real server:

```
CONNECT_SERVER=https://pub.demo.posit.team CONNECT_API_KEY=<key> npx playwright test pins-remote --project e2e-electron
```
