### PR TITLE
fix: complete execObservable on close to avoid dropping final stdout (fixes venv create flake)

### DIFF
--- a/extensions/positron-python/src/client/common/process/rawProcessApis.ts
+++ b/extensions/positron-python/src/client/common/process/rawProcessApis.ts
@@ -280,16 +280,22 @@ export function execObservable(
         on(proc.stdout, 'data', (data: Buffer) => sendOutput('stdout', data));
         on(proc.stderr, 'data', (data: Buffer) => sendOutput('stderr', data));
 
+        // --- Start Positron ---
+        // Complete the output stream on 'close', not 'exit'. Node emits 'exit'
+        // as soon as the process ends, but 'close' fires only after the stdio
+        // streams have finished draining. Completing on 'exit' can race the
+        // final stdout chunk (e.g. create_venv.py's `CREATED_VENV:` marker),
+        // which then gets dropped -- surfacing as a spurious "Failed to create
+        // virtual environment" even though the venv was created.
+        proc.once('exit', () => {
+            procExited = true;
+        });
         proc.once('close', () => {
             procExited = true;
             subscriber.complete();
             internalDisposables.forEach((d) => d.dispose());
         });
-        proc.once('exit', () => {
-            procExited = true;
-            subscriber.complete();
-            internalDisposables.forEach((d) => d.dispose());
-        });
+        // --- End Positron ---
         proc.once('error', (ex) => {
             procExited = true;
             subscriber.error(ex);

--- a/extensions/positron-python/src/test/common/process/rawProcessApis.unit.test.ts
+++ b/extensions/positron-python/src/test/common/process/rawProcessApis.unit.test.ts
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { ChildProcess } from 'child_process';
+import { execObservable } from '../../../client/common/process/rawProcessApis';
+import { Output } from '../../../client/common/process/types';
+import { MockChildProcess } from '../../mocks/mockChildProcess';
+
+// Stub the raw required module (what rawProcessApis calls), not the
+// `import * as` namespace wrapper, whose getters are non-configurable.
+// Use a `require()` call rather than `import = require` so it compiles under
+// the ESM-target build too (import-assignment is a TS1202 error there).
+const childProcess: typeof import('child_process') = require('child_process');
+
+suite('execObservable - trailing output', () => {
+    let proc: MockChildProcess;
+
+    setup(() => {
+        proc = new MockChildProcess('python', ['create_venv.py']);
+        sinon.stub(childProcess, 'spawn').returns(proc as unknown as ChildProcess);
+    });
+
+    teardown(() => {
+        sinon.restore();
+    });
+
+    // Reproduces the venv "Failed to create virtual environment" flake: a child
+    // process's final stdout line (create_venv.py's `CREATED_VENV:` marker) is
+    // produced and the process exits 0, but the chunk lands after the `exit`
+    // event. Node emits `exit` before the stdout pipe finishes draining (`close`
+    // is the drain-complete event), so if execObservable completes on `exit` the
+    // trailing chunk is dropped. Asserts the marker is delivered, so it fails
+    // against the current `exit`-completes code and passes once completion waits
+    // for `close`.
+    test('delivers a stdout chunk that arrives after the process exit event', (done) => {
+        const received: string[] = [];
+        const result = execObservable('python', ['create_venv.py'], { doNotLog: true });
+
+        result.out.subscribe(
+            (value: Output<string>) => received.push(value.out),
+            (err) => done(err),
+            () => {
+                try {
+                    expect(received.join('')).to.contain(
+                        'CREATED_VENV:',
+                        'the stdout chunk emitted after the exit event was dropped',
+                    );
+                    done();
+                } catch (ex) {
+                    done(ex);
+                }
+            },
+        );
+
+        // Model Node's real ordering under load: some output, then the process
+        // exit, then the final buffered stdout chunk drains, then close.
+        proc.stdout!.emit('data', Buffer.from('Running: python -m venv .venv\n'));
+        proc.emit('exit', 0, null);
+        proc.stdout!.emit('data', Buffer.from('CREATED_VENV:/tmp/x/.venv/bin/python\n'));
+        proc.emit('close', 0, null);
+    });
+});

--- a/extensions/positron-python/src/test/common/process/rawProcessApis.unit.test.ts
+++ b/extensions/positron-python/src/test/common/process/rawProcessApis.unit.test.ts
@@ -1,5 +1,7 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
 
 import { expect } from 'chai';
 import * as sinon from 'sinon';


### PR DESCRIPTION
Fixes #15028

This PR fixes Python venv creation being reported as "Error while creating virtual environment" even though the venv was created, which left the New Folder Flow without a console session. The issue was caused by `execObservable` completing its output observable on the process `exit` event (and detaching the stdout listener there) while Node emits `exit` before the stdout pipe finishes draining -- so the final stdout chunk could be dropped. For venv creation that chunk is `create_venv.py`'s `CREATED_VENV:<path>` marker, so `createVenv` resolved with no path despite exit code 0 and `venvCreationProvider.ts:372` threw. The fix completes the observable on `close` (drain-complete) instead of `exit`.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed an intermittent "Error while creating virtual environment" when creating a Python venv, even though the environment was created successfully. (#15028)

### Validation Steps

@:new-folder-flow

1. New Folder Flow -> Python Project -> new `venv` environment.
2. Verify the venv is created and its console session starts (no error notification).

A deterministic unit test also covers the mechanism -- a mock child process emitting a stdout chunk after `exit` but before `close`:

```bash
cd extensions/positron-python && npm run test:unittests -- --grep "trailing output"
```

Note: this touches completion timing for all `execObservable` consumers, so the existing `execObservable` kill/cancel/streaming integration coverage (`proc.observable.test.ts`) should run clean in CI.

### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- venv creation misreported as failed; final stdout chunk dropped on process exit</summary>

- **Spec:** `test/e2e/tests/new-folder-flow/new-folder-flow-python.test.ts`
  - **Test:** `New Folder Flow: Python Project > New env: Venv environment`
- **Signal:** logs show `Running: python -m venv .venv`, then no further script output, then `venvCreationProvider.ts:372` "Failed to create" 6-9s later; `CREATED_VENV` absent from captured output though the process exits 0; `.venv/bin/python` registered as a runtime seconds after the "failure." Reproduced deterministically in a unit test.
- **Frequency:** 12 occurrences in 14 days, ~4% of runs, ubuntu/chromium only (high-parallelism web runner); 0 on electron/win.
- **Hypothesis:** race -- `execObservable` completed on `exit` and detached the stdout listener before the pipe drained, dropping the trailing `CREATED_VENV:` marker under event-loop contention.

</details>
