### PR TITLE
e2e: fix R session mistargeted after leftover session in shiny test

### DIFF
--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -559,12 +559,15 @@ export class Sessions {
 			// trusts whichever session is currently active; confirm it actually matches the
 			// language we just requested before returning it, otherwise callers (e.g.
 			// pasteCodeToConsole) end up targeting the wrong session's console input.
+			// Match the "Select runtime from quick pick" budget above -- this check is
+			// effectively finishing off that same runtime-selection process, and is exposed
+			// to the same CI-load-driven extension host stalls.
 			const expectedIdPrefix = new RegExp(`^${language.toLowerCase()}(-notebook)?-`, 'i');
 			let sessionId: string | undefined;
 			await expect(async () => {
 				sessionId = await this.getCurrentSessionId();
 				expect(sessionId).toMatch(expectedIdPrefix);
-			}, `Wait for ${language} session to become active`).toPass({ timeout: 10000 });
+			}, `Wait for ${language} session to become active`).toPass({ timeout: 30000 });
 
 			return sessionId!;
 		});

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -553,7 +553,20 @@ export class Sessions {
 				}
 			}
 
-			return this.getCurrentSessionId();
+			// The foreground-session switch to the session we just started is async
+			// (it lags the "started" text above), so a leftover session from an
+			// earlier test in the same suite can still be active here. getCurrentSessionId()
+			// trusts whichever session is currently active; confirm it actually matches the
+			// language we just requested before returning it, otherwise callers (e.g.
+			// pasteCodeToConsole) end up targeting the wrong session's console input.
+			const expectedIdPrefix = new RegExp(`^${language.toLowerCase()}(-notebook)?-`, 'i');
+			let sessionId: string | undefined;
+			await expect(async () => {
+				sessionId = await this.getCurrentSessionId();
+				expect(sessionId).toMatch(expectedIdPrefix);
+			}, `Wait for ${language} session to become active`).toPass({ timeout: 10000 });
+
+			return sessionId!;
 		});
 	}
 


### PR DESCRIPTION
### Summary
Fixes a shared e2e session-start helper that could return the wrong session id when a leftover session from an earlier test was still active.
- `Sessions.startAndSkipMetadata()` trusted whichever console was currently "active" without confirming it matched the just-requested language
- The foreground-session switch is async, so a session left active by a preceding test in the same suite (e.g. Python before R in `shiny.test.ts`) could still be foreground past the runtime-selection step
- Downstream callers (`pasteCodeToConsole`) then typed code into the wrong session's console input
- Now verifies the returned session id matches the requested language before returning it

### QA Notes
@:apps @:sessions @:web

### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- leftover session from preceding test races the foreground-session switch, causing code to be pasted into the wrong console</summary>

- **Spec:** `test/e2e/tests/shiny/shiny.test.ts`
  - **Test:** `Shiny Application > R - Verify Basic Shiny App`
- **Signal:** R kernel log shows zero `execute_request` messages for the entire failed attempt (only kernel-startup/comm-handshake, then heartbeats). Trace timeline shows, right after "R 4.4.0" is selected in the quick pick, a click landing on the leftover Python session's info-button testid (`info-python-...`), and `getMetadata()`'s tab-click re-selecting that Python tab as active -- before `pasteCodeToConsole` runs. Independently confirmed against source: `startAndSkipMetadata`'s readiness check (`sessions.ts:532`) only asserts *some* active console shows "started" text, and `getCurrentSessionId()` (`sessions.ts:669`) returns whichever session is currently active with no cross-check against the language just requested.
- **Frequency:** 3/477 runs (0.6% of total runs; 17% of this test's sampled flaky occurrences), win/electron only. All 3 sampled occurrences land on or after PR #14984's merge commit, which removed an incidental delay (the console-info-popup RPC wait) that had likely been giving the foreground-session switch enough time to land first -- unmasking this preexisting test-infra race rather than introducing a new one.
- **Hypothesis:** Test-infra race, not a product bug -- Positron's single-active-console invariant is implemented correctly; the Playwright helper trusted "whichever session is active" without confirming it was the one just started.

Note: this test also has two other failure patterns from the same triage pass, not addressed by this PR -- a generic interpreter-selection quick-pick race (`sessions.ts:527`, 56% of sampled occurrences, still live, not Shiny-specific) and a console-info-popup RPC race (28%, already resolved by #14984).

</details>

