### PR TITLE
e2e: use pre-launch settings for modal editor overlay test

### DIFF
--- a/scripts/derive-test-change-tags.mjs
+++ b/scripts/derive-test-change-tags.mjs
@@ -185,20 +185,32 @@ function main() {
 				console.error(`derive-test-change-tags: ${file} has no declared tags for "${spec.title}" -- add tags or tag the PR body manually.`);
 				continue;
 			}
-			// Already covered? Check against the spec's ORIGINAL tags: if a
-			// platform tag it carries is already selected (e.g. author added
-			// @:win), the test genuinely runs in that lane -- nothing to add.
-			const covered = [...spec.tags].some(t => selected.has(t));
-			if (covered) { continue; }
 			// Restrict the cover candidates to feature tags. A spec left with no
 			// eligible tag (only platform/special tags, e.g. a @:win-only test)
 			// can't be auto-covered -- warn like the untagged case rather than
 			// silently miss it or select a lane-triggering tag.
 			const eligible = featureAllow ? [...spec.tags].filter(t => featureAllow.has(t)) : [...spec.tags];
 			if (eligible.length === 0) {
-				console.error(`derive-test-change-tags: ${file} "${spec.title}" is tagged only with platform/non-feature tags (${[...spec.tags].join(', ')}) -- add a feature tag or tag the PR body manually.`);
+				// No feature tag exists to derive at all -- fall back to the
+				// spec's full (platform-included) tag set for the coverage
+				// check, so a @:win-only test whose author already typed
+				// @:win is recognized as covered and skipped silently rather
+				// than warned about.
+				const covered = [...spec.tags].some(t => selected.has(t));
+				if (!covered) {
+					console.error(`derive-test-change-tags: ${file} "${spec.title}" is tagged only with platform/non-feature tags (${[...spec.tags].join(', ')}) -- add a feature tag or tag the PR body manually.`);
+				}
 				continue;
 			}
+			// Already covered? Check against the spec's FEATURE tags only. A
+			// platform tag (e.g. @:web) already being selected does guarantee
+			// the spec runs in CI, but it says nothing about the spec's real
+			// feature scope, so it must not suppress deriving that scope: the
+			// PR comment's "why these tags" explanation and the weekly
+			// tag-map audit both depend on this signal naming the actual
+			// feature, not "covered by an unrelated platform lane."
+			const covered = eligible.some(t => selected.has(t));
+			if (covered) { continue; }
 			touchedUncovered.push({ ...spec, tags: new Set(eligible) });
 		}
 	}

--- a/scripts/test/pr-tags-lib-test.sh
+++ b/scripts/test/pr-tags-lib-test.sh
@@ -1169,6 +1169,14 @@ assert_eq "empty --feature-tags behaves like no allowlist (not an empty allowlis
 OUT="$(node "$DERIVE_SCRIPT" --changed-files "$DERIVE_DIR/changed.txt" --selected-tags "" --feature-tags "$FEATURE_ALLOW" --list-json "$DERIVE_DIR/plat-list.json")"
 assert_eq "with allowlist: platform tag excluded, pricier feature tag chosen" "@:search" "$OUT"
 
+# Regression: a platform tag already selected (e.g. the author typed @:web, or
+# an unrelated file in the same PR triggered @:cross-browser) must NOT count
+# as "covered" for a spec that also carries a real feature tag -- the platform
+# tag guarantees the spec runs in CI, but says nothing about its feature scope,
+# and that scope must still surface so the PR comment/tag-map audit can see it.
+OUT="$(node "$DERIVE_SCRIPT" --changed-files "$DERIVE_DIR/changed.txt" --selected-tags "@:cross-browser" --feature-tags "$FEATURE_ALLOW" --list-json "$DERIVE_DIR/plat-list.json")"
+assert_eq "platform tag already selected does not suppress the spec's real feature tag" "@:search" "$OUT"
+
 changed_file "test/e2e/tests/webonly/webonly.test.ts"
 WARN_OUT="$(node "$DERIVE_SCRIPT" --changed-files "$DERIVE_DIR/changed.txt" --selected-tags "" --feature-tags "$FEATURE_ALLOW" --list-json "$DERIVE_DIR/plat-list.json" 2>&1 1>/dev/null)"
 if printf '%s' "$WARN_OUT" | grep -qF "platform/non-feature"; then
@@ -1178,6 +1186,16 @@ else
 fi
 STDOUT_ONLY="$(node "$DERIVE_SCRIPT" --changed-files "$DERIVE_DIR/changed.txt" --selected-tags "" --feature-tags "$FEATURE_ALLOW" --list-json "$DERIVE_DIR/plat-list.json" 2>/dev/null)"
 assert_eq "platform-only touched test: nothing added to stdout" "" "$STDOUT_ONLY"
+
+# When a platform-only spec's own platform tag IS already selected, it must
+# still be treated as covered and skipped silently (no warning) -- the
+# feature-tags-only "covered" check only applies once a real feature tag
+# exists to protect; a spec with no feature tag at all falls back to the old
+# any-tag check.
+NO_WARN_OUT="$(node "$DERIVE_SCRIPT" --changed-files "$DERIVE_DIR/changed.txt" --selected-tags "@:web" --feature-tags "$FEATURE_ALLOW" --list-json "$DERIVE_DIR/plat-list.json" 2>&1 1>/dev/null)"
+assert_eq "platform-only touched test already covered by its own platform tag: no warning" "" "$NO_WARN_OUT"
+NO_WARN_STDOUT="$(node "$DERIVE_SCRIPT" --changed-files "$DERIVE_DIR/changed.txt" --selected-tags "@:web" --feature-tags "$FEATURE_ALLOW" --list-json "$DERIVE_DIR/plat-list.json" 2>/dev/null)"
+assert_eq "platform-only touched test already covered: nothing added to stdout" "" "$NO_WARN_STDOUT"
 
 rm -rf "$DERIVE_DIR"
 

--- a/test/e2e/tests/editor-action-bar/settings-modal.test.ts
+++ b/test/e2e/tests/editor-action-bar/settings-modal.test.ts
@@ -21,9 +21,23 @@
  * the modal here. `editor.actionBar.enabled` is turned on so the action bar *would* render
  * inside the modal if the suppression gate were missing, which is what makes the absence
  * assertion meaningful rather than vacuous.
+ *
+ * Both settings are written pre-launch (via `beforeApp`/`settingsFile`) rather than set
+ * mid-test, so the config service reads them at startup instead of racing a live
+ * file-watcher reload.
  */
 
-import { test, expect, tags } from '../_test.setup';
+import { test as base, expect, tags } from '../_test.setup';
+
+const test = base.extend<{}, {}>({
+	beforeApp: [
+		async ({ settingsFile }, use) => {
+			await settingsFile.append({ 'editor.actionBar.enabled': true, 'workbench.editor.useModal': 'all' });
+			await use();
+		},
+		{ scope: 'worker' }
+	],
+});
 
 test.use({
 	suiteId: __filename
@@ -37,14 +51,7 @@ test.describe('Editor Action Bar: Modal Editor Overlay', {
 		await runCommand('workbench.action.closeModalEditor');
 	});
 
-	test('does not render the Positron editor action bar inside the modal editor overlay', async function ({ page, settings, runCommand }) {
-		// keepOpen: false forces the settings reload to settle before we open an editor,
-		// so `useModal: 'all'` is in effect by the time the editor is routed.
-		await settings.set(
-			{ 'editor.actionBar.enabled': true, 'workbench.editor.useModal': 'all' },
-			{ keepOpen: false }
-		);
-
+	test('does not render the Positron editor action bar inside the modal editor overlay', async function ({ page, runCommand }) {
 		await runCommand('workbench.action.files.newUntitledFile');
 
 		const modal = page.locator('.monaco-modal-editor-block');


### PR DESCRIPTION
### Summary
Two fixes: a flaky modal-editor e2e test, and a tag-derivation gap it surfaced.
- `settings-modal.test.ts` set `useModal`/`actionBar` mid-test with no reload, racing config propagation; the modal sometimes never opened on web (electron was 8/8). Moved both settings pre-launch (`beforeApp` + `settingsFile`).
- `derive-test-change-tags.mjs` treated an already-selected platform tag (e.g. the web one) as sufficient coverage, suppressing the touched test's feature-tag derivation. Now only feature tags count as coverage; platform-only specs still fall back to the old check.

### QA Notes
Test + tooling only. Regression coverage added in `scripts/test/pr-tags-lib-test.sh`.

@:web

### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- pre-launch settings write removes a mid-test config-propagation race that only manifested on web/chromium</summary>

- **Spec:** `test/e2e/tests/editor-action-bar/settings-modal.test.ts`
  - **Test:** `Editor Action Bar: Modal Editor Overlay > does not render the Positron editor action bar inside the modal editor overlay`
- **Signal:** Trace timelines for both sampled occurrences (rhel/chromium, ubuntu/chromium) show an identical shape: `settings.set()` writes/saves settings, a fixed `waitForReady` wait elapses, `workbench.action.files.newUntitledFile` fires, and the next `expect(.monaco-modal-editor-block).toBeVisible()` fails immediately. DOM-presence analysis confirms `.monaco-modal-editor-block` was NEVER present in any of the ~218 sampled frame snapshots in either trace -- the modal never opened. Source confirms the live-config path is sound (`ModalEditorPart` / `editorGroupFinder.ts` read `useModal` live via `onDidChangeConfiguration`); the gap is `settings.set()` used no `reload`, so the routing check could observe the pre-change value before the file-watcher propagated.
- **Frequency:** 4/19 runs (21% fail+flaky) over 14 days, 100% of this test's sampled failures, chromium/web only -- zero on electron.
- **Hypothesis:** Test-infra race, not a product bug. Fix moves both settings pre-launch (`beforeApp`/`settingsFile`, matching `missing-packages.test.ts`) so config is read at startup instead of racing a live reload.

</details>
