### PR TITLE
Run SQLite data driver integration tests in CI

### DIFF
--- a/scripts/test-integration-pr.sh
+++ b/scripts/test-integration-pr.sh
@@ -91,6 +91,24 @@ npm run test-extension -- -l positron-duckdb
 kill_app
 
 echo
+echo "### Positron DuckDB data connection tests"
+echo
+npm run test-extension -- -l positron-data-driver-duckdb
+kill_app
+
+echo
+echo "### Positron SQLite data connection tests"
+echo
+npm run test-extension -- -l positron-data-driver-sqlite
+kill_app
+
+echo
+echo "### Positron Connect Pins data connection tests"
+echo
+npm run test-extension -- -l positron-data-driver-pins
+kill_app
+
+echo
 echo "### Positron Zed tests"
 echo
 npm run test-extension -- -l positron-zed

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -384,6 +384,12 @@ npm run test-extension -- -l positron-data-driver-duckdb
 kill_app
 
 echo
+echo "### Positron SQLite data connection tests"
+echo
+npm run test-extension -- -l positron-data-driver-sqlite
+kill_app
+
+echo
 echo "### Positron Connect Pins data connection tests"
 echo
 npm run test-extension -- -l positron-data-driver-pins


### PR DESCRIPTION
## Summary

Fixes #15020.

The `positron-data-driver-sqlite` extension had a label in `.vscode-test.js` but was never invoked by the integration test scripts, so its unit tests (`sqliteTableView`, `sqliteWorkerClient`, `sqliteDriver`, `dataConnectionIntegration`) never ran in CI. This wires it into `scripts/test-integration.sh` alongside the DuckDB driver.

While confirming where the DuckDB driver was wired, I found that `scripts/test-integration-pr.sh` (the PR-only ext-host lane) had drifted: the newer data-driver suites `positron-data-driver-duckdb` and `positron-data-driver-pins` were added to the full lane only (in #15010 and #14874), so they have never gated PRs. This PR also adds all three data-driver suites to the PR lane so its Positron section matches the full lane.

## What changed

- `scripts/test-integration.sh`: add `positron-data-driver-sqlite`.
- `scripts/test-integration-pr.sh`: add `positron-data-driver-sqlite`, `positron-data-driver-duckdb`, and `positron-data-driver-pins` (the latter two repair pre-existing drift).

The PR lane remains deliberately Positron-only (no upstream VS Code suites); that split is unchanged.

## Native binding note (the #15020 caveat)

The issue flagged that `better-sqlite3` isn't ABI-stable the way DuckDB's `@duckdb/node-api` is, and asked to confirm the binding loads in the ext-host lane. It does: the SQLite worker forks with `ELECTRON_RUN_AS_NODE=1`, so under `@vscode/test-electron` it loads the Electron-ABI `better_sqlite3.node` built by `build/npm/postinstall.ts`.

Confirmed locally: the suite passes (32 tests), including `survives a worker crash ... and respawns`, which forks the real worker and loads the native binding.

## QA

- [ ] Extension host CI (Electron + Remote) is green, including the new `### Positron SQLite data connection tests` step in both lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)