### PR TITLE
e2e: fix Python app play-button race with app detection

### DIFF
--- a/test/e2e/pages/editor.ts
+++ b/test/e2e/pages/editor.ts
@@ -75,16 +75,27 @@ export class Editor {
 		});
 	}
 
-	async pressPlay(skipToastVerification: boolean = false): Promise<void> {
+	async pressPlay(options: { skipToastVerification?: boolean; appName?: string } = {}): Promise<void> {
+		const { skipToastVerification = false, appName } = options;
 		await test.step('Press play button', async () => {
+			const page = this.code.driver.currentPage;
+			// For web-app files the framework-specific run button ("Run <name> App in Terminal")
+			// only appears once Positron's async app detection sets the pythonAppFramework context
+			// key. Target that button by name so Playwright waits for detection to finish; clicking
+			// the generic PLAY_BUTTON can race detection and hit "Run Python File in Console", which
+			// runs the file as a plain script and never launches the app (so the toast never shows).
+			const playButton = appName
+				? page.getByRole('button', { name: `Run ${appName} App in Terminal` })
+				: page.locator(PLAY_BUTTON);
+
 			if (!skipToastVerification) {
 				// Set up the toast locator BEFORE clicking to avoid racing with a fast-dismissing toast
-				const appRunningToast = this.code.driver.currentPage.locator('.notifications-toasts').getByText(/Running.*application:/);
-				await this.code.driver.currentPage.locator(PLAY_BUTTON).click();
+				const appRunningToast = page.locator('.notifications-toasts').getByText(/Running.*application:/);
+				await playButton.click();
 				await expect(appRunningToast).toBeVisible({ timeout: 30000 });
 				await expect(appRunningToast).not.toBeVisible({ timeout: 45000 });
 			} else {
-				await this.code.driver.currentPage.locator(PLAY_BUTTON).click();
+				await playButton.click();
 			}
 		});
 	}

--- a/test/e2e/tests/apps/python-apps.test.ts
+++ b/test/e2e/tests/apps/python-apps.test.ts
@@ -72,12 +72,12 @@ test.describe('Python Applications', {
 			await openFile(join('workspaces', 'python_apps', appTest.filePath));
 
 			// Press play and verify the content is visible in the viewer frame
-			await editor.pressPlay();
+			await editor.pressPlay({ appName: appTest.name });
 			await viewer.expectContentVisible(appTest.locator, {
 				onRetry: async () => {
 					await terminal.clickTerminalTab();
 					await terminal.sendKeysToTerminal('Control+C');
-					await editor.pressPlay();
+					await editor.pressPlay({ appName: appTest.name });
 				}
 			});
 
@@ -95,14 +95,14 @@ test.describe('Python Applications', {
 
 		// Open the Streamlit app file and press play
 		await openFile(join('workspaces', 'python_apps', 'streamlit_example', 'streamlit_example.py'));
-		await editor.pressPlay();
+		await editor.pressPlay({ appName: 'Streamlit' });
 		await viewer.expectContentVisible(
 			frame => frame.getByRole('button', { name: 'Deploy' }),
 			{
 				onRetry: async () => {
 					await terminal.clickTerminalTab();
 					await terminal.sendKeysToTerminal('Control+C');
-					await editor.pressPlay();
+					await editor.pressPlay({ appName: 'Streamlit' });
 				}
 			}
 		);

--- a/test/e2e/tests/debug/python-module-loading.test.ts
+++ b/test/e2e/tests/debug/python-module-loading.test.ts
@@ -27,7 +27,7 @@ test.describe('Python Debugging', {
 
 			await openFile(join('workspaces', 'python_module_caching', 'app.py'));
 
-			await app.workbench.editor.pressPlay(true);
+			await app.workbench.editor.pressPlay({ skipToastVerification: true });
 
 			await app.workbench.console.waitForConsoleContents('Hello World');
 
@@ -47,7 +47,7 @@ test.describe('Python Debugging', {
 		await test.step('Re-run with edited helper', async () => {
 			await openFile(join('workspaces', 'python_module_caching', 'app.py'));
 
-			await app.workbench.editor.pressPlay(true);
+			await app.workbench.editor.pressPlay({ skipToastVerification: true });
 
 			await app.workbench.console.waitForConsoleContents('Goodbye World');
 		});


### PR DESCRIPTION
### Summary
Fixes a Windows-only flake in the Python app tests where pressing play raced Positron's async web-app detection.
- `pressPlay()` clicked the generic `.codicon-play` button, which on a slow Windows runner could land before the `pythonAppFramework` context key was set and the framework-specific run button appeared.
- The generic button runs the file as a plain script (`execInConsole`), so the app server never starts and the `Running <name> application:` toast never shows -> 30s timeout.
- `pressPlay()` now targets the framework button by name (`Run <name> App in Terminal`), so Playwright waits for detection before clicking.
- Converted `pressPlay`'s arg to an options object (`{ skipToastVerification?, appName? }`); updated all callers.

@:apps 

### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- play-button click races async web-app detection, firing the generic run command instead of the app runner</summary>

- **Spec:** `test/e2e/tests/apps/python-apps.test.ts`
  - **Test:** `Python Applications > Python - Verify Basic Gradio App`
- **Signal:** Trace click of `.codicon-play` at t=88203 (~16:21:12.0); `pythonAppFramework=gradio` detection didn't complete until 16:21:16.175, so the fired command was `python.execInConsole` (generic "Run Python File in Console") at 16:21:16.367, not `python.execGradioInTerminal`. The run-app `App Launcher.log` has zero entries for the test (`runApplication()` never reached), so the `withProgress` "Running application" toast never rendered; ptyhost is idle for ~26s until teardown `^C`. Contributing load factor: `GitHub.copilot-chat` activated right after the click and made the ext host UNRESPONSIVE (95.9% of 3.2s) with a `GitHubLoginFailed` burst.
- **Frequency:** 9/492 runs (1.8%), all `flaky`, win/electron only (0 failures on mac/ubuntu/debian/opensuse/rhel/sles).
- **Hypothesis:** Test-side detection-vs-interaction race, load-sensitive on Windows CI (more parallel workers). Not a timeout issue -- the wrong command already ran; a longer wait can't recover that attempt.

Note: this test has a second, unrelated minor pattern (session-metadata dialog RPC race, issue #14983, 2/9) not addressed here.

</details>
