### PR TITLE
Fix flaky positron-code-cells decorations test

### DIFF
--- a/extensions/positron-code-cells/src/test/decorations.test.ts
+++ b/extensions/positron-code-cells/src/test/decorations.test.ts
@@ -5,7 +5,7 @@
 
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import { closeAllEditors, delay, disposeAll } from './utils';
+import { closeAllEditors, disposeAll, waitFor } from './utils';
 import { SetDecorations, activateDecorations, focusedCellBackgroundDecorationType, focusedCellBottomDecorationType, focusedCellTopDecorationType } from '../decorations';
 
 suite('Decorations', () => {
@@ -30,6 +30,22 @@ suite('Decorations', () => {
 		assert.deepStrictEqual(
 			decorations.get(type), expected, 'Cell decoration ranges are not equal'
 		);
+	}
+
+	function cellDecorationRangesEqual(type: vscode.TextEditorDecorationType, expected: vscode.Range[]): boolean {
+		try {
+			assert.deepStrictEqual(decorations.get(type), expected);
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	// Decorations update asynchronously in response to editor events, so poll
+	// until they match rather than waiting a fixed delay (which flakes under CI load).
+	async function assertCellDecorationRangesEventuallyEqual(type: vscode.TextEditorDecorationType, expected: vscode.Range[]): Promise<void> {
+		await waitFor(() => cellDecorationRangesEqual(type, expected));
+		assertCellDecorationRangesEqual(type, expected);
 	}
 
 	test('Opening an empty Python document', async () => {
@@ -65,8 +81,7 @@ suite('Decorations', () => {
 		assertCellDecorationRangesEqual(focusedCellBackgroundDecorationType, [new vscode.Range(0, 0, 0, 4)]);
 
 		// Decorations update after a delay
-		await delay(400);
-		assertCellDecorationRangesEqual(focusedCellBackgroundDecorationType, [new vscode.Range(1, 0, 1, 4)]);
+		await assertCellDecorationRangesEventuallyEqual(focusedCellBackgroundDecorationType, [new vscode.Range(1, 0, 1, 4)]);
 	});
 
 	test('Removing all code cells from a Python document', async () => {
@@ -81,8 +96,7 @@ suite('Decorations', () => {
 		assertCellDecorationRangesEqual(focusedCellBackgroundDecorationType, [new vscode.Range(0, 0, 0, 4)]);
 
 		// Decorations update after a delay
-		await delay(400);
-		assertCellDecorationRangesEqual(focusedCellBackgroundDecorationType, []);
+		await assertCellDecorationRangesEventuallyEqual(focusedCellBackgroundDecorationType, []);
 	});
 
 	test('Changing the active editor', async () => {
@@ -91,8 +105,7 @@ suite('Decorations', () => {
 
 		// Decorations update after a delay
 		await showTextDocument('');
-		await delay(400);
-		assertCellDecorationRangesEqual(focusedCellBackgroundDecorationType, []);
+		await assertCellDecorationRangesEventuallyEqual(focusedCellBackgroundDecorationType, []);
 	});
 
 	test('Changing the cell style option', async () => {

--- a/extensions/positron-code-cells/src/test/utils.ts
+++ b/extensions/positron-code-cells/src/test/utils.ts
@@ -15,3 +15,21 @@ export function disposeAll(disposables: vscode.Disposable[]) {
 export function delay(ms: number) {
 	return new Promise(resolve => setTimeout(resolve, ms));
 }
+
+/**
+ * Poll `predicate` until it returns true or the timeout elapses.
+ *
+ * Useful for asserting on state that updates asynchronously (e.g. editor
+ * decorations that refresh after an editor event fires). Returns once the
+ * predicate passes; on timeout it returns anyway so the caller's own assertion
+ * can produce a meaningful failure message.
+ */
+export async function waitFor(predicate: () => boolean, timeout = 2000, interval = 50): Promise<void> {
+	const start = Date.now();
+	while (!predicate()) {
+		if (Date.now() - start >= timeout) {
+			return;
+		}
+		await delay(interval);
+	}
+}


### PR DESCRIPTION
## Summary

The `Decorations` suite in `positron-code-cells` asserted on editor decoration state after a fixed `await delay(400)`. Decorations refresh **asynchronously** in response to `onDidChangeTextEditorSelection` / `onDidChangeActiveTextEditor` events, and under CI load the event did not always propagate within 400ms, so the decoration was still on the previous cell when the assertion ran.

Observed failing on `main` ([run 29843970293](https://github.com/posit-dev/positron/actions/runs/29843970293/job/88679651591)):

```
1) Decorations
     Changing the selected code cell in a Python document:
   AssertionError [ERR_ASSERTION]: Cell decoration ranges are not equal
   + actual   _line: 0   (decoration stayed on the first cell)
   - expected _line: 1   (should have moved to the second cell)
```

## Fix

Replace the fixed sleep with a poll-until-match approach:

- `waitFor(predicate, timeout=2000, interval=50)` in the test utils - polls until the predicate passes or times out, returning either way so the caller's own assertion still produces a clean failure message on genuine breakage.
- `assertCellDecorationRangesEventuallyEqual` in the test - polls until the decoration ranges match, then runs the identical assertion. Applied to the three tests that used `await delay(400)`.

The synchronous "decorations do not update immediately" checks are unchanged - those correctly verify the event is async.

## Behavior

- Passing condition: resolves as soon as the event lands (the flaky test now completes in ~69ms instead of always blocking 400ms).
- Slow event: waits up to 2s instead of failing at 400ms.
- Real regression: still fails with the same assertion message.

## Testing

Ran the full `positron-code-cells` extension-host suite locally in Electron: **71 passing, 0 failing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)