### PR TITLE
build: fix ai-config/dist missing on cache-hit CI builds

### DIFF
--- a/.github/cache-scripts/cache-paths.sh
+++ b/.github/cache-scripts/cache-paths.sh
@@ -67,9 +67,16 @@ fi
 # What: Root node_modules, build tools, test dependencies, npm/node-gyp caches,
 #       and artifacts generated during postinstall (e.g., ESM dependencies)
 # Invalidates: When any core package-lock.json changes OR Node.js major version changes
-#              OR postinstall scripts change (see generate-package-locks-hash.sh)
+#              OR postinstall scripts change OR the ai-lib submodule is bumped
+#              (see generate-package-locks-hash.sh)
 # Why cache node-gyp: Avoids downloading Node.js headers (saves 10-30s, more reliable)
 # Node.js version: Major version included in cache key (ABI is stable within major versions)
+# ai-lib/packages/ai-config/dist: Built by extensions/authentication's postinstall
+#       (npm --prefix ../../ai-lib run build -w ai-config). It lives outside node_modules
+#       and outside extensions/, so neither the extension caches nor node_modules cover it;
+#       without this it goes missing on a cache hit. The ai-lib submodule gitlink is folded
+#       into this cache's key so a bump rebuilds it (see generate-package-locks-hash.sh).
+#       NOTE: entries are read line-by-line, so no inline comments inside the heredoc.
 read -r -d '' NPM_CORE_PATHS << EOF || true
 .npm-cache
 $NODE_GYP_CACHE
@@ -82,6 +89,7 @@ remote/reh-web/node_modules
 test/integration/browser/node_modules
 test/monaco/node_modules
 test/mcp/node_modules
+ai-lib/packages/ai-config/dist
 EOF
 
 # ----------------------------------------------------------------------------

--- a/.github/cache-scripts/generate-package-locks-hash.sh
+++ b/.github/cache-scripts/generate-package-locks-hash.sh
@@ -128,11 +128,20 @@ buildScripts.forEach(f => console.error('  → ' + f));
 // cache on every bump, so a stale build is never restored. A package-lock.json
 // signal alone would miss source-only bumps (and ai-lib's lockfile isn't even
 // at the core-dir path -- it's the workspace root's).
-const { execSync } = require('child_process');
+// spawnSync with an argument array (never a shell string) so submodule paths
+// parsed from .gitmodules can't be interpreted as shell syntax.
+const { spawnSync } = require('child_process');
+const git = (args) => {
+  const r = spawnSync('git', args, { encoding: 'utf8' });
+  if (r.status !== 0) {
+    throw new Error('git ' + args.join(' ') + ' failed: ' + (r.stderr || '').trim());
+  }
+  return r.stdout;
+};
 
 let submodulePaths = [];
 try {
-  const out = execSync('git config --file .gitmodules --get-regexp path', { encoding: 'utf8' });
+  const out = git(['config', '--file', '.gitmodules', '--get-regexp', 'path']);
   submodulePaths = out.split('\n').map(l => l.trim().split(/\s+/)[1]).filter(Boolean);
 } catch {
   // No .gitmodules (or no submodules) -- nothing to fold in.
@@ -151,7 +160,7 @@ const submoduleGitlinks = [...submoduleRoots].sort().map(sub => ({
   sub,
   // Read the gitlink from the tree, so this works even when the submodule
   // isn't checked out. Throws loudly if a declared submodule can't resolve.
-  sha: execSync('git rev-parse HEAD:' + sub, { encoding: 'utf8' }).trim(),
+  sha: git(['rev-parse', 'HEAD:' + sub]).trim(),
 }));
 
 console.error('');

--- a/.github/cache-scripts/generate-package-locks-hash.sh
+++ b/.github/cache-scripts/generate-package-locks-hash.sh
@@ -8,6 +8,10 @@
 # The hash includes:
 # 1. All core package-lock.json files (dependency versions)
 # 2. Build scripts that affect postinstall behavior (what gets generated)
+# 3. Gitlink SHAs of submodules that host a core dir (e.g. ai-lib). Their build
+#    output is cached (see cache-paths.sh) and regenerated only on a submodule
+#    bump, which moves the gitlink SHA. Deps-only signals would miss source-only
+#    bumps and restore a stale build.
 #
 # When any of these change, the hash changes and cache invalidates.
 #
@@ -115,12 +119,55 @@ console.error('Hashing ' + buildScripts.length + ' build scripts:');
 buildScripts.forEach(f => console.error('  → ' + f));
 
 // ----------------------------------------------------------------------------
+// Step 3.5: Collect submodule gitlink SHAs for core dirs hosted in a submodule
+// ----------------------------------------------------------------------------
+// A core dir such as 'ai-lib/packages/ai-config' lives inside the ai-lib
+// submodule. Its build output is cached (cache-paths.sh) but is regenerated
+// only when the submodule is bumped, which moves the gitlink SHA the parent
+// repo records for that submodule. Folding that SHA into the key busts the
+// cache on every bump, so a stale build is never restored. A package-lock.json
+// signal alone would miss source-only bumps (and ai-lib's lockfile isn't even
+// at the core-dir path -- it's the workspace root's).
+const { execSync } = require('child_process');
+
+let submodulePaths = [];
+try {
+  const out = execSync('git config --file .gitmodules --get-regexp path', { encoding: 'utf8' });
+  submodulePaths = out.split('\n').map(l => l.trim().split(/\s+/)[1]).filter(Boolean);
+} catch {
+  // No .gitmodules (or no submodules) -- nothing to fold in.
+}
+
+const submoduleRoots = new Set();
+for (const dir of coreDirs) {
+  for (const sub of submodulePaths) {
+    if (dir === sub || dir.startsWith(sub + '/')) {
+      submoduleRoots.add(sub);
+    }
+  }
+}
+
+const submoduleGitlinks = [...submoduleRoots].sort().map(sub => ({
+  sub,
+  // Read the gitlink from the tree, so this works even when the submodule
+  // isn't checked out. Throws loudly if a declared submodule can't resolve.
+  sha: execSync('git rev-parse HEAD:' + sub, { encoding: 'utf8' }).trim(),
+}));
+
+console.error('');
+console.error('Hashing ' + submoduleGitlinks.length + ' submodule gitlink(s):');
+submoduleGitlinks.forEach(({ sub, sha }) => console.error('  → ' + sub + ' @ ' + sha));
+
+// ----------------------------------------------------------------------------
 // Step 4: Hash all files together
 // ----------------------------------------------------------------------------
 // Read each file and update the running hash. Sort order ensures deterministic hash.
 const hash = crypto.createHash('sha256');
 for (const file of [...lockFiles, ...buildScripts]) {
   hash.update(fs.readFileSync(file));
+}
+for (const { sub, sha } of submoduleGitlinks) {
+  hash.update(sub + ':' + sha);
 }
 
 const finalHash = hash.digest('hex');

--- a/build/npm/postinstall.ts
+++ b/build/npm/postinstall.ts
@@ -503,11 +503,18 @@ async function runWithConcurrency(tasks: (() => Promise<void>)[], concurrency: n
  * keyed on the ai-lib submodule gitlink) so full cache-hit runs that skip
  * postinstall entirely still get it restored.
  */
-async function buildAiConfig(): Promise<void> {
+async function buildAiConfig({ force }: { force: boolean }): Promise<void> {
 	const aiConfigDir = path.join(root, 'ai-lib', 'packages', 'ai-config');
 	if (!fs.existsSync(aiConfigDir)) {
 		// ai-lib submodule not checked out (e.g. a shallow/partial checkout that
 		// doesn't need it); nothing to build.
+		return;
+	}
+	// In the up-to-date fast path (force=false) skip the rebuild if dist/ is
+	// already present -- nothing changed, so rebuilding would just add tsc +
+	// generate-schema to every `npm install`. The full install path passes
+	// force=true because deps just changed and dist/ may be stale or absent.
+	if (!force && fs.existsSync(path.join(aiConfigDir, 'dist', 'index.js'))) {
 		return;
 	}
 	log('ai-lib/packages/ai-config', 'Building ai-config (generate-schema + tsc)...');
@@ -544,8 +551,9 @@ async function main() {
 		// so a cached/already-installed node_modules still gets repaired here.
 		await buildSqliteServerBinding();
 		// Likewise ensure ai-config's dist/ exists (the authentication extension
-		// imports it at compile time); tsc is incremental so this is cheap.
-		await buildAiConfig();
+		// imports it at compile time). Nothing changed, so skip the rebuild if
+		// it's already there.
+		await buildAiConfig({ force: false });
 		child_process.execSync('git config pull.rebase merges');
 		child_process.execSync('git config blame.ignoreRevsFile .git-blame-ignore-revs');
 		return;
@@ -666,8 +674,9 @@ async function main() {
 	await buildSqliteServerBinding();
 	// Build ai-config's dist/ (imported by the authentication extension at
 	// compile time). Kept here rather than in the authentication postinstall,
-	// which npm skips whenever that extension is restored from cache.
-	await buildAiConfig();
+	// which npm skips whenever that extension is restored from cache. Deps just
+	// changed, so force a rebuild rather than trusting a possibly-stale dist/.
+	await buildAiConfig({ force: true });
 	// --- End Positron ---
 
 	child_process.execSync('git config pull.rebase merges');

--- a/build/npm/postinstall.ts
+++ b/build/npm/postinstall.ts
@@ -485,6 +485,36 @@ async function runWithConcurrency(tasks: (() => Promise<void>)[], concurrency: n
 	}
 }
 
+// --- Start Positron ---
+/**
+ * Build the ai-config package (from the ai-lib submodule).
+ *
+ * ai-config emits dist/ via tsc, and the authentication extension imports it at
+ * COMPILE time (`import ... from 'ai-config/node'`, resolved by the package's
+ * exports map to dist/). The build used to be a side effect of the
+ * authentication extension's own postinstall, but npm skips that postinstall
+ * whenever the extension's node_modules is restored from cache -- so on
+ * cache-hit runs (the common case) dist/ was never built and compilation failed
+ * with "Cannot find module 'ai-config/node'".
+ *
+ * Building here -- next to the always-run buildSqliteServerBinding, in both the
+ * up-to-date and full postinstall paths -- makes dist/ deterministic regardless
+ * of the extension cache state. dist/ is also cached on its own (cache-paths.sh,
+ * keyed on the ai-lib submodule gitlink) so full cache-hit runs that skip
+ * postinstall entirely still get it restored.
+ */
+async function buildAiConfig(): Promise<void> {
+	const aiConfigDir = path.join(root, 'ai-lib', 'packages', 'ai-config');
+	if (!fs.existsSync(aiConfigDir)) {
+		// ai-lib submodule not checked out (e.g. a shallow/partial checkout that
+		// doesn't need it); nothing to build.
+		return;
+	}
+	log('ai-lib/packages/ai-config', 'Building ai-config (generate-schema + tsc)...');
+	await spawnAsync(npm, ['--prefix', 'ai-lib', 'run', 'build', '-w', 'ai-config'], { cwd: root });
+}
+// --- End Positron ---
+
 async function main() {
 	// --- Start Positron ---
 	// Sync the submodules before anything else — extensions install runs
@@ -513,6 +543,9 @@ async function main() {
 		// and cheap when the binary is already correct (see buildSqliteServerBinding),
 		// so a cached/already-installed node_modules still gets repaired here.
 		await buildSqliteServerBinding();
+		// Likewise ensure ai-config's dist/ exists (the authentication extension
+		// imports it at compile time); tsc is incremental so this is cheap.
+		await buildAiConfig();
 		child_process.execSync('git config pull.rebase merges');
 		child_process.execSync('git config blame.ignoreRevsFile .git-blame-ignore-revs');
 		return;
@@ -631,6 +664,10 @@ async function main() {
 	// The SQLite data driver's native binding must also load in the server/remote
 	// extension host (plain Node, a different ABI than the desktop Electron host).
 	await buildSqliteServerBinding();
+	// Build ai-config's dist/ (imported by the authentication extension at
+	// compile time). Kept here rather than in the authentication postinstall,
+	// which npm skips whenever that extension is restored from cache.
+	await buildAiConfig();
 	// --- End Positron ---
 
 	child_process.execSync('git config pull.rebase merges');

--- a/extensions/authentication/package.json
+++ b/extensions/authentication/package.json
@@ -24,9 +24,6 @@
 		"onCommand:authentication.migrateSettingsToProvidersJson"
 	],
 	"main": "./out/extension.js",
-	"scripts": {
-		"postinstall": "npm --prefix ../../ai-lib run build -w ai-config"
-	},
 	"dependencies": {
 		"@aws-sdk/credential-providers": "^3.734.0",
 		"@aws-sdk/types": "^3.734.0",


### PR DESCRIPTION
### Summary

Fixes `ai-config/dist` going missing on cache-hit CI runs, where the authentication extension fails to compile with `Cannot find module 'ai-config/node'`. Root cause is pre-existing from #14928; main breaks on cache-hit runs today.

- Build ai-config in `build/npm/postinstall.ts` (deterministic, alongside `buildSqliteServerBinding`) instead of `extensions/authentication`'s postinstall, which npm skips whenever that extension is restored from cache
- Cache `ai-lib/packages/ai-config/dist` in npm-core, keyed on the ai-lib submodule gitlink so a bump rebuilds it (deps-only signals miss source-only bumps)
- Use a `spawnSync` arg-array for the submodule gitlink git calls
- Drop the now-redundant postinstall from `extensions/authentication`

### QA Notes

CI-only; no runtime behavior change. Touches the assistant team's component (`authentication` build wiring). Prevention (making the uncached-artifacts guard blocking) is split to #15044, which lands after this.
