### PR TITLE
Fix Data Explorer wedging permanently after a failed cache update

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/common/tableDataCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/tableDataCache.ts
@@ -356,134 +356,188 @@ export class TableDataCache extends Disposable {
 		// Clear the trim cache timeout.
 		this.clearTrimCacheTimeout();
 
-		// Set the updating flag.
+		// Set the updating flag. This is cleared in the finally block below, even when a backend
+		// request rejects, so that a single failed update (e.g. a malformed get_row_labels request)
+		// cannot permanently wedge the cache and leave the grid blank. See
+		// https://github.com/posit-dev/positron/issues/12547.
 		this._updating = true;
+		try {
+			// Get the size of the data and whether it has row labels.
+			const tableState = await this._dataExplorerClientInstance.getBackendState();
+			this._columns = tableState.table_shape.num_columns;
+			this._rows = tableState.table_shape.num_rows;
+			this._hasRowLabels = tableState.has_row_labels;
 
-		// Get the size of the data and whether it has row labels.
-		const tableState = await this._dataExplorerClientInstance.getBackendState();
-		this._columns = tableState.table_shape.num_columns;
-		this._rows = tableState.table_shape.num_rows;
-		this._hasRowLabels = tableState.has_row_labels;
+			// If there are no columns, immediately fire an update and return,
+			// otherwise, continue on to fetch and cache the column schema.
+			// This check for columns is done before checking the number of rows
+			// to handle the case where a dataset has column headers but zero rows.
+			// See https://github.com/posit-dev/positron/issues/9619
+			if (this._columns === 0) {
+				// Clear existing caches for a clean display.
+				this._rowLabelCache.clear();
+				this._dataColumnCache.clear();
+				this._columnSchemaCache.clear();
 
-		// If there are no columns, immediately fire an update and return,
-		// otherwise, continue on to fetch and cache the column schema.
-		// This check for columns is done before checking the number of rows
-		// to handle the case where a dataset has column headers but zero rows.
-		// See https://github.com/posit-dev/positron/issues/9619
-		if (this._columns === 0) {
-			// Clear existing caches for a clean display.
-			this._rowLabelCache.clear();
-			this._dataColumnCache.clear();
-			this._columnSchemaCache.clear();
+				// Fire the update event before returning to ensure UI updates even with zero columns.
+				this._onDidUpdateEmitter.fire();
 
-			// Fire the update event before returning to ensure UI updates even with zero columns.
-			this._onDidUpdateEmitter.fire();
+				// Return.
+				return;
+			}
 
-			// Clear the updating flag.
-			this._updating = false;
+			// Set the invalidate cache flags.
+			const invalidateColumnSchemaCache = (updateDescriptor.invalidateCache & InvalidateCacheFlags.ColumnSchema) === InvalidateCacheFlags.ColumnSchema;
+			const invalidateDataCache = (updateDescriptor.invalidateCache & InvalidateCacheFlags.Data) === InvalidateCacheFlags.Data;
 
-			// Return.
-			return;
-		}
+			// Sort the column and row indices in the update descriptor.
+			updateDescriptor.columnIndices.sort((a, b) => a - b);
+			updateDescriptor.rowIndices.sort((a, b) => a - b);
 
-		// Set the invalidate cache flags.
-		const invalidateColumnSchemaCache = (updateDescriptor.invalidateCache & InvalidateCacheFlags.ColumnSchema) === InvalidateCacheFlags.ColumnSchema;
-		const invalidateDataCache = (updateDescriptor.invalidateCache & InvalidateCacheFlags.Data) === InvalidateCacheFlags.Data;
-
-		// Sort the column and row indices in the update descriptor.
-		updateDescriptor.columnIndices.sort((a, b) => a - b);
-		updateDescriptor.rowIndices.sort((a, b) => a - b);
-
-		// Set the column indices of the table schema we need to load.
-		let columnIndices: number[];
-		if (invalidateColumnSchemaCache) {
-			columnIndices = updateDescriptor.columnIndices;
-		} else {
-			columnIndices = [];
-			for (const index of updateDescriptor.columnIndices) {
-				if (!this._columnSchemaCache.has(index)) {
-					columnIndices.push(index);
+			// Set the column indices of the table schema we need to load.
+			let columnIndices: number[];
+			if (invalidateColumnSchemaCache) {
+				columnIndices = updateDescriptor.columnIndices;
+			} else {
+				columnIndices = [];
+				for (const index of updateDescriptor.columnIndices) {
+					if (!this._columnSchemaCache.has(index)) {
+						columnIndices.push(index);
+					}
 				}
 			}
-		}
 
-		// Clear the column schema cache, if we're supposed to.
-		if (invalidateColumnSchemaCache) {
-			this._columnSchemaCache.clear();
-		}
+			// Clear the column schema cache, if we're supposed to.
+			if (invalidateColumnSchemaCache) {
+				this._columnSchemaCache.clear();
+			}
 
-		// Load the table schema we need to load.
-		const tableSchema = await this._dataExplorerClientInstance.getSchema(columnIndices);
+			// Load the table schema we need to load.
+			const tableSchema = await this._dataExplorerClientInstance.getSchema(columnIndices);
 
-		// Cache the column schemas that were returned.
-		for (const columnSchema of tableSchema.columns) {
-			this._columnSchemaCache.set(columnSchema.column_index, columnSchema);
-		}
+			// Cache the column schemas that were returned.
+			for (const columnSchema of tableSchema.columns) {
+				this._columnSchemaCache.set(columnSchema.column_index, columnSchema);
+			}
 
-		// If there are no rows, immediately fire an update and return.
-		// This check is done after checking for columns to handle the case
-		// where a dataset has column headers but zero rows.
-		// See https://github.com/posit-dev/positron/issues/9619
-		if (this._rows === 0) {
-			// Clear existing data caches for a clean display.
-			this._rowLabelCache.clear();
-			this._dataColumnCache.clear();
+			// If there are no rows, immediately fire an update and return.
+			// This check is done after checking for columns to handle the case
+			// where a dataset has column headers but zero rows.
+			// See https://github.com/posit-dev/positron/issues/9619
+			if (this._rows === 0) {
+				// Clear existing data caches for a clean display.
+				this._rowLabelCache.clear();
+				this._dataColumnCache.clear();
 
-			// Fire the update event before returning to ensure UI updates with column headers.
+				// Fire the update event before returning to ensure UI updates with column headers.
+				this._onDidUpdateEmitter.fire();
+
+				// Return.
+				return;
+			}
+
+			// Fire the onDidUpdate event.
 			this._onDidUpdateEmitter.fire();
 
-			// Clear the updating flag.
-			this._updating = false;
+			// Determine whether the row indices are contiguous.
+			const rowIndicesAreContiguous = isContiguous(updateDescriptor.rowIndices);
 
-			// Return.
-			return;
-		}
-
-		// Fire the onDidUpdate event.
-		this._onDidUpdateEmitter.fire();
-
-		// Determine whether the row indices are contiguous.
-		const rowIndicesAreContiguous = isContiguous(updateDescriptor.rowIndices);
-
-		// Create the array selection spec.
-		let spec: ArraySelection;
-		if (rowIndicesAreContiguous) {
-			spec = {
-				first_index: updateDescriptor.rowIndices[0],
-				last_index: updateDescriptor.rowIndices[updateDescriptor.rowIndices.length - 1],
-			};
-		} else {
-			spec = {
-				indices: updateDescriptor.rowIndices,
-			};
-		}
-
-		// Build an array of the column selections to load.
-		const columnSelections: ColumnSelection[] = [];
-		if (invalidateDataCache) {
-			// The data cache is being invalidated. Load everything.
-			for (const columnIndex of updateDescriptor.columnIndices) {
-				columnSelections.push({
-					column_index: columnIndex,
-					spec
-				});
+			// Create the array selection spec.
+			let spec: ArraySelection;
+			if (rowIndicesAreContiguous) {
+				spec = {
+					first_index: updateDescriptor.rowIndices[0],
+					last_index: updateDescriptor.rowIndices[updateDescriptor.rowIndices.length - 1],
+				};
+			} else {
+				spec = {
+					indices: updateDescriptor.rowIndices,
+				};
 			}
-		} else {
-			// The data cache is not being invalidated. Load everything we don't have cached.
-			for (const columnIndex of updateDescriptor.columnIndices) {
-				const dataColumn = this._dataColumnCache.get(columnIndex);
-				if (!dataColumn) {
-					// The data column isn't cached. Load it.
+
+			// Build an array of the column selections to load.
+			const columnSelections: ColumnSelection[] = [];
+			if (invalidateDataCache) {
+				// The data cache is being invalidated. Load everything.
+				for (const columnIndex of updateDescriptor.columnIndices) {
 					columnSelections.push({
 						column_index: columnIndex,
 						spec
 					});
+				}
+			} else {
+				// The data cache is not being invalidated. Load everything we don't have cached.
+				for (const columnIndex of updateDescriptor.columnIndices) {
+					const dataColumn = this._dataColumnCache.get(columnIndex);
+					if (!dataColumn) {
+						// The data column isn't cached. Load it.
+						columnSelections.push({
+							column_index: columnIndex,
+							spec
+						});
+					} else {
+						// The data column is cached. Load any cells that are not cached.
+						let contiguous = true;
+						const rowIndices: number[] = [];
+						for (const rowIndex of updateDescriptor.rowIndices) {
+							if (!dataColumn.has(rowIndex)) {
+								// Add the index.
+								rowIndices.push(rowIndex);
+
+								// Check whether the indices are contiguous.
+								if (contiguous && rowIndices.length > 1 && rowIndices[rowIndices.length - 2] + 1 !== rowIndices[rowIndices.length - 1]) {
+									contiguous = false;
+								}
+							}
+						}
+
+						// If there are cells that are not cached, add the column and its spec.
+						if (rowIndices.length) {
+							if (contiguous) {
+								columnSelections.push({
+									column_index: columnIndex,
+									spec: {
+										first_index: rowIndices[0],
+										last_index: rowIndices[rowIndices.length - 1]
+									}
+								});
+							} else {
+								columnSelections.push({
+									column_index: columnIndex,
+									spec: {
+										indices: rowIndices
+									}
+								});
+							}
+						}
+					}
+				}
+			}
+
+			// Get the row labels.
+			let rowLabels: ArraySelection | undefined;
+			if (!tableState.has_row_labels || updateDescriptor.rowIndices.length === 0) {
+				// No row labels to fetch. The empty-selection case also guards against sending a
+				// malformed get_row_labels request with { indices: [] }, which the backend can reject
+				// (e.g. R matrices with row names). See https://github.com/posit-dev/positron/issues/12547.
+				rowLabels = undefined;
+			} else {
+				if (invalidateDataCache) {
+					if (rowIndicesAreContiguous) {
+						rowLabels = {
+							first_index: updateDescriptor.rowIndices[0],
+							last_index: updateDescriptor.rowIndices[updateDescriptor.rowIndices.length - 1],
+						};
+					} else {
+						rowLabels = {
+							indices: updateDescriptor.rowIndices
+						};
+					}
 				} else {
-					// The data column is cached. Load any cells that are not cached.
 					let contiguous = true;
 					const rowIndices: number[] = [];
 					for (const rowIndex of updateDescriptor.rowIndices) {
-						if (!dataColumn.has(rowIndex)) {
+						if (!this._rowLabelCache.has(rowIndex)) {
 							// Add the index.
 							rowIndices.push(rowIndex);
 
@@ -494,184 +548,136 @@ export class TableDataCache extends Disposable {
 						}
 					}
 
-					// If there are cells that are not cached, add the column and its spec.
-					if (rowIndices.length) {
-						if (contiguous) {
-							columnSelections.push({
-								column_index: columnIndex,
-								spec: {
-									first_index: rowIndices[0],
-									last_index: rowIndices[rowIndices.length - 1]
-								}
-							});
-						} else {
-							columnSelections.push({
-								column_index: columnIndex,
-								spec: {
-									indices: rowIndices
-								}
-							});
-						}
-					}
-				}
-			}
-		}
-
-		// Get the row labels.
-		let rowLabels: ArraySelection | undefined;
-		if (!tableState.has_row_labels) {
-			rowLabels = undefined;
-		} else {
-			if (invalidateDataCache) {
-				if (rowIndicesAreContiguous) {
-					rowLabels = {
-						first_index: updateDescriptor.rowIndices[0],
-						last_index: updateDescriptor.rowIndices[updateDescriptor.rowIndices.length - 1],
-					};
-				} else {
-					rowLabels = {
-						indices: updateDescriptor.rowIndices
-					};
-				}
-			} else {
-				let contiguous = true;
-				const rowIndices: number[] = [];
-				for (const rowIndex of updateDescriptor.rowIndices) {
-					if (!this._rowLabelCache.has(rowIndex)) {
-						// Add the index.
-						rowIndices.push(rowIndex);
-
-						// Check whether the indices are contiguous.
-						if (contiguous && rowIndices.length > 1 && rowIndices[rowIndices.length - 2] + 1 !== rowIndices[rowIndices.length - 1]) {
-							contiguous = false;
-						}
-					}
-				}
-
-				// If there are labels that are not cached,
-				if (!rowIndices.length) {
-					rowLabels = undefined;
-				} else {
-					if (contiguous) {
-						rowLabels = {
-							first_index: rowIndices[0],
-							last_index: rowIndices[rowIndices.length - 1]
-						};
+					// If there are labels that are not cached,
+					if (!rowIndices.length) {
+						rowLabels = undefined;
 					} else {
-						rowLabels = { indices: rowIndices };
+						if (contiguous) {
+							rowLabels = {
+								first_index: rowIndices[0],
+								last_index: rowIndices[rowIndices.length - 1]
+							};
+						} else {
+							rowLabels = { indices: rowIndices };
+						}
 					}
 				}
+
 			}
 
-		}
+			// Get the table row labels.
+			const tableRowLabels = !rowLabels ? undefined : await this._dataExplorerClientInstance.getRowLabels(rowLabels);
 
-		// Get the table row labels.
-		const tableRowLabels = !rowLabels ? undefined : await this._dataExplorerClientInstance.getRowLabels(rowLabels);
-
-		// Clear the data cache, if we're supposed to.
-		if (invalidateDataCache) {
-			this._rowLabelCache.clear();
-			this._dataColumnCache.clear();
-		}
-
-		// Get the data values
-		const tableData = await this._dataExplorerClientInstance.getDataValues(columnSelections);
-
-		// Update the data column cache.
-		for (let column = 0; column < tableData.columns.length; column++) {
-			// Get the column selection.
-			const columnSelection = columnSelections[column];
-
-			// Get or create the data column.
-			let dataColumn = this._dataColumnCache.get(columnSelection.column_index);
-			if (!dataColumn) {
-				dataColumn = new Map<number, DataCell>();
-				this._dataColumnCache.set(columnSelection.column_index, dataColumn);
+			// Clear the data cache, if we're supposed to.
+			if (invalidateDataCache) {
+				this._rowLabelCache.clear();
+				this._dataColumnCache.clear();
 			}
 
-			// Update the cell values.
-			for (let row = 0; row < tableData.columns[column].length; row++) {
-				// Get the cell value.
-				const value = tableData.columns[column][row];
+			// Get the data values
+			const tableData = await this._dataExplorerClientInstance.getDataValues(columnSelections);
 
-				// Convert the cell value into a data cell.
-				let dataCell: DataCell;
-				if (typeof value === 'number') {
-					dataCell = decodeSpecialValue(value);
-				} else {
-					dataCell = {
-						formatted: value,
-						kind: DataCellKind.NON_NULL
-					};
+			// Update the data column cache.
+			for (let column = 0; column < tableData.columns.length; column++) {
+				// Get the column selection.
+				const columnSelection = columnSelections[column];
+
+				// Get or create the data column.
+				let dataColumn = this._dataColumnCache.get(columnSelection.column_index);
+				if (!dataColumn) {
+					dataColumn = new Map<number, DataCell>();
+					this._dataColumnCache.set(columnSelection.column_index, dataColumn);
 				}
 
-				// Set the row index.
-				let rowIndex: number;
-				if (isDataSelectionRange(columnSelection.spec)) {
-					rowIndex = columnSelection.spec.first_index + row;
-				} else if (isDataSelectionIndices(columnSelection.spec)) {
-					rowIndex = columnSelection.spec.indices[row];
-				} else {
-					continue;
-				}
+				// Update the cell values.
+				for (let row = 0; row < tableData.columns[column].length; row++) {
+					// Get the cell value.
+					const value = tableData.columns[column][row];
 
-				// Cache the cell.
-				dataColumn.set(rowIndex, dataCell);
+					// Convert the cell value into a data cell.
+					let dataCell: DataCell;
+					if (typeof value === 'number') {
+						dataCell = decodeSpecialValue(value);
+					} else {
+						dataCell = {
+							formatted: value,
+							kind: DataCellKind.NON_NULL
+						};
+					}
+
+					// Set the row index.
+					let rowIndex: number;
+					if (isDataSelectionRange(columnSelection.spec)) {
+						rowIndex = columnSelection.spec.first_index + row;
+					} else if (isDataSelectionIndices(columnSelection.spec)) {
+						rowIndex = columnSelection.spec.indices[row];
+					} else {
+						continue;
+					}
+
+					// Cache the cell.
+					dataColumn.set(rowIndex, dataCell);
+				}
 			}
-		}
 
-		// Update the row labels cache.
-		if (rowLabels && tableRowLabels) {
-			for (let row = 0; row < tableRowLabels.row_labels[0].length; row++) {
-				// Set the row index.
-				let rowIndex: number;
-				if (isDataSelectionRange(rowLabels)) {
-					rowIndex = rowLabels.first_index + row;
-				} else if (isDataSelectionIndices(rowLabels)) {
-					rowIndex = rowLabels.indices[row];
-				} else {
-					continue;
+			// Update the row labels cache.
+			if (rowLabels && tableRowLabels) {
+				for (let row = 0; row < tableRowLabels.row_labels[0].length; row++) {
+					// Set the row index.
+					let rowIndex: number;
+					if (isDataSelectionRange(rowLabels)) {
+						rowIndex = rowLabels.first_index + row;
+					} else if (isDataSelectionIndices(rowLabels)) {
+						rowIndex = rowLabels.indices[row];
+					} else {
+						continue;
+					}
+
+					// Cache the row label.
+					this._rowLabelCache.set(rowIndex, tableRowLabels.row_labels[0][row]);
 				}
-
-				// Cache the row label.
-				this._rowLabelCache.set(rowIndex, tableRowLabels.row_labels[0][row]);
 			}
-		}
 
-		// Fire the onDidUpdate event.
-		this._onDidUpdateEmitter.fire();
+			// Fire the onDidUpdate event.
+			this._onDidUpdateEmitter.fire();
 
-		// Clear the updating flag.
-		this._updating = false;
+			// Schedule trimming the cache.
+			if (updateDescriptor.invalidateCache !== InvalidateCacheFlags.All) {
+				// Set the trim cache timeout.
+				this._trimCacheTimeout = setTimeout(() => {
+					// Release the trim cache timeout.
+					this._trimCacheTimeout = undefined;
 
-		// If there's a pending update descriptor, update the cache again.
-		if (this._pendingUpdateDescriptor) {
-			// Get the pending update descriptor and clear it.
-			const pendingUpdateDescriptor = this._pendingUpdateDescriptor;
-			this._pendingUpdateDescriptor = undefined;
+					// Trim the column schema cache, if it wasn't invalidated.
+					const columnIndices = new Set(updateDescriptor.columnIndices);
+					if (!invalidateColumnSchemaCache) {
+						this.trimColumnSchemaCache(columnIndices);
+					}
 
-			// Update the cache for the pending update descriptor.
-			return this.update(pendingUpdateDescriptor);
-		}
+					// Trim the data cache, if it wasn't invalidated.
+					if (!invalidateDataCache) {
+						this.trimDataCache(columnIndices, new Set(updateDescriptor.rowIndices));
+					}
+				}, TRIM_CACHE_TIMEOUT);
+			}
+		} catch (error) {
+			// Log and swallow. Rethrowing would skip draining the pending descriptor below, which
+			// would stall scroll-driven updates after a failed backend request.
+			console.error('Failed to update the table data cache:', error);
+		} finally {
+			// Clear the updating flag.
+			this._updating = false;
 
-		// Schedule trimming the cache.
-		if (updateDescriptor.invalidateCache !== InvalidateCacheFlags.All) {
-			// Set the trim cache timeout.
-			this._trimCacheTimeout = setTimeout(() => {
-				// Release the trim cache timeout.
-				this._trimCacheTimeout = undefined;
+			// If an update arrived while this one was in flight, process it now so that scrolling
+			// continues to load rows even after a failure.
+			if (this._pendingUpdateDescriptor) {
+				// Get the pending update descriptor and clear it.
+				const pendingUpdateDescriptor = this._pendingUpdateDescriptor;
+				this._pendingUpdateDescriptor = undefined;
 
-				// Trim the column schema cache, if it wasn't invalidated.
-				const columnIndices = new Set(updateDescriptor.columnIndices);
-				if (!invalidateColumnSchemaCache) {
-					this.trimColumnSchemaCache(columnIndices);
-				}
-
-				// Trim the data cache, if it wasn't invalidated.
-				if (!invalidateDataCache) {
-					this.trimDataCache(columnIndices, new Set(updateDescriptor.rowIndices));
-				}
-			}, TRIM_CACHE_TIMEOUT);
+				// Update the cache for the pending update descriptor.
+				await this.update(pendingUpdateDescriptor);
+			}
 		}
 	}
 

--- a/src/vs/workbench/services/positronDataExplorer/common/tableDataCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/tableDataCache.ts
@@ -565,9 +565,6 @@ export class TableDataCache extends Disposable {
 
 			}
 
-			// Get the table row labels.
-			const tableRowLabels = !rowLabels ? undefined : await this._dataExplorerClientInstance.getRowLabels(rowLabels);
-
 			// Clear the data cache, if we're supposed to.
 			if (invalidateDataCache) {
 				this._rowLabelCache.clear();
@@ -620,21 +617,30 @@ export class TableDataCache extends Disposable {
 				}
 			}
 
-			// Update the row labels cache.
-			if (rowLabels && tableRowLabels) {
-				for (let row = 0; row < tableRowLabels.row_labels[0].length; row++) {
-					// Set the row index.
-					let rowIndex: number;
-					if (isDataSelectionRange(rowLabels)) {
-						rowIndex = rowLabels.first_index + row;
-					} else if (isDataSelectionIndices(rowLabels)) {
-						rowIndex = rowLabels.indices[row];
-					} else {
-						continue;
-					}
+			// Load and cache the row labels. Row labels are secondary to the cell data, so this is done
+			// after the data above has been cleared, refetched, and cached, and its failure is isolated
+			// here. A rejected getRowLabels then degrades to missing labels rather than aborting the data
+			// refresh and leaving stale cells on screen. See https://github.com/posit-dev/positron/issues/12547.
+			if (rowLabels) {
+				try {
+					const tableRowLabels = await this._dataExplorerClientInstance.getRowLabels(rowLabels);
+					for (let row = 0; row < tableRowLabels.row_labels[0].length; row++) {
+						// Set the row index.
+						let rowIndex: number;
+						if (isDataSelectionRange(rowLabels)) {
+							rowIndex = rowLabels.first_index + row;
+						} else if (isDataSelectionIndices(rowLabels)) {
+							rowIndex = rowLabels.indices[row];
+						} else {
+							continue;
+						}
 
-					// Cache the row label.
-					this._rowLabelCache.set(rowIndex, tableRowLabels.row_labels[0][row]);
+						// Cache the row label.
+						this._rowLabelCache.set(rowIndex, tableRowLabels.row_labels[0][row]);
+					}
+				} catch (error) {
+					// Log and continue; the cell data above is already loaded.
+					console.error('Failed to load table row labels:', error);
 				}
 			}
 

--- a/src/vs/workbench/services/positronDataExplorer/test/common/tableDataCache.vitest.ts
+++ b/src/vs/workbench/services/positronDataExplorer/test/common/tableDataCache.vitest.ts
@@ -104,6 +104,26 @@ describe('TableDataCache', () => {
 		});
 	});
 
+	it('refreshes invalidated data even when the row-labels request fails', async () => {
+		ensureNoLeakedDisposables();
+
+		// Seed the cache, then invalidate. On an invalidating refresh (e.g. a sort or filter change)
+		// the data cache is cleared and refetched. A row-labels failure during that refresh must not
+		// abort the data path, otherwise the grid keeps showing the stale pre-invalidation cells.
+		getDataValues
+			.mockResolvedValueOnce({ columns: [['old'], ['old']] })
+			.mockResolvedValue({ columns: [['new'], ['new']] });
+
+		// First update caches "old".
+		await cache.update({ invalidateCache: InvalidateCacheFlags.Data, columnIndices: [0, 1], rowIndices: [0, 1] });
+
+		// Invalidating refresh whose row-labels fetch rejects. The cells must still update to "new".
+		getRowLabels.mockRejectedValueOnce(new Error('row.names should be strings, got 0'));
+		await cache.update({ invalidateCache: InvalidateCacheFlags.Data, columnIndices: [0, 1], rowIndices: [0, 1] });
+
+		expect(cache.getDataCell(0, 0)?.formatted).toBe('new');
+	});
+
 	it('drains the pending update queued while the in-flight update fails', async () => {
 		ensureNoLeakedDisposables();
 

--- a/src/vs/workbench/services/positronDataExplorer/test/common/tableDataCache.vitest.ts
+++ b/src/vs/workbench/services/positronDataExplorer/test/common/tableDataCache.vitest.ts
@@ -1,0 +1,165 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { InvalidateCacheFlags, TableDataCache } from '../../common/tableDataCache.js';
+import { getColumnSchema } from '../../common/positronDataExplorerMocks.js';
+import { DataExplorerClientInstance } from '../../../languageRuntime/common/languageRuntimeDataExplorerClient.js';
+import { ensureNoLeakedDisposables } from '../../../../../test/vitest/vitestUtils.js';
+import {
+	BackendState,
+	ColumnDisplayType,
+	ColumnSelection,
+	SupportStatus,
+	TableData,
+	TableRowLabels,
+	TableSchema
+} from '../../../languageRuntime/common/positronDataExplorerComm.js';
+
+/**
+ * Builds a backend state advertising `has_row_labels`, as a matrix with row names does. The cache
+ * only reads the table shape and this flag, so the rest is filler.
+ */
+function backendState(hasRowLabels: boolean): BackendState {
+	return {
+		display_name: 'test-table',
+		table_shape: { num_rows: 100, num_columns: 2 },
+		table_unfiltered_shape: { num_rows: 100, num_columns: 2 },
+		has_row_labels: hasRowLabels,
+		column_filters: [],
+		row_filters: [],
+		sort_keys: [],
+		supported_features: {
+			search_schema: { support_status: SupportStatus.Supported, supported_types: [] },
+			set_column_filters: { support_status: SupportStatus.Supported, supported_types: [] },
+			set_row_filters: { support_status: SupportStatus.Supported, supports_conditions: SupportStatus.Supported, supported_types: [] },
+			get_column_profiles: { support_status: SupportStatus.Supported, supported_types: [] },
+			export_data_selection: { support_status: SupportStatus.Supported, supported_formats: [] },
+			set_sort_columns: { support_status: SupportStatus.Supported },
+			convert_to_code: { support_status: SupportStatus.Supported }
+		}
+	};
+}
+
+describe('TableDataCache', () => {
+	let getBackendState: ReturnType<typeof vi.fn>;
+	let getRowLabels: ReturnType<typeof vi.fn>;
+	let getDataValues: ReturnType<typeof vi.fn>;
+	let cache: TableDataCache;
+
+	beforeEach(() => {
+		const state = backendState(true);
+
+		getBackendState = vi.fn().mockResolvedValue(state);
+		// Resolve schema for exactly the requested indices.
+		const getSchema = vi.fn(async (indices: number[]): Promise<TableSchema> => ({
+			columns: indices.map(i => getColumnSchema(`col${i}`, i, 'number', ColumnDisplayType.Floating))
+		}));
+		// Return one formatted value per requested cell so the data cache is populated.
+		getDataValues = vi.fn(async (columns: ColumnSelection[]): Promise<TableData> => ({
+			columns: columns.map(() => ['1'])
+		}));
+		// Return one row label per selection.
+		getRowLabels = vi.fn(async (): Promise<TableRowLabels> => ({ row_labels: [['A']] }));
+
+		const client: Partial<DataExplorerClientInstance> = {
+			getBackendState: getBackendState as DataExplorerClientInstance['getBackendState'],
+			getSchema: getSchema as DataExplorerClientInstance['getSchema'],
+			getDataValues: getDataValues as DataExplorerClientInstance['getDataValues'],
+			getRowLabels: getRowLabels as DataExplorerClientInstance['getRowLabels'],
+		};
+
+		cache = new TableDataCache(client as DataExplorerClientInstance);
+	});
+
+	afterEach(() => {
+		cache.dispose();
+	});
+
+	it('keeps processing updates after a rejected row-labels request', async () => {
+		ensureNoLeakedDisposables();
+
+		// The first update's row-labels fetch rejects. This used to throw out of update() before the
+		// updating flag was cleared, permanently wedging the cache so every later update parked itself
+		// behind the in-progress guard and the grid never repainted (posit-dev/positron#12547).
+		getRowLabels.mockRejectedValueOnce(new Error('row.names should be strings, got 0'));
+
+		await cache.update({ invalidateCache: InvalidateCacheFlags.Data, columnIndices: [0, 1], rowIndices: [0, 1] });
+
+		// Despite the failure, a subsequent update (as the user scrolls) is processed rather than
+		// silently dropped, and its data and row labels are cached.
+		await cache.update({ invalidateCache: InvalidateCacheFlags.Data, columnIndices: [0, 1], rowIndices: [0, 1] });
+
+		expect({
+			dataCached: cache.getDataCell(0, 0)?.formatted,
+			rowLabelCached: cache.getRowLabel(0),
+			rowLabelRequests: getRowLabels.mock.calls.length,
+		}).toEqual({
+			dataCached: '1',
+			rowLabelCached: 'A',
+			rowLabelRequests: 2,
+		});
+	});
+
+	it('drains the pending update queued while the in-flight update fails', async () => {
+		ensureNoLeakedDisposables();
+
+		// This is the actual #12547 flow. On open, the first cache update runs before the viewport
+		// rows are laid out and fails; while it is in flight the real viewport update arrives and parks
+		// as the pending descriptor. Before the fix, the failure left the updating flag stuck and the
+		// pending update never ran, so the grid stayed blank. The recovery must happen through the
+		// pending-descriptor drain, not a fresh caller-driven update.
+
+		// Gate the first update's backend-state fetch so the second update arrives while it is parked.
+		let signalFirstStarted!: () => void;
+		const firstStarted = new Promise<void>(resolve => { signalFirstStarted = resolve; });
+		let releaseFirst!: () => void;
+		const firstGate = new Promise<void>(resolve => { releaseFirst = resolve; });
+
+		let callIndex = 0;
+		getBackendState.mockImplementation(async () => {
+			if (callIndex++ === 0) {
+				signalFirstStarted();
+				await firstGate;
+			}
+			return backendState(true);
+		});
+		// The first (in-flight) update fails on its row-labels fetch; the pending update then succeeds.
+		getRowLabels.mockRejectedValueOnce(new Error('row.names should be strings, got 0'));
+
+		// First update: parks on the gated backend-state fetch. Not awaited yet.
+		const firstPass = cache.update({ invalidateCache: InvalidateCacheFlags.Data, columnIndices: [0, 1], rowIndices: [0, 1] });
+		await firstStarted;
+
+		// Second update arrives while the first is in flight, so it parks as the pending descriptor.
+		void cache.update({ invalidateCache: InvalidateCacheFlags.Data, columnIndices: [0, 1], rowIndices: [2, 3] });
+
+		// Let the first update finish and fail; the pending second update must drain and load its data.
+		releaseFirst();
+		await firstPass;
+
+		expect({
+			pendingUpdateData: cache.getDataCell(0, 2)?.formatted,
+			pendingUpdateLabel: cache.getRowLabel(2),
+			rowLabelRequests: getRowLabels.mock.calls.length,
+		}).toEqual({
+			pendingUpdateData: '1',
+			pendingUpdateLabel: 'A',
+			rowLabelRequests: 2,
+		});
+	});
+
+	it('does not request row labels when the row selection is empty', async () => {
+		ensureNoLeakedDisposables();
+
+		// On open, the first cache update runs before the viewport rows are laid out, so it carries an
+		// empty row selection. Sending get_row_labels with { indices: [] } is what the backend rejects,
+		// so the cache must not issue that request at all.
+		await cache.update({ invalidateCache: InvalidateCacheFlags.Data, columnIndices: [0, 1], rowIndices: [] });
+
+		expect(getRowLabels).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
This is the Positron-side hardening half of the fix for #12547. The Ark root-cause fix is posit-dev/ark#1357.

### Summary

When the Data Explorer opens, the first cache update can run before the viewport rows are laid out, so it carries an empty row selection. For a backend that reports row labels (an R matrix with row names does), that produced a malformed `get_row_labels` request that the backend rejected. `TableDataCache.update()` set its in-progress flag with no `try/finally`, so the rejected request threw out of the method before the flag was cleared. Every subsequent update (scrolling, resizing, sorting) then parked itself behind the in-progress guard and returned, so the grid never repainted: it stayed blank even though the next request would have succeeded.

This PR hardens `TableDataCache.update()` so a single failed backend request degrades one paint instead of permanently wedging the viewer:

- Wrap the update body in `try/catch/finally` so the in-progress flag is always cleared and the pending-update descriptor still drains, even when a backend request rejects. This mirrors the same hardening already applied to `TableSummaryCache.update()`. This makes the git diff look bigger than the substance of the change here!
- Skip the `get_row_labels` request entirely when the row selection is empty, so the malformed request is never sent.
- Decouple row-label loading from cell-data loading. On an invalidating refresh (sort or filter), row labels are now fetched after the data cache is cleared, refetched, and repopulated, and a row-labels failure is isolated so it degrades to missing labels instead of aborting the data refresh and leaving stale cells on screen.

Either side alone unblanks the viewer. The two changes are independent and can land in either order.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed the Data Explorer grid remaining blank after a failed backend request (#12547).

### Validation Steps

@:data-explorer

Automated: `npx vitest run src/vs/workbench/services/positronDataExplorer/test/common/tableDataCache.vitest.ts` covers flag-clear on rejection, pending-descriptor drain on failure, the empty-selection skip, and data-refresh isolation from row-label failures.

Manual (the un-blanking is verifiable against the current vendored Ark):

1. In an R session, confirm the grid renders instead of showing blank:

   ```r
   m <- matrix(1:4, nrow = 2)
   rownames(m) <- c("A", "B")
   View(m)
   ```

<img width="1402" height="1003" alt="Screenshot 2026-07-21 at 7 09 26 PM" src="https://github.com/user-attachments/assets/d01af619-5780-461c-bbe6-fd959d833252" />


2. Scroll after opening a larger matrix and confirm it keeps repainting:

   ```r
   big <- matrix(1:2000, ncol = 2)
   rownames(big) <- paste0("r", 1:1000)
   View(big)
   ```

3. Confirm regressions are unaffected: `View(matrix(1:4, nrow = 2))` (no row names), `View(mtcars)`, and `View(iris)` all render normally.
