### PR TITLE
build: fix ai-config build spawn EINVAL on Windows

### DIFF
--- a/build/npm/postinstall.ts
+++ b/build/npm/postinstall.ts
@@ -42,10 +42,19 @@ function spawnAsync(command: string, args: string[], opts: child_process.SpawnOp
 		let output = '';
 		child.stdout?.on('data', (data: Buffer) => { output += data.toString(); });
 		child.stderr?.on('data', (data: Buffer) => { output += data.toString(); });
-		child.on('error', reject);
-		child.on('close', (code) => {
+		// Name the command and cwd on failure so a crash points at the process that
+		// died. Concurrent installs interleave output, and a bare "exited with code"
+		// (e.g. a native module aborting with the Windows 0xC0000409 / 3221226505 exit
+		// code) doesn't say which dir crashed; the cwd is what identifies it.
+		const where = opts.cwd ? ` (cwd: ${opts.cwd})` : '';
+		const commandLine = `${command} ${args.join(' ')}`.trim();
+		child.on('error', (err) => {
+			reject(new Error(`Failed to spawn "${commandLine}"${where}: ${err.message}`));
+		});
+		child.on('close', (code, signal) => {
 			if (code !== 0) {
-				reject(new Error(`Process exited with code: ${code}\n${output}`));
+				const sig = signal ? `, signal: ${signal}` : '';
+				reject(new Error(`Command "${commandLine}"${where} exited with code: ${code}${sig}\n${output}`));
 			} else {
 				resolve(output);
 			}

--- a/build/npm/postinstall.ts
+++ b/build/npm/postinstall.ts
@@ -518,7 +518,9 @@ async function buildAiConfig({ force }: { force: boolean }): Promise<void> {
 		return;
 	}
 	log('ai-lib/packages/ai-config', 'Building ai-config (generate-schema + tsc)...');
-	await spawnAsync(npm, ['--prefix', 'ai-lib', 'run', 'build', '-w', 'ai-config'], { cwd: root });
+	// shell: true is required on Windows, where `npm` resolves to npm.cmd -- Node's
+	// child_process.spawn refuses to launch a .cmd directly (EINVAL) without it.
+	await spawnAsync(npm, ['--prefix', 'ai-lib', 'run', 'build', '-w', 'ai-config'], { cwd: root, shell: true });
 }
 // --- End Positron ---
 


### PR DESCRIPTION
### Summary

Fixes Windows CI failing at "Install node dependencies" after #15043, and improves diagnostics for a separate pre-existing Windows install flake.

- Add `shell: true` to the `buildAiConfig` spawn -- `npm` resolves to `npm.cmd` on Windows and Node rejects launching a `.cmd` without a shell (`spawn EINVAL`); this was the deterministic #15043 regression
- Name the command + cwd (+ signal) on `spawnAsync` failures so a crash during the concurrent extension installs points at the offending dir instead of a bare `Process exited with code: N`

### QA Notes

CI-only; no runtime behavior change. The second change is diagnostic groundwork for the pre-existing `0xC0000409` / `3221226505` crash in the extensions install (predates #15043, intermittent, retry usually recovers). @:win