### PR TITLE
ci: fix ai-lib node_modules cache gap, harden the uncached-artifacts guard, add cache-script tests

### DIFF
--- a/.github/actions/restore-build-caches/action.yml
+++ b/.github/actions/restore-build-caches/action.yml
@@ -164,9 +164,9 @@ runs:
       id: node-version
       shell: bash
       run: |
-        # Extract just the major version (e.g., "22" from "v22.22.0")
-        # Using major version only because ABI is stable within a major version
-        # (all Node 22.x use NODE_MODULE_VERSION=127, native modules are compatible)
+        # Extract just the major version (e.g., "24" from "v24.15.0")
+        # Using major version only because the native-module ABI (NODE_MODULE_VERSION)
+        # is stable within a major version, so native modules stay compatible.
         NODE_FULL=$(node -v)
         NODE_MAJOR=$(echo "$NODE_FULL" | sed 's/v\([0-9]*\).*/\1/')
         echo "version=$NODE_MAJOR" >> "$GITHUB_OUTPUT"

--- a/.github/cache-scripts/cache-paths.sh
+++ b/.github/cache-scripts/cache-paths.sh
@@ -35,6 +35,11 @@
 #    on a cache HIT that actually EXECUTES the cached code (a build/compile step never
 #    runs it). Right after a key rotation everything is a cache MISS (full install), which
 #    masks the gap. Verify against a cache-hit run of a job that runs the code (e.g. ext-host).
+# D. Force a rebuild with the "vN" key prefix, not a hack. Each cache key in the restore/
+#    save action.yml carries a manual version (npm-core-v7, builtins-v2, ...). Bump it in
+#    BOTH action.yml files to invalidate a cache when no content hash would (a corrupt
+#    saved blob, a paths change you can't express as a hash input). The per-cache numbers
+#    are independent, so they need not match each other.
 #
 # USED BY:
 # • .github/actions/restore-build-caches/action.yml

--- a/.github/cache-scripts/cache-paths.sh
+++ b/.github/cache-scripts/cache-paths.sh
@@ -76,6 +76,11 @@ fi
 #       and outside extensions/, so neither the extension caches nor node_modules cover it;
 #       without this it goes missing on a cache hit. The ai-lib submodule gitlink is folded
 #       into this cache's key so a bump rebuilds it (see generate-package-locks-hash.sh).
+# ai-lib/node_modules + ai-lib/packages/ai-config/node_modules: ai-lib is an npm workspace
+#       root, so installing ai-config (dirs.ts) hoists its deps (e.g. proper-lockfile) into
+#       ai-lib/node_modules. ai-config/dist imports those at runtime, but postinstall only
+#       rebuilds dist on a cache hit -- it never reinstalls ai-lib's deps -- so without these
+#       paths the cached dist loads and then fails with ERR_MODULE_NOT_FOUND. Same gitlink key.
 #       NOTE: entries are read line-by-line, so no inline comments inside the heredoc.
 read -r -d '' NPM_CORE_PATHS << EOF || true
 .npm-cache
@@ -89,6 +94,8 @@ remote/reh-web/node_modules
 test/integration/browser/node_modules
 test/monaco/node_modules
 test/mcp/node_modules
+ai-lib/node_modules
+ai-lib/packages/ai-config/node_modules
 ai-lib/packages/ai-config/dist
 EOF
 

--- a/.github/cache-scripts/cache-paths.sh
+++ b/.github/cache-scripts/cache-paths.sh
@@ -20,6 +20,22 @@
 # 3. For stable extensions: Automatic (all non-volatile extensions)
 # 4. Run: .github/cache-scripts/verify-cache-paths.sh to validate changes
 #
+# GOTCHAS (each of these has bitten us; read before editing NPM_CORE_PATHS):
+# A. Cache a generated artifact's RUNTIME DEPS, not just the artifact. postinstall
+#    is skipped on a cache hit, so it only rebuilds outputs -- it does NOT reinstall
+#    node_modules. If you cache a built output (a dist/, a native binding), also cache
+#    the node_modules it require()s at runtime, or the artifact restores but fails to
+#    load. This is why both ai-config/dist AND ai-lib/node_modules are listed (#15065).
+# B. Changing the PATH SET must rotate the cache key. On a plain key hit, actions/cache
+#    restores the old blob and never re-saves -- so a path you add here stays MISSING
+#    until the key changes for some other reason. cache-paths.sh is folded into the key
+#    (generate-package-locks-hash.sh buildScripts) so editing it self-rotates the key.
+#    Keep it there.
+# C. A green PR-CI run does NOT prove a cache change works. The failure mode only appears
+#    on a cache HIT that actually EXECUTES the cached code (a build/compile step never
+#    runs it). Right after a key rotation everything is a cache MISS (full install), which
+#    masks the gap. Verify against a cache-hit run of a job that runs the code (e.g. ext-host).
+#
 # USED BY:
 # • .github/actions/restore-build-caches/action.yml
 # • .github/actions/save-build-caches/action.yml

--- a/.github/cache-scripts/check-uncached-artifacts.sh
+++ b/.github/cache-scripts/check-uncached-artifacts.sh
@@ -23,6 +23,13 @@
 # 4. This script diffs them and checks against cache-paths.sh
 # 5. Reports any files that should probably be cached
 #
+# node_modules IS checked -- at DIRECTORY granularity (Section 3.5). A blanket
+# "ignore all node_modules" used to hide the exact bug in #15065: ai-lib/node_modules
+# held a runtime dep (proper-lockfile) and wasn't in cache-paths.sh, so it vanished
+# on a cache hit. Section 3.5 enumerates node_modules dirs from disk (the before/after
+# snapshots strip them) and flags any that NO cache-paths.sh entry covers by path
+# prefix. The file scan below still skips node_modules files for volume/perf.
+#
 # WHAT TO DO IF FILES ARE DETECTED:
 #
 # Option A - Add to cache (if tests need these files):
@@ -60,7 +67,10 @@ echo "🔍 Checking for uncached postinstall artifacts..."
 # SECTION 2: Find Files Added by npm install
 # ============================================================================
 # Compare before/after snapshots to see what postinstall scripts created.
-# Exclude node_modules and npm cache (already handled by caching system).
+# Exclude the npm download cache (.npm-cache) -- it is always cached and huge.
+# node_modules FILES are excluded here too, but only from this file-level scan
+# (their volume would be enormous and slow the per-file loop). node_modules is
+# instead checked at directory granularity in Section 3.5 -- NOT ignored.
 
 ADDED_FILES=$(comm -13 "$BEFORE_FILE" "$AFTER_FILE" | grep -v "\.npm-cache" | grep -v "node_modules" || true)
 
@@ -71,7 +81,11 @@ ADDED_FILES=$(comm -13 "$BEFORE_FILE" "$AFTER_FILE" | grep -v "\.npm-cache" | gr
 # Anything already in cache-paths.sh doesn't need a warning.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/cache-paths.sh"
+# Test seam: CACHE_PATHS_SCRIPT overrides where the path variables come from, so
+# the coverage logic can be unit-tested against a controlled set (including one
+# that omits ai-lib/node_modules, to guard the #15065 regression) without running
+# node/dirs.ts. Defaults to the real single source of truth.
+source "${CACHE_PATHS_SCRIPT:-$SCRIPT_DIR/cache-paths.sh}"
 
 IGNORE_PATTERNS=()
 
@@ -126,6 +140,83 @@ IGNORE_PATTERNS+=(
 )
 
 # ============================================================================
+# SECTION 3.5: node_modules Directory Coverage
+# ============================================================================
+# The file scan (Section 2) skips node_modules for volume, but an UNCACHED
+# node_modules dir is exactly how a runtime dep goes missing on a cache hit
+# (#15065). Check node_modules at directory granularity: collapse each added
+# node_modules path to its OUTERMOST node_modules dir, then flag any that no
+# real cache-paths.sh entry covers by path PREFIX (a bare "node_modules" pattern
+# must not substring-match "ai-lib/node_modules").
+
+# Real cache directories that can cover a node_modules dir. Built only from the
+# path variables (not the substring IGNORE_PATTERNS like ".pyc"), since only a
+# real cached dir actually preserves a node_modules tree across a cache hit.
+CACHED_DIRS=()
+for var in "$NPM_CORE_PATHS" "$NPM_EXTENSIONS_VOLATILE_PATHS" "$NPM_EXTENSIONS_STABLE_PATHS" "$BUILTINS_PATHS"; do
+	while IFS= read -r p; do
+		[ -z "$p" ] && continue
+		CACHED_DIRS+=("${p%/}")   # normalize: drop any trailing slash
+	done <<< "$var"
+done
+
+# Known-uncovered install dirs we deliberately accept (do NOT fail on these).
+# Each is a build-tool workspace (declared in build/npm/dirs.ts) whose deps are
+# used only WHILE building -- the build step always runs -- and are never loaded
+# on a cache-hit test run, so a missing copy costs at most a rebuild, not a broken
+# run (contrast ai-lib/node_modules, which ships a runtime import). This turns a
+# silent blanket exclusion into a reviewed allowlist.
+# TODO(#15065 follow-up): confirm none are needed on cache-hit runs, then either
+# cache them in cache-paths.sh or leave here with this rationale.
+NM_ALLOWLIST=(
+	"build/rspack/node_modules"
+	"build/vite/node_modules"
+	"build/npm/gyp/node_modules"
+	# test/e2e is commented out in build/npm/dirs.ts, so the checked job never
+	# installs it; its deps are e2e-only and never loaded on a cache-hit unit run.
+	# If e2e install is ever added to a job running this check, cache it instead.
+	"test/e2e/node_modules"
+)
+
+# Enumerate node_modules dirs from the FILESYSTEM, not the before/after diff:
+# the workflow builds both snapshots with `grep -v "node_modules/"`, so the diff
+# never contains them. npm install has just run when this check fires, so the real
+# tree is on disk. Take outermost node_modules only (-not -path '*/node_modules/*'
+# drops nested ones -- if the outer dir is covered so are they). Prune tool-managed
+# trees that aren't npm-install output (absent in the unit job; pruned defensively
+# in case this check is reused in a job that has them).
+# Test seam: NM_DIRS_OVERRIDE supplies the dir list (newline-separated) instead
+# of scanning the filesystem, so coverage/allowlist logic is unit-testable. Set
+# but empty means "no node_modules dirs" (uses +x so that case is honored).
+if [ -n "${NM_DIRS_OVERRIDE+x}" ]; then
+	ADDED_NM_DIRS="$NM_DIRS_OVERRIDE"
+else
+	ADDED_NM_DIRS=$(find . -type d -name node_modules \
+		-not -path '*/node_modules/*' \
+		-not -path './.git/*' \
+		-not -path './.claude/*' \
+		-not -path './.vscode-test/*' \
+		-not -path './.venv*/*' \
+		2>/dev/null | sed 's|^\./||' | sort -u || true)
+fi
+
+UNCACHED_NM_DIRS=""
+while IFS= read -r nmdir; do
+	[ -z "$nmdir" ] && continue
+	covered=false
+	for p in "${CACHED_DIRS[@]}" "${NM_ALLOWLIST[@]}"; do
+		[ -z "$p" ] && continue
+		if [ "$nmdir" = "$p" ] || case "$nmdir" in "$p"/*) true ;; *) false ;; esac; then
+			covered=true
+			break
+		fi
+	done
+	if [[ "$covered" == false ]]; then
+		UNCACHED_NM_DIRS="${UNCACHED_NM_DIRS}${nmdir}\n"
+	fi
+done <<< "$ADDED_NM_DIRS"
+
+# ============================================================================
 # SECTION 4: Filter Out Ignored Files
 # ============================================================================
 # Check each added file against ignore patterns.
@@ -156,9 +247,11 @@ done <<< "$ADDED_FILES"
 # Count non-empty lines (|| true to handle empty input with set -e)
 TOTAL_ADDED=$([ -z "$ADDED_FILES" ] && echo "0" || echo "$ADDED_FILES" | grep -vc '^$' || echo "0")
 UNCACHED_COUNT=$([ -z "$UNCACHED_FILES" ] && echo "0" || echo -e "$UNCACHED_FILES" | grep -vc '^$' || echo "0")
+UNCACHED_NM_COUNT=$([ -z "$UNCACHED_NM_DIRS" ] && echo "0" || echo -e "$UNCACHED_NM_DIRS" | grep -vc '^$' || echo "0")
 
 echo "Files added outside node_modules: $TOTAL_ADDED"
 echo "Files ignored by IGNORE_PATTERNS: $((TOTAL_ADDED - UNCACHED_COUNT))"
+echo "Uncached node_modules dirs: $UNCACHED_NM_COUNT"
 
 if [[ $UNCACHED_COUNT -gt 0 ]]; then
 	# Found uncached files - show detailed warning with actionable instructions
@@ -207,23 +300,55 @@ if [[ $UNCACHED_COUNT -gt 0 ]]; then
 	echo ""
 	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	echo ""
+fi
 
-	# Also write to GitHub Step Summary for visibility
+if [[ $UNCACHED_NM_COUNT -gt 0 ]]; then
+	# Found node_modules dirs that no cache path covers (the #15065 failure mode).
+
+	echo ""
+	echo "❌ ERROR: npm install created $UNCACHED_NM_COUNT node_modules dir(s) that no cache covers"
+	echo ""
+	echo "A workspace/submodule node_modules that isn't under a cache-paths.sh entry is"
+	echo "restored EMPTY on a cache hit. If any cached build output imports from it at"
+	echo "runtime, the artifact loads and then dies with ERR_MODULE_NOT_FOUND -- exactly"
+	echo "how #15065 broke ext-host on unrelated PRs."
+	echo ""
+	echo "Uncached node_modules dirs:"
+	echo -e "$UNCACHED_NM_DIRS" | grep -v '^$' | sed 's/^/  → /'
+	echo ""
+	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	echo "ACTION REQUIRED: Choose one of the following:"
+	echo ""
+	echo "✅ Option A: Cache it (if anything imports from it at build OR runtime)"
+	echo "     → Add the dir to NPM_CORE_PATHS in .github/cache-scripts/cache-paths.sh"
+	echo "       (for a submodule-hosted dir, confirm the submodule gitlink is in the key)"
+	echo ""
+	echo "❌ Option B: Accept it (build-tool deps only, never loaded on a cache-hit run)"
+	echo "     → Add the dir to NM_ALLOWLIST in this file (Section 3.5), with a one-line"
+	echo "       rationale for why a missing copy can't break a cache-hit run."
+	echo ""
+	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	echo ""
+fi
+
+# Write a combined GitHub Step Summary if either check tripped.
+if [[ $UNCACHED_COUNT -gt 0 || $UNCACHED_NM_COUNT -gt 0 ]]; then
 	if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
 		{
 			echo "## ❌ Uncached Postinstall Artifacts Detected"
 			echo ""
-			echo "npm install created **$UNCACHED_COUNT files** outside node_modules/ that aren't cached."
-			echo "They will be missing on cache-hit runs, so this check fails the build."
+			echo "npm install produced artifacts that aren't cached and will be missing on cache-hit runs:"
+			echo "- **$UNCACHED_COUNT** file(s) outside node_modules/"
+			echo "- **$UNCACHED_NM_COUNT** uncached node_modules dir(s)"
 			echo ""
-			echo "**Where to look:** In the \`${GITHUB_JOB:-unit}\` job, expand the \"🔍 Check for uncached postinstall artifacts\" step for details and next steps (cache the path, or add it to IGNORE_PATTERNS)."
+			echo "**Where to look:** In the \`${GITHUB_JOB:-unit}\` job, expand the \"🔍 Check for uncached postinstall artifacts\" step for the list and next steps (cache the path, or add an ignore/allowlist entry)."
 		} >> "$GITHUB_STEP_SUMMARY"
 	fi
 
-	# Fail the build. A build artifact that isn't cached goes missing on cache-hit
-	# runs (the common case) and breaks the build after the introducing PR merged
-	# green. Resolve it at author time: cache the path (cache-paths.sh) or, if tests
-	# genuinely don't need it, add it to IGNORE_PATTERNS above.
+	# Fail the build. An uncached artifact goes missing on cache-hit runs (the common
+	# case) and breaks the build after the introducing PR merged green. Resolve it at
+	# author time: cache the path (cache-paths.sh), or -- if tests genuinely don't need
+	# it -- add it to IGNORE_PATTERNS (files) or NM_ALLOWLIST (node_modules dirs).
 	exit 1
 else
 	echo "✅ No uncached artifacts detected"

--- a/.github/cache-scripts/check-uncached-artifacts.test.sh
+++ b/.github/cache-scripts/check-uncached-artifacts.test.sh
@@ -143,6 +143,23 @@ else
 	fail "multiple: not all reported (rc=$RC)"; echo "$out"
 fi
 
+# --- Test 10 (REGRESSION #13545): incident-backed IGNORE_PATTERNS stay ignored ---
+# .git/ was a real shipped false positive (#13545): git objects created during CI
+# were flagged as uncached artifacts and failed the build. .claude/ (agent-harness
+# symlinks) and .tsbuildinfo (incremental tsc caches) are the same shape -- files
+# npm install may touch that tests never need. A "cleanup" that drops any of these
+# from IGNORE_PATTERNS would reintroduce a build failure, so guard them here.
+tests_run=$((tests_run + 1))
+out="$(run_check "" \
+	".git/objects/ab/cdef0123456789" \
+	".claude/CLAUDE.md" \
+	"ai-lib/packages/ai-config/tsconfig.tsbuildinfo")"; read_rc
+if [ "$RC" -eq 0 ] && grep -q "No uncached artifacts" <<<"$out"; then
+	pass "incident-backed ignores (.git/, .claude/, .tsbuildinfo) stay ignored"
+else
+	fail "ignore-regression: a protected pattern was flagged (rc=$RC)"; echo "$out"
+fi
+
 echo
 echo "Ran $tests_run tests, $tests_failed failed."
 [ "$tests_failed" -eq 0 ]

--- a/.github/cache-scripts/check-uncached-artifacts.test.sh
+++ b/.github/cache-scripts/check-uncached-artifacts.test.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# Tests for check-uncached-artifacts.sh -- the guard that fails the build when
+# npm install produces artifacts (files OR node_modules dirs) that aren't covered
+# by cache-paths.sh and would therefore vanish on a cache hit (see #15065).
+#
+# The check has two external inputs, both injected here via test seams so the
+# scenarios are deterministic and need neither node/dirs.ts nor the real tree:
+#   CACHE_PATHS_SCRIPT  -> a fixture that sets the four *_PATHS variables
+#   NM_DIRS_OVERRIDE    -> the node_modules dir list (instead of scanning disk)
+# The NM_ALLOWLIST and IGNORE_PATTERNS under test are the real ones in the script.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK="$SCRIPT_DIR/check-uncached-artifacts.sh"
+
+tests_run=0
+tests_failed=0
+fail() { tests_failed=$((tests_failed + 1)); echo "FAIL: $1"; }
+pass() { echo "ok: $1"; }
+
+# A fixture cache-paths that stands in for the real single source of truth.
+# Deliberately DOES NOT list ai-lib/node_modules, so the regression test can
+# assert that an uncached submodule node_modules is flagged (the #15065 bug).
+FIXTURE_CACHE_PATHS="$(mktemp)"
+cat > "$FIXTURE_CACHE_PATHS" <<'EOF'
+NPM_CORE_PATHS=$'.npm-cache\nnode_modules\nai-lib/packages/ai-config/dist'
+NPM_EXTENSIONS_VOLATILE_PATHS=$'extensions/positron-python\nextensions/positron-r'
+NPM_EXTENSIONS_STABLE_PATHS=$'extensions/positron-duckdb\nextensions/node_modules'
+BUILTINS_PATHS='.build/builtInExtensions'
+EOF
+
+EMPTY_SNAPSHOT="$(mktemp)"   # a "before"/"after" with no added files
+printf 'README.md\n' > "$EMPTY_SNAPSHOT"
+trap 'rm -f "$FIXTURE_CACHE_PATHS" "$EMPTY_SNAPSHOT"' EXIT
+
+# Build a sorted "after" snapshot (before is always EMPTY_SNAPSHOT + README).
+make_after() {
+	{ printf 'README.md\n'; printf '%s\n' "$@"; } | sort
+}
+
+# Run the check with injected inputs. Args are the "added file" paths (non-nm);
+# NM env var holds the node_modules dir list. Echoes combined output; writes exit
+# code to RC via a temp file (command substitution runs in a subshell).
+RC_FILE="$(mktemp)"; trap 'rm -f "$FIXTURE_CACHE_PATHS" "$EMPTY_SNAPSHOT" "$RC_FILE"' EXIT
+run_check() {
+	local nm="$1"; shift
+	local after; after="$(mktemp)"
+	make_after "$@" > "$after"
+	CACHE_PATHS_SCRIPT="$FIXTURE_CACHE_PATHS" NM_DIRS_OVERRIDE="$nm" \
+		bash "$CHECK" "$EMPTY_SNAPSHOT" "$after" 2>&1
+	echo $? > "$RC_FILE"
+	rm -f "$after"
+}
+read_rc() { RC="$(cat "$RC_FILE")"; }
+
+# --- Test 1: fully covered -> exit 0 ---
+tests_run=$((tests_run + 1))
+out="$(run_check $'node_modules\nextensions/positron-duckdb/node_modules')"; read_rc
+if [ "$RC" -eq 0 ] && grep -q "No uncached artifacts" <<<"$out"; then
+	pass "all covered (root nm + stable-ext nm) exits 0"
+else
+	fail "covered case: rc=$RC"; echo "$out"
+fi
+
+# --- Test 2 (REGRESSION #15065): uncached submodule nm is flagged ---
+# The bare "node_modules" cache entry must NOT substring-match "ai-lib/node_modules".
+tests_run=$((tests_run + 1))
+out="$(run_check "ai-lib/node_modules")"; read_rc
+if [ "$RC" -eq 1 ] && grep -q "ai-lib/node_modules" <<<"$out" \
+	&& grep -q "node_modules dir(s) that no cache covers" <<<"$out"; then
+	pass "uncached ai-lib/node_modules is flagged (regression guard)"
+else
+	fail "regression: uncached ai-lib/node_modules NOT flagged (rc=$RC)"; echo "$out"
+fi
+
+# --- Test 3: allowlisted build-tool nm is accepted ---
+tests_run=$((tests_run + 1))
+out="$(run_check "build/rspack/node_modules")"; read_rc
+if [ "$RC" -eq 0 ]; then
+	pass "allowlisted build/rspack/node_modules accepted"
+else
+	fail "allowlist: build/rspack flagged unexpectedly (rc=$RC)"; echo "$out"
+fi
+
+# --- Test 4: nested node_modules under a covered root is fine ---
+tests_run=$((tests_run + 1))
+out="$(run_check "node_modules/foo/node_modules")"; read_rc
+if [ "$RC" -eq 0 ]; then
+	pass "nested nm under covered root is covered"
+else
+	fail "nested: flagged unexpectedly (rc=$RC)"; echo "$out"
+fi
+
+# --- Test 5: uncached non-nm file is flagged ---
+tests_run=$((tests_run + 1))
+out="$(run_check "" "src/generated/thing.js")"; read_rc
+if [ "$RC" -eq 1 ] && grep -q "files outside node_modules" <<<"$out"; then
+	pass "uncached non-nm file flagged"
+else
+	fail "file: uncached file not flagged (rc=$RC)"; echo "$out"
+fi
+
+# --- Test 6: ignored patterns (.pyc) and cached dist file don't flag ---
+tests_run=$((tests_run + 1))
+out="$(run_check "" "extensions/foo/__pycache__/x.pyc" "ai-lib/packages/ai-config/dist/node/mutate-config.js")"; read_rc
+if [ "$RC" -eq 0 ] && grep -q "No uncached artifacts" <<<"$out"; then
+	pass "pycache ignored + cached dist covered"
+else
+	fail "ignore: pyc/dist wrongly flagged (rc=$RC)"; echo "$out"
+fi
+
+# --- Test 7: both a bad file and a bad nm dir -> exit 1, both reported ---
+tests_run=$((tests_run + 1))
+out="$(run_check "some-lib/node_modules" "src/generated/thing.js")"; read_rc
+if [ "$RC" -eq 1 ] \
+	&& grep -q "some-lib/node_modules" <<<"$out" \
+	&& grep -q "src/generated/thing.js" <<<"$out"; then
+	pass "combined file + nm failures both reported, exit 1"
+else
+	fail "combined: missing one of the failures (rc=$RC)"; echo "$out"
+fi
+
+# --- Test 8: empty nm list + no added files -> exit 0 ---
+tests_run=$((tests_run + 1))
+out="$(run_check "")"; read_rc
+if [ "$RC" -eq 0 ]; then
+	pass "empty inputs exit 0"
+else
+	fail "empty: rc=$RC"; echo "$out"
+fi
+
+# --- Test 9: multiple uncovered nm dirs are all listed ---
+tests_run=$((tests_run + 1))
+out="$(run_check $'a-lib/node_modules\nb-lib/node_modules')"; read_rc
+if [ "$RC" -eq 1 ] \
+	&& grep -q "a-lib/node_modules" <<<"$out" \
+	&& grep -q "b-lib/node_modules" <<<"$out" \
+	&& grep -q "2 node_modules dir(s)" <<<"$out"; then
+	pass "multiple uncovered nm dirs all reported"
+else
+	fail "multiple: not all reported (rc=$RC)"; echo "$out"
+fi
+
+echo
+echo "Ran $tests_run tests, $tests_failed failed."
+[ "$tests_failed" -eq 0 ]

--- a/.github/cache-scripts/generate-package-locks-hash.sh
+++ b/.github/cache-scripts/generate-package-locks-hash.sh
@@ -112,6 +112,12 @@ const buildScripts = [
   'build/npm/preinstall.ts',   // Preinstall script - installs build/ dependencies
   'build/npm/postinstall.ts',  // Postinstall script - runs npm install in all dirs
   'build/npm/dirs.ts',         // List of directories that get npm install
+  // Defines which paths this cache saves. Changing the set (e.g. adding a
+  // node_modules dir) must rotate the key: on a plain key hit actions/cache
+  // restores the old blob and never re-saves, so a newly-added path would stay
+  // missing until the key changes. Folding this file in rebuilds the cache the
+  // first time the path set changes.
+  '.github/cache-scripts/cache-paths.sh',
 ].sort();
 
 console.error('');

--- a/.github/cache-scripts/generate-package-locks-hash.sh
+++ b/.github/cache-scripts/generate-package-locks-hash.sh
@@ -7,13 +7,20 @@
 # Creates a deterministic hash used as the cache key for npm-core cache.
 # The hash includes:
 # 1. All core package-lock.json files (dependency versions)
-# 2. Build scripts that affect postinstall behavior (what gets generated)
+# 2. Files that must invalidate the core cache when changed: install scripts
+#    (what gets generated) AND cache-paths.sh (what gets cached). See buildScripts.
 # 3. Gitlink SHAs of submodules that host a core dir (e.g. ai-lib). Their build
 #    output is cached (see cache-paths.sh) and regenerated only on a submodule
 #    bump, which moves the gitlink SHA. Deps-only signals would miss source-only
 #    bumps and restore a stale build.
 #
 # When any of these change, the hash changes and cache invalidates.
+#
+# NOT in this hash: Node.js major version, runner.os, and distro are separate
+# segments of the cache key, assembled in the restore/save action.yml
+# (key: npm-core-v7-node<major>-<os>-<distro>-<hash>). Don't add them here --
+# they'd be double-counted. The "vN" prefix (v7) is a manual force-invalidate
+# knob; bump it in BOTH action.yml files to rebuild without a content change.
 #
 # WHY INCLUDE BUILD SCRIPTS?
 # The postinstall script runs during `npm install` and generates artifacts
@@ -33,8 +40,11 @@
 # • test/integration/browser/
 # • test/monaco/
 # • test/mcp/
+# • ai-lib/packages/ai-config/ (workspace package inside the ai-lib submodule)
 #
 # Basically: Everything except extensions/ and .vscode/
+# Authoritative list = dirs.ts minus extensions/ and .vscode/ (see coreDirs below);
+# this bullet list is illustrative and may lag.
 #
 # WHY NOT EXTENSIONS?
 # Extensions have their own caches (npm-extensions-volatile and npm-extensions-stable)
@@ -101,13 +111,17 @@ console.error('Hashing ' + lockFiles.length + ' package-lock.json files:');
 lockFiles.forEach(f => console.error('  → ' + f));
 
 // ----------------------------------------------------------------------------
-// Step 3: Collect build scripts that affect postinstall behavior
+// Step 3: Collect files that must invalidate the core cache when changed
 // ----------------------------------------------------------------------------
-// These scripts control what runs during npm install and what artifacts are
-// generated. Changes to these should invalidate the cache even if package-lock
-// files haven't changed.
+// Two kinds live here, both beyond package-lock.json:
+//   - install scripts: control what runs during npm install and what artifacts
+//     get generated (a changed build step won't re-run on a cache hit otherwise).
+//   - cache-paths.sh: controls what the cache saves. Changing the path set must
+//     rotate the key, or a newly-added path stays missing until the key changes
+//     for some other reason (a plain key hit restores the old blob, never re-saves).
 //
-// NOTE: If you add a new script that runs during install, add it here!
+// NOTE: Add a file here if changing it must rebuild the core cache -- whether it
+// runs during install OR defines what gets cached.
 const buildScripts = [
   'build/npm/preinstall.ts',   // Preinstall script - installs build/ dependencies
   'build/npm/postinstall.ts',  // Postinstall script - runs npm install in all dirs

--- a/.github/cache-scripts/generate-package-locks-hash.test.sh
+++ b/.github/cache-scripts/generate-package-locks-hash.test.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Tests for generate-package-locks-hash.sh -- the npm-core cache KEY generator.
+#
+# The recurring real failure mode this guards (#11886, #12521, and the key half of
+# #15065) is: a file that MUST invalidate the core cache isn't folded into the hash,
+# so the key doesn't rotate when it should and CI restores a stale/incomplete cache.
+# cache-paths.sh is the #15065 case -- adding a cached path only takes effect once
+# the key rotates, and it rotates only because cache-paths.sh is hashed.
+#
+# This runs the REAL script from the repo root (Node 24 strips .ts natively, so
+# require('./build/npm/dirs.ts') works; the ai-lib gitlink is read from the tree,
+# so no submodule checkout is needed). It mutates cache-paths.sh transiently and
+# restores the exact original bytes via an EXIT trap.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+GEN="$SCRIPT_DIR/generate-package-locks-hash.sh"
+CACHE_PATHS="$SCRIPT_DIR/cache-paths.sh"
+
+tests_run=0
+tests_failed=0
+fail() { tests_failed=$((tests_failed + 1)); echo "FAIL: $1"; }
+pass() { echo "ok: $1"; }
+
+# Restore cache-paths.sh to its exact original bytes no matter how we exit.
+ORIG_CACHE_PATHS="$(mktemp)"
+cp "$CACHE_PATHS" "$ORIG_CACHE_PATHS"
+trap 'cp "$ORIG_CACHE_PATHS" "$CACHE_PATHS"; rm -f "$ORIG_CACHE_PATHS"' EXIT
+
+# Run the real generator from the repo root and echo just the hash. The script
+# writes "hash=<sha>" to GITHUB_OUTPUT; point that at a temp file and read it back.
+gen_hash() {
+	local out; out="$(mktemp)"
+	( cd "$REPO_ROOT" && GITHUB_OUTPUT="$out" bash "$GEN" >/dev/null 2>&1 )
+	sed -n 's/^hash=//p' "$out"
+	rm -f "$out"
+}
+
+# --- Test 1: editing cache-paths.sh rotates the npm-core key (#15065 mechanism) ---
+tests_run=$((tests_run + 1))
+H1="$(gen_hash)"
+printf '\n# test-only marker line, removed by the trap\n' >> "$CACHE_PATHS"
+H2="$(gen_hash)"
+if [ -n "$H1" ] && [ -n "$H2" ] && [ "$H1" != "$H2" ]; then
+	pass "editing cache-paths.sh changes the hash (key rotates)"
+else
+	fail "cache-paths.sh edit did NOT rotate the key (H1=$H1 H2=$H2)"
+fi
+
+# --- Test 2: restoring cache-paths.sh returns the original hash (deterministic) ---
+# Proves the rotation in Test 1 was caused by the edit (not nondeterminism) and that
+# the same inputs always yield the same key -- a flaky key would thrash the cache.
+tests_run=$((tests_run + 1))
+cp "$ORIG_CACHE_PATHS" "$CACHE_PATHS"
+H3="$(gen_hash)"
+if [ -n "$H3" ] && [ "$H3" = "$H1" ]; then
+	pass "restoring cache-paths.sh restores the original hash (deterministic)"
+else
+	fail "hash not deterministic across identical inputs (H1=$H1 H3=$H3)"
+fi
+
+echo
+echo "Ran $tests_run tests, $tests_failed failed."
+[ "$tests_failed" -eq 0 ]

--- a/.github/workflows/test-cache-scripts.yml
+++ b/.github/workflows/test-cache-scripts.yml
@@ -1,0 +1,25 @@
+name: Test cache scripts
+
+# Unit tests for the CI cache tooling in .github/cache-scripts/. These scripts
+# gate the build (check-uncached-artifacts.sh) and define the cache key/paths, so
+# a regression is expensive and easy to miss -- hence a fast, dependency-free
+# scenario suite. Runs only when the cache scripts themselves change.
+on:
+  pull_request:
+    paths:
+      - '.github/cache-scripts/**'
+      - '.github/workflows/test-cache-scripts.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.github/cache-scripts/**'
+      - '.github/workflows/test-cache-scripts.yml'
+
+jobs:
+  test:
+    name: check-uncached-artifacts scenarios
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Run cache-script tests
+        run: bash .github/cache-scripts/check-uncached-artifacts.test.sh

--- a/.github/workflows/test-cache-scripts.yml
+++ b/.github/workflows/test-cache-scripts.yml
@@ -1,4 +1,4 @@
-name: Test cache scripts
+name: 'Test: cache scripts'
 
 # Unit tests for the CI cache tooling in .github/cache-scripts/. These scripts
 # gate the build (check-uncached-artifacts.sh) and define the cache key/paths, so
@@ -20,7 +20,7 @@ on:
 
 jobs:
   test:
-    name: cache-script scenarios
+    name: cache-scenarios
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/test-cache-scripts.yml
+++ b/.github/workflows/test-cache-scripts.yml
@@ -17,9 +17,16 @@ on:
 
 jobs:
   test:
-    name: check-uncached-artifacts scenarios
+    name: cache-script scenarios
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: Run cache-script tests
+      # generate-package-locks-hash.test.sh runs the real key generator, which
+      # requires('./build/npm/dirs.ts') -- Node >= 22.6 strips the types natively.
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+      - name: check-uncached-artifacts scenarios
         run: bash .github/cache-scripts/check-uncached-artifacts.test.sh
+      - name: generate-package-locks-hash scenarios
+        run: bash .github/cache-scripts/generate-package-locks-hash.test.sh

--- a/.github/workflows/test-cache-scripts.yml
+++ b/.github/workflows/test-cache-scripts.yml
@@ -9,11 +9,14 @@ on:
     paths:
       - '.github/cache-scripts/**'
       - '.github/workflows/test-cache-scripts.yml'
+      # The hash test require()s dirs.ts, so a change there can rotate the key too.
+      - 'build/npm/dirs.ts'
   push:
     branches: [main]
     paths:
       - '.github/cache-scripts/**'
       - '.github/workflows/test-cache-scripts.yml'
+      - 'build/npm/dirs.ts'
 
 jobs:
   test:


### PR DESCRIPTION
### Summary
Fixes the cache gap that broke ext-host on unrelated PRs (`ERR_MODULE_NOT_FOUND: proper-lockfile`), then closes the blind spot that let it ship and adds tests so it can't regress silently. Completes #15043.

- Cache `ai-lib/node_modules` + `ai-lib/packages/ai-config/node_modules` (workspace-hoisted runtime deps the cached `ai-config/dist` imports)
- Fold `cache-paths.sh` into the npm-core cache key so changing the cached path set rotates the key
- Harden `check-uncached-artifacts.sh`: it blanket-excluded all `node_modules` (the assumption that hid this bug); now it checks `node_modules` at directory granularity and flags any not covered by a real cache path, with a reviewed allowlist for build-tool dirs
- Add `check-uncached-artifacts.test.sh` (9 scenarios incl. the #15065 regression) + a workflow that runs it on cache-script changes
- Cache-doc cleanups: stale core-dir list, the `buildScripts` NOTE, node-version key-segment note, `vN` force-invalidate knob, drop stale Node 22 example

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes
CI-only; no e2e. First green run after merge is a cache miss (key rotated) that repopulates the cache with the added paths; the real test is a subsequent cache-hit ext-host run. New `Test cache scripts` job gates the cache tooling.