### PR TITLE
fix: defer ipywidgets notebook attach until its editor exists

### DIFF
--- a/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
+++ b/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
@@ -258,7 +258,7 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 				if (isEqual(session.metadata.notebookUri, e?.uri)) {
 					return;
 				}
-				this._logService.debug(`Editor model changed for session '${session.sessionId}, disposing ipywidgets instance`);
+				this._logService.debug(`Editor model changed for session '${session.sessionId}', disposing ipywidgets instance`);
 				disposables.dispose();
 			}));
 
@@ -267,7 +267,7 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 				if (e !== notebookEditor) {
 					return;
 				}
-				this._logService.debug(`Notebook editor removed for session '${session.sessionId}, disposing ipywidgets instance`);
+				this._logService.debug(`Notebook editor removed for session '${session.sessionId}', disposing ipywidgets instance`);
 				disposables.dispose();
 			}));
 		};

--- a/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
+++ b/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
@@ -7,6 +7,7 @@ import { ILanguageRuntimeMessageClearOutput, ILanguageRuntimeMessageError, ILang
 import { ILanguageRuntimeSession, IRuntimeClientInstance, IRuntimeSessionService, RuntimeClientType } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { IPositronIPyWidgetsService } from '../../../services/positronIPyWidgets/common/positronIPyWidgetsService.js';
+import { INotebookEditor } from '../../notebook/browser/notebookBrowser.js';
 import { INotebookEditorService } from '../../notebook/browser/services/notebookEditorService.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
@@ -234,52 +235,69 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 	}
 
 	private attachNotebookSession(session: ILanguageRuntimeSession, disposables: DisposableStore) {
+		// Bind the ipywidgets instance to a matching notebook editor.
+		const attachToEditor = (notebookEditor: INotebookEditor) => {
+			this._logService.debug(`Found a notebook editor for session '${session.sessionId}', starting ipywidgets instance`);
+
+			// We found a matching notebook editor, create an ipywidgets instance.
+			const { messaging, instance } = this.createWidgetInstance(
+				session,
+				notebookEditor.getId()
+			);
+			disposables.add(messaging);
+			disposables.add(instance);
+			this._notebookInstancesBySessionId.set(session.sessionId, instance);
+
+			// Unregister the instance when the session is disposed.
+			disposables.add(toDisposable(() => {
+				this._notebookInstancesBySessionId.delete(session.sessionId);
+			}));
+
+			// Dispose when the notebook text model changes.
+			disposables.add(notebookEditor.onDidChangeModel((e) => {
+				if (isEqual(session.metadata.notebookUri, e?.uri)) {
+					return;
+				}
+				this._logService.debug(`Editor model changed for session '${session.sessionId}, disposing ipywidgets instance`);
+				disposables.dispose();
+			}));
+
+			// Dispose when the notebook editor is removed.
+			disposables.add(this._notebookEditorService.onDidRemoveNotebookEditor((e) => {
+				if (e !== notebookEditor) {
+					return;
+				}
+				this._logService.debug(`Notebook editor removed for session '${session.sessionId}, disposing ipywidgets instance`);
+				disposables.dispose();
+			}));
+		};
+
+		// Dispose when the session ends. Registered up front so a session that
+		// ends before its editor appears still tears down the deferred listener.
+		disposables.add(session.onDidEndSession((e) => {
+			disposables.dispose();
+		}));
+
 		// For built-in notebooks: find the session's notebook editor by its notebook URI.
 		const notebookEditor = this._notebookEditorService.listNotebookEditors().find(
 			(editor) => isEqual(session.metadata.notebookUri, editor.textModel?.uri));
 
-		if (!notebookEditor) {
-			this._logService.error(`Could not find a notebook editor for session '${session.sessionId}'`);
+		if (notebookEditor) {
+			attachToEditor(notebookEditor);
 			return;
 		}
 
-		this._logService.debug(`Found an existing notebook editor for session '${session.sessionId}, starting ipywidgets instance`);
-
-		// We found a matching notebook editor, create an ipywidgets instance.
-		const { messaging, instance } = this.createWidgetInstance(
-			session,
-			notebookEditor.getId()
-		);
-		disposables.add(messaging);
-		disposables.add(instance);
-		this._notebookInstancesBySessionId.set(session.sessionId, instance);
-
-		// Unregister the instance when the session is disposed.
-		disposables.add(toDisposable(() => {
-			this._notebookInstancesBySessionId.delete(session.sessionId);
-		}));
-
-		// Dispose when the notebook text model changes.
-		disposables.add(notebookEditor.onDidChangeModel((e) => {
-			if (isEqual(session.metadata.notebookUri, e?.uri)) {
+		// The editor may not exist yet: the session can re-register before its
+		// editor is recreated (e.g. after a window reload). Defer the attach
+		// until a matching editor appears instead of giving up here, which
+		// would leave the widget permanently unrendered.
+		this._logService.debug(`No notebook editor yet for session '${session.sessionId}', waiting for one to appear`);
+		const deferredAttach = disposables.add(this._notebookEditorService.onDidAddNotebookEditor((editor) => {
+			if (!isEqual(session.metadata.notebookUri, editor.textModel?.uri)) {
 				return;
 			}
-			this._logService.debug(`Editor model changed for session '${session.sessionId}, disposing ipywidgets instance`);
-			disposables.dispose();
-		}));
-
-		// Dispose when the notebook editor is removed.
-		disposables.add(this._notebookEditorService.onDidRemoveNotebookEditor((e) => {
-			if (e !== notebookEditor) {
-				return;
-			}
-			this._logService.debug(`Notebook editor removed for session '${session.sessionId}, disposing ipywidgets instance`);
-			disposables.dispose();
-		}));
-
-		// Dispose when the session ends.
-		disposables.add(session.onDidEndSession((e) => {
-			disposables.dispose();
+			deferredAttach.dispose();
+			attachToEditor(editor);
 		}));
 	}
 

--- a/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
+++ b/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
@@ -2,7 +2,7 @@
  *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
-import { Disposable, DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableMap, DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { ILanguageRuntimeMessageClearOutput, ILanguageRuntimeMessageError, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessageResult, ILanguageRuntimeMessageStream, LanguageRuntimeMessageType, LanguageRuntimeSessionMode, RuntimeOutputKind, RuntimeState } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, IRuntimeClientInstance, IRuntimeSessionService, RuntimeClientType } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
@@ -72,7 +72,7 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 	override dispose(): void {
 		super.dispose();
 		// Clean up disposables linked to any connected sessions
-		this._sessionToDisposablesMap.forEach(disposables => disposables.dispose());
+		this._sessionToDisposablesMap.dispose();
 	}
 
 	/**
@@ -166,7 +166,7 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 	 * repeatedly attaching to the same session which can happen in the case of the application
 	 * closing before the session ends
 	 */
-	private _sessionToDisposablesMap = new Map<string, DisposableStore>();
+	private readonly _sessionToDisposablesMap = new DisposableMap<string, DisposableStore>();
 
 	private attachSession(session: ILanguageRuntimeSession) {
 		// Check if we're already attached here
@@ -177,8 +177,9 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 		}
 		const disposables = new DisposableStore();
 		this._sessionToDisposablesMap.set(session.sessionId, disposables);
-		// Cleanup from map when disposed.
-		disposables.add(toDisposable(() => this._sessionToDisposablesMap.delete(session.sessionId)));
+		// Cleanup from map when disposed. Use deleteAndLeak: the store is disposing
+		// itself right now, so just remove the map entry, don't dispose it again.
+		disposables.add(toDisposable(() => this._sessionToDisposablesMap.deleteAndLeak(session.sessionId)));
 
 		switch (session.metadata.sessionMode) {
 			case LanguageRuntimeSessionMode.Console:

--- a/src/vs/workbench/contrib/positronIPyWidgets/test/browser/positronIPyWidgetsService.vitest.ts
+++ b/src/vs/workbench/contrib/positronIPyWidgets/test/browser/positronIPyWidgetsService.vitest.ts
@@ -148,18 +148,22 @@ describe('Positron - PositronIPyWidgetsService', () => {
 		// improper disposal of listeners
 	});
 
-	async function createNotebookInstance() {
-		const notebookUri = URI.file('notebook.ipynb');
-
-		// Add a mock notebook editor.
+	function createNotebookEditor(notebookUri: URI): TestNotebookEditor {
 		const onDidChangeModel = ctx.disposables.add(new Emitter<NotebookTextModel | undefined>());
-		const notebookEditor = <TestNotebookEditor>{
+		return <TestNotebookEditor>{
 			getId() { return 'test-notebook-editor-id'; },
 			onDidChangeModel: onDidChangeModel.event,
 			textModel: { uri: notebookUri },
 			getViewModel() { return undefined; },
 			changeModel(uri) { onDidChangeModel.fire(<NotebookTextModel>{ uri }); },
 		};
+	}
+
+	async function createNotebookInstance() {
+		const notebookUri = URI.file('notebook.ipynb');
+
+		// Add a mock notebook editor.
+		const notebookEditor = createNotebookEditor(notebookUri);
 		notebookEditorService.addNotebookEditor(notebookEditor);
 
 		// Start a notebook session.
@@ -212,6 +216,32 @@ describe('Positron - PositronIPyWidgetsService', () => {
 
 		// Check that the instance was removed.
 		expect(positronIpywidgetsService.hasNotebookWidgetInstance(session.sessionId)).toBe(false);
+	});
+
+	it('notebook session: attaches widget when the editor appears after the session starts', async () => {
+		// Regression (win/electron flake): after a window reload, the notebook
+		// session can re-register before its editor is recreated. The attach
+		// must defer and bind once the matching editor appears, rather than
+		// giving up on a one-shot lookup and leaving the widget unrendered.
+		const notebookUri = URI.file('notebook.ipynb');
+
+		// Start the notebook session BEFORE its editor exists.
+		const session = await startTestLanguageRuntimeSession(
+			ctx.instantiationService,
+			ctx.disposables,
+			{ sessionMode: LanguageRuntimeSessionMode.Notebook, notebookUri },
+		);
+		await timeout(0);
+
+		// No matching editor yet, so no instance yet.
+		expect(positronIpywidgetsService.hasNotebookWidgetInstance(session.sessionId)).toBe(false);
+
+		// The editor appears afterward.
+		notebookEditorService.addNotebookEditor(createNotebookEditor(notebookUri));
+		await timeout(0);
+
+		// The widget should now be attached to the late-arriving editor.
+		expect(positronIpywidgetsService.hasNotebookWidgetInstance(session.sessionId)).toBe(true);
 	});
 
 });

--- a/src/vs/workbench/contrib/positronIPyWidgets/test/browser/positronIPyWidgetsService.vitest.ts
+++ b/src/vs/workbench/contrib/positronIPyWidgets/test/browser/positronIPyWidgetsService.vitest.ts
@@ -244,6 +244,31 @@ describe('Positron - PositronIPyWidgetsService', () => {
 		expect(positronIpywidgetsService.hasNotebookWidgetInstance(session.sessionId)).toBe(true);
 	});
 
+	it('notebook session: does not attach a widget when the session ends before its editor appears', async () => {
+		// The deferred-attach listener must be torn down when the session ends,
+		// so an editor that appears for an already-ended session never triggers
+		// a phantom attach (guards the up-front onDidEndSession registration).
+		const notebookUri = URI.file('notebook.ipynb');
+
+		// Start the notebook session before its editor exists.
+		const session = await startTestLanguageRuntimeSession(
+			ctx.instantiationService,
+			ctx.disposables,
+			{ sessionMode: LanguageRuntimeSessionMode.Notebook, notebookUri },
+		);
+		await timeout(0);
+
+		// End the session while it is still waiting for an editor.
+		session.endSession();
+		await timeout(0);
+
+		// A matching editor appears afterward: it must not resurrect the session.
+		notebookEditorService.addNotebookEditor(createNotebookEditor(notebookUri));
+		await timeout(0);
+
+		expect(positronIpywidgetsService.hasNotebookWidgetInstance(session.sessionId)).toBe(false);
+	});
+
 });
 
 describe('Positron - IPyWidgetsInstance constructor', () => {


### PR DESCRIPTION
Interactive ipywidgets (e.g. a Plotly `fig.show()`) fail to render when a notebook runtime session registers before its notebook editor exists. `attachNotebookSession` did a one-shot editor lookup and gave up permanently on a miss, logging "Could not find a notebook editor for session". It now defers via `onDidAddNotebookEditor` and binds once a matching-URI editor appears.

- Found while investigating a Quarto e2e flake; on closer inspection this fix does not apply to Quarto documents (their inline output rendering never routes through `attachNotebookSession` -- no `INotebookEditor` is ever created for a `.qmd` file). It's a real, distinct race for genuine notebook editors (`.ipynb`, Positron Notebook): a preceding window reload restarts the extension host, and the session can re-register before its notebook editor is recreated, so the one-shot lookup misses and the widget never renders.
- Deferred listener is tracked on the session's `DisposableStore` and torn down on session end, so a session that ends before its editor appears still cleans up.
- Adds regression tests for the late-arriving editor (widget attaches) and the early-session-end path (no phantom attach).
- Also swaps the per-session disposables map to `DisposableMap`, replacing the hand-rolled dispose-all/dispose-on-overwrite bookkeeping.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed interactive widgets (ipywidgets) not rendering in notebooks when their editor is recreated after a window reload.

### Validation Steps

@:positron-notebooks

Open a notebook with an interactive ipywidget output, reload the window, and verify the widget re-renders instead of staying blank.
