### PR TITLE
Python: Typed helper for `content.positron`

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/execute_request.py
+++ b/extensions/positron-python/python_files/posit/positron/execute_request.py
@@ -1,0 +1,82 @@
+#
+# Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+# Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+#
+
+import logging
+from typing import Optional, Union
+
+from ._vendor.pydantic import (
+    BaseModel,
+    Field,
+    StrictFloat,
+    StrictInt,
+    StrictStr,
+    ValidationError,
+)
+
+logger = logging.getLogger(__name__)
+
+Number = Union[StrictInt, StrictFloat]
+
+
+class Position(BaseModel):
+    """A zero-indexed (line, character) position within a document."""
+
+    line: StrictInt = 0
+    character: StrictInt = 0
+
+
+class Range(BaseModel):
+    """A range within a document."""
+
+    start: Position = Field(default_factory=Position)
+    end: Position = Field(default_factory=Position)
+
+
+class Location(BaseModel):
+    """A range within a document, identified by URI."""
+
+    uri: StrictStr
+    range: Range = Field(default_factory=Range)
+
+
+class PositronExecuteRequest(BaseModel):
+    """Typed view of an execute_request's `content.positron` object."""
+
+    code_location: Optional[Location] = None
+    fig_width: Optional[Number] = Field(
+        None, alias="fig-width", description="Figure width in inches"
+    )
+    fig_height: Optional[Number] = Field(
+        None, alias="fig-height", description="Figure height in inches"
+    )
+    output_width_px: Optional[Number] = Field(
+        None, description="Output area width in logical (CSS) pixels"
+    )
+    output_pixel_ratio: Optional[Number] = Field(
+        None, description="Output area device pixel ratio, e.g. 1.0 or 2.0"
+    )
+
+    @classmethod
+    def from_message(cls, message: dict) -> "PositronExecuteRequest":
+        """Parse from a Jupyter shell message."""
+        content = message.get("content", {})
+        positron = content.get("positron", {}) if isinstance(content, dict) else {}
+        if not isinstance(positron, dict):
+            return cls()
+
+        try:
+            return cls.parse_obj(positron)
+        except ValidationError as e:
+            # Drop only the top-level keys that failed validation and re-parse,
+            # so one malformed field doesn't discard the valid ones. Pydantic v1
+            # reports each error's location by wire key, so `loc[0]` matches the
+            # keys of `positron` directly.
+            bad_keys = {err["loc"][0] for err in e.errors()}
+            cleaned = {k: v for k, v in positron.items() if k not in bad_keys}
+            try:
+                return cls.parse_obj(cleaned)
+            except ValidationError:
+                logger.debug("Failed to parse positron execute request", exc_info=True)
+                return cls()

--- a/extensions/positron-python/python_files/posit/positron/matplotlib_backend.py
+++ b/extensions/positron-python/python_files/posit/positron/matplotlib_backend.py
@@ -27,6 +27,8 @@ import matplotlib.pyplot as plt
 from matplotlib.backend_bases import FigureManagerBase
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 
+from .execute_request import PositronExecuteRequest
+
 if TYPE_CHECKING:
     from matplotlib.figure import Figure
 
@@ -141,21 +143,16 @@ class FigureManagerPositron(FigureManagerBase):
         code: str = content.get("code", "")
 
         # Extract code_location from the positron metadata, if present
-        positron_meta = content.get("positron", {})
-        code_location = positron_meta.get("code_location", None) if positron_meta else None
-
+        code_location = PositronExecuteRequest.from_message(parent).code_location
         origin: PlotOrigin | None = None
-        if code_location:
-            loc_range = code_location.get("range", {})
-            start = loc_range.get("start", {})
-            end = loc_range.get("end", {})
+        if code_location is not None:
             origin = PlotOrigin(
-                uri=code_location["uri"],
+                uri=code_location.uri,
                 range=PlotRange(
-                    start_line=start.get("line", 0),
-                    start_character=start.get("character", 0),
-                    end_line=end.get("line", 0),
-                    end_character=end.get("character", 0),
+                    start_line=code_location.range.start.line,
+                    start_character=code_location.range.start.character,
+                    end_line=code_location.range.end.line,
+                    end_character=code_location.range.end.character,
                 ),
             )
 

--- a/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
@@ -38,6 +38,7 @@ from .access_keys import encode_access_key
 from .connections import ConnectionsService
 from .data_explorer import DataExplorerService, DataExplorerWarning
 from .debugger import PositronDebugger
+from .execute_request import PositronExecuteRequest
 from .help import HelpService, _distribution_to_modules, help  # noqa: A004
 from .lsp import LSPService
 from .patch.bokeh import handle_bokeh_output, patch_bokeh_no_access
@@ -556,13 +557,11 @@ class PositronShell(ZMQInteractiveShell):
         """
         try:
             parent: dict[str, Any] = self.kernel.get_parent("shell")
-            content = parent.get("content", {})
-            metadata = content.get("positron", {})
-            code_location = metadata.get("code_location")
-            if not code_location:
+            code_location = PositronExecuteRequest.from_message(parent).code_location
+            if code_location is None:
                 return None
 
-            editor_uri = urlparse(code_location.get("uri", ""))
+            editor_uri = urlparse(code_location.uri)
             if editor_uri.scheme != "file":
                 return None
 

--- a/extensions/positron-python/python_files/posit/positron/tests/test_execute_request.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_execute_request.py
@@ -1,0 +1,127 @@
+#
+# Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+# Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+#
+
+from positron.execute_request import PositronExecuteRequest
+
+
+def test_parses_code_location() -> None:
+    """A full code_location (uri + range) populates the nested model."""
+    message = {
+        "content": {
+            "positron": {
+                "code_location": {
+                    "uri": "file:///tmp/foo.py",
+                    "range": {
+                        "start": {"line": 1, "character": 2},
+                        "end": {"line": 3, "character": 4},
+                    },
+                }
+            }
+        }
+    }
+
+    meta = PositronExecuteRequest.from_message(message)
+
+    assert meta.code_location is not None
+    assert meta.code_location.uri == "file:///tmp/foo.py"
+    assert meta.code_location.range.start.line == 1
+    assert meta.code_location.range.start.character == 2
+    assert meta.code_location.range.end.line == 3
+    assert meta.code_location.range.end.character == 4
+
+
+def test_parses_kebab_case_fig_size() -> None:
+    """Kebab-case `fig-width`/`fig-height` populate `fig_width`/`fig_height`."""
+    message = {"content": {"positron": {"fig-width": 6.4, "fig-height": 4.8}}}
+
+    meta = PositronExecuteRequest.from_message(message)
+
+    assert meta.fig_width == 6.4
+    assert meta.fig_height == 4.8
+
+
+def test_parses_snake_case_output_layout() -> None:
+    """Snake-case `output_width_px`/`output_pixel_ratio` parse without an alias."""
+    message = {"content": {"positron": {"output_width_px": 800, "output_pixel_ratio": 2.0}}}
+
+    meta = PositronExecuteRequest.from_message(message)
+
+    assert meta.output_width_px == 800
+    assert meta.output_pixel_ratio == 2.0
+
+
+def test_missing_positron_key_is_empty() -> None:
+    """Missing `content`/`positron` key yields an empty model without raising."""
+    meta = PositronExecuteRequest.from_message({})
+
+    assert meta.code_location is None
+    assert meta.fig_width is None
+    assert meta.fig_height is None
+    assert meta.output_width_px is None
+    assert meta.output_pixel_ratio is None
+
+
+def test_fully_malformed_input_degrades_to_empty() -> None:
+    """Every field malformed -> empty model via the ValidationError guard, no raise."""
+    message = {"content": {"positron": {"code_location": "not-a-dict", "fig-width": [1, 2, 3]}}}
+
+    meta = PositronExecuteRequest.from_message(message)
+
+    assert meta.code_location is None
+    assert meta.fig_width is None
+
+
+def test_malformed_field_does_not_discard_valid_siblings() -> None:
+    """A single malformed field degrades to None; valid siblings still parse."""
+    message = {
+        "content": {
+            "positron": {
+                "code_location": "not-a-dict",  # invalid
+                "fig-width": 6.4,  # valid
+                "fig-height": 4.8,  # valid
+            }
+        }
+    }
+
+    meta = PositronExecuteRequest.from_message(message)
+
+    assert meta.code_location is None
+    assert meta.fig_width == 6.4
+    assert meta.fig_height == 4.8
+
+
+def test_nested_malformed_value_drops_whole_code_location() -> None:
+    """A bad nested range value drops code_location but keeps valid siblings."""
+    message = {
+        "content": {
+            "positron": {
+                "code_location": {
+                    "uri": "file:///tmp/foo.py",
+                    "range": {"start": {"line": "not-an-int"}},
+                },
+                "fig-width": 6.4,
+            }
+        }
+    }
+
+    meta = PositronExecuteRequest.from_message(message)
+
+    assert meta.code_location is None
+    assert meta.fig_width == 6.4
+
+
+def test_non_dict_positron_is_empty() -> None:
+    """A non-dict `positron` (or `content`) yields an empty model without raising."""
+    assert PositronExecuteRequest.from_message({"content": {"positron": "nope"}}).fig_width is None
+    assert PositronExecuteRequest.from_message({"content": "nope"}).fig_width is None
+
+
+def test_unknown_keys_are_ignored() -> None:
+    """Unknown keys (e.g. `fig-dpi`) pass through harmlessly."""
+    message = {"content": {"positron": {"fig-width": 6.4, "fig-dpi": 100}}}
+
+    meta = PositronExecuteRequest.from_message(message)
+
+    assert meta.fig_width == 6.4


### PR DESCRIPTION
This PR introduces a typed helper for the `content.positron` metadata dict that we were using in a few places, and that I'll also use to address https://github.com/posit-dev/positron/issues/12660.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:plots @:console

Covered by Python unit tests (`test_execute_request.py`, plus the unchanged `TestEditorSysPath` and plot-origin tests).