### PR TITLE
api: generalize install packages

### DIFF
--- a/extensions/positron-python/src/client/positron/missingPackages.ts
+++ b/extensions/positron-python/src/client/positron/missingPackages.ts
@@ -58,6 +58,18 @@ function topLevelModule(module: string): string {
     return module.split('.')[0];
 }
 
+/** Python: `ModuleNotFoundError: No module named 'foo'`. */
+const PYTHON_MISSING_MODULE_REGEX = /No module named ['"]([^'"]+)['"]/;
+
+/**
+ * Build a probe snippet (`import foo`) from a Python missing-module error, or
+ * undefined when the message is not a missing-module error.
+ */
+export function pythonMissingPackageProbe(errorMessage: string): string | undefined {
+    const name = PYTHON_MISSING_MODULE_REGEX.exec(errorMessage)?.[1];
+    return name ? `import ${name}` : undefined;
+}
+
 /** PEP 503 canonicalization: lowercase and collapse runs of `-_.` to a dash. */
 function canonicalizeName(name: string): string {
     return name.replace(/[-_.]+/g, '-').toLowerCase();

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -41,7 +41,7 @@ import { getIpykernelBundle, IpykernelBundle } from './ipykernel';
 import { getActiveInterpreterConfigTarget, whenTimeout } from './util';
 import { PackageManagerFactory } from './packages/packageManagerFactory';
 import { IPackageManager } from './packages/types';
-import { listMissingPythonPackages } from './missingPackages';
+import { listMissingPythonPackages, pythonMissingPackageProbe } from './missingPackages';
 
 /** Regex for commands to uninstall packages using supported Python package managers. */
 const _uninstallCommandRegex = /(pip|pipenv|conda).*uninstall|poetry.*remove/;
@@ -394,6 +394,10 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             return [];
         }
         return listMissingPythonPackages(this, this._packageManager, target, token);
+    }
+
+    getMissingPackageProbe(error: positron.RuntimeConsoleError): string | undefined {
+        return pythonMissingPackageProbe(error.message);
     }
 
     private async _setupIpykernel(interpreter: PythonEnvironment, kernelSpec: JupyterKernelSpec): Promise<void> {

--- a/extensions/positron-python/src/test/positron/missingPackages.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/missingPackages.unit.test.ts
@@ -3,12 +3,17 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as assert from 'assert';
 import { expect } from 'chai';
 import * as path from 'path';
 import * as sinon from 'sinon';
 import * as positron from 'positron';
 import * as vscode from 'vscode';
-import { listMissingPythonPackages, parsePythonImports } from '../../client/positron/missingPackages';
+import {
+    listMissingPythonPackages,
+    parsePythonImports,
+    pythonMissingPackageProbe,
+} from '../../client/positron/missingPackages';
 import { IPackageManager, PackageSession } from '../../client/positron/packages/types';
 
 suite('parsePythonImports', () => {
@@ -35,6 +40,16 @@ suite('parsePythonImports', () => {
         const code = ['import pandas; import numpy', 'x = 1; import requests; from flask import Flask'].join('\n');
 
         expect(parsePythonImports(code).sort()).to.deep.equal(['flask', 'numpy', 'pandas', 'requests'].sort());
+    });
+});
+
+suite('pythonMissingPackageProbe', () => {
+    test('returns an import snippet for a ModuleNotFoundError', () => {
+        assert.strictEqual(pythonMissingPackageProbe(`No module named 'requests'`), 'import requests');
+    });
+
+    test('returns undefined for an unrelated error', () => {
+        assert.strictEqual(pythonMissingPackageProbe('SyntaxError: invalid syntax'), undefined);
     });
 });
 

--- a/extensions/positron-python/src/test/positron/missingPackages.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/missingPackages.unit.test.ts
@@ -3,7 +3,6 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as assert from 'assert';
 import { expect } from 'chai';
 import * as path from 'path';
 import * as sinon from 'sinon';
@@ -45,11 +44,11 @@ suite('parsePythonImports', () => {
 
 suite('pythonMissingPackageProbe', () => {
     test('returns an import snippet for a ModuleNotFoundError', () => {
-        assert.strictEqual(pythonMissingPackageProbe(`No module named 'requests'`), 'import requests');
+        expect(pythonMissingPackageProbe(`No module named 'requests'`)).to.equal('import requests');
     });
 
     test('returns undefined for an unrelated error', () => {
-        assert.strictEqual(pythonMissingPackageProbe('SyntaxError: invalid syntax'), undefined);
+        expect(pythonMissingPackageProbe('SyntaxError: invalid syntax')).to.equal(undefined);
     });
 });
 

--- a/extensions/positron-r/src/missingPackages.ts
+++ b/extensions/positron-r/src/missingPackages.ts
@@ -37,6 +37,21 @@ export function parseRPackageReferences(code: string): string[] {
 }
 
 /**
+ * R: `Error in library(foo) : there is no package called 'foo'`. R renders the
+ * package name in curly quotes (U+2018/U+2019); accept those and straight quotes.
+ */
+const R_MISSING_PACKAGE_REGEX = /there is no package called ['"\u2018]([^'"\u2019]+)['"\u2019]/;
+
+/**
+ * Build a probe snippet (`library(foo)`) from an R missing-package error, or
+ * undefined when the message is not a missing-package error.
+ */
+export function rMissingPackageProbe(errorMessage: string): string | undefined {
+	const name = R_MISSING_PACKAGE_REGEX.exec(errorMessage)?.[1];
+	return name ? `library(${name})` : undefined;
+}
+
+/**
  * Analyzes R code and returns the packages it references that are not installed
  * AND that are available in the session's configured repositories.
  *

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -18,7 +18,7 @@ import { RSessionManager } from './session-manager';
 import { LOGGER, supervisorApi } from './extension.js';
 import { ArkComm } from './ark-comm';
 import { RPackageManager } from './packages';
-import { listMissingRPackages } from './missingPackages';
+import { listMissingRPackages, rMissingPackageProbe } from './missingPackages';
 import { RMetadataExtra } from './r-installation';
 import { warnOnArkVersionMismatch } from './arkVersionCheck';
 
@@ -832,6 +832,10 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 			return [];
 		}
 		return listMissingRPackages(this._packageManager, target, token);
+	}
+
+	getMissingPackageProbe(error: positron.RuntimeConsoleError): string | undefined {
+		return rMissingPackageProbe(error.message);
 	}
 
 	private async createKernel(): Promise<JupyterLanguageRuntimeSession> {

--- a/extensions/positron-r/src/test/missing-packages.test.ts
+++ b/extensions/positron-r/src/test/missing-packages.test.ts
@@ -7,7 +7,7 @@ import './mocha-setup';
 
 import * as assert from 'assert';
 import * as positron from 'positron';
-import { listMissingRPackages, parseRPackageReferences } from '../missingPackages';
+import { listMissingRPackages, parseRPackageReferences, rMissingPackageProbe } from '../missingPackages';
 import { RPackageManager } from '../packages';
 
 function makePackage(name: string): positron.LanguageRuntimePackage {
@@ -40,6 +40,24 @@ suite('parseRPackageReferences', () => {
 			parseRPackageReferences(code).sort(),
 			['data.table', 'dplyr', 'ggplot2', 'jsonlite', 'stringr'].sort(),
 		);
+	});
+});
+
+suite('rMissingPackageProbe', () => {
+	test('returns a library() snippet for a missing-package error with curly quotes', () => {
+		assert.strictEqual(
+			rMissingPackageProbe('Error in library(tidyverse) : there is no package called ‘tidyverse’'),
+			'library(tidyverse)');
+	});
+
+	test('returns a library() snippet with straight quotes', () => {
+		assert.strictEqual(
+			rMissingPackageProbe(`there is no package called 'tidyverse'`),
+			'library(tidyverse)');
+	});
+
+	test('returns undefined for an unrelated error', () => {
+		assert.strictEqual(rMissingPackageProbe('object not found'), undefined);
 	});
 });
 

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1440,6 +1440,19 @@ declare module 'positron' {
 	}
 
 	/**
+	 * A runtime error surfaced in the console, passed to `getMissingPackageProbe`
+	 * so the runtime can recognize its own missing-package error format.
+	 */
+	export interface RuntimeConsoleError {
+		/** The error name, e.g. "ModuleNotFoundError". May be empty. */
+		readonly name: string;
+		/** The error message, e.g. "No module named 'foo'". */
+		readonly message: string;
+		/** The error traceback, one entry per line. */
+		readonly traceback: string[];
+	}
+
+	/**
 	 * Basic metadata about an active language runtime session, including
 	 * immutable metadata about the session itself and metadata about the
 	 * runtime with which it is associated.
@@ -1711,6 +1724,21 @@ declare module 'positron' {
 		 * @param token Optional cancellation token.
 		 */
 		listMissingPackages?(target: RuntimeMissingPackagesTarget, token?: vscode.CancellationToken): Thenable<RuntimeMissingPackage[]>;
+
+		/**
+		 * Given a console error produced by this session, return a minimal code
+		 * snippet that references the missing package (e.g. `import foo`), for
+		 * the frontend to feed back through `listMissingPackages` and confirm the
+		 * package is installable. Return undefined when the error is not a
+		 * recognized missing-package error.
+		 *
+		 * Owning error-message parsing here (rather than in the frontend) keeps
+		 * the frontend language-agnostic.
+		 *
+		 * @param error The console error to inspect.
+		 * @param token Optional cancellation token.
+		 */
+		getMissingPackageProbe?(error: RuntimeConsoleError, token?: vscode.CancellationToken): string | undefined | Thenable<string | undefined>;
 	}
 
 

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -13,7 +13,7 @@ import {
 } from '../../common/positron/extHost.positron.protocol.js';
 import { extHostNamedCustomer, IExtHostContext } from '../../../services/extensions/common/extHostCustomers.js';
 import { IHostedLanguageContribution, ILanguageRuntimeClientCreatedEvent, ILanguageRuntimeInfo, ILanguageRuntimeMessage, ILanguageRuntimeMessageCommClosed, ILanguageRuntimeMessageCommData, ILanguageRuntimeMessageCommOpen, ILanguageRuntimeMessageError, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, ILanguageRuntimeMessageStream, ILanguageRuntimeMetadata, ILanguageRuntimeSessionState as ILanguageRuntimeSessionState, ILanguageRuntimeService, ILanguageRuntimeStartupFailure, LanguageRuntimeMessageType, RuntimeBusyBehavior, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState, ILanguageRuntimeExit, RuntimeOutputKind, RuntimeExitReason, ILanguageRuntimeMessageWebOutput, PositronOutputLocation, LanguageRuntimeSessionMode, ILanguageRuntimeMessageResult, ILanguageRuntimeMessageClearOutput, ILanguageRuntimeMessageIPyWidget, IRuntimeManager, IRuntimeRootSignature, ILanguageRuntimeMessageUpdateOutput, ILanguageRuntimeResourceUsage, ILanguageRuntimeLaunchInfo } from '../../../services/languageRuntime/common/languageRuntimeService.js';
-import { ILanguageRuntimePackage, ILanguageRuntimePackageManager, ILanguageRuntimeSession, ILanguageRuntimeSessionManager, IPackageSpec, IRuntimeMissingPackage, IRuntimeMissingPackagesTarget, IRuntimeSessionMetadata, IRuntimeSessionService, RuntimeStartMode } from '../../../services/runtimeSession/common/runtimeSessionService.js';
+import { ILanguageRuntimePackage, ILanguageRuntimePackageManager, ILanguageRuntimeSession, ILanguageRuntimeSessionManager, IPackageSpec, IRuntimeConsoleError, IRuntimeMissingPackage, IRuntimeMissingPackagesTarget, IRuntimeSessionMetadata, IRuntimeSessionService, RuntimeStartMode } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { Disposable, DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
 import { Event, Emitter } from '../../../../base/common/event.js';
 import { IPositronConsoleService } from '../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
@@ -790,6 +790,10 @@ class ExtHostLanguageRuntimeSessionAdapter extends Disposable implements ILangua
 
 	listMissingPackages(target: IRuntimeMissingPackagesTarget, token?: CancellationToken): Promise<IRuntimeMissingPackage[]> {
 		return this._proxy.$listMissingPackages(this.handle, target, token ?? CancellationToken.None);
+	}
+
+	getMissingPackageProbe(error: IRuntimeConsoleError, token?: CancellationToken): Promise<string | undefined> {
+		return this._proxy.$getMissingPackageProbe(this.handle, error, token ?? CancellationToken.None);
 	}
 
 	async showOutput(channel?: LanguageRuntimeSessionChannel): Promise<void> {

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -201,7 +201,7 @@ const MAX_EXECUTION_CODE_LOCATIONS = 32;
 
 // Adapter class; presents an ILanguageRuntime interface that connects to the
 // extension host proxy to supply language features.
-class ExtHostLanguageRuntimeSessionAdapter extends Disposable implements ILanguageRuntimeSession {
+export class ExtHostLanguageRuntimeSessionAdapter extends Disposable implements ILanguageRuntimeSession {
 
 	private readonly _stateEmitter = new Emitter<RuntimeState>();
 	private readonly _startupEmitter = new Emitter<ILanguageRuntimeInfo>();
@@ -279,6 +279,23 @@ class ExtHostLanguageRuntimeSessionAdapter extends Disposable implements ILangua
 
 		// Save handle
 		this.handle = initialState.handle;
+
+		// Wire the optional missing-package methods only when the extension's
+		// session implements them; see the field declarations.
+		if (initialState.capabilities.listMissingPackages) {
+			this.listMissingPackages = (target, token) =>
+				this._proxy.$listMissingPackages(this.handle, target, token ?? CancellationToken.None);
+		}
+		if (initialState.capabilities.getMissingPackageProbe) {
+			// Project to the declared IRuntimeConsoleError shape so extensions
+			// never receive extra frontend fields (e.g. sessionId, languageId).
+			this.getMissingPackageProbe = (error, token) =>
+				this._proxy.$getMissingPackageProbe(
+					this.handle,
+					{ name: error.name, message: error.message, traceback: error.traceback },
+					token ?? CancellationToken.None);
+		}
+
 		this.dynState = {
 			busy: false,
 			// If the session is a notebook session, set the current notebook URI
@@ -788,13 +805,14 @@ class ExtHostLanguageRuntimeSessionAdapter extends Disposable implements ILangua
 		return this._packageManager;
 	}
 
-	listMissingPackages(target: IRuntimeMissingPackagesTarget, token?: CancellationToken): Promise<IRuntimeMissingPackage[]> {
-		return this._proxy.$listMissingPackages(this.handle, target, token ?? CancellationToken.None);
-	}
-
-	getMissingPackageProbe(error: IRuntimeConsoleError, token?: CancellationToken): Promise<string | undefined> {
-		return this._proxy.$getMissingPackageProbe(this.handle, error, token ?? CancellationToken.None);
-	}
+	/**
+	 * Optional missing-package methods, assigned in the constructor only when
+	 * the extension's session implements them. Presence-as-capability: the
+	 * workbench gates features on `!!session.listMissingPackages`, and a
+	 * prototype method would read as "supported" for every session.
+	 */
+	readonly listMissingPackages?: (target: IRuntimeMissingPackagesTarget, token?: CancellationToken) => Promise<IRuntimeMissingPackage[]>;
+	readonly getMissingPackageProbe?: (error: IRuntimeConsoleError, token?: CancellationToken) => Promise<string | undefined>;
 
 	async showOutput(channel?: LanguageRuntimeSessionChannel): Promise<void> {
 		return this._proxy.$showOutputLanguageRuntime(this.handle, channel);

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -13,7 +13,7 @@ import { IEditorContext } from '../../../services/frontendMethods/common/editorC
 import { RuntimeClientType, LanguageRuntimeSessionChannel } from './extHostTypes.positron.js';
 import { IRange } from '../../../../editor/common/core/range.js';
 import { INotebookContextDTO, NotebookCellType } from '../../../common/positron/notebookAssistant.js';
-import { ActiveRuntimeSessionMetadata, EnvironmentVariableAction, LanguageRuntimeDynState, LanguageRuntimePackage, PackageSpec, RuntimeMissingPackage, RuntimeMissingPackagesTarget, RuntimeSessionMetadata, type notebooks } from 'positron';
+import { ActiveRuntimeSessionMetadata, EnvironmentVariableAction, LanguageRuntimeDynState, LanguageRuntimePackage, PackageSpec, RuntimeConsoleError, RuntimeMissingPackage, RuntimeMissingPackagesTarget, RuntimeSessionMetadata, type notebooks } from 'positron';
 import { IDriverMetadata, Input } from '../../../services/positronConnections/common/interfaces/positronConnectionsDriver.js';
 import { IAvailableDriverMethods } from '../../browser/positron/mainThreadConnections.js';
 import { IChatRequestData, IGenerateAssistantPromptRequest, IPositronChatContext, IPositronLanguageModelConfig, IPositronLanguageModelSource, IShowLanguageModelConfigOptions } from '../../../contrib/positronAssistant/common/interfaces/positronAssistantService.js';
@@ -154,6 +154,7 @@ export interface ExtHostLanguageRuntimeShape {
 	$searchPackageVersions(handle: number, name: string, token: CancellationToken): Promise<string[]>;
 	$getPackageMetadata(handle: number, packageNames: string[], token: CancellationToken): Promise<Record<string, Partial<LanguageRuntimePackage>> | undefined>;
 	$listMissingPackages(handle: number, target: RuntimeMissingPackagesTarget, token: CancellationToken): Promise<RuntimeMissingPackage[]>;
+	$getMissingPackageProbe(handle: number, error: RuntimeConsoleError, token: CancellationToken): Promise<string | undefined>;
 	$getPackageDetail(handle: number, name: string, token: CancellationToken): Promise<Partial<LanguageRuntimePackage> | undefined>;
 	$getRuntimePickerItems(handle: number): Promise<IRuntimePickerItem[]>;
 	$handleRuntimePickerSelection(handle: number, itemId: string): Promise<string | undefined>;

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -36,11 +36,24 @@ if (Object.values(MainContext)[0].nid !== 1) {
 }
 
 /**
+ * Which optional missing-package methods the extension's session object
+ * implements. Method presence does not survive the RPC boundary (the
+ * main-thread adapter would otherwise have to define every method), so the
+ * extension host reports the capabilities explicitly when the session is
+ * created or restored, and the adapter wires only the supported methods.
+ */
+export interface RuntimeSessionCapabilities {
+	readonly listMissingPackages: boolean;
+	readonly getMissingPackageProbe: boolean;
+}
+
+/**
  * The initial state returned when starting or resuming a runtime session.
  */
 export interface RuntimeInitialState {
 	handle: number;
 	dynState: LanguageRuntimeDynState;
+	capabilities: RuntimeSessionCapabilities;
 }
 
 /**

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -908,6 +908,18 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		return (await session.listMissingPackages?.(target, token)) ?? [];
 	}
 
+	async $getMissingPackageProbe(
+		handle: number,
+		error: positron.RuntimeConsoleError,
+		token: CancellationToken,
+	): Promise<string | undefined> {
+		if (handle >= this._runtimeSessions.length) {
+			throw new Error(`Cannot get missing-package probe: session handle '${handle}' not found or no longer valid.`);
+		}
+		const session = this._runtimeSessions[handle];
+		return (await session.getMissingPackageProbe?.(error, token)) ?? undefined;
+	}
+
 	async $getPackageDetail(
 		handle: number,
 		name: string,

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -28,6 +28,17 @@ import { ICodeLocation } from '../../../services/positronConsole/common/codeLoca
 import * as typeConvert from '../extHostTypeConverters.js';
 
 /**
+ * Derives the session's optional-method capabilities for the main thread,
+ * which cannot observe method presence across the RPC boundary.
+ */
+function sessionCapabilities(session: positron.LanguageRuntimeSession): extHostProtocol.RuntimeSessionCapabilities {
+	return {
+		listMissingPackages: !!session.listMissingPackages,
+		getMissingPackageProbe: !!session.getMissingPackageProbe,
+	};
+}
+
+/**
  * Interface for code execution observers
  */
 interface IExecutionObserver {
@@ -434,7 +445,8 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 
 			const initalState = {
 				handle,
-				dynState: await session.getDynState()
+				dynState: await session.getDynState(),
+				capabilities: sessionCapabilities(session),
 			};
 			return initalState;
 		} else {
@@ -569,7 +581,8 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 				const handle = this.attachToSession(session);
 				const initalState = {
 					handle,
-					dynState: await session.getDynState()
+					dynState: await session.getDynState(),
+					capabilities: sessionCapabilities(session),
 				};
 				return initalState;
 			} else {
@@ -917,7 +930,7 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 			throw new Error(`Cannot get missing-package probe: session handle '${handle}' not found or no longer valid.`);
 		}
 		const session = this._runtimeSessions[handle];
-		return (await session.getMissingPackageProbe?.(error, token)) ?? undefined;
+		return session.getMissingPackageProbe?.(error, token);
 	}
 
 	async $getPackageDetail(

--- a/src/vs/workbench/api/test/browser/positron/mainThreadLanguageRuntime.vitest.ts
+++ b/src/vs/workbench/api/test/browser/positron/mainThreadLanguageRuntime.vitest.ts
@@ -5,11 +5,23 @@
 
 /// <reference types="vitest/globals" />
 
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { Event } from '../../../../../base/common/event.js';
 import { URI } from '../../../../../base/common/uri.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
+import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { ensureNoLeakedDisposables } from '../../../../../test/vitest/vitestUtils.js';
+import { INotebookService } from '../../../../contrib/notebook/common/notebookService.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { IWorkbenchEnvironmentService } from '../../../../services/environment/common/environmentService.js';
+import { ILanguageRuntimeMetadata } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { IPathService } from '../../../../services/path/common/pathService.js';
-import { buildRuntimeOpenEventResource } from '../../../browser/positron/mainThreadLanguageRuntime.js';
+import { IRuntimeSessionMetadata, IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
+import { ExtHostLanguageRuntimeShape, RuntimeSessionCapabilities } from '../../../common/positron/extHost.positron.protocol.js';
+import { buildRuntimeOpenEventResource, ExtHostLanguageRuntimeSessionAdapter } from '../../../browser/positron/mainThreadLanguageRuntime.js';
 
 /**
  * `pathService.fileURI()` is stubbed so these tests run on any host OS;
@@ -71,5 +83,78 @@ describe('buildRuntimeOpenEventResource', () => {
 			remoteAuthority: 'localhost:8080',
 		});
 		expect(uri.toString()).toBe('vscode-remote://localhost:8080/home/jenny/foo.R');
+	});
+});
+
+describe('ExtHostLanguageRuntimeSessionAdapter - missing-package capabilities', () => {
+	const disposables = ensureNoLeakedDisposables();
+
+	function createAdapter(capabilities: RuntimeSessionCapabilities) {
+		const $getMissingPackageProbe = vi.fn().mockResolvedValue('import requests');
+		const proxy = stubInterface<ExtHostLanguageRuntimeShape>({
+			$getMissingPackageProbe,
+			// Read by the adapter's dispose() via ensureNoLeakedDisposables.
+			$disposeLanguageRuntime: vi.fn(),
+		});
+		const adapter = disposables.add(new ExtHostLanguageRuntimeSessionAdapter(
+			{
+				handle: 0,
+				dynState: { inputPrompt: '>', continuationPrompt: '+', sessionName: 'test' },
+				capabilities,
+			},
+			stubInterface<ILanguageRuntimeMetadata>({}),
+			stubInterface<IRuntimeSessionMetadata>({ notebookUri: undefined }),
+			stubInterface<IRuntimeSessionService>({
+				onDidChangeForegroundSession: Event.None,
+				onDidReceiveRuntimeEvent: Event.None,
+			}),
+			stubInterface<INotificationService>({}),
+			new NullLogService(),
+			stubInterface<ICommandService>({}),
+			stubInterface<INotebookService>({}),
+			stubInterface<IEditorService>({}),
+			stubInterface<IPathService>({}),
+			stubInterface<IWorkbenchEnvironmentService>({}),
+			proxy,
+			stubInterface<IOpenerService>({}),
+		));
+		return { adapter, $getMissingPackageProbe };
+	}
+
+	it('leaves the optional methods undefined when the extension session lacks them', () => {
+		const { adapter } = createAdapter({ listMissingPackages: false, getMissingPackageProbe: false });
+
+		expect(adapter.listMissingPackages).toBeUndefined();
+		expect(adapter.getMissingPackageProbe).toBeUndefined();
+	});
+
+	it('defines the optional methods when the extension session implements them', () => {
+		const { adapter } = createAdapter({ listMissingPackages: true, getMissingPackageProbe: true });
+
+		expect(adapter.listMissingPackages).toBeDefined();
+		expect(adapter.getMissingPackageProbe).toBeDefined();
+	});
+
+	it('projects the console error to name/message/traceback before crossing the RPC boundary', async () => {
+		const { adapter, $getMissingPackageProbe } = createAdapter({ listMissingPackages: true, getMissingPackageProbe: true });
+
+		// A frontend IConsoleError carries extra fields (sessionId, languageId)
+		// that must not reach extensions; keep it as a variable so the extra
+		// fields pass the structural check.
+		const error = {
+			name: 'ModuleNotFoundError',
+			message: `No module named 'requests'`,
+			traceback: [],
+			sessionId: 's1',
+			languageId: 'python',
+		};
+
+		await adapter.getMissingPackageProbe!(error, CancellationToken.None);
+
+		expect($getMissingPackageProbe).toHaveBeenCalledWith(
+			0,
+			{ name: 'ModuleNotFoundError', message: `No module named 'requests'`, traceback: [] },
+			CancellationToken.None,
+		);
 	});
 });

--- a/src/vs/workbench/api/test/common/positron/extHostLanguageRuntime.vitest.ts
+++ b/src/vs/workbench/api/test/common/positron/extHostLanguageRuntime.vitest.ts
@@ -399,6 +399,36 @@ describe('ExtHostLanguageRuntime', () => {
 			await expect(runtime.$disposeLanguageRuntime(secondHandle)).resolves.toBeUndefined();
 		});
 	});
+
+	describe('$createLanguageRuntimeSession capabilities', () => {
+		/** A session that implements the optional missing-package methods. */
+		class CapableSession extends TestSession {
+			override async listMissingPackages(): Promise<positron.RuntimeMissingPackage[]> {
+				return [];
+			}
+			override getMissingPackageProbe(): string | undefined {
+				return undefined;
+			}
+		}
+
+		it('reports false for optional missing-package methods the session lacks', async () => {
+			runtime.registerLanguageRuntimeManager(extension, 'r', new TestManager(new TestSession()));
+
+			const init = await runtime.$createLanguageRuntimeSession(runtimeMetadata, sessionMetadata, 'test');
+
+			expect(init.capabilities).toEqual({ listMissingPackages: false, getMissingPackageProbe: false });
+			await runtime.$disposeLanguageRuntime(init.handle);
+		});
+
+		it('reports true for optional missing-package methods the session implements', async () => {
+			runtime.registerLanguageRuntimeManager(extension, 'r', new TestManager(new CapableSession()));
+
+			const init = await runtime.$createLanguageRuntimeSession(runtimeMetadata, sessionMetadata, 'test');
+
+			expect(init.capabilities).toEqual({ listMissingPackages: true, getMissingPackageProbe: true });
+			await runtime.$disposeLanguageRuntime(init.handle);
+		});
+	});
 });
 
 /**

--- a/src/vs/workbench/contrib/positronMissingPackages/browser/missingPackageProvider.ts
+++ b/src/vs/workbench/contrib/positronMissingPackages/browser/missingPackageProvider.ts
@@ -15,24 +15,16 @@ import { IMissingPackagesService } from '../common/missingPackagesService.js';
 /** Setting that gates the console install suggestion. */
 const SUGGEST_INSTALL_ON_ERROR = 'packages.suggestInstallOnError';
 
-/** Python: `ModuleNotFoundError: No module named 'foo'`. */
-const PYTHON_MISSING_MODULE_REGEX = /No module named ['"]([^'"]+)['"]/;
-
-/**
- * R: `Error in library(foo) : there is no package called 'foo'`. R renders the
- * package name in curly quotes (U+2018/U+2019); accept those and straight quotes.
- */
-const R_MISSING_PACKAGE_REGEX = /there is no package called ['"\u2018]([^'"\u2019]+)['"\u2019]/;
-
 /**
  * A console-error followup provider that offers to install a missing package
  * when a runtime reports a missing-module / missing-package error.
  *
- * It routes a synthetic reference to the package through the missing-packages
- * service to confirm the package is actually installable in this environment
- * (and to recover the install name), so it never offers a package it cannot
- * install. Going through the service (rather than the session directly) shares
- * the analysis cache, in-flight dedupe, and resilience guards.
+ * It delegates recognition of the error to the session's runtime (which owns
+ * its own error format and recovers the install name), then confirms the
+ * package is actually installable in this environment before offering it, so
+ * it never offers a package it cannot install. Going through the service
+ * (rather than the session directly) shares the analysis cache, in-flight
+ * dedupe, and resilience guards.
  */
 export class MissingPackageErrorProvider implements IConsoleErrorSuggestionProvider {
 	constructor(
@@ -46,19 +38,10 @@ export class MissingPackageErrorProvider implements IConsoleErrorSuggestionProvi
 			return [];
 		}
 
-		const referencedName = extractMissingName(error);
-		if (!referencedName) {
-			return [];
-		}
-
-		// Analyze a synthetic reference to the package: it confirms the package is
-		// missing AND installable, and recovers the install name.
-		const code = syntheticReference(error.languageId, referencedName);
-		if (!code) {
-			return [];
-		}
-
-		const missing = await this._missingPackagesService.analyzeCode(error.sessionId, code, token);
+		// Ask the session's runtime whether this error names a missing package,
+		// then confirm it is actually installable. The runtime owns its own error
+		// format, so this provider stays language-agnostic.
+		const missing = await this._missingPackagesService.analyzeError(error.sessionId, error, token);
 
 		return missing.map(pkg => ({
 			icon: Codicon.lightBulb,
@@ -71,8 +54,6 @@ export class MissingPackageErrorProvider implements IConsoleErrorSuggestionProvi
 						packages: [pkg],
 					});
 				} catch (err) {
-					// Surface the failure so a click that does nothing visible
-					// (network / package-manager error) isn't silently swallowed.
 					this._notificationService.error(localize(
 						'positron.missingPackages.installFailed',
 						"Failed to install '{0}': {1}",
@@ -82,28 +63,6 @@ export class MissingPackageErrorProvider implements IConsoleErrorSuggestionProvi
 			},
 		}));
 	}
-}
-
-/** Extracts the referenced package/module name from a recognized error message. */
-function extractMissingName(error: IConsoleError): string | undefined {
-	if (error.languageId === 'python') {
-		return PYTHON_MISSING_MODULE_REGEX.exec(error.message)?.[1];
-	}
-	if (error.languageId === 'r') {
-		return R_MISSING_PACKAGE_REGEX.exec(error.message)?.[1];
-	}
-	return undefined;
-}
-
-/** Builds a minimal code snippet that references `name` for the analyzer to inspect. */
-function syntheticReference(languageId: string, name: string): string | undefined {
-	if (languageId === 'python') {
-		return `import ${name}`;
-	}
-	if (languageId === 'r') {
-		return `library(${name})`;
-	}
-	return undefined;
 }
 
 /**

--- a/src/vs/workbench/contrib/positronMissingPackages/browser/missingPackagesCommands.ts
+++ b/src/vs/workbench/contrib/positronMissingPackages/browser/missingPackagesCommands.ts
@@ -13,13 +13,12 @@ import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextke
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { IProgressService, ProgressLocation } from '../../../../platform/progress/common/progress.js';
-import { ResourceContextKey } from '../../../common/contextkeys.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../positronNotebook/common/positronNotebookCommon.js';
-import { QUARTO_LANGUAGE_IDS } from '../../positronQuarto/common/positronQuartoConfig.js';
 import { IMissingPackagesResult, IMissingPackagesService } from '../common/missingPackagesService.js';
 import { installPackagesLabel, installingMessage } from './missingPackagesBadge.js';
 import { showMissingPackagesInstallModal } from './missingPackagesInstallModal.js';
+import { MISSING_PACKAGES_SUPPORTED_KEY } from './missingPackagesContextKey.js';
 
 /** Command category, matching the Packages pane commands. */
 const PACKAGES_CATEGORY = localize2('packages', 'Packages');
@@ -28,13 +27,12 @@ export const CHECK_MISSING_PACKAGES_COMMAND_ID = 'positron.missingPackages.check
 export const INSTALL_MISSING_PACKAGES_COMMAND_ID = 'positron.missingPackages.install';
 
 /**
- * The editors these commands apply to: Python and R scripts, Quarto documents,
- * and Positron notebooks. Matches where the editor/notebook badge appears.
+ * The editors these commands apply to: whatever the capability context key
+ * covers, plus Positron notebooks. Matches where the editor/notebook badge
+ * appears.
  */
 const MISSING_PACKAGES_SUPPORTED = ContextKeyExpr.or(
-	ContextKeyExpr.equals(ResourceContextKey.LangId.key, 'python'),
-	ContextKeyExpr.equals(ResourceContextKey.LangId.key, 'r'),
-	...QUARTO_LANGUAGE_IDS.map(langId => ContextKeyExpr.equals(ResourceContextKey.LangId.key, langId)),
+	MISSING_PACKAGES_SUPPORTED_KEY,
 	ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
 );
 

--- a/src/vs/workbench/contrib/positronMissingPackages/browser/missingPackagesContextKey.ts
+++ b/src/vs/workbench/contrib/positronMissingPackages/browser/missingPackagesContextKey.ts
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { IContextKey, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
+import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { ILanguageRuntimeSession, IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
+import { QUARTO_LANGUAGE_IDS } from '../../positronQuarto/common/positronQuartoConfig.js';
+
+/**
+ * True when the active editor's content can be checked for missing packages:
+ * a Quarto document (multi-language, split per chunk downstream), or a language
+ * whose console session implements `listMissingPackages`. Language-agnostic:
+ * any runtime that implements the capability qualifies, with no language names.
+ */
+export const MISSING_PACKAGES_SUPPORTED_KEY = new RawContextKey<boolean>('positronActiveEditorSupportsMissingPackages', false);
+
+/**
+ * Pure predicate behind {@link MISSING_PACKAGES_SUPPORTED_KEY}, split out so it
+ * can be unit-tested without the workbench.
+ *
+ * @param languageId The active text editor's language id, or undefined.
+ * @param session The console session for `languageId`, or undefined.
+ */
+export function activeEditorSupportsMissingPackages(languageId: string | undefined, session: ILanguageRuntimeSession | undefined): boolean {
+	if (!languageId) {
+		return false;
+	}
+	if (QUARTO_LANGUAGE_IDS.includes(languageId)) {
+		return true;
+	}
+	return !!session?.listMissingPackages;
+}
+
+/**
+ * Maintains {@link MISSING_PACKAGES_SUPPORTED_KEY} in response to active-editor
+ * and runtime-session changes.
+ */
+export class MissingPackagesContextKeyContribution extends Disposable {
+	static readonly ID = 'workbench.contrib.positronMissingPackagesContextKey';
+
+	private readonly _supported: IContextKey<boolean>;
+
+	constructor(
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IEditorService private readonly _editorService: IEditorService,
+		@IRuntimeSessionService private readonly _runtimeSessionService: IRuntimeSessionService,
+	) {
+		super();
+		this._supported = MISSING_PACKAGES_SUPPORTED_KEY.bindTo(contextKeyService);
+		this._register(this._editorService.onDidActiveEditorChange(() => this._update()));
+		this._register(this._runtimeSessionService.onDidStartRuntime(() => this._update()));
+		this._register(this._runtimeSessionService.onDidChangeForegroundSession(() => this._update()));
+		this._update();
+	}
+
+	private _update(): void {
+		const languageId = this._editorService.activeTextEditorLanguageId;
+		const session = languageId ? this._runtimeSessionService.getConsoleSessionForLanguage(languageId) : undefined;
+		this._supported.set(activeEditorSupportsMissingPackages(languageId, session));
+	}
+}

--- a/src/vs/workbench/contrib/positronMissingPackages/browser/missingPackagesContextKey.ts
+++ b/src/vs/workbench/contrib/positronMissingPackages/browser/missingPackagesContextKey.ts
@@ -52,7 +52,10 @@ export class MissingPackagesContextKeyContribution extends Disposable {
 		this._supported = MISSING_PACKAGES_SUPPORTED_KEY.bindTo(contextKeyService);
 		this._register(this._editorService.onDidActiveEditorChange(() => this._update()));
 		this._register(this._runtimeSessionService.onDidStartRuntime(() => this._update()));
+		this._register(this._runtimeSessionService.onDidFailStartRuntime(() => this._update()));
+		this._register(this._runtimeSessionService.onDidChangeRuntimeState(() => this._update()));
 		this._register(this._runtimeSessionService.onDidChangeForegroundSession(() => this._update()));
+		this._register(this._runtimeSessionService.onDidDeleteRuntimeSession(() => this._update()));
 		this._update();
 	}
 

--- a/src/vs/workbench/contrib/positronMissingPackages/browser/missingPackagesServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronMissingPackages/browser/missingPackagesServiceImpl.ts
@@ -13,7 +13,7 @@ import { IModelService } from '../../../../editor/common/services/model.js';
 import { ITextModelService } from '../../../../editor/common/services/resolverService.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IPositronPackagesService } from '../../positronPackages/browser/interfaces/positronPackagesService.js';
-import { IPackageSpec, IRuntimeMissingPackage, IRuntimeMissingPackagesTarget, IRuntimeSessionService, ILanguageRuntimeSession } from '../../../services/runtimeSession/common/runtimeSessionService.js';
+import { IPackageSpec, IRuntimeConsoleError, IRuntimeMissingPackage, IRuntimeMissingPackagesTarget, IRuntimeSessionService, ILanguageRuntimeSession } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { RuntimeState } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { IMissingPackagesGroup, IMissingPackagesResult, IMissingPackagesService } from '../common/missingPackagesService.js';
 import { INotebookService } from '../../notebook/common/notebookService.js';
@@ -169,6 +169,24 @@ export class MissingPackagesService extends Disposable implements IMissingPackag
 			target: { code },
 		};
 		return this._computeTarget(target);
+	}
+
+	async analyzeError(sessionId: string, error: IRuntimeConsoleError, token?: CancellationToken): Promise<IRuntimeMissingPackage[]> {
+		const session = this._runtimeSessionService.getSession(sessionId);
+		if (!session?.getMissingPackageProbe) {
+			return [];
+		}
+		let probe: string | undefined;
+		try {
+			probe = await session.getMissingPackageProbe(error, token);
+		} catch (err) {
+			this._logService.warn(`[MissingPackages] getMissingPackageProbe failed for session '${sessionId}': ${err}`);
+			return [];
+		}
+		if (!probe) {
+			return [];
+		}
+		return this.analyzeCode(sessionId, probe, token);
 	}
 
 	async install(group: IMissingPackagesGroup, token?: CancellationToken): Promise<void> {

--- a/src/vs/workbench/contrib/positronMissingPackages/browser/positronMissingPackages.contribution.ts
+++ b/src/vs/workbench/contrib/positronMissingPackages/browser/positronMissingPackages.contribution.ts
@@ -13,10 +13,8 @@ import { InstantiationType, registerSingleton } from '../../../../platform/insta
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { PositronActionBarWidgetRegistry } from '../../../../platform/positronActionBar/browser/positronActionBarWidgetRegistry.js';
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from '../../../common/contributions.js';
-import { ResourceContextKey } from '../../../common/contextkeys.js';
 import { LifecyclePhase } from '../../../services/lifecycle/common/lifecycle.js';
 import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../positronNotebook/common/positronNotebookCommon.js';
-import { QUARTO_LANGUAGE_IDS } from '../../positronQuarto/common/positronQuartoConfig.js';
 import { IMissingPackagesService } from '../common/missingPackagesService.js';
 import { MissingPackagesService } from './missingPackagesServiceImpl.js';
 import { MissingPackageFollowupContribution } from './missingPackageProvider.js';
@@ -24,6 +22,7 @@ import { MissingPackagesBadgeMount } from './missingPackagesBadgeMount.js';
 import { MissingPackagesPrecomputeContribution } from './missingPackagesPrecompute.js';
 import { IMissingPackagesPreflightService, MissingPackagesPreflightService } from './missingPackagesPreflightService.js';
 import { registerMissingPackagesCommands } from './missingPackagesCommands.js';
+import { MISSING_PACKAGES_SUPPORTED_KEY, MissingPackagesContextKeyContribution } from './missingPackagesContextKey.js';
 
 // Register the missing-packages services.
 registerSingleton(IMissingPackagesService, MissingPackagesService, InstantiationType.Delayed);
@@ -47,19 +46,21 @@ workbenchRegistry.registerWorkbenchContribution(MissingPackageFollowupContributi
 // Keep the cache warm for the active editor so the preflight check never blocks.
 workbenchRegistry.registerWorkbenchContribution(MissingPackagesPrecomputeContribution, LifecyclePhase.Restored);
 
-// Editor action bar badge (scenario 2) for Python and R scripts and Quarto
-// documents. The editor action bar is disabled for notebooks, so notebooks get
-// a separate mount below. Quarto documents are multi-language; the service
-// splits them into per-language code chunks and routes each to its session.
+// Maintains the capability context key that gates the editor badge and the
+// command-palette commands (scenario 2). Language-agnostic: driven by whether
+// the active editor's runtime supports missing-package checks.
+workbenchRegistry.registerWorkbenchContribution(MissingPackagesContextKeyContribution, LifecyclePhase.Restored);
+
+// Editor action bar badge (scenario 2) for scripts whose language has a session
+// that supports missing packages, and Quarto documents. The editor action bar
+// is disabled for notebooks, so notebooks get a separate mount below. Quarto
+// documents are multi-language; the service splits them into per-language code
+// chunks and routes each to its session.
 PositronActionBarWidgetRegistry.registerWidget({
 	id: 'positronMissingPackages.editorBadge',
 	menuId: MenuId.EditorActionsRight,
 	order: 95,
-	when: ContextKeyExpr.or(
-		ContextKeyExpr.equals(ResourceContextKey.LangId.key, 'python'),
-		ContextKeyExpr.equals(ResourceContextKey.LangId.key, 'r'),
-		...QUARTO_LANGUAGE_IDS.map(langId => ContextKeyExpr.equals(ResourceContextKey.LangId.key, langId)),
-	),
+	when: MISSING_PACKAGES_SUPPORTED_KEY,
 	selfContained: true,
 	componentFactory: (accessor) => () => React.createElement(MissingPackagesBadgeMount, { accessor }),
 });

--- a/src/vs/workbench/contrib/positronMissingPackages/common/missingPackagesService.ts
+++ b/src/vs/workbench/contrib/positronMissingPackages/common/missingPackagesService.ts
@@ -7,7 +7,7 @@ import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Event } from '../../../../base/common/event.js';
 import { URI } from '../../../../base/common/uri.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
-import { IRuntimeMissingPackage } from '../../../services/runtimeSession/common/runtimeSessionService.js';
+import { IRuntimeConsoleError, IRuntimeMissingPackage } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 
 export const IMissingPackagesService = createDecorator<IMissingPackagesService>('missingPackagesService');
 
@@ -76,6 +76,15 @@ export interface IMissingPackagesService {
 	 * when the session is gone, cannot analyze packages, or is shutting down.
 	 */
 	analyzeCode(sessionId: string, code: string, token?: CancellationToken): Promise<IRuntimeMissingPackage[]>;
+
+	/**
+	 * Given a console error from a session, ask the session's runtime for a probe
+	 * snippet that references the missing package, then analyze it (sharing the
+	 * same cache, dedupe, and resilience as {@link analyzeCode}). Returns an empty
+	 * array when the runtime does not recognize the error, the package is
+	 * installed, or the runtime does not support this.
+	 */
+	analyzeError(sessionId: string, error: IRuntimeConsoleError, token?: CancellationToken): Promise<IRuntimeMissingPackage[]>;
 
 	/**
 	 * Installs the given group's packages against its session. Resolves when the

--- a/src/vs/workbench/contrib/positronMissingPackages/test/browser/missingPackageProvider.vitest.ts
+++ b/src/vs/workbench/contrib/positronMissingPackages/test/browser/missingPackageProvider.vitest.ts
@@ -49,24 +49,24 @@ describe('MissingPackageErrorProvider', () => {
 		enabled?: boolean;
 		missing?: IRuntimeMissingPackage[];
 	} = {}) {
-		const analyzeCode = vi.fn<(...args: unknown[]) => Promise<IRuntimeMissingPackage[]>>()
+		const analyzeError = vi.fn<(...args: unknown[]) => Promise<IRuntimeMissingPackage[]>>()
 			.mockResolvedValue(options.missing ?? [{ name: 'requests' }]);
 		const install = vi.fn().mockResolvedValue(undefined);
-		const missingPackagesService = stubInterface<IMissingPackagesService>({ analyzeCode, install });
+		const missingPackagesService = stubInterface<IMissingPackagesService>({ analyzeError, install });
 		const configurationService = stubInterface<IConfigurationService>({ getValue: () => options.enabled ?? true });
 		const notificationError = vi.fn();
 		const notificationService = stubInterface<INotificationService>({ error: notificationError });
 		const provider = new MissingPackageErrorProvider(missingPackagesService, configurationService, notificationService);
-		return { provider, analyzeCode, install, notificationError };
+		return { provider, analyzeError, install, notificationError };
 	}
 
-	it('offers an install action for a Python missing-module error', async () => {
-		const { provider, analyzeCode, install } = setup();
-		const error = makeError({ languageId: 'python', name: 'ModuleNotFoundError', message: `No module named 'requests'` });
+	it('offers an install action for a package the runtime reports missing', async () => {
+		const { provider, analyzeError, install } = setup();
+		const error = makeError({ name: 'ModuleNotFoundError', message: `No module named 'requests'` });
 
 		const suggestions = await provider.provideSuggestions(error, CancellationToken.None);
 
-		expect(analyzeCode).toHaveBeenCalledWith('s1', 'import requests', CancellationToken.None);
+		expect(analyzeError).toHaveBeenCalledWith('s1', error, CancellationToken.None);
 		expect(suggestions).toHaveLength(1);
 		expect(suggestions[0].label).toBe('Install requests');
 
@@ -74,43 +74,25 @@ describe('MissingPackageErrorProvider', () => {
 		expect(install).toHaveBeenCalledWith({ sessionId: 's1', languageId: 'python', packages: [{ name: 'requests' }] });
 	});
 
-	it('matches an R missing-package error with curly quotes', async () => {
-		const { provider, analyzeCode } = setup({ missing: [{ name: 'tidyverse' }] });
-		const error = makeError({
-			languageId: 'r',
-			message: 'Error in library(tidyverse) : there is no package called \u2018tidyverse\u2019',
-		});
-
-		const suggestions = await provider.provideSuggestions(error, CancellationToken.None);
-
-		expect(analyzeCode).toHaveBeenCalledWith('s1', 'library(tidyverse)', CancellationToken.None);
-		expect(suggestions.map(s => s.label)).toEqual(['Install tidyverse']);
-	});
-
 	it('offers nothing when the setting is disabled', async () => {
-		const { provider, analyzeCode } = setup({ enabled: false });
-		const error = makeError({ message: `No module named 'requests'` });
+		const { provider, analyzeError } = setup({ enabled: false });
 
-		expect(await provider.provideSuggestions(error, CancellationToken.None)).toEqual([]);
-		expect(analyzeCode).not.toHaveBeenCalled();
+		expect(await provider.provideSuggestions(makeError({}), CancellationToken.None)).toEqual([]);
+		expect(analyzeError).not.toHaveBeenCalled();
 	});
 
-	it('offers nothing when the analyzer finds no installable package', async () => {
+	it('offers nothing when the runtime reports no installable package', async () => {
 		const { provider } = setup({ missing: [] });
-		const error = makeError({ message: `No module named 'garfblatz'` });
 
-		expect(await provider.provideSuggestions(error, CancellationToken.None)).toEqual([]);
+		expect(await provider.provideSuggestions(makeError({}), CancellationToken.None)).toEqual([]);
 	});
 
 	it('surfaces a notification when the install fails, without rejecting', async () => {
 		const { provider, install, notificationError } = setup();
 		install.mockRejectedValueOnce(new Error('network down'));
-		const error = makeError({ languageId: 'python', message: `No module named 'requests'` });
 
-		const suggestions = await provider.provideSuggestions(error, CancellationToken.None);
+		const suggestions = await provider.provideSuggestions(makeError({}), CancellationToken.None);
 
-		// `run` swallows the install failure after surfacing it to the user, so the
-		// click handler never sees an unhandled rejection.
 		await expect(suggestions[0].run()).resolves.toBeUndefined();
 		expect(notificationError).toHaveBeenCalledWith(`Failed to install 'requests': network down`);
 	});

--- a/src/vs/workbench/contrib/positronMissingPackages/test/browser/missingPackagesContextKey.vitest.ts
+++ b/src/vs/workbench/contrib/positronMissingPackages/test/browser/missingPackagesContextKey.vitest.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { ILanguageRuntimeSession } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
+import { activeEditorSupportsMissingPackages } from '../../browser/missingPackagesContextKey.js';
+
+describe('activeEditorSupportsMissingPackages', () => {
+	const sessionWithCapability = stubInterface<ILanguageRuntimeSession>({ listMissingPackages: async () => [] });
+	const sessionWithoutCapability = stubInterface<ILanguageRuntimeSession>({ listMissingPackages: undefined });
+
+	it('is false when there is no active language', () => {
+		expect(activeEditorSupportsMissingPackages(undefined, undefined)).toBe(false);
+	});
+
+	it('is true for a Quarto document regardless of session', () => {
+		expect(activeEditorSupportsMissingPackages('quarto', undefined)).toBe(true);
+	});
+
+	it('is true when the active language has a session that supports missing packages', () => {
+		expect(activeEditorSupportsMissingPackages('anything', sessionWithCapability)).toBe(true);
+	});
+
+	it('is false when the active language session does not support missing packages', () => {
+		expect(activeEditorSupportsMissingPackages('anything', sessionWithoutCapability)).toBe(false);
+	});
+});

--- a/src/vs/workbench/contrib/positronMissingPackages/test/browser/missingPackagesContextKey.vitest.ts
+++ b/src/vs/workbench/contrib/positronMissingPackages/test/browser/missingPackagesContextKey.vitest.ts
@@ -5,9 +5,14 @@
 
 /// <reference types="vitest/globals" />
 
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { IContextKey, IContextKeyService, ContextKeyValue } from '../../../../../platform/contextkey/common/contextkey.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
-import { ILanguageRuntimeSession } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
-import { activeEditorSupportsMissingPackages } from '../../browser/missingPackagesContextKey.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
+import { RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
+import { ILanguageRuntimeSession, ILanguageRuntimeSessionStateEvent, IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
+import { activeEditorSupportsMissingPackages, MISSING_PACKAGES_SUPPORTED_KEY, MissingPackagesContextKeyContribution } from '../../browser/missingPackagesContextKey.js';
 
 describe('activeEditorSupportsMissingPackages', () => {
 	const sessionWithCapability = stubInterface<ILanguageRuntimeSession>({ listMissingPackages: async () => [] });
@@ -27,5 +32,138 @@ describe('activeEditorSupportsMissingPackages', () => {
 
 	it('is false when the active language session does not support missing packages', () => {
 		expect(activeEditorSupportsMissingPackages('anything', sessionWithoutCapability)).toBe(false);
+	});
+});
+
+describe('MissingPackagesContextKeyContribution', () => {
+	const onDidActiveEditorChange = new Emitter<void>();
+	const onDidStartRuntime = new Emitter<ILanguageRuntimeSession>();
+	const onDidFailStartRuntime = new Emitter<ILanguageRuntimeSession>();
+	const onDidChangeRuntimeState = new Emitter<ILanguageRuntimeSessionStateEvent>();
+	const onDidChangeForegroundSession = new Emitter<ILanguageRuntimeSession | undefined>();
+	const onDidDeleteRuntimeSession = new Emitter<string>();
+
+	const sessionWithCapability = stubInterface<ILanguageRuntimeSession>({
+		sessionId: 'julia-session',
+		listMissingPackages: async () => [],
+	});
+
+	let activeLanguageId: string | undefined;
+	let activeSession: ILanguageRuntimeSession | undefined;
+	let supported: boolean | undefined;
+
+	const ctx = createTestContainer()
+		.stub(IContextKeyService, {
+			onDidChangeContext: Event.None,
+			bufferChangeEvents: (callback: () => void) => callback(),
+			createKey: <T extends ContextKeyValue>(key: string, defaultValue: T | undefined): IContextKey<T> => {
+				let value = defaultValue;
+				if (key === MISSING_PACKAGES_SUPPORTED_KEY.key && typeof defaultValue === 'boolean') {
+					supported = defaultValue;
+				}
+				return {
+					set: newValue => {
+						value = newValue;
+						if (key === MISSING_PACKAGES_SUPPORTED_KEY.key && typeof newValue === 'boolean') {
+							supported = newValue;
+						}
+					},
+					reset: () => {
+						value = defaultValue;
+						if (key === MISSING_PACKAGES_SUPPORTED_KEY.key && typeof defaultValue === 'boolean') {
+							supported = defaultValue;
+						}
+					},
+					get: () => value,
+				};
+			},
+			getContextKeyValue: () => supported,
+		})
+		.stub(IEditorService, {
+			get activeTextEditorLanguageId() {
+				return activeLanguageId;
+			},
+			onDidActiveEditorChange: onDidActiveEditorChange.event,
+		})
+		.stub(IRuntimeSessionService, {
+			onDidStartRuntime: onDidStartRuntime.event,
+			onDidFailStartRuntime: onDidFailStartRuntime.event,
+			onDidChangeRuntimeState: onDidChangeRuntimeState.event,
+			onDidChangeForegroundSession: onDidChangeForegroundSession.event,
+			onDidDeleteRuntimeSession: onDidDeleteRuntimeSession.event,
+			getConsoleSessionForLanguage: () => activeSession,
+		})
+		.build();
+
+	beforeEach(() => {
+		activeLanguageId = 'julia';
+		activeSession = sessionWithCapability;
+		supported = undefined;
+	});
+
+	function createContribution(): MissingPackagesContextKeyContribution {
+		return ctx.disposables.add(ctx.instantiationService.createInstance(MissingPackagesContextKeyContribution));
+	}
+
+	it('updates when the active session is deleted', () => {
+		createContribution();
+		expect(supported).toBe(true);
+
+		activeSession = undefined;
+		onDidDeleteRuntimeSession.fire('julia-session');
+
+		expect(supported).toBe(false);
+	});
+
+	it('updates when the active editor language changes', () => {
+		activeLanguageId = undefined;
+		activeSession = undefined;
+		createContribution();
+		expect(supported).toBe(false);
+
+		activeLanguageId = 'julia';
+		activeSession = sessionWithCapability;
+		onDidActiveEditorChange.fire();
+		expect(supported).toBe(true);
+
+		activeLanguageId = 'plaintext';
+		activeSession = undefined;
+		onDidActiveEditorChange.fire();
+		expect(supported).toBe(false);
+	});
+
+	it('updates when the foreground session changes', () => {
+		activeSession = undefined;
+		createContribution();
+		expect(supported).toBe(false);
+
+		activeSession = sessionWithCapability;
+		onDidChangeForegroundSession.fire(sessionWithCapability);
+		expect(supported).toBe(true);
+
+		activeSession = undefined;
+		onDidChangeForegroundSession.fire(undefined);
+		expect(supported).toBe(false);
+	});
+
+	it('updates when the active session changes runtime state or fails startup', () => {
+		createContribution();
+		expect(supported).toBe(true);
+
+		activeSession = undefined;
+		onDidChangeRuntimeState.fire({
+			session_id: 'julia-session',
+			old_state: RuntimeState.Ready,
+			new_state: RuntimeState.Exited,
+		});
+		expect(supported).toBe(false);
+
+		activeSession = sessionWithCapability;
+		onDidStartRuntime.fire(sessionWithCapability);
+		expect(supported).toBe(true);
+
+		activeSession = undefined;
+		onDidFailStartRuntime.fire(sessionWithCapability);
+		expect(supported).toBe(false);
 	});
 });

--- a/src/vs/workbench/contrib/positronMissingPackages/test/browser/missingPackagesService.vitest.ts
+++ b/src/vs/workbench/contrib/positronMissingPackages/test/browser/missingPackagesService.vitest.ts
@@ -260,6 +260,32 @@ describe('MissingPackagesService', () => {
 		expect(listMissingPackages).not.toHaveBeenCalled();
 	});
 
+	it('analyzeError probes the runtime then analyzes the probe snippet', async () => {
+		const service = createService();
+
+		// The session's runtime recognizes the error and returns a probe snippet
+		// referencing the missing package; analyzeError hands it to the same
+		// analyzeCode path, which reports it via listMissingPackages (its default
+		// resolved value, [{ name: 'requests' }]).
+		session.getMissingPackageProbe = vi.fn(async () => 'import requests');
+
+		const result = await service.analyzeError(sessionId, { name: 'ModuleNotFoundError', message: `No module named 'requests'`, traceback: [] });
+
+		expect(session.getMissingPackageProbe).toHaveBeenCalledWith(
+			{ name: 'ModuleNotFoundError', message: `No module named 'requests'`, traceback: [] },
+			undefined,
+		);
+		expect(result).toEqual([{ name: 'requests' }]);
+	});
+
+	it('analyzeError returns empty when the runtime does not recognize the error', async () => {
+		const service = createService();
+		session.getMissingPackageProbe = vi.fn(async () => undefined);
+
+		expect(await service.analyzeError(sessionId, { name: '', message: 'boom', traceback: [] })).toEqual([]);
+		expect(listMissingPackages).not.toHaveBeenCalled();
+	});
+
 	it('getCached never triggers work', () => {
 		const service = createService();
 

--- a/src/vs/workbench/contrib/positronMissingPackages/test/browser/missingPackagesService.vitest.ts
+++ b/src/vs/workbench/contrib/positronMissingPackages/test/browser/missingPackagesService.vitest.ts
@@ -286,6 +286,24 @@ describe('MissingPackagesService', () => {
 		expect(listMissingPackages).not.toHaveBeenCalled();
 	});
 
+	it('analyzeError returns empty when the session does not support probes', async () => {
+		const service = createService();
+		session.getMissingPackageProbe = undefined;
+
+		expect(await service.analyzeError(sessionId, { name: '', message: 'boom', traceback: [] })).toEqual([]);
+		expect(listMissingPackages).not.toHaveBeenCalled();
+	});
+
+	it('analyzeError returns empty when the probe rejects, without propagating', async () => {
+		const service = createService();
+		session.getMissingPackageProbe = vi.fn(async () => { throw new Error('ext host gone'); });
+
+		// The resilience guard: a broken runtime must degrade to "no suggestion",
+		// not surface an unhandled rejection to the console UI.
+		expect(await service.analyzeError(sessionId, { name: '', message: 'boom', traceback: [] })).toEqual([]);
+		expect(listMissingPackages).not.toHaveBeenCalled();
+	});
+
 	it('getCached never triggers work', () => {
 		const service = createService();
 

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -290,6 +290,18 @@ export interface ILanguageRuntimeSession extends IDisposable {
 	 * @param token Optional cancellation token.
 	 */
 	listMissingPackages?(target: IRuntimeMissingPackagesTarget, token?: CancellationToken): Promise<IRuntimeMissingPackage[]>;
+
+	/**
+	 * Given a console error from this session, return a code snippet that
+	 * references the missing package (for the frontend to analyze via
+	 * `listMissingPackages`), or undefined when the error is not a recognized
+	 * missing-package error. Returns undefined if the runtime does not support
+	 * this.
+	 *
+	 * @param error The console error to inspect.
+	 * @param token Optional cancellation token.
+	 */
+	getMissingPackageProbe?(error: IRuntimeConsoleError, token?: CancellationToken): Promise<string | undefined>;
 }
 
 export interface INotebookRuntimeSessionMetadata extends IRuntimeSessionMetadata {
@@ -402,6 +414,18 @@ export interface IRuntimeMissingPackagesTarget {
 
 	/** URI of a saved file to analyze. The runtime may read/parse it directly. */
 	readonly uri?: string;
+}
+
+/**
+ * A runtime error surfaced in the console, passed to `getMissingPackageProbe`.
+ */
+export interface IRuntimeConsoleError {
+	/** The error name, e.g. "ModuleNotFoundError". May be empty. */
+	readonly name: string;
+	/** The error message, e.g. "No module named 'foo'". */
+	readonly message: string;
+	/** The error traceback, one entry per line. */
+	readonly traceback: string[];
 }
 
 /**


### PR DESCRIPTION
Fixes #14675

### Summary

The missing-packages prompts (editor/notebook badge, "Check/Install Missing Packages" command-palette commands, and the console-error install suggestion) were partly hardcoded to Python and R: the badge and commands matched a fixed list of language IDs, and the console-error provider recognized only Python's and R's error-message formats via regexes baked into the frontend.

This PR makes the frontend language-agnostic, so any runtime that implements the capability participates with no per-language changes in Positron core:

- The editor badge and command-palette commands are now gated on a capability context key (`positronActiveEditorSupportsMissingPackages`), true when the active editor is a Quarto document or its console session implements `listMissingPackages`, replacing the hardcoded python/r/Quarto allowlist.
- The console-error install suggestion delegates error recognition to the session's runtime via a new optional API method, `LanguageRuntimeSession.getMissingPackageProbe(error)`. The runtime owns its own error format and returns a probe snippet (e.g. `import foo` / `library(foo)`) that the frontend routes back through the existing installable-package check. The Python/R error regexes moved into the `positron-python` and `positron-r` extensions.

As a result, Julia (which already implements `listMissingPackages`, [TidierOrg/positron-julia#36](https://github.com/TidierOrg/positron-julia/pull/36)) immediately gets the editor badge and commands; it will get the console-error suggestion once the Julia extension implements `getMissingPackageProbe`.

### Release Notes

#### New Features

- Missing-package install prompts (editor/notebook badge, command-palette commands, and the console-error install suggestion) now work for any language runtime that implements the capability, rather than being hardcoded to Python and R (#14675)

#### Bug Fixes

- N/A

### Validation Steps

@:packages-pane @:console

Verify the Python and R paths are unchanged (regression check):

1. In a Python console, run `import cowsay` (not installed by default). An "Install cowsay" lightbulb suggestion should appear in the console; clicking it installs the package.
2. Open a `.py` script that imports an uninstalled package and confirm the editor action-bar badge appears and installs it.
3. Repeat with R: run `library(cowsay)` in an R console and open a `.R` script; confirm the same suggestion and badge behavior.

If the Julia extension is installed:

4. Open a `.jl` file backed by a Julia session that supports missing packages, and confirm the editor badge and the "Check for Missing Packages" / "Install Missing Packages" command-palette commands now appear.

