### PR TITLE
Make it possible to cancel a run in the R test explorer

### DIFF
--- a/extensions/positron-r/resources/testing/r.pkg.test.explorer.fixture/tests/testthat/test-cancel.R
+++ b/extensions/positron-r/resources/testing/r.pkg.test.explorer.fixture/tests/testthat/test-cancel.R
@@ -1,0 +1,10 @@
+test_that("a test that can be cancelled", {
+  # The e2e writes CANCEL to trigger this sleep.
+  if (file.exists("CANCEL")) {
+    on.exit(file.create("ON.EXIT"))
+    Sys.sleep(30)
+    # If we successfully interrupt during the sleep, we never get this far.
+    file.create("SLEEP COMPLETED")
+  }
+  expect_true(TRUE)
+})

--- a/extensions/positron-r/resources/testing/r.pkg.test.explorer.fixture/tests/testthat/test-cancel.R
+++ b/extensions/positron-r/resources/testing/r.pkg.test.explorer.fixture/tests/testthat/test-cancel.R
@@ -1,10 +1,21 @@
 test_that("a test that can be cancelled", {
-  # The e2e writes CANCEL to trigger this sleep.
+  # The e2e creates a CANCEL file to trigger this extended period of a sleepy
+  # heartbeat.
+  #
+  # If we successfully interrupt the test run, the heartbeat stops and the
+  # COMPLETED file does not get written.
+  #
+  # A graceful interrupt (SIGINT, POSIX case) runs on.exit() and the ON.EXIT
+  # file is written.
+  #
+  # On Windows, we have to force-kill and ON.EXIT is not created.
   if (file.exists("CANCEL")) {
     on.exit(file.create("ON.EXIT"))
-    Sys.sleep(30)
-    # If we successfully interrupt during the sleep, we never get this far.
-    file.create("SLEEP COMPLETED")
+    for (i in seq_len(600)) {
+      cat(".", file = "HEARTBEAT", append = TRUE)
+      Sys.sleep(0.1)
+    }
+    file.create("COMPLETED")
   }
   expect_true(TRUE)
 })

--- a/extensions/positron-r/resources/testing/r.pkg.test.explorer.fixture/tests/testthat/test-multi-line-desc.R
+++ b/extensions/positron-r/resources/testing/r.pkg.test.explorer.fixture/tests/testthat/test-multi-line-desc.R
@@ -1,4 +1,0 @@
-test_that("test_that with a
-multi-line description passes", {
-  expect_equal(2 * 2, 4)
-})

--- a/extensions/positron-r/resources/testing/r.pkg.test.explorer.fixture/tests/testthat/test-tricky-desc.R
+++ b/extensions/positron-r/resources/testing/r.pkg.test.explorer.fixture/tests/testthat/test-tricky-desc.R
@@ -1,0 +1,24 @@
+test_that("test_that with a
+multi-line description passes", {
+  expect_true(TRUE)
+})
+
+test_that("test_that with 'single quotes' fails", {
+  expect_true(FALSE)
+})
+
+test_that("test_that with one ' single quote passes", {
+  expect_true(TRUE)
+})
+
+test_that("test_that with `backticks` fails", {
+  expect_true(FALSE)
+})
+
+test_that("test_that with an & ampersand passes", {
+  expect_true(TRUE)
+})
+
+test_that("test_that with a slash / fails", {
+  expect_true(FALSE)
+})

--- a/extensions/positron-r/src/test/util-testing.unit.test.ts
+++ b/extensions/positron-r/src/test/util-testing.unit.test.ts
@@ -10,8 +10,9 @@ suite('escapeLabelForRDesc', () => {
 	const cases: Record<string, [input: string, expected: string]> = {
 		'leaves a plain label untouched': ['plain label', 'plain label'],
 		'escapes single quotes': ['it\'s fine', 'it\\\'s fine'],
-		'escapes double quotes and backticks': ['a "b" `c`', 'a \\"b\\" \\`c\\`'],
-		'escapes a LF newline': ['multi\nline', 'multi\\nline'],
+		'leaves double quotes and backticks untouched': ['a "b" `c`', 'a "b" `c`'],
+		'leaves a LF newline untouched': ['multi\nline', 'multi\nline'],
+		'leaves backslashes untouched': ['a\\b', 'a\\b'],
 	};
 
 	for (const [name, [input, expected]] of Object.entries(cases)) {

--- a/extensions/positron-r/src/test/util-testing.unit.test.ts
+++ b/extensions/positron-r/src/test/util-testing.unit.test.ts
@@ -8,11 +8,12 @@ import { escapeLabelForRDesc } from '../testing/util-testing';
 
 suite('escapeLabelForRDesc', () => {
 	const cases: Record<string, [input: string, expected: string]> = {
+		'leaves an empty label untouched': ['', ''],
 		'leaves a plain label untouched': ['plain label', 'plain label'],
-		'escapes single quotes': ['it\'s fine', 'it\\\'s fine'],
-		'leaves double quotes and backticks untouched': ['a "b" `c`', 'a "b" `c`'],
-		'leaves a LF newline untouched': ['multi\nline', 'multi\nline'],
-		'leaves backslashes untouched': ['a\\b', 'a\\b'],
+		'escapes single quotes': ['it\'s a \'test\'', 'it\\\'s a \\\'test\\\''],
+		'escapes newlines': ['a\nb\nc', 'a\\nb\\nc'],
+		'escapes single quotes and newlines together': ['line \'one\'\nline \'two\'', 'line \\\'one\\\'\\nline \\\'two\\\''],
+		'leaves double quotes, backticks, and backslashes untouched': ['a "b" `c` d\\e & f / g', 'a "b" `c` d\\e & f / g'],
 	};
 
 	for (const [name, [input, expected]] of Object.entries(cases)) {

--- a/extensions/positron-r/src/testing/runner-testthat.ts
+++ b/extensions/positron-r/src/testing/runner-testthat.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { spawn, ChildProcess } from 'child_process';
+import { spawn, spawnSync, ChildProcess } from 'child_process';
 import split2 from 'split2';
 import { LOGGER } from '../extension';
 import { checkInstalled, getLocale } from '../session';
@@ -24,8 +24,8 @@ const testReporterPath = path
 const activeRunProcesses = new Set<ChildProcess>();
 
 // Signal the R test-run process by PID. POSIX SIGINT lets R unwind gracefully;
-// SIGKILL forces it. Windows has no per-process signal, so taskkill /F is always a
-// forceful terminate.
+// SIGKILL forces it. Windows has no per-process signal, so taskkill force-terminates;
+// /T also kills the child R process (the R.exe front-end spawns the actual R).
 function signalRunProcess(childProcess: ChildProcess, signal: NodeJS.Signals): void {
 	const pid = childProcess.pid;
 	if (pid === undefined) {
@@ -33,7 +33,8 @@ function signalRunProcess(childProcess: ChildProcess, signal: NodeJS.Signals): v
 	}
 	try {
 		if (process.platform === 'win32') {
-			spawn('taskkill', ['/pid', String(pid), '/F']);
+			const result = spawnSync('taskkill', ['/pid', String(pid), '/T', '/F'], { encoding: 'utf8' });
+			LOGGER.info(`taskkill /T /F pid=${pid}: status=${result.status}, stdout=${result.stdout?.trim()}, stderr=${result.stderr?.trim()}`);
 		} else {
 			process.kill(pid, signal);
 		}

--- a/extensions/positron-r/src/testing/runner-testthat.ts
+++ b/extensions/positron-r/src/testing/runner-testthat.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { spawn } from 'child_process';
+import { spawn, ChildProcess } from 'child_process';
 import split2 from 'split2';
 import { LOGGER } from '../extension';
 import { checkInstalled, getLocale } from '../session';
@@ -18,9 +18,46 @@ const testReporterPath = path
 	.join(EXTENSION_ROOT_DIR, 'resources', 'testing', 'vscodereporter')
 	.replace(/\\/g, '/');
 
+// Test-run R processes currently in flight. The OS won't reap them if the extension
+// host goes away mid-run, so we track them and hard-kill any survivors when the test
+// explorer is disposed (see killActiveTestRuns).
+const activeRunProcesses = new Set<ChildProcess>();
+
+// Signal the R test-run process by PID. POSIX SIGINT lets R unwind gracefully;
+// SIGKILL forces it. Windows has no per-process signal, so taskkill /F is always a
+// forceful terminate.
+function signalRunProcess(childProcess: ChildProcess, signal: NodeJS.Signals): void {
+	const pid = childProcess.pid;
+	if (pid === undefined) {
+		return;
+	}
+	try {
+		if (process.platform === 'win32') {
+			spawn('taskkill', ['/pid', String(pid), '/F']);
+		} else {
+			process.kill(pid, signal);
+		}
+	} catch (err) {
+		LOGGER.warn(`Failed to send ${signal} to the R test run: ${err}`);
+	}
+}
+
+/**
+ * Hard-kill any in-flight test-run processes. Called when the test explorer is torn
+ * down so a run interrupted by a window close or reload can't leak the R process.
+ * There's no time for graceful cleanup on this path, so we SIGKILL.
+ */
+export function killActiveTestRuns(): void {
+	for (const childProcess of activeRunProcesses) {
+		signalRunProcess(childProcess, 'SIGKILL');
+	}
+	activeRunProcesses.clear();
+}
+
 export async function runThatTest(
 	testingTools: TestingTools,
 	run: vscode.TestRun,
+	token: vscode.CancellationToken,
 	test?: vscode.TestItem
 ): Promise<string> {
 	// in all scenarios, we execute devtools::SOMETHING() in a child process
@@ -92,25 +129,65 @@ export async function runThatTest(
 		`devtools::${devtoolsMethod}('${testPath}',` +
 		`${descInsert}reporter = VSCodeReporter)`;
 	const binpath = RSessionManager.instance.getLastBinpath();
-	const command = `"${binpath}" --no-echo -e "${devtoolsCall}"`;
-	LOGGER.info(`devtools call is:\n${command}`);
+	const args = ['--no-echo', '-e', devtoolsCall];
+	LOGGER.info(`R binary is: ${binpath}`);
+	LOGGER.info(`devtools call is:\n${devtoolsCall}`);
 
 	const wd = testingTools.packageRoot.fsPath;
 	LOGGER.info(`Running devtools call in working directory ${wd}`);
 	const locale = await getLocale();
 	LOGGER.info(`Locale info from active R session: ${JSON.stringify(locale, null, 2)}`);
 	let hostFile = '';
-	// TODO @jennybc: if this code stays, figure this out
-	// eslint-disable-next-line no-async-promise-executor
-	return new Promise<string>(async (resolve, reject) => {
-		const childProcess = spawn(command, {
+	return new Promise<string>((resolve, reject) => {
+		const childProcess = spawn(binpath, args, {
 			cwd: wd,
-			shell: true,
 			env: {
 				...process.env,
 				LANG: locale['LANG']
 			}
 		});
+		activeRunProcesses.add(childProcess);
+
+		let cancelled = false;
+		let forceQuitTimer: NodeJS.Timeout | undefined;
+		const cancellation = token.onCancellationRequested(() => {
+			cancelled = true;
+			LOGGER.info('Test run cancelled; interrupting R so cleanup can run');
+			// Append now, not on exit: core can finalize a cancelled run before R
+			// exits, so a note appended on exit may be dropped.
+			run.appendOutput('\r\nThe test run was stopped at the user\'s request.\r\n');
+			// SIGINT lets R unwind and run on.exit / withr / teardown cleanup before
+			// exiting; SIGTERM and SIGKILL would skip all of that. So we hope
+			// that SIGINT works.
+			signalRunProcess(childProcess, 'SIGINT');
+			// If R hasn't stopped after a grace period (e.g. a non-interruptible
+			// C loop), we offer to force quit. We use 7s because it's less than the
+			// 10s after which the core test explorer makes the run look cancelled in
+			// the UI even though it hasn't really stopped -- so we prompt before that.
+			forceQuitTimer = setTimeout(() => {
+				if (childProcess.exitCode !== null || childProcess.signalCode !== null) {
+					return;
+				}
+				vscode.window.showWarningMessage(
+					vscode.l10n.t('R is not responding to the interrupt signal. You can force quit, but this may skip test cleanup and teardown.'),
+					vscode.l10n.t('Force Quit')
+				).then((choice) => {
+					if (choice !== undefined &&
+						childProcess.exitCode === null && childProcess.signalCode === null) {
+						LOGGER.info('User chose to force quit the R test run');
+						signalRunProcess(childProcess, 'SIGKILL');
+					}
+				});
+			}, 7_000);
+		});
+		const cleanup = () => {
+			cancellation.dispose();
+			if (forceQuitTimer !== undefined) {
+				clearTimeout(forceQuitTimer);
+			}
+			activeRunProcesses.delete(childProcess);
+		};
+
 		let stdout = '';
 		let sawEndReporter = false;
 		const testStartDates = new WeakMap<vscode.TestItem, number>();
@@ -219,9 +296,15 @@ export async function runThatTest(
 				}
 			});
 		childProcess.once('exit', (code, signal) => {
+			cleanup();
 			const stderr = String(childProcess.stderr.read() ?? '');
 			stdout += stderr;
 			if (sawEndReporter) {
+				resolve(stdout);
+				return;
+			}
+			if (cancelled) {
+				// The user stopped the run; the note was appended at cancellation time.
 				resolve(stdout);
 				return;
 			}
@@ -240,6 +323,7 @@ export async function runThatTest(
 			reject(new Error(detail || `R exited with ${how} before completing.`));
 		});
 		childProcess.once('error', (err) => {
+			cleanup();
 			reject(err);
 		});
 	});

--- a/extensions/positron-r/src/testing/runner.ts
+++ b/extensions/positron-r/src/testing/runner.ts
@@ -98,7 +98,7 @@ export async function runHandler(
 			} else {
 				LOGGER.info(`Running test with label "${test!.label}"`);
 			}
-			const stdout = await runThatTest(testingTools, run, test);
+			const stdout = await runThatTest(testingTools, run, token, test);
 			LOGGER.info(`Test output:\n${stdout}`);
 		} catch (error) {
 			LOGGER.error(`Run errored with reason: "${error}"`);

--- a/extensions/positron-r/src/testing/testing.ts
+++ b/extensions/positron-r/src/testing/testing.ts
@@ -8,6 +8,7 @@ import { ItemType, TestingTools } from './util-testing';
 import { discoverTestFiles, loadTestsFromFile } from './loader';
 import { createTestthatWatchers } from './watcher';
 import { runHandler } from './runner';
+import { killActiveTestRuns } from './runner-testthat';
 import { LOGGER } from '../extension';
 import { detectRPackage, getRPackageName } from '../contexts';
 
@@ -74,6 +75,9 @@ export async function discoverTests(context: vscode.ExtensionContext) {
 	);
 	context.subscriptions.push(controller);
 	context.subscriptions.push(_onDidDiscoverTestFiles);
+	// If the extension host is torn down (window close / reload) mid-run, the spawned
+	// R process won't be reaped automatically, so kill any survivors.
+	context.subscriptions.push({ dispose: killActiveTestRuns });
 
 	const testItemData = new WeakMap<vscode.TestItem, ItemType>();
 	const testingTools: TestingTools = {

--- a/extensions/positron-r/src/testing/util-testing.ts
+++ b/extensions/positron-r/src/testing/util-testing.ts
@@ -43,7 +43,9 @@ export function uriToFileNodeId(uri: vscode.Uri): string {
  * `devtools::test_active_file(..., desc = 'LABEL')`.
  */
 export function escapeLabelForRDesc(label: string): string {
-	return label.replace(/'/g, '\\\'');
+	return label
+		.replace(/'/g, '\\\'')
+		.replace(/\n/g, '\\n');
 }
 
 export interface TestParser {

--- a/extensions/positron-r/src/testing/util-testing.ts
+++ b/extensions/positron-r/src/testing/util-testing.ts
@@ -39,16 +39,11 @@ export function uriToFileNodeId(uri: vscode.Uri): string {
 }
 
 /**
- * Escape a test label for use as the `desc` argument when running a single test
- * via R. The label is embedded in an R single-quoted string literal, itself inside
- * a double-quoted shell `-e` argument, so embedded quotes and backticks must be
- * escaped. The `\n` inside a multi-line description must also be escaped for
- * proper handling on Windows (#10133).
+ * Escape a test label for embedding in a call like
+ * `devtools::test_active_file(..., desc = 'LABEL')`.
  */
 export function escapeLabelForRDesc(label: string): string {
-	return label
-		.replace(/(['"`])/g, '\\$1')
-		.replace(/\n/g, '\\n');
+	return label.replace(/'/g, '\\\'');
 }
 
 export interface TestParser {

--- a/test/e2e/pages/testExplorer.ts
+++ b/test/e2e/pages/testExplorer.ts
@@ -10,6 +10,19 @@ import { Explorer } from './explorer';
 
 const TEST_EXPLORER_ICON = '.composite-bar .codicon-test-view-icon';
 
+// Codicon classes on a test row's `.computed-state` icon, per result state. The icon
+// tracks transient states (Queued/Running) live, unlike the aria-label. Running is a
+// generic spinner; the rest are testing-specific icons.
+const STATE_ICON_CLASS = {
+	Unset: 'codicon-testing-unset-icon',
+	Queued: 'codicon-testing-queued-icon',
+	Running: 'codicon-modifier-spin',
+	Passed: 'codicon-testing-passed-icon',
+	Failed: 'codicon-testing-failed-icon',
+	Errored: 'codicon-testing-error-icon',
+	Skipped: 'codicon-testing-skipped-icon',
+} as const;
+
 /*
  *  Reuseable Positron test explorer functionality for tests to leverage.
  */
@@ -32,6 +45,10 @@ export class TestExplorer extends Explorer {
 
 	async clearAllTestResults(): Promise<void> {
 		await this.quickaccess.runCommand('testing.clearTestResults');
+	}
+
+	async cancelTestRun(): Promise<void> {
+		await this.quickaccess.runCommand('testing.cancelRun');
 	}
 
 	async expectTestItems(labels: string[], timeout?: number): Promise<void> {
@@ -73,5 +90,11 @@ export class TestExplorer extends Explorer {
 	async expectTestStatus(label: string, state: 'Passed' | 'Failed' | 'Errored' | 'Skipped', timeout?: number): Promise<void> {
 		const tree = this.code.driver.currentPage.locator('.test-explorer');
 		await expect(tree.getByLabel(`${label} (${state})`)).toBeVisible({ timeout });
+	}
+
+	async expectTestIcon(label: string, state: keyof typeof STATE_ICON_CLASS, timeout?: number): Promise<void> {
+		const tree = this.code.driver.currentPage.locator('.test-explorer');
+		const row = tree.locator('.monaco-list-row', { hasText: label });
+		await expect(row.locator('.computed-state')).toHaveClass(new RegExp(STATE_ICON_CLASS[state]), { timeout });
 	}
 }

--- a/test/e2e/tests/test-explorer/test-explorer.test.ts
+++ b/test/e2e/tests/test-explorer/test-explorer.test.ts
@@ -6,7 +6,7 @@
 import path = require('path');
 import fs = require('fs');
 import { copyFixtureFolder } from '../../infra/test-runner';
-import { test, tags } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
@@ -167,5 +167,30 @@ test.describe('R Test Explorer', { tag: [tags.TEST_EXPLORER, tags.R_PKG_DEVELOPM
 		// 'Passed' must be cleared to 'Skipped', not left stale.
 		await testExplorer.runAllTests();
 		await testExplorer.expectTestStatus(AFTER, 'Skipped', 60000);
+	});
+
+	test('A running test can be cancelled', async function ({ app }, testInfo) {
+		const { testExplorer } = app.workbench;
+		const testthatDir = path.join(path.dirname(app.workspacePathOrFolder), fixtureFolderFor(testInfo.title, testInfo.workerIndex), 'tests', 'testthat');
+		const LABEL = 'a test that can be cancelled';
+
+		// This sentinel file triggers a long sleep in the test, which opens a
+		// nice window for us to cancel it here.
+		fs.writeFileSync(path.join(testthatDir, 'CANCEL'), '');
+
+		await testExplorer.expectTestItems(['test-cancel.R']);
+		await testExplorer.expandAllTests();
+		await testExplorer.runTest(LABEL);
+
+		// Make sure the test is actually running (not just queued), so we
+		// exercise the interrupt, rather than a no-op cancel of a queued run.
+		await testExplorer.expectTestIcon(LABEL, 'Running', 60000);
+		await testExplorer.cancelTestRun();
+
+		// Core marks any cancelled run Skipped, so also verify R was explicitly
+		// interrupted.
+		await expect.poll(() => fs.existsSync(path.join(testthatDir, 'ON.EXIT')), { timeout: 45000 }).toBe(true);
+		expect(fs.existsSync(path.join(testthatDir, 'SLEEP COMPLETED'))).toBe(false);
+		await testExplorer.expectTestStatus(LABEL, 'Skipped', 60000);
 	});
 });

--- a/test/e2e/tests/test-explorer/test-explorer.test.ts
+++ b/test/e2e/tests/test-explorer/test-explorer.test.ts
@@ -68,16 +68,37 @@ test.describe('R Test Explorer', { tag: [tags.TEST_EXPLORER, tags.R_PKG_DEVELOPM
 		await testExplorer.expectTestStatus('test_that number 2 fails', 'Failed');
 	});
 
-	// https://github.com/posit-dev/positron/issues/10133
-	test('Test with multi-line description can be run by itself', async function ({ app }) {
+	test('Tests with tricky descriptions report the correct status', async function ({ app }) {
 		const { testExplorer } = app.workbench;
-		const MULTI_LINE_LABEL = 'test_that with a multi-line description passes';
 
-		await testExplorer.expectTestItems(['test-multi-line-desc.R']);
+		await testExplorer.expectTestItems(['test-tricky-desc.R']);
+		await testExplorer.runAllTests();
+		await testExplorer.expectTestStatus('test-tricky-desc.R', 'Failed', 60000);
+
+		await testExplorer.expandAllTests();
+		await testExplorer.expectTestStatus('test_that with a multi-line description passes', 'Passed');
+		await testExplorer.expectTestStatus('test_that with \'single quotes\' fails', 'Failed');
+		await testExplorer.expectTestStatus('test_that with one \' single quote passes', 'Passed');
+		await testExplorer.expectTestStatus('test_that with `backticks` fails', 'Failed');
+		await testExplorer.expectTestStatus('test_that with an & ampersand passes', 'Passed');
+		await testExplorer.expectTestStatus('test_that with a slash / fails', 'Failed');
+	});
+
+	// https://github.com/posit-dev/positron/issues/10133
+	test('Tests with tricky descriptions can be run individually', async function ({ app }) {
+		const { testExplorer } = app.workbench;
+
+		await testExplorer.expectTestItems(['test-tricky-desc.R']);
 		await testExplorer.expandAllTests();
 
-		await testExplorer.runTest(MULTI_LINE_LABEL);
-		await testExplorer.expectTestStatus(MULTI_LINE_LABEL, 'Passed', 60000);
+		await testExplorer.runTest('test_that with a multi-line description passes');
+		await testExplorer.expectTestStatus('test_that with a multi-line description passes', 'Passed', 60000);
+
+		await testExplorer.runTest('test_that with \'single quotes\' fails');
+		await testExplorer.expectTestStatus('test_that with \'single quotes\' fails', 'Failed', 60000);
+
+		await testExplorer.runTest('test_that with `backticks` fails');
+		await testExplorer.expectTestStatus('test_that with `backticks` fails', 'Failed', 60000);
 	});
 
 	// https://github.com/posit-dev/positron/issues/2929

--- a/test/e2e/tests/test-explorer/test-explorer.test.ts
+++ b/test/e2e/tests/test-explorer/test-explorer.test.ts
@@ -173,24 +173,38 @@ test.describe('R Test Explorer', { tag: [tags.TEST_EXPLORER, tags.R_PKG_DEVELOPM
 		const { testExplorer } = app.workbench;
 		const testthatDir = path.join(path.dirname(app.workspacePathOrFolder), fixtureFolderFor(testInfo.title, testInfo.workerIndex), 'tests', 'testthat');
 		const LABEL = 'a test that can be cancelled';
+		const heartbeat = path.join(testthatDir, 'HEARTBEAT');
 
-		// This sentinel file triggers a long sleep in the test, which opens a
-		// nice window for us to cancel it here.
+		// This sentinel makes the test emit a heartbeat for about a minute, so
+		// it runs long enough for us to cancel it.
 		fs.writeFileSync(path.join(testthatDir, 'CANCEL'), '');
 
 		await testExplorer.expectTestItems(['test-cancel.R']);
 		await testExplorer.expandAllTests();
 		await testExplorer.runTest(LABEL);
 
-		// Make sure the test is actually running (not just queued), so we
-		// exercise the interrupt, rather than a no-op cancel of a queued run.
+		// Cancel only once the test is genuinely running, so we exercise a real
+		// interrupt and not a no-op cancel of a still-queued run.
 		await testExplorer.expectTestIcon(LABEL, 'Running', 60000);
+		await expect.poll(() => fs.existsSync(heartbeat), { timeout: 60000 }).toBe(true);
+
 		await testExplorer.cancelTestRun();
 
-		// Core marks any cancelled run Skipped, so also verify R was explicitly
-		// interrupted.
-		await expect.poll(() => fs.existsSync(path.join(testthatDir, 'ON.EXIT')), { timeout: 45000 }).toBe(true);
-		expect(fs.existsSync(path.join(testthatDir, 'SLEEP COMPLETED'))).toBe(false);
+		// Has the heartbeat stopped?
+		let lastSize = -1;
+		await expect.poll(() => {
+			const size = fs.existsSync(heartbeat) ? fs.statSync(heartbeat).size : -1;
+			const frozen = size > 0 && size === lastSize;
+			lastSize = size;
+			return frozen;
+		}, { timeout: 30000, intervals: [500] }).toBe(true);
+		expect(fs.existsSync(path.join(testthatDir, 'COMPLETED'))).toBe(false);
+
+		// We can only do a graceful interrupt (SIGINT) on POSIX, not Windows.
+		if (process.platform !== 'win32') {
+			await expect.poll(() => fs.existsSync(path.join(testthatDir, 'ON.EXIT')), { timeout: 10000 }).toBe(true);
+		}
+
 		await testExplorer.expectTestStatus(LABEL, 'Skipped', 60000);
 	});
 });


### PR DESCRIPTION
Closes #15130 
@:test-explorer @:web @:win

Adds support for stopping an in-progress test run in the R test explorer. The stop button and `testing.cancelRun` now interrupt the R process we spawn to run `devtools::test()` / `test_active_file()`. The UI also displays accurate statuses on tests/files and reflects that the test run is over.

<img width="458" height="280" alt="cancel-test-run-button" src="https://github.com/user-attachments/assets/7ce2fa8a-a635-4482-b888-7ae39ab8ab8c" />

There are 2 main pieces to the work:

* Handling the run's cancellation token: Previously we did *nothing* with the token, so R kept running to completion (or not 😬) in the background and the run never truly ended in the UI.

  The R test explorer plugs into the testing framework that Positron inherits from VS Code core. This core *did* mark cancelled tests as "Skipped" after ~10s, but the spinner and timer kept counting up and the test explorer was hung until R finished on its own or the user reloaded the window.

* Interrupting R: This is a lot harder than the cancellation token and requires a direct handle on its process. Previously the test run was spawned through a shell (`spawn(command, { shell: true })`), so the tracked pid was the shell, not R. Now we spawn R directly, so we can knock it on the head. This change caused a few other ripples in the code.

New behaviour on cancel:

* Terminate the R process running the tests:
  - On macOS and linux, we send SIGINT and R unwinds and runs `on.exit` / `withr` / `teardown` cleanup before exiting. Graceful.
  - On Windows, we have to do `taskkill /pid <pid> /T /F`, which just force kills it, without doing cleanup. In theory, it is possible to signal a graceful interrupt, but in reality it's pretty hard and out of scope. `/T` (tree kill) is required because `R.exe` is a front-end that spawns the real interpreter (`Rterm.exe`) as a child, so we must kill the tree.
  - After a 7s grace period, if R hasn't stopped, a non-modal **Force Quit** prompt offers `SIGKILL` (warning that cleanup/teardown may be skipped). Mostly only relevant to the macOS/linux case.
  - In-flight run processes are tracked; if the extension host goes away mid-run (window close/reload), we `SIGKILL` survivors so R can't leak. Very much an edge case.
* The run ends promptly: spinner and timer stop, and you can start another run (instead of the explorer being stuck).
* TEST RESULTS shows "The test run was stopped at the user's request."
* The run's queued-but-not-run items settle to "Skipped".

<img width="718" height="235" alt="after-cancel" src="https://github.com/user-attachments/assets/a1868207-0537-49f2-b9bb-f6ade79a2efe" />

### Known limitations

- If a package has `Config/testthat/parallel: true` in `DESCRIPTION`, test files still running when you cancel are killed without cleanup. That's just how testthat shuts down its worker subprocesses. It's not something positron-r controls.
- Windows cancel is forceful. `taskkill /F` is `TerminateProcess`, so `on.exit`/teardown do not run. There is no per-process graceful interrupt available to us from Node on Windows and there is no precedent for anything better in VS Code core or any other built-in extension. There are ways to do this with native code, but that would be another adventure like the one re: accessing the Windows registry, which I am not eager to repeat.

More than you ever wanted to know about interrupting R and background tasks: <https://blog.r-project.org/2023/05/23/not-interrupting-background-tasks-with-ctrl-c/>

### Testing

- I worked through a large manual test matrix which I'll put some notes on in a comment. So much of this is interactive and transient UI stuff that is not amenable to non-flaky e2e tests.
- One new e2e test that checks for test actually running, test being interrupted and not completing, test appearing as skipped, and (on macOS/linux) test cleanup happening. I have seen this go from red to green locally and on Windows in CI.
- Update to unit tests of `escapeLabelForRDesc()`.
- At the time of writing, the e2e chromium failures are all related to `New Folder Flow: Python Project › New env: ...` and have no apparent connection to this work.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- The R test explorer now implements "Cancel Test Run".

#### Bug Fixes

- N/A


### Validation Steps

If you want to verify basic functionality, just start a test run in any R package that takes several second or more. Click the square stop button to interrupt it.

Below I'll list the manual test matrix I worked through.