### PR TITLE
refactor(positronIPyWidgets): use DisposableMap for per-session disposables

### DIFF
--- a/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
+++ b/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
@@ -2,7 +2,7 @@
  *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
-import { Disposable, DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableMap, DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { ILanguageRuntimeMessageClearOutput, ILanguageRuntimeMessageError, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessageResult, ILanguageRuntimeMessageStream, LanguageRuntimeMessageType, LanguageRuntimeSessionMode, RuntimeOutputKind, RuntimeState } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, IRuntimeClientInstance, IRuntimeSessionService, RuntimeClientType } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
@@ -71,7 +71,7 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 	override dispose(): void {
 		super.dispose();
 		// Clean up disposables linked to any connected sessions
-		this._sessionToDisposablesMap.forEach(disposables => disposables.dispose());
+		this._sessionToDisposablesMap.dispose();
 	}
 
 	/**
@@ -165,7 +165,7 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 	 * repeatedly attaching to the same session which can happen in the case of the application
 	 * closing before the session ends
 	 */
-	private _sessionToDisposablesMap = new Map<string, DisposableStore>();
+	private readonly _sessionToDisposablesMap = new DisposableMap<string, DisposableStore>();
 
 	private attachSession(session: ILanguageRuntimeSession) {
 		// Check if we're already attached here
@@ -176,8 +176,9 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 		}
 		const disposables = new DisposableStore();
 		this._sessionToDisposablesMap.set(session.sessionId, disposables);
-		// Cleanup from map when disposed.
-		disposables.add(toDisposable(() => this._sessionToDisposablesMap.delete(session.sessionId)));
+		// Cleanup from map when disposed. Use deleteAndLeak: the store is disposing
+		// itself right now, so just remove the map entry, don't dispose it again.
+		disposables.add(toDisposable(() => this._sessionToDisposablesMap.deleteAndLeak(session.sessionId)));
 
 		switch (session.metadata.sessionMode) {
 			case LanguageRuntimeSessionMode.Console:


### PR DESCRIPTION
### Summary
Replaces `PositronIPyWidgetsService`'s hand-rolled `Map<string, DisposableStore>` with `DisposableMap`, which already provides the dispose-all-and-clear and dispose-on-overwrite behavior the class was implementing manually.
- `dispose()` now calls `_sessionToDisposablesMap.dispose()` instead of a manual `forEach(disposables => disposables.dispose())`.
- Per-session cleanup uses `deleteAndLeak` (remove the map entry without re-disposing a store that's already mid-disposal) instead of the native `Map.delete`.
- No behavior change: `attachSession`'s existing warn-and-dispose-before-overwrite check is untouched, since `DisposableStore.isDisposed` and `.get()`/`.set()` work the same against either container type.

### QA Notes
Pure refactor, no test changes needed; existing `positronIPyWidgetsService.vitest.ts` suite (19 tests) passes unchanged.
