### PR TITLE
Fix DuckDB on Intel Macs: Copy npm_config_arch => npm_config_cpu

### DIFF
--- a/build/npm/postinstall.ts
+++ b/build/npm/postinstall.ts
@@ -62,6 +62,29 @@ function spawnAsync(command: string, args: string[], opts: child_process.SpawnOp
 	});
 }
 
+// --- Start Positron ---
+/**
+ * Whether the given dir packages prebuilt per-arch *runtime* native bindings that
+ * must match the cross-build *target* architecture rather than the host. Keyed off a
+ * direct dependency on @duckdb/node-api (which pulls in @duckdb/node-bindings-<os>-<arch>
+ * as optional deps); this excludes host-tool dirs (ai-lib, build, ...) whose native
+ * optional deps -- e.g. the TypeScript 7 compiler binary -- must stay on the host arch.
+ * See the call site in npmInstallAsync and issue #15042.
+ */
+function dirShipsPrebuiltRuntimeBindings(dir: string): boolean {
+	const packageJsonPath = path.join(root, dir, 'package.json');
+	if (!fs.existsSync(packageJsonPath)) {
+		return false;
+	}
+	try {
+		const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+		return Boolean(pkg.dependencies?.['@duckdb/node-api'] || pkg.optionalDependencies?.['@duckdb/node-api']);
+	} catch {
+		return false;
+	}
+}
+// --- End Positron ---
+
 async function npmInstallAsync(dir: string, opts?: child_process.SpawnOptions): Promise<void> {
 	const finalOpts: child_process.SpawnOptions = {
 		env: { ...process.env },
@@ -79,10 +102,18 @@ async function npmInstallAsync(dir: string, opts?: child_process.SpawnOptions): 
 	// `--cpu` (`npm_config_cpu`) config overrides it. Without this, packages that
 	// ship prebuilt per-arch bindings via optional dependencies (e.g. @duckdb/node-api
 	// -> @duckdb/node-bindings-darwin-*) get the host-arch binding bundled instead of
-	// the target's, and fail to load at runtime with MODULE_NOT_FOUND. Translate the
-	// target arch into `npm_config_cpu` so npm selects the correct optional deps.
+	// the target's, and fail to load at runtime with MODULE_NOT_FOUND.
+	//
+	// This must be scoped, NOT applied globally: `--cpu` also steers the optional
+	// deps of *build-time* tools that run on the host during install (e.g. the
+	// native TypeScript 7 compiler ships `@typescript/typescript-<os>-<arch>` and
+	// runs `tsc` on the host), and forcing those to the target arch makes the host
+	// tool unable to load its own binary. So only translate the arch for dirs that
+	// ship prebuilt per-arch *runtime* bindings we package into the app -- detected
+	// by a direct dependency on @duckdb/node-api, which excludes host-tool dirs like
+	// ai-lib and build. See
 	const env = finalOpts.env;
-	if (env && env['npm_config_arch'] && !env['npm_config_cpu']) {
+	if (env && env['npm_config_arch'] && !env['npm_config_cpu'] && dirShipsPrebuiltRuntimeBindings(dir)) {
 		env['npm_config_cpu'] = env['npm_config_arch'];
 	}
 	// --- End Positron ---

--- a/build/npm/postinstall.ts
+++ b/build/npm/postinstall.ts
@@ -70,6 +70,23 @@ async function npmInstallAsync(dir: string, opts?: child_process.SpawnOptions): 
 		shell: true,
 	};
 
+	// --- Start Positron ---
+	// When cross-building (e.g. an x64 build on an arm64 macOS machine) the build
+	// sets `npm_config_arch` to the *target* architecture. node-gyp reads that to
+	// compile native modules for the target, but npm ignores `arch` when choosing
+	// which platform-specific optional dependencies to install -- it filters those
+	// by the package's `cpu` field, which npm derives from `process.arch` unless the
+	// `--cpu` (`npm_config_cpu`) config overrides it. Without this, packages that
+	// ship prebuilt per-arch bindings via optional dependencies (e.g. @duckdb/node-api
+	// -> @duckdb/node-bindings-darwin-*) get the host-arch binding bundled instead of
+	// the target's, and fail to load at runtime with MODULE_NOT_FOUND. Translate the
+	// target arch into `npm_config_cpu` so npm selects the correct optional deps.
+	const env = finalOpts.env;
+	if (env && env['npm_config_arch'] && !env['npm_config_cpu']) {
+		env['npm_config_cpu'] = env['npm_config_arch'];
+	}
+	// --- End Positron ---
+
 	const command = process.env['npm_command'] || 'install';
 
 	if (process.env['VSCODE_REMOTE_DEPENDENCIES_CONTAINER_NAME'] && /^(.build\/distro\/npm\/)?remote$/.test(dir)) {


### PR DESCRIPTION
Fixes #15042

Intel (x64) macOS builds are produced on arm64 build machines, so the build sets `npm_config_arch=x64` to signal the cross-compilation target. node-gyp honors that when compiling native modules, but npm ignores `arch` when choosing which platform-specific *optional* dependencies to install -- it filters those by each package's `cpu` field, which it derives from `process.arch` (the arm64 host) unless the `--cpu` config overrides it.

`@duckdb/node-api` ships its prebuilt bindings as per-arch optional dependencies (`@duckdb/node-bindings-darwin-x64`, `-darwin-arm64`, ...), so the x64 build ended up bundling the host's `darwin-arm64` binding. On an Intel Mac, DuckDB then looks for `@duckdb/node-bindings-darwin-x64/duckdb.node`, which isn't present, and the Data Explorer fails with `MODULE_NOT_FOUND`.

The fix copies `npm_config_arch` into `npm_config_cpu` in the extension install step (`build/npm/postinstall.ts`), so npm selects the optional dependency matching the target architecture. 

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed the Data Explorer failing to open on Intel (x64) macOS with a missing `@duckdb/node-bindings-darwin-x64/duckdb.node` error (#15042)

### Validation Steps

@:data-explorer

This regression only reproduces in an x64 build produced on an arm64 machine, so validation requires an Intel (x64) macOS build artifact rather than a local dev build:

1. Build/obtain an x64 macOS build (e.g. the `x64` macOS build workflow) and install it on an Intel Mac (or verify the packaged `extensions/positron-duckdb/node_modules/@duckdb/` contains `node-bindings-darwin-x64`).
2. Double-click a `.csv` file in the File Explorer pane.
3. Verify the Data Explorer opens and renders the data instead of showing "The DuckDb process terminated unexpectedly".
