### PR TITLE
Add Viewer history navigation

### DIFF
--- a/src/vs/workbench/contrib/positronPreview/browser/components/basicActionBars.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/components/basicActionBars.tsx
@@ -20,6 +20,7 @@ import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { PreviewWebview } from '../previewWebview.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
+import { PreviewHistoryActions } from './previewHistoryActions.js';
 
 const clear = localize('positron.preview.html.clear', "Clear the content");
 
@@ -60,6 +61,7 @@ export const BasicActionBars = (props: PropsWithChildren<BasicActionBarsProps>) 
 			<div className='action-bars preview-action-bar'>
 				<PositronActionBar borderBottom={true} borderTop={true} paddingLeft={kPaddingLeft} paddingRight={kPaddingRight}>
 					<ActionBarRegion location='left'>
+						<PreviewHistoryActions />
 						<span className='codicon codicon-file'></span>
 					</ActionBarRegion>
 					<ActionBarRegion location='center'>

--- a/src/vs/workbench/contrib/positronPreview/browser/components/htmlActionBars.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/components/htmlActionBars.tsx
@@ -24,6 +24,7 @@ import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { PreviewOpenTarget } from '../positronPreviewSevice.js';
+import { PreviewHistoryActions } from './previewHistoryActions.js';
 
 const reload = localize('positron.preview.html.reload', "Reload the content");
 const clear = localize('positron.preview.html.clear', "Clear the content");
@@ -120,6 +121,7 @@ export const HtmlActionBars = (props: PropsWithChildren<HtmlActionBarsProps>) =>
 			<div className='action-bars preview-action-bar'>
 				<PositronActionBar borderBottom={true} borderTop={true} paddingLeft={kPaddingLeft} paddingRight={kPaddingRight}>
 					<ActionBarRegion location='left'>
+						<PreviewHistoryActions />
 						<span className='codicon codicon-file'></span>
 					</ActionBarRegion>
 					<ActionBarRegion location='center'>

--- a/src/vs/workbench/contrib/positronPreview/browser/components/previewHistoryActions.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/components/previewHistoryActions.tsx
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { localize } from '../../../../../nls.js';
+import { ActionBarButton } from '../../../../../platform/positronActionBar/browser/components/actionBarButton.js';
+
+const showPreviousPreview = localize('positron.preview.previous', "Show Previous Viewer Item");
+const showNextPreview = localize('positron.preview.next', "Show Next Viewer Item");
+
+/**
+ * Buttons for navigating between the outputs in the Viewer history.
+ */
+export const PreviewHistoryActions = () => {
+	const services = usePositronReactServicesContext();
+
+	return (
+		<>
+			<ActionBarButton
+				ariaLabel={showPreviousPreview}
+				disabled={!services.positronPreviewService.canSelectPreviousPreview}
+				icon={ThemeIcon.fromId('positron-left-arrow')}
+				tooltip={showPreviousPreview}
+				onPressed={() => services.positronPreviewService.selectPreviousPreview()}
+			/>
+			<ActionBarButton
+				ariaLabel={showNextPreview}
+				disabled={!services.positronPreviewService.canSelectNextPreview}
+				icon={ThemeIcon.fromId('positron-right-arrow')}
+				tooltip={showNextPreview}
+				onPressed={() => services.positronPreviewService.selectNextPreview()}
+			/>
+		</>
+	);
+};

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
@@ -147,6 +147,22 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 		return this._items.get(this._selectedItemId);
 	}
 
+	get canSelectPreviousPreview(): boolean {
+		return this.activePreviewIndex > 0;
+	}
+
+	get canSelectNextPreview(): boolean {
+		const index = this.activePreviewIndex;
+		return index >= 0 && index < this.previewWebviews.length - 1;
+	}
+
+	/**
+	 * Gets the index of the active preview in the Viewer history.
+	 */
+	private get activePreviewIndex(): number {
+		return this.previewWebviews.findIndex(preview => preview.previewId === this._selectedItemId);
+	}
+
 	clearAllPreviews(): void {
 		// Set the active preview to nothing; this has the side effect of
 		// clearing the preview pane.
@@ -188,6 +204,22 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 		}
 	}
 
+	selectPreviousPreview(): void {
+		const previews = this.previewWebviews;
+		const index = this.activePreviewIndex;
+		if (index > 0) {
+			this.activePreviewWebviewId = previews[index - 1].previewId;
+		}
+	}
+
+	selectNextPreview(): void {
+		const previews = this.previewWebviews;
+		const index = this.activePreviewIndex;
+		if (index >= 0 && index < previews.length - 1) {
+			this.activePreviewWebviewId = previews[index + 1].previewId;
+		}
+	}
+
 	onDidChangeActivePreviewWebview: Event<string>;
 
 	onDidCreatePreviewWebview: Event<PreviewWebview>;
@@ -199,8 +231,7 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 		preserveFocus?: boolean | undefined): PreviewWebview {
 		const webview = this._webviewService.createWebviewOverlay(webviewInitInfo);
 		const preview = this.createPreviewWebview(previewId, webview, viewType, title);
-		this._items.set(preview.previewId, preview);
-		this.openPreviewWebview(preview, preserveFocus);
+		this.addAndActivatePreview(preview, preserveFocus);
 		return preview;
 	}
 
@@ -296,10 +327,20 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 		// Remove any other previews from the item list; they can be expensive
 		// to keep around.
 		this._items.clearAndDisposeAll();
-		this._items.set(preview.previewId, preview);
 
 		// Open the preview
-		this.openPreviewWebview(preview);
+		this.addAndActivatePreview(preview);
+	}
+
+	/**
+	 * Adds a preview to the Viewer history and makes it active.
+	 */
+	private addAndActivatePreview(
+		preview: PreviewWebview,
+		preserveFocus?: boolean
+	): void {
+		this._items.set(preview.previewId, preview);
+		this.openPreviewWebview(preview, preserveFocus);
 	}
 
 	/**
@@ -345,8 +386,8 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 		// Create the preview
 		const preview = this.createPreviewHtml('', previewId, extension, uri, evt);
 
-		// Make the preview active and return it
-		this.makeActivePreview(preview);
+		// Add the preview to the Viewer history and return it.
+		this.addAndActivatePreview(preview);
 		return preview;
 	}
 
@@ -455,8 +496,7 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 				'notebookRenderer',
 				session.dynState.sessionName
 			);
-			this._items.set(preview.previewId, preview);
-			this.openPreviewWebview(preview, false);
+			this.addAndActivatePreview(preview, false);
 		}
 	}
 
@@ -475,7 +515,7 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 		// Create the preview
 		const preview = this.createPreviewHtml(session.sessionId, previewId, webviewExtension, event.uri, event.event);
 
-		this.makeActivePreview(preview);
+		this.addAndActivatePreview(preview);
 	}
 
 	/**
@@ -607,7 +647,7 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 	 */
 	public openWebview(previewId: string, webview: IOverlayWebview, title: string): PreviewWebview {
 		const preview = this.createPreviewWebview(previewId, webview, 'notebookRenderer', title);
-		this.makeActivePreview(preview);
+		this.addAndActivatePreview(preview);
 		return preview;
 	}
 
@@ -670,7 +710,7 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 		</html>`);
 
 		const preview = new PreviewWebview(POSITRON_PREVIEW_HTML_VIEW_TYPE, previewId, title, overlay);
-		this.makeActivePreview(preview);
+		this.addAndActivatePreview(preview);
 		return preview;
 	}
 }

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreviewSevice.ts
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreviewSevice.ts
@@ -129,6 +129,28 @@ export interface IPositronPreviewService {
 
 	set activePreviewWebviewId(id: string);
 
+	/**
+	 * Whether there is a preview before the active preview in the Viewer
+	 * history.
+	 */
+	get canSelectPreviousPreview(): boolean;
+
+	/**
+	 * Whether there is a preview after the active preview in the Viewer
+	 * history.
+	 */
+	get canSelectNextPreview(): boolean;
+
+	/**
+	 * Selects the preview before the active preview, if there is one.
+	 */
+	selectPreviousPreview(): void;
+
+	/**
+	 * Selects the preview after the active preview, if there is one.
+	 */
+	selectNextPreview(): void;
+
 	openEditor(uri: URI, title?: string): Promise<void>;
 
 	editorWebview(editorId: string): PreviewWebview | undefined;

--- a/src/vs/workbench/contrib/positronPreview/test/electron-browser/positronPreviewService.vitest.ts
+++ b/src/vs/workbench/contrib/positronPreview/test/electron-browser/positronPreviewService.vitest.ts
@@ -28,4 +28,58 @@ describe('Positron - Preview Service', () => {
 		storageService.store(STORAGE_KEY, 'someUnknownValue', StorageScope.WORKSPACE, StorageTarget.MACHINE);
 		expect(previewService.getDefaultOpenTarget()).toBe(PreviewOpenTarget.Browser);
 	});
+
+	it('retains and navigates Viewer output history', () => {
+		const historyState = () => ({
+			previewIds: previewService.previewWebviews.map(preview => preview.previewId),
+			activePreviewId: previewService.activePreviewWebviewId,
+			canSelectPrevious: previewService.canSelectPreviousPreview,
+			canSelectNext: previewService.canSelectNextPreview,
+		});
+
+		previewService.openHtmlString('first', '<p>First</p>', 'First');
+		previewService.openHtmlString('second', '<p>Second</p>', 'Second');
+		const newestState = historyState();
+
+		previewService.selectPreviousPreview();
+		const previousState = historyState();
+
+		previewService.selectNextPreview();
+		const nextState = historyState();
+
+		previewService.clearAllPreviews();
+		const clearedState = historyState();
+
+		expect({
+			newestState,
+			previousState,
+			nextState,
+			clearedState,
+		}).toEqual({
+			newestState: {
+				previewIds: ['first', 'second'],
+				activePreviewId: 'second',
+				canSelectPrevious: true,
+				canSelectNext: false,
+			},
+			previousState: {
+				previewIds: ['first', 'second'],
+				activePreviewId: 'first',
+				canSelectPrevious: false,
+				canSelectNext: true,
+			},
+			nextState: {
+				previewIds: ['first', 'second'],
+				activePreviewId: 'second',
+				canSelectPrevious: true,
+				canSelectNext: false,
+			},
+			clearedState: {
+				previewIds: [],
+				activePreviewId: '',
+				canSelectPrevious: false,
+				canSelectNext: false,
+			},
+		});
+	});
 });

--- a/test/e2e/pages/viewer.ts
+++ b/test/e2e/pages/viewer.ts
@@ -14,6 +14,8 @@ const VIEWER_PANEL = '[id="workbench.panel.positronPreview"]';
 const ACTION_BAR = '.positron-action-bar';
 const OPEN_IN_DROPDOWN_BUTTON = '.preview-action-bar .action-bar-button-drop-down-button[aria-label="Select where to open"]';
 const OPEN_IN_PRIMARY_BUTTON = '.preview-action-bar .action-bar-button-action-button[aria-label="Select where to open"]';
+const PREVIOUS_VIEWER_ITEM_BUTTON = 'Show Previous Viewer Item';
+const NEXT_VIEWER_ITEM_BUTTON = 'Show Next Viewer Item';
 
 const FULL_APP = 'body';
 
@@ -66,6 +68,18 @@ export class Viewer {
 	async clickOpenInPrimaryButton() {
 		await test.step('Click primary half of "Open in..." split button', async () => {
 			await this.code.driver.currentPage.locator(OPEN_IN_PRIMARY_BUTTON).click();
+		});
+	}
+
+	async showPreviousViewerItem() {
+		await test.step('Show previous Viewer item', async () => {
+			await this.code.driver.currentPage.getByRole('button', { name: PREVIOUS_VIEWER_ITEM_BUTTON }).click();
+		});
+	}
+
+	async showNextViewerItem() {
+		await test.step('Show next Viewer item', async () => {
+			await this.code.driver.currentPage.getByRole('button', { name: NEXT_VIEWER_ITEM_BUTTON }).click();
 		});
 	}
 

--- a/test/e2e/tests/viewer/viewer.test.ts
+++ b/test/e2e/tests/viewer/viewer.test.ts
@@ -51,6 +51,24 @@ test.describe('Viewer', { tag: [tags.VIEWER, tags.CONSOLE] }, () => {
 		await viewer.expectContentVisible(frame => frame.getByText('Datsun 710'));
 	});
 
+	test('R - Verify Viewer navigates HTML output history', {
+		tag: [tags.WEB, tags.ARK, tags.CROSS_BROWSER]
+	}, async function ({ app, r }) {
+		const { console, viewer } = app.workbench;
+
+		await console.executeCode('R', rReactableHistoryFirstScript);
+		await viewer.expectContentVisible(frame => frame.getByText('first-result'));
+
+		await console.executeCode('R', rReactableHistorySecondScript);
+		await viewer.expectContentVisible(frame => frame.getByText('second-result'));
+
+		await viewer.showPreviousViewerItem();
+		await viewer.expectContentVisible(frame => frame.getByText('first-result'));
+
+		await viewer.showNextViewerItem();
+		await viewer.expectContentVisible(frame => frame.getByText('second-result'));
+	});
+
 	test('R - Verify Viewer displays reprex code output', {
 		tag: [tags.WEB, tags.ARK, tags.CROSS_BROWSER]
 	}, async function ({ app, r }) {
@@ -77,5 +95,9 @@ modelsummary(m1)`;
 
 const rReactableScript = `library(reactable)
 mtcars |> reactable::reactable()`;
+
+const rReactableHistoryFirstScript = `reactable::reactable(data.frame(result = "first-result"))`;
+
+const rReactableHistorySecondScript = `reactable::reactable(data.frame(result = "second-result"))`;
 
 const rReprexScript = `reprex::reprex(rbinom(3, size = 10, prob = 0.5), comment = "#;-)")`;


### PR DESCRIPTION
Fixes #8647.

Viewer output now remains available for the lifetime of the current window instead of each generated HTML page replacing the previous one. The HTML and notebook-renderer toolbars include previous/next buttons for moving through the in-memory output list. URL previews keep their existing browser navigation behavior.

### Release Notes

#### New Features

- Added previous and next navigation for Viewer output generated in the current project window.

#### Bug Fixes

- N/A

### Validation Steps

1. Generate two HTML Viewer outputs, such as two reactable tables.
2. Confirm the newest output is shown.
3. Use the left and right buttons to move between both outputs.
4. Confirm Clear removes the output history.

Validated locally with:

- npm run compile-check-ts-native
- npx vitest run src/vs/workbench/contrib/positronPreview/test/electron-browser/positronPreviewService.vitest.ts