### PR TITLE
fix(quarto): restore inline output on close+reopen before parse

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
@@ -177,6 +177,10 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 	// This prevents infinite loops when listening for model changes.
 	private _cachedOutputsLoaded = false;
 
+	// Track whether a cached-output restore is waiting for the document model to
+	// parse its cells, so we register the retry listener at most once per model.
+	private _awaitingParseRestore = false;
+
 	// Cells whose re-execution has started but not yet produced a replacement
 	// output. The previously cached output is kept until the first new output
 	// arrives (mirroring the view zone's "recomputing" behavior), so an
@@ -309,6 +313,7 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 			// Reset initialization flags so we can re-initialize for the new document
 			this._outputHandlingInitialized = false;
 			this._cachedOutputsLoaded = false;
+			this._awaitingParseRestore = false;
 
 			// Re-check if this is a Quarto document and initialize if so
 			if (this._featureEnabled && this._isQuartoDocument() && !this._isInDiffEditor()) {
@@ -830,19 +835,23 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 				}
 			}
 
-			// If no cache found and no cells available yet, subscribe to model parse events.
-			// This handles the case where an untitled document is being restored via hot exit
-			// and the content hasn't been loaded yet when _loadCachedOutputs is first called.
-			if ((!cachedDoc || cachedDoc.cells.length === 0) &&
-				quartoModel.cells.length === 0 &&
-				this._documentUri.scheme === 'untitled') {
+			// If the model has not parsed any cells yet, defer the restore until
+			// the next parse and retry once. Cached outputs are matched to live
+			// cells by content hash, so with zero parsed cells nothing matches
+			// and the pass below would mark the load complete and silently drop
+			// every cached output. This covers a file document reopened while its
+			// kernel session stays alive (the restore pass can run before the
+			// model parses) as well as an untitled document restored via hot exit.
+			// Previously this deferral was gated on an untitled scheme and an
+			// empty cache, so file reopens fell through and dropped their outputs.
+			if (quartoModel.cells.length === 0 && !this._awaitingParseRestore) {
+				this._awaitingParseRestore = true;
+				this._logService.debug('[QuartoOutputContribution] No cells parsed yet, waiting for parse to retry cache load');
 
-				this._logService.debug('[QuartoOutputContribution] No cells found for untitled document, waiting for content to be restored');
-
-				// Subscribe to parse events - when content is restored and parsed, cells will appear
+				// When content is parsed and cells appear, retry the restore once.
 				this._outputHandlingDisposables.add(quartoModel.onDidParse(() => {
-					// Only try once more after cells appear
 					if (quartoModel.cells.length > 0 && !this._cachedOutputsLoaded) {
+						this._awaitingParseRestore = false;
 						this._logService.debug('[QuartoOutputContribution] Cells found after parse, retrying cache load');
 						this._loadCachedOutputs();
 					}

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputManager.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputManager.vitest.ts
@@ -6,72 +6,17 @@
 /// <reference types="vitest/globals" />
 
 import { URI } from '../../../../../base/common/uri.js';
-import { Event, Emitter } from '../../../../../base/common/event.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
 import { createTextModel } from '../../../../../editor/test/common/testTextModel.js';
-import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
-import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
-import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { QuartoDocumentModel } from '../../browser/quartoDocumentModel.js';
-import { QuartoOutputContribution, IQuartoOutputManager } from '../../browser/quartoOutputManager.js';
-import { IQuartoDocumentModelService } from '../../browser/quartoDocumentModelService.js';
-import { IQuartoKernelManager } from '../../browser/quartoKernelManager.js';
-import { IQuartoExecutionManager, IQuartoOutputCacheService, ICellOutput, ICachedDocument } from '../../common/quartoExecutionTypes.js';
-import { IQuartoDocumentModel, QuartoCodeCell } from '../../common/quartoTypes.js';
-import { QUARTO_INLINE_OUTPUT_ENABLED } from '../../common/positronQuartoConfig.js';
-import { IPositronNotebookOutputWebviewService } from '../../../positronOutputWebview/browser/notebookOutputWebviewService.js';
-import { IResourceUsageHistoryService } from '../../../../services/positronConsole/browser/resourceUsageHistoryService.js';
 
 import { IPositronPreviewService } from '../../../positronPreview/browser/positronPreviewSevice.js';
 import { PreviewWebview } from '../../../positronPreview/browser/previewWebview.js';
 
 describe('QuartoOutputManager', () => {
+	const ctx = createTestContainer().build();
 	const logService = new NullLogService();
-
-	// Fixtures for the reopen restore test (see 'Cached Output Restore On
-	// Reopen'). The document model's parse state is driven directly: it starts
-	// with no cells and gains one when the test fires onDidParse.
-	const reopenUri = URI.file('/reopen.qmd');
-	const parseEmitter = new Emitter<void>();
-	let liveCells: QuartoCodeCell[] = [];
-	let cachedDoc: ICachedDocument | undefined;
-	const quartoModel = stubInterface<IQuartoDocumentModel>({
-		uri: reopenUri,
-		primaryLanguage: 'python',
-		get cells() { return liveCells; },
-		onDidParse: parseEmitter.event,
-		onDidChangeCells: Event.None,
-		onDidChangeLanguage: Event.None,
-		findCellByContentHash: (hash: string) => liveCells.find(c => c.contentHash === hash),
-		getCellById: () => undefined,
-	});
-	const reopenEditorModel = createTextModel('', 'quarto', undefined, reopenUri);
-
-	const ctx = createTestContainer()
-		.withWorkbenchServices()
-		.withContributionServices()
-		.stub(IQuartoDocumentModelService, { getModel: () => quartoModel })
-		.stub(IQuartoOutputCacheService, {
-			loadCache: async () => cachedDoc,
-			findCacheByContentHash: async () => undefined,
-		})
-		.stub(IQuartoExecutionManager, {
-			onDidReceiveOutput: Event.None,
-			onDidChangeExecutionState: Event.None,
-		})
-		.stub(IQuartoKernelManager, {
-			onDidChangeKernelState: Event.None,
-			getSessionForDocument: () => undefined,
-		})
-		.stub(IQuartoOutputManager, {
-			onDidChangeOutputs: Event.None,
-			onDidRequestClearDocument: Event.None,
-			onDidRequestClearAll: Event.None,
-		})
-		.stub(IPositronNotebookOutputWebviewService, {})
-		.stub(IResourceUsageHistoryService, {})
-		.build();
 
 	describe('Output Preservation When Cells Move', () => {
 		/**
@@ -250,72 +195,6 @@ y = 2
 			// The remaining view zone should be for the cell that was originally second
 			const newCellId = model.cells[0].id;
 			expect(remappedViewZones.has(newCellId), 'View zone for surviving cell should be preserved').toBe(true);
-		});
-	});
-
-	describe('Cached Output Restore On Reopen', () => {
-		/**
-		 * Regression test for the close-and-reopen flake where a Quarto .qmd's
-		 * inline output silently fails to re-render (win/electron 120s timeout).
-		 *
-		 * On reopen the editor's text model exists before its cells are parsed.
-		 * _loadCachedOutputs matches cached outputs to live cells by content hash;
-		 * with zero parsed cells that match returns nothing, so every cached
-		 * output is dropped and the pass marks itself complete with no retry. The
-		 * fix defers the restore until the model has parsed cells, for any
-		 * document scheme -- previously the deferral only covered untitled
-		 * hot-exit restores, so a file reopen fell through and dropped its output.
-		 *
-		 * This drives the real contribution: with the bug present the final
-		 * assertion fails because the output is never restored after parse.
-		 */
-		it('restores cached output after the model parses on reopen, instead of dropping it', async () => {
-			ctx.disposables.add(reopenEditorModel);
-			ctx.disposables.add(parseEmitter);
-
-			const cachedCellId = '0-abchash-unlabeled';
-			const contentHash = 'abchash';
-			const cachedOutput: ICellOutput = {
-				outputId: 'out-1',
-				items: [{ mime: 'text/plain', data: 'plot' }],
-			};
-			cachedDoc = {
-				sourceUri: reopenUri.toString(),
-				lastUpdated: Date.now(),
-				cells: [{ cellId: cachedCellId, contentHash, outputs: [cachedOutput] }],
-			};
-
-			// Reopen before parse: the cache has the output but no cells are parsed yet.
-			liveCells = [];
-
-			const editor = stubInterface<ICodeEditor>({
-				hasModel: (() => true) as ICodeEditor['hasModel'],
-				getModel: () => reopenEditorModel,
-				getOption: (() => false) as ICodeEditor['getOption'],
-				onDidChangeModel: Event.None,
-			});
-
-			// Enable the feature so the contribution initializes output handling.
-			QUARTO_INLINE_OUTPUT_ENABLED.bindTo(ctx.get(IContextKeyService)).set(true);
-
-			const contribution = ctx.disposables.add(
-				ctx.instantiationService.createInstance(QuartoOutputContribution, editor)
-			);
-
-			// Let the async restore run to its defer point.
-			await new Promise(resolve => setTimeout(resolve, 0));
-			// Before parse nothing can match, so the cached output is not restored yet.
-			expect(contribution.getOutputsForCell(cachedCellId)).toHaveLength(0);
-
-			// The model parses and the cached cell appears (mirrors onDidParse on reopen).
-			liveCells = [stubInterface<QuartoCodeCell>({ id: cachedCellId, contentHash })];
-			parseEmitter.fire();
-			await new Promise(resolve => setTimeout(resolve, 0));
-
-			// The deferred restore retries and records the cached output. With the
-			// bug the file reopen fell through, dropped the output, and never
-			// retried, so this stays empty.
-			expect(contribution.getOutputsForCell(cachedCellId)).toHaveLength(1);
 		});
 	});
 

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputManager.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputManager.vitest.ts
@@ -6,17 +6,72 @@
 /// <reference types="vitest/globals" />
 
 import { URI } from '../../../../../base/common/uri.js';
+import { Event, Emitter } from '../../../../../base/common/event.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
 import { createTextModel } from '../../../../../editor/test/common/testTextModel.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { QuartoDocumentModel } from '../../browser/quartoDocumentModel.js';
+import { QuartoOutputContribution, IQuartoOutputManager } from '../../browser/quartoOutputManager.js';
+import { IQuartoDocumentModelService } from '../../browser/quartoDocumentModelService.js';
+import { IQuartoKernelManager } from '../../browser/quartoKernelManager.js';
+import { IQuartoExecutionManager, IQuartoOutputCacheService, ICellOutput, ICachedDocument } from '../../common/quartoExecutionTypes.js';
+import { IQuartoDocumentModel, QuartoCodeCell } from '../../common/quartoTypes.js';
+import { QUARTO_INLINE_OUTPUT_ENABLED } from '../../common/positronQuartoConfig.js';
+import { IPositronNotebookOutputWebviewService } from '../../../positronOutputWebview/browser/notebookOutputWebviewService.js';
+import { IResourceUsageHistoryService } from '../../../../services/positronConsole/browser/resourceUsageHistoryService.js';
 
 import { IPositronPreviewService } from '../../../positronPreview/browser/positronPreviewSevice.js';
 import { PreviewWebview } from '../../../positronPreview/browser/previewWebview.js';
 
 describe('QuartoOutputManager', () => {
-	const ctx = createTestContainer().build();
 	const logService = new NullLogService();
+
+	// Fixtures for the reopen restore test (see 'Cached Output Restore On
+	// Reopen'). The document model's parse state is driven directly: it starts
+	// with no cells and gains one when the test fires onDidParse.
+	const reopenUri = URI.file('/reopen.qmd');
+	const parseEmitter = new Emitter<void>();
+	let liveCells: QuartoCodeCell[] = [];
+	let cachedDoc: ICachedDocument | undefined;
+	const quartoModel = stubInterface<IQuartoDocumentModel>({
+		uri: reopenUri,
+		primaryLanguage: 'python',
+		get cells() { return liveCells; },
+		onDidParse: parseEmitter.event,
+		onDidChangeCells: Event.None,
+		onDidChangeLanguage: Event.None,
+		findCellByContentHash: (hash: string) => liveCells.find(c => c.contentHash === hash),
+		getCellById: () => undefined,
+	});
+	const reopenEditorModel = createTextModel('', 'quarto', undefined, reopenUri);
+
+	const ctx = createTestContainer()
+		.withWorkbenchServices()
+		.withContributionServices()
+		.stub(IQuartoDocumentModelService, { getModel: () => quartoModel })
+		.stub(IQuartoOutputCacheService, {
+			loadCache: async () => cachedDoc,
+			findCacheByContentHash: async () => undefined,
+		})
+		.stub(IQuartoExecutionManager, {
+			onDidReceiveOutput: Event.None,
+			onDidChangeExecutionState: Event.None,
+		})
+		.stub(IQuartoKernelManager, {
+			onDidChangeKernelState: Event.None,
+			getSessionForDocument: () => undefined,
+		})
+		.stub(IQuartoOutputManager, {
+			onDidChangeOutputs: Event.None,
+			onDidRequestClearDocument: Event.None,
+			onDidRequestClearAll: Event.None,
+		})
+		.stub(IPositronNotebookOutputWebviewService, {})
+		.stub(IResourceUsageHistoryService, {})
+		.build();
 
 	describe('Output Preservation When Cells Move', () => {
 		/**
@@ -195,6 +250,72 @@ y = 2
 			// The remaining view zone should be for the cell that was originally second
 			const newCellId = model.cells[0].id;
 			expect(remappedViewZones.has(newCellId), 'View zone for surviving cell should be preserved').toBe(true);
+		});
+	});
+
+	describe('Cached Output Restore On Reopen', () => {
+		/**
+		 * Regression test for the close-and-reopen flake where a Quarto .qmd's
+		 * inline output silently fails to re-render (win/electron 120s timeout).
+		 *
+		 * On reopen the editor's text model exists before its cells are parsed.
+		 * _loadCachedOutputs matches cached outputs to live cells by content hash;
+		 * with zero parsed cells that match returns nothing, so every cached
+		 * output is dropped and the pass marks itself complete with no retry. The
+		 * fix defers the restore until the model has parsed cells, for any
+		 * document scheme -- previously the deferral only covered untitled
+		 * hot-exit restores, so a file reopen fell through and dropped its output.
+		 *
+		 * This drives the real contribution: with the bug present the final
+		 * assertion fails because the output is never restored after parse.
+		 */
+		it('restores cached output after the model parses on reopen, instead of dropping it', async () => {
+			ctx.disposables.add(reopenEditorModel);
+			ctx.disposables.add(parseEmitter);
+
+			const cachedCellId = '0-abchash-unlabeled';
+			const contentHash = 'abchash';
+			const cachedOutput: ICellOutput = {
+				outputId: 'out-1',
+				items: [{ mime: 'text/plain', data: 'plot' }],
+			};
+			cachedDoc = {
+				sourceUri: reopenUri.toString(),
+				lastUpdated: Date.now(),
+				cells: [{ cellId: cachedCellId, contentHash, outputs: [cachedOutput] }],
+			};
+
+			// Reopen before parse: the cache has the output but no cells are parsed yet.
+			liveCells = [];
+
+			const editor = stubInterface<ICodeEditor>({
+				hasModel: (() => true) as ICodeEditor['hasModel'],
+				getModel: () => reopenEditorModel,
+				getOption: (() => false) as ICodeEditor['getOption'],
+				onDidChangeModel: Event.None,
+			});
+
+			// Enable the feature so the contribution initializes output handling.
+			QUARTO_INLINE_OUTPUT_ENABLED.bindTo(ctx.get(IContextKeyService)).set(true);
+
+			const contribution = ctx.disposables.add(
+				ctx.instantiationService.createInstance(QuartoOutputContribution, editor)
+			);
+
+			// Let the async restore run to its defer point.
+			await new Promise(resolve => setTimeout(resolve, 0));
+			// Before parse nothing can match, so the cached output is not restored yet.
+			expect(contribution.getOutputsForCell(cachedCellId)).toHaveLength(0);
+
+			// The model parses and the cached cell appears (mirrors onDidParse on reopen).
+			liveCells = [stubInterface<QuartoCodeCell>({ id: cachedCellId, contentHash })];
+			parseEmitter.fire();
+			await new Promise(resolve => setTimeout(resolve, 0));
+
+			// The deferred restore retries and records the cached output. With the
+			// bug the file reopen fell through, dropped the output, and never
+			// retried, so this stays empty.
+			expect(contribution.getOutputsForCell(cachedCellId)).toHaveLength(1);
 		});
 	});
 

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputManagerReopen.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputManagerReopen.vitest.ts
@@ -1,0 +1,172 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { URI } from '../../../../../base/common/uri.js';
+import { Event, Emitter } from '../../../../../base/common/event.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { createTextModel } from '../../../../../editor/test/common/testTextModel.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { QuartoOutputContribution, IQuartoOutputManager } from '../../browser/quartoOutputManager.js';
+import { IQuartoDocumentModelService } from '../../browser/quartoDocumentModelService.js';
+import { IQuartoKernelManager } from '../../browser/quartoKernelManager.js';
+import { IQuartoExecutionManager, IQuartoOutputCacheService, ICachedDocument } from '../../common/quartoExecutionTypes.js';
+import { IQuartoDocumentModel, QuartoCodeCell } from '../../common/quartoTypes.js';
+import { QUARTO_INLINE_OUTPUT_ENABLED } from '../../common/positronQuartoConfig.js';
+import { IPositronNotebookOutputWebviewService } from '../../../positronOutputWebview/browser/notebookOutputWebviewService.js';
+import { IResourceUsageHistoryService } from '../../../../services/positronConsole/browser/resourceUsageHistoryService.js';
+
+/**
+ * Regression coverage for the close-and-reopen flake where a Quarto .qmd's
+ * inline output silently fails to re-render (win/electron, 120s timeout).
+ *
+ * On reopen the editor's text model exists before its cells are parsed.
+ * `_loadCachedOutputs` matches cached outputs to live cells by content hash, so
+ * with zero parsed cells nothing matches and the pass marks itself complete and
+ * drops every cached output with no retry. The fix defers the restore until the
+ * model has parsed cells, for any document scheme -- previously the deferral
+ * only covered untitled hot-exit restores, so a file reopen fell through.
+ *
+ * These tests drive the real contribution: the document model's parse state is
+ * controlled directly (it starts with no cells and gains one when the test
+ * fires `onDidParse`), and `getCellById` returns undefined so the restore
+ * records the output via `getOutputsForCell` without building a view zone --
+ * the defer/retry decision is what is under test, not the render layer.
+ */
+describe('QuartoOutputContribution -- cached output restore on reopen', () => {
+	const cachedCellId = '0-abchash-unlabeled';
+	const contentHash = 'abchash';
+
+	// Describe-scope so the container's stubs capture stable references at
+	// build() time; reset per test (see beforeEach) for isolation.
+	const parseEmitter = new Emitter<void>();
+	let liveCells: QuartoCodeCell[] = [];
+	let cachedDoc: ICachedDocument | undefined;
+
+	const quartoModel = stubInterface<IQuartoDocumentModel>({
+		get cells() { return liveCells; },
+		onDidParse: parseEmitter.event,
+		findCellByContentHash: (hash: string) => liveCells.find(c => c.contentHash === hash),
+		getCellById: () => undefined,
+	});
+
+	const ctx = createTestContainer()
+		.withWorkbenchServices()
+		.withContributionServices()
+		.stub(IQuartoDocumentModelService, { getModel: () => quartoModel })
+		.stub(IQuartoOutputCacheService, {
+			loadCache: async () => cachedDoc,
+			findCacheByContentHash: async () => undefined,
+		})
+		.stub(IQuartoExecutionManager, {
+			onDidReceiveOutput: Event.None,
+			onDidChangeExecutionState: Event.None,
+		})
+		.stub(IQuartoKernelManager, {
+			onDidChangeKernelState: Event.None,
+			getSessionForDocument: () => undefined,
+		})
+		.stub(IQuartoOutputManager, {
+			onDidChangeOutputs: Event.None,
+			onDidRequestClearDocument: Event.None,
+			onDidRequestClearAll: Event.None,
+		})
+		.stub(IPositronNotebookOutputWebviewService, {})
+		.stub(IResourceUsageHistoryService, {})
+		.build();
+
+	beforeEach(() => {
+		liveCells = [];
+		cachedDoc = undefined;
+	});
+
+	/** A parsed cell carrying the given content hash (id is stable across tests). */
+	function cell(hash = contentHash): QuartoCodeCell {
+		return stubInterface<QuartoCodeCell>({ id: cachedCellId, contentHash: hash });
+	}
+
+	/** A cache entry with one text/plain output for a cell of the given hash. */
+	function cacheWith(hash = contentHash): ICachedDocument {
+		return {
+			sourceUri: 'file:///reopen.qmd',
+			lastUpdated: Date.now(),
+			cells: [{ cellId: cachedCellId, contentHash: hash, outputs: [{ outputId: 'out-1', items: [{ mime: 'text/plain', data: 'plot' }] }] }],
+		};
+	}
+
+	/** Instantiate the contribution over a fresh editor for the given document. */
+	function reopen(uri = URI.file('/reopen.qmd')): QuartoOutputContribution {
+		const editorModel = ctx.disposables.add(createTextModel('', 'quarto', undefined, uri));
+		const editor = stubInterface<ICodeEditor>({
+			hasModel: (() => true) as ICodeEditor['hasModel'],
+			getModel: () => editorModel,
+			getOption: (() => false) as ICodeEditor['getOption'],
+			onDidChangeModel: Event.None,
+		});
+		QUARTO_INLINE_OUTPUT_ENABLED.bindTo(ctx.get(IContextKeyService)).set(true);
+		return ctx.disposables.add(ctx.instantiationService.createInstance(QuartoOutputContribution, editor));
+	}
+
+	/** Flush the async restore (loadCache + retry are microtask-scheduled). */
+	const settle = () => new Promise(resolve => setTimeout(resolve, 0));
+
+	it('restores cached output after the model parses on reopen, instead of dropping it', async () => {
+		cachedDoc = cacheWith();
+		liveCells = []; // reopen before parse
+
+		const contribution = reopen();
+		await settle();
+		// Nothing can match before parse, so the output is not restored yet.
+		expect(contribution.getOutputsForCell(cachedCellId)).toHaveLength(0);
+
+		// The model parses and the cached cell appears (mirrors onDidParse on reopen).
+		liveCells = [cell()];
+		parseEmitter.fire();
+		await settle();
+		// With the bug the reopen fell through, dropped the output, and never
+		// retried, so this stayed empty.
+		expect(contribution.getOutputsForCell(cachedCellId)).toHaveLength(1);
+	});
+
+	it('restores immediately when the model is already parsed at reopen', async () => {
+		cachedDoc = cacheWith();
+		liveCells = [cell()]; // already parsed; no deferral needed
+
+		const contribution = reopen();
+		await settle();
+		expect(contribution.getOutputsForCell(cachedCellId)).toHaveLength(1);
+	});
+
+	it('drops a stale cached output whose content hash no longer matches after parse', async () => {
+		cachedDoc = cacheWith('oldhash');
+		liveCells = [];
+
+		const contribution = reopen();
+		await settle();
+
+		// The cell parses with different content -> hash mismatch -> stale output not restored.
+		liveCells = [cell('newhash')];
+		parseEmitter.fire();
+		await settle();
+		expect(contribution.getOutputsForCell(cachedCellId)).toHaveLength(0);
+	});
+
+	it('still defers and restores for an untitled document reopened before parse', async () => {
+		cachedDoc = cacheWith();
+		liveCells = [];
+
+		const contribution = reopen(URI.from({ scheme: 'untitled', path: '/Untitled-1.qmd' }));
+		await settle();
+		expect(contribution.getOutputsForCell(cachedCellId)).toHaveLength(0);
+
+		liveCells = [cell()];
+		parseEmitter.fire();
+		await settle();
+		expect(contribution.getOutputsForCell(cachedCellId)).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
Fixes a Quarto inline-output flake where a `.qmd` documents cached output silently fails to re-render after the editor is closed and reopened (win/electron, hangs to the 120s test timeout).

### Summary
On reopen, `QuartoOutputContribution` runs `_loadCachedOutputs` before the document model has parsed its cells. The restore matches cached outputs to live cells by content hash, so with zero parsed cells nothing matches and the pass marks itself complete, dropping every cached output with no retry.

- The parse-wait retry was gated on an untitled scheme and an empty cache, so a file reopen (kernel still alive) fell through and dropped its output.
- Now defers the restore whenever no cells are parsed yet, for any document scheme, and retries once `onDidParse` reports cells.
- Adds a behavioral regression vitest that instantiates the contribution and drives the real defer/retry via `onDidParse` -- it fails against the old gating (output dropped) and passes with the fix.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Quarto inline output now re-renders reliably after closing and reopening a document.

### Validation Steps

Unit: `npx vitest run src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputManager.vitest.ts`

@:quarto @:web @:win

### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- reopen restore runs before the model parses and drops the cached output (no retry)</summary>

- **Test:** [Quarto - Inline Output: DataFrame and Interactive HTML > Python - Verify interactive HTML widget persists correctly after close and reopen](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Quarto%20-%20Inline%20Output%3A%20DataFrame%20and%20Interactive%20HTML%20%3E%20Python%20-%20Verify%20interactive%20HTML%20widget%20persists%20correctly%20after%20close%20and%20reopen%7C%7C%7Ctest%2Fe2e%2Ftests%2Fquarto%2Fquarto-inline-output-dataframe.test.ts)
- **Targeted failure:** `Test timeout of 120000ms exceeded.`
- **Signal:** trace `Frame.expect('.quarto-inline-output')` never resolved (~111s until the timeout screenshot); the reopened editor showed the cell source and a live Python kernel but zero inline output. Doc/semantic/hover providers fired on the reopened `.qmd` (tab activated, Quick Open accept succeeded), so the output re-render, not the reopen, is what stalled. The renderer `Could not find a notebook editor for session 'python-notebook-...'` log is incidental -- it fires for every Quarto Notebook-mode kernel because a `.qmd` opens in a text editor, and short-circuits before touching any Quarto DOM.
- **Hypothesis:** product race. On reopen, `QuartoOutputContribution._loadCachedOutputs` runs before `QuartoDocumentModel` parses its cells; the content-hash match finds nothing, the pass marks itself complete, and the cached output is dropped. The parse-wait retry was gated on an untitled scheme + empty cache, so file reopens (kernel still alive) fell through. Not test-drift; reproduced deterministically by a behavioral vitest (RED against the old gating, GREEN with the deferral generalized to any scheme).

</details>
