### PR TITLE
Remove chat.useCopilotParticipantsWithOtherProviders setting

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -319,13 +319,6 @@ configurationRegistry.registerConfiguration({
 			default: true,
 			agentsWindow: { default: false },
 		},
-		// --- Start Positron ---
-		'chat.useCopilotParticipantsWithOtherProviders': {
-			type: 'boolean',
-			markdownDescription: nls.localize('chat.useCopilotParticipantsWithOtherProviders', "Allow any model in Positron Assistant to use chat participants provided by GitHub Copilot.\n\nThis requires that you are signed into Copilot, and **may send data to Copilot models regardless of the selected provider when Copilot participants are used**.\n\nFor example, if you enable this setting and you are using Anthropic as a provider, GitHub Copilot participants are available. When invoked, the participants may send data to Copilot models.\n\n See also: `#positron.assistant.alwaysIncludeCopilotTools#`"),
-			default: false
-		},
-		// --- End Positron ---
 		'chat.editing.autoAcceptDelay': {
 			type: 'number',
 			markdownDescription: nls.localize('chat.editing.autoAcceptDelay', "Delay after which changes made by chat are automatically accepted. Values are in seconds, `0` means disabled and `100` seconds is the maximum."),


### PR DESCRIPTION
Removes the `chat.useCopilotParticipantsWithOtherProviders` setting contribution, which is no longer used.

### Validation Steps

@:assistant

1. Open the Settings editor and search for "useCopilotParticipantsWithOtherProviders".
2. Confirm the setting no longer appears.
