### PR TITLE
e2e: fix no-op interpreter rescan recovery in sessions.startAndSkipMetadata

### DIFF
--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -526,11 +526,15 @@ export class Sessions {
 					});
 				} catch (e) {
 					// Auto-discovery is intermittent: POSITRON_PY_VER_SEL's interpreter
-					// can be missing from the quick pick on the first attempt. Force a
-					// rescan so the next retry of this `toPass` iteration sees it.
+					// can be missing from the quick pick on the first attempt -- notably
+					// on remote hosts, where interpreter registration can lag the
+					// discovery-complete signal. Force a fresh cross-host rescan so the
+					// next retry of this `toPass` iteration sees it. (The former
+					// `python.refreshInterpreters` command does not exist, so this
+					// recovery was silently a no-op.)
 					if (language === 'Python') {
 						await this.quickinput.closeQuickInput().catch(() => { });
-						await this.quickaccess.runCommand('python.refreshInterpreters').catch(() => { });
+						await this.quickaccess.runCommand('workbench.action.language.runtime.discoverAllRuntimes').catch(() => { });
 					}
 					throw e;
 				}


### PR DESCRIPTION
### Summary
The catch-path recovery in `sessions.startAndSkipMetadata` ran `python.refreshInterpreters`, which is not a registered command in this fork, so the call threw and was swallowed by `.catch(() => {})` -- the intended interpreter rescan never happened.

- Switch the recovery to `workbench.action.language.runtime.discoverAllRuntimes`, which re-runs discovery across all extension hosts (including a remote SSH host)
- Gives the retry loop a real chance to surface a late-registering remote interpreter instead of a silent no-op
- Partial mitigation for the remote discovery-complete race in #15101 (root cause is product-side, not fixed here)

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:remote-ssh

Run the Remote SSH suite; confirm `Verify SSH connection into docker image` selects the remote Python interpreter without flaking on the runtime quick pick.

### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- PRODUCT race in RuntimeStartupService.completeDiscovery: 'discovery complete' is an AND over only extension-host managers ALREADY registered, so it fires (clearing the picker placeholder) before the remote SSH host registers/finishes discovery; and it resets all per-host flags on Complete, so a late remote completion never re-fires the phase. The remote Python interpreter is therefore absent from the runtime pick when the test reads it. Secondary TEST bug: the retry's recovery command python.refreshInterpreters does not exist in this fork (swallowed by .catch), so the rescan is a no-op.</summary>

- **Test:** [Remote SSH > Verify SSH connection into docker image](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Remote%20SSH%20%3E%20Verify%20SSH%20connection%20into%20docker%20image%7C%7C%7Ctest%2Fe2e%2Ftests%2Fremote-ssh%2Fremote-ssh.test.ts)
- **Targeted failure:** Error: Select runtime from quick pick -> expect(.monaco-list-row[aria-label*="Python 3.10.12"]).toBeVisible() element(s) not found
- **Signal:** runtimeStartup.ts:767-790 completeDiscovery ANDs over currently-registered hosts only, no remote-host enumeration, resets flags at 787-789; languageRuntimeActions.ts:586-657 placeholder tied to startupPhase===Complete; sessions.ts:531-533 recovery runs non-existent python.refreshInterpreters (only match in repo is a test method name). Trace: ~10 retries t=106-136s, row never found; console Phase 'complete' t=105743. 22% (2/9) on main.
- **Frequency:** 2/9 runs (22.2%), ubuntu/electron
- **Hypothesis:** Confirmed hypothesis (a): remote interpreter registration lags the discovery-complete signal because completeDiscovery does not await extension hosts that have not yet registered a manager (window2/remote SSH). On the ~22% of runs where the remote MainThreadLanguageRuntime registers after the local host completes, phase flips to Complete, placeholder clears, waitForInterpreterDiscoveryToComplete returns early, and the flag-reset means the remote host's later completeDiscovery cannot re-fire Complete; the only recovery is the picker's onDidRegisterRuntime rebuild, which the test races. Hypothesis (b) refuted but revealed a real test bug: python.refreshInterpreters is not a registered command; the correct rescan is workbench.action.language.runtime.discoverAllRuntimes (rediscoverAllRuntimes). Fixing the test command is a partial mitigation, not the root fix.

</details>
