### PR TITLE
skill(triage-e2e-test): handle split outcomes (root-cause issue + mitigation PR)

### DIFF
--- a/.claude/skills/triage-e2e-test/SKILL.md
+++ b/.claude/skills/triage-e2e-test/SKILL.md
@@ -68,7 +68,8 @@ payloads to the per-triage work directory `.claude/work/triage-e2e-test/<id>/`
   from the checkpoint + history and appends it to the resolving PR (`--pr`) or
   issue (`--issue`). Idempotent. Only writer of `diagnosisBlockRecorded`, so it
   is what unblocks `phase=done`. Opening a PR via `positron-pr-helper` does NOT
-  record the block -- run this after.
+  record the block -- run this after. `--secondary` appends the block to a
+  second artifact without repointing `outcomeRef` (see "Split outcome").
 
 ## Start or resume
 
@@ -200,22 +201,30 @@ The outcome spans two axes (what you found x what you did):
 
 | Outcome | Meaning | Where the block goes | To reach `done` |
 |---|---|---|---|
-| `fix-test` | test bug, fixed in a PR | the PR | `record-diagnosis.js --pr <n>` |
-| `fix-product` | product bug, fixed in a PR | the PR | `record-diagnosis.js --pr <n>` |
-| `file-issue` | product bug, filed not fixed | the new issue | `record-diagnosis.js --issue <n>` |
-| `no-op` | not fixed and not filed (accepted flake, dup, backlog, handed off) | checkpoint only | `--set outcomeReason="..."` |
+| `fix-test` | test bug, fixed in a PR | the PR | `record-diagnosis.js --pr <n> --outcome fix-test` |
+| `fix-product` | product bug, fixed in a PR | the PR | `record-diagnosis.js --pr <n> --outcome fix-product` |
+| `file-issue` | product bug, filed not fixed | the new issue | `record-diagnosis.js --issue <n> --outcome file-issue` |
+| `no-op` | not fixed and not filed (accepted flake, dup, backlog, handed off) | checkpoint only | `--set outcome=no-op --set outcomeReason="..."` |
 
-`outcome` is the **primary** artifact -- a secondary note (e.g. mentioning a
-product race in the backlog while you fix the test) does not change it.
+`outcome` is the **primary** artifact -- a secondary *note* (e.g. mentioning a
+product race in the backlog while you fix the test) does not change it. A second
+*artifact* is different: see the split-outcome rule below.
 
 **A returning sub-tool is not the end of the triage** -- opening the PR via
 `positron-pr-helper` or a passing `author-vitest-tests` run resolves a *step*.
 Once the PR/issue exists:
 
-1. `record-diagnosis.js --triage-id <id> --pr <n>` (or `--issue <n>`) appends the
-   block and sets `outcomeRef` + `diagnosisBlockRecorded`. For a `no-op`, skip
-   this and `checkpoint.js --set outcome=no-op --set outcomeReason="..."` instead.
+1. `record-diagnosis.js --triage-id <id> --pr <n> --outcome <fix-test|fix-product>`
+   (or `--issue <n> --outcome file-issue`) appends the block and sets `outcome` +
+   `outcomeRef` + `diagnosisBlockRecorded` in one call. For a `no-op`, skip this
+   and `checkpoint.js --set outcome=no-op --set outcomeReason="..."` instead.
 2. `checkpoint.js --set phase=done`.
+
+**Split outcome (two artifacts).** When the root cause and a mitigation land
+separately -- e.g. a product bug filed as an issue *plus* a fix PR -- the block
+goes on **both**. Do step 1 for the primary (the artifact matching `outcome`),
+then rerun `record-diagnosis.js --pr <n> --secondary` for the other: it appends
+the block but won't repoint `outcomeRef`/`outcome`. `outcome` stays single.
 
 ## Non-goals
 

--- a/.claude/skills/triage-e2e-test/scripts/record-diagnosis.js
+++ b/.claude/skills/triage-e2e-test/scripts/record-diagnosis.js
@@ -15,7 +15,13 @@
 // Usage:
 //   node record-diagnosis.js --triage-id <id> --pr <n> [--outcome fix-test|fix-product]
 //   node record-diagnosis.js --triage-id <id> --issue <n> [--outcome file-issue]
+//   node record-diagnosis.js --triage-id <id> --pr <n> --secondary   # extra artifact, keep outcomeRef
 //   node record-diagnosis.js --triage-id <id> --pr <n> --dry-run   # render only, no write
+//
+// A single triage can resolve across TWO artifacts -- e.g. a root-cause issue
+// (the `outcome`) plus a mitigation PR. Record the primary artifact first (the
+// one that matches `outcome`; it sets `outcomeRef`), then record the other with
+// `--secondary` so the block lands on both without repointing `outcomeRef`.
 //
 // Options:
 //   --triage-id <id>   work-dir id  [required]
@@ -23,6 +29,8 @@
 //   --issue <n>        target issue number
 //   --repo <owner/repo>  default: posit-dev/positron
 //   --outcome <o>      also set checkpoint outcome (fix-test | fix-product | file-issue)
+//   --secondary        append the block to a supplementary artifact; leave
+//                      `outcomeRef`/`outcome` untouched (the primary owns them)
 //   --dry-run          print the rendered block; do not edit the artifact or checkpoint
 //
 // Output (stdout): compact JSON { block, target, alreadyPresent, recorded }.
@@ -106,11 +114,14 @@ function ghPatchBody(repo, kind, num, bodyFile) {
 }
 
 function main() {
-	const args = parseArgs(process.argv.slice(2), ['dry-run']);
+	const args = parseArgs(process.argv.slice(2), ['dry-run', 'secondary']);
 	const triageId = args['triage-id'];
 	if (!triageId) { fail('Missing --triage-id.'); }
 	if (args.outcome && !ARTIFACT_OUTCOMES.includes(args.outcome)) {
 		fail(`--outcome must be one of ${ARTIFACT_OUTCOMES.join(' | ')} (use checkpoint.js for no-op).`);
+	}
+	if (args.secondary && args.outcome) {
+		fail('--secondary records a supplementary artifact and must not set --outcome (the primary owns the outcome).');
 	}
 
 	const dir = triageDir(triageId);
@@ -158,9 +169,14 @@ function main() {
 	}
 
 	// Update the checkpoint: this is the only writer of diagnosisBlockRecorded.
+	// A --secondary artifact still gets the block, but must not repoint the
+	// outcome or its ref -- those belong to the primary artifact recorded
+	// without --secondary. Fall back to setting outcomeRef only if none exists
+	// yet, so a lone/first call always leaves the done-gate a ref to check.
 	state.diagnosisBlockRecorded = true;
-	state.outcomeRef = htmlUrl || `${repo}#${num}`;
-	if (args.outcome) { state.outcome = args.outcome; }
+	const thisRef = htmlUrl || `${repo}#${num}`;
+	if (!args.secondary || !state.outcomeRef) { state.outcomeRef = thisRef; }
+	if (args.outcome && !args.secondary) { state.outcome = args.outcome; }
 	state.updatedAt = new Date().toISOString();
 	writeJson(sp, state);
 


### PR DESCRIPTION
### Summary
When a triage both files a root-cause issue and opens a mitigation PR, the diagnosis block belongs on both -- but `record-diagnosis.js` overwrote `outcomeRef` on every call, so recording on the second artifact repointed the checkpoint away from the primary.

- Add `--secondary` to `record-diagnosis.js`: appends the block but preserves the existing `outcomeRef`/`outcome` (and rejects a contradictory `--outcome`)
- Document the split-outcome close-out sequence in `SKILL.md` 
- Pass `--outcome` in the documented close-out commands so the happy path reaches `phase=done` without tripping the outcome gate

### QA Notes
Skill tooling only; no product or e2e-test code. Verified locally: `--secondary` preserves `outcomeRef`, the `--secondary`+`--outcome` guard fires, and a fresh-agent read of the revised close-out section produced the correct primary-then-secondary sequence.