### PR TITLE
fix(quarto): await readiness on adopted-session path

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoKernelManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoKernelManager.ts
@@ -567,6 +567,12 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 		if (adoptedSession) {
 			const state = adoptedSession.getRuntimeState();
 			if (state !== RuntimeState.Exited && state !== RuntimeState.Uninitialized) {
+				// The adopted session may still be starting (e.g. restoring after
+				// a window reload). Wait for it to become ready before returning,
+				// mirroring the start path, so callers don't execute into a
+				// not-yet-ready session that silently drops the request.
+				// (_waitForSessionReady resolves immediately if already ready.)
+				await this._waitForSessionReady(adoptedSession, token ?? CancellationToken.None);
 				return adoptedSession;
 			}
 		}

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoKernelManager.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoKernelManager.vitest.ts
@@ -6,7 +6,7 @@
 /// <reference types="vitest/globals" />
 
 import { URI } from '../../../../../base/common/uri.js';
-import { Event } from '../../../../../base/common/event.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
 import { ensureNoLeakedDisposables } from '../../../../../test/vitest/vitestUtils.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
@@ -15,7 +15,7 @@ import { TestConfigurationService } from '../../../../../platform/configuration/
 import { INotificationService } from '../../../../../platform/notification/common/notification.js';
 import { TestRuntimeStartupService } from '../../../../services/runtimeStartup/test/common/testRuntimeStartupService.js';
 import { ILanguageRuntimeMetadata, ILanguageRuntimeService, LanguageRuntimeSessionMode, LanguageRuntimeStartupBehavior, LanguageRuntimeSessionLocation, RuntimeExitReason, RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
-import { ILanguageRuntimeSession, IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
+import { ILanguageRuntimeSession, INotebookLanguageRuntimeSession, IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { IQuartoDocumentModel } from '../../common/quartoTypes.js';
 import { IQuartoDocumentModelService } from '../../browser/quartoDocumentModelService.js';
 import { IQuartoOutputCacheService } from '../../common/quartoExecutionTypes.js';
@@ -285,6 +285,74 @@ describe('QuartoKernelManager', () => {
 		// A URI with no matching visible editor yields no language, so there is
 		// no interpreter to name.
 		expect(kernelManager.getPreferredRuntimeForDocument(URI.file('/test/other.qmd'))).toBeUndefined();
+	});
+
+	it('ensureKernelForDocument waits for an adopted starting session to become ready', async () => {
+		// A session that is restoring after a window reload: present in the
+		// runtime session service but still Starting, not yet Ready. Returning
+		// it before it is ready lets callers execute into a session that drops
+		// the request (the inline-output-on-reload flake).
+		const stateEmitter = disposables.add(new Emitter<RuntimeState>());
+		let sessionState = RuntimeState.Starting;
+		const restoringSession = stubInterface<INotebookLanguageRuntimeSession>({
+			sessionId: 'restoring-session',
+			runtimeMetadata: pythonRuntime1,
+			getRuntimeState() { return sessionState; },
+			onDidChangeRuntimeState: stateEmitter.event,
+			onDidCompleteStartup: Event.None,
+			onDidEncounterStartupFailure: Event.None,
+			onDidEndSession: Event.None,
+			async shutdown() { },
+		});
+
+		const sessionService = stubInterface<IRuntimeSessionService>({
+			async startNewRuntimeSession(runtimeId: string) {
+				startedRuntimeIds.push(runtimeId);
+				return `session-${nextSessionId++}`;
+			},
+			getNotebookSessionForNotebookUri(_uri: URI) { return restoringSession; },
+			getActiveSessions() { return []; },
+			async shutdownNotebookSession() { },
+			onDidStartRuntime: Event.None,
+		});
+
+		const km = disposables.add(new QuartoKernelManager(
+			sessionService,
+			runtimeStartupService,
+			stubInterface<ILanguageRuntimeService>({ get registeredRuntimes() { return registeredRuntimes; } }),
+			stubInterface<IQuartoDocumentModelService>({ getModel() { return stubInterface<IQuartoDocumentModel>({ primaryLanguage: 'python', cells: [] }); } }),
+			stubInterface<IEditorService>({
+				findEditors() { return []; },
+				get visibleTextEditorControls() { return [] as unknown as IEditorService['visibleTextEditorControls']; },
+				onDidCloseEditor: Event.None as Event<IEditorCloseEvent>,
+			}),
+			new NullLogService(),
+			stubInterface<INotificationService>({ warn: vi.fn(), info: vi.fn(), notify: vi.fn() }),
+			new TestConfigurationService(),
+			storageService,
+			stubInterface<IQuartoOutputCacheService>({}),
+		));
+
+		let resolved = false;
+		const ensurePromise = km.ensureKernelForDocument(docUri).then(session => {
+			resolved = true;
+			return session;
+		});
+
+		// Let the async adopt path run. It must not resolve while the adopted
+		// session is still Starting.
+		await new Promise(resolve => setTimeout(resolve, 0));
+		expect(resolved).toBe(false);
+
+		// The session finishes starting.
+		sessionState = RuntimeState.Ready;
+		stateEmitter.fire(RuntimeState.Ready);
+
+		const session = await ensurePromise;
+		expect(resolved).toBe(true);
+		expect(session).toBe(restoringSession);
+		// No new session should have been started; the existing one was adopted.
+		expect(startedRuntimeIds).toEqual([]);
 	});
 
 	it('changeKernelForDocument fires state change events', async () => {


### PR DESCRIPTION
### Summary
Quarto inline output could silently fail to run after a window reload because `ensureKernelForDocument` returned an adopted session while it was still starting.

- On the start path the manager awaited `_waitForSessionReady`; the adopt-existing-session path returned immediately.
- After a reload, the restoring session was adopted un-ready, so `_executeRange` fired `execute()` into it and the request was dropped with no replay.
- Fix: await readiness on the adopt branch too, mirroring the start path (`_waitForSessionReady` resolves immediately if already ready).
- Adds a regression Vitest that adopts a Starting session and asserts the call doesn't resolve until it becomes Ready.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed Quarto inline output sometimes not running on the first execution after a window reload.

### Validation Steps

@:win @:web @:quarto

Open a `.qmd` with inline output enabled, reload the window, then run a cell. Output should appear on the first run (no dropped execution).


### E2E Triage Diagnosis

<details>
<summary>🟡 <b>Medium confidence</b> -- Cell execution is dropped when a run fires before the Quarto session is ready -- ensureKernelForDocument returns an adopted, still-Starting session without awaiting readiness.</summary>

- **Test:** [Quarto - Inline Output: DataFrame and Interactive HTML > Python - Verify interactive HTML widget persists correctly after close and reopen](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Quarto%20-%20Inline%20Output%3A%20DataFrame%20and%20Interactive%20HTML%20%3E%20Python%20-%20Verify%20interactive%20HTML%20widget%20persists%20correctly%20after%20close%20and%20reopen%7C%7C%7Ctest%2Fe2e%2Ftests%2Fquarto%2Fquarto-inline-output-dataframe.test.ts)
- **Targeted failure:** Test timeout of 120000ms exceeded.
- **Signal:** After a preceding window-reload test, interactive_plot.qmd opened and the run fired (13:12:32) before the kernel was ready (13:12:39). The adopted python-notebook session received only a startup execution and went idle -- never a quarto-exec-* execute_request, no execute_result on IOPub, no output received by QuartoOutputContribution, and 'No variables have been created' in the Variables pane. A sibling passing session in the same run got a quarto-exec-* request plus an execute_result. The reopen/restore path was never reached (a single contribution 'Initializing'), so this is distinct from the reopen-restore flake fixed in #15091.
- **Frequency:** 18/465 runs (3.8%), win/electron
- **Hypothesis:** Product race. QuartoKernelManager.ensureKernelForDocument (quartoKernelManager.ts:542-576) awaits _waitForSessionReady on the clean-start path (:942) but returns an adopted session in any non-terminal state, including Starting/Initializing, without awaiting readiness (_adoptSession :259-291 via :566-572). _executeRange then calls session.execute(...quarto-exec...) (quartoExecutionManager.ts:797) into a not-yet-ready session and the request is lost; no queue or ready-listener replays it. Fixed by awaiting readiness on the adopt path.

</details>
