### PR TITLE
skill(triage-e2e-test): store triage state in shared git dir for cross-worktree resume

### DIFF
--- a/.claude/skills/triage-e2e-test/SKILL.md
+++ b/.claude/skills/triage-e2e-test/SKILL.md
@@ -45,8 +45,9 @@ Violating the letter of these rules is violating their spirit.
 ## Scripts
 
 Run from the repo root. All emit **compact JSON to stdout** and write full
-payloads to the per-triage work directory `.claude/work/triage-e2e-test/<id>/`
-(gitignored). They wrap the `e2e-failure-analyzer` scripts (no copies).
+payloads to the per-triage work directory under the shared git common dir
+(`<git-common-dir>/triage-e2e-test/<id>/`, so `--resume` works from any
+worktree). They wrap the `e2e-failure-analyzer` scripts (no copies).
 
 - `scripts/triage-history.js` -- dual-branch history retrieval + merge. Resolves
   the branch, queries the current branch and `main`, merges patterns by failure

--- a/.claude/skills/triage-e2e-test/scripts/checkpoint.js
+++ b/.claude/skills/triage-e2e-test/scripts/checkpoint.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 // checkpoint.js -- durable triage state for start / resume / status.
 //
-// State lives at .claude/work/triage-e2e-test/<triage-id>/state.json (gitignored).
+// State lives at <git-common-dir>/triage-e2e-test/<triage-id>/state.json,
+// shared across worktrees so --resume works from any checkout.
 // A resume reads the checkpoint and continues from `phase`/`nextAction` without
 // replaying completed history work.
 //

--- a/.claude/skills/triage-e2e-test/scripts/lib.js
+++ b/.claude/skills/triage-e2e-test/scripts/lib.js
@@ -23,9 +23,27 @@ export function analyzerScript(name) {
 	return path.resolve(HERE, '..', '..', 'e2e-failure-analyzer', 'scripts', name);
 }
 
-/** Root of all triage work directories. Gitignored (.claude/work/**). */
+/**
+ * Root of all triage work directories.
+ *
+ * Anchored on the shared git *common* dir (e.g. <repo>/.git/triage-e2e-test) so
+ * a triage started in one worktree is visible from every other worktree and
+ * `--resume <id>` works no matter which checkout runs it. The previous location
+ * (.claude/work/**) is gitignored and per-worktree, so a resume from a different
+ * worktree silently found nothing. Falls back to that legacy path outside a git repo.
+ */
+let _workRootCache;
 export function workRoot() {
-	return path.join(repoRoot(), '.claude', 'work', 'triage-e2e-test');
+	if (_workRootCache) { return _workRootCache; }
+	const res = tryRun('git', ['rev-parse', '--git-common-dir']);
+	if (res.ok && res.stdout.trim()) {
+		// --git-common-dir is relative to repoRoot for the main worktree (".git")
+		// and absolute for linked worktrees; path.resolve handles both.
+		_workRootCache = path.join(path.resolve(repoRoot(), res.stdout.trim()), 'triage-e2e-test');
+	} else {
+		_workRootCache = path.join(repoRoot(), '.claude', 'work', 'triage-e2e-test');
+	}
+	return _workRootCache;
 }
 
 /** Per-triage work directory. */

--- a/.claude/skills/triage-e2e-test/scripts/test/lib.test.js
+++ b/.claude/skills/triage-e2e-test/scripts/test/lib.test.js
@@ -1,6 +1,8 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { deriveTriageId } from '../lib.js';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { deriveTriageId, workRoot, repoRoot } from '../lib.js';
 
 test('deriveTriageId is stable, slugged, and hash-suffixed', () => {
 	const id = deriveTriageId('Data Explorer > opens a file|||data-explorer.test.ts');
@@ -14,4 +16,17 @@ test('deriveTriageId does not collide when two tests share a leaf name', () => {
 	const a = deriveTriageId('Data Explorer > opens a file|||data-explorer.test.ts');
 	const b = deriveTriageId('Plots > opens a file|||plots.test.ts');
 	assert.notEqual(a, b);
+});
+
+test('workRoot lives under the shared git common dir, not the per-worktree .claude/work', () => {
+	// .claude/work is gitignored and per-worktree, so state stored there is invisible
+	// to `--resume` run from any other worktree. Anchoring on the git *common* dir
+	// gives every worktree the same absolute path.
+	const root = workRoot();
+	assert.doesNotMatch(root, /[/\\]\.claude[/\\]work[/\\]/);
+	const commonDir = path.resolve(
+		repoRoot(),
+		execFileSync('git', ['rev-parse', '--git-common-dir'], { cwd: repoRoot(), encoding: 'utf8' }).trim()
+	);
+	assert.equal(root, path.join(commonDir, 'triage-e2e-test'));
 });


### PR DESCRIPTION
### Summary
Triage checkpoint state was anchored on the per-worktree, gitignored `.claude/work/`, so a triage started in one worktree was invisible to `--resume`/`--status` run from another (the state looked gone).
- `workRoot()` now anchors on the shared git common dir (`git rev-parse --git-common-dir`), identical across every worktree of the repo
- Falls back to the legacy `.claude/work/` path when outside a git repo
- Updates the path references in `checkpoint.js` and `SKILL.md`
- Adds a unit test asserting `workRoot()` lives under the git common dir

### QA Notes
Tooling-only change to the `triage-e2e-test` skill; no product code. Run `node --test .claude/skills/triage-e2e-test/scripts/test/lib.test.js`.