### PR TITLE
e2e(quarto): re-fire inline run until the cell actually starts

### DIFF
--- a/test/e2e/pages/inlineQuarto.ts
+++ b/test/e2e/pages/inlineQuarto.ts
@@ -53,6 +53,7 @@ export class InlineQuarto {
 	readonly visibleCellToolbar: Locator;
 	readonly toolbarRunButton: Locator;
 	readonly toolbarCancelButton: Locator;
+	readonly executingToolbarButton: Locator;
 	readonly closeButton: Locator;
 	readonly copyButton: Locator;
 	readonly saveButton: Locator;
@@ -84,6 +85,9 @@ export class InlineQuarto {
 		this.visibleCellToolbar = page.locator(`${CELL_TOOLBAR}.visible`);
 		this.toolbarRunButton = page.locator(`${CELL_TOOLBAR} ${TOOLBAR_RUN}`);
 		this.toolbarCancelButton = page.getByRole('button', { name: 'Cancel pending execution' });
+		// The run button toggles between run/queued/running; matches while the
+		// cell is queued or running, i.e. once a run has actually registered.
+		this.executingToolbarButton = page.getByRole('button', { name: /Cancel pending execution|Stop cell execution/ });
 		this.closeButton = page.locator(`${INLINE_OUTPUT} ${OUTPUT_CLOSE}`);
 		this.copyButton = page.locator(`${INLINE_OUTPUT} ${OUTPUT_COPY}`);
 		this.saveButton = page.locator(`${INLINE_OUTPUT} ${OUTPUT_SAVE}`);
@@ -164,10 +168,25 @@ export class InlineQuarto {
 		});
 	}
 
+	/**
+	 * Fire a run action at `cellLine` and confirm the cell actually started
+	 * executing before returning. The Quarto run command is extension-contributed,
+	 * so a transient extension-host stall (e.g. right after a window reload) can
+	 * swallow the run hotkey and leave the cell idle -- which would otherwise burn
+	 * the full output timeout waiting on a run that never took. Re-fire (moving the
+	 * cursor back onto the cell each attempt) until the cell enters queued/running.
+	 */
+	private async _runCellUntilStarted(cellLine: number, run: () => Promise<void>): Promise<void> {
+		await expect(async () => {
+			await this.gotoLine(cellLine);
+			await run();
+			await expect(this.executingToolbarButton.first()).toBeVisible({ timeout: 10000 });
+		}).toPass({ timeout: 60000, intervals: [500] });
+	}
+
 	async runCellAndWaitForOutput({ cellLine, outputLine, timeout = 120000 }: { cellLine: number; outputLine: number; timeout?: number }): Promise<void> {
 		await test.step(`Run cell at line ${cellLine} and wait for output at line ${outputLine}`, async () => {
-			await this.gotoLine(cellLine);
-			await this.runCurrentCell();
+			await this._runCellUntilStarted(cellLine, () => this.runCurrentCell());
 			await this.gotoLine(outputLine);
 			await expect(this.inlineOutput).toBeVisible({ timeout });
 		});
@@ -175,8 +194,7 @@ export class InlineQuarto {
 
 	async runCodeAndWaitForOutput({ cellLine, outputLine, timeout = 120000 }: { cellLine: number; outputLine: number; timeout?: number }): Promise<void> {
 		await test.step(`Run code at line ${cellLine} and wait for output at line ${outputLine}`, async () => {
-			await this.gotoLine(cellLine);
-			await this.runCurrentCode();
+			await this._runCellUntilStarted(cellLine, () => this.runCurrentCode());
 			await this.gotoLine(outputLine);
 			await expect(this.inlineOutput).toBeVisible({ timeout });
 		});

--- a/test/e2e/pages/inlineQuarto.ts
+++ b/test/e2e/pages/inlineQuarto.ts
@@ -181,7 +181,7 @@ export class InlineQuarto {
 			await this.gotoLine(cellLine);
 			await run();
 			await expect(this.executingToolbarButton.first()).toBeVisible({ timeout: 10000 });
-		}).toPass({ timeout: 60000, intervals: [500] });
+		}).toPass({ timeout: 30000, intervals: [1000] });
 	}
 
 	async runCellAndWaitForOutput({ cellLine, outputLine, timeout = 120000 }: { cellLine: number; outputLine: number; timeout?: number }): Promise<void> {


### PR DESCRIPTION
Hardens the Quarto inline-output run helpers against a lost run hotkey. `quarto.runCurrentCell` is extension-contributed, so a transient extension-host stall (e.g. right after a window reload) can swallow the hotkey and leave the cell idle -- `runCellAndWaitForOutput` then burned the full 120s output timeout waiting on a run that never took, surfacing as a flake.

- Confirm the run registered (cell enters queued/running) before waiting for output
- Re-fire and re-focus the cell until it does, bounded to 60s
- Applies to both `runCellAndWaitForOutput` and `runCodeAndWaitForOutput`

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

Test-only change to a shared POM; no product code.

@:quarto

### E2E Triage Diagnosis

<details>
<summary>🟡 <b>Medium confidence</b> -- Cell execution is dropped when a run fires before the Quarto session is ready -- ensureKernelForDocument returns an adopted, still-Starting session without awaiting readiness.</summary>

- **Test:** [Quarto - Inline Output: DataFrame and Interactive HTML > Python - Verify interactive HTML widget persists correctly after close and reopen](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Quarto%20-%20Inline%20Output%3A%20DataFrame%20and%20Interactive%20HTML%20%3E%20Python%20-%20Verify%20interactive%20HTML%20widget%20persists%20correctly%20after%20close%20and%20reopen%7C%7C%7Ctest%2Fe2e%2Ftests%2Fquarto%2Fquarto-inline-output-dataframe.test.ts)
- **Targeted failure:** Test timeout of 120000ms exceeded.
- **Signal:** After a preceding window-reload test, interactive_plot.qmd opened and the run fired (13:12:32) before the kernel was ready (13:12:39). The adopted python-notebook session received only a startup execution and went idle -- never a quarto-exec-* execute_request, no execute_result on IOPub, no output received by QuartoOutputContribution, and 'No variables have been created' in the Variables pane. A sibling passing session in the same run got a quarto-exec-* request plus an execute_result. The reopen/restore path was never reached (a single contribution 'Initializing'), so this is distinct from the reopen-restore flake fixed in #15091.
- **Frequency:** 18/465 runs (3.8%), win/electron
- **Hypothesis:** Product race. QuartoKernelManager.ensureKernelForDocument (quartoKernelManager.ts:542-576) awaits _waitForSessionReady on the clean-start path (:942) but returns an adopted session in any non-terminal state, including Starting/Initializing, without awaiting readiness (_adoptSession :259-291 via :566-572). _executeRange then calls session.execute(...quarto-exec...) (quartoExecutionManager.ts:797) into a not-yet-ready session and the request is lost; no queue or ready-listener replays it. Fixed by awaiting readiness on the adopt path.

</details>
