### PR TITLE
Enable `assistant.positronCommandIntegration` in Positron

### DIFF
--- a/src/vs/workbench/contrib/positronAiFeatures/browser/positronAiFeatures.contribution.ts
+++ b/src/vs/workbench/contrib/positronAiFeatures/browser/positronAiFeatures.contribution.ts
@@ -7,12 +7,20 @@ import { Action2, registerAction2 } from '../../../../platform/actions/common/ac
 import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';
 import { ServicesAccessor } from '../../../../editor/browser/editorExtensions.js';
 import { localize2 } from '../../../../nls.js';
+import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { Registry } from '../../../../platform/registry/common/platform.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { IUntitledTextResourceEditorInput } from '../../../common/editor.js';
 import { AgentAllowedCommandsService, IAgentAllowedCommandsService } from '../common/agentAllowedCommandsService.js';
 
 registerSingleton(IAgentAllowedCommandsService, AgentAllowedCommandsService, InstantiationType.Delayed);
+
+// The Posit Assistant extension ships `assistant.positronCommandIntegration` off by
+// default; Positron turns it on so the assistant can run IDE commands out of the box.
+// Users can still opt out per user/workspace.
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
+	.registerDefaultConfigurations([{ overrides: { 'assistant.positronCommandIntegration': true } }]);
 
 registerAction2(class ShowAgentAllowedCommandsAction extends Action2 {
 	constructor() {


### PR DESCRIPTION
With posit-dev/assistant#1810 and this PR, we will give Posit Assistant the ability to run Positron IDE commands on the user's behalf, like changing the layout, focusing a pane, managing packages, or restarting a session, through a new `positronCommand` tool gated by per-command approval. The assistant PR adds the tool and the `assistant.positronCommandIntegration` setting that guards it, shipped off by default since it's experimental, and this PR flips Positron's default for that setting to `true` so the integration is on by default in Positron. Users can still turn it off per user or workspace.

The default is registered with `registerDefaultConfigurations` in `positronAiFeatures.contribution.ts`, next to the agent-command service it enables. This works even though `posit.assistant` contributes the setting's schema later: the override is keyed by setting id and gets applied once the property registers.

### Screenshots

<img width="1565" height="970" alt="Screenshot 2026-07-23 at 4 49 09 PM" src="https://github.com/user-attachments/assets/0663fea5-547d-4b11-a359-f72b90a0fc42" />

**Setting ON**


https://github.com/user-attachments/assets/f19af6a5-6098-4ccc-8f31-0a0d585860cb



**Setting OFF**

https://github.com/user-attachments/assets/67db6f9a-a788-4270-9b85-357b2c456ed0



### Release Notes

#### New Features

- Added support for the `assistant.positronCommandIntegration` setting, which lets Posit Assistant run a subset of approved Positron commands. This setting is enabled by default in Positron.

#### Bug Fixes

- N/A

### Validation Steps

@:assistant

1. Build Positron from this branch and run it with a Posit Assistant build that includes the `assistant.positronCommandIntegration` setting (posit-dev/assistant#1810).
2. Open Settings, search `positronCommandIntegration`, and verify it's enabled by default with no user/workspace override set.
3. Start a conversation, ask the assistant to run a Positron command (e.g. "clear the console"), and confirm it runs.
4. Turn the setting off, and verify the `positronCommand` tool is no longer offered.
