### PR TITLE
skill: tighten author-vitest-tests, review-vitest-tests, author-e2e-tests

### DIFF
--- a/.claude/rules/vitest-tests.md
+++ b/.claude/rules/vitest-tests.md
@@ -113,6 +113,14 @@ Prefer `.stub()` via the builder for DI services -- `vi.mock` is the escape hatc
 
 **Inline snapshots:** Use `toMatchInlineSnapshot()` when you'd rather diff a known-good shape than maintain many separate assertions. Specifically: multi-property output (parser results, component markup), **exact-preservation** tests (round-trip fidelity, character-exact strings), **arrays of structured objects with 3+ entries**, **single objects projected to 3+ fields**, or when you'd otherwise write **3+ separate `.toBe()`/`.toEqual()` assertions against the same object** -- a known-good shape is easier to eyeball than a literal and survives field renames. Project structured objects to the relevant fields first: `expect({ kind, source, language }).toMatchInlineSnapshot(...)` beats snapshotting whole objects with irrelevant nested fields. For simple values, prefer `.toBe(...)`. Vitest fills and updates snapshots with `--update`; when one fails, read the diff before accepting.
 
+**Avoid snapshots when:**
+- an explicit assertion would be clearer about what's actually being checked (a single value, a boolean condition)
+- the output is large -- a snapshot that scrolls past a screen hides the one field that matters
+- the output is unstable -- timestamps, generated ids, or ordering that isn't guaranteed will cause spurious diffs unrelated to the behavior under test
+- only a few properties matter -- project to those fields (see above) rather than snapshotting the whole object as a substitute for picking the relevant assertions
+
+A snapshot should make the test easier to read and maintain, not just be the fastest thing to generate.
+
 ## Working examples
 
 - [positronUpdateUtils](../../src/vs/platform/update/test/common/positronUpdateUtils.vitest.ts) -- plain: pure function, no services, no builder

--- a/.claude/skills/author-e2e-tests/SKILL.md
+++ b/.claude/skills/author-e2e-tests/SKILL.md
@@ -9,6 +9,17 @@ description: Use when writing, debugging, or maintaining Playwright e2e tests fo
 
 Provides specialized knowledge and patterns for writing correct, reliable Playwright e2e tests that follow Positron's established conventions and avoid common mistakes.
 
+## Philosophy: What Makes a Good E2E Test
+
+Prefer the smallest test that confidently protects the intended user-visible behavior. Do not add additional scenarios or assertions simply because they are easy to write -- extra setup, incidental checks, and duplicate assertions add maintenance cost and flake surface without adding confidence.
+
+A good e2e test:
+- validates observable user behavior, not implementation details
+- exercises a complete workflow, not a fragment of one
+- minimizes setup to what the regression actually needs
+- remains deterministic -- no reliance on fixed waits, execution order, or leftover state
+- isolates the single regression it protects, so a failure points at one cause
+
 ## When to Use This Skill
 
 Load this skill when:
@@ -75,62 +86,17 @@ test.describe('Feature Name', {
 
 See `references/fixtures.md` for complete fixture documentation.
 
-## Quick Reference: Page Objects
+## Page Objects
 
-Access via `app.workbench.*`:
+UI interactions go through `app.workbench.*` page objects, not raw locators. Before writing any interaction: check for an existing method, then consider adding a reusable one, and only fall back to a raw locator when neither fits -- see `references/common-mistakes.md` #15 for the full workflow, and `references/page-objects.md` for usage idioms and "Finding the Exact Source" for looking up the exact signature in `test/e2e/pages/*.ts`. **Never guess or paraphrase a method name -- copy it from the source file.**
 
-```typescript
-const { console, variables, dataExplorer, plots, notebooks, sessions } = app.workbench;
+## Assertions
 
-// Execute code
-await console.executeCode('Python', 'x = 1');
+Standard Playwright web-first assertions apply, with the project's 15s default timeout covering most checks -- don't add `{ timeout }` reflexively. See `references/assertions.md` for choosing between `toPass`, `expect.poll`, and plain web-first assertions, selector priority, and what makes an assertion worth adding versus redundant.
 
-// Wait for content
-await console.waitForConsoleContents('expected text');
+## Test Tags
 
-// Variable interaction
-await variables.doubleClickVariableRow('df');
-
-// Data explorer
-await dataExplorer.grid.verifyTableData([{ col: 'value' }]);
-```
-
-See `references/page-objects.md` for usage idioms and "Finding the Exact Source" for how to look up the exact signature directly from `test/e2e/pages/*.ts`. **Never guess or paraphrase a method name -- copy it from the source file.**
-
-## Quick Reference: Assertions
-
-```typescript
-// Default 15s timeout covers most UI checks -- no override needed
-await expect(locator).toBeVisible();
-
-// Override only for a known-slow operation (see references/assertions.md)
-await expect(locator).toBeVisible({ timeout: 60000 });
-
-// Text content
-await expect(locator).toHaveText('expected');
-await expect(locator).toContainText('partial');
-
-// Count
-await expect(locator).toHaveCount(3, { timeout: 15000 });
-
-// Retry pattern for flaky operations
-await expect(async () => {
-	await someAction();
-	await expect(resultLocator).toBeVisible({ timeout: 2000 }); // fail quickly
-}).toPass({ timeout: 15000 });
-```
-
-See `references/assertions.md` for retry-mechanism choice (`toPass` vs `expect.poll` vs web-first) and selector priority.
-
-## Quick Reference: Test Tags
-
-Tag every `test.describe` via the `tag` array. Available tags are the `FeatureTags` (what the test covers) and `PlatformTags` (where it runs) enums in `test/e2e/infra/test-runner/test-tags.ts` -- read those for the current set. A test with no platform tag runs only on Linux/Electron; add `tags.WEB` / `tags.WIN` to broaden.
-
-```typescript
-test.describe('Console Tests', {
-	tag: [tags.WEB, tags.WIN, tags.CRITICAL, tags.CONSOLE]
-}, () => { ... });
-```
+Tag every `test.describe` via the `tag` array. Available tags are the `FeatureTags` (what the test covers) and `PlatformTags` (where it runs) enums in `test/e2e/infra/test-runner/test-tags.ts`. A test with no platform tag runs only on Linux/Electron; add `tags.WEB` / `tags.WIN` to broaden. See `references/test-structure.md` for the full tagging and annotation model.
 
 ## Performance / Metric Tests
 
@@ -152,6 +118,7 @@ All performance/metric tests must include `tags.PERFORMANCE` in their tag list.
 **Quality issues:**
 4. **Timeout overrides added reflexively** - the 15s default covers most UI checks; only override for a known-slow (or known-fast) operation
 5. **No `test.step()`** - wrap complex multi-action sequences for better reports
+6. **Fixed waits** - `page.waitForTimeout(...)` instead of a web-first assertion, `expect.poll`, `toPass`, or a POM wait helper
 
 See `references/common-mistakes.md` for detailed gotchas with code examples.
 

--- a/.claude/skills/author-e2e-tests/references/assertions.md
+++ b/.claude/skills/author-e2e-tests/references/assertions.md
@@ -58,6 +58,14 @@ because other skill files point at this as the canonical order.
 3. **Text content** -- `getByText('Python')`, `filter({ hasText: 'expected' })`
 4. **CSS selectors** -- `page.locator('.monaco-workbench')`. Least stable; use only when nothing above fits.
 
+## Assertion Quality
+
+More assertions is not more confidence. Before adding one, check that it validates something the others in the test don't already cover:
+
+- Prefer the one assertion that uniquely identifies the regression over several that would all fail for the same underlying reason (e.g. assert the final rendered value rather than every intermediate state that led to it).
+- Don't assert on behavior incidental to what the test is named for (e.g. checking a row count in a test whose regression is about cell text).
+- A test with more assertions isn't inherently more thorough -- it's often checking more than its name promises, and harder to debug when it fails, since it's unclear which assertion caught the regression.
+
 ## Positron assertion helpers
 
 Most Positron assertions go through POM methods rather than raw locators. See

--- a/.claude/skills/author-e2e-tests/references/common-mistakes.md
+++ b/.claude/skills/author-e2e-tests/references/common-mistakes.md
@@ -126,6 +126,8 @@ await expect(async () => {
 
 ### 8. No Cleanup in afterEach
 
+Leave the application in a clean state for the next test. Prefer cleanup in `afterEach` over relying on execution order or whatever state a prior test happened to leave behind -- state leakage between tests is one of the most common sources of e2e flakiness.
+
 **WRONG:**
 ```typescript
 test.describe('Tests', () => {
@@ -309,7 +311,13 @@ Page objects encapsulate:
 
 ### 15. Not Checking Page Object Methods First
 
-Before writing custom locator code, check the POM's source file in `test/e2e/pages/` for an existing method (see `references/page-objects.md`, "Finding the Exact Source", for how to locate it from `app.workbench.<name>`). Most common operations are already implemented -- copy the exact method name from source rather than guessing or paraphrasing it.
+Before writing custom locator code:
+
+1. Check the POM's source file in `test/e2e/pages/` for an existing method (see `references/page-objects.md`, "Finding the Exact Source", for how to locate it from `app.workbench.<name>`). Most common operations are already implemented -- copy the exact method name from source rather than guessing or paraphrasing it.
+2. If no method exists but the interaction is one other tests would plausibly need, add a reusable method to the page object instead of inlining locator code in the test.
+3. Only fall back to raw locator code in the test file itself when neither an existing nor a new reusable method fits -- e.g. a one-off check against structural markup no other test will need.
+
+This keeps locator logic in one place instead of duplicated (and potentially drifting) across tests.
 
 ```typescript
 // Instead of custom code, use:
@@ -326,6 +334,32 @@ await app.workbench.notebooks.selectInterpreter(...)
 
 Even a correctly-scoped `test.beforeAll` + `settings.set(...)` reloads the window, and for discovery/session-gating settings that reload can be flaky (it doesn't always re-run every cold-launch code path). Apply settings you know up front before the app launches instead. `references/fixtures.md`, "Custom Test Setup Files", covers the pre-launch options end to end: an existing base worker option via `test.use(...)`, a directory-wide `_test.setup.ts`, or a custom `beforeApp` override.
 
+## Fixed Waits
+
+### 17. Using page.waitForTimeout Instead of a Retrying Assertion
+
+**WRONG:**
+```typescript
+await button.click();
+await page.waitForTimeout(2000);  // Guesses how long the UI needs
+await expect(resultLocator).toBeVisible();
+```
+
+A fixed sleep either wastes time (waiting longer than necessary) or flakes under load (the UI needed more than the guessed duration). Prefer, in order:
+
+- a web-first assertion with an appropriate timeout: `await expect(resultLocator).toBeVisible({ timeout: 10000 })`
+- `expect.poll` for a non-Locator value that needs retrying (see `references/assertions.md`)
+- `toPass` when the action itself might need reissuing, not just the check
+- an existing POM wait helper (e.g. `console.waitForReady`) if one already encodes the right condition
+
+**CORRECT:**
+```typescript
+await button.click();
+await expect(resultLocator).toBeVisible({ timeout: 10000 });
+```
+
+Reach for `page.waitForTimeout` only for a genuinely unusual case with no observable condition to assert on -- and say why in a comment, since a reviewer will otherwise flag it as a race waiting to happen.
+
 ## Summary: Pre-Submit Checklist
 
 Before submitting a test, verify:
@@ -337,7 +371,9 @@ Before submitting a test, verify:
 - [ ] Settings known before the test runs are applied pre-launch (`beforeApp`/`settingsFile`), not via a mid-test `settings.set()` reload
 - [ ] Timeout overrides exist only where an operation is known to be slower (or should fail faster) than the 15s default -- not added reflexively to every assertion
 - [ ] Uses `toPass` for potentially flaky operations
+- [ ] No `page.waitForTimeout(...)` fixed sleeps unless there's no observable condition to assert on instead
 - [ ] Has cleanup in `afterEach`
 - [ ] Uses page object methods instead of raw locators where possible, with method names copied from source in `test/e2e/pages/` (not guessed)
 - [ ] Raw Playwright sequences (not already a POM call) are wrapped in `test.step()`; POM calls that already self-wrap are not double-wrapped
 - [ ] Test is independent (doesn't rely on other tests)
+- [ ] Every assertion validates something distinct -- no redundant checks that would all fail for the same reason, no scenarios added just because they were easy to write

--- a/.claude/skills/author-vitest-tests/SKILL.md
+++ b/.claude/skills/author-vitest-tests/SKILL.md
@@ -141,7 +141,8 @@ If the dev asks for changes, revise the plan and re-present. Repeat until confir
 For each approved item:
 
 1. **Write the test** following the conventions in [`.claude/rules/vitest-tests.md`](../../rules/vitest-tests.md) (file layout, `/// <reference>`, assertions, builder usage, inline snapshots). For React tests, also follow [`.claude/rules/vitest-rtl.md`](../../rules/vitest-rtl.md). Authoring-specific quality bar:
-   - Each describe block: happy path, boundary case, and at least one negative case.
+   - Cover the meaningful behavioral partitions for the regression under test. Consider happy, boundary, error, absent-data, and negative cases where they represent distinct observable behavior -- happy/boundary/negative are heuristics, not a quota. Do not invent a test just to fill a category; a describe block with only a happy-path test is correct if no other partition is distinct.
+   - Favor fewer high-value tests over more low-value ones. Before adding a case, ask whether it would catch a regression a reviewer would actually care about -- skip artificial boundary probes, trivial negative cases, and assertions that duplicate a nearby test.
    - If setup exceeds ~20 lines of stubs, extract a helper function.
    - Minimize imports: if you're importing 5+ service identifiers just for `.stub()` calls, extract a helper.
 
@@ -155,7 +156,7 @@ For each approved item:
 
 6. Move to the next file. Do NOT ask the dev after each file.
 
-7. After all tests pass, run the full Vitest suite: `npm run test:positron`
+Don't run the full suite here -- it runs exactly once, after Phase 3 fixes land (see below). Running it now just duplicates that pass.
 
 ### Builder enforcement
 
@@ -183,7 +184,8 @@ Agent({
 For each issue:
 1. Apply the fix
 2. Re-run the affected test: `npx vitest run <path-to-test-file>`
-3. Re-run the full suite: `npx vitest run`
+
+After all fixes are applied, run the full suite exactly once: `npm run test:positron` (equivalent to `npx vitest run` -- pick one, don't run both). This is the only full-suite run in the whole workflow; preceding steps only ever run targeted files.
 
 Present the dev with a summary:
 - How many issues the review caught
@@ -193,6 +195,7 @@ Present the dev with a summary:
 ## Hard rules
 
 - **Test for regressions, not coverage.** Before writing any test, state what user-visible or system-observable regression it guards against. If you can't answer, skip the test. A test that verifies an internal counter, array index, or call count — where the real invariant is a downstream side-effect — is testing structure, not behavior. Coverage is a side-effect of good tests, not a goal.
+- **Don't pad for category coverage.** Happy/boundary/negative are heuristics for finding distinct behaviors, not a per-describe quota. When in doubt, write fewer high-value tests instead of more low-value ones.
 - **Don't over-test.** Test public behavior, not implementation details.
 - **Don't export internals for testing.** Test behavior through rendered output or public API.
 - **Don't write E2E tests.** Flag for E2E if needed, but don't write them.

--- a/.claude/skills/review-vitest-tests/SKILL.md
+++ b/.claude/skills/review-vitest-tests/SKILL.md
@@ -21,6 +21,8 @@ $ARGUMENTS should contain the test file path(s) to review. For each test file, a
 
 Evaluate each test file against this checklist. Report ONLY items that fail -- don't list passing items. Also flag any cross-file inconsistencies (e.g., same service stubbed differently, different assertion styles for the same pattern).
 
+**Weight findings by impact.** Correctness bugs (0, 2, 9), missing behavioral coverage (5), flaky/nondeterministic tests (7, 9), and incorrect abstractions (2's private-method-seam and wide-cast checks) matter most -- lead with those in the report. Findings that are purely stylistic (1's naming/import tidiness, 6's consistency) are worth reporting only when there's a concrete maintainability or correctness benefit; don't create churn over preference alone.
+
 ### 0. Test value and falsifiability
 
 For each test, ask: **what specific production code change would make it fail, and does that change represent a user-visible or system-observable regression?**
@@ -53,7 +55,7 @@ Any stubs that mock more than what the tests actually exercise? Any stub objects
 
 ### 5. Edge case coverage
 
-For each public method or event tested, is there: (a) a happy-path test, (b) a no-op or boundary test, (c) at least one negative or interaction test? List specific missing cases.
+For each public method or event tested, is there a distinct behavioral partition that's untested -- a happy path, a boundary, an error, an absent-data case, or a negative/interaction case that would represent genuinely different observable behavior? List specific missing cases. Don't flag a missing category just because the checklist names it; only flag it if that partition is actually distinct from what's already covered and would catch a real regression.
 
 ### 6. Pattern consistency
 
@@ -74,6 +76,10 @@ Any `new Emitter()` created inside an `it()` callback whose `.event` is expected
 ### 10. Spy cleanup
 
 Any `vi.spyOn(console, ...)` or `vi.spyOn(obj, 'method')` without a corresponding restore? Accept only `restoreMocks: true` in the vitest config, `afterEach(() => vi.restoreAllMocks())`, or `spy.mockRestore()` inside a `finally` block. Flag inline `mockRestore()` placed after `expect` calls as fragile -- a failing assertion skips it, and the spy leaks into subsequent tests. (Note: the project's `vitest.config.ts` already sets `restoreMocks: true` globally, so most new tests need no per-file cleanup.)
+
+### 11. Snapshot appropriateness
+
+For each `toMatchInlineSnapshot()` call, check against the criteria in `.claude/rules/vitest-tests.md`'s Inline snapshots section. Flag it if: explicit assertions would be clearer for what's actually being checked, the snapshotted output is large or has unstable fields (timestamps, generated ids, ordering), or only a few properties matter and the rest is noise the reader has to skip past. Suggest projecting to the relevant fields (`expect({ kind, source })...`) or replacing with a direct `.toBe()`/`.toEqual()` where that would read more clearly.
 
 ## Output format
 

--- a/.claude/skills/triage-e2e-test/references/evidence-escalation.md
+++ b/.claude/skills/triage-e2e-test/references/evidence-escalation.md
@@ -38,6 +38,15 @@ to the raw logs (Level 4).
 
 ## Reading raw logs (Level 4)
 
+The S3 report is the complete source -- it keeps each attempt (attempt 0 = the
+failure). Do **not** hand-download a GitHub Actions artifact zip to get app-side
+logs: with CI `retries=1`, a flaky test's per-test logs
+(`server/.../positron.positron-supervisor/*.log`, kernel logs) are overwritten by
+the passing retry in the artifact, so it shows a *clean* run and will mislead you
+into thinking the failing logs are gone. `--keep-raw-logs` on the report is the
+path to the failing kernel/supervisor logs; never escalate to a ci-arm repro just
+to recapture logs the report already has.
+
 Re-run `fetch-pattern-evidence.js` with `--keep-raw-logs`, or the underlying
 processor without `--cleanup`. The raw `logs-<shortId>.zip` is left in the OS
 temp dir, at the path the script prints to stderr on its last line:


### PR DESCRIPTION
### Summary
- Sharpens the Vitest and E2E authoring skills toward smaller, higher-value tests instead of quota-driven ones.
- Replace happy/boundary/negative test quotas with behavioral-partition guidance across both Vitest skills
- Strengthen inline-snapshot guidance and add a snapshot-appropriateness review check
- Trim duplicated e2e quick-reference code examples down to reference-doc pointers

### QA Notes
Skill/rule doc-only change under `.claude/skills` and `.claude/rules`; no product code touched, no e2e/vitest tags apply.