### PR TITLE
skill(triage-e2e-test): validate diagnosis header fields before recording

### DIFF
--- a/.claude/skills/triage-e2e-test/references/evidence-escalation.md
+++ b/.claude/skills/triage-e2e-test/references/evidence-escalation.md
@@ -74,6 +74,18 @@ node .claude/skills/e2e-failure-analyzer/scripts/e2e-process-s3.js ... \
   | jq '.testDetails[0].attempts[0].trace.timeline'
 ```
 
+## Contrast the failing attempt against a passing one
+
+For a suspected race, the digest shows *what* failed but not *which
+interleaving* separates pass from fail. The S3 report retains every attempt
+(attempt 0 = the failure; later attempts = passing retries), so a green run's
+logs are already in the same report -- no second fetch, no ci-arm. Diff the two
+attempts' `[info]`-level orderings in the same channel file (e.g. the kernel /
+supervisor log): the line whose relative order flips between them is the race,
+and the direction of the flip tells you which ordering is the bug. This turns an
+"is it even a race" hunch into a named mechanism -- it's what separates a Signal
+that cites an ordering from one that only restates the timeout.
+
 ## Retrieval failures
 
 - **403 from the processor** means "this particular upload isn't fetchable"

--- a/.claude/skills/triage-e2e-test/scripts/checkpoint.js
+++ b/.claude/skills/triage-e2e-test/scripts/checkpoint.js
@@ -62,6 +62,22 @@ export const SETTABLE_FIELDS = new Set([
 ]);
 
 /**
+ * Every top-level field the state legitimately holds (the initState shape).
+ * `--patch` deep-merges, so a top-level key it *introduces* is almost always a
+ * nesting mistake: `--patch '{"confidence":"high"}'` meant `diagnosis.confidence`
+ * but silently creates a stray top-level `confidence` the renderer never reads.
+ * `applyMutations` rejects unknown top-level patch keys so that fails loudly,
+ * the same way `--set` rejects unknown fields. Deep keys under a known object
+ * (`diagnosis.mechanismMap`) stay free -- the check is top-level only.
+ */
+export const KNOWN_FIELDS = new Set([
+	'version', 'triageId', 'testKey', 'branch', 'lookbackDays', 'phase',
+	'history', 'patterns', 'selectedPattern', 'priorTriage', 'evidence',
+	'diagnosis', 'outcome', 'outcomeRef', 'outcomeReason',
+	'diagnosisBlockRecorded', 'nextAction', 'updatedAt',
+]);
+
+/**
  * Default next action for each phase. Advancing `phase` without also setting
  * `nextAction` would otherwise leave the init default stale, so a resume would
  * print a misleading step. `--set phase=X` derives the matching next action
@@ -94,6 +110,12 @@ export function applyMutations(state, patch, sets = []) {
 	const touched = new Set();
 	let next = state;
 	if (patch) {
+		const unknown = Object.keys(patch).filter(k => !KNOWN_FIELDS.has(k));
+		if (unknown.length) {
+			throw new Error(`--patch introduced unknown top-level field(s): ${unknown.join(', ')}. ` +
+				`Nest under a known object (e.g. {"diagnosis": {"${unknown[0]}": ...}}) or use --set for a scalar. ` +
+				`Known: ${[...KNOWN_FIELDS].join(', ')}.`);
+		}
 		next = applyPatch(next, patch);
 		for (const k of Object.keys(patch)) { touched.add(k); }
 	}

--- a/.claude/skills/triage-e2e-test/scripts/record-diagnosis.js
+++ b/.claude/skills/triage-e2e-test/scripts/record-diagnosis.js
@@ -49,6 +49,41 @@ const BLOCK_HEADING = '### E2E Triage Diagnosis';
 // no-op (checkpoint-only) is out of scope -- that goes through checkpoint.js.
 const ARTIFACT_OUTCOMES = OUTCOMES.filter(o => o !== 'no-op');
 const CONFIDENCE_EMOJI = { high: '\u{1F7E2}', medium: '\u{1F7E1}', low: '\u{1F534}' };
+const CONFIDENCE_LEVELS = Object.keys(CONFIDENCE_EMOJI);
+// The summary is the one-line teaser inside <summary>. A multi-paragraph value
+// renders as a wall of text in the collapsed header; this bounds it generously
+// (a normal teaser is 150-350 chars) so the full mechanism stays in the bullets.
+const MAX_SUMMARY_LEN = 600;
+
+/**
+ * Validate the checkpoint fields that drive the rendered <summary> header.
+ * `renderBlock` is a forgiving renderer -- an unknown `confidence` silently
+ * falls back to a medium emoji plus a title-cased dump of the raw string, and
+ * an overlong `summary` lands whole inside the header. That produces a
+ * janky-but-valid block that sails onto a real PR. Fail loudly here, before the
+ * block is written, so the author fixes the diagnosis instead. Returns a
+ * human-readable error string, or null when the fields are clean.
+ */
+export function validateDiagnosis(d) {
+	const conf = String(d.confidence ?? '').toLowerCase();
+	if (!CONFIDENCE_LEVELS.includes(conf)) {
+		return `diagnosis.confidence must be one of ${CONFIDENCE_LEVELS.join(' | ')} ` +
+			`(got ${JSON.stringify(d.confidence)}); it maps to the emoji + label in the block header.`;
+	}
+	const summary = String(d.summary ?? '').trim();
+	if (!summary) {
+		return 'diagnosis.summary is required -- it is the one-line teaser in the <summary> header.';
+	}
+	if (/[\r\n]/.test(summary)) {
+		return 'diagnosis.summary must be a single line (no line breaks); ' +
+			'put the full mechanism in the Signal / Hypothesis bullets.';
+	}
+	if (summary.length > MAX_SUMMARY_LEN) {
+		return `diagnosis.summary is ${summary.length} chars; keep it under ${MAX_SUMMARY_LEN} ` +
+			'as a one-line teaser and put the full mechanism in the Signal / Hypothesis bullets.';
+	}
+	return null;
+}
 
 /** Human frequency string from the selected history pattern, e.g.
  *  "31/317 runs (9.8%), ubuntu/chromium". Returns null when unavailable. */
@@ -131,6 +166,10 @@ function main() {
 	if (!state.diagnosis || typeof state.diagnosis !== 'object') {
 		fail('Checkpoint has no diagnosis object. Save one (checkpoint.js --patch) before recording.');
 	}
+	// Guard the header fields before rendering, so a malformed diagnosis is
+	// caught at --dry-run / record time rather than shipping a janky block.
+	const problem = validateDiagnosis(state.diagnosis);
+	if (problem) { fail(problem); }
 
 	const historyFile = path.join(dir, 'history-summary.json');
 	const history = fs.existsSync(historyFile) ? readJson(historyFile) : null;

--- a/.claude/skills/triage-e2e-test/scripts/test/checkpoint.test.js
+++ b/.claude/skills/triage-e2e-test/scripts/test/checkpoint.test.js
@@ -78,6 +78,21 @@ test('applyMutations rejects a --set on a non-mutable field', () => {
 	assert.equal(applyMutations({ phase: 'x' }, null, [['phase', 'implementation']]).phase, 'implementation');
 });
 
+test('applyMutations rejects a --patch that introduces an unknown top-level field', () => {
+	// The footgun: `--patch {"confidence":...}` meant `diagnosis.confidence` but
+	// silently created a stray top-level key the renderer never reads.
+	assert.throws(() => applyMutations({ phase: 'x' }, { confidence: 'high' }, []), /unknown top-level field/);
+	assert.throws(() => applyMutations({ phase: 'x' }, { reproResult: 'note' }, []), /unknown top-level field/);
+});
+
+test('applyMutations allows a --patch on a known object field and its deep keys', () => {
+	// Nesting under a known object is the correct usage; deep keys stay free.
+	const out = applyMutations({ phase: 'x', diagnosis: { confidence: 'low' } },
+		{ diagnosis: { confidence: 'high', mechanismMap: 'anything' } }, []);
+	assert.equal(out.diagnosis.confidence, 'high');
+	assert.equal(out.diagnosis.mechanismMap, 'anything');
+});
+
 test('checkDoneGate blocks done with no outcome set', () => {
 	const gate = checkDoneGate({ phase: 'done' });
 	assert.equal(gate.ok, false);

--- a/.claude/skills/triage-e2e-test/scripts/test/record-diagnosis.test.js
+++ b/.claude/skills/triage-e2e-test/scripts/test/record-diagnosis.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { renderBlock, deriveFrequency } from '../record-diagnosis.js';
+import { renderBlock, deriveFrequency, validateDiagnosis } from '../record-diagnosis.js';
 import { extractDiagnosisFields } from '../find-prior-triage.js';
 
 const meta = () => ({
@@ -49,6 +49,29 @@ test('renderBlock falls back to a plain title when no dashboard url', () => {
 test('renderBlock maps confidence to emoji and defaults to medium', () => {
 	assert.match(renderBlock({ ...diagnosis(), confidence: 'low' }, meta()), /\u{1F534}/u);
 	assert.match(renderBlock({ hypothesis: 'x' }, meta()), /\u{1F7E1}/u); // medium default
+});
+
+test('validateDiagnosis accepts a clean diagnosis', () => {
+	assert.equal(validateDiagnosis(diagnosis()), null);
+});
+
+test('validateDiagnosis rejects a confidence outside high/medium/low', () => {
+	// The exact bug that shipped: a whole phrase as confidence renders 🟡 + a
+	// title-cased dump instead of a level.
+	assert.match(validateDiagnosis({ ...diagnosis(), confidence: 'high-root-cause-supervisor-ordering-race' }), /confidence must be one of/);
+	assert.match(validateDiagnosis({ ...diagnosis(), confidence: undefined }), /confidence must be one of/);
+});
+
+test('validateDiagnosis requires a summary', () => {
+	assert.match(validateDiagnosis({ ...diagnosis(), summary: '' }), /summary is required/);
+	assert.match(validateDiagnosis({ ...diagnosis(), summary: '   ' }), /summary is required/);
+});
+
+test('validateDiagnosis rejects a multi-line or overlong summary', () => {
+	// The other half of the shipped bug: the full mechanism dumped into the
+	// one-line <summary> header.
+	assert.match(validateDiagnosis({ ...diagnosis(), summary: 'line one\nline two' }), /single line/);
+	assert.match(validateDiagnosis({ ...diagnosis(), summary: 'x'.repeat(601) }), /chars; keep it under/);
 });
 
 test('deriveFrequency builds runs/percentage/env from the selected pattern', () => {


### PR DESCRIPTION
### Summary
Three triage-skill guardrail fixes from a triage session, all closing silent-wrong-state footguns.
- `record-diagnosis.js`: add `validateDiagnosis()` (called in `main()` before rendering) so a `confidence` outside `high`/`medium`/`low` or a multi-line/overlong `summary` fails at `--dry-run`/record time instead of rendering a janky block. `renderBlock` stays a forgiving pure renderer.
- `checkpoint.js`: `--patch` now rejects top-level keys outside the known state shape, mirroring `--set`'s existing unknown-field guard. Catches a nesting mistake (e.g. `--patch '{"confidence":...}'` meant for `diagnosis.confidence`) that silently created a stray field; deep keys under a known object stay free.
- `evidence-escalation.md`: recommend diffing the failing attempt's logs against a passing attempt's for race diagnosis (all attempts live in the same S3 report).
- Unit tests for both guards.

### QA Notes
`node --test .claude/skills/triage-e2e-test/scripts/test/*.test.js` (49 passing)
