### PR TITLE
E2E test: temporary fix for Ruff being broken

### DIFF
--- a/test/e2e/fixtures/settingsSkipPyrefly.json
+++ b/test/e2e/fixtures/settingsSkipPyrefly.json
@@ -1,6 +1,7 @@
 {
 	"extensions.allowed": {
 		"meta.pyrefly": false,
+		"charliermarsh.ruff": false,
 		"*": true
 	}
 }


### PR DESCRIPTION
## Summary

The `charliermarsh.ruff` extension is currently broken and is breaking the e2e test suite. This adds it to the `settingsSkipPyrefly.json` fixture (`extensions.allowed`) so it's disabled during e2e runs, keeping the suite functional until the extension is fixed.

The ruff-dependent tests are run in the nightly pyrefly workflow, so this should not affect coverage in the regular suite.

## Notes

- This fixture is merged into e2e settings whenever `ALLOW_PYREFLY !== 'true'` (the default), so this disables ruff for all e2e runs, not just the nightly workflow.
- This is intended to be temporary and should be reverted once the ruff extension is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)