### PR TITLE
fix(ci): retry ext-host Electron cold-starts on startup segfault

### DIFF
--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -210,11 +210,39 @@ else
 	kill_app() { killall $INTEGRATION_TEST_APP_NAME || true; }
 fi
 
+# --- Start Positron ---
+# Headless Electron intermittently GP-faults on startup in libexpat while
+# fontconfig initializes fonts on a glib worker thread (a thread-safety race in
+# the system font libraries; crash stack: libexpat <- libfontconfig <-
+# libpangoft2). It happens before any test runs, exits 139 (SIGSEGV), and takes
+# the whole suite down with it. The race lives in system libraries we can't
+# patch, so retry an invocation that dies with a startup segfault: a fresh
+# process is a new roll of the dice and succeeds nearly every time. Only exit
+# 139 is retried -- any other non-zero exit is a real test failure and is
+# returned immediately so it is never masked. Mirrors the helper in
+# test-remote-integration.sh.
+run_integration_test() {
+	local attempt=1 max_attempts=3 status
+	while true; do
+		set +e
+		"$@"
+		status=$?
+		set -e
+		if [ "$status" -ne 139 ] || [ "$attempt" -ge "$max_attempts" ]; then
+			return "$status"
+		fi
+		echo "Electron exited 139 (startup segfault, likely fontconfig race); retrying (attempt $((attempt + 1))/$max_attempts)..."
+		kill_app
+		attempt=$((attempt + 1))
+	done
+}
+# --- End Positron ---
+
 if should_run_suite api-folder; then
 echo
 echo "### API tests (folder)"
 echo
-"$INTEGRATION_TEST_ELECTRON_PATH" $ROOT/extensions/vscode-api-tests/testWorkspace --enable-proposed-api=vscode.vscode-api-tests --extensionDevelopmentPath=$ROOT/extensions/vscode-api-tests --extensionTestsPath=$ROOT/extensions/vscode-api-tests/out/singlefolder-tests $API_TESTS_EXTRA_ARGS
+run_integration_test "$INTEGRATION_TEST_ELECTRON_PATH" $ROOT/extensions/vscode-api-tests/testWorkspace --enable-proposed-api=vscode.vscode-api-tests --extensionDevelopmentPath=$ROOT/extensions/vscode-api-tests --extensionTestsPath=$ROOT/extensions/vscode-api-tests/out/singlefolder-tests $API_TESTS_EXTRA_ARGS
 kill_app
 fi
 
@@ -222,7 +250,7 @@ if should_run_suite api-workspace; then
 echo
 echo "### API tests (workspace)"
 echo
-"$INTEGRATION_TEST_ELECTRON_PATH" $ROOT/extensions/vscode-api-tests/testworkspace.code-workspace --enable-proposed-api=vscode.vscode-api-tests --extensionDevelopmentPath=$ROOT/extensions/vscode-api-tests --extensionTestsPath=$ROOT/extensions/vscode-api-tests/out/workspace-tests $API_TESTS_EXTRA_ARGS
+run_integration_test "$INTEGRATION_TEST_ELECTRON_PATH" $ROOT/extensions/vscode-api-tests/testworkspace.code-workspace --enable-proposed-api=vscode.vscode-api-tests --extensionDevelopmentPath=$ROOT/extensions/vscode-api-tests --extensionTestsPath=$ROOT/extensions/vscode-api-tests/out/workspace-tests $API_TESTS_EXTRA_ARGS
 kill_app
 fi
 
@@ -249,7 +277,7 @@ if should_run_suite typescript; then
 echo
 echo "### TypeScript tests"
 echo
-"$INTEGRATION_TEST_ELECTRON_PATH" $ROOT/extensions/typescript-language-features/test-workspace --extensionDevelopmentPath=$ROOT/extensions/typescript-language-features --extensionTestsPath=$ROOT/extensions/typescript-language-features/out/test/unit $API_TESTS_EXTRA_ARGS
+run_integration_test "$INTEGRATION_TEST_ELECTRON_PATH" $ROOT/extensions/typescript-language-features/test-workspace --extensionDevelopmentPath=$ROOT/extensions/typescript-language-features --extensionTestsPath=$ROOT/extensions/typescript-language-features/out/test/unit $API_TESTS_EXTRA_ARGS
 kill_app
 fi
 
@@ -265,7 +293,7 @@ if should_run_suite emmet; then
 echo
 echo "### Emmet tests"
 echo
-"$INTEGRATION_TEST_ELECTRON_PATH" $ROOT/extensions/emmet/test-workspace --extensionDevelopmentPath=$ROOT/extensions/emmet --extensionTestsPath=$ROOT/extensions/emmet/out/test $API_TESTS_EXTRA_ARGS
+run_integration_test "$INTEGRATION_TEST_ELECTRON_PATH" $ROOT/extensions/emmet/test-workspace --extensionDevelopmentPath=$ROOT/extensions/emmet --extensionTestsPath=$ROOT/extensions/emmet/out/test $API_TESTS_EXTRA_ARGS
 kill_app
 fi
 
@@ -273,7 +301,7 @@ if should_run_suite git; then
 echo
 echo "### Git tests"
 echo
-"$INTEGRATION_TEST_ELECTRON_PATH" $(mktemp -d 2>/dev/null) --extensionDevelopmentPath=$ROOT/extensions/git --extensionTestsPath=$ROOT/extensions/git/out/test $API_TESTS_EXTRA_ARGS
+run_integration_test "$INTEGRATION_TEST_ELECTRON_PATH" $(mktemp -d 2>/dev/null) --extensionDevelopmentPath=$ROOT/extensions/git --extensionTestsPath=$ROOT/extensions/git/out/test $API_TESTS_EXTRA_ARGS
 kill_app
 fi
 


### PR DESCRIPTION
## Problem

The ext-host **Electron** test job (`test / ext-host`) has been failing on `main` with **exit code 139** (SIGSEGV), not a test failure -- all test suites pass. The crash is a startup segfault in [`scripts/test-integration.sh`](https://github.com/posit-dev/positron/blob/main/scripts/test-integration.sh) when it cold-starts a fresh Electron per test workspace:

```
Received signal 11 SI_KERNEL (General Protection Fault)
  libexpat.so.1.9.1  <-  libfontconfig.so.1.12.1  <-  libpangoft2  (fontconfig FcInit on a glib worker thread)
./scripts/test-integration.sh: line 252: Segmentation fault (core dumped) "$INTEGRATION_TEST_ELECTRON_PATH" .../typescript-language-features/test-workspace ...
##[error]Process completed with exit code 139.
```

It recurs across recent `main` runs (e.g. [this run](https://github.com/posit-dev/positron/actions/runs/30098533769/job/89498502282), plus jobs `89254020574` and `89494467177`), always with the same stack.

## Root cause

This is the same fontconfig/libexpat thread-safety race that #14931 addressed at the image layer. That PR:

- confirmed the CI image ships the CVE-2024-45490-patched libexpat (`2.6.1-2ubuntu0.4`) + a prebuilt font cache, and
- added a `run_integration_test` retry helper to `test-remote-integration.sh`.

But #14931's own comment noted the image hardening "shrink[s] the window to near-zero" rather than eliminating the race -- fontconfig still parses its config XML through libexpat on every `FcInit`, on every Electron cold start. And the retry helper was only ever applied to the **Remote** suite, never to the **Electron** suite (`test-integration.sh`), which is where the remaining crashes land.

## Fix

Port the existing `run_integration_test` helper into `test-integration.sh` and wrap the five direct-Electron invocations (api-folder, api-workspace, typescript, emmet, git).

- Retries up to 3 times, **only** on exit 139.
- Any other non-zero exit is returned immediately, so real test failures are never masked.
- Semantics identical to the helper already in `test-remote-integration.sh`.

Scope kept surgical: `npm run test-extension` and `node-electron.sh` (css/html) invocations are left unwrapped, matching the remote script (only direct `$INTEGRATION_TEST_ELECTRON_PATH` cold-starts hit this crash). The remote script's software-GL flags were intentionally not ported here -- the retry is the safety net; those flags are a separate follow-up lever if this alone proves insufficient.

## Testing

The failure is a low-frequency environmental race, so a green run doesn't prove the fix and reproducing locally isn't practical. Validated: `bash -n` parses, precommit hygiene passes, and the helper is a direct port of the one proven on the Remote suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)