### PR TITLE
Update supervisor version to pick up new Windows signed build

### DIFF
--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -189,7 +189,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "kallichore": "0.1.67"
+      "kallichore": "0.1.68"
     }
   },
   "extensionDependencies": [


### PR DESCRIPTION
No functionality change; this just updates the embedded kernel supervisor version to one signed with the updated DigiCert certificate. 