### PR TITLE
ci(e2e): resolve Windows/macOS R versions dynamically via r-hub

### DIFF
--- a/.github/workflows/test-e2e-macos-run.yml
+++ b/.github/workflows/test-e2e-macos-run.yml
@@ -178,12 +178,21 @@ jobs:
           fi
 
       - name: Install Rig and R
+        id: r-versions
         run: |
           if brew list --cask | grep -q "^r$"; then
             brew uninstall r
           fi
-          R_VERSION="4.5.2"
-          R_ALTERNATE_VERSION="4.3.0"
+          # Resolve the default (release) and alternate (oldrel-2) R versions
+          # dynamically from the r-hub rversions API -- the same service
+          # r-lib/actions/setup-r uses -- so they track the current R release
+          # instead of being pinned. Emitted as step outputs for the
+          # POSITRON_R_VER_SEL / POSITRON_R_ALT_VER_SEL selectors below.
+          R_VERSION=$(curl -fsSL --retry 3 --retry-delay 2 https://api.r-hub.io/rversions/r-release | python3 -c 'import json,sys; print(json.load(sys.stdin)["version"])')
+          R_ALTERNATE_VERSION=$(curl -fsSL --retry 3 --retry-delay 2 https://api.r-hub.io/rversions/r-oldrel/2 | python3 -c 'import json,sys; print(json.load(sys.stdin)["version"])')
+          echo "Resolved R release=$R_VERSION, oldrel-2=$R_ALTERNATE_VERSION"
+          echo "r_version=$R_VERSION" >> "$GITHUB_OUTPUT"
+          echo "r_alt_version=$R_ALTERNATE_VERSION" >> "$GITHUB_OUTPUT"
           # Install rig from its official release .pkg rather than Homebrew.
           # The r-lib/rig brew tap has been unreliable (third-party tap trust
           # prompts and cask checksum mismatches); the .pkg is the method
@@ -210,7 +219,7 @@ jobs:
           echo "Installing R version $R_ALTERNATE_VERSION using Rig..."
           rig add "$R_ALTERNATE_VERSION"
 
-      - name: Install R packages for 4.5.2
+      - name: Install R packages (default R version)
         env:
           # Pin to a frozen PPM snapshot instead of `latest`. `latest` is a rolling
           # target: pak resolves a version from the metadata, but by the time it
@@ -293,9 +302,9 @@ jobs:
       - name: Run Tests (Electron)
         env:
           POSITRON_PY_VER_SEL: 3.10.10
-          POSITRON_R_VER_SEL: 4.5.2
+          POSITRON_R_VER_SEL: ${{ steps.r-versions.outputs.r_version }}
           POSITRON_PY_ALT_VER_SEL: 3.11.0
-          POSITRON_R_ALT_VER_SEL: 4.3.0
+          POSITRON_R_ALT_VER_SEL: ${{ steps.r-versions.outputs.r_alt_version }}
           REPORTER_REPO_NAME: positron
           COMMIT_INFO_MESSAGE: ${{ github.event.head_commit.message }}
           CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}

--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -363,11 +363,23 @@ jobs:
         run: |
           winget install --id Posit.rig --accept-source-agreements --accept-package-agreements
 
-      # Install R 4.4.0 using rig
-      - name: Install R 4.4.0
+      # Resolve and install R via rig. The default (release) and alternate
+      # (oldrel-2) versions are resolved dynamically from the r-hub rversions
+      # API -- the same service r-lib/actions/setup-r uses -- so they track the
+      # current R release instead of being pinned. Both resolved numbers are
+      # emitted as step outputs and reused for the package cache key/path and
+      # the POSITRON_R_VER_SEL / POSITRON_R_ALT_VER_SEL selectors below.
+      - name: Install default R and resolve versions
+        id: r-versions
+        shell: pwsh
         run: |
-          rig add 4.4.0
-          rig default 4.4.0
+          $release = (Invoke-RestMethod -Uri 'https://api.r-hub.io/rversions/r-release' -MaximumRetryCount 3 -RetryIntervalSec 5).version
+          $oldrel2 = (Invoke-RestMethod -Uri 'https://api.r-hub.io/rversions/r-oldrel/2' -MaximumRetryCount 3 -RetryIntervalSec 5).version
+          Write-Host "Resolved R release=$release, oldrel-2=$oldrel2"
+          "r_version=$release" >> $env:GITHUB_OUTPUT
+          "r_alt_version=$oldrel2" >> $env:GITHUB_OUTPUT
+          rig add $release
+          rig default $release
           rig ls
 
       - name: Stage R DESCRIPTION file
@@ -385,12 +397,12 @@ jobs:
         with:
           path: |
             ~\AppData\Local\R\cache
-            C:\Program Files\R\R-4.4.0\library
-          key: ${{ runner.os }}-r-4.4.0-${{ steps.download-r-desc.outputs.description-hash }}
+            C:\Program Files\R\R-${{ steps.r-versions.outputs.r_version }}\library
+          key: ${{ runner.os }}-r-${{ steps.r-versions.outputs.r_version }}-${{ steps.download-r-desc.outputs.description-hash }}
           restore-keys: |
-            ${{ runner.os }}-r-4.4.0-
+            ${{ runner.os }}-r-${{ steps.r-versions.outputs.r_version }}-
 
-      - name: Install R packages for 4.4.0
+      - name: Install R packages (default R version)
         env:
           # Pin to a frozen PPM snapshot instead of `latest`. `latest` is a rolling
           # target: pak resolves a version from the metadata, but by the time it
@@ -412,13 +424,16 @@ jobs:
         with:
           path: |
             ~\AppData\Local\R\cache
-            C:\Program Files\R\R-4.4.0\library
-          key: ${{ runner.os }}-r-4.4.0-${{ steps.download-r-desc.outputs.description-hash }}
+            C:\Program Files\R\R-${{ steps.r-versions.outputs.r_version }}\library
+          key: ${{ runner.os }}-r-${{ steps.r-versions.outputs.r_version }}-${{ steps.download-r-desc.outputs.description-hash }}
 
-      # Install R 4.4.2 using rig
-      - name: Install R 4.4.2
+      # Install the alternate R version (oldrel-2). Added after the default's
+      # packages are installed so `rig default` stays on the release version
+      # during the package install above.
+      - name: Install alternate R (oldrel-2)
+        shell: pwsh
         run: |
-          rig add 4.4.2
+          rig add ${{ steps.r-versions.outputs.r_alt_version }}
           rig ls
 
       - name: Setup Graphviz
@@ -554,9 +569,9 @@ jobs:
         shell: bash
         env:
           POSITRON_PY_VER_SEL: 3.10.10
-          POSITRON_R_VER_SEL: 4.4.0
+          POSITRON_R_VER_SEL: ${{ steps.r-versions.outputs.r_version }}
           POSITRON_PY_ALT_VER_SEL: 3.13.0
-          POSITRON_R_ALT_VER_SEL: 4.4.2
+          POSITRON_R_ALT_VER_SEL: ${{ steps.r-versions.outputs.r_alt_version }}
           PWTEST_BLOB_DO_NOT_REMOVE: 1
         run: npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project "${{ inputs.project }}" --reporter=null
 
@@ -564,9 +579,9 @@ jobs:
         shell: bash
         env:
           POSITRON_PY_VER_SEL: 3.10.10
-          POSITRON_R_VER_SEL: 4.4.0
+          POSITRON_R_VER_SEL: ${{ steps.r-versions.outputs.r_version }}
           POSITRON_PY_ALT_VER_SEL: 3.13.0
-          POSITRON_R_ALT_VER_SEL: 4.4.2
+          POSITRON_R_ALT_VER_SEL: ${{ steps.r-versions.outputs.r_alt_version }}
           COMMIT_INFO_MESSAGE: ${{ github.event.head_commit.message }}
           PWTEST_BLOB_DO_NOT_REMOVE: 1
           CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}

--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -411,10 +411,8 @@ jobs:
           # RSQLite). A dated snapshot keeps metadata and binaries consistent.
           PPM_REPO: https://packagemanager.posit.co/cran/2026-06-30
         run: |
-          Rscript -e "options(repos = c(CRAN = Sys.getenv('PPM_REPO'))); install.packages('pak')"
-          # openssl 2.4.1 Windows binary was never published to the package manager; pin to 2.4.2
-          # so pak doesn't attempt to download the missing binary.
-          Rscript -e "options(repos = c(CRAN = Sys.getenv('PPM_REPO'))); pak::pak('openssl@2.4.2')"
+          # pak is provided by rig (rig installs it on `rig add`), so there's no
+          # need to install it explicitly -- the macOS lane relies on the same.
           Rscript -e "options(repos = c(CRAN = Sys.getenv('PPM_REPO'))); pak::local_install_dev_deps(ask = FALSE, upgrade = FALSE)"
 
       - name: Save R packages cache


### PR DESCRIPTION
### Summary

The Windows and macOS e2e workflows pinned the two R versions they install (default + alternate) to hardcoded numbers that had to be bumped by hand. This resolves them at runtime instead: a step queries the r-hub rversions API (the same service `r-lib/actions/setup-r` uses) for `r-release` (default) and `r-oldrel/2` (alternate), then feeds the resolved versions to `rig add`, the Windows R-packages cache key/path, and the `POSITRON_R_VER_SEL` / `POSITRON_R_ALT_VER_SEL` selectors. Today that resolves to R 4.6.1 (release) and 4.4.3 (oldrel-2), and it now tracks upstream automatically instead of drifting out of date.

`rig` continues to perform the installs. `r-lib/actions/setup-r` was considered (it is what the ark repo uses) but can only host a single R version per OS: on Windows it hardcodes `/DIR=C:\R` (a second install overwrites the first, and `C:\R` is not a Positron interpreter-discovery root), and on macOS the CRAN `.pkg` installer removes previously-installed framework versions. The e2e suite needs both the default and alternate R installed and discoverable at once (for example, the interpreter session-picker test starts the alternate R), so `rig` remains the right tool; only the version selection changed.

Changes are limited to two CI workflow files:
- `.github/workflows/test-e2e-windows-run.yml`
- `.github/workflows/test-e2e-macos-run.yml`

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:interpreter @:ark @:sessions @:win

This is a CI-configuration-only change (only the two workflow files above are modified; no application or test source), so there is no unit/e2e coverage to add -- the workflows are themselves the thing under test.

To validate end to end, the Full Suite was dispatched on this branch scoped to only the affected lanes (Windows + both macOS architectures):

https://github.com/posit-dev/positron/actions/runs/30119460909

That run exercises R installation, discovery, and package availability for both the default and alternate versions on `electron-win`, `macos-arm64`, and `macos-x64`. On the PR gate the R suites above run through the updated Windows R-install path (rig installs the r-hub-resolved release + oldrel-2, packages install into the release library, and Positron discovers both). The macOS lanes are not part of the PR gate, so the linked Full Suite run is the only place they are covered. Confirm R sessions start for both the default and alternate interpreters and that R-package-dependent tests pass.
