### PR TITLE
Scroll Quarto documents automatically to reveal inline output

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
@@ -38,6 +38,7 @@ import {
 	IQuartoExecutionManager,
 	DEFAULT_EXECUTION_CONFIG,
 	DATA_EXPLORER_MIME_TYPE,
+	WillExecuteEvent,
 } from '../common/quartoExecutionTypes.js';
 import { usingQuartoInlineOutputStatementSplitting } from '../common/positronQuartoConfig.js';
 import { RuntimeOnlineState, RuntimeCodeExecutionMode, RuntimeErrorBehavior, ILanguageRuntimeMessageWebOutput } from '../../../services/languageRuntime/common/languageRuntimeService.js';
@@ -199,6 +200,9 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 	private readonly _onDidExecuteCode = this._register(new Emitter<ILanguageRuntimeCodeExecutedEvent>());
 	readonly onDidExecuteCode: Event<ILanguageRuntimeCodeExecutedEvent> = this._onDidExecuteCode.event;
 
+	private readonly _onWillExecute = this._register(new Emitter<WillExecuteEvent>());
+	readonly onWillExecute: Event<WillExecuteEvent> = this._onWillExecute.event;
+
 	constructor(
 		@IQuartoKernelManager private readonly _kernelManager: IQuartoKernelManager,
 		@IQuartoDocumentModelService private readonly _documentModelService: IQuartoDocumentModelService,
@@ -285,6 +289,9 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 			this._logService.debug(`[QuartoExecutionManager] All cells filtered out by eval: false`);
 			return;
 		}
+
+		// Signal a fresh execution gesture so consumers (e.g. auto-scroll) re-arm.
+		this._onWillExecute.fire({ documentUri });
 
 		// Add filtered cells to queue with Queued state
 		for (const cell of filteredCells) {
@@ -525,6 +532,9 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 			this._logService.debug(`[QuartoExecutionManager] All cells filtered out by eval: false`);
 			return;
 		}
+
+		// Signal a fresh execution gesture so consumers (e.g. auto-scroll) re-arm.
+		this._onWillExecute.fire({ documentUri });
 
 		// Add all ranges to queued state with decorations.
 		// Use effectiveCodeRange (excluding option lines like #| label: ...) so

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
@@ -438,11 +438,17 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 		}));
 
 		// Arm auto-scroll on a fresh execution gesture (Run Cell, Run All, ...)
-		// so the editor follows the output it produces.
+		// so the editor follows the output it produces. The same Quarto document
+		// can be open in more than one editor at once (a split view); each has
+		// its own contribution and they all see this URI-keyed event. Only the
+		// editor the gesture came from -- the active one -- should follow it, so
+		// re-evaluate arming on every gesture: the active editor arms and any
+		// other pane showing the same document disarms. Without this a run in one
+		// pane would hijack the scroll position of the other.
 		this._outputHandlingDisposables.add(this._executionManager.onWillExecute(event => {
 			if (this._autoScrollEnabled && this._documentUri &&
 				event.documentUri.toString() === this._documentUri.toString()) {
-				this._autoScrollArmed = true;
+				this._autoScrollArmed = this._isActiveEditor();
 			}
 		}));
 
@@ -1171,6 +1177,17 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 			documentUri: this._documentUri!,
 			outputs: outputs,
 		});
+	}
+
+	/**
+	 * Whether this contribution's editor is the one the user is currently
+	 * working in. The same Quarto document can be open in several editors at
+	 * once (a split view), each with its own contribution; only the active
+	 * editor should arm auto-scroll so running a cell in one pane doesn't yank
+	 * the scroll position of another pane showing the same file.
+	 */
+	private _isActiveEditor(): boolean {
+		return this._editorService.activeTextEditorControl === this._editor;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
@@ -7,7 +7,7 @@ import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
-import { IEditorContribution } from '../../../../editor/common/editorCommon.js';
+import { IEditorContribution, ScrollType } from '../../../../editor/common/editorCommon.js';
 import { EditorOption } from '../../../../editor/common/config/editorOptions.js';
 import { Range } from '../../../../editor/common/core/range.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
@@ -25,7 +25,7 @@ import { IEditorService } from '../../../services/editor/common/editorService.js
 import { IPositronPreviewService } from '../../positronPreview/browser/positronPreviewSevice.js';
 import { IQuartoDocumentModelService } from './quartoDocumentModelService.js';
 import { IQuartoExecutionManager, ICellOutput, ICellOutputItem, CellExecutionState, IQuartoOutputCacheService, QuartoCellErrorContext } from '../common/quartoExecutionTypes.js';
-import { QUARTO_INLINE_OUTPUT_ENABLED, POSITRON_QUARTO_INLINE_OUTPUT_MAX_LINES_KEY, QUARTO_INLINE_OUTPUT_MAX_LINES_KEY, affectsQuartoConfig, getQuartoConfigValue, isQuartoDocument } from '../common/positronQuartoConfig.js';
+import { QUARTO_INLINE_OUTPUT_ENABLED, POSITRON_QUARTO_INLINE_OUTPUT_MAX_LINES_KEY, QUARTO_INLINE_OUTPUT_MAX_LINES_KEY, QUARTO_INLINE_OUTPUT_AUTO_SCROLL_KEY, affectsQuartoConfig, getQuartoConfigValue, isQuartoDocument, usingQuartoInlineOutputAutoScroll } from '../common/positronQuartoConfig.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IPositronNotebookOutputWebviewService } from '../../positronOutputWebview/browser/notebookOutputWebviewService.js';
 import { IQuartoKernelManager } from './quartoKernelManager.js';
@@ -151,6 +151,67 @@ export interface IQuartoOutputManager {
 }
 
 /**
+ * Vertical geometry needed to decide how far to scroll to reveal an output
+ * view zone. All values are in the editor's scroll-content coordinate space.
+ */
+export interface QuartoAutoScrollLayout {
+	/** Top of the output view zone (offset of its first pixel). */
+	readonly zoneTop: number;
+	/** Bottom of the output view zone (offset just past its last pixel). */
+	readonly zoneBottom: number;
+	/** The editor's current scrollTop. */
+	readonly scrollTop: number;
+	/** The height of the visible editor viewport. */
+	readonly viewportHeight: number;
+	/** The total scrollable height of the editor content. */
+	readonly scrollHeight: number;
+}
+
+/**
+ * Compute the scrollTop the editor should move to in order to reveal an output
+ * view zone, or `undefined` when no scroll is necessary.
+ *
+ * Output is emitted at the bottom of the zone, so we keep the bottom of the
+ * zone at the bottom of the viewport: freshly produced output stays in view
+ * even for a zone taller than the editor (which then tails, like a console).
+ * Scrolls the minimum amount needed -- while the bottom of the zone is already
+ * on screen the scroll position is left alone.
+ */
+export function computeAutoScrollTop(layout: QuartoAutoScrollLayout): number | undefined {
+	const { zoneTop, zoneBottom, scrollTop, viewportHeight, scrollHeight } = layout;
+
+	// Bail if the zone hasn't been laid out yet or there is no viewport.
+	if (zoneBottom <= zoneTop || viewportHeight <= 0) {
+		return undefined;
+	}
+
+	const scrollBottom = scrollTop + viewportHeight;
+
+	// Nothing to do while the bottom of the zone is already on screen -- the
+	// newest output is visible. This also covers a tall zone that is already
+	// tailing (bottom at the viewport bottom, top scrolled off above).
+	if (zoneBottom > scrollTop && zoneBottom <= scrollBottom) {
+		return undefined;
+	}
+
+	// Pin the bottom of the zone to the bottom of the viewport, whether it is
+	// currently below (grew past the bottom) or above (a cell that ran further
+	// up the document) the visible area.
+	let target = zoneBottom - viewportHeight;
+
+	// Clamp to the valid scroll range.
+	const maxScrollTop = Math.max(0, scrollHeight - viewportHeight);
+	target = Math.max(0, Math.min(target, maxScrollTop));
+
+	// Ignore sub-pixel adjustments (and no-ops after clamping).
+	if (Math.abs(target - scrollTop) < 1) {
+		return undefined;
+	}
+
+	return target;
+}
+
+/**
  * Editor contribution that manages output view zones for a single editor.
  * One instance per editor that displays a Quarto document.
  */
@@ -168,6 +229,17 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 	private _featureEnabled: boolean;
 	private _outputHandlingInitialized = false;
 	private _maxLines: number;
+
+	// Whether the editor should scroll to follow inline output (the setting).
+	private _autoScrollEnabled: boolean;
+	// Whether auto-scroll is currently active. Armed by a fresh execution
+	// gesture and disarmed when the user moves the viewport themselves.
+	private _autoScrollArmed = false;
+	// The cell whose output view zone we are currently following.
+	private _autoScrollTrackedCellId: string | undefined;
+	// True while applying a programmatic scroll, so its scroll event isn't
+	// mistaken for the user scrolling away.
+	private _autoScrollProgrammatic = false;
 
 	// Track subscriptions from _initializeOutputHandling() separately so they can be
 	// disposed when the model changes, preventing duplicate event handlers
@@ -246,6 +318,9 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 		// Get max lines configuration
 		this._maxLines = getQuartoConfigValue(this._configurationService, QUARTO_INLINE_OUTPUT_MAX_LINES_KEY, POSITRON_QUARTO_INLINE_OUTPUT_MAX_LINES_KEY, 40);
 
+		// Get auto-scroll configuration (defaults to on)
+		this._autoScrollEnabled = usingQuartoInlineOutputAutoScroll(this._configurationService);
+
 		// Check if feature is enabled (context key checks both setting and extension installation)
 		this._featureEnabled = this._contextKeyService.getContextKeyValue<boolean>(QUARTO_INLINE_OUTPUT_ENABLED.key) ?? false;
 
@@ -256,13 +331,19 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 			}
 		}));
 
-		// Listen for max lines configuration changes
+		// Listen for max lines and auto-scroll configuration changes
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
 			if (affectsQuartoConfig(e, QUARTO_INLINE_OUTPUT_MAX_LINES_KEY, POSITRON_QUARTO_INLINE_OUTPUT_MAX_LINES_KEY)) {
 				this._maxLines = getQuartoConfigValue(this._configurationService, QUARTO_INLINE_OUTPUT_MAX_LINES_KEY, POSITRON_QUARTO_INLINE_OUTPUT_MAX_LINES_KEY, 40);
 				// Update all existing view zones
 				for (const viewZone of this._viewZones.values()) {
 					viewZone.maxLines = this._maxLines;
+				}
+			}
+			if (e.affectsConfiguration(QUARTO_INLINE_OUTPUT_AUTO_SCROLL_KEY)) {
+				this._autoScrollEnabled = usingQuartoInlineOutputAutoScroll(this._configurationService);
+				if (!this._autoScrollEnabled) {
+					this._autoScrollArmed = false;
 				}
 			}
 		}));
@@ -356,6 +437,29 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 			}
 		}));
 
+		// Arm auto-scroll on a fresh execution gesture (Run Cell, Run All, ...)
+		// so the editor follows the output it produces.
+		this._outputHandlingDisposables.add(this._executionManager.onWillExecute(event => {
+			if (this._autoScrollEnabled && this._documentUri &&
+				event.documentUri.toString() === this._documentUri.toString()) {
+				this._autoScrollArmed = true;
+			}
+		}));
+
+		// Disarm auto-scroll once the user moves the viewport themselves. Only a
+		// vertical scroll we didn't initiate counts; a view zone growing changes
+		// the scroll height but not scrollTop, so it won't disarm.
+		this._outputHandlingDisposables.add(this._editor.onDidScrollChange(e => {
+			if (!e.scrollTopChanged) {
+				return;
+			}
+			if (this._autoScrollProgrammatic) {
+				this._autoScrollProgrammatic = false;
+				return;
+			}
+			this._autoScrollArmed = false;
+		}));
+
 		// Listen for execution state changes to manage recomputing state and update view zone button
 		this._outputHandlingDisposables.add(this._executionManager.onDidChangeExecutionState(event => {
 			if (this._featureEnabled &&
@@ -385,6 +489,14 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 						event.execution.startTime,
 						event.execution.endTime,
 					);
+				}
+
+				// Follow this cell while it runs so its status/output stays in
+				// view (no-op unless auto-scroll is armed). Tracking the running
+				// cell is what makes Run All scroll through the document.
+				if (isRunning) {
+					this._autoScrollTrackedCellId = cellId;
+					this._revealTrackedCell();
 				}
 
 				// Track execution info so it survives tab switches
@@ -1020,6 +1132,10 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 		// Add output to view zone
 		viewZone.addOutput(output);
 
+		// Follow the output as it appears (no-op unless auto-scroll is armed).
+		this._autoScrollTrackedCellId = cellId;
+		this._revealTrackedCell();
+
 		// Save to cache and track content hash
 		if (this._documentUri) {
 			const model = this._editor.getModel();
@@ -1055,6 +1171,58 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 			documentUri: this._documentUri!,
 			outputs: outputs,
 		});
+	}
+
+	/**
+	 * Scroll the editor to reveal the currently tracked cell's output view zone,
+	 * but only when auto-scroll is armed. A no-op when the feature is disabled,
+	 * the user has scrolled away, the zone isn't visible, or the bottom of the
+	 * zone (where new output appears) is already on screen. Keeps the bottom of
+	 * the zone at the bottom of the viewport (see {@link computeAutoScrollTop}).
+	 */
+	private _revealTrackedCell(): void {
+		if (!this._autoScrollEnabled || !this._autoScrollArmed || !this._autoScrollTrackedCellId) {
+			return;
+		}
+
+		const viewZone = this._viewZones.get(this._autoScrollTrackedCellId);
+		if (!viewZone || !viewZone.isVisible()) {
+			return;
+		}
+
+		const model = this._editor.getModel();
+		if (!model) {
+			return;
+		}
+
+		// The view zone sits after this (model) line; guard against a stale
+		// anchor after edits.
+		const afterLine = viewZone.afterLineNumber;
+		if (afterLine < 1 || afterLine > model.getLineCount()) {
+			return;
+		}
+
+		// Top of the zone is the offset just after its anchor line (Monaco's
+		// getBottomForLineNumber excludes view-zone whitespace); the zone's own
+		// reserved height gives the bottom. Using heightInPx avoids depending on
+		// the include-view-zones offset overload and handles a last-line anchor.
+		const zoneTop = this._editor.getBottomForLineNumber(afterLine);
+		const layoutInfo = this._editor.getLayoutInfo();
+		const target = computeAutoScrollTop({
+			zoneTop,
+			zoneBottom: zoneTop + viewZone.heightInPx,
+			scrollTop: this._editor.getScrollTop(),
+			viewportHeight: layoutInfo.height,
+			scrollHeight: this._editor.getScrollHeight(),
+		});
+
+		if (target === undefined) {
+			return;
+		}
+
+		// Mark the scroll as programmatic so its scroll event doesn't disarm us.
+		this._autoScrollProgrammatic = true;
+		this._editor.setScrollTop(target, ScrollType.Immediate);
 	}
 
 	private _createViewZone(cellId: string): QuartoOutputViewZone | undefined {
@@ -1123,6 +1291,14 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 		// Set up popout handler
 		this._outputHandlingDisposables.add(viewZone.onPopoutRequested(request => {
 			this._handlePopoutRequest(request);
+		}));
+
+		// Keep this cell in view as its output grows (e.g. streaming text or an
+		// image finishing loading) while we're following it.
+		this._outputHandlingDisposables.add(viewZone.onDidChangeHeight(() => {
+			if (this._autoScrollTrackedCellId === cellId) {
+				this._revealTrackedCell();
+			}
 		}));
 
 		// Set initial execution state

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
@@ -354,6 +354,12 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 	private readonly _onDidChangeCollapsed = this._register(new Emitter<boolean>());
 	readonly onDidChangeCollapsed: VSEvent<boolean> = this._onDidChangeCollapsed.event;
 
+	// Fires whenever the view zone's laid-out height changes (output added,
+	// truncated, or an async output such as an image finishing loading). Used by
+	// the output manager to keep growing output in view while auto-scrolling.
+	private readonly _onDidChangeHeight = this._register(new Emitter<void>());
+	readonly onDidChangeHeight: VSEvent<void> = this._onDidChangeHeight.event;
+
 	// Quick-fix support for error outputs (suppressed by default; the live
 	// execution path calls enableQuickFix() to opt in).
 	private _quickFixEnabled = false;
@@ -3005,6 +3011,9 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 			this._editor.changeViewZones(accessor => {
 				accessor.layoutZone(this._zoneId!);
 			});
+
+			// Notify listeners so a growing output can be kept in view.
+			this._onDidChangeHeight.fire();
 		} else if (!this._zoneId) {
 			this.heightInPx = newHeight;
 		}

--- a/src/vs/workbench/contrib/positronQuarto/common/positronQuartoConfig.ts
+++ b/src/vs/workbench/contrib/positronQuarto/common/positronQuartoConfig.ts
@@ -51,6 +51,12 @@ export const QUARTO_INLINE_OUTPUT_SHOW_CELL_TOOLBAR_KEY = 'quarto.inlineOutput.s
 export const QUARTO_INLINE_OUTPUT_SPLIT_STATEMENTS_KEY = 'quarto.inlineOutput.splitStatements';
 
 /**
+ * Configuration key for automatically scrolling the editor to reveal inline
+ * output as it is produced.
+ */
+export const QUARTO_INLINE_OUTPUT_AUTO_SCROLL_KEY = 'quarto.inlineOutput.autoScroll';
+
+/**
  * @deprecated Use {@link QUARTO_INLINE_OUTPUT_ENABLED_KEY}. Kept as a working alias.
  */
 export const POSITRON_QUARTO_INLINE_OUTPUT_KEY = 'positron.quarto.inlineOutput.enabled';
@@ -167,6 +173,15 @@ configurationRegistry.registerConfiguration({
 			markdownDescription: localize(
 				'positron.quarto.inlineOutput.splitStatements',
 				'Execute Quarto inline code statement by statement when the language provides input boundaries, so each statement can produce inline output.'
+			),
+			scope: ConfigurationScope.WINDOW,
+		},
+		[QUARTO_INLINE_OUTPUT_AUTO_SCROLL_KEY]: {
+			type: 'boolean',
+			default: true,
+			markdownDescription: localize(
+				'positron.quarto.inlineOutput.autoScroll',
+				'Automatically scroll the editor to reveal inline output as cells run, so newly produced output stays in view.'
 			),
 			scope: ConfigurationScope.WINDOW,
 		},
@@ -313,6 +328,16 @@ export function usingQuartoCellToolbar(configurationService: IConfigurationServi
  */
 export function usingQuartoInlineOutputStatementSplitting(configurationService: IConfigurationService): boolean {
 	return getQuartoConfigValue(configurationService, QUARTO_INLINE_OUTPUT_SPLIT_STATEMENTS_KEY, POSITRON_QUARTO_INLINE_OUTPUT_SPLIT_STATEMENTS_KEY, true);
+}
+
+/**
+ * Helper function to check if the editor should auto-scroll to reveal inline
+ * output as it is produced. Defaults to true when the setting is unset.
+ * @param configurationService The configuration service instance
+ * @returns true if auto-scrolling to inline output is enabled
+ */
+export function usingQuartoInlineOutputAutoScroll(configurationService: IConfigurationService): boolean {
+	return configurationService.getValue<boolean>(QUARTO_INLINE_OUTPUT_AUTO_SCROLL_KEY) !== false;
 }
 
 /**

--- a/src/vs/workbench/contrib/positronQuarto/common/quartoExecutionTypes.ts
+++ b/src/vs/workbench/contrib/positronQuarto/common/quartoExecutionTypes.ts
@@ -163,6 +163,16 @@ export interface FragmentProgressChangeEvent {
 }
 
 /**
+ * Event emitted at the start of an execution gesture (Run Cell, Run All, etc.),
+ * before any cells begin running. Consumers use this to re-arm behaviors that a
+ * fresh gesture should reset, such as auto-scrolling to reveal inline output.
+ */
+export interface WillExecuteEvent {
+	/** Document URI whose cells are about to execute */
+	readonly documentUri: URI;
+}
+
+/**
  * Configuration for execution behavior.
  */
 export interface IQuartoExecutionConfig {
@@ -204,6 +214,12 @@ export interface IQuartoExecutionManager {
 	 * Used to update the gutter as individual statements execute within a cell.
 	 */
 	readonly onDidChangeFragmentProgress: Event<FragmentProgressChangeEvent>;
+
+	/**
+	 * Event fired at the start of an execution gesture (Run Cell, Run All,
+	 * etc.), before any cells begin running.
+	 */
+	readonly onWillExecute: Event<WillExecuteEvent>;
 
 	/**
 	 * Execute a single cell.

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoAutoScroll.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoAutoScroll.vitest.ts
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { computeAutoScrollTop, QuartoAutoScrollLayout } from '../../browser/quartoOutputManager.js';
+
+// computeAutoScrollTop decides how far the editor must scroll to reveal an
+// output view zone. Output appears at the bottom of the zone, so it keeps the
+// bottom of the zone at the bottom of the viewport (tailing a zone taller than
+// the editor), and scrolls the minimum necessary: a zone whose bottom is
+// already visible is left alone. All offsets are in the editor's scroll-content
+// coordinate space (0 = top of content).
+describe('computeAutoScrollTop', () => {
+	// A viewport 100px tall over 1000px of content, scrolled to the top.
+	function layout(overrides: Partial<QuartoAutoScrollLayout>): QuartoAutoScrollLayout {
+		return {
+			zoneTop: 0,
+			zoneBottom: 0,
+			scrollTop: 0,
+			viewportHeight: 100,
+			scrollHeight: 1000,
+			...overrides,
+		};
+	}
+
+	it('does not scroll when the zone bottom is already visible', () => {
+		// Zone occupies 40-80 within the visible 0-100 window.
+		expect(computeAutoScrollTop(layout({ zoneTop: 40, zoneBottom: 80 }))).toBeUndefined();
+	});
+
+	it('does not scroll while a tall zone is already tailing', () => {
+		// Zone 200-500 with its bottom (500) pinned at the viewport bottom.
+		expect(computeAutoScrollTop(layout({ zoneTop: 200, zoneBottom: 500, scrollTop: 400 })))
+			.toBeUndefined();
+	});
+
+	it('scrolls down to pin the zone bottom to the viewport bottom', () => {
+		// Zone 200-260 (fits) sits below the visible 0-100 window.
+		expect(computeAutoScrollTop(layout({ zoneTop: 200, zoneBottom: 260 })))
+			.toBe(160); // zoneBottom - viewportHeight
+	});
+
+	it('scrolls up to bring the bottom of a zone above the viewport into view', () => {
+		// Zone 250-290 sits entirely above the visible 500-600 window.
+		expect(computeAutoScrollTop(layout({ zoneTop: 250, zoneBottom: 290, scrollTop: 500 })))
+			.toBe(190); // zoneBottom - viewportHeight
+	});
+
+	it('tails a zone taller than the viewport, showing its most recent output', () => {
+		// Zone 200-500 (300px) is taller than the 100px viewport: keep the
+		// bottom (newest output) in view rather than its start.
+		expect(computeAutoScrollTop(layout({ zoneTop: 200, zoneBottom: 500 })))
+			.toBe(400); // zoneBottom - viewportHeight
+	});
+
+	it('clamps the target to the maximum scroll position', () => {
+		// Revealing the zone bottom would require scrollTop 950, but content is
+		// only 1000px over a 100px viewport, so the max scrollTop is 900.
+		expect(computeAutoScrollTop(layout({ zoneTop: 980, zoneBottom: 1050, scrollHeight: 1000 })))
+			.toBe(900);
+	});
+
+	it('returns undefined when the zone has no laid-out height', () => {
+		expect(computeAutoScrollTop(layout({ zoneTop: 200, zoneBottom: 200 }))).toBeUndefined();
+	});
+
+	it('returns undefined when there is no viewport height', () => {
+		expect(computeAutoScrollTop(layout({ zoneTop: 200, zoneBottom: 260, viewportHeight: 0 }))).toBeUndefined();
+	});
+
+	it('ignores sub-pixel adjustments', () => {
+		// The zone bottom is 0.5px below the viewport bottom: not worth a scroll.
+		expect(computeAutoScrollTop(layout({ zoneTop: 60, zoneBottom: 100.5 }))).toBeUndefined();
+	});
+});

--- a/src/vs/workbench/contrib/positronQuarto/test/common/quartoConfig.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/common/quartoConfig.vitest.ts
@@ -8,8 +8,10 @@
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import {
 	POSITRON_QUARTO_INLINE_OUTPUT_KEY,
+	QUARTO_INLINE_OUTPUT_AUTO_SCROLL_KEY,
 	QUARTO_INLINE_OUTPUT_ENABLED_KEY,
 	getQuartoConfigValue,
+	usingQuartoInlineOutputAutoScroll,
 } from '../../common/positronQuartoConfig.js';
 
 describe('getQuartoConfigValue', () => {
@@ -40,6 +42,28 @@ describe('getQuartoConfigValue', () => {
 			oldOnly: true,
 			newOnly: true,
 			both: false,
+		});
+	});
+});
+
+describe('usingQuartoInlineOutputAutoScroll', () => {
+	it('defaults on and is only off when explicitly set to false', async () => {
+		const unset = new TestConfigurationService();
+
+		const off = new TestConfigurationService();
+		await off.setUserConfiguration(QUARTO_INLINE_OUTPUT_AUTO_SCROLL_KEY, false);
+
+		const on = new TestConfigurationService();
+		await on.setUserConfiguration(QUARTO_INLINE_OUTPUT_AUTO_SCROLL_KEY, true);
+
+		expect({
+			unset: usingQuartoInlineOutputAutoScroll(unset),
+			off: usingQuartoInlineOutputAutoScroll(off),
+			on: usingQuartoInlineOutputAutoScroll(on),
+		}).toEqual({
+			unset: true,
+			off: false,
+			on: true,
 		});
 	});
 });

--- a/test/e2e/pages/inlineQuarto.ts
+++ b/test/e2e/pages/inlineQuarto.ts
@@ -209,8 +209,19 @@ export class InlineQuarto {
 	 */
 	async runCellAndExpectOutputInViewport({ cellLine, timeout = 120000 }: { cellLine: number; timeout?: number }): Promise<void> {
 		await test.step(`Run cell at line ${cellLine} and expect its output scrolled into view`, async () => {
-			await this._runCellUntilStarted(cellLine, () => this.runCurrentCell());
-			await expect(this.outputContent.first()).toBeInViewport({ timeout });
+			// Don't gate on the executing toolbar button (as `_runCellUntilStarted`
+			// does): auto-scroll reveals the output by scrolling the cell's top --
+			// and its floating toolbar, which hides itself once off-screen -- out of
+			// view the instant the cell starts running, so the button can vanish
+			// before Playwright observes it (a race that only loses under CI load).
+			// Re-fire the run instead (re-homing the cursor each attempt, to survive
+			// a swallowed run hotkey) until the output itself is scrolled into view,
+			// which is the behavior under test.
+			await expect(async () => {
+				await this.gotoLine(cellLine);
+				await this.runCurrentCell();
+				await expect(this.outputContent.first()).toBeInViewport({ timeout: 20000 });
+			}).toPass({ timeout, intervals: [2000] });
 		});
 	}
 

--- a/test/e2e/pages/inlineQuarto.ts
+++ b/test/e2e/pages/inlineQuarto.ts
@@ -118,6 +118,16 @@ export class InlineQuarto {
 		return this.inlineOutput.nth(index).locator(OUTPUT_CONTENT);
 	}
 
+	/**
+	 * Inline output content scoped to a single editor group. The same Quarto
+	 * document can be open in more than one editor at once (a split view); each
+	 * group renders its own copy of the view zones, so scope by group to tell
+	 * the panes apart.
+	 */
+	getOutputContentInGroup(group: Locator): Locator {
+		return group.locator(`${INLINE_OUTPUT} ${OUTPUT_CONTENT}`);
+	}
+
 	getOutputItemAt(index: number): Locator {
 		return this.inlineOutput.nth(index).locator(OUTPUT_ITEM).first();
 	}

--- a/test/e2e/pages/inlineQuarto.ts
+++ b/test/e2e/pages/inlineQuarto.ts
@@ -200,6 +200,34 @@ export class InlineQuarto {
 		});
 	}
 
+	/**
+	 * Run the cell at `cellLine` and wait for auto-scroll to bring its inline
+	 * output into the viewport. Deliberately does NOT navigate to the output
+	 * (which would scroll on its own and mask the behavior under test), so the
+	 * cell should be taller than the viewport for its output to start below the
+	 * fold.
+	 */
+	async runCellAndExpectOutputInViewport({ cellLine, timeout = 120000 }: { cellLine: number; timeout?: number }): Promise<void> {
+		await test.step(`Run cell at line ${cellLine} and expect its output scrolled into view`, async () => {
+			await this._runCellUntilStarted(cellLine, () => this.runCurrentCell());
+			await expect(this.outputContent.first()).toBeInViewport({ timeout });
+		});
+	}
+
+	/**
+	 * Run the cell at `cellLine` and confirm its inline output is NOT scrolled
+	 * into the viewport (used to verify auto-scroll stays off). Waits for the
+	 * kernel to go idle first so the output has actually been produced and just
+	 * remains below the fold.
+	 */
+	async runCellAndExpectOutputNotInViewport({ cellLine }: { cellLine: number }): Promise<void> {
+		await test.step(`Run cell at line ${cellLine} and expect its output to stay below the fold`, async () => {
+			await this._runCellUntilStarted(cellLine, () => this.runCurrentCell());
+			await this.expectKernelIdle();
+			await expect(this.outputContent.first()).not.toBeInViewport();
+		});
+	}
+
 	async clickToolbarRunButton(index = 0): Promise<void> {
 		await test.step(`Click run button on cell toolbar ${index}`, async () => {
 			const runButton = this.cellToolbar.nth(index).locator(TOOLBAR_RUN);

--- a/test/e2e/test-files/workspaces/quarto_inline_output/autoscroll.qmd
+++ b/test/e2e/test-files/workspaces/quarto_inline_output/autoscroll.qmd
@@ -1,0 +1,84 @@
+---
+title: "Auto Scroll"
+jupyter: python3
+---
+
+## Auto scroll
+
+This cell is intentionally taller than the editor viewport so that its inline
+output is rendered below the fold when the cursor sits at the top of the cell.
+
+```{python}
+#| label: autoscroll
+# padding line 01
+# padding line 02
+# padding line 03
+# padding line 04
+# padding line 05
+# padding line 06
+# padding line 07
+# padding line 08
+# padding line 09
+# padding line 10
+# padding line 11
+# padding line 12
+# padding line 13
+# padding line 14
+# padding line 15
+# padding line 16
+# padding line 17
+# padding line 18
+# padding line 19
+# padding line 20
+# padding line 21
+# padding line 22
+# padding line 23
+# padding line 24
+# padding line 25
+# padding line 26
+# padding line 27
+# padding line 28
+# padding line 29
+# padding line 30
+# padding line 31
+# padding line 32
+# padding line 33
+# padding line 34
+# padding line 35
+# padding line 36
+# padding line 37
+# padding line 38
+# padding line 39
+# padding line 40
+# padding line 41
+# padding line 42
+# padding line 43
+# padding line 44
+# padding line 45
+# padding line 46
+# padding line 47
+# padding line 48
+# padding line 49
+# padding line 50
+# padding line 51
+# padding line 52
+# padding line 53
+# padding line 54
+# padding line 55
+# padding line 56
+# padding line 57
+# padding line 58
+# padding line 59
+# padding line 60
+# padding line 61
+# padding line 62
+# padding line 63
+# padding line 64
+# padding line 65
+# padding line 66
+# padding line 67
+# padding line 68
+# padding line 69
+# padding line 70
+print("AUTOSCROLL_MARKER")
+```

--- a/test/e2e/tests/quarto/quarto-inline-output-autoscroll.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-autoscroll.test.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { expect } from '@playwright/test';
 import { join } from 'path';
 import { test, tags } from './_test.setup';
 
@@ -54,5 +55,38 @@ test.describe('Quarto - Inline Output: Auto Scroll', {
 		await inlineQuarto.runCellAndExpectOutputNotInViewport({ cellLine: CELL_LINE });
 
 		await settings.set({ 'quarto.inlineOutput.autoScroll': true }, { reload: 'web' });
+	});
+
+	test('Python - running a cell in one split pane does not scroll the other pane', async function ({ python, app, openFile, runCommand }) {
+		const { editors, inlineQuarto } = app.workbench;
+
+		await openFile(join('workspaces', 'quarto_inline_output', 'autoscroll.qmd'));
+		await editors.waitForActiveTab('autoscroll.qmd');
+		await inlineQuarto.expectKernelStatusVisible();
+
+		// Open the same document in a second, side-by-side editor. The split
+		// leaves the new (right) group active and both panes scrolled to the top,
+		// so the cell's output starts below the fold in each.
+		await runCommand('workbench.action.splitEditorRight');
+		await editors.expectEditorGroupCount(2);
+		await editors.expectEditorGroupActive(1);
+
+		const leftOutput = inlineQuarto.getOutputContentInGroup(editors.editorGroup(0));
+		const rightOutput = inlineQuarto.getOutputContentInGroup(editors.editorGroup(1));
+
+		// Run the cell in the active (right) pane. Auto-scroll should reveal its
+		// output there. (Re-fire the run until the output scrolls into view, as
+		// the single-pane test does, to survive a swallowed run hotkey.)
+		await expect(async () => {
+			await inlineQuarto.gotoLine(CELL_LINE);
+			await inlineQuarto.runCurrentCell();
+			await expect(rightOutput.first()).toBeInViewport({ timeout: 20000 });
+		}).toPass({ timeout: 120000, intervals: [2000] });
+
+		// The run must not hijack the left pane: it never armed auto-scroll, so
+		// its viewport stays put and the same output remains below the fold.
+		// (Before the fix both panes armed off the URI-keyed execution event and
+		// the left pane scrolled in lockstep with the right.)
+		await expect(leftOutput.first()).not.toBeInViewport();
 	});
 });

--- a/test/e2e/tests/quarto/quarto-inline-output-autoscroll.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-autoscroll.test.ts
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { join } from 'path';
+import { test, tags } from './_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+// The fixture's single code cell is taller than the editor viewport, so when
+// the cursor sits at the top of the cell its inline output is rendered below
+// the fold. This lets us verify that auto-scroll reveals output the user would
+// otherwise not see (posit-dev/positron#14659) without navigating to the output
+// ourselves (which would scroll on its own and mask the behavior).
+const CELL_LINE = 15;
+
+test.describe('Quarto - Inline Output: Auto Scroll', {
+	tag: [tags.WEB, tags.WIN, tags.QUARTO]
+}, () => {
+
+	test.afterEach(async function ({ hotKeys }) {
+		await hotKeys.closeAllEditors();
+	});
+
+	test('Python - scrolls to reveal inline output produced below the viewport', async function ({ python, app, openFile }) {
+		const { editors, inlineQuarto } = app.workbench;
+
+		await openFile(join('workspaces', 'quarto_inline_output', 'autoscroll.qmd'));
+		await editors.waitForActiveTab('autoscroll.qmd');
+		await inlineQuarto.expectKernelStatusVisible();
+		await editors.clickTab('autoscroll.qmd');
+
+		// Auto-scroll is on by default: running the cell should bring its output
+		// into view even though it starts below the fold.
+		await inlineQuarto.runCellAndExpectOutputInViewport({ cellLine: CELL_LINE });
+		await inlineQuarto.expectStdoutContains('AUTOSCROLL_MARKER');
+	});
+
+	test('Python - leaves the viewport alone when auto-scroll is disabled', async function ({ python, app, openFile, settings }) {
+		const { editors, inlineQuarto } = app.workbench;
+
+		await settings.set({ 'quarto.inlineOutput.autoScroll': false }, { reload: 'web' });
+
+		await openFile(join('workspaces', 'quarto_inline_output', 'autoscroll.qmd'));
+		await editors.waitForActiveTab('autoscroll.qmd');
+		await inlineQuarto.expectKernelStatusVisible();
+		await editors.clickTab('autoscroll.qmd');
+
+		// With the setting off, the output is still produced but stays below the
+		// fold -- the editor must not scroll on its own.
+		await inlineQuarto.runCellAndExpectOutputNotInViewport({ cellLine: CELL_LINE });
+
+		await settings.set({ 'quarto.inlineOutput.autoScroll': true }, { reload: 'web' });
+	});
+});


### PR DESCRIPTION
Fixes #14659

### Summary

When a Quarto or R Markdown code cell produces inline output, the editor now scrolls to keep that output in view, so running a cell whose output lands below the viewport no longer looks like it did nothing. Running all cells tracks execution as it moves down through the document.

Auto-scroll keeps the bottom of the output view zone pinned to the bottom of the editor, so freshly emitted output stays visible even when it is taller than the editor (it tails, like a console). It scrolls only when necessary -- output that is already fully visible is left alone -- and follows a console-like heuristic: it arms on each run gesture (Run Cell, Run All, etc.) and stops if you move the editor yourself, then re-arms the next time you run cells.

A new setting, `quarto.inlineOutput.autoScroll` (default on, grouped with the other inline-output settings), turns the behavior off.

Implementation: a new `onWillExecute` event on the Quarto execution manager arms auto-scroll per gesture; a new height-change event on the output view zone lets streaming/async output stay followed; and `QuartoOutputContribution` arms/disarms and reveals the tracked cell's view zone via an extracted pure `computeAutoScrollTop` helper.

### Release Notes

#### New Features

- Quarto and R Markdown: the editor scrolls to reveal inline cell output as it is produced, controllable via the new `quarto.inlineOutput.autoScroll` setting (#14659)

#### Bug Fixes

- N/A

### Validation Steps

Enable the feature first (`quarto.inlineOutput.enabled: true`).

@:quarto

1. Create a `.qmd` with several screens of prose and cells. Scroll so the bottom of a code cell (and the space below it) is off-screen, then run that cell -- the editor should scroll so the output is visible.
2. Run a cell that emits a lot of output (taller than the editor) -- the newest output should stay pinned at the bottom of the viewport as it streams.
3. Run All from the top of a long document -- the editor should follow execution down the document.
4. While output is being produced, scroll away manually -- auto-scrolling should stop for the rest of that run, then resume the next time you run cells.
5. Set `quarto.inlineOutput.autoScroll: false` and repeat step 1 -- the editor should not scroll on its own.

Automated coverage: `quartoAutoScroll.vitest.ts` (reveal decision), `quartoConfig.vitest.ts` (setting default), and `test/e2e/tests/quarto/quarto-inline-output-autoscroll.test.ts` (reveals off-screen output; stays put when disabled).
