### PR TITLE
Make Positron layout commands agent-invocable

### DIFF
--- a/src/vs/workbench/services/positronLayout/browser/layouts/layoutAction.ts
+++ b/src/vs/workbench/services/positronLayout/browser/layouts/layoutAction.ts
@@ -7,6 +7,7 @@ import { ILocalizedString } from '../../../../../nls.js';
 import { Categories } from '../../../../../platform/action/common/actionCommonCategories.js';
 import { Action2 } from '../../../../../platform/actions/common/actions.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
+import { ICommandMetadata } from '../../../../../platform/commands/common/commands.js';
 import { ContextKeyExpression } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IPositronLayoutService } from '../interfaces/positronLayoutService.js';
 import { CustomPositronLayoutDescription } from '../../common/positronCustomViews.js';
@@ -27,6 +28,10 @@ export type PositronLayoutInfo = {
 	 * it in grey or for a command, do not allow to invoke it)
 	 */
 	precondition: ContextKeyExpression;
+	/**
+	 * Command metadata, e.g. to expose the layout command to AI agents.
+	 */
+	metadata?: ICommandMetadata;
 };
 
 export abstract class PositronLayoutAction extends Action2 {
@@ -40,7 +45,8 @@ export abstract class PositronLayoutAction extends Action2 {
 			title: layoutInfo.label,
 			category: Categories.View,
 			f1: showInPalette,
-			precondition: layoutInfo.precondition
+			precondition: layoutInfo.precondition,
+			metadata: layoutInfo.metadata
 		});
 
 		this._layout = layoutInfo.layoutDescriptor;

--- a/src/vs/workbench/services/positronLayout/browser/layouts/positronFourPaneDsLayout.ts
+++ b/src/vs/workbench/services/positronLayout/browser/layouts/positronFourPaneDsLayout.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize2 } from '../../../../../nls.js';
+import { localize, localize2 } from '../../../../../nls.js';
 import { registerAction2 } from '../../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { Parts } from '../../../layout/browser/layoutService.js';
@@ -15,6 +15,10 @@ export const positronFourPaneDsLayout: PositronLayoutInfo = {
 	codicon: 'positron-four-pane-ds-layout',
 	label: localize2('choseLayout.stacked', 'Stacked Layout'),
 	precondition: ContextKeyExpr.true(),
+	metadata: {
+		description: localize('positron.choseLayout.stacked.description', "Switch to the stacked data science layout: editor with the explorer sidebar, a bottom panel with console and terminal, and a secondary sidebar with variables and plots."),
+		agentCompatible: true,
+	},
 	layoutDescriptor: {
 		[Parts.SIDEBAR_PART]: {
 			size: '15%',

--- a/src/vs/workbench/services/positronLayout/browser/layouts/positronNotebookLayout.ts
+++ b/src/vs/workbench/services/positronLayout/browser/layouts/positronNotebookLayout.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize2 } from '../../../../../nls.js';
+import { localize, localize2 } from '../../../../../nls.js';
 import { Action2, registerAction2 } from '../../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
@@ -17,6 +17,10 @@ export const positronNotebookLayout: PositronLayoutInfo = {
 	codicon: 'positron-notebook-layout',
 	label: localize2('chooseLayout.notebookLayout', 'Notebook Layout'),
 	precondition: ContextKeyExpr.true(),
+	metadata: {
+		description: localize('positron.chooseLayout.notebookLayout.description', "Switch to the notebook layout, optimized for notebook workflows: editor with the primary sidebar visible, the bottom panel hidden, and a secondary sidebar with variables."),
+		agentCompatible: true,
+	},
 	layoutDescriptor: {
 		[Parts.PANEL_PART]: {
 			size: '40%',

--- a/src/vs/workbench/services/positronLayout/browser/layouts/positronTwoPaneLayout.ts
+++ b/src/vs/workbench/services/positronLayout/browser/layouts/positronTwoPaneLayout.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize2 } from '../../../../../nls.js';
+import { localize, localize2 } from '../../../../../nls.js';
 import { registerAction2 } from '../../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { Parts } from '../../../layout/browser/layoutService.js';
@@ -15,6 +15,10 @@ export const positronTwoPaneLayout: PositronLayoutInfo = {
 	codicon: 'positron-two-pane-ds-layout',
 	label: localize2('choseLayout.sideBySide', 'Side-By-Side Layout'),
 	precondition: ContextKeyExpr.true(),
+	metadata: {
+		description: localize('positron.choseLayout.sideBySide.description', "Switch to the side-by-side data science layout: editor next to a secondary sidebar with console, variables, and plots, with the primary sidebar and bottom panel hidden."),
+		agentCompatible: true,
+	},
 	layoutDescriptor: {
 		[Parts.PANEL_PART]: {
 			hidden: true,


### PR DESCRIPTION
Addresses part of #15063.

### Summary

Makes the three Positron layout commands invocable by Posit Assistant:

- `workbench.action.positronFourPaneDataScienceLayout`
- `workbench.action.positronTwoPaneDataScienceLayout`
- `workbench.action.positronNotebookLayout`

Each command's registration gains `agentCompatible: true` and a model-facing `description` derived from its actual layout descriptor, so the assistant can pick the right layout by name. The metadata is threaded through the shared `PositronLayoutInfo` plumbing in `layoutAction.ts` (new optional `metadata` field); other layouts using the base class are unaffected. Metadata-only change -- no `run()` behavior changes.

### Screenshots

(to be added: assistant switching layouts via positronCommand)

### Release Notes

#### New Features

- Posit Assistant can switch between the data science, side-by-side, and notebook layouts (#15063)

#### Bug Fixes

- N/A

### Validation Steps

@:layouts

1. **Verify the agent contract**: open the Command Palette and run "Developer: Show All Agent-Compatible Commands". Expected: the JSON list includes all three layout command ids above, each with a description and `agentCompatible: true`.
2. **Verify user behavior is unchanged**: run each of the three layout commands from the palette (search "layout"). Expected: the layout switches exactly as before.
3. **Verify assistant invocation**: with Posit Assistant connected, ask "switch to the notebook layout". Expected: the assistant runs the command and the layout changes without any picker.
