### PR TITLE
Make discoverAllRuntimes agent-invocable

### DIFF
--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -1325,7 +1325,11 @@ export function registerLanguageRuntimeActions() {
 				id: LANGUAGE_RUNTIME_DISCOVER_RUNTIMES_ID,
 				title: localize2('workbench.action.language.runtime.discoverAllRuntimes', "Discover All Interpreters"),
 				f1: true,
-				category
+				category,
+				metadata: {
+					description: localize('positron.languageRuntime.discoverAllRuntimes.description', "Re-scan the machine for available interpreters and update the list of registered interpreter runtimes. Use this when an interpreter was installed or removed after startup and does not appear in the interpreter list."),
+					agentCompatible: true,
+				}
 			});
 		}
 


### PR DESCRIPTION
Addresses part of #15063.

### Summary

Makes `workbench.action.language.runtime.discoverAllRuntimes` invocable by Posit Assistant. The registration gains `agentCompatible: true` and a model-facing `description` explaining that it re-scans the machine for interpreters and refreshes the registered runtime list. Metadata-only change -- the command takes no arguments and its `run()` is untouched.

### Release Notes

#### New Features

- Posit Assistant can trigger interpreter rediscovery (#15063)

#### Bug Fixes

- N/A

### Validation Steps

@:interpreter

1. **Verify the agent contract**: open the Command Palette and run "Developer: Show All Agent-Compatible Commands". Expected: the list includes `workbench.action.language.runtime.discoverAllRuntimes` with a description and no args.
2. **Verify user behavior is unchanged**: run "Discover All Interpreters" from the palette. Expected: discovery re-runs as before.
3. **Verify assistant invocation**: install a new interpreter (or create a venv), then ask the assistant to "rescan for interpreters". Expected: the command runs and the new interpreter appears in the interpreter picker.
