### PR TITLE
Make console session commands agent-invocable

### DIFF
--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -139,6 +139,59 @@ async function selectLanguage(accessor: ServicesAccessor) {
 }
 
 /**
+ * Whether a session is in a state where it can still be used. Sessions that
+ * have exited (or never finished initializing) are left out: they are not
+ * offered in the session picker, and they cannot be made the foreground
+ * session.
+ *
+ * @param session The session to check.
+ * @returns Whether the session is usable.
+ */
+function isActiveSessionState(session: ILanguageRuntimeSession): boolean {
+	switch (session.getRuntimeState()) {
+		case RuntimeState.Initializing:
+		case RuntimeState.Starting:
+		case RuntimeState.Ready:
+		case RuntimeState.Idle:
+		case RuntimeState.Busy:
+		case RuntimeState.Restarting:
+		case RuntimeState.Exiting:
+		case RuntimeState.Offline:
+		case RuntimeState.Interrupting:
+			return true;
+		default:
+			return false;
+	}
+}
+
+/**
+ * The result of the Start New Console Session command. Reported as data rather
+ * than left implicit so a programmatic caller can tell a started session apart
+ * from a picker the user dismissed.
+ */
+export interface IStartNewConsoleSessionResult {
+	/** Whether a new console session was started. */
+	readonly started: boolean;
+	/** The id of the new session, set when `started` is true. */
+	readonly sessionId?: string;
+	/** Why no session was started, set when `started` is false. */
+	readonly message?: string;
+}
+
+/**
+ * The result of the Select Session command. Reported as data for the same
+ * reason as {@link IStartNewConsoleSessionResult}.
+ */
+export interface ISelectSessionResult {
+	/** Whether the foreground session was changed. */
+	readonly selected: boolean;
+	/** The id of the session that is now in the foreground, set when `selected` is true. */
+	readonly sessionId?: string;
+	/** Why the foreground session was not changed, set when `selected` is false. */
+	readonly message?: string;
+}
+
+/**
  * Helper function that asks the user to select a language runtime session from
  * an array of existing language runtime sessions.
  *
@@ -184,31 +237,13 @@ export const selectLanguageRuntimeSession = async (
 			languageService,
 		);
 
-	// Filter active sessions by runtime state (exclude exited/uninitialized sessions).
-	const isActiveState = (session: ILanguageRuntimeSession) => {
-		switch (session.getRuntimeState()) {
-			case RuntimeState.Initializing:
-			case RuntimeState.Starting:
-			case RuntimeState.Ready:
-			case RuntimeState.Idle:
-			case RuntimeState.Busy:
-			case RuntimeState.Restarting:
-			case RuntimeState.Exiting:
-			case RuntimeState.Offline:
-			case RuntimeState.Interrupting:
-				return true;
-			default:
-				return false;
-		}
-	};
-
 	const currentForegroundSession = runtimeSessionService.foregroundSession;
 	const sessionItems: IQuickPickItem[] = [];
 
 	// Create quick pick items for active console sessions sorted by creation time, oldest to newest.
 	const consoleItems: IQuickPickItem[] = runtimeSessionService.activeSessions
 		.filter(session => session.metadata.sessionMode === LanguageRuntimeSessionMode.Console)
-		.filter(isActiveState)
+		.filter(isActiveSessionState)
 		.sort((a, b) => a.metadata.createdTimestamp - b.metadata.createdTimestamp)
 		.map(session => ({
 			id: session.sessionId,
@@ -234,7 +269,7 @@ export const selectLanguageRuntimeSession = async (
 		// Active notebook sessions (includes quarto), sorted by creation time.
 		const activeNotebookSessions = runtimeSessionService.activeSessions
 			.filter(session => session.metadata.sessionMode === LanguageRuntimeSessionMode.Notebook)
-			.filter(isActiveState)
+			.filter(isActiveSessionState)
 			.sort((a, b) => a.metadata.createdTimestamp - b.metadata.createdTimestamp);
 
 		const notebookItems: IQuickPickItem[] = activeNotebookSessions
@@ -318,9 +353,10 @@ export const selectLanguageRuntimeSession = async (
 	// Handle the user's selection.
 	if (result?.id === startNewRuntimeId) {
 		// If the user selected "New Console Session...", execute the command to start a new console session.
-		const sessionId: string | undefined = await commandService.executeCommand(LANGUAGE_RUNTIME_START_NEW_CONSOLE_SESSION_ID);
-		if (sessionId) {
-			return runtimeSessionService.activeSessions.find(session => session.sessionId === sessionId);
+		const started = await commandService.executeCommand<IStartNewConsoleSessionResult>(
+			LANGUAGE_RUNTIME_START_NEW_CONSOLE_SESSION_ID);
+		if (started?.sessionId) {
+			return runtimeSessionService.activeSessions.find(session => session.sessionId === started.sessionId);
 		}
 	} else if (result?.id === changeNotebookSessionId) {
 		await commandService.executeCommand(SELECT_KERNEL_ID_POSITRON);
@@ -332,6 +368,42 @@ export const selectLanguageRuntimeSession = async (
 	}
 	return undefined;
 };
+
+/**
+ * Helper function that applies a newly selected language runtime session as
+ * the foreground session: for notebook sessions, focuses the associated
+ * editor first; for console sessions, drives focus into the console pane.
+ * Shared by the interactive picker path and the agent-supplied sessionId
+ * path in SelectSessionAction so both flow through the same logic.
+ *
+ * Takes already-resolved services (rather than a ServicesAccessor) because
+ * callers may invoke this after an `await`, at which point a ServicesAccessor
+ * is no longer valid to read from.
+ *
+ * @param commandService The command service.
+ * @param editorService The editor service.
+ * @param runtimeSessionService The runtime session service.
+ * @param session The session to make the foreground session.
+ */
+async function applySelectedSession(
+	commandService: ICommandService,
+	editorService: IEditorService,
+	runtimeSessionService: IRuntimeSessionService,
+	session: ILanguageRuntimeSession
+): Promise<void> {
+	const notebookUri = session.metadata.notebookUri;
+	if (notebookUri) {
+		// For notebook sessions, we want to focus the editor
+		// associated with the session's notebook URI when changing
+		// the foreground session.
+		await editorService.openEditor({ resource: notebookUri });
+		runtimeSessionService.foregroundSession = session;
+	} else {
+		// For console sessions, drive focus into the console pane
+		runtimeSessionService.foregroundSession = session;
+		commandService.executeCommand('workbench.panel.positronConsole.focus');
+	}
+}
 
 /**
  * IInterpreterGroup interface.
@@ -827,6 +899,182 @@ export class DuplicateActiveConsoleSessionAction extends Action2 {
 	}
 }
 
+/**
+ * Action that allows the user to create a new console session from a list of registered runtimes.
+ */
+export class StartNewConsoleSessionAction extends Action2 {
+	/**
+	 * Constructor.
+	 */
+	constructor() {
+		super({
+			icon: Codicon.plus,
+			id: LANGUAGE_RUNTIME_START_NEW_CONSOLE_SESSION_ID,
+			title: localize2('positron.languageRuntime.startConsoleSession', 'Start New Console Session'),
+			category,
+			f1: true,
+			menu: [{
+				group: 'navigation',
+				id: MenuId.ViewTitle,
+				order: 1,
+				when: ContextKeyExpr.and(
+					ContextKeyExpr.equals('view', POSITRON_CONSOLE_VIEW_ID),
+					PositronConsoleInstancesExistContext.negate()
+				),
+			}],
+			keybinding: {
+				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Slash,
+				mac: { primary: KeyMod.WinCtrl | KeyMod.Shift | KeyCode.Slash },
+				weight: KeybindingWeight.WorkbenchContrib
+			},
+			metadata: {
+				description: localize('positron.languageRuntime.startNewConsoleSession.description', "Start a new console session for a language runtime."),
+				agentCompatible: true,
+				args: [
+					{
+						name: 'runtimeId',
+						description: 'Runtime id to start a console session for. Always supply this when running the command programmatically: with no id the command opens a runtime picker and waits for the user to choose one.',
+						schema: { type: 'string' },
+					},
+				],
+				returns: 'An object with started, sessionId, and message. started is true when a console session was started, with sessionId identifying it; when started is false, message explains why (the user dismissed the runtime picker).',
+			},
+		});
+	}
+
+	async run(accessor: ServicesAccessor, runtimeId?: string): Promise<IStartNewConsoleSessionResult> {
+		// Access services.
+		const commandService = accessor.get(ICommandService);
+		const runtimeSessionService = accessor.get(IRuntimeSessionService);
+
+		// Only treat a non-empty string as a supplied id: menu callers can
+		// forward a context object as the first argument.
+		const suppliedRuntimeId = typeof runtimeId === 'string' && runtimeId.length > 0 ? runtimeId : undefined;
+		let selectedRuntime: ILanguageRuntimeMetadata | undefined;
+		if (suppliedRuntimeId) {
+			// A runtime id was supplied (e.g. by an agent): resolve it
+			// directly and skip the picker. An id that resolves to nothing is a
+			// caller error, so throw rather than falling back to the picker,
+			// which would leave a programmatic caller waiting on the user.
+			const languageRuntimeService = accessor.get(ILanguageRuntimeService);
+			selectedRuntime = languageRuntimeService.getRegisteredRuntime(suppliedRuntimeId);
+			if (!selectedRuntime) {
+				throw new Error(localize('positron.languageRuntime.startConsoleSession.unknownRuntime',
+					"No registered runtime with id '{0}'.", suppliedRuntimeId));
+			}
+		} else {
+			// Prompt the user to select a runtime to start
+			selectedRuntime = await selectNewLanguageRuntime(
+				accessor,
+				{ title: localize('positron.languageRuntime.startConsoleSession', 'Start New Console Session') }
+			);
+		}
+
+		// The user dismissed the picker without choosing a runtime.
+		if (!selectedRuntime?.runtimeId) {
+			return {
+				started: false,
+				message: localize('positron.languageRuntime.startConsoleSession.noRuntimeSelected',
+					"No runtime was selected, so no console session was started."),
+			};
+		}
+
+		// Drive focus into the Positron console.
+		commandService.executeCommand('workbench.panel.positronConsole.focus');
+
+		const sessionId = await runtimeSessionService.startNewRuntimeSession(
+			selectedRuntime.runtimeId,
+			selectedRuntime.runtimeName,
+			LanguageRuntimeSessionMode.Console,
+			undefined,
+			suppliedRuntimeId ? 'Runtime id supplied to startNewConsoleSession command' : 'User selected runtime',
+			RuntimeStartMode.Starting,
+			true
+		);
+		return { started: true, sessionId };
+	}
+}
+
+/**
+ * Action that allows the user to change the foreground session.
+ */
+export class SelectSessionAction extends Action2 {
+	/**
+	 * Constructor.
+	 */
+	constructor() {
+		super({
+			id: LANGUAGE_RUNTIME_SELECT_SESSION_ID,
+			title: localize2('positron.languageRuntime.selectSession.commandTitle', 'Select Session'),
+			f1: true,
+			category,
+			metadata: {
+				description: localize('positron.languageRuntime.selectSession.description', "Select the session to make active."),
+				agentCompatible: true,
+				args: [
+					{
+						name: 'sessionId',
+						description: 'Id of the session to make active. Always supply this when running the command programmatically: with no id the command opens a session picker and waits for the user to choose one.',
+						schema: { type: 'string' },
+					},
+				],
+				returns: 'An object with selected, sessionId, and message. selected is true when the foreground session changed, with sessionId identifying it; when selected is false, message explains why (the user dismissed the session picker).',
+			},
+		});
+	}
+
+	async run(accessor: ServicesAccessor, sessionId?: string): Promise<ISelectSessionResult> {
+		// Access services up front: the accessor is only valid synchronously,
+		// and selectLanguageRuntimeSession below awaits.
+		const commandService = accessor.get(ICommandService);
+		const editorService = accessor.get(IEditorService);
+		const runtimeSessionService = accessor.get(IRuntimeSessionService);
+
+		// Only treat a non-empty string as a supplied id: menu callers can
+		// forward a context object as the first argument.
+		const suppliedSessionId = typeof sessionId === 'string' && sessionId.length > 0 ? sessionId : undefined;
+		let newActiveSession: ILanguageRuntimeSession | undefined;
+		if (suppliedSessionId) {
+			// A session id was supplied (e.g. by an agent): resolve it directly
+			// and skip the picker. An id that names no session, or one that has
+			// exited, is a caller error, so throw rather than falling back to
+			// the picker, which would leave a programmatic caller waiting on the
+			// user.
+			newActiveSession = runtimeSessionService.getSession(suppliedSessionId);
+			if (!newActiveSession) {
+				throw new Error(localize('positron.languageRuntime.selectSession.unknownSession',
+					"No active session with id '{0}'.", suppliedSessionId));
+			}
+			// The picker leaves exited sessions out, so they can't be selected
+			// by id either.
+			if (!isActiveSessionState(newActiveSession)) {
+				throw new Error(localize('positron.languageRuntime.selectSession.exitedSession',
+					"Session '{0}' has exited and cannot be made the active session.", suppliedSessionId));
+			}
+		} else {
+			// Prompt the user to select a runtime to use.
+			newActiveSession = await selectLanguageRuntimeSession(accessor,
+				{
+					allowStartSession: true,
+					title: localize('positron.languageRuntime.changeForegroundSession.quickPickTitle', 'Running Interpreter Sessions')
+				}
+			);
+		}
+
+		// The user dismissed the picker without choosing a session.
+		if (!newActiveSession) {
+			return {
+				selected: false,
+				message: localize('positron.languageRuntime.selectSession.noSessionSelected',
+					"No session was selected, so the active session is unchanged."),
+			};
+		}
+
+		await applySelectedSession(commandService, editorService, runtimeSessionService, newActiveSession);
+		return { selected: true, sessionId: newActiveSession.sessionId };
+	}
+}
+
 export function registerLanguageRuntimeActions() {
 	/**
 	 * Helper function to register a language runtime action.
@@ -927,105 +1175,9 @@ export function registerLanguageRuntimeActions() {
 			notificationService.info(localize('interpreterCleared', 'The {0} interpreter has been cleared from this workspace.', quickPickItem.runtime.runtimeName));
 		});
 
-	/**
-	 * Action that allows the user to change the foreground session.
-	 */
-	registerLanguageRuntimeAction(
-		LANGUAGE_RUNTIME_SELECT_SESSION_ID,
-		localize2('positron.languageRuntime.selectSession.commandTitle', 'Select Session'),
-		async accessor => {
-			// Access services.
-			const commandService = accessor.get(ICommandService);
-			const editorService = accessor.get(IEditorService);
-			const runtimeSessionService = accessor.get(IRuntimeSessionService);
+	registerAction2(SelectSessionAction);
 
-			// Prompt the user to select a runtime to use.
-			const newActiveSession = await selectLanguageRuntimeSession(accessor,
-				{
-					allowStartSession: true,
-					title: localize('positron.languageRuntime.changeForegroundSession.quickPickTitle', 'Running Interpreter Sessions')
-				}
-			);
-
-			if (!newActiveSession) {
-				return;
-			}
-
-			const notebookUri = newActiveSession.metadata.notebookUri;
-			if (notebookUri) {
-				// For notebook sessions, we want to focus the editor
-				// associated with the session's notebook URI when changing
-				// the foreground session.
-				await editorService.openEditor({ resource: notebookUri });
-				runtimeSessionService.foregroundSession = newActiveSession;
-			} else {
-				// For console sessions, drive focus into the console pane
-				runtimeSessionService.foregroundSession = newActiveSession;
-				commandService.executeCommand('workbench.panel.positronConsole.focus');
-			}
-		}
-	);
-
-	/**
-	 * Action that allows the user to create a new console session from a list of registered runtimes.
-	 */
-	registerAction2(class extends Action2 {
-		/**
-		 * Constructor.
-		 */
-		constructor() {
-			super({
-				icon: Codicon.plus,
-				id: LANGUAGE_RUNTIME_START_NEW_CONSOLE_SESSION_ID,
-				title: localize2('positron.languageRuntime.startConsoleSession', 'Start New Console Session'),
-				category,
-				f1: true,
-				menu: [{
-					group: 'navigation',
-					id: MenuId.ViewTitle,
-					order: 1,
-					when: ContextKeyExpr.and(
-						ContextKeyExpr.equals('view', POSITRON_CONSOLE_VIEW_ID),
-						PositronConsoleInstancesExistContext.negate()
-					),
-				}],
-				keybinding: {
-					primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Slash,
-					mac: { primary: KeyMod.WinCtrl | KeyMod.Shift | KeyCode.Slash },
-					weight: KeybindingWeight.WorkbenchContrib
-				}
-			});
-		}
-
-		async run(accessor: ServicesAccessor) {
-			// Access services.
-			const commandService = accessor.get(ICommandService);
-			const runtimeSessionService = accessor.get(IRuntimeSessionService);
-
-			// Prompt the user to select a runtime to start
-			const selectedRuntime = await selectNewLanguageRuntime(
-				accessor,
-				{ title: localize('positron.languageRuntime.startConsoleSession', 'Start New Console Session') }
-			);
-
-			// If the user selected a runtime, set it as the active runtime
-			if (selectedRuntime?.runtimeId) {
-				// Drive focus into the Positron console.
-				commandService.executeCommand('workbench.panel.positronConsole.focus');
-
-				return await runtimeSessionService.startNewRuntimeSession(
-					selectedRuntime.runtimeId,
-					selectedRuntime.runtimeName,
-					LanguageRuntimeSessionMode.Console,
-					undefined,
-					'User selected runtime',
-					RuntimeStartMode.Starting,
-					true
-				);
-			}
-			return undefined;
-		}
-	});
+	registerAction2(StartNewConsoleSessionAction);
 
 	/**
 	 * Action that allows the user to rename an active session.

--- a/src/vs/workbench/contrib/languageRuntime/test/browser/languageRuntimeActions.vitest.ts
+++ b/src/vs/workbench/contrib/languageRuntime/test/browser/languageRuntimeActions.vitest.ts
@@ -7,12 +7,12 @@
 
 import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
 import { IQuickInputService, IQuickPickItem, QuickInputHideReason, QuickPickItem } from '../../../../../platform/quickinput/common/quickInput.js';
-import { ILanguageRuntimeMetadata, ILanguageRuntimeService, IRuntimePickerContribution, IRuntimePickerItem, LanguageRuntimeSessionLocation, LanguageRuntimeSessionMode, LanguageRuntimeStartupBehavior, RuntimeStartupPhase } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
+import { ILanguageRuntimeMetadata, ILanguageRuntimeService, IRuntimePickerContribution, IRuntimePickerItem, LanguageRuntimeSessionLocation, LanguageRuntimeSessionMode, LanguageRuntimeStartupBehavior, RuntimeState, RuntimeStartupPhase } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { IRuntimeStartupService } from '../../../../services/runtimeStartup/common/runtimeStartupService.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { TestQuickPick } from '../../../../../test/vitest/testQuickPick.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
-import { DuplicateActiveConsoleSessionAction, selectLanguageRuntimeSession, selectNewLanguageRuntime } from '../../browser/languageRuntimeActions.js';
+import { DuplicateActiveConsoleSessionAction, SelectSessionAction, StartNewConsoleSessionAction, selectLanguageRuntimeSession, selectNewLanguageRuntime } from '../../browser/languageRuntimeActions.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
@@ -824,5 +824,276 @@ describe('DuplicateActiveConsoleSessionAction', () => {
 			RuntimeStartMode.Starting,
 			true
 		);
+	});
+});
+
+describe('StartNewConsoleSessionAction', () => {
+	const startNewRuntimeSession = vi.fn(async (): Promise<string> => 'new-session-id');
+	const executeCommand = vi.fn(async () => undefined);
+	let pick: TestQuickPick<IQuickPickItem>;
+	let preferredByLanguage: Map<string, ILanguageRuntimeMetadata>;
+
+	const ctx = createTestContainer()
+		.withRuntimeServices()
+		.stub(IRuntimeSessionService, stubInterface<IRuntimeSessionService>({ startNewRuntimeSession }))
+		.stub(ICommandService, { executeCommand })
+		// The picker only lists a language once it has a preferred runtime for it,
+		// so registerRuntime below records each runtime as its language's preferred.
+		.stub(IRuntimeStartupService, {
+			getPreferredRuntime: (languageId: string) => preferredByLanguage.get(languageId),
+		})
+		.stub(IQuickInputService, stubInterface<IQuickInputService>({
+			createQuickPick: (() => pick.asQuickPick()) as IQuickInputService['createQuickPick'],
+		}))
+		.build();
+
+	beforeEach(() => {
+		pick = ctx.disposables.add(new TestQuickPick<IQuickPickItem>());
+		preferredByLanguage = new Map();
+		ctx.get(ILanguageRuntimeService).setStartupPhase(RuntimeStartupPhase.Complete);
+	});
+
+	function runAction(runtimeId?: string) {
+		return ctx.instantiationService.invokeFunction(accessor =>
+			new StartNewConsoleSessionAction().run(accessor, runtimeId));
+	}
+
+	function registerRuntime(runtimeId: string, runtimeName: string) {
+		const runtimeService = ctx.get(ILanguageRuntimeService);
+		const runtime = makeRuntime({ runtimeId, runtimeName });
+		ctx.disposables.add(runtimeService.registerRuntime(runtime));
+		preferredByLanguage.set(runtime.languageId, runtime);
+	}
+
+	// Agent-invocable path: a runtimeId is supplied, so the command must
+	// resolve it directly and skip the picker entirely.
+	it('starts the session for a registered runtimeId without opening a picker', async () => {
+		registerRuntime('py-1', 'Python 3.12 (System)');
+
+		const result = await runAction('py-1');
+
+		expect(result).toEqual({ started: true, sessionId: 'new-session-id' });
+		expect(pick.show).not.toHaveBeenCalled();
+		expect(executeCommand).toHaveBeenCalledWith('workbench.panel.positronConsole.focus');
+		expect(startNewRuntimeSession).toHaveBeenCalledWith(
+			'py-1',
+			'Python 3.12 (System)',
+			LanguageRuntimeSessionMode.Console,
+			undefined,
+			'Runtime id supplied to startNewConsoleSession command',
+			RuntimeStartMode.Starting,
+			true
+		);
+	});
+
+	// An unresolvable runtimeId must surface a clear error rather than
+	// silently falling back to the interactive picker, which would leave a
+	// programmatic caller waiting on the user.
+	it('throws without starting a session or opening a picker for an unknown runtimeId', async () => {
+		await expect(runAction('does-not-exist')).rejects.toThrow(/does-not-exist/);
+		expect(pick.show).not.toHaveBeenCalled();
+		expect(startNewRuntimeSession).not.toHaveBeenCalled();
+		expect(executeCommand).not.toHaveBeenCalled();
+	});
+
+	// User path: no id, so the picker opens and the chosen runtime starts.
+	it('starts the runtime the user picks when no runtimeId is supplied', async () => {
+		registerRuntime('r-1', 'R 4.4.1');
+
+		const promise = runAction();
+		await vi.waitFor(() => expect(pick.show).toHaveBeenCalled());
+		pick.accept(pick.items.find((item): item is IQuickPickItem =>
+			item.type !== 'separator' && item.id === 'r-1')!);
+
+		expect(await promise).toEqual({ started: true, sessionId: 'new-session-id' });
+		expect(startNewRuntimeSession).toHaveBeenCalledWith(
+			'r-1',
+			'R 4.4.1',
+			LanguageRuntimeSessionMode.Console,
+			undefined,
+			'User selected runtime',
+			RuntimeStartMode.Starting,
+			true
+		);
+	});
+
+	// A dismissed picker must report that nothing happened rather than looking
+	// like a success to a programmatic caller.
+	it('reports started: false when the user dismisses the picker', async () => {
+		const promise = runAction();
+		await vi.waitFor(() => expect(pick.show).toHaveBeenCalled());
+		pick.cancel();
+
+		expect(await promise).toEqual({
+			started: false,
+			message: 'No runtime was selected, so no console session was started.',
+		});
+		expect(startNewRuntimeSession).not.toHaveBeenCalled();
+	});
+
+	// Menu callers can forward a context object as the first argument; it
+	// must be treated as "no id supplied" (picker path), not as a runtime id.
+	it('opens the picker when a menu context object is forwarded as the argument', async () => {
+		const menuContext = { instance: {} };
+		const promise = runAction(menuContext as never);
+		await vi.waitFor(() => expect(pick.show).toHaveBeenCalled());
+
+		pick.cancel();
+
+		await expect(promise).resolves.toMatchObject({ started: false });
+		expect(startNewRuntimeSession).not.toHaveBeenCalled();
+	});
+});
+
+describe('SelectSessionAction', () => {
+	const executeCommand = vi.fn(async () => undefined);
+	const openEditor = vi.fn(async () => undefined);
+	const pickFn = vi.fn(async (): Promise<QuickPickItem | undefined> => undefined);
+
+	let foregroundSession: ILanguageRuntimeSession | undefined;
+	let sessionsById: Map<string, ILanguageRuntimeSession>;
+
+	const ctx = createTestContainer()
+		.withRuntimeServices()
+		.stub(IRuntimeSessionService, stubInterface<IRuntimeSessionService>({
+			get foregroundSession() { return foregroundSession; },
+			set foregroundSession(session) { foregroundSession = session; },
+			get activeSessions() { return [...sessionsById.values()]; },
+			getSession: (sessionId: string) => sessionsById.get(sessionId),
+		}))
+		.stub(ICommandService, { executeCommand })
+		.stub(IEditorService, stubInterface<IEditorService>({ openEditor }))
+		.stub(IQuickInputService, stubInterface<IQuickInputService>({
+			// Narrow to IQuickInputService['pick'] because the field is overloaded
+			// (canPickMany: true returns Promise<T[]>, canPickMany: false returns
+			// Promise<T>); our single-shape stub satisfies only one overload and
+			// TS rejects it without the cast.
+			pick: pickFn as IQuickInputService['pick'],
+		}))
+		.build();
+
+	beforeEach(() => {
+		foregroundSession = undefined;
+		sessionsById = new Map();
+	});
+
+	function runAction(sessionId?: string) {
+		return ctx.instantiationService.invokeFunction(accessor =>
+			new SelectSessionAction().run(accessor, sessionId));
+	}
+
+	function addSession(
+		sessionId: string,
+		overrides: { notebookUri?: URI; runtimeState?: RuntimeState } = {},
+	): ILanguageRuntimeSession {
+		const { notebookUri, runtimeState = RuntimeState.Idle } = overrides;
+		const session = stubInterface<ILanguageRuntimeSession>({
+			sessionId,
+			metadata: {
+				sessionId,
+				sessionMode: notebookUri
+					? LanguageRuntimeSessionMode.Notebook
+					: LanguageRuntimeSessionMode.Console,
+				notebookUri,
+				createdTimestamp: 0,
+				startReason: 'test',
+			},
+			runtimeMetadata: makeRuntime(),
+			dynState: {
+				sessionName: sessionId,
+				currentWorkingDirectory: '',
+				busy: false,
+				inputPrompt: '>',
+				continuationPrompt: '+',
+			},
+			getRuntimeState: () => runtimeState,
+		});
+		sessionsById.set(sessionId, session);
+		return session;
+	}
+
+	// Agent-invocable path: a sessionId is supplied, so the command must
+	// resolve it directly and skip the picker entirely.
+	it('resolves a console sessionId directly, focuses the console, and skips the picker', async () => {
+		const session = addSession('console-1');
+
+		const result = await runAction('console-1');
+
+		expect(result).toEqual({ selected: true, sessionId: 'console-1' });
+		expect(pickFn).not.toHaveBeenCalled();
+		expect(foregroundSession).toBe(session);
+		expect(executeCommand).toHaveBeenCalledWith('workbench.panel.positronConsole.focus');
+		expect(openEditor).not.toHaveBeenCalled();
+	});
+
+	it('resolves a notebook sessionId directly, opens its editor, and skips the picker', async () => {
+		const uri = URI.file('/path/to/notebook.ipynb');
+		const session = addSession('notebook-1', { notebookUri: uri });
+
+		const result = await runAction('notebook-1');
+
+		expect(result).toEqual({ selected: true, sessionId: 'notebook-1' });
+		expect(pickFn).not.toHaveBeenCalled();
+		expect(foregroundSession).toBe(session);
+		expect(openEditor).toHaveBeenCalledWith({ resource: uri });
+		expect(executeCommand).not.toHaveBeenCalled();
+	});
+
+	// An unresolvable sessionId must surface a clear error rather than
+	// silently falling back to the interactive picker, which would leave a
+	// programmatic caller waiting on the user.
+	it('throws without changing the foreground session or opening a picker for an unknown sessionId', async () => {
+		await expect(runAction('does-not-exist')).rejects.toThrow(/does-not-exist/);
+
+		expect(pickFn).not.toHaveBeenCalled();
+		expect(foregroundSession).toBeUndefined();
+		expect(executeCommand).not.toHaveBeenCalled();
+		expect(openEditor).not.toHaveBeenCalled();
+	});
+
+	// The picker leaves exited sessions out, so selecting one by id must fail
+	// too rather than making a dead session the foreground session.
+	it('throws for a session that has exited', async () => {
+		addSession('exited-1', { runtimeState: RuntimeState.Exited });
+
+		await expect(runAction('exited-1')).rejects.toThrow(/has exited/);
+		expect(foregroundSession).toBeUndefined();
+	});
+
+	// User path: no id, so the picker opens and the chosen session is applied.
+	it('applies the session the user picks when sessionId is omitted', async () => {
+		const session = addSession('console-1');
+		pickFn.mockResolvedValueOnce({ id: 'console-1', label: 'console-1' });
+
+		const result = await runAction();
+
+		expect(result).toEqual({ selected: true, sessionId: 'console-1' });
+		expect(pickFn).toHaveBeenCalled();
+		expect(foregroundSession).toBe(session);
+		expect(executeCommand).toHaveBeenCalledWith('workbench.panel.positronConsole.focus');
+	});
+
+	// A dismissed picker must report that nothing happened rather than looking
+	// like a success to a programmatic caller.
+	it('reports selected: false when the user dismisses the picker', async () => {
+		const result = await runAction();
+
+		expect(result).toEqual({
+			selected: false,
+			message: 'No session was selected, so the active session is unchanged.',
+		});
+		expect(pickFn).toHaveBeenCalled();
+		expect(foregroundSession).toBeUndefined();
+	});
+
+	// Menu callers can forward a context object as the first argument; it
+	// must be treated as "no id supplied" (picker path), not as a session id.
+	it('opens the picker when a menu context object is forwarded as the argument', async () => {
+		const menuContext = { instance: {} };
+		const result = await runAction(menuContext as never);
+
+		expect(result).toMatchObject({ selected: false });
+		expect(pickFn).toHaveBeenCalled();
+		expect(foregroundSession).toBeUndefined();
 	});
 });


### PR DESCRIPTION
Addresses part of #15063.

### Summary

Makes two console commands invocable by Posit Assistant:

- `workbench.action.language.runtime.startNewConsoleSession`: gains a `runtimeId` argument. When supplied, the session starts headless (no runtime picker); an unknown id throws so `positron.ai.validateAndExecuteCommand` reports `{ok: false}` instead of silently succeeding. The anonymous action class is promoted to an exported `StartNewConsoleSessionAction` for testability.
- `workbench.action.language.runtime.selectSession`: same treatment with a `sessionId` argument (`SelectSessionAction`), converted off the shared `registerLanguageRuntimeAction` helper so it can carry arg metadata. An id naming a session that has exited throws too, because the session picker already leaves exited sessions out and selecting one by id shouldn't get around that.

Both commands only show interactive pickers if a runtimeId/sessionId is not provided which lets us programmatically execute the command without interruption. If the id _is_ omitted the picker still opens and waits on the user, and the command has no way to tell an agent caller from a human one (nothing in `ICommandService` carries the caller, and `validateAndExecute` is deliberately not a policy gate -- see posit-dev/assistant#1810). So the id is declared required in the agent metadata that `positron.ai.getAgentAllowedCommands()` reports, while the argument stays optional in code to keep the palette, keybinding, and menu paths working.

Both commands also report their outcome as data now: `startNewConsoleSession` returns `{started, sessionId, message}` and `selectSession` returns `{selected, sessionId, message}`. Without this, a picker the user dismissed reached Assistant as `Ran '<command id>'.`, which reads as success even though nothing happened. `startNewConsoleSession` used to return a bare session id string, so `selectLanguageRuntimeSession` now reads `sessionId` off the result -- that's the "New Console Session..." item inside the Select Session picker.

### MAJOR GAP

This PR only updates the commands to be non-interactive but doesn't make them usable by Assistant without some additional context.

Posit Assistant does not currently have a way to learn what a valid `runtimeId`/`sessionId` value is. These are currently internal values within Positron. The initial plan was to leverage `getRegisteredRuntimes()` to create a mapping of runtimes to their IDs for `workbench.action.language.runtime.startNewConsoleSession` and provide that context alongside the system prompt. I was going to do something similar for `workbench.action.language.runtime.selectSession`.

Given that we want to move away from putting context in the system prompt, we need to provide this context some other way. We can't add new tools to Assistant, so the stepping stone is still two commands (`getRuntimeIds`, `getSessionIds`) that Assistant can run through `positronCommand` to get the information it needs, reading `getRegisteredRuntimes()` and `activeSessions` on the Positron side. We document all four commands in the same reference file and tell Assistant how to use them together. Tracking that in #15346.

One lookup fewer than planned: `startNewConsoleSession` now returns the new `sessionId`, so starting a session and then making it active doesn't need `getSessionIds` at all. And `getSessionIds` can filter with the `isActiveSessionState` helper this PR extracts, so the sessions it lists are exactly the ones `selectSession` will accept.

### Screenshots

Took some videos to show that the existing behavior has not changed

https://github.com/user-attachments/assets/a3328012-3406-4b4a-b7fc-8c477dcdab2c


https://github.com/user-attachments/assets/9df4eb21-e293-4856-a446-14e31135aaf6


https://github.com/user-attachments/assets/540e3728-a3af-400f-88ae-137a6592930f


https://github.com/user-attachments/assets/7caa5ed9-9041-4b94-82c4-b5204b77ee50


### Release Notes

#### New Features

- Posit Assistant can start console sessions and switch sessions (#15063)

#### Bug Fixes

- N/A

### Validation Steps

@:console @:sessions

**Verify user behavior is unchanged**

1. From the palette run "Start New Console Session" and verify a picker opens for the user to select a runtime. Pick one and verify the session starts.
2. Run it again and dismiss the picker with `Esc`. Verify nothing starts and **no error notification appears**.
3. From the palette run "Select Session" and verify a picker opens for the user to select a session. Pick one and verify it becomes the active session.
4. Run "Select Session" again and choose **"New Console Session..."**. Verify the runtime picker opens and the session you pick starts and becomes active. (This path reads the new return value.)
5. With no console sessions running, verify the `+` button in the Console pane title bar still opens the runtime picker.

**Verify the commands are advertised to Assistant**

6. Run "Developer: Show Agent-Allowed Commands" and verify both `workbench.action.language.runtime.startNewConsoleSession` and `workbench.action.language.runtime.selectSession` appear, each with its `args` entry (`required: true`, `type: "string"`) and a `returns` description.

**Verify the non-interactive path**

SETUP: get a real `runtimeId` and `sessionId` for an existing session via the Runtimes debug panel (enable `interpreters.showSessions` setting to see it). The ID field in the table is the session ID.

<img width="1433" height="970" alt="image" src="https://github.com/user-attachments/assets/6f072f62-0e74-447d-8dd7-228b84b2a2d0" />


7. Add temporary `keybindings.json` entries and press each key. Verify the session starts / becomes active with **no picker opening**:

```json
{ "key": "cmd+1", "command": "workbench.action.language.runtime.startNewConsoleSession", "args": "<runtimeId>" },
{ "key": "cmd+2", "command": "workbench.action.language.runtime.selectSession", "args": "<sessionId>" }
```

8. Change both `args` values to `"does-not-exist"` and press each key again. Verify each one **fails with an error instead of opening a picker** (a keybinding surfaces the thrown message as a warning notification).
9. Shut down a console session, then set the `selectSession` binding's `args` to that exited session's id. Verify it fails with `Session '<id>' has exited and cannot be made the active session.` and the active session does not change.
