### PR TITLE
Make positronNotebook.selectKernel agent-invocable

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction.ts
@@ -65,9 +65,10 @@ export class SelectPositronNotebookKernelAction extends Action2 {
 			runtime = languageRuntimeService.getRegisteredRuntime(runtimeId);
 			if (!runtime) {
 				const notificationService = accessor.get(INotificationService);
-				notificationService.error(localize('positronNotebookActions.selectKernel.unknownRuntime',
-					"No registered runtime with id '{0}'.", runtimeId));
-				return false;
+				const message = localize('positronNotebookActions.selectKernel.unknownRuntime',
+					"No registered runtime with id '{0}'.", runtimeId);
+				notificationService.error(message);
+				throw new Error(message);
 			}
 		} else {
 			const selectedKernel = notebookKernelService.getMatchingKernel(notebook).selected;

--- a/src/vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction.ts
@@ -7,18 +7,20 @@ import { localize, localize2 } from '../../../../nls.js';
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { INotebookKernelService } from '../../notebook/common/notebookKernelService.js';
 import { POSITRON_RUNTIME_NOTEBOOK_KERNELS_EXTENSION_ID } from '../../runtimeNotebookKernel/common/runtimeNotebookKernelConfig.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { getNotebookInstanceFromActiveEditorPane } from './notebookUtils.js';
 import { Codicon } from '../../../../base/common/codicons.js';
+import { ILanguageRuntimeMetadata, ILanguageRuntimeService } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { selectNewLanguageRuntime } from '../../languageRuntime/browser/languageRuntimeActions.js';
 import { SELECT_KERNEL_ID_POSITRON } from '../common/positronNotebookCommon.js';
 
 const NOTEBOOK_ACTIONS_CATEGORY_POSITRON = localize2('positronNotebookActions.category', 'Positron Notebook');
 const NOTEBOOK_IS_ACTIVE_EDITOR = ContextKeyExpr.equals('activeEditor', 'workbench.editor.positronNotebook');
 
-class SelectPositronNotebookKernelAction extends Action2 {
+export class SelectPositronNotebookKernelAction extends Action2 {
 
 	constructor() {
 		super({
@@ -31,11 +33,18 @@ class SelectPositronNotebookKernelAction extends Action2 {
 			menu: [{
 				id: MenuId.PositronNotebookKernelSubmenu,
 				order: 0,
-			}]
+			}],
+			metadata: {
+				description: localize('positron.selectKernel.description', "Select the kernel for the active notebook."),
+				agentCompatible: true,
+				args: [
+					{ name: 'runtimeId', isOptional: true, description: "Runtime id to use as the notebook kernel. If omitted, a kernel picker opens.", schema: { type: 'string' } },
+				],
+			},
 		});
 	}
 
-	async run(accessor: ServicesAccessor): Promise<boolean> {
+	async run(accessor: ServicesAccessor, runtimeId?: string): Promise<boolean> {
 		const notebookKernelService = accessor.get(INotebookKernelService);
 		const activeNotebook = getNotebookInstanceFromActiveEditorPane(accessor.get(IEditorService));
 
@@ -48,18 +57,32 @@ class SelectPositronNotebookKernelAction extends Action2 {
 			return false;
 		}
 
-		const selectedKernel = notebookKernelService.getMatchingKernel(notebook).selected;
-		const currentRuntimeId = selectedKernel?.extension.value === POSITRON_RUNTIME_NOTEBOOK_KERNELS_EXTENSION_ID
-			? selectedKernel.id.slice(POSITRON_RUNTIME_NOTEBOOK_KERNELS_EXTENSION_ID.length + 1)
-			: undefined;
+		let runtime: ILanguageRuntimeMetadata | undefined;
+		if (runtimeId) {
+			// A runtime id was supplied (e.g. by an agent): resolve it
+			// directly and skip the picker.
+			const languageRuntimeService = accessor.get(ILanguageRuntimeService);
+			runtime = languageRuntimeService.getRegisteredRuntime(runtimeId);
+			if (!runtime) {
+				const notificationService = accessor.get(INotificationService);
+				notificationService.error(localize('positronNotebookActions.selectKernel.unknownRuntime',
+					"No registered runtime with id '{0}'.", runtimeId));
+				return false;
+			}
+		} else {
+			const selectedKernel = notebookKernelService.getMatchingKernel(notebook).selected;
+			const currentRuntimeId = selectedKernel?.extension.value === POSITRON_RUNTIME_NOTEBOOK_KERNELS_EXTENSION_ID
+				? selectedKernel.id.slice(POSITRON_RUNTIME_NOTEBOOK_KERNELS_EXTENSION_ID.length + 1)
+				: undefined;
 
-		const runtime = await selectNewLanguageRuntime(accessor, {
-			title: localize('positronNotebookActions.selectKernel.title', 'Select Positron Notebook Kernel'),
-			currentRuntimeId,
-		});
+			runtime = await selectNewLanguageRuntime(accessor, {
+				title: localize('positronNotebookActions.selectKernel.title', 'Select Positron Notebook Kernel'),
+				currentRuntimeId,
+			});
 
-		if (!runtime) {
-			return false;
+			if (!runtime) {
+				return false;
+			}
 		}
 
 		const kernel = notebookKernelService.getMatchingKernel(notebook).all.find(

--- a/src/vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction.ts
@@ -35,17 +35,21 @@ export class SelectPositronNotebookKernelAction extends Action2 {
 				order: 0,
 			}],
 			metadata: {
-				description: localize('positron.selectKernel.description', "Select the kernel for the active notebook."),
+				description: localize('positronNotebookActions.selectKernel.description', "Select the kernel for the active notebook."),
 				agentCompatible: true,
 				args: [
 					{ name: 'runtimeId', isOptional: true, description: 'Runtime id to use as the notebook kernel. If omitted, a kernel picker opens.', schema: { type: 'string' } },
 				],
+				returns: 'True when a kernel was selected; false when no notebook is active or the picker was dismissed.',
 			},
 		});
 	}
 
 	async run(accessor: ServicesAccessor, runtimeId?: string): Promise<boolean> {
+		// The accessor is only valid synchronously, so resolve every service
+		// before the awaited picker below.
 		const notebookKernelService = accessor.get(INotebookKernelService);
+		const notificationService = accessor.get(INotificationService);
 		const activeNotebook = getNotebookInstanceFromActiveEditorPane(accessor.get(IEditorService));
 
 		if (!activeNotebook) {
@@ -57,16 +61,18 @@ export class SelectPositronNotebookKernelAction extends Action2 {
 			return false;
 		}
 
+		// Only treat a non-empty string as a supplied id: the kernel badge
+		// submenu forwards a context object as the first argument.
+		const suppliedRuntimeId = typeof runtimeId === 'string' && runtimeId.length > 0 ? runtimeId : undefined;
 		let runtime: ILanguageRuntimeMetadata | undefined;
-		if (runtimeId) {
+		if (suppliedRuntimeId) {
 			// A runtime id was supplied (e.g. by an agent): resolve it
 			// directly and skip the picker.
 			const languageRuntimeService = accessor.get(ILanguageRuntimeService);
-			runtime = languageRuntimeService.getRegisteredRuntime(runtimeId);
+			runtime = languageRuntimeService.getRegisteredRuntime(suppliedRuntimeId);
 			if (!runtime) {
-				const notificationService = accessor.get(INotificationService);
 				const message = localize('positronNotebookActions.selectKernel.unknownRuntime',
-					"No registered runtime with id '{0}'.", runtimeId);
+					"No registered runtime with id '{0}'.", suppliedRuntimeId);
 				notificationService.error(message);
 				throw new Error(message);
 			}
@@ -90,6 +96,15 @@ export class SelectPositronNotebookKernelAction extends Action2 {
 			k => k.id === `${POSITRON_RUNTIME_NOTEBOOK_KERNELS_EXTENSION_ID}/${runtime.runtimeId}`
 		);
 		if (!kernel) {
+			// For an agent-supplied runtime id, surface the failure instead of
+			// returning false, which validateAndExecuteCommand would report as
+			// success.
+			if (suppliedRuntimeId) {
+				const message = localize('positronNotebookActions.selectKernel.noKernelForRuntime',
+					"No notebook kernel found for runtime id '{0}'.", suppliedRuntimeId);
+				notificationService.error(message);
+				throw new Error(message);
+			}
 			return false;
 		}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction.ts
@@ -38,7 +38,7 @@ export class SelectPositronNotebookKernelAction extends Action2 {
 				description: localize('positron.selectKernel.description', "Select the kernel for the active notebook."),
 				agentCompatible: true,
 				args: [
-					{ name: 'runtimeId', isOptional: true, description: "Runtime id to use as the notebook kernel. If omitted, a kernel picker opens.", schema: { type: 'string' } },
+					{ name: 'runtimeId', isOptional: true, description: 'Runtime id to use as the notebook kernel. If omitted, a kernel picker opens.', schema: { type: 'string' } },
 				],
 			},
 		});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/SelectPositronNotebookKernelAction.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/SelectPositronNotebookKernelAction.vitest.ts
@@ -97,12 +97,11 @@ describe('SelectPositronNotebookKernelAction', () => {
 
 	// An unresolvable runtimeId must surface a clear error rather than
 	// silently falling back to the interactive picker.
-	it('notifies and returns false for an unknown runtimeId', async () => {
+	it('throws and notifies without selecting a kernel for an unknown runtimeId', async () => {
 		stubKernelService([]);
 
-		const result = await runAction('does-not-exist');
+		await expect(runAction('does-not-exist')).rejects.toThrow(/does-not-exist/);
 
-		expect(result).toBe(false);
 		expect(notifyError).toHaveBeenCalledWith(expect.stringContaining('does-not-exist'));
 		expect(selectKernelForNotebook).not.toHaveBeenCalled();
 		expect(grabFocus).not.toHaveBeenCalled();

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/SelectPositronNotebookKernelAction.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/SelectPositronNotebookKernelAction.vitest.ts
@@ -1,0 +1,110 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
+import { ILanguageRuntimeMetadata, ILanguageRuntimeService, LanguageRuntimeSessionLocation, LanguageRuntimeStartupBehavior } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { INotebookKernel, INotebookKernelService } from '../../../notebook/common/notebookKernelService.js';
+import { POSITRON_RUNTIME_NOTEBOOK_KERNELS_EXTENSION_ID } from '../../../runtimeNotebookKernel/common/runtimeNotebookKernelConfig.js';
+import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../common/positronNotebookCommon.js';
+import { SelectPositronNotebookKernelAction } from '../../browser/SelectPositronNotebookKernelAction.js';
+
+function makeRuntime(overrides: Partial<ILanguageRuntimeMetadata> = {}): ILanguageRuntimeMetadata {
+	const languageId = overrides.languageId ?? 'python';
+	const base: ILanguageRuntimeMetadata = {
+		extensionId: new ExtensionIdentifier('test-extension'),
+		base64EncodedIconSvg: '',
+		extraRuntimeData: { supported: true },
+		runtimeId: `${languageId}-${Math.random().toString(36).slice(2)}`,
+		runtimePath: '/usr/bin/test',
+		runtimeVersion: '0.0.0',
+		sessionLocation: LanguageRuntimeSessionLocation.Browser,
+		startupBehavior: LanguageRuntimeStartupBehavior.Implicit,
+		languageId,
+		languageName: 'Python',
+		languageVersion: '3.12.0',
+		runtimeName: 'Python 3.12 (System)',
+		runtimeShortName: '3.12',
+		runtimeSource: 'System',
+	};
+	return { ...base, ...overrides };
+}
+
+describe('SelectPositronNotebookKernelAction', () => {
+	const notebookUri = URI.parse('file:///test.ipynb');
+	const grabFocus = vi.fn();
+	const selectKernelForNotebook = vi.fn();
+	const notifyError = vi.fn();
+
+	const ctx = createTestContainer()
+		.withRuntimeServices()
+		.stub(IEditorService, {
+			activeEditorPane: {
+				getId: () => POSITRON_NOTEBOOK_EDITOR_ID,
+				notebookInstance: {
+					textModel: { uri: notebookUri, notebookType: 'jupyter-notebook' },
+					grabFocus,
+				},
+			},
+		})
+		.stub(INotificationService, stubInterface<INotificationService>({ error: notifyError }))
+		.build();
+
+	function registerKernel(runtime: ILanguageRuntimeMetadata): INotebookKernel {
+		return stubInterface<INotebookKernel>({
+			id: `${POSITRON_RUNTIME_NOTEBOOK_KERNELS_EXTENSION_ID}/${runtime.runtimeId}`,
+		});
+	}
+
+	function stubKernelService(all: INotebookKernel[]) {
+		ctx.instantiationService.stub(INotebookKernelService, {
+			getMatchingKernel: () => ({ selected: undefined, suggestions: [], all, hidden: [] }),
+			selectKernelForNotebook,
+		});
+	}
+
+	function runAction(runtimeId?: string) {
+		return ctx.instantiationService.invokeFunction(accessor =>
+			new SelectPositronNotebookKernelAction().run(accessor, runtimeId));
+	}
+
+	// Agent-invocable path: a runtimeId is supplied, so the command must
+	// resolve it directly and skip the picker entirely.
+	it('selects the kernel for a registered runtimeId without opening a picker', async () => {
+		const runtimeService = ctx.get(ILanguageRuntimeService);
+		const runtime = makeRuntime({ runtimeId: 'py-1' });
+		ctx.disposables.add(runtimeService.registerRuntime(runtime));
+		const kernel = registerKernel(runtime);
+		stubKernelService([kernel]);
+
+		const result = await runAction('py-1');
+
+		expect(result).toBe(true);
+		expect(selectKernelForNotebook).toHaveBeenCalledWith(
+			kernel,
+			{ uri: notebookUri, notebookType: 'jupyter-notebook' },
+		);
+		expect(grabFocus).toHaveBeenCalledOnce();
+	});
+
+	// An unresolvable runtimeId must surface a clear error rather than
+	// silently falling back to the interactive picker.
+	it('notifies and returns false for an unknown runtimeId', async () => {
+		stubKernelService([]);
+
+		const result = await runAction('does-not-exist');
+
+		expect(result).toBe(false);
+		expect(notifyError).toHaveBeenCalledWith(expect.stringContaining('does-not-exist'));
+		expect(selectKernelForNotebook).not.toHaveBeenCalled();
+		expect(grabFocus).not.toHaveBeenCalled();
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/SelectPositronNotebookKernelAction.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/SelectPositronNotebookKernelAction.vitest.ts
@@ -7,6 +7,8 @@
 
 import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
 import { INotificationService } from '../../../../../platform/notification/common/notification.js';
+import { IQuickInputService, IQuickPickItem } from '../../../../../platform/quickinput/common/quickInput.js';
+import { TestQuickPick } from '../../../../../test/vitest/testQuickPick.js';
 import { ILanguageRuntimeMetadata, ILanguageRuntimeService, LanguageRuntimeSessionLocation, LanguageRuntimeStartupBehavior } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { URI } from '../../../../../base/common/uri.js';
@@ -43,6 +45,7 @@ describe('SelectPositronNotebookKernelAction', () => {
 	const grabFocus = vi.fn();
 	const selectKernelForNotebook = vi.fn();
 	const notifyError = vi.fn();
+	let pick: TestQuickPick<IQuickPickItem>;
 
 	const ctx = createTestContainer()
 		.withRuntimeServices()
@@ -56,7 +59,14 @@ describe('SelectPositronNotebookKernelAction', () => {
 			},
 		})
 		.stub(INotificationService, stubInterface<INotificationService>({ error: notifyError }))
+		.stub(IQuickInputService, stubInterface<IQuickInputService>({
+			createQuickPick: (() => pick.asQuickPick()) as IQuickInputService['createQuickPick'],
+		}))
 		.build();
+
+	beforeEach(() => {
+		pick = ctx.disposables.add(new TestQuickPick<IQuickPickItem>());
+	});
 
 	function registerKernel(runtime: ILanguageRuntimeMetadata): INotebookKernel {
 		return stubInterface<INotebookKernel>({
@@ -105,5 +115,38 @@ describe('SelectPositronNotebookKernelAction', () => {
 		expect(notifyError).toHaveBeenCalledWith(expect.stringContaining('does-not-exist'));
 		expect(selectKernelForNotebook).not.toHaveBeenCalled();
 		expect(grabFocus).not.toHaveBeenCalled();
+	});
+
+	// A resolvable runtimeId with no matching notebook kernel must also
+	// surface a clear error: returning false would look like success to
+	// validateAndExecuteCommand.
+	it('throws and notifies when the runtime resolves but no notebook kernel matches', async () => {
+		const runtimeService = ctx.get(ILanguageRuntimeService);
+		const runtime = makeRuntime({ runtimeId: 'py-2' });
+		ctx.disposables.add(runtimeService.registerRuntime(runtime));
+		stubKernelService([]);
+
+		await expect(runAction('py-2')).rejects.toThrow(/py-2/);
+
+		expect(notifyError).toHaveBeenCalledWith(expect.stringContaining('py-2'));
+		expect(selectKernelForNotebook).not.toHaveBeenCalled();
+		expect(grabFocus).not.toHaveBeenCalled();
+	});
+
+	// The kernel badge submenu forwards a context object as the first
+	// argument; it must be treated as "no id supplied" (picker path), not
+	// as a runtime id.
+	it('opens the picker when a menu context object is forwarded as the argument', async () => {
+		stubKernelService([]);
+
+		const menuContext = { instance: {} };
+		const promise = runAction(menuContext as never);
+		await vi.waitFor(() => expect(pick.show).toHaveBeenCalled());
+
+		pick.cancel();
+
+		await expect(promise).resolves.toBe(false);
+		expect(notifyError).not.toHaveBeenCalled();
+		expect(selectKernelForNotebook).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
Addresses part of #15063.

### Summary

Makes `positronNotebook.selectKernel` invocable by Posit Assistant. The command gains an optional `runtimeId` argument: when supplied, the kernel is selected headless (no picker); when omitted, the existing kernel picker opens unchanged. Failure paths that matter to an agent throw (after notifying) so `positron.ai.validateAndExecuteCommand` reports `{ok: false}`: an unknown runtime id, and a resolvable runtime with no matching notebook kernel. The boolean result is documented via `returns` metadata.

The kernel status badge submenu forwards a context object as the command's first argument, so only a non-empty string is treated as a supplied id -- the badge's "Change Kernel..." flow keeps opening the picker (regression-tested).

### Screenshots

(to be added: assistant changing a notebook kernel via positronCommand)

### Release Notes

#### New Features

- Posit Assistant can select the kernel for the active notebook (#15063)

#### Bug Fixes

- N/A

### Validation Steps

@:positron-notebooks

1. **Unit tests**: `npx vitest run src/vs/workbench/contrib/positronNotebook/test/browser/SelectPositronNotebookKernelAction.vitest.ts`. Expected: 4 tests pass.
2. **Verify the agent contract**: run "Developer: Show All Agent-Compatible Commands". Expected: `positronNotebook.selectKernel` listed with an optional `runtimeId` string argument and a `returns` note.
3. **Verify user behavior is unchanged**: open a Positron notebook, click the kernel badge, choose "Change Kernel...". Expected: the kernel picker opens as before (this exercises the forwarded-context-object path).
4. **Verify the headless path**: with the assistant connected and a notebook open, ask it to "switch this notebook to the Python 3.12 kernel". Expected: the kernel changes with no picker.
