### PR TITLE
Make vscode.open agent-invocable

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -451,7 +451,14 @@ function registerOpenEditorAPICommands(): void {
 		},
 		metadata: {
 			description: 'Opens the provided resource in the editor.',
-			args: [{ name: 'Uri' }]
+			// --- Start Positron ---
+			// Advertise this command to AI agents (positron.ai.getAgentAllowedCommands)
+			// and document the argument they should pass. A plain path string works:
+			// it is parsed into a file URI by the opener service.
+			agentCompatible: true,
+			// args: [{ name: 'Uri' }]
+			args: [{ name: 'Uri', description: 'Absolute file path or URI of the resource to open. Tabular data files such as .csv and .parquet open in the Data Explorer.', schema: { type: 'string' } }]
+			// --- End Positron ---
 		}
 	});
 

--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -457,7 +457,11 @@ function registerOpenEditorAPICommands(): void {
 			// it is parsed into a file URI by the opener service.
 			agentCompatible: true,
 			// args: [{ name: 'Uri' }]
-			args: [{ name: 'Uri', description: 'Absolute file path or URI of the resource to open. Tabular data files such as .csv and .parquet open in the Data Explorer.', schema: { type: 'string' } }]
+			args: [{
+			  name: 'Uri',
+			  description: 'Absolute path or file URI of the file to open. Relative paths resolve against the filesystem root, not the workspace, so always pass an absolute path; on Windows pass a file:///C:/... URI rather than a bare drive-letter path. Tabular files (.csv, .tsv, .parquet, .xlsx, and .gz variants, lowercase extension) open in Data Explorer. http/https URLs open in an external browser, not an editor.',
+			schema: { type: 'string' }
+  }]
 			// --- End Positron ---
 		}
 	});


### PR DESCRIPTION
Addresses part of #15063.

### Summary

Makes `vscode.open` invocable by Posit Assistant, so the assistant can open files -- including opening `.csv`/`.parquet` files in the Data Explorer via Positron's editor resolver.

The command already works through the agent path today: `positron.ai.validateAndExecuteCommand` executes the renderer-side registration directly (bypassing the extension-host API converter that rejects plain path strings), and a string path falls through to the opener service, which parses it as a file URI. The only gap was discovery metadata: the renderer registration in the upstream `editorCommands.ts` declared a bare `Uri` arg with no description or schema.

This PR adds `agentCompatible: true` and a documented string schema for the argument, wrapped in Start/End Positron markers with the upstream arg line preserved in a comment. No behavior change for any caller.

### Screenshots

(to be added: assistant opening a csv in Data Explorer via positronCommand)

### Release Notes

#### New Features

- Posit Assistant can open files, including tabular data files in the Data Explorer (#15063)

#### Bug Fixes

- N/A

### Validation Steps

@:data-explorer @:editor

1. **Verify the agent contract**: run "Developer: Show All Agent-Compatible Commands". Expected: `vscode.open` listed with a described string `Uri` argument.
2. **Verify user behavior is unchanged**: open files normally (double-click in Explorer, Quick Open). Expected: no change.
