### PR TITLE
feat: expose active console as vscode.TextEditor via positron.window

### DIFF
--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -57,6 +57,10 @@ const HelpLines = [
 	'console active   - Show the current active console editor URI, language, and text (tests positron.window.activeConsoleEditor)',
 	'console watch    - Subscribe to onDidChangeActiveConsoleEditor and print each change',
 	'console watch stop - Stop watching for active console changes',
+	'console edit X   - Replace the console input with X via TextEditor.edit() (tests the Editor interface)',
+	'console append X - Insert X at the end of the console input via TextEditor.edit()',
+	'console insert X - Insert X at the cursor via TextEditor.insertSnippet()',
+	'console select   - Select the entire console input and report TextEditor.selection',
 	'connection X     - Create a database connection, optionally named X',
 	'connection close - Close a random database connection',
 	'code X Y         - Simulates a successful X line input with Y lines of output (where X >= 1 and Y >= 0)',
@@ -477,6 +481,13 @@ export class PositronZedRuntimeSession implements positron.LanguageRuntimeSessio
 			} else {
 				this.simulateConnection(id, code, title);
 			}
+			return;
+		} else if (match = code.match(/^console (edit|insert|append|select)(?: ([\s\S]*))?$/)) {
+			// Exercise the editing side of positron.window.activeConsoleEditor's
+			// vscode.TextEditor interface (edit(), insertSnippet(), selection).
+			const subcommand = match[1];
+			const arg = (match.length > 2 && match[2] !== undefined) ? match[2] : '';
+			this.simulateConsoleEditorCommand(id, code, subcommand, arg);
 			return;
 		}
 
@@ -2028,6 +2039,67 @@ export class PositronZedRuntimeSession implements positron.LanguageRuntimeSessio
 			this.simulateOutputMessage(parentId, output);
 		}
 		this.simulateIdleState(parentId);
+	}
+
+	/**
+	 * Exercises the mutating side of the `vscode.TextEditor` interface exposed by
+	 * `positron.window.activeConsoleEditor`. This complements the read-only `console active`
+	 * and `console watch` commands by verifying that `edit()`, `insertSnippet()`, and
+	 * `selection` operate on the live console input.
+	 * @param parentId The parent identifier.
+	 * @param code The originating command text.
+	 * @param subcommand The editor operation to perform: `edit`, `append`, `insert`, or `select`.
+	 * @param arg The text argument for `edit`, `append`, and `insert` (ignored for `select`).
+	 */
+	private simulateConsoleEditorCommand(parentId: string, code: string, subcommand: string, arg: string) {
+		const editor = positron.window.activeConsoleEditor;
+		if (!editor) {
+			this.simulateUnsuccessfulCodeExecution(parentId, code, 'No Active Console',
+				`No console editor is currently active.\n`, []);
+			return;
+		}
+
+		// The full range of the current console input, used for whole-document operations.
+		const fullRange = () => new vscode.Range(
+			editor.document.positionAt(0),
+			editor.document.positionAt(editor.document.getText().length));
+
+		switch (subcommand) {
+			case 'edit': {
+				// Replace the entire input with `arg`.
+				editor.edit(editBuilder => editBuilder.replace(fullRange(), arg)).then((applied) => {
+					this.simulateSuccessfulCodeExecution(parentId, code,
+						`edit() replace applied: ${applied}\nText: ${JSON.stringify(editor.document.getText())}`);
+				});
+				break;
+			}
+			case 'append': {
+				// Insert `arg` at the end of the input.
+				editor.edit(editBuilder => editBuilder.insert(fullRange().end, arg)).then((applied) => {
+					this.simulateSuccessfulCodeExecution(parentId, code,
+						`edit() insert applied: ${applied}\nText: ${JSON.stringify(editor.document.getText())}`);
+				});
+				break;
+			}
+			case 'insert': {
+				// Insert `arg` as a snippet at the current cursor position.
+				editor.insertSnippet(new vscode.SnippetString(arg)).then((applied) => {
+					this.simulateSuccessfulCodeExecution(parentId, code,
+						`insertSnippet() applied: ${applied}\nText: ${JSON.stringify(editor.document.getText())}`);
+				});
+				break;
+			}
+			case 'select': {
+				// Set the selection to cover the whole input, then read it back.
+				editor.selection = new vscode.Selection(fullRange().start, fullRange().end);
+				const selection = editor.selection;
+				this.simulateSuccessfulCodeExecution(parentId, code,
+					`Selection: [${selection.start.line}:${selection.start.character} - ` +
+					`${selection.end.line}:${selection.end.character}]\n` +
+					`Selected text: ${JSON.stringify(editor.document.getText(selection))}`);
+				break;
+			}
+		}
 	}
 
 	/**

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -54,6 +54,9 @@ const HelpLines = [
 	'busy X Y         - Simulates an interuptible busy state for X seconds that takes Y seconds to interrupt (default X = 5, Y = 1)',
 	'cd X             - Changes the current working directory to X, or to a random directory if X is not specified',
 	'clock            - Show a plot containing a clock, using the notebook renderer API',
+	'console active   - Show the current active console editor (tests positron.window.activeConsoleEditor)',
+	'console watch    - Subscribe to onDidChangeActiveConsoleEditor and print each change',
+	'console watch stop - Stop watching for active console changes',
 	'connection X     - Create a database connection, optionally named X',
 	'connection close - Close a random database connection',
 	'code X Y         - Simulates a successful X line input with Y lines of output (where X >= 1 and Y >= 0)',
@@ -190,6 +193,11 @@ export class PositronZedRuntimeSession implements positron.LanguageRuntimeSessio
 	 * execution.
 	 */
 	private _busyInterruptSeconds: number;
+
+	/**
+	 * Disposable for the active `console watch` subscription; undefined when not watching.
+	 */
+	private _consoleWatchDisposable: vscode.Disposable | undefined;
 
 	/**
 	 * The number of seconds by which a shutdown should be delayed. This is used
@@ -935,6 +943,43 @@ export class PositronZedRuntimeSession implements positron.LanguageRuntimeSessio
 
 			case 'pwd': {
 				this.simulateSuccessfulCodeExecution(id, code, this._workingDirectory);
+				break;
+			}
+
+			case 'console active': {
+				const active = positron.window.activeConsoleEditor;
+				const msg = active
+					? `Active console: defined (session is live)`
+					: `Active console: none (no console is currently active)`;
+				this.simulateSuccessfulCodeExecution(id, code, msg);
+				break;
+			}
+
+			case 'console watch': {
+				if (this._consoleWatchDisposable) {
+					this.simulateSuccessfulCodeExecution(id, code, `Already watching. Use 'console watch stop' to stop.`);
+					break;
+				}
+				const watchId = id;
+				this._consoleWatchDisposable = positron.window.onDidChangeActiveConsoleEditor((activeConsole) => {
+					const msg = activeConsole
+						? `[console watch] Active console changed: defined`
+						: `[console watch] Active console changed: none`;
+					this.simulateOutputMessage(watchId, msg + '\n');
+				});
+				this.context.subscriptions.push(this._consoleWatchDisposable);
+				this.simulateSuccessfulCodeExecution(id, code, `Watching for active console changes. Switch consoles to see events. Use 'console watch stop' to stop.`);
+				break;
+			}
+
+			case 'console watch stop': {
+				if (this._consoleWatchDisposable) {
+					this._consoleWatchDisposable.dispose();
+					this._consoleWatchDisposable = undefined;
+					this.simulateSuccessfulCodeExecution(id, code, `Stopped watching for active console changes.`);
+				} else {
+					this.simulateSuccessfulCodeExecution(id, code, `Not currently watching. Use 'console watch' to start.`);
+				}
 				break;
 			}
 

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -54,7 +54,7 @@ const HelpLines = [
 	'busy X Y         - Simulates an interuptible busy state for X seconds that takes Y seconds to interrupt (default X = 5, Y = 1)',
 	'cd X             - Changes the current working directory to X, or to a random directory if X is not specified',
 	'clock            - Show a plot containing a clock, using the notebook renderer API',
-	'console active   - Show the current active console editor (tests positron.window.activeConsoleEditor)',
+	'console active   - Show the current active console editor URI, language, and text (tests positron.window.activeConsoleEditor)',
 	'console watch    - Subscribe to onDidChangeActiveConsoleEditor and print each change',
 	'console watch stop - Stop watching for active console changes',
 	'connection X     - Create a database connection, optionally named X',
@@ -947,10 +947,10 @@ export class PositronZedRuntimeSession implements positron.LanguageRuntimeSessio
 			}
 
 			case 'console active': {
-				const active = positron.window.activeConsoleEditor;
-				const msg = active
-					? `Active console: defined (session is live)`
-					: `Active console: none (no console is currently active)`;
+				const editor = positron.window.activeConsoleEditor;
+				const msg = editor
+					? `Active console editor: ${editor.document.uri.toString()}\nLanguage: ${editor.document.languageId}\nText: ${JSON.stringify(editor.document.getText())}`
+					: `Active console editor: none (no console is currently active)`;
 				this.simulateSuccessfulCodeExecution(id, code, msg);
 				break;
 			}
@@ -961,9 +961,9 @@ export class PositronZedRuntimeSession implements positron.LanguageRuntimeSessio
 					break;
 				}
 				const watchId = id;
-				this._consoleWatchDisposable = positron.window.onDidChangeActiveConsoleEditor((activeConsole) => {
-					const msg = activeConsole
-						? `[console watch] Active console changed: defined`
+				this._consoleWatchDisposable = positron.window.onDidChangeActiveConsoleEditor((editor) => {
+					const msg = editor
+						? `[console watch] Active console changed: ${editor.document.uri.toString()} (${editor.document.languageId})`
 						: `[console watch] Active console changed: none`;
 					this.simulateOutputMessage(watchId, msg + '\n');
 				});

--- a/package-lock.json
+++ b/package-lock.json
@@ -3678,15 +3678,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/watcher/node_modules/@parcel/watcher-linux-arm-musl": {
-      "optional": true
-    },
-    "node_modules/@parcel/watcher/node_modules/@parcel/watcher-linux-arm64-musl": {
-      "optional": true
-    },
-    "node_modules/@parcel/watcher/node_modules/@parcel/watcher-linux-x64-musl": {
-      "optional": true
-    },
     "node_modules/@parcel/watcher/node_modules/node-addon-api": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
@@ -22952,9 +22943,6 @@
         "cpu-features": "~0.0.10",
         "nan": "^2.23.0"
       }
-    },
-    "node_modules/ssh2/node_modules/cpu-features": {
-      "optional": true
     },
     "node_modules/stable": {
       "version": "0.1.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3678,6 +3678,15 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@parcel/watcher/node_modules/@parcel/watcher-linux-arm-musl": {
+      "optional": true
+    },
+    "node_modules/@parcel/watcher/node_modules/@parcel/watcher-linux-arm64-musl": {
+      "optional": true
+    },
+    "node_modules/@parcel/watcher/node_modules/@parcel/watcher-linux-x64-musl": {
+      "optional": true
+    },
     "node_modules/@parcel/watcher/node_modules/node-addon-api": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
@@ -22943,6 +22952,9 @@
         "cpu-features": "~0.0.10",
         "nan": "^2.23.0"
       }
+    },
+    "node_modules/ssh2/node_modules/cpu-features": {
+      "optional": true
     },
     "node_modules/stable": {
       "version": "0.1.8",

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2585,14 +2585,18 @@ declare module 'positron' {
 		export function getConsoleForLanguage(languageId: string): Thenable<Console | undefined>;
 
 		/**
-		 * The currently active console, or `undefined` if no console is active.
+		 * The currently active console editor, or `undefined` if no console is active.
+		 * Provides the full `vscode.TextEditor` API for the console input, including
+		 * `document`, `selection`, `edit()`, and `insertSnippet()`.
+		 *
+		 * Note: this editor is intentionally NOT `vscode.window.activeTextEditor`.
 		 */
-		export const activeConsoleEditor: Console | undefined;
+		export const activeConsoleEditor: vscode.TextEditor | undefined;
 
 		/**
-		 * An event that fires when the active console changes.
+		 * An event that fires when the active console editor changes.
 		 */
-		export const onDidChangeActiveConsoleEditor: vscode.Event<Console | undefined>;
+		export const onDidChangeActiveConsoleEditor: vscode.Event<vscode.TextEditor | undefined>;
 
 		/**
 		 * Fires when the width of the console input changes. The new width is passed as

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2585,6 +2585,16 @@ declare module 'positron' {
 		export function getConsoleForLanguage(languageId: string): Thenable<Console | undefined>;
 
 		/**
+		 * The currently active console, or `undefined` if no console is active.
+		 */
+		export const activeConsoleEditor: Console | undefined;
+
+		/**
+		 * An event that fires when the active console changes.
+		 */
+		export const onDidChangeActiveConsoleEditor: vscode.Event<Console | undefined>;
+
+		/**
 		 * Fires when the width of the console input changes. The new width is passed as
 		 * a number, which represents the number of characters that can fit in the
 		 * console horizontally.

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2585,16 +2585,21 @@ declare module 'positron' {
 		export function getConsoleForLanguage(languageId: string): Thenable<Console | undefined>;
 
 		/**
-		 * The currently active console editor, or `undefined` if no console is active.
-		 * Provides the full `vscode.TextEditor` API for the console input, including
-		 * `document`, `selection`, `edit()`, and `insertSnippet()`.
+		 * The currently active console editor, or `undefined` if no console is active or its
+		 * input has not mounted yet. Provides the full `vscode.TextEditor` API for the console
+		 * input, including `document`, `selection`, `edit()`, and `insertSnippet()`.
 		 *
-		 * Note: this editor is intentionally NOT `vscode.window.activeTextEditor`.
+		 * Note: the console editor is deliberately not surfaced through the standard `vscode`
+		 * editor APIs. It is never `vscode.window.activeTextEditor`, never appears in
+		 * `vscode.window.visibleTextEditors`, and never raises the
+		 * `vscode.window.onDidChangeTextEditor*` events. This property and
+		 * `onDidChangeActiveConsoleEditor` are the only way to reach it.
 		 */
 		export const activeConsoleEditor: vscode.TextEditor | undefined;
 
 		/**
-		 * An event that fires when the active console editor changes.
+		 * An event that fires when the active console editor changes, including when the active
+		 * console's input editor mounts or unmounts.
 		 */
 		export const onDidChangeActiveConsoleEditor: vscode.Event<vscode.TextEditor | undefined>;
 

--- a/src/vs/workbench/api/browser/mainThreadDocumentsAndEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadDocumentsAndEditors.ts
@@ -470,12 +470,19 @@ export class MainThreadDocumentsAndEditors implements IMainThreadEditorLocator, 
 			);
 
 			this._textEditors.set(id, editor);
-			this._mainThreadEditors.handleTextEditorAdded(editor);
+
+			// Order matters, and mirrors `_onDelta`: tell the ext host about the editor first, then
+			// wire up the dependent editor state. `handleTextEditorAdded` starts an autorun that
+			// immediately sends `$acceptEditorDiffInformation` for this id, and the ext host throws
+			// `unknown text editor` for any id it hasn't received an `addedEditors` delta for.
 			this._proxy.$acceptDocumentsAndEditorsDelta({
 				addedEditors: [this._toTextEditorAddData(editor)],
 			});
+			this._mainThreadEditors.handleTextEditorAdded(editor);
 
 			store.add(toDisposable(() => {
+				// Mirror image of registration: drop the listeners before the ext host forgets the
+				// editor, so nothing can send it state for an id it no longer knows.
 				this._textEditors.delete(id);
 				editor.dispose();
 				this._mainThreadEditors.handleTextEditorRemoved(id);

--- a/src/vs/workbench/api/browser/mainThreadDocumentsAndEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadDocumentsAndEditors.ts
@@ -454,33 +454,52 @@ export class MainThreadDocumentsAndEditors implements IMainThreadEditorLocator, 
 	 * @returns A disposable that removes the editor from the ext host when disposed
 	 */
 	registerConsoleEditor(id: string, codeEditor: ICodeEditor): IDisposable {
+		const store = new DisposableStore();
+
+		const doRegister = (model: ITextModel) => {
+			const editor = new MainThreadTextEditor(
+				id,
+				model,
+				codeEditor,
+				{ onGainedFocus() { }, onLostFocus() { } },
+				this._mainThreadDocuments,
+				this._modelService,
+				this._clipboardService,
+			);
+
+			this._textEditors.set(id, editor);
+			this._mainThreadEditors.handleTextEditorAdded(editor);
+			this._proxy.$acceptDocumentsAndEditorsDelta({
+				addedEditors: [this._toTextEditorAddData(editor)],
+			});
+
+			store.add(toDisposable(() => {
+				this._textEditors.delete(id);
+				editor.dispose();
+				this._mainThreadEditors.handleTextEditorRemoved(id);
+				this._proxy.$acceptDocumentsAndEditorsDelta({ removedEditors: [id] });
+			}));
+		};
+
 		const model = codeEditor.getModel();
-		if (!model) {
-			return toDisposable(() => { });
+		if (model) {
+			doRegister(model);
+		} else {
+			// The console input assigns its code editor before attaching the text model, so the
+			// model may not be present yet. Wait for it rather than silently skipping registration,
+			// otherwise `positron.window.activeConsoleEditor` would never resolve this editor.
+			const sub = store.add(codeEditor.onDidChangeModel(e => {
+				if (e.newModelUrl) {
+					const newModel = codeEditor.getModel();
+					if (newModel) {
+						sub.dispose();
+						doRegister(newModel);
+					}
+				}
+			}));
 		}
 
-		const editor = new MainThreadTextEditor(
-			id,
-			model,
-			codeEditor,
-			{ onGainedFocus() { }, onLostFocus() { } },
-			this._mainThreadDocuments,
-			this._modelService,
-			this._clipboardService,
-		);
-
-		this._textEditors.set(id, editor);
-		this._mainThreadEditors.handleTextEditorAdded(editor);
-		this._proxy.$acceptDocumentsAndEditorsDelta({
-			addedEditors: [this._toTextEditorAddData(editor)],
-		});
-
-		return toDisposable(() => {
-			this._textEditors.delete(id);
-			editor.dispose();
-			this._mainThreadEditors.handleTextEditorRemoved(id);
-			this._proxy.$acceptDocumentsAndEditorsDelta({ removedEditors: [id] });
-		});
+		return store;
 	}
 	// --- End Positron ---
 }

--- a/src/vs/workbench/api/browser/mainThreadDocumentsAndEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadDocumentsAndEditors.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Event } from '../../../base/common/event.js';
-import { combinedDisposable, DisposableStore, DisposableMap } from '../../../base/common/lifecycle.js';
+import { combinedDisposable, DisposableStore, DisposableMap, IDisposable, toDisposable } from '../../../base/common/lifecycle.js';
 import { ICodeEditor, isCodeEditor, isDiffEditor, IActiveCodeEditor } from '../../../editor/browser/editorBrowser.js';
 import { ICodeEditorService } from '../../../editor/browser/services/codeEditorService.js';
 import { IEditor } from '../../../editor/common/editorCommon.js';
@@ -33,6 +33,9 @@ import { IPaneCompositePartService } from '../../services/panecomposite/browser/
 import { ViewContainerLocation } from '../../common/views.js';
 import { IConfigurationService } from '../../../platform/configuration/common/configuration.js';
 import { IQuickDiffModelService } from '../../contrib/scm/browser/quickDiffModel.js';
+// --- Start Positron ---
+import { IMainThreadConsoleEditorManager, MainPositronContext } from '../common/positron/extHost.positron.protocol.js';
+// --- End Positron ---
 
 
 class TextEditorSnapshot {
@@ -274,7 +277,9 @@ class MainThreadDocumentAndEditorStateComputer {
 }
 
 @extHostCustomer
-export class MainThreadDocumentsAndEditors implements IMainThreadEditorLocator {
+// --- Start Positron ---
+export class MainThreadDocumentsAndEditors implements IMainThreadEditorLocator, IMainThreadConsoleEditorManager {
+// --- End Positron ---
 
 	private readonly _toDispose = new DisposableStore();
 	private readonly _proxy: ExtHostDocumentsAndEditorsShape;
@@ -310,6 +315,11 @@ export class MainThreadDocumentsAndEditors implements IMainThreadEditorLocator {
 
 		// It is expected that the ctor of the state computer calls our `_onDelta`.
 		this._toDispose.add(new MainThreadDocumentAndEditorStateComputer(delta => this._onDelta(delta), _modelService, codeEditorService, this._editorService, paneCompositeService));
+
+		// --- Start Positron ---
+		// Register this instance so MainThreadConsoleService can reach it via getRaw.
+		extHostContext.set(MainPositronContext.MainThreadConsoleEditorManager, this);
+		// --- End Positron ---
 	}
 
 	dispose(): void {
@@ -433,4 +443,44 @@ export class MainThreadDocumentsAndEditors implements IMainThreadEditorLocator {
 	getEditor(id: string): MainThreadTextEditor | undefined {
 		return this._textEditors.get(id);
 	}
+
+	// --- Start Positron ---
+	/**
+	 * Registers a console input editor so it is accessible as a `vscode.TextEditor` via
+	 * `positron.window.activeConsoleEditor`. The editor is NOT set as `vscode.window.activeTextEditor`.
+	 *
+	 * @param id A stable id for this editor (e.g. `console-<sessionId>`)
+	 * @param codeEditor The Monaco editor backing the console input
+	 * @returns A disposable that removes the editor from the ext host when disposed
+	 */
+	registerConsoleEditor(id: string, codeEditor: ICodeEditor): IDisposable {
+		const model = codeEditor.getModel();
+		if (!model) {
+			return toDisposable(() => { });
+		}
+
+		const editor = new MainThreadTextEditor(
+			id,
+			model,
+			codeEditor,
+			{ onGainedFocus() { }, onLostFocus() { } },
+			this._mainThreadDocuments,
+			this._modelService,
+			this._clipboardService,
+		);
+
+		this._textEditors.set(id, editor);
+		this._mainThreadEditors.handleTextEditorAdded(editor);
+		this._proxy.$acceptDocumentsAndEditorsDelta({
+			addedEditors: [this._toTextEditorAddData(editor)],
+		});
+
+		return toDisposable(() => {
+			this._textEditors.delete(id);
+			editor.dispose();
+			this._mainThreadEditors.handleTextEditorRemoved(id);
+			this._proxy.$acceptDocumentsAndEditorsDelta({ removedEditors: [id] });
+		});
+	}
+	// --- End Positron ---
 }

--- a/src/vs/workbench/api/browser/mainThreadDocumentsAndEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadDocumentsAndEditors.ts
@@ -4,7 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Event } from '../../../base/common/event.js';
+// --- Start Positron ---
+// Added `IDisposable` and `toDisposable` for `registerConsoleEditor` below. Extended in place
+// rather than imported separately to avoid a duplicate import of `lifecycle.js`.
+// import { combinedDisposable, DisposableStore, DisposableMap } from '../../../base/common/lifecycle.js';
 import { combinedDisposable, DisposableStore, DisposableMap, IDisposable, toDisposable } from '../../../base/common/lifecycle.js';
+// --- End Positron ---
 import { ICodeEditor, isCodeEditor, isDiffEditor, IActiveCodeEditor } from '../../../editor/browser/editorBrowser.js';
 import { ICodeEditorService } from '../../../editor/browser/services/codeEditorService.js';
 import { IEditor } from '../../../editor/common/editorCommon.js';
@@ -34,6 +39,8 @@ import { ViewContainerLocation } from '../../common/views.js';
 import { IConfigurationService } from '../../../platform/configuration/common/configuration.js';
 import { IQuickDiffModelService } from '../../contrib/scm/browser/quickDiffModel.js';
 // --- Start Positron ---
+// Used by `registerConsoleEditor`, which exposes the console input editor to the extension host
+// as a `vscode.TextEditor`.
 import { IMainThreadConsoleEditorManager, MainPositronContext } from '../common/positron/extHost.positron.protocol.js';
 // --- End Positron ---
 
@@ -278,6 +285,9 @@ class MainThreadDocumentAndEditorStateComputer {
 
 @extHostCustomer
 // --- Start Positron ---
+// Additionally implement IMainThreadConsoleEditorManager so MainThreadConsoleService can register
+// console input editors with the extension host (see `registerConsoleEditor` below).
+// export class MainThreadDocumentsAndEditors implements IMainThreadEditorLocator {
 export class MainThreadDocumentsAndEditors implements IMainThreadEditorLocator, IMainThreadConsoleEditorManager {
 	// --- End Positron ---
 

--- a/src/vs/workbench/api/browser/mainThreadDocumentsAndEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadDocumentsAndEditors.ts
@@ -4,12 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Event } from '../../../base/common/event.js';
-// --- Start Positron ---
-// Added `IDisposable` and `toDisposable` for `registerConsoleEditor` below. Extended in place
-// rather than imported separately to avoid a duplicate import of `lifecycle.js`.
-// import { combinedDisposable, DisposableStore, DisposableMap } from '../../../base/common/lifecycle.js';
-import { combinedDisposable, DisposableStore, DisposableMap, IDisposable, toDisposable } from '../../../base/common/lifecycle.js';
-// --- End Positron ---
+import { combinedDisposable, DisposableStore, DisposableMap } from '../../../base/common/lifecycle.js';
 import { ICodeEditor, isCodeEditor, isDiffEditor, IActiveCodeEditor } from '../../../editor/browser/editorBrowser.js';
 import { ICodeEditorService } from '../../../editor/browser/services/codeEditorService.js';
 import { IEditor } from '../../../editor/common/editorCommon.js';
@@ -39,9 +34,9 @@ import { ViewContainerLocation } from '../../common/views.js';
 import { IConfigurationService } from '../../../platform/configuration/common/configuration.js';
 import { IQuickDiffModelService } from '../../contrib/scm/browser/quickDiffModel.js';
 // --- Start Positron ---
-// Used by `registerConsoleEditor`, which exposes the console input editor to the extension host
-// as a `vscode.TextEditor`.
-import { IMainThreadConsoleEditorManager, MainPositronContext } from '../common/positron/extHost.positron.protocol.js';
+// Used by `registerHiddenTextEditor`, which lets Positron expose an editor to the extension host
+// without adding it to the core documents-and-editors state.
+import { IHiddenTextEditorRegistration, IMainThreadHiddenEditorManager, MainPositronContext } from '../common/positron/extHost.positron.protocol.js';
 // --- End Positron ---
 
 
@@ -285,10 +280,11 @@ class MainThreadDocumentAndEditorStateComputer {
 
 @extHostCustomer
 // --- Start Positron ---
-// Additionally implement IMainThreadConsoleEditorManager so MainThreadConsoleService can register
-// console input editors with the extension host (see `registerConsoleEditor` below).
+// Additionally implement IMainThreadHiddenEditorManager so MainThreadConsoleService can register
+// the console input editor without it leaking into core editor APIs (see
+// `registerHiddenTextEditor` below).
 // export class MainThreadDocumentsAndEditors implements IMainThreadEditorLocator {
-export class MainThreadDocumentsAndEditors implements IMainThreadEditorLocator, IMainThreadConsoleEditorManager {
+export class MainThreadDocumentsAndEditors implements IMainThreadEditorLocator, IMainThreadHiddenEditorManager {
 	// --- End Positron ---
 
 	private readonly _toDispose = new DisposableStore();
@@ -328,7 +324,7 @@ export class MainThreadDocumentsAndEditors implements IMainThreadEditorLocator, 
 
 		// --- Start Positron ---
 		// Register this instance so MainThreadConsoleService can reach it via getRaw.
-		extHostContext.set(MainPositronContext.MainThreadConsoleEditorManager, this);
+		extHostContext.set(MainPositronContext.MainThreadHiddenEditorManager, this);
 		// --- End Positron ---
 	}
 
@@ -456,73 +452,39 @@ export class MainThreadDocumentsAndEditors implements IMainThreadEditorLocator, 
 
 	// --- Start Positron ---
 	/**
-	 * Registers a console input editor so it is accessible as a `vscode.TextEditor` via
-	 * `positron.window.activeConsoleEditor`. The editor is NOT set as `vscode.window.activeTextEditor`.
+	 * Registers an editor that is deliberately hidden from the core editor pipeline: it is never
+	 * sent through `$acceptDocumentsAndEditorsDelta`, so it does not appear in
+	 * `vscode.window.visibleTextEditors`, never becomes `vscode.window.activeTextEditor`, and
+	 * never raises `vscode.window.onDidChangeTextEditorSelection` and friends.
 	 *
-	 * @param id A stable id for this editor (e.g. `console-<sessionId>`)
-	 * @param codeEditor The Monaco editor backing the console input
-	 * @param onRegistered Invoked once the editor has been sent to the ext host. Registration is
-	 * deferred until the code editor has a text model, so this may run after this method returns.
-	 * @returns A disposable that removes the editor from the ext host when disposed
+	 * The editor is only added to the main-thread editor map, so that operations the extension host
+	 * addresses by id (`edit()`, `insertSnippet()`, selection writes) can resolve it. It is up to
+	 * the caller to forward `addData` and `onPropertiesChanged` to the extension host over a
+	 * Positron-specific channel; see `MainThreadConsoleService` for the console input editor that
+	 * backs `positron.window.activeConsoleEditor`.
 	 */
-	registerConsoleEditor(id: string, codeEditor: ICodeEditor, onRegistered?: () => void): IDisposable {
-		const store = new DisposableStore();
+	registerHiddenTextEditor(id: string, codeEditor: ICodeEditor, model: ITextModel): IHiddenTextEditorRegistration {
+		const editor = new MainThreadTextEditor(
+			id,
+			model,
+			codeEditor,
+			{ onGainedFocus() { }, onLostFocus() { } },
+			this._mainThreadDocuments,
+			this._modelService,
+			this._clipboardService,
+		);
+		this._textEditors.set(id, editor);
 
-		const doRegister = (model: ITextModel) => {
-			const editor = new MainThreadTextEditor(
-				id,
-				model,
-				codeEditor,
-				{ onGainedFocus() { }, onLostFocus() { } },
-				this._mainThreadDocuments,
-				this._modelService,
-				this._clipboardService,
-			);
-
-			this._textEditors.set(id, editor);
-
-			// Order matters, and mirrors `_onDelta`: tell the ext host about the editor first, then
-			// wire up the dependent editor state. `handleTextEditorAdded` starts an autorun that
-			// immediately sends `$acceptEditorDiffInformation` for this id, and the ext host throws
-			// `unknown text editor` for any id it hasn't received an `addedEditors` delta for.
-			this._proxy.$acceptDocumentsAndEditorsDelta({
-				addedEditors: [this._toTextEditorAddData(editor)],
-			});
-			this._mainThreadEditors.handleTextEditorAdded(editor);
-
-			store.add(toDisposable(() => {
-				// Mirror image of registration: drop the listeners before the ext host forgets the
-				// editor, so nothing can send it state for an id it no longer knows.
+		return {
+			addData: this._toTextEditorAddData(editor),
+			onPropertiesChanged: editor.onPropertiesChanged,
+			dispose: () => {
 				this._textEditors.delete(id);
+				// Disposing the editor also disposes its `onPropertiesChanged` emitter, so no
+				// further state can be forwarded for an id the caller is about to retire.
 				editor.dispose();
-				this._mainThreadEditors.handleTextEditorRemoved(id);
-				this._proxy.$acceptDocumentsAndEditorsDelta({ removedEditors: [id] });
-			}));
-
-			// Notify the caller last, so that anything it sends to the ext host (e.g. the active
-			// console editor id) arrives after the delta that makes the editor resolvable there.
-			onRegistered?.();
+			}
 		};
-
-		const model = codeEditor.getModel();
-		if (model) {
-			doRegister(model);
-		} else {
-			// The console input assigns its code editor before attaching the text model, so the
-			// model may not be present yet. Wait for it rather than silently skipping registration,
-			// otherwise `positron.window.activeConsoleEditor` would never resolve this editor.
-			const sub = store.add(codeEditor.onDidChangeModel(e => {
-				if (e.newModelUrl) {
-					const newModel = codeEditor.getModel();
-					if (newModel) {
-						sub.dispose();
-						doRegister(newModel);
-					}
-				}
-			}));
-		}
-
-		return store;
 	}
 	// --- End Positron ---
 }

--- a/src/vs/workbench/api/browser/mainThreadDocumentsAndEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadDocumentsAndEditors.ts
@@ -279,7 +279,7 @@ class MainThreadDocumentAndEditorStateComputer {
 @extHostCustomer
 // --- Start Positron ---
 export class MainThreadDocumentsAndEditors implements IMainThreadEditorLocator, IMainThreadConsoleEditorManager {
-// --- End Positron ---
+	// --- End Positron ---
 
 	private readonly _toDispose = new DisposableStore();
 	private readonly _proxy: ExtHostDocumentsAndEditorsShape;
@@ -451,9 +451,11 @@ export class MainThreadDocumentsAndEditors implements IMainThreadEditorLocator, 
 	 *
 	 * @param id A stable id for this editor (e.g. `console-<sessionId>`)
 	 * @param codeEditor The Monaco editor backing the console input
+	 * @param onRegistered Invoked once the editor has been sent to the ext host. Registration is
+	 * deferred until the code editor has a text model, so this may run after this method returns.
 	 * @returns A disposable that removes the editor from the ext host when disposed
 	 */
-	registerConsoleEditor(id: string, codeEditor: ICodeEditor): IDisposable {
+	registerConsoleEditor(id: string, codeEditor: ICodeEditor, onRegistered?: () => void): IDisposable {
 		const store = new DisposableStore();
 
 		const doRegister = (model: ITextModel) => {
@@ -479,6 +481,10 @@ export class MainThreadDocumentsAndEditors implements IMainThreadEditorLocator, 
 				this._mainThreadEditors.handleTextEditorRemoved(id);
 				this._proxy.$acceptDocumentsAndEditorsDelta({ removedEditors: [id] });
 			}));
+
+			// Notify the caller last, so that anything it sends to the ext host (e.g. the active
+			// console editor id) arrives after the delta that makes the editor resolvable there.
+			onRegistered?.();
 		};
 
 		const model = codeEditor.getModel();

--- a/src/vs/workbench/api/browser/positron/mainThreadConsoleService.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadConsoleService.ts
@@ -28,6 +28,12 @@ export class MainThreadConsoleService implements MainThreadConsoleServiceShape {
 	/** Disposables for registered console text editors, keyed by session id. */
 	private readonly _consoleEditorDisposables = new Map<string, MutableDisposable<IDisposable>>();
 
+	/** Session ids whose console text editor is known to the extension host. */
+	private readonly _registeredConsoleEditors = new Set<string>();
+
+	/** The last editor id sent to the extension host, used to suppress duplicate notifications. */
+	private _notifiedConsoleEditorId: string | null = null;
+
 	private readonly _proxy: ExtHostConsoleServiceShape;
 
 	constructor(
@@ -129,7 +135,17 @@ export class MainThreadConsoleService implements MainThreadConsoleServiceShape {
 			const mutable = new MutableDisposable<IDisposable>();
 			this._consoleEditorDisposables.set(sessionId, mutable);
 			this._disposables.add(mutable);
-			mutable.value = manager.registerConsoleEditor(editorId, instance.codeEditor!);
+			// Registration is deferred until the code editor has a text model, so the editor is
+			// only resolvable in the ext host once `onRegistered` runs. Notifying any earlier
+			// would fire `onDidChangeActiveConsoleEditor` with an unresolvable editor.
+			mutable.value = manager.registerConsoleEditor(editorId, instance.codeEditor!, () => {
+				this._registeredConsoleEditors.add(sessionId);
+
+				// If this instance is the active console, notify now.
+				if (this._positronConsoleService.activePositronConsoleInstance === instance) {
+					this._setActiveConsoleEditor(editorId);
+				}
+			});
 		};
 
 		if (instance.codeEditor) {
@@ -141,11 +157,6 @@ export class MainThreadConsoleService implements MainThreadConsoleServiceShape {
 			const sub = instance.onDidSetCodeEditor(() => {
 				sub.dispose();
 				doRegister();
-
-				// If this instance is already the active console, notify now.
-				if (this._positronConsoleService.activePositronConsoleInstance === instance) {
-					this._proxy.$setActiveConsoleEditor(editorId);
-				}
 			});
 			this._disposables.add(sub);
 		}
@@ -157,16 +168,29 @@ export class MainThreadConsoleService implements MainThreadConsoleServiceShape {
 	 */
 	private _notifyActiveConsoleEditor(instance: IPositronConsoleInstance | undefined): void {
 		if (!instance) {
-			this._proxy.$setActiveConsoleEditor(null);
+			this._setActiveConsoleEditor(null);
 			return;
 		}
 		const sessionId = instance.sessionMetadata.sessionId;
-		const editorId = `console-${sessionId}`;
-		// Only notify if the editor has been registered (codeEditor is set).
-		if (instance.codeEditor && this._consoleEditorDisposables.has(sessionId)) {
-			this._proxy.$setActiveConsoleEditor(editorId);
+		// Only notify with an editor id once the ext host knows about the editor; until then the
+		// active console has no resolvable editor. `_registerConsoleEditor` notifies once it does.
+		if (this._registeredConsoleEditors.has(sessionId)) {
+			this._setActiveConsoleEditor(`console-${sessionId}`);
+		} else {
+			this._setActiveConsoleEditor(null);
 		}
-		// If codeEditor isn't set yet, _registerConsoleEditor will notify once it mounts.
+	}
+
+	/**
+	 * Sends the active console editor id to the extension host, skipping notifications that
+	 * wouldn't change the value the extension host already has.
+	 */
+	private _setActiveConsoleEditor(editorId: string | null): void {
+		if (this._notifiedConsoleEditorId === editorId) {
+			return;
+		}
+		this._notifiedConsoleEditorId = editorId;
+		this._proxy.$setActiveConsoleEditor(editorId);
 	}
 
 	// --- from extension host process

--- a/src/vs/workbench/api/browser/positron/mainThreadConsoleService.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadConsoleService.ts
@@ -3,8 +3,10 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DisposableStore, IDisposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
-import { ExtHostConsoleServiceShape, ExtHostPositronContext, IMainThreadConsoleEditorManager, MainPositronContext, MainThreadConsoleServiceShape } from '../../common/positron/extHost.positron.protocol.js';
+import { DisposableMap, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
+import { ITextModel } from '../../../../editor/common/model.js';
+import { ExtHostConsoleServiceShape, ExtHostPositronContext, IMainThreadHiddenEditorManager, MainPositronContext, MainThreadConsoleServiceShape } from '../../common/positron/extHost.positron.protocol.js';
 import { extHostNamedCustomer, IExtHostContext } from '../../../services/extensions/common/extHostCustomers.js';
 import { IPositronConsoleInstance, IPositronConsoleService } from '../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
 import { MainThreadConsole } from './mainThreadConsole.js';
@@ -25,16 +27,20 @@ export class MainThreadConsoleService implements MainThreadConsoleServiceShape {
 	 */
 	private readonly _mainThreadConsolesBySessionId = new Map<string, MainThreadConsole>();
 
-	/** Disposables for registered console text editors, keyed by session id. */
-	private readonly _consoleEditorDisposables = new Map<string, MutableDisposable<IDisposable>>();
-
-	/** Session ids whose console text editor is known to the extension host. */
-	private readonly _registeredConsoleEditors = new Set<string>();
-
-	/** The last editor id sent to the extension host, used to suppress duplicate notifications. */
-	private _notifiedConsoleEditorId: string | null = null;
+	/**
+	 * Console input editor tracking, keyed by session id. Each entry owns the current editor
+	 * registration plus the subscription that re-registers it when the Console view remounts, and
+	 * is disposed when the console is deleted.
+	 */
+	private readonly _consoleEditorTracking = this._disposables.add(new DisposableMap<string>());
 
 	private readonly _proxy: ExtHostConsoleServiceShape;
+
+	/**
+	 * Lets us register the console input editor with the extension host without it entering the
+	 * core documents-and-editors state.
+	 */
+	private readonly _hiddenEditorManager: IMainThreadHiddenEditorManager;
 
 	constructor(
 		extHostContext: IExtHostContext,
@@ -42,6 +48,10 @@ export class MainThreadConsoleService implements MainThreadConsoleServiceShape {
 	) {
 		// Create the proxy for the extension host.
 		this._proxy = extHostContext.getProxy(ExtHostPositronContext.ExtHostConsoleService);
+
+		this._hiddenEditorManager = extHostContext.getRaw<IMainThreadHiddenEditorManager, IMainThreadHiddenEditorManager>(
+			MainPositronContext.MainThreadHiddenEditorManager
+		);
 
 		// Register to be notified of changes to the console width; when they are
 		// received, forward them to the extension host so extensions can be
@@ -55,20 +65,15 @@ export class MainThreadConsoleService implements MainThreadConsoleServiceShape {
 		// in the main thread too
 		this._disposables.add(
 			this._positronConsoleService.onDidStartPositronConsoleInstance((console) => {
-				const sessionId = console.sessionMetadata.sessionId;
+				this._addConsole(console);
+			})
+		);
 
-				// First update ext host
-				this._proxy.$addConsole(sessionId);
-
-				// Then update main thread
-				this.addConsole(sessionId, console);
-
-				// Register the console's Monaco editor with the text editor tracking so
-				// extensions can access it via positron.window.activeConsoleEditor.
-				const manager = extHostContext.getRaw<IMainThreadConsoleEditorManager, IMainThreadConsoleEditorManager>(
-					MainPositronContext.MainThreadConsoleEditorManager
-				);
-				this._registerConsoleEditor(console, manager);
+		// Retire the console's editor registration when the console goes away, so the extension
+		// host cannot keep handing out a `TextEditor` for a disposed console.
+		this._disposables.add(
+			this._positronConsoleService.onDidDeletePositronConsoleInstance((console) => {
+				this._consoleEditorTracking.deleteAndDispose(console.sessionMetadata.sessionId);
 			})
 		);
 
@@ -76,9 +81,20 @@ export class MainThreadConsoleService implements MainThreadConsoleServiceShape {
 		this._disposables.add(
 			this._positronConsoleService.onDidChangeActivePositronConsoleInstance((instance) => {
 				this._proxy.$onDidChangeActiveConsole(instance?.sessionId);
-				this._notifyActiveConsoleEditor(instance);
 			})
 		);
+
+		// Replay the consoles that already exist. This service is recreated whenever the extension
+		// host restarts, and consoles started before that never re-fire
+		// `onDidStartPositronConsoleInstance`, so without this the extension host would never learn
+		// about a console that is already running.
+		for (const instance of this._positronConsoleService.positronConsoleInstances) {
+			this._addConsole(instance);
+		}
+		const activeInstance = this._positronConsoleService.activePositronConsoleInstance;
+		if (activeInstance) {
+			this._proxy.$onDidChangeActiveConsole(activeInstance.sessionId);
+		}
 
 		// TODO:
 		// As of right now, we never delete console instances from the maps in
@@ -86,6 +102,8 @@ export class MainThreadConsoleService implements MainThreadConsoleServiceShape {
 		// know when a console is stopped. In particular, we should really call the `ExtHostConsole`
 		// `dispose()` method, which will ensure that any API callers who use the corresponding
 		// `Console` object will get a warning / error when calling the API of a closed console.
+		// (Note that the console's *editor* registration is cleaned up on
+		// `onDidDeletePositronConsoleInstance` above; it is the `Console` object that outlives it.)
 		//
 		// this._disposables.add(
 		// 	this._positronConsoleService.onDidRemovePositronConsoleInstance((console) => {
@@ -102,14 +120,20 @@ export class MainThreadConsoleService implements MainThreadConsoleServiceShape {
 
 	dispose(): void {
 		this._disposables.dispose();
-		for (const d of this._consoleEditorDisposables.values()) {
-			d.dispose();
-		}
 	}
 
-	private addConsole(sessionId: string, console: IPositronConsoleInstance) {
-		const mainThreadConsole = new MainThreadConsole(console);
-		this._mainThreadConsolesBySessionId.set(sessionId, mainThreadConsole);
+	private _addConsole(instance: IPositronConsoleInstance): void {
+		const sessionId = instance.sessionMetadata.sessionId;
+
+		// First update ext host
+		this._proxy.$addConsole(sessionId);
+
+		// Then update main thread
+		this._mainThreadConsolesBySessionId.set(sessionId, new MainThreadConsole(instance));
+
+		// Finally, expose the console's Monaco editor to extensions so they can reach it via
+		// `positron.window.activeConsoleEditor`.
+		this._trackConsoleEditor(instance);
 	}
 
 	// TODO:
@@ -121,76 +145,80 @@ export class MainThreadConsoleService implements MainThreadConsoleServiceShape {
 	// }
 
 	/**
-	 * Registers the Monaco editor for `instance` with the text editor tracking pipeline so
-	 * that extensions can use `positron.window.activeConsoleEditor` to access a full
-	 * `vscode.TextEditor` for the console input.
+	 * Keeps the extension host's view of `instance`'s input editor up to date for the lifetime of
+	 * the console.
 	 *
-	 * The editor is intentionally NOT set as `vscode.window.activeTextEditor`.
+	 * The Console view can remount -- moving the pane, or recreating it, builds a fresh Monaco
+	 * editor and text model -- so we stay subscribed to `onDidSetCodeEditor` and replace the
+	 * registration each time rather than registering only the first editor.
 	 */
-	private _registerConsoleEditor(instance: IPositronConsoleInstance, manager: IMainThreadConsoleEditorManager): void {
+	private _trackConsoleEditor(instance: IPositronConsoleInstance): void {
 		const sessionId = instance.sessionMetadata.sessionId;
-		const editorId = `console-${sessionId}`;
+		const tracking = new DisposableStore();
 
-		const doRegister = () => {
-			const mutable = new MutableDisposable<IDisposable>();
-			this._consoleEditorDisposables.set(sessionId, mutable);
-			this._disposables.add(mutable);
-			// Registration is deferred until the code editor has a text model, so the editor is
-			// only resolvable in the ext host once `onRegistered` runs. Notifying any earlier
-			// would fire `onDidChangeActiveConsoleEditor` with an unresolvable editor.
-			mutable.value = manager.registerConsoleEditor(editorId, instance.codeEditor!, () => {
-				this._registeredConsoleEditors.add(sessionId);
+		// Holds the registration for the console's current code editor; assigning replaces (and
+		// disposes) the registration for the previous one.
+		const registration = tracking.add(new MutableDisposable<IDisposable>());
 
-				// If this instance is the active console, notify now.
-				if (this._positronConsoleService.activePositronConsoleInstance === instance) {
-					this._setActiveConsoleEditor(editorId);
-				}
-			});
-		};
+		tracking.add(instance.onDidSetCodeEditor((codeEditor) => {
+			registration.value = this._registerConsoleEditor(sessionId, codeEditor);
+		}));
 
 		if (instance.codeEditor) {
-			// Editor already mounted — register immediately.
-			doRegister();
-		} else {
-			// Editor not yet mounted (React component hasn't mounted yet).
-			// Wait for the first assignment.
-			const sub = instance.onDidSetCodeEditor(() => {
-				sub.dispose();
-				doRegister();
-			});
-			this._disposables.add(sub);
+			// The editor is already mounted, so `onDidSetCodeEditor` has already fired for it.
+			registration.value = this._registerConsoleEditor(sessionId, instance.codeEditor);
 		}
+
+		// Replaces (and disposes) any tracking left over from a previous session with this id.
+		this._consoleEditorTracking.set(sessionId, tracking);
 	}
 
 	/**
-	 * Notifies the extension host of the active console editor id so
-	 * `positron.window.activeConsoleEditor` can be updated.
+	 * Registers a single console input editor with the extension host, and returns a disposable
+	 * that retires it again.
 	 */
-	private _notifyActiveConsoleEditor(instance: IPositronConsoleInstance | undefined): void {
-		if (!instance) {
-			this._setActiveConsoleEditor(null);
-			return;
-		}
-		const sessionId = instance.sessionMetadata.sessionId;
-		// Only notify with an editor id once the ext host knows about the editor; until then the
-		// active console has no resolvable editor. `_registerConsoleEditor` notifies once it does.
-		if (this._registeredConsoleEditors.has(sessionId)) {
-			this._setActiveConsoleEditor(`console-${sessionId}`);
-		} else {
-			this._setActiveConsoleEditor(null);
-		}
-	}
+	private _registerConsoleEditor(sessionId: string, codeEditor: ICodeEditor): IDisposable {
+		const store = new DisposableStore();
+		const editorId = `console-${sessionId}`;
 
-	/**
-	 * Sends the active console editor id to the extension host, skipping notifications that
-	 * wouldn't change the value the extension host already has.
-	 */
-	private _setActiveConsoleEditor(editorId: string | null): void {
-		if (this._notifiedConsoleEditorId === editorId) {
-			return;
+		const doRegister = (model: ITextModel) => {
+			const registration = store.add(this._hiddenEditorManager.registerHiddenTextEditor(editorId, codeEditor, model));
+
+			// The editor travels over the Positron-only console channel, never through
+			// `$acceptDocumentsAndEditorsDelta`, so it stays out of `visibleTextEditors` and the
+			// core editor events (posit-dev/positron#780).
+			this._proxy.$addConsoleEditor(sessionId, registration.addData);
+			store.add(registration.onPropertiesChanged((data) => {
+				this._proxy.$acceptConsoleEditorPropertiesChanged(sessionId, data);
+			}));
+
+			// Added last so it is disposed last: the extension host is told to forget the editor
+			// only after the main thread has stopped producing state for it.
+			store.add(toDisposable(() => this._proxy.$removeConsoleEditor(sessionId)));
+		};
+
+		// Unmounting the Console view disposes the editor without clearing
+		// `IPositronConsoleInstance.codeEditor`, so retire the registration here rather than let
+		// the extension host keep resolving a disposed editor until a new one mounts.
+		store.add(codeEditor.onDidDispose(() => store.dispose()));
+
+		const model = codeEditor.getModel();
+		if (model) {
+			doRegister(model);
+		} else {
+			// The console input assigns its code editor before attaching the text model. Wait for
+			// the model rather than skipping registration, otherwise the editor would never be
+			// resolvable through `positron.window.activeConsoleEditor`.
+			const modelListener = store.add(codeEditor.onDidChangeModel(() => {
+				const newModel = codeEditor.getModel();
+				if (newModel) {
+					modelListener.dispose();
+					doRegister(newModel);
+				}
+			}));
 		}
-		this._notifiedConsoleEditorId = editorId;
-		this._proxy.$setActiveConsoleEditor(editorId);
+
+		return store;
 	}
 
 	// --- from extension host process

--- a/src/vs/workbench/api/browser/positron/mainThreadConsoleService.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadConsoleService.ts
@@ -56,6 +56,13 @@ export class MainThreadConsoleService implements MainThreadConsoleServiceShape {
 			})
 		);
 
+		// Forward active console changes to the extension host
+		this._disposables.add(
+			this._positronConsoleService.onDidChangeActivePositronConsoleInstance((instance) => {
+				this._proxy.$onDidChangeActiveConsole(instance?.sessionId);
+			})
+		);
+
 		// TODO:
 		// As of right now, we never delete console instances from the maps in
 		// `MainThreadConsoleService` and `ExtHostConsoleService` because we don't have a hook to
@@ -122,6 +129,10 @@ export class MainThreadConsoleService implements MainThreadConsoleServiceShape {
 		}
 
 		return Promise.resolve(undefined);
+	}
+
+	$getActiveConsoleSessionId(): Promise<string | undefined> {
+		return Promise.resolve(this._positronConsoleService.activePositronConsoleInstance?.sessionId);
 	}
 
 	$tryPasteText(sessionId: string, text: string): void {

--- a/src/vs/workbench/api/browser/positron/mainThreadConsoleService.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadConsoleService.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Lazy } from '../../../../base/common/lazy.js';
 import { DisposableMap, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
 import { ITextModel } from '../../../../editor/common/model.js';
@@ -39,8 +40,14 @@ export class MainThreadConsoleService implements MainThreadConsoleServiceShape {
 	/**
 	 * Lets us register the console input editor with the extension host without it entering the
 	 * core documents-and-editors state.
+	 *
+	 * Resolved lazily, on first registration: the actor is set by `MainThreadDocumentsAndEditors`,
+	 * a plain `@extHostCustomer`, and those are constructed after the named customers this class is
+	 * one of (`ExtensionHostManager._createExtensionHostCustomers`). Resolving it in the constructor
+	 * would throw (`RPCProtocol.getRaw` requires the actor to be set), and the thrown error is
+	 * swallowed by the customer loop -- taking this service's whole RPC channel down with it.
 	 */
-	private readonly _hiddenEditorManager: IMainThreadHiddenEditorManager;
+	private readonly _hiddenEditorManager: Lazy<IMainThreadHiddenEditorManager>;
 
 	constructor(
 		extHostContext: IExtHostContext,
@@ -49,9 +56,10 @@ export class MainThreadConsoleService implements MainThreadConsoleServiceShape {
 		// Create the proxy for the extension host.
 		this._proxy = extHostContext.getProxy(ExtHostPositronContext.ExtHostConsoleService);
 
-		this._hiddenEditorManager = extHostContext.getRaw<IMainThreadHiddenEditorManager, IMainThreadHiddenEditorManager>(
-			MainPositronContext.MainThreadHiddenEditorManager
-		);
+		this._hiddenEditorManager = new Lazy(() =>
+			extHostContext.getRaw<IMainThreadHiddenEditorManager, IMainThreadHiddenEditorManager>(
+				MainPositronContext.MainThreadHiddenEditorManager
+			));
 
 		// Register to be notified of changes to the console width; when they are
 		// received, forward them to the extension host so extensions can be
@@ -84,17 +92,7 @@ export class MainThreadConsoleService implements MainThreadConsoleServiceShape {
 			})
 		);
 
-		// Replay the consoles that already exist. This service is recreated whenever the extension
-		// host restarts, and consoles started before that never re-fire
-		// `onDidStartPositronConsoleInstance`, so without this the extension host would never learn
-		// about a console that is already running.
-		for (const instance of this._positronConsoleService.positronConsoleInstances) {
-			this._addConsole(instance);
-		}
-		const activeInstance = this._positronConsoleService.activePositronConsoleInstance;
-		if (activeInstance) {
-			this._proxy.$onDidChangeActiveConsole(activeInstance.sessionId);
-		}
+		this._replayExistingConsoles();
 
 		// TODO:
 		// As of right now, we never delete console instances from the maps in
@@ -120,6 +118,41 @@ export class MainThreadConsoleService implements MainThreadConsoleServiceShape {
 
 	dispose(): void {
 		this._disposables.dispose();
+	}
+
+	/**
+	 * Announces the consoles that already exist to the extension host. This service is recreated
+	 * whenever the extension host restarts, and consoles started before that never re-fire
+	 * `onDidStartPositronConsoleInstance`, so without this the extension host would never learn
+	 * about a console that is already running.
+	 *
+	 * Deferred to a microtask, i.e. until after every extension host customer has been constructed.
+	 * The console input's *document* only reaches the extension host in the first
+	 * `$acceptDocumentsAndEditorsDelta`, which `MainThreadDocumentsAndEditors` sends from its own
+	 * constructor -- and being a plain `@extHostCustomer` it is constructed after named customers
+	 * like this one. Replaying during construction would put `$addConsoleEditor` ahead of that delta
+	 * on the wire, and the extension host drops an editor whose document it does not have yet.
+	 */
+	private _replayExistingConsoles(): void {
+		queueMicrotask(() => {
+			if (this._disposables.isDisposed) {
+				return;
+			}
+
+			for (const instance of this._positronConsoleService.positronConsoleInstances) {
+				if (this._mainThreadConsolesBySessionId.has(instance.sessionMetadata.sessionId)) {
+					// Started while the replay was pending, so
+					// `onDidStartPositronConsoleInstance` already announced it.
+					continue;
+				}
+				this._addConsole(instance);
+			}
+
+			const activeInstance = this._positronConsoleService.activePositronConsoleInstance;
+			if (activeInstance) {
+				this._proxy.$onDidChangeActiveConsole(activeInstance.sessionId);
+			}
+		});
 	}
 
 	private _addConsole(instance: IPositronConsoleInstance): void {
@@ -154,22 +187,32 @@ export class MainThreadConsoleService implements MainThreadConsoleServiceShape {
 	 */
 	private _trackConsoleEditor(instance: IPositronConsoleInstance): void {
 		const sessionId = instance.sessionMetadata.sessionId;
+
+		// Retire any tracking left over from a previous session with this id *before* building its
+		// replacement, for the same reason as `replaceRegistration` below.
+		this._consoleEditorTracking.deleteAndDispose(sessionId);
+
 		const tracking = new DisposableStore();
 
-		// Holds the registration for the console's current code editor; assigning replaces (and
-		// disposes) the registration for the previous one.
+		// Holds the registration for the console's current code editor.
 		const registration = tracking.add(new MutableDisposable<IDisposable>());
 
-		tracking.add(instance.onDidSetCodeEditor((codeEditor) => {
+		// Retires the previous registration before creating its replacement. Every registration for
+		// this console uses the editor id `console-<sessionId>`, and both the main thread's editor
+		// map and the extension host's console editor map are keyed by it, so disposing the old
+		// registration *after* the new one exists would retire the new editor instead of the old.
+		const replaceRegistration = (codeEditor: ICodeEditor) => {
+			registration.clear();
 			registration.value = this._registerConsoleEditor(sessionId, codeEditor);
-		}));
+		};
+
+		tracking.add(instance.onDidSetCodeEditor(replaceRegistration));
 
 		if (instance.codeEditor) {
 			// The editor is already mounted, so `onDidSetCodeEditor` has already fired for it.
-			registration.value = this._registerConsoleEditor(sessionId, instance.codeEditor);
+			replaceRegistration(instance.codeEditor);
 		}
 
-		// Replaces (and disposes) any tracking left over from a previous session with this id.
 		this._consoleEditorTracking.set(sessionId, tracking);
 	}
 
@@ -182,7 +225,7 @@ export class MainThreadConsoleService implements MainThreadConsoleServiceShape {
 		const editorId = `console-${sessionId}`;
 
 		const doRegister = (model: ITextModel) => {
-			const registration = store.add(this._hiddenEditorManager.registerHiddenTextEditor(editorId, codeEditor, model));
+			const registration = store.add(this._hiddenEditorManager.value.registerHiddenTextEditor(editorId, codeEditor, model));
 
 			// The editor travels over the Positron-only console channel, never through
 			// `$acceptDocumentsAndEditorsDelta`, so it stays out of `visibleTextEditors` and the

--- a/src/vs/workbench/api/browser/positron/mainThreadConsoleService.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadConsoleService.ts
@@ -3,8 +3,8 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DisposableStore } from '../../../../base/common/lifecycle.js';
-import { ExtHostConsoleServiceShape, ExtHostPositronContext, MainPositronContext, MainThreadConsoleServiceShape } from '../../common/positron/extHost.positron.protocol.js';
+import { DisposableStore, IDisposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { ExtHostConsoleServiceShape, ExtHostPositronContext, IMainThreadConsoleEditorManager, MainPositronContext, MainThreadConsoleServiceShape } from '../../common/positron/extHost.positron.protocol.js';
 import { extHostNamedCustomer, IExtHostContext } from '../../../services/extensions/common/extHostCustomers.js';
 import { IPositronConsoleInstance, IPositronConsoleService } from '../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
 import { MainThreadConsole } from './mainThreadConsole.js';
@@ -24,6 +24,9 @@ export class MainThreadConsoleService implements MainThreadConsoleServiceShape {
 	 * Kept in sync with consoles in `ExtHostConsoleService`
 	 */
 	private readonly _mainThreadConsolesBySessionId = new Map<string, MainThreadConsole>();
+
+	/** Disposables for registered console text editors, keyed by session id. */
+	private readonly _consoleEditorDisposables = new Map<string, MutableDisposable<IDisposable>>();
 
 	private readonly _proxy: ExtHostConsoleServiceShape;
 
@@ -53,6 +56,13 @@ export class MainThreadConsoleService implements MainThreadConsoleServiceShape {
 
 				// Then update main thread
 				this.addConsole(sessionId, console);
+
+				// Register the console's Monaco editor with the text editor tracking so
+				// extensions can access it via positron.window.activeConsoleEditor.
+				const manager = extHostContext.getRaw<IMainThreadConsoleEditorManager, IMainThreadConsoleEditorManager>(
+					MainPositronContext.MainThreadConsoleEditorManager
+				);
+				this._registerConsoleEditor(console, manager);
 			})
 		);
 
@@ -60,6 +70,7 @@ export class MainThreadConsoleService implements MainThreadConsoleServiceShape {
 		this._disposables.add(
 			this._positronConsoleService.onDidChangeActivePositronConsoleInstance((instance) => {
 				this._proxy.$onDidChangeActiveConsole(instance?.sessionId);
+				this._notifyActiveConsoleEditor(instance);
 			})
 		);
 
@@ -85,6 +96,9 @@ export class MainThreadConsoleService implements MainThreadConsoleServiceShape {
 
 	dispose(): void {
 		this._disposables.dispose();
+		for (const d of this._consoleEditorDisposables.values()) {
+			d.dispose();
+		}
 	}
 
 	private addConsole(sessionId: string, console: IPositronConsoleInstance) {
@@ -99,6 +113,61 @@ export class MainThreadConsoleService implements MainThreadConsoleServiceShape {
 	// 	// No dispose() method to call
 	// 	this._mainThreadConsolesByLanguageId.delete(id);
 	// }
+
+	/**
+	 * Registers the Monaco editor for `instance` with the text editor tracking pipeline so
+	 * that extensions can use `positron.window.activeConsoleEditor` to access a full
+	 * `vscode.TextEditor` for the console input.
+	 *
+	 * The editor is intentionally NOT set as `vscode.window.activeTextEditor`.
+	 */
+	private _registerConsoleEditor(instance: IPositronConsoleInstance, manager: IMainThreadConsoleEditorManager): void {
+		const sessionId = instance.sessionMetadata.sessionId;
+		const editorId = `console-${sessionId}`;
+
+		const doRegister = () => {
+			const mutable = new MutableDisposable<IDisposable>();
+			this._consoleEditorDisposables.set(sessionId, mutable);
+			this._disposables.add(mutable);
+			mutable.value = manager.registerConsoleEditor(editorId, instance.codeEditor!);
+		};
+
+		if (instance.codeEditor) {
+			// Editor already mounted — register immediately.
+			doRegister();
+		} else {
+			// Editor not yet mounted (React component hasn't mounted yet).
+			// Wait for the first assignment.
+			const sub = instance.onDidSetCodeEditor(() => {
+				sub.dispose();
+				doRegister();
+
+				// If this instance is already the active console, notify now.
+				if (this._positronConsoleService.activePositronConsoleInstance === instance) {
+					this._proxy.$setActiveConsoleEditor(editorId);
+				}
+			});
+			this._disposables.add(sub);
+		}
+	}
+
+	/**
+	 * Notifies the extension host of the active console editor id so
+	 * `positron.window.activeConsoleEditor` can be updated.
+	 */
+	private _notifyActiveConsoleEditor(instance: IPositronConsoleInstance | undefined): void {
+		if (!instance) {
+			this._proxy.$setActiveConsoleEditor(null);
+			return;
+		}
+		const sessionId = instance.sessionMetadata.sessionId;
+		const editorId = `console-${sessionId}`;
+		// Only notify if the editor has been registered (codeEditor is set).
+		if (instance.codeEditor && this._consoleEditorDisposables.has(sessionId)) {
+			this._proxy.$setActiveConsoleEditor(editorId);
+		}
+		// If codeEditor isn't set yet, _registerConsoleEditor will notify once it mounts.
+	}
 
 	// --- from extension host process
 

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -235,6 +235,12 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			getConsoleForLanguage(languageId: string) {
 				return extHostConsoleService.getConsoleForLanguage(languageId);
 			},
+			get activeConsoleEditor() {
+				return extHostConsoleService.activeConsole;
+			},
+			get onDidChangeActiveConsoleEditor() {
+				return extHostConsoleService.onDidChangeActiveConsole;
+			},
 			get onDidChangeConsoleWidth() {
 				return extHostConsoleService.onDidChangeConsoleWidth;
 			},

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -29,6 +29,7 @@ import { ExtHostLanguageFeatures } from '../extHostLanguageFeatures.js';
 import { createExtHostQuickOpen } from '../extHostQuickOpen.js';
 import { ExtHostOutputService } from '../extHostOutput.js';
 import { ExtHostConsoleService } from './extHostConsoleService.js';
+import { ExtHostDocumentsAndEditors } from '../extHostDocumentsAndEditors.js';
 import { ExtHostMethods } from './extHostMethods.js';
 import { ExtHostEditors } from '../extHostTextEditors.js';
 import { UiFrontendRequest } from '../../../services/languageRuntime/common/positronUiComm.js';
@@ -80,13 +81,14 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 		rpcProtocol.getRaw(ExtHostContext.ExtHostLanguageFeatures);
 	const extHostEditors: ExtHostEditors = rpcProtocol.getRaw(ExtHostContext.ExtHostEditors);
 	const extHostDocuments: ExtHostDocuments = rpcProtocol.getRaw(ExtHostContext.ExtHostDocuments);
+	const extHostDocumentsAndEditors: ExtHostDocumentsAndEditors = rpcProtocol.getRaw(ExtHostContext.ExtHostDocumentsAndEditors);
 	const extHostQuickOpen = rpcProtocol.set(ExtHostPositronContext.ExtHostQuickOpen, createExtHostQuickOpen(rpcProtocol, extHostWorkspace, extHostCommands));
 	const extHostLanguageRuntime = rpcProtocol.set(ExtHostPositronContext.ExtHostLanguageRuntime, new ExtHostLanguageRuntime(rpcProtocol, extHostLogService));
 	const extHostAiFeatures = rpcProtocol.set(ExtHostPositronContext.ExtHostAiFeatures, new ExtHostAiFeatures(rpcProtocol, extHostCommands));
 	const extHostPreviewPanels = rpcProtocol.set(ExtHostPositronContext.ExtHostPreviewPanel, new ExtHostPreviewPanels(rpcProtocol, extHostWebviews, extHostWorkspace));
 	const extHostModalDialogs = rpcProtocol.set(ExtHostPositronContext.ExtHostModalDialogs, new ExtHostModalDialogs(rpcProtocol));
 	const extHostContextKeyService = rpcProtocol.set(ExtHostPositronContext.ExtHostContextKeyService, new ExtHostContextKeyService(rpcProtocol));
-	const extHostConsoleService = rpcProtocol.set(ExtHostPositronContext.ExtHostConsoleService, new ExtHostConsoleService(rpcProtocol, extHostLogService));
+	const extHostConsoleService = rpcProtocol.set(ExtHostPositronContext.ExtHostConsoleService, new ExtHostConsoleService(rpcProtocol, extHostLogService, extHostDocumentsAndEditors));
 	const extHostPlotsService = rpcProtocol.set(ExtHostPositronContext.ExtHostPlotsService, new ExtHostPlotsService(rpcProtocol));
 	const extHostMethods = rpcProtocol.set(ExtHostPositronContext.ExtHostMethods,
 		new ExtHostMethods(rpcProtocol, extHostEditors, extHostDocuments, extHostModalDialogs,
@@ -236,10 +238,10 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 				return extHostConsoleService.getConsoleForLanguage(languageId);
 			},
 			get activeConsoleEditor() {
-				return extHostConsoleService.activeConsole;
+				return extHostConsoleService.activeConsoleEditor;
 			},
 			get onDidChangeActiveConsoleEditor() {
-				return extHostConsoleService.onDidChangeActiveConsole;
+				return extHostConsoleService.onDidChangeActiveConsoleEditor;
 			},
 			get onDidChangeConsoleWidth() {
 				return extHostConsoleService.onDidChangeConsoleWidth;

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -26,6 +26,7 @@ import { ILanguageRuntimeCodeExecutedEvent } from '../../../services/positronCon
 import { IPositronChatProvider } from '../../../contrib/chat/common/languageModels.js';
 import { ICodeLocation } from '../../../services/positronConsole/common/codeLocation.js';
 import { EvalResult } from '../../../services/languageRuntime/common/positronUiComm.js';
+import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
 
 // NOTE: This check is really to ensure that extHost.protocol is included by the TypeScript compiler
 // as a dependency of this module, and therefore that it's initialized first. This is to avoid a
@@ -171,6 +172,15 @@ export interface ExtHostConsoleServiceShape {
 	$addConsole(sessionId: string): void;
 	$removeConsole(sessionId: string): void;
 	$onDidChangeActiveConsole(sessionId: string | undefined): void;
+	$setActiveConsoleEditor(editorId: string | null): void;
+}
+
+/**
+ * Implemented by MainThreadDocumentsAndEditors to allow Positron-specific
+ * console editor registration without exposing the full upstream internals.
+ */
+export interface IMainThreadConsoleEditorManager {
+	registerConsoleEditor(id: string, codeEditor: ICodeEditor): IDisposable;
 }
 
 export interface MainThreadMethodsShape { }
@@ -498,6 +508,7 @@ export interface MainThreadPositronEphemeralStorageShape extends IDisposable {
 }
 
 export const MainPositronContext = {
+	MainThreadConsoleEditorManager: createProxyIdentifier<IMainThreadConsoleEditorManager>('MainThreadConsoleEditorManager'),
 	MainThreadLanguageRuntime: createProxyIdentifier<MainThreadLanguageRuntimeShape>('MainThreadLanguageRuntime'),
 	MainThreadPreviewPanel: createProxyIdentifier<MainThreadPreviewPanelShape>('MainThreadPreviewPanel'),
 	MainThreadModalDialogs: createProxyIdentifier<MainThreadModalDialogsShape>('MainThreadModalDialogs'),

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -180,7 +180,17 @@ export interface ExtHostConsoleServiceShape {
  * console editor registration without exposing the full upstream internals.
  */
 export interface IMainThreadConsoleEditorManager {
-	registerConsoleEditor(id: string, codeEditor: ICodeEditor): IDisposable;
+	/**
+	 * Registers a console input editor with the extension host.
+	 *
+	 * @param id A stable id for this editor (e.g. `console-<sessionId>`)
+	 * @param codeEditor The Monaco editor backing the console input
+	 * @param onRegistered Invoked once the editor is actually known to the extension host.
+	 * Registration is deferred until the code editor has a text model, so this may be called
+	 * after `registerConsoleEditor` returns (or never, if a model is never attached).
+	 * @returns A disposable that removes the editor from the ext host when disposed
+	 */
+	registerConsoleEditor(id: string, codeEditor: ICodeEditor, onRegistered?: () => void): IDisposable;
 }
 
 export interface MainThreadMethodsShape { }

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -7,7 +7,7 @@ import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { IDisposable } from '../../../../base/common/lifecycle.js';
 import { IHostedLanguageContribution, ILanguageRuntimeInfo, ILanguageRuntimeMetadata, IRuntimeRootSignature, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState, ILanguageRuntimeMessage, ILanguageRuntimeExit, RuntimeExitReason, LanguageRuntimeSessionMode, ILanguageRuntimeResourceUsage, ILanguageRuntimeLaunchInfo } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { createProxyIdentifier, IRPCProtocol, SerializableObjectWithBuffers } from '../../../services/extensions/common/proxyIdentifier.js';
-import { MainContext, IWebviewPortMapping, WebviewExtensionDescription, IChatProgressDto, ExtHostQuickOpenShape } from '../extHost.protocol.js';
+import { MainContext, IWebviewPortMapping, WebviewExtensionDescription, IChatProgressDto, ExtHostQuickOpenShape, ITextEditorAddData, IEditorPropertiesChangeData } from '../extHost.protocol.js';
 import { URI, UriComponents } from '../../../../base/common/uri.js';
 import { IEditorContext } from '../../../services/frontendMethods/common/editorContext.js';
 import { RuntimeClientType, LanguageRuntimeSessionChannel } from './extHostTypes.positron.js';
@@ -27,6 +27,8 @@ import { IPositronChatProvider } from '../../../contrib/chat/common/languageMode
 import { ICodeLocation } from '../../../services/positronConsole/common/codeLocation.js';
 import { EvalResult } from '../../../services/languageRuntime/common/positronUiComm.js';
 import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
+import { ITextModel } from '../../../../editor/common/model.js';
+import { Event } from '../../../../base/common/event.js';
 
 // NOTE: This check is really to ensure that extHost.protocol is included by the TypeScript compiler
 // as a dependency of this module, and therefore that it's initialized first. This is to avoid a
@@ -172,25 +174,43 @@ export interface ExtHostConsoleServiceShape {
 	$addConsole(sessionId: string): void;
 	$removeConsole(sessionId: string): void;
 	$onDidChangeActiveConsole(sessionId: string | undefined): void;
-	$setActiveConsoleEditor(editorId: string | null): void;
+
+	// Console input editors travel over this Positron-only channel rather than the core
+	// `$acceptDocumentsAndEditorsDelta` one, so they never surface through the standard VS Code
+	// editor APIs (`visibleTextEditors`, `onDidChangeTextEditorSelection`, ...).
+	$addConsoleEditor(sessionId: string, data: ITextEditorAddData): void;
+	$removeConsoleEditor(sessionId: string): void;
+	$acceptConsoleEditorPropertiesChanged(sessionId: string, data: IEditorPropertiesChangeData): void;
 }
 
 /**
- * Implemented by MainThreadDocumentsAndEditors to allow Positron-specific
- * console editor registration without exposing the full upstream internals.
+ * A text editor that lives in the main thread's editor map -- so operations the extension host
+ * addresses by id (`edit()`, `insertSnippet()`, selection writes) can resolve it -- but which is
+ * deliberately absent from the core documents-and-editors state.
  */
-export interface IMainThreadConsoleEditorManager {
+export interface IHiddenTextEditorRegistration extends IDisposable {
+	/** The data the extension host needs to build its own editor object for this editor. */
+	readonly addData: ITextEditorAddData;
+
+	/** Fires when the editor's selections, options or visible ranges change. */
+	readonly onPropertiesChanged: Event<IEditorPropertiesChangeData>;
+}
+
+/**
+ * Implemented by MainThreadDocumentsAndEditors so Positron can register editors that are hidden
+ * from the core editor pipeline, without exposing the full upstream internals.
+ */
+export interface IMainThreadHiddenEditorManager {
 	/**
-	 * Registers a console input editor with the extension host.
+	 * Registers a hidden text editor.
 	 *
 	 * @param id A stable id for this editor (e.g. `console-<sessionId>`)
-	 * @param codeEditor The Monaco editor backing the console input
-	 * @param onRegistered Invoked once the editor is actually known to the extension host.
-	 * Registration is deferred until the code editor has a text model, so this may be called
-	 * after `registerConsoleEditor` returns (or never, if a model is never attached).
-	 * @returns A disposable that removes the editor from the ext host when disposed
+	 * @param codeEditor The Monaco editor to expose
+	 * @param model The text model attached to `codeEditor`
+	 * @returns A registration the caller must forward to the extension host over its own channel,
+	 * and dispose when the editor goes away
 	 */
-	registerConsoleEditor(id: string, codeEditor: ICodeEditor, onRegistered?: () => void): IDisposable;
+	registerHiddenTextEditor(id: string, codeEditor: ICodeEditor, model: ITextModel): IHiddenTextEditorRegistration;
 }
 
 export interface MainThreadMethodsShape { }
@@ -518,7 +538,7 @@ export interface MainThreadPositronEphemeralStorageShape extends IDisposable {
 }
 
 export const MainPositronContext = {
-	MainThreadConsoleEditorManager: createProxyIdentifier<IMainThreadConsoleEditorManager>('MainThreadConsoleEditorManager'),
+	MainThreadHiddenEditorManager: createProxyIdentifier<IMainThreadHiddenEditorManager>('MainThreadHiddenEditorManager'),
 	MainThreadLanguageRuntime: createProxyIdentifier<MainThreadLanguageRuntimeShape>('MainThreadLanguageRuntime'),
 	MainThreadPreviewPanel: createProxyIdentifier<MainThreadPreviewPanelShape>('MainThreadPreviewPanel'),
 	MainThreadModalDialogs: createProxyIdentifier<MainThreadModalDialogsShape>('MainThreadModalDialogs'),

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -163,12 +163,14 @@ export interface MainThreadConsoleServiceShape {
 	$getConsoleWidth(): Promise<number>;
 	$getSessionIdForLanguage(languageId: string): Promise<string | undefined>;
 	$tryPasteText(sessionId: string, text: string): void;
+	$getActiveConsoleSessionId(): Promise<string | undefined>;
 }
 
 export interface ExtHostConsoleServiceShape {
 	$onDidChangeConsoleWidth(newWidth: number): void;
 	$addConsole(sessionId: string): void;
 	$removeConsole(sessionId: string): void;
+	$onDidChangeActiveConsole(sessionId: string | undefined): void;
 }
 
 export interface MainThreadMethodsShape { }

--- a/src/vs/workbench/api/common/positron/extHostConsoleService.ts
+++ b/src/vs/workbench/api/common/positron/extHostConsoleService.ts
@@ -4,11 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as positron from 'positron';
+import * as vscode from 'vscode';
 import { Emitter } from '../../../../base/common/event.js';
 import * as extHostProtocol from './extHost.positron.protocol.js';
 import { ExtHostConsole } from './extHostConsole.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { dispose } from '../../../../base/common/lifecycle.js';
+import { ExtHostDocumentsAndEditors } from '../extHostDocumentsAndEditors.js';
 
 export class ExtHostConsoleService implements extHostProtocol.ExtHostConsoleServiceShape {
 
@@ -27,6 +29,8 @@ export class ExtHostConsoleService implements extHostProtocol.ExtHostConsoleServ
 
 	private readonly _onDidChangeActiveConsole = new Emitter<positron.Console | undefined>();
 
+	private readonly _onDidChangeActiveConsoleEditor = new Emitter<vscode.TextEditor | undefined>();
+
 	private _activeConsoleSessionId: string | undefined;
 
 	// Guards the startup seed: once a live $onDidChangeActiveConsole arrives we
@@ -38,6 +42,7 @@ export class ExtHostConsoleService implements extHostProtocol.ExtHostConsoleServ
 	constructor(
 		mainContext: extHostProtocol.IMainPositronContext,
 		private readonly _logService: ILogService,
+		private readonly _extHostDocumentsAndEditors: ExtHostDocumentsAndEditors,
 	) {
 		this._proxy = mainContext.getProxy(extHostProtocol.MainPositronContext.MainThreadConsoleService);
 
@@ -62,11 +67,19 @@ export class ExtHostConsoleService implements extHostProtocol.ExtHostConsoleServ
 
 	onDidChangeActiveConsole = this._onDidChangeActiveConsole.event;
 
+	onDidChangeActiveConsoleEditor = this._onDidChangeActiveConsoleEditor.event;
+
 	get activeConsole(): positron.Console | undefined {
 		if (this._activeConsoleSessionId === undefined) {
 			return undefined;
 		}
 		return this._extHostConsolesBySessionId.get(this._activeConsoleSessionId)?.getConsole();
+	}
+
+	get activeConsoleEditor(): vscode.TextEditor | undefined {
+		return this._activeConsoleSessionId
+			? this._extHostDocumentsAndEditors.getEditor(`console-${this._activeConsoleSessionId}`)?.value
+			: undefined;
 	}
 
 	/**
@@ -140,5 +153,11 @@ export class ExtHostConsoleService implements extHostProtocol.ExtHostConsoleServ
 		this._activeConsoleSessionId = sessionId;
 		this._onDidChangeActiveConsole.fire(this.activeConsole);
 	}
-}
 
+	// Called when the active console editor changes (separate from vscode.window.activeTextEditor).
+	// The editorId is derived from the active session, so we fire using the getter which derives
+	// the TextEditor from _activeConsoleSessionId (already updated by $onDidChangeActiveConsole).
+	$setActiveConsoleEditor(_editorId: string | null): void {
+		this._onDidChangeActiveConsoleEditor.fire(this.activeConsoleEditor);
+	}
+}

--- a/src/vs/workbench/api/common/positron/extHostConsoleService.ts
+++ b/src/vs/workbench/api/common/positron/extHostConsoleService.ts
@@ -5,12 +5,18 @@
 
 import * as positron from 'positron';
 import * as vscode from 'vscode';
+import { coalesce } from '../../../../base/common/arrays.js';
 import { Emitter } from '../../../../base/common/event.js';
+import { Lazy } from '../../../../base/common/lazy.js';
+import { URI } from '../../../../base/common/uri.js';
+import { IEditorPropertiesChangeData, ITextEditorAddData, MainContext, MainThreadTextEditorsShape } from '../extHost.protocol.js';
 import * as extHostProtocol from './extHost.positron.protocol.js';
 import { ExtHostConsole } from './extHostConsole.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { dispose } from '../../../../base/common/lifecycle.js';
 import { ExtHostDocumentsAndEditors } from '../extHostDocumentsAndEditors.js';
+import { ExtHostTextEditor } from '../extHostTextEditor.js';
+import * as typeConverters from '../extHostTypeConverters.js';
 
 export class ExtHostConsoleService implements extHostProtocol.ExtHostConsoleServiceShape {
 
@@ -25,6 +31,16 @@ export class ExtHostConsoleService implements extHostProtocol.ExtHostConsoleServ
 	 */
 	private readonly _extHostConsolesBySessionId = new Map<string, ExtHostConsole>();
 
+	/**
+	 * Console input editors, keyed by session id.
+	 *
+	 * Deliberately held here rather than in `ExtHostDocumentsAndEditors`: these editors must not
+	 * surface through the standard VS Code editor APIs (`vscode.window.visibleTextEditors`,
+	 * `onDidChangeTextEditorSelection`, ...), only through
+	 * `positron.window.activeConsoleEditor` (posit-dev/positron#780).
+	 */
+	private readonly _consoleEditorsBySessionId = new Map<string, ExtHostTextEditor>();
+
 	private readonly _onDidChangeConsoleWidth = new Emitter<number>();
 
 	private readonly _onDidChangeActiveConsole = new Emitter<positron.Console | undefined>();
@@ -33,11 +49,20 @@ export class ExtHostConsoleService implements extHostProtocol.ExtHostConsoleServ
 
 	private _activeConsoleSessionId: string | undefined;
 
+	/**
+	 * The editor last reported through `onDidChangeActiveConsoleEditor`. The active console and its
+	 * editor arrive on separate calls (and in either order), so this suppresses events that would
+	 * not change what extensions see.
+	 */
+	private _notifiedActiveConsoleEditor: vscode.TextEditor | undefined;
+
 	// Guards the startup seed: once a live $onDidChangeActiveConsole arrives we
 	// must not let the async startup promise overwrite it.
 	private _receivedLiveActiveConsoleEvent = false;
 
 	private readonly _proxy: extHostProtocol.MainThreadConsoleServiceShape;
+
+	private readonly _editorsProxy: MainThreadTextEditorsShape;
 
 	constructor(
 		mainContext: extHostProtocol.IMainPositronContext,
@@ -45,6 +70,9 @@ export class ExtHostConsoleService implements extHostProtocol.ExtHostConsoleServ
 		private readonly _extHostDocumentsAndEditors: ExtHostDocumentsAndEditors,
 	) {
 		this._proxy = mainContext.getProxy(extHostProtocol.MainPositronContext.MainThreadConsoleService);
+		// Console editors are addressed by id on the standard text editor channel, so `edit()`,
+		// `insertSnippet()` and selection writes work exactly as they do for any other editor.
+		this._editorsProxy = mainContext.getProxy(MainContext.MainThreadTextEditors);
 
 		// Fetch the current active console session on startup so we don't miss
 		// consoles that were already active before this ext host started.
@@ -60,6 +88,7 @@ export class ExtHostConsoleService implements extHostProtocol.ExtHostConsoleServ
 			if (sessionId !== undefined && this._extHostConsolesBySessionId.has(sessionId)) {
 				this._onDidChangeActiveConsole.fire(this.activeConsole);
 			}
+			this._fireActiveConsoleEditorIfChanged();
 		});
 	}
 
@@ -69,6 +98,10 @@ export class ExtHostConsoleService implements extHostProtocol.ExtHostConsoleServ
 
 	onDidChangeActiveConsoleEditor = this._onDidChangeActiveConsoleEditor.event;
 
+	/**
+	 * The active console. Internal for now: this backs `activeConsoleEditor` and is not exposed on
+	 * `positron.window`.
+	 */
 	get activeConsole(): positron.Console | undefined {
 		if (this._activeConsoleSessionId === undefined) {
 			return undefined;
@@ -77,8 +110,8 @@ export class ExtHostConsoleService implements extHostProtocol.ExtHostConsoleServ
 	}
 
 	get activeConsoleEditor(): vscode.TextEditor | undefined {
-		return this._activeConsoleSessionId
-			? this._extHostDocumentsAndEditors.getEditor(`console-${this._activeConsoleSessionId}`)?.value
+		return this._activeConsoleSessionId !== undefined
+			? this._consoleEditorsBySessionId.get(this._activeConsoleSessionId)?.value
 			: undefined;
 	}
 
@@ -152,12 +185,78 @@ export class ExtHostConsoleService implements extHostProtocol.ExtHostConsoleServ
 		this._receivedLiveActiveConsoleEvent = true;
 		this._activeConsoleSessionId = sessionId;
 		this._onDidChangeActiveConsole.fire(this.activeConsole);
+		this._fireActiveConsoleEditorIfChanged();
 	}
 
-	// Called when the active console editor changes (separate from vscode.window.activeTextEditor).
-	// The editorId is derived from the active session, so we fire using the getter which derives
-	// the TextEditor from _activeConsoleSessionId (already updated by $onDidChangeActiveConsole).
-	$setActiveConsoleEditor(_editorId: string | null): void {
-		this._onDidChangeActiveConsoleEditor.fire(this.activeConsoleEditor);
+	// Called when a console's input editor becomes available. The console input mounts (and
+	// remounts) independently of the console itself, so this can arrive before or after the
+	// console becomes active.
+	$addConsoleEditor(sessionId: string, data: ITextEditorAddData): void {
+		const uri = URI.revive(data.documentUri);
+		const documentData = this._extHostDocumentsAndEditors.getDocument(uri);
+		if (!documentData) {
+			// The console input model is synchronized before its editor is registered, so this
+			// should not happen; bail out rather than hand back an editor with no document.
+			this._logService.error(`ExtHostConsoleService: no document for console editor '${uri.toString()}'`);
+			return;
+		}
+
+		this._consoleEditorsBySessionId.get(sessionId)?.dispose();
+		this._consoleEditorsBySessionId.set(sessionId, new ExtHostTextEditor(
+			data.id,
+			this._editorsProxy,
+			this._logService,
+			new Lazy(() => documentData.document),
+			data.selections.map(typeConverters.Selection.to),
+			data.options,
+			data.visibleRanges.map(range => typeConverters.Range.to(range)),
+			typeof data.editorPosition === 'number' ? typeConverters.ViewColumn.to(data.editorPosition) : undefined
+		));
+
+		this._fireActiveConsoleEditorIfChanged();
+	}
+
+	// Called when a console's input editor goes away, either because the console was deleted or
+	// because the Console view unmounted.
+	$removeConsoleEditor(sessionId: string): void {
+		const editor = this._consoleEditorsBySessionId.get(sessionId);
+		if (!editor) {
+			return;
+		}
+		this._consoleEditorsBySessionId.delete(sessionId);
+		editor.dispose();
+		this._fireActiveConsoleEditorIfChanged();
+	}
+
+	// Called when a console editor's selections, options or visible ranges change. Only the editor
+	// state is updated: these deliberately do not raise the core
+	// `vscode.window.onDidChangeTextEditor*` events.
+	$acceptConsoleEditorPropertiesChanged(sessionId: string, data: IEditorPropertiesChangeData): void {
+		const editor = this._consoleEditorsBySessionId.get(sessionId);
+		if (!editor) {
+			return;
+		}
+		if (data.options) {
+			editor._acceptOptions(data.options);
+		}
+		if (data.selections) {
+			editor._acceptSelections(data.selections.selections.map(typeConverters.Selection.to));
+		}
+		if (data.visibleRanges) {
+			editor._acceptVisibleRanges(coalesce(data.visibleRanges.map(typeConverters.Range.to)));
+		}
+	}
+
+	/**
+	 * Fires `onDidChangeActiveConsoleEditor`, unless the active console editor is the same one
+	 * extensions were last told about.
+	 */
+	private _fireActiveConsoleEditorIfChanged(): void {
+		const editor = this.activeConsoleEditor;
+		if (editor === this._notifiedActiveConsoleEditor) {
+			return;
+		}
+		this._notifiedActiveConsoleEditor = editor;
+		this._onDidChangeActiveConsoleEditor.fire(editor);
 	}
 }

--- a/src/vs/workbench/api/common/positron/extHostConsoleService.ts
+++ b/src/vs/workbench/api/common/positron/extHostConsoleService.ts
@@ -25,6 +25,14 @@ export class ExtHostConsoleService implements extHostProtocol.ExtHostConsoleServ
 
 	private readonly _onDidChangeConsoleWidth = new Emitter<number>();
 
+	private readonly _onDidChangeActiveConsole = new Emitter<positron.Console | undefined>();
+
+	private _activeConsoleSessionId: string | undefined;
+
+	// Guards the startup seed: once a live $onDidChangeActiveConsole arrives we
+	// must not let the async startup promise overwrite it.
+	private _receivedLiveActiveConsoleEvent = false;
+
 	private readonly _proxy: extHostProtocol.MainThreadConsoleServiceShape;
 
 	constructor(
@@ -32,9 +40,34 @@ export class ExtHostConsoleService implements extHostProtocol.ExtHostConsoleServ
 		private readonly _logService: ILogService,
 	) {
 		this._proxy = mainContext.getProxy(extHostProtocol.MainPositronContext.MainThreadConsoleService);
+
+		// Fetch the current active console session on startup so we don't miss
+		// consoles that were already active before this ext host started.
+		this._proxy.$getActiveConsoleSessionId().then((sessionId) => {
+			// A live $onDidChangeActiveConsole event already arrived; skip so we
+			// don't overwrite it with a potentially stale startup value.
+			if (this._receivedLiveActiveConsoleEvent) {
+				return;
+			}
+			this._activeConsoleSessionId = sessionId;
+			// If $addConsole already registered this session before the promise
+			// resolved, the re-fire guard in $addConsole was skipped. Fire now.
+			if (sessionId !== undefined && this._extHostConsolesBySessionId.has(sessionId)) {
+				this._onDidChangeActiveConsole.fire(this.activeConsole);
+			}
+		});
 	}
 
 	onDidChangeConsoleWidth = this._onDidChangeConsoleWidth.event;
+
+	onDidChangeActiveConsole = this._onDidChangeActiveConsole.event;
+
+	get activeConsole(): positron.Console | undefined {
+		if (this._activeConsoleSessionId === undefined) {
+			return undefined;
+		}
+		return this._extHostConsolesBySessionId.get(this._activeConsoleSessionId)?.getConsole();
+	}
 
 	/**
 	 * Queries the main thread for the current width of the console input.
@@ -86,6 +119,11 @@ export class ExtHostConsoleService implements extHostProtocol.ExtHostConsoleServ
 	$addConsole(sessionId: string): void {
 		const extHostConsole = new ExtHostConsole(sessionId, this._proxy, this._logService);
 		this._extHostConsolesBySessionId.set(sessionId, extHostConsole);
+		// If the active session ID arrived before this console was registered, re-fire now that
+		// the map is populated so listeners receive the resolved console instead of undefined.
+		if (sessionId === this._activeConsoleSessionId) {
+			this._onDidChangeActiveConsole.fire(this.activeConsole);
+		}
 	}
 
 	// Called when a console instance is removed
@@ -94,6 +132,13 @@ export class ExtHostConsoleService implements extHostProtocol.ExtHostConsoleServ
 		this._extHostConsolesBySessionId.delete(sessionId);
 		// "Dispose" of an `ExtHostConsole`, ensuring that future API calls warn / error
 		dispose(extHostConsole);
+	}
+
+	// Called when the active console changes
+	$onDidChangeActiveConsole(sessionId: string | undefined): void {
+		this._receivedLiveActiveConsoleEvent = true;
+		this._activeConsoleSessionId = sessionId;
+		this._onDidChangeActiveConsole.fire(this.activeConsole);
 	}
 }
 

--- a/src/vs/workbench/api/common/positron/extHostConsoleService.ts
+++ b/src/vs/workbench/api/common/positron/extHostConsoleService.ts
@@ -89,6 +89,10 @@ export class ExtHostConsoleService implements extHostProtocol.ExtHostConsoleServ
 				this._onDidChangeActiveConsole.fire(this.activeConsole);
 			}
 			this._fireActiveConsoleEditorIfChanged();
+		}).catch((err) => {
+			// Survivable: extensions just do not see a console that was already active before this
+			// extension host started until the next `$onDidChangeActiveConsole`.
+			this._logService.error('ExtHostConsoleService: failed to seed the active console', err);
 		});
 	}
 

--- a/src/vs/workbench/api/test/browser/positron/consoleEditorTestServices.ts
+++ b/src/vs/workbench/api/test/browser/positron/consoleEditorTestServices.ts
@@ -55,6 +55,16 @@ export class ConsoleEditorTestServices {
 	/** Deltas the main thread sent to the (fake) extension host. */
 	readonly deltas: IDocumentsAndEditorsDelta[] = [];
 
+	/**
+	 * Editor ids the main thread sent state for before the ext host knew about them. The real
+	 * `ExtHostEditors` throws `unknown text editor` in this case, so anything recorded here is a
+	 * bug in the ordering of the calls the main thread makes.
+	 */
+	readonly unknownEditorCalls: string[] = [];
+
+	/** Editor ids the (fake) ext host currently knows about, per the deltas it received. */
+	private readonly _knownEditorIds = new Set<string>();
+
 	readonly modelService: ModelService;
 	readonly documentsAndEditors: MainThreadDocumentsAndEditors;
 
@@ -115,8 +125,17 @@ export class ConsoleEditorTestServices {
 
 		this.documentsAndEditors = new MainThreadDocumentsAndEditors(
 			SingleProxyRPCProtocol({
-				$acceptDocumentsAndEditorsDelta: (delta: IDocumentsAndEditorsDelta) => { this.deltas.push(delta); },
-				$acceptEditorDiffInformation: (_id: string, _diffInformation: ITextEditorDiffInformation | undefined) => { }
+				$acceptDocumentsAndEditorsDelta: (delta: IDocumentsAndEditorsDelta) => {
+					this.deltas.push(delta);
+					delta.addedEditors?.forEach(e => this._knownEditorIds.add(e.id));
+					delta.removedEditors?.forEach(id => this._knownEditorIds.delete(id));
+				},
+				$acceptEditorDiffInformation: (id: string, _diffInformation: ITextEditorDiffInformation | undefined) => {
+					this._recordEditorIdLookup(id);
+				},
+				$acceptEditorPropertiesChanged: (id: string) => {
+					this._recordEditorIdLookup(id);
+				}
 			}),
 			this.modelService,
 			textFileService,
@@ -181,6 +200,13 @@ export class ConsoleEditorTestServices {
 
 	consoleRemoves(id: string): IDocumentsAndEditorsDelta[] {
 		return this.deltas.filter(d => d.removedEditors?.includes(id));
+	}
+
+	/** Mimics the ext host resolving an editor id, recording the ones it can't resolve. */
+	private _recordEditorIdLookup(id: string): void {
+		if (!this._knownEditorIds.has(id)) {
+			this.unknownEditorCalls.push(id);
+		}
 	}
 
 	dispose(): void {

--- a/src/vs/workbench/api/test/browser/positron/consoleEditorTestServices.ts
+++ b/src/vs/workbench/api/test/browser/positron/consoleEditorTestServices.ts
@@ -42,7 +42,7 @@ import { SingleProxyRPCProtocol } from '../../common/testRPCProtocol.js';
 
 /**
  * A real `MainThreadDocumentsAndEditors` plus the services it needs, wired for tests that
- * exercise the Positron-only console editor registration path.
+ * exercise the Positron-only hidden editor registration path.
  *
  * The wiring mirrors the upstream Mocha suite in `../mainThreadDocumentsAndEditors.test.ts`
  * (real `ModelService` + real test code editors) so that `ICodeEditor.onDidChangeModel` fires
@@ -52,18 +52,15 @@ import { SingleProxyRPCProtocol } from '../../common/testRPCProtocol.js';
  */
 export class ConsoleEditorTestServices {
 
-	/** Deltas the main thread sent to the (fake) extension host. */
+	/** Deltas the main thread sent to the (fake) extension host on the core channel. */
 	readonly deltas: IDocumentsAndEditorsDelta[] = [];
 
 	/**
-	 * Editor ids the main thread sent state for before the ext host knew about them. The real
-	 * `ExtHostEditors` throws `unknown text editor` in this case, so anything recorded here is a
-	 * bug in the ordering of the calls the main thread makes.
+	 * Editor ids the main thread sent core editor state for (`$acceptEditorPropertiesChanged`,
+	 * `$acceptEditorDiffInformation`). Read through `coreEditorStateCalls`, which filters out the
+	 * ambient state computer's own composite ids.
 	 */
-	readonly unknownEditorCalls: string[] = [];
-
-	/** Editor ids the (fake) ext host currently knows about, per the deltas it received. */
-	private readonly _knownEditorIds = new Set<string>();
+	private readonly _coreEditorStateCalls: string[] = [];
 
 	readonly modelService: ModelService;
 	readonly documentsAndEditors: MainThreadDocumentsAndEditors;
@@ -127,14 +124,12 @@ export class ConsoleEditorTestServices {
 			SingleProxyRPCProtocol({
 				$acceptDocumentsAndEditorsDelta: (delta: IDocumentsAndEditorsDelta) => {
 					this.deltas.push(delta);
-					delta.addedEditors?.forEach(e => this._knownEditorIds.add(e.id));
-					delta.removedEditors?.forEach(id => this._knownEditorIds.delete(id));
 				},
 				$acceptEditorDiffInformation: (id: string, _diffInformation: ITextEditorDiffInformation | undefined) => {
-					this._recordEditorIdLookup(id);
+					this._coreEditorStateCalls.push(id);
 				},
 				$acceptEditorPropertiesChanged: (id: string) => {
-					this._recordEditorIdLookup(id);
+					this._coreEditorStateCalls.push(id);
 				}
 			}),
 			this.modelService,
@@ -189,24 +184,22 @@ export class ConsoleEditorTestServices {
 	}
 
 	/**
-	 * Deltas emitted by `registerConsoleEditor` contain a single `addedEditors` entry whose id is
-	 * the console id we passed; deltas from the ambient state computer use composite
-	 * `${editorId},${modelId}` ids, so filtering by our exact id isolates the registration under
-	 * test.
+	 * Every mention of `id` on the core documents-and-editors channel. The ambient state computer
+	 * uses composite `${editorId},${modelId}` ids of its own, so matching our exact id isolates the
+	 * hidden registration under test: it must never show up, since that channel is what feeds
+	 * `vscode.window.visibleTextEditors`.
 	 */
-	consoleAdds(id: string): IDocumentsAndEditorsDelta[] {
-		return this.deltas.filter(d => d.addedEditors?.some(e => e.id === id));
+	coreDeltaMentions(id: string): IDocumentsAndEditorsDelta[] {
+		return this.deltas.filter(d => d.addedEditors?.some(e => e.id === id) || d.removedEditors?.includes(id));
 	}
 
-	consoleRemoves(id: string): IDocumentsAndEditorsDelta[] {
-		return this.deltas.filter(d => d.removedEditors?.includes(id));
-	}
-
-	/** Mimics the ext host resolving an editor id, recording the ones it can't resolve. */
-	private _recordEditorIdLookup(id: string): void {
-		if (!this._knownEditorIds.has(id)) {
-			this.unknownEditorCalls.push(id);
-		}
+	/**
+	 * Core editor state (`$acceptEditorPropertiesChanged` / `$acceptEditorDiffInformation`) the
+	 * main thread sent for `id`. A hidden editor must never appear here: those calls are how a
+	 * console editor would leak into `vscode.window.onDidChangeTextEditor*`.
+	 */
+	coreEditorStateCalls(id: string): string[] {
+		return this._coreEditorStateCalls.filter(callId => callId === id);
 	}
 
 	dispose(): void {

--- a/src/vs/workbench/api/test/browser/positron/consoleEditorTestServices.ts
+++ b/src/vs/workbench/api/test/browser/positron/consoleEditorTestServices.ts
@@ -1,0 +1,191 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Event } from '../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { ICodeEditorService } from '../../../../../editor/browser/services/codeEditorService.js';
+import { ILanguageConfigurationService } from '../../../../../editor/common/languages/languageConfigurationRegistry.js';
+import { ILanguageService } from '../../../../../editor/common/languages/language.js';
+import { ITextModel } from '../../../../../editor/common/model.js';
+import { LanguageService } from '../../../../../editor/common/services/languageService.js';
+import { ModelService } from '../../../../../editor/common/services/modelService.js';
+import { ITreeSitterLibraryService } from '../../../../../editor/common/services/treeSitter/treeSitterLibraryService.js';
+import { TestCodeEditorService } from '../../../../../editor/test/browser/editorTestServices.js';
+import { createTestCodeEditor, ITestCodeEditor } from '../../../../../editor/test/browser/testCodeEditor.js';
+import { TestLanguageConfigurationService } from '../../../../../editor/test/common/modes/testLanguageConfigurationService.js';
+import { TestTreeSitterLibraryService } from '../../../../../editor/test/common/services/testTreeSitterLibraryService.js';
+import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { TestDialogService } from '../../../../../platform/dialogs/test/common/testDialogService.js';
+import { ITextEditorDiffInformation } from '../../../../../platform/editor/common/editor.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
+import { TestNotificationService } from '../../../../../platform/notification/test/common/testNotificationService.js';
+import { TestThemeService } from '../../../../../platform/theme/test/common/testThemeService.js';
+import { IUndoRedoService } from '../../../../../platform/undoRedo/common/undoRedo.js';
+import { UndoRedoService } from '../../../../../platform/undoRedo/common/undoRedoService.js';
+import { UriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentityService.js';
+import { IQuickDiffModelService } from '../../../../contrib/scm/browser/quickDiffModel.js';
+import { IPaneCompositePartService } from '../../../../services/panecomposite/browser/panecomposite.js';
+import { ITextFileEditorModelManager, ITextFileService } from '../../../../services/textfile/common/textfiles.js';
+import { IUntitledTextEditorModelManager } from '../../../../services/untitled/common/untitledTextEditorService.js';
+import { TestEditorGroupsService, TestEditorService, TestEnvironmentService, TestPathService } from '../../../../test/browser/workbenchTestServices.js';
+import { TestTextResourcePropertiesService, TestWorkingCopyFileService } from '../../../../test/common/workbenchTestServices.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { MainThreadDocumentsAndEditors } from '../../../browser/mainThreadDocumentsAndEditors.js';
+import { IDocumentsAndEditorsDelta } from '../../../common/extHost.protocol.js';
+import { SingleProxyRPCProtocol } from '../../common/testRPCProtocol.js';
+
+/**
+ * A real `MainThreadDocumentsAndEditors` plus the services it needs, wired for tests that
+ * exercise the Positron-only console editor registration path.
+ *
+ * The wiring mirrors the upstream Mocha suite in `../mainThreadDocumentsAndEditors.test.ts`
+ * (real `ModelService` + real test code editors) so that `ICodeEditor.onDidChangeModel` fires
+ * genuinely when a model is attached -- the exact timing console editor registration depends on.
+ *
+ * Create one per test and `dispose()` it in `afterEach`.
+ */
+export class ConsoleEditorTestServices {
+
+	/** Deltas the main thread sent to the (fake) extension host. */
+	readonly deltas: IDocumentsAndEditorsDelta[] = [];
+
+	readonly modelService: ModelService;
+	readonly documentsAndEditors: MainThreadDocumentsAndEditors;
+
+	private readonly _codeEditorService: TestCodeEditorService;
+
+	/** Long-lived services; disposed last, after everything that reads them. */
+	private readonly _services = new DisposableStore();
+
+	/**
+	 * Editors, models and console registrations created by a test. Disposed while the main-thread
+	 * instance is still alive so their `MainThreadTextEditor`s drain through the live state
+	 * computer.
+	 */
+	private readonly _perTest = new DisposableStore();
+
+	constructor() {
+		const configService = new TestConfigurationService();
+		configService.setUserConfiguration('editor', { 'detectIndentation': false });
+		const dialogService = new TestDialogService();
+		const notificationService = new TestNotificationService();
+		const undoRedoService = new UndoRedoService(dialogService, notificationService);
+		const themeService = new TestThemeService();
+		// TestInstantiationService here only bootstraps the ModelService helper (per vitest-tests.md
+		// exception), it is not used as the primary DI container for the class under test.
+		const instantiationService = new TestInstantiationService();
+		instantiationService.set(ILanguageService, this._services.add(new LanguageService()));
+		instantiationService.set(ILanguageConfigurationService, this._services.add(new TestLanguageConfigurationService()));
+		instantiationService.set(ITreeSitterLibraryService, new TestTreeSitterLibraryService());
+		instantiationService.set(IUndoRedoService, undoRedoService);
+		this.modelService = this._services.add(new ModelService(
+			configService,
+			new TestTextResourcePropertiesService(configService),
+			undoRedoService,
+			instantiationService
+		));
+		this._codeEditorService = this._services.add(new TestCodeEditorService(themeService));
+		const textFileService = new class extends mock<ITextFileService>() {
+			override isDirty() { return false; }
+			// Only the events subscribed by MainThreadDocuments's constructor are read here.
+			override files = stubInterface<ITextFileEditorModelManager>({
+				onDidSave: Event.None,
+				onDidChangeDirty: Event.None,
+				onDidChangeEncoding: Event.None
+			});
+			override untitled = stubInterface<IUntitledTextEditorModelManager>({
+				onDidChangeEncoding: Event.None
+			});
+			override getEncoding() { return 'utf8'; }
+		};
+		const workbenchEditorService = this._services.add(new TestEditorService());
+		const editorGroupService = new TestEditorGroupsService();
+
+		const fileService = new class extends mock<IFileService>() {
+			override onDidRunOperation = Event.None;
+			override onDidChangeFileSystemProviderCapabilities = Event.None;
+			override onDidChangeFileSystemProviderRegistrations = Event.None;
+		};
+
+		this.documentsAndEditors = new MainThreadDocumentsAndEditors(
+			SingleProxyRPCProtocol({
+				$acceptDocumentsAndEditorsDelta: (delta: IDocumentsAndEditorsDelta) => { this.deltas.push(delta); },
+				$acceptEditorDiffInformation: (_id: string, _diffInformation: ITextEditorDiffInformation | undefined) => { }
+			}),
+			this.modelService,
+			textFileService,
+			workbenchEditorService,
+			this._codeEditorService,
+			fileService,
+			null!,
+			editorGroupService,
+			new class extends mock<IPaneCompositePartService>() implements IPaneCompositePartService {
+				override onDidPaneCompositeOpen = Event.None;
+				override onDidPaneCompositeClose = Event.None;
+				override getActivePaneComposite() {
+					return undefined;
+				}
+			},
+			TestEnvironmentService,
+			new TestWorkingCopyFileService(),
+			this._services.add(new UriIdentityService(fileService)),
+			new class extends mock<IClipboardService>() {
+				override readText() {
+					return Promise.resolve('clipboard_contents');
+				}
+			},
+			new TestPathService(),
+			new TestConfigurationService(),
+			new class extends mock<IQuickDiffModelService>() {
+				override createQuickDiffModelReference() {
+					return undefined;
+				}
+			}
+		);
+	}
+
+	/** Creates a test code editor, optionally with a model already attached. */
+	createCodeEditor(model: ITextModel | undefined): ITestCodeEditor {
+		return this._perTest.add(createTestCodeEditor(model, {
+			hasTextFocus: false,
+			serviceCollection: new ServiceCollection(
+				[ICodeEditorService, this._codeEditorService]
+			)
+		}));
+	}
+
+	createModel(value: string): ITextModel {
+		return this._perTest.add(this.modelService.createModel(value, null));
+	}
+
+	/** Registers a disposable owned by the current test (e.g. a console editor registration). */
+	add<T extends { dispose(): void }>(disposable: T): T {
+		return this._perTest.add(disposable);
+	}
+
+	/**
+	 * Deltas emitted by `registerConsoleEditor` contain a single `addedEditors` entry whose id is
+	 * the console id we passed; deltas from the ambient state computer use composite
+	 * `${editorId},${modelId}` ids, so filtering by our exact id isolates the registration under
+	 * test.
+	 */
+	consoleAdds(id: string): IDocumentsAndEditorsDelta[] {
+		return this.deltas.filter(d => d.addedEditors?.some(e => e.id === id));
+	}
+
+	consoleRemoves(id: string): IDocumentsAndEditorsDelta[] {
+		return this.deltas.filter(d => d.removedEditors?.includes(id));
+	}
+
+	dispose(): void {
+		this._perTest.dispose();
+		this.documentsAndEditors.dispose();
+		this._services.dispose();
+	}
+}

--- a/src/vs/workbench/api/test/browser/positron/mainThreadConsoleService.vitest.ts
+++ b/src/vs/workbench/api/test/browser/positron/mainThreadConsoleService.vitest.ts
@@ -9,10 +9,11 @@ import { ILanguageRuntimeMetadata, LanguageRuntimeSessionMode } from '../../../.
 import { IRuntimeSessionMetadata } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { TestPositronConsoleInstance, TestPositronConsoleService } from '../../../../services/positronConsole/test/browser/testPositronConsoleService.js';
 import { IExtHostContext } from '../../../../services/extensions/common/extHostCustomers.js';
+import { ProxyIdentifier } from '../../../../services/extensions/common/proxyIdentifier.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { ensureNoLeakedDisposables } from '../../../../../test/vitest/vitestUtils.js';
 import { MainThreadConsoleService } from '../../../browser/positron/mainThreadConsoleService.js';
-import { ExtHostConsoleServiceShape } from '../../../common/positron/extHost.positron.protocol.js';
+import { ExtHostConsoleServiceShape, MainPositronContext } from '../../../common/positron/extHost.positron.protocol.js';
 import { SingleProxyRPCProtocol } from '../../common/testRPCProtocol.js';
 import { ConsoleEditorTestServices } from './consoleEditorTestServices.js';
 
@@ -38,7 +39,14 @@ describe('MainThreadConsoleService (console editors)', () => {
 	let mainThreadConsoleService: MainThreadConsoleService;
 	let calls: ConsoleEditorCall[];
 
-	function createMainThreadConsoleService(): MainThreadConsoleService {
+	/**
+	 * An `IExtHostContext` that resolves raw actors the way `RPCProtocol` does: `getRaw` throws
+	 * until the actor has been `set`. That ordering is the point -- `MainThreadConsoleService` is an
+	 * `@extHostNamedCustomer` and the hidden editor manager is set by `MainThreadDocumentsAndEditors`,
+	 * a plain `@extHostCustomer` constructed afterwards, so the actor is missing for the whole of
+	 * `MainThreadConsoleService`'s constructor.
+	 */
+	function createExtHostContext(): IExtHostContext {
 		const proxy = stubInterface<ExtHostConsoleServiceShape>({
 			$addConsole: vi.fn(),
 			$onDidChangeActiveConsole: (sessionId: string | undefined) => {
@@ -57,20 +65,53 @@ describe('MainThreadConsoleService (console editors)', () => {
 			},
 			$acceptConsoleEditorPropertiesChanged: vi.fn()
 		});
-		const extHostContext: IExtHostContext = {
+		const locals = new Map<string, unknown>();
+		return {
 			...SingleProxyRPCProtocol(proxy),
-			// `getRaw` is generic over the proxy identifier, so the cast is what tells the
-			// compiler which actor this test hands back -- the hidden editor manager.
-			getRaw: <T, R extends T>(): R => services.documentsAndEditors as unknown as R,
+			set: <T, R extends T>(identifier: ProxyIdentifier<T>, instance: R): R => {
+				locals.set(identifier.sid, instance);
+				return instance;
+			},
+			getRaw: <T, R extends T>(identifier: ProxyIdentifier<T>): R => {
+				const local = locals.get(identifier.sid);
+				if (!local) {
+					// Same failure as `RPCProtocol.getRaw`. Thrown from a customer's constructor it
+					// leaves that customer's RPC channel unregistered entirely.
+					throw new Error(`Missing actor ${identifier.sid}.`);
+				}
+				return local as R;
+			}
 		};
-		return new MainThreadConsoleService(extHostContext, consoleService);
 	}
 
-	beforeEach(() => {
+	/** Registers the hidden editor manager, as the plain customer that owns it does. */
+	function registerHiddenEditorManager(extHostContext: IExtHostContext): void {
+		extHostContext.set(MainPositronContext.MainThreadHiddenEditorManager, services.documentsAndEditors);
+	}
+
+	/** Constructs the service the way `ExtensionHostManager` does: named customer, then the rest. */
+	function createMainThreadConsoleService(): MainThreadConsoleService {
+		const extHostContext = createExtHostContext();
+		const service = new MainThreadConsoleService(extHostContext, consoleService);
+		registerHiddenEditorManager(extHostContext);
+		return service;
+	}
+
+	/**
+	 * Lets the deferred constructor replay run, as it does once every customer is constructed.
+	 */
+	function flushDeferredReplay(): Promise<void> {
+		return new Promise<void>((resolve) => setTimeout(resolve, 0));
+	}
+
+	beforeEach(async () => {
 		services = new ConsoleEditorTestServices();
 		calls = [];
 		consoleService = new TestPositronConsoleService();
 		mainThreadConsoleService = createMainThreadConsoleService();
+		// Start each test from a settled service: no consoles exist yet, so the replay is a no-op,
+		// but it must not still be pending while a test records calls.
+		await flushDeferredReplay();
 	});
 
 	afterEach(() => {
@@ -105,6 +146,15 @@ describe('MainThreadConsoleService (console editors)', () => {
 		instance.setCodeEditor(editor);
 		editor.setModel(services.createModel('> '));
 		return editor;
+	}
+
+	// A console whose input editor is already mounted by the time the service sees it -- what an
+	// already-running console looks like after an extension host restart.
+	function addPreMountedConsole(sessionId: string): TestPositronConsoleInstance {
+		const instance = createInstance(sessionId);
+		instance.codeEditor = services.createCodeEditor(services.createModel('> '));
+		consoleService.addTestConsoleInstance(instance);
+		return instance;
 	}
 
 	/** Only the console editor traffic, dropping the active-console bookkeeping. */
@@ -166,7 +216,7 @@ describe('MainThreadConsoleService (console editors)', () => {
 		expect(services.documentsAndEditors.getEditor('console-session-1')).toBeUndefined();
 	});
 
-	it('replays consoles that already exist when the service is created', () => {
+	it('replays consoles that already exist, but only once every customer is constructed', async () => {
 		// Simulates an extension host restart: the consoles are already running and will never
 		// re-fire `onDidStartPositronConsoleInstance`.
 		addMountedConsole('session-a');
@@ -174,8 +224,18 @@ describe('MainThreadConsoleService (console editors)', () => {
 		consoleService.setActivePositronConsoleSession('session-a');
 		calls = [];
 
-		const replayed = createMainThreadConsoleService();
+		const extHostContext = createExtHostContext();
+		const replayed = new MainThreadConsoleService(extHostContext, consoleService);
 		try {
+			// Nothing yet. The console input's document only reaches the extension host in the
+			// initial documents-and-editors delta, which the customer registering the hidden editor
+			// manager sends from its own constructor -- i.e. after this one has run. Announcing an
+			// editor here would arrive ahead of its document and the extension host would drop it.
+			expect(calls).toEqual([]);
+
+			registerHiddenEditorManager(extHostContext);
+			await flushDeferredReplay();
+
 			expect(calls).toEqual([
 				{ kind: 'add', sessionId: 'session-a', editorId: 'console-session-a', resolvable: true },
 				{ kind: 'add', sessionId: 'session-b', editorId: 'console-session-b', resolvable: true },
@@ -184,6 +244,61 @@ describe('MainThreadConsoleService (console editors)', () => {
 		} finally {
 			replayed.dispose();
 		}
+	});
+
+	it('registers editors even though the hidden editor manager does not exist yet while it constructs', async () => {
+		// Drop the service created in `beforeEach` so only the one under test reports traffic.
+		mainThreadConsoleService.dispose();
+
+		const extHostContext = createExtHostContext();
+		// Named customers are constructed first, so resolving the manager here throws -- and the
+		// customer loop swallows constructor errors, so an eager `getRaw` would silently leave this
+		// service's whole RPC channel (`$getConsoleWidth`, `$tryPasteText`, ...) unregistered.
+		expect(() => extHostContext.getRaw(MainPositronContext.MainThreadHiddenEditorManager)).toThrow();
+		mainThreadConsoleService = new MainThreadConsoleService(extHostContext, consoleService);
+		registerHiddenEditorManager(extHostContext);
+		await flushDeferredReplay();
+		calls = [];
+
+		addMountedConsole('session-1');
+
+		expect(editorCalls()).toEqual([
+			{ kind: 'add', sessionId: 'session-1', editorId: 'console-session-1', resolvable: true }
+		]);
+	});
+
+	it('replaces the registration when the console input swaps in a new editor', () => {
+		const instance = addMountedConsole('session-1');
+		calls = [];
+
+		// A fresh editor is assigned while the previous one is still alive (the Console view
+		// re-created it without disposing the old widget first).
+		const replacement = services.createCodeEditor(services.createModel('> '));
+		instance.setCodeEditor(replacement);
+
+		// The old registration must be retired first: it shares the editor id with its replacement,
+		// so cleaning it up afterwards would retire the new editor instead.
+		expect(editorCalls()).toEqual([
+			{ kind: 'remove', sessionId: 'session-1' },
+			{ kind: 'add', sessionId: 'session-1', editorId: 'console-session-1', resolvable: true }
+		]);
+		expect(services.documentsAndEditors.getEditor('console-session-1')?.getCodeEditor()).toBe(replacement);
+	});
+
+	it('retires the previous tracking when the same session id is registered again', () => {
+		addMountedConsole('session-1');
+		calls = [];
+
+		// The console instance for this session is replaced in place, and its editor is already
+		// mounted, so the new registration exists before the old tracking is torn down.
+		const replacement = addPreMountedConsole('session-1');
+
+		expect(editorCalls()).toEqual([
+			{ kind: 'remove', sessionId: 'session-1' },
+			{ kind: 'add', sessionId: 'session-1', editorId: 'console-session-1', resolvable: true }
+		]);
+		expect(services.documentsAndEditors.getEditor('console-session-1')?.getCodeEditor())
+			.toBe(replacement.codeEditor);
 	});
 
 	it('announces each console as it becomes active', () => {

--- a/src/vs/workbench/api/test/browser/positron/mainThreadConsoleService.vitest.ts
+++ b/src/vs/workbench/api/test/browser/positron/mainThreadConsoleService.vitest.ts
@@ -16,50 +16,61 @@ import { ExtHostConsoleServiceShape } from '../../../common/positron/extHost.pos
 import { SingleProxyRPCProtocol } from '../../common/testRPCProtocol.js';
 import { ConsoleEditorTestServices } from './consoleEditorTestServices.js';
 
-// A record of every `$setActiveConsoleEditor` call the main thread made, paired with whether the
-// extension host could have resolved that editor at the time of the call. `resolvable: false`
-// means `positron.window.activeConsoleEditor` would have been `undefined` when the
-// `onDidChangeActiveConsoleEditor` event fired -- the bug this suite guards against.
-interface IActiveEditorNotification {
-	editorId: string | null;
-	resolvable: boolean;
-}
+// The Positron-only console editor traffic the main thread sent to the (fake) extension host, in
+// order. `resolvable` records whether the editor id in an `add` could be resolved on the main
+// thread at the time of the call -- `false` would mean the extension host was handed an editor id
+// it cannot use.
+type ConsoleEditorCall =
+	| { kind: 'add'; sessionId: string; editorId: string; resolvable: boolean }
+	| { kind: 'remove'; sessionId: string }
+	| { kind: 'activeConsole'; sessionId: string | undefined };
 
-// Tests for the notification side of `positron.window.activeConsoleEditor`: the main thread must
-// only tell the extension host about a console editor once that editor has actually been
-// registered, which is deferred until the console input attaches its text model.
-describe('MainThreadConsoleService (active console editor)', () => {
+// Tests for `positron.window.activeConsoleEditor` as seen from the main thread: the console input
+// editor must reach the extension host on the Positron-only console channel (never the core
+// documents-and-editors delta), only once it actually has a text model, and must be retired when
+// the Console view remounts or the console goes away.
+describe('MainThreadConsoleService (console editors)', () => {
 
 	ensureNoLeakedDisposables();
 
 	let services: ConsoleEditorTestServices;
 	let consoleService: TestPositronConsoleService;
 	let mainThreadConsoleService: MainThreadConsoleService;
-	let notifications: IActiveEditorNotification[];
+	let calls: ConsoleEditorCall[];
 
-	beforeEach(() => {
-		services = new ConsoleEditorTestServices();
-		notifications = [];
-
+	function createMainThreadConsoleService(): MainThreadConsoleService {
 		const proxy = stubInterface<ExtHostConsoleServiceShape>({
 			$addConsole: vi.fn(),
-			$onDidChangeActiveConsole: vi.fn(),
-			$setActiveConsoleEditor: (editorId: string | null) => {
-				notifications.push({
-					editorId,
-					resolvable: editorId !== null && services.documentsAndEditors.getEditor(editorId) !== undefined
+			$onDidChangeActiveConsole: (sessionId: string | undefined) => {
+				calls.push({ kind: 'activeConsole', sessionId });
+			},
+			$addConsoleEditor: (sessionId, data) => {
+				calls.push({
+					kind: 'add',
+					sessionId,
+					editorId: data.id,
+					resolvable: services.documentsAndEditors.getEditor(data.id) !== undefined
 				});
-			}
+			},
+			$removeConsoleEditor: (sessionId: string) => {
+				calls.push({ kind: 'remove', sessionId });
+			},
+			$acceptConsoleEditorPropertiesChanged: vi.fn()
 		});
 		const extHostContext: IExtHostContext = {
 			...SingleProxyRPCProtocol(proxy),
 			// `getRaw` is generic over the proxy identifier, so the cast is what tells the
-			// compiler which actor this test hands back -- the console editor manager.
+			// compiler which actor this test hands back -- the hidden editor manager.
 			getRaw: <T, R extends T>(): R => services.documentsAndEditors as unknown as R,
 		};
+		return new MainThreadConsoleService(extHostContext, consoleService);
+	}
 
+	beforeEach(() => {
+		services = new ConsoleEditorTestServices();
+		calls = [];
 		consoleService = new TestPositronConsoleService();
-		mainThreadConsoleService = new MainThreadConsoleService(extHostContext, consoleService);
+		mainThreadConsoleService = createMainThreadConsoleService();
 	});
 
 	afterEach(() => {
@@ -85,72 +96,109 @@ describe('MainThreadConsoleService (active console editor)', () => {
 	function addMountedConsole(sessionId: string): TestPositronConsoleInstance {
 		const instance = createInstance(sessionId);
 		consoleService.addTestConsoleInstance(instance);
-		const editor = services.createCodeEditor(undefined);
-		instance.setCodeEditor(editor);
-		editor.setModel(services.createModel('> '));
+		mountEditor(instance);
 		return instance;
 	}
 
-	it('waits for the editor to exist before announcing it to the ext host', () => {
-		const instance = createInstance('session-1');
-		consoleService.addTestConsoleInstance(instance);
-		consoleService.setActivePositronConsoleSession('session-1');
-
-		// The console is active but has no input editor yet, so there is nothing to announce.
-		expect(notifications).toEqual([]);
-
-		// The console input assigns its code editor before attaching a text model. Registration
-		// with the ext host is deferred until the model arrives, so announcing the editor here
-		// would fire `onDidChangeActiveConsoleEditor` with an unresolvable editor -- and, since
-		// there is no second notification, extensions would never see the usable one.
+	function mountEditor(instance: TestPositronConsoleInstance) {
 		const editor = services.createCodeEditor(undefined);
 		instance.setCodeEditor(editor);
-		expect(notifications).toEqual([]);
-		expect(services.consoleAdds('console-session-1')).toHaveLength(0);
+		editor.setModel(services.createModel('> '));
+		return editor;
+	}
+
+	/** Only the console editor traffic, dropping the active-console bookkeeping. */
+	function editorCalls(): ConsoleEditorCall[] {
+		return calls.filter(call => call.kind !== 'activeConsole');
+	}
+
+	it('waits for the text model before announcing the editor to the ext host', () => {
+		const instance = createInstance('session-1');
+		consoleService.addTestConsoleInstance(instance);
+
+		// The console exists but has no input editor yet, so there is nothing to announce.
+		expect(editorCalls()).toEqual([]);
+
+		// The console input assigns its code editor before attaching a text model. Announcing the
+		// editor here would hand the ext host an editor id it cannot resolve.
+		const editor = services.createCodeEditor(undefined);
+		instance.setCodeEditor(editor);
+		expect(editorCalls()).toEqual([]);
 
 		// Attaching the model completes registration; only now is the editor announced.
 		editor.setModel(services.createModel('> '));
-		expect(notifications).toEqual([{ editorId: 'console-session-1', resolvable: true }]);
+		expect(editorCalls()).toEqual([
+			{ kind: 'add', sessionId: 'session-1', editorId: 'console-session-1', resolvable: true }
+		]);
 	});
 
-	it('announces the editor of each console as it becomes active', () => {
-		// Each console announces itself once mounted, since adding it also makes it active.
+	it('keeps the console editor off the core documents-and-editors channel', () => {
+		addMountedConsole('session-1');
+
+		// The editor travels only over the Positron console channel, so it never appears in
+		// `vscode.window.visibleTextEditors` or the core editor events (posit-dev/positron#780).
+		expect(services.coreDeltaMentions('console-session-1')).toEqual([]);
+		expect(services.coreEditorStateCalls('console-session-1')).toEqual([]);
+	});
+
+	it('re-registers the editor when the Console view remounts', () => {
+		const instance = addMountedConsole('session-1');
+		calls = [];
+
+		// Remount: the old editor widget is disposed and a fresh one is assigned. Without the
+		// re-registration the ext host would keep resolving the disposed editor and model.
+		instance.codeEditor!.dispose();
+		mountEditor(instance);
+
+		expect(editorCalls()).toEqual([
+			{ kind: 'remove', sessionId: 'session-1' },
+			{ kind: 'add', sessionId: 'session-1', editorId: 'console-session-1', resolvable: true }
+		]);
+	});
+
+	it('retires the editor when the console is deleted', () => {
+		addMountedConsole('session-1');
+		calls = [];
+
+		consoleService.deletePositronConsoleSession('session-1');
+
+		expect(editorCalls()).toEqual([{ kind: 'remove', sessionId: 'session-1' }]);
+		expect(services.documentsAndEditors.getEditor('console-session-1')).toBeUndefined();
+	});
+
+	it('replays consoles that already exist when the service is created', () => {
+		// Simulates an extension host restart: the consoles are already running and will never
+		// re-fire `onDidStartPositronConsoleInstance`.
 		addMountedConsole('session-a');
 		addMountedConsole('session-b');
+		consoleService.setActivePositronConsoleSession('session-a');
+		calls = [];
+
+		const replayed = createMainThreadConsoleService();
+		try {
+			expect(calls).toEqual([
+				{ kind: 'add', sessionId: 'session-a', editorId: 'console-session-a', resolvable: true },
+				{ kind: 'add', sessionId: 'session-b', editorId: 'console-session-b', resolvable: true },
+				{ kind: 'activeConsole', sessionId: 'session-a' },
+			]);
+		} finally {
+			replayed.dispose();
+		}
+	});
+
+	it('announces each console as it becomes active', () => {
+		addMountedConsole('session-a');
+		addMountedConsole('session-b');
+		calls = [];
 
 		consoleService.setActivePositronConsoleSession('session-a');
 		consoleService.setActivePositronConsoleSession('session-b');
-		// Re-activating the console that is already announced is not a change.
-		consoleService.setActivePositronConsoleSession('session-b');
 
-		expect(notifications).toEqual([
-			{ editorId: 'console-session-a', resolvable: true },
-			{ editorId: 'console-session-b', resolvable: true },
-			{ editorId: 'console-session-a', resolvable: true },
-			{ editorId: 'console-session-b', resolvable: true },
+		// The extension host derives the active console editor from the active session, so the
+		// main thread only has to report which console is active.
+		expect(calls).toEqual([
+			{ kind: 'activeConsole', sessionId: 'session-a' },
+			{ kind: 'activeConsole', sessionId: 'session-b' },
 		]);
-	});
-
-	it('clears the announced editor when the newly active console has none yet', () => {
-		addMountedConsole('session-a');
-
-		// A console whose input has not mounted becomes active: the ext host must stop reporting
-		// the previous console's editor rather than hold on to a stale one.
-		const pending = createInstance('session-pending');
-		consoleService.addTestConsoleInstance(pending);
-		consoleService.setActivePositronConsoleSession('session-pending');
-
-		expect(notifications).toEqual([
-			{ editorId: 'console-session-a', resolvable: true },
-			{ editorId: null, resolvable: false },
-		]);
-
-		// Once its editor mounts, the pending console announces it.
-		const editor = services.createCodeEditor(undefined);
-		pending.setCodeEditor(editor);
-		editor.setModel(services.createModel('> '));
-
-		expect(notifications).toHaveLength(3);
-		expect(notifications[2]).toEqual({ editorId: 'console-session-pending', resolvable: true });
 	});
 });

--- a/src/vs/workbench/api/test/browser/positron/mainThreadConsoleService.vitest.ts
+++ b/src/vs/workbench/api/test/browser/positron/mainThreadConsoleService.vitest.ts
@@ -1,0 +1,156 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { ILanguageRuntimeMetadata, LanguageRuntimeSessionMode } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
+import { IRuntimeSessionMetadata } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
+import { TestPositronConsoleInstance, TestPositronConsoleService } from '../../../../services/positronConsole/test/browser/testPositronConsoleService.js';
+import { IExtHostContext } from '../../../../services/extensions/common/extHostCustomers.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { ensureNoLeakedDisposables } from '../../../../../test/vitest/vitestUtils.js';
+import { MainThreadConsoleService } from '../../../browser/positron/mainThreadConsoleService.js';
+import { ExtHostConsoleServiceShape } from '../../../common/positron/extHost.positron.protocol.js';
+import { SingleProxyRPCProtocol } from '../../common/testRPCProtocol.js';
+import { ConsoleEditorTestServices } from './consoleEditorTestServices.js';
+
+// A record of every `$setActiveConsoleEditor` call the main thread made, paired with whether the
+// extension host could have resolved that editor at the time of the call. `resolvable: false`
+// means `positron.window.activeConsoleEditor` would have been `undefined` when the
+// `onDidChangeActiveConsoleEditor` event fired -- the bug this suite guards against.
+interface IActiveEditorNotification {
+	editorId: string | null;
+	resolvable: boolean;
+}
+
+// Tests for the notification side of `positron.window.activeConsoleEditor`: the main thread must
+// only tell the extension host about a console editor once that editor has actually been
+// registered, which is deferred until the console input attaches its text model.
+describe('MainThreadConsoleService (active console editor)', () => {
+
+	ensureNoLeakedDisposables();
+
+	let services: ConsoleEditorTestServices;
+	let consoleService: TestPositronConsoleService;
+	let mainThreadConsoleService: MainThreadConsoleService;
+	let notifications: IActiveEditorNotification[];
+
+	beforeEach(() => {
+		services = new ConsoleEditorTestServices();
+		notifications = [];
+
+		const proxy = stubInterface<ExtHostConsoleServiceShape>({
+			$addConsole: vi.fn(),
+			$onDidChangeActiveConsole: vi.fn(),
+			$setActiveConsoleEditor: (editorId: string | null) => {
+				notifications.push({
+					editorId,
+					resolvable: editorId !== null && services.documentsAndEditors.getEditor(editorId) !== undefined
+				});
+			}
+		});
+		const extHostContext: IExtHostContext = {
+			...SingleProxyRPCProtocol(proxy),
+			// `getRaw` is generic over the proxy identifier, so the cast is what tells the
+			// compiler which actor this test hands back -- the console editor manager.
+			getRaw: <T, R extends T>(): R => services.documentsAndEditors as unknown as R,
+		};
+
+		consoleService = new TestPositronConsoleService();
+		mainThreadConsoleService = new MainThreadConsoleService(extHostContext, consoleService);
+	});
+
+	afterEach(() => {
+		// Dispose the console registrations while the main-thread editor tracking is still alive.
+		mainThreadConsoleService.dispose();
+		services.dispose();
+	});
+
+	function createInstance(sessionId: string): TestPositronConsoleInstance {
+		const sessionMetadata: IRuntimeSessionMetadata = {
+			sessionId,
+			sessionMode: LanguageRuntimeSessionMode.Console,
+			notebookUri: undefined,
+			createdTimestamp: 0,
+			startReason: 'test',
+		};
+		const runtimeMetadata = stubInterface<ILanguageRuntimeMetadata>({ languageId: 'python' });
+		return new TestPositronConsoleInstance(sessionId, 'Python', sessionMetadata, runtimeMetadata);
+	}
+
+	// Drives a console through the real mount sequence: the instance starts without a code editor,
+	// the React input assigns one, and only then is a text model attached.
+	function addMountedConsole(sessionId: string): TestPositronConsoleInstance {
+		const instance = createInstance(sessionId);
+		consoleService.addTestConsoleInstance(instance);
+		const editor = services.createCodeEditor(undefined);
+		instance.setCodeEditor(editor);
+		editor.setModel(services.createModel('> '));
+		return instance;
+	}
+
+	it('waits for the editor to exist before announcing it to the ext host', () => {
+		const instance = createInstance('session-1');
+		consoleService.addTestConsoleInstance(instance);
+		consoleService.setActivePositronConsoleSession('session-1');
+
+		// The console is active but has no input editor yet, so there is nothing to announce.
+		expect(notifications).toEqual([]);
+
+		// The console input assigns its code editor before attaching a text model. Registration
+		// with the ext host is deferred until the model arrives, so announcing the editor here
+		// would fire `onDidChangeActiveConsoleEditor` with an unresolvable editor -- and, since
+		// there is no second notification, extensions would never see the usable one.
+		const editor = services.createCodeEditor(undefined);
+		instance.setCodeEditor(editor);
+		expect(notifications).toEqual([]);
+		expect(services.consoleAdds('console-session-1')).toHaveLength(0);
+
+		// Attaching the model completes registration; only now is the editor announced.
+		editor.setModel(services.createModel('> '));
+		expect(notifications).toEqual([{ editorId: 'console-session-1', resolvable: true }]);
+	});
+
+	it('announces the editor of each console as it becomes active', () => {
+		// Each console announces itself once mounted, since adding it also makes it active.
+		addMountedConsole('session-a');
+		addMountedConsole('session-b');
+
+		consoleService.setActivePositronConsoleSession('session-a');
+		consoleService.setActivePositronConsoleSession('session-b');
+		// Re-activating the console that is already announced is not a change.
+		consoleService.setActivePositronConsoleSession('session-b');
+
+		expect(notifications).toEqual([
+			{ editorId: 'console-session-a', resolvable: true },
+			{ editorId: 'console-session-b', resolvable: true },
+			{ editorId: 'console-session-a', resolvable: true },
+			{ editorId: 'console-session-b', resolvable: true },
+		]);
+	});
+
+	it('clears the announced editor when the newly active console has none yet', () => {
+		addMountedConsole('session-a');
+
+		// A console whose input has not mounted becomes active: the ext host must stop reporting
+		// the previous console's editor rather than hold on to a stale one.
+		const pending = createInstance('session-pending');
+		consoleService.addTestConsoleInstance(pending);
+		consoleService.setActivePositronConsoleSession('session-pending');
+
+		expect(notifications).toEqual([
+			{ editorId: 'console-session-a', resolvable: true },
+			{ editorId: null, resolvable: false },
+		]);
+
+		// Once its editor mounts, the pending console announces it.
+		const editor = services.createCodeEditor(undefined);
+		pending.setCodeEditor(editor);
+		editor.setModel(services.createModel('> '));
+
+		expect(notifications).toHaveLength(3);
+		expect(notifications[2]).toEqual({ editorId: 'console-session-pending', resolvable: true });
+	});
+});

--- a/src/vs/workbench/api/test/browser/positron/mainThreadDocumentsAndEditors.vitest.ts
+++ b/src/vs/workbench/api/test/browser/positron/mainThreadDocumentsAndEditors.vitest.ts
@@ -5,12 +5,15 @@
 
 /// <reference types="vitest/globals" />
 
+import { Selection } from '../../../../../editor/common/core/selection.js';
 import { ensureNoLeakedDisposables } from '../../../../../test/vitest/vitestUtils.js';
+import { IEditorPropertiesChangeData } from '../../../common/extHost.protocol.js';
 import { ConsoleEditorTestServices } from './consoleEditorTestServices.js';
 
-// Tests for the Positron-only `MainThreadDocumentsAndEditors.registerConsoleEditor` method, which
-// backs `positron.window.activeConsoleEditor`. See `ConsoleEditorTestServices` for the wiring.
-describe('MainThreadDocumentsAndEditors (Positron console editor)', () => {
+// Tests for the Positron-only `MainThreadDocumentsAndEditors.registerHiddenTextEditor` method,
+// which backs `positron.window.activeConsoleEditor`. See `ConsoleEditorTestServices` for the
+// wiring.
+describe('MainThreadDocumentsAndEditors (Positron hidden editor)', () => {
 
 	ensureNoLeakedDisposables();
 
@@ -26,65 +29,41 @@ describe('MainThreadDocumentsAndEditors (Positron console editor)', () => {
 		services.dispose();
 	});
 
-	it('registers immediately when the code editor already has a model', () => {
+	it('makes the editor resolvable by id without touching the core editor channel', () => {
 		const model = services.createModel('> ');
 		const editor = services.createCodeEditor(model);
 
-		const store = services.documentsAndEditors.registerConsoleEditor('console-1', editor);
+		const registration = services.documentsAndEditors.registerHiddenTextEditor('console-1', editor, model);
 
-		expect(services.consoleAdds('console-1')).toHaveLength(1);
+		// Resolvable by id, so `edit()` / `insertSnippet()` / selection writes from the extension
+		// host reach this editor...
+		expect(services.documentsAndEditors.getEditor('console-1')).toBeDefined();
+		expect(registration.addData).toMatchObject({ id: 'console-1', documentUri: model.uri });
 
-		// Disposing the registration removes the editor from the ext host.
-		store.dispose();
-		expect(services.consoleRemoves('console-1')).toHaveLength(1);
+		// ...but invisible to core VS Code editor APIs: no `addedEditors` delta, and no editor
+		// state sent on the core channel (posit-dev/positron#780).
+		expect(services.coreDeltaMentions('console-1')).toEqual([]);
+		expect(services.coreEditorStateCalls('console-1')).toEqual([]);
+
+		registration.dispose();
+		expect(services.documentsAndEditors.getEditor('console-1')).toBeUndefined();
+		expect(services.coreDeltaMentions('console-1')).toEqual([]);
 	});
 
-	it('defers registration until a model is attached (the fix)', () => {
-		// Console input assigns its code editor before the text model attaches.
-		const editor = services.createCodeEditor(undefined);
+	it('reports property changes to its own listener rather than the core channel', () => {
+		const model = services.createModel('hello');
+		const editor = services.createCodeEditor(model);
 
-		services.add(services.documentsAndEditors.registerConsoleEditor('console-2', editor));
+		const registration = services.add(services.documentsAndEditors.registerHiddenTextEditor('console-2', editor, model));
 
-		// Nothing registered yet -- a regression that bailed on the missing model would leave
-		// `activeConsoleEditor` permanently unresolved here.
-		expect(services.consoleAdds('console-2')).toHaveLength(0);
+		const changes: IEditorPropertiesChangeData[] = [];
+		services.add(registration.onPropertiesChanged(data => changes.push(data)));
 
-		// Attaching the model fires `onDidChangeModel` with a new url, which triggers registration.
-		editor.setModel(services.createModel('> '));
-		expect(services.consoleAdds('console-2')).toHaveLength(1);
+		editor.setSelection(new Selection(1, 1, 1, 4));
 
-		// A later model swap must not register the console editor a second time.
-		editor.setModel(services.createModel('>> '));
-		expect(services.consoleAdds('console-2')).toHaveLength(1);
-	});
-
-	it('sends the added-editor delta before any state for that editor', () => {
-		const editor = services.createCodeEditor(services.createModel('> '));
-
-		const store = services.add(services.documentsAndEditors.registerConsoleEditor('console-4', editor));
-
-		// `handleTextEditorAdded` immediately pushes diff information for the new id. Sending that
-		// before the `addedEditors` delta made the ext host throw `unknown text editor` on every
-		// console session startup.
-		expect(services.unknownEditorCalls).toEqual([]);
-
-		store.dispose();
-		expect(services.unknownEditorCalls).toEqual([]);
-	});
-
-	it('notifies the caller only once the editor is known to the ext host', () => {
-		const editor = services.createCodeEditor(undefined);
-		const onRegistered = vi.fn(() => services.consoleAdds('console-3').length);
-
-		services.add(services.documentsAndEditors.registerConsoleEditor('console-3', editor, onRegistered));
-
-		expect(onRegistered).not.toHaveBeenCalled();
-
-		editor.setModel(services.createModel('> '));
-
-		// Called exactly once, and only after the `addedEditors` delta went out -- callers rely on
-		// that ordering to avoid announcing an editor the ext host can't resolve yet.
-		expect(onRegistered).toHaveBeenCalledTimes(1);
-		expect(onRegistered).toHaveReturnedWith(1);
+		expect(changes.at(-1)?.selections?.selections).toMatchObject([
+			{ selectionStartLineNumber: 1, selectionStartColumn: 1, positionLineNumber: 1, positionColumn: 4 }
+		]);
+		expect(services.coreEditorStateCalls('console-2')).toEqual([]);
 	});
 });

--- a/src/vs/workbench/api/test/browser/positron/mainThreadDocumentsAndEditors.vitest.ts
+++ b/src/vs/workbench/api/test/browser/positron/mainThreadDocumentsAndEditors.vitest.ts
@@ -5,207 +5,72 @@
 
 /// <reference types="vitest/globals" />
 
-import { MainThreadDocumentsAndEditors } from '../../../browser/mainThreadDocumentsAndEditors.js';
-import { SingleProxyRPCProtocol } from '../../common/testRPCProtocol.js';
-import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
-import { ModelService } from '../../../../../editor/common/services/modelService.js';
-import { TestCodeEditorService } from '../../../../../editor/test/browser/editorTestServices.js';
-import { ITextFileEditorModelManager, ITextFileService } from '../../../../services/textfile/common/textfiles.js';
-import { IUntitledTextEditorModelManager } from '../../../../services/untitled/common/untitledTextEditorService.js';
-import { IDocumentsAndEditorsDelta } from '../../../common/extHost.protocol.js';
-import { createTestCodeEditor, ITestCodeEditor } from '../../../../../editor/test/browser/testCodeEditor.js';
-import { mock } from '../../../../../base/test/common/mock.js';
-import { TestEditorService, TestEditorGroupsService, TestEnvironmentService, TestPathService } from '../../../../test/browser/workbenchTestServices.js';
-import { Event } from '../../../../../base/common/event.js';
-import { ITextModel } from '../../../../../editor/common/model.js';
-import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
-import { ICodeEditorService } from '../../../../../editor/browser/services/codeEditorService.js';
-import { IFileService } from '../../../../../platform/files/common/files.js';
-import { TestThemeService } from '../../../../../platform/theme/test/common/testThemeService.js';
-import { UndoRedoService } from '../../../../../platform/undoRedo/common/undoRedoService.js';
-import { TestDialogService } from '../../../../../platform/dialogs/test/common/testDialogService.js';
-import { TestNotificationService } from '../../../../../platform/notification/test/common/testNotificationService.js';
-import { TestTextResourcePropertiesService, TestWorkingCopyFileService } from '../../../../test/common/workbenchTestServices.js';
-import { UriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentityService.js';
-import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
-import { IPaneCompositePartService } from '../../../../services/panecomposite/browser/panecomposite.js';
-import { ITextEditorDiffInformation } from '../../../../../platform/editor/common/editor.js';
-import { DisposableStore } from '../../../../../base/common/lifecycle.js';
-import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
-import { ILanguageService } from '../../../../../editor/common/languages/language.js';
-import { LanguageService } from '../../../../../editor/common/services/languageService.js';
-import { ILanguageConfigurationService } from '../../../../../editor/common/languages/languageConfigurationRegistry.js';
-import { TestLanguageConfigurationService } from '../../../../../editor/test/common/modes/testLanguageConfigurationService.js';
-import { IUndoRedoService } from '../../../../../platform/undoRedo/common/undoRedo.js';
-import { IQuickDiffModelService } from '../../../../contrib/scm/browser/quickDiffModel.js';
-import { ITreeSitterLibraryService } from '../../../../../editor/common/services/treeSitter/treeSitterLibraryService.js';
-import { TestTreeSitterLibraryService } from '../../../../../editor/test/common/services/testTreeSitterLibraryService.js';
 import { ensureNoLeakedDisposables } from '../../../../../test/vitest/vitestUtils.js';
-import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { ConsoleEditorTestServices } from './consoleEditorTestServices.js';
 
 // Tests for the Positron-only `MainThreadDocumentsAndEditors.registerConsoleEditor` method, which
-// backs `positron.window.activeConsoleEditor`. The setup mirrors the upstream Mocha suite in
-// `../mainThreadDocumentsAndEditors.test.ts` (real ModelService + real test code editors) so that
-// `ICodeEditor.onDidChangeModel` fires genuinely when a model is attached -- the exact timing the
-// fix depends on.
+// backs `positron.window.activeConsoleEditor`. See `ConsoleEditorTestServices` for the wiring.
 describe('MainThreadDocumentsAndEditors (Positron console editor)', () => {
 
-	// Long-lived services (disposed after the per-test teardown below runs).
-	const disposables = ensureNoLeakedDisposables();
+	ensureNoLeakedDisposables();
 
-	let modelService: ModelService;
-	let codeEditorService: TestCodeEditorService;
-	let documentsAndEditors: MainThreadDocumentsAndEditors;
-	// Editors, models and console registrations created within a test. Disposed while the
-	// main-thread instance is still alive so their `MainThreadTextEditor`s drain through the live
-	// state computer, then the instance itself is disposed in `afterEach`.
-	let perTest: DisposableStore;
-	const deltas: IDocumentsAndEditorsDelta[] = [];
-
-	function createCodeEditor(model: ITextModel | undefined): ITestCodeEditor {
-		return perTest.add(createTestCodeEditor(model, {
-			hasTextFocus: false,
-			serviceCollection: new ServiceCollection(
-				[ICodeEditorService, codeEditorService]
-			)
-		}));
-	}
-
-	function createModel(value: string): ITextModel {
-		return perTest.add(modelService.createModel(value, null));
-	}
-
-	// Deltas emitted by `registerConsoleEditor` contain a single `addedEditors` entry whose id is the
-	// console id we passed; deltas from the ambient state computer use composite `${editorId},${modelId}`
-	// ids, so filtering by our exact id isolates the registration under test.
-	function consoleAdds(id: string): IDocumentsAndEditorsDelta[] {
-		return deltas.filter(d => d.addedEditors?.some(e => e.id === id));
-	}
-
-	function consoleRemoves(id: string): IDocumentsAndEditorsDelta[] {
-		return deltas.filter(d => d.removedEditors?.includes(id));
-	}
+	let services: ConsoleEditorTestServices;
 
 	beforeEach(() => {
-		deltas.length = 0;
-		perTest = new DisposableStore();
-
-		const configService = new TestConfigurationService();
-		configService.setUserConfiguration('editor', { 'detectIndentation': false });
-		const dialogService = new TestDialogService();
-		const notificationService = new TestNotificationService();
-		const undoRedoService = new UndoRedoService(dialogService, notificationService);
-		const themeService = new TestThemeService();
-		// TestInstantiationService here only bootstraps the ModelService helper (per vitest-tests.md
-		// exception), it is not used as the primary DI container for the class under test.
-		const instantiationService = new TestInstantiationService();
-		instantiationService.set(ILanguageService, disposables.add(new LanguageService()));
-		instantiationService.set(ILanguageConfigurationService, disposables.add(new TestLanguageConfigurationService()));
-		instantiationService.set(ITreeSitterLibraryService, new TestTreeSitterLibraryService());
-		instantiationService.set(IUndoRedoService, undoRedoService);
-		modelService = disposables.add(new ModelService(
-			configService,
-			new TestTextResourcePropertiesService(configService),
-			undoRedoService,
-			instantiationService
-		));
-		codeEditorService = disposables.add(new TestCodeEditorService(themeService));
-		const textFileService = new class extends mock<ITextFileService>() {
-			override isDirty() { return false; }
-			// Only the events subscribed by MainThreadDocuments's constructor are read here.
-			override files = stubInterface<ITextFileEditorModelManager>({
-				onDidSave: Event.None,
-				onDidChangeDirty: Event.None,
-				onDidChangeEncoding: Event.None
-			});
-			override untitled = stubInterface<IUntitledTextEditorModelManager>({
-				onDidChangeEncoding: Event.None
-			});
-			override getEncoding() { return 'utf8'; }
-		};
-		const workbenchEditorService = disposables.add(new TestEditorService());
-		const editorGroupService = new TestEditorGroupsService();
-
-		const fileService = new class extends mock<IFileService>() {
-			override onDidRunOperation = Event.None;
-			override onDidChangeFileSystemProviderCapabilities = Event.None;
-			override onDidChangeFileSystemProviderRegistrations = Event.None;
-		};
-
-		documentsAndEditors = new MainThreadDocumentsAndEditors(
-			SingleProxyRPCProtocol({
-				$acceptDocumentsAndEditorsDelta: (delta: IDocumentsAndEditorsDelta) => { deltas.push(delta); },
-				$acceptEditorDiffInformation: (_id: string, _diffInformation: ITextEditorDiffInformation | undefined) => { }
-			}),
-			modelService,
-			textFileService,
-			workbenchEditorService,
-			codeEditorService,
-			fileService,
-			null!,
-			editorGroupService,
-			new class extends mock<IPaneCompositePartService>() implements IPaneCompositePartService {
-				override onDidPaneCompositeOpen = Event.None;
-				override onDidPaneCompositeClose = Event.None;
-				override getActivePaneComposite() {
-					return undefined;
-				}
-			},
-			TestEnvironmentService,
-			new TestWorkingCopyFileService(),
-			disposables.add(new UriIdentityService(fileService)),
-			new class extends mock<IClipboardService>() {
-				override readText() {
-					return Promise.resolve('clipboard_contents');
-				}
-			},
-			new TestPathService(),
-			new TestConfigurationService(),
-			new class extends mock<IQuickDiffModelService>() {
-				override createQuickDiffModelReference() {
-					return undefined;
-				}
-			}
-		);
+		services = new ConsoleEditorTestServices();
 	});
 
 	// Registered after `ensureNoLeakedDisposables`, so it runs before the leak check (Vitest runs
-	// afterEach hooks in reverse registration order): drain the test's editors/models first, then
-	// tear down the main-thread instance.
+	// afterEach hooks in reverse registration order).
 	afterEach(() => {
-		perTest.dispose();
-		documentsAndEditors.dispose();
+		services.dispose();
 	});
 
 	it('registers immediately when the code editor already has a model', () => {
-		const model = createModel('> ');
-		const editor = createCodeEditor(model);
+		const model = services.createModel('> ');
+		const editor = services.createCodeEditor(model);
 
-		const store = documentsAndEditors.registerConsoleEditor('console-1', editor);
+		const store = services.documentsAndEditors.registerConsoleEditor('console-1', editor);
 
-		expect(consoleAdds('console-1')).toHaveLength(1);
+		expect(services.consoleAdds('console-1')).toHaveLength(1);
 
 		// Disposing the registration removes the editor from the ext host.
 		store.dispose();
-		expect(consoleRemoves('console-1')).toHaveLength(1);
+		expect(services.consoleRemoves('console-1')).toHaveLength(1);
 	});
 
 	it('defers registration until a model is attached (the fix)', () => {
 		// Console input assigns its code editor before the text model attaches.
-		const editor = createCodeEditor(undefined);
+		const editor = services.createCodeEditor(undefined);
 
-		perTest.add(documentsAndEditors.registerConsoleEditor('console-2', editor));
+		services.add(services.documentsAndEditors.registerConsoleEditor('console-2', editor));
 
 		// Nothing registered yet -- a regression that bailed on the missing model would leave
 		// `activeConsoleEditor` permanently unresolved here.
-		expect(consoleAdds('console-2')).toHaveLength(0);
+		expect(services.consoleAdds('console-2')).toHaveLength(0);
 
 		// Attaching the model fires `onDidChangeModel` with a new url, which triggers registration.
-		editor.setModel(createModel('> '));
-		expect(consoleAdds('console-2')).toHaveLength(1);
+		editor.setModel(services.createModel('> '));
+		expect(services.consoleAdds('console-2')).toHaveLength(1);
 
 		// A later model swap must not register the console editor a second time.
-		editor.setModel(createModel('>> '));
-		expect(consoleAdds('console-2')).toHaveLength(1);
+		editor.setModel(services.createModel('>> '));
+		expect(services.consoleAdds('console-2')).toHaveLength(1);
+	});
+
+	it('notifies the caller only once the editor is known to the ext host', () => {
+		const editor = services.createCodeEditor(undefined);
+		const onRegistered = vi.fn(() => services.consoleAdds('console-3').length);
+
+		services.add(services.documentsAndEditors.registerConsoleEditor('console-3', editor, onRegistered));
+
+		expect(onRegistered).not.toHaveBeenCalled();
+
+		editor.setModel(services.createModel('> '));
+
+		// Called exactly once, and only after the `addedEditors` delta went out -- callers rely on
+		// that ordering to avoid announcing an editor the ext host can't resolve yet.
+		expect(onRegistered).toHaveBeenCalledTimes(1);
+		expect(onRegistered).toHaveReturnedWith(1);
 	});
 });

--- a/src/vs/workbench/api/test/browser/positron/mainThreadDocumentsAndEditors.vitest.ts
+++ b/src/vs/workbench/api/test/browser/positron/mainThreadDocumentsAndEditors.vitest.ts
@@ -58,6 +58,20 @@ describe('MainThreadDocumentsAndEditors (Positron console editor)', () => {
 		expect(services.consoleAdds('console-2')).toHaveLength(1);
 	});
 
+	it('sends the added-editor delta before any state for that editor', () => {
+		const editor = services.createCodeEditor(services.createModel('> '));
+
+		const store = services.add(services.documentsAndEditors.registerConsoleEditor('console-4', editor));
+
+		// `handleTextEditorAdded` immediately pushes diff information for the new id. Sending that
+		// before the `addedEditors` delta made the ext host throw `unknown text editor` on every
+		// console session startup.
+		expect(services.unknownEditorCalls).toEqual([]);
+
+		store.dispose();
+		expect(services.unknownEditorCalls).toEqual([]);
+	});
+
 	it('notifies the caller only once the editor is known to the ext host', () => {
 		const editor = services.createCodeEditor(undefined);
 		const onRegistered = vi.fn(() => services.consoleAdds('console-3').length);

--- a/src/vs/workbench/api/test/browser/positron/mainThreadDocumentsAndEditors.vitest.ts
+++ b/src/vs/workbench/api/test/browser/positron/mainThreadDocumentsAndEditors.vitest.ts
@@ -1,0 +1,211 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { MainThreadDocumentsAndEditors } from '../../../browser/mainThreadDocumentsAndEditors.js';
+import { SingleProxyRPCProtocol } from '../../common/testRPCProtocol.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { ModelService } from '../../../../../editor/common/services/modelService.js';
+import { TestCodeEditorService } from '../../../../../editor/test/browser/editorTestServices.js';
+import { ITextFileEditorModelManager, ITextFileService } from '../../../../services/textfile/common/textfiles.js';
+import { IUntitledTextEditorModelManager } from '../../../../services/untitled/common/untitledTextEditorService.js';
+import { IDocumentsAndEditorsDelta } from '../../../common/extHost.protocol.js';
+import { createTestCodeEditor, ITestCodeEditor } from '../../../../../editor/test/browser/testCodeEditor.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { TestEditorService, TestEditorGroupsService, TestEnvironmentService, TestPathService } from '../../../../test/browser/workbenchTestServices.js';
+import { Event } from '../../../../../base/common/event.js';
+import { ITextModel } from '../../../../../editor/common/model.js';
+import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
+import { ICodeEditorService } from '../../../../../editor/browser/services/codeEditorService.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
+import { TestThemeService } from '../../../../../platform/theme/test/common/testThemeService.js';
+import { UndoRedoService } from '../../../../../platform/undoRedo/common/undoRedoService.js';
+import { TestDialogService } from '../../../../../platform/dialogs/test/common/testDialogService.js';
+import { TestNotificationService } from '../../../../../platform/notification/test/common/testNotificationService.js';
+import { TestTextResourcePropertiesService, TestWorkingCopyFileService } from '../../../../test/common/workbenchTestServices.js';
+import { UriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentityService.js';
+import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
+import { IPaneCompositePartService } from '../../../../services/panecomposite/browser/panecomposite.js';
+import { ITextEditorDiffInformation } from '../../../../../platform/editor/common/editor.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ILanguageService } from '../../../../../editor/common/languages/language.js';
+import { LanguageService } from '../../../../../editor/common/services/languageService.js';
+import { ILanguageConfigurationService } from '../../../../../editor/common/languages/languageConfigurationRegistry.js';
+import { TestLanguageConfigurationService } from '../../../../../editor/test/common/modes/testLanguageConfigurationService.js';
+import { IUndoRedoService } from '../../../../../platform/undoRedo/common/undoRedo.js';
+import { IQuickDiffModelService } from '../../../../contrib/scm/browser/quickDiffModel.js';
+import { ITreeSitterLibraryService } from '../../../../../editor/common/services/treeSitter/treeSitterLibraryService.js';
+import { TestTreeSitterLibraryService } from '../../../../../editor/test/common/services/testTreeSitterLibraryService.js';
+import { ensureNoLeakedDisposables } from '../../../../../test/vitest/vitestUtils.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+
+// Tests for the Positron-only `MainThreadDocumentsAndEditors.registerConsoleEditor` method, which
+// backs `positron.window.activeConsoleEditor`. The setup mirrors the upstream Mocha suite in
+// `../mainThreadDocumentsAndEditors.test.ts` (real ModelService + real test code editors) so that
+// `ICodeEditor.onDidChangeModel` fires genuinely when a model is attached -- the exact timing the
+// fix depends on.
+describe('MainThreadDocumentsAndEditors (Positron console editor)', () => {
+
+	// Long-lived services (disposed after the per-test teardown below runs).
+	const disposables = ensureNoLeakedDisposables();
+
+	let modelService: ModelService;
+	let codeEditorService: TestCodeEditorService;
+	let documentsAndEditors: MainThreadDocumentsAndEditors;
+	// Editors, models and console registrations created within a test. Disposed while the
+	// main-thread instance is still alive so their `MainThreadTextEditor`s drain through the live
+	// state computer, then the instance itself is disposed in `afterEach`.
+	let perTest: DisposableStore;
+	const deltas: IDocumentsAndEditorsDelta[] = [];
+
+	function createCodeEditor(model: ITextModel | undefined): ITestCodeEditor {
+		return perTest.add(createTestCodeEditor(model, {
+			hasTextFocus: false,
+			serviceCollection: new ServiceCollection(
+				[ICodeEditorService, codeEditorService]
+			)
+		}));
+	}
+
+	function createModel(value: string): ITextModel {
+		return perTest.add(modelService.createModel(value, null));
+	}
+
+	// Deltas emitted by `registerConsoleEditor` contain a single `addedEditors` entry whose id is the
+	// console id we passed; deltas from the ambient state computer use composite `${editorId},${modelId}`
+	// ids, so filtering by our exact id isolates the registration under test.
+	function consoleAdds(id: string): IDocumentsAndEditorsDelta[] {
+		return deltas.filter(d => d.addedEditors?.some(e => e.id === id));
+	}
+
+	function consoleRemoves(id: string): IDocumentsAndEditorsDelta[] {
+		return deltas.filter(d => d.removedEditors?.includes(id));
+	}
+
+	beforeEach(() => {
+		deltas.length = 0;
+		perTest = new DisposableStore();
+
+		const configService = new TestConfigurationService();
+		configService.setUserConfiguration('editor', { 'detectIndentation': false });
+		const dialogService = new TestDialogService();
+		const notificationService = new TestNotificationService();
+		const undoRedoService = new UndoRedoService(dialogService, notificationService);
+		const themeService = new TestThemeService();
+		// TestInstantiationService here only bootstraps the ModelService helper (per vitest-tests.md
+		// exception), it is not used as the primary DI container for the class under test.
+		const instantiationService = new TestInstantiationService();
+		instantiationService.set(ILanguageService, disposables.add(new LanguageService()));
+		instantiationService.set(ILanguageConfigurationService, disposables.add(new TestLanguageConfigurationService()));
+		instantiationService.set(ITreeSitterLibraryService, new TestTreeSitterLibraryService());
+		instantiationService.set(IUndoRedoService, undoRedoService);
+		modelService = disposables.add(new ModelService(
+			configService,
+			new TestTextResourcePropertiesService(configService),
+			undoRedoService,
+			instantiationService
+		));
+		codeEditorService = disposables.add(new TestCodeEditorService(themeService));
+		const textFileService = new class extends mock<ITextFileService>() {
+			override isDirty() { return false; }
+			// Only the events subscribed by MainThreadDocuments's constructor are read here.
+			override files = stubInterface<ITextFileEditorModelManager>({
+				onDidSave: Event.None,
+				onDidChangeDirty: Event.None,
+				onDidChangeEncoding: Event.None
+			});
+			override untitled = stubInterface<IUntitledTextEditorModelManager>({
+				onDidChangeEncoding: Event.None
+			});
+			override getEncoding() { return 'utf8'; }
+		};
+		const workbenchEditorService = disposables.add(new TestEditorService());
+		const editorGroupService = new TestEditorGroupsService();
+
+		const fileService = new class extends mock<IFileService>() {
+			override onDidRunOperation = Event.None;
+			override onDidChangeFileSystemProviderCapabilities = Event.None;
+			override onDidChangeFileSystemProviderRegistrations = Event.None;
+		};
+
+		documentsAndEditors = new MainThreadDocumentsAndEditors(
+			SingleProxyRPCProtocol({
+				$acceptDocumentsAndEditorsDelta: (delta: IDocumentsAndEditorsDelta) => { deltas.push(delta); },
+				$acceptEditorDiffInformation: (_id: string, _diffInformation: ITextEditorDiffInformation | undefined) => { }
+			}),
+			modelService,
+			textFileService,
+			workbenchEditorService,
+			codeEditorService,
+			fileService,
+			null!,
+			editorGroupService,
+			new class extends mock<IPaneCompositePartService>() implements IPaneCompositePartService {
+				override onDidPaneCompositeOpen = Event.None;
+				override onDidPaneCompositeClose = Event.None;
+				override getActivePaneComposite() {
+					return undefined;
+				}
+			},
+			TestEnvironmentService,
+			new TestWorkingCopyFileService(),
+			disposables.add(new UriIdentityService(fileService)),
+			new class extends mock<IClipboardService>() {
+				override readText() {
+					return Promise.resolve('clipboard_contents');
+				}
+			},
+			new TestPathService(),
+			new TestConfigurationService(),
+			new class extends mock<IQuickDiffModelService>() {
+				override createQuickDiffModelReference() {
+					return undefined;
+				}
+			}
+		);
+	});
+
+	// Registered after `ensureNoLeakedDisposables`, so it runs before the leak check (Vitest runs
+	// afterEach hooks in reverse registration order): drain the test's editors/models first, then
+	// tear down the main-thread instance.
+	afterEach(() => {
+		perTest.dispose();
+		documentsAndEditors.dispose();
+	});
+
+	it('registers immediately when the code editor already has a model', () => {
+		const model = createModel('> ');
+		const editor = createCodeEditor(model);
+
+		const store = documentsAndEditors.registerConsoleEditor('console-1', editor);
+
+		expect(consoleAdds('console-1')).toHaveLength(1);
+
+		// Disposing the registration removes the editor from the ext host.
+		store.dispose();
+		expect(consoleRemoves('console-1')).toHaveLength(1);
+	});
+
+	it('defers registration until a model is attached (the fix)', () => {
+		// Console input assigns its code editor before the text model attaches.
+		const editor = createCodeEditor(undefined);
+
+		perTest.add(documentsAndEditors.registerConsoleEditor('console-2', editor));
+
+		// Nothing registered yet -- a regression that bailed on the missing model would leave
+		// `activeConsoleEditor` permanently unresolved here.
+		expect(consoleAdds('console-2')).toHaveLength(0);
+
+		// Attaching the model fires `onDidChangeModel` with a new url, which triggers registration.
+		editor.setModel(createModel('> '));
+		expect(consoleAdds('console-2')).toHaveLength(1);
+
+		// A later model swap must not register the console editor a second time.
+		editor.setModel(createModel('>> '));
+		expect(consoleAdds('console-2')).toHaveLength(1);
+	});
+});

--- a/src/vs/workbench/api/test/common/positron/extHostConsoleService.vitest.ts
+++ b/src/vs/workbench/api/test/common/positron/extHostConsoleService.vitest.ts
@@ -5,14 +5,19 @@
 
 /// <reference types="vitest/globals" />
 
+import { URI } from '../../../../../base/common/uri.js';
 import { mock } from '../../../../../base/test/common/mock.js';
+import { RenderLineNumbersType, TextEditorCursorStyle } from '../../../../../editor/common/config/editorOptions.js';
+import { Selection } from '../../../../../editor/common/core/selection.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { ensureNoLeakedDisposables } from '../../../../../test/vitest/vitestUtils.js';
+import { ITextEditorAddData } from '../../../common/extHost.protocol.js';
 import { MainThreadConsoleServiceShape } from '../../../common/positron/extHost.positron.protocol.js';
 import { ExtHostConsoleService } from '../../../common/positron/extHostConsoleService.js';
 import { SingleProxyRPCProtocol } from '../testRPCProtocol.js';
+import { ExtHostDocumentData } from '../../../common/extHostDocumentData.js';
 import { ExtHostDocumentsAndEditors } from '../../../common/extHostDocumentsAndEditors.js';
-import { ExtHostTextEditor } from '../../../common/extHostTextEditor.js';
 
 function createMockShape(activeSessionId: string | undefined = undefined) {
 	return new class extends mock<MainThreadConsoleServiceShape>() {
@@ -53,11 +58,47 @@ function createControllableMockShape() {
 	return { shape, resolveActiveSessionId: (id: string | undefined) => resolve(id) };
 }
 
-/** Minimal DocsAndEditors stub; `idToEditor` maps editor id → the ExtHostTextEditor stub. */
-function createDocsAndEditors(idToEditor: Record<string, ExtHostTextEditor> = {}) {
+/** The console input document URI for `sessionId`, as the main thread would report it. */
+function documentUri(sessionId: string): URI {
+	return URI.from({ scheme: 'inmemory', path: `/repl-python-${sessionId}` });
+}
+
+/**
+ * A `$addConsoleEditor` payload for `sessionId`, mirroring what the main thread derives from the
+ * console input's `MainThreadTextEditor`.
+ */
+function createEditorAddData(sessionId: string): ITextEditorAddData {
+	return {
+		id: `console-${sessionId}`,
+		documentUri: documentUri(sessionId),
+		options: {
+			tabSize: 4,
+			indentSize: 4,
+			originalIndentSize: 4,
+			insertSpaces: true,
+			cursorStyle: TextEditorCursorStyle.Line,
+			lineNumbers: RenderLineNumbersType.Off
+		},
+		selections: [{ selectionStartLineNumber: 1, selectionStartColumn: 1, positionLineNumber: 1, positionColumn: 1 }],
+		visibleRanges: [],
+		editorPosition: undefined
+	};
+}
+
+/**
+ * Minimal DocsAndEditors stub. `ExtHostConsoleService` builds its own `ExtHostTextEditor` for each
+ * console editor, so all it needs from here is the document behind the editor's URI.
+ */
+function createDocsAndEditors(sessionIds: string[] = []) {
+	const documents = new Map(sessionIds.map(sessionId => [
+		documentUri(sessionId).toString(),
+		stubInterface<ExtHostDocumentData>({
+			document: stubInterface<import('vscode').TextDocument>({ uri: documentUri(sessionId) })
+		})
+	]));
 	return new class extends mock<ExtHostDocumentsAndEditors>() {
-		override getEditor(id: string): ExtHostTextEditor | undefined {
-			return idToEditor[id];
+		override getDocument(uri: URI): ExtHostDocumentData | undefined {
+			return documents.get(uri.toString());
 		}
 	};
 }
@@ -192,7 +233,7 @@ describe('ExtHostConsoleService', function () {
 		expect(fired[0]).toBe(svc.activeConsole);
 	});
 
-	describe('$setActiveConsoleEditor / activeConsoleEditor', function () {
+	describe('console editors / activeConsoleEditor', function () {
 
 		it('returns undefined initially', function () {
 			const shape = createMockShape();
@@ -200,84 +241,152 @@ describe('ExtHostConsoleService', function () {
 			expect(svc.activeConsoleEditor).toBeUndefined();
 		});
 
-		it('sets activeConsoleEditor from registered editor (derived via _activeConsoleSessionId)', function () {
-			const fakeValue = Object.freeze({}) as import('vscode').TextEditor;
-			const fakeExtEditor = { value: fakeValue } as unknown as ExtHostTextEditor;
-			// getEditor key matches `console-${sessionId}` format used by the getter
-			const docsAndEditors = createDocsAndEditors({ 'console-session-1': fakeExtEditor });
-
+		it('resolves the active console editor once the editor is registered', function () {
 			const shape = createMockShape();
-			const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService(), docsAndEditors);
+			const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService(), createDocsAndEditors(['session-1']));
 
 			const fired: (import('vscode').TextEditor | undefined)[] = [];
 			disposables.add(svc.onDidChangeActiveConsoleEditor((e) => fired.push(e)));
 
-			// $onDidChangeActiveConsole sets _activeConsoleSessionId; $setActiveConsoleEditor fires the event
 			svc.$onDidChangeActiveConsole('session-1');
-			svc.$setActiveConsoleEditor('console-session-1');
+			// No editor yet: the console input mounts separately, so nothing to report.
+			expect(svc.activeConsoleEditor).toBeUndefined();
+			expect(fired).toEqual([]);
 
-			expect(svc.activeConsoleEditor).toBe(fakeValue);
-			expect(fired).toEqual([fakeValue]);
+			svc.$addConsoleEditor('session-1', createEditorAddData('session-1'));
+
+			expect(svc.activeConsoleEditor?.document.uri).toEqual(documentUri('session-1'));
+			expect(fired).toEqual([svc.activeConsoleEditor]);
 		});
 
-		it('clears activeConsoleEditor when session becomes null', function () {
-			const fakeValue = Object.freeze({}) as import('vscode').TextEditor;
-			const fakeExtEditor = { value: fakeValue } as unknown as ExtHostTextEditor;
-			const docsAndEditors = createDocsAndEditors({ 'console-session-1': fakeExtEditor });
-
+		it('resolves when the editor is registered before the console becomes active', function () {
 			const shape = createMockShape();
-			const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService(), docsAndEditors);
-
-			svc.$onDidChangeActiveConsole('session-1');
-			svc.$setActiveConsoleEditor('console-session-1');
-			expect(svc.activeConsoleEditor).toBe(fakeValue);
+			const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService(), createDocsAndEditors(['session-1']));
 
 			const fired: (import('vscode').TextEditor | undefined)[] = [];
 			disposables.add(svc.onDidChangeActiveConsoleEditor((e) => fired.push(e)));
 
-			// Active console clears; $onDidChangeActiveConsole(undefined) precedes $setActiveConsoleEditor(null)
+			svc.$addConsoleEditor('session-1', createEditorAddData('session-1'));
+			expect(svc.activeConsoleEditor).toBeUndefined();
+			expect(fired).toEqual([]);
+
+			svc.$onDidChangeActiveConsole('session-1');
+			expect(svc.activeConsoleEditor).toBeDefined();
+			expect(fired).toEqual([svc.activeConsoleEditor]);
+		});
+
+		it('clears the active console editor when the console is no longer active', function () {
+			const shape = createMockShape();
+			const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService(), createDocsAndEditors(['session-1']));
+
+			svc.$addConsoleEditor('session-1', createEditorAddData('session-1'));
+			svc.$onDidChangeActiveConsole('session-1');
+			expect(svc.activeConsoleEditor).toBeDefined();
+
+			const fired: (import('vscode').TextEditor | undefined)[] = [];
+			disposables.add(svc.onDidChangeActiveConsoleEditor((e) => fired.push(e)));
+
 			svc.$onDidChangeActiveConsole(undefined);
-			svc.$setActiveConsoleEditor(null);
 			expect(svc.activeConsoleEditor).toBeUndefined();
 			expect(fired).toEqual([undefined]);
 		});
 
-		it('yields undefined when no active session even with an editorId signal', function () {
+		it('clears the active console editor when the editor is removed', function () {
+			const shape = createMockShape();
+			const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService(), createDocsAndEditors(['session-1']));
+
+			svc.$addConsoleEditor('session-1', createEditorAddData('session-1'));
+			svc.$onDidChangeActiveConsole('session-1');
+
+			const fired: (import('vscode').TextEditor | undefined)[] = [];
+			disposables.add(svc.onDidChangeActiveConsoleEditor((e) => fired.push(e)));
+
+			// The Console view unmounted, or the console was deleted.
+			svc.$removeConsoleEditor('session-1');
+			expect(svc.activeConsoleEditor).toBeUndefined();
+			expect(fired).toEqual([undefined]);
+		});
+
+		it('re-registering replaces the editor, so a remount is not left pointing at the old one', function () {
+			const shape = createMockShape();
+			const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService(), createDocsAndEditors(['session-1']));
+
+			svc.$addConsoleEditor('session-1', createEditorAddData('session-1'));
+			svc.$onDidChangeActiveConsole('session-1');
+			const firstEditor = svc.activeConsoleEditor;
+
+			const fired: (import('vscode').TextEditor | undefined)[] = [];
+			disposables.add(svc.onDidChangeActiveConsoleEditor((e) => fired.push(e)));
+
+			// The Console view remounted: the main thread retires the old registration and sends a
+			// new one for the freshly created editor.
+			svc.$removeConsoleEditor('session-1');
+			svc.$addConsoleEditor('session-1', createEditorAddData('session-1'));
+
+			expect(svc.activeConsoleEditor).not.toBe(firstEditor);
+			expect(fired).toEqual([undefined, svc.activeConsoleEditor]);
+		});
+
+		it('fires once per change as the active console moves between consoles', function () {
+			const shape = createMockShape();
+			const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService(), createDocsAndEditors(['session-a', 'session-b']));
+
+			svc.$addConsoleEditor('session-a', createEditorAddData('session-a'));
+			svc.$addConsoleEditor('session-b', createEditorAddData('session-b'));
+
+			const fired: (import('vscode').TextEditor | undefined)[] = [];
+			disposables.add(svc.onDidChangeActiveConsoleEditor((e) => fired.push(e)));
+
+			svc.$onDidChangeActiveConsole('session-a');
+			const editorA = svc.activeConsoleEditor;
+			svc.$onDidChangeActiveConsole('session-b');
+			const editorB = svc.activeConsoleEditor;
+			// Re-activating the console that is already reported is not a change.
+			svc.$onDidChangeActiveConsole('session-b');
+			svc.$onDidChangeActiveConsole(undefined);
+
+			expect(fired).toEqual([editorA, editorB, undefined]);
+			expect(svc.activeConsoleEditor).toBeUndefined();
+		});
+
+		it('applies selection changes to the console editor without touching core editor events', function () {
+			const shape = createMockShape();
+			const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService(), createDocsAndEditors(['session-1']));
+
+			svc.$addConsoleEditor('session-1', createEditorAddData('session-1'));
+			svc.$onDidChangeActiveConsole('session-1');
+
+			svc.$acceptConsoleEditorPropertiesChanged('session-1', {
+				options: null,
+				visibleRanges: null,
+				selections: { source: 'api', selections: [new Selection(1, 1, 1, 4)] }
+			});
+
+			const selection = svc.activeConsoleEditor!.selection;
+			expect({
+				start: [selection.start.line, selection.start.character],
+				end: [selection.end.line, selection.end.character]
+			}).toEqual({ start: [0, 0], end: [0, 3] });
+		});
+
+		it('ignores editor traffic for an unknown session', function () {
 			const shape = createMockShape();
 			const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService(), nullDocsAndEditors);
 
 			const fired: (import('vscode').TextEditor | undefined)[] = [];
 			disposables.add(svc.onDidChangeActiveConsoleEditor((e) => fired.push(e)));
 
-			// Without $onDidChangeActiveConsole, _activeConsoleSessionId is undefined
-			svc.$setActiveConsoleEditor('console-session-1');
-			expect(svc.activeConsoleEditor).toBeUndefined();
-			expect(fired).toEqual([undefined]);
-		});
-
-		it('fires onDidChangeActiveConsoleEditor on each session change', function () {
-			const fakeA = Object.freeze({}) as import('vscode').TextEditor;
-			const fakeB = Object.freeze({}) as import('vscode').TextEditor;
-			const docsAndEditors = createDocsAndEditors({
-				'console-session-a': { value: fakeA } as unknown as ExtHostTextEditor,
-				'console-session-b': { value: fakeB } as unknown as ExtHostTextEditor,
+			// No document for this session, so no editor can be built.
+			svc.$addConsoleEditor('session-1', createEditorAddData('session-1'));
+			svc.$removeConsoleEditor('session-1');
+			svc.$acceptConsoleEditorPropertiesChanged('session-1', {
+				options: createEditorAddData('session-1').options,
+				selections: null,
+				visibleRanges: null
 			});
 
-			const shape = createMockShape();
-			const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService(), docsAndEditors);
-
-			const fired: (import('vscode').TextEditor | undefined)[] = [];
-			disposables.add(svc.onDidChangeActiveConsoleEditor((e) => fired.push(e)));
-
-			svc.$onDidChangeActiveConsole('session-a');
-			svc.$setActiveConsoleEditor('console-session-a');
-			svc.$onDidChangeActiveConsole('session-b');
-			svc.$setActiveConsoleEditor('console-session-b');
-			svc.$onDidChangeActiveConsole(undefined);
-			svc.$setActiveConsoleEditor(null);
-
-			expect(fired).toEqual([fakeA, fakeB, undefined]);
 			expect(svc.activeConsoleEditor).toBeUndefined();
+			expect(fired).toEqual([]);
 		});
 	});
 });

--- a/src/vs/workbench/api/test/common/positron/extHostConsoleService.vitest.ts
+++ b/src/vs/workbench/api/test/common/positron/extHostConsoleService.vitest.ts
@@ -216,6 +216,23 @@ describe('ExtHostConsoleService', function () {
 		expect(fired).toHaveLength(1); // no spurious second event
 	});
 
+	it('logs instead of rejecting when the startup seed fails', async function () {
+		const shape = new class extends mock<MainThreadConsoleServiceShape>() {
+			override $getActiveConsoleSessionId(): Promise<string | undefined> {
+				return Promise.reject(new Error('extension host was torn down'));
+			}
+		};
+		const logService = new NullLogService();
+		const error = vi.spyOn(logService, 'error');
+
+		// An unhandled rejection here would surface as an extension host error with no context.
+		const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), logService, nullDocsAndEditors);
+		await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+		expect(error).toHaveBeenCalledOnce();
+		expect(svc.activeConsole).toBeUndefined();
+	});
+
 	it('constructor seeds _activeConsoleSessionId from $getActiveConsoleSessionId', async function () {
 		const shape = createMockShape('session-preexisting');
 		const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService(), nullDocsAndEditors);

--- a/src/vs/workbench/api/test/common/positron/extHostConsoleService.vitest.ts
+++ b/src/vs/workbench/api/test/common/positron/extHostConsoleService.vitest.ts
@@ -1,0 +1,181 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { mock } from '../../../../../base/test/common/mock.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { ensureNoLeakedDisposables } from '../../../../../test/vitest/vitestUtils.js';
+import { MainThreadConsoleServiceShape } from '../../../common/positron/extHost.positron.protocol.js';
+import { ExtHostConsoleService } from '../../../common/positron/extHostConsoleService.js';
+import { SingleProxyRPCProtocol } from '../testRPCProtocol.js';
+
+function createMockShape(activeSessionId: string | undefined = undefined) {
+	return new class extends mock<MainThreadConsoleServiceShape>() {
+		private _activeSessionId = activeSessionId;
+		override $getActiveConsoleSessionId(): Promise<string | undefined> {
+			return Promise.resolve(this._activeSessionId);
+		}
+		override $getConsoleWidth(): Promise<number> {
+			return Promise.resolve(80);
+		}
+		override $getSessionIdForLanguage(_languageId: string): Promise<string | undefined> {
+			return Promise.resolve(undefined);
+		}
+		override $tryPasteText(_sessionId: string, _text: string): void {
+			// no-op
+		}
+	};
+}
+
+// Returns a shape whose $getActiveConsoleSessionId promise is manually resolved via the
+// returned callback — lets tests control when the startup seed arrives.
+function createControllableMockShape() {
+	let resolve: (sessionId: string | undefined) => void;
+	const shape = new class extends mock<MainThreadConsoleServiceShape>() {
+		override $getActiveConsoleSessionId(): Promise<string | undefined> {
+			return new Promise((r) => { resolve = r; });
+		}
+		override $getConsoleWidth(): Promise<number> {
+			return Promise.resolve(80);
+		}
+		override $getSessionIdForLanguage(_languageId: string): Promise<string | undefined> {
+			return Promise.resolve(undefined);
+		}
+		override $tryPasteText(_sessionId: string, _text: string): void {
+			// no-op
+		}
+	};
+	return { shape, resolveActiveSessionId: (id: string | undefined) => resolve(id) };
+}
+
+describe('ExtHostConsoleService', function () {
+
+	const disposables = ensureNoLeakedDisposables();
+
+	it('normal order: $addConsole then $onDidChangeActiveConsole resolves activeConsole', function () {
+		const shape = createMockShape();
+		const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService());
+
+		const fired: (import('positron').Console | undefined)[] = [];
+		disposables.add(svc.onDidChangeActiveConsole((c) => fired.push(c)));
+
+		svc.$addConsole('session-1');
+		svc.$onDidChangeActiveConsole('session-1');
+
+		expect(svc.activeConsole).toBeDefined();
+		expect(fired.length).toBe(1);
+		expect(fired[0]).toBe(svc.activeConsole);
+	});
+
+	it('race condition: $onDidChangeActiveConsole before $addConsole fires again on $addConsole', function () {
+		const shape = createMockShape();
+		const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService());
+
+		const fired: (import('positron').Console | undefined)[] = [];
+		disposables.add(svc.onDidChangeActiveConsole((c) => fired.push(c)));
+
+		// Active session arrives before the console is registered
+		svc.$onDidChangeActiveConsole('session-1');
+		expect(svc.activeConsole).toBeUndefined();
+		expect(fired).toEqual([undefined]);
+
+		// Console is registered later — should re-fire with the resolved console
+		svc.$addConsole('session-1');
+		expect(svc.activeConsole).toBeDefined();
+		expect(fired.length).toBe(2);
+		expect(fired[1]).toBe(svc.activeConsole);
+	});
+
+	it('$onDidChangeActiveConsole(undefined) clears activeConsole and fires with undefined', function () {
+		const shape = createMockShape();
+		const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService());
+
+		svc.$addConsole('session-1');
+		svc.$onDidChangeActiveConsole('session-1');
+		expect(svc.activeConsole).toBeDefined();
+
+		const fired: (import('positron').Console | undefined)[] = [];
+		disposables.add(svc.onDidChangeActiveConsole((c) => fired.push(c)));
+
+		svc.$onDidChangeActiveConsole(undefined);
+		expect(svc.activeConsole).toBeUndefined();
+		expect(fired).toEqual([undefined]);
+	});
+
+	it('unknown sessionId: activeConsole is undefined when sessionId is not registered', function () {
+		const shape = createMockShape();
+		const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService());
+
+		const fired: (import('positron').Console | undefined)[] = [];
+		disposables.add(svc.onDidChangeActiveConsole((c) => fired.push(c)));
+
+		svc.$onDidChangeActiveConsole('session-unknown');
+		expect(svc.activeConsole).toBeUndefined();
+		expect(fired).toEqual([undefined]);
+	});
+
+	it('startup race: $addConsole before $getActiveConsoleSessionId resolves still fires event', async function () {
+		const { shape, resolveActiveSessionId } = createControllableMockShape();
+		const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService());
+
+		const fired: (import('positron').Console | undefined)[] = [];
+		disposables.add(svc.onDidChangeActiveConsole((c) => fired.push(c)));
+
+		// Console registers BEFORE the startup promise resolves
+		svc.$addConsole('session-preexisting');
+		expect(svc.activeConsole).toBeUndefined();
+		expect(fired).toHaveLength(0);
+
+		// Startup promise resolves — should set active and fire the event
+		resolveActiveSessionId('session-preexisting');
+		await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+		expect(svc.activeConsole).toBeDefined();
+		expect(fired).toHaveLength(1);
+		expect(fired[0]).toBe(svc.activeConsole);
+	});
+
+	it('startup race: live $onDidChangeActiveConsole before $getActiveConsoleSessionId resolves wins', async function () {
+		const { shape, resolveActiveSessionId } = createControllableMockShape();
+		const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService());
+
+		svc.$addConsole('session-1');
+		svc.$addConsole('session-stale');
+
+		const fired: (import('positron').Console | undefined)[] = [];
+		disposables.add(svc.onDidChangeActiveConsole((c) => fired.push(c)));
+
+		// Live event fires: session-1 is the active console
+		svc.$onDidChangeActiveConsole('session-1');
+		const activeFromLiveEvent = svc.activeConsole;
+		expect(activeFromLiveEvent).toBeDefined();
+		expect(fired).toHaveLength(1);
+
+		// Startup promise resolves with a stale session ID — must not overwrite
+		resolveActiveSessionId('session-stale');
+		await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+		expect(svc.activeConsole).toBe(activeFromLiveEvent);
+		expect(fired).toHaveLength(1); // no spurious second event
+	});
+
+	it('constructor seeds _activeConsoleSessionId from $getActiveConsoleSessionId', async function () {
+		const shape = createMockShape('session-preexisting');
+		const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService());
+
+		// Wait for the async init promise to resolve
+		await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+		// Adding a console with the pre-existing session ID should re-fire the event
+		const fired: (import('positron').Console | undefined)[] = [];
+		disposables.add(svc.onDidChangeActiveConsole((c) => fired.push(c)));
+
+		svc.$addConsole('session-preexisting');
+		expect(svc.activeConsole).toBeDefined();
+		expect(fired.length).toBe(1);
+		expect(fired[0]).toBe(svc.activeConsole);
+	});
+});

--- a/src/vs/workbench/api/test/common/positron/extHostConsoleService.vitest.ts
+++ b/src/vs/workbench/api/test/common/positron/extHostConsoleService.vitest.ts
@@ -11,6 +11,8 @@ import { ensureNoLeakedDisposables } from '../../../../../test/vitest/vitestUtil
 import { MainThreadConsoleServiceShape } from '../../../common/positron/extHost.positron.protocol.js';
 import { ExtHostConsoleService } from '../../../common/positron/extHostConsoleService.js';
 import { SingleProxyRPCProtocol } from '../testRPCProtocol.js';
+import { ExtHostDocumentsAndEditors } from '../../../common/extHostDocumentsAndEditors.js';
+import { ExtHostTextEditor } from '../../../common/extHostTextEditor.js';
 
 function createMockShape(activeSessionId: string | undefined = undefined) {
 	return new class extends mock<MainThreadConsoleServiceShape>() {
@@ -51,13 +53,24 @@ function createControllableMockShape() {
 	return { shape, resolveActiveSessionId: (id: string | undefined) => resolve(id) };
 }
 
+/** Minimal DocsAndEditors stub; `idToEditor` maps editor id → the ExtHostTextEditor stub. */
+function createDocsAndEditors(idToEditor: Record<string, ExtHostTextEditor> = {}) {
+	return new class extends mock<ExtHostDocumentsAndEditors>() {
+		override getEditor(id: string): ExtHostTextEditor | undefined {
+			return idToEditor[id];
+		}
+	};
+}
+
+const nullDocsAndEditors = createDocsAndEditors();
+
 describe('ExtHostConsoleService', function () {
 
 	const disposables = ensureNoLeakedDisposables();
 
 	it('normal order: $addConsole then $onDidChangeActiveConsole resolves activeConsole', function () {
 		const shape = createMockShape();
-		const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService());
+		const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService(), nullDocsAndEditors);
 
 		const fired: (import('positron').Console | undefined)[] = [];
 		disposables.add(svc.onDidChangeActiveConsole((c) => fired.push(c)));
@@ -72,7 +85,7 @@ describe('ExtHostConsoleService', function () {
 
 	it('race condition: $onDidChangeActiveConsole before $addConsole fires again on $addConsole', function () {
 		const shape = createMockShape();
-		const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService());
+		const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService(), nullDocsAndEditors);
 
 		const fired: (import('positron').Console | undefined)[] = [];
 		disposables.add(svc.onDidChangeActiveConsole((c) => fired.push(c)));
@@ -91,7 +104,7 @@ describe('ExtHostConsoleService', function () {
 
 	it('$onDidChangeActiveConsole(undefined) clears activeConsole and fires with undefined', function () {
 		const shape = createMockShape();
-		const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService());
+		const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService(), nullDocsAndEditors);
 
 		svc.$addConsole('session-1');
 		svc.$onDidChangeActiveConsole('session-1');
@@ -107,7 +120,7 @@ describe('ExtHostConsoleService', function () {
 
 	it('unknown sessionId: activeConsole is undefined when sessionId is not registered', function () {
 		const shape = createMockShape();
-		const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService());
+		const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService(), nullDocsAndEditors);
 
 		const fired: (import('positron').Console | undefined)[] = [];
 		disposables.add(svc.onDidChangeActiveConsole((c) => fired.push(c)));
@@ -119,7 +132,7 @@ describe('ExtHostConsoleService', function () {
 
 	it('startup race: $addConsole before $getActiveConsoleSessionId resolves still fires event', async function () {
 		const { shape, resolveActiveSessionId } = createControllableMockShape();
-		const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService());
+		const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService(), nullDocsAndEditors);
 
 		const fired: (import('positron').Console | undefined)[] = [];
 		disposables.add(svc.onDidChangeActiveConsole((c) => fired.push(c)));
@@ -140,7 +153,7 @@ describe('ExtHostConsoleService', function () {
 
 	it('startup race: live $onDidChangeActiveConsole before $getActiveConsoleSessionId resolves wins', async function () {
 		const { shape, resolveActiveSessionId } = createControllableMockShape();
-		const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService());
+		const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService(), nullDocsAndEditors);
 
 		svc.$addConsole('session-1');
 		svc.$addConsole('session-stale');
@@ -164,7 +177,7 @@ describe('ExtHostConsoleService', function () {
 
 	it('constructor seeds _activeConsoleSessionId from $getActiveConsoleSessionId', async function () {
 		const shape = createMockShape('session-preexisting');
-		const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService());
+		const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService(), nullDocsAndEditors);
 
 		// Wait for the async init promise to resolve
 		await new Promise<void>((resolve) => setTimeout(resolve, 0));
@@ -177,5 +190,94 @@ describe('ExtHostConsoleService', function () {
 		expect(svc.activeConsole).toBeDefined();
 		expect(fired.length).toBe(1);
 		expect(fired[0]).toBe(svc.activeConsole);
+	});
+
+	describe('$setActiveConsoleEditor / activeConsoleEditor', function () {
+
+		it('returns undefined initially', function () {
+			const shape = createMockShape();
+			const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService(), nullDocsAndEditors);
+			expect(svc.activeConsoleEditor).toBeUndefined();
+		});
+
+		it('sets activeConsoleEditor from registered editor (derived via _activeConsoleSessionId)', function () {
+			const fakeValue = Object.freeze({}) as import('vscode').TextEditor;
+			const fakeExtEditor = { value: fakeValue } as unknown as ExtHostTextEditor;
+			// getEditor key matches `console-${sessionId}` format used by the getter
+			const docsAndEditors = createDocsAndEditors({ 'console-session-1': fakeExtEditor });
+
+			const shape = createMockShape();
+			const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService(), docsAndEditors);
+
+			const fired: (import('vscode').TextEditor | undefined)[] = [];
+			disposables.add(svc.onDidChangeActiveConsoleEditor((e) => fired.push(e)));
+
+			// $onDidChangeActiveConsole sets _activeConsoleSessionId; $setActiveConsoleEditor fires the event
+			svc.$onDidChangeActiveConsole('session-1');
+			svc.$setActiveConsoleEditor('console-session-1');
+
+			expect(svc.activeConsoleEditor).toBe(fakeValue);
+			expect(fired).toEqual([fakeValue]);
+		});
+
+		it('clears activeConsoleEditor when session becomes null', function () {
+			const fakeValue = Object.freeze({}) as import('vscode').TextEditor;
+			const fakeExtEditor = { value: fakeValue } as unknown as ExtHostTextEditor;
+			const docsAndEditors = createDocsAndEditors({ 'console-session-1': fakeExtEditor });
+
+			const shape = createMockShape();
+			const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService(), docsAndEditors);
+
+			svc.$onDidChangeActiveConsole('session-1');
+			svc.$setActiveConsoleEditor('console-session-1');
+			expect(svc.activeConsoleEditor).toBe(fakeValue);
+
+			const fired: (import('vscode').TextEditor | undefined)[] = [];
+			disposables.add(svc.onDidChangeActiveConsoleEditor((e) => fired.push(e)));
+
+			// Active console clears; $onDidChangeActiveConsole(undefined) precedes $setActiveConsoleEditor(null)
+			svc.$onDidChangeActiveConsole(undefined);
+			svc.$setActiveConsoleEditor(null);
+			expect(svc.activeConsoleEditor).toBeUndefined();
+			expect(fired).toEqual([undefined]);
+		});
+
+		it('yields undefined when no active session even with an editorId signal', function () {
+			const shape = createMockShape();
+			const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService(), nullDocsAndEditors);
+
+			const fired: (import('vscode').TextEditor | undefined)[] = [];
+			disposables.add(svc.onDidChangeActiveConsoleEditor((e) => fired.push(e)));
+
+			// Without $onDidChangeActiveConsole, _activeConsoleSessionId is undefined
+			svc.$setActiveConsoleEditor('console-session-1');
+			expect(svc.activeConsoleEditor).toBeUndefined();
+			expect(fired).toEqual([undefined]);
+		});
+
+		it('fires onDidChangeActiveConsoleEditor on each session change', function () {
+			const fakeA = Object.freeze({}) as import('vscode').TextEditor;
+			const fakeB = Object.freeze({}) as import('vscode').TextEditor;
+			const docsAndEditors = createDocsAndEditors({
+				'console-session-a': { value: fakeA } as unknown as ExtHostTextEditor,
+				'console-session-b': { value: fakeB } as unknown as ExtHostTextEditor,
+			});
+
+			const shape = createMockShape();
+			const svc = new ExtHostConsoleService(SingleProxyRPCProtocol(shape), new NullLogService(), docsAndEditors);
+
+			const fired: (import('vscode').TextEditor | undefined)[] = [];
+			disposables.add(svc.onDidChangeActiveConsoleEditor((e) => fired.push(e)));
+
+			svc.$onDidChangeActiveConsole('session-a');
+			svc.$setActiveConsoleEditor('console-session-a');
+			svc.$onDidChangeActiveConsole('session-b');
+			svc.$setActiveConsoleEditor('console-session-b');
+			svc.$onDidChangeActiveConsole(undefined);
+			svc.$setActiveConsoleEditor(null);
+
+			expect(fired).toEqual([fakeA, fakeB, undefined]);
+			expect(svc.activeConsoleEditor).toBeUndefined();
+		});
 	});
 });

--- a/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
@@ -488,6 +488,12 @@ export interface IPositronConsoleInstance {
 	codeEditor: ICodeEditor | undefined;
 
 	/**
+	 * An event that fires when the code editor is assigned for the first time
+	 * (i.e. when the ConsoleInput React component mounts and sets the editor).
+	 */
+	readonly onDidSetCodeEditor: Event<ICodeEditor>;
+
+	/**
 	 * Toggles trace.
 	 */
 	toggleTrace(): void;

--- a/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
@@ -488,8 +488,9 @@ export interface IPositronConsoleInstance {
 	codeEditor: ICodeEditor | undefined;
 
 	/**
-	 * An event that fires when the code editor is assigned for the first time
-	 * (i.e. when the ConsoleInput React component mounts and sets the editor).
+	 * An event that fires each time a code editor is assigned (i.e. every time the ConsoleInput
+	 * React component mounts and sets the editor). Fires again on remount with the new editor,
+	 * since the previous one has been disposed by then.
 	 */
 	readonly onDidSetCodeEditor: Event<ICodeEditor>;
 

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -1046,6 +1046,16 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 		}
 		this._positronConsoleInstancesBySessionId.delete(sessionId);
 
+		// If nothing above claimed the active console, clear it. Neither branch always does: the
+		// foreground session handler ignores `undefined`, which is what the console branch sets when
+		// there is no other session to fall back to, and the notebook branch has nothing to switch
+		// to when the deleted instance is not in the map. Without this, the deleted instance stays
+		// the active console -- and the extension host keeps handing out its session (and its
+		// `positron.window.activeConsoleEditor`) to extensions.
+		if (this._activePositronConsoleInstance === consoleInstance) {
+			this.setActivePositronConsoleInstance(undefined);
+		}
+
 		consoleInstance.dispose();
 
 		this._onDidDeletePositronConsoleInstanceEmitter.fire(consoleInstance);

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -1358,7 +1358,8 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	private readonly _onDidRequestRevealExecutionEmitter = this._register(new Emitter<string>);
 
 	/**
-	 * Fires once when the ConsoleInput React component assigns the code editor.
+	 * Fires each time the ConsoleInput React component assigns the code editor, including on
+	 * remount.
 	 */
 	private readonly _onDidSetCodeEditorEmitter = this._register(new Emitter<ICodeEditor>());
 

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -1358,6 +1358,11 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	private readonly _onDidRequestRevealExecutionEmitter = this._register(new Emitter<string>);
 
 	/**
+	 * Fires once when the ConsoleInput React component assigns the code editor.
+	 */
+	private readonly _onDidSetCodeEditorEmitter = this._register(new Emitter<ICodeEditor>());
+
+	/**
 	 * Provides access to the code editor, if it's available. Note that we generally prefer to
 	 * interact with this editor indirectly, since its state is managed by React.
 	 */
@@ -1465,6 +1470,9 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 */
 	set codeEditor(value: ICodeEditor | undefined) {
 		this._codeEditor = value;
+		if (value) {
+			this._onDidSetCodeEditorEmitter.fire(value);
+		}
 	}
 
 	get sessionMetadata(): IRuntimeSessionMetadata {
@@ -1653,6 +1661,11 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 * onDidPasteText event.
 	 */
 	readonly onDidPasteText = this._onDidPasteTextEmitter.event;
+
+	/**
+	 * onDidSetCodeEditor event.
+	 */
+	readonly onDidSetCodeEditor = this._onDidSetCodeEditorEmitter.event;
 
 	/**
 	 * onDidSelectAll event.

--- a/src/vs/workbench/services/positronConsole/test/browser/positronConsoleService.vitest.ts
+++ b/src/vs/workbench/services/positronConsole/test/browser/positronConsoleService.vitest.ts
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { Event } from '../../../../../base/common/event.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { startTestLanguageRuntimeSession } from '../../../runtimeSession/test/common/testRuntimeSessionService.js';
+import { IConsoleFindWidget, IConsoleFindWidgetFactory, IPositronConsoleInstance } from '../../browser/interfaces/positronConsoleService.js';
+import { PositronConsoleService } from '../../browser/positronConsoleService.js';
+
+describe('PositronConsoleService', () => {
+
+	const ctx = createTestContainer()
+		.withWorkbenchServices()
+		// Console instances create a find widget on construction; the widget itself is UI that
+		// nothing here exercises.
+		.stub(IConsoleFindWidgetFactory, {
+			createFindWidget: () => stubInterface<IConsoleFindWidget>({
+				onDidHide: Event.None,
+				dispose: () => { }
+			})
+		})
+		.build();
+
+	it('clears the active console instance when the active console is deleted', async () => {
+		const consoleService = ctx.disposables.add(
+			ctx.instantiationService.createInstance(PositronConsoleService));
+		const session = await startTestLanguageRuntimeSession(ctx.instantiationService, ctx.disposables);
+		expect(consoleService.activePositronConsoleInstance?.sessionId).toBe(session.sessionId);
+
+		const active: (IPositronConsoleInstance | undefined)[] = [];
+		ctx.disposables.add(consoleService.onDidChangeActivePositronConsoleInstance(
+			instance => active.push(instance)));
+
+		// There is no other console to fall back to, so nothing else reports an active console
+		// change here: the foreground session becomes `undefined`, which the foreground session
+		// handler ignores. Consumers that track the active console -- the extension host behind
+		// `positron.window.activeConsoleEditor` among them -- would keep the deleted console.
+		consoleService.deletePositronConsoleSession(session.sessionId);
+
+		expect(active.map(instance => instance?.sessionId)).toEqual([undefined]);
+		expect(consoleService.activePositronConsoleInstance).toBeUndefined();
+	});
+});

--- a/src/vs/workbench/services/positronConsole/test/browser/testPositronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/test/browser/testPositronConsoleService.ts
@@ -332,8 +332,18 @@ export class TestPositronConsoleInstance implements IPositronConsoleInstance {
 		public readonly sessionMetadata: IRuntimeSessionMetadata,
 		public readonly runtimeMetadata: ILanguageRuntimeMetadata,
 		public readonly runtimeItems: RuntimeItem[] = [],
-		public readonly codeEditor: ICodeEditor | undefined = undefined
+		public codeEditor: ICodeEditor | undefined = undefined
 	) { }
+
+	/**
+	 * Attaches a code editor and fires the onDidSetCodeEditor event, mirroring the console input
+	 * component assigning its Monaco editor once it mounts.
+	 * @param codeEditor The code editor to attach.
+	 */
+	setCodeEditor(codeEditor: ICodeEditor): void {
+		this.codeEditor = codeEditor;
+		this._onDidSetCodeEditorEmitter.fire(codeEditor);
+	}
 
 	get onFocusInput(): Event<FocusInputOptions> {
 		return this._onFocusInputEmitter.event;

--- a/src/vs/workbench/services/positronConsole/test/browser/testPositronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/test/browser/testPositronConsoleService.ts
@@ -313,6 +313,7 @@ export class TestPositronConsoleInstance implements IPositronConsoleInstance {
 	private readonly _onDidAttachSessionEmitter = new Emitter<ILanguageRuntimeSession | undefined>();
 	private readonly _onDidChangeWidthInCharsEmitter = new Emitter<number>();
 	private readonly _onDidRequestRevealExecutionEmitter = new Emitter<string>();
+	private readonly _onDidSetCodeEditorEmitter = new Emitter<ICodeEditor>();
 
 	private _findWidget: IConsoleFindWidget | undefined;
 
@@ -404,6 +405,10 @@ export class TestPositronConsoleInstance implements IPositronConsoleInstance {
 
 	get onDidRequestRevealExecution(): Event<string> {
 		return this._onDidRequestRevealExecutionEmitter.event;
+	}
+
+	get onDidSetCodeEditor(): Event<ICodeEditor> {
+		return this._onDidSetCodeEditorEmitter.event;
 	}
 
 	get onDidChangeWidthInChars(): Event<number> {


### PR DESCRIPTION
Fixes #1507

Adds `positron.window.activeConsoleEditor` and `positron.window.onDidChangeActiveConsoleEditor` to the Positron extension API, exposing the console input as a `vscode.TextEditor` (parallel to VS Code's `activeTextEditor` and `activeNotebookEditor`). The console editor is registered with the extension host's text editor machinery via a Positron-specific path that preserves `isSimpleWidget: true`, so it is never surfaced as `vscode.window.activeTextEditor` -- only through the new Positron API.

### Release Notes

#### New Features

- Added `positron.window.activeConsoleEditor` and `onDidChangeActiveConsoleEditor` -- expose the active console input as a `vscode.TextEditor` so extensions can read and edit console text using the standard editor API (#1507)

#### Bug Fixes

- N/A

### Validation Steps

@:console

1. Start a Zed (or R/Python) console session in Positron.
2. In the Zed console, run `console active` -- the output should show the console's `inmemory://` URI, language ID, and current input text.
3. Run `console watch`, then switch between different language consoles -- each switch should fire an event showing the new editor's URI. Run `console watch stop` to stop.
4. Exercise the mutating `vscode.TextEditor` API against the console input:
   - `console edit foo` -- replaces the input with `foo` via `TextEditor.edit()`.
   - `console append bar` -- inserts `bar` at the end via `TextEditor.edit()`.
   - `console insert baz` -- inserts `baz` at the cursor via `TextEditor.insertSnippet()`.
   - `console select` -- selects the whole input and reports `TextEditor.selection`.