### PR TITLE
Add cwd, args-array, and debug preview to positron-run-app API

### DIFF
--- a/extensions/authentication/package-lock.json
+++ b/extensions/authentication/package-lock.json
@@ -7,7 +7,6 @@
 		"": {
 			"name": "authentication",
 			"version": "0.0.1",
-			"hasInstallScript": true,
 			"dependencies": {
 				"@aws-sdk/credential-providers": "^3.734.0",
 				"@aws-sdk/types": "^3.734.0",

--- a/extensions/authentication/package-lock.json
+++ b/extensions/authentication/package-lock.json
@@ -7,6 +7,7 @@
 		"": {
 			"name": "authentication",
 			"version": "0.0.1",
+			"hasInstallScript": true,
 			"dependencies": {
 				"@aws-sdk/credential-providers": "^3.734.0",
 				"@aws-sdk/types": "^3.734.0",

--- a/extensions/positron-python/src/client/positron-run-app.d.ts
+++ b/extensions/positron-python/src/client/positron-run-app.d.ts
@@ -8,18 +8,75 @@ import * as positron from 'positron';
 import * as vscode from 'vscode';
 
 /**
- * Options returned from ${@link RunAppOptions.getTerminalOptions}.
+ * Options shared by every {@link RunAppTerminalOptions} variant.
  */
-export interface RunAppTerminalOptions {
+interface RunAppTerminalOptionsBase {
     /**
-     * The command line to run in the terminal.
+     * The optional working directory to create the terminal with. When unset,
+     * the terminal inherits the default working directory (typically the
+     * workspace root).
      */
-    commandLine: string;
+    cwd?: string;
 
     /**
      * The optional environment variables to create the terminal with.
      */
     env?: { [key: string]: string | null | undefined };
+}
+
+/**
+ * Options returned from ${@link RunAppOptions.getTerminalOptions}.
+ *
+ * Provide the command to run in exactly one of two ways (the two forms are
+ * mutually exclusive):
+ *
+ * - {@link RunAppTerminalCommandLineOptions.commandLine commandLine}: a
+ *   pre-escaped command line string. The caller is responsible for
+ *   shell-escaping any paths or arguments.
+ * - {@link RunAppTerminalCommandOptions.command command} (with optional
+ *   {@link RunAppTerminalCommandOptions.args args}): the executable and its
+ *   arguments as separate values. positron-run-app builds the command line and
+ *   applies shell-appropriate escaping for the terminal's shell, so callers
+ *   don't have to worry about spaces in interpreter or application paths.
+ *
+ * Prefer the {@link RunAppTerminalCommandOptions.command command}/
+ * {@link RunAppTerminalCommandOptions.args args} form for new callers.
+ */
+export type RunAppTerminalOptions = RunAppTerminalCommandLineOptions | RunAppTerminalCommandOptions;
+
+/**
+ * The pre-escaped command line form of {@link RunAppTerminalOptions}.
+ */
+export interface RunAppTerminalCommandLineOptions extends RunAppTerminalOptionsBase {
+    /**
+     * The command line to run in the terminal. Must already be escaped for the
+     * target shell.
+     */
+    commandLine: string;
+
+    command?: never;
+    args?: never;
+}
+
+/**
+ * The executable-and-arguments form of {@link RunAppTerminalOptions}, escaped
+ * for the terminal's shell by positron-run-app.
+ */
+export interface RunAppTerminalCommandOptions extends RunAppTerminalOptionsBase {
+    /**
+     * The executable to run (e.g. an interpreter path). positron-run-app escapes
+     * {@link command} and {@link args} for the terminal's shell and runs the
+     * resulting command line.
+     */
+    command: string;
+
+    /**
+     * The arguments to pass to {@link command}. Each argument is escaped
+     * independently for the terminal's shell.
+     */
+    args?: string[];
+
+    commandLine?: never;
 }
 
 /**
@@ -33,6 +90,18 @@ export interface RunAppConsoleCode {
 }
 
 /**
+ * How to preview the application once the URL is detected.
+ *
+ * - `'viewer'`   — open in the Positron Viewer pane.
+ * - `'editor'`   — open in an editor tab.
+ * - `'external'` — open in an external browser.
+ * - `'none'`     — skip URL detection and preview entirely.
+ * - `'manual'`   — detect the URL but return it to the caller
+ *                   instead of previewing.
+ */
+export type PreviewMode = 'viewer' | 'editor' | 'external' | 'none' | 'manual';
+
+/**
  * Shared options for running an application.
  */
 interface RunAppOptionsBase {
@@ -40,6 +109,14 @@ interface RunAppOptionsBase {
      * The human-readable label for the application e.g. `'Streamlit'`.
      */
     name: string;
+
+    /**
+     * How to preview the application once the URL is detected.
+     *
+     * Defaults to `'default'`, which resolves to the user's
+     * `positron.runApp.previewMode` setting (initially `'viewer'`).
+     */
+    preview?: PreviewMode | 'default';
 
     /**
      * The optional URL path at which to preview the application.
@@ -63,6 +140,12 @@ interface RunAppOptionsBase {
      * runtimes without DAP support to avoid a waiting overhead on every run.
      */
     debugAdapterType?: string;
+
+    /**
+     * Optional timeout in milliseconds for URL detection in application output.
+     * If not specified, a default timeout is used.
+     */
+    urlDetectionTimeout?: number;
 }
 
 /**
@@ -127,6 +210,14 @@ export interface DebugAppOptions {
     ): vscode.DebugConfiguration | undefined | Promise<vscode.DebugConfiguration | undefined>;
 
     /**
+     * How to preview the application once the URL is detected.
+     *
+     * Defaults to `'default'`, which resolves to the user's
+     * `positron.runApp.previewMode` setting (initially `'viewer'`).
+     */
+    preview?: PreviewMode | 'default';
+
+    /**
      * The optional URL path at which to preview the application.
      */
     urlPath?: string;
@@ -140,6 +231,12 @@ export interface DebugAppOptions {
      * An optional array of app URI formats to parse the URI from the terminal output.
      */
     appUrlStrings?: string[];
+
+    /**
+     * Optional timeout in milliseconds for URL detection in application output.
+     * If not specified, a default timeout is used.
+     */
+    urlDetectionTimeout?: number;
 }
 
 /**
@@ -150,19 +247,23 @@ export interface PositronRunApp {
      * Run an application in the terminal.
      *
      * @param options Options for running the application.
-     * @returns If terminal shell integration is supported, resolves when the application server has
-     *  started, otherwise resolves when the command has been sent to the terminal.
+     * @returns If terminal shell integration is supported, resolves when the
+     *  application server has started, otherwise resolves when the command has
+     *  been sent to the terminal. When `preview` is `'manual'`, resolves with
+     *  the detected URL (rejects if detection fails).
      */
-    runApplication(options: RunAppOptions): Promise<void>;
+    runApplication(options: RunAppOptions): Promise<vscode.Uri | undefined>;
 
     /**
      * Run an application in a new console session.
      *
      * @param options Options for running the application.
      * @returns Resolves when the application server has started, or when the
-     *  code has been sent to the console if URL detection times out.
+     *  code has been sent to the console if URL detection times out. When
+     *  `preview` is `'manual'`, resolves with the detected URL (rejects if
+     *  detection fails).
      */
-    runApplicationInConsole(options: RunConsoleAppOptions): Promise<void>;
+    runApplicationInConsole(options: RunConsoleAppOptions): Promise<vscode.Uri | undefined>;
 
     /**
      * Debug an application.

--- a/extensions/positron-python/src/client/positron/webAppCommands.ts
+++ b/extensions/positron-python/src/client/positron/webAppCommands.ts
@@ -131,7 +131,7 @@ function registerExecCommand(
                     return undefined;
                 }
 
-                const args = [runtime.runtimePath];
+                const args: string[] = [];
                 if ('module' in config) {
                     args.push('-m', config.module);
                 } else {
@@ -141,8 +141,11 @@ function registerExecCommand(
                     args.push(...config.args);
                 }
 
+                // Pass the interpreter and args separately so positron-run-app
+                // escapes them for the target shell (e.g. paths with spaces).
                 const terminalOptions: RunAppTerminalOptions = {
-                    commandLine: args.join(' '),
+                    command: runtime.runtimePath,
+                    args,
                 };
                 // Add environment variables if any.
                 if (config.env && Object.keys(config.env).length > 0) {

--- a/extensions/positron-python/src/test/positron/webAppCommands.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/webAppCommands.unit.test.ts
@@ -42,8 +42,11 @@ suite('Web app commands', () => {
             async runApplication(_options) {
                 assert.ok(!runAppOptions, 'runApplication called more than once');
                 runAppOptions = _options;
+                return undefined;
             },
-            async runApplicationInConsole() {},
+            async runApplicationInConsole() {
+                return undefined;
+            },
             async debugApplication(_options) {
                 assert.ok(!debugAppOptions, 'debugApplication called more than once');
                 debugAppOptions = _options;

--- a/extensions/positron-python/src/test/positron/webAppCommands.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/webAppCommands.unit.test.ts
@@ -148,7 +148,8 @@ suite('Web app commands', () => {
 
     test('Exec Dash in terminal - without urlPrefix', async () => {
         await verifyRunAppCommand(Commands.Exec_Dash_In_Terminal, {
-            commandLine: `${runtimePath} ${documentPath}`,
+            command: runtimePath,
+            args: [documentPath],
             env: { PYTHONPATH: workspacePath },
         });
     });
@@ -157,7 +158,8 @@ suite('Web app commands', () => {
         await verifyRunAppCommand(
             Commands.Exec_Dash_In_Terminal,
             {
-                commandLine: `${runtimePath} ${documentPath}`,
+                command: runtimePath,
+                args: [documentPath],
                 env: {
                     PYTHONPATH: workspacePath,
                     DASH_URL_BASE_PATHNAME: urlPrefix,
@@ -169,7 +171,8 @@ suite('Web app commands', () => {
 
     test('Exec FastAPI in terminal - fastapi-cli installed', async () => {
         await verifyRunAppCommand(Commands.Exec_FastAPI_In_Terminal, {
-            commandLine: `${runtimePath} -m fastapi dev ${documentPath}`,
+            command: runtimePath,
+            args: ['-m', 'fastapi', 'dev', documentPath],
         });
     });
 
@@ -178,7 +181,7 @@ suite('Web app commands', () => {
 
         await verifyRunAppCommand(
             Commands.Exec_FastAPI_In_Terminal,
-            { commandLine: `${runtimePath} -m uvicorn --reload ${path.parse(documentPath).name}:app` },
+            { command: runtimePath, args: ['-m', 'uvicorn', '--reload', `${path.parse(documentPath).name}:app`] },
             { documentText: 'app = FastAPI()' },
         );
     });
@@ -192,14 +195,15 @@ suite('Web app commands', () => {
     test('Exec FastAPI in terminal - with urlPrefix', async () => {
         await verifyRunAppCommand(
             Commands.Exec_FastAPI_In_Terminal,
-            { commandLine: `${runtimePath} -m fastapi dev ${documentPath}` },
+            { command: runtimePath, args: ['-m', 'fastapi', 'dev', documentPath] },
             { urlPrefix },
         );
     });
 
     test('Exec Flask in terminal - without urlPrefix', async () => {
         await verifyRunAppCommand(Commands.Exec_Flask_In_Terminal, {
-            commandLine: `${runtimePath} -m flask --app ${documentPath} run`,
+            command: runtimePath,
+            args: ['-m', 'flask', '--app', documentPath, 'run'],
         });
     });
 
@@ -207,7 +211,8 @@ suite('Web app commands', () => {
         await verifyRunAppCommand(
             Commands.Exec_Flask_In_Terminal,
             {
-                commandLine: `${runtimePath} -m flask --app ${documentPath} run`,
+                command: runtimePath,
+                args: ['-m', 'flask', '--app', documentPath, 'run'],
             },
             { urlPrefix },
         );
@@ -215,7 +220,8 @@ suite('Web app commands', () => {
 
     test('Exec Gradio in terminal - without urlPrefix', async () => {
         await verifyRunAppCommand(Commands.Exec_Gradio_In_Terminal, {
-            commandLine: `${runtimePath} ${documentPath}`,
+            command: runtimePath,
+            args: [documentPath],
         });
     });
 
@@ -223,7 +229,8 @@ suite('Web app commands', () => {
         await verifyRunAppCommand(
             Commands.Exec_Gradio_In_Terminal,
             {
-                commandLine: `${runtimePath} ${documentPath}`,
+                command: runtimePath,
+                args: [documentPath],
             },
             { urlPrefix },
         );
@@ -231,7 +238,8 @@ suite('Web app commands', () => {
 
     test('Exec Streamlit in terminal - without urlPrefix', async () => {
         await verifyRunAppCommand(Commands.Exec_Streamlit_In_Terminal, {
-            commandLine: `${runtimePath} -m streamlit run ${documentPath} --server.headless true`,
+            command: runtimePath,
+            args: ['-m', 'streamlit', 'run', documentPath, '--server.headless', 'true'],
         });
     });
 
@@ -239,7 +247,8 @@ suite('Web app commands', () => {
         await verifyRunAppCommand(
             Commands.Exec_Streamlit_In_Terminal,
             {
-                commandLine: `${runtimePath} -m streamlit run ${documentPath} --server.headless true`,
+                command: runtimePath,
+                args: ['-m', 'streamlit', 'run', documentPath, '--server.headless', 'true'],
             },
             { urlPrefix },
         );

--- a/extensions/positron-run-app/src/api.ts
+++ b/extensions/positron-run-app/src/api.ts
@@ -10,7 +10,7 @@ import { DebugAdapterTrackerFactory } from './debugAdapterTrackerFactory';
 import { log } from './extension';
 import { DebugAppOptions, PositronRunApp, PreviewMode, RunAppOptions, RunConsoleAppOptions } from './positron-run-app';
 import { AppUrlDetector } from './appUrlDetector';
-import { raceTimeout, SequencerByKey } from './utils';
+import { buildCommandLine, raceTimeout, SequencerByKey } from './utils';
 import { DAP_CONFIGURATION_TIMEOUT, IS_POSITRON_WEB, IS_RUNNING_ON_PWB, SHELL_INTEGRATION_TIMEOUT } from './constants.js';
 import { AppPreviewOptions, Config, PositronProxyInfo } from './types.js';
 import { shouldUsePositronProxy, showShellIntegrationNotSupportedMessage, showEnableShellIntegrationMessage } from './api-utils.js';
@@ -156,6 +156,13 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 			return;
 		}
 
+		// Resolve the command line to run. Callers provide either a pre-escaped
+		// `commandLine` string or a `command`/`args` pair that we escape for the
+		// terminal's shell (the two forms are mutually exclusive).
+		const commandLine = terminalOptions.command !== undefined
+			? buildCommandLine(vscode.env.shell, terminalOptions.command, terminalOptions.args)
+			: terminalOptions.commandLine;
+
 		// Show shell integration prompts and check if shell integration is:
 		// - enabled in the workspace, and
 		// - supported in the terminal.
@@ -169,6 +176,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 		// Create a new terminal for the application.
 		const terminal = vscode.window.createTerminal({
 			name: options.name,
+			cwd: terminalOptions.cwd,
 			env: terminalOptions.env,
 		});
 
@@ -254,7 +262,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 			await this.setShellIntegrationSupported(true);
 
 			// Execute the command.
-			const execution = shellIntegration.executeCommand(terminalOptions.commandLine);
+			const execution = shellIntegration.executeCommand(commandLine);
 
 			// Wait for the server URL in the execution output.
 			if (preview !== 'none') {
@@ -287,7 +295,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 			//       then open the URL in the viewer pane.
 
 			// Execute the command without shell integration.
-			terminal.sendText(terminalOptions.commandLine, true);
+			terminal.sendText(commandLine, true);
 
 			// Remember that shell integration is not supported to display the guide in future runs.
 			await this.setShellIntegrationSupported(false);
@@ -538,6 +546,19 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 
 		const debugAppRequestId = debugConfig.debugAppRequestId = randomUUID();
 
+		// Resolve how to preview the app once its URL is detected. Honors the
+		// per-app `preview` option and, via `parsePreviewMode`, the user's
+		// `positron.runApp.previewMode` setting.
+		const preview = parsePreviewMode(options.preview);
+
+		// When previewing is disabled, skip URL detection entirely and just
+		// start the debug session.
+		if (preview === 'none') {
+			progress.report({ message: vscode.l10n.t('Starting application...') });
+			await vscode.debug.startDebugging(undefined, debugConfig);
+			return;
+		}
+
 		// Create a promise that resolves when the server URL has been previewed,
 		// or an error has occurred, or it times out.
 		const debugPreviewTimeout = (options.urlDetectionTimeout ?? readUrlDetectionTimeout()) + 5_000;
@@ -556,6 +577,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 
 							if (await e.terminal.processId === processId) {
 								const previewOptions: AppPreviewOptions = {
+									preview,
 									terminalPid: processId,
 									proxyInfo,
 									urlPath: options.urlPath,

--- a/extensions/positron-run-app/src/positron-run-app.d.ts
+++ b/extensions/positron-run-app/src/positron-run-app.d.ts
@@ -8,18 +8,77 @@ import * as positron from 'positron';
 import * as vscode from 'vscode';
 
 /**
- * Options returned from ${@link RunAppOptions.getTerminalOptions}.
+ * Options shared by every {@link RunAppTerminalOptions} variant.
  */
-export interface RunAppTerminalOptions {
+interface RunAppTerminalOptionsBase {
 	/**
-	 * The command line to run in the terminal.
+	 * The optional working directory to create the terminal with. When unset,
+	 * the terminal inherits the default working directory (typically the
+	 * workspace root).
 	 */
-	commandLine: string;
+	cwd?: string;
 
 	/**
 	 * The optional environment variables to create the terminal with.
 	 */
 	env?: { [key: string]: string | null | undefined };
+}
+
+/**
+ * Options returned from ${@link RunAppOptions.getTerminalOptions}.
+ *
+ * Provide the command to run in exactly one of two ways (the two forms are
+ * mutually exclusive):
+ *
+ * - {@link RunAppTerminalCommandLineOptions.commandLine commandLine}: a
+ *   pre-escaped command line string. The caller is responsible for
+ *   shell-escaping any paths or arguments.
+ * - {@link RunAppTerminalCommandOptions.command command} (with optional
+ *   {@link RunAppTerminalCommandOptions.args args}): the executable and its
+ *   arguments as separate values. positron-run-app builds the command line and
+ *   applies shell-appropriate escaping for the terminal's shell, so callers
+ *   don't have to worry about spaces in interpreter or application paths.
+ *
+ * Prefer the {@link RunAppTerminalCommandOptions.command command}/
+ * {@link RunAppTerminalCommandOptions.args args} form for new callers.
+ */
+export type RunAppTerminalOptions =
+	| RunAppTerminalCommandLineOptions
+	| RunAppTerminalCommandOptions;
+
+/**
+ * The pre-escaped command line form of {@link RunAppTerminalOptions}.
+ */
+export interface RunAppTerminalCommandLineOptions extends RunAppTerminalOptionsBase {
+	/**
+	 * The command line to run in the terminal. Must already be escaped for the
+	 * target shell.
+	 */
+	commandLine: string;
+
+	command?: never;
+	args?: never;
+}
+
+/**
+ * The executable-and-arguments form of {@link RunAppTerminalOptions}, escaped
+ * for the terminal's shell by positron-run-app.
+ */
+export interface RunAppTerminalCommandOptions extends RunAppTerminalOptionsBase {
+	/**
+	 * The executable to run (e.g. an interpreter path). positron-run-app escapes
+	 * {@link command} and {@link args} for the terminal's shell and runs the
+	 * resulting command line.
+	 */
+	command: string;
+
+	/**
+	 * The arguments to pass to {@link command}. Each argument is escaped
+	 * independently for the terminal's shell.
+	 */
+	args?: string[];
+
+	commandLine?: never;
 }
 
 /**
@@ -151,6 +210,14 @@ export interface DebugAppOptions {
 		document: vscode.TextDocument,
 		urlPrefix?: string,
 	): vscode.DebugConfiguration | undefined | Promise<vscode.DebugConfiguration | undefined>;
+
+	/**
+	 * How to preview the application once the URL is detected.
+	 *
+	 * Defaults to `'default'`, which resolves to the user's
+	 * `positron.runApp.previewMode` setting (initially `'viewer'`).
+	 */
+	preview?: PreviewMode | 'default';
 
 	/**
 	 * The optional URL path at which to preview the application.

--- a/extensions/positron-run-app/src/test/commandLine.test.ts
+++ b/extensions/positron-run-app/src/test/commandLine.test.ts
@@ -1,0 +1,83 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { buildCommandLine } from '../utils';
+
+suite('buildCommandLine', () => {
+	test('bash escaping', () => {
+		assert.strictEqual(
+			buildCommandLine('bash', 'python', ['app.py']),
+			'python app.py');
+		assert.strictEqual(
+			buildCommandLine('bash', 'python', ['-m', 'shiny', 'run', '--flag=true']),
+			'python -m shiny run --flag=true');
+		// Spaces and special characters are backslash-escaped.
+		assert.strictEqual(
+			buildCommandLine('bash', '/path with spaces/python', ['my app.py']),
+			'/path\\ with\\ spaces/python my\\ app.py');
+		assert.strictEqual(
+			buildCommandLine('bash', 'echo', ['{$} (']),
+			'echo \\{\\$\\}\\ \\(');
+		// Empty argument becomes "".
+		assert.strictEqual(
+			buildCommandLine('bash', 'cmd', ['']),
+			'cmd ""');
+	});
+
+	test('cmd.exe escaping', () => {
+		assert.strictEqual(
+			buildCommandLine('cmd.exe', 'python', ['app.py']),
+			'python app.py');
+		// Paths with spaces are wrapped in double quotes.
+		assert.strictEqual(
+			buildCommandLine('cmd.exe', 'C:\\Program Files\\Python\\python.exe', ['my app.py']),
+			'"C:\\Program Files\\Python\\python.exe" "my app.py"');
+		assert.strictEqual(
+			buildCommandLine('cmd.exe', 'cmd', ['^!< ']),
+			'cmd "^^^!^< "');
+		assert.strictEqual(
+			buildCommandLine('cmd.exe', 'cmd', ['"A>0"']),
+			'cmd """A^>0"""');
+		assert.strictEqual(
+			buildCommandLine('cmd.exe', 'cmd', ['']),
+			'cmd ""');
+	});
+
+	test('powershell escaping', () => {
+		// The quoted executable is invoked with the call operator `&`.
+		assert.strictEqual(
+			buildCommandLine('powershell', 'python', ['app.py']),
+			`& 'python' 'app.py'`);
+		assert.strictEqual(
+			buildCommandLine('pwsh', 'python', ['-m', 'shiny', 'run']),
+			`& 'python' '-m' 'shiny' 'run'`);
+		assert.strictEqual(
+			buildCommandLine('powershell', 'C:\\path with spaces\\python.exe', ['my app.py']),
+			`& 'C:\\path with spaces\\python.exe' 'my app.py'`);
+		// Single quotes are doubled.
+		assert.strictEqual(
+			buildCommandLine('powershell', 'echo', [`it's`]),
+			`& 'echo' 'it''s'`);
+		// A trailing backslash is escaped so it doesn't escape the closing quote.
+		assert.strictEqual(
+			buildCommandLine('powershell', 'cmd', ['dir\\']),
+			`& 'cmd' 'dir\\\\'`);
+	});
+
+	test('command with no args', () => {
+		assert.strictEqual(buildCommandLine('bash', 'python'), 'python');
+		assert.strictEqual(buildCommandLine('cmd.exe', 'python'), 'python');
+		assert.strictEqual(buildCommandLine('powershell', 'python'), `& 'python'`);
+	});
+
+	test('unknown shell falls back to platform default', () => {
+		const result = buildCommandLine(undefined, 'python', ['my app.py']);
+		const expected = process.platform === 'win32'
+			? '"python" "my app.py"' // cmd.exe quoting
+			: 'python my\\ app.py'; // bash quoting
+		assert.strictEqual(result, expected);
+	});
+});

--- a/extensions/positron-run-app/src/utils.ts
+++ b/extensions/positron-run-app/src/utils.ts
@@ -66,3 +66,74 @@ export function removeAnsiEscapeCodes(str: string): string {
 
 	return str;
 }
+
+/*
+ * Shell-appropriate command-line quoting. The per-shell `quote` functions are
+ * adapted from `prepareCommand` in
+ * ../../../src/vs/workbench/contrib/debug/node/terminals.ts (core is not
+ * importable from an extension). Unlike the original, this only quotes a
+ * command and its arguments; the working directory and environment are handled
+ * separately when the terminal is created.
+ */
+
+const enum ShellType { cmd, powershell, bash }
+
+function detectShellType(shell: string | undefined): ShellType {
+	const s = (shell ?? '').trim().toLowerCase();
+	if (s.indexOf('powershell') >= 0 || s.indexOf('pwsh') >= 0) {
+		return ShellType.powershell;
+	} else if (s.indexOf('cmd.exe') >= 0) {
+		return ShellType.cmd;
+	} else if (s.indexOf('bash') >= 0) {
+		return ShellType.bash;
+	} else if (process.platform === 'win32') {
+		return ShellType.cmd; // pick a good default for Windows
+	} else {
+		return ShellType.bash; // pick a good default for anything else
+	}
+}
+
+/**
+ * Build a shell-escaped command line from an executable and its arguments,
+ * quoting each value for the given shell.
+ *
+ * @param shell The shell the command line will run in (e.g. `vscode.env.shell`).
+ * @param command The executable to run.
+ * @param args The arguments to pass to `command`.
+ * @returns The escaped command line string.
+ */
+export function buildCommandLine(shell: string | undefined, command: string, args: string[] = []): string {
+	const parts = [command, ...args];
+
+	switch (detectShellType(shell)) {
+		case ShellType.powershell: {
+			const quote = (s: string) => {
+				s = s.replace(/\'/g, '\'\'');
+				if (s.length > 0 && s.charAt(s.length - 1) === '\\') {
+					return `'${s}\\'`;
+				}
+				return `'${s}'`;
+			};
+			// In PowerShell a quoted executable must be invoked with the call
+			// operator `&`.
+			const cmd = quote(parts[0]);
+			const rest = parts.slice(1).map(quote);
+			return [cmd[0] === '\'' ? `& ${cmd}` : cmd, ...rest].join(' ');
+		}
+		case ShellType.cmd: {
+			const quote = (s: string) => {
+				s = s.replace(/\"/g, '""');
+				s = s.replace(/([><!^&|])/g, '^$1');
+				return (' "'.split('').some(char => s.includes(char)) || s.length === 0) ? `"${s}"` : s;
+			};
+			return parts.map(quote).join(' ');
+		}
+		case ShellType.bash: {
+			const quote = (s: string) => {
+				s = s.replace(/(["'\\\$!><#()\[\]*&^| ;{}?`])/g, '\\$1');
+				return s.length === 0 ? `""` : s;
+			};
+			return parts.map(quote).join(' ');
+		}
+	}
+}


### PR DESCRIPTION
Fixes #14973

### Summary

Extends the `positron-run-app` API so more consumers (notably the external Shiny extension) can adopt it, without changing behavior for existing callers. There are three additions:

**1. `command`/`args` as an alternative to `commandLine`**

`RunAppTerminalOptions` is now a discriminated union. A caller supplies the command to run in exactly one of two mutually exclusive ways:

- `commandLine` -- a pre-escaped command line string (the previous, still-supported form).
- `command` (plus optional `args`) -- the executable and its arguments as separate, unescaped values. positron-run-app builds the command line and applies shell-appropriate quoting via the new `buildCommandLine` helper (adapted from core's `prepareCommand`), so callers no longer have to hand-escape interpreter or application paths. This handles paths with spaces correctly across bash, PowerShell/pwsh, and cmd.

New callers should prefer the `command`/`args` form.

**2. Optional `cwd`**

`RunAppTerminalOptions` gains an optional `cwd`, passed straight through to `createTerminal`. When unset, the terminal inherits the default working directory (typically the workspace root) exactly as before.

**3. `preview` on `DebugAppOptions`**

`DebugAppOptions` gains an optional `preview` field (`PreviewMode | 'default'`). Debugging now resolves the preview mode the same way `runApplication` already did, instead of unconditionally using the Viewer. See the behavior note below.

**In-repo migration**

The `positron-python` web app launchers are migrated to the `command`/`args` form, removing their unescaped `args.join(' ')`. The vendored `.d.ts` copy is regenerated.

### API shape

```ts
/** Options shared by every RunAppTerminalOptions variant. */
interface RunAppTerminalOptionsBase {
	/** Optional working directory for the terminal. Inherits the default when unset. */
	cwd?: string;
	/** Optional environment variables for the terminal. */
	env?: { [key: string]: string | null | undefined };
}

/** Supply the command in exactly one of two mutually exclusive ways. */
type RunAppTerminalOptions =
	| RunAppTerminalCommandLineOptions
	| RunAppTerminalCommandOptions;

/** Pre-escaped command line (the existing form). */
interface RunAppTerminalCommandLineOptions extends RunAppTerminalOptionsBase {
	/** Must already be escaped for the target shell. */
	commandLine: string;
	command?: never;
	args?: never;
}

/** Executable + args, escaped for the terminal's shell by positron-run-app. */
interface RunAppTerminalCommandOptions extends RunAppTerminalOptionsBase {
	command: string;
	args?: string[];
	commandLine?: never;
}
```

Example -- the new `command`/`args` form (from the migrated `positron-python` launcher):

```ts
await runAppApi.runApplication({
	name,
	async getTerminalOptions(runtime, document, urlPrefix) {
		// Pass the interpreter and args separately; positron-run-app escapes
		// them for the target shell (e.g. paths with spaces).
		return {
			command: runtime.runtimePath,
			args: ['-m', 'uvicorn', 'app:app'],
			cwd: appDir,          // new, optional
			env: { PORT: '8000' },
		};
	},
});
```

The pre-escaped form still works unchanged:

```ts
return { commandLine: `"${runtime.runtimePath}" -m uvicorn app:app` };
```

### Backwards compatibility

This is an additive change; existing callers keep working with no code changes.

- **`commandLine` form still works, at both the type and runtime level.** The `commandLine`-only variant keeps `commandLine: string` required, so `{ commandLine, env }` still type-checks. At runtime the consumer falls back to `terminalOptions.commandLine` whenever `command` is undefined.
- **`cwd` is optional and defaults to the prior behavior** (terminal inherits the default cwd).
- **The external Shiny extension** (which consumes the vendored `.d.ts` and returns `{ commandLine }`) needs no changes.

One intentional **behavior change** for existing debug callers: `debugApplication` now honors the preview mode instead of always using the Viewer. For a caller that does not set `preview`, the mode resolves to the user's `positron.runApp.previewMode` setting (default `viewer`). So:

- Default setting (`viewer`): identical to before.
- `editor` / `external` / `manual`: debug now honors the setting rather than forcing the Viewer.
- `none`: debug skips URL detection and just starts the session.

This makes `debugApplication` consistent with `runApplication`, which already read the setting.

Two minor type-only caveats, unlikely to affect an options-bag consumer: `RunAppTerminalOptions` is now a `type` rather than an `interface` (so `interface X extends RunAppTerminalOptions` / declaration merging would no longer work), and reading `.commandLine` off the bare union type now yields `string | undefined` rather than `string`.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

@:apps

Run the built-in Python web apps (Dash, FastAPI, Gradio, Streamlit, Flask) via "Run App in Terminal" and confirm each still launches and previews in the Viewer, exercising the new escaped `command`/`args` path. Optionally place an app under a directory whose path contains spaces to confirm the shell escaping and `cwd` handling. To exercise the debug `preview` change, set `positron.runApp.previewMode` to a non-default value and debug an app.
