### PR TITLE
Strip lightningcss platform binaries from packaged app

### DIFF
--- a/build/.moduleignore
+++ b/build/.moduleignore
@@ -262,3 +262,26 @@ zone.js/dist/**
 # in websocket's browser.js inside a try/catch with a globalThis fallback,
 # so it is unnecessary in the browsers/runtimes VS Code supports.
 es5-ext/**
+
+# --- Start Positron ---
+# lightningcss is a build-time CSS tool pulled in transitively as an optional
+# dependency of vite (a devDependency of the ai-lib file: packages ai-config,
+# ai-credentials, and ai-provider-bridge). Positron does not load it at runtime,
+# so none of its platform binaries should ship. In particular, the
+# lightningcss-linux-x64-musl / lightningcss-linux-arm64-musl .node files break
+# the Linux .deb/.rpm packaging step: dpkg-shlibdeps analyzes every bundled
+# *.node file and aborts because it cannot resolve libc.musl-*.so.1 in the
+# glibc build sysroot. Strip lightningcss and all its platform packages.
+lightningcss/**
+lightningcss-android-arm64/**
+lightningcss-darwin-arm64/**
+lightningcss-darwin-x64/**
+lightningcss-freebsd-x64/**
+lightningcss-linux-arm-gnueabihf/**
+lightningcss-linux-arm64-gnu/**
+lightningcss-linux-arm64-musl/**
+lightningcss-linux-x64-gnu/**
+lightningcss-linux-x64-musl/**
+lightningcss-win32-arm64-msvc/**
+lightningcss-win32-x64-msvc/**
+# --- End Positron ---


### PR DESCRIPTION
### Summary

Fixes the daily Linux release build, which fails during the `.deb`/`.rpm` packaging step (`vscode-linux-x64-prepare-deb`) with:

```
cannot find library libc.musl-x86_64.so.1 needed by
  .../resources/app/node_modules/lightningcss-linux-x64-musl/lightningcss.linux-x64-musl.node
dpkg-shlibdeps failed with exit code 2
```

`build/linux/dependencies-generator.ts` runs `find <app>/node_modules -name '*.node'` and feeds every bundled native module to `dpkg-shlibdeps`. The packaged app now contains `lightningcss` platform binaries, including the musl variant, which `dpkg-shlibdeps` cannot resolve against the glibc build sysroot.

`lightningcss` is a build-time CSS tool pulled in transitively as an optional dependency of `vite` (a devDependency of the `ai-lib` `file:` packages `ai-config`, `ai-credentials`, and `ai-provider-bridge` added in #15094). Positron never loads it at runtime, so none of its platform binaries should ship.

This adds `lightningcss` and all its platform packages to `build/.moduleignore`, mirroring the existing `@github/copilot-linuxmusl-*` precedent, so they are stripped from the packaged app. This also removes dead weight from the shipped bundle.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Restores daily builds

### Validation Steps

@:debian-electron @:rhel-electron

This is a build-packaging change with no runtime behavior, so there is no unit/e2e test to author for it. Validation is that the Linux packages still build and run:

1. The Linux daily build's "Prepare Linux packages" step completes (no `dpkg-shlibdeps` / `libc.musl` error).
2. The resulting `.deb` (Debian) and `.rpm` (RHEL) packages install and Positron launches normally.
