### PR TITLE
fix(python): match new-folder workspace by path when URI scheme differs

### DIFF
--- a/extensions/positron-python/src/client/positron/createEnvApi.ts
+++ b/extensions/positron-python/src/client/positron/createEnvApi.ts
@@ -17,7 +17,7 @@ import { IPythonRuntimeManager } from './manager';
 import { getExtension } from '../common/vscodeApis/extensionsApi';
 import { PythonExtension } from '../api/types';
 import { PVSC_EXTENSION_ID } from '../common/constants';
-import { getConfiguration, getWorkspaceFolder } from '../common/vscodeApis/workspaceApis';
+import { getConfiguration, getWorkspaceFolder, onDidChangeWorkspaceFolders } from '../common/vscodeApis/workspaceApis';
 import { CONDA_PROVIDER_ID } from '../pythonEnvironments/creation/provider/condaCreationProvider';
 import { VenvCreationProviderId } from '../pythonEnvironments/creation/provider/venvCreationProvider';
 import { UV_PROVIDER_ID } from '../pythonEnvironments/creation/provider/uvCreationProvider';
@@ -48,16 +48,55 @@ export interface CreateEnvironmentAndRegisterOptions
     workspaceFolder?: string;
 }
 
+// A folder just created by the New Folder Flow can take a moment to reach this
+// extension host's own `workspace.workspaceFolders` (worse on remote/web). Bound
+// the wait so a folder that genuinely never registers still fails instead of
+// hanging forever.
+const WORKSPACE_FOLDER_REGISTRATION_TIMEOUT_MS = 10_000;
+
 /**
- * Rehydrates a workspace folder URI string into a `WorkspaceFolder`.
+ * Waits for a workspace folder matching `targetUri` to appear in
+ * `workspace.workspaceFolders`, up to `timeoutMs`.
+ * @param targetUri The URI to watch for.
+ * @param timeoutMs The maximum time to wait.
+ * @returns The matching `WorkspaceFolder`, or undefined if the timeout elapsed first.
+ */
+function waitForWorkspaceFolder(targetUri: Uri, timeoutMs: number): Promise<WorkspaceFolder | undefined> {
+    return new Promise((resolve) => {
+        // `timer` and `disposable` each close over the other. Declaring `timer` (a
+        // setTimeout, which the spec guarantees never fires synchronously) first
+        // means `disposable` is always assigned before `timer`'s callback could run.
+        let disposable: ReturnType<typeof onDidChangeWorkspaceFolders>;
+        const timer = setTimeout(() => {
+            disposable.dispose();
+            resolve(undefined);
+        }, timeoutMs);
+        disposable = onDidChangeWorkspaceFolders(() => {
+            const folder = getWorkspaceFolder(targetUri);
+            if (folder) {
+                clearTimeout(timer);
+                disposable.dispose();
+                resolve(folder);
+            }
+        });
+    });
+}
+
+/**
+ * Rehydrates a workspace folder URI string into a `WorkspaceFolder`. If the folder
+ * isn't visible to this extension host yet, waits for it to register instead of
+ * failing immediately (see `WORKSPACE_FOLDER_REGISTRATION_TIMEOUT_MS`).
  * @param workspaceFolderUri The URI string of the workspace folder, or undefined.
  * @returns The corresponding `WorkspaceFolder`, or undefined if no URI was given.
  */
-function rehydrateWorkspaceFolder(workspaceFolderUri: string | undefined): WorkspaceFolder | undefined {
+async function rehydrateWorkspaceFolder(workspaceFolderUri: string | undefined): Promise<WorkspaceFolder | undefined> {
     if (!workspaceFolderUri) {
         return undefined;
     }
-    const folder = getWorkspaceFolder(Uri.parse(workspaceFolderUri));
+    const targetUri = Uri.parse(workspaceFolderUri);
+    const folder =
+        getWorkspaceFolder(targetUri) ??
+        (await waitForWorkspaceFolder(targetUri, WORKSPACE_FOLDER_REGISTRATION_TIMEOUT_MS));
     if (!folder) {
         throw new Error(`Workspace folder not found for URI: ${workspaceFolderUri}`);
     }
@@ -100,7 +139,7 @@ export async function createEnvironmentAndRegister(
     }
     const resolvedOptions: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal = {
         ...options,
-        workspaceFolder: rehydrateWorkspaceFolder(options.workspaceFolder),
+        workspaceFolder: await rehydrateWorkspaceFolder(options.workspaceFolder),
     };
     const result = await handleCreateEnvironmentCommand(providers, resolvedOptions);
     if (result?.path) {

--- a/extensions/positron-python/src/client/positron/createEnvApi.ts
+++ b/extensions/positron-python/src/client/positron/createEnvApi.ts
@@ -65,8 +65,7 @@ function rehydrateWorkspaceFolder(workspaceFolderUri: string | undefined): Works
     }
     const targetUri = Uri.parse(workspaceFolderUri);
     const folder =
-        getWorkspaceFolder(targetUri) ??
-        (getWorkspaceFolders() ?? []).find((f) => f.uri.path === targetUri.path);
+        getWorkspaceFolder(targetUri) ?? (getWorkspaceFolders() ?? []).find((f) => f.uri.path === targetUri.path);
     if (!folder) {
         throw new Error(`Workspace folder not found for URI: ${workspaceFolderUri}`);
     }

--- a/extensions/positron-python/src/client/positron/createEnvApi.ts
+++ b/extensions/positron-python/src/client/positron/createEnvApi.ts
@@ -17,7 +17,7 @@ import { IPythonRuntimeManager } from './manager';
 import { getExtension } from '../common/vscodeApis/extensionsApi';
 import { PythonExtension } from '../api/types';
 import { PVSC_EXTENSION_ID } from '../common/constants';
-import { getConfiguration, getWorkspaceFolder, onDidChangeWorkspaceFolders } from '../common/vscodeApis/workspaceApis';
+import { getConfiguration, getWorkspaceFolder, getWorkspaceFolders } from '../common/vscodeApis/workspaceApis';
 import { CONDA_PROVIDER_ID } from '../pythonEnvironments/creation/provider/condaCreationProvider';
 import { VenvCreationProviderId } from '../pythonEnvironments/creation/provider/venvCreationProvider';
 import { UV_PROVIDER_ID } from '../pythonEnvironments/creation/provider/uvCreationProvider';
@@ -48,55 +48,25 @@ export interface CreateEnvironmentAndRegisterOptions
     workspaceFolder?: string;
 }
 
-// A folder just created by the New Folder Flow can take a moment to reach this
-// extension host's own `workspace.workspaceFolders` (worse on remote/web). Bound
-// the wait so a folder that genuinely never registers still fails instead of
-// hanging forever.
-const WORKSPACE_FOLDER_REGISTRATION_TIMEOUT_MS = 10_000;
-
 /**
- * Waits for a workspace folder matching `targetUri` to appear in
- * `workspace.workspaceFolders`, up to `timeoutMs`.
- * @param targetUri The URI to watch for.
- * @param timeoutMs The maximum time to wait.
- * @returns The matching `WorkspaceFolder`, or undefined if the timeout elapsed first.
- */
-function waitForWorkspaceFolder(targetUri: Uri, timeoutMs: number): Promise<WorkspaceFolder | undefined> {
-    return new Promise((resolve) => {
-        // `timer` and `disposable` each close over the other. Declaring `timer` (a
-        // setTimeout, which the spec guarantees never fires synchronously) first
-        // means `disposable` is always assigned before `timer`'s callback could run.
-        let disposable: ReturnType<typeof onDidChangeWorkspaceFolders>;
-        const timer = setTimeout(() => {
-            disposable.dispose();
-            resolve(undefined);
-        }, timeoutMs);
-        disposable = onDidChangeWorkspaceFolders(() => {
-            const folder = getWorkspaceFolder(targetUri);
-            if (folder) {
-                clearTimeout(timer);
-                disposable.dispose();
-                resolve(folder);
-            }
-        });
-    });
-}
-
-/**
- * Rehydrates a workspace folder URI string into a `WorkspaceFolder`. If the folder
- * isn't visible to this extension host yet, waits for it to register instead of
- * failing immediately (see `WORKSPACE_FOLDER_REGISTRATION_TIMEOUT_MS`).
+ * Rehydrates a workspace folder URI string into a `WorkspaceFolder`.
+ *
+ * The URI string is produced by the workbench/main thread, but this extension host
+ * may represent the same folder under a different URI scheme -- e.g. the main
+ * thread's `vscode-remote://` vs. a remote extension host's `file://`. An
+ * exact-URI lookup therefore misses even when the folder is registered, so fall
+ * back to matching by path before giving up.
  * @param workspaceFolderUri The URI string of the workspace folder, or undefined.
  * @returns The corresponding `WorkspaceFolder`, or undefined if no URI was given.
  */
-async function rehydrateWorkspaceFolder(workspaceFolderUri: string | undefined): Promise<WorkspaceFolder | undefined> {
+function rehydrateWorkspaceFolder(workspaceFolderUri: string | undefined): WorkspaceFolder | undefined {
     if (!workspaceFolderUri) {
         return undefined;
     }
     const targetUri = Uri.parse(workspaceFolderUri);
     const folder =
         getWorkspaceFolder(targetUri) ??
-        (await waitForWorkspaceFolder(targetUri, WORKSPACE_FOLDER_REGISTRATION_TIMEOUT_MS));
+        (getWorkspaceFolders() ?? []).find((f) => f.uri.path === targetUri.path);
     if (!folder) {
         throw new Error(`Workspace folder not found for URI: ${workspaceFolderUri}`);
     }

--- a/extensions/positron-python/src/test/positron/createEnvApi.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/createEnvApi.unit.test.ts
@@ -31,8 +31,7 @@ suite('Positron Create Environment APIs', () => {
     let handleCreateEnvironmentCommandStub: sinon.SinonStub;
     let getConfigurationStub: sinon.SinonStub;
     let getWorkspaceFolderStub: sinon.SinonStub;
-    let onDidChangeWorkspaceFoldersStub: sinon.SinonStub;
-    let workspaceFolderChangeHandlers: Array<() => void>;
+    let getWorkspaceFoldersStub: sinon.SinonStub;
 
     const disposables: IDisposableRegistry = [];
     const mockProvider = createTypeMoq<CreateEnvironmentProvider>();
@@ -96,12 +95,8 @@ suite('Positron Create Environment APIs', () => {
             uri.toString() === workspace1UriString ? workspace1 : undefined,
         );
 
-        workspaceFolderChangeHandlers = [];
-        onDidChangeWorkspaceFoldersStub = sinon.stub(workspaceApis, 'onDidChangeWorkspaceFolders');
-        onDidChangeWorkspaceFoldersStub.callsFake((handler: () => void) => {
-            workspaceFolderChangeHandlers.push(handler);
-            return { dispose: () => { } };
-        });
+        getWorkspaceFoldersStub = sinon.stub(workspaceApis, 'getWorkspaceFolders');
+        getWorkspaceFoldersStub.returns([workspace1]);
 
         registerCommandStub.callsFake((_command: string, _callback: (...args: any[]) => any) => ({
             dispose: () => {
@@ -191,56 +186,41 @@ suite('Positron Create Environment APIs', () => {
         assert.isUndefined(dispatched.workspaceFolder);
     });
 
-    test('Waits for a not-yet-visible workspace folder to register, then dispatches once it appears', async () => {
+    test('Matches by path when the URI scheme differs (remote ext host sees file://, caller sent vscode-remote://)', async () => {
         const resultPath = '/path/to/created/env';
         pythonRuntimeManager
             .setup((p) => p.registerLanguageRuntimeFromPath(resultPath))
             .returns(() => Promise.resolve(createTypeMoq<positron.LanguageRuntimeMetadata>().object));
         handleCreateEnvironmentCommandStub.returns(Promise.resolve({ path: resultPath }));
 
-        // Simulate a brand-new workspace folder that the extension host doesn't see yet.
+        // The caller sends the workbench/main-thread URI (vscode-remote://), but this
+        // extension host represents the same folder as file://. Exact-URI lookup misses;
+        // the path-based fallback against getWorkspaceFolders() should still resolve it.
+        const remoteUri = workspace1.uri.with({ scheme: 'vscode-remote', authority: 'localhost:9000' });
         getWorkspaceFolderStub.callsFake(() => undefined);
+        getWorkspaceFoldersStub.returns([workspace1]);
 
-        const resultPromise = createEnvironmentAndRegister(mockProviders, pythonRuntimeManager.object, {
+        await createEnvironmentAndRegister(mockProviders, pythonRuntimeManager.object, {
             ...envOptions,
+            workspaceFolder: remoteUri.toString(),
         });
 
-        assert.strictEqual(
-            workspaceFolderChangeHandlers.length,
-            1,
-            'should subscribe to workspace folder changes while waiting',
-        );
-        assert.isTrue(handleCreateEnvironmentCommandStub.notCalled, 'should not dispatch before the folder registers');
-
-        // The folder registers; fire the change event that should wake the wait.
-        getWorkspaceFolderStub.callsFake((uri: Uri) => (uri.toString() === workspace1UriString ? workspace1 : undefined));
-        workspaceFolderChangeHandlers[0]();
-
-        const result = await resultPromise;
-
-        assert.isDefined(result?.path);
         const dispatched = handleCreateEnvironmentCommandStub.firstCall.args[1];
         assert.strictEqual(dispatched.workspaceFolder, workspace1);
     });
 
-    test('Throws once the registration wait times out without the folder ever appearing', async () => {
-        const clock = sinon.useFakeTimers();
-        try {
-            getWorkspaceFolderStub.callsFake(() => undefined);
-            const unknownUri = Uri.file('/no/such/workspace').toString();
+    test('Throws when no workspace folder matches by exact URI or by path', async () => {
+        getWorkspaceFolderStub.callsFake(() => undefined);
+        getWorkspaceFoldersStub.returns([workspace1]);
+        const unknownUri = Uri.file('/no/such/workspace').toString();
 
-            const resultPromise = createEnvironmentAndRegister(mockProviders, pythonRuntimeManager.object, {
+        await assert.isRejected(
+            createEnvironmentAndRegister(mockProviders, pythonRuntimeManager.object, {
                 ...envOptions,
                 workspaceFolder: unknownUri,
-            });
-            // Never fire a change event -- the folder never registers. Advance well
-            // past any reasonable wait bound instead of waiting in real time.
-            await clock.tickAsync(60_000);
-
-            await assert.isRejected(resultPromise, /Workspace folder not found/);
-            assert.isTrue(handleCreateEnvironmentCommandStub.notCalled);
-        } finally {
-            clock.restore();
-        }
+            }),
+            /Workspace folder not found/,
+        );
+        assert.isTrue(handleCreateEnvironmentCommandStub.notCalled);
     });
 });

--- a/extensions/positron-python/src/test/positron/createEnvApi.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/createEnvApi.unit.test.ts
@@ -193,20 +193,23 @@ suite('Positron Create Environment APIs', () => {
             .returns(() => Promise.resolve(createTypeMoq<positron.LanguageRuntimeMetadata>().object));
         handleCreateEnvironmentCommandStub.returns(Promise.resolve({ path: resultPath }));
 
-        // The caller sends the workbench/main-thread URI (vscode-remote://), but this
-        // extension host represents the same folder as file://. Exact-URI lookup misses;
-        // the path-based fallback against getWorkspaceFolders() should still resolve it.
-        const remoteUri = workspace1.uri.with({ scheme: 'vscode-remote', authority: 'localhost:9000' });
+        // The real remote case: the folder lives on a remote (POSIX) host. The caller sends
+        // the workbench/main-thread URI (vscode-remote://), but this extension host sees the
+        // same folder as file://, with an identical path. Exact-URI lookup misses on the
+        // scheme; the path-based fallback against getWorkspaceFolders() should resolve it.
+        const remoteFolderPath = '/home/user/new-uv_736628';
+        const extHostFolder = { uri: Uri.file(remoteFolderPath), name: 'new-uv_736628', index: 0 };
+        const callerUri = Uri.from({ scheme: 'vscode-remote', authority: 'localhost:9000', path: remoteFolderPath });
         getWorkspaceFolderStub.callsFake(() => undefined);
-        getWorkspaceFoldersStub.returns([workspace1]);
+        getWorkspaceFoldersStub.returns([extHostFolder]);
 
         await createEnvironmentAndRegister(mockProviders, pythonRuntimeManager.object, {
             ...envOptions,
-            workspaceFolder: remoteUri.toString(),
+            workspaceFolder: callerUri.toString(),
         });
 
         const dispatched = handleCreateEnvironmentCommandStub.firstCall.args[1];
-        assert.strictEqual(dispatched.workspaceFolder, workspace1);
+        assert.strictEqual(dispatched.workspaceFolder, extHostFolder);
     });
 
     test('Throws when no workspace folder matches by exact URI or by path', async () => {

--- a/extensions/positron-python/src/test/positron/createEnvApi.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/createEnvApi.unit.test.ts
@@ -31,6 +31,8 @@ suite('Positron Create Environment APIs', () => {
     let handleCreateEnvironmentCommandStub: sinon.SinonStub;
     let getConfigurationStub: sinon.SinonStub;
     let getWorkspaceFolderStub: sinon.SinonStub;
+    let onDidChangeWorkspaceFoldersStub: sinon.SinonStub;
+    let workspaceFolderChangeHandlers: Array<() => void>;
 
     const disposables: IDisposableRegistry = [];
     const mockProvider = createTypeMoq<CreateEnvironmentProvider>();
@@ -93,6 +95,13 @@ suite('Positron Create Environment APIs', () => {
         getWorkspaceFolderStub.callsFake((uri: Uri) =>
             uri.toString() === workspace1UriString ? workspace1 : undefined,
         );
+
+        workspaceFolderChangeHandlers = [];
+        onDidChangeWorkspaceFoldersStub = sinon.stub(workspaceApis, 'onDidChangeWorkspaceFolders');
+        onDidChangeWorkspaceFoldersStub.callsFake((handler: () => void) => {
+            workspaceFolderChangeHandlers.push(handler);
+            return { dispose: () => { } };
+        });
 
         registerCommandStub.callsFake((_command: string, _callback: (...args: any[]) => any) => ({
             dispose: () => {
@@ -182,16 +191,56 @@ suite('Positron Create Environment APIs', () => {
         assert.isUndefined(dispatched.workspaceFolder);
     });
 
-    test('Throws when workspaceFolder URI does not resolve to a known workspace folder', async () => {
-        const unknownUri = Uri.file('/no/such/workspace').toString();
+    test('Waits for a not-yet-visible workspace folder to register, then dispatches once it appears', async () => {
+        const resultPath = '/path/to/created/env';
+        pythonRuntimeManager
+            .setup((p) => p.registerLanguageRuntimeFromPath(resultPath))
+            .returns(() => Promise.resolve(createTypeMoq<positron.LanguageRuntimeMetadata>().object));
+        handleCreateEnvironmentCommandStub.returns(Promise.resolve({ path: resultPath }));
 
-        await assert.isRejected(
-            createEnvironmentAndRegister(mockProviders, pythonRuntimeManager.object, {
+        // Simulate a brand-new workspace folder that the extension host doesn't see yet.
+        getWorkspaceFolderStub.callsFake(() => undefined);
+
+        const resultPromise = createEnvironmentAndRegister(mockProviders, pythonRuntimeManager.object, {
+            ...envOptions,
+        });
+
+        assert.strictEqual(
+            workspaceFolderChangeHandlers.length,
+            1,
+            'should subscribe to workspace folder changes while waiting',
+        );
+        assert.isTrue(handleCreateEnvironmentCommandStub.notCalled, 'should not dispatch before the folder registers');
+
+        // The folder registers; fire the change event that should wake the wait.
+        getWorkspaceFolderStub.callsFake((uri: Uri) => (uri.toString() === workspace1UriString ? workspace1 : undefined));
+        workspaceFolderChangeHandlers[0]();
+
+        const result = await resultPromise;
+
+        assert.isDefined(result?.path);
+        const dispatched = handleCreateEnvironmentCommandStub.firstCall.args[1];
+        assert.strictEqual(dispatched.workspaceFolder, workspace1);
+    });
+
+    test('Throws once the registration wait times out without the folder ever appearing', async () => {
+        const clock = sinon.useFakeTimers();
+        try {
+            getWorkspaceFolderStub.callsFake(() => undefined);
+            const unknownUri = Uri.file('/no/such/workspace').toString();
+
+            const resultPromise = createEnvironmentAndRegister(mockProviders, pythonRuntimeManager.object, {
                 ...envOptions,
                 workspaceFolder: unknownUri,
-            }),
-            /Workspace folder not found/,
-        );
-        assert.isTrue(handleCreateEnvironmentCommandStub.notCalled);
+            });
+            // Never fire a change event -- the folder never registers. Advance well
+            // past any reasonable wait bound instead of waiting in real time.
+            await clock.tickAsync(60_000);
+
+            await assert.isRejected(resultPromise, /Workspace folder not found/);
+            assert.isTrue(handleCreateEnvironmentCommandStub.notCalled);
+        } finally {
+            clock.restore();
+        }
     });
 });


### PR DESCRIPTION
Fixes #15153

On web/remote, the New Folder Flow passes the workspace folder to `python.createEnvironmentAndRegister` as a main-thread URI string (`vscode-remote://`), but the extension host represents the same folder as `file://`. The exact-URI `getWorkspaceFolder()` lookup misses on the scheme difference and throws, so the new venv's runtime metadata never gets registered and the console never gets a session.

- Falls back to a path-based match against the extension host's own workspace folders when the exact-URI lookup misses
- Removes the `onDidChangeWorkspaceFolders` wait, which could never resolve: `openFolder(forceReuseWindow)` restarts the extension host with the folder already present, so that event never fires for it
- Adds a unit test for the scheme-mismatch case

### QA Notes

@:new-folder-flow @:web

Verified locally: RED (old await-fix) fails 3/3, GREEN (path-fix) passes 5/5 on `--project e2e-chromium`.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix a web/remote failure where creating a new Python environment via the New Folder Flow could leave the console without a session (#15153)

### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence (updated 2026-07-27, supersedes earlier registration-race diagnosis)</b> -- main-thread vs. extension-host URI scheme mismatch on remote/web, confirmed by local repro.</summary>

- **Test:** [New Folder Flow: Python Project > New env: uv environment](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=New%20Folder%20Flow%3A%20Python%20Project%20%3E%20New%20env%3A%20uv%20environment%7C%7C%7Ctest%2Fe2e%2Ftests%2Fnew-folder-flow%2Fnew-folder-flow-python.test.ts)
- **Targeted failure:** the console never reaches the `>>>` prompt; the test waits out its 120s timeout in `waitForReady`.
- **Signal:** Instrumented repro (3/3): `rehydrate entry: wanted=vscode-remote://localhost:9000/.../new-uv_XXXX direct=MISS folders=[file:///.../new-uv_XXXX] -> resolved: UNDEFINED`. The folder is registered the whole time under `file://` while the caller sent `vscode-remote://`; same path, different scheme, so the exact-URI lookup misses and throws. The earlier registration-race reading was wrong: `openFolder({forceReuseWindow:true})` restarts the ext host with the folder already present as `workspaceFolders[0]`, so `onDidChangeWorkspaceFolders` never fires for it.
- **Frequency:** 2/442 CI runs (0.5%), ubuntu/chromium; web-only (desktop matches on `file://`).
- **Fix:** path-based fallback match in `rehydrateWorkspaceFolder()`. RED (await-fix) 3/3 fail, GREEN (path-fix) 5/5 pass locally, plus a unit test for the scheme-mismatch case.
- **Hypothesis:** product regression from #14890 -- the URI-string round-trip it introduced does not survive the main-thread/ext-host scheme difference on remote/web.

</details>