### PR TITLE
ci(e2e): map positronAiFeatures dir to @:assistant tag

### DIFF
--- a/.github/workflows/test-tag-paths-map.json
+++ b/.github/workflows/test-tag-paths-map.json
@@ -20,6 +20,7 @@
   "src/vs/workbench/contrib/positronModalDialogs/": ["@:modal"],
   "src/vs/workbench/services/positronModalDialogs/": ["@:modal"],
   "src/vs/workbench/contrib/positronAssistant/": ["@:assistant"],
+  "src/vs/workbench/contrib/positronAiFeatures/": ["@:assistant"],
   "src/vs/workbench/contrib/positronRuntimeSessions/": ["@:sessions"],
   "src/vs/workbench/contrib/positronSession/": ["@:sessions"],
 


### PR DESCRIPTION
### Summary
Resolves the tag-map drift flagged by the weekly check: the new `positronAiFeatures/` directory had no e2e tag mapping.

- Map `src/vs/workbench/contrib/positronAiFeatures/` to `@:assistant`

### QA Notes
Config only; no code change. `scripts/check-test-tag-map.sh` passes.