### PR TITLE
Revive ai diagnostics report command

### DIFF
--- a/.github/workflows/test-tag-paths-map.json
+++ b/.github/workflows/test-tag-paths-map.json
@@ -37,6 +37,7 @@
   "extensions/authentication/": ["@:assistant"],
   "extensions/copilot/": ["@:assistant"],
   "extensions/copilot/src/extension/prompts/node/base/positronAssistant.tsx": ["@:assistant"],
+  "extensions/next-edit-suggestions/": ["@:assistant"],
   "extensions/positron-connections/": ["@:connections"],
   "extensions/positron-notebooks/": ["@:positron-notebooks"],
   "extensions/positron-reticulate/": ["@:reticulate"],

--- a/extensions/authentication/src/authProvider.ts
+++ b/extensions/authentication/src/authProvider.ts
@@ -79,6 +79,11 @@ export class AuthProvider
 		this.logger = new AuthProviderLogger(this.displayName);
 	}
 
+	/** Human-readable provider name, e.g. for diagnostics. */
+	get label(): string {
+		return this.displayName;
+	}
+
 	/** Whether this provider blocks sign-out for chain sessions. */
 	get chainPreventsSignOut(): boolean {
 		return !!this.credentialChain?.preventSignOut;

--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -102,18 +102,20 @@ export async function migrateSettingsAndPrimeCatalog(
 export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(log);
 
-	await migrateSettingsAndPrimeCatalog(context);
-
 	// Bridge the buffered trace/debug logs to the core "Collect AI Diagnostics"
 	// command. That command runs in the workbench (renderer), which can't read an
 	// extension's activate() exports, so it invokes this command across the
 	// extension-host boundary and receives the return value. The `getLogs` export
 	// below stays for any extension-to-extension consumer. Not declared in
-	// package.json, so it stays out of the command palette.
+	// package.json, so it stays out of the command palette. Registered before the
+	// migration and catalog init below so the logs stay reachable if either throws
+	// or hangs.
 	context.subscriptions.push(
 		vscode.commands.registerCommand('authentication.getDiagnosticLogs',
 			() => log.formatEntriesForDiagnostics()),
 	);
+
+	await migrateSettingsAndPrimeCatalog(context);
 
 	// Reports provider state for the core "AI: Create Diagnostic Report" command:
 	// which providers the user is signed in to, and which are turned off in

--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -104,6 +104,59 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	await migrateSettingsAndPrimeCatalog(context);
 
+	// Bridge the buffered trace/debug logs to the core "Collect AI Diagnostics"
+	// command. That command runs in the workbench (renderer), which can't read an
+	// extension's activate() exports, so it invokes this command across the
+	// extension-host boundary and receives the return value. The `getLogs` export
+	// below stays for any extension-to-extension consumer. Not declared in
+	// package.json, so it stays out of the command palette.
+	context.subscriptions.push(
+		vscode.commands.registerCommand('authentication.getDiagnosticLogs',
+			() => log.formatEntriesForDiagnostics()),
+	);
+
+	// Reports provider state for the core "AI: Create Diagnostic Report" command:
+	// which providers the user is signed in to, and which are turned off in
+	// settings. Returns display names only (no account details). Bridged as a
+	// command for the same reason as the logs above.
+	context.subscriptions.push(
+		vscode.commands.registerCommand('authentication.getProviderDiagnostics', async () => {
+			const authenticated: string[] = [];
+
+			// "Authenticated" means an active session (getSessions().length > 0),
+			// matching how the Accounts UI decides signed-in - not isConfigured(),
+			// which also counts providers set up once but now signed out or expired.
+			await Promise.all([...authProviders.values()].map(async (provider) => {
+				try {
+					if ((await provider.getSessions()).length > 0) {
+						authenticated.push(provider.label);
+					}
+				} catch (e) {
+					log.warn(`getProviderDiagnostics: could not check ${provider.label}: ${e instanceof Error ? e.message : String(e)}`);
+				}
+			}));
+
+			// Copilot rides GitHub's built-in auth, not a registered AuthProvider.
+			try {
+				if (await vscode.authentication.getSession('github', [], { silent: true })) {
+					authenticated.push('GitHub Copilot');
+				}
+			} catch (e) {
+				log.warn(`getProviderDiagnostics: could not check GitHub: ${e instanceof Error ? e.message : String(e)}`);
+			}
+
+			// "Disabled" means the provider's catalog entry isn't enabled.
+			// Enablement now lives in the provider catalog (providers.json), not
+			// the deprecated `*.enable` settings. Match core's rule: enabled only
+			// when `enabled === true`, so a missing or false entry counts as off.
+			const disabled = Object.values(PROVIDER_METADATA)
+				.filter(meta => !meta.catalogId || getCachedProvider(meta.catalogId)?.enabled !== true)
+				.map(meta => meta.displayName);
+
+			return { authenticated: authenticated.sort(), disabled: disabled.sort() };
+		}),
+	);
+
 	await registerAnthropicProvider(context);
 	registerPositAIProvider(context);
 	registerFoundryProvider(context);

--- a/extensions/next-edit-suggestions/src/extension.ts
+++ b/extensions/next-edit-suggestions/src/extension.ts
@@ -12,11 +12,26 @@ import { deriveStatusContext, isAIEnabled, isCompletionEnabled, isCompletionEnab
 import { getLLMConfiguration, isSignedIn, resetModelCache } from './model.js';
 import { sendFeedback } from './feedback.js';
 import { debounceDelayMs, generateSuggestion } from './suggestions.js';
+import { BufferedLogOutputChannel } from './log.js';
 
-export const log = vscode.window.createOutputChannel('Next Edit Suggestions', { log: true });
+export const log = new BufferedLogOutputChannel(
+	vscode.window.createOutputChannel('Next Edit Suggestions', { log: true })
+);
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
 	context.subscriptions.push(log);
+
+	// Exposes the buffered trace/debug logs to the core "Collect AI Diagnostics"
+	// command. It runs in the workbench (renderer), which can't read an
+	// extension's activate() exports, so we bridge via a command: the command
+	// invocation and its return value cross the extension-host boundary.
+	// Registered first thing so the logs stay reachable even if the rest of
+	// activation fails or hangs. Not declared in package.json, so it stays out
+	// of the command palette.
+	context.subscriptions.push(
+		vscode.commands.registerCommand('next-edit-suggestions.getDiagnosticLogs',
+			() => log.formatEntriesForDiagnostics()),
+	);
 
 	log.info('Next Edit Suggestions extension is now activating...');
 

--- a/extensions/next-edit-suggestions/src/log.ts
+++ b/extensions/next-edit-suggestions/src/log.ts
@@ -1,0 +1,142 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+export interface LogEntry {
+	timestamp: Date;
+	level: 'trace' | 'debug' | 'info' | 'warn' | 'error';
+	message: string;
+}
+
+/**
+ * A wrapper around LogOutputChannel that maintains an in-memory circular buffer
+ * of recent log entries for diagnostics collection.
+ *
+ * Entries are buffered unconditionally, before the underlying channel's log-level
+ * filter runs, so `formatEntriesForDiagnostics()` returns trace/debug lines even
+ * when the user's display level is higher. This lets the "Collect AI Diagnostics"
+ * command gather full-detail logs without asking the user to reproduce the issue.
+ */
+export class BufferedLogOutputChannel implements vscode.LogOutputChannel {
+	private readonly buffer: LogEntry[] = [];
+
+	constructor(
+		private readonly channel: vscode.LogOutputChannel,
+		private readonly maxEntries: number = 500
+	) { }
+
+	get logLevel(): vscode.LogLevel {
+		return this.channel.logLevel;
+	}
+
+	get onDidChangeLogLevel(): vscode.Event<vscode.LogLevel> {
+		return this.channel.onDidChangeLogLevel;
+	}
+
+	get name(): string {
+		return this.channel.name;
+	}
+
+	append(value: string): void {
+		this.channel.append(value);
+	}
+
+	appendLine(value: string): void {
+		this.channel.appendLine(value);
+	}
+
+	replace(value: string): void {
+		this.channel.replace(value);
+	}
+
+	clear(): void {
+		this.channel.clear();
+	}
+
+	show(preserveFocus?: boolean): void;
+	show(column?: vscode.ViewColumn, preserveFocus?: boolean): void;
+	show(
+		columnOrPreserveFocus?: vscode.ViewColumn | boolean,
+		preserveFocus?: boolean
+	): void {
+		// Must cast to any to match vscode.LogOutputChannel overloaded signature
+		// eslint-disable-next-line local/code-no-any-casts
+		this.channel.show(columnOrPreserveFocus as any, preserveFocus);
+	}
+
+	hide(): void {
+		this.channel.hide();
+	}
+
+	dispose(): void {
+		this.channel.dispose();
+	}
+
+	private addToBuffer(level: LogEntry['level'], message: string): void {
+		this.buffer.push({
+			timestamp: new Date(),
+			level,
+			message
+		});
+
+		if (this.buffer.length > this.maxEntries) {
+			this.buffer.shift();
+		}
+	}
+
+	private formatMessageWithArgs(
+		message: string,
+		args: any[]
+	): string {
+		return args.length > 0 ? `${message} ${args.join(' ')}` : message;
+	}
+
+	trace(message: string, ...args: any[]): void {
+		this.addToBuffer('trace', this.formatMessageWithArgs(message, args));
+		this.channel.trace(message, ...args);
+	}
+
+	debug(message: string, ...args: any[]): void {
+		this.addToBuffer('debug', this.formatMessageWithArgs(message, args));
+		this.channel.debug(message, ...args);
+	}
+
+	info(message: string, ...args: any[]): void {
+		this.addToBuffer('info', this.formatMessageWithArgs(message, args));
+		this.channel.info(message, ...args);
+	}
+
+	warn(message: string, ...args: any[]): void {
+		this.addToBuffer('warn', this.formatMessageWithArgs(message, args));
+		this.channel.warn(message, ...args);
+	}
+
+	error(message: string, ...args: any[]): void;
+	error(message: Error): void;
+	error(message: string | Error, ...args: any[]): void {
+		const formattedMessage = message instanceof Error
+			? `${message.message}\n${message.stack}`
+			: this.formatMessageWithArgs(message, args);
+		this.addToBuffer('error', formattedMessage);
+		this.channel.error(message, ...args);
+	}
+
+	formatEntriesForDiagnostics(count: number = 500): string {
+		const entries = count < this.buffer.length
+			? this.buffer.slice(-count)
+			: this.buffer;
+
+		if (entries.length === 0) {
+			return 'No log entries available';
+		}
+
+		return entries.map(entry => {
+			const timestamp = entry.timestamp.toISOString();
+			const levelStr = entry.level.toUpperCase().padEnd(5);
+			return `[${timestamp}] ${levelStr} ${entry.message}`;
+		}).join('\n');
+	}
+}

--- a/src/vs/platform/positronHeadlessLanguageModel/common/engine.ts
+++ b/src/vs/platform/positronHeadlessLanguageModel/common/engine.ts
@@ -82,7 +82,12 @@ export interface IModelDescriptor {
 	readonly id: string;
 	readonly name: string;
 	readonly vendor: string;
-	/** The provider that serves this model. A routing secret, never exposed to consumers. */
+	/**
+	 * The provider that serves this model. A routing secret: kept off the
+	 * feature-facing model listing so nothing can select a backend by provider.
+	 * Only the AI diagnostic report sees it, via
+	 * `getModelListingDiagnostics`.
+	 */
 	readonly providerId: string;
 }
 

--- a/src/vs/workbench/contrib/positronAssistant/browser/aiDiagnostics.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/aiDiagnostics.ts
@@ -12,7 +12,9 @@ import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '.
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
+import { IProgressService, ProgressLocation } from '../../../../platform/progress/common/progress.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { ExtensionIdentifier } from '../../../../platform/extensions/common/extensions.js';
 import { PlatformToString, platform } from '../../../../base/common/platform.js';
@@ -21,9 +23,11 @@ import { parse } from '../../../../base/common/json.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { IAiProviderService } from '../../../services/positronAiProvider/common/aiProviderService.js';
+import { IHeadlessLanguageModelService, IModelListingDiagnostics } from '../../../services/positronHeadlessLanguageModel/common/headlessLanguageModelService.js';
 import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { IOutputService, isMultiSourceOutputChannelDescriptor, isSingleSourceOutputChannelDescriptor } from '../../../services/output/common/output.js';
+import { ILanguageModelsService } from '../../chat/common/languageModels.js';
 import { ChatConfiguration } from '../../chat/common/constants.js';
 import { AI_ENABLED_KEY } from '../common/positronAIConfiguration.js';
 
@@ -33,6 +37,25 @@ import { AI_ENABLED_KEY } from '../common/positronAIConfiguration.js';
 export interface IAIDiagnosticsSetting {
 	readonly key: string;
 	readonly value: unknown;
+}
+
+/**
+ * One model registered with the built-in language model API, projected to the
+ * few fields the report shows.
+ */
+export interface IAIDiagnosticsBuiltinModel {
+	readonly id: string;
+	readonly name: string;
+	/** The provider that registered it (e.g. "copilot"); groups the model in the report. */
+	readonly provider: string;
+}
+
+/** One model row under a provider, from either source. */
+interface IAIDiagnosticsModelRow {
+	readonly id: string;
+	readonly name: string;
+	/** The vendor the provider branded the model as, where it reports one. */
+	readonly vendor?: string;
 }
 
 /**
@@ -90,6 +113,26 @@ export interface IAIDiagnosticsInputs {
 	/** Provider labels turned off in settings (empty when none/unknown). */
 	readonly disabledProviders: readonly string[];
 	/**
+	 * What each provider actually contributed, as opposed to what providers.json
+	 * declares. Reported per queried provider so a provider that returned nothing,
+	 * or whose models all lost the cross-provider de-duplication, is visible rather
+	 * than silently absent.
+	 */
+	readonly modelListing: IModelListingDiagnostics;
+	/**
+	 * Models registered with the built-in language model API, which is where
+	 * GitHub Copilot's live. Merged into the same per-provider listing as
+	 * {@link modelListing}: which of the two paths a model arrived through is
+	 * Positron's plumbing, not something the report should make the reader parse.
+	 */
+	readonly builtinModels: readonly IAIDiagnosticsBuiltinModel[];
+	/**
+	 * True when a model listing timed out or failed, so the section above is
+	 * partial. Kept separate from "no models" because the two look identical in
+	 * the data and mean opposite things to whoever reads the report.
+	 */
+	readonly modelsIncomplete: boolean;
+	/**
 	 * Contents of providers.json, redacted and rendered inside a JSON fence. A
 	 * `// ...` comment line when the file is missing or the catalog is unavailable
 	 * (mirrors the settings block's placeholder).
@@ -126,6 +169,58 @@ export function generateAIDiagnosticsReport(inputs: IAIDiagnosticsInputs): strin
 
 	const providerList = (providers: readonly string[]) =>
 		providers.length === 0 ? 'None' : providers.map(p => `- ${p}`).join('\n');
+
+	// One list per provider, merging both places models can come from (the
+	// provider sweep and the built-in language model API). Which of the two a
+	// model arrived through is Positron's plumbing, not something a reader should
+	// have to reason about, so it isn't shown. Group by provider rather than by
+	// the model's vendor: vendor is only what the provider branded the model as,
+	// and an OpenAI-compatible gateway reports "OpenAI" for a Google model.
+	const byProvider = new Map<string, IAIDiagnosticsModelRow[]>();
+	const groupFor = (providerId: string): IAIDiagnosticsModelRow[] => {
+		let models = byProvider.get(providerId);
+		if (!models) {
+			models = [];
+			byProvider.set(providerId, models);
+		}
+		return models;
+	};
+	// Seed every queried provider so one that returned nothing still gets a
+	// heading: "signed in but contributed zero models" is worth seeing.
+	for (const providerId of inputs.modelListing.queriedProviders) {
+		groupFor(providerId);
+	}
+	for (const model of inputs.modelListing.models) {
+		groupFor(model.providerId).push(model);
+	}
+	for (const model of inputs.builtinModels) {
+		const models = groupFor(model.provider);
+		// A provider reachable both ways lists the same model twice; keep the
+		// sweep's copy, which carries the vendor.
+		if (!models.some(existing => existing.id === model.id)) {
+			models.push({ id: model.id, name: model.name });
+		}
+	}
+
+	const modelsBlock = byProvider.size === 0
+		? (inputs.modelsIncomplete
+			? 'Could not be retrieved in time. Re-run the report: the listing is cached once it succeeds, so a second run usually has it.'
+			: 'None. No provider was queried (each was disabled, had no registered auth backend, or had no credentials) and no extension registered a chat model.')
+		: [...byProvider]
+			.map(([providerId, models]) => {
+				if (models.length === 0) {
+					return `**${providerId}** (0)\n\nQueried, but returned no models.`;
+				}
+				return `**${providerId}** (${models.length})\n\n${models
+					.map(m => `- \`${m.id}\` (${m.name && m.name !== m.id ? `${m.name}${m.vendor ? ', ' : ''}` : ''}${m.vendor ?? ''})`)
+					.join('\n')}`;
+			})
+			.join('\n\n');
+
+	const totalModels = [...byProvider.values()].reduce((count, models) => count + models.length, 0);
+	const incompleteNote = inputs.modelsIncomplete && byProvider.size > 0
+		? '\n\nSome providers did not respond in time, so this list may be incomplete.'
+		: '';
 
 	const optionalLine = (label: string, value: string | undefined) => value ? `\n- ${label}: ${value}` : '';
 
@@ -166,6 +261,12 @@ ${providerList(inputs.authenticatedProviders)}
 ### Disabled
 
 ${providerList(inputs.disabledProviders)}
+
+### Available Models
+
+Models each provider offers (${totalModels} total).${incompleteNote}
+
+${modelsBlock}
 
 ### Configuration
 
@@ -319,6 +420,16 @@ const MAX_LOG_LINES = 500;
 /** Bound activation + bridge calls so a stuck extension can't hang the report. */
 const BRIDGE_TIMEOUT_MS = 5000;
 
+/**
+ * Model listings get a longer bound than the bridge calls. They are the only
+ * step that reaches the network, and the built-in listing resolves every chat
+ * vendor, which can mean activating an extension and fetching its model list.
+ * The bound exists to guarantee the report appears at all, not to keep the wait
+ * short, so it is generous: cutting it too fine drops providers that would have
+ * answered. On timeout the section says so rather than claiming there are none.
+ */
+const MODEL_LISTING_TIMEOUT_MS = 10000;
+
 /** Trims log content to the most recent {@link MAX_LOG_LINES} lines. */
 export function capLogLines(content: string): string {
 	const lines = content.split('\n');
@@ -421,9 +532,13 @@ export class CreateAIDiagnosticReportAction extends Action2 {
 		const outputService = accessor.get(IOutputService);
 		const fileService = accessor.get(IFileService);
 		const aiProviderService = accessor.get(IAiProviderService);
+		const headlessLanguageModelService = accessor.get(IHeadlessLanguageModelService);
+		const languageModelsService = accessor.get(ILanguageModelsService);
 		const editorService = accessor.get(IEditorService);
 		const quickInputService = accessor.get(IQuickInputService);
 		const notificationService = accessor.get(INotificationService);
+		const progressService = accessor.get(IProgressService);
+		const logService = accessor.get(ILogService);
 
 		// When Posit Assistant is installed, ask up front whether to also produce
 		// its diagnostics bundle. The report is always generated; the bundle is
@@ -438,83 +553,106 @@ export class CreateAIDiagnosticReportAction extends Action2 {
 			includeBundle = choice;
 		}
 
-		const settings = collectNonDefaultAISettings(configurationService);
+		// Collection is a handful of bounded steps, each waiting on an extension
+		// bridge, a file read, or a provider listing. Usually a second or two, but
+		// a stuck extension can push it to the sum of the timeouts, so report which
+		// step is running rather than leaving the window silent.
+		const report = await progressService.withProgress({
+			location: ProgressLocation.Notification,
+			title: localize('positron.ai.diagnostics.generating', "Generating AI diagnostic report"),
+		}, async progress => {
+			const settings = collectNonDefaultAISettings(configurationService);
 
-		const statuses = extensionService.getExtensionsStatus();
-		const statusFor = (id: string): string =>
-			describeExtensionStatus(Object.entries(statuses).find(([key]) => ExtensionIdentifier.equals(key, id))?.[1]);
+			const statuses = extensionService.getExtensionsStatus();
+			const statusFor = (id: string): string =>
+				describeExtensionStatus(Object.entries(statuses).find(([key]) => ExtensionIdentifier.equals(key, id))?.[1]);
 
-		const extensions: IAIDiagnosticsExtension[] = [];
-		const logs: IAIDiagnosticsLogSection[] = [];
+			const extensions: IAIDiagnosticsExtension[] = [];
+			const logs: IAIDiagnosticsLogSection[] = [];
 
-		// Posit-owned surfaces: bridge command per extension.
-		for (const source of AI_LOG_SOURCES) {
-			const extension = await extensionService.getExtension(source.id);
-			extensions.push({ label: source.label, id: source.id, version: extension?.version, status: extension ? statusFor(source.id) : undefined });
-			if (!extension) {
-				logs.push({ label: source.label, content: 'Extension not installed' });
-				continue;
+			// Posit-owned surfaces: bridge command per extension.
+			progress.report({ message: localize('positron.ai.diagnostics.collectingLogs', "Collecting extension logs") });
+			for (const source of AI_LOG_SOURCES) {
+				const extension = await extensionService.getExtension(source.id);
+				extensions.push({ label: source.label, id: source.id, version: extension?.version, status: extension ? statusFor(source.id) : undefined });
+				if (!extension) {
+					logs.push({ label: source.label, content: 'Extension not installed' });
+					continue;
+				}
+				logs.push({ label: source.label, content: await collectBridgedLogs(source, extensionService, commandService) });
 			}
-			logs.push({ label: source.label, content: await collectBridgedLogs(source, extensionService, commandService) });
-		}
 
-		// GitHub Copilot: third-party, so no bridge command. Read its log file(s)
-		// directly, and only when Copilot is enabled (`chat.disableAIFeatures` off).
-		const copilotEnabled = configurationService.getValue(ChatConfiguration.AIDisabled) !== true;
-		for (const channel of COPILOT_CHANNELS) {
-			const extension = await extensionService.getExtension(channel.extensionId);
-			extensions.push({ label: channel.label, id: channel.extensionId, version: extension?.version, status: extension ? statusFor(channel.extensionId) : undefined });
-			if (!copilotEnabled) {
-				logs.push({ label: channel.label, content: 'Skipped (GitHub Copilot is disabled)' });
-				continue;
+			// GitHub Copilot: third-party, so no bridge command. Read its log file(s)
+			// directly, and only when Copilot is enabled (`chat.disableAIFeatures` off).
+			const copilotEnabled = configurationService.getValue(ChatConfiguration.AIDisabled) !== true;
+			for (const channel of COPILOT_CHANNELS) {
+				const extension = await extensionService.getExtension(channel.extensionId);
+				extensions.push({ label: channel.label, id: channel.extensionId, version: extension?.version, status: extension ? statusFor(channel.extensionId) : undefined });
+				if (!copilotEnabled) {
+					logs.push({ label: channel.label, content: 'Skipped (GitHub Copilot is disabled)' });
+					continue;
+				}
+				logs.push({ label: channel.label, content: await collectCopilotLogs(channel, extensionService, outputService, fileService) });
 			}
-			logs.push({ label: channel.label, content: await collectCopilotLogs(channel, extensionService, outputService, fileService) });
-		}
 
-		const providers = await collectProviderDiagnostics(extensionService, commandService);
-		const providerConfig = await collectProvidersConfig(aiProviderService, fileService);
+			progress.report({ message: localize('positron.ai.diagnostics.collectingProviders', "Reading provider configuration") });
+			const providers = await collectProviderDiagnostics(extensionService, commandService);
+			const providerConfig = await collectProvidersConfig(aiProviderService, fileService);
 
-		const bundle = includeBundle
-			? localize('positron.ai.diagnostics.bundleRequested', "Requested. Posit Assistant saves the bundle and shows its location in a notification.")
-			: undefined;
+			// Independent sources, so run them together: the section's worst case is
+			// one timeout, not two. Either coming back undefined leaves the report
+			// intact and marks the listing incomplete.
+			progress.report({ message: localize('positron.ai.diagnostics.listingModels', "Listing available models") });
+			const [listing, builtin] = await Promise.all([
+				collectAvailableModels(headlessLanguageModelService, logService),
+				collectBuiltinModels(languageModelsService, logService),
+			]);
 
-		// Extension-backed toggles (Posit Assistant, NES, Copilot chat) read as
-		// "not installed" when their extension is absent, since the setting is then
-		// unregistered and would otherwise default to "Enabled" - contradicting the
-		// Extensions list. Notebook AI and console actions are core, so always show.
-		const nesInstalled = !!await extensionService.getExtension('positron.next-edit-suggestions');
-		const copilotChatInstalled = !!await extensionService.getExtension('GitHub.copilot-chat');
-		// NES's `enabled` is a per-language-type map; the `*` wildcard is the overall on/off.
-		const nesEnabled = configurationService.getValue<Record<string, boolean>>('nextEditSuggestions.enabled')?.['*'];
-		const features: IAIDiagnosticsFeature[] = [
-			{ label: 'Posit Assistant', setting: 'assistant.enabled', state: featureState(assistantInstalled, configurationService.getValue('assistant.enabled')) },
-			{ label: 'Posit AI NES', setting: 'nextEditSuggestions.enabled', state: featureState(nesInstalled, nesEnabled) },
-			{ label: 'Notebook AI', setting: 'notebook.ai.enabled', state: describeFeatureToggle(configurationService.getValue('notebook.ai.enabled')) },
-			{ label: 'Console Fix & Explain', setting: 'console.assistantActions.enabled', state: describeFeatureToggle(configurationService.getValue('console.assistantActions.enabled')) },
-			{ label: 'GitHub Copilot Chat', setting: ChatConfiguration.AIDisabled, state: featureState(copilotChatInstalled, copilotEnabled) },
-		];
+			const bundle = includeBundle
+				? localize('positron.ai.diagnostics.bundleRequested', "Requested. Posit Assistant saves the bundle and shows its location in a notification.")
+				: undefined;
 
-		const report = generateAIDiagnosticsReport({
-			generatedAt: new Date().toISOString(),
-			aiEnabled: configurationService.getValue<boolean>(AI_ENABLED_KEY) !== false,
-			features,
-			application: productService.nameLong,
-			positronVersion: productService.positronVersion,
-			positronBuildNumber: productService.positronBuildNumber,
-			vscodeVersion: productService.version,
-			commit: productService.commit,
-			buildDate: productService.date,
-			quality: productService.quality,
-			os: PlatformToString(platform),
-			remote: environmentService.remoteAuthority,
-			extensions,
-			authenticatedProviders: providers.authenticated,
-			disabledProviders: providers.disabled,
-			providersConfig: providerConfig.content,
-			providersConfigPath: providerConfig.path,
-			settings,
-			logs,
-			bundle,
+			// Extension-backed toggles (Posit Assistant, NES, Copilot chat) read as
+			// "not installed" when their extension is absent, since the setting is then
+			// unregistered and would otherwise default to "Enabled" - contradicting the
+			// Extensions list. Notebook AI and console actions are core, so always show.
+			const nesInstalled = !!await extensionService.getExtension('positron.next-edit-suggestions');
+			const copilotChatInstalled = !!await extensionService.getExtension('GitHub.copilot-chat');
+			// NES's `enabled` is a per-language-type map; the `*` wildcard is the overall on/off.
+			const nesEnabled = configurationService.getValue<Record<string, boolean>>('nextEditSuggestions.enabled')?.['*'];
+			const features: IAIDiagnosticsFeature[] = [
+				{ label: 'Posit Assistant', setting: 'assistant.enabled', state: featureState(assistantInstalled, configurationService.getValue('assistant.enabled')) },
+				{ label: 'Posit AI NES', setting: 'nextEditSuggestions.enabled', state: featureState(nesInstalled, nesEnabled) },
+				{ label: 'Notebook AI', setting: 'notebook.ai.enabled', state: describeFeatureToggle(configurationService.getValue('notebook.ai.enabled')) },
+				{ label: 'Console Fix & Explain', setting: 'console.assistantActions.enabled', state: describeFeatureToggle(configurationService.getValue('console.assistantActions.enabled')) },
+				{ label: 'GitHub Copilot Chat', setting: ChatConfiguration.AIDisabled, state: featureState(copilotChatInstalled, copilotEnabled) },
+			];
+
+			return generateAIDiagnosticsReport({
+				generatedAt: new Date().toISOString(),
+				aiEnabled: configurationService.getValue<boolean>(AI_ENABLED_KEY) !== false,
+				features,
+				application: productService.nameLong,
+				positronVersion: productService.positronVersion,
+				positronBuildNumber: productService.positronBuildNumber,
+				vscodeVersion: productService.version,
+				commit: productService.commit,
+				buildDate: productService.date,
+				quality: productService.quality,
+				os: PlatformToString(platform),
+				remote: environmentService.remoteAuthority,
+				extensions,
+				authenticatedProviders: providers.authenticated,
+				disabledProviders: providers.disabled,
+				modelListing: listing ?? { queriedProviders: [], models: [] },
+				builtinModels: builtin ?? [],
+				modelsIncomplete: listing === undefined || builtin === undefined,
+				providersConfig: providerConfig.content,
+				providersConfigPath: providerConfig.path,
+				settings,
+				logs,
+				bundle,
+			});
 		});
 
 		await editorService.openEditor({ resource: undefined, contents: report, languageId: 'markdown' });
@@ -556,6 +694,58 @@ async function activateWithTimeout(extensionService: IExtensionService, id: stri
 		extensionService.activateById(identifier, { startup: false, extensionId: identifier, activationEvent: 'api' }),
 		BRIDGE_TIMEOUT_MS,
 	);
+}
+
+/**
+ * Asks the headless language model service what the configured providers
+ * actually list. This is a live call, so it can hit the network - that's the
+ * point, since it reports reality rather than what providers.json declares. The
+ * result is cached by the service, so it's free when a feature already listed
+ * this session.
+ *
+ * Returns `undefined` when the listing didn't come back, which the report shows
+ * as "could not be retrieved". Distinct from an empty listing: a slow provider
+ * must not be reported as "you have no models".
+ */
+async function collectAvailableModels(service: IHeadlessLanguageModelService, logService: ILogService): Promise<IModelListingDiagnostics | undefined> {
+	try {
+		const listing = await raceTimeout(service.getModelListingDiagnostics(), MODEL_LISTING_TIMEOUT_MS);
+		if (!listing) {
+			logService.warn(`[ai-diagnostics] Model listing timed out after ${MODEL_LISTING_TIMEOUT_MS}ms; report omits it.`);
+		}
+		return listing;
+	} catch (error) {
+		logService.warn(`[ai-diagnostics] Model listing failed; report omits it: ${error}`);
+		return undefined;
+	}
+}
+
+/**
+ * Lists the built-in language model API's models. An empty selector matches
+ * everything and resolves each vendor lazily, so this can activate a chat
+ * extension that hasn't started yet - acceptable for a report the user asked
+ * for, and the same thing the bridge log collection already does.
+ *
+ * Returns `undefined` when the listing didn't come back, for the same reason as
+ * {@link collectAvailableModels}.
+ */
+async function collectBuiltinModels(service: ILanguageModelsService, logService: ILogService): Promise<readonly IAIDiagnosticsBuiltinModel[] | undefined> {
+	try {
+		const identifiers = await raceTimeout(service.selectLanguageModels({}), MODEL_LISTING_TIMEOUT_MS);
+		if (!identifiers) {
+			logService.warn(`[ai-diagnostics] Built-in model listing timed out after ${MODEL_LISTING_TIMEOUT_MS}ms; report omits it.`);
+			return undefined;
+		}
+		return identifiers.flatMap(identifier => {
+			const metadata = service.lookupLanguageModel(identifier);
+			return metadata
+				? [{ id: metadata.id, name: metadata.name, provider: metadata.vendor }]
+				: [];
+		});
+	} catch (error) {
+		logService.warn(`[ai-diagnostics] Built-in model listing failed; report omits it: ${error}`);
+		return undefined;
+	}
 }
 
 async function collectBridgedLogs(

--- a/src/vs/workbench/contrib/positronAssistant/browser/aiDiagnostics.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/aiDiagnostics.ts
@@ -20,6 +20,7 @@ import { IWorkbenchEnvironmentService } from '../../../services/environment/comm
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { IOutputService, isMultiSourceOutputChannelDescriptor, isSingleSourceOutputChannelDescriptor } from '../../../services/output/common/output.js';
 import { ChatConfiguration } from '../../chat/common/constants.js';
+import { AI_ENABLED_KEY } from '../common/positronAIConfiguration.js';
 
 /**
  * A single AI-related setting whose value differs from its registered default.
@@ -54,8 +55,21 @@ export interface IAIDiagnosticsExtension {
  * {@link generateAIDiagnosticsReport} formatter so the formatting is testable
  * without services.
  */
+/** One AI feature's on/off state, as shown in the report. */
+export interface IAIDiagnosticsFeature {
+	readonly label: string;
+	/** The setting key that controls this feature. */
+	readonly setting: string;
+	/** "Enabled", "Disabled", or a raw value for non-boolean toggles. */
+	readonly state: string;
+}
+
 export interface IAIDiagnosticsInputs {
 	readonly generatedAt: string;
+	/** The `ai.enabled` main switch; when false, every AI feature is off regardless of its own toggle. */
+	readonly aiEnabled: boolean;
+	/** Per-feature on/off state (NES, notebook AI, console Fix & Explain, Copilot chat). */
+	readonly features: readonly IAIDiagnosticsFeature[];
 	readonly application: string;
 	readonly positronVersion: string;
 	readonly positronBuildNumber: number;
@@ -100,6 +114,13 @@ export function generateAIDiagnosticsReport(inputs: IAIDiagnosticsInputs): strin
 
 	const optionalLine = (label: string, value: string | undefined) => value ? `\n- ${label}: ${value}` : '';
 
+	const featuresBlock = [
+		inputs.aiEnabled
+			? '- AI features (`ai.enabled`): Enabled'
+			: '- AI features (`ai.enabled`): **Disabled - all AI features below are off regardless of their own settings**',
+		...inputs.features.map(f => `- ${f.label} (\`${f.setting}\`): ${f.state}`),
+	].join('\n');
+
 	return `# AI Diagnostic Report
 
 Generated: ${inputs.generatedAt}
@@ -117,11 +138,17 @@ Generated: ${inputs.generatedAt}
 
 ${extensionsBlock}
 
-## Authenticated Providers
+## AI Features
+
+${featuresBlock}
+
+## Providers
+
+### Authenticated
 
 ${providerList(inputs.authenticatedProviders)}
 
-## Disabled Providers
+### Disabled
 
 ${providerList(inputs.disabledProviders)}
 
@@ -244,6 +271,21 @@ export function hasExplicitValue(inspected: IExplicitScopes): boolean {
 		?? inspected.workspaceValue ?? inspected.workspaceFolderValue ?? inspected.policyValue) !== undefined;
 }
 
+/**
+ * Renders a feature toggle's on/off state. Defaults (undefined) read as Enabled
+ * since Positron's AI feature settings default on; a non-boolean value is shown
+ * as-is.
+ */
+export function describeFeatureToggle(value: unknown): string {
+	if (value === false) {
+		return 'Disabled';
+	}
+	if (value === true || value === undefined) {
+		return 'Enabled';
+	}
+	return JSON.stringify(value);
+}
+
 /** The activation fields of `IExtensionsStatus` that the report renders. */
 interface IActivationStatus {
 	readonly activationStarted: boolean;
@@ -331,8 +373,20 @@ export class CreateAIDiagnosticReportAction extends Action2 {
 
 		const providers = await collectProviderDiagnostics(extensionService, commandService);
 
+		// NES's `enabled` is a per-language-type map; the `*` wildcard is the
+		// overall on/off, so report that.
+		const nesEnabled = configurationService.getValue<Record<string, boolean>>('nextEditSuggestions.enabled')?.['*'];
+		const features: IAIDiagnosticsFeature[] = [
+			{ label: 'Posit AI NES', setting: 'nextEditSuggestions.enabled', state: describeFeatureToggle(nesEnabled) },
+			{ label: 'Notebook AI', setting: 'notebook.ai.enabled', state: describeFeatureToggle(configurationService.getValue('notebook.ai.enabled')) },
+			{ label: 'Console Fix & Explain', setting: 'console.assistantActions.enabled', state: describeFeatureToggle(configurationService.getValue('console.assistantActions.enabled')) },
+			{ label: 'GitHub Copilot Chat', setting: ChatConfiguration.AIDisabled, state: copilotEnabled ? 'Enabled' : 'Disabled' },
+		];
+
 		const report = generateAIDiagnosticsReport({
 			generatedAt: new Date().toISOString(),
+			aiEnabled: configurationService.getValue<boolean>(AI_ENABLED_KEY) !== false,
+			features,
 			application: productService.nameLong,
 			positronVersion: productService.positronVersion,
 			positronBuildNumber: productService.positronBuildNumber,

--- a/src/vs/workbench/contrib/positronAssistant/browser/aiDiagnostics.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/aiDiagnostics.ts
@@ -294,6 +294,16 @@ export function describeFeatureToggle(value: unknown): string {
 	return JSON.stringify(value);
 }
 
+/**
+ * Renders an extension-backed feature's state. When the owning extension isn't
+ * installed the setting is unregistered (`getValue` returns undefined), so
+ * report "not installed" rather than letting {@link describeFeatureToggle}
+ * default it to "Enabled".
+ */
+export function featureState(installed: boolean, value: unknown): string {
+	return installed ? describeFeatureToggle(value) : 'Not installed';
+}
+
 /** The activation fields of `IExtensionsStatus` that the report renders. */
 interface IActivationStatus {
 	readonly activationStarted: boolean;
@@ -351,8 +361,9 @@ export class CreateAIDiagnosticReportAction extends Action2 {
 		// When Posit Assistant is installed, ask up front whether to also produce
 		// its diagnostics bundle. The report is always generated; the bundle is
 		// opt-in. Escaping the prompt cancels the command.
+		const assistantInstalled = !!await extensionService.getExtension(ASSISTANT_EXTENSION_ID);
 		let includeBundle = false;
-		if (await extensionService.getExtension(ASSISTANT_EXTENSION_ID)) {
+		if (assistantInstalled) {
 			const choice = await promptForBundle(quickInputService);
 			if (choice === undefined) {
 				return;
@@ -399,14 +410,20 @@ export class CreateAIDiagnosticReportAction extends Action2 {
 			? localize('positron.ai.diagnostics.bundleRequested', "Requested. Posit Assistant saves the bundle and shows its location in a notification.")
 			: undefined;
 
-		// NES's `enabled` is a per-language-type map; the `*` wildcard is the
-		// overall on/off, so report that.
+		// Extension-backed toggles (Posit Assistant, NES, Copilot chat) read as
+		// "not installed" when their extension is absent, since the setting is then
+		// unregistered and would otherwise default to "Enabled" - contradicting the
+		// Extensions list. Notebook AI and console actions are core, so always show.
+		const nesInstalled = !!await extensionService.getExtension('positron.next-edit-suggestions');
+		const copilotChatInstalled = !!await extensionService.getExtension('GitHub.copilot-chat');
+		// NES's `enabled` is a per-language-type map; the `*` wildcard is the overall on/off.
 		const nesEnabled = configurationService.getValue<Record<string, boolean>>('nextEditSuggestions.enabled')?.['*'];
 		const features: IAIDiagnosticsFeature[] = [
-			{ label: 'Posit AI NES', setting: 'nextEditSuggestions.enabled', state: describeFeatureToggle(nesEnabled) },
+			{ label: 'Posit Assistant', setting: 'assistant.enabled', state: featureState(assistantInstalled, configurationService.getValue('assistant.enabled')) },
+			{ label: 'Posit AI NES', setting: 'nextEditSuggestions.enabled', state: featureState(nesInstalled, nesEnabled) },
 			{ label: 'Notebook AI', setting: 'notebook.ai.enabled', state: describeFeatureToggle(configurationService.getValue('notebook.ai.enabled')) },
 			{ label: 'Console Fix & Explain', setting: 'console.assistantActions.enabled', state: describeFeatureToggle(configurationService.getValue('console.assistantActions.enabled')) },
-			{ label: 'GitHub Copilot Chat', setting: ChatConfiguration.AIDisabled, state: copilotEnabled ? 'Enabled' : 'Disabled' },
+			{ label: 'GitHub Copilot Chat', setting: ChatConfiguration.AIDisabled, state: featureState(copilotChatInstalled, copilotEnabled) },
 		];
 
 		const report = generateAIDiagnosticsReport({

--- a/src/vs/workbench/contrib/positronAssistant/browser/aiDiagnostics.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/aiDiagnostics.ts
@@ -17,7 +17,10 @@ import { IFileService } from '../../../../platform/files/common/files.js';
 import { ExtensionIdentifier } from '../../../../platform/extensions/common/extensions.js';
 import { PlatformToString, platform } from '../../../../base/common/platform.js';
 import { raceTimeout } from '../../../../base/common/async.js';
+import { parse } from '../../../../base/common/json.js';
+import { Schemas } from '../../../../base/common/network.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
+import { IAiProviderService } from '../../../services/positronAiProvider/common/aiProviderService.js';
 import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { IOutputService, isMultiSourceOutputChannelDescriptor, isSingleSourceOutputChannelDescriptor } from '../../../services/output/common/output.js';
@@ -86,6 +89,14 @@ export interface IAIDiagnosticsInputs {
 	readonly authenticatedProviders: readonly string[];
 	/** Provider labels turned off in settings (empty when none/unknown). */
 	readonly disabledProviders: readonly string[];
+	/**
+	 * Contents of providers.json, redacted and rendered inside a JSON fence. A
+	 * `// ...` comment line when the file is missing or the catalog is unavailable
+	 * (mirrors the settings block's placeholder).
+	 */
+	readonly providersConfig: string;
+	/** Path to providers.json, shown so support knows where the config lives; omitted when unknown. */
+	readonly providersConfigPath: string | undefined;
 	readonly settings: readonly IAIDiagnosticsSetting[];
 	readonly logs: readonly IAIDiagnosticsLogSection[];
 	/** Assistant diagnostics bundle result (path or status); omitted when not requested. */
@@ -129,7 +140,7 @@ export function generateAIDiagnosticsReport(inputs: IAIDiagnosticsInputs): strin
 
 Generated: ${inputs.generatedAt}
 
-**Privacy Notice**: This report includes extension versions, non-default configuration settings, system information, and recent log entries. It does NOT include API keys or authentication tokens (those are stored separately, not in settings). However, configured base URLs may reveal internal endpoints. Please review before sharing.
+**Privacy Notice**: This report includes extension versions, non-default configuration settings, provider connection config, system information, and recent log entries. It does NOT include API keys or authentication tokens (those are stored separately, not in settings or providers.json), and custom header values are redacted. However, configured base URLs may reveal internal endpoints. Please review before sharing.
 
 ## Version Information
 
@@ -155,6 +166,14 @@ ${providerList(inputs.authenticatedProviders)}
 ### Disabled
 
 ${providerList(inputs.disabledProviders)}
+
+### Configuration
+
+Provider configuration from \`providers.json\`${inputs.providersConfigPath ? ` (\`${inputs.providersConfigPath}\`)` : ''}:
+
+\`\`\`json
+${inputs.providersConfig}
+\`\`\`
 
 ## Configuration Settings
 
@@ -206,6 +225,53 @@ export const REDACTED_VALUE = '<redacted>';
 export function isSensitiveSettingKey(key: string): boolean {
 	const segment = key.split('.').pop()?.toLowerCase() ?? '';
 	return SENSITIVE_KEY_SEGMENTS.some(sensitive => segment.includes(sensitive));
+}
+
+/**
+ * Redacts secrets from providers.json for the report, keeping the file's own
+ * JSON shape. providers.json holds no secrets by design (API keys and tokens
+ * live in env vars and the credential store), but `customHeaders` is free-form,
+ * so a user can hand-place an auth token there. Header names are kept (so the
+ * shape stays visible) and their values redacted; any `apiKey`/`token`/`secret`/
+ * `password` key is redacted whole as a belt-and-suspenders guard.
+ *
+ * The input is parsed tolerantly (comments / trailing commas allowed), then
+ * re-serialized as clean JSON. If it can't be parsed, the raw text is returned
+ * unchanged - a malformed file is worth seeing, and it holds no secrets bar the
+ * customHeaders edge case.
+ */
+export function redactProvidersConfig(raw: string): string {
+	const parsed = parse(raw);
+	if (parsed === undefined || typeof parsed !== 'object') {
+		return raw;
+	}
+	return JSON.stringify(redactSensitiveValues(parsed), null, 2);
+}
+
+/** Recursively redacts sensitive values in a parsed providers.json object. */
+function redactSensitiveValues(value: unknown): unknown {
+	if (Array.isArray(value)) {
+		return value.map(redactSensitiveValues);
+	}
+	if (value && typeof value === 'object') {
+		const out: Record<string, unknown> = {};
+		for (const [key, val] of Object.entries(value)) {
+			out[key] = isSensitiveSettingKey(key) ? redactSensitiveValue(key, val) : redactSensitiveValues(val);
+		}
+		return out;
+	}
+	return value;
+}
+
+/**
+ * Redacts one sensitive value. `customHeaders` is a name->value map, so redact
+ * each value but keep the names; everything else is replaced wholesale.
+ */
+function redactSensitiveValue(key: string, value: unknown): unknown {
+	if (key.toLowerCase().includes('customheaders') && value && typeof value === 'object' && !Array.isArray(value)) {
+		return Object.fromEntries(Object.keys(value).map(name => [name, REDACTED_VALUE]));
+	}
+	return REDACTED_VALUE;
 }
 
 /**
@@ -354,6 +420,7 @@ export class CreateAIDiagnosticReportAction extends Action2 {
 		const environmentService = accessor.get(IWorkbenchEnvironmentService);
 		const outputService = accessor.get(IOutputService);
 		const fileService = accessor.get(IFileService);
+		const aiProviderService = accessor.get(IAiProviderService);
 		const editorService = accessor.get(IEditorService);
 		const quickInputService = accessor.get(IQuickInputService);
 		const notificationService = accessor.get(INotificationService);
@@ -405,6 +472,7 @@ export class CreateAIDiagnosticReportAction extends Action2 {
 		}
 
 		const providers = await collectProviderDiagnostics(extensionService, commandService);
+		const providerConfig = await collectProvidersConfig(aiProviderService, fileService);
 
 		const bundle = includeBundle
 			? localize('positron.ai.diagnostics.bundleRequested', "Requested. Posit Assistant saves the bundle and shows its location in a notification.")
@@ -442,6 +510,8 @@ export class CreateAIDiagnosticReportAction extends Action2 {
 			extensions,
 			authenticatedProviders: providers.authenticated,
 			disabledProviders: providers.disabled,
+			providersConfig: providerConfig.content,
+			providersConfigPath: providerConfig.path,
 			settings,
 			logs,
 			bundle,
@@ -534,6 +604,36 @@ async function collectProviderDiagnostics(
 		return (await raceTimeout(collect(), BRIDGE_TIMEOUT_MS)) ?? empty;
 	} catch {
 		return empty;
+	}
+}
+
+/**
+ * Reads providers.json for the report. Resolves its location from the catalog
+ * service (which re-homes the path onto the remote authority when connected),
+ * then reads the file fresh and redacts secrets. Reading the file directly -
+ * rather than the catalog's warmed snapshot - means the first invocation sees
+ * the real config even if the snapshot hasn't caught up yet. Returns a `// ...`
+ * placeholder (rendered inside the JSON fence) when the file is missing or the
+ * catalog is unreachable.
+ */
+async function collectProvidersConfig(
+	aiProviderService: IAiProviderService,
+	fileService: IFileService,
+): Promise<{ content: string; path: string | undefined }> {
+	let uri;
+	try {
+		uri = await aiProviderService.getConfigFileUri();
+	} catch {
+		return { content: '// Provider catalog unavailable', path: undefined };
+	}
+	const path = uri.scheme === Schemas.file ? uri.fsPath : uri.toString(true);
+	try {
+		const file = await fileService.readFile(uri);
+		return { content: redactProvidersConfig(file.value.toString()), path };
+	} catch {
+		// Most often the file doesn't exist yet: provider config falls back to
+		// built-in defaults until the user configures a provider.
+		return { content: '// No providers.json found (provider configuration is using defaults)', path };
 	}
 }
 

--- a/src/vs/workbench/contrib/positronAssistant/browser/aiDiagnostics.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/aiDiagnostics.ts
@@ -3,13 +3,15 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize2 } from '../../../../nls.js';
+import { localize, localize2 } from '../../../../nls.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { Action2 } from '../../../../platform/actions/common/actions.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
+import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { ExtensionIdentifier } from '../../../../platform/extensions/common/extensions.js';
@@ -86,6 +88,8 @@ export interface IAIDiagnosticsInputs {
 	readonly disabledProviders: readonly string[];
 	readonly settings: readonly IAIDiagnosticsSetting[];
 	readonly logs: readonly IAIDiagnosticsLogSection[];
+	/** Assistant diagnostics bundle result (path or status); omitted when not requested. */
+	readonly bundle?: string;
 }
 
 /**
@@ -161,7 +165,7 @@ ${settingsBlock}
 \`\`\`
 
 ${logsBlock}
-`;
+${inputs.bundle ? `\n## Assistant Diagnostics Bundle\n\n${inputs.bundle}\n` : ''}`;
 }
 
 /** Setting-key prefixes that identify AI-related settings. */
@@ -220,6 +224,10 @@ const AI_LOG_SOURCES: readonly { label: string; id: string; command: string }[] 
 /** The authentication extension and its bridge command reporting provider state. */
 const AUTH_EXTENSION_ID = 'positron.authentication';
 const AUTH_PROVIDERS_COMMAND = 'authentication.getProviderDiagnostics';
+
+/** The Posit Assistant extension and its bridge command producing the diagnostics bundle. */
+const ASSISTANT_EXTENSION_ID = 'posit.assistant';
+const ASSISTANT_BUNDLE_COMMAND = 'posit.assistant.collectDiagnosticsBundle';
 
 /** Shape returned by {@link AUTH_PROVIDERS_COMMAND}. */
 interface IProviderDiagnostics {
@@ -337,6 +345,20 @@ export class CreateAIDiagnosticReportAction extends Action2 {
 		const outputService = accessor.get(IOutputService);
 		const fileService = accessor.get(IFileService);
 		const editorService = accessor.get(IEditorService);
+		const quickInputService = accessor.get(IQuickInputService);
+		const notificationService = accessor.get(INotificationService);
+
+		// When Posit Assistant is installed, ask up front whether to also produce
+		// its diagnostics bundle. The report is always generated; the bundle is
+		// opt-in. Escaping the prompt cancels the command.
+		let includeBundle = false;
+		if (await extensionService.getExtension(ASSISTANT_EXTENSION_ID)) {
+			const choice = await promptForBundle(quickInputService);
+			if (choice === undefined) {
+				return;
+			}
+			includeBundle = choice;
+		}
 
 		const settings = collectNonDefaultAISettings(configurationService);
 
@@ -373,6 +395,10 @@ export class CreateAIDiagnosticReportAction extends Action2 {
 
 		const providers = await collectProviderDiagnostics(extensionService, commandService);
 
+		const bundle = includeBundle
+			? localize('positron.ai.diagnostics.bundleRequested', "Requested. Posit Assistant saves the bundle and shows its location in a notification.")
+			: undefined;
+
 		// NES's `enabled` is a per-language-type map; the `*` wildcard is the
 		// overall on/off, so report that.
 		const nesEnabled = configurationService.getValue<Record<string, boolean>>('nextEditSuggestions.enabled')?.['*'];
@@ -401,9 +427,19 @@ export class CreateAIDiagnosticReportAction extends Action2 {
 			disabledProviders: providers.disabled,
 			settings,
 			logs,
+			bundle,
 		});
 
 		await editorService.openEditor({ resource: undefined, contents: report, languageId: 'markdown' });
+
+		// Fire the bundle after the report is open, and don't await it: the
+		// Assistant's command shows its own notification (and reveal/download),
+		// which would otherwise block the report from appearing until dismissed.
+		if (includeBundle) {
+			collectAssistantBundle(extensionService, commandService, false).catch(error => {
+				notificationService.warn(localize('positron.ai.diagnostics.bundleFailed', "Could not produce the Posit Assistant diagnostics bundle: {0}", error instanceof Error ? error.message : String(error)));
+			});
+		}
 	}
 }
 
@@ -482,6 +518,45 @@ async function collectProviderDiagnostics(
 	} catch {
 		return empty;
 	}
+}
+
+/**
+ * When Posit Assistant is installed, asks whether to also produce its diagnostics
+ * bundle - the extra artifact that carries the chat conversation. Returns the
+ * choice, or `undefined` if the user cancels (Escape), which aborts the command.
+ */
+async function promptForBundle(quickInputService: IQuickInputService): Promise<boolean | undefined> {
+	const items: (IQuickPickItem & { includeBundle: boolean })[] = [
+		{
+			label: localize('positron.ai.diagnostics.reportOnly', "Report only"),
+			detail: localize('positron.ai.diagnostics.reportOnly.detail', "Auth providers, feature enablement, settings, and recent logs."),
+			includeBundle: false,
+		},
+		{
+			label: localize('positron.ai.diagnostics.reportAndBundle', "Report and diagnostics bundle"),
+			detail: localize('positron.ai.diagnostics.reportAndBundle.detail', "A zip with detailed Assistant logs, recent model requests and errors, and the open conversation (if any)."),
+			includeBundle: true,
+		},
+	];
+	const picked = await quickInputService.pick(items, {
+		placeHolder: localize('positron.ai.diagnostics.bundlePrompt', "Include the diagnostics bundle? Add it if you need to share the chat conversation."),
+	});
+	return picked && picked.includeBundle;
+}
+
+/**
+ * Asks Posit Assistant to produce its diagnostics bundle via a bridge command.
+ * The Assistant writes the zip and handles its own reveal/download and progress
+ * UI, so this just kicks it off - the caller fires it after the report opens and
+ * doesn't await it, so the report isn't blocked behind the Assistant's UI.
+ */
+async function collectAssistantBundle(
+	extensionService: IExtensionService,
+	commandService: ICommandService,
+	includeAttachments: boolean,
+): Promise<void> {
+	await activateWithTimeout(extensionService, ASSISTANT_EXTENSION_ID);
+	await commandService.executeCommand(ASSISTANT_BUNDLE_COMMAND, { includeAttachments });
 }
 
 async function collectCopilotLogs(

--- a/src/vs/workbench/contrib/positronAssistant/browser/aiDiagnostics.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/aiDiagnostics.ts
@@ -15,21 +15,26 @@ import { INotificationService } from '../../../../platform/notification/common/n
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { IProgressService, ProgressLocation } from '../../../../platform/progress/common/progress.js';
-import { IFileService } from '../../../../platform/files/common/files.js';
+import { FileOperationResult, IFileService, toFileOperationResult } from '../../../../platform/files/common/files.js';
 import { ExtensionIdentifier } from '../../../../platform/extensions/common/extensions.js';
+import { IExtensionManagementService, ILocalExtension } from '../../../../platform/extensionManagement/common/extensionManagement.js';
 import { PlatformToString, platform } from '../../../../base/common/platform.js';
 import { raceTimeout } from '../../../../base/common/async.js';
 import { parse } from '../../../../base/common/json.js';
 import { Schemas } from '../../../../base/common/network.js';
-import { IExtensionService } from '../../../services/extensions/common/extensions.js';
+import { IExtensionService, IExtensionsStatus } from '../../../services/extensions/common/extensions.js';
 import { IAiProviderService } from '../../../services/positronAiProvider/common/aiProviderService.js';
 import { IHeadlessLanguageModelService, IModelListingDiagnostics } from '../../../services/positronHeadlessLanguageModel/common/headlessLanguageModelService.js';
 import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { IUntitledTextResourceEditorInput } from '../../../common/editor.js';
 import { IOutputService, isMultiSourceOutputChannelDescriptor, isSingleSourceOutputChannelDescriptor } from '../../../services/output/common/output.js';
 import { ILanguageModelsService } from '../../chat/common/languageModels.js';
 import { ChatConfiguration } from '../../chat/common/constants.js';
 import { AI_ENABLED_KEY } from '../common/positronAIConfiguration.js';
+import { NES_ENABLE_SETTING } from './nextEditSuggestionsDashboard.js';
+import { GIT_SUGGESTIONS_ENABLED_KEY } from './commitMessageAction.js';
+import { NOTEBOOK_AI_ENABLED_KEY } from '../../positronNotebook/common/positronNotebookConfig.js';
 
 /**
  * A single AI-related setting whose value differs from its registered default.
@@ -66,23 +71,24 @@ export interface IAIDiagnosticsLogSection {
 	readonly content: string;
 }
 
+/** Whether an AI extension is running, installed but switched off, or absent. */
+export type AIDiagnosticsExtensionPresence = 'running' | 'disabled' | 'missing';
+
 /**
  * One AI-related extension's presence/version/activation state.
  */
 export interface IAIDiagnosticsExtension {
 	readonly label: string;
 	readonly id: string;
+	readonly presence: AIDiagnosticsExtensionPresence;
 	/** `undefined` when the extension is not installed. */
 	readonly version: string | undefined;
-	/** Activation state (e.g. "active", "not activated, 1 runtime error"); only meaningful when installed. */
+	/** Activation state (e.g. "active", "not activated, 1 runtime error"); only meaningful when running. */
 	readonly status?: string;
+	/** Manifest/extension-point problem and runtime error text. */
+	readonly messages?: readonly string[];
 }
 
-/**
- * Everything the report needs, gathered by the action and passed to the pure
- * {@link generateAIDiagnosticsReport} formatter so the formatting is testable
- * without services.
- */
 /** One AI feature's on/off state, as shown in the report. */
 export interface IAIDiagnosticsFeature {
 	readonly label: string;
@@ -92,6 +98,17 @@ export interface IAIDiagnosticsFeature {
 	readonly state: string;
 }
 
+/** One setting a Posit Workbench admin enforced through `POSITRON_ENFORCED_SETTINGS`. */
+export interface IAIDiagnosticsEnforcedSetting {
+	readonly key: string;
+	readonly value: string;
+}
+
+/**
+ * Everything the report needs, gathered by the action and passed to the pure
+ * {@link generateAIDiagnosticsReport} formatter so the formatting is testable
+ * without services.
+ */
 export interface IAIDiagnosticsInputs {
 	readonly generatedAt: string;
 	/** The `ai.enabled` main switch; when false, every AI feature is off regardless of its own toggle. */
@@ -133,6 +150,11 @@ export interface IAIDiagnosticsInputs {
 	 */
 	readonly modelsIncomplete: boolean;
 	/**
+	 * Why the listing is incomplete, when the cause was an error rather than a
+	 * timeout. A timeout is worth re-running; an error names what broke.
+	 */
+	readonly modelsIncompleteReason?: string;
+	/**
 	 * Contents of providers.json, redacted and rendered inside a JSON fence. A
 	 * `// ...` comment line when the file is missing or the catalog is unavailable
 	 * (mirrors the settings block's placeholder).
@@ -141,10 +163,19 @@ export interface IAIDiagnosticsInputs {
 	/** Path to providers.json, shown so support knows where the config lives; omitted when unknown. */
 	readonly providersConfigPath: string | undefined;
 	readonly settings: readonly IAIDiagnosticsSetting[];
+	/** Settings a Workbench admin enforced. */
+	readonly enforcedSettings: readonly IAIDiagnosticsEnforcedSetting[];
 	readonly logs: readonly IAIDiagnosticsLogSection[];
 	/** Assistant diagnostics bundle result (path or status); omitted when not requested. */
 	readonly bundle?: string;
 }
+
+/** How an extension's presence renders when there's no version to show. */
+const PRESENCE_LABELS: Record<AIDiagnosticsExtensionPresence, string> = {
+	running: 'Installed',
+	disabled: 'Installed but disabled',
+	missing: 'Not installed',
+};
 
 /**
  * Builds the markdown diagnostics report. Pure: no services, no I/O, so it can
@@ -157,11 +188,26 @@ export function generateAIDiagnosticsReport(inputs: IAIDiagnosticsInputs): strin
 			.map(s => `  "${s.key}": ${JSON.stringify(s.value, null, 2).split('\n').join('\n  ')}`)
 			.join(',\n');
 
+	// One line per extension, with any error text as sub-bullets beneath it.
 	const extensionsBlock = inputs.extensions
-		.map(e => e.version
-			? `- ${e.label}: Version ${e.version}${e.status ? ` (${e.status})` : ''}`
-			: `- ${e.label}: Not installed`)
+		.map(e => {
+			const summary = e.version
+				? `Version ${e.version}${e.presence === 'disabled' ? ' (installed but disabled)' : e.status ? ` (${e.status})` : ''}`
+				: PRESENCE_LABELS[e.presence];
+			const messages = (e.messages ?? []).map(message => `\n  - ${message}`).join('');
+			return `- ${e.label}: ${summary}${messages}`;
+		})
 		.join('\n');
+
+	// Omitted when nothing is enforced.
+	const enforcedBlock = inputs.enforcedSettings.length === 0
+		? ''
+		: `\n## Admin Enforced Settings
+
+Enforced by a Posit Workbench administrator. These cannot be changed from Positron - the fix is a server configuration change.
+
+${inputs.enforcedSettings.map(s => `- \`${s.key}\`: ${s.value}`).join('\n')}
+`;
 
 	const logsBlock = inputs.logs
 		.map(section => `## ${section.label} Logs\n\n\`\`\`\n${section.content}\n\`\`\``)
@@ -204,7 +250,9 @@ export function generateAIDiagnosticsReport(inputs: IAIDiagnosticsInputs): strin
 
 	const modelsBlock = byProvider.size === 0
 		? (inputs.modelsIncomplete
-			? 'Could not be retrieved in time. Re-run the report: the listing is cached once it succeeds, so a second run usually has it.'
+			? (inputs.modelsIncompleteReason
+				? `Could not be retrieved: ${inputs.modelsIncompleteReason}`
+				: 'Could not be retrieved in time. Re-run the report: the listing is cached once it succeeds, so a second run usually has it.')
 			: 'None. No provider was queried (each was disabled, had no registered auth backend, or had no credentials) and no extension registered a chat model.')
 		: [...byProvider]
 			.map(([providerId, models]) => {
@@ -219,7 +267,9 @@ export function generateAIDiagnosticsReport(inputs: IAIDiagnosticsInputs): strin
 
 	const totalModels = [...byProvider.values()].reduce((count, models) => count + models.length, 0);
 	const incompleteNote = inputs.modelsIncomplete && byProvider.size > 0
-		? '\n\nSome providers did not respond in time, so this list may be incomplete.'
+		? (inputs.modelsIncompleteReason
+			? `\n\nThis list may be incomplete: ${inputs.modelsIncompleteReason}`
+			: '\n\nSome providers did not respond in time, so this list may be incomplete.')
 		: '';
 
 	const optionalLine = (label: string, value: string | undefined) => value ? `\n- ${label}: ${value}` : '';
@@ -283,7 +333,7 @@ Non-default AI-related settings:
 \`\`\`json
 ${settingsBlock}
 \`\`\`
-
+${enforcedBlock}
 ${logsBlock}
 ${inputs.bundle ? `\n## Assistant Diagnostics Bundle\n\n${inputs.bundle}\n` : ''}`;
 }
@@ -297,7 +347,8 @@ const AI_SETTING_PREFIXES = [
 	'positron.assistant.',
 	'authentication.',
 	'console.assistantActions.',
-	'github.copilot',
+	'git.suggestions.',
+	'github.copilot.',
 ];
 
 /** AI-related settings that don't share one of the AI prefixes. */
@@ -396,6 +447,9 @@ const AUTH_PROVIDERS_COMMAND = 'authentication.getProviderDiagnostics';
 const ASSISTANT_EXTENSION_ID = 'posit.assistant';
 const ASSISTANT_BUNDLE_COMMAND = 'posit.assistant.collectDiagnosticsBundle';
 
+/** The Next Edit Suggestions extension. */
+const NES_EXTENSION_ID = 'positron.next-edit-suggestions';
+
 /** Shape returned by {@link AUTH_PROVIDERS_COMMAND}. */
 interface IProviderDiagnostics {
 	readonly authenticated: string[];
@@ -473,12 +527,12 @@ export function describeFeatureToggle(value: unknown): string {
 
 /**
  * Renders an extension-backed feature's state. When the owning extension isn't
- * installed the setting is unregistered (`getValue` returns undefined), so
- * report "not installed" rather than letting {@link describeFeatureToggle}
+ * running the setting is unregistered (`getValue` returns undefined), so
+ * report the extension's presence rather than letting {@link describeFeatureToggle}
  * default it to "Enabled".
  */
-export function featureState(installed: boolean, value: unknown): string {
-	return installed ? describeFeatureToggle(value) : 'Not installed';
+export function featureState(presence: AIDiagnosticsExtensionPresence, value: unknown): string {
+	return presence === 'running' ? describeFeatureToggle(value) : PRESENCE_LABELS[presence];
 }
 
 /** The activation fields of `IExtensionsStatus` that the report renders. */
@@ -527,6 +581,7 @@ export class CreateAIDiagnosticReportAction extends Action2 {
 		const configurationService = accessor.get(IConfigurationService);
 		const commandService = accessor.get(ICommandService);
 		const extensionService = accessor.get(IExtensionService);
+		const extensionManagementService = accessor.get(IExtensionManagementService);
 		const productService = accessor.get(IProductService);
 		const environmentService = accessor.get(IWorkbenchEnvironmentService);
 		const outputService = accessor.get(IOutputService);
@@ -540,12 +595,18 @@ export class CreateAIDiagnosticReportAction extends Action2 {
 		const progressService = accessor.get(IProgressService);
 		const logService = accessor.get(ILogService);
 
+		// Resolved once; the Extensions list, log sections, and feature rows all read it.
+		const presenceOf = await resolveExtensionPresence(extensionService, extensionManagementService, [
+			...AI_LOG_SOURCES.map(source => source.id),
+			...COPILOT_CHANNELS.map(channel => channel.extensionId),
+		]);
+
 		// When Posit Assistant is installed, ask up front whether to also produce
 		// its diagnostics bundle. The report is always generated; the bundle is
 		// opt-in. Escaping the prompt cancels the command.
-		const assistantInstalled = !!await extensionService.getExtension(ASSISTANT_EXTENSION_ID);
+		const assistantPresence = presenceOf(ASSISTANT_EXTENSION_ID).presence;
 		let includeBundle = false;
-		if (assistantInstalled) {
+		if (assistantPresence === 'running') {
 			const choice = await promptForBundle(quickInputService);
 			if (choice === undefined) {
 				return;
@@ -561,11 +622,13 @@ export class CreateAIDiagnosticReportAction extends Action2 {
 			location: ProgressLocation.Notification,
 			title: localize('positron.ai.diagnostics.generating', "Generating AI diagnostic report"),
 		}, async progress => {
-			const settings = collectNonDefaultAISettings(configurationService);
+			const { settings, enforced: enforcedSettings } = collectAISettings(configurationService);
 
-			const statuses = extensionService.getExtensionsStatus();
-			const statusFor = (id: string): string =>
-				describeExtensionStatus(Object.entries(statuses).find(([key]) => ExtensionIdentifier.equals(key, id))?.[1]);
+			// Canonical ids can differ in casing from ours (e.g. `GitHub.copilot-chat`).
+			const statuses = new Map(Object.entries(extensionService.getExtensionsStatus())
+				.map(([key, status]) => [key.toLowerCase(), status]));
+			const describe = (label: string, id: string): IAIDiagnosticsExtension =>
+				describeExtension(label, id, presenceOf(id), statuses.get(id.toLowerCase()));
 
 			const extensions: IAIDiagnosticsExtension[] = [];
 			const logs: IAIDiagnosticsLogSection[] = [];
@@ -573,10 +636,10 @@ export class CreateAIDiagnosticReportAction extends Action2 {
 			// Posit-owned surfaces: bridge command per extension.
 			progress.report({ message: localize('positron.ai.diagnostics.collectingLogs', "Collecting extension logs") });
 			for (const source of AI_LOG_SOURCES) {
-				const extension = await extensionService.getExtension(source.id);
-				extensions.push({ label: source.label, id: source.id, version: extension?.version, status: extension ? statusFor(source.id) : undefined });
-				if (!extension) {
-					logs.push({ label: source.label, content: 'Extension not installed' });
+				extensions.push(describe(source.label, source.id));
+				const presence = presenceOf(source.id).presence;
+				if (presence !== 'running') {
+					logs.push({ label: source.label, content: PRESENCE_LABELS[presence] });
 					continue;
 				}
 				logs.push({ label: source.label, content: await collectBridgedLogs(source, extensionService, commandService) });
@@ -586,13 +649,11 @@ export class CreateAIDiagnosticReportAction extends Action2 {
 			// directly, and only when Copilot is enabled (`chat.disableAIFeatures` off).
 			const copilotEnabled = configurationService.getValue(ChatConfiguration.AIDisabled) !== true;
 			for (const channel of COPILOT_CHANNELS) {
-				const extension = await extensionService.getExtension(channel.extensionId);
-				extensions.push({ label: channel.label, id: channel.extensionId, version: extension?.version, status: extension ? statusFor(channel.extensionId) : undefined });
-				if (!copilotEnabled) {
-					logs.push({ label: channel.label, content: 'Skipped (GitHub Copilot is disabled)' });
-					continue;
-				}
-				logs.push({ label: channel.label, content: await collectCopilotLogs(channel, extensionService, outputService, fileService) });
+				extensions.push(describe(channel.label, channel.extensionId));
+				logs.push({
+					label: channel.label,
+					content: await copilotLogSection(channel, presenceOf(channel.extensionId).presence, copilotEnabled, extensionService, outputService, fileService),
+				});
 			}
 
 			progress.report({ message: localize('positron.ai.diagnostics.collectingProviders', "Reading provider configuration") });
@@ -603,9 +664,10 @@ export class CreateAIDiagnosticReportAction extends Action2 {
 			// one timeout, not two. Either coming back undefined leaves the report
 			// intact and marks the listing incomplete.
 			progress.report({ message: localize('positron.ai.diagnostics.listingModels', "Listing available models") });
+			const listingFailure: IListingFailure = {};
 			const [listing, builtin] = await Promise.all([
-				collectAvailableModels(headlessLanguageModelService, logService),
-				collectBuiltinModels(languageModelsService, logService),
+				collectAvailableModels(headlessLanguageModelService, logService, listingFailure),
+				collectBuiltinModels(languageModelsService, logService, listingFailure),
 			]);
 
 			const bundle = includeBundle
@@ -615,17 +677,17 @@ export class CreateAIDiagnosticReportAction extends Action2 {
 			// Extension-backed toggles (Posit Assistant, NES, Copilot chat) read as
 			// "not installed" when their extension is absent, since the setting is then
 			// unregistered and would otherwise default to "Enabled" - contradicting the
-			// Extensions list. Notebook AI and console actions are core, so always show.
-			const nesInstalled = !!await extensionService.getExtension('positron.next-edit-suggestions');
-			const copilotChatInstalled = !!await extensionService.getExtension('GitHub.copilot-chat');
+			// Extensions list. Notebook AI, console actions, and Git suggestions are
+			// core, so always show.
 			// NES's `enabled` is a per-language-type map; the `*` wildcard is the overall on/off.
-			const nesEnabled = configurationService.getValue<Record<string, boolean>>('nextEditSuggestions.enabled')?.['*'];
+			const nesEnabled = configurationService.getValue<Record<string, boolean>>(NES_ENABLE_SETTING)?.['*'];
 			const features: IAIDiagnosticsFeature[] = [
-				{ label: 'Posit Assistant', setting: 'assistant.enabled', state: featureState(assistantInstalled, configurationService.getValue('assistant.enabled')) },
-				{ label: 'Posit AI NES', setting: 'nextEditSuggestions.enabled', state: featureState(nesInstalled, nesEnabled) },
-				{ label: 'Notebook AI', setting: 'notebook.ai.enabled', state: describeFeatureToggle(configurationService.getValue('notebook.ai.enabled')) },
+				{ label: 'Posit Assistant', setting: 'assistant.enabled', state: featureState(assistantPresence, configurationService.getValue('assistant.enabled')) },
+				{ label: 'Posit AI NES', setting: NES_ENABLE_SETTING, state: featureState(presenceOf(NES_EXTENSION_ID).presence, nesEnabled) },
+				{ label: 'Notebook AI', setting: NOTEBOOK_AI_ENABLED_KEY, state: describeFeatureToggle(configurationService.getValue(NOTEBOOK_AI_ENABLED_KEY)) },
 				{ label: 'Console Fix & Explain', setting: 'console.assistantActions.enabled', state: describeFeatureToggle(configurationService.getValue('console.assistantActions.enabled')) },
-				{ label: 'GitHub Copilot Chat', setting: ChatConfiguration.AIDisabled, state: featureState(copilotChatInstalled, copilotEnabled) },
+				{ label: 'Git Suggestions', setting: GIT_SUGGESTIONS_ENABLED_KEY, state: describeFeatureToggle(configurationService.getValue(GIT_SUGGESTIONS_ENABLED_KEY)) },
+				{ label: 'GitHub Copilot Chat', setting: ChatConfiguration.AIDisabled, state: featureState(presenceOf(COPILOT_CHANNELS[0].extensionId).presence, copilotEnabled) },
 			];
 
 			return generateAIDiagnosticsReport({
@@ -647,41 +709,129 @@ export class CreateAIDiagnosticReportAction extends Action2 {
 				modelListing: listing ?? { queriedProviders: [], models: [] },
 				builtinModels: builtin ?? [],
 				modelsIncomplete: listing === undefined || builtin === undefined,
+				modelsIncompleteReason: listingFailure.reason,
 				providersConfig: providerConfig.content,
 				providersConfigPath: providerConfig.path,
 				settings,
+				enforcedSettings,
 				logs,
 				bundle,
 			});
 		});
 
-		await editorService.openEditor({ resource: undefined, contents: report, languageId: 'markdown' });
+		// Pinned so the next editor the user opens doesn't replace the report.
+		await editorService.openEditor({
+			resource: undefined,
+			contents: report,
+			languageId: 'markdown',
+			options: { pinned: true },
+		} satisfies IUntitledTextResourceEditorInput);
 
 		// Fire the bundle after the report is open, and don't await it: the
 		// Assistant's command shows its own notification (and reveal/download),
 		// which would otherwise block the report from appearing until dismissed.
 		if (includeBundle) {
-			collectAssistantBundle(extensionService, commandService, false).catch(error => {
+			collectAssistantBundle(extensionService, commandService).catch(error => {
 				notificationService.warn(localize('positron.ai.diagnostics.bundleFailed', "Could not produce the Posit Assistant diagnostics bundle: {0}", error instanceof Error ? error.message : String(error)));
 			});
 		}
 	}
 }
 
-function collectNonDefaultAISettings(configurationService: IConfigurationService): IAIDiagnosticsSetting[] {
+/**
+ * The AI settings that aren't at their default, and the subset a Posit Workbench
+ * admin enforced. An enforced setting arrives as `policyValue`, so the two come
+ * from one walk over the AI keys.
+ */
+function collectAISettings(configurationService: IConfigurationService): {
+	settings: IAIDiagnosticsSetting[];
+	enforced: IAIDiagnosticsEnforcedSetting[];
+} {
 	const properties = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).getConfigurationProperties();
 	const keys = Object.keys(properties)
 		.filter(key => AI_SETTING_EXACT_KEYS.includes(key) || AI_SETTING_PREFIXES.some(prefix => key.startsWith(prefix)))
 		.sort();
 
 	const settings: IAIDiagnosticsSetting[] = [];
+	const enforced: IAIDiagnosticsEnforcedSetting[] = [];
 	for (const key of keys) {
 		const inspected = configurationService.inspect(key);
 		if (hasExplicitValue(inspected)) {
 			settings.push({ key, value: isSensitiveSettingKey(key) ? REDACTED_VALUE : inspected.value });
 		}
+		if (inspected.policyValue !== undefined) {
+			enforced.push({
+				key,
+				value: isSensitiveSettingKey(key)
+					? REDACTED_VALUE
+					: typeof inspected.policyValue === 'object' ? JSON.stringify(inspected.policyValue) : String(inspected.policyValue),
+			});
+		}
 	}
-	return settings;
+	return { settings, enforced };
+}
+
+/**
+ * Looks up whether each extension is running, installed but disabled, or absent.
+ * `IExtensionService.getExtension` only sees running extensions, so the installed
+ * set is needed too.
+ */
+async function resolveExtensionPresence(
+	extensionService: IExtensionService,
+	extensionManagementService: IExtensionManagementService,
+	ids: readonly string[],
+): Promise<(id: string) => IExtensionPresence> {
+	// No type filter: the Posit AI extensions ship built-in (System), so restricting
+	// to User would miss all of them. A failure here must not lose the report.
+	let installed: readonly ILocalExtension[] = [];
+	try {
+		installed = await extensionManagementService.getInstalled();
+	} catch {
+		installed = [];
+	}
+
+	const presence = new Map<string, IExtensionPresence>();
+	for (const id of ids) {
+		const running = await extensionService.getExtension(id);
+		if (running) {
+			presence.set(id, { presence: 'running', version: running.version });
+			continue;
+		}
+		// Installed but not running: usually disabled, but an extension-kind
+		// mismatch or untrusted workspace lands here too.
+		const local = installed.find(e => ExtensionIdentifier.equals(e.identifier.id, id));
+		presence.set(id, local
+			? { presence: 'disabled', version: local.manifest.version }
+			: { presence: 'missing', version: undefined });
+	}
+	return id => presence.get(id) ?? { presence: 'missing', version: undefined };
+}
+
+/** One extension's resolved presence and version. */
+interface IExtensionPresence {
+	readonly presence: AIDiagnosticsExtensionPresence;
+	readonly version: string | undefined;
+}
+
+/** The report row for one extension. */
+function describeExtension(
+	label: string,
+	id: string,
+	{ presence, version }: IExtensionPresence,
+	status: IExtensionsStatus | undefined,
+): IAIDiagnosticsExtension {
+	const messages = [
+		...status?.messages.map(message => message.message) ?? [],
+		...status?.runtimeErrors.map(error => error instanceof Error ? (error.stack ?? error.message) : String(error)) ?? [],
+	];
+	return {
+		label,
+		id,
+		presence,
+		version,
+		status: presence === 'running' ? describeExtensionStatus(status) : undefined,
+		messages: messages.length > 0 ? messages : undefined,
+	};
 }
 
 /**
@@ -696,6 +846,11 @@ async function activateWithTimeout(extensionService: IExtensionService, id: stri
 	);
 }
 
+/** Collects the error message from a failed listing, left unset on a timeout. */
+interface IListingFailure {
+	reason?: string;
+}
+
 /**
  * Asks the headless language model service what the configured providers
  * actually list. This is a live call, so it can hit the network - that's the
@@ -707,7 +862,7 @@ async function activateWithTimeout(extensionService: IExtensionService, id: stri
  * as "could not be retrieved". Distinct from an empty listing: a slow provider
  * must not be reported as "you have no models".
  */
-async function collectAvailableModels(service: IHeadlessLanguageModelService, logService: ILogService): Promise<IModelListingDiagnostics | undefined> {
+async function collectAvailableModels(service: IHeadlessLanguageModelService, logService: ILogService, failure: IListingFailure): Promise<IModelListingDiagnostics | undefined> {
 	try {
 		const listing = await raceTimeout(service.getModelListingDiagnostics(), MODEL_LISTING_TIMEOUT_MS);
 		if (!listing) {
@@ -715,6 +870,7 @@ async function collectAvailableModels(service: IHeadlessLanguageModelService, lo
 		}
 		return listing;
 	} catch (error) {
+		failure.reason = error instanceof Error ? error.message : String(error);
 		logService.warn(`[ai-diagnostics] Model listing failed; report omits it: ${error}`);
 		return undefined;
 	}
@@ -729,7 +885,7 @@ async function collectAvailableModels(service: IHeadlessLanguageModelService, lo
  * Returns `undefined` when the listing didn't come back, for the same reason as
  * {@link collectAvailableModels}.
  */
-async function collectBuiltinModels(service: ILanguageModelsService, logService: ILogService): Promise<readonly IAIDiagnosticsBuiltinModel[] | undefined> {
+async function collectBuiltinModels(service: ILanguageModelsService, logService: ILogService, failure: IListingFailure): Promise<readonly IAIDiagnosticsBuiltinModel[] | undefined> {
 	try {
 		const identifiers = await raceTimeout(service.selectLanguageModels({}), MODEL_LISTING_TIMEOUT_MS);
 		if (!identifiers) {
@@ -743,6 +899,7 @@ async function collectBuiltinModels(service: ILanguageModelsService, logService:
 				: [];
 		});
 	} catch (error) {
+		failure.reason = error instanceof Error ? error.message : String(error);
 		logService.warn(`[ai-diagnostics] Built-in model listing failed; report omits it: ${error}`);
 		return undefined;
 	}
@@ -759,14 +916,22 @@ async function collectBridgedLogs(
 	// registered at the very start of activate(), so it resolves even if the
 	// rest of activation is still pending. Bounded so a stuck extension can't
 	// hang the whole report.
-	const collect = async (): Promise<string> => {
-		await activateWithTimeout(extensionService, source.id);
-		const content = await commandService.executeCommand<string>(source.command);
-		return capLogLines(content ?? 'No log entries available');
-	};
+	//
+	// A failed or hung activation still leaves the command registered, and those
+	// logs are the ones that explain it, so ask for them anyway. The bridge call
+	// gets its own budget: sharing one with the activation means a hang consumes it
+	// all and the command never runs.
 	try {
-		const result = await raceTimeout(collect(), BRIDGE_TIMEOUT_MS);
-		return result ?? `Logs unavailable: timed out after ${BRIDGE_TIMEOUT_MS}ms (extension may be stuck activating)`;
+		await activateWithTimeout(extensionService, source.id);
+	} catch {
+		// Fall through to the bridge call.
+	}
+	try {
+		let timedOut = false;
+		const content = await raceTimeout(commandService.executeCommand<string>(source.command), BRIDGE_TIMEOUT_MS, () => { timedOut = true; });
+		return timedOut
+			? `Logs unavailable: timed out after ${BRIDGE_TIMEOUT_MS}ms (extension may be stuck activating)`
+			: capLogLines(content ?? 'No log entries available');
 	} catch (error) {
 		return `Logs unavailable: ${error instanceof Error ? error.message : String(error)}`;
 	}
@@ -786,12 +951,15 @@ async function collectProviderDiagnostics(
 	if (!await extensionService.getExtension(AUTH_EXTENSION_ID)) {
 		return empty;
 	}
-	const collect = async (): Promise<IProviderDiagnostics> => {
-		await activateWithTimeout(extensionService, AUTH_EXTENSION_ID);
-		return (await commandService.executeCommand<IProviderDiagnostics>(AUTH_PROVIDERS_COMMAND)) ?? empty;
-	};
+	// The bridge call gets its own budget, for the same reason as the log
+	// collection above: one shared with the activation is spent by a hang.
 	try {
-		return (await raceTimeout(collect(), BRIDGE_TIMEOUT_MS)) ?? empty;
+		await activateWithTimeout(extensionService, AUTH_EXTENSION_ID);
+	} catch {
+		// Fall through to the bridge call.
+	}
+	try {
+		return (await raceTimeout(commandService.executeCommand<IProviderDiagnostics>(AUTH_PROVIDERS_COMMAND), BRIDGE_TIMEOUT_MS)) ?? empty;
 	} catch {
 		return empty;
 	}
@@ -820,10 +988,14 @@ async function collectProvidersConfig(
 	try {
 		const file = await fileService.readFile(uri);
 		return { content: redactProvidersConfig(file.value.toString()), path };
-	} catch {
+	} catch (error) {
 		// Most often the file doesn't exist yet: provider config falls back to
-		// built-in defaults until the user configures a provider.
-		return { content: '// No providers.json found (provider configuration is using defaults)', path };
+		// built-in defaults until the user configures a provider. Permission and
+		// remote filesystem errors are real findings, so report those.
+		if (toFileOperationResult(error) === FileOperationResult.FILE_NOT_FOUND) {
+			return { content: '// No providers.json found (provider configuration is using defaults)', path };
+		}
+		return { content: `// Could not read providers.json: ${error instanceof Error ? error.message : String(error)}`, path };
 	}
 }
 
@@ -860,10 +1032,38 @@ async function promptForBundle(quickInputService: IQuickInputService): Promise<b
 async function collectAssistantBundle(
 	extensionService: IExtensionService,
 	commandService: ICommandService,
-	includeAttachments: boolean,
 ): Promise<void> {
 	await activateWithTimeout(extensionService, ASSISTANT_EXTENSION_ID);
-	await commandService.executeCommand(ASSISTANT_BUNDLE_COMMAND, { includeAttachments });
+	await commandService.executeCommand(ASSISTANT_BUNDLE_COMMAND, { includeAttachments: false });
+}
+
+/**
+ * The Copilot log section. {@link collectCopilotLogs} activates the extension
+ * first, so an absent, disabled, or unactivatable Copilot is guarded here rather
+ * than rejecting out of the whole report.
+ */
+async function copilotLogSection(
+	channel: { label: string; extensionId: string },
+	presence: AIDiagnosticsExtensionPresence,
+	copilotEnabled: boolean,
+	extensionService: IExtensionService,
+	outputService: IOutputService,
+	fileService: IFileService,
+): Promise<string> {
+	if (presence === 'missing') {
+		return 'Extension not installed';
+	}
+	if (presence === 'disabled') {
+		return 'Extension installed but disabled';
+	}
+	if (!copilotEnabled) {
+		return 'Skipped (GitHub Copilot is disabled)';
+	}
+	try {
+		return await collectCopilotLogs(channel, extensionService, outputService, fileService);
+	} catch (error) {
+		return `Logs unavailable: ${error instanceof Error ? error.message : String(error)}`;
+	}
 }
 
 async function collectCopilotLogs(

--- a/src/vs/workbench/contrib/positronAssistant/browser/aiDiagnostics.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/aiDiagnostics.ts
@@ -1,0 +1,468 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize2 } from '../../../../nls.js';
+import { Registry } from '../../../../platform/registry/common/platform.js';
+import { Action2 } from '../../../../platform/actions/common/actions.js';
+import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { IProductService } from '../../../../platform/product/common/productService.js';
+import { IFileService } from '../../../../platform/files/common/files.js';
+import { ExtensionIdentifier } from '../../../../platform/extensions/common/extensions.js';
+import { PlatformToString, platform } from '../../../../base/common/platform.js';
+import { raceTimeout } from '../../../../base/common/async.js';
+import { IExtensionService } from '../../../services/extensions/common/extensions.js';
+import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
+import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { IOutputService, isMultiSourceOutputChannelDescriptor, isSingleSourceOutputChannelDescriptor } from '../../../services/output/common/output.js';
+import { ChatConfiguration } from '../../chat/common/constants.js';
+
+/**
+ * A single AI-related setting whose value differs from its registered default.
+ */
+export interface IAIDiagnosticsSetting {
+	readonly key: string;
+	readonly value: unknown;
+}
+
+/**
+ * A block of collected logs for one AI surface.
+ */
+export interface IAIDiagnosticsLogSection {
+	readonly label: string;
+	readonly content: string;
+}
+
+/**
+ * One AI-related extension's presence/version/activation state.
+ */
+export interface IAIDiagnosticsExtension {
+	readonly label: string;
+	readonly id: string;
+	/** `undefined` when the extension is not installed. */
+	readonly version: string | undefined;
+	/** Activation state (e.g. "active", "not activated, 1 runtime error"); only meaningful when installed. */
+	readonly status?: string;
+}
+
+/**
+ * Everything the report needs, gathered by the action and passed to the pure
+ * {@link generateAIDiagnosticsReport} formatter so the formatting is testable
+ * without services.
+ */
+export interface IAIDiagnosticsInputs {
+	readonly generatedAt: string;
+	readonly application: string;
+	readonly positronVersion: string;
+	readonly positronBuildNumber: number;
+	readonly vscodeVersion: string;
+	readonly commit: string | undefined;
+	readonly buildDate: string | undefined;
+	readonly quality: string | undefined;
+	readonly os: string;
+	readonly remote: string | undefined;
+	readonly extensions: readonly IAIDiagnosticsExtension[];
+	/** Provider labels the user is authenticated with (empty when none/unknown). */
+	readonly authenticatedProviders: readonly string[];
+	/** Provider labels turned off in settings (empty when none/unknown). */
+	readonly disabledProviders: readonly string[];
+	readonly settings: readonly IAIDiagnosticsSetting[];
+	readonly logs: readonly IAIDiagnosticsLogSection[];
+}
+
+/**
+ * Builds the markdown diagnostics report. Pure: no services, no I/O, so it can
+ * be unit-tested by feeding stub inputs and snapshotting the output.
+ */
+export function generateAIDiagnosticsReport(inputs: IAIDiagnosticsInputs): string {
+	const settingsBlock = inputs.settings.length === 0
+		? '  // No non-default settings configured'
+		: inputs.settings
+			.map(s => `  "${s.key}": ${JSON.stringify(s.value, null, 2).split('\n').join('\n  ')}`)
+			.join(',\n');
+
+	const extensionsBlock = inputs.extensions
+		.map(e => e.version
+			? `- ${e.label}: Version ${e.version}${e.status ? ` (${e.status})` : ''}`
+			: `- ${e.label}: Not installed`)
+		.join('\n');
+
+	const logsBlock = inputs.logs
+		.map(section => `## ${section.label} Logs\n\n\`\`\`\n${section.content}\n\`\`\``)
+		.join('\n\n');
+
+	const providerList = (providers: readonly string[]) =>
+		providers.length === 0 ? 'None' : providers.map(p => `- ${p}`).join('\n');
+
+	const optionalLine = (label: string, value: string | undefined) => value ? `\n- ${label}: ${value}` : '';
+
+	return `# AI Diagnostic Report
+
+Generated: ${inputs.generatedAt}
+
+**Privacy Notice**: This report includes extension versions, non-default configuration settings, system information, and recent log entries. It does NOT include API keys or authentication tokens (those are stored separately, not in settings). However, configured base URLs may reveal internal endpoints. Please review before sharing.
+
+## Version Information
+
+- Application: ${inputs.application}
+- Positron: ${inputs.positronVersion} build ${inputs.positronBuildNumber}
+- Code OSS: ${inputs.vscodeVersion}${optionalLine('Commit', inputs.commit)}${optionalLine('Build date', inputs.buildDate)}${optionalLine('Quality', inputs.quality)}
+- OS: ${inputs.os}${optionalLine('Remote', inputs.remote)}
+
+### Extensions
+
+${extensionsBlock}
+
+## Authenticated Providers
+
+${providerList(inputs.authenticatedProviders)}
+
+## Disabled Providers
+
+${providerList(inputs.disabledProviders)}
+
+## Configuration Settings
+
+Non-default AI-related settings:
+
+\`\`\`json
+${settingsBlock}
+\`\`\`
+
+${logsBlock}
+`;
+}
+
+/** Setting-key prefixes that identify AI-related settings. */
+const AI_SETTING_PREFIXES = [
+	'ai.',
+	'notebook.ai.',
+	'nextEditSuggestions.',
+	'assistant.',
+	'positron.assistant.',
+	'authentication.',
+	'console.assistantActions.',
+	'github.copilot',
+];
+
+/** AI-related settings that don't share one of the AI prefixes. */
+const AI_SETTING_EXACT_KEYS: string[] = [ChatConfiguration.AIDisabled];
+
+/**
+ * Setting-key final segments whose value may hold a secret (custom request
+ * headers carrying auth tokens, API keys, etc.). Their values are redacted in
+ * the report so it never leaks keys or tokens the user stored in settings.json.
+ * Matched case-insensitively against the key's last segment.
+ *
+ * Note `credentials` is deliberately NOT here: the `authentication.*.credentials`
+ * settings hold non-secret config vars (AWS_PROFILE/AWS_REGION, SNOWFLAKE_ACCOUNT,
+ * GOOGLE_VERTEX_PROJECT, etc.), not the actual secrets, which resolve from the
+ * environment or credential chain. Those values are useful in a report.
+ */
+const SENSITIVE_KEY_SEGMENTS = ['customheaders', 'apikey', 'token', 'secret', 'password'];
+
+/** Placeholder shown in place of a redacted setting value. */
+export const REDACTED_VALUE = '<redacted>';
+
+/**
+ * Whether a setting's value should be redacted from the report because the key
+ * suggests it holds a credential or auth token.
+ */
+export function isSensitiveSettingKey(key: string): boolean {
+	const segment = key.split('.').pop()?.toLowerCase() ?? '';
+	return SENSITIVE_KEY_SEGMENTS.some(sensitive => segment.includes(sensitive));
+}
+
+/**
+ * AI surfaces that expose their buffered trace/debug logs through a bridge
+ * command. Each extension registers the command from its `activate()`; the
+ * command's return value crosses the extension-host boundary back to this
+ * workbench action. The Posit Assistant command is implemented in the
+ * posit-dev/assistant repo; this action tolerates its absence.
+ */
+const AI_LOG_SOURCES: readonly { label: string; id: string; command: string }[] = [
+	{ label: 'Authentication', id: 'positron.authentication', command: 'authentication.getDiagnosticLogs' },
+	{ label: 'Posit Assistant', id: 'posit.assistant', command: 'posit.assistant.getDiagnosticLogs' },
+	{ label: 'Posit AI NES', id: 'positron.next-edit-suggestions', command: 'next-edit-suggestions.getDiagnosticLogs' },
+];
+
+/** The authentication extension and its bridge command reporting provider state. */
+const AUTH_EXTENSION_ID = 'positron.authentication';
+const AUTH_PROVIDERS_COMMAND = 'authentication.getProviderDiagnostics';
+
+/** Shape returned by {@link AUTH_PROVIDERS_COMMAND}. */
+interface IProviderDiagnostics {
+	readonly authenticated: string[];
+	readonly disabled: string[];
+}
+
+/**
+ * GitHub Copilot output channels, collected only when Copilot is enabled. In
+ * Positron the single `GitHub.copilot-chat` extension provides both the chat UI
+ * and inline completions (it bundles completions-core and logs both to the same
+ * channel), so there's no separate `github.copilot` completions extension to
+ * report - upstream VS Code ships those as two marketplace extensions, but
+ * Positron does not.
+ */
+const COPILOT_CHANNELS: readonly { label: string; extensionId: string }[] = [
+	{ label: 'GitHub Copilot', extensionId: 'GitHub.copilot-chat' },
+];
+
+/** Keep reports bounded: only the most recent lines of each log. */
+const MAX_LOG_LINES = 500;
+
+/** Bound activation + bridge calls so a stuck extension can't hang the report. */
+const BRIDGE_TIMEOUT_MS = 5000;
+
+/** Trims log content to the most recent {@link MAX_LOG_LINES} lines. */
+export function capLogLines(content: string): string {
+	const lines = content.split('\n');
+	return lines.length > MAX_LOG_LINES ? lines.slice(-MAX_LOG_LINES).join('\n') : content;
+}
+
+/** The scopes at which a configuration value can be explicitly set. */
+interface IExplicitScopes {
+	readonly userValue?: unknown;
+	readonly userLocalValue?: unknown;
+	readonly userRemoteValue?: unknown;
+	readonly workspaceValue?: unknown;
+	readonly workspaceFolderValue?: unknown;
+	readonly policyValue?: unknown;
+}
+
+/**
+ * Whether a setting has an explicit value at any scope (user, workspace, folder,
+ * or policy). Policy covers Posit Workbench's enforced settings. A setting left
+ * at its registered default reads `undefined` at every scope.
+ */
+export function hasExplicitValue(inspected: IExplicitScopes): boolean {
+	return (inspected.userValue ?? inspected.userLocalValue ?? inspected.userRemoteValue
+		?? inspected.workspaceValue ?? inspected.workspaceFolderValue ?? inspected.policyValue) !== undefined;
+}
+
+/** The activation fields of `IExtensionsStatus` that the report renders. */
+interface IActivationStatus {
+	readonly activationStarted: boolean;
+	readonly activationTimes: unknown;
+	readonly runtimeErrors: readonly unknown[];
+}
+
+/**
+ * Renders an extension's activation state for the report. Activation failures
+ * are a prime thing this report should surface, so it distinguishes active,
+ * still-activating, and never-activated, and counts runtime errors.
+ */
+export function describeExtensionStatus(status: IActivationStatus | undefined): string {
+	if (!status || !status.activationStarted) {
+		return 'not activated';
+	}
+	const state = status.activationTimes ? 'active' : 'activation started, not finished';
+	const errors = status.runtimeErrors.length;
+	return errors > 0 ? `${state}, ${errors} runtime error${errors === 1 ? '' : 's'}` : state;
+}
+
+/**
+ * Creates an AI diagnostic report: itemizes non-default AI settings and gathers
+ * trace/debug logs from Authentication, Posit Assistant, Posit AI NES, and (when
+ * enabled) GitHub Copilot, then opens the report in an editor. Runs without
+ * asking the user to reproduce: the Posit surfaces buffer their recent
+ * trace/debug in memory and hand it over via a bridge command.
+ */
+export class CreateAIDiagnosticReportAction extends Action2 {
+	static readonly ID = 'workbench.action.positronAssistant.createAIDiagnosticReport';
+
+	constructor() {
+		super({
+			id: CreateAIDiagnosticReportAction.ID,
+			title: localize2('positron.ai.createDiagnosticReport', "Create Diagnostic Report"),
+			category: localize2('positron.ai.category', "AI"),
+			f1: true,
+			// No precondition: the command must work even when AI features are off,
+			// since one reason to run it is to debug why something is disabled.
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const configurationService = accessor.get(IConfigurationService);
+		const commandService = accessor.get(ICommandService);
+		const extensionService = accessor.get(IExtensionService);
+		const productService = accessor.get(IProductService);
+		const environmentService = accessor.get(IWorkbenchEnvironmentService);
+		const outputService = accessor.get(IOutputService);
+		const fileService = accessor.get(IFileService);
+		const editorService = accessor.get(IEditorService);
+
+		const settings = collectNonDefaultAISettings(configurationService);
+
+		const statuses = extensionService.getExtensionsStatus();
+		const statusFor = (id: string): string =>
+			describeExtensionStatus(Object.entries(statuses).find(([key]) => ExtensionIdentifier.equals(key, id))?.[1]);
+
+		const extensions: IAIDiagnosticsExtension[] = [];
+		const logs: IAIDiagnosticsLogSection[] = [];
+
+		// Posit-owned surfaces: bridge command per extension.
+		for (const source of AI_LOG_SOURCES) {
+			const extension = await extensionService.getExtension(source.id);
+			extensions.push({ label: source.label, id: source.id, version: extension?.version, status: extension ? statusFor(source.id) : undefined });
+			if (!extension) {
+				logs.push({ label: source.label, content: 'Extension not installed' });
+				continue;
+			}
+			logs.push({ label: source.label, content: await collectBridgedLogs(source, extensionService, commandService) });
+		}
+
+		// GitHub Copilot: third-party, so no bridge command. Read its log file(s)
+		// directly, and only when Copilot is enabled (`chat.disableAIFeatures` off).
+		const copilotEnabled = configurationService.getValue(ChatConfiguration.AIDisabled) !== true;
+		for (const channel of COPILOT_CHANNELS) {
+			const extension = await extensionService.getExtension(channel.extensionId);
+			extensions.push({ label: channel.label, id: channel.extensionId, version: extension?.version, status: extension ? statusFor(channel.extensionId) : undefined });
+			if (!copilotEnabled) {
+				logs.push({ label: channel.label, content: 'Skipped (GitHub Copilot is disabled)' });
+				continue;
+			}
+			logs.push({ label: channel.label, content: await collectCopilotLogs(channel, extensionService, outputService, fileService) });
+		}
+
+		const providers = await collectProviderDiagnostics(extensionService, commandService);
+
+		const report = generateAIDiagnosticsReport({
+			generatedAt: new Date().toISOString(),
+			application: productService.nameLong,
+			positronVersion: productService.positronVersion,
+			positronBuildNumber: productService.positronBuildNumber,
+			vscodeVersion: productService.version,
+			commit: productService.commit,
+			buildDate: productService.date,
+			quality: productService.quality,
+			os: PlatformToString(platform),
+			remote: environmentService.remoteAuthority,
+			extensions,
+			authenticatedProviders: providers.authenticated,
+			disabledProviders: providers.disabled,
+			settings,
+			logs,
+		});
+
+		await editorService.openEditor({ resource: undefined, contents: report, languageId: 'markdown' });
+	}
+}
+
+function collectNonDefaultAISettings(configurationService: IConfigurationService): IAIDiagnosticsSetting[] {
+	const properties = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).getConfigurationProperties();
+	const keys = Object.keys(properties)
+		.filter(key => AI_SETTING_EXACT_KEYS.includes(key) || AI_SETTING_PREFIXES.some(prefix => key.startsWith(prefix)))
+		.sort();
+
+	const settings: IAIDiagnosticsSetting[] = [];
+	for (const key of keys) {
+		const inspected = configurationService.inspect(key);
+		if (hasExplicitValue(inspected)) {
+			settings.push({ key, value: isSensitiveSettingKey(key) ? REDACTED_VALUE : inspected.value });
+		}
+	}
+	return settings;
+}
+
+/**
+ * Best-effort activation, bounded by {@link BRIDGE_TIMEOUT_MS} so a stuck
+ * extension can't hang the report. Resolves whether or not activation finished.
+ */
+async function activateWithTimeout(extensionService: IExtensionService, id: string): Promise<void> {
+	const identifier = new ExtensionIdentifier(id);
+	await raceTimeout(
+		extensionService.activateById(identifier, { startup: false, extensionId: identifier, activationEvent: 'api' }),
+		BRIDGE_TIMEOUT_MS,
+	);
+}
+
+async function collectBridgedLogs(
+	source: { label: string; id: string; command: string },
+	extensionService: IExtensionService,
+	commandService: ICommandService,
+): Promise<string> {
+	// Activate first so the extension's bridge command is registered before we
+	// call it, which avoids CommandService's fallback of star-activating every
+	// extension while waiting for the command to appear. The bridge command is
+	// registered at the very start of activate(), so it resolves even if the
+	// rest of activation is still pending. Bounded so a stuck extension can't
+	// hang the whole report.
+	const collect = async (): Promise<string> => {
+		await activateWithTimeout(extensionService, source.id);
+		const content = await commandService.executeCommand<string>(source.command);
+		return capLogLines(content ?? 'No log entries available');
+	};
+	try {
+		const result = await raceTimeout(collect(), BRIDGE_TIMEOUT_MS);
+		return result ?? `Logs unavailable: timed out after ${BRIDGE_TIMEOUT_MS}ms (extension may be stuck activating)`;
+	} catch (error) {
+		return `Logs unavailable: ${error instanceof Error ? error.message : String(error)}`;
+	}
+}
+
+/**
+ * Asks the authentication extension which providers the user is authenticated
+ * with and which are disabled, via its bridge command. Returns empty lists when
+ * auth isn't installed or the call fails, so the report shows "None" rather than
+ * erroring.
+ */
+async function collectProviderDiagnostics(
+	extensionService: IExtensionService,
+	commandService: ICommandService,
+): Promise<IProviderDiagnostics> {
+	const empty: IProviderDiagnostics = { authenticated: [], disabled: [] };
+	if (!await extensionService.getExtension(AUTH_EXTENSION_ID)) {
+		return empty;
+	}
+	const collect = async (): Promise<IProviderDiagnostics> => {
+		await activateWithTimeout(extensionService, AUTH_EXTENSION_ID);
+		return (await commandService.executeCommand<IProviderDiagnostics>(AUTH_PROVIDERS_COMMAND)) ?? empty;
+	};
+	try {
+		return (await raceTimeout(collect(), BRIDGE_TIMEOUT_MS)) ?? empty;
+	} catch {
+		return empty;
+	}
+}
+
+async function collectCopilotLogs(
+	channel: { label: string; extensionId: string },
+	extensionService: IExtensionService,
+	outputService: IOutputService,
+	fileService: IFileService,
+): Promise<string> {
+	// Copilot registers its output channel during activation, so activate it
+	// first (we only get here when Copilot is enabled) or the descriptor lookup
+	// finds nothing when Copilot hasn't been used yet this session.
+	await activateWithTimeout(extensionService, channel.extensionId);
+
+	const descriptor = outputService.getChannelDescriptors().find(d => d.extensionId === channel.extensionId);
+	if (!descriptor) {
+		return 'Output channel not available';
+	}
+
+	const resources = isSingleSourceOutputChannelDescriptor(descriptor)
+		? [descriptor.source.resource]
+		: isMultiSourceOutputChannelDescriptor(descriptor)
+			? descriptor.source.map(s => s.resource)
+			: [];
+	if (resources.length === 0) {
+		return 'No log file available';
+	}
+
+	const parts: string[] = [];
+	for (const resource of resources) {
+		try {
+			const file = await fileService.readFile(resource);
+			parts.push(file.value.toString());
+		} catch (error) {
+			parts.push(`Could not read ${resource.toString()}: ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}
+	return capLogLines(parts.join('\n'));
+}

--- a/src/vs/workbench/contrib/positronAssistant/browser/aiDiagnostics.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/aiDiagnostics.ts
@@ -140,7 +140,7 @@ export function generateAIDiagnosticsReport(inputs: IAIDiagnosticsInputs): strin
 
 Generated: ${inputs.generatedAt}
 
-**Privacy Notice**: This report includes extension versions, non-default configuration settings, provider connection config, system information, and recent log entries. It does NOT include API keys or authentication tokens (those are stored separately, not in settings or providers.json), and custom header values are redacted. However, configured base URLs may reveal internal endpoints. Please review before sharing.
+**Privacy Notice**: This report includes extension versions, non-default configuration settings, provider connection config, system information, and recent log entries. Known secret fields are redacted: API keys, tokens, and custom header values are replaced with \`<redacted>\`, and keys/tokens are stored separately from settings and providers.json to begin with. Everything else is shown as you configured it, including base URLs (which may reveal internal endpoints) and connection settings. Please read through the whole report and remove anything sensitive before you share it.
 
 ## Version Information
 

--- a/src/vs/workbench/contrib/positronAssistant/browser/positronAssistant.contribution.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/positronAssistant.contribution.ts
@@ -29,6 +29,7 @@ import { PositronAssistantToolsContribution } from './tools/positronAssistantToo
 import { IAiProviderService } from '../../../services/positronAiProvider/common/aiProviderService.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';
+import { CreateAIDiagnosticReportAction } from './aiDiagnostics.js';
 // Importing this module also registers the `ai.enabled` main switch for Positron's AI features.
 import { AI_ENABLED_KEY } from '../common/positronAIConfiguration.js';
 
@@ -38,6 +39,9 @@ import './inlineCompletionsMigration.js';
 
 // Register the commit message generation feature.
 registerCommitMessageGeneration();
+
+// Register the "AI: Create Diagnostic Report" command.
+registerAction2(CreateAIDiagnosticReportAction);
 
 const consoleLanguageIds = ['r', 'python'];
 

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/aiDiagnostics.vitest.ts
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/aiDiagnostics.vitest.ts
@@ -33,6 +33,28 @@ function inputs(overrides: Partial<IAIDiagnosticsInputs> = {}): IAIDiagnosticsIn
 		],
 		authenticatedProviders: ['GitHub Copilot', 'Posit AI'],
 		disabledProviders: ['DeepSeek', 'Snowflake Cortex'],
+		modelListing: {
+			queriedProviders: ['positai', 'copilot', 'deepseek'],
+			models: [
+				{ id: 'claude-sonnet-4-5', name: 'Claude Sonnet 4.5', vendor: 'Anthropic', providerId: 'positai' },
+				// Vendor is what the provider branded it as, so an OpenAI-compatible
+				// gateway reports "OpenAI" for a Google model. It must still group
+				// under the provider that returned it.
+				{ id: 'google/gemma-4-26B', name: 'Gemma 4 26B', vendor: 'OpenAI', providerId: 'positai' },
+				// Copilot offers a model Posit AI also offers. It loses the service's
+				// dedupe, so it only reaches the report because the listing is
+				// reported pre-dedupe.
+				{ id: 'claude-sonnet-4-5', name: 'Claude Sonnet 4.5', vendor: 'Anthropic', providerId: 'copilot' },
+				{ id: 'gpt-5', name: 'gpt-5', vendor: 'OpenAI', providerId: 'copilot' },
+			],
+		},
+		builtinModels: [
+			// `gpt-5` also came back from the provider sweep below, so it must not
+			// be listed twice under copilot.
+			{ id: 'gpt-5', name: 'GPT-5', provider: 'copilot' },
+			{ id: 'gemini-3-pro', name: 'Gemini 3 Pro', provider: 'copilot' },
+		],
+		modelsIncomplete: false,
 		providersConfig: '{\n  "version": 1,\n  "providers": {\n    "anthropic": {\n      "enabled": true\n    }\n  }\n}',
 		providersConfigPath: '/home/user/.posit/ai/providers.json',
 		settings: [
@@ -54,7 +76,7 @@ describe('generateAIDiagnosticsReport', () => {
 
 			Generated: 2026-07-23T00:00:00.000Z
 
-			**Privacy Notice**: This report includes extension versions, non-default configuration settings, provider connection config, system information, and recent log entries. It does NOT include API keys or authentication tokens (those are stored separately, not in settings or providers.json), and custom header values are redacted. However, configured base URLs may reveal internal endpoints. Please review before sharing.
+			**Privacy Notice**: This report includes extension versions, non-default configuration settings, provider connection config, system information, and recent log entries. Known secret fields are redacted: API keys, tokens, and custom header values are replaced with \`<redacted>\`, and keys/tokens are stored separately from settings and providers.json to begin with. Everything else is shown as you configured it, including base URLs (which may reveal internal endpoints) and connection settings. Please read through the whole report and remove anything sensitive before you share it.
 
 			## Version Information
 
@@ -91,6 +113,25 @@ describe('generateAIDiagnosticsReport', () => {
 
 			- DeepSeek
 			- Snowflake Cortex
+
+			### Available Models
+
+			Models each provider offers (5 total).
+
+			**positai** (2)
+
+			- \`claude-sonnet-4-5\` (Claude Sonnet 4.5, Anthropic)
+			- \`google/gemma-4-26B\` (Gemma 4 26B, OpenAI)
+
+			**copilot** (3)
+
+			- \`claude-sonnet-4-5\` (Claude Sonnet 4.5, Anthropic)
+			- \`gpt-5\` (OpenAI)
+			- \`gemini-3-pro\` (Gemini 3 Pro)
+
+			**deepseek** (0)
+
+			Queried, but returned no models.
 
 			### Configuration
 
@@ -154,6 +195,54 @@ describe('generateAIDiagnosticsReport', () => {
 		const report = generateAIDiagnosticsReport(inputs({ authenticatedProviders: [], disabledProviders: [] }));
 		expect(report).toContain('### Authenticated\n\nNone');
 		expect(report).toContain('### Disabled\n\nNone');
+	});
+
+	it('explains the empty case rather than showing a bare "None" for available models', () => {
+		const report = generateAIDiagnosticsReport(inputs({ modelListing: { queriedProviders: [], models: [] }, builtinModels: [] }));
+		expect(report).toContain('None. No provider was queried (each was disabled, had no registered auth backend, or had no credentials) and no extension registered a chat model.');
+	});
+
+	it('shows a queried provider that returned nothing instead of omitting it', () => {
+		const report = generateAIDiagnosticsReport(inputs({
+			modelListing: { queriedProviders: ['positai', 'copilot'], models: [] },
+			builtinModels: [],
+		}));
+		expect(report).toContain('**copilot** (0)\n\nQueried, but returned no models.');
+	});
+
+	it('lists a model under every provider that offers it, not just the one that wins de-duplication', () => {
+		const report = generateAIDiagnosticsReport(inputs());
+		expect(report.split('`claude-sonnet-4-5`')).toHaveLength(3);
+	});
+
+	it('lists built-in language model API models under the same provider heading, without duplicating a model both sources report', () => {
+		const report = generateAIDiagnosticsReport(inputs());
+		// One copilot group holding both sources' models, and `gpt-5` once.
+		expect(report).toContain('**copilot** (3)\n\n- `claude-sonnet-4-5` (Claude Sonnet 4.5, Anthropic)\n- `gpt-5` (OpenAI)\n- `gemini-3-pro` (Gemini 3 Pro)');
+		expect(report.split('`gpt-5`')).toHaveLength(2);
+	});
+
+	it('gives a provider only the built-in API knows about its own heading', () => {
+		const report = generateAIDiagnosticsReport(inputs({
+			modelListing: { queriedProviders: [], models: [] },
+			builtinModels: [{ id: 'gpt-5', name: 'GPT-5', provider: 'copilot' }],
+		}));
+		expect(report).toContain('**copilot** (1)\n\n- `gpt-5` (GPT-5)');
+	});
+
+	it('says the model listing could not be retrieved rather than claiming there are none', () => {
+		const report = generateAIDiagnosticsReport(inputs({
+			modelListing: { queriedProviders: [], models: [] },
+			builtinModels: [],
+			modelsIncomplete: true,
+		}));
+		expect(report).toContain('Could not be retrieved in time. Re-run the report: the listing is cached once it succeeds, so a second run usually has it.');
+	});
+
+	it('flags a partial model listing while still showing what came back', () => {
+		const report = generateAIDiagnosticsReport(inputs({ modelsIncomplete: true }));
+		expect(report).toContain('Some providers did not respond in time, so this list may be incomplete.');
+		expect(report).toContain('**positai** (2)');
 	});
 
 	it('renders a placeholder in the JSON fence and omits the path when providers.json is unavailable', () => {

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/aiDiagnostics.vitest.ts
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/aiDiagnostics.vitest.ts
@@ -5,13 +5,14 @@
 
 /// <reference types="vitest/globals" />
 
-import { capLogLines, describeExtensionStatus, describeFeatureToggle, generateAIDiagnosticsReport, hasExplicitValue, IAIDiagnosticsInputs, isSensitiveSettingKey } from '../../browser/aiDiagnostics.js';
+import { capLogLines, describeExtensionStatus, describeFeatureToggle, featureState, generateAIDiagnosticsReport, hasExplicitValue, IAIDiagnosticsInputs, isSensitiveSettingKey } from '../../browser/aiDiagnostics.js';
 
 function inputs(overrides: Partial<IAIDiagnosticsInputs> = {}): IAIDiagnosticsInputs {
 	return {
 		generatedAt: '2026-07-23T00:00:00.000Z',
 		aiEnabled: true,
 		features: [
+			{ label: 'Posit Assistant', setting: 'assistant.enabled', state: 'Enabled' },
 			{ label: 'Posit AI NES', setting: 'nextEditSuggestions.enabled', state: 'Enabled' },
 			{ label: 'Notebook AI', setting: 'notebook.ai.enabled', state: 'Disabled' },
 			{ label: 'Console Fix & Explain', setting: 'console.assistantActions.enabled', state: 'Enabled' },
@@ -71,6 +72,7 @@ describe('generateAIDiagnosticsReport', () => {
 			## AI Features
 
 			- AI features (\`ai.enabled\`): Enabled
+			- Posit Assistant (\`assistant.enabled\`): Enabled
 			- Posit AI NES (\`nextEditSuggestions.enabled\`): Enabled
 			- Notebook AI (\`notebook.ai.enabled\`): Disabled
 			- Console Fix & Explain (\`console.assistantActions.enabled\`): Enabled
@@ -158,6 +160,24 @@ describe('describeFeatureToggle', () => {
 			def: describeFeatureToggle(undefined),
 			object: describeFeatureToggle({ '*': true, markdown: false }),
 		}).toEqual({ on: 'Enabled', off: 'Disabled', def: 'Enabled', object: '{"*":true,"markdown":false}' });
+	});
+});
+
+describe('featureState', () => {
+	it('reports "not installed" when the owning extension is absent, else the toggle', () => {
+		expect({
+			absent: featureState(false, undefined),
+			absentIgnoresValue: featureState(false, true),
+			installedOn: featureState(true, true),
+			installedOff: featureState(true, false),
+			installedDefault: featureState(true, undefined),
+		}).toEqual({
+			absent: 'Not installed',
+			absentIgnoresValue: 'Not installed',
+			installedOn: 'Enabled',
+			installedOff: 'Disabled',
+			installedDefault: 'Enabled',
+		});
 	});
 });
 

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/aiDiagnostics.vitest.ts
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/aiDiagnostics.vitest.ts
@@ -28,8 +28,8 @@ function inputs(overrides: Partial<IAIDiagnosticsInputs> = {}): IAIDiagnosticsIn
 		os: 'Mac',
 		remote: undefined,
 		extensions: [
-			{ label: 'Authentication', id: 'positron.authentication', version: '1.0.0', status: 'active' },
-			{ label: 'Posit AI NES', id: 'positron.next-edit-suggestions', version: undefined },
+			{ label: 'Authentication', id: 'positron.authentication', presence: 'running', version: '1.0.0', status: 'active' },
+			{ label: 'Posit AI NES', id: 'positron.next-edit-suggestions', presence: 'missing', version: undefined },
 		],
 		authenticatedProviders: ['GitHub Copilot', 'Posit AI'],
 		disabledProviders: ['DeepSeek', 'Snowflake Cortex'],
@@ -61,6 +61,7 @@ function inputs(overrides: Partial<IAIDiagnosticsInputs> = {}): IAIDiagnosticsIn
 			{ key: 'ai.enabled', value: false },
 			{ key: 'nextEditSuggestions.enabled', value: { python: true } },
 		],
+		enforcedSettings: [],
 		logs: [
 			{ label: 'Authentication', content: '[2026-07-23T00:00:00.000Z] TRACE signed in' },
 			{ label: 'Posit AI NES', content: 'Extension not installed' },
@@ -174,6 +175,40 @@ describe('generateAIDiagnosticsReport', () => {
 		`);
 	});
 
+	it('distinguishes an installed-but-disabled extension from one that is absent', () => {
+		const report = generateAIDiagnosticsReport(inputs({
+			extensions: [
+				{ label: 'Posit Assistant', id: 'posit.assistant', presence: 'disabled', version: '2.0.0' },
+				{ label: 'Posit AI NES', id: 'positron.next-edit-suggestions', presence: 'missing', version: undefined },
+			],
+		}));
+		expect(report).toContain('- Posit Assistant: Version 2.0.0 (installed but disabled)');
+		expect(report).toContain('- Posit AI NES: Not installed');
+	});
+
+	it('renders manifest and runtime error text beneath the extension, not just a count', () => {
+		const report = generateAIDiagnosticsReport(inputs({
+			extensions: [{
+				label: 'Authentication',
+				id: 'positron.authentication',
+				presence: 'running',
+				version: '1.0.0',
+				status: 'active, 1 runtime error',
+				messages: ['Cannot read properties of undefined (reading \'baseUrl\')'],
+			}],
+		}));
+		expect(report).toContain('- Authentication: Version 1.0.0 (active, 1 runtime error)\n  - Cannot read properties of undefined (reading \'baseUrl\')');
+	});
+
+	it('adds an enforced-settings section only when an admin enforced something', () => {
+		expect(generateAIDiagnosticsReport(inputs())).not.toContain('## Admin Enforced Settings');
+		const report = generateAIDiagnosticsReport(inputs({
+			enforcedSettings: [{ key: 'ai.enabled', value: 'false' }],
+		}));
+		expect(report).toContain('## Admin Enforced Settings');
+		expect(report).toContain('- `ai.enabled`: false');
+	});
+
 	it('notes when no non-default settings are configured', () => {
 		const report = generateAIDiagnosticsReport(inputs({ settings: [] }));
 		expect(report).toContain('// No non-default settings configured');
@@ -245,6 +280,26 @@ describe('generateAIDiagnosticsReport', () => {
 		expect(report).toContain('**positai** (2)');
 	});
 
+	it('names a listing failure instead of describing it as a timeout', () => {
+		const report = generateAIDiagnosticsReport(inputs({
+			modelListing: { queriedProviders: [], models: [] },
+			builtinModels: [],
+			modelsIncomplete: true,
+			modelsIncompleteReason: 'AI provider catalog unavailable',
+		}));
+		expect(report).toContain('Could not be retrieved: AI provider catalog unavailable');
+		expect(report).not.toContain('in time');
+	});
+
+	it('names a listing failure on a partial list too', () => {
+		const report = generateAIDiagnosticsReport(inputs({
+			modelsIncomplete: true,
+			modelsIncompleteReason: 'AI provider catalog unavailable',
+		}));
+		expect(report).toContain('This list may be incomplete: AI provider catalog unavailable');
+		expect(report).toContain('**positai** (2)');
+	});
+
 	it('renders a placeholder in the JSON fence and omits the path when providers.json is unavailable', () => {
 		const report = generateAIDiagnosticsReport(inputs({ providersConfig: '// Provider catalog unavailable', providersConfigPath: undefined }));
 		expect(report).toContain('Provider configuration from `providers.json`:\n\n```json\n// Provider catalog unavailable\n```');
@@ -275,19 +330,21 @@ describe('describeFeatureToggle', () => {
 });
 
 describe('featureState', () => {
-	it('reports "not installed" when the owning extension is absent, else the toggle', () => {
+	it('reports the extension\'s presence when it is not running, else the toggle', () => {
 		expect({
-			absent: featureState(false, undefined),
-			absentIgnoresValue: featureState(false, true),
-			installedOn: featureState(true, true),
-			installedOff: featureState(true, false),
-			installedDefault: featureState(true, undefined),
+			absent: featureState('missing', undefined),
+			absentIgnoresValue: featureState('missing', true),
+			disabled: featureState('disabled', true),
+			runningOn: featureState('running', true),
+			runningOff: featureState('running', false),
+			runningDefault: featureState('running', undefined),
 		}).toEqual({
 			absent: 'Not installed',
 			absentIgnoresValue: 'Not installed',
-			installedOn: 'Enabled',
-			installedOff: 'Disabled',
-			installedDefault: 'Enabled',
+			disabled: 'Installed but disabled',
+			runningOn: 'Enabled',
+			runningOff: 'Disabled',
+			runningDefault: 'Enabled',
 		});
 	});
 });

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/aiDiagnostics.vitest.ts
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/aiDiagnostics.vitest.ts
@@ -1,0 +1,197 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { capLogLines, describeExtensionStatus, generateAIDiagnosticsReport, hasExplicitValue, IAIDiagnosticsInputs, isSensitiveSettingKey } from '../../browser/aiDiagnostics.js';
+
+function inputs(overrides: Partial<IAIDiagnosticsInputs> = {}): IAIDiagnosticsInputs {
+	return {
+		generatedAt: '2026-07-23T00:00:00.000Z',
+		application: 'Positron',
+		positronVersion: '2026.07.0',
+		positronBuildNumber: 42,
+		vscodeVersion: '1.99.0',
+		commit: 'abc123',
+		buildDate: '2026-07-20T12:00:00.000Z',
+		quality: 'stable',
+		os: 'Mac',
+		remote: undefined,
+		extensions: [
+			{ label: 'Authentication', id: 'positron.authentication', version: '1.0.0', status: 'active' },
+			{ label: 'Posit AI NES', id: 'positron.next-edit-suggestions', version: undefined },
+		],
+		authenticatedProviders: ['GitHub Copilot', 'Posit AI'],
+		disabledProviders: ['DeepSeek', 'Snowflake Cortex'],
+		settings: [
+			{ key: 'ai.enabled', value: false },
+			{ key: 'nextEditSuggestions.enabled', value: { python: true } },
+		],
+		logs: [
+			{ label: 'Authentication', content: '[2026-07-23T00:00:00.000Z] TRACE signed in' },
+			{ label: 'Posit AI NES', content: 'Extension not installed' },
+		],
+		...overrides,
+	};
+}
+
+describe('generateAIDiagnosticsReport', () => {
+	it('renders versions, settings, extensions, and per-surface logs', () => {
+		expect(generateAIDiagnosticsReport(inputs())).toMatchInlineSnapshot(`
+			"# AI Diagnostic Report
+
+			Generated: 2026-07-23T00:00:00.000Z
+
+			**Privacy Notice**: This report includes extension versions, non-default configuration settings, system information, and recent log entries. It does NOT include API keys or authentication tokens (those are stored separately, not in settings). However, configured base URLs may reveal internal endpoints. Please review before sharing.
+
+			## Version Information
+
+			- Application: Positron
+			- Positron: 2026.07.0 build 42
+			- Code OSS: 1.99.0
+			- Commit: abc123
+			- Build date: 2026-07-20T12:00:00.000Z
+			- Quality: stable
+			- OS: Mac
+
+			### Extensions
+
+			- Authentication: Version 1.0.0 (active)
+			- Posit AI NES: Not installed
+
+			## Authenticated Providers
+
+			- GitHub Copilot
+			- Posit AI
+
+			## Disabled Providers
+
+			- DeepSeek
+			- Snowflake Cortex
+
+			## Configuration Settings
+
+			Non-default AI-related settings:
+
+			\`\`\`json
+			  "ai.enabled": false,
+			  "nextEditSuggestions.enabled": {
+			    "python": true
+			  }
+			\`\`\`
+
+			## Authentication Logs
+
+			\`\`\`
+			[2026-07-23T00:00:00.000Z] TRACE signed in
+			\`\`\`
+
+			## Posit AI NES Logs
+
+			\`\`\`
+			Extension not installed
+			\`\`\`
+			"
+		`);
+	});
+
+	it('notes when no non-default settings are configured', () => {
+		const report = generateAIDiagnosticsReport(inputs({ settings: [] }));
+		expect(report).toContain('// No non-default settings configured');
+	});
+
+	it('includes the remote line only when a remote authority is present', () => {
+		expect(generateAIDiagnosticsReport(inputs({ remote: 'ssh-remote+host' }))).toContain('- Remote: ssh-remote+host');
+		expect(generateAIDiagnosticsReport(inputs())).not.toContain('- Remote:');
+	});
+
+	it('omits optional version lines when their values are absent', () => {
+		const report = generateAIDiagnosticsReport(inputs({ commit: undefined, buildDate: undefined, quality: undefined }));
+		expect(report).not.toContain('- Commit:');
+		expect(report).not.toContain('- Build date:');
+		expect(report).not.toContain('- Quality:');
+	});
+
+	it('shows "None" for authenticated and disabled providers when both are empty', () => {
+		const report = generateAIDiagnosticsReport(inputs({ authenticatedProviders: [], disabledProviders: [] }));
+		expect(report).toContain('## Authenticated Providers\n\nNone');
+		expect(report).toContain('## Disabled Providers\n\nNone');
+	});
+});
+
+describe('isSensitiveSettingKey', () => {
+	it('flags credential and auth-token keys for redaction, leaves others alone', () => {
+		const sensitive = [
+			'authentication.anthropic.customHeaders',
+			'authentication.openai-api.apiKey',
+			'provider.accessToken',
+			'foo.clientSecret',
+			'db.password',
+		];
+		const safe = [
+			'ai.enabled',
+			'authentication.anthropic.baseUrl',
+			// Named "credentials" but holds non-secret config vars (profile, region, account).
+			'authentication.aws.credentials',
+			'authentication.snowflake.credentials',
+			'nextEditSuggestions.enabled',
+			'console.assistantActions.enabled',
+		];
+		expect({
+			sensitive: sensitive.filter(isSensitiveSettingKey),
+			safe: safe.filter(isSensitiveSettingKey),
+		}).toEqual({ sensitive, safe: [] });
+	});
+});
+
+describe('hasExplicitValue', () => {
+	it('is true when a value is set at any scope, false when everything is default', () => {
+		expect({
+			default: hasExplicitValue({}),
+			user: hasExplicitValue({ userValue: false }),
+			workspace: hasExplicitValue({ workspaceValue: { a: 1 } }),
+			policy: hasExplicitValue({ policyValue: true }),
+		}).toEqual({ default: false, user: true, workspace: true, policy: true });
+	});
+
+	it('treats an explicit falsy value as set', () => {
+		// `false` / `''` / `0` are real values, not "unset" - the ?? chain must keep them.
+		expect(hasExplicitValue({ userValue: false })).toBe(true);
+		expect(hasExplicitValue({ workspaceValue: '' })).toBe(true);
+	});
+});
+
+describe('describeExtensionStatus', () => {
+	it('summarizes activation state and runtime errors', () => {
+		expect({
+			missing: describeExtensionStatus(undefined),
+			notStarted: describeExtensionStatus({ activationStarted: false, activationTimes: undefined, runtimeErrors: [] }),
+			active: describeExtensionStatus({ activationStarted: true, activationTimes: {}, runtimeErrors: [] }),
+			activating: describeExtensionStatus({ activationStarted: true, activationTimes: undefined, runtimeErrors: [] }),
+			withErrors: describeExtensionStatus({ activationStarted: true, activationTimes: {}, runtimeErrors: [new Error('a'), new Error('b')] }),
+			oneError: describeExtensionStatus({ activationStarted: true, activationTimes: undefined, runtimeErrors: [new Error('a')] }),
+		}).toEqual({
+			missing: 'not activated',
+			notStarted: 'not activated',
+			active: 'active',
+			activating: 'activation started, not finished',
+			withErrors: 'active, 2 runtime errors',
+			oneError: 'activation started, not finished, 1 runtime error',
+		});
+	});
+});
+
+describe('capLogLines', () => {
+	it('keeps content under the cap and trims to the most recent lines over it', () => {
+		const under = 'a\nb\nc';
+		const over = Array.from({ length: 600 }, (_, i) => `line ${i}`).join('\n');
+		const capped = capLogLines(over).split('\n');
+		expect({
+			underUnchanged: capLogLines(under) === under,
+			cappedLineCount: capped.length,
+			keptMostRecent: capped[capped.length - 1],
+		}).toEqual({ underUnchanged: true, cappedLineCount: 500, keptMostRecent: 'line 599' });
+	});
+});

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/aiDiagnostics.vitest.ts
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/aiDiagnostics.vitest.ts
@@ -5,7 +5,7 @@
 
 /// <reference types="vitest/globals" />
 
-import { capLogLines, describeExtensionStatus, describeFeatureToggle, featureState, generateAIDiagnosticsReport, hasExplicitValue, IAIDiagnosticsInputs, isSensitiveSettingKey } from '../../browser/aiDiagnostics.js';
+import { capLogLines, describeExtensionStatus, describeFeatureToggle, featureState, generateAIDiagnosticsReport, hasExplicitValue, IAIDiagnosticsInputs, isSensitiveSettingKey, redactProvidersConfig } from '../../browser/aiDiagnostics.js';
 
 function inputs(overrides: Partial<IAIDiagnosticsInputs> = {}): IAIDiagnosticsInputs {
 	return {
@@ -33,6 +33,8 @@ function inputs(overrides: Partial<IAIDiagnosticsInputs> = {}): IAIDiagnosticsIn
 		],
 		authenticatedProviders: ['GitHub Copilot', 'Posit AI'],
 		disabledProviders: ['DeepSeek', 'Snowflake Cortex'],
+		providersConfig: '{\n  "version": 1,\n  "providers": {\n    "anthropic": {\n      "enabled": true\n    }\n  }\n}',
+		providersConfigPath: '/home/user/.posit/ai/providers.json',
 		settings: [
 			{ key: 'ai.enabled', value: false },
 			{ key: 'nextEditSuggestions.enabled', value: { python: true } },
@@ -52,7 +54,7 @@ describe('generateAIDiagnosticsReport', () => {
 
 			Generated: 2026-07-23T00:00:00.000Z
 
-			**Privacy Notice**: This report includes extension versions, non-default configuration settings, system information, and recent log entries. It does NOT include API keys or authentication tokens (those are stored separately, not in settings). However, configured base URLs may reveal internal endpoints. Please review before sharing.
+			**Privacy Notice**: This report includes extension versions, non-default configuration settings, provider connection config, system information, and recent log entries. It does NOT include API keys or authentication tokens (those are stored separately, not in settings or providers.json), and custom header values are redacted. However, configured base URLs may reveal internal endpoints. Please review before sharing.
 
 			## Version Information
 
@@ -89,6 +91,21 @@ describe('generateAIDiagnosticsReport', () => {
 
 			- DeepSeek
 			- Snowflake Cortex
+
+			### Configuration
+
+			Provider configuration from \`providers.json\` (\`/home/user/.posit/ai/providers.json\`):
+
+			\`\`\`json
+			{
+			  "version": 1,
+			  "providers": {
+			    "anthropic": {
+			      "enabled": true
+			    }
+			  }
+			}
+			\`\`\`
 
 			## Configuration Settings
 
@@ -137,6 +154,11 @@ describe('generateAIDiagnosticsReport', () => {
 		const report = generateAIDiagnosticsReport(inputs({ authenticatedProviders: [], disabledProviders: [] }));
 		expect(report).toContain('### Authenticated\n\nNone');
 		expect(report).toContain('### Disabled\n\nNone');
+	});
+
+	it('renders a placeholder in the JSON fence and omits the path when providers.json is unavailable', () => {
+		const report = generateAIDiagnosticsReport(inputs({ providersConfig: '// Provider catalog unavailable', providersConfigPath: undefined }));
+		expect(report).toContain('Provider configuration from `providers.json`:\n\n```json\n// Provider catalog unavailable\n```');
 	});
 
 	it('adds the Assistant bundle section only when a bundle was requested', () => {
@@ -203,6 +225,48 @@ describe('isSensitiveSettingKey', () => {
 			sensitive: sensitive.filter(isSensitiveSettingKey),
 			safe: safe.filter(isSensitiveSettingKey),
 		}).toEqual({ sensitive, safe: [] });
+	});
+});
+
+describe('redactProvidersConfig', () => {
+	it('keeps non-secret config verbatim, redacts custom header values (keeping names) and whole secret keys', () => {
+		const raw = JSON.stringify({
+			version: 1,
+			providers: {
+				anthropic: { enabled: true, baseUrl: 'https://api.anthropic.com/v1' },
+				gateway: {
+					enabled: true,
+					baseUrl: 'https://gateway.example.com/v1',
+					customHeaders: { Authorization: 'Bearer sk-secret', 'x-org': 'acme' },
+					apiKey: 'sk-should-not-be-here',
+				},
+			},
+		});
+		expect(redactProvidersConfig(raw)).toMatchInlineSnapshot(`
+			"{
+			  "version": 1,
+			  "providers": {
+			    "anthropic": {
+			      "enabled": true,
+			      "baseUrl": "https://api.anthropic.com/v1"
+			    },
+			    "gateway": {
+			      "enabled": true,
+			      "baseUrl": "https://gateway.example.com/v1",
+			      "customHeaders": {
+			        "Authorization": "<redacted>",
+			        "x-org": "<redacted>"
+			      },
+			      "apiKey": "<redacted>"
+			    }
+			  }
+			}"
+		`);
+	});
+
+	it('parses tolerantly (comments / trailing commas) and returns the raw text when it cannot parse', () => {
+		expect(redactProvidersConfig('{\n  // a comment\n  "version": 1,\n}')).toBe('{\n  "version": 1\n}');
+		expect(redactProvidersConfig('not json at all')).toBe('not json at all');
 	});
 });
 

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/aiDiagnostics.vitest.ts
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/aiDiagnostics.vitest.ts
@@ -5,11 +5,18 @@
 
 /// <reference types="vitest/globals" />
 
-import { capLogLines, describeExtensionStatus, generateAIDiagnosticsReport, hasExplicitValue, IAIDiagnosticsInputs, isSensitiveSettingKey } from '../../browser/aiDiagnostics.js';
+import { capLogLines, describeExtensionStatus, describeFeatureToggle, generateAIDiagnosticsReport, hasExplicitValue, IAIDiagnosticsInputs, isSensitiveSettingKey } from '../../browser/aiDiagnostics.js';
 
 function inputs(overrides: Partial<IAIDiagnosticsInputs> = {}): IAIDiagnosticsInputs {
 	return {
 		generatedAt: '2026-07-23T00:00:00.000Z',
+		aiEnabled: true,
+		features: [
+			{ label: 'Posit AI NES', setting: 'nextEditSuggestions.enabled', state: 'Enabled' },
+			{ label: 'Notebook AI', setting: 'notebook.ai.enabled', state: 'Disabled' },
+			{ label: 'Console Fix & Explain', setting: 'console.assistantActions.enabled', state: 'Enabled' },
+			{ label: 'GitHub Copilot Chat', setting: 'chat.disableAIFeatures', state: 'Enabled' },
+		],
 		application: 'Positron',
 		positronVersion: '2026.07.0',
 		positronBuildNumber: 42,
@@ -61,12 +68,22 @@ describe('generateAIDiagnosticsReport', () => {
 			- Authentication: Version 1.0.0 (active)
 			- Posit AI NES: Not installed
 
-			## Authenticated Providers
+			## AI Features
+
+			- AI features (\`ai.enabled\`): Enabled
+			- Posit AI NES (\`nextEditSuggestions.enabled\`): Enabled
+			- Notebook AI (\`notebook.ai.enabled\`): Disabled
+			- Console Fix & Explain (\`console.assistantActions.enabled\`): Enabled
+			- GitHub Copilot Chat (\`chat.disableAIFeatures\`): Enabled
+
+			## Providers
+
+			### Authenticated
 
 			- GitHub Copilot
 			- Posit AI
 
-			## Disabled Providers
+			### Disabled
 
 			- DeepSeek
 			- Snowflake Cortex
@@ -116,8 +133,25 @@ describe('generateAIDiagnosticsReport', () => {
 
 	it('shows "None" for authenticated and disabled providers when both are empty', () => {
 		const report = generateAIDiagnosticsReport(inputs({ authenticatedProviders: [], disabledProviders: [] }));
-		expect(report).toContain('## Authenticated Providers\n\nNone');
-		expect(report).toContain('## Disabled Providers\n\nNone');
+		expect(report).toContain('### Authenticated\n\nNone');
+		expect(report).toContain('### Disabled\n\nNone');
+	});
+
+	it('flags when the ai.enabled main switch is off', () => {
+		expect(generateAIDiagnosticsReport(inputs({ aiEnabled: false })))
+			.toContain('- AI features (`ai.enabled`): **Disabled - all AI features below are off regardless of their own settings**');
+		expect(generateAIDiagnosticsReport(inputs())).toContain('- AI features (`ai.enabled`): Enabled');
+	});
+});
+
+describe('describeFeatureToggle', () => {
+	it('maps booleans and defaults to Enabled/Disabled, shows other values raw', () => {
+		expect({
+			on: describeFeatureToggle(true),
+			off: describeFeatureToggle(false),
+			def: describeFeatureToggle(undefined),
+			object: describeFeatureToggle({ '*': true, markdown: false }),
+		}).toEqual({ on: 'Enabled', off: 'Disabled', def: 'Enabled', object: '{"*":true,"markdown":false}' });
 	});
 });
 

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/aiDiagnostics.vitest.ts
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/aiDiagnostics.vitest.ts
@@ -137,6 +137,12 @@ describe('generateAIDiagnosticsReport', () => {
 		expect(report).toContain('### Disabled\n\nNone');
 	});
 
+	it('adds the Assistant bundle section only when a bundle was requested', () => {
+		expect(generateAIDiagnosticsReport(inputs())).not.toContain('## Assistant Diagnostics Bundle');
+		expect(generateAIDiagnosticsReport(inputs({ bundle: 'Requested (with attachments).' })))
+			.toContain('## Assistant Diagnostics Bundle\n\nRequested (with attachments).');
+	});
+
 	it('flags when the ai.enabled main switch is off', () => {
 		expect(generateAIDiagnosticsReport(inputs({ aiEnabled: false })))
 			.toContain('- AI features (`ai.enabled`): **Disabled - all AI features below are off regardless of their own settings**');

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/AssistantPanel/notebookSuggestions.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/AssistantPanel/notebookSuggestions.vitest.ts
@@ -24,6 +24,7 @@ function fakeService(result: StreamTextResult): IHeadlessLanguageModelService {
 		_serviceBrand: undefined,
 		streamText: async () => result,
 		getAvailableModels: async () => [],
+		getModelListingDiagnostics: async () => [],
 		onDidChangeAvailableModels: Event.None,
 	};
 }

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/AssistantPanel/notebookSuggestions.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/AssistantPanel/notebookSuggestions.vitest.ts
@@ -24,7 +24,7 @@ function fakeService(result: StreamTextResult): IHeadlessLanguageModelService {
 		_serviceBrand: undefined,
 		streamText: async () => result,
 		getAvailableModels: async () => [],
-		getModelListingDiagnostics: async () => [],
+		getModelListingDiagnostics: async () => ({ queriedProviders: [], models: [] }),
 		onDidChangeAvailableModels: Event.None,
 	};
 }

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/ghostCell/ghostCellSuggestion.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/ghostCell/ghostCellSuggestion.vitest.ts
@@ -27,6 +27,7 @@ function fakeService(result: StreamTextResult): IHeadlessLanguageModelService {
 		_serviceBrand: undefined,
 		streamText: async () => result,
 		getAvailableModels: async () => [],
+		getModelListingDiagnostics: async () => [],
 		onDidChangeAvailableModels: Event.None,
 	};
 }

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/ghostCell/ghostCellSuggestion.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/ghostCell/ghostCellSuggestion.vitest.ts
@@ -27,7 +27,7 @@ function fakeService(result: StreamTextResult): IHeadlessLanguageModelService {
 		_serviceBrand: undefined,
 		streamText: async () => result,
 		getAvailableModels: async () => [],
-		getModelListingDiagnostics: async () => [],
+		getModelListingDiagnostics: async () => ({ queriedProviders: [], models: [] }),
 		onDidChangeAvailableModels: Event.None,
 	};
 }

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/visualize/visualizationSuggestion.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/visualize/visualizationSuggestion.vitest.ts
@@ -32,6 +32,7 @@ function fakeService(result: StreamTextResult): IHeadlessLanguageModelService {
 		_serviceBrand: undefined,
 		streamText: async () => result,
 		getAvailableModels: async () => [],
+		getModelListingDiagnostics: async () => [],
 		onDidChangeAvailableModels: Event.None,
 	};
 }

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/visualize/visualizationSuggestion.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/visualize/visualizationSuggestion.vitest.ts
@@ -32,7 +32,7 @@ function fakeService(result: StreamTextResult): IHeadlessLanguageModelService {
 		_serviceBrand: undefined,
 		streamText: async () => result,
 		getAvailableModels: async () => [],
-		getModelListingDiagnostics: async () => [],
+		getModelListingDiagnostics: async () => ({ queriedProviders: [], models: [] }),
 		onDidChangeAvailableModels: Event.None,
 	};
 }

--- a/src/vs/workbench/services/positronHeadlessLanguageModel/browser/abstractHeadlessLanguageModelService.ts
+++ b/src/vs/workbench/services/positronHeadlessLanguageModel/browser/abstractHeadlessLanguageModelService.ts
@@ -18,6 +18,7 @@ import {
 	FastCheap,
 	IAvailableModel,
 	IHeadlessLanguageModelService,
+	IModelListingDiagnostics,
 	IStreamTextRequest,
 	ModelSelection,
 	StreamTextResult,
@@ -28,10 +29,22 @@ import { type CredentialConfig, shapeCredentials } from 'ai-provider-bridge/cred
 
 interface IResolvedState {
 	readonly models: readonly IModelDescriptor[];
+	/**
+	 * Every model each provider returned, before the cross-provider de-duplication
+	 * that produces {@link models}. Kept for diagnostics: a provider whose models
+	 * all lost the dedupe contributes nothing to `models`, which otherwise looks
+	 * identical to the provider having returned nothing at all.
+	 */
+	readonly allModels: readonly IModelDescriptor[];
+	/** Providers actually queried this listing, whether or not they returned models. */
+	readonly queriedProviders: readonly string[];
 	readonly anyCredential: boolean;
 	/** Whether any enabled, registered provider was a candidate at all (vs. genuine absence). */
 	readonly anyProvider: boolean;
 }
+
+/** No engine, or the listing failed: nothing available, nothing queried. */
+const EMPTY_STATE: IResolvedState = { models: [], allModels: [], queriedProviders: [], anyCredential: false, anyProvider: false };
 
 /**
  * Built-in preference patterns for the fast/cheap model tier, tried in order
@@ -284,22 +297,41 @@ export abstract class AbstractHeadlessLanguageModelService extends Disposable im
 	}
 
 	async getAvailableModels(): Promise<readonly IAvailableModel[]> {
-		// A transient failure yields an empty list (the list API has no reason
-		// slot); the state cache self-heals so the next call can recover.
-		let state: IResolvedState;
+		const state = await this.resolveState();
+		return state.models.map(model => ({ id: model.id, name: model.name, vendor: model.vendor }));
+	}
+
+	async getModelListingDiagnostics(): Promise<IModelListingDiagnostics> {
+		const state = await this.resolveState();
+		return {
+			queriedProviders: state.queriedProviders,
+			models: state.allModels.map(model => ({
+				id: model.id,
+				name: model.name,
+				vendor: model.vendor,
+				providerId: model.providerId,
+			})),
+		};
+	}
+
+	/**
+	 * The cached listing state, or an empty one. A transient failure yields empty
+	 * (no accessor here has a reason slot); the state cache self-heals so the next
+	 * call can recover.
+	 */
+	private async resolveState(): Promise<IResolvedState> {
 		try {
-			state = await this._state.get();
+			return await this._state.get();
 		} catch (error) {
 			this._logService.warn(`[headless-lm] Listing available models failed: ${error}`);
-			return [];
+			return EMPTY_STATE;
 		}
-		return state.models.map(model => ({ id: model.id, name: model.name, vendor: model.vendor }));
 	}
 
 	private async computeState(): Promise<IResolvedState> {
 		const engine = this.getEngine();
 		if (!engine) {
-			return { models: [], anyCredential: false, anyProvider: false };
+			return EMPTY_STATE;
 		}
 
 		// Wait for the catalog snapshot before reading enablement/connection: a
@@ -341,8 +373,11 @@ export abstract class AbstractHeadlessLanguageModelService extends Disposable im
 			}
 		}));
 
+		const allModels = byPriority(listed.flat());
 		return {
-			models: distinct(byPriority(listed.flat()), model => model.id),
+			models: distinct(allModels, model => model.id),
+			allModels,
+			queriedProviders: credentialed.map(entry => entry.providerId),
 			anyCredential: credentialed.length > 0,
 			anyProvider: relevant.length > 0,
 		};

--- a/src/vs/workbench/services/positronHeadlessLanguageModel/browser/abstractHeadlessLanguageModelService.ts
+++ b/src/vs/workbench/services/positronHeadlessLanguageModel/browser/abstractHeadlessLanguageModelService.ts
@@ -302,7 +302,9 @@ export abstract class AbstractHeadlessLanguageModelService extends Disposable im
 	}
 
 	async getModelListingDiagnostics(): Promise<IModelListingDiagnostics> {
-		const state = await this.resolveState();
+		// Not resolveState(): its empty fallback would report a listing failure as
+		// "no provider was queried".
+		const state = await this._state.get();
 		return {
 			queriedProviders: state.queriedProviders,
 			models: state.allModels.map(model => ({

--- a/src/vs/workbench/services/positronHeadlessLanguageModel/common/headlessLanguageModelService.ts
+++ b/src/vs/workbench/services/positronHeadlessLanguageModel/common/headlessLanguageModelService.ts
@@ -42,6 +42,16 @@ export interface IHeadlessLanguageModelService {
 	getAvailableModels(): Promise<readonly IAvailableModel[]>;
 
 	/**
+	 * What each provider actually contributed, for the AI diagnostic report. Unlike
+	 * {@link getAvailableModels} this reports before de-duplication and names the
+	 * providers that were queried, so "my provider is signed in but none of its
+	 * models show up" has a visible answer. Feature code must use
+	 * `getAvailableModels`: requests select a model and the service picks the
+	 * provider, so branching on the provider id would route around that.
+	 */
+	getModelListingDiagnostics(): Promise<IModelListingDiagnostics>;
+
+	/**
 	 * Fires when the available-model set changes -- for example after a sign-in
 	 * or sign-out -- so a picker can stay current.
 	 */
@@ -150,6 +160,38 @@ export interface IAvailableModel {
 	readonly id: string;
 	/** A human-readable display name. */
 	readonly name: string;
-	/** The display vendor, for grouping in a picker (e.g. "Anthropic", "OpenAI"). */
+	/**
+	 * The vendor the model is branded under (e.g. "Anthropic", "OpenAI"), for
+	 * grouping in a picker. This is what the provider reports, so it describes the
+	 * model, not who served it: an OpenAI-compatible gateway will report "OpenAI"
+	 * for a Google model.
+	 */
 	readonly vendor: string;
+}
+
+/**
+ * An available model plus the provider serving it, for the AI diagnostic report.
+ * Kept off {@link IAvailableModel} so feature code can't reach the provider id
+ * and start routing by it; only diagnostics, which reports rather than decides,
+ * gets to see it.
+ */
+export interface IModelWithProvider extends IAvailableModel {
+	/** The provider that returned this model (e.g. "positai", "copilot"). */
+	readonly providerId: string;
+}
+
+/** What the AI diagnostic report needs to explain a provider's contribution. */
+export interface IModelListingDiagnostics {
+	/**
+	 * Providers actually queried, whether or not they returned anything. A
+	 * provider missing here was skipped before the call: disabled in the catalog,
+	 * its auth backend unregistered, or no credentials resolved.
+	 */
+	readonly queriedProviders: readonly string[];
+	/**
+	 * Every model returned, before de-duplication. Pre-dedupe because a provider
+	 * whose models a higher-priority provider also offers contributes nothing to
+	 * the deduped set, which reads identically to it having returned nothing.
+	 */
+	readonly models: readonly IModelWithProvider[];
 }

--- a/src/vs/workbench/services/positronHeadlessLanguageModel/common/headlessLanguageModelService.ts
+++ b/src/vs/workbench/services/positronHeadlessLanguageModel/common/headlessLanguageModelService.ts
@@ -48,6 +48,9 @@ export interface IHeadlessLanguageModelService {
 	 * models show up" has a visible answer. Feature code must use
 	 * `getAvailableModels`: requests select a model and the service picks the
 	 * provider, so branching on the provider id would route around that.
+	 *
+	 * Rejects when the listing failed (catalog unavailable, engine or bridge
+	 * startup error), where {@link getAvailableModels} degrades to an empty list.
 	 */
 	getModelListingDiagnostics(): Promise<IModelListingDiagnostics>;
 

--- a/src/vs/workbench/services/positronHeadlessLanguageModel/test/browser/headlessLanguageModelService.vitest.ts
+++ b/src/vs/workbench/services/positronHeadlessLanguageModel/test/browser/headlessLanguageModelService.vitest.ts
@@ -352,6 +352,45 @@ describe('HeadlessLanguageModelService', () => {
 			expect(models[0]).not.toHaveProperty('providerId');
 		});
 
+		it('exposes provider identity and the queried providers through the diagnostics accessor', async () => {
+			signedInAuthProviders.add('anthropic-api');
+			const service = createService(fakeEngine({ models: { anthropic: [model('claude-haiku', 'Claude Haiku', 'anthropic', 'Anthropic')] } }));
+			expect(await service.getModelListingDiagnostics()).toEqual({
+				queriedProviders: ['anthropic'],
+				models: [{ id: 'claude-haiku', name: 'Claude Haiku', vendor: 'Anthropic', providerId: 'anthropic' }],
+			});
+		});
+
+		it('keeps a de-duplicated model visible to diagnostics under both providers', async () => {
+			signedInAuthProviders.add('posit-ai');
+			signedInAuthProviders.add('anthropic-api');
+			const service = createService(fakeEngine({
+				models: {
+					positai: [model('claude-haiku', 'Claude Haiku', 'positai', 'Anthropic')],
+					anthropic: [model('claude-haiku', 'Claude Haiku', 'anthropic', 'Anthropic')],
+				},
+			}));
+
+			// A picker sees the winning copy only.
+			expect(await service.getAvailableModels()).toEqual([{ id: 'claude-haiku', name: 'Claude Haiku', vendor: 'Anthropic' }]);
+
+			// Diagnostics sees both, so "anthropic returned nothing" and "anthropic
+			// lost the dedupe" don't look the same in the report.
+			expect(await service.getModelListingDiagnostics()).toEqual({
+				queriedProviders: ['positai', 'anthropic'],
+				models: [
+					{ id: 'claude-haiku', name: 'Claude Haiku', vendor: 'Anthropic', providerId: 'positai' },
+					{ id: 'claude-haiku', name: 'Claude Haiku', vendor: 'Anthropic', providerId: 'anthropic' },
+				],
+			});
+		});
+
+		it('reports a provider that was queried but returned no models', async () => {
+			signedInAuthProviders.add('anthropic-api');
+			const service = createService(fakeEngine({ models: {} }));
+			expect(await service.getModelListingDiagnostics()).toEqual({ queriedProviders: ['anthropic'], models: [] });
+		});
+
 		it('fires onDidChangeAvailableModels only when a mapped provider changes', async () => {
 			const service = createService(fakeEngine());
 			// Provider mappings load from the engine asynchronously; wait for them

--- a/src/vs/workbench/services/positronHeadlessLanguageModel/test/browser/headlessLanguageModelService.vitest.ts
+++ b/src/vs/workbench/services/positronHeadlessLanguageModel/test/browser/headlessLanguageModelService.vitest.ts
@@ -649,6 +649,17 @@ describe('HeadlessLanguageModelService', () => {
 			expect(result).toEqual({ available: false, reason: 'temporarily-unavailable' });
 		});
 
+		it('rejects the diagnostics listing on a catalog failure rather than reporting nothing was queried', async () => {
+			providerStatus = 'error';
+			catalogSnapshot = new Map();
+			signedInAuthProviders.add('anthropic-api');
+			const service = createService(fakeEngine({ models: { anthropic: [model('claude-haiku', 'Claude Haiku', 'anthropic')] } }));
+
+			// A picker degrades to an empty list; the report sees the failure.
+			expect(await service.getAvailableModels()).toEqual([]);
+			await expect(service.getModelListingDiagnostics()).rejects.toThrow('AI provider catalog unavailable');
+		});
+
 		it('treats an empty catalog with status ready as genuine provider absence', async () => {
 			providerStatus = 'ready';
 			catalogSnapshot = new Map();


### PR DESCRIPTION
Closes https://github.com/posit-dev/positron/issues/15117
Companion https://github.com/posit-dev/assistant/pull/1904

### Summary

Adds an `AI: Create Diagnostic Report` command that gathers everything needed to debug an AI problem into a single markdown report and opens it in an editor, so the user can read it over before sharing. This replaces the "Positron Assistant: Collect Diagnostics" command that went away when the Positron Assistant extension was removed, and widens it to cover all of today's AI areas: Authentication, Posit Assistant, Posit AI NES, and GitHub Copilot.

The report has these sections:

- **Version Information** - application, Positron version and build, Code OSS version, commit, build date, quality, OS, remote. Plus each AI extension's version and activation state (including runtime error counts).
- **AI Features** - the `ai.enabled` main switch, then each feature's own toggle (NES, notebook AI, console Fix & Explain, Copilot chat). When `ai.enabled` is off the report says outright that everything below it is off regardless. Extension-backed toggles read "Not installed" when their extension is absent, instead of reporting the unregistered setting's default and contradicting the Extensions list.
- **Providers** - which providers the user is signed in to, which are turned off, the models each provider actually offers, and the contents of `providers.json` (redacted, with its path).
- **Configuration Settings** - only AI settings whose value differs from the registered default, with secrets redacted.
- **Logs** - recent trace/debug from Authentication, Posit Assistant, Posit AI NES, and GitHub Copilot (the last only when Copilot is enabled). Capped at the most recent 500 lines each.
- **Assistant Diagnostics Bundle** - optional. When Posit Assistant is installed the command asks up front whether to also produce its bundle; the report itself is always generated.

### Getting trace/debug without asking for a repro

The main problem the issue describes is that by the time something goes wrong, the useful trace and debug lines were never written, because the user's log level is higher. The Posit-owned extensions now buffer every entry in memory at all levels, before the output channel's display filter runs, and hand the buffer over on request.

- NES gets this through a new `BufferedLogOutputChannel` (a 500-entry circular buffer wrapping its real `LogOutputChannel`).
- Each extension exposes its buffer through a bridge command (`*.getDiagnosticLogs`). The report runs in the workbench, which can't read an extension's `activate()` exports, so a command invocation is how the data crosses the extension-host boundary. These commands aren't declared in `package.json`, so they stay out of the command palette. NES and Authentication register theirs first thing in `activate()`, so the logs are still reachable if the rest of activation stalls.
- The Posit Assistant side (log bridge and bundle bridge) landed separately in `posit-dev/assistant`.
- GitHub Copilot is third-party, so there's no bridge to add. Its log file is read directly through its output channel descriptor.

### Model listing

Adds `getModelListingDiagnostics()` to `IHeadlessLanguageModelService`. It reports models *before* the cross-provider de-duplication, plus the list of providers actually queried, so a report can distinguish three cases that otherwise look identical: the provider wasn't queried at all (disabled, or no credentials), it was queried and returned nothing, or its models lost the dedupe to a higher-priority provider.

`providerId` deliberately stays off the feature-facing `IAvailableModel`. Requests select a model and the service picks the provider, so exposing the provider id to feature code would let something route around that. Only diagnostics, which reports rather than decides, sees it. Models registered with the built-in language model API (where Copilot's live) are merged into the same per-provider listing, since which of the two paths a model arrived through is Positron's plumbing and not something a reader should have to reason about.

### Robustness

- The command has no precondition. It has to work when AI features are off, since "why is this disabled?" is one of the reasons to run it.
- Every extension activation and bridge call is bounded at 5s, and each model listing at 10s, so a stuck extension can't hang the report. A listing that times out is reported as incomplete rather than as zero models.
- A progress notification names the step currently running, since the total wait can add up if something is stuck.

### Redaction

`apiKey`, `token`, `secret`, and `password` keys and all `customHeaders` values are replaced with `<redacted>`, in both the settings block and `providers.json`. Everything else is shown as configured, including base URLs, which can name internal endpoints. The report opens with a privacy notice spelling this out and asking the user to read the whole thing before sharing it.

### Also in here

Maps `extensions/next-edit-suggestions/` to the assistant tag in `test-tag-paths-map.json`, so NES changes auto-tag the right e2e suite.

### Testing

24 new vitest cases in `aiDiagnostics.vitest.ts` cover the pure report formatter (snapshotted) and each helper: feature-toggle description, sensitive-key detection, `providers.json` redaction, explicit-value detection, extension status description, and log capping. Two new cases in `headlessLanguageModelService.vitest.ts` cover the diagnostics accessor, including the de-duplication case.

Known gap: the extension-side logic isn't covered yet. The auth `getProviderDiagnostics` command and the NES buffered log channel need cases in the `authentication` and `next-edit-suggestions` mocha suites. Tracked as a follow-up along with showing the selected model per feature, and routing notebook AI and console Fix & Explain logs into the report.

### Release Notes

#### New Features

- Added an "AI: Create Diagnostic Report" command that collects AI settings, provider and model state, and recent AI logs into a single report for troubleshooting (#15117)

#### Bug Fixes

- N/A

### Validation Steps

@:assistant

1. Run **AI: Create Diagnostic Report** from the command palette. With Posit Assistant installed you'll be asked whether to include its diagnostics bundle; either answer should produce the report, and pressing Escape should cancel the whole command.
2. Check the report opens in an editor and every section is filled in: version info, extensions with activation state, AI features, providers, `providers.json`, non-default settings, and a log section per AI area.
3. Confirm the logs include `trace` and `debug` lines even though your log level is at the default. Nothing should need reproducing first.
4. Set `ai.enabled` to `false` and run it again. The command should still work, and the AI Features section should say the main switch is off and everything below it is off regardless.
5. Sign in to at least one provider and confirm it shows under Providers > Authenticated, with its models listed under Available Models. Sign out and confirm the report reflects that.
6. Set a custom header on a provider and confirm the value reads `<redacted>` in both the settings block and the `providers.json` block.
7. With Copilot disabled (`chat.disableAIFeatures` on), confirm the report skips the Copilot log section; turn it back on and confirm the section returns.
8. Uninstall Posit Assistant or NES and confirm their features read "Not installed" rather than "Enabled", and the Extensions list agrees.
