### PR TITLE
Fix console wedging on restart when the kernel exit arrives out of order

### DIFF
--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -2092,7 +2092,14 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 	}
 
 	private onExited(exitCode: number) {
-		if (this._restarting) {
+		// `_restarting` is cleared as soon as the replacement kernel reports that
+		// it's starting, which can happen before this exit arrives. The exit
+		// reason isn't affected by that ordering, so check it too; otherwise we
+		// tear down the websocket the replacement kernel is already using.
+		const restarting = this._restarting ||
+			this._exitReason === positron.RuntimeExitReason.Restart;
+
+		if (restarting) {
 			// If we're restarting, wait for the kernel to start up again
 			this.log(`Kernel exited with code ${exitCode}; waiting for restart to finish.`, vscode.LogLevel.Info);
 		} else {

--- a/extensions/positron-supervisor/src/test/restartExitOrdering.test.ts
+++ b/extensions/positron-supervisor/src/test/restartExitOrdering.test.ts
@@ -1,0 +1,143 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as positron from 'positron';
+import { KallichoreSession } from '../KallichoreSession';
+import { KallichoreTransport } from '../KallichoreApiInstance';
+import { DefaultApi } from '../kcclient/api';
+import { JupyterCommand } from '../jupyter/JupyterCommand';
+
+/**
+ * Regression tests for the restart message ordering race.
+ *
+ * A restart produces two independent notifications from the Kallichore server:
+ * the outgoing kernel's `exited` message, and the replacement kernel's
+ * `starting` status. They originate from different server tasks, so their
+ * order is not guaranteed. When `starting` arrives first the session must
+ * still recognise the exit as part of the restart, and in particular must not
+ * tear down the websocket that the replacement kernel is already using.
+ *
+ * See https://github.com/posit-dev/positron/issues/10016.
+ */
+suite('Restart exit ordering', () => {
+
+	function createRuntimeMetadata(): positron.LanguageRuntimeMetadata {
+		return {
+			runtimePath: '/usr/bin/R',
+			runtimeId: '00000000-0000-0000-0000-000000000000',
+			runtimeName: 'R 4.5.2',
+			runtimeShortName: '4.5',
+			runtimeVersion: '0.1',
+			runtimeSource: 'Test',
+			languageName: 'R',
+			languageId: 'r',
+			languageVersion: '4.5.2',
+			base64EncodedIconSvg: undefined,
+			startupBehavior: positron.LanguageRuntimeStartupBehavior.Implicit,
+			sessionLocation: positron.LanguageRuntimeSessionLocation.Workspace,
+			extraRuntimeData: {},
+		};
+	}
+
+	function createSessionMetadata(): positron.RuntimeSessionMetadata {
+		return {
+			sessionId: 'r-test-0001',
+			sessionMode: positron.LanguageRuntimeSessionMode.Console,
+			notebookUri: undefined,
+		};
+	}
+
+	/**
+	 * Creates a session whose restart request stays in flight until the
+	 * returned `completeRestart` is called, mirroring the real server, which
+	 * only answers the restart request once the replacement kernel is up.
+	 */
+	function newSession() {
+		let completeRestart = () => { };
+		const restartAnswered = new Promise<void>(resolve => { completeRestart = resolve; });
+		const api = {
+			restartSession: async () => {
+				await restartAnswered;
+				return {};
+			},
+		} as unknown as DefaultApi;
+
+		const session = new KallichoreSession(
+			createSessionMetadata(),
+			createRuntimeMetadata(),
+			{ sessionName: 'R 4.5.2', inputPrompt: '>', continuationPrompt: '+' },
+			api,
+			KallichoreTransport.TCP,
+			async () => { /* server is assumed running */ },
+			/* new */ true,
+		);
+		return { session, completeRestart };
+	}
+
+	/** Drives the session's state machine to an open connection. */
+	function markConnected(session: KallichoreSession) {
+		session.handleMessage({ kind: 'kernel', status: { status: 'offline', reason: 'test setup' } });
+		session.handleMessage({ kind: 'kernel', status: { status: 'idle', reason: 'test setup' } });
+	}
+
+	/**
+	 * Reports whether the session's connection is still usable. Sends are
+	 * gated on the connection barrier, so a send that never settles means the
+	 * session considers itself disconnected.
+	 */
+	async function connectionIsUsable(session: KallichoreSession): Promise<boolean> {
+		// The command never reaches a socket; we only care whether the send
+		// gets past the connection barrier.
+		const command = { sendCommand: async () => { } } as unknown as JupyterCommand<unknown>;
+		const sent = session.sendCommand(command).then(() => true, () => true);
+		const timedOut = new Promise<boolean>(resolve => setTimeout(() => resolve(false), 100));
+		return Promise.race([sent, timedOut]);
+	}
+
+	test('keeps the connection when the exit arrives before the replacement kernel starts', async () => {
+		const { session, completeRestart } = newSession();
+		markConnected(session);
+		try {
+			const restarting = session.restart();
+
+			// The ordering the supervisor has always assumed.
+			session.handleMessage({ kind: 'kernel', status: { status: 'exited', reason: 'child process exited' } });
+			session.handleMessage({ kind: 'kernel', exited: 0 });
+			session.handleMessage({ kind: 'kernel', status: { status: 'starting', reason: 'start API called' } });
+
+			assert.strictEqual(await connectionIsUsable(session), true,
+				'the connection should survive a restart');
+
+			completeRestart();
+			await restarting;
+		} finally {
+			session.dispose();
+		}
+	});
+
+	test('keeps the connection when the exit arrives after the replacement kernel starts', async () => {
+		const { session, completeRestart } = newSession();
+		markConnected(session);
+		try {
+			const restarting = session.restart();
+
+			// The replacement kernel announces itself before the outgoing
+			// kernel's exit is delivered.
+			session.handleMessage({ kind: 'kernel', status: { status: 'exited', reason: 'child process exited' } });
+			session.handleMessage({ kind: 'kernel', status: { status: 'starting', reason: 'start API called' } });
+			session.handleMessage({ kind: 'kernel', exited: 0 });
+
+			assert.strictEqual(await connectionIsUsable(session), true,
+				'the late exit belongs to the outgoing kernel and must not close ' +
+				'the websocket the replacement kernel is using');
+
+			completeRestart();
+			await restarting;
+		} finally {
+			session.dispose();
+		}
+	});
+});

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -2813,6 +2813,15 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 				this.addRuntimeItemTrace(`onDidEndSession (code ${exit.exit_code}, reason '${exit.reason}')`);
 			}
 
+			// A restart exit can arrive after the replacement kernel has already
+			// reported that it's starting. It describes the previous kernel, not
+			// the session we're attached to now, so acting on it would clear the
+			// starting item and detach a session that is coming back online.
+			if (exit.reason === RuntimeExitReason.Restart &&
+				this._state === PositronConsoleState.Starting) {
+				return;
+			}
+
 			// Clear any starting item still present.
 			this.clearStartingItem();
 

--- a/src/vs/workbench/services/positronConsole/test/browser/consoleRestartOrdering.vitest.ts
+++ b/src/vs/workbench/services/positronConsole/test/browser/consoleRestartOrdering.vitest.ts
@@ -1,0 +1,147 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { Event } from '../../../../../base/common/event.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IWorkspaceTrustManagementService } from '../../../../../platform/workspace/common/workspaceTrust.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { TestWorkspaceTrustManagementService } from '../../../../test/common/workbenchTestServices.js';
+import { ILanguageRuntimeMetadata, LanguageRuntimeSessionMode, LanguageStartupBehavior, RuntimeExitReason, RuntimeState } from '../../../languageRuntime/common/languageRuntimeService.js';
+import { IRuntimeSessionService } from '../../../runtimeSession/common/runtimeSessionService.js';
+import { IRuntimeStartupService } from '../../../runtimeStartup/common/runtimeStartupService.js';
+import { createTestLanguageRuntimeMetadata, startTestLanguageRuntimeSession } from '../../../runtimeSession/test/common/testRuntimeSessionService.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { RuntimeItemStandard } from '../../browser/classes/runtimeItemStandard.js';
+import { PositronConsoleService, scrollbackSizeSettingId } from '../../browser/positronConsoleService.js';
+import { IConsoleFindWidget, IConsoleFindWidgetFactory, IPositronConsoleInstance } from '../../browser/interfaces/positronConsoleService.js';
+
+/**
+ * Regression tests for https://github.com/posit-dev/positron/issues/10016.
+ *
+ * On an in-place kernel restart the supervisor emits two independent signals: the
+ * `Starting` state of the replacement kernel, and the `Restart` exit of the kernel
+ * that just went away. Their relative order is not guaranteed. The console has to
+ * end up showing "<session> restarted." either way.
+ */
+describe('Positron - console restart ordering', () => {
+	const ctx = createTestContainer()
+		.withRuntimeServices()
+		.stub(IRuntimeStartupService, {
+			getRestoredSessions: () => Promise.resolve([]),
+			onSessionRestoreFailure: Event.None,
+		})
+		.stub(IConsoleFindWidgetFactory, {
+			createFindWidget: () => stubInterface<IConsoleFindWidget>({
+				onDidHide: Event.None,
+				dispose: () => { },
+			}),
+		})
+		.build();
+
+	let consoleService: PositronConsoleService;
+	let runtime: ILanguageRuntimeMetadata;
+
+	beforeEach(() => {
+		const configService = ctx.instantiationService.get(IConfigurationService) as TestConfigurationService;
+		configService.setUserConfiguration('interpreters.startupBehavior', LanguageStartupBehavior.Auto);
+		// Without a scrollback budget the console trims every item but the newest.
+		configService.setUserConfiguration(scrollbackSizeSettingId, 1000);
+
+		const workspaceTrust = ctx.instantiationService.get(IWorkspaceTrustManagementService) as TestWorkspaceTrustManagementService;
+		workspaceTrust.setWorkspaceTrust(true);
+
+		consoleService = ctx.disposables.add(
+			ctx.instantiationService.createInstance(PositronConsoleService));
+
+		runtime = createTestLanguageRuntimeMetadata(ctx.instantiationService, ctx.disposables);
+
+		const runtimeSessionService = ctx.instantiationService.get(IRuntimeSessionService);
+		ctx.disposables.add({
+			dispose() {
+				runtimeSessionService.activeSessions.forEach(s => s.dispose());
+			}
+		});
+	});
+
+	/**
+	 * Starts a console session and returns it alongside its console instance.
+	 */
+	async function startConsoleSession() {
+		const session = await startTestLanguageRuntimeSession(
+			ctx.instantiationService,
+			ctx.disposables,
+			{
+				runtime,
+				sessionName: runtime.runtimeName,
+				startReason: 'Test requested a console session',
+				sessionMode: LanguageRuntimeSessionMode.Console,
+			});
+		// Let the initial start complete, as it has by the time a user can ask
+		// for a restart.
+		session.setRuntimeState(RuntimeState.Ready);
+		const consoleInstance = consoleService.positronConsoleInstances.find(
+			instance => instance.sessionId === session.sessionId)!;
+		return { session, consoleInstance };
+	}
+
+	/** Flattens every runtime item in the console down to its rendered text. */
+	function consoleText(consoleInstance: IPositronConsoleInstance): string {
+		return consoleInstance.runtimeItems
+			.filter(item => item instanceof RuntimeItemStandard)
+			.flatMap(item => item.outputLines)
+			.flatMap(line => line.outputRuns.map(run => run.text))
+			.join('\n');
+	}
+
+	it('shows "restarted." when the restart exit arrives before the new kernel starts', async () => {
+		const { session, consoleInstance } = await startConsoleSession();
+
+		session.setRuntimeState(RuntimeState.Exited);
+		session.endSession({ reason: RuntimeExitReason.Restart });
+		session.setRuntimeState(RuntimeState.Starting);
+		session.setRuntimeState(RuntimeState.Ready);
+
+		expect(consoleText(consoleInstance)).toMatchInlineSnapshot(`
+			"Test 0.0.1 started.
+			Test 0.0.1 exited (preparing for restart)
+			Test 0.0.1 restarted."
+		`);
+	});
+
+	it('shows "restarted." when the restart exit arrives after the new kernel starts', async () => {
+		const { session, consoleInstance } = await startConsoleSession();
+
+		session.setRuntimeState(RuntimeState.Exited);
+		session.setRuntimeState(RuntimeState.Starting);
+		// The exit of the previous kernel lands late, after the replacement has
+		// already begun starting.
+		session.endSession({ reason: RuntimeExitReason.Restart });
+		session.setRuntimeState(RuntimeState.Ready);
+
+		// The late exit is dropped, so there's no "exited (preparing for restart)"
+		// line here. Appending it would report the exit as happening after the
+		// restart finished.
+		expect(consoleText(consoleInstance)).toMatchInlineSnapshot(`
+			"Test 0.0.1 started.
+			Test 0.0.1 restarted."
+		`);
+	});
+
+	it('stays attached when the restart exit arrives after the new kernel starts', async () => {
+		const { session, consoleInstance } = await startConsoleSession();
+
+		session.setRuntimeState(RuntimeState.Exited);
+		session.setRuntimeState(RuntimeState.Starting);
+		session.endSession({ reason: RuntimeExitReason.Restart });
+		session.setRuntimeState(RuntimeState.Ready);
+
+		// Detaching here would leave the console unable to see anything the
+		// restarted session does, even though it is online.
+		expect(consoleInstance.runtimeAttached).toBe(true);
+	});
+});


### PR DESCRIPTION
Addresses another bit of #10016, specifically https://github.com/posit-dev/positron/issues/10016#issuecomment-5037251419

A kernel restart produces two independent notifications from the Kallichore server: 
- the outgoing kernel's `exited` message
- the replacement kernel's `starting` status
 
They come from different server tasks, so their order is not guaranteed, but both the console and the supervisor assumed the exit always arrived first.

When `starting` won the race, the console deleted the "<session> restarting." item it had just added and detached from the session. The subsequent Ready then had nothing to swap, so the transcript ended at "<session> exited (preparing for restart)", the session indicator stayed on Starting with Restart disabled, and the console was left detached from a kernel that was actually online. Separately, the supervisor tore down the websocket the replacement kernel was already using, logging "cleaning up" and "Websocket closed with kernel in status starting".

I believe this is the flake behind the `Console - Clipboard` tests, which failed on first attempt in 11 of 138 merge-to-main runs over the last 14 days (10 R, 1 Python).

- `positronConsoleService`: a Restart exit that arrives while the console is already Starting describes the previous kernel, not the session we're attached to now, so it's ignored.
- `KallichoreSession`: `onExited` no longer relies solely on `_restarting`, which is cleared as soon as the replacement kernel reports that it's starting. The exit reason is unaffected by the ordering, so it's checked too.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix the console intermittently failing to come back after restarting an interpreter (#10016)

### Validation Steps

@:console @:sessions @:ark

**Normal restart.** Start an R console, click Restart. Confirm "R x.y.z restarted." appears, the session indicator returns to idle with Restart re-enabled, and `1 + 1` still executes afterwards. Repeat with Python.

**Force the race.** It's timing-dependent, so if you really want to see this in a dev build, then by hand make the exit notification always land after the replacement kernel's `starting` status. In `extensions/positron-supervisor/src/KallichoreSession.ts`, in `handleKernelMessage`, replace the body of the `exited` branch with:

```ts
setTimeout(() => this.onExited(data.exited), 50);
return;
```

Rebuild and restart a console. Before this change the console stops at "exited (preparing for restart)" and wedges; after it, it should behave exactly as a normal restart. Revert the edit when done.

**Check the supervisor log.** In the Kernel Supervisor output channel, a restart should read:

```
Restarting
Kernel exited with code 0; waiting for restart to finish.
Kernel is ready.
```

It should not contain "cleaning up." or "Websocket closed with kernel in status starting".

**Adjacent paths that share the exit handler.** Confirm these are unchanged: shutting down a session, deleting a session, force-quitting a busy session, a kernel that crashes on its own (`quit("no")` in R, `os._exit(1)` in Python), and restarting an interpreter after _Developer: Restart Extension Host_.
