### PR TITLE
Use ai-config's legacy settings map in the migration and provider catalog

### DIFF
--- a/extensions/authentication/package-lock.json
+++ b/extensions/authentication/package-lock.json
@@ -32,6 +32,9 @@
 				"tsx": "^4.20.6",
 				"typescript": "^7.0.2",
 				"vitest": "^3.2.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@aws-crypto/sha256-browser": {

--- a/extensions/authentication/package-lock.json
+++ b/extensions/authentication/package-lock.json
@@ -28,19 +28,10 @@
 			},
 			"devDependencies": {
 				"@types/node": "22.x",
-				"@types/positron-vscode": "npm:@types/vscode@^1.100.0",
 				"@types/proper-lockfile": "^4.1.4",
 				"tsx": "^4.20.6",
 				"typescript": "^7.0.2",
 				"vitest": "^3.2.1"
-			},
-			"peerDependencies": {
-				"vscode": "^1.100.0"
-			},
-			"peerDependenciesMeta": {
-				"vscode": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@aws-crypto/sha256-browser": {

--- a/extensions/authentication/src/migration/migrateToProvidersJson.ts
+++ b/extensions/authentication/src/migration/migrateToProvidersJson.ts
@@ -8,7 +8,6 @@ import * as vscode from 'vscode';
 import { log } from '../log';
 import {
 	buildProvidersConfigFromSettings,
-	InferCapabilitiesFn,
 	MigrationSettingsReader,
 } from './providersJson';
 
@@ -24,8 +23,6 @@ export interface RunMigrationOptions {
 	configPath?: string;
 	/** Override the settings source (tests). */
 	reader?: MigrationSettingsReader;
-	/** Override capability inference (tests). */
-	inferCapabilities?: InferCapabilitiesFn;
 }
 
 /** Reads explicitly-set GLOBAL values only; defaults and workspace scopes are ignored. */
@@ -36,25 +33,11 @@ export function createGlobalSettingsReader(): MigrationSettingsReader {
 	};
 }
 
-/**
- * Zero-value capability synthesizer for presence checks. Capabilities only
- * shape the values written into custom models, never whether a setting
- * migrates, so hasMigratableSettings can stay synchronous instead of
- * dynamically importing ai-config's real inferModelCapabilities.
- */
-const PRESENCE_CHECK_CAPABILITIES: InferCapabilitiesFn = () => ({
-	maxContextLength: 0,
-	supportsTools: false,
-	supportsImages: false,
-	supportsToolResultImages: false,
-	supportsWebSearch: false,
-});
-
 /** True when the settings hold values the migration would actually write (empty values are filtered). */
 export function hasMigratableSettings(
 	reader: MigrationSettingsReader = createGlobalSettingsReader()
 ): boolean {
-	return buildProvidersConfigFromSettings(reader, PRESENCE_CHECK_CAPABILITIES) !== undefined;
+	return buildProvidersConfigFromSettings(reader) !== undefined;
 }
 
 /**
@@ -102,16 +85,16 @@ export async function userProvidersFileIsPopulated(configPath?: string): Promise
  */
 export async function runMigration(opts: RunMigrationOptions): Promise<MigrationResult> {
 	const reader = opts.reader ?? createGlobalSettingsReader();
-	const { mutateProvidersConfig, inferModelCapabilities, providersConfigSchema } = await import('ai-config/node');
-	const mapped = buildProvidersConfigFromSettings(reader, opts.inferCapabilities ?? inferModelCapabilities);
+	const { mutateProvidersConfig, providersConfigSchema } = await import('ai-config/node');
+	const mapped = buildProvidersConfigFromSettings(reader);
 	if (!mapped) {
 		log.info('[migration] No provider settings to migrate');
 		return { outcome: 'nothing-to-migrate' };
 	}
 
-	// The builder assembles loosely-typed blocks; validate the assembled config
-	// against ai-config's schema before writing so a bad mapping fails loudly
-	// here instead of writing malformed providers.json.
+	// Validate the assembled config against ai-config's schema before writing
+	// so a bad mapping fails loudly here instead of writing malformed
+	// providers.json.
 	const config = providersConfigSchema.parse(mapped.config);
 
 	if (!opts.overwrite && await userProvidersFileIsPopulated(opts.configPath)) {

--- a/extensions/authentication/src/migration/migrateToProvidersJson.ts
+++ b/extensions/authentication/src/migration/migrateToProvidersJson.ts
@@ -86,7 +86,10 @@ export async function userProvidersFileIsPopulated(configPath?: string): Promise
 export async function runMigration(opts: RunMigrationOptions): Promise<MigrationResult> {
 	const reader = opts.reader ?? createGlobalSettingsReader();
 	const { mutateProvidersConfig, providersConfigSchema } = await import('ai-config/node');
-	const mapped = buildProvidersConfigFromSettings(reader);
+	const mapped = buildProvidersConfigFromSettings(reader, {
+		debug: (m: string) => log.debug(m),
+		warn: (m: string) => log.warn(m),
+	});
 	if (!mapped) {
 		log.info('[migration] No provider settings to migrate');
 		return { outcome: 'nothing-to-migrate' };

--- a/extensions/authentication/src/migration/providersJson.ts
+++ b/extensions/authentication/src/migration/providersJson.ts
@@ -3,281 +3,59 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { InferredModelCapabilities } from 'ai-config/node';
+/**
+ * PROVIDER-SETTINGS-MIGRATION(legacy-positron): the legacy settings →
+ * providers.json map and translator live in ai-config
+ * (`translateLegacyPositronSettings`), shared with the catalog's runtime
+ * legacy layers so the migration and the runtime channels can never diverge.
+ * This module is the migration-shaped wrapper over that translator.
+ */
 
-export type InferCapabilitiesFn = (providerId: string, modelId: string) => InferredModelCapabilities;
+import { legacySettingKeys, translateLegacyPositronSettings, type EnforcedProvidersConfig, type SettingMigration } from 'ai-config';
+
+export type { SettingMigration };
 
 /** Reads one setting's explicitly-set GLOBAL value (undefined when unset). */
 export interface MigrationSettingsReader {
 	globalValue<T>(key: string): T | undefined;
 }
 
-/** One settings.json key mapped to the dotted providers.json path it wrote. */
-export interface SettingMigration {
-	/** Source settings.json key. */
-	readonly source: string;
-	/** Destination providers.json dotted path (e.g. providers.openai.baseUrl). */
-	readonly destination: string;
-	/**
-	 * Log-safe rendering of the written value. Header values are reduced to
-	 * their names since they can carry auth tokens; all other values are safe
-	 * to show verbatim.
-	 */
-	readonly value: string;
-}
-
-/** A single provider block: plain data assembled field by field. */
-type Block = Record<string, unknown>;
-
 export interface MappedProvidersConfig {
 	/**
-	 * Loosely-typed assembled config. runMigration validates it through
-	 * providersConfigSchema before writing; the builder stays synchronous
-	 * (hasMigratableSettings needs it) and cannot reach the schema value, which
-	 * ai-config/node only exposes via dynamic import.
+	 * The assembled providers.json fragment. runMigration validates it through
+	 * providersConfigSchema before writing, so a bad mapping fails loudly there
+	 * instead of writing malformed providers.json.
 	 */
-	config: { providers: Record<string, Block> };
+	config: EnforcedProvidersConfig;
 	/** Number of settings.json entries consumed (for the success toast). */
 	settingCount: number;
 	/** Source-to-destination record of every value written (for logging). */
-	migrations: SettingMigration[];
+	migrations: readonly SettingMigration[];
 }
 
-interface ApiKeyConnectionSetting {
-	readonly configKey: string;
-	readonly providerId: string;
-}
+/** Every setting the migration consumes. */
+export const MIGRATABLE_SETTING_KEYS: readonly string[] = legacySettingKeys();
 
-/** authentication.<configKey>.{baseUrl,customHeaders} -> providers.<id>. */
-const API_KEY_CONNECTION_SETTINGS: readonly ApiKeyConnectionSetting[] = [
-	{ configKey: 'anthropic', providerId: 'anthropic' },
-	{ configKey: 'openai-api', providerId: 'openai' },
-	{ configKey: 'google', providerId: 'gemini' },
-	{ configKey: 'deepseek-api', providerId: 'deepseek' },
-	{ configKey: 'foundry', providerId: 'ms-foundry' },
-	{ configKey: 'openai-compatible', providerId: 'openai-compatible' },
-	{ configKey: 'googleVertex', providerId: 'google-vertex' },
-];
-
-interface EnablementSetting {
-	readonly providerId: string;
-	/** positron.assistant.provider.<name>.enable (older generation). */
-	readonly oldKey?: string;
-	/** assistant.provider.<name>.enabled (newer generation; wins when both set). */
-	readonly newKey?: string;
-}
-
-interface ModelOverrideSetting {
-	/** positron.assistant.models.overrides.<settingName>. */
-	readonly settingName: string;
-	readonly providerId: string;
-}
-
-const MODEL_OVERRIDE_SETTINGS: readonly ModelOverrideSetting[] = [
-	{ settingName: 'anthropic', providerId: 'anthropic' },
-	{ settingName: 'amazonBedrock', providerId: 'bedrock' },
-	{ settingName: 'snowflakeCortex', providerId: 'snowflake-cortex' },
-	{ settingName: 'msFoundry', providerId: 'ms-foundry' },
-	{ settingName: 'openAI', providerId: 'openai' },
-	{ settingName: 'customProvider', providerId: 'openai-compatible' },
-	{ settingName: 'positAI', providerId: 'positai' },
-	{ settingName: 'google', providerId: 'gemini' },
-];
-
-/** Shape of one legacy positron.assistant.models.overrides.<name> entry. */
-interface LegacyModelOverride {
-	name: string;
-	identifier: string;
-	maxInputTokens?: number;
-	maxOutputTokens?: number;
-}
-
-const ENABLEMENT_SETTINGS: readonly EnablementSetting[] = [
-	{ providerId: 'anthropic', oldKey: 'positron.assistant.provider.anthropic.enable' },
-	{ providerId: 'openai', oldKey: 'positron.assistant.provider.openAI.enable' },
-	{ providerId: 'gemini', oldKey: 'positron.assistant.provider.google.enable' },
-	{ providerId: 'bedrock', oldKey: 'positron.assistant.provider.amazonBedrock.enable' },
-	{ providerId: 'snowflake-cortex', oldKey: 'positron.assistant.provider.snowflakeCortex.enable' },
-	{ providerId: 'ms-foundry', oldKey: 'positron.assistant.provider.msFoundry.enable' },
-	{ providerId: 'openai-compatible', oldKey: 'positron.assistant.provider.customProvider.enable' },
-	{ providerId: 'positai', oldKey: 'positron.assistant.provider.positAI.enable' },
-	{ providerId: 'copilot', oldKey: 'positron.assistant.provider.githubCopilot.enable' },
-	{ providerId: 'google-vertex', newKey: 'assistant.provider.googleVertex.enabled' },
-	{ providerId: 'deepseek', newKey: 'assistant.provider.deepseek.enabled' },
-];
-
-/** Every setting the migration consumes; hasMigratableSettings scans this. */
-export const MIGRATABLE_SETTING_KEYS: readonly string[] = [
-	...API_KEY_CONNECTION_SETTINGS.flatMap(s => [
-		`authentication.${s.configKey}.baseUrl`,
-		`authentication.${s.configKey}.customHeaders`,
-	]),
-	'authentication.googleVertex.credentials',
-	'authentication.aws.credentials',
-	'authentication.snowflake.credentials',
-	'authentication.snowflake.customHeaders',
-	...ENABLEMENT_SETTINGS.flatMap(s => [s.oldKey, s.newKey]).filter((k): k is string => !!k),
-	...MODEL_OVERRIDE_SETTINGS.map(s => `positron.assistant.models.overrides.${s.settingName}`),
-];
-
+/**
+ * Translate the legacy settings visible through `reader` into a
+ * providers.json fragment, or `undefined` when nothing maps (empty values are
+ * filtered). Base URLs are written in their corrected form (a bare
+ * `https://api.anthropic.com` becomes `.../v1`) — providers.json gets no
+ * runtime correction, so a verbatim bare host would be broken as written.
+ */
 export function buildProvidersConfigFromSettings(
-	reader: MigrationSettingsReader,
-	inferCapabilities: InferCapabilitiesFn
+	reader: MigrationSettingsReader
 ): MappedProvidersConfig | undefined {
-	const providers: Record<string, Block> = {};
-	const migrations: SettingMigration[] = [];
-
-	const merge = (providerId: string, fragment: Block) => {
-		providers[providerId] = { ...providers[providerId], ...fragment };
-	};
-	const record = (source: string, destination: string, value: string) => {
-		migrations.push({ source, destination, value });
-	};
-
-	// --- authentication.<configKey>.{baseUrl,customHeaders} -----------------
-	for (const s of API_KEY_CONNECTION_SETTINGS) {
-		const rawBaseUrl = nonEmptyString(reader.globalValue<string>(`authentication.${s.configKey}.baseUrl`));
-		if (rawBaseUrl) {
-			merge(s.providerId, { baseUrl: rawBaseUrl });
-			record(`authentication.${s.configKey}.baseUrl`, `providers.${s.providerId}.baseUrl`, JSON.stringify(rawBaseUrl));
-		}
-		const headers = nonEmptyHeaders(reader.globalValue<Record<string, string>>(`authentication.${s.configKey}.customHeaders`));
-		if (headers) {
-			merge(s.providerId, { customHeaders: headers });
-			record(`authentication.${s.configKey}.customHeaders`, `providers.${s.providerId}.customHeaders`, headerNames(headers));
-		}
-	}
-
-	// --- authentication.googleVertex.credentials -> googleCloud -------------
-	const vertexCreds = reader.globalValue<Record<string, string>>('authentication.googleVertex.credentials');
-	const googleCloud: Block = {};
-	if (nonEmptyString(vertexCreds?.GOOGLE_VERTEX_PROJECT)) {
-		googleCloud.project = vertexCreds!.GOOGLE_VERTEX_PROJECT;
-		record('authentication.googleVertex.credentials', 'providers.google-vertex.googleCloud.project', JSON.stringify(googleCloud.project));
-	}
-	if (nonEmptyString(vertexCreds?.GOOGLE_VERTEX_LOCATION)) {
-		googleCloud.location = vertexCreds!.GOOGLE_VERTEX_LOCATION;
-		record('authentication.googleVertex.credentials', 'providers.google-vertex.googleCloud.location', JSON.stringify(googleCloud.location));
-	}
-	if (Object.keys(googleCloud).length > 0) {
-		merge('google-vertex', { googleCloud });
-	}
-
-	// --- authentication.aws.credentials -> bedrock.aws -----------------------
-	const awsCreds = reader.globalValue<Record<string, string>>('authentication.aws.credentials');
-	const aws: Block = {};
-	if (nonEmptyString(awsCreds?.AWS_PROFILE)) {
-		aws.profile = awsCreds!.AWS_PROFILE;
-		record('authentication.aws.credentials', 'providers.bedrock.aws.profile', JSON.stringify(aws.profile));
-	}
-	if (nonEmptyString(awsCreds?.AWS_REGION)) {
-		aws.region = awsCreds!.AWS_REGION;
-		record('authentication.aws.credentials', 'providers.bedrock.aws.region', JSON.stringify(aws.region));
-	}
-	if (Object.keys(aws).length > 0) {
-		merge('bedrock', { aws });
-	}
-
-	// --- authentication.snowflake.* -> snowflake-cortex ----------------------
-	const snowflakeCreds = reader.globalValue<Record<string, string>>('authentication.snowflake.credentials');
-	const snowflake: Block = {};
-	if (nonEmptyString(snowflakeCreds?.SNOWFLAKE_ACCOUNT)) {
-		snowflake.account = snowflakeCreds!.SNOWFLAKE_ACCOUNT;
-		record('authentication.snowflake.credentials', 'providers.snowflake-cortex.snowflake.account', JSON.stringify(snowflake.account));
-	}
-	if (nonEmptyString(snowflakeCreds?.SNOWFLAKE_HOME)) {
-		snowflake.home = snowflakeCreds!.SNOWFLAKE_HOME;
-		record('authentication.snowflake.credentials', 'providers.snowflake-cortex.snowflake.home', JSON.stringify(snowflake.home));
-	}
-	if (Object.keys(snowflake).length > 0) {
-		merge('snowflake-cortex', { snowflake });
-	}
-	const snowflakeHeaders = nonEmptyHeaders(reader.globalValue<Record<string, string>>('authentication.snowflake.customHeaders'));
-	if (snowflakeHeaders) {
-		merge('snowflake-cortex', { customHeaders: snowflakeHeaders });
-		record('authentication.snowflake.customHeaders', 'providers.snowflake-cortex.customHeaders', headerNames(snowflakeHeaders));
-	}
-
-	// --- enablement toggles -> providers.<id>.enabled ------------------------
-	for (const s of ENABLEMENT_SETTINGS) {
-		const newValue = s.newKey ? reader.globalValue<boolean>(s.newKey) : undefined;
-		const oldValue = s.oldKey ? reader.globalValue<boolean>(s.oldKey) : undefined;
-		const enabled = newValue ?? oldValue;
-		if (enabled !== undefined) {
-			merge(s.providerId, { enabled });
-			record(newValue !== undefined ? s.newKey! : s.oldKey!, `providers.${s.providerId}.enabled`, String(enabled));
-		}
-	}
-
-	// --- model overrides -> models.custom + discovery off --------------------
-	for (const s of MODEL_OVERRIDE_SETTINGS) {
-		const raw = reader.globalValue<LegacyModelOverride[]>(`positron.assistant.models.overrides.${s.settingName}`);
-		if (!Array.isArray(raw)) {
-			continue;
-		}
-		const entries = raw.filter((e): e is LegacyModelOverride =>
-			!!e && typeof e === 'object' && typeof e.name === 'string' && typeof e.identifier === 'string');
-		if (entries.length === 0) {
-			continue;
-		}
-		const custom = entries.map(entry => buildCustomModel(s.providerId, entry, inferCapabilities));
-		merge(s.providerId, { models: { discovery: 'off', custom } });
-		const modelIds = entries.map(e => e.identifier).join(', ');
-		record(`positron.assistant.models.overrides.${s.settingName}`, `providers.${s.providerId}.models.custom`, `[${modelIds}]`);
-	}
-
-	if (Object.keys(providers).length === 0) {
+	const { config, migrations } = translateLegacyPositronSettings({
+		get: key => reader.globalValue(key),
+	});
+	if (!config.providers || Object.keys(config.providers).length === 0) {
 		return undefined;
 	}
 	return {
-		config: { providers },
+		config,
+		// The toast counts distinct source settings, not destination fields.
 		settingCount: new Set(migrations.map(m => m.source)).size,
 		migrations,
 	};
-}
-
-/**
- * Legacy entries carry only name/identifier/token limits; capabilities are
- * synthesized, user token limits win, and maxContextLength never drops below
- * the user's maxInputTokens.
- */
-function buildCustomModel(providerId: string, entry: LegacyModelOverride, inferCapabilities: InferCapabilitiesFn): Block {
-	const caps = inferCapabilities(providerId, entry.identifier);
-	const maxInputTokens = entry.maxInputTokens ?? caps.maxInputTokens;
-	const maxOutputTokens = entry.maxOutputTokens ?? caps.maxOutputTokens;
-	const model: Block = {
-		id: entry.identifier,
-		name: entry.name,
-		maxContextLength: Math.max(caps.maxContextLength, entry.maxInputTokens ?? 0),
-		supportsTools: caps.supportsTools,
-		supportsImages: caps.supportsImages,
-		supportsToolResultImages: caps.supportsToolResultImages,
-		supportsWebSearch: caps.supportsWebSearch,
-	};
-	if (maxInputTokens !== undefined) {
-		model.maxInputTokens = maxInputTokens;
-	}
-	if (maxOutputTokens !== undefined) {
-		model.maxOutputTokens = maxOutputTokens;
-	}
-	if (caps.thinkingEffortLevels !== undefined) {
-		model.thinkingEffortLevels = caps.thinkingEffortLevels;
-	}
-	if (caps.protocol !== undefined) {
-		model.protocol = caps.protocol;
-	}
-	return model;
-}
-
-function nonEmptyString(value: string | undefined): string | undefined {
-	return value && value.trim() !== '' ? value : undefined;
-}
-
-function nonEmptyHeaders(headers: Record<string, string> | undefined): Record<string, string> | undefined {
-	return headers && Object.keys(headers).length > 0 ? headers : undefined;
-}
-
-/** Header names only; values can carry auth tokens and must not be logged. */
-function headerNames(headers: Record<string, string>): string {
-	return `[${Object.keys(headers).join(', ')}]`;
 }

--- a/extensions/authentication/src/migration/providersJson.ts
+++ b/extensions/authentication/src/migration/providersJson.ts
@@ -11,7 +11,7 @@
  * This module is the migration-shaped wrapper over that translator.
  */
 
-import { legacySettingKeys, translateLegacyPositronSettings, type EnforcedProvidersConfig, type LoggerLike, type SettingMigration } from 'ai-config';
+import { legacySettingKeys, translateLegacyPositronSettings, type ProvidersConfigFragment, type LoggerLike, type SettingMigration } from 'ai-config';
 
 export type { SettingMigration };
 
@@ -26,7 +26,7 @@ export interface MappedProvidersConfig {
 	 * providersConfigSchema before writing, so a bad mapping fails loudly there
 	 * instead of writing malformed providers.json.
 	 */
-	config: EnforcedProvidersConfig;
+	config: ProvidersConfigFragment;
 	/** Number of settings.json entries consumed (for the success toast). */
 	settingCount: number;
 	/** Source-to-destination record of every value written (for logging). */

--- a/extensions/authentication/src/migration/providersJson.ts
+++ b/extensions/authentication/src/migration/providersJson.ts
@@ -11,7 +11,7 @@
  * This module is the migration-shaped wrapper over that translator.
  */
 
-import { legacySettingKeys, translateLegacyPositronSettings, type EnforcedProvidersConfig, type SettingMigration } from 'ai-config';
+import { legacySettingKeys, translateLegacyPositronSettings, type EnforcedProvidersConfig, type LoggerLike, type SettingMigration } from 'ai-config';
 
 export type { SettingMigration };
 
@@ -42,13 +42,17 @@ export const MIGRATABLE_SETTING_KEYS: readonly string[] = legacySettingKeys();
  * filtered). Base URLs are written in their corrected form (a bare
  * `https://api.anthropic.com` becomes `.../v1`) — providers.json gets no
  * runtime correction, so a verbatim bare host would be broken as written.
+ * Wrong-shaped values are dropped per key; `logger` receives one warning per
+ * dropped key, so a migration that skips a setting says so instead of
+ * silently reporting success.
  */
 export function buildProvidersConfigFromSettings(
-	reader: MigrationSettingsReader
+	reader: MigrationSettingsReader,
+	logger?: LoggerLike
 ): MappedProvidersConfig | undefined {
 	const { config, migrations } = translateLegacyPositronSettings({
 		get: key => reader.globalValue(key),
-	});
+	}, logger);
 	if (!config.providers || Object.keys(config.providers).length === 0) {
 		return undefined;
 	}

--- a/extensions/authentication/src/test/providersJsonMapping.test.ts
+++ b/extensions/authentication/src/test/providersJsonMapping.test.ts
@@ -4,23 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { buildProvidersConfigFromSettings, InferCapabilitiesFn, MIGRATABLE_SETTING_KEYS, MigrationSettingsReader } from '../migration/providersJson';
+import { inferModelCapabilities } from 'ai-config';
+import { buildProvidersConfigFromSettings, MIGRATABLE_SETTING_KEYS, MigrationSettingsReader } from '../migration/providersJson';
 
 function readerOf(values: Record<string, unknown>): MigrationSettingsReader {
 	return { globalValue: <T,>(key: string) => values[key] as T | undefined };
 }
 
-const fakeCaps: InferCapabilitiesFn = () => ({
-	maxContextLength: 128_000,
-	supportsTools: true,
-	supportsImages: false,
-	supportsToolResultImages: false,
-	supportsWebSearch: false,
-});
-
 suite('buildProvidersConfigFromSettings', () => {
 	test('returns undefined when nothing is set', () => {
-		assert.strictEqual(buildProvidersConfigFromSettings(readerOf({}), fakeCaps), undefined);
+		assert.strictEqual(buildProvidersConfigFromSettings(readerOf({})), undefined);
 	});
 
 	test('maps connection settings to provider blocks', () => {
@@ -28,7 +21,7 @@ suite('buildProvidersConfigFromSettings', () => {
 			'authentication.anthropic.baseUrl': 'https://gateway.example.com',
 			'authentication.anthropic.customHeaders': { 'x-team': 'data-science' },
 			'authentication.openai-api.baseUrl': 'https://openai.example.com',
-		}), fakeCaps);
+		}));
 		assert.deepStrictEqual(result?.config.providers?.anthropic, {
 			baseUrl: 'https://gateway.example.com',
 			customHeaders: { 'x-team': 'data-science' },
@@ -37,10 +30,24 @@ suite('buildProvidersConfigFromSettings', () => {
 		assert.strictEqual(result?.settingCount, 3);
 	});
 
+	test('corrects a bare public host to its versioned form', () => {
+		// providers.json gets no runtime correction, so writing the bare host
+		// verbatim would produce a broken config (posit-dev/positron#15171).
+		const result = buildProvidersConfigFromSettings(readerOf({
+			'authentication.anthropic.baseUrl': 'https://api.anthropic.com',
+		}));
+		assert.deepStrictEqual(result?.config.providers?.anthropic, {
+			baseUrl: 'https://api.anthropic.com/v1',
+		});
+		assert.deepStrictEqual(result?.migrations, [
+			{ source: 'authentication.anthropic.baseUrl', destination: 'providers.anthropic.baseUrl', value: '"https://api.anthropic.com/v1"' },
+		]);
+	});
+
 	test('copies the foundry base URL verbatim', () => {
 		const result = buildProvidersConfigFromSettings(readerOf({
 			'authentication.foundry.baseUrl': 'https://my-resource.services.ai.azure.com',
-		}), fakeCaps);
+		}));
 		assert.deepStrictEqual(result?.config.providers?.['ms-foundry'], {
 			baseUrl: 'https://my-resource.services.ai.azure.com',
 		});
@@ -50,7 +57,7 @@ suite('buildProvidersConfigFromSettings', () => {
 		assert.strictEqual(buildProvidersConfigFromSettings(readerOf({
 			'authentication.anthropic.baseUrl': '',
 			'authentication.anthropic.customHeaders': {},
-		}), fakeCaps), undefined);
+		})), undefined);
 	});
 
 	test('maps grouped credential settings to their sections', () => {
@@ -58,10 +65,26 @@ suite('buildProvidersConfigFromSettings', () => {
 			'authentication.aws.credentials': { AWS_PROFILE: 'default', AWS_REGION: 'us-east-1' },
 			'authentication.googleVertex.credentials': { GOOGLE_VERTEX_PROJECT: 'my-project', GOOGLE_VERTEX_LOCATION: 'us-central1' },
 			'authentication.snowflake.credentials': { SNOWFLAKE_ACCOUNT: 'MYORG-MYACCT', SNOWFLAKE_HOME: '/tmp/snow' },
-		}), fakeCaps);
+		}));
 		assert.deepStrictEqual(result?.config.providers?.bedrock, { aws: { profile: 'default', region: 'us-east-1' } });
 		assert.deepStrictEqual(result?.config.providers?.['google-vertex'], { googleCloud: { project: 'my-project', location: 'us-central1' } });
 		assert.deepStrictEqual(result?.config.providers?.['snowflake-cortex'], { snowflake: { account: 'MYORG-MYACCT', home: '/tmp/snow' } });
+	});
+
+	test('maps the snowflake host and the databricks section (union gains)', () => {
+		// Previously runtime-only reads; the shared map migrates them too.
+		const result = buildProvidersConfigFromSettings(readerOf({
+			'authentication.snowflake.credentials': { SNOWFLAKE_HOST: 'acct.snowflakecomputing.com' },
+			'authentication.databricks.credentials': { DATABRICKS_HOST: 'dbx.example.com' },
+			'authentication.databricks.customHeaders': { 'x-team': 'ml' },
+		}));
+		assert.deepStrictEqual(result?.config.providers?.['snowflake-cortex'], {
+			snowflake: { host: 'acct.snowflakecomputing.com' },
+		});
+		assert.deepStrictEqual(result?.config.providers?.databricks, {
+			databricks: { host: 'dbx.example.com' },
+			customHeaders: { 'x-team': 'ml' },
+		});
 	});
 
 	test('records source-to-destination migrations with log-safe values', () => {
@@ -69,7 +92,7 @@ suite('buildProvidersConfigFromSettings', () => {
 			'authentication.openai-api.baseUrl': 'https://openai.example.com',
 			'authentication.openai-api.customHeaders': { 'x-api-key': 'sk-secret-token', 'x-team': 'data-science' },
 			'authentication.aws.credentials': { AWS_PROFILE: 'default', AWS_REGION: 'us-east-1' },
-		}), fakeCaps);
+		}));
 		assert.deepStrictEqual(result?.migrations, [
 			{ source: 'authentication.openai-api.baseUrl', destination: 'providers.openai.baseUrl', value: '"https://openai.example.com"' },
 			// Header values can carry auth tokens; only names are logged.
@@ -86,7 +109,7 @@ suite('buildProvidersConfigFromSettings', () => {
 			'positron.assistant.provider.anthropic.enable': false,
 			'positron.assistant.provider.google.enable': true,
 			'assistant.provider.deepseek.enabled': false,
-		}), fakeCaps);
+		}));
 		assert.strictEqual(result?.config.providers?.anthropic?.enabled, false);
 		assert.strictEqual(result?.config.providers?.gemini?.enabled, true);
 		assert.strictEqual(result?.config.providers?.deepseek?.enabled, false);
@@ -98,41 +121,40 @@ suite('buildProvidersConfigFromSettings', () => {
 				{ name: 'Sonnet (team)', identifier: 'claude-sonnet-4-5', maxInputTokens: 300_000 },
 				{ identifier: 'missing-name' }, // malformed: skipped
 			],
-		}), fakeCaps);
-		// The malformed entry is skipped; maxContextLength floors at the user's
-		// maxInputTokens (300_000 > the fakeCaps 128_000).
-		assert.deepStrictEqual(result?.config.providers?.anthropic?.models, {
-			discovery: 'off',
-			custom: [{
-				id: 'claude-sonnet-4-5',
-				name: 'Sonnet (team)',
-				maxContextLength: 300_000,
-				maxInputTokens: 300_000,
-				supportsTools: true,
-				supportsImages: false,
-				supportsToolResultImages: false,
-				supportsWebSearch: false,
-			}],
-		});
+		}));
+		const models = result?.config.providers?.anthropic?.models;
+		assert.strictEqual(models?.discovery, 'off');
+		assert.strictEqual(models?.custom?.length, 1);
+		const model = models?.custom?.[0];
+		const caps = inferModelCapabilities('anthropic', 'claude-sonnet-4-5');
+		assert.strictEqual(model?.id, 'claude-sonnet-4-5');
+		assert.strictEqual(model?.name, 'Sonnet (team)');
+		// The user's token limit wins and floors maxContextLength.
+		assert.strictEqual(model?.maxInputTokens, 300_000);
+		assert.strictEqual(model?.maxContextLength, Math.max(caps.maxContextLength, 300_000));
+		// Capabilities are synthesized from ai-config's inference tables.
+		assert.strictEqual(model?.supportsTools, caps.supportsTools);
+		assert.strictEqual(model?.supportsImages, caps.supportsImages);
+		assert.strictEqual(model?.maxOutputTokens, caps.maxOutputTokens);
+		assert.deepStrictEqual(model?.thinkingEffortLevels, caps.thinkingEffortLevels);
 	});
 
 	test('an overrides array with only malformed entries maps nothing', () => {
 		assert.strictEqual(buildProvidersConfigFromSettings(readerOf({
 			'positron.assistant.models.overrides.openAI': [{ nope: true }],
-		}), fakeCaps), undefined);
+		})), undefined);
 	});
 
-	test('the real inferModelCapabilities satisfies the custom-model schema', async () => {
-		const { inferModelCapabilities, customModelSchema } = await import('ai-config/node');
+	test('synthesized custom models satisfy the custom-model schema', async () => {
+		const { customModelSchema } = await import('ai-config/node');
 		const result = buildProvidersConfigFromSettings(readerOf({
 			'positron.assistant.models.overrides.anthropic': [{ name: 'Sonnet', identifier: 'claude-sonnet-4-5' }],
-		}), inferModelCapabilities);
-		const models = result?.config.providers?.anthropic?.models as { custom?: unknown[] } | undefined;
-		customModelSchema.parse(models?.custom?.[0]);
+		}));
+		customModelSchema.parse(result?.config.providers?.anthropic?.models?.custom?.[0]);
 	});
 
 	test('every migratable setting maps to config the real ai-config schema accepts', async () => {
-		const { inferModelCapabilities, providersConfigSchema } = await import('ai-config/node');
+		const { providersConfigSchema } = await import('ai-config/node');
 		const values: Record<string, unknown> = {};
 		for (const key of MIGRATABLE_SETTING_KEYS) {
 			if (key === 'authentication.aws.credentials') {
@@ -140,7 +162,9 @@ suite('buildProvidersConfigFromSettings', () => {
 			} else if (key === 'authentication.googleVertex.credentials') {
 				values[key] = { GOOGLE_VERTEX_PROJECT: 'proj', GOOGLE_VERTEX_LOCATION: 'us-central1' };
 			} else if (key === 'authentication.snowflake.credentials') {
-				values[key] = { SNOWFLAKE_ACCOUNT: 'MYORG-MYACCT', SNOWFLAKE_HOME: '/opt/snowflake' };
+				values[key] = { SNOWFLAKE_ACCOUNT: 'MYORG-MYACCT', SNOWFLAKE_HOME: '/opt/snowflake', SNOWFLAKE_HOST: 'acct.snowflakecomputing.com' };
+			} else if (key === 'authentication.databricks.credentials') {
+				values[key] = { DATABRICKS_HOST: 'dbx.example.com' };
 			} else if (key.endsWith('.baseUrl')) {
 				values[key] = 'https://gateway.example.com';
 			} else if (key.endsWith('.customHeaders')) {
@@ -153,7 +177,7 @@ suite('buildProvidersConfigFromSettings', () => {
 				assert.fail(`unhandled migratable key ${key}; add a branch with a realistic value`);
 			}
 		}
-		const result = buildProvidersConfigFromSettings(readerOf(values), inferModelCapabilities);
+		const result = buildProvidersConfigFromSettings(readerOf(values));
 		assert.ok(result, 'buildProvidersConfigFromSettings returned undefined');
 		assert.strictEqual(result.settingCount, MIGRATABLE_SETTING_KEYS.length);
 		providersConfigSchema.parse(result.config);
@@ -162,7 +186,9 @@ suite('buildProvidersConfigFromSettings', () => {
 	test('MIGRATABLE_SETTING_KEYS covers a spot-check of each family', () => {
 		for (const key of [
 			'authentication.anthropic.baseUrl',
+			'authentication.github.customHeaders',
 			'authentication.aws.credentials',
+			'authentication.databricks.credentials',
 			'authentication.snowflake.customHeaders',
 			'positron.assistant.provider.githubCopilot.enable',
 			'assistant.provider.googleVertex.enabled',

--- a/extensions/authentication/src/test/providersJsonMapping.test.ts
+++ b/extensions/authentication/src/test/providersJsonMapping.test.ts
@@ -104,7 +104,7 @@ suite('buildProvidersConfigFromSettings', () => {
 		assert.strictEqual(result?.settingCount, 3);
 	});
 
-	test('maps enablement toggles with the newer generation winning', () => {
+	test('maps enablement toggles from both key generations', () => {
 		const result = buildProvidersConfigFromSettings(readerOf({
 			'positron.assistant.provider.anthropic.enable': false,
 			'positron.assistant.provider.google.enable': true,
@@ -113,6 +113,21 @@ suite('buildProvidersConfigFromSettings', () => {
 		assert.strictEqual(result?.config.providers?.anthropic?.enabled, false);
 		assert.strictEqual(result?.config.providers?.gemini?.enabled, true);
 		assert.strictEqual(result?.config.providers?.deepseek?.enabled, false);
+	});
+
+	test('warns through the supplied logger when a wrong-shaped value is dropped', () => {
+		const warnings: string[] = [];
+		const result = buildProvidersConfigFromSettings(
+			readerOf({
+				'authentication.anthropic.baseUrl': 42,
+				'authentication.openai-api.baseUrl': 'https://openai.example.com',
+			}),
+			{ debug: () => { }, warn: (message: string) => { warnings.push(message); } }
+		);
+		assert.strictEqual(result?.config.providers?.anthropic, undefined);
+		assert.deepStrictEqual(result?.config.providers?.openai, { baseUrl: 'https://openai.example.com' });
+		assert.strictEqual(warnings.length, 1);
+		assert.ok(warnings[0].includes('authentication.anthropic.baseUrl'));
 	});
 
 	test('converts model overrides to custom models with discovery off', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -242,19 +242,10 @@
       },
       "devDependencies": {
         "@types/node": "22.x",
-        "@types/positron-vscode": "npm:@types/vscode@^1.100.0",
         "@types/proper-lockfile": "^4.1.4",
         "tsx": "^4.20.6",
         "typescript": "^7.0.2",
         "vitest": "^3.2.1"
-      },
-      "peerDependencies": {
-        "vscode": "^1.100.0"
-      },
-      "peerDependenciesMeta": {
-        "vscode": {
-          "optional": true
-        }
       }
     },
     "ai-lib/packages/ai-config/node_modules/@types/node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -246,6 +246,9 @@
         "tsx": "^4.20.6",
         "typescript": "^7.0.2",
         "vitest": "^3.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "ai-lib/packages/ai-config/node_modules/@types/node": {

--- a/src/vs/code/electron-utility/sharedProcess/sharedProcessMain.ts
+++ b/src/vs/code/electron-utility/sharedProcess/sharedProcessMain.ts
@@ -28,7 +28,7 @@ import { HEADLESS_LM_ENGINE_CHANNEL } from '../../../platform/positronHeadlessLa
 import { HeadlessLanguageModelEngine } from '../../../platform/positronHeadlessLanguageModel/node/headlessLanguageModelEngine.js';
 import { HeadlessLanguageModelEngineChannel } from '../../../platform/positronHeadlessLanguageModel/node/headlessLanguageModelEngineChannel.js';
 import { POSITRON_AI_PROVIDER_CHANNEL } from '../../../platform/positronAiProvider/common/aiProviderCatalog.js';
-import { AiProviderCatalog } from '../../../platform/positronAiProvider/node/aiProviderCatalog.js';
+import { AiProviderCatalog, createConfigurationLegacySettingsReader } from '../../../platform/positronAiProvider/node/aiProviderCatalog.js';
 import { AiProviderCatalogChannel } from '../../../platform/positronAiProvider/node/aiProviderCatalogChannel.js';
 // --- End Positron ---
 import { DiagnosticsService } from '../../../platform/diagnostics/node/diagnosticsService.js';
@@ -511,7 +511,12 @@ class SharedProcessMain extends Disposable implements IClientConnectionFilter {
 		// AI provider catalog: resolves providers.json + enforced/default env
 		// fragments where they live (this process's HOME/env); the workbench
 		// reads it over this channel.
-		const aiProviderCatalog = this._store.add(new AiProviderCatalog(accessor.get(ILogService)));
+		const aiProviderCatalog = this._store.add(new AiProviderCatalog(accessor.get(ILogService), {
+			// PROVIDER-SETTINGS-MIGRATION(legacy-positron): fold this process's view
+			// of the legacy settings (the default profile's user settings.json)
+			// into the catalog until the migration window closes.
+			legacyPositronSettings: createConfigurationLegacySettingsReader(accessor.get(IConfigurationService)),
+		}));
 		this.server.registerChannel(POSITRON_AI_PROVIDER_CHANNEL, new AiProviderCatalogChannel(aiProviderCatalog));
 		// --- End Positron ---
 

--- a/src/vs/platform/positronAiProvider/node/aiProviderCatalog.ts
+++ b/src/vs/platform/positronAiProvider/node/aiProviderCatalog.ts
@@ -21,7 +21,7 @@ import { IAiProviderCatalog, IProviderCatalogChangeData, IResolvedProviderData }
  * coarse (any config change fires) — the catalog watch debounces and diffs.
  */
 export function createConfigurationLegacySettingsReader(
-	configurationService: IConfigurationService
+	configurationService: Pick<IConfigurationService, 'inspect' | 'onDidChangeConfiguration'>
 ): LegacySettingsReader {
 	return {
 		get: key => configurationService.inspect(key).userValue,

--- a/src/vs/platform/positronAiProvider/node/aiProviderCatalog.ts
+++ b/src/vs/platform/positronAiProvider/node/aiProviderCatalog.ts
@@ -3,12 +3,31 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { ProviderCatalogChange, ResolvedProvider } from 'ai-config/node';
+import type { LegacySettingsReader, ProviderCatalogChange, ResolvedProvider } from 'ai-config/node';
 import { Emitter, Event } from '../../../base/common/event.js';
 import { Disposable, toDisposable } from '../../../base/common/lifecycle.js';
 import { URI } from '../../../base/common/uri.js';
+import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { ILogService } from '../../log/common/log.js';
 import { IAiProviderCatalog, IProviderCatalogChangeData, IResolvedProviderData } from '../common/aiProviderCatalog.js';
+
+/**
+ * PROVIDER-SETTINGS-MIGRATION(legacy-positron): a LegacySettingsReader over a
+ * configuration service, handed to the catalog loader's
+ * `legacyPositronSettings` option. `get` reads `inspect(key).userValue` —
+ * the user-set value only, never policy/default values, so enforced settings
+ * cannot leak into the non-enforced legacy layer (the loader reads
+ * POSITRON_ENFORCED_SETTINGS from the environment itself). The watch is
+ * coarse (any config change fires) — the catalog watch debounces and diffs.
+ */
+export function createConfigurationLegacySettingsReader(
+	configurationService: IConfigurationService
+): LegacySettingsReader {
+	return {
+		get: key => configurationService.inspect(key).userValue,
+		watch: onChange => configurationService.onDidChangeConfiguration(() => onChange()),
+	};
+}
 
 /**
  * Owns the ai-config catalog lifecycle node-side: initial load, file/env
@@ -23,7 +42,12 @@ export class AiProviderCatalog extends Disposable implements IAiProviderCatalog 
 
 	constructor(
 		private readonly _logService: ILogService,
-		private readonly _options?: { configPath?: string; envVars?: Record<string, string | undefined> },
+		private readonly _options?: {
+			configPath?: string;
+			envVars?: Record<string, string | undefined>;
+			// PROVIDER-SETTINGS-MIGRATION(legacy-positron)
+			legacyPositronSettings?: LegacySettingsReader;
+		},
 	) {
 		super();
 	}
@@ -33,6 +57,7 @@ export class AiProviderCatalog extends Disposable implements IAiProviderCatalog 
 			baseline: { defaultEnabled: true },
 			configPath: this._options?.configPath,
 			envVars: this._options?.envVars,
+			legacyPositronSettings: this._options?.legacyPositronSettings,
 			logger: {
 				debug: (message: string) => this._logService.debug(`[AI Provider Catalog] ${message}`),
 				warn: (message: string) => this._logService.warn(`[AI Provider Catalog] ${message}`),

--- a/src/vs/platform/positronAiProvider/test/node/aiProviderCatalog.vitest.ts
+++ b/src/vs/platform/positronAiProvider/test/node/aiProviderCatalog.vitest.ts
@@ -75,4 +75,72 @@ describe('AiProviderCatalog', () => {
 		await new Promise(r => setTimeout(r, 600));
 		expect(fired).not.toHaveBeenCalled();
 	}, 10_000);
+
+	// PROVIDER-SETTINGS-MIGRATION(legacy-positron) gate: delete this block with
+	// the loader option.
+	describe('legacyPositronSettings pass-through', () => {
+		function readerOf(values: Record<string, unknown>) {
+			return {
+				get: (key: string) => values[key],
+				watch: () => ({ dispose: () => { } }),
+			};
+		}
+
+		it('surfaces legacy settings in the catalog (below the user file)', async () => {
+			const configPath = join(dir, 'providers.json');
+			fs.writeFileSync(configPath, JSON.stringify({
+				version: 1,
+				providers: { openai: { baseUrl: 'https://user-openai.example/v1' } },
+			}));
+			catalog = new AiProviderCatalog(new NullLogService(), {
+				configPath,
+				envVars: {},
+				legacyPositronSettings: readerOf({
+					'authentication.anthropic.baseUrl': 'https://legacy.example/v1',
+					'authentication.openai-api.baseUrl': 'https://legacy-openai.example/v1',
+				}),
+			});
+			const providers = await catalog.getCatalog();
+			// Legacy contributes anthropic; the user file wins for openai.
+			expect(providers.find(p => p.id === 'anthropic')?.connection.baseUrl)
+				.toBe('https://legacy.example/v1');
+			expect(providers.find(p => p.id === 'openai')?.connection.baseUrl)
+				.toBe('https://user-openai.example/v1');
+		});
+
+		it('POSITRON_ENFORCED_SETTINGS beats the user file', async () => {
+			const configPath = join(dir, 'providers.json');
+			fs.writeFileSync(configPath, JSON.stringify({
+				version: 1,
+				providers: { anthropic: { enabled: true, baseUrl: 'https://user.example/v1' } },
+			}));
+			catalog = new AiProviderCatalog(new NullLogService(), {
+				configPath,
+				envVars: {
+					POSITRON_ENFORCED_SETTINGS: JSON.stringify({
+						'authentication.anthropic.baseUrl': 'https://enforced.example/v1',
+						'positron.assistant.provider.anthropic.enable': false,
+					}),
+				},
+				legacyPositronSettings: readerOf({}),
+			});
+			const anthropic = (await catalog.getCatalog()).find(p => p.id === 'anthropic')!;
+			expect({ enabled: anthropic.enabled, baseUrl: anthropic.connection.baseUrl })
+				.toEqual({ enabled: false, baseUrl: 'https://enforced.example/v1' });
+		});
+
+		it('no reader → no legacy layers, even with the env var set', async () => {
+			const configPath = join(dir, 'providers.json');
+			catalog = new AiProviderCatalog(new NullLogService(), {
+				configPath,
+				envVars: {
+					POSITRON_ENFORCED_SETTINGS: JSON.stringify({
+						'authentication.anthropic.baseUrl': 'https://enforced.example/v1',
+					}),
+				},
+			});
+			const anthropic = (await catalog.getCatalog()).find(p => p.id === 'anthropic')!;
+			expect(anthropic.connection.baseUrl).toBeUndefined();
+		});
+	});
 });

--- a/src/vs/platform/positronAiProvider/test/node/configurationLegacySettingsReader.vitest.ts
+++ b/src/vs/platform/positronAiProvider/test/node/configurationLegacySettingsReader.vitest.ts
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { Emitter } from '../../../../base/common/event.js';
+import { ConfigurationTarget, IConfigurationChangeEvent, IConfigurationValue } from '../../../configuration/common/configuration.js';
+import { createConfigurationLegacySettingsReader } from '../../node/aiProviderCatalog.js';
+
+// PROVIDER-SETTINGS-MIGRATION(legacy-positron): delete with the reader.
+//
+// Pins the reader's load-bearing invariant: `get` surfaces `inspect(key).userValue`
+// only — never the effective value — so policy/default/enforced values cannot be
+// promoted into the non-enforced `legacy-positron` layer. The catalog tests inject
+// hand-rolled readers, so a regression to `getValue(key)` here would pass them all.
+describe('createConfigurationLegacySettingsReader', () => {
+	function stubService(inspections: Record<string, IConfigurationValue<unknown>>) {
+		const changeEmitter = new Emitter<IConfigurationChangeEvent>();
+		return {
+			changeEmitter,
+			service: {
+				inspect: <T,>(key: string): IConfigurationValue<T> =>
+					(inspections[key] ?? {}) as IConfigurationValue<T>,
+				onDidChangeConfiguration: changeEmitter.event,
+			},
+		};
+	}
+
+	it('surfaces only userValue, never default/policy/effective values', () => {
+		const { service } = stubService({
+			'authentication.anthropic.baseUrl': {
+				defaultValue: 'https://default.example/v1',
+				userValue: 'https://user.example/v1',
+				policyValue: 'https://policy.example/v1',
+				value: 'https://policy.example/v1',
+			},
+		});
+		expect(createConfigurationLegacySettingsReader(service).get('authentication.anthropic.baseUrl'))
+			.toBe('https://user.example/v1');
+	});
+
+	it('returns undefined when a key has only default and policy values', () => {
+		const { service } = stubService({
+			'authentication.anthropic.baseUrl': {
+				defaultValue: 'https://default.example/v1',
+				policyValue: 'https://policy.example/v1',
+				value: 'https://policy.example/v1',
+			},
+		});
+		expect(createConfigurationLegacySettingsReader(service).get('authentication.anthropic.baseUrl'))
+			.toBeUndefined();
+	});
+
+	it('preserves a user-set false (?? semantics live in the caller, not the reader)', () => {
+		const { service } = stubService({
+			'positron.assistant.provider.anthropic.enable': {
+				defaultValue: true,
+				userValue: false,
+				value: false,
+			},
+		});
+		expect(createConfigurationLegacySettingsReader(service).get('positron.assistant.provider.anthropic.enable'))
+			.toBe(false);
+	});
+
+	it('watch subscribes to onDidChangeConfiguration and stops on dispose', () => {
+		const { service, changeEmitter } = stubService({});
+		const onChange = vi.fn();
+		const subscription = createConfigurationLegacySettingsReader(service).watch(onChange);
+
+		const event: IConfigurationChangeEvent = {
+			source: ConfigurationTarget.USER,
+			affectedKeys: new Set(['authentication.anthropic.baseUrl']),
+			change: { keys: [], overrides: [] },
+			affectsConfiguration: () => true,
+		};
+		changeEmitter.fire(event);
+		expect(onChange).toHaveBeenCalledTimes(1);
+
+		subscription.dispose();
+		changeEmitter.fire(event);
+		expect(onChange).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/vs/server/node/serverServices.ts
+++ b/src/vs/server/node/serverServices.ts
@@ -122,7 +122,7 @@ import { HEADLESS_LM_ENGINE_CHANNEL } from '../../platform/positronHeadlessLangu
 import { HeadlessLanguageModelEngine } from '../../platform/positronHeadlessLanguageModel/node/headlessLanguageModelEngine.js';
 import { HeadlessLanguageModelEngineChannel } from '../../platform/positronHeadlessLanguageModel/node/headlessLanguageModelEngineChannel.js';
 import { POSITRON_AI_PROVIDER_CHANNEL } from '../../platform/positronAiProvider/common/aiProviderCatalog.js';
-import { AiProviderCatalog } from '../../platform/positronAiProvider/node/aiProviderCatalog.js';
+import { AiProviderCatalog, createConfigurationLegacySettingsReader } from '../../platform/positronAiProvider/node/aiProviderCatalog.js';
 import { AiProviderCatalogChannel } from '../../platform/positronAiProvider/node/aiProviderCatalogChannel.js';
 // --- End Positron ---
 
@@ -416,7 +416,12 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 		// AI provider catalog: resolves providers.json + enforced/default env
 		// fragments where they live (this remote host's HOME/env); the
 		// workbench reaches it over this channel.
-		const aiProviderCatalog = disposables.add(new AiProviderCatalog(logService));
+		const aiProviderCatalog = disposables.add(new AiProviderCatalog(logService, {
+			// PROVIDER-SETTINGS-MIGRATION(legacy-positron): fold this host's view of
+			// the legacy settings (the remote machine settings) into the catalog
+			// until the migration window closes.
+			legacyPositronSettings: createConfigurationLegacySettingsReader(configurationService),
+		}));
 		socketServer.registerChannel(POSITRON_AI_PROVIDER_CHANNEL, new AiProviderCatalogChannel(aiProviderCatalog));
 		// --- End Positron ---
 		// clean up extensions folder

--- a/src/vs/workbench/services/positronHeadlessLanguageModel/browser/abstractHeadlessLanguageModelService.ts
+++ b/src/vs/workbench/services/positronHeadlessLanguageModel/browser/abstractHeadlessLanguageModelService.ts
@@ -430,6 +430,9 @@ export abstract class AbstractHeadlessLanguageModelService extends Disposable im
 				const cfg = this._configService.getValue<{ SNOWFLAKE_HOST?: string; SNOWFLAKE_ACCOUNT?: string }>('authentication.snowflake.credentials');
 				return { host: cfg?.SNOWFLAKE_HOST, account: cfg?.SNOWFLAKE_ACCOUNT };
 			},
+			getDatabricks: () => ({
+				host: this._configService.getValue<{ DATABRICKS_HOST?: string }>('authentication.databricks.credentials')?.DATABRICKS_HOST,
+			}),
 		};
 	}
 }


### PR DESCRIPTION
Companion to posit-dev/ai-lib#36 (ai-config now owns the legacy settings map in one shared module); also fixes #15171. **Depends on the ai-lib PR** — the `ai-lib` submodule pin points at its branch, so bump the pin to the merged sha if ai-lib squashes. The assistant-extension adoption is posit-dev/assistant#1909.

**The migration now uses the shared translator.** `providersJson.ts` drops its ~284 lines of local tables and becomes a thin wrapper over ai-config's `translateLegacyPositronSettings`. `MIGRATABLE_SETTING_KEYS` comes from the shared `legacySettingKeys()`; the `InferCapabilitiesFn` injection is gone (the translator is sync). The user-facing flow in `migrateToProvidersJson.ts` is unchanged, and per-key drop warnings now reach the migration log. Two intentional behavior changes:

- **The #15171 fix:** bare hosts are written corrected (`https://api.anthropic.com` → `…/v1`; same for openai/gemini/lmstudio) instead of verbatim, which produced a broken providers.json. The migration hasn't shipped, so no existing files need repair.
- The migration picks up rows the runtime side already had: `github` → `copilot`, `SNOWFLAKE_HOST`, and the databricks host/headers. No-ops when unset.

**The provider catalog now sees legacy settings.** `AiProviderCatalog` gains a `legacyPositronSettings` option, and `createConfigurationLegacySettingsReader` adapts a configuration service into the reader ai-config expects (`inspect(key).userValue` + `onDidChangeConfiguration`). Both catalog sites pass it — shared process and server — so each folds in the legacy settings visible to it, and `POSITRON_ENFORCED_SETTINGS` provider keys apply at the right rank: above the user's providers.json, below the canonical `POSIT_AI_PROVIDERS_ENFORCED`. The reader returns only user-set values (never `policyValue`), so enforced settings can't leak into the non-enforced layer (pinned by `configurationLegacySettingsReader.vitest.ts`).

**Pin-bump fallout:** the new pin makes `getDatabricks` a required `CredentialConfig` member; `abstractHeadlessLanguageModelService.ts` implements it (reads `authentication.databricks.credentials.DATABRICKS_HOST`, mirroring `getSnowflake`).

**Heads-up for #15121** (no textual conflict, but on rebase): its `providerCatalog.ts` must pass `legacyPositronSettings` (extension-host reader, `workspaceValue ?? globalValue`) or its cached catalog misses both layers; its `VERSIONED_HOSTS` table should call ai-config's exported `normalizeBaseUrlForProvider` instead; its rewritten `credentialConfig()` needs a `getDatabricks`. The rest is aligned: its env-fallback removals match this design, and `maybeAutoMigrate()` picks up the #15171 fix automatically.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- The AI provider settings migration writes versioned base URLs (e.g. `https://api.anthropic.com/v1`) instead of copying bare hosts verbatim into `providers.json` (#15171).

### Validation Steps

Automated (run on this branch):

- `npx vitest run src/vs/platform/positronAiProvider/` — 16 passed, incl. 3 new pass-through tests (legacy below user file; enforced env var beats user file; no reader → no layers) and the 4 `configurationLegacySettingsReader.vitest.ts` reader-contract tests.
- `npx tsc -p src/tsconfig.json --noEmit` and `npx tsc -p extensions/authentication/tsconfig.json` — clean.
- `npm run test-extension -- -l authentication` — 141 passing, 0 failures (includes `providersJsonMapping.test.ts` with the bare-host correction and the new snowflake/databricks rows, and `migrateToProvidersJson.test.ts`).
- Checkout recipe (verified in a pristine clone): `git submodule update --init ai-lib` → `npm install` → `npm run build:ai-lib`. Don't run `npm install` inside `ai-lib/`.

Manual (run in dev Positron with the assistant extension, isolated `--user-data-dir`):

1. **Migration** ✓: with `authentication.anthropic.baseUrl: "https://api.anthropic.com"` (bare) and a versioned `authentication.openai-api.baseUrl` set, **"Migrate AI Provider Settings to providers.json"** wrote the anthropic URL corrected to `…/v1` (the #15171 fix), the versioned URL verbatim, and logged one `source -> destination = value` line per setting.
2. **Legacy layer live** ✓: a wrong-typed legacy value in user settings was dropped with the loader's `[ai-config] Ignoring legacy Positron setting …` warn-once in the extension host — the live-ConfigurationService reader feeds the `legacy-positron` layer (the vitest coverage injects a fake reader, so this pins the real wiring).
3. **Enforced source live** ✓: launching with `POSITRON_ENFORCED_SETTINGS='{"authentication.openai-api.baseUrl":123}'` (the same key a valid string in settings.json) produced the warn-once for that key — the env payload reaches the loader's enforced layer.
4. **Not directly observable on this branch:** the resolved catalog's values/rank have no UI consumer yet — the provider modal's enablement and Base URL come from core's direct settings read and the auth extension's own constants until #15121 wires `IAiProviderService` in. Rank-order semantics are pinned by the automated suites above. The shared-process/server catalogs likewise have no live consumer to observe; re-do this spot-check when #15121 lands.
