### PR TITLE
skill(triage-e2e-test): fix diluted failure-rate metrics and checkpoint

### DIFF
--- a/.claude/skills/triage-e2e-test/SKILL.md
+++ b/.claude/skills/triage-e2e-test/SKILL.md
@@ -25,7 +25,8 @@ only when a stage needs them.
   patterns is.
 - Resolve the exact **full hierarchical** test title and spec path.
 - Investigate **one** selected pattern at a time; ask which when there's more
-  than one.
+  than one. Never fetch evidence for a pattern the engineer didn't select --
+  ask first, even to check a side theory about how patterns relate.
 - Fetch **one** representative occurrence first; a second needs a stated reason.
 - Escalate evidence only to answer a concrete question. Keep large output on
   disk, not in the conversation.
@@ -109,13 +110,17 @@ saved data is invalid, or the branch/test identity changed.
    ```
    A non-`none` verdict changes the plan -- read [`references/prior-triage.md`](references/prior-triage.md).
    `open-attempt-in-flight` means stop and point at the open PR.
-6. **Present the failure modes as a table** (never a run-on sentence). Include a
-   "Seen on" column whenever two branches were queried:
+6. **Present the failure modes as a table** (never a run-on sentence). Use each
+   pattern's `rates` array (per branch, scoped to the environments it occurred
+   in) for the Rate column -- never `count / totalRuns`: that blends branches
+   and environments together and can understate a pattern confined to one
+   environment on one branch by 100x. Include a "Seen on" column whenever two
+   branches were queried:
 
-   | # | Failure mode | Count | % | Environments | Seen on |
+   | # | Failure mode | Count | Rate | Environments | Seen on |
    |---|---|---|---|---|---|
-   | A | `toBeVisible()` timeout: `getByLabel('...')` | 104 | 99% | ubuntu/electron | both |
-   | B | `locator.click` timeout: `.monaco-list-row` | 1 | 1% | win/electron | main only |
+   | A | `locator.click` timeout: `.codicon-maximize` | 4 | 100% on feature/x | ubuntu/chromium | feature/x only |
+   | B | `toBeVisible()` timeout: `getByLabel('...')` | 3 | 1.9% on main | ubuntu/electron | main only |
 
 7. **Ask which pattern to prioritize whenever the table has more than one row.**
    Give your own read ("A is dominant at 99% -- start there, or focus on B?")

--- a/.claude/skills/triage-e2e-test/references/diagnosis-block.md
+++ b/.claude/skills/triage-e2e-test/references/diagnosis-block.md
@@ -28,7 +28,7 @@ root-cause prediction at authoring time, so its accuracy can be scored later.
 - **Test:** [<full hierarchical test title>](<test_detail_view_url>)
 - **Targeted failure:** <exact surface error/assertion string, e.g. `Test timeout of 120000ms exceeded`>
 - **Signal:** <trace-timeline mechanism observation, not the bare assertion string>
-- **Frequency:** <count/percentage + environment, e.g. "5/313 runs (1.6%), ubuntu/electron">
+- **Frequency:** <auto-derived, one clause per branch scoped to the pattern's environments, e.g. "4/4 runs (100%) on feature/x; 5/313 runs (1.6%) on main, ubuntu/electron">
 - **Hypothesis:** <root-cause mechanism -- race / isolation / contention / infra / product-bug>
 
 </details>

--- a/.claude/skills/triage-e2e-test/scripts/checkpoint.js
+++ b/.claude/skills/triage-e2e-test/scripts/checkpoint.js
@@ -8,9 +8,13 @@
 //
 // Usage:
 //   node checkpoint.js --triage-id <id> --init --test-key <key> [--branch b] [--lookback-days n]
+//     -- also seeds history/patterns from this triage's history-summary.json, if present
 //   node checkpoint.js --triage-id <id> --read
 //   node checkpoint.js --triage-id <id> --set phase=hypothesis-ready --set selectedPattern=A
 //   node checkpoint.js --triage-id <id> --patch '<json>'     # deep-merge a JSON object
+//     -- WARNING: arrays (e.g. patterns) REPLACE wholesale, not merge by element.
+//     -- to annotate one pattern without resending the others, use --patch-pattern instead:
+//   node checkpoint.js --triage-id <id> --patch-pattern A --patch '{"note": "..."}'
 //   node checkpoint.js --status                              # list all triages
 //   node checkpoint.js --triage-id <id> --validate
 
@@ -186,6 +190,41 @@ export function applyPatch(state, patch) {
 	return out;
 }
 
+/**
+ * Merge a partial object into exactly ONE pattern (matched by id) inside the
+ * `patterns` array, leaving every other pattern untouched. A top-level
+ * `--patch '{"patterns": [...]}'` replaces the whole array (per applyPatch's
+ * array-replace rule above) -- a real footgun for annotating a single pattern,
+ * since it silently drops every other pattern's data unless the caller
+ * reconstructs and resends the full array. This is the safe path for that.
+ */
+export function mergePatternPatch(patterns, patternId, patch) {
+	const list = Array.isArray(patterns) ? patterns : [];
+	const idx = list.findIndex(p => p.id === patternId);
+	if (idx === -1) {
+		const have = list.map(p => p.id).join(', ') || 'none';
+		throw new Error(`No pattern with id "${patternId}" in this checkpoint (have: ${have}).`);
+	}
+	const merged = applyPatch(list[idx], patch);
+	return list.map((p, i) => i === idx ? merged : p);
+}
+
+/**
+ * Seed `history` + `patterns` from the on-disk `history-summary.json` that
+ * `triage-history.js` already wrote to this triage's work dir. Makes `--init`
+ * actually record the patterns (as the skill's workflow describes) instead of
+ * requiring a separate manual `--patch` of the full `patterns` array -- which
+ * is exactly the step where the array-replace footgun above bites.
+ */
+export function applyHistorySummary(state, summary) {
+	if (!summary || !Array.isArray(summary.patterns)) { return state; }
+	return {
+		...state,
+		history: { branchSummary: summary.branchSummary, verdict: summary.verdict },
+		patterns: summary.patterns,
+	};
+}
+
 /** Coerce `key=value` string values into booleans/numbers/null where obvious. */
 export function coerce(value) {
 	if (value === 'true') { return true; }
@@ -253,7 +292,14 @@ function main() {
 			fail(`A checkpoint for triage "${triageId}" already exists -- resume it (--read) or pass --force to overwrite.`, { stateFile: path.relative(process.cwd(), sp) });
 		}
 		ensureDir(triageDir(triageId));
-		const state = newState(triageId, args);
+		let state = newState(triageId, args);
+		// Auto-seed history + patterns from triage-history.js's already-written
+		// summary, if present -- see applyHistorySummary's doc comment.
+		const historyFile = path.join(triageDir(triageId), 'history-summary.json');
+		if (fs.existsSync(historyFile)) {
+			try { state = applyHistorySummary(state, readJson(historyFile)); }
+			catch { /* malformed summary file -- leave state as a bare init rather than failing */ }
+		}
 		writeJson(sp, state);
 		emit({ ...state, stateFile: path.relative(process.cwd(), sp) });
 		return;
@@ -270,7 +316,8 @@ function main() {
 		return;
 	}
 
-	// Mutations: --patch and/or repeated --set key=value.
+	// Mutations: --patch and/or repeated --set key=value, or --patch-pattern <id>
+	// to merge into just one pattern (see mergePatternPatch's doc comment).
 	let patch = null;
 	if (args.patch) {
 		try { patch = JSON.parse(args.patch); } catch { fail('--patch must be valid JSON.'); }
@@ -285,7 +332,16 @@ function main() {
 		}
 	}
 
-	if (!patch && sets.length === 0) { fail('Nothing to do (use --init/--read/--set/--patch/--status/--validate).'); }
+	const patchPatternId = args['patch-pattern'];
+	if (!patch && sets.length === 0 && !patchPatternId) {
+		fail('Nothing to do (use --init/--read/--set/--patch/--patch-pattern/--status/--validate).');
+	}
+	if (patchPatternId) {
+		if (!patch) { fail('--patch-pattern requires --patch \'<json>\' with the fields to merge into that one pattern.'); }
+		try { state = { ...state, patterns: mergePatternPatch(state.patterns, patchPatternId, patch) }; }
+		catch (e) { fail(e.message); }
+		patch = null; // consumed by the single-pattern merge, not a top-level patch
+	}
 	try {
 		state = applyMutations(state, patch, sets);
 	} catch (e) {

--- a/.claude/skills/triage-e2e-test/scripts/record-diagnosis.js
+++ b/.claude/skills/triage-e2e-test/scripts/record-diagnosis.js
@@ -85,8 +85,12 @@ export function validateDiagnosis(d) {
 	return null;
 }
 
-/** Human frequency string from the selected history pattern, e.g.
- *  "31/317 runs (9.8%), ubuntu/chromium". Returns null when unavailable. */
+/** Human frequency string from the selected history pattern, one clause per
+ *  branch scoped to the environments the pattern actually occurred in, e.g.
+ *  "4/4 runs (100%) on feature/x; 3/157 runs (1.9%) on main, ubuntu/chromium".
+ *  Returns null when unavailable. Never blends counts/runs across branches or
+ *  environments -- that silently understates a pattern concentrated in one
+ *  environment on one branch (see triage-history.js scopedRunsForEnvironments). */
 export function deriveFrequency(history, selectedPattern) {
 	if (!history || !Array.isArray(history.patterns)) { return null; }
 	// When a pattern is selected, its stats or nothing -- never silently fall back
@@ -96,11 +100,16 @@ export function deriveFrequency(history, selectedPattern) {
 		? history.patterns.find(x => x.id === selectedPattern)
 		: history.patterns[0];
 	if (!p) { return null; }
-	const denom = history.branchSummary?.mainRuns || history.branchSummary?.currentBranchRuns;
-	const runs = denom ? `${p.count}/${denom} runs` : `${p.count} runs`;
-	const pct = typeof p.percentage === 'number' ? ` (${p.percentage}%)` : '';
 	const envs = Array.isArray(p.environments) && p.environments.length ? `, ${p.environments.join(', ')}` : '';
-	return `${runs}${pct}${envs}`;
+	if (!Array.isArray(p.rates) || !p.rates.length) {
+		return `${p.count} runs${envs}`;
+	}
+	const clauses = p.rates.map(r => {
+		const runs = r.environmentRuns ? `${r.count}/${r.environmentRuns} runs` : `${r.count} runs`;
+		const pct = typeof r.ratePercent === 'number' ? ` (${r.ratePercent}%)` : '';
+		return `${runs}${pct} on ${r.branch}`;
+	});
+	return `${clauses.join('; ')}${envs}`;
 }
 
 /**

--- a/.claude/skills/triage-e2e-test/scripts/test/checkpoint.test.js
+++ b/.claude/skills/triage-e2e-test/scripts/test/checkpoint.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { validateCheckpoint, applyPatch, coerce, PHASES, PHASE_NEXT_ACTION, applyMutations, defaultNextAction, checkDoneGate, OUTCOMES, SETTABLE_FIELDS } from '../checkpoint.js';
+import { validateCheckpoint, applyPatch, coerce, PHASES, PHASE_NEXT_ACTION, applyMutations, defaultNextAction, checkDoneGate, OUTCOMES, SETTABLE_FIELDS, mergePatternPatch, applyHistorySummary } from '../checkpoint.js';
 
 const valid = () => ({ version: 1, triageId: 'x', testKey: 'A > b|||spec.ts', phase: 'awaiting-pattern-selection' });
 
@@ -115,4 +115,25 @@ test('checkDoneGate: no-op needs a reason, not a block', () => {
 
 test('OUTCOMES covers the found x decided matrix', () => {
 	assert.deepEqual(OUTCOMES, ['fix-test', 'fix-product', 'file-issue', 'no-op']);
+});
+
+test('mergePatternPatch merges into one pattern by id, leaving the others untouched', () => {
+	const patterns = [{ id: 'A', count: 4 }, { id: 'B', count: 3 }];
+	const out = mergePatternPatch(patterns, 'A', { note: 'branch-specific' });
+	assert.deepEqual(out[0], { id: 'A', count: 4, note: 'branch-specific' });
+	assert.deepEqual(out[1], { id: 'B', count: 3 }); // untouched -- the whole point vs. a top-level --patch
+});
+
+test('mergePatternPatch throws with the available ids when the target id is missing', () => {
+	assert.throws(() => mergePatternPatch([{ id: 'A' }], 'Z', {}), /No pattern with id "Z".*have: A/);
+});
+
+test('applyHistorySummary seeds history + patterns from an on-disk summary; no-ops without one', () => {
+	const state = { phase: 'awaiting-pattern-selection', patterns: [] };
+	const summary = { branchSummary: { currentBranch: 'x', currentBranchRuns: 11 }, verdict: 'ok', patterns: [{ id: 'A', count: 4 }] };
+	const out = applyHistorySummary(state, summary);
+	assert.deepEqual(out.history, { branchSummary: summary.branchSummary, verdict: 'ok' });
+	assert.deepEqual(out.patterns, [{ id: 'A', count: 4 }]);
+	assert.equal(applyHistorySummary(state, null), state);
+	assert.equal(applyHistorySummary(state, { patterns: 'not-an-array' }), state);
 });

--- a/.claude/skills/triage-e2e-test/scripts/test/history-merge.test.js
+++ b/.claude/skills/triage-e2e-test/scripts/test/history-merge.test.js
@@ -1,9 +1,10 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { normalizePattern, mergeHistory, classifyVerdict, patternLabel } from '../triage-history.js';
+import { normalizePattern, mergeHistory, classifyVerdict, patternLabel, scopedRunsForEnvironments } from '../triage-history.js';
 
-const mkTest = (runs, patterns) => ({ history: { total_runs: runs }, failure_patterns: patterns });
+const mkTest = (runs, patterns, environmentBreakdown) => ({ history: { total_runs: runs }, failure_patterns: patterns, environment_breakdown: environmentBreakdown });
 const occ = (sha, os = 'ubuntu', browser = 'electron') => ({ sha, os, browser, outcome: 'flaky', report_url: `https://x/${sha}/index.html` });
+const env = (os, browser, total_runs) => ({ os, browser, total_runs });
 
 test('normalizePattern collapses whitespace, lowercases, and truncates', () => {
 	assert.equal(normalizePattern('  Error:  Foo\n\nBar  '), 'error: foo bar');
@@ -25,6 +26,38 @@ test('mergeHistory matches patterns across branches by text, not position', () =
 	assert.equal(patterns[0].seenOn, 'both');
 	assert.equal(patterns[1].seenOn, 'main only');
 	assert.deepEqual(patterns[0].id + patterns[1].id, 'AB');
+});
+
+test('mergeHistory scopes each branch rate to the environments the pattern occurred in, not blended totals', () => {
+	// Regression: a pattern confined to one environment on one branch must not be
+	// diluted by dividing its count by the combined total_runs of both branches
+	// across all environments (that understated a 100%-in-environment failure as 0.8%).
+	const current = mkTest(11, [
+		{ pattern: 'locator.click timeout', count: 4, occurrences: [occ('c1', 'ubuntu', 'chromium')] },
+	], [
+		env('ubuntu', 'chromium', 4), env('ubuntu', 'electron', 3), env('win', 'electron', 4),
+	]);
+	const main = mkTest(480, [
+		{ pattern: 'locator.click timeout', count: 3, occurrences: [occ('m1', 'ubuntu', 'chromium')] },
+	], [
+		env('ubuntu', 'chromium', 157), env('ubuntu', 'electron', 142), env('win', 'electron', 133),
+	]);
+	const { patterns } = mergeHistory(current, main, 'feature/x', 1);
+
+	assert.equal(patterns[0].environments.length, 1);
+	assert.equal(patterns[0].environments[0], 'ubuntu/chromium');
+	const byBranch = Object.fromEntries(patterns[0].rates.map(r => [r.branch, r]));
+	assert.deepEqual(byBranch['feature/x'], { branch: 'feature/x', count: 4, environmentRuns: 4, ratePercent: 100 });
+	assert.deepEqual(byBranch.main, { branch: 'main', count: 3, environmentRuns: 157, ratePercent: 1.9 });
+});
+
+test('scopedRunsForEnvironments sums only matching os/browser entries, null when no match or no breakdown', () => {
+	const breakdown = [env('ubuntu', 'chromium', 10), env('win', 'electron', 5)];
+	assert.equal(scopedRunsForEnvironments(breakdown, ['ubuntu/chromium']), 10);
+	assert.equal(scopedRunsForEnvironments(breakdown, ['ubuntu/chromium', 'win/electron']), 15);
+	assert.equal(scopedRunsForEnvironments(breakdown, ['mac/electron']), null);
+	assert.equal(scopedRunsForEnvironments(null, ['ubuntu/chromium']), null);
+	assert.equal(scopedRunsForEnvironments(breakdown, []), null);
 });
 
 test('mergeHistory prefers a current-branch representative occurrence and keeps only N', () => {

--- a/.claude/skills/triage-e2e-test/scripts/test/record-diagnosis.test.js
+++ b/.claude/skills/triage-e2e-test/scripts/test/record-diagnosis.test.js
@@ -74,19 +74,28 @@ test('validateDiagnosis rejects a multi-line or overlong summary', () => {
 	assert.match(validateDiagnosis({ ...diagnosis(), summary: 'x'.repeat(601) }), /chars; keep it under/);
 });
 
-test('deriveFrequency builds runs/percentage/env from the selected pattern', () => {
+test('deriveFrequency renders one clause per branch, scoped to matching environments (never blended)', () => {
 	const history = {
 		branchSummary: { mainRuns: 317 },
 		patterns: [
-			{ id: 'A', count: 31, percentage: 9.8, environments: ['ubuntu/chromium'] },
-			{ id: 'B', count: 1, percentage: 0.3, environments: ['ubuntu/electron'] },
+			{
+				id: 'A', count: 34, environments: ['ubuntu/chromium'],
+				rates: [
+					{ branch: 'feature/x', count: 4, environmentRuns: 4, ratePercent: 100 },
+					{ branch: 'main', count: 30, environmentRuns: 157, ratePercent: 19.1 },
+				],
+			},
+			{ id: 'B', count: 1, environments: ['ubuntu/electron'], rates: [{ branch: 'main', count: 1, environmentRuns: 317, ratePercent: 0.3 }] },
 		],
 	};
-	assert.equal(deriveFrequency(history, 'A'), '31/317 runs (9.8%), ubuntu/chromium');
-	assert.equal(deriveFrequency(history, 'B'), '1/317 runs (0.3%), ubuntu/electron');
+	assert.equal(deriveFrequency(history, 'A'), '4/4 runs (100%) on feature/x; 30/157 runs (19.1%) on main, ubuntu/chromium');
+	assert.equal(deriveFrequency(history, 'B'), '1/317 runs (0.3%) on main, ubuntu/electron');
 	assert.equal(deriveFrequency(null, 'A'), null);
 	// A selected-but-unmatched pattern returns null, never the dominant pattern's numbers.
 	assert.equal(deriveFrequency(history, 'Z'), null);
 	// No selection falls back to the dominant (first) pattern.
-	assert.equal(deriveFrequency(history, null), '31/317 runs (9.8%), ubuntu/chromium');
+	assert.equal(deriveFrequency(history, null), '4/4 runs (100%) on feature/x; 30/157 runs (19.1%) on main, ubuntu/chromium');
+	// Missing environment_breakdown data (environmentRuns null) still renders a count, no bogus rate.
+	const noBreakdown = { patterns: [{ id: 'C', count: 2, environments: [], rates: [{ branch: 'main', count: 2, environmentRuns: null, ratePercent: null }] }] };
+	assert.equal(deriveFrequency(noBreakdown, 'C'), '2 runs on main');
 });

--- a/.claude/skills/triage-e2e-test/scripts/triage-history.js
+++ b/.claude/skills/triage-e2e-test/scripts/triage-history.js
@@ -51,6 +51,29 @@ function occEnvironments(occurrences) {
 	return [...envs];
 }
 
+function envKey(os, browser) {
+	return [os, browser].filter(Boolean).join('/');
+}
+
+/**
+ * Sum `total_runs` from a test object's `environment_breakdown` for exactly the
+ * environments a pattern occurred in. Returns null when the breakdown is
+ * missing or none of its entries match (so callers can tell "no data" apart
+ * from a genuine zero).
+ */
+export function scopedRunsForEnvironments(environmentBreakdown, environments) {
+	if (!Array.isArray(environmentBreakdown) || !environments.length) { return null; }
+	let sum = 0;
+	let matched = false;
+	for (const e of environmentBreakdown) {
+		if (environments.includes(envKey(e.os, e.browser))) {
+			sum += e.total_runs || 0;
+			matched = true;
+		}
+	}
+	return matched ? sum : null;
+}
+
 /**
  * Merge the current-branch and main test objects into a single ordered pattern
  * list. Patterns are matched across branches by normalized failure text, never
@@ -89,6 +112,7 @@ export function mergeHistory(current, main, currentBranch, occurrencesPerPattern
 					fullPattern: p.pattern,
 					branches: new Set(),
 					count: 0,
+					branchCounts: new Map(),
 					environments: new Set(),
 					occurrences: [],
 				});
@@ -96,6 +120,7 @@ export function mergeHistory(current, main, currentBranch, occurrencesPerPattern
 			const entry = byKey.get(key);
 			entry.branches.add(branchLabel);
 			entry.count += p.count || 0;
+			entry.branchCounts.set(branchLabel, (entry.branchCounts.get(branchLabel) || 0) + (p.count || 0));
 			for (const e of occEnvironments(p.occurrences)) { entry.environments.add(e); }
 			for (const o of (p.occurrences || [])) {
 				entry.occurrences.push({ branch: branchLabel, ...o });
@@ -109,6 +134,7 @@ export function mergeHistory(current, main, currentBranch, occurrencesPerPattern
 	const currentRuns = current?.history?.total_runs ?? null;
 	const mainRuns = main?.history?.total_runs ?? null;
 	const totalRuns = (currentRuns || 0) + (mainRuns || 0);
+	const breakdownByBranch = { [currentBranch]: current?.environment_breakdown, main: main?.environment_breakdown };
 
 	const patterns = [...byKey.values()]
 		.sort((a, b) => b.count - a.count)
@@ -121,12 +147,26 @@ export function mergeHistory(current, main, currentBranch, occurrencesPerPattern
 			// One representative occurrence by default; prefer a current-branch one.
 			const rep = entry.occurrences.find(o => o.branch === currentBranch) || entry.occurrences[0] || null;
 			const kept = entry.occurrences.slice(0, occurrencesPerPattern);
+			const environments = [...entry.environments];
+			// Per-branch rate scoped to the environments this pattern actually occurred
+			// in -- NOT count/totalRuns (that blends branches and environments together
+			// and can understate a pattern by 100x when it is concentrated in one
+			// environment on one branch; see triage-history.md).
+			const rates = [...entry.branchCounts.entries()].map(([branch, count]) => {
+				const environmentRuns = scopedRunsForEnvironments(breakdownByBranch[branch], environments);
+				return {
+					branch,
+					count,
+					environmentRuns,
+					ratePercent: environmentRuns ? Math.round((count / environmentRuns) * 1000) / 10 : null,
+				};
+			});
 			return {
 				id: patternLabel(i), // A, B, .. Z, AA, AB, ...
 				failure: entry.failure,
 				count: entry.count,
-				percentage: totalRuns ? Math.round((entry.count / totalRuns) * 1000) / 10 : null,
-				environments: [...entry.environments],
+				rates,
+				environments,
 				seenOn,
 				representativeOccurrence: rep && {
 					branch: rep.branch, sha: rep.sha, os: rep.os,
@@ -240,7 +280,7 @@ function main() {
 			queriedBranches: queriedCurrent ? [currentBranch, 'main'] : ['main'],
 		},
 		patterns: merged.patterns.map(p => ({
-			id: p.id, failure: p.failure, count: p.count, percentage: p.percentage,
+			id: p.id, failure: p.failure, count: p.count, rates: p.rates,
 			environments: p.environments, seenOn: p.seenOn,
 			representativeOccurrence: p.representativeOccurrence,
 		})),


### PR DESCRIPTION
### Summary
Fixes a metrics bug in triage-e2e-test where failure-pattern rates were diluted across branches/environments, plus  checkpoint.js silently dropped pattern data on partial patches.
- triage-history.js: replace blended `percentage` with per-branch `rates[]` scoped to the pattern's actual environments (a pattern hitting 100% of one environment on one branch was reporting as 0.8%)
- record-diagnosis.js: `deriveFrequency` no longer pairs a branch-specific count with the wrong branch's total run count
- checkpoint.js: `--init` auto-seeds history/patterns from the on-disk history summary; new `--patch-pattern <id>` for safely annotating one pattern instead of resending the whole array
- SKILL.md: corrected example table/column, tightened the "investigate one pattern" rule to forbid fetching evidence for unselected patterns without asking first
- Added/updated regression tests for all of the above

### QA Notes
n/a