### PR TITLE
Bump Ark to posit-dev/ark#1309

### DIFF
--- a/.claude/skills/bump-ark/bump_ark.py
+++ b/.claude/skills/bump-ark/bump_ark.py
@@ -510,9 +510,11 @@ def open_or_update_tracked_bump(
     tip = branch_head_sha(branch)
     if tip is None:
         ensure_branch(target_sha, title, branch)
-    elif branch_submodule_sha(branch) != target_sha:
-        eprint(f"Advancing {branch} to {target_sha}")
-        stack_submodule_commit(branch, target_sha, title, tip)
+    else:
+        main_tip = main_tip_sha()
+        if branch_submodule_sha(branch) != target_sha or missing_main_tip(tip, main_tip):
+            eprint(f"Advancing {branch} to {target_sha}")
+            stack_submodule_commit(branch, target_sha, title, tip, main_tip)
 
     if pr:
         gh(
@@ -575,10 +577,8 @@ def ensure_branch(target_sha: str, title: str, branch: str):
     ):
         return
 
-    base_commit = gh_json("api", f"repos/{POSITRON_REPO}/git/ref/heads/{BASE_BRANCH}")[
-        "object"
-    ]["sha"]
-    new_commit = make_bump_commit(target_sha, title, base_commit)
+    base_commit = main_tip_sha()
+    new_commit = make_bump_commit(target_sha, title, base_commit, [base_commit])
     gh(
         "api",
         "-X",
@@ -591,20 +591,20 @@ def ensure_branch(target_sha: str, title: str, branch: str):
 
 
 # Create a commit that sets the submodule gitlink (mode 160000, type commit) to
-# `target_sha`, parented on `parent`. The tree is `parent`'s own tree with only the
-# gitlink swapped, so the commit is a pure one-file change. Returns the new commit
-# sha.
+# `target_sha`, on top of `parents`. The tree is `tree_source`'s own tree with only
+# the gitlink swapped, so the commit differs from `tree_source` by exactly that one
+# file. Returns the new commit sha.
 #
-# Why parent's tree and not current main's tree: a PR's diff is measured from its
-# merge base, the commit the branch was cut from, which stacking never moves. If we
-# rebuilt the tree from current main, every file main touched since the fork would
-# land in the bump PR's diff, and a later main edit to one of them would conflict on
-# merge. A pure gitlink delta keeps the PR touching only the submodule, however far
-# main has drifted.
-def make_bump_commit(target_sha: str, title: str, parent: str) -> str:
-    base_tree = gh_json("api", f"repos/{POSITRON_REPO}/git/commits/{parent}")["tree"][
-        "sha"
-    ]
+# `tree_source` must be one of `parents`, normally the newest one (main's tip when
+# merging main in, otherwise the sole parent). A PR's diff is measured from its
+# merge base, so building the tree from that same parent keeps it as the merge base
+# and the diff scoped to the gitlink alone. Building the tree from a commit outside
+# `parents` would leave everything that commit added since the real merge base
+# looking like part of this change.
+def make_bump_commit(target_sha: str, title: str, tree_source: str, parents: list[str]) -> str:
+    base_tree = gh_json("api", f"repos/{POSITRON_REPO}/git/commits/{tree_source}")[
+        "tree"
+    ]["sha"]
     new_tree = gh_json(
         "api",
         "-X",
@@ -631,7 +631,7 @@ def make_bump_commit(target_sha: str, title: str, parent: str) -> str:
         f"repos/{POSITRON_REPO}/git/commits",
         "--input",
         "-",
-        input_obj={"message": title, "tree": new_tree, "parents": [parent]},
+        input_obj={"message": title, "tree": new_tree, "parents": parents},
     )["sha"]
 
 
@@ -647,12 +647,40 @@ def branch_submodule_sha(branch: str) -> Optional[str]:
     return json.loads(proc.stdout)["sha"]
 
 
+def main_tip_sha() -> str:
+    return gh_json("api", f"repos/{POSITRON_REPO}/git/ref/heads/{BASE_BRANCH}")[
+        "object"
+    ]["sha"]
+
+
+# True when `main_tip` isn't reachable from `tip` yet, i.e. this branch's last bump
+# commit predates `main_tip` and still needs a merge commit to pull it in. Left
+# unmerged, the branch and main have each changed the same gitlink path since their
+# last common ancestor, which GitHub can't auto-resolve and shows as a conflict.
+def stale_against_main(compare_status: str) -> bool:
+    return compare_status != "behind"
+
+
+def missing_main_tip(tip: str, main_tip: str) -> bool:
+    if tip == main_tip:
+        return False
+    status = gh_json("api", f"repos/{POSITRON_REPO}/compare/{tip}...{main_tip}")[
+        "status"
+    ]
+    return stale_against_main(status)
+
+
 # Advance an existing branch to a new commit that sets the submodule to
-# `target_sha`, stacked on the current tip so the ref move is a fast-forward. The
-# ref PATCH omits `force`, so a non-fast-forward (someone advanced the branch since
-# `tip` was read) is rejected rather than clobbering their work.
-def stack_submodule_commit(branch: str, target_sha: str, title: str, tip: str):
-    new_commit = make_bump_commit(target_sha, title, tip)
+# `target_sha`. Always merges in main's current tip as a second parent (unless it's
+# already the branch's tip), so a bump branch whose gitlink change would otherwise
+# conflict with one already merged into main gets folded in before it can ever show
+# as conflicted on GitHub. The ref PATCH omits `force`; since `tip` is always one of
+# the new commit's parents, moving the ref there is still a fast-forward, so a
+# non-fast-forward (someone advanced the branch since `tip` was read) is rejected
+# rather than clobbering their work.
+def stack_submodule_commit(branch: str, target_sha: str, title: str, tip: str, main_tip: str):
+    parents = [tip] if tip == main_tip else [tip, main_tip]
+    new_commit = make_bump_commit(target_sha, title, main_tip, parents)
     gh(
         "api",
         "-X",

--- a/.claude/skills/bump-ark/bump_ark.py
+++ b/.claude/skills/bump-ark/bump_ark.py
@@ -486,7 +486,7 @@ def open_or_update_tracked_bump(
         "--state",
         "open",
         "--json",
-        "number,url,author",
+        "number,url,author,title,body",
     )
     pr = prs[0] if prs else None
 
@@ -510,27 +510,39 @@ def open_or_update_tracked_bump(
     tip = branch_head_sha(branch)
     if tip is None:
         ensure_branch(target_sha, title, branch)
+        branch_changed = True
     else:
         main_tip = main_tip_sha()
-        if branch_submodule_sha(branch) != target_sha or missing_main_tip(tip, main_tip):
+        branch_changed = branch_submodule_sha(branch) != target_sha or missing_main_tip(
+            tip, main_tip
+        )
+        if branch_changed:
             eprint(f"Advancing {branch} to {target_sha}")
             stack_submodule_commit(branch, target_sha, title, tip, main_tip)
+        else:
+            eprint(f"{branch} is already at {target_sha} and up to date with {BASE_BRANCH}. Nothing to advance.")
 
     if pr:
-        gh(
-            "api",
-            "-X",
-            "PATCH",
-            f"repos/{POSITRON_REPO}/pulls/{pr['number']}",
-            "--input",
-            "-",
-            input_obj={"title": title, "body": body},
-        )
-        eprint(f"Updated {pr['url']}")
+        # A branch move already implies new content for the PR (at minimum the
+        # commit list), so only compare title/body against the existing PR when the
+        # branch itself didn't change.
+        if branch_changed or pr["title"] != title or pr["body"] != body:
+            gh(
+                "api",
+                "-X",
+                "PATCH",
+                f"repos/{POSITRON_REPO}/pulls/{pr['number']}",
+                "--input",
+                "-",
+                input_obj={"title": title, "body": body},
+            )
+            eprint(f"Updated PR #{pr['number']}")
+        else:
+            eprint(f"PR #{pr['number']} is already up to date. Nothing to change.")
         print(pr["url"])
         return
 
-    url = gh_json(
+    created = gh_json(
         "api",
         "-X",
         "POST",
@@ -538,9 +550,9 @@ def open_or_update_tracked_bump(
         "--input",
         "-",
         input_obj={"title": title, "head": branch, "base": BASE_BRANCH, "body": body},
-    )["html_url"]
-    eprint(f"Opened {url}")
-    print(url)
+    )
+    eprint(f"Opened PR #{created['number']}")
+    print(created["html_url"])
 
 
 # True when we must refuse: a main bump (`enforce_author`) with an open PR that

--- a/.claude/skills/bump-ark/test_bump_ark.py
+++ b/.claude/skills/bump-ark/test_bump_ark.py
@@ -26,6 +26,7 @@ from bump_ark import (  # noqa: E402
     first_parent_commits,
     parse_args,
     pr_resolution,
+    stale_against_main,
     tag_line,
     walk_first_parents,
 )
@@ -246,6 +247,22 @@ class AuthorGateTest(unittest.TestCase):
 
     def test_foreign_pr_refuses(self):
         self.assertTrue(blocked_by_pr_owner(True, True, "someone", "me", False))
+
+
+class StaleAgainstMainTest(unittest.TestCase):
+    def test_behind_means_already_merged(self):
+        self.assertFalse(stale_against_main("behind"))
+
+    def test_ahead_means_still_missing(self):
+        self.assertTrue(stale_against_main("ahead"))
+
+    def test_diverged_means_still_missing(self):
+        self.assertTrue(stale_against_main("diverged"))
+
+    def test_identical_means_still_missing(self):
+        # Unreachable via missing_main_tip's tip == main_tip shortcut, but the pure
+        # function itself has no such guard, so cover it directly.
+        self.assertTrue(stale_against_main("identical"))
 
 
 class BuildBodyTest(unittest.TestCase):


### PR DESCRIPTION
Closes #14481
Closes #14909

@:ark

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed hangs with the Evaluate pane of the debugger (https://github.com/posit-dev/positron/issues/14481). When an expression takes a long time to evaluate (or even infloops), it is now cancelled after 1 second.

- Fixed usability issue in R completions of string-quoted names in brackets (https://github.com/posit-dev/positron/issues/14909).

### Commits

- [Run Evaluate requests with timeout (#1309)](https://github.com/posit-dev/ark/commit/db054ebabb074e58af0b4ddcbfdb9c995415c0b3)
- [Fix within string subset completions on non-syntactic names (#1353)](https://github.com/posit-dev/ark/commit/198c705f1c448eabe984d7f29aacb2bcd120388a)
- [Disable diagnostics in installed sources](https://github.com/posit-dev/ark/commit/2873233cf8cd5434289eda9a71f1efa14fd7eef0)