### PR TITLE
Stream esbuild extension files sequentially to avoid EMFILE on Windows

### DIFF
--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -334,16 +334,16 @@ function fromLocalEsbuild(extensionPath: string, esbuildConfigFileName: string):
 			fileNames = Array.from(new Set([...fileNames, ...packagedDependencyFileNames]));
 		}
 
-		const files = fileNames
-			.map(fileName => path.join(extensionPath, fileName))
-			.map(filePath => new File({
-				path: filePath,
-				stat: fs.statSync(filePath),
-				base: extensionPath,
-				contents: fs.createReadStream(filePath)
-			}));
-
-		es.readArray(files).pipe(result);
+		// --- Start Positron ---
+		// Stream the files sequentially rather than eagerly opening a read
+		// stream for every file up front. Extensions with npm dependencies
+		// (e.g. positron-data-driver-snowflake, which bundles @azure/msal-node)
+		// enumerate thousands of node_modules files here; opening a descriptor
+		// for all of them at once exhausts the open-file limit and fails the
+		// Windows build with EMFILE. createSequentialFileStream opens one file
+		// at a time, matching fromLocalNormal. See posit-dev/positron#14998.
+		createSequentialFileStream(extensionPath, fileNames).pipe(result);
+		// --- End Positron ---
 	}).catch(err => {
 		console.error(extensionPath);
 		console.error(packagedDependencies);


### PR DESCRIPTION
## Summary

The Windows daily release build (positron-builds) fails in the `vscode-win32-x64` packaging task with:

```
'vscode-win32-x64' errored after 1.23 min
Error: EMFILE: too many open files, open '...\positron-data-driver-snowflake\node_modules\@azure\msal-node\dist\config\ManagedIdentityId.mjs.map'
```

`fromLocalEsbuild` in `build/lib/extensions.ts` packaged extension files by eagerly constructing an `fs.createReadStream` (an open file descriptor) for **every** file up front, then piping the whole array at once:

```js
const files = fileNames
    .map(fileName => path.join(extensionPath, fileName))
    .map(filePath => new File({ ..., contents: fs.createReadStream(filePath) }));
es.readArray(files).pipe(result);
```

For an extension packaged with npm dependencies, `fileNames` includes the entire `node_modules` tree. `positron-data-driver-snowflake` (added to `extensionsWithNpmDeps` in #14998) bundles `@azure/msal-node`, whose many files pushed the number of simultaneously-open descriptors past the Windows open-file limit → `EMFILE`.

A helper built for exactly this problem — `createSequentialFileStream`, which opens one file at a time — already exists and is used by `fromLocalNormal`. The esbuild path simply never adopted it.

## Fix

Wire `fromLocalEsbuild` to `createSequentialFileStream`, matching `fromLocalNormal`. One-line behavioral change; the sequential stream produces the same vinyl files, just without opening every descriptor at once.

## Why Windows-only / why now

- Windows has a much lower default file-descriptor ceiling than the Linux/macOS build runners, so only Windows tips over.
- The Snowflake data driver landed in #14998 and started taking the esbuild + npm-deps packaging path with a heavy `node_modules`; the next scheduled daily build broke and re-ran identically.

## Notes

- `fromLocalWebpack` has the same eager pattern but serves only webpack-bundled `positron-python` with `node_modules` excluded (bounded file count), so it won't hit EMFILE. Left as-is to keep this fix surgical — it's already marked temporary pending the esbuild migration.

## Testing

- `build/lib/extensions.ts` typechecks clean; precommit hygiene passed.
- Full validation is the Windows packaging build in positron-builds once the submodule pin is bumped to include this change.

Failing run for reference: https://github.com/posit-dev/positron-builds/actions/runs/30340243261/job/90307106921
