### PR TITLE
Quarto: Render high DPI images at their intended size

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
@@ -2037,7 +2037,7 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 			}
 			// Cast to ILanguageRuntimeMessageWebOutput to get resource_roots if available
 			const webMessage = message as ILanguageRuntimeMessageWebOutput;
-			this._handleOutputMessage(tracker, documentUri, message.data, webMessage);
+			this._handleOutputMessage(tracker, documentUri, message.data, message.outputMetadata, webMessage);
 		}));
 
 		// Handle result messages (execute_result) - these are computation results like "2 + 3"
@@ -2045,7 +2045,7 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 			if (message.parent_id !== executionId) {
 				return;
 			}
-			this._handleOutputMessage(tracker, documentUri, message.data);
+			this._handleOutputMessage(tracker, documentUri, message.data, message.outputMetadata);
 		}));
 
 		// Handle stream messages (stdout/stderr)
@@ -2096,6 +2096,7 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 		tracker: ExecutionTracker,
 		documentUri: URI,
 		data: Record<string, unknown>,
+		outputMetadata?: Record<string, unknown>,
 		runtimeMessage?: ILanguageRuntimeMessageWebOutput
 	): void {
 		const outputItems: ICellOutputItem[] = [];
@@ -2180,7 +2181,7 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 				};
 			}
 
-			this._addOutput(tracker, documentUri, outputItems, webviewMetadata);
+			this._addOutput(tracker, documentUri, outputItems, webviewMetadata, outputMetadata);
 		}
 	}
 
@@ -2191,7 +2192,8 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 		tracker: ExecutionTracker,
 		documentUri: URI,
 		items: ICellOutputItem[],
-		webviewMetadata?: ICellOutputWebviewMetadata
+		webviewMetadata?: ICellOutputWebviewMetadata,
+		outputMetadata?: Record<string, unknown>
 	): void {
 		// Check output limits
 		if (tracker.outputCount >= DEFAULT_EXECUTION_CONFIG.maxOutputItems) {
@@ -2239,6 +2241,7 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 			outputId: generateUuid(),
 			items,
 			webviewMetadata,
+			outputMetadata,
 		};
 
 		// Store output

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputCacheService.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputCacheService.ts
@@ -914,7 +914,7 @@ export class QuartoOutputCacheService extends Disposable implements IQuartoOutpu
 		// Preserve webviewMetadata in the ipynb metadata field
 		// This is critical for interactive outputs (Plotly, widgets, etc.) that need
 		// webview rendering - without this metadata, they fall back to text rendering
-		const metadata: Record<string, unknown> = {};
+		const metadata: Record<string, unknown> = { ...output.outputMetadata };
 		if (output.webviewMetadata) {
 			metadata.quarto_webview_metadata = output.webviewMetadata;
 		}
@@ -967,16 +967,22 @@ export class QuartoOutputCacheService extends Disposable implements IQuartoOutpu
 				break;
 		}
 
-		// Restore webviewMetadata from ipynb metadata if present
-		// This allows interactive outputs (Plotly, widgets, etc.) to render via webview
-		const webviewMetadata = (ipynbOutput.output_type === 'execute_result' || ipynbOutput.output_type === 'display_data')
-			? ipynbOutput.metadata?.quarto_webview_metadata as ICellOutputWebviewMetadata | undefined
-			: undefined;
+		// Restore webviewMetadata and outputMetadata from ipynb metadata if present:
+		// - webviewMetadata allows interactive outputs (Plotly, widgets, etc.) to render via webview
+		// - outputMetadata preserves output metadata e.g. image sizes on high DPI displays
+		let webviewMetadata: ICellOutputWebviewMetadata | undefined;
+		let outputMetadata: Record<string, unknown> | undefined;
+		if (ipynbOutput.output_type === 'execute_result' || ipynbOutput.output_type === 'display_data') {
+			const { quarto_webview_metadata, ...rest } = ipynbOutput.metadata ?? {};
+			webviewMetadata = quarto_webview_metadata as ICellOutputWebviewMetadata | undefined;
+			outputMetadata = rest;
+		}
 
 		return {
 			outputId: generateUuid(),
 			items,
 			webviewMetadata,
+			outputMetadata
 		};
 	}
 

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
@@ -2294,7 +2294,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		}
 
 		if (mime.startsWith('image/')) {
-			return this._renderImage(mime, data, output.outputId);
+			return this._renderImage(mime, data, output.outputId, output.outputMetadata);
 		}
 
 		if (mime === 'text/html') {
@@ -2602,13 +2602,32 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		return container;
 	}
 
-	private _renderImage(mime: string, data: string, outputId: string): HTMLElement {
+	private _renderImage(
+		mime: string,
+		data: string,
+		outputId: string,
+		outputMetadata?: Record<string, unknown>
+	): HTMLElement {
 		const container = document.createElement('div');
 		container.className = 'quarto-output-image-container';
 
 		const img = document.createElement('img');
 		img.className = 'quarto-output-image';
 		img.setAttribute('alt', localize('outputImage', 'Output image'));
+
+		// Set width and height from output metadata if available.
+		// On high DPI displays, kernels render images at >1 pixel ratio
+		// and specify the actual display size in the metadata.
+		const meta = outputMetadata?.[mime];
+		if (meta && typeof meta === 'object') {
+			const { width, height } = meta as Record<string, unknown>;
+			if (typeof width === 'number') {
+				img.width = width;
+			}
+			if (typeof height === 'number') {
+				img.height = height;
+			}
+		}
 
 		// Cache the natural dimensions once the image loads so the collapse
 		// summary can show "Plot (WxH)".

--- a/src/vs/workbench/contrib/positronQuarto/common/quartoExecutionTypes.ts
+++ b/src/vs/workbench/contrib/positronQuarto/common/quartoExecutionTypes.ts
@@ -111,6 +111,8 @@ export interface ICellOutput {
 	readonly items: ICellOutputItem[];
 	/** Optional metadata for webview rendering */
 	readonly webviewMetadata?: ICellOutputWebviewMetadata;
+	/** Optional per-mime output metadata e.g. `{ 'image/png': { width, height } }` */
+	readonly outputMetadata?: Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
Fixes #15183.

**Before:**

<img width="1847" height="1929" alt="image" src="https://github.com/user-attachments/assets/64d0e15b-71d0-468c-a26b-89cbf8d5106b" />

**After:**

<img width="924" height="909" alt="image" src="https://github.com/user-attachments/assets/0b29d8a2-c59a-403d-bba0-d8f5205c014b" />

### Release Notes

#### New Features

- Quarto inline output renders images at higher resolution on retina (#15183).

#### Bug Fixes

- N/A

### Validation Steps

@:quarto

See the linked issue.