### PR TITLE
Use IPython `capture` helpers in tests; extract `patch_positron_execute_request`

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/tests/conftest.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/conftest.py
@@ -3,7 +3,6 @@
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 #
 
-from http.server import HTTPServer
 from typing import Iterable
 from unittest.mock import MagicMock, Mock
 
@@ -162,27 +161,6 @@ def mock_ui_service(shell: PositronShell, monkeypatch: pytest.MonkeyPatch) -> Mo
 def mock_help_service(shell: PositronShell, monkeypatch: pytest.MonkeyPatch) -> Mock:
     mock = Mock()
     monkeypatch.setattr(shell.kernel, "help_service", mock)
-    return mock
-
-
-@pytest.fixture
-def mock_displayhook(shell: PositronShell, monkeypatch: pytest.MonkeyPatch) -> Mock:
-    mock = Mock()
-    monkeypatch.setattr(shell, "displayhook", mock)
-    return mock
-
-
-@pytest.fixture
-def mock_display_pub(shell: PositronShell, monkeypatch: pytest.MonkeyPatch) -> Mock:
-    mock = Mock()
-    monkeypatch.setattr(shell, "display_pub", mock)
-    return mock
-
-
-@pytest.fixture
-def mock_handle_request(monkeypatch: pytest.MonkeyPatch) -> Mock:
-    mock = Mock()
-    monkeypatch.setattr(HTTPServer, "handle_request", mock)
     return mock
 
 

--- a/extensions/positron-python/python_files/posit/positron/tests/test_patch/test_bokeh.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_patch/test_bokeh.py
@@ -3,9 +3,8 @@
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 #
 
-from unittest.mock import Mock
-
 import pytest
+from IPython.utils.capture import capture_output
 
 from positron.positron_ipkernel import PositronShell
 
@@ -15,7 +14,7 @@ MIME_TYPE_POSITRON_WEBVIEW_FLAG = "application/positron-webview-load.v0+json"
 
 
 @pytest.mark.usefixtures("enable_bokeh_output_notebook")
-def test_bokeh_mime_tagging(shell: PositronShell, mock_display_pub: Mock):
+def test_bokeh_mime_tagging(shell: PositronShell):
     """
     Test mime tagging.
 
@@ -23,23 +22,21 @@ def test_bokeh_mime_tagging(shell: PositronShell, mock_display_pub: Mock):
     on messages that the front-end will use to know that the data coming over should be replayed in
     multiple steps.
     """
-    shell.run_cell(
-        """\
-from bokeh.plotting import figure, show
-p = figure(title="Simple line example", x_axis_label='x', y_axis_label='y')
-p.line([1, 2, 3, 4, 5], [6, 7, 2, 4, 5], legend_label="Temp.", line_width=2)
-show(p)
-"""
-    )
-
-    calls = mock_display_pub.publish.call_args_list
+    with capture_output() as captured:
+        shell.run_cell(
+            """\
+    from bokeh.plotting import figure, show
+    p = figure(title="Simple line example", x_axis_label='x', y_axis_label='y')
+    p.line([1, 2, 3, 4, 5], [6, 7, 2, 4, 5], legend_label="Temp.", line_width=2)
+    show(p)
+    """
+        )
 
     # Assert that one of the calls has the MIME_TYPE_POSITRON_WEBVIEW_FLAG key in it along with a
     # text/html key
     assert any(
-        MIME_TYPE_POSITRON_WEBVIEW_FLAG in call.kwargs["data"]
-        and "text/html" in call.kwargs["data"]
-        for call in calls
+        MIME_TYPE_POSITRON_WEBVIEW_FLAG in output.data and "text/html" in output.data
+        for output in captured.outputs
     )
 
 

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_ipkernel.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_ipkernel.py
@@ -8,7 +8,7 @@ import logging
 import os
 from pathlib import Path
 from typing import Any, Tuple, cast
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 from ipykernel.compiler import get_tmp_directory
@@ -21,7 +21,12 @@ from positron.session_mode import SessionMode
 from positron.utils import alias_home
 
 from .conftest import PositronShell
-from .utils import CapturedError, assert_register_table_called, capture_errors
+from .utils import (
+    CapturedError,
+    assert_register_table_called,
+    capture_errors,
+    patch_positron_execute_request,
+)
 
 try:
     import lightning
@@ -486,10 +491,7 @@ class TestEditorSysPath:
         editor_dir.mkdir()
         test_file = editor_dir / "test_module.py"
         test_file.write_text("x = 42")
-
-        # Set up the parent message with code_location pointing to the test file
         editor_uri = test_file.as_uri()
-        parent = {"content": {"positron": {"code_location": {"uri": editor_uri}}}}
 
         # Ensure we're in a different directory
         original_cwd = Path.cwd()
@@ -500,7 +502,8 @@ class TestEditorSysPath:
             sys.path.remove(str(editor_dir))
 
         # Add the path (simulates pre_run_cell)
-        with patch.object(shell.kernel, "get_parent", return_value=parent):
+        # with code_location pointing to the test file
+        with patch_positron_execute_request({"code_location": {"uri": editor_uri}}):
             added_path = shell._add_editor_dir_to_sys_path()  # noqa: SLF001
 
         # Check that editor_dir was added to sys.path
@@ -523,17 +526,14 @@ class TestEditorSysPath:
         # Create a test file in cwd
         cwd = Path.cwd()
         test_file = cwd / "test_file_in_cwd.py"
-
-        # Set up the parent message with code_location pointing to a file in cwd
         editor_uri = test_file.as_uri()
-        parent = {"content": {"positron": {"code_location": {"uri": editor_uri}}}}
 
         # Count how many times cwd appears in sys.path before
         cwd_str = str(cwd)
         count_before = sys.path.count(cwd_str)
 
-        # Try to add the path
-        with patch.object(shell.kernel, "get_parent", return_value=parent):
+        # Try to add the path, with code_location pointing to a file in cwd
+        with patch_positron_execute_request({"code_location": {"uri": editor_uri}}):
             added_path = shell._add_editor_dir_to_sys_path()  # noqa: SLF001
 
         # Should not have added anything since it's the cwd
@@ -547,13 +547,10 @@ class TestEditorSysPath:
         """Test that nothing happens when no code_location is in the execute request."""
         import sys
 
-        # Parent message without positron metadata (e.g. console input)
-        parent = {"content": {}}
-
         sys_path_before = sys.path.copy()
 
-        # Try to add the path
-        with patch.object(shell.kernel, "get_parent", return_value=parent):
+        # Try to add the path, without positron metadata (e.g. console input)
+        with patch_positron_execute_request():
             added_path = shell._add_editor_dir_to_sys_path()  # noqa: SLF001
 
         # Should not have added anything
@@ -566,13 +563,10 @@ class TestEditorSysPath:
         """Test that non-file URIs are ignored."""
         import sys
 
-        # code_location with a non-file URI
-        parent = {"content": {"positron": {"code_location": {"uri": "untitled:Untitled-1"}}}}
-
         sys_path_before = sys.path.copy()
 
-        # Try to add the path
-        with patch.object(shell.kernel, "get_parent", return_value=parent):
+        # Try to add the path - code_location with a non-file URI
+        with patch_positron_execute_request({"code_location": {"uri": "untitled:Untitled-1"}}):
             added_path = shell._add_editor_dir_to_sys_path()  # noqa: SLF001
 
         # Should not have added anything
@@ -607,10 +601,7 @@ class TestEditorSysPath:
         editor_dir.mkdir()
         test_module = editor_dir / "my_test_module.py"
         test_module.write_text("TEST_VALUE = 'hello from module'")
-
-        # Set up the parent message with code_location pointing to the test module
         editor_uri = test_module.as_uri()
-        parent = {"content": {"positron": {"code_location": {"uri": editor_uri}}}}
 
         # Remove editor_dir from sys.path if present
         while str(editor_dir) in sys.path:
@@ -621,7 +612,7 @@ class TestEditorSysPath:
 
         # Run a cell that imports the module - this should work because
         # _handle_pre_run_cell adds the editor directory via code_location
-        with patch.object(shell.kernel, "get_parent", return_value=parent):
+        with patch_positron_execute_request({"code_location": {"uri": editor_uri}}):
             result = shell.run_cell("import my_test_module; value = my_test_module.TEST_VALUE")
         result.raise_error()
 
@@ -650,9 +641,6 @@ class TestEditorSysPath:
         test_file = editor_dir / "test_module.py"
         test_file.write_text("x = 42")
 
-        # Parent message without code_location (e.g. code typed in console)
-        parent = {"content": {}}
-
         # Ensure we're in a different directory
         original_cwd = Path.cwd()
         assert str(editor_dir) != str(original_cwd)
@@ -663,8 +651,8 @@ class TestEditorSysPath:
 
         sys_path_before = sys.path.copy()
 
-        # Try to add the path
-        with patch.object(shell.kernel, "get_parent", return_value=parent):
+        # Try to add the path - with no code_location (e.g. code typed in console)
+        with patch_positron_execute_request():
             added_path = shell._add_editor_dir_to_sys_path()  # noqa: SLF001
 
         # Should not have added anything since there is no code_location

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_ipkernel.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_ipkernel.py
@@ -21,7 +21,7 @@ from positron.session_mode import SessionMode
 from positron.utils import alias_home
 
 from .conftest import PositronShell
-from .utils import assert_register_table_called
+from .utils import CapturedError, assert_register_table_called, capture_errors
 
 try:
     import lightning
@@ -187,9 +187,8 @@ def traceback_result(
     request: pytest.FixtureRequest,
     shell: PositronShell,
     tmp_path: Path,
-    mock_displayhook: Mock,
     monkeypatch,
-) -> tuple[Path, Any]:
+) -> tuple[Path, CapturedError]:
     # Ensure that we're in console mode.
     monkeypatch.setattr(shell, "session_mode", SessionMode.CONSOLE)
 
@@ -202,21 +201,14 @@ def traceback_result(
     file.write_text(code)
 
     # Temporarily add the module to sys.path and call a function from it, which should error.
-    with prepended_to_syspath(str(tmp_path)):
+    with prepended_to_syspath(str(tmp_path)), capture_errors() as errors:
         shell.run_cell(f"import {request.function.__name__} as test_traceback; test_traceback.g()")
 
-    # Check that a single message was sent to the frontend.
-    call_args_list = mock_displayhook.session.send.call_args_list
-    assert len(call_args_list) == 1
+    # Check that a single error was sent to the frontend.
+    assert len(errors) == 1
+    error = errors[0]
 
-    call_args = call_args_list[0]
-
-    # Check that the message was sent over the "error" stream.
-    assert call_args.args[1] == "error"
-
-    exc_content = call_args.args[2]
-
-    return (file, exc_content)
+    return (file, error)
 
 
 @pytest.mark.xfail(
@@ -224,7 +216,7 @@ def traceback_result(
     reason="IPython >= 9.0.0 does not support the old traceback format",
 )
 def test_console_traceback(shell: PositronShell, traceback_result) -> None:
-    file, exc_content = traceback_result
+    file, error = traceback_result
 
     # NOTE(seem): This is not elegant, but I'm not sure how else to test this than other than to
     # compare the beginning of each frame of the traceback. The escape codes make it particularly
@@ -251,7 +243,7 @@ def test_console_traceback(shell: PositronShell, traceback_result) -> None:
     traceback_frame_header = f"File {colors.filenameEm}{osc8};line={{line}};{uri}{st}{path}:{{line}}{osc8};;{st}{colors.Normal}, in {colors.vName}{{func}}{colors.valEm}(){colors.Normal}"
 
     # Check that two frames were included (the top frame is included in the exception value below).
-    traceback = exc_content["traceback"]
+    traceback = error.traceback
     assert len(traceback) == 2
 
     # Check the beginning of each frame.
@@ -259,12 +251,10 @@ def test_console_traceback(shell: PositronShell, traceback_result) -> None:
     assert_ansi_string_startswith(traceback[1], traceback_frame_header.format(line=2, func="f"))
 
     # Check the exception name.
-    assert exc_content["ename"] == "Exception"
+    assert error.ename == "Exception"
 
     # The exception value should include the top of the stack trace.
-    assert_ansi_string_startswith(
-        exc_content["evalue"], "This is an error!\nCell " + colors.filenameEm
-    )
+    assert_ansi_string_startswith(error.evalue, "This is an error!\nCell " + colors.filenameEm)
 
 
 @pytest.mark.xfail(
@@ -272,7 +262,7 @@ def test_console_traceback(shell: PositronShell, traceback_result) -> None:
     reason="IPython < 9.0.0 does not support the new traceback format",
 )
 def test_console_traceback_ipy9(shell: PositronShell, traceback_result) -> None:
-    file, exc_content = traceback_result
+    file, error = traceback_result
 
     # NOTE(seem): This is not elegant, but I'm not sure how else to test this than other than to
     # compare the beginning of each frame of the traceback. The escape codes make it particularly
@@ -300,7 +290,7 @@ def test_console_traceback_ipy9(shell: PositronShell, traceback_result) -> None:
     )
 
     # Check that two frames were included (the top frame is included in the exception value below).
-    traceback = exc_content["traceback"]
+    traceback = error.traceback
     assert len(traceback) == 2
 
     # Check the beginning of each frame.
@@ -308,18 +298,16 @@ def test_console_traceback_ipy9(shell: PositronShell, traceback_result) -> None:
     assert_ansi_string_startswith(traceback[1], traceback_frame_header.format(line=2, func="f"))
 
     # Check the exception name.
-    assert exc_content["ename"] == "Exception"
+    assert error.ename == "Exception"
 
     # The exception value should include the top of the stack trace.
     assert_ansi_string_startswith(
-        exc_content["evalue"],
+        error.evalue,
         "This is an error!\n" + colors.format([(ultratb.Token.NormalEm, "Cell")]),  # type: ignore
     )
 
 
-def test_notebook_traceback(
-    shell: PositronShell, tmp_path: Path, mock_displayhook: Mock, monkeypatch
-) -> None:
+def test_notebook_traceback(shell: PositronShell, tmp_path: Path, monkeypatch) -> None:
     # Ensure that we're in notebook mode.
     monkeypatch.setattr(shell, "session_mode", SessionMode.NOTEBOOK)
 
@@ -332,27 +320,20 @@ def test_notebook_traceback(
     file.write_text(code)
 
     # Temporarily add the module to sys.path and call a function from it, which should error.
-    with prepended_to_syspath(str(tmp_path)):
+    with prepended_to_syspath(str(tmp_path)), capture_errors() as errors:
         shell.run_cell("import test_traceback; test_traceback.g()")
 
     # Check that a single message was sent to the frontend.
-    call_args_list = mock_displayhook.session.send.call_args_list
-    assert len(call_args_list) == 1
-
-    call_args = call_args_list[0]
-
-    # Check that the message was sent over the "error" stream.
-    assert call_args.args[1] == "error"
-
-    exc_content = call_args.args[2]
+    assert len(errors) == 1
+    error = errors[0]
 
     # Check that we haven't removed any frames.
     # We don't check the traceback contents in this case since that's tested in IPython.
-    assert len(exc_content["traceback"]) == 6
+    assert len(error.traceback) == 6
 
     # Check that we haven't modified any other contents.
-    assert exc_content["ename"] == "Exception"
-    assert exc_content["evalue"] == "This is an error!"
+    assert error.ename == "Exception"
+    assert error.evalue == "This is an error!"
 
 
 def assert_ansi_string_startswith(actual: str, expected: str) -> None:

--- a/extensions/positron-python/python_files/posit/positron/tests/utils.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/utils.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import os
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterator
+from typing import TYPE_CHECKING, Any, Generator
 from unittest.mock import Mock, patch
 
 from IPython.core.getipython import get_ipython
@@ -150,8 +150,11 @@ def dummy_rpc_request(*args):
 
 
 @contextmanager
-def patch_positron_execute_request(shell, positron: dict | None = None):
+def patch_positron_execute_request(positron: dict | None = None):
     """Patch the shell's get_parent to return a message with the given positron dict."""
+    shell = get_ipython()
+    if shell is None:
+        raise RuntimeError("patch_positron_execute_request() must be used in an IPython shell")
     positron = positron or {}
     parent = {"content": {"positron": positron}}
     with patch.object(shell.kernel, "get_parent", return_value=parent):
@@ -174,7 +177,7 @@ class CapturedError:
 
 
 @contextmanager
-def capture_errors() -> Iterator[list[CapturedError]]:
+def capture_errors() -> Generator[list[CapturedError]]:
     """Capture errors published by the kernel."""
     shell = get_ipython()
     if shell is None:
@@ -185,7 +188,7 @@ def capture_errors() -> Iterator[list[CapturedError]]:
     original_send = session.send
 
     def send(stream, msg_or_type=None, content=None, *args, **kwargs):
-        if msg_or_type == "error":
+        if msg_or_type == "error" and content is not None:
             error = CapturedError(
                 ename=content["ename"],
                 evalue=content["evalue"],

--- a/extensions/positron-python/python_files/posit/positron/tests/utils.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/utils.py
@@ -3,17 +3,22 @@
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 #
 
+from __future__ import annotations
+
 import os
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, List, Optional, Set
-from unittest.mock import Mock
+from typing import TYPE_CHECKING, Any, Iterator
+from unittest.mock import Mock, patch
 
-from positron._vendor.pydantic import BaseModel
-from positron.utils import JsonData, JsonRecord
+from IPython.core.getipython import get_ipython
+
+if TYPE_CHECKING:
+    from positron._vendor.pydantic import BaseModel
+    from positron.utils import JsonData, JsonRecord
 
 
-def assert_pydantic_model_equal(actual: BaseModel, expected: BaseModel, exclude: Set[str]) -> None:
+def assert_pydantic_model_equal(actual: BaseModel, expected: BaseModel, exclude: set[str]) -> None:
     actual_dict = actual.dict(exclude=exclude)
     expected_dict = expected.dict(exclude=exclude)
     assert actual_dict == expected_dict
@@ -30,7 +35,7 @@ def preserve_working_directory():
 
 
 def assert_register_table_called(
-    mock_dataexplorer_service: Mock, obj: Any, title: str, variable_path: Optional[List[str]] = None
+    mock_dataexplorer_service: Mock, obj: Any, title: str, variable_path: list[str] | None = None
 ) -> None:
     call_args_list = mock_dataexplorer_service.register_table.call_args_list
     assert len(call_args_list) == 1
@@ -48,7 +53,7 @@ def assert_register_table_called(
 
 
 def comm_message(
-    data: Optional[JsonRecord] = None,
+    data: JsonRecord | None = None,
 ) -> JsonRecord:
     if data is None:
         data = {}
@@ -64,7 +69,7 @@ def comm_request(data: JsonRecord, **kwargs) -> JsonRecord:
     return {"content": {"data": data, **kwargs.pop("content", {})}, **kwargs}
 
 
-def comm_open_message(target_name: str, data: Optional[JsonRecord] = None) -> JsonRecord:
+def comm_open_message(target_name: str, data: JsonRecord | None = None) -> JsonRecord:
     return {
         **comm_message(data),
         "target_name": target_name,
@@ -92,7 +97,7 @@ def json_rpc_error(code: int, message: str) -> JsonRecord:
     )
 
 
-def json_rpc_notification(method: str, params: Optional[JsonRecord] = None) -> JsonRecord:
+def json_rpc_notification(method: str, params: JsonRecord | None = None) -> JsonRecord:
     return comm_message(
         {
             "jsonrpc": "2.0",
@@ -104,7 +109,7 @@ def json_rpc_notification(method: str, params: Optional[JsonRecord] = None) -> J
 
 def json_rpc_request(
     method: str,
-    params: Optional[JsonRecord] = None,
+    params: JsonRecord | None = None,
     **content: JsonData,
 ) -> JsonRecord:
     data = {"params": params} if params else {}
@@ -142,3 +147,55 @@ def percent_difference(actual: float, expected: float) -> float:
 
 def dummy_rpc_request(*args):
     return json_rpc_request(*args, comm_id="dummy_comm_id")
+
+
+@contextmanager
+def patch_positron_execute_request(shell, positron: dict | None = None):
+    """Patch the shell's get_parent to return a message with the given positron dict."""
+    positron = positron or {}
+    parent = {"content": {"positron": positron}}
+    with patch.object(shell.kernel, "get_parent", return_value=parent):
+        yield
+
+
+def run_with_metadata(shell, code: str, positron: dict | None = None):
+    """Run a cell with the given positron metadata."""
+    with patch_positron_execute_request(shell, positron):
+        return shell.run_cell(code).raise_error()
+
+
+class CapturedError:
+    """A captured kernel error message."""
+
+    def __init__(self, ename: str, evalue: str, traceback: list[str]):
+        self.ename = ename
+        self.evalue = evalue
+        self.traceback = traceback
+
+
+@contextmanager
+def capture_errors() -> Iterator[list[CapturedError]]:
+    """Capture errors published by the kernel."""
+    shell = get_ipython()
+    if shell is None:
+        raise RuntimeError("capture_errors() must be used in an IPython shell")
+
+    errors: list[CapturedError] = []
+    session = shell.displayhook.session
+    original_send = session.send
+
+    def send(stream, msg_or_type=None, content=None, *args, **kwargs):
+        if msg_or_type == "error":
+            error = CapturedError(
+                ename=content["ename"],
+                evalue=content["evalue"],
+                traceback=content["traceback"],
+            )
+            errors.append(error)
+        return original_send(stream, msg_or_type, content, *args, **kwargs)
+
+    session.send = send
+    try:
+        yield errors
+    finally:
+        session.send = original_send

--- a/extensions/positron-python/python_files/posit/positron/tests/utils.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/utils.py
@@ -178,7 +178,7 @@ class CapturedError:
 
 
 @contextmanager
-def capture_errors() -> Generator[list[CapturedError]]:
+def capture_errors() -> Generator[list[CapturedError], None, None]:
     """Capture errors published by the kernel."""
     from positron.positron_ipkernel import PositronShell
 

--- a/extensions/positron-python/python_files/posit/positron/tests/utils.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/utils.py
@@ -11,8 +11,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generator
 from unittest.mock import Mock, patch
 
-from IPython.core.getipython import get_ipython
-
 if TYPE_CHECKING:
     from positron._vendor.pydantic import BaseModel
     from positron.utils import JsonData, JsonRecord
@@ -152,18 +150,21 @@ def dummy_rpc_request(*args):
 @contextmanager
 def patch_positron_execute_request(positron: dict | None = None):
     """Patch the shell's get_parent to return a message with the given positron dict."""
-    shell = get_ipython()
-    if shell is None:
-        raise RuntimeError("patch_positron_execute_request() must be used in an IPython shell")
+    from positron.positron_ipkernel import PositronIPyKernel
+
+    kernel = PositronIPyKernel.instance()
     positron = positron or {}
     parent = {"content": {"positron": positron}}
-    with patch.object(shell.kernel, "get_parent", return_value=parent):
+    with patch.object(kernel, "get_parent", return_value=parent):
         yield
 
 
-def run_with_metadata(shell, code: str, positron: dict | None = None):
+def run_with_metadata(code: str, positron: dict | None = None):
     """Run a cell with the given positron metadata."""
-    with patch_positron_execute_request(shell, positron):
+    from positron.positron_ipkernel import PositronShell
+
+    shell = PositronShell.instance()
+    with patch_positron_execute_request(positron):
         return shell.run_cell(code).raise_error()
 
 
@@ -179,12 +180,11 @@ class CapturedError:
 @contextmanager
 def capture_errors() -> Generator[list[CapturedError]]:
     """Capture errors published by the kernel."""
-    shell = get_ipython()
-    if shell is None:
-        raise RuntimeError("capture_errors() must be used in an IPython shell")
+    from positron.positron_ipkernel import PositronShell
 
+    shell = PositronShell.instance()
     errors: list[CapturedError] = []
-    session = shell.displayhook.session
+    session = shell.displayhook.session  # type: ignore
     original_send = session.send
 
     def send(stream, msg_or_type=None, content=None, *args, **kwargs):


### PR DESCRIPTION
Small refactor to use IPython's existing `capture_output` and our own similar `capture_errors` helpers instead of mocking. I came across this while working on something else and figured it was a small but worthwhile improvement. Also added `patch_positron_execute_request`.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

Only test code affected.