### PR TITLE
e2e: start a fresh conversation before asserting the Posit Assistant welcome page

### DIFF
--- a/test/e2e/tests/posit-assistant/posit-assistant.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant.test.ts
@@ -32,6 +32,15 @@ test.describe('Posit Assistant', {
 			test(`${provider} - Open Posit Assistant and verify welcome page`, async function ({ app }) {
 				await app.workbench.positAssistant.open();
 				await app.workbench.positAssistant.waitForReady();
+				// Posit Assistant persists client state (including the active
+				// conversation) in a file store shared machine-wide (assistant#1888,
+				// wave-2 conversation substrate), so a fresh Positron instance
+				// restores the last conversation left by ANY earlier suite on the
+				// same runner (e.g. the sign-in suite's "Say hello" chats) instead
+				// of showing the welcome page. Start a fresh conversation first so
+				// the landing page renders deterministically.
+				// See https://github.com/posit-dev/positron/issues/15187
+				await app.workbench.positAssistant.startNewConversation();
 				await app.workbench.positAssistant.expectWelcomeVisible();
 			});
 


### PR DESCRIPTION
Fixes #15187

The Posit Assistant welcome-page e2e test fails deterministically on every assistant-tagged CI run since 2026-07-28. Posit Assistant's wave-2 conversation substrate (posit-dev/assistant#1888, merged 2026-07-27) persists client state - including the active conversation - in a machine-wide file store under `~/.posit/assistant`. On CI, all Playwright workers share HOME, so a fresh Positron instance restores the conversation left behind by an earlier suite in the same job (the sign-in suite's "Say hello" chats) instead of showing the welcome landing page, and `expectWelcomeVisible()` times out.

This PR starts a fresh conversation before asserting the welcome hero, matching the pattern every other test in the file already uses. Full root-cause analysis, including the worker-level scheduling evidence and the passing-run control group, is in #15187.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A (test-only change)

### Validation Steps

@:assistant

The modified test is `test/e2e/tests/posit-assistant/posit-assistant.test.ts` ("Open Posit Assistant and verify welcome page"). It requires an Anthropic API key, so CI is the practical way to exercise it; the assistant suite runs it under the tag above. To reproduce the original failure mode, run the posit-assistant sign-in suite first, then this test: without this fix the welcome page is replaced by the restored sign-in conversation; with it, the landing page renders after the new-conversation reset.
