### PR TITLE
e2e: stop forcing the session tab click through notification toasts

### DIFF
--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -731,14 +731,19 @@ export class Sessions {
 
 			if (!isSingleSession && sessionId) {
 				const targetTab = this.getSessionTab(sessionId);
+
 				await expect(async () => {
-					// Use force to bypass notification toasts that may overlay the tab. A
-					// toast can also swallow the click outright (it's on top, so the real
-					// tab never receives it) -- verify the tab actually went active instead
-					// of assuming the click landed, and retry if it didn't.
-					await targetTab.click({ force: true });
-					await expect(targetTab).toHaveClass(/tab-button--active/);
-				}, `Select session tab: ${sessionId}`).toPass({ timeout: 10000 });
+					// Toasts render over the session tab bar, and their auto-dismiss timer
+					// is held open while the pointer sits on them -- keep the mouse clear.
+					await this.page.mouse.move(0, 0);
+
+					// No force: let Playwright wait until the tab itself receives the
+					// click, rather than dispatching it into whatever is on top. Inner
+					// timeouts stay well under the outer budget, otherwise the first
+					// attempt consumes it and this never retries.
+					await targetTab.click({ timeout: 5000 });
+					await expect(targetTab).toHaveClass(/tab-button--active/, { timeout: 2000 });
+				}, `Select session tab: ${sessionId}`).toPass({ timeout: 30000 });
 			}
 
 			const metadata = await this.extractMetadataFromDialog(sessionId);

--- a/test/e2e/tests/packages-pane/packages-pane.test.ts
+++ b/test/e2e/tests/packages-pane/packages-pane.test.ts
@@ -84,6 +84,14 @@ test.describe('Packages Pane', {
 		});
 
 	test.describe('Help button', { tag: [tags.HELP] }, () => {
+		test.beforeAll(async function ({ runCommand }) {
+			// Session tabs render at the right edge of the console pane, in the same band
+			// where notification toasts stack upward from the bottom of the window. The
+			// package install/uninstall tests above raise those toasts, so maximize the
+			// panel to lift the tabs clear of them.
+			await runCommand('workbench.action.maximizePanel');
+		});
+
 		test('R - Opens package help in Help pane', async function ({ app, r: _r }) {
 			const { packages } = app.workbench;
 


### PR DESCRIPTION
### Summary

Fixes a flaky `Select session tab: r-<id>` failure in `sessions.getMetadata()`. The tab was clicked with `force: true`, which skips the hit-target check and dispatches the click at the tab's coordinates even when a notification toast is on top of it. The toast absorbed the click, the tab never went active, and the surrounding retry could not recover: its inner assertion inherited the 15s global expect timeout against a 10s outer budget, so exactly one attempt ever ran.

Note: the getMetaData() change is going to be a moot point once chris' PR merges in.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

@:packages-pane @:help @:sessions @:web

Test-only change; `getMetadata()` is called by every session start, so the sessions suite is the blast radius. Verified locally on electron and chromium (5/6 in the packages-pane spec; the one failure, the Python pythonAlt package list, is pre-existing on main at 12.5% on mac/electron).


### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- sessions.getMetadata() clicked the console session tab with force: true, which skips the hit-target check and dispatches the click at the tab coordinates even while a notification toast covers it. The toast absorbed the click (the Ports view opened in the next frame), so the tab never gained tab-button--active. The surrounding toPass could not recover: the inner expect inherited the 15s global expect timeout against a 10s outer budget, so exactly one attempt ever ran.</summary>

- **Test:** [Packages Pane > Help button > R - Opens package help in Help pane](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Packages%20Pane%20%3E%20Help%20button%20%3E%20R%20-%20Opens%20package%20help%20in%20Help%20pane%7C%7C%7Ctest%2Fe2e%2Ftests%2Fpackages-pane%2Fpackages-pane.test.ts)
- **Targeted failure:** Error: Select session tab: r-<id> -- toPass timeout after 10s in sessions.getMetadata()
- **Signal:** Trace timeline: one Frame.click on console-tab-r-ed60382d (ok at t=1964189), then a single Frame.expect at t=1964219 that never returns (failure screenshot t=1973813, ~9.6s later) -- zero retry iterations. Screencast frame 21 (t=1963807, pre-click) shows the console session tab bar covered by three stacked toasts: two 'Package cowsay was installed/uninstalled -- a session restart may be required' from the preceding R package test, plus the web-only port-forward toast. Frame 24 (t=1964220, post-click) shows the bottom panel switched from CONSOLE to PORTS with the 'See all forwarded ports' link highlighted. playwright.config.ts:74 sets expect.timeout=15000; sessions.ts:741 sets toPass timeout=10000.
- **Frequency:** 1/136 runs (0.7%) on main, ubuntu/chromium
- **Hypothesis:** Two layers. (1) POM (sessions.ts getMetadata): drop force: true so Playwright waits until the tab itself is hittable instead of dispatching a click into whatever toast is on top; give the inner click/assert explicit short timeouts (5s/2s) so the outer toPass budget can actually iterate -- previously the inner expect inherited the 15s global timeout against a 10s outer budget, so exactly one attempt ever ran; park the mouse at (0,0) each iteration since a toast auto-dismiss timer is held open while the pointer sits on it. (2) Spec (packages-pane.test.ts, Help button beforeAll): run the workbench.action.maximizePanel command so the session tab list -- which renders at the RIGHT edge of the console pane and stacks downward from the container top -- sits clear of the toast band, which is anchored right:3px/bottom:25px and stacks upward. Rejected: toasts.closeAll() inside getMetadata (racy hover/index, plus a global side effect in a helper every sessions.start calls); enterLayout(fullSizedPanel) (makeMaximizedPartLayout hides the sidebar, where the Packages pane lives); resizePanelToHeight (a pixel guess that squeezes the sidebar at 600 of 800px); and clicking the maximize icon (it sits inside the same toast band this is avoiding).

</details>

