### PR TITLE
e2e: wait for a new conversation to land before selecting a model

### DIFF
--- a/test/e2e/pages/positAssistant.ts
+++ b/test/e2e/pages/positAssistant.ts
@@ -197,6 +197,14 @@ export class PositAssistant {
 			}
 			throw e;
 		}
+		// The click is handled asynchronously: for up to ~1s the pane still shows
+		// the outgoing conversation, its model selection, and an editable input, so
+		// `waitForReady()` alone is satisfied against the old conversation. The
+		// button flips to disabled only once the fresh conversation has actually
+		// landed -- which is also when the model selection is dropped -- so wait for
+		// that here, or a model the caller selects next gets clobbered mid-test and
+		// Send stays disabled.
+		await expect(button).toBeDisabled();
 		await this.waitForReady();
 	}
 
@@ -239,9 +247,16 @@ export class PositAssistant {
 
 	/**
 	 * Clicks the send button to submit the current message.
+	 *
+	 * Send is disabled until the input has text and a model is selected. Waiting
+	 * for it to be enabled first turns "the model selection was dropped" into a
+	 * named assertion failure instead of a 30s click timeout that reports the send
+	 * button as the culprit.
 	 */
 	async clickSend(): Promise<void> {
-		await this.frame.locator(SEND_BUTTON).click();
+		const sendButton = this.frame.locator(SEND_BUTTON);
+		await expect(sendButton).toBeEnabled();
+		await sendButton.click();
 	}
 
 	/**


### PR DESCRIPTION
Hardens the Posit Assistant e2e helpers against a race between starting a new
conversation and selecting a provider model.

### Summary

`startNewConversation()` returned as soon as `waitForReady()` passed (chat input
visible, send button rendered, stop button hidden). Those conditions are all
satisfied by the *outgoing* conversation: the click is handled asynchronously,
and for up to ~1s the pane still shows the previous conversation, its model
selection, and an editable input.

Tests that select a provider model immediately after starting a new conversation
therefore raced that switch. When the switch landed late it cleared the model
selection (expected behavior for a new conversation), leaving Send disabled and
the test hanging for 30s on `locator.click` against
`<button disabled data-testid="chat-send-button">`.

Traces from run 30394474232 (chromium / ubuntu) show the sequence precisely: the
picker read "Claude Sonnet 5 (Anthropic)" from the model click through Escape,
the input click, and the start of typing, then flipped back to "Select Model" at
the same instant the message list cleared, the welcome page appeared, and the
new-conversation button became disabled -- ~885ms after the new-conversation
click. Both `anthropic-api - Execute R code via Posit Assistant` and
`openai-api - Sign in, send hello, sign out` failed this way in that run.

Two changes:

- `startNewConversation()` waits for the new-conversation button to become
  disabled -- the state the helper already treats as "on a fresh conversation" --
  before returning.
- `clickSend()` waits for the send button to be enabled before clicking, so a
  dropped model selection surfaces as a named assertion failure instead of a 30s
  timeout that blames the send button.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A (e2e test infrastructure only)

### Validation Steps

@:assistant @:web @:win

The assistant suites exercise both changed helpers in every test
(`startNewConversation()` -> `selectProviderModel()` -> `sendMessage()`). Watch for:

1. No `locator.click` timeouts on `button:has(svg.lucide-arrow-up)`.
2. If the race recurs, it should now fail fast at the `toBeEnabled()` assertion in
   `clickSend()`, naming the send button state, instead of after a 30s click timeout.
3. The new `toBeDisabled()` wait in `startNewConversation()` assumes the button always
   ends up disabled after a successful new-conversation click. That held in both traces
   and matches the helper's existing early-return logic, but if some path leaves it
   enabled the helper will now fail there.

The Azure Workbench assistant suite (`posit-assistant-foundry.test.ts`) uses the same
two helpers and is not covered by the tags above -- worth a run if you want coverage there.
