### PR TITLE
Fix data explorer column auto-sizing when the width calculators arrive late or change mid-calculation

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
@@ -20,6 +20,7 @@ import { usePositronDataExplorerContext } from '../../../positronDataExplorerCon
 import { FontMeasurements } from '../../../../../../editor/browser/config/fontMeasurements.js';
 import { SORTING_BUTTON_WIDTH } from '../../../../positronDataGrid/components/dataGridColumnHeader.js';
 import { usePositronReactServicesContext } from '../../../../../../base/browser/positronReactRendererContext.js';
+import { ColumnWidthCalculators } from '../../../../../services/positronDataExplorer/common/tableDataCache.js';
 import { PositronDataExplorerLayout } from '../../../../../services/positronDataExplorer/browser/interfaces/positronDataExplorerService.js';
 import { VerticalSplitter, VerticalSplitterResizeParams } from '../../../../../../base/browser/ui/positronComponents/splitters/verticalSplitter.js';
 import { SummaryRowActionBar } from './summaryRowActionBar/summaryRowActionBar.js';
@@ -66,27 +67,37 @@ export const DataExplorer = () => {
 		const horizontalCellPadding =
 			context.instance.tableDataDataGridInstance.horizontalCellPadding * 2;
 
-		// Calculate the width of a sort digit. The sort index is styled with font-variant-numeric
-		// tabular-nums, so we can calculate the width of the sort index by multiplying the width of
-		// a sort digit by 2.
-		const canvas = window.document.createElement('canvas');
-		const canvasRenderingContext2D = canvas.getContext('2d');
-		let sortIndexWidth;
-		if (!canvasRenderingContext2D) {
-			sortIndexWidth = 0;
-		} else {
-			const sortIndexExemplarStyle = DOM.getComputedStyle(sortIndexExemplarRef.current);
-			canvasRenderingContext2D.font = sortIndexExemplarStyle.font;
-			sortIndexWidth = canvasRenderingContext2D.measureText('99').width;
-		}
-
 		/**
-		 * The column header width calculator.
-		 * @param columnName The column name.
-		 * @param typeName The type name.
-		 * @returns The column header width.
+		 * Creates the column header width calculator.
+		 *
+		 * The canvas, the exemplar fonts, and the basic column header width are all established
+		 * here, once, because none of them change while the calculator is in use. The calculator
+		 * that comes back reads nothing from the document, which matters because the table data
+		 * cache holds it across several backend round trips and calls it once per column: reading a
+		 * computed style per call cost a style resolution per column, and threw outright if the
+		 * calculator was called after this component unmounted, when the exemplar refs are null.
+		 * @returns The column header width calculator.
 		 */
-		const columnHeaderWidthCalculator = (columnName: string, typeName: string) => {
+		const createColumnHeaderWidthCalculator = (): ColumnWidthCalculators['columnHeaderWidthCalculator'] => {
+			// Create a canvas and a 2D rendering context for it to measure text with. The canvas is
+			// never added to the document, so it stays usable for as long as the calculator is held.
+			const canvas = window.document.createElement('canvas');
+			const canvasRenderingContext2D = canvas.getContext('2d');
+
+			// Measure the width of a sort digit and read the exemplar fonts. The sort index is
+			// styled with font-variant-numeric tabular-nums, so we can calculate the width of the
+			// sort index by multiplying the width of a sort digit by 2.
+			let sortIndexWidth = 0;
+			let columnNameFont = '';
+			let typeNameFont = '';
+			if (canvasRenderingContext2D) {
+				canvasRenderingContext2D.font =
+					DOM.getComputedStyle(sortIndexExemplarRef.current).font;
+				sortIndexWidth = canvasRenderingContext2D.measureText('99').width;
+				columnNameFont = DOM.getComputedStyle(columnNameExemplarRef.current).font;
+				typeNameFont = DOM.getComputedStyle(typeNameExemplarRef.current).font;
+			}
+
 			// Calculate the basic column header width. This allows for horizontal cell padding,
 			// the sorting button, the sort indicator, the sort index, and the border to be
 			// displayed, at a minimum.
@@ -98,66 +109,64 @@ export const DataExplorer = () => {
 				SORTING_BUTTON_WIDTH +	// The sorting button width.
 				1;						// +1 for the border.
 
-			// If the column header is empty, return the basic column header width.
-			if (!columnName && !typeName) {
-				return basicColumnHeaderWidth;
-			}
+			return (columnName, typeName) => {
+				// If the column header is empty, or text cannot be measured, return the basic
+				// column header width.
+				if ((!columnName && !typeName) || !canvasRenderingContext2D) {
+					return basicColumnHeaderWidth;
+				}
 
-			// Create a canvas and create a 2D rendering context for it to measure text.
-			const canvas = window.document.createElement('canvas');
-			const canvasRenderingContext2D = canvas.getContext('2d');
-
-			// If the 2D canvas rendering context couldn't be created, return the basic column
-			// header width.
-			if (!canvasRenderingContext2D) {
-				return basicColumnHeaderWidth;
-			}
-
-			// Set the column name width.
-			let columnNameWidth;
-			if (!columnName) {
-				columnNameWidth = 0;
-			} else {
 				// Measure the column name width using the font of the column name exemplar.
-				const columnNameExemplarStyle =
-					DOM.getComputedStyle(columnNameExemplarRef.current);
-				canvasRenderingContext2D.font = columnNameExemplarStyle.font;
-				columnNameWidth = canvasRenderingContext2D.measureText(columnName).width;
-			}
+				let columnNameWidth = 0;
+				if (columnName) {
+					canvasRenderingContext2D.font = columnNameFont;
+					columnNameWidth = canvasRenderingContext2D.measureText(columnName).width;
+				}
 
-			// Set the type name width.
-			let typeNameWidth;
-			if (!typeName) {
-				typeNameWidth = 0;
-			} else {
 				// Measure the type name width using the font of the type name exemplar.
-				const typeNameExemplarStyle = DOM.getComputedStyle(typeNameExemplarRef.current);
-				canvasRenderingContext2D.font = typeNameExemplarStyle.font;
-				typeNameWidth = canvasRenderingContext2D.measureText(typeName).width;
-			}
+				let typeNameWidth = 0;
+				if (typeName) {
+					canvasRenderingContext2D.font = typeNameFont;
+					typeNameWidth = canvasRenderingContext2D.measureText(typeName).width;
+				}
 
-			// Calculate return the column header width.
-			return Math.ceil(Math.max(columnNameWidth, typeNameWidth) + basicColumnHeaderWidth);
+				// Calculate and return the column header width.
+				return Math.ceil(Math.max(columnNameWidth, typeNameWidth) + basicColumnHeaderWidth);
+			};
 		};
 
-		// Get the editor font space width.
-		const { spaceWidth } = FontMeasurements.readFontInfo(
-			window,
-			createBareFontInfoFromRawSettings(
-				services.configurationService.getValue<IEditorOptions>('editor'),
-				PixelRatio.getInstance(window).value
-			)
-		);
+		// Create the column header width calculator. Once is enough: it measures with the exemplar
+		// fonts, which are the inherited workbench font plus static CSS, so nothing it depends on
+		// changes over the lifetime of this component.
+		const columnHeaderWidthCalculator = createColumnHeaderWidthCalculator();
 
-		// Set the width calculators.
-		context.instance.tableDataDataGridInstance.setWidthCalculators({
-			columnHeaderWidthCalculator,
-			columnValueWidthCalculator: length => Math.ceil(
-				(spaceWidth * length) +
-				horizontalCellPadding +
-				1 // For the border.
-			)
-		});
+		/**
+		 * Creates the column width calculators. Column values are rendered in the editor font, so the
+		 * column value width calculator is rebuilt whenever that font changes.
+		 * @returns The column width calculators.
+		 */
+		const createColumnWidthCalculators = (): ColumnWidthCalculators => {
+			// Get the editor font space width.
+			const { spaceWidth } = FontMeasurements.readFontInfo(
+				window,
+				createBareFontInfoFromRawSettings(
+					services.configurationService.getValue<IEditorOptions>('editor'),
+					PixelRatio.getInstance(window).value
+				)
+			);
+
+			return {
+				columnHeaderWidthCalculator,
+				columnValueWidthCalculator: length => Math.ceil(
+					(spaceWidth * length) +
+					horizontalCellPadding +
+					1 // For the border.
+				)
+			};
+		};
+
+		// Set the column width calculators.
+		context.instance.tableDataDataGridInstance.setColumnWidthCalculators(createColumnWidthCalculators());
 
 		// Create a disposable store for event handlers within this layout effect
 		const disposableStore = new DisposableStore();
@@ -175,30 +184,18 @@ export const DataExplorer = () => {
 					configurationChangeEvent.affectedKeys.has('editor.lineHeight') ||
 					configurationChangeEvent.affectedKeys.has('editor.letterSpacing')
 				) {
-					// Get the editor font space width.
-					const { spaceWidth } = FontMeasurements.readFontInfo(
-						window,
-						createBareFontInfoFromRawSettings(
-							services.configurationService.getValue<IEditorOptions>('editor'),
-							PixelRatio.getInstance(window).value
-						)
+					// Rebuild the column width calculators so column values are measured with the new
+					// editor font.
+					context.instance.tableDataDataGridInstance.setColumnWidthCalculators(
+						createColumnWidthCalculators()
 					);
-
-					context.instance.tableDataDataGridInstance.setWidthCalculators({
-						columnHeaderWidthCalculator,
-						columnValueWidthCalculator: length => Math.ceil(
-							(spaceWidth * length) +
-							horizontalCellPadding +
-							1 // For the border.
-						)
-					});
 				}
 			}
 		}));
 
 		// Return the cleanup function that disposes event listeners and cleans up resources
 		return () => {
-			context.instance.tableDataDataGridInstance.setWidthCalculators(undefined);
+			context.instance.tableDataDataGridInstance.setColumnWidthCalculators(undefined);
 			disposableStore.dispose();
 		};
 	}, [services.configurationService, context.instance.tableDataDataGridInstance]);

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -102,12 +102,6 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 */
 	private _initialLoadInProgress = false;
 
-	/**
-	 * Whether the last layout update calculated column widths. It doesn't when the column width
-	 * calculators haven't been supplied yet, which is used to recalculate them once they arrive.
-	 */
-	private _columnWidthsCalculated = false;
-
 	//#endregion Private Properties
 
 	//#region Constructor
@@ -766,16 +760,11 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	setColumnWidthCalculators(columnWidthCalculators?: ColumnWidthCalculators) {
 		this._tableDataCache.setColumnWidthCalculators(columnWidthCalculators);
 
-		// The calculators come from the data explorer's React tree, which mounts asynchronously, so
-		// the initial load can calculate column widths before they arrive. That calculation returns
-		// no widths and nothing else asks for them again, leaving the columns at their default
-		// width. Recalculate now that the calculators are available.
-		//
-		// Only when the widths are actually missing. This instance's React tree is unmounted when
-		// its editor pane is handed to another data explorer, and mounted again when the user comes
-		// back to it, so this is called repeatedly for an instance that already has its widths --
-		// where recalculating would cost needless backend round trips.
-		if (columnWidthCalculators && this._initialLoadComplete && !this._columnWidthsCalculated) {
+		// Recalculate the column widths with the new calculators. Supplying calculators means the
+		// columns are to be measured with them, whether they are arriving for the first time -- the
+		// panel mounts asynchronously, so the initial load can run before they are here -- or
+		// replacing an earlier set that measured with a font the user has since changed.
+		if (columnWidthCalculators && this._initialLoadComplete) {
 			this.recalculateColumnWidths().catch(onUnexpectedError);
 		}
 	}
@@ -945,7 +934,6 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		// Set the layout entries.
 		this._columnLayoutManager.setEntries(state.table_shape.num_columns, columnWidths);
 		this._rowLayoutManager.setEntries(state.table_shape.num_rows);
-		this._columnWidthsCalculated = columnWidths !== undefined;
 
 		// For zero-row case (e.g., after filtering), ensure a full reset of scroll positions
 		if (state.table_shape.num_rows === 0) {
@@ -1005,11 +993,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 			return;
 		}
 
-		// Calculate the column widths. This is only reached with the calculators in place, so the
-		// widths have now been calculated as well as they are going to be -- record that even if
-		// none came back, which is the case for a table with too many columns to auto-size. Leaving
-		// it unrecorded would retry this on every remount, for a result that cannot change.
-		this._columnWidthsCalculated = true;
+		// Calculate the column widths.
 		const columnWidths = await this._tableDataCache.calculateColumnWidths(
 			this.minimumColumnWidth,
 			this.maximumColumnWidth

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -102,6 +102,13 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 */
 	private _initialLoadInProgress = false;
 
+	/**
+	 * Counts the column width calculations that have been started. A calculation compares the
+	 * generation it started in against this before applying its widths, so that a slower
+	 * calculation cannot overwrite the widths of a later one that has already finished.
+	 */
+	private _columnWidthsGeneration = 0;
+
 	//#endregion Private Properties
 
 	//#region Constructor
@@ -931,7 +938,9 @@ export class TableDataDataGridInstance extends DataGridInstance {
 			this.maximumColumnWidth
 		);
 
-		// Set the layout entries.
+		// Set the layout entries. These widths are the newest, so a column width calculation still
+		// awaiting the backend is now stale and drops its result rather than overwriting them.
+		this._columnWidthsGeneration++;
 		this._columnLayoutManager.setEntries(state.table_shape.num_columns, columnWidths);
 		this._rowLayoutManager.setEntries(state.table_shape.num_rows);
 
@@ -994,13 +1003,17 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		}
 
 		// Calculate the column widths.
+		const generation = ++this._columnWidthsGeneration;
 		const columnWidths = await this._tableDataCache.calculateColumnWidths(
 			this.minimumColumnWidth,
 			this.maximumColumnWidth
 		);
 
-		// If the widths could not be calculated, leave the layout entries as they are.
-		if (!columnWidths) {
+		// If newer widths have been applied while this calculation was awaiting the backend, these
+		// ones are stale -- two editor font changes in quick succession start two calculations, and
+		// the slower one must not win. If the widths could not be calculated, leave the layout
+		// entries as they are.
+		if (generation !== this._columnWidthsGeneration || !columnWidths) {
 			return;
 		}
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -9,6 +9,7 @@ import { JSX } from 'react';
 // Other dependencies.
 import { localize } from '../../../../nls.js';
 import { Emitter } from '../../../../base/common/event.js';
+import { onUnexpectedError } from '../../../../base/common/errors.js';
 import { Severity } from '../../../../platform/notification/common/notification.js';
 import { PositronActionBarHoverManager } from '../../../../platform/positronActionBar/browser/positronActionBarHoverManager.js';
 import { IColumnSortKey } from '../../../browser/positronDataGrid/interfaces/columnSortKey.js';
@@ -21,7 +22,7 @@ import { DataExplorerClientInstance } from '../../languageRuntime/common/languag
 import { CustomContextMenuSeparator } from '../../../browser/positronComponents/customContextMenu/customContextMenuSeparator.js';
 import { MAX_ADVANCED_LAYOUT_ENTRY_COUNT } from '../../../browser/positronDataGrid/classes/layoutManager.js';
 import { PositronDataExplorerCommandId } from '../../../contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.js';
-import { InvalidateCacheFlags, TableDataCache, WidthCalculators } from '../common/tableDataCache.js';
+import { InvalidateCacheFlags, TableDataCache, ColumnWidthCalculators } from '../common/tableDataCache.js';
 import { CustomContextMenuEntry, showCustomContextMenu } from '../../../browser/positronComponents/customContextMenu/customContextMenu.js';
 import { BackendState, ColumnSchema, ExportFormat, RowFilter, SupportStatus } from '../../languageRuntime/common/positronDataExplorerComm.js';
 import { ClipboardData, ColumnSelectionState, ColumnSortKeyDescriptor, DataGridInstance, MouseSelectionType, RowSelectionState } from '../../../browser/positronDataGrid/classes/dataGridInstance.js';
@@ -94,6 +95,18 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 * Used to trigger initial load when first becoming visible.
 	 */
 	private _initialLoadComplete = false;
+
+	/**
+	 * Whether the initial data load is running. Used to keep other layout updates from duplicating
+	 * the work it is already doing, and to keep it from being started twice.
+	 */
+	private _initialLoadInProgress = false;
+
+	/**
+	 * Whether the last layout update calculated column widths. It doesn't when the column width
+	 * calculators haven't been supplied yet, which is used to recalculate them once they arrive.
+	 */
+	private _columnWidthsCalculated = false;
 
 	//#endregion Private Properties
 
@@ -172,6 +185,14 @@ export class TableDataDataGridInstance extends DataGridInstance {
 			// onDidDataUpdate, which set the pending flags and will
 			// rebuild everything when we become visible again.
 			if (!this._visible) {
+				return;
+			}
+
+			// Skip while the initial load is running. It updates the layout entries and rebuilds
+			// the sort keys itself, so doing it here as well duplicates the schema and data round
+			// trips that calculating the column widths makes -- and the initial load reads the
+			// backend state fresh, so it picks up this state anyway.
+			if (this._initialLoadInProgress) {
 				return;
 			}
 
@@ -739,11 +760,24 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	//#region Public Methods
 
 	/**
-	 * Sets the width calculators.
-	 * @param widthCalculators The width calculators.
+	 * Sets the column width calculators.
+	 * @param columnWidthCalculators The column width calculators.
 	 */
-	setWidthCalculators(widthCalculators?: WidthCalculators) {
-		this._tableDataCache.setWidthCalculators(widthCalculators);
+	setColumnWidthCalculators(columnWidthCalculators?: ColumnWidthCalculators) {
+		this._tableDataCache.setColumnWidthCalculators(columnWidthCalculators);
+
+		// The calculators come from the data explorer's React tree, which mounts asynchronously, so
+		// the initial load can calculate column widths before they arrive. That calculation returns
+		// no widths and nothing else asks for them again, leaving the columns at their default
+		// width. Recalculate now that the calculators are available.
+		//
+		// Only when the widths are actually missing. This instance's React tree is unmounted when
+		// its editor pane is handed to another data explorer, and mounted again when the user comes
+		// back to it, so this is called repeatedly for an instance that already has its widths --
+		// where recalculating would cost needless backend round trips.
+		if (columnWidthCalculators && this._initialLoadComplete && !this._columnWidthsCalculated) {
+			this.recalculateColumnWidths().catch(onUnexpectedError);
+		}
 	}
 
 	/**
@@ -831,12 +865,28 @@ export class TableDataDataGridInstance extends DataGridInstance {
 
 		// Initial load: first time becoming visible, no data loaded yet.
 		if (!this._initialLoadComplete) {
+			// Don't start a second initial load on top of one that's still running.
+			if (this._initialLoadInProgress) {
+				return;
+			}
+
+			this._initialLoadInProgress = true;
 			this._initialLoadComplete = true;
 			this._pendingSchemaUpdate = false;
 			this._pendingDataUpdate = false;
-			await this.updateLayoutEntries();
-			this.rebuildSortKeysFromCache();
-			await this.fetchData(InvalidateCacheFlags.All);
+			try {
+				await this.updateLayoutEntries();
+				this.rebuildSortKeysFromCache();
+				await this.fetchData(InvalidateCacheFlags.All);
+			} catch (error) {
+				// The load didn't finish, so let becoming visible again retry it. Without this the
+				// grid keeps whatever it had -- for a first load, no data at all -- and nothing
+				// would ask for the rest of it again.
+				this._initialLoadComplete = false;
+				throw error;
+			} finally {
+				this._initialLoadInProgress = false;
+			}
 			return;
 		}
 
@@ -895,6 +945,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		// Set the layout entries.
 		this._columnLayoutManager.setEntries(state.table_shape.num_columns, columnWidths);
 		this._rowLayoutManager.setEntries(state.table_shape.num_rows);
+		this._columnWidthsCalculated = columnWidths !== undefined;
 
 		// For zero-row case (e.g., after filtering), ensure a full reset of scroll positions
 		if (state.table_shape.num_rows === 0) {
@@ -937,6 +988,41 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		await this.updateLayoutEntries();
 		this.rebuildSortKeysFromCache();
 		await this.fetchData(InvalidateCacheFlags.Data);
+	}
+
+	/**
+	 * Recalculates the column widths and applies them to the column layout entries.
+	 *
+	 * Deliberately narrower than updateLayoutEntries: it doesn't re-read the backend state or
+	 * re-run the advanced layout limits check, which would re-raise the sticky notification for a
+	 * wide dataset that the user may have dismissed.
+	 */
+	private async recalculateColumnWidths(): Promise<void> {
+		// Get the cached backend state for the column count. The initial load populated it, so this
+		// is a guard rather than a real case.
+		const state = this._dataExplorerClientInstance.cachedBackendState;
+		if (!state) {
+			return;
+		}
+
+		// Calculate the column widths. This is only reached with the calculators in place, so the
+		// widths have now been calculated as well as they are going to be -- record that even if
+		// none came back, which is the case for a table with too many columns to auto-size. Leaving
+		// it unrecorded would retry this on every remount, for a result that cannot change.
+		this._columnWidthsCalculated = true;
+		const columnWidths = await this._tableDataCache.calculateColumnWidths(
+			this.minimumColumnWidth,
+			this.maximumColumnWidth
+		);
+
+		// If the widths could not be calculated, leave the layout entries as they are.
+		if (!columnWidths) {
+			return;
+		}
+
+		// Set the column layout entries and repaint with the new widths.
+		this._columnLayoutManager.setEntries(state.table_shape.num_columns, columnWidths);
+		this.fireOnDidUpdateEvent();
 	}
 
 	/**

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -995,13 +995,6 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 * wide dataset that the user may have dismissed.
 	 */
 	private async recalculateColumnWidths(): Promise<void> {
-		// Get the cached backend state for the column count. The initial load populated it, so this
-		// is a guard rather than a real case.
-		const state = this._dataExplorerClientInstance.cachedBackendState;
-		if (!state) {
-			return;
-		}
-
 		// Calculate the column widths.
 		const generation = ++this._columnWidthsGeneration;
 		const columnWidths = await this._tableDataCache.calculateColumnWidths(
@@ -1014,6 +1007,16 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		// the slower one must not win. If the widths could not be calculated, leave the layout
 		// entries as they are.
 		if (generation !== this._columnWidthsGeneration || !columnWidths) {
+			return;
+		}
+
+		// Take the column count from the backend state the calculation itself worked from:
+		// calculateColumnWidths awaits getBackendState, which leaves its result in
+		// cachedBackendState, so reading it here pairs the count with the widths rather than with a
+		// state that may have moved on since. The initial load populated it, so the guard is for
+		// completeness rather than a real case.
+		const state = this._dataExplorerClientInstance.cachedBackendState;
+		if (!state) {
 			return;
 		}
 

--- a/src/vs/workbench/services/positronDataExplorer/common/tableDataCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/tableDataCache.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -19,9 +19,9 @@ const TRIM_CACHE_TIMEOUT = 3_000;
 const CHUNK_SIZE = 4_096;
 
 /**
- * WidthCalculators interface.
+ * ColumnWidthCalculators interface.
  */
-export interface WidthCalculators {
+export interface ColumnWidthCalculators {
 	columnHeaderWidthCalculator: (columnName: string, typeName: string) => number;
 	columnValueWidthCalculator: (length: number) => number;
 }
@@ -151,9 +151,9 @@ export class TableDataCache extends Disposable {
 	private _hasRowLabels = false;
 
 	/**
-	 * Gets or sets the width calculators.
+	 * Gets or sets the column width calculators.
 	 */
-	private _widthCalculators?: WidthCalculators;
+	private _columnWidthCalculators?: ColumnWidthCalculators;
 
 	/**
 	 * Gets the column schema cache.
@@ -231,11 +231,11 @@ export class TableDataCache extends Disposable {
 	//#region Public Methods
 
 	/**
-	 * Sets the width calculators.
-	 * @param widthCalculators The width calculators.
+	 * Sets the column width calculators.
+	 * @param columnWidthCalculators The column width calculators.
 	 */
-	setWidthCalculators(widthCalculators?: WidthCalculators) {
-		this._widthCalculators = widthCalculators;
+	setColumnWidthCalculators(columnWidthCalculators?: ColumnWidthCalculators) {
+		this._columnWidthCalculators = columnWidthCalculators;
 	}
 
 	/**
@@ -248,8 +248,15 @@ export class TableDataCache extends Disposable {
 		minimumColumnWidth: number,
 		maximumColumnWidth: number
 	): Promise<number[] | undefined> {
-		// If the width calculators are not set, return undefined.
-		if (!this._widthCalculators) {
+		// If the column width calculators are not set, return undefined.
+		//
+		// Captured into a local rather than read from the field on each use. The calculators are
+		// set through a public setter while this method awaits several backend round trips, so a
+		// later read of the field can find a different value -- or undefined -- even though the
+		// guard below passed. TypeScript carries the narrowing across the awaits and doesn't catch
+		// it. Working from the local also keeps every width in one result measured consistently.
+		const columnWidthCalculators = this._columnWidthCalculators;
+		if (!columnWidthCalculators) {
 			return undefined;
 		}
 
@@ -277,7 +284,7 @@ export class TableDataCache extends Disposable {
 			for (let i = 0; i < tableSchema.columns.length; i++) {
 				const columnSchema = tableSchema.columns[i];
 				columnWidths[columnIndex + i] = pinToRange(
-					this._widthCalculators.columnHeaderWidthCalculator(
+					columnWidthCalculators.columnHeaderWidthCalculator(
 						columnSchema.column_name,
 						columnSchema.type_name
 					),
@@ -316,7 +323,7 @@ export class TableDataCache extends Disposable {
 
 					// Calculate the column value width.
 					const columnValueWidth = pinToRange(
-						this._widthCalculators.columnValueWidthCalculator(
+						columnWidthCalculators.columnValueWidthCalculator(
 							dataCell.formatted.length
 						),
 						minimumColumnWidth,

--- a/src/vs/workbench/services/positronDataExplorer/test/browser/tableDataDataGridInstance.vitest.ts
+++ b/src/vs/workbench/services/positronDataExplorer/test/browser/tableDataDataGridInstance.vitest.ts
@@ -275,14 +275,18 @@ describe('TableDataDataGridInstance', () => {
 		expect(instance.firstColumn?.width).toBe(CALCULATED_COLUMN_WIDTH);
 	});
 
-	it('leaves the column widths alone when none can be calculated', async () => {
-		// A table with too many columns to auto-size returns no widths. The columns keep the widths
-		// they have -- the default ones on a first load -- rather than being reset to nothing.
-		vi.spyOn(cache, 'calculateColumnWidths').mockResolvedValue(undefined);
-
+	it('keeps the calculated column widths when a later calculation produces none', async () => {
 		instance.setColumnWidthCalculators(columnWidthCalculators());
 		await instance.setVisible(true);
+		expect(instance.firstColumn?.width).toBe(CALCULATED_COLUMN_WIDTH);
 
-		expect(instance.firstColumn?.width).toBe(DEFAULT_COLUMN_WIDTH);
+		// A table that has grown past the auto-size limit returns no widths. The columns keep the
+		// widths they have rather than falling back to the default ones.
+		const calculateColumnWidths = vi.spyOn(cache, 'calculateColumnWidths')
+			.mockResolvedValue(undefined);
+		instance.setColumnWidthCalculators(columnWidthCalculators(WIDER_COLUMN_WIDTH));
+
+		await vi.waitFor(() => expect(calculateColumnWidths).toHaveBeenCalled());
+		expect(instance.firstColumn?.width).toBe(CALCULATED_COLUMN_WIDTH);
 	});
 });

--- a/src/vs/workbench/services/positronDataExplorer/test/browser/tableDataDataGridInstance.vitest.ts
+++ b/src/vs/workbench/services/positronDataExplorer/test/browser/tableDataDataGridInstance.vitest.ts
@@ -1,0 +1,219 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { Emitter } from '../../../../../base/common/event.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
+import { NullHoverService } from '../../../../../platform/hover/test/browser/nullHoverService.js';
+import { PositronReactServices } from '../../../../../base/browser/positronReactServices.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { DataExplorerClientInstance } from '../../../languageRuntime/common/languageRuntimeDataExplorerClient.js';
+import {
+	BackendState,
+	ColumnDisplayType,
+	ColumnSelection,
+	SchemaUpdateEvent,
+	SupportStatus,
+	TableData,
+	TableSchema
+} from '../../../languageRuntime/common/positronDataExplorerComm.js';
+import { TableDataDataGridInstance } from '../../browser/tableDataDataGridInstance.js';
+import { getColumnSchema } from '../../common/positronDataExplorerMocks.js';
+import { TableDataCache } from '../../common/tableDataCache.js';
+
+/**
+ * The default column width the data grid falls back to when no calculated widths are available.
+ */
+const DEFAULT_COLUMN_WIDTH = 200;
+
+/**
+ * The width the test column header width calculator reports.
+ */
+const CALCULATED_COLUMN_WIDTH = 321;
+
+/**
+ * Builds a backend state. The instance reads the table shape, the sort keys, and the supported
+ * features from it, so the rest is filler.
+ */
+function backendState(): BackendState {
+	return {
+		display_name: 'test-table',
+		table_shape: { num_rows: 100, num_columns: 2 },
+		table_unfiltered_shape: { num_rows: 100, num_columns: 2 },
+		has_row_labels: false,
+		column_filters: [],
+		row_filters: [],
+		sort_keys: [],
+		supported_features: {
+			search_schema: { support_status: SupportStatus.Supported, supported_types: [] },
+			set_column_filters: { support_status: SupportStatus.Supported, supported_types: [] },
+			set_row_filters: { support_status: SupportStatus.Supported, supports_conditions: SupportStatus.Supported, supported_types: [] },
+			get_column_profiles: { support_status: SupportStatus.Supported, supported_types: [] },
+			export_data_selection: { support_status: SupportStatus.Supported, supported_formats: [] },
+			set_sort_columns: { support_status: SupportStatus.Supported },
+			convert_to_code: { support_status: SupportStatus.Supported }
+		}
+	};
+}
+
+/**
+ * Returns column width calculators that report a fixed column header width.
+ */
+function columnWidthCalculators() {
+	return {
+		columnHeaderWidthCalculator: () => CALCULATED_COLUMN_WIDTH,
+		columnValueWidthCalculator: () => 50
+	};
+}
+
+describe('TableDataDataGridInstance', () => {
+	const ctx = createTestContainer()
+		.withReactServices()
+		.stub(IConfigurationService, new TestConfigurationService())
+		.stub(IHoverService, NullHoverService)
+		.build();
+
+	let cache: TableDataCache;
+	let instance: TableDataDataGridInstance;
+	let backendStateEmitter: Emitter<BackendState>;
+	let getBackendState: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		// TableDataDataGridInstance reads PositronReactServices.services (static singleton) in its
+		// constructor. Bridge the builder-configured DI container to the singleton so the services
+		// stubbed above flow through to the instance under test.
+		PositronReactServices.services = ctx.reactServices;
+
+		backendStateEmitter = new Emitter<BackendState>();
+		getBackendState = vi.fn().mockResolvedValue(backendState());
+
+		const client: Partial<DataExplorerClientInstance> = {
+			cachedBackendState: backendState(),
+			onDidClose: new Emitter<void>().event,
+			onDidSchemaUpdate: new Emitter<SchemaUpdateEvent>().event,
+			onDidDataUpdate: new Emitter<void>().event,
+			onDidUpdateBackendState: backendStateEmitter.event,
+			getBackendState: getBackendState as DataExplorerClientInstance['getBackendState'],
+			getSchema: vi.fn(async (indices: number[]): Promise<TableSchema> => ({
+				columns: indices.map(i =>
+					getColumnSchema(`col${i}`, i, 'number', ColumnDisplayType.Floating)
+				)
+			})),
+			getDataValues: vi.fn(async (columns: ColumnSelection[]): Promise<TableData> => ({
+				columns: columns.map(() => ['1'])
+			})),
+			getSupportedFeatures: vi.fn().mockReturnValue(backendState().supported_features),
+		};
+
+		// The real cache is used so that the column width calculators are exercised end to end.
+		cache = new TableDataCache(client as DataExplorerClientInstance);
+		instance = new TableDataDataGridInstance(client as DataExplorerClientInstance, cache);
+	});
+
+	afterEach(() => {
+		instance.dispose();
+		cache.dispose();
+		backendStateEmitter.dispose();
+		PositronReactServices.services = undefined!;
+	});
+
+	it('recalculates the column widths when the calculators arrive after the initial load', async () => {
+		// The data explorer's React tree mounts asynchronously, so the initial load can run before
+		// the column width calculators are supplied. The columns are left at the default width, and
+		// without a recalculation nothing would ask for the widths again.
+		await instance.setVisible(true);
+		expect(instance.firstColumn?.width).toBe(DEFAULT_COLUMN_WIDTH);
+
+		// Supplying the calculators recalculates the widths.
+		instance.setColumnWidthCalculators(columnWidthCalculators());
+		await vi.waitFor(() =>
+			expect(instance.firstColumn?.width).toBe(CALCULATED_COLUMN_WIDTH)
+		);
+	});
+
+	it('applies the calculated widths on the initial load when the calculators arrive first', async () => {
+		const calculateColumnWidths = vi.spyOn(cache, 'calculateColumnWidths');
+
+		instance.setColumnWidthCalculators(columnWidthCalculators());
+		await instance.setVisible(true);
+
+		expect(instance.firstColumn?.width).toBe(CALCULATED_COLUMN_WIDTH);
+
+		// The initial load already calculated the widths, so the setter must not schedule redundant
+		// work of its own.
+		expect(calculateColumnWidths).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not recalculate the column widths when the calculators are set again', async () => {
+		instance.setColumnWidthCalculators(columnWidthCalculators());
+		await instance.setVisible(true);
+
+		// The React tree that supplies the calculators is unmounted when this instance's editor pane
+		// is handed to another data explorer, and mounted again when the user comes back, so the
+		// setter is called again for an instance whose widths are already calculated. That must not
+		// cost another round trip.
+		const calculateColumnWidths = vi.spyOn(cache, 'calculateColumnWidths');
+		instance.setColumnWidthCalculators(columnWidthCalculators());
+
+		expect(calculateColumnWidths).not.toHaveBeenCalled();
+		expect(instance.firstColumn?.width).toBe(CALCULATED_COLUMN_WIDTH);
+	});
+
+	it('does not update the layout twice when a backend state event arrives during the initial load', async () => {
+		instance.setColumnWidthCalculators(columnWidthCalculators());
+		const calculateColumnWidths = vi.spyOn(cache, 'calculateColumnWidths');
+
+		// The backend state arrives while the initial load is awaiting it. Both the initial load and
+		// the backend state handler update the layout entries, and each one calculates the column
+		// widths -- a schema and a data round trip per page of columns. Only one is needed.
+		getBackendState.mockImplementationOnce(async () => {
+			const state = backendState();
+			backendStateEmitter.fire(state);
+			return state;
+		});
+
+		await instance.setVisible(true);
+
+		expect(calculateColumnWidths).toHaveBeenCalledTimes(1);
+		expect(instance.firstColumn?.width).toBe(CALCULATED_COLUMN_WIDTH);
+	});
+
+	it('retries the initial load after it fails', async () => {
+		instance.setColumnWidthCalculators(columnWidthCalculators());
+
+		// A failure partway through the initial load leaves the grid without its data, and the
+		// deferred-update path has nothing pending to act on, so becoming visible again has to run
+		// the load rather than treat it as done.
+		getBackendState.mockRejectedValueOnce(new Error('backend went away'));
+		await expect(instance.setVisible(true)).rejects.toThrow('backend went away');
+
+		const update = vi.spyOn(cache, 'update');
+		await instance.setVisible(true);
+
+		expect(update).toHaveBeenCalled();
+		expect(instance.firstColumn?.width).toBe(CALCULATED_COLUMN_WIDTH);
+	});
+
+	it('recalculates the column widths only once when no widths can be calculated', async () => {
+		// A table with too many columns to auto-size returns no widths, however many times it's
+		// asked. Retrying on each remount would cost a backend round trip per switch back to the
+		// tab, so a recalculation that came back empty must not be attempted again.
+		const calculateColumnWidths = vi.spyOn(cache, 'calculateColumnWidths')
+			.mockResolvedValue(undefined);
+
+		await instance.setVisible(true);
+		calculateColumnWidths.mockClear();
+
+		instance.setColumnWidthCalculators(columnWidthCalculators());
+		await vi.waitFor(() => expect(calculateColumnWidths).toHaveBeenCalledTimes(1));
+
+		instance.setColumnWidthCalculators(columnWidthCalculators());
+		expect(calculateColumnWidths).toHaveBeenCalledTimes(1);
+		expect(instance.firstColumn?.width).toBe(DEFAULT_COLUMN_WIDTH);
+	});
+});

--- a/src/vs/workbench/services/positronDataExplorer/test/browser/tableDataDataGridInstance.vitest.ts
+++ b/src/vs/workbench/services/positronDataExplorer/test/browser/tableDataDataGridInstance.vitest.ts
@@ -43,6 +43,11 @@ const CALCULATED_COLUMN_WIDTH = 321;
 const WIDER_COLUMN_WIDTH = 456;
 
 /**
+ * The width a superseded calculation reports, which must never reach the columns.
+ */
+const STALE_COLUMN_WIDTH = 111;
+
+/**
  * Builds a backend state. The instance reads the table shape, the sort keys, and the supported
  * features from it, so the rest is filler.
  */
@@ -179,6 +184,60 @@ describe('TableDataDataGridInstance', () => {
 		instance.setColumnWidthCalculators(columnWidthCalculators(WIDER_COLUMN_WIDTH));
 
 		await vi.waitFor(() => expect(instance.firstColumn?.width).toBe(WIDER_COLUMN_WIDTH));
+	});
+
+	it('ignores a column width calculation that a later one has superseded', async () => {
+		instance.setColumnWidthCalculators(columnWidthCalculators());
+		await instance.setVisible(true);
+
+		// Two editor font changes in quick succession start two calculations. Hold the first one so
+		// it resolves after the second, which is what varying backend round trip times produce.
+		let resolveSuperseded!: (columnWidths: number[]) => void;
+		const superseded = new Promise<number[]>(resolve => {
+			resolveSuperseded = resolve;
+		});
+		const calculateColumnWidths = vi.spyOn(cache, 'calculateColumnWidths')
+			.mockReturnValueOnce(superseded)
+			.mockResolvedValueOnce([WIDER_COLUMN_WIDTH, WIDER_COLUMN_WIDTH]);
+
+		instance.setColumnWidthCalculators(columnWidthCalculators());
+		instance.setColumnWidthCalculators(columnWidthCalculators(WIDER_COLUMN_WIDTH));
+
+		// The second calculation lands first and its widths are applied.
+		await vi.waitFor(() => expect(instance.firstColumn?.width).toBe(WIDER_COLUMN_WIDTH));
+
+		// The first now resolves. Its widths were measured with the font the user has already
+		// changed away from, so they must not replace the ones the columns have.
+		resolveSuperseded([STALE_COLUMN_WIDTH, STALE_COLUMN_WIDTH]);
+		await vi.waitFor(() => expect(calculateColumnWidths).toHaveBeenCalledTimes(2));
+
+		expect(instance.firstColumn?.width).toBe(WIDER_COLUMN_WIDTH);
+	});
+
+	it('ignores a column width calculation that a layout update has superseded', async () => {
+		instance.setColumnWidthCalculators(columnWidthCalculators());
+		await instance.setVisible(true);
+
+		// A font change starts a calculation; hold it so that a layout update -- a backend state
+		// change, a schema update, a filter -- applies its own widths while it is still in flight.
+		let resolveSuperseded!: (columnWidths: number[]) => void;
+		const superseded = new Promise<number[]>(resolve => {
+			resolveSuperseded = resolve;
+		});
+		const calculateColumnWidths = vi.spyOn(cache, 'calculateColumnWidths')
+			.mockReturnValueOnce(superseded)
+			.mockResolvedValueOnce([WIDER_COLUMN_WIDTH, WIDER_COLUMN_WIDTH]);
+
+		instance.setColumnWidthCalculators(columnWidthCalculators());
+		backendStateEmitter.fire(backendState());
+
+		await vi.waitFor(() => expect(instance.firstColumn?.width).toBe(WIDER_COLUMN_WIDTH));
+
+		// The held calculation now resolves against layout entries that have moved on.
+		resolveSuperseded([STALE_COLUMN_WIDTH, STALE_COLUMN_WIDTH]);
+		await vi.waitFor(() => expect(calculateColumnWidths).toHaveBeenCalledTimes(2));
+
+		expect(instance.firstColumn?.width).toBe(WIDER_COLUMN_WIDTH);
 	});
 
 	it('does not update the layout twice when a backend state event arrives during the initial load', async () => {

--- a/src/vs/workbench/services/positronDataExplorer/test/browser/tableDataDataGridInstance.vitest.ts
+++ b/src/vs/workbench/services/positronDataExplorer/test/browser/tableDataDataGridInstance.vitest.ts
@@ -24,7 +24,7 @@ import {
 } from '../../../languageRuntime/common/positronDataExplorerComm.js';
 import { TableDataDataGridInstance } from '../../browser/tableDataDataGridInstance.js';
 import { getColumnSchema } from '../../common/positronDataExplorerMocks.js';
-import { TableDataCache } from '../../common/tableDataCache.js';
+import { ColumnWidthCalculators, TableDataCache } from '../../common/tableDataCache.js';
 
 /**
  * The default column width the data grid falls back to when no calculated widths are available.
@@ -35,6 +35,12 @@ const DEFAULT_COLUMN_WIDTH = 200;
  * The width the test column header width calculator reports.
  */
 const CALCULATED_COLUMN_WIDTH = 321;
+
+/**
+ * The width a second set of column width calculators reports, standing in for the wider font a
+ * change to `editor.fontFamily` or `editor.fontSize` produces.
+ */
+const WIDER_COLUMN_WIDTH = 456;
 
 /**
  * Builds a backend state. The instance reads the table shape, the sort keys, and the supported
@@ -63,10 +69,11 @@ function backendState(): BackendState {
 
 /**
  * Returns column width calculators that report a fixed column header width.
+ * @param columnWidth The column header width to report.
  */
-function columnWidthCalculators() {
+function columnWidthCalculators(columnWidth = CALCULATED_COLUMN_WIDTH): ColumnWidthCalculators {
 	return {
-		columnHeaderWidthCalculator: () => CALCULATED_COLUMN_WIDTH,
+		columnHeaderWidthCalculator: () => columnWidth,
 		columnValueWidthCalculator: () => 50
 	};
 }
@@ -149,19 +156,29 @@ describe('TableDataDataGridInstance', () => {
 		expect(calculateColumnWidths).toHaveBeenCalledTimes(1);
 	});
 
-	it('does not recalculate the column widths when the calculators are set again', async () => {
+	it('recalculates the column widths whenever the calculators are set again', async () => {
+		instance.setColumnWidthCalculators(columnWidthCalculators());
+		await instance.setVisible(true);
+		expect(instance.firstColumn?.width).toBe(CALCULATED_COLUMN_WIDTH);
+
+		// Supplying calculators means the columns are to be measured with them. An editor font change
+		// rebuilds them, and they then measure column values -- and so the columns -- differently, so
+		// widths calculated with the previous set no longer fit their values.
+		instance.setColumnWidthCalculators(columnWidthCalculators(WIDER_COLUMN_WIDTH));
+
+		await vi.waitFor(() => expect(instance.firstColumn?.width).toBe(WIDER_COLUMN_WIDTH));
+	});
+
+	it('recalculates the column widths when the calculators are cleared and supplied again', async () => {
 		instance.setColumnWidthCalculators(columnWidthCalculators());
 		await instance.setVisible(true);
 
-		// The React tree that supplies the calculators is unmounted when this instance's editor pane
-		// is handed to another data explorer, and mounted again when the user comes back, so the
-		// setter is called again for an instance whose widths are already calculated. That must not
-		// cost another round trip.
-		const calculateColumnWidths = vi.spyOn(cache, 'calculateColumnWidths');
-		instance.setColumnWidthCalculators(columnWidthCalculators());
+		// Unmounting the panel clears the calculators, and mounting it again supplies a rebuilt set --
+		// which measures with the editor font as it stands then, whether or not it changed in between.
+		instance.setColumnWidthCalculators(undefined);
+		instance.setColumnWidthCalculators(columnWidthCalculators(WIDER_COLUMN_WIDTH));
 
-		expect(calculateColumnWidths).not.toHaveBeenCalled();
-		expect(instance.firstColumn?.width).toBe(CALCULATED_COLUMN_WIDTH);
+		await vi.waitFor(() => expect(instance.firstColumn?.width).toBe(WIDER_COLUMN_WIDTH));
 	});
 
 	it('does not update the layout twice when a backend state event arrives during the initial load', async () => {
@@ -199,21 +216,14 @@ describe('TableDataDataGridInstance', () => {
 		expect(instance.firstColumn?.width).toBe(CALCULATED_COLUMN_WIDTH);
 	});
 
-	it('recalculates the column widths only once when no widths can be calculated', async () => {
-		// A table with too many columns to auto-size returns no widths, however many times it's
-		// asked. Retrying on each remount would cost a backend round trip per switch back to the
-		// tab, so a recalculation that came back empty must not be attempted again.
-		const calculateColumnWidths = vi.spyOn(cache, 'calculateColumnWidths')
-			.mockResolvedValue(undefined);
+	it('leaves the column widths alone when none can be calculated', async () => {
+		// A table with too many columns to auto-size returns no widths. The columns keep the widths
+		// they have -- the default ones on a first load -- rather than being reset to nothing.
+		vi.spyOn(cache, 'calculateColumnWidths').mockResolvedValue(undefined);
 
+		instance.setColumnWidthCalculators(columnWidthCalculators());
 		await instance.setVisible(true);
-		calculateColumnWidths.mockClear();
 
-		instance.setColumnWidthCalculators(columnWidthCalculators());
-		await vi.waitFor(() => expect(calculateColumnWidths).toHaveBeenCalledTimes(1));
-
-		instance.setColumnWidthCalculators(columnWidthCalculators());
-		expect(calculateColumnWidths).toHaveBeenCalledTimes(1);
 		expect(instance.firstColumn?.width).toBe(DEFAULT_COLUMN_WIDTH);
 	});
 });

--- a/src/vs/workbench/services/positronDataExplorer/test/common/tableDataCache.vitest.ts
+++ b/src/vs/workbench/services/positronDataExplorer/test/common/tableDataCache.vitest.ts
@@ -172,6 +172,51 @@ describe('TableDataCache', () => {
 		});
 	});
 
+	it('survives the column width calculators being cleared mid-calculation', async () => {
+		ensureNoLeakedDisposables();
+
+		// calculateColumnWidths guards the calculators up front, then awaits several backend round
+		// trips before using them. setColumnWidthCalculators is public and can be called during those
+		// awaits, so the guard alone doesn't make the later dereferences safe -- previously this
+		// threw "Cannot read properties of undefined (reading 'columnHeaderWidthCalculator')" out
+		// of the width calculation.
+		cache.setColumnWidthCalculators({
+			columnHeaderWidthCalculator: () => 100,
+			columnValueWidthCalculator: () => 50,
+		});
+
+		// Clear them as soon as the first backend round trip is awaited.
+		getBackendState.mockImplementationOnce(async () => {
+			cache.setColumnWidthCalculators(undefined);
+			return backendState(true);
+		});
+
+		await expect(cache.calculateColumnWidths(50, 400)).resolves.toEqual([100, 100]);
+	});
+
+	it('measures with one set of column width calculators when they are replaced mid-calculation', async () => {
+		ensureNoLeakedDisposables();
+
+		// An editor font change replaces the calculators. A calculation already in flight has to
+		// finish with the set it started with, or one result would mix widths measured two ways.
+		cache.setColumnWidthCalculators({
+			columnHeaderWidthCalculator: () => 100,
+			columnValueWidthCalculator: () => 50,
+		});
+
+		// Replace them with calculators reporting much larger widths, as soon as the first backend
+		// round trip is awaited.
+		getBackendState.mockImplementationOnce(async () => {
+			cache.setColumnWidthCalculators({
+				columnHeaderWidthCalculator: () => 300,
+				columnValueWidthCalculator: () => 350,
+			});
+			return backendState(true);
+		});
+
+		await expect(cache.calculateColumnWidths(50, 400)).resolves.toEqual([100, 100]);
+	});
+
 	it('does not request row labels when the row selection is empty', async () => {
 		ensureNoLeakedDisposables();
 


### PR DESCRIPTION
Fixes #15189

Opening a table, or a column of a table, from the Data Connections tree intermittently failed to open it at all: the Data Explorer editor appeared and stayed empty — no columns, no rows — with a `TypeError` from `TableDataCache.calculateColumnWidths` in the log and nothing surfaced in the UI. Other times the same action opened the table or column but left its columns at the default width instead of auto-sizing them. Which one you got was purely a matter of timing, because the column width calculators are created by a React layout effect in the Data Explorer panel while the calculations that consume them run on the grid instance, which outlives any React tree. Nothing about it is specific to tables or to columns — both open a Data Explorer over the same grid instance and cache, and both run the same width calculation.

The crash is the calculators being cleared after `calculateColumnWidths` has already checked them — it awaits three backend round trips between that check and its last use of them, and opening a Data Explorer into a reused editor pane unmounts the previous panel and clears them mid-calculation. What turned that into an empty editor is separate: the initial load set `_initialLoadComplete` and cleared its pending flags before doing any work, and the width calculation happens before the layout entries are set, so a throw meant no entries, no sort keys and no data, with nothing left to trigger another attempt. The un-auto-sized case is the same race landing earlier: the initial load calls `calculateColumnWidths` before the layout effect has run, the calculation returns nothing, and because the setter was a plain field assignment nothing recalculated when the calculators arrived a moment later.

Fixed by capturing the calculators into a local for the duration of a calculation; measuring everything they need once while the panel is mounted, so nothing they do reads the document (this also removes a canvas allocation and two `getComputedStyle` calls per column — on a 1000-column table, 1000 canvases and 2000 style resolutions become 1 and 3); recalculating the column widths whenever the calculators are set, since supplying them means the columns are to be measured with them; suppressing the duplicate `updateLayoutEntries` that every open was running concurrently, which halves the schema and data round trips width calculation makes; and rolling back a failed initial load instead of marking it complete, so that becoming visible again runs it. That last one makes the empty-grid case recoverable rather than self-healing — `setVisible(true)` fires on a visibility transition, so recovery means switching away from the tab and back; nothing retries on its own while the editor stays visible.

Concurrent width calculations are now ordered as well. Each takes a generation on entry and drops its result if newer widths have been applied while it was awaiting the backend, so the slower of two overlapping calculations can't win — reachable both from the duplicated pair every open used to run and, after this change, from two editor font changes in quick succession. Applying layout entries bumps the same generation, so a calculation that started before a layout update stands down rather than overwriting it. The recalculation also takes its column count from the state the calculation itself worked from, so the count and the widths always pair.

Recalculating whenever the calculators are set also fixes a longstanding separate bug: changing the editor font never resized columns, so values re-rendered in the new font inside columns still sized for the old one and wide values such as UUIDs were truncated.

All of it traces to #5078 (October 2024), which moved column widths from being derived on demand — `getColumnWidth` computed a width every time the grid needed one, straight from the calculators — to being precomputed once into layout entries, without a path to recompute them when the calculators change. One consequence of the fix worth knowing at review time: because setting calculators always remeasures, switching back to a Data Explorer tab whose panel was unmounted remeasures its columns, three round trips for a table under 250 columns. That is closer to the pre-#5078 behavior than to a regression.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed the Data Explorer intermittently failing to open a table or column from the Data Connections tree, leaving an empty editor (#15189)
- Fixed Data Explorer columns not being auto-sized when opening a table or column (#15189)
- Fixed Data Explorer column widths not adjusting when the editor font changes (#15189)

### Validation Steps

@:data-explorer @:connections

The original failure was intermittent — it needs a width calculation still awaiting Redshift when the outgoing Data Explorer's panel is torn down, so it didn't reproduce on every open and doesn't reproduce at all against a local backend. Step 2 is a best-effort attempt at the reported path; the rest are checks on behavior that must work. The races themselves are covered deterministically by the unit tests below rather than by hand.

1. Open a data frame in the Data Explorer. Column headers should be sized to their contents, with room for the sort button and sort index, and column values sized to the editor font.
2. With a Redshift connection in the Data Connections tree, expand a database to a table and its columns. Open the table, then open several of its columns one after another, letting each land in the preview tab, and mix tables and columns across a handful of attempts. Each should open populated and auto-sized, with nothing logged to the console. Before this change some opens produced the error and an empty editor and others didn't, depending on how much of the width calculation was still in flight when the previous panel came down — tables and columns both.
3. With a Data Explorer open, change `editor.fontFamily` (e.g. Inconsolata to Menlo) and `editor.fontSize`. Columns should resize so values still fit; header widths don't change, since the header exemplars inherit the workbench font rather than the editor font. Then change the font while a Data Explorer is in a background tab and switch back to it — it should resize too.
4. Open two data frames, pin both tabs, and switch between them a few times. Each should show correct widths, with no error and no visible flicker. Note that switching back now remeasures that explorer's columns, so a brief backend round trip on each switch is expected.
5. If you have a table with more than 1000 columns, open it. Auto-sizing is deliberately skipped at that width, so the columns keep the default width and nothing should be logged.

Unit coverage: eleven new tests, each verified to fail against the unfixed source. Two in `tableDataCache.vitest.ts` clear and then replace the calculators from inside the mocked `getBackendState`, reproducing a mid-calculation change deterministically without depending on panel lifecycle timing. Nine in a new `tableDataDataGridInstance.vitest.ts` drive a real `TableDataCache` over a mocked client so widths are exercised end to end: calculators arriving after the initial load; arriving before it; being set again; being cleared and supplied again; a calculation superseded by a later one; a calculation superseded by a layout update; a backend state event arriving mid-load; a failed initial load being retried; and widths already calculated surviving a later calculation that produces none.

The column header measuring itself has no unit coverage and can't practically get any, since jsdom's canvas has no `measureText` — that part was verified by hand, including the editor font change resizing columns. There's also no e2e coverage of column widths anywhere under `test/e2e/tests/data-explorer/`.
