### PR TITLE
ci-arm lab: unambiguous failure signal, local refs, submodule bootstrap

### DIFF
--- a/.devcontainer/ci-arm/README.md
+++ b/.devcontainer/ci-arm/README.md
@@ -187,7 +187,12 @@ steps 1-2 are done (worktree created, secrets added). The build runs through thi
    > [!IMPORTANT]
    > **Check the result by grepping the output for `ci-lab-up: SUCCESS` or `ci-lab-up: FAILED`,**
    > which names the phase that failed. Don't rely on `$?` if you piped through `tee` -- a pipeline
-   > reports tee's exit status (always 0), not the script's, so a failed run looks green.
+   > reports tee's exit status (always 0), not the script's, so a failed run looks green. Both
+   > trailers go to stdout; redirect with `2>&1` so the diagnostics behind a failure are captured too:
+   >
+   > ```bash
+   > ./ci-lab-up.sh <ref> 2>&1 | tee /tmp/ci-lab-up.log
+   > ```
 
 2. **Run a spec** in the container (from the same `.devcontainer/ci-arm` dir, so Compose finds this
    project's `docker-compose.yml` and `.env`):
@@ -371,8 +376,9 @@ It removes this project's dev container, its data volumes (root + e2e + remote `
   before digging further.
 - **A drifted submodule pointer looks like a dirty tree.** A stale submodule checkout from an earlier
   session shows up as ` M ai-lib` or ` M extensions/positron-r/ark`, and "commit or stash" is the wrong
-  advice -- committing a drifted pointer is actively harmful. `ci-lab-up.sh` detects the
-  submodule-only case and prints the `git submodule update --init --recursive <path>` that fixes it.
+  advice -- committing a drifted pointer is actively harmful, and stashing it leaves the gitlink where
+  it was. `ci-lab-up.sh` calls out any drifted submodule it sees and prints the
+  `git submodule update --init --recursive <path>` that fixes it, separately from any ordinary edits.
 - **Generating a patch? Use `git diff --no-color`.** If your git config forces color on, a plain
   `git diff > x.patch` embeds ANSI escapes and `git apply` rejects the file with the unhelpful
   `No valid patches in input`.

--- a/.devcontainer/ci-arm/README.md
+++ b/.devcontainer/ci-arm/README.md
@@ -75,9 +75,30 @@ That's it - you have a working CI lab.
 
 ## Workflows
 
-Two audiences, two subsections below: a human driving VS Code's Dev Containers UI, or an agent (e.g.
-Claude Code) driving the same stack headlessly over `docker compose` / `docker exec`. Both need
-[Setup](#setup) done first.
+The first subsection below applies to everyone. The two after it split by audience: a human driving
+VS Code's Dev Containers UI, or an agent (e.g. Claude Code) driving the same stack headlessly over
+`docker compose` / `docker exec`. All of them need [Setup](#setup) done first.
+
+### Reproducing a CI-only flake
+
+**Run the *whole* spec at `--workers=1`.** Positron doesn't split a single spec file across workers,
+so its tests run in order and share app state. A test that only fails in CI often passes in isolation
+(a single `--grep`) yet fails in a full-file run because an earlier test left state behind -- **don't
+conclude "can't reproduce" from an isolated run.**
+
+Whatever you changed to chase the flake has to actually be compiled before you run. `out/` is
+bind-mounted and reflects whichever branch was last built here, so it does not follow a bare
+`git checkout` or a hand edit:
+
+| You did this | Then do this |
+|---|---|
+| pushed a branch | `ci-lab-up.sh <branch>` |
+| committed to a local-only branch, or want a specific SHA | `ci-lab-up.sh <ref>` -- it falls back to a local ref when the ref isn't on origin, so instrumentation branches don't need pushing |
+| edited source in place | `ci-lab-up.sh --local` (headless) or let the **Watch** task recompile (UI) |
+| nothing; just rerunning | nothing |
+
+Any of the first three reconcile dependencies *and* recompile `out/`. Without one of them nothing is
+recompiled, and "ready" only means the last build's artifacts are present.
 
 ### User Workflows (VS Code UI)
 
@@ -116,6 +137,10 @@ from the terminal: `npx playwright test --project e2e-electron --grep @:search`.
 
 Headed runs (`e2e-electron` and `e2e-chromium`) render on the headless display. Open the noVNC link in the **Doctor** to view it live. Use the **Report** task to serve the report at any time.
 
+Chasing a CI-only failure rather than running a spec? Read
+[Reproducing a CI-only flake](#reproducing-a-ci-only-flake) first -- a single `--grep` run is the
+most common way to wrongly conclude the flake doesn't reproduce.
+
 #### Test data (test-files)
 
 The e2e tests open files from `test/e2e/test-files` in the repo; the framework copies them into the
@@ -145,11 +170,24 @@ steps 1-2 are done (worktree created, secrets added). The build runs through thi
 
    ```bash
    cd <worktree>/.devcontainer/ci-arm
-   ./ci-lab-up.sh [<branch>]
+   ./ci-lab-up.sh [<ref> | --local]
    ```
 
-   `ci-lab-up.sh` detects cold/warm/hot itself; with a `<branch>` it also checks out that branch and
-   reconciles deps + `out/`. A cold build is ~10 min -- run it in the background; clean exit = ready.
+   `ci-lab-up.sh` detects cold/warm/hot itself. Three modes, differing only in what gets recompiled
+   before the run -- see [Reproducing a CI-only flake](#reproducing-a-ci-only-flake) for which to pick:
+
+   | Invocation | What it does |
+   |---|---|
+   | `ci-lab-up.sh <ref>` | checks out `<ref>`, then reconciles deps + recompiles `out/`. Resolves from origin first, then as a local branch/tag/SHA -- so a local-only instrumentation branch works unpushed |
+   | `ci-lab-up.sh --local` | no git operation; reconciles + recompiles against the current working tree |
+   | `ci-lab-up.sh` | nothing recompiled; the current checkout is assumed already built |
+
+   A cold build is ~10 min -- run it in the background.
+
+   > [!IMPORTANT]
+   > **Check the result by grepping the output for `ci-lab-up: SUCCESS` or `ci-lab-up: FAILED`,**
+   > which names the phase that failed. Don't rely on `$?` if you piped through `tee` -- a pipeline
+   > reports tee's exit status (always 0), not the script's, so a failed run looks green.
 
 2. **Run a spec** in the container (from the same `.devcontainer/ci-arm` dir, so Compose finds this
    project's `docker-compose.yml` and `.env`):
@@ -159,31 +197,34 @@ steps 1-2 are done (worktree created, secrets added). The build runs through thi
      "cd \$POSITRON_WORKSPACE_PATH && ./.devcontainer/ci-arm/run-e2e.sh test/e2e/tests/<area>/<file>.test.ts --workers=1"
    ```
 
-**Reproducing a CI-only flake? Run the *whole* spec at `--workers=1`** (as the command above does).
-Positron doesn't split a single spec file across workers, so its tests run in order and share app
-state. A test that only fails in CI often passes in isolation (a single `--grep`) yet fails because an
-earlier test in the same file left state behind -- don't conclude "can't reproduce" from an isolated
-run.
-
-**How it works, and when it breaks.** `ci-lab-up.sh` chains `initialize.sh` -> `docker compose up -d`
--> cold-or-ready detection -> `post-create.sh` if cold (~10 min) -> the idempotent `post-start.sh`
-(display, VNC, postgres). A `<branch>` argument also checks out that branch and reconciles deps +
-`out/`. When a phase fails, read its log (`/tmp/post-create.log`, `/tmp/compile.log`) and the script's
-`=== ci-lab-up: <phase> ===` echoes, then rerun that phase. Three non-obvious things it handles:
+**How it works, and when it breaks.** `ci-lab-up.sh` chains `initialize.sh` (workspace env + submodule
+checkout) -> `docker compose up -d` -> cold-or-ready detection -> `post-create.sh` if cold (~10 min) ->
+the idempotent `post-start.sh` (display, VNC, postgres), with the reconcile + recompile in between when
+a `<ref>` or `--local` asked for it. When a phase fails, read its log (`/tmp/post-create.log`,
+`/tmp/compile.log`) and the script's `=== ci-lab-up: <phase> ===` echoes, then rerun that phase. Four
+non-obvious things it handles:
 
 - **"Ready" checks artifacts, not just the marker.** Detection keys off `.build/.ci-arm-state/complete`
   *and* `out/main.js` + a populated `node_modules` -- a container can read built yet still fail a run
   with `Cannot find module`. That case is treated as cold; reinstall + recompile (or rerun
-  `ci-lab-up.sh <branch>`).
+  `ci-lab-up.sh <ref>`). Note "ready" is still only a statement about the *last* build: without a
+  `<ref>` or `--local` it says nothing about whether `out/` matches your working tree, which is why
+  the no-argument mode says so explicitly on exit.
+- **Submodules are checked out host-side, on purpose.** `ai-lib` is private and the container has no
+  GitHub credentials, so if `build/npm/postinstall.ts` has to clone it the whole root install aborts
+  and you get a confusing downstream `TS2688: Cannot find type definition file for 'node'` from
+  whichever extension is newest. `initialize.sh` runs on the host, where your credentials are, and
+  checks out any missing submodule before the container needs it.
 - **No `containerEnv` over plain `docker compose`.** The four interpreter version selectors in
   `devcontainer.json`'s `containerEnv` are injected by the Dev Containers extension, not by
   `docker compose exec`, and the e2e suite throws without them. That's why runs go through
   `run-e2e.sh`, which reads the pins and exports them (plus `DISPLAY`, `--project e2e-electron`,
   `GITHUB_ACTIONS=true`, which is what makes image-comparison tests actually compare).
-- **Branch switches stale deps and `out/`.** `out/` is bind-mounted and reflects whichever branch was
-  last built here. Passing `<branch>` to `ci-lab-up.sh` reconciles both (sha-compare against
-  `.build/.ci-arm-state/*.sha`, then `reinstall-deps.sh` / incremental compile as needed) -- prefer it
-  over a bare `git checkout`.
+- **Branch switches and hand edits stale deps and `out/`.** `out/` is bind-mounted and reflects
+  whichever branch was last built here. `ci-lab-up.sh <ref>` (or `--local` for uncommitted edits)
+  reconciles both (sha-compare against `.build/.ci-arm-state/*.sha`, then `reinstall-deps.sh` /
+  incremental compile as needed) -- prefer either over a bare `git checkout`. Neither rebuilds
+  Electron; a change needing `npm run electron` wants a full **Rebuild**.
 
 ## Reference
 
@@ -324,6 +365,17 @@ It removes this project's dev container, its data volumes (root + e2e + remote `
 - **`npm ci` may leave files staged in your worktree.** Positron's postinstall runs
   `git add --renormalize`, which stages line-ending changes in your bind-mounted index. It's
   harmless: `git restore --staged .`.
+- **First install after an `ai-lib` gitlink bump fails; just run it twice.** When a branch moves the
+  `ai-lib` submodule pointer, the first `npm install` / `fast-install.ts` errors out; a second run
+  succeeds. `ci-lab-up.sh` doesn't retry for you, so if a reconcile fails on `ai-lib`, rerun it once
+  before digging further.
+- **A drifted submodule pointer looks like a dirty tree.** A stale submodule checkout from an earlier
+  session shows up as ` M ai-lib` or ` M extensions/positron-r/ark`, and "commit or stash" is the wrong
+  advice -- committing a drifted pointer is actively harmful. `ci-lab-up.sh` detects the
+  submodule-only case and prints the `git submodule update --init --recursive <path>` that fixes it.
+- **Generating a patch? Use `git diff --no-color`.** If your git config forces color on, a plain
+  `git diff > x.patch` embeds ANSI escapes and `git apply` rejects the file with the unhelpful
+  `No valid patches in input`.
 - **Python/R interpreters dead after building one checkout both ways** - wrong-OS `pet`/`ark`/`kcserver`
   (see [Don't mix container and native builds](#dont-mix-container-and-native-builds)). The Doctor's
   **Interpreters** row flags this; run **Positron CI: Reinstall interpreters** to restore the Linux
@@ -336,8 +388,9 @@ It removes this project's dev container, its data volumes (root + e2e + remote `
   - **Mid-session (messier).** `git checkout` in the open container, then reload the window and let
     **Watch** recompile (restart any running Positron/debug). Note Watch recompiles but does *not*
     check dependency drift -- rely on the Doctor's **Build** row to flag stale deps.
-  - **Headless.** `ci-lab-up.sh <branch>` (see [Claude Workflows](#claude-workflows-cli-only-headless))
-    does the same thing over the CLI, including the dependency-drift check Watch doesn't handle.
+  - **Headless.** `ci-lab-up.sh <ref>` (see [Claude Workflows](#claude-workflows-cli-only-headless))
+    does the same thing over the CLI, including the dependency-drift check Watch doesn't handle. It
+    accepts a local-only branch or a SHA, and `--local` reconciles uncommitted edits in place.
 
   Whichever path you take, keep the **Doctor** open: its Build and Interpreters rows tell you what
   went stale and which task fixes it.

--- a/.devcontainer/ci-arm/ci-lab-up.sh
+++ b/.devcontainer/ci-arm/ci-lab-up.sh
@@ -22,8 +22,11 @@
 # A cold build takes ~10 minutes -- run this in the background and wait for it to exit. Re-running is
 # safe and fast when nothing changed.
 #
-# CHECKING THE RESULT: grep the output for `ci-lab-up: SUCCESS` or `ci-lab-up: FAILED`. Do not rely
-# on `$?` if you piped this through `tee` -- the pipeline reports tee's status, not this script's.
+# CHECKING THE RESULT: grep stdout for `ci-lab-up: SUCCESS` or `ci-lab-up: FAILED` (the latter names
+# the phase). Do not rely on `$?` if you piped through `tee` -- the pipeline reports tee's status, not
+# this script's. Capture with `2>&1` so the diagnostics behind a failure land in the log too:
+#
+#   ./.devcontainer/ci-arm/ci-lab-up.sh <ref> 2>&1 | tee /tmp/ci-lab-up.log
 set -euo pipefail
 
 BRANCH=""
@@ -43,11 +46,15 @@ cd "$SCRIPT_DIR"                                             # so `docker compos
 # Every phase announces itself and records itself, so the EXIT trap below can name the phase that
 # failed. That trailer is the only reliable failure signal a caller has: the usual
 # `ci-lab-up.sh ... 2>&1 | tee log` invocation reports tee's exit status (always 0), masking ours.
+#
+# Both trailers go to stdout, deliberately. Diagnostics belong on stderr, but a status trailer that
+# lands on a different stream than its SUCCESS counterpart is a trap: `... | tee log` would capture
+# SUCCESS and drop FAILED, leaving a log with no failure marker at all.
 CURRENT_STEP="startup"
 step() { CURRENT_STEP="$1"; printf '\n=== ci-lab-up: %s ===\n' "$1"; }
 on_exit() {
 	local rc=$?
-	[ "$rc" -eq 0 ] || printf '\nci-lab-up: FAILED at step %s (exit %d)\n' "'$CURRENT_STEP'" "$rc" >&2
+	[ "$rc" -eq 0 ] || printf '\nci-lab-up: FAILED at step %s (exit %d)\n' "'$CURRENT_STEP'" "$rc"
 }
 trap on_exit EXIT
 
@@ -80,14 +87,21 @@ if [ -n "$BRANCH" ]; then
 			$DIRTY
 		EOF
 
-		if [ -n "$DRIFTED" ] && [ "$OTHER_DIRT" = false ]; then
+		# Report drift whenever it's present, even alongside ordinary edits: stashing everything
+		# and retrying would leave the gitlink exactly where it was and fail again.
+		if [ -n "$DRIFTED" ]; then
 			echo "ci-lab-up: ERROR: submodule pointer(s) differ from what HEAD records:$DRIFTED" >&2
-			echo "ci-lab-up: that is a stale submodule checkout, not local work -- do NOT commit it. Restore with:" >&2
+			echo "ci-lab-up: that is a stale submodule checkout, not local work -- do NOT commit or stash it. Restore with:" >&2
 			echo "ci-lab-up:   git -C '$REPO_ROOT' submodule update --init --recursive$DRIFTED" >&2
-			exit 1
 		fi
-		echo "ci-lab-up: ERROR: working tree is dirty; commit or stash before switching refs" >&2
-		git -C "$REPO_ROOT" status --short >&2
+		if [ "$OTHER_DIRT" = true ]; then
+			if [ -n "$DRIFTED" ]; then
+				echo "ci-lab-up: ERROR: separately, there are uncommitted changes; commit or stash those too" >&2
+			else
+				echo "ci-lab-up: ERROR: working tree is dirty; commit or stash before switching refs" >&2
+			fi
+			git -C "$REPO_ROOT" status --short >&2
+		fi
 		exit 1
 	fi
 

--- a/.devcontainer/ci-arm/ci-lab-up.sh
+++ b/.devcontainer/ci-arm/ci-lab-up.sh
@@ -6,48 +6,107 @@
 # (initialize -> compose up -> detect cold/warm/hot -> build-if-needed -> per-start setup) into one
 # idempotent step, so no phase can be skipped or run out of order. Pair it with run-e2e.sh:
 #
-#   ./.devcontainer/ci-arm/ci-lab-up.sh [<branch>]
+#   ./.devcontainer/ci-arm/ci-lab-up.sh [<ref> | --local]
 #   docker compose exec -T test bash -lc \
 #     "cd \$POSITRON_WORKSPACE_PATH && ./.devcontainer/ci-arm/run-e2e.sh test/e2e/tests/<area>/<f>.test.ts --workers=1"
 #
-# With <branch> it points the worktree at that branch first (fetch + checkout), then reconciles
-# dependencies and recompiles out/ so the build matches the new source. Without it, the current
-# checkout is assumed already built. A cold build takes ~10 minutes -- run this in the background
-# and wait for it to exit; a clean exit means ready. Re-running is safe and fast when nothing changed.
+# Three modes, differing only in whether source is reconciled before the run:
+#
+#   <ref>     point the worktree at that ref first, then reconcile deps and recompile out/ so the
+#             build matches the new source. Resolved from origin, else from a local ref/SHA -- so a
+#             local-only instrumentation branch works without pushing it.
+#   --local   no git operation; reconcile and recompile against the current working tree. Use this
+#             after editing source in the lab worktree by hand.
+#   (none)    the current checkout is assumed already built; nothing is recompiled.
+#
+# A cold build takes ~10 minutes -- run this in the background and wait for it to exit. Re-running is
+# safe and fast when nothing changed.
+#
+# CHECKING THE RESULT: grep the output for `ci-lab-up: SUCCESS` or `ci-lab-up: FAILED`. Do not rely
+# on `$?` if you piped this through `tee` -- the pipeline reports tee's status, not this script's.
 set -euo pipefail
 
 BRANCH=""
+RECONCILE=false
 case "${1:-}" in
-	-h | --help) echo "usage: ci-lab-up.sh [<branch>]  (see header comment for details)"; exit 0 ;;
+	-h | --help) echo "usage: ci-lab-up.sh [<ref> | --local]  (see header comment for details)"; exit 0 ;;
+	--local) RECONCILE=true ;;
 	-*) echo "ci-lab-up: unknown option '$1'" >&2; exit 2 ;;
 	"") : ;;
-	*) BRANCH="$1" ;;
+	*) BRANCH="$1"; RECONCILE=true ;;
 esac
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"   # .devcontainer/ci-arm
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$SCRIPT_DIR"                                             # so `docker compose` finds this checkout
 
-step() { printf '\n=== ci-lab-up: %s ===\n' "$1"; }
+# Every phase announces itself and records itself, so the EXIT trap below can name the phase that
+# failed. That trailer is the only reliable failure signal a caller has: the usual
+# `ci-lab-up.sh ... 2>&1 | tee log` invocation reports tee's exit status (always 0), masking ours.
+CURRENT_STEP="startup"
+step() { CURRENT_STEP="$1"; printf '\n=== ci-lab-up: %s ===\n' "$1"; }
+on_exit() {
+	local rc=$?
+	[ "$rc" -eq 0 ] || printf '\nci-lab-up: FAILED at step %s (exit %d)\n' "'$CURRENT_STEP'" "$rc" >&2
+}
+trap on_exit EXIT
 
 # Run a command inside the test container from the workspace root, failing loudly (a masked failure
 # inside a pipe or an && / || list is the whole reason this wrapper sets -e and pipefail).
 in_ctr() { docker compose exec -T test bash -lc "set -eo pipefail; cd \"\$POSITRON_WORKSPACE_PATH\" && $1"; }
 
-# 1. Optional branch switch (host-side git). Refuse on a dirty tree so we never half-switch or
-#    silently carry uncommitted changes onto another branch.
+# 1. Optional ref switch (host-side git). Refuse on a dirty tree so we never half-switch or
+#    silently carry uncommitted changes onto another ref.
 if [ -n "$BRANCH" ]; then
 	step "checkout $BRANCH"
-	if [ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]; then
-		echo "ci-lab-up: ERROR: working tree is dirty; commit or stash before switching branches" >&2
+	DIRTY="$(git -C "$REPO_ROOT" status --porcelain)"
+	if [ -n "$DIRTY" ]; then
+		# Classify the dirt. A gitlink left at a different commit than HEAD records (a stale
+		# submodule checkout from an earlier session) shows up here as ` M <path>` and is
+		# indistinguishable from an edited file in porcelain output -- but "commit or stash" is
+		# the wrong advice for it, since committing a drifted pointer is actively harmful.
+		SUBMODULE_PATHS="$(git -C "$REPO_ROOT" config -f "$REPO_ROOT/.gitmodules" \
+			--get-regexp '^submodule\..*\.path$' 2>/dev/null | awk '{print $2}' || true)"
+		DRIFTED=""
+		OTHER_DIRT=false
+		while IFS= read -r line; do
+			[ -n "$line" ] || continue
+			if printf '%s\n' "$SUBMODULE_PATHS" | grep -qxF -- "${line:3}"; then
+				DRIFTED="$DRIFTED ${line:3}"
+			else
+				OTHER_DIRT=true
+			fi
+		done <<-EOF
+			$DIRTY
+		EOF
+
+		if [ -n "$DRIFTED" ] && [ "$OTHER_DIRT" = false ]; then
+			echo "ci-lab-up: ERROR: submodule pointer(s) differ from what HEAD records:$DRIFTED" >&2
+			echo "ci-lab-up: that is a stale submodule checkout, not local work -- do NOT commit it. Restore with:" >&2
+			echo "ci-lab-up:   git -C '$REPO_ROOT' submodule update --init --recursive$DRIFTED" >&2
+			exit 1
+		fi
+		echo "ci-lab-up: ERROR: working tree is dirty; commit or stash before switching refs" >&2
 		git -C "$REPO_ROOT" status --short >&2
 		exit 1
 	fi
-	git -C "$REPO_ROOT" fetch origin "$BRANCH"
+
+	# Resolve from origin first (the common case: a pushed branch), then from a local ref. The
+	# local fallback is what makes a throwaway instrumentation branch usable without pushing it.
+	if git -C "$REPO_ROOT" fetch origin "$BRANCH"; then
+		echo "ci-lab-up: resolved '$BRANCH' from origin"
+	elif git -C "$REPO_ROOT" rev-parse --verify --quiet "$BRANCH^{commit}" >/dev/null; then
+		echo "ci-lab-up: '$BRANCH' is not on origin (fetch failed above); using the local ref"
+	else
+		echo "ci-lab-up: ERROR: cannot resolve '$BRANCH' -- tried fetching it from origin and" >&2
+		echo "ci-lab-up: resolving it as a local branch, tag, or SHA. Neither worked." >&2
+		exit 1
+	fi
 	git -C "$REPO_ROOT" checkout "$BRANCH"
 fi
 
-# 2. Workspace env (.env: bind-mount paths + a per-checkout COMPOSE_PROJECT_NAME). Idempotent.
+# 2. Workspace env (.env: bind-mount paths + a per-checkout COMPOSE_PROJECT_NAME) and submodule
+#    checkout. Host-side, so the private ai-lib submodule clones with your credentials. Idempotent.
 step "initialize"
 ./initialize.sh
 
@@ -68,9 +127,10 @@ if [ "$STATE" = COLD ]; then
 	# 5. First-time (or recovery) build: ~10 min. Blocks until done; log kept for failures.
 	step "cold build (post-create.sh, ~10 min)"
 	in_ctr './.devcontainer/ci-arm/post-create.sh 2>&1 | tee /tmp/post-create.log'
-elif [ -n "$BRANCH" ]; then
-	# Build present but we just switched branches: reconcile deps and recompile out/ so both match
-	# the new source. (Without a branch switch the current checkout is assumed already built.)
+elif [ "$RECONCILE" = true ]; then
+	# Build present, but source moved under it (a ref switch, or --local after editing by hand):
+	# reconcile deps and recompile out/ so both match the current source. Skipped without either,
+	# where the current checkout is assumed already built.
 	step "reconcile dependencies"
 	# Root deps go through fast-install.ts, not a root-lockfile-only sha compare: it hashes every
 	# dir in build/npm/dirs.ts (root plus each extension), so a branch that only changes an
@@ -93,7 +153,18 @@ in_ctr './.devcontainer/ci-arm/post-start.sh'
 
 step "ready"
 cat <<'MSG'
-ci-lab-up: the lab is ready. Run a spec with:
+ci-lab-up: SUCCESS -- the lab is ready. Run a spec with:
   docker compose exec -T test bash -lc \
     "cd \$POSITRON_WORKSPACE_PATH && ./.devcontainer/ci-arm/run-e2e.sh test/e2e/tests/<area>/<file>.test.ts --workers=1"
 MSG
+
+# "Ready" without a reconcile only means the last build's artifacts are present -- it says nothing
+# about whether they match the working tree. Spell that out rather than let it read as "your edits
+# are compiled", which is the trap in the no-argument path.
+if [ "$RECONCILE" = false ] && [ "$STATE" != COLD ]; then
+	cat <<'MSG'
+
+Note: nothing was recompiled this run, so out/ reflects whatever was last built here,
+not your current working tree. If you edited source, rerun with --local.
+MSG
+fi

--- a/.devcontainer/ci-arm/initialize.sh
+++ b/.devcontainer/ci-arm/initialize.sh
@@ -3,6 +3,10 @@
 # Detects the checkout path and the git common dir so docker-compose can bind-mount both
 # at their real host paths — which is what makes a git *worktree* work inside the container
 # (worktree git metadata uses absolute host paths). Harmless for a normal clone.
+#
+# Also checks out any uninitialized submodules. This has to happen host-side: ai-lib is private
+# and the container has no GitHub credentials, so build/npm/postinstall.ts aborts the whole root
+# install if it has to clone ai-lib itself.
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"   # .devcontainer/ci-arm
 ROOT="$(cd "$HERE/../.." && pwd)"       # the checkout root (worktree or clone)
@@ -13,6 +17,34 @@ case "$GITCOMMON" in
   /*) : ;;                                                  # already absolute
   *)  GITCOMMON="$(cd "$ROOT" && cd "$(dirname "$GITCOMMON")" && pwd)/$(basename "$GITCOMMON")" ;;
 esac
+
+# Check out any submodule that isn't there yet. On failure, name the two things that actually
+# cause it -- git reports only "clone ... failed", which points at neither:
+#   - leftovers in the submodule path (e.g. packages/*/node_modules from an earlier session's
+#     install) with no .git. Some git versions clone into a non-empty directory and some refuse,
+#     so this is diagnosed after the attempt rather than pre-empting it.
+#   - no read access to a private submodule (ai-lib).
+# Removing tens of MB unattended isn't this script's call to make, so it prints the command.
+if [ -f "$ROOT/.gitmodules" ]; then
+  while read -r _ SUB; do
+    [ -n "$SUB" ] || continue
+    [ -e "$ROOT/$SUB/.git" ] && continue                      # already checked out
+    LEFTOVERS=false
+    [ -n "$(ls -A "$ROOT/$SUB" 2>/dev/null)" ] && LEFTOVERS=true
+    echo "ci-arm initialize: checking out submodule $SUB"
+    if ! git -C "$ROOT" submodule update --init --recursive "$SUB"; then
+      echo "ci-arm initialize: ERROR: could not check out submodule '$SUB'." >&2
+      if [ "$LEFTOVERS" = true ]; then
+        echo "ci-arm initialize: '$SUB' already held files but was not a submodule checkout, which is" >&2
+        echo "ci-arm initialize: the likely cause. Remove it and rerun:" >&2
+        echo "ci-arm initialize:   rm -rf '$ROOT/$SUB'" >&2
+      else
+        echo "ci-arm initialize: check that you have read access to it (ai-lib is private)." >&2
+      fi
+      exit 1
+    fi
+  done < <(git -C "$ROOT" config -f "$ROOT/.gitmodules" --get-regexp '^submodule\..*\.path$')
+fi
 
 [ -f "$ENV" ] || cp "$HERE/.env.example" "$ENV"
 


### PR DESCRIPTION
### Summary

Fixes five things that blocked a headless (agent-driven) CI-repro session in the ci-arm lab, four of which reported success while failing. Dev tooling only -- no product source or test changes.

- `ci-lab-up.sh` prints `FAILED at step '<phase>'` / `SUCCESS`; callers pipe through `tee`, which reported tee's exit status and masked failures the script already exited non-zero on
- `<ref>` now resolves from origin, then as a local branch/tag/SHA, so a local-only instrumentation branch works unpushed
- New `--local` mode reconciles deps and recompiles `out/` against the working tree; the no-argument mode now states that it recompiled nothing
- The dirty-tree check classifies gitlinks and suggests `git submodule update` for a drifted pointer instead of "commit or stash"
- `initialize.sh` checks out missing submodules host-side, where credentials are -- a container-side `ai-lib` clone aborts the root install and surfaces as an unrelated `TS2688`

README: the flake-repro warning moves out of the agent-only section into a shared one mapping what you changed to the invocation that compiles it, plus gotchas for the `ai-lib` gitlink bump, drifted gitlinks, and forced git color breaking generated patches.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

No e2e tags: this touches only `.devcontainer/ci-arm/`, so no product code or test is exercised by the suite.

Verified against a synthetic repo with a submodule and an origin remote (Docker stubbed), covering all three invocation modes, all four ref-resolution outcomes, both dirty-check classifications, all three submodule states, and the FAILED trailer surviving a `tee` pipeline. `shellcheck` clean.

To spot-check by hand from a lab worktree: `./.devcontainer/ci-arm/ci-lab-up.sh no-such-ref 2>&1 | tee /tmp/x.log; echo $?` should print `0` (the pipeline) while the log ends in `ci-lab-up: FAILED at step 'checkout no-such-ref' (exit 1)`.
