### PR TITLE
fix(quarto): don't auto-expand inline output over an explicit user collapse

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
@@ -1580,7 +1580,7 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 	 */
 	setAllOutputsCollapsed(collapsed: boolean): void {
 		for (const viewZone of this._viewZones.values()) {
-			viewZone.setCollapsed(collapsed);
+			viewZone.setCollapsed(collapsed, true);
 		}
 	}
 

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
@@ -201,6 +201,21 @@ export function chooseHtmlRenderMode(html: string, hasWebviewService: boolean): 
 }
 
 /**
+ * Whether a fresh output arriving mid-re-execution should expand a collapsed
+ * output. Expanding is the default so the user sees new results, but it must not
+ * override a collapse the user made *during* this execution: output can arrive
+ * hundreds of ms after they collapsed, and silently re-expanding both discards
+ * an explicit action and leaves the next toggle inverted (posit-dev/positron
+ * flake in quarto-inline-output-collapse).
+ *
+ * A collapse made *before* the re-execution started does not suppress the
+ * expand, which is the case the behavior exists for.
+ */
+export function shouldExpandOnFreshOutput(isCollapsed: boolean, userCollapsedDuringExecution: boolean): boolean {
+	return isCollapsed && !userCollapsedDuringExecution;
+}
+
+/**
  * View zone for displaying Quarto cell output inline in the editor.
  * Supports text, images, error output, and complex webview-based outputs.
  */
@@ -329,6 +344,9 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 
 	// Collapse state: when true, outputs are hidden and a textual summary is shown
 	private _isCollapsed = false;
+	// Set when the user collapses while the cell is re-executing, so a late
+	// output doesn't expand it back out from under them.
+	private _userCollapsedDuringExecution = false;
 	// Collapse chevron button (portaled into the editor's container node)
 	private readonly _collapseButton: HTMLButtonElement;
 	private _collapseChevronIcon!: HTMLSpanElement;
@@ -461,13 +479,13 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		this._summaryElement.addEventListener('click', (e) => {
 			e.preventDefault();
 			e.stopPropagation();
-			this.setCollapsed(false);
+			this.setCollapsed(false, true);
 		});
 		this._summaryElement.addEventListener('keydown', (e) => {
 			if (e.key === 'Enter' || e.key === ' ') {
 				e.preventDefault();
 				e.stopPropagation();
-				this.setCollapsed(false);
+				this.setCollapsed(false, true);
 			}
 		});
 		this._styledContainer.appendChild(this._summaryElement);
@@ -672,6 +690,10 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 			return;
 		}
 		this._isRecomputing = isRecomputing;
+		if (isRecomputing) {
+			// A new execution starts a new window for the user's collapse intent.
+			this._userCollapsedDuringExecution = false;
+		}
 		this._updateRecomputingState();
 	}
 
@@ -1062,8 +1084,9 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 			this._disposeAllWebviews();
 			this._disposeAllReactRenderers();
 			this.setRecomputing(false);
-			// Fresh outputs on re-execution: expand so the user sees them.
-			if (this._isCollapsed) {
+			// Fresh outputs on re-execution: expand so the user sees them, unless
+			// the user collapsed during this execution.
+			if (shouldExpandOnFreshOutput(this._isCollapsed, this._userCollapsedDuringExecution)) {
 				this.setCollapsed(false);
 			}
 		}
@@ -1133,6 +1156,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		// Reset collapse state so the next output starts expanded
 		const wasCollapsed = this._isCollapsed;
 		this._isCollapsed = false;
+		this._userCollapsedDuringExecution = false;
 		this._styledContainer.classList.remove('quarto-output-collapsed');
 		this._collapseChevronIcon.classList.remove('collapsed');
 		const collapseLabel = localize('quartoCollapseOutput', 'Collapse Output');
@@ -1597,14 +1621,22 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 	 * Toggle the collapsed state of the output.
 	 */
 	toggleCollapsed(): void {
-		this.setCollapsed(!this._isCollapsed);
+		this.setCollapsed(!this._isCollapsed, true);
 	}
 
 	/**
 	 * Set the collapsed state. When collapsed, the output content is hidden
 	 * and a textual summary is shown in its place.
+	 *
+	 * @param userInitiated Whether this came from a user action (chevron, toggle
+	 * command, summary click) rather than a restore or an automatic expand. A
+	 * user collapse during a re-execution suppresses the auto-expand that a late
+	 * output would otherwise trigger.
 	 */
-	setCollapsed(collapsed: boolean): void {
+	setCollapsed(collapsed: boolean, userInitiated = false): void {
+		if (userInitiated) {
+			this._userCollapsedDuringExecution = collapsed && this._isRecomputing;
+		}
 		if (this._isCollapsed === collapsed) {
 			return;
 		}

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputViewZone.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputViewZone.vitest.ts
@@ -5,7 +5,7 @@
 
 /// <reference types="vitest/globals" />
 
-import { chooseHtmlRenderMode, isInertHtml, isWebviewOverlayShown } from '../../browser/quartoOutputViewZone.js';
+import { chooseHtmlRenderMode, isInertHtml, isWebviewOverlayShown, shouldExpandOnFreshOutput } from '../../browser/quartoOutputViewZone.js';
 
 // The inline-output webview is a fixed-position overlay anchored to a
 // placeholder inside the editor view zone. It must be shown only while its view
@@ -90,5 +90,27 @@ describe('chooseHtmlRenderMode', () => {
 
 	it('falls back to the warning only when no webview service exists', () => {
 		expect(chooseHtmlRenderMode(activeHtml, false)).toBe('warning');
+	});
+});
+
+// A cell's output can arrive hundreds of ms after the user collapsed it, while
+// the zone is still in its recomputing window. Expanding on fresh output is the
+// default so new results are visible, but doing it after an explicit collapse
+// discards the user's action and inverts the next toggle: the following toggle
+// reads the collapsed flag as false and collapses again instead of expanding.
+// That is the quarto-inline-output-collapse flake.
+describe('shouldExpandOnFreshOutput', () => {
+	it('expands a collapsed output when the user did not collapse during this execution', () => {
+		// The case the behavior exists for: collapsed before the re-run started.
+		expect(shouldExpandOnFreshOutput(true, false)).toBe(true);
+	});
+
+	it('leaves it collapsed when the user collapsed during this execution', () => {
+		expect(shouldExpandOnFreshOutput(true, true)).toBe(false);
+	});
+
+	it('does nothing when the output is already expanded', () => {
+		expect(shouldExpandOnFreshOutput(false, false)).toBe(false);
+		expect(shouldExpandOnFreshOutput(false, true)).toBe(false);
 	});
 });

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputViewZone.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputViewZone.vitest.ts
@@ -5,7 +5,13 @@
 
 /// <reference types="vitest/globals" />
 
-import { chooseHtmlRenderMode, isInertHtml, isWebviewOverlayShown, shouldExpandOnFreshOutput } from '../../browser/quartoOutputViewZone.js';
+import { Event } from '../../../../../base/common/event.js';
+import { BareFontInfo } from '../../../../../editor/common/config/fontInfo.js';
+import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
+import { EditorOption } from '../../../../../editor/common/config/editorOptions.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { ICellOutput } from '../../common/quartoExecutionTypes.js';
+import { chooseHtmlRenderMode, isInertHtml, isWebviewOverlayShown, QuartoOutputViewZone } from '../../browser/quartoOutputViewZone.js';
 
 // The inline-output webview is a fixed-position overlay anchored to a
 // placeholder inside the editor view zone. It must be shown only while its view
@@ -98,19 +104,74 @@ describe('chooseHtmlRenderMode', () => {
 // default so new results are visible, but doing it after an explicit collapse
 // discards the user's action and inverts the next toggle: the following toggle
 // reads the collapsed flag as false and collapses again instead of expanding.
-// That is the quarto-inline-output-collapse flake.
-describe('shouldExpandOnFreshOutput', () => {
-	it('expands a collapsed output when the user did not collapse during this execution', () => {
-		// The case the behavior exists for: collapsed before the re-run started.
-		expect(shouldExpandOnFreshOutput(true, false)).toBe(true);
+// That is the quarto-inline-output-collapse flake (posit-dev/positron#15205).
+//
+// These drive the real view zone rather than the collapse predicate on its own:
+// the bug was never in the predicate but in the ordering of setRecomputing /
+// setCollapsed / addOutput around it, so the sequence is what has to be pinned.
+describe('QuartoOutputViewZone collapse across a re-execution', () => {
+	function createViewZone(): QuartoOutputViewZone {
+		const containerDomNode = document.createElement('div');
+		const editor = stubInterface<ICodeEditor>({
+			getContainerDomNode: () => containerDomNode,
+			onDidChangeConfiguration: Event.None,
+			onDidLayoutChange: Event.None,
+			onDidScrollChange: Event.None,
+			onDidContentSizeChange: Event.None,
+			onDidChangeHiddenAreas: Event.None,
+			onMouseMove: Event.None,
+			onMouseLeave: Event.None,
+			// The zone reads only fontInfo, and only hands it to `applyFontInfo`,
+			// which takes a BareFontInfo. Throwing on any other option keeps the
+			// stub honest if the zone starts reading more of the editor config.
+			getOption: ((id: EditorOption) => {
+				if (id !== EditorOption.fontInfo) {
+					throw new Error(`unexpected getOption(${id})`);
+				}
+				return BareFontInfo._create('monospace', 'normal', 12, '', '', 18, 0, 1, false);
+			}) as ICodeEditor['getOption'],
+		});
+		return new QuartoOutputViewZone(editor, 'cell-1', 1);
+	}
+
+	function textOutput(id: string, text: string): ICellOutput {
+		return { outputId: id, items: [{ mime: 'text/plain', data: text }] };
+	}
+
+	it('keeps the output collapsed when the user collapses mid-execution', () => {
+		const zone = createViewZone();
+		zone.addOutput(textOutput('out-1', 'first run'));
+
+		// Re-run: the zone enters recomputing while the old output is still shown.
+		zone.setRecomputing(true);
+		// The user collapses during that window.
+		zone.toggleCollapsed();
+		expect(zone.isCollapsed).toBe(true);
+
+		// The new output lands hundreds of ms later. It must not undo the collapse.
+		zone.addOutput(textOutput('out-2', 'second run'));
+		expect(zone.isCollapsed).toBe(true);
+
+		// And the next toggle expands, rather than collapsing a second time.
+		zone.toggleCollapsed();
+		expect(zone.isCollapsed).toBe(false);
+
+		zone.dispose();
 	});
 
-	it('leaves it collapsed when the user collapsed during this execution', () => {
-		expect(shouldExpandOnFreshOutput(true, true)).toBe(false);
-	});
+	it('expands on fresh output when the collapse predates the re-execution', () => {
+		const zone = createViewZone();
+		zone.addOutput(textOutput('out-1', 'first run'));
 
-	it('does nothing when the output is already expanded', () => {
-		expect(shouldExpandOnFreshOutput(false, false)).toBe(false);
-		expect(shouldExpandOnFreshOutput(false, true)).toBe(false);
+		// Collapsed while idle, before anything re-runs.
+		zone.toggleCollapsed();
+		expect(zone.isCollapsed).toBe(true);
+
+		// This is the case the auto-expand exists for: new results become visible.
+		zone.setRecomputing(true);
+		zone.addOutput(textOutput('out-2', 'second run'));
+		expect(zone.isCollapsed).toBe(false);
+
+		zone.dispose();
 	});
 });


### PR DESCRIPTION
### Summary
A fresh output arriving mid-re-execution called `setCollapsed(false)` unconditionally, discarding a collapse the user made during that execution. The next toggle then read the state as expanded and collapsed again instead of expanding.

- Track whether a collapse was user-initiated during the current execution and skip the auto-expand in that case
- A collapse made *before* the re-execution still expands on fresh output, which is what that behavior exists for
- Decision extracted to `shouldExpandOnFreshOutput()` with unit coverage
- Fixes a 19.5% ubuntu/chromium flake in the Quarto inline-output collapse suite

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Collapsing Quarto inline output while a cell is re-running no longer springs back open when the new output arrives

### Validation Steps

@:quarto @:web

Run a Quarto cell whose output is slow (e.g. `time.sleep(6)` before `plt.show()`), re-run it, collapse the output while it is recomputing, and confirm it stays collapsed when the new output lands. Toggling afterwards should expand it.

Verified on the ci-arm CI image (ubuntu24-arm64, chromium) with a temporary forced-race test: it failed pre-fix with the auto-expand overriding the collapse, and passed 3/3 post-fix with the guard engaging on every run.


### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- A fresh output arriving mid-re-execution calls setCollapsed(false) from QuartoOutputViewZone.addOutput, discarding a collapse the user made during that execution. The second toggle then reads _isCollapsed===false and collapses again instead of expanding, so the output is still collapsed when the test asserts expanded.</summary>

- **Test:** [Quarto - Inline Output: Collapse > Python - Verify output can be collapsed and expanded via toggle command](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Quarto%20-%20Inline%20Output%3A%20Collapse%20%3E%20Python%20-%20Verify%20output%20can%20be%20collapsed%20and%20expanded%20via%20toggle%20command%7C%7C%7Ctest%2Fe2e%2Ftests%2Fquarto%2Fquarto-inline-output-collapse.test.ts)
- **Targeted failure:** Pattern A: expectOutputExpanded() / not.toHaveClass(quarto-output-collapsed) at quarto-inline-output-collapse.test.ts:61, 19.5% on ubuntu/chromium
- **Signal:** REPRODUCED on the real CI image (ci-arm ubuntu24-arm64, e2e-chromium, whole spec, --repeat-each=3 --workers=1): 1 failed / 5 passed, same not.toHaveClass error. Instrumented sequence of the failing run: toggleCommand{found:true,collapsedBefore:false} -> setCollapsed{collapsed:true,connected:true} -> setCollapsed{collapsed:false} at 20.967 WITH NO toggleCommand line (the smoking gun) -> toggleCommand{found:true,collapsedBefore:false} -> setCollapsed{collapsed:true} -> final class quarto-inline-output quarto-output-collapsed. Passing runs show collapsedBefore:true on the second toggle and no orphan setCollapsed. The orphan setCollapsed(false) is quartoOutputViewZone.ts:1075 in addOutput(): when _isRecomputing is true the first fresh output calls setRecomputing(false) then setCollapsed(false) (comment: Fresh outputs on re-execution: expand so the user sees them). Both passing runs ended with class quarto-output-recomputing still set, proving the cell is still executing in every run and only the arrival timing differs. Enabling condition: inlineQuarto.runCellAndWaitForOutput waits only for expect(this.inlineOutput).toBeVisible(), and the view zone becomes visible while the cell is still executing (status-only zone), so the test always toggles mid-execution.
- **Frequency:** 26/133 runs (19.5%) on main, ubuntu/chromium
- **Hypothesis:** CONFIRMED by differential evidence between failing and passing runs on the CI image, not inference. The ~19.5% CI rate is the probability that the first post-recompute output lands inside the ~900ms window between the two toggle commands.

</details>
