### PR TITLE
fix: gate quarto run-cell e2e helper on a durable execution signal

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoCellToolbar.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoCellToolbar.ts
@@ -165,8 +165,9 @@ export class QuartoCellToolbar extends Disposable implements IOverlayWidget {
 	 */
 	updateCell(cell: QuartoCodeCell, cellIndex: number, totalCells: number): void {
 		if (cell.id !== this._cell.id) {
-			// Re-pointed at a different cell, so the retained execution id belongs to
-			// the old one. Drop it rather than let it read as this cell's last run.
+			// Cell ids embed index and content hash, so this fires both for a genuinely
+			// different cell and for the same cell after an edit. Drop in both cases: a
+			// retained id must never outlive the run it describes.
 			this._domNode.removeAttribute(EXECUTION_ID_ATTR);
 		}
 		this._cell = cell;
@@ -179,11 +180,9 @@ export class QuartoCellToolbar extends Disposable implements IOverlayWidget {
 	/**
 	 * Set the execution state of the cell, which affects the Run/Stop button.
 	 *
-	 * `executionId` is recorded on the DOM node and kept there after the run ends.
-	 * The run button only reflects the queued/running state for as long as the cell
-	 * is actually executing, which can be a couple hundred milliseconds -- too
-	 * short for an e2e test to reliably observe. The retained id is what lets a
-	 * test confirm a run registered at all, after the fact.
+	 * `executionId` is mirrored onto the DOM node and retained after the run ends, so
+	 * a test can confirm a run registered even though the queued/running button state
+	 * is gone by then.
 	 */
 	setExecutionState(state: CellExecutionState, executionId?: string): void {
 		this._executionState = state;

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoCellToolbar.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoCellToolbar.ts
@@ -17,6 +17,12 @@ import { ThemeIcon } from '../../../../base/common/themables.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { getWindow } from '../../../../base/browser/dom.js';
 
+/** Current execution state of the cell, mirrored onto the toolbar's DOM node. */
+const EXECUTION_STATE_ATTR = 'data-execution-state';
+
+/** Id of the cell's most recent execution; retained after that execution ends. */
+const EXECUTION_ID_ATTR = 'data-execution-id';
+
 /**
  * A toolbar widget that appears in the upper-right corner of Quarto code cells.
  * Provides buttons for Run Cell, Run Above, and Run Below actions.
@@ -158,6 +164,11 @@ export class QuartoCellToolbar extends Disposable implements IOverlayWidget {
 	 * instead of being destroyed and recreated.
 	 */
 	updateCell(cell: QuartoCodeCell, cellIndex: number, totalCells: number): void {
+		if (cell.id !== this._cell.id) {
+			// Re-pointed at a different cell, so the retained execution id belongs to
+			// the old one. Drop it rather than let it read as this cell's last run.
+			this._domNode.removeAttribute(EXECUTION_ID_ATTR);
+		}
 		this._cell = cell;
 		this._cellIndex = cellIndex;
 		this._totalCells = totalCells;
@@ -167,9 +178,19 @@ export class QuartoCellToolbar extends Disposable implements IOverlayWidget {
 
 	/**
 	 * Set the execution state of the cell, which affects the Run/Stop button.
+	 *
+	 * `executionId` is recorded on the DOM node and kept there after the run ends.
+	 * The run button only reflects the queued/running state for as long as the cell
+	 * is actually executing, which can be a couple hundred milliseconds -- too
+	 * short for an e2e test to reliably observe. The retained id is what lets a
+	 * test confirm a run registered at all, after the fact.
 	 */
-	setExecutionState(state: CellExecutionState): void {
+	setExecutionState(state: CellExecutionState, executionId?: string): void {
 		this._executionState = state;
+		this._domNode.setAttribute(EXECUTION_STATE_ATTR, state);
+		if (executionId) {
+			this._domNode.setAttribute(EXECUTION_ID_ATTR, executionId);
+		}
 		this._updateRunButton();
 	}
 
@@ -259,6 +280,7 @@ export class QuartoCellToolbar extends Disposable implements IOverlayWidget {
 	private _createDomNode(): HTMLElement {
 		const container = document.createElement('div');
 		container.className = 'quarto-cell-toolbar';
+		container.setAttribute(EXECUTION_STATE_ATTR, this._executionState);
 
 		// Run/Stop button (rendered first, styled distinctly in green)
 		this._runButton = document.createElement('button');

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoCellToolbarController.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoCellToolbarController.ts
@@ -133,7 +133,7 @@ export class QuartoCellToolbarController extends Disposable implements IEditorCo
 		this._disposables.add(this._executionManager.onDidChangeExecutionState((event) => {
 			const toolbar = this._toolbars.get(event.execution.cellId);
 			if (toolbar) {
-				toolbar.setExecutionState(event.execution.state);
+				toolbar.setExecutionState(event.execution.state, event.execution.executionId);
 			}
 		}));
 

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoCellToolbar.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoCellToolbar.vitest.ts
@@ -4,12 +4,22 @@
  *--------------------------------------------------------------------------------------------*/
 
 /// <reference types="vitest/globals" />
+/// <reference types="@testing-library/jest-dom/vitest" />
 
 import { URI } from '../../../../../base/common/uri.js';
+import { Event } from '../../../../../base/common/event.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
 import { createTextModel } from '../../../../../editor/test/common/testTextModel.js';
+import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
+import { EditorLayoutInfo, EditorMinimapLayoutInfo } from '../../../../../editor/common/config/editorOptions.js';
+import { IManagedHover } from '../../../../../base/browser/ui/hover/hover.js';
+import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
+import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
 import { QuartoDocumentModel } from '../../browser/quartoDocumentModel.js';
+import { QuartoCellToolbar } from '../../browser/quartoCellToolbar.js';
+import { CellExecutionState } from '../../common/quartoExecutionTypes.js';
 
 describe('QuartoCellToolbar - Position Updates', () => {
 	const ctx = createTestContainer().build();
@@ -215,5 +225,109 @@ y = 2
 			// The key insight: a toolbar controller listening to onDidParse
 			// can refresh cell references and update positions correctly
 		});
+	});
+});
+
+describe('QuartoCellToolbar - Execution State DOM', () => {
+	const ctx = createTestContainer().build();
+	const logService = new NullLogService();
+
+	const TWO_CELLS = `\`\`\`{python}
+x = 1
+\`\`\`
+
+\`\`\`{python}
+y = 2
+\`\`\`
+`;
+
+	/**
+	 * Build a toolbar for `cellIndex` of a two-cell document, along with the parsed
+	 * cells so a test can re-point the toolbar at a different one.
+	 */
+	function createToolbar(cellIndex = 0) {
+		const textModel = createTextModel(TWO_CELLS, null, undefined, URI.file('/test.qmd'));
+		ctx.disposables.add(textModel);
+		const model = new QuartoDocumentModel(textModel, logService);
+		ctx.disposables.add(model);
+
+		const editor = stubInterface<ICodeEditor>({
+			addOverlayWidget: vi.fn(),
+			removeOverlayWidget: vi.fn(),
+			onDidScrollChange: Event.None,
+			onDidLayoutChange: Event.None,
+			getTopForLineNumber: () => 0,
+			getScrollTop: () => 0,
+			getLayoutInfo: () => stubInterface<EditorLayoutInfo>({
+				height: 500,
+				verticalScrollbarWidth: 10,
+				minimap: stubInterface<EditorMinimapLayoutInfo>({ minimapWidth: 0 }),
+			}),
+			// `getOption` is generic over the option id, so a fixed line height can't
+			// be expressed in its signature.
+			getOption: (() => 18) as ICodeEditor['getOption'],
+		});
+		const hoverService = stubInterface<IHoverService>({
+			setupManagedHover: () => stubInterface<IManagedHover>({ dispose: () => { } }),
+		});
+		const keybindingService = stubInterface<IKeybindingService>({ lookupKeybinding: () => undefined });
+
+		const toolbar = new QuartoCellToolbar(
+			editor, model.cells[cellIndex], cellIndex, model.cells.length,
+			() => { }, () => { }, () => { }, () => { }, () => { }, () => { },
+			hoverService, keybindingService
+		);
+		ctx.disposables.add(toolbar);
+
+		return { toolbar, cells: model.cells, domNode: toolbar.getDomNode() };
+	}
+
+	it('retains the execution id after the run finishes', () => {
+		const { toolbar, domNode } = createToolbar();
+
+		toolbar.setExecutionState(CellExecutionState.Queued, 'quarto-exec-1');
+		toolbar.setExecutionState(CellExecutionState.Running, 'quarto-exec-1');
+		toolbar.setExecutionState(CellExecutionState.Completed, 'quarto-exec-1');
+
+		// The queued/running button state is gone once the cell finishes, so the
+		// retained id is the only durable evidence the run happened at all.
+		expect(domNode).toHaveAttribute('data-execution-id', 'quarto-exec-1');
+		expect(domNode).toHaveAttribute('data-execution-state', 'completed');
+	});
+
+	it('records a fresh execution id on a re-run of the same cell', () => {
+		const { toolbar, domNode } = createToolbar();
+
+		toolbar.setExecutionState(CellExecutionState.Completed, 'quarto-exec-1');
+		toolbar.setExecutionState(CellExecutionState.Running, 'quarto-exec-2');
+
+		expect(domNode).toHaveAttribute('data-execution-id', 'quarto-exec-2');
+	});
+
+	it('reports idle before any execution', () => {
+		const { domNode } = createToolbar();
+
+		expect(domNode).not.toHaveAttribute('data-execution-id');
+		expect(domNode).toHaveAttribute('data-execution-state', 'idle');
+	});
+
+	it('drops the retained execution id when re-pointed at another cell', () => {
+		const { toolbar, cells, domNode } = createToolbar();
+		toolbar.setExecutionState(CellExecutionState.Completed, 'quarto-exec-1');
+
+		toolbar.updateCell(cells[1], 1, cells.length);
+
+		expect(domNode).not.toHaveAttribute('data-execution-id');
+	});
+
+	it('keeps the retained execution id when re-pointed at the same cell', () => {
+		const { toolbar, cells, domNode } = createToolbar();
+		toolbar.setExecutionState(CellExecutionState.Completed, 'quarto-exec-1');
+
+		// Cell content is unchanged, so the toolbar is being reused rather than
+		// reassigned -- the cell's last run still belongs to it.
+		toolbar.updateCell(cells[0], 0, cells.length);
+
+		expect(domNode).toHaveAttribute('data-execution-id', 'quarto-exec-1');
 	});
 });

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoCellToolbar.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoCellToolbar.vitest.ts
@@ -295,6 +295,18 @@ y = 2
 		expect(domNode).toHaveAttribute('data-execution-state', 'completed');
 	});
 
+	it('retains the execution id after the run errors', () => {
+		const { toolbar, domNode } = createToolbar();
+
+		toolbar.setExecutionState(CellExecutionState.Running, 'quarto-exec-err');
+		toolbar.setExecutionState(CellExecutionState.Error, 'quarto-exec-err');
+
+		// A cell that errors still registered a run, so the gate must see it --
+		// otherwise a failing cell reads as a run that never dispatched.
+		expect(domNode).toHaveAttribute('data-execution-id', 'quarto-exec-err');
+		expect(domNode).toHaveAttribute('data-execution-state', 'error');
+	});
+
 	it('records a fresh execution id on a re-run of the same cell', () => {
 		const { toolbar, domNode } = createToolbar();
 

--- a/test/e2e/pages/inlineQuarto.ts
+++ b/test/e2e/pages/inlineQuarto.ts
@@ -15,6 +15,10 @@ const INLINE_OUTPUT = '.quarto-inline-output';
 const OUTPUT_CONTENT = '.quarto-output-content';
 const OUTPUT_ITEM = '.quarto-output-item';
 const CELL_TOOLBAR = '.quarto-cell-toolbar';
+// Set by the cell toolbar on every execution state change and retained after the
+// execution ends, unlike the queued/running run button.
+const EXECUTION_ID_ATTR = 'data-execution-id';
+const EXECUTED_CELL_TOOLBAR = `${CELL_TOOLBAR}[${EXECUTION_ID_ATTR}]`;
 const TOOLBAR_RUN = '.quarto-toolbar-run';
 const TOOLBAR_MORE = '.quarto-toolbar-more';
 const OUTPUT_CLOSE = '.quarto-output-close';
@@ -51,9 +55,9 @@ export class InlineQuarto {
 	readonly outputItem: Locator;
 	readonly cellToolbar: Locator;
 	readonly visibleCellToolbar: Locator;
+	readonly executedCellToolbar: Locator;
 	readonly toolbarRunButton: Locator;
 	readonly toolbarCancelButton: Locator;
-	readonly executingToolbarButton: Locator;
 	readonly closeButton: Locator;
 	readonly copyButton: Locator;
 	readonly saveButton: Locator;
@@ -83,11 +87,9 @@ export class InlineQuarto {
 		this.outputItem = page.locator(`${INLINE_OUTPUT} ${OUTPUT_ITEM}`);
 		this.cellToolbar = page.locator(CELL_TOOLBAR);
 		this.visibleCellToolbar = page.locator(`${CELL_TOOLBAR}.visible`);
+		this.executedCellToolbar = page.locator(EXECUTED_CELL_TOOLBAR);
 		this.toolbarRunButton = page.locator(`${CELL_TOOLBAR} ${TOOLBAR_RUN}`);
 		this.toolbarCancelButton = page.getByRole('button', { name: 'Cancel pending execution' });
-		// The run button toggles between run/queued/running; matches while the
-		// cell is queued or running, i.e. once a run has actually registered.
-		this.executingToolbarButton = page.getByRole('button', { name: /Cancel pending execution|Stop cell execution/ });
 		this.closeButton = page.locator(`${INLINE_OUTPUT} ${OUTPUT_CLOSE}`);
 		this.copyButton = page.locator(`${INLINE_OUTPUT} ${OUTPUT_COPY}`);
 		this.saveButton = page.locator(`${INLINE_OUTPUT} ${OUTPUT_SAVE}`);
@@ -179,18 +181,39 @@ export class InlineQuarto {
 	}
 
 	/**
+	 * Every execution id the cell toolbars have recorded so far. A toolbar keeps its
+	 * cell's most recent execution id after that run finishes, so an id here is
+	 * durable evidence a run registered -- it does not expire the way the toolbar's
+	 * queued/running button state does.
+	 */
+	private async _recordedExecutionIds(): Promise<string[]> {
+		const toolbars = await this.executedCellToolbar.all();
+		const ids = await Promise.all(toolbars.map(toolbar => toolbar.getAttribute(EXECUTION_ID_ATTR)));
+		return ids.filter((id): id is string => id !== null);
+	}
+
+	/**
 	 * Fire a run action at `cellLine` and confirm the cell actually started
 	 * executing before returning. The Quarto run command is extension-contributed,
 	 * so a transient extension-host stall (e.g. right after a window reload) can
 	 * swallow the run hotkey and leave the cell idle -- which would otherwise burn
 	 * the full output timeout waiting on a run that never took. Re-fire (moving the
-	 * cursor back onto the cell each attempt) until the cell enters queued/running.
+	 * cursor back onto the cell each attempt) until a new execution is recorded.
+	 *
+	 * Waits for an execution id the toolbars had not recorded before this call
+	 * rather than for the toolbar's queued/running button: a short cell can finish
+	 * in a couple hundred milliseconds, and the toolbar is only rendered while the
+	 * cursor is in its cell and it is on screen, so that button routinely comes and
+	 * goes between polls under CI load even though the run took fine.
 	 */
 	private async _runCellUntilStarted(cellLine: number, run: () => Promise<void>): Promise<void> {
+		const before = new Set(await this._recordedExecutionIds());
 		await expect(async () => {
 			await this.gotoLine(cellLine);
 			await run();
-			await expect(this.executingToolbarButton.first()).toBeVisible({ timeout: 10000 });
+			await expect
+				.poll(async () => (await this._recordedExecutionIds()).some(id => !before.has(id)), { timeout: 10000, intervals: [250] })
+				.toBe(true);
 		}).toPass({ timeout: 30000, intervals: [1000] });
 	}
 

--- a/test/e2e/pages/inlineQuarto.ts
+++ b/test/e2e/pages/inlineQuarto.ts
@@ -55,7 +55,9 @@ export class InlineQuarto {
 	readonly outputItem: Locator;
 	readonly cellToolbar: Locator;
 	readonly visibleCellToolbar: Locator;
-	readonly executedCellToolbar: Locator;
+	// Backs the run gate only; keeping it private keeps the `data-execution-id`
+	// contract an implementation detail that can be swapped without touching tests.
+	private readonly executedCellToolbar: Locator;
 	readonly toolbarRunButton: Locator;
 	readonly toolbarCancelButton: Locator;
 	readonly closeButton: Locator;
@@ -181,20 +183,15 @@ export class InlineQuarto {
 	}
 
 	/**
-	 * Every execution id the cell toolbars have recorded so far. A toolbar keeps its
-	 * cell's most recent execution id after that run finishes, so an id here is
-	 * durable evidence a run registered -- it does not expire the way the toolbar's
-	 * queued/running button state does.
-	 *
-	 * Document-scoped, not cell-scoped: the toolbar DOM carries no cell identity, so
-	 * a new id proves *some* cell ran, not which one. That is enough here because
-	 * Quarto executes a document's cells one at a time, and the caller goes on to
-	 * wait for output at a specific line anyway.
+	 * Execution ids recorded across all cell toolbars. Document-scoped, not
+	 * cell-scoped: the toolbar DOM carries no cell identity, so a new id proves
+	 * *some* cell ran, not which one.
 	 */
 	private async _recordedExecutionIds(): Promise<string[]> {
-		const toolbars = await this.executedCellToolbar.all();
-		const ids = await Promise.all(toolbars.map(toolbar => toolbar.getAttribute(EXECUTION_ID_ATTR)));
-		return ids.filter((id): id is string => id !== null);
+		return this.executedCellToolbar.evaluateAll(
+			(toolbars, attr) => toolbars.map(toolbar => toolbar.getAttribute(attr)!),
+			EXECUTION_ID_ATTR
+		);
 	}
 
 	/**
@@ -205,11 +202,10 @@ export class InlineQuarto {
 	 * the full output timeout waiting on a run that never took. Re-fire (moving the
 	 * cursor back onto the cell each attempt) until a new execution is recorded.
 	 *
-	 * Waits for an execution id the toolbars had not recorded before this call
-	 * rather than for the toolbar's queued/running button: a short cell can finish
-	 * in a couple hundred milliseconds, and the toolbar is only rendered while the
-	 * cursor is in its cell and it is on screen, so that button routinely comes and
-	 * goes between polls under CI load even though the run took fine.
+	 * Gates on a newly recorded execution id rather than the toolbar's
+	 * queued/running button: a short cell can finish in a couple hundred
+	 * milliseconds, and that button is only visible while the cursor is in its cell
+	 * and it is on screen, so it comes and goes between polls under CI load.
 	 */
 	private async _runCellUntilStarted(cellLine: number, run: () => Promise<void>): Promise<void> {
 		const before = new Set(await this._recordedExecutionIds());

--- a/test/e2e/pages/inlineQuarto.ts
+++ b/test/e2e/pages/inlineQuarto.ts
@@ -185,6 +185,11 @@ export class InlineQuarto {
 	 * cell's most recent execution id after that run finishes, so an id here is
 	 * durable evidence a run registered -- it does not expire the way the toolbar's
 	 * queued/running button state does.
+	 *
+	 * Document-scoped, not cell-scoped: the toolbar DOM carries no cell identity, so
+	 * a new id proves *some* cell ran, not which one. That is enough here because
+	 * Quarto executes a document's cells one at a time, and the caller goes on to
+	 * wait for output at a specific line anyway.
 	 */
 	private async _recordedExecutionIds(): Promise<string[]> {
 		const toolbars = await this.executedCellToolbar.all();


### PR DESCRIPTION
### Summary
The Quarto e2e helper `_runCellUntilStarted` confirmed a cell run had registered by waiting for the toolbar's queued/running button. That button exists only while the cell executes (as little as ~200ms), and the toolbar is hidden unless the cursor is in its cell and it is on screen, so the gate missed runs that had actually dispatched, reached the kernel and completed.

- Cell toolbar mirrors its execution state onto `data-execution-state` on its DOM node
- Toolbar retains `data-execution-id` after the execution ends, and clears it when re-pointed at another cell
- E2E helper now waits for an execution id the toolbars had not recorded before the attempt
- Adds 5 vitest cases locking the retained-attribute contract the page object depends on

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:quarto @:web

The inline-output specs should pass without relying on catching the toolbar's executing button mid-run. Confirmed there were no quarto flakes on this PR!


### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- The run-registered gate asserts on the cell toolbar executing button, whose visibility is cursor/hover/viewport-gated and whose executing label lives only for the 176-770ms the cell runs.</summary>

- **Test:** [Quarto - Inline Output: Popout > Python - Verify popout button appears for plot output and opens image in new tab](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Quarto%20-%20Inline%20Output%3A%20Popout%20%3E%20Python%20-%20Verify%20popout%20button%20appears%20for%20plot%20output%20and%20opens%20image%20in%20new%20tab%7C%7C%7Ctest%2Fe2e%2Ftests%2Fquarto%2Fquarto-inline-output-popout.test.ts)
- **Targeted failure:** Error: expect(locator).toBeVisible() failed -- getByRole(button, { name: /Cancel pending execution|Stop cell execution/ }).first(), element(s) not found
- **Signal:** All three retried runs dispatched, reached the kernel (quarto-exec-* execute_request -> status ok -> PNG display_data) and completed in 176-770ms, with QuartoOutputContribution receiving output each time; the cell toolbar object existed continuously (created 14:15:17.875, disposed 14:15:50.283, no rebuild), yet the executing-state button was never in the a11y tree during polling windows that opened before each execution and ran 10s past it -- so the button was visibility-gated (display:none viewport cull or missing .visible class), not absent because the run failed.
- **Frequency:** 3/143 runs (2.1%) on main, ubuntu/electron
- **Hypothesis:** race

</details>
