### PR TITLE
e2e: unbreak the Workbench lane (Databricks consent screen + getMetadata driver fallback)

### DIFF
--- a/test/e2e/infra/playwrightDriver.ts
+++ b/test/e2e/infra/playwrightDriver.ts
@@ -755,6 +755,28 @@ export class PlaywrightDriver {
 			[await this.getDriverHandle(), id, args] as const
 		);
 	}
+
+	/**
+	 * Whether `window.driver` is present on the page, i.e. whether the smoke-test driver
+	 * (and with it `executeCommand` and the `registerCommandIfSmokeTestDriver` commands)
+	 * is available.
+	 *
+	 * The driver only registers when the app runs with `--enable-smoke-test-driver`, which
+	 * our Electron and browser harnesses pass themselves. The Workbench lane connects to a
+	 * server that Posit Workbench launched, so there is no such flag and no driver -- tests
+	 * that would otherwise use the driver need a UI-based path there. Note that `isAlive()`
+	 * cannot answer this: `evaluateHandle('window.driver')` resolves to an `undefined`
+	 * handle rather than throwing.
+	 */
+	async isDriverAvailable(): Promise<boolean> {
+		try {
+			return await this.page.evaluate(() => Reflect.get(window, 'driver') !== undefined);
+		} catch {
+			// Page navigating or closed; treat the driver as unavailable rather than throwing
+			// from what callers use as a capability probe.
+			return false;
+		}
+	}
 	// --- End Positron ---
 
 	private async getDriverHandle(): Promise<playwright.JSHandle<IWindowDriver>> {

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -753,11 +753,19 @@ export class Sessions {
 	 */
 	async getMetadata(sessionId?: string): Promise<SessionMetaData> {
 		return await test.step(`Get metadata for: ${sessionId ?? 'current session'}`, async () => {
-			// Read the metadata directly from the runtime session service via the
+			// Prefer reading the metadata directly from the runtime session service via the
 			// internal `_positron.session.getMetadata` command (registered in
 			// languageRuntimeActionsForSmokeTests.ts). This avoids selecting the
 			// session tab and scraping the info popup, which is slower and flaky
 			// when notification toasts overlay the tab.
+			//
+			// Both the command and the `executeCommand` bridge it travels over are gated on
+			// `--enable-smoke-test-driver`, which the Workbench lane never has: Posit Workbench
+			// launches the Positron server itself. Scrape the info popup there instead.
+			if (!await this.code.driver.isDriverAvailable()) {
+				return await this.getMetadataFromDialog(sessionId);
+			}
+
 			const metadata = await this.code.driver.executeCommand<SessionMetaData | undefined>(
 				'_positron.session.getMetadata',
 				sessionId
@@ -769,6 +777,64 @@ export class Sessions {
 
 			return metadata;
 		});
+	}
+
+	/**
+	 * Helper: Read session metadata by opening the console session info popup.
+	 *
+	 * Fallback for environments without the smoke-test driver -- see `getMetadata()`. Unlike
+	 * the command-based read this drives the UI, so it has to bring the target session tab to
+	 * the foreground first and dismiss the popup afterwards.
+	 *
+	 * @param sessionId the session ID to get metadata for, otherwise will use the current session
+	 * @returns the metadata of the session
+	 */
+	private async getMetadataFromDialog(sessionId?: string): Promise<SessionMetaData> {
+		// Kept structurally identical to the pre-command implementation (including the
+		// `console.focus()` that getSessionCount() does on the way past), since that is the
+		// version proven against the Workbench lane.
+		const isSingleSession = (await this.getSessionCount()) === 1;
+
+		if (!isSingleSession && sessionId) {
+			const targetTab = this.getSessionTab(sessionId);
+
+			await expect(async () => {
+				// Toasts render over the session tab bar, and their auto-dismiss timer
+				// is held open while the pointer sits on them -- keep the mouse clear.
+				await this.page.mouse.move(0, 0);
+
+				// No force: let Playwright wait until the tab itself receives the
+				// click, rather than dispatching it into whatever is on top. Inner
+				// timeouts stay well under the outer budget, otherwise the first
+				// attempt consumes it and this never retries.
+				await targetTab.click({ timeout: 5000 });
+				await expect(targetTab).toHaveClass(/tab-button--active/, { timeout: 2000 });
+			}, `Select session tab: ${sessionId}`).toPass({ timeout: 30000 });
+		}
+
+		let metadata: SessionMetaData | undefined;
+
+		await expect(async () => {
+			await this.openMetadataDialog(sessionId);
+			const [name, id, state, path, source] = await Promise.all([
+				this.metadataDialog.getByTestId('session-name').textContent(),
+				this.metadataDialog.getByTestId('session-id').textContent(),
+				this.metadataDialog.getByTestId('session-state').textContent(),
+				this.metadataDialog.getByTestId('session-path').textContent(),
+				this.metadataDialog.getByTestId('session-source').textContent(),
+			]);
+			metadata = {
+				name: (name ?? '').trim(),
+				id: (id ?? '').replace('Session ID: ', ''),
+				state: (state ?? '').replace('State: ', '') as SessionState,
+				path: (path ?? '').replace('Path: ', ''),
+				source: (source ?? '').replace('Source: ', ''),
+			};
+		}, 'Extract session metadata').toPass({ intervals: [500], timeout: 10000 });
+
+		await this.page.keyboard.press('Escape');
+
+		return metadata!;
 	}
 
 	/**

--- a/test/e2e/pages/workbench/dashboard.page.ts
+++ b/test/e2e/pages/workbench/dashboard.page.ts
@@ -3,11 +3,26 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect, BrowserContext } from '@playwright/test';
+import { expect, BrowserContext, Page } from '@playwright/test';
 import { Code } from '../../infra/code.js';
 import { QuickInput } from '../quickInput.js';
 import { generateTOTP } from '../../utils/totp.js';
 import { isOktaLockedOut, otpRetryDelayMs } from '../../utils/otpRetry.js';
+
+/**
+ * The OAuth flow is complete once the provider redirects back to Workbench.
+ *
+ * Matched on host rather than by searching the whole URL for the callback path: Databricks
+ * carries `redirect_uri=...%2Foauth_redirect_callback` in the query string of its own consent
+ * screen, so a substring match reports "complete" while still sitting on the provider's page.
+ */
+const isWorkbenchCallback = (url: URL) => url.host === 'localhost:8787';
+
+/**
+ * Databricks ends its OAuth flow on an "Authorize as.." consent screen under `/oauth-prompt/`
+ * (currently `/oauth-prompt/select-group`) before redirecting to the callback.
+ */
+const isDatabricksAuthorizePrompt = (url: URL) => url.pathname.startsWith('/oauth-prompt/');
 
 export class DashboardPage {
 	get title() { return this.code.driver.currentPage.getByRole('link', { name: 'Workbench projects' }); }
@@ -252,7 +267,13 @@ export class DashboardPage {
 			await verifyOtpButton.click();
 
 			try {
-				await oauthPage.waitForURL(/oauth_redirect_callback|localhost:8787/, { timeout: 15000 });
+				// Okta hands the flow back to Databricks, which either redirects straight to the
+				// callback or first shows its "Authorize as.." consent screen. Reaching either one
+				// means the OTP was accepted, so stop retrying and finish the flow below.
+				await oauthPage.waitForURL(
+					url => isWorkbenchCallback(url) || isDatabricksAuthorizePrompt(url),
+					{ timeout: 15000 }
+				);
 				otpAccepted = true;
 				break;
 			} catch {
@@ -274,6 +295,10 @@ export class DashboardPage {
 			}
 		}
 
+		if (otpAccepted && !oauthPage.isClosed()) {
+			await this.confirmDatabricksAuthorizePrompt(oauthPage);
+		}
+
 		try {
 			if (otpAccepted) {
 				await oauthPage.waitForTimeout(2000);
@@ -288,6 +313,36 @@ export class DashboardPage {
 		// Verify credentials are enabled
 		await expect(enabledWidget).toBeVisible({ timeout: 30000 });
 		this.code.logger.log('Databricks OAuth setup complete');
+	}
+
+	/**
+	 * Confirms the "Authorize as.." consent screen Databricks shows at the end of its OAuth flow.
+	 *
+	 * The screen preselects the group to authorize as (the service account belongs to one), so we
+	 * only have to confirm it. "Continue" is rendered as a link, not a button. Databricks skips the
+	 * screen in some cases (e.g. an existing grant), so a missing prompt is not a failure -- the
+	 * caller's credential-widget assertion is the real verdict.
+	 *
+	 * @param oauthPage The OAuth tab, parked on the consent screen or already past it
+	 */
+	private async confirmDatabricksAuthorizePrompt(oauthPage: Page): Promise<void> {
+		if (!isDatabricksAuthorizePrompt(new URL(oauthPage.url()))) {
+			this.code.logger.log('No Databricks "Authorize as.." prompt; OAuth flow continued without it');
+			return;
+		}
+
+		const continueLink = oauthPage.getByRole('link', { name: 'Continue', exact: true });
+		await expect(continueLink).toBeVisible({ timeout: 15000 });
+		await continueLink.click();
+		this.code.logger.log('Confirmed Databricks "Authorize as.." prompt');
+
+		try {
+			await oauthPage.waitForURL(isWorkbenchCallback, { timeout: 15000 });
+		} catch {
+			// The tab often closes itself the moment the callback lands, which cancels the wait.
+			// Defer to the caller's credential-widget check rather than failing here.
+			this.code.logger.log('Did not observe the OAuth callback after confirming; deferring to widget check');
+		}
 	}
 
 	/**


### PR DESCRIPTION
Two independent fixes, both needed to get the Workbench e2e lane green again.

## 1. Databricks added a consent screen to its OAuth flow

Databricks now ends its OAuth flow on an "Authorize as.." screen at
`/oauth-prompt/select-group`. The managed-credentials test never got past it, so the
`workbench-databricks` shard has been failing nightly (e.g.
[positron-builds run 29989485459](https://github.com/posit-dev/positron-builds/actions/runs/29989485459))
with an assertion that points nowhere near the real problem:

```
Error: expect(locator).toBeVisible() failed
Locator: locator('[aria-label*="Databricks"][aria-label*="Enabled"]')
Timeout: 30000ms
```

The direct cause wasn't the missing click, it was the success check. We waited on:

```ts
waitForURL(/oauth_redirect_callback|localhost:8787/)
```

and the consent screen's own URL carries the callback in its query string:

```
https://<workspace>.cloud.databricks.com/oauth-prompt/select-group
  ?next_url=/oidc/v1/authorize...
  &redirect_uri=http%3A%2F%2Flocalhost%3A8787%2Foauth_redirect_callback
```

Underscores aren't percent-encoded, so `oauth_redirect_callback` appears literally and the
substring regex matched while we were still sitting on the consent screen. The trace shows the
wait resolving in 2.2s of its 15s budget, then the tab being closed -- the flow was abandoned
mid-consent while the logs reported an accepted OTP.

In `test/e2e/pages/workbench/dashboard.page.ts`:

- Match OAuth completion with a `(url: URL) => boolean` predicate on `url.host`, not a substring
  regex over the whole URL. Every step of an OAuth flow carries the callback URL in its query
  string, so substring matching is unsafe by construction.
- Treat reaching either the consent screen or the callback as OTP-accepted, so the existing retry
  loop stops correctly on both paths.
- Add `confirmDatabricksAuthorizePrompt()`: click Continue (a link, not a button; the group
  dropdown already preselects the service account's group), then wait for the callback. No-ops
  when Databricks skips the screen.

Snowflake is unaffected: it verifies via widget-state polling, and no other call site used the regex.

## 2. #15163 broke every Workbench test that starts a session

With the OAuth fix in place the databricks shard got all the way to session startup and then hit
this, as did the `default` and `snowflake` shards (14 failed / 18 flaky on `default`, which does
no OAuth at all):

```
page.evaluate: TypeError: Cannot read properties of undefined (reading 'executeCommand')
  at Sessions.getMetadata (test/e2e/pages/sessions.ts:755)
  at Sessions.start (test/e2e/pages/sessions.ts:135)
```

#15163 rewrote `getMetadata()` to read via the internal `_positron.session.getMetadata` command.
Both halves of that path are gated on `--enable-smoke-test-driver`:

- `window.driver`, the bridge `executeCommand` travels over ([window.ts:330](https://github.com/posit-dev/positron/blob/main/src/vs/workbench/browser/window.ts#L330))
- the command itself, via `registerCommandIfSmokeTestDriver` ([smokeTestCommands.ts:65](https://github.com/posit-dev/positron/blob/main/src/vs/workbench/common/positron/smokeTestCommands.ts#L65))

Our Electron and browser harnesses pass that flag themselves. The Workbench lane connects to a
server **Posit Workbench** launched, so neither exists there.

This isn't new -- `saveWebClientLogs` has failed the same way in this lane for as long as it has
existed (visible in the 07-23 nightly log as `Cannot read properties of undefined (reading
'getLogs')`), harmlessly, because nothing on the critical path used the driver. #15163 put it there.

Fix: restore the popup-scraping read as a fallback, selected by a new
`driver.isDriverAvailable()` capability probe. The command path stays the default everywhere it
works, so the flakiness #15163 removed does not come back for Electron/browser; only the Workbench
lane pays the UI cost. The fallback body is a faithful restoration of the pre-#15163 logic, kept
structurally identical (down to the `console.focus()` that `getSessionCount()` does on the way
past) since that is the version proven against this lane.

`driver.executeCommand` has exactly one caller, so `getMetadata` is the whole blast radius.

Carried in this PR rather than a separate one: Chris is out this week and this blocks the whole
Workbench lane, so it needs to land with the OAuth fix for either to be verifiable in CI. Reviewers
wanting just one of the two can review by commit -- `4724556a59` is the Databricks consent screen,
`0ae8278763` is the getMetadata fallback.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

@:workbench @:jupyter @:sessions @:web @:data-explorer

`@:workbench` runs all four Workbench shards -- `databricks` is the one the OAuth fix targets,
and all of them exercise the `getMetadata` fallback. Green on the previous run: databricks,
default, snowflake and azure all passed, where default had been 14 failed / 18 flaky.

`@:jupyter` is here to check a second lane. `app-jupyter`, `app-workbench` and `app-external`
all reach Positron through an external server, so none of them get `--enable-smoke-test-driver`
and none of them have `window.driver`. Jupyter-tagged tests such as data-explorer-r do start R
sessions through `sessions.start`, so #15163 should have broken that lane the same way -- no
nightly has run since it landed, so this is the first look. If so, the capability probe fixes
Jupyter for free.

`@:sessions @:web @:data-explorer` mirrors what #15163 validated with, to confirm the capability
probe hasn't disturbed the command path in the lanes that do have the driver. The Windows tag is
dropped for turnaround time; electron, chromium and the four Workbench shards already passed on
the previous run. (Deliberately not naming that tag literally here -- `pr-tags-parse.sh` greps the
whole description, so even mentioning it in prose re-enables the lane.)

Note that `@:workbench-databricks` on its own does **not** enable the lane -- `pr-tags-parse.sh`
matches a bare `@:workbench` and explicitly excludes the longer variants. Each shard then applies
its own hardcoded grep.
