### PR TITLE
Skip R e2e tests blocked by Ark LSP hang

### DIFF
--- a/test/e2e/tests/autocomplete/autocomplete.test.ts
+++ b/test/e2e/tests/autocomplete/autocomplete.test.ts
@@ -87,8 +87,11 @@ test.describe('Autocomplete', {
 		await console.expectSuggestionListToContain('abspath, def abspath(path)');
 	});
 
-	test('R - Verify autocomplete suggestions in Console and Editor', {
-		tag: [tags.ARK]
+	// Skipped: the Ark LSP can hang, so completion requests go unanswered and
+	// the suggestion list stays empty. Un-skip when #15211 is fixed.
+	test.skip('R - Verify autocomplete suggestions in Console and Editor', {
+		tag: [tags.ARK],
+		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/15211' }]
 	}, async function ({ app, runCommand, sessions, hotKeys }) {
 		const { editors, console } = app.workbench;
 

--- a/test/e2e/tests/code-actions/r.test.ts
+++ b/test/e2e/tests/code-actions/r.test.ts
@@ -19,8 +19,13 @@ test.describe('R Code Actions', { tag: [tags.EDITOR, tags.WIN, tags.WEB, tags.AR
 	});
 
 
-	test('R - Can execute code in untitled file with Ctrl+Enter', {
-		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/11533' }]
+	// Skipped: the Ark LSP can hang, so the statement range request never
+	// resolves and nothing is sent to the console. Un-skip when #15211 is fixed.
+	test.skip('R - Can execute code in untitled file with Ctrl+Enter', {
+		annotation: [
+			{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/11533' },
+			{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/15211' }
+		]
 	}, async ({ app, r, page }) => {
 		const { editors, quickaccess, quickInput, console } = app.workbench;
 


### PR DESCRIPTION
Skips two R e2e tests that started failing intermittently after the Ark submodule bump in #15190.

The Ark LSP can stop servicing requests entirely -- the process stays up and the R kernel stays healthy, but the LSP goes permanently silent. While it's wedged:

- the `statementRange` request behind Ctrl+Enter never resolves, so no code is sent to the console
- completion requests go unanswered, so the suggestion list stays empty

Worst on Windows, but not Windows-only. Root cause is on the Ark side (R source downloading plus a congested blocking thread pool) and @lionel- has a fix in progress, so this just cuts the CI noise in the meantime.

Both tests are annotated with #15211, which has an explicit "re-enable the skipped tests" gate on closing, so the skips get reverted with the fix. The Ctrl+Enter test keeps its original #11533 annotation alongside the new one.

Full diagnosis and logs are in [this Slack thread](https://positpbc.slack.com/archives/C09A9GNM9EJ/p1785338766646919).

### QA Notes

Verified via `--list --reporter=json` that both tests now report `expectedStatus: skipped` and that the issue annotations carry through. No product code touched.

@:ark @:editor
