### PR TITLE
Process extension files sequentially

### DIFF
--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -229,16 +229,11 @@ function fromLocalWebpack(extensionPath: string, webpackConfigFileName: string, 
 		// node_modules out of the packaged extension.
 		return listExtensionFiles({ cwd: extensionPath, packageManager: vsce.PackageManager.None });
 	}).then(fileNames => {
-		const files = fileNames
-			.map(fileName => path.join(extensionPath, fileName))
-			.map(filePath => new File({
-				path: filePath,
-				stat: fs.statSync(filePath),
-				base: extensionPath,
-				contents: fs.createReadStream(filePath)
-			}));
-
-		es.readArray(files).pipe(result);
+		// Stream the files sequentially rather than eagerly opening a read
+		// stream for every file up front, matching fromLocalEsbuild and
+		// fromLocalNormal. Avoids exhausting the open-file limit (EMFILE/EBADF)
+		// when packaging extensions with many files. See posit-dev/positron#14998.
+		createSequentialFileStream(extensionPath, fileNames).pipe(result);
 	}).catch(err => {
 		console.error(extensionPath);
 		result.emit('error', err);


### PR DESCRIPTION
## Summary

Packaging builds (e.g. `npm run gulp vscode-darwin-arm64`) fail while bundling the last built-in extension with:

```
Error: spawn EBADF
    at ChildProcess.spawn (node:internal/child_process:441:11)
    ...
    at fromLocalEsbuild (build/lib/extensions.ts)
```



## Root cause

`fromLocalEsbuild` and `fromLocalWebpack` built a full array of Vinyl `File` objects up front, one per file, each with `contents: fs.createReadStream(...)`. `fs.createReadStream` opens its file descriptor on construction, so this holds a
descriptor open for **every file at once**. For the Npm-strategy data drivers (which package large `node_modules` trees), that is thousands of descriptors per extension, accumulated across the pipeline.

Instrumenting the spawn point showed open-FD counts jumping from ~16 to 5,000+ at the Positron extensions and reaching ~12,000 at the last one, at which point `child_process.spawn` can no longer allocate the descriptors it needs for the child's stdio and fails with `EBADF`. (The same exhaustion surfaced earlier as `EMFILE` on the Windows build.)

## Fix

Use the existing `createSequentialFileStream` helper -- which opens one file at a time and was already used by `fromLocalNormal` -- in both `fromLocalEsbuild` and `fromLocalWebpack`. At most one read stream per extension is open at a time, so the descriptor count stays flat regardless of how many files an extension ships.

No behavioral change to the packaged output; only the read scheduling changes.

## Relationship to #14998

PR #14998 already applied this exact fix to `fromLocalEsbuild` on `main`. Branches based on `main` from before that landed still hit the failure. This change brings the esbuild path in line with #14998 and additionally applies the same fix to
`fromLocalWebpack` (the `positron-python` bundling path), which #14998 left as the eager `es.readArray` and is the same class of bug.

## Testing

- `npm run gulp vscode-darwin-arm64` now completes successfully (previously failed at the last extension with `spawn EBADF`).
