### PR TITLE
Add Refresh and Refresh All to Data Connections with expansion-preserving tree reload and reloaded indicator

### DIFF
--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
@@ -141,8 +141,10 @@ export const DataGridColumnHeader = (props: DataGridColumnHeaderProps) => {
 	// Determine whether the column is selected.
 	const selected = (columnSelectionState & ColumnSelectionState.Selected) !== 0;
 
-	// Render the column title
-	const renderedColumn = renderLeadingTrailingWhitespace(props.column?.name);
+	// Render the column title. An undefined column means the schema hasn't been read yet, so
+	// render nothing. The <empty> placeholder is reserved for columns whose name really is empty,
+	// which can only be determined once the schema has arrived.
+	const renderedColumn = props.column && renderLeadingTrailingWhitespace(props.column.name);
 
 	// Render.
 	return (

--- a/src/vs/workbench/browser/positronTree/classes/positronTreeInstance.css
+++ b/src/vs/workbench/browser/positronTree/classes/positronTreeInstance.css
@@ -28,6 +28,50 @@
 	color: var(--vscode-list-activeSelectionForeground);
 }
 
+/*
+ * The two rules below are identical apart from their animation name, and so are the two keyframes.
+ * The row alternates between them by reload generation (see cell()): a CSS animation restarts only
+ * when animation-name changes, so a row re-marked while its previous run is still going needs a
+ * different name to start over rather than sit out the new highlight.
+ */
+.positron-tree-row.recently-refreshed-even {
+	animation: positron-tree-recently-refreshed-even 1400ms ease-out forwards;
+}
+
+.positron-tree-row.recently-refreshed-odd {
+	animation: positron-tree-recently-refreshed-odd 1400ms ease-out forwards;
+}
+
+@keyframes positron-tree-recently-refreshed-even {
+	0%,
+	20% {
+		box-shadow: inset 1px 0 0 var(--vscode-list-focusOutline);
+	}
+
+	100% {
+		box-shadow: inset 1px 0 0 transparent;
+	}
+}
+
+@keyframes positron-tree-recently-refreshed-odd {
+	0%,
+	20% {
+		box-shadow: inset 1px 0 0 var(--vscode-list-focusOutline);
+	}
+
+	100% {
+		box-shadow: inset 1px 0 0 transparent;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.positron-tree-row.recently-refreshed-even,
+	.positron-tree-row.recently-refreshed-odd {
+		box-shadow: inset 1px 0 0 var(--vscode-list-focusOutline);
+		animation: none;
+	}
+}
+
 .positron-tree-indent {
 	flex: 0 0 auto;
 	height: 100%;
@@ -53,9 +97,14 @@
 	outline: none !important;
 }
 
-/* The leaf twisty (an empty placeholder for alignment) is not clickable. */
+/*
+ * The leaf twisty (an empty placeholder for alignment) is not clickable, nor is one on a loading
+ * or stale row. The :disabled rule covers the stale case, where the row keeps its collapsed or
+ * expanded class but the twisty is inert while an ancestor refreshes.
+ */
 .positron-tree-twisty-leaf,
-.positron-tree-twisty-loading {
+.positron-tree-twisty-loading,
+.positron-tree-twisty:disabled {
 	cursor: default;
 }
 

--- a/src/vs/workbench/browser/positronTree/classes/positronTreeInstance.tsx
+++ b/src/vs/workbench/browser/positronTree/classes/positronTreeInstance.tsx
@@ -11,6 +11,8 @@ import { JSX, ReactNode, MouseEvent as ReactMouseEvent } from 'react';
 
 // Other dependencies.
 import { Emitter, Event } from '../../../../base/common/event.js';
+import { disposableTimeout, Limiter } from '../../../../base/common/async.js';
+import { IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { positronClassNames } from '../../../../base/common/positronUtilities.js';
 import { DataGridInstance, MouseSelectionType, RowSelectionState, SelectionCursorOptions, selectionCursorOptions } from '../../positronDataGrid/classes/dataGridInstance.js';
 import { TreeNode, TreeNodeContext, VisibleNode } from './treeNode.js';
@@ -35,6 +37,15 @@ export type PositronTreeGetRoots<T> = () => Promise<readonly TreeNode<T>[]>;
 export type PositronTreeGetChildren<T> = (node: TreeNode<T>) => Promise<readonly TreeNode<T>[]>;
 
 /**
+ * PositronTreeGetReloadKey type. Returns the identity a node keeps across a reload, used to match
+ * a pre-reload node to its post-reload counterpart among its siblings so reload() can restore
+ * expansion. Defaults to the node id, which is correct whenever ids are derived from the data
+ * itself. Supply this when ids carry per-fetch state (a handle, a sequence number) and so change
+ * on every fetch even though the node they describe hasn't.
+ */
+export type PositronTreeGetReloadKey<T> = (node: TreeNode<T>) => string;
+
+/**
  * PositronTreeBaseOptions type. The tree options other than the cursor/commit options, which come
  * from SelectionCursorOptions (see PositronTreeInstanceOptions).
  */
@@ -47,6 +58,9 @@ interface PositronTreeBaseOptions<T> {
 
 	// Renderer for the row content area.
 	readonly renderNode: PositronTreeRenderNode<T>;
+
+	// Cross-reload identity for a node. Defaults to the node id. See PositronTreeGetReloadKey.
+	readonly getReloadKey?: PositronTreeGetReloadKey<T>;
 
 	// Row height in pixels.
 	readonly rowHeight: number;
@@ -70,6 +84,45 @@ export type PositronTreeInstanceOptions<T> = PositronTreeBaseOptions<T> & Select
 const DEFAULT_INDENT_WIDTH = 12;
 
 /**
+ * How long, in milliseconds, the rows a reload brought in stay marked as recently refreshed. Set
+ * just past the CSS animation that renders the mark (see positronTreeInstance.css) so the rows
+ * finish easing out before the class comes off, with no visible pop at the end.
+ */
+const REFRESHED_HIGHLIGHT_DURATION = 1500;
+
+/**
+ * How many getChildren calls a reload runs at once while restoring expansion. Enough to keep a
+ * wide restore prompt, low enough that refreshing a connection with dozens of expanded nodes
+ * doesn't fan out into dozens of simultaneous queries against the source.
+ */
+const RESTORE_FETCH_CONCURRENCY = 8;
+
+/**
+ * ExpansionSnapshot type. The shape of an expanded subtree, captured before a reload drops it.
+ * Each level maps a child's reload key to that child's own snapshot; only expanded children are
+ * present, so the snapshot mirrors exactly what the user had open.
+ */
+interface ExpansionSnapshot {
+	readonly children: Map<string, ExpansionSnapshot>;
+}
+
+/**
+ * SubtreeFetch type. A reloaded subtree, fetched in full before any of it is applied to the tree.
+ * Holding the whole result until it's ready is what lets a reload swap the subtree in one
+ * projection rebuild, instead of emptying the rows and refilling them level by level.
+ */
+interface SubtreeFetch<T> {
+	// The reloaded node's new children.
+	readonly children: readonly TreeNode<T>[];
+
+	// Loaded children for each restored descendant, keyed by its (new) node id.
+	readonly descendants: Map<string, readonly TreeNode<T>[]>;
+
+	// The restored descendants to mark expanded.
+	readonly expanded: Set<string>;
+}
+
+/**
  * PositronTreeInstance class. A virtualized, async tree control built as a single-column
  * subclass of DataGridInstance. The instance owns the tree state (roots, expansion, loading,
  * errors, loaded children) and projects it to a flat list of visible rows that the data grid
@@ -87,6 +140,9 @@ export class PositronTreeInstance<T> extends DataGridInstance {
 	private _getChildren: PositronTreeGetChildren<T>;
 	private _renderNode: PositronTreeRenderNode<T>;
 
+	// Cross-reload identity for a node.
+	private readonly _getReloadKey: PositronTreeGetReloadKey<T>;
+
 	// Per-level indent width in pixels and whether to apply default focus/selection styling.
 	private readonly _indentWidth: number;
 	private readonly _useDefaultStyling: boolean;
@@ -98,9 +154,28 @@ export class PositronTreeInstance<T> extends DataGridInstance {
 	private readonly _loading = new Set<string>();
 	private readonly _errors = new Map<string, unknown>();
 
+	// Nodes with a reload in flight. Kept apart from _loading because a reload leaves the
+	// existing rows on screen -- only the twisty changes -- until the new subtree is committed.
+	private readonly _refreshing = new Set<string>();
+
+	// Nodes a reload just swapped in, each stamped with the generation of the reload that marked
+	// it, held for REFRESHED_HIGHLIGHT_DURATION so the rows can show that the refresh landed. The
+	// stamp is what lets overlapping reloads coexist -- see _markRecentlyRefreshed.
+	private readonly _recentlyRefreshed = new Map<string, number>();
+
+	// Incremented for each batch of marks, so every batch is distinguishable from the last.
+	private _refreshGeneration = 0;
+
 	// Pending fetch promises keyed by node id. Re-entrant expand() / invalidate() calls return
 	// the in-flight promise rather than starting a second fetch.
 	private readonly _pendingChildrenFetches = new Map<string, Promise<void>>();
+
+	// Pending reloads keyed by node id. A second reload() for a node already reloading joins the
+	// in-flight one rather than starting a competing fetch of the same subtree.
+	private readonly _pendingReloads = new Map<string, Promise<void>>();
+
+	// Pending whole-tree reload. Same idea for reloadAll, which spans every root.
+	private _pendingReloadAll: Promise<void> | undefined;
 
 	// Pending roots fetch. Same idea for getRoots / refresh.
 	private _pendingRootsFetch: Promise<void> | undefined;
@@ -111,6 +186,9 @@ export class PositronTreeInstance<T> extends DataGridInstance {
 	// Whether the initial roots load has completed at least once. Lets consumers distinguish
 	// "loading initial data" from "no roots."
 	private _initialLoadCompleted = false;
+
+	// Outstanding focus holds. See holdFocusAppearance.
+	private _focusHolds = 0;
 
 	// Fires when the tree's loading state changes (initial load, roots fetch, or per-node fetch).
 	private readonly _onDidChangeLoadingEmitter = this._register(new Emitter<void>());
@@ -152,6 +230,7 @@ export class PositronTreeInstance<T> extends DataGridInstance {
 		this._getRoots = options.getRoots;
 		this._getChildren = options.getChildren;
 		this._renderNode = options.renderNode;
+		this._getReloadKey = options.getReloadKey ?? (node => node.id);
 		this._indentWidth = options.indentWidth ?? DEFAULT_INDENT_WIDTH;
 		this._useDefaultStyling = options.useDefaultStyling ?? true;
 
@@ -177,6 +256,14 @@ export class PositronTreeInstance<T> extends DataGridInstance {
 
 	get visibleNodes(): readonly VisibleNode<T>[] {
 		return this._visibleNodes;
+	}
+
+	/**
+	 * Whether the tree should render as focused. True while a focus hold is outstanding, even
+	 * though DOM focus has moved elsewhere -- see holdFocusAppearance.
+	 */
+	override get focused(): boolean {
+		return this._focusHolds > 0 || super.focused;
 	}
 
 	//#endregion Public Properties
@@ -238,6 +325,140 @@ export class PositronTreeInstance<T> extends DataGridInstance {
 	}
 
 	/**
+	 * Reloads a node's subtree from the source, replacing the loaded children of the node and all
+	 * of its loaded descendants -- releasing any per-fetch resources they hold.
+	 *
+	 * The subtree is fetched in full off to the side and swapped in as a single update, so the
+	 * rows on screen stay put and change over in one frame. The node reports `refreshing` while
+	 * the fetch runs (see VisibleNode) and its existing children remain visible throughout;
+	 * nothing is torn down before the replacement is in hand.
+	 *
+	 * The expansion the user had open is preserved: every expanded descendant is captured up
+	 * front and re-fetched as part of the reload, for each one whose counterpart is still there.
+	 * Descendants that no longer exist are simply not restored, and ones that appeared while the
+	 * tree was open stay collapsed. Nodes are matched to their counterparts by reload key (see
+	 * PositronTreeGetReloadKey), not by id, so the restore survives sources that mint a fresh id
+	 * for a node on every fetch.
+	 *
+	 * A collapsed node has nothing on screen to preserve, so it just drops its stale children and
+	 * re-fetches them on its next expand. If the reload's top-level fetch fails, the stale
+	 * subtree is dropped and the error is recorded against the node, matching a failed expand --
+	 * the twisty surfaces the message and toggling the node retries.
+	 *
+	 * Differs from invalidate, which re-fetches a single level and leaves already-loaded
+	 * descendants in place. Reach for reload when the descendants can't be trusted after the
+	 * re-fetch -- either because their data is derived from the parent's, or because the
+	 * re-fetch invalidates the resources they were loaded with.
+	 */
+	async reload(id: string): Promise<void> {
+		const node = this._findNode(id);
+		if (node === undefined || !node.hasChildren) {
+			return;
+		}
+
+		// Nothing is on screen beneath a collapsed node, so there's no swap to stage: drop the
+		// stale children and let the next expand fetch them.
+		if (!this._expanded.has(id)) {
+			this.dropLoadedChildren(id);
+			return;
+		}
+
+		// Re-entrant: join the in-flight reload if one is already running for this id.
+		const existing = this._pendingReloads.get(id);
+		if (existing !== undefined) {
+			return existing;
+		}
+
+		const expansion = this._captureExpansion(id);
+
+		this._refreshing.add(id);
+		this._rebuildProjection();
+		this._onDidChangeLoadingEmitter.fire();
+
+		const reloadPromise = (async () => {
+			try {
+				const fetched = await this._fetchSubtree(node, expansion);
+
+				// The tree can move on while the fetch is in flight: the node may have been
+				// collapsed -- which for some consumers also releases the very resources the
+				// fetch used -- or dropped from the tree outright. Installing the result then
+				// would resurrect a subtree the tree has abandoned, and because expand() doesn't
+				// re-fetch a node whose children are already loaded, those rows would never be
+				// replaced. Discarding leaves the node unloaded, so its next expand fetches
+				// afresh.
+				if (this._expanded.has(id) && this._findNode(id) !== undefined) {
+					this._applySubtree(id, fetched);
+				}
+			} catch (err) {
+				// The node's own fetch failed, so there's no replacement subtree to swap in.
+				// Drop the stale one and record the error: leaving the children in place would
+				// strand the node in a permanent error state, since re-expanding a node whose
+				// children are already loaded doesn't re-fetch (and so never clears the error).
+				this._dropLoadedChildren(id);
+				this._errors.set(id, err);
+				console.error(`[PositronTree] reload failed for node ${id}:`, err);
+			} finally {
+				this._refreshing.delete(id);
+				this._pendingReloads.delete(id);
+				this._rebuildProjection();
+				this._onDidChangeLoadingEmitter.fire();
+			}
+		})();
+
+		this._pendingReloads.set(id, reloadPromise);
+		return reloadPromise;
+	}
+
+	/**
+	 * Reloads everything on screen: re-runs getRoots, then reloads the subtree under every expanded
+	 * root, so the whole visible tree comes back from the source. Expansion is preserved and each
+	 * subtree swaps in as a unit, exactly as a per-node reload does.
+	 *
+	 * Differs from refresh, which re-runs getRoots and leaves the loaded subtrees alone.
+	 *
+	 * Re-entrant, like refresh and reload: calling it again while one is running joins that pass
+	 * rather than starting a second sweep of the tree. That lets a consumer leave its refresh
+	 * control enabled and simply let the extra activations fold into the run already going --
+	 * preferable to disabling the control, since clicking a disabled control moves focus to its
+	 * container and leaves a focus ring behind.
+	 */
+	async reloadAll(): Promise<void> {
+		if (this._pendingReloadAll !== undefined) {
+			return this._pendingReloadAll;
+		}
+
+		const reloadAllPromise = (async () => {
+			try {
+				await this.refresh();
+
+				// Roots are independent sources, so they reload concurrently; each reload bounds the
+				// fan-out of its own descendant fetches. Collapsed roots have nothing on screen and
+				// just drop their stale children, so the next expand fetches afresh.
+				await Promise.all(this._roots.map(root => this.reload(root.id)));
+			} finally {
+				this._pendingReloadAll = undefined;
+			}
+		})();
+
+		this._pendingReloadAll = reloadAllPromise;
+		return reloadAllPromise;
+	}
+
+	/**
+	 * Whether a reload of the given node's subtree is in flight.
+	 */
+	isRefreshing(id: string): boolean {
+		return this._refreshing.has(id);
+	}
+
+	/**
+	 * Whether the given node's children are currently loaded.
+	 */
+	hasLoadedChildren(id: string): boolean {
+		return this._children.has(id);
+	}
+
+	/**
 	 * Push escape hatch: replace the roots without going through getRoots. Used when the
 	 * consumer has the data in hand (e.g. a sync event source).
 	 */
@@ -270,24 +491,7 @@ export class PositronTreeInstance<T> extends DataGridInstance {
 	 * handle) that have become stale and need to be re-fetched against a fresh resource.
 	 */
 	dropLoadedChildren(id: string): void {
-		// Walk the loaded subtree under `id` so descendants get cleaned too. The id itself is
-		// not removed from any structural map -- it's the children we drop.
-		const stack: string[] = [id];
-		while (stack.length > 0) {
-			const current = stack.pop()!;
-			const loaded = this._children.get(current);
-			if (loaded === undefined) {
-				continue;
-			}
-			for (const child of loaded) {
-				stack.push(child.id);
-				this._expanded.delete(child.id);
-				this._errors.delete(child.id);
-				this._loading.delete(child.id);
-			}
-			this._children.delete(current);
-		}
-		this._errors.delete(id);
+		this._dropLoadedChildren(id);
 		this._rebuildProjection();
 	}
 
@@ -379,6 +583,34 @@ export class PositronTreeInstance<T> extends DataGridInstance {
 
 	//#endregion Public Methods - Renderer Update
 
+	//#region Public Methods - Focus
+
+	/**
+	 * Holds the tree in its focused appearance while something transient takes DOM focus away from
+	 * it -- a row's context menu, typically. Without the hold the tree blurs the moment the menu
+	 * opens, and the row the menu belongs to drops to the dimmer inactive-selection styling just
+	 * as the user is looking at it.
+	 *
+	 * Dispose the returned handle when the overlay closes. Holds are counted, so overlapping
+	 * overlays each keep their own; disposing a handle twice is a no-op.
+	 */
+	holdFocusAppearance(): IDisposable {
+		this._focusHolds++;
+		this.fireOnDidUpdateEvent();
+
+		let released = false;
+		return toDisposable(() => {
+			if (released) {
+				return;
+			}
+			released = true;
+			this._focusHolds--;
+			this.fireOnDidUpdateEvent();
+		});
+	}
+
+	//#endregion Public Methods - Focus
+
 	//#region Private Methods
 
 	private _findNode(id: string): TreeNode<T> | undefined {
@@ -398,6 +630,182 @@ export class PositronTreeInstance<T> extends DataGridInstance {
 			}
 		}
 		return undefined;
+	}
+
+	/**
+	 * Captures the expanded shape of the loaded subtree under the given node, keyed by reload key.
+	 * Only expanded children are recorded, and the walk descends only through them -- a collapsed
+	 * node's own children were never on screen, so there's nothing to restore beneath it.
+	 */
+	private _captureExpansion(id: string): ExpansionSnapshot {
+		const children = new Map<string, ExpansionSnapshot>();
+		for (const child of this._children.get(id) ?? []) {
+			if (this._expanded.has(child.id)) {
+				children.set(this._getReloadKey(child), this._captureExpansion(child.id));
+			}
+		}
+		return { children };
+	}
+
+	/**
+	 * Fetches a node's children and, beneath them, the children of every descendant the snapshot
+	 * says was expanded. Nothing is written to the tree's own state -- the result is assembled
+	 * separately so the caller can apply it all at once.
+	 */
+	private async _fetchSubtree(node: TreeNode<T>, snapshot: ExpansionSnapshot): Promise<SubtreeFetch<T>> {
+		const children = await this._getChildren(node);
+		const fetched: SubtreeFetch<T> = { children, descendants: new Map(), expanded: new Set() };
+
+		// Restoring a wide subtree can mean dozens of getChildren calls. Expansion has always been
+		// serial -- the user opens one node at a time -- so an unbounded restore would put a burst
+		// of concurrent work on a source that has never seen it from this tree. The limiter is
+		// per-reload, and it wraps only the getChildren call, never the recursion beneath it: a
+		// queued task that waited on another queued task could deadlock once the cap is reached.
+		const limiter = new Limiter<readonly TreeNode<T>[]>(RESTORE_FETCH_CONCURRENCY);
+		try {
+			await this._fetchRestoredDescendants(children, snapshot, fetched, limiter);
+		} finally {
+			limiter.dispose();
+		}
+
+		return fetched;
+	}
+
+	/**
+	 * Matches freshly fetched children against a captured snapshot and fetches the children of
+	 * each match, recursing to the depth the snapshot records. A branch whose fetch fails is left
+	 * out of the result -- it comes back collapsed and unloaded, so expanding it retries and
+	 * surfaces the error there -- rather than failing the whole reload.
+	 */
+	private async _fetchRestoredDescendants(
+		children: readonly TreeNode<T>[],
+		snapshot: ExpansionSnapshot,
+		fetched: SubtreeFetch<T>,
+		limiter: Limiter<readonly TreeNode<T>[]>
+	): Promise<void> {
+		if (snapshot.children.size === 0) {
+			return;
+		}
+
+		// Each key is consumed on first match, so siblings sharing a reload key are restored
+		// one-to-one instead of all matching the same snapshot entry.
+		const unmatched = new Map(snapshot.children);
+		const fetches: Promise<void>[] = [];
+		for (const child of children) {
+			if (unmatched.size === 0) {
+				break;
+			}
+
+			const key = this._getReloadKey(child);
+			const childSnapshot = unmatched.get(key);
+			if (childSnapshot === undefined || !child.hasChildren) {
+				continue;
+			}
+
+			unmatched.delete(key);
+			fetches.push((async () => {
+				let grandchildren: readonly TreeNode<T>[];
+				try {
+					grandchildren = await limiter.queue(() => this._getChildren(child));
+				} catch (err) {
+					console.error(`[PositronTree] reload could not restore node ${child.id}:`, err);
+					return;
+				}
+				fetched.descendants.set(child.id, grandchildren);
+				fetched.expanded.add(child.id);
+				await this._fetchRestoredDescendants(grandchildren, childSnapshot, fetched, limiter);
+			})());
+		}
+
+		// Siblings fetch concurrently (up to the limiter's cap) -- they're independent, and none of
+		// them is on screen yet.
+		await Promise.all(fetches);
+	}
+
+	/**
+	 * Swaps a fetched subtree in for the node's current one. Every mutation happens before the
+	 * single projection rebuild, so the rows change over in one frame instead of emptying out and
+	 * refilling.
+	 */
+	private _applySubtree(id: string, fetched: SubtreeFetch<T>): void {
+		this._dropLoadedChildren(id);
+		this._children.set(id, fetched.children);
+		for (const [descendantId, children] of fetched.descendants) {
+			this._children.set(descendantId, children);
+		}
+		for (const descendantId of fetched.expanded) {
+			this._expanded.add(descendantId);
+		}
+
+		// The reloaded node together with everything the reload brought in beneath it -- the new
+		// children and, under them, the children of each restored descendant.
+		//
+		// The node itself is included even though it wasn't replaced: the mark says "this was
+		// refreshed", and a whole-tree reload that marked only descendants would leave the roots
+		// looking untouched by the very action the user invoked on them.
+		const installed = [...fetched.children, ...Array.from(fetched.descendants.values()).flat()];
+		this._markRecentlyRefreshed([id, ...installed.map(node => node.id)]);
+	}
+
+	/**
+	 * Marks a batch of nodes as recently refreshed and schedules the batch to clear on its own
+	 * timer.
+	 *
+	 * Each id is stamped with this batch's generation, and the timer clears only the ids still
+	 * carrying it. A node re-marked by a later reload therefore belongs to that reload, and the
+	 * earlier timer leaves it alone -- without the stamp, an id present in both batches (any node
+	 * whose id is stable across fetches, such as a root) would lose its highlight on the earlier
+	 * timer, part way through the run it was owed.
+	 *
+	 * The generation is also what lets the row restart the highlight animation: see the
+	 * alternating class names in cell().
+	 */
+	private _markRecentlyRefreshed(ids: readonly string[]): void {
+		if (ids.length === 0) {
+			return;
+		}
+
+		const generation = ++this._refreshGeneration;
+		for (const id of ids) {
+			this._recentlyRefreshed.set(id, generation);
+		}
+
+		// disposableTimeout removes itself from the store once it fires, so the store doesn't
+		// accumulate spent timers over a long session -- and a disposed tree cancels the pending
+		// ones instead of rebuilding a projection after teardown.
+		disposableTimeout(() => {
+			for (const id of ids) {
+				if (this._recentlyRefreshed.get(id) === generation) {
+					this._recentlyRefreshed.delete(id);
+				}
+			}
+			this._rebuildProjection();
+		}, REFRESHED_HIGHLIGHT_DURATION, this._store);
+	}
+
+	/**
+	 * The body of dropLoadedChildren, without the projection rebuild, so a reload can drop the
+	 * old subtree and install the new one within a single rebuild.
+	 */
+	private _dropLoadedChildren(id: string): void {
+		// Walk the loaded subtree under `id` so descendants get cleaned too. The id itself is
+		// not removed from any structural map -- it's the children we drop.
+		const stack: string[] = [id];
+		while (stack.length > 0) {
+			const current = stack.pop()!;
+			const loaded = this._children.get(current);
+			if (loaded === undefined) {
+				continue;
+			}
+			for (const child of loaded) {
+				stack.push(child.id);
+				this._expanded.delete(child.id);
+				this._errors.delete(child.id);
+				this._loading.delete(child.id);
+			}
+			this._children.delete(current);
+		}
+		this._errors.delete(id);
 	}
 
 	private async _fetchChildren(node: TreeNode<T>): Promise<void> {
@@ -440,6 +848,8 @@ export class PositronTreeInstance<T> extends DataGridInstance {
 			loading: this._loading,
 			errors: this._errors,
 			children: this._children,
+			refreshing: this._refreshing,
+			recentlyRefreshed: this._recentlyRefreshed,
 		});
 
 		// All rows are the same height; the row layout manager just needs the count.
@@ -571,15 +981,34 @@ export class PositronTreeInstance<T> extends DataGridInstance {
 			void this.toggle(visible.node.id);
 		};
 
-		const twistyClickable = visible.expandState !== 'leaf' && visible.expandState !== 'loading';
+		// Nothing to toggle on a leaf, nothing to interrupt on a row already fetching, and a stale
+		// row's twisty is inert because expanding it would fetch against a resource the ancestor's
+		// refresh may already have released -- the subtree is about to be replaced wholesale anyway,
+		// and the ancestor's spinner is what tells the user why.
+		const twistyDisabled = visible.expandState === 'leaf'
+			|| visible.expandState === 'loading'
+			|| visible.stale;
 		const errorMessage = visible.expandState === 'error' ? formatError(this._errors.get(visible.node.id)) : undefined;
+
+		// A refreshing node spins in place: its expandState (and so its rows) are untouched while
+		// the replacement subtree is fetched, and only the glyph reflects the work in flight.
+		const twistyGlyphState = visible.refreshing ? 'loading' : visible.expandState;
+
+		// The highlight alternates between two identical animations by generation parity. A CSS
+		// animation restarts only when its animation-name changes, so a row that is still mid-run
+		// when a second reload re-marks it would otherwise finish the old run and then sit at zero
+		// opacity for the rest of the new one -- the second refresh would look like it did nothing.
+		const refreshedClass = visible.recentlyRefreshed
+			? (visible.refreshGeneration % 2 === 0 ? 'recently-refreshed-even' : 'recently-refreshed-odd')
+			: undefined;
 
 		return (
 			<div
 				className={positronClassNames(
 					'positron-tree-row',
 					{ 'focused': this._useDefaultStyling && cursor && treeFocused },
-					{ 'selected': this._useDefaultStyling && selected }
+					{ 'selected': this._useDefaultStyling && selected },
+					refreshedClass
 				)}
 			>
 				<div
@@ -587,18 +1016,18 @@ export class PositronTreeInstance<T> extends DataGridInstance {
 					style={{ width: visible.depth * this._indentWidth }}
 				/>
 				<button
-					aria-label={twistyClickable ? (visible.expandState === 'expanded' ? 'Collapse' : 'Expand') : undefined}
+					aria-label={twistyDisabled ? undefined : (visible.expandState === 'expanded' ? 'Collapse' : 'Expand')}
 					className={positronClassNames(
 						'positron-tree-twisty',
 						`positron-tree-twisty-${visible.expandState}`
 					)}
-					disabled={!twistyClickable}
+					disabled={twistyDisabled}
 					tabIndex={-1}
 					title={errorMessage}
 					type='button'
-					onClick={twistyClickable ? onTwistyClick : undefined}
+					onClick={onTwistyClick}
 				>
-					{renderTwistyGlyph(visible.expandState)}
+					{renderTwistyGlyph(twistyGlyphState)}
 				</button>
 				<div className='positron-tree-content'>
 					{this._renderNode(visible, { index: rowIndex, cursor, treeFocused, selected })}

--- a/src/vs/workbench/browser/positronTree/classes/treeNode.ts
+++ b/src/vs/workbench/browser/positronTree/classes/treeNode.ts
@@ -44,6 +44,30 @@ export interface VisibleNode<T> {
 	readonly node: TreeNode<T>;
 	readonly depth: number;
 	readonly expandState: TreeExpandState;
+
+	// Whether a reload of this node's subtree is in flight. Deliberately separate from
+	// expandState: a reload swaps the subtree in place, so the current (stale) children stay on
+	// screen throughout and only the twisty reflects that work is happening.
+	readonly refreshing: boolean;
+
+	// Whether this row was part of a reload that just landed -- either the reloaded node itself or
+	// one of the rows brought in beneath it. True only for a moment after the swap, so the
+	// refreshed block can call attention to itself; a reload that returns identical data is
+	// otherwise indistinguishable from nothing having happened.
+	readonly recentlyRefreshed: boolean;
+
+	// Whether an ancestor of this row has a reload in flight. The row is still on screen -- a
+	// reload doesn't tear its subtree down before the replacement arrives -- but it is about to be
+	// replaced, and any per-fetch resource it carries may already have been released by the
+	// ancestor's own fetch. Consumers should suppress actions on a stale row rather than let the
+	// user operate on something that is on its way out.
+	readonly stale: boolean;
+
+	// Which reload marked this row, or 0 when it isn't marked. Rows use the parity to alternate
+	// between two otherwise identical highlight animations, because a CSS animation only restarts
+	// when its animation-name changes -- without that, a row re-marked while its previous run was
+	// still going would sit out the new one.
+	readonly refreshGeneration: number;
 }
 
 /**

--- a/src/vs/workbench/browser/positronTree/classes/treeProjection.ts
+++ b/src/vs/workbench/browser/positronTree/classes/treeProjection.ts
@@ -16,6 +16,10 @@ export interface TreeProjectionInput<T> {
 	readonly loading: ReadonlySet<string>;
 	readonly errors: ReadonlyMap<string, unknown>;
 	readonly children: ReadonlyMap<string, readonly TreeNode<T>[]>;
+	readonly refreshing: ReadonlySet<string>;
+
+	// Recently refreshed node ids, each mapped to the generation of the reload that marked it.
+	readonly recentlyRefreshed: ReadonlyMap<string, number>;
 }
 
 /**
@@ -37,25 +41,42 @@ export interface TreeProjectionInput<T> {
  * expanded set whose children have never loaded (e.g. the very first frame after expand() was
  * called) renders with expandState 'loading' and no visible children -- a fetch is in flight
  * or queued, and the next projection rebuild after children arrive will reveal them.
+ *
+ * A node being reloaded is the exception: it keeps its current expandState (and so its currently
+ * loaded children stay on screen) and carries `refreshing` instead, because a reload replaces the
+ * subtree in a single commit rather than emptying it first. Everything beneath it is marked
+ * `stale` for the duration, since those rows are about to be replaced.
  */
 export function buildVisibleNodes<T>(input: TreeProjectionInput<T>): readonly VisibleNode<T>[] {
 	const result: VisibleNode<T>[] = [];
 
-	const walk = (siblings: readonly TreeNode<T>[], depth: number): void => {
+	const walk = (siblings: readonly TreeNode<T>[], depth: number, stale: boolean): void => {
 		for (const node of siblings) {
 			const expandState = computeExpandState(node, input);
-			result.push({ node, depth, expandState });
+			const refreshGeneration = input.recentlyRefreshed.get(node.id);
+			result.push({
+				node,
+				depth,
+				expandState,
+				refreshing: input.refreshing.has(node.id),
+				recentlyRefreshed: refreshGeneration !== undefined,
+				refreshGeneration: refreshGeneration ?? 0,
+				stale,
+			});
 
 			if (expandState === 'expanded') {
 				const loaded = input.children.get(node.id);
 				if (loaded !== undefined) {
-					walk(loaded, depth + 1);
+					// Staleness inherits: everything under a refreshing node is on its way out, so
+					// the flag passes down from wherever it was first set. The refreshing node
+					// itself is not stale -- it is the one being replaced into, not replaced.
+					walk(loaded, depth + 1, stale || input.refreshing.has(node.id));
 				}
 			}
 		}
 	};
 
-	walk(input.roots, 0);
+	walk(input.roots, 0, false);
 	return result;
 }
 

--- a/src/vs/workbench/browser/positronTree/test/browser/positronTree.vitest.tsx
+++ b/src/vs/workbench/browser/positronTree/test/browser/positronTree.vitest.tsx
@@ -180,6 +180,521 @@ describe('PositronTreeInstance', () => {
 		expect(tree.rows).toBe(3);
 	});
 
+	it('reload re-fetches an expanded node and restores the expansion beneath it', async () => {
+		// Every branch yields one branch child, so the tree can be opened to any depth.
+		const getChildren = vi.fn(async (node: TreeNode<DemoNode>) => [branch(`${node.id}.0`)]);
+		const instance = new PositronTreeInstance<DemoNode>({
+			rowHeight: ROW_HEIGHT,
+			getRoots: async () => [branch('r0')],
+			getChildren,
+			renderNode: visible => <span>{visible.node.data.label}</span>,
+		});
+		store.add(instance);
+		await instance.refresh();
+
+		// Open three levels: r0 -> r0.0 -> r0.0.0 (which loads r0.0.0.0).
+		await instance.expand('r0');
+		await instance.expand('r0.0');
+		await instance.expand('r0.0.0');
+		const callsBeforeReload = getChildren.mock.calls.length;
+		const rowsBeforeReload = instance.rows;
+
+		await instance.reload('r0');
+
+		expect({
+			callsBeforeReload,
+			// Each of the three re-expanded levels was re-fetched.
+			callsAfterReload: getChildren.mock.calls.length,
+			// The same rows are on screen as before the reload.
+			rowsBeforeReload,
+			rows: instance.rows,
+			expanded: ['r0', 'r0.0', 'r0.0.0'].filter(id => instance.isExpanded(id)),
+		}).toMatchInlineSnapshot(`
+			{
+			  "callsAfterReload": 6,
+			  "callsBeforeReload": 3,
+			  "expanded": [
+			    "r0",
+			    "r0.0",
+			    "r0.0.0",
+			  ],
+			  "rows": 4,
+			  "rowsBeforeReload": 4,
+			}
+		`);
+	});
+
+	it('reload leaves expansion behind for descendants that no longer exist', async () => {
+		// 'gone' disappears on the second fetch of r0; 'stays' survives it.
+		let firstFetch = true;
+		const instance = new PositronTreeInstance<DemoNode>({
+			rowHeight: ROW_HEIGHT,
+			getRoots: async () => [branch('r0')],
+			getChildren: async node => {
+				if (node.id !== 'r0') {
+					return [leaf(`${node.id}.child`)];
+				}
+				const children = firstFetch ? [branch('gone'), branch('stays')] : [branch('stays')];
+				firstFetch = false;
+				return children;
+			},
+			renderNode: visible => <span>{visible.node.data.label}</span>,
+		});
+		store.add(instance);
+		await instance.refresh();
+
+		await instance.expand('r0');
+		await instance.expand('gone');
+		await instance.expand('stays');
+
+		await instance.reload('r0');
+
+		expect({
+			goneRestored: instance.isExpanded('gone'),
+			staysRestored: instance.isExpanded('stays'),
+			rows: instance.rows, // r0 + stays + stays.child
+		}).toMatchInlineSnapshot(`
+			{
+			  "goneRestored": false,
+			  "rows": 3,
+			  "staysRestored": true,
+			}
+		`);
+	});
+
+	it('reload matches nodes by reload key when ids change on every fetch', async () => {
+		// Mimics a source that mints a fresh id per fetch (e.g. a handle from a counter): the id
+		// carries a fetch sequence number, while the label identifies the node itself.
+		let fetchSequence = 0;
+		const instance = new PositronTreeInstance<DemoNode>({
+			rowHeight: ROW_HEIGHT,
+			getRoots: async () => [branch('r0')],
+			getChildren: async node => {
+				const id = `child@${fetchSequence++}`;
+				return [{ id, data: { label: `${node.data.label}.child` }, hasChildren: true }];
+			},
+			getReloadKey: node => node.data.label,
+			renderNode: visible => <span>{visible.node.data.label}</span>,
+		});
+		store.add(instance);
+		await instance.refresh();
+
+		await instance.expand('r0');
+		const childId = instance.visibleNodes[1].node.id;
+		await instance.expand(childId);
+		const rowsBeforeReload = instance.rows;
+
+		await instance.reload('r0');
+
+		// The re-fetched child has a different id, so only a key-based match can restore it.
+		const reloadedChildId = instance.visibleNodes[1].node.id;
+		expect({
+			childId,
+			reloadedChildId,
+			rowsBeforeReload,
+			rows: instance.rows,
+			reloadedChildExpanded: instance.isExpanded(reloadedChildId),
+		}).toMatchInlineSnapshot(`
+			{
+			  "childId": "child@0",
+			  "reloadedChildExpanded": true,
+			  "reloadedChildId": "child@2",
+			  "rows": 3,
+			  "rowsBeforeReload": 3,
+			}
+		`);
+	});
+
+	it('reload keeps the stale subtree on screen until the new one is ready', async () => {
+		// The reload's fetch is held open so the in-flight state can be observed. Without the
+		// staged swap, the rows would empty out here and refill when the fetch lands.
+		const pending = deferred<readonly TreeNode<DemoNode>[]>();
+		let reloading = false;
+		const instance = new PositronTreeInstance<DemoNode>({
+			rowHeight: ROW_HEIGHT,
+			getRoots: async () => [branch('r0')],
+			getChildren: async node => reloading ? pending.promise : [leaf(`${node.id}.0`), leaf(`${node.id}.1`)],
+			renderNode: visible => <span>{visible.node.data.label}</span>,
+		});
+		store.add(instance);
+		await instance.refresh();
+		await instance.expand('r0');
+
+		reloading = true;
+		const reload = instance.reload('r0');
+		const inFlight = {
+			rows: instance.rows,
+			refreshing: instance.isRefreshing('r0'),
+			// The row keeps its expanded state -- only the twisty glyph changes.
+			expandState: instance.visibleNodes[0].expandState,
+		};
+
+		pending.resolve([leaf('r0.0'), leaf('r0.1')]);
+		await reload;
+
+		expect({
+			inFlight,
+			rowsAfter: instance.rows,
+			refreshingAfter: instance.isRefreshing('r0'),
+		}).toMatchInlineSnapshot(`
+			{
+			  "inFlight": {
+			    "expandState": "expanded",
+			    "refreshing": true,
+			    "rows": 3,
+			  },
+			  "refreshingAfter": false,
+			  "rowsAfter": 3,
+			}
+		`);
+	});
+
+	it('reload discards its result if the node was collapsed while the fetch was in flight', async () => {
+		// Mirrors a consumer whose collapse releases the resources the fetch is using -- Data
+		// Connections disconnects and drops the subtree. A late commit would install rows whose
+		// handles are already dead, and expand() never re-fetches a node whose children are
+		// loaded, so they would be stuck there.
+		class DropOnCollapseTree extends PositronTreeInstance<DemoNode> {
+			override collapse(id: string): void {
+				this.dropLoadedChildren(id);
+				super.collapse(id);
+			}
+		}
+
+		const pending = deferred<readonly TreeNode<DemoNode>[]>();
+		let reloading = false;
+		const tree = new DropOnCollapseTree({
+			rowHeight: ROW_HEIGHT,
+			getRoots: async () => [branch('r0')],
+			getChildren: async () => reloading ? pending.promise : [leaf('before')],
+			renderNode: visible => <span>{visible.node.data.label}</span>,
+		});
+		store.add(tree);
+		await tree.refresh();
+		await tree.expand('r0');
+
+		reloading = true;
+		const reload = tree.reload('r0');
+		tree.collapse('r0');
+		pending.resolve([leaf('after')]);
+		await reload;
+
+		expect({
+			expanded: tree.isExpanded('r0'),
+			// Nothing installed, so the next expand fetches against a live resource.
+			loadedChildren: tree.hasLoadedChildren('r0'),
+		}).toEqual({ expanded: false, loadedChildren: false });
+	});
+
+	it('reload caps how many getChildren calls run at once while restoring', async () => {
+		// A root with more expanded children than the concurrency cap, so the restore has to
+		// queue rather than fire them all at once.
+		const wide = Array.from({ length: 20 }, (_, i) => branch(`child${i}`));
+		let inFlight = 0;
+		let peakInFlight = 0;
+		const tree = new PositronTreeInstance<DemoNode>({
+			rowHeight: ROW_HEIGHT,
+			getRoots: async () => [branch('r0')],
+			getChildren: async node => {
+				if (node.id === 'r0') {
+					return wide;
+				}
+				inFlight++;
+				peakInFlight = Math.max(peakInFlight, inFlight);
+				await new Promise(resolve => setTimeout(resolve, 0));
+				inFlight--;
+				return [leaf(`${node.id}.leaf`)];
+			},
+			renderNode: visible => <span>{visible.node.data.label}</span>,
+		});
+		store.add(tree);
+		await tree.refresh();
+		await tree.expand('r0');
+		for (const child of wide) {
+			await tree.expand(child.id);
+		}
+
+		peakInFlight = 0;
+		await tree.reload('r0');
+
+		expect({
+			restored: wide.filter(child => tree.isExpanded(child.id)).length,
+			cappedBelowChildCount: peakInFlight < wide.length,
+			peakInFlight,
+		}).toEqual({ restored: 20, cappedBelowChildCount: true, peakInFlight: 8 });
+	});
+
+	it('marks everything under a refreshing node stale, and nothing else', async () => {
+		// Two roots, each with a child that has its own child, so the walk has depth and a sibling
+		// branch that must stay untouched.
+		const pending = deferred<readonly TreeNode<DemoNode>[]>();
+		let reloading = false;
+		const tree = new PositronTreeInstance<DemoNode>({
+			rowHeight: ROW_HEIGHT,
+			getRoots: async () => [branch('r0'), branch('r1')],
+			getChildren: async node => {
+				if (reloading && node.id === 'r0') {
+					return pending.promise;
+				}
+				return node.id.includes('.') ? [leaf(`${node.id}.leaf`)] : [branch(`${node.id}.c`)];
+			},
+			renderNode: visible => <span>{visible.node.data.label}</span>,
+		});
+		store.add(tree);
+		await tree.refresh();
+		await tree.expand('r0');
+		await tree.expand('r0.c');
+		await tree.expand('r1');
+		await tree.expand('r1.c');
+
+		reloading = true;
+		const reload = tree.reload('r0');
+		const duringRefresh = tree.visibleNodes.map(v => `${v.node.id}${v.stale ? ':stale' : ''}`);
+
+		pending.resolve([branch('r0.c')]);
+		await reload;
+
+		expect({
+			// r0 is refreshing, not stale: it is the node being replaced into. Its whole subtree is
+			// stale. r1's branch is untouched.
+			duringRefresh,
+			anyStaleAfter: tree.visibleNodes.some(v => v.stale),
+		}).toMatchInlineSnapshot(`
+			{
+			  "anyStaleAfter": false,
+			  "duringRefresh": [
+			    "r0",
+			    "r0.c:stale",
+			    "r0.c.leaf:stale",
+			    "r1",
+			    "r1.c",
+			    "r1.c.leaf",
+			  ],
+			}
+		`);
+	});
+
+	it('reload drops the stale subtree and records the error when the fetch fails', async () => {
+		let shouldFail = false;
+		const instance = new PositronTreeInstance<DemoNode>({
+			rowHeight: ROW_HEIGHT,
+			getRoots: async () => [branch('r0')],
+			getChildren: async node => {
+				if (shouldFail) {
+					throw new Error('connection lost');
+				}
+				return [leaf(`${node.id}.0`)];
+			},
+			renderNode: visible => <span>{visible.node.data.label}</span>,
+		});
+		store.add(instance);
+		await instance.refresh();
+		await instance.expand('r0');
+
+		shouldFail = true;
+		await instance.reload('r0');
+
+		expect({
+			rows: instance.rows,
+			error: (instance.getError('r0') as Error).message,
+			loadedChildren: instance.hasLoadedChildren('r0'),
+			refreshing: instance.isRefreshing('r0'),
+		}).toMatchInlineSnapshot(`
+			{
+			  "error": "connection lost",
+			  "loadedChildren": false,
+			  "refreshing": false,
+			  "rows": 1,
+			}
+		`);
+	});
+
+	it('reload marks the rows it brought in as recently refreshed, then clears the mark', async () => {
+		vi.useFakeTimers();
+		try {
+			const tree = await newTree(1, 2);
+			await tree.expand('r0');
+
+			await tree.reload('r0');
+			// The reloaded node is marked along with the rows brought in beneath it, so the whole
+			// refreshed block reads as one.
+			const marked = tree.visibleNodes.filter(v => v.recentlyRefreshed).map(v => v.node.id);
+
+			// The highlight is on a timer, so it clears without any further interaction.
+			await vi.advanceTimersByTimeAsync(3000);
+
+			expect({
+				marked,
+				afterTimeout: tree.visibleNodes.filter(v => v.recentlyRefreshed).map(v => v.node.id),
+			}).toMatchInlineSnapshot(`
+				{
+				  "afterTimeout": [],
+				  "marked": [
+				    "r0",
+				    "r0.0",
+				    "r0.1",
+				  ],
+				}
+			`);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('reload drops a collapsed node\'s children so the next expand re-fetches', async () => {
+		const tree = await newTree(1, 2);
+		await tree.expand('r0');
+		tree.collapse('r0');
+
+		await tree.reload('r0');
+
+		expect(tree.hasLoadedChildren('r0')).toBe(false);
+	});
+
+	it('reloadAll re-runs getRoots and reloads every expanded root', async () => {
+		const getRoots = vi.fn(async () => [branch('r0'), branch('r1')]);
+		const getChildren = vi.fn(async (node: TreeNode<DemoNode>) => [leaf(`${node.id}.0`)]);
+		const tree = new PositronTreeInstance<DemoNode>({
+			rowHeight: ROW_HEIGHT,
+			getRoots,
+			getChildren,
+			renderNode: visible => <span>{visible.node.data.label}</span>,
+		});
+		store.add(tree);
+		await tree.refresh();
+
+		// Only r0 is opened, so only its subtree is on screen.
+		await tree.expand('r0');
+		const rootsBefore = getRoots.mock.calls.length;
+		const childrenBefore = getChildren.mock.calls.length;
+
+		await tree.reloadAll();
+
+		expect({
+			rootsFetches: getRoots.mock.calls.length - rootsBefore,
+			// r0's subtree is re-fetched; collapsed r1 has nothing on screen to replace.
+			childrenFetches: getChildren.mock.calls.length - childrenBefore,
+			stillExpanded: tree.isExpanded('r0'),
+			rows: tree.rows,
+		}).toEqual({ rootsFetches: 1, childrenFetches: 1, stillExpanded: true, rows: 3 });
+	});
+
+	it('a second reload keeps the highlight on rows the first one had already marked', async () => {
+		vi.useFakeTimers();
+		try {
+			// Root ids are stable while child ids carry a per-fetch handle, as in Data Connections.
+			// The root is therefore in both reloads' batches, and the first batch's timer must not
+			// clear a mark the second reload has taken over.
+			let handle = 0;
+			const tree = new PositronTreeInstance<DemoNode>({
+				rowHeight: ROW_HEIGHT,
+				getRoots: async () => [{ id: 'root', data: { label: 'root' }, hasChildren: true }],
+				getChildren: async () => [{ id: `child@${handle++}`, data: { label: 'child' }, hasChildren: false }],
+				getReloadKey: node => node.data.label,
+				renderNode: visible => <span>{visible.node.data.label}</span>,
+			});
+			store.add(tree);
+			await tree.refresh();
+			await tree.expand('root');
+
+			await tree.reload('root');
+			const firstGeneration = tree.visibleNodes[0].refreshGeneration;
+
+			// Second reload lands mid-highlight.
+			await vi.advanceTimersByTimeAsync(500);
+			await tree.reload('root');
+			// A fresh generation is what makes the row restart its animation rather than sit out
+			// the new highlight.
+			const secondGeneration = tree.visibleNodes[0].refreshGeneration;
+
+			// The first reload's timer comes due; it must not clear what the second one re-marked.
+			await vi.advanceTimersByTimeAsync(1000);
+			const afterFirstTimer = tree.visibleNodes.map(v => v.recentlyRefreshed);
+
+			// The second reload's own timer then clears everything.
+			await vi.advanceTimersByTimeAsync(600);
+
+			expect({
+				afterFirstTimer,
+				generationAdvanced: secondGeneration > firstGeneration,
+				afterSecondTimer: tree.visibleNodes.map(v => v.recentlyRefreshed),
+			}).toEqual({
+				afterFirstTimer: [true, true],
+				generationAdvanced: true,
+				afterSecondTimer: [false, false],
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('reloadAll folds a repeat press into the pass already running', async () => {
+		// Hammering the refresh action must not start a second sweep of the tree: the control stays
+		// enabled (a disabled one would steal focus on click), so the extra presses land here.
+		const pending = deferred<readonly TreeNode<DemoNode>[]>();
+		let reloading = false;
+		let signalSubtreeFetchStarted!: () => void;
+		const subtreeFetchStarted = new Promise<void>(resolve => { signalSubtreeFetchStarted = resolve; });
+
+		const getRoots = vi.fn(async () => [branch('r0')]);
+		const getChildren = vi.fn(async () => {
+			if (!reloading) {
+				return [leaf('r0.0')];
+			}
+			signalSubtreeFetchStarted();
+			return pending.promise;
+		});
+		const tree = new PositronTreeInstance<DemoNode>({
+			rowHeight: ROW_HEIGHT,
+			getRoots,
+			getChildren,
+			renderNode: visible => <span>{visible.node.data.label}</span>,
+		});
+		store.add(tree);
+		await tree.refresh();
+		await tree.expand('r0');
+
+		reloading = true;
+		const rootsBefore = getRoots.mock.calls.length;
+
+		const first = tree.reloadAll();
+
+		// Wait until the roots pass has finished and the subtree fetch is in flight. That is the
+		// window a second press actually lands in -- pressing during the roots pass is already
+		// absorbed by refresh's own re-entrancy, so it would prove nothing.
+		await subtreeFetchStarted;
+		const second = tree.reloadAll();
+
+		pending.resolve([leaf('r0.0')]);
+		await Promise.all([first, second]);
+
+		// A second sweep would have re-run getRoots.
+		expect(getRoots.mock.calls.length - rootsBefore).toBe(1);
+	});
+
+	it('holds the focused appearance while an overlay owns DOM focus', async () => {
+		const tree = await newTree(1, 0);
+		tree.setFocused(true);
+
+		// A row's context menu opens: it takes DOM focus, which blurs the tree, but the row it
+		// belongs to should keep its active-selection styling.
+		const hold = tree.holdFocusAppearance();
+		tree.setFocused(false);
+		const whileHeld = tree.focused;
+
+		hold.dispose();
+		const afterRelease = tree.focused;
+
+		// Disposing twice must not drive the count negative and re-focus the tree.
+		hold.dispose();
+
+		expect({ whileHeld, afterRelease, afterDoubleDispose: tree.focused }).toEqual({
+			whileHeld: true,
+			afterRelease: false,
+			afterDoubleDispose: false,
+		});
+	});
+
 	it('setChildren pushes loaded children without invoking getChildren', async () => {
 		const tree = await newTree(2, 0); // getChildren would yield nothing; push explicitly instead
 		tree.setChildren('r0', [leaf('pushed-a'), leaf('pushed-b')]);
@@ -415,6 +930,36 @@ describe('PositronTree rendering and loading states', () => {
 		children.resolve([leaf('r0.0')]);
 		await expanding;
 		expect(await screen.findByText('r0.0')).toBeInTheDocument();
+	});
+
+	it('makes a stale row\'s twisty inert while an ancestor refreshes', async () => {
+		const pending = deferred<readonly TreeNode<DemoNode>[]>();
+		let reloading = false;
+		const instance = makeTree(
+			async () => [branch('r0')],
+			async node => reloading && node.id === 'r0' ? pending.promise : [branch('r0.c')]
+		);
+		await instance.refresh();
+		await instance.expand('r0');
+		rtl.render(<PositronTree instance={instance} />);
+
+		// Before the refresh, r0.c offers an Expand affordance.
+		expect(await screen.findByRole('button', { name: 'Expand' })).toBeInTheDocument();
+
+		reloading = true;
+		const reload = instance.reload('r0');
+
+		// While r0 refreshes, r0.c is stale: expanding it would fetch against a resource the
+		// refresh may already have released, so the twisty loses its label and is disabled.
+		await waitFor(() => expect(screen.queryByRole('button', { name: 'Expand' })).not.toBeInTheDocument());
+		// The row is still on screen -- a reload doesn't empty the subtree before its replacement.
+		expect(screen.getByText('r0.c')).toBeInTheDocument();
+
+		pending.resolve([branch('r0.c')]);
+		await reload;
+
+		// Once the replacement lands the affordance comes back.
+		expect(await screen.findByRole('button', { name: 'Expand' })).toBeInTheDocument();
 	});
 
 	it('shows a clickable error affordance carrying the failure message when a child fetch fails', async () => {

--- a/src/vs/workbench/contrib/positronDataConnections/browser/classes/dataConnectionsTreeInstance.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/classes/dataConnectionsTreeInstance.tsx
@@ -9,8 +9,9 @@ import { ReactNode } from 'react';
 // Other dependencies.
 import { DataConnectionEntryRow } from '../components/dataConnectionEntryRow.js';
 import { DataConnectionNodeRow } from '../components/dataConnectionNodeRow.js';
-import { TreeNode, VisibleNode } from '../../../../browser/positronTree/classes/treeNode.js';
+import { TreeNode, TreeNodeContext, VisibleNode } from '../../../../browser/positronTree/classes/treeNode.js';
 import { PositronTreeInstance } from '../../../../browser/positronTree/classes/positronTreeInstance.js';
+import { MouseSelectionType } from '../../../../browser/positronDataGrid/classes/dataGridInstance.js';
 import { IDataConnectionNodeDTO } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDTOs.js';
 import { IDataConnectionInstance } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionInstance.js';
 import { IPositronDataConnectionsService } from '../../../../services/positronDataConnections/common/interfaces/positronDataConnectionsService.js';
@@ -54,10 +55,28 @@ const entryNodeId = (profile: IDataConnectionProfile): string => `entry:${profil
 const dtoNodeId = (handle: IDataConnectionHandle, dto: IDataConnectionNodeDTO): string =>
 	`dto:${handle.handle}:${dto.nodeHandle}`;
 
+/**
+ * The identity a node keeps across a refresh, used by the tree to re-expand a subtree after
+ * reload. Node handles are minted from a counter on every fetch, so a node's id always changes
+ * even when the node itself hasn't -- its kind and name are what actually stay the same. The pair
+ * is JSON-encoded so a name that happens to contain the separator can't collide with a different
+ * kind/name pair.
+ *
+ * DTO keys deliberately don't include the originating connection handle: the tree matches a node
+ * to its counterpart among its own siblings, which always come from the same connection, so a
+ * kind/name pair only ever has to be unique within one level.
+ *
+ * Exported for tests.
+ */
+export const reloadKey = (node: DataConnectionNode): string =>
+	node.kind === 'entry'
+		? entryNodeId(node.entry.profile)
+		: JSON.stringify([node.dto.kind, node.dto.name]);
+
 const wrapEntry = (entry: DataConnectionEntry): TreeNode<DataConnectionNode> => ({
 	id: entryNodeId(entry.profile),
 	data: { kind: 'entry', entry },
-	// Entries always show a twistie -- clicking it connects (or disconnects). Whether children
+	// Entries always show a twisty -- clicking it connects (or disconnects). Whether children
 	// exist is only knowable after the connect succeeds.
 	hasChildren: true,
 });
@@ -84,7 +103,8 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 			getRoots: async () => buildEntries(_service).map(wrapEntry),
 			// Bound to `this` so the closure can reach _service for the connect-on-expand path.
 			getChildren: node => this._fetchChildrenForNode(node),
-			renderNode: renderRow,
+			getReloadKey: node => reloadKey(node.data),
+			renderNode: (visible, context) => this._renderRow(visible, context),
 		});
 
 		// When profiles or instances change, rebuild roots so each entry sees its current
@@ -116,7 +136,7 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 	/**
 	 * Fetches children for a node. For an entry node without a live instance, opens the
 	 * connection first, then fetches the top-level DTOs against the new handle. Running this
-	 * inside the base class's _fetchChildren means the loading state (twistie spinner) covers
+	 * inside the base class's _fetchChildren means the loading state (twisty spinner) covers
 	 * the connect + getChildren as one continuous operation, and a connect failure surfaces
 	 * through the tree's existing error state.
 	 */
@@ -135,6 +155,46 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 				const dtos = await data.handle.nodeGetChildren(data.dto.nodeHandle);
 				return dtos.map(dto => wrapDto(dto, data.handle));
 			}
+		}
+	}
+
+	/**
+	 * Renders one row. Each row gets callbacks bound to its own node id and position, so a row can
+	 * act on itself without knowing anything about the tree.
+	 *
+	 * Reload (rather than invalidate) is required at every level: re-fetching a connection's
+	 * top-level nodes invalidates every node handle the extension host has issued for that
+	 * connection, and re-fetching an interior node's children issues new handles for them. In
+	 * both cases the descendants loaded under the old handles are stale, so they're dropped and
+	 * re-fetched rather than left in place. Reload restores the expansion the user had open (see
+	 * reloadKey for how a node is matched to its post-refresh counterpart).
+	 */
+	private _renderRow(visible: VisibleNode<DataConnectionNode>, context: TreeNodeContext): ReactNode {
+		const { id, data } = visible.node;
+
+		// Fire-and-forget: reload drives the twisty's loading state and records any failure
+		// against the node, so there's nothing for the row to await.
+		// Offered whatever the node's expansion state: on an expanded node the subtree visibly
+		// swaps, and on a collapsed one the stale children are dropped so the next expand fetches
+		// from the source. Nothing is on screen beneath a collapsed node, so the absence of a
+		// visible change there isn't the silent no-op it would be on an expanded one.
+		const onRefresh = () => { void this.reload(id); };
+
+		// Rows announce their context menu here rather than selecting themselves directly, so the
+		// tree owns what opening a menu means: select the row the menu belongs to (as a left click
+		// would), and keep the tree looking focused while the menu holds DOM focus. The returned
+		// handle is disposed when the menu closes.
+		const onMenuOpening = () => {
+			void this.mouseSelectRow(context.index, MouseSelectionType.Single);
+			return this.holdFocusAppearance();
+		};
+
+		switch (data.kind) {
+			case 'entry':
+				// Entries are roots, so no ancestor can be refreshing them out from under the row.
+				return <DataConnectionEntryRow entry={data.entry} onMenuOpening={onMenuOpening} onRefresh={onRefresh} />;
+			case 'dto':
+				return <DataConnectionNodeRow dto={data.dto} handle={data.handle} stale={visible.stale} onMenuOpening={onMenuOpening} onRefresh={onRefresh} />;
 		}
 	}
 
@@ -157,14 +217,4 @@ function buildEntries(service: IPositronDataConnectionsService): DataConnectionE
 		profile,
 		instance: service.getInstanceForProfile(profile.id),
 	}));
-}
-
-function renderRow(visible: VisibleNode<DataConnectionNode>): ReactNode {
-	const data = visible.node.data;
-	switch (data.kind) {
-		case 'entry':
-			return <DataConnectionEntryRow entry={data.entry} />;
-		case 'dto':
-			return <DataConnectionNodeRow dto={data.dto} handle={data.handle} />;
-	}
 }

--- a/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionEntryRow.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionEntryRow.tsx
@@ -7,10 +7,11 @@
 import './dataConnectionEntryRow.css';
 
 // React.
-import { useRef } from 'react';
+import { MouseEvent as ReactMouseEvent, useRef } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
+import { IDisposable } from '../../../../../base/common/lifecycle.js';
 import { ConfigureDataConnection } from '../dialogs/configureDataConnection.js';
 import { showConnectDataConnectionWith } from '../dialogs/connectDataConnectionWith.js';
 import { DataConnectionEntry } from '../classes/dataConnectionsTreeInstance.js';
@@ -20,6 +21,7 @@ import { PYTHON_ICON_BASE64, R_ICON_BASE64 } from '../../../../services/positron
 import { CustomContextMenuItem } from '../../../../browser/positronComponents/customContextMenu/customContextMenuItem.js';
 import { CustomContextMenuSeparator } from '../../../../browser/positronComponents/customContextMenu/customContextMenuSeparator.js';
 import { CustomContextMenuEntry, showCustomContextMenu } from '../../../../browser/positronComponents/customContextMenu/customContextMenu.js';
+import { AnchorPoint } from '../../../../browser/positronComponents/positronModalPopup/positronModalPopup.js';
 import { resolveDataConnectionMechanism } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
 
 /**
@@ -28,18 +30,27 @@ import { resolveDataConnectionMechanism } from '../../../../services/positronDat
 interface DataConnectionEntryRowProps {
 	// The data connection entry to render.
 	entry: DataConnectionEntry;
+
+	// Reloads this connection's subtree. Supplied by the tree, which binds it to this row's node id.
+	onRefresh: () => void;
+
+	// Tells the tree this row is opening a menu, so it can select the row and hold its focused
+	// appearance. Dispose the returned handle when the menu closes.
+	onMenuOpening: () => IDisposable;
 }
 
 /**
  * DataConnectionEntryRow component. Renders a root-level entry: the saved profile plus, when
  * connected, a live-status indicator. Twistie click (handled by PositronTree) opens or closes
- * the connection; the actions menu exposes runtime-language connect options and edit/remove.
+ * the connection; the actions menu -- reachable from the actions button or by right-clicking the
+ * row -- exposes refresh, runtime-language connect options, and edit/remove.
  */
-export const DataConnectionEntryRow = ({ entry }: DataConnectionEntryRowProps) => {
+export const DataConnectionEntryRow = ({ entry, onMenuOpening, onRefresh }: DataConnectionEntryRowProps) => {
 	// Services.
 	const { notificationService, positronDataConnectionsService } = usePositronReactServicesContext();
 
 	// Reference hooks.
+	const rowRef = useRef<HTMLDivElement>(null);
 	const actionsButtonRef = useRef<HTMLButtonElement>(null);
 
 	// Extract the profile from the entry for easy access.
@@ -100,14 +111,13 @@ export const DataConnectionEntryRow = ({ entry }: DataConnectionEntryRowProps) =
 	};
 
 	/**
-	 * Shows the actions menu for this connection entry.
+	 * Shows the actions menu for this connection entry, anchored to the supplied element (the
+	 * actions button when the menu was opened from it; the row itself on right-click). A right
+	 * click also supplies the pointer position, so the menu opens where the user clicked rather
+	 * than at the row's edge; opening from the button has no pointer position to honor and lines
+	 * up with the button instead.
 	 */
-	const showActionsMenu = () => {
-		// Guard: if the ref isn't set, we have no anchor for the menu, so do nothing.
-		if (!actionsButtonRef.current) {
-			return;
-		}
-
+	const showActionsMenu = (anchorElement: HTMLElement, anchorPoint?: AnchorPoint) => {
 		// Get the driver.
 		const driver = positronDataConnectionsService.driverManager.getDriver(profile.driverMetadata.id);
 		if (!driver) {
@@ -159,8 +169,15 @@ export const DataConnectionEntryRow = ({ entry }: DataConnectionEntryRowProps) =
 		const rSupported = driver.metadata.supportedLanguageIds.includes('r');
 		const sqlSupported = driver.metadata.supportedLanguageIds.includes('sql');
 
-		// Build the menu entries.
+		// Build the menu entries. Refresh leads, separated from the profile actions below it --
+		// Edit Connection is always present, so the separator always has something under it.
 		const entries: CustomContextMenuEntry[] = [
+			new CustomContextMenuItem({
+				icon: 'refresh',
+				label: localize('positron.dataConnections.refresh', "Refresh"),
+				onSelected: onRefresh,
+			}),
+			new CustomContextMenuSeparator(),
 			new CustomContextMenuItem({
 				icon: 'edit',
 				label: localize('positron.dataConnections.editConnection', "Edit Connection"),
@@ -211,19 +228,53 @@ export const DataConnectionEntryRow = ({ entry }: DataConnectionEntryRowProps) =
 				onSelected: () => positronDataConnectionsService.removeProfile(profile.id),
 			}));
 
+		// Announced before the menu shows so the row is already selected and the tree still reads
+		// as focused when the menu paints over it. Acquired here rather than on entry to the
+		// function so the early returns above can't leave a hold outstanding.
+		const menuHold = onMenuOpening();
+
 		// Show the menu.
 		showCustomContextMenu({
-			anchorElement: actionsButtonRef.current,
+			anchorElement,
+			anchorPoint,
 			popupPosition: 'auto',
 			popupAlignment: 'auto',
 			width: 'auto',
-			entries
+			entries,
+			onClose: () => menuHold.dispose()
 		});
+	};
+
+	/**
+	 * Opens the actions menu from the actions button.
+	 */
+	const onActionsClick = () => {
+		// Guard: if the ref isn't set, we have no anchor for the menu, so do nothing.
+		if (actionsButtonRef.current) {
+			showActionsMenu(actionsButtonRef.current);
+		}
+	};
+
+	/**
+	 * Opens the actions menu from a right-click anywhere on the row.
+	 */
+	const onContextMenu = (e: ReactMouseEvent<HTMLDivElement>) => {
+		// Guard: if the ref isn't set, we have no anchor for the menu, so do nothing.
+		if (!rowRef.current) {
+			return;
+		}
+		e.preventDefault();
+		e.stopPropagation();
+		showActionsMenu(rowRef.current, { clientX: e.clientX, clientY: e.clientY });
 	};
 
 	// Render.
 	return (
-		<div className='data-connection-entry-row'>
+		// The row is a presentational element inside a tree that owns focus and keyboard
+		// navigation; right-click is a pointer affordance for the actions menu, which the
+		// keyboard-reachable actions button also opens. Matches VS Code's tree behavior.
+		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
+		<div ref={rowRef} className='data-connection-entry-row' onContextMenu={onContextMenu}>
 			<div className='codicon codicon-positron-db-database data-connection-entry-icon' />
 			<div className='data-connection-entry-text'>
 				{profile.connectionName}
@@ -234,7 +285,7 @@ export const DataConnectionEntryRow = ({ entry }: DataConnectionEntryRowProps) =
 				ref={actionsButtonRef}
 				aria-label={localize('positron.dataConnections.actions', "Actions")}
 				className='data-connection-entry-actions'
-				onClick={showActionsMenu}
+				onClick={onActionsClick}
 			>
 				<div className='codicon codicon-ellipsis' />
 			</button>

--- a/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionNodeRow.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionNodeRow.tsx
@@ -11,9 +11,11 @@ import { MouseEvent as ReactMouseEvent, useRef, useState } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
+import { IDisposable } from '../../../../../base/common/lifecycle.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
-import { showCustomContextMenu } from '../../../../browser/positronComponents/customContextMenu/customContextMenu.js';
 import { CustomContextMenuItem } from '../../../../browser/positronComponents/customContextMenu/customContextMenuItem.js';
+import { CustomContextMenuSeparator } from '../../../../browser/positronComponents/customContextMenu/customContextMenuSeparator.js';
+import { CustomContextMenuEntry, showCustomContextMenu } from '../../../../browser/positronComponents/customContextMenu/customContextMenu.js';
 import { IDataConnectionHandle } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
 import { IDataConnectionNodeDTO } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDTOs.js';
 
@@ -95,14 +97,27 @@ const canPreview = (dto: IDataConnectionNodeDTO): boolean =>
 interface DataConnectionNodeRowProps {
 	dto: IDataConnectionNodeDTO;
 	handle: IDataConnectionHandle;
+
+	// Reloads this node's subtree. Supplied by the tree, which binds it to this row's node id.
+	onRefresh: () => void;
+
+	// Tells the tree this row is opening a context menu, so it can select the row and hold its
+	// focused appearance. Dispose the returned handle when the menu closes.
+	onMenuOpening: () => IDisposable;
+
+	// Whether an ancestor is being refreshed, so this row is about to be replaced. The node handle
+	// it holds may already be dead -- a connection-level refresh releases every node handle it
+	// issued -- so no action is offered until the replacement lands.
+	stale: boolean;
 }
 
 /**
  * DataConnectionNodeRow component. Renders one server-side connection node (catalog, schema,
  * table, view, column, etc.) inside the tree. Previewable table/view nodes open in the Data
- * Explorer on double-click or via the "Open in Data Explorer" context-menu action.
+ * Explorer on double-click or via the "Open in Data Explorer" context-menu action; nodes that
+ * can have children offer a "Refresh" action that re-fetches the subtree.
  */
-export const DataConnectionNodeRow = ({ dto, handle }: DataConnectionNodeRowProps) => {
+export const DataConnectionNodeRow = ({ dto, handle, onMenuOpening, onRefresh, stale }: DataConnectionNodeRowProps) => {
 	const { notificationService } = usePositronReactServicesContext();
 	const rowRef = useRef<HTMLDivElement>(null);
 	// Opening a preview can take a moment (a driver may download data first). Track it so the row can
@@ -130,29 +145,66 @@ export const DataConnectionNodeRow = ({ dto, handle }: DataConnectionNodeRowProp
 	};
 
 	const onDoubleClick = () => {
-		if (canPreview(dto)) {
+		if (canPreview(dto) && !stale) {
 			openInDataExplorer();
 		}
 	};
 
 	const onContextMenu = (e: ReactMouseEvent<HTMLDivElement>) => {
-		if (!canPreview(dto) || !rowRef.current) {
+		if (!rowRef.current) {
 			return;
 		}
+
+		// An ancestor is refreshing, so this row is on its way out and its handle may already be
+		// dead. Offer nothing until the replacement arrives; the ancestor's spinner is the signal.
+		if (stale) {
+			return;
+		}
+
+		// Build the entries that apply to this node. Refresh leads, offered for any node that can
+		// have children, expanded or not -- a leaf is the only case with nothing to re-fetch.
+		// Preview follows for previewable nodes, separated from Refresh when both are present.
+		const entries: CustomContextMenuEntry[] = [];
+		if (dto.hasGetChildren) {
+			entries.push(new CustomContextMenuItem({
+				icon: 'refresh',
+				label: localize('positron.dataConnections.refresh', "Refresh"),
+				onSelected: onRefresh,
+			}));
+		}
+		if (canPreview(dto)) {
+			if (entries.length > 0) {
+				entries.push(new CustomContextMenuSeparator());
+			}
+			entries.push(new CustomContextMenuItem({
+				icon: 'table',
+				label: localize('positron.dataConnections.openInDataExplorer', "Open in Data Explorer"),
+				onSelected: openInDataExplorer,
+			}));
+		}
+
+		// Nothing applies to this node (e.g. a non-previewable leaf), so leave the event alone
+		// rather than swallowing it to show an empty menu.
+		if (entries.length === 0) {
+			return;
+		}
+
 		e.preventDefault();
 		e.stopPropagation();
+
+		// Announced before the menu shows so the row is already selected and the tree still reads
+		// as focused when the menu paints over it.
+		const menuHold = onMenuOpening();
 		showCustomContextMenu({
 			anchorElement: rowRef.current,
+			// Anchored to the pointer rather than the row, so the menu opens where the user
+			// clicked instead of snapping to the row's edge.
+			anchorPoint: { clientX: e.clientX, clientY: e.clientY },
 			popupPosition: 'auto',
 			popupAlignment: 'auto',
 			width: 'auto',
-			entries: [
-				new CustomContextMenuItem({
-					icon: 'table',
-					label: localize('positron.dataConnections.openInDataExplorer', "Open in Data Explorer"),
-					onSelected: openInDataExplorer,
-				}),
-			],
+			entries,
+			onClose: () => menuHold.dispose(),
 		});
 	};
 

--- a/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionsPanel.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionsPanel.tsx
@@ -50,6 +50,29 @@ export const DataConnectionsPanel = () => {
 	// Right action bar actions.
 	const rightActions: DynamicActionBarAction[] = [];
 
+	// Refresh all. Pushed before Add Connection because the action bar lays each group out in array
+	// order, left to right, so this sits to its left.
+	const refreshAll = localize('positronDataConnections.refreshAll', "Refresh All");
+	rightActions.push({
+		fixedWidth: DEFAULT_ACTION_BAR_BUTTON_WIDTH,
+		separator: false,
+		component: (
+			<ActionBarButton
+				ariaLabel={refreshAll}
+				// Left enabled while a refresh is running rather than disabled: clicking a disabled
+				// control moves focus to the view pane and leaves a focus ring behind, and a user
+				// hammering this button would collect one. reloadAll is re-entrant, so the extra
+				// presses fold into the run already in flight.
+				disabled={false}
+				icon={ThemeIcon.fromId('refresh')}
+				tooltip={refreshAll}
+				// Fire-and-forget: each reloaded connection drives its own twisty spinner and
+				// records any failure against its node, so there's nothing to await here.
+				onPressed={() => { void treeInstance.reloadAll(); }}
+			/>
+		)
+	});
+
 	// Add connection.
 	const addConnection = localize('positronDataConnections.addConnection', "Add Connection");
 	rightActions.push({

--- a/src/vs/workbench/contrib/positronDataConnections/test/browser/dataConnectionNodeRow.vitest.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/test/browser/dataConnectionNodeRow.vitest.tsx
@@ -1,0 +1,195 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { IDisposable } from '../../../../../base/common/lifecycle.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { CustomContextMenuSeparator } from '../../../../browser/positronComponents/customContextMenu/customContextMenuSeparator.js';
+import { IDataConnectionNodeDTO } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDTOs.js';
+import { IDataConnectionHandle } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
+import { DataConnectionNodeRow } from '../../browser/components/dataConnectionNodeRow.js';
+
+// showCustomContextMenu renders a modal popup into the workbench DOM, which isn't what these tests
+// are about -- the behavior under test is which entries the row decides to offer, and whether it
+// opens a menu at all. Mocking the one module lets us read the entries straight off the call.
+const { showCustomContextMenu } = vi.hoisted(() => ({ showCustomContextMenu: vi.fn() }));
+vi.mock('../../../../browser/positronComponents/customContextMenu/customContextMenu.js', () => ({
+	showCustomContextMenu,
+}));
+
+describe('DataConnectionNodeRow', () => {
+	const ctx = createTestContainer().withReactServices().build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
+
+	function createDto(overrides: Partial<IDataConnectionNodeDTO> = {}): IDataConnectionNodeDTO {
+		return {
+			nodeHandle: 1,
+			name: 'users',
+			kind: 'table',
+			hasGetChildren: false,
+			hasPreview: true,
+			...overrides,
+		};
+	}
+
+	/**
+	 * Renders a row and right-clicks it. Returns the handle's nodePreview spy, the row's callbacks,
+	 * and the labels of the menu entries the row offered ('---' for a separator), or undefined when
+	 * the row declined to open a menu at all.
+	 */
+	async function rightClickRow(dto: IDataConnectionNodeDTO, stale = false) {
+		const nodePreview = vi.fn().mockResolvedValue(undefined);
+		const handle = stubInterface<IDataConnectionHandle>({ handle: 1, nodePreview });
+		const onRefresh = vi.fn();
+		const disposeHold = vi.fn();
+		// A plain IDisposable rather than toDisposable(), so the tracker doesn't count the tests
+		// that deliberately never close the menu as leaks.
+		const onMenuOpening = vi.fn((): IDisposable => ({ dispose: disposeHold }));
+
+		rtl.render(
+			<DataConnectionNodeRow
+				dto={dto}
+				handle={handle}
+				stale={stale}
+				onMenuOpening={onMenuOpening}
+				onRefresh={onRefresh}
+			/>
+		);
+
+		const user = userEvent.setup();
+		// The row itself is a structural div with no role or label, so target its name instead --
+		// pointer events there bubble up to the row's handlers, which is what a real click does too.
+		const rowText = screen.getByText(dto.name);
+		await user.pointer({ keys: '[MouseRight]', target: rowText });
+
+		const call = showCustomContextMenu.mock.calls.at(-1)?.[0];
+		const labels = call?.entries.map((entry: unknown) =>
+			entry instanceof CustomContextMenuSeparator ? '---' : (entry as { options: { label: string } }).options.label
+		);
+
+		return { labels, call, rowText, user, nodePreview, onRefresh, onMenuOpening, disposeHold };
+	}
+
+	it('offers Refresh above Open in Data Explorer for a previewable node with children', async () => {
+		const { labels } = await rightClickRow(createDto({ hasGetChildren: true, hasPreview: true }));
+
+		expect(labels).toMatchInlineSnapshot(`
+			[
+			  "Refresh",
+			  "---",
+			  "Open in Data Explorer",
+			]
+		`);
+	});
+
+	it('offers only Refresh for a node that has children but no preview', async () => {
+		const { labels } = await rightClickRow(
+			createDto({ kind: 'schema', name: 'public', hasGetChildren: true, hasPreview: false })
+		);
+
+		expect(labels).toMatchInlineSnapshot(`
+			[
+			  "Refresh",
+			]
+		`);
+	});
+
+	it('offers only Open in Data Explorer for a previewable leaf', async () => {
+		const { labels } = await rightClickRow(createDto({ hasGetChildren: false, hasPreview: true }));
+
+		expect(labels).toMatchInlineSnapshot(`
+			[
+			  "Open in Data Explorer",
+			]
+		`);
+	});
+
+	it('opens no menu for a leaf with nothing to offer, leaving the event alone', async () => {
+		const { labels, onMenuOpening } = await rightClickRow(
+			createDto({ kind: 'column', name: 'id', hasGetChildren: false, hasPreview: false })
+		);
+
+		// No menu, and no focus hold taken -- an empty menu would be worse than none, and holding
+		// the tree's focused appearance for a menu that never opened would never be released.
+		expect({ labels, heldFocus: onMenuOpening.mock.calls.length }).toMatchInlineSnapshot(`
+			{
+			  "heldFocus": 0,
+			  "labels": undefined,
+			}
+		`);
+	});
+
+	// The safety property: a stale row's node handle may already have been released by the
+	// ancestor's refresh, so acting on it would hit a dead handle.
+	it('offers nothing on a stale row, even when actions would otherwise apply', async () => {
+		const { labels, onMenuOpening } = await rightClickRow(
+			createDto({ hasGetChildren: true, hasPreview: true }),
+			true
+		);
+
+		expect({ labels, heldFocus: onMenuOpening.mock.calls.length }).toMatchInlineSnapshot(`
+			{
+			  "heldFocus": 0,
+			  "labels": undefined,
+			}
+		`);
+	});
+
+	it('does not open a preview when a stale row is double-clicked', async () => {
+		const { rowText, user, nodePreview } = await rightClickRow(createDto({ hasPreview: true }), true);
+
+		await user.dblClick(rowText);
+
+		expect(nodePreview).not.toHaveBeenCalled();
+	});
+
+	it('opens a preview when a previewable row is double-clicked', async () => {
+		const { rowText, user, nodePreview } = await rightClickRow(createDto({ nodeHandle: 42, hasPreview: true }));
+
+		await user.dblClick(rowText);
+
+		expect(nodePreview).toHaveBeenCalledWith(42);
+	});
+
+	it('holds the tree focused while the menu is open and releases the hold when it closes', async () => {
+		const { call, onMenuOpening, disposeHold } = await rightClickRow(
+			createDto({ hasGetChildren: true })
+		);
+
+		const heldBeforeClose = disposeHold.mock.calls.length;
+		call.onClose();
+
+		expect({
+			heldFocus: onMenuOpening.mock.calls.length,
+			heldBeforeClose,
+			releasedAfterClose: disposeHold.mock.calls.length,
+		}).toMatchInlineSnapshot(`
+			{
+			  "heldBeforeClose": 0,
+			  "heldFocus": 1,
+			  "releasedAfterClose": 1,
+			}
+		`);
+	});
+
+	it('invokes the tree-supplied reload when Refresh is selected', async () => {
+		const { call, onRefresh } = await rightClickRow(createDto({ hasGetChildren: true }));
+
+		call.entries[0].options.onSelected();
+
+		expect(onRefresh).toHaveBeenCalledOnce();
+	});
+
+	it('anchors the menu at the pointer rather than the row edge', async () => {
+		const { call } = await rightClickRow(createDto({ hasGetChildren: true }));
+
+		expect(call.anchorPoint).toEqual({ clientX: expect.any(Number), clientY: expect.any(Number) });
+	});
+});

--- a/src/vs/workbench/contrib/positronDataConnections/test/browser/dataConnectionsTreeInstance.vitest.ts
+++ b/src/vs/workbench/contrib/positronDataConnections/test/browser/dataConnectionsTreeInstance.vitest.ts
@@ -1,0 +1,138 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { DataConnectionNode, reloadKey } from '../../browser/classes/dataConnectionsTreeInstance.js';
+import { IDataConnectionNodeDTO } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDTOs.js';
+import { IDataConnectionHandle, IDataConnectionProfile } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+
+function createProfile(overrides: Partial<IDataConnectionProfile> = {}): IDataConnectionProfile {
+	return {
+		id: 'conn-1',
+		driverMetadata: {
+			id: 'test-driver',
+			name: 'Test Driver',
+			iconSvg: '',
+			supportedLanguageIds: ['python', 'r'],
+		},
+		connectionName: 'My Connection',
+		mechanismId: 'test-mechanism',
+		parameterValues: { host: 'localhost' },
+		...overrides,
+	};
+}
+
+function createHandle(handle: number): IDataConnectionHandle {
+	return stubInterface<IDataConnectionHandle>({ handle });
+}
+
+/**
+ * An entry node for the given profile.
+ */
+function entryNode(profile: IDataConnectionProfile): DataConnectionNode {
+	return { kind: 'entry', entry: { profile } };
+}
+
+/**
+ * A DTO node. nodeHandle defaults to a throwaway value because the whole point of reloadKey is
+ * that it doesn't participate -- tests that care pass it explicitly.
+ */
+function dtoNode(
+	dto: Partial<IDataConnectionNodeDTO> & Pick<IDataConnectionNodeDTO, 'kind' | 'name'>,
+	handle = 1
+): DataConnectionNode {
+	return {
+		kind: 'dto',
+		dto: { nodeHandle: 99, hasGetChildren: true, hasPreview: false, ...dto },
+		handle: createHandle(handle),
+	};
+}
+
+describe('dataConnectionsTreeInstance reloadKey', () => {
+	it('keys an entry on its profile id, so a renamed connection keeps its identity', () => {
+		const before = reloadKey(entryNode(createProfile({ connectionName: 'Sales DB' })));
+		const after = reloadKey(entryNode(createProfile({ connectionName: 'Sales Warehouse' })));
+
+		expect({ before, after, stable: before === after }).toMatchInlineSnapshot(`
+			{
+			  "after": "entry:conn-1",
+			  "before": "entry:conn-1",
+			  "stable": true,
+			}
+		`);
+	});
+
+	it('gives different profiles different keys', () => {
+		expect(reloadKey(entryNode(createProfile({ id: 'conn-1' }))))
+			.not.toBe(reloadKey(entryNode(createProfile({ id: 'conn-2' }))));
+	});
+
+	// The property the whole reload/re-expand path depends on: node handles are minted from a
+	// counter on every fetch, so the same logical node comes back with a different handle (and
+	// therefore a different node id) and must still match its pre-reload counterpart.
+	it('keys a DTO on kind and name, ignoring the per-fetch node handle', () => {
+		const before = reloadKey(dtoNode({ kind: 'schema', name: 'public', nodeHandle: 7 }));
+		const after = reloadKey(dtoNode({ kind: 'schema', name: 'public', nodeHandle: 412 }));
+
+		expect({ before, after, stable: before === after }).toMatchInlineSnapshot(`
+			{
+			  "after": "["schema","public"]",
+			  "before": "["schema","public"]",
+			  "stable": true,
+			}
+		`);
+	});
+
+	it('ignores the originating connection handle, since matching is per sibling level', () => {
+		expect(reloadKey(dtoNode({ kind: 'table', name: 'users' }, 1)))
+			.toBe(reloadKey(dtoNode({ kind: 'table', name: 'users' }, 2)));
+	});
+
+	it('distinguishes a name from a kind, and both from the other DTO fields', () => {
+		const keys = [
+			reloadKey(dtoNode({ kind: 'table', name: 'users' })),
+			reloadKey(dtoNode({ kind: 'view', name: 'users' })),
+			reloadKey(dtoNode({ kind: 'table', name: 'orders' })),
+			// dataType / isPrimaryKey / hasPreview are not part of the identity: a column whose
+			// type changed between fetches is still the same column.
+			reloadKey(dtoNode({ kind: 'table', name: 'users', dataType: 'int', isPrimaryKey: true, hasPreview: true })),
+		];
+
+		expect(keys).toMatchInlineSnapshot(`
+			[
+			  "["table","users"]",
+			  "["view","users"]",
+			  "["table","orders"]",
+			  "["table","users"]",
+			]
+		`);
+	});
+
+	// The reason the pair is JSON-encoded rather than concatenated. Under a naive \`\${kind}:\${name}\`
+	// both of these pairs would render as 'a:b:c' and the tree would restore the wrong sibling.
+	it('does not collide when a name contains the separator', () => {
+		expect(reloadKey(dtoNode({ kind: 'a', name: 'b:c' })))
+			.not.toBe(reloadKey(dtoNode({ kind: 'a:b', name: 'c' })));
+	});
+
+	it('does not collide when a name contains quotes or brackets', () => {
+		const keys = [
+			reloadKey(dtoNode({ kind: 'table', name: '","' })),
+			reloadKey(dtoNode({ kind: 'table', name: '' })),
+			reloadKey(dtoNode({ kind: 'table', name: '"]' })),
+		];
+
+		expect(new Set(keys).size).toBe(keys.length);
+	});
+
+	it('never collides with an entry key', () => {
+		// An entry key is 'entry:<id>'; a DTO key is a JSON array, so the two spaces can't meet
+		// even for a DTO deliberately named to look like an entry.
+		expect(reloadKey(dtoNode({ kind: 'entry', name: 'conn-1' })))
+			.not.toBe(reloadKey(entryNode(createProfile({ id: 'conn-1' }))));
+	});
+});


### PR DESCRIPTION
Fixes #14624

### Summary

Adds a **Refresh** action to every level of the Data Connections panel and a **Refresh All** button to the panel's action bar, so a connection's tree can be brought back from the source without disconnecting and reconnecting.

Refresh is a true subtree reload rather than a single-level re-fetch, because re-fetching a connection's top-level nodes invalidates every node handle the extension host has issued for that connection (and re-fetching an interior node issues new handles for its children). Descendants loaded under the old handles are therefore dropped and re-fetched rather than left in place.

The expansion the user had open is preserved across the reload. Node handles are minted from a counter on every fetch, so a node's id always changes even when the node itself hasn't; the tree matches pre- and post-reload nodes by a consumer-supplied reload key (kind + name for Data Connections) instead of by id. Descendants that no longer exist are simply not restored, and ones that appeared while the tree was open stay collapsed.

The subtree is fetched in full off to the side and swapped in as a single projection rebuild, so the rows on screen stay put and change over in one frame instead of emptying and refilling level by level. While the fetch runs, the node's twisty spins and its existing children remain visible -- nothing is torn down before the replacement is in hand. Rows beneath an in-flight refresh are marked stale and offer no actions, since the handles they carry may already have been released.

**Reloaded indicator.** When the swap lands, the reloaded node and every row brought in beneath it briefly highlight with a leading edge marker that eases out over about a second. Without it, a refresh against unchanged data is indistinguishable from nothing having happened -- the rows are identical, so the user has no confirmation the action did anything. The highlight alternates between two otherwise identical animations by reload generation, because a CSS animation only restarts when its `animation-name` changes; a row re-marked while its previous run was still going would otherwise sit out the new one. It honors `prefers-reduced-motion`, falling back to a static marker.

Supporting work in `PositronTreeInstance`: new `reload` / `reloadAll` (both re-entrant), `refreshing` / `stale` / `recentlyRefreshed` state on `VisibleNode`, a bounded-concurrency restore so a wide subtree doesn't fan out into dozens of simultaneous queries, and `holdFocusAppearance` so the tree keeps its focused styling while a context menu owns DOM focus.

Also included: entry rows now open their actions menu on right-click anywhere in the row (previously only via the actions button), and both menu types anchor at the pointer rather than the row edge.

Unrelated rider, one line: Data Explorer column headers no longer flash `<empty>` before the schema arrives. `DataGridColumnHeader` was passing `props.column?.name` into a helper that coalesces `undefined` to `''` and renders the `<empty>` placeholder, which collapsed "schema not read yet" and "column name is genuinely empty" into one state. It now checks the column descriptor itself, so an unloaded header renders blank and `<empty>` only appears once the schema confirms it.

### Screenshots

Here's a screen recording of using refresh at various levels of Data Connections.

<p>


https://github.com/user-attachments/assets/d172f4bb-04be-41f4-b34d-0d7deead520d



</p>

### Release Notes

#### New Features

- Added Refresh and Refresh All actions to the Data Connections panel. Refreshing preserves the expanded state of the tree and briefly highlights the rows that were reloaded (#14624)

#### Bug Fixes

- Data Explorer column headers no longer briefly display `<empty>` while a slow connection's schema is loading

### Validation Steps

@:connections @:data-explorer

1. Enable Data Connections, then create and connect a DuckDB or SQLite connection.
2. Expand the connection several levels deep (catalog -> schema -> table -> columns).
3. Right-click an interior node and choose **Refresh**. Verify the node's twisty spins, its existing children stay on screen while the fetch runs, and the subtree then swaps in place with the expansion you had open still open.
4. Verify the reloaded node and the rows beneath it briefly highlight after the swap, then settle. Refresh the same node twice in quick succession and verify the second refresh re-triggers the highlight rather than leaving the rows unmarked.
5. Enable "Reduce motion" in your OS accessibility settings and refresh again. Verify the marker still appears, without animating.
6. While a refresh is in flight, right-click a row beneath the refreshing node. Verify no context menu appears and its twisty is inert.
7. Right-click a collapsed node and choose **Refresh**, then expand it. Verify the children are re-fetched from the source.
8. Press **Refresh All** in the panel action bar with several connections expanded. Verify every expanded connection reloads, keeps its expansion, and shows the highlight. Press it repeatedly mid-run and verify the presses fold into the run already going rather than queueing extra sweeps.
9. Right-click anywhere on a connection entry row (not just the actions button) and verify the actions menu opens at the pointer, with **Refresh** at the top, and that the row is selected and the panel still reads as focused while the menu is open.
10. Modify the database externally (add a table), then Refresh the schema node and verify the new table appears.
11. For the column header fix: open a table in the Data Explorer over a high-latency connection and verify the headers render blank rather than `<empty>` until the schema arrives.
