### PR TITLE
skill (triage-e2e-test): add Last Seen column to failure table

### DIFF
--- a/.claude/skills/triage-e2e-test/SKILL.md
+++ b/.claude/skills/triage-e2e-test/SKILL.md
@@ -97,19 +97,24 @@ saved data is invalid, or the branch/test identity changed.
    A non-`none` verdict changes the plan -- read [`references/prior-triage.md`](references/prior-triage.md).
    `open-attempt-in-flight` means stop and point at the open PR.
 6. **Present the failure modes as a table** (never a run-on sentence). The Rate
-   column comes from each pattern's `rates` array, never `count / totalRuns`.
+   column comes from each pattern's `rates` array, never `count / totalRuns`;
+   Last seen renders `lastSeen` as `5d ago (Jul 24)`, or just `today` at 0d.
    Include a "Seen on" column whenever two branches were queried:
 
-   | # | Failure mode | Count | Rate | Environments | Seen on |
-   |---|---|---|---|---|---|
-   | A | `locator.click` timeout: `.codicon-maximize` | 4 | 100% on feature/x | ubuntu/chromium | feature/x only |
-   | B | `toBeVisible()` timeout: `getByLabel('...')` | 3 | 1.9% on main | ubuntu/electron | main only |
+   | # | Failure mode | Count | Rate | Last seen | Environments | Seen on |
+   |---|---|---|---|---|---|---|
+   | A | `locator.click` timeout: `.codicon-maximize` | 4 | 100% on feature/x | 5d ago (Jul 24) | ubuntu/chromium | feature/x only |
+   | B | `toBeVisible()` timeout: `getByLabel('...')` | 3 | 1.9% on main | today | ubuntu/electron | main only |
+
+   Count and Rate are cumulative over the lookback, so they cannot separate an
+   acute burst a merged fix already closed from an ongoing drip. **A pattern whose
+   `daysAgo` is stale next to the others is an already-fixed candidate: say so in
+   your recommendation** instead of steering the engineer there on count alone.
 
 7. **Ask which pattern to prioritize whenever the table has more than one row.**
    Give your own read ("A is dominant at 99% -- start there, or focus on B?")
-   but let the engineer decide; they may know a recent fix made the dominant
-   share stale, or already know which failure they care about. A single pattern
-   needs no choice. Save the selection to the checkpoint (`--set
+   but let the engineer decide; they may already know which failure they care
+   about. A single pattern needs no choice. Save the selection to the checkpoint (`--set
    selectedPattern=A --set phase=pattern-selected`).
 
 ## Investigate the selected pattern

--- a/.claude/skills/triage-e2e-test/references/history-query.md
+++ b/.claude/skills/triage-e2e-test/references/history-query.md
@@ -25,6 +25,28 @@ for the full worked example.
 | `zero-runs-both` | **every** queried branch reports `total_runs: 0` | **stop.** This is a key mismatch, not a clean record -- rebuild the full hierarchical key (above) and re-run |
 | `clean` | nonzero runs, no failure patterns | **stop.** Nothing to triage -- report a clean bill of health for the lookback window |
 
+## How `lastSeen` is derived
+
+The test-health API puts **no timestamp on occurrences**, so `triage-history.js`
+derives one per pattern into `lastSeen: { date, daysAgo, sha }`:
+
+1. `git show -s --format=%cI <sha>` -- the local commit date. Offline, instant,
+   and within minutes of the CI run date.
+2. `gh api repos/{owner}/{repo}/actions/runs/<id> --jq .created_at` -- fallback
+   when the sha isn't in the local clone (shallow clone, force-push, unfetched
+   branch). Authoritative but needs network.
+3. Neither resolves -> `{ date: null, daysAgo: null, sha }`. The sha still names
+   the latest occurrence, because the API returns occurrences most-recent-first.
+
+That ordering is why `lastSeen` is accurate even at the default
+`--occurrences-per-pattern 1`: index 0 already *is* the most recent occurrence,
+so the date only has to be resolved, not searched for.
+
+`lastSeen` does **not** reorder the table -- patterns stay count-descending. It
+is a separate axis: a high-count pattern with a stale `daysAgo` was likely an
+acute burst that a merged fix already closed, which count and rate alone cannot
+show. Check it against `find-prior-triage.js` before recommending it.
+
 ## API unreachable
 
 `triage-history.js` exits non-zero with `{ "error": ... }` when a branch query

--- a/.claude/skills/triage-e2e-test/scripts/test/history-merge.test.js
+++ b/.claude/skills/triage-e2e-test/scripts/test/history-merge.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { normalizePattern, mergeHistory, classifyVerdict, patternLabel, scopedRunsForEnvironments } from '../triage-history.js';
+import { normalizePattern, mergeHistory, classifyVerdict, patternLabel, scopedRunsForEnvironments, resolveLastSeen } from '../triage-history.js';
 
 const mkTest = (runs, patterns, environmentBreakdown) => ({ history: { total_runs: runs }, failure_patterns: patterns, environment_breakdown: environmentBreakdown });
 const occ = (sha, os = 'ubuntu', browser = 'electron') => ({ sha, os, browser, outcome: 'flaky', report_url: `https://x/${sha}/index.html` });
@@ -66,6 +66,39 @@ test('mergeHistory prefers a current-branch representative occurrence and keeps 
 	const { patterns } = mergeHistory(current, main, 'feature/x', 1);
 	assert.equal(patterns[0].representativeOccurrence.sha, 'cur');
 	assert.equal(patterns[0].keptOccurrences.length, 1);
+});
+
+test('resolveLastSeen picks the newest occurrence by date, not API order', () => {
+	const now = Date.parse('2026-07-29T00:00:00Z');
+	const dates = { old: '2026-07-20T10:00:00Z', new: '2026-07-28T10:00:00Z' };
+	// Deliberately out of order: the newest must win on date, not position.
+	const got = resolveLastSeen([occ('old'), occ('new')], o => dates[o.sha], now);
+	assert.deepEqual(got, { date: '2026-07-28', daysAgo: 1, sha: 'new' });
+});
+
+test('resolveLastSeen falls back to the first occurrence identity when no date resolves', () => {
+	// A shallow clone with no gh fallback must still name the latest occurrence
+	// (API order is most-recent-first) rather than dropping lastSeen entirely.
+	const got = resolveLastSeen([occ('a'), occ('b')], () => null);
+	assert.deepEqual(got, { date: null, daysAgo: null, sha: 'a' });
+	assert.equal(resolveLastSeen([], () => null), null);
+});
+
+test('mergeHistory surfaces lastSeen per pattern so a stale burst is distinguishable from a live drip', () => {
+	const now = Date.parse('2026-07-29T00:00:00Z');
+	const dates = { stale: '2026-07-24T10:00:00Z', live: '2026-07-29T10:00:00Z' };
+	const main = mkTest(100, [
+		{ pattern: 'acute burst, already fixed', count: 10, occurrences: [occ('stale')] },
+		{ pattern: 'ongoing drip', count: 3, occurrences: [occ('live')] },
+	]);
+	const { patterns } = mergeHistory(null, main, 'main', 1, o => dates[o.sha]);
+	// Sort stays count-descending; recency is surfaced, not used to reorder.
+	assert.deepEqual(
+		patterns.map(p => [p.failure, p.lastSeen.date]),
+		[['acute burst, already fixed', '2026-07-24'], ['ongoing drip', '2026-07-29']],
+	);
+	assert.equal(mergeHistory(null, main, 'main', 1, o => dates[o.sha]).patterns[0].lastSeen.daysAgo > 0, true);
+	assert.equal(resolveLastSeen([occ('live')], o => dates[o.sha], now).daysAgo, 0);
 });
 
 test('classifyVerdict: both branches zero-runs is a key mismatch, not clean', () => {

--- a/.claude/skills/triage-e2e-test/scripts/triage-history.js
+++ b/.claude/skills/triage-e2e-test/scripts/triage-history.js
@@ -3,7 +3,7 @@
 //
 // Wraps e2e-failure-analyzer/scripts/e2e-query-history.js: resolves the branch,
 // queries the current branch and main, merges their failure patterns by failure
-// text, computes counts/percentages/seen-on, detects zero-run conditions,
+// text, computes counts/percentages/seen-on/last-seen, detects zero-run conditions,
 // selects ONE representative occurrence per pattern, writes the full responses
 // to disk, and prints only a compact JSON summary to stdout.
 //
@@ -55,6 +55,64 @@ function envKey(os, browser) {
 	return [os, browser].filter(Boolean).join('/');
 }
 
+const occurrenceDateCache = new Map();
+
+/**
+ * Calendar date of one failure occurrence. The test-health API returns no
+ * timestamp on occurrences, so derive one: the local git commit date of the sha
+ * (offline and instant, and within minutes of the CI run), falling back to the
+ * GitHub run's created_at when the sha is not in the local clone (shallow clone,
+ * force-push, or a branch never fetched). Returns null when neither answers.
+ */
+export function occurrenceDate(o) {
+	const key = o?.sha || o?.run_url;
+	if (!key) { return null; }
+	if (occurrenceDateCache.has(key)) { return occurrenceDateCache.get(key); }
+
+	let iso = null;
+	if (o.sha) {
+		const r = tryRun('git', ['show', '-s', '--format=%cI', o.sha]);
+		if (r.ok) { iso = r.stdout.trim().split('\n').pop() || null; }
+	}
+	if (!iso && o.run_url) {
+		const runId = String(o.run_url).match(/\/runs\/(\d+)/)?.[1];
+		if (runId) {
+			// {owner}/{repo} are resolved by gh from the working directory.
+			const r = tryRun('gh', ['api', `repos/{owner}/{repo}/actions/runs/${runId}`, '--jq', '.created_at']);
+			if (r.ok) { iso = r.stdout.trim() || null; }
+		}
+	}
+	occurrenceDateCache.set(key, iso);
+	return iso;
+}
+
+/**
+ * Most recent occurrence of a pattern. Recency is what separates an acute burst
+ * that a merged fix already closed from an ongoing drip -- without it a stale
+ * pattern and a live one look identical in the failure table.
+ *
+ * Occurrences arrive most-recent-first from the API, so index 0 is the fallback
+ * identity when no date resolves: a stale clone must still report *which*
+ * occurrence was latest, just without a date.
+ */
+export function resolveLastSeen(occurrences, dateFor, now = Date.now()) {
+	let best = null;
+	for (const o of occurrences || []) {
+		const t = Date.parse(dateFor(o) || '');
+		if (Number.isNaN(t)) { continue; }
+		if (!best || t > best.t) { best = { t, iso: dateFor(o), o }; }
+	}
+	if (!best) {
+		const first = (occurrences || [])[0];
+		return first ? { date: null, daysAgo: null, sha: first.sha ?? null } : null;
+	}
+	return {
+		date: best.iso.slice(0, 10),
+		daysAgo: Math.max(0, Math.round((now - best.t) / 86400000)),
+		sha: best.o.sha ?? null,
+	};
+}
+
 /**
  * Sum `total_runs` from a test object's `environment_breakdown` for exactly the
  * environments a pattern occurred in. Returns null when the breakdown is
@@ -100,7 +158,7 @@ export function patternLabel(i) {
 	return label;
 }
 
-export function mergeHistory(current, main, currentBranch, occurrencesPerPattern = 1) {
+export function mergeHistory(current, main, currentBranch, occurrencesPerPattern = 1, dateFor = () => null) {
 	const byKey = new Map();
 
 	const ingest = (testObj, branchLabel) => {
@@ -168,6 +226,7 @@ export function mergeHistory(current, main, currentBranch, occurrencesPerPattern
 				rates,
 				environments,
 				seenOn,
+				lastSeen: resolveLastSeen(entry.occurrences, dateFor),
 				representativeOccurrence: rep && {
 					branch: rep.branch, sha: rep.sha, os: rep.os,
 					browser: rep.browser, outcome: rep.outcome, report_url: rep.report_url,
@@ -258,7 +317,7 @@ function main() {
 	const testName = (mainTest || currentTest)?.testName || testKey.split('|||')[0];
 	const specPath = (mainTest || currentTest)?.specPath || testKey.split('|||')[1];
 
-	const merged = mergeHistory(currentTest, mainTest, currentBranch, occ);
+	const merged = mergeHistory(currentTest, mainTest, currentBranch, occ, occurrenceDate);
 	const verdict = classifyVerdict({
 		currentBranch,
 		currentRuns: merged.currentRuns,
@@ -281,7 +340,7 @@ function main() {
 		},
 		patterns: merged.patterns.map(p => ({
 			id: p.id, failure: p.failure, count: p.count, rates: p.rates,
-			environments: p.environments, seenOn: p.seenOn,
+			environments: p.environments, seenOn: p.seenOn, lastSeen: p.lastSeen,
 			representativeOccurrence: p.representativeOccurrence,
 		})),
 		verdict: verdict.verdict,


### PR DESCRIPTION
### Summary

The triage failure-pattern table had no recency signal, so an acute burst that a merged fix already closed looked identical to an ongoing drip and could get recommended days after it stopped occurring. This adds a per-pattern `lastSeen` and a Last seen column.

- `triage-history.js` emits `lastSeen: { date, daysAgo, sha }` per pattern
- Date derived from the sha's local git commit date, with the GitHub run's `created_at` as fallback (the test-health API has no timestamp on occurrences)
- Degrades to naming the latest occurrence without a date when neither source resolves
- Patterns stay sorted count-descending; recency is a separate axis, not a re-sort
- SKILL.md renders it as `5d ago (Jul 24)` / `today` and requires calling out a stale pattern as an already-fixed candidate
- Mechanics documented in `references/history-query.md`; 3 unit tests added

### QA Notes

Skill tooling only, no product code. `node --test .claude/skills/triage-e2e-test/scripts/test/*.test.js` -- 57/57 pass.
