### PR TITLE
Narrow Vitest extension file watcher scope

### DIFF
--- a/positron.code-workspace
+++ b/positron.code-workspace
@@ -8,6 +8,12 @@
 		}
 	],
 	"settings": {
-		"search.followSymlinks": false
-    }
+		"search.followSymlinks": false,
+		// The Vitest extension registers one file watcher per workspace folder from
+		// this pattern, which defaults to "**/*". That covers out/ and .build/, which
+		// churn constantly under the build daemons, and extension-created watchers do
+		// not inherit files.watcherExclude -- the event volume then saturates the
+		// extension host. Narrow it to the sources the root vitest.config.ts collects.
+		"vitest.filesWatcherInclude": "src/vs/**/*.{ts,tsx}"
+	}
 }


### PR DESCRIPTION
I was encountering extension host crashes when working on the Positron repo while the vitest extension is installed (used to easily manage and run our unit tests). Claude found this fix which worked in my testing.

<details>

<summary><strong>Generated PR description</strong></summary>

### Summary

The Vitest extension registers one file watcher per workspace folder, built from `vitest.filesWatcherInclude`. That setting defaults to `"**/*"`, so the watcher covers the entire repo root -- including `out/` and `.build/`, which churn constantly while the build daemons run. Extension-created watchers do not inherit `files.watcherExclude`, so the repo's existing exclusions in `.vscode/settings.json` don't apply to it.

Every build-output write therefore becomes a watcher event to glob-match and marshal over the extension-host RPC channel. In a 31.8s extension-host CPU profile, 97.3% of inclusive time sat under the extension's `watchTestFilesInWorkspace`, dominated by glob matching plus `postMessage` / `createUnsafeArrayBuffer` serialization.

Symptom: the extension host went unresponsive about 20 seconds after every start, and was terminated and auto-restarted roughly every 3.5 minutes. Commands invoked from the command palette showed "Activating extensions..." and then silently did nothing, because the handler never got a turn on the blocked event loop.

Narrowing the pattern to `src/vs/**/*.{ts,tsx}` takes the watcher from ~744,000 matched files to ~8,100, and excludes `out/`, `.build/`, and `node_modules` entirely -- the directories responsible for the event volume. What's left is hand-edited TypeScript, so events arrive at human save frequency.

The setting is workspace-scoped, so it applies only when the repo is opened via `positron.code-workspace`.

#### Note on scope

An earlier revision of this PR also set `vitest.configSearchPatternExclude`, to cut config discovery from 8 configs to 1. That was dropped: the profile does not implicate config discovery (test-item construction totalled ~31ms of the 31.8s), and excluding those configs would have broken Test Explorer discovery for the 493 test files under `extensions/copilot` and 41 under `ai-lib/packages`.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

No e2e test tags apply, and none are listed deliberately. This changes a development workspace settings file only: no product code, nothing in the shipped build, no runtime behavior. CI's tag parser matches a literal tag string anywhere in the body, so naming an unrelated suite here would trigger it for nothing.

Local verification for a reviewer:

1. Open the repo via `positron.code-workspace` with the Vitest extension enabled, and start the build daemons (`npm run build-start`) so `out/` is actively churning.
2. Open **Output -> Vitest**. The `[VSCODE] Watching positron with pattern` line should read `src/vs/**/*.{ts,tsx}` rather than `**/*`.
3. Run `Developer: Show Running Extensions` and confirm Vitest reports a finite activation time instead of staying in "Activating...", and that the extension host is not flagged unresponsive.
4. Confirm the Test Explorer still discovers `src/vs/**/*.vitest.{ts,tsx}` and that `npx vitest run <file>` still works.

PETE: not applicable -- config-only change with no testable behavior.

</details>