### PR TITLE
Bump Ark to posit-dev/ark#1370

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -234,6 +234,11 @@
             "default": true,
             "markdownDescription": "%r.configuration.oak.sourceFetching.enabled.description%"
           },
+          "oak.diagnostics.experimental.enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "%r.configuration.oak.diagnostics.experimental.enabled.description%"
+          },
           "positron.r.symbols.includeAssignmentsInBlocks": {
             "type": "boolean",
             "default": false,

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -229,6 +229,11 @@
             "default": true,
             "description": "%r.configuration.diagnostics.enable.description%"
           },
+          "oak.sourceFetching.enabled": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "%r.configuration.oak.sourceFetching.enabled.description%"
+          },
           "positron.r.symbols.includeAssignmentsInBlocks": {
             "type": "boolean",
             "default": false,

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -81,6 +81,7 @@
 	"r.configuration.pipe.magrittr.description": "Pipe operator from the magrittr package, re-exported by many other packages",
 	"r.configuration.diagnostics.enable.description": "Enable R diagnostics globally",
 	"r.configuration.oak.sourceFetching.enabled.description": "Recover the R sources of the packages your workspace uses, for intellisense and code navigation. Sources come from your local installation when available, and are otherwise downloaded from CRAN and cached on disk.",
+	"r.configuration.oak.diagnostics.experimental.enabled.description": "Whether the new R language engine Oak should publish diagnostics that are still experimental.",
 	"r.configuration.symbols.includeAssignmentsInBlocks.description": "Controls whether assigned objects inside `{}` blocks are included as document symbols, in addition to top-level assignments. Reopen files or restart the server for the setting to take effect.",
 	"r.configuration.workspaceSymbols.includeCommentSections.description": "Controls whether comment sections like `# My section ---` are included as workspace symbols.",
 	"r.configuration.autoConvertFilePaths.description": "Automatically convert file paths when pasting files from file manager into R scripts. Converts backslashes (\\) to forward slashes (/), adds quotes, and formats multiple files as R vectors.",

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -80,6 +80,7 @@
 	"r.configuration.pipe.native.description": "Native pipe available in R >= 4.1",
 	"r.configuration.pipe.magrittr.description": "Pipe operator from the magrittr package, re-exported by many other packages",
 	"r.configuration.diagnostics.enable.description": "Enable R diagnostics globally",
+	"r.configuration.oak.sourceFetching.enabled.description": "Recover the R sources of the packages your workspace uses, for intellisense and code navigation. Sources come from your local installation when available, and are otherwise downloaded from CRAN and cached on disk.",
 	"r.configuration.symbols.includeAssignmentsInBlocks.description": "Controls whether assigned objects inside `{}` blocks are included as document symbols, in addition to top-level assignments. Reopen files or restart the server for the setting to take effect.",
 	"r.configuration.workspaceSymbols.includeCommentSections.description": "Controls whether comment sections like `# My section ---` are included as workspace symbols.",
 	"r.configuration.autoConvertFilePaths.description": "Automatically convert file paths when pasting files from file manager into R scripts. Converts backslashes (\\) to forward slashes (/), adds quotes, and formats multiple files as R vectors.",

--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -138,6 +138,16 @@ export class ArkLsp implements vscode.Disposable {
 		const { notebookUri } = this._metadata;
 
 		const clientOptions: LanguageClientOptions = {
+			// Settings the server needs early before it answers `initialize`.
+			initializationOptions: {
+				oak: {
+					sourceFetching: {
+						enabled: vscode.workspace
+							.getConfiguration('oak.sourceFetching')
+							.get<boolean>('enabled', true),
+					},
+				},
+			},
 			// If this client belongs to a notebook, set the document selector to only include that notebook,
 			// Quarto virtual documents (vdocs), and notebook console inputs (inmemory scheme).
 			// Otherwise, this is the main client for this language, so set the document selector to include

--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -138,16 +138,6 @@ export class ArkLsp implements vscode.Disposable {
 		const { notebookUri } = this._metadata;
 
 		const clientOptions: LanguageClientOptions = {
-			// Settings the server needs early before it answers `initialize`.
-			initializationOptions: {
-				oak: {
-					sourceFetching: {
-						enabled: vscode.workspace
-							.getConfiguration('oak.sourceFetching')
-							.get<boolean>('enabled', true),
-					},
-				},
-			},
 			// If this client belongs to a notebook, set the document selector to only include that notebook,
 			// Quarto virtual documents (vdocs), and notebook console inputs (inmemory scheme).
 			// Otherwise, this is the main client for this language, so set the document selector to include


### PR DESCRIPTION
Closes #15259

@:ark

### Release Notes

#### New Features

- The R language engine now downloads and caches sources on disk. This allows you to read actual sources with full context and comments when you navigate to the definition of package functions. And this allows the analysis engine to discover much more about how R code you're using works, which will be the basis for more sophisticated diagnostics in the future. You can disable source fetching at any time with the new `oak.sourceFetching.enabled` setting.

#### Bug Fixes

- N/A

### Commits

- [Add source fetching settings (#1370)](https://github.com/posit-dev/ark/commit/885fac431b43323836d0f6e4a68bcaa8e9c17dbd)
- [Respect a lone `fig-width` or `fig-height` in plot sizing metadata (#1386)](https://github.com/posit-dev/ark/commit/dd6ff5cbdc4c5663be925e0b1d40e4a1b5c8ac27)