### PR TITLE
fix: keep the notebook attached when a restart exit arrives out of order

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -34,7 +34,7 @@ import { ICommandService } from '../../../../platform/commands/common/commands.j
 import { SELECT_KERNEL_ID_POSITRON } from '../common/positronNotebookCommon.js';
 import { INotebookKernelService } from '../../notebook/common/notebookKernelService.js';
 import { ILanguageRuntimeSession, IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
-import { ILanguageRuntimeService, RuntimeStartupPhase, RuntimeState } from '../../../services/languageRuntime/common/languageRuntimeService.js';
+import { ILanguageRuntimeService, RuntimeExitReason, RuntimeStartupPhase, RuntimeState } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { IPositronWebviewPreloadService } from '../../../services/positronWebviewPreloads/browser/positronWebviewPreloadService.js';
 import { autorun, autorunDelta, IObservable, observableFromEvent, observableValue, runOnChange } from '../../../../base/common/observable.js';
@@ -2251,7 +2251,17 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		const disposables = this._runtimeSessionDisposables.value = new DisposableStore();
 
 		// Clean up when the session ends
-		this._register(session.onDidEndSession(() => {
+		this._register(session.onDidEndSession((exit) => {
+			// A restart exit can arrive after the replacement kernel has already
+			// reported that it's starting, in which case we've re-attached to the
+			// same session above. The exit describes the previous kernel, not the
+			// session we hold now, so detaching would leave the notebook without a
+			// session for a kernel that is coming back online.
+			if (exit.reason === RuntimeExitReason.Restart &&
+				session.getRuntimeState() !== RuntimeState.Exited) {
+				return;
+			}
+
 			disposables.dispose();
 			this.kernelStatus.set(NotebookKernelStatus.Exited, undefined);
 			this.runtimeSession.set(undefined, undefined);

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookRestartOrdering.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookRestartOrdering.vitest.ts
@@ -15,7 +15,6 @@ import { createTestLanguageRuntimeMetadata, startTestLanguageRuntimeSession } fr
 import { CellKind } from '../../../notebook/common/notebookCommon.js';
 import { INotebookKernelService } from '../../../notebook/common/notebookKernelService.js';
 import { INotebookService } from '../../../notebook/common/notebookService.js';
-import { RuntimeNotebookKernel } from '../../../runtimeNotebookKernel/browser/runtimeNotebookKernel.js';
 import { createTestPositronNotebookInstance, TestPositronNotebookInstance } from './testPositronNotebookInstance.js';
 
 /**

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookRestartOrdering.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookRestartOrdering.vitest.ts
@@ -1,0 +1,120 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { Event } from '../../../../../base/common/event.js';
+import { toDisposable } from '../../../../../base/common/lifecycle.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { ILanguageRuntimeMetadata, LanguageRuntimeSessionMode, RuntimeExitReason, RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
+import { IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
+import { TestLanguageRuntimeSession } from '../../../../services/runtimeSession/test/common/testLanguageRuntimeSession.js';
+import { createTestLanguageRuntimeMetadata, startTestLanguageRuntimeSession } from '../../../../services/runtimeSession/test/common/testRuntimeSessionService.js';
+import { CellKind } from '../../../notebook/common/notebookCommon.js';
+import { INotebookKernelService } from '../../../notebook/common/notebookKernelService.js';
+import { INotebookService } from '../../../notebook/common/notebookService.js';
+import { RuntimeNotebookKernel } from '../../../runtimeNotebookKernel/browser/runtimeNotebookKernel.js';
+import { createTestPositronNotebookInstance, TestPositronNotebookInstance } from './testPositronNotebookInstance.js';
+
+/**
+ * Regression tests for https://github.com/posit-dev/positron/issues/10016.
+ *
+ * An in-place kernel restart produces two independent signals: the replacement
+ * kernel's `Starting` state and the outgoing kernel's `Restart` exit. Their order
+ * is not guaranteed. The notebook re-attaches to the (same) session on `Starting`,
+ * so a `Restart` exit that lands afterwards describes a kernel that is already
+ * gone -- acting on it detaches a session that is coming back online, and the
+ * kernel status badge never leaves "Disconnected".
+ */
+describe('Positron - notebook restart ordering', () => {
+	const ctx = createTestContainer().withNotebookEditorServices().build();
+
+	let runtime: ILanguageRuntimeMetadata;
+	let notebook: TestPositronNotebookInstance;
+
+	beforeEach(async () => {
+		const runtimeSessionService = ctx.instantiationService.get(IRuntimeSessionService);
+		// Selecting a kernel would otherwise auto-start a session that races the
+		// one the test starts explicitly.
+		runtimeSessionService.implicitStartupSuppressed = true;
+		ctx.disposables.add(toDisposable(() => {
+			runtimeSessionService.activeSessions.forEach(session => session.dispose());
+		}));
+
+		// RuntimeNotebookKernelService creates the notebook kernel when the
+		// runtime registers.
+		const notebookKernelService = ctx.instantiationService.get(INotebookKernelService);
+		const kernelAdded = Event.toPromise(notebookKernelService.onDidAddKernel);
+		runtime = createTestLanguageRuntimeMetadata(ctx.instantiationService, ctx.disposables);
+		const kernel = await kernelAdded;
+
+		notebook = createTestPositronNotebookInstance(
+			[['print("hello")', 'python', CellKind.Code]],
+			ctx,
+		);
+
+		// The test notebook model is created directly rather than through
+		// INotebookService, which RuntimeNotebookKernelService looks it up in
+		// when a kernel is selected.
+		const notebookService = ctx.instantiationService.get(INotebookService);
+		vi.spyOn(notebookService, 'getNotebookTextModel').mockReturnValue(notebook.textModel);
+
+		notebookKernelService.selectKernelForNotebook(
+			kernel, { uri: notebook.uri, notebookType: notebook.viewType });
+		expect(notebook.kernel.get()).toBe(kernel);
+	});
+
+	/** Starts a notebook session for the notebook and lets its start complete. */
+	async function startNotebookSession(): Promise<TestLanguageRuntimeSession> {
+		const session = await startTestLanguageRuntimeSession(
+			ctx.instantiationService,
+			ctx.disposables,
+			{
+				runtime,
+				notebookUri: notebook.uri,
+				sessionName: runtime.runtimeName,
+				sessionMode: LanguageRuntimeSessionMode.Notebook,
+				startReason: 'Test requested a notebook session',
+			});
+		session.setRuntimeState(RuntimeState.Ready);
+		expect(notebook.runtimeSession.get()).toBe(session);
+		return session;
+	}
+
+	it('stays attached when the restart exit arrives before the new kernel starts', async () => {
+		const session = await startNotebookSession();
+
+		session.setRuntimeState(RuntimeState.Exited);
+		session.endSession({ reason: RuntimeExitReason.Restart });
+		session.setRuntimeState(RuntimeState.Starting);
+		session.setRuntimeState(RuntimeState.Ready);
+
+		expect(notebook.runtimeSession.get()).toBe(session);
+	});
+
+	it('stays attached when the restart exit arrives after the new kernel starts', async () => {
+		const session = await startNotebookSession();
+
+		session.setRuntimeState(RuntimeState.Exited);
+		session.setRuntimeState(RuntimeState.Starting);
+		// The exit of the previous kernel lands late, after the replacement has
+		// already begun starting and the notebook has re-attached.
+		session.endSession({ reason: RuntimeExitReason.Restart });
+		session.setRuntimeState(RuntimeState.Ready);
+
+		// Detaching here leaves the badge showing "Disconnected" for a session
+		// that is online, with nothing left to trigger a re-attach.
+		expect(notebook.runtimeSession.get()).toBe(session);
+	});
+
+	it('detaches when the session ends for good', async () => {
+		const session = await startNotebookSession();
+
+		session.setRuntimeState(RuntimeState.Exited);
+		session.endSession({ reason: RuntimeExitReason.Shutdown });
+
+		expect(notebook.runtimeSession.get()).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Addresses another bit of #10016, the notebook half of what #15172 fixed for the console.

### Summary
A kernel restart produces two independent signals whose order isn't guaranteed: the replacement kernel's `starting` status and the outgoing kernel's `Restart` exit. When `starting` wins, the notebook re-attaches to the same session, and the late exit then tore that attachment down with nothing left to re-attach it, leaving the kernel status badge stuck on "Disconnected".

- Ignore a `Restart` exit in `PositronNotebookInstance` when the session is no longer `Exited`
- Mirrors the guard `positronConsoleService` got in #15172
- Adds `notebookRestartOrdering.vitest.ts` covering both orderings plus a real shutdown

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix the notebook kernel status badge staying on "Disconnected" after a kernel restart (#10016)

### Validation Steps

@:positron-notebooks @:sessions @:web @:win

Restart the kernel from a Positron notebook repeatedly and verify the badge returns to idle each time.


### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- PR #15172 fixed the supervisor half of the restart exited/starting reorder race, but PositronNotebookInstance has the identical race one layer up. When 'starting' wins, the session's late onDidEndSession teardown lands AFTER _maybeAttachSession has already re-attached the same session object, so runtimeSession is set back to undefined. With no later re-attach trigger, useSessionRuntimeState never subscribes and KernelStatusBadge renders Disconnected indefinitely, timing out the 30s idle-icon assertion inside restart({waitForRestart:true}).</summary>

- **Test:** [Positron Notebooks: Kernel Behavior > ensure variable and output persistence after kernel restart](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Positron%20Notebooks%3A%20Kernel%20Behavior%20%3E%20ensure%20variable%20and%20output%20persistence%20after%20kernel%20restart%7C%7C%7Ctest%2Fe2e%2Ftests%2Fnotebooks-positron%2Fnotebook-kernel-behavior.test.ts)
- **Targeted failure:** Pattern A: expect(.editor-action-bar-container >> .codicon-positron-runtime-status-idle).toBeVisible() 30s timeout inside notebooksPositron.kernel.restart({waitForRestart:true}); 4/31 (12.9%) on ubuntu/electron in the 2 days AFTER #15172 merged.
- **Signal:** Run 30492492457, sha d3972b0e (2026-07-29, ~29h after #15172 merged bb705a82). R Supervisor.log: 'status: starting' 22:33:08.962 BEFORE 'exited:0' 22:33:08.966, and the supervisor logged 'Kernel exited with code 0; waiting for restart to finish' -- no 'cleaning up.', no 'Websocket closed with kernel in status starting', no disconnect/reconnect; State: exited => starting => idle => ready (restart complete) at 22:33:09.375, i.e. #15172 is working. renderer.log brackets the re-attach with two teardowns: 'Notebook session for <uri> exited.' 08.965 -> 'Already attached to session, disposing existing listeners before reattaching: r-notebook-aef35087' 08.966 -> 'Could not find a notebook editor' 08.966 -> 'Lookup ...: not found' 08.966 -> 'Notebook session for <uri> exited.' 08.971 (onDidEndSession, LATE). grep count of 'Unexpected session started' = 0, proving _maybeAttachSession did NOT bail and did re-attach. Trace: same idle locator PASSED earlier in the same run at t=1832827; failing expect t=1837506 after Restart Kernel click t=1837397, screenshot t=1867538 shows variables cleared + outputs persisted + badge not idle.
- **Frequency:** 4/31 runs (12.9%) on main, ubuntu/electron
- **Hypothesis:** Notebook frontend teardown/attach ordering race (root cause). PositronNotebookInstance._maybeAttachSession (PositronNotebookInstance.ts:2247-2257) sets kernelStatus=Connected and runtimeSession=session, then registers session.onDidEndSession on this._register (the instance store, not the per-attach disposables). An in-place restart reuses the SAME session object, so on the exited-after-starting reorder the teardown callback runs after the re-attach and does runtimeSession.set(undefined). No later trigger re-runs _maybeAttachSession, so KernelStatusBadge (KernelStatusBadge.tsx:41-69,116-119) -> useSessionRuntimeState (useSessionRuntimeState.tsx:19-45) never subscribes and RuntimeStatusIcon renders Disconnected forever. Under the normal exited-first order the teardown runs before the re-attach and the badge recovers, which is why this is intermittent.
- **Supersedes:** Round 1 (2026-07-24) diagnosis of the supervisor socket-close race, fixed by #15172 (PR #15114 closed in its favor). That fix is confirmed working; this is the unfixed frontend half that round 1 deferred as a 'DEFENSIVE (frontend, larger, separate)' follow-up.

</details>
