### PR TITLE
Compile prerequisite extensions before starting watchers in watch-extensions

### DIFF
--- a/build/gulpfile.extensions.ts
+++ b/build/gulpfile.extensions.ts
@@ -251,8 +251,12 @@ const tasks = compilations.map(function (tsconfigFile) {
 		await Promise.all([copyNonTs, tsgo]);
 	}));
 
-	const watchTask = task.define(`watch-extension:${name}`, task.series(cleanTask, () => {
-		// --- Start Positron ---
+	// --- Start Positron ---
+	// The watch stream is extracted from `watchTask` so it can also run without the upstream clean
+	// step. `watch-extensions` compiles a few in-repo packages up front (see `watchExtensionsImpl`
+	// below); cleaning out/ in those packages' watchers would delete the .d.ts files their dependent
+	// extensions are about to resolve.
+	const createWatchStream = () => {
 		const nonts = gulp.src(src, srcOpts).pipe(filter(['**', '!**/*.ts', '!**/*.tsx'], { dot: true }));
 
 		// The Python extension's integration tests create and delete directories in a way that
@@ -272,7 +276,6 @@ const tasks = compilations.map(function (tsconfigFile) {
 
 		const watchInput = watcher(src, { ...srcOpts, ...{ ignored, readDelay: 200 } });
 		const watchNonTs = watchInput.pipe(filter(['**', '!**/*.ts', '!**/*.tsx'], { dot: true })).pipe(gulp.dest(out));
-		// --- End Positron ---
 		const tsgoStream = watchInput.pipe(util.debounce(() => {
 			onExtensionCompilationStart();
 			const stream = createTsgoStream(absolutePath, { taskName: 'extensions' }, () => rewriteTsgoSourceMappingUrlsIfNeeded(false, out, baseUrl));
@@ -295,14 +298,20 @@ const tasks = compilations.map(function (tsconfigFile) {
 		const watchStream = es.merge(nonts.pipe(gulp.dest(out)), watchNonTs, tsgoStream);
 
 		return watchStream;
-	}));
+	};
+
+	const watchTask = task.define(`watch-extension:${name}`, task.series(cleanTask, createWatchStream));
+	const watchTaskNoClean = task.define(`watch-extension-no-clean:${name}`, createWatchStream);
+	// --- End Positron ---
 
 	// Tasks
 	task.task(transpileTask);
 	task.task(compileTask);
 	task.task(watchTask);
 
-	return { transpileTask, compileTask, watchTask };
+	// --- Start Positron ---
+	return { transpileTask, compileTask, watchTask, watchTaskNoClean };
+	// --- End Positron ---
 });
 
 const transpileExtensionsTask = task.define('transpile-extensions', task.parallel(...tasks.map(t => t.transpileTask)));
@@ -331,7 +340,20 @@ export const compileExtensionsTask = task.define('compile-extensions', compileEx
 // --- End Positron ---
 task.task(compileExtensionsTask);
 
-export const watchExtensionsTask = task.define('watch-extensions', task.parallel(...tasks.map(t => t.watchTask)));
+// --- Start Positron ---
+// The same prerequisite ordering as `compile-extensions` above, adapted for watch mode. Watchers are
+// long-lived, so they cannot be sequenced with each other; instead compile the prerequisites to
+// completion first, then start every watcher in parallel, with the prerequisites' watchers skipping
+// the clean step so they do not delete the out/ that was just produced for their dependents.
+// export const watchExtensionsTask = task.define('watch-extensions', task.parallel(...tasks.map(t => t.watchTask)));
+const watchExtensionsImpl = orderedPrerequisites.length > 0
+	? task.series(
+		...orderedPrerequisites.map(index => tasks[index].compileTask),
+		task.parallel(...tasks.map((t, index) => prerequisiteIndexSet.has(index) ? t.watchTaskNoClean : t.watchTask))
+	)
+	: task.parallel(...tasks.map(t => t.watchTask));
+export const watchExtensionsTask = task.define('watch-extensions', watchExtensionsImpl);
+// --- End Positron ---
 task.task(watchExtensionsTask);
 
 //#region Extension media


### PR DESCRIPTION
### Problem

Ext - Build Task is red almost all the time

<p>
<img width="245" height="181" alt="Ext - Build Task" src="https://github.com/user-attachments/assets/93505ae0-095a-480f-8344-c7a6c3d07ddc" />
</p>

### Fix

Apply the same prerequisite ordering that `compile-extensions` already uses to `watch-extensions`.

### Summary

`watch-extensions` started every extension watcher in parallel, so extensions that consume an in-repo package's compiled `out/` (currently `positron-data-explorer-duckdb` -> `positron-data-explorer-protocol`) could race: a watcher's clean step deletes `out/` while a dependent is already resolving its `.d.ts` files. This compiles the ordered prerequisites to completion first, then starts all watchers in parallel. Since watchers are long-lived, they can't be sequenced with each other, so the prerequisites' watchers use a new `watch-extension-no-clean:<name>` variant that skips the clean step and preserves the `out/` that was just built for their dependents. The watch stream body is extracted into a `createWatchStream()` helper so both variants share it; no behavior change for extensions that aren't prerequisites.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

Build-only change, no e2e coverage applies.

1. From a clean tree (`git clean -xfd extensions/positron-data-explorer-*/out` or equivalent), run `npm run watch-extensions`.
2. Verify `positron-data-explorer-protocol` and `positron-data-explorer-duckdb` compile before the remaining watchers start, and that no `Cannot find module`/unresolved-import errors appear for the DuckDB backend.
3. Edit a file in each of those two extensions and confirm the watcher still picks up the change and recompiles.
4. Confirm `npm run compile-extensions` is unchanged.
