### PR TITLE
python: remove check for build-system in pyproject.toml

### DIFF
--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/venvUtils.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/venvUtils.ts
@@ -57,10 +57,6 @@ function tomlParse(content: string): tomljs.JsonMap {
     return {};
 }
 
-function tomlHasBuildSystem(toml: tomljs.JsonMap): boolean {
-    return toml['build-system'] !== undefined;
-}
-
 function tomlHasProject(toml: tomljs.JsonMap): boolean {
     return toml.project !== undefined;
 }
@@ -143,7 +139,7 @@ async function pickRequirementsFiles(
 
 export function isPipInstallableToml(tomlContent: string): boolean {
     const toml = tomlParse(tomlContent);
-    return tomlHasBuildSystem(toml) && tomlHasProject(toml);
+    return tomlHasProject(toml);
 }
 
 export interface IPackageInstallSelection {
@@ -165,20 +161,15 @@ export async function pickPackagesToInstall(
             traceVerbose(`Looking for toml pyproject.toml with optional dependencies at: ${tomlPath}`);
 
             let extras: string[] = [];
-            let hasBuildSystem = false;
             let hasProject = false;
 
             if (await fs.pathExists(tomlPath)) {
                 const toml = tomlParse(await fs.readFile(tomlPath, 'utf-8'));
                 extras = getTomlOptionalDeps(toml);
-                hasBuildSystem = tomlHasBuildSystem(toml);
                 hasProject = tomlHasProject(toml);
 
                 if (!hasProject) {
                     traceVerbose('Create env: Found toml without project. So we will not use editable install.');
-                }
-                if (!hasBuildSystem) {
-                    traceVerbose('Create env: Found toml without build system. So we will not use editable install.');
                 }
                 if (extras.length === 0) {
                     traceVerbose('Create env: Found toml without optional dependencies.');
@@ -188,7 +179,7 @@ export async function pickPackagesToInstall(
                 return MultiStepAction.Back;
             }
 
-            if (hasBuildSystem && hasProject) {
+            if (hasProject) {
                 if (extras.length > 0) {
                     traceVerbose('Create Env: Found toml with optional dependencies.');
 
@@ -218,7 +209,7 @@ export async function pickPackagesToInstall(
                     packages.push({ installType: 'toml', source: tomlPath });
                 }
             } else if (context === MultiStepAction.Back) {
-                // This step is not really used because there is no build system in toml, so just go back
+                // This step is not really used because there is no project in toml, so just go back
                 return MultiStepAction.Back;
             }
 

--- a/extensions/positron-python/src/test/pythonEnvironments/creation/provider/venvUtils.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/creation/provider/venvUtils.unit.test.ts
@@ -54,14 +54,19 @@ suite('Venv Utils test', () => {
         assert.deepStrictEqual(actual, []);
     });
 
-    test('Toml found with no build system', async () => {
+    test('Toml found with project but no build system', async () => {
         findFilesStub.resolves([]);
         pathExistsStub.resolves(true);
         readFileStub.resolves('[project]\nname = "spam"\nversion = "2020.0.0"\n');
 
         const actual = await pickPackagesToInstall(workspace1);
         assert.isTrue(showQuickPickWithBackStub.notCalled);
-        assert.deepStrictEqual(actual, []);
+        assert.deepStrictEqual(actual, [
+            {
+                installType: 'toml',
+                source: path.join(workspace1.uri.fsPath, 'pyproject.toml'),
+            },
+        ]);
     });
 
     test('Toml found with no project table', async () => {

--- a/extensions/positron-python/src/test/pythonEnvironments/creation/pyProjectTomlContext.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/creation/pyProjectTomlContext.unit.test.ts
@@ -39,7 +39,7 @@ function getNonInstallableToml(): typemoq.IMock<TextDocument> {
     pyprojectToml.setup((p) => p.fileName).returns(() => pyprojectTomlPath);
     pyprojectToml
         .setup((p) => p.getText(typemoq.It.isAny()))
-        .returns(() => '[project]\nname = "spam"\nversion = "2020.0.0"\n');
+        .returns(() => '[tool.poetry]\nname = "spam"\nversion = "2020.0.0"\n');
     return pyprojectToml;
 }
 


### PR DESCRIPTION
Fixes #15167

Positron only offered to create an environment for a `pyproject.toml` when it had both a `[project]` table and a `[build-system]` table. Many `pyproject.toml` files (e.g. those generated by `uv init`) omit `[build-system]`, so Positron silently skipped the create-environment prompt and the pip-install-from-pyproject.toml flow entirely. `isPipInstallableToml()` now only requires `[project]`.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix Positron not offering to create an environment for a `pyproject.toml` without a `[build-system]` table (#15167)

### Validation Steps

@:interpreter

1. Create a new empty folder containing just a `pyproject.toml` with a `[project]` table and no `[build-system]` table, e.g.:
   ```toml
   [project]
   name = "test"
   version = "0.1.0"
   dependencies = ["pandas"]
   ```
2. Open the folder in Positron with no interpreter or venv previously selected for it.
3. Verify Positron now offers to create an environment.
4. Accept the prompt and verify the dependencies from `pyproject.toml` are installed into the new environment.