### PR TITLE
skill(triage-e2e-test): score post-fix evidence instead of assuming it

### DIFF
--- a/.claude/skills/triage-e2e-test/SKILL.md
+++ b/.claude/skills/triage-e2e-test/SKILL.md
@@ -95,6 +95,9 @@ saved data is invalid, or the branch/test identity changed.
      --occurrence-shas '["<sha1>","<sha2>"]'
    ```
    A non-`none` verdict changes the plan -- read [`references/prior-triage.md`](references/prior-triage.md).
+   `none` is not conclusive -- it matches spec paths, so a POM/helper-only fix
+   never registers. If the failing locator is gone from the working tree, read
+   that file anyway.
    `open-attempt-in-flight` means stop and point at the open PR.
 6. **Present the failure modes as a table** (never a run-on sentence). The Rate
    column comes from each pattern's `rates` array, never `count / totalRuns`;

--- a/.claude/skills/triage-e2e-test/SKILL.md
+++ b/.claude/skills/triage-e2e-test/SKILL.md
@@ -33,7 +33,8 @@ only when a stage needs them.
   step (below). Keep large output on disk, not in the conversation.
 - **Never** increase a timeout or add an arbitrary wait as the fix.
 - **Never** claim a flaky test is fixed on one green run.
-- A previous merged fix must be checked against subsequent failures.
+- A previous merged fix must be checked against subsequent failures, and that
+  check reported as four lines, not a triage report (`references/prior-triage.md`).
 - Root-cause claims cite observed evidence and the alternatives ruled out.
 - Checkpoint at every phase transition.
 

--- a/.claude/skills/triage-e2e-test/references/prior-triage.md
+++ b/.claude/skills/triage-e2e-test/references/prior-triage.md
@@ -31,6 +31,45 @@ pattern's occurrences all predating a fix, another's all postdating it -- that
 split **is** the diagnosis: the predating pattern is old news, the postdating
 one is what's still live. Lead with the split.
 
+## When `none` is not proof there was no prior fix
+
+The script matches **spec paths** in PR bodies. A fix that only touched a POM,
+fixture, or helper never names the spec, so it returns `none` while a merged fix
+exists. Whenever the failing locator or helper is **absent from the working
+tree**, it was replaced -- find by what, before trusting `none`:
+
+```bash
+git log --oneline -S'<failing locator or helper name>' -- test/e2e/
+```
+
+## Verifying a suspected fix by hand
+
+1. **Get every failure SHA.** `triage-history.js` keeps 1; the API allows 20.
+   Above 20 it returns 400 and leaves the *previous* raw JSON in place, which
+   reads as "the API only has one occurrence" -- it doesn't.
+   ```bash
+   node .claude/skills/e2e-failure-analyzer/scripts/e2e-query-history.js \
+     --repo positron --test-keys '["<key>"]' --branch main \
+     --lookback-days 14 --occurrences-per-pattern 20
+   ```
+2. **Partition them:** `git merge-base --is-ancestor <fixSha> <occSha>` per SHA.
+3. **Bracket the onset:** sweep `--lookback-days` (2/3/6/8/11/14). The smallest
+   window where the count saturates brackets it; clean runs in the window
+   immediately before a suspected regressor confirm it.
+4. **Get the denominator.** The API returns SHAs for failures only, so count
+   post-fix runs from CI instead:
+   ```bash
+   gh api 'repos/posit-dev/positron/actions/runs?branch=main&created=>=<YYYY-MM-DD>' \
+     --jq '.workflow_runs[] | select(.name=="Test: Merge to branch")
+           | [.head_sha, .created_at, (.conclusion//"running")] | @tsv'
+   ```
+   Exclude in-flight runs. A workflow `conclusion` of `failure` is the whole
+   suite, not this test -- it is not an occurrence.
+5. **State sufficiency as a number.** Zero failures in N post-fix runs at
+   baseline rate p is only worth `(1-p)^N`: at p~0.5, N=4 is ~0.06 --
+   suggestive, not proof. Report the figure and what N would settle it. Never
+   call a fix closed on a handful of green runs.
+
 ## Supersedes
 
 If a merged fix didn't hold (`recurred-after-fix`), the eventual diagnosis block

--- a/.claude/skills/triage-e2e-test/references/prior-triage.md
+++ b/.claude/skills/triage-e2e-test/references/prior-triage.md
@@ -12,8 +12,8 @@ partition; this file explains how to act on its verdict.
 | `none` | no PR body names this spec path | nothing to reconcile; proceed normally |
 | `open-attempt-in-flight` | an unmerged PR already diagnoses this test | **stop.** Point the engineer at the open PR (`openAttempts[].url`) instead of starting a parallel diagnosis |
 | `recurred-after-fix` | occurrences post-date a merged fix's commit | lead with this. Treat the prior hypothesis as **ruled out**, not a guess to re-test -- start from "why didn't that fix hold," not from re-deriving the same mechanism |
-| `fix-holding` | a merged fix exists, no occurrences post-date it, enough runs since | the fix looks like it held; say so, and check whether the live pattern is a different failure mode than the one it closed |
-| `too-recent-to-tell` | merged fix is very recent, few/no runs since | say so explicitly; do not declare success or failure prematurely |
+| `fix-holding` | a merged fix exists, no occurrences post-date it, and enough post-fix runs in the failing lane to mean something | the fix looks like it held; quote `sufficiency.probabilityIfUnfixed`, and check whether the live pattern is a different failure mode than the one it closed |
+| `too-recent-to-tell` | too few post-fix runs to judge -- **including none supplied at all** | say so explicitly; do not declare success or failure prematurely. `sufficiency.runsNeeded` is how many clean runs would settle it |
 
 ## Reading `mergedAttempts[]`
 
@@ -33,42 +33,30 @@ one is what's still live. Lead with the split.
 
 ## When `none` is not proof there was no prior fix
 
-The script matches **spec paths** in PR bodies. A fix that only touched a POM,
-fixture, or helper never names the spec, so it returns `none` while a merged fix
-exists. Whenever the failing locator or helper is **absent from the working
-tree**, it was replaced -- find by what, before trusting `none`:
+The search matches **spec paths** in PR bodies, so a fix that only touched a POM,
+fixture, or helper never registers. If the failing locator is absent from the
+working tree it was replaced -- find by what, then re-run with `--fix-sha` so the
+ancestry partition and verdict still apply:
 
 ```bash
-git log --oneline -S'<failing locator or helper name>' -- test/e2e/
+git log --oneline -S'<failing locator or helper>' -- test/e2e/
 ```
 
-## Verifying a suspected fix by hand
+## Judging whether a fix held
 
-1. **Get every failure SHA.** `triage-history.js` keeps 1; the API allows 20.
-   Above 20 it returns 400 and leaves the *previous* raw JSON in place, which
-   reads as "the API only has one occurrence" -- it doesn't.
-   ```bash
-   node .claude/skills/e2e-failure-analyzer/scripts/e2e-query-history.js \
-     --repo positron --test-keys '["<key>"]' --branch main \
-     --lookback-days 14 --occurrences-per-pattern 20
-   ```
-2. **Partition them:** `git merge-base --is-ancestor <fixSha> <occSha>` per SHA.
-3. **Bracket the onset:** sweep `--lookback-days` (2/3/6/8/11/14). The smallest
-   window where the count saturates brackets it; clean runs in the window
-   immediately before a suspected regressor confirm it.
-4. **Get the denominator.** The API returns SHAs for failures only, so count
-   post-fix runs from CI instead:
-   ```bash
-   gh api 'repos/posit-dev/positron/actions/runs?branch=main&created=>=<YYYY-MM-DD>' \
-     --jq '.workflow_runs[] | select(.name=="Test: Merge to branch")
-           | [.head_sha, .created_at, (.conclusion//"running")] | @tsv'
-   ```
-   Exclude in-flight runs. A workflow `conclusion` of `failure` is the whole
-   suite, not this test -- it is not an occurrence.
-5. **State sufficiency as a number.** Zero failures in N post-fix runs at
-   baseline rate p is only worth `(1-p)^N`: at p~0.5, N=4 is ~0.06 --
-   suggestive, not proof. Report the figure and what N would settle it. Never
-   call a fix closed on a handful of green runs.
+Occurrence SHAs are the numerator only. Pass `--post-fix-runs` (and
+`--baseline-rate` from the pattern's `rates[]`) to get a scored `sufficiency`
+object; without a denominator the verdict is `too-recent-to-tell` by
+construction, never `fix-holding`. Read three fields off it:
+
+- `probabilityIfUnfixed` -- `(1-p)^N`: how often that clean streak happens by
+  luck anyway. Quote it. At p~0.5, N=4 is ~0.06: suggestive, not proof.
+- `runsNeeded` -- clean runs required to clear the bar. A rare flake needs far
+  more than a frequent one, so this is what "check back later" should mean.
+- `scopeWarning` -- set when `--environment` was omitted. Both numbers must
+  describe **one** os/browser lane; a test-health `total_runs` spans them all,
+  and mixing it with a lane-specific rate inflates N and clears the bar on runs
+  that never exercised the failing lane.
 
 ## Supersedes
 

--- a/.claude/skills/triage-e2e-test/references/prior-triage.md
+++ b/.claude/skills/triage-e2e-test/references/prior-triage.md
@@ -60,6 +60,20 @@ construction, never `fix-holding`. Read three fields off it:
   and mixing it with a lane-specific rate inflates N and clears the bar on runs
   that never exercised the failing lane.
 
+## Reporting the check
+
+A fix-held check is a status line, not a triage report. The engineer already
+knows the mechanism, so restating the diagnosis, the failure-mode table, the
+onset commit, or how you counted is noise. Four lines, in this order:
+
+1. **Verdict** -- holding / too early / recurred, in a few words.
+2. **Evidence** -- clean post-fix runs against `runsNeeded`, plus
+   `probabilityIfUnfixed` phrased as "happens by luck X% of the time anyway".
+3. **When it settles** -- the remaining runs, in wall-clock time.
+4. **Action** -- usually "nothing to do"; on `recurred`, the next step.
+
+Add nothing else unless asked.
+
 ## Supersedes
 
 If a merged fix didn't hold (`recurred-after-fix`), the eventual diagnosis block

--- a/.claude/skills/triage-e2e-test/references/prior-triage.md
+++ b/.claude/skills/triage-e2e-test/references/prior-triage.md
@@ -53,6 +53,8 @@ construction, never `fix-holding`. Read three fields off it:
   luck anyway. Quote it. At p~0.5, N=4 is ~0.06: suggestive, not proof.
 - `runsNeeded` -- clean runs required to clear the bar. A rare flake needs far
   more than a frequent one, so this is what "check back later" should mean.
+  Very sensitive to `p` -- one real triage needed 4 runs at a 54% burst rate but
+  15 at the 19% lookback rate. Feed the lookback rate from `rates[]`; say which.
 - `scopeWarning` -- set when `--environment` was omitted. Both numbers must
   describe **one** os/browser lane; a test-health `total_runs` spans them all,
   and mixing it with a lane-specific rate inflates N and clears the bar on runs

--- a/.claude/skills/triage-e2e-test/scripts/find-prior-triage.js
+++ b/.claude/skills/triage-e2e-test/scripts/find-prior-triage.js
@@ -14,12 +14,21 @@
 // Options:
 //   --spec-path <path>           exact spec path from the test key  [required]
 //   --occurrence-shas <json>     JSON array of occurrence SHAs to test for ancestry
+//   --fix-sha <sha>              treat this commit as a merged fix even if no PR
+//                                body names the spec (POM/helper-only fixes)
+//   --post-fix-runs <n>          CI runs of this test since the fix -- the
+//                                denominator, without which "held" is unprovable
+//   --baseline-rate <p>          pre-fix per-run failure rate (0-1), to score how
+//                                much a clean post-fix streak is actually worth
+//   --environment <os/browser>   lane both numbers above describe (e.g.
+//                                ubuntu/chromium); omitting it warns, since an
+//                                all-env run total inflates the denominator
 //   --repo <owner/repo>          default: posit-dev/positron
 //   --triage-id <id>             work-dir id  [required for disk output]
 //   --limit <n>                  PR search limit (default: 50)
 //
-// Output (stdout): compact JSON { openAttempts[], mergedAttempts[], verdict,
-//   rawResultFile }. Exit 0; on gh failure prints { error }.
+// Output (stdout): compact JSON { openAttempts[], mergedAttempts[], sufficiency,
+//   verdict, rawResultFile }. Exit 0; on gh failure prints { error }.
 
 import path from 'path';
 import {
@@ -49,10 +58,51 @@ export function extractDiagnosisFields(body) {
 }
 
 /**
+ * Score whether a clean post-fix streak is strong enough to call a fix held.
+ *
+ * Absence of post-fix failures is only evidence in proportion to how many runs
+ * produced it: at a baseline failure rate `p`, N clean runs would happen by luck
+ * with probability `(1-p)^N` even if nothing were fixed. Without a denominator
+ * at all, a clean streak is worth nothing, so `postFixRuns: null` is never
+ * meaningful -- that is the difference between "no failures seen" and "held".
+ *
+ * Both numbers must describe the SAME single environment. Most flakes are
+ * environment-specific, and pairing an env-specific rate with an all-env run
+ * total inflates N (a test-health `total_runs` spans every os/browser lane), which
+ * shrinks `(1-p)^N` and clears the bar on runs that never exercised the failing
+ * lane. `environment` is recorded so the verdict is self-describing, and its
+ * absence raises `scopeWarning` rather than being silently assumed safe.
+ *
+ * @param {{postFixRuns: number|null, baselineRate: number|null, environment?: string|null,
+ *          alpha?: number, floor?: number}} o
+ * @returns {{meaningful: boolean, postFixRuns: number|null, baselineRate: number|null,
+ *            environment: string|null, scopeWarning: string|null,
+ *            probabilityIfUnfixed: number|null, runsNeeded: number|null}}
+ */
+export function assessSufficiency({ postFixRuns, baselineRate, environment = null, alpha = 0.05, floor = 10 }) {
+	const n = Number.isFinite(postFixRuns) ? postFixRuns : null;
+	const p = Number.isFinite(baselineRate) && baselineRate > 0 && baselineRate < 1 ? baselineRate : null;
+	const scopeWarning = (n !== null && !environment)
+		? 'postFixRuns/baselineRate have no --environment: confirm both describe one os/browser lane, not an all-env total.'
+		: null;
+	const base = { postFixRuns: n, baselineRate: p, environment: environment || null, scopeWarning };
+	if (n === null) {
+		return { ...base, meaningful: false, probabilityIfUnfixed: null, runsNeeded: null };
+	}
+	if (p === null) {
+		// No baseline to score against: fall back to a plain run-count floor.
+		return { ...base, meaningful: n >= floor, probabilityIfUnfixed: null, runsNeeded: floor };
+	}
+	const probabilityIfUnfixed = Math.pow(1 - p, n);
+	const runsNeeded = Math.ceil(Math.log(alpha) / Math.log(1 - p));
+	return { ...base, meaningful: probabilityIfUnfixed <= alpha, probabilityIfUnfixed, runsNeeded };
+}
+
+/**
  * Derive the overall reconciliation verdict from the classified attempts.
  * afterFixCount is the number of supplied occurrences that post-date the most
- * recent merged fix; runsMeaningful signals whether enough runs have accrued
- * since the merge to judge "held".
+ * recent merged fix; runsMeaningful comes from `assessSufficiency` and is true
+ * only when enough post-fix runs have accrued to judge "held".
  */
 export function deriveVerdict({ openAttempts, mergedAttempts, afterFixCount, runsMeaningful }) {
 	if (openAttempts.length > 0) { return 'open-attempt-in-flight'; }
@@ -112,6 +162,10 @@ function main() {
 	if (args['occurrence-shas']) {
 		try { shas = JSON.parse(args['occurrence-shas']); } catch { fail('--occurrence-shas must be a JSON array.'); }
 	}
+	const fixSha = args['fix-sha'] || null;
+	const postFixRuns = args['post-fix-runs'] === undefined ? null : Number(args['post-fix-runs']);
+	const baselineRate = args['baseline-rate'] === undefined ? null : Number(args['baseline-rate']);
+	const environment = args.environment || null;
 
 	const search = ghSearch(repo, limit);
 	if (!search.ok) { fail(`gh search failed: ${search.stderr}`, { triageId }); }
@@ -136,15 +190,28 @@ function main() {
 		});
 	}
 
-	const afterFixCount = mergedAttempts.reduce((n, m) => n + m.afterFixFailureCount, 0);
-	// We can only tell whether a merged fix held by checking occurrence SHAs for
-	// ancestry against the merge commit. With none supplied (--occurrence-shas
-	// omitted) there's nothing to check, so the verdict is too-recent-to-tell
-	// rather than a false "fix-holding".
-	const runsMeaningful = shas.length > 0;
-	const verdict = deriveVerdict({ openAttempts, mergedAttempts, afterFixCount, runsMeaningful });
+	// A fix that only touched a POM, fixture, or helper never names the spec, so
+	// the search above misses it entirely. --fix-sha lets the caller supply it so
+	// the ancestry partition and verdict still apply.
+	if (fixSha && mergedAttempts.length === 0) {
+		const anc = ancestryAfterFix(fixSha, shas);
+		mergedAttempts.push({
+			number: null, url: null, mergedAt: null, mergeSha: fixSha,
+			hypothesis: null, targetedFailure: null, confidence: null,
+			source: 'fix-sha-override',
+			afterFixShas: anc.afterFix, beforeFixShas: anc.beforeFix, unknownShas: anc.unknown,
+			afterFixFailureCount: anc.afterFix.length,
+		});
+	}
 
-	const result = { specPath, openAttempts, mergedAttempts, verdict };
+	const afterFixCount = mergedAttempts.reduce((n, m) => n + m.afterFixFailureCount, 0);
+	// Occurrence SHAs supply the numerator only. Judging "held" needs the
+	// denominator too -- how many runs produced the clean streak -- so an absent
+	// --post-fix-runs yields too-recent-to-tell, never a false "fix-holding".
+	const sufficiency = assessSufficiency({ postFixRuns, baselineRate, environment });
+	const verdict = deriveVerdict({ openAttempts, mergedAttempts, afterFixCount, runsMeaningful: sufficiency.meaningful });
+
+	const result = { specPath, openAttempts, mergedAttempts, sufficiency, verdict };
 
 	let rawResultFile = null;
 	if (triageId) {

--- a/.claude/skills/triage-e2e-test/scripts/test/prior-triage-lib.test.js
+++ b/.claude/skills/triage-e2e-test/scripts/test/prior-triage-lib.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { bodyNamesSpec, extractDiagnosisFields, deriveVerdict } from '../find-prior-triage.js';
+import { bodyNamesSpec, extractDiagnosisFields, deriveVerdict, assessSufficiency } from '../find-prior-triage.js';
 
 test('bodyNamesSpec filters by exact spec path', () => {
 	const body = 'blah\n- **Spec:** `test/e2e/tests/data-explorer.test.ts`\nblah';
@@ -44,4 +44,47 @@ test('deriveVerdict: fix holding vs too-recent', () => {
 
 test('deriveVerdict: nothing found', () => {
 	assert.equal(deriveVerdict({ openAttempts: [], mergedAttempts: [], afterFixCount: 0, runsMeaningful: true }), 'none');
+});
+
+test('assessSufficiency: no denominator is never meaningful', () => {
+	// The regression this guards: a clean streak over an unknown number of runs
+	// used to read as "fix-holding" off a single supplied occurrence SHA.
+	assert.deepEqual(assessSufficiency({ postFixRuns: null, baselineRate: 0.5 }), {
+		meaningful: false, postFixRuns: null, baselineRate: 0.5,
+		environment: null, scopeWarning: null,
+		probabilityIfUnfixed: null, runsNeeded: null,
+	});
+});
+
+test('assessSufficiency: scores a clean streak against the baseline rate', () => {
+	// 4 clean runs at a 50% baseline is ~6% -- suggestive, short of the 5% bar.
+	const four = assessSufficiency({ postFixRuns: 4, baselineRate: 0.5 });
+	assert.deepEqual(
+		[four.meaningful, Number(four.probabilityIfUnfixed.toFixed(4)), four.runsNeeded],
+		[false, 0.0625, 5]
+	);
+	assert.equal(assessSufficiency({ postFixRuns: 5, baselineRate: 0.5 }).meaningful, true);
+	// A rare flake needs far more clean runs to clear the same bar.
+	assert.equal(assessSufficiency({ postFixRuns: 5, baselineRate: 0.02 }).runsNeeded, 149);
+});
+
+test('assessSufficiency: warns when the numbers have no environment scope', () => {
+	// Most flakes are lane-specific; an all-env run total inflates N and would
+	// clear the bar on runs that never exercised the failing lane.
+	assert.match(assessSufficiency({ postFixRuns: 5, baselineRate: 0.5 }).scopeWarning, /--environment/);
+	assert.deepEqual(
+		(({ environment, scopeWarning }) => ({ environment, scopeWarning }))(
+			assessSufficiency({ postFixRuns: 5, baselineRate: 0.5, environment: 'ubuntu/chromium' })
+		),
+		{ environment: 'ubuntu/chromium', scopeWarning: null }
+	);
+	// Nothing to mis-scope when there is no denominator at all.
+	assert.equal(assessSufficiency({ postFixRuns: null, baselineRate: 0.5 }).scopeWarning, null);
+});
+
+test('assessSufficiency: falls back to a run floor without a baseline', () => {
+	assert.equal(assessSufficiency({ postFixRuns: 9, baselineRate: null }).meaningful, false);
+	assert.equal(assessSufficiency({ postFixRuns: 10, baselineRate: null }).meaningful, true);
+	// Out-of-range rates are treated as absent rather than trusted.
+	assert.equal(assessSufficiency({ postFixRuns: 10, baselineRate: 1 }).baselineRate, null);
 });


### PR DESCRIPTION
### Summary
`find-prior-triage.js` computed `runsMeaningful` as `shas.length > 0` -- a presence check, not the sufficiency test its doc claimed. With `triage-history.js` keeping one occurrence by default, `fix-holding` could fire off a single pre-fix SHA and no denominator at all. Also pins how a fix-held re-check is reported.

- Replace it with `assessSufficiency`: `(1-p)^N` against a real post-fix run count, so an absent denominator yields `too-recent-to-tell` by construction
- Require `--environment`, since pairing a lane-specific rate with an all-env `total_runs` inflates N and clears the bar on runs that never hit the failing lane
- Emit `probabilityIfUnfixed` / `runsNeeded` / `scopeWarning` so reports quote a number instead of a vibe
- Add `--fix-sha` for POM/helper-only fixes the spec-path search cannot see
- Report a fix-held check as four lines (verdict / evidence / when it settles / action) instead of a full triage report
- Document verifying a merged fix, and pin the lookback rate as the baseline feeding `runsNeeded`

### QA Notes
`node --test test/*.test.js` in the skill scripts dir: 61 pass. New cases verified RED by reverting each behavior (2 fail). Skill-only change; no product code.