### PR TITLE
e2e: fail fast when every interpreter quick pick row is deprioritized

### DIFF
--- a/test/e2e/pages/notebooks.ts
+++ b/test/e2e/pages/notebooks.ts
@@ -9,7 +9,7 @@ import { QuickAccess } from './quickaccess';
 import { basename } from 'path';
 import test, { expect, FrameLocator, Locator } from '@playwright/test';
 import { HotKeys } from './hotKeys.js';
-import { DEPRIORITIZED_PYTHON_SOURCES } from './sessions';
+import { ALLOW_DEPRIORITIZED_PYTHON_FALLBACK, DEPRIORITIZED_PYTHON_SOURCES } from './sessions';
 import { escapeRegExp } from '../utils/strings';
 
 const KERNEL_DROPDOWN = 'a.kernel-label';
@@ -94,6 +94,7 @@ export class Notebooks {
 			await this.quickinput.type(desiredKernel);
 			await this.quickinput.selectQuickInputElementContaining(`${kernelGroup} ${desiredKernel}`, {
 				deprioritize: kernelGroup === 'Python' ? DEPRIORITIZED_PYTHON_SOURCES : undefined,
+				allowDeprioritizedFallback: ALLOW_DEPRIORITIZED_PYTHON_FALLBACK,
 			});
 			await this.quickinput.waitForQuickInputClosed();
 

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -10,7 +10,7 @@ import { QuickAccess } from './quickaccess';
 import test, { expect, Locator } from '@playwright/test';
 import { HotKeys } from './hotKeys.js';
 import { ContextMenu, MenuItemState } from './dialog-contextMenu.js';
-import { ACTIVE_STATUS_ICON, DEPRIORITIZED_PYTHON_SOURCES, DISCONNECTED_STATUS_ICON, IDLE_STATUS_ICON, SessionState } from './sessions.js';
+import { ACTIVE_STATUS_ICON, ALLOW_DEPRIORITIZED_PYTHON_FALLBACK, DEPRIORITIZED_PYTHON_SOURCES, DISCONNECTED_STATUS_ICON, IDLE_STATUS_ICON, SessionState } from './sessions.js';
 import { basename, relative } from 'path';
 
 const DEFAULT_TIMEOUT = 10000;
@@ -2024,6 +2024,7 @@ export class Kernel extends KernelBase {
 				timeout: 1000,
 				force: false,
 				deprioritize: kernelGroup === 'Python' ? DEPRIORITIZED_PYTHON_SOURCES : undefined,
+				allowDeprioritizedFallback: ALLOW_DEPRIORITIZED_PYTHON_FALLBACK,
 			});
 			await this.quickinput.waitForQuickInputClosed();
 		});
@@ -2088,6 +2089,7 @@ export class Kernel extends KernelBase {
 				timeout: 1000,
 				force: false,
 				deprioritize: kernelGroup === 'Python' ? DEPRIORITIZED_PYTHON_SOURCES : undefined,
+				allowDeprioritizedFallback: ALLOW_DEPRIORITIZED_PYTHON_FALLBACK,
 			});
 			await this.quickinput.waitForQuickInputClosed();
 			this.code.logger.log(`Selected kernel: ${desiredKernel}`);

--- a/test/e2e/pages/quickInput.ts
+++ b/test/e2e/pages/quickInput.ts
@@ -185,7 +185,7 @@ export class QuickInput {
 
 	async selectQuickInputElementContaining(
 		text: string,
-		{ timeout, force = true, deprioritize }: { timeout?: number; force?: boolean; deprioritize?: string[] } = {},
+		{ timeout, force = true, deprioritize, allowDeprioritizedFallback = false }: { timeout?: number; force?: boolean; deprioritize?: string[]; allowDeprioritizedFallback?: boolean } = {},
 	): Promise<string> {
 		const matches = this.code.driver.currentPage
 			.locator(`${QuickInput.QUICK_INPUT_RESULT}[aria-label*="${text}"]`);
@@ -193,20 +193,23 @@ export class QuickInput {
 		// By default select the first matching row. When `deprioritize` is set and
 		// several rows share `text` (e.g. a project venv and a base pyenv both
 		// labeled "Python 3.10.12"), prefer the first row whose aria-label contains
-		// none of the deprioritized source markers. Falls back to the first match
-		// when every match is deprioritized (e.g. a platform where only the base
-		// interpreter is installed).
+		// none of the deprioritized source markers. When every match is
+		// deprioritized the intended row has not registered yet, so throw and let
+		// the caller's retry reopen the picker: clicking a base install instead
+		// starts the wrong (often unusable) interpreter and defers the failure to a
+		// downstream timeout. Pass `allowDeprioritizedFallback` where only base
+		// installs exist (Windows/macOS CI).
 		let target = matches.first();
 		if (deprioritize?.length) {
 			await expect(target).toBeVisible({ timeout });
-			const count = await matches.count();
-			for (let i = 0; i < count; i++) {
-				const row = matches.nth(i);
-				const ariaLabel = (await row.getAttribute('aria-label')) ?? '';
-				if (!deprioritize.some(source => ariaLabel.includes(source))) {
-					target = row;
-					break;
-				}
+			const ariaLabels = await matches.evaluateAll(rows => rows.map(row => row.getAttribute('aria-label') ?? ''));
+			const preferred = ariaLabels.findIndex(label => !deprioritize.some(source => label.includes(source)));
+			if (preferred >= 0) {
+				target = matches.nth(preferred);
+			} else if (!allowDeprioritizedFallback) {
+				throw new Error(
+					`No non-deprioritized quick pick row matching "${text}". Deprioritized matches: ${JSON.stringify(ariaLabels)}`
+				);
 			}
 		}
 

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -26,6 +26,13 @@ export const DISCONNECTED_STATUS_ICON = '.codicon-positron-runtime-status-discon
 // the quick pick label produced by getRuntimeSourceAndShortName.
 export const DEPRIORITIZED_PYTHON_SOURCES = ['(Pyenv', '(Global', '(System', '(Unknown'];
 
+// Whether clicking a deprioritized row is acceptable when it is the only match.
+// The Linux CI images provide a venv interpreter at the selected version, so rows
+// that are all deprioritized there mean the venv has not registered yet and the
+// selection should be retried. Windows and macOS CI install a bare System/Pyenv
+// Python, where every row is legitimately deprioritized.
+export const ALLOW_DEPRIORITIZED_PYTHON_FALLBACK = process.platform !== 'linux';
+
 // Quickpick labels - keep in sync with languageRuntimeActions.ts
 const INTERPRETER_SESSIONS_LABEL = 'Interpreter Sessions';
 const START_NEW_CONSOLE_SESSION_LABEL = 'Start New Console Session';
@@ -549,6 +556,7 @@ export class Sessions {
 					await this.quickinput.selectQuickInputElementContaining(`${language} ${version}`, {
 						timeout: 2000,
 						deprioritize: language === 'Python' ? DEPRIORITIZED_PYTHON_SOURCES : undefined,
+						allowDeprioritizedFallback: ALLOW_DEPRIORITIZED_PYTHON_FALLBACK,
 					});
 				} catch (e) {
 					// Auto-discovery is intermittent: POSITRON_PY_VER_SEL's interpreter


### PR DESCRIPTION
### Summary

`selectQuickInputElementContaining` silently clicked the first match when every row matching the version was deprioritized. On the Linux CI images that means clicking the uv-managed base install instead of `/root/.venv` before it has registered -- that interpreter cannot start, so the failure surfaced 90s later as a `/started/` timeout instead of at the picker. Source of a 4.3% ubuntu/electron flake in the Quarto inline-output persistence test.

- Throw when `deprioritize` is set and no non-deprioritized row exists, listing the rows that were seen
- The existing retry in `startAndSkipMetadata` now reopens the picker, giving the venv time to register
- Windows (System) and macOS (Pyenv) CI have only deprioritized rows, so they keep the first-match fallback via `ALLOW_DEPRIORITIZED_PYTHON_FALLBACK`
- Applied to the session-start and notebook kernel-selection call sites

### QA Notes

Test-infra only; no product code. Windows and macOS lanes matter here -- they take the fallback path, not the new throw.

### Validation Steps

@:quarto @:sessions @:notebooks @:positron-notebooks @:interpreter @:win @:web

### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- Test-side: when every quick-pick match is deprioritized, selectQuickInputElementContaining silently clicks the first match (the broken uv managed base interpreter), so the session never starts and the 90s /started/ wait times out.</summary>

- **Test:** [Quarto - Inline Output: Persistence > Python - Verify kernel status persists after window reload](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Quarto%20-%20Inline%20Output%3A%20Persistence%20%3E%20Python%20-%20Verify%20kernel%20status%20persists%20after%20window%20reload%7C%7C%7Ctest%2Fe2e%2Ftests%2Fquarto%2Fquarto-inline-output-persistence.test.ts)
- **Targeted failure:** Pattern A -- expect(locator).toBeVisible() failed on locator('.console-instance[style*="z-index: auto"]').getByText(/started/); 6 occurrences, 4.2% on main, ubuntu/electron
- **Signal:** Trace timeline t=3093637 shows exactly 2 rows matching aria-label*="Python 3.10.12" (nth=0 and nth=1 read, no nth=2). Both matched DEPRIORITIZED_PYTHON_SOURCES (sessions.ts:27), so the loop at quickInput.ts:203-210 never broke out and fell through to matches.first(). Error-context snapshot, console tabpanel: "Python 3.10.12 (Global) failed to start. Could not start runtime: failed to resolve interpreter /root/.local/share/uv/python/cpython-3.10.12-linux-x86_64-gnu/bin/python". Failure line is sessions.ts:574 inside startAndSkipMetadata setup -- not in any Quarto or reload assertion.
- **Frequency:** 6/139 runs (4.3%) on main, ubuntu/electron
- **Hypothesis:** /root/.venv -- the only non-deprioritized 3.10.12 in the ubuntu24 CI image (Dockerfile.ubuntu24_04:159-176; asserted as the expected winner in remote-ssh.test.ts:85-96) -- had not yet registered as a runtime at click time. waitForInterpreterDiscoveryToComplete (quickInput.ts:94-108) only clears the "Discovering interpreters" placeholder and does not gate on the venv locator registering. The deprioritize fallback then converts "the interpreter I want is not listed yet" into "start a known-bad interpreter and wait 90s for a status that can never arrive". Ruled out: ordering flip (the image has exactly one non-deprioritized 3.10.12, so 2-rows-both-deprioritized means the venv row was missing, not reordered); never-rendered console (console-instance was present and showed explicit failure text); locator drift (/started/ is the correct locator, the session genuinely never started); Quarto/reload mechanics (failure precedes them). Surviving alternative (low): $HOME/.venv is structurally unregisterable on this image, making the third row impossible rather than late -- contradicted by the 95.8% pass rate.

</details>
