### PR TITLE
Connected indicator, Data Explorer-aware disconnect, and remove confirmation

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -705,6 +705,7 @@
 		"--vscode-positronModalDialog-buttonBorder",
 		"--vscode-positronModalDialog-buttonDestructiveBackground",
 		"--vscode-positronModalDialog-buttonDestructiveForeground",
+		"--vscode-positronModalDialog-buttonDestructiveHoverBackground",
 		"--vscode-positronModalDialog-buttonDisabledBackground",
 		"--vscode-positronModalDialog-buttonDisabledBorder",
 		"--vscode-positronModalDialog-buttonDisabledForeground",

--- a/extensions/positron-data-driver-duckdb/src/duckdbConnection.ts
+++ b/extensions/positron-data-driver-duckdb/src/duckdbConnection.ts
@@ -95,9 +95,10 @@ export class DuckDBConnection implements positron.DataConnection, IDuckDBPreview
 	/**
 	 * Opens the given table or view in the Data Explorer. Registers a table view with the RPC
 	 * handler under a stable per-connection dataset id, then asks Positron to open (or focus) the
-	 * explorer backed by this extension's provider.
+	 * explorer backed by this extension's provider. Returns the dataset id it was opened under, which
+	 * Positron uses to tell that this connection has a Data Explorer open on it.
 	 */
-	async previewObject(schemaName: string, tableName: string, kind: 'table' | 'view'): Promise<void> {
+	async previewObject(schemaName: string, tableName: string, kind: 'table' | 'view'): Promise<string> {
 		this._ensureConnected();
 		const datasetId = `duckdbconn:${this._connectionId}:${kind}:${schemaName}.${tableName}`;
 		await this._dataExplorerHandler.openTableView(datasetId, this._lease!.client, schemaName, tableName, kind);
@@ -107,13 +108,15 @@ export class DuckDBConnection implements positron.DataConnection, IDuckDBPreview
 			datasetId,
 			displayName: tableName,
 		});
+		return datasetId;
 	}
 
 	/**
 	 * Opens a single column of the given table or view in the Data Explorer as a one-column grid.
-	 * Uses a dataset id distinct from the table's so both can be open at once.
+	 * Uses a dataset id distinct from the table's so both can be open at once. Returns the dataset id
+	 * it was opened under.
 	 */
-	async previewColumn(schemaName: string, tableName: string, kind: 'table' | 'view', columnName: string): Promise<void> {
+	async previewColumn(schemaName: string, tableName: string, kind: 'table' | 'view', columnName: string): Promise<string> {
 		this._ensureConnected();
 		const datasetId = `duckdbconn:${this._connectionId}:column:${schemaName}.${tableName}.${columnName}`;
 		await this._dataExplorerHandler.openColumnView(datasetId, this._lease!.client, schemaName, tableName, kind, columnName);
@@ -123,6 +126,7 @@ export class DuckDBConnection implements positron.DataConnection, IDuckDBPreview
 			datasetId,
 			displayName: `${tableName}.${columnName}`,
 		});
+		return datasetId;
 	}
 
 	/** Returns whether this connection was opened in read-only mode. */

--- a/extensions/positron-data-driver-duckdb/src/duckdbNodes.ts
+++ b/extensions/positron-data-driver-duckdb/src/duckdbNodes.ts
@@ -11,10 +11,10 @@ import { IDuckDBQueryClient } from 'positron-data-explorer-duckdb';
  * DuckDBConnection, which owns the worker client and the dataset registration.
  */
 export interface IDuckDBPreviewHost {
-	/** Opens the given table or view in the Data Explorer. */
-	previewObject(schemaName: string, tableName: string, kind: 'table' | 'view'): Promise<void>;
-	/** Opens a single column of the given table or view in the Data Explorer. */
-	previewColumn(schemaName: string, tableName: string, kind: 'table' | 'view', columnName: string): Promise<void>;
+	/** Opens the given table or view in the Data Explorer, returning its dataset id. */
+	previewObject(schemaName: string, tableName: string, kind: 'table' | 'view'): Promise<string>;
+	/** Opens a single column of the given table or view in the Data Explorer, returning its dataset id. */
+	previewColumn(schemaName: string, tableName: string, kind: 'table' | 'view', columnName: string): Promise<string>;
 }
 
 /**

--- a/extensions/positron-data-driver-pins/src/pinsConnection.ts
+++ b/extensions/positron-data-driver-pins/src/pinsConnection.ts
@@ -160,8 +160,12 @@ export class PinsConnection implements positron.DataConnection, IPinsBrowseHost 
 	 * its data file, downloads that file (reusing the cached copy when present), loads it into the
 	 * DuckDB worker as a table, and opens the explorer over it. Convert-to-Code in the resulting
 	 * explorer emits `pin_read` code rather than SQL against the throwaway table.
+	 *
+	 * Returns the dataset id the explorer was opened under, which Positron uses to tell that this
+	 * connection has a Data Explorer open on it, or undefined when a disconnect raced the preview and
+	 * nothing was opened.
 	 */
-	async previewPin(pin: PinInfo, bundleId: string, isActiveVersion: boolean): Promise<void> {
+	async previewPin(pin: PinInfo, bundleId: string, isActiveVersion: boolean): Promise<string | undefined> {
 		this._ensureConnected();
 
 		// Resolve the version's data file and confirm it is a previewable, single-file tabular type.
@@ -226,6 +230,7 @@ export class PinsConnection implements positron.DataConnection, IPinsBrowseHost 
 
 		this._logger.info(`Opening ${displayName} in the Data Explorer`);
 		await positron.dataExplorer.open({ providerId: PINS_DATA_EXPLORER_PROVIDER_ID, datasetId, displayName });
+		return datasetId;
 	}
 
 	/** Marks the connection disconnected, releases previewed views, and closes the DuckDB worker. */

--- a/extensions/positron-data-driver-pins/src/pinsNodes.ts
+++ b/extensions/positron-data-driver-pins/src/pinsNodes.ts
@@ -44,8 +44,10 @@ export interface IPinsBrowseHost {
 	 * @param bundleId The bundle (version) id whose data to preview.
 	 * @param isActiveVersion Whether `bundleId` is the pin's active version; the active version reads
 	 * as the latest, so its generated code omits the explicit `version` argument.
+	 * @returns The dataset id the explorer was opened under, or undefined when a disconnect raced the
+	 * preview and nothing was opened.
 	 */
-	previewPin(pin: PinInfo, bundleId: string, isActiveVersion: boolean): Promise<void>;
+	previewPin(pin: PinInfo, bundleId: string, isActiveVersion: boolean): Promise<string | undefined>;
 }
 
 /**

--- a/extensions/positron-data-driver-postgresql/src/postgresqlConnection.ts
+++ b/extensions/positron-data-driver-postgresql/src/postgresqlConnection.ts
@@ -311,9 +311,10 @@ export class PostgreSQLConnection implements positron.DataConnection, IPostgresC
 	 * handler under a stable per-connection dataset id, then asks Positron to open (or focus) the
 	 * explorer backed by this extension's provider. `client` is the client the object's node was built
 	 * against and `database` is the database it lives in (undefined in single-database mode), so the
-	 * dataset id and query client match the right database.
+	 * dataset id and query client match the right database. Returns the dataset id it was opened
+	 * under, which Positron uses to tell that this connection has a Data Explorer open on it.
 	 */
-	async previewObject(client: PostgreSQLClient, database: string | undefined, schemaName: string, tableName: string, kind: 'table' | 'view'): Promise<void> {
+	async previewObject(client: PostgreSQLClient, database: string | undefined, schemaName: string, tableName: string, kind: 'table' | 'view'): Promise<string> {
 		this._ensureConnected();
 		const datasetId = `postgresql:${this._connectionId}:${database ?? ''}:${kind}:${schemaName}.${tableName}`;
 		await this._dataExplorerHandler.openTableView(datasetId, this._queryClient(client), schemaName, tableName, kind);
@@ -323,13 +324,15 @@ export class PostgreSQLConnection implements positron.DataConnection, IPostgresC
 			datasetId,
 			displayName: tableName,
 		});
+		return datasetId;
 	}
 
 	/**
 	 * Opens a single column of the given table or view in the Data Explorer as a one-column grid.
-	 * Uses a dataset id distinct from the table's so both can be open at once.
+	 * Uses a dataset id distinct from the table's so both can be open at once. Returns the dataset id
+	 * it was opened under.
 	 */
-	async previewColumn(client: PostgreSQLClient, database: string | undefined, schemaName: string, tableName: string, kind: 'table' | 'view', columnName: string): Promise<void> {
+	async previewColumn(client: PostgreSQLClient, database: string | undefined, schemaName: string, tableName: string, kind: 'table' | 'view', columnName: string): Promise<string> {
 		this._ensureConnected();
 		const datasetId = `postgresql:${this._connectionId}:${database ?? ''}:column:${schemaName}.${tableName}.${columnName}`;
 		await this._dataExplorerHandler.openColumnView(datasetId, this._queryClient(client), schemaName, tableName, kind, columnName);
@@ -339,6 +342,7 @@ export class PostgreSQLConnection implements positron.DataConnection, IPostgresC
 			datasetId,
 			displayName: `${tableName}.${columnName}`,
 		});
+		return datasetId;
 	}
 
 	/** A query client over the given pg client, for the Data Explorer table views. */

--- a/extensions/positron-data-driver-postgresql/src/postgresqlNodes.ts
+++ b/extensions/positron-data-driver-postgresql/src/postgresqlNodes.ts
@@ -14,10 +14,10 @@ import { PostgreSQLClient } from './postgresqlClient.js';
  * so previewed datasets stay unique across databases.
  */
 export interface IPostgresPreviewHost {
-	/** Opens the given table or view in the Data Explorer. */
-	previewObject(client: PostgreSQLClient, database: string | undefined, schemaName: string, tableName: string, kind: 'table' | 'view'): Promise<void>;
-	/** Opens a single column of the given table or view in the Data Explorer. */
-	previewColumn(client: PostgreSQLClient, database: string | undefined, schemaName: string, tableName: string, kind: 'table' | 'view', columnName: string): Promise<void>;
+	/** Opens the given table or view in the Data Explorer, returning its dataset id. */
+	previewObject(client: PostgreSQLClient, database: string | undefined, schemaName: string, tableName: string, kind: 'table' | 'view'): Promise<string>;
+	/** Opens a single column of the given table or view in the Data Explorer, returning its dataset id. */
+	previewColumn(client: PostgreSQLClient, database: string | undefined, schemaName: string, tableName: string, kind: 'table' | 'view', columnName: string): Promise<string>;
 }
 
 /**

--- a/extensions/positron-data-driver-postgresql/src/test/postgresqlDriver.test.ts
+++ b/extensions/positron-data-driver-postgresql/src/test/postgresqlDriver.test.ts
@@ -24,8 +24,8 @@ const TEST_CONFIG: PostgreSQLConnectionConfig = {
 // handler would register a vscode command that collides with the activated extension's. One object
 // satisfies both the connection's host interface and the node-builder's preview-host interface.
 const noopHost = {
-	previewObject: async () => { },
-	previewColumn: async () => { },
+	previewObject: async () => 'noop-dataset',
+	previewColumn: async () => 'noop-dataset',
 	openTableView: async () => { },
 	openColumnView: async () => { },
 	closeTableView: () => { },

--- a/extensions/positron-data-driver-redshift/src/redshiftConnection.ts
+++ b/extensions/positron-data-driver-redshift/src/redshiftConnection.ts
@@ -109,9 +109,10 @@ export class RedshiftConnection implements positron.DataConnection, IRedshiftPre
 	/**
 	 * Opens the given table or view in the Data Explorer. Registers a table view with the RPC handler
 	 * under a stable per-connection dataset id, then asks Positron to open (or focus) the explorer
-	 * backed by this extension's provider.
+	 * backed by this extension's provider. Returns the dataset id it was opened under, which Positron
+	 * uses to tell that this connection has a Data Explorer open on it.
 	 */
-	async previewObject(client: RedshiftClient, database: string | undefined, schemaName: string, tableName: string, kind: 'table' | 'view'): Promise<void> {
+	async previewObject(client: RedshiftClient, database: string | undefined, schemaName: string, tableName: string, kind: 'table' | 'view'): Promise<string> {
 		this._ensureConnected();
 		const datasetId = `redshift:${this._connectionId}:${database ?? ''}:${kind}:${schemaName}.${tableName}`;
 		await this._dataExplorerHandler.openTableView(datasetId, this._queryClient(client), database, schemaName, tableName, kind);
@@ -121,13 +122,15 @@ export class RedshiftConnection implements positron.DataConnection, IRedshiftPre
 			datasetId,
 			displayName: tableName,
 		});
+		return datasetId;
 	}
 
 	/**
 	 * Opens a single column of the given table or view in the Data Explorer as a one-column grid.
-	 * Uses a dataset id distinct from the table's so both can be open at once.
+	 * Uses a dataset id distinct from the table's so both can be open at once. Returns the dataset id
+	 * it was opened under.
 	 */
-	async previewColumn(client: RedshiftClient, database: string | undefined, schemaName: string, tableName: string, kind: 'table' | 'view', columnName: string): Promise<void> {
+	async previewColumn(client: RedshiftClient, database: string | undefined, schemaName: string, tableName: string, kind: 'table' | 'view', columnName: string): Promise<string> {
 		this._ensureConnected();
 		const datasetId = `redshift:${this._connectionId}:${database ?? ''}:column:${schemaName}.${tableName}.${columnName}`;
 		await this._dataExplorerHandler.openColumnView(datasetId, this._queryClient(client), database, schemaName, tableName, kind, columnName);
@@ -137,6 +140,7 @@ export class RedshiftConnection implements positron.DataConnection, IRedshiftPre
 			datasetId,
 			displayName: `${tableName}.${columnName}`,
 		});
+		return datasetId;
 	}
 
 	/** A query client over the given pg client, for the Data Explorer table views. */

--- a/extensions/positron-data-driver-redshift/src/redshiftNodes.ts
+++ b/extensions/positron-data-driver-redshift/src/redshiftNodes.ts
@@ -32,10 +32,10 @@ const SYSTEM_SCHEMAS_SQL = SYSTEM_SCHEMAS.map(s => `'${s}'`).join(', ');
  * database in single-database mode), so cross-database previews use a three-part reference.
  */
 export interface IRedshiftPreviewHost {
-	/** Opens the given table or view in the Data Explorer. */
-	previewObject(client: RedshiftClient, database: string | undefined, schemaName: string, tableName: string, kind: 'table' | 'view'): Promise<void>;
-	/** Opens a single column of the given table or view in the Data Explorer. */
-	previewColumn(client: RedshiftClient, database: string | undefined, schemaName: string, tableName: string, kind: 'table' | 'view', columnName: string): Promise<void>;
+	/** Opens the given table or view in the Data Explorer, returning its dataset id. */
+	previewObject(client: RedshiftClient, database: string | undefined, schemaName: string, tableName: string, kind: 'table' | 'view'): Promise<string>;
+	/** Opens a single column of the given table or view in the Data Explorer, returning its dataset id. */
+	previewColumn(client: RedshiftClient, database: string | undefined, schemaName: string, tableName: string, kind: 'table' | 'view', columnName: string): Promise<string>;
 }
 
 // --- Single-database family (connected database, information_schema) ---

--- a/extensions/positron-data-driver-redshift/src/test/redshiftDriver.test.ts
+++ b/extensions/positron-data-driver-redshift/src/test/redshiftDriver.test.ts
@@ -25,8 +25,8 @@ const TEST_CONFIG: RedshiftConnectionConfig = {
 // handler would register a vscode command that collides with the activated extension's. One object
 // satisfies both the connection's host interface and the node-builder's preview-host interface.
 const noopHost = {
-	previewObject: async () => { },
-	previewColumn: async () => { },
+	previewObject: async () => 'noop-dataset',
+	previewColumn: async () => 'noop-dataset',
 	openTableView: async () => { },
 	openColumnView: async () => { },
 	closeTableView: () => { },

--- a/extensions/positron-data-driver-snowflake/src/snowflakeConnection.ts
+++ b/extensions/positron-data-driver-snowflake/src/snowflakeConnection.ts
@@ -85,9 +85,10 @@ export class SnowflakeConnection implements positron.DataConnection, ISnowflakeP
 	/**
 	 * Opens the given table or view in the Data Explorer. Registers a table view with the RPC handler
 	 * under a stable per-connection dataset id, then asks Positron to open (or focus) the explorer
-	 * backed by this extension's provider.
+	 * backed by this extension's provider. Returns the dataset id it was opened under, which Positron
+	 * uses to tell that this connection has a Data Explorer open on it.
 	 */
-	async previewObject(client: SnowflakeClient, database: string, schemaName: string, tableName: string, kind: 'table' | 'view'): Promise<void> {
+	async previewObject(client: SnowflakeClient, database: string, schemaName: string, tableName: string, kind: 'table' | 'view'): Promise<string> {
 		this._ensureConnected();
 		const datasetId = datasetKey(this._connectionId, kind, database, schemaName, tableName);
 		await this._dataExplorerHandler.openTableView(datasetId, this._queryClient(client), database, schemaName, tableName, kind);
@@ -97,13 +98,15 @@ export class SnowflakeConnection implements positron.DataConnection, ISnowflakeP
 			datasetId,
 			displayName: tableName,
 		});
+		return datasetId;
 	}
 
 	/**
 	 * Opens a single column of the given table or view in the Data Explorer as a one-column grid.
-	 * Uses a dataset id distinct from the table's so both can be open at once.
+	 * Uses a dataset id distinct from the table's so both can be open at once. Returns the dataset id
+	 * it was opened under.
 	 */
-	async previewColumn(client: SnowflakeClient, database: string, schemaName: string, tableName: string, kind: 'table' | 'view', columnName: string): Promise<void> {
+	async previewColumn(client: SnowflakeClient, database: string, schemaName: string, tableName: string, kind: 'table' | 'view', columnName: string): Promise<string> {
 		this._ensureConnected();
 		const datasetId = datasetKey(this._connectionId, 'column', database, schemaName, tableName, columnName);
 		await this._dataExplorerHandler.openColumnView(datasetId, this._queryClient(client), database, schemaName, tableName, kind, columnName);
@@ -113,6 +116,7 @@ export class SnowflakeConnection implements positron.DataConnection, ISnowflakeP
 			datasetId,
 			displayName: `${tableName}.${columnName}`,
 		});
+		return datasetId;
 	}
 
 	/** A query client over the given sdk client, for the Data Explorer table views. */

--- a/extensions/positron-data-driver-snowflake/src/snowflakeNodes.ts
+++ b/extensions/positron-data-driver-snowflake/src/snowflakeNodes.ts
@@ -36,10 +36,10 @@ function schemaRef(database: string, schemaName: string): string {
  * against; `database` is the database the object lives in, so previews use a three-part reference.
  */
 export interface ISnowflakePreviewHost {
-	/** Opens the given table or view in the Data Explorer. */
-	previewObject(client: SnowflakeClient, database: string, schemaName: string, tableName: string, kind: 'table' | 'view'): Promise<void>;
-	/** Opens a single column of the given table or view in the Data Explorer. */
-	previewColumn(client: SnowflakeClient, database: string, schemaName: string, tableName: string, kind: 'table' | 'view', columnName: string): Promise<void>;
+	/** Opens the given table or view in the Data Explorer, returning its dataset id. */
+	previewObject(client: SnowflakeClient, database: string, schemaName: string, tableName: string, kind: 'table' | 'view'): Promise<string>;
+	/** Opens a single column of the given table or view in the Data Explorer, returning its dataset id. */
+	previewColumn(client: SnowflakeClient, database: string, schemaName: string, tableName: string, kind: 'table' | 'view', columnName: string): Promise<string>;
 }
 
 /**

--- a/extensions/positron-data-driver-snowflake/src/test/snowflakeDriver.test.ts
+++ b/extensions/positron-data-driver-snowflake/src/test/snowflakeDriver.test.ts
@@ -21,8 +21,8 @@ const TEST_CONFIG: SnowflakeConnectionConfig = {
 // handler would register a vscode command that collides with the activated extension's. One object
 // satisfies both the connection's host interface and the node-builder's preview-host interface.
 const noopHost = {
-	previewObject: async () => { },
-	previewColumn: async () => { },
+	previewObject: async () => 'noop-dataset',
+	previewColumn: async () => 'noop-dataset',
 	openTableView: async () => { },
 	openColumnView: async () => { },
 	closeTableView: () => { },
@@ -353,7 +353,7 @@ suite('Snowflake Driver Tests', () => {
 		// building the node through createSchemaNode must carry the database, schema, name, and kind
 		// through to previewObject.
 		const calls: unknown[][] = [];
-		const recordingHost = { ...noopHost, previewObject: async (...args: unknown[]) => { calls.push(args); } };
+		const recordingHost = { ...noopHost, previewObject: async (...args: unknown[]) => { calls.push(args); return 'noop-dataset'; } };
 
 		const schemaNode = createSchemaNode(mock, recordingHost, 'ANALYTICS', 'PUBLIC');
 		const tables = await tablesOf(schemaNode);

--- a/extensions/positron-data-driver-sqlite/src/sqliteConnection.ts
+++ b/extensions/positron-data-driver-sqlite/src/sqliteConnection.ts
@@ -92,9 +92,10 @@ export class SQLiteConnection implements positron.DataConnection, ISqlitePreview
 	/**
 	 * Opens the given table or view in the Data Explorer. Registers a table view with the RPC
 	 * handler under a stable per-connection dataset id, then asks Positron to open (or focus) the
-	 * explorer backed by this extension's RPC command.
+	 * explorer backed by this extension's RPC command. Returns the dataset id it was opened under,
+	 * which Positron uses to tell that this connection has a Data Explorer open on it.
 	 */
-	async previewObject(name: string, kind: 'table' | 'view'): Promise<void> {
+	async previewObject(name: string, kind: 'table' | 'view'): Promise<string> {
 		this._ensureConnected();
 		const datasetId = `sqlite:${this._connectionId}:${kind}:${name}`;
 		await this._dataExplorerHandler.openTableView(datasetId, this._client!, name, kind);
@@ -104,13 +105,15 @@ export class SQLiteConnection implements positron.DataConnection, ISqlitePreview
 			datasetId,
 			displayName: name,
 		});
+		return datasetId;
 	}
 
 	/**
 	 * Opens a single column of the given table or view in the Data Explorer as a one-column grid.
-	 * Uses a dataset id distinct from the table's so both can be open at once.
+	 * Uses a dataset id distinct from the table's so both can be open at once. Returns the dataset id
+	 * it was opened under.
 	 */
-	async previewColumn(tableName: string, kind: 'table' | 'view', columnName: string): Promise<void> {
+	async previewColumn(tableName: string, kind: 'table' | 'view', columnName: string): Promise<string> {
 		this._ensureConnected();
 		const datasetId = `sqlite:${this._connectionId}:column:${tableName}.${columnName}`;
 		await this._dataExplorerHandler.openColumnView(datasetId, this._client!, tableName, kind, columnName);
@@ -120,6 +123,7 @@ export class SQLiteConnection implements positron.DataConnection, ISqlitePreview
 			datasetId,
 			displayName: `${tableName}.${columnName}`,
 		});
+		return datasetId;
 	}
 
 	/** Returns whether this connection was opened in read-only mode. */

--- a/extensions/positron-data-driver-sqlite/src/sqliteNodes.ts
+++ b/extensions/positron-data-driver-sqlite/src/sqliteNodes.ts
@@ -11,10 +11,10 @@ import { ISqliteQueryClient } from './sqliteWorkerClient.js';
  * SQLiteConnection, which owns the worker client and the dataset registration.
  */
 export interface ISqlitePreviewHost {
-	/** Opens the given table or view in the Data Explorer. */
-	previewObject(name: string, kind: 'table' | 'view'): Promise<void>;
-	/** Opens a single column of the given table or view in the Data Explorer. */
-	previewColumn(tableName: string, kind: 'table' | 'view', columnName: string): Promise<void>;
+	/** Opens the given table or view in the Data Explorer, returning its dataset id. */
+	previewObject(name: string, kind: 'table' | 'view'): Promise<string>;
+	/** Opens a single column of the given table or view in the Data Explorer, returning its dataset id. */
+	previewColumn(tableName: string, kind: 'table' | 'view', columnName: string): Promise<string>;
 }
 
 /**

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2348,8 +2348,14 @@ declare module 'positron' {
 
 		/**
 		 * Preview the data in this node (e.g., SELECT * FROM table LIMIT 100).
+		 *
+		 * Return the dataset id the preview was opened under -- the same `datasetId` passed to
+		 * `positron.dataExplorer.open` -- so Positron can relate the open Data Explorer back to the
+		 * connection it came from. Returning nothing is supported, but Positron then has no way to
+		 * know the connection has an open Data Explorer, and may close the connection while it is
+		 * still in use.
 		 */
-		preview?(): Thenable<void>;
+		preview?(): Thenable<string | void>;
 	}
 
 	/**

--- a/src/vs/workbench/api/browser/positron/mainThreadDataConnections.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadDataConnections.ts
@@ -211,10 +211,12 @@ export class MainThreadDataConnections implements MainThreadDataConnectionsShape
 	}
 
 	/**
-	 * Previews a node through the main thread handle.
+	 * Previews a node through the main thread handle. Goes through the service rather than calling
+	 * the handle directly so the resulting Data Explorer is recorded against the connection, the
+	 * same as a preview started from the Data Connections panel.
 	 */
-	async $nodePreviewViaService(connectionHandle: number, nodeHandle: number): Promise<void> {
-		return this._getHandle(connectionHandle).nodePreview(nodeHandle);
+	async $nodePreviewViaService(connectionHandle: number, nodeHandle: number): Promise<string | undefined> {
+		return this._dataConnectionsService.previewNode(this._getHandle(connectionHandle), nodeHandle);
 	}
 
 	/**
@@ -348,9 +350,10 @@ class MainThreadDataConnectionHandleAdapter implements IDataConnectionHandle {
 	}
 
 	/**
-	 * Triggers a data preview for the given node (e.g. table contents).
+	 * Triggers a data preview for the given node (e.g. table contents), resolving to the dataset id
+	 * the extension opened it under, if it reported one.
 	 */
-	async nodePreview(nodeHandle: number): Promise<void> {
+	async nodePreview(nodeHandle: number): Promise<string | undefined> {
 		return this._proxy.$nodePreview(this.handle, nodeHandle);
 	}
 

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -281,9 +281,10 @@ export interface MainThreadDataConnectionsShape extends IDisposable {
 	$nodeGetChildrenViaService(connectionHandle: number, nodeHandle: number): Promise<IDataConnectionNodeDTO[]>;
 
 	/**
-	 * Previews a node via the main thread service.
+	 * Previews a node via the main thread service. Resolves to the dataset id the preview was
+	 * opened under, or undefined when the driver did not report one.
 	 */
-	$nodePreviewViaService(connectionHandle: number, nodeHandle: number): Promise<void>;
+	$nodePreviewViaService(connectionHandle: number, nodeHandle: number): Promise<string | undefined>;
 
 	/**
 	 * Releases a connection handle via the main thread service.
@@ -305,7 +306,7 @@ export interface ExtHostDataConnectionsShape {
 	$connectionDisconnect(connectionHandle: number): Promise<void>;
 	$connectionIsConnected(connectionHandle: number): Promise<boolean>;
 	$nodeGetChildren(connectionHandle: number, nodeHandle: number): Promise<IDataConnectionNodeDTO[]>;
-	$nodePreview(connectionHandle: number, nodeHandle: number): Promise<void>;
+	$nodePreview(connectionHandle: number, nodeHandle: number): Promise<string | undefined>;
 	$releaseConnection(connectionHandle: number): void;
 }
 

--- a/src/vs/workbench/api/common/positron/extHostDataConnections.ts
+++ b/src/vs/workbench/api/common/positron/extHostDataConnections.ts
@@ -257,8 +257,12 @@ export class ExtHostDataConnections implements extHostProtocol.ExtHostDataConnec
 		return this._serializeNodes(connectionHandle, children);
 	}
 
-	/** Triggers a data preview for a node (e.g. SELECT * FROM table LIMIT 100). */
-	async $nodePreview(connectionHandle: number, nodeHandle: number): Promise<void> {
+	/**
+	 * Triggers a data preview for a node (e.g. SELECT * FROM table LIMIT 100). Returns the dataset
+	 * id the driver opened the preview under, so core can relate the resulting Data Explorer back to
+	 * this connection. Drivers may return nothing, in which case there is nothing to relate.
+	 */
+	async $nodePreview(connectionHandle: number, nodeHandle: number): Promise<string | undefined> {
 		const nodeMap = this._nodes.get(connectionHandle);
 		if (!nodeMap) {
 			throw new Error(`Connection handle ${connectionHandle} not found`);
@@ -267,7 +271,8 @@ export class ExtHostDataConnections implements extHostProtocol.ExtHostDataConnec
 		if (!node || !node.preview) {
 			throw new Error(`Node handle ${nodeHandle} does not support preview`);
 		}
-		await node.preview();
+		const datasetId = await node.preview();
+		return typeof datasetId === 'string' ? datasetId : undefined;
 	}
 
 	/** Frees a connection handle and all its associated node handles. */

--- a/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/components/destructiveTwoButtonFooter.css
+++ b/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/components/destructiveTwoButtonFooter.css
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/*
+ * Footer layout, matching the plain two button footer. The destructive treatment itself lives on
+ * `.positron-dynamic-modal-dialog-box .dialog-button.destructive` in positronDynamicModalDialog.css,
+ * alongside the default button's, so all of the dialog button variants stay in one place.
+ */
+.positron-dynamic-modal-dialog-box .destructive-two-button-footer {
+	gap: 10px;
+	height: 48px;
+	display: flex;
+	padding: 0 16px;
+	flex: 0 0 auto;
+	justify-content: end;
+	align-items: flex-start;
+}
+
+.positron-dynamic-modal-dialog-box .destructive-two-button-footer.top-border {
+	height: auto;
+	padding-top: 16px;
+	padding-bottom: 16px;
+	border-top: solid 1px var(--vscode-positronModalDialog-border);
+}

--- a/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/components/destructiveTwoButtonFooter.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/components/destructiveTwoButtonFooter.tsx
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import './destructiveTwoButtonFooter.css';
+
+// Other dependencies.
+import { FooterButton } from './footerButton.js';
+import * as platform from '../../../../../base/common/platform.js';
+import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
+
+/**
+ * DestructiveTwoButtonFooterProps interface.
+ */
+interface DestructiveTwoButtonFooterProps {
+	primaryButtonTitle: string;
+	secondaryButtonTitle: string;
+	topBorder?: boolean;
+	onPrimaryButton: () => void;
+	onSecondaryButton: () => void;
+}
+
+/**
+ * DestructiveTwoButtonFooter component. A two button footer whose primary button performs a
+ * destructive action -- removing a saved connection, discarding work -- and so is filled with the
+ * destructive red rather than the accent color a default button gets, and does not take the opening
+ * focus the way a plain two button footer's primary does.
+ * @param props A DestructiveTwoButtonFooterProps that contains the component properties.
+ * @returns The rendered component.
+ */
+export const DestructiveTwoButtonFooter = (props: DestructiveTwoButtonFooterProps) => {
+	// Primary button. Destructive rather than default: the two treatments are alternatives, and the
+	// red fill is what marks the action as one the user cannot take back. Deliberately not focused --
+	// see the secondary button below.
+	const primaryButton = (
+		<FooterButton destructive type='submit' onPressed={props.onPrimaryButton}>
+			{props.primaryButtonTitle}
+		</FooterButton>
+	);
+
+	// Secondary button. It takes the focus rather than the primary, unlike a plain two button footer:
+	// the primary action here cannot be taken back, so Enter and Escape should both back out of the
+	// dialog and taking the action should cost a deliberate click or Tab.
+	const secondaryButton = (
+		<FooterButton autoFocus onPressed={props.onSecondaryButton}>
+			{props.secondaryButtonTitle}
+		</FooterButton>
+	);
+
+	// Render.
+	return (
+		<div className={positronClassNames('destructive-two-button-footer', { 'top-border': props.topBorder })}>
+			{/* On Windows, the primary button comes first; on macOS/Linux, the secondary button comes first. */}
+			{platform.isWindows
+				? <>{primaryButton}{secondaryButton}</>
+				: <>{secondaryButton}{primaryButton}</>
+			}
+		</div>
+	);
+};

--- a/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/components/footerButton.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/components/footerButton.tsx
@@ -19,6 +19,12 @@ import { Button } from '../../../../../base/browser/ui/positronComponents/button
 interface FooterButtonProps {
 	autoFocus?: boolean;
 	default?: boolean;
+	/**
+	 * Whether this button performs a destructive action, which fills it with the destructive red.
+	 * An alternative to `default`, not a modifier on it: both set the button's fill, so a button is
+	 * one or the other.
+	 */
+	destructive?: boolean;
 	disabled?: boolean;
 	type?: 'button' | 'submit';
 	onPressed: () => void;
@@ -36,7 +42,8 @@ export const FooterButton = (props: PropsWithChildren<FooterButtonProps>) => {
 			className={positronClassNames(
 				'dialog-button',
 				'footer-button',
-				{ 'default': props.default }
+				{ 'default': props.default },
+				{ 'destructive': props.destructive }
 			)}
 			disabled={props.disabled}
 			type={props.type}

--- a/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.css
+++ b/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.css
@@ -84,7 +84,7 @@
 	VS Code 1.109.0 changed secondary buttons to have transparent background and no border in dark mode.
 	For modal dialog buttons, we need a visible border for secondary buttons (Cancel, Back, etc.)
 */
-.vs-dark .positron-dynamic-modal-dialog-box .dialog-button:not(.default) {
+.vs-dark .positron-dynamic-modal-dialog-box .dialog-button:not(.default):not(.destructive) {
 	border: 1px solid var(--vscode-button-border);
 }
 
@@ -99,7 +99,18 @@
 
 .positron-dynamic-modal-dialog-box .dialog-button.destructive {
 	color: var(--vscode-positronModalDialog-buttonDestructiveForeground);
+	border: 1px solid var(--vscode-positronModalDialog-buttonDestructiveBackground);
 	background-color: var(--vscode-positronModalDialog-buttonDestructiveBackground);
+}
+
+/*
+ * Needed as well as the rule above, which sets a background at the same specificity as
+ * `.dialog-button:hover` but later in the file: without this, a destructive button would be the only
+ * one that doesn't respond to the pointer.
+ */
+.positron-dynamic-modal-dialog-box .dialog-button.destructive:hover {
+	border-color: var(--vscode-positronModalDialog-buttonDestructiveHoverBackground);
+	background: var(--vscode-positronModalDialog-buttonDestructiveHoverBackground);
 }
 
 .positron-dynamic-modal-dialog-box .dialog-button:focus {

--- a/src/vs/workbench/browser/positronTree/classes/positronTreeInstance.tsx
+++ b/src/vs/workbench/browser/positronTree/classes/positronTreeInstance.tsx
@@ -541,6 +541,15 @@ export class PositronTreeInstance<T> extends DataGridInstance {
 		return this._expanded.has(id);
 	}
 
+	/**
+	 * Gets whether the node's children are loaded. A node keeps its loaded children while collapsed,
+	 * so consumers whose children carry per-fetch resources can use this to tell whether there is
+	 * anything to drop (see {@link dropLoadedChildren}).
+	 */
+	hasLoadedChildren(id: string): boolean {
+		return this._children.has(id);
+	}
+
 	isLoading(id: string): boolean {
 		return this._loading.has(id);
 	}

--- a/src/vs/workbench/browser/positronTree/classes/positronTreeInstance.tsx
+++ b/src/vs/workbench/browser/positronTree/classes/positronTreeInstance.tsx
@@ -452,7 +452,9 @@ export class PositronTreeInstance<T> extends DataGridInstance {
 	}
 
 	/**
-	 * Whether the given node's children are currently loaded.
+	 * Whether the given node's children are currently loaded. A node keeps its loaded children while
+	 * collapsed, so consumers whose children carry per-fetch resources can use this to tell whether
+	 * there is anything to drop (see {@link dropLoadedChildren}).
 	 */
 	hasLoadedChildren(id: string): boolean {
 		return this._children.has(id);
@@ -539,15 +541,6 @@ export class PositronTreeInstance<T> extends DataGridInstance {
 
 	isExpanded(id: string): boolean {
 		return this._expanded.has(id);
-	}
-
-	/**
-	 * Gets whether the node's children are loaded. A node keeps its loaded children while collapsed,
-	 * so consumers whose children carry per-fetch resources can use this to tell whether there is
-	 * anything to drop (see {@link dropLoadedChildren}).
-	 */
-	hasLoadedChildren(id: string): boolean {
-		return this._children.has(id);
 	}
 
 	isLoading(id: string): boolean {

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -1215,20 +1215,30 @@ export const POSITRON_MODAL_DIALOG_DEFAULT_BUTTON_FOREGROUND = registerColor('po
 	hcLight: buttonForeground
 }, localize('positronModalDialog.defaultButtonForeground', "Positron modal dialog default button foreground color."));
 
-// Positron modal dialog button destructive background color.
+// Positron modal dialog button destructive background color. Filled with the same red a destructive
+// context menu item is labelled in, so an irreversible action reads the same wherever it is offered.
 export const POSITRON_MODAL_DIALOG_BUTTON_DESTRUCTIVE_BACKGROUND = registerColor('positronModalDialog.buttonDestructiveBackground', {
-	dark: buttonSecondaryBackground,
-	light: buttonSecondaryBackground,
-	hcDark: buttonSecondaryBackground,
-	hcLight: buttonSecondaryBackground
+	dark: errorForeground,
+	light: errorForeground,
+	hcDark: errorForeground,
+	hcLight: errorForeground
 }, localize('positronModalDialog.buttonDestructiveBackground', "Positron modal dialog button destructive background color."));
 
-// Positron modal dialog button destructive foreground color.
+// Positron modal dialog button destructive hover background color.
+export const POSITRON_MODAL_DIALOG_BUTTON_DESTRUCTIVE_HOVER_BACKGROUND = registerColor('positronModalDialog.buttonDestructiveHoverBackground', {
+	dark: lighten(POSITRON_MODAL_DIALOG_BUTTON_DESTRUCTIVE_BACKGROUND, 0.15),
+	light: darken(POSITRON_MODAL_DIALOG_BUTTON_DESTRUCTIVE_BACKGROUND, 0.15),
+	hcDark: lighten(POSITRON_MODAL_DIALOG_BUTTON_DESTRUCTIVE_BACKGROUND, 0.15),
+	hcLight: darken(POSITRON_MODAL_DIALOG_BUTTON_DESTRUCTIVE_BACKGROUND, 0.15)
+}, localize('positronModalDialog.buttonDestructiveHoverBackground', "Positron modal dialog button destructive hover background color."));
+
+// Positron modal dialog button destructive foreground color. White, for legibility on the red fill,
+// following statusBarItem.errorForeground.
 export const POSITRON_MODAL_DIALOG_BUTTON_DESTRUCTIVE_FOREGROUND = registerColor('positronModalDialog.buttonDestructiveForeground', {
-	dark: buttonSecondaryForeground,
-	light: buttonSecondaryForeground,
-	hcDark: buttonSecondaryForeground,
-	hcLight: buttonSecondaryForeground
+	dark: Color.white,
+	light: Color.white,
+	hcDark: Color.white,
+	hcLight: Color.white
 }, localize('positronModalDialog.buttonDestructiveForeground', "Positron modal dialog button destructive foreground color."));
 
 // Positron modal dialog button disabled foreground color.

--- a/src/vs/workbench/contrib/positronDataConnections/browser/classes/dataConnectionsTreeInstance.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/classes/dataConnectionsTreeInstance.tsx
@@ -36,7 +36,7 @@ export interface DataConnectionEntry {
 
 /**
  * DataConnectionNode discriminated union. Each tree node wraps exactly one of:
- * - an entry (root rows; expanding connects, collapsing disconnects),
+ * - an entry (root rows; expanding connects, collapsing may disconnect -- see collapse below),
  * - a server-side node DTO returned from a connection's getChildren / nodeGetChildren calls.
  *
  * DTO nodes carry the originating IDataConnectionHandle so deeper children can be fetched
@@ -76,8 +76,8 @@ export const reloadKey = (node: DataConnectionNode): string =>
 const wrapEntry = (entry: DataConnectionEntry): TreeNode<DataConnectionNode> => ({
 	id: entryNodeId(entry.profile),
 	data: { kind: 'entry', entry },
-	// Entries always show a twisty -- clicking it connects (or disconnects). Whether children
-	// exist is only knowable after the connect succeeds.
+	// Entries always show a twisty -- clicking it connects (or collapses, which may disconnect).
+	// Whether children exist is only knowable after the connect succeeds.
 	hasChildren: true,
 });
 
@@ -92,8 +92,9 @@ const wrapDto = (dto: IDataConnectionNodeDTO, handle: IDataConnectionHandle): Tr
  *
  * Roots are one entry per saved profile, joined with its live instance (if connected). Expanding
  * an entry opens the connection via the service and fetches the connection's top-level DTOs;
- * collapsing an entry closes the connection and drops the loaded subtree so the next expand
- * re-fetches against a fresh handle.
+ * collapsing an entry closes the connection -- immediately, or once the last Data Explorer previewed
+ * from it closes -- and drops the loaded subtree so the next expand re-fetches against a fresh
+ * handle.
  */
 export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnectionNode> {
 	constructor(private readonly _service: IPositronDataConnectionsService) {
@@ -111,24 +112,53 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 		// connected/disconnected state. setRoots is sync and preserves existing expansion /
 		// loaded children by id, so unaffected entries keep their state.
 		const refreshRoots = () => {
-			this.setRoots(buildEntries(this._service).map(wrapEntry));
+			const entries = buildEntries(this._service);
+			this.setRoots(entries.map(wrapEntry));
+
+			// A loaded DTO subtree is only valid while its connection is open -- its node handles live
+			// in the ext host and die with the connection -- so drop the subtree of any entry that no
+			// longer has a live instance, and the next expand re-fetches against a fresh handle. Doing
+			// it here covers every route a connection can close by, not just the ones the tree starts:
+			// a collapse, a deferred close once the last Data Explorer closed, or the driver dropping
+			// the connection on its own.
+			for (const entry of entries) {
+				const id = entryNodeId(entry.profile);
+				if (entry.instance === undefined && this.hasLoadedChildren(id)) {
+					this.dropLoadedChildren(id);
+				}
+			}
 		};
 		this._register(this._service.onDidChangeProfiles(refreshRoots));
 		this._register(this._service.onDidChangeInstances(refreshRoots));
 	}
 
 	/**
-	 * Tree-semantic collapse. For entry nodes, disconnects the underlying connection and drops
-	 * any loaded DTO subtree so the next expand re-fetches against a fresh handle. Disconnect is
-	 * fire-and-forget -- the UI shouldn't block on the network round trip to close the channel.
+	 * Tree-semantic expand. Expanding a connected entry means the user wants the connection again, so
+	 * it cancels any pending close a previous collapse left behind.
+	 */
+	override async expand(id: string): Promise<void> {
+		const node = this._findEntryNode(id);
+		if (node !== undefined) {
+			this._service.cancelDisconnectWhenUnused(node.entry.profile.id);
+		}
+		await super.expand(id);
+	}
+
+	/**
+	 * Tree-semantic collapse. Collapsing an entry gives up the tree's use of its connection, which
+	 * closes the connection unless Data Explorers previewed from it are still open. In that case the
+	 * connection stays up and closes when the last of them does: collapsing an entry is how a user
+	 * reclaims the panel's vertical space, and previews opened from it should keep working. The entry
+	 * row's connected indicator shows the connection is still live in the meantime, and its loaded
+	 * subtree is kept too, so re-expanding is immediate rather than a fresh round trip.
+	 *
+	 * The subtree is dropped when the connection actually closes, wherever that happens -- see the
+	 * roots refresh in the constructor.
 	 */
 	override collapse(id: string): void {
 		const node = this._findEntryNode(id);
 		if (node !== undefined && node.entry.instance !== undefined) {
-			// Drop loaded children first so the projection updates before the service-driven
-			// rebuild (from onDidChangeInstances) lands.
-			this.dropLoadedChildren(id);
-			void this._service.disconnect(node.entry.profile.id);
+			this._service.disconnectWhenUnused(node.entry.profile.id);
 		}
 		super.collapse(id);
 	}

--- a/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionEntryRow.css
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionEntryRow.css
@@ -28,6 +28,15 @@
 	transform: translateY(-0.5px);
 }
 
+.data-connection-entry-connected {
+	flex: 0 0 auto;
+	width: 6px;
+	height: 6px;
+	margin: 0 5px;
+	border-radius: 50%;
+	background-color: var(--vscode-charts-green);
+}
+
 .data-connection-entry-actions {
 	display: flex;
 	width: 20px;

--- a/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionEntryRow.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionEntryRow.tsx
@@ -14,6 +14,7 @@ import { localize } from '../../../../../nls.js';
 import { IDisposable } from '../../../../../base/common/lifecycle.js';
 import { ConfigureDataConnection } from '../dialogs/configureDataConnection.js';
 import { showConnectDataConnectionWith } from '../dialogs/connectDataConnectionWith.js';
+import { showRemoveDataConnectionConfirmation } from '../dialogs/removeDataConnectionConfirmation.js';
 import { DataConnectionEntry } from '../classes/dataConnectionsTreeInstance.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { PositronModalDialogReactRenderer } from '../../../../../base/browser/positronModalDialogReactRenderer.js';
@@ -41,9 +42,10 @@ interface DataConnectionEntryRowProps {
 
 /**
  * DataConnectionEntryRow component. Renders a root-level entry: the saved profile plus, when
- * connected, a live-status indicator. Twistie click (handled by PositronTree) opens or closes
- * the connection; the actions menu -- reachable from the actions button or by right-clicking the
- * row -- exposes refresh, runtime-language connect options, and edit/remove.
+ * connected, a live-status indicator. Twistie click (handled by PositronTree) opens the connection;
+ * collapsing closes it only when nothing else is using it (see DataConnectionsTreeInstance). The
+ * actions menu -- reachable from the actions button or by right-clicking the row -- exposes
+ * refresh, runtime-language connect options, and edit/remove.
  */
 export const DataConnectionEntryRow = ({ entry, onMenuOpening, onRefresh }: DataConnectionEntryRowProps) => {
 	// Services.
@@ -108,6 +110,21 @@ export const DataConnectionEntryRow = ({ entry, onMenuOpening, onRefresh }: Data
 				}}
 			/>
 		);
+	};
+
+	/**
+	 * Confirms removing this connection profile, then removes it. Removal deletes the profile's saved
+	 * settings and secrets, and closes its connection along with any Data Explorers previewed from it,
+	 * so the count of those goes into the prompt.
+	 */
+	const confirmRemoveProfile = async () => {
+		const confirmed = await showRemoveDataConnectionConfirmation(
+			profile.connectionName,
+			positronDataConnectionsService.countOpenDataExplorers(profile.id)
+		);
+		if (confirmed) {
+			positronDataConnectionsService.removeProfile(profile.id);
+		}
 	};
 
 	/**
@@ -225,7 +242,7 @@ export const DataConnectionEntryRow = ({ entry, onMenuOpening, onRefresh }: Data
 				destructive: true,
 				icon: 'trash',
 				label: localize('positron.dataConnections.remove', "Remove"),
-				onSelected: () => positronDataConnectionsService.removeProfile(profile.id),
+				onSelected: () => confirmRemoveProfile(),
 			}));
 
 		// Announced before the menu shows so the row is already selected and the tree still reads
@@ -268,6 +285,9 @@ export const DataConnectionEntryRow = ({ entry, onMenuOpening, onRefresh }: Data
 		showActionsMenu(rowRef.current, { clientX: e.clientX, clientY: e.clientY });
 	};
 
+	// The connected indicator's label, used as both its tooltip and its accessible name.
+	const connectedLabel = localize('positron.dataConnections.connected', "Connected");
+
 	// Render.
 	return (
 		// The row is a presentational element inside a tree that owns focus and keyboard
@@ -281,6 +301,17 @@ export const DataConnectionEntryRow = ({ entry, onMenuOpening, onRefresh }: Data
 				{' · '}
 				{profile.driverMetadata.name}
 			</div>
+			{entry.instance && (
+				// Shown whenever the profile has a live connection, including while the entry is
+				// collapsed -- collapsing does not necessarily disconnect, so this is how the user
+				// tells a live connection from a saved-but-closed one.
+				<div
+					aria-label={connectedLabel}
+					className='data-connection-entry-connected'
+					role='img'
+					title={connectedLabel}
+				/>
+			)}
 			<button
 				ref={actionsButtonRef}
 				aria-label={localize('positron.dataConnections.actions', "Actions")}

--- a/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionNodeRow.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionNodeRow.tsx
@@ -118,7 +118,7 @@ interface DataConnectionNodeRowProps {
  * can have children offer a "Refresh" action that re-fetches the subtree.
  */
 export const DataConnectionNodeRow = ({ dto, handle, onMenuOpening, onRefresh, stale }: DataConnectionNodeRowProps) => {
-	const { notificationService } = usePositronReactServicesContext();
+	const { notificationService, positronDataConnectionsService } = usePositronReactServicesContext();
 	const rowRef = useRef<HTMLDivElement>(null);
 	// Opening a preview can take a moment (a driver may download data first). Track it so the row can
 	// show a spinner for the duration, matching the tree's busy treatment on expansion.
@@ -131,7 +131,10 @@ export const DataConnectionNodeRow = ({ dto, handle, onMenuOpening, onRefresh, s
 		}
 		setOpening(true);
 		try {
-			await handle.nodePreview(dto.nodeHandle);
+			// Preview through the service rather than the handle so the Data Explorer this opens is
+			// recorded against the connection; collapsing the connection consults that record before
+			// deciding whether it can be closed.
+			await positronDataConnectionsService.previewNode(handle, dto.nodeHandle);
 		} catch (error) {
 			notificationService.error(localize(
 				'positron.dataConnections.openInDataExplorerFailed',

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/removeDataConnectionConfirmation.css
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/removeDataConnectionConfirmation.css
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/*
+ * Separates the consequences of removing a connection into paragraphs. A gap rather than a margin on
+ * the second paragraph, so nothing has to change when the dialog has only the first one (a connection
+ * with no open Data Explorers).
+ */
+.remove-data-connection-confirmation {
+	display: flex;
+	gap: 12px;
+	flex-direction: column;
+}

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/removeDataConnectionConfirmation.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/removeDataConnectionConfirmation.tsx
@@ -1,0 +1,118 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Other dependencies.
+import { localize } from '../../../../../nls.js';
+import { PositronModalDialogReactRenderer } from '../../../../../base/browser/positronModalDialogReactRenderer.js';
+import { DestructiveTwoButtonFooter } from '../../../../browser/positronComponents/positronDynamicModalDialog/components/destructiveTwoButtonFooter.js';
+import { PositronDynamicModalDialog } from '../../../../browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.js';
+
+// The width of the Remove Connection confirmation dialog.
+const REMOVE_CONNECTION_CONFIRMATION_WIDTH = 460;
+
+/**
+ * Shows the Remove Connection confirmation dialog. Removing a connection deletes its saved settings
+ * and stored secrets, and takes down anything still using it, so the dialog spells out what goes
+ * with it before the user commits.
+ * @param connectionName The name of the connection to be removed.
+ * @param openDataExplorerCount How many Data Explorers previewed from the connection are open, and
+ * so will close along with it. Zero when none are.
+ * @returns A promise that resolves to true if the user confirmed, or false if they cancelled.
+ */
+export const showRemoveDataConnectionConfirmation = (
+	connectionName: string,
+	openDataExplorerCount: number
+): Promise<boolean> => {
+	// Create the renderer.
+	const renderer = new PositronModalDialogReactRenderer();
+
+	return new Promise<boolean>(resolve => {
+		// Settle once: dispose the renderer and resolve with the user's choice. Guards against the
+		// dialog's onCancel firing again after an explicit Remove or Cancel.
+		let settled = false;
+		const settle = (confirmed: boolean) => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			renderer.dispose();
+			resolve(confirmed);
+		};
+
+		// Render the dialog.
+		renderer.render(
+			<RemoveDataConnectionConfirmation
+				connectionName={connectionName}
+				openDataExplorerCount={openDataExplorerCount}
+				renderer={renderer}
+				onCancel={() => settle(false)}
+				onConfirm={() => settle(true)}
+			/>
+		);
+	});
+};
+
+/**
+ * RemoveDataConnectionConfirmationProps interface.
+ */
+interface RemoveDataConnectionConfirmationProps {
+	readonly connectionName: string;
+	readonly openDataExplorerCount: number;
+	readonly renderer: PositronModalDialogReactRenderer;
+	readonly onConfirm: () => void;
+	readonly onCancel: () => void;
+}
+
+/**
+ * RemoveDataConnectionConfirmation component.
+ * @param props The component props.
+ */
+const RemoveDataConnectionConfirmation = (props: RemoveDataConnectionConfirmationProps) => {
+	// The consequence of removing the connection. Named separately per count, since localized strings
+	// cannot select a plural form from a placeholder.
+	let dataExplorersDetail;
+	if (props.openDataExplorerCount === 1) {
+		dataExplorersDetail = localize(
+			'positron.removeDataConnectionConfirmation.oneDataExplorer',
+			"The Data Explorer open on this connection will close."
+		);
+	} else if (props.openDataExplorerCount > 1) {
+		dataExplorersDetail = localize(
+			'positron.removeDataConnectionConfirmation.manyDataExplorers',
+			"The {0} Data Explorers open on this connection will close.",
+			props.openDataExplorerCount
+		);
+	}
+
+	return (
+		<PositronDynamicModalDialog
+			content={
+				<div>
+					<div>
+						{localize(
+							'positron.removeDataConnectionConfirmation.detail',
+							"The saved settings and stored secrets for '{0}' will be deleted. This cannot be undone.",
+							props.connectionName
+						)}
+					</div>
+					{dataExplorersDetail && <div>{dataExplorersDetail}</div>}
+				</div>
+			}
+			footer={
+				<DestructiveTwoButtonFooter
+					primaryButtonTitle={localize('positron.removeDataConnectionConfirmation.confirm', "Remove")}
+					secondaryButtonTitle={localize('positron.removeDataConnectionConfirmation.cancel', "Cancel")}
+					onPrimaryButton={props.onConfirm}
+					onSecondaryButton={props.onCancel}
+				/>
+			}
+			renderer={props.renderer}
+			title={localize('positron.removeDataConnectionConfirmation.title', "Remove Connection?")}
+			titleSize='large'
+			width={REMOVE_CONNECTION_CONFIRMATION_WIDTH}
+			onCancel={props.onCancel}
+		/>
+	);
+};

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/removeDataConnectionConfirmation.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/removeDataConnectionConfirmation.tsx
@@ -3,6 +3,9 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+// CSS.
+import './removeDataConnectionConfirmation.css';
+
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
 import { PositronModalDialogReactRenderer } from '../../../../../base/browser/positronModalDialogReactRenderer.js';
@@ -89,7 +92,7 @@ const RemoveDataConnectionConfirmation = (props: RemoveDataConnectionConfirmatio
 	return (
 		<PositronDynamicModalDialog
 			content={
-				<div>
+				<div className='remove-data-connection-confirmation'>
 					<div>
 						{localize(
 							'positron.removeDataConnectionConfirmation.detail',

--- a/src/vs/workbench/contrib/positronDataConnections/test/browser/dataConnectionEntryRow.vitest.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/test/browser/dataConnectionEntryRow.vitest.tsx
@@ -1,0 +1,53 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { screen } from '@testing-library/react';
+import { IDisposable } from '../../../../../base/common/lifecycle.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { IDataConnectionInstance } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionInstance.js';
+import { IDataConnectionProfile } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
+import { DataConnectionEntryRow } from '../../browser/components/dataConnectionEntryRow.js';
+
+const profile: IDataConnectionProfile = {
+	id: 'conn-1',
+	driverMetadata: {
+		id: 'test-driver',
+		name: 'Test Driver',
+		iconSvg: '',
+		supportedLanguageIds: [],
+	},
+	connectionName: 'My Connection',
+	mechanismId: 'test-mechanism',
+	parameterValues: {},
+};
+
+describe('DataConnectionEntryRow', () => {
+	const ctx = createTestContainer().withReactServices().build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
+
+	// The tree supplies these; neither is exercised here, where the indicator is what's under test.
+	const onRefresh = vi.fn();
+	const onMenuOpening = vi.fn((): IDisposable => ({ dispose: vi.fn() }));
+
+	it('shows the connected indicator for a profile with a live connection', () => {
+		const instance = stubInterface<IDataConnectionInstance>({ id: 'instance-1', profileId: profile.id });
+
+		rtl.render(<DataConnectionEntryRow entry={{ profile, instance }} onMenuOpening={onMenuOpening} onRefresh={onRefresh} />);
+
+		// The indicator is a bare dot, so its accessible name is the only thing to query it by.
+		expect(screen.getByRole('img', { name: 'Connected' })).toBeInTheDocument();
+	});
+
+	it('shows no connected indicator for a saved profile that is not connected', () => {
+		rtl.render(<DataConnectionEntryRow entry={{ profile }} onMenuOpening={onMenuOpening} onRefresh={onRefresh} />);
+
+		expect(screen.queryByRole('img', { name: 'Connected' })).not.toBeInTheDocument();
+		expect(screen.getByText('My Connection', { exact: false })).toBeInTheDocument();
+	});
+});

--- a/src/vs/workbench/contrib/positronDataConnections/test/browser/dataConnectionNodeRow.vitest.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/test/browser/dataConnectionNodeRow.vitest.tsx
@@ -14,6 +14,7 @@ import { createTestContainer } from '../../../../../test/vitest/positronTestCont
 import { CustomContextMenuSeparator } from '../../../../browser/positronComponents/customContextMenu/customContextMenuSeparator.js';
 import { IDataConnectionNodeDTO } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDTOs.js';
 import { IDataConnectionHandle } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
+import { IPositronDataConnectionsService } from '../../../../services/positronDataConnections/common/interfaces/positronDataConnectionsService.js';
 import { DataConnectionNodeRow } from '../../browser/components/dataConnectionNodeRow.js';
 
 // showCustomContextMenu renders a modal popup into the workbench DOM, which isn't what these tests
@@ -25,7 +26,13 @@ vi.mock('../../../../browser/positronComponents/customContextMenu/customContextM
 }));
 
 describe('DataConnectionNodeRow', () => {
-	const ctx = createTestContainer().withReactServices().build();
+	// The row previews through the service rather than the handle, so the connection can record the
+	// Data Explorer it opened.
+	const previewNode = vi.fn().mockResolvedValue(undefined);
+	const ctx = createTestContainer()
+		.withReactServices()
+		.stub(IPositronDataConnectionsService, { previewNode })
+		.build();
 	const rtl = setupRTLRenderer(() => ctx.reactServices);
 
 	function createDto(overrides: Partial<IDataConnectionNodeDTO> = {}): IDataConnectionNodeDTO {
@@ -40,13 +47,12 @@ describe('DataConnectionNodeRow', () => {
 	}
 
 	/**
-	 * Renders a row and right-clicks it. Returns the handle's nodePreview spy, the row's callbacks,
-	 * and the labels of the menu entries the row offered ('---' for a separator), or undefined when
-	 * the row declined to open a menu at all.
+	 * Renders a row and right-clicks it. Returns the row's connection handle, its callbacks, and the
+	 * labels of the menu entries the row offered ('---' for a separator), or undefined when the row
+	 * declined to open a menu at all.
 	 */
 	async function rightClickRow(dto: IDataConnectionNodeDTO, stale = false) {
-		const nodePreview = vi.fn().mockResolvedValue(undefined);
-		const handle = stubInterface<IDataConnectionHandle>({ handle: 1, nodePreview });
+		const handle = stubInterface<IDataConnectionHandle>({ handle: 1 });
 		const onRefresh = vi.fn();
 		const disposeHold = vi.fn();
 		// A plain IDisposable rather than toDisposable(), so the tracker doesn't count the tests
@@ -74,7 +80,7 @@ describe('DataConnectionNodeRow', () => {
 			entry instanceof CustomContextMenuSeparator ? '---' : (entry as { options: { label: string } }).options.label
 		);
 
-		return { labels, call, rowText, user, nodePreview, onRefresh, onMenuOpening, disposeHold };
+		return { labels, call, rowText, user, handle, onRefresh, onMenuOpening, disposeHold };
 	}
 
 	it('offers Refresh above Open in Data Explorer for a previewable node with children', async () => {
@@ -143,19 +149,19 @@ describe('DataConnectionNodeRow', () => {
 	});
 
 	it('does not open a preview when a stale row is double-clicked', async () => {
-		const { rowText, user, nodePreview } = await rightClickRow(createDto({ hasPreview: true }), true);
+		const { rowText, user } = await rightClickRow(createDto({ hasPreview: true }), true);
 
 		await user.dblClick(rowText);
 
-		expect(nodePreview).not.toHaveBeenCalled();
+		expect(previewNode).not.toHaveBeenCalled();
 	});
 
 	it('opens a preview when a previewable row is double-clicked', async () => {
-		const { rowText, user, nodePreview } = await rightClickRow(createDto({ nodeHandle: 42, hasPreview: true }));
+		const { rowText, user, handle } = await rightClickRow(createDto({ nodeHandle: 42, hasPreview: true }));
 
 		await user.dblClick(rowText);
 
-		expect(nodePreview).toHaveBeenCalledWith(42);
+		expect(previewNode).toHaveBeenCalledWith(handle, 42);
 	});
 
 	it('holds the tree focused while the menu is open and releases the hold when it closes', async () => {

--- a/src/vs/workbench/contrib/positronDataConnections/test/browser/dataConnectionsTreeInstance.vitest.ts
+++ b/src/vs/workbench/contrib/positronDataConnections/test/browser/dataConnectionsTreeInstance.vitest.ts
@@ -5,10 +5,14 @@
 
 /// <reference types="vitest/globals" />
 
-import { DataConnectionNode, reloadKey } from '../../browser/classes/dataConnectionsTreeInstance.js';
-import { IDataConnectionNodeDTO } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDTOs.js';
-import { IDataConnectionHandle, IDataConnectionProfile } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { DataConnectionNode, DataConnectionsTreeInstance, reloadKey } from '../../browser/classes/dataConnectionsTreeInstance.js';
+import { IDataConnectionNodeDTO } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDTOs.js';
+import { IDataConnectionInstance } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionInstance.js';
+import { IDataConnectionHandle, IDataConnectionProfile } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
+import { IPositronDataConnectionsService } from '../../../../services/positronDataConnections/common/interfaces/positronDataConnectionsService.js';
 
 function createProfile(overrides: Partial<IDataConnectionProfile> = {}): IDataConnectionProfile {
 	return {
@@ -134,5 +138,122 @@ describe('dataConnectionsTreeInstance reloadKey', () => {
 		// even for a DTO deliberately named to look like an entry.
 		expect(reloadKey(dtoNode({ kind: 'entry', name: 'conn-1' })))
 			.not.toBe(reloadKey(entryNode(createProfile({ id: 'conn-1' }))));
+	});
+});
+
+describe('DataConnectionsTreeInstance', () => {
+	const ctx = createTestContainer().build();
+
+	// The tree's id for the single profile these tests use.
+	const ENTRY_ID = 'entry:conn-1';
+
+	const profile = createProfile({
+		connectionName: 'Test Connection',
+		driverMetadata: {
+			id: 'test-driver',
+			name: 'Test Driver',
+			iconSvg: '',
+			supportedLanguageIds: [],
+		},
+		parameterValues: {},
+	});
+
+	// Fires when the service's set of live connections changes, which is what drives the tree to
+	// rebuild its roots.
+	const onDidChangeInstances = new Emitter<IDataConnectionInstance[]>();
+
+	/**
+	 * Builds a tree over one profile, connected unless `connected` says otherwise. `setConnected`
+	 * flips the profile's live state and notifies the tree, standing in for the service connecting or
+	 * disconnecting it.
+	 */
+	function createTree(connected = true) {
+		const getChildren = vi.fn(async () => []);
+		const instance = stubInterface<IDataConnectionInstance>({
+			id: 'instance-1',
+			profileId: profile.id,
+			connectionHandle: stubInterface<IDataConnectionHandle>({ handle: 1, getChildren }),
+		});
+
+		let liveInstance = connected ? instance : undefined;
+		const service = stubInterface<IPositronDataConnectionsService>({
+			onDidChangeProfiles: Event.None,
+			onDidChangeInstances: onDidChangeInstances.event,
+			getProfiles: () => [profile],
+			getInstanceForProfile: () => liveInstance,
+			connect: async () => instance,
+			disconnectWhenUnused: vi.fn(),
+			cancelDisconnectWhenUnused: vi.fn(),
+		});
+
+		const tree = new DataConnectionsTreeInstance(service);
+		ctx.disposables.add(tree);
+
+		const setConnected = (nowConnected: boolean) => {
+			liveInstance = nowConnected ? instance : undefined;
+			onDidChangeInstances.fire(nowConnected ? [instance] : []);
+		};
+
+		return { tree, service, getChildren, setConnected };
+	}
+
+	it('gives up its use of the connection when a connected entry is collapsed', async () => {
+		const { tree, service } = createTree();
+		await tree.refresh();
+		await tree.expand(ENTRY_ID);
+
+		tree.collapse(ENTRY_ID);
+
+		// The service decides whether that closes the connection now or once the last Data Explorer
+		// previewed from it is closed.
+		expect(service.disconnectWhenUnused).toHaveBeenCalledWith(profile.id);
+	});
+
+	it('does not touch the connection when an entry that is not connected is collapsed', async () => {
+		const { tree, service } = createTree(false);
+		await tree.refresh();
+		await tree.expand(ENTRY_ID);
+
+		tree.collapse(ENTRY_ID);
+
+		expect(service.disconnectWhenUnused).not.toHaveBeenCalled();
+	});
+
+	it('cancels a pending close when the entry is expanded again', async () => {
+		const { tree, service } = createTree();
+		await tree.refresh();
+		await tree.expand(ENTRY_ID);
+		tree.collapse(ENTRY_ID);
+
+		await tree.expand(ENTRY_ID);
+
+		expect(service.cancelDisconnectWhenUnused).toHaveBeenCalledWith(profile.id);
+	});
+
+	it('keeps the loaded subtree across a collapse while the connection is still open', async () => {
+		const { tree, getChildren } = createTree();
+		await tree.refresh();
+		await tree.expand(ENTRY_ID);
+		expect(getChildren).toHaveBeenCalledTimes(1);
+
+		tree.collapse(ENTRY_ID);
+		await tree.expand(ENTRY_ID);
+
+		// The node handles in the loaded subtree are still valid, so re-expanding costs no round trip.
+		expect(getChildren).toHaveBeenCalledTimes(1);
+	});
+
+	it('drops the loaded subtree once the connection closes', async () => {
+		const { tree, getChildren, setConnected } = createTree();
+		await tree.refresh();
+		await tree.expand(ENTRY_ID);
+		tree.collapse(ENTRY_ID);
+
+		// The connection closes -- here after its last Data Explorer did, which the service drives.
+		setConnected(false);
+
+		// Its node handles died with it, so re-expanding has to fetch the subtree again.
+		await tree.expand(ENTRY_ID);
+		expect(getChildren).toHaveBeenCalledTimes(2);
 	});
 });

--- a/src/vs/workbench/contrib/positronDataConnections/test/browser/removeDataConnectionConfirmation.vitest.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/test/browser/removeDataConnectionConfirmation.vitest.tsx
@@ -1,0 +1,88 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { PositronReactServices } from '../../../../../base/browser/positronReactServices.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
+import { showRemoveDataConnectionConfirmation } from '../../browser/dialogs/removeDataConnectionConfirmation.js';
+
+describe('showRemoveDataConnectionConfirmation', () => {
+	const ctx = createTestContainer().withReactServices().build();
+
+	// The dialog renders itself through its own PositronModalDialogReactRenderer rather than being
+	// handed to rtl.render, so this only establishes the services context it renders into.
+	setupRTLRenderer(() => ctx.reactServices);
+
+	beforeEach(() => {
+		// PositronModalDialogReactRenderer reads the services singleton in its constructor to find the
+		// container to render into, so the container's services have to be reachable from there.
+		PositronReactServices.services = ctx.reactServices;
+	});
+
+	it('names the connection and warns that the removal cannot be undone', async () => {
+		const confirmation = showRemoveDataConnectionConfirmation('My Connection', 0);
+
+		expect(await screen.findByText(/'My Connection' will be deleted/)).toBeInTheDocument();
+		expect(screen.getByText(/cannot be undone/)).toBeInTheDocument();
+
+		// No Data Explorers are open, so the dialog says nothing about closing any.
+		expect(screen.queryByText(/Data Explorer/)).not.toBeInTheDocument();
+
+		await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+		expect(await confirmation).toBe(false);
+	});
+
+	it('warns about a single open Data Explorer', async () => {
+		const confirmation = showRemoveDataConnectionConfirmation('My Connection', 1);
+
+		expect(await screen.findByText('The Data Explorer open on this connection will close.'))
+			.toBeInTheDocument();
+
+		await userEvent.click(screen.getByRole('button', { name: 'Remove' }));
+		expect(await confirmation).toBe(true);
+	});
+
+	it('opens with the focus on Cancel, not on the confirming button', async () => {
+		const confirmation = showRemoveDataConnectionConfirmation('My Connection', 0);
+
+		// Removing a connection cannot be undone, so the keystrokes that dismiss a dialog must not
+		// carry it out: Enter on the focused Cancel button backs out.
+		const cancelButton = await screen.findByRole('button', { name: 'Cancel' });
+		expect(cancelButton).toHaveFocus();
+		expect(screen.getByRole('button', { name: 'Remove' })).not.toHaveFocus();
+
+		await userEvent.keyboard('{Enter}');
+		expect(await confirmation).toBe(false);
+	});
+
+	it('styles the confirming button as destructive rather than as the default', async () => {
+		const confirmation = showRemoveDataConnectionConfirmation('My Connection', 0);
+
+		// The class is what the destructive footer contributes, and carries the red; a default-styled
+		// primary would take the accent fill instead and leave that red unreadable.
+		const removeButton = await screen.findByRole('button', { name: 'Remove' });
+		expect(removeButton).toHaveClass('destructive');
+		expect(removeButton).not.toHaveClass('default');
+
+		// Settle the dialog: it renders into the layout container through its own renderer, which
+		// outlives RTL's cleanup, so a dialog left open would still be there for the next test.
+		await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+		expect(await confirmation).toBe(false);
+	});
+
+	it('warns about several open Data Explorers', async () => {
+		const confirmation = showRemoveDataConnectionConfirmation('My Connection', 3);
+
+		expect(await screen.findByText('The 3 Data Explorers open on this connection will close.'))
+			.toBeInTheDocument();
+
+		await userEvent.click(screen.getByRole('button', { name: 'Remove' }));
+		expect(await confirmation).toBe(true);
+	});
+});

--- a/src/vs/workbench/services/positronDataConnections/browser/positronDataConnectionsService.ts
+++ b/src/vs/workbench/services/positronDataConnections/browser/positronDataConnectionsService.ts
@@ -9,12 +9,15 @@ import { Disposable } from '../../../../base/common/lifecycle.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { ISecretStorageService } from '../../../../platform/secrets/common/secrets.js';
 import { DataConnectionsDriverManager } from './dataConnectionsDriverManager.js';
+import { IEditorIdentifier } from '../../../common/editor.js';
+import { IEditorService } from '../../editor/common/editorService.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { IDataConnectionInstance } from '../common/interfaces/dataConnectionInstance.js';
+import { PositronDataExplorerUri } from '../../positronDataExplorer/common/positronDataExplorerUri.js';
 import { IPositronDataConnectionsService } from '../common/interfaces/positronDataConnectionsService.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
-import { IDataConnectionProfile, resolveDataConnectionMechanism } from '../common/interfaces/dataConnectionDriver.js';
+import { IDataConnectionHandle, IDataConnectionProfile, resolveDataConnectionMechanism } from '../common/interfaces/dataConnectionDriver.js';
 import { IDataConnectionsDriverManager } from '../common/interfaces/dataConnectionsDriverManager.js';
 
 // Storage key prefix for persisted data connection profiles. Each data connection profile gets
@@ -52,6 +55,18 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 	// Data connection instances.
 	private readonly _instances: IDataConnectionInstance[] = [];
 
+	// Dataset ids that previews opened in the Data Explorer, keyed by the profile whose connection
+	// they were previewed from. Recorded by previewNode and dropped when the profile disconnects.
+	// A recorded id outlives its editor -- the user can close the tab at any time -- so this is a
+	// record of what was opened, not of what is still open; countOpenDataExplorers resolves the
+	// difference against the editor service.
+	private readonly _previewedDatasetIds = new Map<string, Set<string>>();
+
+	// Profiles whose connection should close as soon as their last Data Explorer does. Populated by
+	// disconnectWhenUnused, drained when an editor closes and leaves the profile with none open, and
+	// cleared when the connection is wanted again or closes by another route.
+	private readonly _disconnectWhenUnused = new Set<string>();
+
 	// Fires when data connection profiles change.
 	private readonly _onDidChangeProfilesEmitter = this._register(new Emitter<IDataConnectionProfile[]>());
 
@@ -65,12 +80,14 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 	/**
 	 * Constructor.
 	 * @param extensionService The extension service.
+	 * @param _editorService The editor service (used to see which previews are still open).
 	 * @param _logService The log service.
 	 * @param _secretStorageService The secret storage service (secret parameter values).
 	 * @param _storageService The storage service (profile metadata).
 	 */
 	constructor(
 		@IExtensionService extensionService: IExtensionService,
+		@IEditorService private readonly _editorService: IEditorService,
 		@ILogService private readonly _logService: ILogService,
 		@ISecretStorageService private readonly _secretStorageService: ISecretStorageService,
 		@IStorageService private readonly _storageService: IStorageService,
@@ -84,6 +101,10 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 		// Load data connection profiles from storage. Secret values stay in secret storage and are
 		// fetched on demand by getProfileWithSecrets.
 		this._loadProfiles();
+
+		// A closing editor may have been the last Data Explorer holding a connection open. The event
+		// fires after the editor leaves its group, so the count below already reflects the close.
+		this._register(this._editorService.onDidCloseEditor(() => this._disconnectUnusedProfiles()));
 	}
 
 	//#endregion Constructor & Dispose
@@ -284,6 +305,12 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 			return;
 		}
 
+		// Close the profile's Data Explorers and its connection. Removing the profile takes its row
+		// out of the Data Connections panel, so a connection left open here would stay open and
+		// unreachable for the rest of the session. Fire-and-forget: the removal shouldn't wait on the
+		// round trips that close the editors and the channel.
+		void this._closeConnectionAndDataExplorers(id);
+
 		// Remove the data connection profile.
 		this._profiles.splice(index, 1);
 
@@ -366,6 +393,12 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 		const instance = this._instances[index];
 		this._instances.splice(index, 1);
 
+		// The connection is going away, so its previewed datasets are no longer meaningful: the
+		// driver tears their backends down, and a later reconnect mints fresh dataset ids. Any
+		// pending close is moot for the same reason, whichever route brought us here.
+		this._previewedDatasetIds.delete(profileId);
+		this._disconnectWhenUnused.delete(profileId);
+
 		try {
 			await instance.connectionHandle.disconnect();
 		} catch (err) {
@@ -377,6 +410,64 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 
 		this._logService.trace(`[DataConnections] Disconnected instance ${instance.id} (profile ${profileId})`);
 		this._onDidChangeInstancesEmitter.fire([...this._instances]);
+	}
+
+	/**
+	 * Previews a node in the Data Explorer, recording the dataset id the driver opened it under
+	 * against the connection's profile.
+	 */
+	async previewNode(handle: IDataConnectionHandle, nodeHandle: number): Promise<string | undefined> {
+		const datasetId = await handle.nodePreview(nodeHandle);
+		if (datasetId === undefined) {
+			return undefined;
+		}
+
+		// Attribute the dataset to the profile this handle belongs to. A handle with no live
+		// instance (e.g. one already disconnected) has nothing to attribute it to; the preview
+		// still happened, it just isn't tracked.
+		const profileId = this._instances.find(i => i.connectionHandle === handle)?.profileId;
+		if (profileId !== undefined) {
+			const datasetIds = this._previewedDatasetIds.get(profileId);
+			if (datasetIds) {
+				datasetIds.add(datasetId);
+			} else {
+				this._previewedDatasetIds.set(profileId, new Set([datasetId]));
+			}
+		}
+
+		return datasetId;
+	}
+
+	/**
+	 * Gets how many Data Explorers are open on data previewed from the given profile's connection.
+	 */
+	countOpenDataExplorers(profileId: string): number {
+		return this._openDataExplorers(profileId).length;
+	}
+
+	/**
+	 * Closes the profile's connection as soon as nothing is using it.
+	 */
+	disconnectWhenUnused(profileId: string): void {
+		if (this.getInstanceForProfile(profileId) === undefined) {
+			return;
+		}
+
+		// Still in use: wait for the last Data Explorer to close. Otherwise close it now. Disconnect
+		// is fire-and-forget either way -- callers shouldn't block on the round trip that closes the
+		// channel.
+		if (this.countOpenDataExplorers(profileId) > 0) {
+			this._disconnectWhenUnused.add(profileId);
+		} else {
+			void this.disconnect(profileId);
+		}
+	}
+
+	/**
+	 * Cancels a pending disconnectWhenUnused for the profile.
+	 */
+	cancelDisconnectWhenUnused(profileId: string): void {
+		this._disconnectWhenUnused.delete(profileId);
 	}
 
 	/**
@@ -401,6 +492,51 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 	}
 
 	//#endregion IPositronDataConnectionsService Implementation
+
+	//#region Private Methods
+
+	/**
+	 * Closes the connections of any profiles waiting on their last Data Explorer, now that one has
+	 * closed. A profile whose other Data Explorers are still open keeps waiting.
+	 */
+	private _disconnectUnusedProfiles(): void {
+		// Iterate a copy: disconnect() mutates the pending set.
+		for (const profileId of [...this._disconnectWhenUnused]) {
+			if (this.countOpenDataExplorers(profileId) === 0) {
+				void this.disconnect(profileId);
+			}
+		}
+	}
+
+	/**
+	 * Gets the editors of the Data Explorers open on data previewed from the given profile's
+	 * connection. The editor service is the authority on what is still open: a recorded dataset whose
+	 * tab the user has since closed has no editors, so it doesn't appear here.
+	 */
+	private _openDataExplorers(profileId: string): readonly IEditorIdentifier[] {
+		const datasetIds = this._previewedDatasetIds.get(profileId);
+		if (datasetIds === undefined) {
+			return [];
+		}
+		return [...datasetIds].flatMap(datasetId =>
+			this._editorService.findEditors(PositronDataExplorerUri.generate(datasetId))
+		);
+	}
+
+	/**
+	 * Closes the Data Explorers previewed from the given profile's connection, then the connection
+	 * itself. The Data Explorers go first because their backends die with the connection: a tab left
+	 * open would show a grid that errors on the next scroll or filter rather than any useful data.
+	 */
+	private async _closeConnectionAndDataExplorers(profileId: string): Promise<void> {
+		const editors = this._openDataExplorers(profileId);
+		if (editors.length > 0) {
+			await this._editorService.closeEditors(editors);
+		}
+		await this.disconnect(profileId);
+	}
+
+	//#endregion Private Methods
 
 	//#region Persistence
 

--- a/src/vs/workbench/services/positronDataConnections/common/interfaces/dataConnectionDriver.ts
+++ b/src/vs/workbench/services/positronDataConnections/common/interfaces/dataConnectionDriver.ts
@@ -188,6 +188,10 @@ export interface IDataConnectionHandle {
 	disconnect(): Promise<void>;
 	isConnected(): Promise<boolean>;
 	nodeGetChildren(nodeHandle: number): Promise<IDataConnectionNodeDTO[]>;
-	nodePreview(nodeHandle: number): Promise<void>;
+	/**
+	 * Previews a node's data in the Data Explorer. Resolves to the dataset id the preview was
+	 * opened under, or undefined when the driver did not report one.
+	 */
+	nodePreview(nodeHandle: number): Promise<string | undefined>;
 	release(): void;
 }

--- a/src/vs/workbench/services/positronDataConnections/common/interfaces/positronDataConnectionsService.ts
+++ b/src/vs/workbench/services/positronDataConnections/common/interfaces/positronDataConnectionsService.ts
@@ -7,7 +7,7 @@ import { Event } from '../../../../../base/common/event.js';
 import { IDisposable } from '../../../../../base/common/lifecycle.js';
 import { IDataConnectionInstance } from './dataConnectionInstance.js';
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
-import { IDataConnectionProfile } from './dataConnectionDriver.js';
+import { IDataConnectionHandle, IDataConnectionProfile } from './dataConnectionDriver.js';
 import { IDataConnectionsDriverManager } from './dataConnectionsDriverManager.js';
 
 // DI token used to inject IPositronDataConnectionsService throughout the workbench.
@@ -96,7 +96,10 @@ export interface IPositronDataConnectionsService extends IDisposable {
 	setPreferredCodeVariant(profileId: string, languageId: string, variantId: string): void;
 
 	/**
-	 * Removes a data connection profile.
+	 * Removes a data connection profile, deleting its persisted settings and stored secrets. Also
+	 * closes anything still using it: the Data Explorers previewed from its connection, and then the
+	 * connection itself, since a removed profile leaves no UI to manage a connection from. Callers
+	 * should confirm with the user first -- none of this is recoverable.
 	 * @param id The data connection profile id to remove.
 	 */
 	removeProfile(id: string): void;
@@ -118,6 +121,42 @@ export interface IPositronDataConnectionsService extends IDisposable {
 	 * @param profileId The data connection profile id to disconnect.
 	 */
 	disconnect(profileId: string): Promise<void>;
+
+	/**
+	 * Previews a node in the Data Explorer, recording the dataset id the driver opened it under
+	 * against the connection's profile so {@link countOpenDataExplorers} can report it later. Callers
+	 * should preview through this method rather than calling handle.nodePreview() directly, so no
+	 * Data Explorer goes unrecorded.
+	 * @param handle The connection handle the node belongs to.
+	 * @param nodeHandle The handle of the node to preview.
+	 * @returns The dataset id the preview was opened under, or undefined if the driver reported none.
+	 */
+	previewNode(handle: IDataConnectionHandle, nodeHandle: number): Promise<string | undefined>;
+
+	/**
+	 * Gets how many Data Explorers are open on data previewed from the given profile's connection.
+	 * Counts only previews the driver reported a dataset id for, and only those whose editor is still
+	 * open -- the user closing a Data Explorer tab brings the count back down.
+	 * @param profileId The data connection profile id.
+	 */
+	countOpenDataExplorers(profileId: string): number;
+
+	/**
+	 * Closes the profile's connection as soon as nothing is using it: right away when it has no open
+	 * Data Explorers, otherwise once the last one is closed. Lets a caller give up its own use of a
+	 * connection without cutting off the Data Explorers still reading from it. No-op if the profile
+	 * has no live connection. Cancel a pending close with {@link cancelDisconnectWhenUnused}.
+	 * @param profileId The data connection profile id.
+	 */
+	disconnectWhenUnused(profileId: string): void;
+
+	/**
+	 * Cancels a pending {@link disconnectWhenUnused} for the profile, keeping its connection open.
+	 * Call this when the connection is wanted again (e.g. the user re-expanded it). No-op if no close
+	 * is pending.
+	 * @param profileId The data connection profile id.
+	 */
+	cancelDisconnectWhenUnused(profileId: string): void;
 
 	/**
 	 * Gets all data connection instances.

--- a/src/vs/workbench/services/positronDataConnections/test/browser/positronDataConnectionsService.vitest.ts
+++ b/src/vs/workbench/services/positronDataConnections/test/browser/positronDataConnectionsService.vitest.ts
@@ -5,15 +5,21 @@
 
 /// <reference types="vitest/globals" />
 
+import { URI } from '../../../../../base/common/uri.js';
+import { Emitter } from '../../../../../base/common/event.js';
 import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
 import { IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { ISecretStorageService } from '../../../../../platform/secrets/common/secrets.js';
 import { TestSecretStorageService } from '../../../../../platform/secrets/test/common/testSecretStorageService.js';
 import { TestStorageService } from '../../../../test/common/workbenchTestServices.js';
 import { NullExtensionService, IExtensionService } from '../../../extensions/common/extensions.js';
+import { IEditorCloseEvent, IEditorIdentifier } from '../../../../common/editor.js';
+import { EditorInput } from '../../../../common/editor/editorInput.js';
+import { IEditorService } from '../../../editor/common/editorService.js';
+import { PositronDataExplorerUri } from '../../../positronDataExplorer/common/positronDataExplorerUri.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
-import { IDataConnectionDriver, IDataConnectionProfile } from '../../common/interfaces/dataConnectionDriver.js';
+import { IDataConnectionDriver, IDataConnectionDriverMetadata, IDataConnectionHandle, IDataConnectionProfile } from '../../common/interfaces/dataConnectionDriver.js';
 import { IPositronDataConnectionsService } from '../../common/interfaces/positronDataConnectionsService.js';
 import { PositronDataConnectionsService } from '../../browser/positronDataConnectionsService.js';
 
@@ -32,16 +38,63 @@ function createProfile(id: string): IDataConnectionProfile {
 	};
 }
 
+function createDriverMetadata(): IDataConnectionDriverMetadata {
+	return {
+		id: 'test-driver',
+		name: 'Test Driver',
+		description: '',
+		iconSvg: '',
+		supportedLanguageIds: [],
+		mechanisms: [{
+			id: 'test-mechanism',
+			label: 'Test Mechanism',
+			description: '',
+			parameters: [],
+		}],
+	};
+}
+
 describe('PositronDataConnectionsService', () => {
+	// The dataset ids whose Data Explorer editor is currently open. The IEditorService stub below
+	// reports an editor for exactly these, so a test can open and close Data Explorer tabs by
+	// mutating the set.
+	const openDatasetIds = new Set<string>();
+
+	// Fires when a Data Explorer editor closes. Tests close a tab by removing its dataset id from
+	// openDatasetIds and firing this, the way the editor part does.
+	const onDidCloseEditor = new Emitter<IEditorCloseEvent>();
+
+	// Maps a Data Explorer resource back to the open dataset id it belongs to, or undefined when no
+	// open dataset matches it.
+	const datasetIdForResource = (resource: URI) => [...openDatasetIds].find(
+		datasetId => PositronDataExplorerUri.generate(datasetId).toString() === resource.toString()
+	);
+
 	const ctx = createTestContainer()
 		.stub(IExtensionService, new NullExtensionService())
 		.stub(ILogService, new NullLogService())
+		.stub(IEditorService, {
+			onDidCloseEditor: onDidCloseEditor.event,
+			findEditors: (resource: URI) => datasetIdForResource(resource) !== undefined
+				? [stubInterface<IEditorIdentifier>({ editor: stubInterface<EditorInput>({ resource }) })]
+				: [],
+			closeEditors: async (editors: readonly IEditorIdentifier[]) => {
+				for (const { editor } of editors) {
+					const datasetId = editor.resource && datasetIdForResource(editor.resource);
+					if (datasetId !== undefined) {
+						openDatasetIds.delete(datasetId);
+					}
+				}
+				onDidCloseEditor.fire(stubInterface<IEditorCloseEvent>({}));
+			},
+		})
 		.build();
 
 	let storageService: TestStorageService;
 	let service: IPositronDataConnectionsService;
 
 	beforeEach(() => {
+		openDatasetIds.clear();
 		storageService = new TestStorageService();
 		ctx.disposables.add(storageService);
 		ctx.instantiationService.stub(IStorageService, storageService);
@@ -121,5 +174,182 @@ describe('PositronDataConnectionsService', () => {
 		// The new value must still be routed to secret storage, not leaked as plaintext into the
 		// public profile returned by getProfile.
 		expect(service.getProfile('conn-1')?.parameterValues).toEqual({});
+	});
+
+	describe('open Data Explorers', () => {
+		/**
+		 * Connects 'conn-1' through a driver that opens a Data Explorer per preview, the way a real
+		 * driver does, reporting `datasetIds` in order -- one per preview. An undefined entry stands
+		 * for a driver that opens a preview without reporting the dataset id it used.
+		 */
+		async function connectProfile(datasetIds: readonly (string | undefined)[]) {
+			const remainingDatasetIds = [...datasetIds];
+			const handle = stubInterface<IDataConnectionHandle>({
+				handle: 1,
+				nodePreview: async () => {
+					const datasetId = remainingDatasetIds.shift();
+					if (datasetId !== undefined) {
+						openDatasetIds.add(datasetId);
+					}
+					return datasetId;
+				},
+				disconnect: async () => { },
+				release: () => { },
+			});
+			service.driverManager.registerDriver(stubInterface<IDataConnectionDriver>({
+				id: 'test-driver',
+				metadata: createDriverMetadata(),
+				connect: async () => handle,
+			}));
+			service.addUpdateProfile(createProfile('conn-1'));
+			return service.connect('conn-1');
+		}
+
+		it('reports a Data Explorer previewed from the connection', async () => {
+			const instance = await connectProfile(['sqlite:conn-1:table:flights']);
+
+			expect(await service.previewNode(instance.connectionHandle, 7))
+				.toBe('sqlite:conn-1:table:flights');
+			expect(service.countOpenDataExplorers('conn-1')).toBe(1);
+		});
+
+		it('stops reporting one the user has closed', async () => {
+			const instance = await connectProfile(['sqlite:conn-1:table:flights']);
+			await service.previewNode(instance.connectionHandle, 7);
+
+			// The user closes the Data Explorer tab. The dataset stays recorded against the profile,
+			// but it no longer has an editor, so it no longer counts.
+			openDatasetIds.clear();
+
+			expect(service.countOpenDataExplorers('conn-1')).toBe(0);
+		});
+
+		it('reports nothing for a driver that does not report its dataset ids', async () => {
+			const instance = await connectProfile([undefined]);
+
+			expect(await service.previewNode(instance.connectionHandle, 7)).toBeUndefined();
+			expect(service.countOpenDataExplorers('conn-1')).toBe(0);
+		});
+
+		it('forgets a profile\'s previews once it disconnects', async () => {
+			const instance = await connectProfile(['sqlite:conn-1:table:flights']);
+			await service.previewNode(instance.connectionHandle, 7);
+
+			await service.disconnect('conn-1');
+
+			// The editor outlives the connection, but the connection's record of it does not: a
+			// reconnect mints fresh dataset ids, so the old ones must not carry over.
+			expect(openDatasetIds.size).toBe(1);
+			expect(service.countOpenDataExplorers('conn-1')).toBe(0);
+		});
+
+		it('reports nothing for a profile that has never been previewed', async () => {
+			await connectProfile(['sqlite:conn-1:table:flights']);
+
+			expect(service.countOpenDataExplorers('conn-1')).toBe(0);
+		});
+
+		describe('disconnectWhenUnused', () => {
+			// Closes the Data Explorer for the given dataset id, as the editor part does: the editor
+			// leaves its group first, then the close event fires.
+			function closeDataExplorer(datasetId: string) {
+				openDatasetIds.delete(datasetId);
+				onDidCloseEditor.fire(stubInterface<IEditorCloseEvent>({}));
+			}
+
+			it('closes the connection right away when nothing is using it', async () => {
+				await connectProfile([]);
+
+				service.disconnectWhenUnused('conn-1');
+
+				expect(service.getInstanceForProfile('conn-1')).toBeUndefined();
+			});
+
+			it('waits for the last Data Explorer to close, then closes the connection', async () => {
+				const instance = await connectProfile(['sqlite:conn-1:table:flights']);
+				await service.previewNode(instance.connectionHandle, 7);
+
+				service.disconnectWhenUnused('conn-1');
+				expect(service.getInstanceForProfile('conn-1')).toBeDefined();
+
+				closeDataExplorer('sqlite:conn-1:table:flights');
+
+				expect(service.getInstanceForProfile('conn-1')).toBeUndefined();
+			});
+
+			it('keeps the connection while another Data Explorer is still open', async () => {
+				const instance = await connectProfile([
+					'sqlite:conn-1:table:flights',
+					'sqlite:conn-1:table:airports',
+				]);
+				await service.previewNode(instance.connectionHandle, 7);
+				await service.previewNode(instance.connectionHandle, 8);
+
+				service.disconnectWhenUnused('conn-1');
+				closeDataExplorer('sqlite:conn-1:table:flights');
+
+				expect(service.getInstanceForProfile('conn-1')).toBeDefined();
+
+				closeDataExplorer('sqlite:conn-1:table:airports');
+
+				expect(service.getInstanceForProfile('conn-1')).toBeUndefined();
+			});
+
+			it('keeps the connection when the pending close is cancelled', async () => {
+				const instance = await connectProfile(['sqlite:conn-1:table:flights']);
+				await service.previewNode(instance.connectionHandle, 7);
+				service.disconnectWhenUnused('conn-1');
+
+				service.cancelDisconnectWhenUnused('conn-1');
+				closeDataExplorer('sqlite:conn-1:table:flights');
+
+				expect(service.getInstanceForProfile('conn-1')).toBeDefined();
+			});
+
+			it('is a no-op for a profile with no live connection', () => {
+				service.addUpdateProfile(createProfile('conn-1'));
+
+				expect(() => service.disconnectWhenUnused('conn-1')).not.toThrow();
+			});
+		});
+
+		describe('removeProfile', () => {
+			it('closes the connection of a removed profile', async () => {
+				await connectProfile([]);
+
+				service.removeProfile('conn-1');
+
+				// Removing the profile takes away the only UI for managing its connection, so leaving
+				// the connection open would leak it for the rest of the session.
+				expect(service.getProfile('conn-1')).toBeUndefined();
+				await vi.waitFor(() => {
+					expect(service.getInstanceForProfile('conn-1')).toBeUndefined();
+				});
+			});
+
+			it('closes the Data Explorers previewed from a removed profile', async () => {
+				const instance = await connectProfile([
+					'sqlite:conn-1:table:flights',
+					'sqlite:conn-1:table:airports',
+				]);
+				await service.previewNode(instance.connectionHandle, 7);
+				await service.previewNode(instance.connectionHandle, 8);
+
+				service.removeProfile('conn-1');
+
+				// Their backends die with the connection, so they would only survive as grids that
+				// error on the next interaction.
+				await vi.waitFor(() => {
+					expect(openDatasetIds.size).toBe(0);
+				});
+				await vi.waitFor(() => {
+					expect(service.getInstanceForProfile('conn-1')).toBeUndefined();
+				});
+			});
+
+			it('is a no-op for a profile that does not exist', () => {
+				expect(() => service.removeProfile('missing')).not.toThrow();
+			});
+		});
 	});
 });


### PR DESCRIPTION
Fixes #14623

### Summary

Removing a data connection deleted its saved profile but left the connection itself open. Because the profile's row was gone from the Data Connections panel, there was no longer any UI that could close it, so the underlying connection stayed open and unreachable for the rest of the session. Remove now closes the connection as part of removing the profile.

That turned out to need an answer to a broader question: when should a connection close? This PR settles the whole lifetime.

Collapsing a connection gives up the panel's use of it and closes it, as before -- unless Data Explorers previewed from that connection are still open, in which case the connection stays up and closes when the last of them is closed. Collapsing is how a user reclaims the panel's vertical space, so previews opened from a connection keep working across a collapse. Re-expanding cancels the pending close. Connection entries now show an indicator when they have a live connection, so a connection kept open behind a collapsed entry is visible rather than a surprise.

Remove now asks for confirmation first, naming the connection and how many open Data Explorers will close with it, since it deletes saved settings and stored secrets and cannot be undone. On confirmation it closes those Data Explorers, then the connection, then the profile. The Data Explorers are closed rather than left open because their backends die with the connection -- a tab left behind would be a grid that errors on the next scroll or filter.

For core to know which Data Explorers belong to which connection, `DataConnectionNode.preview()` now returns the dataset id it opened the explorer under (the same id passed to `positron.dataExplorer.open`). The return value is optional, so a driver that reports nothing still works; it just can't hold its connection open. All six in-repo drivers report it. Core records those ids per profile and asks the editor service which still have an editor open, so closing a Data Explorer tab is immediately reflected.

Supporting changes: a new `DestructiveTwoButtonFooter` for confirmation dialogs whose primary action can't be undone. It fills the primary button with the destructive red (`positronModalDialog.buttonDestructiveBackground` now resolves to the same red a destructive context menu item uses) and focuses Cancel rather than the destructive button, so Enter and Escape both back out. `TwoButtonFooter` is unchanged.

A dedicated Disconnect action is deliberately not added here (idea 2 in the issue). Collapse and Remove both close the connection now, so the gap the issue describes is closed without a third control; a separate Disconnect item can follow if it's still wanted.

Note for reviewers: this overlaps #15215 (Refresh / Refresh All) in four files, plus a `hasLoadedChildren` helper both branches add to `PositronTreeInstance` that git auto-merges into a duplicate. This branch will rebase onto main after #15215 lands.

### Screenshots

Connected data connection indicated with a green dot on the right:
<p>
<img width="1514" height="1041" alt="image" src="https://github.com/user-attachments/assets/fb2b03fb-62f0-4ffa-9417-b40c4f20c59e" />
</p>

Remove connection confirmation when there are no Data Explorer instances open:
<p>
<img width="481" height="187" alt="image" src="https://github.com/user-attachments/assets/b37df86c-b8ca-452d-b6b7-3b7ecb2ca021" />
</p>

Data connection with a Data Explorer open:
<p>
<img width="3028" height="2082" alt="image" src="https://github.com/user-attachments/assets/9295bd9a-e1e3-4e8b-aeb0-1f5a0c19f6e3" />
</p>

Remove connection confirmation when there is one Data Explorer instance open:
<p>
<img width="483" height="213" alt="image" src="https://github.com/user-attachments/assets/a9e17760-b4fa-4592-baaa-69a19937e96d" />
</p>

Remove connection confirmation when there are more than one Data Explorer instances open:
<p>
<img width="481" height="213" alt="image" src="https://github.com/user-attachments/assets/bd24cc37-14df-4cd1-badc-2f469fef81f8" />
</p>

### Release Notes

#### New Features

- Data Connections entries now show an indicator while a connection is open (#14623)
- Collapsing a data connection keeps it open while Data Explorers previewed from it are still open, and closes it when the last one is closed (#14623)
- Removing a data connection now asks for confirmation and reports how many open Data Explorers will close with it (#14623)

#### Bug Fixes

- Removing a data connection now closes the underlying connection instead of leaving it open for the rest of the session (#14623)

### Validation Steps

@:connections @:data-explorer

1. Create a SQLite or DuckDB connection and expand it in the Data Connections panel. Confirm the entry shows the connected indicator.
2. Double-click a table to open it in the Data Explorer, then collapse the connection. The Data Explorer must keep working (scroll, sort, filter) and the entry must still show the connected indicator.
3. Re-expand the connection. It should expand immediately, without re-fetching, and stay connected.
4. Collapse it again, then close the Data Explorer tab. The connected indicator should disappear, and re-expanding should reconnect and re-fetch the tree.
5. Open two Data Explorers from one connection and collapse it. Closing the first must leave the connection open; closing the second must close it.
6. Collapse a connection with no Data Explorers open. It should disconnect immediately.
7. With a Data Explorer open, choose Remove from the connection's Actions menu. The dialog must name the connection and say one Data Explorer will close. Confirm that Cancel is focused, that Escape and Enter both dismiss it without removing, and that confirming closes the Data Explorer tab and removes the connection.
8. Remove a connection with no Data Explorers open, and confirm the dialog omits the sentence about Data Explorers.
