### PR TITLE
feat(llm-docs): wire the on-disk docs bundle into the extension host

### DIFF
--- a/product.json
+++ b/product.json
@@ -5,6 +5,7 @@
 	"version": "",
 	"positronVersion": "2026.08.0",
 	"positronBuildNumber": 0,
+	"positronLlmsDocsUrl": "https://cdn.posit.co/positron/releases/docs",
 	"applicationName": "positron",
 	"dataFolderName": ".positron",
 	"sharedDataFolderName": ".positron-shared",

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -3520,6 +3520,53 @@ declare module 'positron' {
 	}
 
 	/**
+	 * Access to Positron product documentation cached on disk.
+	 */
+	namespace docs {
+		/**
+		 * A bundle of Positron documentation available on the extension host's
+		 * local filesystem.
+		 */
+		export interface LocalDocs {
+			/** Absolute path of the extracted bundle root, on the extension host's filesystem. */
+			readonly path: string;
+
+			/** Bundle format version. Currently 1. */
+			readonly schema: number;
+
+			/** Docs version this bundle was generated from, e.g. '2026.05.0-179'. */
+			readonly version: string;
+
+			/** 'positron' or 'workbench'. */
+			readonly profile: string;
+
+			/** Base URL for building a citable web link to a page in this bundle. */
+			readonly docsBaseUrl: string;
+
+			/** True when the bundle matches the running build exactly. */
+			readonly isExactMatch: boolean;
+		}
+
+		/**
+		 * Get the locally cached Positron documentation, downloading it if it is
+		 * not present yet.
+		 *
+		 * Safe to call per docs need: a successful result is cached in process,
+		 * and concurrent calls join a single in-flight download rather than
+		 * starting several. Waits at most 10 seconds for an in-flight download;
+		 * on timeout the download continues in the background and is available
+		 * to the next call.
+		 *
+		 * Resolves to `undefined` when there are no local docs, which means the
+		 * caller should fall back to fetching documentation from the web. That
+		 * is the only meaning of `undefined`.
+		 *
+		 * @returns A Thenable resolving to the local docs, or undefined.
+		 */
+		export function getLocalDocs(): Thenable<LocalDocs | undefined>;
+	}
+
+	/**
 	 * Experimental AI features.
 	 */
 	namespace ai {

--- a/src/vs/base/common/product.ts
+++ b/src/vs/base/common/product.ts
@@ -78,6 +78,13 @@ export interface IProductConfiguration {
 	/** The Positron build number; unique within the Positron version */
 	readonly positronBuildNumber: number;
 
+	/**
+	 * Base URL for the slim LLM docs bundles the AI assistant reads from disk.
+	 * Overridden at runtime by the POSITRON_LLMS_DOCS_URL environment variable.
+	 * Distinct from the docs *website* URL, which is a separate knob.
+	 */
+	readonly positronLlmsDocsUrl?: string;
+
 	/** The linux package type (DEB or RPM) */
 	readonly packageType?: string;
 	// --- End Positron ---

--- a/src/vs/platform/positronDocs/common/positronDocsBundle.ts
+++ b/src/vs/platform/positronDocs/common/positronDocsBundle.ts
@@ -151,6 +151,21 @@ function isNonEmptyString(value: unknown): value is string {
 	return typeof value === 'string' && value.length > 0;
 }
 
+/** Versions we are willing to use as a directory name. Excludes `.` and `..`. */
+const SAFE_VERSION = /^[A-Za-z0-9._-]+$/;
+
+/**
+ * The manifest version becomes a path segment under the cache root, so it is
+ * validated here rather than at the point of use.
+ *
+ * Same reasoning as guardEntryNames: the checksum proves the bundle arrived
+ * intact, not that the CDN that served it is honest, so a value like `../..`
+ * would otherwise let a rename escape the cache root.
+ */
+function isSafePathSegment(value: string): boolean {
+	return SAFE_VERSION.test(value) && value !== '.' && value !== '..';
+}
+
 /**
  * Parse bundle.json, rejecting anything this build cannot read.
  *
@@ -178,6 +193,9 @@ export function parseManifest(raw: string): IDocsBundleManifest | undefined {
 		return undefined;
 	}
 	if (typeof candidate.fileCount !== 'number' || !Number.isInteger(candidate.fileCount) || candidate.fileCount <= 0) {
+		return undefined;
+	}
+	if (!isSafePathSegment(candidate.version)) {
 		return undefined;
 	}
 	return {

--- a/src/vs/platform/positronDocs/common/positronDocsBundle.ts
+++ b/src/vs/platform/positronDocs/common/positronDocsBundle.ts
@@ -32,6 +32,13 @@ export const DOCS_INDEX_FILENAME = 'llms.txt';
  */
 export const DOCS_MAX_DOWNLOAD_BYTES = 25 * 1024 * 1024;
 
+/**
+ * Cap on the checksum file, which holds one `<64 hex chars>  <name>` line.
+ * Tight rather than generous: unlike the bundle this has a fixed shape, so a
+ * body anywhere near this size is already a wrong or hostile object.
+ */
+export const DOCS_MAX_CHECKSUM_BYTES = 8 * 1024;
+
 export type DocsProfile = 'positron' | 'workbench';
 
 /**

--- a/src/vs/platform/positronDocs/common/positronDocsCache.ts
+++ b/src/vs/platform/positronDocs/common/positronDocsCache.ts
@@ -119,6 +119,21 @@ export class PositronDocsCache {
 		this._generation++;
 	}
 
+	/**
+	 * The cached bundle, if any, without touching the network.
+	 *
+	 * Used when a caller has stopped waiting for an in-flight fetch: the
+	 * cache-present rule says a valid cache is served regardless, and awaiting
+	 * `ensure()` would defeat the point of the timeout.
+	 */
+	async peek(request: IDocsBundleRequest): Promise<ILocalDocs | undefined> {
+		if (this._attempted) {
+			return this._result;
+		}
+		const exactVersion = resolveBundleRequest(request).exact.version;
+		return await this._readCached(await this._readState(), exactVersion);
+	}
+
 	private async _ensureOnce(request: IDocsBundleRequest): Promise<ILocalDocs | undefined> {
 		const resolved = resolveBundleRequest(request);
 		const state = await this._readState();

--- a/src/vs/platform/positronDocs/common/positronDocsCache.ts
+++ b/src/vs/platform/positronDocs/common/positronDocsCache.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import {
-	DOCS_BUNDLE_SCHEMA, DOCS_FAILURE_THROTTLE_MS, DOCS_MAX_DOWNLOAD_BYTES,
+	DOCS_BUNDLE_SCHEMA, DOCS_FAILURE_THROTTLE_MS, DOCS_MAX_CHECKSUM_BYTES, DOCS_MAX_DOWNLOAD_BYTES,
 	DOCS_STATE_FILENAME, DocsResolution,
 	IDocsBundleManifest, IDocsBundleRequest, IDocsCacheState, IResolvedBundle, IResolvedBundleRequest,
 	parseDigestFile, resolveBundleRequest,
@@ -340,7 +340,7 @@ export class PositronDocsCache {
 			// A zip that cannot be verified is never extracted, even though
 			// that means a cold cache gets no local docs until the checksum file
 			// appears. Proceeding unverified would make the digest decorative.
-			const checksum = await http.get(target.sha256Url);
+			const checksum = await http.get(target.sha256Url, { maxBytes: DOCS_MAX_CHECKSUM_BYTES });
 			if (checksum.status !== 200 || !checksum.body) {
 				return { kind: 'rejected', reason: `checksum file unavailable (HTTP ${checksum.status})` };
 			}

--- a/src/vs/platform/positronDocs/common/positronDocsTriggers.ts
+++ b/src/vs/platform/positronDocs/common/positronDocsTriggers.ts
@@ -70,7 +70,7 @@ export class PositronDocsTriggers {
 	 * or returns the completed result.
 	 */
 	async getLocalDocs(): Promise<ILocalDocs | undefined> {
-		const { cache, delay, logger, request, waitMs } = this._options;
+		const { cache, logger, request, waitMs } = this._options;
 		if (!await this._options.isAiEnabled()) {
 			// Logged, not silent: from the caller's side this is indistinguishable
 			// from "no docs on disk", and the reason is the first thing anyone
@@ -79,15 +79,7 @@ export class PositronDocsTriggers {
 			return undefined;
 		}
 
-		const fetching: Promise<RaceOutcome> = cache.ensure(request)
-			.then(docs => ({ timedOut: false as const, docs }))
-			.catch(error => {
-				logger.warn(`${LOG_PREFIX} docs fetch failed: ${error instanceof Error ? error.message : String(error)}`);
-				return { timedOut: false as const, docs: undefined };
-			});
-		const timingOut: Promise<RaceOutcome> = delay(waitMs).then(() => ({ timedOut: true as const }));
-
-		const winner = await Promise.race([fetching, timingOut]);
+		const winner = await Promise.race([this._fetchDocs(), this._timeOut()]);
 		if (!winner.timedOut) {
 			return winner.docs;
 		}
@@ -97,5 +89,21 @@ export class PositronDocsTriggers {
 		// applies, so hand back whatever is already on disk.
 		logger.info(`${LOG_PREFIX} local docs not ready within ${waitMs}ms; continuing in the background`);
 		return await cache.peek(request);
+	}
+
+	/** Fetch branch of the race. Absorbs its own failure so the race never rejects. */
+	private async _fetchDocs(): Promise<RaceOutcome> {
+		try {
+			return { timedOut: false, docs: await this._options.cache.ensure(this._options.request) };
+		} catch (error) {
+			this._options.logger.warn(`${LOG_PREFIX} docs fetch failed: ${error instanceof Error ? error.message : String(error)}`);
+			return { timedOut: false, docs: undefined };
+		}
+	}
+
+	/** Timeout branch of the race. */
+	private async _timeOut(): Promise<RaceOutcome> {
+		await this._options.delay(this._options.waitMs);
+		return { timedOut: true };
 	}
 }

--- a/src/vs/platform/positronDocs/common/positronDocsTriggers.ts
+++ b/src/vs/platform/positronDocs/common/positronDocsTriggers.ts
@@ -71,6 +71,10 @@ export class PositronDocsTriggers {
 	async getLocalDocs(): Promise<ILocalDocs | undefined> {
 		const { cache, delay, logger, request, waitMs } = this._options;
 		if (!await this._options.isAiEnabled()) {
+			// Logged, not silent: from the caller's side this is indistinguishable
+			// from "no docs on disk", and the reason is the first thing anyone
+			// asking "why is the assistant using web docs?" needs to see.
+			logger.info(`${LOG_PREFIX} ai.enabled is off; not serving local docs`);
 			return undefined;
 		}
 

--- a/src/vs/platform/positronDocs/common/positronDocsTriggers.ts
+++ b/src/vs/platform/positronDocs/common/positronDocsTriggers.ts
@@ -6,7 +6,8 @@
 import { IDocsBundleRequest } from './positronDocsBundle.js';
 import { IDocsLogger, ILocalDocs } from './positronDocsIO.js';
 
-const LOG_PREFIX = '[positron-docs]';
+// Matches the cache module's prefix so one grep covers the whole feature.
+const LOG_PREFIX = '[llm-docs]';
 
 /** The slice of PositronDocsCache the triggers need. */
 export interface IDocsCacheLike {

--- a/src/vs/platform/positronDocs/common/positronDocsTriggers.ts
+++ b/src/vs/platform/positronDocs/common/positronDocsTriggers.ts
@@ -1,0 +1,96 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IDocsBundleRequest } from './positronDocsBundle.js';
+import { IDocsLogger, ILocalDocs } from './positronDocsIO.js';
+
+const LOG_PREFIX = '[positron-docs]';
+
+/** The slice of PositronDocsCache the triggers need. */
+export interface IDocsCacheLike {
+	ensure(request: IDocsBundleRequest): Promise<ILocalDocs | undefined>;
+	peek(request: IDocsBundleRequest): Promise<ILocalDocs | undefined>;
+	invalidate(): void;
+}
+
+export interface IPositronDocsTriggersOptions {
+	readonly cache: IDocsCacheLike;
+	readonly request: IDocsBundleRequest;
+	readonly logger: IDocsLogger;
+	/** Read live: ai.enabled is WINDOW-scoped and toggles without a reload. */
+	readonly isAiEnabled: () => Promise<boolean>;
+	/** How long getLocalDocs() waits for an in-flight fetch. */
+	readonly waitMs: number;
+	/** Injected so tests control the timeout without fake timers. */
+	readonly delay: (ms: number) => Promise<void>;
+}
+
+/** Race outcome, tagged so a resolved-but-undefined fetch stays distinguishable. */
+type RaceOutcome =
+	| { readonly timedOut: false; readonly docs: ILocalDocs | undefined }
+	| { readonly timedOut: true };
+
+/**
+ * The three entry points into one operation.
+ *
+ * Launch and config-flip are fire-and-forget with no timeout, since nothing is
+ * waiting on them. Only `getLocalDocs()` is bounded, because a slow link must
+ * not stall an assistant response.
+ */
+export class PositronDocsTriggers {
+
+	constructor(private readonly _options: IPositronDocsTriggersOptions) { }
+
+	/** Launch trigger, and the tail of a config flip. Never throws. */
+	async runBackgroundFetch(): Promise<void> {
+		if (!await this._options.isAiEnabled()) {
+			this._options.logger.info(`${LOG_PREFIX} ai.enabled is off; not fetching docs`);
+			return;
+		}
+		try {
+			await this._options.cache.ensure(this._options.request);
+		} catch (error) {
+			// A background trigger has no caller to surface this to, and a docs
+			// download failing is not worth interrupting anyone over.
+			this._options.logger.warn(`${LOG_PREFIX} background docs fetch failed: ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}
+
+	/** ai.enabled false-to-true: the one in-session re-attempt the design allows. */
+	async onAiEnabledFlippedTrue(): Promise<void> {
+		this._options.cache.invalidate();
+		await this.runBackgroundFetch();
+	}
+
+	/**
+	 * First-need trigger. Starts the operation if idle, joins it if in flight,
+	 * or returns the completed result.
+	 */
+	async getLocalDocs(): Promise<ILocalDocs | undefined> {
+		const { cache, delay, logger, request, waitMs } = this._options;
+		if (!await this._options.isAiEnabled()) {
+			return undefined;
+		}
+
+		const fetching: Promise<RaceOutcome> = cache.ensure(request)
+			.then(docs => ({ timedOut: false as const, docs }))
+			.catch(error => {
+				logger.warn(`${LOG_PREFIX} docs fetch failed: ${error instanceof Error ? error.message : String(error)}`);
+				return { timedOut: false as const, docs: undefined };
+			});
+		const timingOut: Promise<RaceOutcome> = delay(waitMs).then(() => ({ timedOut: true as const }));
+
+		const winner = await Promise.race([fetching, timingOut]);
+		if (!winner.timedOut) {
+			return winner.docs;
+		}
+
+		// The download continues in the background and is available to the next
+		// call; only this caller stops waiting. The cache-present rule still
+		// applies, so hand back whatever is already on disk.
+		logger.info(`${LOG_PREFIX} local docs not ready within ${waitMs}ms; continuing in the background`);
+		return await cache.peek(request);
+	}
+}

--- a/src/vs/platform/positronDocs/test/common/fakes.ts
+++ b/src/vs/platform/positronDocs/test/common/fakes.ts
@@ -145,6 +145,13 @@ export interface IFakeHttpRoute {
 	readonly throws?: string;
 	/** Response size in bytes for the maxBytes check; defaults to body length. */
 	readonly byteLength?: number;
+	/**
+	 * Awaited before the response is produced, on both GET and HEAD, so a test
+	 * can suspend one caller inside its request and run another window's work in
+	 * the gap. Deterministic by construction: the test decides when the request
+	 * resumes, rather than hoping a timer lands in the right interleaving.
+	 */
+	readonly onRequest?: () => Promise<void>;
 }
 
 export class FakeHttpClient implements IDocsHttpClient {
@@ -160,6 +167,9 @@ export class FakeHttpClient implements IDocsHttpClient {
 	async get(url: string, options?: IDocsHttpGetOptions): Promise<IDocsHttpResponse> {
 		this.getCalls.push(url);
 		const route = this.routes.get(url) ?? { status: 404 };
+		if (route.onRequest) {
+			await route.onRequest();
+		}
 		if (route.throws) {
 			throw new Error(route.throws);
 		}
@@ -179,6 +189,12 @@ export class FakeHttpClient implements IDocsHttpClient {
 	async head(url: string): Promise<IDocsHttpResponse> {
 		this.headCalls.push(url);
 		const route = this.routes.get(url) ?? { status: 404 };
+		// Honoured here as well as in get(): a release build's convergence probe
+		// is a HEAD, so a test pausing that probe would otherwise be ignored
+		// silently rather than failing.
+		if (route.onRequest) {
+			await route.onRequest();
+		}
 		if (route.throws) {
 			throw new Error(route.throws);
 		}

--- a/src/vs/platform/positronDocs/test/common/positronDocsBundle.vitest.ts
+++ b/src/vs/platform/positronDocs/test/common/positronDocsBundle.vitest.ts
@@ -90,6 +90,12 @@ describe('parseManifest', () => {
 		['malformed JSON', '{ not json'],
 		['missing version', JSON.stringify({ schema: 1, profile: 'positron', fileCount: 90, docsBaseUrl: 'x', generated: 'y' })],
 		['non-numeric fileCount', JSON.stringify({ ...JSON.parse(valid), fileCount: 'ninety' })],
+		// The version becomes a directory name under the cache root, so anything
+		// that could steer a rename out of it has to be rejected at parse time.
+		['a version that escapes the cache root', JSON.stringify({ ...JSON.parse(valid), version: '../../evil' })],
+		['a version that is a parent reference', JSON.stringify({ ...JSON.parse(valid), version: '..' })],
+		['an absolute version', JSON.stringify({ ...JSON.parse(valid), version: '/etc/passwd' })],
+		['a version with a Windows separator', JSON.stringify({ ...JSON.parse(valid), version: '..\\evil' })],
 	])('rejects %s', (_label, raw) => {
 		expect(parseManifest(raw)).toBeUndefined();
 	});

--- a/src/vs/platform/positronDocs/test/common/positronDocsCache.vitest.ts
+++ b/src/vs/platform/positronDocs/test/common/positronDocsCache.vitest.ts
@@ -501,6 +501,54 @@ describe('PositronDocsCache: a cache installed mid-attempt', () => {
 	});
 });
 
+describe('PositronDocsCache: peek', () => {
+	it('serves the installed bundle off disk while a fetch is still in flight', async () => {
+		const ctx = setup();
+		ctx.publish(LATEST_ZIP, payload('2026.04.0-100'), 'etag-april');
+		await ctx.cache.ensure(request({ quality: 'dailies' }));
+
+		// The next session, with a download that never completes. This is the
+		// bounded-wait path: getLocalDocs() stops waiting and peeks, and the
+		// cache-present rule says the bundle already on disk is still served.
+		let release!: () => void;
+		const held = new Promise<void>(resolve => { release = resolve; });
+		const next = new PositronDocsCache({
+			rootPath: ROOT, files: ctx.files, archive: ctx.archive, logger: ctx.logger,
+			now: () => 2_000_000, newId: () => 'peek',
+			http: { get: async () => { await held; throw new Error('ENOTFOUND'); }, head: url => ctx.http.head(url) },
+		});
+		const pending = next.ensure(request({ quality: 'dailies' }));
+
+		const peeked = await next.peek(request({ quality: 'dailies' }));
+
+		expect(peeked?.version).toBe('2026.04.0-100');
+		expect(peeked?.path).toBe(`${ROOT}/2026.04.0-100`);
+
+		release();
+		await pending;
+	});
+
+	it('returns undefined on a cold cache', async () => {
+		const ctx = setup();
+		expect(await ctx.cache.peek(request())).toBeUndefined();
+	});
+
+	it('returns the completed result once an attempt has finished', async () => {
+		const ctx = setup();
+		ctx.publish(EXACT_ZIP, payload('2026.05.0-179'));
+		await ctx.cache.ensure(request());
+
+		// The session's answer is fixed after ensure(), so peek hands back the
+		// memoized result rather than re-validating the directory. Deleting the
+		// directory is what tells the two branches apart.
+		await ctx.files.delete(`${ROOT}/2026.05.0-179`);
+
+		expect((await ctx.cache.peek(request()))?.version).toBe('2026.05.0-179');
+		// A fresh cache has nothing memoized, so it reads the truth on disk.
+		expect(await ctx.makeCache().peek(request())).toBeUndefined();
+	});
+});
+
 describe('PositronDocsCache: single flight', () => {
 	it('joins two concurrent calls into one download', async () => {
 		const ctx = setup();

--- a/src/vs/platform/positronDocs/test/common/positronDocsCache.vitest.ts
+++ b/src/vs/platform/positronDocs/test/common/positronDocsCache.vitest.ts
@@ -555,35 +555,40 @@ describe('PositronDocsCache: a cache installed mid-attempt', () => {
 	// on web docs until the next relaunch.
 	it('serves a bundle another window installed while this attempt was in flight', async () => {
 		const ctx = setup();
-		ctx.publish(LATEST_ZIP, payload('2026.05.0-179'));
+		const windowA = ctx.openWindow('a');
+		const windowB = ctx.openWindow('b');
 
-		let release!: () => void;
-		const held = new Promise<void>(resolve => { release = resolve; });
-		const secondWindow = new PositronDocsCache({
-			rootPath: ROOT, files: ctx.files, archive: ctx.archive, logger: ctx.logger,
-			now: () => 2_000_000, newId: () => 'second',
-			http: {
-				// Hangs until released, then fails: this window reads an empty cache
-				// on the way in and never installs anything itself.
-				get: async () => { await held; throw new Error('ENOTFOUND'); },
-				head: url => ctx.http.head(url),
-			},
-		});
+		// A's download stalls where the test can hold it, then fails outright. It
+		// reads an empty cache on the way in and never installs anything itself.
+		const download = pausable();
+		windowA.http.route(LATEST_ZIP, { status: 200, throws: 'ENOTFOUND', onRequest: download.hold });
+		windowB.publish(LATEST_ZIP, payload('2026.05.0-179'));
 
-		const pending = secondWindow.ensure(request({ quality: 'dailies' }));
-		expect((await ctx.cache.ensure(request({ quality: 'dailies' })))?.version).toBe('2026.05.0-179');
+		// Deliberately not awaited: A has to stay in flight while B runs. Await
+		// it here and there is no gap for B to install into.
+		const windowAFinished = windowA.cache.ensure(DAILIES);
 
-		release();
-		expect((await pending)?.version).toBe('2026.05.0-179');
+		await download.reached;
+		await windowB.cache.ensure(DAILIES);
+		expect((await ctx.readState()).version).toBe('2026.05.0-179');
 
-		// The failing window records its failure without erasing the version the
-		// other window installed. Losing that would orphan the bundle on disk for
-		// every later session, not just this one.
+		download.release();
+		// Cache-present rule across windows: A serves what B installed rather
+		// than memoizing undefined and staying on web docs until the next launch.
+		expect((await windowAFinished)?.version).toBe('2026.05.0-179');
+
+		// A records its failure without erasing the version B wrote. state.json is
+		// the only thing that names a bundle directory, so overwriting it would
+		// strand B's bundle on disk for every later session, not just this one.
 		const state = await ctx.readState();
 		expect({ version: state.version, lastError: state.lastError }).toEqual({
 			version: '2026.05.0-179',
 			lastError: 'ENOTFOUND',
 		});
+		// Still recorded as a failure, so the throttle works.
+		expect(state.lastFailureAt).toBeDefined();
+		// A later session finds the bundle too, rather than downloading it again.
+		expect((await ctx.makeCache().peek(DAILIES))?.version).toBe('2026.05.0-179');
 	});
 });
 
@@ -774,47 +779,6 @@ describe('PositronDocsCache: superseded version cleanup', () => {
 		const relaunch = await ctx.makeCache().ensure(request());
 		expect(relaunch?.version).toBe('2026.05.0-179');
 		expect(await ctx.files.exists(`${ROOT}/2026.04.0-100`)).toBe(false);
-	});
-
-	/**
-	 * Two Positron windows share one cache directory.
-	 *
-	 * Window A starts a download that will fail slowly. While it is still
-	 * waiting, window B finishes installing a good bundle. When A finally fails
-	 * it must record that failure without erasing the version B just wrote:
-	 * state.json is the only thing that names a bundle directory, so overwriting
-	 * it strands B's bundle on disk where no later session will ever find it.
-	 */
-	it('does not orphan a bundle another window installed mid-fetch', async () => {
-		const ctx = setup();
-		const windowA = ctx.openWindow('a');
-		const windowB = ctx.openWindow('b');
-
-		// Window A's download stalls where the test can hold it, then 503s.
-		const download = pausable();
-		windowA.http.route(LATEST_ZIP, { status: 503, onRequest: download.hold });
-		windowB.publish(LATEST_ZIP, payload('2026.05.0-179'));
-
-		// Deliberately not awaited: A has to stay in flight while B runs. Await
-		// it here and there is no gap for B to install into.
-		const windowAFinished = windowA.cache.ensure(DAILIES);
-
-		await download.reached;
-		await windowB.cache.ensure(DAILIES);
-		expect((await ctx.readState()).version).toBe('2026.05.0-179');
-
-		download.release();
-		const docsA = await windowAFinished;
-
-		const state = await ctx.readState();
-		// B's version survives A's failure write...
-		expect(state.version).toBe('2026.05.0-179');
-		// ...and A's failure is still recorded, so the throttle works.
-		expect(state.lastFailureAt).toBeDefined();
-		// Cache-present rule across windows: A serves what B installed.
-		expect(docsA?.version).toBe('2026.05.0-179');
-		// A later session finds it too, rather than downloading it again.
-		expect((await ctx.makeCache().peek(DAILIES))?.version).toBe('2026.05.0-179');
 	});
 
 	it('never touches entries it did not supersede, including another window in-flight work', async () => {

--- a/src/vs/platform/positronDocs/test/common/positronDocsCache.vitest.ts
+++ b/src/vs/platform/positronDocs/test/common/positronDocsCache.vitest.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 /// <reference types="vitest/globals" />
 
+import { DeferredPromise } from '../../../../base/common/async.js';
 import { DOCS_MAX_DOWNLOAD_BYTES, IDocsBundleRequest } from '../../common/positronDocsBundle.js';
 import { PositronDocsCache } from '../../common/positronDocsCache.js';
 import { fakeDigest, fakeZip, FakeArchive, FakeFileStore, FakeHttpClient, recordingLogger } from './fakes.js';
@@ -55,15 +56,65 @@ function setup() {
 		newId: () => `id${++ids}`,
 	});
 	const cache = makeCache();
+	/** Route `zipUrl` on `client`, with a matching checksum file. */
+	const publishOn = (client: FakeHttpClient, zipUrl: string, body: string, etag?: string) => {
+		client.route(zipUrl, { status: 200, body, etag });
+		client.route(`${zipUrl}.sha256sum`, { status: 200, body: `${fakeDigest(body)}  bundle.zip\n` });
+	};
 	return {
 		cache, makeCache, files, http, archive, logger,
 		advance: (ms: number) => { clock += ms; },
 		/** The persisted cache state, parsed. */
 		readState: async () => JSON.parse(await files.readFile(STATE_PATH)),
 		/** Serve `zipUrl` with a matching, correctly-formatted checksum file. */
-		publish: (zipUrl: string, body: string, etag?: string) => {
-			http.route(zipUrl, { status: 200, body, etag });
-			http.route(`${zipUrl}.sha256sum`, { status: 200, body: `${fakeDigest(body)}  bundle.zip\n` });
+		publish: (zipUrl: string, body: string, etag?: string) => publishOn(http, zipUrl, body, etag),
+		/**
+		 * A separate extension host over the same cache directory.
+		 *
+		 * Unlike `makeCache()` - which models the *next launch* of this window,
+		 * sharing its HTTP client - this models a *concurrent* window: its own
+		 * HTTP stack, so one window can see the alias fail while the other sees
+		 * it succeed, over the same files.
+		 */
+		openWindow: (idPrefix: string) => {
+			const windowHttp = new FakeHttpClient();
+			const windowLogger = recordingLogger();
+			let windowIds = 0;
+			return {
+				http: windowHttp,
+				logger: windowLogger,
+				cache: new PositronDocsCache({
+					rootPath: ROOT, files, archive,
+					http: windowHttp,
+					logger: windowLogger,
+					now: () => clock,
+					newId: () => `${idPrefix}${++windowIds}`,
+				}),
+				publish: (zipUrl: string, body: string, etag?: string) => publishOn(windowHttp, zipUrl, body, etag),
+			};
+		},
+	};
+}
+
+/** A dailies build, which targets the `latest` alias with no HEAD probe. */
+const DAILIES = request({ quality: 'dailies' });
+
+/**
+ * A pause the test can drop inside a fake HTTP request.
+ *
+ * Pass `hold` as a route's `onRequest`. Then `await reached` blocks until the
+ * request arrives, and `release()` lets it finish. The interleaving is chosen
+ * by the test rather than by timing, so there is nothing here to flake.
+ */
+function pausable() {
+	const arrived = new DeferredPromise<void>();
+	const released = new DeferredPromise<void>();
+	return {
+		reached: arrived.p,
+		release: () => released.complete(undefined),
+		hold: async () => {
+			arrived.complete(undefined);
+			await released.p;
 		},
 	};
 }
@@ -688,6 +739,47 @@ describe('PositronDocsCache: superseded version cleanup', () => {
 		const relaunch = await ctx.makeCache().ensure(request());
 		expect(relaunch?.version).toBe('2026.05.0-179');
 		expect(await ctx.files.exists(`${ROOT}/2026.04.0-100`)).toBe(false);
+	});
+
+	/**
+	 * Two Positron windows share one cache directory.
+	 *
+	 * Window A starts a download that will fail slowly. While it is still
+	 * waiting, window B finishes installing a good bundle. When A finally fails
+	 * it must record that failure without erasing the version B just wrote:
+	 * state.json is the only thing that names a bundle directory, so overwriting
+	 * it strands B's bundle on disk where no later session will ever find it.
+	 */
+	it('does not orphan a bundle another window installed mid-fetch', async () => {
+		const ctx = setup();
+		const windowA = ctx.openWindow('a');
+		const windowB = ctx.openWindow('b');
+
+		// Window A's download stalls where the test can hold it, then 503s.
+		const download = pausable();
+		windowA.http.route(LATEST_ZIP, { status: 503, onRequest: download.hold });
+		windowB.publish(LATEST_ZIP, payload('2026.05.0-179'));
+
+		// Deliberately not awaited: A has to stay in flight while B runs. Await
+		// it here and there is no gap for B to install into.
+		const windowAFinished = windowA.cache.ensure(DAILIES);
+
+		await download.reached;
+		await windowB.cache.ensure(DAILIES);
+		expect((await ctx.readState()).version).toBe('2026.05.0-179');
+
+		download.release();
+		const docsA = await windowAFinished;
+
+		const state = await ctx.readState();
+		// B's version survives A's failure write...
+		expect(state.version).toBe('2026.05.0-179');
+		// ...and A's failure is still recorded, so the throttle works.
+		expect(state.lastFailureAt).toBeDefined();
+		// Cache-present rule across windows: A serves what B installed.
+		expect(docsA?.version).toBe('2026.05.0-179');
+		// A later session finds it too, rather than downloading it again.
+		expect((await ctx.makeCache().peek(DAILIES))?.version).toBe('2026.05.0-179');
 	});
 
 	it('never touches entries it did not supersede, including another window in-flight work', async () => {

--- a/src/vs/platform/positronDocs/test/common/positronDocsCache.vitest.ts
+++ b/src/vs/platform/positronDocs/test/common/positronDocsCache.vitest.ts
@@ -202,12 +202,15 @@ describe('PositronDocsCache: download rejections on a cold cache', () => {
 	// Each of these must leave no version directory behind and return
 	// undefined, so the assistant falls back to the web exactly as it does
 	// today. Task 6 asserts the same failures against a warm cache.
-	// `expectedLog` is what makes each case falsifiable: every rejection produces
-	// the same three observable outcomes, so without a distinct reason a test
-	// would still pass if the code refused the bundle for the wrong reason.
+	// `expectedLog` is what makes each case falsifiable: every one of these
+	// produces the same three observable outcomes, so without a distinct reason a
+	// test would still pass if the code refused the bundle for the wrong reason.
 	// Matched across both levels on purpose - which level each outcome kind logs
 	// at is asserted separately below.
-	async function expectRejected(configure: (ctx: ReturnType<typeof setup>) => void, expectedLog: string) {
+	//
+	// Named for the outcome rather than "rejected": an unpublished bundle is a
+	// different outcome kind in the source, and it belongs here too.
+	async function expectNoInstall(configure: (ctx: ReturnType<typeof setup>) => void, expectedLog: string) {
 		const ctx = setup();
 		configure(ctx);
 		const docs = await ctx.cache.ensure(request());
@@ -223,51 +226,52 @@ describe('PositronDocsCache: download rejections on a cold cache', () => {
 		// rather than left implicit, because "no docs and no directory" is what
 		// keeps the assistant on web docs, and several tests below use an
 		// all-404 CDN as setup without ever checking that outcome.
-		const ctx = await expectRejected(c => {
+		const ctx = await expectNoInstall(c => {
 			c.http.route(EXACT_ZIP, { status: 404 });
 			c.http.route(LATEST_ZIP, { status: 404 });
 		}, `no bundle published at ${LATEST_ZIP}`);
 
-		// Nothing but the state file: no version directory under any name, so a
-		// later convergence pass still sees a cold cache.
-		expect(ctx.files.listUnder(ROOT).filter(p => p !== STATE_PATH)).toEqual([]);
+		// Nothing at all, state.json included. That last part is load-bearing: a
+		// state file here would carry lastFailureAt and throttle the next attempt,
+		// which is exactly what the 404 path must not do.
+		expect(ctx.files.listUnder(ROOT)).toEqual([]);
 	});
 
 	it('rejects when the checksum file 404s', async () => {
-		await expectRejected(c => {
+		await expectNoInstall(c => {
 			c.http.route(EXACT_ZIP, { status: 200, body: payload('2026.05.0-179') });
 			c.http.route(`${EXACT_ZIP}.sha256sum`, { status: 404 });
 		}, 'checksum file unavailable (HTTP 404)');
 	});
 
 	it('rejects when the checksum file is unparseable', async () => {
-		await expectRejected(c => {
+		await expectNoInstall(c => {
 			c.http.route(EXACT_ZIP, { status: 200, body: payload('2026.05.0-179') });
 			c.http.route(`${EXACT_ZIP}.sha256sum`, { status: 200, body: '<!DOCTYPE html><html>404</html>' });
 		}, 'checksum file does not hold a sha256 digest');
 	});
 
 	it('rejects when the digest does not match the zip', async () => {
-		await expectRejected(c => {
+		await expectNoInstall(c => {
 			c.http.route(EXACT_ZIP, { status: 200, body: payload('2026.05.0-179') });
 			c.http.route(`${EXACT_ZIP}.sha256sum`, { status: 200, body: `${'b'.repeat(64)}  bundle.zip` });
 		}, 'digest mismatch');
 	});
 
 	it('rejects a corrupt archive', async () => {
-		await expectRejected(c => {
+		await expectNoInstall(c => {
 			c.publish(EXACT_ZIP, 'not-a-zip-at-all');
 		}, 'corrupt archive');
 	});
 
 	it('rejects an archive entry that escapes the target', async () => {
-		await expectRejected(c => {
+		await expectNoInstall(c => {
 			c.publish(EXACT_ZIP, fakeZip({ 'llms.txt': 'x', '../../evil.sh': 'rm -rf /' }));
 		}, 'archive entry escapes the target: ../../evil.sh');
 	});
 
 	it('rejects a bundle whose schema is not 1', async () => {
-		await expectRejected(c => {
+		await expectNoInstall(c => {
 			c.publish(EXACT_ZIP, fakeZip({
 				'bundle.json': JSON.stringify({ schema: 2, profile: 'positron', version: '2026.05.0-179', generated: 'g', docsBaseUrl: 'd', fileCount: 2 }),
 				'llms.txt': '# Positron\n',
@@ -276,7 +280,7 @@ describe('PositronDocsCache: download rejections on a cold cache', () => {
 	});
 
 	it('rejects a bundle whose fileCount does not match', async () => {
-		await expectRejected(c => {
+		await expectNoInstall(c => {
 			c.publish(EXACT_ZIP, fakeZip({
 				'bundle.json': JSON.stringify({ schema: 1, profile: 'positron', version: '2026.05.0-179', generated: 'g', docsBaseUrl: 'd', fileCount: 99 }),
 				'llms.txt': '# Positron\n',
@@ -285,7 +289,7 @@ describe('PositronDocsCache: download rejections on a cold cache', () => {
 	});
 
 	it('aborts a download that exceeds the size cap', async () => {
-		await expectRejected(c => {
+		await expectNoInstall(c => {
 			c.http.route(EXACT_ZIP, { status: 200, body: payload('2026.05.0-179'), byteLength: DOCS_MAX_DOWNLOAD_BYTES + 1 });
 			c.http.route(`${EXACT_ZIP}.sha256sum`, { status: 200, body: `${'c'.repeat(64)}  x` });
 		}, `exceeds ${DOCS_MAX_DOWNLOAD_BYTES} bytes`);
@@ -297,7 +301,7 @@ describe('PositronDocsCache: download rejections on a cold cache', () => {
 		// object. The fake only enforces a cap it was given, so this is also what
 		// proves the checksum request carries maxBytes at all - the zip's own
 		// oversize test cannot cover that, it passes with the second call uncapped.
-		await expectRejected(c => {
+		await expectNoInstall(c => {
 			c.http.route(EXACT_ZIP, { status: 200, body: payload('2026.05.0-179') });
 			c.http.route(`${EXACT_ZIP}.sha256sum`, {
 				status: 200,
@@ -308,19 +312,19 @@ describe('PositronDocsCache: download rejections on a cold cache', () => {
 	});
 
 	it('returns undefined on a network failure', async () => {
-		await expectRejected(c => {
+		await expectNoInstall(c => {
 			c.http.route(EXACT_ZIP, { status: 0, throws: 'getaddrinfo ENOTFOUND cdn.posit.co' });
 		}, 'getaddrinfo ENOTFOUND cdn.posit.co');
 	});
 
 	it('returns undefined on a 5xx', async () => {
-		await expectRejected(c => {
+		await expectNoInstall(c => {
 			c.http.route(EXACT_ZIP, { status: 503 });
 		}, 'unexpected HTTP 503 from HEAD');
 	});
 
 	it('returns undefined on a disk write error', async () => {
-		await expectRejected(c => {
+		await expectNoInstall(c => {
 			c.publish(EXACT_ZIP, payload('2026.05.0-179'));
 			c.files.failWritesUnder = ROOT;
 		}, 'ENOSPC');
@@ -331,13 +335,13 @@ describe('PositronDocsCache: download rejections on a cold cache', () => {
 		// unreachable CDN stays at info. A payload that arrived and was refused
 		// is different: something is wrong with what was published, and that
 		// earns a warn.
-		const failed = await expectRejected(c => {
+		const failed = await expectNoInstall(c => {
 			c.http.route(EXACT_ZIP, { status: 404 });
 			c.http.route(LATEST_ZIP, { status: 0, throws: 'getaddrinfo ENOTFOUND cdn.posit.co' });
 		}, 'fetch failed for');
 		expect(failed.logger.warns).toEqual([]);
 
-		const refused = await expectRejected(c => {
+		const refused = await expectNoInstall(c => {
 			c.publish(EXACT_ZIP, 'not-a-zip-at-all');
 		}, 'corrupt archive');
 		expect(refused.logger.warns.join('\n')).toContain('rejected bundle from');

--- a/src/vs/platform/positronDocs/test/common/positronDocsCache.vitest.ts
+++ b/src/vs/platform/positronDocs/test/common/positronDocsCache.vitest.ts
@@ -5,7 +5,7 @@
 /// <reference types="vitest/globals" />
 
 import { DeferredPromise } from '../../../../base/common/async.js';
-import { DOCS_MAX_DOWNLOAD_BYTES, IDocsBundleRequest } from '../../common/positronDocsBundle.js';
+import { DOCS_MAX_CHECKSUM_BYTES, DOCS_MAX_DOWNLOAD_BYTES, IDocsBundleRequest } from '../../common/positronDocsBundle.js';
 import { PositronDocsCache } from '../../common/positronDocsCache.js';
 import { fakeDigest, fakeZip, FakeArchive, FakeFileStore, FakeHttpClient, recordingLogger } from './fakes.js';
 
@@ -218,6 +218,21 @@ describe('PositronDocsCache: download rejections on a cold cache', () => {
 		return ctx;
 	}
 
+	it('installs nothing when no bundle is published at either URL', async () => {
+		// The pre-launch state: neither exact nor latest exists yet. Asserted
+		// rather than left implicit, because "no docs and no directory" is what
+		// keeps the assistant on web docs, and several tests below use an
+		// all-404 CDN as setup without ever checking that outcome.
+		const ctx = await expectRejected(c => {
+			c.http.route(EXACT_ZIP, { status: 404 });
+			c.http.route(LATEST_ZIP, { status: 404 });
+		}, `no bundle published at ${LATEST_ZIP}`);
+
+		// Nothing but the state file: no version directory under any name, so a
+		// later convergence pass still sees a cold cache.
+		expect(ctx.files.listUnder(ROOT).filter(p => p !== STATE_PATH)).toEqual([]);
+	});
+
 	it('rejects when the checksum file 404s', async () => {
 		await expectRejected(c => {
 			c.http.route(EXACT_ZIP, { status: 200, body: payload('2026.05.0-179') });
@@ -274,6 +289,22 @@ describe('PositronDocsCache: download rejections on a cold cache', () => {
 			c.http.route(EXACT_ZIP, { status: 200, body: payload('2026.05.0-179'), byteLength: DOCS_MAX_DOWNLOAD_BYTES + 1 });
 			c.http.route(`${EXACT_ZIP}.sha256sum`, { status: 200, body: `${'c'.repeat(64)}  x` });
 		}, `exceeds ${DOCS_MAX_DOWNLOAD_BYTES} bytes`);
+	});
+
+	it('aborts a checksum download that exceeds the checksum cap', async () => {
+		// A separate, much smaller cap than the zip's: the checksum file is one
+		// line, so anything larger is a redirect to an error page or a hostile
+		// object. The fake only enforces a cap it was given, so this is also what
+		// proves the checksum request carries maxBytes at all - the zip's own
+		// oversize test cannot cover that, it passes with the second call uncapped.
+		await expectRejected(c => {
+			c.http.route(EXACT_ZIP, { status: 200, body: payload('2026.05.0-179') });
+			c.http.route(`${EXACT_ZIP}.sha256sum`, {
+				status: 200,
+				body: `${'c'.repeat(64)}  x`,
+				byteLength: DOCS_MAX_CHECKSUM_BYTES + 1,
+			});
+		}, `exceeds ${DOCS_MAX_CHECKSUM_BYTES} bytes`);
 	});
 
 	it('returns undefined on a network failure', async () => {

--- a/src/vs/platform/positronDocs/test/common/positronDocsTriggers.vitest.ts
+++ b/src/vs/platform/positronDocs/test/common/positronDocsTriggers.vitest.ts
@@ -54,6 +54,9 @@ describe('PositronDocsTriggers: ai.enabled gating', () => {
 		expect(await ctx.triggers.getLocalDocs()).toBeUndefined();
 		expect(ctx.ensure).not.toHaveBeenCalled();
 		expect(ctx.peek).not.toHaveBeenCalled();
+		// Undefined here looks identical to "no docs on disk" from the caller's
+		// side, so the reason has to be in the log.
+		expect(ctx.logger.infos.join('\n')).toContain('ai.enabled is off; not serving local docs');
 	});
 
 	it('fetches on launch when ai.enabled is true', async () => {

--- a/src/vs/platform/positronDocs/test/common/positronDocsTriggers.vitest.ts
+++ b/src/vs/platform/positronDocs/test/common/positronDocsTriggers.vitest.ts
@@ -1,0 +1,129 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+/// <reference types="vitest/globals" />
+
+import { IDocsBundleRequest } from '../../common/positronDocsBundle.js';
+import { ILocalDocs } from '../../common/positronDocsIO.js';
+import { IDocsCacheLike, PositronDocsTriggers } from '../../common/positronDocsTriggers.js';
+import { recordingLogger } from './fakes.js';
+
+const REQUEST: IDocsBundleRequest = {
+	quality: 'dailies', positronVersion: '2026.05.0', positronBuildNumber: 179,
+	profile: 'positron', baseUrl: 'https://cdn.posit.co/positron/releases/docs',
+};
+
+const DOCS: ILocalDocs = {
+	path: '/cache/2026.05.0-179', schema: 1, version: '2026.05.0-179',
+	profile: 'positron', docsBaseUrl: 'https://positron.posit.co/', isExactMatch: true,
+};
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>(r => { resolve = r; });
+	return { promise, resolve };
+}
+
+function setup(options: { aiEnabled?: boolean; peeked?: ILocalDocs } = {}) {
+	const ensureGate = deferred<ILocalDocs | undefined>();
+	const timeoutGate = deferred<void>();
+	const ensure = vi.fn(() => ensureGate.promise);
+	const peek = vi.fn(async () => options.peeked);
+	const invalidate = vi.fn();
+	const cache: IDocsCacheLike = { ensure, peek, invalidate };
+	const logger = recordingLogger();
+	const triggers = new PositronDocsTriggers({
+		cache, request: REQUEST, logger,
+		isAiEnabled: async () => options.aiEnabled ?? true,
+		waitMs: 10_000,
+		delay: () => timeoutGate.promise,
+	});
+	return { triggers, ensure, peek, invalidate, logger, ensureGate, timeoutGate };
+}
+
+describe('PositronDocsTriggers: ai.enabled gating', () => {
+	it('does not fetch on launch when ai.enabled is false', async () => {
+		const ctx = setup({ aiEnabled: false });
+		await ctx.triggers.runBackgroundFetch();
+		expect(ctx.ensure).not.toHaveBeenCalled();
+	});
+
+	it('returns undefined from getLocalDocs without touching the cache when ai.enabled is false', async () => {
+		const ctx = setup({ aiEnabled: false });
+		expect(await ctx.triggers.getLocalDocs()).toBeUndefined();
+		expect(ctx.ensure).not.toHaveBeenCalled();
+		expect(ctx.peek).not.toHaveBeenCalled();
+	});
+
+	it('fetches on launch when ai.enabled is true', async () => {
+		const ctx = setup();
+		const running = ctx.triggers.runBackgroundFetch();
+		ctx.ensureGate.resolve(DOCS);
+		await running;
+		expect(ctx.ensure).toHaveBeenCalledTimes(1);
+	});
+
+	it('invalidates and refetches when ai.enabled flips true', async () => {
+		const ctx = setup();
+		const running = ctx.triggers.onAiEnabledFlippedTrue();
+		ctx.ensureGate.resolve(DOCS);
+		await running;
+		expect(ctx.invalidate).toHaveBeenCalledTimes(1);
+		expect(ctx.ensure).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('PositronDocsTriggers: joining and the bounded wait', () => {
+	// The single-flight itself lives in PositronDocsCache (covered by
+	// positronDocsCache.vitest.ts). What matters here is that the triggers
+	// delegate every caller to it rather than keeping their own state.
+	it('serves every concurrent caller from the same delegated fetch', async () => {
+		const ctx = setup();
+		const background = ctx.triggers.runBackgroundFetch();
+		const first = ctx.triggers.getLocalDocs();
+		const second = ctx.triggers.getLocalDocs();
+		ctx.ensureGate.resolve(DOCS);
+
+		expect(await first).toEqual(DOCS);
+		expect(await second).toEqual(DOCS);
+		await background;
+		// Each caller went straight to the cache with the same request, and none
+		// of them short-circuited or held a private copy of the result.
+		expect(ctx.ensure.mock.calls).toEqual([[REQUEST], [REQUEST], [REQUEST]]);
+	});
+
+	it('returns the existing cached bundle on timeout, and does not cancel the fetch', async () => {
+		const ctx = setup({ peeked: DOCS });
+		const pending = ctx.triggers.getLocalDocs();
+		ctx.timeoutGate.resolve();
+
+		expect(await pending).toEqual(DOCS);
+		expect(ctx.peek).toHaveBeenCalledTimes(1);
+		expect(ctx.logger.infos.join('\n')).toContain('continuing in the background');
+
+		// The download was never cancelled; only the caller stopped waiting.
+		ctx.ensureGate.resolve(DOCS);
+		expect(await ctx.triggers.getLocalDocs()).toEqual(DOCS);
+	});
+
+	it('returns undefined on timeout with a cold cache', async () => {
+		const ctx = setup({ peeked: undefined });
+		const pending = ctx.triggers.getLocalDocs();
+		ctx.timeoutGate.resolve();
+		expect(await pending).toBeUndefined();
+	});
+
+	it('swallows a fetch rejection so a background trigger never throws', async () => {
+		const ctx = setup();
+		const ensure = vi.fn(async () => { throw new Error('boom'); });
+		const triggers = new PositronDocsTriggers({
+			cache: { ensure, peek: async () => undefined, invalidate: vi.fn() },
+			request: REQUEST, logger: ctx.logger,
+			isAiEnabled: async () => true, waitMs: 10_000, delay: () => new Promise(() => { }),
+		});
+
+		await expect(triggers.runBackgroundFetch()).resolves.toBeUndefined();
+		expect(ctx.logger.warns.join('\n')).toContain('boom');
+	});
+});

--- a/src/vs/platform/positronDocs/test/common/positronDocsTriggers.vitest.ts
+++ b/src/vs/platform/positronDocs/test/common/positronDocsTriggers.vitest.ts
@@ -42,6 +42,24 @@ function setup(options: { aiEnabled?: boolean; peeked?: ILocalDocs } = {}) {
 	return { triggers, ensure, peek, invalidate, logger, ensureGate, timeoutGate };
 }
 
+/**
+ * Triggers whose fetch always rejects, over a cold cache. The timeout never
+ * fires, so the rejection is what settles the race in `getLocalDocs`.
+ */
+function rejectingTriggers(logger: ReturnType<typeof recordingLogger>, message: string) {
+	return new PositronDocsTriggers({
+		cache: {
+			ensure: async () => { throw new Error(message); },
+			peek: async () => undefined,
+			invalidate: vi.fn(),
+		},
+		request: REQUEST, logger,
+		isAiEnabled: async () => true,
+		waitMs: 10_000,
+		delay: () => new Promise(() => { }),
+	});
+}
+
 describe('PositronDocsTriggers: ai.enabled gating', () => {
 	it('does not fetch on launch when ai.enabled is false', async () => {
 		const ctx = setup({ aiEnabled: false });
@@ -119,14 +137,22 @@ describe('PositronDocsTriggers: joining and the bounded wait', () => {
 
 	it('swallows a fetch rejection so a background trigger never throws', async () => {
 		const ctx = setup();
-		const ensure = vi.fn(async () => { throw new Error('boom'); });
-		const triggers = new PositronDocsTriggers({
-			cache: { ensure, peek: async () => undefined, invalidate: vi.fn() },
-			request: REQUEST, logger: ctx.logger,
-			isAiEnabled: async () => true, waitMs: 10_000, delay: () => new Promise(() => { }),
-		});
 
-		await expect(triggers.runBackgroundFetch()).resolves.toBeUndefined();
-		expect(ctx.logger.warns.join('\n')).toContain('boom');
+		await expect(rejectingTriggers(ctx.logger, 'boom').runBackgroundFetch()).resolves.toBeUndefined();
+
+		// The full prefix, not just 'boom': getLocalDocs logs its own rejection
+		// with a different one, and the two must stay distinguishable in a log.
+		expect(ctx.logger.warns.join('\n')).toContain('[llm-docs] background docs fetch failed: boom');
+	});
+
+	it('returns undefined when the fetch rejects rather than propagating to the caller', async () => {
+		// getLocalDocs sits on an assistant response path, so a rejected download
+		// has to read as "no local docs" and fall back to the web, not throw.
+		const ctx = setup();
+
+		expect(await rejectingTriggers(ctx.logger, 'boom').getLocalDocs()).toBeUndefined();
+
+		expect(ctx.logger.warns.join('\n')).toContain('[llm-docs] docs fetch failed: boom');
+		expect(ctx.logger.warns.join('\n')).not.toContain('background docs fetch failed');
 	});
 });

--- a/src/vs/platform/positronDocs/test/common/positronDocsValidate.vitest.ts
+++ b/src/vs/platform/positronDocs/test/common/positronDocsValidate.vitest.ts
@@ -8,8 +8,15 @@ import { guardEntryNames, validateExtractedBundle } from '../../common/positronD
 import { FakeFileStore } from './fakes.js';
 
 describe('guardEntryNames', () => {
-	it('accepts ordinary nested entries', () => {
-		expect(guardEntryNames(['llms.txt', 'bundle.json', 'release-notes/release-2026-05.llms.md'])).toBeUndefined();
+	it.each([
+		['ordinary nested entries', ['llms.txt', 'bundle.json', 'release-notes/release-2026-05.llms.md']],
+		// The depth counter exists so traversal that stays inside the target is
+		// allowed. Without a case that must pass, rejecting every '..' outright
+		// would satisfy the whole rejection table below.
+		['a traversal that nets back inside', ['docs/../llms.txt']],
+		['a leading ./ and a doubled slash', ['./llms.txt', 'docs//welcome.llms.md']],
+	])('accepts %s', (_label, names) => {
+		expect(guardEntryNames(names)).toBeUndefined();
 	});
 
 	// The archive arrives over the network, so we assert these ourselves rather

--- a/src/vs/workbench/api/common/extHostExtensionService.ts
+++ b/src/vs/workbench/api/common/extHostExtensionService.ts
@@ -106,6 +106,11 @@ export abstract class AbstractExtHostExtensionService extends Disposable impleme
 	private readonly _readyToStartExtensionHost: Barrier;
 	private readonly _readyToRunExtensions: Barrier;
 	private readonly _eagerExtensionsActivated: Barrier;
+	// --- Start Positron ---
+	// Opened at the same 10-second-capped point upstream fires onStartupFinished,
+	// so background work can defer until the activation burst has drained.
+	private readonly _positronStartupFinished: Barrier;
+	// --- End Positron ---
 
 	private readonly _activationEventsReader: SyncedActivationEventsReader;
 	protected readonly _myRegistry: ExtensionDescriptionRegistry;
@@ -158,6 +163,9 @@ export abstract class AbstractExtHostExtensionService extends Disposable impleme
 		this._readyToStartExtensionHost = new Barrier();
 		this._readyToRunExtensions = new Barrier();
 		this._eagerExtensionsActivated = new Barrier();
+		// --- Start Positron ---
+		this._positronStartupFinished = new Barrier();
+		// --- End Positron ---
 		this._activationEventsReader = new SyncedActivationEventsReader(this._initData.extensions.activationEvents);
 		this._globalRegistry = new ExtensionDescriptionRegistry(this._activationEventsReader, this._initData.extensions.allExtensions);
 		const myExtensionsSet = new ExtensionIdentifierSet(this._initData.extensions.myExtensions);
@@ -698,10 +706,30 @@ export abstract class AbstractExtHostExtensionService extends Disposable impleme
 
 		Promise.race([eagerExtensionsActivation, timeout(10000)]).then(() => {
 			this._activateAllStartupFinished();
+			// --- Start Positron ---
+			// Positron: see whenStartupFinished(). Opened here rather than off
+			// _eagerExtensionsActivated because that barrier waits on the uncapped
+			// activation promise, and a hung eager extension must delay dependent
+			// background work rather than suppress it.
+			this._positronStartupFinished.open();
+			// --- End Positron ---
 		});
 
 		return eagerExtensionsActivation;
 	}
+
+	// --- Start Positron ---
+	/**
+	 * Resolves once eager extension activation has settled, at the same point
+	 * upstream fires `onStartupFinished`. Capped at 10 seconds, so a hung eager
+	 * extension delays this rather than never resolving it. Background work that
+	 * must not compete with startup waits on this instead of guessing a delay
+	 * from construction time.
+	 */
+	public async whenStartupFinished(): Promise<void> {
+		await this._positronStartupFinished.wait();
+	}
+	// --- End Positron ---
 
 	private _handleWorkspaceContainsEagerExtensions(folders: ReadonlyArray<vscode.WorkspaceFolder>): Promise<void> {
 		if (folders.length === 0) {

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -46,6 +46,7 @@ import { ExtHostPositronEphemeralStorage } from './extHostPositronEphemeralStora
 import { IExtHostStorage } from '../extHostStorage.js';
 import { ExtHostLifecycle } from './extHostLifecycle.js';
 import { ExtHostFileTransfer } from './extHostFileTransfer.js';
+import { IExtHostDocs } from './extHostDocs.js';
 
 /**
  * Factory interface for creating an instance of the Positron API.
@@ -65,6 +66,7 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 	const extHostCommands = accessor.get(IExtHostCommands);
 	const extHostLogService = accessor.get(ILogService);
 	const extHostConfiguration = accessor.get(IExtHostConfiguration);
+	const extHostDocs = accessor.get(IExtHostDocs);
 
 	// Retrieve the raw `ExtHostWebViews` object from the rpcProtocol; this
 	// object is needed to create webviews, and was previously created in
@@ -643,6 +645,16 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			}
 		};
 
+		const docs: typeof positron.docs = {
+			/**
+			 * Get the locally cached Positron documentation, or undefined when
+			 * the caller should fall back to the web.
+			 */
+			async getLocalDocs(): Promise<positron.docs.LocalDocs | undefined> {
+				return await extHostDocs.getLocalDocs();
+			},
+		};
+
 		const workspace: typeof positron.workspace = {
 			registerConfigurationMigrations(migrations: ReadonlyArray<positron.ConfigurationMigrationSpec>): vscode.Disposable {
 				extHostConfiguration.registerConfigurationMigrations(extension, migrations);
@@ -662,6 +674,7 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			methods,
 			environment,
 			paths,
+			docs,
 			connections,
 			dataConnections,
 			dataExplorer,

--- a/src/vs/workbench/api/common/positron/extHostDocs.ts
+++ b/src/vs/workbench/api/common/positron/extHostDocs.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type * as positron from 'positron';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+
+export const IExtHostDocs = createDecorator<IExtHostDocs>('IExtHostDocs');
+
+export interface IExtHostDocs {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Resolve the locally cached docs bundle, or undefined when there are none
+	 * and the caller should use the web.
+	 */
+	getLocalDocs(): Promise<positron.docs.LocalDocs | undefined>;
+}
+
+/**
+ * Web-worker extension host variant.
+ *
+ * Returns undefined rather than throwing NotSupportedError, because undefined
+ * is already the documented "no local docs, use the web" contract - throwing
+ * would force every caller to wrap the call in a try/catch to get the same
+ * behaviour. There is nothing to download to: the worker host has no
+ * filesystem, and base/node/zip.ts is node-layer only.
+ */
+export class WorkerExtHostDocs implements IExtHostDocs {
+	readonly _serviceBrand: undefined;
+
+	async getLocalDocs(): Promise<positron.docs.LocalDocs | undefined> {
+		return undefined;
+	}
+}

--- a/src/vs/workbench/api/node/extHost.node.services.ts
+++ b/src/vs/workbench/api/node/extHost.node.services.ts
@@ -31,6 +31,10 @@ import { IExtHostMpcService } from '../common/extHostMcp.js';
 import { NodeExtHostMpcService } from './extHostMcpNode.js';
 import { IExtHostAuthentication } from '../common/extHostAuthentication.js';
 import { NodeExtHostAuthentication } from './extHostAuthentication.js';
+// --- Start Positron ---
+import { IExtHostDocs } from '../common/positron/extHostDocs.js';
+import { NodeExtHostDocs } from './positron/extHostDocsNode.js';
+// --- End Positron ---
 
 // #########################################################################
 // ###                                                                   ###
@@ -53,3 +57,10 @@ registerSingleton(IExtHostTerminalService, ExtHostTerminalService, Instantiation
 registerSingleton(IExtHostTunnelService, NodeExtHostTunnelService, InstantiationType.Eager);
 registerSingleton(IExtHostVariableResolverProvider, NodeExtHostVariableResolverProviderService, InstantiationType.Eager);
 registerSingleton(IExtHostMpcService, NodeExtHostMpcService, InstantiationType.Eager);
+
+// --- Start Positron ---
+// Eager so the launch trigger has something to fire from. The constructor only
+// arms a scheduler off the startup-finished signal and installs a config
+// listener; it never touches the network.
+registerSingleton(IExtHostDocs, NodeExtHostDocs, InstantiationType.Eager);
+// --- End Positron ---

--- a/src/vs/workbench/api/node/positron/extHostDocsNode.ts
+++ b/src/vs/workbench/api/node/positron/extHostDocsNode.ts
@@ -27,7 +27,7 @@ import { IExtHostExtensionService } from '../../common/extHostExtensionService.j
 import { IExtHostInitDataService } from '../../common/extHostInitDataService.js';
 import { IExtHostDocs } from '../../common/positron/extHostDocs.js';
 
-const CACHE_DIR_NAME = 'positron-docs';
+const CACHE_DIR_NAME = 'positron-llm-docs';
 const DEFAULT_BUNDLE_BASE_URL = 'https://cdn.posit.co/positron/releases/docs';
 const REQUEST_TIMEOUT_MS = 30_000;
 const MAX_REDIRECTS = 3;
@@ -223,7 +223,8 @@ export class NodeExtHostDocs extends Disposable implements IExtHostDocs {
 		super();
 
 		// A sibling of globalStorage, so there is no risk of colliding with an
-		// extension id. Profile-scoped, which is one 655KB copy per profile.
+		// extension id. Kept namespaced because the rest of that directory is
+		// upstream-owned. Profile-scoped, which is one 655KB copy per profile.
 		const root = joinPath(dirname(initData.environment.globalStorageHome), CACHE_DIR_NAME);
 		const request = deriveBundleRequest(initData, process.env);
 		const logger = {

--- a/src/vs/workbench/api/node/positron/extHostDocsNode.ts
+++ b/src/vs/workbench/api/node/positron/extHostDocsNode.ts
@@ -1,0 +1,251 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createHash } from 'crypto';
+import * as fs from 'fs';
+import type * as positron from 'positron';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { dirname as pathDirname } from '../../../../base/common/path.js';
+import { isWorkbench } from '../../../../base/common/platform.js';
+import { dirname, joinPath } from '../../../../base/common/resources.js';
+import { generateUuid } from '../../../../base/common/uuid.js';
+import * as pfs from '../../../../base/node/pfs.js';
+import { extract } from '../../../../base/node/zip.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import product from '../../../../platform/product/common/product.js';
+import { DocsProfile, IDocsBundleRequest } from '../../../../platform/positronDocs/common/positronDocsBundle.js';
+import { PositronDocsCache } from '../../../../platform/positronDocs/common/positronDocsCache.js';
+import { IDocsArchive, IDocsFileStore, IDocsHttpClient, IDocsHttpGetOptions, IDocsHttpResponse } from '../../../../platform/positronDocs/common/positronDocsIO.js';
+import { AI_ENABLED_KEY } from '../../../contrib/positronAssistant/common/positronAIConfigurationKeys.js';
+import { IExtHostConfiguration } from '../../common/extHostConfiguration.js';
+import { IExtHostInitDataService } from '../../common/extHostInitDataService.js';
+import { IExtHostDocs } from '../../common/positron/extHostDocs.js';
+
+const CACHE_DIR_NAME = 'positron-docs';
+const DEFAULT_BUNDLE_BASE_URL = 'https://cdn.posit.co/positron/releases/docs';
+const REQUEST_TIMEOUT_MS = 30_000;
+const MAX_REDIRECTS = 3;
+
+/**
+ * HTTP over node's https/http. The extension host already proxy-patches these
+ * modules, so enterprise proxies work with no extra code here.
+ */
+class NodeDocsHttpClient implements IDocsHttpClient {
+
+	async get(url: string, options: IDocsHttpGetOptions = {}): Promise<IDocsHttpResponse> {
+		return await this._request(url, 'GET', options, 0);
+	}
+
+	async head(url: string): Promise<IDocsHttpResponse> {
+		return await this._request(url, 'HEAD', {}, 0);
+	}
+
+	private async _request(url: string, method: 'GET' | 'HEAD', options: IDocsHttpGetOptions, redirects: number): Promise<IDocsHttpResponse> {
+		// Dynamically imported: http and https are slow to load, so the layer
+		// rules only allow them as type imports at module scope.
+		const { request: sendRequest } = url.startsWith('http:') ? await import('http') : await import('https');
+		return await new Promise<IDocsHttpResponse>((resolve, reject) => {
+			const headers: Record<string, string> = {};
+			if (options.etag) {
+				headers['If-None-Match'] = options.etag;
+			}
+			const request = sendRequest(url, { method, headers, timeout: REQUEST_TIMEOUT_MS }, response => {
+				const status = response.statusCode ?? 0;
+				const location = response.headers.location;
+
+				if (status >= 300 && status < 400 && location) {
+					response.resume();
+					if (redirects >= MAX_REDIRECTS) {
+						reject(new Error(`too many redirects for ${url}`));
+						return;
+					}
+					resolve(this._request(new URL(location, url).toString(), method, options, redirects + 1));
+					return;
+				}
+
+				const etag = typeof response.headers.etag === 'string' ? response.headers.etag : undefined;
+				if (method === 'HEAD' || status === 304 || status !== 200) {
+					response.resume();
+					resolve({ status, etag });
+					return;
+				}
+
+				const chunks: Buffer[] = [];
+				let total = 0;
+				response.on('data', (chunk: Buffer) => {
+					total += chunk.length;
+					if (options.maxBytes !== undefined && total > options.maxBytes) {
+						// A wrong or hostile object must not be able to fill the disk.
+						request.destroy();
+						reject(new Error(`response from ${url} exceeds ${options.maxBytes} bytes`));
+						return;
+					}
+					chunks.push(chunk);
+				});
+				response.on('end', () => resolve({ status, etag, body: new Uint8Array(Buffer.concat(chunks)) }));
+				response.on('error', reject);
+			});
+			request.on('timeout', () => request.destroy(new Error(`request to ${url} timed out`)));
+			request.on('error', reject);
+			request.end();
+		});
+	}
+}
+
+class NodeDocsFileStore implements IDocsFileStore {
+
+	async exists(target: string): Promise<boolean> {
+		return await pfs.Promises.exists(target);
+	}
+
+	async readFile(target: string): Promise<string> {
+		return await fs.promises.readFile(target, 'utf8');
+	}
+
+	async writeFile(target: string, data: string | Uint8Array): Promise<void> {
+		await fs.promises.mkdir(pathDirname(target), { recursive: true });
+		await pfs.Promises.writeFile(target, data);
+	}
+
+	async mkdir(target: string): Promise<void> {
+		await fs.promises.mkdir(target, { recursive: true });
+	}
+
+	async rename(from: string, to: string): Promise<void> {
+		await pfs.Promises.rename(from, to);
+	}
+
+	async delete(target: string): Promise<void> {
+		await pfs.Promises.rm(target);
+	}
+
+	/** Empty array for a missing path, which is what the port promises. */
+	async readdir(target: string): Promise<string[]> {
+		try {
+			return await pfs.Promises.readdir(target);
+		} catch {
+			return [];
+		}
+	}
+
+	async isDirectory(target: string): Promise<boolean> {
+		try {
+			return (await fs.promises.stat(target)).isDirectory();
+		} catch {
+			return false;
+		}
+	}
+
+	async sha256(target: string): Promise<string> {
+		return createHash('sha256').update(await fs.promises.readFile(target)).digest('hex');
+	}
+}
+
+class NodeDocsArchive implements IDocsArchive {
+
+	/**
+	 * List entries without extracting, so the traversal guard runs first.
+	 *
+	 * base/node/zip.ts does not export an entry-listing helper, and its own
+	 * check (`targetDirName.startsWith(targetPath)`) is a prefix test that
+	 * ignores the final path segment. The archive arrives over the network, so
+	 * we open it with yauzl ourselves and assert before writing anything.
+	 */
+	async entryNames(zipPath: string): Promise<string[]> {
+		const { open } = await import('yauzl');
+		return await new Promise<string[]>((resolve, reject) => {
+			open(zipPath, { lazyEntries: true }, (error, zipfile) => {
+				if (error || !zipfile) {
+					reject(error ?? new Error(`could not open ${zipPath}`));
+					return;
+				}
+				const names: string[] = [];
+				zipfile.on('entry', entry => {
+					names.push(entry.fileName);
+					zipfile.readEntry();
+				});
+				zipfile.on('end', () => resolve(names));
+				zipfile.on('error', reject);
+				zipfile.readEntry();
+			});
+		});
+	}
+
+	async extract(zipPath: string, targetPath: string): Promise<void> {
+		await extract(zipPath, targetPath, {}, CancellationToken.None);
+	}
+}
+
+/**
+ * Work out what this build should ask the CDN for.
+ *
+ * Exported as a free function so it is testable without constructing the
+ * service or reaching into its internals.
+ */
+export function deriveBundleRequest(initData: IExtHostInitDataService, env: NodeJS.ProcessEnv): IDocsBundleRequest {
+	const override = env['POSITRON_LLMS_DOCS_URL'];
+	return {
+		quality: initData.quality,
+		positronVersion: initData.positronVersion,
+		positronBuildNumber: initData.positronBuildNumber,
+		// isWorkbench is already `!!process.env.RS_SERVER_URL` on the node side.
+		profile: (isWorkbench ? 'workbench' : 'positron') as DocsProfile,
+		baseUrl: (override && override.length > 0)
+			? override
+			: (product.positronLlmsDocsUrl ?? DEFAULT_BUNDLE_BASE_URL),
+	};
+}
+
+export class NodeExtHostDocs extends Disposable implements IExtHostDocs {
+
+	readonly _serviceBrand: undefined;
+
+	private readonly _cache: PositronDocsCache;
+	private readonly _request: IDocsBundleRequest;
+
+	constructor(
+		@IExtHostInitDataService initData: IExtHostInitDataService,
+		@IExtHostConfiguration private readonly _configuration: IExtHostConfiguration,
+		@ILogService private readonly _logService: ILogService,
+	) {
+		super();
+
+		// A sibling of globalStorage, so there is no risk of colliding with an
+		// extension id. Profile-scoped, which is one 655KB copy per profile.
+		const root = joinPath(dirname(initData.environment.globalStorageHome), CACHE_DIR_NAME);
+
+		this._request = deriveBundleRequest(initData, process.env);
+		this._cache = new PositronDocsCache({
+			rootPath: root.fsPath,
+			http: new NodeDocsHttpClient(),
+			files: new NodeDocsFileStore(),
+			archive: new NodeDocsArchive(),
+			logger: {
+				info: message => this._logService.info(message),
+				warn: message => this._logService.warn(message),
+			},
+			now: () => Date.now(),
+			newId: () => generateUuid(),
+		});
+	}
+
+	async getLocalDocs(): Promise<positron.docs.LocalDocs | undefined> {
+		if (!await this._isAiEnabled()) {
+			return undefined;
+		}
+		return await this._cache.ensure(this._request);
+	}
+
+	/**
+	 * Read live rather than caching at construction: ai.enabled is
+	 * WINDOW-scoped and toggles without a reload, so a value captured once in
+	 * the constructor goes stale.
+	 */
+	private async _isAiEnabled(): Promise<boolean> {
+		const provider = await this._configuration.getConfigProvider();
+		return provider.getConfiguration().get<boolean>(AI_ENABLED_KEY) === true;
+	}
+}

--- a/src/vs/workbench/api/node/positron/extHostDocsNode.ts
+++ b/src/vs/workbench/api/node/positron/extHostDocsNode.ts
@@ -40,8 +40,14 @@ const GET_LOCAL_DOCS_WAIT_MS = 10_000;
 /**
  * HTTP over node's https/http. The extension host already proxy-patches these
  * modules, so enterprise proxies work with no extra code here.
+ *
+ * Exported for its own tests: the byte cap, the redirect cap, and the timeout
+ * are enforced here and nowhere else, so the cache's fakes cannot cover them.
  */
-class NodeDocsHttpClient implements IDocsHttpClient {
+export class NodeDocsHttpClient implements IDocsHttpClient {
+
+	/** Injected so a test can assert the timeout without waiting 30 seconds. */
+	constructor(private readonly _timeoutMs: number = REQUEST_TIMEOUT_MS) { }
 
 	async get(url: string, options: IDocsHttpGetOptions = {}): Promise<IDocsHttpResponse> {
 		return await this._request(url, 'GET', options, 0);
@@ -60,7 +66,7 @@ class NodeDocsHttpClient implements IDocsHttpClient {
 			if (options.etag) {
 				headers['If-None-Match'] = options.etag;
 			}
-			const request = sendRequest(url, { method, headers, timeout: REQUEST_TIMEOUT_MS }, response => {
+			const request = sendRequest(url, { method, headers, timeout: this._timeoutMs }, response => {
 				const status = response.statusCode ?? 0;
 				const location = response.headers.location;
 

--- a/src/vs/workbench/api/node/positron/extHostDocsNode.ts
+++ b/src/vs/workbench/api/node/positron/extHostDocsNode.ts
@@ -6,6 +6,7 @@
 import { createHash } from 'crypto';
 import * as fs from 'fs';
 import type * as positron from 'positron';
+import { RunOnceScheduler } from '../../../../base/common/async.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { dirname as pathDirname } from '../../../../base/common/path.js';
@@ -19,8 +20,10 @@ import product from '../../../../platform/product/common/product.js';
 import { DocsProfile, IDocsBundleRequest } from '../../../../platform/positronDocs/common/positronDocsBundle.js';
 import { PositronDocsCache } from '../../../../platform/positronDocs/common/positronDocsCache.js';
 import { IDocsArchive, IDocsFileStore, IDocsHttpClient, IDocsHttpGetOptions, IDocsHttpResponse } from '../../../../platform/positronDocs/common/positronDocsIO.js';
+import { PositronDocsTriggers } from '../../../../platform/positronDocs/common/positronDocsTriggers.js';
 import { AI_ENABLED_KEY } from '../../../contrib/positronAssistant/common/positronAIConfigurationKeys.js';
 import { IExtHostConfiguration } from '../../common/extHostConfiguration.js';
+import { IExtHostExtensionService } from '../../common/extHostExtensionService.js';
 import { IExtHostInitDataService } from '../../common/extHostInitDataService.js';
 import { IExtHostDocs } from '../../common/positron/extHostDocs.js';
 
@@ -28,6 +31,11 @@ const CACHE_DIR_NAME = 'positron-docs';
 const DEFAULT_BUNDLE_BASE_URL = 'https://cdn.posit.co/positron/releases/docs';
 const REQUEST_TIMEOUT_MS = 30_000;
 const MAX_REDIRECTS = 3;
+// Measured from the startup-finished signal, not from construction: the delay
+// exists to stay clear of the eager-activation burst, and construction happens
+// before it. See the design spec, "The launch anchor".
+const LAUNCH_DELAY_MS = 5_000;
+const GET_LOCAL_DOCS_WAIT_MS = 10_000;
 
 /**
  * HTTP over node's https/http. The extension host already proxy-patches these
@@ -203,12 +211,13 @@ export class NodeExtHostDocs extends Disposable implements IExtHostDocs {
 
 	readonly _serviceBrand: undefined;
 
-	private readonly _cache: PositronDocsCache;
-	private readonly _request: IDocsBundleRequest;
+	private readonly _triggers: PositronDocsTriggers;
+	private readonly _launch: RunOnceScheduler;
 
 	constructor(
 		@IExtHostInitDataService initData: IExtHostInitDataService,
 		@IExtHostConfiguration private readonly _configuration: IExtHostConfiguration,
+		@IExtHostExtensionService private readonly _extensionService: IExtHostExtensionService,
 		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
@@ -216,27 +225,82 @@ export class NodeExtHostDocs extends Disposable implements IExtHostDocs {
 		// A sibling of globalStorage, so there is no risk of colliding with an
 		// extension id. Profile-scoped, which is one 655KB copy per profile.
 		const root = joinPath(dirname(initData.environment.globalStorageHome), CACHE_DIR_NAME);
+		const request = deriveBundleRequest(initData, process.env);
+		const logger = {
+			info: (message: string) => this._logService.info(message),
+			warn: (message: string) => this._logService.warn(message),
+		};
 
-		this._request = deriveBundleRequest(initData, process.env);
-		this._cache = new PositronDocsCache({
+		const cache = new PositronDocsCache({
 			rootPath: root.fsPath,
 			http: new NodeDocsHttpClient(),
 			files: new NodeDocsFileStore(),
 			archive: new NodeDocsArchive(),
-			logger: {
-				info: message => this._logService.info(message),
-				warn: message => this._logService.warn(message),
-			},
+			logger,
 			now: () => Date.now(),
 			newId: () => generateUuid(),
 		});
+
+		this._triggers = new PositronDocsTriggers({
+			cache,
+			request,
+			logger,
+			isAiEnabled: () => this._isAiEnabled(),
+			waitMs: GET_LOCAL_DOCS_WAIT_MS,
+			delay: ms => new Promise(resolve => setTimeout(resolve, ms)),
+		});
+
+		// Launch trigger. Nothing above touched the network or the disk: the
+		// constructor only arms a scheduler and installs a config listener. That
+		// discipline is what keeps a slow download off the extension
+		// activation path, and the construction test asserts it.
+		this._launch = this._register(new RunOnceScheduler(() => { void this._triggers.runBackgroundFetch(); }, LAUNCH_DELAY_MS));
+		void this._scheduleLaunchAfterStartup();
+
+		void this._listenForAiEnabledFlip();
 	}
 
 	async getLocalDocs(): Promise<positron.docs.LocalDocs | undefined> {
-		if (!await this._isAiEnabled()) {
-			return undefined;
+		return await this._triggers.getLocalDocs();
+	}
+
+	/**
+	 * The launch delay is measured from the startup-finished signal rather than
+	 * from construction, so the download stays clear of the eager-activation
+	 * burst instead of guessing how long that burst takes. The signal is capped
+	 * at 10 seconds upstream, so a hung eager extension delays this fetch rather
+	 * than suppressing it. Trigger 3 (getLocalDocs) is the backstop either way.
+	 */
+	private async _scheduleLaunchAfterStartup(): Promise<void> {
+		await this._extensionService.whenStartupFinished();
+		if (this._store.isDisposed) {
+			return;
 		}
-		return await this._cache.ensure(this._request);
+		this._launch.schedule();
+	}
+
+	/**
+	 * ai.enabled toggles without a window reload, so a mid-session flip must
+	 * work. getConfigProvider() is barrier-gated, hence the async helper rather
+	 * than an inline subscription.
+	 */
+	private async _listenForAiEnabledFlip(): Promise<void> {
+		const provider = await this._configuration.getConfigProvider();
+		if (this._store.isDisposed) {
+			return;
+		}
+		let enabled = provider.getConfiguration().get<boolean>(AI_ENABLED_KEY) === true;
+		this._register(provider.onDidChangeConfiguration(async event => {
+			if (!event.affectsConfiguration(AI_ENABLED_KEY)) {
+				return;
+			}
+			const next = provider.getConfiguration().get<boolean>(AI_ENABLED_KEY) === true;
+			const flippedOn = next && !enabled;
+			enabled = next;
+			if (flippedOn) {
+				await this._triggers.onAiEnabledFlippedTrue();
+			}
+		}));
 	}
 
 	/**

--- a/src/vs/workbench/api/test/node/positron/extHostDocsNode.vitest.ts
+++ b/src/vs/workbench/api/test/node/positron/extHostDocsNode.vitest.ts
@@ -6,7 +6,11 @@
 
 import { randomUUID } from 'crypto';
 import { existsSync } from 'fs';
+// Type-only, with createServer dynamically imported below: the layer rule bans
+// http at module scope, and the source module honours it the same way.
+import type { IncomingMessage, Server, ServerResponse } from 'http';
 import type * as vscode from 'vscode';
+import type { AddressInfo } from 'net';
 import { tmpdir } from 'os';
 import { Emitter } from '../../../../../base/common/event.js';
 import { Disposable } from '../../../../../base/common/lifecycle.js';
@@ -19,7 +23,7 @@ import { AI_ENABLED_KEY } from '../../../../contrib/positronAssistant/common/pos
 import { ExtHostConfigProvider, IExtHostConfiguration } from '../../../common/extHostConfiguration.js';
 import { IExtHostExtensionService } from '../../../common/extHostExtensionService.js';
 import { IExtHostInitDataService } from '../../../common/extHostInitDataService.js';
-import { deriveBundleRequest, NodeExtHostDocs } from '../../../node/positron/extHostDocsNode.js';
+import { deriveBundleRequest, NodeDocsHttpClient, NodeExtHostDocs } from '../../../node/positron/extHostDocsNode.js';
 
 // `quality` is spelled out in the default rather than filled in with `??`, so a
 // caller can pass `quality: undefined` to model a dev build.
@@ -263,5 +267,165 @@ describe('NodeExtHostDocs ai.enabled flip', () => {
 		await ctx.set(true);
 
 		expect(ctx.onAiEnabledFlippedTrue).not.toHaveBeenCalled();
+	});
+});
+
+describe('NodeDocsHttpClient', () => {
+	// Driven against a real http server rather than a mocked `http` module. The
+	// byte cap, the redirect cap, and the timeout are enforced by this class and
+	// by nothing else - PositronDocsCache's fakes reimplement the cap as a size
+	// comparison - so a test that stubs `request` would assert the fake again.
+	let server: Server;
+	let base: string;
+	/** Set per test to decide how the server answers. */
+	let handler: (req: IncomingMessage, res: ServerResponse) => void;
+
+	beforeEach(async () => {
+		const { createServer } = await import('http');
+		server = createServer((req, res) => handler(req, res));
+		await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+		base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+	});
+
+	afterEach(async () => {
+		// The connection-failure test closes the server itself, so this is
+		// conditional rather than unconditional.
+		if (server.listening) {
+			await new Promise<void>(resolve => server.close(() => resolve()));
+		}
+	});
+
+	it('returns the body and the etag on a 200', async () => {
+		handler = (_req, res) => res.writeHead(200, { etag: '"v1"' }).end('hello');
+
+		const response = await new NodeDocsHttpClient().get(`${base}/bundle.zip`);
+
+		expect(response.status).toBe(200);
+		expect(response.etag).toBe('"v1"');
+		expect(new TextDecoder().decode(response.body)).toBe('hello');
+	});
+
+	it('sends If-None-Match and reports a 304 with no body', async () => {
+		let seen: string | undefined;
+		handler = (req, res) => {
+			seen = req.headers['if-none-match'];
+			res.writeHead(304, { etag: '"v1"' }).end();
+		};
+
+		const response = await new NodeDocsHttpClient().get(`${base}/bundle.zip`, { etag: '"v1"' });
+
+		expect(seen).toBe('"v1"');
+		expect(response.status).toBe(304);
+		expect(response.body).toBeUndefined();
+	});
+
+	it.each([404, 503])('reports HTTP %i without a body', async (status) => {
+		handler = (_req, res) => res.writeHead(status).end('an error page');
+
+		const response = await new NodeDocsHttpClient().get(`${base}/bundle.zip`);
+
+		expect(response.status).toBe(status);
+		expect(response.body).toBeUndefined();
+	});
+
+	it('reports a status and etag for HEAD without reading a body', async () => {
+		handler = (_req, res) => res.writeHead(200, { etag: '"v2"', 'content-length': '5' }).end();
+
+		const response = await new NodeDocsHttpClient().head(`${base}/bundle.zip`);
+
+		expect(response.status).toBe(200);
+		expect(response.etag).toBe('"v2"');
+		expect(response.body).toBeUndefined();
+	});
+
+	it('rejects and tears the request down once the response exceeds maxBytes', async () => {
+		// 8MB in 64KB chunks, far past what a socket buffer holds, so the server
+		// is still mid-stream when the cap trips. A payload small enough to buffer
+		// in one go would let the server finish writing either way, and the test
+		// would pass without the abort.
+		const total = 8 * 1024 * 1024;
+		let written = 0;
+		/** Resolves with whether the server finished writing before the socket died. */
+		let endedBeforeClose: Promise<boolean>;
+		handler = (_req, res) => {
+			endedBeforeClose = new Promise<boolean>(resolve => res.on('close', () => resolve(res.writableEnded)));
+			res.writeHead(200);
+			const pump = () => {
+				while (written < total) {
+					written += 64 * 1024;
+					if (!res.write('x'.repeat(64 * 1024))) {
+						res.once('drain', pump);
+						return;
+					}
+				}
+				res.end();
+			};
+			pump();
+		};
+
+		await expect(new NodeDocsHttpClient().get(`${base}/bundle.zip`, { maxBytes: 4096 }))
+			.rejects.toThrow(/exceeds 4096 bytes/);
+
+		// The abort is the point: without destroy() the client would keep reading
+		// and buffering all 8MB behind a rejection that has already been reported.
+		expect(await endedBeforeClose!).toBe(false);
+		expect(written).toBeLessThan(total);
+	});
+
+	it('follows a redirect and returns the final body', async () => {
+		handler = (req, res) => {
+			if (req.url === '/bundle.zip') {
+				res.writeHead(302, { location: '/moved.zip' }).end();
+				return;
+			}
+			res.writeHead(200).end('after the redirect');
+		};
+
+		const response = await new NodeDocsHttpClient().get(`${base}/bundle.zip`);
+
+		expect(new TextDecoder().decode(response.body)).toBe('after the redirect');
+	});
+
+	it('resolves a relative Location against the URL it came from', async () => {
+		handler = (req, res) => {
+			if (req.url === '/docs/bundle.zip') {
+				res.writeHead(301, { location: 'actual.zip' }).end();
+				return;
+			}
+			res.writeHead(200).end(req.url);
+		};
+
+		const response = await new NodeDocsHttpClient().get(`${base}/docs/bundle.zip`);
+
+		expect(new TextDecoder().decode(response.body)).toBe('/docs/actual.zip');
+	});
+
+	it('gives up rather than following a redirect loop', async () => {
+		let hops = 0;
+		handler = (_req, res) => {
+			hops++;
+			res.writeHead(302, { location: '/again.zip' }).end();
+		};
+
+		await expect(new NodeDocsHttpClient().get(`${base}/bundle.zip`)).rejects.toThrow(/too many redirects/);
+		// MAX_REDIRECTS hops are followed, and the one that would exceed it is not.
+		expect(hops).toBe(4);
+	});
+
+	it('rejects when the server never responds', async () => {
+		// Accepted and then left hanging, which is the failure a read timeout
+		// exists for: a connect timeout would not catch it.
+		handler = () => { };
+
+		await expect(new NodeDocsHttpClient(50).get(`${base}/bundle.zip`)).rejects.toThrow(/timed out/);
+	});
+
+	it('rejects when the connection fails', async () => {
+		// Bound, then closed, so the port is known to be free rather than guessed.
+		const port = (server.address() as AddressInfo).port;
+		await new Promise<void>(resolve => server.close(() => resolve()));
+
+		await expect(new NodeDocsHttpClient().get(`http://127.0.0.1:${port}/bundle.zip`))
+			.rejects.toThrow(/ECONNREFUSED/);
 	});
 });

--- a/src/vs/workbench/api/test/node/positron/extHostDocsNode.vitest.ts
+++ b/src/vs/workbench/api/test/node/positron/extHostDocsNode.vitest.ts
@@ -1,0 +1,92 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+/// <reference types="vitest/globals" />
+
+import { randomUUID } from 'crypto';
+import { existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from '../../../../../base/common/path.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { IExtHostConfiguration } from '../../../common/extHostConfiguration.js';
+import { IExtHostInitDataService } from '../../../common/extHostInitDataService.js';
+import { deriveBundleRequest, NodeExtHostDocs } from '../../../node/positron/extHostDocsNode.js';
+
+// `quality` is spelled out in the default rather than filled in with `??`, so a
+// caller can pass `quality: undefined` to model a dev build.
+function initData(overrides: { quality?: string | undefined; version?: string; build?: number } = { quality: 'releases' }) {
+	return stubInterface<IExtHostInitDataService>({
+		quality: overrides.quality,
+		positronVersion: overrides.version ?? '2026.05.0',
+		positronBuildNumber: overrides.build ?? 179,
+		environment: stubInterface<IExtHostInitDataService['environment']>({
+			globalStorageHome: URI.file('/userdata/User/globalStorage'),
+		}),
+	});
+}
+
+describe('deriveBundleRequest', () => {
+	it('reads version, build number, and quality from init data', () => {
+		expect(deriveBundleRequest(initData(), {})).toMatchObject({
+			quality: 'releases',
+			positronVersion: '2026.05.0',
+			positronBuildNumber: 179,
+		});
+	});
+
+	it('falls back to the product.json default when no env override is set', () => {
+		expect(deriveBundleRequest(initData(), {}).baseUrl)
+			.toBe('https://cdn.posit.co/positron/releases/docs');
+	});
+
+	it('lets POSITRON_LLMS_DOCS_URL take precedence over the product.json value', () => {
+		// This override is what makes the feature verifiable on demand against
+		// a local fixture server, since product.json is baked at build time.
+		expect(deriveBundleRequest(initData(), { POSITRON_LLMS_DOCS_URL: 'http://127.0.0.1:8099/docs' }).baseUrl)
+			.toBe('http://127.0.0.1:8099/docs');
+	});
+
+	it('ignores an empty POSITRON_LLMS_DOCS_URL rather than building a relative URL', () => {
+		expect(deriveBundleRequest(initData(), { POSITRON_LLMS_DOCS_URL: '' }).baseUrl)
+			.toBe('https://cdn.posit.co/positron/releases/docs');
+	});
+
+	it('resolves the profile to positron on desktop', () => {
+		// isWorkbench is false in the Vitest process, which has no RS_SERVER_URL.
+		expect(deriveBundleRequest(initData(), {}).profile).toBe('positron');
+	});
+
+	it('passes an undefined quality through for dev builds', () => {
+		expect(deriveBundleRequest(initData({ quality: undefined }), {}).quality).toBeUndefined();
+	});
+});
+
+describe('NodeExtHostDocs construction', () => {
+	// The one risk specific to hosting this on the extension host is a slow or
+	// hung download landing on an activation path. The constructor must only
+	// install a scheduler and a config listener, so it must not have created
+	// the cache directory or resolved the barrier-gated config provider.
+	it('performs no filesystem or configuration work', async () => {
+		const root = join(tmpdir(), `positron-docs-ctor-${randomUUID()}`);
+		const getConfigProvider = vi.fn(() => new Promise<never>(() => { }));
+		const service = new NodeExtHostDocs(
+			stubInterface<IExtHostInitDataService>({
+				quality: 'dailies',
+				positronVersion: '2026.05.0',
+				positronBuildNumber: 179,
+				environment: stubInterface<IExtHostInitDataService['environment']>({
+					globalStorageHome: URI.file(join(root, 'globalStorage')),
+				}),
+			}),
+			stubInterface<IExtHostConfiguration>({ getConfigProvider }),
+			new NullLogService(),
+		);
+
+		expect(existsSync(join(root, 'positron-docs'))).toBe(false);
+		expect(getConfigProvider).not.toHaveBeenCalled();
+		service.dispose();
+	});
+});

--- a/src/vs/workbench/api/test/node/positron/extHostDocsNode.vitest.ts
+++ b/src/vs/workbench/api/test/node/positron/extHostDocsNode.vitest.ts
@@ -13,8 +13,9 @@ import type * as vscode from 'vscode';
 import type { AddressInfo } from 'net';
 import { tmpdir } from 'os';
 import { Emitter } from '../../../../../base/common/event.js';
-import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { join } from '../../../../../base/common/path.js';
+import { assertDefined } from '../../../../../base/common/types.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
 import { PositronDocsTriggers } from '../../../../../platform/positronDocs/common/positronDocsTriggers.js';
@@ -92,6 +93,12 @@ function cacheRoot(label: string): string {
 }
 
 describe('NodeExtHostDocs construction', () => {
+	// Disposed from afterEach rather than at the end of each test: a failing
+	// assertion would skip an inline dispose() and leak the scheduler and the
+	// config listener into whatever runs next.
+	const store = new DisposableStore();
+	afterEach(() => store.clear());
+
 	// The one risk specific to hosting this on the extension host is a slow or
 	// hung download landing on an activation path. The constructor must only
 	// arm a scheduler and start installing a config listener, so with a config
@@ -100,7 +107,7 @@ describe('NodeExtHostDocs construction', () => {
 	it('performs no filesystem work and does not wait on startup or configuration', async () => {
 		const root = cacheRoot('ctor');
 		const getConfigProvider = vi.fn(() => new Promise<never>(() => { }));
-		const service = new NodeExtHostDocs(
+		store.add(new NodeExtHostDocs(
 			initDataAt(root),
 			stubInterface<IExtHostConfiguration>({ getConfigProvider }),
 			stubInterface<IExtHostExtensionService>({
@@ -108,26 +115,31 @@ describe('NodeExtHostDocs construction', () => {
 				whenStartupFinished: () => new Promise<void>(() => { }),
 			}),
 			new NullLogService(),
-		);
+		));
 
 		expect(existsSync(join(root, 'positron-llm-docs'))).toBe(false);
 		// Called, but never awaited to completion - the listener install is a
 		// detached continuation, not part of construction.
 		expect(getConfigProvider).toHaveBeenCalledTimes(1);
-		service.dispose();
 	});
 });
 
 describe('NodeExtHostDocs launch anchor', () => {
+	const store = new DisposableStore();
 	beforeEach(() => vi.useFakeTimers());
-	afterEach(() => vi.useRealTimers());
+	afterEach(() => {
+		// Before the timers go back to real: the scheduler being disposed is
+		// still armed under fake time.
+		store.clear();
+		vi.useRealTimers();
+	});
 
 	function build(startupFinished: Promise<void>) {
 		// Spying on the trigger rather than the ports: this asserts *when* the
 		// launch fetch fires, and running the real one would reach the network.
 		const runBackgroundFetch = vi.spyOn(PositronDocsTriggers.prototype, 'runBackgroundFetch')
 			.mockResolvedValue(undefined);
-		const service = new NodeExtHostDocs(
+		const service = store.add(new NodeExtHostDocs(
 			initDataAt(cacheRoot('anchor')),
 			stubInterface<IExtHostConfiguration>({
 				getConfigProvider: async () => stubInterface<ExtHostConfigProvider>({
@@ -137,7 +149,7 @@ describe('NodeExtHostDocs launch anchor', () => {
 			}),
 			stubInterface<IExtHostExtensionService>({ whenStartupFinished: () => startupFinished }),
 			new NullLogService(),
-		);
+		));
 		return { service, runBackgroundFetch };
 	}
 
@@ -145,7 +157,6 @@ describe('NodeExtHostDocs launch anchor', () => {
 		const ctx = build(new Promise<void>(() => { }));
 		await vi.advanceTimersByTimeAsync(60_000);
 		expect(ctx.runBackgroundFetch).not.toHaveBeenCalled();
-		ctx.service.dispose();
 	});
 
 	it('fetches 5 seconds after the signal resolves', async () => {
@@ -156,7 +167,6 @@ describe('NodeExtHostDocs launch anchor', () => {
 		expect(ctx.runBackgroundFetch).not.toHaveBeenCalled();
 		await vi.advanceTimersByTimeAsync(2_000);
 		expect(ctx.runBackgroundFetch).toHaveBeenCalledOnce();
-		ctx.service.dispose();
 	});
 
 	it('does not fetch if disposed between the signal and the delay', async () => {
@@ -170,6 +180,9 @@ describe('NodeExtHostDocs launch anchor', () => {
 });
 
 describe('NodeExtHostDocs ai.enabled flip', () => {
+	const store = new DisposableStore();
+	afterEach(() => store.clear());
+
 	// ai.enabled is WINDOW-scoped and toggles without a reload, so the false-to-true
 	// flip is the one in-session re-attempt the design allows. Spying on the trigger
 	// rather than the cache: what matters here is which config transitions reach it.
@@ -180,7 +193,7 @@ describe('NodeExtHostDocs ai.enabled flip', () => {
 		const subscribe = vi.fn((listener: (e: vscode.ConfigurationChangeEvent) => unknown) => changed.event(listener));
 		let enabled = initiallyEnabled;
 
-		const service = new NodeExtHostDocs(
+		const service = store.add(new NodeExtHostDocs(
 			initDataAt(cacheRoot('flip')),
 			stubInterface<IExtHostConfiguration>({
 				getConfigProvider: async () => stubInterface<ExtHostConfigProvider>({
@@ -191,7 +204,7 @@ describe('NodeExtHostDocs ai.enabled flip', () => {
 			// Never resolves: the launch fetch must stay out of this test's way.
 			stubInterface<IExtHostExtensionService>({ whenStartupFinished: () => new Promise<void>(() => { }) }),
 			new NullLogService(),
-		);
+		));
 
 		// The listener install is a detached continuation off an awaited
 		// getConfigProvider(), so it is not in place when the constructor returns.
@@ -215,7 +228,6 @@ describe('NodeExtHostDocs ai.enabled flip', () => {
 		await ctx.set(true);
 
 		expect(ctx.onAiEnabledFlippedTrue).toHaveBeenCalledTimes(1);
-		ctx.service.dispose();
 	});
 
 	it('does not refetch when ai.enabled flips true to false', async () => {
@@ -224,7 +236,6 @@ describe('NodeExtHostDocs ai.enabled flip', () => {
 		await ctx.set(false);
 
 		expect(ctx.onAiEnabledFlippedTrue).not.toHaveBeenCalled();
-		ctx.service.dispose();
 	});
 
 	it('does not refetch when a change leaves ai.enabled true', async () => {
@@ -235,7 +246,6 @@ describe('NodeExtHostDocs ai.enabled flip', () => {
 		await ctx.set(true);
 
 		expect(ctx.onAiEnabledFlippedTrue).not.toHaveBeenCalled();
-		ctx.service.dispose();
 	});
 
 	it('ignores a change to an unrelated setting', async () => {
@@ -245,7 +255,6 @@ describe('NodeExtHostDocs ai.enabled flip', () => {
 		await ctx.set(true, 'editor.fontSize');
 
 		expect(ctx.onAiEnabledFlippedTrue).not.toHaveBeenCalled();
-		ctx.service.dispose();
 	});
 
 	it('fires once per flip, not once per event', async () => {
@@ -257,7 +266,6 @@ describe('NodeExtHostDocs ai.enabled flip', () => {
 		await ctx.set(true);
 
 		expect(ctx.onAiEnabledFlippedTrue).toHaveBeenCalledTimes(2);
-		ctx.service.dispose();
 	});
 
 	it('stops listening once disposed', async () => {
@@ -282,6 +290,9 @@ describe('NodeDocsHttpClient', () => {
 
 	beforeEach(async () => {
 		const { createServer } = await import('http');
+		// Reset per test so a case that forgets to set one fails loudly instead of
+		// silently inheriting the previous test's server behaviour.
+		handler = (_req, res) => { res.writeHead(500).end('no handler set for this test'); };
 		server = createServer((req, res) => handler(req, res));
 		await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
 		base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
@@ -346,7 +357,7 @@ describe('NodeDocsHttpClient', () => {
 		const total = 8 * 1024 * 1024;
 		let written = 0;
 		/** Resolves with whether the server finished writing before the socket died. */
-		let endedBeforeClose: Promise<boolean>;
+		let endedBeforeClose: Promise<boolean> | undefined;
 		handler = (_req, res) => {
 			endedBeforeClose = new Promise<boolean>(resolve => res.on('close', () => resolve(res.writableEnded)));
 			res.writeHead(200);
@@ -368,8 +379,22 @@ describe('NodeDocsHttpClient', () => {
 
 		// The abort is the point: without destroy() the client would keep reading
 		// and buffering all 8MB behind a rejection that has already been reported.
-		expect(await endedBeforeClose!).toBe(false);
+		assertDefined(endedBeforeClose, 'the request never reached the server');
+		expect(await endedBeforeClose).toBe(false);
 		expect(written).toBeLessThan(total);
+	});
+
+	it('accepts a response of exactly maxBytes', async () => {
+		// The cap rejects on `>`, so the boundary itself must be served. Without
+		// this, tightening the comparison to `>=` would refuse a bundle that is
+		// exactly at the limit and every other test would stay green.
+		const body = 'x'.repeat(4096);
+		handler = (_req, res) => res.writeHead(200).end(body);
+
+		const response = await new NodeDocsHttpClient().get(`${base}/bundle.zip`, { maxBytes: 4096 });
+
+		expect(response.status).toBe(200);
+		expect(new TextDecoder().decode(response.body)).toBe(body);
 	});
 
 	it('follows a redirect and returns the final body', async () => {
@@ -400,16 +425,36 @@ describe('NodeDocsHttpClient', () => {
 		expect(new TextDecoder().decode(response.body)).toBe('/docs/actual.zip');
 	});
 
-	it('gives up rather than following a redirect loop', async () => {
-		let hops = 0;
+	// This pair pins the redirect cap from both sides. MAX_REDIRECTS is 3, so a
+	// chain of three must arrive and a fourth must not be followed. Either test
+	// alone would pass with an off-by-one in the comparison.
+	it('follows a chain of redirects up to the cap', async () => {
+		let served = 0;
 		handler = (_req, res) => {
-			hops++;
+			if (served < 3) {
+				served++;
+				res.writeHead(302, { location: `/hop${served}` }).end();
+				return;
+			}
+			res.writeHead(200).end('arrived');
+		};
+
+		const response = await new NodeDocsHttpClient().get(`${base}/bundle.zip`);
+
+		expect(new TextDecoder().decode(response.body)).toBe('arrived');
+		expect(served).toBe(3);
+	});
+
+	it('gives up rather than following a redirect loop', async () => {
+		let requests = 0;
+		handler = (_req, res) => {
+			requests++;
 			res.writeHead(302, { location: '/again.zip' }).end();
 		};
 
 		await expect(new NodeDocsHttpClient().get(`${base}/bundle.zip`)).rejects.toThrow(/too many redirects/);
-		// MAX_REDIRECTS hops are followed, and the one that would exceed it is not.
-		expect(hops).toBe(4);
+		// Three redirects are followed; the fourth response is where it stops.
+		expect(requests).toBe(4);
 	});
 
 	it('rejects when the server never responds', async () => {

--- a/src/vs/workbench/api/test/node/positron/extHostDocsNode.vitest.ts
+++ b/src/vs/workbench/api/test/node/positron/extHostDocsNode.vitest.ts
@@ -75,7 +75,7 @@ describe('NodeExtHostDocs construction', () => {
 	// provider and a startup signal that never resolve it must still return,
 	// having created no cache directory.
 	it('performs no filesystem work and does not wait on startup or configuration', async () => {
-		const root = join(tmpdir(), `positron-docs-ctor-${randomUUID()}`);
+		const root = join(tmpdir(), `positron-llm-docs-ctor-${randomUUID()}`);
 		const getConfigProvider = vi.fn(() => new Promise<never>(() => { }));
 		const service = new NodeExtHostDocs(
 			stubInterface<IExtHostInitDataService>({
@@ -94,7 +94,7 @@ describe('NodeExtHostDocs construction', () => {
 			new NullLogService(),
 		);
 
-		expect(existsSync(join(root, 'positron-docs'))).toBe(false);
+		expect(existsSync(join(root, 'positron-llm-docs'))).toBe(false);
 		// Called, but never awaited to completion - the listener install is a
 		// detached continuation, not part of construction.
 		expect(getConfigProvider).toHaveBeenCalledTimes(1);
@@ -111,7 +111,7 @@ describe('NodeExtHostDocs launch anchor', () => {
 		// launch fetch fires, and running the real one would reach the network.
 		const runBackgroundFetch = vi.spyOn(PositronDocsTriggers.prototype, 'runBackgroundFetch')
 			.mockResolvedValue(undefined);
-		const root = join(tmpdir(), `positron-docs-anchor-${randomUUID()}`);
+		const root = join(tmpdir(), `positron-llm-docs-anchor-${randomUUID()}`);
 		const service = new NodeExtHostDocs(
 			stubInterface<IExtHostInitDataService>({
 				quality: 'dailies',

--- a/src/vs/workbench/api/test/node/positron/extHostDocsNode.vitest.ts
+++ b/src/vs/workbench/api/test/node/positron/extHostDocsNode.vitest.ts
@@ -8,12 +8,14 @@ import { randomUUID } from 'crypto';
 import { existsSync } from 'fs';
 import type * as vscode from 'vscode';
 import { tmpdir } from 'os';
+import { Emitter } from '../../../../../base/common/event.js';
 import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { join } from '../../../../../base/common/path.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
 import { PositronDocsTriggers } from '../../../../../platform/positronDocs/common/positronDocsTriggers.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { AI_ENABLED_KEY } from '../../../../contrib/positronAssistant/common/positronAIConfigurationKeys.js';
 import { ExtHostConfigProvider, IExtHostConfiguration } from '../../../common/extHostConfiguration.js';
 import { IExtHostExtensionService } from '../../../common/extHostExtensionService.js';
 import { IExtHostInitDataService } from '../../../common/extHostInitDataService.js';
@@ -68,6 +70,23 @@ describe('deriveBundleRequest', () => {
 	});
 });
 
+/** Init data for a build whose cache would land under `root`, if it created one. */
+function initDataAt(root: string) {
+	return stubInterface<IExtHostInitDataService>({
+		quality: 'dailies',
+		positronVersion: '2026.05.0',
+		positronBuildNumber: 179,
+		environment: stubInterface<IExtHostInitDataService['environment']>({
+			globalStorageHome: URI.file(join(root, 'globalStorage')),
+		}),
+	});
+}
+
+/** A cache root under tmpdir that no test creates; unique per call. */
+function cacheRoot(label: string): string {
+	return join(tmpdir(), `positron-llm-docs-${label}-${randomUUID()}`);
+}
+
 describe('NodeExtHostDocs construction', () => {
 	// The one risk specific to hosting this on the extension host is a slow or
 	// hung download landing on an activation path. The constructor must only
@@ -75,17 +94,10 @@ describe('NodeExtHostDocs construction', () => {
 	// provider and a startup signal that never resolve it must still return,
 	// having created no cache directory.
 	it('performs no filesystem work and does not wait on startup or configuration', async () => {
-		const root = join(tmpdir(), `positron-llm-docs-ctor-${randomUUID()}`);
+		const root = cacheRoot('ctor');
 		const getConfigProvider = vi.fn(() => new Promise<never>(() => { }));
 		const service = new NodeExtHostDocs(
-			stubInterface<IExtHostInitDataService>({
-				quality: 'dailies',
-				positronVersion: '2026.05.0',
-				positronBuildNumber: 179,
-				environment: stubInterface<IExtHostInitDataService['environment']>({
-					globalStorageHome: URI.file(join(root, 'globalStorage')),
-				}),
-			}),
+			initDataAt(root),
 			stubInterface<IExtHostConfiguration>({ getConfigProvider }),
 			stubInterface<IExtHostExtensionService>({
 				// Never resolves: construction must not depend on startup finishing.
@@ -111,16 +123,8 @@ describe('NodeExtHostDocs launch anchor', () => {
 		// launch fetch fires, and running the real one would reach the network.
 		const runBackgroundFetch = vi.spyOn(PositronDocsTriggers.prototype, 'runBackgroundFetch')
 			.mockResolvedValue(undefined);
-		const root = join(tmpdir(), `positron-llm-docs-anchor-${randomUUID()}`);
 		const service = new NodeExtHostDocs(
-			stubInterface<IExtHostInitDataService>({
-				quality: 'dailies',
-				positronVersion: '2026.05.0',
-				positronBuildNumber: 179,
-				environment: stubInterface<IExtHostInitDataService['environment']>({
-					globalStorageHome: URI.file(join(root, 'globalStorage')),
-				}),
-			}),
+			initDataAt(cacheRoot('anchor')),
 			stubInterface<IExtHostConfiguration>({
 				getConfigProvider: async () => stubInterface<ExtHostConfigProvider>({
 					getConfiguration: () => stubInterface<vscode.WorkspaceConfiguration>({ get: () => true }),
@@ -158,5 +162,106 @@ describe('NodeExtHostDocs launch anchor', () => {
 		ctx.service.dispose();
 		await vi.advanceTimersByTimeAsync(60_000);
 		expect(ctx.runBackgroundFetch).not.toHaveBeenCalled();
+	});
+});
+
+describe('NodeExtHostDocs ai.enabled flip', () => {
+	// ai.enabled is WINDOW-scoped and toggles without a reload, so the false-to-true
+	// flip is the one in-session re-attempt the design allows. Spying on the trigger
+	// rather than the cache: what matters here is which config transitions reach it.
+	async function build(initiallyEnabled: boolean) {
+		const onAiEnabledFlippedTrue = vi.spyOn(PositronDocsTriggers.prototype, 'onAiEnabledFlippedTrue')
+			.mockResolvedValue(undefined);
+		const changed = new Emitter<vscode.ConfigurationChangeEvent>();
+		const subscribe = vi.fn((listener: (e: vscode.ConfigurationChangeEvent) => unknown) => changed.event(listener));
+		let enabled = initiallyEnabled;
+
+		const service = new NodeExtHostDocs(
+			initDataAt(cacheRoot('flip')),
+			stubInterface<IExtHostConfiguration>({
+				getConfigProvider: async () => stubInterface<ExtHostConfigProvider>({
+					getConfiguration: () => stubInterface<vscode.WorkspaceConfiguration>({ get: () => enabled }),
+					onDidChangeConfiguration: subscribe,
+				}),
+			}),
+			// Never resolves: the launch fetch must stay out of this test's way.
+			stubInterface<IExtHostExtensionService>({ whenStartupFinished: () => new Promise<void>(() => { }) }),
+			new NullLogService(),
+		);
+
+		// The listener install is a detached continuation off an awaited
+		// getConfigProvider(), so it is not in place when the constructor returns.
+		// Waiting on the subscription itself beats guessing at a microtask count.
+		await vi.waitFor(() => expect(subscribe).toHaveBeenCalledTimes(1));
+
+		return {
+			service, onAiEnabledFlippedTrue,
+			/** Move ai.enabled and fire the change event the provider would. */
+			set: async (next: boolean, affectedKey = AI_ENABLED_KEY) => {
+				enabled = next;
+				changed.fire({ affectsConfiguration: (section: string) => section === affectedKey });
+				await Promise.resolve();
+			},
+		};
+	}
+
+	it('refetches when ai.enabled flips false to true', async () => {
+		const ctx = await build(false);
+
+		await ctx.set(true);
+
+		expect(ctx.onAiEnabledFlippedTrue).toHaveBeenCalledTimes(1);
+		ctx.service.dispose();
+	});
+
+	it('does not refetch when ai.enabled flips true to false', async () => {
+		const ctx = await build(true);
+
+		await ctx.set(false);
+
+		expect(ctx.onAiEnabledFlippedTrue).not.toHaveBeenCalled();
+		ctx.service.dispose();
+	});
+
+	it('does not refetch when a change leaves ai.enabled true', async () => {
+		// A rewrite of the same value still fires the event. Treating it as a flip
+		// would re-download the bundle on every unrelated settings.json save.
+		const ctx = await build(true);
+
+		await ctx.set(true);
+
+		expect(ctx.onAiEnabledFlippedTrue).not.toHaveBeenCalled();
+		ctx.service.dispose();
+	});
+
+	it('ignores a change to an unrelated setting', async () => {
+		const ctx = await build(false);
+
+		// The value moved, but this event does not claim to affect ai.enabled.
+		await ctx.set(true, 'editor.fontSize');
+
+		expect(ctx.onAiEnabledFlippedTrue).not.toHaveBeenCalled();
+		ctx.service.dispose();
+	});
+
+	it('fires once per flip, not once per event', async () => {
+		const ctx = await build(false);
+
+		await ctx.set(true);
+		await ctx.set(true);
+		await ctx.set(false);
+		await ctx.set(true);
+
+		expect(ctx.onAiEnabledFlippedTrue).toHaveBeenCalledTimes(2);
+		ctx.service.dispose();
+	});
+
+	it('stops listening once disposed', async () => {
+		const ctx = await build(false);
+		ctx.service.dispose();
+
+		await ctx.set(true);
+
+		expect(ctx.onAiEnabledFlippedTrue).not.toHaveBeenCalled();
 	});
 });

--- a/src/vs/workbench/api/test/node/positron/extHostDocsNode.vitest.ts
+++ b/src/vs/workbench/api/test/node/positron/extHostDocsNode.vitest.ts
@@ -6,12 +6,16 @@
 
 import { randomUUID } from 'crypto';
 import { existsSync } from 'fs';
+import type * as vscode from 'vscode';
 import { tmpdir } from 'os';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { join } from '../../../../../base/common/path.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { PositronDocsTriggers } from '../../../../../platform/positronDocs/common/positronDocsTriggers.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
-import { IExtHostConfiguration } from '../../../common/extHostConfiguration.js';
+import { ExtHostConfigProvider, IExtHostConfiguration } from '../../../common/extHostConfiguration.js';
+import { IExtHostExtensionService } from '../../../common/extHostExtensionService.js';
 import { IExtHostInitDataService } from '../../../common/extHostInitDataService.js';
 import { deriveBundleRequest, NodeExtHostDocs } from '../../../node/positron/extHostDocsNode.js';
 
@@ -67,9 +71,10 @@ describe('deriveBundleRequest', () => {
 describe('NodeExtHostDocs construction', () => {
 	// The one risk specific to hosting this on the extension host is a slow or
 	// hung download landing on an activation path. The constructor must only
-	// install a scheduler and a config listener, so it must not have created
-	// the cache directory or resolved the barrier-gated config provider.
-	it('performs no filesystem or configuration work', async () => {
+	// arm a scheduler and start installing a config listener, so with a config
+	// provider and a startup signal that never resolve it must still return,
+	// having created no cache directory.
+	it('performs no filesystem work and does not wait on startup or configuration', async () => {
 		const root = join(tmpdir(), `positron-docs-ctor-${randomUUID()}`);
 		const getConfigProvider = vi.fn(() => new Promise<never>(() => { }));
 		const service = new NodeExtHostDocs(
@@ -82,11 +87,76 @@ describe('NodeExtHostDocs construction', () => {
 				}),
 			}),
 			stubInterface<IExtHostConfiguration>({ getConfigProvider }),
+			stubInterface<IExtHostExtensionService>({
+				// Never resolves: construction must not depend on startup finishing.
+				whenStartupFinished: () => new Promise<void>(() => { }),
+			}),
 			new NullLogService(),
 		);
 
 		expect(existsSync(join(root, 'positron-docs'))).toBe(false);
-		expect(getConfigProvider).not.toHaveBeenCalled();
+		// Called, but never awaited to completion - the listener install is a
+		// detached continuation, not part of construction.
+		expect(getConfigProvider).toHaveBeenCalledTimes(1);
 		service.dispose();
+	});
+});
+
+describe('NodeExtHostDocs launch anchor', () => {
+	beforeEach(() => vi.useFakeTimers());
+	afterEach(() => vi.useRealTimers());
+
+	function build(startupFinished: Promise<void>) {
+		// Spying on the trigger rather than the ports: this asserts *when* the
+		// launch fetch fires, and running the real one would reach the network.
+		const runBackgroundFetch = vi.spyOn(PositronDocsTriggers.prototype, 'runBackgroundFetch')
+			.mockResolvedValue(undefined);
+		const root = join(tmpdir(), `positron-docs-anchor-${randomUUID()}`);
+		const service = new NodeExtHostDocs(
+			stubInterface<IExtHostInitDataService>({
+				quality: 'dailies',
+				positronVersion: '2026.05.0',
+				positronBuildNumber: 179,
+				environment: stubInterface<IExtHostInitDataService['environment']>({
+					globalStorageHome: URI.file(join(root, 'globalStorage')),
+				}),
+			}),
+			stubInterface<IExtHostConfiguration>({
+				getConfigProvider: async () => stubInterface<ExtHostConfigProvider>({
+					getConfiguration: () => stubInterface<vscode.WorkspaceConfiguration>({ get: () => true }),
+					onDidChangeConfiguration: () => Disposable.None,
+				}),
+			}),
+			stubInterface<IExtHostExtensionService>({ whenStartupFinished: () => startupFinished }),
+			new NullLogService(),
+		);
+		return { service, runBackgroundFetch };
+	}
+
+	it('does not fetch while the startup-finished signal is pending', async () => {
+		const ctx = build(new Promise<void>(() => { }));
+		await vi.advanceTimersByTimeAsync(60_000);
+		expect(ctx.runBackgroundFetch).not.toHaveBeenCalled();
+		ctx.service.dispose();
+	});
+
+	it('fetches 5 seconds after the signal resolves', async () => {
+		let resolve!: () => void;
+		const ctx = build(new Promise<void>(r => { resolve = r; }));
+		resolve();
+		await vi.advanceTimersByTimeAsync(4_000);
+		expect(ctx.runBackgroundFetch).not.toHaveBeenCalled();
+		await vi.advanceTimersByTimeAsync(2_000);
+		expect(ctx.runBackgroundFetch).toHaveBeenCalledOnce();
+		ctx.service.dispose();
+	});
+
+	it('does not fetch if disposed between the signal and the delay', async () => {
+		let resolve!: () => void;
+		const ctx = build(new Promise<void>(r => { resolve = r; }));
+		resolve();
+		ctx.service.dispose();
+		await vi.advanceTimersByTimeAsync(60_000);
+		expect(ctx.runBackgroundFetch).not.toHaveBeenCalled();
 	});
 });

--- a/src/vs/workbench/api/worker/extHost.worker.services.ts
+++ b/src/vs/workbench/api/worker/extHost.worker.services.ts
@@ -12,6 +12,9 @@ import { ExtHostLogService } from '../common/extHostLogService.js';
 import { ExtensionStoragePaths, IExtensionStoragePaths } from '../common/extHostStoragePaths.js';
 import { ExtHostTelemetry, IExtHostTelemetry } from '../common/extHostTelemetry.js';
 import { ExtHostExtensionService } from './extHostExtensionService.js';
+// --- Start Positron ---
+import { IExtHostDocs, WorkerExtHostDocs } from '../common/positron/extHostDocs.js';
+// --- End Positron ---
 
 // #########################################################################
 // ###                                                                   ###
@@ -24,3 +27,10 @@ registerSingleton(IExtHostAuthentication, ExtHostAuthentication, InstantiationTy
 registerSingleton(IExtHostExtensionService, ExtHostExtensionService, InstantiationType.Eager);
 registerSingleton(IExtensionStoragePaths, ExtensionStoragePaths, InstantiationType.Eager);
 registerSingleton(IExtHostTelemetry, new SyncDescriptor(ExtHostTelemetry, [true], true));
+
+// --- Start Positron ---
+// The Positron API factory runs in this host too, so positron.docs needs a
+// registration here. The worker host has no filesystem, so it gets the
+// always-undefined variant.
+registerSingleton(IExtHostDocs, WorkerExtHostDocs, InstantiationType.Eager);
+// --- End Positron ---

--- a/src/vs/workbench/contrib/positronAssistant/common/positronAIConfiguration.ts
+++ b/src/vs/workbench/contrib/positronAssistant/common/positronAIConfiguration.ts
@@ -10,19 +10,12 @@ import {
 	IConfigurationRegistry,
 } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
+import { AI_ENABLED_KEY } from './positronAIConfigurationKeys.js';
 
-/**
- * Main switch for Positron's AI features. When off, all of Positron's AI
- * features (Next Edit Suggestions, notebook AI, console Fix/Explain, etc.) are
- * turned off.
- *
- * Owned by Positron. It sits above the Posit Assistant extension's
- * `assistant.enabled` (which controls the chat UI): Posit Assistant also reads
- * `ai.enabled`, so when it's off the assistant is off regardless of
- * `assistant.enabled`. This setting seeds the `ai.*` namespace for
- * Positron-owned AI configuration.
- */
-export const AI_ENABLED_KEY = 'ai.enabled';
+// Re-exported so existing importers do not have to move. New callers outside
+// the workbench (e.g. the extension host) should import the keys module
+// directly to avoid this file's registerConfiguration side effect.
+export { AI_ENABLED_KEY };
 
 const configurationRegistry = Registry.as<IConfigurationRegistry>(Extensions.Configuration);
 configurationRegistry.registerConfiguration({

--- a/src/vs/workbench/contrib/positronAssistant/common/positronAIConfigurationKeys.ts
+++ b/src/vs/workbench/contrib/positronAssistant/common/positronAIConfigurationKeys.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Main switch for Positron's AI features. When off, all of Positron's AI
+ * features (Next Edit Suggestions, notebook AI, console Fix/Explain, etc.) are
+ * turned off.
+ *
+ * Owned by Positron. It sits above the Posit Assistant extension's
+ * `assistant.enabled` (which controls the chat UI): Posit Assistant also reads
+ * `ai.enabled`, so when it's off the assistant is off regardless of
+ * `assistant.enabled`. This setting seeds the `ai.*` namespace for
+ * Positron-owned AI configuration.
+ *
+ * This module is deliberately free of imports and side effects so processes
+ * without a Settings UI - notably the extension host - can read the key without
+ * pulling in the configuration registry or re-registering the `ai` node. The
+ * registration itself lives in `positronAIConfiguration.ts`.
+ */
+export const AI_ENABLED_KEY = 'ai.enabled';

--- a/test/manual/llm-docs/README.md
+++ b/test/manual/llm-docs/README.md
@@ -1,0 +1,132 @@
+# llm-docs manual QA harness
+
+Exercises the local-docs bundle pipeline against a running Positron, without
+touching the real CDN. This is the harness behind PR #15251's validation table,
+kept in the repo so the table stays reproducible.
+
+- `server.mjs` - fixture CDN, serves the same URL shapes as cdn.posit.co
+- `ext/` - throwaway extension that calls `positron.docs.getLocalDocs()`
+
+Nothing to install: `server.mjs` has no dependencies and the extension is plain
+JavaScript. Nothing here ships - it is not in any build glob and no product code
+references it.
+
+## Run
+
+Terminal 1 - the fixture CDN:
+
+```bash
+node test/manual/llm-docs/server.mjs
+```
+
+Terminal 2 - Positron, pointed at it. Use a throwaway user-data-dir: the docs
+cache lives inside it, so a dedicated one keeps QA state out of your real
+profile and lets you reset by deleting a directory.
+
+```bash
+POSITRON_LLMS_DOCS_URL=http://127.0.0.1:8099 \
+  ./scripts/code.sh \
+  --user-data-dir /tmp/positron-docs-qa \
+  --extensionDevelopmentPath "$PWD/test/manual/llm-docs/ext" \
+  --log info
+```
+
+`--log info` matters: every decision is logged at info, so without it the
+Output pane shows nothing and you are guessing.
+
+## Where to look
+
+| What | Where |
+|---|---|
+| Decisions | Output > Extension Host, filter `[llm-docs]` |
+| Cache | `/tmp/positron-docs-qa/User/positron-llm-docs/` |
+| Recorded state | `.../positron-llm-docs/state.json` (`resolution`, `etag`, `lastError`) |
+| What the client asked for | `curl localhost:8099/_ctl/log` |
+
+`state.json` is worth watching directly - `resolution` and `lastFailureAt` are
+not on the public API, so it is the only place to see fallback vs exact and
+whether the failure throttle armed.
+
+## Commands (Command Palette)
+
+- **Docs QA: Get Local Docs** - calls the API, reports the result and elapsed ms
+- **Docs QA: Get Local Docs Twice Concurrently** - single-flight check; expect
+  one GET in the server log, two callers served
+- **Docs QA: Open the Cached llms.txt** - proves the returned path is real
+
+## Scenarios
+
+Switch without restarting Positron:
+
+```bash
+curl localhost:8099/_ctl/scenario/digest-mismatch
+```
+
+| Scenario | Expected |
+|---|---|
+| `ok` | Installs, `9999.01.0-1`, `isExactMatch: false` |
+| `bundle-404` | `undefined`, no version directory |
+| `checksum-404` | Zip fetched, install refused, `undefined` |
+| `digest-mismatch` | Rejected, `digest mismatch` logged |
+| `checksum-garbage` | Rejected, `does not hold a sha256 digest` |
+| `corrupt-zip` | Rejected, `corrupt archive` |
+| `file-count-mismatch` | Rejected, `file-count-mismatch` |
+| `evil-version` | Rejected at manifest parse; nothing written outside the root |
+| `slow` | `undefined` at ~10s, download continues, next call served |
+| `oversize` | Aborted, `exceeds 26214400 bytes` |
+| `oversize-checksum` | Aborted, `exceeds 8192 bytes` |
+| `exact-published` | Only meaningful on a faked release build - see below |
+
+After switching scenarios, `invalidate` the in-process memo by toggling
+`ai.enabled` off and back on, or the cache will keep serving what it already
+has. That toggle is itself trigger 2, so it is worth exercising anyway.
+
+## Scenarios this cannot reach as a dev build
+
+`product.json` has no `quality` field in a dev build, so `initData.quality` is
+`undefined` and resolution is always `latest-by-policy`. The release-only paths
+- `exact`, `fallback`, the HEAD convergence probe, and superseded-directory
+cleanup - need:
+
+```bash
+# temporary, do not commit
+npx json -I -f product.json -e 'this.quality="releases"'
+```
+
+Then the exact URL is built from your build's version, so set the fixture's
+notion of "published" accordingly. `exact-published` serves any exact version
+that is asked for, so it will resolve `exact` immediately; the default
+scenarios 404 on exact, which is the `fallback` case.
+
+Revert `product.json` when you are done - a committed `quality` field changes
+update-channel behaviour well beyond this feature.
+
+The `workbench` profile also cannot be reached here: it keys off
+`RS_SERVER_URL`, so it needs a Workbench container. That row is untested in the
+PR table for the same reason.
+
+## The failure throttle will bite you
+
+If the fixture server is not running when Positron tries to fetch, that is a
+hard failure, and a hard failure suppresses the next attempt for an hour
+(`DOCS_FAILURE_THROTTLE_MS`). The log says so:
+
+```
+[llm-docs] skipping fetch; a hard failure is still inside the throttle window
+```
+
+`lastFailureAt` lives in `state.json`, so neither toggling `ai.enabled` nor
+relaunching Positron shortens the wait - `invalidate()` clears the in-process
+gate only. Start the server before Positron, and if you have already tripped it,
+delete the cache directory.
+
+## Reset between runs
+
+```bash
+rm -rf /tmp/positron-docs-qa/User/positron-llm-docs
+curl localhost:8099/_ctl/reset   # clears the request log
+```
+
+Do this before every scenario. Deleting the directory is what clears both the
+cached bundle and the failure throttle; skip it and you will see a stale success
+and conclude the scenario passed.

--- a/test/manual/llm-docs/README.md
+++ b/test/manual/llm-docs/README.md
@@ -39,47 +39,73 @@ Output pane shows nothing and you are guessing.
 | What | Where |
 |---|---|
 | Decisions | Output > Extension Host, filter `[llm-docs]` |
+| Results, state, requests | Output > Docs QA |
 | Cache | `/tmp/positron-docs-qa/User/positron-llm-docs/` |
 | Recorded state | `.../positron-llm-docs/state.json` (`resolution`, `etag`, `lastError`) |
 | What the client asked for | `curl localhost:8099/_ctl/log` |
+
+The Docs QA channel summarises the last three of those, so the only pane you
+normally need beside it is Extension Host - that is where the `[llm-docs]`
+decisions land, and the extension cannot read them.
 
 `state.json` is worth watching directly - `resolution` and `lastFailureAt` are
 not on the public API, so it is the only place to see fallback vs exact and
 whether the failure throttle armed.
 
-## Commands (Command Palette)
+Note that Positron writes its logs under `~/.local/state/positron/logs/`, not
+inside `--user-data-dir`, if you would rather grep
+`window1/exthost/exthost.log` than use the Output pane.
+
+## Scenarios
+
+**Docs QA: Run Scenario** is the whole loop in one command. Pick a scenario from
+the list and it switches the fixture, deletes the cache directory, clears the
+server log, clears the in-process memo, calls `getLocalDocs()`, and prints the
+expectation next to what actually happened:
+
+```
+scenario  digest-mismatch
+expect    rejected, "digest mismatch" logged
+cleared   /tmp/positron-docs-qa/User/positron-llm-docs
+memo      invalidated via an ai.enabled off/on flip
+result     1289ms  undefined
+disk      state.json
+state     resolution: latest-by-policy, version: -, lastError: digest mismatch ...
+server    15:31:02  GET /positron-llms-latest.zip
+          15:31:02  GET /positron-llms-latest.zip.sha256sum
+```
+
+It reports; it does not assert. Read the `[llm-docs]` decisions in Output >
+Extension Host and compare against `expect` yourself.
+
+The scenario list, and the expectation for each, lives beside the behaviour in
+`server.mjs` - the picker reads it over `/_ctl/scenarios`, so
+`curl localhost:8099/_ctl/scenarios` gets you the same list from a terminal.
+
+### Doing it by hand
+
+Only needed for the release-build cases below, where you are driving
+`product.json` as well. Three steps, and skipping any one of them will show you
+a stale result and let you conclude the scenario passed:
+
+```bash
+curl localhost:8099/_ctl/scenario/digest-mismatch
+rm -rf /tmp/positron-docs-qa/User/positron-llm-docs   # cache and failure throttle
+curl localhost:8099/_ctl/reset                        # request log
+```
+
+Then, in Positron: toggle `ai.enabled` off and back on, and run **Docs QA: Get
+Local Docs**. The toggle is what clears the in-process memo - deleting the cache
+directory does not, because `PositronDocsCache` remembers the first completed
+attempt per window and only `invalidate()` clears that. The toggle is also
+trigger 2, so it is worth exercising anyway.
+
+## Other commands (Command Palette)
 
 - **Docs QA: Get Local Docs** - calls the API, reports the result and elapsed ms
 - **Docs QA: Get Local Docs Twice Concurrently** - single-flight check; expect
   one GET in the server log, two callers served
 - **Docs QA: Open the Cached llms.txt** - proves the returned path is real
-
-## Scenarios
-
-Switch without restarting Positron:
-
-```bash
-curl localhost:8099/_ctl/scenario/digest-mismatch
-```
-
-| Scenario | Expected |
-|---|---|
-| `ok` | Installs, `9999.01.0-1`, `isExactMatch: false` |
-| `bundle-404` | `undefined`, no version directory |
-| `checksum-404` | Zip fetched, install refused, `undefined` |
-| `digest-mismatch` | Rejected, `digest mismatch` logged |
-| `checksum-garbage` | Rejected, `does not hold a sha256 digest` |
-| `corrupt-zip` | Rejected, `corrupt archive` |
-| `file-count-mismatch` | Rejected, `file-count-mismatch` |
-| `evil-version` | Rejected at manifest parse; nothing written outside the root |
-| `slow` | `undefined` at ~10s, download continues, next call served |
-| `oversize` | Aborted, `exceeds 26214400 bytes` |
-| `oversize-checksum` | Aborted, `exceeds 8192 bytes` |
-| `exact-published` | Only meaningful on a faked release build - see below |
-
-After switching scenarios, `invalidate` the in-process memo by toggling
-`ai.enabled` off and back on, or the cache will keep serving what it already
-has. That toggle is itself trigger 2, so it is worth exercising anyway.
 
 ## Scenarios this cannot reach as a dev build
 
@@ -117,16 +143,6 @@ hard failure, and a hard failure suppresses the next attempt for an hour
 
 `lastFailureAt` lives in `state.json`, so neither toggling `ai.enabled` nor
 relaunching Positron shortens the wait - `invalidate()` clears the in-process
-gate only. Start the server before Positron, and if you have already tripped it,
-delete the cache directory.
-
-## Reset between runs
-
-```bash
-rm -rf /tmp/positron-docs-qa/User/positron-llm-docs
-curl localhost:8099/_ctl/reset   # clears the request log
-```
-
-Do this before every scenario. Deleting the directory is what clears both the
-cached bundle and the failure throttle; skip it and you will see a stale success
-and conclude the scenario passed.
+gate only. Deleting the cache directory is what clears it, which **Docs QA: Run
+Scenario** does on every run, so it is only a trap if you are driving the fixture
+by hand. Start the server before Positron either way.

--- a/test/manual/llm-docs/ext/extension.js
+++ b/test/manual/llm-docs/ext/extension.js
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Throwaway extension for exercising positron.docs.getLocalDocs() by hand.
+// Reports timing as well as the result, since the 10s bounded wait is one of
+// the things worth checking and it is invisible in the return value.
+
+const vscode = require('vscode');
+const positron = require('positron');
+
+/** @param {vscode.ExtensionContext} context */
+function activate(context) {
+	const out = vscode.window.createOutputChannel('Docs QA');
+	context.subscriptions.push(out);
+
+	const call = async (label) => {
+		const started = Date.now();
+		try {
+			const docs = await positron.docs.getLocalDocs();
+			const elapsed = Date.now() - started;
+			out.appendLine(`${label}  ${elapsed}ms  ${docs ? JSON.stringify(docs, null, 2) : 'undefined'}`);
+			return { docs, elapsed };
+		} catch (error) {
+			out.appendLine(`${label}  threw: ${error}`);
+			throw error;
+		}
+	};
+
+	context.subscriptions.push(vscode.commands.registerCommand('docsQa.getLocalDocs', async () => {
+		out.show(true);
+		const { docs, elapsed } = await call('getLocalDocs');
+		// `resolution` is deliberately not on the public API - read it from
+		// state.json or the [llm-docs] log when you need it.
+		vscode.window.showInformationMessage(
+			docs
+				? `${elapsed}ms - ${docs.version} (exact: ${docs.isExactMatch}, profile: ${docs.profile})`
+				: `${elapsed}ms - undefined (see Docs QA output)`);
+	}));
+
+	// Both calls start before either is awaited, which is what makes this a
+	// single-flight check rather than two sequential calls.
+	context.subscriptions.push(vscode.commands.registerCommand('docsQa.getLocalDocsTwice', async () => {
+		out.show(true);
+		const [a, b] = await Promise.all([call('concurrent A'), call('concurrent B')]);
+		vscode.window.showInformationMessage(
+			`A: ${a.docs?.version ?? 'undefined'} (${a.elapsed}ms), B: ${b.docs?.version ?? 'undefined'} (${b.elapsed}ms). `
+			+ `Check the fixture server log for exactly one GET.`);
+	}));
+
+	context.subscriptions.push(vscode.commands.registerCommand('docsQa.readIndex', async () => {
+		const docs = await positron.docs.getLocalDocs();
+		if (!docs) {
+			vscode.window.showWarningMessage('No local docs - nothing to open.');
+			return;
+		}
+		const index = vscode.Uri.file(`${docs.path}/llms.txt`);
+		await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(index));
+	}));
+}
+
+function deactivate() { }
+
+module.exports = { activate, deactivate };

--- a/test/manual/llm-docs/ext/extension.js
+++ b/test/manual/llm-docs/ext/extension.js
@@ -7,13 +7,28 @@
 // Reports timing as well as the result, since the 10s bounded wait is one of
 // the things worth checking and it is invisible in the return value.
 
+const fs = require('fs');
+const path = require('path');
 const vscode = require('vscode');
 const positron = require('positron');
+
+const AI_ENABLED_KEY = 'ai.enabled';
+// The cache lives beside globalStorage, so the extension can find it from its
+// own storage path without hard-coding a user-data-dir.
+const CACHE_DIR_NAME = 'positron-llm-docs';
+const FIXTURE_URL = process.env.POSITRON_LLMS_DOCS_URL || 'http://127.0.0.1:8099';
+// The ai.enabled listener in the extension host reacts to the config change
+// asynchronously. Without a pause, getLocalDocs() can beat invalidate() to the
+// cache and read the memo the flip was meant to clear.
+const FLIP_SETTLE_MS = 500;
 
 /** @param {vscode.ExtensionContext} context */
 function activate(context) {
 	const out = vscode.window.createOutputChannel('Docs QA');
 	context.subscriptions.push(out);
+
+	// <user-data-dir>/User/globalStorage/<ext-id> -> <user-data-dir>/User/<cache>
+	const cacheDir = path.join(path.dirname(path.dirname(context.globalStorageUri.fsPath)), CACHE_DIR_NAME);
 
 	const call = async (label) => {
 		const started = Date.now();
@@ -49,6 +64,69 @@ function activate(context) {
 			+ `Check the fixture server log for exactly one GET.`);
 	}));
 
+	/**
+	 * One command for a whole scenario: switch the fixture, clear everything that
+	 * would let a stale result through, trigger a fetch, and report.
+	 *
+	 * Clearing is the part that is easy to get wrong by hand. Deleting the cache
+	 * directory is not enough on its own - PositronDocsCache memoizes the first
+	 * completed attempt per window, and only invalidate() clears that. The one
+	 * public route to invalidate() is flipping ai.enabled false-to-true, so that
+	 * is what this does.
+	 */
+	context.subscriptions.push(vscode.commands.registerCommand('docsQa.runScenario', async () => {
+		let available;
+		try {
+			available = await ctl('/_ctl/scenarios', 'json');
+		} catch (error) {
+			// A 404 means something is listening but does not know this route, which
+			// in practice means an older or copied-out server.mjs. Worth separating
+			// from "nothing is listening": only the latter can arm the throttle, and
+			// only the former is fixed by restarting the right file.
+			vscode.window.showErrorMessage(String(error).includes('404')
+				? `The fixture CDN at ${FIXTURE_URL} has no /_ctl/scenarios route, so it is not `
+				+ `this repo's server.mjs. Restart it from the worktree: `
+				+ `"node test/manual/llm-docs/server.mjs".`
+				: `Cannot reach the fixture CDN at ${FIXTURE_URL}: ${error}. Start it with `
+				+ `"node test/manual/llm-docs/server.mjs" - and note that a failed docs fetch `
+				+ `arms the one-hour throttle, so delete the cache directory if one landed.`);
+			return;
+		}
+
+		const picked = await vscode.window.showQuickPick(
+			available.map(s => ({
+				label: s.name,
+				description: s.expect,
+				detail: s.current ? 'currently selected on the fixture server' : undefined,
+			})),
+			{ title: 'Docs QA: run a scenario', placeHolder: 'Resets the cache and the memo, then calls getLocalDocs()' });
+		if (!picked) {
+			return;
+		}
+
+		out.show(true);
+		out.appendLine(`\n${'='.repeat(72)}\nscenario  ${picked.label}\nexpect    ${picked.description}`);
+
+		await ctl(`/_ctl/scenario/${picked.label}`);
+		// Order matters: clear the disk before the log, so the log holds only the
+		// requests this run provokes.
+		await fs.promises.rm(cacheDir, { recursive: true, force: true });
+		out.appendLine(`cleared   ${cacheDir}`);
+		await ctl('/_ctl/reset');
+
+		await flipAiEnabled();
+		out.appendLine(`memo      invalidated via an ${AI_ENABLED_KEY} off/on flip`);
+
+		const { docs, elapsed } = await call('result   ');
+		out.appendLine(`disk      ${(await readdir(cacheDir)).join(', ') || '(nothing)'}`);
+		out.appendLine(`state     ${await readState(cacheDir)}`);
+		out.appendLine(`server    ${(await ctl('/_ctl/log')).trim().split('\n').join('\n          ')}`);
+		out.appendLine(`\nNow read the decisions: Output > Extension Host, filter [llm-docs].`);
+
+		vscode.window.showInformationMessage(
+			`${picked.label}: ${docs ? `${docs.version} (exact: ${docs.isExactMatch})` : 'undefined'} in ${elapsed}ms. See Docs QA output.`);
+	}));
+
 	context.subscriptions.push(vscode.commands.registerCommand('docsQa.readIndex', async () => {
 		const docs = await positron.docs.getLocalDocs();
 		if (!docs) {
@@ -58,6 +136,46 @@ function activate(context) {
 		const index = vscode.Uri.file(`${docs.path}/llms.txt`);
 		await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(index));
 	}));
+}
+
+/** Fixture control plane. Returns parsed JSON or the raw body. */
+async function ctl(route, as = 'text') {
+	const response = await fetch(`${FIXTURE_URL}${route}`);
+	if (!response.ok) {
+		throw new Error(`${route} -> ${response.status}`);
+	}
+	return as === 'json' ? await response.json() : await response.text();
+}
+
+/**
+ * false-to-true is the transition the extension host listens for, so both writes
+ * are needed even when the setting already reads true.
+ */
+async function flipAiEnabled() {
+	const config = vscode.workspace.getConfiguration();
+	await config.update(AI_ENABLED_KEY, false, vscode.ConfigurationTarget.Global);
+	await config.update(AI_ENABLED_KEY, true, vscode.ConfigurationTarget.Global);
+	await new Promise(resolve => setTimeout(resolve, FLIP_SETTLE_MS));
+}
+
+/** What landed in the cache root, which is how "no version directory" is checked. */
+async function readdir(target) {
+	try {
+		return await fs.promises.readdir(target);
+	} catch {
+		return [];
+	}
+}
+
+/** resolution and lastFailureAt are not on the public API; state.json is the only view. */
+async function readState(cacheDir) {
+	try {
+		const state = JSON.parse(await fs.promises.readFile(path.join(cacheDir, 'state.json'), 'utf8'));
+		return `resolution: ${state.resolution}, version: ${state.version ?? '-'}, `
+			+ `lastError: ${state.lastError ?? '-'}, lastFailureAt: ${state.lastFailureAt ?? '-'}`;
+	} catch {
+		return '(no state.json)';
+	}
 }
 
 function deactivate() { }

--- a/test/manual/llm-docs/ext/package.json
+++ b/test/manual/llm-docs/ext/package.json
@@ -1,0 +1,35 @@
+{
+	"name": "docs-qa",
+	"displayName": "Docs QA",
+	"description": "Throwaway extension for exercising positron.docs.getLocalDocs().",
+	"version": "0.0.1",
+	"publisher": "posit",
+	"engines": {
+		"vscode": "^1.65.0"
+	},
+	"main": "./extension.js",
+	"activationEvents": [
+		"onCommand:docsQa.getLocalDocs",
+		"onCommand:docsQa.getLocalDocsTwice",
+		"onCommand:docsQa.readIndex"
+	],
+	"contributes": {
+		"commands": [
+			{
+				"command": "docsQa.getLocalDocs",
+				"title": "Docs QA: Get Local Docs",
+				"category": "Docs QA"
+			},
+			{
+				"command": "docsQa.getLocalDocsTwice",
+				"title": "Docs QA: Get Local Docs Twice Concurrently",
+				"category": "Docs QA"
+			},
+			{
+				"command": "docsQa.readIndex",
+				"title": "Docs QA: Open the Cached llms.txt",
+				"category": "Docs QA"
+			}
+		]
+	}
+}

--- a/test/manual/llm-docs/ext/package.json
+++ b/test/manual/llm-docs/ext/package.json
@@ -9,12 +9,18 @@
 	},
 	"main": "./extension.js",
 	"activationEvents": [
+		"onCommand:docsQa.runScenario",
 		"onCommand:docsQa.getLocalDocs",
 		"onCommand:docsQa.getLocalDocsTwice",
 		"onCommand:docsQa.readIndex"
 	],
 	"contributes": {
 		"commands": [
+			{
+				"command": "docsQa.runScenario",
+				"title": "Docs QA: Run Scenario",
+				"category": "Docs QA"
+			},
 			{
 				"command": "docsQa.getLocalDocs",
 				"title": "Docs QA: Get Local Docs",

--- a/test/manual/llm-docs/server.mjs
+++ b/test/manual/llm-docs/server.mjs
@@ -1,0 +1,254 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Fixture CDN for the llm-docs bundle. Serves the same URL shapes as
+// cdn.posit.co so POSITRON_LLMS_DOCS_URL can point here instead.
+//
+//   node server.mjs [--port 8099]
+//
+// Scenarios are switched at runtime, so one Positron session can be walked
+// through several of them:
+//
+//   curl localhost:8099/_ctl/scenario/ok
+//   curl localhost:8099/_ctl/scenario/digest-mismatch
+//   curl localhost:8099/_ctl/log        # what the client has requested
+//
+// See scenarios below for the full list.
+
+import { createHash } from 'node:crypto';
+import { createServer } from 'node:http';
+import { deflateRawSync } from 'node:zlib';
+
+const port = Number(process.argv[process.argv.indexOf('--port') + 1]) || 8099;
+
+// A version this build will never match, so a release build stays in
+// `fallback` rather than accidentally resolving `exact`.
+const LATEST_VERSION = '9999.01.0-1';
+
+/** Minimal zip writer: stored-or-deflated entries, no dependencies. */
+function makeZip(entries) {
+	const chunks = [];
+	const central = [];
+	let offset = 0;
+	const crcTable = [];
+	for (let i = 0; i < 256; i++) {
+		let c = i;
+		for (let k = 0; k < 8; k++) { c = c & 1 ? 0xEDB88320 ^ (c >>> 1) : c >>> 1; }
+		crcTable[i] = c >>> 0;
+	}
+	const crc32 = buf => {
+		let c = 0xFFFFFFFF;
+		for (const byte of buf) { c = crcTable[(c ^ byte) & 0xFF] ^ (c >>> 8); }
+		return (c ^ 0xFFFFFFFF) >>> 0;
+	};
+
+	for (const [name, contents] of Object.entries(entries)) {
+		const nameBuf = Buffer.from(name, 'utf8');
+		const raw = Buffer.from(contents, 'utf8');
+		const deflated = deflateRawSync(raw);
+		const useDeflate = deflated.length < raw.length;
+		const body = useDeflate ? deflated : raw;
+		const local = Buffer.alloc(30);
+		local.writeUInt32LE(0x04034b50, 0);
+		local.writeUInt16LE(20, 4);
+		local.writeUInt16LE(useDeflate ? 8 : 0, 8);
+		local.writeUInt32LE(crc32(raw), 14);
+		local.writeUInt32LE(body.length, 18);
+		local.writeUInt32LE(raw.length, 22);
+		local.writeUInt16LE(nameBuf.length, 26);
+		chunks.push(local, nameBuf, body);
+
+		const dir = Buffer.alloc(46);
+		dir.writeUInt32LE(0x02014b50, 0);
+		dir.writeUInt16LE(20, 4);
+		dir.writeUInt16LE(20, 6);
+		dir.writeUInt16LE(useDeflate ? 8 : 0, 10);
+		dir.writeUInt32LE(crc32(raw), 16);
+		dir.writeUInt32LE(body.length, 20);
+		dir.writeUInt32LE(raw.length, 24);
+		dir.writeUInt16LE(nameBuf.length, 28);
+		dir.writeUInt32LE(offset, 42);
+		central.push(dir, nameBuf);
+		offset += local.length + nameBuf.length + body.length;
+	}
+
+	const centralBuf = Buffer.concat(central);
+	const end = Buffer.alloc(22);
+	end.writeUInt32LE(0x06054b50, 0);
+	end.writeUInt16LE(Object.keys(entries).length, 8);
+	end.writeUInt16LE(Object.keys(entries).length, 10);
+	end.writeUInt32LE(centralBuf.length, 12);
+	end.writeUInt32LE(offset, 16);
+	return Buffer.concat([...chunks, centralBuf, end]);
+}
+
+// Bundles are built once and reused. The zip and its checksum arrive as two
+// separate requests, so anything that varies per call (a timestamp, say) makes
+// every install fail a digest check that is actually working correctly.
+const bundleCache = new Map();
+
+/** A structurally valid bundle. fileCount must match what the zip holds. */
+function makeBundle(version, options = {}) {
+	const key = `${version}|${options.fileCount ?? ''}|${options.extraPages ?? ''}`;
+	let zip = bundleCache.get(key);
+	if (!zip) {
+		zip = buildBundle(version, options);
+		bundleCache.set(key, zip);
+	}
+	return zip;
+}
+
+function buildBundle(version, { fileCount, extraPages = 0 } = {}) {
+	const entries = {
+		'llms.txt': `# Positron docs (fixture ${version})\n\n- [Console](console.md)\n`,
+		'console.md': `# Console\n\nFixture page from bundle ${version}.\n`,
+	};
+	for (let i = 0; i < extraPages; i++) {
+		entries[`page-${i}.md`] = `# Page ${i}\n`;
+	}
+	const declared = fileCount ?? Object.keys(entries).length + 1; // +1 for bundle.json
+	entries['bundle.json'] = JSON.stringify({
+		schema: 1,
+		profile: 'positron',
+		version,
+		// Fixed, not `new Date()`: see the bundleCache note above.
+		generated: '2026-08-01T00:00:00Z',
+		docsBaseUrl: 'https://positron.posit.co/',
+		fileCount: declared,
+	}, null, 2);
+	return makeZip(entries);
+}
+
+const sha256 = buf => createHash('sha256').update(buf).digest('hex');
+
+// Each scenario decides how the latest zip, its checksum, and the exact
+// version are served. `exact` responses are what a release build HEADs first.
+const scenarios = {
+	/** Happy path: latest publishes, exact does not. */
+	'ok': {},
+	/** Nothing published at all. Expect: undefined, no cache directory. */
+	'bundle-404': { zip: 404 },
+	/** Zip published, checksum missing. Expect: install refused. */
+	'checksum-404': { checksum: 404 },
+	/** Checksum names a digest the zip does not have. Expect: rejected. */
+	'digest-mismatch': { digest: 'mismatch' },
+	/** Checksum body is not a digest at all. */
+	'checksum-garbage': { digest: 'garbage' },
+	/** Truncated zip. Expect: "corrupt archive". */
+	'corrupt-zip': { corrupt: true },
+	/** Manifest declares more files than the zip holds. */
+	'file-count-mismatch': { fileCount: 99 },
+	/** Manifest version escapes the cache root. Expect: rejected, no write. */
+	'evil-version': { version: '../../evil' },
+	/** Slower than the 10s bounded wait. Expect: undefined, then served. */
+	'slow': { delayMs: 20_000 },
+	/** Exact version is published too. Set POSITRON_QA_EXACT to your build. */
+	'exact-published': { exactPublished: true },
+	/** Bigger than the 25MB cap. Expect: aborted. */
+	'oversize': { oversize: true },
+	/** Checksum body over the 8KB cap. Expect: aborted. */
+	'oversize-checksum': { oversizeChecksum: true },
+};
+
+let current = 'ok';
+let etagCounter = 1;
+const log = [];
+
+const server = createServer(async (req, res) => {
+	const url = new URL(req.url, `http://localhost:${port}`);
+	const path = url.pathname;
+
+	if (path.startsWith('/_ctl/scenario/')) {
+		const next = path.slice('/_ctl/scenario/'.length);
+		if (!scenarios[next]) {
+			res.writeHead(400).end(`unknown scenario. try: ${Object.keys(scenarios).join(', ')}\n`);
+			return;
+		}
+		current = next;
+		// A new scenario is a new object, so the ETag must change or a client
+		// holding the old one gets a 304 and never sees the new body.
+		etagCounter++;
+		res.writeHead(200).end(`scenario = ${current}\n`);
+		return;
+	}
+	if (path === '/_ctl/log') {
+		res.writeHead(200).end(log.join('\n') + '\n');
+		return;
+	}
+	if (path === '/_ctl/reset') {
+		log.length = 0;
+		res.writeHead(200).end('log cleared\n');
+		return;
+	}
+
+	const s = scenarios[current];
+	const line = `${new Date().toISOString().slice(11, 23)}  ${req.method} ${path}${req.headers['if-none-match'] ? `  If-None-Match: ${req.headers['if-none-match']}` : ''}`;
+	log.push(line);
+	console.log(`[${current}] ${line}`);
+
+	const isChecksum = path.endsWith('.sha256sum');
+	const zipPath = isChecksum ? path.slice(0, -'.sha256sum'.length) : path;
+	const match = /^\/positron-(?:workbench-)?llms-(.+)\.zip$/.exec(zipPath);
+	if (!match) {
+		res.writeHead(404).end();
+		return;
+	}
+	const requested = match[1];
+	const isLatest = requested === 'latest';
+
+	// An exact request only succeeds in the scenario that publishes it.
+	if (!isLatest && !s.exactPublished) {
+		res.writeHead(404).end();
+		return;
+	}
+
+	if (s.delayMs) {
+		await new Promise(resolve => setTimeout(resolve, s.delayMs));
+	}
+
+	const version = s.version ?? (isLatest ? LATEST_VERSION : requested);
+	const zip = s.oversize
+		? Buffer.alloc(26 * 1024 * 1024, 0x41)
+		: makeBundle(version, { fileCount: s.fileCount });
+	const body = s.corrupt ? zip.subarray(0, Math.floor(zip.length / 2)) : zip;
+	const etag = `"fixture-${current}-${etagCounter}"`;
+
+	if (isChecksum) {
+		if (s.checksum === 404) {
+			res.writeHead(404).end();
+			return;
+		}
+		if (s.oversizeChecksum) {
+			res.writeHead(200, { 'content-type': 'text/plain' }).end('x'.repeat(9 * 1024));
+			return;
+		}
+		const digest = s.digest === 'mismatch' ? 'b'.repeat(64)
+			: s.digest === 'garbage' ? 'not-a-digest-at-all'
+				: sha256(body);
+		res.writeHead(200, { 'content-type': 'text/plain' }).end(`${digest}  positron-llms-${requested}.zip\n`);
+		return;
+	}
+
+	if (s.zip === 404) {
+		res.writeHead(404).end();
+		return;
+	}
+
+	// Conditional GET support, so the 304 path is exercisable.
+	if (req.headers['if-none-match'] === etag) {
+		res.writeHead(304, { etag }).end();
+		return;
+	}
+	if (req.method === 'HEAD') {
+		res.writeHead(200, { etag, 'content-length': String(body.length) }).end();
+		return;
+	}
+	res.writeHead(200, { etag, 'content-type': 'application/zip', 'content-length': String(body.length) }).end(body);
+});
+
+server.listen(port, '127.0.0.1', () => {
+	console.log(`docs fixture CDN on http://127.0.0.1:${port}  (scenario: ${current})`);
+	console.log(`scenarios: ${Object.keys(scenarios).join(', ')}`);
+});

--- a/test/manual/llm-docs/server.mjs
+++ b/test/manual/llm-docs/server.mjs
@@ -125,31 +125,34 @@ const sha256 = buf => createHash('sha256').update(buf).digest('hex');
 
 // Each scenario decides how the latest zip, its checksum, and the exact
 // version are served. `exact` responses are what a release build HEADs first.
+//
+// `expect` is served over /_ctl/scenarios and shown by the extension's "Run
+// Scenario" command, so it stays next to the behaviour it describes.
 const scenarios = {
 	/** Happy path: latest publishes, exact does not. */
-	'ok': {},
-	/** Nothing published at all. Expect: undefined, no cache directory. */
-	'bundle-404': { zip: 404 },
-	/** Zip published, checksum missing. Expect: install refused. */
-	'checksum-404': { checksum: 404 },
-	/** Checksum names a digest the zip does not have. Expect: rejected. */
-	'digest-mismatch': { digest: 'mismatch' },
+	'ok': { expect: `installs ${LATEST_VERSION}, isExactMatch: false` },
+	/** Nothing published at all. */
+	'bundle-404': { zip: 404, expect: 'undefined, no version directory' },
+	/** Zip published, checksum missing. */
+	'checksum-404': { checksum: 404, expect: 'zip fetched, install refused, undefined' },
+	/** Checksum names a digest the zip does not have. */
+	'digest-mismatch': { digest: 'mismatch', expect: 'rejected, "digest mismatch" logged' },
 	/** Checksum body is not a digest at all. */
-	'checksum-garbage': { digest: 'garbage' },
-	/** Truncated zip. Expect: "corrupt archive". */
-	'corrupt-zip': { corrupt: true },
+	'checksum-garbage': { digest: 'garbage', expect: 'rejected, "does not hold a sha256 digest"' },
+	/** Truncated zip. */
+	'corrupt-zip': { corrupt: true, expect: 'rejected, "corrupt archive"' },
 	/** Manifest declares more files than the zip holds. */
-	'file-count-mismatch': { fileCount: 99 },
-	/** Manifest version escapes the cache root. Expect: rejected, no write. */
-	'evil-version': { version: '../../evil' },
-	/** Slower than the 10s bounded wait. Expect: undefined, then served. */
-	'slow': { delayMs: 20_000 },
-	/** Exact version is published too. Set POSITRON_QA_EXACT to your build. */
-	'exact-published': { exactPublished: true },
-	/** Bigger than the 25MB cap. Expect: aborted. */
-	'oversize': { oversize: true },
-	/** Checksum body over the 8KB cap. Expect: aborted. */
-	'oversize-checksum': { oversizeChecksum: true },
+	'file-count-mismatch': { fileCount: 99, expect: 'rejected, "file-count-mismatch"' },
+	/** Manifest version escapes the cache root. */
+	'evil-version': { version: '../../evil', expect: 'rejected at manifest parse; nothing written outside the root' },
+	/** Slower than the 10s bounded wait. */
+	'slow': { delayMs: 20_000, expect: 'undefined at ~10s, download continues, next call served' },
+	/** Exact version is published too. Release-quality builds only. */
+	'exact-published': { exactPublished: true, expect: 'only meaningful on a faked release build - see the README' },
+	/** Bigger than the 25MB cap. */
+	'oversize': { oversize: true, expect: 'aborted, "exceeds 26214400 bytes"' },
+	/** Checksum body over the 8KB cap. */
+	'oversize-checksum': { oversizeChecksum: true, expect: 'aborted, "exceeds 8192 bytes"' },
 };
 
 let current = 'ok';
@@ -171,6 +174,12 @@ const server = createServer(async (req, res) => {
 		// holding the old one gets a 304 and never sees the new body.
 		etagCounter++;
 		res.writeHead(200).end(`scenario = ${current}\n`);
+		return;
+	}
+	if (path === '/_ctl/scenarios') {
+		// JSON so the extension can build its picker without duplicating the list.
+		const body = Object.entries(scenarios).map(([name, s]) => ({ name, expect: s.expect, current: name === current }));
+		res.writeHead(200, { 'content-type': 'application/json' }).end(JSON.stringify(body));
 		return;
 	}
 	if (path === '/_ctl/log') {


### PR DESCRIPTION
### Summary

Wires the docs-bundle cache from PR #15242 into the extension host and exposes it to extensions as `positron.docs.getLocalDocs()`, so the AI assistant can read Positron docs from disk instead of fetching them from the web.

- Declares the `positron.docs` API surface plus the `positronLlmsDocsUrl` product field, overridable at runtime with `POSITRON_LLMS_DOCS_URL`
- Adds `IExtHostDocs`: node port adapters over http/fs/yauzl, and an always-undefined web-worker variant
- Adds the trigger layer: launch fetch, `getLocalDocs()` with a 10s bounded wait, and a mid-session `ai.enabled` flip
- Gates every path on `ai.enabled`, read live
- Publishes the extension host's startup-finished moment so the launch fetch stays clear of the eager-activation burst
- Adds `test/manual/llm-docs/`, the fixture CDN and throwaway extension used for the table below

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

Reproduce any row with the harness in `test/manual/llm-docs/` - see its README. Start the fixture CDN, launch Positron pointed at it, then run **Docs QA: Run Scenario** from the Command Palette: it switches the fixture, clears the cache and the in-process memo, calls the API, and prints the expectation beside what happened. One session covers every scenario.

| Scenario | Result |
|---|---|
| Dev build resolves `latest-by-policy` | Bundle installed to `<userdata>/User/positron-llm-docs/<version>/` |
| `ai.enabled: false` | No request at all, `undefined`, no cache directory |
| `ai.enabled` flipped true mid-session | Fetch fires with no reload |
| Two concurrent `getLocalDocs()` calls | One download, both callers served |
| Bundle 404 | `undefined`, no cache, no state written |
| Checksum file 404 | Zip fetched, install refused, `undefined` |
| Digest mismatch | Install refused, `undefined` |
| Checksum body is not a digest | Install refused |
| Corrupt archive | Install refused |
| Manifest file count disagrees with the zip | Install refused |
| Manifest version escapes the cache root | Rejected at parse; nothing written outside the root |
| Checksum body over the size cap | Aborted |
| Zip over the size cap | Aborted |
| Release build, exact bundle published | `resolution: exact`, `isExactMatch: true` |
| Release build, exact not yet published | HEAD 404 then latest, `resolution: fallback` |
| Relaunch on an exact cache | Zero network requests |
| Relaunch on a fallback cache | Re-HEADs exact every launch |
| Exact publishes later | Converges to exact, superseded directory deleted |
| Unchanged bundle, stored ETag | Single conditional GET, 304, cache kept |
| CDN 404 with a warm cache | Cached bundle still served |
| Server slower than the bounded wait | `undefined` at 10s, download continues, next call served |
| Server unreachable, then reachable | Hard failure throttles the next attempt for an hour; see note below |
| Workbench profile and server-side cache | Not run: needs a Workbench container |

Decisions are logged under `[llm-docs]` in Output > Extension Host:

```
[llm-docs] fetching http://.../positron-llms-latest.zip (latest-by-policy)
[llm-docs] installed 9999.01.0-1 from http://.../positron-llms-latest.zip
[llm-docs] ai.enabled is off; not serving local docs
```

Note on the throttle: a hard failure sets `lastFailureAt` in `state.json`, which suppresses the next attempt for `DOCS_FAILURE_THROTTLE_MS` (1 hour). `invalidate()` clears the in-process gate only, so neither the `ai.enabled` flip nor a relaunch shortens that window. Behaviour is as designed and the comment on `invalidate()` now says so; whether an explicit user action should clear `lastFailureAt` is tracked separately.

### QA Notes

Depends on #15242 and must not merge before it.

If you pull the branch to try it yourself, `test/manual/llm-docs/README.md` is the whole setup - a fixture CDN and a throwaway extension, no install step, nothing that ships. **Docs QA: Run Scenario** drives any row in the table above end to end.

