### PR TITLE
e2e: trace-level supervisor logs for the Python console suite

### DIFF
--- a/test/e2e/tests/console/console-python.test.ts
+++ b/test/e2e/tests/console/console-python.test.ts
@@ -8,7 +8,15 @@ import { test as base, tags } from '../_test.setup';
 const test = base.extend<{}, {}>({
 	beforeApp: [
 		async ({ settingsFile }, use) => {
-			await settingsFile.append({ 'python.useBundledIpykernel': false });
+			await settingsFile.append({
+				'python.useBundledIpykernel': false,
+				// Trace-level supervisor logs to diagnose https://github.com/posit-dev/positron/issues/15060.
+				// At the default `debug` level the supervisor logs "sending to Jupyter socket Shell"
+				// before queueing to an in-process channel; only `trace` logs the actual ZMQ send, which
+				// is what tells us whether a wedged kernel ever received the message. Must be pre-launch:
+				// the level is read once when the supervisor server starts.
+				'kernelSupervisor.logLevel': 'trace',
+			});
 			await use();
 		},
 		{ scope: 'worker' }


### PR DESCRIPTION
### Summary

Turns on trace-level kernel supervisor logging for the Python console e2e suite, to get evidence that distinguishes the two candidate mechanisms behind #15060. Diagnostic only, intended to be reverted once #15060 is diagnosed

### QA Notes

`@:console` `@:web` `@:win`. Verified locally: supervisor log reports `log level: trace` and emits 1664 trace lines including the shell-send pair. Adds ~550 KB to the spec's supervisor log.
