### PR TITLE
Attempt to fix flaky positron-code-cells decorations test

### DIFF
--- a/extensions/positron-code-cells/src/decorations.ts
+++ b/extensions/positron-code-cells/src/decorations.ts
@@ -66,10 +66,15 @@ export function activateDecorations(
 	setDecorations: SetDecorations = defaultSetDecorations,
 ): void {
 	let timeout: NodeJS.Timeout | undefined = undefined;
-	let activeEditor = vscode.window.activeTextEditor;
 
 	// Update the active editor's cell decorations.
+	//
+	// The active editor is read on each update rather than cached, since the
+	// extension host briefly reports no active text editor while editors are
+	// switching. A cached editor is cleared by that transient event and never
+	// restored until the next one arrives, leaving the decorations stale.
 	function updateDecorations() {
+		const activeEditor = vscode.window.activeTextEditor;
 		const docManager = activeEditor && getOrCreateDocumentManager(activeEditor.document);
 		if (!activeEditor || !docManager) {
 			return;
@@ -118,12 +123,17 @@ export function activateDecorations(
 
 	}
 
-	// Trigger an update of the active editor's cell decorations, with optional throttling.
-	function triggerUpdateDecorations(throttle = false) {
+	// Cancel a pending throttled update, if any.
+	function cancelUpdateDecorations() {
 		if (timeout) {
 			clearTimeout(timeout);
 			timeout = undefined;
 		}
+	}
+
+	// Trigger an update of the active editor's cell decorations, with optional throttling.
+	function triggerUpdateDecorations(throttle = false) {
+		cancelUpdateDecorations();
 		if (throttle) {
 			timeout = setTimeout(updateDecorations, 250);
 		} else {
@@ -132,14 +142,19 @@ export function activateDecorations(
 	}
 
 	// Trigger a decorations update for the current active editor.
-	if (activeEditor) {
+	if (vscode.window.activeTextEditor) {
 		triggerUpdateDecorations();
 	}
 
 	disposables.push(
-		// Trigger a decorations update when the active editor changes.
+		// Drop a pending throttled update so it can't run after disposal.
+		new vscode.Disposable(cancelUpdateDecorations),
+
+		// Trigger a decorations update when the active editor changes. A pending
+		// throttled update is deliberately left alone when there is no active
+		// editor, so that a transient "no active editor" event doesn't discard an
+		// update that a content change already scheduled.
 		vscode.window.onDidChangeActiveTextEditor(editor => {
-			activeEditor = editor;
 			if (editor) {
 				triggerUpdateDecorations();
 			}
@@ -147,14 +162,14 @@ export function activateDecorations(
 
 		// Trigger a decorations update when the active editor's content changes.
 		vscode.workspace.onDidChangeTextDocument(event => {
-			if (activeEditor && event.document === activeEditor.document) {
+			if (event.document === vscode.window.activeTextEditor?.document) {
 				triggerUpdateDecorations(true);
 			}
 		}),
 
 		// Trigger a decorations update when the active editor's selection changes.
 		vscode.window.onDidChangeTextEditorSelection(event => {
-			if (activeEditor && event.textEditor === activeEditor) {
+			if (event.textEditor === vscode.window.activeTextEditor) {
 				triggerUpdateDecorations();
 			}
 		}),

--- a/extensions/positron-code-cells/src/test/decorations.test.ts
+++ b/extensions/positron-code-cells/src/test/decorations.test.ts
@@ -14,15 +14,23 @@ suite('Decorations', () => {
 	const setDecorations: SetDecorations = (_editor, decorationType, ranges) => {
 		decorations.set(decorationType, ranges);
 	};
-	setup(() => {
+	setup(async () => {
 		// Activate decorations with a custom setDecorations that stores the decorated ranges.
 		activateDecorations(disposables, setDecorations);
 
-		// Default to background style.
-		switchCellStyle('background');
+		// Default to background style. Awaited so that the resulting configuration
+		// change event can't land in the middle of a test.
+		await switchCellStyle('background');
 	});
 	teardown(async () => {
 		disposeAll(disposables);
+		disposables.length = 0;
+
+		// Start each test with no recorded ranges, so that a decoration update that
+		// never happens fails against `undefined` rather than silently matching the
+		// ranges left behind by the previous test.
+		decorations.clear();
+
 		await closeAllEditors();
 	});
 
@@ -88,9 +96,10 @@ suite('Decorations', () => {
 		const editor = await showTextDocument('# %%');
 		assertCellDecorationRangesEqual(focusedCellBackgroundDecorationType, [new vscode.Range(0, 0, 0, 4)]);
 
-		await editor.edit((editBuilder) => {
+		const result = await editor.edit((editBuilder) => {
 			editBuilder.delete(new vscode.Range(0, 0, 1, 0));
 		});
+		assert.ok(result, 'The edit was not applied');
 
 		// Decorations do not update immediately
 		assertCellDecorationRangesEqual(focusedCellBackgroundDecorationType, [new vscode.Range(0, 0, 0, 4)]);
@@ -135,5 +144,5 @@ async function showTextDocument(content?: string): Promise<vscode.TextEditor> {
 
 async function switchCellStyle(cellStyle: string) {
 	const configuration = vscode.workspace.getConfiguration();
-	await configuration.update("codeCells.cellStyle", cellStyle, vscode.ConfigurationTarget.Global);
+	await configuration.update('codeCells.cellStyle', cellStyle, vscode.ConfigurationTarget.Global);
 }


### PR DESCRIPTION
Attempts to fix the recurring `Decorations > Removing all code cells from a Python document` failure in the `positron-code-cells` extension host suite:

```
AssertionError [ERR_ASSERTION]: Cell decoration ranges are not equal
+ actual   [ Range { _start: (0,0), _end: (0,4) } ]   (the pre-edit value)
- expected []
```

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

The real coverage is the extension host suite, which exercises the decoration paths directly:

```bash
npm run test-extension -- -l positron-code-cells
```

Expect 71 passing. To sanity check the product behaviour by hand: open a Python file containing `# %%`, confirm the focused cell is highlighted, delete the cell marker, and confirm the highlight disappears; then switch to another editor and back and confirm the highlight still tracks the cursor.