### PR TITLE
Bump bundled Quarto to 1.10.18

### DIFF
--- a/build/lib/quarto.js
+++ b/build/lib/quarto.js
@@ -129,7 +129,7 @@ function getQuartoLinux(version) {
  */
 function getQuartoStream() {
     // quarto version
-    const version = '1.9.38';
+    const version = '1.10.18';
     (0, fancy_log_1.default)(`Synchronizing quarto ${version}...`);
     // Get the download/unpack stream for the current platform
     return process.platform === 'win32' ?

--- a/build/lib/quarto.ts
+++ b/build/lib/quarto.ts
@@ -92,7 +92,7 @@ function getQuartoLinux(version: string): Stream {
  */
 export function getQuartoStream(): Stream {
 	// quarto version
-	const version = '1.9.38';
+	const version = '1.10.18';
 
 	fancyLog(`Synchronizing quarto ${version}...`);
 


### PR DESCRIPTION
Bumps the bundled Quarto from 1.9.38 to 1.10.18, which was [recently released](https://opensource.posit.co/blog/2026-08-03_quarto-1-10/). The [1.10 changelog](https://github.com/quarto-dev/quarto-cli/blob/v1.10.18/news/changelog-1.10.md) has the full list of what users get. I think the timing here is good to bump it today, ahead of our 2026.08 release.

This is a version string in `build/lib/quarto.ts` plus the checked-in compiled `build/lib/quarto.js`; nothing else in the repo pins a Quarto version. Since this crosses a minor version rather than a patch, I did check the two things that could plausibly break in the download and unpack code:

- All four release assets the build fetches still exist for `v1.10.18` (`-win.zip`, `-macos.tar.gz`, `-linux-amd64.tar.gz`, `-linux-arm64.tar.gz`).
- The unpacked tree still has `bin/tools/{aarch64,x86_64}`, which is what the macOS opposite-arch filter in `getQuartoBinaries` depends on. `npm run download-quarto` on an arm64 Mac unpacks cleanly and `.build/quarto/bin/quarto --version` reports `1.10.18`.

### Release Notes

#### New Features

- Updated the bundled version of Quarto to 1.10.18.

#### Bug Fixes

- N/A

### Validation Steps

There is not much to validate on a dev build here because Quarto is only downloaded and bundled during a _release_ build, so a local dev build (and the e2e suite running against one) uses whatever Quarto is already on your `PATH`, not the pinned version. I've been using Quarto 1.10 for a while now and have not had problems with anything.

The real validation would be on a build artifact:

1. Install a release build from this branch (or the next daily once it is merged).
2. Open a `.qmd` file and render or preview it, with both an R and a Python chunk.
3. Confirm the bundled Quarto is the new version: run `quarto --version` in a terminal that resolves to the bundled binary, or check the Quarto output channel from the render in step 2. It should report `1.10.18`.
