### PR TITLE
Read the code cells delimiter once per parse, not once per line

### DIFF
--- a/extensions/positron-code-cells/src/parser.ts
+++ b/extensions/positron-code-cells/src/parser.ts
@@ -16,8 +16,8 @@ export enum CellType {
 }
 
 export interface CellParser {
-	isCellStart(line: string): boolean;
-	isCellEnd(line: string): boolean;
+	isCellStart(line: string, additionalCellDelimiter: string): boolean;
+	isCellEnd(line: string, additionalCellDelimiter: string): boolean;
 	getCellType(line: string): CellType;
 	getCellText(cell: Cell, document: vscode.TextDocument): string;
 	newCell(): string;
@@ -64,14 +64,18 @@ const pythonMarkdownRegExp = new RegExp(/^#\s*%%[^[]*\[markdown\]/);
 const rIsCellStartRegExp = new RegExp(/^#\s*(%%|\+)/);
 const rIsSectionHeaderRegExp = new RegExp(/^#+.*[-=]{4,}\s*$/);
 
+// Reading a configuration value is expensive: each call rebuilds and clones the
+// consolidated configuration model in the extension host. Callers must read the
+// delimiter once per parse and pass it down to the line predicates, never once
+// per line of the document. See https://github.com/posit-dev/positron/issues/14990.
 function getAdditionalCellDelimiter(): string {
 	return vscode.workspace.getConfiguration('codeCells').get('additionalCellDelimiter', '# COMMAND ----------');
 }
 
 // TODO: Expose an API to let extensions register parsers
 const pythonCellParser: CellParser = {
-	isCellStart: (line) => pythonIsCellStartRegExp.test(line) || line === getAdditionalCellDelimiter(),
-	isCellEnd: (_line) => false,
+	isCellStart: (line, additionalCellDelimiter) => pythonIsCellStartRegExp.test(line) || line === additionalCellDelimiter,
+	isCellEnd: () => false,
 	getCellType: (line) => pythonMarkdownRegExp.test(line) ? CellType.Markdown : CellType.Code,
 	getCellText: (cell, document) =>
 		cell.type === CellType.Code
@@ -81,8 +85,8 @@ const pythonCellParser: CellParser = {
 };
 
 const rCellParser: CellParser = {
-	isCellStart: (line) => rIsCellStartRegExp.test(line) || line === getAdditionalCellDelimiter(),
-	isCellEnd: (_line) => _line !== getAdditionalCellDelimiter() && rIsSectionHeaderRegExp.test(_line),
+	isCellStart: (line, additionalCellDelimiter) => rIsCellStartRegExp.test(line) || line === additionalCellDelimiter,
+	isCellEnd: (line, additionalCellDelimiter) => line !== additionalCellDelimiter && rIsSectionHeaderRegExp.test(line),
 	getCellType: (_line) => CellType.Code,
 	getCellText: getCellText,
 	newCell: () => '\n# %%\n'
@@ -99,11 +103,20 @@ export function getParser(languageId: string): CellParser | undefined {
 }
 
 // This function was adapted from the vscode-jupyter extension.
-export function parseCells(document: vscode.TextDocument): Cell[] {
+//
+// The delimiter reader is injectable so that tests can count how often it is
+// called; production callers use the default.
+export function parseCells(
+	document: vscode.TextDocument,
+	readAdditionalCellDelimiter: () => string = getAdditionalCellDelimiter,
+): Cell[] {
 	const parser = getParser(document.languageId);
 	if (!parser) {
 		return [];
 	}
+
+	// Read once for the whole document, before the loop over its lines.
+	const additionalCellDelimiter = readAdditionalCellDelimiter();
 
 	const cells: Cell[] = [];
 	let currentStart: vscode.Position | undefined;
@@ -112,7 +125,7 @@ export function parseCells(document: vscode.TextDocument): Cell[] {
 	for (let index = 0; index < document.lineCount; index += 1) {
 		const line = document.lineAt(index);
 
-		if (parser.isCellStart(line.text)) {
+		if (parser.isCellStart(line.text, additionalCellDelimiter)) {
 			// The current cell had no explicit end, close and push it now
 			if (currentStart !== undefined && currentType !== undefined && currentEnd === undefined) {
 				currentEnd = document.lineAt(index - 1).range.end;
@@ -126,7 +139,7 @@ export function parseCells(document: vscode.TextDocument): Cell[] {
 		}
 
 		if (currentStart !== undefined) {
-			if (parser.isCellEnd(line.text)) {
+			if (parser.isCellEnd(line.text, additionalCellDelimiter)) {
 				// The current cell has an explicit end
 				currentEnd = document.lineAt(index - 1).range.end;
 			} else if (index === document.lineCount - 1) {

--- a/extensions/positron-code-cells/src/test/parser.test.ts
+++ b/extensions/positron-code-cells/src/test/parser.test.ts
@@ -23,6 +23,28 @@ suite('Parsers', () => {
 		});
 	});
 
+	// Regression test for https://github.com/posit-dev/positron/issues/14990. The
+	// additional cell delimiter used to be read from the configuration inside the
+	// per-line predicates, so parsing a long document read it once per line. Each
+	// read rebuilds and clones the consolidated configuration model in the extension
+	// host, and parseCells() runs on every document change, so typing in a long file
+	// queued up seconds of work per keystroke.
+	test('Reads the additional cell delimiter once per parse, not once per line', async () => {
+		const content = ['# %%', ...Array.from({ length: 1000 }, (_, i) => `x${i} <- ${i}`)].join('\n');
+		const document = await vscode.workspace.openTextDocument({ language: 'r', content });
+
+		let reads = 0;
+		const cells = parseCells(document, () => {
+			reads += 1;
+			return '# COMMAND ----------';
+		});
+
+		// The cell assertion guards against a vacuous pass: no reads at all would
+		// also satisfy the count below if parsing bailed out early.
+		assert.strictEqual(cells.length, 1, 'Expected the document to parse into a single cell');
+		assert.strictEqual(reads, 1, 'Expected exactly one configuration read per parse');
+	});
+
 	suite('Python Parser', () => {
 		const language = 'python';
 		const codeCellBody = '123\n456';


### PR DESCRIPTION
- Fixes #14990
- Fixes #15250
- Honestly, probably fixes A LOT of problems we have had around editing feeling snappy

The code cells parser read the `codeCells.additionalCellDelimiter` setting from inside `isCellStart` and `isCellEnd`, which run once per line of the document. Every read rebuilds and deep-clones the consolidated configuration model in the extension host (microsoft/vscode#243350), and `parseCells()` runs on every document change, so editing a long R or Python file did roughly one configuration read per line per keystroke. The delimiter is now read once per parse and passed to the line predicates, so the cost no longer scales with the size of the file.

In a CPU profile attached to #15250 (a 3600-line Python file), 16.8s of a 26.5s profile was spent in `parseCells` -> `isCellStart` -> `getConfiguration` -> `merge` -> `deepClone`, with nothing else above 0.1s. Because the extension host is single threaded, that also stalled unrelated work: console execution, R language server requests, and Air's will-save formatting.

No caching or invalidation was needed, since `documentManager` already reparses open documents when this setting changes.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed slow typing, formatting, and saving in long R and Python files (#14990, #15250)

### Validation Steps

@:editor

1. Open a long R or Python script. [across.R](https://github.com/tidyverse/dplyr/blob/main/R/across.R) from dplyr (1048 lines) is a good one, or generate a file of a few thousand lines.
2. Type quickly, hold down a key, or mass-indent a block. Typing should keep up, and the delay should not grow as you type.
3. Save the file. It should save promptly, with no `Aborted onWillSaveTextDocument-event` in the Window log.
4. Confirm cell parsing still works: add `# %%` markers and check the cell highlighting, the Run Cell code lenses, and the cell folding ranges.
5. Set `codeCells.additionalCellDelimiter` to a custom string and confirm a line matching it still starts a cell, with no reload needed.
