### PR TITLE
Fix wrapped package labels in the connection code dialog's picker

### DIFF
--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/connectDataConnectionWith.css
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/connectDataConnectionWith.css
@@ -15,7 +15,7 @@
 }
 
 .connect-data-connection-with.has-variants {
-	grid-template-columns: 160px auto;
+	grid-template-columns: 170px auto;
 	grid-template-areas:
 		"library-header code-header"
 		"variants       code";
@@ -54,13 +54,16 @@
 
 .connect-data-connection-with .variant-list-item {
 	width: 100%;
-	height: 28px;
 	display: flex;
 	cursor: pointer;
-	padding: 0 8px;
+	min-height: 28px;
+	padding: 8px 8px;
+	flex-shrink: 0;
 	border-radius: 4px;
 	align-items: center;
+	box-sizing: border-box;
 	justify-content: flex-start;
+	overflow-wrap: break-word;
 	color: var(--vscode-foreground);
 	background: transparent;
 }


### PR DESCRIPTION
Fixes #14904

The Package picker in the Connect With dialog pinned every row to a fixed 28px height with no vertical padding. "Environment Variables" needs a 161px column once the list border and item padding are counted, so at the old 160px it wrapped to two lines -- and because the row height was fixed, the second line spilled past the selection highlight and crowded the row beneath it.

The variant column is now 170px, which fits the longest label the drivers ship in English on a single line. Rows are also no longer pinned to a single-line height: they use `min-height` plus vertical padding, so a label that still wraps (a long driver-supplied or translated name) grows its row and keeps the same breathing room a single-line label gets. `flex-shrink: 0` stops a list long enough to scroll from squeezing those taller rows back down and clipping the second line.

CSS only -- no markup, behavior, or API changes.

### Screenshots

When a package name does wrap, it does so by wrapping to two (or more) lines plus vertical padding:

<p>
<img width="826" height="514" alt="Connect Pins - Posit Connect Pins with Python!" src="https://github.com/user-attachments/assets/38048e04-94fc-4f44-83c7-0ca333157012" />
</p>

The variant columns is now 170px so "Environment Variables" fits comfortably:

<p>
<img width="829" height="516" alt="Connect Pins • Posit Connect Pins with Python" src="https://github.com/user-attachments/assets/ebd16efb-cc93-413f-b8b3-f4253436d1cf" />
</p>

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed the spacing of wrapped package names in the package picker of the Connect With dialog (#14904)

### Validation Steps

@:connections

No new automated tests: this is a styling-only change with no unit-testable seam, and asserting pixel geometry in e2e would be brittle. The existing connections suite already opens this dialog and asserts package selection, so it covers regressions in the dialog's markup and roles.
