### PR TITLE
Make the providerCatalog disabledIds test deterministic

### DIFF
--- a/extensions/authentication/src/test/providerCatalog.test.ts
+++ b/extensions/authentication/src/test/providerCatalog.test.ts
@@ -81,8 +81,14 @@ suite('providerCatalog', () => {
 		assert.strictEqual(getCachedProvider('does-not-exist'), undefined);
 	});
 
+	// The only test here that depends on fs.watch delivery. Delivery is normally
+	// ~700ms (300ms debounce plus the settle) but has been observed taking
+	// several seconds under extension-host load, so the wait is deliberately
+	// generous: a slow delivery should read as a slow pass, not a red build. A
+	// timeout at this length means the event was never delivered at all, which
+	// is a real defect rather than contention.
 	test('a file edit fires onDidChangeProviderCatalog with the changed provider id', async function () {
-		this.timeout(10000);
+		this.timeout(30000);
 		writeConfig(configPath, { anthropic: { baseUrl: 'https://original.example.com' } });
 		await initProviderCatalog(context, { configPath });
 		await settle();
@@ -90,7 +96,7 @@ suite('providerCatalog', () => {
 		let baseUrlInsideListener: string | undefined;
 		const changePromise = nextCatalogChange(() => {
 			baseUrlInsideListener = getCachedProvider('anthropic')?.connection.baseUrl;
-		});
+		}, 20000);
 
 		writeConfig(configPath, { anthropic: { baseUrl: 'https://changed.example.com' } });
 
@@ -106,18 +112,24 @@ suite('providerCatalog', () => {
 		);
 	});
 
-	test('disabling a provider surfaces it in disabledIds', async function () {
-		this.timeout(10000);
+	test('disabling a provider surfaces it in disabledIds', async () => {
 		writeConfig(configPath, { anthropic: { enabled: true } });
 		await initProviderCatalog(context, { configPath });
-		await settle();
 		assert.strictEqual(getCachedProvider('anthropic')?.enabled, true);
 
-		const changePromise = nextCatalogChange();
-		writeConfig(configPath, { anthropic: { enabled: false } });
+		// Drive the reload directly instead of through the file watcher. The
+		// disabledIds diff lives in applyCatalog, which the watch handler and
+		// refreshProviderCatalog both funnel through, so this covers the same
+		// logic with no dependence on fs.watch delivery latency. The watcher's
+		// own delivery is covered by the file-edit test above.
+		let payload: Parameters<Parameters<typeof onDidChangeProviderCatalog>[0]>[0] | undefined;
+		const sub = onDidChangeProviderCatalog(p => { payload = p; });
 
-		const change = await changePromise;
-		assert.ok(change.disabledIds.includes('anthropic'), 'disabledIds should include anthropic');
+		writeConfig(configPath, { anthropic: { enabled: false } });
+		await refreshProviderCatalog();
+		sub.dispose();
+
+		assert.ok(payload?.disabledIds.includes('anthropic'), 'disabledIds should include anthropic');
 		assert.strictEqual(getCachedProvider('anthropic')?.enabled, false);
 	});
 


### PR DESCRIPTION
### Summary

`providerCatalog > disabling a provider surfaces it in disabledIds` has been timing out on the **Electron ext-host lane** on most main merge runs since 2026-07-31, with `Error: Timed out waiting for onDidChangeProviderCatalog`.

It is **not attributable to any single PR.** The first failing commit ([#15238](https://github.com/posit-dev/positron/pull/15238)) is a `positron-python` change unrelated to this code, and the failure has since been misattributed to whichever PR's merge run happened to get looked at — most recently [#14886](https://github.com/posit-dev/positron/pull/14886), which touches only `extensions/positron-r`.

### Why it flakes

The test waited up to 5s for an `fs.watch`-driven event. Measured delivery in CI is bimodal — and the slow mode sits right on the deadline:

| Run | sibling watcher test | `disabledIds` |
|---|---|---|
| 30821026687 | 708ms | 705ms |
| 30833747572 | 723ms | 2427ms |
| 30674434608 | 707ms | **timeout** |
| older passes | — | 4836 / 5365 / 5500 / 5564ms |

Anything that nudges delivery past 5000ms turns the lane red.

### The fix

The watcher isn't what this test is about. The `disabledIds` diff lives in `applyCatalog()`, which the watch handler and `refreshProviderCatalog()` both funnel through, and which diffs the extension's own `cache` — populated by an **awaited** load in `initProviderCatalog()`. Driving the reload through `refreshProviderCatalog()` covers the same diff logic with no timing dependency at all.

Coverage of `fs.watch` delivery itself stays in the file-edit test above, which has never flaked (steady ~710ms across every run observed). Its wait is raised to 20s so slow delivery reads as a slow pass rather than a red build. The duration mocha prints each run remains the latency signal, and a timeout at that length would mean the event was never delivered at all — a real defect rather than contention.

### Not fixed here

While diagnosing this I found a genuine race in `ai-config`'s catalog watcher (`ai-lib/packages/ai-config/src/node/watch-catalog.ts`): `rebuild()` is async and unserialized, assigning `previousCatalog` after an `await`, with the initial snapshot fired as a bare `void rebuild()`. An edit arriving while that read is in flight is either **swallowed** (both rebuilds agree, `diffCatalogs` returns `undefined`) or fires with **stale** content. Both arms reproduce deterministically.

That's a user-facing bug — a `providers.json` edit during startup can be dropped or applied backwards — and it's tracked separately at posit-dev/ai-lib#44, with a deterministic repro. It is **not** fixed by this PR — the reference is deliberately plain, with no closing keyword, so merging this cannot auto-close it.

Whether that race is what was actually failing in CI is unresolved: it predicts a binary outcome, while the observed latency spread (2427ms, ~5.5s) is better explained by extension-host contention. Both may be true. This PR removes the flake either way, and preserves the latency signal so the open question stays observable.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

Test-only change to the ext-host suite; no product code touched.

1. `test / ext-host` should pass on this PR.
2. In the Electron ext-host log, `a file edit fires onDidChangeProviderCatalog` should report a duration — that number is the ongoing watcher-latency diagnostic.
3. `disabling a provider surfaces it in disabledIds` should now complete in single-digit ms.

Locally verified: `tsc --noEmit -p extensions/authentication/tsconfig.json` and `eslint` both clean. The ext-host suite itself was not run locally.


