### PR TITLE
Fix R architecture misdetection for conda-forge arm64 R on macOS

### DIFF
--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -306,6 +306,111 @@ export function sniffWindowsBinaryArchitecture(binaryPath?: string): WindowsKern
 	}
 }
 
+/** Architecture as reported by `RInstallation.arch` (Rig-style, e.g. arm64, x86_64). */
+type MachOArch = 'arm64' | 'x86_64';
+
+// Mach-O magic numbers (see <mach-o/loader.h> and <mach-o/fat.h>).
+const MH_MAGIC_64 = 0xfeedfacf;   // thin 64-bit, host-endian (little-endian on disk today)
+const MH_CIGAM_64 = 0xcffaedfe;   // thin 64-bit, byte-swapped
+const FAT_MAGIC = 0xcafebabe;     // universal (fat) binary, big-endian
+const FAT_MAGIC_64 = 0xcafebabf;  // universal (fat) binary with 64-bit offsets
+
+// CPU types (see <mach/machine.h>). The 0x01000000 bit is CPU_ARCH_ABI64.
+const CPU_TYPE_X86_64 = 0x01000007;
+const CPU_TYPE_ARM64 = 0x0100000c;
+
+/**
+ * Maps a Mach-O `cputype` value to the architecture strings used by
+ * `RInstallation.arch`.
+ */
+function machOArchFromCpuType(cpuType: number): MachOArch | undefined {
+	switch (cpuType >>> 0) {
+		case CPU_TYPE_ARM64:
+			return 'arm64';
+		case CPU_TYPE_X86_64:
+			return 'x86_64';
+		default:
+			return undefined;
+	}
+}
+
+/**
+ * Sniffs the architecture of a macOS binary by examining its Mach-O header.
+ *
+ * The conda-forge `Built` field records the (cross-compilation) build farm's
+ * platform rather than the installed binary's architecture, so the actual
+ * Mach-O header is the reliable source. This is the macOS analog of
+ * {@link sniffWindowsBinaryArchitecture}.
+ *
+ * For universal (fat) binaries, the slice matching the current process
+ * architecture is preferred (that is the slice macOS runs natively); if there
+ * is no such slice but only one slice exists, that slice is returned.
+ *
+ * @param binaryPath The path to the Mach-O executable (e.g. `<R home>/bin/exec/R`).
+ * @returns The detected architecture, or undefined if it can't be determined.
+ */
+export function sniffMachOBinaryArchitecture(binaryPath?: string): MachOArch | undefined {
+	if (!binaryPath) {
+		return undefined;
+	}
+	try {
+		const fd = fs.openSync(binaryPath, 'r');
+		try {
+			// Enough to cover the fat header plus a handful of fat_arch entries.
+			const header = Buffer.alloc(4096);
+			const bytesRead = fs.readSync(fd, header, 0, header.length, 0);
+			if (bytesRead < 8) {
+				return undefined;
+			}
+
+			// Fat headers and their fields are stored big-endian on disk.
+			const magicBE = header.readUInt32BE(0);
+			if (magicBE === FAT_MAGIC || magicBE === FAT_MAGIC_64) {
+				const is64 = magicBE === FAT_MAGIC_64;
+				const nFatArch = header.readUInt32BE(4);
+				// fat_arch is 20 bytes; fat_arch_64 is 32 bytes. cputype is the first field.
+				const entrySize = is64 ? 32 : 20;
+				const arches = new Set<MachOArch>();
+				for (let i = 0; i < nFatArch; i++) {
+					const offset = 8 + i * entrySize;
+					if (offset + 4 > bytesRead) {
+						break;
+					}
+					const arch = machOArchFromCpuType(header.readUInt32BE(offset));
+					if (arch) {
+						arches.add(arch);
+					}
+				}
+				// Prefer the slice that matches the host, since that is what runs natively.
+				const hostArch: MachOArch | undefined =
+					process.arch === 'arm64' ? 'arm64' : process.arch === 'x64' ? 'x86_64' : undefined;
+				if (hostArch && arches.has(hostArch)) {
+					return hostArch;
+				}
+				return arches.size === 1 ? [...arches][0] : undefined;
+			}
+
+			// Thin Mach-O: read the magic in both byte orders to determine endianness,
+			// then read the cputype (the field immediately after the magic).
+			const magicLE = header.readUInt32LE(0);
+			if (magicLE === MH_MAGIC_64) {
+				return machOArchFromCpuType(header.readUInt32LE(4));
+			}
+			if (magicLE === MH_CIGAM_64) {
+				return machOArchFromCpuType(header.readUInt32BE(4));
+			}
+
+			// Not a 64-bit Mach-O we recognize (e.g. legacy 32-bit), which we don't support.
+			return undefined;
+		} finally {
+			fs.closeSync(fd);
+		}
+	} catch (error) {
+		LOGGER.debug(`Unable to determine macOS R architecture from ${binaryPath}: ${error}`);
+		return undefined;
+	}
+}
+
 /**
  * Sets up ark as a discoverable Jupyter kernel so that external tools like
  * Quarto can find it via `jupyter kernelspec list`.

--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -11,7 +11,7 @@ import { LOGGER } from './extension';
 import { MINIMUM_R_VERSION } from './constants';
 import { arePathsSame } from './path-utils';
 import { getDefaultInterpreterPath, isExcludedInstallation } from './interpreter-settings.js';
-import { normalizeWindowsArch, sniffWindowsBinaryArchitecture } from './kernel.js';
+import { normalizeWindowsArch, sniffMachOBinaryArchitecture, sniffWindowsBinaryArchitecture } from './kernel.js';
 
 /**
  * Extra metadata included in the LanguageRuntimeMetadata for R installations.
@@ -375,6 +375,17 @@ export class RInstallation {
 				if (normalizedArch && detectedArch !== normalizedArch) {
 					LOGGER.warn(`Discrepancy between derived Windows architecture ${derivedArch} and sniffed architecture ${detectedArch} for R ${this.version} at ${this.binpath}`);
 				}
+			}
+		} else if (process.platform === 'darwin') {
+			// The DESCRIPTION 'Built' field records the build farm's platform, which
+			// for cross-compiled builds (notably conda-forge osx-arm64 R) does not
+			// match the installed binary. Prefer sniffing the actual Mach-O executable,
+			// analogous to the PE-header sniffing above for Windows. See #15297.
+			const execPath = path.join(this.homepath, 'bin', 'exec', 'R');
+			const detectedArch = sniffMachOBinaryArchitecture(execPath);
+			if (detectedArch && detectedArch !== derivedArch) {
+				LOGGER.info(`Corrected R architecture from '${derivedArch || 'unknown'}' (DESCRIPTION Built field) to '${detectedArch}' (Mach-O header) for R ${this.version} at ${execPath}`);
+				derivedArch = detectedArch;
 			}
 		}
 

--- a/extensions/positron-r/src/test/sniff-macho.unit.test.ts
+++ b/extensions/positron-r/src/test/sniff-macho.unit.test.ts
@@ -1,0 +1,82 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import './mocha-setup';
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { sniffMachOBinaryArchitecture } from '../kernel';
+
+const CPU_TYPE_X86_64 = 0x01000007;
+const CPU_TYPE_ARM64 = 0x0100000c;
+
+/** Writes a minimal thin 64-bit Mach-O header (little-endian) for the given cputype. */
+function writeThinMachO(cpuType: number): string {
+	const buf = Buffer.alloc(32);
+	buf.writeUInt32LE(0xfeedfacf, 0); // MH_MAGIC_64
+	buf.writeUInt32LE(cpuType >>> 0, 4); // cputype
+	return writeTempBinary(buf);
+}
+
+/** Writes a minimal universal (fat) Mach-O header (big-endian) for the given cputypes. */
+function writeFatMachO(cpuTypes: number[]): string {
+	const buf = Buffer.alloc(8 + cpuTypes.length * 20);
+	buf.writeUInt32BE(0xcafebabe, 0); // FAT_MAGIC
+	buf.writeUInt32BE(cpuTypes.length, 4); // nfat_arch
+	cpuTypes.forEach((cpuType, i) => {
+		buf.writeUInt32BE(cpuType >>> 0, 8 + i * 20); // fat_arch.cputype
+	});
+	return writeTempBinary(buf);
+}
+
+const tempFiles: string[] = [];
+
+function writeTempBinary(buf: Buffer): string {
+	const file = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'macho-')), 'exec');
+	fs.writeFileSync(file, buf);
+	tempFiles.push(file);
+	return file;
+}
+
+suite('sniffMachOBinaryArchitecture', () => {
+
+	suiteTeardown(() => {
+		for (const file of tempFiles) {
+			fs.rmSync(path.dirname(file), { recursive: true, force: true });
+		}
+	});
+
+	test('thin arm64 binary', () => {
+		assert.strictEqual(sniffMachOBinaryArchitecture(writeThinMachO(CPU_TYPE_ARM64)), 'arm64');
+	});
+
+	test('thin x86_64 binary', () => {
+		assert.strictEqual(sniffMachOBinaryArchitecture(writeThinMachO(CPU_TYPE_X86_64)), 'x86_64');
+	});
+
+	test('universal binary prefers the host architecture', () => {
+		const arch = sniffMachOBinaryArchitecture(writeFatMachO([CPU_TYPE_X86_64, CPU_TYPE_ARM64]));
+		const expected = process.arch === 'arm64' ? 'arm64' : process.arch === 'x64' ? 'x86_64' : undefined;
+		assert.strictEqual(arch, expected);
+	});
+
+	test('single-slice universal binary returns that slice', () => {
+		// A fat binary whose only slice does not match the host still resolves.
+		const otherArch = process.arch === 'arm64' ? CPU_TYPE_X86_64 : CPU_TYPE_ARM64;
+		const expected = otherArch === CPU_TYPE_ARM64 ? 'arm64' : 'x86_64';
+		assert.strictEqual(sniffMachOBinaryArchitecture(writeFatMachO([otherArch])), expected);
+	});
+
+	test('undefined and missing paths return undefined', () => {
+		assert.strictEqual(sniffMachOBinaryArchitecture(undefined), undefined);
+		assert.strictEqual(sniffMachOBinaryArchitecture('/nonexistent/exec/R'), undefined);
+	});
+
+	test('unrecognized header returns undefined', () => {
+		assert.strictEqual(sniffMachOBinaryArchitecture(writeTempBinary(Buffer.alloc(64))), undefined);
+	});
+});


### PR DESCRIPTION
Fixes #15297

On macOS arm64, a native arm64 conda-forge R build was misdetected as x64, triggering a spurious "different architecture (x64) than your system (arm64)" warning at session start.

The interpreter architecture was derived solely from the `Built` field of `<R home>/library/utils/DESCRIPTION`. conda-forge's osx-arm64 packages are cross-compiled on x86_64 workers and stamp the build farm's platform (`x86_64-apple-darwin13.4.0`) into that field, so it does not reflect the installed binary. The binary itself, `R.version$arch`, and `Sys.info()[["machine"]]` all correctly report arm64.

This adds `sniffMachOBinaryArchitecture()`, a Mach-O header sniff analogous to the existing Windows PE-header sniff, and prefers it over the DESCRIPTION field on macOS by inspecting the real executable at `<R home>/bin/exec/R` (the discovered binary is usually a shell-script wrapper). Universal (fat) binaries resolve to the slice matching the host, so Intel Macs stay correct. Windows and Linux behavior is unchanged.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix R interpreter architecture being misdetected as x64 for native arm64 conda-forge R on macOS (#15297)

### Validation Steps

@:interpreter

Requires an Apple Silicon Mac with miniforge/conda.

1. Create a native arm64 conda-forge R env:
   ```bash
   CONDA_SUBDIR=osx-arm64 conda create -y -n datasci -c conda-forge r-base=4.4.3
   ```
2. Register it in Positron via `"positron.r.customBinaries": ["<env>/bin/R"]` and reload.
3. Start an R console on that interpreter.
4. Verify **no** architecture mismatch warning appears, and the console banner reports `Platform: aarch64-apple-darwin...`.

Before this change the warning appeared; after it, the interpreter is correctly detected as arm64. Automated coverage: `extensions/positron-r/src/test/sniff-macho.unit.test.ts` exercises the Mach-O sniff (thin arm64/x86_64, universal/host-preference, and error paths).
