### PR TITLE
e2e: skip reticulate tests blocked on #10953

### DIFF
--- a/test/e2e/tests/reticulate/reticulate-multiple.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-multiple.test.ts
@@ -17,7 +17,11 @@ test.use({
 test.describe('Reticulate', {
 	tag: [tags.RETICULATE, tags.WEB, tags.ARK, tags.SOFT_FAIL],
 }, () => {
-	test('R - Verify Basic Reticulate Functionality using reticulate::repl_python() with multiple sessions', async function ({ app, sessions, logger }) {
+	// Skipped: execute requests sent to the reticulate Python session hang in CI, so the
+	// variable never appears and the test spins until it times out. Un-skip when #10953 is fixed.
+	test.skip('R - Verify Basic Reticulate Functionality using reticulate::repl_python() with multiple sessions', {
+		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/10953' }]
+	}, async function ({ app, sessions, logger }) {
 		const { console } = app.workbench;
 
 		// start R session and start reticulate within it

--- a/test/e2e/tests/reticulate/reticulate-repl-python.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-repl-python.test.ts
@@ -17,7 +17,11 @@ test.use({
 test.describe('Reticulate', {
 	tag: [tags.RETICULATE, tags.WEB, tags.ARK, tags.SOFT_FAIL],
 }, () => {
-	test('R - Verify Basic Reticulate Functionality using reticulate::repl_python()', async function ({ app, sessions, logger }) {
+	// Skipped: execute requests sent to the reticulate Python session hang in CI, so the
+	// variable never appears and the test spins until it times out. Un-skip when #10953 is fixed.
+	test.skip('R - Verify Basic Reticulate Functionality using reticulate::repl_python()', {
+		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/10953' }]
+	}, async function ({ app, sessions, logger }) {
 		const { console } = app.workbench;
 
 		// start new reticulate session and verify functionality

--- a/test/e2e/tests/reticulate/reticulate-stop-start.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-stop-start.test.ts
@@ -17,8 +17,11 @@ test.use({
 test.describe('Reticulate', {
 	tag: [tags.RETICULATE, tags.WEB, tags.SOFT_FAIL],
 }, () => {
-	test('R - Verify Reticulate Stop/Start Functionality', {
-		tag: [tags.ARK]
+	// Skipped: execute requests sent to the reticulate Python session hang in CI, so the
+	// variable never appears and the test spins until it times out. Un-skip when #10953 is fixed.
+	test.skip('R - Verify Reticulate Stop/Start Functionality', {
+		tag: [tags.ARK],
+		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/10953' }]
 	}, async function ({ app, r }) {
 		const { sessions, modals } = app.workbench;
 


### PR DESCRIPTION
## Summary

Skips the three reticulate e2e tests that call `verifyReticulateFunctionality`, pending a fix for #10953.

| Test | Action |
|---|---|
| `reticulate-multiple.test.ts` | skipped |
| `reticulate-repl-python.test.ts` | skipped |
| `reticulate-stop-start.test.ts` | skipped |
| `reticulate-restart.test.ts` | left running |
| `reticulate-variables.test.ts` | left running |

Each skip carries `annotation: [{ type: 'issue', description: '.../issues/10953' }]` plus an "Un-skip when #10953 is fixed" comment, matching the convention already used in `autocomplete.test.ts` and `code-actions/r.test.ts`.

## Why

Execute requests sent to the reticulate Python session are never processed in CI. The `toPass()` loop in [`verifyReticulateFunction.ts`](https://github.com/posit-dev/positron/blob/main/test/e2e/tests/reticulate/helpers/verifyReticulateFunction.ts#L21-L29) re-sends `x = 200` until the 120s test timeout, always failing on the downstream Variables pane assertion:

```
Error: Can create variable in Python session
Locator: .variables-instance[style*="z-index: 1"] .variable-item ... .name-column 'x'
Error: element(s) not found
Call Log: Test timeout of 120000ms exceeded
```

`console.executeCode` reports success in this state because `waitForReady` only asserts the active line shows `>>>`, and that prompt stays in the DOM when the kernel goes dark — so the hang never surfaces at the point of send.

Recent occurrences on `main`, across both electron and chromium:

- [30846044718](https://github.com/posit-dev/positron/actions/runs/30846044718) — `reticulate-stop-start`, electron-2, failed attempt 1 + retry
- [30850328359](https://github.com/posit-dev/positron/actions/runs/30850328359) — `reticulate-stop-start`, electron-2, identical assertion
- [30846740485](https://github.com/posit-dev/positron/actions/runs/30846740485) — `reticulate-multiple`, chromium-2, identical assertion

`reticulate-restart` and `reticulate-variables` are untouched: the former only starts/restarts a session, and the latter runs through the R console rather than the reticulate Python kernel. Neither is implicated in #10953.

## Note on root cause

These tests already carry `soft-fail`, so they weren't turning the merge lane red — the motivation is the ~2 min of wall clock per attempt (doubled by the retry) and the triage noise.

I confirmed the failure *signature* matches #10953 but could not confirm its root cause from the artifacts, so this PR does not claim the diagnosis is closed. The distinguishing evidence in the issue (kcserver `Queueing request ... N pending requests`, kernel going dark after a `setConsoleWidth` comm_msg) needs per-attempt kernel logs, and those weren't retrievable: `test-merge.yml` sets `upload_logs: false` for electron, the `blob-report` artifact is deleted by the merge-reports job, and the surviving chromium `test-logs` tree is keyed by test file so a passing retry overwrites the failing attempt's logs.

One alternative I could not rule out: the locator targets the foreground variables instance (`[style*="z-index: 1"]`), and the helper's own comment warns that foreground can be reassigned asynchronously when multiple same-language sessions are open. If the pane is stuck on the wrong session, `x` would be set but invisible — identical error text, different cause. Both failing tests involve two reticulate sessions.

## QA Notes

No product code changes; e2e test annotations only. Verified locally with the JSON reporter that the three tests now report `expectedStatus: skipped` with the issue annotation attached, and that the other two still report `passed`.

@:reticulate
