### PR TITLE
Fix fresh-clone `npm install` when npm pre-creates the ai-lib submodule dir

### DIFF
--- a/build/npm/initAiLibSubmodule.ts
+++ b/build/npm/initAiLibSubmodule.ts
@@ -1,0 +1,104 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as child_process from 'child_process';
+import * as fs from 'fs';
+import path from 'path';
+
+const SUBMODULE_PATH = 'ai-lib';
+
+/**
+ * Initialize the ai-lib submodule, tolerating a submodule directory that npm has
+ * already populated.
+ *
+ * `git submodule update --init` clones into the submodule path, and git refuses to
+ * clone into a directory that is not empty. That is exactly the state a fresh clone
+ * is in by the time this runs: the root package.json declares `file:` dependencies
+ * on the ai-lib workspace packages, and because those packages' devDependencies all
+ * conflict with the root's (typescript, vitest, @types/node, zod), package-lock.json
+ * records them nested at `ai-lib/packages/<pkg>/node_modules/...`. npm materializes
+ * those paths during reify -- which happens BEFORE any lifecycle script, `preinstall`
+ * included -- so the very first `npm install` after a clone creates `ai-lib/packages`
+ * and then fails here with:
+ *
+ *     fatal: destination path '.../ai-lib' already exists and is not an empty directory.
+ *
+ * and it fails the same way on every subsequent run, because nothing ever clears the
+ * directory. Moving the init earlier cannot fix this; the init has to cope with the
+ * directory already existing. So: move the pre-existing entries aside, let git clone
+ * into the now-empty path, then merge them back over the checkout.
+ *
+ * This is deliberately specific to ai-lib rather than a general submodule helper.
+ * Moving a submodule's contents aside is only safe because everything that can be
+ * there is npm-generated and reproducible -- for a submodule with a real working
+ * tree (ark), the right answer to "not empty" is to fail loudly instead.
+ *
+ * @param root Absolute path to the repository root.
+ * @param log Logger for progress messages.
+ */
+export function initAiLibSubmodule(root: string, log: (message: string) => void): void {
+	const submoduleAbs = path.join(root, SUBMODULE_PATH);
+	if (fs.existsSync(path.join(submoduleAbs, '.git'))) {
+		return;
+	}
+
+	// Stash inside .build (gitignored, and on the same filesystem as the submodule
+	// so the moves are renames rather than copies of a full node_modules tree).
+	const stashDir = path.join(root, '.build', `${SUBMODULE_PATH}-init-stash`);
+	const stray = fs.existsSync(submoduleAbs) ? fs.readdirSync(submoduleAbs) : [];
+
+	if (stray.length) {
+		log(`Submodule directory is not empty (${stray.join(', ')}); moving contents aside so git can clone into it...`);
+		fs.rmSync(stashDir, { recursive: true, force: true });
+		fs.mkdirSync(stashDir, { recursive: true });
+		for (const entry of stray) {
+			fs.renameSync(path.join(submoduleAbs, entry), path.join(stashDir, entry));
+		}
+	}
+
+	try {
+		log('Submodule not initialized; running `git submodule update --init`...');
+		const result = child_process.spawnSync('git', ['submodule', 'update', '--init', '--', SUBMODULE_PATH], {
+			cwd: root,
+			stdio: 'inherit',
+		});
+		if (result.error) {
+			throw result.error;
+		}
+		if (result.status !== 0) {
+			throw new Error(`\`git submodule update --init -- ${SUBMODULE_PATH}\` exited with code ${result.status}`);
+		}
+	} finally {
+		// Restore on failure too (e.g. offline): the stash holds the only copy of
+		// whatever was there, and a half-installed node_modules still beats none.
+		if (stray.length) {
+			mergeInto(stashDir, submoduleAbs);
+			fs.rmSync(stashDir, { recursive: true, force: true });
+		}
+	}
+}
+
+/**
+ * Move everything under `from` into `to`, recursing into directories that exist on
+ * both sides. Entries already present in `to` are left alone -- the checkout is the
+ * source of truth for anything git tracks, and in practice the two do not overlap
+ * at all, since the stash only ever holds npm-generated `node_modules` trees.
+ */
+function mergeInto(from: string, to: string): void {
+	fs.mkdirSync(to, { recursive: true });
+	for (const entry of fs.readdirSync(from)) {
+		const src = path.join(from, entry);
+		const dest = path.join(to, entry);
+		// lstat, not stat: node_modules is full of symlinks, and a symlink should be
+		// moved as-is rather than descended into. throwIfNoEntry:false also treats a
+		// dangling symlink at dest as "present" so the rename below cannot EEXIST.
+		const destStat = fs.lstatSync(dest, { throwIfNoEntry: false });
+		if (!destStat) {
+			fs.renameSync(src, dest);
+		} else if (destStat.isDirectory() && fs.lstatSync(src).isDirectory()) {
+			mergeInto(src, dest);
+		}
+	}
+}

--- a/build/npm/postinstall.ts
+++ b/build/npm/postinstall.ts
@@ -10,6 +10,9 @@ import * as child_process from 'child_process';
 import { createRequire } from 'module';
 import { dirs } from './dirs.ts';
 import { root, stateFile, stateContentsFile, computeState, computeContents, isUpToDate } from './installStateHash.ts';
+// --- Start Positron ---
+import { initAiLibSubmodule } from './initAiLibSubmodule.ts';
+// --- End Positron ---
 
 const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 const rootNpmrcConfigKeys = getNpmrcConfigKeys(path.join(root, '.npmrc'));
@@ -593,12 +596,12 @@ async function main() {
 	// authentication extension's postinstall, which builds ai-config from the
 	// ai-lib submodule. Unlike ark, ai-lib has no install step of its own to
 	// initialize it, so a missing ai-lib checkout is initialized here first —
-	// there is no working tree to lose.
+	// there is no working tree to lose. npm has already created
+	// ai-lib/packages/<pkg>/node_modules by this point (the root package.json takes
+	// `file:` deps on those packages), so the init has to be able to clone into a
+	// directory that is not empty -- see initAiLibSubmodule.
 	try {
-		if (!fs.existsSync(path.join(root, 'ai-lib', '.git'))) {
-			log('ai-lib', 'Submodule not initialized; running `git submodule update --init`...');
-			run('git', ['submodule', 'update', '--init', '--', 'ai-lib'], { cwd: root, stdio: 'inherit' });
-		}
+		initAiLibSubmodule(root, message => log('ai-lib', message));
 		await syncSubmoduleIfSafe('extensions/positron-r/ark');
 		await syncSubmoduleIfSafe('ai-lib');
 	} catch (err) {


### PR DESCRIPTION
### Problem

In a freshly-cloned positron repo, `npm install` results in:

```
[ai-lib] Submodule not initialized; running `git submodule update --init`...
[/Users/brian/positron] $ git submodule update --init -- ai-lib
Submodule 'ai-lib' (https://github.com/posit-dev/ai-lib.git) registered for path 'ai-lib'
fatal: destination path '/Users/brian/positron/ai-lib' already exists and is not an empty directory.
fatal: clone of 'https://github.com/posit-dev/ai-lib.git' into submodule path '/Users/brian/positron/ai-lib' failed
Failed to clone 'ai-lib'. Retry scheduled
fatal: destination path '/Users/brian/positron/ai-lib' already exists and is not an empty directory.
fatal: clone of 'https://github.com/posit-dev/ai-lib.git' into submodule path '/Users/brian/positron/ai-lib' failed
Failed to clone 'ai-lib' a second time, aborting
ERR Process exited with code: 1
npm error code 1
npm error path /Users/brian/positron
npm error command failed
npm error command sh -c node build/npm/postinstall.ts
npm error A complete log of this run can be found in: /Users/brian/.npm/_logs/2026-08-04T00_19_48_587Z-debug-0.log
```

The only workaround for this is to manually run `git submodule update --init --recursive ai-lib` before running `npm install`.

### Overview

The root `package.json` takes `file:` dependencies on the ai-lib workspace packages, and because those packages' devDependencies conflict with the root's (typescript, vitest, @types/node, zod), `package-lock.json` records them nested at `ai-lib/packages/<pkg>/node_modules/...`. npm materializes those paths during reify, which happens *before* any lifecycle script -- `preinstall` included -- so `ai-lib/packages` already exists by the time postinstall runs `git submodule update --init`, and git refuses to clone into a non-empty directory. It then fails identically on every subsequent run, because nothing ever clears the directory. Moving the init earlier can't fix this; the init itself has to cope with the directory already existing.

This PR extracts the init into `build/npm/initAiLibSubmodule.ts`, which moves any pre-existing entries aside into a gitignored stash under `.build/` (same filesystem, so the moves are renames rather than copies of a full `node_modules` tree), runs the clone into the now-empty path, then merges the stashed entries back over the checkout. The restore runs in a `finally` block so an init failure (e.g. offline) doesn't strand the only copy of what was there.

The helper is deliberately specific to ai-lib rather than a general submodule utility: moving a submodule's contents aside is only safe because everything that can be in `ai-lib` at that point is npm-generated and reproducible. For a submodule with a real working tree (ark), the correct response to "not empty" remains to fail loudly, and that behavior is unchanged.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A (developer-facing build fix, no user-visible change)

### Validation Steps

No e2e tags apply -- this changes only the npm postinstall path and no product code. Every CI job exercises the fix implicitly by running `npm install`.

To validate locally, reproduce the original failure and confirm the fix:

1. Clone the repo fresh (or `rm -rf node_modules ai-lib` in an existing checkout, then `git submodule deinit -f ai-lib`).
2. Run `npm install`. On `main` this fails with the `already exists and is not an empty directory` error; on this branch it completes.
3. Confirm the submodule is a real checkout: `ls ai-lib/.git` and `git submodule status ai-lib` (should not be prefixed with `-`).
4. Confirm the nested npm trees survived the move: `ls ai-lib/packages/*/node_modules`.
5. Confirm no stash was left behind: `ls .build` should contain no `ai-lib-init-stash`.
6. Run `npm install` a second time and verify it's a no-op for the submodule (the early-return on `ai-lib/.git` takes effect).
7. Verify ark is unaffected: it still uses `syncSubmoduleIfSafe` and is not moved aside.
