### PR TITLE
Raise the code cells decorations test poll budget to 15s

### DIFF
--- a/extensions/positron-code-cells/src/test/utils.ts
+++ b/extensions/positron-code-cells/src/test/utils.ts
@@ -23,8 +23,14 @@ export function delay(ms: number) {
  * decorations that refresh after an editor event fires). Returns once the
  * predicate passes; on timeout it returns anyway so the caller's own assertion
  * can produce a meaningful failure message.
+ *
+ * The default timeout is deliberately generous: polling exits as soon as the
+ * predicate passes, so it only delays genuinely failing runs. A loaded CI
+ * runner has been observed to delay editor event delivery beyond 2 seconds
+ * (see https://github.com/posit-dev/positron/pull/15289 checks), while the
+ * mocha per-test cap for this suite is 60 seconds.
  */
-export async function waitFor(predicate: () => boolean, timeout = 2000, interval = 50): Promise<void> {
+export async function waitFor(predicate: () => boolean, timeout = 15_000, interval = 50): Promise<void> {
 	const start = Date.now();
 	while (!predicate()) {
 		if (Date.now() - start >= timeout) {

--- a/extensions/positron-code-cells/src/test/utils.ts
+++ b/extensions/positron-code-cells/src/test/utils.ts
@@ -17,18 +17,11 @@ export function delay(ms: number) {
 }
 
 /**
- * Poll `predicate` until it returns true or the timeout elapses.
+ * Polls until the predicate succeeds or the timeout expires. On timeout, returns
+ * without throwing so the caller's assertion can report the relevant failure.
  *
- * Useful for asserting on state that updates asynchronously (e.g. editor
- * decorations that refresh after an editor event fires). Returns once the
- * predicate passes; on timeout it returns anyway so the caller's own assertion
- * can produce a meaningful failure message.
- *
- * The default timeout is deliberately generous: polling exits as soon as the
- * predicate passes, so it only delays genuinely failing runs. A loaded CI
- * runner has been observed to delay editor event delivery beyond 2 seconds
- * (see https://github.com/posit-dev/positron/pull/15289 checks), while the
- * mocha per-test cap for this suite is 60 seconds.
+ * The generous default accommodates delayed editor events on loaded CI runners.
+ * Successful waits still return as soon as the predicate passes.
  */
 export async function waitFor(predicate: () => boolean, timeout = 15_000, interval = 50): Promise<void> {
 	const start = Date.now();


### PR DESCRIPTION
Increases the default timeout for the `positron-code-cells` test helper `waitFor` from 2 seconds to 15 seconds.

### Summary

`Decorations > Changing the selected code cell in a Python document` failed again on a heavily loaded CI runner ([failing job](https://github.com/posit-dev/positron/actions/runs/30831632476/job/91765193080)). The decoration was still attached to the previously selected cell when the 2-second polling window expired.

This has the same signature as the failure addressed by #15038, which replaced a fixed 400 ms delay with polling:

- In the failing job, the sibling test's equivalent wait took 1,026 ms instead of approximately 80 ms locally.
- The full suite ran 10–70 times slower than it does locally, while the Copilot extension reported unhandled-rejection handlers taking more than one second.
- After #15283, a transient period without an active editor cannot permanently lose the decoration update: `onDidChangeActiveTextEditor` triggers another update using current editor state.
- The failure did not reproduce in 15 local full-suite runs or eight runs with all CPU cores oversubscribed twofold.

Because `waitFor` returns as soon as its predicate succeeds, increasing the timeout does not slow passing tests. It only gives unusually slow CI runners more time before reporting a failure. The suite's per-test Mocha timeout remains 60 seconds.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

This is a test-only change covered by the `test / ext-host` CI job. To validate locally:

```bash
npm run test-extension -- -l positron-code-cells
```

Expect 72 passing tests.
