### PR TITLE
fix(positron-r): distinguish Homebrew Caskroom runtimes

### DIFF
--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -616,8 +616,8 @@ export function classifyRRuntimeSource(
 		(packagerMetadata !== undefined && isPixiMetadata(packagerMetadata)) || hasReason(ReasonDiscovered.PIXI);
 	const isCondaInstallation =
 		(packagerMetadata !== undefined && isCondaMetadata(packagerMetadata)) || hasReason(ReasonDiscovered.CONDA);
-	// Homebrew installations are identified by a 'homebrew' path component.
-	const isHomebrewInstallation = binpath.includes('/homebrew/');
+	// Homebrew installations are identified by a 'homebrew' path component, excluding Caskroom installs.
+	const isHomebrewInstallation = binpath.includes('/homebrew/') && !binpath.includes('/homebrew/Caskroom/');
 
 	if (isModuleInstallation) {
 		return RRuntimeSource.module;

--- a/extensions/positron-r/src/test/classify-runtime-source.test.ts
+++ b/extensions/positron-r/src/test/classify-runtime-source.test.ts
@@ -63,6 +63,18 @@ suite('classifyRRuntimeSource', () => {
 		);
 	});
 
+	test('classifies a miniforge environment in the Homebrew Caskroom as system without metadata', () => {
+		assert.strictEqual(
+			classifyRRuntimeSource(
+				'/opt/homebrew/Caskroom/miniforge/base/envs/myenv/bin/R',
+				undefined,
+				[ReasonDiscovered.userSetting],
+				false,
+			),
+			RRuntimeSource.system,
+		);
+	});
+
 	test('classifies homebrew, user, and system installations without metadata', () => {
 		assert.strictEqual(
 			classifyRRuntimeSource('/opt/homebrew/bin/R', undefined, [ReasonDiscovered.HQ], false),


### PR DESCRIPTION
Fixes #15300

The R runtime source classifier used `/homebrew/` anywhere in the binary path to label an installation as Homebrew. Homebrew Caskroom paths also contain Conda environments, so a user-selected Miniforge R binary could be displayed as Homebrew.

This change excludes `/homebrew/Caskroom/` from that heuristic while keeping metadata/reason precedence and the existing `/opt/homebrew/bin/R` Homebrew behavior.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- R binaries selected from Homebrew Caskroom Conda environments are no longer labeled as Homebrew when no package metadata is available.

### Validation Steps

- Targeted classifier harness: 5/5 tests passed, including the new Caskroom regression and existing Conda/Pixi/Module/System/User cases.
- ESLint passed for `provider.ts` and `classify-runtime-source.test.ts`.
- The official extension-host test and full extension compile could not run in the API-based partial checkout (`vscode-test` and the complete VS Code/Positron type graph were unavailable).