### PR TITLE
Persist auxiliary window chrome traits

### DIFF
--- a/src/vs/workbench/browser/parts/editor/auxiliaryEditorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/auxiliaryEditorPart.ts
@@ -176,6 +176,15 @@ export class AuxiliaryEditorPart {
 				return;
 			}
 
+			// --- Start Positron ---
+			// A `lockCompact` window is chromeless because it is compact, and
+			// compact mode is persisted: letting a stray editor or menu action
+			// switch it off would grow workbench chrome back on every restore.
+			if (options?.lockCompact === true) {
+				return;
+			}
+			// --- End Positron ---
+
 			compact = newCompact;
 			auxiliaryWindow.updateOptions({ compact });
 			titlebarPart?.updateOptions({ compact });

--- a/src/vs/workbench/contrib/positronEditorActions/browser/positronDedicatedWindow.ts
+++ b/src/vs/workbench/contrib/positronEditorActions/browser/positronDedicatedWindow.ts
@@ -11,15 +11,24 @@ import { IAuxiliaryWindowOpenOptions } from '../../../services/auxiliaryWindow/b
 import { IEditorGroupsService } from '../../../services/editor/common/editorGroupsService.js';
 
 /**
- * Moves the active editor into a "dedicated window": an auxiliary window with
- * a native OS title bar and compact chrome (no editor tabs, no status bar),
- * sized to match the window the editor moves out of.
- *
- * The command is intent-level on purpose: what a dedicated window looks like
- * is policy owned here, so callers never learn about auxiliary window options.
- * It is not exposed in the command palette; callers invoke it by id after
- * making the editor to move the active one -- the same contract as
- * `workbench.action.moveEditorToNewWindow`.
+ * The single definition of the "dedicated window" look: native OS title bar,
+ * compact chrome, sized to (and opening over) the window the editor leaves.
+ * `extraTraits` may add traits but never replace the shape -- the dedicated
+ * look wins.
+ */
+export function dedicatedWindowOptions(sourceWindow: Window, extraTraits?: IAuxiliaryWindowOpenOptions): IAuxiliaryWindowOpenOptions {
+	return {
+		...extraTraits,
+		compact: true,
+		nativeTitlebar: true,
+		bounds: { width: sourceWindow.outerWidth, height: sourceWindow.outerHeight }
+	};
+}
+
+/**
+ * Moves the active editor into a dedicated window. Not in the palette;
+ * callers invoke it by id after making the editor to move the active one,
+ * the same contract as `workbench.action.moveEditorToNewWindow`.
  */
 CommandsRegistry.registerCommand('positron.editor.moveIntoDedicatedWindow', async (accessor: ServicesAccessor) => {
 	const editorGroupsService = accessor.get(IEditorGroupsService);
@@ -30,16 +39,8 @@ CommandsRegistry.registerCommand('positron.editor.moveIntoDedicatedWindow', asyn
 		return; // nothing to move; do not open an empty window
 	}
 
-	// Size the dedicated window like the source window, which is still the
-	// active window at this point; it intentionally opens exactly over it.
-	const sourceWindow = getActiveWindow();
-	const options: IAuxiliaryWindowOpenOptions = {
-		compact: true,
-		nativeTitlebar: true,
-		bounds: { width: sourceWindow.outerWidth, height: sourceWindow.outerHeight }
-	};
-
-	const auxiliaryEditorPart = await editorGroupsService.createAuxiliaryEditorPart(options);
+	// The source window is still the active window at this point.
+	const auxiliaryEditorPart = await editorGroupsService.createAuxiliaryEditorPart(dedicatedWindowOptions(getActiveWindow()));
 	sourceGroup.moveEditors(prepareMoveCopyEditors(sourceGroup, [editor]), auxiliaryEditorPart.activeGroup);
 	auxiliaryEditorPart.activeGroup.focus();
 });

--- a/src/vs/workbench/services/auxiliaryWindow/browser/auxiliaryWindowService.ts
+++ b/src/vs/workbench/services/auxiliaryWindow/browser/auxiliaryWindowService.ts
@@ -260,7 +260,6 @@ export class AuxiliaryWindow extends BaseWindow implements IAuxiliaryWindow {
 			},
 			zoomLevel: getZoomLevel(this.window),
 			// --- Start Positron ---
-			// compact: this.compact
 			compact: this.compact,
 			// `EditorParts.restoreState()` feeds this object straight back in as
 			// open options, so anything omitted here is a trait the restored

--- a/src/vs/workbench/services/auxiliaryWindow/browser/auxiliaryWindowService.ts
+++ b/src/vs/workbench/services/auxiliaryWindow/browser/auxiliaryWindowService.ts
@@ -57,6 +57,16 @@ export interface IAuxiliaryWindowOpenOptions {
 	readonly notResizable?: boolean;
 	readonly noBackgroundThrottling?: boolean;
 	readonly backgroundColor?: string;
+
+	// --- Start Positron ---
+	/**
+	 * Makes compact mode a property of the window rather than a toggle: the
+	 * automatic exits from compact mode and the user-facing compact actions
+	 * are ignored. For windows that show exactly one thing with no workbench
+	 * chrome, where losing compact mode would break the surface.
+	 */
+	readonly lockCompact?: boolean;
+	// --- End Positron ---
 }
 
 export interface IAuxiliaryWindowService {
@@ -115,12 +125,21 @@ export class AuxiliaryWindow extends BaseWindow implements IAuxiliaryWindow {
 
 	readonly whenStylesHaveLoaded: Promise<void>;
 
-	private compact = false;
+	// --- Start Positron ---
+	// private compact = false;
+	private compact: boolean;
+	// Some opening traits cannot be read back from the live window. Keep them
+	// separate from `updateOptions()`, which only changes live compact state.
+	private readonly openOptions: IAuxiliaryWindowOpenOptions;
+	// --- End Positron ---
 
 	constructor(
 		readonly window: CodeWindow,
 		readonly container: HTMLElement,
 		stylesHaveLoaded: Barrier,
+		// --- Start Positron ---
+		openOptions: IAuxiliaryWindowOpenOptions | undefined,
+		// --- End Positron ---
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IHostService hostService: IHostService,
 		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService,
@@ -129,14 +148,26 @@ export class AuxiliaryWindow extends BaseWindow implements IAuxiliaryWindow {
 	) {
 		super(window, undefined, hostService, environmentService, contextMenuService, layoutService);
 
+		// --- Start Positron ---
+		this.openOptions = { ...openOptions };
+		this.compact = openOptions?.compact === true;
+		// --- End Positron ---
+
 		this.whenStylesHaveLoaded = stylesHaveLoaded.wait().then(() => undefined);
 
 		this.registerListeners();
 	}
 
-	updateOptions(options: { compact: boolean }): void {
-		this.compact = options.compact;
+	// --- Start Positron ---
+	// updateOptions(options: { compact: boolean }): void {
+	// 	this.compact = options.compact;
+	// }
+	updateOptions(options: { compact: boolean } | undefined): void {
+		if (options) {
+			this.compact = options.compact;
+		}
 	}
+	// --- End Positron ---
 
 	private registerListeners(): void {
 		this._register(addDisposableListener(this.window, EventType.BEFORE_UNLOAD, (e: BeforeUnloadEvent) => this.handleBeforeUnload(e)));
@@ -228,7 +259,16 @@ export class AuxiliaryWindow extends BaseWindow implements IAuxiliaryWindow {
 				height: this.window.outerHeight
 			},
 			zoomLevel: getZoomLevel(this.window),
-			compact: this.compact
+			// --- Start Positron ---
+			// compact: this.compact
+			compact: this.compact,
+			// `EditorParts.restoreState()` feeds this object straight back in as
+			// open options, so anything omitted here is a trait the restored
+			// window loses.
+			nativeTitlebar: this.openOptions.nativeTitlebar,
+			disableFullscreen: this.openOptions.disableFullscreen,
+			lockCompact: this.openOptions.lockCompact
+			// --- End Positron ---
 		};
 	}
 
@@ -281,8 +321,12 @@ export class BrowserAuxiliaryWindowService extends Disposable implements IAuxili
 		const containerDisposables = new DisposableStore();
 		const { container, stylesLoaded } = this.createContainer(targetWindow, containerDisposables, options);
 
-		const auxiliaryWindow = this.createAuxiliaryWindow(targetWindow, container, stylesLoaded);
-		auxiliaryWindow.updateOptions({ compact: options?.compact ?? false });
+		// --- Start Positron ---
+		// const auxiliaryWindow = this.createAuxiliaryWindow(targetWindow, container, stylesLoaded);
+		const auxiliaryWindow = this.createAuxiliaryWindow(targetWindow, container, stylesLoaded, options);
+		// auxiliaryWindow.updateOptions({ compact: options?.compact ?? false });
+		// Opening traits are constructor state. Live updates remain compact-only.
+		// --- End Positron ---
 
 		const registryDisposables = new DisposableStore();
 		this.windows.set(targetWindow.vscodeWindowId, auxiliaryWindow);
@@ -316,9 +360,13 @@ export class BrowserAuxiliaryWindowService extends Disposable implements IAuxili
 		return auxiliaryWindow;
 	}
 
-	protected createAuxiliaryWindow(targetWindow: CodeWindow, container: HTMLElement, stylesLoaded: Barrier): AuxiliaryWindow {
-		return new AuxiliaryWindow(targetWindow, container, stylesLoaded, this.configurationService, this.hostService, this.environmentService, this.contextMenuService, this.layoutService);
+	// --- Start Positron ---
+	// protected createAuxiliaryWindow(targetWindow: CodeWindow, container: HTMLElement, stylesLoaded: Barrier): AuxiliaryWindow {
+	// 	return new AuxiliaryWindow(targetWindow, container, stylesLoaded, this.configurationService, this.hostService, this.environmentService, this.contextMenuService, this.layoutService);
+	protected createAuxiliaryWindow(targetWindow: CodeWindow, container: HTMLElement, stylesLoaded: Barrier, options?: IAuxiliaryWindowOpenOptions): AuxiliaryWindow {
+		return new AuxiliaryWindow(targetWindow, container, stylesLoaded, options, this.configurationService, this.hostService, this.environmentService, this.contextMenuService, this.layoutService);
 	}
+	// --- End Positron ---
 
 	private async openWindow(options?: IAuxiliaryWindowOpenOptions): Promise<Window | undefined> {
 		const activeWindow = getActiveWindow();

--- a/src/vs/workbench/services/auxiliaryWindow/electron-browser/auxiliaryWindowService.ts
+++ b/src/vs/workbench/services/auxiliaryWindow/electron-browser/auxiliaryWindowService.ts
@@ -42,6 +42,9 @@ export class NativeAuxiliaryWindow extends AuxiliaryWindow {
 		window: CodeWindow,
 		container: HTMLElement,
 		stylesHaveLoaded: Barrier,
+		// --- Start Positron ---
+		openOptions: IAuxiliaryWindowOpenOptions | undefined,
+		// --- End Positron ---
 		@IConfigurationService configurationService: IConfigurationService,
 		@INativeHostService private readonly nativeHostService: INativeHostService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
@@ -51,7 +54,10 @@ export class NativeAuxiliaryWindow extends AuxiliaryWindow {
 		@IContextMenuService contextMenuService: IContextMenuService,
 		@IWorkbenchLayoutService layoutService: IWorkbenchLayoutService
 	) {
-		super(window, container, stylesHaveLoaded, configurationService, hostService, environmentService, contextMenuService, layoutService);
+		// --- Start Positron ---
+		// super(window, container, stylesHaveLoaded, configurationService, hostService, environmentService, contextMenuService, layoutService);
+		super(window, container, stylesHaveLoaded, openOptions, configurationService, hostService, environmentService, contextMenuService, layoutService);
+		// --- End Positron ---
 
 		if (!isMacintosh) {
 			// For now, limit this to platforms that have clear maximised
@@ -177,9 +183,13 @@ export class NativeAuxiliaryWindowService extends BrowserAuxiliaryWindowService 
 		return super.createContainer(auxiliaryWindow, disposables);
 	}
 
-	protected override createAuxiliaryWindow(targetWindow: CodeWindow, container: HTMLElement, stylesHaveLoaded: Barrier): AuxiliaryWindow {
-		return new NativeAuxiliaryWindow(targetWindow, container, stylesHaveLoaded, this.configurationService, this.nativeHostService, this.instantiationService, this.hostService, this.environmentService, this.dialogService, this.contextMenuService, this.layoutService);
+	// --- Start Positron ---
+	// protected override createAuxiliaryWindow(targetWindow: CodeWindow, container: HTMLElement, stylesHaveLoaded: Barrier): AuxiliaryWindow {
+	// 	return new NativeAuxiliaryWindow(targetWindow, container, stylesHaveLoaded, this.configurationService, this.nativeHostService, this.instantiationService, this.hostService, this.environmentService, this.dialogService, this.contextMenuService, this.layoutService);
+	protected override createAuxiliaryWindow(targetWindow: CodeWindow, container: HTMLElement, stylesHaveLoaded: Barrier, options?: IAuxiliaryWindowOpenOptions): AuxiliaryWindow {
+		return new NativeAuxiliaryWindow(targetWindow, container, stylesHaveLoaded, options, this.configurationService, this.nativeHostService, this.instantiationService, this.hostService, this.environmentService, this.dialogService, this.contextMenuService, this.layoutService);
 	}
+	// --- End Positron ---
 }
 
 registerSingleton(IAuxiliaryWindowService, NativeAuxiliaryWindowService, InstantiationType.Delayed);

--- a/src/vs/workbench/services/auxiliaryWindow/test/browser/auxiliaryWindowService.vitest.ts
+++ b/src/vs/workbench/services/auxiliaryWindow/test/browser/auxiliaryWindowService.vitest.ts
@@ -1,0 +1,112 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { mainWindow } from '../../../../../base/browser/window.js';
+import { Barrier } from '../../../../../base/common/async.js';
+import { Event } from '../../../../../base/common/event.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IContextMenuService } from '../../../../../platform/contextview/browser/contextView.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { ensureNoLeakedDisposables } from '../../../../../test/vitest/vitestUtils.js';
+import { IWorkbenchEnvironmentService } from '../../../environment/common/environmentService.js';
+import { IHostService } from '../../../host/browser/host.js';
+import { IWorkbenchLayoutService } from '../../../layout/browser/layoutService.js';
+import { AuxiliaryWindow, IAuxiliaryWindowOpenOptions } from '../../browser/auxiliaryWindowService.js';
+
+class TestAuxiliaryWindow extends AuxiliaryWindow {
+
+	protected override enableWindowFocusOnElementFocus(): void { }
+	protected override enableMultiWindowAwareTimeout(): void { }
+}
+
+describe('AuxiliaryWindow', () => {
+	const disposables = ensureNoLeakedDisposables();
+
+	function createAuxiliaryWindow(openOptions?: IAuxiliaryWindowOpenOptions): AuxiliaryWindow {
+		const stylesHaveLoaded = new Barrier();
+		stylesHaveLoaded.open();
+
+		return disposables.add(new TestAuxiliaryWindow(
+			mainWindow,
+			mainWindow.document.createElement('div'),
+			stylesHaveLoaded,
+			openOptions,
+			stubInterface<IConfigurationService>(),
+			stubInterface<IHostService>({ onDidChangeFullScreen: Event.None }),
+			stubInterface<IWorkbenchEnvironmentService>(),
+			stubInterface<IContextMenuService>({
+				onDidShowContextMenu: Event.None,
+				onDidHideContextMenu: Event.None,
+			}),
+			stubInterface<IWorkbenchLayoutService>({ activeContainer: mainWindow.document.body }),
+		));
+	}
+
+	// Opening traits are immutable window identity; live compact changes must not
+	// replace them or every later restore comes back with different chrome.
+	it('keeps the traits it was opened with when compact state changes', () => {
+		const auxiliaryWindow = createAuxiliaryWindow({
+			compact: true,
+			lockCompact: true,
+			nativeTitlebar: true,
+			disableFullscreen: true,
+		});
+		auxiliaryWindow.updateOptions({ compact: false });
+
+		expect(auxiliaryWindow.createState()).toMatchObject({
+			compact: false,
+			lockCompact: true,
+			nativeTitlebar: true,
+			disableFullscreen: true,
+		});
+	});
+
+	// `EditorParts.restoreState()` feeds a persisted state object straight back
+	// in as open options, so a trait only survives a restore if it makes the
+	// full round trip out of one window, through JSON storage, and into the
+	// next.
+	it('round-trips its traits through serialized state into a restored window', () => {
+		const original = createAuxiliaryWindow({
+			compact: true,
+			lockCompact: true,
+			nativeTitlebar: true,
+			disableFullscreen: true,
+		});
+
+		const restored = createAuxiliaryWindow(JSON.parse(JSON.stringify(original.createState())));
+
+		expect(restored.createState()).toMatchObject({
+			compact: true,
+			lockCompact: true,
+			nativeTitlebar: true,
+			disableFullscreen: true,
+		});
+	});
+
+	// State persisted before the traits existed carries only `compact`; it must
+	// restore exactly as it always has, with no trait invented for it.
+	it('restores state persisted before chrome traits existed', () => {
+		const restored = createAuxiliaryWindow(JSON.parse('{ "compact": true }'));
+
+		const state = restored.createState();
+		expect(state.compact).toBe(true);
+		expect(state.lockCompact).toBeUndefined();
+		expect(state.nativeTitlebar).toBeUndefined();
+		expect(state.disableFullscreen).toBeUndefined();
+	});
+
+	it('is unchanged by an updateOptions call with no options', () => {
+		const auxiliaryWindow = createAuxiliaryWindow({ compact: true, nativeTitlebar: true });
+
+		auxiliaryWindow.updateOptions(undefined);
+
+		expect(auxiliaryWindow.createState()).toMatchObject({
+			compact: true,
+			nativeTitlebar: true,
+		});
+	});
+});

--- a/src/vs/workbench/services/editor/common/editorGroupsService.ts
+++ b/src/vs/workbench/services/editor/common/editorGroupsService.ts
@@ -667,7 +667,14 @@ export interface IEditorGroupsService extends IEditorGroupsContainer {
 	 * Opens a new window with a full editor part instantiated
 	 * in there at the optional position and size on screen.
 	 */
-	createAuxiliaryEditorPart(options?: { bounds?: Partial<IRectangle>; compact?: boolean; alwaysOnTop?: boolean }): Promise<IAuxiliaryEditorPart>;
+	// --- Start Positron ---
+	// createAuxiliaryEditorPart(options?: { bounds?: Partial<IRectangle>; compact?: boolean; alwaysOnTop?: boolean }): Promise<IAuxiliaryEditorPart>;
+	// `nativeTitlebar` and `lockCompact` are declared here so Positron's
+	// chromeless dedicated windows can ask for them through this interface. The
+	// shape stays inlined rather than importing `IAuxiliaryWindowOpenOptions`
+	// because that type lives in a `browser` layer this `common` file cannot see.
+	createAuxiliaryEditorPart(options?: { bounds?: Partial<IRectangle>; compact?: boolean; alwaysOnTop?: boolean; nativeTitlebar?: boolean; lockCompact?: boolean }): Promise<IAuxiliaryEditorPart>;
+	// --- End Positron ---
 
 	/**
 	 * Creates a modal editor part that shows in a modal overlay


### PR DESCRIPTION
Part 1 of progress towards #15309.

Auxiliary windows currently persist live compact state but lose construction-time chrome traits during restoration which means they open up in a super confusing effectively useless format. This PR:

- Persists native title bar, fullscreen, and compact-lock traits.
- Adds `lockCompact` for surfaces that must remain chromeless.
- Centralizes the dedicated-window appearance in `dedicatedWindowOptions()`.

### Reviewer Q&A

**Why change the generic auxiliary-window service?**  
Restoration is owned there. Fixing it at the consumer would duplicate window-state machinery.

**Why separate opening traits from live compact state?**  
Compact mode can change while open. Construction traits cannot be reliably read from the live window and must retain their opening values.

**Does `lockCompact` lock the whole window?**  
No. It only prevents transitions out of compact mode. Moving, resizing, and closing remain unchanged.

**Is old persisted state compatible?**  
Yes. Missing traits remain undefined and preserve previous behavior.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

- `npm run build-check`
- Auxiliary-window Vitest suite: 4 tests passed
- No TypeScript errors in touched files
