### PR TITLE
Add generic standalone mode coordination

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -153,6 +153,9 @@ import { EphemeralStateService } from '../../platform/ephemeralState/common/ephe
 import { EPHEMERAL_STATE_CHANNEL_NAME, EphemeralStateChannel } from '../../platform/ephemeralState/common/ephemeralStateIpc.js';
 import { PositronMemoryUsageMainService } from '../../platform/positronMemoryUsage/electron-main/positronMemoryUsageMainService.js';
 import { POSITRON_MEMORY_INFO_CHANNEL_NAME, PositronMemoryInfoChannel } from '../../platform/positronMemoryUsage/common/positronMemoryUsageIpc.js';
+import { IPositronStandaloneModeMainService, POSITRON_STANDALONE_MODE_CHANNEL_NAME } from '../../platform/positronStandaloneMode/common/positronStandaloneMode.js';
+import { PositronStandaloneModeChannel } from '../../platform/positronStandaloneMode/common/positronStandaloneModeIpc.js';
+import { PositronStandaloneModeMainService } from '../../platform/positronStandaloneMode/electron-main/positronStandaloneModeMainService.js';
 import { recolorDevIcon } from '../../platform/windows/electron-main/devIconColorizer.js';
 // --- End Positron ---
 
@@ -222,6 +225,9 @@ export class CodeApplication extends Disposable {
 	private windowsMainService: IWindowsMainService | undefined;
 	private auxiliaryWindowsMainService: IAuxiliaryWindowsMainService | undefined;
 	private nativeHostMainService: INativeHostMainService | undefined;
+	// --- Start Positron ---
+	private positronStandaloneModeMainService: IPositronStandaloneModeMainService | undefined;
+	// --- End Positron ---
 
 	constructor(
 		private readonly mainProcessNodeIpcServer: NodeIPCServer,
@@ -621,16 +627,40 @@ export class CodeApplication extends Disposable {
 
 			// Handle paths delayed in case more are coming!
 			runningTimeout = setTimeout(async () => {
-				await this.windowsMainService?.open({
-					context: OpenContext.DOCK /* can also be opening from finder while app is running */,
-					cli: this.environmentMainService.args,
-					urisToOpen: macOpenFileURIs,
-					gotoLineMode: false,
-					preferNewWindow: true /* dropping on the dock or opening from finder prefers to open in a new window */
-				});
-
+				// --- Start Positron ---
+				// A Finder or Dock open must not land behind an engaged
+				// standalone mode window, so it is routed by the standalone
+				// mode policy like a second-instance open (LaunchMainService).
+				const urisToOpen = macOpenFileURIs;
 				macOpenFileURIs = [];
 				runningTimeout = undefined;
+
+				const openFinderFiles = () => {
+					void this.windowsMainService?.open({
+						// --- End Positron ---
+						context: OpenContext.DOCK /* can also be opening from finder while app is running */,
+						cli: this.environmentMainService.args,
+						// --- Start Positron ---
+						// urisToOpen: macOpenFileURIs,
+						urisToOpen,
+						// --- End Positron ---
+						gotoLineMode: false,
+						preferNewWindow: true /* dropping on the dock or opening from finder prefers to open in a new window */
+					});
+					// --- Start Positron ---
+				};
+				if (this.positronStandaloneModeMainService) {
+					await this.positronStandaloneModeMainService.handleExternalOpen(
+						openFinderFiles,
+						(engagedWindowId, exitCommandId) => this.windowsMainService?.getWindowById(engagedWindowId)?.sendWhenReady('vscode:runAction', CancellationToken.None, {
+							id: exitCommandId,
+							from: 'menu',
+						})
+					);
+				} else {
+					openFinderFiles();
+				}
+				// --- End Positron ---
 			}, 100);
 		});
 
@@ -1236,6 +1266,12 @@ export class CodeApplication extends Disposable {
 		// Menubar
 		services.set(IMenubarMainService, new SyncDescriptor(MenubarMainService));
 
+		// --- Start Positron ---
+		// Standalone mode: which window, if any, presents a single view as the
+		// whole product
+		services.set(IPositronStandaloneModeMainService, new SyncDescriptor(PositronStandaloneModeMainService));
+		// --- End Positron ---
+
 		// Extension Host Starter
 		services.set(IExtensionHostStarter, new SyncDescriptor(ExtensionHostStarter));
 
@@ -1487,6 +1523,11 @@ export class CodeApplication extends Disposable {
 		const memoryUsageMainService = new PositronMemoryUsageMainService();
 		const memoryInfoChannel = new PositronMemoryInfoChannel(memoryUsageMainService);
 		mainProcessElectronServer.registerChannel(POSITRON_MEMORY_INFO_CHANNEL_NAME, memoryInfoChannel);
+
+		// Standalone Mode
+		this.positronStandaloneModeMainService = accessor.get(IPositronStandaloneModeMainService);
+		const standaloneModeChannel = new PositronStandaloneModeChannel(this.positronStandaloneModeMainService);
+		mainProcessElectronServer.registerChannel(POSITRON_STANDALONE_MODE_CHANNEL_NAME, standaloneModeChannel);
 		// --- End Positron ---
 
 		// Utility Process Worker

--- a/src/vs/platform/launch/electron-main/launchMainService.ts
+++ b/src/vs/platform/launch/electron-main/launchMainService.ts
@@ -5,6 +5,11 @@
 
 import { app } from 'electron';
 import { coalesce } from '../../../base/common/arrays.js';
+// --- Start Positron ---
+import { CancellationToken } from '../../../base/common/cancellation.js';
+import { IAuxiliaryWindowsMainService } from '../../auxiliaryWindow/electron-main/auxiliaryWindows.js';
+import { IPositronStandaloneModeMainService } from '../../positronStandaloneMode/common/positronStandaloneMode.js';
+// --- End Positron ---
 import { IProcessEnvironment, isMacintosh } from '../../../base/common/platform.js';
 import { URI } from '../../../base/common/uri.js';
 import { whenDeleted } from '../../../base/node/pfs.js';
@@ -45,6 +50,10 @@ export class LaunchMainService implements ILaunchMainService {
 		@IWindowsMainService private readonly windowsMainService: IWindowsMainService,
 		@IURLService private readonly urlService: IURLService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
+		// --- Start Positron ---
+		@IAuxiliaryWindowsMainService private readonly auxiliaryWindowsMainService: IAuxiliaryWindowsMainService,
+		@IPositronStandaloneModeMainService private readonly positronStandaloneModeMainService: IPositronStandaloneModeMainService,
+		// --- End Positron ---
 	) { }
 
 	async start(args: NativeParsedArgs, userEnv: IProcessEnvironment): Promise<void> {
@@ -150,6 +159,21 @@ export class LaunchMainService implements ILaunchMainService {
 
 		// Start without file/folder arguments
 		else if (!args._.length && !args['folder-uri'] && !args['file-uri']) {
+			// --- Start Positron ---
+			// A bare relaunch while standalone mode is engaged means "bring
+			// Positron forward", and the product surface is the engaged
+			// window; falling through would reveal the hidden IDE.
+			if (this.positronStandaloneModeMainService.isEngaged) {
+				this.logService.info('[standalone mode] Focusing the engaged window for an argumentless launch');
+				const lastActiveAuxiliaryWindow = this.auxiliaryWindowsMainService.getLastActiveWindow();
+				if (lastActiveAuxiliaryWindow && !this.positronStandaloneModeMainService.isEngagedElsewhere(lastActiveAuxiliaryWindow.parentId)) {
+					lastActiveAuxiliaryWindow.focus();
+				} else {
+					this.windowsMainService.getWindows().find(window => !this.positronStandaloneModeMainService.isEngagedElsewhere(window.id))?.focus();
+				}
+				return;
+			}
+			// --- End Positron ---
 			let openNewWindow = false;
 
 			// Force new window
@@ -205,7 +229,12 @@ export class LaunchMainService implements ILaunchMainService {
 
 		// Start with file/folder arguments
 		else {
-			usedWindows = await this.windowsMainService.open({
+			// --- Start Positron ---
+			// An open landing behind an engaged standalone mode window would
+			// reveal the hidden IDE, so it is routed through
+			// `handleExternalOpen`.
+			const openWithArguments = () => this.windowsMainService.open({
+				// --- End Positron ---
 				...baseConfig,
 				forceNewWindow: args['new-window'],
 				preferNewWindow: !args['reuse-window'] && !args.wait,
@@ -217,6 +246,19 @@ export class LaunchMainService implements ILaunchMainService {
 				noRecentEntry: !!args['skip-add-to-recently-opened'],
 				gotoLineMode: args.goto
 			});
+			// --- Start Positron ---
+			let opening: Promise<ICodeWindow[]> | undefined;
+			// `opening` is assigned before `handleExternalOpen` resolves,
+			// even when the open first waits out an engaged window's exit.
+			await this.positronStandaloneModeMainService.handleExternalOpen(
+				() => { opening = openWithArguments(); },
+				(engagedWindowId, exitCommandId) => this.windowsMainService.getWindowById(engagedWindowId)?.sendWhenReady('vscode:runAction', CancellationToken.None, {
+					id: exitCommandId,
+					from: 'menu',
+				})
+			);
+			usedWindows = opening ? await opening : [];
+			// --- End Positron ---
 		}
 
 		// If the other instance is waiting to be killed, we hook up a window listener if one window

--- a/src/vs/platform/menubar/electron-main/menubar.ts
+++ b/src/vs/platform/menubar/electron-main/menubar.ts
@@ -26,6 +26,9 @@ import { INativeRunActionInWindowRequest, INativeRunKeybindingInWindowRequest, I
 import { IWindowsCountChangedEvent, IWindowsMainService, OpenContext } from '../../windows/electron-main/windows.js';
 import { IWorkspacesHistoryMainService } from '../../workspaces/electron-main/workspacesHistoryMainService.js';
 import { Disposable } from '../../../base/common/lifecycle.js';
+// --- Start Positron ---
+import { IPositronStandaloneModeMainService } from '../../positronStandaloneMode/common/positronStandaloneMode.js';
+// --- End Positron ---
 
 const telemetryFrom = 'menu';
 
@@ -78,7 +81,10 @@ export class Menubar extends Disposable {
 		@ILogService private readonly logService: ILogService,
 		@INativeHostMainService private readonly nativeHostMainService: INativeHostMainService,
 		@IProductService private readonly productService: IProductService,
-		@IAuxiliaryWindowsMainService private readonly auxiliaryWindowsMainService: IAuxiliaryWindowsMainService
+		@IAuxiliaryWindowsMainService private readonly auxiliaryWindowsMainService: IAuxiliaryWindowsMainService,
+		// --- Start Positron ---
+		@IPositronStandaloneModeMainService private readonly positronStandaloneModeMainService: IPositronStandaloneModeMainService
+		// --- End Positron ---
 	) {
 		super();
 
@@ -184,6 +190,12 @@ export class Menubar extends Disposable {
 		// Rebuild menu when update state changes so update menu items reflect
 		// the current state (e.g. "Restart to Update" instead of "Check for Updates...").
 		this._register(this.updateService.onStateChange(() => this.scheduleUpdateMenu()));
+
+		// --- Start Positron ---
+		// Swap between the full menu and the standalone mode menu as the mode
+		// engages and releases.
+		this._register(this.positronStandaloneModeMainService.onDidChange(() => this.scheduleUpdateMenu()));
+		// --- End Positron ---
 	}
 
 	private get currentEnableMenuBarMnemonics(): boolean {
@@ -268,6 +280,17 @@ export class Menubar extends Disposable {
 			this.oldMenus.push(oldMenu);
 		}
 
+		// --- Start Positron ---
+		// While standalone mode is engaged, the IDE's menus would operate a
+		// window the user is not supposed to see -- and with an auxiliary
+		// window focused the fallback handlers even act from the main process.
+		// Present a minimal menu until the mode releases.
+		if (this.positronStandaloneModeMainService.isEngaged) {
+			this.installStandaloneModeMenu();
+			return;
+		}
+		// --- End Positron ---
+
 		// If we don't have a menu yet, set it to null to avoid the electron menu.
 		// This should only happen on the first launch ever
 		if (Object.keys(this.menubarMenus).length === 0) {
@@ -292,7 +315,20 @@ export class Menubar extends Disposable {
 			this.appMenuInstalled = true;
 
 			const dockMenu = new Menu();
-			dockMenu.append(new MenuItem({ label: this.mnemonicLabel(nls.localize({ key: 'miNewWindow', comment: ['&& denotes a mnemonic'] }, "New &&Window")), click: () => this.windowsMainService.openEmptyWindow({ context: OpenContext.DOCK }) }));
+			// --- Start Positron ---
+			// dockMenu.append(new MenuItem({ label: this.mnemonicLabel(nls.localize({ key: 'miNewWindow', comment: ['&& denotes a mnemonic'] }, "New &&Window")), click: () => this.windowsMainService.openEmptyWindow({ context: OpenContext.DOCK }) }));
+			// The Dock menu installs once and never rebuilds, so it cannot be
+			// swapped while standalone mode is engaged; guard the handler
+			// instead.
+			dockMenu.append(new MenuItem({
+				label: this.mnemonicLabel(nls.localize({ key: 'miNewWindow', comment: ['&& denotes a mnemonic'] }, "New &&Window")), click: () => {
+					if (this.positronStandaloneModeMainService.isEngaged) {
+						return;
+					}
+					this.windowsMainService.openEmptyWindow({ context: OpenContext.DOCK });
+				}
+			}));
+			// --- End Positron ---
 
 			app.dock!.setMenu(dockMenu);
 		}
@@ -404,6 +440,54 @@ export class Menubar extends Disposable {
 			}
 		}
 	}
+
+	// --- Start Positron ---
+	/**
+	 * The application menu while standalone mode is engaged: the application
+	 * menu itself for hiding and quitting, and an Edit menu of native
+	 * text-editing roles so the clipboard keeps its accelerators inside the
+	 * standalone webview. Everything that would open, reveal, or operate the
+	 * IDE is left out; `install()` rebuilds the full menus once the mode
+	 * releases.
+	 */
+	private installStandaloneModeMenu(): void {
+		if (!isMacintosh) {
+			// The window-drawn menubar takes this path too on Windows and
+			// Linux; no native menu means nothing to trim.
+			this.doSetApplicationMenu(null);
+			return;
+		}
+
+		const menubar = new Menu();
+
+		const applicationMenu = new Menu();
+		applicationMenu.append(new MenuItem({ label: nls.localize('mHide', "Hide {0}", this.productService.nameLong), role: 'hide', accelerator: 'Command+H' }));
+		applicationMenu.append(new MenuItem({ label: nls.localize('mHideOthers', "Hide Others"), role: 'hideOthers', accelerator: 'Command+Alt+H' }));
+		applicationMenu.append(new MenuItem({ label: nls.localize('mShowAll', "Show All"), role: 'unhide' }));
+		applicationMenu.append(__separator__());
+		applicationMenu.append(new MenuItem(this.likeAction('workbench.action.quit', {
+			label: nls.localize('miQuit', "Quit {0}", this.productService.nameLong),
+			click: async (_item, _window, event) => {
+				if (await this.confirmBeforeQuit(event)) {
+					this.nativeHostMainService.quit(undefined);
+				}
+			}
+		})));
+		menubar.append(new MenuItem({ label: this.productService.nameShort, submenu: applicationMenu }));
+
+		const editMenu = new Menu();
+		editMenu.append(new MenuItem({ role: 'undo' }));
+		editMenu.append(new MenuItem({ role: 'redo' }));
+		editMenu.append(__separator__());
+		editMenu.append(new MenuItem({ role: 'cut' }));
+		editMenu.append(new MenuItem({ role: 'copy' }));
+		editMenu.append(new MenuItem({ role: 'paste' }));
+		editMenu.append(new MenuItem({ role: 'selectAll' }));
+		menubar.append(new MenuItem({ label: nls.localize('positron.standaloneMode.editMenu', "Edit"), submenu: editMenu }));
+
+		this.doSetApplicationMenu(menubar);
+	}
+	// --- End Positron ---
 
 	private setMacApplicationMenu(macApplicationMenu: Menu): void {
 		const about = this.createMenuItem(nls.localize('mAbout', "About {0}", this.productService.nameLong), 'workbench.action.showAboutDialog');

--- a/src/vs/platform/positronStandaloneMode/common/positronStandaloneMode.ts
+++ b/src/vs/platform/positronStandaloneMode/common/positronStandaloneMode.ts
@@ -1,0 +1,68 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Event } from '../../../base/common/event.js';
+import { createDecorator } from '../../instantiation/common/instantiation.js';
+
+export const POSITRON_STANDALONE_MODE_CHANNEL_NAME = 'positronStandaloneMode';
+
+/**
+ * The main process's record of standalone mode: which window, if any, is
+ * presenting a single view as the whole product surface. The renderer that
+ * enters the mode reports engagement here; the main process reads it to keep
+ * the mode single-instance, trim the native menus, and route external opens.
+ */
+export interface IPositronStandaloneModeState {
+	/**
+	 * Atomically claim the mode for a window. Resolves `true` when the window
+	 * now holds the engagement, including when it already held it, so re-entry
+	 * in the engaged window stays legitimate. Resolves `false`, and changes
+	 * nothing, when another window holds it.
+	 *
+	 * @param exitCommandId the workbench command that leaves the mode in the
+	 * engaging window. Declared at acquire time so the main process can ask
+	 * the mode to stand down (for an externally requested open) without
+	 * knowing which feature engaged it.
+	 */
+	acquire(windowId: number, exitCommandId: string): Promise<boolean>;
+
+	/** Give up the engagement. Only the holder's release changes anything. */
+	release(windowId: number): Promise<void>;
+}
+
+export const IPositronStandaloneModeMainService = createDecorator<IPositronStandaloneModeMainService>('positronStandaloneModeMainService');
+
+export interface IPositronStandaloneModeMainService extends IPositronStandaloneModeState {
+	readonly _serviceBrand: undefined;
+
+	/** Fires when the mode is engaged or released in any window. */
+	readonly onDidChange: Event<void>;
+
+	/** Whether any window currently presents the mode. */
+	readonly isEngaged: boolean;
+
+	/**
+	 * Whether a window other than the given one presents the mode: re-entry
+	 * in the engaged window is legitimate, a second window is a duplicate
+	 * product surface.
+	 */
+	isEngagedElsewhere(windowId: number): boolean;
+
+	/**
+	 * Route an externally requested open. While engaged, `exitMode` is asked
+	 * to run the engagement's declared exit
+	 * command in the engaged window, and `open` waits for the engagement to
+	 * actually release -- bounded by `EXTERNAL_OPEN_EXIT_WAIT` so an
+	 * unresponsive window cannot swallow the user's open.
+	 */
+	handleExternalOpen(open: () => void, exitMode: (engagedWindowId: number, exitCommandId: string) => void): Promise<void>;
+}
+
+/**
+ * How long an external open waits for the engaged window to release before
+ * proceeding anyway: generous next to an ordinary exit, but bounded so a hung
+ * renderer cannot swallow the open.
+ */
+export const EXTERNAL_OPEN_EXIT_WAIT = 10_000;

--- a/src/vs/platform/positronStandaloneMode/common/positronStandaloneModeIpc.ts
+++ b/src/vs/platform/positronStandaloneMode/common/positronStandaloneModeIpc.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../base/common/cancellation.js';
+import { Event } from '../../../base/common/event.js';
+import { IChannel, IServerChannel } from '../../../base/parts/ipc/common/ipc.js';
+import { IPositronStandaloneModeState } from './positronStandaloneMode.js';
+
+/**
+ * Server-side IPC channel over which a window reports standalone mode
+ * engagement to the main process.
+ */
+export class PositronStandaloneModeChannel implements IServerChannel {
+
+	constructor(private readonly service: IPositronStandaloneModeState) { }
+
+	async call<T>(_ctx: unknown, command: string, args?: unknown, _cancellationToken?: CancellationToken): Promise<T> {
+		switch (command) {
+			case 'acquire': {
+				const [windowId, exitCommandId] = args as [number, string];
+				return await this.service.acquire(windowId, exitCommandId) as T;
+			}
+			case 'release': {
+				const [windowId] = args as [number];
+				return await this.service.release(windowId) as T;
+			}
+		}
+		throw new Error(`Command not found: ${command}`);
+	}
+
+	listen<T>(_ctx: unknown, _event: string, _arg?: unknown): Event<T> {
+		throw new Error('Method not implemented.');
+	}
+}
+
+/**
+ * Client-side channel a window uses to claim and release standalone mode.
+ */
+export class PositronStandaloneModeChannelClient implements IPositronStandaloneModeState {
+
+	constructor(private readonly channel: IChannel) { }
+
+	acquire(windowId: number, exitCommandId: string): Promise<boolean> {
+		return this.channel.call('acquire', [windowId, exitCommandId]);
+	}
+
+	release(windowId: number): Promise<void> {
+		return this.channel.call('release', [windowId]);
+	}
+}

--- a/src/vs/platform/positronStandaloneMode/electron-main/positronStandaloneModeMainService.ts
+++ b/src/vs/platform/positronStandaloneMode/electron-main/positronStandaloneModeMainService.ts
@@ -1,0 +1,134 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { app, BrowserWindow } from 'electron';
+import { Emitter, Event } from '../../../base/common/event.js';
+import { Disposable } from '../../../base/common/lifecycle.js';
+import { ILogService } from '../../log/common/log.js';
+import { EXTERNAL_OPEN_EXIT_WAIT, IPositronStandaloneModeMainService } from '../common/positronStandaloneMode.js';
+
+export class PositronStandaloneModeMainService extends Disposable implements IPositronStandaloneModeMainService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _onDidChange = this._register(new Emitter<void>());
+	readonly onDidChange: Event<void> = this._onDidChange.event;
+
+	/**
+	 * The window presenting standalone mode and the command that exits the
+	 * mode there, when there is one.
+	 */
+	private engagement: { windowId: number; exitCommandId: string } | undefined = undefined;
+
+	private get engagedWindowId(): number | undefined {
+		return this.engagement?.windowId;
+	}
+
+	constructor(
+		@ILogService private readonly logService: ILogService
+	) {
+		super();
+
+		// A window that goes away without releasing its claim must not leave
+		// the mode engaged forever. Reload and a dead renderer keep the
+		// BrowserWindow while discarding the renderer that held the claim, so
+		// all three paths release; a reloaded window re-enters through its
+		// restored intent. Watched per window because the bundled electron
+		// typings expose no application-level closed event.
+		const onWindowCreated = (_event: Electron.Event, window: BrowserWindow) => {
+			const windowId = window.id;
+			const releaseIfHeld = () => {
+				if (windowId === this.engagedWindowId) {
+					this.doRelease(windowId);
+				}
+			};
+			window.on('closed', releaseIfHeld);
+			window.webContents.on('did-navigate', releaseIfHeld);
+			window.webContents.on('render-process-gone', releaseIfHeld);
+		};
+		app.on('browser-window-created', onWindowCreated);
+		this._register({ dispose: () => app.removeListener('browser-window-created', onWindowCreated) });
+	}
+
+	get isEngaged(): boolean {
+		return this.engagedWindowId !== undefined;
+	}
+
+	isEngagedElsewhere(windowId: number): boolean {
+		return this.engagedWindowId !== undefined && this.engagedWindowId !== windowId;
+	}
+
+	async acquire(windowId: number, exitCommandId: string): Promise<boolean> {
+		if (this.engagedWindowId !== undefined && this.engagedWindowId !== windowId) {
+			this.logService.info(`[standalone mode] Window ${windowId} asked to engage while window ${this.engagedWindowId} holds the mode`);
+			return false;
+		}
+		if (this.engagedWindowId !== windowId) {
+			this.engagement = { windowId, exitCommandId };
+			this.logService.trace(`[standalone mode] Engaged in window ${windowId}`);
+			this._onDidChange.fire();
+		} else if (this.engagement?.exitCommandId !== exitCommandId) {
+			// A successful reacquire redeclares the command used by future opens.
+			this.engagement = { windowId, exitCommandId };
+		}
+		return true;
+	}
+
+	async release(windowId: number): Promise<void> {
+		this.doRelease(windowId);
+	}
+
+	private doRelease(windowId: number): void {
+		if (this.engagedWindowId !== windowId) {
+			return;
+		}
+		this.engagement = undefined;
+		this.logService.trace('[standalone mode] Released');
+		this._onDidChange.fire();
+	}
+
+	async handleExternalOpen(open: () => void, exitMode: (engagedWindowId: number, exitCommandId: string) => void): Promise<void> {
+		const engagement = this.engagement;
+		if (!engagement) {
+			open();
+			return;
+		}
+
+		this.logService.info('[standalone mode] Leaving the mode for an externally requested open');
+		exitMode(engagement.windowId, engagement.exitCommandId);
+
+		// Opening into a reused window can reload the very renderer still
+		// running the exit, so wait for the claim to drop, but never indefinitely.
+		if (!await this.waitForRelease(EXTERNAL_OPEN_EXIT_WAIT)) {
+			this.logService.warn(`[standalone mode] Not released within ${EXTERNAL_OPEN_EXIT_WAIT}ms; opening anyway`);
+		}
+		open();
+	}
+
+	/**
+	 * Resolves `true` once no window holds the claim, `false` after
+	 * `timeoutMs`. Hand-rolled so the listener is dropped on the timeout path
+	 * too; a listener per timed-out open would accumulate.
+	 */
+	private waitForRelease(timeoutMs: number): Promise<boolean> {
+		if (!this.isEngaged) {
+			return Promise.resolve(true);
+		}
+		return new Promise<boolean>(resolve => {
+			const listener = this.onDidChange(() => {
+				if (!this.isEngaged) {
+					clearTimeout(timer);
+					listener.dispose();
+					resolve(true);
+				}
+			});
+			const timer = setTimeout(() => {
+				listener.dispose();
+				resolve(false);
+			}, timeoutMs);
+		});
+	}
+
+}

--- a/src/vs/platform/positronStandaloneMode/test/electron-main/positronStandaloneModeMainService.vitest.ts
+++ b/src/vs/platform/positronStandaloneMode/test/electron-main/positronStandaloneModeMainService.vitest.ts
@@ -1,0 +1,172 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { ensureNoLeakedDisposables } from '../../../../test/vitest/vitestUtils.js';
+import { NullLogService } from '../../../log/common/log.js';
+import { EXTERNAL_OPEN_EXIT_WAIT } from '../../common/positronStandaloneMode.js';
+import { PositronStandaloneModeMainService } from '../../electron-main/positronStandaloneModeMainService.js';
+
+// The service watches windows through electron's app; the tests drive those
+// watchers by invoking the captured `browser-window-created` handler with a
+// hand-made window, since electron's real objects cannot exist outside the
+// main process.
+const { electronApp } = vi.hoisted(() => ({
+	electronApp: {
+		listeners: new Map<string, (...args: unknown[]) => void>(),
+		on(event: string, listener: (...args: unknown[]) => void) { this.listeners.set(event, listener); },
+		removeListener(event: string) { this.listeners.delete(event); },
+	}
+}));
+vi.mock('electron', () => ({ app: electronApp, BrowserWindow: class { } }));
+
+/** A window as far as the service's watchers are concerned. */
+function createWindow(id: number) {
+	const windowListeners = new Map<string, () => void>();
+	const webContentsListeners = new Map<string, () => void>();
+	const window = {
+		id,
+		on: (event: string, listener: () => void) => windowListeners.set(event, listener),
+		webContents: { on: (event: string, listener: () => void) => webContentsListeners.set(event, listener) },
+	};
+	electronApp.listeners.get('browser-window-created')?.(undefined, window);
+	return {
+		close: () => windowListeners.get('closed')?.(),
+		reload: () => webContentsListeners.get('did-navigate')?.(),
+		crash: () => webContentsListeners.get('render-process-gone')?.(),
+	};
+}
+
+describe('PositronStandaloneModeMainService', () => {
+	const disposables = ensureNoLeakedDisposables();
+
+	function build() {
+		return disposables.add(new PositronStandaloneModeMainService(new NullLogService()));
+	}
+
+	it('grants the claim to one window and denies the other', async () => {
+		const service = build();
+
+		expect(await service.acquire(1, 'test.exit')).toBe(true);
+		expect(await service.acquire(2, 'test.exit')).toBe(false);
+
+		// The loser's failed claim must not have disturbed the holder.
+		expect(service.isEngaged).toBe(true);
+		expect(service.isEngagedElsewhere(1)).toBe(false);
+		expect(service.isEngagedElsewhere(2)).toBe(true);
+	});
+
+	it('lets the holder reclaim without a release in between', async () => {
+		const service = build();
+
+		expect(await service.acquire(1, 'test.exit')).toBe(true);
+		expect(await service.acquire(1, 'test.exit')).toBe(true);
+	});
+
+	it('uses the exit command declared by the holder\'s latest acquire', async () => {
+		const service = build();
+		await service.acquire(1, 'test.oldExit');
+		await service.acquire(1, 'test.newExit');
+		const exitMode = vi.fn(() => void service.release(1));
+
+		await service.handleExternalOpen(vi.fn(), exitMode);
+
+		expect(exitMode).toHaveBeenCalledWith(1, 'test.newExit');
+	});
+
+	it('ignores a release from a window that does not hold the claim', async () => {
+		const service = build();
+		await service.acquire(1, 'test.exit');
+
+		await service.release(2);
+
+		expect(service.isEngaged).toBe(true);
+	});
+
+	it('frees the claim for the next window once the holder releases', async () => {
+		const service = build();
+		await service.acquire(1, 'test.exit');
+
+		await service.release(1);
+
+		expect(service.isEngaged).toBe(false);
+		expect(await service.acquire(2, 'test.exit')).toBe(true);
+	});
+
+	it('releases the claim when the engaged window closes, reloads, or loses its renderer', async () => {
+		for (const goAway of ['close', 'reload', 'crash'] as const) {
+			const service = build();
+			const window = createWindow(7);
+			await service.acquire(7, 'test.exit');
+
+			window[goAway]();
+
+			expect(service.isEngaged).toBe(false);
+		}
+	});
+
+	it('keeps the claim when an unrelated window goes away', async () => {
+		const service = build();
+		const bystander = createWindow(8);
+		await service.acquire(7, 'test.exit');
+
+		bystander.close();
+
+		expect(service.isEngaged).toBe(true);
+	});
+
+	it('opens an external request only after the engaged window released', async () => {
+		const service = build();
+		await service.acquire(1, 'test.exit');
+
+		const order: string[] = [];
+		const handled = service.handleExternalOpen(
+			() => order.push('open'),
+			// The exit callback is fire-and-forget toward the renderer; the
+			// release arrives later, the way a real exit reports back.
+			() => queueMicrotask(() => {
+				order.push('release');
+				void service.release(1);
+			})
+		);
+
+		await handled;
+
+		expect(order).toEqual(['release', 'open']);
+		expect(service.isEngaged).toBe(false);
+	});
+
+	it('stops waiting on a hung exit and opens anyway', async () => {
+		vi.useFakeTimers();
+		try {
+			const service = build();
+			await service.acquire(1, 'test.exit');
+
+			const open = vi.fn();
+			const exitMode = vi.fn(); // never releases
+			const handled = service.handleExternalOpen(open, exitMode);
+
+			await vi.advanceTimersByTimeAsync(EXTERNAL_OPEN_EXIT_WAIT);
+			await handled;
+
+			expect(exitMode).toHaveBeenCalledWith(1, 'test.exit');
+			expect(open).toHaveBeenCalledTimes(1);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('opens immediately when the mode is not engaged', async () => {
+		const service = build();
+		const open = vi.fn();
+		const exitMode = vi.fn();
+
+		await service.handleExternalOpen(open, exitMode);
+
+		expect(open).toHaveBeenCalledTimes(1);
+		expect(exitMode).not.toHaveBeenCalled();
+	});
+});

--- a/src/vs/platform/window/common/window.ts
+++ b/src/vs/platform/window/common/window.ts
@@ -476,6 +476,15 @@ export interface INativeWindowConfiguration extends IWindowConfiguration, Native
 	adminPoliciesData?: string; // JSON string of enforced settings from POSITRON_ENFORCED_SETTINGS
 	// --- End PWB ---
 
+	// --- Start Positron ---
+	/**
+	 * Whether another window held standalone mode when this window opened.
+	 * The mode is one surface per application instance, so a window opened
+	 * while it is engaged elsewhere must not enter it itself.
+	 */
+	standaloneModeEngagedElsewhere?: boolean;
+	// --- End Positron ---
+
 	isSessionsWindow?: boolean;
 }
 

--- a/src/vs/platform/windows/electron-main/windowImpl.ts
+++ b/src/vs/platform/windows/electron-main/windowImpl.ts
@@ -40,6 +40,9 @@ import { IWindowState, ICodeWindow, ILoadEvent, WindowMode, WindowError, LoadRea
 import { IPolicyService } from '../../policy/common/policy.js';
 import { IUserDataProfile } from '../../userDataProfile/common/userDataProfile.js';
 import { IStateService } from '../../state/node/state.js';
+// --- Start Positron ---
+import { IPositronStandaloneModeMainService } from '../../positronStandaloneMode/common/positronStandaloneMode.js';
+// --- End Positron ---
 import { IUserDataProfilesMainService } from '../../userDataProfile/electron-main/userDataProfile.js';
 import { ILoggerMainService } from '../../log/electron-main/loggerService.js';
 import { IInstantiationService } from '../../instantiation/common/instantiation.js';
@@ -696,7 +699,10 @@ export class CodeWindow extends BaseWindow implements ICodeWindow {
 		@IProtocolMainService protocolMainService: IProtocolMainService,
 		@IWindowsMainService private readonly windowsMainService: IWindowsMainService,
 		@IStateService stateService: IStateService,
-		@IInstantiationService instantiationService: IInstantiationService
+		@IInstantiationService instantiationService: IInstantiationService,
+		// --- Start Positron ---
+		@IPositronStandaloneModeMainService private readonly positronStandaloneModeMainService: IPositronStandaloneModeMainService
+		// --- End Positron ---
 	) {
 		super(configurationService, stateService, environmentMainService, logService);
 
@@ -1348,6 +1354,14 @@ export class CodeWindow extends BaseWindow implements ICodeWindow {
 		delete configuration.filesToDiff;
 		delete configuration.filesToMerge;
 		delete configuration.filesToWait;
+
+		// --- Start Positron ---
+		// The engagement stamp describes open time; a reload happens later, so
+		// refresh it. Otherwise a window opened while the mode was engaged
+		// elsewhere would stay locked out after that engagement ended, for as
+		// long as it only ever reloaded.
+		configuration.standaloneModeEngagedElsewhere = this.positronStandaloneModeMainService.isEngagedElsewhere(this.id);
+		// --- End Positron ---
 
 		// Some configuration things get inherited if the window is being reloaded and we are
 		// in extension development mode. These options are all development related.

--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -52,6 +52,9 @@ import { IThemeMainService } from '../../theme/electron-main/themeMainService.js
 import { IEditorOptions, ITextEditorOptions } from '../../editor/common/editor.js';
 import { IUserDataProfile } from '../../userDataProfile/common/userDataProfile.js';
 import { IPolicyService } from '../../policy/common/policy.js';
+// --- Start Positron ---
+import { IPositronStandaloneModeMainService } from '../../positronStandaloneMode/common/positronStandaloneMode.js';
+// --- End Positron ---
 import { IUserDataProfilesMainService } from '../../userDataProfile/electron-main/userDataProfile.js';
 import { ILoggerMainService } from '../../log/electron-main/loggerService.js';
 import { IAuxiliaryWindowsMainService } from '../../auxiliaryWindow/electron-main/auxiliaryWindows.js';
@@ -235,7 +238,10 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 		@IProtocolMainService private readonly protocolMainService: IProtocolMainService,
 		@IThemeMainService private readonly themeMainService: IThemeMainService,
 		@IAuxiliaryWindowsMainService private readonly auxiliaryWindowsMainService: IAuxiliaryWindowsMainService,
-		@ICSSDevelopmentService private readonly cssDevelopmentService: ICSSDevelopmentService
+		@ICSSDevelopmentService private readonly cssDevelopmentService: ICSSDevelopmentService,
+		// --- Start Positron ---
+		@IPositronStandaloneModeMainService private readonly positronStandaloneModeMainService: IPositronStandaloneModeMainService
+		// --- End Positron ---
 	) {
 		super();
 
@@ -1539,6 +1545,15 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 			isPortable: this.environmentMainService.isPortable,
 
 			windowId: -1,	// Will be filled in by the window once loaded later
+
+			// --- Start Positron ---
+			// For a reused window, "elsewhere" is relative to that window, so
+			// the holder is not locked out of its own re-entry. Refreshed on
+			// reload (CodeWindow#reload).
+			standaloneModeEngagedElsewhere: window
+				? this.positronStandaloneModeMainService.isEngagedElsewhere(window.id)
+				: this.positronStandaloneModeMainService.isEngaged,
+			// --- End Positron ---
 
 			mainPid: process.pid,
 

--- a/src/vs/workbench/services/environment/electron-browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/electron-browser/environmentService.ts
@@ -54,6 +54,14 @@ export interface INativeWorkbenchEnvironmentService extends IBrowserWorkbenchEnv
 
 	// --- Editors to --wait
 	readonly filesToWait?: IPathsToWaitFor;
+
+	// --- Start Positron ---
+	/**
+	 * Whether another window held standalone mode when this window opened;
+	 * when set, this window must not enter the mode at startup.
+	 */
+	readonly standaloneModeEngagedElsewhere: boolean;
+	// --- End Positron ---
 }
 
 export class NativeWorkbenchEnvironmentService extends AbstractNativeEnvironmentService implements INativeWorkbenchEnvironmentService {
@@ -167,6 +175,10 @@ export class NativeWorkbenchEnvironmentService extends AbstractNativeEnvironment
 	// Positron docs URL is not used in desktop mode; returns undefined to use default.
 	get positronDocsUrl(): string | undefined {
 		return undefined;
+	}
+
+	get standaloneModeEngagedElsewhere(): boolean {
+		return this.configuration.standaloneModeEngagedElsewhere === true;
 	}
 	// --- End Positron ---
 


### PR DESCRIPTION
Part 2 of progress towards #15309.

Stacked on #15310.

This PR adds a main-process coordinator for presenting one window as the application surface:

- Atomic application-wide acquisition with a declared exit command.
- Safe routing for second-instance, Finder, and Dock file opens.
- Correct focus behavior for argumentless relaunches.
- Minimal native menus while engaged.
- An `engaged elsewhere` startup stamp for other windows.

_Posit Assistant's upcoming canvas tool will become the first consumer in the next PR._

### Reviewer Q&A

**Why is this a main-process service?**  
Only the main process can coordinate multiple renderers, native menus, and external application opens.

**Does standalone mode replace or destroy the main renderer?**  
No. Presentation belongs to the consumer. The coordinator only records ownership and routes application-level behavior.

**What if the holder does not exit?**  
External opens wait up to 10 seconds, then proceed so a hung renderer cannot swallow the request.

**Why is engagement not persisted?**  
It represents a live renderer. Consumers may persist intent and reacquire after restoration.

**Why are protocol URLs excluded?**  
They include non-window flows such as authentication callbacks. The forced-exit policy applies to file and folder opens.

**Does the menu restriction affect other windows?**  
Yes. Electron's native menu is application-wide, matching the application-wide definition of standalone mode.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

- `npm run build-check`
- Standalone-mode and auxiliary-window Vitest suites: 14 tests passed
- No TypeScript errors in touched files
