### PR TITLE
Don't label Homebrew cask R installs as Homebrew

### DIFF
--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -581,6 +581,49 @@ function isRRuntimeCacheable(rInst: RInstallation): boolean {
 }
 
 /**
+ * Matches a Homebrew Cellar path component followed by a formula directory, as in
+ * `/opt/homebrew/Cellar/r/4.6.1/bin/R`. Matching the Cellar rather than the prefix
+ * keeps this working across Homebrew prefixes, which differ by platform.
+ */
+const HOMEBREW_CELLAR_RE = /\/Cellar\/[^/]+\//;
+
+/**
+ * Decide whether an R binary path belongs to a Homebrew-managed installation.
+ *
+ * Discovery resolves symlinks before classification (see `discoverAdHocBinaries`
+ * and `discoverHQBinaries`), so this normally sees the real install path rather
+ * than a `bin/R` symlink.
+ *
+ * @param binpath The R binary path.
+ * @returns Whether the path is a Homebrew-managed R installation.
+ */
+function isHomebrewPath(binpath: string): boolean {
+	// A cask is just an installer Homebrew downloads and runs; whatever lands
+	// under Caskroom is managed by that installer, not by Homebrew. Miniforge is
+	// the case that motivated this check: `brew install --cask miniforge` puts a
+	// conda distribution at /opt/homebrew/Caskroom/miniforge/base, so R in one of
+	// its environments is a conda R that merely happens to sit under the Homebrew
+	// prefix. See https://github.com/posit-dev/positron/issues/15300.
+	if (binpath.includes('/Caskroom/')) {
+		return false;
+	}
+
+	// Formula installs live in a Cellar under the Homebrew prefix. The prefix
+	// varies (/opt/homebrew on Apple Silicon, /usr/local on Intel macOS,
+	// /home/linuxbrew/.linuxbrew on Linux), so key off the Cellar instead.
+	if (HOMEBREW_CELLAR_RE.test(binpath)) {
+		return true;
+	}
+
+	// Fall back to the Apple Silicon prefix, which is unambiguous even for an
+	// unresolved symlink such as /opt/homebrew/bin/R (reachable when the path
+	// comes straight from a setting rather than from discovery). We deliberately
+	// don't match the Intel prefix here: /usr/local/bin/R is also where CRAN's
+	// installer symlinks R, so it can't identify Homebrew on its own.
+	return binpath.includes('/opt/homebrew/');
+}
+
+/**
  * Classify the source/packager that governs an R installation, used for the
  * runtime's display source (System, Module, Conda, ...) and name amendment.
  *
@@ -616,8 +659,7 @@ export function classifyRRuntimeSource(
 		(packagerMetadata !== undefined && isPixiMetadata(packagerMetadata)) || hasReason(ReasonDiscovered.PIXI);
 	const isCondaInstallation =
 		(packagerMetadata !== undefined && isCondaMetadata(packagerMetadata)) || hasReason(ReasonDiscovered.CONDA);
-	// Homebrew installations are identified by a 'homebrew' path component.
-	const isHomebrewInstallation = binpath.includes('/homebrew/');
+	const isHomebrewInstallation = isHomebrewPath(binpath);
 
 	if (isModuleInstallation) {
 		return RRuntimeSource.module;

--- a/extensions/positron-r/src/test/classify-runtime-source.test.ts
+++ b/extensions/positron-r/src/test/classify-runtime-source.test.ts
@@ -77,4 +77,45 @@ suite('classifyRRuntimeSource', () => {
 			RRuntimeSource.system,
 		);
 	});
+
+	test('recognizes Homebrew by its Cellar layout, not by the Homebrew prefix alone', () => {
+		// Discovery resolves symlinks before classifying, so these are the real
+		// install paths rather than the `bin/R` symlinks that point at them.
+		const expected: [string, RRuntimeSource][] = [
+			// Formula installs, one per Homebrew prefix: Apple Silicon, Intel, Linux.
+			['/opt/homebrew/Cellar/r/4.6.1/bin/R', RRuntimeSource.homebrew],
+			['/usr/local/Cellar/r/4.6.1/bin/R', RRuntimeSource.homebrew],
+			['/home/linuxbrew/.linuxbrew/Cellar/r/4.6.1/bin/R', RRuntimeSource.homebrew],
+			// An unresolved Apple Silicon symlink, which a settings path can still
+			// produce, stays recognizable.
+			['/opt/homebrew/bin/R', RRuntimeSource.homebrew],
+			// Regression, posit-dev/positron#15300: `brew install --cask miniforge`
+			// puts a conda distribution under the Homebrew prefix, so R in one of its
+			// environments is not a Homebrew-managed R.
+			['/opt/homebrew/Caskroom/miniforge/base/envs/datasci/bin/R', RRuntimeSource.system],
+			// CRAN's installer, which symlinks /usr/local/bin/R just as Homebrew does
+			// on Intel macOS. Neither the framework path nor the symlink is Homebrew.
+			['/Library/Frameworks/R.framework/Versions/4.5-arm64/Resources/bin/R', RRuntimeSource.system],
+			['/usr/local/bin/R', RRuntimeSource.system],
+		];
+
+		const actual = expected.map(([binpath]): [string, RRuntimeSource] =>
+			[binpath, classifyRRuntimeSource(binpath, undefined, [ReasonDiscovered.adHoc], false)]);
+
+		assert.deepStrictEqual(actual, expected);
+	});
+
+	test('classifies conda metadata over a cask path (#15300)', () => {
+		// With `positron.r.interpreters.condaDiscovery` on, the same miniforge
+		// environment arrives with conda metadata and must be labelled Conda.
+		assert.strictEqual(
+			classifyRRuntimeSource(
+				'/opt/homebrew/Caskroom/miniforge/base/envs/datasci/bin/R',
+				{ environmentPath: '/opt/homebrew/Caskroom/miniforge/base/envs/datasci' },
+				[ReasonDiscovered.CONDA],
+				false,
+			),
+			RRuntimeSource.conda,
+		);
+	});
 });


### PR DESCRIPTION
Fixes #15300.

### Problem

`classifyRRuntimeSource` identified Homebrew installs with a bare substring test, `binpath.includes('/homebrew/')`. That is wrong in both directions:

- **Over-matches cask payloads.** A cask is just an installer that Homebrew downloads and runs; its payload is managed by that installer, not by Homebrew. `brew install --cask miniforge` puts a conda distribution at `/opt/homebrew/Caskroom/miniforge/base`, so R in one of its environments was labelled `R 4.6.1 (Homebrew)` when it is really a conda R that happens to sit under the Homebrew prefix. This is the reported bug.
- **Under-matches real Homebrew installs.** The Homebrew prefix is platform dependent. On Intel macOS a formula install resolves to `/usr/local/Cellar/r/<version>/bin/R`, which contains no `/homebrew/` component, so genuine Homebrew R was labelled `System` there.

### Fix

Key off the Cellar layout that formula installs share across every prefix (`/opt/homebrew` on Apple Silicon, `/usr/local` on Intel, `/home/linuxbrew/.linuxbrew` on Linux), and exclude Caskroom payloads.

`/usr/local/bin/R` is deliberately *not* treated as Homebrew: CRAN's installer symlinks that same path, so it cannot identify Homebrew on its own. The Apple Silicon prefix is kept as a fallback so an unresolved `/opt/homebrew/bin/R` coming straight from a setting (rather than from discovery, which realpaths binaries) still classifies correctly.

### Scope

This corrects the *source* classification only. With no conda metadata attached, the reporter's runtime now falls through to `System` and displays as plain `R 4.6.1` rather than `R 4.6.1 (Homebrew)` -- the neutral-label outcome suggested in the issue.

Getting it to read `(Conda: datasci)` instead requires inferring conda metadata for binaries registered via `positron.r.customBinaries`, which is a behavioral change rather than a cosmetic one: conda metadata drives a `conda activate <env>` startup command in `kernel-spec.ts`. That belongs in its own change. Users wanting the Conda label today can enable `positron.r.interpreters.condaDiscovery`, which attaches the metadata and already takes precedence over the Homebrew path check.

### QA Notes

Unit tests added to `extensions/positron-r/src/test/classify-runtime-source.test.ts` covering the cask payload, formula installs under all three prefixes, the unresolved Apple Silicon symlink, and CRAN paths. Verified they fail without the production change.

```
npm run test-extension -- -l positron-r --grep classifyRRuntimeSource
```

Manual check on Apple Silicon: with `positron.r.customBinaries` pointing at `/opt/homebrew/Caskroom/miniforge/base/envs/datasci/bin/R`, the interpreter picker no longer labels it Homebrew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)