### PR TITLE
Present Canvas as a standalone application surface

### DIFF
--- a/build/lib/i18n.resources.json
+++ b/build/lib/i18n.resources.json
@@ -183,6 +183,10 @@
 			"project": "vscode-workbench"
 		},
 		{
+			"name": "vs/workbench/contrib/positronCanvas",
+			"project": "vscode-workbench"
+		},
+		{
 			"name": "vs/workbench/contrib/positronVariables",
 			"project": "vscode-workbench"
 		},

--- a/src/vs/workbench/browser/parts/editor/editorActionBarFactory.tsx
+++ b/src/vs/workbench/browser/parts/editor/editorActionBarFactory.tsx
@@ -13,6 +13,7 @@ import { Emitter } from '../../../../base/common/event.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { Disposable, DisposableMap, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { EditorResourceAccessor, SideBySideEditor } from '../../../common/editor.js';
+import { CANVAS_WEBVIEW_VIEW_TYPE } from '../../../common/positronCanvasIdentity.js';
 import { IAction, Separator, SubmenuAction } from '../../../../base/common/actions.js';
 import { actionTooltip } from '../../../../platform/positronActionBar/common/helpers.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
@@ -199,17 +200,22 @@ export class EditorActionBarFactory extends Disposable {
 		];
 
 		// Splice the move editor to new window command button into the right action bar elements.
-		rightActionBarElements.splice(
-			rightActionBarElements.length - 1,
-			0,
-			<ActionBarCommandButton
-				ariaLabel={positronMoveIntoNewWindowAriaLabel}
-				commandId='workbench.action.moveEditorToNewWindow'
-				disabled={auxiliaryWindow}
-				icon={ThemeIcon.fromId('positron-open-in-new-window')}
-				tooltip={positronMoveIntoNewWindowTooltip}
-			/>
-		);
+		// Not for Canvas panels: their action bar carries "Open Canvas" instead
+		// (positronCanvas.contribution.ts), and a plain detached editor window
+		// is the degraded shape of what that button opens.
+		if (this.contextKeyService.getContextKeyValue<string>('activeWebviewPanelId') !== CANVAS_WEBVIEW_VIEW_TYPE) {
+			rightActionBarElements.splice(
+				rightActionBarElements.length - 1,
+				0,
+				<ActionBarCommandButton
+					ariaLabel={positronMoveIntoNewWindowAriaLabel}
+					commandId='workbench.action.moveEditorToNewWindow'
+					disabled={auxiliaryWindow}
+					icon={ThemeIcon.fromId('positron-open-in-new-window')}
+					tooltip={positronMoveIntoNewWindowTooltip}
+				/>
+			);
+		}
 
 		// Return the action bar.
 		return (

--- a/src/vs/workbench/common/positronCanvasIdentity.ts
+++ b/src/vs/workbench/common/positronCanvasIdentity.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Webview panel view type of a Posit Assistant Canvas panel -- the whole of
+ * Canvas-panel identity. Comparing a `WebviewInput.providerId` against it is
+ * the declared way to recognize a Canvas, synchronously and without activating
+ * the extension. Lives in workbench/common (not the positronCanvas contrib)
+ * because the editor part needs it too and cannot import from contrib. Part of
+ * the cross-repo seam documented in contrib/positronCanvas/README.md.
+ */
+export const CANVAS_WEBVIEW_VIEW_TYPE = 'posit-assistant.canvas';

--- a/src/vs/workbench/contrib/positronCanvas/README.md
+++ b/src/vs/workbench/contrib/positronCanvas/README.md
@@ -1,0 +1,43 @@
+# Positron Canvas mode
+
+Canvas mode presents Posit Assistant's Canvas panel as the whole product: one
+conversation in a chromeless standalone window, with the IDE window minimized.
+Positron owns windows, groups, focus, and the mode transaction; the assistant
+owns Canvas content, panel identity, singleton-ness, and UI readiness. When a
+new command is needed in either direction, ask which side owns the fact, not
+which side finds it convenient to act.
+
+## The command seam
+
+The cross-repo subset below also lives in the assistant repo at
+`packages/positron/src/frontend-canvas/README.md`; change that subset in both
+places. Positron's full public namespace is pinned by
+`test/electron-browser/positronCanvasCommands.vitest.ts`.
+
+Registered by Positron, called by the assistant:
+
+- `positron.canvas.enter` - plain command, the assistant's API into Canvas
+  mode. Returns a `CanvasEntryOutcome` (`common/positronCanvasMode.ts`) and
+  never notifies; presentation belongs to the caller.
+- `positron.canvas.exit` - palette action, deliberately unbound: Escape is
+  pressed constantly in a chat UI, and a chord that swaps the whole product
+  surface is worse than no shortcut. The user-facing way out is the Canvas
+  top bar's "Open Positron" control. Resolves `true` only when it actually
+  left Canvas mode; the assistant treats anything else as a failed exit.
+- `positron.canvas.isActive` - plain command; whether Canvas is the only
+  visible surface. Gates the Canvas UI's "Open Positron" control.
+
+Registered by Positron for its own UI:
+
+- `positron.canvas.open` - Canvas editor-action command. Same service call as
+  `positron.canvas.enter`, but it owns the failure notification. Deliberately
+  absent from the palette: a Canvas-capable assistant owns discovery through
+  its `posit-assistant.openCanvas` command, so older assistants expose nothing.
+
+Registered by the assistant, called by Positron:
+
+- `posit-assistant.openCanvasInline` - ensures the singleton Canvas panel,
+  resolving only when its UI is ready and rejecting when Canvas is unavailable
+  or failed. Positron invokes it before trusting even a restored panel.
+- View type `posit-assistant.canvas` - the whole of Canvas-panel identity;
+  `PositronCanvasService` recognizes a Canvas by `providerId` alone.

--- a/src/vs/workbench/contrib/positronCanvas/browser/positronCanvasCommandLockdown.ts
+++ b/src/vs/workbench/contrib/positronCanvas/browser/positronCanvasCommandLockdown.ts
@@ -1,0 +1,67 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { KeyChord, KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
+import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
+import { KeybindingsRegistry, KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { PositronCanvasModeActiveContext } from '../common/positronCanvasMode.js';
+
+/**
+ * Swallowed chords resolve to this no-op instead of their commands, so the
+ * keys are consumed rather than falling through to whatever sits under the
+ * webview (a removal rule cannot carry a `when` clause). Deliberately outside
+ * the pinned `positron.canvas.*` seam namespace: this command is internal.
+ */
+const SUPPRESSED_KEY_COMMAND = 'positronCanvasLockdown.suppressedKey';
+
+/**
+ * Keeps the IDE's command surface out of reach while Canvas mode is active: a
+ * narrow deny list of the escapes demonstrated in smoke testing (palette,
+ * quick open, new/opened editors, new windows), gated on
+ * `PositronCanvasModeActiveContext`, not a policy layer over all commands.
+ * The chords mirror the denied commands' default bindings; a custom user
+ * binding is deliberately respected as an explicit instruction. The native
+ * menu is trimmed separately (Menubar#install), and OS-level opens are routed
+ * in the main process (LaunchMainService).
+ */
+export function registerCanvasCommandLockdown(): void {
+	CommandsRegistry.registerCommand(SUPPRESSED_KEY_COMMAND, () => { });
+
+	// One entry per denied command, carrying that command's default chords.
+	const suppressed: { primary: number; secondary?: number[]; mac?: { primary: number; secondary?: number[] } }[] = [
+		// workbench.action.showCommands (Positron already unbinds its F1
+		// secondary in favor of Show Help at Cursor).
+		{ primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyP },
+		// workbench.action.quickOpen
+		{
+			primary: KeyMod.CtrlCmd | KeyCode.KeyP,
+			secondary: [KeyMod.CtrlCmd | KeyCode.KeyE],
+			mac: { primary: KeyMod.CtrlCmd | KeyCode.KeyP, secondary: undefined }
+		},
+		// workbench.action.files.newUntitledFile
+		{ primary: KeyMod.CtrlCmd | KeyCode.KeyN },
+		// workbench.action.newWindow
+		{ primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyN },
+		// workbench.action.files.openFile / openFolder (Windows, Linux) and
+		// openFileFolder (macOS) share Ctrl/Cmd+O; openFolder adds a chord.
+		{
+			primary: KeyMod.CtrlCmd | KeyCode.KeyO,
+			secondary: [KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyO)],
+			mac: { primary: KeyMod.CtrlCmd | KeyCode.KeyO, secondary: undefined }
+		}
+	];
+
+	for (const keybinding of suppressed) {
+		KeybindingsRegistry.registerKeybindingRule({
+			...keybinding,
+			id: SUPPRESSED_KEY_COMMAND,
+			// Above the denied commands' own WorkbenchContrib-weight rules, so
+			// this rule wins while its `when` holds without depending on
+			// registration order.
+			weight: KeybindingWeight.WorkbenchContrib + 50,
+			when: PositronCanvasModeActiveContext
+		});
+	}
+}

--- a/src/vs/workbench/contrib/positronCanvas/common/positronCanvasMode.ts
+++ b/src/vs/workbench/contrib/positronCanvas/common/positronCanvasMode.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../../nls.js';
+import { RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
+
+// The `positron.canvas.*` commands and `CANVAS_WEBVIEW_VIEW_TYPE` are the seam
+// between Positron and Posit Assistant; ../README.md is the canonical
+// description, mirrored in the assistant repo's `frontend-canvas/README.md`.
+
+export { CANVAS_WEBVIEW_VIEW_TYPE } from '../../../common/positronCanvasIdentity.js';
+
+/**
+ * How an attempt to enter Canvas mode ended. Data rather than an exception so
+ * every caller (palette action, the assistant over the command seam) can
+ * present each non-entry case with the right copy.
+ */
+export type CanvasEntryOutcome =
+	| { readonly entered: true }
+	| {
+		readonly entered: false;
+		/**
+		 * `ai-disabled`: the `ai.enabled` switch is off.
+		 * `engaged-elsewhere`: another window already presents Canvas.
+		 * `no-panel`: Posit Assistant did not produce a Canvas panel.
+		 * `no-window`: the panel could not get a window of its own, or the
+		 * IDE window could not be put away behind it.
+		 * `superseded`: the user asked for the IDE back mid-entry.
+		 */
+		readonly reason: 'ai-disabled' | 'engaged-elsewhere' | 'no-panel' | 'no-window' | 'superseded';
+		/** Localized, user-presentable description of the reason. */
+		readonly message: string;
+	};
+
+/**
+ * Set while Canvas is the only surface the user can see. Gates the action
+ * that hands the user back to the IDE.
+ */
+export const PositronCanvasModeActiveContext = new RawContextKey<boolean>('positronCanvasModeActive', false, localize('positron.canvas.modeActiveContext', "Whether Canvas is currently the only visible Positron surface."));
+
+/**
+ * Command id of the action that exits Canvas mode; part of the pinned
+ * `positron.canvas.*` seam (../README.md). Also declared to the main process
+ * as standalone mode's exit command at engagement time, so an externally
+ * requested open can ask Canvas to stand down without the main process
+ * knowing about Canvas.
+ */
+export const CANVAS_EXIT_COMMAND_ID = 'positron.canvas.exit';

--- a/src/vs/workbench/contrib/positronCanvas/electron-browser/positronCanvas.contribution.ts
+++ b/src/vs/workbench/contrib/positronCanvas/electron-browser/positronCanvas.contribution.ts
@@ -1,0 +1,107 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Codicon } from '../../../../base/common/codicons.js';
+import { localize2 } from '../../../../nls.js';
+import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';
+import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
+import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { INotificationService } from '../../../../platform/notification/common/notification.js';
+import { AI_ENABLED_KEY } from '../../positronAssistant/common/positronAIConfiguration.js';
+import { registerCanvasCommandLockdown } from '../browser/positronCanvasCommandLockdown.js';
+import { CANVAS_EXIT_COMMAND_ID, CANVAS_WEBVIEW_VIEW_TYPE, PositronCanvasModeActiveContext } from '../common/positronCanvasMode.js';
+import { IPositronCanvasService, PositronCanvasService } from './positronCanvasService.js';
+
+registerSingleton(IPositronCanvasService, PositronCanvasService, InstantiationType.Delayed);
+
+/**
+ * Enters Canvas mode from the Canvas editor's action bar. The assistant owns
+ * palette discovery, so Positron stays dormant when the installed assistant
+ * does not provide Canvas. Both entry points land on the same service call;
+ * this action adds the presentation of not getting in.
+ */
+class OpenCanvasAction extends Action2 {
+
+	static readonly ID = 'positron.canvas.open';
+
+	constructor() {
+		super({
+			id: OpenCanvasAction.ID,
+			title: localize2('positron.canvas.open', "Open Canvas"),
+			category: Categories.View,
+			f1: false,
+			precondition: ContextKeyExpr.has(`config.${AI_ENABLED_KEY}`),
+			icon: Codicon.screenFull,
+			menu: [{
+				// Shown where the active editor is a Canvas panel, in place of
+				// the standard move-into-new-window button, which is suppressed
+				// for Canvas (editorActionBarFactory.tsx).
+				id: MenuId.EditorActionsRight,
+				group: 'navigation',
+				when: ContextKeyExpr.and(
+					ContextKeyExpr.equals('activeWebviewPanelId', CANVAS_WEBVIEW_VIEW_TYPE),
+					ContextKeyExpr.has(`config.${AI_ENABLED_KEY}`)
+				)
+			}]
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const canvasService = accessor.get(IPositronCanvasService);
+		const notificationService = accessor.get(INotificationService);
+		const outcome = await canvasService.enter();
+		if (!outcome.entered) {
+			// A notification: the user asked from inside a working IDE.
+			notificationService.error(outcome.message);
+		}
+	}
+}
+
+/**
+ * Leaves Canvas mode for the full IDE. Deliberately unbound: Escape is pressed
+ * constantly in a chat UI, and a chord that swaps the whole product surface is
+ * worse than no shortcut. The way out is Canvas's own "Open Positron" control.
+ */
+class ExitCanvasModeAction extends Action2 {
+
+	static readonly ID = CANVAS_EXIT_COMMAND_ID;
+
+	constructor() {
+		super({
+			id: ExitCanvasModeAction.ID,
+			title: localize2('positron.canvas.exit', "Exit Canvas to the Positron IDE"),
+			category: Categories.View,
+			f1: true,
+			precondition: PositronCanvasModeActiveContext
+		});
+	}
+
+	override run(accessor: ServicesAccessor): Promise<boolean> {
+		return accessor.get(IPositronCanvasService).exit();
+	}
+}
+
+registerAction2(OpenCanvasAction);
+registerAction2(ExitCanvasModeAction);
+registerCanvasCommandLockdown();
+
+/**
+ * Posit Assistant's way into Canvas mode. A plain command: it returns the
+ * entry outcome and never notifies, so the caller decides the presentation.
+ */
+CommandsRegistry.registerCommand('positron.canvas.enter', (accessor: ServicesAccessor) => {
+	return accessor.get(IPositronCanvasService).enter();
+});
+
+/**
+ * Whether Canvas is being shown as the whole product; gates the Canvas UI's
+ * "Open Positron" control.
+ */
+CommandsRegistry.registerCommand('positron.canvas.isActive', (accessor: ServicesAccessor): boolean => {
+	return accessor.get(IPositronCanvasService).isActive;
+});

--- a/src/vs/workbench/contrib/positronCanvas/electron-browser/positronCanvasService.ts
+++ b/src/vs/workbench/contrib/positronCanvas/electron-browser/positronCanvasService.ts
@@ -1,0 +1,503 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { getActiveWindow } from '../../../../base/browser/dom.js';
+import { mainWindow } from '../../../../base/browser/window.js';
+import { raceTimeout } from '../../../../base/common/async.js';
+import { Event } from '../../../../base/common/event.js';
+import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { localize } from '../../../../nls.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { IMainProcessService } from '../../../../platform/ipc/common/mainProcessService.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { INativeHostService } from '../../../../platform/native/common/native.js';
+import { POSITRON_STANDALONE_MODE_CHANNEL_NAME } from '../../../../platform/positronStandaloneMode/common/positronStandaloneMode.js';
+import { PositronStandaloneModeChannelClient } from '../../../../platform/positronStandaloneMode/common/positronStandaloneModeIpc.js';
+import { prepareMoveCopyEditors } from '../../../browser/parts/editor/editor.js';
+import { EditorsOrder } from '../../../common/editor.js';
+import { IAuxiliaryEditorPart, IEditorGroup, IEditorGroupsService, IEditorPart, GroupsOrder } from '../../../services/editor/common/editorGroupsService.js';
+import { IHostService } from '../../../services/host/browser/host.js';
+import { IWorkbenchLayoutService, Parts } from '../../../services/layout/browser/layoutService.js';
+import { AI_ENABLED_KEY } from '../../positronAssistant/common/positronAIConfiguration.js';
+import { dedicatedWindowOptions } from '../../positronEditorActions/browser/positronDedicatedWindow.js';
+import { WebviewInput } from '../../webviewPanel/browser/webviewEditorInput.js';
+import { CANVAS_EXIT_COMMAND_ID, CANVAS_WEBVIEW_VIEW_TYPE, CanvasEntryOutcome, PositronCanvasModeActiveContext } from '../common/positronCanvasMode.js';
+
+/**
+ * Posit Assistant's command to open a Canvas panel as an ordinary editor --
+ * the only thing core needs from the extension.
+ */
+const CANVAS_ENSURE_COMMAND = 'posit-assistant.openCanvasInline';
+
+/**
+ * Cap on waiting for the assistant to produce a panel. `executeCommand`
+ * blocks unboundedly on extension activation; the command itself settles
+ * within the assistant's own 14s ensure deadline, so this only adds headroom
+ * for activation.
+ */
+const CANVAS_ENSURE_TIMEOUT = 20_000;
+
+export const IPositronCanvasService = createDecorator<IPositronCanvasService>('positronCanvasService');
+
+export interface IPositronCanvasService {
+
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Present Canvas as the whole product: one conversation in a standalone
+	 * window, IDE window out of the way. Absorbs every starting position and
+	 * concurrent callers; never leaves the user with no visible window.
+	 * Resolves an outcome rather than throwing for known non-entry cases,
+	 * because how a non-entry is shown depends on who asked (palette
+	 * notification or the assistant across the command seam).
+	 */
+	enter(): Promise<CanvasEntryOutcome>;
+
+	/**
+	 * Whether Canvas is currently the only surface the user can see. Gates
+	 * the Canvas UI's "Open Positron" control.
+	 */
+	readonly isActive: boolean;
+
+	/**
+	 * Hand the user back to the full IDE, moving the live conversation into
+	 * it rather than throwing it away. Resolves `true` only when it actually
+	 * left Canvas mode; the assistant treats anything else as a failed exit.
+	 */
+	exit(): Promise<boolean>;
+}
+
+/** A Canvas panel and the group it currently lives in. */
+interface ICanvasEditor {
+	readonly group: IEditorGroup;
+	readonly editor: WebviewInput;
+}
+
+export class PositronCanvasService extends Disposable implements IPositronCanvasService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly modeActiveContext: IContextKey<boolean>;
+
+	/**
+	 * Where the main process hears about the engagement, so it can keep other
+	 * windows out, trim the native menus, and route external opens; see
+	 * `IPositronStandaloneModeMainService`.
+	 */
+	private readonly standaloneModeChannel: PositronStandaloneModeChannelClient;
+
+	/** Whether this window holds the application-wide claim. */
+	private engagementHeld = false;
+
+	/**
+	 * The window presenting Canvas, plus everything to undo when it stops.
+	 * Disposing the store is the whole teardown.
+	 */
+	private readonly canvasWindow = this._register(new MutableDisposable<DisposableStore>());
+	private canvasGroup: IEditorGroup | undefined;
+
+	/** Set while the IDE window has been put away on Canvas's behalf. */
+	private ideWindowHidden = false;
+
+	/** In-flight `enter()`; concurrent callers coalesce onto it. */
+	private entering: Promise<CanvasEntryOutcome> | undefined;
+
+	/**
+	 * Bumped by every `exit()`. Entry is a sequence of awaits; one that
+	 * resumes after an exit landed inside it would silently undo the exit, so
+	 * `doEnter()` captures the count and rechecks it after each await.
+	 */
+	private exitGeneration = 0;
+
+	constructor(
+		@IEditorGroupsService private readonly editorGroupsService: IEditorGroupsService,
+		@ICommandService private readonly commandService: ICommandService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@INativeHostService private readonly nativeHostService: INativeHostService,
+		@IHostService private readonly hostService: IHostService,
+		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
+		@ILogService private readonly logService: ILogService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IMainProcessService mainProcessService: IMainProcessService
+	) {
+		super();
+
+		this.modeActiveContext = PositronCanvasModeActiveContext.bindTo(contextKeyService);
+		this.standaloneModeChannel = new PositronStandaloneModeChannelClient(mainProcessService.getChannel(POSITRON_STANDALONE_MODE_CHANNEL_NAME));
+	}
+
+	/**
+	 * Claim the application-wide engagement before any entry work. The main
+	 * process decides atomically, so of two racing windows exactly one
+	 * proceeds. Idempotent for the holder, which keeps re-entry legitimate.
+	 */
+	private async acquireEngagement(): Promise<boolean> {
+		try {
+			// The exit command travels with the claim, so the main process can
+			// ask Canvas to stand down for an external open without knowing
+			// about Canvas.
+			const granted = await this.standaloneModeChannel.acquire(mainWindow.vscodeWindowId, CANVAS_EXIT_COMMAND_ID);
+			this.engagementHeld = this.engagementHeld || granted;
+			return granted;
+		} catch (error) {
+			// Losing the channel loses the cross-window guarantee, not the
+			// ability to present Canvas in this window.
+			this.logService.error('[canvas] Could not claim Canvas mode with the main process; continuing', error);
+			return true;
+		}
+	}
+
+	/**
+	 * Give the claim back. Fire-and-forget: failing to say so must not fail
+	 * the exit it rode along with.
+	 */
+	private releaseEngagement(): void {
+		if (!this.engagementHeld) {
+			return;
+		}
+		this.engagementHeld = false;
+		this.standaloneModeChannel.release(mainWindow.vscodeWindowId)
+			.catch(error => this.logService.error('[canvas] Could not release Canvas mode with the main process', error));
+	}
+
+	/**
+	 * Release after an entry that did not end presenting. Guarded: a failed
+	 * re-entry must not drop the claim of the Canvas still being presented.
+	 */
+	private releaseEngagementUnlessPresenting(): void {
+		if (this.canvasWindow.value === undefined) {
+			this.releaseEngagement();
+		}
+	}
+
+	enter(): Promise<CanvasEntryOutcome> {
+		this.entering ??= this.doEnter().finally(() => this.entering = undefined);
+		return this.entering;
+	}
+
+	private async doEnter(): Promise<CanvasEntryOutcome> {
+		// Read live: `ai.enabled` toggles without a reload.
+		if (this.configurationService.getValue<boolean>(AI_ENABLED_KEY) === false) {
+			this.logService.info('[canvas] Not entering Canvas mode: ai.enabled is false');
+			return {
+				entered: false,
+				reason: 'ai-disabled',
+				message: localize('positron.canvas.aiDisabled', "Canvas is unavailable because AI features are disabled.")
+			};
+		}
+
+		// Captured before the claim's await so an exit arriving mid-claim
+		// supersedes this entry like any other.
+		const generation = this.exitGeneration;
+
+		// Claimed before any other await, so no second window can start an
+		// entry between here and the Canvas window appearing.
+		if (!await this.acquireEngagement()) {
+			return {
+				entered: false,
+				reason: 'engaged-elsewhere',
+				message: localize('positron.canvas.engagedElsewhere', "Canvas is already open in another Positron window.")
+			};
+		}
+
+		try {
+			return await this.doEnterEngaged(generation);
+		} finally {
+			this.releaseEngagementUnlessPresenting();
+		}
+	}
+
+	private async doEnterEngaged(generation: number): Promise<CanvasEntryOutcome> {
+		const superseded = () => this.exitGeneration !== generation;
+		const supersededOutcome: CanvasEntryOutcome = {
+			entered: false,
+			reason: 'superseded',
+			message: localize('positron.canvas.superseded', "Canvas stopped opening because Positron was asked for the IDE.")
+		};
+		if (superseded()) {
+			this.logService.info('[canvas] Abandoning entry: the user left Canvas while the application-wide claim was pending');
+			return supersededOutcome;
+		}
+
+		const canvas = await this.ensureCanvasEditor();
+		if (superseded()) {
+			this.logService.info('[canvas] Abandoning entry: the user left Canvas while it was opening');
+			return supersededOutcome;
+		}
+		if (!canvas) {
+			return {
+				entered: false,
+				reason: 'no-panel',
+				message: localize('positron.canvas.couldNotOpen', "Canvas could not be opened. Check the Posit Assistant output for details.")
+			};
+		}
+
+		// A panel already outside the IDE window is one we (or a restore) put
+		// there; adopt it as is. Restored windows come back with locked
+		// compact mode intact, so there is nothing to repair.
+		const part = this.editorGroupsService.getPart(canvas.group);
+		const canvasWindow = part === this.editorGroupsService.mainPart
+			? await this.promoteToCanvasWindow(canvas, superseded)
+			: { part, group: canvas.group };
+
+		if (superseded()) {
+			this.logService.info('[canvas] Abandoning entry: the user left Canvas while its window was being created');
+			return supersededOutcome;
+		}
+
+		if (!canvasWindow) {
+			return {
+				entered: false,
+				reason: 'no-window',
+				message: localize('positron.canvas.couldNotOpenWindow', "Canvas could not be opened in its own window.")
+			};
+		}
+
+		this.adoptCanvasWindow(canvasWindow.part, canvasWindow.group);
+
+		// Only now, with a live Canvas window on screen, is it safe to put
+		// the IDE window away.
+		try {
+			await this.hideIdeWindow();
+		} catch (error) {
+			// A visible IDE next to Canvas is recoverable; a committed entry
+			// over a failed hide is not, so run the normal merge-back transaction.
+			this.logService.error('[canvas] Could not put the IDE window away; leaving Canvas mode', error);
+			await this.exit();
+			return {
+				entered: false,
+				reason: 'no-window',
+				message: localize('positron.canvas.couldNotHideIde', "Canvas could not take over from the Positron window.")
+			};
+		}
+
+		if (superseded()) {
+			// The exit already unwound everything, but its reveal may have
+			// raced the minimize in flight here; reveal unconditionally.
+			this.logService.info('[canvas] Abandoning entry: Canvas went away while the IDE window was being put away');
+			await this.revealIdeWindow(true);
+			return supersededOutcome;
+		}
+
+		return { entered: true };
+	}
+
+	get isActive(): boolean {
+		return this.modeActiveContext.get() === true;
+	}
+
+	async exit(): Promise<boolean> {
+		// Retires any entry still in flight, before anything it could race with.
+		this.exitGeneration++;
+
+		const canvasGroup = this.canvasGroup;
+
+		// Read before `stopPresenting()`, which is what makes it false.
+		const wasActive = this.canvasWindow.value !== undefined;
+
+		// Stop presenting first: it drops the listener that treats the Canvas
+		// window going away as something to recover from. The claim goes back
+		// even when no Canvas window was up yet -- an exit landing inside an
+		// in-flight entry must not leave the early claim behind.
+		this.stopPresenting();
+		this.releaseEngagement();
+
+		// Show the IDE before moving anything into it: the move focuses its
+		// target, and focusing a group in an off-screen window leaves the
+		// user with no visible focused window.
+		await this.revealIdeWindow();
+
+		if (canvasGroup) {
+			// Unlock so the group is an ordinary group for as long as it
+			// survives the merge.
+			canvasGroup.lock(false);
+
+			// Merge, never `close()`: close treats a webview panel as
+			// non-confirming and destroys it, dropping the live conversation.
+			if (!this.editorGroupsService.mergeGroup(canvasGroup, this.editorGroupsService.mainPart.activeGroup)) {
+				this.logService.error('[canvas] Could not merge the Canvas group into the IDE; moving its editors individually');
+				canvasGroup.moveEditors(prepareMoveCopyEditors(canvasGroup, canvasGroup.editors.slice()), this.editorGroupsService.mainPart.activeGroup);
+			}
+
+			// The editor area auto-hides when its last editor leaves, so an
+			// IDE window that had only Canvas open comes back without one.
+			// Only when the merge happened: an exit with nothing to merge
+			// must not override an editor area the user hid deliberately.
+			this.layoutService.setPartHidden(false, Parts.EDITOR_PART);
+			this.editorGroupsService.mainPart.activeGroup.focus();
+		}
+
+		return wasActive;
+	}
+
+	/**
+	 * The most recently active Canvas panel anywhere in the workbench.
+	 * The assistant's ensure command owns singleton-ness; this scan only finds
+	 * the ready panel that command selected or created.
+	 */
+	private findCanvasEditor(): ICanvasEditor | undefined {
+		const found: ICanvasEditor[] = [];
+
+		for (const group of this.editorGroupsService.getGroups(GroupsOrder.MOST_RECENTLY_ACTIVE)) {
+			// `group.editors` is tab order; only `getEditors(MOST_RECENTLY_ACTIVE)`
+			// orders within a group.
+			for (const editor of group.getEditors(EditorsOrder.MOST_RECENTLY_ACTIVE)) {
+				if (editor instanceof WebviewInput && editor.providerId === CANVAS_WEBVIEW_VIEW_TYPE) {
+					found.push({ group, editor });
+				}
+			}
+		}
+
+		if (found.length > 1) {
+			// Non-destructive on purpose: closing the extras would dispose
+			// live assistant sessions.
+			this.logService.warn(`[canvas] ${found.length} Canvas panels are open; presenting the most recently active one`);
+		}
+
+		return found.at(0);
+	}
+
+	private async ensureCanvasEditor(): Promise<ICanvasEditor | undefined> {
+		// `raceTimeout` resolves undefined on timeout and when the command
+		// resolves undefined (which it always does); only the callback can
+		// tell them apart.
+		let timedOut = false;
+
+		try {
+			await raceTimeout(
+				this.commandService.executeCommand(CANVAS_ENSURE_COMMAND),
+				CANVAS_ENSURE_TIMEOUT,
+				() => {
+					timedOut = true;
+					this.logService.error(`[canvas] ${CANVAS_ENSURE_COMMAND} did not complete within ${CANVAS_ENSURE_TIMEOUT}ms`);
+				}
+			);
+		} catch (error) {
+			this.logService.error(`[canvas] ${CANVAS_ENSURE_COMMAND} failed`, error);
+			return undefined;
+		}
+
+		// A timeout is a failure, never a panel to adopt: the panel a scan
+		// would find is one the assistant is still working on, and its own
+		// readiness deadline is about to dispose it. Adopting it would report
+		// success, minimize the IDE, then bounce the user back.
+		if (timedOut) {
+			return undefined;
+		}
+
+		return this.findCanvasEditor();
+	}
+
+	/**
+	 * Moves a Canvas panel out of the IDE window into a window of its own.
+	 * Returns nothing if the move did not happen, so the caller does not hide
+	 * the IDE behind a window that never got its editor. `superseded` is
+	 * checked before the panel is moved: a panel pulled out of an IDE window
+	 * the user was just handed back is worse than no window at all.
+	 */
+	private async promoteToCanvasWindow(canvas: ICanvasEditor, superseded: () => boolean): Promise<{ part: IAuxiliaryEditorPart; group: IEditorGroup } | undefined> {
+		let part: IAuxiliaryEditorPart;
+		try {
+			part = await this.editorGroupsService.createAuxiliaryEditorPart(dedicatedWindowOptions(getActiveWindow(), {
+				// Compact mode is what makes the window chromeless, so it must
+				// not be something a stray editor or menu action can switch off.
+				lockCompact: true
+			}));
+		} catch (error) {
+			this.logService.error('[canvas] Could not create a window for Canvas', error);
+			return undefined;
+		}
+
+		if (superseded()) {
+			// Empty, so closing it takes its window with it.
+			part.close();
+			return undefined;
+		}
+
+		if (!canvas.group.moveEditors(prepareMoveCopyEditors(canvas.group, [canvas.editor]), part.activeGroup)) {
+			this.logService.error('[canvas] Could not move the Canvas editor into its own window');
+			part.close();
+			return undefined;
+		}
+
+		return { part, group: part.activeGroup };
+	}
+
+	/**
+	 * Takes ownership of the window presenting Canvas: keeps it single-editor,
+	 * arranges for the IDE to come back if it disappears, and focuses it.
+	 */
+	private adoptCanvasWindow(part: IEditorPart, group: IEditorGroup): void {
+		this.stopPresenting();
+
+		const disposables = new DisposableStore();
+
+		// A locked group keeps Canvas alone in its window: the editor service
+		// routes anything else to the next unlocked group, back in the IDE.
+		// Without it a file opened while Canvas has focus would silently
+		// cover Canvas, since compact mode draws no tabs.
+		group.lock(true);
+
+		// The window can also go away without anyone asking us (OS close
+		// button, renderer crash); the IDE window has to come back.
+		disposables.add(Event.once(part.onWillDispose)(() => {
+			// Losing the window supersedes an in-flight entry the same way an
+			// exit does; without this it would resume and report success for
+			// a window that no longer exists.
+			this.exitGeneration++;
+
+			this.stopPresenting();
+			this.releaseEngagement();
+
+			void this.revealIdeWindow();
+		}));
+
+		this.canvasWindow.value = disposables;
+		this.canvasGroup = group;
+		this.modeActiveContext.set(true);
+
+		group.focus();
+	}
+
+	/**
+	 * Forget the window we were presenting Canvas in. Does not touch the
+	 * group: this also runs while that window is being disposed, and the
+	 * group's lock dies with it either way.
+	 */
+	private stopPresenting(): void {
+		this.canvasWindow.clear();
+		this.canvasGroup = undefined;
+		this.modeActiveContext.set(false);
+	}
+
+	private async hideIdeWindow(): Promise<void> {
+		// Unguarded, unlike `revealIdeWindow()`: re-entry can focus
+		// (un-minimize) the IDE window on its way in, so skipping "already
+		// hidden" work would leave it behind Canvas.
+		this.ideWindowHidden = true;
+
+		// Minimize rather than hide: a minimized window is still listed by
+		// the OS, so the user can always get back to Positron, and an app
+		// with no visible windows has its own hazards.
+		await this.nativeHostService.minimizeWindow({ targetWindowId: mainWindow.vscodeWindowId });
+	}
+
+	/**
+	 * @param force reveal even when we do not believe the IDE window is away,
+	 * for the one caller with a minimize of its own in flight.
+	 */
+	private async revealIdeWindow(force = false): Promise<void> {
+		if (!this.ideWindowHidden && !force) {
+			return;
+		}
+		this.ideWindowHidden = false;
+
+		// Focusing is what un-minimizes; there is no separate restore call.
+		await this.hostService.focus(mainWindow);
+	}
+}

--- a/src/vs/workbench/contrib/positronCanvas/test/browser/positronCanvasCommandLockdown.vitest.ts
+++ b/src/vs/workbench/contrib/positronCanvas/test/browser/positronCanvasCommandLockdown.vitest.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { OperatingSystem } from '../../../../../base/common/platform.js';
+import { KeybindingsRegistry, KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { USLayoutResolvedKeybinding } from '../../../../../platform/keybinding/common/usLayoutResolvedKeybinding.js';
+import { registerCanvasCommandLockdown } from '../../browser/positronCanvasCommandLockdown.js';
+
+const SUPPRESSED_KEY_COMMAND = 'positronCanvasLockdown.suppressedKey';
+
+registerCanvasCommandLockdown();
+
+function suppressedBindings(os: OperatingSystem) {
+	return KeybindingsRegistry.getDefaultKeybindingsForOS(os)
+		.filter(item => item.command === SUPPRESSED_KEY_COMMAND && item.keybinding)
+		.map(item => ({
+			chord: USLayoutResolvedKeybinding.resolveKeybinding(item.keybinding!, os)[0].getDispatchChords().join(' '),
+			when: item.when?.serialize(),
+			weight: item.weight1,
+		}))
+		.sort((left, right) => left.chord.localeCompare(right.chord));
+}
+
+describe('Canvas command lockdown', () => {
+	it.each([
+		['macOS', OperatingSystem.Macintosh, ['meta+N', 'meta+O', 'meta+P', 'shift+meta+N', 'shift+meta+P']],
+		['Linux', OperatingSystem.Linux, ['ctrl+E', 'ctrl+K ctrl+O', 'ctrl+N', 'ctrl+O', 'ctrl+P', 'ctrl+shift+N', 'ctrl+shift+P']],
+		['Windows', OperatingSystem.Windows, ['ctrl+E', 'ctrl+K ctrl+O', 'ctrl+N', 'ctrl+O', 'ctrl+P', 'ctrl+shift+N', 'ctrl+shift+P']],
+	] as const)('pins the default escape chords, context, and precedence on %s', (_name, os, expectedChords) => {
+		const bindings = suppressedBindings(os);
+
+		expect(bindings.map(binding => binding.chord)).toEqual(expectedChords);
+		expect(bindings.every(binding => binding.when === 'positronCanvasModeActive')).toBe(true);
+		expect(bindings.every(binding => binding.weight === KeybindingWeight.WorkbenchContrib + 50)).toBe(true);
+	});
+});

--- a/src/vs/workbench/contrib/positronCanvas/test/electron-browser/positronCanvasCommands.vitest.ts
+++ b/src/vs/workbench/contrib/positronCanvas/test/electron-browser/positronCanvasCommands.vitest.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { isIMenuItem, MenuId, MenuRegistry } from '../../../../../platform/actions/common/actions.js';
+import { CommandsRegistry } from '../../../../../platform/commands/common/commands.js';
+import '../../electron-browser/positronCanvas.contribution.js';
+
+/**
+ * Pins Positron's public `positron.canvas.*` command surface. The cross-repo
+ * subset is also documented in the assistant's `frontend-canvas/README.md`;
+ * changing that subset requires changing both documents together.
+ */
+describe('positron.canvas command surface', () => {
+
+	it('registers exactly the commands the seam is documented to have', () => {
+		const canvasCommands = [...CommandsRegistry.getCommands().keys()]
+			.filter(id => id.startsWith('positron.canvas.'))
+			.sort();
+
+		expect(canvasCommands).toEqual([
+			'positron.canvas.enter',
+			'positron.canvas.exit',
+			'positron.canvas.isActive',
+			'positron.canvas.open',
+		]);
+	});
+
+	it('leaves user-facing discovery to the Canvas-capable assistant', () => {
+		const canvasPaletteCommands = MenuRegistry.getMenuItems(MenuId.CommandPalette)
+			.filter(isIMenuItem)
+			.map(item => item.command.id)
+			.filter(id => id.startsWith('positron.canvas.'));
+
+		expect(canvasPaletteCommands).toEqual(['positron.canvas.exit']);
+	});
+});

--- a/src/vs/workbench/contrib/positronCanvas/test/electron-browser/positronCanvasService.vitest.ts
+++ b/src/vs/workbench/contrib/positronCanvas/test/electron-browser/positronCanvasService.vitest.ts
@@ -1,0 +1,390 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { DeferredPromise } from '../../../../../base/common/async.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { IChannel } from '../../../../../base/parts/ipc/common/ipc.js';
+import { IMainProcessService } from '../../../../../platform/ipc/common/mainProcessService.js';
+import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { INativeHostService } from '../../../../../platform/native/common/native.js';
+import { IThemeService } from '../../../../../platform/theme/common/themeService.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { EditorsOrder } from '../../../../common/editor.js';
+import { IAuxiliaryEditorPart, IEditorGroup, IEditorGroupsService, IEditorPart } from '../../../../services/editor/common/editorGroupsService.js';
+import { IHostService } from '../../../../services/host/browser/host.js';
+import { IWorkbenchLayoutService } from '../../../../services/layout/browser/layoutService.js';
+import { IOverlayWebview } from '../../../webview/browser/webview.js';
+import { WebviewInput } from '../../../webviewPanel/browser/webviewEditorInput.js';
+import { CANVAS_WEBVIEW_VIEW_TYPE } from '../../common/positronCanvasMode.js';
+import { PositronCanvasService } from '../../electron-browser/positronCanvasService.js';
+
+/** The command the assistant contributes to produce a Canvas panel. */
+const CANVAS_ENSURE_COMMAND = 'posit-assistant.openCanvasInline';
+
+describe('PositronCanvasService', () => {
+	const ctx = createTestContainer().build();
+
+	/**
+	 * A group whose editor list the test can rearrange.
+	 *
+	 * `editors` is tab order; `mruEditors` is what the group reports for
+	 * `EditorsOrder.MOST_RECENTLY_ACTIVE`, which is a different order whenever a
+	 * group holds more than one editor.
+	 */
+	function createGroup(editors: WebviewInput[] = [], mruEditors: WebviewInput[] = editors): IEditorGroup {
+		const group = stubInterface<IEditorGroup>({
+			editors,
+			getEditors: (order: EditorsOrder) => order === EditorsOrder.MOST_RECENTLY_ACTIVE ? mruEditors : editors,
+			lock: vi.fn(),
+			focus: vi.fn(),
+			isActive: vi.fn().mockReturnValue(true),
+			isSticky: vi.fn().mockReturnValue(false),
+			getIndexOfEditor: vi.fn().mockReturnValue(0),
+			moveEditors: vi.fn().mockReturnValue(true),
+		});
+		return group;
+	}
+
+	function createPart(activeGroup: IEditorGroup, onWillDispose: Event<void> = Event.None): IAuxiliaryEditorPart {
+		return stubInterface<IAuxiliaryEditorPart>({ activeGroup, onWillDispose, close: vi.fn() });
+	}
+
+	/** A Canvas panel, recognized by its contributed view type. */
+	function createCanvasEditor(): WebviewInput {
+		const editor = new WebviewInput(
+			{ viewType: CANVAS_WEBVIEW_VIEW_TYPE, providedId: CANVAS_WEBVIEW_VIEW_TYPE, name: 'Canvas', iconPath: undefined },
+			stubInterface<IOverlayWebview>({ state: undefined, dispose: vi.fn() }),
+			stubInterface<IThemeService>({ onDidColorThemeChange: Event.None }),
+		);
+		ctx.disposables.add(editor);
+		return editor;
+	}
+
+	/**
+	 * Wires the service up over a workbench whose groups the test controls.
+	 *
+	 * `auxiliaryGroups` are the groups, in most-recently-active order, that live
+	 * in a window of their own; the main part's group is always last, so a Canvas
+	 * panel still in the IDE window loses the MRU race.
+	 */
+	function build(options: {
+		auxiliaryGroups?: IEditorGroup[];
+		mainGroup?: IEditorGroup;
+		onWillDispose?: Event<void>;
+		executeCommand?: () => Promise<undefined>;
+		createAuxiliaryEditorPart?: IEditorGroupsService['createAuxiliaryEditorPart'];
+		acquireGranted?: boolean | Promise<boolean>;
+		minimizeWindow?: () => Promise<void>;
+	} = {}) {
+		const auxiliaryGroups = options.auxiliaryGroups ?? [];
+		const mainGroup = options.mainGroup ?? createGroup();
+		const mainPart = createPart(mainGroup);
+		const auxiliaryGroup = auxiliaryGroups.at(0);
+		const auxiliaryPart = createPart(auxiliaryGroup ?? createGroup(), options.onWillDispose ?? Event.None);
+
+		const parts = new Map<IEditorGroup, IEditorPart>(auxiliaryGroups.map(group => [group, auxiliaryPart]));
+		parts.set(mainGroup, mainPart);
+
+		const executeCommand = vi.fn(options.executeCommand ?? (() => Promise.resolve(undefined)));
+		const mergeGroup = vi.fn().mockReturnValue(true);
+		const setPartHidden = vi.fn();
+		const minimizeWindow = vi.fn(options.minimizeWindow ?? (() => Promise.resolve()));
+		const createAuxiliaryEditorPart = vi.fn(options.createAuxiliaryEditorPart ?? (() => Promise.resolve(auxiliaryPart)));
+
+		ctx.instantiationService.stub(IEditorGroupsService, stubInterface<IEditorGroupsService>({
+			mainPart,
+			getGroups: () => [...auxiliaryGroups, mainGroup],
+			getPart: (group: IEditorGroup) => parts.get(group) ?? mainPart,
+			mergeGroup,
+			createAuxiliaryEditorPart,
+		}));
+		ctx.instantiationService.stub(ICommandService, stubInterface<ICommandService>({ executeCommand }));
+		ctx.instantiationService.stub(IConfigurationService, stubInterface<IConfigurationService>({ getValue: () => true }));
+		ctx.instantiationService.stub(INativeHostService, stubInterface<INativeHostService>({ minimizeWindow }));
+		const focus = vi.fn().mockResolvedValue(undefined);
+		ctx.instantiationService.stub(IHostService, stubInterface<IHostService>({ focus }));
+		ctx.instantiationService.stub(IWorkbenchLayoutService, stubInterface<IWorkbenchLayoutService>({ setPartHidden }));
+		ctx.instantiationService.stub(ILogService, new NullLogService());
+		ctx.instantiationService.stub(IContextKeyService, new MockContextKeyService());
+		// The engagement channel: `acquire` grants unless the test says
+		// otherwise, `release` resolves. Recorded so tests can assert the
+		// claim's lifecycle against the mode transaction.
+		const channelCall = vi.fn().mockImplementation((command: string) =>
+			Promise.resolve(command === 'acquire' ? (options.acquireGranted ?? true) : undefined));
+		ctx.instantiationService.stub(IMainProcessService, stubInterface<IMainProcessService>({
+			getChannel: () => stubInterface<IChannel>({ call: channelCall })
+		}));
+
+		const service = ctx.disposables.add(ctx.instantiationService.createInstance(PositronCanvasService));
+
+		return { service, mainGroup, auxiliaryPart, executeCommand, mergeGroup, setPartHidden, minimizeWindow, channelCall, focus };
+	}
+
+	it('coalesces concurrent entries so the assistant is asked for one Canvas', async () => {
+		const created = new DeferredPromise<undefined>();
+		const canvasEditors: WebviewInput[] = [];
+		const auxiliaryGroup = createGroup(canvasEditors);
+		const { service, executeCommand } = build({
+			auxiliaryGroups: [auxiliaryGroup],
+			executeCommand: () => created.p,
+		});
+
+		const first = service.enter();
+		const second = service.enter();
+
+		// The ensure command runs once the entry has claimed Canvas mode with
+		// the main process, one await in.
+		await vi.waitFor(() => expect(executeCommand).toHaveBeenCalled());
+		expect(executeCommand).toHaveBeenCalledTimes(1);
+		expect(executeCommand).toHaveBeenCalledWith(CANVAS_ENSURE_COMMAND);
+
+		// The command is what puts a Canvas panel in the workbench.
+		canvasEditors.push(createCanvasEditor());
+		await created.complete(undefined);
+
+		expect(await Promise.all([first, second])).toEqual([{ entered: true }, { entered: true }]);
+		expect(executeCommand).toHaveBeenCalledTimes(1);
+	});
+
+	it('reports a no-panel outcome when the assistant produces no Canvas', async () => {
+		const { service, executeCommand } = build();
+
+		const outcome = await service.enter();
+
+		expect(executeCommand).toHaveBeenCalledWith(CANVAS_ENSURE_COMMAND);
+		expect(outcome).toMatchObject({ entered: false, reason: 'no-panel' });
+	});
+
+	it('does not adopt a restored Canvas when the assistant cannot ensure it', async () => {
+		const restored = createCanvasEditor();
+		const mainGroup = createGroup([restored]);
+		const { service, executeCommand, minimizeWindow } = build({
+			mainGroup,
+			executeCommand: () => Promise.reject(new Error('command not found')),
+		});
+
+		expect(await service.enter()).toMatchObject({ entered: false, reason: 'no-panel' });
+
+		expect(executeCommand).toHaveBeenCalledWith(CANVAS_ENSURE_COMMAND);
+		expect(minimizeWindow).not.toHaveBeenCalled();
+		expect(mainGroup.editors).toEqual([restored]);
+	});
+
+	it('presents the most recently active Canvas and leaves duplicates open', async () => {
+		const recent = createCanvasEditor();
+		const older = createCanvasEditor();
+		const recentGroup = createGroup([recent]);
+		const olderGroup = createGroup([older]);
+		const { service, executeCommand } = build({ auxiliaryGroups: [recentGroup, olderGroup] });
+
+		expect(await service.enter()).toEqual({ entered: true });
+
+		// The MRU group is the one taken over; the duplicate keeps its editor.
+		expect(recentGroup.lock).toHaveBeenCalledWith(true);
+		expect(olderGroup.lock).not.toHaveBeenCalled();
+		expect(olderGroup.editors).toEqual([older]);
+		expect(executeCommand).toHaveBeenCalledWith(CANVAS_ENSURE_COMMAND);
+	});
+
+	it('presents the most recently used Canvas of two sharing a group', async () => {
+		const older = createCanvasEditor();
+		const recent = createCanvasEditor();
+		// Tab order puts the older panel first; use order is the other way
+		// round, and use order is what Canvas mode follows.
+		const mainGroup = createGroup([older, recent], [recent, older]);
+		const { service } = build({ mainGroup });
+
+		expect(await service.enter()).toEqual({ entered: true });
+
+		const moved = vi.mocked(mainGroup.moveEditors).mock.calls[0][0];
+		expect(moved.map(entry => entry.editor)).toStrictEqual([recent]);
+	});
+
+	it('reports a no-panel outcome when the assistant runs past the create timeout', async () => {
+		vi.useFakeTimers();
+		try {
+			const canvasEditors: WebviewInput[] = [];
+			const mainGroup = createGroup(canvasEditors);
+			// The assistant's webview panel exists as soon as it opens one, long
+			// before the Canvas inside it is ready, so a scan after the timeout
+			// would find a panel that is about to be torn down.
+			const { service } = build({
+				mainGroup,
+				executeCommand: () => {
+					canvasEditors.push(createCanvasEditor());
+					return new DeferredPromise<undefined>().p;
+				},
+			});
+
+			const entering = service.enter();
+			await vi.advanceTimersByTimeAsync(20_000);
+
+			expect(await entering).toMatchObject({ entered: false, reason: 'no-panel' });
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('lets an exit stand that lands while the Canvas window is being created', async () => {
+		const created = new DeferredPromise<IAuxiliaryEditorPart>();
+		const mainGroup = createGroup([createCanvasEditor()]);
+		const { service, auxiliaryPart, minimizeWindow } = build({
+			mainGroup,
+			createAuxiliaryEditorPart: () => created.p,
+		});
+
+		const entering = service.enter();
+		// Window creation takes hundreds of milliseconds; the user asks for the
+		// IDE back while it is still running.
+		expect(await service.exit()).toBe(false);
+		await created.complete(auxiliaryPart);
+
+		// The entry must not resume into a window the user has since left: no
+		// re-minimized IDE and no reported entry.
+		expect(await entering).toMatchObject({ entered: false });
+		expect(minimizeWindow).not.toHaveBeenCalled();
+		expect(service.isActive).toBe(false);
+	});
+
+	it('starts no Canvas work after an exit wins a pending engagement claim', async () => {
+		const acquired = new DeferredPromise<boolean>();
+		const { service, executeCommand, channelCall } = build({ acquireGranted: acquired.p });
+
+		const entering = service.enter();
+		await vi.waitFor(() => expect(channelCall).toHaveBeenCalledWith('acquire', expect.anything()));
+		expect(await service.exit()).toBe(false);
+		await acquired.complete(true);
+
+		expect(await entering).toMatchObject({ entered: false, reason: 'superseded' });
+		expect(executeCommand).not.toHaveBeenCalled();
+		expect(channelCall).toHaveBeenCalledWith('release', expect.anything());
+	});
+
+	it('reports no-window when auxiliary window creation rejects', async () => {
+		const mainGroup = createGroup([createCanvasEditor()]);
+		const { service, minimizeWindow } = build({
+			mainGroup,
+			createAuxiliaryEditorPart: () => Promise.reject(new Error('window creation failed')),
+		});
+
+		expect(await service.enter()).toMatchObject({ entered: false, reason: 'no-window' });
+		expect(minimizeWindow).not.toHaveBeenCalled();
+		expect(service.isActive).toBe(false);
+	});
+
+	it('merges Canvas back into the IDE when minimizing the IDE fails', async () => {
+		const auxiliaryGroup = createGroup([createCanvasEditor()]);
+		const { service, mainGroup, mergeGroup } = build({
+			auxiliaryGroups: [auxiliaryGroup],
+			minimizeWindow: () => Promise.reject(new Error('minimize failed')),
+		});
+
+		expect(await service.enter()).toMatchObject({ entered: false, reason: 'no-window' });
+
+		expect(mergeGroup).toHaveBeenCalledWith(auxiliaryGroup, mainGroup);
+		expect(auxiliaryGroup.lock).toHaveBeenNthCalledWith(1, true);
+		expect(auxiliaryGroup.lock).toHaveBeenNthCalledWith(2, false);
+		expect(service.isActive).toBe(false);
+	});
+
+	it('merges the Canvas group back into the IDE rather than closing it', async () => {
+		const auxiliaryGroup = createGroup([createCanvasEditor()]);
+		const { service, mainGroup, mergeGroup } = build({ auxiliaryGroups: [auxiliaryGroup] });
+		await service.enter();
+
+		expect(await service.exit()).toBe(true);
+
+		// Merging is what keeps the live conversation: closing an auxiliary part
+		// destroys a webview panel instead of moving it.
+		expect(mergeGroup).toHaveBeenCalledWith(auxiliaryGroup, mainGroup);
+		expect(auxiliaryGroup.lock).toHaveBeenCalledWith(false);
+		expect(service.isActive).toBe(false);
+	});
+
+	it('reports an exit that had no Canvas to leave', async () => {
+		const { service, mergeGroup, setPartHidden } = build();
+
+		expect(await service.exit()).toBe(false);
+
+		expect(mergeGroup).not.toHaveBeenCalled();
+		// Nothing was undone, so nothing is redone: unhiding here would override
+		// an editor area the user hid deliberately.
+		expect(setPartHidden).not.toHaveBeenCalled();
+	});
+
+	it('reports engaged-elsewhere and asks the assistant for nothing when another window holds the claim', async () => {
+		const { service, executeCommand, channelCall } = build({ acquireGranted: false });
+
+		expect(await service.enter()).toMatchObject({ entered: false, reason: 'engaged-elsewhere' });
+
+		// A denied claim was never held, so there is nothing to release and
+		// no Canvas work to have started.
+		expect(executeCommand).not.toHaveBeenCalled();
+		expect(channelCall).not.toHaveBeenCalledWith('release', expect.anything());
+	});
+
+	it('gives the claim back when the assistant produces no Canvas', async () => {
+		const { service, channelCall } = build();
+
+		expect(await service.enter()).toMatchObject({ entered: false, reason: 'no-panel' });
+
+		expect(channelCall).toHaveBeenCalledWith('acquire', expect.anything());
+		expect(channelCall).toHaveBeenCalledWith('release', expect.anything());
+	});
+
+	it('holds the claim while presenting and gives it back on exit', async () => {
+		const auxiliaryGroup = createGroup([createCanvasEditor()]);
+		const { service, channelCall } = build({ auxiliaryGroups: [auxiliaryGroup] });
+
+		await service.enter();
+		expect(channelCall).not.toHaveBeenCalledWith('release', expect.anything());
+
+		expect(await service.exit()).toBe(true);
+		expect(channelCall).toHaveBeenCalledWith('release', expect.anything());
+	});
+
+	it('does not report entry when the Canvas window dies while the IDE is being put away', async () => {
+		const willDispose = new Emitter<void>();
+		ctx.disposables.add(willDispose);
+		const minimize = new DeferredPromise<void>();
+		const auxiliaryGroup = createGroup([createCanvasEditor()]);
+		const { service, minimizeWindow, focus } = build({
+			auxiliaryGroups: [auxiliaryGroup],
+			onWillDispose: willDispose.event,
+			minimizeWindow: () => minimize.p,
+		});
+
+		const entering = service.enter();
+		await vi.waitFor(() => expect(minimizeWindow).toHaveBeenCalled());
+
+		// The OS close button lands while the IDE minimize is still in flight.
+		willDispose.fire();
+		await minimize.complete();
+
+		expect(await entering).toMatchObject({ entered: false, reason: 'superseded' });
+		expect(service.isActive).toBe(false);
+		// Whatever order the dying window's reveal and the minimize settled
+		// in, the user ends with a visible IDE.
+		expect(focus).toHaveBeenCalled();
+	});
+
+	it('moves the editors one by one when the merge back into the IDE fails', async () => {
+		const auxiliaryGroup = createGroup([createCanvasEditor()]);
+		const { service, mergeGroup } = build({ auxiliaryGroups: [auxiliaryGroup] });
+		await service.enter();
+
+		mergeGroup.mockReturnValue(false);
+
+		expect(await service.exit()).toBe(true);
+		expect(auxiliaryGroup.moveEditors).toHaveBeenCalled();
+	});
+});

--- a/src/vs/workbench/workbench.desktop.main.ts
+++ b/src/vs/workbench/workbench.desktop.main.ts
@@ -197,6 +197,7 @@ import './contrib/emergencyAlert/electron-browser/emergencyAlert.contribution.js
 
 // --- Start Positron ---
 import './contrib/positronPreview/electron-browser/positronPreview.contribution.js';
+import './contrib/positronCanvas/electron-browser/positronCanvas.contribution.js';
 // --- End Positron ---
 
 // MCP


### PR DESCRIPTION
Part 3 of progress towards #15309.

Stacked on #15311.

This PR adds Canvas mode itself:

- Moves a ready Canvas editor into a locked, chromeless auxiliary window.
- Minimizes the IDE only after the Canvas window is usable.
- Merges the live Canvas editor back into the IDE on exit.
- Handles concurrent entry, failures, and entry/exit races.
- Restricts the default IDE escape shortcuts while Canvas is active.
- Defines and tests the Positron/Assistant command seam.

Posit Assistant owns Canvas discovery and readiness. Without a Canvas-capable Assistant, Positron exposes no Open Canvas palette command.

Launch flags, startup behavior, and persistence are deferred to the next PR.

### Reviewer Q&A

**Why does this live in Positron?**  
Positron owns native windows, editor groups, focus, and presentation. Assistant owns Canvas content, identity, and readiness.

**How are commands restricted?**  
This is a narrow UX deny list for default shortcuts that reveal IDE surfaces, not a command sandbox. Other commands and custom user keybindings remain available.

**What happens without a Canvas-capable Assistant?**  
Assistant owns the user-facing Open Canvas command. If entry is invoked indirectly, the readiness handshake fails safely before any editor is moved or the IDE is minimized.

**What happens to the main IDE renderer?**  
It remains alive and is only minimized. Exit reveals it before moving or focusing editors.

**How is the live conversation preserved?**  
Entry moves the existing webview editor. Exit merges its group back into the IDE instead of closing or recreating it.

**How stable is the cross-repo interface?**  
The seam is limited to Canvas identity, ensure-ready, enter, exit, and active-state commands. Assistant can change Canvas internals while preserving those behaviors.

**Why are launch and persistence absent?**  
This layer contains only Canvas presentation. `--canvas`, startup restoration, and stored intent belong to the next PR.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

- `npm run build-check`
- Canvas, standalone-mode, and auxiliary-window Vitest suites: 36 tests passed
- No TypeScript errors in touched files
