### PR TITLE
Launch and restore workspaces in Canvas mode

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -739,6 +739,14 @@ export class CodeApplication extends Disposable {
 		// Open Windows
 		await appInstantiationService.invokeFunction(accessor => this.openFirstWindow(accessor, initialProtocolUrls));
 
+		// --- Start Positron ---
+		// `--canvas` applies to the launch, not the process: every later window
+		// is built from these same args, so a flag left set would outrank an
+		// explicit Canvas exit for the rest of the run. The startup windows
+		// have consumed it, so drop it here.
+		delete this.environmentMainService.args.canvas;
+		// --- End Positron ---
+
 		// Signal phase: after window open
 		this.lifecycleMainService.phase = LifecycleMainPhase.AfterWindowOpen;
 

--- a/src/vs/platform/environment/common/argv.ts
+++ b/src/vs/platform/environment/common/argv.ts
@@ -112,6 +112,9 @@ export interface NativeParsedArgs {
 	'open-url'?: boolean;
 	'skip-release-notes'?: boolean;
 	'skip-welcome'?: boolean;
+	// --- Start Positron ---
+	'canvas'?: boolean;
+	// --- End Positron ---
 	'disable-telemetry'?: boolean;
 	'export-default-configuration'?: string;
 	'export-policy-data'?: string;

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -187,6 +187,9 @@ export const OPTIONS: OptionDescriptions<Required<NativeParsedArgs>> = {
 	'logExtensionHostCommunication': { type: 'boolean' },
 	'skip-release-notes': { type: 'boolean' },
 	'skip-welcome': { type: 'boolean' },
+	// --- Start Positron ---
+	'canvas': { type: 'boolean', cat: 'o', description: localize('canvas', "Open Canvas as the only window instead of the full Positron interface.") },
+	// --- End Positron ---
 	'disable-telemetry': { type: 'boolean' },
 	'disable-updates': { type: 'boolean' },
 	'share-secrets-with-agents-app': { type: 'boolean' },

--- a/src/vs/platform/launch/common/positronCanvasLaunch.ts
+++ b/src/vs/platform/launch/common/positronCanvasLaunch.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/** What this decision reads: whether the window was opened with `--canvas`. */
+export interface ICanvasLaunchCandidate {
+	readonly config: { readonly canvas?: boolean } | undefined;
+}
+
+export interface ICanvasLaunchArgs {
+	readonly canvas?: boolean;
+}
+
+/** Assigns a `--canvas` launch to exactly one window configuration. */
+export class CanvasLaunchWindowAssigner {
+
+	private readonly assignedLaunches = new WeakSet<ICanvasLaunchArgs>();
+
+	assign(args: ICanvasLaunchArgs | undefined): boolean {
+		if (args?.canvas !== true || this.assignedLaunches.has(args)) {
+			return false;
+		}
+
+		this.assignedLaunches.add(args);
+		return true;
+	}
+}
+
+/**
+ * Which window, if any, should be told to open Canvas after a forwarded
+ * `--canvas` launch. Last active wins. If any used window carries the flag,
+ * no action is sent: it enters through the startup contribution, which waits
+ * for editor groups to restore; the action path would scan pre-restore groups
+ * and ask for a second panel.
+ */
+export function selectCanvasLaunchWindow<T extends ICanvasLaunchCandidate>(
+	usedWindows: readonly T[],
+	lastActiveWindow: T | undefined
+): T | undefined {
+	if (usedWindows.some(window => window.config?.canvas)) {
+		return undefined;
+	}
+
+	const candidate = lastActiveWindow && usedWindows.includes(lastActiveWindow)
+		? lastActiveWindow
+		: usedWindows.at(0);
+
+	return candidate;
+}

--- a/src/vs/platform/launch/electron-main/launchMainService.ts
+++ b/src/vs/platform/launch/electron-main/launchMainService.ts
@@ -7,6 +7,7 @@ import { app } from 'electron';
 import { coalesce } from '../../../base/common/arrays.js';
 // --- Start Positron ---
 import { CancellationToken } from '../../../base/common/cancellation.js';
+import { selectCanvasLaunchWindow } from '../common/positronCanvasLaunch.js';
 import { IAuxiliaryWindowsMainService } from '../../auxiliaryWindow/electron-main/auxiliaryWindows.js';
 import { IPositronStandaloneModeMainService } from '../../positronStandaloneMode/common/positronStandaloneMode.js';
 // --- End Positron ---
@@ -162,8 +163,10 @@ export class LaunchMainService implements ILaunchMainService {
 			// --- Start Positron ---
 			// A bare relaunch while standalone mode is engaged means "bring
 			// Positron forward", and the product surface is the engaged
-			// window; falling through would reveal the hidden IDE.
-			if (this.positronStandaloneModeMainService.isEngaged) {
+			// window; falling through would reveal the hidden IDE. A
+			// `--canvas` launch falls through on purpose: it re-enters Canvas
+			// explicitly below.
+			if (!args.canvas && this.positronStandaloneModeMainService.isEngaged) {
 				this.logService.info('[standalone mode] Focusing the engaged window for an argumentless launch');
 				const lastActiveAuxiliaryWindow = this.auxiliaryWindowsMainService.getLastActiveWindow();
 				if (lastActiveAuxiliaryWindow && !this.positronStandaloneModeMainService.isEngagedElsewhere(lastActiveAuxiliaryWindow.parentId)) {
@@ -231,8 +234,7 @@ export class LaunchMainService implements ILaunchMainService {
 		else {
 			// --- Start Positron ---
 			// An open landing behind an engaged standalone mode window would
-			// reveal the hidden IDE, so it is routed through
-			// `handleExternalOpen`.
+			// reveal the hidden IDE, so every file or folder open first exits it.
 			const openWithArguments = () => this.windowsMainService.open({
 				// --- End Positron ---
 				...baseConfig,
@@ -260,6 +262,26 @@ export class LaunchMainService implements ILaunchMainService {
 			usedWindows = opening ? await opening : [];
 			// --- End Positron ---
 		}
+
+		// --- Start Positron ---
+		// A reused renderer consumed its startup arguments on an earlier
+		// launch, so it learns about a forwarded `--canvas` as an action;
+		// newly opened windows carry the flag in their configuration instead
+		// (see `selectCanvasLaunchWindow`).
+		if (args.canvas) {
+			const canvasWindow = selectCanvasLaunchWindow(usedWindows, this.windowsMainService.getLastActiveWindow());
+			if (canvasWindow) {
+				canvasWindow.sendWhenReady('vscode:runAction', CancellationToken.None, {
+					// The palette action rather than `positron.canvas.enter`:
+					// it owns the failure notification, and `runAction`
+					// ignores return values.
+					id: 'positron.canvas.open',
+					from: 'menu',
+				});
+				canvasWindow.focus();
+			}
+		}
+		// --- End Positron ---
 
 		// If the other instance is waiting to be killed, we hook up a window listener if one window
 		// is being used and only then resolve the startup promise which will kill this second instance.

--- a/src/vs/platform/launch/test/common/positronCanvasLaunch.vitest.ts
+++ b/src/vs/platform/launch/test/common/positronCanvasLaunch.vitest.ts
@@ -1,0 +1,80 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { CanvasLaunchWindowAssigner, selectCanvasLaunchWindow } from '../../common/positronCanvasLaunch.js';
+
+function launchWindow(canvas?: boolean) {
+	return { config: { canvas } };
+}
+
+describe('CanvasLaunchWindowAssigner', () => {
+	it('assigns each Canvas launch to exactly one window', () => {
+		const assigner = new CanvasLaunchWindowAssigner();
+		const firstLaunch = { canvas: true };
+		const secondLaunch = { canvas: true };
+
+		expect([
+			assigner.assign(firstLaunch),
+			assigner.assign(firstLaunch),
+			assigner.assign(secondLaunch),
+			assigner.assign({}),
+			assigner.assign(undefined),
+		]).toEqual([true, false, true, false, false]);
+	});
+});
+
+describe('selectCanvasLaunchWindow', () => {
+	it('returns nothing when the launch opened no windows', () => {
+		expect(selectCanvasLaunchWindow([], undefined)).toBeUndefined();
+	});
+
+	it('targets a single reused window', () => {
+		const reused = launchWindow();
+
+		expect(selectCanvasLaunchWindow([reused], reused)).toBe(reused);
+	});
+
+	it('leaves a freshly opened window to its own startup entry', () => {
+		const fresh = launchWindow(true);
+
+		expect(selectCanvasLaunchWindow([fresh], fresh)).toBeUndefined();
+	});
+
+	it('targets only the last active window when several were used', () => {
+		const first = launchWindow();
+		const lastActive = launchWindow();
+
+		expect(selectCanvasLaunchWindow([first, lastActive], lastActive)).toBe(lastActive);
+	});
+
+	it('falls back to the first window when the last active one is unrelated', () => {
+		const used = launchWindow();
+		const unrelated = launchWindow();
+
+		expect(selectCanvasLaunchWindow([used], unrelated)).toBe(used);
+	});
+
+	it('sends nothing when the last active window already carries the flag', () => {
+		const reused = launchWindow();
+		const fresh = launchWindow(true);
+
+		expect(selectCanvasLaunchWindow([reused, fresh], fresh)).toBeUndefined();
+	});
+
+	it('sends nothing when any used window carries the flag', () => {
+		const fresh = launchWindow(true);
+		const reused = launchWindow();
+
+		expect(selectCanvasLaunchWindow([fresh, reused], reused)).toBeUndefined();
+	});
+
+	it('treats a window with no configuration yet as reused', () => {
+		const loading = { config: undefined };
+
+		expect(selectCanvasLaunchWindow([loading], loading)).toBe(loading);
+	});
+});

--- a/src/vs/platform/windows/electron-main/windowImpl.ts
+++ b/src/vs/platform/windows/electron-main/windowImpl.ts
@@ -1356,6 +1356,10 @@ export class CodeWindow extends BaseWindow implements ICodeWindow {
 		delete configuration.filesToWait;
 
 		// --- Start Positron ---
+		// CLI Canvas intent applies to the launch only; active Canvas mode is
+		// restored through workspace storage, so a later explicit exit sticks.
+		delete configuration.canvas;
+
 		// The engagement stamp describes open time; a reload happens later, so
 		// refresh it. Otherwise a window opened while the mode was engaged
 		// elsewhere would stay locked out after that engagement ended, for as

--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -53,6 +53,7 @@ import { IEditorOptions, ITextEditorOptions } from '../../editor/common/editor.j
 import { IUserDataProfile } from '../../userDataProfile/common/userDataProfile.js';
 import { IPolicyService } from '../../policy/common/policy.js';
 // --- Start Positron ---
+import { CanvasLaunchWindowAssigner } from '../../launch/common/positronCanvasLaunch.js';
 import { IPositronStandaloneModeMainService } from '../../positronStandaloneMode/common/positronStandaloneMode.js';
 // --- End Positron ---
 import { IUserDataProfilesMainService } from '../../userDataProfile/electron-main/userDataProfile.js';
@@ -213,6 +214,9 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 	readonly onDidTriggerSystemContextMenu = this._onDidTriggerSystemContextMenu.event;
 
 	private readonly windows = new Map<number, ICodeWindow>();
+	// --- Start Positron ---
+	private readonly canvasLaunchWindowAssigner = new CanvasLaunchWindowAssigner();
+	// --- End Positron ---
 
 	private readonly windowsStateHandler: WindowsStateHandler;
 
@@ -1548,6 +1552,10 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 			windowId: -1,	// Will be filled in by the window once loaded later
 
 			// --- Start Positron ---
+			// Restoring several windows reuses one CLI argument object. Only one
+			// may consume `--canvas`; standalone mode rejects all later entries.
+			canvas: this.canvasLaunchWindowAssigner.assign(options.cli ?? this.environmentMainService.args),
+
 			// For a reused window, "elsewhere" is relative to that window, so
 			// the holder is not locked out of its own re-entry. Refreshed on
 			// reload (CodeWindow#reload).

--- a/src/vs/workbench/contrib/positronCanvas/README.md
+++ b/src/vs/workbench/contrib/positronCanvas/README.md
@@ -27,12 +27,13 @@ Registered by Positron, called by the assistant:
 - `positron.canvas.isActive` - plain command; whether Canvas is the only
   visible surface. Gates the Canvas UI's "Open Positron" control.
 
-Registered by Positron for its own UI:
+Registered by Positron for its own UI and launch integration:
 
-- `positron.canvas.open` - Canvas editor-action command. Same service call as
-  `positron.canvas.enter`, but it owns the failure notification. Deliberately
-  absent from the palette: a Canvas-capable assistant owns discovery through
-  its `posit-assistant.openCanvas` command, so older assistants expose nothing.
+- `positron.canvas.open` - Canvas editor-action command, also targeted by a
+  forwarded `--canvas` launch. Same service call as `positron.canvas.enter`,
+  but it owns the failure notification. Deliberately absent from the palette:
+  a Canvas-capable assistant owns discovery through its
+  `posit-assistant.openCanvas` command, so older assistants expose nothing.
 
 Registered by the assistant, called by Positron:
 
@@ -41,3 +42,32 @@ Registered by the assistant, called by Positron:
   or failed. Positron invokes it before trusting even a restored panel.
 - View type `posit-assistant.canvas` - the whole of Canvas-panel identity;
   `PositronCanvasService` recognizes a Canvas by `providerId` alone.
+
+## Loading surfaces
+
+Two deliberate layers, not duplication:
+
+- Positron's startup curtain (`canvasStartupPresenter.ts`) covers the IDE
+  while Canvas starts. It speaks as Positron ("Canvas could not start") and
+  owns Retry / Open Positron / Quit, because it can reach the IDE and the
+  application lifecycle.
+- The assistant's webview bootstrap (static HTML, then
+  `CanvasBootstrapSurface`) covers the conversation loading inside the Canvas
+  window. It speaks as Canvas and owns Retry only.
+
+Keep the split: the curtain never talks about conversations, the webview
+never offers a way out of Canvas mode besides the top bar's Open Positron.
+
+## Workspace trust at boot
+
+The workspace trust startup prompt renders in the main window, which Canvas
+mode minimizes, and an undecided workspace holds back trust-gated extensions -
+including the authentication providers behind the Canvas model picker. Boot
+therefore waits for the trust decision behind the curtain before entering
+Canvas (`browser/positronCanvasTrustGate.ts`): the curtain's z-index sits
+below workbench dialogs, so the native prompt shows over it and Canvas
+proceeds on either answer. When no prompt is coming (trust disabled, already
+trusted, or suppressed by setting or an earlier answer), the gate stays out of
+the way and an untrusted Canvas is the assistant's restricted-mode surface to
+explain. Trust stays native workbench UI; it is deliberately not plumbed
+through the command seam.

--- a/src/vs/workbench/contrib/positronCanvas/browser/canvasStartupPresenter.ts
+++ b/src/vs/workbench/contrib/positronCanvas/browser/canvasStartupPresenter.ts
@@ -1,0 +1,238 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, DisposableStore, IDisposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { localize } from '../../../../nls.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { CanvasEntryOutcome } from '../common/positronCanvasMode.js';
+
+/**
+ * Appends one accessible Canvas curtain to a workbench container.
+ *
+ * The curtain covers the workbench visually, but the workbench's existing
+ * children stay in the accessibility tree and the tab order unless marked
+ * inert here. Call the returned `release` when the curtain comes down to
+ * restore them.
+ */
+function createCanvasCurtainElement(container: HTMLElement): { element: HTMLElement; release: () => void } {
+	const element = container.ownerDocument.createElement('div');
+	element.className = 'positron-canvas-startup-curtain';
+	element.setAttribute('role', 'status');
+	element.setAttribute('aria-live', 'polite');
+
+	const covered = Array.from(container.children) as HTMLElement[];
+	for (const sibling of covered) {
+		sibling.inert = true;
+	}
+
+	container.appendChild(element);
+	return {
+		element,
+		release: () => {
+			for (const sibling of covered) {
+				sibling.inert = false;
+			}
+		},
+	};
+}
+
+/** Replaces curtain content with the passive Canvas loading state. */
+function renderCanvasLoading(element: HTMLElement): void {
+	element.setAttribute('aria-busy', 'true');
+	const document = element.ownerDocument;
+	const card = document.createElement('div');
+	card.className = 'positron-canvas-startup-card';
+	const brand = document.createElement('div');
+	brand.className = 'positron-canvas-startup-brand';
+	brand.textContent = localize('positron.canvas.loadingBrand', "Canvas");
+	const spinner = document.createElement('div');
+	spinner.className = 'positron-canvas-startup-spinner';
+	spinner.setAttribute('role', 'progressbar');
+	spinner.setAttribute('aria-label', localize('positron.canvas.loadingLabel', "Loading Canvas"));
+	const message = document.createElement('p');
+	message.className = 'positron-canvas-startup-message';
+	message.textContent = localize('positron.canvas.loadingMessage', "Loading Canvas...");
+	card.append(brand, spinner, message);
+	element.replaceChildren(card);
+}
+
+/** One interactive Canvas loading and failure curtain. */
+class CanvasStartupCurtain extends Disposable {
+	private readonly actionDisposables = this._register(new MutableDisposable<DisposableStore>());
+	private readonly element: HTMLElement;
+	private readonly releaseSiblings: () => void;
+	private running = false;
+	private disposed = false;
+
+	constructor(
+		container: HTMLElement,
+		private readonly enter: () => Promise<CanvasEntryOutcome>,
+		private readonly recoverMainWindow: () => Promise<void>,
+		private readonly quit: () => Promise<void>,
+		private readonly logService: ILogService,
+		private readonly onDidDispose: () => void,
+	) {
+		super();
+		const { element, release } = createCanvasCurtainElement(container);
+		this.element = element;
+		this.releaseSiblings = release;
+		void this.start();
+	}
+
+	private async start(): Promise<void> {
+		if (this.running || this.disposed) {
+			return;
+		}
+		this.running = true;
+		this.showLoading();
+		try {
+			const outcome = await this.enter();
+			if (this.disposed) {
+				return;
+			}
+			if (outcome.entered) {
+				this.dispose();
+				return;
+			}
+			if (outcome.reason === 'superseded') {
+				// The IDE was asked for mid-entry and is being revealed; a
+				// failure card over it would demand a second "Open Positron"
+				// for a decision the user already made.
+				this.logService.info('[canvas] Standalone startup stood down: the IDE was requested while Canvas was opening');
+				this.dispose();
+				return;
+			}
+			this.logService.info(`[canvas] Standalone startup did not enter Canvas: ${outcome.reason}`);
+			this.showFailure(outcome.message);
+		} catch (error) {
+			if (this.disposed) {
+				return;
+			}
+			this.logService.error('[canvas] Standalone startup failed.', error);
+			this.showFailure(localize('positron.canvas.startupFailure', "Canvas could not be loaded. Try again, open Positron, or quit."));
+		} finally {
+			this.running = false;
+		}
+	}
+
+	private showLoading(): void {
+		// Loading is a passive announcement, not something the user acts on, so
+		// the curtain stays a polite status region.
+		this.element.setAttribute('role', 'status');
+		this.element.setAttribute('aria-live', 'polite');
+		this.element.removeAttribute('aria-modal');
+		this.element.removeAttribute('aria-labelledby');
+		renderCanvasLoading(this.element);
+		this.actionDisposables.clear();
+	}
+
+	private showFailure(detail: string): void {
+		this.element.setAttribute('aria-busy', 'false');
+		// Failure needs the user to act (Retry, Open Positron, Quit), so it is a
+		// dialog rather than a status update: screen readers move focus to it
+		// instead of merely announcing it.
+		this.element.setAttribute('role', 'dialog');
+		this.element.setAttribute('aria-modal', 'true');
+		this.element.removeAttribute('aria-live');
+		const document = this.element.ownerDocument;
+		const actions = new DisposableStore();
+		this.actionDisposables.value = actions;
+		const card = document.createElement('div');
+		card.className = 'positron-canvas-startup-card';
+		const brand = document.createElement('div');
+		brand.className = 'positron-canvas-startup-brand';
+		brand.id = 'positron-canvas-startup-failure-brand';
+		brand.textContent = localize('positron.canvas.failureBrand', "Canvas could not start");
+		this.element.setAttribute('aria-labelledby', brand.id);
+		const message = document.createElement('p');
+		message.className = 'positron-canvas-startup-message';
+		message.textContent = detail;
+		const buttons = document.createElement('div');
+		buttons.className = 'positron-canvas-startup-actions';
+		const retry = this.createButton(localize('positron.canvas.retry', "Retry"), true, () => void this.start(), actions);
+		const openPositron = this.createButton(localize('positron.canvas.openPositron', "Open Positron"), false, () => void this.openPositron(), actions);
+		const quit = this.createButton(localize('positron.canvas.quit', "Quit"), false, () => void this.quit(), actions);
+		buttons.append(retry, openPositron, quit);
+		card.append(brand, message, buttons);
+		this.element.replaceChildren(card);
+		retry.focus();
+	}
+
+	private async openPositron(): Promise<void> {
+		if (this.running || this.disposed) {
+			return;
+		}
+		this.running = true;
+		try {
+			await this.recoverMainWindow();
+			this.dispose();
+		} catch (error) {
+			this.logService.error('[canvas] Failed to recover the Positron window.', error);
+		} finally {
+			this.running = false;
+		}
+	}
+
+	private createButton(
+		label: string,
+		primary: boolean,
+		onClick: () => void,
+		disposables: DisposableStore,
+	): HTMLButtonElement {
+		const button = this.element.ownerDocument.createElement('button');
+		button.className = `positron-canvas-startup-button${primary ? ' primary' : ''}`;
+		button.textContent = label;
+		button.type = 'button';
+		button.addEventListener('click', onClick);
+		disposables.add({ dispose: () => button.removeEventListener('click', onClick) });
+		return button;
+	}
+
+	override dispose(): void {
+		if (this.disposed) {
+			return;
+		}
+		this.disposed = true;
+		this.releaseSiblings();
+		this.element.remove();
+		super.dispose();
+		this.onDidDispose();
+	}
+}
+
+/** Presents at most one Canvas startup curtain in a workbench window. */
+export class CanvasStartupPresenter extends Disposable {
+	private readonly currentCurtain = this._register(new MutableDisposable<IDisposable>());
+
+	constructor(
+		private readonly container: HTMLElement,
+		private readonly enter: () => Promise<CanvasEntryOutcome>,
+		private readonly recoverMainWindow: () => Promise<void>,
+		private readonly quit: () => Promise<void>,
+		private readonly logService: ILogService,
+	) {
+		super();
+	}
+
+	/** Presents loading, then enters Canvas behind the curtain. */
+	present(): void {
+		if (this.currentCurtain.value) {
+			return;
+		}
+		const curtain = new CanvasStartupCurtain(
+			this.container,
+			this.enter,
+			this.recoverMainWindow,
+			this.quit,
+			this.logService,
+			() => {
+				if (this.currentCurtain.value === curtain) {
+					this.currentCurtain.clearAndLeak();
+				}
+			},
+		);
+		this.currentCurtain.value = curtain;
+	}
+}

--- a/src/vs/workbench/contrib/positronCanvas/browser/positronCanvas.contribution.css
+++ b/src/vs/workbench/contrib/positronCanvas/browser/positronCanvas.contribution.css
@@ -1,0 +1,84 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.positron-canvas-startup-curtain {
+	position: fixed;
+	inset: 0;
+	/* Above notification toasts (2545) and quick input (2550), below workbench
+	dialogs (2575): the workspace trust prompt must stay visible and answerable
+	over the curtain during Canvas boot. */
+	z-index: 2560;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: var(--vscode-editor-background);
+	color: var(--vscode-foreground);
+	font-family: inherit;
+}
+
+.positron-canvas-startup-card {
+	display: flex;
+	width: min(420px, calc(100vw - 48px));
+	flex-direction: column;
+	align-items: center;
+	gap: 14px;
+	text-align: center;
+}
+
+.positron-canvas-startup-brand {
+	font-size: 24px;
+	font-weight: 650;
+	letter-spacing: -0.02em;
+}
+
+.positron-canvas-startup-message {
+	margin: 0;
+	color: var(--vscode-descriptionForeground);
+	font-size: 13px;
+	line-height: 1.5;
+}
+
+.positron-canvas-startup-spinner {
+	width: 24px;
+	height: 24px;
+	border: 3px solid var(--vscode-widget-border, var(--vscode-contrastBorder, transparent));
+	border-top-color: var(--vscode-progressBar-background);
+	border-radius: 50%;
+	animation: positron-canvas-spin 800ms linear infinite;
+}
+
+.positron-canvas-startup-actions {
+	display: flex;
+	gap: 8px;
+}
+
+.positron-canvas-startup-button {
+	min-width: 88px;
+	padding: 7px 14px;
+	border: 1px solid var(--vscode-button-secondaryBorder, var(--vscode-contrastBorder, transparent));
+	border-radius: 5px;
+	background: var(--vscode-button-secondaryBackground);
+	color: var(--vscode-button-secondaryForeground);
+	cursor: pointer;
+	font: inherit;
+}
+
+.positron-canvas-startup-button:hover {
+	background: var(--vscode-button-secondaryHoverBackground);
+}
+
+.positron-canvas-startup-button.primary {
+	border-color: var(--vscode-button-border, var(--vscode-contrastBorder, transparent));
+	background: var(--vscode-button-background);
+	color: var(--vscode-button-foreground);
+}
+
+.positron-canvas-startup-button.primary:hover {
+	background: var(--vscode-button-hoverBackground);
+}
+
+@keyframes positron-canvas-spin {
+	to { transform: rotate(360deg); }
+}

--- a/src/vs/workbench/contrib/positronCanvas/browser/positronCanvasTrustGate.ts
+++ b/src/vs/workbench/contrib/positronCanvas/browser/positronCanvasTrustGate.ts
@@ -1,0 +1,94 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { timeout } from '../../../../base/common/async.js';
+import { Event } from '../../../../base/common/event.js';
+import { localize } from '../../../../nls.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IStorageService, StorageScope } from '../../../../platform/storage/common/storage.js';
+import { isVirtualWorkspace } from '../../../../platform/workspace/common/virtualWorkspace.js';
+import { IWorkspaceContextService, WorkbenchState } from '../../../../platform/workspace/common/workspace.js';
+import { IWorkspaceTrustEnablementService, IWorkspaceTrustManagementService, IWorkspaceTrustRequestService } from '../../../../platform/workspace/common/workspaceTrust.js';
+import { IHostService } from '../../../services/host/browser/host.js';
+import { WORKSPACE_TRUST_STARTUP_PROMPT } from '../../../services/workspaces/common/workspaceTrust.js';
+
+/**
+ * Mirrors the file-local STARTUP_PROMPT_SHOWN_KEY in
+ * `workbench/contrib/workspace/browser/workspace.contribution.ts`. If the key
+ * drifts, the gate mispredicts "prompt is coming" and initiates its own trust
+ * request below - an extra dialog, never a hang.
+ */
+const STARTUP_PROMPT_SHOWN_KEY = 'workspace.trust.startupPrompt.shown';
+
+export interface CanvasTrustDecisionServices {
+	readonly configurationService: IConfigurationService;
+	readonly contextService: IWorkspaceContextService;
+	readonly hostService: IHostService;
+	readonly storageService: IStorageService;
+	readonly trustEnablementService: IWorkspaceTrustEnablementService;
+	readonly trustManagementService: IWorkspaceTrustManagementService;
+	readonly trustRequestService: IWorkspaceTrustRequestService;
+}
+
+/**
+ * Resolves once the workspace trust decision that gates extension activation
+ * has been made, or immediately when no decision is pending.
+ *
+ * Canvas boot must wait for this before it covers the IDE: the workspace
+ * trust startup prompt renders in the main window, which Canvas mode
+ * minimizes, and an undecided workspace keeps trust-gated extensions - the
+ * authentication providers behind the Canvas model picker among them - from
+ * activating. Deciding behind the startup curtain (whose z-index sits below
+ * workbench dialogs) keeps the prompt visible and answered before Canvas is
+ * the only surface.
+ *
+ * The conditions mirror `WorkspaceTrustUXHandler.showModalOnStart`: whenever
+ * that startup prompt is not coming (trust disabled, already trusted, prompt
+ * suppressed by setting or an earlier answer), the gate stays out of the way
+ * rather than second-guessing the user's startup-prompt preference - Canvas
+ * then enters untrusted and the assistant's restricted-mode surface owns the
+ * explanation. When the prompt is coming, the gate joins its coalesced
+ * request via `requestWorkspaceTrust`, resolving on either answer.
+ */
+export async function awaitWorkspaceTrustDecisionForCanvas(services: CanvasTrustDecisionServices): Promise<void> {
+	const { configurationService, contextService, hostService, storageService, trustEnablementService, trustManagementService, trustRequestService } = services;
+
+	await trustManagementService.workspaceTrustInitialized;
+
+	if (!trustEnablementService.isWorkspaceTrustEnabled()) {
+		return;
+	}
+	if (trustManagementService.isWorkspaceTrusted()) {
+		return;
+	}
+	if (!trustManagementService.canSetWorkspaceTrust()) {
+		return;
+	}
+	if (isVirtualWorkspace(contextService.getWorkspace())) {
+		return;
+	}
+	if (contextService.getWorkbenchState() === WorkbenchState.EMPTY) {
+		return;
+	}
+	const startupPrompt = configurationService.getValue<'always' | 'once' | 'never'>(WORKSPACE_TRUST_STARTUP_PROMPT);
+	if (startupPrompt === 'never') {
+		return;
+	}
+	if (startupPrompt === 'once' && storageService.getBoolean(STARTUP_PROMPT_SHOWN_KEY, StorageScope.WORKSPACE, false)) {
+		return;
+	}
+
+	// The startup prompt initiates only once the window has focus; wait for
+	// the same signal so the request to join exists. The yield lets the UX
+	// handler's earlier-registered focus listener initiate first.
+	if (!hostService.hasFocus) {
+		await Event.toPromise(Event.filter(hostService.onDidChangeFocus, focused => focused));
+	}
+	await timeout(0);
+
+	await trustRequestService.requestWorkspaceTrust({
+		message: localize('positron.canvas.trustRequest', "Canvas starts AI and runtime features that are disabled until you decide whether to trust this folder.")
+	});
+}

--- a/src/vs/workbench/contrib/positronCanvas/common/positronCanvasMode.ts
+++ b/src/vs/workbench/contrib/positronCanvas/common/positronCanvasMode.ts
@@ -4,7 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from '../../../../nls.js';
+import { ConfigurationScope, Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
+import { Registry } from '../../../../platform/registry/common/platform.js';
 
 // The `positron.canvas.*` commands and `CANVAS_WEBVIEW_VIEW_TYPE` are the seam
 // between Positron and Posit Assistant; ../README.md is the canonical
@@ -13,9 +15,64 @@ import { RawContextKey } from '../../../../platform/contextkey/common/contextkey
 export { CANVAS_WEBVIEW_VIEW_TYPE } from '../../../common/positronCanvasIdentity.js';
 
 /**
+ * Boots the workspace straight into Canvas mode. WINDOW-scoped so a workspace
+ * can be a Canvas workspace.
+ */
+export const CANVAS_OPEN_ON_STARTUP_KEY = 'canvas.openOnStartup';
+
+/**
+ * Remembers that this workspace was presenting Canvas when it last stopped, so
+ * a relaunch comes back into Canvas mode. Records what the user was in, never
+ * what they configured, so it is storage rather than a setting.
+ */
+export const CANVAS_MODE_STORAGE_KEY = 'positron.canvasMode.active';
+
+/** Everything the boot-into-Canvas decision reads. */
+export interface ICanvasStartSignals {
+	/** The `ai.enabled` main switch, read live. */
+	readonly aiEnabled: boolean;
+	/** Whether another window held standalone mode when this window opened. */
+	readonly engagedElsewhere: boolean;
+	/** Whether the window was opened with `--canvas`. */
+	readonly canvasFlag: boolean;
+	/**
+	 * Explicitly configured `canvas.openOnStartup`. Must come from
+	 * `inspect()`, not `getValue`: an explicit `false` must override a stored
+	 * intent, and `getValue` cannot tell explicit `false` apart from unset.
+	 */
+	readonly configuredOpenOnStartup: boolean | undefined;
+	/** Whether the workspace was in Canvas mode when it last stopped. */
+	readonly storedIntent: boolean;
+}
+
+/**
+ * Whether a window should boot straight into Canvas mode. Two window-level
+ * vetoes beat every entry signal: `ai.enabled` off (the in-service gate only
+ * fires behind the startup curtain, which would then show its failure card on
+ * every launch), and the mode engaged in another window (stored intent is
+ * shared per workspace, so a second window would otherwise re-enter on its
+ * own). Then precedence: a fresh `--canvas` always wins; an explicitly
+ * configured `canvas.openOnStartup` beats the stored intent in both
+ * directions; the stored intent then makes "relaunch into whatever you quit
+ * in" true.
+ */
+export function shouldStartInCanvasMode(signals: ICanvasStartSignals): boolean {
+	if (!signals.aiEnabled || signals.engagedElsewhere) {
+		return false;
+	}
+	if (signals.canvasFlag) {
+		return true;
+	}
+	if (signals.configuredOpenOnStartup !== undefined) {
+		return signals.configuredOpenOnStartup;
+	}
+	return signals.storedIntent;
+}
+
+/**
  * How an attempt to enter Canvas mode ended. Data rather than an exception so
- * every caller (palette action, the assistant over the command seam) can
- * present each non-entry case with the right copy.
+ * every caller (curtain, palette action, forwarded launch, the assistant over
+ * the command seam) can present each non-entry case with the right copy.
  */
 export type CanvasEntryOutcome =
 	| { readonly entered: true }
@@ -48,3 +105,19 @@ export const PositronCanvasModeActiveContext = new RawContextKey<boolean>('posit
  * knowing about Canvas.
  */
 export const CANVAS_EXIT_COMMAND_ID = 'positron.canvas.exit';
+
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
+	id: 'canvas',
+	title: localize('positron.canvas.title', "Canvas"),
+	type: 'object',
+	properties: {
+		[CANVAS_OPEN_ON_STARTUP_KEY]: {
+			type: 'boolean',
+			default: false,
+			description: localize('positron.canvas.openOnStartup', "Experimental. Open Canvas as the only window when this workspace starts, instead of the full Positron interface. Requires a Canvas-capable Posit Assistant."),
+			included: false,
+			tags: ['experimental'],
+			scope: ConfigurationScope.WINDOW
+		}
+	}
+});

--- a/src/vs/workbench/contrib/positronCanvas/electron-browser/positronCanvas.contribution.ts
+++ b/src/vs/workbench/contrib/positronCanvas/electron-browser/positronCanvas.contribution.ts
@@ -3,27 +3,51 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import '../browser/positronCanvas.contribution.css';
 import { Codicon } from '../../../../base/common/codicons.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
 import { localize2 } from '../../../../nls.js';
 import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
+import { IStorageService, StorageScope } from '../../../../platform/storage/common/storage.js';
+import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
+import { IWorkspaceTrustEnablementService, IWorkspaceTrustManagementService, IWorkspaceTrustRequestService } from '../../../../platform/workspace/common/workspaceTrust.js';
+import { prepareMoveCopyEditors } from '../../../browser/parts/editor/editor.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
+import { IAuxiliaryWindowService } from '../../../services/auxiliaryWindow/browser/auxiliaryWindowService.js';
+import { GroupsOrder, IEditorGroup, IEditorGroupsService } from '../../../services/editor/common/editorGroupsService.js';
+import { INativeWorkbenchEnvironmentService } from '../../../services/environment/electron-browser/environmentService.js';
+import { IHostService } from '../../../services/host/browser/host.js';
+import { IWorkbenchLayoutService, Parts } from '../../../services/layout/browser/layoutService.js';
 import { AI_ENABLED_KEY } from '../../positronAssistant/common/positronAIConfiguration.js';
+import { WebviewInput } from '../../webviewPanel/browser/webviewEditorInput.js';
+import { CanvasStartupPresenter } from '../browser/canvasStartupPresenter.js';
 import { registerCanvasCommandLockdown } from '../browser/positronCanvasCommandLockdown.js';
-import { CANVAS_EXIT_COMMAND_ID, CANVAS_WEBVIEW_VIEW_TYPE, PositronCanvasModeActiveContext } from '../common/positronCanvasMode.js';
+import { awaitWorkspaceTrustDecisionForCanvas } from '../browser/positronCanvasTrustGate.js';
+import { CANVAS_EXIT_COMMAND_ID, CANVAS_MODE_STORAGE_KEY, CANVAS_OPEN_ON_STARTUP_KEY, CANVAS_WEBVIEW_VIEW_TYPE, PositronCanvasModeActiveContext, shouldStartInCanvasMode } from '../common/positronCanvasMode.js';
 import { IPositronCanvasService, PositronCanvasService } from './positronCanvasService.js';
 
 registerSingleton(IPositronCanvasService, PositronCanvasService, InstantiationType.Delayed);
 
+export function mergeRestoredCanvasGroup(group: IEditorGroup, target: IEditorGroup, editorGroupsService: IEditorGroupsService): void {
+	group.lock(false);
+	if (!editorGroupsService.mergeGroup(group, target)) {
+		group.moveEditors(prepareMoveCopyEditors(group, group.editors.slice()), target);
+	}
+}
+
 /**
- * Enters Canvas mode from the Canvas editor's action bar. The assistant owns
- * palette discovery, so Positron stays dormant when the installed assistant
- * does not provide Canvas. Both entry points land on the same service call;
- * this action adds the presentation of not getting in.
+ * Enters Canvas mode from a forwarded `--canvas` launch and the Canvas editor's
+ * action bar. The assistant owns palette discovery, so Positron stays dormant
+ * when the installed assistant does not provide Canvas. Both entry points land
+ * on the same service call; this action adds the presentation of not getting in.
  */
 class OpenCanvasAction extends Action2 {
 
@@ -56,7 +80,8 @@ class OpenCanvasAction extends Action2 {
 		const notificationService = accessor.get(INotificationService);
 		const outcome = await canvasService.enter();
 		if (!outcome.entered) {
-			// A notification: the user asked from inside a working IDE.
+			// A notification, not the startup curtain: the user asked from
+			// inside a working IDE.
 			notificationService.error(outcome.message);
 		}
 	}
@@ -105,3 +130,138 @@ CommandsRegistry.registerCommand('positron.canvas.enter', (accessor: ServicesAcc
 CommandsRegistry.registerCommand('positron.canvas.isActive', (accessor: ServicesAccessor): boolean => {
 	return accessor.get(IPositronCanvasService).isActive;
 });
+
+/**
+ * Boots the window straight into Canvas mode, behind a curtain: without one
+ * the user watches the IDE paint and restore for seconds first, and a startup
+ * failure would have no usable IDE to notify into.
+ */
+class PositronCanvasStartupContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'positron.canvas.startup';
+
+	constructor(
+		@IPositronCanvasService private readonly canvasService: IPositronCanvasService,
+		@IAuxiliaryWindowService private readonly auxiliaryWindowService: IAuxiliaryWindowService,
+		@IEditorGroupsService private readonly editorGroupsService: IEditorGroupsService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@INativeWorkbenchEnvironmentService private readonly environmentService: INativeWorkbenchEnvironmentService,
+		@IStorageService private readonly storageService: IStorageService,
+		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
+		@IHostService private readonly hostService: IHostService,
+		@IWorkspaceContextService private readonly contextService: IWorkspaceContextService,
+		@IWorkspaceTrustEnablementService private readonly trustEnablementService: IWorkspaceTrustEnablementService,
+		@IWorkspaceTrustManagementService private readonly trustManagementService: IWorkspaceTrustManagementService,
+		@IWorkspaceTrustRequestService private readonly trustRequestService: IWorkspaceTrustRequestService,
+		@ILogService private readonly logService: ILogService
+	) {
+		super();
+
+		// Runs at BlockRestore to get in front of the workbench; a single
+		// await before the curtain element is in the DOM reintroduces the IDE
+		// flash it exists to prevent.
+		if (this.shouldBootIntoCanvasMode()) {
+			this.startInCanvasMode();
+		} else {
+			this.dropRestoredCanvasWindows();
+		}
+	}
+
+	/**
+	 * A window booting into the IDE must not come up with a live Canvas window
+	 * beside it, yet layout restore brings one back whenever the session quit
+	 * in Canvas mode. Merge such a window's Canvas back into the IDE as an
+	 * inline tab (the conversation survives; the emptied window closes
+	 * itself). Recognized by the `lockCompact` trait, which only Canvas mode
+	 * sets and which survives restore -- a Canvas panel the user popped out by
+	 * hand lacks the trait and is left where they put it.
+	 */
+	private dropRestoredCanvasWindows(): void {
+		(async () => {
+			await this.editorGroupsService.whenRestored;
+
+			let merged = false;
+			for (const part of this.editorGroupsService.parts) {
+				if (part === this.editorGroupsService.mainPart) {
+					continue;
+				}
+				if (this.auxiliaryWindowService.getWindow(part.windowId)?.createState().lockCompact !== true) {
+					continue;
+				}
+				const groups = part.getGroups(GroupsOrder.MOST_RECENTLY_ACTIVE);
+				const editors = groups.flatMap(group => group.editors);
+				if (editors.length === 0 || !editors.every(editor => editor instanceof WebviewInput && editor.providerId === CANVAS_WEBVIEW_VIEW_TYPE)) {
+					continue;
+				}
+				this.logService.info('[canvas] Merging a restored Canvas window back into the IDE: Canvas mode is not engaged');
+				for (const group of groups) {
+					mergeRestoredCanvasGroup(group, this.editorGroupsService.mainPart.activeGroup, this.editorGroupsService);
+				}
+				merged = true;
+			}
+
+			if (merged) {
+				// A merge into an auto-hidden editor area would leave the
+				// Canvas tab invisible.
+				this.layoutService.setPartHidden(false, Parts.EDITOR_PART);
+			}
+		})().catch(error => this.logService.error('[canvas] Could not check for restored Canvas windows', error));
+	}
+
+	/**
+	 * Flag: launch into Canvas once. Setting: a Canvas workspace. Stored
+	 * intent: the workspace was in Canvas mode when it last stopped.
+	 * `shouldStartInCanvasMode` owns their precedence; exit clears only the
+	 * stored intent, never the configuration.
+	 */
+	private shouldBootIntoCanvasMode(): boolean {
+		const setting = this.configurationService.inspect<boolean>(CANVAS_OPEN_ON_STARTUP_KEY);
+		return shouldStartInCanvasMode({
+			// Read live: `ai.enabled` toggles without a window reload.
+			aiEnabled: this.configurationService.getValue<boolean>(AI_ENABLED_KEY) !== false,
+			engagedElsewhere: this.environmentService.standaloneModeEngagedElsewhere,
+			canvasFlag: this.environmentService.args.canvas === true,
+			configuredOpenOnStartup: setting.policyValue ?? setting.workspaceFolderValue ?? setting.workspaceValue ?? setting.userValue ?? setting.applicationValue,
+			storedIntent: this.storageService.getBoolean(CANVAS_MODE_STORAGE_KEY, StorageScope.WORKSPACE, false)
+		});
+	}
+
+	private startInCanvasMode(): void {
+		const presenter = this._register(new CanvasStartupPresenter(
+			this.layoutService.mainContainer,
+			async () => {
+				// The workspace trust decision must land before Canvas covers
+				// the IDE: the trust startup prompt renders in this main
+				// window, which Canvas mode minimizes, and an undecided
+				// workspace holds back trust-gated extensions - including the
+				// auth providers behind the Canvas model picker. The prompt
+				// shows over the curtain (dialogs render above it) and the
+				// gate resolves on either answer.
+				await awaitWorkspaceTrustDecisionForCanvas({
+					configurationService: this.configurationService,
+					contextService: this.contextService,
+					hostService: this.hostService,
+					storageService: this.storageService,
+					trustEnablementService: this.trustEnablementService,
+					trustManagementService: this.trustManagementService,
+					trustRequestService: this.trustRequestService
+				});
+				// Wait for editors, not merely the restored phase (which races
+				// a short timeout): entering early would find no restored
+				// Canvas panel and create a second one.
+				await this.editorGroupsService.whenRestored;
+				return this.canvasService.enter();
+			},
+			// Exit is the whole of "Open Positron": it clears the durable
+			// intent, and its IDE-restoring steps are safe no-ops when Canvas
+			// never came up.
+			() => this.canvasService.exit().then(() => undefined),
+			() => this.hostService.shutdown(),
+			this.logService
+		));
+
+		presenter.present();
+	}
+}
+
+registerWorkbenchContribution2(PositronCanvasStartupContribution.ID, PositronCanvasStartupContribution, WorkbenchPhase.BlockRestore);

--- a/src/vs/workbench/contrib/positronCanvas/electron-browser/positronCanvasService.ts
+++ b/src/vs/workbench/contrib/positronCanvas/electron-browser/positronCanvasService.ts
@@ -18,15 +18,17 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { INativeHostService } from '../../../../platform/native/common/native.js';
 import { POSITRON_STANDALONE_MODE_CHANNEL_NAME } from '../../../../platform/positronStandaloneMode/common/positronStandaloneMode.js';
 import { PositronStandaloneModeChannelClient } from '../../../../platform/positronStandaloneMode/common/positronStandaloneModeIpc.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { prepareMoveCopyEditors } from '../../../browser/parts/editor/editor.js';
 import { EditorsOrder } from '../../../common/editor.js';
 import { IAuxiliaryEditorPart, IEditorGroup, IEditorGroupsService, IEditorPart, GroupsOrder } from '../../../services/editor/common/editorGroupsService.js';
 import { IHostService } from '../../../services/host/browser/host.js';
 import { IWorkbenchLayoutService, Parts } from '../../../services/layout/browser/layoutService.js';
+import { ILifecycleService } from '../../../services/lifecycle/common/lifecycle.js';
 import { AI_ENABLED_KEY } from '../../positronAssistant/common/positronAIConfiguration.js';
 import { dedicatedWindowOptions } from '../../positronEditorActions/browser/positronDedicatedWindow.js';
 import { WebviewInput } from '../../webviewPanel/browser/webviewEditorInput.js';
-import { CANVAS_EXIT_COMMAND_ID, CANVAS_WEBVIEW_VIEW_TYPE, CanvasEntryOutcome, PositronCanvasModeActiveContext } from '../common/positronCanvasMode.js';
+import { CANVAS_EXIT_COMMAND_ID, CANVAS_MODE_STORAGE_KEY, CANVAS_WEBVIEW_VIEW_TYPE, CanvasEntryOutcome, PositronCanvasModeActiveContext } from '../common/positronCanvasMode.js';
 
 /**
  * Posit Assistant's command to open a Canvas panel as an ordinary editor --
@@ -53,8 +55,8 @@ export interface IPositronCanvasService {
 	 * window, IDE window out of the way. Absorbs every starting position and
 	 * concurrent callers; never leaves the user with no visible window.
 	 * Resolves an outcome rather than throwing for known non-entry cases,
-	 * because how a non-entry is shown depends on who asked (palette
-	 * notification or the assistant across the command seam).
+	 * because how a non-entry is shown depends on who asked (startup curtain,
+	 * palette notification, or the assistant across the command seam).
 	 */
 	enter(): Promise<CanvasEntryOutcome>;
 
@@ -121,6 +123,8 @@ export class PositronCanvasService extends Disposable implements IPositronCanvas
 		@INativeHostService private readonly nativeHostService: INativeHostService,
 		@IHostService private readonly hostService: IHostService,
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
+		@IStorageService private readonly storageService: IStorageService,
+		@ILifecycleService private readonly lifecycleService: ILifecycleService,
 		@ILogService private readonly logService: ILogService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IMainProcessService mainProcessService: IMainProcessService
@@ -181,7 +185,8 @@ export class PositronCanvasService extends Disposable implements IPositronCanvas
 	}
 
 	private async doEnter(): Promise<CanvasEntryOutcome> {
-		// Read live: `ai.enabled` toggles without a reload.
+		// Read live: `ai.enabled` toggles without a reload, and it must hold
+		// even for a workspace configured to boot into Canvas.
 		if (this.configurationService.getValue<boolean>(AI_ENABLED_KEY) === false) {
 			this.logService.info('[canvas] Not entering Canvas mode: ai.enabled is false');
 			return {
@@ -299,6 +304,10 @@ export class PositronCanvasService extends Disposable implements IPositronCanvas
 
 		// Read before `stopPresenting()`, which is what makes it false.
 		const wasActive = this.canvasWindow.value !== undefined;
+
+		// Unconditional: exit means "I want the IDE" in every sense,
+		// including what this workspace launches into next time.
+		this.setCanvasModeIntent(false);
 
 		// Stop presenting first: it drops the listener that treats the Canvas
 		// window going away as something to recover from. The claim goes back
@@ -454,12 +463,20 @@ export class PositronCanvasService extends Disposable implements IPositronCanvas
 			this.stopPresenting();
 			this.releaseEngagement();
 
+			// The aux part is disposed during an ordinary quit too, and
+			// clearing there would erase the very intent that "quit in
+			// Canvas, relaunch into Canvas" is made of.
+			if (!this.lifecycleService.willShutdown) {
+				this.setCanvasModeIntent(false);
+			}
+
 			void this.revealIdeWindow();
 		}));
 
 		this.canvasWindow.value = disposables;
 		this.canvasGroup = group;
 		this.modeActiveContext.set(true);
+		this.setCanvasModeIntent(true);
 
 		group.focus();
 	}
@@ -475,10 +492,24 @@ export class PositronCanvasService extends Disposable implements IPositronCanvas
 		this.modeActiveContext.set(false);
 	}
 
+	/**
+	 * Records, or forgets, that this workspace should come back into Canvas
+	 * mode. Tracks what is on screen, not configuration: set while presenting,
+	 * cleared by every way of leaving except application shutdown.
+	 * MACHINE-targeted because it describes this installation's window state.
+	 */
+	private setCanvasModeIntent(active: boolean): void {
+		if (active) {
+			this.storageService.store(CANVAS_MODE_STORAGE_KEY, true, StorageScope.WORKSPACE, StorageTarget.MACHINE);
+		} else {
+			this.storageService.remove(CANVAS_MODE_STORAGE_KEY, StorageScope.WORKSPACE);
+		}
+	}
+
 	private async hideIdeWindow(): Promise<void> {
-		// Unguarded, unlike `revealIdeWindow()`: re-entry can focus
-		// (un-minimize) the IDE window on its way in, so skipping "already
-		// hidden" work would leave it behind Canvas.
+		// Unguarded, unlike `revealIdeWindow()`: a forwarded `--canvas`
+		// re-entry can focus (un-minimize) the IDE window on its way in, so
+		// skipping "already hidden" work would leave it behind Canvas.
 		this.ideWindowHidden = true;
 
 		// Minimize rather than hide: a minimized window is still listed by

--- a/src/vs/workbench/contrib/positronCanvas/test/browser/canvasStartupPresenter.vitest.ts
+++ b/src/vs/workbench/contrib/positronCanvas/test/browser/canvasStartupPresenter.vitest.ts
@@ -1,0 +1,205 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+/// <reference types="@testing-library/jest-dom/vitest" />
+
+// eslint-disable-next-line local/code-import-patterns -- Semantic DOM queries for a non-React presenter.
+import { within } from '@testing-library/dom';
+// eslint-disable-next-line local/code-import-patterns -- User events exercise the presenter's native DOM buttons.
+import { userEvent } from '@testing-library/user-event';
+import { DeferredPromise } from '../../../../../base/common/async.js';
+import { toDisposable } from '../../../../../base/common/lifecycle.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { ensureNoLeakedDisposables } from '../../../../../test/vitest/vitestUtils.js';
+import { CanvasStartupPresenter } from '../../browser/canvasStartupPresenter.js';
+import { CanvasEntryOutcome } from '../../common/positronCanvasMode.js';
+
+const ENTERED: CanvasEntryOutcome = { entered: true };
+const AI_DISABLED: CanvasEntryOutcome = {
+	entered: false,
+	reason: 'ai-disabled',
+	message: 'Canvas is unavailable because AI features are disabled.',
+};
+
+describe('CanvasStartupPresenter', () => {
+	const disposables = ensureNoLeakedDisposables();
+
+	/** Creates an attached DOM root compatible with jest-dom presence checks. */
+	function createContainer(): HTMLElement {
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		disposables.add(toDisposable(() => container.remove()));
+		return container;
+	}
+
+	/** Adds a stand-in for the covered workbench so inert handling is checkable. */
+	function addWorkbenchSibling(container: HTMLElement): HTMLElement {
+		const sibling = document.createElement('div');
+		sibling.textContent = 'workbench';
+		container.appendChild(sibling);
+		return sibling;
+	}
+
+	function createPresenter(container: HTMLElement, callbacks: {
+		enter: () => Promise<CanvasEntryOutcome>;
+		recoverMainWindow?: () => Promise<void>;
+		quit?: () => Promise<void>;
+		logError?: (message: string, error: unknown) => void;
+	}): CanvasStartupPresenter {
+		return disposables.add(new CanvasStartupPresenter(
+			container,
+			callbacks.enter,
+			callbacks.recoverMainWindow ?? vi.fn().mockResolvedValue(undefined),
+			callbacks.quit ?? vi.fn().mockResolvedValue(undefined),
+			stubInterface<ILogService>({ error: callbacks.logError ?? vi.fn(), info: vi.fn() }),
+		));
+	}
+
+	// The point of the curtain: it has to be on screen before the workbench gets
+	// a chance to paint, so nothing about presenting loading may be deferred.
+	it('shows one loading curtain synchronously and enters behind it', () => {
+		const entry = new DeferredPromise<CanvasEntryOutcome>();
+		const enter = vi.fn().mockReturnValue(entry.p);
+		const container = createContainer();
+		const presenter = createPresenter(container, { enter });
+
+		presenter.present();
+		presenter.present();
+
+		const curtain = within(container).getByRole('status');
+		expect(curtain).toHaveAttribute('aria-busy', 'true');
+		expect(within(curtain).getByRole('progressbar', { name: 'Loading Canvas' })).toBeInTheDocument();
+		expect(within(container).getAllByRole('status')).toHaveLength(1);
+		expect(enter).toHaveBeenCalledTimes(1);
+	});
+
+	it('takes the curtain down once Canvas is being presented', async () => {
+		const container = createContainer();
+		const presenter = createPresenter(container, { enter: vi.fn().mockResolvedValue(ENTERED) });
+
+		presenter.present();
+
+		await vi.waitFor(() => expect(within(container).queryByRole('status')).not.toBeInTheDocument());
+	});
+
+	// The curtain covering the workbench visually isn't enough: the covered
+	// elements must also drop out of the tab order and accessibility tree while
+	// it's up, and rejoin once it comes down.
+	it('marks the covered workbench inert while the curtain is up, then releases it', async () => {
+		const container = createContainer();
+		const sibling = addWorkbenchSibling(container);
+		const presenter = createPresenter(container, { enter: vi.fn().mockResolvedValue(ENTERED) });
+
+		presenter.present();
+		expect(sibling.inert).toBe(true);
+
+		await vi.waitFor(() => expect(within(container).queryByRole('status')).not.toBeInTheDocument());
+		expect(sibling.inert).toBe(false);
+	});
+
+	it('stands down without a dialog when the entry was superseded', async () => {
+		const container = createContainer();
+		const presenter = createPresenter(container, {
+			enter: vi.fn().mockResolvedValue({
+				entered: false,
+				reason: 'superseded',
+				message: 'Canvas stopped opening because Positron was asked for the IDE.'
+			} satisfies CanvasEntryOutcome)
+		});
+
+		presenter.present();
+
+		// The user already chose the IDE; a failure card demanding a second
+		// choice would be the curtain arguing with them.
+		await vi.waitFor(() => expect(within(container).queryByRole('status')).not.toBeInTheDocument());
+		expect(within(container).queryByRole('alertdialog')).not.toBeInTheDocument();
+	});
+
+	it('presents a non-entry outcome as a dialog focused on Retry', async () => {
+		const container = createContainer();
+		const presenter = createPresenter(container, { enter: vi.fn().mockResolvedValue(AI_DISABLED) });
+
+		presenter.present();
+
+		// The curtain starts as a status region (loading); once it needs the user
+		// to act, it becomes a dialog, so it's found by its new role here.
+		const curtain = await vi.waitFor(() => within(container).getByRole('dialog'));
+		expect(within(curtain).getAllByRole('button')).toHaveLength(3);
+		expect(curtain).toHaveAttribute('aria-busy', 'false');
+		expect(curtain).toHaveAccessibleName('Canvas could not start');
+		expect(within(curtain).getByText('Canvas is unavailable because AI features are disabled.')).toBeInTheDocument();
+		expect(within(curtain).getByRole('button', { name: 'Retry' })).toHaveFocus();
+		expect(within(curtain).getByRole('button', { name: 'Open Positron' })).toBeInTheDocument();
+		expect(within(curtain).getByRole('button', { name: 'Quit' })).toBeInTheDocument();
+	});
+
+	it('keeps a thrown entry failure behind the curtain', async () => {
+		const error = new Error('entry failed');
+		const logError = vi.fn();
+		const container = createContainer();
+		const presenter = createPresenter(container, { enter: vi.fn().mockRejectedValue(error), logError });
+
+		presenter.present();
+
+		const curtain = within(container).getByRole('status');
+		await vi.waitFor(() => expect(within(curtain).getAllByRole('button')).toHaveLength(3));
+		expect(within(container).getAllByRole('dialog')).toHaveLength(1);
+		expect(within(curtain).getByText('Canvas could not be loaded. Try again, open Positron, or quit.')).toBeInTheDocument();
+		expect(within(curtain).getByRole('button', { name: 'Retry' })).toHaveFocus();
+		expect(logError).toHaveBeenCalledWith('[canvas] Standalone startup failed.', error);
+	});
+
+	it('returns to loading and enters again when Retry is clicked', async () => {
+		const firstEntry = new DeferredPromise<CanvasEntryOutcome>();
+		const retryEntry = new DeferredPromise<CanvasEntryOutcome>();
+		const enter = vi.fn()
+			.mockReturnValueOnce(firstEntry.p)
+			.mockReturnValueOnce(retryEntry.p);
+		const container = createContainer();
+		const presenter = createPresenter(container, { enter });
+
+		presenter.present();
+		const curtain = within(container).getByRole('status');
+		await firstEntry.complete(AI_DISABLED);
+		await vi.waitFor(() => expect(within(curtain).getAllByRole('button')).toHaveLength(3));
+
+		const user = userEvent.setup();
+		await user.click(within(curtain).getByRole('button', { name: 'Retry' }));
+
+		await vi.waitFor(() => expect(enter).toHaveBeenCalledTimes(2));
+		expect(curtain).toHaveAttribute('aria-busy', 'true');
+		expect(within(curtain).queryAllByRole('button')).toHaveLength(0);
+
+		await retryEntry.complete(ENTERED);
+		await vi.waitFor(() => expect(within(container).queryByRole('status')).not.toBeInTheDocument());
+	});
+
+	it('hands Open Positron and Quit to their callbacks', async () => {
+		const recoverMainWindow = vi.fn().mockResolvedValue(undefined);
+		const quit = vi.fn().mockResolvedValue(undefined);
+		const container = createContainer();
+		const presenter = createPresenter(container, {
+			enter: vi.fn().mockResolvedValue(AI_DISABLED),
+			recoverMainWindow,
+			quit,
+		});
+
+		presenter.present();
+		const curtain = within(container).getByRole('status');
+		await vi.waitFor(() => expect(within(curtain).getAllByRole('button')).toHaveLength(3));
+
+		const user = userEvent.setup();
+		await user.click(within(curtain).getByRole('button', { name: 'Quit' }));
+		expect(quit).toHaveBeenCalledTimes(1);
+
+		await user.click(within(curtain).getByRole('button', { name: 'Open Positron' }));
+		expect(recoverMainWindow).toHaveBeenCalledTimes(1);
+		// Recovering leaves the IDE on screen, so the curtain has nothing left to
+		// cover.
+		await vi.waitFor(() => expect(within(container).queryByRole('status')).not.toBeInTheDocument());
+	});
+});

--- a/src/vs/workbench/contrib/positronCanvas/test/browser/positronCanvasTrustGate.vitest.ts
+++ b/src/vs/workbench/contrib/positronCanvas/test/browser/positronCanvasTrustGate.vitest.ts
@@ -1,0 +1,117 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { Emitter } from '../../../../../base/common/event.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IStorageService } from '../../../../../platform/storage/common/storage.js';
+import { IWorkspaceContextService, IWorkspace, WorkbenchState } from '../../../../../platform/workspace/common/workspace.js';
+import { IWorkspaceTrustEnablementService, IWorkspaceTrustManagementService, IWorkspaceTrustRequestService } from '../../../../../platform/workspace/common/workspaceTrust.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { ensureNoLeakedDisposables } from '../../../../../test/vitest/vitestUtils.js';
+import { IHostService } from '../../../../services/host/browser/host.js';
+import { awaitWorkspaceTrustDecisionForCanvas, CanvasTrustDecisionServices } from '../../browser/positronCanvasTrustGate.js';
+
+describe('awaitWorkspaceTrustDecisionForCanvas', () => {
+	const disposables = ensureNoLeakedDisposables();
+
+	interface Overrides {
+		trustEnabled?: boolean;
+		trusted?: boolean;
+		canSetTrust?: boolean;
+		workbenchState?: WorkbenchState;
+		startupPrompt?: 'always' | 'once' | 'never';
+		promptShown?: boolean;
+		hasFocus?: boolean;
+		onDidChangeFocus?: Emitter<boolean>;
+		requestWorkspaceTrust?: () => Promise<boolean | undefined>;
+	}
+
+	function createServices(overrides: Overrides = {}): CanvasTrustDecisionServices & { requestSpy: ReturnType<typeof vi.fn> } {
+		const requestSpy = vi.fn(overrides.requestWorkspaceTrust ?? (() => Promise.resolve(true)));
+		const workspace = stubInterface<IWorkspace>({
+			folders: [{ uri: URI.file('/workspace'), name: 'workspace', index: 0, toResource: (relative: string) => URI.file(`/workspace/${relative}`) }],
+			configuration: null,
+		});
+		return {
+			configurationService: stubInterface<IConfigurationService>({
+				getValue: vi.fn().mockReturnValue(overrides.startupPrompt ?? 'once'),
+			}),
+			contextService: stubInterface<IWorkspaceContextService>({
+				getWorkspace: () => workspace,
+				getWorkbenchState: () => overrides.workbenchState ?? WorkbenchState.FOLDER,
+			}),
+			hostService: stubInterface<IHostService>({
+				hasFocus: overrides.hasFocus ?? true,
+				onDidChangeFocus: (overrides.onDidChangeFocus ?? disposables.add(new Emitter<boolean>())).event,
+			}),
+			storageService: stubInterface<IStorageService>({
+				getBoolean: vi.fn().mockReturnValue(overrides.promptShown ?? false),
+			}),
+			trustEnablementService: stubInterface<IWorkspaceTrustEnablementService>({
+				isWorkspaceTrustEnabled: () => overrides.trustEnabled ?? true,
+			}),
+			trustManagementService: stubInterface<IWorkspaceTrustManagementService>({
+				workspaceTrustInitialized: Promise.resolve(),
+				isWorkspaceTrusted: () => overrides.trusted ?? false,
+				canSetWorkspaceTrust: () => overrides.canSetTrust ?? true,
+			}),
+			trustRequestService: stubInterface<IWorkspaceTrustRequestService>({
+				requestWorkspaceTrust: requestSpy,
+			}),
+			requestSpy,
+		};
+	}
+
+	it.each([
+		['trust is disabled', { trustEnabled: false }],
+		['the workspace is already trusted', { trusted: true }],
+		['trust cannot be set', { canSetTrust: false }],
+		['the window is empty', { workbenchState: WorkbenchState.EMPTY }],
+		['the startup prompt is configured to never show', { startupPrompt: 'never' as const }],
+		['a once-only startup prompt was already answered', { startupPrompt: 'once' as const, promptShown: true }],
+	])('resolves without a trust request when %s', async (_name, overrides) => {
+		const services = createServices(overrides);
+
+		await awaitWorkspaceTrustDecisionForCanvas(services);
+
+		expect(services.requestSpy).not.toHaveBeenCalled();
+	});
+
+	it('joins the pending trust request and resolves with its answer', async () => {
+		let resolveRequest!: (trusted: boolean | undefined) => void;
+		const services = createServices({
+			requestWorkspaceTrust: () => new Promise<boolean | undefined>(resolve => { resolveRequest = resolve; }),
+		});
+
+		let settled = false;
+		const gate = awaitWorkspaceTrustDecisionForCanvas(services).then(() => { settled = true; });
+
+		await vi.waitFor(() => expect(services.requestSpy).toHaveBeenCalledTimes(1));
+		expect(settled).toBe(false);
+
+		resolveRequest(undefined);
+		await gate;
+		expect(settled).toBe(true);
+	});
+
+	it('waits for window focus before requesting trust', async () => {
+		const focusEmitter = disposables.add(new Emitter<boolean>());
+		const services = createServices({ hasFocus: false, onDidChangeFocus: focusEmitter });
+
+		const gate = awaitWorkspaceTrustDecisionForCanvas(services);
+
+		// The gate is parked on the focus event, not a timer, so a couple of
+		// macrotask flushes deterministically shows it has not requested yet.
+		await new Promise(resolve => setTimeout(resolve, 2));
+		expect(services.requestSpy).not.toHaveBeenCalled();
+
+		focusEmitter.fire(true);
+		await gate;
+		expect(services.requestSpy).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/vs/workbench/contrib/positronCanvas/test/common/positronCanvasMode.vitest.ts
+++ b/src/vs/workbench/contrib/positronCanvas/test/common/positronCanvasMode.vitest.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { ConfigurationModelParser } from '../../../../../platform/configuration/common/configurationModels.js';
+import { ConfigurationScope, Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../../platform/configuration/common/configurationRegistry.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { Registry } from '../../../../../platform/registry/common/platform.js';
+import { CANVAS_OPEN_ON_STARTUP_KEY, ICanvasStartSignals, shouldStartInCanvasMode } from '../../common/positronCanvasMode.js';
+
+function signals(overrides: Partial<ICanvasStartSignals>): ICanvasStartSignals {
+	return {
+		aiEnabled: true,
+		engagedElsewhere: false,
+		canvasFlag: false,
+		configuredOpenOnStartup: undefined,
+		storedIntent: false,
+		...overrides
+	};
+}
+
+describe('shouldStartInCanvasMode', () => {
+
+	it('never starts when ai.enabled is false, regardless of other signals', () => {
+		expect(shouldStartInCanvasMode(signals({ aiEnabled: false, canvasFlag: true, configuredOpenOnStartup: true, storedIntent: true }))).toBe(false);
+		expect(shouldStartInCanvasMode(signals({ aiEnabled: false, configuredOpenOnStartup: true }))).toBe(false);
+		expect(shouldStartInCanvasMode(signals({ aiEnabled: false, storedIntent: true }))).toBe(false);
+	});
+
+	it('never starts when the mode is engaged in another window, regardless of other signals', () => {
+		expect(shouldStartInCanvasMode(signals({ engagedElsewhere: true, canvasFlag: true, configuredOpenOnStartup: true, storedIntent: true }))).toBe(false);
+		expect(shouldStartInCanvasMode(signals({ engagedElsewhere: true, configuredOpenOnStartup: true }))).toBe(false);
+		expect(shouldStartInCanvasMode(signals({ engagedElsewhere: true, storedIntent: true }))).toBe(false);
+	});
+
+	it('honors a fresh --canvas unconditionally once the vetoes pass', () => {
+		expect(shouldStartInCanvasMode(signals({ canvasFlag: true, configuredOpenOnStartup: false }))).toBe(true);
+	});
+
+	it('lets an explicitly configured setting beat the stored intent in both directions', () => {
+		// Configuration is what the user asked for; storage is only what they
+		// last did.
+		expect(shouldStartInCanvasMode(signals({ configuredOpenOnStartup: false, storedIntent: true }))).toBe(false);
+		expect(shouldStartInCanvasMode(signals({ configuredOpenOnStartup: true, storedIntent: false }))).toBe(true);
+	});
+
+	it('relaunches into whatever the workspace quit in when nothing is configured', () => {
+		expect(shouldStartInCanvasMode(signals({ storedIntent: true }))).toBe(true);
+		expect(shouldStartInCanvasMode(signals({ storedIntent: false }))).toBe(false);
+	});
+});
+
+describe('canvas.openOnStartup configuration', () => {
+
+	it('is hidden, experimental, and still readable from settings.json', () => {
+		const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
+		const property = registry.getExcludedConfigurationProperties()[CANVAS_OPEN_ON_STARTUP_KEY];
+
+		expect(registry.getConfigurationProperties()[CANVAS_OPEN_ON_STARTUP_KEY]).toBeUndefined();
+		expect(property).toMatchObject({
+			included: false,
+			tags: ['experimental'],
+			scope: ConfigurationScope.WINDOW,
+		});
+
+		const parser = new ConfigurationModelParser('canvas settings', new NullLogService());
+		parser.parse(JSON.stringify({ [CANVAS_OPEN_ON_STARTUP_KEY]: true }), { scopes: [ConfigurationScope.WINDOW] });
+
+		expect(parser.configurationModel.getValue(CANVAS_OPEN_ON_STARTUP_KEY)).toBe(true);
+	});
+});

--- a/src/vs/workbench/contrib/positronCanvas/test/electron-browser/positronCanvasContribution.vitest.ts
+++ b/src/vs/workbench/contrib/positronCanvas/test/electron-browser/positronCanvasContribution.vitest.ts
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { URI } from '../../../../../base/common/uri.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { ensureNoLeakedDisposables } from '../../../../../test/vitest/vitestUtils.js';
+import { IEditorGroup, IEditorGroupsService } from '../../../../services/editor/common/editorGroupsService.js';
+import { TestEditorInput } from '../../../../test/browser/workbenchTestServices.js';
+import { mergeRestoredCanvasGroup } from '../../electron-browser/positronCanvas.contribution.js';
+
+describe('mergeRestoredCanvasGroup', () => {
+	const disposables = ensureNoLeakedDisposables();
+
+	function createGroup() {
+		const editor = disposables.add(new TestEditorInput(URI.file('/canvas'), 'canvas'));
+		return stubInterface<IEditorGroup>({
+			editors: [editor],
+			getIndexOfEditor: vi.fn().mockReturnValue(0),
+			isActive: vi.fn().mockReturnValue(true),
+			isSticky: vi.fn().mockReturnValue(false),
+			lock: vi.fn(),
+			moveEditors: vi.fn().mockReturnValue(true),
+		});
+	}
+
+	it('unlocks and merges the group', () => {
+		const group = createGroup();
+		const target = stubInterface<IEditorGroup>();
+		const editorGroupsService = stubInterface<IEditorGroupsService>({ mergeGroup: vi.fn().mockReturnValue(true) });
+
+		mergeRestoredCanvasGroup(group, target, editorGroupsService);
+
+		expect(group.lock).toHaveBeenCalledWith(false);
+		expect(editorGroupsService.mergeGroup).toHaveBeenCalledWith(group, target);
+		expect(group.moveEditors).not.toHaveBeenCalled();
+	});
+
+	it('moves the editors when the group cannot be merged', () => {
+		const group = createGroup();
+		const target = stubInterface<IEditorGroup>();
+		const editorGroupsService = stubInterface<IEditorGroupsService>({ mergeGroup: vi.fn().mockReturnValue(false) });
+
+		mergeRestoredCanvasGroup(group, target, editorGroupsService);
+
+		expect(group.moveEditors).toHaveBeenCalledWith([
+			{
+				editor: group.editors[0],
+				options: { inactive: false, pinned: true, preserveFocus: undefined, sticky: false },
+			},
+		], target);
+	});
+});

--- a/src/vs/workbench/contrib/positronCanvas/test/electron-browser/positronCanvasService.vitest.ts
+++ b/src/vs/workbench/contrib/positronCanvas/test/electron-browser/positronCanvasService.vitest.ts
@@ -15,6 +15,7 @@ import { IChannel } from '../../../../../base/parts/ipc/common/ipc.js';
 import { IMainProcessService } from '../../../../../platform/ipc/common/mainProcessService.js';
 import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
 import { INativeHostService } from '../../../../../platform/native/common/native.js';
+import { IStorageService, StorageScope } from '../../../../../platform/storage/common/storage.js';
 import { IThemeService } from '../../../../../platform/theme/common/themeService.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
@@ -22,9 +23,10 @@ import { EditorsOrder } from '../../../../common/editor.js';
 import { IAuxiliaryEditorPart, IEditorGroup, IEditorGroupsService, IEditorPart } from '../../../../services/editor/common/editorGroupsService.js';
 import { IHostService } from '../../../../services/host/browser/host.js';
 import { IWorkbenchLayoutService } from '../../../../services/layout/browser/layoutService.js';
+import { ILifecycleService } from '../../../../services/lifecycle/common/lifecycle.js';
 import { IOverlayWebview } from '../../../webview/browser/webview.js';
 import { WebviewInput } from '../../../webviewPanel/browser/webviewEditorInput.js';
-import { CANVAS_WEBVIEW_VIEW_TYPE } from '../../common/positronCanvasMode.js';
+import { CANVAS_MODE_STORAGE_KEY, CANVAS_WEBVIEW_VIEW_TYPE } from '../../common/positronCanvasMode.js';
 import { PositronCanvasService } from '../../electron-browser/positronCanvasService.js';
 
 /** The command the assistant contributes to produce a Canvas panel. */
@@ -79,6 +81,7 @@ describe('PositronCanvasService', () => {
 	function build(options: {
 		auxiliaryGroups?: IEditorGroup[];
 		mainGroup?: IEditorGroup;
+		willShutdown?: boolean;
 		onWillDispose?: Event<void>;
 		executeCommand?: () => Promise<undefined>;
 		createAuxiliaryEditorPart?: IEditorGroupsService['createAuxiliaryEditorPart'];
@@ -95,6 +98,7 @@ describe('PositronCanvasService', () => {
 		parts.set(mainGroup, mainPart);
 
 		const executeCommand = vi.fn(options.executeCommand ?? (() => Promise.resolve(undefined)));
+		const storageService = stubInterface<IStorageService>({ store: vi.fn(), remove: vi.fn() });
 		const mergeGroup = vi.fn().mockReturnValue(true);
 		const setPartHidden = vi.fn();
 		const minimizeWindow = vi.fn(options.minimizeWindow ?? (() => Promise.resolve()));
@@ -113,6 +117,8 @@ describe('PositronCanvasService', () => {
 		const focus = vi.fn().mockResolvedValue(undefined);
 		ctx.instantiationService.stub(IHostService, stubInterface<IHostService>({ focus }));
 		ctx.instantiationService.stub(IWorkbenchLayoutService, stubInterface<IWorkbenchLayoutService>({ setPartHidden }));
+		ctx.instantiationService.stub(IStorageService, storageService);
+		ctx.instantiationService.stub(ILifecycleService, stubInterface<ILifecycleService>({ willShutdown: options.willShutdown === true }));
 		ctx.instantiationService.stub(ILogService, new NullLogService());
 		ctx.instantiationService.stub(IContextKeyService, new MockContextKeyService());
 		// The engagement channel: `acquire` grants unless the test says
@@ -126,7 +132,7 @@ describe('PositronCanvasService', () => {
 
 		const service = ctx.disposables.add(ctx.instantiationService.createInstance(PositronCanvasService));
 
-		return { service, mainGroup, auxiliaryPart, executeCommand, mergeGroup, setPartHidden, minimizeWindow, channelCall, focus };
+		return { service, mainGroup, auxiliaryPart, executeCommand, storageService, mergeGroup, setPartHidden, minimizeWindow, channelCall, focus };
 	}
 
 	it('coalesces concurrent entries so the assistant is asked for one Canvas', async () => {
@@ -237,7 +243,7 @@ describe('PositronCanvasService', () => {
 	it('lets an exit stand that lands while the Canvas window is being created', async () => {
 		const created = new DeferredPromise<IAuxiliaryEditorPart>();
 		const mainGroup = createGroup([createCanvasEditor()]);
-		const { service, auxiliaryPart, minimizeWindow } = build({
+		const { service, auxiliaryPart, storageService, minimizeWindow } = build({
 			mainGroup,
 			createAuxiliaryEditorPart: () => created.p,
 		});
@@ -249,8 +255,9 @@ describe('PositronCanvasService', () => {
 		await created.complete(auxiliaryPart);
 
 		// The entry must not resume into a window the user has since left: no
-		// re-minimized IDE and no reported entry.
+		// re-stored intent, no re-minimized IDE, and no reported entry.
 		expect(await entering).toMatchObject({ entered: false });
+		expect(storageService.store).not.toHaveBeenCalled();
 		expect(minimizeWindow).not.toHaveBeenCalled();
 		expect(service.isActive).toBe(false);
 	});
@@ -296,9 +303,19 @@ describe('PositronCanvasService', () => {
 		expect(service.isActive).toBe(false);
 	});
 
+	it('records the durable intent while it is presenting Canvas', async () => {
+		const auxiliaryGroup = createGroup([createCanvasEditor()]);
+		const { service, storageService } = build({ auxiliaryGroups: [auxiliaryGroup] });
+
+		await service.enter();
+
+		expect(storageService.store).toHaveBeenCalledWith(CANVAS_MODE_STORAGE_KEY, true, StorageScope.WORKSPACE, expect.anything());
+		expect(service.isActive).toBe(true);
+	});
+
 	it('merges the Canvas group back into the IDE rather than closing it', async () => {
 		const auxiliaryGroup = createGroup([createCanvasEditor()]);
-		const { service, mainGroup, mergeGroup } = build({ auxiliaryGroups: [auxiliaryGroup] });
+		const { service, mainGroup, mergeGroup, storageService } = build({ auxiliaryGroups: [auxiliaryGroup] });
 		await service.enter();
 
 		expect(await service.exit()).toBe(true);
@@ -307,11 +324,12 @@ describe('PositronCanvasService', () => {
 		// destroys a webview panel instead of moving it.
 		expect(mergeGroup).toHaveBeenCalledWith(auxiliaryGroup, mainGroup);
 		expect(auxiliaryGroup.lock).toHaveBeenCalledWith(false);
+		expect(storageService.remove).toHaveBeenCalledWith(CANVAS_MODE_STORAGE_KEY, StorageScope.WORKSPACE);
 		expect(service.isActive).toBe(false);
 	});
 
 	it('reports an exit that had no Canvas to leave', async () => {
-		const { service, mergeGroup, setPartHidden } = build();
+		const { service, mergeGroup, storageService, setPartHidden } = build();
 
 		expect(await service.exit()).toBe(false);
 
@@ -319,6 +337,41 @@ describe('PositronCanvasService', () => {
 		// Nothing was undone, so nothing is redone: unhiding here would override
 		// an editor area the user hid deliberately.
 		expect(setPartHidden).not.toHaveBeenCalled();
+		// Still cleared: exit means "I want the IDE" in every sense, including
+		// what this workspace launches into next time.
+		expect(storageService.remove).toHaveBeenCalledWith(CANVAS_MODE_STORAGE_KEY, StorageScope.WORKSPACE);
+	});
+
+	it('forgets the durable intent when the Canvas window goes away mid-session', async () => {
+		const willDispose = new Emitter<void>();
+		ctx.disposables.add(willDispose);
+		const auxiliaryGroup = createGroup([createCanvasEditor()]);
+		const { service, storageService } = build({ auxiliaryGroups: [auxiliaryGroup], onWillDispose: willDispose.event });
+		await service.enter();
+		expect(service.isActive).toBe(true);
+
+		willDispose.fire();
+
+		expect(storageService.remove).toHaveBeenCalledWith(CANVAS_MODE_STORAGE_KEY, StorageScope.WORKSPACE);
+	});
+
+	it('keeps the durable intent when the window goes away because the app is quitting', async () => {
+		const willDispose = new Emitter<void>();
+		ctx.disposables.add(willDispose);
+		const auxiliaryGroup = createGroup([createCanvasEditor()]);
+		const { service, storageService } = build({
+			auxiliaryGroups: [auxiliaryGroup],
+			onWillDispose: willDispose.event,
+			willShutdown: true,
+		});
+		await service.enter();
+
+		willDispose.fire();
+
+		// Quitting in Canvas mode is exactly what "relaunch into Canvas" is made
+		// of; clearing here would erase it.
+		expect(storageService.remove).not.toHaveBeenCalled();
+		expect(service.isActive).toBe(false);
 	});
 
 	it('reports engaged-elsewhere and asks the assistant for nothing when another window holds the claim', async () => {


### PR DESCRIPTION
Part 4 of progress towards #15309.

Stacked on #15315.

This PR adds Canvas launch and restoration:

- Adds `--canvas` for fresh and forwarded launches.
- Covers startup with an inert curtain until Canvas is ready or recovery is chosen.
- Waits for the workspace trust decision behind the curtain before entering Canvas.
- Adds a hidden, experimental `canvas.openOnStartup` setting for `settings.json`.
- Remembers per-workspace Canvas intent across relaunches.
- Merges a restored Canvas window back into the IDE when Canvas mode is not selected.

### Reviewer Q&A

**What decides whether a window starts in Canvas?**  
After AI-disabled and engaged-elsewhere vetoes, `--canvas` wins, then an explicitly configured setting, then stored workspace intent. Explicit `false` overrides stored intent.

**What happens without a Canvas-capable Assistant?**  
The readiness handshake fails before standalone mode engages. The curtain offers Retry, Open Positron, and Quit; a stale restored panel is not trusted.

**Why not check the Assistant version?**  
The behavioral handshake avoids coupling Positron to Assistant release numbers and remains safe if Canvas is renamed or removed.

**Does the startup setting affect ordinary users?**  
No. It is hidden from the Settings UI, tagged experimental, and only takes effect when manually added to `settings.json`.

**What happens after an Assistant downgrade?**  
Stored intent can be cleared by choosing Open Positron. An explicit `canvas.openOnStartup: true` continues to request Canvas until the user disables it, with the same recoverable curtain on failure.

**Why is a startup curtain necessary?**  
Assistant and editor restoration require the workbench to initialize. The curtain prevents an IDE flash and makes the covered workbench inert while entry is pending.

**Why does boot wait for the workspace trust decision?**  
The trust startup prompt renders in the main window, which Canvas mode minimizes, and an undecided workspace holds back trust-gated extensions -- including the authentication providers behind the Canvas model picker, leaving Canvas with an empty model list. The gate (`positronCanvasTrustGate.ts`) mirrors the startup prompt's own gating and joins its coalesced request, so it never prompts when the user's `security.workspace.trust.startupPrompt` preference or an earlier answer suppressed it; Canvas then enters untrusted and the Assistant's restricted-mode surface explains. The curtain's z-index sits below workbench dialogs so the native prompt stays visible over it. Trust deliberately stays native workbench UI rather than crossing the command seam.

**How are restored Canvas windows distinguished from user pop-outs?**  
Only locked compact windows containing exclusively Canvas editors are merged back. Manually popped-out panels are left alone.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

- `npm run build-check`
- Canvas, standalone-mode, launch, and auxiliary-window Vitest suites: 72 tests passed
- No TypeScript errors in touched files
