### PR TITLE
Let users mute update notifications by source

### DIFF
--- a/.github/workflows/test-tag-paths-map.json
+++ b/.github/workflows/test-tag-paths-map.json
@@ -158,6 +158,7 @@
   "src/vs/workbench/contrib/welcomeGettingStarted/browser/media/positronGettingStarted.css": ["@:welcome"],
   "src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcome": ["@:welcome"],
   "src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedPositronNotebookContent.ts": ["@:welcome"],
+  "src/vs/workbench/services/notification/": [],
   "src/vs/workbench/services/themes/": [],
   "src/vs/workbench/services/themes/browser/positronColorThemeFilter.ts": []
 }

--- a/src/vs/platform/notification/common/notification.ts
+++ b/src/vs/platform/notification/common/notification.ts
@@ -329,6 +329,18 @@ export interface IPromptOptions extends INotificationProperties {
 	 * any of the provided choices.
 	 */
 	onCancel?: () => void;
+
+	// --- Start Positron ---
+	/**
+	 * The source of the notification appears as additional information.
+	 *
+	 * Providing a source in the `INotificationSource` form also registers the
+	 * notification with the do-not-disturb-by-source system, so users can mute
+	 * notifications from this source. Note that only notifications with
+	 * `DEFAULT` or `OPTIONAL` priority are affected by that filter.
+	 */
+	readonly source?: string | INotificationSource;
+	// --- End Positron ---
 }
 
 export interface IStatusMessageOptions {

--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -16,7 +16,7 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../platfo
 // Add IUpdate, DisablementReason for Positron's update workflow.
 import { IUpdateService, State as UpdateState, StateType, IUpdate } from '../../../../platform/update/common/update.js';
 // --- End Positron ---
-import { INotificationService, NotificationPriority, Severity } from '../../../../platform/notification/common/notification.js';
+import { INotificationService, INotificationSource, NotificationPriority, Severity } from '../../../../platform/notification/common/notification.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IBrowserWorkbenchEnvironmentService } from '../../../services/environment/browser/environmentService.js';
 import { ReleaseNotesManager } from './releaseNotesEditor.js';
@@ -45,6 +45,20 @@ import { IPositronVersion, parse } from '../../../../platform/update/common/posi
 
 export const CONTEXT_UPDATE_STATE = new RawContextKey<string>('updateState', StateType.Uninitialized);
 export const MAJOR_MINOR_UPDATE_AVAILABLE = new RawContextKey<boolean>('majorMinorUpdateAvailable', false);
+
+// --- Start Positron ---
+/**
+ * Tags update notifications with a filterable source, so users can mute them from the
+ * notification's own gear menu or via "Do Not Disturb Mode By Source...".
+ *
+ * Only notifications with `DEFAULT` or `OPTIONAL` priority are silenced by that filter,
+ * so results of an explicit "Check for Updates" (which use `URGENT`) still show through.
+ */
+export const UPDATE_NOTIFICATION_SOURCE: INotificationSource = {
+	id: 'update',
+	label: nls.localize('positron.updateNotificationSource', "Update")
+};
+// --- End Positron ---
 
 let releaseNotesManager: ReleaseNotesManager | undefined = undefined;
 
@@ -403,6 +417,7 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 			severity: Severity.Info,
 			message: nls.localize('noUpdatesAvailable', "There are currently no updates available."),
 			priority: NotificationPriority.OPTIONAL,
+			source: UPDATE_NOTIFICATION_SOURCE,
 		});
 	}
 
@@ -413,6 +428,7 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 			message: nls.localize('updateDownloading', "Downloading update... You'll be notified when it's ready to install."),
 			priority: NotificationPriority.URGENT,
 			sticky: false, // Auto-dismiss since we'll show another notification when ready
+			source: UPDATE_NOTIFICATION_SOURCE,
 		});
 	}
 	// --- End Positron ---
@@ -443,7 +459,10 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 					this.instantiationService.invokeFunction(accessor => showReleaseNotes(accessor, productVersion));
 				}
 			}],
-			{ priority: NotificationPriority.OPTIONAL }
+			// --- Start Positron ---
+			// { priority: NotificationPriority.OPTIONAL }
+			{ priority: NotificationPriority.OPTIONAL, source: UPDATE_NOTIFICATION_SOURCE }
+			// --- End Positron ---
 		);
 	}
 
@@ -488,7 +507,8 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 			// { priority: NotificationPriority.OPTIONAL }
 			{
 				priority: this.explicitCheck ? NotificationPriority.URGENT : NotificationPriority.OPTIONAL,
-				sticky: this.explicitCheck
+				sticky: this.explicitCheck,
+				source: UPDATE_NOTIFICATION_SOURCE
 			}
 			// --- End Positron ---
 		);
@@ -541,7 +561,8 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 				sticky: true,
 				// --- Start Positron ---
 				// priority: NotificationPriority.OPTIONAL
-				priority: this.explicitCheck ? NotificationPriority.URGENT : NotificationPriority.OPTIONAL
+				priority: this.explicitCheck ? NotificationPriority.URGENT : NotificationPriority.OPTIONAL,
+				source: UPDATE_NOTIFICATION_SOURCE
 				// --- End Positron ---
 
 			}

--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -16,7 +16,12 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../platfo
 // Add IUpdate, DisablementReason for Positron's update workflow.
 import { IUpdateService, State as UpdateState, StateType, IUpdate } from '../../../../platform/update/common/update.js';
 // --- End Positron ---
-import { INotificationService, INotificationSource, NotificationPriority, Severity } from '../../../../platform/notification/common/notification.js';
+import { INotificationService, NotificationPriority, Severity } from '../../../../platform/notification/common/notification.js';
+// --- Start Positron ---
+// Add INotificationSource so update notifications can carry a filterable source.
+// eslint-disable-next-line no-duplicate-imports
+import { INotificationSource } from '../../../../platform/notification/common/notification.js';
+// --- End Positron ---
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IBrowserWorkbenchEnvironmentService } from '../../../services/environment/browser/environmentService.js';
 import { ReleaseNotesManager } from './releaseNotesEditor.js';

--- a/src/vs/workbench/services/notification/common/notificationService.ts
+++ b/src/vs/workbench/services/notification/common/notificationService.ts
@@ -309,7 +309,12 @@ export class NotificationService extends Disposable implements INotificationServ
 
 		// Show notification with actions
 		const actions: INotificationActions = { primary: primaryActions, secondary: secondaryActions };
-		const handle = this.notify({ severity, message, actions, sticky: options?.sticky, priority: options?.priority });
+		// --- Start Positron ---
+		// Forward `source` so that prompts can participate in do-not-disturb-by-source
+		// filtering, which previously only worked for `notify()` callers.
+		// const handle = this.notify({ severity, message, actions, sticky: options?.sticky, priority: options?.priority });
+		const handle = this.notify({ severity, message, actions, sticky: options?.sticky, priority: options?.priority, source: options?.source });
+		// --- End Positron ---
 
 		Event.once(handle.onDidClose)(() => {
 

--- a/src/vs/workbench/services/notification/test/common/notificationSource.vitest.ts
+++ b/src/vs/workbench/services/notification/test/common/notificationSource.vitest.ts
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { toDisposable } from '../../../../../base/common/lifecycle.js';
+import { InMemoryStorageService } from '../../../../../platform/storage/common/storage.js';
+import { INotificationSource, NotificationPriority, NotificationsFilter, Severity } from '../../../../../platform/notification/common/notification.js';
+import { ensureNoLeakedDisposables } from '../../../../../test/vitest/vitestUtils.js';
+import { NotificationService } from '../../common/notificationService.js';
+
+/**
+ * Covers Positron's change to forward `source` from `IPromptOptions` through
+ * `NotificationService.prompt()`. Without it, prompts could not participate in
+ * do-not-disturb-by-source filtering, so a caller had no way to let users mute
+ * a category of notifications.
+ *
+ * The two tests below exercise the two distinct paths that a forwarded source
+ * feeds: the filter check when a notification is created, and the automatic
+ * source registration that populates the do-not-disturb picker.
+ */
+describe('NotificationService.prompt source forwarding', () => {
+	const store = ensureNoLeakedDisposables();
+
+	const source: INotificationSource = { id: 'test.source', label: 'Test Source' };
+
+	function createService() {
+		return store.add(new NotificationService(store.add(new InMemoryStorageService())));
+	}
+
+	function prompt(service: NotificationService, priority: NotificationPriority) {
+		const handle = service.prompt(
+			Severity.Info,
+			'A message with a mutable source.',
+			[{ label: 'Do Something', run: () => { } }],
+			{ priority, sticky: true, source }
+		);
+
+		// Read the view item before closing; closing removes it from the model.
+		const item = service.model.notifications[0];
+		store.add(toDisposable(() => handle.close()));
+
+		return item;
+	}
+
+	it('silences a prompt when its source is filtered', () => {
+		const service = createService();
+		service.setFilter({ ...source, filter: NotificationsFilter.ERROR });
+
+		// SILENT keeps the notification in the notifications center but suppresses the
+		// toast, and wins over `sticky`.
+		expect(prompt(service, NotificationPriority.OPTIONAL).priority).toBe(NotificationPriority.SILENT);
+	});
+
+	it('registers the source so it appears in the do-not-disturb filter list', () => {
+		const service = createService();
+		prompt(service, NotificationPriority.OPTIONAL);
+
+		expect(service.getFilters()).toEqual([
+			{ id: 'test.source', label: 'Test Source', filter: NotificationsFilter.OFF }
+		]);
+	});
+});


### PR DESCRIPTION
Related to part of #15031

Update notifications carried no notification `source`, so they never appeared in _Notifications: Toggle Do Not Disturb Mode By Source..._ and offered no per-source mute action. The only way to stop them was to turn updates off entirely with `update.mode` or `update.autoUpdate`.

`source` already existed on `INotification`, but not on `IPromptOptions`, and `NotificationService.prompt()` dropped it on the way to `notify()`. Every update notification is a `prompt()` call, so there was no way to tag them. This PR adds `source` to `IPromptOptions`, forwards it in `prompt()`, and tags all five update notifications with a shared `UPDATE_NOTIFICATION_SOURCE` (`id: 'update'`, label "Update"). This _is_ upstream code, but I think worth changing. IMO this looks more like an omission on their part.

The report in #15031 has two parts. The deluge of repeated notifications is a symptom of updates failing and re-notifying, which is the installer deadlock tracked in #13988; this PR does not touch that part. What it does address is the reporter's follow-up ask: "it would be nice to be able to see which of the notification sources handles daily update messages, so they can be turned off if needed." This gives users an escape hatch while the underlying failure is fixed separately, so the issue should stay open.

### Release Notes

#### New Features

- Update notifications can now be muted, either from the notification's gear menu or via _Notifications: Toggle Do Not Disturb Mode By Source..._ (#15031)

#### Bug Fixes

- N/A

### Validation Steps

@:packages-pane

Note that the tag above is not exercising this change directly. There is no e2e coverage of auto-update at all (#6332). It is included because this PR modifies the shared `NotificationService.prompt()` used across the app, and the packages pane suite raises and dismisses notification toasts, so it smoke-tests that ordinary prompts still render.

Unit coverage: `src/vs/workbench/services/notification/test/common/notificationSource.vitest.ts`

```
npx vitest run src/vs/workbench/services/notification/test/common/notificationSource.vitest.ts
```

A manual check can only really be seen on a build that can receive a real update, like tomorrow's daily:

1. Wait for an automatic update notification to appear, or install back to an old daily.
2. Click the gear icon on the notification. Confirm _Turn Off Info and Warning Notifications from 'Update'_ appears, then click it.
3. Run _Notifications: Toggle Do Not Disturb Mode By Source..._ and confirm **Update** is listed and now toggled off.
4. Trigger another automatic update notification. Confirm no toast appears, and that the notification is still present in the notifications center (bell icon).
5. Run _Check for Updates..._ from the command palette. Confirm its result still toasts, since explicit checks use `URGENT` priority and bypass the filter.
