### PR TITLE
skill(triage-e2e-test): stop stale evidence from reading as the current occurrence

### DIFF
--- a/.claude/skills/triage-e2e-test/SKILL.md
+++ b/.claude/skills/triage-e2e-test/SKILL.md
@@ -38,15 +38,21 @@ only when a stage needs them.
 - Root-cause claims cite observed evidence and the alternatives ruled out.
 - Checkpoint at every phase transition.
 
-## Prerequisites
+## Requirements
 
+- **Claude Code**, run from a **Positron** checkout: the scripts resolve the repo
+  root from their own location and keep triage state in the shared git dir.
+- On PATH: `node`, `git`, `gh` (authenticated), `unzip`.
 - `E2E_INSIGHTS_API_KEY` set, or present in the repo-root `.env.e2e` (the query
-  script falls back to it automatically). Node.js and `unzip` on PATH.
+  script falls back to it automatically).
+- Neighbor skills: `e2e-failure-analyzer` (its `e2e-query-history.js` and
+  `e2e-process-s3.js` are invoked directly); at the fix stage
+  `positron-pr-helper`, `author-vitest-tests`, `author-e2e-tests`.
 
 ## Scripts
 
 Run from the repo root. Flags and output contracts:
-[`scripts/README.md`](scripts/README.md). If a script itself breaks, see
+[`references/scripts.md`](references/scripts.md). If a script itself breaks, see
 [`references/script-fallbacks.md`](references/script-fallbacks.md).
 
 | Script | Use it to |

--- a/.claude/skills/triage-e2e-test/references/diagnosis-block.md
+++ b/.claude/skills/triage-e2e-test/references/diagnosis-block.md
@@ -21,8 +21,12 @@ root-cause prediction at authoring time, so its accuracy can be scored later.
 
 ## Required fields
 
-Saved on the checkpoint under `diagnosis`, validated by `record-diagnosis.js`
-before it renders. These are the rendered fields, not every key on `diagnosis`:
+Saved on the checkpoint under `diagnosis`. These are the rendered fields, not
+every key on `diagnosis`. **Only `confidence` and `summary` are hard-validated**
+by `record-diagnosis.js` (a bad value fails before anything is written); the rest
+render as `n/a` when missing rather than failing, so "required" below is the
+standard the block is held to, not a guarantee the script enforces. `--dry-run`
+is how you catch a thin block:
 
 | Field | Required | Shape |
 |---|---|---|

--- a/.claude/skills/triage-e2e-test/references/scripts.md
+++ b/.claude/skills/triage-e2e-test/references/scripts.md
@@ -1,0 +1,168 @@
+# Scripts -- flags and output contracts
+
+Reference for the five helpers in `scripts/`. Read it when you need a flag that
+the SKILL's workflow steps don't already spell out, or when you need to know what
+a script's output actually contains. If a script is *broken* and you need to do
+its work by hand, that is [`script-fallbacks.md`](script-fallbacks.md) instead.
+
+End-to-end runs of these commands in order:
+[`workflow-examples.md`](workflow-examples.md).
+
+## Shared conventions
+
+- **Run from the repo root**, as `node .claude/skills/triage-e2e-test/scripts/<name>.js`.
+- **stdout is compact JSON only.** Large payloads (full API responses, processor
+  output, trace timelines) are written to disk and referenced by path, so they
+  never enter the conversation.
+- **Errors are structured**: `{ "error": "..." }` on stdout plus a non-zero exit.
+  Treat that as stop-and-surface, never as "no data" or a cue to fall back to a
+  broader search.
+- **Work directory**: `<git-common-dir>/triage-e2e-test/<triage-id>/`. It is
+  anchored on the git *common* dir, so a triage started in one worktree resumes
+  from any other. Outside a git repo it falls back to
+  `.claude/work/triage-e2e-test/`.
+- **`--triage-id`** is the same value everywhere. `triage-history.js` derives it
+  (`<leaf-test-slug>-<hash8>`) and returns it as `triageId`; pass that verbatim to
+  every later script. Inventing one splits the checkpoint from the work dir
+  holding the history and evidence, which is what `--resume` reads.
+
+## `triage-history.js`
+
+Dual-branch failure history: queries the current branch and `main`, merges
+`failure_patterns[]` by normalized failure text, and picks one representative
+occurrence per pattern.
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--test-key <key>` | *required* | `testName\|\|\|specPath` |
+| `--repo <id>` | `positron` | test-health repo id |
+| `--branch <branch>` | current git branch | skips the git lookup; `main` means only main is queried |
+| `--lookback-days <n>` | `14` | 1-30 |
+| `--occurrences-per-pattern <n>` | `1` | raise to `2` only for a listed escalation reason |
+| `--triage-id <id>` | derived from the test key | |
+
+**Output:** `{ triageId, testKey, testName, specPath, testDetailViewUrl,
+branchSummary, patterns[], verdict, stop, note, lookbackDays, queriedAt,
+rawResultFile, summaryFile }`.
+
+Each `patterns[]` entry: `{ id, failure, count, rates[], environments[], seenOn,
+lastSeen, representativeOccurrence }`.
+
+- `rates[]` is per branch: `{ branch, count, environmentRuns, ratePercent }`.
+  `environmentRuns` is scoped to the environments the pattern actually occurred
+  in, which is why the table's Rate column reads from `rates` and never from
+  `count / totalRuns`.
+- `lastSeen` is `{ date, daysAgo, sha }`, any of which may be `null` -- see
+  [`history-query.md`](history-query.md#how-lastseen-is-derived).
+- `id` is a spreadsheet-style label: `A`..`Z`, then `AA`, `AB`, ...
+
+Also writes `history-summary.json` and `history-raw.json` to the work dir.
+`checkpoint.js --init` auto-seeds `history` + `patterns` from that summary file.
+
+Verdicts (`ok`, `ok-current-branch-new`, `zero-runs-both`, `clean`) are explained
+in [`history-query.md`](history-query.md).
+
+## `find-prior-triage.js`
+
+Searches PRs carrying an `E2E Triage Diagnosis` block, keeps the ones whose body
+names this spec path, and partitions the supplied occurrence SHAs by git ancestry
+against each merged fix.
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--spec-path <path>` | *required* | exact spec path from the test key |
+| `--occurrence-shas <json>` | `[]` | JSON array; **omitting it forces the `too-recent-to-tell` verdict** (nothing to check ancestry against) |
+| `--repo <owner/repo>` | `posit-dev/positron` | |
+| `--triage-id <id>` | none | needed for the on-disk `prior-triage-raw.json` |
+| `--limit <n>` | `50` | PR search limit |
+
+**Output:** `{ specPath, openAttempts[], mergedAttempts[], verdict,
+rawResultFile }`. Verdict meanings and how to act on them:
+[`prior-triage.md`](prior-triage.md).
+
+## `fetch-pattern-evidence.js`
+
+Runs the S3 report processor for **one** occurrence of **one** pattern, filtered
+to the test under triage, and prints a manifest instead of the multi-megabyte
+payload.
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--report-url <url>` | *required* | the pattern's `representativeOccurrence.report_url`; the `index.html#?testId=` fragment is stripped for you and the testId reused as the filter |
+| `--triage-id <id>` | *required* | |
+| `--pattern <id>` | `A` | names the evidence sub-directory |
+| `--title <full title>` | none | filter fallback when the URL carries no `testId` |
+| `--test-id <id>` | none | explicit testId filter |
+| `--keep-raw-logs` | off | extracts the raw logs into `<evidenceDir>/raw-logs/`. Without it the processor cleans up its temp extract, so escalating to raw logs means refetching with the flag |
+| `--occurrence <label>` | none | nests artifacts under `evidence/<pattern>/<label>` so several occurrences of one pattern can coexist. Use it whenever you fetch a second occurrence |
+
+**Output:** `{ evidenceDir, summaryFile, timelineFile, snapshotFile,
+screenshots[], rawLogDir, rawLogsRetained, rawEvidenceFile, failure }`. Paths
+are repo-relative; `timelineFile` and `snapshotFile` may be `null`.
+
+The evidence dir is keyed by **pattern**, not by occurrence, so each fetch clears
+the artifacts it owns first. Otherwise a previous occurrence's `raw-logs/`
+survives and reads as the current one's. Trust `rawLogsRetained` over the
+presence of a `raw-logs/` directory.
+
+**Read `summaryFile` first**, and open anything else only under the gate in
+[`evidence-escalation.md`](evidence-escalation.md).
+
+## `checkpoint.js`
+
+Durable triage state at `<work-dir>/state.json`.
+
+| Invocation | Does |
+|---|---|
+| `--triage-id <id> --init --test-key <key> [--branch b] [--lookback-days n] [--force]` | create state; auto-seeds `history`/`patterns` from `history-summary.json` if present. Refuses to clobber an existing checkpoint without `--force` |
+| `--triage-id <id> --read` | print state (plus `_validation` when invalid) |
+| `--triage-id <id> --validate` | print `{ ok, errors[], phase, nextAction }` only |
+| `--triage-id <id> --set key=value` | set one scalar; repeatable |
+| `--triage-id <id> --patch '<json>'` | deep-merge an object |
+| `--triage-id <id> --patch-pattern <id> --patch '<json>'` | merge into exactly one `patterns[]` entry |
+| `--status` | list every saved triage |
+
+- **`--set` accepts only** `phase`, `nextAction`, `selectedPattern`,
+  `lookbackDays`, `branch`, `outcome`, `outcomeRef`, `outcomeReason`,
+  `diagnosisBlockRecorded`. Object fields go through `--patch`.
+- **`--patch` rejects unknown top-level keys.** `--patch '{"confidence":"high"}'`
+  fails loudly rather than creating a stray top-level field the renderer never
+  reads; nest it (`{"diagnosis":{"confidence":"high"}}`).
+- **`--patch` replaces arrays wholesale.** To annotate one pattern without
+  resending the rest, use `--patch-pattern`.
+- **Setting `phase` derives `nextAction`** unless `nextAction` is set in the same
+  call.
+- **Phases**, in order: `awaiting-pattern-selection`, `pattern-selected`,
+  `evidence-gathered`, `hypothesis-ready`, `awaiting-clear`, `implementation`,
+  `done`.
+- **`phase=done` is gated.** It requires an `outcome`; `no-op` additionally
+  requires `outcomeReason`, and every other outcome requires `outcomeRef` plus
+  `diagnosisBlockRecorded=true` (only `record-diagnosis.js` sets that flag). A
+  blocked write fails with `{ error, gate }` and does not persist.
+
+## `record-diagnosis.js`
+
+Renders the `E2E Triage Diagnosis` block from the checkpoint's `diagnosis` object
+plus the test title / dashboard URL / frequency pulled from `history-summary.json`,
+and appends it to a PR or issue.
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--triage-id <id>` | *required* | |
+| `--pr <n>` / `--issue <n>` | one required unless `--dry-run` | |
+| `--repo <owner/repo>` | `posit-dev/positron` | |
+| `--outcome <o>` | none | `fix-test` \| `fix-product` \| `file-issue`; `no-op` goes through `checkpoint.js` |
+| `--secondary` | off | append to a supplementary artifact without repointing `outcome`/`outcomeRef`; cannot be combined with `--outcome` |
+| `--dry-run` | off | render and print only; touches neither the artifact nor the checkpoint |
+
+**Output:** `{ block, target, alreadyPresent, recorded, outcome }`.
+
+- **Idempotent**: a body already containing the block heading is left alone and
+  the flag is re-affirmed.
+- **Validates before rendering**: `diagnosis.confidence` must be
+  `high|medium|low`, and `diagnosis.summary` must be a non-empty single line under
+  600 chars. Other fields render as `n/a` when missing rather than failing, so
+  `--dry-run` is the way to catch a thin block.
+- Always writes `diagnosis-block.md` to the work dir, `--dry-run` included.
+
+Field-by-field guidance: [`diagnosis-block.md`](diagnosis-block.md).

--- a/.claude/skills/triage-e2e-test/scripts/fetch-pattern-evidence.js
+++ b/.claude/skills/triage-e2e-test/scripts/fetch-pattern-evidence.js
@@ -10,10 +10,15 @@
 //
 // Usage:
 //   node fetch-pattern-evidence.js --report-url <url> --triage-id <id> --pattern <A> \
-//     (--title '<full title>' | --test-id <id>) [--keep-raw-logs]
+//     (--title '<full title>' | --test-id <id>) [--keep-raw-logs] [--occurrence <label>]
+//
+// --occurrence nests the artifacts under evidence/<pattern>/<label>, so several
+// occurrences of the same pattern can be compared side by side instead of
+// overwriting each other.
 //
 // Output (stdout): compact JSON manifest { evidenceDir, summaryFile,
-//   timelineFile, snapshotFile, screenshots[], rawLogDir, failure }.
+//   timelineFile, snapshotFile, screenshots[], rawLogDir, rawLogsRetained,
+//   failure }.
 
 import path from 'path';
 import fs from 'fs';
@@ -32,6 +37,27 @@ export function normalizeReportUrl(reportUrl) {
 	const base = url.replace(/index\.html.*$/, '');
 	const m = url.match(/testId=([^&\s]+)/);
 	return { baseUrl: base.endsWith('/') ? base : base + '/', testId: m ? m[1] : null };
+}
+
+/**
+ * Artifacts this script owns inside an evidence dir, cleared before each fetch.
+ *
+ * The dir is keyed by pattern, not by occurrence. The processor overwrites
+ * summary.md and evidence-raw.json but leaves a previous --keep-raw-logs bundle
+ * in place, so without this a prior occurrence's logs read as this one's. Every
+ * name here is regenerated from the report, so clearing is always safe.
+ */
+const MANAGED_ARTIFACTS = [
+	'raw-logs', 'screenshots', 'error-context',
+	'summary.md', 'timeline.txt', 'evidence-raw.json',
+];
+
+export function clearManagedArtifacts(evidenceDir) {
+	const present = MANAGED_ARTIFACTS.filter(n => fs.existsSync(path.join(evidenceDir, n)));
+	for (const name of present) {
+		fs.rmSync(path.join(evidenceDir, name), { recursive: true, force: true });
+	}
+	return present;
 }
 
 /** Pick the single test detail matching the filter, or the sole one present. */
@@ -124,7 +150,12 @@ function main() {
 	if (testId) { filterArgs.push('--test-id', testId); }
 	else if (title) { filterArgs.push('--title', title); }
 
-	const evidenceDir = ensureDir(path.join(triageDir(triageId), 'evidence', pattern));
+	const occurrence = args.occurrence || null;
+	const evidenceDir = ensureDir(path.join(
+		triageDir(triageId), 'evidence', pattern, ...(occurrence ? [occurrence] : []),
+	));
+	clearManagedArtifacts(evidenceDir);
+	const rawLogsDir = path.join(evidenceDir, 'raw-logs');
 
 	let stdout;
 	try {
@@ -132,7 +163,7 @@ function main() {
 		// Extract raw logs into this triage's evidence dir rather than leaving them
 		// in a shared temp dir, where logs-<shortId>.zip collides across every test
 		// in the same spec file and a stale sibling's bundle reads as this run's.
-		if (args['keep-raw-logs']) { procArgs.push('--raw-logs-out', path.join(evidenceDir, 'raw-logs')); }
+		if (args['keep-raw-logs']) { procArgs.push('--raw-logs-out', rawLogsDir); }
 		else { procArgs.push('--cleanup'); }
 		stdout = runNode(analyzerScript('e2e-process-s3.js'), procArgs);
 	} catch (err) {
@@ -148,6 +179,13 @@ function main() {
 	const summaryFile = writeText(path.join(evidenceDir, 'summary.md'), summary.markdown);
 	const timelineFile = summary.timeline ? writeText(path.join(evidenceDir, 'timeline.txt'), summary.timeline) : null;
 
+	// Report the raw-log dir this fetch actually produced. The processor only
+	// reports rawLogsDir per test detail when --raw-logs-out was passed, so fall
+	// back to the dir on disk: a null here next to a populated raw-logs/ is how a
+	// stale bundle gets read as the current occurrence's.
+	const reportedRawLogs = (result.testDetails || []).find(t => t.rawLogsDir)?.rawLogsDir || null;
+	const rawLogDir = reportedRawLogs || (fs.existsSync(rawLogsDir) ? rawLogsDir : null);
+
 	const rel = p => (p ? path.relative(process.cwd(), p) : null);
 	emit({
 		evidenceDir: rel(evidenceDir),
@@ -155,7 +193,10 @@ function main() {
 		timelineFile: rel(timelineFile),
 		snapshotFile: rel(summary.snapshotFile),
 		screenshots: (summary.screenshots || []).map(rel),
-		rawLogDir: rel((result.testDetails || []).find(t => t.rawLogsDir)?.rawLogsDir || null),
+		rawLogDir: rel(rawLogDir),
+		// Without --keep-raw-logs the processor cleans up its temp extract, so
+		// escalating to raw logs means refetching with the flag.
+		rawLogsRetained: Boolean(rawLogDir),
 		rawEvidenceFile: rel(rawFile),
 		failure: summary.failure ? summary.failure.slice(0, 200) : null,
 	});

--- a/.claude/skills/triage-e2e-test/scripts/test/evidence-summary.test.js
+++ b/.claude/skills/triage-e2e-test/scripts/test/evidence-summary.test.js
@@ -1,6 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { normalizeReportUrl, buildEvidenceSummary } from '../fetch-pattern-evidence.js';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { normalizeReportUrl, buildEvidenceSummary, clearManagedArtifacts } from '../fetch-pattern-evidence.js';
 
 test('normalizeReportUrl strips index.html + fragment and extracts testId', () => {
 	const url = 'https://cf.net/playwright-report-1-2-ubuntu/index.html#?testId=abc123-def';
@@ -51,4 +54,20 @@ test('buildEvidenceSummary is graceful when no matching detail exists', () => {
 	const s = buildEvidenceSummary({ testDetails: [] }, { testId: 'missing' });
 	assert.match(s.markdown, /No matching test detail/);
 	assert.equal(s.failure, null);
+});
+
+test('clearManagedArtifacts drops a previous occurrence\'s artifacts, including raw-logs', () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'triage-evidence-'));
+	fs.mkdirSync(path.join(dir, 'raw-logs', 'julyrun'), { recursive: true });
+	fs.writeFileSync(path.join(dir, 'summary.md'), 'stale');
+	fs.writeFileSync(path.join(dir, 'notes-by-hand.md'), 'keep me');
+
+	const cleared = clearManagedArtifacts(dir);
+
+	assert.deepEqual(cleared.sort(), ['raw-logs', 'summary.md']);
+	assert.equal(fs.existsSync(path.join(dir, 'raw-logs')), false);
+	// Anything the script does not own is left alone.
+	assert.equal(fs.readFileSync(path.join(dir, 'notes-by-hand.md'), 'utf8'), 'keep me');
+	assert.deepEqual(clearManagedArtifacts(dir), [], 'second call is a no-op');
+	fs.rmSync(dir, { recursive: true, force: true });
 });


### PR DESCRIPTION
### Summary
Fetching a second occurrence of the same failure pattern left the previous occurrence's raw logs on disk while the manifest reported `rawLogDir: null`, so days-old logs read as the current occurrence's. Hit this during a live triage of #15060, where July logs nearly got used as August evidence.

- Clear the artifacts the script owns before each fetch (the evidence dir is keyed by pattern, not by occurrence)
- `rawLogDir` falls back to the dir on disk so it can't be `null` while logs are present; new `rawLogsRetained` tells escalation whether a refetch with `--keep-raw-logs` is needed
- New `--occurrence <label>` nests artifacts per occurrence, for comparing several occurrences of one pattern
- Fix the Scripts link: SKILL.md pointed at `scripts/README.md`, which exists neither in git nor on disk; the real file is `references/scripts.md`, which `.gitignore` had excluded from tracking
- Correct `diagnosis-block.md`: `record-diagnosis.js` hard-validates only `confidence` and `summary`, not every "required" field

### QA Notes
Skill-only change, no product code. `node --test .claude/skills/triage-e2e-test/scripts/test/*.test.js` passes 62 tests, including a new case for the clearing behavior.