### PR TITLE
e2e: re-drive the Quarto inline-output reveal instead of waiting it out

### DIFF
--- a/test/e2e/pages/inlineQuarto.ts
+++ b/test/e2e/pages/inlineQuarto.ts
@@ -218,19 +218,33 @@ export class InlineQuarto {
 		}).toPass({ timeout: 30000, intervals: [1000] });
 	}
 
-	async runCellAndWaitForOutput({ cellLine, outputLine, timeout = 120000 }: { cellLine: number; outputLine: number; timeout?: number }): Promise<void> {
+	/**
+	 * Navigate to `outputLine` and confirm the inline output rendered, re-driving
+	 * the navigation until it does. Monaco sets a view zone to `display: none`
+	 * whenever it falls outside the rendered range, so an output that resizes
+	 * itself after the reveal (a plotly webview settling to its final height
+	 * shrinks the document, which makes Monaco clamp scrollTop back to the
+	 * bottom) can end up stranded off-screen with nothing left to scroll it into
+	 * view. Repeating the reveal recovers; a single long wait never can.
+	 */
+	private async _revealOutput(outputLine: number, timeout: number): Promise<void> {
+		await expect(async () => {
+			await this.gotoLine(outputLine);
+			await expect(this.inlineOutput).toBeVisible({ timeout: 5000 });
+		}).toPass({ timeout, intervals: [1000] });
+	}
+
+	async runCellAndWaitForOutput({ cellLine, outputLine, timeout = 60000 }: { cellLine: number; outputLine: number; timeout?: number }): Promise<void> {
 		await test.step(`Run cell at line ${cellLine} and wait for output at line ${outputLine}`, async () => {
 			await this._runCellUntilStarted(cellLine, () => this.runCurrentCell());
-			await this.gotoLine(outputLine);
-			await expect(this.inlineOutput).toBeVisible({ timeout });
+			await this._revealOutput(outputLine, timeout);
 		});
 	}
 
-	async runCodeAndWaitForOutput({ cellLine, outputLine, timeout = 120000 }: { cellLine: number; outputLine: number; timeout?: number }): Promise<void> {
+	async runCodeAndWaitForOutput({ cellLine, outputLine, timeout = 60000 }: { cellLine: number; outputLine: number; timeout?: number }): Promise<void> {
 		await test.step(`Run code at line ${cellLine} and wait for output at line ${outputLine}`, async () => {
 			await this._runCellUntilStarted(cellLine, () => this.runCurrentCode());
-			await this.gotoLine(outputLine);
-			await expect(this.inlineOutput).toBeVisible({ timeout });
+			await this._revealOutput(outputLine, timeout);
 		});
 	}
 

--- a/test/e2e/pages/inlineQuarto.ts
+++ b/test/e2e/pages/inlineQuarto.ts
@@ -226,25 +226,35 @@ export class InlineQuarto {
 	 * shrinks the document, which makes Monaco clamp scrollTop back to the
 	 * bottom) can end up stranded off-screen with nothing left to scroll it into
 	 * view. Repeating the reveal recovers; a single long wait never can.
+	 *
+	 * Pass `outputLine` a line at or above the output -- usually the cell's
+	 * closing fence. A line past the end of the document clamps to the last line
+	 * and reveals it at maximum scroll, which is where the strand happens.
+	 *
+	 * `target` overrides what is waited for (e.g. `inlineOutput.last()` for a
+	 * document with several cells); it defaults to any inline output.
 	 */
-	private async _revealOutput(outputLine: number, timeout: number): Promise<void> {
-		await expect(async () => {
-			await this.gotoLine(outputLine);
-			await expect(this.inlineOutput).toBeVisible({ timeout: 5000 });
-		}).toPass({ timeout, intervals: [1000] });
+	async revealOutput(outputLine: number, { target, timeout = 30000 }: { target?: Locator; timeout?: number } = {}): Promise<void> {
+		await test.step(`Reveal inline output at line ${outputLine}`, async () => {
+			const output = target ?? this.inlineOutput;
+			await expect(async () => {
+				await this.gotoLine(outputLine);
+				await expect(output).toBeVisible({ timeout: 5000 });
+			}).toPass({ timeout, intervals: [1000] });
+		});
 	}
 
 	async runCellAndWaitForOutput({ cellLine, outputLine, timeout = 60000 }: { cellLine: number; outputLine: number; timeout?: number }): Promise<void> {
 		await test.step(`Run cell at line ${cellLine} and wait for output at line ${outputLine}`, async () => {
 			await this._runCellUntilStarted(cellLine, () => this.runCurrentCell());
-			await this._revealOutput(outputLine, timeout);
+			await this.revealOutput(outputLine, { timeout });
 		});
 	}
 
 	async runCodeAndWaitForOutput({ cellLine, outputLine, timeout = 60000 }: { cellLine: number; outputLine: number; timeout?: number }): Promise<void> {
 		await test.step(`Run code at line ${cellLine} and wait for output at line ${outputLine}`, async () => {
 			await this._runCellUntilStarted(cellLine, () => this.runCurrentCode());
-			await this._revealOutput(outputLine, timeout);
+			await this.revealOutput(outputLine, { timeout });
 		});
 	}
 

--- a/test/e2e/tests/quarto/quarto-inline-output-basic.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-basic.test.ts
@@ -28,7 +28,7 @@ test.describe('Quarto - Inline Output: Basic', {
 
 		// Run the cell and wait for output
 		await editors.clickTab('simple_plot.qmd');
-		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 12, outputLine: 25 });
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 12, outputLine: 20 });
 
 		// Verify output content
 		await inlineQuarto.expectOutputVisible();
@@ -50,7 +50,7 @@ test.describe('Quarto - Inline Output: Basic', {
 
 		// Run the cell and wait for output
 		await editors.clickTab('simple_plot.qmd');
-		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 12, outputLine: 25 });
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 12, outputLine: 20 });
 
 		// Verify there is exactly ONE output view zone, not duplicates
 		await inlineQuarto.expectOutputsExist(1);
@@ -69,7 +69,7 @@ test.describe('Quarto - Inline Output: Basic', {
 
 		// Run the cell and wait for output
 		await editors.clickTab('simple_plot.qmd');
-		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 12, outputLine: 25 });
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 12, outputLine: 20 });
 
 		// Scroll to make sure the output area is in view
 		await inlineQuarto.gotoLine(20);

--- a/test/e2e/tests/quarto/quarto-inline-output-collapse.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-collapse.test.ts
@@ -28,7 +28,7 @@ test.describe('Quarto - Inline Output: Collapse', {
 		await inlineQuarto.expectKernelStatusVisible();
 
 		await editors.clickTab('simple_plot.qmd');
-		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 12, outputLine: 25 });
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 12, outputLine: 20 });
 		await inlineQuarto.expectOutputExpanded();
 
 		await inlineQuarto.clickCollapseChevron();
@@ -48,7 +48,7 @@ test.describe('Quarto - Inline Output: Collapse', {
 		await editors.clickTab('simple_plot.qmd');
 		await hotKeys.closeSecondarySidebar();
 		await hotKeys.toggleBottomPanel();
-		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 12, outputLine: 25 });
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 12, outputLine: 20 });
 		await inlineQuarto.expectOutputExpanded();
 
 		// Place the cursor inside the code cell so the toggle command finds it.

--- a/test/e2e/tests/quarto/quarto-inline-output-copy-select.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-copy-select.test.ts
@@ -28,7 +28,7 @@ test.describe('Quarto - Inline Output: Copy and Select', {
 
 		// Run the cell and wait for output
 		await editors.clickTab('text_output.qmd');
-		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 13, outputLine: 20 });
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 13, outputLine: 15 });
 		await inlineQuarto.expectStdoutContains('Hello World');
 
 		// Select text via drag and verify
@@ -91,7 +91,7 @@ test.describe('Quarto - Inline Output: Copy and Select', {
 
 		// Run the cell and wait for output
 		await editors.clickTab('text_output.qmd');
-		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 13, outputLine: 20 });
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 13, outputLine: 15 });
 
 		// Position cursor back in cell and use copy command
 		await inlineQuarto.gotoLine(13);

--- a/test/e2e/tests/quarto/quarto-inline-output-dataframe.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-dataframe.test.ts
@@ -29,7 +29,7 @@ test.describe('Quarto - Inline Output: DataFrame and Interactive HTML', {
 
 		// Run the cell and wait for output
 		await editors.clickTab('py_data_frame.qmd');
-		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 7, outputLine: 12 });
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 7, outputLine: 9 });
 		await inlineQuarto.expectOutputVisible();
 
 		// Verify exactly one output item (no duplicates)
@@ -59,7 +59,7 @@ test.describe('Quarto - Inline Output: DataFrame and Interactive HTML', {
 
 		// Run the cell and wait for output
 		await editors.clickTab('py_data_frame.qmd');
-		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 7, outputLine: 12 });
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 7, outputLine: 9 });
 		await inlineQuarto.expectOutputVisible();
 
 		// Verify inline data explorer appears
@@ -87,7 +87,7 @@ test.describe('Quarto - Inline Output: DataFrame and Interactive HTML', {
 
 		// Run the cell and wait for output
 		await editors.clickTab('r_data_frame.qmd');
-		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 7, outputLine: 20 });
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 7, outputLine: 11 });
 		await inlineQuarto.expectOutputVisible();
 
 		// Verify inline data explorer appears
@@ -117,7 +117,7 @@ test.describe('Quarto - Inline Output: DataFrame and Interactive HTML', {
 
 		// Run the cell and wait for output
 		await editors.clickTab('r_data_frame.qmd');
-		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 7, outputLine: 20 });
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 7, outputLine: 11 });
 		await inlineQuarto.expectOutputVisible();
 
 		// Verify inline data explorer appears with live data
@@ -137,7 +137,7 @@ test.describe('Quarto - Inline Output: DataFrame and Interactive HTML', {
 
 		// Verify output persisted - should show text fallback with actual
 		// data frame content, not the "Hello, world!" stub from text/html
-		await inlineQuarto.gotoLine(20);
+		await inlineQuarto.gotoLine(11);
 		await inlineQuarto.expectOutputVisible({ timeout: 1000 });
 		await inlineQuarto.expectOutputContainsText(/Alice|Name/i, { timeout: 15000 });
 		await inlineQuarto.expectOutputNotContainsText('Hello, world!');
@@ -158,7 +158,7 @@ test.describe('Quarto - Inline Output: DataFrame and Interactive HTML', {
 
 		// Run the cell and wait for output
 		await editors.clickTab('interactive_plot.qmd');
-		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 8, outputLine: 15 });
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 8, outputLine: 10 });
 		await inlineQuarto.expectOutputVisible();
 
 		// Verify webview/HTML output
@@ -170,7 +170,7 @@ test.describe('Quarto - Inline Output: DataFrame and Interactive HTML', {
 		await editors.waitForActiveTab('interactive_plot.qmd');
 
 		// Verify output persisted
-		await inlineQuarto.gotoLine(15);
+		await inlineQuarto.gotoLine(10);
 		await inlineQuarto.expectOutputVisible();
 		await inlineQuarto.expectWebviewOrHtmlVisible();
 
@@ -190,7 +190,7 @@ test.describe('Quarto - Inline Output: DataFrame and Interactive HTML', {
 
 		// Run the cell and wait for output
 		await editors.clickTab('interactive_plot.qmd');
-		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 8, outputLine: 15 });
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 8, outputLine: 10 });
 		await inlineQuarto.expectOutputVisible();
 		await inlineQuarto.expectWebviewOrHtmlVisible();
 
@@ -209,7 +209,7 @@ test.describe('Quarto - Inline Output: DataFrame and Interactive HTML', {
 		await inlineQuarto.expectKernelStatusVisible();
 
 		// Verify output persisted
-		await inlineQuarto.gotoLine(15);
+		await inlineQuarto.gotoLine(10);
 		await inlineQuarto.expectOutputVisible({ timeout: 1000 });
 		await inlineQuarto.expectWebviewOrHtmlVisible(1000);
 

--- a/test/e2e/tests/quarto/quarto-inline-output-dataframe.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-dataframe.test.ts
@@ -29,7 +29,7 @@ test.describe('Quarto - Inline Output: DataFrame and Interactive HTML', {
 
 		// Run the cell and wait for output
 		await editors.clickTab('py_data_frame.qmd');
-		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 7, outputLine: 9 });
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 7, outputLine: 11 });
 		await inlineQuarto.expectOutputVisible();
 
 		// Verify exactly one output item (no duplicates)
@@ -59,7 +59,7 @@ test.describe('Quarto - Inline Output: DataFrame and Interactive HTML', {
 
 		// Run the cell and wait for output
 		await editors.clickTab('py_data_frame.qmd');
-		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 7, outputLine: 9 });
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 7, outputLine: 11 });
 		await inlineQuarto.expectOutputVisible();
 
 		// Verify inline data explorer appears
@@ -87,7 +87,7 @@ test.describe('Quarto - Inline Output: DataFrame and Interactive HTML', {
 
 		// Run the cell and wait for output
 		await editors.clickTab('r_data_frame.qmd');
-		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 7, outputLine: 11 });
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 7, outputLine: 12 });
 		await inlineQuarto.expectOutputVisible();
 
 		// Verify inline data explorer appears
@@ -117,7 +117,7 @@ test.describe('Quarto - Inline Output: DataFrame and Interactive HTML', {
 
 		// Run the cell and wait for output
 		await editors.clickTab('r_data_frame.qmd');
-		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 7, outputLine: 11 });
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 7, outputLine: 12 });
 		await inlineQuarto.expectOutputVisible();
 
 		// Verify inline data explorer appears with live data
@@ -137,7 +137,7 @@ test.describe('Quarto - Inline Output: DataFrame and Interactive HTML', {
 
 		// Verify output persisted - should show text fallback with actual
 		// data frame content, not the "Hello, world!" stub from text/html
-		await inlineQuarto.gotoLine(11);
+		await inlineQuarto.gotoLine(12);
 		await inlineQuarto.expectOutputVisible({ timeout: 1000 });
 		await inlineQuarto.expectOutputContainsText(/Alice|Name/i, { timeout: 15000 });
 		await inlineQuarto.expectOutputNotContainsText('Hello, world!');

--- a/test/e2e/tests/quarto/quarto-inline-output-execution.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-execution.test.ts
@@ -79,8 +79,9 @@ One more line for good measure.
 		await inlineQuarto.gotoLine(25);
 		await inlineQuarto.runCurrentCode();
 
-		// Verify no errors and output is correct
-		await inlineQuarto.gotoLine(30);
+		// Verify no errors and output is correct. Line 25 is the second cell's
+		// closing fence after the three inserted lines shifted it down.
+		await inlineQuarto.revealOutput(25, { target: inlineQuarto.getInlineOutputAt(1) });
 		await inlineQuarto.expectOutputVisible({ index: 1 });
 		await inlineQuarto.expectErrorCount(0);
 

--- a/test/e2e/tests/quarto/quarto-inline-output-persistence.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-persistence.test.ts
@@ -33,7 +33,7 @@ test.describe('Quarto - Inline Output: Persistence', {
 
 		// Run the cell and wait for output
 		await editors.clickTab('simple_plot.qmd');
-		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 12, outputLine: 25 });
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 12, outputLine: 20 });
 		await inlineQuarto.expectOutputVisible();
 
 		// Close and reopen the file
@@ -42,7 +42,7 @@ test.describe('Quarto - Inline Output: Persistence', {
 		await editors.waitForActiveTab('simple_plot.qmd');
 
 		// Verify output persisted
-		await inlineQuarto.gotoLine(25);
+		await inlineQuarto.revealOutput(20);
 		await inlineQuarto.expectOutputVisible();
 	});
 
@@ -104,7 +104,7 @@ print("Hello from untitled!")
 
 		// Run the cell and wait for output
 		await editors.clickTab('simple_plot.qmd');
-		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 12, outputLine: 25 });
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 12, outputLine: 20 });
 
 		// Get initial kernel text
 		await inlineQuarto.expectKernelIdle();

--- a/test/e2e/tests/quarto/quarto-inline-output-popout.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-popout.test.ts
@@ -37,7 +37,7 @@ test.describe('Quarto - Inline Output: Popout', {
 
 		// Run the cell and wait for output
 		await editors.clickTab('simple_plot.qmd');
-		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 12, outputLine: 25 });
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 12, outputLine: 20 });
 
 		// Save the plot — hover directly on the (CSS-hidden) save button with
 		// force:true so the mouse lands at the button's position, triggering the
@@ -71,7 +71,7 @@ test.describe('Quarto - Inline Output: Popout', {
 
 		// Run the cell and wait for output
 		await editors.clickTab('simple_plot.qmd');
-		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 12, outputLine: 25 });
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 12, outputLine: 20 });
 		await inlineQuarto.expectOutputVisible();
 
 		// Verify new tab opens with image when popout button is clicked
@@ -95,7 +95,7 @@ test.describe('Quarto - Inline Output: Popout', {
 
 		// Run the cell and wait for output
 		await editors.clickTab(tab1);
-		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 13, outputLine: 20 });
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 13, outputLine: 15 });
 
 		// Verify new tab opens with text output when popout command is run
 		await inlineQuarto.gotoLine(13);
@@ -114,7 +114,7 @@ test.describe('Quarto - Inline Output: Popout', {
 
 		// Run the cell and wait for output
 		await editors.clickTab('r_errors.qmd');
-		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 8, outputLine: 15 });
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 8, outputLine: 10 });
 
 		// Verify error is visible and popout button is hidden
 		await inlineQuarto.expectErrorCount(1);
@@ -134,7 +134,7 @@ test.describe('Quarto - Inline Output: Popout', {
 
 			// Run the cell and wait for output
 			await editors.clickTab('interactive_plot.qmd');
-			await inlineQuarto.runCellAndWaitForOutput({ cellLine: 8, outputLine: 15 });
+			await inlineQuarto.runCellAndWaitForOutput({ cellLine: 8, outputLine: 10 });
 			await inlineQuarto.expectOutputVisible();
 
 			// Run the popout command and verify viewer panel opens with interactive HTML
@@ -154,7 +154,7 @@ test.describe('Quarto - Inline Output: Popout', {
 
 		// Run the cell and wait for output
 		await editors.clickTab('simple_plot.qmd');
-		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 12, outputLine: 25 });
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 12, outputLine: 20 });
 		await inlineQuarto.expectOutputVisible();
 
 		// Run the popout command and verify new tab opens with image
@@ -176,7 +176,7 @@ test.describe('Quarto - Inline Output: Popout', {
 
 		// Run the cell and wait for output
 		await editors.clickTab('py_data_frame.qmd');
-		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 8, outputLine: 15 });
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 8, outputLine: 11 });
 		await inlineQuarto.expectOutputVisible();
 
 		// Run the popout command and verify viewer panel opens with DataFrame HTML

--- a/test/e2e/tests/quarto/quarto-inline-output-static.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-static.test.ts
@@ -84,8 +84,10 @@ test.describe('Quarto - Inline Output: Static Content', {
 		const runButton = inlineQuarto.cellToolbar.last().locator('.quarto-toolbar-run');
 		await runButton.click();
 
-		// Wait for output
-		await inlineQuarto.revealOutput(29, { target: inlineQuarto.inlineOutput.last() });
+		// Wait for output. Line 29 is the bash cell's closing fence; a line past
+		// EOF would clamp to the last line and reveal it at maximum scroll.
+		await inlineQuarto.gotoLine(29);
+		await expect(inlineQuarto.inlineOutput.last()).toBeVisible();
 
 		// Verify output content
 		await expect(inlineQuarto.inlineOutput.last().locator('.quarto-output-content')).toBeVisible({ timeout: 10000 });

--- a/test/e2e/tests/quarto/quarto-inline-output-static.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-static.test.ts
@@ -85,8 +85,7 @@ test.describe('Quarto - Inline Output: Static Content', {
 		await runButton.click();
 
 		// Wait for output
-		await inlineQuarto.gotoLine(35);
-		await expect(inlineQuarto.inlineOutput.last()).toBeVisible();
+		await inlineQuarto.revealOutput(29, { target: inlineQuarto.inlineOutput.last() });
 
 		// Verify output content
 		await expect(inlineQuarto.inlineOutput.last().locator('.quarto-output-content')).toBeVisible({ timeout: 10000 });

--- a/test/e2e/tests/quarto/quarto-inline-output-tab-switch.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-tab-switch.test.ts
@@ -31,7 +31,7 @@ test.describe('Quarto - Inline Output: Tab Switch Persistence', {
 		await inlineQuarto.expectKernelStatusVisible();
 
 		// Step 3: Run the cell and verify the inline data explorer appears
-		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 7, outputLine: 20 });
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 7, outputLine: 12 });
 		await inlineQuarto.expectOutputVisible();
 		await inlineDataExplorer.expectToBeVisible();
 		await inlineDataExplorer.expectGridToBeReady();
@@ -47,7 +47,7 @@ test.describe('Quarto - Inline Output: Tab Switch Persistence', {
 
 		// Step 6: Scroll to where the output should be and verify the data
 		// explorer is still showing (not fallen back to text)
-		await inlineQuarto.gotoLine(20);
+		await inlineQuarto.revealOutput(12);
 		await inlineQuarto.expectOutputVisible();
 		await inlineDataExplorer.expectToBeVisible();
 		await inlineDataExplorer.expectGridToBeReady();

--- a/test/e2e/tests/quarto/quarto-variables-follow.test.ts
+++ b/test/e2e/tests/quarto/quarto-variables-follow.test.ts
@@ -37,7 +37,7 @@ test.describe('Quarto - Variables Follow Mode', {
 
 		// Step 3: Run the current cell to start the Quarto kernel and create variables
 		await editors.clickTab('report.qmd');
-		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 17, outputLine: 30 });
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 17, outputLine: 28 });
 
 		// After running code in the QMD, variables pane should show the QMD's variables
 		await variables.waitForVariableRow('theta');


### PR DESCRIPTION
### Summary
Quarto inline-output reveals navigated past EOF to the document's last line, so a self-resizing output (the plotly webview settling shorter) made Monaco clamp scrollTop to the bottom and set the view zone to `display: none`, with nothing left to scroll it back into view. Triaged from `Python - Verify interactive HTML widget persists correctly after window reload` (7 failures / 5.8% on main, ubuntu/chromium), then found in 8 more specs -- 22 call sites in all.
- add `revealOutput()`, which re-drives `gotoLine` + `toBeVisible` under `expect.toPass()` so a post-reveal resize can recover
- run helpers use it, and their default drops from 120000ms (equal to the test timeout, which hid the assertion behind a bare test timeout) to 60000ms
- correct 22 `outputLine` / `gotoLine` values to the cell's closing fence instead of a line past EOF

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:quarto @:web

Test-only change. Local runs: full quarto sweep on electron 60/62 and on chromium 47/49 -- in both, every failure is a test I did not touch (a console session start, a webview restore, an untitled-doc toolbar, and a bash cell that yields a status-only output), and the two that recurred also fail on `main`. The CI-only condition for the original flake -- a ~283px editor viewport -- does not reproduce locally, so the post-merge trend is the real evidence.
