### PR TITLE
Restore tslib dev flag in Python extension package-lock.json

### DIFF
--- a/extensions/positron-python/package-lock.json
+++ b/extensions/positron-python/package-lock.json
@@ -14890,6 +14890,7 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
             "license": "0BSD"
         },
         "node_modules/tty-browserify": {


### PR DESCRIPTION
Restores the `"dev": true` flag on the top-level `tslib` entry in `extensions/positron-python/package-lock.json`, so the committed lockfile matches what a fresh clone actually installs.

### Summary

`tslib@2.8.1` sits exactly on the peer-only/dev boundary in this extension. Its only production in-edges are `peerDependencies` of the `@microsoft/applicationinsights-*` packages (pulled in by `@vscode/extension-telemetry`); every `dependencies` edge comes from dev-only packages (`@azure/*`, `@typespec/ts-http-runtime`).

The root `.npmrc` sets `legacy-peer-deps="true"`, and npm exports its config as `npm_config_*` env vars when it runs the root `postinstall`, which `build/npm/postinstall.ts` inherits when it spawns `npm install` in each extension directory. With `legacy-peer-deps` in effect npm ignores the peer edges, leaving `tslib` reachable only from devDependencies -- hence `"dev": true`.

npm's project `.npmrc` lookup does not walk up parent directories, so running `npm install` directly inside `extensions/positron-python/` never sees `legacy-peer-deps`, honors the peer edges, and drops the flag. Both values come from legitimate install paths; the root-driven one is what the shipped build uses, so that is the one that belongs in git. This line last flipped in #15312 and was previously restored by #14450.

Verified against `main`'s lockfile in a scratch directory: `npm install --package-lock-only` produces no flag, while `npm install --package-lock-only --legacy-peer-deps` produces `"dev": true`.

No dependency versions change and no package is added or removed, so the installed tree is identical either way.

33 other Positron-authored extensions with lockfiles also lack `legacy-peer-deps` in their `.npmrc`, while every upstream VS Code extension has it. Adding it to those is deliberately out of scope here -- `legacy-peer-deps` suppresses genuine peer conflict errors, so adopting it more broadly deserves its own discussion. If this line flips back again, that is the signal to have it.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:critical

1. From a fresh clone, run `npm install` at the repo root.
2. Run `git status` and confirm `extensions/positron-python/package-lock.json` is unmodified.
