### PR TITLE
Exclude broken argcomplete 3.7.1 from Python CI nox install

### DIFF
--- a/.github/workflows/positron-python-ci.yml
+++ b/.github/workflows/positron-python-ci.yml
@@ -245,7 +245,12 @@ jobs:
       - name: Install testing requirements
         run: |
           uv run scripts/vendor.py
-          uv pip install nox
+          # argcomplete is a nox dependency. 3.7.1 annotates a class attribute
+          # with PEP 604 `str | bytes`, which is evaluated at runtime and needs
+          # Python 3.10+, but the release still declares requires_python>=3.8.
+          # uv installs it into this 3.9 venv and importing nox then raises
+          # TypeError. Drop the exclusion once upstream corrects the metadata.
+          uv pip install nox 'argcomplete!=3.7.1'
 
       - name: Run tests
         run: npm run positron:testMinimumPythonReqs


### PR DESCRIPTION
Unblocks `positron-python` CI, which is currently red on `main` and on every PR that touches the extension.

### Summary

The `Test Minimum Positron IPyKernel Dependencies (ubuntu-latest, 3.9)` job fails while importing nox:

```
File ".venv/lib/python3.9/site-packages/argcomplete/completers.py", line 35, in ChoicesCompleter
choices: Final[Mapping[str, str | bytes]]
TypeError: unsupported operand type(s) for |: 'type' and 'type'
```

`argcomplete 3.7.1` (published 2026-08-04 15:03 UTC) annotates a class attribute with PEP 604 `str | bytes`. Class-body annotations are evaluated at runtime, so this requires Python 3.10+, but the release still declares `requires_python>=3.8` -- uv installs it into the 3.9 venv and importing nox raises. The job installs nox unpinned, so it picked up the new version automatically. First red run on `main` was `eabc8ddc8` at 15:26 UTC, roughly 20 minutes after the release; the last green run was 2026-07-31. `argcomplete 3.7.0` is unaffected.

This adds an exclusion to that one install step:

```
uv pip install nox 'argcomplete!=3.7.1'
```

`!=3.7.1` rather than `<3.7.1` so a corrected 3.7.2 is picked up automatically instead of freezing argcomplete at the current version. The comment in the workflow records why the exclusion exists and when it can be removed. This is the only unpinned nox install in the repo; the other `argcomplete` references are vendored `jupyter_core` / `traitlets` code and are unrelated.

Worth reporting upstream separately, since the underlying problem is `requires_python` metadata that doesn't match the code.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

No e2e tags apply -- this changes a CI workflow only, with no product code touched. The Python CI run on this PR is the validation: the `Test Minimum Positron IPyKernel Dependencies (ubuntu-latest, 3.9)` job should go green.

Locally verified that the constraint resolves as intended under Python 3.9: