### PR TITLE
fix: re-file the Quarto output cache when an untitled document is saved in web

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
@@ -380,11 +380,9 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 			const newModel = this._editor.getModel();
 			this._documentUri = newModel?.uri;
 
-			// Handle untitled->saved transition: transfer cache from old URI to new URI
-			// This happens when a user saves an untitled Quarto document to a file.
-			// Any non-untitled scheme counts as saved: in a remote or web window the
-			// saved document is `vscode-remote`, and requiring `file` here left the
-			// cache keyed to the untitled URI, so outputs were lost on reload.
+			// Handle untitled->saved transition: transfer cache from old URI to new URI.
+			// Any non-untitled scheme counts as saved; a remote or web window saves
+			// to `vscode-remote`, not `file`.
 			if (previousUri && this._documentUri &&
 				previousUri.scheme === 'untitled' &&
 				this._documentUri.scheme !== 'untitled' &&

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
@@ -381,10 +381,13 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 			this._documentUri = newModel?.uri;
 
 			// Handle untitled->saved transition: transfer cache from old URI to new URI
-			// This happens when a user saves an untitled Quarto document to a file
+			// This happens when a user saves an untitled Quarto document to a file.
+			// Any non-untitled scheme counts as saved: in a remote or web window the
+			// saved document is `vscode-remote`, and requiring `file` here left the
+			// cache keyed to the untitled URI, so outputs were lost on reload.
 			if (previousUri && this._documentUri &&
 				previousUri.scheme === 'untitled' &&
-				this._documentUri.scheme === 'file' &&
+				this._documentUri.scheme !== 'untitled' &&
 				this._isQuartoDocument()) {
 				this._transferCacheFromUntitled(previousUri, this._documentUri);
 			}

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputManagerSaveAs.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputManagerSaveAs.vitest.ts
@@ -36,7 +36,8 @@ import { IResourceUsageHistoryService } from '../../../../services/positronConso
  * saved URI to restore from once the window reloaded.
  *
  * These tests drive the real contribution across an `onDidChangeModel` from an
- * untitled model to a saved one, and assert which URI the cache was written to.
+ * untitled model to a saved one, and assert what the cache was written under --
+ * the URI, and the cell id and hash a reload would have to look the outputs up by.
  */
 describe('QuartoOutputContribution -- cache rebind on Save As', () => {
 	const cellId = '0-abchash-unlabeled';
@@ -51,27 +52,32 @@ describe('QuartoOutputContribution -- cache rebind on Save As', () => {
 	let untitledCache = new Map<string, ICellOutput[]>();
 	let currentModel: ITextModel | undefined;
 
-	/** URIs the contribution wrote cached output to, in call order. */
-	let savedToUris: string[] = [];
+	/** Cache writes the contribution made, in call order. */
+	let cacheWrites: { uri: string; cellId: string; contentHash: string }[] = [];
 	/** URIs whose cache the contribution cleared, in call order. */
 	let clearedUris: string[] = [];
 
 	const quartoModel = stubInterface<IQuartoDocumentModel>({
 		get cells() { return liveCells; },
 		onDidParse: Event.None,
-		findCellByContentHash: (hash: string) => liveCells.find(c => c.contentHash === hash),
 		getCellById: (id: string) => liveCells.find(c => c.id === id),
 	});
 
 	const ctx = createTestContainer()
-		.withWorkbenchServices()
 		.withContributionServices()
 		.stub(IQuartoDocumentModelService, { getModel: () => quartoModel })
 		.stub(IQuartoOutputCacheService, {
+			// No cache exists under the saved URI until the rebind writes one.
+			// These two are read inside the restore pass's try/catch, so leaving
+			// them unstubbed would abort that pass silently rather than loudly.
 			loadCache: async () => undefined,
 			findCacheByContentHash: async () => undefined,
 			getCachedOutputs: (uri: URI) => uri.toString() === untitledUri.toString() ? untitledCache : new Map(),
-			saveOutput: (uri: URI) => { savedToUris.push(uri.toString()); },
+			// A reload restores by cell id and hash, so record those alongside the
+			// URI -- a write under the pre-save id is as lost as no write at all.
+			saveOutput: (uri: URI, cellId: string, contentHash: string) => {
+				cacheWrites.push({ uri: uri.toString(), cellId, contentHash });
+			},
 			clearCache: (uri: URI) => { clearedUris.push(uri.toString()); },
 		})
 		.stub(IQuartoExecutionManager, {
@@ -95,16 +101,16 @@ describe('QuartoOutputContribution -- cache rebind on Save As', () => {
 	beforeEach(() => {
 		liveCells = [];
 		untitledCache = new Map([[cellId, [output]]]);
-		savedToUris = [];
+		cacheWrites = [];
 		clearedUris = [];
 		currentModel = undefined;
 	});
 
 	/** A parsed cell for the one-line code range the text models below carry. */
-	function cell(): QuartoCodeCell {
+	function cell(overrides: { id?: string; contentHash?: string } = {}): QuartoCodeCell {
 		return stubInterface<QuartoCodeCell>({
-			id: cellId,
-			contentHash,
+			id: overrides.id ?? cellId,
+			contentHash: overrides.contentHash ?? contentHash,
 			label: undefined,
 			codeStartLine: 1,
 			codeEndLine: 1,
@@ -119,9 +125,10 @@ describe('QuartoOutputContribution -- cache rebind on Save As', () => {
 
 	/**
 	 * Instantiate the contribution over an untitled document, then fire the
-	 * model change that a Save As produces, landing on `savedUri`.
+	 * model change that a Save As produces, landing on `savedUri`. The saved
+	 * document parses as `savedCells`, which defaults to the cached cell.
 	 */
-	function saveAsTo(savedUri: URI): void {
+	function saveAsTo(savedUri: URI, savedCells: QuartoCodeCell[] = [cell()]): QuartoOutputContribution {
 		modelFor(untitledUri);
 		const editor = stubInterface<ICodeEditor>({
 			hasModel: (() => true) as ICodeEditor['hasModel'],
@@ -131,42 +138,95 @@ describe('QuartoOutputContribution -- cache rebind on Save As', () => {
 			onDidScrollChange: Event.None,
 		});
 		QUARTO_INLINE_OUTPUT_ENABLED.bindTo(ctx.get(IContextKeyService)).set(true);
-		ctx.disposables.add(ctx.instantiationService.createInstance(QuartoOutputContribution, editor));
+		const contribution = ctx.disposables.add(ctx.instantiationService.createInstance(QuartoOutputContribution, editor));
 
 		// The save swaps the editor's model for the saved document, which the
 		// document model reports as parsed by the time the change is handled.
 		modelFor(savedUri);
-		liveCells = [cell()];
+		liveCells = savedCells;
 		modelChangeEmitter.fire({ oldModelUrl: untitledUri, newModelUrl: savedUri });
+		return contribution;
 	}
 
 	it('rebinds the cache to a vscode-remote document saved from untitled', () => {
 		const savedUri = URI.from({ scheme: 'vscode-remote', authority: 'localhost:9000', path: '/w/saved.qmd' });
 
-		saveAsTo(savedUri);
+		const contribution = saveAsTo(savedUri);
 
 		// With the bug the rebind was skipped for any non-file scheme, so the
 		// cache stayed under the untitled URI and the reload had nothing to load.
-		expect({ savedToUris, clearedUris }).toEqual({
-			savedToUris: [savedUri.toString()],
+		// The in-memory outputs are what keep the output on screen across the save.
+		expect({
+			cacheWrites,
+			clearedUris,
+			outputs: contribution.getOutputsForCell(cellId),
+		}).toEqual({
+			cacheWrites: [{ uri: savedUri.toString(), cellId, contentHash }],
 			clearedUris: [untitledUri.toString()],
+			outputs: [output],
 		});
 	});
 
 	it('rebinds the cache to a file document saved from untitled', () => {
 		const savedUri = URI.file('/w/saved.qmd');
 
-		saveAsTo(savedUri);
+		const contribution = saveAsTo(savedUri);
 
-		expect({ savedToUris, clearedUris }).toEqual({
-			savedToUris: [savedUri.toString()],
+		expect({
+			cacheWrites,
+			clearedUris,
+			outputs: contribution.getOutputsForCell(cellId),
+		}).toEqual({
+			cacheWrites: [{ uri: savedUri.toString(), cellId, contentHash }],
 			clearedUris: [untitledUri.toString()],
+			outputs: [output],
+		});
+	});
+
+	it('rebinds to a cell whose index shifted, matching on the content hash prefix', () => {
+		// The cached id encodes the cell's index (`0-abchash-unlabeled`), so an
+		// edit above the cell changes its id. The rebind falls back to matching
+		// the hash prefix, and the outputs must follow the cell's new id.
+		const savedUri = URI.file('/w/saved.qmd');
+		const shifted = cell({ id: '1-abchash-unlabeled', contentHash: `${contentHash}9f` });
+
+		const contribution = saveAsTo(savedUri, [shifted]);
+
+		expect({
+			cacheWrites,
+			outputsUnderNewId: contribution.getOutputsForCell(shifted.id),
+			outputsUnderCachedId: contribution.getOutputsForCell(cellId),
+		}).toEqual({
+			// Written under the cell's new id, not the cached one it matched by.
+			cacheWrites: [{ uri: savedUri.toString(), cellId: shifted.id, contentHash: shifted.contentHash }],
+			outputsUnderNewId: [output],
+			outputsUnderCachedId: [],
+		});
+	});
+
+	it('writes nothing for a cached cell that matches no cell in the saved document', () => {
+		const savedUri = URI.file('/w/saved.qmd');
+		const unrelated = cell({ id: '0-zzzhash-unlabeled', contentHash: 'zzzhash' });
+
+		const contribution = saveAsTo(savedUri, [unrelated]);
+
+		// Nothing transfers, and the untitled cache is cleared regardless, so a
+		// cell edited during the save loses its output. Asserting the clear pins
+		// today's behavior rather than endorsing it.
+		expect({
+			cacheWrites,
+			clearedUris,
+			outputs: contribution.getOutputsForCell(unrelated.id),
+		}).toEqual({
+			cacheWrites: [],
+			clearedUris: [untitledUri.toString()],
+			outputs: [],
 		});
 	});
 
 	it('does not rebind when an untitled document is swapped for another untitled one', () => {
 		saveAsTo(URI.from({ scheme: 'untitled', path: '/Untitled-2.qmd' }));
 
-		expect({ savedToUris, clearedUris }).toEqual({ savedToUris: [], clearedUris: [] });
+		expect({ cacheWrites, clearedUris }).toEqual({ cacheWrites: [], clearedUris: [] });
 	});
 });

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputManagerSaveAs.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputManagerSaveAs.vitest.ts
@@ -25,19 +25,12 @@ import { IResourceUsageHistoryService } from '../../../../services/positronConso
 
 /**
  * Regression coverage for inline output disappearing after a window reload when
- * an untitled Quarto document was saved with Save As (71% on sles/chromium).
+ * an untitled Quarto document was saved with Save As.
  *
- * On the untitled->saved transition the contribution rebinds the output cache
- * from the untitled URI to the saved document's URI. That rebind used to require
- * a `file` scheme, so in a remote or web window -- where a saved document is
- * `vscode-remote` -- it never ran and the cache stayed keyed to the untitled URI.
- * Output still rendered right after the save, because the content-hash fallback
- * matched the still-live untitled cache in memory, but nothing existed under the
- * saved URI to restore from once the window reloaded.
- *
- * These tests drive the real contribution across an `onDidChangeModel` from an
- * untitled model to a saved one, and assert what the cache was written under --
- * the URI, and the cell id and hash a reload would have to look the outputs up by.
+ * On the untitled->saved transition the contribution rebinds the output cache to
+ * the saved document's URI. The rebind used to require a `file` scheme, so a
+ * remote or web save (`vscode-remote`) left the cache keyed to the untitled URI
+ * with nothing for the reload to restore from.
  */
 describe('QuartoOutputContribution -- cache rebind on Save As', () => {
 	const cellId = '0-abchash-unlabeled';
@@ -148,28 +141,14 @@ describe('QuartoOutputContribution -- cache rebind on Save As', () => {
 		return contribution;
 	}
 
-	it('rebinds the cache to a vscode-remote document saved from untitled', () => {
-		const savedUri = URI.from({ scheme: 'vscode-remote', authority: 'localhost:9000', path: '/w/saved.qmd' });
-
-		const contribution = saveAsTo(savedUri);
-
-		// With the bug the rebind was skipped for any non-file scheme, so the
-		// cache stayed under the untitled URI and the reload had nothing to load.
-		// The in-memory outputs are what keep the output on screen across the save.
-		expect({
-			cacheWrites,
-			clearedUris,
-			outputs: contribution.getOutputsForCell(cellId),
-		}).toEqual({
-			cacheWrites: [{ uri: savedUri.toString(), cellId, contentHash }],
-			clearedUris: [untitledUri.toString()],
-			outputs: [output],
-		});
-	});
-
-	it('rebinds the cache to a file document saved from untitled', () => {
-		const savedUri = URI.file('/w/saved.qmd');
-
+	// The rebind is scheme-independent: with the bug it was skipped for any
+	// non-file scheme, so the cache stayed under the untitled URI and the reload
+	// had nothing to load. The in-memory outputs keep the output on screen
+	// across the save either way.
+	it.each([
+		['vscode-remote', URI.from({ scheme: 'vscode-remote', authority: 'localhost:9000', path: '/w/saved.qmd' })],
+		['file', URI.file('/w/saved.qmd')],
+	])('rebinds the cache to a %s document saved from untitled', (_scheme, savedUri) => {
 		const contribution = saveAsTo(savedUri);
 
 		expect({

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputManagerSaveAs.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputManagerSaveAs.vitest.ts
@@ -1,0 +1,172 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { URI } from '../../../../../base/common/uri.js';
+import { Event, Emitter } from '../../../../../base/common/event.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { createTextModel } from '../../../../../editor/test/common/testTextModel.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
+import { ITextModel } from '../../../../../editor/common/model.js';
+import { IModelChangedEvent } from '../../../../../editor/common/editorCommon.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { QuartoOutputContribution, IQuartoOutputManager } from '../../browser/quartoOutputManager.js';
+import { IQuartoDocumentModelService } from '../../browser/quartoDocumentModelService.js';
+import { IQuartoKernelManager } from '../../browser/quartoKernelManager.js';
+import { IQuartoExecutionManager, IQuartoOutputCacheService, ICellOutput } from '../../common/quartoExecutionTypes.js';
+import { IQuartoDocumentModel, QuartoCodeCell } from '../../common/quartoTypes.js';
+import { QUARTO_INLINE_OUTPUT_ENABLED } from '../../common/positronQuartoConfig.js';
+import { IPositronNotebookOutputWebviewService } from '../../../positronOutputWebview/browser/notebookOutputWebviewService.js';
+import { IResourceUsageHistoryService } from '../../../../services/positronConsole/browser/resourceUsageHistoryService.js';
+
+/**
+ * Regression coverage for inline output disappearing after a window reload when
+ * an untitled Quarto document was saved with Save As (71% on sles/chromium).
+ *
+ * On the untitled->saved transition the contribution rebinds the output cache
+ * from the untitled URI to the saved document's URI. That rebind used to require
+ * a `file` scheme, so in a remote or web window -- where a saved document is
+ * `vscode-remote` -- it never ran and the cache stayed keyed to the untitled URI.
+ * Output still rendered right after the save, because the content-hash fallback
+ * matched the still-live untitled cache in memory, but nothing existed under the
+ * saved URI to restore from once the window reloaded.
+ *
+ * These tests drive the real contribution across an `onDidChangeModel` from an
+ * untitled model to a saved one, and assert which URI the cache was written to.
+ */
+describe('QuartoOutputContribution -- cache rebind on Save As', () => {
+	const cellId = '0-abchash-unlabeled';
+	const contentHash = 'abchash';
+	const untitledUri = URI.from({ scheme: 'untitled', path: '/Untitled-1.qmd' });
+	const output: ICellOutput = { outputId: 'out-1', items: [{ mime: 'text/plain', data: 'plot' }] };
+
+	// Describe-scope so the container's stubs capture stable references at
+	// build() time; reset per test (see beforeEach) for isolation.
+	const modelChangeEmitter = new Emitter<IModelChangedEvent>();
+	let liveCells: QuartoCodeCell[] = [];
+	let untitledCache = new Map<string, ICellOutput[]>();
+	let currentModel: ITextModel | undefined;
+
+	/** URIs the contribution wrote cached output to, in call order. */
+	let savedToUris: string[] = [];
+	/** URIs whose cache the contribution cleared, in call order. */
+	let clearedUris: string[] = [];
+
+	const quartoModel = stubInterface<IQuartoDocumentModel>({
+		get cells() { return liveCells; },
+		onDidParse: Event.None,
+		findCellByContentHash: (hash: string) => liveCells.find(c => c.contentHash === hash),
+		getCellById: (id: string) => liveCells.find(c => c.id === id),
+	});
+
+	const ctx = createTestContainer()
+		.withWorkbenchServices()
+		.withContributionServices()
+		.stub(IQuartoDocumentModelService, { getModel: () => quartoModel })
+		.stub(IQuartoOutputCacheService, {
+			loadCache: async () => undefined,
+			findCacheByContentHash: async () => undefined,
+			getCachedOutputs: (uri: URI) => uri.toString() === untitledUri.toString() ? untitledCache : new Map(),
+			saveOutput: (uri: URI) => { savedToUris.push(uri.toString()); },
+			clearCache: (uri: URI) => { clearedUris.push(uri.toString()); },
+		})
+		.stub(IQuartoExecutionManager, {
+			onDidReceiveOutput: Event.None,
+			onDidChangeExecutionState: Event.None,
+			onWillExecute: Event.None,
+		})
+		.stub(IQuartoKernelManager, {
+			onDidChangeKernelState: Event.None,
+			getSessionForDocument: () => undefined,
+		})
+		.stub(IQuartoOutputManager, {
+			onDidChangeOutputs: Event.None,
+			onDidRequestClearDocument: Event.None,
+			onDidRequestClearAll: Event.None,
+		})
+		.stub(IPositronNotebookOutputWebviewService, {})
+		.stub(IResourceUsageHistoryService, {})
+		.build();
+
+	beforeEach(() => {
+		liveCells = [];
+		untitledCache = new Map([[cellId, [output]]]);
+		savedToUris = [];
+		clearedUris = [];
+		currentModel = undefined;
+	});
+
+	/** A parsed cell for the one-line code range the text models below carry. */
+	function cell(): QuartoCodeCell {
+		return stubInterface<QuartoCodeCell>({
+			id: cellId,
+			contentHash,
+			label: undefined,
+			codeStartLine: 1,
+			codeEndLine: 1,
+		});
+	}
+
+	/** Swap in a text model for the given URI; returns it for the editor stub. */
+	function modelFor(uri: URI): ITextModel {
+		currentModel = ctx.disposables.add(createTextModel('print("hi")', 'quarto', undefined, uri));
+		return currentModel;
+	}
+
+	/**
+	 * Instantiate the contribution over an untitled document, then fire the
+	 * model change that a Save As produces, landing on `savedUri`.
+	 */
+	function saveAsTo(savedUri: URI): void {
+		modelFor(untitledUri);
+		const editor = stubInterface<ICodeEditor>({
+			hasModel: (() => true) as ICodeEditor['hasModel'],
+			getModel: () => currentModel ?? null,
+			getOption: (() => false) as ICodeEditor['getOption'],
+			onDidChangeModel: modelChangeEmitter.event,
+			onDidScrollChange: Event.None,
+		});
+		QUARTO_INLINE_OUTPUT_ENABLED.bindTo(ctx.get(IContextKeyService)).set(true);
+		ctx.disposables.add(ctx.instantiationService.createInstance(QuartoOutputContribution, editor));
+
+		// The save swaps the editor's model for the saved document, which the
+		// document model reports as parsed by the time the change is handled.
+		modelFor(savedUri);
+		liveCells = [cell()];
+		modelChangeEmitter.fire({ oldModelUrl: untitledUri, newModelUrl: savedUri });
+	}
+
+	it('rebinds the cache to a vscode-remote document saved from untitled', () => {
+		const savedUri = URI.from({ scheme: 'vscode-remote', authority: 'localhost:9000', path: '/w/saved.qmd' });
+
+		saveAsTo(savedUri);
+
+		// With the bug the rebind was skipped for any non-file scheme, so the
+		// cache stayed under the untitled URI and the reload had nothing to load.
+		expect({ savedToUris, clearedUris }).toEqual({
+			savedToUris: [savedUri.toString()],
+			clearedUris: [untitledUri.toString()],
+		});
+	});
+
+	it('rebinds the cache to a file document saved from untitled', () => {
+		const savedUri = URI.file('/w/saved.qmd');
+
+		saveAsTo(savedUri);
+
+		expect({ savedToUris, clearedUris }).toEqual({
+			savedToUris: [savedUri.toString()],
+			clearedUris: [untitledUri.toString()],
+		});
+	});
+
+	it('does not rebind when an untitled document is swapped for another untitled one', () => {
+		saveAsTo(URI.from({ scheme: 'untitled', path: '/Untitled-2.qmd' }));
+
+		expect({ savedToUris, clearedUris }).toEqual({ savedToUris: [], clearedUris: [] });
+	});
+});


### PR DESCRIPTION
### Summary

When you run a Quarto cell, Positron saves a copy of the output to a cache filed under the document's address. Saving an untitled document with Save As is supposed to re-file that cache under the new filename, but the code only did so when the new address looked like a plain local file. In Positron Web and remote sessions a saved file has a different kind of address, so the cache stayed filed under "Untitled-1" and a window reload found nothing to restore, so the output vanished.

- Re-file the cache for any saved address, not just plain local files
- The output looked fine right after the save because a copy in memory was matched by cell content; only a reload exposed the loss
- Explains why this failed on web (71% on sles/chromium) but almost never on desktop, where a saved file does have a plain local address
- One thing to flag for review: when a cached cell matches no cell in the saved document, the untitled cache is cleared anyway, so a cell edited during the save loses its output. The new test pins that behavior; making the clear conditional would be a separate change
- Adds `quartoOutputManagerSaveAs.vitest.ts` covering the re-filing for a remote address, a local file, and untitled-to-untitled

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Quarto inline output no longer disappears after reloading the window when an untitled document was saved with Save As

### Validation Steps

@:quarto @:web @:win

1. Open a new untitled Quarto document, add a Python cell, and run it
2. Save As to a real filename, then reload the window
3. The cell's output should still be there

### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- CORRECTED (supersedes the parse-race summary below): on Save As the Quarto output cache is never rebound from the untitled URI to the saved document, because _transferCacheFromUntitled is gated on this._documentUri.scheme === (file) (quartoOutputManager.ts:391) and in web a saved document URI is vscode-remote. The post-save assertion still passes via the in-memory findCacheByContentHash fallback to the live untitled cache; that fallback cannot survive a window reload, so post-reload restore finds no cache under the saved URI and mints zero view zones.</summary>

- **Test:** [Quarto - Inline Output: Persistence > Python - Verify inline output works in untitled Quarto document and persists through save](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Quarto%20-%20Inline%20Output%3A%20Persistence%20%3E%20Python%20-%20Verify%20inline%20output%20works%20in%20untitled%20Quarto%20document%20and%20persists%20through%20save%7C%7C%7Ctest%2Fe2e%2Ftests%2Fquarto%2Fquarto-inline-output-persistence.test.ts)
- **Targeted failure:** Pattern A -- expect(locator).toBeVisible() on locator('.quarto-inline-output').first().locator('.quarto-output-content'), 5 occurrences / 71.4% of 7 runs on main, sles/chromium, rep sha dea62542943085c854378d6c4132f800c0c5a1ba (run 30889748402).
- **Signal:** VERBOSE=1 e2e-chromium run (renderer trace + console forwarded to e2e-test-runner.log), repeat1 failing at spec line 92: 19:22:39.886 Saved output for cell 0-c2a393fb-unlabeled in untitled:Untitled-1; 19:22:40.719 Initializing for vscode-remote://.../test-...qmd (Save As -> vscode-remote scheme, so no Transferring cache from untitled to file line ever appears); 19:22:40.777 No cache file found for vscode-remote://...; 19:22:40.780 Found matching untitled cache: untitled:Untitled-1 with 1 matching cells -> Found cache by content hash match -> Restored cached outputs for 1 cells (this is what makes the post-save assert pass); 19:22:43.75 Flushing all caches / Flush complete; after reload 19:22:46.16 Initializing for the saved URI -> 19:22:46.399 No cache file found -> 19:22:46.541 No cached outputs to restore, with no untitled-cache match this time. Environment skew confirmed by mechanism: desktop saves to a file-scheme URI so the transfer runs (0.8% on win/electron) while web never does (71.4% on sles/chromium).
- **Frequency:** 5/7 runs (71.4%) on main, sles/chromium
- **Hypothesis:** Dropping the file-scheme requirement on the untitled->saved transition (accept any non-untitled scheme) makes the transfer write the cache under the real saved URI, so the post-reload restore finds it. The #15091 deferral fix is a genuine but separate bug: its log lines (No cells parsed yet, waiting for parse to retry cache load -> Cells found after parse, retrying cache load, 19:22:37) show it running as designed on the untitled document without affecting this failure. Ruled out: lost debounced write (the cache service joins flushAll on onWillShutdown and Flush complete is logged before the reload); _transferCacheFromUntitled losing a parse race (it is never called at all -- no transfer log line); the deferral gate (fix present and exercised, e2e rate unchanged: pre-fix 1/3, post-fix 4/6, verbose 4/4).
- **Supersedes:** PR #15091 (closed unmerged 2026-07-23, same mechanism, first found via the dataframe close+reopen flake)

</details>

