### PR TITLE
fix(quarto): wait for the document parse before restoring cached output

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoDocumentModel.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoDocumentModel.ts
@@ -112,6 +112,19 @@ export class QuartoDocumentModel extends Disposable implements IQuartoDocumentMo
 		return this._cells;
 	}
 
+	get isParsed(): boolean {
+		// The constructor parses the initial content synchronously, so cells are
+		// unknown only while a debounced re-parse of changed content is pending.
+		return this._parseTimeout === undefined;
+	}
+
+	async whenParsed(): Promise<void> {
+		if (this._parseTimeout === undefined) {
+			return;
+		}
+		await Event.toPromise(this.onDidParse);
+	}
+
 	getCellById(id: string): QuartoCodeCell | undefined {
 		return this._cellsById.get(id);
 	}

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoDocumentModel.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoDocumentModel.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Barrier } from '../../../../base/common/async.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable, IDisposable } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -57,6 +58,9 @@ export class QuartoDocumentModel extends Disposable implements IQuartoDocumentMo
 	private _cellsById = new Map<string, QuartoCodeCell>();
 	private _parseTimeout: ReturnType<typeof setTimeout> | undefined;
 
+	// Open while `_cells` reflects the document's current content.
+	private _parsedBarrier = new Barrier();
+
 	private readonly _onDidChangeCells = this._register(new Emitter<QuartoCellChangeEvent>());
 	readonly onDidChangeCells: Event<QuartoCellChangeEvent> = this._onDidChangeCells.event;
 
@@ -77,6 +81,7 @@ export class QuartoDocumentModel extends Disposable implements IQuartoDocumentMo
 
 		// Listen for changes with debouncing
 		this._register(this._textModel.onDidChangeContent(() => {
+			this._markUnparsed();
 			if (this._parseTimeout) {
 				clearTimeout(this._parseTimeout);
 			}
@@ -115,14 +120,22 @@ export class QuartoDocumentModel extends Disposable implements IQuartoDocumentMo
 	get isParsed(): boolean {
 		// The constructor parses the initial content synchronously, so cells are
 		// unknown only while a debounced re-parse of changed content is pending.
-		return this._parseTimeout === undefined;
+		return this._parsedBarrier.isOpen();
 	}
 
 	async whenParsed(): Promise<void> {
-		if (this._parseTimeout === undefined) {
-			return;
+		await this._parsedBarrier.wait();
+	}
+
+	/**
+	 * Closes the parse gate so `whenParsed` callers wait for the pending re-parse.
+	 * A `Barrier` can't be re-closed, hence the replacement -- but only when open,
+	 * since replacing a closed one strands the callers already waiting on it.
+	 */
+	private _markUnparsed(): void {
+		if (this._parsedBarrier.isOpen()) {
+			this._parsedBarrier = new Barrier();
 		}
-		await Event.toPromise(this.onDidParse);
 	}
 
 	getCellById(id: string): QuartoCodeCell | undefined {
@@ -238,6 +251,8 @@ export class QuartoDocumentModel extends Disposable implements IQuartoDocumentMo
 		}
 
 		this._jupyterKernel = parsed.jupyterKernel;
+
+		this._parsedBarrier.open();
 
 		// Always fire onDidParse after re-parsing, even if cells didn't change.
 		// This allows listeners to update positions based on fresh cell line numbers.

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
@@ -934,6 +934,16 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 
 			const quartoModel = this._documentModelService.getModel(model);
 
+			// Both lookups below match cached outputs to live cells by content
+			// hash, so they need the model's cells to be current.
+			if (!quartoModel.isParsed) {
+				this._logService.debug('[QuartoOutputContribution] Waiting for the document to be parsed before restoring cached outputs');
+				await quartoModel.whenParsed();
+				if (this._cachedOutputsLoaded || this._store.isDisposed) {
+					return;
+				}
+			}
+
 			// If no cache found, try to find cache by content hash
 			// This handles two cases:
 			// 1. A file document that was just saved from an untitled document
@@ -947,26 +957,6 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 				if (cachedDoc) {
 					this._logService.debug('[QuartoOutputContribution] Found cache by content hash match');
 				}
-			}
-
-			// If no cache found and no cells available yet, subscribe to model parse events.
-			// This handles the case where an untitled document is being restored via hot exit
-			// and the content hasn't been loaded yet when _loadCachedOutputs is first called.
-			if ((!cachedDoc || cachedDoc.cells.length === 0) &&
-				quartoModel.cells.length === 0 &&
-				this._documentUri.scheme === 'untitled') {
-
-				this._logService.debug('[QuartoOutputContribution] No cells found for untitled document, waiting for content to be restored');
-
-				// Subscribe to parse events - when content is restored and parsed, cells will appear
-				this._outputHandlingDisposables.add(quartoModel.onDidParse(() => {
-					// Only try once more after cells appear
-					if (quartoModel.cells.length > 0 && !this._cachedOutputsLoaded) {
-						this._logService.debug('[QuartoOutputContribution] Cells found after parse, retrying cache load');
-						this._loadCachedOutputs();
-					}
-				}));
-				return;
 			}
 
 			// Mark as loaded to prevent re-entry

--- a/src/vs/workbench/contrib/positronQuarto/common/quartoTypes.ts
+++ b/src/vs/workbench/contrib/positronQuarto/common/quartoTypes.ts
@@ -205,6 +205,22 @@ export interface IQuartoDocumentModel extends IDisposable {
 	readonly cells: readonly QuartoCodeCell[];
 
 	/**
+	 * Whether `cells` reflects the document's current content. False while a
+	 * debounced re-parse of changed content is pending.
+	 *
+	 * An empty `cells` list means "this document has no code cells" only when
+	 * this is true; otherwise the cells aren't known yet.
+	 */
+	readonly isParsed: boolean;
+
+	/**
+	 * Resolves once `cells` reflects the document's current content, immediately
+	 * if it already does. Callers that read `cells` to decide something about
+	 * the document, rather than to react to an edit, should await this first.
+	 */
+	whenParsed(): Promise<void>;
+
+	/**
 	 * Fired when cells change (add/remove/modify).
 	 */
 	readonly onDidChangeCells: Event<QuartoCellChangeEvent>;

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoDocumentModel.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoDocumentModel.vitest.ts
@@ -650,6 +650,21 @@ x = 1
 
 			await expect(model.whenParsed()).resolves.toBeUndefined();
 		});
+
+		it('whenParsed resolves for a waiter that arrived before a further edit rescheduled the parse', async () => {
+			const textModel = createTextModel('Just some markdown.\n', null, undefined, URI.file('/test.qmd'));
+			ctx.disposables.add(textModel);
+			const model = new QuartoDocumentModel(textModel, logService);
+			ctx.disposables.add(model);
+
+			textModel.setValue('```{python}\nx = 1\n```\n');
+			const waiter = model.whenParsed();
+			// Restarts the debounce; the waiter above must still be released.
+			textModel.setValue('```{python}\nx = 2\n```\n');
+
+			await expect(waiter).resolves.toBeUndefined();
+			expect(model.isParsed).toBe(true);
+		});
 	});
 
 });

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoDocumentModel.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoDocumentModel.vitest.ts
@@ -625,5 +625,31 @@ x = 1
 		});
 	});
 
+	// Callers that read `cells` to decide something about the document need to
+	// tell "this document has no cells" apart from "the cells aren't known yet".
+	describe('isParsed', () => {
+		it('is false while a debounced re-parse is pending, and true once it lands', async () => {
+			const textModel = createTextModel('Just some markdown.\n', null, undefined, URI.file('/test.qmd'));
+			ctx.disposables.add(textModel);
+			const model = new QuartoDocumentModel(textModel, logService);
+			ctx.disposables.add(model);
+
+			expect(model.isParsed).toBe(true);
+
+			textModel.setValue('```{python}\nx = 1\n```\n');
+			expect(model.isParsed).toBe(false);
+
+			await model.whenParsed();
+
+			expect(model.isParsed).toBe(true);
+			expect(model.cells.length).toBe(1);
+		});
+
+		it('whenParsed resolves without waiting when no re-parse is pending', async () => {
+			const model = createModel('Just some markdown.\n');
+
+			await expect(model.whenParsed()).resolves.toBeUndefined();
+		});
+	});
 
 });

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputManagerReopen.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputManagerReopen.vitest.ts
@@ -1,0 +1,192 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { URI } from '../../../../../base/common/uri.js';
+import { Event, Emitter } from '../../../../../base/common/event.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { createTextModel } from '../../../../../editor/test/common/testTextModel.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { QuartoOutputContribution, IQuartoOutputManager } from '../../browser/quartoOutputManager.js';
+import { IQuartoDocumentModelService } from '../../browser/quartoDocumentModelService.js';
+import { IQuartoKernelManager } from '../../browser/quartoKernelManager.js';
+import { IQuartoExecutionManager, IQuartoOutputCacheService, ICachedDocument } from '../../common/quartoExecutionTypes.js';
+import { IQuartoDocumentModel, QuartoCodeCell } from '../../common/quartoTypes.js';
+import { QUARTO_INLINE_OUTPUT_ENABLED } from '../../common/positronQuartoConfig.js';
+import { IPositronNotebookOutputWebviewService } from '../../../positronOutputWebview/browser/notebookOutputWebviewService.js';
+import { IResourceUsageHistoryService } from '../../../../services/positronConsole/browser/resourceUsageHistoryService.js';
+
+/**
+ * Regression coverage for the close-and-reopen flake where a Quarto .qmd's
+ * inline output silently fails to re-render.
+ *
+ * `_loadCachedOutputs` matches cached outputs to live cells by content hash, so
+ * a restore that ran before the parse matched nothing and marked itself
+ * complete, dropping every cached output. It now waits on the model's parse
+ * state, which separates "not parsed yet" from "parsed, and this document has
+ * no cells".
+ *
+ * `getCellById` returns undefined throughout, so the restore records outputs
+ * via `getOutputsForCell` without building a view zone: the wait decision is
+ * under test, not the render layer.
+ */
+describe('QuartoOutputContribution -- cached output restore on reopen', () => {
+	const cachedCellId = '0-abchash-unlabeled';
+	const contentHash = 'abchash';
+
+	// Describe-scope so the container's stubs capture stable references at
+	// build() time; reset per test (see beforeEach) for isolation.
+	const parseEmitter = new Emitter<void>();
+	let liveCells: QuartoCodeCell[] = [];
+	let isParsed = false;
+	let cachedDoc: ICachedDocument | undefined;
+	let hashMatchedDoc: ICachedDocument | undefined;
+
+	// Spied so the fallback's arguments can be asserted: it keys off the model's
+	// cells, so the hashes it receives show whether it ran before or after the parse.
+	const findCacheByContentHash = vi.fn(async (_targetUri: URI, _contentHashes: string[]) => hashMatchedDoc);
+
+	const quartoModel = stubInterface<IQuartoDocumentModel>({
+		get cells() { return liveCells; },
+		get isParsed() { return isParsed; },
+		whenParsed: async () => {
+			if (!isParsed) {
+				await Event.toPromise(parseEmitter.event);
+			}
+		},
+		onDidParse: parseEmitter.event,
+		findCellByContentHash: (hash: string) => liveCells.find(c => c.contentHash === hash),
+		getCellById: () => undefined,
+	});
+
+	const ctx = createTestContainer()
+		.withContributionServices()
+		.stub(IQuartoDocumentModelService, { getModel: () => quartoModel })
+		.stub(IQuartoOutputCacheService, {
+			loadCache: async () => cachedDoc,
+			findCacheByContentHash,
+		})
+		.stub(IQuartoExecutionManager, {
+			onDidReceiveOutput: Event.None,
+			onDidChangeExecutionState: Event.None,
+			onWillExecute: Event.None,
+		})
+		.stub(IQuartoKernelManager, {
+			onDidChangeKernelState: Event.None,
+			getSessionForDocument: () => undefined,
+		})
+		.stub(IQuartoOutputManager, {
+			onDidChangeOutputs: Event.None,
+			onDidRequestClearDocument: Event.None,
+			onDidRequestClearAll: Event.None,
+		})
+		.stub(IPositronNotebookOutputWebviewService, {})
+		.stub(IResourceUsageHistoryService, {})
+		.build();
+
+	beforeEach(() => {
+		liveCells = [];
+		isParsed = false;
+		cachedDoc = undefined;
+		hashMatchedDoc = undefined;
+	});
+
+	/** Mirror a parse landing on the model: cells appear and `isParsed` flips. */
+	function parse(cells: QuartoCodeCell[]): void {
+		liveCells = cells;
+		isParsed = true;
+		parseEmitter.fire();
+	}
+
+	/** The parsed cell the cached output belongs to. */
+	function cell(): QuartoCodeCell {
+		return stubInterface<QuartoCodeCell>({ id: cachedCellId, contentHash });
+	}
+
+	/** A cache entry with one text/plain output for that cell. */
+	function cacheWith(): ICachedDocument {
+		return {
+			sourceUri: 'file:///reopen.qmd',
+			lastUpdated: Date.now(),
+			cells: [{ cellId: cachedCellId, contentHash, outputs: [{ outputId: 'out-1', items: [{ mime: 'text/plain', data: 'plot' }] }] }],
+		};
+	}
+
+	/** Instantiate the contribution over a fresh editor for the document. */
+	function reopen(): QuartoOutputContribution {
+		const uri = URI.file('/reopen.qmd');
+		const editorModel = ctx.disposables.add(createTextModel('', 'quarto', undefined, uri));
+		const editor = stubInterface<ICodeEditor>({
+			hasModel: (() => true) as ICodeEditor['hasModel'],
+			getModel: () => editorModel,
+			getOption: (() => false) as ICodeEditor['getOption'],
+			onDidChangeModel: Event.None,
+			onDidScrollChange: Event.None,
+		});
+		QUARTO_INLINE_OUTPUT_ENABLED.bindTo(ctx.get(IContextKeyService)).set(true);
+		return ctx.disposables.add(ctx.instantiationService.createInstance(QuartoOutputContribution, editor));
+	}
+
+	/** Flush the async restore (loadCache and the parse wait are microtask-scheduled). */
+	const settle = () => new Promise(resolve => setTimeout(resolve, 0));
+
+	it('restores cached output once the model parses', async () => {
+		cachedDoc = cacheWith();
+		isParsed = false; // opened before the parse landed
+
+		const contribution = reopen();
+		await settle();
+		// Nothing can match before parse, so the output is not restored yet. This
+		// is a weak guard: it also holds if the restore simply hasn't run, since
+		// the contribution exposes no "awaiting parse" state to assert on. The
+		// post-parse assertion below is what carries the signal.
+		expect(contribution.getOutputsForCell(cachedCellId)).toHaveLength(0);
+
+		// The model parses and the cached cell appears (mirrors onDidParse on reopen).
+		parse([cell()]);
+		await settle();
+		// With the bug the reopen fell through, dropped the output, and never
+		// retried, so this stayed empty.
+		expect(contribution.getOutputsForCell(cachedCellId)).toHaveLength(1);
+	});
+
+	// The wait has to come before the content-hash fallback, not after it: the
+	// fallback searches on the model's cells, so running it pre-parse searches
+	// an empty list and finds nothing to restore.
+	it('runs the content-hash fallback with the parsed cells', async () => {
+		cachedDoc = undefined;			// nothing cached under this URI
+		hashMatchedDoc = cacheWith();	// but the cell's content is cached elsewhere
+		isParsed = false;
+
+		const contribution = reopen();
+		await settle();
+		expect(findCacheByContentHash).not.toHaveBeenCalled();
+
+		parse([cell()]);
+		await settle();
+		expect(findCacheByContentHash).toHaveBeenCalledWith(expect.anything(), [contentHash]);
+		expect(contribution.getOutputsForCell(cachedCellId)).toHaveLength(1);
+	});
+
+	// A parsed document that reports no cells is authoritative, so the restore
+	// completes rather than waiting for a parse that will never add cells.
+	it('completes the restore for a parsed document with no cells', async () => {
+		cachedDoc = cacheWith();
+		liveCells = [];
+		isParsed = true;
+
+		const contribution = reopen();
+		await settle();
+		expect(contribution.getOutputsForCell(cachedCellId)).toHaveLength(0);
+
+		// A later parse must not re-run the restore: the load already completed.
+		parse([cell()]);
+		await settle();
+		expect(contribution.getOutputsForCell(cachedCellId)).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
### Summary

Restoring a Quarto document's cached inline output read the model's cell list without checking whether it was current. A restore that ran while a re-parse was still pending matched nothing by content hash and marked itself complete, dropping every cached output. The document model now reports its parse state, so the restore waits instead of inferring it from an empty cell list.

- `IQuartoDocumentModel.isParsed` separates "this document has no code cells" from "the cells aren't known yet"
- `whenParsed()` lets the restore await the parse instead of retrying on a parse event
- The wait moved above the content-hash fallback, which also read cells too early
- The previous guard only covered untitled documents, and only when no cache was found on disk

Note: the demonstrable trigger is the 100ms debounced re-parse. The close+reopen ordering this PR was opened around could not be reproduced, and the e2e failure that led here was diagnosed and fixed separately in #15331.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Quarto inline output is no longer dropped when the cached output is restored while the document is being re-parsed

### Validation Steps

@:quarto @:web @:win

1. Open a Quarto document with cell output, close it, and reopen it -- the output should reappear, including on a fresh window
2. Save an untitled Quarto document with cell output to a file, then reload the window -- the output should survive

### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- CORRECTED (supersedes the parse-race summary below): on Save As the Quarto output cache is never rebound from the untitled URI to the saved document, because _transferCacheFromUntitled is gated on this._documentUri.scheme === (file) (quartoOutputManager.ts:391) and in web a saved document URI is vscode-remote. The post-save assertion still passes via the in-memory findCacheByContentHash fallback to the live untitled cache; that fallback cannot survive a window reload, so post-reload restore finds no cache under the saved URI and mints zero view zones.</summary>

- **Test:** [Quarto - Inline Output: Persistence > Python - Verify inline output works in untitled Quarto document and persists through save](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Quarto%20-%20Inline%20Output%3A%20Persistence%20%3E%20Python%20-%20Verify%20inline%20output%20works%20in%20untitled%20Quarto%20document%20and%20persists%20through%20save%7C%7C%7Ctest%2Fe2e%2Ftests%2Fquarto%2Fquarto-inline-output-persistence.test.ts)
- **Targeted failure:** Pattern A -- expect(locator).toBeVisible() on locator('.quarto-inline-output').first().locator('.quarto-output-content'), 5 occurrences / 71.4% of 7 runs on main, sles/chromium, rep sha dea62542943085c854378d6c4132f800c0c5a1ba (run 30889748402).
- **Signal:** VERBOSE=1 e2e-chromium run (renderer trace + console forwarded to e2e-test-runner.log), repeat1 failing at spec line 92: 19:22:39.886 Saved output for cell 0-c2a393fb-unlabeled in untitled:Untitled-1; 19:22:40.719 Initializing for vscode-remote://.../test-...qmd (Save As -> vscode-remote scheme, so no Transferring cache from untitled to file line ever appears); 19:22:40.777 No cache file found for vscode-remote://...; 19:22:40.780 Found matching untitled cache: untitled:Untitled-1 with 1 matching cells -> Found cache by content hash match -> Restored cached outputs for 1 cells (this is what makes the post-save assert pass); 19:22:43.75 Flushing all caches / Flush complete; after reload 19:22:46.16 Initializing for the saved URI -> 19:22:46.399 No cache file found -> 19:22:46.541 No cached outputs to restore, with no untitled-cache match this time. Environment skew confirmed by mechanism: desktop saves to a file-scheme URI so the transfer runs (0.8% on win/electron) while web never does (71.4% on sles/chromium).
- **Frequency:** 5/7 runs (71.4%) on main, sles/chromium
- **Hypothesis:** Dropping the file-scheme requirement on the untitled->saved transition (accept any non-untitled scheme) makes the transfer write the cache under the real saved URI, so the post-reload restore finds it. The #15091 deferral fix is a genuine but separate bug: its log lines (No cells parsed yet, waiting for parse to retry cache load -> Cells found after parse, retrying cache load, 19:22:37) show it running as designed on the untitled document without affecting this failure. Ruled out: lost debounced write (the cache service joins flushAll on onWillShutdown and Flush complete is logged before the reload); _transferCacheFromUntitled losing a parse race (it is never called at all -- no transfer log line); the deferral gate (fix present and exercised, e2e rate unchanged: pre-fix 1/3, post-fix 4/6, verbose 4/4).
- **Supersedes:** PR #15091 (closed unmerged 2026-07-23, same mechanism, first found via the dataframe close+reopen flake)

</details>

