### PR TITLE
Ship the ai-lib packages the remote server loads at runtime

### DIFF
--- a/.github/workflows/test-e2e-remote-ssh-ubuntu.yml
+++ b/.github/workflows/test-e2e-remote-ssh-ubuntu.yml
@@ -62,6 +62,18 @@ jobs:
         if: ${{ inputs.commit != '' }}
         run: git checkout ${{ inputs.commit }}
 
+      # The Anthropic key the assistant sign-in test types into the Configure
+      # Providers modal. Read by the test runner on this host, not in the
+      # container: the modal writes it to the remote credential store itself.
+      - name: Load secret
+        uses: 1password/load-secrets-action@v4
+        with:
+          # Export loaded secrets as environment variables
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
+
       - uses: docker/login-action@v4
         with:
           registry: ghcr.io

--- a/build/gulpfile.reh.ts
+++ b/build/gulpfile.reh.ts
@@ -36,6 +36,7 @@ import { getCopilotExcludeFilter, getCopilotRuntimePrebuildFiles, getRipgrepExcl
 import { positronBuildNumber, releaseChannel } from './utils.ts';
 // eslint-disable-next-line no-duplicate-imports
 import { copyExtensionBinariesTask } from './gulpfile.extensions.ts';
+import { getAiLibServerDependencies } from './lib/ai-lib-dependencies.ts';
 import { getQuartoBinaries } from './lib/quarto.ts';
 // --- End Positron ---
 // --- Start PWB: build-time gzip compression ---
@@ -529,7 +530,17 @@ function packageTask(type: string, platform: string, arch: string, sourceFolderN
 		// --- Start Positron ---
 		const productionDependencies = getProductionDependencies(isWebType(type) ? REMOTE_REH_WEB_FOLDER : REMOTE_FOLDER);
 		const dependenciesSrc = productionDependencies.map(d => path.relative(REPO_ROOT, d)).map(d => [`${d}/**`, `!${d}/**/{test,tests}/**`, `!${d}/.bin/**`]).flat();
-		const cleanedDeps = gulp.src(dependenciesSrc, { base: packageJsonBase, dot: true })
+		// The ai-lib packages the server loads at runtime are `file:` dependencies
+		// of the root package.json, so the walk above (rooted at remote/) misses
+		// them. Ship them alongside, skipping whatever the remote dependencies
+		// already provide at the same path. See ai-lib-dependencies.ts.
+		const shippedModulePaths = productionDependencies
+			.map(d => path.relative(path.join(REPO_ROOT, packageJsonBase), d).split(path.sep).join('/'))
+			.filter(d => d.startsWith('node_modules/'));
+		const cleanedDeps = es.merge(
+			gulp.src(dependenciesSrc, { base: packageJsonBase, dot: true }),
+			getAiLibServerDependencies(shippedModulePaths)
+		)
 			// --- End Positron ---
 			// filter out unnecessary files, no source maps in server build
 			.pipe(filter(['**', '!**/package-lock.json', '!**/*.{js,css}.map']))

--- a/build/lib/ai-lib-dependencies.ts
+++ b/build/lib/ai-lib-dependencies.ts
@@ -70,9 +70,17 @@ function toRepoRelative(moduleDir: string): string {
 	return relative.split(path.sep).join('/');
 }
 
+/** A module to copy: where it is installed, and where the server loads it from. */
+export interface AiLibServerModule {
+	/** Repository-relative directory of the installed module. */
+	source: string;
+	/** Path under the server root, always inside `node_modules/`. */
+	destination: string;
+}
+
 /**
  * The production dependency closure of {@link AI_LIB_SERVER_PACKAGES}, as
- * repository-relative directories.
+ * source/destination pairs.
  *
  * Each dependency is resolved from the directory that declares it, so a version
  * npm had to nest (ai-config's zod 4 against the server's zod 3, the bridge's
@@ -80,14 +88,18 @@ function toRepoRelative(moduleDir: string): string {
  * path and keeps winning over the hoisted copy once shipped. Dev and peer
  * dependencies are not walked: the packages ship prebuilt `dist/` output, and
  * their only peer (`vscode`) comes from the host at runtime.
+ *
+ * Pairs are keyed by destination, not source: a dependency hoisted to the
+ * ai-lib checkout root belongs to each ai-lib package that requires it, and
+ * lands once per package (see {@link toServerModulePath}).
  */
-export function getAiLibProductionDependencies(packageNames: string[] = AI_LIB_SERVER_PACKAGES): string[] {
-	const resolved = new Set<string>();
-	const queue: { name: string; fromDir: string; optional: boolean }[] =
-		packageNames.map(name => ({ name, fromDir: REPO_ROOT, optional: false }));
+export function getAiLibServerModules(packageNames: string[] = AI_LIB_SERVER_PACKAGES): AiLibServerModule[] {
+	const modules = new Map<string, string>();
+	const queue: { name: string; fromDir: string; optional: boolean; owner: string }[] =
+		packageNames.map(name => ({ name, fromDir: REPO_ROOT, optional: false, owner: name }));
 
 	while (queue.length > 0) {
-		const { name, fromDir, optional } = queue.shift()!;
+		const { name, fromDir, optional, owner } = queue.shift()!;
 		const moduleDir = findModuleDir(name, fromDir);
 		if (!moduleDir) {
 			if (optional) {
@@ -95,35 +107,57 @@ export function getAiLibProductionDependencies(packageNames: string[] = AI_LIB_S
 			}
 			throw new Error(`Cannot resolve ai-lib dependency '${name}' from ${fromDir}. Run 'npm install' first.`);
 		}
-		if (resolved.has(moduleDir)) {
+
+		const source = toRepoRelative(moduleDir);
+		const destination = toServerModulePath(source, owner);
+		if (modules.has(destination)) {
 			continue;
 		}
-		resolved.add(moduleDir);
+		modules.set(destination, source);
 
 		const manifest = readManifest(moduleDir);
 		for (const dependency of Object.keys(manifest.dependencies ?? {})) {
-			queue.push({ name: dependency, fromDir: moduleDir, optional: false });
+			queue.push({ name: dependency, fromDir: moduleDir, optional: false, owner });
 		}
 		for (const dependency of Object.keys(manifest.optionalDependencies ?? {})) {
-			queue.push({ name: dependency, fromDir: moduleDir, optional: true });
+			queue.push({ name: dependency, fromDir: moduleDir, optional: true, owner });
 		}
 	}
 
-	return [...resolved].map(toRepoRelative).sort();
+	return [...modules]
+		.map(([destination, source]) => ({ source, destination }))
+		.sort((a, b) => a.destination.localeCompare(b.destination));
 }
 
 /**
- * Where a resolved dependency belongs in the server's `node_modules`. Packages
- * already installed under `node_modules/` keep their path; the ai-lib checkouts
- * (and anything nested inside them) move from `ai-lib/packages/` into
- * `node_modules/`, which is the layout the desktop app ships.
+ * Where a resolved dependency belongs in the server's `node_modules`, given the
+ * ai-lib package (`owner`) whose closure reached it.
+ *
+ * Packages installed under the repository's own `node_modules/` keep their path;
+ * the ai-lib checkouts (and anything nested inside them) move from
+ * `ai-lib/packages/` into `node_modules/`, which is the layout the desktop app
+ * ships.
+ *
+ * A dependency hoisted to the ai-lib checkout root -- which happens once someone
+ * runs `npm install` inside `ai-lib` to work on it, since Positron's own install
+ * only populates the packages -- has no counterpart in the server layout, where
+ * the packages sit directly under `node_modules/`. It travels nested under its
+ * owner instead of at the top level, so the owner keeps the version it declared:
+ * top level would collide with the server's own copy (ai-lib hoists zod 4 while
+ * the server ships zod 3) and lose to it, since a caller drops destinations the
+ * remote dependencies already provide.
  */
-export function toServerModulePath(repoRelativeDir: string): string {
+export function toServerModulePath(repoRelativeDir: string, owner: string): string {
 	if (repoRelativeDir.startsWith('node_modules/')) {
 		return repoRelativeDir;
 	}
 	if (repoRelativeDir.startsWith('ai-lib/packages/')) {
 		return `node_modules/${repoRelativeDir.slice('ai-lib/packages/'.length)}`;
+	}
+	const marker = '/node_modules/';
+	const nameStart = repoRelativeDir.lastIndexOf(marker);
+	if (repoRelativeDir.startsWith('ai-lib/') && nameStart !== -1) {
+		return `node_modules/${owner}/node_modules/${repoRelativeDir.slice(nameStart + marker.length)}`;
 	}
 	throw new Error(`Unexpected ai-lib dependency location: ${repoRelativeDir}`);
 }
@@ -143,19 +177,16 @@ export function toServerModulePath(repoRelativeDir: string): string {
  */
 export function getAiLibServerDependencies(alreadyShippedModulePaths: Iterable<string> = []): NodeJS.ReadWriteStream {
 	const alreadyShipped = new Set(alreadyShippedModulePaths);
-	const streams = getAiLibProductionDependencies()
-		.filter(dir => !alreadyShipped.has(toServerModulePath(dir)))
-		.map(dir => {
-			const destination = toServerModulePath(dir);
-			return gulp.src([
-				`${dir}/**`,
-				`!${dir}/node_modules/**`,
-				`!${dir}/**/{test,tests}/**`,
-			], { cwd: REPO_ROOT, base: dir, dot: true })
-				.pipe(rename(file => {
-					file.dirname = path.join(destination, file.dirname ?? '');
-				}));
-		});
+	const streams = getAiLibServerModules()
+		.filter(({ destination }) => !alreadyShipped.has(destination))
+		.map(({ source, destination }) => gulp.src([
+			`${source}/**`,
+			`!${source}/node_modules/**`,
+			`!${source}/**/{test,tests}/**`,
+		], { cwd: REPO_ROOT, base: source, dot: true })
+			.pipe(rename(file => {
+				file.dirname = path.join(destination, file.dirname ?? '');
+			})));
 
 	return es.merge(streams);
 }

--- a/build/lib/ai-lib-dependencies.ts
+++ b/build/lib/ai-lib-dependencies.ts
@@ -138,27 +138,38 @@ export function getAiLibServerModules(packageNames: string[] = AI_LIB_SERVER_PAC
  * `ai-lib/packages/` into `node_modules/`, which is the layout the desktop app
  * ships.
  *
- * A dependency hoisted to the ai-lib checkout root -- which happens once someone
+ * A dependency hoisted above the package checkouts -- which happens once someone
  * runs `npm install` inside `ai-lib` to work on it, since Positron's own install
  * only populates the packages -- has no counterpart in the server layout, where
  * the packages sit directly under `node_modules/`. It travels nested under its
  * owner instead of at the top level, so the owner keeps the version it declared:
  * top level would collide with the server's own copy (ai-lib hoists zod 4 while
  * the server ships zod 3) and lose to it, since a caller drops destinations the
- * remote dependencies already provide.
+ * remote dependencies already provide. Everything below the hoist point keeps its
+ * nesting, so a dependency npm nested for a version conflict stays distinct from
+ * the copy it was nested against.
  */
 export function toServerModulePath(repoRelativeDir: string, owner: string): string {
 	if (repoRelativeDir.startsWith('node_modules/')) {
 		return repoRelativeDir;
 	}
-	if (repoRelativeDir.startsWith('ai-lib/packages/')) {
-		return `node_modules/${repoRelativeDir.slice('ai-lib/packages/'.length)}`;
+
+	const packagesPrefix = 'ai-lib/packages/';
+	if (repoRelativeDir.startsWith(packagesPrefix)) {
+		const belowPackages = repoRelativeDir.slice(packagesPrefix.length);
+		// `<pkg>` or `<pkg>/node_modules/<dep>`, the shape the server keeps verbatim.
+		// A `node_modules/` first segment is instead a hoist to the packages dir.
+		if (!belowPackages.startsWith('node_modules/')) {
+			return `node_modules/${belowPackages}`;
+		}
 	}
-	const marker = '/node_modules/';
-	const nameStart = repoRelativeDir.lastIndexOf(marker);
-	if (repoRelativeDir.startsWith('ai-lib/') && nameStart !== -1) {
-		return `node_modules/${owner}/node_modules/${repoRelativeDir.slice(nameStart + marker.length)}`;
+
+	const marker = 'node_modules/';
+	const hoistPoint = repoRelativeDir.indexOf(marker);
+	if (repoRelativeDir.startsWith('ai-lib/') && hoistPoint !== -1) {
+		return `node_modules/${owner}/node_modules/${repoRelativeDir.slice(hoistPoint + marker.length)}`;
 	}
+
 	throw new Error(`Unexpected ai-lib dependency location: ${repoRelativeDir}`);
 }
 

--- a/build/lib/ai-lib-dependencies.ts
+++ b/build/lib/ai-lib-dependencies.ts
@@ -1,0 +1,161 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import es from 'event-stream';
+import * as fs from 'fs';
+import * as path from 'path';
+import { gulp, rename } from './gulp/facade.ts';
+
+const REPO_ROOT = fs.realpathSync(path.dirname(path.dirname(import.meta.dirname)));
+
+/**
+ * The ai-lib packages the server (REH) loads at runtime.
+ *
+ * `ai-config` backs the AI provider catalog and `ai-provider-bridge` backs the
+ * headless language model engine; both are registered in `serverServices.ts`
+ * and reach their package through a bare dynamic import (`ai-config/node`,
+ * `ai-provider-bridge`), so the package has to exist in the server's
+ * `node_modules` at runtime.
+ *
+ * They are consumed from the ai-lib submodule as `file:` dependencies of the
+ * *root* package.json, which is why `getProductionDependencies('remote')` never
+ * sees them: nothing under `remote/` depends on them. Without the explicit copy
+ * below the imports fail with ERR_MODULE_NOT_FOUND on the remote host, which
+ * silently empties the provider catalog (posit-dev/positron#15306) and disables
+ * headless model egress.
+ */
+export const AI_LIB_SERVER_PACKAGES = ['ai-config', 'ai-provider-bridge'];
+
+interface PackageManifest {
+	dependencies?: Record<string, string>;
+	optionalDependencies?: Record<string, string>;
+}
+
+function readManifest(moduleDir: string): PackageManifest {
+	return JSON.parse(fs.readFileSync(path.join(moduleDir, 'package.json'), 'utf8'));
+}
+
+/**
+ * Resolve `name` the way Node will at runtime: walk `node_modules` upwards from
+ * `fromDir`, stopping at the repository root. Returns the real (symlink-free)
+ * directory, so a `file:` linked package resolves to its checkout under
+ * `ai-lib/packages/`.
+ */
+function findModuleDir(name: string, fromDir: string): string | undefined {
+	let dir = fromDir;
+
+	while (true) {
+		const candidate = path.join(dir, 'node_modules', name);
+		if (fs.existsSync(path.join(candidate, 'package.json'))) {
+			return fs.realpathSync(candidate);
+		}
+		if (dir === REPO_ROOT) {
+			return undefined;
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) {
+			return undefined;
+		}
+		dir = parent;
+	}
+}
+
+function toRepoRelative(moduleDir: string): string {
+	const relative = path.relative(REPO_ROOT, moduleDir);
+	if (relative.startsWith('..') || path.isAbsolute(relative)) {
+		throw new Error(`ai-lib dependency resolved outside the repository: ${moduleDir}`);
+	}
+	return relative.split(path.sep).join('/');
+}
+
+/**
+ * The production dependency closure of {@link AI_LIB_SERVER_PACKAGES}, as
+ * repository-relative directories.
+ *
+ * Each dependency is resolved from the directory that declares it, so a version
+ * npm had to nest (ai-config's zod 4 against the server's zod 3, the bridge's
+ * `@github/copilot-sdk` 0.2 against the server's 1.x) is reported at its nested
+ * path and keeps winning over the hoisted copy once shipped. Dev and peer
+ * dependencies are not walked: the packages ship prebuilt `dist/` output, and
+ * their only peer (`vscode`) comes from the host at runtime.
+ */
+export function getAiLibProductionDependencies(packageNames: string[] = AI_LIB_SERVER_PACKAGES): string[] {
+	const resolved = new Set<string>();
+	const queue: { name: string; fromDir: string; optional: boolean }[] =
+		packageNames.map(name => ({ name, fromDir: REPO_ROOT, optional: false }));
+
+	while (queue.length > 0) {
+		const { name, fromDir, optional } = queue.shift()!;
+		const moduleDir = findModuleDir(name, fromDir);
+		if (!moduleDir) {
+			if (optional) {
+				continue;
+			}
+			throw new Error(`Cannot resolve ai-lib dependency '${name}' from ${fromDir}. Run 'npm install' first.`);
+		}
+		if (resolved.has(moduleDir)) {
+			continue;
+		}
+		resolved.add(moduleDir);
+
+		const manifest = readManifest(moduleDir);
+		for (const dependency of Object.keys(manifest.dependencies ?? {})) {
+			queue.push({ name: dependency, fromDir: moduleDir, optional: false });
+		}
+		for (const dependency of Object.keys(manifest.optionalDependencies ?? {})) {
+			queue.push({ name: dependency, fromDir: moduleDir, optional: true });
+		}
+	}
+
+	return [...resolved].map(toRepoRelative).sort();
+}
+
+/**
+ * Where a resolved dependency belongs in the server's `node_modules`. Packages
+ * already installed under `node_modules/` keep their path; the ai-lib checkouts
+ * (and anything nested inside them) move from `ai-lib/packages/` into
+ * `node_modules/`, which is the layout the desktop app ships.
+ */
+export function toServerModulePath(repoRelativeDir: string): string {
+	if (repoRelativeDir.startsWith('node_modules/')) {
+		return repoRelativeDir;
+	}
+	if (repoRelativeDir.startsWith('ai-lib/packages/')) {
+		return `node_modules/${repoRelativeDir.slice('ai-lib/packages/'.length)}`;
+	}
+	throw new Error(`Unexpected ai-lib dependency location: ${repoRelativeDir}`);
+}
+
+/**
+ * Stream the ai-lib packages the server loads at runtime, plus their production
+ * dependency closure, rewritten to the `node_modules/**` paths the server
+ * resolves them from. Callers merge this alongside the `remote/` production
+ * dependencies so both get the same filtering (`.moduleignore`, source maps).
+ *
+ * `alreadyShippedModulePaths` are the destinations the caller already packages
+ * from `remote/package.json` (e.g. `node_modules/@github/copilot`); a shared
+ * dependency is left to that copy rather than shipped twice, which also keeps
+ * the target-platform copy of a per-platform package instead of the host's.
+ * Nested `node_modules` are excluded per directory because the closure reports
+ * every nested dependency as its own entry with its own destination.
+ */
+export function getAiLibServerDependencies(alreadyShippedModulePaths: Iterable<string> = []): NodeJS.ReadWriteStream {
+	const alreadyShipped = new Set(alreadyShippedModulePaths);
+	const streams = getAiLibProductionDependencies()
+		.filter(dir => !alreadyShipped.has(toServerModulePath(dir)))
+		.map(dir => {
+			const destination = toServerModulePath(dir);
+			return gulp.src([
+				`${dir}/**`,
+				`!${dir}/node_modules/**`,
+				`!${dir}/**/{test,tests}/**`,
+			], { cwd: REPO_ROOT, base: dir, dot: true })
+				.pipe(rename(file => {
+					file.dirname = path.join(destination, file.dirname ?? '');
+				}));
+		});
+
+	return es.merge(streams);
+}

--- a/build/lib/test/ai-lib-dependencies.test.ts
+++ b/build/lib/test/ai-lib-dependencies.test.ts
@@ -36,18 +36,32 @@ suite('ai-lib-dependencies', () => {
 		// An `npm install` inside ai-lib hoists to a location the server layout has
 		// no counterpart for, so it travels nested under the package that needs it
 		// rather than at the top level, where the server's own copy would win.
-		test('nests a dependency hoisted to the ai-lib root under its owner', () => {
+		// Nesting below the hoist point is preserved: flattening `a/node_modules/b`
+		// to `b` would collide with a sibling `b` of another version.
+		test('nests a dependency hoisted above the packages under its owner', () => {
 			assert.deepStrictEqual([
 				toServerModulePath('ai-lib/node_modules/zod', 'ai-config'),
 				toServerModulePath('ai-lib/node_modules/zod', 'ai-provider-bridge'),
 				toServerModulePath('ai-lib/node_modules/@github/copilot-sdk', 'ai-provider-bridge'),
 				toServerModulePath('ai-lib/node_modules/a/node_modules/b', 'ai-config'),
+				toServerModulePath('ai-lib/packages/node_modules/zod', 'ai-config'),
 			], [
 				'node_modules/ai-config/node_modules/zod',
 				'node_modules/ai-provider-bridge/node_modules/zod',
 				'node_modules/ai-provider-bridge/node_modules/@github/copilot-sdk',
-				'node_modules/ai-config/node_modules/b',
+				'node_modules/ai-config/node_modules/a/node_modules/b',
+				'node_modules/ai-config/node_modules/zod',
 			]);
+		});
+
+		// The nested copy and the copy it was nested against stay distinct, so the
+		// destination-keyed closure cannot drop one of them.
+		test('keeps two versions of the same dependency apart', () => {
+			const destinations = [
+				'ai-lib/node_modules/b',
+				'ai-lib/node_modules/a/node_modules/b',
+			].map(dir => toServerModulePath(dir, 'ai-config'));
+			assert.deepStrictEqual(new Set(destinations).size, destinations.length);
 		});
 
 		test('rejects a location that is neither', () => {

--- a/build/lib/test/ai-lib-dependencies.test.ts
+++ b/build/lib/test/ai-lib-dependencies.test.ts
@@ -1,0 +1,115 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { suite, test } from 'node:test';
+import fs from 'fs';
+import path from 'path';
+import { AI_LIB_SERVER_PACKAGES, getAiLibProductionDependencies, toServerModulePath } from '../ai-lib-dependencies.ts';
+
+const REPO_ROOT = path.dirname(path.dirname(path.dirname(import.meta.dirname)));
+
+/** The closure is read off the real install, so skip when it isn't there. */
+const installed = AI_LIB_SERVER_PACKAGES.every(
+	name => fs.existsSync(path.join(REPO_ROOT, 'node_modules', name, 'package.json')));
+
+suite('ai-lib-dependencies', () => {
+
+	suite('toServerModulePath', () => {
+
+		test('maps installed modules, ai-lib checkouts, and nested versions', () => {
+			assert.deepStrictEqual([
+				'node_modules/ai',
+				'node_modules/@aws-sdk/client-bedrock',
+				'ai-lib/packages/ai-config',
+				'ai-lib/packages/ai-config/node_modules/zod',
+			].map(toServerModulePath), [
+				'node_modules/ai',
+				'node_modules/@aws-sdk/client-bedrock',
+				'node_modules/ai-config',
+				'node_modules/ai-config/node_modules/zod',
+			]);
+		});
+
+		test('rejects a location that is neither', () => {
+			assert.throws(() => toServerModulePath('remote/node_modules/ws'), /Unexpected ai-lib dependency location/);
+		});
+	});
+
+	suite('getAiLibProductionDependencies', () => {
+
+		test('includes the packages the server imports', { skip: !installed }, () => {
+			const dirs = getAiLibProductionDependencies();
+			assert.deepStrictEqual(
+				AI_LIB_SERVER_PACKAGES.filter(name => dirs.includes(`ai-lib/packages/${name}`)),
+				AI_LIB_SERVER_PACKAGES);
+		});
+
+		test('includes the deps that resolve outside the packages', { skip: !installed }, () => {
+			const dirs = getAiLibProductionDependencies(['ai-config']);
+			// zod is nested (ai-config wants 4.x against the app's 3.x) while
+			// proper-lockfile hoists; both have to travel with the package.
+			assert.deepStrictEqual([
+				dirs.includes('ai-lib/packages/ai-config/node_modules/zod'),
+				dirs.some(dir => dir.endsWith('/proper-lockfile')),
+			], [true, true]);
+		});
+
+		test('does not walk dev dependencies', { skip: !installed }, () => {
+			const dirs = getAiLibProductionDependencies();
+			assert.deepStrictEqual(
+				dirs.filter(dir => /\/(typescript|vitest|vite|esbuild|husky|tsx)$/.test(dir)),
+				[]);
+		});
+
+		test('every entry has a server destination', { skip: !installed }, () => {
+			assert.deepStrictEqual(
+				getAiLibProductionDependencies().filter(dir => !toServerModulePath(dir).startsWith('node_modules/')),
+				[]);
+		});
+
+		test('reports an unresolvable package instead of skipping it', () => {
+			assert.throws(
+				() => getAiLibProductionDependencies(['ai-lib-package-that-does-not-exist']),
+				/Cannot resolve ai-lib dependency/);
+		});
+	});
+
+	// The server resolves these packages from its own node_modules, so a node-side
+	// import of one that AI_LIB_SERVER_PACKAGES omits fails with
+	// ERR_MODULE_NOT_FOUND on the remote host only -- invisible in a local desktop
+	// build. See posit-dev/positron#15306.
+	test('covers every ai-lib package the node layer imports', () => {
+		const imported = new Set<string>();
+		const nodeSources = collectFiles(path.join(REPO_ROOT, 'src', 'vs', 'platform'))
+			.filter(file => file.includes(`${path.sep}node${path.sep}`) && file.endsWith('.ts'));
+
+		for (const file of nodeSources) {
+			const contents = fs.readFileSync(file, 'utf8');
+			for (const match of contents.matchAll(/\bimport\(\s*['"](ai-[^'"/]+)/g)) {
+				imported.add(match[1]);
+			}
+		}
+
+		// `scanned` guards against the scan silently finding nothing.
+		assert.deepStrictEqual({
+			unpackaged: [...imported].filter(name => !AI_LIB_SERVER_PACKAGES.includes(name)),
+			scanned: imported.size > 0,
+		}, { unpackaged: [], scanned: true });
+	});
+});
+
+function collectFiles(dir: string): string[] {
+	const files: string[] = [];
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const entryPath = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			files.push(...collectFiles(entryPath));
+		} else {
+			files.push(entryPath);
+		}
+	}
+	return files;
+}

--- a/build/lib/test/ai-lib-dependencies.test.ts
+++ b/build/lib/test/ai-lib-dependencies.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import { suite, test } from 'node:test';
 import fs from 'fs';
 import path from 'path';
-import { AI_LIB_SERVER_PACKAGES, getAiLibProductionDependencies, toServerModulePath } from '../ai-lib-dependencies.ts';
+import { AI_LIB_SERVER_PACKAGES, getAiLibServerModules, toServerModulePath } from '../ai-lib-dependencies.ts';
 
 const REPO_ROOT = path.dirname(path.dirname(path.dirname(import.meta.dirname)));
 
@@ -25,7 +25,7 @@ suite('ai-lib-dependencies', () => {
 				'node_modules/@aws-sdk/client-bedrock',
 				'ai-lib/packages/ai-config',
 				'ai-lib/packages/ai-config/node_modules/zod',
-			].map(toServerModulePath), [
+			].map(dir => toServerModulePath(dir, 'ai-config')), [
 				'node_modules/ai',
 				'node_modules/@aws-sdk/client-bedrock',
 				'node_modules/ai-config',
@@ -33,46 +33,67 @@ suite('ai-lib-dependencies', () => {
 			]);
 		});
 
+		// An `npm install` inside ai-lib hoists to a location the server layout has
+		// no counterpart for, so it travels nested under the package that needs it
+		// rather than at the top level, where the server's own copy would win.
+		test('nests a dependency hoisted to the ai-lib root under its owner', () => {
+			assert.deepStrictEqual([
+				toServerModulePath('ai-lib/node_modules/zod', 'ai-config'),
+				toServerModulePath('ai-lib/node_modules/zod', 'ai-provider-bridge'),
+				toServerModulePath('ai-lib/node_modules/@github/copilot-sdk', 'ai-provider-bridge'),
+				toServerModulePath('ai-lib/node_modules/a/node_modules/b', 'ai-config'),
+			], [
+				'node_modules/ai-config/node_modules/zod',
+				'node_modules/ai-provider-bridge/node_modules/zod',
+				'node_modules/ai-provider-bridge/node_modules/@github/copilot-sdk',
+				'node_modules/ai-config/node_modules/b',
+			]);
+		});
+
 		test('rejects a location that is neither', () => {
-			assert.throws(() => toServerModulePath('remote/node_modules/ws'), /Unexpected ai-lib dependency location/);
+			assert.throws(
+				() => toServerModulePath('remote/node_modules/ws', 'ai-config'),
+				/Unexpected ai-lib dependency location/);
 		});
 	});
 
-	suite('getAiLibProductionDependencies', () => {
+	suite('getAiLibServerModules', () => {
 
 		test('includes the packages the server imports', { skip: !installed }, () => {
-			const dirs = getAiLibProductionDependencies();
+			const modules = getAiLibServerModules();
 			assert.deepStrictEqual(
-				AI_LIB_SERVER_PACKAGES.filter(name => dirs.includes(`ai-lib/packages/${name}`)),
+				AI_LIB_SERVER_PACKAGES.filter(name =>
+					modules.some(m => m.source === `ai-lib/packages/${name}` && m.destination === `node_modules/${name}`)),
 				AI_LIB_SERVER_PACKAGES);
 		});
 
 		test('includes the deps that resolve outside the packages', { skip: !installed }, () => {
-			const dirs = getAiLibProductionDependencies(['ai-config']);
+			const modules = getAiLibServerModules(['ai-config']);
 			// zod is nested (ai-config wants 4.x against the app's 3.x) while
 			// proper-lockfile hoists; both have to travel with the package.
 			assert.deepStrictEqual([
-				dirs.includes('ai-lib/packages/ai-config/node_modules/zod'),
-				dirs.some(dir => dir.endsWith('/proper-lockfile')),
+				modules.some(m => m.destination === 'node_modules/ai-config/node_modules/zod'),
+				modules.some(m => m.destination.endsWith('/proper-lockfile')),
 			], [true, true]);
 		});
 
 		test('does not walk dev dependencies', { skip: !installed }, () => {
-			const dirs = getAiLibProductionDependencies();
 			assert.deepStrictEqual(
-				dirs.filter(dir => /\/(typescript|vitest|vite|esbuild|husky|tsx)$/.test(dir)),
+				getAiLibServerModules().filter(m => /\/(typescript|vitest|vite|esbuild|husky|tsx)$/.test(m.source)),
 				[]);
 		});
 
-		test('every entry has a server destination', { skip: !installed }, () => {
-			assert.deepStrictEqual(
-				getAiLibProductionDependencies().filter(dir => !toServerModulePath(dir).startsWith('node_modules/')),
-				[]);
+		test('every destination is under node_modules and unique', { skip: !installed }, () => {
+			const destinations = getAiLibServerModules().map(m => m.destination);
+			assert.deepStrictEqual({
+				outside: destinations.filter(d => !d.startsWith('node_modules/')),
+				duplicates: destinations.length - new Set(destinations).size,
+			}, { outside: [], duplicates: 0 });
 		});
 
 		test('reports an unresolvable package instead of skipping it', () => {
 			assert.throws(
-				() => getAiLibProductionDependencies(['ai-lib-package-that-does-not-exist']),
+				() => getAiLibServerModules(['ai-lib-package-that-does-not-exist']),
 				/Cannot resolve ai-lib dependency/);
 		});
 	});

--- a/test/e2e/tests/remote-ssh/connect.ts
+++ b/test/e2e/tests/remote-ssh/connect.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { Page } from 'playwright';
+import { test, expect } from '../_test.setup';
+import { Application } from '../../infra';
+import { createWorkbenchFromPage, waitForAnyNewWindow, Workbench } from '../../infra/workbench';
+
+/**
+ * Records the docker host's SSH keys so the connection can use
+ * StrictHostKeyChecking (the workflow points the "remote" host at this file).
+ * Call from `beforeAll` before {@link connectToRemoteHost}.
+ */
+export function sshKeyscan(host: string, port: number, knownHostsPath: string) {
+	// Run ssh-keyscan and capture stdout (the host keys)
+	const out = execFileSync('ssh-keyscan', ['-p', String(port), host], {
+		stdio: ['ignore', 'pipe', 'inherit'],
+	});
+	// Ensure the file exists, then append
+	fs.mkdirSync(path.dirname(knownHostsPath), { recursive: true });
+	fs.appendFileSync(knownHostsPath, out);
+}
+
+/**
+ * Connects to the docker SSH host and returns the remote window plus a
+ * {@link Workbench} bound to it. Every page object on that workbench drives the
+ * remote window, so a test reads the same as its local equivalent.
+ *
+ * Also repoints the interpreter-version env vars at the remote host's versions,
+ * for tests that start sessions there.
+ */
+export async function connectToRemoteHost(app: Application): Promise<{ sshWin: Page; sshWorkbench: Workbench }> {
+	const sshWin = await test.step(`Connect to docker image`, async () => {
+		// Start waiting for *any* new window before we trigger the UI that opens it
+		const sshWinPromise = waitForAnyNewWindow(app.code.electronApp!, async () => {
+			await app.workbench.quickInput.waitForQuickInputOpened();
+			await app.workbench.quickInput.selectQuickInputElementContaining('Connect to Host...');
+			await app.workbench.quickInput.selectQuickInputElementContaining('remote');
+		}, { timeout: 60_000 });
+
+		// Kick off the action that reveals the quick input (if needed)
+		await app.code.driver.currentPage.locator('.codicon-remote').click();
+
+		// Grab the new window (no URL/title/selector filtering)
+		const sshWin = await sshWinPromise;
+
+		// Continue as before
+		await expect(sshWin.getByText('Enter password')).toBeVisible({ timeout: 60_000 });
+		await sshWin.keyboard.type('root');
+		await sshWin.keyboard.press('Enter');
+
+		const alertLocator = sshWin.locator('.statusbar-item-label', { hasText: 'Opening Remote' });
+		await expect(alertLocator).toBeVisible({ timeout: 10_000 });
+		await expect(alertLocator).not.toBeVisible({ timeout: 60_000 });
+
+		return sshWin;
+	});
+
+	const sshWorkbench = await test.step(`Create a workbench instance from the remote page`, async () => {
+		const sshWorkbench = createWorkbenchFromPage(app.code, sshWin);
+
+		process.env.POSITRON_PY_VER_SEL = process.env.POSITRON_PY_REMOTE_VER_SEL!;
+		process.env.POSITRON_R_VER_SEL = process.env.POSITRON_R_REMOTE_VER_SEL!;
+
+		return sshWorkbench;
+	});
+
+	return { sshWin, sshWorkbench };
+}

--- a/test/e2e/tests/remote-ssh/remote-ssh-assistant.test.ts
+++ b/test/e2e/tests/remote-ssh/remote-ssh-assistant.test.ts
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test, expect, tags } from '../_test.setup';
+import { connectToRemoteHost, sshKeyscan } from './connect';
+
+test.use({
+	suiteId: __filename
+});
+
+// Only the remote-ssh tag: the lane that runs this suite is the one that
+// extracts a real REH tarball into the docker host, which is what makes the test
+// meaningful. Assistant lanes have no SSH host to connect to.
+test.describe('Remote SSH: Posit Assistant', {
+	tag: [tags.REMOTE_SSH]
+}, () => {
+
+	test.beforeAll(async () => {
+		try {
+			sshKeyscan('127.0.0.1', 3456, '/tmp/known_hosts');
+		} catch (err) {
+			throw new Error(`ssh-keyscan failed: ${(err as Error).message}`);
+		}
+	});
+
+	// The provider list, the credential store, and the model request all live on
+	// the remote host in a remote session: the catalog resolves from the remote
+	// ~/.posit/ai/providers.json, the API key is written to the remote credential
+	// store, and egress originates there. So this covers what a unit test cannot
+	// reach -- when the server was missing the ai-config module the modal offered
+	// only the local providers and the Anthropic tile was absent entirely
+	// (posit-dev/positron#15306).
+	test('Sign in to Anthropic and chat against the remote host', async function ({ app }) {
+		// Opening the SSH connection alone can take most of the default 2 minute
+		// budget, before the sign-in and the model round-trip.
+		test.slow();
+
+		const { sshWorkbench } = await connectToRemoteHost(app);
+
+		await sshWorkbench.modelProviderAuth.loginModelProvider('anthropic-api');
+
+		try {
+			await sshWorkbench.positAssistant.open();
+			await sshWorkbench.positAssistant.waitForReady();
+			await sshWorkbench.positAssistant.startNewConversation();
+
+			// Select the just-signed-in provider's model rather than relying on an
+			// auto-selected default, which may belong to another signed-in provider.
+			// `newConversation: false` keeps that selection.
+			await sshWorkbench.positAssistant.selectProviderModel('anthropic-api');
+			await sshWorkbench.positAssistant.sendMessage('Say hello', true, { newConversation: false });
+			await sshWorkbench.positAssistant.expectResponseVisible();
+
+			const responseText = await sshWorkbench.positAssistant.getLastResponseText();
+			expect(responseText.length).toBeGreaterThan(0);
+		} finally {
+			await sshWorkbench.modelProviderAuth.logoutModelProvider('anthropic-api');
+		}
+	});
+});

--- a/test/e2e/tests/remote-ssh/remote-ssh.test.ts
+++ b/test/e2e/tests/remote-ssh/remote-ssh.test.ts
@@ -4,25 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { test, expect, tags } from '../_test.setup';
-import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
-import { createWorkbenchFromPage, waitForAnyNewWindow } from '../../infra/workbench';
+import { connectToRemoteHost, sshKeyscan } from './connect';
 import { pythonDynamicPlot } from '../shared/plots.constants.js';
 const settingsPath = require('node:path').resolve(__dirname, '../../fixtures/settingsDocker.json');
 
 test.use({
 	suiteId: __filename
 });
-
-function sshKeyscan(host: string, port: number, knownHostsPath: string) {
-	// Run ssh-keyscan and capture stdout (the host keys)
-	const out = execFileSync('ssh-keyscan', ['-p', String(port), host], {
-		stdio: ['ignore', 'pipe', 'inherit'],
-	});
-	// Ensure the file exists, then append
-	fs.mkdirSync(require('node:path').dirname(knownHostsPath), { recursive: true });
-	fs.appendFileSync(knownHostsPath, out);
-}
 
 test.describe('Remote SSH', {
 	tag: [tags.REMOTE_SSH]
@@ -45,41 +34,7 @@ test.describe('Remote SSH', {
 	// session before the SSH connection, which only adds time and a startup flake surface.
 	test('Verify SSH connection into docker image', async function ({ app, runDockerCommand }) {
 
-		const sshWin = await test.step(`Connect to docker image`, async () => {
-			// Start waiting for *any* new window before we trigger the UI that opens it
-			const sshWinPromise = waitForAnyNewWindow(app.code.electronApp!, async () => {
-				await app.workbench.quickInput.waitForQuickInputOpened();
-				await app.workbench.quickInput.selectQuickInputElementContaining('Connect to Host...');
-				await app.workbench.quickInput.selectQuickInputElementContaining('remote');
-			}, { timeout: 60_000 });
-
-			// Kick off the action that reveals the quick input (if needed)
-			await app.code.driver.currentPage.locator('.codicon-remote').click();
-
-			// Grab the new window (no URL/title/selector filtering)
-			const sshWin = await sshWinPromise;
-
-			// Continue as before
-			await expect(sshWin.getByText('Enter password')).toBeVisible({ timeout: 60_000 });
-			await sshWin.keyboard.type('root');
-			await sshWin.keyboard.press('Enter');
-
-			const alertLocator = sshWin.locator('.statusbar-item-label', { hasText: 'Opening Remote' });
-			await expect(alertLocator).toBeVisible({ timeout: 10_000 });
-			await expect(alertLocator).not.toBeVisible({ timeout: 60_000 });
-
-			return sshWin;
-		});
-
-		const sshWorkbench = await test.step(`Create a workbench instance from the remote page`, async () => {
-			const sshWorkbench = createWorkbenchFromPage(app.code, sshWin);
-
-			process.env.POSITRON_PY_VER_SEL = process.env.POSITRON_PY_REMOTE_VER_SEL!;
-			process.env.POSITRON_R_VER_SEL = process.env.POSITRON_R_REMOTE_VER_SEL!;
-
-			return sshWorkbench;
-		});
-
+		const { sshWin, sshWorkbench } = await connectToRemoteHost(app);
 
 		const pythonSession = await test.step(`Check that correct Python is being used`, async () => {
 			// The remote host has both a base interpreter and the project venv at this


### PR DESCRIPTION
Fixes #15306

Once connected to a remote (WSL or Remote SSH), only the local model providers could be configured -- Ollama and LM Studio were the only entries left in Configure LLM Providers.

The server registers the AI provider catalog and the headless language model engine, and both reach their implementation through a bare dynamic import: `ai-config/node` and `ai-provider-bridge`. Neither package shipped in the REH tarball. They are `file:` dependencies of the root package.json, while the build walks production dependencies rooted at `remote/` -- so nothing under `remote/` referenced them and the walk never saw them. The desktop app walks from the root, which is why local sessions were fine.

On the remote host both imports failed with `ERR_MODULE_NOT_FOUND`. For the catalog that meant the channel call rejected, the workbench service kept its empty snapshot, and `isSourceEnabled` filtered out every provider carrying a `catalogId` -- leaving exactly the local ones, which have none. The headless engine lost model egress the same way (commit messages, notebook ghost cells, visualize suggestions); that gap is older, already present in the 07-09 server build.

This resolves the production dependency closure of both packages the way node will at runtime and streams it into the server's `node_modules` alongside the remote dependencies, so it gets the same filtering. Resolving each dependency from the directory that declares it keeps a version npm had to nest nested -- ai-config's zod 4 against the server's zod 3, the bridge's `@github/copilot-sdk` 0.2 against the server's 1.x -- and destinations the remote dependencies already provide are skipped, so per-platform packages stay target-arch.

The server dependency payload grows ~82 MB uncompressed (`@aws-sdk`, `@smithy`, `@ai-sdk`, and the rest of the bridge's externalized SDKs).

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Restore configuration of non-local LLM providers when connected to a remote session over WSL or Remote SSH (#15306)

### Validation Steps

@:remote-ssh @:web @:workbench

New coverage in this PR: `test/e2e/tests/remote-ssh/remote-ssh-assistant.test.ts` signs in to Anthropic and holds a conversation from the remote window. The remote-ssh lane is the only one that extracts a real REH tarball, so it is the only place the shipped artifact gets exercised -- against a server missing these packages the Anthropic tile never renders and the test fails at sign-in.

The web and workbench tags cover the other side of the split. Posit Workbench is built by the same packaging task (`gulp vscode-reh-web-pwb-linux-x64` -> `isWebType()` -> the same dependency pipeline), and its server had no ai-lib packages either, so a Workbench session showed the same local-providers-only list. The workbench lane rebuilds that artifact, and its azure shard runs `test/e2e/tests/workbench/posit-assistant/posit-assistant-foundry.test.ts`, which authenticates a catalog-backed provider (ms-foundry) and asks it for a response -- the Workbench analogue of this bug.

Manual check:

1. Connect to a WSL or SSH remote.
2. Open Configure LLM Providers.
3. Verify the full provider list appears (Anthropic, OpenAI, Copilot, Bedrock, ...) rather than only Ollama and LM Studio.
4. Sign in to one provider and send a chat message.

The dependency-closure logic has unit coverage in `build/lib/test/ai-lib-dependencies.test.ts` (`cd build && npm run test`), including a guard that fails if a node-side bare import of an ai-lib package is not packaged. Worth flagging for reviewers: no workflow currently runs the `build/` test suite, so those tests do not execute in CI today.
