### PR TITLE
Upstream merge from vscode-server

### DIFF
--- a/src/vs/server/node/serverEnvironmentService.ts
+++ b/src/vs/server/node/serverEnvironmentService.ts
@@ -32,9 +32,10 @@ export const serverOptions: OptionDescriptions<Required<ServerParsedArgs>> = {
 	'print-startup-performance': { type: 'boolean' },
 	'print-ip-address': { type: 'boolean' },
 	'accept-server-license-terms': { type: 'boolean', cat: 'o', description: nls.localize('acceptLicenseTerms', "If set, the user accepts the server license terms and the server will be started without a user prompt.") },
-	// --- Start PWB: disable file downloads ---
+	// --- Start PWB: disable file downloads, enable localhost proxy port verification ---
 	'disable-file-downloads': { type: 'boolean', cat: 'o', description: nls.localize('disableFileDownloads', "Disables file downloads.") },
 	'disable-file-uploads': { type: 'boolean', cat: 'o', description: nls.localize('disableFileUploads', "Disables file uploads.") },
+	'www-proxy-localhost-verify-port-owner': { type: 'string', cat: 'o', args: 'true | false', description: nls.localize('wwwProxyLocalhostVerifyPortOwner', "Verifies that a localhost /proxy/<port>/ request targets a port owned by this session's user before forwarding it. Enabled unless set to exactly \"0\" or \"false\".") },
 	// --- End PWB ---
 	'server-data-dir': { type: 'string', cat: 'o', description: nls.localize('serverDataDir', "Specifies the directory that server data is kept in.") },
 	'telemetry-level': { type: 'string', cat: 'o', args: 'level', description: nls.localize('telemetry-level', "Sets the initial telemetry level. Valid levels are: 'off', 'crash', 'error' and 'all'. If not specified, the server will send telemetry until a client connects, it will then use the clients telemetry setting. Setting this to 'off' is equivalent to --disable-telemetry") },
@@ -127,9 +128,15 @@ export const serverOptions: OptionDescriptions<Required<ServerParsedArgs>> = {
 
 export interface ServerParsedArgs {
 
-	// --- Start PWB: disable file downloads ---
+	// --- Start PWB: disable file downloads, enable /proxy/ port ownership verification ---
 	'disable-file-downloads'?: boolean;
 	'disable-file-uploads'?: boolean;
+	/**
+	 * Whether to verify that a localhost `/proxy/<port>/` request targets a port owned by this
+	 * session's user before forwarding it. Verification is enabled for any value other than
+	 * exactly `"0"` or `"false"`, including when unspecified.
+	 */
+	'www-proxy-localhost-verify-port-owner'?: string;
 	// --- End PWB ---
 	// --- Start Positron ---
 	'bootstrap-extensions-dir'?: string;

--- a/src/vs/server/node/socketOwnership.ts
+++ b/src/vs/server/node/socketOwnership.ts
@@ -1,0 +1,185 @@
+/* eslint-disable header/header */
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Determines the uid that owns a localhost TCP listening socket so the `/proxy/<port>/` route
+// can refuse to proxy to ports owned by other users (rstudio-pro#11470, vscode-server#388).
+//
+// This reproduces the guarantee of the rserver fix (which uses NETLINK_SOCK_DIAG) by reading the
+// same kernel data exposed as text in `/proc/net/tcp[6]`. It is dependency-free, needs no special
+// privileges, and -- being a plain file read -- is not blocked by the seccomp/capability profiles
+// that can restrict netlink. Linux-only; callers fail open on non-Linux / when `/proc` is absent.
+
+import { readFileSync } from 'fs';
+
+/**
+ * The subset of this module's exports that `WebClientServer` depends on for its `/proxy/`
+ * ownership gate, expressed as an interface so tests can inject stubs in place of the real
+ * `/proc`-reading implementations (see webClientServer.vitest.ts).
+ */
+export interface ISocketOwnershipCheck {
+	getListeningPortUid(port: number): number | undefined;
+	isProxyPortOwnershipEnforced(uid: number): boolean;
+}
+
+const PROC_TCP_FILES = ['/proc/net/tcp', '/proc/net/tcp6'];
+
+/** `st` column value for a socket in the LISTEN state, as rendered in /proc/net/tcp. */
+const TCP_LISTEN_STATE = '0A';
+
+/**
+ * Parse a `/proc/net/tcp[6]` `local_address`/`rem_address` hex string into its address bytes in
+ * network order. The kernel prints each 32-bit word of the address byte-swapped (host order), so
+ * this reverses the bytes within each 8-hex-char word while preserving word order -- this works
+ * unchanged for both the single-word IPv4 form and the four-word IPv6 form.
+ */
+function parseProcAddressBytes(hexAddr: string): number[] {
+	const bytes: number[] = [];
+	for (let wordStart = 0; wordStart < hexAddr.length; wordStart += 8) {
+		const word = hexAddr.slice(wordStart, wordStart + 8);
+		for (let i = word.length - 2; i >= 0; i -= 2) {
+			bytes.push(parseInt(word.slice(i, i + 2), 16));
+		}
+	}
+	return bytes;
+}
+
+/**
+ * Whether an address's bytes are exactly the IPv4 loopback address `127.0.0.1` -- the specific
+ * address Linux's `ip_route_connect()` rewrites an unspecified (`0.0.0.0`) destination to (see
+ * `getListeningPortUid`), as opposed to any other address in `127.0.0.0/8`.
+ */
+function isExactLoopbackMatch(bytes: number[]): boolean {
+	return bytes.length === 4 && bytes[0] === 127 && bytes[1] === 0 && bytes[2] === 0 && bytes[3] === 1;
+}
+
+/**
+ * Whether an address's bytes are the IPv4 wildcard (`0.0.0.0`) or IPv6 wildcard (`::`, which under
+ * Linux's default dual-stack behaviour also accepts an IPv4-mapped connection).
+ */
+function isWildcardMatch(bytes: number[]): boolean {
+	return (bytes.length === 4 || bytes.length === 16) && bytes.every(b => b === 0);
+}
+
+/** A LISTEN socket found in `/proc/net/tcp[6]` for a given port, before address-reachability filtering. */
+interface ListenerEntry {
+	addressHex: string;
+	uid: number;
+}
+
+/**
+ * Scan `/proc/net/tcp` and `/proc/net/tcp6` for all LISTEN sockets bound to `port`, in file order.
+ */
+function collectListeners(port: number): ListenerEntry[] {
+	const entries: ListenerEntry[] = [];
+	for (const file of PROC_TCP_FILES) {
+		let contents: string;
+		try {
+			contents = readFileSync(file, 'utf8');
+		} catch {
+			continue; // file absent (e.g. no IPv6) or unreadable -- try the next
+		}
+
+		const lines = contents.split('\n');
+		// Skip the header line (index 0); each subsequent line is one socket.
+		for (let i = 1; i < lines.length; i++) {
+			const fields = lines[i].trim().split(/\s+/);
+			// Columns: 0=sl 1=local_address 2=rem_address 3=st ... 7=uid
+			if (fields.length < 8) {
+				continue;
+			}
+			if (fields[3] !== TCP_LISTEN_STATE) {
+				continue;
+			}
+			const [addressHex, portHex] = fields[1].split(':');
+			if (parseInt(portHex, 16) !== port) {
+				continue;
+			}
+			const uid = parseInt(fields[7], 10);
+			if (!Number.isNaN(uid)) {
+				entries.push({ addressHex, uid });
+			}
+		}
+	}
+	return entries;
+}
+
+/**
+ * Pick the uid of the LISTEN entry that would actually service a `/proxy/<port>/` request.
+ * `WebClientServer` always dials `http://0.0.0.0:<port>`, which Linux's `ip_route_connect()`
+ * rewrites to exactly `127.0.0.1` -- so a listener bound to that specific address, if one exists,
+ * is who receives the connection. Mirroring the kernel's own listener lookup in
+ * `__inet_lookup_listener()` (which hashes on the destination address first and only falls back to
+ * the wildcard/`INADDR_ANY` bucket if that exact lookup misses), an exact `127.0.0.1` match takes
+ * priority over a wildcard (`0.0.0.0`/`::`) match on the same port -- if both exist, simply
+ * returning whichever entry appears first could attribute the port to the wrong uid, independent
+ * of which process actually started listening first. A listener bound only to some other specific
+ * address -- including other loopback addresses like `127.0.0.2`, or the IPv6-only loopback `::1`
+ * -- is never reachable this way, even though it may share the same port, so it must not be treated
+ * as the owner of that port for this check.
+ *
+ * Exported (rather than folded into `getListeningPortUid`) so the priority policy can be unit
+ * tested against fabricated entries, independent of real `/proc` state or process uids.
+ */
+export function selectOwnerUid(entries: ListenerEntry[]): number | undefined {
+	const parsed = entries.map(e => ({ bytes: parseProcAddressBytes(e.addressHex), uid: e.uid }));
+	return parsed.find(e => isExactLoopbackMatch(e.bytes))?.uid
+		?? parsed.find(e => isWildcardMatch(e.bytes))?.uid;
+}
+
+/**
+ * Look up the uid owning the TCP socket that would actually service a `/proxy/<port>/` request, by
+ * scanning `/proc/net/tcp` and `/proc/net/tcp6` (see `selectOwnerUid` for the priority policy).
+ *
+ * @returns the owner uid, or `undefined` if no reachable LISTEN socket for the port was found or
+ *          /proc could not be read.
+ */
+export function getListeningPortUid(port: number): number | undefined {
+	return selectOwnerUid(collectListeners(port));
+}
+
+let procTcpAvailable: boolean | undefined;
+
+/**
+ * One-time (cached) capability probe: whether this process can read `/proc/net/tcp` and parse a
+ * numeric uid column from it. Mirrors the rserver fix's `probeSockDiagAvailable()` -- when this is
+ * false the runtime cannot support the ownership check at all and callers degrade to no enforcement
+ * rather than break proxying.
+ */
+export function isProcTcpAvailable(): boolean {
+	if (procTcpAvailable === undefined) {
+		procTcpAvailable = probeProcTcp();
+	}
+	return procTcpAvailable;
+}
+
+function probeProcTcp(): boolean {
+	let contents: string;
+	try {
+		contents = readFileSync('/proc/net/tcp', 'utf8');
+	} catch {
+		return false;
+	}
+	// Require at least the header plus one parseable data row with a numeric uid column, so a
+	// stubbed/empty procfs (e.g. in a restricted sandbox) is treated as unavailable.
+	const lines = contents.split('\n');
+	for (let i = 1; i < lines.length; i++) {
+		const fields = lines[i].trim().split(/\s+/);
+		if (fields.length >= 8 && !Number.isNaN(parseInt(fields[7], 10))) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * Whether `/proxy/` port-ownership enforcement can and should run for a session with the given uid.
+ * Enforcement is skipped for root-owned sessions (uid 0 -- every port trivially "matches", so the
+ * check adds nothing; parity with rserver's `launcher-sessions-container-run-as-root` behaviour) and
+ * when the /proc capability is absent.
+ */
+export function isProxyPortOwnershipEnforced(uid: number): boolean {
+	return uid !== 0 && isProcTcpAvailable();
+}

--- a/src/vs/server/node/webClientServer.ts
+++ b/src/vs/server/node/webClientServer.ts
@@ -35,6 +35,8 @@ import httpProxy from 'http-proxy';
 // eslint-disable-next-line no-duplicate-imports
 import { existsSync } from 'fs';
 import { kProxyRegex, VSCODE_STATIC_PREFIX, WORKBENCH_DEPLOYMENT_PREFIX } from './pwbConstants.js';
+import { getListeningPortUid, isProxyPortOwnershipEnforced, ISocketOwnershipCheck } from './socketOwnership.js';
+import type * as net from 'net';
 // --- End PWB ---
 // --- Start Positron ---
 import { HAS_STATIC_ROUTE } from './pwbConstants.js';
@@ -160,6 +162,16 @@ export class WebClientServer {
 	// --- Start PWB ---
 	private readonly _proxyServer;
 	private readonly _rsLoginCheckScriptTag: string;
+	private _loggedProxyOwnershipDisabled = false;
+	private _socketOwnershipCheck: ISocketOwnershipCheck = { getListeningPortUid, isProxyPortOwnershipEnforced };
+
+	/**
+	 * Test-only seam for the `/proxy/` ownership gate (rstudio-pro#11470): overrides the
+	 * `/proc`-reading implementations with stubs. Not called in production. See webClientServer.vitest.ts.
+	 */
+	setSocketOwnershipCheckForTesting(check: ISocketOwnershipCheck): void {
+		this._socketOwnershipCheck = check;
+	}
 	// --- End PWB ---
 
 	constructor(
@@ -245,6 +257,12 @@ export class WebClientServer {
 			}
 			// --- PWB Start: Server proxy support ---
 			if (kProxyRegex.test(pathname)) {
+				// Refuse to proxy to a localhost port owned by another user (rstudio-pro#11470).
+				const proxyPort = this._parseProxyPort(pathname);
+				if (proxyPort !== undefined && !this._verifyProxyPortOwnership(proxyPort)) {
+					return serveError(req, res, 403, 'Access to the requested port is forbidden.');
+				}
+
 				let path: string = pathname.replace('/proxy/', 'http://0.0.0.0:');
 
 				// Append query string if it exists
@@ -277,11 +295,63 @@ export class WebClientServer {
 	 * Handle proxy requests for websockets
 	 */
 	async handleUpgrade(req: http.IncomingMessage, socket: unknown, upgradeHead: unknown, parsedUrl: string): Promise<void> {
+		// Refuse to proxy to a localhost port owned by another user (rstudio-pro#11470). There is no
+		// response object on the upgrade path, so on failure we just destroy the socket.
+		const proxyPort = this._parseProxyPort(parsedUrl);
+		if (proxyPort !== undefined && !this._verifyProxyPortOwnership(proxyPort)) {
+			(socket as net.Socket).destroy();
+			return;
+		}
+
 		const path: string = parsedUrl.replace('/proxy/', 'http://0.0.0.0:');
 		return this._proxyServer.ws(req, socket, upgradeHead, {
 			ignorePath: true,
 			target: path
 		});
+	}
+
+	/**
+	 * Extract the localhost port number from a `/proxy/<port>/...` path, or undefined if it can't be
+	 * parsed (in which case the caller skips the ownership check rather than blocking).
+	 */
+	private _parseProxyPort(pathname: string): number | undefined {
+		const match = /\/proxy\/([0-9]+)/.exec(pathname);
+		if (!match) {
+			return undefined;
+		}
+		const port = parseInt(match[1], 10);
+		return Number.isNaN(port) ? undefined : port;
+	}
+
+	/**
+	 * Verify the localhost port we've been asked to proxy to is owned by this session's user. Each
+	 * vscode-server session runs as its own user, so the expected owner is simply our own uid.
+	 * Skipped entirely when disabled via `--www-proxy-localhost-verify-port-owner=0` (or `=false`).
+	 * Otherwise fails open when enforcement is not applicable (non-Linux, root session, or /proc
+	 * unreadable); fails closed (returns false) when the check runs but no matching listener is
+	 * owned by us.
+	 */
+	private _verifyProxyPortOwnership(port: number): boolean {
+		const verifyPortOwnerArg = this._environmentService.args['www-proxy-localhost-verify-port-owner'];
+		if (verifyPortOwnerArg === '0' || verifyPortOwnerArg === 'false') {
+			return true;
+		}
+
+		const uid = process.getuid?.() ?? 0;
+		if (!this._socketOwnershipCheck.isProxyPortOwnershipEnforced(uid)) {
+			if (!this._loggedProxyOwnershipDisabled && uid !== 0) {
+				this._loggedProxyOwnershipDisabled = true;
+				this._logService.warn(`Cannot verify which local ports belong to your session, so requests will be forwarded to any port on this server without verifying ownership.`);
+			}
+			return true;
+		}
+
+		const ownerUid = this._socketOwnershipCheck.getListeningPortUid(port);
+		if (ownerUid === uid) {
+			return true;
+		}
+		this._logService.warn(`Cannot forward your request to port ${port}: it is in use by another user (uid ${ownerUid ?? '<no listener>'}, not your uid ${uid}). You can only reach applications running under your own account.`);
+		return false;
 	}
 	// --- PWB End ---
 

--- a/src/vs/server/test/node/socketOwnership.vitest.ts
+++ b/src/vs/server/test/node/socketOwnership.vitest.ts
@@ -1,0 +1,82 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import * as net from 'net';
+import { getListeningPortUid, isProcTcpAvailable, isProxyPortOwnershipEnforced, selectOwnerUid } from '../../node/socketOwnership.js';
+
+// These helpers read /proc/net/tcp, which only exists on Linux.
+describe.runIf(process.platform === 'linux')('socketOwnership', () => {
+
+	it('getListeningPortUid returns our uid for a loopback listener and undefined for an unused port', async () => {
+		const server = net.createServer();
+		try {
+			const port = await new Promise<number>((resolve, reject) => {
+				server.on('error', reject);
+				server.listen(0, '127.0.0.1', () => resolve((server.address() as net.AddressInfo).port));
+			});
+
+			expect({
+				listenerUid: getListeningPortUid(port),
+				unusedPort: getListeningPortUid(0),
+			}).toEqual({
+				listenerUid: process.getuid!(),
+				unusedPort: undefined,
+			});
+		} finally {
+			await new Promise<void>(resolve => server.close(() => resolve()));
+		}
+	});
+
+	it('getListeningPortUid ignores a listener bound only to a non-loopback address', async () => {
+		// A /proxy/<port>/ request always dials http://0.0.0.0:<port>, which Linux's
+		// ip_route_connect() rewrites to exactly 127.0.0.1 -- it can never reach a socket bound
+		// solely to some other specific address, even if that socket is LISTENing on the same port
+		// and even if that address is also loopback (127.0.0.0/8 is loopback, but only 127.0.0.1 is
+		// the rewrite target).
+		const server = net.createServer();
+		try {
+			const port = await new Promise<number>((resolve, reject) => {
+				server.on('error', reject);
+				server.listen(0, '127.0.0.2', () => resolve((server.address() as net.AddressInfo).port));
+			});
+
+			expect(getListeningPortUid(port)).toBeUndefined();
+		} finally {
+			await new Promise<void>(resolve => server.close(() => resolve()));
+		}
+	});
+
+	it('selectOwnerUid prefers an exact 127.0.0.1 match over a 0.0.0.0 wildcard match, regardless of entry order', () => {
+		// Linux's __inet_lookup_listener() hashes on the destination address first and only falls
+		// back to the wildcard/INADDR_ANY bucket if that exact lookup misses -- so if both a wildcard
+		// and an exact-loopback listener exist on the same port, the exact-loopback one is who
+		// actually receives a /proxy/<port>/ connection. That priority must not depend on which
+		// /proc/net/tcp line happens to appear first (i.e. which process started listening first).
+		const wildcard = { addressHex: '00000000', uid: 111 }; // 0.0.0.0
+		const exactLoopback = { addressHex: '0100007F', uid: 222 }; // 127.0.0.1
+
+		expect({
+			wildcardFirst: selectOwnerUid([wildcard, exactLoopback]),
+			exactFirst: selectOwnerUid([exactLoopback, wildcard]),
+		}).toEqual({
+			wildcardFirst: 222,
+			exactFirst: 222,
+		});
+	});
+
+	it('capability probe and enforcement gating', () => {
+		expect({
+			available: isProcTcpAvailable(),
+			enforcedForUser: isProxyPortOwnershipEnforced(process.getuid!()),
+			enforcedForRoot: isProxyPortOwnershipEnforced(0),
+		}).toEqual({
+			available: true,
+			enforcedForUser: process.getuid!() !== 0,
+			enforcedForRoot: false,
+		});
+	});
+});

--- a/src/vs/server/test/node/webClientServer.vitest.ts
+++ b/src/vs/server/test/node/webClientServer.vitest.ts
@@ -1,0 +1,262 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+// eslint-disable-next-line local/code-no-http-import
+import * as http from 'http';
+import * as net from 'net';
+import * as url from 'url';
+import { mock, mockObject, upcastPartial } from '../../../base/test/common/mock.js';
+import { ILogService, NullLogService } from '../../../platform/log/common/log.js';
+import { IServerEnvironmentService, ServerParsedArgs } from '../../node/serverEnvironmentService.js';
+import { IRequestService } from '../../../platform/request/common/request.js';
+import { IProductService } from '../../../platform/product/common/productService.js';
+import { ICSSDevelopmentService } from '../../../platform/cssDev/node/cssDevService.js';
+import { NoneServerConnectionToken } from '../../node/serverConnectionToken.js';
+import { WebClientServer } from '../../node/webClientServer.js';
+import { ISocketOwnershipCheck } from '../../node/socketOwnership.js';
+
+// None of the tests below exercise real /proc reads -- getListeningPortUid/isProxyPortOwnershipEnforced
+// are stubbed via WebClientServer#setSocketOwnershipCheckForTesting -- so, unlike socketOwnership.vitest.ts,
+// these run on every platform.
+
+class EmptyRequestService extends mock<IRequestService>() { }
+class EmptyProductService extends mock<IProductService>() { }
+
+function createWebClientServer(ownershipCheck: ISocketOwnershipCheck, logService: ILogService = new NullLogService(), args: Partial<ServerParsedArgs> = {}): WebClientServer {
+	const webClientServer = new WebClientServer(
+		new NoneServerConnectionToken(),
+		'/',
+		'',
+		mockObject<IServerEnvironmentService>()({ args: upcastPartial(args) }) as unknown as IServerEnvironmentService,
+		logService,
+		new EmptyRequestService(),
+		new EmptyProductService(),
+		mockObject<ICSSDevelopmentService>()({ isEnabled: false }) as unknown as ICSSDevelopmentService
+	);
+	webClientServer.setSocketOwnershipCheckForTesting(ownershipCheck);
+	return webClientServer;
+}
+
+const ourUid = process.getuid?.() ?? 0;
+const foreignUid = ourUid + 1; // guaranteed mismatch regardless of the uid the test happens to run as
+
+function listen(server: http.Server | net.Server, port: number, host: string): Promise<void> {
+	return new Promise((resolve, reject) => {
+		server.once('error', reject);
+		server.listen(port, host, () => resolve());
+	});
+}
+
+describe('WebClientServer /proxy/ port ownership gate', () => {
+
+	describe('handle()', () => {
+
+		it('rejects with 403 when the port is owned by another uid, and logs a warning', async () => {
+			const ownershipCheck: ISocketOwnershipCheck = {
+				getListeningPortUid: vi.fn().mockReturnValue(foreignUid),
+				isProxyPortOwnershipEnforced: vi.fn().mockReturnValue(true),
+			};
+			const logService = new NullLogService();
+			const warn = vi.spyOn(logService, 'warn');
+			const webClientServer = createWebClientServer(ownershipCheck, logService);
+
+			const frontServer = http.createServer((req, res) => {
+				const parsedUrl = url.parse(req.url!, true);
+				webClientServer.handle(req, res, parsedUrl, parsedUrl.pathname!);
+			});
+			try {
+				await listen(frontServer, 0, '127.0.0.1');
+				const { port } = frontServer.address() as net.AddressInfo;
+
+				const response = await new Promise<{ status: number | undefined; body: string }>((resolve, reject) => {
+					http.get(`http://127.0.0.1:${port}/proxy/9999/`, res => {
+						let body = '';
+						res.on('data', chunk => body += chunk);
+						res.on('end', () => resolve({ status: res.statusCode, body }));
+					}).on('error', reject);
+				});
+
+				expect({ status: response.status, body: response.body, loggedWarning: warn.mock.calls.length === 1 })
+					.toEqual({ status: 403, body: 'Access to the requested port is forbidden.', loggedWarning: true });
+			} finally {
+				frontServer.close();
+			}
+		});
+
+		it('proxies through to the backend when the port is owned by our uid', async () => {
+			const ownershipCheck: ISocketOwnershipCheck = {
+				getListeningPortUid: vi.fn().mockReturnValue(ourUid),
+				isProxyPortOwnershipEnforced: vi.fn().mockReturnValue(true),
+			};
+			const webClientServer = createWebClientServer(ownershipCheck);
+
+			const backendServer = http.createServer((_req, res) => res.end('ok'));
+			const frontServer = http.createServer((req, res) => {
+				const parsedUrl = url.parse(req.url!, true);
+				webClientServer.handle(req, res, parsedUrl, parsedUrl.pathname!);
+			});
+			try {
+				await listen(backendServer, 0, '127.0.0.1');
+				const { port: backendPort } = backendServer.address() as net.AddressInfo;
+				await listen(frontServer, 0, '127.0.0.1');
+				const { port: frontPort } = frontServer.address() as net.AddressInfo;
+
+				const response = await new Promise<{ status: number | undefined; body: string }>((resolve, reject) => {
+					http.get(`http://127.0.0.1:${frontPort}/proxy/${backendPort}/`, res => {
+						let body = '';
+						res.on('data', chunk => body += chunk);
+						res.on('end', () => resolve({ status: res.statusCode, body }));
+					}).on('error', reject);
+				});
+
+				expect(response).toEqual({ status: 200, body: 'ok' });
+			} finally {
+				frontServer.close();
+				backendServer.close();
+			}
+		});
+
+		it('fails open (does not block) when ownership enforcement is unavailable, and logs once', async () => {
+			const ownershipCheck: ISocketOwnershipCheck = {
+				getListeningPortUid: vi.fn(),
+				isProxyPortOwnershipEnforced: vi.fn().mockReturnValue(false),
+			};
+			const logService = new NullLogService();
+			const warn = vi.spyOn(logService, 'warn');
+			const webClientServer = createWebClientServer(ownershipCheck, logService);
+
+			const backendServer = http.createServer((_req, res) => res.end('ok'));
+			const frontServer = http.createServer((req, res) => {
+				const parsedUrl = url.parse(req.url!, true);
+				webClientServer.handle(req, res, parsedUrl, parsedUrl.pathname!);
+			});
+			try {
+				await listen(backendServer, 0, '127.0.0.1');
+				const { port: backendPort } = backendServer.address() as net.AddressInfo;
+				await listen(frontServer, 0, '127.0.0.1');
+				const { port: frontPort } = frontServer.address() as net.AddressInfo;
+
+				const response = await new Promise<{ status: number | undefined; body: string }>((resolve, reject) => {
+					http.get(`http://127.0.0.1:${frontPort}/proxy/${backendPort}/`, res => {
+						let body = '';
+						res.on('data', chunk => body += chunk);
+						res.on('end', () => resolve({ status: res.statusCode, body }));
+					}).on('error', reject);
+				});
+
+				expect({
+					status: response.status,
+					body: response.body,
+					loggedDisabledWarning: warn.mock.calls.length === 1,
+					consultedPortUid: (ownershipCheck.getListeningPortUid as ReturnType<typeof vi.fn>).mock.calls.length > 0,
+				}).toEqual({ status: 200, body: 'ok', loggedDisabledWarning: true, consultedPortUid: false });
+			} finally {
+				frontServer.close();
+				backendServer.close();
+			}
+		});
+
+		for (const disableValue of ['0', 'false']) {
+			it(`proxies through without consulting ownership when disabled via --www-proxy-localhost-verify-port-owner=${disableValue}`, async () => {
+				const ownershipCheck: ISocketOwnershipCheck = {
+					getListeningPortUid: vi.fn().mockReturnValue(foreignUid),
+					isProxyPortOwnershipEnforced: vi.fn().mockReturnValue(true),
+				};
+				const webClientServer = createWebClientServer(ownershipCheck, new NullLogService(), { 'www-proxy-localhost-verify-port-owner': disableValue });
+
+				const backendServer = http.createServer((_req, res) => res.end('ok'));
+				const frontServer = http.createServer((req, res) => {
+					const parsedUrl = url.parse(req.url!, true);
+					webClientServer.handle(req, res, parsedUrl, parsedUrl.pathname!);
+				});
+				try {
+					await listen(backendServer, 0, '127.0.0.1');
+					const { port: backendPort } = backendServer.address() as net.AddressInfo;
+					await listen(frontServer, 0, '127.0.0.1');
+					const { port: frontPort } = frontServer.address() as net.AddressInfo;
+
+					const response = await new Promise<{ status: number | undefined; body: string }>((resolve, reject) => {
+						http.get(`http://127.0.0.1:${frontPort}/proxy/${backendPort}/`, res => {
+							let body = '';
+							res.on('data', chunk => body += chunk);
+							res.on('end', () => resolve({ status: res.statusCode, body }));
+						}).on('error', reject);
+					});
+
+					expect({
+						status: response.status,
+						body: response.body,
+						consultedPortUid: (ownershipCheck.getListeningPortUid as ReturnType<typeof vi.fn>).mock.calls.length > 0,
+					}).toEqual({ status: 200, body: 'ok', consultedPortUid: false });
+				} finally {
+					frontServer.close();
+					backendServer.close();
+				}
+			});
+		}
+	});
+
+	describe('handleUpgrade()', () => {
+
+		// A minimal but valid WS upgrade request: http-proxy's own checkMethodAndHeader pass destroys the
+		// socket for any request that isn't `GET` with an `Upgrade: websocket` header, independent of our
+		// ownership gate, so the fake request must satisfy that or the two failure modes are indistinguishable.
+		function fakeUpgradeRequest(pathname: string): http.IncomingMessage {
+			return mockObject<http.IncomingMessage>()({
+				method: 'GET',
+				url: pathname,
+				headers: { upgrade: 'websocket', connection: 'Upgrade' },
+			}) as unknown as http.IncomingMessage;
+		}
+
+		async function connectedSocketPair(): Promise<{ server: net.Server; socket: net.Socket }> {
+			const server = net.createServer();
+			await listen(server, 0, '127.0.0.1');
+			const { port } = server.address() as net.AddressInfo;
+			const socket = net.connect(port, '127.0.0.1');
+			await new Promise<void>((resolve, reject) => {
+				socket.once('connect', () => resolve());
+				socket.once('error', reject);
+			});
+			return { server, socket };
+		}
+
+		it('destroys the socket when the port is owned by another uid, without reaching the proxy', async () => {
+			const ownershipCheck: ISocketOwnershipCheck = {
+				getListeningPortUid: vi.fn().mockReturnValue(foreignUid),
+				isProxyPortOwnershipEnforced: vi.fn().mockReturnValue(true),
+			};
+			const webClientServer = createWebClientServer(ownershipCheck);
+			const { server, socket } = await connectedSocketPair();
+
+			try {
+				await webClientServer.handleUpgrade(fakeUpgradeRequest('/proxy/9999/'), socket, Buffer.alloc(0), '/proxy/9999/');
+				expect(socket.destroyed).toBe(true);
+			} finally {
+				socket.destroy();
+				server.close();
+			}
+		});
+
+		it('does not destroy the socket when the port is owned by our uid', async () => {
+			const ownershipCheck: ISocketOwnershipCheck = {
+				getListeningPortUid: vi.fn().mockReturnValue(ourUid),
+				isProxyPortOwnershipEnforced: vi.fn().mockReturnValue(true),
+			};
+			const webClientServer = createWebClientServer(ownershipCheck);
+			const { server, socket } = await connectedSocketPair();
+
+			try {
+				await webClientServer.handleUpgrade(fakeUpgradeRequest('/proxy/9999/'), socket, Buffer.alloc(0), '/proxy/9999/');
+				expect(socket.destroyed).toBe(false);
+			} finally {
+				socket.destroy();
+				server.close();
+			}
+		});
+	});
+});

--- a/src/vs/server/test/node/webClientServer.vitest.ts
+++ b/src/vs/server/test/node/webClientServer.vitest.ts
@@ -50,8 +50,11 @@ function createWebClientServer(ownershipCheck: ISocketOwnershipCheck, logService
 	return webClientServer;
 }
 
-const ourUid = process.getuid?.() ?? 0;
-const foreignUid = ourUid + 1; // guaranteed mismatch regardless of the uid the test happens to run as
+// Fixed rather than read from the real process: CI containers commonly run as root (uid 0), and
+// production code intentionally skips the "ownership check disabled" log when uid === 0 (see
+// _verifyProxyPortOwnership), which would make these expectations flake depending on who runs them.
+const ourUid = 1000;
+const foreignUid = ourUid + 1;
 
 function listen(server: http.Server | net.Server, port: number, host: string): Promise<void> {
 	return new Promise((resolve, reject) => {
@@ -61,6 +64,10 @@ function listen(server: http.Server | net.Server, port: number, host: string): P
 }
 
 describe('WebClientServer /proxy/ port ownership gate', () => {
+
+	beforeEach(() => {
+		vi.spyOn(process, 'getuid').mockReturnValue(ourUid);
+	});
 
 	describe('handle()', () => {
 

--- a/src/vs/server/test/node/webClientServer.vitest.ts
+++ b/src/vs/server/test/node/webClientServer.vitest.ts
@@ -5,6 +5,15 @@
 
 /// <reference types="vitest/globals" />
 
+// webClientServer.ts computes APP_ROOT at module load via FileAccess.asFileUri(''), which
+// requires globalThis._VSCODE_FILE_ROOT. That's normally set by a bootstrap entry point (see
+// agentHostServerMain.ts), which this plain Vitest run doesn't go through -- set it ourselves,
+// hoisted above the import so it's in place before webClientServer.ts's top-level code runs.
+// Avoids importing the `url` module here since vi.hoisted runs before this file's own imports.
+vi.hoisted(() => {
+	globalThis._VSCODE_FILE_ROOT = new URL('../../../../..', import.meta.url).pathname;
+});
+
 // eslint-disable-next-line local/code-no-http-import
 import * as http from 'http';
 import * as net from 'net';


### PR DESCRIPTION
Upstream merge from vscode-server, bringing in rstudio/vscode-server#389.

### Summary

Verifies the localhost port a `/proxy/<port>/` request targets is owned by the requesting session's own user before proxying HTTP or WebSocket traffic to it. This closes a cross-user isolation gap on multi-user Workbench hosts (rstudio-pro#11470): without this check, one user's session could proxy into a port bound by another user's process on the same host.

Ownership is determined by reading `/proc/net/tcp[6]` for the listening socket's uid -- the same kernel data rserver's `NETLINK_SOCK_DIAG`-based fix relies on, without adding a native dependency. Enforcement fails open when unavailable (non-Linux, root sessions, unreadable `/proc`) and fails closed on a uid mismatch, returning 403 for HTTP requests and destroying the socket for WebSocket upgrades. A new `--www-proxy-localhost-verify-port-owner` flag disables the check if an environment needs to.

New tests (`socketOwnership.vitest.ts`, `webClientServer.vitest.ts`) are ported as Vitest rather than upstream's Mocha `.test.ts`, per Positron's convention for new Positron-owned server code.

Other commits on `upstream/main` since the last pull (#13497) were triaged and left out:

| Reason | Commits |
| --- | --- |
| Already implemented in Positron | <ul><li>rstudio/vscode-server#385 (terminal paste popup fix in Firefox/Safari, ported via #14568)</li><li>rstudio/vscode-server#366 (extension host hang defense, ported via #14673)</li></ul> |
| `rstudio.rstudio-workbench` version bumps; Positron's `product.json` already pins an equal or newer version | <ul><li>rstudio/vscode-server#377</li><li>rstudio/vscode-server#365</li></ul> |
| CI automation only (`.github/`, `Jenkinsfile`) | <ul><li>rstudio/vscode-server#393</li><li>rstudio/vscode-server#390</li><li>rstudio/vscode-server#372</li><li>rstudio/vscode-server#369</li></ul> |

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Isolate `/proxy/` port access to the requesting session's own user on multi-user Workbench hosts

### Validation Steps

@:workbench @:web @:jupyter

1. Start Positron Server / Workbench with two sessions running as different users on the same host.
2. Have user B start a process listening on a localhost port (e.g. `python -m http.server 8123`).
3. As user A, request `/proxy/8123/` through the Workbench-fronted URL -- expect a 403 "Access to the requested port is forbidden." response instead of a proxied response.
4. As user B, request `/proxy/8123/` (their own port) -- expect normal proxying to succeed.
5. Verify a WebSocket upgrade to another user's port is refused (socket destroyed, no proxy connection established), and to your own port succeeds.
6. Verify `--www-proxy-localhost-verify-port-owner=0` disables the check (proxying succeeds regardless of port ownership).
