### PR TITLE
fix(runtime): skip unregistered runtimes when resolving the preferred runtime

### DIFF
--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -1733,12 +1733,9 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 	/**
 	 * Gets the preferred runtime for a language
 	 *
-	 * Every preference source is validated against the registered runtimes
-	 * before it is returned; callers start sessions from the result, and
-	 * starting a session from an unregistered runtime id throws. Sessions and
-	 * the most-recently-started map can both outlive the runtime they name
-	 * (e.g. a restored session after a window reload rediscovers runtimes), so
-	 * an unregistered id falls through to the next source instead.
+	 * A preference source can outlive the runtime it names (e.g. a session
+	 * restored across a window reload), so an unregistered id falls through
+	 * to the next source rather than being returned.
 	 *
 	 * @param languageId The language identifier
 	 * @returns The preferred runtime metadata, or undefined if no preferred

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -1733,6 +1733,13 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 	/**
 	 * Gets the preferred runtime for a language
 	 *
+	 * Every preference source is validated against the registered runtimes
+	 * before it is returned; callers start sessions from the result, and
+	 * starting a session from an unregistered runtime id throws. Sessions and
+	 * the most-recently-started map can both outlive the runtime they name
+	 * (e.g. a restored session after a window reload rediscovers runtimes), so
+	 * an unregistered id falls through to the next source instead.
+	 *
 	 * @param languageId The language identifier
 	 * @returns The preferred runtime metadata, or undefined if no preferred
 	 *  runtime is available.
@@ -1742,7 +1749,11 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 		const activeSession =
 			this._runtimeSessionService.getConsoleSessionForLanguage(languageId);
 		if (activeSession) {
-			return activeSession.runtimeMetadata;
+			const activeSessionRuntime =
+				this._languageRuntimeService.getRegisteredRuntime(activeSession.runtimeMetadata.runtimeId);
+			if (activeSessionRuntime) {
+				return activeSessionRuntime;
+			}
 		}
 
 		// If there's a runtime affiliated with the workspace for the language,
@@ -1759,7 +1770,11 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 		// If there is a most recently started runtime for the language, return it.
 		const mostRecentlyStartedRuntime = this._mostRecentlyStartedRuntimesByLanguageId.get(languageId);
 		if (mostRecentlyStartedRuntime) {
-			return mostRecentlyStartedRuntime;
+			const mostRecentlyStartedRuntimeInfo =
+				this._languageRuntimeService.getRegisteredRuntime(mostRecentlyStartedRuntime.runtimeId);
+			if (mostRecentlyStartedRuntimeInfo) {
+				return mostRecentlyStartedRuntimeInfo;
+			}
 		}
 
 		// If there are registered runtimes for the language, return the first.

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -1748,7 +1748,7 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 				: undefined;
 
 		// Preference order:
-		//   1. The active console session for the language
+		//   1. The runtime backing the active console session for the language
 		//   2. The runtime affiliated with the workspace
 		//   3. The most recently started runtime for the language
 		//   4. Any registered runtime for the language

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -1745,48 +1745,19 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 	 *  runtime is available.
 	 */
 	public getPreferredRuntime(languageId: string): ILanguageRuntimeMetadata | undefined {
-		// If there's an active session for the language, return it.
-		const activeSession =
-			this._runtimeSessionService.getConsoleSessionForLanguage(languageId);
-		if (activeSession) {
-			const activeSessionRuntime =
-				this._languageRuntimeService.getRegisteredRuntime(activeSession.runtimeMetadata.runtimeId);
-			if (activeSessionRuntime) {
-				return activeSessionRuntime;
-			}
-		}
+		const registered = (metadata: ILanguageRuntimeMetadata | undefined) =>
+			metadata
+				? this._languageRuntimeService.getRegisteredRuntime(metadata.runtimeId)
+				: undefined;
 
-		// If there's a runtime affiliated with the workspace for the language,
-		// return it.
-		const affiliatedRuntimeMetadata = this.getAffiliatedRuntimeMetadata(languageId);
-		if (affiliatedRuntimeMetadata) {
-			const affiliatedRuntimeInfo =
-				this._languageRuntimeService.getRegisteredRuntime(affiliatedRuntimeMetadata.runtimeId);
-			if (affiliatedRuntimeInfo) {
-				return affiliatedRuntimeInfo;
-			}
-		}
-
-		// If there is a most recently started runtime for the language, return it.
-		const mostRecentlyStartedRuntime = this._mostRecentlyStartedRuntimesByLanguageId.get(languageId);
-		if (mostRecentlyStartedRuntime) {
-			const mostRecentlyStartedRuntimeInfo =
-				this._languageRuntimeService.getRegisteredRuntime(mostRecentlyStartedRuntime.runtimeId);
-			if (mostRecentlyStartedRuntimeInfo) {
-				return mostRecentlyStartedRuntimeInfo;
-			}
-		}
-
-		// If there are registered runtimes for the language, return the first.
-		const languageRuntimeInfos =
-			this._languageRuntimeService.registeredRuntimes
-				.filter(info => info.languageId === languageId);
-		if (languageRuntimeInfos.length) {
-			return languageRuntimeInfos[0];
-		}
-
-		// Nothing is registered, so we don't have a preferred runtime for this language.
-		return undefined;
+		// In preference order: the active console session, the runtime affiliated
+		// with the workspace, the most recently started runtime, then any
+		// registered runtime for the language.
+		const consoleSession = this._runtimeSessionService.getConsoleSessionForLanguage(languageId);
+		return registered(consoleSession?.runtimeMetadata)
+			?? registered(this.getAffiliatedRuntimeMetadata(languageId))
+			?? registered(this._mostRecentlyStartedRuntimesByLanguageId.get(languageId))
+			?? this._languageRuntimeService.registeredRuntimes.find(info => info.languageId === languageId);
 	}
 
 	/**

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -1750,9 +1750,11 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 				? this._languageRuntimeService.getRegisteredRuntime(metadata.runtimeId)
 				: undefined;
 
-		// In preference order: the active console session, the runtime affiliated
-		// with the workspace, the most recently started runtime, then any
-		// registered runtime for the language.
+		// Preference order:
+		//   1. The active console session for the language
+		//   2. The runtime affiliated with the workspace
+		//   3. The most recently started runtime for the language
+		//   4. Any registered runtime for the language
 		const consoleSession = this._runtimeSessionService.getConsoleSessionForLanguage(languageId);
 		return registered(consoleSession?.runtimeMetadata)
 			?? registered(this.getAffiliatedRuntimeMetadata(languageId))

--- a/src/vs/workbench/services/runtimeStartup/test/common/runtimeStartup.vitest.ts
+++ b/src/vs/workbench/services/runtimeStartup/test/common/runtimeStartup.vitest.ts
@@ -32,6 +32,7 @@ import {
 import { BeforeShutdownEvent, ILifecycleService, WillShutdownEvent } from '../../../lifecycle/common/lifecycle.js';
 import { IPositronNewFolderService, NewFolderStartupPhase } from '../../../positronNewFolder/common/positronNewFolder.js';
 import { ILanguageRuntimeSession } from '../../../runtimeSession/common/runtimeSessionService.js';
+import { createTestLanguageRuntimeMetadata, startTestLanguageRuntimeSession } from '../../../runtimeSession/test/common/testRuntimeSessionService.js';
 import { RuntimeStartupService } from '../../common/runtimeStartup.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import {
@@ -1107,6 +1108,65 @@ describe('RuntimeStartupService - affiliation healing', () => {
 
 		// getAffiliatedRuntimes() returns the live registered metadata (absolute path).
 		expect(svc.getAffiliatedRuntimes()[0].runtimePath).toBe(freshRuntimePath);
+	});
+});
+
+describe('RuntimeStartupService - getPreferredRuntime', () => {
+
+	const ctx = createTestContainer()
+		.withRuntimeServices()
+		.stub(IEphemeralStateService, {
+			getItem: () => Promise.resolve(undefined),
+			setItem: () => Promise.resolve(),
+		})
+		.stub(ILifecycleService, {
+			onBeforeShutdown: new Emitter<BeforeShutdownEvent>().event,
+			onWillShutdown: new Emitter<WillShutdownEvent>().event,
+		})
+		.stub(IPositronNewFolderService, {
+			onDidChangeNewFolderStartupPhase: new Emitter<NewFolderStartupPhase>().event,
+			startupPhase: NewFolderStartupPhase.Complete,
+		})
+		.stub(IProgressService, {})
+		.stub(IWorkbenchEnvironmentService, { remoteAuthority: undefined })
+		.stub(INotificationService, new TestNotificationService())
+		.stub(IRuntimeDiscoveryCache, {})
+		.build();
+
+	it('skips a preferred runtime that is no longer registered', async () => {
+		const svc = ctx.disposables.add(
+			ctx.instantiationService.createInstance(RuntimeStartupService)) as RuntimeStartupService;
+		const languageRuntimeService = ctx.get(ILanguageRuntimeService);
+
+		// Start a console session, which makes its runtime both the active
+		// console session for the language and the most recently started
+		// runtime for it.
+		const staleRuntime = createTestLanguageRuntimeMetadata(ctx.instantiationService, ctx.disposables);
+		await startTestLanguageRuntimeSession(ctx.instantiationService, ctx.disposables, { runtime: staleRuntime });
+
+		// Register a second runtime for the same language, then unregister the
+		// one the session was started from - the shape left behind when a
+		// window reload rediscovers runtimes and the old ids go away while a
+		// restored session still references them.
+		const liveRuntime = metadata({ languageId: staleRuntime.languageId, runtimeId: 'rt-live' });
+		ctx.disposables.add(languageRuntimeService.registerRuntime(liveRuntime));
+		languageRuntimeService.unregisterRuntime(staleRuntime.runtimeId);
+
+		// Handing back the unregistered runtime makes every caller that starts
+		// a session from it fail with "No language runtime with id X was found".
+		expect(svc.getPreferredRuntime(staleRuntime.languageId)?.runtimeId).toBe(liveRuntime.runtimeId);
+	});
+
+	it('prefers the active console session runtime while it is still registered', async () => {
+		const svc = ctx.disposables.add(
+			ctx.instantiationService.createInstance(RuntimeStartupService)) as RuntimeStartupService;
+
+		const sessionRuntime = createTestLanguageRuntimeMetadata(ctx.instantiationService, ctx.disposables);
+		await startTestLanguageRuntimeSession(ctx.instantiationService, ctx.disposables, { runtime: sessionRuntime });
+		ctx.disposables.add(ctx.get(ILanguageRuntimeService).registerRuntime(
+			metadata({ languageId: sessionRuntime.languageId, runtimeId: 'rt-other' })));
+
+		expect(svc.getPreferredRuntime(sessionRuntime.languageId)?.runtimeId).toBe(sessionRuntime.runtimeId);
 	});
 });
 


### PR DESCRIPTION
### Summary
`getPreferredRuntime` handed back the active console session's runtime and the most-recently-started runtime without checking either is still registered, so callers could start a session from a runtime id that no longer exists and fail with "No language runtime with id X was found".

- Validate both preference sources against the registered runtimes, matching what the affiliation branch already does
- Fall through to the next preference source when the id is unregistered
- Adds vitest coverage for the fallthrough and for keeping a still-registered session runtime preferred

Found while triaging the `Quarto - Inline Output: Persistence > Python - Verify kernel status persists after window reload` flake: a stale session runtime id made the Quarto kernel start fail 3x and go terminal, so no cell ever executed.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed intermittent "No language runtime with id ... was found" failures when starting a kernel after a window reload

### Validation Steps

@:quarto @:console @:sessions @:web

### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- Product race: IRuntimeStartupService.getPreferredRuntime can return runtime metadata for a runtime that is not in registeredRuntimes (the active-console-session and most-recently-started-runtime branches are unvalidated), so Quarto's kernel start throws "No language runtime with id X was found", retries 3x with the same resolution, then goes terminal until the user clicks Retry. No cell ever executes, so the e2e run gate re-fires for 30s and fails.</summary>

- **Test:** [Quarto - Inline Output: Persistence > Python - Verify kernel status persists after window reload](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Quarto%20-%20Inline%20Output%3A%20Persistence%20%3E%20Python%20-%20Verify%20kernel%20status%20persists%20after%20window%20reload%7C%7C%7Ctest%2Fe2e%2Ftests%2Fquarto%2Fquarto-inline-output-persistence.test.ts)
- **Targeted failure:** Pattern B -- expect(received).toBe(expected) Expected true / Received false, Timeout 10000ms then 30000ms, at inlineQuarto.ts:218 (_runCellUntilStarted). 3 occurrences: 1.6% on main (2), 1/1 on mi/quarto-restore-race-reland. ubuntu/electron only.
- **Signal:** Last screencast frame (evidence/B/screenshots/...frame2.jpeg) shows notification: "Failed to start kernel for 'simple_plot.qmd': No language runtime with id '37d58d7b83c86c7526f3a87a10d83199' was found." with a Retry button. Console log t=1278451: "Session untitled-test-3lf2rr.qmd (python-notebook-914f0b23) from runtime 37d58d7b83c86c7526f3a87a10d83199 (Python 3.10.12 (Global)) is not active" -- same runtime id, previous test's session. Trace timeline: continuous Frame.evalOnSelectorAll on .quarto-cell-toolbar[data-execution-id] from t=1280359 to t=1310872 with re-fire cycles at t=1281255 / 1293329 / 1305352 (three toPass attempts), no execution id ever recorded.
- **Frequency:** 1/1 runs (100%) on mi/quarto-restore-race-reland; 2/127 runs (1.6%) on main, ubuntu/electron
- **Hypothesis:** Call chain: quartoExecutionManager.ts:686 -> quartoKernelManager.ts:543-575 ensureKernelForDocument -> :777-816 _startKernelWithRetry -> :875-891 _startKernel -> :745-761 _resolveRuntimeForLanguage -> runtimeStartup.ts:1740-1773 getPreferredRuntime -> quartoKernelManager.ts:912-920 startNewRuntimeSession -> runtimeSession.ts:674-677 throw. getPreferredRuntime branch (a) active console session runtimeMetadata (:1741-1746) and branch (c) _mostRecentlyStartedRuntimesByLanguageId (:1759-1762) are returned without a getRegisteredRuntime check; only the affiliation branch (:1751-1756) validates. quartoKernelManager never awaits onDidRegisterRuntime or a discovery signal (the RuntimeStartupPhase.Complete gate exists only in positronQuarto.contribution.ts:169-176 / :259-262 and does not cover the execute/command entrypoints). Ruled out: runtime id churn across reload -- Python runtimeIds are a deterministic sha256 of interpreter path + version (extensions/positron-python/src/client/positron/runtime.ts:245-249). Ruled out: swallowed run hotkey -- _runCellUntilStarted re-homed the cursor and re-fired 3x. Ruled out: gate blind to a real execution -- console idle, no output rendered. Ruled out: my branch -- pattern also occurs on main. Ruled out: locator drift. Surviving alternative (medium): which unvalidated branch supplied the id -- restored-session metadata after the previous test's reloadWindow, or a most-recently-started entry for a different 3.10.12 interpreter path (the ubuntu CI image has several).

</details>
