### PR TITLE
e2e: fix both renv new-folder flakes (Windows modal wait, ubuntu unwaited install)

### DIFF
--- a/test/e2e/infra/workbench.ts
+++ b/test/e2e/infra/workbench.ts
@@ -132,7 +132,7 @@ export class Workbench {
 		this.newFolderFlow = new NewFolderFlow(code, this.quickaccess);
 		this.output = new Output(code, this.quickaccess, this.quickInput);
 		this.console = new Console(code, this.quickInput, this.hotKeys, this.contextMenu);
-		this.modals = new Modals(code, this.toasts, this.console);
+		this.modals = new Modals(code, this.toasts);
 		this.clipboard = new Clipboard(code, this.hotKeys);
 		this.sessions = new Sessions(code, this.quickaccess, this.quickInput, this.console, this.contextMenu, this.modals);
 		this.notebooks = new Notebooks(code, this.quickInput, this.quickaccess, this.hotKeys);

--- a/test/e2e/pages/dialog-modals.ts
+++ b/test/e2e/pages/dialog-modals.ts
@@ -5,7 +5,6 @@
 
 import test, { expect, Locator } from '@playwright/test';
 import { Code } from '../infra/code.js';
-import { Console } from '../infra';
 import { Toasts } from './dialog-toasts.js';
 
 export class Modals {
@@ -16,7 +15,7 @@ export class Modals {
 	public get cancelButton(): Locator { return this.modalBox.getByRole('button', { name: 'Cancel' }); }
 	public getButton(label: string | RegExp): Locator { return this.modalBox.getByRole('button', { name: label }); }
 
-	constructor(private readonly code: Code, private toasts: Toasts, private console: Console) { }
+	constructor(private readonly code: Code, private toasts: Toasts) { }
 
 	// --- Actions ---
 
@@ -60,24 +59,22 @@ export class Modals {
 	/**
 	 * Interacts with the Renv install modal dialog box. This dialog box appears when a user opts to
 	 * use Renv in the New Folder Flow and creates a new folder, but Renv is not installed.
+	 *
+	 * The modal only appears once the new folder has finished loading and the R session has started,
+	 * so wait for the folder to be open before calling this -- otherwise the timeout below is spent
+	 * on the window reload rather than on the modal itself.
+	 *
 	 * @param action The action to take on the modal dialog box. Either 'install' or 'cancel'.
 	 */
 	async installRenvModal(action: 'install' | 'cancel') {
-		try {
-			await expect(this.code.driver.currentPage.locator('.simple-title-bar').filter({ hasText: 'Missing R package' })).toBeVisible({ timeout: 40000 });
+		await expect(this.code.driver.currentPage.locator('.simple-title-bar').filter({ hasText: 'Missing R package' })).toBeVisible({ timeout: 40000 });
 
-			if (action === 'install') {
-				this.code.logger.log('Install Renv modal detected: clicking `Install now`');
-				await this.getButton('Install now').click();
-			} else if (action === 'cancel') {
-				this.code.logger.log('Install Renv modal detected: clicking `Cancel`');
-				await this.getButton('Cancel').click();
-			}
-		} catch (error) {
-			this.code.logger.log('No Renv modal detected; interacting with console directly');
-
-			await this.console.typeToConsole('y');
-			await this.console.sendEnterKey();
+		if (action === 'install') {
+			this.code.logger.log('Install Renv modal detected: clicking `Install now`');
+			await this.getButton('Install now').click();
+		} else if (action === 'cancel') {
+			this.code.logger.log('Install Renv modal detected: clicking `Cancel`');
+			await this.getButton('Cancel').click();
 		}
 	}
 

--- a/test/e2e/pages/utils/packageManager.ts
+++ b/test/e2e/pages/utils/packageManager.ts
@@ -39,6 +39,28 @@ export class PackageManager {
 
 			await this.app.workbench.console.executeCode(packageInfo.type, command);
 			await expect(this.app.code.driver.currentPage.getByText(expectedOutput)).toBeVisible();
+
+			if (packageInfo.type === 'R') {
+				// The output matched above is printed when `install.packages()` starts, not when it
+				// finishes, and the console keeps showing the `>` prompt while it runs, so
+				// `executeCode`'s readiness check returns almost immediately. Wait for the call to
+				// actually return -- otherwise a caller that creates a new folder next reloads the
+				// window and kills the session mid-install.
+				await this.app.workbench.console.waitForConsoleExecution({ timeout: 120000 });
+
+				if (action === 'install') {
+					// Confirm the package really landed, so a failed install fails here instead of
+					// surfacing later as an unexpected "Missing R package" modal blocking the
+					// workbench. Only checked for `install`: after `remove.packages()`,
+					// `requireNamespace` still reports TRUE if the namespace is already loaded in
+					// the session (which it is in an renv-activated folder).
+					await this.app.workbench.console.executeCode(
+						'R',
+						`cat("${packageName}-available:", requireNamespace("${packageName}", quietly = TRUE), "\\n")`
+					);
+					await this.app.workbench.console.waitForConsoleContents(`${packageName}-available: TRUE`);
+				}
+			}
 		});
 	}
 

--- a/test/e2e/tests/new-folder-flow/new-folder-flow-r.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-r.test.ts
@@ -55,6 +55,10 @@ test.describe('New Folder Flow: R Project', { tag: [tags.MODAL, tags.NEW_FOLDER_
 	});
 
 	test('R - Cancel Renv install', { tag: [tags.WIN] }, async function ({ app, packages }) {
+		// Uninstalling renv, reloading into the new folder, starting an R session and then waiting
+		// out the renv modal adds up to more than the default 2 minute budget on Windows CI.
+		test.slow();
+
 		const folderName = addRandomNumSuffix('r-cancelRenvInstall');
 
 		await packages.manage('renv', 'uninstall');
@@ -65,8 +69,11 @@ test.describe('New Folder Flow: R Project', { tag: [tags.MODAL, tags.NEW_FOLDER_
 			rEnvCheckbox: true,
 		});
 
-		await handleRenvInstallModal(app, 'cancel');
+		// Wait for the new folder to finish loading before waiting on the modal. `createNewFolder`
+		// returns as soon as the wizard closes, and the reload can take 25-40s on Windows CI --
+		// waiting on the modal first spends its timeout on the reload instead of on the modal.
 		await verifyFolderCreation(app, folderName);
+		await handleRenvInstallModal(app, 'cancel');
 		await verifyConsoleReady(app, folderTemplate);
 	});
 });

--- a/test/e2e/tests/new-folder-flow/new-folder-flow-r.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-r.test.ts
@@ -38,6 +38,9 @@ test.describe('New Folder Flow: R Project', { tag: [tags.MODAL, tags.NEW_FOLDER_
 	});
 
 	test('R - Renv already installed', { tag: [tags.WIN] }, async function ({ app, packages }) {
+		// Installing renv, reloading into the new folder and then running renv::init() in it adds
+		// up to more than the default 2 minute budget on slower runners.
+		test.slow();
 
 		await packages.manage('renv', 'install');
 


### PR DESCRIPTION
Fixes both new-folder-flow renv flakes, one per platform. Neither is a product regression: in both cases the test races the app and loses.

### Summary

**1. "R - Cancel Renv install" on Windows** (10 flaky + 1 failed out of 122 win/electron runs; [run 30944006762](https://github.com/posit-dev/positron/actions/runs/30944006762))

The 40s wait for the "Missing R package" modal starts as soon as the New Folder wizard closes, but the workbench still has to reload into the new folder before the modal can appear. That reload consumed 23.4s and 36.5s of the 40s budget across the two attempts, so `r.renvInit` fired 2.3s and 9.4s after the deadline. The runtime startup phases progressed in normal order both times, just slowly.

Wait for the folder to be open (`verifyFolderCreation`, a DOM text read that is unaffected by the open dialog) before waiting on the modal, so each wait gets its own budget. Measured against those two attempts, the modal arrives 19s and 13s after the folder-open assertion resolves.

**2. "R - Renv already installed" on ubuntu** (10 failed + 6 flaky out of ~120 ubuntu/electron runs; [run 30948032053](https://github.com/posit-dev/positron/actions/runs/30948032053))

The "Missing R package" modal appeared even though the test pre-installs renv, because `PackageManager.manage()` never waited for the install to finish. The install step took 5.1s and 2.7s across the two attempts: `executeCode`'s readiness check returned in 37ms (the console shows the `>` prompt while R is busy) and the `Installing|Downloading|Fetched` match only proves `install.packages()` started -- R prints that immediately. The test created the folder ~7-10s in, and the reload killed the session mid-install, so renv really was missing in the new folder.

Wait for the console to go idle after `install.packages()`/`remove.packages()`, then confirm the package is available before returning. The confirmation is install-only: after `remove.packages()`, `requireNamespace()` still reports TRUE when the namespace is already loaded, which it is in an renv-activated folder.

**Shared cleanup:** drop the fallback in `installRenvModal` that typed `y` into the console when the modal didn't show in time (added in #8620 for docker/web). It turned a slow modal into an unrelated failure -- the dialog stayed open and intercepted the next click, which is what got reported in both runs above as a 30s `locator.click` timeout on the Console tab, and `y` landed in the R console as `Error: object 'y' not found`. In the cancel case it also asks for the opposite of what the test wants. Failing at the modal assertion says what actually went wrong, and should replace the "Unknown error" entries this test accumulated in the test-health history. `Modals` no longer needs its `Console` dependency, so the constructor parameter and the `workbench.ts` call site drop it.

`test.slow()` on both tests: each has exceeded the default 2 minute budget in the last two weeks, and waiting for the install properly makes the second one longer.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:new-folder-flow @:modal @:win

Test-only change; the new-folder-flow suite is the validation. The R suite runs serially, so all three of its tests exercise both changed helpers. `PackageManager` is also used by the Python `snowflake` path, which is unchanged (its expected output already marks the end of the install).
