### PR TITLE
Let the session resolve the version to install

### DIFF
--- a/extensions/positron-python/src/client/positron/packages/condaPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/condaPackageManager.ts
@@ -54,6 +54,80 @@ function parseCondaSearchResult(jsonString: string): CondaSearchResult {
 }
 
 /**
+ * Compare two package names the way conda does, ignoring case and treating `-`,
+ * `_` and `.` as the same separator.
+ */
+function sameCondaPackage(a: string, b: string): boolean {
+    const normalize = (value: string) => value.trim().toLowerCase().replace(/[-_.]+/g, '-');
+    return normalize(a) === normalize(b);
+}
+
+/**
+ * Read the version conda said it would link for a package, out of
+ * `conda install --dry-run --json` output.
+ *
+ * The plan lives under `actions.LINK`. It is absent when conda has nothing to do,
+ * which is a real outcome rather than an error, so this returns undefined and
+ * leaves the caller to say what it means. Anything unexpected in the JSON is
+ * treated the same way: this is a version lookup, not a place to fail loudly.
+ */
+export function parseCondaLinkedVersion(jsonString: string, name: string): string | undefined {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(jsonString);
+    } catch {
+        return undefined;
+    }
+    if (typeof parsed !== 'object' || parsed === null) {
+        return undefined;
+    }
+    const actions = (parsed as { actions?: unknown }).actions;
+    if (typeof actions !== 'object' || actions === null) {
+        return undefined;
+    }
+    const link = (actions as { LINK?: unknown }).LINK;
+    if (!Array.isArray(link)) {
+        return undefined;
+    }
+    for (const entry of link) {
+        if (typeof entry !== 'object' || entry === null) {
+            continue;
+        }
+        const { name: entryName, version } = entry as { name?: unknown; version?: unknown };
+        if (typeof entryName === 'string' && typeof version === 'string' && sameCondaPackage(entryName, name)) {
+            return version;
+        }
+    }
+    return undefined;
+}
+
+/**
+ * Read a package's installed version out of `conda list --json` output, which is
+ * an array of environment entries.
+ */
+export function parseCondaListedVersion(jsonString: string, name: string): string | undefined {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(jsonString);
+    } catch {
+        return undefined;
+    }
+    if (!Array.isArray(parsed)) {
+        return undefined;
+    }
+    for (const entry of parsed) {
+        if (typeof entry !== 'object' || entry === null) {
+            continue;
+        }
+        const { name: entryName, version } = entry as { name?: unknown; version?: unknown };
+        if (typeof entryName === 'string' && typeof version === 'string' && sameCondaPackage(entryName, name)) {
+            return version;
+        }
+    }
+    return undefined;
+}
+
+/**
  * Conda Package Manager
  *
  * Provides package management functionality for Python sessions using conda.
@@ -205,9 +279,70 @@ export class CondaPackageManager implements IPackageManager {
         }
     }
 
+    /**
+     * Resolve the version conda would install for a package, by asking conda's
+     * solver what it would do.
+     *
+     * `conda install --dry-run` reports the package it would link, which accounts
+     * for the configured channels, their priority, and everything already in the
+     * environment. The versions from `conda search` are not used for this: they are
+     * ordered by upload time, so a rebuild of an older version published later
+     * would come out on top.
+     *
+     * When the environment already has the newest version, conda has nothing to
+     * link and says so. The answer is then the installed version, because that is
+     * what conda would leave in place.
+     *
+     * @param name Package name
+     * @param token Optional cancellation token
+     */
+    async resolveInstallVersion(name: string, token?: vscode.CancellationToken): Promise<string | undefined> {
+        if (token?.isCancellationRequested) {
+            throw new vscode.CancellationError();
+        }
+
+        await this._ensureConda();
+
+        try {
+            const result = await this._executeCondaWithOutput(['install', '--dry-run', '--json', name], token);
+            const linked = parseCondaLinkedVersion(result, name);
+            if (linked) {
+                return linked;
+            }
+        } catch (e) {
+            if (e instanceof vscode.CancellationError) {
+                throw e;
+            }
+            // A non-zero exit means conda could not solve for the package at all,
+            // which includes an unknown name.
+            return undefined;
+        }
+
+        return this._getInstalledVersion(name, token);
+    }
+
     // =========================================================================
     // Private helper methods
     // =========================================================================
+
+    /**
+     * The version of a package currently installed in the environment, via
+     * `conda list`, or undefined when it isn't installed.
+     */
+    private async _getInstalledVersion(
+        name: string,
+        token?: vscode.CancellationToken,
+    ): Promise<string | undefined> {
+        try {
+            const result = await this._executeCondaWithOutput(['list', name, '--json'], token);
+            return parseCondaListedVersion(result, name);
+        } catch (e) {
+            if (e instanceof vscode.CancellationError) {
+                throw e;
+            }
+            return undefined;
+        }
+    }
 
     /**
      * Ensure conda is available, throwing an error if not.

--- a/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
@@ -19,6 +19,26 @@ import { findWorkspaceRequirementsFile, USE_REQUIREMENTS_FILE_SETTING } from './
 import { IPackageManager, MessageEmitter, PackageSession } from './types';
 
 /**
+ * Read the version out of `pip index versions <name>` output.
+ *
+ * pip leads with the package it found and the version it would install, as
+ * `requests (2.32.5)`, then lists the rest. An `INSTALLED:`/`LATEST:` pair follows
+ * only when the package is already installed, and its `LATEST` repeats the first
+ * line, so the first line is the one thing always there to read.
+ *
+ * pip's warnings go to stderr, so only the first non-empty stdout line matters.
+ */
+export function parsePipIndexVersion(stdout: string): string | undefined {
+    for (const line of stdout.split('\n')) {
+        const match = /^\s*\S+\s+\(([^)]+)\)/.exec(line);
+        if (match) {
+            return match[1].trim() || undefined;
+        }
+    }
+    return undefined;
+}
+
+/**
  * Pip Package Manager
  *
  * Provides package management functionality for Python sessions using pip.
@@ -216,6 +236,44 @@ export class PipPackageManager implements IPackageManager {
             (specs) => this._callMethod<Record<string, boolean>>('checkRequiresPython', token, specs),
             token,
         );
+    }
+
+    /**
+     * Resolve the version pip would install for a package, by asking pip.
+     *
+     * `pip index versions` reports the newest version pip would pick for this
+     * interpreter. Because pip answers, the result honours the configured index
+     * (`index-url`, `extra-index-url`, `pip.conf`, Posit Package Manager), the
+     * package's `Requires-Python`, the availability of a compatible wheel, and
+     * pip's default of skipping prereleases. None of that is re-derived here.
+     *
+     * pip exits non-zero when no distribution matches, which is the same answer as
+     * an unknown package name, so both resolve to undefined.
+     *
+     * @param name Package name
+     * @param token Optional cancellation token
+     */
+    async resolveInstallVersion(name: string, token?: vscode.CancellationToken): Promise<string | undefined> {
+        if (token?.isCancellationRequested) {
+            throw new vscode.CancellationError();
+        }
+
+        await this._ensurePip();
+
+        const pythonService = await this._getPythonService();
+        const proxyFlags = this._getProxyFlags();
+        try {
+            const result = await pythonService.execModule('pip', ['index', 'versions', name, '--no-color', ...proxyFlags], {
+                token,
+            });
+            return parsePipIndexVersion(result.stdout);
+        } catch (e) {
+            if (e instanceof vscode.CancellationError) {
+                throw e;
+            }
+            // A non-zero exit means pip found nothing to install.
+            return undefined;
+        }
     }
 
     // =========================================================================

--- a/extensions/positron-python/src/client/positron/packages/types.ts
+++ b/extensions/positron-python/src/client/positron/packages/types.ts
@@ -80,6 +80,17 @@ export interface IPackageManager {
     searchPackageVersions(name: string, token?: vscode.CancellationToken): Promise<string[]>;
 
     /**
+     * Resolve the version this environment would install for a package right now.
+     * Implementations ask the packaging tool itself rather than comparing version
+     * strings, so the answer honours the configured index, the interpreter's own
+     * compatibility rules and the tool's policy on prereleases.
+     * @param name Package name
+     * @param token Optional cancellation token
+     * @returns The version to install, or undefined if the package has none
+     */
+    resolveInstallVersion?(name: string, token?: vscode.CancellationToken): Promise<string | undefined>;
+
+    /**
      * Fetch additional metadata for packages from external sources (e.g., P3M).
      * This is called separately from getPackages() to allow the UI to display
      * the basic package list quickly while metadata loads in the background.

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -21,6 +21,31 @@ import { searchPyPI, searchPyPIVersions } from './pypiSearch';
 import { IPackageManager, MessageEmitter, PackageSession } from './types';
 
 /**
+ * Read the pinned version out of `uv pip compile` output.
+ *
+ * uv prints one `name==version` line per resolved requirement, with comment lines
+ * starting `#`. The name it prints is normalised (lowercased, runs of `_`, `.` and
+ * `-` collapsed to `-`), so the requested name is normalised the same way before
+ * matching rather than compared literally.
+ */
+export function parseUvCompiledVersion(stdout: string, name: string): string | undefined {
+    const normalize = (value: string) => value.trim().toLowerCase().replace(/[-_.]+/g, '-');
+    const wanted = normalize(name);
+    for (const line of stdout.split('\n')) {
+        const trimmed = line.trim();
+        if (trimmed === '' || trimmed.startsWith('#')) {
+            continue;
+        }
+        // Stop at the first of the extras, markers or trailing comment uv can append.
+        const match = /^([^=<>!~;[\s]+)==([^\s;#]+)/.exec(trimmed);
+        if (match && normalize(match[1]) === wanted) {
+            return match[2];
+        }
+    }
+    return undefined;
+}
+
+/**
  * uv Package Manager
  *
  * Provides package management functionality for Python sessions using uv.
@@ -231,6 +256,55 @@ export class UvPackageManager implements IPackageManager {
             (specs) => this._callMethod<Record<string, boolean>>('checkRequiresPython', token, specs),
             token,
         );
+    }
+
+    /**
+     * Resolve the version uv would install for a package, by asking uv.
+     *
+     * `uv pip compile` resolves a requirement and prints the pin it settled on.
+     * Because uv answers, the result honours the configured index, the
+     * interpreter's own compatibility rules and uv's policy on prereleases, all of
+     * which uv evaluates with `pep440_rs`. None of it is re-derived here.
+     *
+     * `--no-deps` keeps the answer to the one package asked about, so an unrelated
+     * conflict elsewhere in the environment cannot make the lookup fail. The name
+     * goes in on stdin, which is why the requirement reads `-`: a file argument
+     * would make uv annotate the output with the file's path.
+     *
+     * uv exits non-zero when it cannot resolve the name, so an unknown package
+     * resolves to undefined.
+     *
+     * @param name Package name
+     * @param token Optional cancellation token
+     */
+    async resolveInstallVersion(name: string, token?: vscode.CancellationToken): Promise<string | undefined> {
+        if (token?.isCancellationRequested) {
+            throw new vscode.CancellationError();
+        }
+
+        await this._ensureUv();
+
+        const processServiceFactory = this._serviceContainer.get<IProcessServiceFactory>(IProcessServiceFactory);
+        const processService = await processServiceFactory.create();
+        const proxyEnv = this._getProxyEnv();
+        try {
+            const result = await processService.exec(
+                'uv',
+                ['pip', 'compile', '-', '--no-deps', '--no-header', '--color', 'never', '--python', this._pythonPath],
+                {
+                    extraVariables: proxyEnv,
+                    stdinStr: name,
+                    token,
+                },
+            );
+            return parseUvCompiledVersion(result.stdout, name);
+        } catch (e) {
+            if (e instanceof vscode.CancellationError) {
+                throw e;
+            }
+            // A non-zero exit means uv found nothing to install.
+            return undefined;
+        }
     }
 
     // =========================================================================

--- a/extensions/positron-python/src/test/positron/condaPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/condaPackageManager.unit.test.ts
@@ -13,7 +13,12 @@ import * as vscode from 'vscode';
 import { ITerminalService, ITerminalServiceFactory } from '../../client/common/terminal/types';
 import { IComponentAdapter, ICondaService } from '../../client/interpreter/contracts';
 import { IServiceContainer } from '../../client/ioc/types';
-import { CondaPackageManager } from '../../client/positron/packages/condaPackageManager';
+import { IProcessService, IProcessServiceFactory } from '../../client/common/process/types';
+import {
+    CondaPackageManager,
+    parseCondaLinkedVersion,
+    parseCondaListedVersion,
+} from '../../client/positron/packages/condaPackageManager';
 import { MessageEmitter, PackageSession } from '../../client/positron/packages/types';
 import { mock } from './utils';
 
@@ -249,5 +254,140 @@ suite('Conda Package Manager', () => {
                 /Could not determine conda environment path/,
             );
         });
+    });
+});
+
+suite('parseCondaLinkedVersion', () => {
+    test('reads the version conda said it would link', () => {
+        const json = JSON.stringify({
+            actions: { LINK: [{ name: 'python', version: '3.12.8' }, { name: 'numpy', version: '2.2.1' }] },
+            success: true,
+        });
+
+        assert.strictEqual(parseCondaLinkedVersion(json, 'numpy'), '2.2.1');
+    });
+
+    test('matches the requested name however it is spelled', () => {
+        const json = JSON.stringify({ actions: { LINK: [{ name: 'ruamel-yaml', version: '0.18.6' }] } });
+
+        assert.strictEqual(parseCondaLinkedVersion(json, 'ruamel.yaml'), '0.18.6');
+    });
+
+    // Conda says this when the environment already has the package at the newest
+    // version. It is not an error, so the caller decides what to do next.
+    test('returns undefined when conda reports nothing to do', () => {
+        const json = JSON.stringify({ message: 'All requested packages already installed.', success: true });
+
+        assert.strictEqual(parseCondaLinkedVersion(json, 'numpy'), undefined);
+    });
+
+    test('returns undefined rather than throwing on unusable output', () => {
+        assert.strictEqual(parseCondaLinkedVersion('not json at all', 'numpy'), undefined);
+        assert.strictEqual(parseCondaLinkedVersion('{"actions": {"LINK": "nope"}}', 'numpy'), undefined);
+        assert.strictEqual(parseCondaLinkedVersion('{}', 'numpy'), undefined);
+    });
+});
+
+suite('parseCondaListedVersion', () => {
+    test('reads a package version out of the environment listing', () => {
+        const json = JSON.stringify([
+            { name: 'numpy', version: '2.2.1' },
+            { name: 'pandas', version: '2.2.3' },
+        ]);
+
+        assert.strictEqual(parseCondaListedVersion(json, 'pandas'), '2.2.3');
+    });
+
+    test('returns undefined when the package is not installed', () => {
+        assert.strictEqual(parseCondaListedVersion('[]', 'numpy'), undefined);
+        assert.strictEqual(parseCondaListedVersion('not json at all', 'numpy'), undefined);
+    });
+});
+
+suite('Conda Package Manager resolveInstallVersion', () => {
+    let condaPackageManager: CondaPackageManager;
+    let execStub: sinon.SinonStub;
+
+    const pythonPath = '/path/to/conda/envs/myenv/bin/python';
+
+    setup(() => {
+        execStub = sinon.stub();
+
+        const serviceContainer = mock<IServiceContainer>({
+            get: <T>(serviceIdentifier: interfaces.ServiceIdentifier<T>) => {
+                switch (serviceIdentifier) {
+                    case ICondaService:
+                        return mock<ICondaService>({
+                            isCondaAvailable: () => Promise.resolve(true),
+                            getCondaFile: () => Promise.resolve('/path/to/conda'),
+                        }) as T;
+                    case IComponentAdapter:
+                        return mock<IComponentAdapter>({
+                            getCondaEnvironment: () =>
+                                Promise.resolve({ name: 'myenv', path: '/path/to/conda/envs/myenv' }),
+                        }) as T;
+                    case IProcessServiceFactory:
+                        return mock<IProcessServiceFactory>({
+                            create: () => Promise.resolve(mock<IProcessService>({ exec: execStub })),
+                        }) as T;
+                    default:
+                        return undefined as T;
+                }
+            },
+        });
+
+        condaPackageManager = new CondaPackageManager(
+            pythonPath,
+            mock<MessageEmitter>({ fire: () => {} }),
+            serviceContainer,
+            mock<PackageSession>({ callMethod: () => Promise.resolve([]) }),
+        );
+    });
+
+    teardown(() => {
+        sinon.restore();
+    });
+
+    // The reason this asks the solver rather than reading `conda search`: search
+    // results are ordered by upload time, so a rebuild of an older version
+    // published later would come out on top of the newer one.
+    test('asks the solver what it would link, not conda search', async () => {
+        execStub.resolves({
+            stdout: JSON.stringify({ actions: { LINK: [{ name: 'numpy', version: '2.2.1' }] } }),
+            stderr: '',
+        });
+
+        const version = await condaPackageManager.resolveInstallVersion('numpy');
+
+        assert.strictEqual(version, '2.2.1');
+        const [, args] = execStub.firstCall.args;
+        assert.deepStrictEqual(args, ['install', '--dry-run', '--json', 'numpy']);
+    });
+
+    test('falls back to the installed version when conda has nothing to link', async () => {
+        execStub
+            .onFirstCall()
+            .resolves({ stdout: JSON.stringify({ message: 'All requested packages already installed.' }), stderr: '' })
+            .onSecondCall()
+            .resolves({ stdout: JSON.stringify([{ name: 'numpy', version: '2.2.1' }]), stderr: '' });
+
+        const version = await condaPackageManager.resolveInstallVersion('numpy');
+
+        assert.strictEqual(version, '2.2.1');
+        assert.deepStrictEqual(execStub.secondCall.args[1], ['list', 'numpy', '--json']);
+    });
+
+    test('resolves undefined when conda cannot solve for the package', async () => {
+        execStub.rejects(new Error('PackagesNotFoundError'));
+
+        assert.strictEqual(await condaPackageManager.resolveInstallVersion('asdasdadfasdf'), undefined);
+    });
+
+    test('rejects before running conda when the token is already canceled', async () => {
+        const source = new vscode.CancellationTokenSource();
+        source.cancel();
+
+        await assert.rejects(() => condaPackageManager.resolveInstallVersion('numpy', source.token));
+        assert.strictEqual(execStub.called, false);
     });
 });

--- a/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/pipPackageManager.unit.test.ts
@@ -17,7 +17,7 @@ import { ITerminalServiceFactory } from '../../client/common/terminal/types';
 import { IFileSystem } from '../../client/common/platform/types';
 import { IWorkspaceService } from '../../client/common/application/types';
 import { IServiceContainer } from '../../client/ioc/types';
-import { PipPackageManager } from '../../client/positron/packages/pipPackageManager';
+import { parsePipIndexVersion, PipPackageManager } from '../../client/positron/packages/pipPackageManager';
 import { PackageSession } from '../../client/positron/packages/types';
 
 interface MessageEmitter {
@@ -298,5 +298,116 @@ suite('PipPackageManager update Tests', () => {
                 expect(fileSystem.createTemporaryFile.called).to.equal(true);
             });
         });
+    });
+});
+
+suite('parsePipIndexVersion', () => {
+    test('reads the version pip leads with', () => {
+        const stdout = [
+            'requests (2.32.5)',
+            'Available versions: 2.32.5, 2.32.4, 2.31.0',
+        ].join('\n');
+
+        expect(parsePipIndexVersion(stdout)).to.equal('2.32.5');
+    });
+
+    // pip adds these two lines only when the package is already installed. LATEST
+    // repeats the first line, so the first line stays the one thing to read.
+    test('ignores the INSTALLED and LATEST lines pip adds for an installed package', () => {
+        const stdout = [
+            'pip (26.0.1)',
+            'Available versions: 26.0.1, 26.0, 25.3',
+            '  INSTALLED: 21.2.4',
+            '  LATEST:    26.0.1',
+        ].join('\n');
+
+        expect(parsePipIndexVersion(stdout)).to.equal('26.0.1');
+    });
+
+    test('returns undefined for output with no version in it', () => {
+        expect(parsePipIndexVersion('')).to.equal(undefined);
+        expect(parsePipIndexVersion('ERROR: No matching distribution found for asdasdadfasdf\n')).to.equal(undefined);
+    });
+});
+
+suite('PipPackageManager resolveInstallVersion', () => {
+    let manager: PipPackageManager;
+    let pythonService: { isModuleInstalled: sinon.SinonStub; execModule: sinon.SinonStub };
+    let originalGetConfiguration: typeof vscode.workspace.getConfiguration;
+
+    setup(() => {
+        pythonService = {
+            isModuleInstalled: sinon.stub().resolves(true),
+            execModule: sinon.stub(),
+        };
+
+        originalGetConfiguration = vscode.workspace.getConfiguration;
+        vscode.workspace.getConfiguration = (_section?: string) =>
+            ({ get: (_key: string, defaultValue?: unknown) => defaultValue } as any);
+
+        const serviceContainer = { get: sinon.stub() } as any;
+        (serviceContainer.get as sinon.SinonStub)
+            .withArgs(IPythonExecutionFactory)
+            .returns({ create: sinon.stub().resolves(pythonService) });
+
+        manager = new PipPackageManager(
+            '/path/to/python',
+            { fire: sinon.stub() },
+            serviceContainer,
+            { metadata: { sessionId: 'test' }, callMethod: sinon.stub().resolves([]) },
+        );
+    });
+
+    teardown(() => {
+        sinon.restore();
+        vscode.workspace.getConfiguration = originalGetConfiguration;
+    });
+
+    test('asks pip which version it would install', async () => {
+        pythonService.execModule
+            .withArgs('pip', sinon.match.array.startsWith(['index', 'versions', 'requests']))
+            .resolves({ stdout: 'requests (2.32.5)\nAvailable versions: 2.32.5, 2.31.0\n', stderr: '' });
+
+        const version = await manager.resolveInstallVersion('requests');
+
+        expect(version).to.equal('2.32.5');
+    });
+
+    test('resolves undefined when pip finds nothing to install', async () => {
+        pythonService.execModule
+            .withArgs('pip', sinon.match.array.startsWith(['index', 'versions']))
+            .rejects(new Error('ERROR: No matching distribution found for asdasdadfasdf'));
+
+        expect(await manager.resolveInstallVersion('asdasdadfasdf')).to.equal(undefined);
+    });
+
+    test('propagates cancellation rather than reporting no version', async () => {
+        pythonService.execModule
+            .withArgs('pip', sinon.match.array.startsWith(['index', 'versions']))
+            .rejects(new vscode.CancellationError());
+
+        let thrown: unknown;
+        try {
+            await manager.resolveInstallVersion('requests');
+        } catch (e) {
+            thrown = e;
+        }
+
+        expect(thrown).to.be.instanceOf(vscode.CancellationError);
+    });
+
+    test('rejects before running pip when the token is already canceled', async () => {
+        const source = new vscode.CancellationTokenSource();
+        source.cancel();
+
+        let thrown: unknown;
+        try {
+            await manager.resolveInstallVersion('requests', source.token);
+        } catch (e) {
+            thrown = e;
+        }
+
+        expect(thrown).to.be.instanceOf(vscode.CancellationError);
+        expect(pythonService.execModule.called).to.equal(false);
     });
 });

--- a/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
@@ -17,7 +17,7 @@ import { IFileSystem } from '../../client/common/platform/types';
 import { IProcessServiceFactory } from '../../client/common/process/types';
 import { ITerminalServiceFactory } from '../../client/common/terminal/types';
 import { IServiceContainer } from '../../client/ioc/types';
-import { UvPackageManager } from '../../client/positron/packages/uvPackageManager';
+import { parseUvCompiledVersion, UvPackageManager } from '../../client/positron/packages/uvPackageManager';
 import { PackageSession } from '../../client/positron/packages/types';
 
 /**
@@ -545,5 +545,113 @@ version = "0.1.0"`);
             expect(uvBin).to.equal('uv');
             expect(args).to.include.members(['add', '--active', '--python', '/path/to/python', 'cowsay==6.1']);
         });
+    });
+});
+
+suite('parseUvCompiledVersion', () => {
+    test('reads the pin uv settled on', () => {
+        expect(parseUvCompiledVersion('requests==2.32.5\n', 'requests')).to.equal('2.32.5');
+    });
+
+    test('skips the comment lines uv writes', () => {
+        const stdout = ['# via -r requirements.in', 'requests==2.32.5', '    # via nothing'].join('\n');
+
+        expect(parseUvCompiledVersion(stdout, 'requests')).to.equal('2.32.5');
+    });
+
+    // uv prints the normalised name, so a requested name spelled with underscores,
+    // dots or capitals still has to match.
+    test('matches the requested name however it is spelled', () => {
+        expect(parseUvCompiledVersion('ruamel-yaml==0.18.6\n', 'ruamel.yaml')).to.equal('0.18.6');
+        expect(parseUvCompiledVersion('zope-interface==7.2\n', 'zope_interface')).to.equal('7.2');
+        expect(parseUvCompiledVersion('flask==3.1.0\n', 'Flask')).to.equal('3.1.0');
+    });
+
+    test('ignores a pin for some other package', () => {
+        expect(parseUvCompiledVersion('urllib3==2.6.3\n', 'requests')).to.equal(undefined);
+    });
+
+    test('returns undefined for empty output', () => {
+        expect(parseUvCompiledVersion('', 'requests')).to.equal(undefined);
+    });
+});
+
+suite('UvPackageManager resolveInstallVersion', () => {
+    let manager: UvPackageManager;
+    let processService: { exec: sinon.SinonStub };
+    let originalGetConfiguration: typeof vscode.workspace.getConfiguration;
+
+    setup(() => {
+        processService = { exec: sinon.stub() };
+
+        // Assign rather than stub: vscode.workspace is a ts-mockito instance here,
+        // and _getProxyEnv reads the http.proxy setting off it.
+        originalGetConfiguration = vscode.workspace.getConfiguration;
+        vscode.workspace.getConfiguration = (_section?: string) =>
+            ({ get: (_key: string, defaultValue?: unknown) => defaultValue } as any);
+
+        const serviceContainer = { get: sinon.stub() } as any;
+        (serviceContainer.get as sinon.SinonStub)
+            .withArgs(IProcessServiceFactory)
+            .returns({ create: sinon.stub().resolves(processService) });
+
+        manager = new UvPackageManager(
+            '/path/to/python',
+            { fire: sinon.stub() },
+            serviceContainer,
+            { metadata: { sessionId: 'test' }, callMethod: sinon.stub().resolves([]) } as unknown as PackageSession,
+        );
+        sinon.stub(manager, 'isUvAvailable').resolves(true);
+    });
+
+    teardown(() => {
+        sinon.restore();
+        vscode.workspace.getConfiguration = originalGetConfiguration;
+    });
+
+    test('asks uv which version it would install, feeding the name in on stdin', async () => {
+        processService.exec.resolves({ stdout: 'requests==2.32.5\n', stderr: '' });
+
+        const version = await manager.resolveInstallVersion('requests');
+
+        expect(version).to.equal('2.32.5');
+        const [uvBin, args, options] = processService.exec.firstCall.args;
+        expect(uvBin).to.equal('uv');
+        expect(args).to.include.members(['pip', 'compile', '-', '--no-deps', '--python', '/path/to/python']);
+        expect(options.stdinStr).to.equal('requests');
+    });
+
+    test('resolves undefined when uv cannot resolve the name', async () => {
+        processService.exec.rejects(new Error('No solution found when resolving dependencies'));
+
+        expect(await manager.resolveInstallVersion('asdasdadfasdf')).to.equal(undefined);
+    });
+
+    test('propagates cancellation rather than reporting no version', async () => {
+        processService.exec.rejects(new vscode.CancellationError());
+
+        let thrown: unknown;
+        try {
+            await manager.resolveInstallVersion('requests');
+        } catch (e) {
+            thrown = e;
+        }
+
+        expect(thrown).to.be.instanceOf(vscode.CancellationError);
+    });
+
+    test('rejects before running uv when the token is already canceled', async () => {
+        const source = new vscode.CancellationTokenSource();
+        source.cancel();
+
+        let thrown: unknown;
+        try {
+            await manager.resolveInstallVersion('requests', source.token);
+        } catch (e) {
+            thrown = e;
+        }
+
+        expect(thrown).to.be.instanceOf(vscode.CancellationError);
+        expect(processService.exec.called).to.equal(false);
     });
 });

--- a/extensions/positron-r/src/packages.ts
+++ b/extensions/positron-r/src/packages.ts
@@ -345,6 +345,22 @@ export class RPackageManager {
 		return result ?? [];
 	}
 
+	/**
+	 * Resolve the version this session would install for a package.
+	 *
+	 * `pkg_search_versions` reads the version out of `available.packages()`, which
+	 * is the one version the configured repositories offer, snapshot pins
+	 * included. That is what `pak::pkg_install(name)` would install, so it is
+	 * returned as-is. No versions are compared here.
+	 *
+	 * @param name Package name
+	 * @param token Optional cancellation token
+	 */
+	async resolveInstallVersion(name: string, token?: vscode.CancellationToken): Promise<string | undefined> {
+		const versions = await this.searchPackageVersions(name, token);
+		return versions.at(0);
+	}
+
 	// =========================================================================
 	// Private helper methods
 	// =========================================================================

--- a/extensions/positron-r/src/test/packages.unit.test.ts
+++ b/extensions/positron-r/src/test/packages.unit.test.ts
@@ -209,3 +209,69 @@ suite('RPackageManager renv detection', () => {
 		);
 	});
 });
+
+suite('RPackageManager resolveInstallVersion', () => {
+	let sandbox: Sinon.SinonSandbox;
+	let session: FakeRSession;
+	let manager: RPackageManager;
+	/** Arguments of each callMethod call, in order. */
+	let calls: unknown[][];
+
+	setup(() => {
+		sandbox = Sinon.createSandbox();
+		session = new FakeRSession();
+		calls = [];
+		manager = new RPackageManager(session as unknown as RSession);
+	});
+
+	teardown(() => {
+		sandbox.restore();
+	});
+
+	/** Makes the session answer `pkg_search_versions` with the given value. */
+	function answerWith(value: string[] | null): void {
+		(session as unknown as { callMethod: unknown }).callMethod = async (method: string, ...args: unknown[]) => {
+			calls.push([method, ...args]);
+			return value;
+		};
+	}
+
+	// available.packages() reports one version per package, and it is the version
+	// pak would install, so it is returned as-is with nothing compared.
+	test('returns the single version the configured repositories offer', async () => {
+		answerWith(['1.1.4']);
+
+		assert.strictEqual(await manager.resolveInstallVersion('dplyr'), '1.1.4');
+		assert.deepStrictEqual(calls[0], ['pkg_search_versions', 'dplyr']);
+	});
+
+	test('returns undefined for a package the repositories do not have', async () => {
+		answerWith([]);
+
+		assert.strictEqual(await manager.resolveInstallVersion('nope'), undefined);
+	});
+
+	test('treats a null answer as no version', async () => {
+		answerWith(null);
+
+		assert.strictEqual(await manager.resolveInstallVersion('nope'), undefined);
+	});
+
+	// The name goes into R code elsewhere in this class, so every path that takes a
+	// name has to validate it, not just the ones that existed first.
+	test('rejects an invalid package name before calling the session', async () => {
+		answerWith(['1.1.4']);
+
+		await assert.rejects(() => manager.resolveInstallVersion('dplyr; system("rm -rf /")'), /Invalid R package name/);
+		assert.strictEqual(calls.length, 0);
+	});
+
+	test('rejects when the token is already canceled', async () => {
+		answerWith(['1.1.4']);
+		const source = new vscode.CancellationTokenSource();
+		source.cancel();
+
+		await assert.rejects(() => manager.resolveInstallVersion('dplyr', source.token));
+		assert.strictEqual(calls.length, 0);
+	});
+});

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1387,6 +1387,30 @@ declare module 'positron' {
 		searchPackageVersions(name: string, token?: vscode.CancellationToken): Thenable<string[]>;
 
 		/**
+		 * Resolve the version this session would install for a package right now.
+		 *
+		 * Implementations ask the tool that does the installing rather than
+		 * comparing version strings themselves, so the answer honours whatever the
+		 * session is configured with: its repositories, the interpreter's own
+		 * version rules, and the tool's policy on prereleases.
+		 *
+		 * The answer applies to installing the package on its own. An update can
+		 * still land on an older version when the tool has to satisfy other
+		 * installed packages at the same time.
+		 *
+		 * Omit this method if the runtime cannot answer; callers then ask for an
+		 * explicit version instead.
+		 *
+		 * @param name Package name
+		 * @param token Optional cancellation token
+		 * @returns The version to install, or undefined if the package has none
+		 */
+		resolveInstallVersion?(
+			name: string,
+			token?: vscode.CancellationToken,
+		): Thenable<string | undefined>;
+
+		/**
 		 * Fetch additional metadata for packages from external sources (e.g., P3M).
 		 * This is called separately from getPackages() to allow the UI to display
 		 * the basic package list quickly while metadata loads in the background.

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -158,6 +158,10 @@ class ExtHostLanguageRuntimePackageManagerAdapter implements ILanguageRuntimePac
 		return this._proxy.$searchPackageVersions(this._handle, name, token);
 	}
 
+	resolveInstallVersion(name: string, token: CancellationToken): Promise<string | undefined> {
+		return this._proxy.$resolveInstallVersion(this._handle, name, token);
+	}
+
 	async getPackageMetadata(
 		packageNames: string[],
 		token: CancellationToken,

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -165,6 +165,7 @@ export interface ExtHostLanguageRuntimeShape {
 	$updateAllPackages(handle: number, token: CancellationToken): Promise<void>;
 	$searchPackages(handle: number, query: string, token: CancellationToken): Promise<LanguageRuntimePackage[]>;
 	$searchPackageVersions(handle: number, name: string, token: CancellationToken): Promise<string[]>;
+	$resolveInstallVersion(handle: number, name: string, token: CancellationToken): Promise<string | undefined>;
 	$getPackageMetadata(handle: number, packageNames: string[], token: CancellationToken): Promise<Record<string, Partial<LanguageRuntimePackage>> | undefined>;
 	$listMissingPackages(handle: number, target: RuntimeMissingPackagesTarget, token: CancellationToken): Promise<RuntimeMissingPackage[]>;
 	$getMissingPackageProbe(handle: number, error: RuntimeConsoleError, token: CancellationToken): Promise<string | undefined>;

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -891,6 +891,18 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		return packageManager.searchPackageVersions(name, token);
 	}
 
+	async $resolveInstallVersion(handle: number, name: string, token: CancellationToken): Promise<string | undefined> {
+		const packageManager = this.getPackageManagerOrThrow(handle, 'resolve install version');
+		// Throw rather than return undefined when the method is missing. The main
+		// thread reaches this package manager through an adapter that defines every
+		// method, so a caller on that side cannot tell an unsupported runtime from a
+		// package with no available version -- undefined already means the latter.
+		if (!packageManager.resolveInstallVersion) {
+			throw new Error('Cannot resolve the version to install: this session cannot look up the newest version of a package. Ask for an exact version instead.');
+		}
+		return packageManager.resolveInstallVersion(name, token);
+	}
+
 	async $getPackageMetadata(
 		handle: number,
 		packageNames: string[],

--- a/src/vs/workbench/api/test/common/positron/extHostLanguageRuntime.vitest.ts
+++ b/src/vs/workbench/api/test/common/positron/extHostLanguageRuntime.vitest.ts
@@ -6,6 +6,7 @@
 /// <reference types="vitest/globals" />
 
 import type * as positron from 'positron';
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { Emitter } from '../../../../../base/common/event.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { mock } from '../../../../../base/test/common/mock.js';
@@ -427,6 +428,57 @@ describe('ExtHostLanguageRuntime', () => {
 
 			expect(init.capabilities).toEqual({ listMissingPackages: true, getMissingPackageProbe: true });
 			await runtime.$disposeLanguageRuntime(init.handle);
+		});
+	});
+
+	describe('$resolveInstallVersion', () => {
+		/**
+		 * A session whose package manager may or may not implement the optional
+		 * `resolveInstallVersion`, so both branches can be driven from a test.
+		 */
+		function sessionWithPackageManager(
+			packageManager: Partial<positron.LanguageRuntimePackageManager>
+		): TestSession {
+			return new class extends TestSession {
+				override getPackageManager(): positron.LanguageRuntimePackageManager {
+					return packageManager as positron.LanguageRuntimePackageManager;
+				}
+			};
+		}
+
+		async function attach(session: TestSession): Promise<number> {
+			runtime.registerLanguageRuntimeManager(extension, 'r', new TestManager(session));
+			const init = await runtime.$createLanguageRuntimeSession(runtimeMetadata, sessionMetadata, 'test');
+			return init.handle;
+		}
+
+		it('forwards to a package manager that implements it', async () => {
+			const resolveInstallVersion = vi.fn().mockResolvedValue('2.32.5');
+			const handle = await attach(sessionWithPackageManager({ resolveInstallVersion }));
+
+			const version = await runtime.$resolveInstallVersion(handle, 'requests', CancellationToken.None);
+
+			expect(version).toBe('2.32.5');
+			expect(resolveInstallVersion).toHaveBeenCalledWith('requests', CancellationToken.None);
+		});
+
+		it('passes undefined through as "this package has no version"', async () => {
+			const handle = await attach(sessionWithPackageManager({
+				resolveInstallVersion: vi.fn().mockResolvedValue(undefined),
+			}));
+
+			await expect(runtime.$resolveInstallVersion(handle, 'nope', CancellationToken.None))
+				.resolves.toBeUndefined();
+		});
+
+		// Throwing is what keeps "this runtime cannot answer" apart from "this
+		// package has no version". The main thread reaches the package manager
+		// through an adapter that defines every method, so it cannot check.
+		it('throws when the package manager does not implement it', async () => {
+			const handle = await attach(sessionWithPackageManager({}));
+
+			await expect(runtime.$resolveInstallVersion(handle, 'requests', CancellationToken.None))
+				.rejects.toThrow(/cannot look up the newest version/);
 		});
 	});
 });

--- a/src/vs/workbench/contrib/positronPackages/browser/interfaces/positronPackagesService.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/interfaces/positronPackagesService.ts
@@ -113,5 +113,14 @@ export interface IPositronPackagesService {
 	 */
 	searchPackageVersions(name: string, token?: CancellationToken): Promise<string[]>;
 
+	/**
+	 * Ask the active session which version it would install for a package right
+	 * now. Resolves undefined when the package has no version available, and
+	 * rejects when the session cannot answer the question at all.
+	 * @param name Package name
+	 * @param token Optional cancellation token
+	 */
+	resolveInstallVersion(name: string, token?: CancellationToken): Promise<string | undefined>;
+
 	getInstances(): IPositronPackagesInstance[];
 }

--- a/src/vs/workbench/contrib/positronPackages/browser/packageVersions.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/packageVersions.ts
@@ -9,10 +9,13 @@ import * as semver from '../../../../base/common/semver/semver.js';
  * Sort version strings in descending order (newest first).
  * Uses semver comparison when possible, falls back to string comparison.
  *
- * This drives the version quick-pick, where the user picks from the whole list,
- * so its ordering is deliberately left as-is. `newestAvailableVersion` does not
- * use it: choosing a version automatically needs the more precise comparison
- * below, because `semver.coerce` truncates anything past three segments.
+ * This only orders the version quick-pick, where the user reads the whole list
+ * and picks from it. Nothing here decides which version to install: that answer
+ * comes from the session, through `resolveInstallVersion`, because only the tool
+ * doing the installing knows its own rules about version numbers.
+ *
+ * `semver.coerce` truncates anything past three segments, so versions that
+ * differ only after that point can land in either order.
  */
 export function sortVersionsDescending(versions: string[]): string[] {
 	return [...versions].sort((a, b) => {
@@ -26,92 +29,4 @@ export function sortVersionsDescending(versions: string[]): string[] {
 		// Fall back to simple string comparison
 		return a < b ? 1 : a > b ? -1 : 0;
 	});
-}
-
-/**
- * Prerelease and development suffixes, as PEP 440 and semver spell them:
- * `2.0.0rc1`, `1.0a2`, `2.0.0-rc.1`, `1.0.0.dev1`, `3.0.0alpha1`.
- *
- * A trailing digit group is required, which is what keeps three things that only
- * look similar out: conda's letter-suffixed builds (`1.1.1c`), R's patch levels
- * (`1.0-3`), and PEP 440 post-releases (`1.0.post1`, which is *newer* than
- * `1.0`, not a prerelease).
- */
-const PRERELEASE_SUFFIX = /[-_.]?(?:a|b|c|rc|alpha|beta|pre|preview|dev)[-_.]?\d+$/i;
-
-/**
- * Whether a version string names a prerelease.
- *
- * The string is tested directly as well as through semver, because semver alone
- * is not enough: `semver.valid` rejects two-component versions like `1.0a2` and
- * `2.0b1`, and `semver.coerce` then drops the suffix, so they would read as the
- * stable `1.0.0` and `2.0.0`.
- */
-function isPrerelease(version: string): boolean {
-	const trimmed = version.trim();
-	if (PRERELEASE_SUFFIX.test(trimmed)) {
-		return true;
-	}
-	const parsed = semver.valid(trimmed, true) || semver.coerce(trimmed);
-	return parsed ? !!semver.prerelease(parsed, true) : false;
-}
-
-/**
- * Split a version into the parts that decide which of two versions is newer: a
- * PEP 440 epoch, and the numeric groups that follow it.
- *
- * Every numeric group is kept, however many there are, so four-segment versions
- * (`1.2.3.4`) and R patch levels (`1.0-3`) compare on their real values rather
- * than being truncated to three segments. Digits inside a suffix count too,
- * which is what orders `1.0.post1` above `1.0` and `1.0.0rc2` above `1.0.0rc1`.
- */
-function releaseKey(version: string): { epoch: number; segments: number[] } {
-	const trimmed = version.trim();
-	const epochSeparator = trimmed.indexOf('!');
-	const epoch = epochSeparator === -1 ? 0 : Number(trimmed.slice(0, epochSeparator)) || 0;
-	const release = epochSeparator === -1 ? trimmed : trimmed.slice(epochSeparator + 1);
-	const segments = (release.match(/\d+/g) ?? []).map(Number);
-	return { epoch, segments };
-}
-
-/**
- * Compare two versions, newest first. A higher epoch always wins; otherwise the
- * numeric groups are compared in order, treating a missing group as zero so
- * `1.2` and `1.2.0` are equal. Versions with no digits at all fall back to
- * string comparison.
- */
-function compareVersionsDescending(a: string, b: string): number {
-	const aKey = releaseKey(a);
-	const bKey = releaseKey(b);
-	if (aKey.epoch !== bKey.epoch) {
-		return bKey.epoch - aKey.epoch;
-	}
-	const length = Math.max(aKey.segments.length, bKey.segments.length);
-	for (let i = 0; i < length; i++) {
-		const aSegment = aKey.segments[i] ?? 0;
-		const bSegment = bKey.segments[i] ?? 0;
-		if (aSegment !== bSegment) {
-			return bSegment - aSegment;
-		}
-	}
-	return a < b ? 1 : a > b ? -1 : 0;
-}
-
-/**
- * Pick the version to use when the caller asked for the newest available one.
- *
- * Prefers the newest stable release over a newer prerelease, matching what the
- * package managers install by default: with versions 1.8, 1.9 and 2.0.0rc1,
- * `pip install <name>` installs 1.9, not the release candidate.
- *
- * Backends disagree on ordering -- R returns a single version, PyPI returns
- * ascending order and does not filter prereleases, conda returns newest-first --
- * so the list is sorted here rather than trusted.
- *
- * Falls back to the newest of everything when a package has published only
- * prereleases, so a caller always gets a version if one exists.
- */
-export function newestAvailableVersion(versions: string[]): string | undefined {
-	const sorted = [...versions].sort(compareVersionsDescending);
-	return sorted.find(version => !isPrerelease(version)) ?? sorted.at(0);
 }

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
@@ -33,7 +33,6 @@ import { IPositronPackagesService } from './interfaces/positronPackagesService.j
 import { PACKAGE_METADATA_CACHE_ENABLED_SETTING, PACKAGE_METADATA_CACHE_MAX_AGE_HOURS_DEFAULT, PACKAGE_METADATA_CACHE_MAX_AGE_HOURS_SETTING } from './packageMetadataCache.js';
 import { PACKAGES_CAN_RUN_ACTION, PACKAGES_HAS_SELECTION, PACKAGES_VIEW_VISIBLE, POSITRON_PACKAGES_ITEM_SIZE, POSITRON_PACKAGES_VIEW_ID } from './positronPackagesContextKeys.js';
 import { installPackage, uninstallPackage, updatePackage } from './positronPackagesQuickPick.js';
-import { newestAvailableVersion } from './packageVersions.js';
 import { PositronPackagesService } from './positronPackagesService.js';
 import { PositronPackagesView } from './positronPackagesView.js';
 
@@ -196,14 +195,19 @@ type VersionResolution =
 
 /**
  * Resolves the version for a direct (non-quick-pick) install or update. A
- * concrete version passes through untouched; `'latest'` is resolved against the
- * repositories configured for the session, so the backend always receives an
- * explicit target.
+ * concrete version passes through untouched; `'latest'` is turned into a real
+ * version number by the session, so the backend always receives an explicit
+ * target.
  *
  * Resolving is required, not merely tidier. pip and uv-outside-a-project reject
  * a missing version on update outright, and on install they write a bare package
  * name into a requirements file with no `--upgrade`, so an already-installed
  * package resolves as satisfied and never moves to the newest version.
+ *
+ * Which version wins is decided by the session's own package manager, which asks
+ * the tool that does the installing. Nothing is compared here: the repositories
+ * the session is configured with and the tool's own rules about version numbers
+ * and prereleases all belong to that tool, not to the frontend.
  *
  * Failures are notified here so both commands report them identically.
  */
@@ -223,25 +227,26 @@ async function resolveTargetVersion(
 		message: nls.localize('positronPackages.versionLookupCanceled', "Finding the latest version of '{0}' was canceled.", name)
 	};
 
-	let versions: string[];
+	let latest: string | undefined;
 	try {
-		versions = await service.searchPackageVersions(name, token);
+		latest = await service.resolveInstallVersion(name, token);
 	} catch (e) {
 		if (isCancellationError(e) || token.isCancellationRequested) {
 			return canceled;
 		}
+		// Also the path for a session that cannot resolve a version at all, which
+		// rejects with a message telling the caller to ask for an exact version.
 		const message = cleanErrorMessage(e);
 		notifications.error(message);
 		return { ok: false, message };
 	}
 
-	// A canceled lookup resolves to an empty list rather than throwing, so check
-	// the token before reporting the package as missing from the repositories.
+	// Check the token before reporting the package as missing: a canceled lookup
+	// can resolve to undefined rather than throwing.
 	if (token.isCancellationRequested) {
 		return canceled;
 	}
 
-	const latest = newestAvailableVersion(versions);
 	if (!latest) {
 		const message = nls.localize('positronPackages.noVersionsAvailable', "No available versions of '{0}' were found. Check the package name and the repositories configured for this session.", name);
 		notifications.error(message);

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesInstance.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesInstance.ts
@@ -33,6 +33,13 @@ export interface IPositronPackagesInstance {
 	searchPackageVersions(name: string, token?: CancellationToken): Promise<string[]>;
 
 	/**
+	 * Ask the session which version it would install for a package right now.
+	 * Resolves undefined when the package has no version available, and rejects
+	 * when the session cannot answer the question at all.
+	 */
+	resolveInstallVersion(name: string, token?: CancellationToken): Promise<string | undefined>;
+
+	/**
 	 * Fetch detail metadata for a single package from the session's package
 	 * manager. Resolves undefined when the manager doesn't support it.
 	 */
@@ -480,6 +487,15 @@ export class PositronPackagesInstance extends Disposable implements IPositronPac
 			return [];
 		}
 		return results;
+	}
+
+	async resolveInstallVersion(name: string, token?: CancellationToken): Promise<string | undefined> {
+		const packageManager = this.getPackageManagerOrThrow();
+		// No presence check and no swallowing of cancellation here, unlike the search
+		// methods above. Both would be reported as "this package has no version
+		// available", which is a different problem with a different fix. The runtime
+		// side rejects when it cannot resolve at all, and the caller checks the token.
+		return packageManager.resolveInstallVersion?.(name, token);
 	}
 
 	async getPackageDetail(name: string, token?: CancellationToken): Promise<Partial<ILanguageRuntimePackage> | undefined> {

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesService.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesService.ts
@@ -284,6 +284,15 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 		throw new Error('No active session found.');
 	}
 
+	async resolveInstallVersion(name: string, token?: CancellationToken): Promise<string | undefined> {
+		const instance = this._activeInstance;
+		if (instance) {
+			return await instance.resolveInstallVersion(name, token);
+		}
+
+		throw new Error('No active session found.');
+	}
+
 	setActivePositronPackagesSession(session: ILanguageRuntimeSession): void {
 		const instance = this._instancesBySessionId.get(session.sessionId);
 		if (instance) {

--- a/src/vs/workbench/contrib/positronPackages/test/browser/installAndUpdatePackage.vitest.ts
+++ b/src/vs/workbench/contrib/positronPackages/test/browser/installAndUpdatePackage.vitest.ts
@@ -37,6 +37,7 @@ describe('packages install and update commands', () => {
 	let installPackages: ReturnType<typeof vi.fn<IPositronPackagesService['installPackages']>>;
 	let updatePackages: ReturnType<typeof vi.fn<IPositronPackagesService['updatePackages']>>;
 	let searchPackageVersions: ReturnType<typeof vi.fn<IPositronPackagesService['searchPackageVersions']>>;
+	let resolveInstallVersion: ReturnType<typeof vi.fn<IPositronPackagesService['resolveInstallVersion']>>;
 	let error: ReturnType<typeof vi.fn<INotificationService['error']>>;
 	let prompt: ReturnType<typeof vi.fn<INotificationService['prompt']>>;
 
@@ -50,6 +51,7 @@ describe('packages install and update commands', () => {
 			installPackages,
 			updatePackages,
 			searchPackageVersions,
+			resolveInstallVersion,
 			searchPackages: vi.fn().mockResolvedValue([]),
 			refreshPackages: vi.fn().mockResolvedValue([]),
 		}));
@@ -86,6 +88,9 @@ describe('packages install and update commands', () => {
 		installPackages = vi.fn<IPositronPackagesService['installPackages']>().mockResolvedValue(undefined);
 		updatePackages = vi.fn<IPositronPackagesService['updatePackages']>().mockResolvedValue(undefined);
 		searchPackageVersions = vi.fn<IPositronPackagesService['searchPackageVersions']>().mockResolvedValue(['1.8', '1.9', '2.0.0rc1']);
+		// The session decides which version 'latest' means, so these tests stub the
+		// answer rather than a list to pick from.
+		resolveInstallVersion = vi.fn<IPositronPackagesService['resolveInstallVersion']>().mockResolvedValue('1.9');
 		error = vi.fn<INotificationService['error']>();
 		prompt = vi.fn<INotificationService['prompt']>();
 		installPackageMock.mockReset().mockResolvedValue(undefined);
@@ -109,14 +114,15 @@ describe('packages install and update commands', () => {
 
 			expect(result).toEqual({ installed: true, name: 'dplyr', version: '1.1.4' });
 			expect(installPackages).toHaveBeenCalledWith([{ name: 'dplyr', version: '1.1.4' }], expect.anything());
-			expect(searchPackageVersions).not.toHaveBeenCalled();
+			expect(resolveInstallVersion).not.toHaveBeenCalled();
 			expect(installPackageMock).not.toHaveBeenCalled();
 		});
 
-		it('resolves \'latest\' to the newest stable version', async () => {
+		it('asks the session what \'latest\' means and installs that version', async () => {
 			const result = await runInstall('dplyr', 'latest');
 
 			expect(result).toEqual({ installed: true, name: 'dplyr', version: '1.9' });
+			expect(resolveInstallVersion).toHaveBeenCalledWith('dplyr', expect.anything());
 			expect(installPackages).toHaveBeenCalledWith([{ name: 'dplyr', version: '1.9' }], expect.anything());
 		});
 
@@ -146,7 +152,7 @@ describe('packages install and update commands', () => {
 		});
 
 		it('reports when no versions are available for \'latest\'', async () => {
-			searchPackageVersions.mockResolvedValue([]);
+			resolveInstallVersion.mockResolvedValue(undefined);
 
 			const result = await runInstall('nope', 'latest');
 
@@ -160,7 +166,7 @@ describe('packages install and update commands', () => {
 		});
 
 		it('reports a failed version lookup for \'latest\'', async () => {
-			searchPackageVersions.mockRejectedValue(new Error('network down'));
+			resolveInstallVersion.mockRejectedValue(new Error('network down'));
 
 			const result = await runInstall('dplyr', 'latest');
 
@@ -169,8 +175,24 @@ describe('packages install and update commands', () => {
 			expect(error).toHaveBeenCalledWith('network down');
 		});
 
+		// A session with no way to answer rejects rather than resolving undefined, so
+		// the user is told to name a version instead of being told the package does
+		// not exist.
+		it('reports a session that cannot resolve \'latest\' as its own failure', async () => {
+			resolveInstallVersion.mockRejectedValue(new Error('this session cannot look up the newest version of a package'));
+
+			const result = await runInstall('dplyr', 'latest');
+
+			expect(result).toEqual({
+				installed: false,
+				name: 'dplyr',
+				message: 'this session cannot look up the newest version of a package',
+			});
+			expect(installPackages).not.toHaveBeenCalled();
+		});
+
 		it('reports a canceled version lookup without an error notification', async () => {
-			searchPackageVersions.mockRejectedValue(new CancellationError());
+			resolveInstallVersion.mockRejectedValue(new CancellationError());
 
 			const result = await runInstall('dplyr', 'latest');
 
@@ -284,7 +306,7 @@ describe('packages install and update commands', () => {
 
 			expect(result).toEqual({ updated: true, name: 'dplyr', version: '1.1.4' });
 			expect(updatePackages).toHaveBeenCalledWith([{ name: 'dplyr', version: '1.1.4' }], expect.anything());
-			expect(searchPackageVersions).not.toHaveBeenCalled();
+			expect(resolveInstallVersion).not.toHaveBeenCalled();
 			expect(updatePackageMock).not.toHaveBeenCalled();
 		});
 
@@ -294,6 +316,7 @@ describe('packages install and update commands', () => {
 			const result = await runUpdate('dplyr', 'latest');
 
 			expect(result).toEqual({ updated: true, name: 'dplyr', version: '1.9' });
+			expect(resolveInstallVersion).toHaveBeenCalledWith('dplyr', expect.anything());
 			expect(updatePackages).toHaveBeenCalledWith([{ name: 'dplyr', version: '1.9' }], expect.anything());
 		});
 
@@ -320,7 +343,7 @@ describe('packages install and update commands', () => {
 		});
 
 		it('reports when no versions are available for \'latest\'', async () => {
-			searchPackageVersions.mockResolvedValue([]);
+			resolveInstallVersion.mockResolvedValue(undefined);
 
 			const result = await runUpdate('nope', 'latest');
 
@@ -333,7 +356,7 @@ describe('packages install and update commands', () => {
 		});
 
 		it('reports a failed version lookup for \'latest\'', async () => {
-			searchPackageVersions.mockRejectedValue(new Error('network down'));
+			resolveInstallVersion.mockRejectedValue(new Error('network down'));
 
 			const result = await runUpdate('dplyr', 'latest');
 

--- a/src/vs/workbench/contrib/positronPackages/test/browser/packageVersions.vitest.ts
+++ b/src/vs/workbench/contrib/positronPackages/test/browser/packageVersions.vitest.ts
@@ -5,7 +5,7 @@
 
 /// <reference types="vitest/globals" />
 
-import { newestAvailableVersion, sortVersionsDescending } from '../../browser/packageVersions.js';
+import { sortVersionsDescending } from '../../browser/packageVersions.js';
 
 describe('sortVersionsDescending', () => {
 	it('sorts newest first, using semver rather than string ordering', () => {
@@ -47,119 +47,5 @@ describe('sortVersionsDescending', () => {
 			rPatchLevel: ['1.0-3', '1.0-10'],
 			pypiPostRelease: ['1.0', '1.0.post1'],
 		});
-	});
-});
-
-describe('newestAvailableVersion', () => {
-	it('prefers the newest stable release over a newer prerelease', () => {
-		// What `pip install <name>` would resolve to for this version list.
-		expect(newestAvailableVersion(['1.8', '1.9', '2.0.0rc1'])).toBe('1.9');
-	});
-
-	it('picks the newest version when all of them are stable', () => {
-		expect(newestAvailableVersion(['1.1.2', '1.1.10', '1.1.4'])).toBe('1.1.10');
-	});
-
-	it('takes PyPI ascending order into account', () => {
-		expect(newestAvailableVersion(['1.26.4', '2.0.0', '2.1.3'])).toBe('2.1.3');
-	});
-
-	it('falls back to the newest prerelease when a package has only prereleases', () => {
-		expect(newestAvailableVersion(['1.0.0rc1', '1.0.0rc2'])).toBe('1.0.0rc2');
-	});
-
-	// semver alone does not catch these: `semver.valid` rejects two-component
-	// versions and `semver.coerce` then drops the suffix, so `1.0a2` would read
-	// as the stable `1.0.0` and be installed over the older stable release.
-	it('skips every prerelease spelling in favor of an older stable release', () => {
-		expect({
-			threeComponentRc: newestAvailableVersion(['1.9', '2.0.0rc1']),
-			threeComponentAlpha: newestAvailableVersion(['1.9.0', '2.0.0a2']),
-			threeComponentBeta: newestAvailableVersion(['1.9.0', '2.0.0b1']),
-			twoComponentAlpha: newestAvailableVersion(['0.9', '1.0a2']),
-			twoComponentBeta: newestAvailableVersion(['1.9', '2.0b1']),
-			dottedDev: newestAvailableVersion(['0.9.0', '1.0.0.dev1']),
-			runTogetherDev: newestAvailableVersion(['0.9.0', '1.0.0dev1']),
-			semverDotted: newestAvailableVersion(['1.9.0', '2.0.0-rc.1']),
-			spelledAlpha: newestAvailableVersion(['1.9.0', '3.0.0alpha1']),
-			pep440C: newestAvailableVersion(['0.9', '1.0c1']),
-		}).toEqual({
-			threeComponentRc: '1.9',
-			threeComponentAlpha: '1.9.0',
-			threeComponentBeta: '1.9.0',
-			twoComponentAlpha: '0.9',
-			twoComponentBeta: '1.9',
-			dottedDev: '0.9.0',
-			runTogetherDev: '0.9.0',
-			semverDotted: '1.9.0',
-			spelledAlpha: '1.9.0',
-			pep440C: '0.9',
-		});
-	});
-
-	// A post-release is newer than the release it follows, and R's patch level is
-	// not a prerelease at all, so neither may be skipped.
-	it('does not mistake post-releases or R patch levels for prereleases', () => {
-		expect({
-			postRelease: newestAvailableVersion(['1.0.post1']),
-			rPatchLevel: newestAvailableVersion(['1.0-3']),
-			calendarVersion: newestAvailableVersion(['2024.1.1']),
-		}).toEqual({
-			postRelease: '1.0.post1',
-			rPatchLevel: '1.0-3',
-			calendarVersion: '2024.1.1',
-		});
-	});
-
-	// conda's letter-suffixed builds have no trailing digits, so the suffix check
-	// passes them through, but semver reads `1.1.1c` as the prerelease `1.1.1-c`
-	// and it loses to plain `1.1.1`. Rare and low-stakes: the fallback still
-	// returns it when it is the only version.
-	it('prefers a plain release over a conda letter-suffixed build', () => {
-		expect({
-			alongsidePlain: newestAvailableVersion(['1.1.1', '1.1.1c']),
-			onItsOwn: newestAvailableVersion(['1.1.1c']),
-		}).toEqual({
-			alongsidePlain: '1.1.1',
-			onItsOwn: '1.1.1c',
-		});
-	});
-
-	it('returns the only version R reports', () => {
-		expect(newestAvailableVersion(['1.1.4'])).toBe('1.1.4');
-	});
-
-	it('returns undefined when no versions are available', () => {
-		expect(newestAvailableVersion([])).toBeUndefined();
-	});
-
-	// Every numeric group counts, so these do not get truncated to three
-	// segments the way semver.coerce would truncate them. The quick-pick's
-	// sortVersionsDescending still does truncate; only automatic selection uses
-	// the precise comparison.
-	it('compares every numeric group rather than the first three', () => {
-		expect({
-			fourSegment: newestAvailableVersion(['1.2.3.4', '1.2.3.5']),
-			rPatchLevel: newestAvailableVersion(['1.0-3', '1.0-10']),
-			calendarVersion: newestAvailableVersion(['2024.1.1', '2024.1.2']),
-			missingGroupIsZero: newestAvailableVersion(['1.2', '1.2.1']),
-		}).toEqual({
-			fourSegment: '1.2.3.5',
-			rPatchLevel: '1.0-10',
-			calendarVersion: '2024.1.2',
-			missingGroupIsZero: '1.2.1',
-		});
-	});
-
-	it('ranks a higher PEP 440 epoch above a larger release number', () => {
-		expect(newestAvailableVersion(['3.0', '1!2.0'])).toBe('1!2.0');
-	});
-
-	it('ranks a post-release above the release it follows', () => {
-		expect(newestAvailableVersion(['1.0', '1.0.post1'])).toBe('1.0.post1');
-	});
-
-	it('falls back to string comparison for versions with no digits', () => {
-		expect(newestAvailableVersion(['alpha', 'beta'])).toBe('beta');
 	});
 });

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -482,6 +482,25 @@ export interface ILanguageRuntimePackageManager {
 	searchPackageVersions(name: string, token?: CancellationToken): Promise<string[]>;
 
 	/**
+	 * Resolve the version this session would install for a package right now.
+	 *
+	 * The runtime asks the tool that does the installing rather than comparing
+	 * version strings, so the answer reflects the session's own repositories and
+	 * the tool's own version rules. Nothing in the frontend re-implements version
+	 * comparison, which is the same reasoning behind `ILanguageRuntimePackage.outdated`.
+	 *
+	 * Resolves to undefined when the package has no version available. Rejects when
+	 * the runtime cannot answer at all, because undefined is already taken.
+	 *
+	 * @param name Package name
+	 * @param token Optional cancellation token
+	 */
+	resolveInstallVersion?(
+		name: string,
+		token?: CancellationToken,
+	): Promise<string | undefined>;
+
+	/**
 	 * Fetch additional metadata for packages from external sources (e.g., P3M).
 	 * This is called separately from getPackages() to allow the UI to display
 	 * the basic package list quickly while metadata loads in the background.


### PR DESCRIPTION
Stacked on #15137. Addresses [Austin's review comment](https://github.com/posit-dev/positron/pull/15137#discussion_r3715444874).

### Summary

#15137 lets an agent pass `'latest'` as the version to `positronPackages.installPackage` and `positronPackages.updatePackage`. Core turned that into a real version number using its own comparator in `packageVersions.ts`.

Austin pointed out this is a repeat of something we have already fixed twice. #13696 moved the outdated flag to the R and Python kernels. #14502 added the `checkRequiresPython` kernel call so PEP 440 (Python's rules for ordering version numbers) is evaluated by `packaging` rather than by TypeScript. `ILanguageRuntimePackage.outdated` even documents that the frontend never re-implements version comparison.

So this asks the session instead. `resolveInstallVersion` is a new optional method on the package manager API: given a package name, it returns the one version that session would install. Core keeps three jobs -- call it when the caller passed `'latest'`, report failure, and hand install and update an explicit version.

Each implementation asks the tool that does the installing:

| Manager | How it answers |
|---|---|
| pip | `pip index versions <name>` |
| uv | `uv pip compile -` with the name on stdin |
| conda | `conda install --dry-run --json`, falling back to the installed version when conda reports nothing to link |
| R | the existing `pkg_search_versions` RPC, which already returns the single version `available.packages()` offers |

The practical difference is which versions are candidates at all. Under the old code the list always came from pypi.org, whatever the session was configured with, so someone on a Posit Package Manager index could be handed a version their index does not carry. Now each tool answers from its own configuration: pip reads `index-url` and friends from `pip.conf` and the environment, uv reads its own config and `UV_*` variables, conda uses its channels and their priority, and R uses whatever repositories `available.packages()` sees. Each also applies its own view of what is installable for the target interpreter, and its own default about prereleases. The two Python calls still pass the `http.proxy` setting through, as the existing calls in those files do.

`newestAvailableVersion` and its four helpers are deleted. `sortVersionsDescending` stays: it only orders the version quick pick, which Austin scoped to a later PR.

### Notes for review

**No ark change, so no submodule bump.** Ark's `pkg_search_versions` already returns exactly one version, read from `available.packages()`, which is what `pak::pkg_install` would install. The R method returns it as-is. Nothing is compared, so nothing is re-implemented.

**A runtime that cannot answer rejects rather than resolving undefined.** `undefined` already means "this package has no version available", and telling a user `numpy` does not exist when the real problem is an unsupported runtime would be worse than useless. The extension host is the only layer that can tell the two apart: the main thread reaches the package manager through an adapter that defines every method, so a presence check on the core side never fires. There is a dead check of exactly that shape already sitting at `positronPackagesInstance.ts:487` for `getPackageDetail`.

**Why the tools themselves, and not a kernel RPC.** #14502's pattern would have been a kernel call: fetch candidates from PyPI as we do today, then have `ui.py` pick the newest with the bundled `packaging`. Two things ruled that out. The candidate list would still be pypi.org-only, so it moves where the comparison happens without changing which versions get compared, which is the actual problem. And `_callMethod` calls `interruptSession` when its token is cancelled (`pipPackageManager.ts:389`), so cancelling a version lookup would interrupt whatever the user is running in the console. Running the tool also matches what these files already do: `_getOutdatedPackages` runs `pip list --outdated` and reads pip's own `latest_version`.

**Two caveats on the Python side.** `pip index versions` prints `WARNING: pip index is currently an experimental command`; it landed in pip 21.2. We read stdout and the warning goes to stderr, and a non-zero exit is treated as "no version available" -- so if that subcommand ever changes, the user sees "No available versions of X were found" rather than a crash. Misleading, but not fatal, and the fallback would be `pip install --dry-run --report`. Separately, the uv call sets no working directory, matching the other `uv pip` calls in that file, so uv discovers `uv.toml` and `[tool.uv]` relative to the extension host's cwd rather than the workspace folder. Worth a follow-up if we want project config to apply here.

**No `RuntimeSessionCapabilities` entry.** That struct exists so a context key can read capability synchronously to gate a menu. Nothing gates on version resolution; it is called on demand inside a command.

**One limitation, stated in the doc comment rather than papered over.** Install and update can legitimately resolve to different versions. pip's update path writes a full freeze with `--upgrade`, so conflicts with other installed pins can land below the newest candidate. One method answers for both. That is no better and no worse than before.

**conda could not be verified locally** (no conda on this machine), so its two parsers are written defensively and covered by unit tests against recorded output shapes. Worth a real conda environment during review.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

@:packages-pane

1. **Verify user behavior is unchanged**: in the Packages pane, install a package from the view-title menu, then update it from the row's Update button. Expected: the search and version pickers work exactly as before.
2. **Verify the agent installs**: with a Python session running, ask the assistant to "install cowsay". Expected: no picker, and the assistant reports a concrete version.
3. **Verify the agent updates**: ask the assistant to "update cowsay to the latest version". Expected: a concrete version rather than "latest". Try this on a pip environment and a uv environment.
4. **Verify R**: with an R session, ask the assistant to "install dplyr". Expected: the version your configured repository offers.
5. **Verify conda**: with a conda environment, ask the assistant to install a package, then ask it to install the same package again. The second time conda has nothing to link, and the assistant should still report the installed version rather than failing.
6. **Verify a failure is still reported as a failure**: ask the assistant to "install a package called asdasdadfasdf". Expected: nothing installed, and a message about no available versions.
7. **The case this change is for**: point pip at a custom index whose newest version of some package is older than PyPI's (`PIP_INDEX_URL`, or a Posit Package Manager snapshot), then ask the assistant to install it. Expected: the index's version. Under the old code you would have got PyPI's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

