### PR TITLE
Fix SVG outputs in Quarto inline output

### DIFF
--- a/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
@@ -18,7 +18,8 @@ import { cellToCellDtoForRestore } from '../../../contrib/positronNotebook/brows
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { encodeBase64 } from '../../../../base/common/buffer.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
-import { isImageMimeType, isSvgMimeType, isTextBasedMimeType } from '../../../contrib/positronNotebook/browser/notebookMimeUtils.js';
+import { isImageMimeType, isTextBasedMimeType } from '../../../contrib/positronNotebook/browser/notebookMimeUtils.js';
+import { isSvgMimeType } from '../../../services/positronPlots/common/imageDataUrl.js';
 import { rasterizeSvgToPng } from '../../../contrib/positronNotebook/browser/svgToPng.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { POSITRON_NOTEBOOK_ASSISTANT_AUTO_FOLLOW_KEY } from '../../../contrib/positronNotebook/common/positronNotebookConfig.js';

--- a/src/vs/workbench/contrib/positronNotebook/browser/getOutputContents.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/getOutputContents.ts
@@ -12,6 +12,7 @@ import { NotebookCellTextModel } from '../../notebook/common/model/notebookCellT
 import { ICellOutput, IOutputItemDto } from '../../notebook/common/notebookCommon.js';
 import { ParsedDataExplorerOutput, ParsedOutput, ParsedTextOutput } from './PositronNotebookCells/IPositronNotebookCell.js';
 import { parseVariablePath } from '../../../services/positronDataExplorer/common/utils.js';
+import { getImageDataUrl } from '../../../services/positronPlots/common/imageDataUrl.js';
 
 /**
  * MIME type for Positron inline data explorer
@@ -208,7 +209,7 @@ export function parseOutputData(outputItem: IOutputItemDto, metadata?: Record<st
 		const height = typeof imgObj?.['height'] === 'number' ? imgObj['height'] : undefined;
 		return {
 			type: 'image',
-			dataUrl: `data:image/png;base64,${encodeBase64(VSBuffer.wrap(data.buffer))}`,
+			dataUrl: getImageDataUrl(mime, encodeBase64(VSBuffer.wrap(data.buffer))),
 			width,
 			height,
 		};
@@ -217,7 +218,7 @@ export function parseOutputData(outputItem: IOutputItemDto, metadata?: Record<st
 	if (mime === 'image/svg+xml') {
 		return {
 			type: 'image',
-			dataUrl: `data:image/svg+xml,${encodeURIComponent(message)}`
+			dataUrl: getImageDataUrl(mime, message)
 		};
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookMimeUtils.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookMimeUtils.ts
@@ -5,10 +5,6 @@
 
 import { isSvgMimeType } from '../../../services/positronPlots/common/imageDataUrl.js';
 
-// Re-export so existing consumers keep importing the SVG check from this
-// module; the definition lives with the image data URL encode/decode helpers.
-export { isSvgMimeType };
-
 /**
  * Image MIME types that should be base64 encoded when serializing notebook outputs.
  * Excludes SVG (image/svg+xml) which is text-based XML.

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookMimeUtils.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookMimeUtils.ts
@@ -3,6 +3,12 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { isSvgMimeType } from '../../../services/positronPlots/common/imageDataUrl.js';
+
+// Re-export so existing consumers keep importing the SVG check from this
+// module; the definition lives with the image data URL encode/decode helpers.
+export { isSvgMimeType };
+
 /**
  * Image MIME types that should be base64 encoded when serializing notebook outputs.
  * Excludes SVG (image/svg+xml) which is text-based XML.
@@ -53,19 +59,6 @@ const TEXT_BASED_MIME_TYPES_SET = new Set<string>(TEXT_BASED_MIME_TYPES);
  */
 export function isImageMimeType(mimeType: string): boolean {
 	return IMAGE_MIME_TYPES_SET.has(mimeType.toLowerCase());
-}
-
-/**
- * Checks if a MIME type is SVG (image/svg+xml), ignoring MIME parameters
- * (e.g. '; charset=utf-8'). SVG is text-based XML rather than binary image
- * data, so it is classified separately from other images.
- * @param mimeType The MIME type to check.
- * @returns True if the MIME type is image/svg+xml.
- */
-export function isSvgMimeType(mimeType: string): boolean {
-	const semicolonIndex = mimeType.indexOf(';');
-	const baseMimeType = semicolonIndex >= 0 ? mimeType.substring(0, semicolonIndex) : mimeType;
-	return baseMimeType.trim().toLowerCase() === 'image/svg+xml';
 }
 
 /**

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
@@ -22,6 +22,7 @@ import { IFileService } from '../../../../platform/files/common/files.js';
 import { basename } from '../../../../base/common/resources.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { IPositronPlotsService } from '../../../services/positronPlots/common/positronPlots.js';
+import { getImageDataUrl } from '../../../services/positronPlots/common/imageDataUrl.js';
 import { getImageOutputName, openImageOutputInNewTab, saveImageOutput } from '../../positronNotebook/common/imageOutputUtils.js';
 import { IPositronPreviewService } from '../../positronPreview/browser/positronPreviewSevice.js';
 import { IQuartoDocumentModelService } from './quartoDocumentModelService.js';
@@ -746,10 +747,7 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 		for (const output of outputs) {
 			for (const item of output.items) {
 				if (item.mime.startsWith('image/')) {
-					const dataUrl = item.data.startsWith('data:')
-						? item.data
-						: `data:${item.mime};base64,${item.data}`;
-					return { type: 'image', dataUrl };
+					return { type: 'image', dataUrl: getImageDataUrl(item.mime, item.data) };
 				}
 			}
 		}

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
@@ -215,13 +215,10 @@ export function shouldExpandOnFreshOutput(isCollapsed: boolean, userCollapsedDur
 }
 
 /**
- * Build a data URL for an image output item.
+ * Creates a data URL for an image output.
  *
- * Kernels send raster images (PNG, JPEG, ...) as base64 strings but SVG as raw
- * markup, so SVG payloads are URL-encoded rather than labelled `;base64,` --
- * a base64 label over raw markup breaks Save Image, whose decoder rejects the
- * first '<' (posit-dev/positron#15277). Data that is already a data URL is
- * returned unchanged.
+ * Raster image payloads are base64-encoded, while SVG payloads contain raw
+ * markup and must be URL-encoded. Existing data URLs are returned unchanged.
  */
 export function getImageDataUrl(mime: string, data: string): string {
 	if (data.startsWith('data:')) {

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
@@ -14,7 +14,7 @@ import { localize } from '../../../../nls.js';
 import { ICellOutput, ICellOutputItem, DATA_EXPLORER_MIME_TYPE, CellExecutionState, QuartoCellErrorContext } from '../common/quartoExecutionTypes.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { formatCellDuration, getRelativeTime } from '../../positronNotebook/browser/notebookCells/cellExecutionUtils.js';
-import { isSvgMimeType } from '../../positronNotebook/browser/notebookMimeUtils.js';
+import { getImageDataUrl } from '../../../services/positronPlots/common/imageDataUrl.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { Event as VSEvent, Emitter } from '../../../../base/common/event.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -212,22 +212,6 @@ export function chooseHtmlRenderMode(html: string, hasWebviewService: boolean): 
  */
 export function shouldExpandOnFreshOutput(isCollapsed: boolean, userCollapsedDuringExecution: boolean): boolean {
 	return isCollapsed && !userCollapsedDuringExecution;
-}
-
-/**
- * Creates a data URL for an image output.
- *
- * Raster image payloads are base64-encoded, while SVG payloads contain raw
- * markup and must be URL-encoded. Existing data URLs are returned unchanged.
- */
-export function getImageDataUrl(mime: string, data: string): string {
-	if (data.startsWith('data:')) {
-		return data;
-	}
-	if (isSvgMimeType(mime)) {
-		return `data:${mime},${encodeURIComponent(data)}`;
-	}
-	return `data:${mime};base64,${data}`;
 }
 
 /**

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
@@ -14,6 +14,7 @@ import { localize } from '../../../../nls.js';
 import { ICellOutput, ICellOutputItem, DATA_EXPLORER_MIME_TYPE, CellExecutionState, QuartoCellErrorContext } from '../common/quartoExecutionTypes.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { formatCellDuration, getRelativeTime } from '../../positronNotebook/browser/notebookCells/cellExecutionUtils.js';
+import { isSvgMimeType } from '../../positronNotebook/browser/notebookMimeUtils.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { Event as VSEvent, Emitter } from '../../../../base/common/event.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -211,6 +212,25 @@ export function chooseHtmlRenderMode(html: string, hasWebviewService: boolean): 
  */
 export function shouldExpandOnFreshOutput(isCollapsed: boolean, userCollapsedDuringExecution: boolean): boolean {
 	return isCollapsed && !userCollapsedDuringExecution;
+}
+
+/**
+ * Build a data URL for an image output item.
+ *
+ * Kernels send raster images (PNG, JPEG, ...) as base64 strings but SVG as raw
+ * markup, so SVG payloads are URL-encoded rather than labelled `;base64,` --
+ * a base64 label over raw markup breaks Save Image, whose decoder rejects the
+ * first '<' (posit-dev/positron#15277). Data that is already a data URL is
+ * returned unchanged.
+ */
+export function getImageDataUrl(mime: string, data: string): string {
+	if (data.startsWith('data:')) {
+		return data;
+	}
+	if (isSvgMimeType(mime)) {
+		return `data:${mime},${encodeURIComponent(data)}`;
+	}
+	return `data:${mime};base64,${data}`;
 }
 
 /**
@@ -1873,10 +1893,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		for (const output of this._outputs) {
 			for (const item of output.items) {
 				if (item.mime.startsWith('image/')) {
-					const dataUrl = item.data.startsWith('data:')
-						? item.data
-						: `data:${item.mime};base64,${item.data}`;
-					return { type: 'plot', dataUrl };
+					return { type: 'plot', dataUrl: getImageDataUrl(item.mime, item.data) };
 				}
 			}
 		}
@@ -1971,10 +1988,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 			for (const item of output.items) {
 				if (item.mime.startsWith('image/')) {
 					// Return the first image found
-					const dataUrl = item.data.startsWith('data:')
-						? item.data
-						: `data:${item.mime};base64,${item.data}`;
-					return { type: 'image', dataUrl };
+					return { type: 'image', dataUrl: getImageDataUrl(item.mime, item.data) };
 				}
 			}
 		}
@@ -2098,10 +2112,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 						return undefined;
 					}
 					// Build the data URL
-					const dataUrl = item.data.startsWith('data:')
-						? item.data
-						: `data:${item.mime};base64,${item.data}`;
-					imageInfo = { dataUrl };
+					imageInfo = { dataUrl: getImageDataUrl(item.mime, item.data) };
 				}
 			}
 		}
@@ -2676,13 +2687,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 			}
 		});
 
-		// Check if data is already a data URL
-		if (data.startsWith('data:')) {
-			img.src = data;
-		} else {
-			// Assume base64 encoded
-			img.src = `data:${mime};base64,${data}`;
-		}
+		img.src = getImageDataUrl(mime, data);
 
 		container.appendChild(img);
 		return container;

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputViewZone.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputViewZone.vitest.ts
@@ -11,7 +11,8 @@ import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
 import { EditorOption } from '../../../../../editor/common/config/editorOptions.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { ICellOutput } from '../../common/quartoExecutionTypes.js';
-import { chooseHtmlRenderMode, isInertHtml, isWebviewOverlayShown, QuartoOutputViewZone } from '../../browser/quartoOutputViewZone.js';
+import { chooseHtmlRenderMode, getImageDataUrl, isInertHtml, isWebviewOverlayShown, QuartoOutputViewZone } from '../../browser/quartoOutputViewZone.js';
+import { decodeImageDataUrl } from '../../../../services/positronPlots/common/imageDataUrl.js';
 
 // The inline-output webview is a fixed-position overlay anchored to a
 // placeholder inside the editor view zone. It must be shown only while its view
@@ -96,6 +97,33 @@ describe('chooseHtmlRenderMode', () => {
 
 	it('falls back to the warning only when no webview service exists', () => {
 		expect(chooseHtmlRenderMode(activeHtml, false)).toBe('warning');
+	});
+});
+
+// Kernels send raster images as base64 but SVG as raw markup, so labelling an
+// SVG payload `;base64,` produces a data URL that the shared decoder rejects:
+// Save Image fails with "Unexpected base64 character" on the first '<'
+// (posit-dev/positron#15277).
+describe('getImageDataUrl', () => {
+	const svg = '<svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg>';
+
+	it('URL-encodes SVG payloads rather than labelling them base64', () => {
+		const dataUrl = getImageDataUrl('image/svg+xml', svg);
+		expect(dataUrl.startsWith('data:image/svg+xml,')).toBe(true);
+	});
+
+	it('produces an SVG data URL the shared decoder round-trips', () => {
+		const decoded = decodeImageDataUrl(getImageDataUrl('image/svg+xml', svg));
+		expect({ mimeType: decoded?.mimeType, data: decoded?.data.toString() })
+			.toEqual({ mimeType: 'image/svg+xml', data: svg });
+	});
+
+	it('labels raster payloads as base64', () => {
+		expect(getImageDataUrl('image/png', 'aGVsbG8=')).toBe('data:image/png;base64,aGVsbG8=');
+	});
+
+	it('returns a payload that is already a data URL unchanged', () => {
+		expect(getImageDataUrl('image/png', 'data:image/png;base64,aGVsbG8=')).toBe('data:image/png;base64,aGVsbG8=');
 	});
 });
 

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputViewZone.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputViewZone.vitest.ts
@@ -100,10 +100,8 @@ describe('chooseHtmlRenderMode', () => {
 	});
 });
 
-// Kernels send raster images as base64 but SVG as raw markup, so labelling an
-// SVG payload `;base64,` produces a data URL that the shared decoder rejects:
-// Save Image fails with "Unexpected base64 character" on the first '<'
-// (posit-dev/positron#15277).
+// Kernels provide raster image payloads as base64 and SVG payloads as raw
+// markup. Both formats must produce data URLs supported by the shared decoder.
 describe('getImageDataUrl', () => {
 	const svg = '<svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg>';
 

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputViewZone.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputViewZone.vitest.ts
@@ -11,8 +11,7 @@ import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
 import { EditorOption } from '../../../../../editor/common/config/editorOptions.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { ICellOutput } from '../../common/quartoExecutionTypes.js';
-import { chooseHtmlRenderMode, getImageDataUrl, isInertHtml, isWebviewOverlayShown, QuartoOutputViewZone } from '../../browser/quartoOutputViewZone.js';
-import { decodeImageDataUrl } from '../../../../services/positronPlots/common/imageDataUrl.js';
+import { chooseHtmlRenderMode, isInertHtml, isWebviewOverlayShown, QuartoOutputViewZone } from '../../browser/quartoOutputViewZone.js';
 
 // The inline-output webview is a fixed-position overlay anchored to a
 // placeholder inside the editor view zone. It must be shown only while its view
@@ -97,31 +96,6 @@ describe('chooseHtmlRenderMode', () => {
 
 	it('falls back to the warning only when no webview service exists', () => {
 		expect(chooseHtmlRenderMode(activeHtml, false)).toBe('warning');
-	});
-});
-
-// Kernels provide raster image payloads as base64 and SVG payloads as raw
-// markup. Both formats must produce data URLs supported by the shared decoder.
-describe('getImageDataUrl', () => {
-	const svg = '<svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg>';
-
-	it('URL-encodes SVG payloads rather than labelling them base64', () => {
-		const dataUrl = getImageDataUrl('image/svg+xml', svg);
-		expect(dataUrl.startsWith('data:image/svg+xml,')).toBe(true);
-	});
-
-	it('produces an SVG data URL the shared decoder round-trips', () => {
-		const decoded = decodeImageDataUrl(getImageDataUrl('image/svg+xml', svg));
-		expect({ mimeType: decoded?.mimeType, data: decoded?.data.toString() })
-			.toEqual({ mimeType: 'image/svg+xml', data: svg });
-	});
-
-	it('labels raster payloads as base64', () => {
-		expect(getImageDataUrl('image/png', 'aGVsbG8=')).toBe('data:image/png;base64,aGVsbG8=');
-	});
-
-	it('returns a payload that is already a data URL unchanged', () => {
-		expect(getImageDataUrl('image/png', 'data:image/png;base64,aGVsbG8=')).toBe('data:image/png;base64,aGVsbG8=');
 	});
 });
 

--- a/src/vs/workbench/services/positronPlots/common/imageDataUrl.ts
+++ b/src/vs/workbench/services/positronPlots/common/imageDataUrl.ts
@@ -93,6 +93,37 @@ export function decodeImageDataUrl(dataUrl: string): DecodedImageDataUrl | undef
 }
 
 /**
+ * Checks if a MIME type is SVG (image/svg+xml), ignoring MIME parameters
+ * (e.g. '; charset=utf-8'). SVG is text-based XML rather than binary image
+ * data, so it is classified separately from other images.
+ * @param mimeType The MIME type to check.
+ * @returns True if the MIME type is image/svg+xml.
+ */
+export function isSvgMimeType(mimeType: string): boolean {
+	const semicolonIndex = mimeType.indexOf(';');
+	const baseMimeType = semicolonIndex >= 0 ? mimeType.substring(0, semicolonIndex) : mimeType;
+	return baseMimeType.trim().toLowerCase() === 'image/svg+xml';
+}
+
+/**
+ * Creates a data URL for an image output.
+ *
+ * Raster image payloads are base64-encoded, while SVG payloads contain raw
+ * markup and must be URL-encoded -- a base64 label over raw markup breaks
+ * {@link decodeImageDataUrl} (posit-dev/positron#15277). Existing data URLs
+ * are returned unchanged.
+ */
+export function getImageDataUrl(mime: string, data: string): string {
+	if (data.startsWith(DATA_URL_PREFIX)) {
+		return data;
+	}
+	if (isSvgMimeType(mime)) {
+		return `data:${mime},${encodeURIComponent(data)}`;
+	}
+	return `data:${mime};base64,${data}`;
+}
+
+/**
  * Number of characters sampled from each end of a data URL by
  * {@link getImageContentId}.
  */

--- a/src/vs/workbench/services/positronPlots/test/common/imageDataUrl.vitest.ts
+++ b/src/vs/workbench/services/positronPlots/test/common/imageDataUrl.vitest.ts
@@ -6,7 +6,7 @@
 /// <reference types="vitest/globals" />
 
 import { VSBuffer, encodeBase64 } from '../../../../../base/common/buffer.js';
-import { decodeImageDataUrl, getImageContentId, getImageExtensionForMimeType, parseImageDataUrl, toBase64ImageDataUrl } from '../../common/imageDataUrl.js';
+import { decodeImageDataUrl, getImageContentId, getImageDataUrl, getImageExtensionForMimeType, parseImageDataUrl, toBase64ImageDataUrl } from '../../common/imageDataUrl.js';
 
 const pngDataUrl = `data:image/png;base64,${encodeBase64(VSBuffer.fromString('fake-png-bytes'))}`;
 const svg = '<svg><circle r="10"/></svg>';
@@ -81,6 +81,28 @@ describe('imageDataUrl', () => {
 
 		it('returns undefined for a malformed data URL', () => {
 			expect(decodeImageDataUrl('not-a-data-url')).toBeUndefined();
+		});
+	});
+
+	// Kernels provide raster image payloads as base64 and SVG payloads as raw
+	// markup. Both formats must produce data URLs supported by the decoder.
+	describe('getImageDataUrl', () => {
+		it('URL-encodes an SVG payload rather than labelling it base64', () => {
+			expect(getImageDataUrl('image/svg+xml', svg)).toBe(svgDataUrl);
+		});
+
+		it('produces an SVG data URL the decoder round-trips', () => {
+			const decoded = decodeImageDataUrl(getImageDataUrl('image/svg+xml', svg));
+			expect({ mimeType: decoded?.mimeType, data: decoded?.data.toString() })
+				.toEqual({ mimeType: 'image/svg+xml', data: svg });
+		});
+
+		it('labels a raster payload as base64', () => {
+			expect(getImageDataUrl('image/png', 'aGVsbG8=')).toBe('data:image/png;base64,aGVsbG8=');
+		});
+
+		it('returns a payload that is already a data URL unchanged', () => {
+			expect(getImageDataUrl('image/png', pngDataUrl)).toBe(pngDataUrl);
 		});
 	});
 


### PR DESCRIPTION
Fixes #15277

Quarto inline output treated every image payload as base64. However, kernels provide SVG images as raw XML, which caused SVG data URLs to be encoded incorrectly.

As a result, SVG output could fail to render inline or save with an “Unexpected base64 character” error.

This change adds a shared helper that:

- URL-encodes SVG markup.
- Continues treating raster image payloads as base64.
- Preserves payloads that are already complete data URLs.

The helper is now used consistently when rendering, saving, copying, and opening inline images in a plot tab.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed rendering, saving, copying, and opening SVG images from Quarto inline output (#15277).

### Validation Steps

@:quarto @:positron-notebooks

1. Open a `.qmd` file and enable **Quarto > Inline Output**.
2. Run the following Python chunk. Until #15276 is fixed, run it twice because the first execution may produce PNG output.

```python
from matplotlib_inline.backend_inline import set_matplotlib_formats

set_matplotlib_formats("svg")

import matplotlib.pyplot as plt

plt.plot([1, 2, 3])
plt.show()
```

3. Confirm that the SVG renders inline.
4. Use **Save Image** and confirm that the file is saved without an error.
5. Copy the image and open it in a plot tab.
