### PR TITLE
Restore paths frontmatter on vitest rule files

### DIFF
--- a/.claude/rules/vitest-rtl.md
+++ b/.claude/rules/vitest-rtl.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - src/**/*.vitest.{ts,tsx}
+  - src/vs/test/vitest/**
+---
+
 # Positron Vitest + React Testing Library
 
 For React component tests (`*.vitest.tsx` using `setupRTLRenderer()`). Read alongside [`vitest-tests.md`](vitest-tests.md) for the builder, file layout, and run commands.

--- a/.claude/rules/vitest-rtl.md
+++ b/.claude/rules/vitest-rtl.md
@@ -1,6 +1,7 @@
 ---
 paths:
   - src/**/*.vitest.{ts,tsx}
+  - vitest.config.ts
   - src/vs/test/vitest/**
 ---
 

--- a/.claude/rules/vitest-tests.md
+++ b/.claude/rules/vitest-tests.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - src/**/*.vitest.{ts,tsx}
+  - src/vs/test/vitest/**
+---
+
 # Positron Vitest Tests
 
 Vitest tests for Positron code (`*.vitest.ts` / `*.vitest.tsx` in `src/vs/`) run directly on your source files -- no build daemons, no compilation step, no waiting. Run `npx vitest <file>` for watch mode (re-runs on save) or `npx vitest run <file>` for a single pass.

--- a/.claude/rules/vitest-tests.md
+++ b/.claude/rules/vitest-tests.md
@@ -1,6 +1,7 @@
 ---
 paths:
   - src/**/*.vitest.{ts,tsx}
+  - vitest.config.ts
   - src/vs/test/vitest/**
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,14 @@ Positron has three test categories:
 	- positron-python has its own test setup -- see `extensions/positron-python/CLAUDE.md`
 - **E2E** (Playwright, full app): `npx playwright test test/e2e/tests/<test-name>.test.ts --project e2e-electron --grep '<pattern>'`
 
+## Directory Structure
+
+- `src/` - Core VS Code source with Positron modifications
+- `extensions/` - Built-in extensions including Positron-specific ones
+- `test/e2e/` - End-to-end Playwright tests
+- `positron/` - Positron-specific code and assets
+- `build/` - Build configuration and scripts
+
 ## Code Style
 
 - Use tabs for indentation in TypeScript/JavaScript, not spaces

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,14 +97,6 @@ Positron has three test categories:
 	- positron-python has its own test setup -- see `extensions/positron-python/CLAUDE.md`
 - **E2E** (Playwright, full app): `npx playwright test test/e2e/tests/<test-name>.test.ts --project e2e-electron --grep '<pattern>'`
 
-## Directory Structure
-
-- `src/` - Core VS Code source with Positron modifications
-- `extensions/` - Built-in extensions including Positron-specific ones
-- `test/e2e/` - End-to-end Playwright tests
-- `positron/` - Positron-specific code and assets
-- `build/` - Build configuration and scripts
-
 ## Code Style
 
 - Use tabs for indentation in TypeScript/JavaScript, not spaces


### PR DESCRIPTION
Restores YAML `paths:` frontmatter on the Vitest and React Testing Library agent rule files. This scopes the rules to relevant Vitest files and configuration instead of loading them for every task.

Claude's `/doctor` skill recommended this change, and I think it makes sense.

PR #13033 originally created `vitest-tests.md` with `paths:` and they were later removed in #13165. Happy to close this PR if that was intentional!

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

This docs-only change affects only Claude Code agent context loading. No e2e tests apply.