### PR TITLE
Pin starlette<1.4.0 for e2e Python dependencies

### DIFF
--- a/test/e2e/test-files/requirements.txt
+++ b/test/e2e/test-files/requirements.txt
@@ -23,6 +23,12 @@ leafmap
 matplotlib
 streamlit-aggrid
 streamlit
+# starlette 1.4.0 made `thread_minimum_size` a required keyword-only argument on
+# GZipResponder. Streamlit's _MediaAwareGZipResponder subclass does not pass it, so
+# every gzip-encoded response 500s and the Streamlit app tests fail on the platforms
+# that resolve Python deps fresh from PyPI (macOS, Windows). Remove this pin once
+# Streamlit releases the fix: https://github.com/streamlit/streamlit/pull/16344
+starlette<1.4.0
 click
 bokeh==3.8.2
 altair


### PR DESCRIPTION
Unblocks the Streamlit `python-apps` e2e failures that started 2026-08-05 on macOS and Windows.

### Summary

starlette 1.4.0 (published 2026-08-05 09:36 UTC) made `thread_minimum_size` a required keyword-only argument on `GZipResponder`:

| | `GZipResponder.__init__` |
|---|---|
| starlette 1.3.1 | `(self, app, minimum_size, compresslevel=9)` |
| starlette 1.4.0 | `(self, app, minimum_size, *, compresslevel, thread_minimum_size)` |

Streamlit's `_MediaAwareGZipResponder` subclass calls it without that argument, so every gzip-encoded response 500s -- including the `/_stcore/health` endpoint the Streamlit app tests poll:

```
TypeError: GZipResponder.__init__() missing 1 required keyword-only argument: 'thread_minimum_size'
```

Only macOS and Windows were affected because they `pip install -r test/e2e/test-files/requirements.txt` fresh from PyPI on every run and that file is unpinned. Ubuntu e2e (including the web/chromium project) runs inside `ghcr.io/posit-dev/positron-ubuntu24` with a pre-baked venv, so its Python deps are frozen by the image tag -- the Streamlit tests do run there, they just weren't exposed to the new wheel.

The pin has to be on starlette rather than streamlit: no released Streamlit version passes the argument (1.59.x, 1.60.0, 1.61.0 and current `develop` all share the call site). CI resolves streamlit 1.59.1 anyway, since `streamlit-aggrid` caps it -- the streamlit 1.61.0 release the night before was not involved.

`starlette<1.4.0` resolves to 1.3.1 and satisfies every starlette consumer in the file (streamlit `<2,>=0.46.0`, gradio `<2.0,>=1.0.1`, fastapi `>=0.46.0`). `uv pip compile` on the full requirements file resolves cleanly with everything else at latest.

Upstream fix: https://github.com/streamlit/streamlit/pull/16344. The pin carries an inline comment pointing at it so it can be dropped once Streamlit releases.

Follow-up to remove the pin is tracked in https://github.com/posit-dev/positron/issues/15357.

### Verification

Reproduced and confirmed locally against a real Streamlit server. Note that bare `curl` returns 200 because it does not send `Accept-Encoding: gzip`, which bypasses the middleware entirely:

| streamlit + starlette | gzip `/_stcore/health` |
|---|---|
| 1.61.0 + 1.4.0 | 500, with the exact CI traceback |
| 1.61.0 + 1.3.1 | 200 |
| 1.59.1 + 1.3.1 (what CI resolves) | 200, no tracebacks |

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A (test infrastructure only)

### Validation Steps

@:apps @:win @:web

The Streamlit cases in `test/e2e/tests/apps/python-apps.test.ts` ("Verify Basic Streamlit App" and "Verify Viewer interrupt button for Streamlit app") should pass on Windows and web. macOS is covered by the merge/daily lane rather than the PR lane. There are no product code changes -- the pin only affects the Python environment the e2e suite installs.


