### PR TITLE
Fix R dirty-document breakpoint e2e flake: wait for the debugger pause before editing

### DIFF
--- a/test/e2e/tests/debug/r-debug.test.ts
+++ b/test/e2e/tests/debug/r-debug.test.ts
@@ -297,7 +297,16 @@ test.describe('R Breakpoints', {
 		await page.keyboard.press(process.platform === 'darwin' ? 'Meta+Enter' : 'Control+Enter');
 		await debug.expectBreakpointVerified(0, 30000);
 
+		// Sourcing the file also runs its trailing lapply(), which calls the
+		// breakpointed function, so the debugger pauses shortly after the
+		// breakpoint verifies. Wait for that pause to land before editing: the
+		// stopped-frame reveal selects line 3, and would otherwise steal the
+		// cursor mid-typing and overwrite the function body.
+		await debug.expectBrowserModeFrame(1);
+		await debug.expectCurrentLineIndicatorVisible();
+
 		// Edit file to make it dirty
+		await app.workbench.editors.selectTab('breakpoint_test.r');
 		await page.keyboard.press('Escape'); // Clear any selection first
 		await page.keyboard.press(process.platform === 'darwin' ? 'Meta+End' : 'Control+End');
 		await page.keyboard.press('Enter');


### PR DESCRIPTION
Fixes a Windows e2e flake in `R Breakpoints > R - Verify breakpoints in dirty (unsaved) documents` (1.6% on `main` over the last 14 days, win/electron; also seen flaky once on macOS, clean 128/128 on ubuntu).

### Summary

The test sources `breakpoint_test.r` with select-all + Ctrl+Enter. That fixture's trailing `lapply()` calls the breakpointed function, so the R debugger pauses a moment after the breakpoint verifies. The test only waited for the gutter dot to turn solid and then immediately started typing a comment.

When the DAP stop landed mid-typing, the stopped-frame reveal selected line 3 and stole the cursor: part of the comment overwrote the function body (`result <- a * b` became `    test comment`), the document stopped parsing as R, the second Ctrl+Enter sent an invalid fragment (`Syntax error: unexpected symbol`), the file was never re-sourced, and the breakpoint never re-verified -- a 30s `toBeVisible` timeout on the second `expectBreakpointVerified`. The split point moved between retries (attempt 0 lost `# `, attempt 1 lost `# t`), which is the signature of the race rather than locator drift.

The fix waits for the pause to land before editing -- the `Browse[1]>` prompt plus the stack-frame indicator -- and selects the editor tab so the typing target is deterministic. This is the same guard the sibling `R - Verify editing file while at breakpoint invalidates breakpoints` test in this file already has. No timeout increases and no arbitrary waits.

Test-only change; no product code is touched.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:debug @:ark @:win

The Windows lane is where this failed, so the `win` tag matters here more than the usual electron run. The test carries no web tag, so it runs on electron and Windows only.

Locally:

```bash
npx playwright test test/e2e/tests/debug/r-debug.test.ts --project e2e-electron --grep 'R Breakpoints'
```

Both dirty-document tests should pass, and the second `expectBreakpointVerified` should no longer be preceded by a corrupted editor buffer. Since this is a race, a single green run is not proof -- the real signal is the failure rate on `main` after merge.


### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- Test bug. Sourcing breakpoint_test.r also runs its trailing lapply(), which calls the breakpointed function, so the R debugger pauses shortly after the breakpoint verifies. The test only waited for the gutter dot to turn solid before typing, so the stopped-frame reveal could land mid-typing, select line 3, and steal the cursor -- corrupting the document into unparseable R so the second Ctrl+Enter never re-sourced the file and the breakpoint never re-verified.</summary>

- **Test:** [R Breakpoints > R - Verify breakpoints in dirty (unsaved) documents](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=R%20Breakpoints%20%3E%20R%20-%20Verify%20breakpoints%20in%20dirty%20%28unsaved%29%20documents%7C%7C%7Ctest%2Fe2e%2Ftests%2Fdebug%2Fr-debug.test.ts)
- **Targeted failure:** expect(locator('.monaco-editor .codicon-debug-breakpoint').first()).toBeVisible() 30s timeout at test/e2e/tests/debug/r-debug.test.ts:315 (the second expectBreakpointVerified, after 'Re-execute WITHOUT saving')
- **Signal:** Failure screenshot (attempt0-frame1): editor line 3 = '    test comment', line 12 = '#', status bar 'Ln 3, Col 21 (12 selected)', call stack 'Paused on step' at multiply_values() breakpoint_test.r:3, console 'Error: Syntax error: unexpected symbol' then 'Browse[1]>'. Timeline: the identical locator passed at t=1502893 earlier in the same run (rules out locator drift). Attempt0 lost '# ', attempt1 lost '# t' -- the split point moved between attempts, which is the signature of a race. Env breakdown: win 1/127 failed, mac 1/8 flaky, ubuntu 128/128 clean.
- **Frequency:** 2/127 runs (1.6%) on main, win/electron
- **Hypothesis:** Waiting for the stopped-state UI (the debug stack-frame indicator, .codicon-debug-stackframe) before the Escape/Ctrl+End/Enter/type sequence closes the window in which the stack-frame reveal can steal the cursor. The typed comment then always lands at end-of-document, the second Ctrl+Enter sources valid R, and the breakpoint re-verifies.

</details>
