### PR TITLE
e2e: stop runtime picker enumeration hanging on single-row entries

### DIFF
--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -1367,39 +1367,33 @@ export class SessionQuickPick {
 			// Page through the list to load all entries (handles virtualized lists)
 			let stable = false;
 			while (!stable) {
-				const entries = this.code.driver.currentPage.locator('.quick-input-list-entry');
-				const entryCount = await entries.count();
+				// Read every rendered entry in a single DOM pass rather than with per-element
+				// locators. quickInputList.ts always renders both `.quick-input-list-row`
+				// elements and the separator, but the *inner* `.label-name
+				// .monaco-highlighted-label` only exists when that row has content. Not every
+				// entry is a runtime -- extensions contribute action items with a label and no
+				// detail (e.g. "$(add) Create Python Environment"), whose second row is empty.
+				// A chained locator read on those waits for an element that never appears,
+				// which surfaced as an opaque "waiting on the predicate" timeout in the caller.
+				// Reading in-page yields '' for a missing node instead of blocking, and keeps
+				// this cheap enough to poll.
+				const entryData = await this.code.driver.currentPage
+					.locator('.quick-input-list-entry')
+					.evaluateAll(entries => entries.map(entry => {
+						const rows = entry.querySelectorAll('.quick-input-list-row');
+						const labelText = (root: Element | undefined) =>
+							root?.querySelector('.label-name .monaco-highlighted-label')?.textContent ?? '';
+
+						return {
+							name: labelText(rows[0]),
+							path: labelText(rows[1]),
+							category: entry.querySelector('.quick-input-list-separator')?.textContent ?? ''
+						};
+					}));
 
 				let newEntriesFound = false;
-				for (let i = 0; i < entryCount; i++) {
-					const entry = entries.nth(i);
-
-					// Not every entry in this quick pick is a runtime: extensions contribute
-					// action items (e.g. "$(add) Create Python Environment") that have a label
-					// but no detail, so they render a single row. Reading a second row from
-					// those blocks until the enclosing timeout instead of returning null, which
-					// surfaces as an opaque "waiting on the predicate" failure in the caller.
-					// Skip anything that isn't a two-row label/path entry.
-					const rows = entry.locator('.quick-input-list-row');
-					if (await rows.count() < 2) {
-						continue;
-					}
-
-					// Get the runtime name from the first row
-					const nameElement = rows.nth(0).locator('.label-name .monaco-highlighted-label');
-					const name = await nameElement.textContent();
-
-					// Get the path from the second row
-					const pathElement = rows.nth(1).locator('.label-name .monaco-highlighted-label');
-					const path = await pathElement.textContent();
-
-					// Get the category from the separator, which is only present on the entry
-					// that starts a group
-					const separatorElement = entry.locator('.quick-input-list-separator');
-					const category = (await separatorElement.count()) > 0
-						? await separatorElement.textContent()
-						: '';
-
+				for (const { name, path, category } of entryData) {
+					// Entries without a path are not runtimes (contributed action items)
 					if (name && path) {
 						const key = `${name}||${path}`;
 						if (!seen.has(key)) {
@@ -1407,7 +1401,7 @@ export class SessionQuickPick {
 							runtimes.push({
 								name: name.trim(),
 								path: path.trim(),
-								category: category?.trim() || ''
+								category: category.trim()
 							});
 							newEntriesFound = true;
 						}

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -1374,17 +1374,31 @@ export class SessionQuickPick {
 				for (let i = 0; i < entryCount; i++) {
 					const entry = entries.nth(i);
 
+					// Not every entry in this quick pick is a runtime: extensions contribute
+					// action items (e.g. "$(add) Create Python Environment") that have a label
+					// but no detail, so they render a single row. Reading a second row from
+					// those blocks until the enclosing timeout instead of returning null, which
+					// surfaces as an opaque "waiting on the predicate" failure in the caller.
+					// Skip anything that isn't a two-row label/path entry.
+					const rows = entry.locator('.quick-input-list-row');
+					if (await rows.count() < 2) {
+						continue;
+					}
+
 					// Get the runtime name from the first row
-					const nameElement = entry.locator('.quick-input-list-row').nth(0).locator('.label-name .monaco-highlighted-label');
+					const nameElement = rows.nth(0).locator('.label-name .monaco-highlighted-label');
 					const name = await nameElement.textContent();
 
 					// Get the path from the second row
-					const pathElement = entry.locator('.quick-input-list-row').nth(1).locator('.label-name .monaco-highlighted-label');
+					const pathElement = rows.nth(1).locator('.label-name .monaco-highlighted-label');
 					const path = await pathElement.textContent();
 
-					// Get the category from the separator
+					// Get the category from the separator, which is only present on the entry
+					// that starts a group
 					const separatorElement = entry.locator('.quick-input-list-separator');
-					const category = await separatorElement.textContent();
+					const category = (await separatorElement.count()) > 0
+						? await separatorElement.textContent()
+						: '';
 
 					if (name && path) {
 						const key = `${name}||${path}`;


### PR DESCRIPTION
Fixes the two `Environment Modules` hard failures in the Workbench e2e lane ([daily run 30986925837](https://github.com/posit-dev/positron-builds/actions/runs/30986925837/job/92280812923)).

### Summary

`getAllAvailableRuntimes()` read a path from the second `.quick-input-list-row` of every entry in the Start New Console Session quick pick, via the chained locator `.quick-input-list-row >> nth=1 >> .label-name .monaco-highlighted-label`.

Extensions contribute action items to that picker that have a label but no detail -- `$(add) Create Python Environment`, added in #15198. [`quickInputList.ts` `renderTemplate()`](https://github.com/posit-dev/positron/blob/main/src/vs/platform/quickinput/browser/quickInputList.ts#L366-L368) always creates both rows and the separator, so the row itself is present; what's missing is the inner `.label-name .monaco-highlighted-label`, because row2's `IconLabel` has no content to render. Playwright's `textContent()` on that chain waits for an element that never appears, so enumeration never returned.

Both environment-modules tests failed this way, reported as `Timeout 30000ms exceeded while waiting on the predicate` pointing at the `toPass` assertion -- which never actually got to run. The trace shows the read stalling on entry 6 for 28s until the `toPass` budget expired, and the failure screenshot shows `R 4.4.1 (Module: R 4.4.1 Module)` sitting in the picker the whole time. The R test would have passed.

This reads all rendered entries in a single `evaluateAll` instead of with per-element locators. A missing node yields `''` rather than blocking, and the existing `name && path` filter drops the contributed action items as intended. It also cuts three round trips per entry per pass, which matters because the caller polls this helper inside `toPass`.

Why it looked intermittent: the contributed item is gated on `hasNonSystemPython`, evaluated when the picker opens, so it isn't present when Python discovery hasn't settled.

Note that the daily run's auto-analysis artifact attributed these two failures to "infrastructure issue (Workbench landing page missing `test-files` project link)". That's not the cause -- the Workbench server was reachable and sign-in succeeded on every attempt.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:workbench

The two `Environment Modules` tests in `test/e2e/tests/workbench/environment-modules/environment-modules.test.ts` are the only callers of this helper, and both carry the workbench tag. They should pass rather than timing out after 30s.

Verified locally by replaying both loop bodies against a page built from `renderTemplate()`'s actual output -- six runtime entries plus one action entry whose second row is present but has an empty `IconLabel`:

```
row-count guard (first attempt): FAILED after 3049ms -- TimeoutError: locator.textContent: Timeout 3000ms exceeded.
batched in-page read (this PR):  OK in 17ms -- 6 runtimes, R Module found: true, action leaked: false
```

The first commit on this branch guarded on `.quick-input-list-row` count, which never fires since both rows are always rendered; it was a no-op and [CI reproduced the original failure](https://github.com/posit-dev/positron/actions/runs/31021780055/job/92366926334?pr=15359). The run above is the corrected check against the real DOM shape.

One thing this PR does not settle: whether `Python 3.12.10 Module` is actually created. Module environments look session-scoped -- the R test's own module shows up in its session, but the Python one from the prior worker doesn't -- so if the Python test still fails it should now fail with a legible "runtime not found" rather than an opaque predicate timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)