### PR TITLE
Fix matplotlib tests on IPython 9.16

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/matplotlib_backend/compat.py
+++ b/extensions/positron-python/python_files/posit/positron/matplotlib_backend/compat.py
@@ -38,10 +38,13 @@ def register_with_legacy_ipython() -> None:
     # `get_backend_registry`, so a module-level import would be circular.
     from .backend import Backend
 
-    # The registry-based lister arrived in the same release that stopped reading the
-    # static table, so its presence tells the two resolution schemes apart. Touching
-    # `pt.backends` on newer IPython would also trip its deprecation warning.
-    if hasattr(pt, "_list_matplotlib_backends_and_gui_loops"):
+    # `backends` is a real module global exactly on the versions that read it: 8.24
+    # renamed it to `_deprecated_backends` behind a `__getattr__` shim when it moved to
+    # the registry, and 9.16 removed the shim. Looking it up in the module's own
+    # namespace therefore tells the two resolution schemes apart *and* confirms there's
+    # a table to write to.
+    legacy_table = vars(pt).get("backends")
+    if legacy_table is None:
         return
     for backend in Backend:
-        pt.backends.setdefault(backend.short_name, backend.full_name)
+        legacy_table.setdefault(backend.short_name, backend.full_name)

--- a/extensions/positron-python/python_files/posit/positron/tests/test_matplotlib_backend/test_enable_matplotlib.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_matplotlib_backend/test_enable_matplotlib.py
@@ -359,15 +359,24 @@ def test_explicit_short_name_without_registry_resolution(
     assert _state(shell, positron_backend) == _positron_active(positron_backend)
 
 
-def test_register_with_legacy_ipython_adds_short_names(monkeypatch: pytest.MonkeyPatch):
-    """On IPython < 8.24, the short names are added to the static backend table for `-l`."""
+def _simulate_legacy_backend_table(monkeypatch: pytest.MonkeyPatch, table: dict[str, str]) -> None:
+    """
+    Make the installed `pylabtools` look like IPython < 8.24's, whose `-l` reads `backends`.
+
+    Assigns into the module's `__dict__` rather than with `monkeypatch.setattr`, so the
+    simulation works on the versions that no longer define `backends` as a real global:
+    8.24 renamed it to `_deprecated_backends` behind a `__getattr__` shim, and 9.16
+    removed the shim, leaving nothing for `setattr` to replace.
+    """
     from IPython.core import pylabtools as pt
 
-    # Simulate IPython < 8.24: no registry-based lister, `-l` reads `pt.backends`.
-    if hasattr(pt, "_list_matplotlib_backends_and_gui_loops"):
-        monkeypatch.delattr(pt, "_list_matplotlib_backends_and_gui_loops")
+    monkeypatch.setitem(pt.__dict__, "backends", table)
+
+
+def test_register_with_legacy_ipython_adds_short_names(monkeypatch: pytest.MonkeyPatch):
+    """On IPython < 8.24, the short names are added to the static backend table for `-l`."""
     legacy_table = {"inline": INLINE_BACKEND_NAME}
-    monkeypatch.setattr(pt, "backends", legacy_table)
+    _simulate_legacy_backend_table(monkeypatch, legacy_table)
 
     compat.register_with_legacy_ipython()
 
@@ -396,10 +405,7 @@ def test_legacy_ipython_lists_short_names_without_a_switch(
     """
     from IPython.core import pylabtools as pt
 
-    # Simulate IPython < 8.24: no registry-based lister, `-l` reads `pt.backends`.
-    if hasattr(pt, "_list_matplotlib_backends_and_gui_loops"):
-        monkeypatch.delattr(pt, "_list_matplotlib_backends_and_gui_loops")
-    monkeypatch.setattr(pt, "backends", {"inline": INLINE_BACKEND_NAME})
+    _simulate_legacy_backend_table(monkeypatch, {"inline": INLINE_BACKEND_NAME})
 
     # The shell was constructed before the simulation was in place, so re-run the hook
     # that registers the names. Notably not `enable_matplotlib`: nothing here switches


### PR DESCRIPTION
Fixes the nightly python CI runs. IPython 9.16 came out recently, which removed the module-level `backends` alias. Behavior is unchanged on every IPython version Positron supports, but the check no longer depends on a private symbol and can no longer raise.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:plots

CI should be green and I'll kick off a nightly run: https://github.com/posit-dev/positron/actions/runs/31037121156

You can confirm the backends still work end to end in a Python console:

1. Run `%matplotlib -l` and verify `positron-console` and `positron-notebook` are listed.
2. Run `import matplotlib.pyplot as plt; plt.plot([0, 1], [0, 1])` and verify the plot renders in the Plots pane.
