### PR TITLE
e2e: anchor Workbench dashboard project locators on the table row

### DIFF
--- a/test/e2e/pages/workbench/dashboard.page.ts
+++ b/test/e2e/pages/workbench/dashboard.page.ts
@@ -16,9 +16,15 @@ export class DashboardPage {
 	get newSessionButton() { return this.code.driver.currentPage.getByRole('button', { name: 'New Session', exact: true }).first(); }
 	get positronProButton() { return this.code.driver.currentPage.getByRole('tab', { name: 'Positron Pro' }); }
 	get sessionNameInput() { return this.code.driver.currentPage.getByRole('textbox', { name: 'Session Name' }); }
-	project = (projectName: string) => this.code.driver.currentPage.getByRole('link', { name: projectName });
-	projectNewSessionButton = (projectName: string) => this.project(projectName).locator('..').locator('..').locator('..').getByRole('button', { name: 'Create new session' });
-	projectCheckbox = (projectName: string) => this.code.driver.currentPage.getByRole('checkbox', { name: `select ${projectName}` });
+	// Anchor on the table row: the project name renders as a link while a session runs but as a
+	// button once it is gone, so neither a link role nor a fixed `.locator('..')` climb out of it
+	// survives both states. A leaked session can leave two rows for one project, hence `.first()`.
+	projectRow = (projectName: string) => this.code.driver.currentPage.getByRole('table', { name: 'Projects table' }).getByRole('row', { name: projectName });
+	projectNewSessionButton = (projectName: string) => this.projectRow(projectName).getByRole('button', { name: 'Create new session' }).first();
+	// The row checkbox is named for the *session* ("select Positron Pro Session"), not the project,
+	// so a `select <project>` name matches nothing and quitSession silently quits nothing. Take
+	// whatever checkbox the project's row holds instead.
+	projectCheckbox = (projectName: string) => this.projectRow(projectName).getByRole('checkbox');
 
 	constructor(private code: Code, private quickInput: QuickInput) { }
 
@@ -37,7 +43,7 @@ export class DashboardPage {
 	 * @returns true if a new session was created, false if project already existed
 	 */
 	async ensureProjectExists(folderToOpen = 'test-files', context?: BrowserContext, managedCredentials?: 'snowflake' | 'databricks' | 'azure'): Promise<boolean> {
-		const existingProject = this.project(folderToOpen);
+		const existingProject = this.projectRow(folderToOpen).first();
 
 		try {
 			await expect(existingProject).toBeVisible({ timeout: 3000 });
@@ -134,17 +140,13 @@ export class DashboardPage {
 		const newProjectCreated = await this.ensureProjectExists(projectName, context, managedCredentials);
 
 		if (!newProjectCreated) {
-			// Project already existed, so we need to launch it
+			// Project already existed, so we need to launch it. Sweep up any session left behind
+			// by a failed teardown first, so they can't accumulate to the point where new sessions
+			// no longer launch; quitSession no-ops when nothing is running.
+			await this.quitSession(projectName);
+
 			const startNewSessionButton = this.projectNewSessionButton(projectName);
-
-			try {
-				await expect(startNewSessionButton).toBeVisible({ timeout: 3000 });
-			} catch {
-				// Clean up existing sessions if new session button is not available
-				await this.quitSession(projectName);
-				await expect(startNewSessionButton).toBeVisible();
-			}
-
+			await expect(startNewSessionButton).toBeVisible();
 			await startNewSessionButton.click();
 			await this.launchButton.click();
 		}

--- a/test/e2e/tests/workbench/enforced-settings/enforced-settings-language-scoped.test.ts
+++ b/test/e2e/tests/workbench/enforced-settings/enforced-settings-language-scoped.test.ts
@@ -179,9 +179,8 @@ test.describe('Workbench: Language-scoped enforced settings', {
 		// Wait for the server to accept connections again. The worker-scoped teardown
 		// (WorkbenchApp.stop) will then navigate to the dashboard and attempt to quit the
 		// session itself. Its goTo + quitSession are already wrapped in try/catch and just
-		// warn on failure, so we don't need to reopen a session here - doing so would
-		// introduce a UI state (project shown as button after a server restart killed the
-		// session) that openSession's locator chain doesn't handle.
+		// warn on failure, so we don't need to reopen a session here - the next spec's
+		// fixture opens its own.
 		await waitForRStudioServerReady();
 	});
 

--- a/test/e2e/tests/workbench/extensions/workbench-extension.test.ts
+++ b/test/e2e/tests/workbench/extensions/workbench-extension.test.ts
@@ -30,8 +30,16 @@ test.describe('Workbench Extension', {
 		// Verify we're on the Workbench landing page
 		await expect(workbenchPage.getByRole('link', { name: 'Workbench projects' })).toBeVisible();
 
-		// Click on Positron Pro Session to return to the session
-		await workbenchPage.getByRole('link', { name: 'test-files' }).click();
+		// Click the session link to return to the session. The Project cell is plain text, so the
+		// only link in the row is the session name -- and that name varies ("Positron Pro Session"
+		// when launched from the row, the project name when created via the New Session dialog).
+		// Anchor on the project's row and take whatever link it holds instead of naming it.
+		await workbenchPage
+			.getByRole('table', { name: 'Projects table' })
+			.getByRole('row', { name: 'test-files' })
+			.getByRole('link')
+			.first()
+			.click();
 
 		// Wait for navigation back to the session
 		await workbenchPage.waitForLoadState('domcontentloaded');


### PR DESCRIPTION
### Summary

The Workbench dashboard POM keyed three locators on names the UI never uses, which made `openSession()` time out after a leaked session was quit -- a 28.6% failure rate for the pins-data-connection test on the workbench-ubuntu daily lane.

- Project name renders as a `button`, not a `link` named for the project, so the old `link -> ..x3 -> Create new session` chain resolved to nothing
- Row checkbox is named `select <session>`, not `select <project>`, so `quitSession()` silently quit nothing and leaked sessions accumulated
- Adds `projectRow()` scoped to the Projects table and derives the new-session button and checkbox from it
- `openSession()` now calls `quitSession()` unconditionally instead of relying on a failed button lookup to trigger cleanup
- Drops a stale comment in the enforced-settings spec that documented this locator gap

Reproduced and verified on `e2e-workbench` against Workbench 2026.08.0-daily+184.pro2 (the CI build) plus a daily Positron: seeding a leaked session named `test-files` reproduces the CI error byte-for-byte on `main`, and the same state passes with this change.

### QA Notes

@:workbench @:connect @:connections

### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- Three dashboard POM locators keyed on the wrong thing. The project name renders as a button (never a link named for the project), the session link is named after the *session*, and the row checkbox is named "select <session>" not "select <project>". So openSession only enters its already-exists branch when a leaked session happens to be named test-files, and then its link-rooted ..x3 chain resolves to nothing once quitSession removes that link.</summary>

- **Test:** [Data Connections - Posit Connect Pins > Add a Connect server and browse its pins in the tree](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Data%20Connections%20-%20Posit%20Connect%20Pins%20%3E%20Add%20a%20Connect%20server%20and%20browse%20its%20pins%20in%20the%20tree%7C%7C%7Ctest%2Fe2e%2Ftests%2Fconnect%2Fpins-data-connection.test.ts)
- **Targeted failure:** expect(locator).toBeVisible() failed / element(s) not found on getByRole('link', {name:'test-files'}).locator('..').locator('..').locator('..').getByRole('button', {name:'Create new session'}) at dashboard.page.ts:145
- **Signal:** error-context aria snapshot shows `cell "test-files ~/test-files"` containing `button "test-files"` (no link in the row) and a visible `button "Create new session"`; Playwright call log says 'element(s) not found' not 'hidden'; screencast frames at t=85619ms and t=100460ms are pixel-identical with only 3 frames across the 15s wait, so the page was static with the target visible for the whole timeout; page.goto to :8787 succeeded in 46ms, so this is not the B/C server-startup family.
- **Frequency:** 4/14 runs (28.6%) on main, ubuntu/chromium
- **Hypothesis:** ensureProjectExists() passes only because getByRole('link',{name:'test-files'}) matches the running session's link (the session is named test-files); openSession() therefore takes the already-exists branch, line 141 fails at 3s because no Create-new-session button exists while the session runs, quitSession() removes the session link, and line 145's link-rooted chain then matches nothing for the full 15s. Falsifiable: anchoring on the Projects table row instead of a link role makes the button resolve while the page is in exactly this state.

- **Verification:** reproduced on `e2e-workbench` against Workbench 2026.08.0-daily+184.pro2 (the CI build) + Positron daily 2026.08.0-304. Seeding a leaked session named `test-files` reproduces the CI failure byte-for-byte on main (same assertion, same 15000ms, same chain, same dashboard.page.ts:145); the identical seeded state passes with the fix, plus two further passes in the no-leak state.
- **Also found:** `projectCheckbox` matched nothing on the live DOM (the row checkbox is named `select <session>`), so `quitSession()` silently quit nothing -- the leaked sessions its own comment warns about were actually accumulating.
- **Intermittency:** deterministic given the state, so the 28.6% rate reflects how often a leaked same-named session exists at fixture start, not a timing race.

</details>

