### PR TITLE
Verify the graphviz install in the Windows and macOS e2e workflows

### DIFF
--- a/.github/workflows/test-e2e-macos-run.yml
+++ b/.github/workflows/test-e2e-macos-run.yml
@@ -278,8 +278,30 @@ jobs:
           python -m pip install ipykernel
           pyenv global 3.10.10
 
+      # Unlike `choco install`, `brew install` does exit non-zero when it fails,
+      # so there is no silent-success hazard here. The retry is for transient
+      # network and tap failures (bottle download 5xx, `brew update` fetch
+      # errors), and the `dot -V` check makes a broken install fail at this step
+      # rather than half an hour later as an unexplained screenshot diff in the
+      # graphviz plot tests.
       - name: Setup Graphviz
-        run: brew install graphviz
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 15
+          shell: bash
+          command: |
+            set -euo pipefail
+            brew install graphviz
+            # Homebrew links `dot` into its prefix bin, which is already on the
+            # runner's PATH, so no PATH fix-up is needed (contrast the Windows
+            # job, where the installer edits the machine PATH instead).
+            if ! command -v dot >/dev/null 2>&1; then
+              echo "brew reported success but dot is not on PATH (see the brew output above)" >&2
+              exit 1
+            fi
+            dot -V
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -434,8 +434,42 @@ jobs:
           rig add ${{ steps.r-versions.outputs.r_alt_version }}
           rig ls
 
+      # `choco install` can exit 0 while installing nothing: when the community
+      # feed returns a 5xx, choco prints "Unable to find package 'Graphviz'" and
+      # "Chocolatey installed 0/0 packages" but still succeeds, so the step goes
+      # green and the graphviz plot tests fail half an hour later as a confusing
+      # screenshot diff. Retry the transient feed failures, then prove `dot` runs
+      # before moving on.
       - name: Setup Graphviz
-        run: choco install graphviz -y --no-progress
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 15
+          shell: pwsh
+          command: |
+            $ErrorActionPreference = 'Stop'
+            choco install graphviz -y --no-progress
+            # The graphviz installer puts its bin dir on the machine PATH, which
+            # the already-running runner process does not pick up. Re-read it so
+            # `dot` resolves here, then publish it for the later test steps.
+            $env:PATH = "$([Environment]::GetEnvironmentVariable('Path', 'Machine'));$env:PATH"
+            $dot = Get-Command dot -ErrorAction SilentlyContinue
+            if (-not $dot) {
+              throw 'choco reported success but dot is not installed (see the choco output above)'
+            }
+            $bin = Split-Path $dot.Source -Parent
+            if ((Get-Content $env:GITHUB_PATH -ErrorAction SilentlyContinue) -notcontains $bin) {
+              Add-Content -Path $env:GITHUB_PATH -Value $bin
+            }
+            # Log the version, checking the exit code rather than the output: dot
+            # writes its version banner to stderr, which 'Stop' would otherwise
+            # treat as a failure.
+            $ErrorActionPreference = 'Continue'
+            dot -V
+            if ($LASTEXITCODE -ne 0) {
+              throw "dot -V failed with exit code $LASTEXITCODE"
+            }
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2


### PR DESCRIPTION
Hardens the `Setup Graphviz` step in the Windows and macOS e2e workflows so a failed
dependency install fails at the install step instead of surfacing as a mystery test
failure half an hour later.

### Summary

On run 31037680022 the Chocolatey community feed returned a 503. `choco install
graphviz` printed "Unable to find package 'Graphviz'" and "Chocolatey installed 0/0
packages" -- and then **exited 0**. The step went green with no `dot` on the box, and
the two plot tests that import the graphviz Python module failed ~30 minutes later as
an opaque screenshot diff with nothing pointing at the missing dependency.

An install step that neither retries transient registry failures nor verifies its
result converts an infra blip into a test failure that looks like a product bug.

Both platforms are now wrapped in `nick-fields/retry@v4` (the wrapper already used
elsewhere in these workflows) and assert that `dot` actually runs:

- **Windows** -- retries the transient feed failures, then re-reads the *machine* PATH
  before checking for `dot`. The installer edits the machine PATH, which the
  already-running runner process cannot see, so verifying in the same step would
  otherwise be a false negative. The resolved bin dir is published to `$GITHUB_PATH`
  so later steps see it too. The check reads `dot -V`'s exit code rather than its
  output, because `dot` writes its version banner to stderr and
  `$ErrorActionPreference = 'Stop'` would treat that as a failure.
- **macOS** -- `brew install` *does* exit non-zero on failure, so the silent-success
  bug does not apply here. The value is retry coverage for transient bottle and tap
  fetch failures, plus the same `dot -V` check so a broken install fails at the
  install step. Homebrew links `dot` into its prefix bin, which is already on the
  runner PATH, so no PATH fix-up is needed.

Linux needs no change: `graphviz` is in the apt package lists baked into the e2e
container images (`docker/images/*/deps/*_packages_*.txt`), which is why there was
never a Setup Graphviz step there. The committed `graphviz-linux.png` baseline
confirms those tests do run on Linux.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A (CI-only change)

### Validation Steps

@:win

CI-only change; there is no product code to cover with a unit or e2e test. The
Windows e2e lane exercises the changed step directly -- confirm the `Setup Graphviz`
step logs a `dot - graphviz version ...` banner and that the two graphviz plot tests
pass.

Note that the macOS lane does not run on pull requests (it runs nightly via
`test-full-suite.yml`), so the macOS half of this change is not exercised by this
PR's CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
