### PR TITLE
13902 pinned columns in data explorer are painted on top of each other

### DIFF
--- a/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.tsx
@@ -282,6 +282,7 @@ export interface ColumnDescriptor {
  */
 export interface ColumnDescriptors {
 	pinnedColumnDescriptors: ColumnDescriptor[];
+	pinnedColumnDescriptorsWidth: number;
 	unpinnedColumnDescriptors: ColumnDescriptor[];
 }
 
@@ -299,6 +300,7 @@ export interface RowDescriptor {
  */
 export interface RowDescriptors {
 	pinnedRowDescriptors: RowDescriptor[];
+	pinnedRowDescriptorsHeight: number;
 	unpinnedRowDescriptors: RowDescriptor[];
 }
 
@@ -1541,6 +1543,7 @@ export abstract class DataGridInstance extends Disposable {
 		// Return the column descriptors.
 		return {
 			pinnedColumnDescriptors,
+			pinnedColumnDescriptorsWidth,
 			unpinnedColumnDescriptors,
 		};
 	}
@@ -1581,6 +1584,7 @@ export abstract class DataGridInstance extends Disposable {
 		// Return the row descriptors.
 		return {
 			pinnedRowDescriptors,
+			pinnedRowDescriptorsHeight,
 			unpinnedRowDescriptors,
 		};
 	}

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRow.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRow.tsx
@@ -19,6 +19,7 @@ import { positronClassNames } from '../../../../base/common/positronUtilities.js
  * DataGridRowProps interface.
  */
 interface DataGridRowProps {
+	clipTop: number;
 	columnDescriptors: ColumnDescriptors;
 	height: number;
 	pinned: boolean;
@@ -36,12 +37,15 @@ export const DataGridRow = (props: DataGridRowProps) => {
 	// Context hooks.
 	const context = usePositronDataGridContext();
 
-	// Render the pinned data grid row cells.
+	// Render the pinned data grid row cells. Pinned cells are never clipped horizontally because
+	// they are painted above the unpinned cells that scroll under them.
 	const dataGridRowCells: JSX.Element[] = [];
 	for (const pinnedColumnDescriptor of props.columnDescriptors.pinnedColumnDescriptors) {
 		dataGridRowCells.push(
 			<DataGridRowCell
 				key={`pinned-row-cell-${props.rowIndex}-${pinnedColumnDescriptor.columnIndex}`}
+				clipLeft={0}
+				clipTop={props.clipTop}
 				columnIndex={pinnedColumnDescriptor.columnIndex}
 				height={props.height}
 				left={pinnedColumnDescriptor.left}
@@ -52,14 +56,18 @@ export const DataGridRow = (props: DataGridRowProps) => {
 		);
 	}
 
-	// Create the unpinned data grid column header elements.
+	// Create the unpinned data grid column header elements. An unpinned cell that scrolls under the
+	// band of pinned columns is clipped so that it does not paint there.
 	for (const unpinnedColumnDescriptor of props.columnDescriptors.unpinnedColumnDescriptors) {
+		const left = unpinnedColumnDescriptor.left - context.instance.horizontalScrollOffset;
 		dataGridRowCells.push(
 			<DataGridRowCell
 				key={`row-cell-${props.rowIndex}-${unpinnedColumnDescriptor.columnIndex}`}
+				clipLeft={Math.max(0, props.columnDescriptors.pinnedColumnDescriptorsWidth - left)}
+				clipTop={props.clipTop}
 				columnIndex={unpinnedColumnDescriptor.columnIndex}
 				height={props.height}
-				left={unpinnedColumnDescriptor.left - context.instance.horizontalScrollOffset}
+				left={left}
 				pinned={false}
 				rowIndex={props.rowIndex}
 				width={unpinnedColumnDescriptor.width}

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRow.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRow.tsx
@@ -37,6 +37,11 @@ export const DataGridRow = (props: DataGridRowProps) => {
 	// Context hooks.
 	const context = usePositronDataGridContext();
 
+	// The width of the band of pinned columns. When no column is pinned, the band is empty and
+	// nothing is clipped; a cell scrolled off the left edge of the viewport is already clipped by
+	// the rows container.
+	const pinnedColumnsWidth = props.columnDescriptors.pinnedColumnDescriptorsWidth;
+
 	// Render the pinned data grid row cells. Pinned cells are never clipped horizontally because
 	// they are painted above the unpinned cells that scroll under them.
 	const dataGridRowCells: JSX.Element[] = [];
@@ -63,7 +68,7 @@ export const DataGridRow = (props: DataGridRowProps) => {
 		dataGridRowCells.push(
 			<DataGridRowCell
 				key={`row-cell-${props.rowIndex}-${unpinnedColumnDescriptor.columnIndex}`}
-				clipLeft={Math.max(0, props.columnDescriptors.pinnedColumnDescriptorsWidth - left)}
+				clipLeft={pinnedColumnsWidth > 0 ? Math.max(0, pinnedColumnsWidth - left) : 0}
 				clipTop={props.clipTop}
 				columnIndex={unpinnedColumnDescriptor.columnIndex}
 				height={props.height}
@@ -82,6 +87,7 @@ export const DataGridRow = (props: DataGridRowProps) => {
 				'data-grid-row',
 				{ pinned: props.pinned },
 			)}
+			data-testid={`data-grid-row-${props.rowIndex}`}
 			style={{
 				top: props.top,
 				height: props.height,

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRow.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRow.tsx
@@ -61,7 +61,7 @@ export const DataGridRow = (props: DataGridRowProps) => {
 		);
 	}
 
-	// Create the unpinned data grid column header elements. An unpinned cell that scrolls under the
+	// Render the unpinned data grid row cells. An unpinned cell that scrolls under the
 	// band of pinned columns is clipped so that it does not paint there.
 	for (const unpinnedColumnDescriptor of props.columnDescriptors.unpinnedColumnDescriptors) {
 		const left = unpinnedColumnDescriptor.left - context.instance.horizontalScrollOffset;

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.tsx
@@ -21,6 +21,8 @@ import { HorizontalSplitter } from '../../../../base/browser/ui/positronComponen
  * DataGridRowCellProps interface.
  */
 interface DataGridRowCellProps {
+	clipLeft: number;
+	clipTop: number;
 	columnIndex: number;
 	height: number;
 	left: number;
@@ -133,6 +135,14 @@ export const DataGridRowCell = (props: DataGridRowCellProps) => {
 		);
 	};
 
+	// Data grid row cells do not paint a background, so a cell that scrolls under a pinned column or
+	// a pinned row would show through it. Clip away the part of the cell that lies within a pinned
+	// band so that only the pinned cell paints there. Clipping also removes the clipped area from
+	// hit testing, so the pinned cell receives the mouse events over it.
+	const clipPath = props.clipLeft > 0 || props.clipTop > 0 ?
+		`inset(${props.clipTop}px 0 0 ${props.clipLeft}px)` :
+		undefined;
+
 	// Render.
 	return (
 		<div
@@ -142,6 +152,7 @@ export const DataGridRowCell = (props: DataGridRowCellProps) => {
 				{ pinned: props.pinned },
 			)}
 			style={{
+				clipPath,
 				height: props.height,
 				left: props.left,
 				width: context.instance.getCustomColumnWidth(props.columnIndex) ?? props.width,

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.tsx
@@ -151,6 +151,7 @@ export const DataGridRowCell = (props: DataGridRowCellProps) => {
 				'data-grid-row-cell',
 				{ pinned: props.pinned },
 			)}
+			data-testid={`data-grid-row-cell-${props.columnIndex}-${props.rowIndex}`}
 			style={{
 				clipPath,
 				height: props.height,

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
@@ -699,13 +699,16 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 	}
 
 	// Create the unpinned data grid row elements. An unpinned row that scrolls under the band of
-	// pinned rows is clipped so that it does not paint there.
+	// pinned rows is clipped so that it does not paint there. When no row is pinned, the band is
+	// empty and nothing is clipped; a row scrolled off the top edge of the viewport is already
+	// clipped by the rows container.
+	const pinnedRowsHeight = rowDescriptors.pinnedRowDescriptorsHeight;
 	for (const unpinnedRowDescriptor of rowDescriptors.unpinnedRowDescriptors) {
 		const top = unpinnedRowDescriptor.top - context.instance.verticalScrollOffset;
 		dataGridRows.push(
 			<DataGridRow
 				key={`unpinned-row-${unpinnedRowDescriptor.rowIndex}`}
-				clipTop={Math.max(0, rowDescriptors.pinnedRowDescriptorsHeight - top)}
+				clipTop={pinnedRowsHeight > 0 ? Math.max(0, pinnedRowsHeight - top) : 0}
 				columnDescriptors={columnDescriptors}
 				height={unpinnedRowDescriptor.height}
 				pinned={false}

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
@@ -680,12 +680,14 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 		height
 	);
 
-	// Create the pinned data grid row elements.
+	// Create the pinned data grid row elements. Pinned rows are never clipped because they are
+	// painted above the unpinned rows that scroll under them.
 	const dataGridRows: JSX.Element[] = [];
 	for (const pinnedRowDescriptor of rowDescriptors.pinnedRowDescriptors) {
 		dataGridRows.push(
 			<DataGridRow
 				key={`pinned-row-${pinnedRowDescriptor.rowIndex}`}
+				clipTop={0}
 				columnDescriptors={columnDescriptors}
 				height={pinnedRowDescriptor.height}
 				pinned={true}
@@ -696,16 +698,19 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 		);
 	}
 
-	// Create the unpinned data grid row elements.
+	// Create the unpinned data grid row elements. An unpinned row that scrolls under the band of
+	// pinned rows is clipped so that it does not paint there.
 	for (const unpinnedRowDescriptor of rowDescriptors.unpinnedRowDescriptors) {
+		const top = unpinnedRowDescriptor.top - context.instance.verticalScrollOffset;
 		dataGridRows.push(
 			<DataGridRow
 				key={`unpinned-row-${unpinnedRowDescriptor.rowIndex}`}
+				clipTop={Math.max(0, rowDescriptors.pinnedRowDescriptorsHeight - top)}
 				columnDescriptors={columnDescriptors}
 				height={unpinnedRowDescriptor.height}
 				pinned={false}
 				rowIndex={unpinnedRowDescriptor.rowIndex}
-				top={unpinnedRowDescriptor.top - context.instance.verticalScrollOffset}
+				top={top}
 				width={width}
 			/>
 		);

--- a/src/vs/workbench/browser/positronDataGrid/test/browser/positronDataGrid.vitest.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/test/browser/positronDataGrid.vitest.tsx
@@ -1,0 +1,374 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+// Testing libraries.
+import { act, screen } from '@testing-library/react';
+
+// Other dependencies.
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { PositronDataGrid } from '../../positronDataGrid.js';
+import { DataGridInstance } from '../../classes/dataGridInstance.js';
+
+// The grid geometry every test works against. Round numbers keep the clipping arithmetic legible.
+const COLUMN_WIDTH = 100;
+const ROW_HEIGHT = 20;
+const COLUMNS = 10;
+const ROWS = 40;
+
+// A viewport that shows a handful of columns and rows, and leaves both axes scrollable.
+const VIEWPORT_WIDTH = 400;
+const VIEWPORT_HEIGHT = 80;
+
+// Scrolls the unpinned columns so that one of them straddles the pinned band: with columns 0 and 1
+// pinned (a 200px band) column 3 lands at left: 150, and with only column 0 pinned (100px) column 2
+// lands at left: 50. Either way, 50px of that column falls inside the band.
+const HORIZONTAL_SCROLL_OFFSET = 150;
+
+// Scrolls the unpinned rows so that row 2 lands at top: 10, 10px inside a one-row (20px) band.
+const VERTICAL_SCROLL_OFFSET = 30;
+
+/**
+ * The data grid sizes itself from the DOM via requestAnimationFrame + ResizeObserver. Neither
+ * produces a real layout in happy-dom, and the grid only paints the rows and columns that fit its
+ * *local* size, so this gives elements a real offset size and hands that size to the grid
+ * synchronously via a ResizeObserver that fires on observe(). Returns a restore function for the
+ * offset overrides; callers must also call vi.unstubAllGlobals().
+ */
+function stubGridLayoutWithSize(width: number, height: number): () => void {
+	const offsetWidthDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth');
+	const offsetHeightDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight');
+	Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { configurable: true, get: () => width });
+	Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, get: () => height });
+
+	// rAF stays a no-op; the size instead arrives from the ResizeObserver below.
+	vi.stubGlobal('requestAnimationFrame', () => 0);
+	vi.stubGlobal('ResizeObserver', class {
+		private readonly _callback: ResizeObserverCallback;
+		constructor(callback: ResizeObserverCallback) { this._callback = callback; }
+		observe() {
+			// Report the stubbed size immediately so the grid sizes itself during render. The grid
+			// only reads contentRect, so the rest of the entry throws if it is ever read.
+			const entry = stubInterface<ResizeObserverEntry>({
+				contentRect: stubInterface<DOMRectReadOnly>({ width, height }),
+			});
+			this._callback([entry], this);
+		}
+		unobserve() { }
+		disconnect() { }
+	});
+
+	return () => {
+		Object.defineProperty(HTMLElement.prototype, 'offsetWidth', offsetWidthDescriptor!);
+		Object.defineProperty(HTMLElement.prototype, 'offsetHeight', offsetHeightDescriptor!);
+	};
+}
+
+/**
+ * A minimal concrete data grid instance. Column and row pinning are enabled, and headers are off so
+ * the grid paints nothing but cells, which is what the pinned band clipping applies to.
+ * @param columnWidths Per-column widths, for the non-uniform case. Defaults to COLUMN_WIDTH each.
+ * @param rowHeights Per-row heights, for the non-uniform case. Defaults to ROW_HEIGHT each.
+ */
+class TestDataGridInstance extends DataGridInstance {
+	constructor(columnWidths?: number[], rowHeights?: number[]) {
+		super({
+			columnHeaders: false,
+			rowHeaders: false,
+			defaultColumnWidth: COLUMN_WIDTH,
+			defaultRowHeight: ROW_HEIGHT,
+			columnResize: false,
+			rowResize: false,
+			columnPinning: true,
+			maximumPinnedColumns: 4,
+			rowPinning: true,
+			maximumPinnedRows: 4,
+			horizontalScrollbar: false,
+			verticalScrollbar: false,
+			useEditorFont: false,
+			automaticLayout: true,
+			cellBorders: false,
+			internalCursor: false,
+		});
+
+		// The layout managers hold the shape the grid lays out from. Real instances fill this in when
+		// their data arrives; this one has a fixed shape.
+		this._columnLayoutManager.setEntries(COLUMNS, columnWidths);
+		this._rowLayoutManager.setEntries(ROWS, rowHeights);
+	}
+
+	get columns() {
+		return COLUMNS;
+	}
+
+	get rows() {
+		return ROWS;
+	}
+
+	cell(columnIndex: number, rowIndex: number) {
+		return <span>{`${columnIndex},${rowIndex}`}</span>;
+	}
+}
+
+describe('DataGridInstance pinned band descriptors', () => {
+	// Descriptor math needs no rendering -- it's a plain class. The builder is still used for its
+	// auto-disposed store and disposable-leak detection.
+	const ctx = createTestContainer().build();
+
+	/**
+	 * Builds a grid whose pinned columns and rows have differing sizes, so that a band size can only
+	 * come from summing the pinned entries -- not from the count times the default size.
+	 */
+	function newUnevenGrid(): TestDataGridInstance {
+		// Columns 0 and 3 are pinned below, at 40px and 60px; rows 0 and 5 at 8px and 12px. Everything
+		// else keeps its default size -- setEntries only honors a size array that covers every entry.
+		const columnWidths = Array.from({ length: COLUMNS }, () => COLUMN_WIDTH);
+		columnWidths[0] = 40;
+		columnWidths[3] = 60;
+		const rowHeights = Array.from({ length: ROWS }, () => ROW_HEIGHT);
+		rowHeights[0] = 8;
+		rowHeights[5] = 12;
+
+		const instance = new TestDataGridInstance(columnWidths, rowHeights);
+		ctx.disposables.add(instance);
+		return instance;
+	}
+
+	it('reports the pinned column band width and shifts the unpinned columns past it', () => {
+		const instance = newUnevenGrid();
+		instance.pinColumn(0);
+		instance.pinColumn(3);
+
+		// The band is 40 + 60 = 100px wide, and the unpinned columns are laid out past it: column 1
+		// starts the unpinned space, so its descriptor sits at 100.
+		const descriptors = instance.getColumnDescriptors(0, VIEWPORT_WIDTH);
+		expect({
+			pinned: descriptors.pinnedColumnDescriptors,
+			pinnedWidth: descriptors.pinnedColumnDescriptorsWidth,
+			firstUnpinned: descriptors.unpinnedColumnDescriptors[0],
+			unpinnedCount: descriptors.unpinnedColumnDescriptors.length,
+		}).toMatchInlineSnapshot(`
+			{
+			  "firstUnpinned": {
+			    "columnIndex": 1,
+			    "left": 100,
+			    "width": 100,
+			  },
+			  "pinned": [
+			    {
+			      "columnIndex": 0,
+			      "left": 0,
+			      "width": 40,
+			    },
+			    {
+			      "columnIndex": 3,
+			      "left": 40,
+			      "width": 60,
+			    },
+			  ],
+			  "pinnedWidth": 100,
+			  "unpinnedCount": 3,
+			}
+		`);
+	});
+
+	it('reports the pinned row band height and shifts the unpinned rows past it', () => {
+		const instance = newUnevenGrid();
+		instance.pinRow(0);
+		instance.pinRow(5);
+
+		// The band is 8 + 12 = 20px tall, and the unpinned rows are laid out past it: row 1 starts
+		// the unpinned space, so its descriptor sits at 20.
+		const descriptors = instance.getRowDescriptors(0, VIEWPORT_HEIGHT);
+		expect({
+			pinned: descriptors.pinnedRowDescriptors,
+			pinnedHeight: descriptors.pinnedRowDescriptorsHeight,
+			firstUnpinned: descriptors.unpinnedRowDescriptors[0],
+			unpinnedCount: descriptors.unpinnedRowDescriptors.length,
+		}).toMatchInlineSnapshot(`
+			{
+			  "firstUnpinned": {
+			    "height": 20,
+			    "rowIndex": 1,
+			    "top": 20,
+			  },
+			  "pinned": [
+			    {
+			      "height": 8,
+			      "rowIndex": 0,
+			      "top": 0,
+			    },
+			    {
+			      "height": 12,
+			      "rowIndex": 5,
+			      "top": 8,
+			    },
+			  ],
+			  "pinnedHeight": 20,
+			  "unpinnedCount": 3,
+			}
+		`);
+	});
+});
+
+describe('PositronDataGrid pinned band clipping', () => {
+	const ctx = createTestContainer().withReactServices().build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
+
+	let restoreLayout: () => void;
+	beforeEach(() => {
+		restoreLayout = stubGridLayoutWithSize(VIEWPORT_WIDTH, VIEWPORT_HEIGHT);
+	});
+	afterEach(() => {
+		restoreLayout();
+		vi.unstubAllGlobals();
+	});
+
+	function newGrid(): TestDataGridInstance {
+		const instance = new TestDataGridInstance();
+		ctx.disposables.add(instance);
+		return instance;
+	}
+
+	/**
+	 * Renders a data grid instance. The viewport size the real app gets from layout arrives from the
+	 * stubbed ResizeObserver during the layout effect, which is also what tells the grid how many
+	 * rows and columns to paint.
+	 */
+	function renderGrid(instance: TestDataGridInstance) {
+		rtl.render(<PositronDataGrid instance={instance} />);
+	}
+
+	/**
+	 * Scrolls the grid, which re-renders the rows at their new offsets.
+	 */
+	async function scrollTo(instance: TestDataGridInstance, horizontal: number, vertical: number) {
+		await act(async () => await instance.setScrollOffsets(horizontal, vertical));
+	}
+
+	/**
+	 * Reads a cell's inline clip-path. An empty string means the cell is unclipped.
+	 */
+	function cellClipPath(columnIndex: number, rowIndex: number) {
+		return screen.getByTestId(`data-grid-row-cell-${columnIndex}-${rowIndex}`).style.clipPath;
+	}
+
+	/**
+	 * Reads a cell's inline left, for the test whose point turns on where the cell sits.
+	 */
+	function cellLeft(columnIndex: number, rowIndex: number) {
+		return screen.getByTestId(`data-grid-row-cell-${columnIndex}-${rowIndex}`).style.left;
+	}
+
+	/**
+	 * Reads a row's inline top. Cells carry no top of their own; the row positions all of them.
+	 */
+	function rowTop(rowIndex: number) {
+		return screen.getByTestId(`data-grid-row-${rowIndex}`).style.top;
+	}
+
+	it('clips the part of a cell that scrolls under the pinned columns', async () => {
+		const instance = newGrid();
+		instance.pinColumn(0);
+		instance.pinColumn(1);
+		renderGrid(instance);
+
+		await scrollTo(instance, HORIZONTAL_SCROLL_OFFSET, 0);
+
+		// Column 3 sits at left: 150, inside the 200px band, so its leftmost 50px has to go. Column 4
+		// starts at left: 250, clear of the band, and neither pinned column paints over anything.
+		expect({
+			pinnedColumn0: cellClipPath(0, 0),
+			pinnedColumn1: cellClipPath(1, 0),
+			straddlingColumn3: cellClipPath(3, 0),
+			clearColumn4: cellClipPath(4, 0),
+		}).toMatchInlineSnapshot(`
+			{
+			  "clearColumn4": "",
+			  "pinnedColumn0": "",
+			  "pinnedColumn1": "",
+			  "straddlingColumn3": "inset(0px 0 0 50px)",
+			}
+		`);
+	});
+
+	it('clips the part of a row that scrolls under the pinned rows', async () => {
+		const instance = newGrid();
+		instance.pinRow(0);
+		renderGrid(instance);
+
+		await scrollTo(instance, 0, VERTICAL_SCROLL_OFFSET);
+
+		// Row 2 straddles the 20px band at top: 10, so every cell in it loses 10px off the top.
+		// Row 3 starts at top: 30, clear of the band.
+		expect({
+			straddlingRow2Column0: cellClipPath(0, 2),
+			straddlingRow2Column1: cellClipPath(1, 2),
+			clearRow3Column0: cellClipPath(0, 3),
+		}).toMatchInlineSnapshot(`
+			{
+			  "clearRow3Column0": "",
+			  "straddlingRow2Column0": "inset(10px 0 0 0px)",
+			  "straddlingRow2Column1": "inset(10px 0 0 0px)",
+			}
+		`);
+	});
+
+	it('clips against both bands at once, including the pinned cells of an unpinned row', async () => {
+		const instance = newGrid();
+		instance.pinColumn(0);
+		instance.pinRow(0);
+		renderGrid(instance);
+
+		await scrollTo(instance, HORIZONTAL_SCROLL_OFFSET, VERTICAL_SCROLL_OFFSET);
+
+		// The two insets compose: a cell inside both bands is clipped on both edges. A pinned column
+		// still scrolls vertically, so its cell in row 2 is clipped at the top; a pinned row still
+		// scrolls horizontally, so its cell in column 2 is clipped at the left.
+		expect({
+			pinnedRowAndColumn: cellClipPath(0, 0),
+			pinnedRowOnly: cellClipPath(2, 0),
+			pinnedColumnOnly: cellClipPath(0, 2),
+			neitherPinned: cellClipPath(2, 2),
+		}).toMatchInlineSnapshot(`
+			{
+			  "neitherPinned": "inset(10px 0 0 50px)",
+			  "pinnedColumnOnly": "inset(10px 0 0 0px)",
+			  "pinnedRowAndColumn": "",
+			  "pinnedRowOnly": "inset(0px 0 0 50px)",
+			}
+		`);
+	});
+
+	it('leaves every cell unclipped when nothing is pinned', async () => {
+		const instance = newGrid();
+		renderGrid(instance);
+
+		await scrollTo(instance, HORIZONTAL_SCROLL_OFFSET, VERTICAL_SCROLL_OFFSET);
+
+		// Cell (1,1) is the one that could regress: it is scrolled off the left and top edges of the
+		// viewport, so subtracting its negative left and top from an empty band would clip it. That
+		// clip would be invisible -- the rows container already hides everything above and to the left
+		// of the viewport -- so what this pins down is that a grid with nothing pinned pays no
+		// clip-path cost at all. The snapshot carries the off-edge position so a later change to the
+		// scroll offsets cannot quietly leave the test asserting nothing.
+		expect({
+			offEdgeCellLeft: cellLeft(1, 1),
+			offEdgeRowTop: rowTop(1),
+			offEdgeCellClipPath: cellClipPath(1, 1),
+			interiorCellClipPath: cellClipPath(2, 2),
+		}).toMatchInlineSnapshot(`
+			{
+			  "interiorCellClipPath": "",
+			  "offEdgeCellClipPath": "",
+			  "offEdgeCellLeft": "-50px",
+			  "offEdgeRowTop": "-10px",
+			}
+		`);
+	});
+});


### PR DESCRIPTION
Fixes #13902

Pinning a column in the Data Explorer and scrolling horizontally left the values from the scrolled columns visible inside the pinned column. Data grid cells stopped painting a background in #13524, so a cell that scrolls under a pinned cell now shows through it: the `z-index` that stacks pinned cells above unpinned ones only hides what is beneath when the cell on top is opaque. The same goes for the vertical axis, where rows scroll under a band of pinned rows, and for the cells of a pinned column, which scroll vertically like any other. Only the column and row headers escaped, because they paint an opaque background.

Rather than reintroduce an opaque cell background, this clips the content that scrolls under a pinned band. `getColumnDescriptors` and `getRowDescriptors` already computed the size of the pinned band internally; they now return it as `pinnedColumnDescriptorsWidth` and `pinnedRowDescriptorsHeight`, and `DataGridRow` / `DataGridRowCell` use it to apply a `clip-path: inset(...)` to the portion of a cell that falls inside either band. The two insets compose, so a cell inside both is clipped on both edges. Clipping also removes the clipped area from hit testing, so the pinned cell receives the mouse events over it.

Cells that do not overlap a pinned band get no `clip-path` at all, so a grid with nothing pinned is unchanged. That case is explicitly guarded: a cell scrolled partly off the left edge of the viewport has a negative `left`, so subtracting it from an empty band would produce a positive inset and clip a cell with no band to clip against.

Tests: a new `positronDataGrid.vitest.tsx` covers the descriptor band sizes over a minimal `DataGridInstance` subclass (with differing pinned sizes, so a band size can only come from summing the pinned entries), and the rendered `clip-path` for each combination of pinned column, pinned row, both, and neither. Two `data-testid` attributes were added to the cell and row roots to address them; the `clip-path` lands on the cell root, which previously had no test-addressable identity.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed columns and rows in the Data Explorer showing through pinned columns and pinned rows while scrolling (#13902)

### Validation Steps

@:data-explorer @:web

1. In an R console, run `View(mtcars)`
2. Right-click the `mpg` column and choose _Pin Column_
3. Scroll horizontally and verify the `cyl` values are clipped at the right edge of `mpg` rather than showing through it
4. Right-click a row header, choose _Pin Row_, then scroll vertically and verify the scrolled rows are clipped at the bottom edge of the pinned row
5. Pin several columns and rows, verify the same at each boundary, then unpin everything and confirm scrolling looks unchanged
