### PR TITLE
Add feature flag + stub for the redesigned welcome page

### DIFF
--- a/.github/workflows/test-tag-paths-map.json
+++ b/.github/workflows/test-tag-paths-map.json
@@ -161,6 +161,7 @@
   "src/vs/workbench/contrib/welcomeGettingStarted/": [],
   "src/vs/workbench/contrib/welcomeGettingStarted/browser/media/positronGettingStarted.css": ["@:welcome"],
   "src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcome": ["@:welcome"],
+  "src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/": ["@:welcome"],
   "src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedPositronNotebookContent.ts": ["@:welcome"],
   "src/vs/workbench/services/notification/": [],
   "src/vs/workbench/services/themes/": [],

--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -1099,6 +1099,7 @@
 		"--vscode-tree-tableOddRowsBackground",
 		"--vscode-walkThrough-embeddedEditorBackground",
 		"--vscode-walkthrough-stepTitle-foreground",
+		"--vscode-walkthroughActivityBarBadge-background",
 		"--vscode-welcomePage-background",
 		"--vscode-welcomePage-progress-background",
 		"--vscode-welcomePage-progress-foreground",

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -90,6 +90,8 @@ import { isDark } from '../../../../platform/theme/common/theme.js';
 // eslint-disable-next-line no-duplicate-imports
 import { isWeb } from '../../../../base/common/platform.js';
 import { gettingStartedPositronNotebookCategoryId } from '../common/gettingStartedPositronNotebookContent.js';
+import { createPositronWelcomePage } from './positronWelcomePage/positronWelcomePage.js';
+import { WELCOME_PAGE_EXPERIMENTAL_KEY } from '../common/positronWelcomePageConfiguration.js';
 // --- End Positron ---
 
 const SLIDE_TRANSITION_TIME_MS = 250;
@@ -286,6 +288,16 @@ export class GettingStartedPage extends EditorPane {
 
 		this._register(this.gettingStartedService.onDidAddWalkthrough(rerender));
 		this._register(this.gettingStartedService.onDidRemoveWalkthrough(rerender));
+
+		// --- Start Positron ---
+		// Rebuild the page when the experimental welcome page setting is toggled,
+		// so switching it does not need a window reload.
+		this._register(this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(WELCOME_PAGE_EXPERIMENTAL_KEY)) {
+				this.buildSlideThrottle.queue(() => this.buildCategoriesSlide());
+			}
+		}));
+		// --- End Positron ---
 
 		this.recentlyOpened = this.workspacesService.getRecentlyOpened();
 		this._register(workspacesService.onDidChangeRecentlyOpened(() => {
@@ -978,41 +990,33 @@ export class GettingStartedPage extends EditorPane {
 			onShowOnStartupChanged();
 		}));
 		// --- Start Positron ---
-		// Positron replaces the upstream header with a theme-aware logo.
+		// Positron replaces the upstream header with a theme-aware logo. The
+		// logo is only shown on the original welcome page, so it is built with
+		// the rest of that page at the bottom of this method.
 		//
 		// const header = $('.header', {},
 		// 	$('h1.product-name.caption', {}, this.productService.nameLong),
 		// 	$('p.subtitle.description', {}, localize({ key: 'gettingStarted.editingEvolved', comment: ['Shown as subtitle on the Welcome page.'] }, "Editing evolved"))
 		// );
-		// Create a function to get the header logo based on theme type
-		const getHeaderLogoClass = () => {
-			return isDark(this.themeService.getColorTheme().type)
-				? 'product-logo welcome-positron-logo-dark'
-				: 'product-logo welcome-positron-logo';
-		};
-		// Create element for the theme-aware logo
-		const logoElement = $('div', { class: getHeaderLogoClass() });
-		// Add a listener to update the logo when the theme changes
-		this.categoriesSlideDisposables.add(
-			this.themeService.onDidColorThemeChange(() => {
-				logoElement.className = getHeaderLogoClass();
-			})
-		);
-		// Display the theme-aware logo in the header
-		const header = $('.header', {}, logoElement);
 		// --- End Positron ---
 
 		const leftColumn = $('.categories-column.categories-column-left', {},);
 		const rightColumn = $('.categories-column.categories-column-right', {},);
 
 		// --- Start Positron ---
-		// Positron shows a Help list where upstream shows its start list.
+		// Positron shows a Help list where upstream shows its start list. The
+		// help list is only shown on the original welcome page, so it is built
+		// in layoutRecentList below.
 		//
 		// const startList = this.buildStartList();
-		const helpList = this.buildHelpList();
 		// --- End Positron ---
 		const recentList = this.buildRecentlyOpenedList();
-		const gettingStartedList = this.buildGettingStartedWalkthroughsList();
+		// --- Start Positron ---
+		// The walkthroughs list is only shown on the original welcome page, so
+		// it is built in layoutRecentList below.
+		//
+		// const gettingStartedList = this.buildGettingStartedWalkthroughsList();
+		// --- End Positron ---
 
 		// --- Start Positron ---
 		// The "Connect to..." button is normally a part of the start list
@@ -1096,6 +1100,11 @@ export class GettingStartedPage extends EditorPane {
 		// 	}
 		// };
 		const layoutRecentList = () => {
+			// These lists are only shown on the original welcome page, so they
+			// are built here rather than with the shared lists above.
+			const helpList = this.buildHelpList();
+			const gettingStartedList = this.buildGettingStartedWalkthroughsList();
+
 			const leftContent = $('div.positron-welcome-left-column');
 			this.positronReactRenderer = createWelcomePageLeft(leftContent);
 			this.categoriesSlideDisposables.add(this.positronReactRenderer);
@@ -1108,18 +1117,48 @@ export class GettingStartedPage extends EditorPane {
 			}
 			reset(rightColumn, gettingStartedList.getDomElement(), helpList.getDomElement());
 		};
-		// --- End Positron ---
 
-		// --- Start Positron ---
-		// Positron lays the page out once; upstream re-runs layoutLists when
-		// the walkthroughs change.
+		// The redesigned welcome page, gated on `welcomePage.experimental`.
+		// Returns undefined when the flag is off, in which case the original
+		// welcome page below is built unchanged.
+		const positronWelcomePageContainer = this.buildPositronWelcomePage(recentList, otherList, footer);
+
+		// When the redesigned page is on, it replaces the whole slide.
 		//
 		// gettingStartedList.onDidChange(layoutLists);
 		// layoutLists();
-		layoutRecentList();
+		//
+		// reset(this.categoriesSlide, $('.gettingStartedCategoriesContainer', {}, header, leftColumn, rightColumn, footer,));
+		if (positronWelcomePageContainer) {
+			reset(this.categoriesSlide, positronWelcomePageContainer);
+		} else {
+			// Everything in this branch is the original welcome page. It goes when
+			// the flag does, along with the files named on
+			// WELCOME_PAGE_EXPERIMENTAL_KEY, leaving the commented-out upstream
+			// code above to be restored or dropped as that change decides.
+
+			// Create a function to get the header logo based on theme type
+			const getHeaderLogoClass = () => {
+				return isDark(this.themeService.getColorTheme().type)
+					? 'product-logo welcome-positron-logo-dark'
+					: 'product-logo welcome-positron-logo';
+			};
+			// Create element for the theme-aware logo
+			const logoElement = $('div', { class: getHeaderLogoClass() });
+			// Add a listener to update the logo when the theme changes
+			this.categoriesSlideDisposables.add(
+				this.themeService.onDidColorThemeChange(() => {
+					logoElement.className = getHeaderLogoClass();
+				})
+			);
+			// Display the theme-aware logo in the header
+			const header = $('.header', {}, logoElement);
+
+			layoutRecentList();
+			reset(this.categoriesSlide, $('.gettingStartedCategoriesContainer', {}, header, leftColumn, rightColumn, footer,));
+		}
 		// --- End Positron ---
 
-		reset(this.categoriesSlide, $('.gettingStartedCategoriesContainer', {}, header, leftColumn, rightColumn, footer,));
 		this.categoriesPageScrollbar?.scanDomNode();
 
 		this.updateCategoryProgress();
@@ -1181,6 +1220,57 @@ export class GettingStartedPage extends EditorPane {
 
 		this.setSlide('categories');
 	}
+
+	// --- Start Positron ---
+	/**
+	 * Builds the redesigned welcome page, which is gated on the
+	 * `welcomePage.experimental` setting. Returns undefined when the setting is
+	 * off, in which case the caller builds the original welcome page instead.
+	 *
+	 * The recent list, the "Connect to..." action and the show on startup
+	 * checkbox are passed in as already-built DOM so that they keep the
+	 * behaviour they have on the original page.
+	 * @param recentList The "Recent" list.
+	 * @param otherList The "Connect to..." action.
+	 * @param footer The "Show welcome page on startup" checkbox row.
+	 * @returns The container to show, or undefined when the setting is off.
+	 */
+	private buildPositronWelcomePage(
+		recentList: GettingStartedIndexList<RecentEntry>,
+		otherList: HTMLElement,
+		footer: HTMLElement
+	): HTMLElement | undefined {
+		// Compare against true rather than checking for false. The setting is
+		// registered with `included: false`, which drops it from the
+		// configuration properties, so its declared default is never applied and
+		// getValue returns undefined when the user has not set it.
+		if (this.configurationService.getValue<boolean>(WELCOME_PAGE_EXPERIMENTAL_KEY) !== true) {
+			return undefined;
+		}
+
+		const reactHost = $('div');
+		this.categoriesSlideDisposables.add(createPositronWelcomePage(reactHost, {
+			recentList: recentList.getDomElement(),
+			// Hide the "Connect to..." button if we are on a web platform
+			connectAction: isWeb ? undefined : otherList,
+			footer,
+			// React mounts asynchronously, so the elements above are not in the
+			// DOM yet when the caller runs registerDispatchListeners, nor when it
+			// measures the slide for scrolling. Redo both once they are.
+			//
+			// registerDispatchListeners clears its listeners and re-walks the
+			// container, so calling it twice is safe. Without the rescan the
+			// scrollable still believes the slide is empty and the page cannot be
+			// scrolled at all once its content is taller than the editor.
+			onDidMount: () => {
+				this.registerDispatchListeners();
+				this.categoriesPageScrollbar?.scanDomNode();
+			},
+		}));
+
+		return reactHost;
+	}
+	// --- End Positron ---
 
 	// --- Start Positron ---
 	private buildHelpList(): GettingStartedIndexList<IWelcomePageHelpEntry> {

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -203,7 +203,10 @@ export class GettingStartedPage extends EditorPane {
 	private showFeaturedWalkthrough = true;
 
 	// --- Start Positron ---
-	private positronReactRenderer!: PositronReactRenderer;
+	// Holds the React root for whichever welcome page is built. Assigning a new
+	// one unmounts the previous one, and clearInput clears it so the tree does
+	// not stay mounted while the editor is closed.
+	private readonly positronReactRenderer = this._register(new MutableDisposable<PositronReactRenderer>());
 	// --- End Positron ---
 
 	get editorInput(): GettingStartedInput | undefined {
@@ -1106,8 +1109,7 @@ export class GettingStartedPage extends EditorPane {
 			const gettingStartedList = this.buildGettingStartedWalkthroughsList();
 
 			const leftContent = $('div.positron-welcome-left-column');
-			this.positronReactRenderer = createWelcomePageLeft(leftContent);
-			this.categoriesSlideDisposables.add(this.positronReactRenderer);
+			this.positronReactRenderer.value = createWelcomePageLeft(leftContent);
 
 			// Hide the "Connect to..." button if we are on a web platform
 			if (!isWeb) {
@@ -1249,7 +1251,7 @@ export class GettingStartedPage extends EditorPane {
 		}
 
 		const reactHost = $('div');
-		this.categoriesSlideDisposables.add(createPositronWelcomePage(reactHost, {
+		this.positronReactRenderer.value = createPositronWelcomePage(reactHost, {
 			recentList: recentList.getDomElement(),
 			// Hide the "Connect to..." button if we are on a web platform
 			connectAction: isWeb ? undefined : otherList,
@@ -1266,7 +1268,7 @@ export class GettingStartedPage extends EditorPane {
 				this.registerDispatchListeners();
 				this.categoriesPageScrollbar?.scanDomNode();
 			},
-		}));
+		});
 
 		return reactHost;
 	}
@@ -1838,7 +1840,9 @@ export class GettingStartedPage extends EditorPane {
 	override clearInput() {
 		this.stepDisposables.clear();
 		// --- Start Positron ---
-		this.positronReactRenderer?.dispose();
+		// Closing the editor does not dispose the pane, so unmount the welcome
+		// page here rather than waiting for the next build or for teardown.
+		this.positronReactRenderer.clear();
 		// --- End Positron ---
 		super.clearInput();
 	}

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -2047,11 +2047,19 @@ export class GettingStartedPage extends EditorPane {
 					this.editorInput.walkthroughPageTitle = undefined;
 				}
 
-				if (this.gettingStartedCategories.length !== this.gettingStartedList.value?.itemCount) {
+				// --- Start Positron ---
+				// Requires the list to exist before treating it as stale. The
+				// redesigned welcome page does not build a walkthrough list, so
+				// without this the comparison against undefined is always true and
+				// every trip back here rebuilds the whole slide.
+				//
+				// if (this.gettingStartedCategories.length !== this.gettingStartedList.value?.itemCount) {
+				if (this.gettingStartedList.value && this.gettingStartedCategories.length !== this.gettingStartedList.value.itemCount) {
 					// extensions may have changed in the time since we last displayed the walkthrough list
 					// rebuild the list
 					this.buildCategoriesSlide();
 				}
+				// --- End Positron ---
 
 				this.selectStep(undefined);
 				this.setSlide('categories');

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
@@ -377,16 +377,22 @@
 	z-index: 1;
 }
 
-/*--- Start Positron ---*/
 .monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-category .featured {
-	border-top: 30px solid var(--vscode-walkthroughActivityBarBadge-background);
-	width: 30px;
-	box-sizing: border-box;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 20px;
 	height: 20px;
 	border-top-left-radius: var(--vscode-cornerRadius-medium, 6px);
 	border-bottom-right-radius: var(--vscode-cornerRadius-medium, 6px);
 	background-color: var(--vscode-activityBarBadge-background);
 	box-sizing: border-box;
+}
+
+/*--- Start Positron ---*/
+/* Positron gives walkthrough badges their own color token. */
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-category .featured {
+	background-color: var(--vscode-walkthroughActivityBarBadge-background);
 }
 
 /*--- End Positron ---*/

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/domSlot.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/domSlot.tsx
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// React.
+import { useLayoutEffect, useRef } from 'react';
+
+/**
+ * DomSlotProps interface.
+ */
+export interface DomSlotProps {
+	/**
+	 * Class name for the wrapper, when the page needs to position the slot.
+	 * Leave unset when the page's own layout already handles it.
+	 */
+	readonly className?: string;
+
+	/**
+	 * The element to place. Built outside React, usually by the editor pane.
+	 */
+	readonly element: HTMLElement;
+}
+
+/**
+ * DomSlot component. Places an element that React does not own into the React
+ * tree. Renders no children, so React never tries to reconcile that element.
+ * @param props A DomSlotProps that contains the component properties.
+ * @returns The rendered component.
+ */
+export const DomSlot = (props: DomSlotProps) => {
+	const ref = useRef<HTMLDivElement>(null);
+
+	useLayoutEffect(() => {
+		const element = props.element;
+		ref.current?.appendChild(element);
+		return () => element.remove();
+	}, [props.element]);
+
+	return <div ref={ref} className={props.className} />;
+};

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/positronWelcomePage.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/positronWelcomePage.css
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/*
+ * Fills the slide when the content is short, so the footer rule below has space
+ * to push against, and grows past it when the content is tall. A fixed height
+ * would clip instead of scroll.
+ *
+ * No horizontal padding here: the parent .gettingStartedSlideCategories already
+ * supplies 24px.
+ */
+.positron-welcome-page {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+	margin: 0 auto;
+	max-width: 1400px;
+	min-height: 100%;
+}
+
+/*
+ * Keeps the "Show welcome page on startup" checkbox at the bottom of the page,
+ * however tall the content above it is.
+ */
+.positron-welcome-page .positron-welcome-page-footer {
+	margin-top: auto;
+}

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/positronWelcomePage.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/positronWelcomePage.tsx
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import './positronWelcomePage.css';
+
+// React.
+import { useEffect } from 'react';
+
+// Other dependencies.
+import { PositronReactRenderer } from '../../../../../base/browser/positronReactRenderer.js';
+import { DomSlot } from './components/domSlot.js';
+
+/**
+ * PositronWelcomePageProps interface.
+ */
+export interface PositronWelcomePageProps {
+	/**
+	 * The "Recent" list. Built by the editor pane because it reuses the
+	 * existing GettingStartedIndexList widget.
+	 */
+	readonly recentList: HTMLElement;
+
+	/**
+	 * The "Connect to..." action. Built by the editor pane. Undefined on web,
+	 * where there is nothing to connect to.
+	 */
+	readonly connectAction?: HTMLElement;
+
+	/**
+	 * The "Show welcome page on startup" checkbox row. Built by the editor pane
+	 * because it reuses the existing Toggle widget and its telemetry.
+	 */
+	readonly footer: HTMLElement;
+
+	/**
+	 * Called once the page is in the DOM. The editor pane uses this to attach
+	 * click handlers to the elements above, which it can only do after React
+	 * has mounted them.
+	 */
+	readonly onDidMount: () => void;
+}
+
+/**
+ * PositronWelcomePage component. The redesigned welcome page, shown when the
+ * `welcomePage.experimental` setting is on.
+ * @param props A PositronWelcomePageProps that contains the component properties.
+ * @returns The rendered component.
+ */
+export const PositronWelcomePage = (props: PositronWelcomePageProps) => {
+	const onDidMount = props.onDidMount;
+
+	// Runs after the DomSlot layout effects, so the slotted elements are in the
+	// DOM by the time the editor pane wires up its click handlers.
+	useEffect(() => {
+		onDidMount();
+	}, [onDidMount]);
+
+	// A fragment, not a wrapping div. createPositronWelcomePage puts the
+	// `positron-welcome-page` class on the container React roots into, so the
+	// layout lives on one element instead of two nested ones.
+	return (
+		<>
+			<p>Hello world</p>
+			<DomSlot element={props.recentList} />
+			{props.connectAction && <DomSlot element={props.connectAction} />}
+			<DomSlot className='positron-welcome-page-footer' element={props.footer} />
+		</>
+	);
+};
+
+/**
+ * Renders the Positron welcome page into a container. The container becomes the
+ * page's layout element, so the caller can pass a bare div.
+ * @param container The container HTMLElement.
+ * @param props A PositronWelcomePageProps that contains the component properties.
+ * @returns The PositronReactRenderer. Dispose it to unmount the page.
+ */
+export const createPositronWelcomePage = (
+	container: HTMLElement,
+	props: PositronWelcomePageProps
+): PositronReactRenderer => {
+	container.classList.add('positron-welcome-page');
+	const renderer = new PositronReactRenderer(container);
+	renderer.render(<PositronWelcomePage {...props} />);
+	return renderer;
+};

--- a/src/vs/workbench/contrib/welcomeGettingStarted/common/positronWelcomePageConfiguration.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/common/positronWelcomePageConfiguration.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../../nls.js';
+import {
+	ConfigurationScope,
+	Extensions,
+	IConfigurationRegistry,
+} from '../../../../platform/configuration/common/configurationRegistry.js';
+import { Registry } from '../../../../platform/registry/common/platform.js';
+
+/**
+ * Configuration key that gates the redesigned welcome page. While this is off,
+ * the welcome page renders its original contents.
+ *
+ * This is a development switch, not a user-facing setting. It is registered
+ * with `included: false` so it stays out of the Settings editor and out of
+ * settings.json IntelliSense. Turn it on by hand-editing settings.json:
+ *
+ *     "welcomePage.experimental": true
+ *
+ * Remove the setting once the redesigned page replaces the original one. The
+ * original page's files go with it, and their names do not make that obvious:
+ * `positronWelcomePageLeft.tsx`, `positronWelcomePageStart.tsx`,
+ * `positronWelcomeButton.tsx` and `positronWelcomeMenuButton.tsx` in
+ * `browser/` all belong to the original page, not to `browser/positronWelcomePage/`.
+ */
+export const WELCOME_PAGE_EXPERIMENTAL_KEY = 'welcomePage.experimental';
+
+const configurationRegistry = Registry.as<IConfigurationRegistry>(Extensions.Configuration);
+configurationRegistry.registerConfiguration({
+	id: 'positron',
+	order: 7,
+	title: localize('positronConfigurationTitle', "Positron"),
+	type: 'object',
+	properties: {
+		[WELCOME_PAGE_EXPERIMENTAL_KEY]: {
+			type: 'boolean',
+			default: false,
+			markdownDescription: localize(
+				'positron.welcomePage.experimental',
+				"Enable the redesigned welcome page. This feature is under active development and may change or be removed without notice."
+			),
+			tags: ['experimental'],
+			scope: ConfigurationScope.WINDOW,
+			included: false,
+		},
+	},
+});

--- a/src/vs/workbench/contrib/welcomeGettingStarted/test/browser/domSlot.vitest.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/test/browser/domSlot.vitest.tsx
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
+import { DomSlot } from '../../browser/positronWelcomePage/components/domSlot.js';
+
+describe('DomSlot', () => {
+	const rtl = setupRTLRenderer();
+
+	/**
+	 * Builds an element standing in for one the editor pane hands to the page,
+	 * such as the recent list or the show on startup checkbox.
+	 */
+	const slottedElement = () => {
+		const element = document.createElement('div');
+		element.textContent = 'Recent';
+		return element;
+	};
+
+	it('places the element inside a bare wrapper when given no class', () => {
+		const element = slottedElement();
+		rtl.render(<DomSlot element={element} />);
+
+		// The recent list and the connect action are slotted this way: the page's
+		// flex gap spaces them, so their wrappers carry no class.
+		expect(element).toBeInTheDocument();
+		expect(element.parentElement).not.toHaveAttribute('class');
+	});
+
+	it('puts the given class on the wrapper', () => {
+		const element = slottedElement();
+		rtl.render(<DomSlot className='positron-welcome-page-footer' element={element} />);
+
+		expect(element.parentElement).toHaveClass('positron-welcome-page-footer');
+	});
+
+	it('removes the element when unmounted', () => {
+		const element = slottedElement();
+		const { unmount } = rtl.render(<DomSlot element={element} />);
+		unmount();
+
+		expect(element).not.toBeInTheDocument();
+	});
+});

--- a/src/vs/workbench/contrib/welcomeGettingStarted/test/browser/positronWelcomePage.vitest.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/test/browser/positronWelcomePage.vitest.tsx
@@ -1,0 +1,115 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { screen } from '@testing-library/react';
+import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
+import { createPositronWelcomePage, PositronWelcomePage } from '../../browser/positronWelcomePage/positronWelcomePage.js';
+
+describe('PositronWelcomePage', () => {
+	const rtl = setupRTLRenderer();
+
+	/**
+	 * Builds the DOM the editor pane hands to the page. These are real widgets
+	 * on the welcome page, so the test only needs something findable in their
+	 * place.
+	 */
+	const slottedDom = () => {
+		const recentList = document.createElement('div');
+		recentList.textContent = 'Recent';
+
+		const connectAction = document.createElement('div');
+		connectAction.textContent = 'Connect to...';
+
+		const footer = document.createElement('div');
+		footer.textContent = 'Show welcome page on startup';
+
+		return { recentList, connectAction, footer };
+	};
+
+	it('renders the recent list, then the connect action, then the footer', () => {
+		const { recentList, connectAction, footer } = slottedDom();
+		const { container } = rtl.render(
+			<PositronWelcomePage
+				connectAction={connectAction}
+				footer={footer}
+				recentList={recentList}
+				onDidMount={vi.fn()}
+			/>
+		);
+
+		expect(container).toHaveTextContent(/Recent.*Connect to\.\.\..*Show welcome page on startup/);
+	});
+
+	it('omits the connect action when there is none, as on web', () => {
+		const { recentList, footer } = slottedDom();
+		rtl.render(
+			<PositronWelcomePage footer={footer} recentList={recentList} onDidMount={vi.fn()} />
+		);
+
+		expect(screen.queryByText('Connect to...')).not.toBeInTheDocument();
+	});
+
+	it('calls onDidMount once every slotted element is in the document', () => {
+		const { recentList, connectAction, footer } = slottedDom();
+		const connectedAtCallTime: { recent: boolean; connect: boolean; footer: boolean }[] = [];
+		const onDidMount = () => {
+			connectedAtCallTime.push({
+				recent: recentList.isConnected,
+				connect: connectAction.isConnected,
+				footer: footer.isConnected,
+			});
+		};
+
+		rtl.render(
+			<PositronWelcomePage
+				connectAction={connectAction}
+				footer={footer}
+				recentList={recentList}
+				onDidMount={onDidMount}
+			/>
+		);
+
+		// The editor pane attaches click handlers from this callback, so it has
+		// to run after the slotted elements land in the DOM, not before.
+		expect(connectedAtCallTime).toEqual([{ recent: true, connect: true, footer: true }]);
+	});
+});
+
+describe('createPositronWelcomePage', () => {
+	const renderInto = (container: HTMLElement) => {
+		const recentList = document.createElement('div');
+		recentList.textContent = 'Recent';
+		const footer = document.createElement('div');
+
+		return createPositronWelcomePage(container, { recentList, footer, onDidMount: vi.fn() });
+	};
+
+	it('makes the container the page layout element', () => {
+		const container = document.createElement('div');
+		const renderer = renderInto(container);
+
+		// The page renders a fragment, so this class is what the CSS hangs off.
+		expect(container).toHaveClass('positron-welcome-page');
+
+		renderer.dispose();
+	});
+
+	it('unmounts the page when the renderer is disposed', async () => {
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		const renderer = renderInto(container);
+
+		expect(await screen.findByText('Recent')).toBeInTheDocument();
+
+		renderer.dispose();
+
+		// The editor pane disposes this on every rebuild of the categories slide,
+		// so a stale page must not be left behind.
+		expect(screen.queryByText('Recent')).not.toBeInTheDocument();
+		container.remove();
+	});
+});

--- a/test/e2e/pages/welcome.ts
+++ b/test/e2e/pages/welcome.ts
@@ -19,7 +19,6 @@ const BUTTON_ROLE = 'button';
 const REDESIGNED_PAGE = '.positron-welcome-page';
 const CATEGORIES_SLIDE = '.gettingStartedSlideCategories';
 const DETAILS_SLIDE = '.gettingStartedSlideDetails';
-const GETTING_STARTED_CONTAINER = '.gettingStartedContainer';
 const STARTUP_CHECKBOX = '#showOnStartup';
 
 export class Welcome {
@@ -157,20 +156,24 @@ export class Welcome {
 	 * @param hidden Which slide should be unreachable.
 	 * @param tabPresses How far to walk the tab order.
 	 */
-	async expectTabToStayOutOf(hidden: 'welcome' | 'walkthrough', tabPresses = 8) {
-		await test.step(`Verify Tab does not reach the hidden ${hidden} slide`, async () => {
+	/**
+	 * Verifies the off-screen slide is inert, which is what keeps its focusable
+	 * content out of the tab order, and that the visible slide is not.
+	 *
+	 * Asserts the mechanism rather than walking the page with Tab. A counted walk
+	 * has to know how many tab stops the page has, and that number changes with
+	 * the recent list and between web and desktop; too low a count stops short of
+	 * the boundary and passes without testing anything.
+	 * @param hidden Which slide is currently parked off-screen.
+	 */
+	async expectHiddenSlideToBeInert(hidden: 'welcome' | 'walkthrough') {
+		await test.step(`Verify the off-screen ${hidden} slide is inert`, async () => {
 			const page = this.code.driver.currentPage;
 			const hiddenSlide = hidden === 'welcome' ? CATEGORIES_SLIDE : DETAILS_SLIDE;
+			const visibleSlide = hidden === 'welcome' ? DETAILS_SLIDE : CATEGORIES_SLIDE;
 
-			await page.locator(GETTING_STARTED_CONTAINER).focus();
-			for (let i = 0; i < tabPresses; i++) {
-				await page.keyboard.press('Tab');
-				const landedInHidden = await page.evaluate(
-					(selector) => !!document.activeElement?.closest(selector),
-					hiddenSlide
-				);
-				expect(landedInHidden, `Tab stop ${i + 1} landed in the off-screen ${hidden} slide`).toBe(false);
-			}
+			await expect(page.locator(hiddenSlide)).toHaveAttribute('inert');
+			await expect(page.locator(visibleSlide)).not.toHaveAttribute('inert');
 		});
 	}
 

--- a/test/e2e/pages/welcome.ts
+++ b/test/e2e/pages/welcome.ts
@@ -16,9 +16,11 @@ const RECENT_SECTION = '.recently-opened';
 const WALKTHROUGH_SECTION = '.getting-started';
 const HEADING_ROLE = 'heading';
 const BUTTON_ROLE = 'button';
+const REDESIGNED_PAGE = '.positron-welcome-page';
 const CATEGORIES_SLIDE = '.gettingStartedSlideCategories';
 const DETAILS_SLIDE = '.gettingStartedSlideDetails';
 const GETTING_STARTED_CONTAINER = '.gettingStartedContainer';
+const STARTUP_CHECKBOX = '#showOnStartup';
 
 export class Welcome {
 
@@ -40,6 +42,8 @@ export class Welcome {
 	get openFolderButton(): Locator { return this.startButtons.getByText('Open Folder'); }
 	get walkthroughSection(): Locator { return this.code.driver.currentPage.locator(WALKTHROUGH_SECTION); }
 	get walkthroughButtons(): Locator { return this.walkthroughSection.getByRole(BUTTON_ROLE); }
+	get redesignedPage(): Locator { return this.code.driver.currentPage.locator(REDESIGNED_PAGE); }
+	get startupCheckbox(): Locator { return this.code.driver.currentPage.locator(STARTUP_CHECKBOX); }
 
 	constructor(private code: Code) { }
 
@@ -127,6 +131,22 @@ export class Welcome {
 	}
 
 	/**
+	 * Verify the redesigned welcome page renders. Only shows when the
+	 * `welcomePage.experimental` setting is on.
+	 */
+	async expectRedesignedPageToBeVisible() {
+		await test.step('Verify redesigned welcome page is visible', async () => {
+			await expect(this.redesignedPage).toBeVisible();
+		});
+	}
+
+	async expectStartupCheckboxToBeVisible() {
+		await test.step('Verify "Show welcome page on startup" checkbox is visible', async () => {
+			await expect(this.startupCheckbox).toBeVisible();
+		});
+	}
+
+	/**
 	 * Verify Tab never reaches the slide that is currently off-screen.
 	 *
 	 * The welcome page and the walkthrough sit side by side in one editor, and
@@ -153,4 +173,5 @@ export class Welcome {
 			}
 		});
 	}
+
 }

--- a/test/e2e/pages/welcome.ts
+++ b/test/e2e/pages/welcome.ts
@@ -146,17 +146,6 @@ export class Welcome {
 	}
 
 	/**
-	 * Verify Tab never reaches the slide that is currently off-screen.
-	 *
-	 * The welcome page and the walkthrough sit side by side in one editor, and
-	 * whichever is hidden is moved off-screen rather than hidden with
-	 * `display: none`. If it stays in the tab order, focus lands somewhere the
-	 * user cannot see, and the browser scrolls it into view, dragging the
-	 * visible slide sideways.
-	 * @param hidden Which slide should be unreachable.
-	 * @param tabPresses How far to walk the tab order.
-	 */
-	/**
 	 * Verifies the off-screen slide is inert, which is what keeps its focusable
 	 * content out of the tab order, and that the visible slide is not.
 	 *

--- a/test/e2e/tests/welcome/welcome-redesign.test.ts
+++ b/test/e2e/tests/welcome/welcome-redesign.test.ts
@@ -49,6 +49,21 @@ async function openWalkthrough(app: Application, runCommand: RunCommand) {
  *
  * Kept separate from welcome.test.ts so the two never share an app: the tests
  * there assert the original page, which only renders with the setting off.
+ *
+ * When the setting becomes the default, these tests move into welcome.test.ts's
+ * `Workspace` describe, whose `beforeEach` already matches this one. The
+ * `beforeApp` wrapper above and this describe stay behind and go with the file.
+ *
+ * | Delete from welcome.test.ts | Replaced by |
+ * |---|---|
+ * | Verify page header, footer, content (Workspace) | Verify redesigned page renders... |
+ * | Verify Tab does not reach the welcome page while a walkthrough is open | the test of the same name here |
+ * | Verify limited walkthroughs on Welcome page and full list in `More...` | nothing: the redesigned page has no walkthrough list, only a link to the quick pick |
+ *
+ * Two groups have no replacement yet, because the redesigned page has no Start
+ * section: the four Python and R `new notebook` / `new file` tests, and the whole
+ * `No Workspace` describe, which drives Open Folder, New Folder and New from Git.
+ * Those need redesigned equivalents before the setting can flip.
  */
 test.describe('Redesigned Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () => {
 
@@ -78,7 +93,7 @@ test.describe('Redesigned Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () =
 		await welcome.expectRedesignedPageToBeVisible();
 		await openWalkthrough(app, runCommand);
 
-		await welcome.expectTabToStayOutOf('welcome');
+		await welcome.expectHiddenSlideToBeInert('welcome');
 	});
 
 	test('Verify Tab does not reach a walkthrough opened earlier, which would shift the page', async function ({ app, hotKeys, runCommand }) {
@@ -93,7 +108,7 @@ test.describe('Redesigned Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () =
 		await welcome.expectRedesignedPageToBeVisible();
 
 		// Tabbing into it would scroll it into view and slide the welcome page
-		// off the left edge. 18 presses clears the whole page, checkbox included.
-		await welcome.expectTabToStayOutOf('walkthrough', 18);
+		// off the left edge.
+		await welcome.expectHiddenSlideToBeInert('walkthrough');
 	});
 });

--- a/test/e2e/tests/welcome/welcome-redesign.test.ts
+++ b/test/e2e/tests/welcome/welcome-redesign.test.ts
@@ -57,8 +57,11 @@ async function openWalkthrough(app: Application, runCommand: RunCommand) {
  * | Delete from welcome.test.ts | Replaced by |
  * |---|---|
  * | Verify page header, footer, content (Workspace) | Verify redesigned page renders... |
- * | Verify Tab does not reach the welcome page while a walkthrough is open | the test of the same name here |
  * | Verify limited walkthroughs on Welcome page and full list in `More...` | nothing: the redesigned page has no walkthrough list, only a link to the quick pick |
+ *
+ * The two tab-order tests here have no counterpart to delete. They cover
+ * setSlideInert, which belongs to the editor pane rather than to either page, so
+ * one copy is enough and it lives with these tests.
  *
  * Two groups have no replacement yet, because the redesigned page has no Start
  * section: the four Python and R `new notebook` / `new file` tests, and the whole

--- a/test/e2e/tests/welcome/welcome-redesign.test.ts
+++ b/test/e2e/tests/welcome/welcome-redesign.test.ts
@@ -1,0 +1,99 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Application } from '../../infra';
+import { test as base, tags } from '../_test.setup';
+
+/**
+ * Turn the setting on before the app launches, rather than through the settings
+ * editor once it is running. `settingsFile` backs the file up and restores it at
+ * worker teardown, so the setting cannot leak into another suite sharing this
+ * worker, and the app never has to reload to pick it up.
+ */
+const test = base.extend<object, { beforeApp: void }>({
+	beforeApp: [async ({ settingsFile }, use) => {
+		await settingsFile.append({ 'welcomePage.experimental': true });
+		await use();
+	}, { scope: 'worker' }],
+});
+
+test.use({
+	suiteId: __filename
+});
+
+type RunCommand = (commandId: string, options?: { keepOpen?: boolean; exactLabelMatch?: boolean }) => Promise<void>;
+
+/**
+ * Open a walkthrough from the command palette, which switches the editor to the
+ * details slide and leaves the welcome page off-screen behind it.
+ *
+ * `keepOpen` stops runCommand from re-clicking until the picker closes: this
+ * command opens a second picker of its own, and that retry loop would dismiss it
+ * before the test could use it. Filter before selecting, because the list is
+ * virtualized and an unfiltered match can sit in the DOM scrolled out of view
+ * where it cannot be clicked.
+ */
+async function openWalkthrough(app: Application, runCommand: RunCommand) {
+	const { quickInput } = app.workbench;
+
+	await runCommand('welcome.showAllWalkthroughs', { keepOpen: true });
+	await quickInput.waitForQuickInputOpened({ timeout: 30000 });
+	await quickInput.type('Migrating from VSCode');
+	await quickInput.selectQuickInputElementContaining('Migrating from VSCode to Positron');
+}
+
+/**
+ * The redesigned welcome page, behind the `welcomePage.experimental` setting.
+ *
+ * Kept separate from welcome.test.ts so the two never share an app: the tests
+ * there assert the original page, which only renders with the setting off.
+ */
+test.describe('Redesigned Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () => {
+
+	test.beforeEach(async function ({ hotKeys, sessions }) {
+		await sessions.expectNoStartUpMessaging();
+		await hotKeys.openWelcomeWalkthrough();
+	});
+
+	test.afterEach(async function ({ hotKeys }) {
+		await hotKeys.closeAllEditors();
+	});
+
+	test('Verify redesigned page renders with the recent list, connect action and startup checkbox', async function ({ app }) {
+		const { welcome } = app.workbench;
+
+		await welcome.expectRedesignedPageToBeVisible();
+		await welcome.expectRecentToBeVisible();
+		await welcome.expectStartupCheckboxToBeVisible();
+		app.web
+			? await welcome.expectConnectToBeVisible(false)
+			: await welcome.expectConnectToBeVisible(true);
+	});
+
+	test('Verify Tab does not reach the welcome page while a walkthrough is open', async function ({ app, runCommand }) {
+		const { welcome } = app.workbench;
+
+		await welcome.expectRedesignedPageToBeVisible();
+		await openWalkthrough(app, runCommand);
+
+		await welcome.expectTabToStayOutOf('welcome');
+	});
+
+	test('Verify Tab does not reach a walkthrough opened earlier, which would shift the page', async function ({ app, hotKeys, runCommand }) {
+		const { welcome } = app.workbench;
+
+		await welcome.expectRedesignedPageToBeVisible();
+
+		// Give the walkthrough slide real content, then come back. Its steps stay
+		// in the DOM, parked off-screen to the right of the welcome page.
+		await openWalkthrough(app, runCommand);
+		await hotKeys.openWelcomeWalkthrough();
+		await welcome.expectRedesignedPageToBeVisible();
+
+		// Tabbing into it would scroll it into view and slide the welcome page
+		// off the left edge. 18 presses clears the whole page, checkbox included.
+		await welcome.expectTabToStayOutOf('walkthrough', 18);
+	});
+});

--- a/test/e2e/tests/welcome/welcome.test.ts
+++ b/test/e2e/tests/welcome/welcome.test.ts
@@ -79,20 +79,7 @@ test.describe('Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () => {
 			const { welcome } = app.workbench;
 
 			await openWalkthrough(app, runCommand);
-			await welcome.expectTabToStayOutOf('welcome');
-		});
-
-		test('Verify Tab does not reach a walkthrough after returning to the welcome page', async function ({ app, hotKeys, runCommand }) {
-			const { welcome } = app.workbench;
-
-			// The walkthrough's steps stay in the DOM after we come back, parked
-			// off-screen to the right. Tabbing into one scrolls it into view and
-			// slides the welcome page off the left edge.
-			await openWalkthrough(app, runCommand);
-			await hotKeys.openWelcomeWalkthrough();
-			await welcome.expectRecentToBeVisible();
-
-			await welcome.expectTabToStayOutOf('walkthrough', 30);
+			await welcome.expectHiddenSlideToBeInert('welcome');
 		});
 
 		test('Python - Verify clicking on `new notebook` from the Welcome page opens notebook and sets kernel', async function ({ app, python }) {

--- a/test/e2e/tests/welcome/welcome.test.ts
+++ b/test/e2e/tests/welcome/welcome.test.ts
@@ -3,32 +3,12 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Application, availableRuntimes } from '../../infra';
+import { availableRuntimes } from '../../infra';
 import { test, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
-
-type RunCommand = (commandId: string, options?: { keepOpen?: boolean; exactLabelMatch?: boolean }) => Promise<void>;
-
-/**
- * Open a walkthrough from the command palette, which switches the editor to the
- * details slide and leaves the welcome page off-screen behind it.
- *
- * `keepOpen` stops runCommand from re-clicking until the picker closes: this
- * command opens a second picker of its own, and that retry loop would dismiss it
- * before the test could use it. Filter before selecting, because the list is
- * virtualized and an unfiltered match can sit in the DOM scrolled out of view.
- */
-async function openWalkthrough(app: Application, runCommand: RunCommand) {
-	const { quickInput } = app.workbench;
-
-	await runCommand('welcome.showAllWalkthroughs', { keepOpen: true });
-	await quickInput.waitForQuickInputOpened({ timeout: 30000 });
-	await quickInput.type('Migrating from VSCode');
-	await quickInput.selectQuickInputElementContaining('Migrating from VSCode to Positron');
-}
 
 test.describe('Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () => {
 	test.afterEach(async function ({ hotKeys }) {
@@ -73,13 +53,6 @@ test.describe('Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () => {
 				'Get Started with Posit Publisher',
 				'Jupyter Notebooks in Positron'
 			]);
-		});
-
-		test('Verify Tab does not reach the welcome page while a walkthrough is open', async function ({ app, runCommand }) {
-			const { welcome } = app.workbench;
-
-			await openWalkthrough(app, runCommand);
-			await welcome.expectHiddenSlideToBeInert('welcome');
 		});
 
 		test('Python - Verify clicking on `new notebook` from the Welcome page opens notebook and sets kernel', async function ({ app, python }) {


### PR DESCRIPTION
Addresses #14934

This PR creates the scaffolding for the new welcome page and adds a `welcomePage.experimental` feature flag that is not exposed in the settings pane. The redesign will land over several PRs which is why we need the flag.

The new welcome page is a stub for now that shows:
- placeholder text ("Hello world")
- "Recent" list
- "Connect to..." action
- "Show welcome page on startup" checkbox 

A quick primer on `gettingStarted.ts`:
- This file creates the editor that houses the welcome page contents AND the walkthrough contents. We want to keep the walkthrough functionality so instead of creating a new welcome page editor, we modify the existing one.
- The `buildExperimentalWelcomePage` function returns a container when the flag is on and `undefined` when it is off. 
- The "Recent" list, "Connect to..." action, and "Show welcome page on startup" checkbox DOM elements are created in `gettingStarted.ts`. We reuse the elements by handing them to React as already-built DOM instead of re-creating React component versions of them. This allows us to get the exact same behavior from the old welcome page for free.

### Screenshots

<img width="1448" height="950" alt="Screenshot 2026-08-05 at 4 58 41 PM" src="https://github.com/user-attachments/assets/0607b4df-388f-4b45-821e-a266da93830a" />

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

SETUP: build and launch Positron from this branch. The flag cannot be set from the Settings editor, so every step below edits user settings.json directly, via **Preferences: Open User Settings (JSON)**.

1. Search the Settings editor for `welcomePage.experimental`. **No result** -- the setting is hidden on purpose.
2. In settings.json, add `"welcomePage.experimental": true` and save. The welcome page rerenders as the new page **without a window reload**.
3. Click a recent folder, then **More...**, then **Connect to...**. All three behave as they do today.
4. In settings.json, change the value to `false` and save. The original welcome page comes back, again without a reload.
5. With the flag off, run **Welcome: Open Walkthrough...** and pick one. It opens in the welcome tab as before.

@:welcome
