### PR TITLE
e2e: pin the provisioned test-files workspace to a main branch

### DIFF
--- a/test/e2e/infra/test-runner/utils.ts
+++ b/test/e2e/infra/test-runner/utils.ts
@@ -42,7 +42,9 @@ export function provisionTestFiles(workspacePath = process.env.WORKSPACE_PATH ||
 	// Inline identity + disabled signing so CI hosts without global git config succeed.
 	try {
 		const git = (args: string) => cp.execSync(`git ${args}`, { cwd: workspacePath, stdio: 'pipe' });
-		git('init -q');
+		// Pin the branch name: it otherwise comes from init.defaultBranch, which is unset
+		// on CI runners, so release screenshots of the workspace show "master".
+		git('init -q -b main');
 		git('add -A');
 		git('-c user.email=e2e@posit.co -c user.name=e2e -c commit.gpgsign=false commit -q -m "test-files baseline"');
 	} catch (error) {


### PR DESCRIPTION
### Summary
This was a fallout due to moving qa content into Positron repo. The e2e test workspace is now created with `git init`, whose branch name comes from `init.defaultBranch` -- unset on CI runners, so it lands on `master`. That branch name is visible in the status bar of the published release screenshots ([positron-website#440](https://github.com/posit-dev/positron-website/pull/440#issuecomment-5205258659)).

- `provisionTestFiles` now runs `git init -q -b main`
- Restores the `main` the workspace had back when it was a clone of qa-example-content

### QA Notes
Confirmed locally that `-b main` wins even against a forced `init.defaultBranch=master`. 
Nightly screenshot run on this branch to confirm end-to-end: [test run](https://github.com/posit-dev/positron/actions/runs/31113712340)
