### PR TITLE
13402 improve collapsed console padding

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleCore.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleCore.tsx
@@ -24,7 +24,7 @@ import { VerticalSplitter, VerticalSplitterResizeParams } from '../../../../../b
 
 // Constants.
 const ACTION_BAR_HEIGHT = 28;
-const MINIMUM_CONSOLE_TAB_LIST_WIDTH = 64;
+const MINIMUM_CONSOLE_TAB_LIST_WIDTH = 60;
 const MINIMUM_CONSOLE_PANE_WIDTH = 120;
 
 // ConsoleCoreProps interface.

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.css
@@ -66,6 +66,16 @@
 
 	/* Grow input to fill available space */
 	flex: 1;
+
+	/*
+	 * An input has an intrinsic minimum width based on its `size` attribute,
+	 * which keeps it from shrinking below roughly 20 characters and pushes it
+	 * off the end of a narrow tab. `min-width` lets it shrink to fit instead.
+	 */
+	min-width: 0;
+
+	/* Keep the border and padding inside the space the tab allots the input */
+	box-sizing: border-box;
 }
 
 .tab-button .session-name-input:focus {

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.css
@@ -33,6 +33,9 @@
 	gap: 4px;
 	height: 22px;
 	width: 100%;
+
+	/* Positions the rename input against the right edge of the tab */
+	position: relative;
 }
 
 .tab-button:hover {
@@ -65,15 +68,24 @@
 	border: 1px solid var(--vscode-input-border);
 	color: var(--vscode-input-foreground);
 
-	/* Grow input to fill available space */
-	flex: 1;
+	/*
+	 * The input is taken out of the flex flow and pinned to the right edge of
+	 * the tab so that it stays put as it resizes. It's sized to the space left
+	 * over by the icons, but once that's narrower than the minimum it grows
+	 * leftward over them instead of shrinking to a sliver: `right` is what's
+	 * anchored, so `min-width` can only push the left edge further left.
+	 */
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	right: 0;
 
 	/*
-	 * An input has an intrinsic minimum width based on its `size` attribute,
-	 * which keeps it from shrinking below roughly 20 characters and pushes it
-	 * off the end of a narrow tab. `min-width` lets it shrink to fit instead.
+	 * 40px is the room the icons take up: two 16px icons, the gap between them,
+	 * and the gap that follows them.
 	 */
-	min-width: 0;
+	width: calc(100% - 40px);
+	min-width: 40px;
 
 	/* Keep the border and padding inside the space the tab allots the input */
 	box-sizing: border-box;
@@ -178,10 +190,10 @@
 /*
  * Hide CPU usage when it's even narrower (at its minimum width).
  *
- * The 64px value corresponds to the MINIMUM_CONSOLE_TAB_LIST_WIDTH, and should be
+ * The 60px value corresponds to the MINIMUM_CONSOLE_TAB_LIST_WIDTH, and should be
  * kept in sync with that constant.
  */
-@container (max-width: 64px) {
+@container (max-width: 60px) {
 	.tab-button .resource-usage-stats .resource-usage-cpu {
 		display: none;
 	}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.css
@@ -57,6 +57,7 @@
 	overflow: hidden;
 	min-width: 0;
 	text-overflow: ellipsis;
+	font-variant-numeric: tabular-nums;
 }
 
 .tab-button .session-name-input {

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.tsx
@@ -7,7 +7,7 @@
 import './consoleTab.css';
 
 // React.
-import React, { KeyboardEvent, MouseEvent, useEffect, useRef, useState } from 'react';
+import React, { KeyboardEvent, MouseEvent, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
@@ -22,7 +22,7 @@ import { isMacintosh } from '../../../../../base/common/platform.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { LanguageRuntimeSessionMode } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { RuntimeIcon } from './runtimeIcon.js';
-import { getSessionDisplayName } from '../../common/sessionDisplayUtils.js';
+import { getFittedSessionName, getSessionDisplayName } from '../../common/sessionDisplayUtils.js';
 import { ResourceUsageGraph } from './resourceUsageGraph.js';
 import { ResourceUsageStats } from './resourceUsageStats.js';
 import { useResourceUsageHistory } from './useResourceUsageHistory.js';
@@ -63,6 +63,7 @@ export const ConsoleTab = ({ positronConsoleInstance, width, onChangeSession }: 
 	const [sessionName, setSessionName] = useState(sessionDisplayName);
 	const resourceUsageHistory = useResourceUsageHistory(positronConsoleInstance);
 	const [consoleState, setConsoleState] = useState(positronConsoleInstance.state);
+	const [fittedSessionName, setFittedSessionName] = useState(sessionDisplayName);
 	const [showResourceMonitor, setShowResourceMonitor] = useState(
 		services.configurationService.getValue<boolean>('console.showResourceMonitor') ?? true
 	);
@@ -70,6 +71,7 @@ export const ConsoleTab = ({ positronConsoleInstance, width, onChangeSession }: 
 	// Refs
 	const tabRef = useRef<HTMLDivElement>(null);
 	const inputRef = React.useRef<HTMLInputElement>(null);
+	const sessionNameRef = useRef<HTMLParagraphElement>(null);
 
 	// Variables
 	const isActiveTab = positronConsoleContext.activePositronConsoleInstance?.sessionMetadata.sessionId === positronConsoleInstance.sessionId;
@@ -132,6 +134,39 @@ export const ConsoleTab = ({ positronConsoleInstance, width, onChangeSession }: 
 			disposableStore.dispose();
 		};
 	}, [services.configurationService, services.runtimeSessionService, positronConsoleInstance]);
+
+	// Fit the session name to the space the tab has for it, dropping trailing
+	// words as the tab narrows. This runs in a layout effect so that the
+	// measurement happens after the tab has been laid out at its new width, but
+	// before the browser paints.
+	useLayoutEffect(() => {
+		const sessionNameElement = sessionNameRef.current;
+		if (!sessionNameElement) {
+			return;
+		}
+
+		// Candidate names are measured in a hidden element inside the session
+		// name element so that they're measured in the font that will render
+		// them. It's positioned absolutely so that it takes no part in layout.
+		const measureElement = sessionNameElement.ownerDocument.createElement('span');
+		measureElement.style.position = 'absolute';
+		measureElement.style.visibility = 'hidden';
+		measureElement.style.whiteSpace = 'pre';
+		sessionNameElement.appendChild(measureElement);
+
+		try {
+			// The session name element is a flex item with a basis of zero, so
+			// its width is the space left over by the icons and the delete
+			// button, regardless of the name currently rendered in it.
+			const availableWidth = sessionNameElement.getBoundingClientRect().width;
+			setFittedSessionName(getFittedSessionName(sessionName, availableWidth, text => {
+				measureElement.textContent = text;
+				return measureElement.getBoundingClientRect().width;
+			}));
+		} finally {
+			measureElement.remove();
+		}
+	}, [width, sessionName, isRenamingSession]);
 
 	// When entering rename mode, focus the input and select its text.
 	useEffect(() => {
@@ -456,7 +491,7 @@ export const ConsoleTab = ({ positronConsoleInstance, width, onChangeSession }: 
 					/>
 				) : (
 					<>
-						<p className='session-name'>{sessionName}</p>
+						<p ref={sessionNameRef} className='session-name'>{fittedSessionName}</p>
 						{/* Show the delete button only if the width of the tab is greater than the minimum width */
 							width > MINIMUM_ACTION_CONSOLE_TAB_WIDTH &&
 							<button

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.tsx
@@ -18,6 +18,7 @@ import { usePositronConsoleContext } from '../positronConsoleContext.js';
 import { IPositronConsoleInstance, PositronConsoleState } from '../../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
 import { IAction } from '../../../../../base/common/actions.js';
 import { AnchorAlignment, AnchorAxisAlignment } from '../../../../../base/browser/ui/contextview/contextview.js';
+import { HoverPosition } from '../../../../../base/browser/ui/hover/hoverWidget.js';
 import { isMacintosh } from '../../../../../base/common/platform.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { LanguageRuntimeSessionMode } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
@@ -74,6 +75,7 @@ export const ConsoleTab = ({ positronConsoleInstance, width, hideSessionName, on
 	const tabRef = useRef<HTMLDivElement>(null);
 	const inputRef = React.useRef<HTMLInputElement>(null);
 	const sessionNameRef = useRef<HTMLParagraphElement>(null);
+	const tooltipRef = useRef('');
 
 	// Variables
 	const isActiveTab = positronConsoleContext.activePositronConsoleInstance?.sessionMetadata.sessionId === positronConsoleInstance.sessionId;
@@ -180,6 +182,36 @@ export const ConsoleTab = ({ positronConsoleInstance, width, hideSessionName, on
 	useEffect(() => {
 		return () => onSessionNameHiddenChange(positronConsoleInstance.sessionId, false);
 	}, [onSessionNameHiddenChange, positronConsoleInstance.sessionId]);
+
+	// The tooltip content: the full session name, but only while the tab is
+	// showing less than all of it. A tooltip repeating a name that's already
+	// fully legible is just noise. Renaming shows the whole name in an input, so
+	// there's nothing to reveal then either.
+	useEffect(() => {
+		const nameIsCutShort = hideSessionName || fittedSessionName !== sessionName;
+		tooltipRef.current = nameIsCutShort && !isRenamingSession ? sessionName : '';
+	}, [hideSessionName, fittedSessionName, sessionName, isRenamingSession]);
+
+	// Show the full session name on hover. The hover targets the whole tab
+	// rather than the name element, because the case that most needs a tooltip
+	// is the one where the name has been squeezed out entirely and there is no
+	// name left to hover over. Reading the content from a ref keeps this
+	// registered once, instead of being torn down and rebuilt as the tab
+	// resizes.
+	useEffect(() => {
+		const tabElement = tabRef.current;
+		if (!tabElement) {
+			return;
+		}
+
+		const hover = services.hoverService.setupDelayedHover(tabElement, () => ({
+			content: tooltipRef.current,
+			target: tabElement,
+			position: { hoverPosition: HoverPosition.BELOW },
+			appearance: { showPointer: true }
+		}));
+		return () => hover.dispose();
+	}, [services.hoverService]);
 
 	// When entering rename mode, focus the input and select its text.
 	useEffect(() => {

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.tsx
@@ -42,10 +42,12 @@ const RESOURCE_GRAPH_HEIGHT = 24;
 interface ConsoleTabProps {
 	readonly positronConsoleInstance: IPositronConsoleInstance;
 	readonly width: number; // The width of the console tab list.
+	readonly hideSessionName: boolean; // Set when any tab has no room for its name.
+	readonly onSessionNameHiddenChange: (sessionId: string, hidden: boolean) => void;
 	readonly onChangeSession: (instance: IPositronConsoleInstance) => void;
 }
 
-export const ConsoleTab = ({ positronConsoleInstance, width, onChangeSession }: ConsoleTabProps) => {
+export const ConsoleTab = ({ positronConsoleInstance, width, hideSessionName, onSessionNameHiddenChange, onChangeSession }: ConsoleTabProps) => {
 
 	// Context
 	const services = usePositronReactServicesContext();
@@ -135,10 +137,10 @@ export const ConsoleTab = ({ positronConsoleInstance, width, onChangeSession }: 
 		};
 	}, [services.configurationService, services.runtimeSessionService, positronConsoleInstance]);
 
-	// Fit the session name to the space the tab has for it, dropping trailing
-	// words as the tab narrows. This runs in a layout effect so that the
-	// measurement happens after the tab has been laid out at its new width, but
-	// before the browser paints.
+	// Fit the session name to the space the tab has for it, ellipsizing it as the
+	// tab narrows. This runs in a layout effect so that the measurement happens
+	// after the tab has been laid out at its new width, but before the browser
+	// paints.
 	useLayoutEffect(() => {
 		const sessionNameElement = sessionNameRef.current;
 		if (!sessionNameElement) {
@@ -159,14 +161,25 @@ export const ConsoleTab = ({ positronConsoleInstance, width, onChangeSession }: 
 			// its width is the space left over by the icons and the delete
 			// button, regardless of the name currently rendered in it.
 			const availableWidth = sessionNameElement.getBoundingClientRect().width;
-			setFittedSessionName(getFittedSessionName(sessionName, availableWidth, text => {
+			const fittedName = getFittedSessionName(sessionName, availableWidth, text => {
 				measureElement.textContent = text;
 				return measureElement.getBoundingClientRect().width;
-			}));
+			});
+			setFittedSessionName(fittedName);
+
+			// Report a name with no room left, so that the tab list can hide the
+			// names on the other tabs too rather than showing a ragged mix of
+			// named and unnamed tabs.
+			onSessionNameHiddenChange(positronConsoleInstance.sessionId, fittedName.length === 0);
 		} finally {
 			measureElement.remove();
 		}
-	}, [width, sessionName, isRenamingSession]);
+	}, [width, sessionName, isRenamingSession, onSessionNameHiddenChange, positronConsoleInstance.sessionId]);
+
+	// Stop counting this tab's name once the tab goes away.
+	useEffect(() => {
+		return () => onSessionNameHiddenChange(positronConsoleInstance.sessionId, false);
+	}, [onSessionNameHiddenChange, positronConsoleInstance.sessionId]);
 
 	// When entering rename mode, focus the input and select its text.
 	useEffect(() => {
@@ -491,7 +504,7 @@ export const ConsoleTab = ({ positronConsoleInstance, width, onChangeSession }: 
 					/>
 				) : (
 					<>
-						<p ref={sessionNameRef} className='session-name'>{fittedSessionName}</p>
+						<p ref={sessionNameRef} className='session-name'>{hideSessionName ? '' : fittedSessionName}</p>
 						{/* Show the delete button only if the width of the tab is greater than the minimum width */
 							width > MINIMUM_ACTION_CONSOLE_TAB_WIDTH &&
 							<button

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.tsx
@@ -12,13 +12,13 @@ import React, { KeyboardEvent, MouseEvent, useEffect, useLayoutEffect, useRef, u
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { IHoverManager } from '../../../../../platform/hover/browser/hoverManager.js';
 import { IConfigurationChangeEvent } from '../../../../../platform/configuration/common/configuration.js';
 import { ConsoleSessionStatusIcon } from './consoleSessionStatusIcon.js';
 import { usePositronConsoleContext } from '../positronConsoleContext.js';
 import { IPositronConsoleInstance, PositronConsoleState } from '../../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
 import { IAction } from '../../../../../base/common/actions.js';
 import { AnchorAlignment, AnchorAxisAlignment } from '../../../../../base/browser/ui/contextview/contextview.js';
-import { HoverPosition } from '../../../../../base/browser/ui/hover/hoverWidget.js';
 import { isMacintosh } from '../../../../../base/common/platform.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { LanguageRuntimeSessionMode } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
@@ -44,11 +44,12 @@ interface ConsoleTabProps {
 	readonly positronConsoleInstance: IPositronConsoleInstance;
 	readonly width: number; // The width of the console tab list.
 	readonly hideSessionName: boolean; // Set when any tab has no room for its name.
+	readonly hoverManager: IHoverManager | undefined; // Shared by every tab in the list.
 	readonly onSessionNameHiddenChange: (sessionId: string, hidden: boolean) => void;
 	readonly onChangeSession: (instance: IPositronConsoleInstance) => void;
 }
 
-export const ConsoleTab = ({ positronConsoleInstance, width, hideSessionName, onSessionNameHiddenChange, onChangeSession }: ConsoleTabProps) => {
+export const ConsoleTab = ({ positronConsoleInstance, width, hideSessionName, hoverManager, onSessionNameHiddenChange, onChangeSession }: ConsoleTabProps) => {
 
 	// Context
 	const services = usePositronReactServicesContext();
@@ -67,6 +68,7 @@ export const ConsoleTab = ({ positronConsoleInstance, width, hideSessionName, on
 	const resourceUsageHistory = useResourceUsageHistory(positronConsoleInstance);
 	const [consoleState, setConsoleState] = useState(positronConsoleInstance.state);
 	const [fittedSessionName, setFittedSessionName] = useState(sessionDisplayName);
+	const [mouseInside, setMouseInside] = useState(false);
 	const [showResourceMonitor, setShowResourceMonitor] = useState(
 		services.configurationService.getValue<boolean>('console.showResourceMonitor') ?? true
 	);
@@ -75,7 +77,6 @@ export const ConsoleTab = ({ positronConsoleInstance, width, hideSessionName, on
 	const tabRef = useRef<HTMLDivElement>(null);
 	const inputRef = React.useRef<HTMLInputElement>(null);
 	const sessionNameRef = useRef<HTMLParagraphElement>(null);
-	const tooltipRef = useRef('');
 
 	// Variables
 	const isActiveTab = positronConsoleContext.activePositronConsoleInstance?.sessionMetadata.sessionId === positronConsoleInstance.sessionId;
@@ -183,35 +184,25 @@ export const ConsoleTab = ({ positronConsoleInstance, width, hideSessionName, on
 		return () => onSessionNameHiddenChange(positronConsoleInstance.sessionId, false);
 	}, [onSessionNameHiddenChange, positronConsoleInstance.sessionId]);
 
-	// The tooltip content: the full session name, but only while the tab is
-	// showing less than all of it. A tooltip repeating a name that's already
-	// fully legible is just noise. Renaming shows the whole name in an input, so
+	// Show the full session name on hover, but only while the tab is showing
+	// less than all of it. A tooltip repeating a name that's already fully
+	// legible is just noise, and renaming shows the whole name in an input, so
 	// there's nothing to reveal then either.
-	useEffect(() => {
-		const nameIsCutShort = hideSessionName || fittedSessionName !== sessionName;
-		tooltipRef.current = nameIsCutShort && !isRenamingSession ? sessionName : '';
-	}, [hideSessionName, fittedSessionName, sessionName, isRenamingSession]);
+	//
+	// The hover targets the whole tab rather than the name element, because the
+	// case that most needs a tooltip is the one where the name has been squeezed
+	// out entirely and there is no name left to hover over.
+	const nameIsCutShort = hideSessionName || fittedSessionName !== sessionName;
+	const tooltip = nameIsCutShort && !isRenamingSession ? sessionName : undefined;
 
-	// Show the full session name on hover. The hover targets the whole tab
-	// rather than the name element, because the case that most needs a tooltip
-	// is the one where the name has been squeezed out entirely and there is no
-	// name left to hover over. Reading the content from a ref keeps this
-	// registered once, instead of being torn down and rebuilt as the tab
-	// resizes.
+	// Re-runs when the tooltip changes as well as when the mouse moves in, so a
+	// name that gets cut short while the pointer is already on the tab updates
+	// the hover in place.
 	useEffect(() => {
-		const tabElement = tabRef.current;
-		if (!tabElement) {
-			return;
+		if (mouseInside) {
+			hoverManager?.showHover(tabRef.current!, tooltip);
 		}
-
-		const hover = services.hoverService.setupDelayedHover(tabElement, () => ({
-			content: tooltipRef.current,
-			target: tabElement,
-			position: { hoverPosition: HoverPosition.BELOW },
-			appearance: { showPointer: true }
-		}));
-		return () => hover.dispose();
-	}, [services.hoverService]);
+	}, [mouseInside, hoverManager, tooltip]);
 
 	// When entering rename mode, focus the input and select its text.
 	useEffect(() => {
@@ -228,6 +219,9 @@ export const ConsoleTab = ({ positronConsoleInstance, width, hideSessionName, on
 	const handleClick = (e: MouseEvent<HTMLDivElement>) => {
 		// Prevent the console from stealing focus from the tab element
 		e.stopPropagation();
+
+		// Don't leave the hover sitting over the tab the user just acted on.
+		hoverManager?.hideHover();
 
 		// Change the active console instance if clicking a different tab
 		if (!isActiveTab) {
@@ -260,9 +254,22 @@ export const ConsoleTab = ({ positronConsoleInstance, width, hideSessionName, on
 			// Show the context menu when the user right-clicks on a tab or
 			// when the user executes ctrl + left-click on macOS
 			if ((e.button === 0 && isMacintosh && e.ctrlKey) || e.button === 2) {
+				// Get the hover out of the way of the menu.
+				hoverManager?.hideHover();
 				showContextMenu(e.clientX, e.clientY);
 			}
 		};
+
+	/**
+	 * Tracks whether the pointer is over the tab, which drives the hover. React's
+	 * onMouseEnter / onMouseLeave map to mouseenter / mouseleave, which don't
+	 * bubble, so moving between the tab's children doesn't re-trigger them.
+	 */
+	const handleMouseEnter = () => setMouseInside(true);
+	const handleMouseLeave = () => {
+		setMouseInside(false);
+		hoverManager?.hideHover();
+	};
 
 	/**
 	 * Shows the context menu when a user right-clicks on a console instance tab.
@@ -513,6 +520,8 @@ export const ConsoleTab = ({ positronConsoleInstance, width, hideSessionName, on
 			tabIndex={isActiveTab ? 0 : -1}
 			onClick={handleClick}
 			onMouseDown={handleMouseDown}
+			onMouseEnter={handleMouseEnter}
+			onMouseLeave={handleMouseLeave}
 		>
 			{/* Header row with session info */}
 			<div className='tab-header show-file-icons'>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.tsx
@@ -512,7 +512,12 @@ export const ConsoleTab = ({ positronConsoleInstance, width, hideSessionName, ho
 		<div
 			ref={tabRef}
 			aria-controls={`console-panel-${positronConsoleInstance.sessionMetadata.sessionId}`}
-			aria-label={positronConsoleInstance.sessionName}
+			// The displayed name rather than the raw one off the instance: for a
+			// notebook session those differ (the tab shows the notebook's
+			// filename), and the accessible name should be what the tab reads
+			// as. It's also the full name, which the rendered one may not be
+			// once it has been ellipsized to fit.
+			aria-label={sessionName}
 			aria-selected={positronConsoleContext.activePositronConsoleInstance?.sessionMetadata.sessionId === positronConsoleInstance.sessionId}
 			className={`tab-button ${positronConsoleContext.activePositronConsoleInstance?.sessionMetadata.sessionId === positronConsoleInstance.sessionId && 'tab-button--active'}`}
 			data-testid={`console-tab-${positronConsoleInstance.sessionMetadata.sessionId}`}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.tsx
@@ -7,7 +7,7 @@
 import './consoleTabList.css';
 
 // React.
-import React, { useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 // Other dependencies.
 import { ConsoleTab } from './consoleTab.js';
@@ -27,6 +27,26 @@ export const ConsoleTabList = (props: ConsoleTabListProps) => {
 	const positronConsoleTabFocusedContextKey = PositronConsoleTabFocused.bindTo(services.contextKeyService);
 
 	const tabListRef = useRef<HTMLDivElement>(null);
+
+	// The sessions whose tab has no room left for its name. Names are hidden on
+	// every tab as soon as one of them runs out of room, so that the list
+	// collapses to icons all at once instead of tab by tab.
+	const [sessionsWithHiddenName, setSessionsWithHiddenName] = useState<ReadonlySet<string>>(() => new Set());
+	const handleSessionNameHiddenChange = useCallback((sessionId: string, hidden: boolean) => {
+		setSessionsWithHiddenName(current => {
+			if (current.has(sessionId) === hidden) {
+				return current;
+			}
+			const updated = new Set(current);
+			if (hidden) {
+				updated.add(sessionId);
+			} else {
+				updated.delete(sessionId);
+			}
+			return updated;
+		});
+	}, []);
+	const hideSessionNames = sessionsWithHiddenName.size > 0;
 
 	// Sort console sessions by created time, oldest to newest
 	const consoleInstances = Array.from(positronConsoleContext.positronConsoleInstances.values()).sort((a, b) => {
@@ -162,9 +182,11 @@ export const ConsoleTabList = (props: ConsoleTabListProps) => {
 			{consoleInstances.map((positronConsoleInstance) =>
 				<ConsoleTab
 					key={positronConsoleInstance.sessionId}
+					hideSessionName={hideSessionNames}
 					positronConsoleInstance={positronConsoleInstance}
 					width={props.width}
 					onChangeSession={() => handleChangeForegroundSession(positronConsoleInstance.sessionId)}
+					onSessionNameHiddenChange={handleSessionNameHiddenChange}
 				/>
 			)}
 		</div>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.tsx
@@ -14,6 +14,9 @@ import { ConsoleTab } from './consoleTab.js';
 import { usePositronConsoleContext } from '../positronConsoleContext.js';
 import { PositronConsoleTabFocused } from '../../../../common/contextkeys.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { IHoverManager } from '../../../../../platform/hover/browser/hoverManager.js';
+import { PositronActionBarHoverManager } from '../../../../../platform/positronActionBar/browser/positronActionBarHoverManager.js';
 
 // ConsoleTabListProps interface.
 interface ConsoleTabListProps {
@@ -27,6 +30,21 @@ export const ConsoleTabList = (props: ConsoleTabListProps) => {
 	const positronConsoleTabFocusedContextKey = PositronConsoleTabFocused.bindTo(services.contextKeyService);
 
 	const tabListRef = useRef<HTMLDivElement>(null);
+
+	// One hover manager for the whole strip, mirroring how the action bar sets
+	// its own up in usePositronActionBarState. Sharing it across the tabs is
+	// what makes moving from one tab to the next show the next name instantly
+	// instead of waiting out the hover delay again.
+	const [hoverManager, setHoverManager] = useState<IHoverManager>();
+	useEffect(() => {
+		const disposableStore = new DisposableStore();
+		setHoverManager(disposableStore.add(new PositronActionBarHoverManager(
+			true,
+			services.configurationService,
+			services.hoverService
+		)));
+		return () => disposableStore.dispose();
+	}, [services.configurationService, services.hoverService]);
 
 	// The sessions whose tab has no room left for its name. Names are hidden on
 	// every tab as soon as one of them runs out of room, so that the list
@@ -183,6 +201,7 @@ export const ConsoleTabList = (props: ConsoleTabListProps) => {
 				<ConsoleTab
 					key={positronConsoleInstance.sessionId}
 					hideSessionName={hideSessionNames}
+					hoverManager={hoverManager}
 					positronConsoleInstance={positronConsoleInstance}
 					width={props.width}
 					onChangeSession={() => handleChangeForegroundSession(positronConsoleInstance.sessionId)}

--- a/src/vs/workbench/contrib/positronConsole/common/sessionDisplayUtils.ts
+++ b/src/vs/workbench/contrib/positronConsole/common/sessionDisplayUtils.ts
@@ -48,6 +48,42 @@ export function getSessionDisplayName(
 }
 
 /**
+ * Fits a session name into the given width by dropping trailing words until
+ * what remains fits, so that names collapse gracefully as a tab narrows:
+ * "Python 3.12.11 (Pyenv)" becomes "Python 3.12.11", then "Python", and
+ * finally an empty string when even the first word doesn't fit (leaving just
+ * the session icons).
+ *
+ * @param sessionName The full session name.
+ * @param availableWidth The width available to render the name, in pixels.
+ * @param measureWidth Measures the rendered width of a candidate name, in pixels.
+ * @returns The longest leading run of words that fits, or an empty string.
+ */
+export function getFittedSessionName(
+	sessionName: string,
+	availableWidth: number,
+	measureWidth: (text: string) => number,
+): string {
+	// The full name is always preferred, and is returned verbatim so that names
+	// which fit are never reformatted.
+	if (measureWidth(sessionName) <= availableWidth) {
+		return sessionName;
+	}
+
+	// Drop trailing words until what's left fits.
+	const words = sessionName.split(/\s+/).filter(word => word.length > 0);
+	for (let wordCount = words.length - 1; wordCount > 0; wordCount--) {
+		const candidate = words.slice(0, wordCount).join(' ');
+		if (measureWidth(candidate) <= availableWidth) {
+			return candidate;
+		}
+	}
+
+	// Not even the first word fits.
+	return '';
+}
+
+/**
  * The subset of session info needed to determine the session icon.
  */
 interface SessionIconInfo {

--- a/src/vs/workbench/contrib/positronConsole/common/sessionDisplayUtils.ts
+++ b/src/vs/workbench/contrib/positronConsole/common/sessionDisplayUtils.ts
@@ -48,16 +48,44 @@ export function getSessionDisplayName(
 }
 
 /**
- * Fits a session name into the given width by dropping trailing words until
- * what remains fits, so that names collapse gracefully as a tab narrows:
- * "Python 3.12.11 (Pyenv)" becomes "Python 3.12.11", then "Python", and
- * finally an empty string when even the first word doesn't fit (leaving just
- * the session icons).
+ * The character appended to an ellipsized session name.
+ */
+const ELLIPSIS = '\u2026';
+
+/**
+ * Whitespace or punctuation of any kind.
+ */
+const SEPARATOR = /[\s\p{P}]/u;
+
+/**
+ * Checks whether a character is one an ellipsized session name shouldn't be left
+ * ending on, so that a name reads "Python..." and "Some-word..." rather than
+ * "Python ..." and "Some-word-...".
+ */
+function isSeparator(character: string): boolean {
+	return SEPARATOR.test(character);
+}
+
+/**
+ * The fewest characters of a session name worth showing. Below this an
+ * ellipsized name says too little to be worth the space it takes.
+ */
+const MINIMUM_FITTED_LENGTH = 3;
+
+/**
+ * Fits a session name into the given width by ellipsizing it, so that names
+ * collapse gracefully as a tab narrows: "Python 3.12.11 (Pyenv)" becomes
+ * "Python 3.12.1...", then "Python 3...", then "Python...", and so on.
+ *
+ * The ellipsis never follows a space or punctuation: a name cut to "Python " or
+ * "Some-word-" has that separator trimmed first. Once fewer than
+ * MINIMUM_FITTED_LENGTH characters of the name would be left, an empty string is
+ * returned and the tab is left showing just the session icons.
  *
  * @param sessionName The full session name.
  * @param availableWidth The width available to render the name, in pixels.
  * @param measureWidth Measures the rendered width of a candidate name, in pixels.
- * @returns The longest leading run of words that fits, or an empty string.
+ * @returns The name, an ellipsized form of it, or an empty string.
  */
 export function getFittedSessionName(
 	sessionName: string,
@@ -65,21 +93,33 @@ export function getFittedSessionName(
 	measureWidth: (text: string) => number,
 ): string {
 	// The full name is always preferred, and is returned verbatim so that names
-	// which fit are never reformatted.
+	// which fit are never ellipsized or trimmed.
 	if (measureWidth(sessionName) <= availableWidth) {
 		return sessionName;
 	}
 
-	// Drop trailing words until what's left fits.
-	const words = sessionName.split(/\s+/).filter(word => word.length > 0);
-	for (let wordCount = words.length - 1; wordCount > 0; wordCount--) {
-		const candidate = words.slice(0, wordCount).join(' ');
+	let length = sessionName.length - 1;
+	while (length >= MINIMUM_FITTED_LENGTH) {
+		// Never leave the ellipsis sitting after a separator.
+		let end = length;
+		while (end > 0 && isSeparator(sessionName.charAt(end - 1))) {
+			end--;
+		}
+
+		if (end < MINIMUM_FITTED_LENGTH) {
+			break;
+		}
+
+		const candidate = sessionName.slice(0, end) + ELLIPSIS;
 		if (measureWidth(candidate) <= availableWidth) {
 			return candidate;
 		}
+
+		// Trimming may have shortened the name past the next length to try.
+		length = end - 1;
 	}
 
-	// Not even the first word fits.
+	// Too little of the name would be left to be worth showing.
 	return '';
 }
 

--- a/src/vs/workbench/contrib/positronConsole/common/sessionDisplayUtils.ts
+++ b/src/vs/workbench/contrib/positronConsole/common/sessionDisplayUtils.ts
@@ -67,10 +67,11 @@ function isSeparator(character: string): boolean {
 }
 
 /**
- * The fewest characters of a session name worth showing. Below this an
- * ellipsized name says too little to be worth the space it takes.
+ * The fewest characters of a session name worth showing. An ellipsized name is
+ * cut back to its first character; past that only the ellipsis itself would be
+ * left, which says nothing at all.
  */
-const MINIMUM_FITTED_LENGTH = 3;
+const MINIMUM_FITTED_LENGTH = 1;
 
 /**
  * Fits a session name into the given width by ellipsizing it, so that names
@@ -78,9 +79,9 @@ const MINIMUM_FITTED_LENGTH = 3;
  * "Python 3.12.1...", then "Python 3...", then "Python...", and so on.
  *
  * The ellipsis never follows a space or punctuation: a name cut to "Python " or
- * "Some-word-" has that separator trimmed first. Once fewer than
- * MINIMUM_FITTED_LENGTH characters of the name would be left, an empty string is
- * returned and the tab is left showing just the session icons.
+ * "Some-word-" has that separator trimmed first. The last thing shown is the
+ * first character and the ellipsis, "P..."; once even that would be clipped, an
+ * empty string is returned and the tab is left showing just the session icons.
  *
  * @param sessionName The full session name.
  * @param availableWidth The width available to render the name, in pixels.

--- a/src/vs/workbench/contrib/positronConsole/common/sessionDisplayUtils.ts
+++ b/src/vs/workbench/contrib/positronConsole/common/sessionDisplayUtils.ts
@@ -53,9 +53,12 @@ export function getSessionDisplayName(
 const ELLIPSIS = '\u2026';
 
 /**
- * Whitespace or punctuation of any kind.
+ * Whitespace, punctuation, or a symbol of any kind. Symbols count because the
+ * trim only ever runs where the name is cut, so the character it removes is
+ * always followed by the ellipsis: a trailing "|" or "+" reads as a connector
+ * left dangling rather than as part of the name.
  */
-const SEPARATOR = /[\s\p{P}]/u;
+const SEPARATOR = /[\s\p{P}\p{S}]/u;
 
 /**
  * Checks whether a character is one an ellipsized session name shouldn't be left

--- a/src/vs/workbench/contrib/positronConsole/test/browser/consoleTab.vitest.tsx
+++ b/src/vs/workbench/contrib/positronConsole/test/browser/consoleTab.vitest.tsx
@@ -10,6 +10,7 @@ import { userEvent } from '@testing-library/user-event';
 import { IAction } from '../../../../../base/common/actions.js';
 import { IContextMenuService } from '../../../../../platform/contextview/browser/contextView.js';
 import { IContextMenuDelegate } from '../../../../../base/browser/contextmenu.js';
+import { IDelayedHoverOptions } from '../../../../../base/browser/ui/hover/hover.js';
 import { ILanguageRuntimeMetadata, LanguageRuntimeSessionMode } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { IPositronConsoleService } from '../../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
 import { IResourceUsageHistoryService } from '../../../../services/positronConsole/browser/resourceUsageHistoryService.js';
@@ -22,40 +23,42 @@ import { ConsoleTab } from '../../browser/components/consoleTab.js';
 import { PositronConsoleContextProvider } from '../../browser/positronConsoleContext.js';
 
 describe('ConsoleTab', () => {
+	// One container for the whole file: the workbench preset registers global
+	// extension point handlers, which can only be set once per module instance.
+	const showContextMenu = vi.fn<(delegate: IContextMenuDelegate) => void>();
+
+	const ctx = createTestContainer()
+		.withReactServices()
+		.stub(IContextMenuService, { showContextMenu })
+		.stub(IResourceUsageHistoryService, { getHistory: async () => [] })
+		.build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
+
+	function addActiveConsoleInstance(sessionId: string, sessionName: string): TestPositronConsoleInstance {
+		const sessionMetadata: IRuntimeSessionMetadata = {
+			sessionId,
+			sessionMode: LanguageRuntimeSessionMode.Console,
+			notebookUri: undefined,
+			createdTimestamp: 0,
+			startReason: 'test',
+		};
+		// ConsoleTab/RuntimeIcon read base64EncodedIconSvg and languageId off runtimeMetadata.
+		const runtimeMetadata = stubInterface<ILanguageRuntimeMetadata>({
+			base64EncodedIconSvg: undefined,
+			languageId: 'python',
+		});
+		const instance = new TestPositronConsoleInstance(
+			sessionId,
+			sessionName,
+			sessionMetadata,
+			runtimeMetadata,
+		);
+		const consoleService = ctx.get(IPositronConsoleService) as TestPositronConsoleService;
+		consoleService.addTestConsoleInstance(instance);
+		return instance;
+	}
+
 	describe('rename session', () => {
-		const showContextMenu = vi.fn<(delegate: IContextMenuDelegate) => void>();
-
-		const ctx = createTestContainer()
-			.withReactServices()
-			.stub(IContextMenuService, { showContextMenu })
-			.stub(IResourceUsageHistoryService, { getHistory: async () => [] })
-			.build();
-		const rtl = setupRTLRenderer(() => ctx.reactServices);
-
-		function addActiveConsoleInstance(sessionId: string, sessionName: string): TestPositronConsoleInstance {
-			const sessionMetadata: IRuntimeSessionMetadata = {
-				sessionId,
-				sessionMode: LanguageRuntimeSessionMode.Console,
-				notebookUri: undefined,
-				createdTimestamp: 0,
-				startReason: 'test',
-			};
-			// ConsoleTab/RuntimeIcon read base64EncodedIconSvg and languageId off runtimeMetadata.
-			const runtimeMetadata = stubInterface<ILanguageRuntimeMetadata>({
-				base64EncodedIconSvg: undefined,
-				languageId: 'python',
-			});
-			const instance = new TestPositronConsoleInstance(
-				sessionId,
-				sessionName,
-				sessionMetadata,
-				runtimeMetadata,
-			);
-			const consoleService = ctx.get(IPositronConsoleService) as TestPositronConsoleService;
-			consoleService.addTestConsoleInstance(instance);
-			return instance;
-		}
-
 		async function openRenameInput(instance: TestPositronConsoleInstance, sessionName: string) {
 			const user = userEvent.setup();
 			rtl.render(
@@ -233,6 +236,57 @@ describe('ConsoleTab', () => {
 			expect(notify).toHaveBeenCalledOnce();
 			expect(screen.queryByRole('tab', { name: newName })).not.toBeInTheDocument();
 			expect(screen.getByRole('tab', { name: sessionName })).toBeInTheDocument();
+		});
+	});
+
+	describe('session name tooltip', () => {
+		/**
+		 * Renders a tab and returns the tooltip text the hover would show. The
+		 * component registers the hover once with a factory that resolves the
+		 * content at hover time, so the content is read by invoking the factory
+		 * rather than by hovering.
+		 */
+		function renderTabAndResolveTooltip(sessionId: string, sessionName: string, hideSessionName: boolean): string {
+			const instance = addActiveConsoleInstance(sessionId, sessionName);
+
+			// Spy rather than stub the hover service: the action bar hover
+			// manager calls hideHover() as it is disposed during RTL cleanup,
+			// so the real implementation has to stay in place.
+			const setupDelayedHover = vi.spyOn(ctx.reactServices.hoverService, 'setupDelayedHover');
+
+			rtl.render(
+				<PositronConsoleContextProvider>
+					<ConsoleTab
+						hideSessionName={hideSessionName}
+						positronConsoleInstance={instance}
+						width={200}
+						onChangeSession={() => { }}
+						onSessionNameHiddenChange={() => { }}
+					/>
+				</PositronConsoleContextProvider>
+			);
+
+			const [target, hoverOptions] = setupDelayedHover.mock.calls.at(-1)!;
+			expect(target).toBe(screen.getByRole('tab'));
+
+			// The component always passes a factory, never a static options object.
+			const content = (hoverOptions as () => IDelayedHoverOptions)().content;
+			return typeof content === 'string' ? content : '';
+		}
+
+		// jsdom reports every element as zero-width, so getFittedSessionName
+		// always finds the full name fits: the rendered name is never cut short
+		// on its own here. hideSessionName is a plain prop, so it drives the
+		// truncated case. Empty content is how IHoverService is told not to
+		// show a hover at all -- see HoverService._createHover.
+		it('offers the full session name when the tab has no room to show it', () => {
+			expect(renderTabAndResolveTooltip('tooltip-session-1', 'My Python Session', true))
+				.toBe('My Python Session');
+		});
+
+		it('offers no tooltip when the tab shows the whole session name', () => {
+			expect(renderTabAndResolveTooltip('tooltip-session-2', 'My Python Session', false))
+				.toBe('');
 		});
 	});
 });

--- a/src/vs/workbench/contrib/positronConsole/test/browser/consoleTab.vitest.tsx
+++ b/src/vs/workbench/contrib/positronConsole/test/browser/consoleTab.vitest.tsx
@@ -5,12 +5,12 @@
 
 /// <reference types="vitest/globals" />
 
-import { act, screen } from '@testing-library/react';
+import { act, fireEvent, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { IAction } from '../../../../../base/common/actions.js';
 import { IContextMenuService } from '../../../../../platform/contextview/browser/contextView.js';
 import { IContextMenuDelegate } from '../../../../../base/browser/contextmenu.js';
-import { IDelayedHoverOptions } from '../../../../../base/browser/ui/hover/hover.js';
+import { IHoverManager } from '../../../../../platform/hover/browser/hoverManager.js';
 import { ILanguageRuntimeMetadata, LanguageRuntimeSessionMode } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { IPositronConsoleService } from '../../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
 import { IResourceUsageHistoryService } from '../../../../services/positronConsole/browser/resourceUsageHistoryService.js';
@@ -26,6 +26,13 @@ describe('ConsoleTab', () => {
 	// One container for the whole file: the workbench preset registers global
 	// extension point handlers, which can only be set once per module instance.
 	const showContextMenu = vi.fn<(delegate: IContextMenuDelegate) => void>();
+
+	// The tab takes its hover manager as a prop (the tab list owns the one the
+	// whole strip shares), so the tests hand it a fake rather than reaching
+	// into IHoverService.
+	const showHover = vi.fn<IHoverManager['showHover']>();
+	const hideHover = vi.fn<IHoverManager['hideHover']>();
+	const hoverManager: IHoverManager = { showHover, hideHover };
 
 	const ctx = createTestContainer()
 		.withReactServices()
@@ -65,6 +72,7 @@ describe('ConsoleTab', () => {
 				<PositronConsoleContextProvider>
 					<ConsoleTab
 						hideSessionName={false}
+						hoverManager={hoverManager}
 						positronConsoleInstance={instance}
 						width={200}
 						onChangeSession={() => { }}
@@ -240,24 +248,13 @@ describe('ConsoleTab', () => {
 	});
 
 	describe('session name tooltip', () => {
-		/**
-		 * Renders a tab and returns the tooltip text the hover would show. The
-		 * component registers the hover once with a factory that resolves the
-		 * content at hover time, so the content is read by invoking the factory
-		 * rather than by hovering.
-		 */
-		function renderTabAndResolveTooltip(sessionId: string, sessionName: string, hideSessionName: boolean): string {
+		function renderTab(sessionId: string, sessionName: string, hideSessionName: boolean) {
 			const instance = addActiveConsoleInstance(sessionId, sessionName);
-
-			// Spy rather than stub the hover service: the action bar hover
-			// manager calls hideHover() as it is disposed during RTL cleanup,
-			// so the real implementation has to stay in place.
-			const setupDelayedHover = vi.spyOn(ctx.reactServices.hoverService, 'setupDelayedHover');
-
 			rtl.render(
 				<PositronConsoleContextProvider>
 					<ConsoleTab
 						hideSessionName={hideSessionName}
+						hoverManager={hoverManager}
 						positronConsoleInstance={instance}
 						width={200}
 						onChangeSession={() => { }}
@@ -265,28 +262,56 @@ describe('ConsoleTab', () => {
 					/>
 				</PositronConsoleContextProvider>
 			);
-
-			const [target, hoverOptions] = setupDelayedHover.mock.calls.at(-1)!;
-			expect(target).toBe(screen.getByRole('tab'));
-
-			// The component always passes a factory, never a static options object.
-			const content = (hoverOptions as () => IDelayedHoverOptions)().content;
-			return typeof content === 'string' ? content : '';
+			return { user: userEvent.setup(), tab: screen.getByRole('tab') };
 		}
 
 		// jsdom reports every element as zero-width, so getFittedSessionName
-		// always finds the full name fits: the rendered name is never cut short
-		// on its own here. hideSessionName is a plain prop, so it drives the
-		// truncated case. Empty content is how IHoverService is told not to
-		// show a hover at all -- see HoverService._createHover.
-		it('offers the full session name when the tab has no room to show it', () => {
-			expect(renderTabAndResolveTooltip('tooltip-session-1', 'My Python Session', true))
-				.toBe('My Python Session');
+		// always finds that the full name fits: the rendered name is never cut
+		// short on its own here. hideSessionName is a plain prop, so it drives
+		// the truncated case. Undefined content is how IHoverManager is told not
+		// to show a hover at all.
+		it('offers the full session name when the tab has no room to show it', async () => {
+			const { user, tab } = renderTab('tooltip-session-1', 'My Python Session', true);
+
+			await user.hover(tab);
+
+			expect(showHover).toHaveBeenCalledWith(tab, 'My Python Session');
 		});
 
-		it('offers no tooltip when the tab shows the whole session name', () => {
-			expect(renderTabAndResolveTooltip('tooltip-session-2', 'My Python Session', false))
-				.toBe('');
+		it('offers no tooltip when the tab shows the whole session name', async () => {
+			const { user, tab } = renderTab('tooltip-session-2', 'My Python Session', false);
+
+			await user.hover(tab);
+
+			expect(showHover).toHaveBeenCalledWith(tab, undefined);
+		});
+
+		// The hover must be driven by mouseenter, which doesn't bubble, and not
+		// by mouseover, which does: the tab wraps two icons, a resource graph
+		// and a delete button, so a bubbling trigger re-fires every time the
+		// pointer crosses between them and restarts the hover delay each time.
+		// fireEvent rather than user-event because the point is which single
+		// raw event reaches the tab.
+		it('ignores a mouseover bubbling up from inside the tab', () => {
+			const { tab } = renderTab('tooltip-session-3', 'My Python Session', true);
+
+			// A move from the tab onto its own delete button. relatedTarget is
+			// what makes it that rather than an arrival from outside the
+			// document, and it's what React reads to decide that the tab was
+			// never re-entered.
+			// eslint-disable-next-line testing-library/prefer-user-event -- userEvent.hover fires a whole pointer sequence; this test is about the single raw event a bubbling trigger would catch.
+			fireEvent.mouseOver(screen.getByTestId('trash-session'), { relatedTarget: tab });
+
+			expect(showHover).not.toHaveBeenCalled();
+		});
+
+		it('hides the hover when the pointer leaves the tab', async () => {
+			const { user, tab } = renderTab('tooltip-session-4', 'My Python Session', true);
+
+			await user.hover(tab);
+			await user.unhover(tab);
+
+			expect(hideHover).toHaveBeenCalled();
 		});
 	});
 });

--- a/src/vs/workbench/contrib/positronConsole/test/browser/consoleTab.vitest.tsx
+++ b/src/vs/workbench/contrib/positronConsole/test/browser/consoleTab.vitest.tsx
@@ -61,9 +61,11 @@ describe('ConsoleTab', () => {
 			rtl.render(
 				<PositronConsoleContextProvider>
 					<ConsoleTab
+						hideSessionName={false}
 						positronConsoleInstance={instance}
 						width={200}
 						onChangeSession={() => { }}
+						onSessionNameHiddenChange={() => { }}
 					/>
 				</PositronConsoleContextProvider>
 			);

--- a/src/vs/workbench/contrib/positronConsole/test/common/sessionDisplayUtils.vitest.ts
+++ b/src/vs/workbench/contrib/positronConsole/test/common/sessionDisplayUtils.vitest.ts
@@ -68,8 +68,9 @@ describe('getFittedSessionName', () => {
 		`);
 	});
 
-	it('trims a trailing separator so the ellipsis never follows punctuation', () => {
+	it('trims a trailing separator so the ellipsis never follows punctuation or a symbol', () => {
 		expect(getFittedSessionName('Some-word-thing', 110, measureWidth)).toBe('Some-word\u2026');
+		expect(getFittedSessionName('R 4.6.0 | x86', 100, measureWidth)).toBe('R 4.6.0\u2026');
 	});
 
 	it('returns an empty string when even the first character and the ellipsis will not fit', () => {

--- a/src/vs/workbench/contrib/positronConsole/test/common/sessionDisplayUtils.vitest.ts
+++ b/src/vs/workbench/contrib/positronConsole/test/common/sessionDisplayUtils.vitest.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { getFittedSessionName } from '../../common/sessionDisplayUtils.js';
+
+/**
+ * Stands in for measuring rendered text, giving every character the same width
+ * so that expected widths can be read off the length of a name.
+ */
+function measureWidth(text: string): number {
+	return text.length * 10;
+}
+
+describe('getFittedSessionName', () => {
+	it('returns the full name unchanged when it fits', () => {
+		expect(getFittedSessionName('Python  3.12.11', 1000, measureWidth)).toBe('Python  3.12.11');
+	});
+
+	it('drops a trailing word at a time as the available width shrinks', () => {
+		const sessionName = 'Python 3.12.11 (Pyenv)';
+		const fittedNames = [300, 220, 200, 140, 100, 60, 50].map(availableWidth => ({
+			availableWidth,
+			fittedName: getFittedSessionName(sessionName, availableWidth, measureWidth),
+		}));
+		expect(fittedNames).toMatchInlineSnapshot(`
+			[
+			  {
+			    "availableWidth": 300,
+			    "fittedName": "Python 3.12.11 (Pyenv)",
+			  },
+			  {
+			    "availableWidth": 220,
+			    "fittedName": "Python 3.12.11 (Pyenv)",
+			  },
+			  {
+			    "availableWidth": 200,
+			    "fittedName": "Python 3.12.11",
+			  },
+			  {
+			    "availableWidth": 140,
+			    "fittedName": "Python 3.12.11",
+			  },
+			  {
+			    "availableWidth": 100,
+			    "fittedName": "Python",
+			  },
+			  {
+			    "availableWidth": 60,
+			    "fittedName": "Python",
+			  },
+			  {
+			    "availableWidth": 50,
+			    "fittedName": "",
+			  },
+			]
+		`);
+	});
+
+	it('returns an empty string for a single-word name that does not fit', () => {
+		expect(getFittedSessionName('Python', 50, measureWidth)).toBe('');
+	});
+});

--- a/src/vs/workbench/contrib/positronConsole/test/common/sessionDisplayUtils.vitest.ts
+++ b/src/vs/workbench/contrib/positronConsole/test/common/sessionDisplayUtils.vitest.ts
@@ -20,9 +20,9 @@ describe('getFittedSessionName', () => {
 		expect(getFittedSessionName('Python  3.12.11', 1000, measureWidth)).toBe('Python  3.12.11');
 	});
 
-	it('drops a trailing word at a time as the available width shrinks', () => {
+	it('ellipsizes the name further as the available width shrinks', () => {
 		const sessionName = 'Python 3.12.11 (Pyenv)';
-		const fittedNames = [300, 220, 200, 140, 100, 60, 50].map(availableWidth => ({
+		const fittedNames = [300, 220, 200, 110, 100, 80, 40, 30].map(availableWidth => ({
 			availableWidth,
 			fittedName: getFittedSessionName(sessionName, availableWidth, measureWidth),
 		}));
@@ -38,29 +38,37 @@ describe('getFittedSessionName', () => {
 			  },
 			  {
 			    "availableWidth": 200,
-			    "fittedName": "Python 3.12.11",
+			    "fittedName": "Python 3.12.11 (Pye…",
 			  },
 			  {
-			    "availableWidth": 140,
-			    "fittedName": "Python 3.12.11",
+			    "availableWidth": 110,
+			    "fittedName": "Python 3.1…",
 			  },
 			  {
 			    "availableWidth": 100,
-			    "fittedName": "Python",
+			    "fittedName": "Python 3…",
 			  },
 			  {
-			    "availableWidth": 60,
-			    "fittedName": "Python",
+			    "availableWidth": 80,
+			    "fittedName": "Python…",
 			  },
 			  {
-			    "availableWidth": 50,
+			    "availableWidth": 40,
+			    "fittedName": "Pyt…",
+			  },
+			  {
+			    "availableWidth": 30,
 			    "fittedName": "",
 			  },
 			]
 		`);
 	});
 
-	it('returns an empty string for a single-word name that does not fit', () => {
-		expect(getFittedSessionName('Python', 50, measureWidth)).toBe('');
+	it('trims a trailing separator so the ellipsis never follows punctuation', () => {
+		expect(getFittedSessionName('Some-word-thing', 110, measureWidth)).toBe('Some-word\u2026');
+	});
+
+	it('returns an empty string when fewer than three characters would be left', () => {
+		expect(getFittedSessionName('Python', 30, measureWidth)).toBe('');
 	});
 });

--- a/src/vs/workbench/contrib/positronConsole/test/common/sessionDisplayUtils.vitest.ts
+++ b/src/vs/workbench/contrib/positronConsole/test/common/sessionDisplayUtils.vitest.ts
@@ -22,7 +22,7 @@ describe('getFittedSessionName', () => {
 
 	it('ellipsizes the name further as the available width shrinks', () => {
 		const sessionName = 'Python 3.12.11 (Pyenv)';
-		const fittedNames = [300, 220, 200, 110, 100, 80, 40, 30].map(availableWidth => ({
+		const fittedNames = [300, 220, 200, 110, 100, 80, 40, 20, 15].map(availableWidth => ({
 			availableWidth,
 			fittedName: getFittedSessionName(sessionName, availableWidth, measureWidth),
 		}));
@@ -57,7 +57,11 @@ describe('getFittedSessionName', () => {
 			    "fittedName": "Pyt…",
 			  },
 			  {
-			    "availableWidth": 30,
+			    "availableWidth": 20,
+			    "fittedName": "P…",
+			  },
+			  {
+			    "availableWidth": 15,
 			    "fittedName": "",
 			  },
 			]
@@ -68,7 +72,7 @@ describe('getFittedSessionName', () => {
 		expect(getFittedSessionName('Some-word-thing', 110, measureWidth)).toBe('Some-word\u2026');
 	});
 
-	it('returns an empty string when fewer than three characters would be left', () => {
-		expect(getFittedSessionName('Python', 30, measureWidth)).toBe('');
+	it('returns an empty string when even the first character and the ellipsis will not fit', () => {
+		expect(getFittedSessionName('Python', 15, measureWidth)).toBe('');
 	});
 });

--- a/test/e2e/pages/editor.ts
+++ b/test/e2e/pages/editor.ts
@@ -59,7 +59,7 @@ export class Editor {
 	 */
 	async selectTab(filename: string): Promise<void> {
 		await test.step(`Select tab ${filename}`, async () => {
-			await this.code.driver.currentPage.getByRole('tab', { name: filename }).click();
+			await this.editorPane.getByRole('tab', { name: filename }).click();
 		});
 	}
 
@@ -259,7 +259,7 @@ export class Editor {
 
 	async replaceTerm(file: string, term: string, line: number, replaceWith: string) {
 		await test.step(`Replace "${term}" on line ${line} with "${replaceWith}"`, async () => {
-			await this.code.driver.currentPage.getByRole('tab', { name: file }).click();
+			await this.editorPane.getByRole('tab', { name: file }).click();
 			await this.clickOnTerm(file, term, line, true);
 			await this.code.driver.currentPage.keyboard.type(replaceWith);
 		});

--- a/test/e2e/pages/editorActionBar.ts
+++ b/test/e2e/pages/editorActionBar.ts
@@ -24,6 +24,10 @@ type EditorActionBarButton =
 
 export class EditorActionBar {
 	get actionBar(): Locator { return this.page.locator('.editor-action-bar > .positron-action-bar > .action-bar-region'); }
+	// Tab lookups are scoped here: a console session tab is also role="tab" and
+	// carries the session's display name, which for a notebook session is the
+	// notebook's filename.
+	get editorPane(): Locator { return this.page.locator('[id="workbench.parts.editor"]'); }
 
 	constructor(private page: Page, private viewer: Viewer, private quickaccess: QuickAccess) { }
 
@@ -99,8 +103,8 @@ export class EditorActionBar {
 	async verifySplitEditor(direction: 'down' | 'right', tabName: string,) {
 		await test.step(`Verify split editor: ${direction}`, async () => {
 			// Verify 2 tabs
-			await expect(this.page.getByRole('tab', { name: tabName })).toHaveCount(2, { timeout: 10000 });
-			const splitTabs = this.page.getByRole('tab', { name: tabName });
+			const splitTabs = this.editorPane.getByRole('tab', { name: tabName });
+			await expect(splitTabs).toHaveCount(2, { timeout: 10000 });
 			const firstTabBox = await splitTabs.nth(0).boundingBox();
 			const secondTabBox = await splitTabs.nth(1).boundingBox();
 

--- a/test/e2e/pages/editors.ts
+++ b/test/e2e/pages/editors.ts
@@ -19,6 +19,21 @@ export class Editors {
 	constructor(private code: Code) { }
 
 	/**
+	 * Get an editor tab by name.
+	 *
+	 * Scoped to the editor part: the workbench has several tab lists, and a
+	 * console session tab carries the session's name as its accessible name --
+	 * which for a notebook session is the notebook's filename. An unscoped
+	 * `getByRole('tab', { name })` therefore matches both the notebook's editor
+	 * tab and its console session tab, and fails Playwright's strict mode.
+	 *
+	 * @param tabName - the name of the tab
+	 */
+	editorTab(tabName: string | RegExp): Locator {
+		return this.editorPart.getByRole('tab', { name: tabName });
+	}
+
+	/**
 	 * Get a specific editor group by index.
 	 * Useful for side-by-side notebook testing where you need to scope actions to a specific editor.
 	 * @param index - 0-based index (0 = leftmost/first group)
@@ -40,7 +55,7 @@ export class Editors {
 
 	async clickTab(tabName: string | RegExp): Promise<void> {
 		await test.step(`Click tab: ${tabName}`, async () => {
-			const tabLocator = this.code.driver.currentPage.getByRole('tab', { name: tabName });
+			const tabLocator = this.editorTab(tabName);
 			await expect(tabLocator).toBeVisible();
 			await tabLocator.click();
 		});
@@ -57,7 +72,7 @@ export class Editors {
 		{ isVisible = true, isSelected = true }: { isVisible?: boolean; isSelected?: boolean }
 	): Promise<void> {
 		await test.step(`Verify tab: ${tabName} is ${isVisible ? '' : 'not'} visible, is ${isSelected ? '' : 'not'} selected`, async () => {
-			const tabLocator = this.code.driver.currentPage.getByRole('tab', { name: tabName });
+			const tabLocator = this.editorTab(tabName);
 
 			await (isVisible
 				? expect(tabLocator).toBeVisible()

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -467,9 +467,13 @@ export class Sessions {
 	private getSessionTab(sessionIdOrName: string): Locator {
 		const sessionIdPattern = /^(python|r)-[a-zA-Z0-9]+$/i;
 
+		// Match by name on the tab's aria-label, not its rendered text: the tab
+		// ellipsizes the session name to fit the space it has, so "Python
+		// (reticulate)" can render as "Python (retic...". The aria-label always
+		// carries the full name.
 		return sessionIdPattern.test(sessionIdOrName)
 			? this.page.getByTestId(`console-tab-${sessionIdOrName}`)
-			: this.sessionTabs.getByText(sessionIdOrName).locator('..');
+			: this.sessionTabs.and(this.page.getByLabel(sessionIdOrName));
 	}
 
 	/**

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -465,7 +465,10 @@ export class Sessions {
 	 * @returns locator for the session tab
 	 */
 	private getSessionTab(sessionIdOrName: string): Locator {
-		const sessionIdPattern = /^(python|r)-[a-zA-Z0-9]+$/i;
+		// Notebook sessions are `<language>-notebook-<hex>`, so the optional
+		// `-notebook` segment is what keeps their ids out of the name branch
+		// below. Mirrors the pattern openMetadataDialog() uses for `info-` ids.
+		const sessionIdPattern = /^(python|r)(-notebook)?-[a-zA-Z0-9]+$/i;
 
 		// Match by name on the tab's aria-label, not its rendered text: the tab
 		// ellipsizes the session name to fit the space it has, so "Python
@@ -704,7 +707,9 @@ export class Sessions {
 				for (const session of allSessions) {
 					// extract session ID from data-testid attribute
 					const testId = await session.getAttribute('data-testid');
-					const match = testId?.match(/console-tab-((python|r)-[a-zA-Z0-9]+)/);
+					// The `-notebook` segment matters: without it a notebook
+					// session's id is captured truncated, as just `python-notebook`.
+					const match = testId?.match(/console-tab-((python|r)(-notebook)?-[a-zA-Z0-9]+)/);
 					const id = match ? match[1] : null;
 
 					// extract session name from aria-label attribute

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -1044,9 +1044,12 @@ export class Sessions {
 	 */
 	async expectSessionNameToBe(sessionId: string, expectedName: string) {
 		await test.step(`Verify session name: ${sessionId} is ${expectedName}`, async () => {
+			// Assert on the aria-label rather than the tab's rendered text: the
+			// tab ellipsizes the name to whatever fits, so the visible text is a
+			// function of how many sessions are open and how wide the pane is.
+			// The aria-label carries the whole name.
 			const sessionTab = this.getSessionTab(sessionId);
-			const tabHeader = sessionTab.locator('.tab-header');
-			await expect(tabHeader).toHaveText(expectedName);
+			await expect(sessionTab).toHaveAttribute('aria-label', expectedName);
 		});
 	}
 

--- a/test/e2e/pages/welcome.ts
+++ b/test/e2e/pages/welcome.ts
@@ -55,7 +55,7 @@ export class Welcome {
 
 	async expectTabTitleToBe(title: string) {
 		await test.step(`Verify tab title: ${title}`, async () => {
-			await expect(this.code.driver.currentPage.getByRole('tab', { name: title })).toBeVisible();
+			await expect(this.code.driver.currentPage.locator('[id="workbench.parts.editor"]').getByRole('tab', { name: title })).toBeVisible();
 		});
 	}
 

--- a/test/e2e/tests/editor-action-bar/editor-action-bar-data-files.test.ts
+++ b/test/e2e/tests/editor-action-bar/editor-action-bar-data-files.test.ts
@@ -132,7 +132,7 @@ async function openDataExplorerViaVariablePane(app: Application, variable: strin
 		// close to the source file's own tab: a page-wide `getByLabel('Close')` can
 		// match an unrelated control and leave the file editor open, whose (disabled)
 		// Save button would then trip the "Save not visible" assertion in the test.
-		const sourceTab = page.getByRole('tab', { name: sourceFileTab });
+		const sourceTab = app.workbench.editors.editorTab(sourceFileTab);
 		await sourceTab.hover();
 		await sourceTab.getByLabel('Close').click();
 		await expect(page.getByText(tabName, { exact: true })).toBeVisible();

--- a/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
@@ -118,7 +118,7 @@ test.describe('Notebook Focus and Selection', {
 		const keyboard = app.code.driver.currentPage.keyboard;
 		await notebooksPositron.newNotebook({ codeCells: 3, markdownCells: 1 });
 
-		const clickTab = (name: string | RegExp) => app.code.driver.currentPage.getByRole('tab', { name }).click();
+		const clickTab = (name: string | RegExp) => app.workbench.editors.editorTab(name).click();
 		// Depending on when this test is run, the untitled notebook may have a different number
 		const TAB_1 = /Untitled-\d+\.ipynb/;
 		const TAB_2 = 'bitmap-notebook.ipynb';

--- a/test/e2e/tests/notebooks-positron/notebook-inline-data-explorer.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-inline-data-explorer.test.ts
@@ -201,7 +201,7 @@ test.describe('Positron Notebooks: Inline Data Explorer', {
 		});
 
 		await test.step('Navigate back to notebook', async () => {
-			await page.getByRole('tab', { name: /Untitled/ }).click();
+			await editors.editorTab(/Untitled/).click();
 			await inlineDataExplorer.expectToBeVisible();
 		});
 

--- a/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
@@ -180,7 +180,7 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 		});
 	});
 
-	test('ensure closing a notebook removes its console session', { tag: [tags.CONSOLE, tags.EDITOR] }, async function ({ app, page, sessions, runCommand }) {
+	test('ensure closing a notebook removes its console session', { tag: [tags.CONSOLE, tags.EDITOR] }, async function ({ app, sessions, runCommand }) {
 		const { notebooksPositron } = app.workbench;
 
 		// clear any sessions left by prior tests (e.g. a terminated notebook
@@ -200,7 +200,7 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 		await sessions.expectStatusToBe('Untitled-1.ipynb', 'idle');
 
 		// closing the notebook removes its console session while the standalone sessions remain (#12940)
-		await page.getByRole('tab', { name: 'Untitled-1.ipynb' }).click();
+		await app.workbench.editors.clickTab('Untitled-1.ipynb');
 		await runCommand('workbench.action.revertAndCloseActiveEditor');
 		await sessions.expectSessionCountToBe(sessionCountBefore);
 	});

--- a/test/e2e/tests/notebooks-positron/notebook-scroll-position.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-scroll-position.test.ts
@@ -40,7 +40,7 @@ test.describe('Positron Notebooks: Scroll Position', {
 		// Switch back to the notebook tab by clicking it directly.
 		// We can't use editors.selectTab() here because it expects a Monaco
 		// editor to receive focus, but the notebook is a custom editor.
-		await app.code.driver.currentPage.getByRole('tab', { name: NOTEBOOK_FILE }).click();
+		await editors.editorTab(NOTEBOOK_FILE).click();
 		await notebooksPositron.expectToBeVisible();
 
 		// Verify the scroll position is restored.

--- a/test/e2e/tests/workbench/enforced-settings/enforced-settings-language-scoped.test.ts
+++ b/test/e2e/tests/workbench/enforced-settings/enforced-settings-language-scoped.test.ts
@@ -297,7 +297,7 @@ async function writeOpenAndSave(
 
 	await test.step(`Open ${fileName} in Positron`, async () => {
 		await app.workbench.quickaccess.openFile(filePath);
-		await expect(page.getByRole('tab', { name: fileName })).toBeVisible();
+		await expect(app.workbench.editors.editorTab(fileName)).toBeVisible();
 	});
 
 	await test.step('Save to trigger formatOnSave (if applicable)', async () => {


### PR DESCRIPTION
Fixes #13402

### Summary

When the console tab list was narrowed all the way, the session name was clipped mid-glyph, leaving a few pixels of text next to the icons instead of collapsing cleanly to just the icons.

Session names are now fitted to the space the tab actually has for them. As the tab narrows, "Python 3.12.11 (Pyenv)" ellipsizes down through "Python 3.12.11 (Pye...", "Python 3.1...", "Python 3...", "Python...", and eventually "P...". Once even the first character and the ellipsis would be clipped, the name is dropped entirely and the tab shows just the status and runtime icons. The ellipsis is never left sitting after a separator: a name cut to "Python ", "Some-word-" or "R 4.6.0 |" has that trailing whitespace, punctuation or symbol trimmed first. The trim is safe because it only ever runs where the name is being cut, so the character it removes is always the one immediately followed by the ellipsis.

Because sessions have names have differing first characters, tabs would otherwise reach that point at different widths, leaving a ragged list where a short "i..." is still labelled next to an unlabelled "R..." tab. So the tab list tracks which tabs have run out of room, and hides the name on every tab as soon as any one of them does. The list collapses to icons all at once and comes back the same way. This avoids one awkward display state as the user is resizing the tabs panel to its minimum size.

The fitting logic is a pure function, `getFittedSessionName`, in `sessionDisplayUtils.ts`: it takes the name, the available width, and a measuring callback, and returns the name, an ellipsized form of it, or an empty string. Separators are matched with `/[\s\p{P}\p{S}]/u`, so all Unicode punctuation and symbols are covered rather than just ASCII. `ConsoleTab` supplies the measurement in a layout effect, measuring candidates in a hidden absolutely positioned span inside the session name element so they're measured in the font that will actually render them, and re-running whenever the tab list width or the session name changes. Because the measurement happens in a layout effect, the fitted name is chosen before the browser paints, so there's no flash of the full name. Each tab keeps measuring and computing its own fitted name even while names are hidden, so hiding is presentation-only and can't feed back into the measurement.

The rename input was reworked to survive the same narrow widths. It's now taken out of the flex flow and pinned to the right edge of the tab, sized to the space the icons leave over but with a 40px minimum; since `right` is what's anchored, that minimum can only push the left edge further left, so at narrow widths the input grows leftward over the runtime and status icons instead of shrinking to an unusable sliver.

Two smaller changes ride along: the session name uses tabular figures, and the minimum console tab list width drops from 64px to 60px, with the resource usage container query updated to match.

### Screenshots

https://github.com/user-attachments/assets/24110fc2-587a-4822-8746-bd8124fdf0d3


https://github.com/user-attachments/assets/2f74d941-2db6-4a83-af94-8941930a0de4

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Console session names now ellipsize to fit the console tab list as it narrows, and are hidden on every tab once any tab runs out of room for its name, so a fully collapsed console shows only the session icons instead of a sliver of clipped text (#13402)
- Fixed the console session rename input shrinking to an unusable sliver and extending past the edge of the tab at narrow widths (#13402)

### QA Notes

`getFittedSessionName` is covered by a new unit test at `src/vs/workbench/contrib/positronConsole/test/common/sessionDisplayUtils.vitest.ts` (4 tests). The main case is a width sweep over "Python 3.12.11 (Pyenv)" captured as an inline snapshot, which pins the whole ladder from full name down through "P..." to empty string, including the exact-fit boundaries; the others cover a name that fits being returned verbatim, the trailing-separator trim for both punctuation and symbols, and the point where even the first character and the ellipsis no longer fit.

The cross-tab hiding and the rename input layout are not unit tested -- both depend on real layout and are best judged by eye.

### Validation Steps

@:console @:sessions

1. Start an R and a Python session so the console tab list shows two tabs with names of noticeably different lengths.
2. Drag the console tab list divider to widen it, and confirm both full session names are shown (for example "Python 3.12.11 (Pyenv)").
3. Narrow the tab list slowly. Confirm each name ellipsizes progressively and stays inside its tab, with no text clipped mid-glyph at any width.
4. Watch the points where the remaining text would end in a space or a period. Confirm the ellipsis follows a letter or digit rather than a separator, so you see "Python..." rather than "Python ..." and "Python 3..." rather than "Python 3....".
5. Keep narrowing until the longer name runs out of room. Confirm both tabs lose their names at the same moment, rather than the shorter name lingering on its own, and that each tab shows only its status and runtime icons.
6. Widen it again and confirm both names reappear together and grow back to the full, un-ellipsized names.
7. Right-click a session tab, choose Rename, and confirm the input is aligned to the right edge of the tab.
8. With the rename input open, narrow the tab list to its minimum. Confirm the input stops shrinking at roughly 40px and extends leftward over the runtime and status icons rather than becoming too narrow to type in, and that it never extends past the right edge of the tab.
9. Rename a session to a long single word with no spaces, and confirm it ellipsizes and collapses the same way.
Changes from the last version: the symbols caveat is gone from QA Notes, the summary and the getFittedSessionName paragraph now say punctuation and symbols with the "only trims where it cuts" reasoning, and the test description mentions both trim cases.