### PR TITLE
Keep Windows install paths under `MAX_PATH`

### DIFF
--- a/build/gulpfile.vscode.ts
+++ b/build/gulpfile.vscode.ts
@@ -28,6 +28,7 @@ import minimist from 'minimist';
 import { compileBuildWithoutManglingTask, compileBuildWithManglingTask } from './gulpfile.compile.ts';
 import { compileNonNativeExtensionsBuildTask, compileNativeExtensionsBuildTask, compileAllExtensionsBuildTask, compileExtensionMediaBuildTask, cleanExtensionsBuildTask, compileCopilotExtensionBuildTask } from './gulpfile.extensions.ts';
 // --- Start Positron ---
+import { checkPathLengths } from './lib/positron-check-path-lengths.ts';
 // Do not import copyCodiconsTask. Positron maintains a custom codicon.ttf in the repo that
 // includes Positron-specific icons. Copying from the npm package would overwrite these.
 // import { copyCodiconsTask } from './lib/compilation.ts';
@@ -709,6 +710,31 @@ function patchWin32DependenciesTask(destinationFolderName: string) {
 	};
 }
 
+// --- Start Positron ---
+/**
+ * Fails the build when the packaged tree holds a path that is too long for a
+ * Windows per-user install or auto-update.
+ *
+ * This task runs for every platform, because the extension dependency trees that
+ * own the longest paths are the same everywhere. The first build of any platform
+ * therefore finds a regression, and not the next Windows release. See
+ * posit-dev/positron#14702.
+ */
+function checkPathLengthsTask(platform: string, destinationFolderName: string) {
+	const outputDir = path.join(path.dirname(root), destinationFolderName);
+
+	return async () => {
+		// The directory that matches the Windows install directory. The measured
+		// paths are then the paths that Inno Setup writes.
+		const appRoot = platform === 'darwin'
+			? path.join(outputDir, `${product.nameLong}.app`, 'Contents')
+			: path.join(outputDir, util.getVersionedResourcesFolder(platform, commit!));
+
+		checkPathLengths(appRoot);
+	};
+}
+// --- End Positron ---
+
 function prepareCopilotRipgrepShimTask(platform: string, arch: string, destinationFolderName: string) {
 	const outputDir = path.join(path.dirname(root), destinationFolderName);
 
@@ -757,7 +783,11 @@ BUILD_TARGETS.forEach(buildTarget => {
 			compileNativeExtensionsBuildTask,
 			util.rimraf(path.join(buildRoot, destinationFolderName)),
 			packageTask(platform, arch, sourceFolderName, destinationFolderName, opts),
-			prepareCopilotRipgrepShimTask(platform, arch, destinationFolderName)
+			// --- Start Positron ---
+			// prepareCopilotRipgrepShimTask(platform, arch, destinationFolderName)
+			prepareCopilotRipgrepShimTask(platform, arch, destinationFolderName),
+			checkPathLengthsTask(platform, destinationFolderName)
+			// --- End Positron ---
 		];
 
 		if (platform === 'win32') {

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -25,6 +25,7 @@ import watcher from './watch/index.ts';
 // --- Start Positron ---
 import os from 'os';
 import { getBootstrapExtensionStream } from './bootstrapExtensions.ts';
+import { isPrunedExtensionDependencyFile, isUnusedCopilotOpenTelemetryPackage } from './positron-path-budget.ts';
 // --- End Positron ---
 
 import { createRequire } from 'module';
@@ -331,6 +332,18 @@ function fromLocalEsbuild(extensionPath: string, esbuildConfigFileName: string):
 		}
 
 		// --- Start Positron ---
+		// Remove the files in the production dependencies of the extension that
+		// no code loads at runtime. These extensions ship node_modules without
+		// change, and most of them have no .vscodeignore. As a result, the
+		// longest paths in the shipped tree were TypeScript declarations. See
+		// positron-path-budget.ts and posit-dev/positron#14702.
+		const prunedFileNames = fileNames.filter(fileName => !isPrunedExtensionDependencyFile(fileName));
+
+		if (prunedFileNames.length !== fileNames.length) {
+			fancyLog(`Pruned ${ansiColors.yellow(String(fileNames.length - prunedFileNames.length))} unused dependency files from ${ansiColors.cyan(extensionName)}`);
+			fileNames = prunedFileNames;
+		}
+
 		// Stream the files sequentially rather than eagerly opening a read
 		// stream for every file up front. Extensions with npm dependencies
 		// (e.g. positron-data-driver-snowflake, which bundles @azure/msal-node)
@@ -749,7 +762,27 @@ export function packageCopilotExtensionStream(disableMangle: boolean): Stream {
 	);
 
 	const productionDependencies = getProductionDependencies('extensions/copilot');
-	const dependenciesSrc = productionDependencies.map(d => path.relative(root, d)).map(d => [`${d}/**`, `!${d}/**/{test,tests}/**`]).flat();
+	// --- Start Positron ---
+	// The extension bundles OpenTelemetry into dist/extension.js and keeps only
+	// @opentelemetry/instrumentation external. No code loads the other
+	// @opentelemetry packages in node_modules. Each OTLP exporter also carries a
+	// nested @opentelemetry/resources, so these packages held some of the longest
+	// paths that Positron shipped. See positron-path-budget.ts and
+	// posit-dev/positron#14702.
+	//
+	// A negative glob excludes each unused package. Without it, a positive glob
+	// for a parent package returns a nested copy of an unused package. The
+	// negative globs come last, because the last glob wins.
+	//
+	const relativeDependencies = productionDependencies.map(d => path.relative(root, d));
+	const unusedDependencies = relativeDependencies.filter(isUnusedCopilotOpenTelemetryPackage);
+	const usedDependencies = relativeDependencies.filter(d => !isUnusedCopilotOpenTelemetryPackage(d));
+	const dependenciesSrc = [
+		...usedDependencies.map(d => [`${d}/**`, `!${d}/**/{test,tests}/**`]).flat(),
+		...unusedDependencies.map(d => `!${d}/**`)
+	];
+	// const dependenciesSrc = productionDependencies.map(d => path.relative(root, d)).map(d => [`${d}/**`, `!${d}/**/{test,tests}/**`]).flat();
+	// --- End Positron ---
 
 	return es.merge(
 		localExtensionsStream,

--- a/build/lib/positron-check-path-lengths.ts
+++ b/build/lib/positron-check-path-lengths.ts
@@ -1,0 +1,114 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import fs from 'fs';
+import path from 'path';
+import fancyLog from 'fancy-log';
+import ansiColors from 'ansi-colors';
+import { MAX_RELATIVE_PATH_LENGTH, describeBudget } from './positron-path-budget.ts';
+
+/** How many offenders to name when the check fails. */
+const REPORTED_OFFENDERS = 10;
+
+export interface IPathLengthResult {
+	/** Number of files walked. */
+	fileCount: number;
+	/** Every path over budget, longest first, relative to the install directory. */
+	offenders: string[];
+	/** Longest path found, relative to the install directory. */
+	longest: string;
+}
+
+/**
+ * Collects every file under `root` as a path relative to `root`, with Windows
+ * separators. A build on any platform then measures the lengths that Windows
+ * gets. The walk itself uses native paths, and the function converts the
+ * separators only at the end.
+ *
+ * The function does not follow a symlink. The tree holds a few symlinks, and a
+ * walk through them counts a file twice and can find a cycle.
+ */
+function collectRelativePaths(root: string): string[] {
+	const results: string[] = [];
+	const stack: string[] = [''];
+
+	while (stack.length) {
+		const relativeDir = stack.pop()!;
+		const entries = fs.readdirSync(path.join(root, relativeDir), { withFileTypes: true });
+
+		for (const entry of entries) {
+			const relativePath = relativeDir ? path.join(relativeDir, entry.name) : entry.name;
+
+			if (entry.isDirectory()) {
+				stack.push(relativePath);
+			} else if (entry.isFile()) {
+				results.push(relativePath.split(path.sep).join('\\'));
+			}
+		}
+	}
+
+	return results;
+}
+
+/**
+ * Measures the packaged application tree against the Windows MAX_PATH budget.
+ *
+ * `appRoot` must be the directory that matches the Windows install directory.
+ * The paths that this function measures are then the paths that Inno Setup
+ * writes. On Windows and Linux, `appRoot` is the packaged output folder. On
+ * macOS it is `<product>.app/Contents`, where `Resources/app/...` has the same
+ * length as `resources\app\...` on Windows.
+ */
+export function measurePathLengths(appRoot: string): IPathLengthResult {
+	const relativePaths = collectRelativePaths(appRoot);
+	relativePaths.sort((a, b) => b.length - a.length);
+
+	return {
+		fileCount: relativePaths.length,
+		offenders: relativePaths.filter(p => p.length > MAX_RELATIVE_PATH_LENGTH),
+		longest: relativePaths[0] ?? ''
+	};
+}
+
+/**
+ * Fails the build when the packaged tree contains a path that a Windows
+ * per-user install or auto-update cannot write.
+ *
+ * The extension trees that own the longest paths are the same on each platform.
+ * A check during the packaging of any platform therefore finds a regression
+ * before it reaches a Windows build.
+ */
+export function checkPathLengths(appRoot: string): void {
+	if (!fs.existsSync(appRoot)) {
+		throw new Error(`Cannot check path lengths. ${appRoot} does not exist.`);
+	}
+
+	const { fileCount, offenders, longest } = measurePathLengths(appRoot);
+
+	if (offenders.length === 0) {
+		fancyLog(`Path lengths ok: the longest of ${fileCount} shipped paths is `
+			+ `${ansiColors.cyan(String(longest.length))} of ${MAX_RELATIVE_PATH_LENGTH} characters `
+			+ `(${ansiColors.gray(longest)})`);
+		return;
+	}
+
+	fancyLog.error(`${offenders.length} shipped path(s) are longer than the Windows MAX_PATH `
+		+ `budget of ${MAX_RELATIVE_PATH_LENGTH} characters (${describeBudget()}).`);
+	fancyLog.error('A Windows per-user install or auto-update cannot write these files:');
+
+	for (const offender of offenders.slice(0, REPORTED_OFFENDERS)) {
+		fancyLog.error(`  ${ansiColors.yellow(String(offender.length))}  ${offender}`);
+	}
+
+	if (offenders.length > REPORTED_OFFENDERS) {
+		fancyLog.error(`  ...and ${offenders.length - REPORTED_OFFENDERS} more.`);
+	}
+
+	fancyLog.error('Make these paths shorter, or do not ship these files.');
+	fancyLog.error('Do not raise the budget.');
+	fancyLog.error('See build/lib/positron-path-budget.ts and posit-dev/positron#14702.');
+
+	throw new Error(`${offenders.length} shipped path(s) are longer than the Windows MAX_PATH budget`);
+}

--- a/build/lib/positron-path-budget.ts
+++ b/build/lib/positron-path-budget.ts
@@ -1,0 +1,175 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import minimatch from 'minimatch';
+
+/**
+ * Windows MAX_PATH budget for the packaged application tree.
+ *
+ * Windows limits a path to MAX_PATH (260) characters. This limit counts the
+ * terminating null, so the longest usable path is 259 characters. Inno Setup 6.4
+ * is not long-path aware, because the installer manifest has no `longPathAware`
+ * element. As a result, the `LongPathsEnabled` registry setting does not raise
+ * this limit for an install or an update.
+ *
+ * A shipped file with a path over the budget does not install. The user gets a
+ * per-file error that they can skip. The install or the auto-update is then
+ * incomplete.
+ *
+ * The budget is what remains after the install prefix and the account name of
+ * the user. Therefore it applies to a path relative to the install directory.
+ * This module measures a path as `resources\app\extensions\...`, which is what
+ * Inno Setup writes inside `C:\Users\<user>\AppData\Local\Programs\Positron\`.
+ *
+ * See https://github.com/posit-dev/positron/issues/14702.
+ */
+
+/** Longest usable Windows path. MAX_PATH is 260 and counts the terminating null. */
+const MAX_USABLE_PATH = 259;
+
+/**
+ * `C:\Users\<user>\AppData\Local\Programs\Positron\` without the account name.
+ * This per-user location is the default, and it is the one that fails. A system
+ * install inside `C:\Program Files\Positron\` is 16 characters shorter.
+ */
+const USER_INSTALL_PREFIX = 42;
+
+/**
+ * A background update writes the new tree to `{app}\_`, then moves it into place.
+ * See `GetDestDir()` in build/win32/positron.iss. Every path is therefore 2
+ * characters longer during an update than during a fresh install. The budget uses
+ * the update, because a budget for the install alone breaks auto-update for users
+ * whose install worked.
+ */
+const BACKGROUND_UPDATE_SUFFIX = 2;
+
+/**
+ * Longest Windows account name that a per-user install and auto-update must
+ * support. Domain accounts of the form `firstname.lastname` often reach 18
+ * characters or more.
+ */
+const ACCOUNT_NAME_ALLOWANCE = 20;
+
+/**
+ * Longest path, relative to the install directory, that a shipped file can have.
+ * The value is 195.
+ */
+export const MAX_RELATIVE_PATH_LENGTH =
+	MAX_USABLE_PATH - USER_INSTALL_PREFIX - BACKGROUND_UPDATE_SUFFIX - ACCOUNT_NAME_ALLOWANCE;
+
+/** Explains the budget in a build log, so that a failure describes itself. */
+export function describeBudget(): string {
+	return `${MAX_USABLE_PATH} usable - ${USER_INSTALL_PREFIX} install prefix`
+		+ ` - ${BACKGROUND_UPDATE_SUFFIX} background-update suffix`
+		+ ` - ${ACCOUNT_NAME_ALLOWANCE} account name = ${MAX_RELATIVE_PATH_LENGTH}`;
+}
+
+/**
+ * Glob patterns for the files that reach the packaged tree but that no code loads
+ * at runtime. Each pattern matches a path relative to an extension directory.
+ *
+ * `isPrunedExtensionDependencyFile` applies these patterns. Use that function
+ * instead of the patterns, so that the packaging code and the tests normalize and
+ * match a path in the same way.
+ *
+ * These patterns match only inside `node_modules`. The extensions in
+ * `extensionsWithNpmDeps` (build/lib/extensions.ts) ship their production
+ * dependencies without change, and most of them have no `.vscodeignore`. As a
+ * result, the type declarations that npm packages ship with their JavaScript go
+ * into the app. These declarations own the longest paths in the tree, because
+ * `@aws-sdk/*` publishes a `dist-types/ts3.4/` variant.
+ *
+ * `build/.moduleignore` already removes `**\/*.ts` from the shared and Copilot
+ * dependency streams. But `cleanNodeModules` never ran over the per-extension
+ * dependencies that vsce collects, so these extensions never got that treatment.
+ *
+ * Only the bundled extensions use these patterns. The extensions that go through
+ * `fromLocalNormal` do not. To use them there, you must add the exception that
+ * `.moduleignore` already carries for `typescript/lib/lib*.d.ts`, which the
+ * TypeScript language service loads at runtime.
+ */
+const EXTENSION_NODE_MODULES_EXCLUDES = [
+	// TypeScript declarations and sources. Node never loads these files. The
+	// build compiles and bundles each extension before packaging. These patterns
+	// also clear the `dist-types` trees, where every file is a declaration or a
+	// declaration map.
+	'node_modules/**/*.ts',
+	'node_modules/**/*.tsx',
+	'node_modules/**/*.d.ts.map',
+	// The ESM twins of `dist-cjs` in the AWS and Smithy SDKs. `@aws-sdk/*` and
+	// `@smithy/*` resolve `main` and the `node` export condition to `dist-cjs`.
+	// The only consumer is `snowflake-sdk`, which stays external to the esbuild
+	// bundle and therefore loads as CommonJS. These patterns name the two package
+	// scopes, because many other packages ship `dist-es` as their only build.
+	'node_modules/@aws-sdk/**/dist-es/**',
+	'node_modules/@smithy/**/dist-es/**',
+];
+
+/**
+ * Whether the package must leave out a file of a bundled extension, because no
+ * code loads that file at runtime.
+ *
+ * `relativePath` is relative to the extension directory. The function accepts
+ * both separators, because vsce reports native ones and the patterns use forward
+ * slashes.
+ *
+ * The packaging code and the tests share this one function. Two separate uses of
+ * the patterns can drift apart. A change to the normalization of a path, or to
+ * the match options, then goes unnoticed.
+ *
+ * No unit test covers the call site in `fromLocalEsbuild`, because a test must
+ * drive vsce and a gulp stream to reach it. `positron-check-path-lengths.ts`
+ * covers it instead. If the prune stops, the longest shipped path returns to 210
+ * characters and packaging fails.
+ */
+export function isPrunedExtensionDependencyFile(relativePath: string): boolean {
+	const normalizedPath = relativePath.split(/[\\/]/).join('/');
+
+	return EXTENSION_NODE_MODULES_EXCLUDES.some(
+		pattern => minimatch(normalizedPath, pattern, { dot: true }));
+}
+
+/**
+ * The `@opentelemetry/*` packages that the Copilot extension needs at runtime.
+ *
+ * The extension bundles OpenTelemetry into `dist/extension.js`. It keeps
+ * `@opentelemetry/instrumentation` external, as the `external` list in
+ * extensions/copilot/.esbuild.mts shows. That package and its dependency closure
+ * must therefore ship.
+ *
+ * The other 17 `@opentelemetry/*` packages in the production dependencies are
+ * already inside the bundle, so the copies in `node_modules` are dead weight.
+ * They are also deep. Each OTLP exporter carries its own nested
+ * `@opentelemetry/resources`, which is the source of the paths in the original
+ * report.
+ */
+export const COPILOT_RUNTIME_OPENTELEMETRY_PACKAGES = new Set([
+	'api',
+	'core',
+	'instrumentation',
+]);
+
+/**
+ * Whether a resolved production-dependency directory is an `@opentelemetry`
+ * package that the Copilot extension does not need at runtime.
+ *
+ * The function examines every `@opentelemetry/` segment, not only the last one.
+ * The build therefore removes a nested copy together with its parent package. An
+ * example is
+ * `@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/core`.
+ * Without this rule, the glob of the parent returns that copy to the package.
+ */
+export function isUnusedCopilotOpenTelemetryPackage(dependencyPath: string): boolean {
+	const segments = dependencyPath.split(/[\\/]/);
+
+	for (let i = 0; i < segments.length - 1; i++) {
+		if (segments[i] === '@opentelemetry'
+			&& !COPILOT_RUNTIME_OPENTELEMETRY_PACKAGES.has(segments[i + 1])) {
+			return true;
+		}
+	}
+
+	return false;
+}

--- a/build/lib/test/positron-check-path-lengths.test.ts
+++ b/build/lib/test/positron-check-path-lengths.test.ts
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { suite, test, before, after } from 'node:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { checkPathLengths, measurePathLengths } from '../positron-check-path-lengths.ts';
+import { MAX_RELATIVE_PATH_LENGTH } from '../positron-path-budget.ts';
+
+/**
+ * Makes a fixture of a packaged tree. The deepest file is `length` characters
+ * from the root. The shape matches a real offender: a chain of node_modules
+ * directories with a file at the end.
+ */
+function writeFileAtDepth(root: string, length: number): string {
+	const segments: string[] = ['resources', 'app', 'extensions', 'ext', 'node_modules'];
+
+	// Add directories of a fixed width. Then set the length of the file name, so
+	// that the total is exactly `length`.
+	while (segments.join('/').length + '/dir0000'.length + '/f.js'.length < length) {
+		segments.push(`dir${String(segments.length).padStart(4, '0')}`);
+	}
+
+	const dir = segments.join('/');
+	const fileName = 'f'.repeat(length - dir.length - 1);
+	fs.mkdirSync(path.join(root, dir), { recursive: true });
+	fs.writeFileSync(path.join(root, dir, fileName), '');
+
+	return `${dir.split('/').join('\\')}\\${fileName}`;
+}
+
+suite('positron-check-path-lengths', () => {
+
+	let appRoot: string;
+
+	before(() => {
+		appRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'positron-path-lengths-'));
+	});
+
+	after(() => {
+		fs.rmSync(appRoot, { recursive: true, force: true });
+	});
+
+	test('measures paths relative to the install directory, using Windows separators', () => {
+		const expected = writeFileAtDepth(appRoot, MAX_RELATIVE_PATH_LENGTH);
+		const result = measurePathLengths(appRoot);
+
+		assert.deepStrictEqual(
+			{ fileCount: result.fileCount, length: result.longest.length, longest: result.longest, offenders: result.offenders },
+			{ fileCount: 1, length: MAX_RELATIVE_PATH_LENGTH, longest: expected, offenders: [] });
+	});
+
+	test('a path exactly at the budget passes, one character more fails', () => {
+		// From the previous test, the tree already holds a file at exactly the
+		// budget. This test therefore checks the limit from both sides.
+		assert.doesNotThrow(() => checkPathLengths(appRoot));
+
+		const tooLong = writeFileAtDepth(appRoot, MAX_RELATIVE_PATH_LENGTH + 1);
+
+		assert.deepStrictEqual(measurePathLengths(appRoot).offenders, [tooLong]);
+		assert.throws(() => checkPathLengths(appRoot), /longer than the Windows MAX_PATH budget/);
+	});
+
+	test('reports a missing tree rather than passing vacuously', () => {
+		assert.throws(
+			() => checkPathLengths(path.join(appRoot, 'does-not-exist')),
+			/does not exist/);
+	});
+});

--- a/build/lib/test/positron-path-budget.test.ts
+++ b/build/lib/test/positron-path-budget.test.ts
@@ -1,0 +1,141 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { suite, test } from 'node:test';
+import {
+	MAX_RELATIVE_PATH_LENGTH,
+	isPrunedExtensionDependencyFile as isPruned,
+	isUnusedCopilotOpenTelemetryPackage,
+} from '../positron-path-budget.ts';
+
+suite('positron-path-budget', () => {
+
+	test('budget leaves room for a long account name during a background update', () => {
+		// 259 usable - 42 install prefix - 2 for the {app}\_ update staging
+		// directory - 20 for the account name. This test exists to catch one
+		// mistake: a smaller allowance that makes a long path fit.
+		assert.strictEqual(MAX_RELATIVE_PATH_LENGTH, 195);
+	});
+
+	test('the path from the original report does not fit, the one that replaced it does', () => {
+		// Both paths come from the released 2026.08.0-331 Windows user installer,
+		// relative to the install directory. The first path broke installs and
+		// auto-updates. The second path is the longest path that ships now.
+		const before = 'resources\\app\\extensions\\positron-data-driver-snowflake\\node_modules\\@aws-sdk\\middleware-sdk-s3\\dist-types\\ts3.4\\submodules\\s3-control\\middleware-host-prefix-deduplication\\hostPrefixDeduplicationMiddleware.d.ts';
+		const after = 'resources\\app\\extensions\\positron-catalog-explorer\\node_modules\\@azure\\msal-browser\\dist\\custom-auth-path\\custom_auth\\core\\auth_flow\\jit\\result\\AuthMethodRegistrationChallengeMethodResult.mjs';
+
+		assert.deepStrictEqual(
+			{
+				before: { length: before.length, fits: before.length <= MAX_RELATIVE_PATH_LENGTH },
+				after: { length: after.length, fits: after.length <= MAX_RELATIVE_PATH_LENGTH },
+				beforeIsPruned: isPruned(before.slice('resources\\app\\extensions\\positron-data-driver-snowflake\\'.length)),
+			},
+			{
+				before: { length: 210, fits: false },
+				after: { length: 191, fits: true },
+				beforeIsPruned: true,
+			});
+	});
+
+	suite('isPrunedExtensionDependencyFile', () => {
+
+		test('prunes declarations and ESM twins, keeps runtime files', () => {
+			const paths = [
+				// The longest path that Positron shipped, and its siblings.
+				'node_modules/@aws-sdk/middleware-sdk-s3/dist-types/ts3.4/submodules/s3-control/x.d.ts',
+				'node_modules/@aws-sdk/middleware-sdk-s3/dist-es/submodules/s3-control/x.js',
+				'node_modules/@smithy/middleware-endpoint/dist-es/adaptors/x.js',
+				'node_modules/@azure/msal-browser/types/custom_auth/core/x.d.ts.map',
+				'node_modules/snowflake-sdk/lib/core.ts',
+				// Runtime files, which must stay in the package.
+				'node_modules/@aws-sdk/middleware-sdk-s3/dist-cjs/index.js',
+				'node_modules/@smithy/middleware-endpoint/dist-cjs/index.js',
+				'node_modules/snowflake-sdk/lib/core.js',
+				'node_modules/snowflake-sdk/package.json',
+				'node_modules/better-sqlite3/build/Release/better_sqlite3.node',
+				// The prune removes `dist-es` only for the two scopes that load
+				// their CommonJS build. For another package, `dist-es` can be
+				// the only build.
+				'node_modules/some-esm-only-package/dist-es/index.js',
+				// The prune reads only node_modules, not the output of the
+				// extension.
+				'dist/extension.js',
+				'src/extension.ts',
+			];
+
+			assert.deepStrictEqual(paths.map(isPruned), [
+				true, true, true, true, true,
+				false, false, false, false, false,
+				false,
+				false, false,
+			]);
+		});
+
+		test('does not mistake .mts or .mjs for a declaration file', () => {
+			assert.deepStrictEqual([
+				'node_modules/pkg/dist/index.mts',
+				'node_modules/pkg/dist/index.mjs',
+				'node_modules/pkg/dist/index.cjs',
+			].map(isPruned), [false, false, false]);
+		});
+
+		test('matches the native separators vsce reports on Windows', () => {
+			assert.deepStrictEqual([
+				'node_modules\\@aws-sdk\\middleware-sdk-s3\\dist-types\\ts3.4\\x.d.ts',
+				'node_modules\\@aws-sdk\\middleware-sdk-s3\\dist-cjs\\index.js',
+			].map(isPruned), [true, false]);
+		});
+
+		test('prunes a dotfile, which a default glob would skip', () => {
+			assert.strictEqual(isPruned('node_modules/pkg/.internal/index.d.ts'), true);
+		});
+	});
+
+	suite('isUnusedCopilotOpenTelemetryPackage', () => {
+
+		test('keeps the externalized instrumentation closure, drops the bundled rest', () => {
+			const dependencies = [
+				// External in extensions/copilot/.esbuild.mts. The extension
+				// therefore loads these from node_modules at runtime.
+				'extensions/copilot/node_modules/@opentelemetry/instrumentation',
+				'extensions/copilot/node_modules/@opentelemetry/api',
+				'extensions/copilot/node_modules/@opentelemetry/core',
+				// Inside dist/extension.js, so dead weight on disk. The nested
+				// resources copies are the source of the paths in #14702.
+				'extensions/copilot/node_modules/@opentelemetry/exporter-metrics-otlp-grpc',
+				'extensions/copilot/node_modules/@opentelemetry/resources',
+				'extensions/copilot/node_modules/@opentelemetry/sdk-trace-node',
+				// The prune keeps this package at the top level. But when the
+				// prune removes a parent package, it also removes the nested
+				// copy, so that the glob of the parent cannot return it.
+				'extensions/copilot/node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/core',
+				// The prune does not touch an unrelated dependency.
+				'extensions/copilot/node_modules/@github/copilot',
+				'extensions/copilot/node_modules/shimmer',
+			];
+
+			assert.deepStrictEqual(dependencies.map(isUnusedCopilotOpenTelemetryPackage), [
+				false, false, false,
+				true, true, true,
+				true,
+				false, false,
+			]);
+		});
+
+		test('ignores a trailing @opentelemetry segment with no package after it', () => {
+			assert.strictEqual(
+				isUnusedCopilotOpenTelemetryPackage('extensions/copilot/node_modules/@opentelemetry'),
+				false);
+		});
+
+		test('handles Windows separators', () => {
+			assert.strictEqual(
+				isUnusedCopilotOpenTelemetryPackage(
+					'extensions\\copilot\\node_modules\\@opentelemetry\\resources'),
+				true);
+		});
+	});
+});

--- a/extensions/positron-python/.vscodeignore
+++ b/extensions/positron-python/.vscodeignore
@@ -35,6 +35,7 @@ noxfile.py
 .prettierrc.js
 .sonarcloud.properties
 .venv/**
+.venv*/**
 .vscode/**
 .vscode-test/**
 .vscode test/**


### PR DESCRIPTION
Fixes #14702

Windows caps a path at MAX_PATH (260) characters including the terminating null, so the longest usable path is 259. Inno Setup 6.4 is not long-path aware (the generated installer's manifest has no `longPathAware` element), which is why enabling the `LongPathsEnabled` registry setting doesn't help, as reported on the issue. Positron was shipping a path of 210 characters relative to the install directory.

The part that wasn't obvious until I measured the real artifact is that a background update stages the new tree in `{app}\_` before swapping it into place (`GetDestDir()` in `build/win32/positron.iss`), so every path is two characters longer during an update than during a fresh install. Every file entry in the installer is scripted to `{code:GetDestDir}`, which `innoextract` confirms. That gives two different cliffs:

| Scenario | Failed at account name length |
|---|---|
| Fresh per-user install | 8 or more |
| Background auto-update | 6 or more |
| System install | never (23 characters of headroom) |

The system-install row is why #15271 saw a system install of the same build succeed: `C:\Program Files\Positron\` is 16 characters shorter than the per-user prefix.

## Why so few people reported it

The arithmetic above says most per-user installs were affected, which doesn't match the report volume. AFAICT this is because the tail is "thin". An 8-character account name overruns exactly one file, 14 characters overruns two, and 20 characters overruns fourteen. Only four shipped files exceeded 200 characters at all. One or two failing files present as a skippable per-file error, so what I believe is happening is that users clicked Skip, Positron still booted, and most never filed anything. Every reporter on the issue describes exactly that. It turns out that report volume is a bad proxy for blast radius here!

## What this PR changes

The longest shipped path drops from 210 to 191 characters, and a new build-time check fails packaging if it ever grows back.

- **Prune files nothing loads at runtime from the production dependencies of bundled extensions.** TypeScript declarations and sources, declaration maps, and the `dist-es` twins of `@aws-sdk` and `@smithy`. This is the structural half of the fix: `cleanNodeModules(build/.moduleignore)` already strips `**/*.ts` from the shared and Copilot dependency streams, but it never ran over the per-extension `node_modules` that vsce collects for the eleven extensions in `extensionsWithNpmDeps`, and ten of those eleven have no `.vscodeignore` at all. So nothing was filtering them. `.moduleignore` would have caught the worst offender for free.

- **Stop shipping the seventeen `@opentelemetry` packages that the Copilot extension bundles into `dist/extension.js`.** Only `@opentelemetry/instrumentation` is left external by `extensions/copilot/.esbuild.mts`, so only it, `api`, and `core` need to ship. The rest are dead weight, and they were pretty deep! Each OTLP exporter carried its own nested `@opentelemetry/resources`, which is exactly the path in the original screenshot on the issue.

- **Exclude `.venv*` from the positron-python package.** The new check found this one. A local `.venv-compile` virtualenv was being packaged into the extension: 1228 files, including one path of 196 characters. It's gitignored but `.vscodeignore` only had `.venv/**`. It doesn't appear in released builds because those start from a clean checkout, so this only affected builds made in a working tree that had compiled the extension.

- **Fail packaging when a shipped path exceeds 195 characters.** The budget is `259 usable - 42 install prefix - 2 update staging directory - 20 account name`. The check measures the packaged tree rather than the source tree. `positron-python`'s nested `@microsoft/applicationinsights-*` trees are the second-longest paths in the source tree at 209 characters and never ship at all, so a source-tree check would fail on a file that can't hurt anyone while the real regression slipped past.

## Measurements

All numbers come from the released `Positron-2026.08.0-331-UserSetup-x64.exe`, sha256 verified against `releases/win/x86_64/user-releases.json` and listed with `innoextract` built from git master (1.9 can't parse Inno Setup 6.4.0.1). 68,611 shipped files.

| | Before | After |
|---|---|---|
| Longest shipped path | 210 | 191 |
| Files shipped | 68,611 | 55,657 |
| Account name headroom on auto-update | 5 characters | 24 characters |

I also verified this against a real local build rather than only against the file list: a full `compile-non-native-extensions-build` across all 125 extensions produces a longest path of 191 with zero paths over budget, with every `dist-types` file, `.d.ts` file, and `@aws-sdk`/`@smithy` `dist-es` file gone from the data drivers, and the 36 `@aws-sdk` `dist-cjs` files that Snowflake actually loads still in place.

## Known gaps

Here are three things a reviewer should know rather than discover later:

1. **No PR-time job packages the app**, so this check runs during a release build, not on this PR. That's weaker than the issue asks for, since it fails a release rather than the PR that introduced the regression. The cheap follow-up is adding `npm --prefix build test` to `test-unit.yml` and turning the measurement into a build unit test, but that's a CI plumbing decision worth making separately.

2. **The `dist-es` removal is not proven yet.** `@aws-sdk/*` and `@smithy/*` resolve `main` and the `node` export condition to `dist-cjs`, and `snowflake-sdk` is externalized from the esbuild bundle so it's required as CommonJS. That should make `dist-es` dead, but it wants a real Snowflake connection to confirm.

3. **The prune's call site isn't unit tested.** `isPrunedExtensionDependencyFile` is the single seam that the packaging code and the tests share, so the pattern list, the match options, and the path normalization are all covered. Reaching the call site in `fromLocalEsbuild` would mean driving vsce and a gulp stream. What covers it instead is the path-length check itself. If the prune stops running, the longest path returns to 210 and packaging fails. This is written into the code comment so it isn't rediscovered later.

## Release Notes

### New Features
- N/A

### Bug Fixes
- Fixed Windows per-user installs and auto-updates failing with a path-too-long error (#14702)

## Validation Steps

**E2E tests can't cover this change, so I haven't tagged any suites.** None of the packaging code in this PR executes there, including the new check, so a green E2E run would be misleading rather than reassuring.

Validation splits into two halves, both of which require release builds. I'll kick those off here in a minute (pending GH actions actually working).

### Half one: did the prune delete anything Positron needs? (platform-independent)

In a real packaged app:

1. Open a Snowflake connection from the Connections pane. This is the check that matters most, because it covers the `dist-es` removal.
2. Open a table from that connection in the Data Explorer.
3. Open Positron Assistant (_not_ Posit Assistant) and send a message, then check the Copilot output channel for any `Cannot find module '@opentelemetry/...'` error. This covers the OpenTelemetry removal.
4. Select a Python interpreter and start a session. This covers the `.venv*` exclusion.
5. Sign in to Catalog Explorer, whose `@azure/msal-browser` tree is what now owns the longest path at 191 characters.

### Half two: does it install and auto-update on Windows?

Use a Windows x64 release build of this branch, and use the **user** setup. A system install won't reproduce the original bug, because its prefix is 16 characters shorter.

**Step 1: the build itself is the first signal.** Packaging now fails if any shipped path exceeds 195 characters, so a Windows build that completes has already told you something. Look for this line in the log:

```
Path lengths ok: the longest of <N> shipped paths is 191 of 195 characters (...)
```

**Step 2: fresh install under a long account name.**

1. Sign in to Windows as an account whose name is 18 characters or longer.
2. Run the `UserSetup` installer.
3. Confirm there's no "cannot create file" error, which is the dialog in the original report.
4. Launch Positron.

**Step 3: auto-update, which is the stricter case.** This is the path that fails two characters earlier, so it's the one worth spending time on.

1. Install 2026.08.0-331 or an older daily under the same long account name.
2. Point it at a channel offering the new build and accept the update.
3. Confirm the update completes with no per-file error and no prompt to skip a file.
4. Confirm no `_` folder is left behind in the install directory. A stranded `{app}\_` is the same symptom as #10484.

**Step 4: measure the installed tree.** In PowerShell:

```powershell
$root = "$env:LOCALAPPDATA\Programs\Positron\"
Get-ChildItem -Recurse -File $root |
  ForEach-Object { $_.FullName.Substring($root.Length) } |
  Sort-Object Length -Descending | Select-Object -First 5 |
  ForEach-Object { "$($_.Length)  $_" }
```

The longest path should be 191 or less. Then confirm no virtualenv shipped:

```powershell
Get-ChildItem -Recurse -Directory -Filter ".venv*" $root
```

That should return nothing.
