### PR TITLE
Make Packages Pane icons consistent

### DIFF
--- a/src/vs/workbench/contrib/positronPackages/browser/packageViewState.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/packageViewState.ts
@@ -40,6 +40,10 @@ export function derivePackageViewState(
 	pkg: ILanguageRuntimePackage | undefined,
 	ctx: PackageViewContext
 ): PackageViewState {
+	// Website before help, matching the order the Packages list uses. The list right-aligns
+	// its icon group, so help (always present there) has to come last to stay pinned to the
+	// row's right edge; the detail page follows that order so an icon does not swap position
+	// when moving between the two views.
 	const website: PackageAction[] = pkg?.url ? ['website'] : [];
 
 	if (!ctx.sessionAlive) {
@@ -50,10 +54,10 @@ export function derivePackageViewState(
 	const showNotActiveHint = !ctx.isActive;
 
 	if (!ctx.installed) {
-		return { installState: 'not-installed', actionsEnabled, actions: ['install', 'help', ...website], showNotActiveHint };
+		return { installState: 'not-installed', actionsEnabled, actions: ['install', ...website, 'help'], showNotActiveHint };
 	}
 	if (pkg?.outdated) {
-		return { installState: 'outdated', actionsEnabled, actions: ['update', 'uninstall', 'help', ...website], showNotActiveHint };
+		return { installState: 'outdated', actionsEnabled, actions: ['update', 'uninstall', ...website, 'help'], showNotActiveHint };
 	}
-	return { installState: 'current', actionsEnabled, actions: ['uninstall', 'help', ...website], showNotActiveHint };
+	return { installState: 'current', actionsEnabled, actions: ['uninstall', ...website, 'help'], showNotActiveHint };
 }

--- a/src/vs/workbench/contrib/positronPackages/test/browser/listPackages.vitest.tsx
+++ b/src/vs/workbench/contrib/positronPackages/test/browser/listPackages.vitest.tsx
@@ -9,7 +9,7 @@
 import React from 'react';
 
 // Testing libraries.
-import { act, screen, waitFor } from '@testing-library/react';
+import { act, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 // Other dependencies.
@@ -67,12 +67,13 @@ function stubGridLayoutWithSize(width: number, height: number): () => void {
 	};
 }
 
-describe('ListPackages highlight', () => {
+describe('ListPackages', () => {
 	// Emitters live at describe scope so the .stub() below captures their .event during build();
 	// tests fire them to drive the view (see the "Common mistakes" note in vitest-tests.md).
 	const onDidRefreshPackagesInstance = new Emitter<ILanguageRuntimePackage[]>();
 	const onDidChangePackages = new Emitter<string[]>();
-	const installed = [pkg('numpy', '1.26.0'), pkg('pandas', '2.0.0')];
+	// numpy carries a url so it renders both action buttons; pandas has none.
+	const installed = [{ ...pkg('numpy', '1.26.0'), url: 'https://numpy.org' }, pkg('pandas', '2.0.0')];
 
 	const fakeInstance = stubInterface<IPositronPackagesInstance>({
 		packages: installed,
@@ -200,5 +201,18 @@ describe('ListPackages highlight', () => {
 		// the nonce is already consumed.
 		act(() => onDidRefreshPackagesInstance.fire([pkg('numpy', '1.26.0'), pkg('pandas', '2.0.0')]));
 		expect(itemRow('numpy')).not.toHaveClass('recently-changed');
+	});
+
+	// The icon group is right-aligned, so help has to come last: it is the only button every
+	// package renders, and keeping it last pins it to the row's right edge whether or not the
+	// package has a website. The detail page follows this same order (see packageViewState).
+	it('renders the website action before the help action, keeping help on the right edge', async () => {
+		renderList();
+		expect(await screen.findByText('numpy')).toBeInTheDocument();
+		const item = itemRow('numpy') as HTMLElement;
+
+		const labels = within(item).getAllByRole('button').map(button => button.getAttribute('aria-label'));
+
+		expect(labels).toEqual(['Open website for numpy', 'Show help for numpy']);
 	});
 });

--- a/src/vs/workbench/contrib/positronPackages/test/browser/packageViewState.vitest.ts
+++ b/src/vs/workbench/contrib/positronPackages/test/browser/packageViewState.vitest.ts
@@ -16,14 +16,14 @@ function pkg(overrides: Partial<ILanguageRuntimePackage> = {}): ILanguageRuntime
 }
 
 describe('derivePackageViewState', () => {
-	it('installed + current + active: uninstall, help, website; actions enabled', () => {
+	it('installed + current + active: uninstall, website, help; actions enabled', () => {
 		expect(derivePackageViewState(pkg(), { installed: true, sessionAlive: true, isActive: true }))
 			.toMatchInlineSnapshot(`
 				{
 				  "actions": [
 				    "uninstall",
-				    "help",
 				    "website",
+				    "help",
 				  ],
 				  "actionsEnabled": true,
 				  "installState": "current",
@@ -32,19 +32,19 @@ describe('derivePackageViewState', () => {
 			`);
 	});
 
-	it('installed + outdated + active: update, uninstall, help, website', () => {
+	it('installed + outdated + active: update, uninstall, website, help', () => {
 		const state = derivePackageViewState(
 			pkg({ outdated: true, latestVersion: '1.1.4' }),
 			{ installed: true, sessionAlive: true, isActive: true });
 		expect(state.installState).toBe('outdated');
-		expect(state.actions).toEqual(['update', 'uninstall', 'help', 'website']);
+		expect(state.actions).toEqual(['update', 'uninstall', 'website', 'help']);
 		expect(state.actionsEnabled).toBe(true);
 	});
 
-	it('not installed + active: install, help, website', () => {
+	it('not installed + active: install, website, help', () => {
 		const state = derivePackageViewState(pkg(), { installed: false, sessionAlive: true, isActive: true });
 		expect(state.installState).toBe('not-installed');
-		expect(state.actions).toEqual(['install', 'help', 'website']);
+		expect(state.actions).toEqual(['install', 'website', 'help']);
 	});
 
 	it('omits website when the package has no url', () => {
@@ -56,7 +56,7 @@ describe('derivePackageViewState', () => {
 		const state = derivePackageViewState(pkg(), { installed: true, sessionAlive: true, isActive: false });
 		expect(state.actionsEnabled).toBe(false);
 		expect(state.showNotActiveHint).toBe(true);
-		expect(state.actions).toEqual(['uninstall', 'help', 'website']);
+		expect(state.actions).toEqual(['uninstall', 'website', 'help']);
 	});
 
 	it('session ended: session-ended state, only website (if url), disabled, no hint', () => {


### PR DESCRIPTION
Fixes #14713

The action icons on a package list item appeared in the opposite order from the icons on the package detail page. This PR changes the detail page to match the list: website, then help.

<img width="1311" height="986" alt="Screenshot 2026-08-06 at 2 36 27 PM" src="https://github.com/user-attachments/assets/40105842-9b13-42b3-8363-da35e02c83c8" />

The list is the constrained side. Its icon group is right-aligned, and help is the only button that every package renders. The website button appears only when the runtime reports a website URL, so Help should come last. The book icon then stays on the right edge of every row, and forms a straight column down the list.

The detail page has no such constraint. Its action row is left-aligned and shows one package at a time.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Show the help and website icons in the same order on package list items and on the package detail page (#14713)

### Validation Steps

@:packages-pane

1. Open the Packages pane.
2. Find a package that has a website, for example numpy or dplyr.
3. Look at the icons on the right of the row. The website (link) icon comes before the help (book) icon.
4. Click the package to open its detail page.
5. Make sure that the two icons are in the same order there.
6. Scroll the list. Make sure that the help icon stays on the right edge of every row.
