### PR TITLE
Release notes links open the downloads page instead of the release notes

### DIFF
--- a/product.json
+++ b/product.json
@@ -44,7 +44,7 @@
 	"agentsTelemetryAppName": "agents",
 	"webviewContentExternalBaseUrlTemplate": "https://{{uuid}}.vscode-cdn.net/insider/ef65ac1ba57f57f2a3961bfe94aa20481caca4c6/out/vs/workbench/contrib/webview/browser/pre/",
 	"updateUrl": "https://cdn.posit.co/positron",
-	"releaseNotesUrl": "https://cdn.posit.co/positron",
+	"releaseNotesUrl": "https://positron.posit.co/release-notes.html",
 	"downloadUrl": "https://positron.posit.co/download",
 	"builtInExtensions": [
 		{

--- a/src/vs/platform/update/common/positronUpdateUtils.ts
+++ b/src/vs/platform/update/common/positronUpdateUtils.ts
@@ -28,6 +28,18 @@ export function buildUpdateUrl(
 }
 
 /**
+ * Builds the URL of the release notes markdown for a version on the update CDN.
+ *
+ * @param updateUrl The update CDN base URL (product.json's `updateUrl`)
+ * @param channel The release channel (e.g. 'releases')
+ * @param version The Positron calver version to fetch release notes for
+ * @returns The complete URL of the release notes markdown file
+ */
+export function buildReleaseNotesUrl(updateUrl: string, channel: string, version: string): string {
+	return `${updateUrl}/${channel}/release-notes/release-${version}.md`;
+}
+
+/**
  * A persisted record of the languages the user ran code in on a given UTC day.
  * Reported on the next update check so usage survives short sessions and cold
  * starts (the check often fires before any code has run in the current session).

--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -411,7 +411,7 @@ export abstract class AbstractUpdateService implements IUpdateService {
 	async getReleaseNotes(version?: string): Promise<string> {
 		const targetVersion = version ?? this.productService.positronVersion;
 		const channel = process.env.POSITRON_UPDATE_CHANNEL ?? this.configurationService.getValue<string>('update.positron.channel');
-		const url = `${this.productService.releaseNotesUrl}/${channel}/release-notes/release-${targetVersion}.md`;
+		const url = `${this.productService.updateUrl}/${channel}/release-notes/release-${targetVersion}.md`;
 		const releaseNotesResponse = await this.requestService.request({ url, callSite: 'update.getReleaseNotes' }, CancellationToken.None);
 
 		if (process.env.POSITRON_UPDATE_CHANNEL) {

--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -37,7 +37,7 @@ import { IUpdate } from '../common/update.js';
 import { hasUpdate } from '../common/positronVersion.js';
 import { INativeHostMainService } from '../../native/electron-main/nativeHostMainService.js';
 import { IStateService } from '../../state/node/state.js';
-import { buildUpdateUrl, mergeActiveLanguageRecord, parseActiveLanguageRecord, reportableLanguages } from '../common/positronUpdateUtils.js';
+import { buildReleaseNotesUrl, buildUpdateUrl, mergeActiveLanguageRecord, parseActiveLanguageRecord, reportableLanguages } from '../common/positronUpdateUtils.js';
 
 // This was modfied from the original createUpdateURL as our update URL structure is much simpler
 export function createUpdateURL(platform: string, channel: string, productService: IProductService): string {
@@ -411,7 +411,7 @@ export abstract class AbstractUpdateService implements IUpdateService {
 	async getReleaseNotes(version?: string): Promise<string> {
 		const targetVersion = version ?? this.productService.positronVersion;
 		const channel = process.env.POSITRON_UPDATE_CHANNEL ?? this.configurationService.getValue<string>('update.positron.channel');
-		const url = `${this.productService.updateUrl}/${channel}/release-notes/release-${targetVersion}.md`;
+		const url = buildReleaseNotesUrl(this.productService.updateUrl ?? '', channel, targetVersion);
 		const releaseNotesResponse = await this.requestService.request({ url, callSite: 'update.getReleaseNotes' }, CancellationToken.None);
 
 		if (process.env.POSITRON_UPDATE_CHANNEL) {

--- a/src/vs/platform/update/test/common/positronUpdateUtils.vitest.ts
+++ b/src/vs/platform/update/test/common/positronUpdateUtils.vitest.ts
@@ -5,7 +5,14 @@
 
 /// <reference types="vitest/globals" />
 
-import { buildUpdateUrl, IActiveLanguageRecord, mergeActiveLanguageRecord, parseActiveLanguageRecord, reportableLanguages } from '../../common/positronUpdateUtils.js';
+import { buildReleaseNotesUrl, buildUpdateUrl, IActiveLanguageRecord, mergeActiveLanguageRecord, parseActiveLanguageRecord, reportableLanguages } from '../../common/positronUpdateUtils.js';
+
+describe('buildReleaseNotesUrl', function () {
+	it('builds the markdown URL from the update CDN base, channel, and version', () => {
+		const result = buildReleaseNotesUrl('https://cdn.posit.co/positron', 'releases', '2026.08.0');
+		expect(result).toBe('https://cdn.posit.co/positron/releases/release-notes/release-2026.08.0.md');
+	});
+});
 
 describe('buildUpdateUrl', function () {
 	const baseUrl = 'https://updates.example.com/releases/darwin/arm64/releases.json';

--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -219,18 +219,18 @@ export class ProductContribution implements IWorkbenchContribution {
 
 			// --- Start Positron ---
 			// Positron uses its calver `parseVersion` (rather than upstream's semver `tryParseVersion`),
-			// `productService.positronVersion`, `productService.downloadUrl`, and gates on the Positron
+			// `productService.positronVersion`, `productService.releaseNotesUrl`, and gates on the Positron
 			// `update.positron.channel === 'releases'` setting.
 			const lastVersion = parseVersion(storageService.get(ProductContribution.KEY, StorageScope.APPLICATION, ''));
 			const currentVersion = parseVersion(productService.positronVersion);
 			const shouldShowReleaseNotes = configurationService.getValue<boolean>('update.showReleaseNotes');
 			const shouldShowPostInstallInfo = configurationService.getValue<boolean>('update.showPostInstallInfo');
-			const downloadUrl = productService.downloadUrl;
+			const releaseNotesUrl = productService.releaseNotesUrl;
 			const channel = configurationService.getValue<string>('update.positron.channel');
 
 			// was there a major/minor update? if so, open release notes (unless post-install info is enabled, which takes over)
 			if (shouldShowReleaseNotes && !shouldShowPostInstallInfo && !environmentService.skipReleaseNotes
-				&& downloadUrl && lastVersion && currentVersion
+				&& releaseNotesUrl && lastVersion && currentVersion
 				&& isMajorMinorUpdate(lastVersion, currentVersion)
 				&& channel === 'releases'
 			) {
@@ -243,8 +243,8 @@ export class ProductContribution implements IWorkbenchContribution {
 							[{
 								label: nls.localize('releaseNotes', "Release Notes"),
 								run: () => {
-									// view release notes from the downloads page
-									const uri = URI.parse(downloadUrl);
+									// view release notes on the Positron website
+									const uri = URI.parse(releaseNotesUrl);
 									openerService.open(uri);
 								}
 							}],

--- a/src/vs/workbench/contrib/update/test/browser/productContribution.vitest.ts
+++ b/src/vs/workbench/contrib/update/test/browser/productContribution.vitest.ts
@@ -1,0 +1,101 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { URI } from '../../../../../base/common/uri.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { INotificationService, IPromptChoice } from '../../../../../platform/notification/common/notification.js';
+import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { IBrowserWorkbenchEnvironmentService } from '../../../../services/environment/browser/environmentService.js';
+import { IHostService } from '../../../../services/host/browser/host.js';
+import { TestProductService } from '../../../../test/common/workbenchTestServices.js';
+import { ProductContribution } from '../../browser/update.js';
+
+describe('ProductContribution', () => {
+	const RELEASE_NOTES_URL = 'https://positron.posit.co/release-notes.html';
+
+	const CURRENT_VERSION = '2026.09.0';
+	const PREVIOUS_VERSION = '2026.08.0';
+
+	const ctx = createTestContainer()
+		.withWorkbenchServices()
+		.build();
+
+	const show = vi.fn<() => Promise<boolean>>();
+	const prompt = vi.fn();
+	const open = vi.fn<(uri: URI) => Promise<boolean>>();
+
+	// `ProductContribution` only uses IInstantiationService to create the release
+	// notes editor manager; returning a fake with a controllable `show` lets tests
+	// choose whether the in-editor path succeeds or falls back to the notification.
+	const instantiationService = stubInterface<IInstantiationService>({
+		createInstance: (() => ({ show })) as unknown as IInstantiationService['createInstance'],
+	});
+
+	function createContribution(productOverrides: Partial<IProductService> = {}): void {
+		new ProductContribution(
+			ctx.get(IStorageService),
+			instantiationService,
+			stubInterface<INotificationService>({ prompt }),
+			stubInterface<IBrowserWorkbenchEnvironmentService>({ skipReleaseNotes: false }),
+			stubInterface<IOpenerService>({ open }),
+			ctx.get(IConfigurationService),
+			stubInterface<IHostService>({ hadLastFocus: () => Promise.resolve(true) }),
+			{
+				...TestProductService,
+				positronVersion: CURRENT_VERSION,
+				releaseNotesUrl: RELEASE_NOTES_URL,
+				downloadUrl: 'https://positron.posit.co/download',
+				...productOverrides,
+			},
+		);
+	}
+
+	beforeEach(async () => {
+		const configuration = ctx.get(IConfigurationService) as TestConfigurationService;
+		configuration.setUserConfiguration('update.showReleaseNotes', true);
+		configuration.setUserConfiguration('update.showPostInstallInfo', false);
+		configuration.setUserConfiguration('update.positron.channel', 'releases');
+
+		ctx.get(IStorageService).store(ProductContribution.KEY, PREVIOUS_VERSION, StorageScope.APPLICATION, StorageTarget.MACHINE);
+	});
+
+	it('prompts with releaseNotesUrl, not downloadUrl, when the release notes editor fails', async () => {
+		show.mockRejectedValue(new Error('release notes not published'));
+
+		createContribution();
+
+		await vi.waitFor(() => expect(prompt).toHaveBeenCalledOnce());
+		const [, message, choices] = prompt.mock.calls[0] as [unknown, string, IPromptChoice[]];
+		expect(message).toContain(CURRENT_VERSION);
+		expect(choices[0].label).toBe('Release Notes');
+
+		choices[0].run();
+
+		expect(open).toHaveBeenCalledOnce();
+		expect(open.mock.calls[0][0].toString()).toBe(RELEASE_NOTES_URL);
+	});
+
+	it('skips the release notes flow when no releaseNotesUrl is configured', async () => {
+		show.mockRejectedValue(new Error('release notes not published'));
+
+		createContribution({ releaseNotesUrl: undefined });
+
+		// The stored version is always advanced to the running version, which
+		// marks the end of the startup flow.
+		await vi.waitFor(() => {
+			expect(ctx.get(IStorageService).get(ProductContribution.KEY, StorageScope.APPLICATION)).toBe(CURRENT_VERSION);
+		});
+		expect(show).not.toHaveBeenCalled();
+		expect(prompt).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
The post-update notification ("Welcome to Positron v2026.08.0! Would you like to read the Release Notes?") sends users to the downloads page, which no longer displays release notes.

The update notifications ("There's an update available", "update is now ready") have the same problem in a different spot. Their **Release Notes** button renders the notes in an editor tab, but when that fetch fails it falls back to opening `releaseNotesUrl` in the browser -- and that was set to the bare CDN address `https://cdn.posit.co/positron`, which is a 403 error page.

This PR points both at the release notes page on the website, `https://positron.posit.co/release-notes.html`.

`releaseNotesUrl` in product.json was doing two jobs, so the fix splits them:

- `releaseNotesUrl` is now the release notes web page, which is what the field means upstream in VS Code. Both browser-opening paths use it.
- The in-editor release notes fetch now builds its CDN path from `updateUrl` instead. `updateUrl` held the identical CDN base, so the fetched URL is unchanged.

Note: this PR does not change the adjacent rough edge: The **Show Release Notes** command still errors instead of falling back to the website when the running version has no published markdown (every dev build on an unreleased version)

### Screenshots

**Show Release Notes renders the notes in the editor**

https://github.com/user-attachments/assets/0d0acf39-5af9-42d6-b9f2-2c2a35fdad88

the Desktop)

**Welcome notification opens the release notes page**

https://github.com/user-attachments/assets/53f8e485-af0f-4f06-a6b0-4d650c74f7fe

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- The Release Notes notification and links now open the release notes page on the Positron website instead of the downloads page

### Validation Steps

@:critical @:welcome

SETUP: run a dev build from this branch; the steps use dev-only commands.

**In-editor release notes (fetch path unchanged)**

1. In product.json, set `positronVersion` to `"2026.08.0"` (the CDN only hosts markdown for shipped releases) and launch.
2. Run **Show Release Notes** from the Command Palette. The notes render in an editor tab titled **Release Notes: 2026.08.0**.
3. Revert `positronVersion` to `"2026.09.0"` and relaunch.

**Welcome notification (the fix)**

4. Run **Developer: Set Last Update Version** and enter `2026.08.0`.
5. Run **Developer: Reload Window**.
6. Expect the notification **Welcome to Positron Dev v2026.09.0! Would you like to read the Release Notes?** If no toast appears, open the notification center via the bell icon in the status bar; the toast is suppressed while the Console has focus.
7. Click **Release Notes**. The browser opens `https://positron.posit.co/release-notes.html` (previously the downloads page).
