### PR TITLE
Revert "Exclude broken argcomplete 3.7.1 from Python CI nox install"

### DIFF
--- a/.github/workflows/positron-python-ci.yml
+++ b/.github/workflows/positron-python-ci.yml
@@ -245,12 +245,7 @@ jobs:
       - name: Install testing requirements
         run: |
           uv run scripts/vendor.py
-          # argcomplete is a nox dependency. 3.7.1 annotates a class attribute
-          # with PEP 604 `str | bytes`, which is evaluated at runtime and needs
-          # Python 3.10+, but the release still declares requires_python>=3.8.
-          # uv installs it into this 3.9 venv and importing nox then raises
-          # TypeError. Drop the exclusion once upstream corrects the metadata.
-          uv pip install nox 'argcomplete!=3.7.1'
+          uv pip install nox
 
       - name: Run tests
         run: npm run positron:testMinimumPythonReqs


### PR DESCRIPTION
Reverts posit-dev/positron#15326. I fixed argcomplete in https://github.com/kislyuk/argcomplete/pull/558.