### PR TITLE
Shut down an idle PET server

### DIFF
--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -842,6 +842,13 @@
                     "scope": "machine-overridable",
                     "type": "string"
                 },
+                "python.locatorIdleTimeout": {
+                    "default": 180,
+                    "markdownDescription": "%python.locatorIdleTimeout.description%",
+                    "minimum": 0,
+                    "scope": "machine-overridable",
+                    "type": "number"
+                },
                 "python.pipenvPath": {
                     "default": "pipenv",
                     "description": "%python.pipenvPath.description%",

--- a/extensions/positron-python/package.nls.json
+++ b/extensions/positron-python/package.nls.json
@@ -89,6 +89,7 @@
     "python.missingPackage.severity.description": "Set severity of missing packages in requirements.txt or pyproject.toml",
     "python.packageManager.useRequirementsFile.description": "Use the workspace root requirements.txt file (when present) as the source of truth for package install and update operations from the Packages pane. When enabled, changes are resolved against requirements.txt; when disabled, they resolve against the currently installed packages instead.",
     "python.locator.description": "Choose how to discover Python interpreters. Native uses [Python Environment Tools](https://github.com/microsoft/python-environment-tools) a faster, Rust-based locator, while JS uses a JavaScript implementation.",
+    "python.locatorIdleTimeout.description": "Time in seconds the native locator server ([Python Environment Tools](https://github.com/microsoft/python-environment-tools)) may sit idle before it is shut down. It restarts automatically on the next discovery request. Set to 0 to keep it running until the window closes. Only applies when `#python.locator#` is `native`.",
     "python.pipenvPath.description": "Path to the pipenv executable to use for activation.",
     "python.poetryPath.description": "Path to the poetry executable.",
     "python.quietMode.description": "Start Positron's IPython shell in quiet mode, to suppress initial version and help messages (restart Positron to apply).",

--- a/extensions/positron-python/src/client/positron/interpreterSettings.ts
+++ b/extensions/positron-python/src/client/positron/interpreterSettings.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -102,6 +102,18 @@ export function getCustomEnvDirs(): string[] {
     }
 
     return [];
+}
+
+/**
+ * Whether interpreter startup is disabled for Python via Positron's
+ * `interpreters.startupBehavior` setting. Reads the python language-scoped
+ * configuration, which falls back to the general value when no `[python]`
+ * override is set. When disabled, eager Python environment discovery (and
+ * the PET server it spawns) is skipped at startup; discovery still runs
+ * lazily if explicitly requested.
+ */
+export function isPythonStartupDisabled(): boolean {
+    return getConfiguration('interpreters', { languageId: 'python' })?.get<string>('startupBehavior') === 'disabled';
 }
 
 /**

--- a/extensions/positron-python/src/client/pythonEnvironments/base/locators/common/nativePythonFinder.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/locators/common/nativePythonFinder.ts
@@ -32,7 +32,7 @@ import { executeCommand } from '../../../../common/vscodeApis/commandApis';
 import { getGlobalStorage, IPersistentStorage } from '../../../../common/persistentState';
 
 // --- Start Positron ---
-import { getCustomEnvDirs } from '../../../../positron/interpreterSettings';
+import { getCustomEnvDirs, isPythonStartupDisabled } from '../../../../positron/interpreterSettings';
 import { traceVerbose } from '../../../../logging';
 import { ADDITIONAL_POSIX_BIN_PATHS } from '../../../common/posixUtils';
 import { PythonEnvSource } from '../../info/index';
@@ -47,6 +47,10 @@ const PYTHON_ENV_TOOLS_PATH = isWindows()
 // --- End Positron ---
 
 const DONT_SHOW_SPAWN_ERROR_AGAIN = 'DONT_SHOW_NATIVE_FINDER_SPAWN_ERROR_AGAIN';
+
+// --- Start Positron ---
+const LOCATOR_IDLE_TIMEOUT_SETTING_KEY = 'locatorIdleTimeout';
+// --- End Positron ---
 
 export interface NativeEnvInfo {
     displayName?: string;
@@ -120,6 +124,12 @@ export interface NativePythonFinder extends Disposable {
      * distinguish a broken locator from an empty one.
      */
     readonly lastDiscoveryError: string | undefined;
+    /**
+     * Process id of the running PET server, or `undefined` when the server is
+     * not running (never started, shut down after the idle timeout, or exited).
+     * Used by tests and diagnostics.
+     */
+    readonly serverPid: number | undefined;
     // --- End Positron ---
 }
 
@@ -181,7 +191,20 @@ export function bufferedEvents<T>(discovered: Event<T>, completed: Promise<void>
 // --- End Positron ---
 
 class NativePythonFinderImpl extends DisposableBase implements NativePythonFinder {
-    private readonly connection: rpc.MessageConnection;
+    // --- Start Positron ---
+    // private readonly connection: rpc.MessageConnection;
+    // The connection and server process are created lazily and can be torn down
+    // (idle timeout, crash, dispose) and recreated by the next request.
+    private connection: rpc.MessageConnection | undefined;
+
+    private serverProc: ch.ChildProcess | undefined;
+
+    private connectionDisposable: Disposable | undefined;
+
+    public get serverPid(): number | undefined {
+        return this.serverProc?.pid;
+    }
+    // --- End Positron ---
 
     // --- Start Positron ---
     // private firstRefreshResults: undefined | (() => AsyncGenerator<NativeEnvInfo, void, unknown>);
@@ -211,14 +234,39 @@ class NativePythonFinderImpl extends DisposableBase implements NativePythonFinde
         this.suppressErrorNotification = this.context
             ? getGlobalStorage<boolean>(this.context, DONT_SHOW_SPAWN_ERROR_AGAIN, false)
             : ({ get: () => false, set: async () => {} } as IPersistentStorage<boolean>);
-        this.connection = this.start();
-        void this.configure();
-        this.firstRefreshResults = this.refreshFirstTime();
+        // --- Start Positron ---
+        // this.connection = this.start();
+        // The connection now starts lazily via ensureConnection(); make sure the
+        // server is stopped when the finder itself is disposed.
+        this._register(new Disposable(() => this.shutdownServer()));
+        // void this.configure();
+        // this.firstRefreshResults = this.refreshFirstTime();
+        // When Python startup is disabled, skip the eager configure and first
+        // refresh so no PET server spawns at startup; discovery still works
+        // lazily when explicitly requested.
+        if (!isPythonStartupDisabled()) {
+            void this.configure();
+            this.firstRefreshResults = this.refreshFirstTime();
+        }
+        // --- End Positron ---
     }
 
-    public async resolve(executable: string): Promise<NativeEnvInfo> {
+    // --- Start Positron ---
+    // Positron wrapper: counts the request so the idle timer stays disarmed while
+    // it runs, then delegates to the upstream body (renamed to `resolveImpl`).
+    // Wrapping rather than re-indenting keeps the upstream body byte-identical,
+    // so upstream merges do not conflict on it. Mirrors configure/configureImpl.
+    public resolve(executable: string): Promise<NativeEnvInfo> {
+        return this.trackRequest(() => this.resolveImpl(executable));
+    }
+
+    private async resolveImpl(executable: string): Promise<NativeEnvInfo> {
+        // --- End Positron ---
         await this.configure();
-        const environment = await this.connection.sendRequest<NativeEnvInfo>('resolve', {
+        // --- Start Positron ---
+        // const environment = await this.connection.sendRequest<NativeEnvInfo>('resolve', {
+        const environment = await this.ensureConnection().sendRequest<NativeEnvInfo>('resolve', {
+            // --- End Positron ---
             executable,
         });
 
@@ -258,6 +306,119 @@ class NativePythonFinderImpl extends DisposableBase implements NativePythonFinde
         // --- End Positron ---
     }
 
+    // --- Start Positron ---
+    /**
+     * Returns the JSON-RPC connection to the PET server, spawning the server
+     * if it is not currently running (first use, after the idle timeout, or
+     * after a crash).
+     */
+    private ensureConnection(): rpc.MessageConnection {
+        if (!this.connection) {
+            this.connection = this.start();
+        }
+        return this.connection;
+    }
+
+    /**
+     * Stops the PET server and disposes the JSON-RPC connection. Safe to call
+     * when the server is not running. The next request respawns the server.
+     */
+    private inFlightRequests = 0;
+
+    private idleTimer: NodeJS.Timeout | undefined;
+
+    /** Marks the start of a PET request; suspends the idle timer. */
+    private beginRequest(): void {
+        this.inFlightRequests += 1;
+        this.clearIdleTimer();
+    }
+
+    /** Marks the end of a PET request; arms the idle timer when none remain. */
+    private endRequest(): void {
+        this.inFlightRequests = Math.max(0, this.inFlightRequests - 1);
+        if (this.inFlightRequests === 0 && this.connection) {
+            this.armIdleTimer();
+        }
+    }
+
+    /**
+     * Runs a PET request with idle-timer accounting, so the server is never shut
+     * down underneath an in-flight request. Lets the upstream method bodies stay
+     * untouched: the exported method becomes a one-line wrapper around this and
+     * the original body keeps its shape as an `Impl` method.
+     */
+    private async trackRequest<T>(run: () => Promise<T>): Promise<T> {
+        this.beginRequest();
+        try {
+            return await run();
+        } finally {
+            this.endRequest();
+        }
+    }
+
+    private clearIdleTimer(): void {
+        if (this.idleTimer) {
+            clearTimeout(this.idleTimer);
+            this.idleTimer = undefined;
+        }
+    }
+
+    /**
+     * Schedules an idle shutdown of the PET server. The timeout is read live
+     * from `python.locatorIdleTimeout` (seconds) so setting changes apply
+     * without a reload; 0 (or a negative value) disables the shutdown.
+     */
+    private armIdleTimer(): void {
+        this.clearIdleTimer();
+        const timeoutSeconds = getConfiguration('python').get<number>(LOCATOR_IDLE_TIMEOUT_SETTING_KEY, 180);
+        if (!timeoutSeconds || timeoutSeconds <= 0) {
+            return;
+        }
+        this.idleTimer = setTimeout(() => {
+            this.idleTimer = undefined;
+            if (this.inFlightRequests === 0 && this.connection) {
+                this.outputChannel.info(
+                    `Shutting down Python Locator server after ${timeoutSeconds}s idle; it restarts on the next request`,
+                );
+                this.shutdownServer();
+            }
+        }, timeoutSeconds * 1000);
+    }
+
+    /**
+     * Clears the cached connection state once `proc`'s server is gone, whether it
+     * exited, failed to spawn, or its RPC connection errored, so the next request
+     * starts a fresh server instead of reusing a dead one. Identity-guarded: a
+     * late event from a superseded server must not clobber its replacement.
+     */
+    private handleServerGone(proc: ch.ChildProcess): void {
+        if (this.serverProc !== proc) {
+            return;
+        }
+        const disposable = this.connectionDisposable;
+        this.serverProc = undefined;
+        this.connection = undefined;
+        this.connectionDisposable = undefined;
+        this.lastConfiguration = undefined;
+        this.clearIdleTimer();
+        // Dispose rather than just drop: disposing the RPC connection rejects
+        // requests that are still in flight. Without this a request issued
+        // against a server that then dies never settles, which is the hang this
+        // whole teardown exists to prevent. On a normal exit `connection.onClose`
+        // would also get here, but a failed spawn has no close and no exit.
+        disposable?.dispose();
+    }
+
+    private shutdownServer(): void {
+        this.clearIdleTimer();
+        const disposable = this.connectionDisposable;
+        this.connectionDisposable = undefined;
+        this.connection = undefined;
+        this.lastConfiguration = undefined;
+        disposable?.dispose();
+    }
+    // --- End Positron ---
+
     // eslint-disable-next-line class-methods-use-this
     private start(): rpc.MessageConnection {
         this.outputChannel.info(`Starting Python Locator ${PYTHON_ENV_TOOLS_PATH} server`);
@@ -272,6 +433,9 @@ class NativePythonFinderImpl extends DisposableBase implements NativePythonFinde
             const stopWatch = new StopWatch();
             const proc = ch.spawn(PYTHON_ENV_TOOLS_PATH, ['server'], { env: process.env });
             this.initialRefreshMetrics.timeToSpawn = stopWatch.elapsedTime;
+            // --- Start Positron ---
+            this.serverProc = proc;
+            // --- End Positron ---
             proc.stdout.pipe(readable, { end: false });
             proc.stderr.on('data', (data) => this.outputChannel.error(data.toString()));
             writable.pipe(proc.stdin, { end: false });
@@ -282,6 +446,12 @@ class NativePythonFinderImpl extends DisposableBase implements NativePythonFinde
                 this.outputChannel.error(`Error details: ${JSON.stringify(error)}`);
                 // --- Start Positron ---
                 this._lastDiscoveryError = error.message;
+                // A process that never started must not stay cached as the current
+                // server: Node may emit 'error' without a following 'exit', so this
+                // is the only teardown some spawn failures get.
+                this.handleServerGone(proc);
+                // eslint-disable-next-line @typescript-eslint/no-use-before-define
+                disposeStreams.dispose();
                 // --- End Positron ---
                 this.handleSpawnError(error.message);
             });
@@ -304,6 +474,18 @@ class NativePythonFinderImpl extends DisposableBase implements NativePythonFinde
                     // --- End Positron ---
                     this.handleSpawnError(errorMessage);
                 }
+                // --- Start Positron ---
+                // Tear down the RPC plumbing whenever the server exits, expected
+                // or not. The stdio pipes use { end: false }, so without this the
+                // connection never closes and any later request hangs forever
+                // instead of respawning the server.
+                this.handleServerGone(proc);
+                // `disposeStreams` is declared after this try block, but the exit
+                // handler only runs on a later event-loop turn, so it is always
+                // initialized by then; `connection.onError` relies on this too.
+                // eslint-disable-next-line @typescript-eslint/no-use-before-define
+                disposeStreams.dispose();
+                // --- End Positron ---
             });
 
             disposables.push({
@@ -320,6 +502,11 @@ class NativePythonFinderImpl extends DisposableBase implements NativePythonFinde
         } catch (ex) {
             this.outputChannel.error(`Error starting Python Finder ${PYTHON_ENV_TOOLS_PATH} server`, ex);
         }
+        // --- Start Positron ---
+        // The spawned process, captured outside the try block above so the
+        // connection-level handlers below can identity-guard their teardown.
+        const spawnedProc = this.serverProc;
+        // --- End Positron ---
         const disposeStreams = new Disposable(() => {
             readable.end();
             writable.end();
@@ -336,6 +523,11 @@ class NativePythonFinderImpl extends DisposableBase implements NativePythonFinde
                 this.outputChannel.error('Connection Error:', ex);
                 // --- Start Positron ---
                 this._lastDiscoveryError = `Connection error: ${String(ex)}`;
+                // The streams are dead, so this connection can never serve another
+                // request; drop it so the next one starts a fresh server.
+                if (spawnedProc) {
+                    this.handleServerGone(spawnedProc);
+                }
                 // --- End Positron ---
             }),
             connection.onNotification('log', (data: NativeLog) => {
@@ -365,7 +557,13 @@ class NativePythonFinderImpl extends DisposableBase implements NativePythonFinde
         );
 
         connection.listen();
-        this._register(Disposable.from(...disposables));
+        // --- Start Positron ---
+        // this._register(Disposable.from(...disposables));
+        // Held per-connection instead of on the class store so shutdownServer()
+        // can dispose one server's resources without leaking entries across
+        // respawns; the class-level dispose runs shutdownServer().
+        this.connectionDisposable = Disposable.from(...disposables);
+        // --- End Positron ---
         return connection;
     }
 
@@ -373,6 +571,12 @@ class NativePythonFinderImpl extends DisposableBase implements NativePythonFinde
         completed: Promise<void>;
         discovered: Event<NativeEnvInfo | NativeEnvManagerInfo>;
     } {
+        // --- Start Positron ---
+        // All notification handlers and requests in this refresh must target one
+        // and the same server instance, so capture the connection once.
+        this.beginRequest();
+        const connection = this.ensureConnection();
+        // --- End Positron ---
         const disposable = this._register(new DisposableStore());
         const discovered = disposable.add(new EventEmitter<NativeEnvInfo | NativeEnvManagerInfo>());
         const completed = createDeferred<void>();
@@ -399,7 +603,10 @@ class NativePythonFinderImpl extends DisposableBase implements NativePythonFinde
         // Assumption is server will ensure there's only one refresh at a time.
         // Perhaps we should have a request Id or the like to map the results back to the `refresh` request.
         disposable.add(
-            this.connection.onNotification('environment', (data: NativeEnvInfo) => {
+            // --- Start Positron ---
+            // this.connection.onNotification('environment', (data: NativeEnvInfo) => {
+            connection.onNotification('environment', (data: NativeEnvInfo) => {
+                // --- End Positron ---
                 this.outputChannel.info(`Discovered env: ${data.executable || data.prefix}`);
                 // We know that in the Python extension if either Version of Prefix is not provided by locator
                 // Then we end up resolving the information.
@@ -411,7 +618,10 @@ class NativePythonFinderImpl extends DisposableBase implements NativePythonFinde
                     // HACK = TEMPORARY WORK AROUND, TO GET STUFF WORKING
                     // HACK = TEMPORARY WORK AROUND, TO GET STUFF WORKING
                     // HACK = TEMPORARY WORK AROUND, TO GET STUFF WORKING
-                    const promise = this.connection
+                    // --- Start Positron ---
+                    // const promise = this.connection
+                    const promise = connection
+                        // --- End Positron ---
                         .sendRequest<NativeEnvInfo>('resolve', {
                             executable: data.executable,
                         })
@@ -427,7 +637,10 @@ class NativePythonFinderImpl extends DisposableBase implements NativePythonFinde
             }),
         );
         disposable.add(
-            this.connection.onNotification('manager', (data: NativeEnvManagerInfo) => {
+            // --- Start Positron ---
+            // this.connection.onNotification('manager', (data: NativeEnvManagerInfo) => {
+            connection.onNotification('manager', (data: NativeEnvManagerInfo) => {
+                // --- End Positron ---
                 this.outputChannel.info(`Discovered manager: (${data.tool}) ${data.executable}`);
                 discovered.fire(data);
             }),
@@ -446,7 +659,10 @@ class NativePythonFinderImpl extends DisposableBase implements NativePythonFinde
         }
         trackPromiseAndNotifyOnCompletion(
             this.configure().then(() =>
-                this.connection
+                // --- Start Positron ---
+                // this.connection
+                connection
+                    // --- End Positron ---
                     .sendRequest<{ duration: number }>('refresh', refreshOptions)
                     .then(({ duration }) => {
                         this.outputChannel.info(`Refresh completed in ${duration}ms`);
@@ -464,7 +680,13 @@ class NativePythonFinderImpl extends DisposableBase implements NativePythonFinde
             ),
         );
 
-        completed.promise.finally(() => disposable.dispose());
+        // --- Start Positron ---
+        // completed.promise.finally(() => disposable.dispose());
+        completed.promise.finally(() => {
+            disposable.dispose();
+            this.endRequest();
+        });
+        // --- End Positron ---
         return {
             completed: completed.promise,
             discovered: discovered.event,
@@ -491,11 +713,12 @@ class NativePythonFinderImpl extends DisposableBase implements NativePythonFinde
      */
     // --- Start Positron ---
     private configure(): Promise<void> {
+        this.beginRequest();
         const next = this.configureQueue.then(() => this.configureImpl());
         // A failed configure must not poison the queue for later callers; the
         // returned promise still rejects so this caller observes the failure.
         this.configureQueue = next.catch(() => undefined);
-        return next;
+        return next.finally(() => this.endRequest());
     }
 
     private async configureImpl() {
@@ -518,15 +741,28 @@ class NativePythonFinderImpl extends DisposableBase implements NativePythonFinde
         try {
             const stopWatch = new StopWatch();
             this.lastConfiguration = options;
-            await this.connection.sendRequest('configure', options);
+            // --- Start Positron ---
+            // await this.connection.sendRequest('configure', options);
+            await this.ensureConnection().sendRequest('configure', options);
+            // --- End Positron ---
             this.initialRefreshMetrics.timeToConfigure = stopWatch.elapsedTime;
         } catch (ex) {
             this.outputChannel.error('Refresh error', ex);
         }
     }
 
-    async getCondaInfo(): Promise<NativeCondaInfo> {
-        return this.connection.sendRequest<NativeCondaInfo>('condaInfo');
+    // --- Start Positron ---
+    // Positron wrapper, as for resolve() above.
+    getCondaInfo(): Promise<NativeCondaInfo> {
+        return this.trackRequest(() => this.getCondaInfoImpl());
+    }
+
+    private async getCondaInfoImpl(): Promise<NativeCondaInfo> {
+        // --- End Positron ---
+        // --- Start Positron ---
+        // return this.connection.sendRequest<NativeCondaInfo>('condaInfo');
+        return this.ensureConnection().sendRequest<NativeCondaInfo>('condaInfo');
+        // --- End Positron ---
     }
 
     private async handleSpawnError(errorMessage: string): Promise<void> {
@@ -659,6 +895,7 @@ export function getNativePythonFinder(context?: IExtensionContext): NativePython
             },
             // --- Start Positron ---
             lastDiscoveryError: undefined,
+            serverPid: undefined,
             // --- End Positron ---
             dispose() {
                 // do nothing
@@ -674,6 +911,16 @@ export function getNativePythonFinder(context?: IExtensionContext): NativePython
     }
     return _finder;
 }
+
+// --- Start Positron ---
+/**
+ * Test-only: constructs a fresh finder, bypassing the module-level singleton,
+ * so lifecycle tests can create and dispose independent instances.
+ */
+export function createNativePythonFinder(cacheDirectory?: Uri, context?: IExtensionContext): NativePythonFinder {
+    return new NativePythonFinderImpl(cacheDirectory, context);
+}
+// --- End Positron ---
 
 export function getCacheDirectory(context: IExtensionContext): Uri {
     return Uri.joinPath(context.globalStorageUri, 'pythonLocator');

--- a/extensions/positron-python/src/client/pythonEnvironments/index.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/index.ts
@@ -50,6 +50,7 @@ import { createEnvExtApi } from '../envExt/envExtApi';
 import { UserSpecifiedEnvironmentLocator } from './base/locators/lowLevel/userSpecifiedEnvLocator';
 import { ModuleEnvironmentLocator } from './base/locators/lowLevel/moduleEnvironmentLocator';
 import { createNativeEnvironmentsApiWithModules } from './nativeAPI';
+import { isPythonStartupDisabled } from '../positron/interpreterSettings';
 // --- End Positron ---
 
 const PYTHON_ENV_INFO_CACHE_KEY = 'PYTHON_ENV_INFO_CACHEv2';
@@ -116,7 +117,10 @@ export async function activateAndRefreshEnvs(api: IDiscoveryAPI): Promise<Activa
      * it has not previously been triggered
      */
 
-    api.triggerRefresh().ignoreErrors();
+    // Skip the eager refresh when Python startup is disabled (#15004).
+    if (!isPythonStartupDisabled()) {
+        api.triggerRefresh().ignoreErrors();
+    }
 
     return {
         fullyReady: Promise.resolve(),

--- a/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
@@ -42,7 +42,7 @@ import { getWorkspaceFolders, onDidChangeWorkspaceFolders } from '../common/vsco
 
 // --- Start Positron ---
 import { getUvDirs, isUvEnvironment, isUvManagedBasePython } from './common/environmentManagers/uv';
-import { isCustomEnvironment } from '../positron/interpreterSettings';
+import { isCustomEnvironment, isPythonStartupDisabled } from '../positron/interpreterSettings';
 import { isAdditionalGlobalBinPath } from './common/environmentManagers/globalInstalledEnvs';
 // eslint-disable-next-line import/no-duplicates
 import { PythonEnvSource } from './base/info';
@@ -815,7 +815,13 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
 
 export function createNativeEnvironmentsApi(finder: NativePythonFinder): IDiscoveryAPI & Disposable {
     const native = new NativePythonEnvironments(finder);
-    native.triggerRefresh().ignoreErrors();
+    // --- Start Positron ---
+    // native.triggerRefresh().ignoreErrors();
+    // Skip the eager refresh when Python startup is disabled (#15004).
+    if (!isPythonStartupDisabled()) {
+        native.triggerRefresh().ignoreErrors();
+    }
+    // --- End Positron ---
     return native;
 }
 
@@ -1301,7 +1307,10 @@ async function checkForExistingEnv(
 export function createNativeEnvironmentsApiWithModules(finder: NativePythonFinder): IDiscoveryAPI & Disposable {
     const native = new NativePythonEnvironments(finder);
     const wrapper = new NativeWithModulesApi(native);
-    wrapper.triggerRefresh().ignoreErrors();
+    // Skip the eager refresh when Python startup is disabled (#15004).
+    if (!isPythonStartupDisabled()) {
+        wrapper.triggerRefresh().ignoreErrors();
+    }
     return wrapper;
 }
 

--- a/extensions/positron-python/src/test/positron/interpreterSettings.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/interpreterSettings.unit.test.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { assert } from 'chai';
+import * as sinon from 'sinon';
+import * as typemoq from 'typemoq';
+import { WorkspaceConfiguration } from 'vscode';
+import * as workspaceApis from '../../client/common/vscodeApis/workspaceApis';
+import { isPythonStartupDisabled } from '../../client/positron/interpreterSettings';
+
+suite('isPythonStartupDisabled', () => {
+    let getConfigurationStub: sinon.SinonStub;
+    let startupBehavior: string | undefined;
+
+    setup(() => {
+        getConfigurationStub = sinon.stub(workspaceApis, 'getConfiguration');
+        const configMock = typemoq.Mock.ofType<WorkspaceConfiguration>();
+        configMock.setup((c) => c.get<string>('startupBehavior')).returns(() => startupBehavior);
+        getConfigurationStub.returns(configMock.object);
+    });
+
+    teardown(() => {
+        sinon.restore();
+    });
+
+    test('returns true only when startupBehavior resolves to disabled', () => {
+        const cases: [string | undefined, boolean][] = [
+            ['disabled', true],
+            ['auto', false],
+            ['manual', false],
+            ['always', false],
+            [undefined, false],
+        ];
+        const results = cases.map(([value]) => {
+            startupBehavior = value;
+            return isPythonStartupDisabled();
+        });
+        assert.deepStrictEqual(
+            results,
+            cases.map(([, expected]) => expected),
+        );
+    });
+
+    test('reads the python language-scoped interpreters configuration', () => {
+        startupBehavior = 'disabled';
+        isPythonStartupDisabled();
+        assert.deepStrictEqual(getConfigurationStub.firstCall.args, ['interpreters', { languageId: 'python' }]);
+    });
+});

--- a/extensions/positron-python/src/test/pythonEnvironments/base/locators/composite/envsCollectionService.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/base/locators/composite/envsCollectionService.unit.test.ts
@@ -31,6 +31,7 @@ import * as nativeFinder from '../../../../../client/pythonEnvironments/base/loc
 class MockNativePythonFinder implements nativeFinder.NativePythonFinder {
     // --- Start Positron ---
     readonly lastDiscoveryError: string | undefined;
+    readonly serverPid: number | undefined;
     // --- End Positron ---
 
     find(_searchPath: string): Promise<nativeFinder.NativeEnvInfo[]> {

--- a/extensions/positron-python/src/test/pythonEnvironments/nativePythonFinderLifecycle.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/nativePythonFinderLifecycle.unit.test.ts
@@ -1,0 +1,190 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Lifecycle tests for the PET server owned by `NativePythonFinderImpl`: idle
+ * shutdown, transparent respawn after a crash, and the startup gate when Python
+ * interpreter startup is disabled. See
+ * https://github.com/posit-dev/positron/issues/15004.
+ *
+ */
+
+import { assert } from 'chai';
+import * as sinon from 'sinon';
+import * as typemoq from 'typemoq';
+import { WorkspaceConfiguration } from 'vscode';
+import {
+    createNativePythonFinder,
+    NativeEnvInfo,
+    NativePythonFinder,
+} from '../../client/pythonEnvironments/base/locators/common/nativePythonFinder';
+import * as windowsApis from '../../client/common/vscodeApis/windowApis';
+import * as workspaceApis from '../../client/common/vscodeApis/workspaceApis';
+import { MockOutputChannel } from '../mockClasses';
+
+suite('Native Python Finder - server lifecycle (#15004)', () => {
+    let getConfigurationStub: sinon.SinonStub;
+    let configMock: typemoq.IMock<WorkspaceConfiguration>;
+    let interpretersConfigMock: typemoq.IMock<WorkspaceConfiguration>;
+    let idleTimeoutSeconds: number;
+    let startupBehavior: string | undefined;
+
+    setup(() => {
+        sinon.stub(windowsApis, 'createLogOutputChannel').returns(new MockOutputChannel('locator'));
+        sinon.stub(workspaceApis, 'getWorkspaceFolderPaths').returns([]);
+
+        idleTimeoutSeconds = 0;
+        startupBehavior = undefined;
+
+        configMock = typemoq.Mock.ofType<WorkspaceConfiguration>();
+        configMock.setup((c) => c.get<string>('venvPath')).returns(() => undefined);
+        configMock.setup((c) => c.get<string[]>('venvFolders')).returns(() => []);
+        configMock.setup((c) => c.get<string>('condaPath')).returns(() => '');
+        configMock.setup((c) => c.get<string>('poetryPath')).returns(() => '');
+        configMock.setup((c) => c.get('locatorIdleTimeout', 180)).returns(() => idleTimeoutSeconds);
+
+        interpretersConfigMock = typemoq.Mock.ofType<WorkspaceConfiguration>();
+        interpretersConfigMock.setup((c) => c.get<string>('startupBehavior')).returns(() => startupBehavior);
+
+        getConfigurationStub = sinon.stub(workspaceApis, 'getConfiguration');
+        getConfigurationStub.callsFake((section?: string) =>
+            section === 'interpreters' ? interpretersConfigMock.object : configMock.object,
+        );
+    });
+
+    teardown(() => {
+        sinon.restore();
+    });
+
+    async function waitFor(condition: () => boolean, timeoutMs: number, what: string): Promise<void> {
+        const start = Date.now();
+        while (!condition()) {
+            if (Date.now() - start > timeoutMs) {
+                throw new Error(`Timed out waiting for ${what}`);
+            }
+            // eslint-disable-next-line no-await-in-loop
+            await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+    }
+
+    async function drainRefresh(finder: NativePythonFinder): Promise<(NativeEnvInfo | unknown)[]> {
+        const envs = [];
+        for await (const env of finder.refresh()) {
+            envs.push(env);
+        }
+        return envs;
+    }
+
+    test('requests after the server process dies respawn it instead of hanging', async () => {
+        const finder = createNativePythonFinder();
+        try {
+            assert.isNotEmpty(await drainRefresh(finder));
+            const pid = finder.serverPid;
+            assert.isDefined(pid, 'server should be running after a refresh');
+
+            process.kill(pid!, 'SIGKILL');
+            await waitFor(() => finder.serverPid === undefined, 10_000, 'server exit to be observed');
+
+            assert.isNotEmpty(await drainRefresh(finder), 'refresh after crash should succeed');
+            assert.isDefined(finder.serverPid, 'server should have respawned');
+        } finally {
+            finder.dispose();
+        }
+    });
+
+    test('server shuts down after the idle timeout and respawns on the next request', async () => {
+        idleTimeoutSeconds = 1;
+        const finder = createNativePythonFinder();
+        try {
+            assert.isNotEmpty(await drainRefresh(finder));
+            assert.isDefined(finder.serverPid, 'server should be running right after a refresh');
+
+            await waitFor(() => finder.serverPid === undefined, 10_000, 'idle shutdown');
+
+            assert.isNotEmpty(await drainRefresh(finder), 'refresh after idle shutdown should succeed');
+            assert.isDefined(finder.serverPid, 'server should have respawned');
+        } finally {
+            finder.dispose();
+        }
+    });
+
+    test('does not spawn the server at construction when Python startup is disabled', async () => {
+        startupBehavior = 'disabled';
+        const finder = createNativePythonFinder();
+        try {
+            await new Promise((resolve) => setTimeout(resolve, 1_000));
+            assert.isUndefined(finder.serverPid, 'no server process expected while disabled');
+
+            // An explicit request still works: it spawns the server lazily.
+            assert.isNotEmpty(await drainRefresh(finder));
+            assert.isDefined(finder.serverPid, 'explicit refresh should spawn the server');
+        } finally {
+            finder.dispose();
+        }
+    });
+
+    test('an in-flight refresh is not interrupted by an idle shutdown', async () => {
+        startupBehavior = 'disabled';
+
+        // Reference run with shutdown disabled, so nothing can cut it short.
+        idleTimeoutSeconds = 0;
+        const reference = createNativePythonFinder();
+        let expected: number;
+        try {
+            expected = (await drainRefresh(reference)).length;
+        } finally {
+            reference.dispose();
+        }
+        assert.isAbove(expected, 0, 'reference refresh should discover environments');
+
+        // The same refresh, but with an idle timeout far shorter than a refresh
+        // takes. Unless the refresh keeps a request in flight, the timer fires
+        // partway through and kills the server. Asserting the result is merely
+        // non-empty would not catch that: PET emits most environments early, so
+        // a truncated refresh still returns some. Compare the full count.
+        idleTimeoutSeconds = 0.005;
+        const finder = createNativePythonFinder();
+        try {
+            assert.strictEqual(
+                (await drainRefresh(finder)).length,
+                expected,
+                'refresh was truncated by an idle shutdown while it was still running',
+            );
+        } finally {
+            finder.dispose();
+        }
+    });
+
+    test('picks up a changed idle timeout without rebuilding the finder', async () => {
+        idleTimeoutSeconds = 0;
+        const finder = createNativePythonFinder();
+        try {
+            assert.isNotEmpty(await drainRefresh(finder));
+            await new Promise((resolve) => setTimeout(resolve, 1_500));
+            assert.isDefined(finder.serverPid, 'server should still be up while the timeout is 0');
+
+            // Change the setting on a live finder; the next request re-arms the
+            // timer and must read the new value rather than a cached one.
+            idleTimeoutSeconds = 1;
+            assert.isNotEmpty(await drainRefresh(finder));
+
+            await waitFor(() => finder.serverPid === undefined, 10_000, 'idle shutdown after the timeout changed');
+        } finally {
+            finder.dispose();
+        }
+    });
+
+    test('idle timeout of 0 keeps the server running', async () => {
+        idleTimeoutSeconds = 0;
+        const finder = createNativePythonFinder();
+        try {
+            assert.isNotEmpty(await drainRefresh(finder));
+            await new Promise((resolve) => setTimeout(resolve, 2_500));
+            assert.isDefined(finder.serverPid, 'server should still be running with timeout 0');
+        } finally {
+            finder.dispose();
+        }
+    });
+});


### PR DESCRIPTION
Fixes #15004

The `pet server` process starts with Positron and stays resident for the whole session. It uses about 7 MB of memory, but it is only needed for Python environment discovery. I'd like to get this proposed change in here pretty early in our milestone, so we can get some miles on it with dailies to see if there are unforeseen problems.

With this PR, the RPC connection to the server is now lazy. After an idle period the server shuts down, and the next discovery request starts a new one. A new setting, `python.locatorIdleTimeout`, controls the delay in seconds. The default is 180, and a value of 0 keeps the server resident for the whole session, which is the old behavior:

<img width="1311" height="986" alt="Screenshot 2026-08-06 at 6 45 03 PM" src="https://github.com/user-attachments/assets/e4cb5d23-8706-4a41-a9f0-65e6cf9d79aa" />

An in-flight request counter keeps the timer disarmed while discovery runs, so a refresh is never cut short. The timeout is read each time the timer is armed, so a change to the setting applies without a window reload.

Process exit, spawn errors, and RPC connection errors now share one teardown that disposes the connection. The teardown is guarded by process identity, so a late event from an old server cannot affect its replacement. Disposing the connection is what rejects requests that are still in flight. The stdio pipes use `{ end: false }`, so before this change a dead server left the connection open. Any later request then hung forever, and only a window reload recovered it.

### On `interpreters.startupBehavior`

This PR adds an `isPythonStartupDisabled()` helper and uses it to skip four eager discovery triggers when the setting resolves to `disabled` for Python. That removes some startup work. It does not stop Python discovery, and an earlier version of this description claimed that it did.

@austin3dickey caught this in review. A `pet` process still starts. I traced it to two causes that are out of scope here. Both run at startup, so a fix for either one alone changes nothing that a user can observe:

1. `extHostLanguageRuntime.ts:1534-1547` runs a discovery pass for any runtime manager that registers after discovery is complete. That branch ignores the disabled set. This is core code and it affects every language.
2. `extension.ts:169-182` schedules an interpreter refresh after activation with no check of the setting. It resolves an interpreter, which starts the server.

Logs and the full trace are in #7445, which is the open issue for this behavior and is older than this PR. I kept the four gates, because they remove real work and because the helper is what a complete fix will use.

The unit tests are in `extensions/positron-python/src/test/pythonEnvironments/nativePythonFinderLifecycle.unit.test.ts` and `src/test/positron/interpreterSettings.unit.test.ts`. Each test was checked by reverting the matching production change and confirming that the test fails.

One gap is worth some review; the path from a failed spawn into the shared teardown has no test. The teardown itself is covered through the process exit path. A test for the spawn failure needs an injectable spawn seam in `nativePythonFinder.ts` and I could not get that to work at all.

Also note that process spawn and kill behavior differs on Windows, and these unit tests run on Linux only.

### Release Notes

#### New Features

- Added a `python.locatorIdleTimeout` setting, which controls how long the Python environment locator server can sit idle before it shuts down (#15004)

#### Bug Fixes

- The Python environment locator server now shuts down when idle and restarts on demand, instead of running for the whole session (#15004)

### Validation Steps

@:interpreter @:sessions @:win @:web

Before starting, check that none of the following are in effect, since each one invalidates the run:
- `python.locatorIdleTimeout` should be unset so the 180 second default applies
- `python.locator` should be unset or `native`, because the idle timer only exists on the native locator and no `pet` process spawns at all under `js`
- `interpreters.startupBehavior` should not be `disabled`, either globally or under a `[python]` override

It helps to run a process watcher in a terminal outside Positron for the whole exercise. It timestamps the pid every 10 seconds, so the moment the process appears or goes away is easy to see:

```bash
while true; do printf '%s  pet=[%s]\n' "$(date +%T)" "$(pgrep -f 'python-env-tools/pet' | tr '\n' ' ')"; sleep 10; done
```

**Scenario 1: default timeout (180s).**

1. Start Positron and open a folder with at least one discoverable Python environment. Within a few seconds the watcher should switch from `pet=[]` to a pid. Note that pid.
2. In the Output pane, select the **Python Locator** channel. This is the primary evidence, because it distinguishes a real idle shutdown from the process dying for some other reason.
3. Wait a little over three minutes without touching anything Python related. The idle timer only arms once every in-flight request has settled, and any new request cancels it. So during the wait, do not open the interpreter picker, do not select or change an interpreter, do not start a Python session, and do not create or delete a virtual environment in the workspace. Editing an unrelated file or leaving the window idle is fine. Allow a little more than three minutes, since the clock starts when the startup refresh finishes rather than when the window opens.
4. Confirm both signals: the watcher shows `pet=[]`, and the Python Locator channel logs `Shutting down Python Locator server after 180s idle; it restarts on the next request`. If the process is gone but that log line is absent, something else killed it and the behavior has not actually been verified.
5. Refresh the interpreter list from the interpreter picker. Confirm three things: the watcher shows a new pid, different from the one noted in step 1; the picker actually lists environments; and the channel logs a fresh `Starting Python Locator ... server` line followed by discovery output. The second of those is the important one, because it proves the respawned server was reconfigured. A server that respawns without being reconfigured comes back with an empty environment list, which is the failure mode #14483 dealt with.
6. Optional but worthwhile: leave the window idle for another three minutes and confirm it shuts down a second time. This catches a timer that only ever arms once.

**Scenario 2: shutdown disabled (escape hatch to the old behavior).**

1. Set `"python.locatorIdleTimeout": 0` and reload the window. Use a reload rather than reusing the previous window, so there is a clean startup spawn to measure from.
2. Note the pid once startup settles, then wait at least three and a half minutes. The wait has to exceed 180 seconds, otherwise the result looks identical whether the timeout is 0 or the default.
3. Confirm the watcher still shows the same pid, not merely that some `pet` process exists. A changed pid would mean the process died and respawned rather than staying resident, which is a different and incorrect behavior. Confirm the Python Locator channel shows no shutdown line and no second start line.
4. Optional, to confirm the setting is read live rather than cached at startup: with Positron still running and the process still resident, change the setting to `15` without reloading, then refresh the interpreter list. Within roughly 15 seconds of that refresh completing, the process should go away and the channel should log the 15 second shutdown message. If the process stays up, the value was cached at construction.

**Scenario 3: Python interpreter startup disabled.**

This scenario is a regression check on the four gates. It is not a check that discovery stops, because it does not! A `pet` process still starts here, which is #7445.

1. Remove `python.locatorIdleTimeout` from settings so the default applies again.
2. Set `"[python]": { "interpreters.startupBehavior": "disabled" }` and reload the window.
3. Confirm Positron starts normally and that no Python session starts.
4. Open the interpreter picker and refresh. Confirm that environments are listed, and that the Python Locator channel logs a `Starting Python Locator ... server` line followed by discovery output.

Step 4 is the point of this scenario. The gates must not break explicit discovery while the setting is `disabled`.
