### PR TITLE
Wait for script execution before opening the SQLite connection viewer

### DIFF
--- a/test/e2e/pages/sideBar.ts
+++ b/test/e2e/pages/sideBar.ts
@@ -7,7 +7,6 @@
 import { Code } from '../infra/code';
 
 const HIDE_SECONDARY_SIDE_BAR = '[aria-label^="Hide Secondary Side Bar"]';
-const SESSION_BUTTON = '[aria-label="Session"]:has-text("Session")';
 
 /*
  *  Reuseable Positron sidebar functionality for tests to leverage.
@@ -19,10 +18,5 @@ export class SideBar {
 	async closeSecondarySideBar() {
 		this.code.logger.log('Hiding secondary side bar');
 		await this.code.driver.currentPage.locator(HIDE_SECONDARY_SIDE_BAR).click();
-	}
-
-	async openSession() {
-		this.code.logger.log('Opening session');
-		await this.code.driver.currentPage.locator(SESSION_BUTTON).click();
 	}
 }

--- a/test/e2e/tests/connections/connections-sqlite.test.ts
+++ b/test/e2e/tests/connections/connections-sqlite.test.ts
@@ -26,20 +26,12 @@ test.describe('SQLite DB Connection', {
 		});
 
 		await test.step('Open connections pane', async () => {
-			try {
-				await app.workbench.layouts.enterLayout('fullSizedAuxBar');
-				// there is a flake of the db connection not displaying in the connections pane after
-				// clicking the db icon. To work around, both a wait and a retry are added.
-				await app.code.driver.currentPage.waitForTimeout(2000);
-				await app.workbench.variables.clickDatabaseIconForVariableRow('conn');
-				await app.workbench.connections.connectIcon.click();
-			} catch (error) {
-				// For some reasonm, on the retry, the pane opens directly to this connection
-				// and the connectIcon.click() is not needed.
-				await app.workbench.sideBar.openSession();
-				await app.code.driver.currentPage.waitForTimeout(2000);
-				await app.workbench.variables.clickDatabaseIconForVariableRow('conn');
-			}
+			await app.workbench.layouts.enterLayout('fullSizedAuxBar');
+			// `df` is the script's last statement, so its arrival means execution finished.
+			// The database icon sends a `view` RPC over the shell channel, which queues behind
+			// the still-running script and never returns if we click too early.
+			await app.workbench.variables.waitForVariableRow('df');
+			await app.workbench.variables.clickDatabaseIconForVariableRow('conn');
 		});
 
 		await test.step('Verify connection nodes', async () => {


### PR DESCRIPTION
### Summary

The SQLite connections test clicked the Variables database icon after a hard-coded 2s wait, while the Python script could still be executing. That click sends a `view` RPC, which queues behind the running script on the shell channel and is registered with no client-side timeout, so the viewer icon sat in "Connection Queued..." indefinitely and the Connections pane never received the connection.

- Wait for `df`, the script's last statement, instead of a fixed 2s sleep
- Drop the connect-icon click: focusing the connection moves the pane to the schema view, where that icon does not exist
- Remove the try/catch retry that the old race required
- Remove `SideBar.openSession()`, whose only caller was that retry path
- Its locator matched the aria-label `Session` exactly, but the live label carries a keybinding suffix, so the retry could never have worked

### QA Notes

@:connections @:web @:win

Not reproduced locally -- this is a ~3% load-dependent flake on ubuntu/chromium, and the web lane is the one that exercises the fix.


### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- The test clicks the Variables database icon while the Python script is still executing, so the view RPC queues behind it and never returns (no client-side timeout), leaving the Connections pane empty.</summary>

- **Test:** [SQLite DB Connection > Python - Can establish a SQLite connection, disconnect & reconnect](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=SQLite%20DB%20Connection%20%3E%20Python%20-%20Can%20establish%20a%20SQLite%20connection%2C%20disconnect%20%26%20reconnect%7C%7C%7Ctest%2Fe2e%2Ftests%2Fconnections%2Fconnections-sqlite.test.ts)
- **Targeted failure:** TimeoutError: locator.click: Timeout 30000ms exceeded.
- **Signal:** Variables viewer icon flips to codicon-notebook-state-pending / 'Connection Queued...' 69ms after the database-icon click and never clears through the last frame 90s later; connections-list-item appears in 0 of 486 DOM snapshots and the connections list virtual-scroll spacer is height:0px, so the pane rendered with zero rows rather than switching to the schema detail view.
- **Frequency:** 4/132 runs (3%) on main, ubuntu/chromium
- **Hypothesis:** race

</details>
