### PR TITLE
fix: rediscover runtimes when the discovery root signature is unavailable

### DIFF
--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -63,6 +63,31 @@ interface IManagerDiscoveryPlan {
 }
 
 /**
+ * Why a warm start had to run a full discovery pass for at least one bucket.
+ * Precedence when several apply, most-specific first: `cold-start` >
+ * `always-rediscover` > `roots-changed` > `signature-unavailable` > `periodic`.
+ */
+type FullDiscoveryReason =
+	| 'cold-start'
+	| 'always-rediscover'
+	| 'roots-changed'
+	| 'signature-unavailable'
+	| 'periodic';
+
+/**
+ * Outcome of asking a manager for its discovery root signature. `unsupported`
+ * (the manager resolved `undefined`) and `failed` (timed out or threw) both
+ * yield no signature, but they are not the same: `unsupported` is a permanent
+ * property of a manager that never implemented the call, so forcing a pass on
+ * it would rediscover on every window open. `failed` means the state is
+ * unknown for this one attempt, and the cache cannot be trusted.
+ */
+type RootSignatureProbe =
+	| { readonly kind: 'ok'; readonly signature: IRuntimeRootSignature }
+	| { readonly kind: 'unsupported' }
+	| { readonly kind: 'failed' };
+
+/**
  * The serialization format for affiliated runtime metadata.
  */
 interface IAffiliatedRuntimeMetadata {
@@ -1215,20 +1240,20 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 			?? RUNTIME_DISCOVERY_CACHE_REFRESH_INTERVAL_DAYS_DEFAULT;
 		const periodicCutoff = Date.now() - refreshDays * 24 * 60 * 60 * 1000;
 
-		// Reason precedence: cold-start > always-rediscover > roots-changed >
-		// periodic. Track the most-specific reason observed across all managers
-		// needing discovery. `always-rediscover` is a permanent contribution
-		// opt-out rather than a transient staleness signal, so it ranks below
-		// cold-start (which describes a one-time situation) but above the
-		// staleness reasons.
-		const reasonRank: Record<'cold-start' | 'always-rediscover' | 'roots-changed' | 'periodic', number> = {
+		// Track the most-specific reason observed across all managers needing
+		// discovery; see `FullDiscoveryReason` for the ordering. `always-rediscover`
+		// is a permanent contribution opt-out rather than a transient staleness
+		// signal, so it ranks below cold-start (which describes a one-time
+		// situation) but above the staleness reasons.
+		const reasonRank: Record<FullDiscoveryReason, number> = {
 			'cold-start': 0,
 			'always-rediscover': 1,
 			'roots-changed': 2,
-			'periodic': 3,
+			'signature-unavailable': 3,
+			'periodic': 4,
 		};
-		let observedReason: 'cold-start' | 'always-rediscover' | 'roots-changed' | 'periodic' | undefined;
-		const promote = (r: 'cold-start' | 'always-rediscover' | 'roots-changed' | 'periodic') => {
+		let observedReason: FullDiscoveryReason | undefined;
+		const promote = (r: FullDiscoveryReason) => {
 			if (observedReason === undefined || reasonRank[r] < reasonRank[observedReason]) {
 				observedReason = r;
 			}
@@ -1259,8 +1284,8 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 
 			const runContributions: IHostedLanguageContribution[] = [];
 			const skipLangs = new Set<string>();
-			let mostSpecificReason: 'cold-start' | 'always-rediscover' | 'roots-changed' | 'periodic' | undefined;
-			const promoteLocal = (r: 'cold-start' | 'always-rediscover' | 'roots-changed' | 'periodic') => {
+			let mostSpecificReason: FullDiscoveryReason | undefined;
+			const promoteLocal = (r: FullDiscoveryReason) => {
 				if (mostSpecificReason === undefined || reasonRank[r] < reasonRank[mostSpecificReason]) {
 					mostSpecificReason = r;
 				}
@@ -1294,12 +1319,18 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 				// without `getDiscoveryRootSignature`, e.g. positron-reticulate
 				// for `python`, doesn't shadow the real owner's signature).
 				const persistedSig = this._discoveryCache.getDiscoveryRootSignature(contrib.extensionId, contrib.languageId);
-				const currentSig = await this._safeGetRootSignature(manager, contrib.extensionId, contrib.languageId);
-				const rootsChanged = currentSig !== undefined && !signaturesEqual(persistedSig, currentSig);
+				const probe = await this._probeRootSignature(manager, contrib.extensionId, contrib.languageId);
+				const rootsChanged = probe.kind === 'ok' && !signaturesEqual(persistedSig, probe.signature);
 
 				if (rootsChanged) {
 					runContributions.push(contrib);
 					promoteLocal('roots-changed');
+				} else if (probe.kind === 'failed') {
+					// "Unknown", not "unchanged": an exclusion is a settings-only edit
+					// that moves no mtime, so the digest is the only staleness signal --
+					// and the cache is not re-filtered against settings when loaded.
+					runContributions.push(contrib);
+					promoteLocal('signature-unavailable');
 				} else if (periodicStale) {
 					runContributions.push(contrib);
 					promoteLocal('periodic');
@@ -1373,9 +1404,11 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 		}
 		const sigByPair = new Map<string, IRuntimeRootSignature>();
 		await Promise.all(Array.from(uniquePairs.values()).map(async ({ extensionId, languageId }) => {
-			const sig = await this._safeGetRootSignature(manager, extensionId, languageId);
-			if (sig !== undefined) {
-				sigByPair.set(`${extensionId}::${languageId}`, sig);
+			const probe = await this._probeRootSignature(manager, extensionId, languageId);
+			// Unsupported and failed both leave the persisted signature untouched:
+			// stamping nothing keeps the next warm start on the safe path.
+			if (probe.kind === 'ok') {
+				sigByPair.set(`${extensionId}::${languageId}`, probe.signature);
 			}
 		}));
 
@@ -1425,32 +1458,44 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 
 	/**
 	 * Call `manager.getDiscoveryRootSignature(extensionId, languageId)`
-	 * defensively: timeout-bound the call, swallow throws, and treat both as
-	 * "no signature available" so the caller falls back to the periodic-
-	 * refresh trigger. We disambiguate by extensionId because multiple
-	 * extensions can register a runtime manager for the same languageId (e.g.
-	 * `ms-python.python` and `positron.positron-reticulate` both register for
-	 * `python`) and only one of them owns the discovery signature for any
-	 * given (extensionId, languageId) bucket.
+	 * defensively: timeout-bound the call and swallow throws, reporting both as
+	 * `failed` (see `RootSignatureProbe` for why that is not `unsupported`). We
+	 * disambiguate by extensionId because multiple extensions can register a
+	 * runtime manager for the same languageId (e.g. `ms-python.python` and
+	 * `positron.positron-reticulate` both register for `python`) and only one
+	 * of them owns the discovery signature for any given (extensionId,
+	 * languageId) bucket.
 	 */
-	private async _safeGetRootSignature(
+	private async _probeRootSignature(
 		manager: IRuntimeManager,
 		extensionId: string,
 		languageId: string,
-	): Promise<IRuntimeRootSignature | undefined> {
+	): Promise<RootSignatureProbe> {
+		let timedOut = false;
 		try {
-			return await raceTimeout(
+			const signature = await raceTimeout(
 				manager.getDiscoveryRootSignature(extensionId, languageId),
 				RuntimeStartupService.ROOT_SIGNATURE_TIMEOUT_MS,
-				() => this._logService.warn(
-					`[Runtime startup] getDiscoveryRootSignature(${extensionId}, ${languageId}) timed out ` +
-					`for manager ${manager.id}; falling back to periodic refresh.`),
+				() => {
+					timedOut = true;
+					this._logService.warn(
+						`[Runtime startup] getDiscoveryRootSignature(${extensionId}, ${languageId}) timed out ` +
+						`for manager ${manager.id}; forcing a full discovery pass.`);
+				},
 			);
+			// `raceTimeout` resolves undefined on timeout too, so the flag is what
+			// separates "took too long" from "manager has no signature to give".
+			if (timedOut) {
+				return { kind: 'failed' };
+			}
+			return signature === undefined
+				? { kind: 'unsupported' }
+				: { kind: 'ok', signature };
 		} catch (err) {
 			this._logService.warn(
 				`[Runtime startup] getDiscoveryRootSignature(${extensionId}, ${languageId}) threw ` +
-				`for manager ${manager.id}; falling back to periodic refresh: ${err}`);
-			return undefined;
+				`for manager ${manager.id}; forcing a full discovery pass: ${err}`);
+			return { kind: 'failed' };
 		}
 	}
 
@@ -1461,21 +1506,21 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 	 * here is cheaper than a sibling helper that re-walks them. `bypassCache`
 	 * paths overwrite this with `'user-triggered'` at the call site.
 	 *
-	 * Precedence (most-specific wins): `cold-start` > `always-rediscover` >
-	 * `roots-changed` > `periodic`. `cold-start` covers managers that never
-	 * produced any cached runtimes; `always-rediscover` covers managers that
-	 * opted out of the cache fast path entirely (non-cacheable runtimes);
-	 * `roots-changed` covers warm starts where a scan-root mtime moved (a new
-	 * interpreter likely showed up); `periodic` covers warm starts where the
-	 * bucket simply aged past the refresh cap.
+	 * `cold-start` covers managers that never produced any cached runtimes;
+	 * `always-rediscover` covers managers that opted out of the cache fast path
+	 * entirely (non-cacheable runtimes); `roots-changed` covers warm starts
+	 * where a scan-root mtime moved (a new interpreter likely showed up);
+	 * `signature-unavailable` covers warm starts where the signature could not
+	 * be obtained, so staleness could not be ruled out; `periodic` covers warm
+	 * starts where the bucket simply aged past the refresh cap.
 	 */
-	private _lastFullDiscoveryReason: 'cold-start' | 'always-rediscover' | 'roots-changed' | 'periodic' = 'cold-start';
+	private _lastFullDiscoveryReason: FullDiscoveryReason = 'cold-start';
 
 	/**
 	 * Per-manager budget for `getDiscoveryRootSignature`. The call should be
 	 * a handful of stats and complete in single-digit milliseconds; if it
-	 * doesn't, log and treat as "no signature" (fall back to periodic) rather
-	 * than blocking warm-start latency on a slow extension.
+	 * doesn't, log and treat as "no signature" (which costs a full rediscovery)
+	 * rather than blocking warm-start latency on a slow extension.
 	 */
 	private static readonly ROOT_SIGNATURE_TIMEOUT_MS = 500;
 

--- a/src/vs/workbench/services/runtimeStartup/test/common/runtimeStartup.vitest.ts
+++ b/src/vs/workbench/services/runtimeStartup/test/common/runtimeStartup.vitest.ts
@@ -597,14 +597,16 @@ describe('RuntimeStartupService - cache-aware discovery', () => {
 			expect(lastFullDiscoveryReason(svc)).toBe('roots-changed');
 		});
 
-		it('falls back to periodic when getDiscoveryRootSignature throws', async () => {
-			// Periodic-stale bucket. If signature check throws, we shouldn't crash --
-			// we should fall through to the periodic decision (which will flag it).
+		it('rediscovers a fresh bucket when getDiscoveryRootSignature throws', async () => {
+			// Fresh bucket, so periodic would NOT fire: the throw is the only reason a
+			// full pass can run. A throw leaves staleness unknown, and the cache is not
+			// re-filtered against current settings on load, so an interpreter the user
+			// just excluded would otherwise be re-registered from cache and startable.
 			const bucket = makeBucket({
 				extensionId: 'ms.python',
 				languageId: 'python',
 				runtimePath: '/usr/bin/python3',
-				lastFullDiscovery: 0,
+				lastFullDiscovery: Date.now(),
 			});
 			cache.setBucket(bucket);
 
@@ -618,18 +620,17 @@ describe('RuntimeStartupService - cache-aware discovery', () => {
 
 			const plans = await managersNeedingFullDiscovery(svc);
 			expect(managersFromPlans(plans)).toEqual([pyManager]);
-			expect(lastFullDiscoveryReason(svc)).toBe('periodic');
+			expect(lastFullDiscoveryReason(svc)).toBe('signature-unavailable');
 		});
 
-		it('falls back to periodic when getDiscoveryRootSignature exceeds its 500ms timeout', async () => {
-			// Stale bucket so periodic fires regardless. The point of this test is
-			// that a never-resolving signature call doesn't hang the warm-start
-			// decision; the 500ms timeout returns undefined -> periodic logic runs.
+		it('rediscovers a fresh bucket when getDiscoveryRootSignature exceeds its 500ms timeout', async () => {
+			// Same contract as the throwing case, and additionally: a never-resolving
+			// signature call must not hang the warm-start decision.
 			const bucket = makeBucket({
 				extensionId: 'ms.python',
 				languageId: 'python',
 				runtimePath: '/usr/bin/python3',
-				lastFullDiscovery: 0,
+				lastFullDiscovery: Date.now(),
 			});
 			cache.setBucket(bucket);
 
@@ -650,7 +651,7 @@ describe('RuntimeStartupService - cache-aware discovery', () => {
 				await vi.advanceTimersByTimeAsync(600);
 				const plans = await promise;
 				expect(managersFromPlans(plans)).toEqual([pyManager]);
-				expect(lastFullDiscoveryReason(svc)).toBe('periodic');
+				expect(lastFullDiscoveryReason(svc)).toBe('signature-unavailable');
 			} finally {
 				vi.useRealTimers();
 			}


### PR DESCRIPTION
Excluding an interpreter did not reliably stick. After a window reload the excluded interpreter could reappear in the runtime picker and start normally, because the cross-window discovery cache re-registered it.

On a warm start the planner asks each runtime manager for a discovery root signature to decide whether that manager's cached entries are stale. An interpreter exclusion is a settings-only edit that moves no file mtime, so the opaque settings digest inside the signature is the only signal that the cache is out of date. When the call timed out (500ms budget) or threw, the missing signature was read as "nothing changed": discovery was skipped and the bucket was loaded from cache instead. Cached entries are not re-filtered against current settings, and an already-registered runtime skips `validateMetadata`, so the guard that rejects an excluded interpreter never ran.

A failed probe is now treated as unknown rather than unchanged, and forces a full discovery pass. A manager that never implemented the signature call is kept distinct from one that failed, so it does not rediscover on every window open.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed an excluded interpreter reappearing in the picker and starting after a window reload

### Validation Steps

@:interpreter @:sessions

1. Set `positron.r.interpreters.exclude` (or `python.interpreters.exclude`) to the path of an installed interpreter.
2. Reload the window.
3. Confirm the excluded interpreter is absent from the runtime picker and cannot be started.

Also targets a flaky e2e failure in `Interpreter: Excludes > R - Can Exclude an Interpreter` (~8% on main, ubuntu/electron). The CI timing race was not reproduced locally, so the flake reduction is predicted from the code path rather than observed.


### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- Positron's cross-window discovery cache re-registers an R interpreter that was discovered before positron.r.interpreters.exclude was written. When getDiscoveryRootSignature times out (500ms budget), runtimeStartup.ts:1298 reads the undefined signature as 'roots unchanged', skips rediscovery for R, and loadFromDiscoveryCache registers the excluded /opt/R/4.4.2 verbatim. registerRuntime never consults exclude settings, and runtimeSession.ts:1678 skips validateMetadata for already-registered runtimes, so the one guard that would throw 'Reason: excluded' never fires and the session starts.</summary>

- **Test:** [Interpreter: Excludes > R - Can Exclude an Interpreter](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Interpreter%3A%20Excludes%20%3E%20R%20-%20Can%20Exclude%20an%20Interpreter%7C%7C%7Ctest%2Fe2e%2Ftests%2Finterpreters%2Fincludes-excludes.test.ts)
- **Targeted failure:** Pattern A: AssertionError 'Expected interpreter to be excluded: /opt/R/4.4.2' at test/e2e/tests/interpreters/helpers/include-excludes.ts:81, 11 occurrences / 8.1% on main, ubuntu/electron. First seen 23 days ago.
- **Signal:** Trace t=1493788 'WARN [Runtime startup] getDiscoveryRootSignature(positron.positron-r, r) timed out for manager 0; falling back to periodic refresh.', 28ms before the startNewConsoleSession command at t=1493816. Phase changed to 'loadingCache' t=1494288, 'discovering' t=1494449, 'complete' t=1494938; picker settled t=1497029, so the list was post-discovery. Screenshot: console reads 'R 4.4.2 started' / 'R version 4.4.2 (2024-10-31)', session list shows R 4.4.1 and R 4.4.2. Code: raceTimeout -> undefined (runtimeStartup.ts:1436-1455, 500ms at :1480); rootsChanged requires currentSig !== undefined (:1298); skipLangs (:1310) so R is not in skipCacheLoad (:1019-1024); cache registers as-is (:1166); registerRuntime ignores exclude (languageRuntime.ts:131-175); validateMetadata skipped for registered runtimes (runtimeSession.ts:1678-1686), bypassing runtime-manager.ts:245. /opt/R/4.4.2 is cacheable per isRRuntimeCacheable (provider.ts:532): system-scoped, real binary, outside the workspace.
- **Frequency:** 11/135 runs (8.1%) on main, ubuntu/electron
- **Hypothesis:** Disabling interpreters.discoveryCache.enabled before app launch means no cached R is ever re-registered, so the Excludes block always sees a freshly discovered (and correctly filtered) runtime list, driving pattern A to zero. If the flake survives with the cache off, the mechanism above is wrong.

</details>
