### PR TITLE
Keep the off-screen walkthrough content out of the tab order on welcome page

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -1992,6 +1992,9 @@ export class GettingStartedPage extends EditorPane {
 			this.container.querySelector('.gettingStartedSlideCategories')!.querySelectorAll('button').forEach(button => button.disabled = false);
 			// eslint-disable-next-line no-restricted-syntax
 			this.container.querySelector('.gettingStartedSlideCategories')!.querySelectorAll('input').forEach(button => button.disabled = false);
+			// --- Start Positron ---
+			this.setSlideInert(false, true);
+			// --- End Positron ---
 		} else {
 			slideManager.classList.add('showDetails');
 			slideManager.classList.remove('showCategories');
@@ -2008,8 +2011,38 @@ export class GettingStartedPage extends EditorPane {
 			this.container.querySelector('.gettingStartedSlideCategories')!.querySelectorAll('button').forEach(button => button.disabled = true);
 			// eslint-disable-next-line no-restricted-syntax
 			this.container.querySelector('.gettingStartedSlideCategories')!.querySelectorAll('input').forEach(button => button.disabled = true);
+			// --- Start Positron ---
+			this.setSlideInert(true, false);
+			// --- End Positron ---
 		}
 	}
+
+	// --- Start Positron ---
+	/**
+	 * Takes the off-screen slide out of the tab order.
+	 *
+	 * The two slides sit side by side and the hidden one is moved off-screen
+	 * rather than hidden with `display: none` which means elements stay focusable.
+	 * The disable pass above only checks buttons and inputs, which leaves the
+	 * "Recent" list delete anchors, the show on startup checkbox and the
+	 * walkthrough's step rows and links enabled. Tabbing into one of those either
+	 * moves focus somewhere invisible or scrolls the off-screen slide into view,
+	 * which drags the visible slide partially out of view.
+	 *
+	 * `inert` is inherited by descendants, so it also covers anything added to a
+	 * slide after this runs.
+	 * @param categories Whether the categories slide should be inert.
+	 * @param details Whether the details slide should be inert.
+	 */
+	private setSlideInert(categories: boolean, details: boolean) {
+		// eslint-disable-next-line no-restricted-syntax
+		const categoriesSlide = this.container.querySelector<HTMLElement>('.gettingStartedSlideCategories');
+		// eslint-disable-next-line no-restricted-syntax
+		const detailsSlide = this.container.querySelector<HTMLElement>('.gettingStartedSlideDetails');
+		if (categoriesSlide) { categoriesSlide.inert = categories; }
+		if (detailsSlide) { detailsSlide.inert = details; }
+	}
+	// --- End Positron ---
 
 	override focus() {
 		super.focus();

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -379,11 +379,13 @@ export class GettingStartedPage extends EditorPane {
 				StorageScope.PROFILE, StorageTarget.MACHINE);
 		}));
 
+		// --- Start Positron ---
 		// Re-layout when the welcome content has fully loaded
 		// Ensures the scroll height is correct since the initial layout is done before the content is loaded
 		this.lifecycleService.when(LifecyclePhase.Eventually).then(() => {
 			this.layout(new Dimension(this.layoutService.mainContainerDimension.width, this.layoutService.mainContainerDimension.height));
 		});
+		// --- End Positron ---
 	}
 
 	// remove when 'workbench.welcomePage.preferReducedMotion' deprecated
@@ -976,8 +978,12 @@ export class GettingStartedPage extends EditorPane {
 			onShowOnStartupChanged();
 		}));
 		// --- Start Positron ---
-		// Diverged from upstream by changing the contents of the welcome page
-
+		// Positron replaces the upstream header with a theme-aware logo.
+		//
+		// const header = $('.header', {},
+		// 	$('h1.product-name.caption', {}, this.productService.nameLong),
+		// 	$('p.subtitle.description', {}, localize({ key: 'gettingStarted.editingEvolved', comment: ['Shown as subtitle on the Welcome page.'] }, "Editing evolved"))
+		// );
 		// Create a function to get the header logo based on theme type
 		const getHeaderLogoClass = () => {
 			return isDark(this.themeService.getColorTheme().type)
@@ -992,15 +998,19 @@ export class GettingStartedPage extends EditorPane {
 				logoElement.className = getHeaderLogoClass();
 			})
 		);
-
 		// Display the theme-aware logo in the header
 		const header = $('.header', {}, logoElement);
+		// --- End Positron ---
 
 		const leftColumn = $('.categories-column.categories-column-left', {},);
 		const rightColumn = $('.categories-column.categories-column-right', {},);
 
+		// --- Start Positron ---
+		// Positron shows a Help list where upstream shows its start list.
+		//
+		// const startList = this.buildStartList();
 		const helpList = this.buildHelpList();
-		//const startList = this.buildStartList();
+		// --- End Positron ---
 		const recentList = this.buildRecentlyOpenedList();
 		const gettingStartedList = this.buildGettingStartedWalkthroughsList();
 
@@ -1054,6 +1064,37 @@ export class GettingStartedPage extends EditorPane {
 			));
 		// --- End Positron ---
 
+		// --- Start Positron ---
+		// Upstream lays out one or two columns depending on whether there are
+		// walkthroughs to show, putting its start list and the recent list in
+		// the left column and moving the recent list to the right one when
+		// there are no walkthroughs. Positron always uses both columns: React
+		// start buttons, the recent list and "Connect to..." on the left,
+		// walkthroughs and help on the right.
+		//
+		// const layoutLists = () => {
+		// 	if (gettingStartedList.itemCount) {
+		// 		this.container.classList.remove('noWalkthroughs');
+		// 		reset(rightColumn, gettingStartedList.getDomElement());
+		// 	}
+		// 	else {
+		// 		this.container.classList.add('noWalkthroughs');
+		// 		reset(rightColumn);
+		// 	}
+		// 	setTimeout(() => this.categoriesPageScrollbar?.scanDomNode(), 50);
+		// 	layoutRecentList();
+		// };
+		//
+		// const layoutRecentList = () => {
+		// 	if (this.container.classList.contains('noWalkthroughs')) {
+		// 		recentList.setLimit(10);
+		// 		reset(leftColumn, startList.getDomElement());
+		// 		reset(rightColumn, recentList.getDomElement());
+		// 	} else {
+		// 		recentList.setLimit(5);
+		// 		reset(leftColumn, startList.getDomElement(), recentList.getDomElement());
+		// 	}
+		// };
 		const layoutRecentList = () => {
 			const leftContent = $('div.positron-welcome-left-column');
 			this.positronReactRenderer = createWelcomePageLeft(leftContent);
@@ -1066,8 +1107,15 @@ export class GettingStartedPage extends EditorPane {
 			}
 			reset(rightColumn, gettingStartedList.getDomElement(), helpList.getDomElement());
 		};
-		layoutRecentList();
+		// --- End Positron ---
 
+		// --- Start Positron ---
+		// Positron lays the page out once; upstream re-runs layoutLists when
+		// the walkthroughs change.
+		//
+		// gettingStartedList.onDidChange(layoutLists);
+		// layoutLists();
+		layoutRecentList();
 		// --- End Positron ---
 
 		reset(this.categoriesSlide, $('.gettingStartedCategoriesContainer', {}, header, leftColumn, rightColumn, footer,));
@@ -1096,14 +1144,22 @@ export class GettingStartedPage extends EditorPane {
 			}
 		}
 
+		// --- Start Positron ---
+		// Positron always shows the index page instead of automatically opening
+		// the first walkthrough category on a fresh install. This disables
+		// upstream's first-session branch below, whose code is kept live so it
+		// still compiles.
+		const autoOpenFirstWalkthrough = false;
+		// --- End Positron ---
 		if (this.editorInput?.showTelemetryNotice && this.productService.openToWelcomeMainPage) {
 			const telemetryNotice = $('p.telemetry-notice');
 			this.buildTelemetryFooter(telemetryNotice);
 			footer.appendChild(telemetryNotice);
 			// --- Start Positron ---
-			// Always show index page instead of automatically opening the first walkthrough category.
-			// Adds `!logoElement` to skip this branch in Positron (logoElement is always present here).
-		} else if (!this.productService.openToWelcomeMainPage && this.showFeaturedWalkthrough && this.storageService.isNew(StorageScope.APPLICATION) && !logoElement && !this.configurationService.getValue<boolean>('workbench.welcomePage.experimentalOnboarding')) {
+			// Adds `autoOpenFirstWalkthrough` (always false) to skip this branch.
+			//
+			// } else if (!this.productService.openToWelcomeMainPage && this.showFeaturedWalkthrough && this.storageService.isNew(StorageScope.APPLICATION) && !this.configurationService.getValue<boolean>('workbench.welcomePage.experimentalOnboarding')) {
+		} else if (autoOpenFirstWalkthrough && !this.productService.openToWelcomeMainPage && this.showFeaturedWalkthrough && this.storageService.isNew(StorageScope.APPLICATION) && !this.configurationService.getValue<boolean>('workbench.welcomePage.experimentalOnboarding')) {
 			// --- End Positron ---
 			const firstSessionDateString = this.storageService.get(firstSessionDateStorageKey, StorageScope.APPLICATION) || new Date().toUTCString();
 			const daysSinceFirstSession = ((+new Date()) - (+new Date(firstSessionDateString))) / 1000 / 60 / 60 / 24;
@@ -1690,9 +1746,9 @@ export class GettingStartedPage extends EditorPane {
 
 	override clearInput() {
 		this.stepDisposables.clear();
-		/*-- Start Positron ---*/
+		// --- Start Positron ---
 		this.positronReactRenderer?.dispose();
-		/*-- End Positron ---*/
+		// --- End Positron ---
 		super.clearInput();
 	}
 

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -1098,6 +1098,7 @@ export class GettingStartedPage extends EditorPane {
 		const layoutRecentList = () => {
 			const leftContent = $('div.positron-welcome-left-column');
 			this.positronReactRenderer = createWelcomePageLeft(leftContent);
+			this.categoriesSlideDisposables.add(this.positronReactRenderer);
 
 			// Hide the "Connect to..." button if we are on a web platform
 			if (!isWeb) {

--- a/test/e2e/pages/welcome.ts
+++ b/test/e2e/pages/welcome.ts
@@ -16,6 +16,9 @@ const RECENT_SECTION = '.recently-opened';
 const WALKTHROUGH_SECTION = '.getting-started';
 const HEADING_ROLE = 'heading';
 const BUTTON_ROLE = 'button';
+const CATEGORIES_SLIDE = '.gettingStartedSlideCategories';
+const DETAILS_SLIDE = '.gettingStartedSlideDetails';
+const GETTING_STARTED_CONTAINER = '.gettingStartedContainer';
 
 export class Welcome {
 
@@ -120,6 +123,34 @@ export class Welcome {
 		await test.step(`Verify walkthroughs count is ${count}`, async () => {
 			const walkthroughs = this.walkthroughSection.getByRole(BUTTON_ROLE);
 			await expect(walkthroughs).toHaveCount(count);
+		});
+	}
+
+	/**
+	 * Verify Tab never reaches the slide that is currently off-screen.
+	 *
+	 * The welcome page and the walkthrough sit side by side in one editor, and
+	 * whichever is hidden is moved off-screen rather than hidden with
+	 * `display: none`. If it stays in the tab order, focus lands somewhere the
+	 * user cannot see, and the browser scrolls it into view, dragging the
+	 * visible slide sideways.
+	 * @param hidden Which slide should be unreachable.
+	 * @param tabPresses How far to walk the tab order.
+	 */
+	async expectTabToStayOutOf(hidden: 'welcome' | 'walkthrough', tabPresses = 8) {
+		await test.step(`Verify Tab does not reach the hidden ${hidden} slide`, async () => {
+			const page = this.code.driver.currentPage;
+			const hiddenSlide = hidden === 'welcome' ? CATEGORIES_SLIDE : DETAILS_SLIDE;
+
+			await page.locator(GETTING_STARTED_CONTAINER).focus();
+			for (let i = 0; i < tabPresses; i++) {
+				await page.keyboard.press('Tab');
+				const landedInHidden = await page.evaluate(
+					(selector) => !!document.activeElement?.closest(selector),
+					hiddenSlide
+				);
+				expect(landedInHidden, `Tab stop ${i + 1} landed in the off-screen ${hidden} slide`).toBe(false);
+			}
 		});
 	}
 }

--- a/test/e2e/tests/welcome/welcome.test.ts
+++ b/test/e2e/tests/welcome/welcome.test.ts
@@ -3,12 +3,32 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { availableRuntimes } from '../../infra';
+import { Application, availableRuntimes } from '../../infra';
 import { test, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
+
+type RunCommand = (commandId: string, options?: { keepOpen?: boolean; exactLabelMatch?: boolean }) => Promise<void>;
+
+/**
+ * Open a walkthrough from the command palette, which switches the editor to the
+ * details slide and leaves the welcome page off-screen behind it.
+ *
+ * `keepOpen` stops runCommand from re-clicking until the picker closes: this
+ * command opens a second picker of its own, and that retry loop would dismiss it
+ * before the test could use it. Filter before selecting, because the list is
+ * virtualized and an unfiltered match can sit in the DOM scrolled out of view.
+ */
+async function openWalkthrough(app: Application, runCommand: RunCommand) {
+	const { quickInput } = app.workbench;
+
+	await runCommand('welcome.showAllWalkthroughs', { keepOpen: true });
+	await quickInput.waitForQuickInputOpened({ timeout: 30000 });
+	await quickInput.type('Migrating from VSCode');
+	await quickInput.selectQuickInputElementContaining('Migrating from VSCode to Positron');
+}
 
 test.describe('Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () => {
 	test.afterEach(async function ({ hotKeys }) {
@@ -53,6 +73,26 @@ test.describe('Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () => {
 				'Get Started with Posit Publisher',
 				'Jupyter Notebooks in Positron'
 			]);
+		});
+
+		test('Verify Tab does not reach the welcome page while a walkthrough is open', async function ({ app, runCommand }) {
+			const { welcome } = app.workbench;
+
+			await openWalkthrough(app, runCommand);
+			await welcome.expectTabToStayOutOf('welcome');
+		});
+
+		test('Verify Tab does not reach a walkthrough after returning to the welcome page', async function ({ app, hotKeys, runCommand }) {
+			const { welcome } = app.workbench;
+
+			// The walkthrough's steps stay in the DOM after we come back, parked
+			// off-screen to the right. Tabbing into one scrolls it into view and
+			// slides the welcome page off the left edge.
+			await openWalkthrough(app, runCommand);
+			await hotKeys.openWelcomeWalkthrough();
+			await welcome.expectRecentToBeVisible();
+
+			await welcome.expectTabToStayOutOf('walkthrough', 30);
 		});
 
 		test('Python - Verify clicking on `new notebook` from the Welcome page opens notebook and sets kernel', async function ({ app, python }) {


### PR DESCRIPTION
This PR fixes a category of rendering/tabbing/keyboard focus bugs for the welcome page. The root of all of these issues is a bug in UPSTREAM code (reproducible in VS Code). It ended up being straightforward to fix so I did while I was doing some other clean up in this file prior to working on #14934.

## Explanation

The welcome page and the walkthrough contents live in the same editor, side by side. Only one is shown on screen at a time; the other is parked one full editor width away. 

Some things to note about walkthrough rendering:
- You need to open a walkthrough to make the walkthrough DOM elements show up in the welcome page
- When you navigate away from a walkthrough (such as back to the welcome page), its contents are still in the dom but visually hidden. This means that you could still tab the elements if they aren't disabled.

The `setSlide` function tries to disabling the controls for a walkthrough that is hidden, but it only does that for `button` and `input` elements. The "Recent" list's delete buttons are `anchors`, the "Show welcome page on startup" checkbox is a `div`, and the walkthrough's step rows and links are `divs` and `anchors`. All of them stay in the tab order while off screen which means you can tab through them even though you can't visually see them!

You can see the issue by doing the following: open a walkthrough (so you've got the elements in the DOM), then go back to the welcome page (this will visually hide the walkthrough elements and disable SOME controls), then tab through all the elements in the welcome page. When you press tab after the last element ("Show welcome page on startup" checkbox) you will see the focus jumps to empty space to the right of the welcome page contents. This is where the visibly walkthrough contents are being rendered! You have to press Tab many times before you can see your focus ring again.

### Screenshots

**BEFORE**

https://github.com/user-attachments/assets/eb14b7f2-3c64-4249-ba68-5620f0984d6c

**AFTER**

https://github.com/user-attachments/assets/270ea0b3-ac18-476f-a953-2ecd65c4bacc


A couple of other things in here that I fixed:

- The fences in `gettingStarted.ts` were nesting three deep and hid which lines were actually ours. They are now one fence per divergence, with the replaced upstream code commented out inside each. No functional change.
- The welcome page's left column is rendered with React. Every time the page rebuilt itself it created a new React renderer without disposing the old one, so they piled up until the tab was closed. We now are cleaning up old roots.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

SETUP: build and launch Positron from this branch, and open the Welcome tab.

1. Run **Welcome: Open Walkthrough...**, pick any walkthrough, then click **Go Back** to return to the welcome page.
2. Press **Tab** repeatedly, through **Recent**, **Connect to...** and the **Show welcome page on startup** checkbox, and keep going. **The welcome page stays put** and focus moves out to the Console. 
3. Open a walkthrough again and press **Tab**. Every stop is a control you can see.
4. Confirm walkthroughs still work normally: click a step, expand it, use its links, and **Go Back**.

@:welcome
@:web
