### PR TITLE
Add high contrast highlight for active console session tab

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.css
@@ -39,9 +39,27 @@
 	background-color: var(--vscode-list-hoverBackground);
 }
 
+/*
+ * Hover cue for high contrast themes, where list.hoverBackground is
+ * undefined. contrastActiveBorder is only defined in high contrast
+ * themes, so this renders nothing elsewhere. Scoped to inactive tabs
+ * so it doesn't override the active tab's solid outline on hover.
+ */
+.tab-button:not(.tab-button--active):hover {
+	outline: 1px dashed var(--vscode-contrastActiveBorder, transparent);
+	outline-offset: -1px;
+}
+
 .tab-button--active {
 	background-color: var(--vscode-list-inactiveSelectionBackground);
 	border-left: 1px solid var(--vscode-panelTitle-activeBorder);
+	/*
+	 * Active cue for high contrast themes, where the selection
+	 * background above is undefined. Offset draws the outline inside
+	 * the button so it isn't clipped by the tab list's overflow.
+	 */
+	outline: 1px solid var(--vscode-contrastActiveBorder, transparent);
+	outline-offset: -1px;
 }
 
 .tab-button--active:hover {

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.css
@@ -40,10 +40,11 @@
 }
 
 /*
- * Hover cue for high contrast themes, where list.hoverBackground is
- * undefined. contrastActiveBorder is only defined in high contrast
- * themes, so this renders nothing elsewhere. Scoped to inactive tabs
- * so it doesn't override the active tab's solid outline on hover.
+ * Hover cue for high contrast themes, matching the list widget's
+ * hover outline convention (listHoverOutline in defaultStyles.ts).
+ * contrastActiveBorder is only defined in high contrast themes, so
+ * this renders nothing elsewhere. Scoped to inactive tabs so it
+ * doesn't override the active tab's solid outline on hover.
  */
 .tab-button:not(.tab-button--active):hover {
 	outline: 1px dashed var(--vscode-contrastActiveBorder, transparent);
@@ -55,8 +56,9 @@
 	border-left: 1px solid var(--vscode-panelTitle-activeBorder);
 	/*
 	 * Active cue for high contrast themes, where the selection
-	 * background above is undefined. Offset draws the outline inside
-	 * the button so it isn't clipped by the tab list's overflow.
+	 * background above is missing (HC Dark) or subtle (HC Light).
+	 * Offset draws the outline inside the button so it isn't
+	 * clipped by the tab list's overflow.
 	 */
 	outline: 1px solid var(--vscode-contrastActiveBorder, transparent);
 	outline-offset: -1px;


### PR DESCRIPTION
Fixes the active console session tab having no visible highlight in high contrast themes.

The active tab's highlight relied on `list.inactiveSelectionBackground`, which the Dark High Contrast theme leaves undefined (HC Dark conveys selection with outlines rather than background fills; HC Light defines only a subtle 10% tint), so the active session was indistinguishable from the other tabs.

This follows the established workbench HC convention (same pattern as the settings editor and the agent title bar widget): the active tab gets a solid 1px `contrastActiveBorder` outline, and inactive tabs get a dashed outline on hover, matching the list widget's `listHoverOutline` convention. `contrastActiveBorder` only resolves to a value in high contrast themes (the CSS variable is not emitted otherwise and the `transparent` fallback applies), so all other themes render identically to before.

### Screenshots

_Placeholder: before/after in Dark High Contrast showing the active session tab outline._

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Show a visible highlight for the active console session tab in high contrast themes

### Validation Steps

@:sessions @:console

Note: this is a CSS-only theming change; the visual outcome was verified manually and the tags above cover the console session tab list against regressions.

1. Set the color theme to "Dark High Contrast" (Preferences: Color Theme).
2. Start two console sessions so the session tab list shows multiple tabs.
3. Verify the active session tab shows a solid outline; select the other tab and verify the outline follows.
4. Hover an inactive tab and verify a dashed outline appears.
5. Switch to "High Contrast Light" and repeat; the outline should render in the theme's focus color.
6. Switch to Positron Dark / Positron Light and verify the tabs look unchanged from before (background highlight, no outline).
