### PR TITLE
Raise the API key validation timeout to 10 seconds

### DIFF
--- a/extensions/authentication/src/constants.ts
+++ b/extensions/authentication/src/constants.ts
@@ -9,7 +9,13 @@ export const IS_RUNNING_ON_PWB =
 	!!process.env.RS_SERVER_URL && vscode.env.uiKind === vscode.UIKind.Web;
 
 export const ANTHROPIC_API_VERSION = '2023-06-01';
-export const KEY_VALIDATION_TIMEOUT_MS = 5000;
+
+// Budget for a validator's single round trip to the provider (validation/*.ts).
+// 5 seconds turned out to be too tight: the OpenAI `/models` call intermittently
+// takes longer than that, which aborted a valid key and surfaced as a sign-in
+// failure. Kept comfortably under the 15 second window the sign-in e2e tests
+// allow for the "Sign out" button to appear.
+export const KEY_VALIDATION_TIMEOUT_MS = 10000;
 export const CREDENTIAL_REFRESH_INTERVAL_MS = 10 * 60 * 1000;
 export const EXPIRY_REFRESH_BUFFER_MS = 60 * 1000;
 


### PR DESCRIPTION
The API key validators in `extensions/authentication` give each provider a single round trip to confirm a key, bounded by an `AbortController`. That budget was 5 seconds, and OpenAI's `GET /v1/models` intermittently takes longer. When it does, a perfectly valid key gets aborted and the sign-in dialog reports "Could not validate OpenAI API key within 5 seconds" -- sign-in never completes, so the posit-assistant sign-in e2e test times out waiting for the "Sign out" button.

This raises `KEY_VALIDATION_TIMEOUT_MS` from 5s to 10s. The constant is shared by every API key validator (OpenAI, Anthropic, Gemini, DeepSeek, Databricks, Foundry, and the OpenAI-compatible custom provider), so the wider budget applies to all of them. Nothing about 5 seconds was OpenAI-specific.

10 seconds rather than 15: the sign-in e2e helper waits 15s for the "Sign out" button to appear, so a 15s validation budget would let a slow-but-successful sign-in race that assertion. 10s doubles the tolerance and keeps 5s of headroom.

Found while triaging the repeated `openai-api` sign-in failures on `main` after 7cf11c8 (run 31196984116). The failure screenshot names the timeout outright, and the ai-lib bump in that commit is not implicated -- the abort happens entirely in Positron's validator, before any ai-lib code runs.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Give language model API key validation more time to finish, so a slow provider response no longer reports a valid key as unvalidated.

### Validation Steps

@:assistant

1. Open the Configure Language Model Providers modal, select OpenAI, enter a valid API key, and click **Sign in**.
2. Confirm sign-in succeeds and the button flips to **Sign out**.
3. Optionally, throttle the network (or point Base URL at a slow proxy) so validation takes 6-9 seconds, and confirm sign-in now succeeds where it previously failed at the 5 second mark.
