### PR TITLE
Fix buggy placement of Quarto output widgets with fix/explain buttons

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/QuartoOutputQuickFix.tsx
+++ b/src/vs/workbench/contrib/positronQuarto/browser/QuartoOutputQuickFix.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 // React.
-import { useCallback } from 'react';
+import { useCallback, useLayoutEffect } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../nls.js';
@@ -24,6 +24,13 @@ interface QuartoOutputQuickFixProps {
 	errorContent: string;
 	/** Cell context resolved at render time. */
 	cellContext?: QuartoCellErrorContext;
+	/**
+	 * Called after each render commits to the DOM. The buttons mount
+	 * asynchronously, so the host view zone uses this to re-measure its height
+	 * once they exist rather than relying on a ResizeObserver to notice the
+	 * growth (which it can miss on a re-run; see posit-dev/positron#14844).
+	 */
+	onLayout?: () => void;
 }
 
 /**
@@ -34,7 +41,14 @@ export const QuartoOutputQuickFix = (props: QuartoOutputQuickFixProps) => {
 	const aiEnabled = usePositronConfiguration<boolean>(AI_ENABLED_KEY);
 	const hasChatModels = useContextKeyFromString<boolean>(POSIT_HAS_CHAT_MODELS_KEY);
 
-	const { errorContent, cellContext } = props;
+	const { errorContent, cellContext, onLayout } = props;
+
+	// Notify the host after every commit (declared before the early return so it
+	// runs whether or not the buttons render). Layout effects fire once the DOM
+	// is in place, so the host measures the true height of the mounted buttons.
+	useLayoutEffect(() => {
+		onLayout?.();
+	});
 
 	const buildPayload = useCallback((): AssistantErrorPayload => {
 		if (!cellContext) {

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
@@ -395,6 +395,9 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		private readonly _resourceUsageHistoryService?: IResourceUsageHistoryService,
 		private readonly _onTimestampTick?: VSEvent<void>,
 		private readonly _hoverService?: IHoverService,
+		// Test seam for the offsetHeight reads in `_updateHeight`. jsdom performs
+		// no layout, so tests inject a measurer that returns synthetic heights.
+		private readonly _measureOffsetHeight: (element: HTMLElement) => number = element => element.offsetHeight,
 	) {
 		super();
 
@@ -2622,6 +2625,11 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 				React.createElement(QuartoOutputQuickFix, {
 					errorContent: errorText,
 					cellContext: this._cellContext,
+					// The buttons mount asynchronously; re-measure once they are in
+					// the DOM so the zone reserves room for them. Relying on the
+					// ResizeObserver alone misses a re-run that produces an
+					// identically sized error (posit-dev/positron#14844).
+					onLayout: () => this._updateHeight(),
 				})
 			);
 		}
@@ -3002,18 +3010,18 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		// next scroll back, the whitespace would jump from 24px to the real
 		// height, causing a large scroll displacement. Skip measurement when
 		// the domNode is hidden to preserve the correct height.
-		if (!this.domNode.offsetHeight) {
+		if (!this._measureOffsetHeight(this.domNode)) {
 			return;
 		}
 
 		// Measure the styled container's height (content + padding + border, but not margin)
 		// plus the status bar height when it's displayed above the output
-		const statusBarHeight = this._statusBar.style.display !== 'none' ? this._statusBar.offsetHeight : 0;
-		const styledHeight = this._styledContainer.offsetHeight + statusBarHeight;
+		const statusBarHeight = this._statusBar.style.display !== 'none' ? this._measureOffsetHeight(this._statusBar) : 0;
+		const styledHeight = this._measureOffsetHeight(this._styledContainer) + statusBarHeight;
 
 		// Use the styled container's height (not including status bar) for button
 		// visibility, since the buttons are positioned inside the styled container
-		const containerHeight = this._styledContainer.offsetHeight;
+		const containerHeight = this._measureOffsetHeight(this._styledContainer);
 
 		if (this._isCollapsed) {
 			// Hide action buttons when collapsed since they operate on the

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputViewZone.vitest.tsx
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoOutputViewZone.vitest.tsx
@@ -5,10 +5,18 @@
 
 /// <reference types="vitest/globals" />
 
+import { act } from '@testing-library/react';
 import { Event } from '../../../../../base/common/event.js';
 import { BareFontInfo } from '../../../../../editor/common/config/fontInfo.js';
 import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
 import { EditorOption } from '../../../../../editor/common/config/editorOptions.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { PositronReactServices } from '../../../../../base/browser/positronReactServices.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { ICellOutput } from '../../common/quartoExecutionTypes.js';
 import { chooseHtmlRenderMode, isInertHtml, isWebviewOverlayShown, QuartoOutputViewZone } from '../../browser/quartoOutputViewZone.js';
@@ -171,6 +179,103 @@ describe('QuartoOutputViewZone collapse across a re-execution', () => {
 		zone.setRecomputing(true);
 		zone.addOutput(textOutput('out-2', 'second run'));
 		expect(zone.isCollapsed).toBe(false);
+
+		zone.dispose();
+	});
+});
+
+// The Fix/Explain quick-fix buttons mount asynchronously (a React root), so
+// they are not in the DOM when addOutput() measures the zone synchronously.
+// The original code relied solely on a ResizeObserver to grow the zone once
+// the buttons appeared, but on a re-run that produces an identically sized
+// error the observer sees no net change from its last-reported size and never
+// fires, leaving the zone too short so the buttons paint over the editor lines
+// below The zone must instead re-measure deterministically once the buttons
+// render.
+describe('QuartoOutputViewZone error quick-fix height', () => {
+	const ctx = createTestContainer()
+		.withReactServices()
+		.stub(ICommandService, { executeCommand: vi.fn().mockResolvedValue(undefined) })
+		.build();
+
+	// jsdom performs no layout, so offsetHeight is always 0. Inject a measurer
+	// that reports the styled container as taller once the Fix/Explain buttons
+	// have been committed to the DOM, standing in for the real height the
+	// buttons occupy. Crucially it does NOT rely on a ResizeObserver, so the
+	// only thing that can grow the zone is the zone's own re-measure.
+	const TEXT_HEIGHT = 40;
+	const BUTTONS_HEIGHT = 30;
+	function measureOffsetHeight(el: HTMLElement): number {
+		if (el.classList.contains('quarto-inline-output-wrapper')) {
+			return 1; // domNode: any non-zero value means "laid out"
+		}
+		if (el.classList.contains('quarto-inline-output')) {
+			// eslint-disable-next-line no-restricted-syntax -- simulating layout: detect the mounted quick-fix subtree
+			const hasButtons = !!el.querySelector('.assistant-error-quick-fix');
+			return TEXT_HEIGHT + (hasButtons ? BUTTONS_HEIGHT : 0);
+		}
+		return 0;
+	}
+
+	function createViewZone(): QuartoOutputViewZone {
+		const containerDomNode = document.createElement('div');
+		const editor = stubInterface<ICodeEditor>({
+			getContainerDomNode: () => containerDomNode,
+			onDidChangeConfiguration: Event.None,
+			onDidLayoutChange: Event.None,
+			onDidScrollChange: Event.None,
+			onDidContentSizeChange: Event.None,
+			onDidChangeHiddenAreas: Event.None,
+			onMouseMove: Event.None,
+			onMouseLeave: Event.None,
+			getOption: ((id: EditorOption) => {
+				if (id !== EditorOption.fontInfo) {
+					throw new Error(`unexpected getOption(${id})`);
+				}
+				return BareFontInfo._create('monospace', 'normal', 12, '', '', 18, 0, 1, false);
+			}) as ICodeEditor['getOption'],
+		});
+		return new QuartoOutputViewZone(
+			editor, 'cell-1', 1,
+			undefined, undefined, 40, undefined, undefined, undefined, undefined, undefined,
+			measureOffsetHeight,
+		);
+	}
+
+	function errorOutput(id: string): ICellOutput {
+		return {
+			outputId: id,
+			items: [{
+				mime: 'application/vnd.code.notebook.error',
+				data: JSON.stringify({ name: 'Error', message: 'oh no', stack: 'Error: oh no' }),
+			}],
+		};
+	}
+
+	it('grows to fit the async quick-fix buttons on the first run and again on a re-run', async () => {
+		// Gate the assistant on so the Fix/Explain buttons actually render.
+		(ctx.get(IConfigurationService) as TestConfigurationService).setUserConfiguration('ai.enabled', true);
+		(ctx.get(IContextKeyService) as MockContextKeyService).createKey('posit-assistant.hasChatModels', true);
+		// The view zone renders the buttons through a PositronReactRenderer,
+		// which reads the services singleton; bridge the test container in.
+		PositronReactServices.services = ctx.reactServices;
+
+		const zone = createViewZone();
+		zone.enableQuickFix();
+
+		await act(async () => {
+			zone.addOutput(errorOutput('err-1'));
+		});
+		expect(zone.heightInPx).toBe(TEXT_HEIGHT + BUTTONS_HEIGHT + 13);
+
+		// Re-run: the same error is produced. A ResizeObserver would see no net
+		// change and stay silent, so the zone's own re-measure is what keeps the
+		// buttons inside the reserved whitespace.
+		zone.setRecomputing(true);
+		await act(async () => {
+			zone.addOutput(errorOutput('err-2'));
+		});
+		expect(zone.heightInPx).toBe(TEXT_HEIGHT + BUTTONS_HEIGHT + 13);
 
 		zone.dispose();
 	});


### PR DESCRIPTION
Fixes #14844

Quarto renders cell output inline in the editor via a Monaco view zone. The Fix/Explain quick-fix buttons for error output mount asynchronously (a React root), so the zone measured its height before the buttons existed and reserved a too-short whitespace. Growing the zone to fit the buttons relied solely on a `ResizeObserver`. On a re-run that produced an identically-sized error, the container shrank (DOM cleared) and grew back to the same height within one frame, so the observer coalesced it to a net-zero change and never fired -- leaving the zone too short and the buttons drawn over the editor lines below. The first run worked because the observer's baseline was the minimum height, so the growth registered as a real change.

The quick-fix component now fires an `onLayout` callback from a layout effect once its buttons commit to the DOM, and the view zone re-measures on that callback. The height is corrected deterministically instead of depending on the observer noticing a net size change; the observer stays as a backstop for other async growth.

<img width="695" height="297" alt="image" src="https://github.com/user-attachments/assets/c614fa75-7a82-4361-80f9-f7587e6809bd" />


### Release Notes

#### New Features
- N/A

#### Bug Fixes

- Fixed the Fix/Explain buttons drawing over the editor when re-running a Quarto cell that errors (#14844)

### Validation Steps

@:quarto

1. Open a `.qmd` document with an R cell that errors, e.g. `stop("oh no")`, followed by some prose.
2. Run the cell -- the error output with Fix/Explain buttons renders correctly inside its box.
3. Run the cell again. The buttons should stay inside the output box and not overlap the editor text below.
