### PR TITLE
Serve language features for Quarto code cells from a hidden notebook

### DIFF
--- a/extensions/positron-python/src/client/positron/lsp.ts
+++ b/extensions/positron-python/src/client/positron/lsp.ts
@@ -33,9 +33,18 @@ const NOTEBOOK_REPL_PATTERN = /^\/notebook-repl-/;
 // src/vs/workbench/contrib/positronQuarto/common/quartoVirtualNotebookTypes.ts.
 const QUARTO_CELLS_NOTEBOOK_TYPE = 'quarto-cells';
 
+// Matches the path of a Quarto or R Markdown document.
+const QUARTO_PATH_PATTERN = /\.(qmd|rmd)$/i;
+
 // Selector for the cells of Quarto virtual notebooks. A cell URI keeps the path
 // of the Quarto document the notebook was built from, so restricting the pattern
 // to Quarto extensions keeps the cells of real notebooks (.ipynb) out.
+//
+// `.Rmd` belongs here as much as `.qmd` does. R Markdown runs more than one
+// engine, so a Python chunk in an `.Rmd` is ordinary (see
+// test/e2e/test-files/workspaces/visual-mode/visual-mode.rmd). This never claims
+// the `.Rmd` document itself: that is `file` scheme with the `quarto` language,
+// and all three filters here have to match.
 const QUARTO_CELL_SELECTOR = {
     language: 'python',
     scheme: 'vscode-notebook-cell',
@@ -144,13 +153,30 @@ export class PythonLsp implements vscode.Disposable {
 
         const { notebookUri, workingDirectory } = this._metadata;
 
+        // Matches the cells of this client's own notebook.
+        //
+        // Skipped for Quarto sessions, whose notebook URI is the path of the .qmd
+        // document. The only Python documents with that path are the cells of the
+        // document's virtual notebook, and the console client serves those, so
+        // matching them here would only duplicate it. For a real notebook (.ipynb)
+        // this is what matches the notebook's own cells.
+        //
+        // `filterCells` below excludes them too, but only covers the case where the
+        // server claims notebook cells through `notebookDocumentSync`. Without that
+        // capability the client syncs them as ordinary text documents, and then the
+        // document selector is the only gate.
+        const ownNotebookCellSelectors =
+            notebookUri && !QUARTO_PATH_PATTERN.test(notebookUri.path)
+                ? [{ language: 'python', pattern: notebookUri.fsPath }]
+                : [];
+
         // If this client belongs to a notebook, set the document selector to only include that notebook,
         // Quarto virtual documents (vdocs), and notebook console inputs (inmemory scheme).
         // Otherwise, this is the main client for this language, so set the document selector to include
         // untitled Python files, in-memory Python files (e.g. the console), and Python files on disk.
         this._clientOptions.documentSelector = notebookUri
             ? [
-                  { language: 'python', pattern: notebookUri.fsPath },
+                  ...ownNotebookCellSelectors,
                   // Match Quarto virtual documents (vdocs). Vdocs are
                   // temporary .py files created for LSP features in
                   // embedded code blocks (e.g. completions, hover).

--- a/extensions/positron-python/src/client/positron/lsp.ts
+++ b/extensions/positron-python/src/client/positron/lsp.ts
@@ -27,6 +27,33 @@ const VDOC_SELECTOR = { language: 'python', pattern: '**/.vdoc.*.{py,PY}' };
 // Regex to match notebook console REPL URIs: /notebook-repl-<lang>-<uuid>
 const NOTEBOOK_REPL_PATTERN = /^\/notebook-repl-/;
 
+// Positron core creates a hidden notebook of this type for each open Quarto
+// document, so that language servers see the embedded code cells as ordinary
+// notebook cells. See
+// src/vs/workbench/contrib/positronQuarto/common/quartoVirtualNotebookTypes.ts.
+const QUARTO_CELLS_NOTEBOOK_TYPE = 'quarto-cells';
+
+// Selector for the cells of Quarto virtual notebooks. A cell URI keeps the path
+// of the Quarto document the notebook was built from, so restricting the pattern
+// to Quarto extensions keeps the cells of real notebooks (.ipynb) out.
+const QUARTO_CELL_SELECTOR = {
+    language: 'python',
+    scheme: 'vscode-notebook-cell',
+    pattern: '**/*.{qmd,QMD,rmd,Rmd,RMD}',
+};
+
+/**
+ * Whether a document is a cell of a Quarto virtual notebook.
+ */
+function isQuartoVirtualCell(document: vscode.TextDocument): boolean {
+    if (document.uri.scheme !== 'vscode-notebook-cell') {
+        return false;
+    }
+    return vscode.workspace.notebookDocuments.some(
+        (notebook) => notebook.notebookType === QUARTO_CELLS_NOTEBOOK_TYPE && notebook.uri.path === document.uri.path,
+    );
+}
+
 /**
  * Global output channel for Python LSP sessions
  *
@@ -146,6 +173,9 @@ export class PythonLsp implements vscode.Disposable {
                   // code blocks when inline output is disabled and
                   // no notebook LSP exists.
                   VDOC_SELECTOR,
+                  // Match Quarto virtual notebook cells. The console
+                  // client serves these for every open Quarto document.
+                  QUARTO_CELL_SELECTOR,
               ];
 
         // This is needed in addition to the document selector, otherwise every client seems to
@@ -156,8 +186,16 @@ export class PythonLsp implements vscode.Disposable {
                   filterCells: (notebookDocument, cells) =>
                       notebookUri.toString() === notebookDocument.uri.toString() ? cells : [],
               }
-            : // For console clients, exclude all notebook cells.
-              { filterCells: () => [] };
+            : // Console clients exclude notebook cells, which belong to their own
+              // notebook's client, except for the cells of Quarto virtual notebooks.
+              // Those have no client of their own. A Quarto session starts only for
+              // the active pinned editor and only when inline output is enabled, so
+              // routing these cells to a session instead would leave every other open
+              // Quarto document without language features.
+              {
+                  filterCells: (notebookDocument, cells) =>
+                      notebookDocument.notebookType === QUARTO_CELLS_NOTEBOOK_TYPE ? cells : [],
+              };
 
         // Override default error handler with one that doesn't automatically restart the client,
         // and that logs to the appropriate place.
@@ -191,6 +229,10 @@ export class PythonLsp implements vscode.Disposable {
                     return true;
                 }
             } else {
+                // Notebook LSP: skip Quarto virtual notebook cells, which the console LSP serves.
+                if (isQuartoVirtualCell(document)) {
+                    return true;
+                }
                 // Notebook LSP: skip regular (non-notebook) console inputs
                 if (document.uri.scheme === 'inmemory' && !NOTEBOOK_REPL_PATTERN.test(document.uri.path)) {
                     return true;

--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -35,6 +35,41 @@ const QUARTO_INPUT_BOUNDARY_SELECTOR = { language: 'r', scheme: 'inmemory', patt
 // Regex to match notebook console REPL URIs: /notebook-repl-<lang>-<uuid>
 const NOTEBOOK_REPL_PATTERN = /^\/notebook-repl-/;
 
+// Positron core creates a hidden notebook of this type for each open Quarto
+// document, so that language servers see the embedded code cells as ordinary
+// notebook cells. See
+// src/vs/workbench/contrib/positronQuarto/common/quartoVirtualNotebookTypes.ts.
+const QUARTO_CELLS_NOTEBOOK_TYPE = 'quarto-cells';
+
+// Matches the path of a Quarto or R Markdown document.
+const QUARTO_PATH_PATTERN = /\.(qmd|rmd)$/i;
+
+// Selector for the cells of Quarto virtual notebooks.
+//
+// Ark declares no `notebookDocumentSync` capability, so the language client
+// syncs these cells as ordinary text documents and the document selector is the
+// only gate. A cell URI keeps the path of the Quarto document the notebook was
+// built from, so restricting the pattern to Quarto extensions keeps the cells of
+// real notebooks (.ipynb) out.
+const QUARTO_CELL_SELECTOR = {
+	language: 'r',
+	scheme: 'vscode-notebook-cell',
+	pattern: '**/*.{qmd,QMD,rmd,Rmd,RMD}',
+};
+
+/**
+ * Whether a document is a cell of a Quarto virtual notebook.
+ */
+function isQuartoVirtualCell(document: vscode.TextDocument): boolean {
+	if (document.uri.scheme !== 'vscode-notebook-cell') {
+		return false;
+	}
+	return vscode.workspace.notebookDocuments.some(
+		notebook => notebook.notebookType === QUARTO_CELLS_NOTEBOOK_TYPE &&
+			notebook.uri.path === document.uri.path
+	);
+}
+
 /**
  * Global output channel for R LSP sessions
  *
@@ -137,6 +172,17 @@ export class ArkLsp implements vscode.Disposable {
 
 		const { notebookUri } = this._metadata;
 
+		// Matches the cells of this client's own notebook.
+		//
+		// Skipped for Quarto sessions, whose notebook URI is the path of the
+		// .qmd document. The only R documents with that path are the cells of
+		// the document's virtual notebook, and the console client serves those,
+		// so matching them here would only duplicate it. For a real notebook
+		// (.ipynb) this is what matches the notebook's own cells.
+		const ownNotebookCellSelectors = notebookUri && !QUARTO_PATH_PATTERN.test(notebookUri.path)
+			? [{ language: 'r', pattern: notebookUri.fsPath }]
+			: [];
+
 		const clientOptions: LanguageClientOptions = {
 			// If this client belongs to a notebook, set the document selector to only include that notebook,
 			// Quarto virtual documents (vdocs), and notebook console inputs (inmemory scheme).
@@ -144,7 +190,7 @@ export class ArkLsp implements vscode.Disposable {
 			// untitled R files, in-memory R files (e.g. the console), and R / Quarto / R Markdown files on disk.
 			documentSelector: notebookUri ?
 				[
-					{ language: 'r', pattern: notebookUri.fsPath },
+					...ownNotebookCellSelectors,
 					// Match Quarto virtual documents (vdocs). Vdocs are
 					// temporary .r files created for LSP features in
 					// embedded code blocks (e.g. completions, hover).
@@ -156,7 +202,16 @@ export class ArkLsp implements vscode.Disposable {
 					// to distinguish them from regular console inputs.
 					{ language: 'r', scheme: 'inmemory' },
 				] :
-				R_DOCUMENT_SELECTORS,
+				[
+					...R_DOCUMENT_SELECTORS,
+					// Match Quarto virtual notebook cells. The console client
+					// serves these for every open Quarto document. A Quarto
+					// session starts only for the active pinned editor and only
+					// when inline output is enabled, so routing these cells to a
+					// session instead would leave every other open Quarto
+					// document without language features.
+					QUARTO_CELL_SELECTOR,
+				],
 			synchronize: notebookUri ?
 				undefined :
 				{
@@ -210,6 +265,10 @@ export class ArkLsp implements vscode.Disposable {
 							return undefined;
 						}
 					} else {
+						// Notebook LSP: skip Quarto virtual notebook cells, which the console LSP serves
+						if (isQuartoVirtualCell(document)) {
+							return undefined;
+						}
 						// Notebook LSP: skip regular (non-notebook) console inputs
 						if (document.uri.scheme === 'inmemory' &&
 							!NOTEBOOK_REPL_PATTERN.test(document.uri.path)) {

--- a/src/vs/workbench/contrib/positronQuarto/browser/positronQuarto.contribution.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/positronQuarto.contribution.ts
@@ -27,6 +27,7 @@ import { QuartoCellToolbarController } from './quartoCellToolbarController.js';
 import { QuartoImagePreviewContribution } from './quartoImagePreview.js';
 import { QuartoEquationPreviewContribution } from './quartoEquationPreview.js';
 import { IQuartoVirtualNotebookService, QuartoVirtualNotebookContribution, QuartoVirtualNotebookService } from './quartoVirtualNotebookService.js';
+import { QuartoEmbeddedLanguageFeatures } from './quartoEmbeddedLanguageFeatures.js';
 import {
 	IS_QUARTO_DOCUMENT,
 	POSITRON_QUARTO_INLINE_OUTPUT_KEY,
@@ -337,6 +338,13 @@ registerWorkbenchContribution2(
 registerWorkbenchContribution2(
 	QuartoVirtualNotebookContribution.ID,
 	QuartoVirtualNotebookContribution,
+	WorkbenchPhase.AfterRestored
+);
+
+// Routes language features for embedded code to the hidden notebook's cells
+registerWorkbenchContribution2(
+	QuartoEmbeddedLanguageFeatures.ID,
+	QuartoEmbeddedLanguageFeatures,
 	WorkbenchPhase.AfterRestored
 );
 

--- a/src/vs/workbench/contrib/positronQuarto/browser/positronQuarto.contribution.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/positronQuarto.contribution.ts
@@ -26,6 +26,7 @@ import { QuartoExecutionDecorations } from './quartoExecutionDecorations.js';
 import { QuartoCellToolbarController } from './quartoCellToolbarController.js';
 import { QuartoImagePreviewContribution } from './quartoImagePreview.js';
 import { QuartoEquationPreviewContribution } from './quartoEquationPreview.js';
+import { IQuartoVirtualNotebookService, QuartoVirtualNotebookContribution, QuartoVirtualNotebookService } from './quartoVirtualNotebookService.js';
 import {
 	IS_QUARTO_DOCUMENT,
 	POSITRON_QUARTO_INLINE_OUTPUT_KEY,
@@ -67,6 +68,7 @@ registerSingleton(IQuartoKernelManager, QuartoKernelManager, InstantiationType.D
 registerSingleton(IQuartoExecutionManager, QuartoExecutionManager, InstantiationType.Delayed);
 registerSingleton(IQuartoOutputCacheService, QuartoOutputCacheService, InstantiationType.Delayed);
 registerSingleton(IQuartoOutputManager, QuartoOutputManagerService, InstantiationType.Delayed);
+registerSingleton(IQuartoVirtualNotebookService, QuartoVirtualNotebookService, InstantiationType.Eager);
 
 // Register editor contributions
 registerEditorContribution(QuartoExecutionDecorations.ID, QuartoExecutionDecorations, EditorContributionInstantiation.AfterFirstRender);
@@ -328,6 +330,13 @@ class QuartoInlineOutputContribution extends Disposable implements IWorkbenchCon
 registerWorkbenchContribution2(
 	QuartoInlineOutputContribution.ID,
 	QuartoInlineOutputContribution,
+	WorkbenchPhase.AfterRestored
+);
+
+// Starts the hidden notebook watcher
+registerWorkbenchContribution2(
+	QuartoVirtualNotebookContribution.ID,
+	QuartoVirtualNotebookContribution,
 	WorkbenchPhase.AfterRestored
 );
 

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoDocumentModel.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoDocumentModel.ts
@@ -127,6 +127,15 @@ export class QuartoDocumentModel extends Disposable implements IQuartoDocumentMo
 		await this._parsedBarrier.wait();
 	}
 
+	synchronize(): void {
+		if (!this._parseTimeout) {
+			return;
+		}
+		clearTimeout(this._parseTimeout);
+		this._parseTimeout = undefined;
+		this._parseDocument();
+	}
+
 	/**
 	 * Closes the parse gate so `whenParsed` callers wait for the pending re-parse.
 	 * A `Barrier` can't be re-closed, hence the replacement -- but only when open,

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoEmbeddedLanguageFeatures.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoEmbeddedLanguageFeatures.ts
@@ -35,7 +35,7 @@ import {
 	usingNativeEmbeddedFeatures,
 } from '../common/positronQuartoConfig.js';
 import { cellRangeToSource, ICellLineSpan, sourcePositionToCell } from '../common/quartoCellPositionMapping.js';
-import { IQuartoVirtualCell, IQuartoVirtualNotebookService } from './quartoVirtualNotebookService.js';
+import { IQuartoVirtualNotebookService } from './quartoVirtualNotebookService.js';
 
 /**
  * Documents that can hold embedded code cells. Taken from the shared list so
@@ -48,9 +48,17 @@ interface ITriggerCharacterProvider {
 	readonly triggerCharacters?: readonly string[];
 }
 
-/** A position in a Quarto document, resolved to the cell that holds it. */
+/**
+ * A position in a Quarto document, resolved to the cell that holds it.
+ *
+ * The line span is copied rather than referenced. Syncing a document can rebuild
+ * its cells while a request is still in flight, and a request that started before
+ * the rebuild has to finish in the coordinates it started with.
+ */
 interface IResolvedCell {
-	readonly cell: IQuartoVirtualCell;
+	readonly textModel: ITextModel;
+	readonly cellUri: URI;
+	readonly span: ICellLineSpan;
 	readonly position: Position;
 }
 
@@ -70,29 +78,63 @@ function mapCompletionItemRange(cell: ICellLineSpan, range: CompletionItem['rang
 }
 
 /**
- * Remap one definition result. Only entries that point into the cell itself are
- * rewritten, onto the source document; a definition in another file is already
- * in the coordinates its own document uses.
+ * Remap every part of a completion item that carries coordinates.
  *
- * `originSelectionRange` is always rewritten. It describes where the request
- * came from, which we translated into the cell before forwarding.
+ * `additionalTextEdits` matters as much as `range` does. It is how a server adds
+ * an import at the top of the file when you accept a symbol, so leaving it in
+ * cell coordinates writes that import into whatever happens to be at the same
+ * line of the Quarto document, which is usually the frontmatter.
+ *
+ * `command.arguments` is opaque, so a command that carries positions cannot be
+ * corrected here. No server we forward to is known to do that.
+ */
+function mapCompletionItem(cell: ICellLineSpan, item: CompletionItem): CompletionItem {
+	return {
+		...item,
+		range: mapCompletionItemRange(cell, item.range),
+		additionalTextEdits: item.additionalTextEdits?.map(edit => ({
+			...edit,
+			range: cellRangeToSource(cell, edit.range),
+		})),
+	};
+}
+
+/** Where a cell lives, for turning a definition inside it into a source location. */
+interface ICellLocation {
+	readonly sourceUri: URI;
+	readonly span: ICellLineSpan;
+}
+
+/**
+ * Remap one definition result.
+ *
+ * A definition can land in any cell, not only the one the request came from. A
+ * server that indexes every open document will happily point at a symbol defined
+ * in an earlier chunk, and returning that verbatim hands the editor a hidden cell
+ * URI that it cannot open. Entries in a real file are already in the coordinates
+ * their own document uses and pass through untouched.
+ *
+ * `originSelectionRange` is always rewritten against the requesting cell. It
+ * describes where the request came from, which we translated before forwarding.
  */
 function mapDefinitionEntry(
-	cell: IQuartoVirtualCell,
-	sourceUri: URI,
+	requestSpan: ICellLineSpan,
+	locate: (uri: URI) => ICellLocation | undefined,
 	entry: Location | LocationLink
 ): Location | LocationLink {
 	const link = entry as LocationLink;
 	const mapped: LocationLink = { ...link };
 
 	if (link.originSelectionRange) {
-		mapped.originSelectionRange = cellRangeToSource(cell, link.originSelectionRange);
+		mapped.originSelectionRange = cellRangeToSource(requestSpan, link.originSelectionRange);
 	}
-	if (entry.uri.toString() === cell.cellUri.toString()) {
-		mapped.uri = sourceUri;
-		mapped.range = cellRangeToSource(cell, entry.range);
+
+	const target = locate(entry.uri);
+	if (target) {
+		mapped.uri = target.sourceUri;
+		mapped.range = cellRangeToSource(target.span, entry.range);
 		if (link.targetSelectionRange) {
-			mapped.targetSelectionRange = cellRangeToSource(cell, link.targetSelectionRange);
+			mapped.targetSelectionRange = cellRangeToSource(target.span, link.targetSelectionRange);
 		}
 	}
 	return mapped;
@@ -131,7 +173,25 @@ abstract class QuartoEmbeddedProvider {
 		if (!cellPosition) {
 			return undefined;
 		}
-		return { cell, position: Position.lift(cellPosition) };
+		return {
+			textModel: cell.textModel,
+			cellUri: cell.cellUri,
+			span: { codeStartLine: cell.codeStartLine, codeEndLine: cell.codeEndLine },
+			position: Position.lift(cellPosition),
+		};
+	}
+
+	/** Find the Quarto document and cell span behind a cell URI, if it is ours. */
+	protected _locateCell(uri: URI): ICellLocation | undefined {
+		const sourceUri = this._virtualNotebooks.getSourceUriForCell(uri);
+		if (!sourceUri) {
+			return undefined;
+		}
+		const cell = this._virtualNotebooks.getCells(sourceUri)
+			.find(candidate => candidate.cellUri.toString() === uri.toString());
+		return cell
+			? { sourceUri, span: { codeStartLine: cell.codeStartLine, codeEndLine: cell.codeEndLine } }
+			: undefined;
 	}
 
 	/**
@@ -144,8 +204,8 @@ abstract class QuartoEmbeddedProvider {
 	 * Outline, and asking every server also doubles the work per request, which
 	 * runs against the slowness this routing exists to fix.
 	 */
-	protected _downstream<T>(registry: LanguageFeatureRegistry<T>, cell: IQuartoVirtualCell): T[] {
-		return registry.ordered(cell.textModel)
+	protected _downstream<T>(registry: LanguageFeatureRegistry<T>, textModel: ITextModel): T[] {
+		return registry.ordered(textModel)
 			.filter(provider => !(provider instanceof QuartoEmbeddedProvider));
 	}
 
@@ -171,7 +231,7 @@ abstract class QuartoEmbeddedProvider {
 	): string[] {
 		const characters = new Set<string>();
 		for (const cell of this._virtualNotebooks.getAllCells()) {
-			for (const provider of this._downstream(registry, cell)) {
+			for (const provider of this._downstream(registry, cell.textModel)) {
 				for (const character of provider.triggerCharacters ?? []) {
 					characters.add(character);
 				}
@@ -184,8 +244,21 @@ abstract class QuartoEmbeddedProvider {
 /**
  * Serves completions inside Quarto code cells.
  */
+interface ICompletionOrigin {
+	readonly provider: CompletionItemProvider;
+	readonly item: CompletionItem;
+	readonly span: ICellLineSpan;
+}
+
 class QuartoEmbeddedCompletionProvider extends QuartoEmbeddedProvider implements CompletionItemProvider {
 	readonly _debugDisplayName = 'quartoEmbeddedCompletions';
+
+	/**
+	 * Where each item we handed out came from, so that resolving it can go back to
+	 * the same provider with the same item. Weak, so entries go away with the items
+	 * the suggest widget drops.
+	 */
+	private readonly _origins = new WeakMap<CompletionItem, ICompletionOrigin>();
 
 	get triggerCharacters(): string[] {
 		return this._collectTriggerCharacters(this._languageFeatures.completionProvider);
@@ -201,10 +274,10 @@ class QuartoEmbeddedCompletionProvider extends QuartoEmbeddedProvider implements
 		if (!resolved) {
 			return undefined;
 		}
-		const { cell, position: cellPosition } = resolved;
+		const { textModel, span, position: cellPosition } = resolved;
 
-		for (const provider of this._downstream(this._languageFeatures.completionProvider, cell)) {
-			const result = await provider.provideCompletionItems(cell.textModel, cellPosition, context, token);
+		for (const provider of this._downstream(this._languageFeatures.completionProvider, textModel)) {
+			const result = await provider.provideCompletionItems(textModel, cellPosition, context, token);
 			if (!result) {
 				continue;
 			}
@@ -213,15 +286,35 @@ class QuartoEmbeddedCompletionProvider extends QuartoEmbeddedProvider implements
 				continue;
 			}
 			return {
-				suggestions: result.suggestions.map(item => ({
-					...item,
-					range: mapCompletionItemRange(cell, item.range),
-				})),
+				suggestions: result.suggestions.map(item => {
+					const mapped = mapCompletionItem(span, item);
+					this._origins.set(mapped, { provider, item, span });
+					return mapped;
+				}),
 				incomplete: result.incomplete,
 				dispose: () => result.dispose?.(),
 			};
 		}
 		return undefined;
+	}
+
+	/**
+	 * Forward resolution to whichever provider produced the item.
+	 *
+	 * Without this the suggest widget skips resolution altogether, because it looks
+	 * for the method on the provider it called, which is this one. That costs the
+	 * documentation panel, and it costs any edit a server only computes on resolve,
+	 * which is the usual way an auto-import arrives.
+	 */
+	async resolveCompletionItem(item: CompletionItem, token: CancellationToken): Promise<CompletionItem> {
+		const origin = this._origins.get(item);
+		if (!origin?.provider.resolveCompletionItem) {
+			return item;
+		}
+		const resolved = await origin.provider.resolveCompletionItem(origin.item, token);
+		// Resolution answers in the cell's coordinates, as the original did, and
+		// carries the same fields that have to move back to the source document.
+		return resolved ? mapCompletionItem(origin.span, resolved) : item;
 	}
 }
 
@@ -238,12 +331,12 @@ class QuartoEmbeddedHoverProvider extends QuartoEmbeddedProvider implements Hove
 		if (!resolved) {
 			return undefined;
 		}
-		const { cell, position: cellPosition } = resolved;
+		const { textModel, span, position: cellPosition } = resolved;
 
-		for (const provider of this._downstream(this._languageFeatures.hoverProvider, cell)) {
-			const result = await provider.provideHover(cell.textModel, cellPosition, token);
+		for (const provider of this._downstream(this._languageFeatures.hoverProvider, textModel)) {
+			const result = await provider.provideHover(textModel, cellPosition, token);
 			if (result) {
-				return result.range ? { ...result, range: cellRangeToSource(cell, result.range) } : result;
+				return result.range ? { ...result, range: cellRangeToSource(span, result.range) } : result;
 			}
 		}
 		return undefined;
@@ -256,12 +349,25 @@ class QuartoEmbeddedHoverProvider extends QuartoEmbeddedProvider implements Hove
  */
 class QuartoEmbeddedSignatureHelpProvider extends QuartoEmbeddedProvider implements SignatureHelpProvider {
 	get signatureHelpTriggerCharacters(): string[] {
-		// The registry stores these as `signatureHelpTriggerCharacters`, so they
-		// need reading under that name rather than the completion one.
+		return this._collectSignatureCharacters(provider => provider.signatureHelpTriggerCharacters);
+	}
+
+	/**
+	 * Retrigger characters are collected as well as trigger characters. The hint
+	 * widget reads them separately, and without them a hint never advances to the
+	 * next parameter as you type past a comma.
+	 */
+	get signatureHelpRetriggerCharacters(): string[] {
+		return this._collectSignatureCharacters(provider => provider.signatureHelpRetriggerCharacters);
+	}
+
+	private _collectSignatureCharacters(
+		select: (provider: SignatureHelpProvider) => readonly string[] | undefined
+	): string[] {
 		const characters = new Set<string>();
 		for (const cell of this._virtualNotebooks.getAllCells()) {
-			for (const provider of this._downstream(this._languageFeatures.signatureHelpProvider, cell)) {
-				for (const character of provider.signatureHelpTriggerCharacters ?? []) {
+			for (const provider of this._downstream(this._languageFeatures.signatureHelpProvider, cell.textModel)) {
+				for (const character of select(provider) ?? []) {
 					characters.add(character);
 				}
 			}
@@ -279,10 +385,10 @@ class QuartoEmbeddedSignatureHelpProvider extends QuartoEmbeddedProvider impleme
 		if (!resolved) {
 			return undefined;
 		}
-		const { cell, position: cellPosition } = resolved;
+		const { textModel, position: cellPosition } = resolved;
 
-		for (const provider of this._downstream(this._languageFeatures.signatureHelpProvider, cell)) {
-			const result = await provider.provideSignatureHelp(cell.textModel, cellPosition, token, context);
+		for (const provider of this._downstream(this._languageFeatures.signatureHelpProvider, textModel)) {
+			const result = await provider.provideSignatureHelp(textModel, cellPosition, token, context);
 			if (result) {
 				return result;
 			}
@@ -304,10 +410,10 @@ class QuartoEmbeddedDefinitionProvider extends QuartoEmbeddedProvider implements
 		if (!resolved) {
 			return undefined;
 		}
-		const { cell, position: cellPosition } = resolved;
+		const { textModel, span, position: cellPosition } = resolved;
 
-		for (const provider of this._downstream(this._languageFeatures.definitionProvider, cell)) {
-			const result = await provider.provideDefinition(cell.textModel, cellPosition, token);
+		for (const provider of this._downstream(this._languageFeatures.definitionProvider, textModel)) {
+			const result = await provider.provideDefinition(textModel, cellPosition, token);
 			if (!result) {
 				continue;
 			}
@@ -315,7 +421,8 @@ class QuartoEmbeddedDefinitionProvider extends QuartoEmbeddedProvider implements
 			if (entries.length === 0) {
 				continue;
 			}
-			return entries.map(entry => mapDefinitionEntry(cell, model.uri, entry)) as LocationLink[];
+			return entries.map(entry =>
+				mapDefinitionEntry(span, uri => this._locateCell(uri), entry)) as LocationLink[];
 		}
 		return undefined;
 	}

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoEmbeddedLanguageFeatures.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoEmbeddedLanguageFeatures.ts
@@ -28,6 +28,7 @@ import {
 } from '../../../../editor/common/languages.js';
 import { ILanguageFeaturesService } from '../../../../editor/common/services/languageFeatures.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { ILogService, LogLevel } from '../../../../platform/log/common/log.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
 import {
 	QUARTO_LANGUAGE_IDS,
@@ -148,7 +149,29 @@ abstract class QuartoEmbeddedProvider {
 	constructor(
 		protected readonly _virtualNotebooks: IQuartoVirtualNotebookService,
 		protected readonly _languageFeatures: ILanguageFeaturesService,
+		protected readonly _logService: ILogService,
 	) { }
+
+	/**
+	 * Record that a request was answered from a cell rather than by the Quarto
+	 * extension's virtual documents.
+	 *
+	 * The two paths run side by side until the extension stops answering, and they
+	 * produce results a user cannot tell apart: Positron deduplicates completion
+	 * items, so even the overlap is invisible. Without this line there is no way to
+	 * confirm the feature is doing anything, which makes it untestable by hand and
+	 * unsupportable in the field.
+	 *
+	 * Guarded rather than left to the log level, because this runs on every
+	 * keystroke that opens the suggest widget and the message would be built even
+	 * when nothing reads it.
+	 */
+	protected _traceForwarded(feature: string, span: ICellLineSpan, providers: readonly unknown[]): void {
+		if (this._logService.getLevel() <= LogLevel.Trace) {
+			this._logService.trace(`[QuartoEmbedded] ${feature} answered from cell ` +
+				`${span.codeStartLine}-${span.codeEndLine} by ${providers.length} provider(s)`);
+		}
+	}
 
 	/**
 	 * Find the cell holding a position in a Quarto document, with the position
@@ -276,7 +299,10 @@ class QuartoEmbeddedCompletionProvider extends QuartoEmbeddedProvider implements
 		}
 		const { textModel, span, position: cellPosition } = resolved;
 
-		for (const provider of this._downstream(this._languageFeatures.completionProvider, textModel)) {
+		const downstream = this._downstream(this._languageFeatures.completionProvider, textModel);
+		this._traceForwarded('completion', span, downstream);
+
+		for (const provider of downstream) {
 			const result = await provider.provideCompletionItems(textModel, cellPosition, context, token);
 			if (!result) {
 				continue;
@@ -333,7 +359,10 @@ class QuartoEmbeddedHoverProvider extends QuartoEmbeddedProvider implements Hove
 		}
 		const { textModel, span, position: cellPosition } = resolved;
 
-		for (const provider of this._downstream(this._languageFeatures.hoverProvider, textModel)) {
+		const downstream = this._downstream(this._languageFeatures.hoverProvider, textModel);
+		this._traceForwarded('hover', span, downstream);
+
+		for (const provider of downstream) {
 			const result = await provider.provideHover(textModel, cellPosition, token);
 			if (result) {
 				return result.range ? { ...result, range: cellRangeToSource(span, result.range) } : result;
@@ -412,7 +441,10 @@ class QuartoEmbeddedDefinitionProvider extends QuartoEmbeddedProvider implements
 		}
 		const { textModel, span, position: cellPosition } = resolved;
 
-		for (const provider of this._downstream(this._languageFeatures.definitionProvider, textModel)) {
+		const downstream = this._downstream(this._languageFeatures.definitionProvider, textModel);
+		this._traceForwarded('definition', span, downstream);
+
+		for (const provider of downstream) {
 			const result = await provider.provideDefinition(textModel, cellPosition, token);
 			if (!result) {
 				continue;
@@ -442,6 +474,7 @@ export class QuartoEmbeddedLanguageFeatures extends Disposable implements IWorkb
 		@IQuartoVirtualNotebookService private readonly _virtualNotebooks: IQuartoVirtualNotebookService,
 		@ILanguageFeaturesService private readonly _languageFeatures: ILanguageFeaturesService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
 
@@ -459,7 +492,7 @@ export class QuartoEmbeddedLanguageFeatures extends Disposable implements IWorkb
 			return;
 		}
 
-		const args = [this._virtualNotebooks, this._languageFeatures] as const;
+		const args = [this._virtualNotebooks, this._languageFeatures, this._logService] as const;
 		this._registrations.add(this._languageFeatures.completionProvider.register(
 			QUARTO_SELECTOR, new QuartoEmbeddedCompletionProvider(...args)));
 		this._registrations.add(this._languageFeatures.hoverProvider.register(

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoEmbeddedLanguageFeatures.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoEmbeddedLanguageFeatures.ts
@@ -1,0 +1,365 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { URI } from '../../../../base/common/uri.js';
+import { Position } from '../../../../editor/common/core/position.js';
+import { IRange } from '../../../../editor/common/core/range.js';
+import { ITextModel } from '../../../../editor/common/model.js';
+import { LanguageSelector } from '../../../../editor/common/languageSelector.js';
+import { LanguageFeatureRegistry } from '../../../../editor/common/languageFeatureRegistry.js';
+import {
+	CompletionContext,
+	CompletionItem,
+	CompletionItemProvider,
+	CompletionList,
+	Definition,
+	DefinitionProvider,
+	Hover,
+	HoverProvider,
+	Location,
+	LocationLink,
+	SignatureHelpContext,
+	SignatureHelpProvider,
+	SignatureHelpResult,
+} from '../../../../editor/common/languages.js';
+import { ILanguageFeaturesService } from '../../../../editor/common/services/languageFeatures.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IWorkbenchContribution } from '../../../common/contributions.js';
+import {
+	QUARTO_LANGUAGE_IDS,
+	QUARTO_NATIVE_LANGUAGE_FEATURES_KEY,
+	usingNativeEmbeddedFeatures,
+} from '../common/positronQuartoConfig.js';
+import { cellRangeToSource, ICellLineSpan, sourcePositionToCell } from '../common/quartoCellPositionMapping.js';
+import { IQuartoVirtualCell, IQuartoVirtualNotebookService } from './quartoVirtualNotebookService.js';
+
+/**
+ * Documents that can hold embedded code cells. Taken from the shared list so
+ * this cannot drift from what the rest of the contribution treats as Quarto.
+ */
+const QUARTO_SELECTOR: LanguageSelector = QUARTO_LANGUAGE_IDS.map(language => ({ language }));
+
+/** A provider that declares the characters it wants to be woken for. */
+interface ITriggerCharacterProvider {
+	readonly triggerCharacters?: readonly string[];
+}
+
+/** A position in a Quarto document, resolved to the cell that holds it. */
+interface IResolvedCell {
+	readonly cell: IQuartoVirtualCell;
+	readonly position: Position;
+}
+
+/**
+ * Remap a completion item's range, which is either a plain range or an
+ * insert/replace pair, from cell coordinates back to source coordinates.
+ */
+function mapCompletionItemRange(cell: ICellLineSpan, range: CompletionItem['range']): CompletionItem['range'] {
+	const pair = range as { insert?: IRange; replace?: IRange };
+	if (pair.insert && pair.replace) {
+		return {
+			insert: cellRangeToSource(cell, pair.insert),
+			replace: cellRangeToSource(cell, pair.replace),
+		};
+	}
+	return cellRangeToSource(cell, range as IRange);
+}
+
+/**
+ * Remap one definition result. Only entries that point into the cell itself are
+ * rewritten, onto the source document; a definition in another file is already
+ * in the coordinates its own document uses.
+ *
+ * `originSelectionRange` is always rewritten. It describes where the request
+ * came from, which we translated into the cell before forwarding.
+ */
+function mapDefinitionEntry(
+	cell: IQuartoVirtualCell,
+	sourceUri: URI,
+	entry: Location | LocationLink
+): Location | LocationLink {
+	const link = entry as LocationLink;
+	const mapped: LocationLink = { ...link };
+
+	if (link.originSelectionRange) {
+		mapped.originSelectionRange = cellRangeToSource(cell, link.originSelectionRange);
+	}
+	if (entry.uri.toString() === cell.cellUri.toString()) {
+		mapped.uri = sourceUri;
+		mapped.range = cellRangeToSource(cell, entry.range);
+		if (link.targetSelectionRange) {
+			mapped.targetSelectionRange = cellRangeToSource(cell, link.targetSelectionRange);
+		}
+	}
+	return mapped;
+}
+
+/**
+ * Shared behaviour for the providers that serve a Quarto document by asking the
+ * providers registered on its hidden notebook cells.
+ */
+abstract class QuartoEmbeddedProvider {
+	constructor(
+		protected readonly _virtualNotebooks: IQuartoVirtualNotebookService,
+		protected readonly _languageFeatures: ILanguageFeaturesService,
+	) { }
+
+	/**
+	 * Find the cell holding a position in a Quarto document, with the position
+	 * translated into that cell's coordinates.
+	 *
+	 * Returns `undefined` for prose, frontmatter, and the fence lines, which the
+	 * Quarto extension's own language server answers.
+	 */
+	protected _resolve(model: ITextModel, position: Position): IResolvedCell | undefined {
+		// Synchronize first. A pending sync can rebuild the cells and dispose the
+		// models they hold, so a cell read beforehand may already be stale.
+		this._virtualNotebooks.ensureSynchronized(model.uri);
+
+		const cell = this._virtualNotebooks.getCellAtLine(model.uri, position.lineNumber);
+		if (!cell) {
+			return undefined;
+		}
+		// Unreachable while the service is consistent, since `getCellAtLine` uses
+		// the same bounds this does. Handled because the return type says it can
+		// be undefined, not as a guard against anything we can produce.
+		const cellPosition = sourcePositionToCell(cell, position);
+		if (!cellPosition) {
+			return undefined;
+		}
+		return { cell, position: Position.lift(cellPosition) };
+	}
+
+	/**
+	 * The providers to ask about a cell, in order.
+	 *
+	 * Callers take the first usable answer rather than merging every provider's,
+	 * because Positron runs more than one language server per language. Pyrefly
+	 * registers alongside the Python server, for instance, so merging produces
+	 * two of everything. That is what posit-dev/positron#13907 looks like in the
+	 * Outline, and asking every server also doubles the work per request, which
+	 * runs against the slowness this routing exists to fix.
+	 */
+	protected _downstream<T>(registry: LanguageFeatureRegistry<T>, cell: IQuartoVirtualCell): T[] {
+		return registry.ordered(cell.textModel)
+			.filter(provider => !(provider instanceof QuartoEmbeddedProvider));
+	}
+
+	/**
+	 * The characters the servers behind the open cells want to be woken for.
+	 *
+	 * The suggest widget reads trigger characters from the providers registered
+	 * on the document being edited, which for a Quarto document is this provider
+	 * alone. The servers that answer are registered on the cells, which no editor
+	 * shows, so their own characters never reach the widget on their own.
+	 *
+	 * Collecting them here rather than listing them by hand means a language we
+	 * have never heard of works as soon as its extension registers a provider,
+	 * and that a server changing its mind needs no change from us. Extensions
+	 * already hand these to Positron: `$registerCompletionsProvider` puts them
+	 * straight onto the provider (`mainThreadLanguageFeatures.ts`).
+	 *
+	 * This is read when the suggest widget rebuilds its map, on editor, language,
+	 * configuration, and provider registry changes, rather than per keystroke.
+	 */
+	protected _collectTriggerCharacters<T extends ITriggerCharacterProvider>(
+		registry: LanguageFeatureRegistry<T>
+	): string[] {
+		const characters = new Set<string>();
+		for (const cell of this._virtualNotebooks.getAllCells()) {
+			for (const provider of this._downstream(registry, cell)) {
+				for (const character of provider.triggerCharacters ?? []) {
+					characters.add(character);
+				}
+			}
+		}
+		return Array.from(characters);
+	}
+}
+
+/**
+ * Serves completions inside Quarto code cells.
+ */
+class QuartoEmbeddedCompletionProvider extends QuartoEmbeddedProvider implements CompletionItemProvider {
+	readonly _debugDisplayName = 'quartoEmbeddedCompletions';
+
+	get triggerCharacters(): string[] {
+		return this._collectTriggerCharacters(this._languageFeatures.completionProvider);
+	}
+
+	async provideCompletionItems(
+		model: ITextModel,
+		position: Position,
+		context: CompletionContext,
+		token: CancellationToken
+	): Promise<CompletionList | undefined> {
+		const resolved = this._resolve(model, position);
+		if (!resolved) {
+			return undefined;
+		}
+		const { cell, position: cellPosition } = resolved;
+
+		for (const provider of this._downstream(this._languageFeatures.completionProvider, cell)) {
+			const result = await provider.provideCompletionItems(cell.textModel, cellPosition, context, token);
+			if (!result) {
+				continue;
+			}
+			if (result.suggestions.length === 0) {
+				result.dispose?.();
+				continue;
+			}
+			return {
+				suggestions: result.suggestions.map(item => ({
+					...item,
+					range: mapCompletionItemRange(cell, item.range),
+				})),
+				incomplete: result.incomplete,
+				dispose: () => result.dispose?.(),
+			};
+		}
+		return undefined;
+	}
+}
+
+/**
+ * Serves hovers inside Quarto code cells.
+ */
+class QuartoEmbeddedHoverProvider extends QuartoEmbeddedProvider implements HoverProvider {
+	async provideHover(
+		model: ITextModel,
+		position: Position,
+		token: CancellationToken
+	): Promise<Hover | undefined> {
+		const resolved = this._resolve(model, position);
+		if (!resolved) {
+			return undefined;
+		}
+		const { cell, position: cellPosition } = resolved;
+
+		for (const provider of this._downstream(this._languageFeatures.hoverProvider, cell)) {
+			const result = await provider.provideHover(cell.textModel, cellPosition, token);
+			if (result) {
+				return result.range ? { ...result, range: cellRangeToSource(cell, result.range) } : result;
+			}
+		}
+		return undefined;
+	}
+}
+
+/**
+ * Serves signature help inside Quarto code cells. Results carry no ranges, so
+ * they pass through untouched.
+ */
+class QuartoEmbeddedSignatureHelpProvider extends QuartoEmbeddedProvider implements SignatureHelpProvider {
+	get signatureHelpTriggerCharacters(): string[] {
+		// The registry stores these as `signatureHelpTriggerCharacters`, so they
+		// need reading under that name rather than the completion one.
+		const characters = new Set<string>();
+		for (const cell of this._virtualNotebooks.getAllCells()) {
+			for (const provider of this._downstream(this._languageFeatures.signatureHelpProvider, cell)) {
+				for (const character of provider.signatureHelpTriggerCharacters ?? []) {
+					characters.add(character);
+				}
+			}
+		}
+		return Array.from(characters);
+	}
+
+	async provideSignatureHelp(
+		model: ITextModel,
+		position: Position,
+		token: CancellationToken,
+		context: SignatureHelpContext
+	): Promise<SignatureHelpResult | undefined> {
+		const resolved = this._resolve(model, position);
+		if (!resolved) {
+			return undefined;
+		}
+		const { cell, position: cellPosition } = resolved;
+
+		for (const provider of this._downstream(this._languageFeatures.signatureHelpProvider, cell)) {
+			const result = await provider.provideSignatureHelp(cell.textModel, cellPosition, token, context);
+			if (result) {
+				return result;
+			}
+		}
+		return undefined;
+	}
+}
+
+/**
+ * Serves go to definition inside Quarto code cells.
+ */
+class QuartoEmbeddedDefinitionProvider extends QuartoEmbeddedProvider implements DefinitionProvider {
+	async provideDefinition(
+		model: ITextModel,
+		position: Position,
+		token: CancellationToken
+	): Promise<Definition | LocationLink[] | undefined> {
+		const resolved = this._resolve(model, position);
+		if (!resolved) {
+			return undefined;
+		}
+		const { cell, position: cellPosition } = resolved;
+
+		for (const provider of this._downstream(this._languageFeatures.definitionProvider, cell)) {
+			const result = await provider.provideDefinition(cell.textModel, cellPosition, token);
+			if (!result) {
+				continue;
+			}
+			const entries = Array.isArray(result) ? result : [result];
+			if (entries.length === 0) {
+				continue;
+			}
+			return entries.map(entry => mapDefinitionEntry(cell, model.uri, entry)) as LocationLink[];
+		}
+		return undefined;
+	}
+}
+
+/**
+ * Registers the providers that serve language features for code cells embedded
+ * in Quarto documents, so that requests are answered in process instead of
+ * through the Quarto extension's temporary virtual documents.
+ */
+export class QuartoEmbeddedLanguageFeatures extends Disposable implements IWorkbenchContribution {
+	static readonly ID = 'workbench.contrib.positronQuartoEmbeddedLanguageFeatures';
+
+	private readonly _registrations = this._register(new DisposableStore());
+
+	constructor(
+		@IQuartoVirtualNotebookService private readonly _virtualNotebooks: IQuartoVirtualNotebookService,
+		@ILanguageFeaturesService private readonly _languageFeatures: ILanguageFeaturesService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+	) {
+		super();
+
+		this._updateRegistrations();
+		this._register(this._configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(QUARTO_NATIVE_LANGUAGE_FEATURES_KEY)) {
+				this._updateRegistrations();
+			}
+		}));
+	}
+
+	private _updateRegistrations(): void {
+		this._registrations.clear();
+		if (!usingNativeEmbeddedFeatures(this._configurationService)) {
+			return;
+		}
+
+		const args = [this._virtualNotebooks, this._languageFeatures] as const;
+		this._registrations.add(this._languageFeatures.completionProvider.register(
+			QUARTO_SELECTOR, new QuartoEmbeddedCompletionProvider(...args)));
+		this._registrations.add(this._languageFeatures.hoverProvider.register(
+			QUARTO_SELECTOR, new QuartoEmbeddedHoverProvider(...args)));
+		this._registrations.add(this._languageFeatures.signatureHelpProvider.register(
+			QUARTO_SELECTOR, new QuartoEmbeddedSignatureHelpProvider(...args)));
+		this._registrations.add(this._languageFeatures.definitionProvider.register(
+			QUARTO_SELECTOR, new QuartoEmbeddedDefinitionProvider(...args)));
+	}
+}

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoVirtualNotebookService.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoVirtualNotebookService.ts
@@ -1,0 +1,476 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../../nls.js';
+import { URI } from '../../../../base/common/uri.js';
+import { VSBuffer } from '../../../../base/common/buffer.js';
+import { Schemas } from '../../../../base/common/network.js';
+import { Disposable, DisposableMap } from '../../../../base/common/lifecycle.js';
+import { ITextModel } from '../../../../editor/common/model.js';
+import { IModelService } from '../../../../editor/common/services/model.js';
+import { ILanguageService } from '../../../../editor/common/languages/language.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { ExtensionIdentifier } from '../../../../platform/extensions/common/extensions.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { IWorkbenchContribution } from '../../../common/contributions.js';
+import { NotebookTextModel } from '../../notebook/common/model/notebookTextModel.js';
+import { CellEditType, CellKind, ICellDto2, NotebookData } from '../../notebook/common/notebookCommon.js';
+import { INotebookSerializer, INotebookService } from '../../notebook/common/notebookService.js';
+import {
+	QUARTO_NATIVE_LANGUAGE_FEATURES_KEY,
+	isQuartoDocument,
+	usingNativeEmbeddedFeatures,
+} from '../common/positronQuartoConfig.js';
+import { IQuartoDocumentModel } from '../common/quartoTypes.js';
+import { QUARTO_CELLS_SCHEME, QUARTO_CELLS_VIEW_TYPE } from '../common/quartoVirtualNotebookTypes.js';
+import { IQuartoDocumentModelService } from './quartoDocumentModelService.js';
+
+/**
+ * A single code cell of a Quarto virtual notebook.
+ */
+export interface IQuartoVirtualCell {
+	/** The `vscode-notebook-cell` URI of this cell. */
+	readonly cellUri: URI;
+	/** Handle of the notebook cell this maps to. */
+	readonly handle: number;
+	/** Language of the cell, for example `r` or `python`. */
+	readonly language: string;
+	/** 1-based line in the source document of the first line of code. */
+	readonly codeStartLine: number;
+	/** 1-based line in the source document of the last line of code. */
+	readonly codeEndLine: number;
+	/** The text model bound to this notebook cell. */
+	readonly textModel: ITextModel;
+}
+
+export interface IQuartoVirtualNotebookService {
+	readonly _serviceBrand: undefined;
+
+	/** Notebook URI for an open Quarto document, if a virtual notebook exists. */
+	getNotebookUri(sourceUri: URI): URI | undefined;
+
+	/** Cells of the virtual notebook for a source document, in document order. */
+	getCells(sourceUri: URI): readonly IQuartoVirtualCell[];
+
+	/** The cell whose code contains the given 1-based source line, if any. */
+	getCellAtLine(sourceUri: URI, lineNumber: number): IQuartoVirtualCell | undefined;
+
+	/** Reverse lookup: the source document owning a cell URI, if it is ours. */
+	getSourceUriForCell(cellUri: URI): URI | undefined;
+
+	/**
+	 * Re-parse and re-sync right now if either is pending, so that the cells of
+	 * a source document match its current content on return.
+	 */
+	ensureSynchronized(sourceUri: URI): void;
+
+	/**
+	 * Resolves once any in-flight notebook creation for a source document has
+	 * settled. Creation is asynchronous, so callers that need to observe the
+	 * result of opening a document have to wait for it.
+	 */
+	whenReady(sourceUri: URI): Promise<void>;
+}
+
+export const IQuartoVirtualNotebookService =
+	createDecorator<IQuartoVirtualNotebookService>('quartoVirtualNotebookService');
+
+/**
+ * Serializer for the hidden notebooks. `INotebookService.createNotebookTextModel`
+ * requires one, but these notebooks are never read from or written to disk, so
+ * the data paths are inert and the persistence paths throw.
+ */
+class QuartoCellsSerializer implements INotebookSerializer {
+	readonly options = {
+		transientOutputs: true,
+		transientCellMetadata: {},
+		transientDocumentMetadata: {},
+		cellContentMetadata: {},
+	};
+
+	async dataToNotebook(): Promise<NotebookData> {
+		return { cells: [], metadata: {} };
+	}
+
+	async notebookToData(): Promise<VSBuffer> {
+		return VSBuffer.fromString('');
+	}
+
+	async save(): Promise<never> {
+		throw new Error('Quarto virtual notebooks are never saved');
+	}
+
+	async searchInNotebooks(): Promise<{ results: never[]; limitHit: boolean }> {
+		return { results: [], limitHit: false };
+	}
+}
+
+/**
+ * The hidden notebook backing a single Quarto document, and the machinery that
+ * keeps it in sync with the source text model.
+ */
+class QuartoVirtualNotebook extends Disposable {
+	private _cells: IQuartoVirtualCell[] = [];
+	private _notebook: NotebookTextModel | undefined;
+
+	readonly notebookUri: URI;
+
+	constructor(
+		readonly sourceUri: URI,
+		private readonly _documentModel: IQuartoDocumentModel,
+		private readonly _modelService: IModelService,
+		private readonly _notebookService: INotebookService,
+		private readonly _languageService: ILanguageService,
+		private readonly _logService: ILogService,
+	) {
+		super();
+		this.notebookUri = sourceUri.with({ scheme: QUARTO_CELLS_SCHEME });
+
+		// onDidParse rather than onDidChangeCells: cells also need re-syncing when
+		// they merely move, which happens whenever prose above a chunk grows or
+		// shrinks. onDidChangeCells stays quiet for that, and stale line spans
+		// would silently misplace every mapped position.
+		this._register(this._documentModel.onDidParse(() => this._sync()));
+	}
+
+	get cells(): readonly IQuartoVirtualCell[] {
+		return this._cells;
+	}
+
+	async initialize(): Promise<void> {
+		if (this._notebookService.getNotebookTextModel(this.notebookUri)) {
+			this._logService.warn(
+				`[QuartoVirtualNotebook] A notebook already exists for ${this.notebookUri.toString()}`);
+			return;
+		}
+
+		const notebook = await this._notebookService.createNotebookTextModel(
+			QUARTO_CELLS_VIEW_TYPE, this.notebookUri);
+		if (this._store.isDisposed) {
+			// The source document closed while creation was in flight.
+			notebook.dispose();
+			return;
+		}
+
+		this._notebook = notebook;
+		this._rebuildCells();
+		this._logService.debug(
+			`[QuartoVirtualNotebook] Created ${this.notebookUri.toString()} with ${this._cells.length} cells`);
+	}
+
+	/** Bring the cells in line with the source document. */
+	synchronize(): void {
+		// A pending re-parse fires onDidParse, which syncs. Sync again anyway:
+		// it is cheap, idempotent, and covers the case where nothing was pending.
+		this._documentModel.synchronize();
+		this._sync();
+	}
+
+	/**
+	 * Reconcile the cells with the source document. Cells are matched by
+	 * position, so a document whose chunks kept their shape gets its cell text
+	 * edited in place and LSP clients see a cheap didChange rather than
+	 * close/open churn. Anything else rebuilds: matching cells across a
+	 * structural change is ambiguous, and a wrong guess silently misplaces every
+	 * position mapped through the cell.
+	 */
+	private _sync(): void {
+		if (!this._notebook || this._store.isDisposed) {
+			return;
+		}
+
+		const sourceCells = this._documentModel.cells;
+		const structureChanged =
+			sourceCells.length !== this._cells.length ||
+			sourceCells.some((sourceCell, index) => sourceCell.language !== this._cells[index].language) ||
+			this._cells.some(cell => cell.textModel.isDisposed());
+
+		if (structureChanged) {
+			this._rebuildCells();
+			return;
+		}
+
+		this._cells = this._cells.map((cell, index) => {
+			const sourceCell = sourceCells[index];
+			const code = this._documentModel.getCellCode(sourceCell);
+			if (cell.textModel.getValue() !== code) {
+				cell.textModel.applyEdits([{ range: cell.textModel.getFullModelRange(), text: code }]);
+			}
+			return {
+				...cell,
+				codeStartLine: sourceCell.codeStartLine,
+				codeEndLine: sourceCell.codeEndLine,
+			};
+		});
+	}
+
+	/**
+	 * Replace every cell. Used to populate the notebook and whenever cells are
+	 * added or removed, where matching old cells to new ones is ambiguous.
+	 */
+	private _rebuildCells(): void {
+		const notebook = this._notebook;
+		if (!notebook || this._store.isDisposed) {
+			return;
+		}
+
+		const sourceCells = this._documentModel.cells;
+		const dtos: ICellDto2[] = sourceCells.map(cell => ({
+			source: this._documentModel.getCellCode(cell),
+			language: cell.language,
+			mime: undefined,
+			cellKind: CellKind.Code,
+			outputs: [],
+		}));
+
+		// Drop the old cells before the edit, not after. A notebook edit fires
+		// its change events synchronously, so any window where `_cells` still
+		// points at models belonging to removed cells is a window in which a
+		// listener can read a model we are about to dispose.
+		this._disposeCells();
+
+		notebook.applyEdits(
+			[{ editType: CellEditType.Replace, index: 0, count: notebook.cells.length, cells: dtos }],
+			true, undefined, () => undefined, undefined, false
+		);
+
+		// Creating a text model at the cell URI is what binds it to the notebook
+		// cell: NotebookTextModel watches IModelService.onModelAdded and adopts
+		// any model whose URI parses as one of its cells. That binding is what
+		// makes the extension host see a real cell TextDocument.
+		this._cells = notebook.cells.map((notebookCell, index) => {
+			const sourceCell = sourceCells[index];
+			const textModel = this._modelService.createModel(
+				notebookCell.getValue(),
+				this._languageService.createById(sourceCell.language),
+				notebookCell.uri
+			);
+			return {
+				cellUri: notebookCell.uri,
+				handle: notebookCell.handle,
+				language: sourceCell.language,
+				codeStartLine: sourceCell.codeStartLine,
+				codeEndLine: sourceCell.codeEndLine,
+				textModel,
+			};
+		});
+	}
+
+	/**
+	 * Dispose the cell text models. We own them: a notebook cell holds only a
+	 * weak reference to its text model and drops it on disposal rather than
+	 * disposing it.
+	 */
+	private _disposeCells(): void {
+		for (const cell of this._cells) {
+			if (!cell.textModel.isDisposed()) {
+				cell.textModel.dispose();
+			}
+		}
+		this._cells = [];
+	}
+
+	override dispose(): void {
+		super.dispose();
+		this._disposeCells();
+		this._notebook?.dispose();
+		this._notebook = undefined;
+		this._logService.debug(
+			`[QuartoVirtualNotebook] Disposed the notebook for ${this.sourceUri.toString()}`);
+	}
+}
+
+/**
+ * Maintains a hidden in-memory notebook for every open Quarto document, so that
+ * embedded code cells are visible to language servers as ordinary notebook
+ * cells. No editor is ever opened for these notebooks, which is what keeps them
+ * invisible to the user while the extension host still sees them.
+ */
+export class QuartoVirtualNotebookService extends Disposable implements IQuartoVirtualNotebookService {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _notebooks = this._register(new DisposableMap<string, QuartoVirtualNotebook>());
+	private readonly _pending = new Map<string, Promise<void>>();
+	private _notebookTypeRegistered = false;
+
+	constructor(
+		@IModelService private readonly _modelService: IModelService,
+		@INotebookService private readonly _notebookService: INotebookService,
+		@IQuartoDocumentModelService private readonly _documentModelService: IQuartoDocumentModelService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@ILanguageService private readonly _languageService: ILanguageService,
+		@ILogService private readonly _logService: ILogService,
+	) {
+		super();
+
+		this._register(this._modelService.onModelAdded(model => this._onModelAdded(model)));
+		this._register(this._modelService.onModelLanguageChanged(e => this._onModelAdded(e.model)));
+		this._register(this._modelService.onModelRemoved(model => this._onModelRemoved(model)));
+		this._register(this._configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(QUARTO_NATIVE_LANGUAGE_FEATURES_KEY)) {
+				this._reconcileAll();
+			}
+		}));
+
+		for (const model of this._modelService.getModels()) {
+			this._onModelAdded(model);
+		}
+	}
+
+	/**
+	 * Register the notebook type and serializer, once, the first time a notebook
+	 * is actually wanted. This is deliberately not constructor work: registering
+	 * the type writes to profile storage, and a user who never turns the setting
+	 * on should not accumulate state for a feature they do not use.
+	 */
+	private _ensureNotebookTypeRegistered(): void {
+		if (this._notebookTypeRegistered) {
+			return;
+		}
+		this._notebookTypeRegistered = true;
+
+		// registerContributedNotebookType writes the type into profile-scoped
+		// storage, which is rehydrated on the next window, so registering
+		// unconditionally throws "ALREADY EXISTS" on every window after the
+		// first. The rehydrated entry is inert (no editor contribution point is
+		// created without an extension, and the filename pattern matches no real
+		// file), so recognizing it and moving on is enough.
+		if (!this._notebookService.getContributedNotebookType(QUARTO_CELLS_VIEW_TYPE)) {
+			this._register(this._notebookService.registerContributedNotebookType(QUARTO_CELLS_VIEW_TYPE, {
+				providerDisplayName: 'Positron',
+				displayName: localize('positron.quartoCells', "Quarto Cells (Internal)"),
+				// Matches no real file, so this type never appears in Open With.
+				filenamePattern: ['*.quarto-cells-internal'],
+			}));
+		}
+
+		// The serializer is not persisted, so it is registered every window.
+		this._register(this._notebookService.registerNotebookSerializer(
+			QUARTO_CELLS_VIEW_TYPE,
+			{ id: new ExtensionIdentifier('positron.quarto-cells'), location: undefined },
+			new QuartoCellsSerializer()
+		));
+	}
+
+	private _onModelAdded(model: ITextModel): void {
+		// Skip the models we create ourselves. Cell URIs carry the source
+		// document's path, so a path-based Quarto check matches them too.
+		if (model.uri.scheme === QUARTO_CELLS_SCHEME || model.uri.scheme === Schemas.vscodeNotebookCell) {
+			return;
+		}
+		if (!usingNativeEmbeddedFeatures(this._configurationService)) {
+			return;
+		}
+		if (!isQuartoDocument(model.uri.path, model.getLanguageId())) {
+			return;
+		}
+
+		const key = model.uri.toString();
+		if (this._notebooks.has(key)) {
+			return;
+		}
+
+		this._ensureNotebookTypeRegistered();
+
+		const notebook = new QuartoVirtualNotebook(
+			model.uri,
+			this._documentModelService.getModel(model),
+			this._modelService,
+			this._notebookService,
+			this._languageService,
+			this._logService,
+		);
+		this._notebooks.set(key, notebook);
+
+		const pending = notebook.initialize()
+			.catch(err => {
+				this._logService.error(
+					`[QuartoVirtualNotebookService] Failed to create a notebook for ${key}`, err);
+				this._notebooks.deleteAndDispose(key);
+			})
+			.finally(() => {
+				if (this._pending.get(key) === pending) {
+					this._pending.delete(key);
+				}
+			});
+		this._pending.set(key, pending);
+	}
+
+	private _onModelRemoved(model: ITextModel): void {
+		if (model.uri.scheme === Schemas.vscodeNotebookCell) {
+			return;
+		}
+		this._notebooks.deleteAndDispose(model.uri.toString());
+	}
+
+	/** Create or drop notebooks to match the current setting value. */
+	private _reconcileAll(): void {
+		if (usingNativeEmbeddedFeatures(this._configurationService)) {
+			for (const model of this._modelService.getModels()) {
+				this._onModelAdded(model);
+			}
+			return;
+		}
+
+		for (const key of [...this._notebooks.keys()]) {
+			this._notebooks.deleteAndDispose(key);
+		}
+	}
+
+	getNotebookUri(sourceUri: URI): URI | undefined {
+		return this._notebooks.get(sourceUri.toString())?.notebookUri;
+	}
+
+	getCells(sourceUri: URI): readonly IQuartoVirtualCell[] {
+		return this._notebooks.get(sourceUri.toString())?.cells ?? [];
+	}
+
+	getCellAtLine(sourceUri: URI, lineNumber: number): IQuartoVirtualCell | undefined {
+		return this.getCells(sourceUri).find(
+			cell => lineNumber >= cell.codeStartLine && lineNumber <= cell.codeEndLine
+		);
+	}
+
+	getSourceUriForCell(cellUri: URI): URI | undefined {
+		const key = cellUri.toString();
+		for (const notebook of this._notebooks.values()) {
+			if (notebook.cells.some(cell => cell.cellUri.toString() === key)) {
+				return notebook.sourceUri;
+			}
+		}
+		return undefined;
+	}
+
+	ensureSynchronized(sourceUri: URI): void {
+		this._notebooks.get(sourceUri.toString())?.synchronize();
+	}
+
+	async whenReady(sourceUri: URI): Promise<void> {
+		await this._pending.get(sourceUri.toString());
+	}
+}
+
+/**
+ * Brings the virtual notebook service into existence.
+ *
+ * The service watches for open Quarto documents rather than answering requests,
+ * so nothing else ever asks for it, and a service nobody depends on is never
+ * constructed. Taking it as a constructor dependency here is what makes it run.
+ * Registering it `Eager` matters for the same reason: a delayed service hands
+ * out a proxy and defers the constructor until a property is read.
+ */
+export class QuartoVirtualNotebookContribution extends Disposable implements IWorkbenchContribution {
+	static readonly ID = 'workbench.contrib.positronQuartoVirtualNotebook';
+
+	constructor(
+		@IQuartoVirtualNotebookService private readonly _virtualNotebookService: IQuartoVirtualNotebookService,
+	) {
+		super();
+		// The service gates itself on the setting and reacts to changes, so
+		// there is nothing to do here beyond depending on it.
+		void this._virtualNotebookService;
+	}
+}

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoVirtualNotebookService.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoVirtualNotebookService.ts
@@ -29,6 +29,17 @@ import { QUARTO_CELLS_SCHEME, QUARTO_CELLS_VIEW_TYPE } from '../common/quartoVir
 import { IQuartoDocumentModelService } from './quartoDocumentModelService.js';
 
 /**
+ * Schemes whose documents are the ones a user edits, and so the only ones worth
+ * a virtual notebook. Everything else with a `.qmd` path (Git diffs, local
+ * history, other read-only providers) is a snapshot of some other revision.
+ */
+const EDITABLE_SCHEMES = new Set<string>([
+	Schemas.file,
+	Schemas.untitled,
+	Schemas.vscodeRemote,
+]);
+
+/**
  * A single code cell of a Quarto virtual notebook.
  */
 export interface IQuartoVirtualCell {
@@ -148,9 +159,11 @@ class QuartoVirtualNotebook extends Disposable {
 
 	async initialize(): Promise<void> {
 		if (this._notebookService.getNotebookTextModel(this.notebookUri)) {
-			this._logService.warn(
-				`[QuartoVirtualNotebook] A notebook already exists for ${this.notebookUri.toString()}`);
-			return;
+			// Throwing rather than returning: without a notebook this object can
+			// never produce a cell, and the caller's failure path removes it so a
+			// later edit can try again. Returning would leave it registered and
+			// permanently inert.
+			throw new Error(`A Quarto virtual notebook already exists for ${this.notebookUri.toString()}`);
 		}
 
 		const notebook = await this._notebookService.createNotebookTextModel(
@@ -336,7 +349,6 @@ export class QuartoVirtualNotebookService extends Disposable implements IQuartoV
 		if (this._notebookTypeRegistered) {
 			return;
 		}
-		this._notebookTypeRegistered = true;
 
 		// registerContributedNotebookType writes the type into profile-scoped
 		// storage, which is rehydrated on the next window, so registering
@@ -359,12 +371,19 @@ export class QuartoVirtualNotebookService extends Disposable implements IQuartoV
 			{ id: new ExtensionIdentifier('positron.quarto-cells'), location: undefined },
 			new QuartoCellsSerializer()
 		));
+
+		// Last, so that a failure part way through is retried rather than leaving
+		// the type half registered and every later notebook creation failing.
+		this._notebookTypeRegistered = true;
 	}
 
 	private _onModelAdded(model: ITextModel): void {
-		// Skip the models we create ourselves. Cell URIs carry the source
-		// document's path, so a path-based Quarto check matches them too.
-		if (model.uri.scheme === QUARTO_CELLS_SCHEME || model.uri.scheme === Schemas.vscodeNotebookCell) {
+		// Only documents the user is actually editing. A Quarto check on the path
+		// alone would also match the read-only models that back a Git diff or a
+		// local history entry, and each of those would get its own notebook whose
+		// cells hold some older revision of the file. Language servers would then
+		// be syncing several versions of the same document at once.
+		if (!EDITABLE_SCHEMES.has(model.uri.scheme)) {
 			return;
 		}
 		if (!usingNativeEmbeddedFeatures(this._configurationService)) {

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoVirtualNotebookService.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoVirtualNotebookService.ts
@@ -55,6 +55,12 @@ export interface IQuartoVirtualNotebookService {
 	/** Cells of the virtual notebook for a source document, in document order. */
 	getCells(sourceUri: URI): readonly IQuartoVirtualCell[];
 
+	/**
+	 * Cells of every virtual notebook. For callers that need to know what the
+	 * open Quarto documents contain overall rather than what one of them holds.
+	 */
+	getAllCells(): readonly IQuartoVirtualCell[];
+
 	/** The cell whose code contains the given 1-based source line, if any. */
 	getCellAtLine(sourceUri: URI, lineNumber: number): IQuartoVirtualCell | undefined;
 
@@ -426,6 +432,14 @@ export class QuartoVirtualNotebookService extends Disposable implements IQuartoV
 
 	getCells(sourceUri: URI): readonly IQuartoVirtualCell[] {
 		return this._notebooks.get(sourceUri.toString())?.cells ?? [];
+	}
+
+	getAllCells(): readonly IQuartoVirtualCell[] {
+		const cells: IQuartoVirtualCell[] = [];
+		for (const notebook of this._notebooks.values()) {
+			cells.push(...notebook.cells);
+		}
+		return cells;
 	}
 
 	getCellAtLine(sourceUri: URI, lineNumber: number): IQuartoVirtualCell | undefined {

--- a/src/vs/workbench/contrib/positronQuarto/common/positronQuartoConfig.ts
+++ b/src/vs/workbench/contrib/positronQuarto/common/positronQuartoConfig.ts
@@ -199,6 +199,7 @@ configurationRegistry.registerConfiguration({
 				'Serve language features for code cells in Quarto and R Markdown documents from Positron. When disabled, the Quarto extension serves them from temporary virtual documents.'
 			),
 			scope: ConfigurationScope.WINDOW,
+			tags: ['experimental'],
 		},
 	},
 });

--- a/src/vs/workbench/contrib/positronQuarto/common/positronQuartoConfig.ts
+++ b/src/vs/workbench/contrib/positronQuarto/common/positronQuartoConfig.ts
@@ -196,7 +196,7 @@ configurationRegistry.registerConfiguration({
 			default: false,
 			markdownDescription: localize(
 				'positron.quarto.embeddedLanguageFeatures.native',
-				'Serve language features for code cells in Quarto and R Markdown documents from Positron. When disabled, the Quarto extension serves them from temporary virtual documents.'
+				'Also serve language features for code cells in Quarto and R Markdown documents from Positron, instead of only from the Quarto extension. The Quarto extension continues to answer these requests from temporary virtual documents until a later release turns that off.'
 			),
 			scope: ConfigurationScope.WINDOW,
 			tags: ['experimental'],

--- a/src/vs/workbench/contrib/positronQuarto/common/positronQuartoConfig.ts
+++ b/src/vs/workbench/contrib/positronQuarto/common/positronQuartoConfig.ts
@@ -57,6 +57,12 @@ export const QUARTO_INLINE_OUTPUT_SPLIT_STATEMENTS_KEY = 'quarto.inlineOutput.sp
 export const QUARTO_INLINE_OUTPUT_AUTO_SCROLL_KEY = 'quarto.inlineOutput.autoScroll';
 
 /**
+ * Configuration key for serving language features in Quarto code cells from
+ * Positron rather than from the Quarto extension's virtual documents.
+ */
+export const QUARTO_NATIVE_LANGUAGE_FEATURES_KEY = 'quarto.embeddedLanguageFeatures.native';
+
+/**
  * @deprecated Use {@link QUARTO_INLINE_OUTPUT_ENABLED_KEY}. Kept as a working alias.
  */
 export const POSITRON_QUARTO_INLINE_OUTPUT_KEY = 'positron.quarto.inlineOutput.enabled';
@@ -182,6 +188,15 @@ configurationRegistry.registerConfiguration({
 			markdownDescription: localize(
 				'positron.quarto.inlineOutput.autoScroll',
 				'Automatically scroll the editor to reveal inline output as cells run, so newly produced output stays in view.'
+			),
+			scope: ConfigurationScope.WINDOW,
+		},
+		[QUARTO_NATIVE_LANGUAGE_FEATURES_KEY]: {
+			type: 'boolean',
+			default: false,
+			markdownDescription: localize(
+				'positron.quarto.embeddedLanguageFeatures.native',
+				'Serve language features for code cells in Quarto and R Markdown documents from Positron. When disabled, the Quarto extension serves them from temporary virtual documents.'
 			),
 			scope: ConfigurationScope.WINDOW,
 		},
@@ -338,6 +353,17 @@ export function usingQuartoInlineOutputStatementSplitting(configurationService: 
  */
 export function usingQuartoInlineOutputAutoScroll(configurationService: IConfigurationService): boolean {
 	return configurationService.getValue<boolean>(QUARTO_INLINE_OUTPUT_AUTO_SCROLL_KEY) !== false;
+}
+
+/**
+ * Helper function to check if Positron serves language features for Quarto code
+ * cells itself. Defaults to false when the setting is unset. There is no
+ * deprecated alias for this key, so it reads through plain `getValue`.
+ * @param configurationService The configuration service instance
+ * @returns true if native embedded language features are enabled
+ */
+export function usingNativeEmbeddedFeatures(configurationService: IConfigurationService): boolean {
+	return configurationService.getValue<boolean>(QUARTO_NATIVE_LANGUAGE_FEATURES_KEY) === true;
 }
 
 /**

--- a/src/vs/workbench/contrib/positronQuarto/common/quartoCellPositionMapping.ts
+++ b/src/vs/workbench/contrib/positronQuarto/common/quartoCellPositionMapping.ts
@@ -1,0 +1,85 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IPosition } from '../../../../editor/common/core/position.js';
+import { IRange } from '../../../../editor/common/core/range.js';
+
+/**
+ * The code of a cell within its source document, as 1-based inclusive line
+ * numbers. The fence lines are not part of the span.
+ *
+ * A chunk with no code puts its fences on consecutive lines, which gives a span
+ * whose end is before its start. Such a span contains no lines, which is what
+ * the functions here report.
+ */
+export interface ICellLineSpan {
+	readonly codeStartLine: number;
+	readonly codeEndLine: number;
+}
+
+/**
+ * How far the cell's code sits below the start of the source document.
+ *
+ * Only lines shift. Columns are the same in both coordinate spaces, because the
+ * Quarto parser recognizes a fence only when it starts at column 0, so cell code
+ * is never indented relative to its source.
+ */
+function lineDelta(cell: ICellLineSpan): number {
+	return cell.codeStartLine - 1;
+}
+
+function containsLine(cell: ICellLineSpan, lineNumber: number): boolean {
+	return lineNumber >= cell.codeStartLine && lineNumber <= cell.codeEndLine;
+}
+
+/**
+ * Map a position in the source document into the cell's coordinate space.
+ * Returns `undefined` when the position is outside the cell's code, including
+ * on either fence line.
+ */
+export function sourcePositionToCell(cell: ICellLineSpan, position: IPosition): IPosition | undefined {
+	if (!containsLine(cell, position.lineNumber)) {
+		return undefined;
+	}
+	return { lineNumber: position.lineNumber - lineDelta(cell), column: position.column };
+}
+
+/**
+ * Map a position in a cell back into source document coordinates.
+ */
+export function cellPositionToSource(cell: ICellLineSpan, position: IPosition): IPosition {
+	return { lineNumber: position.lineNumber + lineDelta(cell), column: position.column };
+}
+
+/**
+ * Map a range in the source document into the cell's coordinate space. Returns
+ * `undefined` unless the whole range is inside the cell's code, so a range that
+ * reaches a fence or the prose around it is rejected rather than clamped.
+ */
+export function sourceRangeToCell(cell: ICellLineSpan, range: IRange): IRange | undefined {
+	if (!containsLine(cell, range.startLineNumber) || !containsLine(cell, range.endLineNumber)) {
+		return undefined;
+	}
+	const delta = lineDelta(cell);
+	return {
+		startLineNumber: range.startLineNumber - delta,
+		startColumn: range.startColumn,
+		endLineNumber: range.endLineNumber - delta,
+		endColumn: range.endColumn,
+	};
+}
+
+/**
+ * Map a range in a cell back into source document coordinates.
+ */
+export function cellRangeToSource(cell: ICellLineSpan, range: IRange): IRange {
+	const delta = lineDelta(cell);
+	return {
+		startLineNumber: range.startLineNumber + delta,
+		startColumn: range.startColumn,
+		endLineNumber: range.endLineNumber + delta,
+		endColumn: range.endColumn,
+	};
+}

--- a/src/vs/workbench/contrib/positronQuarto/common/quartoTypes.ts
+++ b/src/vs/workbench/contrib/positronQuarto/common/quartoTypes.ts
@@ -221,6 +221,15 @@ export interface IQuartoDocumentModel extends IDisposable {
 	whenParsed(): Promise<void>;
 
 	/**
+	 * Re-parses right now if a debounced re-parse is pending, so that `cells`
+	 * reflects the document's current content on return. No-op otherwise.
+	 *
+	 * This is the synchronous counterpart to {@link whenParsed}, for callers on
+	 * a path that cannot await, such as a language feature provider.
+	 */
+	synchronize(): void;
+
+	/**
 	 * Fired when cells change (add/remove/modify).
 	 */
 	readonly onDidChangeCells: Event<QuartoCellChangeEvent>;

--- a/src/vs/workbench/contrib/positronQuarto/common/quartoVirtualNotebookTypes.ts
+++ b/src/vs/workbench/contrib/positronQuarto/common/quartoVirtualNotebookTypes.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Identifiers for the hidden notebooks that back Quarto documents.
+ *
+ * These live in their own dependency-free module because code outside this
+ * contribution has to recognize the hidden notebooks and skip them. Importing a
+ * leaf module keeps those call sites from pulling in the notebook service.
+ */
+
+/**
+ * View type of the hidden notebooks backing Quarto documents.
+ *
+ * Deliberately distinct from real notebook types. Notebook logic elsewhere in
+ * the workbench keys on the view type to decide whether a notebook is one it
+ * should act on, so a private type keeps these out of the way.
+ */
+export const QUARTO_CELLS_VIEW_TYPE = 'quarto-cells';
+
+/**
+ * URI scheme of the hidden notebooks.
+ *
+ * A notebook URI is its source document's URI with the scheme swapped, so the
+ * path is preserved and path-pattern LSP selectors still match. The source file
+ * URI cannot be reused as-is: the extension host cannot hold a text document
+ * and a notebook document at the same URI.
+ */
+export const QUARTO_CELLS_SCHEME = 'quarto-cells';

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoDocumentModel.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoDocumentModel.vitest.ts
@@ -667,4 +667,32 @@ x = 1
 		});
 	});
 
+	describe('synchronize', () => {
+		it('flushes a pending debounced re-parse without awaiting', () => {
+			const textModel = createTextModel('```{r}\nx <- 1\n```\n', null, undefined, URI.file('/test.qmd'));
+			ctx.disposables.add(textModel);
+			const model = new QuartoDocumentModel(textModel, logService);
+			ctx.disposables.add(model);
+
+			textModel.setValue('```{r}\nx <- 1\ny <- 2\n```\n');
+			expect(model.isParsed).toBe(false);
+
+			model.synchronize();
+
+			expect(model.isParsed).toBe(true);
+			expect(model.cells[0].codeEndLine).toBe(3);
+		});
+
+		it('is a no-op when no re-parse is pending', () => {
+			const model = createModel('```{r}\nx <- 1\n```\n');
+			const parses = vi.fn();
+			ctx.disposables.add(model.onDidParse(parses));
+
+			model.synchronize();
+
+			expect(parses).not.toHaveBeenCalled();
+			expect(model.isParsed).toBe(true);
+		});
+	});
+
 });

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoEmbeddedLanguageFeatures.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoEmbeddedLanguageFeatures.vitest.ts
@@ -84,7 +84,8 @@ describe('QuartoEmbeddedLanguageFeatures', () => {
 	 * cell's own. Nothing does that in production, which is why forwarding cannot
 	 * loop there, but it is what makes the recursion guard observable.
 	 */
-	function createFeatures(options: { alwaysFindCell?: IQuartoVirtualCell } = {}): void {
+	function createFeatures(options: { alwaysFindCell?: IQuartoVirtualCell; cells?: IQuartoVirtualCell[] } = {}): void {
+		const cells = options.cells ?? [cell];
 		const virtualNotebooks = stubInterface<IQuartoVirtualNotebookService>({
 			ensureSynchronized: () => { calls.push('ensureSynchronized'); },
 			getCellAtLine: (_uri, lineNumber) => {
@@ -94,7 +95,10 @@ describe('QuartoEmbeddedLanguageFeatures', () => {
 				}
 				return lineNumber >= cell.codeStartLine && lineNumber <= cell.codeEndLine ? cell : undefined;
 			},
-			getAllCells: () => [cell],
+			getAllCells: () => cells,
+			getCells: () => cells,
+			getSourceUriForCell: (uri) =>
+				cells.some(c => c.cellUri.toString() === uri.toString()) ? SOURCE_URI : undefined,
 		});
 		ctx.disposables.add(new QuartoEmbeddedLanguageFeatures(
 			virtualNotebooks, languageFeatures, configurationService));
@@ -257,6 +261,81 @@ describe('QuartoEmbeddedLanguageFeatures', () => {
 		}).toEqual({ labels: ['from-answers'], declinedFirst: true });
 	});
 
+	it('remaps the extra edits a completion carries, not only its own range', async () => {
+		// This is how a server adds an import when you accept a symbol. Left in cell
+		// coordinates it lands at the same line number of the Quarto document, which
+		// is usually the frontmatter.
+		registerCompletions('downstream', [{
+			label: 'array',
+			kind: CompletionItemKind.Variable,
+			insertText: 'array',
+			range: { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 3 },
+			additionalTextEdits: [{
+				range: { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 1 },
+				text: 'import numpy as np\n',
+			}],
+		}]);
+		createFeatures();
+
+		const result = await completionProvider().provideCompletionItems(
+			sourceModel, IN_CELL, { triggerKind: 0 }, CancellationToken.None);
+
+		expect(result?.suggestions[0].additionalTextEdits).toEqual([{
+			range: { startLineNumber: 4, startColumn: 1, endLineNumber: 4, endColumn: 1 },
+			text: 'import numpy as np\n',
+		}]);
+	});
+
+	it('resolves a completion through the provider that produced it', async () => {
+		// The suggest widget looks for resolveCompletionItem on the provider it
+		// called, which is ours, so without forwarding there is no documentation
+		// panel and no lazily computed edits.
+		ctx.disposables.add(languageFeatures.completionProvider.register({ language: 'r' }, {
+			_debugDisplayName: 'downstream',
+			provideCompletionItems: () => ({
+				suggestions: [suggestion('xylophone', 1)],
+			}),
+			resolveCompletionItem: (item) => ({
+				...item,
+				detail: 'resolved detail',
+				additionalTextEdits: [{
+					range: { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 1 },
+					text: 'library(dplyr)\n',
+				}],
+			}),
+		}));
+		createFeatures();
+
+		const provider = completionProvider();
+		const list = await provider.provideCompletionItems(
+			sourceModel, IN_CELL, { triggerKind: 0 }, CancellationToken.None);
+		const resolved = await provider.resolveCompletionItem!(list!.suggestions[0], CancellationToken.None);
+
+		expect({
+			detail: resolved?.detail,
+			// Edits from resolution need the same remapping as the first response.
+			edits: resolved?.additionalTextEdits,
+		}).toEqual({
+			detail: 'resolved detail',
+			edits: [{
+				range: { startLineNumber: 4, startColumn: 1, endLineNumber: 4, endColumn: 1 },
+				text: 'library(dplyr)\n',
+			}],
+		});
+	});
+
+	it('returns the item unchanged when the provider cannot resolve', async () => {
+		registerCompletions('downstream', [suggestion('xylophone', 1)]);
+		createFeatures();
+
+		const provider = completionProvider();
+		const list = await provider.provideCompletionItems(
+			sourceModel, IN_CELL, { triggerKind: 0 }, CancellationToken.None);
+		const item = list!.suggestions[0];
+
+		expect(await provider.resolveCompletionItem!(item, CancellationToken.None)).toBe(item);
+	});
+
 	it('returns nothing when the only provider has nothing to offer', async () => {
 		registerCompletions('empty', []);
 		createFeatures();
@@ -414,6 +493,52 @@ describe('QuartoEmbeddedLanguageFeatures', () => {
 			uri: SOURCE_URI,
 			range: { startLineNumber: 5, startColumn: 1, endLineNumber: 5, endColumn: 2 },
 		}]);
+	});
+
+	it('remaps a definition that lands in a different chunk', async () => {
+		// Servers index every open document, so a definition can sit in an earlier
+		// chunk. Returned as-is, the editor is handed a hidden cell URI it cannot
+		// open, which is what Go to Definition would try to do.
+		const otherCellUri = URI.parse('vscode-notebook-cell:/test/doc.qmd#ch1');
+		const otherCell: IQuartoVirtualCell = {
+			...cell, cellUri: otherCellUri, codeStartLine: 20, codeEndLine: 22,
+		};
+		ctx.disposables.add(languageFeatures.definitionProvider.register({ language: 'r' }, {
+			provideDefinition: (): LocationLink[] => [{
+				uri: otherCellUri,
+				range: { startLineNumber: 2, startColumn: 1, endLineNumber: 2, endColumn: 5 },
+			}],
+		} satisfies DefinitionProvider));
+		createFeatures({ cells: [cell, otherCell] });
+
+		const provider = languageFeatures.definitionProvider.ordered(sourceModel)[0];
+		const result = await provider.provideDefinition(sourceModel, IN_CELL, CancellationToken.None);
+
+		// Cell line 2 of a chunk starting at source line 20.
+		expect(result).toEqual([{
+			uri: SOURCE_URI,
+			range: { startLineNumber: 21, startColumn: 1, endLineNumber: 21, endColumn: 5 },
+		}]);
+	});
+
+	it('collects signature help retrigger characters as well as trigger characters', async () => {
+		// The hint widget reads the two sets separately. Without the retrigger set a
+		// hint never advances to the next parameter as you type past a comma.
+		ctx.disposables.add(languageFeatures.signatureHelpProvider.register({ language: 'r' }, {
+			signatureHelpTriggerCharacters: ['('],
+			signatureHelpRetriggerCharacters: [',', ')'],
+			provideSignatureHelp: () => undefined,
+		} satisfies SignatureHelpProvider));
+		createFeatures();
+
+		const provider = languageFeatures.signatureHelpProvider.ordered(sourceModel)[0];
+		expect({
+			trigger: provider.signatureHelpTriggerCharacters?.slice().sort(),
+			retrigger: provider.signatureHelpRetriggerCharacters?.slice().sort(),
+		}).toEqual({
+			trigger: ['('],
+			retrigger: [')', ','],
+		});
 	});
 
 	it('forwards signature help to the cell model and returns it unchanged', async () => {

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoEmbeddedLanguageFeatures.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoEmbeddedLanguageFeatures.vitest.ts
@@ -23,6 +23,7 @@ import {
 	SignatureHelpProvider,
 	SignatureHelpResult,
 } from '../../../../../editor/common/languages.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
@@ -101,7 +102,7 @@ describe('QuartoEmbeddedLanguageFeatures', () => {
 				cells.some(c => c.cellUri.toString() === uri.toString()) ? SOURCE_URI : undefined,
 		});
 		ctx.disposables.add(new QuartoEmbeddedLanguageFeatures(
-			virtualNotebooks, languageFeatures, configurationService));
+			virtualNotebooks, languageFeatures, configurationService, new NullLogService()));
 	}
 
 	function completionProvider(): CompletionItemProvider {

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoEmbeddedLanguageFeatures.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoEmbeddedLanguageFeatures.vitest.ts
@@ -1,0 +1,489 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { Position } from '../../../../../editor/common/core/position.js';
+import { ITextModel } from '../../../../../editor/common/model.js';
+import { createTextModel } from '../../../../../editor/test/common/testTextModel.js';
+import { LanguageFeaturesService } from '../../../../../editor/common/services/languageFeaturesService.js';
+import {
+	CompletionItemKind,
+	CompletionItemProvider,
+	CompletionList,
+	DefinitionProvider,
+	Hover,
+	HoverProvider,
+	Location,
+	LocationLink,
+	SignatureHelpProvider,
+	SignatureHelpResult,
+} from '../../../../../editor/common/languages.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { QUARTO_NATIVE_LANGUAGE_FEATURES_KEY } from '../../common/positronQuartoConfig.js';
+import { IQuartoVirtualCell, IQuartoVirtualNotebookService } from '../../browser/quartoVirtualNotebookService.js';
+import { QuartoEmbeddedLanguageFeatures } from '../../browser/quartoEmbeddedLanguageFeatures.js';
+
+// The source document, with the R chunk's code on lines 4 and 5:
+//
+//   1  # Intro
+//   2
+//   3  ```{r}
+//   4  x <- 1
+//   5  y <- 2
+//   6  ```
+const SOURCE = ['# Intro', '', '```{r}', 'x <- 1', 'y <- 2', '```', ''].join('\n');
+const SOURCE_URI = URI.file('/test/doc.qmd');
+const CELL_URI = URI.parse('vscode-notebook-cell:/test/doc.qmd#ch0');
+
+// Line 4 of the source is line 1 of the cell.
+const IN_CELL = new Position(4, 3);
+const IN_PROSE = new Position(1, 1);
+
+describe('QuartoEmbeddedLanguageFeatures', () => {
+	const ctx = createTestContainer().build();
+
+	let languageFeatures: LanguageFeaturesService;
+	let configurationService: TestConfigurationService;
+	let sourceModel: ITextModel;
+	let cellModel: ITextModel;
+	let cell: IQuartoVirtualCell;
+	let calls: string[];
+
+	beforeEach(async () => {
+		calls = [];
+		languageFeatures = new LanguageFeaturesService();
+		configurationService = new TestConfigurationService();
+		await configurationService.setUserConfiguration(QUARTO_NATIVE_LANGUAGE_FEATURES_KEY, true);
+
+		sourceModel = createTextModel(SOURCE, 'quarto', undefined, SOURCE_URI);
+		ctx.disposables.add(sourceModel);
+		cellModel = createTextModel('x <- 1\ny <- 2', 'r', undefined, CELL_URI);
+		ctx.disposables.add(cellModel);
+
+		cell = {
+			cellUri: CELL_URI,
+			handle: 0,
+			language: 'r',
+			codeStartLine: 4,
+			codeEndLine: 5,
+			textModel: cellModel,
+		};
+	});
+
+	/**
+	 * Builds the contribution, which is what registers the providers.
+	 *
+	 * `alwaysFindCell` makes the service claim a cell for every URI, including a
+	 * cell's own. Nothing does that in production, which is why forwarding cannot
+	 * loop there, but it is what makes the recursion guard observable.
+	 */
+	function createFeatures(options: { alwaysFindCell?: IQuartoVirtualCell } = {}): void {
+		const virtualNotebooks = stubInterface<IQuartoVirtualNotebookService>({
+			ensureSynchronized: () => { calls.push('ensureSynchronized'); },
+			getCellAtLine: (_uri, lineNumber) => {
+				calls.push(`getCellAtLine:${lineNumber}`);
+				if (options.alwaysFindCell) {
+					return options.alwaysFindCell;
+				}
+				return lineNumber >= cell.codeStartLine && lineNumber <= cell.codeEndLine ? cell : undefined;
+			},
+			getAllCells: () => [cell],
+		});
+		ctx.disposables.add(new QuartoEmbeddedLanguageFeatures(
+			virtualNotebooks, languageFeatures, configurationService));
+	}
+
+	function completionProvider(): CompletionItemProvider {
+		return languageFeatures.completionProvider.ordered(sourceModel)[0];
+	}
+
+	/** A downstream provider registered on the cell's language, as a real one would be. */
+	function registerCompletions(name: string, suggestions: CompletionList['suggestions']): void {
+		ctx.disposables.add(languageFeatures.completionProvider.register({ language: 'r' }, {
+			_debugDisplayName: name,
+			provideCompletionItems: (model, position) => {
+				calls.push(`${name}:${model.uri.toString()}@${position.lineNumber}:${position.column}`);
+				return { suggestions };
+			},
+		}));
+	}
+
+	function suggestion(label: string, line: number) {
+		return {
+			label,
+			kind: CompletionItemKind.Variable,
+			insertText: label,
+			range: { startLineNumber: line, startColumn: 1, endLineNumber: line, endColumn: 3 },
+		};
+	}
+
+	it('forwards a completion request to the cell model and remaps the result', async () => {
+		registerCompletions('downstream', [suggestion('xylophone', 1)]);
+		createFeatures();
+
+		const result = await completionProvider().provideCompletionItems(
+			sourceModel, IN_CELL, { triggerKind: 0 }, CancellationToken.None);
+
+		expect({
+			// Called against the cell, at the cell-relative position.
+			forwardedTo: calls.filter(c => c.startsWith('downstream:')),
+			// Ranges come back in source document coordinates.
+			range: result?.suggestions[0].range,
+		}).toEqual({
+			forwardedTo: [`downstream:${CELL_URI.toString()}@1:3`],
+			range: { startLineNumber: 4, startColumn: 1, endLineNumber: 4, endColumn: 3 },
+		});
+	});
+
+	it('synchronizes the cells before looking one up', async () => {
+		// A sync can rebuild the cells and dispose the old models, so reading a
+		// cell first would hand back a model that is about to be thrown away.
+		registerCompletions('downstream', [suggestion('xylophone', 1)]);
+		createFeatures();
+
+		await completionProvider().provideCompletionItems(
+			sourceModel, IN_CELL, { triggerKind: 0 }, CancellationToken.None);
+
+		expect(calls.slice(0, 2)).toEqual(['ensureSynchronized', 'getCellAtLine:4']);
+	});
+
+	it('declines positions outside a cell, leaving prose to the Quarto server', async () => {
+		registerCompletions('downstream', [suggestion('xylophone', 1)]);
+		createFeatures();
+
+		const result = await completionProvider().provideCompletionItems(
+			sourceModel, IN_PROSE, { triggerKind: 0 }, CancellationToken.None);
+
+		expect({
+			result,
+			forwarded: calls.some(c => c.startsWith('downstream:')),
+		}).toEqual({ result: undefined, forwarded: false });
+	});
+
+	it('takes the first provider that answers and does not consult the rest', async () => {
+		// Positron runs more than one language server per language. Merging their
+		// answers duplicates every item, which is posit-dev/positron#13907.
+		registerCompletions('alpha', [suggestion('from-alpha', 1)]);
+		registerCompletions('beta', [suggestion('from-beta', 1)]);
+		createFeatures();
+
+		const result = await completionProvider().provideCompletionItems(
+			sourceModel, IN_CELL, { triggerKind: 0 }, CancellationToken.None);
+
+		// Which provider `ordered()` puts first is not part of the contract, so
+		// the expectation is derived from whichever one was actually asked. What
+		// matters is that exactly one was asked, and that its answer is returned
+		// whole rather than merged with the other's.
+		const consulted = calls.filter(c => c.startsWith('alpha:') || c.startsWith('beta:'));
+		expect({
+			consulted: consulted.length,
+			labels: result?.suggestions.map(s => s.label),
+		}).toEqual({
+			consulted: 1,
+			labels: [consulted[0].startsWith('alpha:') ? 'from-alpha' : 'from-beta'],
+		});
+	});
+
+	it('moves past a provider with nothing to offer', async () => {
+		// The registry breaks score ties by registration time, latest first, so
+		// registering the empty one last is what puts it at the front.
+		registerCompletions('answers', [suggestion('from-answers', 1)]);
+		registerCompletions('empty', []);
+		createFeatures();
+
+		const result = await completionProvider().provideCompletionItems(
+			sourceModel, IN_CELL, { triggerKind: 0 }, CancellationToken.None);
+
+		expect({
+			labels: result?.suggestions.map(s => s.label),
+			consultedEmptyFirst: calls.filter(c => c.startsWith('empty:') || c.startsWith('answers:')),
+		}).toEqual({
+			labels: ['from-answers'],
+			consultedEmptyFirst: [
+				`empty:${CELL_URI.toString()}@1:3`,
+				`answers:${CELL_URI.toString()}@1:3`,
+			],
+		});
+	});
+
+	it('remaps a completion range given as an insert and replace pair', async () => {
+		// Servers commonly return this form instead of a single range, and both
+		// halves are in cell coordinates.
+		registerCompletions('downstream', [{
+			label: 'xylophone',
+			kind: CompletionItemKind.Variable,
+			insertText: 'xylophone',
+			range: {
+				insert: { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 2 },
+				replace: { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 4 },
+			},
+		}]);
+		createFeatures();
+
+		const result = await completionProvider().provideCompletionItems(
+			sourceModel, IN_CELL, { triggerKind: 0 }, CancellationToken.None);
+
+		expect(result?.suggestions[0].range).toEqual({
+			insert: { startLineNumber: 4, startColumn: 1, endLineNumber: 4, endColumn: 2 },
+			replace: { startLineNumber: 4, startColumn: 1, endLineNumber: 4, endColumn: 4 },
+		});
+	});
+
+	it('moves past a provider that returns nothing at all', async () => {
+		// Distinct from an empty list: a provider can decline outright.
+		registerCompletions('answers', [suggestion('from-answers', 1)]);
+		ctx.disposables.add(languageFeatures.completionProvider.register({ language: 'r' }, {
+			_debugDisplayName: 'declines',
+			provideCompletionItems: () => {
+				calls.push('declines:called');
+				return undefined;
+			},
+		}));
+		createFeatures();
+
+		const result = await completionProvider().provideCompletionItems(
+			sourceModel, IN_CELL, { triggerKind: 0 }, CancellationToken.None);
+
+		expect({
+			labels: result?.suggestions.map(s => s.label),
+			declinedFirst: calls.indexOf('declines:called') !== -1,
+		}).toEqual({ labels: ['from-answers'], declinedFirst: true });
+	});
+
+	it('returns nothing when the only provider has nothing to offer', async () => {
+		registerCompletions('empty', []);
+		createFeatures();
+
+		const result = await completionProvider().provideCompletionItems(
+			sourceModel, IN_CELL, { triggerKind: 0 }, CancellationToken.None);
+
+		// An empty list is not an answer. Returning it would stop the suggest
+		// widget from falling through to whatever else could contribute.
+		expect(result).toBeUndefined();
+	});
+
+	it('does not forward to itself', async () => {
+		// A cell whose code starts on line 1 maps every position to itself, and a
+		// service that claims a cell for any URI keeps that going. Neither happens
+		// in production, where a chunk always sits below its opening fence and a
+		// cell URI has no notebook of its own, so those two facts are what make
+		// forwarding terminate. This pins the guard that does not rely on either.
+		const degenerate: IQuartoVirtualCell = { ...cell, codeStartLine: 1, codeEndLine: 6 };
+		registerCompletions('downstream', [suggestion('xylophone', 1)]);
+		createFeatures({ alwaysFindCell: degenerate });
+		const provider = completionProvider();
+		// Registered last, so the registry consults it before the downstream one.
+		// Without the self-check this recurses until the stack gives out.
+		ctx.disposables.add(languageFeatures.completionProvider.register({ language: 'r' }, provider));
+
+		const result = await provider.provideCompletionItems(
+			sourceModel, IN_CELL, { triggerKind: 0 }, CancellationToken.None);
+
+		expect(result?.suggestions.map(s => s.label)).toEqual(['xylophone']);
+	});
+
+	it('forwards a hover to the cell model and remaps the range', async () => {
+		ctx.disposables.add(languageFeatures.hoverProvider.register({ language: 'r' }, {
+			provideHover: (model, position): Hover => {
+				calls.push(`hover:${model.uri.toString()}@${position.lineNumber}:${position.column}`);
+				return {
+					contents: [{ value: 'docs' }],
+					range: { startLineNumber: 2, startColumn: 1, endLineNumber: 2, endColumn: 2 },
+				};
+			},
+		} satisfies HoverProvider));
+		createFeatures();
+
+		const provider = languageFeatures.hoverProvider.ordered(sourceModel)[0];
+		// Source line 5 is the cell's line 2.
+		const result = await provider.provideHover(sourceModel, new Position(5, 4), CancellationToken.None);
+
+		expect({
+			forwardedTo: calls.filter(c => c.startsWith('hover:')),
+			range: (result as Hover).range,
+		}).toEqual({
+			forwardedTo: [`hover:${CELL_URI.toString()}@2:4`],
+			range: { startLineNumber: 5, startColumn: 1, endLineNumber: 5, endColumn: 2 },
+		});
+	});
+
+	it('leaves a hover that carries no range alone', async () => {
+		// Hovers often have no range, and the editor then uses the word at the
+		// position. Inventing one, or dropping the hover, would both be wrong.
+		ctx.disposables.add(languageFeatures.hoverProvider.register({ language: 'r' }, {
+			provideHover: (): Hover => ({ contents: [{ value: 'docs' }] }),
+		} satisfies HoverProvider));
+		createFeatures();
+
+		const provider = languageFeatures.hoverProvider.ordered(sourceModel)[0];
+		const result = await provider.provideHover(sourceModel, IN_CELL, CancellationToken.None);
+
+		expect(result).toEqual({ contents: [{ value: 'docs' }] });
+	});
+
+	it('remaps definitions inside the cell and passes other files through', async () => {
+		const otherFile = URI.file('/test/helpers.R');
+		ctx.disposables.add(languageFeatures.definitionProvider.register({ language: 'r' }, {
+			provideDefinition: (model, position): LocationLink[] => {
+				calls.push(`definition:${model.uri.toString()}@${position.lineNumber}:${position.column}`);
+				return [
+					{
+						uri: CELL_URI,
+						range: { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 2 },
+						targetSelectionRange: { startLineNumber: 1, startColumn: 3, endLineNumber: 1, endColumn: 4 },
+						originSelectionRange: { startLineNumber: 2, startColumn: 1, endLineNumber: 2, endColumn: 2 },
+					},
+					{
+						uri: otherFile,
+						range: { startLineNumber: 7, startColumn: 1, endLineNumber: 7, endColumn: 2 },
+					},
+				];
+			},
+		} satisfies DefinitionProvider));
+		createFeatures();
+
+		const provider = languageFeatures.definitionProvider.ordered(sourceModel)[0];
+		const result = await provider.provideDefinition(sourceModel, IN_CELL, CancellationToken.None);
+
+		expect({
+			forwardedTo: calls.filter(c => c.startsWith('definition:')),
+			result,
+		}).toEqual({
+			forwardedTo: [`definition:${CELL_URI.toString()}@1:3`],
+			result: [
+				{
+					// Points at the Quarto document, not the hidden cell.
+					uri: SOURCE_URI,
+					range: { startLineNumber: 4, startColumn: 1, endLineNumber: 4, endColumn: 2 },
+					targetSelectionRange: { startLineNumber: 4, startColumn: 3, endLineNumber: 4, endColumn: 4 },
+					originSelectionRange: { startLineNumber: 5, startColumn: 1, endLineNumber: 5, endColumn: 2 },
+				},
+				{
+					// A different file is already in its own coordinates.
+					uri: otherFile,
+					range: { startLineNumber: 7, startColumn: 1, endLineNumber: 7, endColumn: 2 },
+				},
+			],
+		});
+	});
+
+	it('moves past a definition provider that finds nothing', async () => {
+		// Same rule as completions: an empty result is not an answer, so the next
+		// provider gets a turn rather than the editor being told there is nothing.
+		ctx.disposables.add(languageFeatures.definitionProvider.register({ language: 'r' }, {
+			provideDefinition: (): LocationLink[] => [{
+				uri: CELL_URI,
+				range: { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 2 },
+			}],
+		} satisfies DefinitionProvider));
+		ctx.disposables.add(languageFeatures.definitionProvider.register({ language: 'r' }, {
+			provideDefinition: (): LocationLink[] => [],
+		} satisfies DefinitionProvider));
+		createFeatures();
+
+		const provider = languageFeatures.definitionProvider.ordered(sourceModel)[0];
+		const result = await provider.provideDefinition(sourceModel, IN_CELL, CancellationToken.None);
+
+		expect(result).toEqual([{
+			uri: SOURCE_URI,
+			range: { startLineNumber: 4, startColumn: 1, endLineNumber: 4, endColumn: 2 },
+		}]);
+	});
+
+	it('handles a definition returned as one location rather than a list', async () => {
+		// `Definition` is `Location | Location[]`, and servers use both forms.
+		ctx.disposables.add(languageFeatures.definitionProvider.register({ language: 'r' }, {
+			provideDefinition: (): Location => ({
+				uri: CELL_URI,
+				range: { startLineNumber: 2, startColumn: 1, endLineNumber: 2, endColumn: 2 },
+			}),
+		} satisfies DefinitionProvider));
+		createFeatures();
+
+		const provider = languageFeatures.definitionProvider.ordered(sourceModel)[0];
+		const result = await provider.provideDefinition(sourceModel, IN_CELL, CancellationToken.None);
+
+		expect(result).toEqual([{
+			uri: SOURCE_URI,
+			range: { startLineNumber: 5, startColumn: 1, endLineNumber: 5, endColumn: 2 },
+		}]);
+	});
+
+	it('forwards signature help to the cell model and returns it unchanged', async () => {
+		ctx.disposables.add(languageFeatures.signatureHelpProvider.register({ language: 'r' }, {
+			provideSignatureHelp: (model, position): SignatureHelpResult => {
+				calls.push(`signature:${model.uri.toString()}@${position.lineNumber}:${position.column}`);
+				return {
+					value: {
+						signatures: [{ label: 'mean(x)', parameters: [] }],
+						activeSignature: 0,
+						activeParameter: 0,
+					},
+					dispose: () => { },
+				};
+			},
+		} satisfies SignatureHelpProvider));
+		createFeatures();
+
+		const provider = languageFeatures.signatureHelpProvider.ordered(sourceModel)[0];
+		const result = await provider.provideSignatureHelp(
+			sourceModel, IN_CELL, CancellationToken.None,
+			{ triggerKind: 1, isRetrigger: false });
+
+		// Signature help has no ranges, so the only thing to get right is where
+		// the request goes.
+		expect({
+			forwardedTo: calls.filter(c => c.startsWith('signature:')),
+			label: result?.value.signatures[0].label,
+		}).toEqual({
+			forwardedTo: [`signature:${CELL_URI.toString()}@1:3`],
+			label: 'mean(x)',
+		});
+	});
+
+	it('takes its trigger characters from the servers behind the cells', async () => {
+		// The suggest widget reads these from the providers on the document being
+		// edited, so a character no cell provider asked for never fires, and one
+		// they did ask for that we fail to repeat is silently dead.
+		ctx.disposables.add(languageFeatures.completionProvider.register({ language: 'r' }, {
+			_debugDisplayName: 'serverA',
+			triggerCharacters: ['$', '@', ':'],
+			provideCompletionItems: () => ({ suggestions: [] }),
+		}));
+		ctx.disposables.add(languageFeatures.completionProvider.register({ language: 'r' }, {
+			_debugDisplayName: 'serverB',
+			triggerCharacters: ['.', '%'],
+			provideCompletionItems: () => ({ suggestions: [] }),
+		}));
+		createFeatures();
+
+		expect(completionProvider().triggerCharacters?.slice().sort())
+			.toEqual(['$', '%', '.', ':', '@']);
+	});
+
+	it('takes signature help trigger characters from the same place', async () => {
+		ctx.disposables.add(languageFeatures.signatureHelpProvider.register({ language: 'r' }, {
+			signatureHelpTriggerCharacters: ['(', ',', '='],
+			provideSignatureHelp: () => undefined,
+		} satisfies SignatureHelpProvider));
+		createFeatures();
+
+		const provider = languageFeatures.signatureHelpProvider.ordered(sourceModel)[0];
+		expect(provider.signatureHelpTriggerCharacters?.slice().sort()).toEqual(['(', ',', '=']);
+	});
+
+	it('registers nothing while the setting is off', async () => {
+		await configurationService.setUserConfiguration(QUARTO_NATIVE_LANGUAGE_FEATURES_KEY, false);
+		registerCompletions('downstream', [suggestion('xylophone', 1)]);
+		createFeatures();
+
+		expect(languageFeatures.completionProvider.ordered(sourceModel)).toEqual([]);
+	});
+});

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoVirtualNotebookService.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoVirtualNotebookService.vitest.ts
@@ -1,0 +1,531 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { URI } from '../../../../../base/common/uri.js';
+import { Schemas } from '../../../../../base/common/network.js';
+import { Disposable, IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { ResourceMap } from '../../../../../base/common/map.js';
+import { ITextModel } from '../../../../../editor/common/model.js';
+import { IModelService } from '../../../../../editor/common/services/model.js';
+import { ILanguageService } from '../../../../../editor/common/languages/language.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { INotebookService } from '../../../notebook/common/notebookService.js';
+import { NotebookTextModel } from '../../../notebook/common/model/notebookTextModel.js';
+import { NotebookProviderInfo } from '../../../notebook/common/notebookProvider.js';
+import { QUARTO_NATIVE_LANGUAGE_FEATURES_KEY } from '../../common/positronQuartoConfig.js';
+import { QUARTO_CELLS_SCHEME, QUARTO_CELLS_VIEW_TYPE } from '../../common/quartoVirtualNotebookTypes.js';
+import { IQuartoDocumentModel } from '../../common/quartoTypes.js';
+import { IQuartoDocumentModelService } from '../../browser/quartoDocumentModelService.js';
+import { QuartoDocumentModel } from '../../browser/quartoDocumentModel.js';
+import { QuartoVirtualNotebookService } from '../../browser/quartoVirtualNotebookService.js';
+
+const R_AND_PYTHON = [
+	'# Intro',
+	'',
+	'```{r}',
+	'x <- 1',
+	'```',
+	'',
+	'```{python}',
+	'import os',
+	'```',
+	'',
+].join('\n');
+
+/**
+ * Documents the churn test steps through, with the cells each one must produce.
+ *
+ * The line numbers are counted off the content beside them rather than derived
+ * from the parser, so a wrong span shows up as a mismatch instead of agreeing
+ * with whatever the code computed.
+ */
+const CHURN_STEPS: readonly {
+	readonly name: string;
+	readonly content: string;
+	readonly cells: readonly (readonly [string, string, number, number])[];
+}[] = [
+		{
+			name: 'one chunk',
+			content: [
+				'# Intro',			// 1
+				'',					// 2
+				'```{r}',			// 3
+				'a <- 1',			// 4
+				'```',				// 5
+				'',
+			].join('\n'),
+			cells: [['r', 'a <- 1', 4, 4]],
+		},
+		{
+			name: 'three chunks',
+			content: [
+				'# Intro',			// 1
+				'',					// 2
+				'```{r}',			// 3
+				'a <- 1',			// 4
+				'```',				// 5
+				'',					// 6
+				'```{r}',			// 7
+				'b <- 2',			// 8
+				'c <- 3',			// 9
+				'```',				// 10
+				'',					// 11
+				'```{r}',			// 12
+				'd <- 4',			// 13
+				'```',				// 14
+				'',
+			].join('\n'),
+			cells: [
+				['r', 'a <- 1', 4, 4],
+				['r', 'b <- 2\nc <- 3', 8, 9],
+				['r', 'd <- 4', 13, 13],
+			],
+		},
+		{
+			name: 'two chunks',
+			content: [
+				'# Intro',			// 1
+				'',					// 2
+				'```{r}',			// 3
+				'a <- 1',			// 4
+				'```',				// 5
+				'',					// 6
+				'```{r}',			// 7
+				'b <- 2',			// 8
+				'c <- 3',			// 9
+				'```',				// 10
+				'',
+			].join('\n'),
+			cells: [
+				['r', 'a <- 1', 4, 4],
+				['r', 'b <- 2\nc <- 3', 8, 9],
+			],
+		},
+		{
+			// Same chunks, more prose above them: the cells move without changing.
+			name: 'two chunks, more prose',
+			content: [
+				'# Intro',			// 1
+				'',					// 2
+				'more prose',		// 3
+				'',					// 4
+				'```{r}',			// 5
+				'a <- 1',			// 6
+				'```',				// 7
+				'',					// 8
+				'```{r}',			// 9
+				'b <- 2',			// 10
+				'c <- 3',			// 11
+				'```',				// 12
+				'',
+			].join('\n'),
+			cells: [
+				['r', 'a <- 1', 6, 6],
+				['r', 'b <- 2\nc <- 3', 10, 11],
+			],
+		},
+		{
+			// Same cell count and spans, different language in the first chunk.
+			name: 'two chunks, first one Python',
+			content: [
+				'# Intro',			// 1
+				'',					// 2
+				'more prose',		// 3
+				'',					// 4
+				'```{python}',		// 5
+				'a = 1',			// 6
+				'```',				// 7
+				'',					// 8
+				'```{r}',			// 9
+				'b <- 2',			// 10
+				'c <- 3',			// 11
+				'```',				// 12
+				'',
+			].join('\n'),
+			cells: [
+				['python', 'a = 1', 6, 6],
+				['r', 'b <- 2\nc <- 3', 10, 11],
+			],
+		},
+	];
+
+describe('QuartoVirtualNotebookService', () => {
+	const logService = new NullLogService();
+	const configurationService = new TestConfigurationService();
+
+	// The real NotebookService installs a process-global handler for the
+	// `notebooks` extension point, so it cannot be rebuilt per test. This fake
+	// covers the parts the service under test uses and hands out real
+	// NotebookTextModels, which is what makes cell URI generation and the
+	// IModelService binding real rather than simulated. Duplicate view type
+	// registration throws exactly as the real store does, which is what the
+	// registration guard has to survive.
+	const notebooks = new ResourceMap<NotebookTextModel>();
+	const contributedTypes = new Set<string>();
+	// Annotated rather than inferred: createNotebookTextModel reads `ctx`, which
+	// is built from this stub, and TypeScript cannot resolve that cycle on its own.
+	const notebookService: INotebookService = stubInterface<INotebookService>({
+		getNotebookTextModel: (uri: URI) => notebooks.get(uri),
+		createNotebookTextModel: async (viewType: string, uri: URI): Promise<NotebookTextModel> => {
+			const notebook = ctx.instantiationService.createInstance(
+				NotebookTextModel, viewType, uri, [], {},
+				{
+					transientOutputs: true,
+					transientCellMetadata: {},
+					transientDocumentMetadata: {},
+					cellContentMetadata: {},
+				}
+			);
+			notebooks.set(uri, notebook);
+			// The real service drops the model on disposal; without this the
+			// fake would keep handing back a dead notebook.
+			ctx.disposables.add(notebook.onWillDispose(() => notebooks.delete(uri)));
+			return notebook;
+		},
+		getContributedNotebookType: (viewType: string) =>
+			contributedTypes.has(viewType)
+				? stubInterface<NotebookProviderInfo>({ id: viewType })
+				: undefined,
+		registerContributedNotebookType: (viewType: string): IDisposable => {
+			if (contributedTypes.has(viewType)) {
+				throw new Error(`notebook type '${viewType}' ALREADY EXISTS`);
+			}
+			contributedTypes.add(viewType);
+			return toDisposable(() => contributedTypes.delete(viewType));
+		},
+		registerNotebookSerializer: (): IDisposable => Disposable.None,
+	});
+
+	// The real QuartoDocumentModelService keys models by text model, which is
+	// exactly what the service under test consumes. Models are created lazily
+	// here and torn down with the container.
+	const documentModels = new Map<string, QuartoDocumentModel>();
+	const documentModelService: Pick<IQuartoDocumentModelService, 'getModel'> = {
+		getModel: (textModel: ITextModel): IQuartoDocumentModel => {
+			const key = textModel.uri.toString();
+			let model = documentModels.get(key);
+			if (!model) {
+				model = new QuartoDocumentModel(textModel, logService);
+				documentModels.set(key, model);
+			}
+			return model;
+		},
+	};
+
+	const ctx = createTestContainer()
+		.withNotebookServices()
+		.stub(INotebookService, notebookService)
+		.stub(IConfigurationService, configurationService)
+		.stub(IQuartoDocumentModelService, documentModelService)
+		.build();
+
+	beforeEach(async () => {
+		contributedTypes.clear();
+		await configurationService.setUserConfiguration(QUARTO_NATIVE_LANGUAGE_FEATURES_KEY, true);
+	});
+
+	afterEach(() => {
+		for (const model of documentModels.values()) {
+			model.dispose();
+		}
+		documentModels.clear();
+		notebooks.clear();
+	});
+
+	function createService(): QuartoVirtualNotebookService {
+		const service = ctx.instantiationService.createInstance(QuartoVirtualNotebookService);
+		ctx.disposables.add(service);
+		return service;
+	}
+
+	function createSourceModel(content: string, path = '/test/doc.qmd'): ITextModel {
+		const modelService = ctx.instantiationService.get(IModelService);
+		const languageService = ctx.instantiationService.get(ILanguageService);
+		const model = modelService.createModel(
+			content,
+			languageService.createById('plaintext'),
+			URI.file(path)
+		);
+		ctx.disposables.add(model);
+		return model;
+	}
+
+	it('creates a hidden notebook whose URI keeps the source path', async () => {
+		const service = createService();
+		const source = createSourceModel(R_AND_PYTHON);
+		await service.whenReady(source.uri);
+
+		const notebookUri = service.getNotebookUri(source.uri);
+		const notebook = ctx.instantiationService.get(INotebookService)
+			.getNotebookTextModel(notebookUri!);
+
+		expect({
+			scheme: notebookUri?.scheme,
+			path: notebookUri?.path,
+			viewType: notebook?.viewType,
+			cellCount: notebook?.cells.length,
+		}).toEqual({
+			scheme: QUARTO_CELLS_SCHEME,
+			path: source.uri.path,
+			viewType: QUARTO_CELLS_VIEW_TYPE,
+			cellCount: 2,
+		});
+	});
+
+	it('creates one bound cell text model per code cell, holding only the code', async () => {
+		const service = createService();
+		const source = createSourceModel(R_AND_PYTHON);
+		await service.whenReady(source.uri);
+
+		expect(service.getCells(source.uri).map(cell => ({
+			scheme: cell.cellUri.scheme,
+			path: cell.cellUri.path,
+			language: cell.language,
+			text: cell.textModel.getValue(),
+			codeStartLine: cell.codeStartLine,
+			codeEndLine: cell.codeEndLine,
+		}))).toEqual([
+			{
+				scheme: Schemas.vscodeNotebookCell,
+				path: source.uri.path,
+				language: 'r',
+				text: 'x <- 1',
+				codeStartLine: 4,
+				codeEndLine: 4,
+			},
+			{
+				scheme: Schemas.vscodeNotebookCell,
+				path: source.uri.path,
+				language: 'python',
+				text: 'import os',
+				codeStartLine: 8,
+				codeEndLine: 8,
+			},
+		]);
+	});
+
+	it('binds each cell text model to its notebook cell', async () => {
+		const service = createService();
+		const source = createSourceModel(R_AND_PYTHON);
+		await service.whenReady(source.uri);
+
+		const notebook = ctx.instantiationService.get(INotebookService)
+			.getNotebookTextModel(service.getNotebookUri(source.uri)!);
+
+		// The binding is what makes the extension host see real cell documents.
+		expect(notebook!.cells.map(cell => cell.textModel?.uri.toString()))
+			.toEqual(service.getCells(source.uri).map(cell => cell.cellUri.toString()));
+	});
+
+	it('does not create a notebook or register the type when the setting is off', async () => {
+		await configurationService.setUserConfiguration(QUARTO_NATIVE_LANGUAGE_FEATURES_KEY, false);
+		const service = createService();
+		const source = createSourceModel(R_AND_PYTHON);
+		await service.whenReady(source.uri);
+
+		expect({
+			notebookUri: service.getNotebookUri(source.uri),
+			// Registering the type writes to profile storage, so a user who
+			// never enables the setting should accumulate nothing.
+			typeRegistered: contributedTypes.has(QUARTO_CELLS_VIEW_TYPE),
+		}).toEqual({
+			notebookUri: undefined,
+			typeRegistered: false,
+		});
+	});
+
+	it('ignores documents that are not Quarto or R Markdown', async () => {
+		const service = createService();
+		const source = createSourceModel('x <- 1\n', '/test/script.R');
+		await service.whenReady(source.uri);
+
+		expect(service.getNotebookUri(source.uri)).toBeUndefined();
+	});
+
+	it('maps source lines to cells and back, treating prose as outside every cell', async () => {
+		const service = createService();
+		const source = createSourceModel(R_AND_PYTHON);
+		await service.whenReady(source.uri);
+
+		const rCell = service.getCellAtLine(source.uri, 4);
+
+		expect({
+			prose: service.getCellAtLine(source.uri, 1)?.language,
+			openingFence: service.getCellAtLine(source.uri, 3)?.language,
+			rCode: service.getCellAtLine(source.uri, 4)?.language,
+			closingFence: service.getCellAtLine(source.uri, 5)?.language,
+			pythonCode: service.getCellAtLine(source.uri, 8)?.language,
+			reverseLookup: service.getSourceUriForCell(rCell!.cellUri)?.toString(),
+		}).toEqual({
+			prose: undefined,
+			openingFence: undefined,
+			rCode: 'r',
+			closingFence: undefined,
+			pythonCode: 'python',
+			reverseLookup: source.uri.toString(),
+		});
+	});
+
+	it('edits cell text in place when only cell content changes', async () => {
+		const service = createService();
+		const source = createSourceModel(R_AND_PYTHON);
+		await service.whenReady(source.uri);
+
+		const before = service.getCells(source.uri)[0];
+		const beforeUri = before.cellUri.toString();
+		const beforeHandle = before.handle;
+
+		source.applyEdits([{
+			range: { startLineNumber: 4, startColumn: 7, endLineNumber: 4, endColumn: 7 },
+			text: '\ny <- 2',
+		}]);
+		service.ensureSynchronized(source.uri);
+
+		const after = service.getCells(source.uri)[0];
+
+		expect({
+			text: after.textModel.getValue(),
+			codeEndLine: after.codeEndLine,
+			uriPreserved: after.cellUri.toString() === beforeUri,
+			handlePreserved: after.handle === beforeHandle,
+			modelPreserved: after.textModel === before.textModel,
+		}).toEqual({
+			text: 'x <- 1\ny <- 2',
+			codeEndLine: 5,
+			uriPreserved: true,
+			handlePreserved: true,
+			modelPreserved: true,
+		});
+	});
+
+	it('rebuilds cells when a chunk is added, without leaving disposed models behind', async () => {
+		const service = createService();
+		const source = createSourceModel(R_AND_PYTHON);
+		await service.whenReady(source.uri);
+
+		source.setValue(R_AND_PYTHON + '```{r}\nmean(x)\n```\n');
+		service.ensureSynchronized(source.uri);
+
+		expect(service.getCells(source.uri).map(cell => ({
+			text: cell.textModel.getValue(),
+			disposed: cell.textModel.isDisposed(),
+		}))).toEqual([
+			{ text: 'x <- 1', disposed: false },
+			{ text: 'import os', disposed: false },
+			{ text: 'mean(x)', disposed: false },
+		]);
+	});
+
+	it('tracks cell text and line spans through repeated churn', async () => {
+		const service = createService();
+		const source = createSourceModel(CHURN_STEPS[0].content);
+		await service.whenReady(source.uri);
+
+		// Three passes so every step is reached from more than one predecessor,
+		// including the shrink direction that leaves cell models to dispose.
+		for (let pass = 0; pass < 3; pass++) {
+			for (const step of CHURN_STEPS) {
+				source.setValue(step.content);
+				// Wait for the debounced parse rather than forcing a sync. The
+				// forced path runs the reconcile twice, and a second pass repairs
+				// spans that the first one got wrong, hiding the bug from a
+				// passive consumer who never asks for a sync.
+				await documentModels.get(source.uri.toString())!.whenParsed();
+
+				expect({
+					step: step.name,
+					cells: service.getCells(source.uri).map(cell =>
+						[cell.language, cell.textModel.getValue(), cell.codeStartLine, cell.codeEndLine]),
+					// Surprise F from the spike: cell models were disposed while
+					// `_cells` still referenced them.
+					allAlive: service.getCells(source.uri).every(cell => !cell.textModel.isDisposed()),
+				}).toEqual({ step: step.name, cells: step.cells, allAlive: true });
+			}
+		}
+	});
+
+	it('keeps line spans fresh when prose above a chunk grows', async () => {
+		const service = createService();
+		const source = createSourceModel(R_AND_PYTHON);
+		await service.whenReady(source.uri);
+
+		// A prose-only edit changes no cell content, so the cell-level change
+		// event stays silent while every chunk below shifts down. Syncing on that
+		// event alone leaves the spans stale, which silently misplaces every
+		// position mapped through a cell.
+		source.applyEdits([{
+			range: { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 1 },
+			text: 'more prose\n\n',
+		}]);
+		await documentModels.get(source.uri.toString())!.whenParsed();
+
+		// Read the way a passive consumer does, without asking for a sync first.
+		expect(service.getCells(source.uri).map(cell => [cell.codeStartLine, cell.codeEndLine]))
+			.toEqual([[6, 6], [10, 10]]);
+	});
+
+	it('disposes the notebook and its cell models when the source document closes', async () => {
+		const service = createService();
+		const source = createSourceModel(R_AND_PYTHON);
+		await service.whenReady(source.uri);
+
+		const notebookUri = service.getNotebookUri(source.uri)!;
+		const cellModels = service.getCells(source.uri).map(cell => cell.textModel);
+
+		ctx.instantiationService.get(IModelService).destroyModel(source.uri);
+
+		expect({
+			notebookUri: service.getNotebookUri(source.uri),
+			notebook: ctx.instantiationService.get(INotebookService).getNotebookTextModel(notebookUri),
+			cells: service.getCells(source.uri),
+			cellModelsDisposed: cellModels.map(model => model.isDisposed()),
+		}).toEqual({
+			notebookUri: undefined,
+			notebook: undefined,
+			cells: [],
+			cellModelsDisposed: [true, true],
+		});
+	});
+
+	it('tolerates the notebook type already being registered', async () => {
+		// Surprise B from the spike: registerContributedNotebookType persists the
+		// type to profile storage and rehydrates it on the next window, so a
+		// second unconditional registration throws "ALREADY EXISTS". Registering
+		// the type up front is what that second window looks like. The failure
+		// was invisible in a single window and only appeared after a reload,
+		// which is why this asserts the service still works rather than just
+		// that construction did not throw.
+		contributedTypes.add(QUARTO_CELLS_VIEW_TYPE);
+
+		const service = createService();
+		const source = createSourceModel(R_AND_PYTHON);
+		await service.whenReady(source.uri);
+
+		expect(service.getCells(source.uri).length).toBe(2);
+	});
+
+	it('drops the notebook when the setting is turned off', async () => {
+		const service = createService();
+		const source = createSourceModel(R_AND_PYTHON);
+		await service.whenReady(source.uri);
+
+		await configurationService.setUserConfiguration(QUARTO_NATIVE_LANGUAGE_FEATURES_KEY, false);
+		configurationService.onDidChangeConfigurationEmitter.fire({
+			affectsConfiguration: () => true,
+			affectedKeys: new Set([QUARTO_NATIVE_LANGUAGE_FEATURES_KEY]),
+			source: 2,
+			change: { keys: [QUARTO_NATIVE_LANGUAGE_FEATURES_KEY], overrides: [] },
+		});
+		await service.whenReady(source.uri);
+
+		expect(service.getNotebookUri(source.uri)).toBeUndefined();
+	});
+});

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoVirtualNotebookService.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoVirtualNotebookService.vitest.ts
@@ -350,6 +350,44 @@ describe('QuartoVirtualNotebookService', () => {
 		expect(service.getNotebookUri(source.uri)).toBeUndefined();
 	});
 
+	it('ignores read-only views of a Quarto document', async () => {
+		// A Git diff or a local history entry has the same path but holds an older
+		// revision. Giving one its own notebook would sync a second, stale copy of
+		// the document to the language servers.
+		const service = createService();
+		const modelService = ctx.instantiationService.get(IModelService);
+		const languageService = ctx.instantiationService.get(ILanguageService);
+		const gitUri = URI.file('/test/doc.qmd').with({ scheme: 'git', query: '{"ref":"HEAD"}' });
+		const gitModel = modelService.createModel(
+			R_AND_PYTHON, languageService.createById('plaintext'), gitUri);
+		ctx.disposables.add(gitModel);
+		await service.whenReady(gitUri);
+
+		expect({
+			notebook: service.getNotebookUri(gitUri),
+			cells: service.getAllCells().length,
+		}).toEqual({ notebook: undefined, cells: 0 });
+	});
+
+	it('gives up its place when a notebook already exists for the document', async () => {
+		// Left registered but without a notebook it would produce no cells forever,
+		// and the guard against duplicates would stop it ever being retried.
+		const service = createService();
+		const source = createSourceModel(R_AND_PYTHON);
+		await service.whenReady(source.uri);
+		const notebookUri = service.getNotebookUri(source.uri)!;
+
+		// A second service over the same notebook map hits the existing model.
+		const second = createService();
+		await second.whenReady(source.uri);
+
+		expect({
+			firstStillWorks: service.getCells(source.uri).length,
+			secondGaveUp: second.getNotebookUri(source.uri),
+			notebookIntact: notebooks.get(notebookUri) !== undefined,
+		}).toEqual({ firstStillWorks: 2, secondGaveUp: undefined, notebookIntact: true });
+	});
+
 	it('maps source lines to cells and back, treating prose as outside every cell', async () => {
 		const service = createService();
 		const source = createSourceModel(R_AND_PYTHON);

--- a/src/vs/workbench/contrib/positronQuarto/test/common/quartoCellPositionMapping.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/common/quartoCellPositionMapping.vitest.ts
@@ -1,0 +1,95 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import {
+	cellPositionToSource,
+	cellRangeToSource,
+	sourcePositionToCell,
+	sourceRangeToCell,
+} from '../../common/quartoCellPositionMapping.js';
+
+// A document whose opening fence is on line 3, code on lines 4 to 6, and
+// closing fence on line 7:
+//
+//   1  # Intro
+//   2
+//   3  ```{r}
+//   4  x <- 1
+//   5  y <- 2
+//   6  z <- 3
+//   7  ```
+const cell = { codeStartLine: 4, codeEndLine: 6 };
+
+describe('quartoCellPositionMapping', () => {
+	it('maps source positions into the cell, and nothing outside the code', () => {
+		expect({
+			firstCodeLine: sourcePositionToCell(cell, { lineNumber: 4, column: 1 }),
+			lastCodeLine: sourcePositionToCell(cell, { lineNumber: 6, column: 9 }),
+			openingFence: sourcePositionToCell(cell, { lineNumber: 3, column: 1 }),
+			closingFence: sourcePositionToCell(cell, { lineNumber: 7, column: 1 }),
+			prose: sourcePositionToCell(cell, { lineNumber: 1, column: 1 }),
+		}).toEqual({
+			// Columns pass through untouched. The parser only recognizes fences
+			// that start at column 0, so cell code is never indented relative to
+			// the source and there is no column offset to apply.
+			firstCodeLine: { lineNumber: 1, column: 1 },
+			lastCodeLine: { lineNumber: 3, column: 9 },
+			openingFence: undefined,
+			closingFence: undefined,
+			prose: undefined,
+		});
+	});
+
+	it('maps cell positions and ranges back to the source document', () => {
+		// Asserted against absolute values rather than through a round trip. A
+		// round trip passes whenever both directions are wrong by the same
+		// amount, which is the most likely way for this to break.
+		expect({
+			firstCodeLine: cellPositionToSource(cell, { lineNumber: 1, column: 1 }),
+			lastCodeLine: cellPositionToSource(cell, { lineNumber: 3, column: 9 }),
+			range: cellRangeToSource(cell, {
+				startLineNumber: 1, startColumn: 2, endLineNumber: 3, endColumn: 4,
+			}),
+		}).toEqual({
+			firstCodeLine: { lineNumber: 4, column: 1 },
+			lastCodeLine: { lineNumber: 6, column: 9 },
+			range: { startLineNumber: 4, startColumn: 2, endLineNumber: 6, endColumn: 4 },
+		});
+	});
+
+	it('accepts ranges inside the code and rejects any that leave it', () => {
+		expect({
+			wholeCell: sourceRangeToCell(cell, {
+				startLineNumber: 4, startColumn: 1, endLineNumber: 6, endColumn: 10,
+			}),
+			startsOnFence: sourceRangeToCell(cell, {
+				startLineNumber: 3, startColumn: 1, endLineNumber: 5, endColumn: 1,
+			}),
+			endsOnFence: sourceRangeToCell(cell, {
+				startLineNumber: 5, startColumn: 1, endLineNumber: 7, endColumn: 1,
+			}),
+		}).toEqual({
+			wholeCell: { startLineNumber: 1, startColumn: 1, endLineNumber: 3, endColumn: 10 },
+			startsOnFence: undefined,
+			endsOnFence: undefined,
+		});
+	});
+
+	it('treats a chunk with no code as containing no lines', () => {
+		// An empty chunk puts the fences on consecutive lines, so the parser
+		// reports a span whose end is before its start.
+		const empty = { codeStartLine: 4, codeEndLine: 3 };
+
+		expect({
+			atStart: sourcePositionToCell(empty, { lineNumber: 4, column: 1 }),
+			atEnd: sourcePositionToCell(empty, { lineNumber: 3, column: 1 }),
+		}).toEqual({
+			atStart: undefined,
+			atEnd: undefined,
+		});
+	});
+});

--- a/src/vs/workbench/contrib/positronQuarto/test/common/quartoConfig.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/common/quartoConfig.vitest.ts
@@ -10,7 +10,9 @@ import {
 	POSITRON_QUARTO_INLINE_OUTPUT_KEY,
 	QUARTO_INLINE_OUTPUT_AUTO_SCROLL_KEY,
 	QUARTO_INLINE_OUTPUT_ENABLED_KEY,
+	QUARTO_NATIVE_LANGUAGE_FEATURES_KEY,
 	getQuartoConfigValue,
+	usingNativeEmbeddedFeatures,
 	usingQuartoInlineOutputAutoScroll,
 } from '../../common/positronQuartoConfig.js';
 
@@ -62,6 +64,28 @@ describe('usingQuartoInlineOutputAutoScroll', () => {
 			on: usingQuartoInlineOutputAutoScroll(on),
 		}).toEqual({
 			unset: true,
+			off: false,
+			on: true,
+		});
+	});
+});
+
+describe('usingNativeEmbeddedFeatures', () => {
+	it('defaults off and is only on when explicitly set to true', async () => {
+		const unset = new TestConfigurationService();
+
+		const off = new TestConfigurationService();
+		await off.setUserConfiguration(QUARTO_NATIVE_LANGUAGE_FEATURES_KEY, false);
+
+		const on = new TestConfigurationService();
+		await on.setUserConfiguration(QUARTO_NATIVE_LANGUAGE_FEATURES_KEY, true);
+
+		expect({
+			unset: usingNativeEmbeddedFeatures(unset),
+			off: usingNativeEmbeddedFeatures(off),
+			on: usingNativeEmbeddedFeatures(on),
+		}).toEqual({
+			unset: false,
 			off: false,
 			on: true,
 		});

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelService.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelService.ts
@@ -35,6 +35,7 @@ import { IEditorService } from '../../../services/editor/common/editorService.js
 import { IEditorGroup, IEditorGroupsService } from '../../../services/editor/common/editorGroupsService.js';
 import { EditorInput } from '../../../common/editor/editorInput.js';
 import { GroupIdentifier, GroupModelChangeKind } from '../../../common/editor.js';
+import { QUARTO_CELLS_VIEW_TYPE } from '../../positronQuarto/common/quartoVirtualNotebookTypes.js';
 
 /**
  * The service responsible for managing {@link RuntimeNotebookKernel}s.
@@ -443,6 +444,14 @@ export class RuntimeNotebookKernelService extends Disposable implements IRuntime
 	}
 
 	private attachNotebook(notebook: NotebookTextModel): void {
+		// Quarto virtual notebooks are hidden models that exist only so language
+		// servers can see embedded code cells. They have no editor, so a session
+		// started here could never be used, but it would still show up in the
+		// session picker
+		if (notebook.notebookType === QUARTO_CELLS_VIEW_TYPE) {
+			return;
+		}
+
 		// If a kernel is already selected for the notebook, there's nothing to do
 		if (this.getOrSelectKernel(notebook)) {
 			return;

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/tests/browser/runtimeNotebookKernelService.vitest.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/tests/browser/runtimeNotebookKernelService.vitest.ts
@@ -28,6 +28,7 @@ import { RuntimeNotebookKernel } from '../../browser/runtimeNotebookKernel.js';
 import { RuntimeNotebookKernelService } from '../../browser/runtimeNotebookKernelService.js';
 import { POSITRON_RUNTIME_NOTEBOOK_KERNELS_EXTENSION_ID } from '../../common/runtimeNotebookKernelConfig.js';
 import { POSITRON_NOTEBOOK_EDITOR_INPUT_ID } from '../../../positronNotebook/common/positronNotebookCommon.js';
+import { QUARTO_CELLS_VIEW_TYPE } from '../../../positronQuarto/common/quartoVirtualNotebookTypes.js';
 import { IEditorGroupsService } from '../../../../services/editor/common/editorGroupsService.js';
 import { EditorInput } from '../../../../common/editor/editorInput.js';
 import { GroupModelChangeKind, IEditorIdentifier } from '../../../../common/editor.js';
@@ -382,6 +383,52 @@ describe('Positron - RuntimeNotebookKernelService', () => {
 			await expect(
 				runtimeNotebookKernelService.executeCodeInCell(URI.parse('file:///unknown.ipynb'), 0, '1 + 1')
 			).rejects.toThrow(/text model/);
+		});
+	});
+
+	describe('Quarto virtual notebooks', () => {
+		/** A notebook shaped like the hidden ones Positron creates per open .qmd. */
+		function createVirtualNotebook(viewType: string): NotebookTextModel {
+			const notebook = createTestNotebookEditor(
+				ctx.instantiationService,
+				ctx.disposables.add(new DisposableStore()),
+				[['x <- 1', runtime.languageId, CellKind.Code, [], {}]],
+			).viewModel.notebookDocument;
+			vi.spyOn(notebook, 'notebookType', 'get').mockReturnValue(viewType);
+			notebook.metadata = { metadata: { language_info: { name: runtime.languageId } } };
+			return notebook;
+		}
+
+		it('no kernel is selected and no session starts for a hidden Quarto notebook', async () => {
+			// These notebooks exist only so language servers can see the code
+			// cells embedded in a .qmd. They have no editor, so a session started
+			// for one is unusable, but it still shows up in the session picker.
+			const selectKernel = vi.spyOn(notebookKernelService, 'selectKernelForNotebook');
+			const startSession = vi.fn();
+			ctx.disposables.add(runtimeSessionService.onWillStartSession(startSession));
+
+			notebookService.onWillAddNotebookDocumentEmitter.fire(createVirtualNotebook(QUARTO_CELLS_VIEW_TYPE));
+			// Session starts are asynchronous, so give one a chance to happen.
+			await timeout(0);
+
+			expect({
+				kernelSelections: selectKernel.mock.calls.length,
+				sessionStarts: startSession.mock.calls.length,
+			}).toEqual({
+				kernelSelections: 0,
+				sessionStarts: 0,
+			});
+		});
+
+		it('an ordinary notebook of the same shape still gets a kernel', async () => {
+			// Guards the guard: the assertions above have to be about the view
+			// type, not about this notebook being unmatchable for other reasons.
+			const selectKernel = vi.spyOn(notebookKernelService, 'selectKernelForNotebook');
+
+			notebookService.onWillAddNotebookDocumentEmitter.fire(createVirtualNotebook(IPYNB_VIEW_TYPE));
+			await timeout(0);
+
+			expect(selectKernel.mock.calls.length).toBeGreaterThan(0);
 		});
 	});
 });


### PR DESCRIPTION
Related to https://github.com/posit-dev/positron/issues/12837

Language features for code inside `.qmd` and `.Rmd` files are answered today by the Quarto extension, which writes a temporary virtual document to disk for almost every request. That costs about five async round trips per completion and is the root of several reported problems: 

- a slow Outline (#14512)
- symbols that appear more than once (#13907)
- stray `.vdoc` files (#11027)
- Problems entries pointing at files the user never opened (#4482)
- etc etc etc

This PR is the first, fundamental part of a different approach. Positron builds a hidden in-memory `NotebookTextModel` for each open Quarto document, with one cell per code chunk. No editor is ever opened for it, so nothing appears in the interface, but the extension host sees ordinary notebook cell documents and language servers sync them through the channel they already use for notebooks. A request for a position inside a chunk is mapped into the cell that holds it, answered by the providers registered on that cell, and mapped back. Prose and frontmatter are declined and still reach the Quarto extension.

Conceptually, a `.qmd` file is a sequence of code cells that share a session, so cells are a more honest model for a Quarto document than one concatenated file with the prose commented out. That misrepresentation is what produces cross-cell scope leakage and diagnostics attributed to files that do not exist.

Completion, hover, signature help, and go to definition are routed here. Outline, statement range, help topics, and diagnostics will follow in later PRs, as does the change that stops the Quarto extension answering these requests.

Everything is behind `quarto.embeddedLanguageFeatures.native`, tagged experimental and off by default. Both paths run when it is on, so nothing changes for anyone who does not opt in.

### Release Notes

#### New Features

- Added an experimental setting, `quarto.embeddedLanguageFeatures.native`, that lets Positron answer completion, hover, signature help, and go to definition for code cells in Quarto and R Markdown documents.

#### Bug Fixes

- N/A


### Validation Steps

@:quarto @:r-markdown @:console @:ark @:notebooks

These suites cover the blast radius rather than the new path. The Quarto and R Markdown suites guard the document model and parser this builds on, the console and ark suites guard the language client selectors that changed for both R and Python, and the notebook suites guard a new view type check in the runtime notebook kernel service, which is the change that reaches furthest outside Quarto.

**Confirming that the new path is the one answering.** Both paths are going to run until a later PR stops the Quarto extension answering, and they produce results a user cannot tell apart, because Positron deduplicates completion items. Use the log rather than the editor:

1. Run _Developer: Set Log Level..._ and choose **Trace**.
2. Set `quarto.embeddedLanguageFeatures.native` to `true`.
3. Open a `.qmd` with an R chunk and start an R session.
4. Type a partial symbol in the chunk, like `data.fr`.
5. Open the Output panel, choose the **Window** channel, and filter for `QuartoEmbedded`.

Expect lines of this shape:

```
[QuartoEmbedded] completion answered from cell 134-136 by 2 provider(s)
[QuartoEmbedded] hover answered from cell 9-20 by 1 provider(s)
```

Filtering for `QuartoVirtualNotebook` also shows one `Created quarto-cells:/...` line per open Quarto document, with the cell count. Together those cover both halves: the cells exist, and requests are answered from them. If completions appear but no `QuartoEmbedded` line does, the Quarto extension is doing all the work and this code is contributing nothing.

**Behavior to check by hand:**

1. Type a partial symbol like `data.fr` in an R chunk and confirm completions appear.
2. Define a dataframe and then type `$` to confirm its columns are offered, rather than a generic list. A context-aware answer is the sign the language server understood the cell, not just that something replied.
3. Accept a completion and confirm the text is inserted at the cursor, not elsewhere in the document.
4. Confirm hover, go to definition, and signature help work inside a chunk.
5. Confirm prose and the YAML frontmatter are unaffected, and that no `QuartoEmbedded` line appears when the cursor is in them.
6. Turn the setting off, reload, and confirm everything still works through the Quarto extension.

**No e2e test is added here, deliberately.** While both paths are live, a test that types in a chunk and asserts a completion appears passes whether or not this code works, because the Quarto extension answers as well. The deduplication above means the two paths cannot be told apart from the outside either. A meaningful e2e test becomes possible in the PR that stops the extension answering, and belongs with that change. Unit coverage here is 268 tests, each checked by breaking the behavior it covers and confirming it fails.
