### PR TITLE
Fix Quarto vdoc LSP routing to read the canonical setting

### DIFF
--- a/extensions/positron-python/src/client/positron/lsp.ts
+++ b/extensions/positron-python/src/client/positron/lsp.ts
@@ -17,6 +17,7 @@ import { PromiseHandles } from './util';
 import { PythonErrorHandler } from './errorHandler';
 import { PythonHelpTopicProvider } from './help';
 import { PythonStatementRangeProvider } from './statementRange';
+import { isQuartoInlineOutputEnabled } from './quarto';
 
 // Regex to match Quarto virtual document files: .vdoc.[uuid].[ext]
 const VDOC_PATTERN = /^\.vdoc\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.\w+$/i;
@@ -177,13 +178,8 @@ export class PythonLsp implements vscode.Disposable {
                 // exists, so the console LSP must handle vdocs.
                 if (document.uri.scheme === 'file') {
                     const baseName = path.basename(document.uri.fsPath);
-                    if (VDOC_PATTERN.test(baseName)) {
-                        const inlineOutputEnabled = vscode.workspace
-                            .getConfiguration('positron.quarto.inlineOutput')
-                            .get<boolean>('enabled', false);
-                        if (inlineOutputEnabled) {
-                            return true;
-                        }
+                    if (VDOC_PATTERN.test(baseName) && isQuartoInlineOutputEnabled()) {
+                        return true;
                     }
                 }
                 // Console LSP: skip notebook console inputs

--- a/extensions/positron-python/src/client/positron/quarto.ts
+++ b/extensions/positron-python/src/client/positron/quarto.ts
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+/**
+ * The canonical setting for Quarto inline output.
+ */
+const QUARTO_INLINE_OUTPUT_ENABLED_KEY = 'quarto.inlineOutput.enabled';
+
+/**
+ * The deprecated alias for {@link QUARTO_INLINE_OUTPUT_ENABLED_KEY}. Positron
+ * keeps this key working during the deprecation window.
+ */
+const POSITRON_QUARTO_INLINE_OUTPUT_ENABLED_KEY = 'positron.quarto.inlineOutput.enabled';
+
+/**
+ * The result of inspecting a boolean setting, narrowed to the levels a user can
+ * set from the extension host.
+ */
+interface BooleanInspection {
+    globalValue?: boolean;
+    workspaceValue?: boolean;
+    workspaceFolderValue?: boolean;
+}
+
+/**
+ * The subset of {@link vscode.WorkspaceConfiguration} needed to resolve a
+ * boolean setting. Declared so tests can supply a plain object.
+ */
+export interface BooleanConfiguration {
+    get(section: string, defaultValue: boolean): boolean;
+    inspect(section: string): BooleanInspection | undefined;
+}
+
+/**
+ * Whether a configuration value has been explicitly set at any level, as opposed
+ * to falling back to its registered default.
+ */
+function isConfigurationSet(inspection: BooleanInspection | undefined): boolean {
+    return (
+        inspection?.globalValue !== undefined ||
+        inspection?.workspaceValue !== undefined ||
+        inspection?.workspaceFolderValue !== undefined
+    );
+}
+
+/**
+ * Whether Quarto inline output is enabled.
+ *
+ * Prefers the canonical `quarto.inlineOutput.enabled` key and falls back to the
+ * deprecated `positron.quarto.inlineOutput.enabled` alias when the canonical key
+ * has not been explicitly set. Both keys are registered with a default of
+ * `false`, so `get()` alone cannot tell an explicit `false` from an unset value,
+ * but `inspect()` can. This mirrors `getQuartoConfigValue()` in Positron core
+ * and `isInlineOutputEnabled()` in the Quarto extension.
+ *
+ * @param config The configuration to read from, defaulting to the workspace configuration.
+ * @returns true if Quarto inline output is enabled.
+ */
+export function isQuartoInlineOutputEnabled(
+    config: BooleanConfiguration = vscode.workspace.getConfiguration(),
+): boolean {
+    for (const key of [QUARTO_INLINE_OUTPUT_ENABLED_KEY, POSITRON_QUARTO_INLINE_OUTPUT_ENABLED_KEY]) {
+        if (isConfigurationSet(config.inspect(key))) {
+            return config.get(key, false);
+        }
+    }
+    return false;
+}

--- a/extensions/positron-python/src/test/positron/quarto.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/quarto.unit.test.ts
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { BooleanConfiguration, isQuartoInlineOutputEnabled } from '../../client/positron/quarto';
+import { mock } from './utils';
+
+const CANONICAL_KEY = 'quarto.inlineOutput.enabled';
+const DEPRECATED_KEY = 'positron.quarto.inlineOutput.enabled';
+
+/**
+ * A configuration where the given keys are set by the user and every other key
+ * falls back to its registered default of `false`.
+ */
+function configuration(userValues: { [key: string]: boolean }): BooleanConfiguration {
+    return mock<BooleanConfiguration>({
+        get: (section: string, defaultValue: boolean) => userValues[section] ?? defaultValue,
+        inspect: (section: string) => ({ globalValue: userValues[section] }),
+    });
+}
+
+suite('isQuartoInlineOutputEnabled', () => {
+    test('Follows the canonical key when only the canonical key is set', () => {
+        assert.strictEqual(isQuartoInlineOutputEnabled(configuration({ [CANONICAL_KEY]: true })), true);
+    });
+
+    test('Falls back to the deprecated key when the canonical key is unset', () => {
+        assert.strictEqual(isQuartoInlineOutputEnabled(configuration({ [DEPRECATED_KEY]: true })), true);
+    });
+
+    test('An explicit false on the canonical key wins over the deprecated key', () => {
+        const config = configuration({ [CANONICAL_KEY]: false, [DEPRECATED_KEY]: true });
+
+        assert.strictEqual(isQuartoInlineOutputEnabled(config), false);
+    });
+});

--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -24,6 +24,7 @@ import { Socket } from 'net';
 import { RHelpTopicProvider } from './help';
 import { R_DOCUMENT_SELECTORS } from './provider';
 import { VirtualDocumentProvider } from './virtual-documents';
+import { isQuartoInlineOutputEnabled } from './quarto';
 
 // Regex to match Quarto virtual document files: .vdoc.[uuid].[ext]
 const VDOC_PATTERN = /^\.vdoc\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.\w+$/i;
@@ -195,13 +196,8 @@ export class ArkLsp implements vscode.Disposable {
 						// exists, so the console LSP must handle vdocs.
 						if (document.uri.scheme === 'file') {
 							const baseName = path.basename(document.uri.fsPath);
-							if (VDOC_PATTERN.test(baseName)) {
-								const inlineOutputEnabled = vscode.workspace
-									.getConfiguration('positron.quarto.inlineOutput')
-									.get<boolean>('enabled', false);
-								if (inlineOutputEnabled) {
-									return undefined;
-								}
+							if (VDOC_PATTERN.test(baseName) && isQuartoInlineOutputEnabled()) {
+								return undefined;
 							}
 						}
 						// Console LSP: skip notebook console inputs

--- a/extensions/positron-r/src/quarto.ts
+++ b/extensions/positron-r/src/quarto.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+/**
+ * The canonical setting for Quarto inline output.
+ */
+const QUARTO_INLINE_OUTPUT_ENABLED_KEY = 'quarto.inlineOutput.enabled';
+
+/**
+ * The deprecated alias for {@link QUARTO_INLINE_OUTPUT_ENABLED_KEY}. Positron
+ * keeps this key working during the deprecation window.
+ */
+const POSITRON_QUARTO_INLINE_OUTPUT_ENABLED_KEY = 'positron.quarto.inlineOutput.enabled';
+
+/**
+ * The result of inspecting a boolean setting, narrowed to the levels a user can
+ * set from the extension host.
+ */
+interface BooleanInspection {
+	globalValue?: boolean;
+	workspaceValue?: boolean;
+	workspaceFolderValue?: boolean;
+}
+
+/**
+ * The subset of {@link vscode.WorkspaceConfiguration} needed to resolve a
+ * boolean setting. Declared so tests can supply a plain object.
+ */
+export interface BooleanConfiguration {
+	get(section: string, defaultValue: boolean): boolean;
+	inspect(section: string): BooleanInspection | undefined;
+}
+
+/**
+ * Whether a configuration value has been explicitly set at any level, as opposed
+ * to falling back to its registered default.
+ */
+function isConfigurationSet(inspection: BooleanInspection | undefined): boolean {
+	return inspection?.globalValue !== undefined ||
+		inspection?.workspaceValue !== undefined ||
+		inspection?.workspaceFolderValue !== undefined;
+}
+
+/**
+ * Whether Quarto inline output is enabled.
+ *
+ * Prefers the canonical `quarto.inlineOutput.enabled` key and falls back to the
+ * deprecated `positron.quarto.inlineOutput.enabled` alias when the canonical key
+ * has not been explicitly set. Both keys are registered with a default of
+ * `false`, so `get()` alone cannot tell an explicit `false` from an unset value,
+ * but `inspect()` can. This mirrors `getQuartoConfigValue()` in Positron core
+ * and `isInlineOutputEnabled()` in the Quarto extension.
+ *
+ * @param config The configuration to read from, defaulting to the workspace configuration.
+ * @returns true if Quarto inline output is enabled.
+ */
+export function isQuartoInlineOutputEnabled(
+	config: BooleanConfiguration = vscode.workspace.getConfiguration()
+): boolean {
+	for (const key of [QUARTO_INLINE_OUTPUT_ENABLED_KEY, POSITRON_QUARTO_INLINE_OUTPUT_ENABLED_KEY]) {
+		if (isConfigurationSet(config.inspect(key))) {
+			return config.get(key, false);
+		}
+	}
+	return false;
+}

--- a/extensions/positron-r/src/test/quarto.unit.test.ts
+++ b/extensions/positron-r/src/test/quarto.unit.test.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { isQuartoInlineOutputEnabled } from '../quarto';
+
+const CANONICAL_KEY = 'quarto.inlineOutput.enabled';
+const DEPRECATED_KEY = 'positron.quarto.inlineOutput.enabled';
+
+/**
+ * Set a user setting, or clear it when the value is undefined.
+ */
+async function setUserValue(key: string, value: boolean | undefined): Promise<void> {
+	await vscode.workspace.getConfiguration().update(key, value, vscode.ConfigurationTarget.Global);
+}
+
+// Reads the real workspace configuration, so that the fallback is checked
+// against the settings machinery rather than against a stand-in for it.
+suite('isQuartoInlineOutputEnabled', () => {
+	teardown(async () => {
+		await setUserValue(CANONICAL_KEY, undefined);
+		await setUserValue(DEPRECATED_KEY, undefined);
+	});
+
+	test('follows the canonical key when only the canonical key is set', async () => {
+		await setUserValue(CANONICAL_KEY, true);
+
+		assert.strictEqual(isQuartoInlineOutputEnabled(), true);
+	});
+
+	test('falls back to the deprecated key when the canonical key is unset', async () => {
+		await setUserValue(DEPRECATED_KEY, true);
+
+		assert.strictEqual(isQuartoInlineOutputEnabled(), true);
+	});
+
+	test('an explicit false on the canonical key wins over the deprecated key', async () => {
+		await setUserValue(CANONICAL_KEY, false);
+		await setUserValue(DEPRECATED_KEY, true);
+
+		assert.strictEqual(isQuartoInlineOutputEnabled(), false);
+	});
+});


### PR DESCRIPTION
Fixes #15409 which I missed when I originally did #14742

The R and Python language clients still read the deprecated `positron.quarto.inlineOutput.enabled` key to decide which language server handles Quarto virtual documents. A user who sets only `quarto.inlineOutput.enabled` gets inline output, but the two clients act as if inline output is off. The console client does not ignore the vdoc, and the notebook client for the Quarto session serves the same vdoc. As a result, two language servers answer the same request for one code chunk. This isn't a big deal because Positron deduplicates completions and keeps only hovers with the highest priority, etc, but we still want to clean this up.

This PR adds an `isQuartoInlineOutputEnabled` helper to each extension. The helper reads the canonical key first, and it uses the deprecated alias only when the user does not set the canonical key. Both keys have a default of `false`, so `get()` cannot tell an explicit `false` from an unset value. The helper uses `inspect()` instead. This matches `getQuartoConfigValue()` in Positron core and `isInlineOutputEnabled()` in the Quarto extension.

Note that the e2e suites already set the canonical key. Both `test/e2e/tests/quarto/_test.setup.ts` and `test/e2e/tests/autocomplete/autocomplete-notebook-console.test.ts` set `quarto.inlineOutput.enabled`, so those suites ran with the duplicate language server condition active.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Quarto code chunks now get completions from the session of the document only, and not also from the console session, when inline output is enabled with the `quarto.inlineOutput.enabled` setting (#15409)


### Validation Steps

@:quarto @:console @:editor @:positron-notebooks

New unit tests cover the setting fallback in both extensions:

- `npm run test-extension -- -l positron-r --grep isQuartoInlineOutputEnabled`, which reads the real workspace configuration in the extension host
- `npm run test:unittests -- --grep isQuartoInlineOutputEnabled`, from `extensions/positron-python`

Both files were verified against the pre-fix logic.

To check by hand:

1. Set `quarto.inlineOutput.enabled` to `true`. Leave `positron.quarto.inlineOutput.enabled` unset.
2. Open a `.qmd` document that has an R or Python code chunk.
3. Make the document the active tab, so that inline output starts a session.
4. Request completions inside the code chunk.
5. Make sure that you get a completion and each completion item appears one time.
