### PR TITLE
docs: fix stale and self-contradicting statements in ROCKY-PLAN.md

### DIFF
--- a/docker/environments/wb-local/ROCKY-PLAN.md
+++ b/docker/environments/wb-local/ROCKY-PLAN.md
@@ -294,19 +294,37 @@ Also done: `rocky_9` added to `ci-images-build-os.yml` (choice, validation,
 `update-ci-images` skill (6 -> 7 builds, PR checklist, and both
 `bump-node-version.sh` / `bump-ppm-snapshot.sh` file lists).
 
-Two latent `rocky_8` bugs surfaced along the way. **Both are now fixed in the
-same PR as this image** (they are the same two defects `rocky_9` had to avoid):
+**Three** latent `rocky_8` bugs surfaced along the way, all now fixed and merged
+in the same PR as this image (#15407):
 
 1. Its PPM channel `__linux__/rockylinux8` does not exist and 404s -- R reported
    zero available packages and fell back to source builds. Corrected to
-   `centos8`, which is what PPM's own API maps `rhel8` to. This is plausibly the
-   root cause of the source-built GEOS/GDAL/libgit2 and `gcc-toolset-13` it
-   carries, but removing those is a **separate, riskier change** and was left
-   alone here.
+   `centos8`, which is what PPM's own API maps `rhel8` to. (Rocky **9** is
+   `rhel9`; there is no `rockylinux*` channel at all.) After the fix PPM served
+   **216 binary packages** on x86_64, and aarch64 binaries too -- which confirms
+   this was forcing the source builds.
 2. Its Quarto `ar x` unpack left the binary off PATH (confirmed against the
    published `positron-rocky8:24.18.0` image config -- `/opt/quarto/bin` is not
    in `PATH` and no symlink is created). Now installs the RPM, verified to work
    on EL8.
+3. **`sf`, `terra` and `gert` could not load at all.** The final `ENV` block
+   *assigned* `LD_LIBRARY_PATH` rather than prepending, discarding the
+   `/opt/gdal`, `/opt/libgit2` and `/opt/geos` entries accumulated above -- so
+   packages compiled against those libraries failed at runtime with
+   `libgdal.so.35: cannot open shared object file` and `libgit2.so.1.8`. This was
+   **pre-existing, not caused by fix 1**: verified by running the same check
+   against the previously published image
+   (`positron-rocky8-arm64@sha256:a52f0ea9`), which fails identically.
+
+Fixing 1 also required `pkg.include_linkingto = TRUE` (added to both images):
+once PPM serves binaries, pak omits `LinkingTo` dependencies from the plan, so
+the packages that have *no* binary for an arch (`arrow` on aarch64) can no longer
+be built from source. This is the remedy pak itself suggests.
+
+**Open follow-up:** all three bugs trace back to `rocky_8`'s `/opt` source-build
+machinery (GEOS/GDAL/libgit2 + `gcc-toolset-13`), which is plausibly unnecessary
+now that its PPM channel works -- `rocky_9` needs none of it. Removing it changes
+what the R packages link against, so it wants its own validation pass.
 
 Original delta list, for reference:
 
@@ -423,10 +441,12 @@ gated behind the broken stop/status described above, and the session-creation AP
 is scoped under `/s/<id>/` rather than the `/api/*` paths, so automated assertion
 of session launch is left to the real e2e suite in Step 5.
 
-**Reusable artifact:** the installed container was snapshotted as
-`rocky9-wb-installed:latest`, which brings a working Workbench up in seconds
-instead of repeating the ~40-minute install while iterating on Steps 2-4.
-Services do not auto-start: start the launcher, wait for its socket, then rserver.
+**Reusable artifact:** the installed container was snapshotted (locally, on the
+machine where the spike ran) as `rocky9-wb-installed:latest`, which brings a
+working Workbench up in seconds instead of repeating the ~40-minute install while
+iterating on Steps 2-4. It is not published anywhere -- recreate it by following
+this step if it is gone. Services do not auto-start: start the launcher, wait for
+`/var/run/rstudio-server/rserver-launcher.socket`, then start rserver.
 
 ### Step 1 (original plan text, for reference)
 

--- a/docker/environments/wb-local/ROCKY-PLAN.md
+++ b/docker/environments/wb-local/ROCKY-PLAN.md
@@ -3,7 +3,12 @@
 Goal: tag a PR with `@:workbench` and `@:workbench-rocky` and get the
 `@:workbench` test suite running in parallel on Ubuntu 24 and Rocky Linux.
 
-Status: planning. Nothing implemented yet.
+Status (2026-08-09): **Steps 0 and 1 are done and merged** (#15407) --
+`ghcr.io/posit-dev/positron-rocky9:24.18.0` is published and verified, and
+Workbench is proven to run on Rocky 9 without systemd. **Step 2 is next.**
+
+Nothing consumes either image yet: `test-e2e-rhel.yml` still pins
+`positron-rocky8:24.15.0`, so repointing it is a separate PR.
 
 ## Target: Rocky 9, not Rocky 8
 
@@ -110,9 +115,6 @@ Mechanism, from the separately verified facts:
 - `start()` then runs `daemon $rserver` and, because status always reports
   stopped, adds a **second** rserver (duplicate rservers were observed directly).
 
-This makes the swap+restart path a **Step 7 correctness blocker**, not the Step 4
-harness annoyance it was previously recorded as.
-
 Demonstrated end to end with a real build swap (bundled build 184 -> downloaded
 build 331, `positron-workbench-linux-arm64-2026.08.0-331.tar.gz`, which also
 confirms `positronDownload.sh` works on Rocky/arm64):
@@ -120,9 +122,13 @@ confirms `positronDownload.sh` works on Rocky/arm64):
 - **CI sequence (`rstudio-server restart`)**: swap at 22:43:20; the rserver still
   holding `:8787` afterwards had started at **22:34:26**, nine minutes before the
   new build existed. Two rservers, exit 0, `HTTP 302` served by the stale one.
-  This is the false pass, reproduced.
 - **Corrected sequence (signal-stop -> wait -> start)**: exactly one rserver,
   started after the swap, `HTTP 302`. Passes.
+
+Note the stale-rserver detail above is *not* by itself a wrong-build test run --
+the session-launch behaviour documented earlier means that rserver still hands new
+sessions whatever is on disk. Fix it for the duplicate-process mess, not because
+the lane would test the wrong Positron.
 
 Mitigation to implement in Step 3/7:
 


### PR DESCRIPTION
Docs only -- no code. Corrects three things in
`docker/environments/wb-local/ROCKY-PLAN.md` that would mislead anyone picking the
Rocky Workbench project up cold.

1. **Stale status header.** It still said "Status: planning. Nothing implemented
   yet." after Steps 0 and 1 had shipped in #15407. Now states where the project
   actually stands, what is next (Step 2), and that nothing consumes either image
   yet because `test-e2e-rhel.yml` still pins `positron-rocky8:24.15.0`.

2. **The document contradicted itself about the `rstudio-server restart` bug.**
   The section header and impact analysis say it is *not* a correctness blocker --
   because Positron turns out to be resolved at session launch from disk, so a
   surviving pre-swap rserver still serves the new build. But two lines further
   down it still called it "a Step 7 correctness blocker" and labelled the
   reproduction "the false pass, reproduced", which was the earlier, wrong
   conclusion. Those stale lines are removed and replaced with an explicit note.

3. **The rocky_8 bug count was wrong.** It said two bugs were found and fixed;
   there were three. The third -- the final `ENV` assigning `LD_LIBRARY_PATH`
   instead of prepending, which left `sf`, `terra` and `gert` unable to load --
   was found after that section was written and only recorded in the Dockerfile
   comment and commit message. Also notes that fixing the PPM channel required
   `pkg.include_linkingto`, and that all three bugs trace back to rocky_8's
   `/opt` source-build machinery (the open follow-up).

Both 1 and 2 are artifacts of correcting earlier conclusions in place and not
sweeping the whole document afterwards.