### PR TITLE
e2e: fix strict-mode violation in expectBrowserModeFrame

### DIFF
--- a/test/e2e/pages/debug.ts
+++ b/test/e2e/pages/debug.ts
@@ -246,7 +246,9 @@ export class Debug {
 	 */
 	async expectBrowserModeFrame(number: number): Promise<void> {
 		await test.step(`Verify in browser mode: frame ${number}`, async () => {
-			await expect(this.code.driver.currentPage.getByText(`Browse[${number}]>`)).toBeVisible();
+			// The prompt renders both in the console output span and in the console input's
+			// line-number gutter; either proves browser mode, so don't fail strict mode on both.
+			await expect(this.code.driver.currentPage.getByText(`Browse[${number}]>`).first()).toBeVisible();
 		});
 	}
 


### PR DESCRIPTION
### Summary
`expectBrowserModeFrame` matched the browse prompt with an unscoped page-wide `getByText`, which can resolve to two nodes and fail strict mode instantly, well before the visibility timeout.

- The prompt renders both as a console output span and in the console input's line-number gutter
- Which node carries a given frame number varies by call site, so scoping to either one breaks the other
- Takes `.first()` instead, so a two-node match resolves rather than throwing

### QA Notes
@:debug @:web


### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- Unscoped page-wide getByText in expectBrowserModeFrame can match both the console output prompt span and the console input line-number gutter, throwing a strict-mode violation.</summary>

- **Test:** [R Breakpoints > R - Verify debug-specific console history](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=R%20Breakpoints%20%3E%20R%20-%20Verify%20debug-specific%20console%20history%7C%7C%7Ctest%2Fe2e%2Ftests%2Fdebug%2Fr-debug.test.ts)
- **Targeted failure:** Error: expect(locator).toBeVisible() failed -- strict mode violation: getByText("Browse[1]>") resolved to 2 elements
- **Signal:** The expect failed after ~59ms against a 15s timeout (trace t=626484..626543), so it never waited; the error names two live nodes holding the prompt string. Local DOM probes confirmed both renderings exist and that which one carries a given frame number varies by call site: in this test the output span read Browse[1]> while the gutter read Browse[2]>, and in the call-stack test only the gutter read Browse[1]> with no matching output span at all.
- **Frequency:** 10/140 runs (7.1%) on main, ubuntu/chromium
- **Hypothesis:** race

</details>
