### PR TITLE
e2e: require a better-ranked Python source when versions collide

### DIFF
--- a/test/e2e/pages/quickInput.ts
+++ b/test/e2e/pages/quickInput.ts
@@ -185,7 +185,8 @@ export class QuickInput {
 
 	async selectQuickInputElementContaining(
 		text: string,
-		{ timeout, force = true, deprioritize }: { timeout?: number; force?: boolean; deprioritize?: string[] } = {},
+		{ timeout, force = true, deprioritize, requireNonDeprioritized = false }:
+			{ timeout?: number; force?: boolean; deprioritize?: string[]; requireNonDeprioritized?: boolean } = {},
 	): Promise<string> {
 		const matches = this.code.driver.currentPage
 			.locator(`${QuickInput.QUICK_INPUT_RESULT}[aria-label*="${text}"]`);
@@ -200,13 +201,29 @@ export class QuickInput {
 		if (deprioritize?.length) {
 			await expect(target).toBeVisible({ timeout });
 			const count = await matches.count();
+			const labels: string[] = [];
+			let found = false;
 			for (let i = 0; i < count; i++) {
 				const row = matches.nth(i);
 				const ariaLabel = (await row.getAttribute('aria-label')) ?? '';
+				labels.push(ariaLabel);
 				if (!deprioritize.some(source => ariaLabel.includes(source))) {
 					target = row;
+					found = true;
 					break;
 				}
+			}
+
+			// A list holding only deprioritized sources may just be incomplete, since
+			// runtimes keep registering after the picker reports discovery complete.
+			// Only worth failing when several rows share `text`: a lone deprioritized row
+			// is the normal shape where one interpreter of this version exists.
+			if (!found && requireNonDeprioritized && count > 1) {
+				throw new Error(
+					`No non-deprioritized "${text}" row in the quick pick; every match is a deprioritized source `
+					+ `(deprioritized: ${deprioritize.join(', ')}; rows: ${labels.join(' | ') || 'none'}). `
+					+ 'The intended runtime has probably not finished registering yet.'
+				);
 			}
 		}
 

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -26,6 +26,10 @@ export const DISCONNECTED_STATUS_ICON = '.codicon-positron-runtime-status-discon
 // the quick pick label produced by getRuntimeSourceAndShortName.
 export const DEPRIORITIZED_PYTHON_SOURCES = ['(Pyenv', '(Global', '(System', '(Unknown'];
 
+// Quick pick attempts that insist on a non-deprioritized Python source before accepting
+// the fallback. Attempts, not a wait: each one re-reads a list that may have grown.
+const STRICT_SOURCE_ATTEMPTS = 3;
+
 // Quickpick labels - keep in sync with languageRuntimeActions.ts
 const INTERPRETER_SESSIONS_LABEL = 'Interpreter Sessions';
 const START_NEW_CONSOLE_SESSION_LABEL = 'Start New Console Session';
@@ -61,6 +65,10 @@ export class Sessions {
 	private get metadataDialog() { return this.page.getByRole('dialog').locator('.console-instance-info').first(); }
 	private consoleInstance = (sessionId: string) => this.page.getByTestId(`console-${sessionId}`);
 	private get outputChannel() { return this.page.getByRole('combobox'); }
+
+	// Quick pick label of the runtime row most recently clicked, e.g. "Python 3.10.12
+	// (uv: root)", compared against the session that actually starts.
+	private _lastSelectedRuntimeLabel: string | undefined;
 
 	constructor(private code: Code, private quickaccess: QuickAccess, private quickinput: QuickInput, private console: Console, private contextMenu: ContextMenu, private modals: Modals) { }
 
@@ -115,7 +123,9 @@ export class Sessions {
 				version: sessionTemplate.version, // This will call the getter again
 			};
 			newSession.id = await this.startAndSkipMetadata(newSession);
-			return await this.getMetadata(newSession.id);
+			const metadata = await this.getMetadata(newSession.id);
+			this.expectStartedSourceToMatchSelection(metadata);
+			return metadata;
 		};
 
 		if (reuse) {
@@ -511,6 +521,10 @@ export class Sessions {
 			triggerMode = 'hotkey',
 		} = options;
 
+		// Callers reach this directly too, bypassing the check that consumes the label, so
+		// clear any leftover rather than compare a stale selection to this session.
+		this._lastSelectedRuntimeLabel = undefined;
+
 		return await test.step(`Start session via ${triggerMode}: ${language} ${version} ${options.disambiguator}`, async () => {
 
 			// Don't try to start a new runtime if one is currently starting up
@@ -518,7 +532,9 @@ export class Sessions {
 
 			// Retry the quick pick interaction to handle race conditions where the
 			// picker may not open or populate correctly on the first attempt.
+			let attempt = 0;
 			await expect(async () => {
+				attempt++;
 				// Dismiss any stale quick input from a previous attempt
 				await this.quickinput.closeQuickInput().catch(() => { });
 
@@ -553,9 +569,14 @@ export class Sessions {
 				// We need to click instead of using 'enter' because the Python select interpreter command
 				// may include additional items above the desired interpreter string.
 				try {
-					await this.quickinput.selectQuickInputElementContaining(`${language} ${version}`, {
+					this._lastSelectedRuntimeLabel = await this.quickinput.selectQuickInputElementContaining(`${language} ${version}`, {
 						timeout: 2000,
 						deprioritize: language === 'Python' ? DEPRIORITIZED_PYTHON_SOURCES : undefined,
+						// The discovery-complete wait above only sees the placeholder clear, which
+						// precedes registration: a uv venv can land after a bare version match
+						// already settled on the same-version base install, where pip then refuses
+						// to install under PEP 668. Retry rather than accept that immediately.
+						requireNonDeprioritized: language === 'Python' && attempt <= STRICT_SOURCE_ATTEMPTS,
 					});
 				} catch (e) {
 					// Auto-discovery is intermittent: POSITRON_PY_VER_SEL's interpreter
@@ -619,6 +640,34 @@ export class Sessions {
 
 			return sessionId!;
 		});
+	}
+
+	/**
+	 * Confirm the session that started is the one that was selected in the quick pick.
+	 *
+	 * Only flags the direction that breaks package installs: a better-ranked row was
+	 * clicked but a deprioritized source started anyway. A deprioritized row being
+	 * clicked was the deliberate fallback, so nothing is asserted there.
+	 */
+	private expectStartedSourceToMatchSelection(metadata: SessionMetaData): void {
+		const selected = this._lastSelectedRuntimeLabel;
+		this._lastSelectedRuntimeLabel = undefined;
+
+		// The markers are Python source names; R shares some spellings (e.g. "System").
+		if (!selected?.startsWith('Python')) {
+			return;
+		}
+
+		const isDeprioritized = (label: string) => DEPRIORITIZED_PYTHON_SOURCES.some(source => label.includes(source));
+		if (isDeprioritized(selected) || !isDeprioritized(`(${metadata.source}`)) {
+			return;
+		}
+
+		throw new Error(
+			`Selected "${selected}" in the quick pick but session ${metadata.id} started on a deprioritized `
+			+ `source "${metadata.source}" (${metadata.path}). The runtime list was re-ranked between `
+			+ 'selection and start.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Summary

A Packages pane test flaked because the Python session sometimes started on a uv-managed base interpreter instead of the uv venv, and `pip install` is refused there under PEP 668 -- so the package never showed up in the list.

- The runtime quick pick reports discovery complete before every runtime has registered.
- Three interpreters report 3.10.12 on Linux CI, and the uv venv registered 4.2s after the session started.
- Prefer a better-ranked interpreter source when several rows share a version, retrying instead of taking the base install.
- Keep the existing fallback where only one interpreter of that version exists (a Pyenv alternate, System Python on Windows).
- Fail at selection when the started session isn't the one picked, instead of as a later install timeout.

### QA Notes

Touches `sessions.start()`, so the blast radius is every test that starts a session.

@:packages-pane @:interpreter @:sessions @:web @:win

### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- openFolder's window reload restarts interpreter discovery; the picker's discovery-complete signal fires before the intended uv venv runtime registers, so the session starts on a uv-managed base Python where PEP 668 makes pip install fail.</summary>

- **Test:** [Packages Pane > Python - Install, search, and uninstall package > Python - Install, search, and uninstall package (python)](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Packages%20Pane%20%3E%20Python%20-%20Install%2C%20search%2C%20and%20uninstall%20package%20%3E%20Python%20-%20Install%2C%20search%2C%20and%20uninstall%20package%20%28python%29%7C%7C%7Ctest%2Fe2e%2Ftests%2Fpackages-pane%2Fpackages-pane.test.ts)
- **Targeted failure:** Error: expect(locator).toBeVisible() failed -- Locator: locator('.positron-packages-list').locator('.packages-list-item-name').filter({ hasText: 'cowsay' }).first(); Expected: visible; Timeout: 60000ms; element(s) not found
- **Signal:** verifyPackagesList passes with rows present, then the install is dispatched and the packages list drops to zero rows for the entire 60s wait. The trace shows the 'Installing packages...' toast appearing normally, but the raw PTY bytes carry pip's real output: 'error: externally-managed-environment / This Python installation is managed by uv'. The session had started at 20:36:46.416 on 'Python 3.10.12 (Global)' = /root/.local/share/uv/python/cpython-3.10-linux-x86_64-gnu/bin/python, while the intended 'Python 3.10.12 (uv: root)' = /root/.venv/bin/python did not finish registering until 20:36:50.612 -- 4.2s after selection. runtimeSource 'Global' routes packageManagerFactory.ts:37 to PipPackageManager instead of UvPackageManager, and pip into a uv-managed base install can never succeed.
- **Frequency:** 4/145 runs (2.8%) on main, ubuntu/electron
- **Hypothesis:** race

</details>

