### PR TITLE
chore: bump insights reporter to 0.55.0 and read e2e setup deps from the root package.json

### DIFF
--- a/.github/actions/setup-e2e-test-dependencies/action.yml
+++ b/.github/actions/setup-e2e-test-dependencies/action.yml
@@ -16,21 +16,41 @@ runs:
       env:
         PLAYWRIGHT_BROWSERS_PATH: .playwright-browsers
       run: |
+        # Read these ranges out of the root package.json while it's still here,
+        # so this action can't drift from it. Hardcoded copies did drift: this
+        # step pinned @playwright/test ^1.53.1 long after the root moved to
+        # ^1.62.1, and the sharding reporter's preprocess hook needs >= 1.62.
+        ROOT_DEPS=$(node -e '
+          const pkg = require("./package.json");
+          const ranges = { ...pkg.dependencies, ...pkg.devDependencies };
+          const names = [
+            "@playwright/test",
+            "@midleman/playwright-reporter",
+            "@midleman/github-actions-reporter",
+            "@vscode/v8-heap-parser",
+          ];
+          const missing = names.filter((n) => !ranges[n]);
+          if (missing.length) {
+            console.error("not declared in the root package.json: " + missing.join(", "));
+            process.exit(1);
+          }
+          console.log(names.map((n) => n + "@" + ranges[n]).join(" "));
+        ')
+
         # Must remove root package.json and provide simple stub to use root dir for test run but not build
         rm package.json
         echo '{"scripts":{"compile":"npx tsc"}}' > package.json
 
-        # Install TypeScript locally
+        # Not inherited from the root on purpose: the root pins a TypeScript dev
+        # build for the product build, and this step only compiles test/e2e.
         npm install typescript
 
-        # Install required dependencies - must keep in sync with root package.json
-        npm install @playwright/test@^1.53.1
+        npm install $ROOT_DEPS
         npx playwright install
         npx playwright install-deps
+
+        # Declared nowhere else, so there is no version to inherit.
         npm install @currents/playwright@^1.14.1
-        npm install @midleman/playwright-reporter@latest
-        npm install @midleman/github-actions-reporter@^1.9.5
-        npm install @vscode/v8-heap-parser@^0.1.0
         npm install fs-extra
         npm install axe-core
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,7 @@
       "devDependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.128",
         "@midleman/github-actions-reporter": "^1.10.1",
-        "@midleman/playwright-reporter": "^0.54.1",
+        "@midleman/playwright-reporter": "^0.55.0",
         "@openai/codex": "^0.134.0",
         "@playwright/cli": "^0.1.9",
         "@playwright/test": "^1.62.1",
@@ -4978,18 +4978,14 @@
       }
     },
     "node_modules/@midleman/playwright-reporter": {
-      "version": "0.54.1",
-      "resolved": "https://registry.npmjs.org/@midleman/playwright-reporter/-/playwright-reporter-0.54.1.tgz",
-      "integrity": "sha512-yxr3p83wgofltTNP1ZrWpRKpPGvBawOKGLXn147RKDjpGhdzR2mj9RLZx0sLOMVDZ/qpecGDpGidZbdbVVcPWQ==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@midleman/playwright-reporter/-/playwright-reporter-0.55.0.tgz",
+      "integrity": "sha512-f1BclSwJoXihp+j1EgrPzN3bIG/Uz2WtUgLslVccm5eFQ/2yy4bNOl0YsbhCQwWClCMZC9BxuuCNHBfgRrVe/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.980.0",
-        "cross-spawn": "^7.0.6",
         "zod": "^3.23.0"
-      },
-      "bin": {
-        "e2e-insights": "dist/cli/index.js"
       },
       "peerDependencies": {
         "@playwright/test": ">=1.40.0"

--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
     "@anthropic-ai/claude-agent-sdk": "0.2.128",
     "@openai/codex": "^0.134.0",
     "@midleman/github-actions-reporter": "^1.10.1",
-    "@midleman/playwright-reporter": "^0.54.1",
+    "@midleman/playwright-reporter": "^0.55.0",
     "@playwright/cli": "^0.1.9",
     "@playwright/test": "^1.62.1",
     "@softwarenerd/deemon-ng": "^1.1.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,11 +28,7 @@ const insightsReporters: ReporterDescription[] = [
 		] as ReporterDescription]
 		: []),
 	...(shardingEnabled
-		? [['@midleman/playwright-reporter/sharding',
-			{
-				repo: 'positron'
-			},
-		] as ReporterDescription]
+		? [['@midleman/playwright-reporter/sharding'] as ReporterDescription]
 		: []),
 ];
 


### PR DESCRIPTION
### Summary

Bumps the Insights reporter to 0.55.0 and stops the e2e setup action's dependency versions from drifting away from the root `package.json`.

- `@midleman/playwright-reporter` `^0.54.1` -> `^0.55.0`
- Drops the now-redundant `repo: 'positron'` option from the sharding reporter config
- The setup action reads `@playwright/test`, both `@midleman/*` reporters, and `@vscode/v8-heap-parser` out of the root `package.json` instead of hardcoding versions
- Fails the step loudly if any of those packages is no longer declared at the root
- Fixes real drift: the action was still pinning `@playwright/test@^1.53.1` while the root was on `^1.62.1`, below the `>= 1.62` the sharding reporter's preprocess hook needs

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

@:critical

CI-only change. Confirm the e2e jobs install the expected versions and that sharding/Insights reporting still uploads.
