### PR TITLE
Present Canvas as a standalone application surface

### DIFF
--- a/build/lib/i18n.resources.json
+++ b/build/lib/i18n.resources.json
@@ -183,6 +183,10 @@
 			"project": "vscode-workbench"
 		},
 		{
+			"name": "vs/workbench/contrib/positronCanvas",
+			"project": "vscode-workbench"
+		},
+		{
 			"name": "vs/workbench/contrib/positronVariables",
 			"project": "vscode-workbench"
 		},

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -149,6 +149,9 @@ import { EphemeralStateService } from '../../platform/ephemeralState/common/ephe
 import { EPHEMERAL_STATE_CHANNEL_NAME, EphemeralStateChannel } from '../../platform/ephemeralState/common/ephemeralStateIpc.js';
 import { PositronMemoryUsageMainService } from '../../platform/positronMemoryUsage/electron-main/positronMemoryUsageMainService.js';
 import { POSITRON_MEMORY_INFO_CHANNEL_NAME, PositronMemoryInfoChannel } from '../../platform/positronMemoryUsage/common/positronMemoryUsageIpc.js';
+import { IPositronStandaloneModeMainService, POSITRON_STANDALONE_MODE_CHANNEL_NAME } from '../../platform/positronStandaloneMode/common/positronStandaloneMode.js';
+import { PositronStandaloneModeChannel } from '../../platform/positronStandaloneMode/common/positronStandaloneModeIpc.js';
+import { PositronStandaloneModeMainService } from '../../platform/positronStandaloneMode/electron-main/positronStandaloneModeMainService.js';
 import { recolorDevIcon } from '../../platform/windows/electron-main/devIconColorizer.js';
 // --- End Positron ---
 
@@ -166,6 +169,9 @@ export class CodeApplication extends Disposable {
 	private windowsMainService: IWindowsMainService | undefined;
 	private auxiliaryWindowsMainService: IAuxiliaryWindowsMainService | undefined;
 	private nativeHostMainService: INativeHostMainService | undefined;
+	// --- Start Positron ---
+	private positronStandaloneModeMainService: IPositronStandaloneModeMainService | undefined;
+	// --- End Positron ---
 
 	constructor(
 		private readonly mainProcessNodeIpcServer: NodeIPCServer,
@@ -557,16 +563,40 @@ export class CodeApplication extends Disposable {
 
 			// Handle paths delayed in case more are coming!
 			runningTimeout = setTimeout(async () => {
-				await this.windowsMainService?.open({
-					context: OpenContext.DOCK /* can also be opening from finder while app is running */,
-					cli: this.environmentMainService.args,
-					urisToOpen: macOpenFileURIs,
-					gotoLineMode: false,
-					preferNewWindow: true /* dropping on the dock or opening from finder prefers to open in a new window */
-				});
-
+				// --- Start Positron ---
+				// A Finder or Dock open must not land behind an engaged
+				// standalone mode window, so it is routed by the standalone
+				// mode policy like a second-instance open (LaunchMainService).
+				const urisToOpen = macOpenFileURIs;
 				macOpenFileURIs = [];
 				runningTimeout = undefined;
+
+				const openFinderFiles = () => {
+					void this.windowsMainService?.open({
+						// --- End Positron ---
+						context: OpenContext.DOCK /* can also be opening from finder while app is running */,
+						cli: this.environmentMainService.args,
+						// --- Start Positron ---
+						// urisToOpen: macOpenFileURIs,
+						urisToOpen,
+						// --- End Positron ---
+						gotoLineMode: false,
+						preferNewWindow: true /* dropping on the dock or opening from finder prefers to open in a new window */
+					});
+					// --- Start Positron ---
+				};
+				if (this.positronStandaloneModeMainService) {
+					await this.positronStandaloneModeMainService.handleExternalOpen(
+						openFinderFiles,
+						(engagedWindowId, exitCommandId) => this.windowsMainService?.getWindowById(engagedWindowId)?.sendWhenReady('vscode:runAction', CancellationToken.None, {
+							id: exitCommandId,
+							from: 'menu',
+						})
+					);
+				} else {
+					openFinderFiles();
+				}
+				// --- End Positron ---
 			}, 100);
 		});
 
@@ -1169,6 +1199,12 @@ export class CodeApplication extends Disposable {
 		// Menubar
 		services.set(IMenubarMainService, new SyncDescriptor(MenubarMainService));
 
+		// --- Start Positron ---
+		// Standalone mode: which window, if any, presents a single view as the
+		// whole product
+		services.set(IPositronStandaloneModeMainService, new SyncDescriptor(PositronStandaloneModeMainService));
+		// --- End Positron ---
+
 		// Extension Host Starter
 		services.set(IExtensionHostStarter, new SyncDescriptor(ExtensionHostStarter));
 
@@ -1410,6 +1446,11 @@ export class CodeApplication extends Disposable {
 		const memoryUsageMainService = new PositronMemoryUsageMainService();
 		const memoryInfoChannel = new PositronMemoryInfoChannel(memoryUsageMainService);
 		mainProcessElectronServer.registerChannel(POSITRON_MEMORY_INFO_CHANNEL_NAME, memoryInfoChannel);
+
+		// Standalone Mode
+		this.positronStandaloneModeMainService = accessor.get(IPositronStandaloneModeMainService);
+		const standaloneModeChannel = new PositronStandaloneModeChannel(this.positronStandaloneModeMainService);
+		mainProcessElectronServer.registerChannel(POSITRON_STANDALONE_MODE_CHANNEL_NAME, standaloneModeChannel);
 		// --- End Positron ---
 
 		// Utility Process Worker

--- a/src/vs/platform/launch/electron-main/launchMainService.ts
+++ b/src/vs/platform/launch/electron-main/launchMainService.ts
@@ -5,6 +5,11 @@
 
 import { app } from 'electron';
 import { coalesce } from '../../../base/common/arrays.js';
+// --- Start Positron ---
+import { CancellationToken } from '../../../base/common/cancellation.js';
+import { IAuxiliaryWindowsMainService } from '../../auxiliaryWindow/electron-main/auxiliaryWindows.js';
+import { IPositronStandaloneModeMainService } from '../../positronStandaloneMode/common/positronStandaloneMode.js';
+// --- End Positron ---
 import { IProcessEnvironment, isMacintosh } from '../../../base/common/platform.js';
 import { URI } from '../../../base/common/uri.js';
 import { whenDeleted } from '../../../base/node/pfs.js';
@@ -45,6 +50,10 @@ export class LaunchMainService implements ILaunchMainService {
 		@IWindowsMainService private readonly windowsMainService: IWindowsMainService,
 		@IURLService private readonly urlService: IURLService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
+		// --- Start Positron ---
+		@IAuxiliaryWindowsMainService private readonly auxiliaryWindowsMainService: IAuxiliaryWindowsMainService,
+		@IPositronStandaloneModeMainService private readonly positronStandaloneModeMainService: IPositronStandaloneModeMainService,
+		// --- End Positron ---
 	) { }
 
 	async start(args: NativeParsedArgs, userEnv: IProcessEnvironment): Promise<void> {
@@ -150,6 +159,21 @@ export class LaunchMainService implements ILaunchMainService {
 
 		// Start without file/folder arguments
 		else if (!args._.length && !args['folder-uri'] && !args['file-uri']) {
+			// --- Start Positron ---
+			// A bare relaunch while standalone mode is engaged means "bring
+			// Positron forward", and the product surface is the engaged
+			// window; falling through would reveal the hidden IDE.
+			if (this.positronStandaloneModeMainService.isEngaged) {
+				this.logService.info('[standalone mode] Focusing the engaged window for an argumentless launch');
+				const lastActiveAuxiliaryWindow = this.auxiliaryWindowsMainService.getLastActiveWindow();
+				if (lastActiveAuxiliaryWindow && !this.positronStandaloneModeMainService.isEngagedElsewhere(lastActiveAuxiliaryWindow.parentId)) {
+					lastActiveAuxiliaryWindow.focus();
+				} else {
+					this.windowsMainService.getWindows().find(window => !this.positronStandaloneModeMainService.isEngagedElsewhere(window.id))?.focus();
+				}
+				return;
+			}
+			// --- End Positron ---
 			let openNewWindow = false;
 
 			// Force new window
@@ -205,7 +229,12 @@ export class LaunchMainService implements ILaunchMainService {
 
 		// Start with file/folder arguments
 		else {
-			usedWindows = await this.windowsMainService.open({
+			// --- Start Positron ---
+			// An open landing behind an engaged standalone mode window would
+			// reveal the hidden IDE, so it is routed through
+			// `handleExternalOpen`.
+			const openWithArguments = () => this.windowsMainService.open({
+				// --- End Positron ---
 				...baseConfig,
 				forceNewWindow: args['new-window'],
 				preferNewWindow: !args['reuse-window'] && !args.wait,
@@ -217,6 +246,19 @@ export class LaunchMainService implements ILaunchMainService {
 				noRecentEntry: !!args['skip-add-to-recently-opened'],
 				gotoLineMode: args.goto
 			});
+			// --- Start Positron ---
+			let opening: Promise<ICodeWindow[]> | undefined;
+			// `opening` is assigned before `handleExternalOpen` resolves,
+			// even when the open first waits out an engaged window's exit.
+			await this.positronStandaloneModeMainService.handleExternalOpen(
+				() => { opening = openWithArguments(); },
+				(engagedWindowId, exitCommandId) => this.windowsMainService.getWindowById(engagedWindowId)?.sendWhenReady('vscode:runAction', CancellationToken.None, {
+					id: exitCommandId,
+					from: 'menu',
+				})
+			);
+			usedWindows = opening ? await opening : [];
+			// --- End Positron ---
 		}
 
 		// If the other instance is waiting to be killed, we hook up a window listener if one window

--- a/src/vs/platform/menubar/electron-main/menubar.ts
+++ b/src/vs/platform/menubar/electron-main/menubar.ts
@@ -26,6 +26,9 @@ import { INativeRunActionInWindowRequest, INativeRunKeybindingInWindowRequest, I
 import { IWindowsCountChangedEvent, IWindowsMainService, OpenContext } from '../../windows/electron-main/windows.js';
 import { IWorkspacesHistoryMainService } from '../../workspaces/electron-main/workspacesHistoryMainService.js';
 import { Disposable } from '../../../base/common/lifecycle.js';
+// --- Start Positron ---
+import { IPositronStandaloneModeMainService } from '../../positronStandaloneMode/common/positronStandaloneMode.js';
+// --- End Positron ---
 
 const telemetryFrom = 'menu';
 
@@ -78,7 +81,10 @@ export class Menubar extends Disposable {
 		@ILogService private readonly logService: ILogService,
 		@INativeHostMainService private readonly nativeHostMainService: INativeHostMainService,
 		@IProductService private readonly productService: IProductService,
-		@IAuxiliaryWindowsMainService private readonly auxiliaryWindowsMainService: IAuxiliaryWindowsMainService
+		@IAuxiliaryWindowsMainService private readonly auxiliaryWindowsMainService: IAuxiliaryWindowsMainService,
+		// --- Start Positron ---
+		@IPositronStandaloneModeMainService private readonly positronStandaloneModeMainService: IPositronStandaloneModeMainService
+		// --- End Positron ---
 	) {
 		super();
 
@@ -184,6 +190,12 @@ export class Menubar extends Disposable {
 		// Rebuild menu when update state changes so update menu items reflect
 		// the current state (e.g. "Restart to Update" instead of "Check for Updates...").
 		this._register(this.updateService.onStateChange(() => this.scheduleUpdateMenu()));
+
+		// --- Start Positron ---
+		// Swap between the full menu and the standalone mode menu as the mode
+		// engages and releases.
+		this._register(this.positronStandaloneModeMainService.onDidChange(() => this.scheduleUpdateMenu()));
+		// --- End Positron ---
 	}
 
 	private get currentEnableMenuBarMnemonics(): boolean {
@@ -268,6 +280,17 @@ export class Menubar extends Disposable {
 			this.oldMenus.push(oldMenu);
 		}
 
+		// --- Start Positron ---
+		// While standalone mode is engaged, the IDE's menus would operate a
+		// window the user is not supposed to see -- and with an auxiliary
+		// window focused the fallback handlers even act from the main process.
+		// Present a minimal menu until the mode releases.
+		if (this.positronStandaloneModeMainService.isEngaged) {
+			this.installStandaloneModeMenu();
+			return;
+		}
+		// --- End Positron ---
+
 		// If we don't have a menu yet, set it to null to avoid the electron menu.
 		// This should only happen on the first launch ever
 		if (Object.keys(this.menubarMenus).length === 0) {
@@ -292,7 +315,20 @@ export class Menubar extends Disposable {
 			this.appMenuInstalled = true;
 
 			const dockMenu = new Menu();
-			dockMenu.append(new MenuItem({ label: this.mnemonicLabel(nls.localize({ key: 'miNewWindow', comment: ['&& denotes a mnemonic'] }, "New &&Window")), click: () => this.windowsMainService.openEmptyWindow({ context: OpenContext.DOCK }) }));
+			// --- Start Positron ---
+			// dockMenu.append(new MenuItem({ label: this.mnemonicLabel(nls.localize({ key: 'miNewWindow', comment: ['&& denotes a mnemonic'] }, "New &&Window")), click: () => this.windowsMainService.openEmptyWindow({ context: OpenContext.DOCK }) }));
+			// The Dock menu installs once and never rebuilds, so it cannot be
+			// swapped while standalone mode is engaged; guard the handler
+			// instead.
+			dockMenu.append(new MenuItem({
+				label: this.mnemonicLabel(nls.localize({ key: 'miNewWindow', comment: ['&& denotes a mnemonic'] }, "New &&Window")), click: () => {
+					if (this.positronStandaloneModeMainService.isEngaged) {
+						return;
+					}
+					this.windowsMainService.openEmptyWindow({ context: OpenContext.DOCK });
+				}
+			}));
+			// --- End Positron ---
 
 			app.dock!.setMenu(dockMenu);
 		}
@@ -404,6 +440,54 @@ export class Menubar extends Disposable {
 			}
 		}
 	}
+
+	// --- Start Positron ---
+	/**
+	 * The application menu while standalone mode is engaged: the application
+	 * menu itself for hiding and quitting, and an Edit menu of native
+	 * text-editing roles so the clipboard keeps its accelerators inside the
+	 * standalone webview. Everything that would open, reveal, or operate the
+	 * IDE is left out; `install()` rebuilds the full menus once the mode
+	 * releases.
+	 */
+	private installStandaloneModeMenu(): void {
+		if (!isMacintosh) {
+			// The window-drawn menubar takes this path too on Windows and
+			// Linux; no native menu means nothing to trim.
+			this.doSetApplicationMenu(null);
+			return;
+		}
+
+		const menubar = new Menu();
+
+		const applicationMenu = new Menu();
+		applicationMenu.append(new MenuItem({ label: nls.localize('mHide', "Hide {0}", this.productService.nameLong), role: 'hide', accelerator: 'Command+H' }));
+		applicationMenu.append(new MenuItem({ label: nls.localize('mHideOthers', "Hide Others"), role: 'hideOthers', accelerator: 'Command+Alt+H' }));
+		applicationMenu.append(new MenuItem({ label: nls.localize('mShowAll', "Show All"), role: 'unhide' }));
+		applicationMenu.append(__separator__());
+		applicationMenu.append(new MenuItem(this.likeAction('workbench.action.quit', {
+			label: nls.localize('miQuit', "Quit {0}", this.productService.nameLong),
+			click: async (_item, _window, event) => {
+				if (await this.confirmBeforeQuit(event)) {
+					this.nativeHostMainService.quit(undefined);
+				}
+			}
+		})));
+		menubar.append(new MenuItem({ label: this.productService.nameShort, submenu: applicationMenu }));
+
+		const editMenu = new Menu();
+		editMenu.append(new MenuItem({ role: 'undo' }));
+		editMenu.append(new MenuItem({ role: 'redo' }));
+		editMenu.append(__separator__());
+		editMenu.append(new MenuItem({ role: 'cut' }));
+		editMenu.append(new MenuItem({ role: 'copy' }));
+		editMenu.append(new MenuItem({ role: 'paste' }));
+		editMenu.append(new MenuItem({ role: 'selectAll' }));
+		menubar.append(new MenuItem({ label: nls.localize('positron.standaloneMode.editMenu', "Edit"), submenu: editMenu }));
+
+		this.doSetApplicationMenu(menubar);
+	}
+	// --- End Positron ---
 
 	private setMacApplicationMenu(macApplicationMenu: Menu): void {
 		const about = this.createMenuItem(nls.localize('mAbout', "About {0}", this.productService.nameLong), 'workbench.action.showAboutDialog');

--- a/src/vs/platform/positronStandaloneMode/common/positronStandaloneMode.ts
+++ b/src/vs/platform/positronStandaloneMode/common/positronStandaloneMode.ts
@@ -1,0 +1,68 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Event } from '../../../base/common/event.js';
+import { createDecorator } from '../../instantiation/common/instantiation.js';
+
+export const POSITRON_STANDALONE_MODE_CHANNEL_NAME = 'positronStandaloneMode';
+
+/**
+ * The main process's record of standalone mode: which window, if any, is
+ * presenting a single view as the whole product surface. The renderer that
+ * enters the mode reports engagement here; the main process reads it to keep
+ * the mode single-instance, trim the native menus, and route external opens.
+ */
+export interface IPositronStandaloneModeState {
+	/**
+	 * Atomically claim the mode for a window. Resolves `true` when the window
+	 * now holds the engagement, including when it already held it, so re-entry
+	 * in the engaged window stays legitimate. Resolves `false`, and changes
+	 * nothing, when another window holds it.
+	 *
+	 * @param exitCommandId the workbench command that leaves the mode in the
+	 * engaging window. Declared at acquire time so the main process can ask
+	 * the mode to stand down (for an externally requested open) without
+	 * knowing which feature engaged it.
+	 */
+	acquire(windowId: number, exitCommandId: string): Promise<boolean>;
+
+	/** Give up the engagement. Only the holder's release changes anything. */
+	release(windowId: number): Promise<void>;
+}
+
+export const IPositronStandaloneModeMainService = createDecorator<IPositronStandaloneModeMainService>('positronStandaloneModeMainService');
+
+export interface IPositronStandaloneModeMainService extends IPositronStandaloneModeState {
+	readonly _serviceBrand: undefined;
+
+	/** Fires when the mode is engaged or released in any window. */
+	readonly onDidChange: Event<void>;
+
+	/** Whether any window currently presents the mode. */
+	readonly isEngaged: boolean;
+
+	/**
+	 * Whether a window other than the given one presents the mode: re-entry
+	 * in the engaged window is legitimate, a second window is a duplicate
+	 * product surface.
+	 */
+	isEngagedElsewhere(windowId: number): boolean;
+
+	/**
+	 * Route an externally requested open. While engaged, `exitMode` is asked
+	 * to run the engagement's declared exit
+	 * command in the engaged window, and `open` waits for the engagement to
+	 * actually release -- bounded by `EXTERNAL_OPEN_EXIT_WAIT` so an
+	 * unresponsive window cannot swallow the user's open.
+	 */
+	handleExternalOpen(open: () => void, exitMode: (engagedWindowId: number, exitCommandId: string) => void): Promise<void>;
+}
+
+/**
+ * How long an external open waits for the engaged window to release before
+ * proceeding anyway: generous next to an ordinary exit, but bounded so a hung
+ * renderer cannot swallow the open.
+ */
+export const EXTERNAL_OPEN_EXIT_WAIT = 10_000;

--- a/src/vs/platform/positronStandaloneMode/common/positronStandaloneModeIpc.ts
+++ b/src/vs/platform/positronStandaloneMode/common/positronStandaloneModeIpc.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../base/common/cancellation.js';
+import { Event } from '../../../base/common/event.js';
+import { IChannel, IServerChannel } from '../../../base/parts/ipc/common/ipc.js';
+import { IPositronStandaloneModeState } from './positronStandaloneMode.js';
+
+/**
+ * Server-side IPC channel over which a window reports standalone mode
+ * engagement to the main process.
+ */
+export class PositronStandaloneModeChannel implements IServerChannel {
+
+	constructor(private readonly service: IPositronStandaloneModeState) { }
+
+	async call<T>(_ctx: unknown, command: string, args?: unknown, _cancellationToken?: CancellationToken): Promise<T> {
+		switch (command) {
+			case 'acquire': {
+				const [windowId, exitCommandId] = args as [number, string];
+				return await this.service.acquire(windowId, exitCommandId) as T;
+			}
+			case 'release': {
+				const [windowId] = args as [number];
+				return await this.service.release(windowId) as T;
+			}
+		}
+		throw new Error(`Command not found: ${command}`);
+	}
+
+	listen<T>(_ctx: unknown, _event: string, _arg?: unknown): Event<T> {
+		throw new Error('Method not implemented.');
+	}
+}
+
+/**
+ * Client-side channel a window uses to claim and release standalone mode.
+ */
+export class PositronStandaloneModeChannelClient implements IPositronStandaloneModeState {
+
+	constructor(private readonly channel: IChannel) { }
+
+	acquire(windowId: number, exitCommandId: string): Promise<boolean> {
+		return this.channel.call('acquire', [windowId, exitCommandId]);
+	}
+
+	release(windowId: number): Promise<void> {
+		return this.channel.call('release', [windowId]);
+	}
+}

--- a/src/vs/platform/positronStandaloneMode/electron-main/positronStandaloneModeMainService.ts
+++ b/src/vs/platform/positronStandaloneMode/electron-main/positronStandaloneModeMainService.ts
@@ -1,0 +1,134 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { app, BrowserWindow } from 'electron';
+import { Emitter, Event } from '../../../base/common/event.js';
+import { Disposable } from '../../../base/common/lifecycle.js';
+import { ILogService } from '../../log/common/log.js';
+import { EXTERNAL_OPEN_EXIT_WAIT, IPositronStandaloneModeMainService } from '../common/positronStandaloneMode.js';
+
+export class PositronStandaloneModeMainService extends Disposable implements IPositronStandaloneModeMainService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _onDidChange = this._register(new Emitter<void>());
+	readonly onDidChange: Event<void> = this._onDidChange.event;
+
+	/**
+	 * The window presenting standalone mode and the command that exits the
+	 * mode there, when there is one.
+	 */
+	private engagement: { windowId: number; exitCommandId: string } | undefined = undefined;
+
+	private get engagedWindowId(): number | undefined {
+		return this.engagement?.windowId;
+	}
+
+	constructor(
+		@ILogService private readonly logService: ILogService
+	) {
+		super();
+
+		// A window that goes away without releasing its claim must not leave
+		// the mode engaged forever. Reload and a dead renderer keep the
+		// BrowserWindow while discarding the renderer that held the claim, so
+		// all three paths release; a reloaded window re-enters through its
+		// restored intent. Watched per window because the bundled electron
+		// typings expose no application-level closed event.
+		const onWindowCreated = (_event: Electron.Event, window: BrowserWindow) => {
+			const windowId = window.id;
+			const releaseIfHeld = () => {
+				if (windowId === this.engagedWindowId) {
+					this.doRelease(windowId);
+				}
+			};
+			window.on('closed', releaseIfHeld);
+			window.webContents.on('did-navigate', releaseIfHeld);
+			window.webContents.on('render-process-gone', releaseIfHeld);
+		};
+		app.on('browser-window-created', onWindowCreated);
+		this._register({ dispose: () => app.removeListener('browser-window-created', onWindowCreated) });
+	}
+
+	get isEngaged(): boolean {
+		return this.engagedWindowId !== undefined;
+	}
+
+	isEngagedElsewhere(windowId: number): boolean {
+		return this.engagedWindowId !== undefined && this.engagedWindowId !== windowId;
+	}
+
+	async acquire(windowId: number, exitCommandId: string): Promise<boolean> {
+		if (this.engagedWindowId !== undefined && this.engagedWindowId !== windowId) {
+			this.logService.info(`[standalone mode] Window ${windowId} asked to engage while window ${this.engagedWindowId} holds the mode`);
+			return false;
+		}
+		if (this.engagedWindowId !== windowId) {
+			this.engagement = { windowId, exitCommandId };
+			this.logService.trace(`[standalone mode] Engaged in window ${windowId}`);
+			this._onDidChange.fire();
+		} else if (this.engagement?.exitCommandId !== exitCommandId) {
+			// A successful reacquire redeclares the command used by future opens.
+			this.engagement = { windowId, exitCommandId };
+		}
+		return true;
+	}
+
+	async release(windowId: number): Promise<void> {
+		this.doRelease(windowId);
+	}
+
+	private doRelease(windowId: number): void {
+		if (this.engagedWindowId !== windowId) {
+			return;
+		}
+		this.engagement = undefined;
+		this.logService.trace('[standalone mode] Released');
+		this._onDidChange.fire();
+	}
+
+	async handleExternalOpen(open: () => void, exitMode: (engagedWindowId: number, exitCommandId: string) => void): Promise<void> {
+		const engagement = this.engagement;
+		if (!engagement) {
+			open();
+			return;
+		}
+
+		this.logService.info('[standalone mode] Leaving the mode for an externally requested open');
+		exitMode(engagement.windowId, engagement.exitCommandId);
+
+		// Opening into a reused window can reload the very renderer still
+		// running the exit, so wait for the claim to drop, but never indefinitely.
+		if (!await this.waitForRelease(EXTERNAL_OPEN_EXIT_WAIT)) {
+			this.logService.warn(`[standalone mode] Not released within ${EXTERNAL_OPEN_EXIT_WAIT}ms; opening anyway`);
+		}
+		open();
+	}
+
+	/**
+	 * Resolves `true` once no window holds the claim, `false` after
+	 * `timeoutMs`. Hand-rolled so the listener is dropped on the timeout path
+	 * too; a listener per timed-out open would accumulate.
+	 */
+	private waitForRelease(timeoutMs: number): Promise<boolean> {
+		if (!this.isEngaged) {
+			return Promise.resolve(true);
+		}
+		return new Promise<boolean>(resolve => {
+			const listener = this.onDidChange(() => {
+				if (!this.isEngaged) {
+					clearTimeout(timer);
+					listener.dispose();
+					resolve(true);
+				}
+			});
+			const timer = setTimeout(() => {
+				listener.dispose();
+				resolve(false);
+			}, timeoutMs);
+		});
+	}
+
+}

--- a/src/vs/platform/positronStandaloneMode/test/electron-main/positronStandaloneModeMainService.vitest.ts
+++ b/src/vs/platform/positronStandaloneMode/test/electron-main/positronStandaloneModeMainService.vitest.ts
@@ -1,0 +1,172 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { ensureNoLeakedDisposables } from '../../../../test/vitest/vitestUtils.js';
+import { NullLogService } from '../../../log/common/log.js';
+import { EXTERNAL_OPEN_EXIT_WAIT } from '../../common/positronStandaloneMode.js';
+import { PositronStandaloneModeMainService } from '../../electron-main/positronStandaloneModeMainService.js';
+
+// The service watches windows through electron's app; the tests drive those
+// watchers by invoking the captured `browser-window-created` handler with a
+// hand-made window, since electron's real objects cannot exist outside the
+// main process.
+const { electronApp } = vi.hoisted(() => ({
+	electronApp: {
+		listeners: new Map<string, (...args: unknown[]) => void>(),
+		on(event: string, listener: (...args: unknown[]) => void) { this.listeners.set(event, listener); },
+		removeListener(event: string) { this.listeners.delete(event); },
+	}
+}));
+vi.mock('electron', () => ({ app: electronApp, BrowserWindow: class { } }));
+
+/** A window as far as the service's watchers are concerned. */
+function createWindow(id: number) {
+	const windowListeners = new Map<string, () => void>();
+	const webContentsListeners = new Map<string, () => void>();
+	const window = {
+		id,
+		on: (event: string, listener: () => void) => windowListeners.set(event, listener),
+		webContents: { on: (event: string, listener: () => void) => webContentsListeners.set(event, listener) },
+	};
+	electronApp.listeners.get('browser-window-created')?.(undefined, window);
+	return {
+		close: () => windowListeners.get('closed')?.(),
+		reload: () => webContentsListeners.get('did-navigate')?.(),
+		crash: () => webContentsListeners.get('render-process-gone')?.(),
+	};
+}
+
+describe('PositronStandaloneModeMainService', () => {
+	const disposables = ensureNoLeakedDisposables();
+
+	function build() {
+		return disposables.add(new PositronStandaloneModeMainService(new NullLogService()));
+	}
+
+	it('grants the claim to one window and denies the other', async () => {
+		const service = build();
+
+		expect(await service.acquire(1, 'test.exit')).toBe(true);
+		expect(await service.acquire(2, 'test.exit')).toBe(false);
+
+		// The loser's failed claim must not have disturbed the holder.
+		expect(service.isEngaged).toBe(true);
+		expect(service.isEngagedElsewhere(1)).toBe(false);
+		expect(service.isEngagedElsewhere(2)).toBe(true);
+	});
+
+	it('lets the holder reclaim without a release in between', async () => {
+		const service = build();
+
+		expect(await service.acquire(1, 'test.exit')).toBe(true);
+		expect(await service.acquire(1, 'test.exit')).toBe(true);
+	});
+
+	it('uses the exit command declared by the holder\'s latest acquire', async () => {
+		const service = build();
+		await service.acquire(1, 'test.oldExit');
+		await service.acquire(1, 'test.newExit');
+		const exitMode = vi.fn(() => void service.release(1));
+
+		await service.handleExternalOpen(vi.fn(), exitMode);
+
+		expect(exitMode).toHaveBeenCalledWith(1, 'test.newExit');
+	});
+
+	it('ignores a release from a window that does not hold the claim', async () => {
+		const service = build();
+		await service.acquire(1, 'test.exit');
+
+		await service.release(2);
+
+		expect(service.isEngaged).toBe(true);
+	});
+
+	it('frees the claim for the next window once the holder releases', async () => {
+		const service = build();
+		await service.acquire(1, 'test.exit');
+
+		await service.release(1);
+
+		expect(service.isEngaged).toBe(false);
+		expect(await service.acquire(2, 'test.exit')).toBe(true);
+	});
+
+	it('releases the claim when the engaged window closes, reloads, or loses its renderer', async () => {
+		for (const goAway of ['close', 'reload', 'crash'] as const) {
+			const service = build();
+			const window = createWindow(7);
+			await service.acquire(7, 'test.exit');
+
+			window[goAway]();
+
+			expect(service.isEngaged).toBe(false);
+		}
+	});
+
+	it('keeps the claim when an unrelated window goes away', async () => {
+		const service = build();
+		const bystander = createWindow(8);
+		await service.acquire(7, 'test.exit');
+
+		bystander.close();
+
+		expect(service.isEngaged).toBe(true);
+	});
+
+	it('opens an external request only after the engaged window released', async () => {
+		const service = build();
+		await service.acquire(1, 'test.exit');
+
+		const order: string[] = [];
+		const handled = service.handleExternalOpen(
+			() => order.push('open'),
+			// The exit callback is fire-and-forget toward the renderer; the
+			// release arrives later, the way a real exit reports back.
+			() => queueMicrotask(() => {
+				order.push('release');
+				void service.release(1);
+			})
+		);
+
+		await handled;
+
+		expect(order).toEqual(['release', 'open']);
+		expect(service.isEngaged).toBe(false);
+	});
+
+	it('stops waiting on a hung exit and opens anyway', async () => {
+		vi.useFakeTimers();
+		try {
+			const service = build();
+			await service.acquire(1, 'test.exit');
+
+			const open = vi.fn();
+			const exitMode = vi.fn(); // never releases
+			const handled = service.handleExternalOpen(open, exitMode);
+
+			await vi.advanceTimersByTimeAsync(EXTERNAL_OPEN_EXIT_WAIT);
+			await handled;
+
+			expect(exitMode).toHaveBeenCalledWith(1, 'test.exit');
+			expect(open).toHaveBeenCalledTimes(1);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('opens immediately when the mode is not engaged', async () => {
+		const service = build();
+		const open = vi.fn();
+		const exitMode = vi.fn();
+
+		await service.handleExternalOpen(open, exitMode);
+
+		expect(open).toHaveBeenCalledTimes(1);
+		expect(exitMode).not.toHaveBeenCalled();
+	});
+});

--- a/src/vs/platform/window/common/window.ts
+++ b/src/vs/platform/window/common/window.ts
@@ -469,6 +469,15 @@ export interface INativeWindowConfiguration extends IWindowConfiguration, Native
 	adminPoliciesData?: string; // JSON string of enforced settings from POSITRON_ENFORCED_SETTINGS
 	// --- End PWB ---
 
+	// --- Start Positron ---
+	/**
+	 * Whether another window held standalone mode when this window opened.
+	 * The mode is one surface per application instance, so a window opened
+	 * while it is engaged elsewhere must not enter it itself.
+	 */
+	standaloneModeEngagedElsewhere?: boolean;
+	// --- End Positron ---
+
 	isSessionsWindow?: boolean;
 }
 

--- a/src/vs/platform/windows/electron-main/windowImpl.ts
+++ b/src/vs/platform/windows/electron-main/windowImpl.ts
@@ -40,6 +40,9 @@ import { IWindowState, ICodeWindow, ILoadEvent, WindowMode, WindowError, LoadRea
 import { IPolicyService } from '../../policy/common/policy.js';
 import { IUserDataProfile } from '../../userDataProfile/common/userDataProfile.js';
 import { IStateService } from '../../state/node/state.js';
+// --- Start Positron ---
+import { IPositronStandaloneModeMainService } from '../../positronStandaloneMode/common/positronStandaloneMode.js';
+// --- End Positron ---
 import { IUserDataProfilesMainService } from '../../userDataProfile/electron-main/userDataProfile.js';
 import { ILoggerMainService } from '../../log/electron-main/loggerService.js';
 import { IInstantiationService } from '../../instantiation/common/instantiation.js';
@@ -696,7 +699,10 @@ export class CodeWindow extends BaseWindow implements ICodeWindow {
 		@IProtocolMainService protocolMainService: IProtocolMainService,
 		@IWindowsMainService private readonly windowsMainService: IWindowsMainService,
 		@IStateService stateService: IStateService,
-		@IInstantiationService instantiationService: IInstantiationService
+		@IInstantiationService instantiationService: IInstantiationService,
+		// --- Start Positron ---
+		@IPositronStandaloneModeMainService private readonly positronStandaloneModeMainService: IPositronStandaloneModeMainService
+		// --- End Positron ---
 	) {
 		super(configurationService, stateService, environmentMainService, logService);
 
@@ -1348,6 +1354,14 @@ export class CodeWindow extends BaseWindow implements ICodeWindow {
 		delete configuration.filesToDiff;
 		delete configuration.filesToMerge;
 		delete configuration.filesToWait;
+
+		// --- Start Positron ---
+		// The engagement stamp describes open time; a reload happens later, so
+		// refresh it. Otherwise a window opened while the mode was engaged
+		// elsewhere would stay locked out after that engagement ended, for as
+		// long as it only ever reloaded.
+		configuration.standaloneModeEngagedElsewhere = this.positronStandaloneModeMainService.isEngagedElsewhere(this.id);
+		// --- End Positron ---
 
 		// Some configuration things get inherited if the window is being reloaded and we are
 		// in extension development mode. These options are all development related.

--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -52,6 +52,9 @@ import { IThemeMainService } from '../../theme/electron-main/themeMainService.js
 import { IEditorOptions, ITextEditorOptions } from '../../editor/common/editor.js';
 import { IUserDataProfile } from '../../userDataProfile/common/userDataProfile.js';
 import { IPolicyService } from '../../policy/common/policy.js';
+// --- Start Positron ---
+import { IPositronStandaloneModeMainService } from '../../positronStandaloneMode/common/positronStandaloneMode.js';
+// --- End Positron ---
 import { IUserDataProfilesMainService } from '../../userDataProfile/electron-main/userDataProfile.js';
 import { ILoggerMainService } from '../../log/electron-main/loggerService.js';
 import { IAuxiliaryWindowsMainService } from '../../auxiliaryWindow/electron-main/auxiliaryWindows.js';
@@ -235,7 +238,10 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 		@IProtocolMainService private readonly protocolMainService: IProtocolMainService,
 		@IThemeMainService private readonly themeMainService: IThemeMainService,
 		@IAuxiliaryWindowsMainService private readonly auxiliaryWindowsMainService: IAuxiliaryWindowsMainService,
-		@ICSSDevelopmentService private readonly cssDevelopmentService: ICSSDevelopmentService
+		@ICSSDevelopmentService private readonly cssDevelopmentService: ICSSDevelopmentService,
+		// --- Start Positron ---
+		@IPositronStandaloneModeMainService private readonly positronStandaloneModeMainService: IPositronStandaloneModeMainService
+		// --- End Positron ---
 	) {
 		super();
 
@@ -1540,6 +1546,15 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 			isPortable: this.environmentMainService.isPortable,
 
 			windowId: -1,	// Will be filled in by the window once loaded later
+
+			// --- Start Positron ---
+			// For a reused window, "elsewhere" is relative to that window, so
+			// the holder is not locked out of its own re-entry. Refreshed on
+			// reload (CodeWindow#reload).
+			standaloneModeEngagedElsewhere: window
+				? this.positronStandaloneModeMainService.isEngagedElsewhere(window.id)
+				: this.positronStandaloneModeMainService.isEngaged,
+			// --- End Positron ---
 
 			mainPid: process.pid,
 

--- a/src/vs/workbench/browser/parts/editor/auxiliaryEditorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/auxiliaryEditorPart.ts
@@ -176,6 +176,15 @@ export class AuxiliaryEditorPart {
 				return;
 			}
 
+			// --- Start Positron ---
+			// A `lockCompact` window is chromeless because it is compact, and
+			// compact mode is persisted: letting a stray editor or menu action
+			// switch it off would grow workbench chrome back on every restore.
+			if (options?.lockCompact === true) {
+				return;
+			}
+			// --- End Positron ---
+
 			compact = newCompact;
 			auxiliaryWindow.updateOptions({ compact });
 			titlebarPart?.updateOptions({ compact });

--- a/src/vs/workbench/browser/parts/editor/editorActionBarFactory.tsx
+++ b/src/vs/workbench/browser/parts/editor/editorActionBarFactory.tsx
@@ -13,6 +13,7 @@ import { Emitter } from '../../../../base/common/event.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { Disposable, DisposableMap, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { EditorResourceAccessor, SideBySideEditor } from '../../../common/editor.js';
+import { CANVAS_WEBVIEW_VIEW_TYPE } from '../../../common/positronCanvasIdentity.js';
 import { IAction, Separator, SubmenuAction } from '../../../../base/common/actions.js';
 import { actionTooltip } from '../../../../platform/positronActionBar/common/helpers.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
@@ -199,17 +200,22 @@ export class EditorActionBarFactory extends Disposable {
 		];
 
 		// Splice the move editor to new window command button into the right action bar elements.
-		rightActionBarElements.splice(
-			rightActionBarElements.length - 1,
-			0,
-			<ActionBarCommandButton
-				ariaLabel={positronMoveIntoNewWindowAriaLabel}
-				commandId='workbench.action.moveEditorToNewWindow'
-				disabled={auxiliaryWindow}
-				icon={ThemeIcon.fromId('positron-open-in-new-window')}
-				tooltip={positronMoveIntoNewWindowTooltip}
-			/>
-		);
+		// Not for Canvas panels: their action bar carries "Open Canvas" instead
+		// (positronCanvas.contribution.ts), and a plain detached editor window
+		// is the degraded shape of what that button opens.
+		if (this.contextKeyService.getContextKeyValue<string>('activeWebviewPanelId') !== CANVAS_WEBVIEW_VIEW_TYPE) {
+			rightActionBarElements.splice(
+				rightActionBarElements.length - 1,
+				0,
+				<ActionBarCommandButton
+					ariaLabel={positronMoveIntoNewWindowAriaLabel}
+					commandId='workbench.action.moveEditorToNewWindow'
+					disabled={auxiliaryWindow}
+					icon={ThemeIcon.fromId('positron-open-in-new-window')}
+					tooltip={positronMoveIntoNewWindowTooltip}
+				/>
+			);
+		}
 
 		// Return the action bar.
 		return (

--- a/src/vs/workbench/common/positronCanvasIdentity.ts
+++ b/src/vs/workbench/common/positronCanvasIdentity.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Webview panel view type of a Posit Assistant Canvas panel -- the whole of
+ * Canvas-panel identity. Comparing a `WebviewInput.providerId` against it is
+ * the declared way to recognize a Canvas, synchronously and without activating
+ * the extension. Lives in workbench/common (not the positronCanvas contrib)
+ * because the editor part needs it too and cannot import from contrib. Part of
+ * the cross-repo seam documented in contrib/positronCanvas/README.md.
+ */
+export const CANVAS_WEBVIEW_VIEW_TYPE = 'posit-assistant.canvas';

--- a/src/vs/workbench/contrib/positronCanvas/README.md
+++ b/src/vs/workbench/contrib/positronCanvas/README.md
@@ -1,0 +1,43 @@
+# Positron Canvas mode
+
+Canvas mode presents Posit Assistant's Canvas panel as the whole product: one
+conversation in a chromeless standalone window, with the IDE window minimized.
+Positron owns windows, groups, focus, and the mode transaction; the assistant
+owns Canvas content, panel identity, singleton-ness, and UI readiness. When a
+new command is needed in either direction, ask which side owns the fact, not
+which side finds it convenient to act.
+
+## The command seam
+
+The cross-repo subset below also lives in the assistant repo at
+`packages/positron/src/frontend-canvas/README.md`; change that subset in both
+places. Positron's full public namespace is pinned by
+`test/electron-browser/positronCanvasCommands.vitest.ts`.
+
+Registered by Positron, called by the assistant:
+
+- `positron.canvas.enter` - plain command, the assistant's API into Canvas
+  mode. Returns a `CanvasEntryOutcome` (`common/positronCanvasMode.ts`) and
+  never notifies; presentation belongs to the caller.
+- `positron.canvas.exit` - palette action, deliberately unbound: Escape is
+  pressed constantly in a chat UI, and a chord that swaps the whole product
+  surface is worse than no shortcut. The user-facing way out is the Canvas
+  top bar's "Open Positron" control. Resolves `true` only when it actually
+  left Canvas mode; the assistant treats anything else as a failed exit.
+- `positron.canvas.isActive` - plain command; whether Canvas is the only
+  visible surface. Gates the Canvas UI's "Open Positron" control.
+
+Registered by Positron for its own UI:
+
+- `positron.canvas.open` - Canvas editor-action command. Same service call as
+  `positron.canvas.enter`, but it owns the failure notification. Deliberately
+  absent from the palette: a Canvas-capable assistant owns discovery through
+  its `posit-assistant.openCanvas` command, so older assistants expose nothing.
+
+Registered by the assistant, called by Positron:
+
+- `posit-assistant.ensureCanvas` - ensures the singleton Canvas panel,
+  resolving only when its UI is ready and rejecting when Canvas is unavailable
+  or failed. Positron invokes it before trusting even a restored panel.
+- View type `posit-assistant.canvas` - the whole of Canvas-panel identity;
+  `PositronCanvasService` recognizes a Canvas by `providerId` alone.

--- a/src/vs/workbench/contrib/positronCanvas/browser/positronCanvasCommandLockdown.ts
+++ b/src/vs/workbench/contrib/positronCanvas/browser/positronCanvasCommandLockdown.ts
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { KeyChord, KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
+import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
+import { KeybindingsRegistry, KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { PositronCanvasModeActiveContext } from '../common/positronCanvasMode.js';
+
+/**
+ * Swallowed chords resolve to this no-op instead of their commands, so the
+ * keys are consumed rather than falling through to whatever sits under the
+ * webview (a removal rule cannot carry a `when` clause). Deliberately outside
+ * the pinned `positron.canvas.*` seam namespace: this command is internal.
+ */
+const SUPPRESSED_KEY_COMMAND = 'positronCanvasLockdown.suppressedKey';
+
+/**
+ * Keeps the IDE's command surface out of reach while Canvas mode is active: a
+ * narrow deny list of the escapes demonstrated in smoke testing (palette,
+ * quick open, new/opened editors, new windows), gated on
+ * `PositronCanvasModeActiveContext`, not a policy layer over all commands.
+ * The chords mirror the denied commands' default bindings; a custom user
+ * binding is deliberately respected as an explicit instruction. The native
+ * menu is trimmed separately (Menubar#install), and OS-level opens are routed
+ * in the main process (LaunchMainService).
+ */
+export function registerCanvasCommandLockdown(): void {
+	CommandsRegistry.registerCommand(SUPPRESSED_KEY_COMMAND, () => { });
+
+	// One entry per denied command, carrying that command's default chords.
+	const suppressed: { primary: number; secondary?: number[]; mac?: { primary: number; secondary?: number[] } }[] = [
+		// workbench.action.showCommands (Positron already unbinds its F1
+		// secondary in favor of Show Help at Cursor).
+		{ primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyP },
+		// workbench.action.quickOpen
+		{
+			primary: KeyMod.CtrlCmd | KeyCode.KeyP,
+			secondary: [KeyMod.CtrlCmd | KeyCode.KeyE],
+			mac: { primary: KeyMod.CtrlCmd | KeyCode.KeyP, secondary: undefined }
+		},
+		// workbench.action.files.newUntitledFile
+		{ primary: KeyMod.CtrlCmd | KeyCode.KeyN },
+		// workbench.action.newWindow
+		{ primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyN },
+		// workbench.action.files.openFile / openFolder (Windows, Linux) and
+		// openFileFolder (macOS) share Ctrl/Cmd+O; openFolder adds a chord.
+		{
+			primary: KeyMod.CtrlCmd | KeyCode.KeyO,
+			secondary: [KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyO)],
+			mac: { primary: KeyMod.CtrlCmd | KeyCode.KeyO, secondary: undefined }
+		},
+		// workbench.action.openRecent opens another folder in a new window
+		// from the quick pick.
+		{
+			primary: KeyMod.CtrlCmd | KeyCode.KeyR,
+			mac: { primary: KeyMod.WinCtrl | KeyCode.KeyR }
+		}
+	];
+
+	for (const keybinding of suppressed) {
+		KeybindingsRegistry.registerKeybindingRule({
+			...keybinding,
+			id: SUPPRESSED_KEY_COMMAND,
+			// Above the denied commands' own WorkbenchContrib-weight rules, so
+			// this rule wins while its `when` holds without depending on
+			// registration order.
+			weight: KeybindingWeight.WorkbenchContrib + 50,
+			when: PositronCanvasModeActiveContext
+		});
+	}
+}

--- a/src/vs/workbench/contrib/positronCanvas/common/positronCanvasMode.ts
+++ b/src/vs/workbench/contrib/positronCanvas/common/positronCanvasMode.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../../nls.js';
+import { RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
+
+// The `positron.canvas.*` commands and `CANVAS_WEBVIEW_VIEW_TYPE` are the seam
+// between Positron and Posit Assistant; ../README.md is the canonical
+// description, mirrored in the assistant repo's `frontend-canvas/README.md`.
+
+export { CANVAS_WEBVIEW_VIEW_TYPE } from '../../../common/positronCanvasIdentity.js';
+
+/**
+ * How an attempt to enter Canvas mode ended. Data rather than an exception so
+ * every caller (palette action, the assistant over the command seam) can
+ * present each non-entry case with the right copy.
+ */
+export type CanvasEntryOutcome =
+	| { readonly entered: true }
+	| {
+		readonly entered: false;
+		/**
+		 * `ai-disabled`: the `ai.enabled` switch is off.
+		 * `engaged-elsewhere`: another window already presents Canvas.
+		 * `no-panel`: Posit Assistant did not produce a Canvas panel.
+		 * `no-window`: the panel could not get a window of its own, or the
+		 * IDE window could not be put away behind it.
+		 * `superseded`: the user asked for the IDE back mid-entry.
+		 */
+		readonly reason: 'ai-disabled' | 'engaged-elsewhere' | 'no-panel' | 'no-window' | 'superseded';
+		/** Localized, user-presentable description of the reason. */
+		readonly message: string;
+	};
+
+/**
+ * Set while Canvas is the only surface the user can see. Gates the action
+ * that hands the user back to the IDE.
+ */
+export const PositronCanvasModeActiveContext = new RawContextKey<boolean>('positronCanvasModeActive', false, localize('positron.canvas.modeActiveContext', "Whether Canvas is currently the only visible Positron surface."));
+
+/**
+ * Command id of the action that exits Canvas mode; part of the pinned
+ * `positron.canvas.*` seam (../README.md). Also declared to the main process
+ * as standalone mode's exit command at engagement time, so an externally
+ * requested open can ask Canvas to stand down without the main process
+ * knowing about Canvas.
+ */
+export const CANVAS_EXIT_COMMAND_ID = 'positron.canvas.exit';

--- a/src/vs/workbench/contrib/positronCanvas/electron-browser/positronCanvas.contribution.ts
+++ b/src/vs/workbench/contrib/positronCanvas/electron-browser/positronCanvas.contribution.ts
@@ -1,0 +1,107 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Codicon } from '../../../../base/common/codicons.js';
+import { localize2 } from '../../../../nls.js';
+import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';
+import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
+import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { INotificationService } from '../../../../platform/notification/common/notification.js';
+import { AI_ENABLED_KEY } from '../../positronAssistant/common/positronAIConfiguration.js';
+import { registerCanvasCommandLockdown } from '../browser/positronCanvasCommandLockdown.js';
+import { CANVAS_EXIT_COMMAND_ID, CANVAS_WEBVIEW_VIEW_TYPE, PositronCanvasModeActiveContext } from '../common/positronCanvasMode.js';
+import { IPositronCanvasService, PositronCanvasService } from './positronCanvasService.js';
+
+registerSingleton(IPositronCanvasService, PositronCanvasService, InstantiationType.Delayed);
+
+/**
+ * Enters Canvas mode from the Canvas editor's action bar. The assistant owns
+ * palette discovery, so Positron stays dormant when the installed assistant
+ * does not provide Canvas. Both entry points land on the same service call;
+ * this action adds the presentation of not getting in.
+ */
+class OpenCanvasAction extends Action2 {
+
+	static readonly ID = 'positron.canvas.open';
+
+	constructor() {
+		super({
+			id: OpenCanvasAction.ID,
+			title: localize2('positron.canvas.open', "Open Canvas"),
+			category: Categories.View,
+			f1: false,
+			precondition: ContextKeyExpr.has(`config.${AI_ENABLED_KEY}`),
+			icon: Codicon.screenFull,
+			menu: [{
+				// Shown where the active editor is a Canvas panel, in place of
+				// the standard move-into-new-window button, which is suppressed
+				// for Canvas (editorActionBarFactory.tsx).
+				id: MenuId.EditorActionsRight,
+				group: 'navigation',
+				when: ContextKeyExpr.and(
+					ContextKeyExpr.equals('activeWebviewPanelId', CANVAS_WEBVIEW_VIEW_TYPE),
+					ContextKeyExpr.has(`config.${AI_ENABLED_KEY}`)
+				)
+			}]
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const canvasService = accessor.get(IPositronCanvasService);
+		const notificationService = accessor.get(INotificationService);
+		const outcome = await canvasService.enter();
+		if (!outcome.entered) {
+			// A notification: the user asked from inside a working IDE.
+			notificationService.error(outcome.message);
+		}
+	}
+}
+
+/**
+ * Leaves Canvas mode for the full IDE. Deliberately unbound: Escape is pressed
+ * constantly in a chat UI, and a chord that swaps the whole product surface is
+ * worse than no shortcut. The way out is Canvas's own "Open Positron" control.
+ */
+class ExitCanvasModeAction extends Action2 {
+
+	static readonly ID = CANVAS_EXIT_COMMAND_ID;
+
+	constructor() {
+		super({
+			id: ExitCanvasModeAction.ID,
+			title: localize2('positron.canvas.exit', "Exit Canvas to the Positron IDE"),
+			category: Categories.View,
+			f1: true,
+			precondition: PositronCanvasModeActiveContext
+		});
+	}
+
+	override run(accessor: ServicesAccessor): Promise<boolean> {
+		return accessor.get(IPositronCanvasService).exit();
+	}
+}
+
+registerAction2(OpenCanvasAction);
+registerAction2(ExitCanvasModeAction);
+registerCanvasCommandLockdown();
+
+/**
+ * Posit Assistant's way into Canvas mode. A plain command: it returns the
+ * entry outcome and never notifies, so the caller decides the presentation.
+ */
+CommandsRegistry.registerCommand('positron.canvas.enter', (accessor: ServicesAccessor) => {
+	return accessor.get(IPositronCanvasService).enter();
+});
+
+/**
+ * Whether Canvas is being shown as the whole product; gates the Canvas UI's
+ * "Open Positron" control.
+ */
+CommandsRegistry.registerCommand('positron.canvas.isActive', (accessor: ServicesAccessor): boolean => {
+	return accessor.get(IPositronCanvasService).isActive;
+});

--- a/src/vs/workbench/contrib/positronCanvas/electron-browser/positronCanvasService.ts
+++ b/src/vs/workbench/contrib/positronCanvas/electron-browser/positronCanvasService.ts
@@ -1,0 +1,503 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { getActiveWindow } from '../../../../base/browser/dom.js';
+import { mainWindow } from '../../../../base/browser/window.js';
+import { raceTimeout } from '../../../../base/common/async.js';
+import { Event } from '../../../../base/common/event.js';
+import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { localize } from '../../../../nls.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { IMainProcessService } from '../../../../platform/ipc/common/mainProcessService.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { INativeHostService } from '../../../../platform/native/common/native.js';
+import { POSITRON_STANDALONE_MODE_CHANNEL_NAME } from '../../../../platform/positronStandaloneMode/common/positronStandaloneMode.js';
+import { PositronStandaloneModeChannelClient } from '../../../../platform/positronStandaloneMode/common/positronStandaloneModeIpc.js';
+import { prepareMoveCopyEditors } from '../../../browser/parts/editor/editor.js';
+import { EditorsOrder } from '../../../common/editor.js';
+import { IAuxiliaryEditorPart, IEditorGroup, IEditorGroupsService, IEditorPart, GroupsOrder } from '../../../services/editor/common/editorGroupsService.js';
+import { IHostService } from '../../../services/host/browser/host.js';
+import { IWorkbenchLayoutService, Parts } from '../../../services/layout/browser/layoutService.js';
+import { AI_ENABLED_KEY } from '../../positronAssistant/common/positronAIConfiguration.js';
+import { dedicatedWindowOptions } from '../../positronEditorActions/browser/positronDedicatedWindow.js';
+import { WebviewInput } from '../../webviewPanel/browser/webviewEditorInput.js';
+import { CANVAS_EXIT_COMMAND_ID, CANVAS_WEBVIEW_VIEW_TYPE, CanvasEntryOutcome, PositronCanvasModeActiveContext } from '../common/positronCanvasMode.js';
+
+/**
+ * Posit Assistant's command to open a Canvas panel as an ordinary editor --
+ * the only thing core needs from the extension.
+ */
+const CANVAS_ENSURE_COMMAND = 'posit-assistant.ensureCanvas';
+
+/**
+ * Cap on waiting for the assistant to produce a panel. `executeCommand`
+ * blocks unboundedly on extension activation; the command itself settles
+ * within the assistant's own 14s ensure deadline, so this only adds headroom
+ * for activation.
+ */
+const CANVAS_ENSURE_TIMEOUT = 20_000;
+
+export const IPositronCanvasService = createDecorator<IPositronCanvasService>('positronCanvasService');
+
+export interface IPositronCanvasService {
+
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Present Canvas as the whole product: one conversation in a standalone
+	 * window, IDE window out of the way. Absorbs every starting position and
+	 * concurrent callers; never leaves the user with no visible window.
+	 * Resolves an outcome rather than throwing for known non-entry cases,
+	 * because how a non-entry is shown depends on who asked (palette
+	 * notification or the assistant across the command seam).
+	 */
+	enter(): Promise<CanvasEntryOutcome>;
+
+	/**
+	 * Whether Canvas is currently the only surface the user can see. Gates
+	 * the Canvas UI's "Open Positron" control.
+	 */
+	readonly isActive: boolean;
+
+	/**
+	 * Hand the user back to the full IDE, moving the live conversation into
+	 * it rather than throwing it away. Resolves `true` only when it actually
+	 * left Canvas mode; the assistant treats anything else as a failed exit.
+	 */
+	exit(): Promise<boolean>;
+}
+
+/** A Canvas panel and the group it currently lives in. */
+interface ICanvasEditor {
+	readonly group: IEditorGroup;
+	readonly editor: WebviewInput;
+}
+
+export class PositronCanvasService extends Disposable implements IPositronCanvasService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly modeActiveContext: IContextKey<boolean>;
+
+	/**
+	 * Where the main process hears about the engagement, so it can keep other
+	 * windows out, trim the native menus, and route external opens; see
+	 * `IPositronStandaloneModeMainService`.
+	 */
+	private readonly standaloneModeChannel: PositronStandaloneModeChannelClient;
+
+	/** Whether this window holds the application-wide claim. */
+	private engagementHeld = false;
+
+	/**
+	 * The window presenting Canvas, plus everything to undo when it stops.
+	 * Disposing the store is the whole teardown.
+	 */
+	private readonly canvasWindow = this._register(new MutableDisposable<DisposableStore>());
+	private canvasGroup: IEditorGroup | undefined;
+
+	/** Set while the IDE window has been put away on Canvas's behalf. */
+	private ideWindowHidden = false;
+
+	/** In-flight `enter()`; concurrent callers coalesce onto it. */
+	private entering: Promise<CanvasEntryOutcome> | undefined;
+
+	/**
+	 * Bumped by every `exit()`. Entry is a sequence of awaits; one that
+	 * resumes after an exit landed inside it would silently undo the exit, so
+	 * `doEnter()` captures the count and rechecks it after each await.
+	 */
+	private exitGeneration = 0;
+
+	constructor(
+		@IEditorGroupsService private readonly editorGroupsService: IEditorGroupsService,
+		@ICommandService private readonly commandService: ICommandService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@INativeHostService private readonly nativeHostService: INativeHostService,
+		@IHostService private readonly hostService: IHostService,
+		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
+		@ILogService private readonly logService: ILogService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IMainProcessService mainProcessService: IMainProcessService
+	) {
+		super();
+
+		this.modeActiveContext = PositronCanvasModeActiveContext.bindTo(contextKeyService);
+		this.standaloneModeChannel = new PositronStandaloneModeChannelClient(mainProcessService.getChannel(POSITRON_STANDALONE_MODE_CHANNEL_NAME));
+	}
+
+	/**
+	 * Claim the application-wide engagement before any entry work. The main
+	 * process decides atomically, so of two racing windows exactly one
+	 * proceeds. Idempotent for the holder, which keeps re-entry legitimate.
+	 */
+	private async acquireEngagement(): Promise<boolean> {
+		try {
+			// The exit command travels with the claim, so the main process can
+			// ask Canvas to stand down for an external open without knowing
+			// about Canvas.
+			const granted = await this.standaloneModeChannel.acquire(mainWindow.vscodeWindowId, CANVAS_EXIT_COMMAND_ID);
+			this.engagementHeld = this.engagementHeld || granted;
+			return granted;
+		} catch (error) {
+			// Losing the channel loses the cross-window guarantee, not the
+			// ability to present Canvas in this window.
+			this.logService.error('[canvas] Could not claim Canvas mode with the main process; continuing', error);
+			return true;
+		}
+	}
+
+	/**
+	 * Give the claim back. Fire-and-forget: failing to say so must not fail
+	 * the exit it rode along with.
+	 */
+	private releaseEngagement(): void {
+		if (!this.engagementHeld) {
+			return;
+		}
+		this.engagementHeld = false;
+		this.standaloneModeChannel.release(mainWindow.vscodeWindowId)
+			.catch(error => this.logService.error('[canvas] Could not release Canvas mode with the main process', error));
+	}
+
+	/**
+	 * Release after an entry that did not end presenting. Guarded: a failed
+	 * re-entry must not drop the claim of the Canvas still being presented.
+	 */
+	private releaseEngagementUnlessPresenting(): void {
+		if (this.canvasWindow.value === undefined) {
+			this.releaseEngagement();
+		}
+	}
+
+	enter(): Promise<CanvasEntryOutcome> {
+		this.entering ??= this.doEnter().finally(() => this.entering = undefined);
+		return this.entering;
+	}
+
+	private async doEnter(): Promise<CanvasEntryOutcome> {
+		// Read live: `ai.enabled` toggles without a reload.
+		if (this.configurationService.getValue<boolean>(AI_ENABLED_KEY) === false) {
+			this.logService.info('[canvas] Not entering Canvas mode: ai.enabled is false');
+			return {
+				entered: false,
+				reason: 'ai-disabled',
+				message: localize('positron.canvas.aiDisabled', "Canvas is unavailable because AI features are disabled.")
+			};
+		}
+
+		// Captured before the claim's await so an exit arriving mid-claim
+		// supersedes this entry like any other.
+		const generation = this.exitGeneration;
+
+		// Claimed before any other await, so no second window can start an
+		// entry between here and the Canvas window appearing.
+		if (!await this.acquireEngagement()) {
+			return {
+				entered: false,
+				reason: 'engaged-elsewhere',
+				message: localize('positron.canvas.engagedElsewhere', "Canvas is already open in another Positron window.")
+			};
+		}
+
+		try {
+			return await this.doEnterEngaged(generation);
+		} finally {
+			this.releaseEngagementUnlessPresenting();
+		}
+	}
+
+	private async doEnterEngaged(generation: number): Promise<CanvasEntryOutcome> {
+		const superseded = () => this.exitGeneration !== generation;
+		const supersededOutcome: CanvasEntryOutcome = {
+			entered: false,
+			reason: 'superseded',
+			message: localize('positron.canvas.superseded', "Canvas stopped opening because Positron was asked for the IDE.")
+		};
+		if (superseded()) {
+			this.logService.info('[canvas] Abandoning entry: the user left Canvas while the application-wide claim was pending');
+			return supersededOutcome;
+		}
+
+		const canvas = await this.ensureCanvasEditor();
+		if (superseded()) {
+			this.logService.info('[canvas] Abandoning entry: the user left Canvas while it was opening');
+			return supersededOutcome;
+		}
+		if (!canvas) {
+			return {
+				entered: false,
+				reason: 'no-panel',
+				message: localize('positron.canvas.couldNotOpen', "Canvas could not be opened. Check the Posit Assistant output for details.")
+			};
+		}
+
+		// A panel already outside the IDE window is one we (or a restore) put
+		// there; adopt it as is. Restored windows come back with locked
+		// compact mode intact, so there is nothing to repair.
+		const part = this.editorGroupsService.getPart(canvas.group);
+		const canvasWindow = part === this.editorGroupsService.mainPart
+			? await this.promoteToCanvasWindow(canvas, superseded)
+			: { part, group: canvas.group };
+
+		if (superseded()) {
+			this.logService.info('[canvas] Abandoning entry: the user left Canvas while its window was being created');
+			return supersededOutcome;
+		}
+
+		if (!canvasWindow) {
+			return {
+				entered: false,
+				reason: 'no-window',
+				message: localize('positron.canvas.couldNotOpenWindow', "Canvas could not be opened in its own window.")
+			};
+		}
+
+		this.adoptCanvasWindow(canvasWindow.part, canvasWindow.group);
+
+		// Only now, with a live Canvas window on screen, is it safe to put
+		// the IDE window away.
+		try {
+			await this.hideIdeWindow();
+		} catch (error) {
+			// A visible IDE next to Canvas is recoverable; a committed entry
+			// over a failed hide is not, so run the normal merge-back transaction.
+			this.logService.error('[canvas] Could not put the IDE window away; leaving Canvas mode', error);
+			await this.exit();
+			return {
+				entered: false,
+				reason: 'no-window',
+				message: localize('positron.canvas.couldNotHideIde', "Canvas could not take over from the Positron window.")
+			};
+		}
+
+		if (superseded()) {
+			// The exit already unwound everything, but its reveal may have
+			// raced the minimize in flight here; reveal unconditionally.
+			this.logService.info('[canvas] Abandoning entry: Canvas went away while the IDE window was being put away');
+			await this.revealIdeWindow(true);
+			return supersededOutcome;
+		}
+
+		return { entered: true };
+	}
+
+	get isActive(): boolean {
+		return this.modeActiveContext.get() === true;
+	}
+
+	async exit(): Promise<boolean> {
+		// Retires any entry still in flight, before anything it could race with.
+		this.exitGeneration++;
+
+		const canvasGroup = this.canvasGroup;
+
+		// Read before `stopPresenting()`, which is what makes it false.
+		const wasActive = this.canvasWindow.value !== undefined;
+
+		// Stop presenting first: it drops the listener that treats the Canvas
+		// window going away as something to recover from. The claim goes back
+		// even when no Canvas window was up yet -- an exit landing inside an
+		// in-flight entry must not leave the early claim behind.
+		this.stopPresenting();
+		this.releaseEngagement();
+
+		// Show the IDE before moving anything into it: the move focuses its
+		// target, and focusing a group in an off-screen window leaves the
+		// user with no visible focused window.
+		await this.revealIdeWindow();
+
+		if (canvasGroup) {
+			// Unlock so the group is an ordinary group for as long as it
+			// survives the merge.
+			canvasGroup.lock(false);
+
+			// Merge, never `close()`: close treats a webview panel as
+			// non-confirming and destroys it, dropping the live conversation.
+			if (!this.editorGroupsService.mergeGroup(canvasGroup, this.editorGroupsService.mainPart.activeGroup)) {
+				this.logService.error('[canvas] Could not merge the Canvas group into the IDE; moving its editors individually');
+				canvasGroup.moveEditors(prepareMoveCopyEditors(canvasGroup, canvasGroup.editors.slice()), this.editorGroupsService.mainPart.activeGroup);
+			}
+
+			// The editor area auto-hides when its last editor leaves, so an
+			// IDE window that had only Canvas open comes back without one.
+			// Only when the merge happened: an exit with nothing to merge
+			// must not override an editor area the user hid deliberately.
+			this.layoutService.setPartHidden(false, Parts.EDITOR_PART);
+			this.editorGroupsService.mainPart.activeGroup.focus();
+		}
+
+		return wasActive;
+	}
+
+	/**
+	 * The most recently active Canvas panel anywhere in the workbench.
+	 * The assistant's ensure command owns singleton-ness; this scan only finds
+	 * the ready panel that command selected or created.
+	 */
+	private findCanvasEditor(): ICanvasEditor | undefined {
+		const found: ICanvasEditor[] = [];
+
+		for (const group of this.editorGroupsService.getGroups(GroupsOrder.MOST_RECENTLY_ACTIVE)) {
+			// `group.editors` is tab order; only `getEditors(MOST_RECENTLY_ACTIVE)`
+			// orders within a group.
+			for (const editor of group.getEditors(EditorsOrder.MOST_RECENTLY_ACTIVE)) {
+				if (editor instanceof WebviewInput && editor.providerId === CANVAS_WEBVIEW_VIEW_TYPE) {
+					found.push({ group, editor });
+				}
+			}
+		}
+
+		if (found.length > 1) {
+			// Non-destructive on purpose: closing the extras would dispose
+			// live assistant sessions.
+			this.logService.warn(`[canvas] ${found.length} Canvas panels are open; presenting the most recently active one`);
+		}
+
+		return found.at(0);
+	}
+
+	private async ensureCanvasEditor(): Promise<ICanvasEditor | undefined> {
+		// `raceTimeout` resolves undefined on timeout and when the command
+		// resolves undefined (which it always does); only the callback can
+		// tell them apart.
+		let timedOut = false;
+
+		try {
+			await raceTimeout(
+				this.commandService.executeCommand(CANVAS_ENSURE_COMMAND),
+				CANVAS_ENSURE_TIMEOUT,
+				() => {
+					timedOut = true;
+					this.logService.error(`[canvas] ${CANVAS_ENSURE_COMMAND} did not complete within ${CANVAS_ENSURE_TIMEOUT}ms`);
+				}
+			);
+		} catch (error) {
+			this.logService.error(`[canvas] ${CANVAS_ENSURE_COMMAND} failed`, error);
+			return undefined;
+		}
+
+		// A timeout is a failure, never a panel to adopt: the panel a scan
+		// would find is one the assistant is still working on, and its own
+		// readiness deadline is about to dispose it. Adopting it would report
+		// success, minimize the IDE, then bounce the user back.
+		if (timedOut) {
+			return undefined;
+		}
+
+		return this.findCanvasEditor();
+	}
+
+	/**
+	 * Moves a Canvas panel out of the IDE window into a window of its own.
+	 * Returns nothing if the move did not happen, so the caller does not hide
+	 * the IDE behind a window that never got its editor. `superseded` is
+	 * checked before the panel is moved: a panel pulled out of an IDE window
+	 * the user was just handed back is worse than no window at all.
+	 */
+	private async promoteToCanvasWindow(canvas: ICanvasEditor, superseded: () => boolean): Promise<{ part: IAuxiliaryEditorPart; group: IEditorGroup } | undefined> {
+		let part: IAuxiliaryEditorPart;
+		try {
+			part = await this.editorGroupsService.createAuxiliaryEditorPart(dedicatedWindowOptions(getActiveWindow(), {
+				// Compact mode is what makes the window chromeless, so it must
+				// not be something a stray editor or menu action can switch off.
+				lockCompact: true
+			}));
+		} catch (error) {
+			this.logService.error('[canvas] Could not create a window for Canvas', error);
+			return undefined;
+		}
+
+		if (superseded()) {
+			// Empty, so closing it takes its window with it.
+			part.close();
+			return undefined;
+		}
+
+		if (!canvas.group.moveEditors(prepareMoveCopyEditors(canvas.group, [canvas.editor]), part.activeGroup)) {
+			this.logService.error('[canvas] Could not move the Canvas editor into its own window');
+			part.close();
+			return undefined;
+		}
+
+		return { part, group: part.activeGroup };
+	}
+
+	/**
+	 * Takes ownership of the window presenting Canvas: keeps it single-editor,
+	 * arranges for the IDE to come back if it disappears, and focuses it.
+	 */
+	private adoptCanvasWindow(part: IEditorPart, group: IEditorGroup): void {
+		this.stopPresenting();
+
+		const disposables = new DisposableStore();
+
+		// A locked group keeps Canvas alone in its window: the editor service
+		// routes anything else to the next unlocked group, back in the IDE.
+		// Without it a file opened while Canvas has focus would silently
+		// cover Canvas, since compact mode draws no tabs.
+		group.lock(true);
+
+		// The window can also go away without anyone asking us (OS close
+		// button, renderer crash); the IDE window has to come back.
+		disposables.add(Event.once(part.onWillDispose)(() => {
+			// Losing the window supersedes an in-flight entry the same way an
+			// exit does; without this it would resume and report success for
+			// a window that no longer exists.
+			this.exitGeneration++;
+
+			this.stopPresenting();
+			this.releaseEngagement();
+
+			void this.revealIdeWindow();
+		}));
+
+		this.canvasWindow.value = disposables;
+		this.canvasGroup = group;
+		this.modeActiveContext.set(true);
+
+		group.focus();
+	}
+
+	/**
+	 * Forget the window we were presenting Canvas in. Does not touch the
+	 * group: this also runs while that window is being disposed, and the
+	 * group's lock dies with it either way.
+	 */
+	private stopPresenting(): void {
+		this.canvasWindow.clear();
+		this.canvasGroup = undefined;
+		this.modeActiveContext.set(false);
+	}
+
+	private async hideIdeWindow(): Promise<void> {
+		// Unguarded, unlike `revealIdeWindow()`: re-entry can focus
+		// (un-minimize) the IDE window on its way in, so skipping "already
+		// hidden" work would leave it behind Canvas.
+		this.ideWindowHidden = true;
+
+		// Minimize rather than hide: a minimized window is still listed by
+		// the OS, so the user can always get back to Positron, and an app
+		// with no visible windows has its own hazards.
+		await this.nativeHostService.minimizeWindow({ targetWindowId: mainWindow.vscodeWindowId });
+	}
+
+	/**
+	 * @param force reveal even when we do not believe the IDE window is away,
+	 * for the one caller with a minimize of its own in flight.
+	 */
+	private async revealIdeWindow(force = false): Promise<void> {
+		if (!this.ideWindowHidden && !force) {
+			return;
+		}
+		this.ideWindowHidden = false;
+
+		// Focusing is what un-minimizes; there is no separate restore call.
+		await this.hostService.focus(mainWindow);
+	}
+}

--- a/src/vs/workbench/contrib/positronCanvas/test/browser/positronCanvasCommandLockdown.vitest.ts
+++ b/src/vs/workbench/contrib/positronCanvas/test/browser/positronCanvasCommandLockdown.vitest.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { OperatingSystem } from '../../../../../base/common/platform.js';
+import { KeybindingsRegistry, KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { USLayoutResolvedKeybinding } from '../../../../../platform/keybinding/common/usLayoutResolvedKeybinding.js';
+import { registerCanvasCommandLockdown } from '../../browser/positronCanvasCommandLockdown.js';
+
+const SUPPRESSED_KEY_COMMAND = 'positronCanvasLockdown.suppressedKey';
+
+registerCanvasCommandLockdown();
+
+function suppressedBindings(os: OperatingSystem) {
+	return KeybindingsRegistry.getDefaultKeybindingsForOS(os)
+		.filter(item => item.command === SUPPRESSED_KEY_COMMAND && item.keybinding)
+		.map(item => ({
+			chord: USLayoutResolvedKeybinding.resolveKeybinding(item.keybinding!, os)[0].getDispatchChords().join(' '),
+			when: item.when?.serialize(),
+			weight: item.weight1,
+		}))
+		.sort((left, right) => left.chord.localeCompare(right.chord));
+}
+
+describe('Canvas command lockdown', () => {
+	it.each([
+		['macOS', OperatingSystem.Macintosh, ['ctrl+R', 'meta+N', 'meta+O', 'meta+P', 'shift+meta+N', 'shift+meta+P']],
+		['Linux', OperatingSystem.Linux, ['ctrl+E', 'ctrl+K ctrl+O', 'ctrl+N', 'ctrl+O', 'ctrl+P', 'ctrl+R', 'ctrl+shift+N', 'ctrl+shift+P']],
+		['Windows', OperatingSystem.Windows, ['ctrl+E', 'ctrl+K ctrl+O', 'ctrl+N', 'ctrl+O', 'ctrl+P', 'ctrl+R', 'ctrl+shift+N', 'ctrl+shift+P']],
+	] as const)('pins the default escape chords, context, and precedence on %s', (_name, os, expectedChords) => {
+		const bindings = suppressedBindings(os);
+
+		expect(bindings.map(binding => binding.chord)).toEqual(expectedChords);
+		expect(bindings.every(binding => binding.when === 'positronCanvasModeActive')).toBe(true);
+		expect(bindings.every(binding => binding.weight === KeybindingWeight.WorkbenchContrib + 50)).toBe(true);
+	});
+});

--- a/src/vs/workbench/contrib/positronCanvas/test/electron-browser/positronCanvasCommands.vitest.ts
+++ b/src/vs/workbench/contrib/positronCanvas/test/electron-browser/positronCanvasCommands.vitest.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { isIMenuItem, MenuId, MenuRegistry } from '../../../../../platform/actions/common/actions.js';
+import { CommandsRegistry } from '../../../../../platform/commands/common/commands.js';
+import '../../electron-browser/positronCanvas.contribution.js';
+
+/**
+ * Pins Positron's public `positron.canvas.*` command surface. The cross-repo
+ * subset is also documented in the assistant's `frontend-canvas/README.md`;
+ * changing that subset requires changing both documents together.
+ */
+describe('positron.canvas command surface', () => {
+
+	it('registers exactly the commands the seam is documented to have', () => {
+		const canvasCommands = [...CommandsRegistry.getCommands().keys()]
+			.filter(id => id.startsWith('positron.canvas.'))
+			.sort();
+
+		expect(canvasCommands).toEqual([
+			'positron.canvas.enter',
+			'positron.canvas.exit',
+			'positron.canvas.isActive',
+			'positron.canvas.open',
+		]);
+	});
+
+	it('leaves user-facing discovery to the Canvas-capable assistant', () => {
+		const canvasPaletteCommands = MenuRegistry.getMenuItems(MenuId.CommandPalette)
+			.filter(isIMenuItem)
+			.map(item => item.command.id)
+			.filter(id => id.startsWith('positron.canvas.'));
+
+		expect(canvasPaletteCommands).toEqual(['positron.canvas.exit']);
+	});
+});

--- a/src/vs/workbench/contrib/positronCanvas/test/electron-browser/positronCanvasService.vitest.ts
+++ b/src/vs/workbench/contrib/positronCanvas/test/electron-browser/positronCanvasService.vitest.ts
@@ -1,0 +1,390 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { DeferredPromise } from '../../../../../base/common/async.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { IChannel } from '../../../../../base/parts/ipc/common/ipc.js';
+import { IMainProcessService } from '../../../../../platform/ipc/common/mainProcessService.js';
+import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { INativeHostService } from '../../../../../platform/native/common/native.js';
+import { IThemeService } from '../../../../../platform/theme/common/themeService.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { EditorsOrder } from '../../../../common/editor.js';
+import { IAuxiliaryEditorPart, IEditorGroup, IEditorGroupsService, IEditorPart } from '../../../../services/editor/common/editorGroupsService.js';
+import { IHostService } from '../../../../services/host/browser/host.js';
+import { IWorkbenchLayoutService } from '../../../../services/layout/browser/layoutService.js';
+import { IOverlayWebview } from '../../../webview/browser/webview.js';
+import { WebviewInput } from '../../../webviewPanel/browser/webviewEditorInput.js';
+import { CANVAS_WEBVIEW_VIEW_TYPE } from '../../common/positronCanvasMode.js';
+import { PositronCanvasService } from '../../electron-browser/positronCanvasService.js';
+
+/** The command the assistant contributes to produce a Canvas panel. */
+const CANVAS_ENSURE_COMMAND = 'posit-assistant.ensureCanvas';
+
+describe('PositronCanvasService', () => {
+	const ctx = createTestContainer().build();
+
+	/**
+	 * A group whose editor list the test can rearrange.
+	 *
+	 * `editors` is tab order; `mruEditors` is what the group reports for
+	 * `EditorsOrder.MOST_RECENTLY_ACTIVE`, which is a different order whenever a
+	 * group holds more than one editor.
+	 */
+	function createGroup(editors: WebviewInput[] = [], mruEditors: WebviewInput[] = editors): IEditorGroup {
+		const group = stubInterface<IEditorGroup>({
+			editors,
+			getEditors: (order: EditorsOrder) => order === EditorsOrder.MOST_RECENTLY_ACTIVE ? mruEditors : editors,
+			lock: vi.fn(),
+			focus: vi.fn(),
+			isActive: vi.fn().mockReturnValue(true),
+			isSticky: vi.fn().mockReturnValue(false),
+			getIndexOfEditor: vi.fn().mockReturnValue(0),
+			moveEditors: vi.fn().mockReturnValue(true),
+		});
+		return group;
+	}
+
+	function createPart(activeGroup: IEditorGroup, onWillDispose: Event<void> = Event.None): IAuxiliaryEditorPart {
+		return stubInterface<IAuxiliaryEditorPart>({ activeGroup, onWillDispose, close: vi.fn() });
+	}
+
+	/** A Canvas panel, recognized by its contributed view type. */
+	function createCanvasEditor(): WebviewInput {
+		const editor = new WebviewInput(
+			{ viewType: CANVAS_WEBVIEW_VIEW_TYPE, providedId: CANVAS_WEBVIEW_VIEW_TYPE, name: 'Canvas', iconPath: undefined },
+			stubInterface<IOverlayWebview>({ state: undefined, dispose: vi.fn() }),
+			stubInterface<IThemeService>({ onDidColorThemeChange: Event.None }),
+		);
+		ctx.disposables.add(editor);
+		return editor;
+	}
+
+	/**
+	 * Wires the service up over a workbench whose groups the test controls.
+	 *
+	 * `auxiliaryGroups` are the groups, in most-recently-active order, that live
+	 * in a window of their own; the main part's group is always last, so a Canvas
+	 * panel still in the IDE window loses the MRU race.
+	 */
+	function build(options: {
+		auxiliaryGroups?: IEditorGroup[];
+		mainGroup?: IEditorGroup;
+		onWillDispose?: Event<void>;
+		executeCommand?: () => Promise<undefined>;
+		createAuxiliaryEditorPart?: IEditorGroupsService['createAuxiliaryEditorPart'];
+		acquireGranted?: boolean | Promise<boolean>;
+		minimizeWindow?: () => Promise<void>;
+	} = {}) {
+		const auxiliaryGroups = options.auxiliaryGroups ?? [];
+		const mainGroup = options.mainGroup ?? createGroup();
+		const mainPart = createPart(mainGroup);
+		const auxiliaryGroup = auxiliaryGroups.at(0);
+		const auxiliaryPart = createPart(auxiliaryGroup ?? createGroup(), options.onWillDispose ?? Event.None);
+
+		const parts = new Map<IEditorGroup, IEditorPart>(auxiliaryGroups.map(group => [group, auxiliaryPart]));
+		parts.set(mainGroup, mainPart);
+
+		const executeCommand = vi.fn(options.executeCommand ?? (() => Promise.resolve(undefined)));
+		const mergeGroup = vi.fn().mockReturnValue(true);
+		const setPartHidden = vi.fn();
+		const minimizeWindow = vi.fn(options.minimizeWindow ?? (() => Promise.resolve()));
+		const createAuxiliaryEditorPart = vi.fn(options.createAuxiliaryEditorPart ?? (() => Promise.resolve(auxiliaryPart)));
+
+		ctx.instantiationService.stub(IEditorGroupsService, stubInterface<IEditorGroupsService>({
+			mainPart,
+			getGroups: () => [...auxiliaryGroups, mainGroup],
+			getPart: (group: IEditorGroup) => parts.get(group) ?? mainPart,
+			mergeGroup,
+			createAuxiliaryEditorPart,
+		}));
+		ctx.instantiationService.stub(ICommandService, stubInterface<ICommandService>({ executeCommand }));
+		ctx.instantiationService.stub(IConfigurationService, stubInterface<IConfigurationService>({ getValue: () => true }));
+		ctx.instantiationService.stub(INativeHostService, stubInterface<INativeHostService>({ minimizeWindow }));
+		const focus = vi.fn().mockResolvedValue(undefined);
+		ctx.instantiationService.stub(IHostService, stubInterface<IHostService>({ focus }));
+		ctx.instantiationService.stub(IWorkbenchLayoutService, stubInterface<IWorkbenchLayoutService>({ setPartHidden }));
+		ctx.instantiationService.stub(ILogService, new NullLogService());
+		ctx.instantiationService.stub(IContextKeyService, new MockContextKeyService());
+		// The engagement channel: `acquire` grants unless the test says
+		// otherwise, `release` resolves. Recorded so tests can assert the
+		// claim's lifecycle against the mode transaction.
+		const channelCall = vi.fn().mockImplementation((command: string) =>
+			Promise.resolve(command === 'acquire' ? (options.acquireGranted ?? true) : undefined));
+		ctx.instantiationService.stub(IMainProcessService, stubInterface<IMainProcessService>({
+			getChannel: () => stubInterface<IChannel>({ call: channelCall })
+		}));
+
+		const service = ctx.disposables.add(ctx.instantiationService.createInstance(PositronCanvasService));
+
+		return { service, mainGroup, auxiliaryPart, executeCommand, mergeGroup, setPartHidden, minimizeWindow, channelCall, focus };
+	}
+
+	it('coalesces concurrent entries so the assistant is asked for one Canvas', async () => {
+		const created = new DeferredPromise<undefined>();
+		const canvasEditors: WebviewInput[] = [];
+		const auxiliaryGroup = createGroup(canvasEditors);
+		const { service, executeCommand } = build({
+			auxiliaryGroups: [auxiliaryGroup],
+			executeCommand: () => created.p,
+		});
+
+		const first = service.enter();
+		const second = service.enter();
+
+		// The ensure command runs once the entry has claimed Canvas mode with
+		// the main process, one await in.
+		await vi.waitFor(() => expect(executeCommand).toHaveBeenCalled());
+		expect(executeCommand).toHaveBeenCalledTimes(1);
+		expect(executeCommand).toHaveBeenCalledWith(CANVAS_ENSURE_COMMAND);
+
+		// The command is what puts a Canvas panel in the workbench.
+		canvasEditors.push(createCanvasEditor());
+		await created.complete(undefined);
+
+		expect(await Promise.all([first, second])).toEqual([{ entered: true }, { entered: true }]);
+		expect(executeCommand).toHaveBeenCalledTimes(1);
+	});
+
+	it('reports a no-panel outcome when the assistant produces no Canvas', async () => {
+		const { service, executeCommand } = build();
+
+		const outcome = await service.enter();
+
+		expect(executeCommand).toHaveBeenCalledWith(CANVAS_ENSURE_COMMAND);
+		expect(outcome).toMatchObject({ entered: false, reason: 'no-panel' });
+	});
+
+	it('does not adopt a restored Canvas when the assistant cannot ensure it', async () => {
+		const restored = createCanvasEditor();
+		const mainGroup = createGroup([restored]);
+		const { service, executeCommand, minimizeWindow } = build({
+			mainGroup,
+			executeCommand: () => Promise.reject(new Error('command not found')),
+		});
+
+		expect(await service.enter()).toMatchObject({ entered: false, reason: 'no-panel' });
+
+		expect(executeCommand).toHaveBeenCalledWith(CANVAS_ENSURE_COMMAND);
+		expect(minimizeWindow).not.toHaveBeenCalled();
+		expect(mainGroup.editors).toEqual([restored]);
+	});
+
+	it('presents the most recently active Canvas and leaves duplicates open', async () => {
+		const recent = createCanvasEditor();
+		const older = createCanvasEditor();
+		const recentGroup = createGroup([recent]);
+		const olderGroup = createGroup([older]);
+		const { service, executeCommand } = build({ auxiliaryGroups: [recentGroup, olderGroup] });
+
+		expect(await service.enter()).toEqual({ entered: true });
+
+		// The MRU group is the one taken over; the duplicate keeps its editor.
+		expect(recentGroup.lock).toHaveBeenCalledWith(true);
+		expect(olderGroup.lock).not.toHaveBeenCalled();
+		expect(olderGroup.editors).toEqual([older]);
+		expect(executeCommand).toHaveBeenCalledWith(CANVAS_ENSURE_COMMAND);
+	});
+
+	it('presents the most recently used Canvas of two sharing a group', async () => {
+		const older = createCanvasEditor();
+		const recent = createCanvasEditor();
+		// Tab order puts the older panel first; use order is the other way
+		// round, and use order is what Canvas mode follows.
+		const mainGroup = createGroup([older, recent], [recent, older]);
+		const { service } = build({ mainGroup });
+
+		expect(await service.enter()).toEqual({ entered: true });
+
+		const moved = vi.mocked(mainGroup.moveEditors).mock.calls[0][0];
+		expect(moved.map(entry => entry.editor)).toStrictEqual([recent]);
+	});
+
+	it('reports a no-panel outcome when the assistant runs past the create timeout', async () => {
+		vi.useFakeTimers();
+		try {
+			const canvasEditors: WebviewInput[] = [];
+			const mainGroup = createGroup(canvasEditors);
+			// The assistant's webview panel exists as soon as it opens one, long
+			// before the Canvas inside it is ready, so a scan after the timeout
+			// would find a panel that is about to be torn down.
+			const { service } = build({
+				mainGroup,
+				executeCommand: () => {
+					canvasEditors.push(createCanvasEditor());
+					return new DeferredPromise<undefined>().p;
+				},
+			});
+
+			const entering = service.enter();
+			await vi.advanceTimersByTimeAsync(20_000);
+
+			expect(await entering).toMatchObject({ entered: false, reason: 'no-panel' });
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('lets an exit stand that lands while the Canvas window is being created', async () => {
+		const created = new DeferredPromise<IAuxiliaryEditorPart>();
+		const mainGroup = createGroup([createCanvasEditor()]);
+		const { service, auxiliaryPart, minimizeWindow } = build({
+			mainGroup,
+			createAuxiliaryEditorPart: () => created.p,
+		});
+
+		const entering = service.enter();
+		// Window creation takes hundreds of milliseconds; the user asks for the
+		// IDE back while it is still running.
+		expect(await service.exit()).toBe(false);
+		await created.complete(auxiliaryPart);
+
+		// The entry must not resume into a window the user has since left: no
+		// re-minimized IDE and no reported entry.
+		expect(await entering).toMatchObject({ entered: false });
+		expect(minimizeWindow).not.toHaveBeenCalled();
+		expect(service.isActive).toBe(false);
+	});
+
+	it('starts no Canvas work after an exit wins a pending engagement claim', async () => {
+		const acquired = new DeferredPromise<boolean>();
+		const { service, executeCommand, channelCall } = build({ acquireGranted: acquired.p });
+
+		const entering = service.enter();
+		await vi.waitFor(() => expect(channelCall).toHaveBeenCalledWith('acquire', expect.anything()));
+		expect(await service.exit()).toBe(false);
+		await acquired.complete(true);
+
+		expect(await entering).toMatchObject({ entered: false, reason: 'superseded' });
+		expect(executeCommand).not.toHaveBeenCalled();
+		expect(channelCall).toHaveBeenCalledWith('release', expect.anything());
+	});
+
+	it('reports no-window when auxiliary window creation rejects', async () => {
+		const mainGroup = createGroup([createCanvasEditor()]);
+		const { service, minimizeWindow } = build({
+			mainGroup,
+			createAuxiliaryEditorPart: () => Promise.reject(new Error('window creation failed')),
+		});
+
+		expect(await service.enter()).toMatchObject({ entered: false, reason: 'no-window' });
+		expect(minimizeWindow).not.toHaveBeenCalled();
+		expect(service.isActive).toBe(false);
+	});
+
+	it('merges Canvas back into the IDE when minimizing the IDE fails', async () => {
+		const auxiliaryGroup = createGroup([createCanvasEditor()]);
+		const { service, mainGroup, mergeGroup } = build({
+			auxiliaryGroups: [auxiliaryGroup],
+			minimizeWindow: () => Promise.reject(new Error('minimize failed')),
+		});
+
+		expect(await service.enter()).toMatchObject({ entered: false, reason: 'no-window' });
+
+		expect(mergeGroup).toHaveBeenCalledWith(auxiliaryGroup, mainGroup);
+		expect(auxiliaryGroup.lock).toHaveBeenNthCalledWith(1, true);
+		expect(auxiliaryGroup.lock).toHaveBeenNthCalledWith(2, false);
+		expect(service.isActive).toBe(false);
+	});
+
+	it('merges the Canvas group back into the IDE rather than closing it', async () => {
+		const auxiliaryGroup = createGroup([createCanvasEditor()]);
+		const { service, mainGroup, mergeGroup } = build({ auxiliaryGroups: [auxiliaryGroup] });
+		await service.enter();
+
+		expect(await service.exit()).toBe(true);
+
+		// Merging is what keeps the live conversation: closing an auxiliary part
+		// destroys a webview panel instead of moving it.
+		expect(mergeGroup).toHaveBeenCalledWith(auxiliaryGroup, mainGroup);
+		expect(auxiliaryGroup.lock).toHaveBeenCalledWith(false);
+		expect(service.isActive).toBe(false);
+	});
+
+	it('reports an exit that had no Canvas to leave', async () => {
+		const { service, mergeGroup, setPartHidden } = build();
+
+		expect(await service.exit()).toBe(false);
+
+		expect(mergeGroup).not.toHaveBeenCalled();
+		// Nothing was undone, so nothing is redone: unhiding here would override
+		// an editor area the user hid deliberately.
+		expect(setPartHidden).not.toHaveBeenCalled();
+	});
+
+	it('reports engaged-elsewhere and asks the assistant for nothing when another window holds the claim', async () => {
+		const { service, executeCommand, channelCall } = build({ acquireGranted: false });
+
+		expect(await service.enter()).toMatchObject({ entered: false, reason: 'engaged-elsewhere' });
+
+		// A denied claim was never held, so there is nothing to release and
+		// no Canvas work to have started.
+		expect(executeCommand).not.toHaveBeenCalled();
+		expect(channelCall).not.toHaveBeenCalledWith('release', expect.anything());
+	});
+
+	it('gives the claim back when the assistant produces no Canvas', async () => {
+		const { service, channelCall } = build();
+
+		expect(await service.enter()).toMatchObject({ entered: false, reason: 'no-panel' });
+
+		expect(channelCall).toHaveBeenCalledWith('acquire', expect.anything());
+		expect(channelCall).toHaveBeenCalledWith('release', expect.anything());
+	});
+
+	it('holds the claim while presenting and gives it back on exit', async () => {
+		const auxiliaryGroup = createGroup([createCanvasEditor()]);
+		const { service, channelCall } = build({ auxiliaryGroups: [auxiliaryGroup] });
+
+		await service.enter();
+		expect(channelCall).not.toHaveBeenCalledWith('release', expect.anything());
+
+		expect(await service.exit()).toBe(true);
+		expect(channelCall).toHaveBeenCalledWith('release', expect.anything());
+	});
+
+	it('does not report entry when the Canvas window dies while the IDE is being put away', async () => {
+		const willDispose = new Emitter<void>();
+		ctx.disposables.add(willDispose);
+		const minimize = new DeferredPromise<void>();
+		const auxiliaryGroup = createGroup([createCanvasEditor()]);
+		const { service, minimizeWindow, focus } = build({
+			auxiliaryGroups: [auxiliaryGroup],
+			onWillDispose: willDispose.event,
+			minimizeWindow: () => minimize.p,
+		});
+
+		const entering = service.enter();
+		await vi.waitFor(() => expect(minimizeWindow).toHaveBeenCalled());
+
+		// The OS close button lands while the IDE minimize is still in flight.
+		willDispose.fire();
+		await minimize.complete();
+
+		expect(await entering).toMatchObject({ entered: false, reason: 'superseded' });
+		expect(service.isActive).toBe(false);
+		// Whatever order the dying window's reveal and the minimize settled
+		// in, the user ends with a visible IDE.
+		expect(focus).toHaveBeenCalled();
+	});
+
+	it('moves the editors one by one when the merge back into the IDE fails', async () => {
+		const auxiliaryGroup = createGroup([createCanvasEditor()]);
+		const { service, mergeGroup } = build({ auxiliaryGroups: [auxiliaryGroup] });
+		await service.enter();
+
+		mergeGroup.mockReturnValue(false);
+
+		expect(await service.exit()).toBe(true);
+		expect(auxiliaryGroup.moveEditors).toHaveBeenCalled();
+	});
+});

--- a/src/vs/workbench/contrib/positronEditorActions/browser/positronDedicatedWindow.ts
+++ b/src/vs/workbench/contrib/positronEditorActions/browser/positronDedicatedWindow.ts
@@ -11,15 +11,24 @@ import { IAuxiliaryWindowOpenOptions } from '../../../services/auxiliaryWindow/b
 import { IEditorGroupsService } from '../../../services/editor/common/editorGroupsService.js';
 
 /**
- * Moves the active editor into a "dedicated window": an auxiliary window with
- * a native OS title bar and compact chrome (no editor tabs, no status bar),
- * sized to match the window the editor moves out of.
- *
- * The command is intent-level on purpose: what a dedicated window looks like
- * is policy owned here, so callers never learn about auxiliary window options.
- * It is not exposed in the command palette; callers invoke it by id after
- * making the editor to move the active one -- the same contract as
- * `workbench.action.moveEditorToNewWindow`.
+ * The single definition of the "dedicated window" look: native OS title bar,
+ * compact chrome, sized to (and opening over) the window the editor leaves.
+ * `extraTraits` may add traits but never replace the shape -- the dedicated
+ * look wins.
+ */
+export function dedicatedWindowOptions(sourceWindow: Window, extraTraits?: IAuxiliaryWindowOpenOptions): IAuxiliaryWindowOpenOptions {
+	return {
+		...extraTraits,
+		compact: true,
+		nativeTitlebar: true,
+		bounds: { width: sourceWindow.outerWidth, height: sourceWindow.outerHeight }
+	};
+}
+
+/**
+ * Moves the active editor into a dedicated window. Not in the palette;
+ * callers invoke it by id after making the editor to move the active one,
+ * the same contract as `workbench.action.moveEditorToNewWindow`.
  */
 CommandsRegistry.registerCommand('positron.editor.moveIntoDedicatedWindow', async (accessor: ServicesAccessor) => {
 	const editorGroupsService = accessor.get(IEditorGroupsService);
@@ -30,16 +39,8 @@ CommandsRegistry.registerCommand('positron.editor.moveIntoDedicatedWindow', asyn
 		return; // nothing to move; do not open an empty window
 	}
 
-	// Size the dedicated window like the source window, which is still the
-	// active window at this point; it intentionally opens exactly over it.
-	const sourceWindow = getActiveWindow();
-	const options: IAuxiliaryWindowOpenOptions = {
-		compact: true,
-		nativeTitlebar: true,
-		bounds: { width: sourceWindow.outerWidth, height: sourceWindow.outerHeight }
-	};
-
-	const auxiliaryEditorPart = await editorGroupsService.createAuxiliaryEditorPart(options);
+	// The source window is still the active window at this point.
+	const auxiliaryEditorPart = await editorGroupsService.createAuxiliaryEditorPart(dedicatedWindowOptions(getActiveWindow()));
 	sourceGroup.moveEditors(prepareMoveCopyEditors(sourceGroup, [editor]), auxiliaryEditorPart.activeGroup);
 	auxiliaryEditorPart.activeGroup.focus();
 });

--- a/src/vs/workbench/services/auxiliaryWindow/browser/auxiliaryWindowService.ts
+++ b/src/vs/workbench/services/auxiliaryWindow/browser/auxiliaryWindowService.ts
@@ -52,6 +52,16 @@ export interface IAuxiliaryWindowOpenOptions {
 
 	readonly nativeTitlebar?: boolean;
 	readonly disableFullscreen?: boolean;
+
+	// --- Start Positron ---
+	/**
+	 * Makes compact mode a property of the window rather than a toggle: the
+	 * automatic exits from compact mode and the user-facing compact actions
+	 * are ignored. For windows that show exactly one thing with no workbench
+	 * chrome, where losing compact mode would break the surface.
+	 */
+	readonly lockCompact?: boolean;
+	// --- End Positron ---
 }
 
 export interface IAuxiliaryWindowService {
@@ -110,12 +120,21 @@ export class AuxiliaryWindow extends BaseWindow implements IAuxiliaryWindow {
 
 	readonly whenStylesHaveLoaded: Promise<void>;
 
-	private compact = false;
+	// --- Start Positron ---
+	// private compact = false;
+	private compact: boolean;
+	// Some opening traits cannot be read back from the live window. Keep them
+	// separate from `updateOptions()`, which only changes live compact state.
+	private readonly openOptions: IAuxiliaryWindowOpenOptions;
+	// --- End Positron ---
 
 	constructor(
 		readonly window: CodeWindow,
 		readonly container: HTMLElement,
 		stylesHaveLoaded: Barrier,
+		// --- Start Positron ---
+		openOptions: IAuxiliaryWindowOpenOptions | undefined,
+		// --- End Positron ---
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IHostService hostService: IHostService,
 		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService,
@@ -124,14 +143,26 @@ export class AuxiliaryWindow extends BaseWindow implements IAuxiliaryWindow {
 	) {
 		super(window, undefined, hostService, environmentService, contextMenuService, layoutService);
 
+		// --- Start Positron ---
+		this.openOptions = { ...openOptions };
+		this.compact = openOptions?.compact === true;
+		// --- End Positron ---
+
 		this.whenStylesHaveLoaded = stylesHaveLoaded.wait().then(() => undefined);
 
 		this.registerListeners();
 	}
 
-	updateOptions(options: { compact: boolean }): void {
-		this.compact = options.compact;
+	// --- Start Positron ---
+	// updateOptions(options: { compact: boolean }): void {
+	// 	this.compact = options.compact;
+	// }
+	updateOptions(options: { compact: boolean } | undefined): void {
+		if (options) {
+			this.compact = options.compact;
+		}
 	}
+	// --- End Positron ---
 
 	private registerListeners(): void {
 		this._register(addDisposableListener(this.window, EventType.BEFORE_UNLOAD, (e: BeforeUnloadEvent) => this.handleBeforeUnload(e)));
@@ -223,7 +254,16 @@ export class AuxiliaryWindow extends BaseWindow implements IAuxiliaryWindow {
 				height: this.window.outerHeight
 			},
 			zoomLevel: getZoomLevel(this.window),
-			compact: this.compact
+			// --- Start Positron ---
+			// compact: this.compact
+			compact: this.compact,
+			// `EditorParts.restoreState()` feeds this object straight back in as
+			// open options, so anything omitted here is a trait the restored
+			// window loses.
+			nativeTitlebar: this.openOptions.nativeTitlebar,
+			disableFullscreen: this.openOptions.disableFullscreen,
+			lockCompact: this.openOptions.lockCompact
+			// --- End Positron ---
 		};
 	}
 
@@ -276,8 +316,12 @@ export class BrowserAuxiliaryWindowService extends Disposable implements IAuxili
 		const containerDisposables = new DisposableStore();
 		const { container, stylesLoaded } = this.createContainer(targetWindow, containerDisposables, options);
 
-		const auxiliaryWindow = this.createAuxiliaryWindow(targetWindow, container, stylesLoaded);
-		auxiliaryWindow.updateOptions({ compact: options?.compact ?? false });
+		// --- Start Positron ---
+		// const auxiliaryWindow = this.createAuxiliaryWindow(targetWindow, container, stylesLoaded);
+		const auxiliaryWindow = this.createAuxiliaryWindow(targetWindow, container, stylesLoaded, options);
+		// auxiliaryWindow.updateOptions({ compact: options?.compact ?? false });
+		// Opening traits are constructor state. Live updates remain compact-only.
+		// --- End Positron ---
 
 		const registryDisposables = new DisposableStore();
 		this.windows.set(targetWindow.vscodeWindowId, auxiliaryWindow);
@@ -311,9 +355,13 @@ export class BrowserAuxiliaryWindowService extends Disposable implements IAuxili
 		return auxiliaryWindow;
 	}
 
-	protected createAuxiliaryWindow(targetWindow: CodeWindow, container: HTMLElement, stylesLoaded: Barrier): AuxiliaryWindow {
-		return new AuxiliaryWindow(targetWindow, container, stylesLoaded, this.configurationService, this.hostService, this.environmentService, this.contextMenuService, this.layoutService);
+	// --- Start Positron ---
+	// protected createAuxiliaryWindow(targetWindow: CodeWindow, container: HTMLElement, stylesLoaded: Barrier): AuxiliaryWindow {
+	// 	return new AuxiliaryWindow(targetWindow, container, stylesLoaded, this.configurationService, this.hostService, this.environmentService, this.contextMenuService, this.layoutService);
+	protected createAuxiliaryWindow(targetWindow: CodeWindow, container: HTMLElement, stylesLoaded: Barrier, options?: IAuxiliaryWindowOpenOptions): AuxiliaryWindow {
+		return new AuxiliaryWindow(targetWindow, container, stylesLoaded, options, this.configurationService, this.hostService, this.environmentService, this.contextMenuService, this.layoutService);
 	}
+	// --- End Positron ---
 
 	private async openWindow(options?: IAuxiliaryWindowOpenOptions): Promise<Window | undefined> {
 		const activeWindow = getActiveWindow();

--- a/src/vs/workbench/services/auxiliaryWindow/electron-browser/auxiliaryWindowService.ts
+++ b/src/vs/workbench/services/auxiliaryWindow/electron-browser/auxiliaryWindowService.ts
@@ -42,6 +42,9 @@ export class NativeAuxiliaryWindow extends AuxiliaryWindow {
 		window: CodeWindow,
 		container: HTMLElement,
 		stylesHaveLoaded: Barrier,
+		// --- Start Positron ---
+		openOptions: IAuxiliaryWindowOpenOptions | undefined,
+		// --- End Positron ---
 		@IConfigurationService configurationService: IConfigurationService,
 		@INativeHostService private readonly nativeHostService: INativeHostService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
@@ -51,7 +54,10 @@ export class NativeAuxiliaryWindow extends AuxiliaryWindow {
 		@IContextMenuService contextMenuService: IContextMenuService,
 		@IWorkbenchLayoutService layoutService: IWorkbenchLayoutService
 	) {
-		super(window, container, stylesHaveLoaded, configurationService, hostService, environmentService, contextMenuService, layoutService);
+		// --- Start Positron ---
+		// super(window, container, stylesHaveLoaded, configurationService, hostService, environmentService, contextMenuService, layoutService);
+		super(window, container, stylesHaveLoaded, openOptions, configurationService, hostService, environmentService, contextMenuService, layoutService);
+		// --- End Positron ---
 
 		if (!isMacintosh) {
 			// For now, limit this to platforms that have clear maximised
@@ -177,9 +183,13 @@ export class NativeAuxiliaryWindowService extends BrowserAuxiliaryWindowService 
 		return super.createContainer(auxiliaryWindow, disposables);
 	}
 
-	protected override createAuxiliaryWindow(targetWindow: CodeWindow, container: HTMLElement, stylesHaveLoaded: Barrier): AuxiliaryWindow {
-		return new NativeAuxiliaryWindow(targetWindow, container, stylesHaveLoaded, this.configurationService, this.nativeHostService, this.instantiationService, this.hostService, this.environmentService, this.dialogService, this.contextMenuService, this.layoutService);
+	// --- Start Positron ---
+	// protected override createAuxiliaryWindow(targetWindow: CodeWindow, container: HTMLElement, stylesHaveLoaded: Barrier): AuxiliaryWindow {
+	// 	return new NativeAuxiliaryWindow(targetWindow, container, stylesHaveLoaded, this.configurationService, this.nativeHostService, this.instantiationService, this.hostService, this.environmentService, this.dialogService, this.contextMenuService, this.layoutService);
+	protected override createAuxiliaryWindow(targetWindow: CodeWindow, container: HTMLElement, stylesHaveLoaded: Barrier, options?: IAuxiliaryWindowOpenOptions): AuxiliaryWindow {
+		return new NativeAuxiliaryWindow(targetWindow, container, stylesHaveLoaded, options, this.configurationService, this.nativeHostService, this.instantiationService, this.hostService, this.environmentService, this.dialogService, this.contextMenuService, this.layoutService);
 	}
+	// --- End Positron ---
 }
 
 registerSingleton(IAuxiliaryWindowService, NativeAuxiliaryWindowService, InstantiationType.Delayed);

--- a/src/vs/workbench/services/auxiliaryWindow/test/browser/auxiliaryWindowService.vitest.ts
+++ b/src/vs/workbench/services/auxiliaryWindow/test/browser/auxiliaryWindowService.vitest.ts
@@ -1,0 +1,112 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { mainWindow } from '../../../../../base/browser/window.js';
+import { Barrier } from '../../../../../base/common/async.js';
+import { Event } from '../../../../../base/common/event.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IContextMenuService } from '../../../../../platform/contextview/browser/contextView.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { ensureNoLeakedDisposables } from '../../../../../test/vitest/vitestUtils.js';
+import { IWorkbenchEnvironmentService } from '../../../environment/common/environmentService.js';
+import { IHostService } from '../../../host/browser/host.js';
+import { IWorkbenchLayoutService } from '../../../layout/browser/layoutService.js';
+import { AuxiliaryWindow, IAuxiliaryWindowOpenOptions } from '../../browser/auxiliaryWindowService.js';
+
+class TestAuxiliaryWindow extends AuxiliaryWindow {
+
+	protected override enableWindowFocusOnElementFocus(): void { }
+	protected override enableMultiWindowAwareTimeout(): void { }
+}
+
+describe('AuxiliaryWindow', () => {
+	const disposables = ensureNoLeakedDisposables();
+
+	function createAuxiliaryWindow(openOptions?: IAuxiliaryWindowOpenOptions): AuxiliaryWindow {
+		const stylesHaveLoaded = new Barrier();
+		stylesHaveLoaded.open();
+
+		return disposables.add(new TestAuxiliaryWindow(
+			mainWindow,
+			mainWindow.document.createElement('div'),
+			stylesHaveLoaded,
+			openOptions,
+			stubInterface<IConfigurationService>(),
+			stubInterface<IHostService>({ onDidChangeFullScreen: Event.None }),
+			stubInterface<IWorkbenchEnvironmentService>(),
+			stubInterface<IContextMenuService>({
+				onDidShowContextMenu: Event.None,
+				onDidHideContextMenu: Event.None,
+			}),
+			stubInterface<IWorkbenchLayoutService>({ activeContainer: mainWindow.document.body }),
+		));
+	}
+
+	// Opening traits are immutable window identity; live compact changes must not
+	// replace them or every later restore comes back with different chrome.
+	it('keeps the traits it was opened with when compact state changes', () => {
+		const auxiliaryWindow = createAuxiliaryWindow({
+			compact: true,
+			lockCompact: true,
+			nativeTitlebar: true,
+			disableFullscreen: true,
+		});
+		auxiliaryWindow.updateOptions({ compact: false });
+
+		expect(auxiliaryWindow.createState()).toMatchObject({
+			compact: false,
+			lockCompact: true,
+			nativeTitlebar: true,
+			disableFullscreen: true,
+		});
+	});
+
+	// `EditorParts.restoreState()` feeds a persisted state object straight back
+	// in as open options, so a trait only survives a restore if it makes the
+	// full round trip out of one window, through JSON storage, and into the
+	// next.
+	it('round-trips its traits through serialized state into a restored window', () => {
+		const original = createAuxiliaryWindow({
+			compact: true,
+			lockCompact: true,
+			nativeTitlebar: true,
+			disableFullscreen: true,
+		});
+
+		const restored = createAuxiliaryWindow(JSON.parse(JSON.stringify(original.createState())));
+
+		expect(restored.createState()).toMatchObject({
+			compact: true,
+			lockCompact: true,
+			nativeTitlebar: true,
+			disableFullscreen: true,
+		});
+	});
+
+	// State persisted before the traits existed carries only `compact`; it must
+	// restore exactly as it always has, with no trait invented for it.
+	it('restores state persisted before chrome traits existed', () => {
+		const restored = createAuxiliaryWindow(JSON.parse('{ "compact": true }'));
+
+		const state = restored.createState();
+		expect(state.compact).toBe(true);
+		expect(state.lockCompact).toBeUndefined();
+		expect(state.nativeTitlebar).toBeUndefined();
+		expect(state.disableFullscreen).toBeUndefined();
+	});
+
+	it('is unchanged by an updateOptions call with no options', () => {
+		const auxiliaryWindow = createAuxiliaryWindow({ compact: true, nativeTitlebar: true });
+
+		auxiliaryWindow.updateOptions(undefined);
+
+		expect(auxiliaryWindow.createState()).toMatchObject({
+			compact: true,
+			nativeTitlebar: true,
+		});
+	});
+});

--- a/src/vs/workbench/services/editor/common/editorGroupsService.ts
+++ b/src/vs/workbench/services/editor/common/editorGroupsService.ts
@@ -667,7 +667,14 @@ export interface IEditorGroupsService extends IEditorGroupsContainer {
 	 * Opens a new window with a full editor part instantiated
 	 * in there at the optional position and size on screen.
 	 */
-	createAuxiliaryEditorPart(options?: { bounds?: Partial<IRectangle>; compact?: boolean; alwaysOnTop?: boolean }): Promise<IAuxiliaryEditorPart>;
+	// --- Start Positron ---
+	// createAuxiliaryEditorPart(options?: { bounds?: Partial<IRectangle>; compact?: boolean; alwaysOnTop?: boolean }): Promise<IAuxiliaryEditorPart>;
+	// `nativeTitlebar` and `lockCompact` are declared here so Positron's
+	// chromeless dedicated windows can ask for them through this interface. The
+	// shape stays inlined rather than importing `IAuxiliaryWindowOpenOptions`
+	// because that type lives in a `browser` layer this `common` file cannot see.
+	createAuxiliaryEditorPart(options?: { bounds?: Partial<IRectangle>; compact?: boolean; alwaysOnTop?: boolean; nativeTitlebar?: boolean; lockCompact?: boolean }): Promise<IAuxiliaryEditorPart>;
+	// --- End Positron ---
 
 	/**
 	 * Creates a modal editor part that shows in a modal overlay

--- a/src/vs/workbench/services/environment/electron-browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/electron-browser/environmentService.ts
@@ -54,6 +54,14 @@ export interface INativeWorkbenchEnvironmentService extends IBrowserWorkbenchEnv
 
 	// --- Editors to --wait
 	readonly filesToWait?: IPathsToWaitFor;
+
+	// --- Start Positron ---
+	/**
+	 * Whether another window held standalone mode when this window opened;
+	 * when set, this window must not enter the mode at startup.
+	 */
+	readonly standaloneModeEngagedElsewhere: boolean;
+	// --- End Positron ---
 }
 
 export class NativeWorkbenchEnvironmentService extends AbstractNativeEnvironmentService implements INativeWorkbenchEnvironmentService {
@@ -167,6 +175,10 @@ export class NativeWorkbenchEnvironmentService extends AbstractNativeEnvironment
 	// Positron docs URL is not used in desktop mode; returns undefined to use default.
 	get positronDocsUrl(): string | undefined {
 		return undefined;
+	}
+
+	get standaloneModeEngagedElsewhere(): boolean {
+		return this.configuration.standaloneModeEngagedElsewhere === true;
 	}
 	// --- End Positron ---
 

--- a/src/vs/workbench/workbench.desktop.main.ts
+++ b/src/vs/workbench/workbench.desktop.main.ts
@@ -197,6 +197,7 @@ import './contrib/emergencyAlert/electron-browser/emergencyAlert.contribution.js
 
 // --- Start Positron ---
 import './contrib/positronPreview/electron-browser/positronPreview.contribution.js';
+import './contrib/positronCanvas/electron-browser/positronCanvas.contribution.js';
 // --- End Positron ---
 
 // MCP


### PR DESCRIPTION
Supersedes #15315, which cannot be reopened because its head branch was rewritten after it was closed. Same stack, rebased on current main.

Part 3 of progress towards #15309.

Stacked on #15311.

This PR adds Canvas mode itself:

- Moves a ready Canvas editor into a locked, chromeless auxiliary window.
- Minimizes the IDE only after the Canvas window is usable.
- Merges the live Canvas editor back into the IDE on exit.
- Handles concurrent entry, failures, and entry/exit races.
- Restricts the default IDE escape shortcuts while Canvas is active.
- Defines and tests the Positron/Assistant command seam.

Posit Assistant owns Canvas discovery and readiness. Without a Canvas-capable Assistant, Positron exposes no Open Canvas palette command.

Launch flags, startup behavior, and persistence are deferred to the next PR.

### Reviewer Q&A

**Why does this live in Positron?**  
Positron owns native windows, editor groups, focus, and presentation. Assistant owns Canvas content, identity, and readiness.

**How are commands restricted?**  
This is a narrow UX deny list for default shortcuts that reveal IDE surfaces, not a command sandbox. Other commands and custom user keybindings remain available.

**What happens without a Canvas-capable Assistant?**  
Assistant owns the user-facing Open Canvas command. If entry is invoked indirectly, the readiness handshake fails safely before any editor is moved or the IDE is minimized.

**What happens to the main IDE renderer?**  
It remains alive and is only minimized. Exit reveals it before moving or focusing editors.

**How is the live conversation preserved?**  
Entry moves the existing webview editor. Exit merges its group back into the IDE instead of closing or recreating it.

**How stable is the cross-repo interface?**  
The seam is limited to Canvas identity, ensure-ready, enter, exit, and active-state commands. Assistant can change Canvas internals while preserving those behaviors.

**Why are launch and persistence absent?**  
This layer contains only Canvas presentation. `--canvas`, startup restoration, and stored intent belong to the next PR.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

- `npm run build-check`
- Canvas, standalone-mode, and auxiliary-window Vitest suites: 36 tests passed
- No TypeScript errors in touched files


https://claude.ai/code/session_01PuEVkfgWrB4cQZA4cbg1em
