### PR TITLE
e2e: wait for the R plot file to be written before asserting it exists

### DIFF
--- a/test/e2e/tests/plots/plots.test.ts
+++ b/test/e2e/tests/plots/plots.test.ts
@@ -556,7 +556,11 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 
 			// Run the code that creates a plot and saves it to the temp file
 			await console.pasteCodeToConsole(rPlotAndSave(tempFilePath), true);
+
+			// The pane plot comes from the block's first statement, so it does not mean the
+			// file was written; the sentinel only prints once dev.off() has flushed the PNG.
 			await plots.waitForCurrentPlot();
+			await console.waitForConsoleContents(PLOT_SAVED_MARKER);
 
 			// Verify that the file exists on disk
 			expect(fs.existsSync(tempFilePath)).toBe(true);
@@ -809,14 +813,20 @@ fig`;
 const rTwoPlots = `plot(1:10)
 plot(1:100)`;
 
+// Printed by the R block once the plot file is closed. Assembled from two fragments at
+// runtime so the console's echo of the pasted source cannot match it before the code runs.
+const PLOT_SAVED_MARKER = 'e2e-plot-saved';
+
 const rPlotAndSave = (filePath: string) => {
 	// Convert backslashes to forward slashes for R compatibility on Windows
 	// (R interprets \U as unicode escape sequence)
 	const safePath = filePath.replace(/\\/g, '/');
+	const marker = `paste0("${PLOT_SAVED_MARKER.slice(0, 4)}", "${PLOT_SAVED_MARKER.slice(4)}")`;
 	return `plot(1:10)
 grDevices::png(filename = "${safePath}")
 plot(1:20)
-dev.off()`;
+dev.off()
+cat(${marker}, "\\n")`;
 };
 
 async function dismissPlotZoomTooltip(page: Page) {


### PR DESCRIPTION
### Summary

`R - plot and save in one block` checked that the saved PNG was on disk ~220ms after sending the code, gated only on `waitForCurrentPlot()`. That pane plot comes from the block's first statement, so it fires before `grDevices::png`/`dev.off()` write the file.

- Wait for a sentinel printed after `dev.off()` returns before asserting the file exists
- Sentinel is assembled from two fragments at runtime, because the console echoes the pasted source and would otherwise satisfy the wait early
- Test-only change; no product code touched

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:plots

Verified by forcing the race (a delay before the file device opens): the assertion fails without this change and passes with it. 3/3 green locally without the forced delay; the mac CI contention that surfaces it was not recreated.


### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- The test checks for the saved PNG on disk ~220ms after pressing Enter, gated only on waitForCurrentPlot(), which is satisfied by the block's FIRST statement (plot(1:10)) rather than by dev.off() flushing the file.</summary>

- **Test:** [Plots > R Plots > R - plot and save in one block](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Plots%20%3E%20R%20Plots%20%3E%20R%20-%20plot%20and%20save%20in%20one%20block%7C%7C%7Ctest%2Fe2e%2Ftests%2Fplots%2Fplots.test.ts)
- **Targeted failure:** expect(fs.existsSync(tempFilePath)).toBe(true) at test/e2e/tests/plots/plots.test.ts:562
- **Signal:** Trace: Enter at t=2292570, waitForCurrentPlot returned t=2292809 (212ms), assertion failed before failure screenshot at t=2292823. Screencast frames show a single pane entry 'plot 1' with y-axis label 1:10, i.e. statement 1; plot(1:20) renders to the grDevices::png device and never reaches the pane. pasteCodeToConsole (console.ts:284) pastes + Enter with no execution barrier. Paste-dropped ruled out: pasted text verified in console input at t=2291112 and a plot rendered.
- **Frequency:** 8/6 runs (133.3%) on main, mac/electron
- **Hypothesis:** Waiting for a sentinel printed after dev.off() returns, before the disk check, removes the race. Verified by forcing the mechanism: with a delay inserted before the file device opens, the assertion fails without the barrier and passes with it. (An earlier attempt waited on dev.off()'s own output, 'null device'; that text never appears here, because dev.off() closes the png device and returns to Positron's still-open graphics device.) If this test fails again with the barrier in place, the file write itself is broken and it is a product bug instead.

</details>

