### PR TITLE
Bound file concurrency in the transpile pipeline to avoid EMFILE

### DIFF
--- a/build/next/index.ts
+++ b/build/next/index.ts
@@ -496,6 +496,24 @@ function needsBomAdded(filePath: string): boolean {
 	return /([\/\\])test\1.*utf8/.test(filePath);
 }
 
+// --- Start Positron ---
+/**
+ * Runs an async mapper over items with bounded concurrency. An unbounded
+ * Promise.all over every source file exhausts the per-process file handle
+ * limit on Windows (EMFILE) now that the source tree exceeds ~8k files.
+ */
+async function mapWithConcurrency<T>(items: readonly T[], mapper: (item: T) => Promise<void>, concurrency = 256): Promise<void> {
+	let next = 0;
+	const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+		while (next < items.length) {
+			const index = next++;
+			await mapper(items[index]);
+		}
+	});
+	await Promise.all(workers);
+}
+// --- End Positron ---
+
 async function copyFile(srcPath: string, destPath: string): Promise<void> {
 	await fs.promises.mkdir(path.dirname(destPath), { recursive: true });
 
@@ -586,11 +604,18 @@ async function copyAllNonTsFiles(outDir: string, excludeTests: boolean): Promise
 
 	const allFiles = [...new Set([...files, ...dtsFiles])];
 
-	await Promise.all(allFiles.map(file => {
+	// --- Start Positron ---
+	// Bounded concurrency to avoid EMFILE on Windows.
+	// await Promise.all(allFiles.map(file => {
+	await mapWithConcurrency(allFiles, file => {
+	// --- End Positron ---
 		const srcPath = path.join(REPO_ROOT, SRC_DIR, file);
 		const destPath = path.join(REPO_ROOT, outDir, file);
 		return copyFile(srcPath, destPath);
-	}));
+	// --- Start Positron ---
+	// }));
+	});
+	// --- End Positron ---
 
 	console.log(`[resources] Copied ${allFiles.length} files`);
 }
@@ -611,11 +636,12 @@ async function copyESMPackageDependencies(outDir: string): Promise<void> {
 	}
 	const destRoot = path.join(REPO_ROOT, outDir, 'esm-package-dependencies');
 	const files = await globAsync('**/*', { cwd: srcRoot, nodir: true });
-	await Promise.all(files.map(file => {
+	// Bounded concurrency to avoid EMFILE on Windows.
+	await mapWithConcurrency(files, file => {
 		const srcPath = path.join(srcRoot, file);
 		const destPath = path.join(destRoot, file);
 		return copyFile(srcPath, destPath);
-	}));
+	});
 	console.log(`[resources] Copied ${files.length} ESM package dependency files to ${outDir}/esm-package-dependencies/`);
 }
 // --- End Positron ---
@@ -824,14 +850,21 @@ async function transpile(outDir: string, excludeTests: boolean): Promise<void> {
 	console.log(`[transpile] Found ${files.length} files`);
 
 	// Transpile all files in parallel using esbuild.transform (fastest approach)
-	await Promise.all(files.map(file => {
+	// --- Start Positron ---
+	// Bounded concurrency to avoid EMFILE on Windows.
+	// await Promise.all(files.map(file => {
+	await mapWithConcurrency(files, file => {
+	// --- End Positron ---
 		const srcPath = path.join(REPO_ROOT, SRC_DIR, file);
 		// --- Start Positron ---
 		// Support .tsx files
 		const destPath = path.join(REPO_ROOT, outDir, file.replace(/\.tsx?$/, '.js'));
 		// --- End Positron ---
 		return transpileFile(srcPath, destPath);
-	}));
+	// --- Start Positron ---
+	// }));
+	});
+	// --- End Positron ---
 }
 
 // ============================================================================


### PR DESCRIPTION
I recently hit a situation where build watchers weren't working my windows box.

The transpile pipeline (`node build/next/index.ts transpile`, run by the
`watch-client-transpile` daemon and the Ctrl+Shift+B build tasks) used an
unbounded `Promise.all` over every source file. The source tree recently crossed
8194 files, just past the ~8192 per-process file handle limit on Windows, so full
builds started failing with `EMFILE` (errno `-4066`).

The quieter failure mode is worse than the loud one. When the watch daemons hit
this on their initial build, they silently dropped files from `out/` (for
example `vs/base/common/semver/semver.js`). Dev launches then crashed with
`ERR_MODULE_NOT_FOUND` while the watch panes looked essentially healthy
("Finished transpilation with 1 errors"), and because subsequent incremental
cycles only process changed files, the lost files were never retried. So this
also explains the "silently incomplete `out/` dir" dev-launch failures people
have hit on Windows -- those were the same bug, not a separate problem.

The fix is a small `mapWithConcurrency` helper (256 workers) applied at the three
unbounded call sites:

- `transpile()`
- `copyAllNonTsFiles()`
- `copyESMPackageDependencies()`

`build/next/index.ts` is an upstream file, so the helper and the two upstream
call-site changes are wrapped in Positron markers with the original lines left
commented out to ease future merge conflicts. `copyESMPackageDependencies()` is
already Positron-owned code, so it needed no additional markers.

Concurrency is bounded rather than made adaptive on purpose: 256 is far enough
below the handle limit to leave headroom for the rest of the process, and it
costs no throughput, so there's no reason to add a tuning knob. Benchmarking the
real unit of work (`readFile` -> `esbuild.transform` -> `mkdir` -> `writeFile`)
over all 8205 files at varying concurrency:

| concurrency | wall time |
|---|---|
| 16 | 8128 ms |
| 64 | 6649 ms |
| **256** | **6895 ms** |
| 1024 | 6900 ms |
| 4096 | 7563 ms |

Throughput plateaus by ~64 and is flat through 1024, then degrades at 4096.
Neither fd count nor `Promise.all` breadth is the limiter: libuv runs `fs` work
on a 4-thread pool by default (`UV_THREADPOOL_SIZE` isn't set anywhere in the
build config) and `esbuild.transform` is bounded by esbuild's own worker process.
That plateau is a property of libuv and esbuild rather than of Windows, so
capping at 256 costs nothing on macOS or Linux either.

### Build Scope

Which pipelines actually run this code, since "build infra change" could sound
broader than it is. `build/next/index.ts` has two subcommands, `transpile` and
`bundle`, and these changes are almost entirely on the `transpile` side. Note
also that two different things are named `transpile-client`:
`npm run transpile-client` is this file, while `npm run gulp transpile-client` is
the older gulp-tsb task and is untouched.

| Build | Command | Path | Affected? |
|---|---|---|---|
| Watch daemons | `watch-client-transpile` | `transpile` + watch initial build | **Yes** -- the original bug |
| Local one-shot / Ctrl+Shift+B | `npm run transpile-client` | `transpile` | **Yes** |
| Sessions e2e CI (ubuntu) | `npm run transpile-client` | `transpile` | **Yes** -- the only CI consumer |
| e2e dev build (ubuntu/macOS/windows) | `npm run compile` -> `gulp compile` | gulp-tsb `compileTask` | No |
| Release builds (positron-builds) | `npm run gulp vscode-<platform>-<arch>` | `bundle` | Only the 15-file ESM copy |

The e2e dev builds are not in this path at all. They build with
`npm-run-all -p compile "electron x64"` plus `npm run prelaunch` (which itself
runs `npm run compile`), resolving to `gulp compile` -> `compileClientTask` ->
`compilation.compileTask('src', 'out')`. `build/lib/compilation.ts` never
references `build/next` and never reads `useEsbuildTranspile`.

Release builds go through `esbuildBundleTask` -> `runEsbuildBundle` -> the
`bundle` subcommand, not `transpile`. Of the three changed functions, `bundle`
calls only `copyESMPackageDependencies()` (15 files), so the cap never engages.
Bundle's real resource copying is `copyResources()`, a sequential `for` loop with
`await copyFile`, which was never unbounded and is untouched. positron-builds
invokes nothing but `npm run gulp vscode-*`. This routing holds because
`useEsbuildTranspile` is `true`; there is also a `core-ci` task that does run
`transpile` into `out-build`, but no workflow in either repo invokes it.

Two consequences worth flagging for review:

- The `EMFILE` bug could only ever have bitten local dev, which is why it showed
  up as a Windows dev-launch failure and never as a red build.
- Conversely, CI won't validate this fix much. The e2e lanes exercise the gulp
  path, so they would never have caught the regression either. `sessions-e2e`
  (ubuntu) is the one CI job that runs the changed code.

The remaining `Promise.all` sites in the file are all inherently small: 3
standalone preload files, the bundle entry-point list, the mangle/NLS
post-process set, and the watch *incremental* batches (bounded by files changed
per debounce). That last one is why incremental cycles never hit `EMFILE` and
never retried the files the initial build lost.

### Release Notes

Build infrastructure only, no user-facing behavior change.

#### New Features

- N/A

#### Bug Fixes

- N/A


### Validation Steps

No feature e2e tags apply. Per the scope table above, `sessions-e2e` (ubuntu) is
the one CI job that exercises this code. To validate locally on Windows:

1. `npm run transpile-client` completes cleanly with no `EMFILE` error. On my
   machine: 8205 files, `[transpile] Done in 12362ms`, 15.9s total.
2. Confirm `out/` is complete afterward -- in particular that
   `out/vs/base/common/semver/semver.js` exists, since that was one of the files
   silently dropped before.
3. Launch the dev build and confirm no `ERR_MODULE_NOT_FOUND`.
4. `npm run typecheck` in `build/` reports no new errors. Note that
   `build/gulpfile.vscode.linux.ts` has 2 pre-existing unused-variable errors
   (`packageJson`, `commit`) that are unrelated to this change and also present
   on `main`.
