### PR TITLE
Show the update notification once per pending version

### DIFF
--- a/.github/workflows/test-tag-paths-map.json
+++ b/.github/workflows/test-tag-paths-map.json
@@ -157,6 +157,7 @@
   "src/vs/workbench/contrib/inlineChat/browser/positronNotebookUtils.ts": ["@:positron-notebooks", "@:assistant"],
   "src/vs/workbench/contrib/preferences/": [],
   "src/vs/workbench/contrib/preferences/common/positronSettingBadges.ts": ["@:vscode-settings"],
+  "src/vs/workbench/contrib/update/": [],
   "src/vs/workbench/contrib/welcomeGettingStarted/": [],
   "src/vs/workbench/contrib/welcomeGettingStarted/browser/media/positronGettingStarted.css": ["@:welcome"],
   "src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcome": ["@:welcome"],

--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -46,6 +46,7 @@ import { getInternalOrg } from '../../../../platform/assignment/common/assignmen
 // --- Start Positron ---
 // Upstream's IVersion / tryParseVersion are unused — Positron uses calver parsing below.
 import { IPositronVersion, parse } from '../../../../platform/update/common/positronVersion.js';
+import { UpdateNotificationThrottle } from '../common/positronUpdateNotificationThrottle.js';
 // --- End Positron ---
 
 export const CONTEXT_UPDATE_STATE = new RawContextKey<string>('updateState', StateType.Uninitialized);
@@ -267,6 +268,7 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 	private majorMinorUpdateAvailableContextKey: IContextKey<boolean>;
 	// --- Start Positron ---
 	private explicitCheck: boolean = false;
+	private readonly notificationThrottle = new UpdateNotificationThrottle();
 	// --- End Positron ---
 
 	constructor(
@@ -449,6 +451,15 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 			return;
 		}
 
+		// --- Start Positron ---
+		// Cap repeats at one notification per pending version per window session.
+		// Checked here, below the early return above, so we only ever record a
+		// notification we actually showed.
+		if (!this.explicitCheck && !this.notificationThrottle.shouldNotify('availableForDownload', update)) {
+			return;
+		}
+		// --- End Positron ---
+
 		this.notificationService.prompt(
 			severity.Info,
 			nls.localize('thereIsUpdateAvailable', "There is an available update."),
@@ -493,6 +504,15 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 			return;
 		}
 
+		// --- Start Positron ---
+		// Cap repeats at one notification per pending version per window session.
+		// Checked here, below the early return above, so we only ever record a
+		// notification we actually showed.
+		if (!this.explicitCheck && !this.notificationThrottle.shouldNotify('downloaded', update)) {
+			return;
+		}
+		// --- End Positron ---
+
 		this.notificationService.prompt(
 			severity.Info,
 			nls.localize('updateAvailable', "There's an update available: {0} {1}", this.productService.nameLong, productVersion),
@@ -526,6 +546,18 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 		// Otherwise respect the throttle
 		const isWindowsSystemWide = isWindows && this.productService.target !== 'user';
 		if (!isWindowsSystemWide && !this.explicitCheck && !this.shouldShowNotification()) {
+			return;
+		}
+
+		// Then cap repeats at one notification per pending version per window
+		// session. The update service can re-enter `Ready` indefinitely for a
+		// single pending update, and upstream's staleness gate above has no
+		// ceiling once it opens. See #15031.
+		//
+		// Unlike that gate, this cap also applies to Windows system-wide
+		// installs, which are just as capable of storming. Only an explicit
+		// "Check for Updates" skips it, because the user asked just now.
+		if (!this.explicitCheck && !this.notificationThrottle.shouldNotify('ready', update)) {
 			return;
 		}
 		// --- End Positron ---

--- a/src/vs/workbench/contrib/update/common/positronUpdateNotificationThrottle.ts
+++ b/src/vs/workbench/contrib/update/common/positronUpdateNotificationThrottle.ts
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IUpdate } from '../../../../platform/update/common/update.js';
+
+/**
+ * The distinct notifications a single pending update can produce as it moves
+ * through the update state machine. Each one tells the user something
+ * different, so each is throttled separately.
+ */
+export type UpdateNotificationStage = 'availableForDownload' | 'downloaded' | 'ready';
+
+/**
+ * Caps update notifications at one per pending version per stage, for the
+ * lifetime of a window.
+ *
+ * The update service can re-enter a notifying state any number of times for
+ * the same pending update. On Windows a deadlocked installer does exactly
+ * that, which is what produced the notification storm in #15031. Upstream's
+ * `shouldShowNotification()` gates on how stale the installed build is, but
+ * puts no ceiling on how often it fires once that gate opens; this supplies
+ * the ceiling.
+ *
+ * State is deliberately in-memory and per window. After a reload or a restart
+ * the update is still pending and worth mentioning once more.
+ */
+export class UpdateNotificationThrottle {
+
+	private readonly notified = new Set<string>();
+
+	/**
+	 * Returns `true` the first time an update version is seen at a given
+	 * stage, and `false` for every repeat within the same window session.
+	 */
+	shouldNotify(stage: UpdateNotificationStage, update: IUpdate): boolean {
+		const version = update.productVersion || update.version;
+		const key = `${stage}:${version}`;
+
+		if (this.notified.has(key)) {
+			return false;
+		}
+
+		this.notified.add(key);
+		return true;
+	}
+}

--- a/src/vs/workbench/contrib/update/test/browser/updateContribution.vitest.ts
+++ b/src/vs/workbench/contrib/update/test/browser/updateContribution.vitest.ts
@@ -1,0 +1,180 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { Emitter } from '../../../../../base/common/event.js';
+import { Disposable, IDisposable } from '../../../../../base/common/lifecycle.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { IUpdateService, State, StateType, UpdateType } from '../../../../../platform/update/common/update.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { IActivityService } from '../../../../services/activity/common/activity.js';
+import { TestProductService } from '../../../../test/common/workbenchTestServices.js';
+import { UpdateContribution } from '../../browser/update.js';
+
+describe('UpdateContribution update notifications', () => {
+	const COMMIT = 'a1b2c3d4e5f6';
+	const DAY_MILLIS = 1000 * 60 * 60 * 24;
+
+	const ctx = createTestContainer()
+		.withWorkbenchServices()
+		.build();
+
+	const prompt = vi.fn<INotificationService['prompt']>();
+	const onStateChange = new Emitter<State>();
+
+	let contribution: IDisposable | undefined;
+
+	/** A `ready` state for a pending update, as the update service would emit it. */
+	function ready(productVersion: string): State {
+		return {
+			type: StateType.Ready,
+			update: { version: `commit-${productVersion}`, productVersion },
+			explicit: false,
+			overwrite: false,
+		};
+	}
+
+	/** An `available for download` state, the notifying stage on Linux. */
+	function availableForDownload(productVersion: string): State {
+		return {
+			type: StateType.AvailableForDownload,
+			update: { version: `commit-${productVersion}`, productVersion },
+		};
+	}
+
+	/** Opens or closes upstream's staleness gate by backdating the notification clock. */
+	function seedStalenessGate(daysSinceLastNotification: number): void {
+		const storageService = ctx.get(IStorageService);
+		storageService.store('update/lastKnownVersion', COMMIT, StorageScope.APPLICATION, StorageTarget.MACHINE);
+		storageService.store('update/updateNotificationTime', Date.now() - daysSinceLastNotification * DAY_MILLIS, StorageScope.APPLICATION, StorageTarget.MACHINE);
+	}
+
+	/** The state handler is `async`; let any pending work settle before asserting. */
+	function settle(): Promise<void> {
+		return new Promise(resolve => setTimeout(resolve, 0));
+	}
+
+	function createContribution(): void {
+		contribution = new UpdateContribution(
+			ctx.get(IStorageService),
+			stubInterface<IInstantiationService>({}),
+			stubInterface<IUpdateService>({
+				onStateChange: onStateChange.event,
+				state: { type: StateType.Idle, updateType: UpdateType.Setup },
+			}),
+			stubInterface<IActivityService>({ showGlobalActivity: () => Disposable.None }),
+			ctx.get(IContextKeyService),
+			// `target: 'user'` keeps the Windows system-wide bypass out of play, so
+			// these tests exercise the same path on every platform.
+			{ ...TestProductService, commit: COMMIT, target: 'user' },
+			stubInterface<INotificationService>({ prompt }),
+			ctx.get(IConfigurationService),
+		);
+	}
+
+	beforeEach(() => {
+		// Six days stale, so upstream's `shouldShowNotification()` gate is open and
+		// the session cap is the only thing left standing between the update
+		// service and the user.
+		seedStalenessGate(6);
+	});
+
+	afterEach(() => {
+		contribution?.dispose();
+		contribution = undefined;
+	});
+
+	it('shows one prompt when the same update repeatedly re-enters the ready state', async () => {
+		createContribution();
+
+		// A deadlocked Windows installer drops the state machine back to `ready`
+		// over and over for one pending update. See #15031.
+		for (let i = 0; i < 5; i++) {
+			onStateChange.fire(ready('2026.09.0'));
+		}
+		await settle();
+
+		expect(prompt).toHaveBeenCalledOnce();
+	});
+
+	it('shows a new prompt once a newer version becomes ready', async () => {
+		createContribution();
+
+		onStateChange.fire(ready('2026.09.0'));
+		onStateChange.fire(ready('2026.09.1'));
+		await settle();
+
+		expect(prompt.mock.calls.map(call => call[1])).toEqual([
+			expect.stringContaining('2026.09.0'),
+			expect.stringContaining('2026.09.1'),
+		]);
+	});
+
+	it('shows a prompt every time when the user explicitly checks for updates', async () => {
+		createContribution();
+
+		for (let i = 0; i < 3; i++) {
+			onStateChange.fire({ type: StateType.CheckingForUpdates, explicit: true });
+			onStateChange.fire(ready('2026.09.0'));
+		}
+		await settle();
+
+		expect(prompt).toHaveBeenCalledTimes(3);
+	});
+
+	it('shows one prompt when the same download stays available', async () => {
+		createContribution();
+
+		for (let i = 0; i < 5; i++) {
+			onStateChange.fire(availableForDownload('2026.09.0'));
+		}
+		await settle();
+
+		expect(prompt).toHaveBeenCalledOnce();
+	});
+
+	it('shows a prompt every time an explicit check finds a download available', async () => {
+		createContribution();
+
+		// The Linux stage has no staleness bypass for explicit checks upstream,
+		// but the session cap must never swallow a check the user just asked for.
+		onStateChange.fire({ type: StateType.CheckingForUpdates, explicit: true });
+		onStateChange.fire(availableForDownload('2026.09.0'));
+		onStateChange.fire(availableForDownload('2026.09.0'));
+		await settle();
+
+		expect(prompt).toHaveBeenCalledTimes(2);
+	});
+
+	it('shows no prompt within five days of the installed build', async () => {
+		seedStalenessGate(2);
+
+		createContribution();
+		onStateChange.fire(ready('2026.09.0'));
+		await settle();
+
+		expect(prompt).not.toHaveBeenCalled();
+	});
+
+	it('does not spend the session cap on a prompt the staleness gate suppressed', async () => {
+		seedStalenessGate(2);
+		createContribution();
+
+		onStateChange.fire(ready('2026.09.0'));
+		// The same pending update, now that the installed build has gone stale.
+		seedStalenessGate(6);
+		onStateChange.fire(ready('2026.09.0'));
+		onStateChange.fire(ready('2026.09.0'));
+		await settle();
+
+		expect(prompt).toHaveBeenCalledOnce();
+	});
+});

--- a/src/vs/workbench/contrib/update/test/common/positronUpdateNotificationThrottle.vitest.ts
+++ b/src/vs/workbench/contrib/update/test/common/positronUpdateNotificationThrottle.vitest.ts
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { IUpdate } from '../../../../../platform/update/common/update.js';
+import { UpdateNotificationThrottle } from '../../common/positronUpdateNotificationThrottle.js';
+
+describe('UpdateNotificationThrottle', () => {
+	function update(version: string, productVersion?: string): IUpdate {
+		return { version, productVersion };
+	}
+
+	it('suppresses every repeat of the same version at the same stage', () => {
+		const throttle = new UpdateNotificationThrottle();
+		const pending = update('commit-one', '2026.09.0');
+
+		// A deadlocked installer can drop the state machine back to `ready`
+		// indefinitely; only the first pass should reach the user.
+		const results = Array.from({ length: 5 }, () => throttle.shouldNotify('ready', pending));
+
+		expect(results).toEqual([true, false, false, false, false]);
+	});
+
+	it('notifies again once a newer version becomes pending', () => {
+		const throttle = new UpdateNotificationThrottle();
+		throttle.shouldNotify('ready', update('commit-one', '2026.09.0'));
+
+		expect(throttle.shouldNotify('ready', update('commit-two', '2026.09.1'))).toBe(true);
+	});
+
+	it('tracks stages independently, so the downloaded toast does not swallow the ready toast', () => {
+		const throttle = new UpdateNotificationThrottle();
+		const pending = update('commit-one', '2026.09.0');
+		throttle.shouldNotify('downloaded', pending);
+
+		expect(throttle.shouldNotify('ready', pending)).toBe(true);
+	});
+
+	it('keys on productVersion when present, ignoring the raw version', () => {
+		const throttle = new UpdateNotificationThrottle();
+		throttle.shouldNotify('ready', update('commit-one', '2026.09.0'));
+
+		expect(throttle.shouldNotify('ready', update('commit-two', '2026.09.0'))).toBe(false);
+	});
+
+	it('falls back to the raw version when productVersion is absent', () => {
+		const throttle = new UpdateNotificationThrottle();
+		throttle.shouldNotify('ready', update('commit-one'));
+
+		expect([
+			throttle.shouldNotify('ready', update('commit-one')),
+			throttle.shouldNotify('ready', update('commit-two')),
+		]).toEqual([false, true]);
+	});
+});


### PR DESCRIPTION
Fixes #15031

Update notifications can repeat without limit for one pending update. This change adds a ceiling of one notification for each pending version, at each stage, for the life of a window.

`shouldShowNotification()` is upstream code. It gates update notifications on the age of the installed build. It compares `productService.commit` with a stored value, and it returns `true` after more than 5 days. The counter resets each time the installed commit changes. The gate has _no_ ceiling. After 5 days it returns `true` on every call. Nothing records that a notification was already shown, and the "Later" button stores nothing. Notification volume is therefore zero or unbounded:

- Day 0 to day 5 after a successful update: no automatic notifications.
- Day 6 onward: one notification for each state change, without limit.

This behavior is pretty much backwards for our daily build folks. A user who updates every day resets the counter every day and never reaches day 6. That user gets no notifications at all. When updates start to fail, the commit stops changing, day 6 arrives, and the gate stays open forever.

The reporter saw the second case. The Windows installer deadlock in #13988 holds the setup mutex. `doApplyUpdate()` then skips the spawn, and the state machine returns to `Ready` at once. Each return produced another notification.

### The fix

A new `UpdateNotificationThrottle` records one notification for each pending version at each stage. The record is in memory and lasts for the life of the window. The cap sits below the staleness gate, and the gate itself does not change.

| User | Before | After |
|---|---|---|
| Daily builds, updates succeed | 0 notifications | 0 notifications |
| Monthly release, one pending version | 1 notification | 1 notification |
| More than 5 days stale, updates fail | unbounded | 1 for each stage, each session |

The change only removes notifications. No user sees more notifications than before.

Two details are deliberate:

- The order. The staleness gate runs first. If the cap ran first, a notification that the gate stopped would use the session slot. The update could then never notify again in that window.
- The scope. The cap also applies to Windows system-wide installs, although the staleness gate does not. These installs sit behind the same deadlocked installer. Only an explicit "Check for Updates" skips the cap, because the user asked for an answer.

### Scope

This change does _not_ correct #13988. That issue still owns the installer deadlock that produces the repeats. This change just guarantees that a single pending update cannot produce more than one notification for each stage in each window session.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Show the update notification once for each pending version (#15031)

### Validation Steps

No e2e tags apply here, and there's nothing to check in a dev build. A build from source has no `commit` in `product.json`, so `shouldShowNotification()` always returns `false` and no automatic notification appears.

Coverage is 12 Vitest tests. These are the first tests of `UpdateContribution`.

```
npx vitest run src/vs/workbench/contrib/update/
```

Full confirmation needs some miles on this with Windows daily build users, probably after #13988 lands as well.