### PR TITLE
Packages Pane: keep names readable at narrow widths, add keyboard access to the row menu

### DIFF
--- a/src/vs/workbench/browser/positronList/classes/positronListInstance.tsx
+++ b/src/vs/workbench/browser/positronList/classes/positronListInstance.tsx
@@ -288,6 +288,19 @@ export class PositronListInstance<TItem, TSection = never> extends DataGridInsta
 		return selected;
 	}
 
+	/**
+	 * Returns the item the cursor is on, or undefined when the cursor is out of range or sitting on
+	 * a section row.
+	 *
+	 * This is the item a keyboard-invoked action should act on. Arrow keys move the cursor without
+	 * moving the selection, so the two disagree as soon as the user navigates, and the cursor is
+	 * the row the user sees as current. A mouse click sets both, so the two agree on that path.
+	 */
+	getCursorItem(): TItem | undefined {
+		const entry = this._entries[this.cursorRowIndex];
+		return entry?.kind === 'item' ? entry.item : undefined;
+	}
+
 	//#endregion Public Methods
 
 	//#region DataGridInstance Implementation

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
@@ -141,13 +141,15 @@
 	font-weight: bold;
 }
 
+/*
+ * The version never shrinks: a truncated version number ("1.0...") is misinformation, while a
+ * truncated name is still identifiable, so the name absorbs all of the ellipsis. Without this the
+ * two shrink at equal priority and a long package name truncates the version even in a wide pane.
+ */
 .packages-list-item-version {
-	flex: 0 1 auto;
-	min-width: 0;
+	flex: 0 0 auto;
 	opacity: 0.7;
 	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
 	font-size: 0.9em;
 	margin-left: 0.5em;
 }

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
@@ -51,11 +51,17 @@ const positronUpdatePackage = localize(
 const ROW_ITEM_HEIGHT = 26;
 const CARD_ITEM_HEIGHT = 72;
 
+// Width below which fixed-size controls are dropped so the package name and version are kept.
+const NARROW_WIDTH_THRESHOLD = 240;
+
 export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 	const {
 		activeInstance,
 	} = usePositronPackagesContext();
 	const services = usePositronReactServicesContext();
+
+	// Whether the pane is too narrow to spend width on the item's fixed-size controls.
+	const isNarrow = props.width < NARROW_WIDTH_THRESHOLD;
 
 	const [packages, setPackages] = useState<ILanguageRuntimePackage[]>([]);
 
@@ -314,6 +320,81 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 		await showPackageHelp(session, services.positronHelpService, services.notificationService, packageName);
 	}, [activeInstance, services]);
 
+	// Shows the row context menu for a package, anchored on either a point (right-click) or an
+	// element (keyboard). Defined at component scope rather than inside the item renderer because
+	// the keyboard path below has no item closure to reach into: it looks the package up from the
+	// list's cursor instead. Both paths must offer the same actions.
+	const showPackageContextMenu = useCallback((
+		pkg: ILanguageRuntimePackage,
+		anchor: { x: number; y: number } | HTMLElement
+	) => {
+		const { name, version, url } = pkg;
+		// Validate the kernel-provided URL in core: only surface http(s) links so a malformed or
+		// non-web scheme (file:, javascript:, ...) coming from the runtime can never reach the
+		// opener.
+		const hasValidUrl = !!url && matchesSomeScheme(url, Schemas.http, Schemas.https);
+
+		services.contextMenuService.showContextMenu({
+			getActions: () => [
+				{
+					id: 'showHelp',
+					label: localize('positronPackages.showHelp', "Show Help"),
+					tooltip: localize('positronPackages.showHelp', "Show Help"),
+					class: undefined,
+					enabled: true,
+					run: () => { void showHelpForPackage(name); }
+				},
+				// Mirrors the icon button, which is only rendered for a package that has a
+				// valid website. This is also the only way to reach the website once the
+				// pane is too narrow to render that button.
+				...(hasValidUrl ? [{
+					id: 'openWebsite',
+					label: localize('positronPackages.openWebsite', "Open Website"),
+					tooltip: localize('positronPackages.openWebsite', "Open Website"),
+					class: undefined,
+					enabled: true,
+					run: () => { void services.openerService.open(URI.parse(url!), { openExternal: true }); }
+				}] : []),
+				new Separator(),
+				{
+					id: 'copy',
+					label: localize('positronPackages.copyPackage', "Copy '{0} ({1})'", name, version),
+					tooltip: localize('positronPackages.copyPackage', "Copy '{0} ({1})'", name, version),
+					class: undefined,
+					enabled: true,
+					run: () => services.clipboardService.writeText(`${name} (${version})`)
+				},
+				{
+					id: 'copyAll',
+					label: localize('positronPackages.copyAllPackages', 'Copy All'),
+					tooltip: localize('positronPackages.copyAllPackages', 'Copy All'),
+					class: undefined,
+					enabled: true,
+					run: () => services.clipboardService.writeText(deduplicatedPackages.map((p) => `${p.name} (${p.version})`).join('\n'))
+				},
+				new Separator(),
+				{
+					id: 'updatePackage',
+					label: positronUpdatePackage,
+					tooltip: positronUpdatePackage,
+					class: undefined,
+					enabled: true,
+					run: () => services.commandService.executeCommand('positronPackages.updatePackage', name)
+
+				},
+				{
+					id: 'uninstallPackage',
+					label: positronUninstallPackage,
+					tooltip: positronUninstallPackage,
+					class: undefined,
+					enabled: true,
+					run: () => services.commandService.executeCommand('positronPackages.uninstallPackage', name)
+				}
+			],
+			getAnchor: () => anchor
+		});
+	}, [services, deduplicatedPackages, showHelpForPackage]);
+
 	// Replace the item renderer whenever its closed-over deps change so the latest
 	// deduplicatedPackages snapshot is visible to "Copy All" and clicks select via the
 	// instance.
@@ -329,57 +410,11 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 			// resolver-supplied `latestVersion` (or P3M as fallback) feeds the
 			// tooltip; without it we'd render "Update available: undefined".
 			const hasUpdate = outdated === true && !!latestVersion;
-
-			const showRowContextMenu = (anchor: { x: number; y: number }) => {
-				services.contextMenuService.showContextMenu({
-					getActions: () => [
-						{
-							id: 'showHelp',
-							label: localize('positronPackages.showHelp', "Show Help"),
-							tooltip: localize('positronPackages.showHelp', "Show Help"),
-							class: undefined,
-							enabled: true,
-							run: () => { void showHelpForPackage(name); }
-						},
-						new Separator(),
-						{
-							id: 'copy',
-							label: localize('positronPackages.copyPackage', "Copy '{0} ({1})'", name, version),
-							tooltip: localize('positronPackages.copyPackage', "Copy '{0} ({1})'", name, version),
-							class: undefined,
-							enabled: true,
-							run: () => services.clipboardService.writeText(`${name} (${version})`)
-						},
-						{
-							id: 'copyAll',
-							label: localize('positronPackages.copyAllPackages', 'Copy All'),
-							tooltip: localize('positronPackages.copyAllPackages', 'Copy All'),
-							class: undefined,
-							enabled: true,
-							run: () => services.clipboardService.writeText(deduplicatedPackages.map((pkg) => `${pkg.name} (${pkg.version})`).join('\n'))
-						},
-						new Separator(),
-						{
-							id: 'updatePackage',
-							label: positronUpdatePackage,
-							tooltip: positronUpdatePackage,
-							class: undefined,
-							enabled: true,
-							run: () => services.commandService.executeCommand('positronPackages.updatePackage', name)
-
-						},
-						{
-							id: 'uninstallPackage',
-							label: positronUninstallPackage,
-							tooltip: positronUninstallPackage,
-							class: undefined,
-							enabled: true,
-							run: () => services.commandService.executeCommand('positronPackages.uninstallPackage', name)
-						}
-					],
-					getAnchor: () => anchor
-				});
-			};
+			// Card mode advertises an update with a ~60px "Update" button on the description row,
+			// which is more width than a narrow pane can spare. Below the threshold it falls back
+			// to the compact arrow that row mode already uses; updating is still a right-click away.
+			const showUpdateButton = hasUpdate && itemSize === 'card' && !isNarrow;
+			const showUpdateIndicator = hasUpdate && !showUpdateButton;
 
 			const helpButton = (
 				<Button
@@ -403,7 +438,9 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 				</Button>
 			) : null;
 
-			const rowActions = (
+			// The buttons are a fixed width, so at narrow pane widths they squeeze the name and
+			// version into ellipses. Drop them below the threshold and let right-click carry them.
+			const rowActions = isNarrow ? null : (
 				<>
 					{urlButton}
 					{helpButton}
@@ -419,7 +456,7 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 						// mousedown, so right-click handling lives on contextmenu instead.
 						e.preventDefault();
 						e.stopPropagation();
-						showRowContextMenu({ x: e.clientX, y: e.clientY });
+						showPackageContextMenu(pkg, { x: e.clientX, y: e.clientY });
 					}}
 					onDoubleClick={() => {
 						// Double-click pins the editor (matching the Extensions pane behaviour).
@@ -443,7 +480,7 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 						<div className='packages-list-item-header'>
 							<div className='packages-list-item-name'>{displayName}</div>
 							<div className='packages-list-item-version'>{version}</div>
-							{itemSize === 'row' && hasUpdate && (
+							{showUpdateIndicator && (
 								<div
 									className='packages-list-item-update'
 									title={localize('positronPackages.updateAvailable', "Update available: {0}", latestVersion)}
@@ -458,7 +495,7 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 								<div className='packages-list-item-description' title={description ?? ''}>
 									{description ?? ''}
 								</div>
-								{hasUpdate && (
+								{showUpdateButton && (
 									<Button
 										ariaLabel={localize('positronPackages.updatePackageAria', "Update {0} to {1}", name, latestVersion)}
 										className='packages-list-item-update-button'
@@ -477,7 +514,7 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 		};
 
 		listInstance.setItemRenderer(renderItem);
-	}, [listInstance, deduplicatedPackages, services, itemSize, showHelpForPackage, flashedIds]);
+	}, [listInstance, deduplicatedPackages, services, itemSize, isNarrow, showHelpForPackage, showPackageContextMenu, flashedIds]);
 
 	// Sync the currently-selected package's name into the packages service. onDidUpdate fires
 	// for any instance change (selection, cursor, scroll), so we dedupe before pushing.
@@ -601,6 +638,39 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 		});
 	};
 
+	// Shift+F10 and the ContextMenu key open the row menu, which is the keyboard equivalent of
+	// right-click. The data grid keeps DOM focus on its own container rather than on a row, so a
+	// keyboard-fired contextmenu event targets that container and never reaches the row's
+	// onContextMenu handler; the list has to translate these keys itself. This matters most below
+	// the narrow-width threshold, where the menu is the only route to the row's actions, but it is
+	// deliberately not width-gated: the menu's Copy and Uninstall entries have no button at any
+	// width. The keydown bubbles up from the focused grid container to this wrapper.
+	const handleListKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+		const isContextMenuKey = e.key === 'ContextMenu' || (e.key === 'F10' && e.shiftKey);
+		if (!isContextMenuKey) {
+			return;
+		}
+
+		// The menu acts on the row the cursor is on, not the selection. Arrow keys move the cursor
+		// and leave the selection behind, so targeting the selection would open the menu for a
+		// different package than the one the user navigated to. A click sets both, so the mouse
+		// path is unaffected.
+		const cursorItem = listInstance.getCursorItem();
+		if (!cursorItem) {
+			return;
+		}
+
+		e.preventDefault();
+		e.stopPropagation();
+
+		// Anchor on the cursor row so the menu opens next to it rather than at the pane's corner.
+		// The class is PositronList's default row styling, applied by the list itself. Falling back
+		// to the wrapper keeps the menu reachable if the row is scrolled out of the rendered window.
+		// eslint-disable-next-line no-restricted-syntax -- the row belongs to PositronList's DOM and carries no role or text of its own to query by.
+		const cursorRow = e.currentTarget.querySelector('.positron-list-row.focused');
+		showPackageContextMenu(cursorItem, (cursorRow as HTMLElement | null) ?? e.currentTarget);
+	};
+
 	// Only show the "No packages found" message when the user has narrowed the
 	// list (free text or active category filters). An unfiltered empty list
 	// renders the (empty) data grid, matching prior behavior.
@@ -623,7 +693,8 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 					onFilterTextChanged={handleFilterTextChanged}
 				/>
 			</div>
-			<div className='packages-list-container'>
+			{/* eslint-disable-next-line jsx-a11y/no-static-element-interactions -- this wrapper only relays a key the focused grid inside it does not handle; the grid owns the focus and the roles. */}
+			<div className='packages-list-container' onKeyDown={handleListKeyDown}>
 				<PositronList
 					emptyListRenderer={emptyListRenderer}
 					instance={listInstance}

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
@@ -52,7 +52,7 @@ const ROW_ITEM_HEIGHT = 26;
 const CARD_ITEM_HEIGHT = 72;
 
 // Width below which fixed-size controls are dropped so the package name and version are kept.
-const NARROW_WIDTH_THRESHOLD = 240;
+const NARROW_WIDTH_THRESHOLD = 200;
 
 export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 	const {

--- a/src/vs/workbench/contrib/positronPackages/test/browser/listPackages.vitest.tsx
+++ b/src/vs/workbench/contrib/positronPackages/test/browser/listPackages.vitest.tsx
@@ -35,6 +35,9 @@ const VIEWPORT_HEIGHT = 400;
 // Below NARROW_WIDTH_THRESHOLD, so the row actions and the Update button drop out.
 const NARROW_VIEWPORT_WIDTH = 180;
 
+// Positron's out-of-box sidebar width, measured in a clean profile at both 1280x800 and 1920x1080.
+const DEFAULT_SIDEBAR_WIDTH = 230;
+
 const pkg = (name: string, version: string): ILanguageRuntimePackage => ({
 	id: name,
 	name,
@@ -252,6 +255,16 @@ describe('ListPackages', () => {
 		expect(await screen.findByText('numpy')).toBeInTheDocument();
 
 		expect(screen.getByRole('button', { name: 'Open website for numpy' })).toBeInTheDocument();
+	});
+
+	// The default layout must not land in narrow mode. This pins the threshold below the shipped
+	// sidebar width so raising it cannot silently take the buttons away from every user.
+	it('keeps the row actions at the default sidebar width', async () => {
+		renderList(DEFAULT_SIDEBAR_WIDTH);
+		expect(await screen.findByText('numpy')).toBeInTheDocument();
+
+		expect(screen.getByRole('button', { name: 'Open website for numpy' })).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Show help for numpy' })).toBeInTheDocument();
 	});
 
 	// Card mode's Update button is a ~60px text button on the description row. Narrow, it is

--- a/src/vs/workbench/contrib/positronPackages/test/browser/listPackages.vitest.tsx
+++ b/src/vs/workbench/contrib/positronPackages/test/browser/listPackages.vitest.tsx
@@ -9,18 +9,21 @@
 import React from 'react';
 
 // Testing libraries.
-import { act, screen, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 // Other dependencies.
 import { Emitter, Event } from '../../../../../base/common/event.js';
+import { IAction } from '../../../../../base/common/actions.js';
 import { IReactComponentContainer } from '../../../../../base/browser/positronReactRenderer.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IContextMenuService } from '../../../../../platform/contextview/browser/contextView.js';
 import { ILanguageRuntimePackage } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { ListPackages } from '../../browser/components/listPackages.js';
+import { PackagesItemSize } from '../../browser/positronPackagesContextKeys.js';
 import { PositronPackagesContextProvider } from '../../browser/positronPackagesContext.js';
 import { IPositronPackagesService } from '../../browser/interfaces/positronPackagesService.js';
 import { IPositronPackagesInstance } from '../../browser/positronPackagesInstance.js';
@@ -28,6 +31,9 @@ import { IPositronPackagesInstance } from '../../browser/positronPackagesInstanc
 // A viewport large enough that both package rows paint at once.
 const VIEWPORT_WIDTH = 300;
 const VIEWPORT_HEIGHT = 400;
+
+// Below NARROW_WIDTH_THRESHOLD, so the row actions and the Update button drop out.
+const NARROW_VIEWPORT_WIDTH = 180;
 
 const pkg = (name: string, version: string): ILanguageRuntimePackage => ({
 	id: name,
@@ -72,8 +78,14 @@ describe('ListPackages', () => {
 	// tests fire them to drive the view (see the "Common mistakes" note in vitest-tests.md).
 	const onDidRefreshPackagesInstance = new Emitter<ILanguageRuntimePackage[]>();
 	const onDidChangePackages = new Emitter<string[]>();
-	// numpy carries a url so it renders both action buttons; pandas has none.
-	const installed = [{ ...pkg('numpy', '1.26.0'), url: 'https://numpy.org' }, pkg('pandas', '2.0.0')];
+	const onDidChangeItemSize = new Emitter<PackagesItemSize>();
+	// numpy carries a url so it renders both action buttons; pandas has none. polars is the
+	// outdated one, so it renders whichever update affordance the current width calls for.
+	const installed = [
+		{ ...pkg('numpy', '1.26.0'), url: 'https://numpy.org' },
+		pkg('pandas', '2.0.0'),
+		{ ...pkg('polars', '0.20.0'), outdated: true, latestVersion: '0.21.0' },
+	];
 
 	const fakeInstance = stubInterface<IPositronPackagesInstance>({
 		packages: installed,
@@ -83,18 +95,21 @@ describe('ListPackages', () => {
 		onDidChangePackages: onDidChangePackages.event,
 	});
 
+	const showContextMenu = vi.fn();
+
 	const ctx = createTestContainer()
 		.withReactServices()
 		.stub(IPositronPackagesService, {
 			activePackagesInstance: fakeInstance,
 			onDidChangeActivePackagesInstance: Event.None,
 			itemSize: 'row',
-			onDidChangeItemSize: Event.None,
+			onDidChangeItemSize: onDidChangeItemSize.event,
 			setSelectedPackage: vi.fn(),
 		})
 		// Selecting a package fires the (fire-and-forget) 'positronPackages.openPackage'
 		// command; stub it so these flash/select tests don't emit unhandled rejections.
 		.stub(ICommandService, { executeCommand: vi.fn() })
+		.stub(IContextMenuService, { showContextMenu })
 		.build();
 	const rtl = setupRTLRenderer(() => ctx.reactServices);
 
@@ -102,17 +117,20 @@ describe('ListPackages', () => {
 	// reactComponentContainer feeds; the container itself is never touched in these tests.
 	const reactComponentContainer = stubInterface<IReactComponentContainer>({});
 
-	let restoreLayout: () => void;
-	beforeEach(() => { restoreLayout = stubGridLayoutWithSize(VIEWPORT_WIDTH, VIEWPORT_HEIGHT); });
+	// Stubbed per render rather than in beforeEach so a test can render at a narrow width and have
+	// the grid's own measurements agree with the width prop it passes the component.
+	let restoreLayout: (() => void) | undefined;
 	afterEach(() => {
 		vi.unstubAllGlobals();
-		restoreLayout();
+		restoreLayout?.();
+		restoreLayout = undefined;
 	});
 
-	function renderList() {
+	function renderList(width = VIEWPORT_WIDTH) {
+		restoreLayout = stubGridLayoutWithSize(width, VIEWPORT_HEIGHT);
 		rtl.render(
 			<PositronPackagesContextProvider reactComponentContainer={reactComponentContainer}>
-				<ListPackages height={VIEWPORT_HEIGHT} reactComponentContainer={reactComponentContainer} width={VIEWPORT_WIDTH} />
+				<ListPackages height={VIEWPORT_HEIGHT} reactComponentContainer={reactComponentContainer} width={width} />
 			</PositronPackagesContextProvider>
 		);
 	}
@@ -214,5 +232,157 @@ describe('ListPackages', () => {
 		const labels = within(item).getAllByRole('button').map(button => button.getAttribute('aria-label'));
 
 		expect(labels).toEqual(['Open website for numpy', 'Show help for numpy']);
+	});
+
+	// The action buttons are a fixed 58px, which at the pane's minimum width squeezes the name down
+	// to an unreadable "nu..." (issue #15122). Below the threshold they drop out entirely and the
+	// context menu carries them instead.
+	it('drops the row actions below the narrow-width threshold', async () => {
+		renderList(NARROW_VIEWPORT_WIDTH);
+		expect(await screen.findByText('numpy')).toBeInTheDocument();
+
+		expect(screen.queryByRole('button', { name: 'Open website for numpy' })).not.toBeInTheDocument();
+		expect(screen.queryByRole('button', { name: 'Show help for numpy' })).not.toBeInTheDocument();
+		// The width the buttons vacate goes to the name and version, which stay whole.
+		expect(screen.getByText('1.26.0')).toBeInTheDocument();
+	});
+
+	it('keeps the row actions at normal widths', async () => {
+		renderList();
+		expect(await screen.findByText('numpy')).toBeInTheDocument();
+
+		expect(screen.getByRole('button', { name: 'Open website for numpy' })).toBeInTheDocument();
+	});
+
+	// Card mode's Update button is a ~60px text button on the description row. Narrow, it is
+	// replaced by the compact arrow indicator that row mode already uses, so the update stays
+	// visible without costing the description its width.
+	it('replaces the card Update button with the compact indicator below the threshold', async () => {
+		renderList(NARROW_VIEWPORT_WIDTH);
+		act(() => onDidChangeItemSize.fire('card'));
+		expect(await screen.findByText('polars')).toBeInTheDocument();
+
+		expect(screen.queryByRole('button', { name: 'Update polars to 0.21.0' })).not.toBeInTheDocument();
+		expect(screen.getByTitle('Update available: 0.21.0')).toBeInTheDocument();
+	});
+
+	it('keeps the card Update button at normal widths', async () => {
+		renderList();
+		act(() => onDidChangeItemSize.fire('card'));
+		expect(await screen.findByText('polars')).toBeInTheDocument();
+
+		expect(screen.getByRole('button', { name: 'Update polars to 0.21.0' })).toBeInTheDocument();
+		expect(screen.queryByTitle('Update available: 0.21.0')).not.toBeInTheDocument();
+	});
+
+	// Show Help has always been in the context menu; the website action joins it so the narrow
+	// layout hides nothing that right-click cannot reach.
+	it('offers the website action in the context menu', async () => {
+		const user = userEvent.setup();
+		renderList();
+		expect(await screen.findByText('numpy')).toBeInTheDocument();
+
+		await user.pointer({ keys: '[MouseRight]', target: itemRow('numpy') as HTMLElement });
+
+		const delegate = showContextMenu.mock.calls[0][0] as { getActions: () => IAction[] };
+		expect(delegate.getActions().map(action => action.label)).toContain('Open Website');
+	});
+
+	// At narrow widths the context menu is the only route to Show Help, Open Website and Update, so
+	// it has to open without a mouse. The grid puts DOM focus on its own container rather than on a
+	// row, so a keyboard-fired contextmenu event never reaches the row's own onContextMenu handler:
+	// the list has to handle these keys itself. Both keys are fired on a descendant of the list
+	// because the grid owns focus, which is exactly how the real keydown arrives (it bubbles).
+	const menuLabels = () => {
+		const delegate = showContextMenu.mock.calls[0][0] as { getActions: () => IAction[] };
+		// Separators report an empty label; drop them so the assertion reads as the visible menu.
+		return delegate.getActions().map(action => action.label).filter(Boolean);
+	};
+
+	it('opens the context menu for the selected package on Shift+F10', async () => {
+		renderList(NARROW_VIEWPORT_WIDTH);
+		expect(await screen.findByText('numpy')).toBeInTheDocument();
+		act(() => onDidChangePackages.fire(['numpy']));
+		await waitFor(() => expect(listRow('numpy')).toHaveClass('selected'));
+
+		// eslint-disable-next-line testing-library/prefer-user-event -- user.keyboard targets document.activeElement, and the virtualized grid takes no real DOM focus in happy-dom.
+		fireEvent.keyDown(screen.getByText('numpy'), { key: 'F10', code: 'F10', shiftKey: true });
+
+		expect(menuLabels()).toEqual([
+			'Show Help',
+			'Open Website',
+			`Copy 'numpy (1.26.0)'`,
+			'Copy All',
+			'Update Package',
+			'Uninstall Package',
+		]);
+	});
+
+	it('opens the context menu for the selected package on the ContextMenu key', async () => {
+		renderList(NARROW_VIEWPORT_WIDTH);
+		expect(await screen.findByText('numpy')).toBeInTheDocument();
+		act(() => onDidChangePackages.fire(['numpy']));
+		await waitFor(() => expect(listRow('numpy')).toHaveClass('selected'));
+
+		// eslint-disable-next-line testing-library/prefer-user-event -- see the note on the Shift+F10 test above.
+		fireEvent.keyDown(screen.getByText('numpy'), { key: 'ContextMenu', code: 'ContextMenu' });
+
+		expect(menuLabels()).toContain('Show Help');
+	});
+
+	// Arrow keys move the cursor but leave the selection behind, so the two disagree as soon as the
+	// user navigates. The menu has to act on the row the cursor is on, which is the one the user
+	// sees as current; acting on the selection would open the menu for a different package.
+	it('targets the row the cursor is on rather than a stale selection', async () => {
+		renderList(NARROW_VIEWPORT_WIDTH);
+		expect(await screen.findByText('numpy')).toBeInTheDocument();
+		act(() => onDidChangePackages.fire(['numpy']));
+		await waitFor(() => expect(listRow('numpy')).toHaveClass('selected'));
+
+		// eslint-disable-next-line testing-library/prefer-user-event -- see the note on the Shift+F10 test above.
+		fireEvent.keyDown(screen.getByText('numpy'), { key: 'ArrowDown', code: 'ArrowDown' });
+		// eslint-disable-next-line testing-library/prefer-user-event -- see the note on the Shift+F10 test above.
+		fireEvent.keyDown(screen.getByText('numpy'), { key: 'ContextMenu', code: 'ContextMenu' });
+
+		// numpy is still the selection, so a menu naming numpy means we targeted the wrong row.
+		expect(menuLabels()).toContain(`Copy 'pandas (2.0.0)'`);
+	});
+
+	// Without a selected package there is no row for the menu to act on.
+	it('opens the menu for the first row before anything is selected', async () => {
+		renderList(NARROW_VIEWPORT_WIDTH);
+		expect(await screen.findByText('numpy')).toBeInTheDocument();
+
+		// eslint-disable-next-line testing-library/prefer-user-event -- see the note on the Shift+F10 test above.
+		fireEvent.keyDown(screen.getByText('numpy'), { key: 'ContextMenu', code: 'ContextMenu' });
+
+		expect(menuLabels()).toContain(`Copy 'numpy (1.26.0)'`);
+	});
+
+	// An empty list has no row under the cursor, so the key has nothing to act on.
+	it('ignores the context menu key when the filter matches no packages', async () => {
+		const user = userEvent.setup();
+		renderList(NARROW_VIEWPORT_WIDTH);
+		expect(await screen.findByText('numpy')).toBeInTheDocument();
+
+		await user.type(screen.getByPlaceholderText('Filter packages'), 'nosuchpackage');
+		expect(await screen.findByText('No packages found.')).toBeInTheDocument();
+
+		// eslint-disable-next-line testing-library/prefer-user-event -- see the note on the Shift+F10 test above.
+		fireEvent.keyDown(screen.getByText('No packages found.'), { key: 'ContextMenu', code: 'ContextMenu' });
+
+		expect(showContextMenu).not.toHaveBeenCalled();
+	});
+
+	// pandas has no url, so there is nothing for the entry to open.
+	it('omits the website action for a package with no url', async () => {
+		const user = userEvent.setup();
+		renderList();
+		expect(await screen.findByText('pandas')).toBeInTheDocument();
+
+		await user.pointer({ keys: '[MouseRight]', target: itemRow('pandas') as HTMLElement });
+
+		const delegate = showContextMenu.mock.calls[0][0] as { getActions: () => IAction[] };
+		expect(delegate.getActions().map(action => action.label)).not.toContain('Open Website');
 	});
 });


### PR DESCRIPTION
Fixes #15122

At the minimum pane width, the Packages pane gave a fixed 58px to the two row action buttons and about 60px to the Update button. These controls squeezed the package name and version into ellipses. A row read "br... 1.0..." and told the user very little useful.

Below a 200px threshold, the item now drops the action buttons and the Update button. The compact update arrow that row mode already uses takes the place of the Update button. The threshold sits below Positron's 230px default sidebar width, so a default layout keeps its buttons. Only a pane that the user makes narrow loses them:

https://github.com/user-attachments/assets/817ffab3-490f-4289-a0a0-4e2a3262c839

The action buttons are reachable with the <kbd>Tab</kbd> key, so the narrow layout must not be the only path to them. The list now opens its row context menu on <kbd>Shift+F10</kbd> and on the <kbd>ContextMenu</kbd> key. The menu also gains an Open Website entry. The data grid keeps DOM focus on its own container instead of on a row, so a keyboard-fired contextmenu event never reaches the row handler. The list translates these two keys itself. This also gives Copy, Copy All and Uninstall a keyboard path at every width, which they did not have before.

The menu acts on the row that the cursor is on, not on the selection. Arrow keys move the cursor and leave the selection behind, so the two disagree after the user navigates. `PositronListInstance` gains `getCursorItem()` for this.

The version no longer shrinks at all, which I think is important here because arguably a truncated version is bordering on misinformation. The name and version shrank at equal priority, so a long name truncated the version even in a wide pane. The name now absorbs the ellipsis.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Keep package names and versions readable when the Packages pane is narrow (#15122)

### Validation Steps

@:packages-pane

1. Start an R or a Python session. Open the Packages pane.
2. Make the sidebar as narrow as it goes. Every row must show its full version. No version ends in an ellipsis.
3. Look at the package names at this width. Short and medium names show in full. A very long name still ends in an ellipsis, which is the expected behavior. The name should take _all_ of the space that is left, and the version keeps its own. (Before this change, both the name and the version were cut.(
4. Make the sidebar wider than 200px. The help button comes back on every row. The website button comes back on the rows for packages that publish a website. An outdated package shows the Update button again.
5. Keep the default sidebar width. Make sure that these buttons are visible. This is the layout before this change.
6. Make the sidebar narrow again. Click a package row. Press the arrow keys to move to a different package. Press <kbd>Shift+F10</kbd>. On macOS, press <kbd>fn+Shift+F10</kbd>, because <kbd>F10</kbd> is the mute key unless you set _Use F1, F2, etc. as standard function keys_. The context menu opens for the package that the cursor is on, not for the package you clicked.
7. If on Windows or Linux, do step 6 again with the <kbd>ContextMenu</kbd> key. This key is usually to the right of the space bar.
8. Make sure that the menu shows Show Help, Copy, Copy All, Update Package and Uninstall Package. For a package that has a website, the menu also shows Open Website.

