### PR TITLE
Quarto virtual notebook: serve language features for code cells in unsaved documents

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoVirtualNotebookService.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoVirtualNotebookService.ts
@@ -22,6 +22,7 @@ import { INotebookSerializer, INotebookService } from '../../notebook/common/not
 import {
 	QUARTO_NATIVE_LANGUAGE_FEATURES_KEY,
 	isQuartoDocument,
+	isQuartoOrRmdFile,
 	usingNativeEmbeddedFeatures,
 } from '../common/positronQuartoConfig.js';
 import { IQuartoDocumentModel } from '../common/quartoTypes.js';
@@ -126,6 +127,25 @@ class QuartoCellsSerializer implements INotebookSerializer {
 }
 
 /**
+ * The URI of the hidden notebook for a source document: the source URI under our
+ * own scheme, since the extension host cannot hold a text document and a notebook
+ * document at the same URI.
+ *
+ * The path is kept because a cell URI carries the path of the notebook it belongs
+ * to, and that path is how a language client tells our cells from the cells of a
+ * real notebook: both clients select on `**\/*.{qmd,rmd}`. An untitled document
+ * has no extension to select on ("Untitled-1", from _Quarto: New Document_), so
+ * it gets a Quarto one. Otherwise its cells reach no language server and the
+ * document silently has no language features.
+ */
+function quartoNotebookUri(sourceUri: URI): URI {
+	return sourceUri.with({
+		scheme: QUARTO_CELLS_SCHEME,
+		path: isQuartoOrRmdFile(sourceUri.path) ? sourceUri.path : `${sourceUri.path}.qmd`,
+	});
+}
+
+/**
  * The hidden notebook backing a single Quarto document, and the machinery that
  * keeps it in sync with the source text model.
  */
@@ -144,7 +164,7 @@ class QuartoVirtualNotebook extends Disposable {
 		private readonly _logService: ILogService,
 	) {
 		super();
-		this.notebookUri = sourceUri.with({ scheme: QUARTO_CELLS_SCHEME });
+		this.notebookUri = quartoNotebookUri(sourceUri);
 
 		// onDidParse rather than onDidChangeCells: cells also need re-syncing when
 		// they merely move, which happens whenever prose above a chunk grows or

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoVirtualNotebookService.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoVirtualNotebookService.vitest.ts
@@ -258,6 +258,30 @@ describe('QuartoVirtualNotebookService', () => {
 		return model;
 	}
 
+	/**
+	 * An untitled Quarto document, which is what _Quarto: New Document_ produces:
+	 * a bare name with no `.qmd` on it, recognized by its language instead.
+	 */
+	function createUntitledSourceModel(content: string, path = 'Untitled-1'): ITextModel {
+		const modelService = ctx.instantiationService.get(IModelService);
+		const languageService = ctx.instantiationService.get(ILanguageService);
+		// The Quarto extension contributes the `quarto` language, so nothing has
+		// registered it here, and `createById` falls back to plaintext for an
+		// unknown id. Without the language the document is unrecognizable: its
+		// path is the other half of the check, and an untitled path has no
+		// extension to go on.
+		if (!languageService.isRegisteredLanguageId('quarto')) {
+			ctx.disposables.add(languageService.registerLanguage({ id: 'quarto', extensions: ['.qmd'] }));
+		}
+		const model = modelService.createModel(
+			content,
+			languageService.createById('quarto'),
+			URI.from({ scheme: Schemas.untitled, path })
+		);
+		ctx.disposables.add(model);
+		return model;
+	}
+
 	it('creates a hidden notebook whose URI keeps the source path', async () => {
 		const service = createService();
 		const source = createSourceModel(R_AND_PYTHON);
@@ -278,6 +302,34 @@ describe('QuartoVirtualNotebookService', () => {
 			viewType: QUARTO_CELLS_VIEW_TYPE,
 			cellCount: 2,
 		});
+	});
+
+	it('gives an untitled document a Quarto path, so the LSP clients match its cells', async () => {
+		const service = createService();
+		const source = createUntitledSourceModel(R_AND_PYTHON);
+		await service.whenReady(source.uri);
+
+		// A cell URI carries the path of the notebook it belongs to, and both LSP
+		// clients gate on that path ending in `.qmd` or `.rmd`, which is what
+		// keeps the cells of real notebooks out. A bare untitled path would match
+		// nothing, so the cells would reach no language server.
+		expect({
+			sourcePath: source.uri.path,
+			notebookPath: service.getNotebookUri(source.uri)?.path,
+			cellPaths: service.getCells(source.uri).map(cell => cell.cellUri.path),
+		}).toEqual({
+			sourcePath: 'Untitled-1',
+			notebookPath: 'Untitled-1.qmd',
+			cellPaths: ['Untitled-1.qmd', 'Untitled-1.qmd'],
+		});
+	});
+
+	it('leaves an untitled document that already has a Quarto path alone', async () => {
+		const service = createService();
+		const source = createUntitledSourceModel(R_AND_PYTHON, 'Untitled-1.qmd');
+		await service.whenReady(source.uri);
+
+		expect(service.getNotebookUri(source.uri)?.path).toBe('Untitled-1.qmd');
 	});
 
 	it('creates one bound cell text model per code cell, holding only the code', async () => {


### PR DESCRIPTION
Related to:

- https://github.com/posit-dev/positron/issues/12837
- https://github.com/posit-dev/positron/pull/15415

A cell URI keeps the path of the notebook that owns it. Both language clients select cells with the pattern `**/*.{qmd,rmd}`. This pattern is what keeps the cells of real notebooks out. An unsaved document has no file extension on its path and no pattern matched its cells, so Positron built the cells and no language server ever saw them.

The virtual notebook now gets a Quarto path even when the source document does not have one, the same way Positron's Quarto kernel manager does (like for the session reconnect logic). The path `Untitled-1` becomes `quarto-cells:Untitled-1.qmd`. Both clients then match the cells in the same way as for a saved document, and the cells of real notebooks stay excluded.

The setting `quarto.embeddedLanguageFeatures.native` is still off by default, so nothing changes for users yet.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:quarto @:r-markdown

Unit tests: `npx vitest run src/vs/workbench/contrib/positronQuarto/test/browser/quartoVirtualNotebookService.vitest.ts`

Note: no e2e test can tell this path apart from the virtual documents of the Quarto extension for now; we'll eventually address that.

1. Set `"quarto.embeddedLanguageFeatures.native": true`.
2. Run _Developer: Set Log Level..._. Select **Window**, then select **Trace**.
3. Run _Developer: Show Window Log_.
4. Run _Quarto: New Quarto Document (qmd)_.
5. Make sure that the log shows `[QuartoVirtualNotebook] Created quarto-cells:Untitled-1.qmd with 0 cells`. The `.qmd` extension is the fix.
6. Add an R chunk that holds `x <- data.frame(alpha = 1, beta = 2)` and `x`.
7. Click **Run Cell** to start an R session if you don't already have one.
8. Type `$` after `x` inside the chunk.
9. Make sure that the log shows `[QuartoEmbedded] completion answered from cell N-M by 2 provider(s)`.
10. Set the setting to `false`.
11. Type `$` again.
12. Make sure that no new `[QuartoEmbedded]` line appears, and that completions still work. This step shows that the line in step 9 comes from this path.

Remember that `alpha` and `beta` appear in the suggest widget in both cases. The widget cannot show which path answered.
