### PR TITLE
Stop the console from stealing focus when another view or editor is focused

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -18,9 +18,7 @@ import { ISelection } from '../../../../../editor/common/core/selection.js';
 import { IKeyboardEvent } from '../../../../../base/browser/keyboardEvent.js';
 import { useStateRef } from '../../../../../base/browser/ui/react/useStateRef.js';
 import { CursorChangeReason } from '../../../../../editor/common/cursorEvents.js';
-import { EditorContextKeys } from '../../../../../editor/common/editorContextKeys.js';
 import { DisposableStore, IDisposable } from '../../../../../base/common/lifecycle.js';
-import { InQuickPickContextKey } from '../../../../browser/quickaccess.js';
 import { FormatOnType } from '../../../../../editor/contrib/format/browser/formatActions.js';
 import { EditorExtensionsRegistry } from '../../../../../editor/browser/editorExtensions.js';
 import { MarkerController } from '../../../../../editor/contrib/gotoError/browser/gotoError.js';
@@ -31,7 +29,6 @@ import { SnippetController2 } from '../../../../../editor/contrib/snippet/browse
 import { ContextMenuController } from '../../../../../editor/contrib/contextmenu/browser/contextmenu.js';
 import { EditOperation, ISingleEditOperation } from '../../../../../editor/common/core/editOperation.js';
 import { TabCompletionController } from '../../../snippets/browser/tabCompletion.js';
-import { TerminalContextKeys } from '../../../terminal/common/terminalContextKey.js';
 import { ParameterHintsController } from '../../../../../editor/contrib/parameterHints/browser/parameterHints.js';
 import { SelectionClipboardContributionID } from '../../../codeEditor/browser/selectionClipboard.js';
 import { LanguageRuntimeSessionMode, RuntimeCodeExecutionMode } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
@@ -46,6 +43,7 @@ import { IInputHistoryEntry } from '../../../../services/positronHistory/common/
 import { CodeAttributionSource, IConsoleCodeAttribution } from '../../../../services/positronConsole/common/positronConsoleCodeExecution.js';
 import { createConsoleInputEditorOptions, createConsoleInputLineNumbersOptions, ILineNumbersOptions } from './consoleInputOptions.js';
 import { createConsoleInputModel } from './consoleInputModel.js';
+import { okToTakeFocus as okToTakeFocusHelper } from './consoleInputFocus.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { getForegroundDebugState, isForegroundDebugSession } from '../../../debug/common/debug.js';
 import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
@@ -123,35 +121,11 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 	 * Determines whether it is OK to take focus.
 	 * @returns true if it is OK to take focus; otherwise, false.
 	 */
-	const okToTakeFocus = () => {
-		// https://github.com/posit-dev/positron/issues/2802
-		// It's only OK to take focus if there is no focused editor. This avoids stealing focus when
-		// the user could be actively working in an editor.
-
-		// Get the context key service context.
-		const contextKeyContext = services.contextKeyService.getContext(
-			DOM.getActiveElement()
-		);
-
-		// Sensitive to all editor contexts, simple (e.g. git commit textbox) or not (e.g. code
-		// editor).
-		if (contextKeyContext.getValue(EditorContextKeys.textInputFocus.key)) {
-			return false;
-		}
-
-		// Sensitive to all quick pick contexts, e.g. the commande palette or the file picker.
-		if (contextKeyContext.getValue(InQuickPickContextKey.key)) {
-			return false;
-		}
-
-		// Sensitive to terminal focus.
-		if (contextKeyContext.getValue(TerminalContextKeys.focus.key)) {
-			return false;
-		}
-
-		// It's OK to take focus.
-		return true;
-	};
+	const okToTakeFocus = () => okToTakeFocusHelper(
+		services.contextKeyService,
+		services.workbenchLayoutService,
+		DOM.getActiveElement()
+	);
 
 	/**
 	 * Updates the code editor widget position.

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -124,6 +124,7 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 	const okToTakeFocus = () => okToTakeFocusHelper(
 		services.contextKeyService,
 		services.workbenchLayoutService,
+		services.webviewService,
 		DOM.getActiveElement()
 	);
 

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInputFocus.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInputFocus.ts
@@ -9,6 +9,7 @@ import { EditorContextKeys } from '../../../../../editor/common/editorContextKey
 import { InQuickPickContextKey } from '../../../../browser/quickaccess.js';
 import { TerminalContextKeys } from '../../../terminal/common/terminalContextKey.js';
 import { FocusedViewContext } from '../../../../common/contextkeys.js';
+import { IWebviewService } from '../../../webview/browser/webview.js';
 import { IWorkbenchLayoutService, Parts } from '../../../../services/layout/browser/layoutService.js';
 import { POSITRON_CONSOLE_VIEW_ID } from '../../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
 
@@ -27,12 +28,14 @@ import { POSITRON_CONSOLE_VIEW_ID } from '../../../../services/positronConsole/b
  *
  * @param contextKeyService The context key service.
  * @param layoutService The workbench layout service.
+ * @param webviewService The webview service.
  * @param activeElement The active element, used to resolve scoped context keys.
  * @returns true if it is OK to take focus; otherwise, false.
  */
 export function okToTakeFocus(
 	contextKeyService: IContextKeyService,
 	layoutService: IWorkbenchLayoutService,
+	webviewService: IWebviewService,
 	activeElement: Element | null
 ): boolean {
 	// Get the context key service context at the active element so that scoped keys resolve from
@@ -66,6 +69,14 @@ export function okToTakeFocus(
 	// Sensitive to focus anywhere in the editor part. This covers editors that hold focus without
 	// a text input, e.g. the Settings editor, the Data Explorer, and the welcome page.
 	if (layoutService.hasFocus(Parts.EDITOR_PART)) {
+		return false;
+	}
+
+	// Sensitive to focus inside a webview, e.g. a chat view contributed by an extension or the
+	// Help pane. A webview mounts its iframe in an overlay at the workbench root rather than
+	// inside its view pane, so focus in the iframe never reaches the view pane's focus tracker:
+	// `focusedView` is reset to empty and the checks above all miss it.
+	if (webviewService.activeWebview) {
 		return false;
 	}
 

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInputFocus.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInputFocus.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Other dependencies.
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { EditorContextKeys } from '../../../../../editor/common/editorContextKeys.js';
+import { InQuickPickContextKey } from '../../../../browser/quickaccess.js';
+import { TerminalContextKeys } from '../../../terminal/common/terminalContextKey.js';
+import { FocusedViewContext } from '../../../../common/contextkeys.js';
+import { IWorkbenchLayoutService, Parts } from '../../../../services/layout/browser/layoutService.js';
+import { POSITRON_CONSOLE_VIEW_ID } from '../../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
+
+/**
+ * Determines whether the console input may take keyboard focus.
+ *
+ * The console input takes focus when it becomes the active console instance and when it mounts.
+ * Both happen during startup, when a runtime auto-starts from an affiliation or a restored
+ * session, so the console must not take focus out from under a user who is working somewhere
+ * else. See https://github.com/posit-dev/positron/issues/2802 and
+ * https://github.com/posit-dev/positron/issues/13155.
+ *
+ * Focus is refused whenever the user is somewhere intentional. When nothing meaningful holds
+ * focus, which is the case on an idle launch, the console does take focus, because console-first
+ * users expect to launch Positron and start typing.
+ *
+ * @param contextKeyService The context key service.
+ * @param layoutService The workbench layout service.
+ * @param activeElement The active element, used to resolve scoped context keys.
+ * @returns true if it is OK to take focus; otherwise, false.
+ */
+export function okToTakeFocus(
+	contextKeyService: IContextKeyService,
+	layoutService: IWorkbenchLayoutService,
+	activeElement: Element | null
+): boolean {
+	// Get the context key service context at the active element so that scoped keys resolve from
+	// the focused widget.
+	const context = contextKeyService.getContext(activeElement);
+
+	// Sensitive to all editor contexts, simple (e.g. git commit textbox) or not (e.g. code
+	// editor).
+	if (context.getValue(EditorContextKeys.textInputFocus.key)) {
+		return false;
+	}
+
+	// Sensitive to all quick pick contexts, e.g. the command palette or the file picker.
+	if (context.getValue(InQuickPickContextKey.key)) {
+		return false;
+	}
+
+	// Sensitive to terminal focus.
+	if (context.getValue(TerminalContextKeys.focus.key)) {
+		return false;
+	}
+
+	// Sensitive to focus in any other view. Every view pane sets this key, so one check covers
+	// Search, Variables, Help, Plots, the Explorer, and any view added later. Focus inside the
+	// console view itself is fine; that is where the console input lives.
+	const focusedView = context.getValue<string>(FocusedViewContext.key);
+	if (focusedView && focusedView !== POSITRON_CONSOLE_VIEW_ID) {
+		return false;
+	}
+
+	// Sensitive to focus anywhere in the editor part. This covers editors that hold focus without
+	// a text input, e.g. the Settings editor, the Data Explorer, and the welcome page.
+	if (layoutService.hasFocus(Parts.EDITOR_PART)) {
+		return false;
+	}
+
+	// It's OK to take focus.
+	return true;
+}

--- a/src/vs/workbench/contrib/positronConsole/test/browser/consoleInputFocus.vitest.ts
+++ b/src/vs/workbench/contrib/positronConsole/test/browser/consoleInputFocus.vitest.ts
@@ -1,0 +1,106 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { ensureNoLeakedDisposables } from '../../../../../test/vitest/vitestUtils.js';
+import { ContextKeyService } from '../../../../../platform/contextkey/browser/contextKeyService.js';
+import { ContextKeyValue } from '../../../../../platform/contextkey/common/contextkey.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { EditorContextKeys } from '../../../../../editor/common/editorContextKeys.js';
+import { InQuickPickContextKey } from '../../../../browser/quickaccess.js';
+import { TerminalContextKeys } from '../../../terminal/common/terminalContextKey.js';
+import { FocusedViewContext } from '../../../../common/contextkeys.js';
+import { IWorkbenchLayoutService, Parts } from '../../../../services/layout/browser/layoutService.js';
+import { POSITRON_CONSOLE_VIEW_ID } from '../../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
+import { okToTakeFocus } from '../../browser/components/consoleInputFocus.js';
+
+interface Scenario {
+	/**
+	 * Keys set on the root context key service, the way viewsService sets
+	 * `focusedView`.
+	 */
+	rootKeys?: Record<string, ContextKeyValue>;
+	/**
+	 * Keys set on a context key service scoped to the focused element, the way an
+	 * editor or the terminal binds its own focus keys. The guard has to resolve
+	 * these through the DOM, which is why the test uses a real
+	 * `ContextKeyService` rather than a stub.
+	 */
+	widgetKeys?: Record<string, ContextKeyValue>;
+	editorPartHasFocus?: boolean;
+}
+
+describe('okToTakeFocus', () => {
+	let disposables: DisposableStore;
+
+	beforeEach(() => {
+		ensureNoLeakedDisposables();
+		disposables = new DisposableStore();
+	});
+
+	afterEach(() => disposables.dispose());
+
+	/**
+	 * Asks the guard about an element that is inside a scoped context, with the
+	 * given keys set on the root and scoped services.
+	 */
+	function check({ rootKeys = {}, widgetKeys = {}, editorPartHasFocus = false }: Scenario = {}): boolean {
+		const contextKeyService = disposables.add(
+			new ContextKeyService(new TestConfigurationService())
+		);
+		for (const [key, value] of Object.entries(rootKeys)) {
+			contextKeyService.createKey(key, value);
+		}
+
+		// The focused element sits inside its own scope, so scoped keys resolve
+		// from it and root keys still fall through to it.
+		const focusedElement = document.createElement('div');
+		const scoped = disposables.add(contextKeyService.createScoped(focusedElement));
+		for (const [key, value] of Object.entries(widgetKeys)) {
+			scoped.createKey(key, value);
+		}
+
+		const layoutService = stubInterface<IWorkbenchLayoutService>({
+			hasFocus: (part: Parts) => part === Parts.EDITOR_PART && editorPartHasFocus
+		});
+
+		return okToTakeFocus(contextKeyService, layoutService, focusedElement);
+	}
+
+	// Every surface the guard has to refuse. One case per surface; the guard's
+	// job here is uniform, so the interesting cases are the two below.
+	it.each<[string, Scenario]>([
+		['a text editor or simple text input', { widgetKeys: { [EditorContextKeys.textInputFocus.key]: true } }],
+		['a quick pick', { widgetKeys: { [InQuickPickContextKey.key]: true } }],
+		['the terminal', { widgetKeys: { [TerminalContextKeys.focus.key]: true } }],
+		['another view', { rootKeys: { [FocusedViewContext.key]: 'workbench.view.search' } }],
+		['the editor part', { editorPartHasFocus: true }],
+	])('refuses focus when %s has it', (_surface, scenario) => {
+		expect(check(scenario)).toBe(false);
+	});
+
+	// On an idle launch nothing meaningful holds focus, so the console takes it:
+	// console-first users expect to launch Positron and start typing. Both empty
+	// shapes occur in production, `undefined` before viewsService binds the key
+	// and `''` after it resets the key on view blur, and neither may count as a
+	// focused view. A guard that compared `focusedView` to the console id without
+	// the empty check would refuse focus here and regress the idle launch.
+	it('takes focus on an idle launch, whether focusedView is unset or reset to empty', () => {
+		expect({
+			unset: check(),
+			resetToEmpty: check({ rootKeys: { [FocusedViewContext.key]: '' } }),
+		}).toEqual({ unset: true, resetToEmpty: true });
+	});
+
+	// Focus already inside the console view is not focus worth protecting; that
+	// is where the console input lives. Refusing here would break switching
+	// between console session tabs.
+	it('takes focus when focus is already in the console view', () => {
+		expect(check({ rootKeys: { [FocusedViewContext.key]: POSITRON_CONSOLE_VIEW_ID } })).toBe(true);
+	});
+});

--- a/src/vs/workbench/contrib/positronConsole/test/browser/consoleInputFocus.vitest.ts
+++ b/src/vs/workbench/contrib/positronConsole/test/browser/consoleInputFocus.vitest.ts
@@ -15,6 +15,7 @@ import { EditorContextKeys } from '../../../../../editor/common/editorContextKey
 import { InQuickPickContextKey } from '../../../../browser/quickaccess.js';
 import { TerminalContextKeys } from '../../../terminal/common/terminalContextKey.js';
 import { FocusedViewContext } from '../../../../common/contextkeys.js';
+import { IWebview, IWebviewService } from '../../../webview/browser/webview.js';
 import { IWorkbenchLayoutService, Parts } from '../../../../services/layout/browser/layoutService.js';
 import { POSITRON_CONSOLE_VIEW_ID } from '../../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
 import { okToTakeFocus } from '../../browser/components/consoleInputFocus.js';
@@ -33,6 +34,12 @@ interface Scenario {
 	 */
 	widgetKeys?: Record<string, ContextKeyValue>;
 	editorPartHasFocus?: boolean;
+	/**
+	 * Whether a webview holds focus. A webview mounts its iframe outside its view
+	 * pane, so this is the only signal the guard gets for focus in a chat view
+	 * contributed by an extension or in the Help pane.
+	 */
+	webviewHasFocus?: boolean;
 }
 
 describe('okToTakeFocus', () => {
@@ -49,7 +56,12 @@ describe('okToTakeFocus', () => {
 	 * Asks the guard about an element that is inside a scoped context, with the
 	 * given keys set on the root and scoped services.
 	 */
-	function check({ rootKeys = {}, widgetKeys = {}, editorPartHasFocus = false }: Scenario = {}): boolean {
+	function check({
+		rootKeys = {},
+		widgetKeys = {},
+		editorPartHasFocus = false,
+		webviewHasFocus = false,
+	}: Scenario = {}): boolean {
 		const contextKeyService = disposables.add(
 			new ContextKeyService(new TestConfigurationService())
 		);
@@ -69,7 +81,11 @@ describe('okToTakeFocus', () => {
 			hasFocus: (part: Parts) => part === Parts.EDITOR_PART && editorPartHasFocus
 		});
 
-		return okToTakeFocus(contextKeyService, layoutService, focusedElement);
+		const webviewService = stubInterface<IWebviewService>({
+			activeWebview: webviewHasFocus ? stubInterface<IWebview>() : undefined
+		});
+
+		return okToTakeFocus(contextKeyService, layoutService, webviewService, focusedElement);
 	}
 
 	// Every surface the guard has to refuse. One case per surface; the guard's
@@ -80,6 +96,7 @@ describe('okToTakeFocus', () => {
 		['the terminal', { widgetKeys: { [TerminalContextKeys.focus.key]: true } }],
 		['another view', { rootKeys: { [FocusedViewContext.key]: 'workbench.view.search' } }],
 		['the editor part', { editorPartHasFocus: true }],
+		['a webview, e.g. an extension chat view or the Help pane', { webviewHasFocus: true }],
 	])('refuses focus when %s has it', (_surface, scenario) => {
 		expect(check(scenario)).toBe(false);
 	});


### PR DESCRIPTION
Fixes #13155

The console input takes keyboard focus when it becomes the active console instance, and again when it mounts. Both events happen at startup, when a runtime starts automatically from an affiliation or a restored session. The `okToTakeFocus()` guard from #2802 declined focus only for text editors, the quick pick, and the terminal. Focus in any other surface was lost.

This change groups the focused surfaces by category, instead of a list of individual views. The guard now also declines focus in two more cases:

- `focusedView` names a view other than the console. Every view pane sets this key. One check covers Search, Variables, Help, Plots, the Explorer, and each view we might add later.
- Focus is anywhere in the editor part. This covers editors that hold focus without a text input, such as Settings, the Data Explorer, and the welcome page.

An idle launch still _does_ focus the console. If nothing holds focus, `focusedView` is empty and no editor has focus. Console-first users can start Positron and type immediately.

The guard moved out of the component closure into `consoleInputFocus.ts`, so a unit test can call it directly. Both focus sites call the guard, so this change corrects both.

#### Behavior change

A launch that restores a focused non-text editor no longer gives focus to the console. Examples are the welcome page and the Settings UI in an editor tab. This is the intended fix, but users could see the difference.

#### Out of scope

`positronConsoleService.executeCode(..., focus: true)` waits for the session to start, then focuses the console. This path never used the guard. This change leaves it as it is, because the caller did actually ask for focus. I'm not sure if I think this is good behavior or not, but it's not what we're fixing here.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- The console no longer takes focus at runtime startup when focus is in another view or editor (#13155)

### Validation Steps

@:console @:sessions @:editor @:variables @:help

Run the unit tests for the guard:

```
npx vitest run src/vs/workbench/contrib/positronConsole/test/browser/consoleInputFocus.vitest.ts
```

The behavior here depends on various startup component timing and wouldn't be a great fit for E2E. The unit tests cover each branch of the guard.

Manual steps:

1. Open a workspace with an affiliated Python or R runtime, so that a runtime starts on launch.
2. Before the runtime has time to start, press <kbd>Cmd+Shift+F</kbd> to open Search. Type a query and keep typing until the runtime is fully started. Focus should stay in Search all the way through the runtime starting.
3. Do step 2 again with focus in something like the Help view.
4. Make the Settings UI or the Welcome page the active editor. Quit Positron, then open it again. Focus should stay in that editor tab.
5. Launch with no editor open, and do not interact. The console should take focus.
6. Start a new session from the Console. The new console session should take focus.
