### PR TITLE
Get the ext-host job green again after the 1.130 merge

### DIFF
--- a/.github/workflows/test-ext-host.yml
+++ b/.github/workflows/test-ext-host.yml
@@ -53,6 +53,12 @@ jobs:
       R_LIBS_SITE: /usr/local/lib/R/site-library
       R_LIBS_USER: /usr/local/lib/R/site-library
       RETICULATE_PYTHON: /root/.venv/bin/python
+      # The agent host e2e tests spawn the bundled Claude CLI, which refuses the
+      # `--allow-dangerously-skip-permissions` flag the agent host always passes
+      # when it runs as root -- and this container runs as root (`--user 0:0`).
+      # `IS_SANDBOX=1` is the CLI's escape hatch for sandboxed environments; the
+      # agent host forwards it to the subprocess (see claudeSdkOptions.ts).
+      IS_SANDBOX: '1'
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/test-ext-host.yml
+++ b/.github/workflows/test-ext-host.yml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 60
     # Run inside the shared CI image, which bakes in the system dependencies,
     # Node (matching .nvmrc), and R 4.5.2 + test-files deps that this
-    # job used to install at runtime. See posit-dev/positron-ci-images.
+    # job used to install at runtime. Built from docker/images/ubuntu24_04.
     container:
       image: ghcr.io/posit-dev/positron-ubuntu24:24.18.0
       # --shm-size: Chromium/Electron exhausts the container's default 64MB

--- a/.github/workflows/test-ext-host.yml
+++ b/.github/workflows/test-ext-host.yml
@@ -180,3 +180,18 @@ jobs:
         env:
           PLAYWRIGHT_BROWSERS_PATH: .playwright-browsers
         run: DISPLAY=:10 ./scripts/test-web-integration.sh --browser chromium
+
+      # The suites already write window, extension-host and main-process logs
+      # (`--logsPath`) plus crash dumps (`--crash-reporter-directory`), but the
+      # job discarded them, so a failure here left only "the test timed out" to
+      # work from. Keep them on failure.
+      - name: Upload extension host logs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ext-host-logs
+          path: |
+            .build/logs
+            .build/crashes
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -42,7 +42,7 @@ jobs:
     timeout-minutes: 60
     # Run inside the shared CI image, which bakes in the system dependencies,
     # Node (matching .nvmrc), and R 4.5.2 + test-files deps that this
-    # job used to install at runtime. See posit-dev/positron-ci-images.
+    # job used to install at runtime. Built from docker/images/ubuntu24_04.
     container:
       image: ghcr.io/posit-dev/positron-ubuntu24:24.18.0
       # --shm-size: the Electron unit runner loads each test file's full module

--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -193,6 +193,24 @@ const defaultLaunchArgs = process.env.API_TESTS_EXTRA_ARGS?.split(' ') || [
 	'--disable-telemetry', '--disable-experiments', '--skip-welcome', '--skip-release-notes', `--crash-reporter-directory=${__dirname}/.build/crashes`, `--logsPath=${__dirname}/.build/logs/integration-tests`, '--no-cached-data', '--disable-updates', '--use-inmemory-secretstorage', '--disable-extensions', '--disable-workspace-trust'
 ];
 
+// --- Start Positron ---
+// Headless Electron on the CI image intermittently GP-faults during startup,
+// inside libexpat while fontconfig initializes fonts on a worker thread (stack:
+// libexpat <- libfontconfig <- libpangoft2). It happens before any test runs and
+// takes the whole suite down. `scripts/test-remote-integration.sh` forces
+// software GL for the launches it drives directly and does not hit this; the
+// suites launched through vscode-test never saw those flags, because
+// `API_TESTS_EXTRA_ARGS` is not exported by the shell drivers, so they fall back
+// to the list above. Add the flags here so every desktop extension suite starts
+// up the same way the Remote ones (and the e2e harness) do.
+//
+// Linux-only: the race is in the Linux system font stack, and forcing software
+// GL for a headless test run is harmless there.
+if (process.platform === 'linux') {
+	defaultLaunchArgs.push('--no-sandbox', '--disable-dev-shm-usage', '--use-gl=swiftshader', '--enable-unsafe-swiftshader', '--disable-gpu-compositing');
+}
+// --- End Positron ---
+
 const config = defineConfig(extensions.map(extension => {
 	/** @type {import('@vscode/test-cli').TestConfiguration} */
 	const config = {

--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -206,8 +206,15 @@ const defaultLaunchArgs = process.env.API_TESTS_EXTRA_ARGS?.split(' ') || [
 //
 // Linux-only: the race is in the Linux system font stack, and forcing software
 // GL for a headless test run is harmless there.
+//
+// `unshift`, not `push`: vscode-test appends `workspaceFolder` as a positional
+// argument after these, and VS Code's CLI parser treats an unrecognized
+// `--flag` as taking the next positional as its value. A Chromium switch left
+// last therefore swallows the workspace path, and the suite launches with no
+// folder open (`workspace.workspaceFolders` undefined). Keep a flag VS Code
+// knows -- `--disable-workspace-trust` above -- at the end of this list.
 if (process.platform === 'linux') {
-	defaultLaunchArgs.push('--no-sandbox', '--disable-dev-shm-usage', '--use-gl=swiftshader', '--enable-unsafe-swiftshader', '--disable-gpu-compositing');
+	defaultLaunchArgs.unshift('--no-sandbox', '--disable-dev-shm-usage', '--use-gl=swiftshader', '--enable-unsafe-swiftshader', '--disable-gpu-compositing');
 }
 // --- End Positron ---
 

--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -253,6 +253,32 @@ const config = defineConfig(extensions.map(extension => {
 
 	if (!config.platform || config.platform === 'desktop') {
 		config.launchArgs = defaultLaunchArgs;
+
+		// --- Start Positron ---
+		// Completions in `settings.json` pull in the JSON schema the Copilot
+		// extension contributes at `ccsettings://root/schema.json` (see
+		// `jsonValidation` in extensions/copilot/package.json, `fileMatch:
+		// settings.json`). Fetching it activates that extension via
+		// `onFileSystem:ccsettings`, and in the CI container that activation does not
+		// complete, so every settings.json completion request hangs until mocha's 60s
+		// timeout -- six deterministic failures per run. Only `settings.json` matches
+		// that `fileMatch`, which is why the suite's other files are unaffected.
+		// Disable the extension here so the suite tests its own providers.
+		//
+		// `--disable-extensions` in the list above cannot do this: it exempts
+		// built-ins (`_isDisabledInEnv` in extensionEnablementService.ts) and every
+		// extension is a built-in when running from source, and its presence also
+		// short-circuits the per-extension list (`disableExtensions` in
+		// environmentService.ts). Hence the filter. The `=` form keeps the trailing
+		// token a value rather than a dangling flag, which would otherwise swallow
+		// the `workspaceFolder` positional vscode-test appends after these.
+		if (extension.label === 'configuration-editing') {
+			config.launchArgs = [
+				...defaultLaunchArgs.filter(a => a !== '--disable-extensions'),
+				'--disable-extension=GitHub.copilot-chat',
+			];
+		}
+		// --- End Positron ---
 		config.useInstallation = {
 			fromPath: process.env.INTEGRATION_TEST_ELECTRON_PATH || `${__dirname}/scripts/code.${process.platform === 'win32' ? 'bat' : 'sh'}`,
 		};

--- a/scripts/test-integration-pr.sh
+++ b/scripts/test-integration-pr.sh
@@ -41,40 +41,68 @@ else
 	kill_app() { killall $INTEGRATION_TEST_APP_NAME || true; }
 fi
 
+# --- Start Positron ---
+# Retry wrapper for the suites launched through `vscode-test`. Headless Electron
+# intermittently GP-faults during startup, in libexpat while fontconfig
+# initializes fonts on a worker thread (stack: libexpat <- libfontconfig <-
+# libpangoft2), before any test runs. `npm run test-extension` swallows the
+# child's 139 and exits 1, so the exit code alone cannot identify it -- match on
+# the crash line `vscode-test` prints instead. Anything else is a real test
+# failure and is returned immediately so it is never masked. Mirrors
+# `run_extension_suite` in test-integration.sh.
+run_extension_suite() {
+	local attempt=1 max_attempts=3 status log
+	log=$(mktemp)
+	while true; do
+		set +e
+		"$@" 2>&1 | tee "$log"
+		status=${PIPESTATUS[0]}
+		set -e
+		if [ "$status" -eq 0 ] || [ "$attempt" -ge "$max_attempts" ] || ! grep -qE "Exit code: +(SIGSEGV|139)" "$log"; then
+			rm -f "$log"
+			return "$status"
+		fi
+		echo "Electron exited with a startup segfault (likely the fontconfig race); retrying (attempt $((attempt + 1))/$max_attempts)..."
+		kill_app
+		attempt=$((attempt + 1))
+	done
+}
+# --- End Positron ---
+
 echo
 echo "### Authentication tests"
 echo
-npm run test-extension -- -l authentication
+run_extension_suite npm run test-extension -- -l authentication
 kill_app
 
 echo
 echo "### Positron Catalog Explorer tests"
 echo
-npm run test-extension -- -l positron-catalog-explorer
+run_extension_suite npm run test-extension -- -l positron-catalog-explorer
 kill_app
 
 echo
 echo "### Positron Code Cells tests"
 echo
-npm run test-extension -- -l positron-code-cells
+run_extension_suite npm run test-extension -- -l positron-code-cells
 kill_app
 
 echo
 echo "### Next Edit Suggestions tests"
 echo
-npm run test-extension -- -l next-edit-suggestions
+run_extension_suite npm run test-extension -- -l next-edit-suggestions
 kill_app
 
 echo
 echo "### Positron R tests"
 echo
-npm run test-extension -- -l positron-r
+run_extension_suite npm run test-extension -- -l positron-r
 kill_app
 
 echo
 echo "### Positron R connections tests"
 echo
-npm run test-extension -- -l positron-connections
+run_extension_suite npm run test-extension -- -l positron-connections
 kill_app
 
 # Disabling Positron Run App tests for now as they are flaky
@@ -87,37 +115,37 @@ kill_app
 echo
 echo "### Positron DuckDB tests"
 echo
-npm run test-extension -- -l positron-duckdb
+run_extension_suite npm run test-extension -- -l positron-duckdb
 kill_app
 
 echo
 echo "### Positron DuckDB data connection tests"
 echo
-npm run test-extension -- -l positron-data-driver-duckdb
+run_extension_suite npm run test-extension -- -l positron-data-driver-duckdb
 kill_app
 
 echo
 echo "### Positron SQLite data connection tests"
 echo
-npm run test-extension -- -l positron-data-driver-sqlite
+run_extension_suite npm run test-extension -- -l positron-data-driver-sqlite
 kill_app
 
 echo
 echo "### Positron Databricks data connection tests"
 echo
-npm run test-extension -- -l positron-data-driver-databricks
+run_extension_suite npm run test-extension -- -l positron-data-driver-databricks
 kill_app
 
 echo
 echo "### Positron Connect Pins data connection tests"
 echo
-npm run test-extension -- -l positron-data-driver-pins
+run_extension_suite npm run test-extension -- -l positron-data-driver-pins
 kill_app
 
 echo
 echo "### Positron Zed tests"
 echo
-npm run test-extension -- -l positron-zed
+run_extension_suite npm run test-extension -- -l positron-zed
 kill_app
 
 # Cleanup

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -238,6 +238,32 @@ run_integration_test() {
 }
 # --- End Positron ---
 
+# --- Start Positron ---
+# Retry wrapper for the suites launched through `vscode-test`. Same startup
+# segfault as `run_integration_test` guards against (libexpat <- libfontconfig
+# <- libpangoft2 during font init), but `npm run test-extension` swallows the
+# child's 139 and exits 1, so the exit code alone cannot identify it -- match on
+# the crash line `vscode-test` prints instead. Anything else is a real test
+# failure and is returned immediately so it is never masked.
+run_extension_suite() {
+	local attempt=1 max_attempts=3 status log
+	log=$(mktemp)
+	while true; do
+		set +e
+		"$@" 2>&1 | tee "$log"
+		status=${PIPESTATUS[0]}
+		set -e
+		if [ "$status" -eq 0 ] || [ "$attempt" -ge "$max_attempts" ] || ! grep -qE "Exit code: +(SIGSEGV|139)" "$log"; then
+			rm -f "$log"
+			return "$status"
+		fi
+		echo "Electron exited with a startup segfault (likely the fontconfig race); retrying (attempt $((attempt + 1))/$max_attempts)..."
+		kill_app
+		attempt=$((attempt + 1))
+	done
+}
+# --- End Positron ---
+
 if should_run_suite api-folder; then
 echo
 echo "### API tests (folder)"
@@ -269,7 +295,7 @@ if should_run_suite terminal-suggest; then
 echo
 echo "### Terminal Suggest tests"
 echo
-npm run test-extension -- -l terminal-suggest --enable-proposed-api=vscode.vscode-api-tests "${GREP_ARGS[@]}"
+run_extension_suite npm run test-extension -- -l terminal-suggest --enable-proposed-api=vscode.vscode-api-tests "${GREP_ARGS[@]}"
 kill_app
 fi
 
@@ -285,7 +311,7 @@ if should_run_suite markdown; then
 echo
 echo "### Markdown tests"
 echo
-npm run test-extension -- -l markdown-language-features "${GREP_ARGS[@]}"
+run_extension_suite npm run test-extension -- -l markdown-language-features "${GREP_ARGS[@]}"
 kill_app
 fi
 
@@ -309,7 +335,7 @@ if should_run_suite git-base; then
 echo
 echo "### Git Base tests"
 echo
-npm run test-extension -- -l git-base "${GREP_ARGS[@]}"
+run_extension_suite npm run test-extension -- -l git-base "${GREP_ARGS[@]}"
 kill_app
 fi
 
@@ -317,7 +343,7 @@ if should_run_suite ipynb; then
 echo
 echo "### Ipynb tests"
 echo
-npm run test-extension -- -l ipynb "${GREP_ARGS[@]}"
+run_extension_suite npm run test-extension -- -l ipynb "${GREP_ARGS[@]}"
 kill_app
 fi
 
@@ -325,7 +351,7 @@ if should_run_suite notebook-renderers; then
 echo
 echo "### Notebook Output tests"
 echo
-npm run test-extension -- -l notebook-renderers "${GREP_ARGS[@]}"
+run_extension_suite npm run test-extension -- -l notebook-renderers "${GREP_ARGS[@]}"
 kill_app
 fi
 
@@ -333,7 +359,7 @@ if should_run_suite configuration-editing; then
 echo
 echo "### Configuration editing tests"
 echo
-npm run test-extension -- -l configuration-editing "${GREP_ARGS[@]}"
+run_extension_suite npm run test-extension -- -l configuration-editing "${GREP_ARGS[@]}"
 kill_app
 fi
 
@@ -341,7 +367,7 @@ if should_run_suite github-authentication; then
 echo
 echo "### GitHub Authentication tests"
 echo
-npm run test-extension -- -l github-authentication "${GREP_ARGS[@]}"
+run_extension_suite npm run test-extension -- -l github-authentication "${GREP_ARGS[@]}"
 kill_app
 fi
 
@@ -349,7 +375,7 @@ if should_run_suite copilot; then
 echo
 echo "### Copilot tests"
 echo
-npm run test-extension -- -l copilot "${GREP_ARGS[@]}"
+run_extension_suite npm run test-extension -- -l copilot "${GREP_ARGS[@]}"
 kill_app
 fi
 
@@ -359,37 +385,37 @@ fi
 echo
 echo "### Authentication tests"
 echo
-npm run test-extension -- -l authentication
+run_extension_suite npm run test-extension -- -l authentication
 kill_app
 
 echo
 echo "### Positron Catalog Explorer tests"
 echo
-npm run test-extension -- -l positron-catalog-explorer
+run_extension_suite npm run test-extension -- -l positron-catalog-explorer
 kill_app
 
 echo
 echo "### Positron Code Cells tests"
 echo
-npm run test-extension -- -l positron-code-cells
+run_extension_suite npm run test-extension -- -l positron-code-cells
 kill_app
 
 echo
 echo "### Next Edit Suggestions tests"
 echo
-npm run test-extension -- -l next-edit-suggestions
+run_extension_suite npm run test-extension -- -l next-edit-suggestions
 kill_app
 
 echo
 echo "### Positron R tests"
 echo
-npm run test-extension -- -l positron-r
+run_extension_suite npm run test-extension -- -l positron-r
 kill_app
 
 echo
 echo "### Positron R connections tests"
 echo
-npm run test-extension -- -l positron-connections
+run_extension_suite npm run test-extension -- -l positron-connections
 kill_app
 
 # Disabling Positron Run App tests for now as they are flaky
@@ -402,37 +428,37 @@ kill_app
 echo
 echo "### Positron DuckDB tests"
 echo
-npm run test-extension -- -l positron-duckdb
+run_extension_suite npm run test-extension -- -l positron-duckdb
 kill_app
 
 echo
 echo "### Positron DuckDB data connection tests"
 echo
-npm run test-extension -- -l positron-data-driver-duckdb
+run_extension_suite npm run test-extension -- -l positron-data-driver-duckdb
 kill_app
 
 echo
 echo "### Positron SQLite data connection tests"
 echo
-npm run test-extension -- -l positron-data-driver-sqlite
+run_extension_suite npm run test-extension -- -l positron-data-driver-sqlite
 kill_app
 
 echo
 echo "### Positron Databricks data connection tests"
 echo
-npm run test-extension -- -l positron-data-driver-databricks
+run_extension_suite npm run test-extension -- -l positron-data-driver-databricks
 kill_app
 
 echo
 echo "### Positron Connect Pins data connection tests"
 echo
-npm run test-extension -- -l positron-data-driver-pins
+run_extension_suite npm run test-extension -- -l positron-data-driver-pins
 kill_app
 
 echo
 echo "### Positron Zed tests"
 echo
-npm run test-extension -- -l positron-zed
+run_extension_suite npm run test-extension -- -l positron-zed
 kill_app
 
 # --- End Positron ---

--- a/src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts
@@ -232,6 +232,19 @@ export function buildSubprocessEnv(proxied: boolean = true): Record<string, stri
 			ANTHROPIC_API_KEY: undefined,
 			HOME: process.env['HOME'],
 			USERPROFILE: process.env['USERPROFILE'],
+			// --- Start Positron ---
+			// The agent host always passes `allowDangerouslySkipPermissions`, which the
+			// SDK turns into `--allow-dangerously-skip-permissions`. The CLI refuses that
+			// flag when it runs as root ("--dangerously-skip-permissions cannot be used
+			// with root/sudo privileges for security reasons") and exits before the first
+			// model call, so every Claude session fails to start. `IS_SANDBOX=1` is the
+			// CLI's escape hatch for container/sandbox environments; forward it so a
+			// Positron running as root in a container (dev containers, and Positron's
+			// extension-host CI job) can still start Claude sessions. Proxy mode replaces
+			// the subprocess env wholesale, so it has to be listed explicitly here; the
+			// native branch below already spreads `process.env`.
+			IS_SANDBOX: process.env['IS_SANDBOX'],
+			// --- End Positron ---
 		}
 		: { ...process.env, ELECTRON_RUN_AS_NODE: '1', NODE_OPTIONS: undefined };
 	for (const key of Object.keys(process.env)) {

--- a/src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts
@@ -219,6 +219,19 @@ export function buildModelEnumerationOptions(): Options {
  * at copilotAgent.ts:434-450.
  *
  * Exported for unit testing as a pure function over `process.env`.
+ *
+ * --- Start Positron ---
+ * Proxy mode additionally forwards `IS_SANDBOX` when it is exactly `'1'`. The
+ * agent host always passes `allowDangerouslySkipPermissions`, which the SDK
+ * turns into `--allow-dangerously-skip-permissions`, and the CLI refuses that
+ * flag as root ("--dangerously-skip-permissions cannot be used with root/sudo
+ * privileges for security reasons"), exiting before the first model call.
+ * `IS_SANDBOX=1` is the CLI's escape hatch for sandboxed environments. This
+ * only propagates a value the surrounding environment has already opted into
+ * -- it does not set one -- so it changes nothing for a Positron whose
+ * environment does not define it. Positron's extension-host CI job is the
+ * caller that does: it runs the agent host e2e tests as root in a container.
+ * --- End Positron ---
  */
 export function buildSubprocessEnv(proxied: boolean = true): Record<string, string | undefined> {
 	// Proxy mode: a sparse env (creds arrive via settings.env), and the user's
@@ -233,17 +246,11 @@ export function buildSubprocessEnv(proxied: boolean = true): Record<string, stri
 			HOME: process.env['HOME'],
 			USERPROFILE: process.env['USERPROFILE'],
 			// --- Start Positron ---
-			// The agent host always passes `allowDangerouslySkipPermissions`, which the
-			// SDK turns into `--allow-dangerously-skip-permissions`. The CLI refuses that
-			// flag when it runs as root ("--dangerously-skip-permissions cannot be used
-			// with root/sudo privileges for security reasons") and exits before the first
-			// model call, so every Claude session fails to start. `IS_SANDBOX=1` is the
-			// CLI's escape hatch for container/sandbox environments; forward it so a
-			// Positron running as root in a container (dev containers, and Positron's
-			// extension-host CI job) can still start Claude sessions. Proxy mode replaces
-			// the subprocess env wholesale, so it has to be listed explicitly here; the
-			// native branch below already spreads `process.env`.
-			IS_SANDBOX: process.env['IS_SANDBOX'],
+			// Let an explicit `IS_SANDBOX=1` reach the CLI; see the note in this
+			// function's doc comment. Only the exact value the CLI's root guard
+			// accepts is forwarded, so an ambient `IS_SANDBOX=0` cannot reach the
+			// paths that read the variable with a plain truthiness test.
+			IS_SANDBOX: process.env['IS_SANDBOX'] === '1' ? '1' : undefined,
 			// --- End Positron ---
 		}
 		: { ...process.env, ELECTRON_RUN_AS_NODE: '1', NODE_OPTIONS: undefined };

--- a/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
@@ -29,6 +29,15 @@ import { DiskFileSystemProvider } from '../../../files/node/diskFileSystemProvid
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { AgentHostGitService } from '../../node/agentHostGitService.js';
 
+// --- Start Positron ---
+// Positron's extension-host CI job runs inside a container as root (`--user 0:0`).
+// Root bypasses file permission checks, so the tests below that make staging fail
+// by `chmod`-ing a file to `0` cannot fail there: `git add` reads the file anyway
+// and the service returns diffs instead of `undefined`. Skip them as root rather
+// than assert something the OS cannot produce.
+const isRoot = typeof process.getuid === 'function' && process.getuid() === 0;
+// --- End Positron ---
+
 function createGitService(disposables: Pick<DisposableStore, 'add'>): AgentHostGitService {
 	const logService = new NullLogService();
 	const fileService = disposables.add(new FileService(logService));
@@ -174,6 +183,13 @@ suite('AgentHostGitService - computeSessionFileDiffs (real git)', () => {
 		try { cp.execFileSync('git', ['--version'], { stdio: 'ignore' }); return true; } catch { return false; }
 	})();
 
+	// --- Start Positron ---
+	// Gate for the two tests that force a staging failure with `chmod 0`. Upstream
+	// gates them on `hasGit && !isWindows`; as root the `chmod` has no effect (see
+	// `isRoot` above), so drop them there too.
+	const stagingFailureTest = hasGit && !isWindows && !isRoot ? test : test.skip;
+	// --- End Positron ---
+
 	let tmpRoot: string | undefined;
 	let svc: AgentHostGitService | undefined;
 
@@ -261,7 +277,10 @@ suite('AgentHostGitService - computeSessionFileDiffs (real git)', () => {
 		});
 	});
 
-	(hasGit && !isWindows ? test : test.skip)('returns undefined when temp-index staging fails', async () => {
+	// --- Start Positron ---
+	// (hasGit && !isWindows ? test : test.skip)('returns undefined when temp-index staging fails', async () => {
+	// --- End Positron ---
+	stagingFailureTest('returns undefined when temp-index staging fails', async () => {
 		const fs = await import('fs/promises');
 		const { dir } = initRepo();
 		const blockedPath = join(dir, 'blocked.txt');
@@ -372,7 +391,10 @@ suite('AgentHostGitService - computeSessionFileDiffs (real git)', () => {
 		assert.deepStrictEqual(treePaths, ['fresh.txt', 'new.txt']);
 	});
 
-	(hasGit && !isWindows ? test : test.skip)('captureWorkingTreeAsTree returns undefined when staging fails', async () => {
+	// --- Start Positron ---
+	// (hasGit && !isWindows ? test : test.skip)('captureWorkingTreeAsTree returns undefined when staging fails', async () => {
+	// --- End Positron ---
+	stagingFailureTest('captureWorkingTreeAsTree returns undefined when staging fails', async () => {
 		const fs = await import('fs/promises');
 		const { dir } = initRepo();
 		const blockedPath = join(dir, 'blocked.txt');

--- a/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
@@ -30,12 +30,49 @@ import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { AgentHostGitService } from '../../node/agentHostGitService.js';
 
 // --- Start Positron ---
-// Positron's extension-host CI job runs inside a container as root (`--user 0:0`).
-// Root bypasses file permission checks, so the tests below that make staging fail
-// by `chmod`-ing a file to `0` cannot fail there: `git add` reads the file anyway
-// and the service returns diffs instead of `undefined`. Skip them as root rather
-// than assert something the OS cannot produce.
-const isRoot = typeof process.getuid === 'function' && process.getuid() === 0;
+// Absolute path of the real `git`, captured before any `PATH` shimming so
+// `withFailingGitAdd` can delegate to it. `undefined` when `git` is not on PATH.
+const realGitPath = (() => {
+	try {
+		return cp.execFileSync('which', ['git'], { encoding: 'utf8' }).split('\n')[0].trim() || undefined;
+	} catch {
+		return undefined;
+	}
+})();
+
+/**
+ * Runs `body` with a `git` on `PATH` that fails `git add` and delegates every
+ * other subcommand to the real binary, so the service's temp-index staging step
+ * fails without depending on file permissions.
+ *
+ * The permission-based alternative (`chmod 0` on a staged file) is a no-op when
+ * the tests run as root, which bypasses the permission check -- and Positron's
+ * extension-host CI job runs in a container as root (`--user 0:0`). This seam
+ * behaves the same for every uid.
+ */
+async function withFailingGitAdd<T>(body: () => Promise<T>): Promise<T> {
+	const fs = await import('fs/promises');
+	const binDir = mkdtempSync(join(tmpdir(), 'agent-host-git-shim-'));
+	const shim = join(binDir, 'git');
+	await fs.writeFile(shim, [
+		'#!/bin/sh',
+		'if [ "$1" = "add" ]; then',
+		'  echo "fatal: simulated staging failure" >&2',
+		'  exit 128',
+		'fi',
+		`exec ${realGitPath} "$@"`,
+		'',
+	].join('\n'));
+	await fs.chmod(shim, 0o755);
+	const savedPath = process.env['PATH'];
+	process.env['PATH'] = `${binDir}:${savedPath ?? ''}`;
+	try {
+		return await body();
+	} finally {
+		process.env['PATH'] = savedPath;
+		rmDirWithRetry(binDir);
+	}
+}
 // --- End Positron ---
 
 function createGitService(disposables: Pick<DisposableStore, 'add'>): AgentHostGitService {
@@ -184,10 +221,10 @@ suite('AgentHostGitService - computeSessionFileDiffs (real git)', () => {
 	})();
 
 	// --- Start Positron ---
-	// Gate for the two tests that force a staging failure with `chmod 0`. Upstream
-	// gates them on `hasGit && !isWindows`; as root the `chmod` has no effect (see
-	// `isRoot` above), so drop them there too.
-	const stagingFailureTest = hasGit && !isWindows && !isRoot ? test : test.skip;
+	// Gate for the two tests that force a staging failure. Upstream gates them on
+	// `hasGit && !isWindows`; the `withFailingGitAdd` shim also needs to know where
+	// the real `git` lives.
+	const stagingFailureTest = hasGit && !isWindows && realGitPath ? test : test.skip;
 	// --- End Positron ---
 
 	let tmpRoot: string | undefined;
@@ -278,21 +315,22 @@ suite('AgentHostGitService - computeSessionFileDiffs (real git)', () => {
 	});
 
 	// --- Start Positron ---
-	// (hasGit && !isWindows ? test : test.skip)('returns undefined when temp-index staging fails', async () => {
-	// --- End Positron ---
+	// Upstream forces the staging failure by making the file unreadable:
+	//   (hasGit && !isWindows ? test : test.skip)('returns undefined when temp-index staging fails', async () => {
+	//     const blockedPath = join(dir, 'blocked.txt');
+	//     await fs.writeFile(blockedPath, 'blocked\n');
+	//     await fs.chmod(blockedPath, 0);
+	// Root bypasses the permission check, so `git add` succeeds and the assertion
+	// cannot hold; fail `git add` itself instead. Same branch, uid-independent.
 	stagingFailureTest('returns undefined when temp-index staging fails', async () => {
 		const fs = await import('fs/promises');
 		const { dir } = initRepo();
-		const blockedPath = join(dir, 'blocked.txt');
-		await fs.writeFile(blockedPath, 'blocked\n');
-		await fs.chmod(blockedPath, 0);
-		try {
-			const result = await svc!.computeSessionFileDiffs(URI.file(dir), { sessionUri: 'copilot:/s' });
-			assert.strictEqual(result, undefined);
-		} finally {
-			await fs.chmod(blockedPath, 0o600);
-		}
+		await fs.writeFile(join(dir, 'blocked.txt'), 'blocked\n');
+
+		const result = await withFailingGitAdd(() => svc!.computeSessionFileDiffs(URI.file(dir), { sessionUri: 'copilot:/s' }));
+		assert.strictEqual(result, undefined);
 	});
+	// --- End Positron ---
 
 	(hasGit ? test : test.skip)('anchors against the merge-base of the requested base branch', async () => {
 		const fs = await import('fs/promises');
@@ -392,21 +430,18 @@ suite('AgentHostGitService - computeSessionFileDiffs (real git)', () => {
 	});
 
 	// --- Start Positron ---
-	// (hasGit && !isWindows ? test : test.skip)('captureWorkingTreeAsTree returns undefined when staging fails', async () => {
-	// --- End Positron ---
+	// Same substitution as the `computeSessionFileDiffs` staging test above:
+	//   (hasGit && !isWindows ? test : test.skip)('captureWorkingTreeAsTree returns undefined when staging fails', async () => {
+	//     await fs.chmod(blockedPath, 0);
 	stagingFailureTest('captureWorkingTreeAsTree returns undefined when staging fails', async () => {
 		const fs = await import('fs/promises');
 		const { dir } = initRepo();
-		const blockedPath = join(dir, 'blocked.txt');
-		await fs.writeFile(blockedPath, 'blocked\n');
-		await fs.chmod(blockedPath, 0);
-		try {
-			const result = await svc!.captureWorkingTreeAsTree(URI.file(dir));
-			assert.strictEqual(result, undefined);
-		} finally {
-			await fs.chmod(blockedPath, 0o600);
-		}
+		await fs.writeFile(join(dir, 'blocked.txt'), 'blocked\n');
+
+		const result = await withFailingGitAdd(() => svc!.captureWorkingTreeAsTree(URI.file(dir)));
+		assert.strictEqual(result, undefined);
 	});
+	// --- End Positron ---
 
 	(hasGit ? test : test.skip)('showBlob retrieves committed content', async () => {
 		const fs = await import('fs/promises');

--- a/src/vs/platform/agentHost/test/node/claudeSdkOptions.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeSdkOptions.test.ts
@@ -81,13 +81,26 @@ suite('claudeSdkOptions / buildSubprocessEnv', () => {
 	// --- Start Positron ---
 	// The CLI refuses `--allow-dangerously-skip-permissions` as root unless
 	// `IS_SANDBOX=1` is set, and proxy mode replaces the subprocess env wholesale,
-	// so the variable has to survive the sparse rebuild.
-	test('forwards IS_SANDBOX in proxy mode, and omits it when unset', () => {
-		clearAndSet({ IS_SANDBOX: '1' });
-		assert.strictEqual(buildSubprocessEnv().IS_SANDBOX, '1');
+	// so the variable has to survive the sparse rebuild. Only the exact value the
+	// root guard accepts is forwarded: other paths in the CLI read the variable
+	// with a plain truthiness test, where the string `'0'` would read as sandboxed.
+	test('forwards IS_SANDBOX in proxy mode only when it is exactly "1"', () => {
+		const forwarded = (value?: string) => {
+			clearAndSet(value === undefined ? {} : { IS_SANDBOX: value });
+			return buildSubprocessEnv().IS_SANDBOX;
+		};
 
-		clearAndSet({});
-		assert.strictEqual(buildSubprocessEnv().IS_SANDBOX, undefined);
+		assert.deepStrictEqual({
+			one: forwarded('1'),
+			zero: forwarded('0'),
+			falseString: forwarded('false'),
+			unset: forwarded(undefined),
+		}, {
+			one: '1',
+			zero: undefined,
+			falseString: undefined,
+			unset: undefined,
+		});
 	});
 	// --- End Positron ---
 

--- a/src/vs/platform/agentHost/test/node/claudeSdkOptions.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeSdkOptions.test.ts
@@ -24,6 +24,9 @@ suite('claudeSdkOptions / buildSubprocessEnv', () => {
 		'PATH',
 		'HOME',
 		'USERPROFILE',
+		// --- Start Positron ---
+		'IS_SANDBOX',
+		// --- End Positron ---
 	];
 
 	function clearAndSet(values: Record<string, string>): void {
@@ -74,6 +77,19 @@ suite('claudeSdkOptions / buildSubprocessEnv', () => {
 			userProfile: 'C:\\Users\\test',
 		});
 	});
+
+	// --- Start Positron ---
+	// The CLI refuses `--allow-dangerously-skip-permissions` as root unless
+	// `IS_SANDBOX=1` is set, and proxy mode replaces the subprocess env wholesale,
+	// so the variable has to survive the sparse rebuild.
+	test('forwards IS_SANDBOX in proxy mode, and omits it when unset', () => {
+		clearAndSet({ IS_SANDBOX: '1' });
+		assert.strictEqual(buildSubprocessEnv().IS_SANDBOX, '1');
+
+		clearAndSet({});
+		assert.strictEqual(buildSubprocessEnv().IS_SANDBOX, undefined);
+	});
+	// --- End Positron ---
 
 	test('always sets ELECTRON_RUN_AS_NODE=1 even when not present in process.env', () => {
 		clearAndSet({});

--- a/src/vs/platform/agentHost/test/node/providerIntegration/copilotMockLlm.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/providerIntegration/copilotMockLlm.integrationTest.ts
@@ -181,7 +181,17 @@ suite('Agent Host Provider Integration — Copilot Idle Release', function () {
 		// Re-subscribe: the server restores the session from disk and the provider
 		// resumes the SDK session on demand. The restored transcript must match
 		// the pre-release view.
-		const after = await fetchSessionWithChat(client, sessionUri);
+		// --- Start Positron ---
+		// (upstream: `const after = await fetchSessionWithChat(client, sessionUri);`)
+		// This is the one subscribe in the test that does real work -- the server
+		// restores the session from disk and the provider resumes the SDK session --
+		// and it was inheriting the client's generic 5s default while the rest of the
+		// test budgets 90-180s. On a loaded CI container that flaked (observed once in
+		// seven full-driver runs; the neighbouring test in the same suite took 7.7s in
+		// the run that failed). 30s matches the other heavyweight subscribes in these
+		// helpers. A genuinely wedged resume still fails -- just 25s later.
+		const after = await fetchSessionWithChat(client, sessionUri, 30_000);
+		// --- End Positron ---
 		assert.deepStrictEqual(transcript(after.turns), transcript(before.turns), 'restored transcript must match the pre-release state');
 
 		// Drive a SECOND turn after the release/resume cycle. This is the key

--- a/src/vs/platform/agentHost/test/node/serverIntegrationTestHelpers.ts
+++ b/src/vs/platform/agentHost/test/node/serverIntegrationTestHelpers.ts
@@ -591,11 +591,16 @@ export function dispatchTurnStarted(c: TestProtocolClient, session: string, turn
  * requests) live on the session's default chat channel, so reading them
  * requires merging the session snapshot with its default chat snapshot.
  */
-export async function fetchSessionWithChat(c: TestProtocolClient, sessionUri: string): Promise<ISessionWithDefaultChat> {
+// --- Start Positron ---
+// `timeoutMs` added: a subscribe that has to restore a released session needs
+// more than the client's generic 5s default. Omitted by every other caller, so
+// their behaviour is unchanged.
+export async function fetchSessionWithChat(c: TestProtocolClient, sessionUri: string, timeoutMs?: number): Promise<ISessionWithDefaultChat> {
 	const owningSession = parseDefaultChatUri(sessionUri) ?? sessionUri;
 	const chatUri = parseDefaultChatUri(sessionUri) ? sessionUri : buildDefaultChatUri(sessionUri);
-	const sessionSnap = await c.call<SubscribeResult>('subscribe', { channel: owningSession });
-	const chatSnap = await c.call<SubscribeResult>('subscribe', { channel: chatUri });
+	const sessionSnap = await c.call<SubscribeResult>('subscribe', { channel: owningSession }, timeoutMs);
+	const chatSnap = await c.call<SubscribeResult>('subscribe', { channel: chatUri }, timeoutMs);
+	// --- End Positron ---
 	return mergeSessionWithDefaultChat(
 		sessionSnap.snapshot!.state as SessionState,
 		chatSnap.snapshot?.state as ChatState | undefined,


### PR DESCRIPTION
## Summary

`test / ext-host` has been red on every main run since the Code OSS 1.130.0 merge. It turned out to be **three unrelated problems stacked behind one another**, each hidden by the one in front of it: `test-integration.sh` runs `set -e` with the node integration tests first, so the Electron step aborted before reaching a single extension suite. Fixing only the first would have produced a differently-red job.

This PR fixes all three, one commit each, and adds two small things that made the diagnosis possible at all.

### 1. Twenty-one agent host tests fail because the job runs as root

The ext-host container runs `--user 0:0`. Two failure modes:

- **Two `AgentHostGitService` tests** force a staging failure with `chmod 000` and assert the service returns `undefined`. Root bypasses the permission check, so `git add` succeeds. Verified:

  ```
  root:     git add -A  ->  succeeds
  non-root: error: open("blocked.txt"): Permission denied
  ```

  Rather than skip them as root (which would mean they run in *no* CI configuration -- Windows is already gated and Linux is the only other job), they now force the failure through a `git` shim on `PATH` that fails `add` and delegates everything else. Same branch, every uid, every POSIX platform.

- **Nineteen `Agent Host E2E - Claude` tests** die at session start. The agent host always sets `allowDangerouslySkipPermissions`, the SDK turns that into `--allow-dangerously-skip-permissions`, and the CLI refuses that flag as root:

  ```
  --dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons   (exit 1)
  ```

  Every session dies before the first model call, which is why the replay proxy reported no cache misses and the Copilot/Codex suites on the same server passed. `IS_SANDBOX=1` is the CLI's escape hatch; proxy mode rebuilds the subprocess env from scratch, so `buildSubprocessEnv()` has to forward it explicitly. Value-checked to exactly `'1'`, since other paths in the CLI read the variable with a plain truthiness test.

### 2. Desktop suites never got the font/GPU hardening the Remote suites have

The libexpat/fontconfig startup segfault that #14931 and #14946 fixed for the Remote driver in July is back, because the desktop drivers got neither half of that fix. It hit four suites across two branches in one afternoon, including an unrelated PR.

|  | software-GL flags | segfault retry |
| --- | --- | --- |
| `test-remote-integration.sh` | yes | yes, every invocation |
| `test-integration.sh` | no | only the 2 `vscode-api-tests` launches |
| `test-integration-pr.sh` | no (`LINUX_EXTRA_ARGS` set, never used) | no |

Two defects behind it: `API_TESTS_EXTRA_ARGS` is never exported, so `.vscode-test.js` silently falls back to its defaults and every vscode-test suite launched with no software GL; and `npm run test-extension` swallows the child's 139 and exits 1, so the existing retry could not recognize these crashes. Fixed by pushing the flags on in the config and adding `run_extension_suite`, wrapped around all 32 suite invocations. A real test failure still returns immediately and is never retried.

### 3. `configuration-editing` settings.json completions hang for 60s each

Six tests, deterministic, desktop only. Instrumenting the suite showed the first completion returning in **128ms** and every one after it **never returning at all** -- 6 of 43 calls with no result, all `settings.json`.

The Copilot extension contributes a JSON schema scoped to that filename (`ccsettings://root/schema.json`, `jsonValidation` in `extensions/copilot/package.json`). Fetching it activates that extension via `onFileSystem:ccsettings` -- which is exactly when the hang begins, 72ms after the one call that succeeded -- and in the CI container that activation does not complete. Only `settings.json` matches the `fileMatch`, which is why `extensions.json`, `launch.json`, `tasks.json` and `keybindings.json` are unaffected.

Disabling that one extension for this suite: **`12 passing (3s)`**, from `6 passing, 6 failing` in 6 minutes. Bisected in CI -- all three AI extensions disabled -> green, then Copilot alone -> green.

Worth knowing: `--disable-extensions` is already in these suites' launch args and **does nothing**. It exempts built-ins ([`_isDisabledInEnv`](https://github.com/posit-dev/positron/blob/main/src/vs/workbench/services/extensionManagement/browser/extensionEnablementService.ts)) and everything is a built-in in a source build; its presence also short-circuits the per-extension list. So these suites have never had the isolation their arguments imply.

### Plus two supporting changes

- **`ext-host-logs` artifact on failure.** The suites already write window, extension-host and main-process logs and crash dumps; the job discarded them, so every failure read as "the test timed out" with nothing behind it. Diagnosing #3 needed a dedicated CI round trip purely to retain files CI had already produced.
- **CI image comments** now point at `docker/images/ubuntu24_04` instead of the retired `posit-dev/positron-ci-images`.

## Verification

Full-driver `workflow_dispatch` runs on this branch (the PR's own `test / ext-host` check runs the PR driver, which exercises none of the above):

| | before | after |
| --- | --- | --- |
| node integration layer | 590 passing, **21 failing** | **611 passing, 0 failing** (3 runs) |
| `configuration-editing` | 6 passing, **6 failing** (6m) | **12 passing** (3s) |
| segfaults / retries fired | 4 crashes across 2 branches | **0 / 0** |

## Known gaps

- **The Copilot activation stall is not root-caused.** We know a settings.json completion depends on that extension activating, and that in this container it does not finish. We do not know why -- it does not reproduce locally, with or without a token. The fix here restores the isolation the suite was written to have; it does not fix whatever wedges activation. Worth an issue against that code with this evidence.
- **The segfault fix is mitigation, not a cure.** Same posture as #14946: software GL shrinks the race window and the retry is the safety net. The race lives in the system font libraries.

## Release Notes

### New Features

- N/A

### Bug Fixes

- N/A

## QA Notes

CI is the test: `test / ext-host` should go green end to end. Worth confirming in the job log that the 19 Claude e2e tests **ran and passed** rather than skipped, that the two git staging tests ran (they are no longer uid-gated), and that `configuration-editing` reports 12 passing in seconds rather than minutes.

One new unit test (`forwards IS_SANDBOX in proxy mode only when it is exactly "1"`). The Mocha/Electron runner is broken on my machine (pre-existing, unrelated), so I verified the changed behaviors directly against the transpiled build and by running the affected extension suites locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)