### PR TITLE
ci-arm: move the lab images to 24.18.0 to match CI

### DIFF
--- a/.devcontainer/ci-arm/README.md
+++ b/.devcontainer/ci-arm/README.md
@@ -1,7 +1,7 @@
 # Positron CI dev container (ubuntu24-arm64)
 
 Develop, debug, and run Positron **inside the actual CI image**
-(`ghcr.io/posit-dev/positron-ubuntu24:24.15.0`) so CI failures reproduce locally. You edit code in VS Code on your host; the build, tests, and Positron itself run in the container.
+(`ghcr.io/posit-dev/positron-ubuntu24:24.18.0`) so CI failures reproduce locally. You edit code in VS Code on your host; the build, tests, and Positron itself run in the container.
 
 > Validated on **arm64** (Apple Silicon) only. The base image is a multi-arch
 > manifest, so Docker resolves the host arch automatically; `POSITRON_CI_IMAGE_ARCH`
@@ -244,7 +244,7 @@ flowchart LR
         web["Browser"]
         src[/"Your checkout<br/>src, out/"/]
     end
-    subgraph ctr["Container: positron-ubuntu24:24.15.0"]
+    subgraph ctr["Container: positron-ubuntu24:24.18.0"]
         desk["Desktop app<br/>(Electron)"]
         srv["Web server<br/>:8080"]
         e2e["e2e tests"]

--- a/.devcontainer/ci-arm/docker-compose.yml
+++ b/.devcontainer/ci-arm/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     # Multi-arch manifest: Docker resolves the host arch automatically (arm64 on
     # Apple Silicon), so no per-arch tag is needed. POSITRON_CI_IMAGE_ARCH (passed
     # into the container below) still selects the Electron build arch in post-create.sh.
-    image: ghcr.io/posit-dev/positron-ubuntu24:24.15.0
+    image: ghcr.io/posit-dev/positron-ubuntu24:24.18.0
     init: true
     privileged: true
     command: /bin/sh -c "while sleep 1000; do :; done"
@@ -37,7 +37,7 @@ services:
       - ci-arm-net
 
   postgres:
-    image: ghcr.io/posit-dev/positron-postgres:24.15.0
+    image: ghcr.io/posit-dev/positron-postgres:24.18.0
     env_file:
       - .env
     environment:


### PR DESCRIPTION
The CI dev container is meant to run Positron inside the same image CI uses, but it still pinned `positron-ubuntu24:24.15.0` and `positron-postgres:24.15.0`. The workflows moved to `24.18.0`.

The 24.15.0 image carries Node 24.15.0, which is older than the `24.18.0` in the repo's `.nvmrc`. The preinstall check rejects it, so `npm ci` fails inside the container and the lab cannot install dependencies at all.

This points both images at `24.18.0` and updates the two image references in the README.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

Existing lab, headless path:

1. `cd .devcontainer/ci-arm && docker compose pull`
2. `./ci-lab-up.sh --local` and confirm it prints `ci-lab-up: SUCCESS`. On the old pin, this stops at `FAILED at step 'reconcile dependencies'` with the Node version error.
3. Run a spec and confirm it passes:
   `docker compose exec -T test bash -lc "cd \$POSITRON_WORKSPACE_PATH && ./.devcontainer/ci-arm/run-e2e.sh test/e2e/tests/sessions/externally-managed-python-prompt.test.ts --workers=1"`

Verified on an arm64 Mac. Recreating the container on the new image reinstalled dependencies and recompiled with 0 errors; the named volumes survive, so no cold rebuild was needed and the next open stays warm.

This touches only the dev container, so it does not affect CI itself or shipped code.
