### PR TITLE
build(e2e): fix the tsc path in the e2e compile script

### DIFF
--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "license": "MIT",
   "scripts": {
-    "compile": "node ../../node_modules/typescript/bin/tsc6",
+    "compile": "node ../../node_modules/typescript/bin/tsc",
     "watch-e2e": "npm run compile -- --watch --preserveWatchOutput",
     "watch": "npm-run-all -lp watch-e2e"
   },


### PR DESCRIPTION
### Summary
`npm run compile` in `test/e2e` fails with `MODULE_NOT_FOUND`: the Code OSS 1.130.0 merge (#15243) left a stray character in the tsc path, making it `typescript/bin/tsc6`.
- Restores the path to `typescript/bin/tsc`, which is what it was before that merge
- Only `tsc` and `tsserver` exist in `node_modules/typescript/bin`, so the script could never have run
- Affects `watch-e2e` and `watch` too, since both delegate to `compile`

### QA Notes
No test tags. Verified `npm run compile` in `test/e2e` now type-checks the suite and exits 0.
