### PR TITLE
Auto-dismiss the interpreter architecture-mismatch toast in e2e runs

### DIFF
--- a/test/e2e/infra/application.ts
+++ b/test/e2e/infra/application.ts
@@ -10,6 +10,7 @@ import { Profiler } from './profiler';
 import { expect } from '@playwright/test';
 import { PositWorkbench } from './workbench-pwb.js';
 import { PositJupyter } from './workbench-jupyter.js';
+import { installArchMismatchNotificationHandler } from './archMismatchNotification.js';
 
 const LOAD_TIMEOUT = 60000;
 
@@ -203,6 +204,14 @@ export class Application {
 		const isWorkbench = this.options.useExternalServer && this.options.externalServerUrl?.includes(':8787');
 		const isJupyter = this.options.useExternalServer && this.options.externalServerUrl?.includes(':8888');
 		const isPositronServer = this.options.useExternalServer && this.options.externalServerUrl?.includes(':8080');
+
+		// --- Start Positron ---
+		// Auto-dismiss the sticky interpreter architecture-mismatch warning, which
+		// otherwise covers the workbench for the whole run on mismatched-arch machines
+		// (notably the Windows arm64 CI lane). Registered here rather than in the app
+		// fixture so it is re-installed on every launch, including `restart()`.
+		await installArchMismatchNotificationHandler(code.driver.currentPage, code.driver.browserContext, this.logger);
+		// --- End Positron ---
 
 		// We need a rendered workbench
 		await measureAndLog(() => code.didFinishLoad(), 'Application#checkWindowReady: wait for navigation to be committed', this.logger);

--- a/test/e2e/infra/archMismatchNotification.ts
+++ b/test/e2e/infra/archMismatchNotification.ts
@@ -1,0 +1,107 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type * as playwright from '@playwright/test';
+import type { Logger } from './logger';
+
+/**
+ * Matches the sticky warning raised by `RuntimeStartupService` when a session starts for
+ * an interpreter whose architecture differs from the system's:
+ *
+ *   The interpreter "Python 3.10.10 (System)" has a different architecture (x64) than
+ *   your system (arm64). This may cause problems with performance and package compatibility.
+ *
+ * On the Windows arm64 lane every interpreter is x64-under-emulation (several test
+ * dependencies have no win-arm64 wheels, and CRAN ships no arm64 Windows R), so this fires
+ * on essentially every session start.
+ */
+const ARCH_MISMATCH_TEXT = /has a different architecture/;
+
+/**
+ * The notification's own dismissal action, labelled "Don't show again for {Language}".
+ * Clicking it persists the dismissal in profile-scoped storage, so the warning stays gone
+ * for the rest of the worker's profile instead of returning on the next session start.
+ */
+const DISMISS_BUTTON_LABEL = /Don't show again for/;
+
+const DISMISS_TIMEOUT = 5000;
+
+/**
+ * Upper bound on how many of these toasts one handler run will dismiss. There is at most
+ * one per language (Python, R), but the loop is bounded so a mis-matching selector can
+ * never spin.
+ */
+const MAX_TOASTS_PER_RUN = 4;
+
+/**
+ * Registers a Playwright locator handler that automatically dismisses the interpreter
+ * architecture-mismatch warning, and only that warning.
+ *
+ * Positron deliberately keeps notification toasts visible during e2e runs (upstream VS Code
+ * suppresses them under `--enable-smoke-test-driver`; see the Positron block in
+ * notificationsToasts.ts), and this particular toast is sticky, so it sits on top of the
+ * workbench and can cover the element a test is trying to click. On the Windows arm64 lane
+ * that is deterministic rather than flaky.
+ *
+ * This is intentionally *not* a blanket "close all toasts": any other unexpected notification
+ * must still surface and fail the test, since that is how real bugs show up.
+ *
+ * The handler is self-gating -- the text only ever appears when the interpreter's
+ * architecture differs from the system's -- so it is registered on every platform. It
+ * dismisses through the product's own "Don't show again" action, so each language's warning
+ * is handled at most once per profile.
+ *
+ * Note that running a locator handler alters page state (focus and mouse position move to
+ * the toast's button). That is bounded here to the first mismatched session start per
+ * language, and is strictly better than the alternative of the toast covering the workbench
+ * for the whole run.
+ *
+ * @param page the page to install the handler on
+ * @param context the page's browser context; windows opened later get the handler too
+ * @param logger records each automatic dismissal, so the suppression is never silent
+ */
+export async function installArchMismatchNotificationHandler(
+	page: playwright.Page,
+	context: playwright.BrowserContext | undefined,
+	logger: Logger
+): Promise<void> {
+	await addHandler(page, logger);
+
+	// Cover windows opened later in the run (e.g. a second workbench window).
+	context?.on('page', newPage => {
+		addHandler(newPage, logger).catch(error => {
+			logger.log(`Arch mismatch notification: could not install handler on new page (${error})`);
+		});
+	});
+}
+
+async function addHandler(page: playwright.Page, logger: Logger): Promise<void> {
+	const notification = page.locator('.notification-toast').filter({ hasText: ARCH_MISMATCH_TEXT });
+
+	// `.first()` because the trigger locator is resolved in strict mode: Python and R can
+	// each raise one of these, and two matches would throw a strict-mode violation out of
+	// whatever action happened to run the handler check.
+	await page.addLocatorHandler(notification.first(), async () => {
+		// Dismiss every matching toast that is currently up, not just the one that
+		// triggered the handler: Python and R each raise their own, and Playwright
+		// requires the locator to be hidden once the handler returns.
+		for (let i = 0; i < MAX_TOASTS_PER_RUN; i++) {
+			const toast = notification.first();
+			if (!(await toast.isVisible())) {
+				return;
+			}
+
+			try {
+				await toast.getByRole('button', { name: DISMISS_BUTTON_LABEL }).click({ timeout: DISMISS_TIMEOUT });
+				logger.log('Arch mismatch notification: dismissed via "Don\'t show again"');
+			} catch (error) {
+				// Leave the toast for Playwright to report against the triggering action
+				// rather than retrying blindly here.
+				logger.log(`Arch mismatch notification: failed to dismiss (${error})`);
+				return;
+			}
+		}
+	});
+}

--- a/test/e2e/infra/index.ts
+++ b/test/e2e/infra/index.ts
@@ -10,6 +10,7 @@ export * from './workbench';
 export * from './test-runner';
 export * from './test-teardown.js';
 export * from './systemDiagnostics';
+export * from './archMismatchNotification';
 
 // pages
 export * from '../pages/console';


### PR DESCRIPTION
Contributes to #10112. Unblocks the Windows arm64 e2e lane being set up in posit-dev/positron-builds#1173.

### Summary

On Windows arm64 every interpreter we test with is x64-under-emulation (pyarrow, psycopg2-binary and fastparquet have no win-arm64 wheels; CRAN ships no arm64 Windows R), so `RuntimeStartupService` raises its sticky architecture-mismatch warning on essentially every session start:

> The interpreter "Python 3.10.10 (System)" has a different architecture (x64) than your system (arm64). This may cause problems with performance and package compatibility.

Positron deliberately keeps notification toasts visible during e2e runs (upstream VS Code suppresses them under `--enable-smoke-test-driver`; see the Positron block in `notificationsToasts.ts`), so this toast sits on top of the workbench and covers whatever a test is trying to click. It deterministically breaks the new-folder-flow "New env: Venv environment" test on the arm64 lane, confirmed twice in CI with traces and screenshots. R sessions raise their own version of the warning, so other suites are exposed too.

This is a harness-only change. Nothing under `src/` changes, so no product behavior changes.

**What it does:** registers a Playwright `addLocatorHandler` scoped to that one notification, which dismisses it through the product's own "Don't show again for {Language}" button. That path persists the dismissal in profile-scoped storage, so the warning does not come back on the next session start.

**What it deliberately does not do:** close all toasts. Any other unexpected notification must still surface and fail the test, since that is how real bugs show up.

Implementation notes:

- Installed from `Application#checkWindowReady` rather than from a fixture, so it is re-registered on every launch including `restart()`. A fixture-level registration is silently lost after a restart.
- Not gated on architecture. The handler is self-gating -- the text only appears when the interpreter's architecture differs from the system's -- which also covers macOS arm64 with an x64 interpreter, and avoids depending on `process.arch`, which reports `x64` on the arm64 lane because the harness Node runs under emulation.
- The trigger locator uses `.first()`, since it is resolved in strict mode and Python and R can each raise one of these at the same time.
- Every automatic dismissal is written to the test log, so the suppression is never silent.

### QA Notes

Verified with a synthetic Playwright reproduction (a toast carrying the same text overlaying the button a test wants to click), covering five cases:

| Case | Result |
|---|---|
| No handler, 1 toast (control) | click blocked, times out -- repro is valid |
| Handler, 1 toast | dismissed, click succeeds |
| Handler, stacked Python + R toasts | both dismissed, click succeeds |
| Handler, no toast | inert |
| Handler, unrelated toast | still blocked, so real failures still surface |

The stacked case is what caught a strict-mode violation in the first version of the handler. This has not yet been exercised against a real arm64 session; that happens on the lane itself.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:critical @:new-folder-flow @:win

The handler is installed in the shared app-startup path, so the critical suite is the regression check here. On x64/amd64 machines the notification never appears and the handler never fires, so a green run means no regression; the behavior it fixes only manifests on the arm64 lane.
