### PR TITLE
Restart Positron after a Windows background update

### DIFF
--- a/build/win32/positron.iss
+++ b/build/win32/positron.iss
@@ -687,6 +687,20 @@ begin
   Result := FileExists(ExpandConstant('{param:update}'))
 end;
 
+// Positron creates a session-end flag file when the OS is shutting down (/sessionend=C:\foo\bar).
+// This prevents calling inno_updater.exe during system shutdown, where the OS would kill it
+// partway through the swap and leave the installation half-updated.
+function SessionEndFileExists(): Boolean;
+begin
+  Result := FileExists(ExpandConstant('{param:sessionend}'))
+end;
+
+// Positron creates a cancel flag file to signal that the update should be aborted (/cancel=C:\foo\bar).
+function CancelFileExists(): Boolean;
+begin
+  Result := FileExists(ExpandConstant('{param:cancel}'))
+end;
+
 function ShouldRunAfterUpdate(): Boolean;
 begin
   if IsBackgroundUpdate() then
@@ -768,17 +782,35 @@ begin
     begin
       CreateMutex('{#AppMutex}-ready');
 
+      // Wait for Positron to exit so that its files can be replaced. This wait is deliberately
+      // unbounded: the `-ready` mutex created above has already told Positron that the update is
+      // staged, so what this loop waits for is the user choosing "Restart to Update", which can
+      // easily be hours away. Writing the cancel file is the only way to abandon the update, and
+      // Positron does that from `cancelPendingUpdate()`.
       Log('Checking whether application is still running...');
       while (CheckForMutexes('{#AppMutex}')) do
       begin
+        if CancelFileExists() then
+        begin
+          Log('Cancel file detected, aborting background update.');
+          Abort;
+        end;
         Sleep(1000)
       end;
       Log('Application appears not to be running.');
 
-      StopTunnelServiceIfNeeded();
+      // Never swap files while the OS session is ending: the OS can kill inno_updater partway
+      // through and leave the installation half-updated.
+      if not SessionEndFileExists() and not CancelFileExists() then
+      begin
+        StopTunnelServiceIfNeeded();
 
-      // inno_updater requires 3 arguments (exe of current installation, lock file status, and a string for the log)
-      Exec(ExpandConstant('{app}\tools\inno_updater.exe'), ExpandConstant('"{app}\{#ExeBasename}.exe" ' + BoolToStr(LockFileExists()) + ' "Updating Positron..."'), '', SW_SHOW, ewWaitUntilTerminated, UpdateResultCode);
+        // inno_updater requires 3 arguments (exe of current installation, lock file status, and a string for the log)
+        Exec(ExpandConstant('{app}\tools\inno_updater.exe'), ExpandConstant('"{app}\{#ExeBasename}.exe" ' + BoolToStr(LockFileExists()) + ' "Updating Positron..."'), '', SW_SHOW, ewWaitUntilTerminated, UpdateResultCode);
+        Log('inno_updater completed with result code ' + IntToStr(UpdateResultCode));
+      end
+      else
+        Log('Skipping inno_updater.exe call because the OS session is ending or cancel was requested.');
     end;
 
     if ShouldRestartTunnelService then

--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -600,7 +600,26 @@ export abstract class AbstractUpdateService extends Disposable implements IUpdat
 		// noop
 	}
 
-	quitAndInstall(): Promise<void> {
+	// --- Start Positron ---
+	/**
+	 * Called once the user has accepted the restart but before the shutdown begins, so that a
+	 * platform can hand off to its installer while the app is still running. Windows needs this:
+	 * the installer reads the update flag file as soon as the app mutex clears, and the mutex is
+	 * released during `onWillShutdown`, which is before `lifecycleMainService.quit()` resolves.
+	 */
+	protected async prepareForQuitAndInstall(): Promise<void> {
+		// noop
+	}
+
+	/** Undoes {@link prepareForQuitAndInstall} when the quit turns out to be vetoed. */
+	protected async undoPrepareForQuitAndInstall(): Promise<void> {
+		// noop
+	}
+
+	// `async` so that `prepareForQuitAndInstall()` can complete before the shutdown starts.
+	// quitAndInstall(): Promise<void> {
+	// --- End Positron ---
+	async quitAndInstall(): Promise<void> {
 		this.logService.trace('update#quitAndInstall, state = ', this.state.type);
 
 		if (this.state.type !== StateType.Ready) {
@@ -613,10 +632,23 @@ export abstract class AbstractUpdateService extends Disposable implements IUpdat
 		this.setState(State.Restarting(this.state.update));
 		this.logService.trace('update#quitAndInstall(): before lifecycle quit()');
 
-		this.lifecycleMainService.quit(true /* will restart */).then(vetod => {
+		// --- Start Positron ---
+		// this.lifecycleMainService.quit(true /* will restart */).then(vetod => {
+
+		await this.prepareForQuitAndInstall();
+
+		// `async` so that the undo completes before Ready is advertised again. Otherwise a failed
+		// restore would leave us advertising Ready with no flag file on disk, and the next ordinary
+		// quit would let the installer swap and then relaunch Positron behind the user's back.
+
+		// --- End Positron ---
+		this.lifecycleMainService.quit(true /* will restart */).then(async vetod => {
 			this.logService.trace(`update#quitAndInstall(): after lifecycle quit() with veto: ${vetod}`);
 			if (vetod) {
 				this.logService.info('update#quitAndInstall(): quit was vetoed, restoring Ready state');
+				// --- Start Positron ---
+				await this.undoPrepareForQuitAndInstall().catch(err => this.logService.error('update#quitAndInstall(): failed to undo the install preparation', err));
+				// --- End Positron ---
 				this.setState(readyState);
 				return;
 			}

--- a/src/vs/platform/update/electron-main/updateService.win32.ts
+++ b/src/vs/platform/update/electron-main/updateService.win32.ts
@@ -40,7 +40,11 @@ import { AbstractUpdateService, createUpdateURL, getUpdateRequestHeaders, Update
 // --- End Positron ---
 
 // --- Start Positron ---
+// eslint-disable-next-line no-duplicate-imports
+import { writeFileSync } from 'fs';
 import { IStateService } from '../../state/node/state.js';
+import { ICodeWindow } from '../../window/electron-main/window.js';
+import { IWindowsMainService } from '../../windows/electron-main/windows.js';
 // --- End Positron ---
 
 interface IAvailableUpdate {
@@ -80,10 +84,20 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
 	get cachePath(): Promise<string> {
 		// --- Start Positron ---
 		// Use Positron specific cache path
-		const result = path.join(tmpdir(), `positron-${this.productService.target}-${process.arch}`);
+		const result = this.cachePathValue;
 		// --- End Positron ---
 		return mkdir(result, { recursive: true }).then(() => result);
 	}
+
+	// --- Start Positron ---
+	/**
+	 * The cache directory, without creating it. `cachePath` mkdirs as a side effect, which is not
+	 * wanted on paths that run before we know whether updates are even enabled.
+	 */
+	private get cachePathValue(): string {
+		return path.join(tmpdir(), `positron-${this.productService.target}-${process.arch}`);
+	}
+	// --- End Positron ---
 
 	@memoize
 	private get mutex(): Promise<typeof import('@vscode/windows-mutex')> {
@@ -108,6 +122,7 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
 		@IMeteredConnectionService meteredConnectionService: IMeteredConnectionService,
 		// --- Start Positron ---
 		@IStateService stateService: IStateService,
+		@IWindowsMainService private readonly windowsMainService: IWindowsMainService,
 		// --- End Positron ---
 	) {
 		super(lifecycleMainService, configurationService, environmentMainService, requestService, logService, telemetryService, applicationStorageMainService, meteredConnectionService, productService, nativeHostMainService, stateService, true);
@@ -135,6 +150,12 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
 	}
 
 	protected override async initialize(): Promise<void> {
+		// --- Start Positron ---
+		// Before the disabled checks below, and without touching disk, so that the listeners are in
+		// place even if updates are turned on later in the session.
+		await this.installSessionEndFlagHandler();
+		// --- End Positron ---
+
 		if (this.productService.win32VersionedUpdate) {
 			const cachePath = await this.cachePath;
 			app.setPath('appUpdate', cachePath);
@@ -165,6 +186,47 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
 
 		await super.initialize();
 	}
+
+	// --- Start Positron ---
+	/**
+	 * Maintains the session-end flag file that `doApplyUpdate()` passes to the installer as
+	 * `/sessionend`. While that flag exists, build/win32/positron.iss skips the file swap, so that
+	 * the OS cannot kill inno_updater partway through an update and leave a half-swapped install.
+	 */
+	private async installSessionEndFlagHandler(): Promise<void> {
+		// `cachePathValue` rather than `cachePath`, so that a disabled update service does not create
+		// the cache directory just by starting up.
+		// Must match the path passed as `/sessionend` in `doApplyUpdate()`.
+		const sessionEndFlagPath = path.join(this.cachePathValue, 'session-ending.flag');
+
+		// Clear a flag left behind by a previous shutdown. The upstream cleanup in `initialize()`
+		// is gated on `win32VersionedUpdate`, which Positron does not set, so without this a single
+		// OS shutdown would leave the flag on disk and every later background update would be
+		// skipped for good. `doApplyUpdate()` clears it again before each spawn.
+		await this.unlink(sessionEndFlagPath);
+
+		// Written synchronously: the OS is tearing the process down and will not wait for us.
+		const onSessionEnd = () => {
+			this.logService.info('update#onSessionEnd: OS session is ending, flagging the update swap to be skipped');
+			try {
+				writeFileSync(sessionEndFlagPath, 'session-end');
+			} catch (err) {
+				this.logService.error('update#onSessionEnd: failed to write the session end flag', err);
+			}
+		};
+
+		// `session-end` is a window event rather than an app event, so it has to be attached to every
+		// window. Whichever window fires first is enough, since all the handler does is write a flag.
+		// The listeners are owned by their BrowserWindow and go away when the window is destroyed.
+		const listenForSessionEnd = (window: ICodeWindow) => {
+			window.win?.on('session-end', onSessionEnd);
+		};
+		for (const window of this.windowsMainService.getWindows()) {
+			listenForSessionEnd(window);
+		}
+		this._register(this.windowsMainService.onDidOpenWindow(listenForSessionEnd));
+	}
+	// --- End Positron ---
 
 	// --- Start Positron ---
 	// 1.107.0 - Disabled pending further investigation into adapting this code for Positron.
@@ -473,6 +535,21 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
 		const sessionEndFlagPath = path.join(cachePath, 'session-ending.flag');
 		const cancelFilePath = path.join(cachePath, `cancel.flag`);
 		const progressFilePath = path.join(cachePath, `update-progress`);
+
+		// --- Start Positron ---
+		// Point Electron's `appUpdate` path at the same directory we pass as `/sessionend`. Upstream
+		// closed microsoft/vscode#264571 ("session-ending.flag is not present") with a commit whose
+		// only relevant change was this call, which implies a native writer that puts the flag in
+		// `appUpdate`. Upstream only does it under `win32VersionedUpdate`, which Positron does not
+		// set, so Positron has never pointed that writer anywhere useful. Done here rather than in
+		// `initialize()` because `setPath` throws unless the directory already exists, and because
+		// this is exactly when the flag starts to matter: an installer is about to wait on it.
+		try {
+			app.setPath('appUpdate', cachePath);
+		} catch (err) {
+			this.logService.warn('update#doApplyUpdate: failed to set the appUpdate path', err);
+		}
+		// --- End Positron ---
 		this.availableUpdate.updateFilePath = path.join(cachePath, `CodeSetup-${this.productService.quality}-${update.version}.flag`);
 		this.availableUpdate.cancelFilePath = cancelFilePath;
 
@@ -486,6 +563,13 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
 		} else {
 			await this.unlink(cancelFilePath);
 			await this.unlink(progressFilePath);
+			// --- Start Positron ---
+			// Clear the session-end flag here as well as at startup. Windows sends WM_ENDSESSION with
+			// `wParam = FALSE` when a shutdown is queried and then cancelled, so the process can outlive
+			// its own `session-end` event. A flag left over from that would make the installer skip the
+			// swap for the rest of the session, silently, on every later update.
+			await this.unlink(sessionEndFlagPath);
+			// --- End Positron ---
 			await pfs.Promises.writeFile(this.availableUpdate.updateFilePath, 'flag');
 
 			// --- Start Positron ---
@@ -670,6 +754,31 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
 		this.availableUpdate = undefined;
 	}
 
+	// --- Start Positron ---
+	protected override async prepareForQuitAndInstall(): Promise<void> {
+		// Deleting the flag file is what tells the waiting installer to relaunch Positron once the
+		// swap finishes (see `LockFileExists` in build/win32/positron.iss). It has to happen before
+		// the shutdown starts, because the app mutex the installer waits on is released during
+		// `onWillShutdown`, and the installer reads the flag as soon as that mutex clears.
+		await this.unlink(this.availableUpdate?.updateFilePath);
+	}
+
+	protected override async undoPrepareForQuitAndInstall(): Promise<void> {
+		// The quit was vetoed, so the user is staying in this session after all. Restore the flag so
+		// that a later plain quit does not relaunch Positron behind their back after the swap.
+		const updateFilePath = this.availableUpdate?.updateFilePath;
+		if (!updateFilePath) {
+			return;
+		}
+
+		try {
+			await pfs.Promises.writeFile(updateFilePath, 'flag');
+		} catch (err) {
+			this.logService.warn('update#undoPrepareForQuitAndInstall: failed to restore the update flag', err);
+		}
+	}
+	// --- End Positron ---
+
 	protected override doQuitAndInstall(): void {
 		if ((this.state.type !== StateType.Ready && this.state.type !== StateType.Restarting) || !this.availableUpdate) {
 			return;
@@ -679,6 +788,11 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
 
 		if (this.availableUpdate.updateFilePath) {
 			try {
+				// --- Start Positron ---
+				// Normally already deleted by `prepareForQuitAndInstall()`. This remains the only
+				// deletion on the relaunch path, where `handleRelaunch()` calls us straight from
+				// `app.on('quit')`, which is after the app mutex has been released.
+				// --- End Positron ---
 				unlinkSync(this.availableUpdate.updateFilePath);
 			} catch {
 				// ignore

--- a/src/vs/platform/update/test/electron-main/positronQuitAndInstall.vitest.ts
+++ b/src/vs/platform/update/test/electron-main/positronQuitAndInstall.vitest.ts
@@ -1,0 +1,131 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { NullLogService } from '../../../log/common/log.js';
+import { ILifecycleMainService } from '../../../lifecycle/electron-main/lifecycleMainService.js';
+import { IConfigurationService } from '../../../configuration/common/configuration.js';
+import { IEnvironmentMainService } from '../../../environment/electron-main/environmentMainService.js';
+import { IRequestService } from '../../../request/common/request.js';
+import { ITelemetryService } from '../../../telemetry/common/telemetry.js';
+import { IApplicationStorageMainService } from '../../../storage/electron-main/storageMainService.js';
+import { IMeteredConnectionService } from '../../../meteredConnection/common/meteredConnection.js';
+import { IProductService } from '../../../product/common/productService.js';
+import { INativeHostMainService } from '../../../native/electron-main/nativeHostMainService.js';
+import { IStateService } from '../../../state/node/state.js';
+import { stubInterface } from '../../../../test/vitest/stubInterface.js';
+import { ensureNoLeakedDisposables } from '../../../../test/vitest/vitestUtils.js';
+import { AbstractUpdateService } from '../../electron-main/abstractUpdateService.js';
+import { State, StateType } from '../../common/update.js';
+
+/**
+ * The Windows installer reads the update flag file as soon as the app mutex clears, and that mutex
+ * is released during `onWillShutdown`, i.e. before `lifecycleMainService.quit()` resolves. So
+ * `prepareForQuitAndInstall()` has to run before the quit, not after it. These tests pin that
+ * ordering, which is easy to lose in an upstream merge.
+ */
+describe('AbstractUpdateService quit-and-install hooks', () => {
+
+	/** Records the order of the interesting calls so a test can assert on the whole sequence. */
+	let calls: string[];
+	/** Whether the fake lifecycle service reports the quit as vetoed. */
+	let veto: boolean;
+
+	class TestUpdateService extends AbstractUpdateService {
+		protected override doCheckForUpdates(): void { }
+		protected override buildUpdateFeedUrl(): string | undefined { return undefined; }
+
+		protected override async prepareForQuitAndInstall(): Promise<void> {
+			// Yield before recording, so that these tests pin *completion* before the quit rather
+			// than merely the call order. Without this, dropping the `await` in `quitAndInstall()`
+			// would reintroduce the race the hook exists to prevent and the tests would stay green.
+			// Do not simplify this away.
+			await new Promise<void>(resolve => setTimeout(resolve, 0));
+			calls.push('prepare');
+		}
+
+		protected override async undoPrepareForQuitAndInstall(): Promise<void> {
+			calls.push('undo');
+		}
+
+		protected override doQuitAndInstall(): void {
+			calls.push('doQuitAndInstall');
+		}
+
+		/** The real service reaches Ready through the download/apply chain, which needs a network. */
+		becomeReady(): void {
+			this.setState(State.Ready({ version: '2026.09.0-1' }, false, false));
+		}
+	}
+
+	function createService(): TestUpdateService {
+		const lifecycleMainService = stubInterface<ILifecycleMainService>({
+			// Never resolves, so `initialize()` stays out of these tests.
+			when: () => new Promise<void>(() => { }),
+			quit: async () => {
+				calls.push('quit');
+				return veto;
+			}
+		});
+
+		return new TestUpdateService(
+			lifecycleMainService,
+			stubInterface<IConfigurationService>({}),
+			stubInterface<IEnvironmentMainService>({}),
+			stubInterface<IRequestService>({}),
+			new NullLogService(),
+			stubInterface<ITelemetryService>({}),
+			stubInterface<IApplicationStorageMainService>({}),
+			stubInterface<IMeteredConnectionService>({}),
+			stubInterface<IProductService>({}),
+			stubInterface<INativeHostMainService>({}),
+			stubInterface<IStateService>({}),
+			false /* supportsUpdateOverwrite */
+		);
+	}
+
+	// Must be at describe scope: the helper registers its own beforeEach/afterEach, so calling it
+	// from inside a running beforeEach registers them too late to have any effect.
+	ensureNoLeakedDisposables();
+
+	beforeEach(() => {
+		calls = [];
+		veto = false;
+	});
+
+	it('prepares for the install before the shutdown starts', async () => {
+		const service = createService();
+		service.becomeReady();
+
+		await service.quitAndInstall();
+		await vi.waitFor(() => expect(calls).toContain('doQuitAndInstall'));
+
+		expect(calls).toEqual(['prepare', 'quit', 'doQuitAndInstall']);
+		service.dispose();
+	});
+
+	it('undoes the preparation and restores Ready when the quit is vetoed', async () => {
+		veto = true;
+		const service = createService();
+		service.becomeReady();
+
+		await service.quitAndInstall();
+		await vi.waitFor(() => expect(calls).toContain('undo'));
+
+		expect(calls).toEqual(['prepare', 'quit', 'undo']);
+		expect(service.state.type).toBe(StateType.Ready);
+		service.dispose();
+	});
+
+	it('does nothing at all when there is no update ready', async () => {
+		const service = createService();
+
+		await service.quitAndInstall();
+
+		expect(calls).toEqual([]);
+		service.dispose();
+	});
+});


### PR DESCRIPTION
Fixes #13988

On Windows, "Restart to Update" closed Positron but did not reopen it. The update sometimes did not apply either. Users relaunched Positron by hand, found the old version, and repeated the update two or three times.

The cause is the order of two events during shutdown. Positron deletes a flag file to tell the waiting installer to relaunch Positron after the file swap. That deletion ran in `doQuitAndInstall()`, which runs after `lifecycleMainService.quit()` resolves. The app mutex that the installer waits on is released earlier, during `onWillShutdown`. The installer polls that mutex once per second. So the installer can find the mutex free while the flag still exists. It then tells `inno_updater` not to relaunch Positron.

This PR makes four changes:

1. Positron deletes the flag before it calls `lifecycleMainService.quit()`. If the quit is vetoed, Positron restores the flag. Two new no-op hooks on `AbstractUpdateService` provide the seam for this.
2. The installer reads the `cancel` parameter in its wait loop and aborts the update. Positron always passed this flag from the TypeScript side, but `positron.iss` never read it. Upstream `code.iss:1799` reads it.
3. The installer reads the `sessionend` parameter and skips the file swap while the OS session ends. This guard prevents a half-swapped install when Windows stops `inno_updater` partway through. Positron writes the flag from a per-window `session-end` listener. Positron clears the flag at startup, and again before each installer spawn.
4. Positron sets the Electron `appUpdate` path to the same directory that it passes as `sessionend`. See Known limitations.

This PR changes some upstream files, although almost all of the new code is additive and sits inside Positron fences. Exactly two upstream literal lines change:

| File | Added | Removed | What was removed |
|---|---|---|---|
| `build/win32/positron.iss` | 36 | 4 | Positron owns this file. The removed lines are the swap block, re-indented into the new guard. |
| `abstractUpdateService.ts` | 34 | 2 | Two signature lines. `quitAndInstall()` and the veto callback both become `async`. Both originals stay as comments. |
| `updateService.win32.ts` | 115 | 1 | This line already sat inside a Positron fence. It builds our custom cache path. |

The fix cannot live anywhere else. The bug is an ordering problem inside the upstream `quitAndInstall()` method. No seam exists between the mutex release in `onWillShutdown` and the point where `quit()` resolves. So the only place to act is before `quit()` is called, and that call site is upstream. `updateService.win32.ts` owns all of the Windows update state (`availableUpdate`, the cache path, and the installer spawn). A separate Positron file cannot own the flag lifecycle without a copy of that state.

I would argue changes 1 and 3 are correcting bugs that upstream VS Code still has, although the upstream exposure is smaller because IIUC background updates go mostly to Insiders builds.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Positron now restarts after it applies a background update on Windows (#13988)
- Windows updates no longer swap files while the OS shuts down, which can leave a half-updated install (#13988)

### Validation Steps

@:win @:critical

A build from this PR cannot update itself from the CDN feed, because its build number does not compare as older than the published builds. Full auto-update validation therefore happens after merge, on a daily build that reaches daily users. A build from this PR can still validate the installer directly, and can validate every part that needs _no_ update.

Automated coverage:

- `npx vitest run src/vs/platform/update/test/electron-main/positronQuitAndInstall.vitest.ts` covers the hook order
- The critical suite runs here because every platform shares `quitAndInstall()`

A successful release build is itself the check that a development machine cannot do. It proves that the edited `positron.iss` still compiles into a working installer. Make sure that a plain install, an upgrade, and an uninstall all work.

#### Installer guards, from a build of this PR

The cancel check and the session-end guard live in `positron.iss`. Call the setup file directly with the same parameters that Positron uses. This needs no update feed. Start Positron first. Then create `%TEMP%\u.flag` and run:

```
Positron-PR-UserSetup-x64.exe /verysilent /log /update="%TEMP%\u.flag" /progress="%TEMP%\p" ^
  /sessionend="%TEMP%\se.flag" /cancel="%TEMP%\c.flag" /nocloseapplications ^
  /mergetasks=runcode,!desktopicon,!quicklaunchicon /DIR="%LOCALAPPDATA%\Programs\Positron"
```

The installer stages the files into `{app}\_` and then waits for Positron to exit.

1. While the installer waits, create `%TEMP%\se.flag`. Then quit Positron.
2. Read the newest setup log in `%TEMP%`. The log must contain `Skipping inno_updater.exe call because the OS session is ending or cancel was requested.`
3. Repeat the command. This time create `%TEMP%\c.flag` instead. The log must contain `Cancel file detected, aborting background update.`
4. Repeat the command once more. Remove `%TEMP%\u.flag` before you quit Positron. The installer must swap the files and then start Positron again.

Step 4 is the deterministic form of the bug in #13988. The flag file controls whether the installer starts Positron again after the swap. Before this PR, Positron still held that file at this point in a real update.

#### Daily build, after merge

For the **first** daily after we merge this, during a background update, the installer comes from the **target** version, and the flag timing comes from the **running** version.

- The first update into a daily with this change runs the new `positron.iss` with the old TypeScript. The session-end guard is active while the flag timing fix is not so a missed restart on that one transition is expected.
- Every update after that has both halves. From there, "Restart to Update" must close and reopen Positron with no manual relaunch.

Watch for these over the next few days after this gets into dailies:

- New reports on #13988 of a missed restart, from two or more daily updates onward.
- Reports of a half-updated install, or of a stray `_` folder in the install directory.
- `session-ending.flag` in `%TEMP%\positron-user-x64\` after a Windows shutdown.

### Known limitation

The relaunch path still has a race condition. `app.on('quit')` calls `handleRelaunch()` after the mutex release. So a restart from another source, for example a display language change, can still swap the files without a relaunch while an update is pending. A fix needs a new hook on the upstream `IRelaunchHandler` interface. This is not filed upstream and maybe deserve a follow-up issue if we see people run into it.

