### PR TITLE
onboarding: remove the "no interpreters found" popup

### DIFF
--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -326,29 +326,10 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 						StorageScope.APPLICATION, StorageTarget.MACHINE);
 				}
 
-				// Check to see if every single language runtime has been disabled.
-				const languageIds = this._languagePacks.keys();
-				let allDisabled = true;
-				for (const languageId of languageIds) {
-					if (this.getStartupBehavior(languageId) !== LanguageStartupBehavior.Disabled) {
-						allDisabled = false;
-						break;
-					}
-				}
-
-				// If there are no runtimes registered, but it isn't because
-				// everything was disabled, show an error.
-				if (this._languageRuntimeService.registeredRuntimes.length === 0 &&
-					!allDisabled) {
-					this._notificationService.error(nls.localize('positron.runtimeStartupService.noRuntimesMessage',
-						"No interpreters found. Please see the [Get Started](https://positron.posit.co/start) \
-						documentation to learn how to prepare your Python and/or R environments to work with Positron."));
-				}
-
 				// If there are no affiliated runtimes, and no starting or running
 				// runtimes, start the first runtime that has Immediate startup
 				// behavior.
-				else if (!this.hasAffiliatedRuntime() &&
+				if (!this.hasAffiliatedRuntime() &&
 					!this._runtimeSessionService.hasStartingOrRunningConsole()) {
 					const languageRuntimes = this._languageRuntimeService.registeredRuntimes
 						.filter(metadata => {

--- a/src/vs/workbench/services/runtimeStartup/test/common/runtimeStartup.vitest.ts
+++ b/src/vs/workbench/services/runtimeStartup/test/common/runtimeStartup.vitest.ts
@@ -27,6 +27,7 @@ import {
 	LanguageRuntimeArchitecture,
 	LanguageRuntimeSessionLocation,
 	LanguageRuntimeStartupBehavior,
+	LanguageStartupBehavior,
 	RuntimeStartupPhase,
 } from '../../../languageRuntime/common/languageRuntimeService.js';
 import { BeforeShutdownEvent, ILifecycleService, WillShutdownEvent } from '../../../lifecycle/common/lifecycle.js';
@@ -1167,6 +1168,57 @@ describe('RuntimeStartupService - getPreferredRuntime', () => {
 			metadata({ languageId: sessionRuntime.languageId, runtimeId: 'rt-other' })));
 
 		expect(svc.getPreferredRuntime(sessionRuntime.languageId)?.runtimeId).toBe(sessionRuntime.runtimeId);
+	});
+});
+
+describe('RuntimeStartupService - discovery completion', () => {
+
+	const notificationService = new TestNotificationService();
+
+	const ctx = createTestContainer()
+		.withRuntimeServices()
+		.stub(IEphemeralStateService, {
+			getItem: () => Promise.resolve(undefined),
+			setItem: () => Promise.resolve(),
+		})
+		.stub(ILifecycleService, {
+			onBeforeShutdown: new Emitter<BeforeShutdownEvent>().event,
+			onWillShutdown: new Emitter<WillShutdownEvent>().event,
+		})
+		.stub(IPositronNewFolderService, {
+			onDidChangeNewFolderStartupPhase: new Emitter<NewFolderStartupPhase>().event,
+			startupPhase: NewFolderStartupPhase.Complete,
+		})
+		.stub(IProgressService, {})
+		.stub(IWorkbenchEnvironmentService, { remoteAuthority: undefined })
+		.stub(INotificationService, notificationService)
+		.stub(IConfigurationService, new TestConfigurationService({
+			// Anything other than 'disabled' - a language the user has not opted
+			// out of is what made the old code treat an empty discovery as an error.
+			'interpreters.startupBehavior': LanguageStartupBehavior.Auto,
+		}))
+		.stub(IRuntimeDiscoveryCache, {})
+		.build();
+
+	it('stays quiet when discovery completes with no runtimes registered', () => {
+		// Finding no interpreters used to raise an error notification pointing at
+		// the general Get Started docs. The welcome page health checks cover that
+		// case now, so completing discovery empty-handed must say nothing.
+		const errorNotification = vi.spyOn(notificationService, 'error');
+
+		const svc = ctx.disposables.add(
+			ctx.instantiationService.createInstance(RuntimeStartupService)) as RuntimeStartupService;
+
+		// Language packs come from an extension point that no unit test can drive,
+		// but an empty map is the one shape that suppressed the old notification on
+		// its own. Seed one enabled language so this asserts the removal itself.
+		(svc as unknown as { _languagePacks: Map<string, ExtensionIdentifier[]> })
+			._languagePacks.set('python', [new ExtensionIdentifier('ms-python.python')]);
+
+		ctx.get(ILanguageRuntimeService).setStartupPhase(RuntimeStartupPhase.Complete);
+
+		expect(ctx.get(ILanguageRuntimeService).registeredRuntimes).toHaveLength(0);
+		expect(errorNotification).not.toHaveBeenCalled();
 	});
 });
 


### PR DESCRIPTION
Fixes #15147. Removes the "No interpreters found" error notification shown at startup when runtime discovery finds nothing.

The health checks coming to the new welcome page cover the same condition with specific, actionable next steps, so this doesn't need a stopgap replacement.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Removed the startup notification that reported no interpreters were found and linked to documentation saying no setup was needed (#15147)

### Validation Steps

@:interpreter @:sessions

1. Start Positron on a machine with no Python or R interpreters available. Confirm no "No interpreters found" error notification appears. (I verified this in the [dev container](https://github.com/posit-dev/positron/tree/main/.devcontainer/ci-arm) with Claude's help.)
2. Start Positron normally, with interpreters installed. Confirm a runtime with immediate startup behavior still auto-starts, and that an affiliated runtime still starts in a folder that has one.
3. Set every language's startup behavior to disabled and restart. Confirm startup is quiet and nothing auto-starts.
