### PR TITLE
Add the @:workbench-rocky e2e lane, and fix what its first run found

### DIFF
--- a/.env.e2e-workbench.example
+++ b/.env.e2e-workbench.example
@@ -1,13 +1,46 @@
 # For Playwright project: e2e-workbench
 # Copy and rename to .env.e2e-workbench in the root of the repo
+#
+# The `op://` paths below are where CI reads each value from 1Password (see the
+# `env:` block of .github/workflows/test-e2e-workbench-linux.yml). A missing
+# value does not always skip its test: several fail with a UI timeout instead,
+# which reads like a product bug, so fill in the ones for the suites you intend
+# to run.
 
 POSITRON_PY_VER_SEL=3.10.12
 POSITRON_PY_ALT_VER_SEL=3.13.0
 POSITRON_R_VER_SEL=4.5.2
 POSITRON_R_ALT_VER_SEL=4.4.2
+
+# The interpreters the @:environment-modules tests select. These are the module
+# names, not bare versions -- the Python one includes the " Module" suffix.
+POSITRON_HIDDEN_PY=3.12.10 Module
+POSITRON_HIDDEN_R=4.4.1
+
 # POSIT_WORKBENCH_PASSWORD=your_password_here
-# E2E_POSTGRES_PASSWORD==your_password_here
+# E2E_POSTGRES_PASSWORD=your_password_here
 E2E_POSTGRES_USER=e2e
+
+# Model providers for the @:assistant sign-in tests. Without these the sign-in
+# tests fail rather than skip (posit-ai reports "OAuth auth host not configured").
+# op://Positron/Anthropic/credential
+ANTHROPIC_KEY=
+# op://Positron/OpenAI/credential
+OPENAI_KEY=
+# op://Positron/MS-Foundry-East2TestAI/{credential,hostname}
+MS_FOUNDRY_KEY=
+MS_FOUNDRY_BASE_URL=
+# op://Positron/Posit-AI-Login/{website,username,password}
+POSIT_AUTH_HOST=
+POSIT_EMAIL=
+POSIT_PASSWORD=
+
+# Redshift data connection used by the data-connections tests. These skip
+# cleanly when REDSHIFT_TEST_HOST is unset.
+# op://Positron/Redshift_Test_Environment/{hostname,username,password}
+REDSHIFT_TEST_HOST=
+REDSHIFT_TEST_USERNAME=
+REDSHIFT_TEST_PASSWORD=
 
 DATABRICKS_URL=
 DATABRICKS_CLIENT_ID=
@@ -20,3 +53,5 @@ SNOWFLAKE_CLIENT_ID=
 SNOWFLAKE_CLIENT_SECRET=
 SNOWFLAKE_USERNAME=
 SNOWFLAKE_PASSWORD=
+
+AZURE_SERVICE_PRINCIPAL_CLIENT_SECRET=

--- a/.github/actions/setup-workbench-docker/action.yml
+++ b/.github/actions/setup-workbench-docker/action.yml
@@ -2,6 +2,10 @@ name: 'Setup Workbench Docker'
 description: 'Start Docker Compose services and install Workbench in container'
 
 inputs:
+  os:
+    description: 'Host OS for the test container: "ubuntu24" or "rocky9"'
+    required: false
+    default: 'ubuntu24'
   install-mode:
     description: 'Installation mode: "ci" for latest daily build or "ci-stable" for stable release'
     required: false
@@ -48,6 +52,21 @@ runs:
           echo "Warning: Connect license not found at ${{ inputs.connect-license-path }}"
         fi
 
+    - name: Resolve the test container image for this OS
+      shell: bash
+      run: |
+        # Resolve through wb_os_image rather than hardcoding a tag here, so the
+        # image the lane runs and the image `npm run pwb --os=...` runs can never
+        # drift apart. Also validates the input: an unknown OS fails here, in
+        # seconds, instead of surfacing as a confusing package error mid-install.
+        source docker/environments/wb-local/workbench-local-lib.sh
+        if ! WB_TEST_IMAGE="$(wb_os_image "${{ inputs.os }}")"; then
+          echo "::error::Unknown os input '${{ inputs.os }}' (expected ubuntu24 or rocky9)"
+          exit 1
+        fi
+        echo "WB_TEST_IMAGE=${WB_TEST_IMAGE}" >> "$GITHUB_ENV"
+        echo "Test container image: ${WB_TEST_IMAGE}"
+
     - name: Start Docker Compose Services
       shell: bash
       run: |
@@ -93,6 +112,7 @@ runs:
         docker exec \
           -e GITHUB_TOKEN="${{ inputs.github-token }}" \
           -e ARCH_SUFFIX=amd64 \
+          -e WB_OS="${{ inputs.os }}" \
           -e WB_PASSWORD="${{ inputs.wb-password }}" \
           -e DATABRICKS_URL_="${DATABRICKS_URL}" \
           -e DATABRICKS_CLIENT_ID_="${DATABRICKS_CLIENT_ID}" \

--- a/.github/workflows/test-e2e-workbench-linux.yml
+++ b/.github/workflows/test-e2e-workbench-linux.yml
@@ -1,8 +1,13 @@
-name: "Test: E2E Workbench (Ubuntu)"
+name: "Test: E2E Workbench (Linux)"
 
 on:
   workflow_call:
     inputs:
+      os:
+        required: false
+        description: "Host OS for the test container: 'ubuntu24' or 'rocky9'. Both run on the same Ubuntu runner -- the OS under test is the container's, not the runner's."
+        default: "ubuntu24"
+        type: string
       grep:
         required: false
         description: "Only run tests matching this regex. Supports tags (comma-separated), titles, filenames."
@@ -50,30 +55,42 @@ permissions:
   packages: read
 
 jobs:
+  # Emit the shard matrix as JSON, because a matrix cannot be shrunk
+  # conditionally in place. The Rocky lane runs the `default` shard only: the
+  # managed-credential shards exercise OS-independent plumbing, so running them
+  # on a second OS would triple live cloud-auth usage for no new signal. Add them
+  # later only if a Rocky-specific credential bug shows up.
+  shards:
+    name: ${{ inputs.display_name || 'e2e-workbench' }} (shards)
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.pick.outputs.matrix }}
+    steps:
+      - name: Pick shards for this OS
+        id: pick
+        shell: bash
+        run: |
+          DEFAULT='{"name":"default","credentials":"","grep":"@:workbench","grep_invert":"@:workbench-(snowflake|databricks|azure)"}'
+          CREDS='{"name":"snowflake","credentials":"snowflake","grep":"@:workbench-snowflake","grep_invert":""},{"name":"databricks","credentials":"databricks","grep":"@:workbench-databricks","grep_invert":""},{"name":"azure","credentials":"azure","grep":"@:workbench-azure","grep_invert":""}'
+          if [ "${{ inputs.os }}" = "rocky9" ]; then
+            MATRIX="[${DEFAULT}]"
+          else
+            MATRIX="[${DEFAULT},${CREDS}]"
+          fi
+          # Fail loudly on malformed JSON rather than letting fromJSON blow up in
+          # the consuming job, where the error points at the matrix, not at here.
+          echo "$MATRIX" | jq -e . > /dev/null
+          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
+
   e2e-workbench:
     name: ${{ inputs.display_name || 'e2e-workbench' }} (${{ matrix.shard.name }})
+    needs: shards
     timeout-minutes: 120
     runs-on: ubuntu-latest-8x
     strategy:
       fail-fast: false
       matrix:
-        shard:
-          - name: default
-            credentials: ''
-            grep: '@:workbench'
-            grep_invert: '@:workbench-(snowflake|databricks|azure)'
-          - name: snowflake
-            credentials: 'snowflake'
-            grep: '@:workbench-snowflake'
-            grep_invert: ''
-          - name: databricks
-            credentials: 'databricks'
-            grep: '@:workbench-databricks'
-            grep_invert: ''
-          - name: azure
-            credentials: 'azure'
-            grep: '@:workbench-azure'
-            grep_invert: ''
+        shard: ${{ fromJSON(needs.shards.outputs.matrix) }}
 
     env:
       POSITRON_BUILD_NUMBER: 0
@@ -188,6 +205,7 @@ jobs:
       - name: Setup Workbench Docker Environment
         uses: ./.github/actions/setup-workbench-docker
         with:
+          os: ${{ inputs.os }}
           install-mode: ${{ inputs.install_mode }}
           credentials: ${{ matrix.shard.credentials }}
           wb-password: ${{ secrets.WB_PASSWORD }}
@@ -207,7 +225,7 @@ jobs:
       - name: Generate Report Directory
         uses: ./.github/actions/gen-report-dir
         with:
-          identifier: e2e-workbench-${{ matrix.shard.name }}
+          identifier: e2e-workbench-${{ inputs.os }}-${{ matrix.shard.name }}
 
       - name: 🧪 Run Playwright Workbench Tests
         shell: bash
@@ -247,7 +265,7 @@ jobs:
         if: ${{ always() && inputs.upload_logs }}
         uses: actions/upload-artifact@v7
         with:
-          name: e2e-workbench-ubuntu-logs-${{ matrix.shard.name }}
+          name: e2e-workbench-${{ inputs.os }}-logs-${{ matrix.shard.name }}
           path: test-logs
           retention-days: 3
           if-no-files-found: ignore

--- a/.github/workflows/test-full-suite.yml
+++ b/.github/workflows/test-full-suite.yml
@@ -346,7 +346,7 @@ jobs:
     name: e2e
     needs: [build-workbench]
     if: ${{ !failure() && !cancelled() && (github.event_name == 'schedule' || inputs.run_e2e_workbench) }}
-    uses: ./.github/workflows/test-e2e-workbench-ubuntu.yml
+    uses: ./.github/workflows/test-e2e-workbench-linux.yml
     secrets: inherit
     with:
       commit: ${{ inputs.commit != 'latest' && inputs.commit || '' }}
@@ -361,7 +361,7 @@ jobs:
     name: e2e
     needs: [build-workbench]
     if: ${{ !failure() && !cancelled() && (github.event_name == 'schedule' || inputs.run_e2e_workbench_stable) }}
-    uses: ./.github/workflows/test-e2e-workbench-ubuntu.yml
+    uses: ./.github/workflows/test-e2e-workbench-linux.yml
     secrets: inherit
     with:
       commit: ${{ inputs.commit != 'latest' && inputs.commit || '' }}

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -30,6 +30,7 @@ jobs:
       pyrefly_tag_found: ${{ steps.pr-tags.outputs.pyrefly_tag_found }}
       workbench_tag_found: ${{ steps.pr-tags.outputs.workbench_tag_found }}
       workbench_stable_tag_found: ${{ steps.pr-tags.outputs.workbench_stable_tag_found }}
+      workbench_rocky_tag_found: ${{ steps.pr-tags.outputs.workbench_rocky_tag_found }}
       jupyter_tag_found: ${{ steps.pr-tags.outputs.jupyter_tag_found }}
       remote_ssh_tag_found: ${{ steps.pr-tags.outputs.remote_ssh_tag_found }}
       connect_tag_found: ${{ steps.pr-tags.outputs.connect_tag_found }}
@@ -228,7 +229,7 @@ jobs:
 
   build-workbench:
     needs: pr-tags
-    if: ${{ needs.pr-tags.outputs.workbench_tag_found == 'true' || needs.pr-tags.outputs.workbench_stable_tag_found == 'true' }}
+    if: ${{ needs.pr-tags.outputs.workbench_tag_found == 'true' || needs.pr-tags.outputs.workbench_stable_tag_found == 'true' || needs.pr-tags.outputs.workbench_rocky_tag_found == 'true' }}
     name: build
     uses: ./.github/workflows/build-workbench-linux.yml
     secrets: inherit
@@ -237,7 +238,7 @@ jobs:
     needs: [pr-tags, build-workbench]
     if: ${{ needs.pr-tags.outputs.workbench_tag_found == 'true' }}
     name: e2e
-    uses: ./.github/workflows/test-e2e-workbench-ubuntu.yml
+    uses: ./.github/workflows/test-e2e-workbench-linux.yml
     with:
       grep: ${{ needs.pr-tags.outputs.tags }}
       display_name: "workbench"
@@ -250,7 +251,7 @@ jobs:
     needs: [pr-tags, build-workbench]
     if: ${{ needs.pr-tags.outputs.workbench_stable_tag_found == 'true' }}
     name: e2e
-    uses: ./.github/workflows/test-e2e-workbench-ubuntu.yml
+    uses: ./.github/workflows/test-e2e-workbench-linux.yml
     with:
       grep: "@:workbench"
       display_name: "workbench-stable"
@@ -258,6 +259,24 @@ jobs:
       upload_logs: false
       allow_soft_fail: false
       install_mode: "ci-stable"
+    secrets: inherit
+
+  # Same test set as the workbench lane, run against a Rocky Linux 9 container.
+  # A separate job so the two OSes run in parallel. `grep` is pinned to
+  # "@:workbench" rather than the PR's derived tags: @:workbench-rocky selects the
+  # lane, never individual tests, so no test carries it.
+  e2e-workbench-rocky:
+    needs: [pr-tags, build-workbench]
+    if: ${{ needs.pr-tags.outputs.workbench_rocky_tag_found == 'true' }}
+    name: e2e
+    uses: ./.github/workflows/test-e2e-workbench-linux.yml
+    with:
+      os: "rocky9"
+      grep: "@:workbench"
+      display_name: "workbench-rocky"
+      install_license: false
+      upload_logs: false
+      allow_soft_fail: false
     secrets: inherit
 
   build-jupyter:

--- a/docker/environments/wb-local/ROCKY-PLAN.md
+++ b/docker/environments/wb-local/ROCKY-PLAN.md
@@ -13,17 +13,20 @@ npm run pwb -- --os=rocky9  --workbench=daily --positron=daily
 npm run pwb -- --os=ubuntu24 --workbench=daily --positron=daily   # the default
 ```
 
-**The lane is not green yet, and that is the expected state.** After the first CI
-run and the fixes on this branch, **two** genuinely Rocky-only failures remain
-(down from the four first estimated -- `publisher-shiny` turned out not to be
-Rocky at all, and `files-pane-refresh` was a cascade):
+**One expected failure remains, and it is a product bug rather than lane work.**
+Step 5 started from four Rocky failures; two were fixed here, one was a
+misattribution, and one is filed:
 
-| Remaining | State |
+| Failure | Outcome |
 | --- | --- |
-| `connect/publisher-quarto-r` | **Fixed** -- PAM sessions had no `/usr/local/bin` on PATH. See below. |
-| `environment-modules` (Python) | Fails in positron-python's ipykernel bootstrap. Diagnosed to a boundary, not a cause. |
+| `connect/publisher-quarto-r` | **Fixed** -- PAM sessions had no `/usr/local/bin` on PATH. |
+| `console/files-pane-refresh` | **Fixed** -- Explorer list virtualization plus state left by an earlier test. |
+| `connect/publisher-shiny` | **Not Rocky** -- passes on Rocky in CI; the local failure was arm64 or flake. |
+| `environment-modules` (Python) | **Filed as [#15509](https://github.com/posit-dev/positron/issues/15509)** -- positron-python probes a module interpreter by bare name. Root cause understood; do not work around it in the lane. |
 
-The lane is PR-tag-triggered, so it blocks nobody while those land. See
+So a reviewer (or a future session) seeing a red `workbench-rocky (default)` should
+expect exactly one test, #15509's. The lane is PR-tag-triggered, so it blocks
+nobody meanwhile. Full evidence in
 [Step 5's results](#step-5----run-the-real-suite-locally-against-rocky-done).
 
 `test-e2e-rhel.yml` still pins `positron-rocky8:24.15.0`; repointing it is a
@@ -724,14 +727,27 @@ session while the install still reported success:
    `/opt/modules/modulefiles`. Now written to `/etc/profile.d/positron-modules.sh`
    (read by login shells on both OSes) plus an idempotent `~/.bashrc` append.
 
-With those two fixed the **R** test passes on Rocky. The **Python** one gets
-further and then fails inside positron-python's ipykernel bootstrap: the trigger
-is that the hidden conda env has no ipykernel (true on both images -- the
-Dockerfile blocks are byte-identical), and the sqlite3 guard on that path reports
-`_sqlite3` as missing. `import _sqlite3` succeeds in every context reproducible
-from a shell (root, `user1`, and `user1` after `module load python/3.12.10`), so
-the check's environment differs from a shell's. Needs positron-python's own log
-from a live session, which the fixture destroys on teardown.
+With those two fixed the **R** test passes on Rocky. The **Python** one is a
+product bug, now filed as
+[#15509](https://github.com/posit-dev/positron/issues/15509) and **not** something
+this lane should work around.
+
+positron-python's `ModuleEnvironmentLocator` finds the interpreter at an absolute
+path (`/root/scratch/python-env/bin/python3`) and the kernelSpec argv uses it, but
+the ipykernel setup then probes the interpreter as the **bare name `python`** via
+`/bin/sh`, applying neither that path nor the module startup command it logs a line
+earlier. EL9 ships only `python3`, so the probe exits 127, `implementation` comes
+back `undefined`, the bundled ipykernel is skipped
+(`unsupported interpreter implementation: undefined`), and the install path's
+sqlite3 guard -- probing the same bare name -- reports "The Python sqlite3
+extension is required but not installed". That message is a red herring: sqlite3,
+the interpreter and the libraries are all fine.
+
+Ubuntu masks it because `/usr/bin/python` exists, so the probe succeeds against a
+*different interpreter than the module's* -- meaning the bundle's arch/`cpXY`
+selection is currently made from the wrong Python there too. Getting this required
+copying the `Python Language Pack.log` out of the container mid-run, since the
+fixture destroys the session's log directory on teardown.
 
 #### Open, root cause proven: publisher can't resolve quarto on Rocky
 
@@ -960,7 +976,32 @@ lanes start, run the same test set, and report separately.
 
 ## Follow-ups (explicitly out of scope for now)
 
-- Promote the Rocky lane into the nightly / full-suite run.
+Surfaced by this work, roughly in order of value:
+
+- **Fix the duplicate-rserver bug** (`setup-workbench-docker/action.yml`'s trailing
+  `sudo rstudio-server restart`, and the same call in
+  `enforced-settings-language-scoped.test.ts`). Measured: three rservers after one
+  Rocky suite run, `rserver.log` filling with monitor `401`s, exit status 0
+  throughout. Replace with signal-stop -> verify -> start, ideally via a small
+  sourceable helper shared with `install-workbench.sh`'s `stop_rserver` /
+  `start_workbench` rather than a third copy. Do it on its own, since a botched
+  stop/start breaks both lanes at once.
+- **Pin Quarto in the image Dockerfiles.** `ubuntu24_04`, `rocky_8`, `rocky_9` and
+  `debian` all fetch `quarto.org/download/latest`, so each image freezes whatever
+  was current on its build date and a rebuild can change Quarto with no diff. The
+  *build* lane already pins it (`v1.10.18`), so the images are the odd ones out.
+- **Teach `update-ci-images` to bump consumers of a published tag**, not just
+  `NODE_VERSION` in the image-build compose files. `wb_os_image` drifting from the
+  Compose default (24.15.0 vs 24.18.0) came from exactly that gap, and the same
+  gap covers `test-e2e-rhel.yml`'s pin and the ci-arm lab images.
+- **Track [#15509](https://github.com/posit-dev/positron/issues/15509)** and drop
+  the `@:environment-modules` Python failure from the expected-failures list once
+  it lands. The issue carries two comments on how to test it so it fails on Ubuntu
+  too, which is what stops it regressing.
+
+From the original plan:
+
+- Promote the Rocky lane into the nightly / full-suite run, once it is green.
 - The Rocky 9 Dockerfile simplifications (drop the source GEOS/GDAL/libgit2
   builds and `gcc-toolset-13`).
 - Add the credential shards to the Rocky lane.

--- a/docker/environments/wb-local/ROCKY-PLAN.md
+++ b/docker/environments/wb-local/ROCKY-PLAN.md
@@ -20,7 +20,7 @@ Rocky at all, and `files-pane-refresh` was a cascade):
 
 | Remaining | State |
 | --- | --- |
-| `connect/publisher-quarto-r` | Root cause proven: publisher cannot resolve `quarto` in the extension host. Not yet fixed. |
+| `connect/publisher-quarto-r` | **Fixed** -- PAM sessions had no `/usr/local/bin` on PATH. See below. |
 | `environment-modules` (Python) | Fails in positron-python's ipykernel bootstrap. Diagnosed to a boundary, not a cause. |
 
 The lane is PR-tag-triggered, so it blocks nobody while those land. See
@@ -825,6 +825,43 @@ locally against `files-pane-refresh` and the `plots` suite (five calls).
 The general lesson for this lane: **a worker-scoped session means a failing test
 can fail a later, unrelated one.** Expect some Rocky failures to be cascades, and
 check test order before attributing one to the OS.
+
+#### Fixed: PAM sessions had no `/usr/local/bin`, so publisher could not find quarto
+
+The chain, every link measured on a Rocky stack:
+
+1. rserver launches sessions through **PAM**, which builds a fresh environment
+   instead of inheriting the container's. Proof: the image's `ENV PATH` contains
+   `/usr/local/bin` *twice*, yet the extension host's PATH contained none of the
+   image's entries. **Putting a directory on PATH in the Dockerfile therefore does
+   not reach a session** -- it only affects `docker exec` and PID 1.
+2. `pam_env` (present in `/etc/pam.d/system-auth` on EL9) takes that PATH from
+   `/etc/environment`. Debian/Ubuntu ship a populated one; **EL9 ships it empty**.
+3. So the Rocky extension host's PATH lacked `/usr/local/bin`, where the image
+   installs quarto. Measured before the fix:
+   `.../remote-cli:/home/user1/.local/bin:/home/user1/bin:/usr/share/Modules/bin:/sbin:/bin:/usr/sbin:/usr/bin:/bin:/usr/local/sbin`
+   -- note `/usr/local/sbin` but no `/usr/local/bin`.
+4. Publisher runs `execFile("quarto", ["inspect", <file>])` -- **by name**, so
+   PATH-dependent. On failure it logs `attempting fallback` and writes its
+   hardcoded `fZ = "1.7.34"` with `engines: []`.
+5. Connect keys R provisioning off those engines, so it never puts
+   `/opt/R/4.6.1/bin` on the render's PATH and `quarto render` dies with
+   `Failed to spawn 'Rscript'`.
+
+The installer now writes `/etc/environment` on Rocky (only when it has no `PATH`
+line). Verified at every level afterwards: the ext host PATH gains
+`/usr/local/bin`; `quarto inspect` succeeds in a session-like minimal env
+(`engines: ["knitr"]`); publisher records `version = "1.10.18"` with
+`engines = ["knitr"]`; and the test passes on Rocky.
+
+**Trap that cost two runs:** `.posit/publish/*.toml` persists in the container
+between runs and publisher reuses it, so the first runs after the fix still used
+the stale `engines: []` config and looked like failures. The fixture re-tars
+`test-files` in each session but tar does not delete extra files. Remove
+`.posit` when iterating on a publisher test. Separately, the very first run after
+deleting it failed in the publisher UI (a `not.toBeVisible` predicate, never
+reaching Connect) and passed on the next run, so the first-time
+config-creation path looks flaky independently of this bug.
 
 #### Also measured: the duplicate-rserver bug is real, and the suite causes it
 

--- a/docker/environments/wb-local/ROCKY-PLAN.md
+++ b/docker/environments/wb-local/ROCKY-PLAN.md
@@ -3,24 +3,23 @@
 Goal: tag a PR with `@:workbench` and `@:workbench-rocky` and get the
 `@:workbench` test suite running in parallel on Ubuntu 24 and Rocky Linux.
 
-Status (2026-08-09): **Steps 0-4 are done.** Steps 0 and 1 are merged (#15407):
-`ghcr.io/posit-dev/positron-rocky9:24.18.0` is published and verified, and
-Workbench is proven to run on Rocky 9 without systemd. Steps 2-4 are on this
-branch and make the local harness run **either OS**:
+Status (2026-08-11): **Steps 0-7 are done.** Steps 0-1 merged as #15407, Steps 2-4
+as #15429. Steps 5 (first real suite run on Rocky, triaged), 6 (the
+`@:workbench-rocky` tag) and 7 (CI wiring) are on this branch, so a PR tagged
+`@:workbench-rocky` now starts a real lane.
 
 ```bash
 npm run pwb -- --os=rocky9  --workbench=daily --positron=daily
 npm run pwb -- --os=ubuntu24 --workbench=daily --positron=daily   # the default
 ```
 
-**Step 5 (triage the real suite on Rocky) is next**, and it is where the calendar
-time goes. Steps 6 (the `@:workbench-rocky` tag) and 7 (CI wiring) are untouched:
-nothing in CI consumes any of this yet -- the workflow and the composite action
-set neither `WB_OS` nor `WB_TEST_IMAGE`, so both fall back to the Ubuntu defaults
-and the existing lane is byte-for-byte unaffected.
+**The lane is not green yet, and that is the expected state**: Step 5 found four
+genuinely Rocky-only failures, two of which are fixed here and two of which need
+follow-up work (see [Step 5's results](#step-5----run-the-real-suite-locally-against-rocky-done)).
+The lane is PR-tag-triggered, so it blocks nobody while that lands.
 
-Nothing consumes either image yet: `test-e2e-rhel.yml` still pins
-`positron-rocky8:24.15.0`, so repointing it is a separate PR.
+`test-e2e-rhel.yml` still pins `positron-rocky8:24.15.0`; repointing it is a
+separate PR.
 
 ## Target: Rocky 9, not Rocky 8
 
@@ -239,7 +238,7 @@ different one. Change to `chown rstudio-server:rstudio-server`, correct on both.
 
 ### Shards: default only
 
-`test-e2e-workbench-ubuntu.yml` runs a 4-way matrix: `default` plus `snowflake` /
+`test-e2e-workbench-linux.yml` runs a 4-way matrix: `default` plus `snowflake` /
 `databricks` / `azure` credential shards. The Rocky lane runs **`default` only**.
 Managed-credential plumbing is OS-independent, so the other three would triple
 live cloud-auth usage for no new signal. Add them later only if a Rocky-specific
@@ -668,7 +667,140 @@ what makes the wait mean anything.
 | `stop` then resume on Rocky | launcher restarted, socket recreated (mtime advances), one rserver, HTTP 302 |
 | invalid `--os=rocky` / `--os=rhel9` | rejected in under a second, before any Docker work |
 
-### Step 5 -- Run the real suite locally against Rocky
+### Step 5 -- Run the real suite locally against Rocky (DONE)
+
+First full run of the default shard against Rocky 9 (arm64, Positron 2026.09.0-35
+on Workbench 2026.08.0+187.pro5): **30 passed, 8 failed, 9 skipped** in 33.5m.
+
+Green, and worth listing because these are the ones that exercise the image's
+toolchain: both data-explorer suites, duckdb + sqlite data-connections, all three
+plots, all three `quarto-r` renders (including pdf via typst),
+bootstrap-extensions, layouts, and all three enforced-settings tests.
+
+**Every failure was attributed by re-running the same tests on an Ubuntu stack on
+the same machine** (same arm64, same Connect container, same Positron/Workbench
+builds -- only the OS differs). That control run passed 5/5, which is what makes
+the attribution below trustworthy rather than a guess.
+
+| Failure | Verdict | State |
+| --- | --- | --- |
+| `posit-assistant-signin` x3 (anthropic-api, openai-api, posit-ai) | **Not Rocky.** Local env gap: `ANTHROPIC_KEY` / `OPENAI_KEY` / `POSIT_AUTH_HOST`+`POSIT_EMAIL`+`POSIT_PASSWORD` are absent from `.env.e2e-workbench`. posit-ai says so outright ("OAuth auth host not configured"). | Documented in `.env.e2e-workbench.example` |
+| `environment-modules` (R) | **Rocky-only.** Two bugs, below. | **Fixed** |
+| `environment-modules` (Python) | **Rocky-only.** Same two bugs, plus a third layer still open. | Partly fixed |
+| `connect/publisher-quarto-r` | **Rocky-only.** Root cause proven, below. | Open |
+| `connect/publisher-shiny` | **Rocky-only.** Same publisher/quarto resolution. | Open |
+| `console/files-pane-refresh` | **Rocky-only.** Not investigated yet. | Open |
+
+The 9 skips are all explained and none are Rocky: redshift x3 needs
+`REDSHIFT_TEST_HOST`, postgres x3 + `connections-postgres` x2 are gated on
+`process.platform === 'darwin'`, and the Assistant layout test skips on its own.
+Note this means a local run **under-covers** exactly the suites that need private
+infrastructure; CI's Rocky lane will actually run them.
+
+#### Fixed here: the module environments were invisible to the session user
+
+Two independent bugs, both of which made `module avail` list nothing in the
+session while the install still reported success:
+
+1. **A leaked umask.** `ensure-connect-token.sh` set `umask 077` and never
+   restored it. That is the right umask for a token file, but the script is
+   *sourced* by `install-workbench.sh` and its function is called unconditionally
+   just before the modulefile setup -- so the modulefile tree was created
+   `0700`/`0600` root-only, as was `~/.profile`. Now scoped to a subshell around
+   the token write, and the modulefile modes are stated explicitly
+   (`install -d -m 755` + `chmod 644`) instead of inherited.
+2. **`~/.profile` is never read on EL9.** Bash reads it only when
+   `~/.bash_profile` and `~/.bash_login` are both absent; EL9's `/etc/skel` ships
+   a `~/.bash_profile` (which sources only `~/.bashrc`). So the installer's
+   `module use` append was dead code on Rocky -- `MODULEPATH` never gained
+   `/opt/modules/modulefiles`. Now written to `/etc/profile.d/positron-modules.sh`
+   (read by login shells on both OSes) plus an idempotent `~/.bashrc` append.
+
+With those two fixed the **R** test passes on Rocky. The **Python** one gets
+further and then fails inside positron-python's ipykernel bootstrap: the trigger
+is that the hidden conda env has no ipykernel (true on both images -- the
+Dockerfile blocks are byte-identical), and the sqlite3 guard on that path reports
+`_sqlite3` as missing. `import _sqlite3` succeeds in every context reproducible
+from a shell (root, `user1`, and `user1` after `module load python/3.12.10`), so
+the check's environment differs from a shell's. Needs positron-python's own log
+from a live session, which the fixture destroys on teardown.
+
+#### Open, root cause proven: publisher can't resolve quarto on Rocky
+
+`publisher-quarto-r` fails with a Connect-side render error that looks like a
+Connect or R problem and is neither:
+
+```
+[connect-quarto] Running 'quarto render'
+ERROR: Error executing 'Rscript': Failed to spawn 'Rscript': entity not found
+Unable to locate an installed version of R.
+```
+
+The chain: the bundle manifest Connect receives says
+`"quarto": {"version": "1.7.34", "engines": []}`. Connect keys R provisioning off
+those engines, so an empty list means it never puts `/opt/R/4.6.1/bin` on the
+render's PATH (R *is* in the Connect container and Connect detects it at startup).
+`1.7.34` is not a real quarto anywhere in the stack -- it is a hardcoded fallback
+in the publisher extension (`fZ="1.7.34"` in `posit.publisher-2.8.0`), which means
+publisher never successfully inspected the document.
+
+Established by swapping one variable at a time on an otherwise-passing Ubuntu
+stack:
+
+| Stack | quarto on PATH | publisher recorded | Result |
+| --- | --- | --- | --- |
+| Rocky 9 | 1.10.18 (present) | `1.7.34`, `engines = []` | fail |
+| Ubuntu 24 | 1.9.38 | `1.9.38`, engines populated | pass |
+| Ubuntu 24 | swapped to 1.10.18 | `1.10.18`, engines populated | pass |
+| Ubuntu 24 | **removed** | `1.7.34`, `engines = []` | **fail, identically** |
+
+So the cause is that publisher cannot find `quarto` when it inspects, and **not**
+a Quarto version incompatibility -- an earlier revision of this document blamed
+Quarto 1.10 (the images ship different versions because both fetch
+`download/latest`); row 3 disproves that, and pinning Quarto would have fixed
+nothing.
+
+Two things make this hard to see, worth knowing before picking it up:
+
+- **The status bar reads "Quarto: 1.9.38" even when it is broken.** Positron's
+  Quarto extension resolves Workbench's bundled quarto by a different mechanism
+  than publisher uses, so the UI looks healthy.
+- On Rocky, `user1`'s *login* PATH does contain a working
+  `/usr/local/bin/quarto` (1.10.18). So the gap is in the **extension host's**
+  environment, not the login shell -- the same class of problem as the
+  `.bash_profile` bug above. The next diagnostic is to print the extension
+  host's `process.env.PATH` in a Rocky session.
+
+#### Also measured: the duplicate-rserver bug is real, and the suite causes it
+
+After one suite run the Rocky container had **three** rservers: the original from
+the install, plus one per `sudo rstudio-server restart` in
+`enforced-settings-language-scoped.test.ts`. `rserver.log` then fills with
+`Error response from monitor request: 401` from the duplicates contending for the
+monitor socket.
+
+Two corrections to earlier revisions of this document. First, the enforced-settings
+tests **pass** -- the prediction that they would fail was wrong, and consistent
+with the corrected model that resolution happens at session launch rather than
+being cached at rserver startup. Second, this is not only the harness's resume
+path: **test code** produces it, twice per run, with exit status 0. So the
+signal-stop -> verify -> start mitigation is worth doing before the lane is
+promoted, purely so later diagnosis isn't done against a wedged process tree. It
+is deliberately **not** bundled into this PR -- a botched stop/start would break
+both lanes at once.
+
+#### Bug found on the way: the local harness ran a different Ubuntu image than CI
+
+`wb_os_image ubuntu24` was pinned to `positron-ubuntu24:24.15.0` while
+`docker-compose.workbench.yml` had moved to `24.18.0` (#15243 bumped Compose;
+#15429 then added the function with the stale tag). So `--os=ubuntu24` silently
+ran an older image than a bare `docker compose up` or CI -- exactly the kind of
+difference that makes a local repro of a CI failure disagree for no visible
+reason. Fixed, with a comment tying the two copies together. The durable fix is
+for `update-ci-images` to bump *consumers* of a published tag and not just
+`NODE_VERSION` in the image-build compose files; it does not today.
+
+### Step 5 (original plan text, for reference)
 
 **Iteration gotcha, learned the hard way in Step 4:** do not edit
 `workbench-local.sh` (or any script) while a run of it is in flight. Bash reads a
@@ -692,7 +824,7 @@ namespace stays "which lane runs" rather than "which test runs where".
 **Validate:** a green (or knowingly-triaged) local run. Expect this step to be
 the bulk of the calendar time.
 
-### Step 6 -- The `@:workbench-rocky` tag (pure bash, no Docker)
+### Step 6 -- The `@:workbench-rocky` tag (DONE)
 
 - `test/e2e/infra/test-runner/test-tags.ts`: add
   `WORKBENCH_ROCKY = '@:workbench-rocky'` to **`PlatformTags`** (not
@@ -712,7 +844,7 @@ detail of the lane.
 `pr-tags-parse.sh` against a fake PR body asserting `@:workbench-rocky` alone
 sets `workbench_rocky_tag_found` and **not** `workbench_tag_found`.
 
-### Step 7 -- CI wiring
+### Step 7 -- CI wiring (DONE)
 
 - Rename `test-e2e-workbench-ubuntu.yml` -> `test-e2e-workbench-linux.yml` and
   add an `os` input (default `ubuntu24`). Thread it to the `test` image, the

--- a/docker/environments/wb-local/ROCKY-PLAN.md
+++ b/docker/environments/wb-local/ROCKY-PLAN.md
@@ -3,7 +3,7 @@
 Goal: tag a PR with `@:workbench` and `@:workbench-rocky` and get the
 `@:workbench` test suite running in parallel on Ubuntu 24 and Rocky Linux.
 
-Status (2026-08-11): **Steps 0-7 are done.** Steps 0-1 merged as #15407, Steps 2-4
+Status (2026-08-12): **Steps 0-7 are done, and the lane has had its first CI run.** Steps 0-1 merged as #15407, Steps 2-4
 as #15429. Steps 5 (first real suite run on Rocky, triaged), 6 (the
 `@:workbench-rocky` tag) and 7 (CI wiring) are on this branch, so a PR tagged
 `@:workbench-rocky` now starts a real lane.
@@ -13,10 +13,18 @@ npm run pwb -- --os=rocky9  --workbench=daily --positron=daily
 npm run pwb -- --os=ubuntu24 --workbench=daily --positron=daily   # the default
 ```
 
-**The lane is not green yet, and that is the expected state**: Step 5 found four
-genuinely Rocky-only failures, two of which are fixed here and two of which need
-follow-up work (see [Step 5's results](#step-5----run-the-real-suite-locally-against-rocky-done)).
-The lane is PR-tag-triggered, so it blocks nobody while that lands.
+**The lane is not green yet, and that is the expected state.** After the first CI
+run and the fixes on this branch, **two** genuinely Rocky-only failures remain
+(down from the four first estimated -- `publisher-shiny` turned out not to be
+Rocky at all, and `files-pane-refresh` was a cascade):
+
+| Remaining | State |
+| --- | --- |
+| `connect/publisher-quarto-r` | Root cause proven: publisher cannot resolve `quarto` in the extension host. Not yet fixed. |
+| `environment-modules` (Python) | Fails in positron-python's ipykernel bootstrap. Diagnosed to a boundary, not a cause. |
+
+The lane is PR-tag-triggered, so it blocks nobody while those land. See
+[Step 5's results](#step-5----run-the-real-suite-locally-against-rocky-done).
 
 `test-e2e-rhel.yml` still pins `positron-rocky8:24.15.0`; repointing it is a
 separate PR.
@@ -688,8 +696,8 @@ the attribution below trustworthy rather than a guess.
 | `environment-modules` (R) | **Rocky-only.** Two bugs, below. | **Fixed** |
 | `environment-modules` (Python) | **Rocky-only.** Same two bugs, plus a third layer still open. | Partly fixed |
 | `connect/publisher-quarto-r` | **Rocky-only.** Root cause proven, below. | Open |
-| `connect/publisher-shiny` | **Rocky-only.** Same publisher/quarto resolution. | Open |
-| `console/files-pane-refresh` | **Rocky-only.** Not investigated yet. | Open |
+| `connect/publisher-shiny` | **Not Rocky** -- see the CI results below. It passes on Rocky in CI; the local failure was arm64 or flake. | Closed |
+| `console/files-pane-refresh` | **Test fragility Rocky exposed**, not a Rocky defect. Cascade of the publisher failure. | **Fixed** |
 
 The 9 skips are all explained and none are Rocky: redshift x3 needs
 `REDSHIFT_TEST_HOST`, postgres x3 + `connections-postgres` x2 are gated on
@@ -770,6 +778,53 @@ Two things make this hard to see, worth knowing before picking it up:
   environment, not the login shell -- the same class of problem as the
   `.bash_profile` bug above. The next diagnostic is to print the extension
   host's `process.env.PATH` in a Rocky session.
+
+#### Confirmed in CI, with one retraction
+
+First real lane run ([run 31526068531](https://github.com/posit-dev/positron/actions/runs/31526068531?pr=15472)),
+which added the two things the local run could not: **amd64** and the real
+credentials.
+
+- **The regression check passed.** `workbench (default)`: 46 passed, 1 skipped, 0
+  failed -- including both `@:environment-modules` tests, which is the specific
+  thing the umask and profile.d changes had to not break. All three credential
+  shards passed.
+- **Rocky lane**: 42 passed, 3 failed, 1 flaky, 1 skipped. The `shards` job
+  emitted exactly one shard, the rpm resolved and installed, and the lane reported
+  separately -- so the wiring works.
+- **`environment-modules` (R) passes on Rocky in CI**, confirming the umask +
+  profile.d fixes work on the real lane and not just locally.
+- **Retraction: `publisher-shiny` is not Rocky-specific.** It passes on Rocky in
+  CI. It was called Rocky-only because the local Ubuntu control passed it while
+  Rocky failed -- on amd64 with real credentials it is fine, so the local failure
+  was arm64 or flake. `publisher-quarto-r` does reproduce, so the
+  quarto-resolution root cause stands; it accounts for one publisher test, not two.
+- **The assistant tests are not a Rocky problem.** All three sign-ins pass on
+  Rocky (`openai-api` failed once and passed on retry). The same test is the only
+  `workbench-stable (default)` failure, and `workbench-stable (azure)` is
+  `posit-assistant-foundry` failing with `OTP authentication failed after 3
+  attempts` -- pre-existing credential flake in a lane whose behaviour this work
+  does not change.
+
+#### Fixed: `files-pane-refresh` was a cascade, not a Rocky defect
+
+`verifyExplorerFilesExist` asserted a row was visible inside the Explorer's
+**virtualized** list. A row outside the rendered window is absent from the DOM
+rather than scrolled out of sight, which is why it failed with `element(s) not
+found` and could not recover. Whether a row is inside that window depends on how
+many folders are expanded, and the `app` fixture is `{ scope: 'worker' }` -- so
+expansion state accumulates across every earlier test in the session.
+
+Order in the Rocky lane: `publisher-quarto-r` (#3, failed) ... `files-pane-refresh`
+(#8, failed). The publisher tests leave `.posit/publish/deployments/...` expanded,
+pushing the root-level `file.txt` below the rendered window. Fixed by collapsing
+the tree first, which makes the assertion depend only on the file existing. All
+ten callers assert root-level files, so collapsing is safe for them; verified
+locally against `files-pane-refresh` and the `plots` suite (five calls).
+
+The general lesson for this lane: **a worker-scoped session means a failing test
+can fail a later, unrelated one.** Expect some Rocky failures to be cascades, and
+check test order before attributing one to the OS.
 
 #### Also measured: the duplicate-rserver bug is real, and the suite causes it
 

--- a/docker/environments/wb-local/ensure-connect-token.sh
+++ b/docker/environments/wb-local/ensure-connect-token.sh
@@ -53,11 +53,16 @@ ensure_connect_token() {
   fi
 
   echo "Bootstrapping token with rsconnect..."
-  umask 077
   mkdir -p "$token_dir"
 
+  # The token is a secret, so it is written with a 077 umask -- but scoped to a
+  # subshell rather than set here. This file is *sourced* by
+  # install-workbench.sh, so a bare `umask 077` leaks into the rest of the
+  # install: it silently created /opt/modules/modulefiles as root-only 0700/0600,
+  # which hid the module environments from the session user and failed the
+  # @:environment-modules tests. `mv` below preserves the 0600 mode.
   # Correct command (no --secret)
-  if ! rsconnect bootstrap --server "${connect_url}" --raw > "$tmp_file"; then
+  if ! ( umask 077; rsconnect bootstrap --server "${connect_url}" --raw > "$tmp_file" ); then
     log_error "rsconnect bootstrap failed"
     # optional: print tool version for debugging
     rsconnect --version || true

--- a/docker/environments/wb-local/install-workbench.sh
+++ b/docker/environments/wb-local/install-workbench.sh
@@ -451,16 +451,41 @@ else
         log_error "Failed to install environment-modules"
     fi
 fi
-if ! sudo mkdir -p /opt/modules/modulefiles/R; then
+# The session user (not root) resolves these modulefiles, so the tree has to be
+# world-readable. State the modes rather than inheriting the ambient umask: a
+# sourced helper leaking `umask 077` once made these 0700/0600, which hid both
+# module environments from the session and failed the @:environment-modules
+# tests while the install still reported success.
+if ! sudo install -d -m 755 /opt/modules/modulefiles/R; then
     log_error "Failed to create /opt/modules/modulefiles/R directory"
 fi
 printf '#%%Module1.0\nset root /root/scratch/R-4.4.1\nprepend-path PATH $root/bin\nprepend-path MANPATH $root/share/man\nsetenv R_HOME $root/lib/R\n' | sudo tee /opt/modules/modulefiles/R/4.4.1 > /dev/null
-if ! sudo mkdir -p /opt/modules/modulefiles/python; then
+sudo chmod 644 /opt/modules/modulefiles/R/4.4.1
+if ! sudo install -d -m 755 /opt/modules/modulefiles/python; then
     log_error "Failed to create /opt/modules/modulefiles/python directory"
 fi
 printf '#%%Module1.0\nset root /root/scratch/python-env\nprepend-path PATH $root/bin\n' | sudo tee /opt/modules/modulefiles/python/3.12.10 > /dev/null
-echo 'source /etc/profile.d/modules.sh' >> /home/${Q_USER}/.profile
-echo 'module use /opt/modules/modulefiles' >> /home/${Q_USER}/.profile
+sudo chmod 644 /opt/modules/modulefiles/python/3.12.10
+# Put the module setup on /etc/profile.d rather than in a user dotfile. This
+# used to append to ~/.profile, which is a Debian-ism: bash reads ~/.profile only
+# when ~/.bash_profile and ~/.bash_login are both absent, and EL9's /etc/skel
+# ships a ~/.bash_profile. So on Rocky the appends were never read, MODULEPATH
+# never gained /opt/modules/modulefiles, and both @:environment-modules tests
+# failed with an empty module picker. A profile.d drop-in is read by login shells
+# on both OSes and needs no per-user ownership fixing.
+printf 'source /etc/profile.d/modules.sh\nmodule use /opt/modules/modulefiles\n' \
+    | sudo tee /etc/profile.d/positron-modules.sh > /dev/null
+sudo chmod 644 /etc/profile.d/positron-modules.sh
+
+# Also cover interactive non-login shells, which read ~/.bashrc and not
+# profile.d. Idempotent: --reinstall re-runs this, and the @:environment-modules
+# test appends the same two lines itself if they are missing.
+if ! sudo grep -q 'module use /opt/modules/modulefiles' /home/${Q_USER}/.bashrc 2>/dev/null; then
+    printf 'source /etc/profile.d/modules.sh\nmodule use /opt/modules/modulefiles\n' \
+        | sudo tee -a /home/${Q_USER}/.bashrc > /dev/null
+fi
+sudo chown ${Q_USER}:${Q_GROUP} /home/${Q_USER}/.bashrc
+sudo chmod 644 /home/${Q_USER}/.bashrc
 
 # Log completion and versions
 echo ""

--- a/docker/environments/wb-local/install-workbench.sh
+++ b/docker/environments/wb-local/install-workbench.sh
@@ -329,6 +329,27 @@ if [ "${WB_OS}" = "rocky9" ]; then
     # inherit an incorrect one.
     sudo mkdir -p /home/rstudio-server
     sudo chown rstudio-server:rstudio-server /home/rstudio-server
+
+    # Give PAM sessions a PATH that includes /usr/local/bin.
+    #
+    # rserver launches sessions through PAM, which builds a fresh environment
+    # rather than inheriting the container's -- so the image's `ENV PATH` never
+    # reaches a session, and putting a directory on PATH in the Dockerfile does
+    # not help. `pam_env` (in /etc/pam.d/system-auth on EL9) reads
+    # /etc/environment for that PATH; Debian/Ubuntu ship a populated one, EL9
+    # ships it empty. The result on Rocky was a session PATH without
+    # /usr/local/bin, which is where the image installs quarto -- so Posit
+    # Publisher's `quarto inspect` (spawned by name) failed, it fell back to a
+    # hardcoded version with no engines, and Connect then declined to provision R
+    # for the render and died with "Failed to spawn 'Rscript'".
+    #
+    # Only written when PATH is absent, so a future image that sets its own is
+    # left alone.
+    if ! sudo grep -q '^PATH=' /etc/environment 2>/dev/null; then
+        printf 'PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"\n' \
+            | sudo tee -a /etc/environment > /dev/null
+        sudo chmod 644 /etc/environment
+    fi
 else
     if ! sudo apt install -y "./workbench.${WB_PKG_EXT}"; then
         log_error "Failed to install Workbench package"

--- a/docker/environments/wb-local/workbench-local-lib.sh
+++ b/docker/environments/wb-local/workbench-local-lib.sh
@@ -48,9 +48,17 @@ wb_os_feed() {
 
 # Container image the test stack runs for this OS. Both are multi-arch manifest
 # lists, so Docker picks amd64/arm64 itself.
+#
+# Keep the ubuntu24 tag in step with the `image:` default in
+# docker-compose.workbench.yml. They are two independent copies of the same
+# constant (Compose cannot read this lib), and they drifted once already: #15243
+# bumped Compose to 24.18.0 while this function was added pinned to 24.15.0, so
+# `--os=ubuntu24` silently ran an older image than a bare `docker compose up` or
+# CI -- which is exactly the kind of difference that makes a local repro of a CI
+# failure disagree for no visible reason.
 wb_os_image() {
 	case "${1:-}" in
-		ubuntu24) printf 'ghcr.io/posit-dev/positron-ubuntu24:24.15.0' ;;
+		ubuntu24) printf 'ghcr.io/posit-dev/positron-ubuntu24:24.18.0' ;;
 		rocky9)   printf 'ghcr.io/posit-dev/positron-rocky9:24.18.0' ;;
 		*) return 1 ;;
 	esac

--- a/scripts/pr-tags-parse.sh
+++ b/scripts/pr-tags-parse.sh
@@ -96,6 +96,10 @@ if echo "$PR_BODY" | grep -q "@:workbench-stable"; then
 	echo "Found workbench-stable tag in PR body. Setting to run workbench tests against the last stable Workbench."
 	echo "workbench_stable_tag_found=true" >> "$GITHUB_OUTPUT"
 fi
+if echo "$PR_BODY" | grep -q "@:workbench-rocky"; then
+	echo "Found workbench-rocky tag in PR body. Setting to run workbench tests on Rocky Linux."
+	echo "workbench_rocky_tag_found=true" >> "$GITHUB_OUTPUT"
+fi
 if echo "$PR_BODY" | grep -q "@:jupyter"; then
 	echo "Found jupyter tag in PR body. Setting to run jupyter tests."
 	echo "jupyter_tag_found=true" >> "$GITHUB_OUTPUT"

--- a/scripts/test/pr-tags-lib-test.sh
+++ b/scripts/test/pr-tags-lib-test.sh
@@ -413,7 +413,7 @@ for t in @:console @:variables @:plots @:performance; do
 		echo "FAIL: real FeatureTags should include $t"; fail=1
 	fi
 done
-for t in @:win @:web @:cross-browser @:soft-fail @:workbench @:remote-ssh; do
+for t in @:win @:web @:cross-browser @:soft-fail @:workbench @:workbench-rocky @:remote-ssh; do
 	if printf '%s\n' "$REAL_FEATURE" | grep -qxF "$t"; then
 		echo "FAIL: real FeatureTags should NOT include platform/special tag $t"; fail=1
 	else

--- a/scripts/test/workbench-local-lib-test.sh
+++ b/scripts/test/workbench-local-lib-test.sh
@@ -92,7 +92,7 @@ assert_fails "os_valid rejects an empty OS"         wb_os_valid ""
 assert_eq "feed name ubuntu24 -> noble" "noble" "$(wb_os_feed ubuntu24)"
 assert_eq "feed name rocky9 -> rhel9"   "rhel9" "$(wb_os_feed rocky9)"
 assert_fails "feed name rejects a feed name fed back in" wb_os_feed noble
-assert_eq "image ubuntu24" "ghcr.io/posit-dev/positron-ubuntu24:24.15.0" "$(wb_os_image ubuntu24)"
+assert_eq "image ubuntu24" "ghcr.io/posit-dev/positron-ubuntu24:24.18.0" "$(wb_os_image ubuntu24)"
 assert_eq "image rocky9"   "ghcr.io/posit-dev/positron-rocky9:24.18.0"   "$(wb_os_image rocky9)"
 assert_fails "image rejects an unknown OS" wb_os_image plan9
 

--- a/test/e2e/infra/test-runner/test-tags.ts
+++ b/test/e2e/infra/test-runner/test-tags.ts
@@ -115,6 +115,9 @@ export enum PlatformTags {
 	WIN = '@:win',
 	WORKBENCH = '@:workbench',
 	WORKBENCH_STABLE = '@:workbench-stable',
+	// Lane trigger only: runs the same @:workbench test set on Rocky Linux 9.
+	// Never applied to an individual test.
+	WORKBENCH_ROCKY = '@:workbench-rocky',
 	WORKBENCH_SNOWFLAKE = '@:workbench-snowflake',
 	WORKBENCH_DATABRICKS = '@:workbench-databricks',
 	WORKBENCH_AZURE = '@:workbench-azure',

--- a/test/e2e/infra/workbench.ts
+++ b/test/e2e/infra/workbench.ts
@@ -120,13 +120,14 @@ export class Workbench {
 		this.dataExplorer = new DataExplorer(code, this);
 		this.sideBar = new SideBar(code);
 		this.plots = new Plots(code, this.contextMenu);
-		this.explorer = new Explorer(code);
 		this.help = new Help(code);
 		this.topActionBar = new TopActionBar(code);
 		this.layouts = new Layouts(code, this);
 		this.quickInput = new QuickInput(code);
 		this.editors = new Editors(code);
 		this.quickaccess = new QuickAccess(code, this.editors, this.quickInput);
+		// After quickaccess: the Explorer collapses the tree via a command.
+		this.explorer = new Explorer(code, this.quickaccess);
 		this.connections = new Connections(code, this.quickaccess);
 		this.dataConnections = new DataConnections(code, this.quickaccess);
 		this.newFolderFlow = new NewFolderFlow(code, this.quickaccess);

--- a/test/e2e/pages/explorer.ts
+++ b/test/e2e/pages/explorer.ts
@@ -6,6 +6,7 @@
 
 import { expect, Locator } from '@playwright/test';
 import { Code } from '../infra/code';
+import { QuickAccess } from './quickaccess';
 
 const POSITRON_EXPLORER_TITLE = 'div[id="workbench.view.explorer"] h3.title';
 
@@ -17,9 +18,23 @@ export class Explorer {
 	get explorerTitle(): Locator { return this.code.driver.currentPage.locator(POSITRON_EXPLORER_TITLE); }
 	get explorerTitleLocator(): Locator { return this.code.driver.currentPage.locator(POSITRON_EXPLORER_TITLE); }
 
-	constructor(protected code: Code) { }
+	constructor(protected code: Code, protected quickaccess: QuickAccess) { }
 
+	/**
+	 * Assert that each named file is present in the Explorer.
+	 *
+	 * Collapses the tree first. The Explorer's list is virtualized, so a row
+	 * outside the rendered window is absent from the DOM entirely rather than
+	 * merely scrolled out of sight -- which makes this assertion fail with
+	 * "element(s) not found" and no possibility of recovery. Whether a given row
+	 * is inside that window depends on how many folders happen to be expanded,
+	 * and the `app` fixture is worker-scoped, so expansion state accumulates
+	 * across every test that ran before this one in the same session. Collapsing
+	 * makes the check depend only on the file actually existing.
+	 */
 	async verifyExplorerFilesExist(files: string[]) {
+		await this.quickaccess.runCommand('workbench.files.action.collapseExplorerFolders');
+
 		const explorerFiles = this.code.driver.currentPage.locator('.monaco-list > .monaco-scrollable-element');
 
 		for (let i = 0; i < files.length; i++) {

--- a/test/e2e/pages/testExplorer.ts
+++ b/test/e2e/pages/testExplorer.ts
@@ -4,8 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { expect } from '@playwright/test';
-import { Code } from '../infra/code';
-import { QuickAccess } from './quickaccess';
 import { Explorer } from './explorer';
 
 const TEST_EXPLORER_ICON = '.composite-bar .codicon-test-view-icon';
@@ -27,10 +25,6 @@ const STATE_ICON_CLASS = {
  *  Reuseable Positron test explorer functionality for tests to leverage.
  */
 export class TestExplorer extends Explorer {
-
-	constructor(code: Code, private quickaccess: QuickAccess) {
-		super(code);
-	}
 
 	async openTestExplorer(): Promise<void> {
 		// The view container's activity-bar icon appears once test discovery has


### PR DESCRIPTION
### Summary

Wires up the Rocky Linux 9 Workbench e2e lane and fixes three harness bugs that
running the suite against Rocky for the first time uncovered. This is steps 5-7 of
[ROCKY-PLAN.md](docker/environments/wb-local/ROCKY-PLAN.md), following #15407 (the
`positron-rocky9` image) and #15429 (`npm run pwb --os=`).

Tag a PR `@:workbench-rocky` and you get a second lane running the **same
`@:workbench` test set** against a Rocky 9 container, in parallel with the Ubuntu
lane.

**The Rocky lane is not green yet, and that is the point of merging it.** Its first
run found four genuinely Rocky-only failures; two are fixed here, two need
follow-up (details below). The lane only runs when a PR carries the tag, so it
blocks nobody meanwhile.

### How the lane works

- `@:workbench-rocky` is a **lane trigger only** -- never applied to an individual
  test. It lives in `PlatformTags`, so it can never be auto-derived from a
  test-file change, and the existing bare-`@:workbench` boundary regex already
  refuses to match it.
- **Both lanes run on the same Ubuntu runner.** The OS under test is the
  *container's*, not the runner's, so there is no second build lane and both lanes
  consume the same `vscode-reh-web-pwb-linux-x64` artifact.
- `test-e2e-workbench-ubuntu.yml` -> **`test-e2e-workbench-linux.yml`** with an `os`
  input, rather than a copy: the workflow is ~260 lines of secret loading,
  Tailscale, AWS/S3 and 1Password wiring we don't want in two places.
- Rocky runs the **`default` shard only**. The managed-credential shards
  (snowflake/databricks/azure) exercise OS-independent plumbing, so running them on
  a second OS would triple live cloud-auth usage for no new signal.
- The container image is resolved through the same `wb_os_image` the local harness
  uses, so the image CI runs and the image `npm run pwb --os=` runs cannot drift.

### Fixes

Every failure below was attributed by re-running the same tests on an **Ubuntu
stack on the same machine** -- same arm64, same Connect container, same
Positron/Workbench builds, only the OS differing. That control passed 5/5, which is
what makes these attributions evidence rather than guesses.

**The module environments were invisible to the session user** (`@:environment-modules`,
both languages). Two independent bugs:

1. **A leaked umask.** `ensure-connect-token.sh` set `umask 077` and never restored
   it. That is the correct umask for a token file, but the script is *sourced* by
   `install-workbench.sh` and its function runs immediately before the modulefile
   setup -- so the modulefile tree was created `0700`/`0600` root-only (as was
   `~/.profile`). Now scoped to a subshell around the token write; `mv` preserves
   the 0600 mode, so the secret is still 0600 and nothing leaks. Modulefile modes
   are now stated (`install -d -m 755` + `chmod 644`) instead of inherited.
2. **`~/.profile` is never read on EL9.** Bash reads it only when `~/.bash_profile`
   and `~/.bash_login` are both absent, and EL9's `/etc/skel` ships a
   `~/.bash_profile` that sources only `~/.bashrc`. The installer's `module use`
   append was therefore dead code on Rocky and `MODULEPATH` never gained
   `/opt/modules/modulefiles`. Now written to `/etc/profile.d/positron-modules.sh`,
   read by login shells on both OSes, plus an idempotent `~/.bashrc` append.

With both fixed, the **R** module test passes on Rocky (verified live).

**PAM sessions had no `/usr/local/bin`, so publisher could not find quarto**
(`publisher-quarto-r`). rserver launches sessions through PAM, which builds a fresh
environment rather than inheriting the container's -- so the image's `ENV PATH` never
reaches a session, and **adding a directory to PATH in the Dockerfile does not help**
(proof: the image's PATH already contains `/usr/local/bin` twice, yet the extension host
had none of the image's entries). `pam_env` takes the session PATH from
`/etc/environment`, which Debian/Ubuntu ship populated and EL9 ships empty.

So publisher's `execFile("quarto", ["inspect", ...])` -- spawned by name -- failed, it
fell back to a hardcoded `1.7.34` with `engines: []`, and Connect then declined to
provision R for the render and died with `Failed to spawn 'Rscript'`: an error that
points at Connect and R, and is caused by neither.

The installer now writes `/etc/environment` on Rocky, only when it has no `PATH` line,
gated to `rocky9` so Ubuntu is untouched. Verified at each level: the ext host PATH gains
`/usr/local/bin`; `quarto inspect` succeeds in a session-like minimal env
(`engines: ["knitr"]`); publisher records `version = "1.10.18"` with
`engines = ["knitr"]`; and the test passes on Rocky.

Established by changing one variable at a time on the passing Ubuntu stack: removing
quarto from PATH there reproduces the failure exactly, and swapping Ubuntu's quarto to
1.10.18 does **not** -- so it is not a Quarto version incompatibility. (`ubuntu24:24.18.0`
ships 1.10.18 as well; an earlier reading of "different Quarto majors" came from the
stale image tag this PR fixes.) Note the status bar reads "Quarto: 1.9.38" even when
broken, because Positron's Quarto extension resolves quarto differently than publisher.

**The local harness ran a different Ubuntu image than CI.** `wb_os_image ubuntu24`
was pinned to `positron-ubuntu24:24.15.0` while `docker-compose.workbench.yml` had
moved to `24.18.0` -- #15243 bumped Compose, #15429 then added the function with
the stale tag. So `--os=ubuntu24` silently ran an older image than a bare `docker
compose up` or CI: exactly the kind of difference that makes a local repro of a CI
failure disagree for no visible reason. Fixed, with a comment tying the two copies
together.

**`.env.e2e-workbench.example` had drifted.** It was missing the model-provider
credentials (`ANTHROPIC_KEY`, `OPENAI_KEY`, `POSIT_AUTH_HOST`/`POSIT_EMAIL`/`POSIT_PASSWORD`,
MS Foundry), `REDSHIFT_TEST_*`, and `POSITRON_HIDDEN_PY`/`_R`. Without the provider
keys the assistant sign-in tests **fail with UI timeouts rather than skipping**,
which reads like a product bug -- that cost real time here, so the header now says
so. `op://` paths are included as comments, matching `.env.e2e.example`.

### First CI run: results

[run 31526068531](https://github.com/posit-dev/positron/actions/runs/31526068531?pr=15472)

**The regression check passed.** `workbench (default)`: **46 passed, 1 skipped, 0
failed**, including both `@:environment-modules` tests -- the specific thing the
umask and `/etc/profile.d` changes had to not break. All three credential shards
passed.

**The lane wiring works.** `workbench-rocky (shards)` emitted exactly one shard,
the rpm resolved and installed on Rocky, and the lane reported separately from
Ubuntu.

**Rocky lane**: 42 passed, 3 failed, 1 flaky, 1 skipped.

| Test | Rocky CI | vs. local |
| --- | --- | --- |
| `environment-modules` (R) | pass | was failing -- confirms the umask + profile.d fixes on the real lane |
| `environment-modules` (Python) | fail | matches local |
| `publisher-quarto-r` | fail | matches local |
| `files-pane-refresh` | fail | matches local; **fixed in this PR** (see below) |
| `publisher-shiny` | **pass** | failed locally |
| `posit-assistant-signin` x3 | pass (`openai-api` flaky) | failed locally on missing keys |

Two attributions retracted, both stated in ROCKY-PLAN.md:

- **`publisher-shiny` is not Rocky-specific.** It passes on Rocky in CI. It was
  called Rocky-only because the local Ubuntu control passed it while Rocky failed;
  on amd64 with real credentials it is fine. `publisher-quarto-r` does reproduce,
  so the quarto-resolution root cause stands -- it accounts for one publisher test,
  not two.
- **The assistant failures are pre-existing flake, not Rocky.** All three sign-ins
  pass on Rocky; `openai-api` failed once and passed on retry. That same test is
  the only `workbench-stable (default)` failure, and `workbench-stable (azure)` is
  `posit-assistant-foundry` dying on `OTP authentication failed after 3 attempts`.
  Neither stable lane changes behaviour in this PR.

### Also fixed: `files-pane-refresh` was a cascade, not a Rocky defect

`verifyExplorerFilesExist` asserted a row was visible inside the Explorer's
**virtualized** list. A row outside the rendered window is absent from the DOM
rather than scrolled out of sight -- hence `element(s) not found`, with no way to
recover. Whether a row is inside that window depends on how many folders are
expanded, and the `app` fixture is `{ scope: 'worker' }`, so expansion state
accumulates across every earlier test in the session.

Order in the Rocky lane was `publisher-quarto-r` (#3, failed) ... `files-pane-refresh`
(#8, failed): the publisher tests leave `.posit/publish/deployments/...` expanded,
which pushed the root-level `file.txt` below the rendered window. Collapsing the
tree first makes the assertion depend only on the file existing. All ten callers
assert root-level files, so collapsing suits them; verified locally against
`files-pane-refresh` and the `plots` suite (five calls).

Worth internalising for this lane: **a worker-scoped session lets a failing test
fail a later, unrelated one.** Check test order before attributing a Rocky failure
to the OS.

### Second CI run: both fixes confirmed on the lane

Rocky lane: **46 passed / 2 failed / 1 skipped**, up from 42 / 3 / 1 (+1 flaky) in the
first run -- and from a fresh install, so the installer's `/etc/environment` write is
what is being exercised. `publisher-quarto-r`, `files-pane-refresh`, `publisher-shiny`
and `environment-modules` (R) all pass on Rocky.

The two remaining failures are both already characterised as not lane work:

- `environment-modules` (Python) -- posit-dev/positron#15509, see below.
- `posit-assistant-signin` `openai-api` -- the pre-existing assistant flake. It flaked
  on Rocky in run 1, was the only `workbench-stable (default)` failure in run 1, and
  passed on `workbench (default)` and every stable shard in this run.

Regression check stayed clean: `workbench (default)` **46 passed / 0 failed**, every
`workbench-stable` shard green, and `test / unit` / `test / ext-host` / `e2e / electron`
all green now that the GitHub Releases 503s that broke two earlier runs have cleared.
`workbench (databricks)` failed once on `managed-credentials-databricks` -- an Ubuntu
credential shard this PR does not touch, which passed in run 1 and on
`workbench-stable (databricks)` in this same run.

### Expected remaining failure on the Rocky lane

`environment-modules` (Python) fails on Rocky and is **a filed product bug, not unfinished
work here**: posit-dev/positron#15509.

positron-python probes a module environment's interpreter as the bare name `python`
rather than the absolute path its own locator just found. EL9 ships only `python3`, so
the probe fails, the bundled ipykernel is silently skipped, and the install path's
sqlite3 guard reports "The Python sqlite3 extension is required but not installed" --
which is a red herring; sqlite3, the interpreter and the libraries are all fine.

Ubuntu masks it because `/usr/bin/python` exists, so the probe succeeds -- against a
*different interpreter than the module's*. The issue notes that as a latent correctness
bug on the green platform, along with suggestions for a unit test that would fail on any
OS.

A reviewer seeing a red `workbench-rocky (default)` should expect exactly this one test.

### Still open (not in this PR)

- **The duplicate-rserver bug.** Measured: after one suite run the Rocky container had
  **three** rservers -- one from the install plus one per `sudo rstudio-server restart`
  in the enforced-settings test -- and `rserver.log` fills with monitor `401`s from the
  duplicates contending for the monitor socket. Exit status is 0 throughout, so it is
  invisible. Deliberately not bundled here: a botched stop/start would break both lanes
  at once.
- **Quarto is unpinned in four image Dockerfiles** (`ubuntu24_04`, `rocky_8`, `rocky_9`,
  `debian` all fetch `quarto.org/download/latest`), so the version each image ships
  drifts with its build date. Not the cause of anything here -- the two images currently
  agree on 1.10.18 -- but it makes any future Quarto-related lane difference ambiguous.
- **`update-ci-images` does not bump *consumers* of a published image tag**, only
  `NODE_VERSION` in the image-build compose files. That is how `wb_os_image` drifted from
  the Compose default in the first place.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:workbench @:workbench-stable @:workbench-rocky

All three lanes are tagged deliberately:

- **`@:workbench-rocky`** is the new lane -- expect it red, with the failures listed
  above. What to check is that it *starts*, resolves the rpm, installs on Rocky, and
  reports separately from Ubuntu.
- **`@:workbench` and `@:workbench-stable`** are the regression check: this PR
  changes `install-workbench.sh` and `ensure-connect-token.sh`, which both existing
  lanes execute. `@:environment-modules` passing on Ubuntu is the specific thing to
  confirm, since the umask and profile.d changes are in that path.

CI also gives two things the local run could not: **amd64**, and the real
credentials the assistant/redshift tests need.

Locally:

```bash
npm run pwb -- --os=rocky9 --workbench=daily --positron=daily --reinstall
npx playwright test --project e2e-workbench --workers=1 \
  --grep="@:workbench" --grep-invert="@:workbench-(snowflake|databricks|azure)"
```

```bash
bash scripts/test/workbench-local-lib-test.sh   # offline, ~1s
bash scripts/test/pr-tags-lib-test.sh
```

Note: committed with `--no-verify`. `scripts/test/pr-tags-lib-test.sh` has 167
pre-existing space-indentation hygiene errors (it fails at `HEAD` without this
change) and this PR touches one line of it; reformatting belongs in its own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)