### PR TITLE
Clear the console input before the R password-prompt test

### DIFF
--- a/test/e2e/tests/console/console-r.test.ts
+++ b/test/e2e/tests/console/console-r.test.ts
@@ -32,8 +32,15 @@ test.describe('Console Pane: R', {
 
 	test('R - Verify password prompt', async function ({ app, r }) {
 
+		// The interrupt test above can leave `Sys.sleep(10)` in the input; pasting
+		// appends at the cursor, so R would get a syntax error instead of a prompt.
+		await app.workbench.console.clearInput();
+
 		await app.workbench.console.pasteCodeToConsole('out <- rstudioapi::askForPassword("enter password")', true);
 
+		// quickInput.type() calls selectText(), which blocks on the always-attached
+		// widget for 30s with a bare locator timeout if the prompt never opens.
+		await app.workbench.quickInput.waitForQuickInputOpened({ timeout: 15000 });
 		await app.workbench.quickInput.type('password');
 		await app.code.driver.currentPage.keyboard.press('Enter');
 


### PR DESCRIPTION
### Summary

`R - Verify password prompt` flaked in CI because it pasted into a console input that was not empty. The preceding interrupt test can leave `Sys.sleep(10)` behind, so R received `Sys.sleep(10)out <- rstudioapi::askForPassword(...)`, returned a syntax error, and never opened the password prompt.

- Clear the console input before pasting, matching the existing guard elsewhere in this file
- Wait for the prompt to open before typing into it
- `pasteInMonaco` validates with `includes()`, so a leftover prefix passes its check unnoticed
- The missing prompt surfaced as a bare 30s `selectText` timeout, pointing away from the real cause

### QA Notes

Reproduced and fixed locally on electron: forcing the leftover input gives the exact CI failure (`locator.selectText` at `quickInput.ts:113`), and the same forced condition passes with the fix. Full spec 6/6.

Not verified: all three CI occurrences were chromium-only and that project will not start in my worktree, so the contention that drives the real failure rate was never recreated. This is a rate fix -- the evidence arrives after merge.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:console @:ark @:web

### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- Leftover Sys.sleep(10) from the preceding cancel-button test is still in the console input; the password test pastes on top of it, R rejects the concatenated line as a syntax error, so askForPassword never runs and the quick-input password box never appears. quickInput.type() then blocks 30s in selectText on the permanently-attached-but-hidden .quick-input-widget input.</summary>

- **Test:** [Console Pane: R > R - Verify password prompt](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Console%20Pane%3A%20R%20%3E%20R%20-%20Verify%20password%20prompt%7C%7C%7Ctest%2Fe2e%2Ftests%2Fconsole%2Fconsole-r.test.ts)
- **Targeted failure:** TimeoutError: locator.selectText: Timeout 30000ms exceeded on .quick-input-widget .quick-input-box input
- **Signal:** Snapshot shows console input = Sys.sleep(10)out <- rstudioapi::askForPassword("enter password") and a rendered Syntax error: unexpected symbol; R Kernel.log shows execute_reply Err(Syntax error: unexpected symbol) at 16:43:32 (t~407500), immediately after the Enter at t=407280; timeline shows waitForSelector resolving in 10ms then a flat 30s gap to the screenshot.
- **Frequency:** 1/141 runs (0.7%) on main, ubuntu/chromium
- **Hypothesis:** Clearing the console input before pasting removes the contamination, so askForPassword runs and the password quick input appears; adding a visibility gate before selectText converts any recurrence into a fast named failure.

</details>

