### PR TITLE
Skip extension versions that depend on blocked extensions

### DIFF
--- a/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
@@ -28,6 +28,7 @@ import { areSameExtensions, ExtensionKey, getGalleryExtensionId, getGalleryExten
 import { ExtensionType, IExtensionManifest, isApplicationScopedExtension, TargetPlatform } from '../../extensions/common/extensions.js';
 // --- Start Positron ---
 import { validatePositronExtensionManifest } from '../../extensions/common/positronExtensionValidator.js';
+import { isBlockedExtension, isUnsatisfiableDependency } from './positronExtensionBlocklist.js';
 // --- End Positron ---
 import { ILogService } from '../../log/common/log.js';
 import { IProductService } from '../../product/common/productService.js';
@@ -37,23 +38,6 @@ import { IUserDataProfilesService } from '../../userDataProfile/common/userDataP
 import { IMarkdownString, MarkdownString } from '../../../base/common/htmlContent.js';
 
 // --- Start Positron ---
-/**
- * List of extension IDs that conflict with Positron built-in features.
- * Please use lower case for everything in here.
- */
-const kPositronDuplicativeExtensions = [
-	'ikuyadeu.r',
-	'reditorsupport.r-lsp',
-	'reditorsupport.r',
-	'rdebugger.r-debugger',
-	'mikhail-arkhipov.r',
-	'vscode.r',
-	'jeanp413.open-remote-ssh',
-	'ms-python.python',
-	'ms-python.vscode-python-envs',
-	'github.copilot-chat'
-];
-
 export interface PositronExtensionCompatibility {
 	compatible: boolean;
 	reason?: string;
@@ -65,8 +49,29 @@ export interface PositronExtensionCompatibility {
  * @returns true if compatible, false if it conflicts with Positron features
  */
 function isPositronExtensionCompatible(extension: { name: string; publisher: string }): boolean {
-	const id = `${extension.publisher}.${extension.name}`.toLowerCase();
-	return !kPositronDuplicativeExtensions.includes(id);
+	return !isBlockedExtension(`${extension.publisher}.${extension.name}`);
+}
+
+/**
+ * Build the error reported when an extension version declares a dependency on an
+ * extension Positron blocks and does not provide as a built-in. Such a version
+ * installs but can never activate, so the install is refused instead (#15124).
+ * @param displayName Display name of the extension being installed
+ * @param version Version of the extension being installed
+ * @param blockedDependencies IDs of the dependencies that can never be satisfied
+ * @returns Error to throw, reported to the user as an install failure
+ */
+function positronBlockedDependencyError(displayName: string, version: string, blockedDependencies: string[]): ExtensionManagementError {
+	return new ExtensionManagementError(
+		nls.localize(
+			'positron.blockedExtensionDependency',
+			"Cannot install version {0} of the '{1}' extension because it depends on '{2}', which conflicts with Positron built-in features.",
+			version,
+			displayName,
+			blockedDependencies.join(', ')
+		),
+		ExtensionManagementErrorCode.Incompatible
+	);
 }
 
 /**
@@ -825,6 +830,17 @@ export abstract class AbstractExtensionManagementService extends CommontExtensio
 				throw new ExtensionManagementError(nls.localize('incompatible platform', "The '{0}' extension is not available in {1} for the {2} platform.", extension.identifier.id, this.productService.nameLong, TargetPlatformToString(targetPlatform)), ExtensionManagementErrorCode.IncompatibleTargetPlatform);
 			}
 
+			// --- Start Positron ---
+			// An explicitly requested version cannot fall back to another version, so report the blocked
+			// dependency instead of the generic incompatible-version error that version selection would
+			// produce once isValidVersion rejects it (#15124).
+			if (sameVersion) {
+				const blockedDependencies = (extension.properties.dependencies ?? []).filter(isUnsatisfiableDependency);
+				if (blockedDependencies.length > 0) {
+					throw positronBlockedDependencyError(extension.displayName ?? extension.identifier.id, extension.version, blockedDependencies);
+				}
+			}
+			// --- End Positron ---
 			compatibleExtension = await this.getCompatibleVersion(extension, sameVersion, installPreRelease, productVersion);
 			if (!compatibleExtension) {
 				/** If no compatible release version is found, check if the extension has a release version or not and throw relevant error */
@@ -844,6 +860,16 @@ export abstract class AbstractExtensionManagementService extends CommontExtensio
 		if (manifest.version !== compatibleExtension.version) {
 			throw new ExtensionManagementError(`Cannot install '${compatibleExtension.identifier.id}' extension because of version mismatch in Marketplace`, ExtensionManagementErrorCode.Invalid);
 		}
+
+		// --- Start Positron ---
+		// The gallery walk (isValidVersion) already steers version selection away from versions that
+		// depend on blocked extensions; this is the authoritative backstop against a gallery that does
+		// not serve dependency metadata, where the manifest is the only source (#15124).
+		const blockedDependencies = (manifest.extensionDependencies ?? []).filter(isUnsatisfiableDependency);
+		if (blockedDependencies.length > 0) {
+			throw positronBlockedDependencyError(compatibleExtension.displayName ?? compatibleExtension.identifier.id, compatibleExtension.version, blockedDependencies);
+		}
+		// --- End Positron ---
 
 		return { extension: compatibleExtension, manifest };
 	}

--- a/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
@@ -830,19 +830,18 @@ export abstract class AbstractExtensionManagementService extends CommontExtensio
 				throw new ExtensionManagementError(nls.localize('incompatible platform', "The '{0}' extension is not available in {1} for the {2} platform.", extension.identifier.id, this.productService.nameLong, TargetPlatformToString(targetPlatform)), ExtensionManagementErrorCode.IncompatibleTargetPlatform);
 			}
 
-			// --- Start Positron ---
-			// An explicitly requested version cannot fall back to another version, so report the blocked
-			// dependency instead of the generic incompatible-version error that version selection would
-			// produce once isValidVersion rejects it (#15124).
-			if (sameVersion) {
+			compatibleExtension = await this.getCompatibleVersion(extension, sameVersion, installPreRelease, productVersion);
+			if (!compatibleExtension) {
+				// --- Start Positron ---
+				// No version passed selection. When the requested version depends on an extension Positron
+				// blocks and does not provide as a built-in, name that dependency instead of blaming the
+				// engine or a missing release version. This covers an explicitly requested version and an
+				// extension whose every version declares such a dependency (#15124).
 				const blockedDependencies = (extension.properties.dependencies ?? []).filter(isUnsatisfiableDependency);
 				if (blockedDependencies.length > 0) {
 					throw positronBlockedDependencyError(extension.displayName ?? extension.identifier.id, extension.version, blockedDependencies);
 				}
-			}
-			// --- End Positron ---
-			compatibleExtension = await this.getCompatibleVersion(extension, sameVersion, installPreRelease, productVersion);
-			if (!compatibleExtension) {
+				// --- End Positron ---
 				/** If no compatible release version is found, check if the extension has a release version or not and throw relevant error */
 				if (!installPreRelease && extension.hasPreReleaseVersion && extension.properties.isPreReleaseVersion && (await this.galleryService.getExtensions([extension.identifier], CancellationToken.None))[0]) {
 					throw new ExtensionManagementError(nls.localize('notFoundReleaseExtension', "Can't install release version of '{0}' extension because it has no release version.", extension.displayName ?? extension.identifier.id), ExtensionManagementErrorCode.ReleaseVersionNotFound);

--- a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
@@ -36,6 +36,7 @@ import { sameGalleryHost } from './extensionGalleryManifestService.js';
 import { TelemetryTrustedValue } from '../../telemetry/common/telemetryUtils.js';
 // --- Start Positron ---
 import { appendPositronGalleryParams, formatPositronVersion, GalleryUsageDataConfigKey, getPositronSessionType, PositronCheckTrigger } from './positronGalleryTelemetry.js';
+import { isUnsatisfiableDependency } from './positronExtensionBlocklist.js';
 // --- End Positron ---
 
 const CURRENT_TARGET_PLATFORM = isWeb ? TargetPlatform.WEB : getTargetPlatform(platform, arch);
@@ -1028,7 +1029,14 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 				targetPlatform: extension.properties.targetPlatform,
 				manifestAsset: extension.assets.manifest,
 				engine: extension.properties.engine,
-				enabledApiProposals: extension.properties.enabledApiProposals
+				// --- Start Positron ---
+				// enabledApiProposals: extension.properties.enabledApiProposals
+
+				// `dependencies` is passed so version validation can reject versions that depend on an
+				// extension Positron blocks and does not provide as a built-in (#15124).
+				enabledApiProposals: extension.properties.enabledApiProposals,
+				dependencies: extension.properties.dependencies
+				// --- End Positron ---
 			},
 			{
 				targetPlatform,
@@ -1042,7 +1050,13 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 	}
 
 	private async isValidVersion(
-		extension: { id: string; version: string; isPreReleaseVersion: boolean; targetPlatform: TargetPlatform; manifestAsset: IGalleryExtensionAsset | null; engine: string | undefined; enabledApiProposals: string[] | undefined },
+		// --- Start Positron ---
+		// extension: { id: string; version: string; isPreReleaseVersion: boolean; targetPlatform: TargetPlatform; manifestAsset: IGalleryExtensionAsset | null; engine: string | undefined; enabledApiProposals: string[] | undefined },
+		//
+		// `dependencies` added so version validation can reject versions that depend on an extension
+		// Positron blocks and does not provide as a built-in (#15124).
+		extension: { id: string; version: string; isPreReleaseVersion: boolean; targetPlatform: TargetPlatform; manifestAsset: IGalleryExtensionAsset | null; engine: string | undefined; enabledApiProposals: string[] | undefined; dependencies: string[] | undefined },
+		// --- End Positron ---
 		{ targetPlatform, compatible, productVersion, version }: Omit<ExtensionVersionCriteria, 'targetPlatform'> & { targetPlatform: TargetPlatform | undefined },
 		publisherDisplayName: string,
 		allTargetPlatforms: TargetPlatform[]
@@ -1078,6 +1092,14 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 		}
 
 		if (compatible) {
+			// --- Start Positron ---
+			// Reject versions that declare a dependency on an extension Positron blocks and does not
+			// provide as a built-in. The compatible-version walk in getValidRawGalleryExtensionVersion
+			// then falls back to the newest older version without such a dependency (#15124).
+			if (extension.dependencies?.some(isUnsatisfiableDependency)) {
+				return false;
+			}
+			// --- End Positron ---
 			if (this.allowedExtensionsService.isAllowed({ id: extension.id, publisherDisplayName, version: extension.version, prerelease: extension.isPreReleaseVersion, targetPlatform: extension.targetPlatform }) !== true) {
 				return false;
 			}
@@ -1388,7 +1410,14 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 					targetPlatform: getTargetPlatformForExtensionVersion(rawGalleryExtensionVersion),
 					engine: getEngine(rawGalleryExtensionVersion),
 					manifestAsset: getVersionAsset(rawGalleryExtensionVersion, AssetType.Manifest),
-					enabledApiProposals: getEnabledApiProposals(rawGalleryExtensionVersion)
+					// --- Start Positron ---
+					// enabledApiProposals: getEnabledApiProposals(rawGalleryExtensionVersion)
+					//
+					// `dependencies` is passed so version validation can reject versions that depend on an
+					// extension Positron blocks and does not provide as a built-in (#15124).
+					enabledApiProposals: getEnabledApiProposals(rawGalleryExtensionVersion),
+					dependencies: getExtensions(rawGalleryExtensionVersion, PropertyType.Dependency)
+					// --- End Positron ---
 				},
 				criteria,
 				rawGalleryExtension.publisher.displayName,
@@ -1907,7 +1936,14 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 							targetPlatform: getTargetPlatformForExtensionVersion(version),
 							engine: getEngine(version),
 							manifestAsset: getVersionAsset(version, AssetType.Manifest),
-							enabledApiProposals: getEnabledApiProposals(version)
+							// --- Start Positron ---
+							// enabledApiProposals: getEnabledApiProposals(version)
+							//
+							// `dependencies` is passed so version validation can reject versions that depend on
+							// an extension Positron blocks and does not provide as a built-in (#15124).
+							enabledApiProposals: getEnabledApiProposals(version),
+							dependencies: getExtensions(version, PropertyType.Dependency)
+							// --- End Positron ---
 						},
 						{
 							compatible: !!onlyCompatible,

--- a/src/vs/platform/extensionManagement/common/positronExtensionBlocklist.ts
+++ b/src/vs/platform/extensionManagement/common/positronExtensionBlocklist.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * List of extension IDs that conflict with Positron built-in features and are
+ * blocked from installation. Please use lower case for everything in here.
+ */
+export const POSITRON_BLOCKED_EXTENSIONS: readonly string[] = [
+	'ikuyadeu.r',
+	'reditorsupport.r-lsp',
+	'reditorsupport.r',
+	'rdebugger.r-debugger',
+	'mikhail-arkhipov.r',
+	'vscode.r',
+	'jeanp413.open-remote-ssh',
+	'ms-python.python',
+	'ms-python.vscode-python-envs',
+	'github.copilot-chat'
+];
+
+/**
+ * The subset of POSITRON_BLOCKED_EXTENSIONS that Positron ships as an in-tree
+ * built-in extension under the same ID. A third-party extension may declare a
+ * dependency on one of these and still work, because the built-in satisfies the
+ * dependency. Keep in sync with extensions/<dir>/package.json publisher and
+ * name; scripts/check-bootstrap-extension-deps.mjs verifies this nightly.
+ */
+export const POSITRON_BLOCKED_EXTENSIONS_WITH_BUILTIN: readonly string[] = [
+	'github.copilot-chat',		// extensions/copilot
+	'jeanp413.open-remote-ssh',	// extensions/open-remote-ssh
+	'ms-python.python',			// extensions/positron-python
+	'vscode.r'					// extensions/r
+];
+
+/**
+ * Check whether an extension ID is blocked from installation in Positron.
+ * @param extensionId Extension ID in publisher.name form
+ * @returns true if the extension conflicts with Positron built-in features
+ */
+export function isBlockedExtension(extensionId: string): boolean {
+	return POSITRON_BLOCKED_EXTENSIONS.includes(extensionId.toLowerCase());
+}
+
+/**
+ * Check whether a declared extension dependency can never be satisfied in
+ * Positron: the ID is blocked from installation and Positron does not provide a
+ * built-in under that ID. A candidate version that declares such a dependency
+ * installs but can never activate (see #15118).
+ * @param extensionId Extension ID in publisher.name form
+ * @returns true if the dependency can never be satisfied
+ */
+export function isUnsatisfiableDependency(extensionId: string): boolean {
+	const id = extensionId.toLowerCase();
+	return POSITRON_BLOCKED_EXTENSIONS.includes(id) && !POSITRON_BLOCKED_EXTENSIONS_WITH_BUILTIN.includes(id);
+}

--- a/src/vs/platform/extensionManagement/test/common/positronExtensionBlocklist.vitest.ts
+++ b/src/vs/platform/extensionManagement/test/common/positronExtensionBlocklist.vitest.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { isUnsatisfiableDependency, POSITRON_BLOCKED_EXTENSIONS, POSITRON_BLOCKED_EXTENSIONS_WITH_BUILTIN } from '../../common/positronExtensionBlocklist.js';
+
+describe('positronExtensionBlocklist', () => {
+
+	it('should treat dependencies on blocked extensions Positron ships as built-ins as satisfiable', () => {
+		// ruff 2026.62.0 depends on ms-python.python; Positron provides it in-tree
+		expect(isUnsatisfiableDependency('ms-python.python')).toBe(false);
+		expect(isUnsatisfiableDependency('GitHub.copilot-chat')).toBe(false);
+	});
+
+	it('should treat dependencies on blocked extensions without a built-in as unsatisfiable', () => {
+		// ruff 2026.64.0 depends on ms-python.vscode-python-envs; nothing in Positron provides it (#15118)
+		expect(isUnsatisfiableDependency('ms-python.vscode-python-envs')).toBe(true);
+		expect(isUnsatisfiableDependency('reditorsupport.r')).toBe(true);
+	});
+
+	it('should treat non-blocked dependencies as satisfiable', () => {
+		expect(isUnsatisfiableDependency('ms-toolsai.jupyter')).toBe(false);
+	});
+
+	it('should keep the built-in carve-out list a subset of the blocklist', () => {
+		expect(POSITRON_BLOCKED_EXTENSIONS_WITH_BUILTIN.every(id => POSITRON_BLOCKED_EXTENSIONS.includes(id))).toBe(true);
+	});
+
+	it('should keep every blocklist entry lower case', () => {
+		expect(POSITRON_BLOCKED_EXTENSIONS.filter(id => id !== id.toLowerCase())).toEqual([]);
+		expect(POSITRON_BLOCKED_EXTENSIONS_WITH_BUILTIN.filter(id => id !== id.toLowerCase())).toEqual([]);
+	});
+
+});


### PR DESCRIPTION
Addresses #15124 but doesn't totally fix it because I'll follow up with a PR for a nightly monitoring situation

Positron blocks a small set of extensions that conflict with built-in features. Until now, nothing looked at the _dependencies_ that an extension version declares. Nothing stopped Positron from installing a version whose `extensionDependencies` name a blocked extension. That version installs, fails to activate, and the "Install and Reload" prompt dead-ends. Ruff 2026.64.0 did this with `ms-python.vscode-python-envs` (#15118).

This PR adds two layered checks:

- The gallery layer reads the dependency metadata of each candidate version inside `isValidVersion`. A version that depends on a blocked extension is not valid. The existing newest-first walk in `getValidRawGalleryExtensionVersion` then selects the newest version without such a dependency. Auto-update stays on a working version instead of moving to a broken one.

- The management layer refuses the install and names the blocked dependency. An explicitly requested version cannot fall back to another version. For that case, `checkAndGetCompatibleVersion` reports the blocked dependency before version selection produces the generic incompatible-version error. A second check reads the manifest after the download. This second check protects against a gallery that does not serve dependency metadata.

<img width="1509" height="1106" alt="Screenshot 2026-08-11 at 2 47 23 PM" src="https://github.com/user-attachments/assets/58c5e0d4-c815-41f8-811c-944ae8eebb33" />

Four of the ten blocked IDs ship in Positron as built-in extensions: `github.copilot-chat`, `jeanp413.open-remote-ssh`, `ms-python.python`, and `vscode.r`. A dependency on one of these is satisfiable, so it does not disqualify a version. Ruff 2026.62.0 depends on `ms-python.python` and stays installable.

The blocklist moves out of a private array in `abstractExtensionManagementService.ts` into a new dependency-free module, `positronExtensionBlocklist.ts`. The gallery service, the management service, and the nightly monitor in PR 2 then read one source of truth.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Positron no longer installs or updates to an extension version that depends on a blocked extension. Positron selects the newest working version instead, when possible. (#15124)

## Validation steps

I tested out these options:

| Install attempt | Declared dependency | Outcome |
| --- | --- | --- |
| `redhat.ansible` (unpinned) | latest 26.6.0 declares `ms-python.vscode-python-envs` | **Falls back**, installs 26.1.3 plus `redhat.vscode-yaml` |
| `redhat.ansible@26.6.0` | `ms-python.vscode-python-envs` | **Blocked**, message names the dependency |
| `redhat.ansible` version picker | 26.3.5 through 26.6.0 declare it | **Hidden**, 26.1.3 is the newest offered |
| `charliermarsh.ruff@2026.64.0` (the #15118 version) | `ms-python.vscode-python-envs` | **Blocked**, message names the dependency |
| `charliermarsh.ruff@2026.62.0` | `ms-python.python` | **Allowed**, built-in satisfies it |
| `charliermarsh.ruff` (unpinned) | none in 2026.70.0 | **Allowed**, installs 2026.70.0 |
| `renan-r-santos.pixi-code` | every version declares `ms-python.vscode-python-envs` | **Blocked**, message names the dependency |
| `ms-python.debugpy` (unpinned, with `ms-python.python` temporarily out of the carve-out) | latest 2026.6.0 declares `ms-python.python` | **Falls back**, installs 2024.2.0; after revert, installs 2026.6.0 |


You can also see a lot of this in the UI:

1. Launch a dev build and open the Extensions pane.
2. Search for `renan-r-santos.pixi-code` and try to install it.
4. Make sure that the dialog names `ms-python.vscode-python-envs` as the reason why you can't.
4. Search for `redhat.ansible` (it also depends on `ms-python.vscode-python-envs` but only for newer versions).
5. Run _Extensions: Install Specific Version of Extension_ and notice you are only offered older versions that do NOT depend on the blocked extension.
6. Try to install, and notice that you get an older version.

Note: Ruff and debugpy ship as bootstrap extensions in a dev build, so their version menu offers nothing to switch to.

### Test coverage

New Vitest file `positronExtensionBlocklist.vitest.ts` covers the blocklist predicates, including the built-in carve-out. The two upstream files get wiring only. Neither `isValidVersion` nor `checkAndGetCompatibleVersion` has a unit-test seam today, so the manual evidence above stands in for them. The existing e2e test `test/e2e/tests/extensions/blocked-installs.test.ts` still covers direct installs of a blocked extension.