### PR TITLE
skip open-ai signin for now

### DIFF
--- a/test/e2e/tests/posit-assistant/posit-assistant-signin.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant-signin.test.ts
@@ -12,7 +12,6 @@ test.use({
 
 const POSIT_ASSISTANT_SIGNIN_PROVIDERS: ModelProvider[] = [
 	'anthropic-api',
-	'openai-api',
 	'amazon-bedrock',
 	'posit-ai',
 	// Microsoft Foundry (Azure) via API key + Base URL on desktop. The managed


### PR DESCRIPTION
OpenAI signin to assistant has be very flaky and noisy due to a variety of issue outside our immediate control.  Taking it out of the sign-in test for now and will revisit after new auth modal is done.

@assistant

#### New Features

- N/A

#### Bug Fixes

- N/A


### Validation Steps

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information on how to validate the change, paying
  special attention to the level of risk, adjacent areas that could
  be affected by the change, and any important contextual information
  not present in the linked issues.
-->
