### PR TITLE
viewer: dont corrupt queries in urls

### DIFF
--- a/src/vs/base/common/positronUtilities.ts
+++ b/src/vs/base/common/positronUtilities.ts
@@ -3,6 +3,8 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { URI } from './uri.js';
+
 // Types.
 type Value = string | number | undefined;
 type Mapping = Record<string, unknown>;
@@ -63,3 +65,29 @@ export const positronClassNames = (...args: Argument[]) => {
 
 	return classes.join(' ');
 };
+
+/**
+ * Serializes a URI for navigation to an external address, preserving query
+ * string delimiters.
+ *
+ * `URI.toString()` treats the query as a single opaque component and escapes
+ * `=` to `%3D` and `&` to `%26`. That is harmless for the custom schemes the
+ * class was designed around, but it corrupts query parameters on `http(s)`
+ * URLs: the server receives one nameless parameter instead of the parameters
+ * that were sent. Round-tripping through the WHATWG `URL` parser keeps the
+ * delimiters intact while still percent-encoding everything that needs it,
+ * including characters such as `"` that would otherwise break out of an HTML
+ * attribute.
+ *
+ * @param uri The URI to serialize.
+ * @returns The serialized URI, or `URI.toString()` when it cannot be parsed.
+ */
+export function externalUriToString(uri: URI): string {
+	try {
+		// `toString(true)` leaves the query untouched; the `URL` parser then
+		// re-encodes each component under the correct rules for its position.
+		return new URL(uri.toString(true)).toString();
+	} catch {
+		return uri.toString();
+	}
+}

--- a/src/vs/base/common/positronUtilities.ts
+++ b/src/vs/base/common/positronUtilities.ts
@@ -70,15 +70,6 @@ export const positronClassNames = (...args: Argument[]) => {
  * Serializes a URI for navigation to an external address, preserving query
  * string delimiters.
  *
- * `URI.toString()` treats the query as a single opaque component and escapes
- * `=` to `%3D` and `&` to `%26`. That is harmless for the custom schemes the
- * class was designed around, but it corrupts query parameters on `http(s)`
- * URLs: the server receives one nameless parameter instead of the parameters
- * that were sent. Round-tripping through the WHATWG `URL` parser keeps the
- * delimiters intact while still percent-encoding everything that needs it,
- * including characters such as `"` that would otherwise break out of an HTML
- * attribute.
- *
  * @param uri The URI to serialize.
  * @returns The serialized URI, or `URI.toString()` when it cannot be parsed.
  */

--- a/src/vs/base/test/common/positronUtilities.vitest.ts
+++ b/src/vs/base/test/common/positronUtilities.vitest.ts
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { externalUriToString } from '../../common/positronUtilities.js';
+import { URI } from '../../common/uri.js';
+
+describe('externalUriToString', () => {
+	test('preserves the query delimiters that URI.toString() escapes', () => {
+		const uri = URI.parse('http://localhost:2718/?access_token=r5CYm4qmOctiDPq7TVrzeg');
+
+		expect(externalUriToString(uri)).toBe('http://localhost:2718/?access_token=r5CYm4qmOctiDPq7TVrzeg');
+	});
+
+	test('preserves delimiters when a parameter is appended to the query', () => {
+		// Mirrors PreviewUrl.navigateToUri, which concatenates a cache-busting nonce
+		// onto the existing query before handing the URI to the webview.
+		const uri = URI.parse('http://localhost:2718/?access_token=abc')
+			.with({ query: 'access_token=abc&_positronRender=1' });
+
+		expect(externalUriToString(uri)).toBe('http://localhost:2718/?access_token=abc&_positronRender=1');
+	});
+
+	test('encodes characters that would break out of an HTML attribute', () => {
+		const uri = URI.parse('http://localhost:2718/?q=a"b');
+
+		expect(externalUriToString(uri)).not.toContain('"');
+	});
+
+	test('leaves a file URI intact', () => {
+		const uri = URI.file('/Users/me/notebook.py');
+
+		expect(externalUriToString(uri)).toBe('file:///Users/me/notebook.py');
+	});
+});

--- a/src/vs/base/test/common/positronUtilities.vitest.ts
+++ b/src/vs/base/test/common/positronUtilities.vitest.ts
@@ -27,7 +27,7 @@ describe('externalUriToString', () => {
 	test('encodes characters that would break out of an HTML attribute', () => {
 		const uri = URI.parse('http://localhost:2718/?q=a"b');
 
-		expect(externalUriToString(uri)).not.toContain('"');
+		expect(externalUriToString(uri)).toBe('http://localhost:2718/?q=a%22b');
 	});
 
 	test('leaves a file URI intact', () => {

--- a/src/vs/workbench/contrib/positronPreview/browser/previewOverlayWebview.ts
+++ b/src/vs/workbench/contrib/positronPreview/browser/previewOverlayWebview.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable } from '../../../../base/common/lifecycle.js';
+import { externalUriToString } from '../../../../base/common/positronUtilities.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IOverlayWebview } from '../../webview/browser/webview.js';
 
@@ -56,7 +57,7 @@ export class PreviewOverlayWebview extends Disposable {
 				</style>
 			</head>
 			<body>
-				<iframe id="preview-iframe" title="Preview Content" src="${uri.toString()}"></iframe>
+				<iframe id="preview-iframe" title="Preview Content" src="${externalUriToString(uri)}"></iframe>
 				<script async type="module">
 					// Get a reference to the VS Code API
 					const vscode = acquireVsCodeApi();

--- a/src/vs/workbench/contrib/positronPreview/browser/previewOverlayWebview.ts
+++ b/src/vs/workbench/contrib/positronPreview/browser/previewOverlayWebview.ts
@@ -5,6 +5,7 @@
 
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { externalUriToString } from '../../../../base/common/positronUtilities.js';
+import { htmlAttributeEncodeValue } from '../../../../base/common/strings.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IOverlayWebview } from '../../webview/browser/webview.js';
 
@@ -57,7 +58,7 @@ export class PreviewOverlayWebview extends Disposable {
 				</style>
 			</head>
 			<body>
-				<iframe id="preview-iframe" title="Preview Content" src="${externalUriToString(uri)}"></iframe>
+				<iframe id="preview-iframe" title="Preview Content" src="${htmlAttributeEncodeValue(externalUriToString(uri))}"></iframe>
 				<script async type="module">
 					// Get a reference to the VS Code API
 					const vscode = acquireVsCodeApi();

--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -17,6 +17,9 @@ import { COI } from '../../../../base/common/network.js';
 import { observableValue } from '../../../../base/common/observable.js';
 import { listenStream } from '../../../../base/common/stream.js';
 import { URI } from '../../../../base/common/uri.js';
+// --- Start Positron ---
+import { externalUriToString } from '../../../../base/common/positronUtilities.js';
+// --- End Positron ---
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { localize } from '../../../../nls.js';
 import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
@@ -791,16 +794,19 @@ export class WebviewElement extends Disposable implements IWebviewElement, Webvi
 			return;
 		}
 
-		// Tell the webview to load the URI
+		// Tell the webview to load the URI. Serialize with
+		// `externalUriToString` rather than `URI.toString()`, which escapes the
+		// `=` and `&` delimiters and would corrupt any query parameters.
 		this._uri = uri;
-		this._send('set-uri', uri.toString());
+		const uriString = externalUriToString(uri);
+		this._send('set-uri', uriString);
 
 		// Wait for the frame to be created by hanging around until Electron
 		// notices that the frame with the requested URL navigated.
 		//
 		// This is a little bit of a hack, but it's the only way to get a handle
 		// to the newly created frame.
-		const frameId = await this.awaitFrameCreation(uri.toString());
+		const frameId = await this.awaitFrameCreation(uriString);
 		this._frameId = frameId;
 
 		return this.injectJavaScript();

--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -794,9 +794,7 @@ export class WebviewElement extends Disposable implements IWebviewElement, Webvi
 			return;
 		}
 
-		// Tell the webview to load the URI. Serialize with
-		// `externalUriToString` rather than `URI.toString()`, which escapes the
-		// `=` and `&` delimiters and would corrupt any query parameters.
+		// Tell the webview to load the URI
 		this._uri = uri;
 		const uriString = externalUriToString(uri);
 		this._send('set-uri', uriString);

--- a/test/e2e/tests/viewer/viewer.test.ts
+++ b/test/e2e/tests/viewer/viewer.test.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { expect } from '@playwright/test';
 import { test, tags } from '../_test.setup';
 
 test.use({
@@ -22,6 +23,23 @@ test.describe('Viewer', { tag: [tags.VIEWER, tags.CONSOLE] }, () => {
 		await viewer.expectViewerPanelVisible();
 		await viewer.expectUrlToHaveValue('http://127.0.0.1:8000/');
 	});
+
+	// Only web renders the preview iframe via an HTML string (previewOverlayWebview.ts);
+	// Electron navigates the webview directly and never produces a #preview-iframe element.
+	test('Python - Verify Viewer preserves query params through HTML embedding', { tag: [tags.WEB_ONLY] },
+		async function ({ app, python }) {
+			const { console, viewer } = app.workbench;
+
+			// `&not;` is a terminated legacy HTML character reference (decodes to the "not
+			// sign" character) that browsers resolve unconditionally inside an unescaped
+			// HTML attribute. If the iframe's `src` isn't HTML-attribute-encoded, this query
+			// string is corrupted before the iframe ever sees it.
+			await console.executeCode('Python', pythonQueryParamScript);
+			await viewer.expectViewerPanelVisible();
+			await expect(viewer.getViewerLocator('#preview-iframe')).toHaveAttribute(
+				'src', /^http:\/\/127\.0\.0\.1:8000\/\?a=1&not;b=2&_positronRender=[0-9a-f]+$/
+			);
+		});
 
 	// note: this test is skipped on firefox - it fails
 	test('Python - Verify Viewer displays great-tables', { tag: [tags.WEB, tags.CROSS_BROWSER] },
@@ -65,6 +83,11 @@ const pythonScript = `import webbrowser
 # will not have any content, but we just want to make sure
 # the viewer will open when webbrowser calls are made
 webbrowser.open('http://127.0.0.1:8000')`;
+
+const pythonQueryParamScript = `import webbrowser
+# will not have any content, but we just want to make sure the
+# query string survives being embedded in the preview iframe's src
+webbrowser.open('http://127.0.0.1:8000/?a=1&not;b=2')`;
 
 const pythonGreatTablesScript = `from great_tables import GT, exibble
 GT(exibble)`;

--- a/test/e2e/tests/viewer/viewer.test.ts
+++ b/test/e2e/tests/viewer/viewer.test.ts
@@ -36,8 +36,11 @@ test.describe('Viewer', { tag: [tags.VIEWER, tags.CONSOLE] }, () => {
 			// string is corrupted before the iframe ever sees it.
 			await console.executeCode('Python', pythonQueryParamScript);
 			await viewer.expectViewerPanelVisible();
+			// The origin is environment-dependent: the web server rewrites localhost URLs
+			// to its port-forwarding proxy (e.g. http://localhost:9000/proxy/8000/), so
+			// only assert on the query string.
 			await expect(viewer.getViewerLocator('#preview-iframe')).toHaveAttribute(
-				'src', /^http:\/\/127\.0\.0\.1:8000\/\?a=1&not;b=2&_positronRender=[0-9a-f]+$/
+				'src', /\/\?a=1&not;b=2&_positronRender=[0-9a-f]+$/
 			);
 		});
 


### PR DESCRIPTION
Related to #11095, but does not fix it.

### Summary

This surfaced while testing marimo notebook support (#11095): marimo's editor UI serves at `http://localhost:<port>/?access_token=...`, and the access token was arriving mangled, breaking authentication. This PR fixes the underlying URI serialization bug in the shared Preview/Viewer webview code; it does not add marimo support itself.

`URI.toString()` treats the query string as a single opaque component and escapes `=` to `%3D` and `&` to `%26`. That's harmless for the custom schemes `URI` was designed around, but it corrupts query parameters when the Preview or Viewer pane navigates a webview to an `http(s)` URL: the target server receives one nameless parameter instead of the parameters that were actually sent.

Adds `externalUriToString()`, which round-trips the URI to preserve query delimiters while still percent-encoding characters (like `"`) that would otherwise break out of the iframe's `src` attribute.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix query parameters (e.g. access tokens) being corrupted when the Viewer pane navigates to a URL

### Validation Steps

@:viewer @:apps @:web

To confirm by hand:
1. Run a tiny script that echoes the request path it receives, e.g.:
   ```python
   from http.server import BaseHTTPRequestHandler, HTTPServer

   class Handler(BaseHTTPRequestHandler):
       def do_GET(self):
           self.send_response(200)
           self.end_headers()
           self.wfile.write(self.path.encode())

   HTTPServer(('localhost', 8123), Handler).serve_forever()
   ```
2. Open `http://localhost:8123/?a=1&b=2` in the Viewer pane. (easiest way to get here is to open another terminal and run `echo 'http://localhost:8123/?a=1&b=2'`)
3. Confirm the page shows `/?a=1&b=2` intact. If you try to do this on main, it arrives as `/?a%3D1%26b%3D2` (corrupted parameter).
