### PR TITLE
Keep this skill from totally borking my dev build forever

### DIFF
--- a/.claude/skills/drive-positron/SKILL.md
+++ b/.claude/skills/drive-positron/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: drive-positron
-description: "Launch Positron dev server in an isolated, disposable profile and control the Electron workbench. Use to reproduce UI bugs, verify UI changes, inspect the DOM, take screenshots, interact with the workbench, or attach a debugger without first writing an end-to-end test. Do not use to provide a persistent app instance for a person; use the launch-positron command for that."
+description: "Launch Positron dev server in an isolated, disposable profile and control the Electron workbench. Use to reproduce UI bugs, verify UI changes, inspect the DOM, take screenshots, interact with the workbench, or attach a debugger without first writing an end-to-end test. Do not use to provide a persistent app instance for a person; use the launch-positron command for that. Only runs when a person invokes it explicitly."
+disable-model-invocation: true
 ---
 
 # Drive Positron through CDP
@@ -16,6 +17,25 @@ Do not use this workflow to hand a persistent Positron instance to a person:
 - no watch process recompiles subsequent source edits.
 
 Use the `launch-positron` command for that case.
+
+## Know what this changes in your checkout
+
+The disposable profile is isolated. The build state is not.
+
+Before it starts the application, `scripts/launch.sh` runs `build/lib/preLaunch.ts` against your real checkout. Pre-launch writes to directories that your normal development build also uses:
+
+- `.build/builtInExtensions/<name>`: pre-launch deletes and re-downloads this directory for every built-in extension whose version on disk does not match `product.json`. A rebase that bumps a built-in extension version is enough to trigger it.
+- `.build/electron`: pre-launch deletes and re-downloads the whole directory when the installed Electron version does not match the expected one.
+- `out/`: pre-launch runs `npm run compile` when this directory is absent. That competes with the build daemons, which own compilation.
+
+An interrupted or failed pre-launch can leave a built-in extension deleted or partially written. Your normal development build then fails to start until you repair it. To repair:
+
+```bash
+npm run download-builtin-extensions
+npm run electron
+```
+
+Do not interrupt the script while it reports that it is running pre-launch.
 
 ## Launch Positron
 

--- a/.claude/skills/drive-positron/scripts/launch.sh
+++ b/.claude/skills/drive-positron/scripts/launch.sh
@@ -212,7 +212,15 @@ echo "[launch.sh] logs: $LOG_FILE" >&2
 
 # Run pre-launch synchronously so download or compilation errors are visible
 # before code.sh starts.
+#
+# Pre-launch is the one step that writes outside the disposable profile. It can
+# delete and re-download $REPO/.build/builtInExtensions/<name> and
+# $REPO/.build/electron, and it compiles into $REPO/out when that directory is
+# absent. An interrupted run can leave a built-in extension half-written, which
+# breaks the normal development build until it is re-downloaded. See SKILL.md.
 echo "[launch.sh] running pre-launch (ensures electron + compiled output + built-ins)..." >&2
+echo "[launch.sh] WARNING: pre-launch writes to the shared .build/ and out/ directories in $REPO." >&2
+echo "[launch.sh] WARNING: interrupting it can leave a built-in extension half-written; repair with 'npm run download-builtin-extensions'." >&2
 if ! ( cd "$REPO" && node build/lib/preLaunch.ts ) >>"$LOG_FILE" 2>&1; then
 	echo "[launch.sh] pre-launch FAILED. Log tail:" >&2
 	tail -n 80 "$LOG_FILE" >&2


### PR DESCRIPTION
I have had multiple instances of this skill totally borking my dev build setup, by which I mean breaking it _permanently_ until I go in and do manual cleanup afterwards. It turns out the `drive-positron` skill can corrupt the build state of your checkout. This PR removes the most common path to that damage and documents the rest.

## Changes

- `disable-model-invocation: true` in the skill frontmatter. Only a person can start this skill with `/drive-positron`. An agent cannot select it automatically, and the refusal message also stops the agent from doing the same steps by other means. I do not want this skill to be invokable by the harness for folks (me!!!) using auto mode.
- A new section in `SKILL.md`, before the launch command, that names the three directories and gives the repair commands.
- A comment and two stderr warnings in `launch.sh` before pre-launch runs, so the risk is visible in the run log.

Pre-launch behavior does not change. `drive-positron-web` does not call pre-launch and is not affected.


