### PR TITLE
Add a walkthrough banner to the redesigned welcome page

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -781,6 +781,8 @@
 		"--vscode-positronVariables-rowHoverBackground",
 		"--vscode-positronVariables-rowHoverForeground",
 		"--vscode-positronWelcome-background",
+		"--vscode-positronWelcome-bannerBackground",
+		"--vscode-positronWelcome-bannerBorder",
 		"--vscode-positronWelcome-foreground",
 		"--vscode-positronWelcome-hoverBackground",
 		"--vscode-positronWelcome-secondaryForeground",

--- a/extensions/theme-defaults/themes/positron_light.json
+++ b/extensions/theme-defaults/themes/positron_light.json
@@ -26,6 +26,7 @@
 		"tab.activeBorderTop": "#3A78B1",
 		"terminalCursor.foreground": "#3A78B1",
 		"terminal.tab.activeBorder": "#3A78B1",
+		"positronWelcome.bannerBackground": "#3A78B11A",
 		"textLink.activeForeground": "#3A78B1",
 		"textLink.foreground": "#3A78B1",
 		"welcomePage.progress.foreground": "#3A78B1",

--- a/src/vs/base/browser/positronReactServices.tsx
+++ b/src/vs/base/browser/positronReactServices.tsx
@@ -15,6 +15,7 @@ import { ICommandService } from '../../platform/commands/common/commands.js';
 import { ILanguageService } from '../../editor/common/languages/language.js';
 import { IHostService } from '../../workbench/services/host/browser/host.js';
 import { IFileDialogService } from '../../platform/dialogs/common/dialogs.js';
+import { ITelemetryService } from '../../platform/telemetry/common/telemetry.js';
 import { IPathService } from '../../workbench/services/path/common/pathService.js';
 import { ITextModelService } from '../../editor/common/services/resolverService.js';
 import { IContextKeyService } from '../../platform/contextkey/common/contextkey.js';
@@ -138,6 +139,7 @@ export class PositronReactServices {
 		@IRuntimeSessionService public readonly runtimeSessionService: IRuntimeSessionService,
 		@IRuntimeStartupService public readonly runtimeStartupService: IRuntimeStartupService,
 		@IStorageService public readonly storageService: IStorageService,
+		@ITelemetryService public readonly telemetryService: ITelemetryService,
 		@ITerminalService public readonly terminalService: ITerminalService,
 		@ITextModelService public readonly textModelService: ITextModelService,
 		@IThemeService public readonly themeService: IThemeService,

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -58,6 +58,11 @@ import { WorkbenchStateContext } from '../../../common/contextkeys.js';
 import { IEditorOpenContext, IEditorSerializer } from '../../../common/editor.js';
 import { IWebviewElement, IWebviewService } from '../../webview/browser/webview.js';
 import './gettingStartedColors.js';
+// --- Start Positron ---
+// Colors for the redesigned welcome page. Registered here for the same reason as
+// the line above: a color has to be registered before any CSS may use it.
+import './positronWelcomePageColors.js';
+// --- End Positron ---
 import { GettingStartedDetailsRenderer } from './gettingStartedDetailsRenderer.js';
 import { gettingStartedCheckedCodicon, gettingStartedUncheckedCodicon } from './gettingStartedIcons.js';
 import { GettingStartedEditorOptions, GettingStartedInput } from './gettingStartedInput.js';

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -140,7 +140,12 @@ const parsedStartEntries: IWelcomePageStartEntry[] = startEntries.map((e, i) => 
 */
 // --- End Positron ---
 
-type GettingStartedActionClassification = {
+// --- Start Positron ---
+// Exported so the redesigned welcome page's walkthrough banner logs this event
+// with the same shape, instead of declaring the event twice.
+// type GettingStartedActionClassification = {
+export type GettingStartedActionClassification = {
+	// --- End Positron ---
 	command: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight'; comment: 'The command being executed on the getting started page.' };
 	walkthroughId: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight'; comment: 'The walkthrough which the command is in' };
 	argument: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight'; comment: 'The arguments being passed to the command' };
@@ -148,7 +153,10 @@ type GettingStartedActionClassification = {
 	comment: 'Help understand what actions are most commonly taken on the getting started page';
 };
 
-type GettingStartedActionEvent = {
+// --- Start Positron ---
+// type GettingStartedActionEvent = {
+export type GettingStartedActionEvent = {
+	// --- End Positron ---
 	command: string;
 	walkthroughId: string | undefined;
 	argument: string | undefined;

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/walkthroughBanner.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/walkthroughBanner.css
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.positron-welcome-page-walkthrough-banner {
+	background-color: var(--vscode-positronWelcome-bannerBackground);
+	border: 1px solid var(--vscode-positronWelcome-bannerBorder);
+	border-radius: 6px;
+	display: flex;
+	gap: 16px;
+	/*
+	 * Clips the text rather than letting it paint outside the banner's border.
+	 * Under about 90px wide, the padding and the icon take up the whole banner, so
+	 * there is no space left to wrap text into.
+	 */
+	overflow: hidden;
+	padding: 20px;
+}
+
+.positron-welcome-page-walkthrough-banner .walkthrough-banner-icon {
+	align-self: center;
+	color: var(--vscode-icon-foreground);
+	flex: 0 0 auto;
+}
+
+/*
+ * Lets the text wrap rather than spill out of the banner in a narrow editor.
+ *
+ * A flex child will not shrink narrower than its longest word unless min-width
+ * is 0. Once the column is narrower than a single word, overflow-wrap breaks
+ * that word.
+ *
+ * Both `anywhere` and `break-word` break the word, but only `anywhere` also lets
+ * the column itself be narrower than one word. With `break-word` the column
+ * stays as wide as its longest word, and the text spills out again.
+ */
+.positron-welcome-page-walkthrough-banner .walkthrough-banner-text {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	min-width: 0;
+	overflow-wrap: anywhere;
+}
+
+.positron-welcome-page-walkthrough-banner .walkthrough-banner-label {
+	color: var(--vscode-descriptionForeground);
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 0.05em;
+	margin: 0;
+	text-transform: uppercase;
+}
+
+.positron-welcome-page-walkthrough-banner .walkthrough-banner-description {
+	margin: 0;
+}
+
+/*
+ * Makes the button look like a link. gettingStarted.css gives every button in
+ * the container a background, padding, and in high contrast themes a border, so
+ * this selector repeats the container chain to win on specificity. Upstream
+ * clears that border for its own link-style buttons through a `.button-link`
+ * class this one does not use.
+ */
+.monaco-workbench .part.editor > .content .gettingStartedContainer
+.positron-welcome-page-walkthrough-banner .walkthrough-banner-link,
+.monaco-workbench .part.editor > .content .gettingStartedContainer
+.positron-welcome-page-walkthrough-banner .walkthrough-banner-link:hover {
+	align-self: flex-start;
+	background: none;
+	border: none;
+	font-size: inherit;
+	margin: 4px 0 0;
+	padding: 0;
+}
+
+/*
+ * Matches the arrow to the link text. gettingStarted.css sets arrow codicons to
+ * 18px and recolors them only when the pointer is on the arrow itself, so this
+ * selector repeats the container chain to win on specificity.
+ */
+.monaco-workbench .part.editor > .content .gettingStartedContainer
+.positron-welcome-page-walkthrough-banner .walkthrough-banner-arrow.codicon {
+	color: inherit;
+	font-size: inherit;
+	margin-left: 4px;
+	vertical-align: middle;
+}

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/walkthroughBanner.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/walkthroughBanner.tsx
@@ -13,6 +13,7 @@ import { useId } from 'react';
 import { localize } from '../../../../../../nls.js';
 import { Button } from '../../../../../../base/browser/ui/positronComponents/button/button.js';
 import { usePositronReactServicesContext } from '../../../../../../base/browser/positronReactRendererContext.js';
+import type { GettingStartedActionClassification, GettingStartedActionEvent } from '../../gettingStarted.js';
 import { IWalkthroughsService } from '../../gettingStartedService.js';
 
 /**
@@ -35,6 +36,14 @@ export const WalkthroughBanner = () => {
 	}
 
 	const showAllWalkthroughs = () => {
+		services.telemetryService.publicLog2<GettingStartedActionEvent, GettingStartedActionClassification>(
+			'gettingStarted.ActionExecuted',
+			{
+				command: 'welcomeBannerSeeAllWalkthroughs',
+				argument: undefined,
+				walkthroughId: undefined,
+			});
+
 		services.commandService.executeCommand('welcome.showAllWalkthroughs');
 	};
 

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/walkthroughBanner.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/walkthroughBanner.tsx
@@ -58,7 +58,7 @@ export const WalkthroughBanner = () => {
 				<p className='walkthrough-banner-description'>
 					{localize(
 						'positron.welcome.walkthroughBannerDescription',
-						"Walk through the basics of using Positron. See what changes if you're moving from VS Code or RStudio."
+						"Take a guided tour of Positron without leaving the IDE. Start with the basics, or see what's different if you're coming from RStudio or VS Code."
 					)}
 				</p>
 				<Button

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/walkthroughBanner.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/walkthroughBanner.tsx
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import './walkthroughBanner.css';
+
+// React.
+import { useId } from 'react';
+
+// Other dependencies.
+import { localize } from '../../../../../../nls.js';
+import { Button } from '../../../../../../base/browser/ui/positronComponents/button/button.js';
+import { usePositronReactServicesContext } from '../../../../../../base/browser/positronReactRendererContext.js';
+import { IWalkthroughsService } from '../../gettingStartedService.js';
+
+/**
+ * WalkthroughBanner component. Points users at the walkthroughs.
+ * @returns The rendered component, or null when there are none to show.
+ */
+export const WalkthroughBanner = () => {
+	const services = usePositronReactServicesContext();
+	const headingId = useId();
+
+	// Read during render rather than tracked with listeners: the editor pane
+	// rebuilds the whole page when a walkthrough is added or removed, and that
+	// remounts this component. The `when` clause is the same filter the quick
+	// pick applies, so the banner cannot show while the list would be empty.
+	const hasWalkthroughs = services.get(IWalkthroughsService).getWalkthroughs()
+		.some(walkthrough => services.contextKeyService.contextMatchesRules(walkthrough.when));
+
+	if (!hasWalkthroughs) {
+		return null;
+	}
+
+	const showAllWalkthroughs = () => {
+		services.commandService.executeCommand('welcome.showAllWalkthroughs');
+	};
+
+	// Render.
+	return (
+		<section aria-labelledby={headingId} className='positron-welcome-page-walkthrough-banner'>
+			<span aria-hidden='true' className='walkthrough-banner-icon codicon codicon-mortar-board' />
+			<div className='walkthrough-banner-text'>
+				<h3 className='walkthrough-banner-label' id={headingId}>
+					{localize('positron.welcome.learn', "Learn")}
+				</h3>
+				<p className='walkthrough-banner-description'>
+					{localize(
+						'positron.welcome.walkthroughBannerDescription',
+						"Walk through the basics of using Positron. See what changes if you're moving from VS Code or RStudio."
+					)}
+				</p>
+				<Button
+					className='walkthrough-banner-link positron-welcome-page-link'
+					onPressed={showAllWalkthroughs}
+				>
+					{localize('positron.welcome.seeAllWalkthroughs', "See all walkthroughs")}
+					<span aria-hidden='true' className='walkthrough-banner-arrow codicon codicon-arrow-right' />
+				</Button>
+			</div>
+		</section>
+	);
+};

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/positronWelcomePage.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/positronWelcomePage.css
@@ -4,13 +4,18 @@
  *--------------------------------------------------------------------------------------------*/
 
 /*
- * Fills the slide when the content is short, so the footer rule below has space
- * to push against, and grows past it when the content is tall. A fixed height
- * would clip instead of scroll.
+ * This page renders inside .gettingStartedContainer, so gettingStarted.css
+ * applies to everything here. Its rules use four-class selectors on bare
+ * elements, so the overrides in this folder repeat the container chain to win on
+ * specificity.
  *
- * No horizontal padding here: the parent .gettingStartedSlideCategories already
- * supplies 24px.
+ * Do not add a page-wide reset. The page also hosts widgets the editor pane
+ * builds -- the recent list, the connect action, the startup checkbox -- and
+ * gettingStarted.css is what styles those correctly. Override on your own
+ * elements only.
  */
+
+/* No horizontal padding: .gettingStartedSlideCategories already supplies 24px. */
 .positron-welcome-page {
 	display: flex;
 	flex-direction: column;
@@ -21,9 +26,19 @@
 }
 
 /*
- * Keeps the "Show welcome page on startup" checkbox at the bottom of the page,
- * however tall the content above it is.
+ * Pins the footer to the bottom of the page. The min-height above leaves free
+ * space when the content is short, and this margin takes all of it.
  */
 .positron-welcome-page .positron-welcome-page-footer {
 	margin-top: auto;
+}
+
+/* Opt-in link color, for elements this page owns rather than the editor pane. */
+.monaco-workbench .part.editor > .content .gettingStartedContainer .positron-welcome-page .positron-welcome-page-link {
+	color: var(--vscode-textLink-foreground);
+	text-decoration: var(--text-link-decoration);
+}
+
+.monaco-workbench .part.editor > .content .gettingStartedContainer .positron-welcome-page .positron-welcome-page-link:hover {
+	color: var(--vscode-textLink-activeForeground);
 }

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/positronWelcomePage.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/positronWelcomePage.tsx
@@ -12,6 +12,7 @@ import { useEffect } from 'react';
 // Other dependencies.
 import { PositronReactRenderer } from '../../../../../base/browser/positronReactRenderer.js';
 import { DomSlot } from './components/domSlot.js';
+import { WalkthroughBanner } from './components/walkthroughBanner.js';
 
 /**
  * PositronWelcomePageProps interface.
@@ -63,7 +64,7 @@ export const PositronWelcomePage = (props: PositronWelcomePageProps) => {
 	// layout lives on one element instead of two nested ones.
 	return (
 		<>
-			<p>Hello world</p>
+			<WalkthroughBanner />
 			<DomSlot element={props.recentList} />
 			{props.connectAction && <DomSlot element={props.connectAction} />}
 			<DomSlot className='positron-welcome-page-footer' element={props.footer} />

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePageColors.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePageColors.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { registerColor } from '../../../../platform/theme/common/colorRegistry.js';
+import { localize } from '../../../../nls.js';
+import { welcomePageTileBackground, welcomePageTileBorder } from './gettingStartedColors.js';
+
+// Colors for the redesigned welcome page, behind the `welcomePage.experimental`
+// setting.
+
+// The default follows the tiles on the original page, which every theme already
+// tunes, so the banner looks native in a theme nobody here has seen. Positron's
+// own light theme paints it a pale blue instead; a theme wanting that look sets
+// this color rather than getting a blue it never chose.
+export const POSITRON_WELCOME_BANNER_BACKGROUND = registerColor('positronWelcome.bannerBackground',
+	welcomePageTileBackground,
+	localize('positronWelcome.bannerBackground', "Background color of the walkthrough banner on the Positron welcome page."));
+
+export const POSITRON_WELCOME_BANNER_BORDER = registerColor('positronWelcome.bannerBorder',
+	welcomePageTileBorder,
+	localize('positronWelcome.bannerBorder', "Border color of the walkthrough banner on the Positron welcome page."));

--- a/src/vs/workbench/contrib/welcomeGettingStarted/test/browser/positronWelcomePage.vitest.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/test/browser/positronWelcomePage.vitest.tsx
@@ -6,31 +6,54 @@
 /// <reference types="vitest/globals" />
 
 import { screen } from '@testing-library/react';
+import { Event } from '../../../../../base/common/event.js';
+import { ContextKeyExpr, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { PositronReactServices } from '../../../../../base/browser/positronReactServices.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { IResolvedWalkthrough, IWalkthroughsService } from '../../browser/gettingStartedService.js';
 import { createPositronWelcomePage, PositronWelcomePage } from '../../browser/positronWelcomePage/positronWelcomePage.js';
 
+/**
+ * The page renders the walkthrough banner, which reads this service. One
+ * walkthrough with no `when` clause is what the real window always has, so the
+ * banner shows and its place in the page order can be asserted.
+ */
+const oneWalkthrough = {
+	getWalkthroughs: () => [stubInterface<IResolvedWalkthrough>({ when: ContextKeyExpr.true() })],
+	onDidAddWalkthrough: Event.None,
+	onDidRemoveWalkthrough: Event.None,
+	onDidChangeWalkthrough: Event.None,
+};
+
+/**
+ * Builds the DOM the editor pane hands to the page. These are real widgets
+ * on the welcome page, so the test only needs something findable in their
+ * place.
+ */
+const slottedDom = () => {
+	const recentList = document.createElement('div');
+	recentList.textContent = 'Recent';
+
+	const connectAction = document.createElement('div');
+	connectAction.textContent = 'Connect to...';
+
+	const footer = document.createElement('div');
+	footer.textContent = 'Show welcome page on startup';
+
+	return { recentList, connectAction, footer };
+};
+
 describe('PositronWelcomePage', () => {
-	const rtl = setupRTLRenderer();
+	const ctx = createTestContainer()
+		.withReactServices()
+		.stub(IWalkthroughsService, oneWalkthrough)
+		.stub(IContextKeyService, stubInterface<IContextKeyService>({ contextMatchesRules: () => true }))
+		.build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
 
-	/**
-	 * Builds the DOM the editor pane hands to the page. These are real widgets
-	 * on the welcome page, so the test only needs something findable in their
-	 * place.
-	 */
-	const slottedDom = () => {
-		const recentList = document.createElement('div');
-		recentList.textContent = 'Recent';
-
-		const connectAction = document.createElement('div');
-		connectAction.textContent = 'Connect to...';
-
-		const footer = document.createElement('div');
-		footer.textContent = 'Show welcome page on startup';
-
-		return { recentList, connectAction, footer };
-	};
-
-	it('renders the recent list, then the connect action, then the footer', () => {
+	it('renders the banner, then the recent list, the connect action and the footer', () => {
 		const { recentList, connectAction, footer } = slottedDom();
 		const { container } = rtl.render(
 			<PositronWelcomePage
@@ -41,7 +64,7 @@ describe('PositronWelcomePage', () => {
 			/>
 		);
 
-		expect(container).toHaveTextContent(/Recent.*Connect to\.\.\..*Show welcome page on startup/);
+		expect(container).toHaveTextContent(/Learn.*Recent.*Connect to\.\.\..*Show welcome page on startup/);
 	});
 
 	it('omits the connect action when there is none, as on web', () => {
@@ -80,6 +103,23 @@ describe('PositronWelcomePage', () => {
 });
 
 describe('createPositronWelcomePage', () => {
+	const ctx = createTestContainer()
+		.withReactServices()
+		.stub(IWalkthroughsService, oneWalkthrough)
+		.stub(IContextKeyService, stubInterface<IContextKeyService>({ contextMatchesRules: () => true }))
+		.build();
+
+	beforeEach(() => {
+		// createPositronWelcomePage builds its own PositronReactRenderer, whose
+		// provider reads this singleton rather than taking services as an
+		// argument. Nothing else can reach into that renderer to supply them.
+		PositronReactServices.services = ctx.reactServices;
+	});
+
+	afterEach(() => {
+		PositronReactServices.services = undefined!;
+	});
+
 	const renderInto = (container: HTMLElement) => {
 		const recentList = document.createElement('div');
 		recentList.textContent = 'Recent';

--- a/src/vs/workbench/contrib/welcomeGettingStarted/test/browser/walkthroughBanner.vitest.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/test/browser/walkthroughBanner.vitest.tsx
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { Event } from '../../../../../base/common/event.js';
+import { ContextKeyExpr, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { IResolvedWalkthrough, IWalkthroughsService } from '../../browser/gettingStartedService.js';
+import { WalkthroughBanner } from '../../browser/positronWelcomePage/components/walkthroughBanner.js';
+
+/**
+ * Builds a resolved walkthrough. Only `when` matters to the banner.
+ * @param id The walkthrough id.
+ * @returns A resolved walkthrough that applies to every window.
+ */
+const walkthrough = (id: string): IResolvedWalkthrough => ({
+	id,
+	title: id,
+	description: '',
+	order: 0,
+	source: 'Built-In',
+	isFeatured: false,
+	when: ContextKeyExpr.true(),
+	steps: [],
+	icon: { type: 'icon', icon: Codicon.mortarBoard },
+	walkthroughPageTitle: id,
+	newItems: false,
+	recencyBonus: 0,
+	newEntry: false,
+});
+
+describe('WalkthroughBanner', () => {
+	const executeCommand = vi.fn();
+
+	const ctx = createTestContainer()
+		.withReactServices()
+		.stub(IWalkthroughsService, {
+			getWalkthroughs: () => [walkthrough('Setup'), walkthrough('Beginner')],
+			onDidAddWalkthrough: Event.None,
+			onDidRemoveWalkthrough: Event.None,
+			onDidChangeWalkthrough: Event.None,
+		})
+		.stub(ICommandService, { executeCommand })
+		// MockContextKeyService answers false to every `when` clause, which would
+		// hide the banner outright.
+		.stub(IContextKeyService, stubInterface<IContextKeyService>({ contextMatchesRules: () => true }))
+		.build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
+
+	it('names the banner and links to the walkthroughs', () => {
+		rtl.render(<WalkthroughBanner />);
+
+		expect(screen.getByRole('region', { name: 'Learn' })).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'See all walkthroughs' })).toBeInTheDocument();
+	});
+
+	it('opens the walkthrough list when clicked', async () => {
+		const user = userEvent.setup();
+		rtl.render(<WalkthroughBanner />);
+
+		await user.click(screen.getByRole('button', { name: 'See all walkthroughs' }));
+
+		expect(executeCommand).toHaveBeenCalledWith('welcome.showAllWalkthroughs');
+	});
+});

--- a/src/vs/workbench/contrib/welcomeGettingStarted/test/browser/walkthroughBanner.vitest.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/test/browser/walkthroughBanner.vitest.tsx
@@ -11,6 +11,7 @@ import { Codicon } from '../../../../../base/common/codicons.js';
 import { Event } from '../../../../../base/common/event.js';
 import { ContextKeyExpr, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
@@ -40,6 +41,7 @@ const walkthrough = (id: string): IResolvedWalkthrough => ({
 
 describe('WalkthroughBanner', () => {
 	const executeCommand = vi.fn();
+	const publicLog2 = vi.fn();
 
 	const ctx = createTestContainer()
 		.withReactServices()
@@ -50,6 +52,7 @@ describe('WalkthroughBanner', () => {
 			onDidChangeWalkthrough: Event.None,
 		})
 		.stub(ICommandService, { executeCommand })
+		.stub(ITelemetryService, { publicLog2 })
 		// MockContextKeyService answers false to every `when` clause, which would
 		// hide the banner outright.
 		.stub(IContextKeyService, stubInterface<IContextKeyService>({ contextMatchesRules: () => true }))
@@ -63,12 +66,17 @@ describe('WalkthroughBanner', () => {
 		expect(screen.getByRole('button', { name: 'See all walkthroughs' })).toBeInTheDocument();
 	});
 
-	it('opens the walkthrough list when clicked', async () => {
+	it('opens the walkthrough list and logs the click', async () => {
 		const user = userEvent.setup();
 		rtl.render(<WalkthroughBanner />);
 
 		await user.click(screen.getByRole('button', { name: 'See all walkthroughs' }));
 
 		expect(executeCommand).toHaveBeenCalledWith('welcome.showAllWalkthroughs');
+		expect(publicLog2).toHaveBeenCalledWith('gettingStarted.ActionExecuted', {
+			command: 'welcomeBannerSeeAllWalkthroughs',
+			argument: undefined,
+			walkthroughId: undefined,
+		});
 	});
 });


### PR DESCRIPTION
Addresses #14934

This PR adds a banner to the redesigned welcome page that points people at the walkthroughs.

A quick primer on where this renders, because it explains most of the CSS:

- The redesigned page renders inside `.gettingStartedContainer`, the same container as the original welcome page, so every rule in `gettingStarted.css` applies to it.
- Those rules target bare elements with four-class selectors and assume the original layout, where every `button` is a padded tile and headings use a hero type scale.
- The CSS for some elements whose styles we want to override is a very long list of nested CSS classes. The reason for this is because we want to override the style without requiring `!important`. There is deliberately no page-wide reset, because the page also hosts widgets the editor pane builds -- the recent list, the connect action, the startup checkbox -- and `gettingStarted.css` is what styles those correctly.

The banner reads the walkthrough list during render rather than subscribing to `IWalkthroughsService`. The editor pane already rebuilds the whole page when a walkthrough is added or removed, and that remounts the component, so installing an extension that contributes one picks up for free. It filters on the same `when` clause the quick pick applies, so the banner can't offer a link to an empty list.

Two colors are registered in `positronWelcomePageColors.ts` that are for the banner background color and banner border color. The colors for these two elements default to `welcomePage.tileBackground` and `welcomePage.tileBorder` which are the colors the original page uses for its walkthrough "tiles". I did this so that non-Positron themes that has been tuned for this page don't need to do anything for the walkthrough banner to look good. You can verify this by viewing any Solarized themes which get their own theme specific color for the banner.

One change I did make is in the Positron light theme: it overrides the background to `#3A78B11A`, a 10% opacity of the Positron blue. 

### Screenshots

https://github.com/user-attachments/assets/7a6f3daa-2965-4c79-bf77-f4f358f976d0

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

SETUP: `welcomePage.experimental` is a hidden setting, so it has to be set in the JSON file rather than the Settings editor.

1. Run **Preferences: Open User Settings (JSON)** and add `"welcomePage.experimental": true`.
2. Run **Help: Welcome**. The page shows a **LEARN** banner above **Recent**, with a description, and a **See all walkthroughs** button that looks like a link.
3. Click **See all walkthroughs**. The **Open Walkthrough...** quick pick opens.
4. Switch to the **Light** theme. The banner background is a pale blue. Switch to **Dark**; it is a neutral grey matching the original page's tiles.
5. Switch to **Dark High Contrast**. The banner has no fill, and its border is what marks it out.
6. Open both sidebars and shrink the window to its narrowest. The text wraps inside the banner and the banner grows taller. Nothing paints outside its border.
7. Add `"accessibility.underlineLinks": true`. The link is underlined by one continuous line under the text, with no second underline under the arrow.
8. Tab to the link. It takes a focus ring. Press Enter and the quick pick opens.
9. Remove `"welcomePage.experimental"` and run **Help: Welcome** again. The original welcome page renders unchanged, with no banner.

@:welcome
@:web