### PR TITLE
DO NOT MERGE: probe required-check behavior for skipped inner jobs

### DIFF
--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -93,6 +93,7 @@ permissions:
 jobs:
   e2e-linux:
     name: ${{ inputs.display_name || 'e2e-linux' }}
+    if: false # EXPERIMENT: does a skipped inner job publish 'e2e / electron'?
     timeout-minutes: 120
     runs-on: ubuntu-latest-8x
     container:

--- a/.github/workflows/test-ext-host.yml
+++ b/.github/workflows/test-ext-host.yml
@@ -27,6 +27,7 @@ permissions:
 jobs:
   ext-host-tests:
     name: ext-host
+    if: false # EXPERIMENT: does a skipped inner job publish 'test / ext-host'?
     runs-on: ubuntu-latest-4x
     timeout-minutes: 60
     # Run inside the shared CI image, which bakes in the system dependencies,

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -34,6 +34,7 @@ permissions:
 jobs:
   unit-tests:
     name: unit
+    if: false # EXPERIMENT: does a skipped inner job publish 'test / unit'?
     runs-on: ubuntu-latest-4x
     # The job takes ~37m when the npm caches hit, so 40m left no headroom: an
     # evicted npm-extensions-stable entry adds ~4m (cold extension install plus


### PR DESCRIPTION
Throwaway probe, closing as soon as the checks report. Do not merge, do not review.

Hardcodes `if: false` on the single inner job of test-unit.yml, test-ext-host.yml and test-e2e-ubuntu.yml to answer one question: when the inner job of a locally called reusable workflow is skipped, does its composed check context (test / unit, test / ext-host, e2e / electron) still publish as skipped -> success, or does the context never appear and leave the required check pending forever?

Determines whether skipping expensive suites needs ~50 step-level guards or one if: per suite.