### PR TITLE
Stop the debugger from auto-attaching to dev build child processes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,6 +18,14 @@
 			"name": "Attach to Extension Host",
 			"timeout": 0,
 			"port": 5870,
+			// --- Start Positron ---
+			// js-debug attaches to grandchild node processes by default, and starts
+			// each one paused at entry inside its bootloader. The extension host
+			// spawns these constantly (language servers, the Quarto CLI), so the
+			// pauses stall those processes and steal focus back to this window.
+			// The compound attaches to every process we care about by port already.
+			"autoAttachChildProcesses": false,
+			// --- End Positron ---
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js",
 				"${workspaceFolder}/extensions/*/out/**/*.js",
@@ -80,6 +88,11 @@
 			"timeout": 30000,
 			"port": 5875,
 			"continueOnAttach": true,
+			// --- Start Positron ---
+			// See the note on "Attach to Extension Host": auto-attaching to
+			// grandchild node processes pauses them at entry and steals focus.
+			"autoAttachChildProcesses": false,
+			// --- End Positron ---
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js"
 			],


### PR DESCRIPTION
I have been having so many problems with my dev build lately! 😭 I think that if we fix https://github.com/posit-dev/positron/pull/15478 and additionally make the change in this PR, I should be in a better state.

When I start a dev build from VS Code in our typical way, focus jumps back to this VS Code window at random times. VS Code opens `ms-vscode.js-debug/src/bootloader.js` and shows what looks like a paused breakpoint. The Breakpoints pane is empty, and no exception breakpoints are on.

What is happening is that the `Positron` compound includes `Attach to Main Process` and `Attach to Extension Host`. Both are `type: node, request: attach`. For those configurations, js-debug sets `autoAttachChildProcesses` to `true` by default. js-debug then writes `VSCODE_INSPECTOR_OPTIONS` into the running dev build, with `autoAttachMode: "always"`. Every descendant process inherits this variable, so every node process that the dev build starts becomes a new child debug session with `waitForDebugger: true`. The process then is paused at entry, inside `bootloader.js`. The Breakpoints pane stays empty because this is an entry pause, not a breakpoint.

This is not only a focus problem as the paused processes are stalled until the debugger releases them.

These processes were auto-attached on one dev build for me, within two minutes of start:

- the Quarto extension language server
- `/Applications/quarto/bin/quarto.js`, twice
- `json-language-features`
- `next-edit-suggestions`

The Quarto CLI starts many times while you edit a `.qmd` file so the problem is worst during Quarto work, which I have been doing a lot of lately..

## The change

Set `"autoAttachChildProcesses": false` on `Attach to Main Process` and `Attach to Extension Host`.

The compound already attaches to the main process, the extension host, the shared process, and the agent host on fixed ports. Those sessions do not change. The only loss is the automatic attach to processes further down the tree, such as language servers. To debug one of _those_, add a configuration for it. This change in the PR solves the problem for me.


## Notes

To find this problem again, `pgrep -fl watchdog.js` lists one js-debug watchdog for each auto-attached child process. This command names the target script and shows `waitForDebugger`:

```
ps eww <pid> | tr ' ' '\n' | grep NODE_INSPECTOR_INFO
```
