### PR TITLE
Run the ext-host suite by default in the full suite

### DIFF
--- a/.github/workflows/test-full-suite.yml
+++ b/.github/workflows/test-full-suite.yml
@@ -92,7 +92,7 @@ on:
       run_ext_host_tests:
         description: "Extension Host Tests"
         required: false
-        default: false
+        default: true
         type: boolean
       commit:
         description: "Commit SHA to test:"


### PR DESCRIPTION
## Summary

Flip `run_ext_host_tests` to default `true` for "Test: Full Suite".

`workflow_dispatch` is the only trigger on this workflow, so that input default is the only thing deciding whether the ext-host job runs. At `false`, the full ext-host suite ran only when someone remembered to tick the box.

## Why

That gap is how the Code OSS 1.130.0 merge landed **21 broken agent host tests and a deterministic `configuration-editing` hang** without anyone seeing it. The PR check runs `test-integration-pr.sh` -- 12 Positron extension suites, which exercise neither the node integration layer nor the upstream desktop suites -- and nothing else ran the full job before the merge. Both problems only surfaced on main, and stayed there for two days (fixed in #15462).

`run_unit_tests` deliberately stays opt-in: unit tests run on every PR already.

## Note, not fixed here

The job's condition is:

```yaml
if: ${{ !failure() && !cancelled() && (github.event_name == 'schedule' || inputs.run_ext_host_tests) }}
```

There is no `schedule:` trigger on this workflow (and no `workflow_call`), so that first clause can never be true. Harmless, but it reads as though the suite runs nightly when it does not -- arguably part of why this gap went unnoticed. Left alone to keep this diff to one line; happy to remove it if reviewers prefer.

## Release Notes

### New Features

- N/A

### Bug Fixes

- N/A

## QA Notes

CI-only, and not exercised by this PR's own checks. To verify: open "Test: Full Suite" in the Actions tab and confirm "Extension Host Tests" is pre-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
