### PR TITLE
Stop the create-venv prompt from disappearing before you answer it

### DIFF
--- a/extensions/positron-python/src/client/common/utils/localize.ts
+++ b/extensions/positron-python/src/client/common/utils/localize.ts
@@ -309,19 +309,21 @@ export namespace InterpreterQuickPickList {
             l10n.t('Virtual environment created with Python {0}', version);
         export const installFailed = (version: string) => l10n.t('Failed to install Python {0}', version);
         export const uvInstallFailed = l10n.t('Failed to install uv');
+        export const createVenvTitle = l10n.t('Create a Virtual Environment');
         export const createVenvPrompt = (version: string, workspaceFolder: string) =>
             l10n.t(
-                'Python {0} was installed. Would you like to use this version to create a virtual environment at: `{1}`?',
+                'Python {0} was installed. Would you like to use this version to create a virtual environment at {1}? (Recommended.)',
                 version,
-                `${workspaceFolder}/.venv`,
+                `<code>${workspaceFolder}/.venv</code>`,
             );
         export const createVenvPromptAlreadyInstalled = (version: string, workspaceFolder: string) =>
             l10n.t(
-                'Python {0} is installed. Would you like to use it to create a virtual environment at: `{1}`?',
+                'Python {0} is installed. Would you like to use it to create a virtual environment at {1}? (Recommended.)',
                 version,
-                `${workspaceFolder}/.venv`,
+                `<code>${workspaceFolder}/.venv</code>`,
             );
-        export const yesRecommended = l10n.t('Yes (recommended)');
+        export const createVenvAccept = l10n.t('Create');
+        export const createVenvSkip = l10n.t('Skip');
         export const creatingVenv = l10n.t('Creating virtual environment');
         export const venvCreated = l10n.t('Virtual environment created');
         export const venvCreationFailed = l10n.t(

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uvPythonInstaller.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uvPythonInstaller.ts
@@ -6,6 +6,7 @@
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import * as positron from 'positron';
 import { traceError, traceInfo } from '../../../logging';
 import { exec } from '../externalDependencies';
 import { isUvInstalled, getAvailablePythonVersions, resetUvCache, isWindowsArm64, execUv } from './uv';
@@ -361,13 +362,14 @@ export async function installPythonViaUv(): Promise<InstallPythonResult> {
                               workspaces[0].name,
                           )
                         : InterpreterQuickPickList.UvInstall.createVenvPrompt(selected.version, workspaces[0].name);
-                    const createVenv = await vscode.window.showInformationMessage(
+                    const createVenv = await positron.window.showSimpleModalDialogPrompt(
+                        InterpreterQuickPickList.UvInstall.createVenvTitle,
                         venvPrompt,
-                        InterpreterQuickPickList.UvInstall.yesRecommended,
-                        Common.bannerLabelNo,
+                        InterpreterQuickPickList.UvInstall.createVenvAccept,
+                        InterpreterQuickPickList.UvInstall.createVenvSkip,
                     );
 
-                    if (createVenv === InterpreterQuickPickList.UvInstall.yesRecommended) {
+                    if (createVenv) {
                         progress.report({ message: InterpreterQuickPickList.UvInstall.creatingVenv });
                         const workspace = workspaces[0];
                         const venvResult = await createVenvHandlingExisting(workspace, () =>

--- a/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uvPythonInstaller.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uvPythonInstaller.unit.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert';
 import * as os from 'os';
 import * as path from 'path';
 import * as sinon from 'sinon';
-import { anything, when, reset, verify } from 'ts-mockito';
+import { anything, capture, when, reset, verify } from 'ts-mockito';
 import { MultiStepAction } from '../../../../client/common/vscodeApis/windowApis';
 import * as fileUtils from '../../../../client/pythonEnvironments/common/externalDependencies';
 import * as logging from '../../../../client/logging';
@@ -22,7 +22,7 @@ import {
     installPythonViaUv,
     showUvInstallError,
 } from '../../../../client/pythonEnvironments/common/environmentManagers/uvPythonInstaller';
-import { mockedVSCodeNamespaces } from '../../../vscode-mock';
+import { mockedPositronNamespaces, mockedVSCodeNamespaces } from '../../../vscode-mock';
 import { Common, InterpreterQuickPickList } from '../../../../client/common/utils/localize';
 import { Commands } from '../../../../client/common/constants';
 
@@ -382,6 +382,19 @@ suite('UV Python Installer Tests', () => {
         let quickPickCallCount: number;
         let quickPickResponses: (any | undefined)[];
 
+        // Answers the modal dialog that asks whether to create a venv. `false` covers both
+        // clicking "No" and dismissing the dialog with Escape.
+        function answerVenvDialog(accepted: boolean): void {
+            when(
+                mockedPositronNamespaces.window!.showSimpleModalDialogPrompt(
+                    anything(),
+                    anything(),
+                    anything(),
+                    anything(),
+                ),
+            ).thenReturn(Promise.resolve(accepted));
+        }
+
         setup(() => {
             isUvInstalledStub = sinon.stub(uv, 'isUvInstalled');
             getWorkspaceFoldersStub = sinon.stub(workspaceApis, 'getWorkspaceFolders');
@@ -403,6 +416,7 @@ suite('UV Python Installer Tests', () => {
 
             // Configure vscode.window mock using ts-mockito
             reset(mockedVSCodeNamespaces.window!);
+            reset(mockedPositronNamespaces.window!);
 
             // withProgress executes the callback immediately
             when(mockedVSCodeNamespaces.window!.withProgress(anything(), anything())).thenCall(
@@ -423,11 +437,9 @@ suite('UV Python Installer Tests', () => {
             when(
                 mockedVSCodeNamespaces.window!.showInformationMessage(anything(), anything(), anything(), anything()),
             ).thenResolve(InterpreterQuickPickList.UvInstall.confirmUvInstallYes as any);
-            // Default: user accepts venv creation when prompted (3 args: message, yes button, no button)
-            when(mockedVSCodeNamespaces.window!.showInformationMessage(anything(), anything(), anything())).thenResolve(
-                InterpreterQuickPickList.UvInstall.yesRecommended as any,
-            );
             when(mockedVSCodeNamespaces.window!.showInformationMessage(anything())).thenResolve(undefined);
+            // Default: user accepts venv creation when the modal dialog asks
+            answerVenvDialog(true);
             when(mockedVSCodeNamespaces.window!.showWarningMessage(anything())).thenResolve(undefined);
 
             mockProgress.report.reset();
@@ -560,7 +572,7 @@ suite('UV Python Installer Tests', () => {
             getAvailablePythonVersionsStub.resolves([
                 { version: '3.13', isInstalled: false, identifier: 'cpython-3.13.1-macos-aarch64-none' },
             ]);
-            // User selects version (venv creation uses showInformationMessage - default returns yes)
+            // User selects version (the venv dialog defaults to accepting)
             quickPickResponses = [{ version: '3.13', label: 'Python 3.13' }];
             // uv python install succeeds
             execStub.onFirstCall().resolves({ stdout: '' });
@@ -585,12 +597,9 @@ suite('UV Python Installer Tests', () => {
             getAvailablePythonVersionsStub.resolves([
                 { version: '3.13', isInstalled: false, identifier: 'cpython-3.13.1-macos-aarch64-none' },
             ]);
-            // User selects version (venv creation uses showInformationMessage - user dismisses)
+            // User selects version, then declines the venv dialog
             quickPickResponses = [{ version: '3.13', label: 'Python 3.13' }];
-            // Override: user dismisses the venv creation notification
-            when(mockedVSCodeNamespaces.window!.showInformationMessage(anything(), anything(), anything())).thenResolve(
-                undefined,
-            );
+            answerVenvDialog(false);
             // uv python install succeeds
             execStub.onFirstCall().resolves({ stdout: '' });
             // uv python find returns path
@@ -606,13 +615,35 @@ suite('UV Python Installer Tests', () => {
             assert.ok(!createUvVenvStub.called);
         });
 
+        test('Asks about the venv with a modal dialog that waits for an answer', async () => {
+            isUvInstalledStub.resolves(true);
+            getAvailablePythonVersionsStub.resolves([
+                { version: '3.13', isInstalled: false, identifier: 'cpython-3.13.1-macos-aarch64-none' },
+            ]);
+            quickPickResponses = [{ version: '3.13', label: 'Python 3.13' }];
+            execStub.onFirstCall().resolves({ stdout: '' }); // uv python install
+            execStub.onSecondCall().resolves({ stdout: '/usr/local/bin/python3.13' }); // uv python find
+            const mockWorkspace = { uri: { fsPath: '/test/workspace' }, name: 'test', index: 0 };
+            getWorkspaceFoldersStub.returns([mockWorkspace]);
+            createUvVenvStub.resolves('/test/workspace/.venv/bin/python');
+
+            await installPythonViaUv();
+
+            // A notification toast purges itself after ~10 seconds, so a slow install could
+            // finish while the user looked away and the prompt would vanish unanswered. The
+            // venv decision has to be a modal dialog instead (posit-dev/positron#14888).
+            const [, message] = capture(mockedPositronNamespaces.window!.showSimpleModalDialogPrompt).last();
+            assert.strictEqual(message, InterpreterQuickPickList.UvInstall.createVenvPrompt('3.13', 'test'));
+            verify(mockedVSCodeNamespaces.window!.showInformationMessage(message, anything(), anything())).never();
+        });
+
         test('Falls back to Python path when venv creation fails', async () => {
             isUvInstalledStub.resolves(true);
             // Return available versions via stub
             getAvailablePythonVersionsStub.resolves([
                 { version: '3.13', isInstalled: false, identifier: 'cpython-3.13.1-macos-aarch64-none' },
             ]);
-            // User selects version (venv creation uses showInformationMessage - default returns yes)
+            // User selects version (the venv dialog defaults to accepting)
             quickPickResponses = [{ version: '3.13', label: 'Python 3.13' }];
             // uv python install succeeds
             execStub.onFirstCall().resolves({ stdout: '' });
@@ -640,7 +671,7 @@ suite('UV Python Installer Tests', () => {
                 getAvailablePythonVersionsStub.resolves([
                     { version: '3.13', isInstalled: false, identifier: 'cpython-3.13.1-macos-aarch64-none' },
                 ]);
-                // version select only - venv creation uses showInformationMessage (default: yes)
+                // version select only - the venv dialog defaults to accepting
                 quickPickResponses = [{ version: '3.13', label: 'Python 3.13' }];
                 execStub.onFirstCall().resolves({ stdout: '' }); // uv python install
                 execStub.onSecondCall().resolves({ stdout: '/usr/local/bin/python3.13' }); // uv python find
@@ -815,16 +846,14 @@ suite('UV Python Installer Tests', () => {
             assert.ok(result.error?.includes('3.13'));
         });
 
-        test('Dismissing "create venv?" notification falls back to base Python', async () => {
+        test('Dismissing the "create venv?" dialog falls back to base Python', async () => {
             isUvInstalledStub.resolves(true);
             getAvailablePythonVersionsStub.resolves([
                 { version: '3.13', isInstalled: false, identifier: 'cpython-3.13.1-macos-aarch64-none' },
             ]);
-            // User selects version, then dismisses the "create venv?" notification (Escape)
+            // User selects version, then dismisses the "create venv?" dialog (Escape)
             quickPickResponses = [{ version: '3.13', label: 'Python 3.13' }];
-            when(mockedVSCodeNamespaces.window!.showInformationMessage(anything(), anything(), anything())).thenResolve(
-                undefined,
-            );
+            answerVenvDialog(false);
             execStub.onFirstCall().resolves({ stdout: '' });
             execStub.onSecondCall().resolves({ stdout: '/usr/local/bin/python3.13' });
             const mockWorkspace = { uri: { fsPath: '/test/workspace' }, name: 'test', index: 0 };


### PR DESCRIPTION
Fixes #14888

After _Python: Install Python via uv_ finishes, Positron asks whether to create a virtual environment in the workspace. That question was a bottom-right notification with _Yes (Recommended)_ and _No_ buttons. A notification toast purges itself after 10 seconds so a slow install can finish while the user looks away and then the question disappeared before the user answered it. No environment was created, and the notification center was the only way back to the question.

An extension cannot ask for a sticky notification so this PR switches us to `positron.window.showSimpleModalDialogPrompt` (instead of `showInformationMessage`) and the question now waits for an answer. The buttons are _Create_ and _Skip_. <kbd>Esc</kbd> does the same as _Skip_ where Positron keeps the base interpreter and creates no environment:

<img width="1325" height="965" alt="Screenshot 2026-08-12 at 3 24 54 PM" src="https://github.com/user-attachments/assets/01c503be-9bf7-4650-b71d-acb2a2eb11de" />

PR #13895 changed this prompt from a quickpick to a notification, because the quickpick was deemed too invasive. I think this modal is a good option and not too invasive; hopefully other folks agree!

### Known behavior: the progress notification waits with the dialog

While the dialog is open, the "Setting up Python" progress notification stays on screen. The dialog is awaited inside the `withProgress` callback. That progress notification closes only after the callback returns (`src/vs/workbench/services/progress/browser/progressService.ts:419-436`).

This behavior is not new. The old notification prompt was awaited in the same place. A purged toast is not a closed notification, so the old prompt also kept its promise pending, and the progress notification also stayed on screen.

A progress spinner that waits for a person is still wrong. The flow reads better as two progress blocks with the question between them. The first block installs Python. The second block creates the environment and refreshes the interpreter list. Do we want to log a further change in this flow?

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- The prompt to create a virtual environment after a uv Python install now waits for an answer instead of disappearing (#14888)

### Validation Steps

@:interpreter @:sessions

Unit tests:

```
cd extensions/positron-python
npm run test:unittests -- --grep "UV Python Installer"
```

Manual steps:

1. Install uv. Open a workspace folder that has no `.venv` and no usable Python.
2. Run _Python: Install Python via uv_ and select a version that is not installed.
3. Keep the Positron window in focus. Do not touch Positron while the install runs.
4. Make sure that the dialog is still on screen 60 seconds after it appears.
5. Click _Create_. Make sure that `.venv` is created in the workspace, and that the console starts on it.
6. Repeat with an installed version, and click _Skip_. Make sure that no `.venv` is created, and that the session starts on the base interpreter.
7. Repeat and press <kbd>Esc</kbd>. The result must match step 6.
8. Repeat in a workspace that already has a `.venv`, and click _Create_. Make sure that the "use existing / delete and recreate" quickpick appears.
9. Open the session picker and select **Install Python via uv**. Make sure that the same dialog appears.
10. Run the flow with no folder open. Make sure that no question appears, and that `~/.venv` is created.
