### PR TITLE
Skipped Python health checks report an id instead of a summary

### DIFF
--- a/extensions/positron-python/src/client/positron/environmentHealth.ts
+++ b/extensions/positron-python/src/client/positron/environmentHealth.ts
@@ -74,8 +74,34 @@ export interface EnvironmentHealthResult {
     interpreterPath?: string;
 }
 
+/**
+ * The claim a check makes, phrased so it reads the same whatever the outcome is: 'pass' means it
+ * holds, 'fail' means it does not, 'skipped' means it was never evaluated. Callers that never run
+ * the probe (a skipped item, a probe that threw) still need the text, so it lives here rather than
+ * inside each probe.
+ */
+export function itemSummary(id: HealthItemId): string {
+    switch (id) {
+        case 'discovery':
+            return vscode.l10n.t('Positron can discover Python environments');
+        case 'pythonInstalled':
+            return vscode.l10n.t('A supported Python is installed');
+        case 'environmentReady':
+            return vscode.l10n.t('The environment is ready to use with Positron');
+        case 'dedicatedEnvironment':
+            return vscode.l10n.t('A dedicated Python environment is available');
+        default:
+            // `id` narrows to `never`; a new HealthItemId without a summary is a compile error.
+            return assertNever(id);
+    }
+}
+
+function assertNever(value: never): never {
+    throw new Error(`Unhandled health item id: ${value}`);
+}
+
 export function probeDiscovery(finder: Pick<NativePythonFinder, 'lastDiscoveryError'>): HealthItem {
-    const summary = vscode.l10n.t('Positron can discover Python environments');
+    const summary = itemSummary('discovery');
     if (finder.lastDiscoveryError) {
         return {
             id: 'discovery',
@@ -123,7 +149,7 @@ export async function probePythonInstalled(deps: {
     allowUvPythonInstall: boolean;
     waitMs: number;
 }): Promise<HealthItem> {
-    const summary = vscode.l10n.t('A supported Python is installed');
+    const summary = itemSummary('pythonInstalled');
     const hasSupported = () => deps.getInterpreters().some((i) => isVersionSupported(i.version));
 
     if (hasSupported()) {
@@ -302,7 +328,7 @@ export function probeDedicatedEnvironment(deps: {
     newFolderFix: HealthItemFix;
 }): HealthItem {
     const id = 'dedicatedEnvironment';
-    const summary = vscode.l10n.t('A dedicated Python environment is available');
+    const summary = itemSummary(id);
 
     if (deps.workspaceOpen) {
         if (deps.interpreterDedicated) {
@@ -353,7 +379,7 @@ export function probeEnvironmentReady(deps: {
     installNativePythonFix?: HealthItemFix;
 }): HealthItem {
     const id = 'environmentReady';
-    const summary = vscode.l10n.t('The environment is ready to use with Positron');
+    const summary = itemSummary(id);
 
     if (!deps.resolvesAndRuns) {
         return {
@@ -409,7 +435,7 @@ interface ItemProducers {
 }
 
 function skipped(id: HealthItemId): HealthItem {
-    return { id, status: 'skipped', summary: id };
+    return { id, status: 'skipped', summary: itemSummary(id) };
 }
 
 async function runItem(id: HealthItemId, produce: () => HealthItem | Promise<HealthItem>): Promise<HealthItem> {
@@ -419,7 +445,7 @@ async function runItem(id: HealthItemId, produce: () => HealthItem | Promise<Hea
         return {
             id,
             status: 'fail',
-            summary: id,
+            summary: itemSummary(id),
             detail: vscode.l10n.t('Health check failed: {0}', ex instanceof Error ? ex.message : String(ex)),
         };
     }

--- a/extensions/positron-python/src/client/positron/environmentHealth.ts
+++ b/extensions/positron-python/src/client/positron/environmentHealth.ts
@@ -81,23 +81,15 @@ export interface EnvironmentHealthResult {
  * inside each probe.
  */
 export function itemSummary(id: HealthItemId): string {
-    switch (id) {
-        case 'discovery':
-            return vscode.l10n.t('Positron can discover Python environments');
-        case 'pythonInstalled':
-            return vscode.l10n.t('A supported Python is installed');
-        case 'environmentReady':
-            return vscode.l10n.t('The environment is ready to use with Positron');
-        case 'dedicatedEnvironment':
-            return vscode.l10n.t('A dedicated Python environment is available');
-        default:
-            // `id` narrows to `never`; a new HealthItemId without a summary is a compile error.
-            return assertNever(id);
-    }
-}
-
-function assertNever(value: never): never {
-    throw new Error(`Unhandled health item id: ${value}`);
+    // Record<HealthItemId, string> requires an entry per id, so adding a check without a summary
+    // is a compile error. Built per call because vscode.l10n.t needs the activated l10n bundle.
+    const summaries: Record<HealthItemId, string> = {
+        discovery: vscode.l10n.t('Positron can discover Python environments'),
+        pythonInstalled: vscode.l10n.t('A supported Python is installed'),
+        environmentReady: vscode.l10n.t('The environment is ready to use with Positron'),
+        dedicatedEnvironment: vscode.l10n.t('A dedicated Python environment is available'),
+    };
+    return summaries[id];
 }
 
 export function probeDiscovery(finder: Pick<NativePythonFinder, 'lastDiscoveryError'>): HealthItem {

--- a/extensions/positron-python/src/test/positron/environmentHealth.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/environmentHealth.unit.test.ts
@@ -446,6 +446,24 @@ suite('Python Environment Health - orchestration', () => {
         });
         assert.strictEqual(result.items[1].status, 'fail');
         assert.include(result.items[1].detail ?? '', 'boom');
+        assert.strictEqual(result.items[1].summary, 'A supported Python is installed');
+    });
+
+    test('skipped items carry the check summary, not the machine id', async () => {
+        const result = await assembleItems({
+            discovery: () => fail('discovery'),
+            pythonInstalled: async () => pass('pythonInstalled'),
+            ready: async () => pass('environmentReady'),
+            dedicated: async () => pass('dedicatedEnvironment'),
+        });
+        assert.deepStrictEqual(
+            result.items.slice(1).map((i) => [i.id, i.summary]),
+            [
+                ['pythonInstalled', 'A supported Python is installed'],
+                ['environmentReady', 'The environment is ready to use with Positron'],
+                ['dedicatedEnvironment', 'A dedicated Python environment is available'],
+            ],
+        );
     });
 });
 


### PR DESCRIPTION
The Python environment health check reports each check as an item with a `summary`, a one-line string meant for display. When a check was skipped, `summary` came back as that check's machine id -- the literal string `pythonInstalled` -- instead of a sentence. The same thing happened when a check threw, so a failed item could report `environmentReady` as its summary too. I hit this while building the welcome page UI that renders this JSON, where the raw ids turned up as row labels.

A quick primer on `environmentHealth.ts`, since it is new enough that most of us have not been in it:

- It runs four checks in dependency order: `discovery`, `pythonInstalled`, `environmentReady`, `dedicatedEnvironment`.
- Each returns a `HealthItem` carrying an `id`, a `status` (`pass`, `warn`, `fail`, or `skipped`), and a `summary`. The type's own comment already documented `summary` as a localized one-liner.
- When a check fails, the checks that depend on it are marked `skipped` rather than run. Those skipped items come from a helper that never calls a probe, and that helper is where the id leaked into the field.

This PR gives every check a single localized summary that both the probe and the skip path read from, so an item carries the same sentence whatever its status turns out to be. The summaries are phrased as claims: `pass` means the claim holds, `fail` means it does not, `skipped` means it was never evaluated.

```json
{ "id": "dedicatedEnvironment", "status": "skipped",
  "summary": "A dedicated Python environment is available" }
```

The `switch` mapping an id to its summary has no `default` branch. An unhandled id narrows to `never` and fails to compile, so a fifth check cannot quietly reintroduce this.

The existing orchestration tests only asserted on `id` and `status` pairs, and built their fixtures with `summary: id`, which is why the bad value looked normal for so long. Added two assertions that pin the actual strings.

### Screenshots

**BEFORE**

<img width="1287" height="1010" alt="Screenshot 2026-08-12 at 4 53 07 PM" src="https://github.com/user-attachments/assets/4104c87e-c90b-43eb-aa11-c2d4a8afe374" />


**AFTER**

<img width="1234" height="1047" alt="Screenshot 2026-08-12 at 4 42 41 PM" src="https://github.com/user-attachments/assets/7d2c14f9-08e4-450d-bbb3-489153fd88b6" />



### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### Validation Steps

@:interpreter

SETUP: open a workspace folder with a Python available. The report is logged to the **Python** output channel, between the `[START] PYTHON ENVIRONMENT HEALTH` and `[END] PYTHON ENVIRONMENT HEALTH` banner lines.

**All four checks pass**

1. Create a venv in the workspace folder with `python -m venv .venv` and select it as the interpreter.
2. Run **Python: Print environment health report to Output** from the Command Palette and read the logged JSON. All four items should be `"status": "pass"`, and every `summary` should read as a sentence, e.g. `"A supported Python is installed"`. None should be a bare id like `"pythonInstalled"`.

**A skipped check carries its summary**

3. Delete the venv from disk: `rm -rf .venv`.
4. Re-run the command _without reloading the window_. A reload drops the deleted venv from the cached interpreter list, so the selection falls back to a global Python and all four checks pass again -- which is not the state we want to look at.
5. `environmentReady` should now be `"status": "fail"` (its interpreter no longer exists on disk), and `dedicatedEnvironment` should be `"status": "skipped"` carrying `"summary": "A dedicated Python environment is available"` -- _not_ `"dedicatedEnvironment"`.

**Unit tests**

6. `cd extensions/positron-python && npm run test:unittests -- --grep "Python Environment Health"`. All 30 should pass, including `skipped items carry the check summary, not the machine id`.

