### PR TITLE
e2e: wait out "Activating Extensions..." in the startup gate

### DIFF
--- a/test/e2e/pages/hotKeys.ts
+++ b/test/e2e/pages/hotKeys.ts
@@ -5,6 +5,7 @@
 
 import test, { expect } from '@playwright/test';
 import { Code } from '../infra/code.js';
+import { STARTUP_MESSAGING_SELECTOR, STARTUP_MESSAGING_TIMEOUT } from './utils/startupMessaging.js';
 
 /**
  * Provides hotkey shortcuts for common operations. References the keybindings defined in `test/e2e/fixtures/keybindings.json`.
@@ -261,7 +262,7 @@ export class HotKeys {
 		await this.code.driver.currentPage.waitForTimeout(3000);
 		await this.code.driver.currentPage.locator('.monaco-workbench').waitFor({ state: 'visible' });
 		if (waitForReady) {
-			await expect(this.code.driver.currentPage.locator('text=/^Setting up|^Waiting for extensions|^Starting|^Preparing|Reconnecting|^Reactivating|^Discovering( \\w+)? interpreters|starting\\.$/i')).toHaveCount(0, { timeout: 90000 });
+			await expect(this.code.driver.currentPage.locator(STARTUP_MESSAGING_SELECTOR)).toHaveCount(0, { timeout: STARTUP_MESSAGING_TIMEOUT });
 		}
 	}
 

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -6,6 +6,7 @@
 import test, { expect, Locator, Page } from '@playwright/test';
 import { Code, QuickAccess, Console, ContextMenu, Modals } from '../infra';
 import { QuickInput } from './quickInput';
+import { STARTUP_MESSAGING_SELECTOR, STARTUP_MESSAGING_TIMEOUT } from './utils/startupMessaging.js';
 
 // Lazy getters for environment variables - these will be evaluated when accessed, not at module load time
 const getDesiredPython = () => process.env.POSITRON_PY_VER_SEL;
@@ -661,7 +662,7 @@ export class Sessions {
 			await expect(this.code.driver.currentPage.locator('[id="workbench.parts.titlebar"]')).toBeVisible({ timeout: 30000 });
 			await this.console.focus();
 			await this.code.driver.currentPage.mouse.move(0, 0);
-			await expect(this.page.locator('text=/^Setting up|^Waiting for extensions|^Starting|^Preparing|Reconnecting|^Reactivating|^Discovering( \\w+)? interpreters|starting\\.$/i')).toHaveCount(0, { timeout: 90000 });
+			await expect(this.page.locator(STARTUP_MESSAGING_SELECTOR)).toHaveCount(0, { timeout: STARTUP_MESSAGING_TIMEOUT });
 		});
 	}
 

--- a/test/e2e/pages/utils/startupMessaging.ts
+++ b/test/e2e/pages/utils/startupMessaging.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Selector matching any status message that means Positron is still coming up.
+ *
+ * Shared by every readiness gate rather than copied into each. The pattern lived
+ * in two places, and a message missing from one of them is invisible: the gate
+ * still passes, just earlier than it should, and the test that follows races
+ * whatever was still starting.
+ *
+ * `Activating Extensions...` comes from upstream's own progress item
+ * (`extensionsActivationProgress.ts`), not from Positron. Each activation there
+ * is raced against a 5s timeout, so this can never hold a gate open for long.
+ */
+export const STARTUP_MESSAGING_SELECTOR =
+	'text=/^Setting up|^Waiting for extensions|^Activating Extensions|^Starting|^Preparing|Reconnecting|^Reactivating|^Discovering( \\w+)? interpreters|starting\\.$/i';
+
+/** How long a readiness gate waits for startup messaging to clear. */
+export const STARTUP_MESSAGING_TIMEOUT = 90000;


### PR DESCRIPTION
`expectNoStartUpMessaging` listed every startup status message except upstream's own extension-activation progress, so the gate could return while extensions were still activating and the test that followed raced them.

- Adds `^Activating Extensions` to the startup messaging pattern
- Moves the pattern and its timeout into one shared module: it was duplicated between `sessions.ts` and `hotKeys.ts`, which is how it drifted in the first place

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

This gate runs from `_test.setup.ts` and the app fixtures, so it is on the path of nearly every e2e test -- a broad run is the validation.

The new alternative cannot hang a gate for long: upstream races each activation against a 5s timeout (`extensionsActivationProgress.ts`), so the progress item always clears. Worst case is a few seconds added per gate; the risk to watch for is tests that were previously passing *early*.
