### PR TITLE
docs: run e2e tests in the background so the session stays interruptible

### DIFF
--- a/.claude/skills/debug-e2e-test/SKILL.md
+++ b/.claude/skills/debug-e2e-test/SKILL.md
@@ -58,6 +58,11 @@ These hold on both entries unless a line names one.
 - Investigate **one** selected pattern at a time (CI); ask which when there's
   more than one. Never fetch evidence for a pattern the engineer didn't select --
   ask first, even to check a side theory about how patterns relate.
+- **Never run a test in the foreground.** Use Bash `run_in_background: true` and
+  tail the log. A foreground call lasting minutes blocks delivery of the
+  engineer's messages until it returns, so "it's hung, stop it" cannot reach you
+  mid-run and you cannot `TaskStop` the run. This matters most here: debugging
+  means watching a run you may well want to abandon.
 - Fetch **one** representative occurrence first; a second only for a listed
   reason in `references/evidence-escalation.md` -- name which.
 - Agree the **fix approach** before the first edit, the same way you agree the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,12 @@ Positron has three test categories:
 	- `npm run test:ext-host` (or `./scripts/test-integration.sh`): run the full CI driver
 	- positron-python has its own test setup -- see `extensions/positron-python/CLAUDE.md`
 - **E2E** (Playwright, full app): `npx playwright test test/e2e/tests/<test-name>.test.ts --project e2e-electron --grep '<pattern>'`
+	- **Run it in the background, not the foreground.** Use Bash `run_in_background: true`
+	  (or `nohup ... &` for runs longer than the tool timeout) and tail the log, rather than
+	  blocking on the call. A single e2e test takes 1-7 minutes and a suite takes tens of
+	  minutes; a foreground call that long means the user's messages are not delivered until
+	  it returns, so "it's stuck, stop" cannot reach you and you cannot `TaskStop` the run.
+	  Background runs also let you watch a log with Monitor and act on failures as they land.
 
 ### Triaging an e2e test that is failing or flaking
 


### PR DESCRIPTION
### Summary

Documents a convention: **run e2e tests in the background, not the foreground.**

Queued user messages are delivered to the agent alongside tool results, so a foreground
Bash call blocks them until it returns. A single e2e test takes 1-7 minutes and a suite
takes tens of minutes -- so "it's stuck, stop it" cannot reach the agent mid-run, and it
cannot cancel the run either.

This came out of a real session debugging the Rocky lane (#15472). Suite runs launched in
the background stayed responsive to messages throughout -- I answered questions and looked
at screenshots while a 33-minute run was going. Single-test runs launched in the
foreground left the engineer waiting minutes for a hung test to time out before their
"it's stuck" was even delivered. Same tool, same test runner; the only difference was the
flag.

Nothing new is needed to fix it -- Bash `run_in_background` already exists. What was
missing was the convention telling the agent to use it.

### Changes

- **`CLAUDE.md`** -- a note under the E2E run command, since that is where the command is
  documented and where an agent looks before running one. This is the important one: no
  skill was loaded when this bit us, so a skill-only fix would have missed it.
- **`.claude/skills/debug-e2e-test/SKILL.md`** -- the same as a non-negotiable rule.
  Debugging a failing test *is* watching a run you may want to abandon, so it matters most
  there.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

Documentation only; no code paths change. Both files pass `npm run precommit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
