### PR TITLE
e2e: let the Posit Assistant model-picker retry loop actually retry

### DIFF
--- a/test/e2e/pages/positAssistant.ts
+++ b/test/e2e/pages/positAssistant.ts
@@ -437,11 +437,11 @@ export class PositAssistant {
 	 * menu and its "Model" submenu, then click the first model in the provider's
 	 * group container.
 	 *
-	 * The open->select->close cycle is retried because providers whose model list
-	 * is populated by a live fetch (e.g. Posit AI) can re-render the group between
-	 * the count check and the click, detaching the item mid-click and hanging the
-	 * click indefinitely. A short inner click timeout lets a stale attempt fail
-	 * fast so the loop reopens the menu and retries against the fresh list.
+	 * The open->select->close cycle is retried because a model list populated by a
+	 * live fetch (Posit AI, or any provider in a remote session) can re-render the
+	 * group mid-click. Every click inside the loop carries a short timeout: an
+	 * unbounded one inherits the default, and a single stalled click eats the whole
+	 * retry budget.
 	 */
 	private async selectProviderModelMenuMode(overflow: Locator, providerName: string): Promise<void> {
 		const modelSubmenu = this.frame.locator('[role="menuitem"][aria-haspopup="menu"]:has(span:text-is("Model"))');
@@ -457,8 +457,8 @@ export class PositAssistant {
 			// group isn't already visible (e.g. a prior iteration reopens after a
 			// stale click).
 			if (!(await group.isVisible().catch(() => false))) {
-				await overflow.click();
-				await modelSubmenu.click();
+				await overflow.click({ timeout: 5000 });
+				await modelSubmenu.click({ timeout: 5000 });
 				await expect(group).toBeVisible({ timeout: 5000 });
 			}
 
@@ -466,14 +466,42 @@ export class PositAssistant {
 			// "More models" disclosure with none shown directly, so the group has no
 			// model item until it's expanded.
 			if (await models.count() === 0) {
-				await group.locator('button:has-text("More models")').click();
+				await group.locator('button:has-text("More models")').click({ timeout: 5000 });
 			}
+			await this.waitForModelListToSettle(models);
 			await models.first().click({ timeout: 5000 });
 
 			// Menu closes on selection; wait for the trigger to collapse so subsequent
 			// actions (e.g. Send) don't race an open overlay.
 			await expect(overflow).toHaveAttribute('aria-expanded', 'false', { timeout: 5000 });
 		}).toPass({ timeout: 30000 });
+	}
+
+	/**
+	 * Waits for a provider group's model items to stop churning: two consecutive
+	 * samples agreeing on the item count and the first item's generated id.
+	 *
+	 * WHY: while the group re-renders, Base UI re-mounts the items behind an inert
+	 * `role="presentation"` backdrop, so a click landing mid-render is blocked and
+	 * then loses its element. The id is sampled alongside the count because a
+	 * re-mount can replace the items without changing how many there are.
+	 */
+	private async waitForModelListToSettle(models: Locator): Promise<void> {
+		let previous = '';
+		await expect.poll(async () => {
+			const count = await models.count();
+			// A sample can lose its element to the very re-mount being waited out.
+			// Only the thrown case is `undefined`: a genuinely missing id attribute
+			// resolves to `null`, a stable value worth comparing.
+			const id = await models.first().getAttribute('id', { timeout: 1000 }).catch(() => undefined);
+			if (id === undefined) {
+				return false;
+			}
+			const current = `${count}:${id}`;
+			const settled = current === previous;
+			previous = current;
+			return settled;
+		}, { timeout: 5000, intervals: [200] }).toBe(true);
 	}
 
 	/**
@@ -510,14 +538,14 @@ export class PositAssistant {
 			// Open the picker if it isn't already open (e.g. a prior iteration
 			// selected the model but Escape didn't land).
 			if (!(await radioGroup.isVisible().catch(() => false))) {
-				await trigger.click();
+				await trigger.click({ timeout: 5000 });
 				await expect(radioGroup).toBeVisible({ timeout: 5000 });
 			}
 			// Some providers (e.g. Microsoft Foundry) list every model under the
 			// "More models" disclosure with none shown directly; expand it so the
 			// provider has a selectable model.
 			if (await directTopModel.count() === 0 && await moreModels.isVisible().catch(() => false)) {
-				await moreModels.click();
+				await moreModels.click({ timeout: 5000 });
 			}
 			// Short click timeout so a menu that closed mid-open fails fast and we
 			// reopen on the next iteration rather than hanging.


### PR DESCRIPTION
### Summary
The remote-ssh Posit Assistant test flakes because the model picker's retry loop cannot actually retry: two clicks inside its 30s budget had no timeout of their own, so one stalled click consumed 24.4s and the loop managed two attempts instead of five.

- Bound every click inside both the menu-mode and inline-mode retry loops
- Wait for the provider's model list to stop re-rendering before clicking it
- No timeouts raised; the outer 30s retry budget is unchanged

### QA Notes
Needs the `@:remote-ssh` lane -- the only evidence available, since the failure is load-dependent and the lane can't be run locally (it needs a Linux DEB + REH tarball in a Docker SSH host). No lane result yet.

### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- The model-picker menu-mode retry loop in positAssistant.selectProviderModelMenuMode cannot absorb the assistant menu's re-mount churn: its own open-steps (overflow.click, modelSubmenu.click) are unbounded, so one stalled submenu click consumed 24.4s of the 30s toPass budget and the loop got only two iterations.</summary>

- **Test:** [Remote SSH: Posit Assistant > Sign in to Anthropic and chat against the remote host](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Remote%20SSH%3A%20Posit%20Assistant%20%3E%20Sign%20in%20to%20Anthropic%20and%20chat%20against%20the%20remote%20host%7C%7C%7Ctest%2Fe2e%2Ftests%2Fremote-ssh%2Fremote-ssh-assistant.test.ts)
- **Targeted failure:** Error: locator.click: Timeout 5000ms exceeded. -- waiting for [data-slot="dropdown-menu-group"]:has([data-slot="dropdown-menu-label"] span:text-is("Anthropic")) >> [role="menuitem"] >> nth=0
- **Signal:** Trace timeline: iter 1 t=92233..97734 (5.5s, inner 5s guard fired); iter 2 re-opened overflow at t=97743 then modelSubmenu.click() at t=97787 never returned before the 30s toPass deadline at t=122219. Call log shows the item churning: 'element is not stable' -> '<div role="presentation" data-base-ui-inert=""></div> intercepts pointer events' -> 'element was detached from the DOM, retrying', item id base-ui-_r_25_ -> base-ui-_r_2h_.
- **Frequency:** 1/6 runs (16.7%) on main, ubuntu/electron
- **Hypothesis:** Bounding every click inside the toPass loop with a short timeout, and waiting for the group's model-item count to be stable across two samples before clicking, lets the loop iterate ~5 times against a settled list instead of stalling. If the re-mount churn is continuous rather than transient, the failure rate will not move and the residue belongs to posit-dev/assistant (inert presentation overlay intercepting its own menu items).

</details>

