### PR TITLE
e2e: make the Explorer collapse opt-in so nested files stay visible

### DIFF
--- a/test/e2e/pages/explorer.ts
+++ b/test/e2e/pages/explorer.ts
@@ -23,17 +23,23 @@ export class Explorer {
 	/**
 	 * Assert that each named file is present in the Explorer.
 	 *
-	 * Collapses the tree first. The Explorer's list is virtualized, so a row
-	 * outside the rendered window is absent from the DOM entirely rather than
-	 * merely scrolled out of sight -- which makes this assertion fail with
-	 * "element(s) not found" and no possibility of recovery. Whether a given row
-	 * is inside that window depends on how many folders happen to be expanded,
-	 * and the `app` fixture is worker-scoped, so expansion state accumulates
-	 * across every test that ran before this one in the same session. Collapsing
-	 * makes the check depend only on the file actually existing.
+	 * The Explorer's list is virtualized, so a row outside the rendered window is
+	 * absent from the DOM entirely rather than merely scrolled out of sight --
+	 * which makes this assertion fail with "element(s) not found" and no
+	 * possibility of recovery. Whether a given row is inside that window depends
+	 * on how many folders happen to be expanded, and the `app` fixture is
+	 * worker-scoped, so expansion state accumulates across every test that ran
+	 * before this one in the same session.
+	 *
+	 * `collapseFirst` folds the tree so that top-level entries are certain to be
+	 * rendered. Use it only for files at the **workspace root**: collapsing hides
+	 * anything nested, so a caller asserting a file inside a folder (e.g. a
+	 * rendered `.html` sitting next to its source) must leave it off.
 	 */
-	async verifyExplorerFilesExist(files: string[]) {
-		await this.quickaccess.runCommand('workbench.files.action.collapseExplorerFolders');
+	async verifyExplorerFilesExist(files: string[], options: { collapseFirst?: boolean } = {}) {
+		if (options.collapseFirst) {
+			await this.quickaccess.runCommand('workbench.files.action.collapseExplorerFolders');
+		}
 
 		const explorerFiles = this.code.driver.currentPage.locator('.monaco-list > .monaco-scrollable-element');
 

--- a/test/e2e/tests/console/files-pane-refresh.test.ts
+++ b/test/e2e/tests/console/files-pane-refresh.test.ts
@@ -22,7 +22,11 @@ test.describe('Files Pane Refresh', { tag: [tags.WEB, tags.WORKBENCH, tags.CONSO
 		const { console, explorer } = app.workbench;
 
 		await console.createFile('R', 'file.txt');
-		await explorer.verifyExplorerFilesExist(['file.txt']);
+		// file.txt is created at the workspace root, which sorts after the
+		// `workspaces` folder -- so with folders left expanded by earlier tests in
+		// this worker's session it falls outside the virtualized list's rendered
+		// window and cannot be found. Collapse first so its position is fixed.
+		await explorer.verifyExplorerFilesExist(['file.txt'], { collapseFirst: true });
 	});
 });
 

--- a/test/e2e/tests/r-markdown/r-markdown.test.ts
+++ b/test/e2e/tests/r-markdown/r-markdown.test.ts
@@ -16,6 +16,9 @@ test.describe('R Markdown', { tag: [tags.WEB, tags.R_MARKDOWN, tags.ARK] }, () =
 	test('Verify can render R Markdown', async function ({ app, r }) {
 		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'basic-rmd-file', 'basicRmd.rmd'));
 		await app.workbench.quickaccess.runCommand('r.rmarkdownRender');
+		// Do not pass `collapseFirst` here: render writes basicRmd.html next to its
+		// source, inside workspaces/basic-rmd-file/, and collapsing the Explorer
+		// folds nested rows out of the virtualized list entirely.
 		await app.workbench.explorer.verifyExplorerFilesExist(['basicRmd.html']);
 	});
 


### PR DESCRIPTION
### Summary

Fixes `Verify can render R Markdown`, which #15472 broke on `main`
([run 31706423039](https://github.com/posit-dev/positron/actions/runs/31706423039)).

That PR made `verifyExplorerFilesExist` collapse the Explorer before asserting, to stop a
root-level file being pushed outside the virtualized list's rendered window by folders
earlier tests had expanded. Collapsing fixes that -- and hides anything **nested**.

`r-markdown` renders `workspaces/basic-rmd-file/basicRmd.rmd`, and `rmarkdown::render`
writes the output next to its source, so `basicRmd.html` is one folder deep. Collapsing
folds it out of the DOM and the assertion cannot find it. It was the only failure, in both
`e2e / electron` and `e2e / chromium`.

The claim in #15472 that "all ten callers assert root-level files" was wrong: it was based
on the file *names*, not on where each file is *created*. `plots` and `new-folder-flow` do
write to their workspace root, which is why they passed and made the claim look safe.

### Fix

Collapsing is now opt-in and off by default, so every caller returns to its pre-#15472
behaviour except the one that needs it:

```ts
async verifyExplorerFilesExist(files: string[], options: { collapseFirst?: boolean } = {})
```

The doc comment states the constraint: use it only for files at the workspace root,
because collapsing hides anything nested. `files-pane-refresh` passes
`{ collapseFirst: true }`, with a comment on why -- `file.txt` sorts after the
`workspaces` folder, so with folders expanded it falls outside the rendered window.

This is the shape the change should have had from the start. Collapsing is *correct* for a
root-level assertion and *wrong* for a nested one, so it was never a property to apply
blanket-wise to a shared helper.

### Also in this branch

A comment at the `r-markdown` call site explaining why it must *not* pass `collapseFirst`.
Without it, adding the option there looks like a harmless consistency tidy-up and
reintroduces this failure.

### Testing

- `files-pane-refresh` verified in the order that originally broke it -- `publisher-quarto-r`
  first, so the publisher tests leave `.posit/publish/...` expanded -- against a Rocky 9
  Workbench stack. That is the regression #15472 was fixing, and it still passes with the
  opt-in.
- `r-markdown` verified locally too: `Verify can render R Markdown` passes in ~12s with the
  fix. My first attempt failed with `Process failed to launch!`, which I wrongly wrote off
  as a broken local Electron; the real cause was `ELECTRON_RUN_AS_NODE=1` leaking in from
  the IDE's extension host, making the Positron binary run as Node and reject
  `--remote-debugging-port`. Documented separately in #15531. Run it with
  `env -u ELECTRON_RUN_AS_NODE -u ELECTRON_NO_ATTACH_CONSOLE`.
  (The second test in that file, `Verify can preview R Markdown`, fails locally on the
  viewer iframe assertion. It passed in CI on the same commit where render failed and does
  not touch `verifyExplorerFilesExist`, so it is neither this regression nor caused by this
  fix -- but it is an undiagnosed local-only failure, noted for honesty.)
- Typecheck (`tsc --noEmit -p test/e2e/tsconfig.json`) and `eslint` clean on both files.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:r-markdown @:workbench

`@:r-markdown` covers the broken test on electron and chromium; `@:workbench` re-checks the
regression the opt-in still has to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)