### PR TITLE
docs(e2e): note the ELECTRON_RUN_AS_NODE leak that breaks electron runs

### DIFF
--- a/test/e2e/CLAUDE.md
+++ b/test/e2e/CLAUDE.md
@@ -47,4 +47,25 @@ If the `BUILD` environment variable is set, unset it before running tests:
 unset BUILD
 ```
 
+**`Process failed to launch!` when running `--project e2e-electron`.** Look past that
+line to the call log; if it says:
+
+```
+[pid=NNNN][err] .../Positron.app/Contents/MacOS/Positron: bad option: --remote-debugging-port=0
+```
+
+then `ELECTRON_RUN_AS_NODE=1` is set in your shell. `<binary>: bad option:` is Node's
+arg-parser error, not Electron's -- the variable makes any Electron binary behave as plain
+Node, which rejects Electron's flags. The `kill EPERM` that usually follows is just
+Playwright trying to kill a process that has already exited, and is not the cause.
+
+This bites terminals launched from *inside* the IDE, including an agent session, because
+the extension host exports it. An ordinary terminal does not inherit it. Run with the
+variables dropped for that command rather than editing your profile:
+
+```bash
+env -u ELECTRON_RUN_AS_NODE -u ELECTRON_NO_ATTACH_CONSOLE \
+  npx playwright test --project e2e-electron <test>
+```
+
 To reproduce and debug a CI failure locally using the actual CI image, see [`.devcontainer/ci-arm/README.md`](../../.devcontainer/ci-arm/README.md).


### PR DESCRIPTION
### Summary

Documents a confusing local failure: an `--project e2e-electron` run started from a
terminal *inside* the IDE dies with `Process failed to launch!`, which reads like a broken
Electron build. The real error is further down Playwright's call log:

```
[pid=NNNN][err] .../Positron.app/Contents/MacOS/Positron: bad option: --remote-debugging-port=0
```

`<binary>: bad option:` is **Node's** arg-parser error, not Electron's. `ELECTRON_RUN_AS_NODE=1`
makes any Electron binary run as plain Node, which rejects Electron's flags. The
`kill EPERM` that usually follows is just Playwright trying to kill a process that already
exited -- a red herring, and the line most likely to be quoted as the cause.

The extension host exports the variable, so terminals launched from inside the IDE inherit
it -- including agent sessions -- while an ordinary terminal does not. That asymmetry is
what makes it hard to place: the identical command works in one terminal and fails in
another, so it gets blamed on the machine or the build.

Fix is per-command, so nobody has to edit a profile:

```bash
env -u ELECTRON_RUN_AS_NODE -u ELECTRON_NO_ATTACH_CONSOLE \
  npx playwright test --project e2e-electron <test>
```

### Why here

`test/e2e/CLAUDE.md`'s Troubleshooting section already carries `unset BUILD`, which is the
same class of problem -- an inherited environment variable that breaks a run for reasons the
error message does not name. This sits next to it.

### How it came up

Found while trying to verify #15530 locally. I hit this, wrote it off as a broken local
Electron, and shipped that PR saying the r-markdown half could only be checked in CI. With
the variables dropped, the test runs fine and the fix verifies locally in about 12 seconds.
The cost of not knowing this is real: it turns an available local check into a CI
round-trip.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

Documentation only. Verified by running the previously failing command both ways:
`ELECTRON_RUN_AS_NODE` set reproduces `bad option: --remote-debugging-port=0`; dropped, the
same test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
