### PR TITLE
Check bootstrap extensions for blocked dependencies and hold back bad bumps

### DIFF
--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -75,10 +75,64 @@ jobs:
           retention-days: 3
           if-no-files-found: ignore
 
+  dependency-check:
+    name: 'check-bootstrap-extension-deps'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: ${{ github.workflow }}-dependency-check
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      issues: write
+    outputs:
+      flagged: ${{ steps.depcheck.outputs.flagged }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+
+      - name: Check bootstrap extension dependencies
+        id: depcheck
+        run: |
+          node scripts/check-bootstrap-extension-deps.ts --json > depcheck.json
+          echo "hits=$(jq '.hits | length' depcheck.json)" >> "$GITHUB_OUTPUT"
+          echo "flagged=$(jq -r '[.hits[].id] | join(" ")' depcheck.json)" >> "$GITHUB_OUTPUT"
+          {
+            jq -r '.summary' depcheck.json
+            jq -r '.warnings[]? | "- " + .' depcheck.json
+            jq -r '.hits[]? | "- HIT: " + .issueTitle' depcheck.json
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open an issue for each hit
+        if: steps.depcheck.outputs.hits != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DRYRUN: ${{ inputs.dryrun }}
+        run: |
+          KNOWN_TITLES=$(gh issue list --repo "$GITHUB_REPOSITORY" --state all \
+            --label "area: extensions" --limit 1000 --json title)
+          jq -c '.hits[]' depcheck.json | while read -r hit; do
+            title=$(jq -r '.issueTitle' <<<"$hit")
+            existing=$(jq --arg t "$title" '[.[] | select(.title == $t)] | length' <<<"$KNOWN_TITLES")
+            if [ "$existing" != "0" ]; then
+              echo "Issue already filed, skipping: $title" >> "$GITHUB_STEP_SUMMARY"
+            elif [ "$DRYRUN" = "true" ]; then
+              echo "[dryrun] Would open issue: $title"
+              jq -r '.issueBody' <<<"$hit" | sed 's/^/[dryrun]   /'
+            else
+              jq -r '.issueBody' <<<"$hit" | gh issue create --repo "$GITHUB_REPOSITORY" \
+                --title "$title" --label "area: extensions" --label "bug" --body-file -
+              echo "Opened issue: $title" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+
   auto-update:
     name: 'auto-update-extensions'
-    if: always() && needs.extensions-linux.result != 'cancelled'
-    needs: [extensions-linux]
+    if: always() && needs.extensions-linux.result != 'cancelled' && needs.dependency-check.result == 'success'
+    needs: [extensions-linux, dependency-check]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -131,19 +185,46 @@ jobs:
       - name: Update extensions
         env:
           TEST_RESULT: ${{ needs.extensions-linux.result }}
+          FLAGGED: ${{ needs.dependency-check.outputs.flagged }}
         run: |
           MISMATCHED=()
           if [ "$TEST_RESULT" = "failure" ] && [ -s mismatched-extensions.txt ]; then
             read -ra MISMATCHED <<< "$(cat mismatched-extensions.txt)"
           fi
           # meta.pyrefly is optional in the test, so bump it every run to catch silent drift.
-          EXTENSIONS_TO_BUMP=(meta.pyrefly "${MISMATCHED[@]}")
-          echo "Bumping extensions: ${EXTENSIONS_TO_BUMP[*]}"
+          CANDIDATES=(meta.pyrefly "${MISMATCHED[@]}")
+          EXTENSIONS_TO_BUMP=()
+          HELD_BACK=()
+          for ext in "${CANDIDATES[@]}"; do
+            if [[ " $FLAGGED " == *" $ext "* ]]; then
+              HELD_BACK+=("$ext")
+            else
+              EXTENSIONS_TO_BUMP+=("$ext")
+            fi
+          done
           {
             echo "### Bootstrap extensions to bump"
             echo ""
-            printf -- '- %s\n' "${EXTENSIONS_TO_BUMP[@]}"
+            if [ ${#EXTENSIONS_TO_BUMP[@]} -eq 0 ]; then
+              echo "- (none)"
+            else
+              printf -- '- %s\n' "${EXTENSIONS_TO_BUMP[@]}"
+            fi
+            if [ ${#HELD_BACK[@]} -gt 0 ]; then
+              echo ""
+              echo "Held back, latest version depends on a blocked extension:"
+              echo ""
+              printf -- '- %s\n' "${HELD_BACK[@]}"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
+          if [ ${#HELD_BACK[@]} -gt 0 ]; then
+            echo "Holding back: ${HELD_BACK[*]}"
+          fi
+          if [ ${#EXTENSIONS_TO_BUMP[@]} -eq 0 ]; then
+            echo "Nothing to bump."
+            exit 0
+          fi
+          echo "Bumping extensions: ${EXTENSIONS_TO_BUMP[*]}"
           ./scripts/update-extensions.sh "${EXTENSIONS_TO_BUMP[@]}"
           git add product.json
 
@@ -317,8 +398,8 @@ jobs:
             -d "$PAYLOAD"
 
   slack-notify:
-    if: always() && needs.extensions-linux.result == 'failure' && needs.auto-update.outputs.pr_url == '' && inputs.dryrun != true
-    needs: [extensions-linux, auto-update]
+    if: always() && inputs.dryrun != true && ((needs.extensions-linux.result == 'failure' && needs.auto-update.outputs.pr_url == '') || needs.dependency-check.result == 'failure')
+    needs: [extensions-linux, auto-update, dependency-check]
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack

--- a/scripts/check-bootstrap-extension-deps.ts
+++ b/scripts/check-bootstrap-extension-deps.ts
@@ -1,0 +1,219 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Checks the latest published version of each bootstrap extension in
+// product.json for a declared dependency on an extension Positron blocks and
+// does not ship as a built-in. Such a version installs but can never activate
+// (posit-dev/positron#15118), so we want a heads-up before a nightly bump or a
+// user update walks into one. See posit-dev/positron#15124.
+//
+// Usage:
+//   node scripts/check-bootstrap-extension-deps.ts [--json] [--fail-on-hit]
+//
+//   json:         write the machine-readable report to stdout instead of the
+//                 human-readable summary. The nightly workflow consumes this.
+//   fail-on-hit:  exit 1 when there is at least one hit. Off by default so a
+//                 hit is reported by opening an issue, not by failing the job.
+//
+// Exit codes: 0 when the check ran (with or without hits), 1 for a hit under
+// --fail-on-hit, 2 when the check itself could not run (network, drift, bad
+// response).
+
+const fs: typeof import('fs/promises') = require('fs/promises');
+const path: typeof import('path') = require('path');
+const { readFile, readdir } = fs;
+const { join } = path;
+
+// Scripts in this directory are CommonJS (see scripts/package.json) while the
+// blocklist is an ES module, so it is pulled in with require(esm). Node strips
+// the types on the way through, which is why the specifier keeps its real .ts
+// extension: nothing compiles this file to .js first.
+const blocklist: typeof import('../src/vs/platform/extensionManagement/common/positronExtensionBlocklist.ts') =
+	require('../src/vs/platform/extensionManagement/common/positronExtensionBlocklist.ts');
+const { POSITRON_BLOCKED_EXTENSIONS_WITH_BUILTIN, isUnsatisfiableDependency } = blocklist;
+
+const root = join(__dirname, '..');
+// Same endpoint scripts/update-extensions.sh resolves bootstrap versions from.
+const P3M_PACKAGES_API = 'https://p3m.dev/__api__/repos/openvsx/packages';
+
+interface IBootstrapExtension {
+	readonly name: string;
+	readonly version: string;
+}
+
+interface IPackageVersion {
+	readonly version: string;
+	readonly pre_release?: boolean;
+	readonly published_at?: string;
+}
+
+interface IExtensionManifest {
+	readonly extensionDependencies?: string[];
+	readonly extensionPack?: string[];
+}
+
+interface IHit {
+	readonly id: string;
+	readonly version: string;
+	readonly blockedDependencies: string[];
+	readonly blockedPackMembers: string[];
+	readonly issueTitle: string;
+	readonly issueBody: string;
+}
+
+interface IExtensionResult {
+	readonly hit?: IHit;
+	readonly warnings: string[];
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+	const res = await fetch(url, { headers: { 'Accept': 'application/json' } });
+	if (!res.ok) {
+		throw new Error(`GET ${url} -> ${res.status} ${res.statusText}`);
+	}
+	return await res.json() as T;
+}
+
+// Every ID in the built-in carve-out list must still name an extension we ship
+// in-tree. If one is ever dropped, dependencies on it become unsatisfiable and
+// the carve-out is silently wrong, so fail the run instead of under-reporting.
+async function assertBuiltinCarveOutIsAccurate(): Promise<void> {
+	const inTreeIds = new Set<string>();
+	for (const entry of await readdir(join(root, 'extensions'), { withFileTypes: true })) {
+		if (!entry.isDirectory()) {
+			continue;
+		}
+		try {
+			const pkg = JSON.parse(await readFile(join(root, 'extensions', entry.name, 'package.json'), 'utf8'));
+			if (pkg.publisher && pkg.name) {
+				inTreeIds.add(`${pkg.publisher}.${pkg.name}`.toLowerCase());
+			}
+		} catch {
+			// Not an extension directory, or no readable manifest; nothing to record.
+		}
+	}
+	const missing = POSITRON_BLOCKED_EXTENSIONS_WITH_BUILTIN.filter(id => !inTreeIds.has(id));
+	if (missing.length > 0) {
+		throw new Error(
+			`POSITRON_BLOCKED_EXTENSIONS_WITH_BUILTIN lists IDs with no in-tree extension: ${missing.join(', ')}. ` +
+			'Remove them from the carve-out in positronExtensionBlocklist.ts; dependencies on them are no longer satisfiable.');
+	}
+}
+
+// Picks the version a bootstrap bump would land on: the most recently published
+// stable release, falling back to prereleases for an extension that only
+// publishes those. Mirrors get_extension_info in scripts/update-extensions.sh.
+function selectLatestVersion(versions: IPackageVersion[]): IPackageVersion | undefined {
+	const stable = versions.filter(v => v.pre_release !== true);
+	const candidates = stable.length > 0 ? stable : versions;
+	// A missing or unparsable published_at sorts oldest rather than poisoning the
+	// comparator with NaN, which would leave the order arbitrary.
+	const publishedAt = (v: IPackageVersion) => Date.parse(v.published_at ?? '') || 0;
+	return candidates
+		.slice()
+		.sort((a, b) => publishedAt(b) - publishedAt(a))[0];
+}
+
+function buildIssueBody(id: string, version: string, pinnedVersion: string, blockedDependencies: string[]): string {
+	return [
+		`The nightly bootstrap extension check found that the latest published version of \`${id}\` declares a dependency that Positron blocks and does not provide as a built-in. An install of this version cannot activate.`,
+		'',
+		`- Extension: \`${id}\``,
+		`- Latest version on the mirror: \`${version}\``,
+		`- Version pinned in \`product.json\`: \`${pinnedVersion}\``,
+		`- Blocked dependency: ${blockedDependencies.map(d => `\`${d}\``).join(', ')}`,
+		'',
+		'Do not pin this version in `product.json`. Bootstrap extensions install from a bundled VSIX, which never reaches the gallery-side check added in posit-dev/positron#15474, so a pinned version with an unsatisfiable dependency ships to every user and never activates. Follow up with the extension maintainers, or ship a built-in that satisfies the dependency.',
+		'',
+		'Opened automatically by the `dependency-check` job in `.github/workflows/extensions-check-nightly.yml`.'
+	].join('\n');
+}
+
+async function checkExtension(ext: IBootstrapExtension, assetBase: string): Promise<IExtensionResult> {
+	const id = ext.name;
+	const [publisher, ...rest] = id.split('.');
+	const name = rest.join('.');
+	const packageInfo = await fetchJson<{ versions?: IPackageVersion[] }>(`${P3M_PACKAGES_API}/${id}`);
+	const latest = selectLatestVersion(packageInfo.versions ?? []);
+	if (!latest?.version) {
+		return { warnings: [`${id}: no published version found on the mirror`] };
+	}
+
+	// The manifest is the extension's package.json, served as its own asset, so
+	// there is no VSIX to download. It resolves without a targetPlatform query
+	// param even for multi-platform extensions.
+	const manifest = await fetchJson<IExtensionManifest>(
+		`${assetBase}/${publisher}/${name}/${latest.version}/Microsoft.VisualStudio.Code.Manifest`);
+	const blockedDependencies = (manifest.extensionDependencies ?? []).filter(isUnsatisfiableDependency);
+	const blockedPackMembers = (manifest.extensionPack ?? []).filter(isUnsatisfiableDependency);
+
+	const warnings: string[] = [];
+	if (blockedPackMembers.length > 0) {
+		// A blocked pack member is skipped at install and the pack still works,
+		// so this is informational only.
+		warnings.push(`${id} ${latest.version}: extension pack lists blocked extension(s) ${blockedPackMembers.join(', ')} (pack members are skipped at install)`);
+	}
+	if (blockedDependencies.length === 0) {
+		return { warnings };
+	}
+
+	return {
+		hit: {
+			id,
+			version: latest.version,
+			blockedDependencies,
+			blockedPackMembers,
+			issueTitle: `Latest ${id} (${latest.version}) depends on blocked extension: ${blockedDependencies.join(', ')}`,
+			issueBody: buildIssueBody(id, latest.version, ext.version, blockedDependencies)
+		},
+		warnings
+	};
+}
+
+async function main(): Promise<void> {
+	const args = new Set(process.argv.slice(2));
+	const product = JSON.parse(await readFile(join(root, 'product.json'), 'utf8'));
+	await assertBuiltinCarveOutIsAccurate();
+
+	// P3M serves assets at {asset_base}/{publisher}/{name}/{version}/{asset},
+	// where asset_base is the gallery serviceUrl with "gallery" replaced by
+	// "asset". Same derivation as scripts/update-extensions.sh.
+	const assetBase: string = product.extensionsGallery.serviceUrl.replace(/\/gallery$/, '/asset');
+	const extensions: IBootstrapExtension[] = product.bootstrapExtensions ?? [];
+	const hits: IHit[] = [];
+	const warnings: string[] = [];
+	for (const ext of extensions) {
+		const result = await checkExtension(ext, assetBase);
+		if (result.hit) {
+			hits.push(result.hit);
+		}
+		warnings.push(...result.warnings);
+	}
+
+	const summary = hits.length === 0
+		? `Checked ${extensions.length} bootstrap extensions: no blocked dependencies in the latest versions.`
+		: `Checked ${extensions.length} bootstrap extensions: ${hits.length} with a blocked dependency in the latest version.`;
+	if (args.has('--json')) {
+		process.stdout.write(JSON.stringify({ hits, warnings, summary }, null, 2) + '\n');
+	} else {
+		console.log(summary);
+		for (const hit of hits) {
+			console.log(`  HIT: ${hit.issueTitle}`);
+		}
+		for (const warning of warnings) {
+			console.log(`  warn: ${warning}`);
+		}
+	}
+	if (hits.length > 0 && args.has('--fail-on-hit')) {
+		// Set the code rather than calling process.exit, which would not flush a
+		// pending --json write to a pipe.
+		process.exitCode = 1;
+	}
+}
+
+main().catch(err => {
+	console.error(`check-bootstrap-extension-deps: ${err.message ?? err}`);
+	process.exit(2);
+});

--- a/src/vs/platform/extensionManagement/common/positronExtensionBlocklist.ts
+++ b/src/vs/platform/extensionManagement/common/positronExtensionBlocklist.ts
@@ -25,7 +25,7 @@ export const POSITRON_BLOCKED_EXTENSIONS: readonly string[] = [
  * built-in extension under the same ID. A third-party extension may declare a
  * dependency on one of these and still work, because the built-in satisfies the
  * dependency. Keep in sync with extensions/<dir>/package.json publisher and
- * name; scripts/check-bootstrap-extension-deps.mjs verifies this nightly.
+ * name; scripts/check-bootstrap-extension-deps.ts verifies this nightly.
  */
 export const POSITRON_BLOCKED_EXTENSIONS_WITH_BUILTIN: readonly string[] = [
 	'github.copilot-chat',		// extensions/copilot


### PR DESCRIPTION
Fixes #15124

This is the second/last PR for #15124. The first PR (#15474) stopped Positron from selecting an extension version that depends on a blocked extension. This PR adds the nightly check for the bootstrap extensions, and it holds back any bump that would pin a broken version.

The two PRs cover different install paths:

- #15474 covers the gallery, where version selection now holds users on the newest working version.
- Bootstrap extensions install from a bundled VSIX, so they never reach that check. If a broken version is pinned in `product.json`, it installs for every user and never activates, which is #15118.

Now `scripts/check-bootstrap-extension-deps.ts` reads the 14 bootstrap extensions in `product.json`. For each one, it resolves the latest published version from the same P3M endpoint that `scripts/update-extensions.sh` uses. It then reads the manifest asset for that version. It reports each `extensionDependencies` entry that Positron blocks and does not ship as a built-in. The script imports `positronExtensionBlocklist.ts` directly, so the blocklist has one source of truth. If the built-in carve-out list names an extension that is no longer in the tree, the script fails with a clear error.

The new `dependency-check` job in `.github/workflows/extensions-check-nightly.yml` runs the script and opens one issue for each hit. It compares titles exactly against the issues that carry the `area: extensions` label, open and closed, so a hit that is already filed or already triaged stays quiet. A newly published broken version files a new issue. I could switch this over to a Slack notification, if we prefer that.

The job also gates `auto-update`. It publishes the flagged extension IDs, and the bump step removes them from its candidate list. `update-extensions.sh` resolves the same "latest stable" version that the check inspected, so without this gate the bump PR would pin exactly the version the check just filed an issue about. The step summary lists the held-back extensions. If `dependency-check` fails, `auto-update` does not run, because we cannot tell whether a bump is safe. Slack reports the failure and the next run picks the bump back up.

The job reports blocked extension pack members as warnings only. A pack member is skipped at install and the pack still works. Only a hard dependency breaks activation.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:extensions

The only change under `src/` is a doc comment, so there is no product behavior to test here. The tag above is a sanity run.

Run the script locally:

```
node scripts/check-bootstrap-extension-deps.ts
node scripts/check-bootstrap-extension-deps.ts --json | jq .
```

It exits 0 and reports 14 extensions with no hits today. It takes about 3 seconds.

To see a hit, remove `'ms-python.python'` from `POSITRON_BLOCKED_EXTENSIONS_WITH_BUILTIN` and run the script again. It then reports `ms-python.debugpy`, and `jq -r '[.hits[].id] | join(" ")'` returns the ID that the bump gate reads. Revert the edit after the test.

After merge, start the workflow with `workflow_dispatch` and `dryrun: true`. The job summary shows the scan result and any held-back extensions. In dryrun mode the job prints the issue it would open, and it creates no issue.
