### PR TITLE
Fall back to the registration id when a provider declares no catalogId

### DIFF
--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -3745,8 +3745,9 @@ declare module 'positron' {
 			displayName: string;
 			/**
 			 * Provider id in the resolved provider catalog (`~/.posit/ai/providers.json`), used to
-			 * resolve enablement and connection config. Undefined for providers with no catalog entry
-			 * (e.g. dev-only providers), which are treated as enabled.
+			 * resolve enablement and connection config. When undefined, `id` is used instead, so a
+			 * provider is still subject to the catalog if the catalog knows that id. Providers the
+			 * catalog has never heard of are treated as enabled.
 			 */
 			catalogId?: string;
 			/**

--- a/src/vs/workbench/api/browser/positron/mainThreadAiFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadAiFeatures.ts
@@ -223,6 +223,10 @@ export class MainThreadAiFeatures extends Disposable implements MainThreadAiFeat
 	}
 
 	async $getRegisteredProviders(): Promise<IPositronLanguageModelSource[]> {
+		// Same timing rule as $getEnabledProviders: the sources are filtered by
+		// catalog enablement, so the pre-initialization snapshot would both drop
+		// providers that are enabled and keep ones providers.json disables.
+		await this._aiProviderService.whenInitialized;
 		return this._positronAssistantConfigurationService.getRegisteredSources();
 	}
 

--- a/src/vs/workbench/api/test/browser/positron/mainThreadAiFeatures.vitest.ts
+++ b/src/vs/workbench/api/test/browser/positron/mainThreadAiFeatures.vitest.ts
@@ -11,7 +11,7 @@ import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { IExtHostContext } from '../../../../services/extensions/common/extHostCustomers.js';
 import { IAiProviderService } from '../../../../services/positronAiProvider/common/aiProviderService.js';
 import { IProviderCatalogChangeData, IResolvedProviderData } from '../../../../../platform/positronAiProvider/common/aiProviderCatalog.js';
-import { IPositronAssistantConfigurationService, IPositronAssistantService } from '../../../../contrib/positronAssistant/common/interfaces/positronAssistantService.js';
+import { IPositronAssistantConfigurationService, IPositronAssistantService, IPositronLanguageModelSource, PositronLanguageModelType } from '../../../../contrib/positronAssistant/common/interfaces/positronAssistantService.js';
 import { IChatService } from '../../../../contrib/chat/common/chatService/chatService.js';
 import { IChatAgentService } from '../../../../contrib/chat/common/participants/chatAgents.js';
 import { ILanguageModelsService } from '../../../../contrib/chat/common/languageModels.js';
@@ -26,6 +26,15 @@ function resolvedProvider(id: string, enabled: boolean): IResolvedProviderData {
 	return { id, enabled, connection: {} };
 }
 
+function languageModelSource(id: string): IPositronLanguageModelSource {
+	return {
+		type: PositronLanguageModelType.Chat,
+		provider: { id, displayName: `Display ${id}` },
+		supportedOptions: [],
+		defaults: {},
+	};
+}
+
 describe('MainThreadAiFeatures', () => {
 	const disposables = ensureNoLeakedDisposables();
 
@@ -33,26 +42,29 @@ describe('MainThreadAiFeatures', () => {
 	let onDidChangeProviders: Emitter<IProviderCatalogChangeData>;
 	let onChangeProviderConfig: Emitter<never>;
 	let onDidChangeProviderEnablement: ReturnType<typeof vi.fn<(id: string, enabled: boolean) => void>>;
+	let getRegisteredSources: ReturnType<typeof vi.fn<() => IPositronLanguageModelSource[]>>;
 
 	/**
 	 * Constructs a MainThreadAiFeatures with the given initial catalog and returns it. The
-	 * returned instance's whenInitialized has already resolved, so the enablement baseline
-	 * snapshot is captured before the test fires any catalog changes.
+	 * enablement baseline snapshot is captured before the test fires any catalog changes.
+	 * Pass a pending `whenInitialized` to drive the pre-initialization timing yourself.
 	 */
-	async function createMainThread(initialCatalog: IResolvedProviderData[]): Promise<MainThreadAiFeatures> {
+	async function createMainThread(initialCatalog: IResolvedProviderData[], whenInitialized: Promise<void> = Promise.resolve()): Promise<MainThreadAiFeatures> {
 		catalog = initialCatalog;
 		onDidChangeProviders = disposables.add(new Emitter<IProviderCatalogChangeData>());
 		onChangeProviderConfig = disposables.add(new Emitter<never>());
 		onDidChangeProviderEnablement = vi.fn<(id: string, enabled: boolean) => void>();
+		getRegisteredSources = vi.fn<() => IPositronLanguageModelSource[]>(() => []);
 
 		const aiProviderService = stubInterface<IAiProviderService>({
-			whenInitialized: Promise.resolve(),
+			whenInitialized,
 			getProviders: () => catalog,
 			isEnabled: (id: string) => catalog.find(p => p.id === id)?.enabled ?? false,
 			onDidChangeProviders: onDidChangeProviders.event,
 		});
 		const positronAssistantConfigurationService = stubInterface<IPositronAssistantConfigurationService>({
 			onChangeProviderConfig: onChangeProviderConfig.event as Event<never>,
+			getRegisteredSources,
 		});
 		const extHostContext = stubInterface<IExtHostContext>({
 			getProxy: (<T>() => stubInterface<ExtHostAiFeaturesShape>({
@@ -75,7 +87,7 @@ describe('MainThreadAiFeatures', () => {
 		));
 
 		// Let the whenInitialized microtask (which captures the enablement baseline) settle.
-		await aiProviderService.whenInitialized;
+		await Promise.resolve();
 		await Promise.resolve();
 
 		return mainThread;
@@ -86,6 +98,22 @@ describe('MainThreadAiFeatures', () => {
 
 		await expect(mainThread.$isProviderEnabled('copilot')).resolves.toBe(true);
 		await expect(mainThread.$isProviderEnabled('unknown')).resolves.toBe(false);
+	});
+
+	it('$getRegisteredProviders waits for initialization before reading the sources', async () => {
+		let initialized: () => void;
+		const whenInitialized = new Promise<void>(resolve => { initialized = resolve; });
+		const mainThread = await createMainThread([resolvedProvider('ollama', false)], whenInitialized);
+		getRegisteredSources.mockReturnValue([languageModelSource('ollama')]);
+
+		// The sources are filtered by catalog enablement, so reading them before the
+		// catalog is loaded would report the empty pre-initialization snapshot.
+		const registered = mainThread.$getRegisteredProviders();
+		await Promise.resolve();
+		expect(getRegisteredSources).not.toHaveBeenCalled();
+
+		initialized!();
+		await expect(registered).resolves.toEqual([languageModelSource('ollama')]);
 	});
 
 	it('forwards a flipped enablement to the extension host', async () => {

--- a/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
@@ -179,10 +179,15 @@ export class PositronAssistantConfigurationService extends Disposable implements
 	}
 
 	private isSourceEnabled(source: IPositronLanguageModelSource): boolean {
-		const catalogId = source.provider.catalogId;
-		// Providers without a catalog entry (dev-only echo/error) follow the
-		// catalog baseline: enabled by default.
-		return catalogId === undefined || this._aiProviderService.isEnabled(catalogId);
+		const { catalogId, id } = source.provider;
+		if (catalogId !== undefined) {
+			return this._aiProviderService.isEnabled(catalogId);
+		}
+		// No declared catalogId: fall back to the registration id so extensions that
+		// haven't opted in still get enforcement. Registrations the catalog has never
+		// heard of stay enabled.
+		return this._aiProviderService.getProvider(id) === undefined
+			|| this._aiProviderService.isEnabled(id);
 	}
 
 	getEnabledProviders(): string[] {

--- a/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
@@ -75,8 +75,9 @@ export interface IPositronProviderMetadata {
 	displayName: string;
 	/**
 	 * Provider id in the resolved provider catalog (`~/.posit/ai/providers.json`),
-	 * used to resolve enablement and connection config. Undefined for providers
-	 * with no catalog entry, which are treated as enabled.
+	 * used to resolve enablement and connection config. When undefined, `id` is
+	 * used instead, so a provider is still subject to the catalog if the catalog
+	 * knows that id. Providers the catalog has never heard of are enabled.
 	 */
 	catalogId?: string;
 	/**

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/positronAssistantConfigurationService.vitest.ts
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/positronAssistantConfigurationService.vitest.ts
@@ -36,6 +36,10 @@ describe('PositronAssistantConfigurationService', () => {
 		.stub(INotificationService, { prompt })
 		.stub(ICommandService, { executeCommand })
 		.stub(IAiProviderService, {
+			// The catalog "knows" exactly the ids in catalogEnabled.
+			getProvider: (id: string) => catalogEnabled.has(id)
+				? { id, enabled: catalogEnabled.get(id) === true, connection: {} }
+				: undefined,
 			isEnabled: (id: string) => catalogEnabled.get(id) === true,
 			onDidChangeProviders: onDidChangeProvidersEmitter.event,
 			whenInitialized: Promise.resolve(),
@@ -195,11 +199,26 @@ describe('PositronAssistantConfigurationService', () => {
 			expect(service.isProviderEnabled('openai')).toBe(true);
 		});
 
-		it('unmapped dev providers (echo) are treated as enabled once registered', () => {
+		it('providers with no catalogId whose id the catalog has never heard of stay enabled', () => {
 			service.registerProvider(makeSource('echo'));
 
 			expect(service.isProviderEnabled('echo')).toBe(true);
 			expect(service.getEnabledProviders()).toEqual(['echo']);
+		});
+
+		it('providers with no catalogId fall back to their registration id for enablement', () => {
+			catalogEnabled.set('ollama', false);
+			service.registerProvider(makeSource('ollama'));
+
+			expect(service.isProviderEnabled('ollama')).toBe(false);
+			expect(service.getEnabledProviders()).toEqual([]);
+		});
+
+		it('a declared catalogId the catalog has never heard of is disabled', () => {
+			service.registerProvider(makeSource('ollama', 'ollama'));
+
+			expect(service.isProviderEnabled('ollama')).toBe(false);
+			expect(service.getEnabledProviders()).toEqual([]);
 		});
 
 		it('unregistered ids are not enabled even when the catalog enables them', () => {

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/positronAssistantConfigurationService.vitest.ts
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/positronAssistantConfigurationService.vitest.ts
@@ -87,8 +87,8 @@ describe('PositronAssistantConfigurationService', () => {
 		});
 
 		it('stays silent for disabled providers', () => {
-			// 'anthropic' has a catalog mapping, so enabled=false is meaningful
-			// (unmapped ids are always treated as enabled).
+			// 'anthropic' is in the catalog with enabled=false, so the provider is
+			// disabled and the error status stays quiet.
 			registerProvider('anthropic', false);
 			service.updateProvider('anthropic', { status: 'error', statusMessage: 'Authentication expired' });
 


### PR DESCRIPTION
Fixes #15416

Companion https://github.com/posit-dev/assistant/pull/2085

`isSourceEnabled()` treated a missing `catalogId` as "enabled", a default left over from the dev-only echo/error providers deleted in #11089. That meant any extension registering a provider without opting in escaped catalog enforcement entirely, which is how Posit Assistant's Ollama and LM Studio buttons survived being disabled in the provider catalog. The registration id is now the fallback, so registrations get enforcement by default. Ids the catalog has no entry for stay enabled. That's deliberate: when the catalog can't load at all (see #15333, where the ai-lib packages were missing from the remote server), an empty snapshot would otherwise disable every provider instead of just the ones an admin turned off.

While in here: `$getRegisteredProviders()` returns catalog-filtered sources but wasn't waiting for the catalog to load, so an extension calling `positron.ai.getRegisteredProviders()` during activation saw the empty pre-initialization snapshot. Providers declaring a `catalogId` got dropped, and ones that don't stayed enabled even when the catalog disables that id, which is the exact case this PR set out to fix. It now awaits `whenInitialized`, matching `$getEnabledProviders()` and `$isProviderEnabled()`.

Posit Assistant is declaring `catalogId` on its side too (https://github.com/posit-dev/assistant/pull/2085).

### Release Notes

#### Bug Fixes

- Don't display disabled local providers in provider modal (#15416)

### Validation Steps

@:assistant

Unit tests:

```bash
npx vitest run src/vs/workbench/contrib/positronAssistant/test/browser/positronAssistantConfigurationService.vitest.ts src/vs/workbench/api/test/browser/positron/mainThreadAiFeatures.vitest.ts
```

Manual, following the issue's reproduction:

1. Launch Positron from a shell with a couple of local providers turned off or modify providers.json directly (access via command `Preferences: Open AI Provider Settings (JSON)`):

	```bash
	export POSIT_AI_PROVIDERS_ENFORCED='{"providers":{"lmstudio":{"enabled":false},"ollama":{"enabled":false}}}'
	```

2. Command Palette -> `Positron Assistant: Configure Language Model Providers`.
3. Verify neither LM Studio nor Ollama is listed, matching how Anthropic already behaves.
4. Relaunch without the env var and confirm both are offered again.
