### PR TITLE
Snowflake field in the new provider modal asks for a base URL

### DIFF
--- a/src/vs/workbench/contrib/positronAssistant/browser/providerFieldLabels.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/providerFieldLabels.ts
@@ -8,12 +8,16 @@ import { localize } from '../../../../nls.js';
 /**
  * Label for a provider's `baseUrl` field. Most providers take an API base URL,
  * but for some the field carries something else entirely -- Databricks stores
- * the workspace host, from which the serving-endpoints URL is derived -- so a
- * generic "Base URL" would mislabel the input.
+ * the workspace host, from which the serving-endpoints URL is derived, and
+ * Snowflake stores the bare account identifier, from which the Cortex URL is
+ * derived (#13750) -- so a generic "Base URL" would mislabel the input.
  */
 export function getBaseUrlLabel(providerId: string): string {
 	if (providerId === 'databricks') {
 		return localize('positron.providerFieldLabels.workspaceUrl', "Workspace URL");
+	}
+	if (providerId === 'snowflake-cortex') {
+		return localize('positron.providerFieldLabels.accountIdentifier', "Account Identifier");
 	}
 	return localize('positron.providerFieldLabels.baseUrl', "Base URL");
 }

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/connectProviderView.vitest.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/connectProviderView.vitest.tsx
@@ -44,6 +44,15 @@ const databricks: IPositronLanguageModelSource = {
 	defaults: { baseUrl: 'https://adb-123.7.azuredatabricks.net' },
 };
 
+// Snowflake stores the bare account, not a URL, in baseUrl.
+const snowflake: IPositronLanguageModelSource = {
+	type: PositronLanguageModelType.Chat,
+	provider: { id: 'snowflake-cortex', displayName: 'Snowflake' },
+	supportedOptions: ['apiKey', 'baseUrl'],
+	signedIn: false,
+	defaults: { baseUrl: 'myorg-account1' },
+};
+
 const custom: IPositronLanguageModelSource = {
 	type: PositronLanguageModelType.Chat,
 	provider: { id: 'openai-compatible', displayName: 'Custom Provider', settingName: 'openai-compatible' },
@@ -158,6 +167,12 @@ describe('ConnectProviderView', () => {
 	it('labels the Databricks base URL input as the workspace URL', () => {
 		rtl.render(<ConnectProviderView source={databricks} onAction={async () => { }} onBack={vi.fn()} onClose={vi.fn()} />);
 		expect(screen.getByLabelText('Workspace URL')).toHaveValue('https://adb-123.7.azuredatabricks.net');
+		expect(screen.queryByLabelText('Base URL')).not.toBeInTheDocument();
+	});
+
+	it('labels the Snowflake base URL input as the account identifier', () => {
+		rtl.render(<ConnectProviderView source={snowflake} onAction={async () => { }} onBack={vi.fn()} onClose={vi.fn()} />);
+		expect(screen.getByLabelText('Account Identifier')).toHaveValue('myorg-account1');
 		expect(screen.queryByLabelText('Base URL')).not.toBeInTheDocument();
 	});
 

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/providerFieldLabels.vitest.ts
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/providerFieldLabels.vitest.ts
@@ -12,6 +12,10 @@ describe('getBaseUrlLabel', () => {
 		expect(getBaseUrlLabel('databricks')).toBe('Workspace URL');
 	});
 
+	it('labels the Snowflake base URL as the account identifier', () => {
+		expect(getBaseUrlLabel('snowflake-cortex')).toBe('Account Identifier');
+	});
+
 	it('labels other providers with the generic base URL label', () => {
 		expect(getBaseUrlLabel('anthropic-api')).toBe('Base URL');
 	});


### PR DESCRIPTION
Addresses #15506

The new Configure LLM Providers modal labels Snowflake's second input "Base URL", but Snowflake does not take a URL. It takes a bare account identifier like `myorg-account1`, and Positron derives the Cortex URL from that. A user who follows the label enters a URL and the sign-in cannot succeed. The legacy dialog gets this right today -- it relabels the input "Account Identifier" (#13750).

This PR ports that behavior to the new modal.

A quick primer on `providerFieldLabels.ts`, since it is a small file that is easy to miss:

- It is one function, `getBaseUrlLabel`, mapping a provider id to the label shown for its `baseUrl` field.
- `baseUrl` is a storage slot, not a promise about the contents. Databricks keeps a workspace host in it and derives the serving-endpoints URL; Snowflake keeps an account and derives the Cortex URL.
- The function exists so those providers do not inherit a label that misdescribes what they want. Databricks was the only entry until now.

Both the connect form and the connected detail line read the label through this function, so the one change covers both views. `connectedProviderView.tsx` needed no edit.

Note: the new modal is still behind the hidden `assistant.newProviderModal` switch, so none of this is user-visible yet. It is one of the gaps that has to close before that switch can flip.

### Screenshots

<img width="639" height="529" alt="image" src="https://github.com/user-attachments/assets/bb517c04-8bb6-45b9-a6e4-6b815e7ffa07" />


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

SETUP: run **Preferences: Open User Settings (JSON)** and add `"assistant.newProviderModal": true`. The switch is not in the Settings editor, so it has to be set in JSON.

1. Run **Authentication: Configure Language Model Providers**. -> The **Configure LLM Providers** modal opens on the provider list.
2. Click **Connect** on **Snowflake**. -> The field below the API key is labeled **Account Identifier**. There is no **Base URL** label on this view.
3. Go **Back**, then click **Connect** on **Databricks**. -> That field is still labeled **Workspace URL**.
4. Go **Back**, then click **Connect** on **Anthropic**. -> That field is still labeled **Base URL**.
5. Sign in to Snowflake with a valid account identifier and PAT, then reopen the modal and click **Edit** on Snowflake. -> The connected view lists the value under **Account Identifier**, not **Base URL**.

@:assistant
