### PR TITLE
Open the new provider modal on the preselected provider

### DIFF
--- a/src/vs/workbench/contrib/positronAssistant/browser/configureLLMProvidersModal.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/configureLLMProvidersModal.tsx
@@ -42,12 +42,18 @@ export const showConfigureLLMProvidersModal = (
 	sources: IPositronLanguageModelSource[],
 	onAction: OnAction,
 	onClose: () => void,
-	_options?: IShowLanguageModelConfigOptions,
+	options?: IShowLanguageModelConfigOptions,
 ) => {
 	const renderer = new PositronModalReactRenderer();
 	renderer.render(
 		<div className='configure-llm-providers-modal' data-testid='configure-llm-providers-modal'>
-			<ConfigureLLMProviders renderer={renderer} sources={sources} onAction={onAction} onClose={onClose} />
+			<ConfigureLLMProviders
+				preselectedProviderId={options?.preselectedProviderId}
+				renderer={renderer}
+				sources={sources}
+				onAction={onAction}
+				onClose={onClose}
+			/>
 		</div>
 	);
 };
@@ -55,14 +61,23 @@ export const showConfigureLLMProvidersModal = (
 export interface ConfigureLLMProvidersProps {
 	renderer: PositronModalReactRenderer;
 	sources: IPositronLanguageModelSource[];
+	/** Provider to open on, skipping the list. Ignored if it is not in `sources`. */
+	preselectedProviderId?: string;
 	onAction: OnAction;
 	onClose: () => void;
 }
 
 export const ConfigureLLMProviders = (props: ConfigureLLMProvidersProps) => {
 	const services = usePositronReactServicesContext();
-	const [view, setView] = useState<'list' | 'connect' | 'connected'>('list');
-	const [selectedProviderId, setSelectedProviderId] = useState<string>();
+
+	// The caller can name a provider to open on -- the "Configure" button on a
+	// provider error notification does, so the user lands on the provider that
+	// reported the problem rather than hunting for it in the list.
+	const preselectedSource = props.sources.find(s => s.provider.id === props.preselectedProviderId);
+	const [view, setView] = useState<'list' | 'connect' | 'connected'>(
+		preselectedSource ? selectProviderView(preselectedSource) : 'list'
+	);
+	const [selectedProviderId, setSelectedProviderId] = useState<string | undefined>(preselectedSource?.provider.id);
 
 	// Live copy of the provider sources. The modal outlives every view, so this
 	// single subscription can never miss an update, and the child views can stay

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/configureLLMProvidersModal.vitest.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/configureLLMProvidersModal.vitest.tsx
@@ -55,9 +55,10 @@ describe('ConfigureLLMProviders', () => {
 		});
 	}
 
-	function renderModal(sources: IPositronLanguageModelSource[]) {
+	function renderModal(sources: IPositronLanguageModelSource[], preselectedProviderId?: string) {
 		return rtl.render(
 			<ConfigureLLMProviders
+				preselectedProviderId={preselectedProviderId}
 				renderer={makeRenderer()}
 				sources={sources}
 				onAction={async () => { }}
@@ -68,6 +69,29 @@ describe('ConfigureLLMProviders', () => {
 
 	it('opens on the provider list', () => {
 		renderModal([anthropic]);
+		expect(screen.getByText('Model Providers')).toBeInTheDocument();
+	});
+
+	it('opens on the connect view for a preselected signed-out provider', () => {
+		renderModal([anthropic, positAi], 'anthropic-api');
+		expect(screen.getByLabelText(/api key/i)).toBeInTheDocument();
+		expect(screen.queryByText('Model Providers')).not.toBeInTheDocument();
+	});
+
+	it('opens on the connected view for a preselected signed-in provider', () => {
+		renderModal([anthropic, { ...positAi, signedIn: true, status: 'ok' as const }], 'posit-ai');
+		expect(screen.getByText(/connected via oauth/i)).toBeInTheDocument();
+	});
+
+	it('opens on the list when the preselected provider is not in the sources', () => {
+		renderModal([anthropic], 'not-a-provider');
+		expect(screen.getByText('Model Providers')).toBeInTheDocument();
+	});
+
+	it('returns to the list from a preselected provider', async () => {
+		const user = userEvent.setup();
+		renderModal([anthropic, positAi], 'anthropic-api');
+		await user.click(screen.getByRole('button', { name: /back/i }));
 		expect(screen.getByText('Model Providers')).toBeInTheDocument();
 	});
 


### PR DESCRIPTION
Addresses #14818

When a provider reports a problem with its configuration or credentials, Positron shows a notification with a **Configure** button. That button passes the provider's id along so the dialog can open on the provider that broke. The legacy dialog reads it and scrolls that provider into view.

The new Configure LLM Providers modal took the same options object and dropped it -- the parameter was named `_options` and never read. You land on the full provider list and have to find the broken provider yourself, which is a step backwards on the exact path a failing provider sends people down.

This PR makes the modal honor `preselectedProviderId`. It opens on that provider's detail view and picks connect or connected with the same `selectProviderView` a click in the list uses, so a signed-out provider gets the sign-in form and a signed-in one gets its detail view. **Back** returns to the list as usual, so nothing else about the navigation changes.

If the id is not in `sources` the modal opens on the list. That is not just defensive -- the notification captures the id when the error fires, and the provider can be disabled in providers.json before the user gets around to clicking **Configure**.

This does not change where the legacy dialog scrolls to, and it does not touch the notification itself.

Note: the new modal is still behind the hidden `assistant.newProviderModal` switch, so this is not user-visible yet. It is one of the gaps that has to close before that switch can flip.

### Screenshots

The command palette cannot pass arguments, so a keybinding is the only way to drive `preselectedProviderId` from the UI the way the provider error notification does. 

Add via `Preferences: Open Keyboard Shortcuts (JSON)`.
```
{
      "key": "ctrl+alt+0",
      "command": "authentication.configureProviders"
},
{
      "key": "ctrl+alt+1",
      "command": "authentication.configureProviders",
      "args": { "preselectedProviderId": "openai-api" }
},
{
      "key": "ctrl+alt+2",
      "command": "authentication.configureProviders",
      "args": { "preselectedProviderId": "anthropic-api" }
},
{
      "key": "ctrl+alt+3",
      "command": "authentication.configureProviders",
      "args": { "preselectedProviderId": "not-a-provider" }
}
```


https://github.com/user-attachments/assets/adc18d3b-6f9c-4487-bb9a-9cb3cc7138e0



### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

SETUP:

- Run **Preferences: Open User Settings (JSON)** and add `"assistant.newProviderModal": true`. The switch is not in the Settings editor, so it has to be set in JSON.
- Add the four keybindings above via **Preferences: Open Keyboard Shortcuts (JSON)**.
- Start Positron with `ANTHROPIC_API_KEY` set and `OPENAI_API_KEY` unset, so Anthropic starts connected and OpenAI starts disconnected. To use different providers, swap their ids into the bindings.

**No argument opens the provider list**

1. Press `ctrl+alt+0`. -> **Configure LLM Providers** opens on the provider list, with Anthropic under **Connected Providers**. Close it.

**A preselected disconnected provider opens on its connect form**

2. Press `ctrl+alt+1`. -> The modal opens titled **Connect to OpenAI**, showing the **API Key** and **Base URL** fields. It does _not_ open on the provider list.
3. Click **Back**. -> The provider list appears. Navigating away from a preselected provider behaves the same as if you had clicked into it from the list. Close the modal.

**A preselected connected provider opens on its detail view**

4. Press `ctrl+alt+2`. -> The modal opens on Anthropic's detail view reading **Connected via ANTHROPIC_API_KEY**, not the sign-in form. Close it.

**An unknown id falls back to the list**

5. Press `ctrl+alt+3`. -> The modal opens on the provider list rather than on a blank or broken view.

@:assistant

