### PR TITLE
Pin the assistant sign-in suites to their dialog at launch

### DIFF
--- a/test/e2e/fixtures/test-setup/app-jupyter.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/app-jupyter.fixtures.ts
@@ -20,7 +20,7 @@ export { RunResult };
 export async function JupyterApp(
 	fixtureOptions: AppFixtureOptions
 ): Promise<{ app: Application; start: () => Promise<void>; stop: () => Promise<void> }> {
-	const { options, useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant } = fixtureOptions;
+	const { options, useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant, extraSettings } = fixtureOptions;
 	const JUPYTER_WORKSPACE_PATH = '/home/jupyter-admin/test-files/';
 
 	const app = createApp({ ...options, workspacePath: JUPYTER_WORKSPACE_PATH });
@@ -32,7 +32,7 @@ export async function JupyterApp(
 		await app.positJupyter.auth.signIn();
 
 		// Now that the user exists, setup the environment
-		await setupJupyterEnvironment(useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant);
+		await setupJupyterEnvironment(useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant, extraSettings);
 
 		// Open Positron from JupyterLab
 		await app.positJupyter.lab.openPositron();
@@ -116,7 +116,7 @@ export async function JupyterApp(
  * Setup the complete Jupyter environment: Docker container, configuration, and permissions
  * NOTE: This must be called AFTER login, as login creates the jupyter-admin user
  */
-async function setupJupyterEnvironment(useLegacyNotebookEditor?: boolean, enableDataConnections?: boolean, enableFoundryAssistant?: boolean): Promise<void> {
+async function setupJupyterEnvironment(useLegacyNotebookEditor?: boolean, enableDataConnections?: boolean, enableFoundryAssistant?: boolean, extraSettings?: Record<string, unknown>): Promise<void> {
 	const TEST_DATA_PATH = join(os.tmpdir(), 'vscsmoke');
 	const DEFAULT_WORKSPACE_PATH = join(TEST_DATA_PATH, 'test-files');
 	const JUPYTER_WORKSPACE_PATH = '/home/jupyter-admin/test-files/';
@@ -152,7 +152,7 @@ async function setupJupyterEnvironment(useLegacyNotebookEditor?: boolean, enable
 		'jupyter-test',
 		'/home/jupyter-admin/.positron-server/data/User/',
 		['settings.json', 'settingsDocker.json', 'settingsWorkbench.json'],
-		dockerSettingsOverrides({ useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant })
+		dockerSettingsOverrides({ useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant, extraSettings })
 	);
 	await copyKeyBindingsToContainer('jupyter-test', '/home/jupyter-admin/.positron-server/data/User/');
 

--- a/test/e2e/fixtures/test-setup/app-workbench.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/app-workbench.fixtures.ts
@@ -23,8 +23,8 @@ const CONTAINER_NAME = 'test';
 export async function WorkbenchApp(
 	fixtureOptions: AppFixtureOptions
 ): Promise<{ app: Application; start: () => Promise<void>; stop: () => Promise<void> }> {
-	const { options, managedCredentials, useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant } = fixtureOptions;
-	const { workspacePath } = await setupWorkbenchEnvironment(managedCredentials, useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant);
+	const { options, managedCredentials, useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant, extraSettings } = fixtureOptions;
+	const { workspacePath } = await setupWorkbenchEnvironment(managedCredentials, useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant, extraSettings);
 
 	const app = createApp({ ...options, workspacePath });
 
@@ -65,7 +65,7 @@ export async function WorkbenchApp(
 			await provisionUserSettings(
 				'/home/rstudio-ide-test/.positron-server/',
 				'rstudio-ide-test',
-				dockerSettingsOverrides({ useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant })
+				dockerSettingsOverrides({ useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant, extraSettings })
 			);
 			await app.positWorkbench.dashboard.openWorkspaceFolder('test-files');
 		}
@@ -108,7 +108,7 @@ export async function WorkbenchApp(
  * the CI install step. The actual credential setup happens in install-workbench.sh; the fixture
  * just records it here so tests/fixtures can make conditional decisions if needed.
  */
-async function setupWorkbenchEnvironment(managedCredentials?: 'snowflake' | 'databricks' | 'azure', useLegacyNotebookEditor?: boolean, enableDataConnections?: boolean, enableFoundryAssistant?: boolean): Promise<{ workspacePath: string; userDataDir: string }> {
+async function setupWorkbenchEnvironment(managedCredentials?: 'snowflake' | 'databricks' | 'azure', useLegacyNotebookEditor?: boolean, enableDataConnections?: boolean, enableFoundryAssistant?: boolean, extraSettings?: Record<string, unknown>): Promise<{ workspacePath: string; userDataDir: string }> {
 	if (managedCredentials) {
 		console.log(`Workbench fixture: expecting managed credential "${managedCredentials}" to be provisioned in the container`);
 	}
@@ -153,7 +153,7 @@ async function setupWorkbenchEnvironment(managedCredentials?: 'snowflake' | 'dat
 	await provisionUserSettings(
 		WORKBENCH_USER_SERVER_DIR,
 		'user1:user1g',
-		dockerSettingsOverrides({ useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant })
+		dockerSettingsOverrides({ useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant, extraSettings })
 	);
 
 	// Fix workspace permissions

--- a/test/e2e/fixtures/test-setup/app.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/app.fixtures.ts
@@ -38,6 +38,7 @@ export interface AppFixtureOptions {
 	 * settings into the container settings.
 	 */
 	enableFoundryAssistant?: boolean;
+	extraSettings?: Record<string, unknown>;
 }
 
 /**

--- a/test/e2e/fixtures/test-setup/docker-utils.ts
+++ b/test/e2e/fixtures/test-setup/docker-utils.ts
@@ -87,7 +87,7 @@ export const FOUNDRY_ASSISTANT_SETTINGS = {
  * suite opts into the Foundry assistant, its settings are merged in. Returns
  * `undefined` when there is nothing to override.
  */
-export function dockerSettingsOverrides(opts: { useLegacyNotebookEditor?: boolean; enableDataConnections?: boolean; enableFoundryAssistant?: boolean }): object | undefined {
+export function dockerSettingsOverrides(opts: { useLegacyNotebookEditor?: boolean; enableDataConnections?: boolean; enableFoundryAssistant?: boolean; extraSettings?: Record<string, unknown> }): object | undefined {
 	const overrides: Record<string, unknown> = {};
 	if (opts.useLegacyNotebookEditor) {
 		overrides['positron.notebook.enabled'] = false;
@@ -97,6 +97,10 @@ export function dockerSettingsOverrides(opts: { useLegacyNotebookEditor?: boolea
 	}
 	if (opts.enableFoundryAssistant) {
 		Object.assign(overrides, FOUNDRY_ASSISTANT_SETTINGS);
+	}
+	// Merged last so a suite's own settings win over the options above.
+	if (opts.extraSettings) {
+		Object.assign(overrides, opts.extraSettings);
 	}
 	return Object.keys(overrides).length > 0 ? overrides : undefined;
 }

--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -60,6 +60,13 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 	// `test.use({ extraEnv: { ANTHROPIC_API_KEY: undefined } })`.
 	extraEnv: [{}, { scope: 'worker', option: true }],
 
+	// Extra user settings written before the app starts, so no window reload is
+	// needed for them to take effect. Opt in with
+	// `test.use({ extraSettings: { 'assistant.newProviderModal': false } })`.
+	// Applies to the Docker apps too: they read settings from inside the container,
+	// so a suite cannot set these at runtime (see dockerSettingsOverrides).
+	extraSettings: [{}, { scope: 'worker', option: true }],
+
 	envVars: [async ({ }, use, workerInfo) => {
 		const projectName = workerInfo.project.name;
 
@@ -126,7 +133,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 	// placeholder for area-specific fixtures that need to run before app starts
 	// e.g. changing settings that require an app reload
 	beforeApp: [
-		async ({ useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant, settingsFile }, use) => {
+		async ({ useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant, extraSettings, settingsFile }, use) => {
 			if (useLegacyNotebookEditor) {
 				// These tests exercise the legacy (VS Code) notebook editor. The
 				// Positron notebook editor is now the default, so disable it before
@@ -151,17 +158,22 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 				await settingsFile.append({ ...FOUNDRY_ASSISTANT_SETTINGS });
 			}
 
+			// Merged last so a suite's own settings win over the options above.
+			if (Object.keys(extraSettings).length > 0) {
+				await settingsFile.append({ ...extraSettings });
+			}
+
 			await use();
 		},
 		{ scope: 'worker' }],
 
-	app: [async ({ options, logsPath, logger, managedCredentials, useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant, extraEnv, beforeApp: _beforeApp }, use, workerInfo) => {
+	app: [async ({ options, logsPath, logger, managedCredentials, useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant, extraEnv, extraSettings, beforeApp: _beforeApp }, use, workerInfo) => {
 		// Merge any suite-provided extraEnv onto the launch options (undefined values
 		// unset a variable for the launched app; see the `extraEnv` option above).
 		const appOptions = Object.keys(extraEnv).length > 0
 			? { ...options, extraEnv: { ...options.extraEnv, ...extraEnv } }
 			: options;
-		const { app, start, stop } = await AppFixture({ options: appOptions, logsPath, logger, workerInfo, managedCredentials, useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant });
+		const { app, start, stop } = await AppFixture({ options: appOptions, logsPath, logger, workerInfo, managedCredentials, useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant, extraSettings });
 
 		// Track the app so afterAll can export the startup trace if setup hangs (times
 		// out) -- in that case this fixture's catch/finally never run. Cleared below.
@@ -651,6 +663,7 @@ export interface WorkerFixtures {
 	enableDataConnections: boolean;
 	enableFoundryAssistant: boolean;
 	extraEnv: Record<string, string | undefined>;
+	extraSettings: Record<string, unknown>;
 	envVars: string;
 	snapshots: boolean;
 	artifactDir: string;

--- a/test/e2e/tests/notebooks-positron/_test.setup.ts
+++ b/test/e2e/tests/notebooks-positron/_test.setup.ts
@@ -10,13 +10,13 @@ interface NotebooksPositronTestFixtures extends TestFixtures {
 
 interface NotebooksPositronWorkerFixtures extends WorkerFixtures {
 	enablePositronNotebooks: boolean;
-	extraSettings: Record<string, unknown> | undefined;
 }
 
 export const test = base.extend<NotebooksPositronTestFixtures, NotebooksPositronWorkerFixtures>({
 	enablePositronNotebooks: [true, { scope: 'worker', option: true }],
-	extraSettings: [undefined, { scope: 'worker', option: true }],
 
+	// This overrides the shared beforeApp rather than running after it, so the
+	// `extraSettings` handling has to be repeated here.
 	beforeApp: [
 		async ({ enablePositronNotebooks, extraSettings, settingsFile }, use) => {
 			if (enablePositronNotebooks) {
@@ -24,10 +24,9 @@ export const test = base.extend<NotebooksPositronTestFixtures, NotebooksPositron
 				// to avoid waiting for a window reload
 				await settingsFile.append({ 'positron.notebook.enabled': true });
 			}
-			if (extraSettings) {
-				// Suite-specific settings applied before launch (opt in with
-				// `test.use({ extraSettings: { ... } })`) to avoid a window reload.
-				await settingsFile.append(extraSettings);
+			// Merged last so a suite's own settings win.
+			if (Object.keys(extraSettings).length > 0) {
+				await settingsFile.append({ ...extraSettings });
 			}
 
 			await use();

--- a/test/e2e/tests/posit-assistant/posit-assistant-signin-new-modal.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant-signin-new-modal.test.ts
@@ -17,6 +17,14 @@ test.use({
 	// Written into user settings before the app starts. Setting this from a
 	// beforeAll instead leaves the first test racing the config reload, which it
 	// loses often enough to fail under CI load.
+	//
+	// Whatever goes wrong with settings here, do not reach for a window reload. A
+	// restarted extension host re-probes the cloud credential-chain metadata
+	// endpoints (AWS/Azure IMDS, metadata.google.internal). Those are unreachable
+	// from the test container and hang, starving DNS for api.anthropic.com and
+	// api.openai.com. Provider key validation then aborts on its own budget
+	// (KEY_VALIDATION_TIMEOUT_MS in extensions/authentication/src/constants.ts) and
+	// the modal never reaches the Connected view.
 	extraSettings: { 'assistant.newProviderModal': true },
 });
 

--- a/test/e2e/tests/posit-assistant/posit-assistant-signin-new-modal.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant-signin-new-modal.test.ts
@@ -14,9 +14,11 @@ test.use({
 	// AWS Bedrock keeps its environment credential chain (it has no key to type and
 	// authenticates from the environment by design).
 	extraEnv: { ANTHROPIC_API_KEY: undefined, OPENAI_API_KEY: undefined },
+	// Written into user settings before the app starts. Setting this from a
+	// beforeAll instead leaves the first test racing the config reload, which it
+	// loses often enough to fail under CI load.
+	extraSettings: { 'assistant.newProviderModal': true },
 });
-
-const NEW_PROVIDER_MODAL_KEY = 'assistant.newProviderModal';
 
 const POSIT_ASSISTANT_SIGNIN_PROVIDERS: ModelProvider[] = [
 	'anthropic-api',
@@ -31,22 +33,6 @@ const POSIT_ASSISTANT_SIGNIN_PROVIDERS: ModelProvider[] = [
 test.describe('Posit Assistant Sign-in (new provider modal)', {
 	tag: [tags.ASSISTANT, tags.WEB, tags.WIN],
 }, () => {
-
-	test.beforeAll('Enable the new provider modal', async function ({ settings }) {
-		// Deliberately no reload: the switch is read live every time the Configure
-		// Providers command runs, so the setting takes effect without one. Reloading
-		// also broke this suite in CI -- the restarted extension host re-probes the
-		// cloud credential-chain metadata endpoints (AWS/Azure IMDS,
-		// metadata.google.internal), which are unreachable in the test container and
-		// hang. Those pending lookups starve DNS for api.anthropic.com /
-		// api.openai.com, so the provider key validation aborted on its fixed 5s
-		// budget and the modal never reached the Connected view.
-		await settings.set({ [NEW_PROVIDER_MODAL_KEY]: true });
-	});
-
-	test.afterAll('Disable the new provider modal', async function ({ settings }) {
-		await settings.remove([NEW_PROVIDER_MODAL_KEY]);
-	});
 
 	for (const provider of POSIT_ASSISTANT_SIGNIN_PROVIDERS) {
 		test(`${provider} - Sign in, send hello, sign out`, async function ({ app }) {

--- a/test/e2e/tests/posit-assistant/posit-assistant-signin.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant-signin.test.ts
@@ -4,10 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { test, tags } from '../_test.setup';
-import { ModelProvider } from '../../pages/modelProviderAuth';
+import { ModelProvider } from '../../pages/modelProviderShared';
 
 test.use({
-	suiteId: __filename
+	suiteId: __filename,
+	// This suite covers the legacy provider dialog. Its new-modal counterpart is
+	// posit-assistant-signin-new-modal. Delete this file, and the pin, when the
+	// legacy dialog is removed.
+	extraSettings: { 'assistant.newProviderModal': false },
 });
 
 const POSIT_ASSISTANT_SIGNIN_PROVIDERS: ModelProvider[] = [


### PR DESCRIPTION
The e2e tests added in #15109 failed on the merge to main: `anthropic-api - Sign in, send hello, sign out` timed out waiting for the new provider modal, on both attempts. https://github.com/posit-dev/positron/actions/runs/31752172999

The failure screenshot shows the _legacy_ provider dialog on screen instead. The suite turned the new modal on from a `test.beforeAll` that calls `settings.set`, which writes user settings, saves the file in the editor, and then waits a fixed 3 seconds. Nothing waits for the workbench to actually apply the value. The trace has the first test pressing the Configure Providers chord 3.44s after the save, with `positronAssistantService` still reading `assistant.newProviderModal` as not-`true`. Only the first test in the file failed -- the four after it passed, because by then the config had caught up.

It was already failing this way on the PR, where the retry rescued it and Playwright reported it as flaky. Merges run the full suite instead of a tag-filtered subset, so each shard carried roughly 3x the tests on the same 2 workers, and the retry ran out of margin.

This PR moves the pin into a shared `extraSettings` worker option, which writes user settings before the app starts, so there is no window to lose. Where that lands:

- `_test.setup.ts` -- the `beforeApp` worker fixture appends `extraSettings` to the settings file, merged last so a suite's own settings win over `useLegacyNotebookEditor` and the other options
- `docker-utils.ts` -- the Docker apps read settings from inside the container, so a suite _cannot_ set them at runtime; `dockerSettingsOverrides` now carries `extraSettings` through
- `notebooks-positron/_test.setup.ts` -- had already grown its own `extraSettings`; that copy is now the shared one

`posit-assistant-signin.test.ts` pins the legacy dialog for the same reason. The pair should each say which dialog it covers rather than inherit whatever the default is, which starts to matter once the modal becomes the default.

Note: this does not touch the other failure in that run. `amazon-bedrock` failed on Windows because Bedrock rejected the QA role's request signature (`The request signature we calculated does not match the signature you provided`), so `ListFoundationModels` returned 0 models and the assistant panel sat in its empty state. That is an AWS problem rather than a test one, and it is being followed up separately. It surfaced as an intercepted click 5 seconds later rather than as "0 models" because `waitForReady()` does not check that a model is available -- worth fixing, but not here.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### Validation Steps

@:assistant @:positron-notebooks

Test-only change, so CI is the validation.

1. Wait for the `e2e / electron`, `e2e / chromium` and `e2e / electron-win` jobs to finish. All five tests in `posit-assistant-signin-new-modal.test.ts` and all four in `posit-assistant-signin.test.ts` should pass.
2. Open each project's Playwright report and check `anthropic-api - Sign in, send hello, sign out` is marked **expected**, not **flaky**. A pass on retry is the exact symptom this PR fixes, so a flaky result here means it is not fixed.
3. Check the notebook suites still pass, since `notebooks-positron/_test.setup.ts` now uses the shared `extraSettings` instead of its own copy. `notebook-output-resize.test.ts` and `notebook-ghost-cell-keyboard-shortcut.test.ts` are the two that set it.
