### PR TITLE
Route Data Explorer RPCs to the extension host that owns the provider

### DIFF
--- a/src/vs/workbench/api/browser/positron/mainThreadDataExplorer.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadDataExplorer.ts
@@ -7,7 +7,7 @@ import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { extHostNamedCustomer, IExtHostContext } from '../../../services/extensions/common/extHostCustomers.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { IPositronDataExplorerService } from '../../../services/positronDataExplorer/browser/interfaces/positronDataExplorerService.js';
-import { IDataExplorerRpcDto, IDataExplorerResponseDto, IDataExplorerRpcTransport, IDataExplorerUiEventDto } from '../../../services/positronDataExplorer/common/dataExplorerRpcTransport.js';
+import { IDataExplorerHostTransport, IDataExplorerRpcDto, IDataExplorerResponseDto, IDataExplorerUiEventDto } from '../../../services/positronDataExplorer/common/dataExplorerRpcTransport.js';
 import { ExtHostDataExplorerShape, ExtHostPositronContext, MainPositronContext, MainThreadDataExplorerShape } from '../../common/positron/extHost.positron.protocol.js';
 
 /**
@@ -20,13 +20,13 @@ function dataExplorerBackendActivationEvent(providerId: string): string {
 }
 
 /**
- * Main thread counterpart to ExtHostDataExplorer. Acts as the {@link IDataExplorerRpcTransport} for
+ * Main thread counterpart to ExtHostDataExplorer. Acts as the {@link IDataExplorerHostTransport} for
  * core Data Explorer backends -- forwarding each RPC over the typed ext-host channel to the
  * providing extension -- and routes the extension's frontend UI events and open requests into the
  * IPositronDataExplorerService. Registers itself as the service's transport for its lifetime.
  */
 @extHostNamedCustomer(MainPositronContext.MainThreadDataExplorer)
-export class MainThreadDataExplorer implements MainThreadDataExplorerShape, IDataExplorerRpcTransport {
+export class MainThreadDataExplorer implements MainThreadDataExplorerShape, IDataExplorerHostTransport {
 
 	private readonly _proxy: ExtHostDataExplorerShape;
 	private readonly _disposables = new DisposableStore();
@@ -41,7 +41,7 @@ export class MainThreadDataExplorer implements MainThreadDataExplorerShape, IDat
 		this._disposables.add(this._dataExplorerService.registerRpcTransport(this));
 	}
 
-	// --- IDataExplorerRpcTransport ---
+	// --- IDataExplorerHostTransport ---
 
 	async activateProvider(providerId: string): Promise<void> {
 		// Backends declare `onPositronDataExplorerBackend:<providerId>` so they stay dormant until a

--- a/src/vs/workbench/api/browser/positron/mainThreadDataExplorer.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadDataExplorer.ts
@@ -5,55 +5,37 @@
 
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { extHostNamedCustomer, IExtHostContext } from '../../../services/extensions/common/extHostCustomers.js';
-import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { IPositronDataExplorerService } from '../../../services/positronDataExplorer/browser/interfaces/positronDataExplorerService.js';
-import { IDataExplorerHostTransport, IDataExplorerRpcDto, IDataExplorerResponseDto, IDataExplorerUiEventDto } from '../../../services/positronDataExplorer/common/dataExplorerRpcTransport.js';
+import { IDataExplorerRpcDto, IDataExplorerResponseDto, IDataExplorerRpcTransport, IDataExplorerUiEventDto } from '../../../services/positronDataExplorer/common/dataExplorerRpcTransport.js';
 import { ExtHostDataExplorerShape, ExtHostPositronContext, MainPositronContext, MainThreadDataExplorerShape } from '../../common/positron/extHost.positron.protocol.js';
 
 /**
- * Activation event a Data Explorer backend extension declares so it activates lazily when a dataset
- * it owns is first accessed, rather than eagerly at startup. The provider id is the suffix, e.g.
- * `onPositronDataExplorerBackend:positron-duckdb`.
- */
-function dataExplorerBackendActivationEvent(providerId: string): string {
-	return `onPositronDataExplorerBackend:${providerId}`;
-}
-
-/**
- * Main thread counterpart to ExtHostDataExplorer. Acts as the {@link IDataExplorerHostTransport} for
- * core Data Explorer backends -- forwarding each RPC over the typed ext-host channel to the
- * providing extension -- and routes the extension's frontend UI events and open requests into the
- * IPositronDataExplorerService. Registers itself as the service's transport for its lifetime.
+ * Main thread counterpart to ExtHostDataExplorer, one per extension host. Acts as this host's
+ * {@link IDataExplorerRpcTransport} for core Data Explorer backends -- forwarding each RPC over the
+ * typed ext-host channel to the providing extension -- routes the extension's frontend UI events and
+ * open requests into the IPositronDataExplorerService, and tells the service which providers this
+ * host owns as their handlers register. The service triggers activation and routes RPCs to the owner.
  */
 @extHostNamedCustomer(MainPositronContext.MainThreadDataExplorer)
-export class MainThreadDataExplorer implements MainThreadDataExplorerShape, IDataExplorerHostTransport {
+export class MainThreadDataExplorer implements MainThreadDataExplorerShape, IDataExplorerRpcTransport {
 
 	private readonly _proxy: ExtHostDataExplorerShape;
 	private readonly _disposables = new DisposableStore();
 
 	constructor(
 		extHostContext: IExtHostContext,
-		@IPositronDataExplorerService private readonly _dataExplorerService: IPositronDataExplorerService,
-		@IExtensionService private readonly _extensionService: IExtensionService
+		@IPositronDataExplorerService private readonly _dataExplorerService: IPositronDataExplorerService
 	) {
 		this._proxy = extHostContext.getProxy(ExtHostPositronContext.ExtHostDataExplorer);
-		// Become the transport core backends use to reach extensions for the ext host's lifetime.
-		this._disposables.add(this._dataExplorerService.registerRpcTransport(this));
+		// Register this host so its provider claims are cleared if the host disconnects.
+		this._disposables.add(this._dataExplorerService.registerRpcHost(this));
 	}
 
-	// --- IDataExplorerHostTransport ---
-
-	async activateProvider(providerId: string): Promise<void> {
-		// Backends declare `onPositronDataExplorerBackend:<providerId>` so they stay dormant until a
-		// dataset they own is accessed. Idempotent, resolves immediately once activated, and a no-op
-		// in hosts the extension isn't installed in.
-		await this._extensionService.activateByEvent(dataExplorerBackendActivationEvent(providerId));
-	}
+	// --- IDataExplorerRpcTransport ---
 
 	handleRpc(providerId: string, rpc: IDataExplorerRpcDto): Promise<IDataExplorerResponseDto> {
-		// The service activates the provider before resolving this transport, so the extension is
-		// already active here; `$handleRpc` additionally waits for the provider to register, covering
-		// the window between activation returning and the handler landing.
+		// The service resolves this transport only once the provider has registered here, so the
+		// extension is already active; `$handleRpc` also waits for the handler as a safety net.
 		return this._proxy.$handleRpc(providerId, rpc);
 	}
 

--- a/src/vs/workbench/api/browser/positron/mainThreadDataExplorer.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadDataExplorer.ts
@@ -31,9 +31,6 @@ export class MainThreadDataExplorer implements MainThreadDataExplorerShape, IDat
 	private readonly _proxy: ExtHostDataExplorerShape;
 	private readonly _disposables = new DisposableStore();
 
-	/** Provider ids that have registered an RPC handler in the ext host (informational). */
-	private readonly _providers = new Set<string>();
-
 	constructor(
 		extHostContext: IExtHostContext,
 		@IPositronDataExplorerService private readonly _dataExplorerService: IPositronDataExplorerService,
@@ -46,12 +43,17 @@ export class MainThreadDataExplorer implements MainThreadDataExplorerShape, IDat
 
 	// --- IDataExplorerRpcTransport ---
 
-	async handleRpc(providerId: string, rpc: IDataExplorerRpcDto): Promise<IDataExplorerResponseDto> {
-		// Activate the providing extension if it hasn't been already: backends declare
-		// `onPositronDataExplorerBackend:<providerId>` so they stay dormant until a dataset they own
-		// is accessed. Idempotent and resolves immediately once activated. `$handleRpc` additionally
-		// waits for the provider to register, covering the activation window.
+	async activateProvider(providerId: string): Promise<void> {
+		// Backends declare `onPositronDataExplorerBackend:<providerId>` so they stay dormant until a
+		// dataset they own is accessed. Idempotent, resolves immediately once activated, and a no-op
+		// in hosts the extension isn't installed in.
 		await this._extensionService.activateByEvent(dataExplorerBackendActivationEvent(providerId));
+	}
+
+	handleRpc(providerId: string, rpc: IDataExplorerRpcDto): Promise<IDataExplorerResponseDto> {
+		// The service activates the provider before resolving this transport, so the extension is
+		// already active here; `$handleRpc` additionally waits for the provider to register, covering
+		// the window between activation returning and the handler landing.
 		return this._proxy.$handleRpc(providerId, rpc);
 	}
 
@@ -62,11 +64,13 @@ export class MainThreadDataExplorer implements MainThreadDataExplorerShape, IDat
 	// --- MainThreadDataExplorerShape (called by the ext host) ---
 
 	$registerRpcHandler(providerId: string): void {
-		this._providers.add(providerId);
+		// Tells the service this host is the one that can service the provider's RPCs. In web there
+		// are two hosts and only one of them has the extension, so this is what routes correctly.
+		this._dataExplorerService.registerRpcProvider(providerId, this);
 	}
 
 	$unregisterRpcHandler(providerId: string): void {
-		this._providers.delete(providerId);
+		this._dataExplorerService.unregisterRpcProvider(providerId, this);
 	}
 
 	$sendUiEvent(event: IDataExplorerUiEventDto): void {

--- a/src/vs/workbench/api/test/browser/positron/mainThreadDataExplorerRouting.vitest.ts
+++ b/src/vs/workbench/api/test/browser/positron/mainThreadDataExplorerRouting.vitest.ts
@@ -182,7 +182,7 @@ describe('Data Explorer RPC transport routing', () => {
 	it('re-routes to a new host after the host that owned the provider disconnects', async () => {
 		// A remote host that goes away must take its provider claim with it, or RPCs keep going to a
 		// disposed transport once the host reconnects.
-		const staleHost = createExtensionHost([DUCKDB_DATA_EXPLORER_PROVIDER_ID]);
+		const staleHost = createExtensionHost();
 		staleHost.mainThread.$registerRpcHandler(DUCKDB_DATA_EXPLORER_PROVIDER_ID);
 		staleHost.mainThread.dispose();
 		const reconnectedHost = createExtensionHost([DUCKDB_DATA_EXPLORER_PROVIDER_ID]);

--- a/src/vs/workbench/api/test/browser/positron/mainThreadDataExplorerRouting.vitest.ts
+++ b/src/vs/workbench/api/test/browser/positron/mainThreadDataExplorerRouting.vitest.ts
@@ -1,0 +1,171 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { Event } from '../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { PositronReactServices } from '../../../../../base/browser/positronReactServices.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { MainThreadDataExplorer } from '../../../browser/positron/mainThreadDataExplorer.js';
+import { ExtHostDataExplorerShape } from '../../../common/positron/extHost.positron.protocol.js';
+import { IExtHostContext } from '../../../../services/extensions/common/extHostCustomers.js';
+import { IExtensionService } from '../../../../services/extensions/common/extensions.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
+import { IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
+import { BackendState, DataExplorerBackendRequest, SupportedFeatures, SupportStatus } from '../../../../services/languageRuntime/common/positronDataExplorerComm.js';
+import { IDataExplorerRpcDto } from '../../../../services/positronDataExplorer/common/dataExplorerRpcTransport.js';
+import { DUCKDB_DATA_EXPLORER_PROVIDER_ID } from '../../../../services/positronDataExplorer/common/positronDataExplorerDuckDBBackend.js';
+import { PositronDataExplorerService } from '../../../../services/positronDataExplorer/browser/positronDataExplorerService.js';
+
+/**
+ * In the web workbench there are two extension hosts -- the browser web-worker host and the remote
+ * server host -- so `MainThreadDataExplorer` (an `@extHostNamedCustomer`) is instantiated twice.
+ * Native backends like positron-duckdb can only run in the remote host, so RPCs must reach the host
+ * that registered the provider rather than whichever host connected most recently.
+ */
+/** Everything unsupported; this test exercises routing, not grid features. */
+const NO_FEATURES: SupportedFeatures = {
+	search_schema: { support_status: SupportStatus.Unsupported, supported_types: [] },
+	set_column_filters: { support_status: SupportStatus.Unsupported, supported_types: [] },
+	set_row_filters: { support_status: SupportStatus.Unsupported, supports_conditions: SupportStatus.Unsupported, supported_types: [] },
+	get_column_profiles: { support_status: SupportStatus.Unsupported, supported_types: [] },
+	set_sort_columns: { support_status: SupportStatus.Unsupported },
+	export_data_selection: { support_status: SupportStatus.Unsupported, supported_formats: [] },
+	convert_to_code: { support_status: SupportStatus.Unsupported },
+};
+
+describe('Data Explorer RPC transport routing', () => {
+	const ctx = createTestContainer()
+		.withReactServices()
+		.stub(IConfigurationService, new TestConfigurationService())
+		.stub(IEditorService, { openEditor: vi.fn().mockResolvedValue(undefined) })
+		.stub(IRuntimeSessionService, {
+			activeSessions: [],
+			onWillStartSession: Event.None,
+			onDidStartRuntime: Event.None,
+			onDidFailStartRuntime: Event.None,
+			onDidChangeRuntimeState: Event.None,
+		})
+		.build();
+
+	let store: DisposableStore;
+	let service: PositronDataExplorerService;
+
+	beforeEach(() => {
+		// PositronDataExplorerInstance reads the singleton in its constructor.
+		PositronReactServices.services = ctx.reactServices;
+		store = new DisposableStore();
+		service = store.add(ctx.instantiationService.createInstance(PositronDataExplorerService));
+	});
+
+	afterEach(() => {
+		store.dispose();
+	});
+
+	/** A minimal backend state, enough for the grid instances the open path spins up. */
+	const backendState = (): BackendState => ({
+		display_name: 'small_file.csv',
+		table_shape: { num_rows: 0, num_columns: 0 },
+		table_unfiltered_shape: { num_rows: 0, num_columns: 0 },
+		has_row_labels: false,
+		column_filters: [],
+		row_filters: [],
+		sort_keys: [],
+		supported_features: NO_FEATURES,
+	});
+
+	/**
+	 * Stands up one extension host's MainThreadDataExplorer over the service, recording its RPCs.
+	 * @param providers Provider ids whose extensions are installed in this host; each registers its
+	 * RPC handler when activated, as the real backends do.
+	 */
+	function createExtensionHost(providers: readonly string[] = []) {
+		const calls: Array<{ providerId: string; rpc: IDataExplorerRpcDto }> = [];
+		const proxy = stubInterface<ExtHostDataExplorerShape>({
+			$handleRpc: (providerId: string, rpc: IDataExplorerRpcDto) => {
+				calls.push({ providerId, rpc });
+				return Promise.resolve({
+					result: rpc.method === DataExplorerBackendRequest.GetState ? backendState() : {}
+				});
+			},
+			$disposeBackend: () => { },
+		});
+		const extHostContext = stubInterface<IExtHostContext>({
+			getProxy: (<T>() => proxy as T) as IExtHostContext['getProxy'],
+		});
+		// The activation stub reaches back into the customer it belongs to, which doesn't exist yet.
+		const host: { mainThread?: MainThreadDataExplorer } = {};
+		const extensionService = stubInterface<IExtensionService>({
+			activateByEvent: (event: string) => {
+				// Activating a backend extension registers its RPC handler; a host that doesn't have the
+				// extension installed just resolves.
+				const providerId = providers.find(p => event === `onPositronDataExplorerBackend:${p}`);
+				if (providerId) {
+					host.mainThread?.$registerRpcHandler(providerId);
+				}
+				return Promise.resolve();
+			},
+		});
+		host.mainThread = store.add(new MainThreadDataExplorer(extHostContext, service, extensionService));
+		return { mainThread: host.mainThread, calls };
+	}
+
+	it('sends RPCs to the host that registered the provider, not the host that connected last', async () => {
+		// The remote host owns positron-duckdb; the web-worker host connects afterwards and never
+		// registers it, so it can never service a DuckDB RPC.
+		const remoteHost = createExtensionHost();
+		remoteHost.mainThread.$registerRpcHandler(DUCKDB_DATA_EXPLORER_PROVIDER_ID);
+		const webWorkerHost = createExtensionHost();
+
+		await service.openWithDuckDB(URI.file('/tmp/small_file.csv'));
+
+		// The backend's bootstrap `open_dataset` is dispatched asynchronously; wait for it to land on
+		// one of the hosts before asserting which one.
+		await vi.waitFor(() => expect(remoteHost.calls.length + webWorkerHost.calls.length).toBeGreaterThan(0));
+
+		expect({
+			remoteFirstCall: remoteHost.calls[0]?.rpc.method,
+			remoteProviderId: remoteHost.calls[0]?.providerId,
+			webWorkerCallCount: webWorkerHost.calls.length,
+		}).toEqual({
+			remoteFirstCall: DataExplorerBackendRequest.OpenDataset,
+			remoteProviderId: DUCKDB_DATA_EXPLORER_PROVIDER_ID,
+			webWorkerCallCount: 0,
+		});
+	});
+
+	it('finds the owning host when the provider only registers as it activates', async () => {
+		// The lazy path: nothing has registered when the file is opened, so the owning host is only
+		// identified by activating the provider in every connected host.
+		const remoteHost = createExtensionHost([DUCKDB_DATA_EXPLORER_PROVIDER_ID]);
+		const webWorkerHost = createExtensionHost();
+
+		await service.openWithDuckDB(URI.file('/tmp/small_file.csv'));
+		await vi.waitFor(() => expect(remoteHost.calls.length + webWorkerHost.calls.length).toBeGreaterThan(0));
+
+		expect({
+			remoteFirstCall: remoteHost.calls[0]?.rpc.method,
+			webWorkerCallCount: webWorkerHost.calls.length,
+		}).toEqual({
+			remoteFirstCall: DataExplorerBackendRequest.OpenDataset,
+			webWorkerCallCount: 0,
+		});
+	});
+
+	it('sends RPCs to the only connected host in a single-host workbench', async () => {
+		// Desktop has one extension host, so there is nothing to disambiguate.
+		const host = createExtensionHost([DUCKDB_DATA_EXPLORER_PROVIDER_ID]);
+
+		await service.openWithDuckDB(URI.file('/tmp/small_file.csv'));
+		await vi.waitFor(() => expect(host.calls.length).toBeGreaterThan(0));
+
+		expect(host.calls[0]?.rpc.method).toBe(DataExplorerBackendRequest.OpenDataset);
+	});
+});

--- a/src/vs/workbench/api/test/browser/positron/mainThreadDataExplorerRouting.vitest.ts
+++ b/src/vs/workbench/api/test/browser/positron/mainThreadDataExplorerRouting.vitest.ts
@@ -41,9 +41,31 @@ const NO_FEATURES: SupportedFeatures = {
  * that registered the provider rather than whichever host connected most recently.
  */
 describe('Data Explorer RPC transport routing', () => {
+	// Provider id -> the host whose extension owns it, populated by createExtensionHost, reset per test.
+	const hostsByProvider = new Map<string, { mainThread: MainThreadDataExplorer; deferRegistration: boolean }>();
+
+	// One core extension service shared by every host, as in the real workbench: activateByEvent fans
+	// out to all hosts, and the host that owns the provider registers its handler in response -- either
+	// during activation, or a tick later when the extension awaits work inside activate().
+	const extensionService = stubInterface<IExtensionService>({
+		activateByEvent: async (event: string) => {
+			for (const [providerId, host] of hostsByProvider) {
+				if (event !== `onPositronDataExplorerBackend:${providerId}`) {
+					continue;
+				}
+				if (host.deferRegistration) {
+					void timeout(0).then(() => host.mainThread.$registerRpcHandler(providerId));
+				} else {
+					host.mainThread.$registerRpcHandler(providerId);
+				}
+			}
+		},
+	});
+
 	const ctx = createTestContainer()
 		.withReactServices()
 		.stub(IConfigurationService, new TestConfigurationService())
+		.stub(IExtensionService, extensionService)
 		.stub(IRuntimeSessionService, {
 			activeSessions: [],
 			onWillStartSession: Event.None,
@@ -56,6 +78,7 @@ describe('Data Explorer RPC transport routing', () => {
 	let service: PositronDataExplorerService;
 
 	beforeEach(() => {
+		hostsByProvider.clear();
 		// PositronDataExplorerInstance reads the singleton in its constructor.
 		PositronReactServices.services = ctx.reactServices;
 		service = ctx.disposables.add(ctx.instantiationService.createInstance(PositronDataExplorerService));
@@ -76,7 +99,7 @@ describe('Data Explorer RPC transport routing', () => {
 	/**
 	 * Stands up one extension host's MainThreadDataExplorer over the service, recording its RPCs.
 	 * @param providers Provider ids whose extensions are installed in this host; each registers its
-	 * RPC handler when activated, as the real backends do.
+	 * RPC handler when the shared extension service activates it, as the real backends do.
 	 * @param deferRegistration Register the handler after activation resolves rather than during it,
 	 * as an extension that awaits work inside `activate()` does.
 	 */
@@ -94,29 +117,11 @@ describe('Data Explorer RPC transport routing', () => {
 		const extHostContext = stubInterface<IExtHostContext>({
 			getProxy: (<T>() => proxy as T) as IExtHostContext['getProxy'],
 		});
-		// The activation stub reaches back into the customer it belongs to, which doesn't exist yet.
-		const host: { mainThread?: MainThreadDataExplorer } = {};
-		const registerAfterActivation = async (providerId: string) => {
-			await timeout(0);
-			host.mainThread?.$registerRpcHandler(providerId);
-		};
-		const extensionService = stubInterface<IExtensionService>({
-			activateByEvent: async (event: string) => {
-				// Activating a backend extension registers its RPC handler; a host that doesn't have the
-				// extension installed just resolves.
-				const providerId = providers.find(p => event === `onPositronDataExplorerBackend:${p}`);
-				if (!providerId) {
-					return;
-				}
-				if (deferRegistration) {
-					registerAfterActivation(providerId);
-				} else {
-					host.mainThread?.$registerRpcHandler(providerId);
-				}
-			},
-		});
-		host.mainThread = ctx.disposables.add(new MainThreadDataExplorer(extHostContext, service, extensionService));
-		return { mainThread: host.mainThread, calls };
+		const mainThread = ctx.disposables.add(new MainThreadDataExplorer(extHostContext, service));
+		for (const providerId of providers) {
+			hostsByProvider.set(providerId, { mainThread, deferRegistration });
+		}
+		return { mainThread, calls };
 	}
 
 	it('sends RPCs to the host that registered the provider, not the host that connected last', async () => {

--- a/src/vs/workbench/api/test/browser/positron/mainThreadDataExplorerRouting.vitest.ts
+++ b/src/vs/workbench/api/test/browser/positron/mainThreadDataExplorerRouting.vitest.ts
@@ -7,6 +7,7 @@
 
 import { Event } from '../../../../../base/common/event.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { timeout } from '../../../../../base/common/async.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { PositronReactServices } from '../../../../../base/browser/positronReactServices.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
@@ -24,12 +25,6 @@ import { IDataExplorerRpcDto } from '../../../../services/positronDataExplorer/c
 import { DUCKDB_DATA_EXPLORER_PROVIDER_ID } from '../../../../services/positronDataExplorer/common/positronDataExplorerDuckDBBackend.js';
 import { PositronDataExplorerService } from '../../../../services/positronDataExplorer/browser/positronDataExplorerService.js';
 
-/**
- * In the web workbench there are two extension hosts -- the browser web-worker host and the remote
- * server host -- so `MainThreadDataExplorer` (an `@extHostNamedCustomer`) is instantiated twice.
- * Native backends like positron-duckdb can only run in the remote host, so RPCs must reach the host
- * that registered the provider rather than whichever host connected most recently.
- */
 /** Everything unsupported; this test exercises routing, not grid features. */
 const NO_FEATURES: SupportedFeatures = {
 	search_schema: { support_status: SupportStatus.Unsupported, supported_types: [] },
@@ -41,6 +36,12 @@ const NO_FEATURES: SupportedFeatures = {
 	convert_to_code: { support_status: SupportStatus.Unsupported },
 };
 
+/**
+ * In the web workbench there are two extension hosts -- the browser web-worker host and the remote
+ * server host -- so `MainThreadDataExplorer` (an `@extHostNamedCustomer`) is instantiated twice.
+ * Native backends like positron-duckdb can only run in the remote host, so RPCs must reach the host
+ * that registered the provider rather than whichever host connected most recently.
+ */
 describe('Data Explorer RPC transport routing', () => {
 	const ctx = createTestContainer()
 		.withReactServices()
@@ -85,8 +86,10 @@ describe('Data Explorer RPC transport routing', () => {
 	 * Stands up one extension host's MainThreadDataExplorer over the service, recording its RPCs.
 	 * @param providers Provider ids whose extensions are installed in this host; each registers its
 	 * RPC handler when activated, as the real backends do.
+	 * @param deferRegistration Register the handler after activation resolves rather than during it,
+	 * as an extension that awaits work inside `activate()` does.
 	 */
-	function createExtensionHost(providers: readonly string[] = []) {
+	function createExtensionHost(providers: readonly string[] = [], deferRegistration = false) {
 		const calls: Array<{ providerId: string; rpc: IDataExplorerRpcDto }> = [];
 		const proxy = stubInterface<ExtHostDataExplorerShape>({
 			$handleRpc: (providerId: string, rpc: IDataExplorerRpcDto) => {
@@ -102,15 +105,23 @@ describe('Data Explorer RPC transport routing', () => {
 		});
 		// The activation stub reaches back into the customer it belongs to, which doesn't exist yet.
 		const host: { mainThread?: MainThreadDataExplorer } = {};
+		const registerAfterActivation = async (providerId: string) => {
+			await timeout(0);
+			host.mainThread?.$registerRpcHandler(providerId);
+		};
 		const extensionService = stubInterface<IExtensionService>({
-			activateByEvent: (event: string) => {
+			activateByEvent: async (event: string) => {
 				// Activating a backend extension registers its RPC handler; a host that doesn't have the
 				// extension installed just resolves.
 				const providerId = providers.find(p => event === `onPositronDataExplorerBackend:${p}`);
-				if (providerId) {
+				if (!providerId) {
+					return;
+				}
+				if (deferRegistration) {
+					registerAfterActivation(providerId);
+				} else {
 					host.mainThread?.$registerRpcHandler(providerId);
 				}
-				return Promise.resolve();
 			},
 		});
 		host.mainThread = store.add(new MainThreadDataExplorer(extHostContext, service, extensionService));
@@ -145,6 +156,24 @@ describe('Data Explorer RPC transport routing', () => {
 		// The lazy path: nothing has registered when the file is opened, so the owning host is only
 		// identified by activating the provider in every connected host.
 		const remoteHost = createExtensionHost([DUCKDB_DATA_EXPLORER_PROVIDER_ID]);
+		const webWorkerHost = createExtensionHost();
+
+		await service.openWithDuckDB(URI.file('/tmp/small_file.csv'));
+		await vi.waitFor(() => expect(remoteHost.calls.length + webWorkerHost.calls.length).toBeGreaterThan(0));
+
+		expect({
+			remoteFirstCall: remoteHost.calls[0]?.rpc.method,
+			webWorkerCallCount: webWorkerHost.calls.length,
+		}).toEqual({
+			remoteFirstCall: DataExplorerBackendRequest.OpenDataset,
+			webWorkerCallCount: 0,
+		});
+	});
+
+	it('waits for a registration that lands after activation resolves', async () => {
+		// activateByEvent can resolve before the host's $registerRpcHandler is processed, so a claim
+		// arriving late must still be routed rather than treated as "no host has this provider".
+		const remoteHost = createExtensionHost([DUCKDB_DATA_EXPLORER_PROVIDER_ID], true);
 		const webWorkerHost = createExtensionHost();
 
 		await service.openWithDuckDB(URI.file('/tmp/small_file.csv'));

--- a/src/vs/workbench/api/test/browser/positron/mainThreadDataExplorerRouting.vitest.ts
+++ b/src/vs/workbench/api/test/browser/positron/mainThreadDataExplorerRouting.vitest.ts
@@ -6,7 +6,6 @@
 /// <reference types="vitest/globals" />
 
 import { Event } from '../../../../../base/common/event.js';
-import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { timeout } from '../../../../../base/common/async.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { PositronReactServices } from '../../../../../base/browser/positronReactServices.js';
@@ -18,7 +17,6 @@ import { MainThreadDataExplorer } from '../../../browser/positron/mainThreadData
 import { ExtHostDataExplorerShape } from '../../../common/positron/extHost.positron.protocol.js';
 import { IExtHostContext } from '../../../../services/extensions/common/extHostCustomers.js';
 import { IExtensionService } from '../../../../services/extensions/common/extensions.js';
-import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { BackendState, DataExplorerBackendRequest, SupportedFeatures, SupportStatus } from '../../../../services/languageRuntime/common/positronDataExplorerComm.js';
 import { IDataExplorerRpcDto } from '../../../../services/positronDataExplorer/common/dataExplorerRpcTransport.js';
@@ -46,7 +44,6 @@ describe('Data Explorer RPC transport routing', () => {
 	const ctx = createTestContainer()
 		.withReactServices()
 		.stub(IConfigurationService, new TestConfigurationService())
-		.stub(IEditorService, { openEditor: vi.fn().mockResolvedValue(undefined) })
 		.stub(IRuntimeSessionService, {
 			activeSessions: [],
 			onWillStartSession: Event.None,
@@ -56,18 +53,12 @@ describe('Data Explorer RPC transport routing', () => {
 		})
 		.build();
 
-	let store: DisposableStore;
 	let service: PositronDataExplorerService;
 
 	beforeEach(() => {
 		// PositronDataExplorerInstance reads the singleton in its constructor.
 		PositronReactServices.services = ctx.reactServices;
-		store = new DisposableStore();
-		service = store.add(ctx.instantiationService.createInstance(PositronDataExplorerService));
-	});
-
-	afterEach(() => {
-		store.dispose();
+		service = ctx.disposables.add(ctx.instantiationService.createInstance(PositronDataExplorerService));
 	});
 
 	/** A minimal backend state, enough for the grid instances the open path spins up. */
@@ -124,7 +115,7 @@ describe('Data Explorer RPC transport routing', () => {
 				}
 			},
 		});
-		host.mainThread = store.add(new MainThreadDataExplorer(extHostContext, service, extensionService));
+		host.mainThread = ctx.disposables.add(new MainThreadDataExplorer(extHostContext, service, extensionService));
 		return { mainThread: host.mainThread, calls };
 	}
 
@@ -185,6 +176,26 @@ describe('Data Explorer RPC transport routing', () => {
 		}).toEqual({
 			remoteFirstCall: DataExplorerBackendRequest.OpenDataset,
 			webWorkerCallCount: 0,
+		});
+	});
+
+	it('re-routes to a new host after the host that owned the provider disconnects', async () => {
+		// A remote host that goes away must take its provider claim with it, or RPCs keep going to a
+		// disposed transport once the host reconnects.
+		const staleHost = createExtensionHost([DUCKDB_DATA_EXPLORER_PROVIDER_ID]);
+		staleHost.mainThread.$registerRpcHandler(DUCKDB_DATA_EXPLORER_PROVIDER_ID);
+		staleHost.mainThread.dispose();
+		const reconnectedHost = createExtensionHost([DUCKDB_DATA_EXPLORER_PROVIDER_ID]);
+
+		await service.openWithDuckDB(URI.file('/tmp/small_file.csv'));
+		await vi.waitFor(() => expect(reconnectedHost.calls.length + staleHost.calls.length).toBeGreaterThan(0));
+
+		expect({
+			reconnectedFirstCall: reconnectedHost.calls[0]?.rpc.method,
+			staleCallCount: staleHost.calls.length,
+		}).toEqual({
+			reconnectedFirstCall: DataExplorerBackendRequest.OpenDataset,
+			staleCallCount: 0,
 		});
 	});
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService.ts
@@ -97,11 +97,26 @@ export interface IPositronDataExplorerService {
 
 	/**
 	 * Registers the transport core backends use to reach backend-providing extensions. Called by
-	 * the main-thread Data Explorer channel actor.
+	 * the main-thread Data Explorer channel actor, once per extension host.
 	 * @param transport The transport.
-	 * @returns A disposable that clears the transport.
+	 * @returns A disposable that unregisters the transport and any providers it owns.
 	 */
 	registerRpcTransport(transport: IDataExplorerRpcTransport): IDisposable;
+
+	/**
+	 * Records that a provider's RPC handler registered in `transport`'s extension host, so RPCs for
+	 * that provider are routed there.
+	 * @param providerId The provider id (e.g. 'positron-duckdb').
+	 * @param transport The transport for the host the handler registered in.
+	 */
+	registerRpcProvider(providerId: string, transport: IDataExplorerRpcTransport): void;
+
+	/**
+	 * Undoes {@link registerRpcProvider}. Ignored if another host now owns the provider.
+	 * @param providerId The provider id.
+	 * @param transport The transport that previously registered it.
+	 */
+	unregisterRpcProvider(providerId: string, transport: IDataExplorerRpcTransport): void;
 
 	/**
 	 * Routes a frontend UI event from a backend-providing extension to the matching backend.

--- a/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService.ts
@@ -8,7 +8,7 @@ import { IDisposable } from '../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IPositronDataExplorerInstance } from './positronDataExplorerInstance.js';
-import { IDataExplorerHostTransport, IDataExplorerUiEventDto } from '../../common/dataExplorerRpcTransport.js';
+import { IDataExplorerRpcTransport, IDataExplorerUiEventDto } from '../../common/dataExplorerRpcTransport.js';
 
 // Create the decorator for the Positron data explorer service (used in dependency injection).
 export const IPositronDataExplorerService = createDecorator<IPositronDataExplorerService>('positronDataExplorerService');
@@ -96,12 +96,14 @@ export interface IPositronDataExplorerService {
 	openWithExtensionBackend(payload: OpenExtensionBackendPayload): Promise<void>;
 
 	/**
-	 * Registers the transport core backends use to reach backend-providing extensions. Called by
-	 * the main-thread Data Explorer channel actor, once per extension host.
-	 * @param transport The transport.
-	 * @returns A disposable that unregisters the transport and any providers it owns.
+	 * Ties a host's provider claims to its connection. There is nothing to record up front -- a host
+	 * matters only once it claims a provider via {@link registerRpcProvider} -- so disposing the
+	 * result is the point: it drops any claims still routed to the host, stopping its RPCs when it
+	 * disconnects. Called by the main-thread Data Explorer channel actor, once per extension host.
+	 * @param transport The host's transport.
+	 * @returns A disposable that drops the host's remaining provider claims.
 	 */
-	registerRpcTransport(transport: IDataExplorerHostTransport): IDisposable;
+	registerRpcHost(transport: IDataExplorerRpcTransport): IDisposable;
 
 	/**
 	 * Records that a provider's RPC handler registered in `transport`'s extension host, so RPCs for
@@ -109,14 +111,14 @@ export interface IPositronDataExplorerService {
 	 * @param providerId The provider id (e.g. 'positron-duckdb').
 	 * @param transport The transport for the host the handler registered in.
 	 */
-	registerRpcProvider(providerId: string, transport: IDataExplorerHostTransport): void;
+	registerRpcProvider(providerId: string, transport: IDataExplorerRpcTransport): void;
 
 	/**
 	 * Undoes {@link registerRpcProvider}. Ignored if another host now owns the provider.
 	 * @param providerId The provider id.
 	 * @param transport The transport that previously registered it.
 	 */
-	unregisterRpcProvider(providerId: string, transport: IDataExplorerHostTransport): void;
+	unregisterRpcProvider(providerId: string, transport: IDataExplorerRpcTransport): void;
 
 	/**
 	 * Routes a frontend UI event from a backend-providing extension to the matching backend.

--- a/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService.ts
@@ -8,7 +8,7 @@ import { IDisposable } from '../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IPositronDataExplorerInstance } from './positronDataExplorerInstance.js';
-import { IDataExplorerRpcTransport, IDataExplorerUiEventDto } from '../../common/dataExplorerRpcTransport.js';
+import { IDataExplorerHostTransport, IDataExplorerUiEventDto } from '../../common/dataExplorerRpcTransport.js';
 
 // Create the decorator for the Positron data explorer service (used in dependency injection).
 export const IPositronDataExplorerService = createDecorator<IPositronDataExplorerService>('positronDataExplorerService');
@@ -101,7 +101,7 @@ export interface IPositronDataExplorerService {
 	 * @param transport The transport.
 	 * @returns A disposable that unregisters the transport and any providers it owns.
 	 */
-	registerRpcTransport(transport: IDataExplorerRpcTransport): IDisposable;
+	registerRpcTransport(transport: IDataExplorerHostTransport): IDisposable;
 
 	/**
 	 * Records that a provider's RPC handler registered in `transport`'s extension host, so RPCs for
@@ -109,14 +109,14 @@ export interface IPositronDataExplorerService {
 	 * @param providerId The provider id (e.g. 'positron-duckdb').
 	 * @param transport The transport for the host the handler registered in.
 	 */
-	registerRpcProvider(providerId: string, transport: IDataExplorerRpcTransport): void;
+	registerRpcProvider(providerId: string, transport: IDataExplorerHostTransport): void;
 
 	/**
 	 * Undoes {@link registerRpcProvider}. Ignored if another host now owns the provider.
 	 * @param providerId The provider id.
 	 * @param transport The transport that previously registered it.
 	 */
-	unregisterRpcProvider(providerId: string, transport: IDataExplorerRpcTransport): void;
+	unregisterRpcProvider(providerId: string, transport: IDataExplorerHostTransport): void;
 
 	/**
 	 * Routes a frontend UI event from a backend-providing extension to the matching backend.

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
@@ -128,6 +128,15 @@ class DataExplorerRuntime extends Disposable {
 }
 
 /**
+ * How long to wait for an extension host to claim a provider after activating it. Activation can
+ * resolve before the host's `$registerRpcHandler` message is processed here -- an extension that
+ * awaits work inside `activate()` before registering does exactly that. Mirrors the ext host's own
+ * wait for a handler to register (`extHostDataExplorer`), so a provider that never registers fails
+ * on the same budget it always has.
+ */
+const PROVIDER_REGISTRATION_TIMEOUT_MS = 30_000;
+
+/**
  * PositronDataExplorerService class.
  */
 export class PositronDataExplorerService extends Disposable implements IPositronDataExplorerService {
@@ -173,6 +182,12 @@ export class PositronDataExplorerService extends Disposable implements IPositron
 	 * ever exists in one host (positron-duckdb is native, so it is always the remote one in web).
 	 */
 	private readonly _providerTransports = new Map<string, IDataExplorerRpcTransport>();
+
+	/**
+	 * Fires the provider id whenever a host claims one, so a resolution in flight can pick up a
+	 * registration that lands after activation resolved.
+	 */
+	private readonly _onDidRegisterRpcProviderEmitter = this._register(new Emitter<string>());
 
 	/**
 	 * The transport handed to backends: it resolves the owning host per RPC rather than binding a
@@ -266,6 +281,7 @@ export class PositronDataExplorerService extends Disposable implements IPositron
 	 */
 	registerRpcProvider(providerId: string, transport: IDataExplorerRpcTransport): void {
 		this._providerTransports.set(providerId, transport);
+		this._onDidRegisterRpcProviderEmitter.fire(providerId);
 	}
 
 	/**
@@ -491,20 +507,40 @@ export class PositronDataExplorerService extends Disposable implements IPositron
 			throw new Error('The Data Explorer RPC transport is not available.');
 		}
 
-		await this._rpcRouter.activateProvider(providerId);
+		// Listen before activating: the registration can land while activation is still settling.
+		// Event.toPromise returns a CancelablePromise, so every path below either awaits or cancels it
+		// to clean up the filtered listener.
+		const registration = Event.toPromise(
+			Event.filter(this._onDidRegisterRpcProviderEmitter.event, id => id === providerId)
+		);
 
-		const activated = this._providerTransports.get(providerId);
-		if (activated) {
-			return activated;
+		try {
+			await this._rpcRouter.activateProvider(providerId);
+
+			const activated = this._providerTransports.get(providerId);
+			if (activated) {
+				return activated;
+			}
+
+			// With a single host there is nowhere else the provider could be, so send the RPC and let
+			// the ext host's own wait for the handler cover a registration that lands late.
+			if (this._rpcTransports.size === 1) {
+				return [...this._rpcTransports][0];
+			}
+
+			// Activation resolved without a claim: wait for the registration to arrive rather than
+			// guessing a host, which is the bug this routing exists to prevent.
+			await raceTimeout(registration, PROVIDER_REGISTRATION_TIMEOUT_MS);
+
+			const late = this._providerTransports.get(providerId);
+			if (late) {
+				return late;
+			}
+
+			throw new Error(`No extension host registered the Data Explorer provider '${providerId}'.`);
+		} finally {
+			registration.cancel();
 		}
-
-		// With a single host there is nowhere else the provider could be, so send the RPC and let the
-		// ext host's own wait for the handler cover a registration that lands late.
-		if (this._rpcTransports.size === 1) {
-			return [...this._rpcTransports][0];
-		}
-
-		throw new Error(`No extension host registered the Data Explorer provider '${providerId}'.`);
 	}
 
 	//#endregion IPositronDataExplorerService Implementation

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
@@ -20,7 +20,7 @@ import { IPositronDataExplorerInstance } from './interfaces/positronDataExplorer
 import { DataExplorerBackendRequest, PositronDataExplorerComm } from '../../languageRuntime/common/positronDataExplorerComm.js';
 import { PositronDataExplorerDuckDBBackend } from '../common/positronDataExplorerDuckDBBackend.js';
 import { PositronDataExplorerExtensionBackend } from '../common/positronDataExplorerExtensionBackend.js';
-import { IDataExplorerRpcTransport, IDataExplorerUiEventDto } from '../common/dataExplorerRpcTransport.js';
+import { IDataExplorerHostTransport, IDataExplorerRpcTransport, IDataExplorerUiEventDto } from '../common/dataExplorerRpcTransport.js';
 import { URI } from '../../../../base/common/uri.js';
 import { RuntimeState } from '../../languageRuntime/common/languageRuntimeService.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
@@ -128,11 +128,9 @@ class DataExplorerRuntime extends Disposable {
 }
 
 /**
- * How long to wait for an extension host to claim a provider after activating it. Activation can
- * resolve before the host's `$registerRpcHandler` message is processed here -- an extension that
- * awaits work inside `activate()` before registering does exactly that. Mirrors the ext host's own
- * wait for a handler to register (`extHostDataExplorer`), so a provider that never registers fails
- * on the same budget it always has.
+ * How long to wait for a host to claim a provider after activating it: activation can resolve before
+ * the host's `$registerRpcHandler` lands, e.g. when the extension awaits work inside `activate()`.
+ * Matches the ext host's own wait for a handler, so an absent provider fails on the same budget.
  */
 const PROVIDER_REGISTRATION_TIMEOUT_MS = 30_000;
 
@@ -175,13 +173,13 @@ export class PositronDataExplorerService extends Disposable implements IPositron
 	 * The transports that reach backend-providing extensions, one per extension host, registered by
 	 * MainThreadDataExplorer. The web workbench has two: the web-worker host and the remote host.
 	 */
-	private readonly _rpcTransports = new Set<IDataExplorerRpcTransport>();
+	private readonly _rpcTransports = new Set<IDataExplorerHostTransport>();
 
 	/**
 	 * The transport for the extension host each provider's RPC handler registered in. A provider only
 	 * ever exists in one host (positron-duckdb is native, so it is always the remote one in web).
 	 */
-	private readonly _providerTransports = new Map<string, IDataExplorerRpcTransport>();
+	private readonly _providerTransports = new Map<string, IDataExplorerHostTransport>();
 
 	/**
 	 * Fires the provider id whenever a host claims one, so a resolution in flight can pick up a
@@ -194,9 +192,6 @@ export class PositronDataExplorerService extends Disposable implements IPositron
 	 * backend to whichever host happened to be connected when the Data Explorer opened.
 	 */
 	private readonly _rpcRouter: IDataExplorerRpcTransport = {
-		activateProvider: async (providerId) => {
-			await Promise.all([...this._rpcTransports].map(transport => transport.activateProvider(providerId)));
-		},
 		handleRpc: async (providerId, rpc) => {
 			const transport = await this._resolveRpcTransport(providerId);
 			return transport.handleRpc(providerId, rpc);
@@ -262,7 +257,7 @@ export class PositronDataExplorerService extends Disposable implements IPositron
 	 * @param transport The transport.
 	 * @returns A disposable that unregisters the transport and any providers it owns.
 	 */
-	registerRpcTransport(transport: IDataExplorerRpcTransport): IDisposable {
+	registerRpcTransport(transport: IDataExplorerHostTransport): IDisposable {
 		this._rpcTransports.add(transport);
 		return toDisposable(() => {
 			this._rpcTransports.delete(transport);
@@ -279,7 +274,7 @@ export class PositronDataExplorerService extends Disposable implements IPositron
 	 * @param providerId The provider id.
 	 * @param transport The transport for that host.
 	 */
-	registerRpcProvider(providerId: string, transport: IDataExplorerRpcTransport): void {
+	registerRpcProvider(providerId: string, transport: IDataExplorerHostTransport): void {
 		this._providerTransports.set(providerId, transport);
 		this._onDidRegisterRpcProviderEmitter.fire(providerId);
 	}
@@ -289,7 +284,7 @@ export class PositronDataExplorerService extends Disposable implements IPositron
 	 * @param providerId The provider id.
 	 * @param transport The transport that previously registered it.
 	 */
-	unregisterRpcProvider(providerId: string, transport: IDataExplorerRpcTransport): void {
+	unregisterRpcProvider(providerId: string, transport: IDataExplorerHostTransport): void {
 		if (this._providerTransports.get(providerId) === transport) {
 			this._providerTransports.delete(providerId);
 		}
@@ -494,10 +489,10 @@ export class PositronDataExplorerService extends Disposable implements IPositron
 
 	/**
 	 * Resolves the transport for the extension host that can service `providerId`. Activating the
-	 * provider in every connected host is what identifies the owner: only the host the extension is
-	 * installed in does anything, and it registers its handler as it activates.
+	 * provider in every host is what identifies the owner: only the host the extension is installed
+	 * in does anything, and it registers its handler as it activates.
 	 */
-	private async _resolveRpcTransport(providerId: string): Promise<IDataExplorerRpcTransport> {
+	private async _resolveRpcTransport(providerId: string): Promise<IDataExplorerHostTransport> {
 		const registered = this._providerTransports.get(providerId);
 		if (registered) {
 			return registered;
@@ -507,37 +502,24 @@ export class PositronDataExplorerService extends Disposable implements IPositron
 			throw new Error('The Data Explorer RPC transport is not available.');
 		}
 
-		// Listen before activating: the registration can land while activation is still settling.
-		// Event.toPromise returns a CancelablePromise, so every path below either awaits or cancels it
-		// to clean up the filtered listener.
+		// Subscribe before activating, so a registration that lands while activation is still settling
+		// isn't missed. Event.toPromise returns a CancelablePromise; cancel it so the filtered listener
+		// is cleaned up on every path.
 		const registration = Event.toPromise(
 			Event.filter(this._onDidRegisterRpcProviderEmitter.event, id => id === providerId)
 		);
 
 		try {
-			await this._rpcRouter.activateProvider(providerId);
-
-			const activated = this._providerTransports.get(providerId);
-			if (activated) {
-				return activated;
+			await Promise.all([...this._rpcTransports].map(transport => transport.activateProvider(providerId)));
+			if (!this._providerTransports.has(providerId)) {
+				await raceTimeout(registration, PROVIDER_REGISTRATION_TIMEOUT_MS);
 			}
 
-			// With a single host there is nowhere else the provider could be, so send the RPC and let
-			// the ext host's own wait for the handler cover a registration that lands late.
-			if (this._rpcTransports.size === 1) {
-				return [...this._rpcTransports][0];
+			const owner = this._providerTransports.get(providerId);
+			if (!owner) {
+				throw new Error(`No extension host registered the Data Explorer provider '${providerId}'.`);
 			}
-
-			// Activation resolved without a claim: wait for the registration to arrive rather than
-			// guessing a host, which is the bug this routing exists to prevent.
-			await raceTimeout(registration, PROVIDER_REGISTRATION_TIMEOUT_MS);
-
-			const late = this._providerTransports.get(providerId);
-			if (late) {
-				return late;
-			}
-
-			throw new Error(`No extension host registered the Data Explorer provider '${providerId}'.`);
+			return owner;
 		} finally {
 			registration.cancel();
 		}

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
@@ -20,7 +20,8 @@ import { IPositronDataExplorerInstance } from './interfaces/positronDataExplorer
 import { DataExplorerBackendRequest, PositronDataExplorerComm } from '../../languageRuntime/common/positronDataExplorerComm.js';
 import { PositronDataExplorerDuckDBBackend } from '../common/positronDataExplorerDuckDBBackend.js';
 import { PositronDataExplorerExtensionBackend } from '../common/positronDataExplorerExtensionBackend.js';
-import { IDataExplorerHostTransport, IDataExplorerRpcTransport, IDataExplorerUiEventDto } from '../common/dataExplorerRpcTransport.js';
+import { IDataExplorerRpcTransport, IDataExplorerUiEventDto } from '../common/dataExplorerRpcTransport.js';
+import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { URI } from '../../../../base/common/uri.js';
 import { RuntimeState } from '../../languageRuntime/common/languageRuntimeService.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
@@ -135,6 +136,15 @@ class DataExplorerRuntime extends Disposable {
 const PROVIDER_REGISTRATION_TIMEOUT_MS = 30_000;
 
 /**
+ * Activation event a Data Explorer backend extension declares so it activates lazily when a dataset
+ * it owns is first accessed. The provider id is the suffix, e.g.
+ * `onPositronDataExplorerBackend:positron-duckdb`.
+ */
+function dataExplorerBackendActivationEvent(providerId: string): string {
+	return `onPositronDataExplorerBackend:${providerId}`;
+}
+
+/**
  * PositronDataExplorerService class.
  */
 export class PositronDataExplorerService extends Disposable implements IPositronDataExplorerService {
@@ -170,16 +180,11 @@ export class PositronDataExplorerService extends Disposable implements IPositron
 	>();
 
 	/**
-	 * The transports that reach backend-providing extensions, one per extension host, registered by
-	 * MainThreadDataExplorer. The web workbench has two: the web-worker host and the remote host.
-	 */
-	private readonly _rpcTransports = new Set<IDataExplorerHostTransport>();
-
-	/**
 	 * The transport for the extension host each provider's RPC handler registered in. A provider only
-	 * ever exists in one host (positron-duckdb is native, so it is always the remote one in web).
+	 * ever exists in one host (positron-duckdb is native, so it is always the remote one in web). This
+	 * is the routing table: a host announces its providers as they register, and RPCs go to the owner.
 	 */
-	private readonly _providerTransports = new Map<string, IDataExplorerHostTransport>();
+	private readonly _providerTransports = new Map<string, IDataExplorerRpcTransport>();
 
 	/**
 	 * Fires the provider id whenever a host claims one, so a resolution in flight can pick up a
@@ -216,6 +221,7 @@ export class PositronDataExplorerService extends Disposable implements IPositron
 	constructor(
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IEditorService private readonly _editorService: IEditorService,
+		@IExtensionService private readonly _extensionService: IExtensionService,
 		@ILogService private readonly _logService: ILogService,
 		@INotificationService private readonly _notificationService: INotificationService,
 		@IRuntimeSessionService private readonly _runtimeSessionService: IRuntimeSessionService
@@ -251,16 +257,15 @@ export class PositronDataExplorerService extends Disposable implements IPositron
 	}
 
 	/**
-	 * Registers the transport that core Data Explorer backends use to reach backend-providing
-	 * extensions. Called by MainThreadDataExplorer for the extension host's lifetime, so one
-	 * transport is registered per host.
-	 * @param transport The transport.
-	 * @returns A disposable that unregisters the transport and any providers it owns.
+	 * Ties a host's provider claims to its connection. Called by MainThreadDataExplorer for the
+	 * extension host's lifetime.
+	 * @param transport The host's transport.
+	 * @returns A disposable that drops the host's remaining provider claims.
 	 */
-	registerRpcTransport(transport: IDataExplorerHostTransport): IDisposable {
-		this._rpcTransports.add(transport);
+	registerRpcHost(transport: IDataExplorerRpcTransport): IDisposable {
+		// Nothing to record up front: a host is only interesting once it claims a provider. Disposal
+		// drops any claims it still owns, so a disconnecting host stops receiving RPCs.
 		return toDisposable(() => {
-			this._rpcTransports.delete(transport);
 			for (const [providerId, registered] of this._providerTransports) {
 				if (registered === transport) {
 					this._providerTransports.delete(providerId);
@@ -274,7 +279,7 @@ export class PositronDataExplorerService extends Disposable implements IPositron
 	 * @param providerId The provider id.
 	 * @param transport The transport for that host.
 	 */
-	registerRpcProvider(providerId: string, transport: IDataExplorerHostTransport): void {
+	registerRpcProvider(providerId: string, transport: IDataExplorerRpcTransport): void {
 		this._providerTransports.set(providerId, transport);
 		this._onDidRegisterRpcProviderEmitter.fire(providerId);
 	}
@@ -284,7 +289,7 @@ export class PositronDataExplorerService extends Disposable implements IPositron
 	 * @param providerId The provider id.
 	 * @param transport The transport that previously registered it.
 	 */
-	unregisterRpcProvider(providerId: string, transport: IDataExplorerHostTransport): void {
+	unregisterRpcProvider(providerId: string, transport: IDataExplorerRpcTransport): void {
 		if (this._providerTransports.get(providerId) === transport) {
 			this._providerTransports.delete(providerId);
 		}
@@ -488,18 +493,15 @@ export class PositronDataExplorerService extends Disposable implements IPositron
 	}
 
 	/**
-	 * Resolves the transport for the extension host that can service `providerId`. Activating the
-	 * provider in every host is what identifies the owner: only the host the extension is installed
-	 * in does anything, and it registers its handler as it activates.
+	 * Resolves the transport for the extension host that can service `providerId`, activating the
+	 * provider if no host has claimed it yet. `activateByEvent` fans out to every extension host;
+	 * only the host the extension is installed in does anything, and it registers its handler as it
+	 * activates, which is what identifies the owning transport.
 	 */
-	private async _resolveRpcTransport(providerId: string): Promise<IDataExplorerHostTransport> {
+	private async _resolveRpcTransport(providerId: string): Promise<IDataExplorerRpcTransport> {
 		const registered = this._providerTransports.get(providerId);
 		if (registered) {
 			return registered;
-		}
-
-		if (this._rpcTransports.size === 0) {
-			throw new Error('The Data Explorer RPC transport is not available.');
 		}
 
 		// Subscribe before activating, so a registration that lands while activation is still settling
@@ -510,7 +512,7 @@ export class PositronDataExplorerService extends Disposable implements IPositron
 		);
 
 		try {
-			await Promise.all([...this._rpcTransports].map(transport => transport.activateProvider(providerId)));
+			await this._extensionService.activateByEvent(dataExplorerBackendActivationEvent(providerId));
 			if (!this._providerTransports.has(providerId)) {
 				await raceTimeout(registration, PROVIDER_REGISTRATION_TIMEOUT_MS);
 			}

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
@@ -130,7 +130,7 @@ class DataExplorerRuntime extends Disposable {
 /**
  * PositronDataExplorerService class.
  */
-class PositronDataExplorerService extends Disposable implements IPositronDataExplorerService {
+export class PositronDataExplorerService extends Disposable implements IPositronDataExplorerService {
 	//#region Private Properties
 
 	/**
@@ -163,9 +163,33 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 	>();
 
 	/**
-	 * The transport that reaches backend-providing extensions, registered by MainThreadDataExplorer.
+	 * The transports that reach backend-providing extensions, one per extension host, registered by
+	 * MainThreadDataExplorer. The web workbench has two: the web-worker host and the remote host.
 	 */
-	private _rpcTransport: IDataExplorerRpcTransport | undefined;
+	private readonly _rpcTransports = new Set<IDataExplorerRpcTransport>();
+
+	/**
+	 * The transport for the extension host each provider's RPC handler registered in. A provider only
+	 * ever exists in one host (positron-duckdb is native, so it is always the remote one in web).
+	 */
+	private readonly _providerTransports = new Map<string, IDataExplorerRpcTransport>();
+
+	/**
+	 * The transport handed to backends: it resolves the owning host per RPC rather than binding a
+	 * backend to whichever host happened to be connected when the Data Explorer opened.
+	 */
+	private readonly _rpcRouter: IDataExplorerRpcTransport = {
+		activateProvider: async (providerId) => {
+			await Promise.all([...this._rpcTransports].map(transport => transport.activateProvider(providerId)));
+		},
+		handleRpc: async (providerId, rpc) => {
+			const transport = await this._resolveRpcTransport(providerId);
+			return transport.handleRpc(providerId, rpc);
+		},
+		disposeBackend: (providerId, datasetId) => {
+			this._providerTransports.get(providerId)?.disposeBackend(providerId, datasetId);
+		}
+	};
 
 	/**
 	 * The onDidRegisterInstance event emitter.
@@ -218,17 +242,41 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 
 	/**
 	 * Registers the transport that core Data Explorer backends use to reach backend-providing
-	 * extensions. Called by MainThreadDataExplorer for the extension host's lifetime.
+	 * extensions. Called by MainThreadDataExplorer for the extension host's lifetime, so one
+	 * transport is registered per host.
 	 * @param transport The transport.
-	 * @returns A disposable that clears the transport.
+	 * @returns A disposable that unregisters the transport and any providers it owns.
 	 */
 	registerRpcTransport(transport: IDataExplorerRpcTransport): IDisposable {
-		this._rpcTransport = transport;
+		this._rpcTransports.add(transport);
 		return toDisposable(() => {
-			if (this._rpcTransport === transport) {
-				this._rpcTransport = undefined;
+			this._rpcTransports.delete(transport);
+			for (const [providerId, registered] of this._providerTransports) {
+				if (registered === transport) {
+					this._providerTransports.delete(providerId);
+				}
 			}
 		});
+	}
+
+	/**
+	 * Records the extension host a provider's RPC handler registered in.
+	 * @param providerId The provider id.
+	 * @param transport The transport for that host.
+	 */
+	registerRpcProvider(providerId: string, transport: IDataExplorerRpcTransport): void {
+		this._providerTransports.set(providerId, transport);
+	}
+
+	/**
+	 * Forgets the extension host a provider's RPC handler registered in.
+	 * @param providerId The provider id.
+	 * @param transport The transport that previously registered it.
+	 */
+	unregisterRpcProvider(providerId: string, transport: IDataExplorerRpcTransport): void {
+		if (this._providerTransports.get(providerId) === transport) {
+			this._providerTransports.delete(providerId);
+		}
 	}
 
 	/**
@@ -375,8 +423,7 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 	 * @param filePath Path to file to open with positron-duckdb extension
 	 */
 	async openWithDuckDB(uri: URI) {
-		const transport = this._ensureRpcTransport();
-		const backend = new PositronDataExplorerDuckDBBackend(transport, uri);
+		const backend = new PositronDataExplorerDuckDBBackend(this._rpcRouter, uri);
 
 		// Associate UI events (like ReturnColumnProfiles) for this file path
 		// with this backend. We're presuming only one backend per file path, so
@@ -404,8 +451,7 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 		// Only build and register a new backend the first time; subsequent calls just focus the
 		// already-open editor below.
 		if (!this._positronDataExplorerInstances.has(datasetId)) {
-			const transport = this._ensureRpcTransport();
-			const backend = new PositronDataExplorerExtensionBackend(transport, providerId, datasetId);
+			const backend = new PositronDataExplorerExtensionBackend(this._rpcRouter, providerId, datasetId);
 
 			// Route async UI events (e.g. column profiles) for this dataset back to this backend.
 			this._uiEventHandlers.set(backend.datasetUri, (event) => {
@@ -431,13 +477,34 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 	}
 
 	/**
-	 * Returns the registered RPC transport, throwing if the extension host has not connected yet.
+	 * Resolves the transport for the extension host that can service `providerId`. Activating the
+	 * provider in every connected host is what identifies the owner: only the host the extension is
+	 * installed in does anything, and it registers its handler as it activates.
 	 */
-	private _ensureRpcTransport(): IDataExplorerRpcTransport {
-		if (!this._rpcTransport) {
+	private async _resolveRpcTransport(providerId: string): Promise<IDataExplorerRpcTransport> {
+		const registered = this._providerTransports.get(providerId);
+		if (registered) {
+			return registered;
+		}
+
+		if (this._rpcTransports.size === 0) {
 			throw new Error('The Data Explorer RPC transport is not available.');
 		}
-		return this._rpcTransport;
+
+		await this._rpcRouter.activateProvider(providerId);
+
+		const activated = this._providerTransports.get(providerId);
+		if (activated) {
+			return activated;
+		}
+
+		// With a single host there is nowhere else the provider could be, so send the RPC and let the
+		// ext host's own wait for the handler cover a registration that lands late.
+		if (this._rpcTransports.size === 1) {
+			return [...this._rpcTransports][0];
+		}
+
+		throw new Error(`No extension host registered the Data Explorer provider '${providerId}'.`);
 	}
 
 	//#endregion IPositronDataExplorerService Implementation

--- a/src/vs/workbench/services/positronDataExplorer/common/dataExplorerRpcTransport.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/dataExplorerRpcTransport.ts
@@ -37,7 +37,10 @@ export interface IDataExplorerUiEventDto {
 }
 
 /**
- * The transport a core Data Explorer backend uses to reach the providing extension.
+ * The transport a core Data Explorer backend uses to reach the extension providing its dataset. Two
+ * things implement it: `MainThreadDataExplorer`, one per extension host, which forwards each RPC over
+ * the typed ext-host channel to the providing extension; and the service's internal router, which
+ * resolves the host that owns a provider and delegates to that host's transport.
  */
 export interface IDataExplorerRpcTransport {
 	/**
@@ -54,19 +57,4 @@ export interface IDataExplorerRpcTransport {
 	 * @param datasetId The dataset identifier (the RPC `uri`) that was closed.
 	 */
 	disposeBackend(providerId: string, datasetId: string): void;
-}
-
-/**
- * One extension host's transport, implemented by `MainThreadDataExplorer`. There is one per host, so
- * a web workbench with a web-worker and a remote host has two, and only one of them has any given
- * provider.
- */
-export interface IDataExplorerHostTransport extends IDataExplorerRpcTransport {
-	/**
-	 * Activates the extension providing `providerId` in this host, if it runs here. Resolves without
-	 * doing anything in a host the extension isn't installed in, so calling it on every host is how
-	 * the owner of a provider is found.
-	 * @param providerId The provider to activate (e.g. 'positron-duckdb').
-	 */
-	activateProvider(providerId: string): Promise<void>;
 }

--- a/src/vs/workbench/services/positronDataExplorer/common/dataExplorerRpcTransport.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/dataExplorerRpcTransport.ts
@@ -38,9 +38,18 @@ export interface IDataExplorerUiEventDto {
 
 /**
  * The transport a core Data Explorer backend uses to reach the providing extension. Implemented by
- * `MainThreadDataExplorer`, which forwards each request over the typed ext-host channel.
+ * `MainThreadDataExplorer`, which forwards each request over the typed ext-host channel. There is
+ * one transport per extension host, so a workbench with both a web-worker and a remote host has two.
  */
 export interface IDataExplorerRpcTransport {
+	/**
+	 * Activates the extension providing `providerId` in this transport's extension host, if it runs
+	 * there. Resolves without doing anything in hosts the extension isn't installed in, so it is safe
+	 * to call on every transport to find out which host owns a provider.
+	 * @param providerId The provider to activate (e.g. 'positron-duckdb').
+	 */
+	activateProvider(providerId: string): Promise<void>;
+
 	/**
 	 * Sends a Data Explorer RPC to the extension that registered `providerId`.
 	 * @param providerId The provider the dataset belongs to (e.g. 'positron-duckdb').

--- a/src/vs/workbench/services/positronDataExplorer/common/dataExplorerRpcTransport.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/dataExplorerRpcTransport.ts
@@ -37,19 +37,9 @@ export interface IDataExplorerUiEventDto {
 }
 
 /**
- * The transport a core Data Explorer backend uses to reach the providing extension. Implemented by
- * `MainThreadDataExplorer`, which forwards each request over the typed ext-host channel. There is
- * one transport per extension host, so a workbench with both a web-worker and a remote host has two.
+ * The transport a core Data Explorer backend uses to reach the providing extension.
  */
 export interface IDataExplorerRpcTransport {
-	/**
-	 * Activates the extension providing `providerId` in this transport's extension host, if it runs
-	 * there. Resolves without doing anything in hosts the extension isn't installed in, so it is safe
-	 * to call on every transport to find out which host owns a provider.
-	 * @param providerId The provider to activate (e.g. 'positron-duckdb').
-	 */
-	activateProvider(providerId: string): Promise<void>;
-
 	/**
 	 * Sends a Data Explorer RPC to the extension that registered `providerId`.
 	 * @param providerId The provider the dataset belongs to (e.g. 'positron-duckdb').
@@ -64,4 +54,19 @@ export interface IDataExplorerRpcTransport {
 	 * @param datasetId The dataset identifier (the RPC `uri`) that was closed.
 	 */
 	disposeBackend(providerId: string, datasetId: string): void;
+}
+
+/**
+ * One extension host's transport, implemented by `MainThreadDataExplorer`. There is one per host, so
+ * a web workbench with a web-worker and a remote host has two, and only one of them has any given
+ * provider.
+ */
+export interface IDataExplorerHostTransport extends IDataExplorerRpcTransport {
+	/**
+	 * Activates the extension providing `providerId` in this host, if it runs here. Resolves without
+	 * doing anything in a host the extension isn't installed in, so calling it on every host is how
+	 * the owner of a provider is found.
+	 * @param providerId The provider to activate (e.g. 'positron-duckdb').
+	 */
+	activateProvider(providerId: string): Promise<void>;
 }

--- a/src/vs/workbench/services/positronDataExplorer/test/common/positronDataExplorerExtensionBackend.vitest.ts
+++ b/src/vs/workbench/services/positronDataExplorer/test/common/positronDataExplorerExtensionBackend.vitest.ts
@@ -30,7 +30,6 @@ describe('PositronDataExplorerExtensionBackend', () => {
 		const calls: Array<{ providerId: string; rpc: IDataExplorerRpcDto }> = [];
 		const disposed: Array<{ providerId: string; datasetId: string }> = [];
 		const transport: IDataExplorerRpcTransport = {
-			activateProvider: () => Promise.resolve(),
 			handleRpc: (providerId, rpc) => {
 				calls.push({ providerId, rpc });
 				return Promise.resolve(respond(rpc));

--- a/src/vs/workbench/services/positronDataExplorer/test/common/positronDataExplorerExtensionBackend.vitest.ts
+++ b/src/vs/workbench/services/positronDataExplorer/test/common/positronDataExplorerExtensionBackend.vitest.ts
@@ -30,6 +30,7 @@ describe('PositronDataExplorerExtensionBackend', () => {
 		const calls: Array<{ providerId: string; rpc: IDataExplorerRpcDto }> = [];
 		const disposed: Array<{ providerId: string; datasetId: string }> = [];
 		const transport: IDataExplorerRpcTransport = {
+			activateProvider: () => Promise.resolve(),
 			handleRpc: (providerId, rpc) => {
 				calls.push({ providerId, rpc });
 				return Promise.resolve(respond(rpc));


### PR DESCRIPTION
Opening a Data Explorer in Positron for Workbench could leave a permanently blank grid: RPCs were routed to whichever extension host registered its transport last, which in web is often not the host positron-duckdb runs in. The explorer then waited 30s for a registration that could never arrive and showed nothing, with no user-visible error.

- Route Data Explorer RPCs by provider id to the extension host that registered the handler
- Wait for a registration that lands after activation resolves instead of failing the RPC
- Split the host-only `activateProvider` out of the backend-facing transport interface
- Add Vitest coverage for the two-extension-host (web) topology, including host disconnect

Diagnosed from the `Data Explorer: Summary Panel > Summary Panel: Search` flake, which is chromium-only at ~2%.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed a blank Data Explorer in Positron for Workbench when the extension host that owns a dataset was not the one core sent its requests to.

### Validation Steps

@:data-explorer @:web @:win

The underlying race is ~2% in CI and did not reproduce locally across five attempts (electron with 31s/60s injected activation stalls, chromium with a 45s stall). The five Vitest cases in `mainThreadDataExplorerRouting.vitest.ts` are the verification: three fail against main inside their routing assertion, and the host-disconnect case fails when the transport's provider cleanup is removed. E2E `data-explorer-summary-panel` is 4/4 on both electron and chromium, which is a regression check only -- a green run cannot show a race is gone.

One occurrence in the failure history (d2dd5d6f6b) shows the same blank-explorer failure with no timeout line logged, so it is likely but not demonstrated to be this bug.


### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- Data Explorer RPCs were routed to whichever extension host registered its transport last, not the host that owns the provider. In web there are two hosts and positron-duckdb (native) can only run in the remote one, so when the web-worker host won the slot every RPC went where the provider could never register, and the explorer stayed blank.</summary>

- **Test:** [Data Explorer: Summary Panel > Summary Panel: Search](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Data%20Explorer%3A%20Summary%20Panel%20%3E%20Summary%20Panel%3A%20Search%7C%7C%7Ctest%2Fe2e%2Ftests%2Fdata-explorer%2Fdata-explorer-summary-panel.test.ts)
- **Targeted failure:** expect('.column-summary').toHaveCount(10) -> Received: 0 (first, pre-search assertion)
- **Signal:** 3/3 occurrences ubuntu/chromium only. 2/3 show the timeout at duckdb activation dispatch +30.0s / +30.053s. In all 3 the 'did not register' error appears ONLY in the browser console (extHostDataExplorer.js served from localhost:9000/9001), never in server/exthost1/remoteexthost.log -- so the timing-out ExtHostDataExplorer is the browser-side host, not the remote host where duckdb activated cleanly. No duckdb/native/activation error in any occurrence.
- **Frequency:** 3/141 runs (2.1%) on main, ubuntu/chromium
- **Hypothesis:** Routing Data Explorer RPCs to the transport whose ext host actually registered that providerId eliminates the failure; the 30s timeout is a symptom, not the mechanism.

</details>

