### PR TITLE
e2e: add data explorer, notebook, editors, console-output memory scenarios

### DIFF
--- a/.github/workflows/test-memory-metrics.yml
+++ b/.github/workflows/test-memory-metrics.yml
@@ -27,7 +27,7 @@ jobs:
       # scenario must not cost us that night's idle datapoint.
       fail-fast: false
       matrix:
-        scenario: [idle, session-python, session-r, data-explorer, notebook]
+        scenario: [idle, session-python, session-r, data-explorer, notebook, editors]
     container:
       image: ghcr.io/posit-dev/positron-ubuntu24:24.18.0
       # The image is private, so the pull needs credentials. Copied from
@@ -54,9 +54,9 @@ jobs:
       # ordinary test runs. It also keeps the job from needing AWS credentials.
       ENABLE_CUSTOM_REPORTER: 'false'
       # Required by the envVars fixture in _test.setup.ts, which validates all
-      # four and fails every test if any is unset. idle and data-explorer never
-      # start a kernel, so these only have to be present there; the session and
-      # notebook scenarios start one explicitly and need real values. Every
+      # four and fails every test if any is unset. idle, data-explorer and editors
+      # never start a kernel, so these only have to be present there; the session
+      # and notebook scenarios start one explicitly and need real values. Every
       # matrix job sets them.
       POSITRON_PY_VER_SEL: "3.10.12"
       POSITRON_R_VER_SEL: 4.5.2

--- a/.github/workflows/test-memory-metrics.yml
+++ b/.github/workflows/test-memory-metrics.yml
@@ -27,7 +27,7 @@ jobs:
       # scenario must not cost us that night's idle datapoint.
       fail-fast: false
       matrix:
-        scenario: [idle, session-python, session-r]
+        scenario: [idle, session-python, session-r, data-explorer, notebook]
     container:
       image: ghcr.io/posit-dev/positron-ubuntu24:24.18.0
       # The image is private, so the pull needs credentials. Copied from
@@ -54,10 +54,10 @@ jobs:
       # ordinary test runs. It also keeps the job from needing AWS credentials.
       ENABLE_CUSTOM_REPORTER: 'false'
       # Required by the envVars fixture in _test.setup.ts, which validates all
-      # four and fails every test if any is unset. The idle scenario pins
-      # interpreters.startupBehavior to manual, so these only have to be
-      # present there; the session scenarios start their session explicitly
-      # and need real values. All three matrix jobs set them.
+      # four and fails every test if any is unset. idle and data-explorer never
+      # start a kernel, so these only have to be present there; the session and
+      # notebook scenarios start one explicitly and need real values. Every
+      # matrix job sets them.
       POSITRON_PY_VER_SEL: "3.10.12"
       POSITRON_R_VER_SEL: 4.5.2
       POSITRON_PY_ALT_VER_SEL: "3.13.0"

--- a/.github/workflows/test-memory-metrics.yml
+++ b/.github/workflows/test-memory-metrics.yml
@@ -27,7 +27,7 @@ jobs:
       # scenario must not cost us that night's idle datapoint.
       fail-fast: false
       matrix:
-        scenario: [idle, session-python, session-r, data-explorer, notebook, editors]
+        scenario: [idle, session-python, session-r, data-explorer, notebook, editors, console-output]
     container:
       image: ghcr.io/posit-dev/positron-ubuntu24:24.18.0
       # The image is private, so the pull needs credentials. Copied from
@@ -55,9 +55,9 @@ jobs:
       ENABLE_CUSTOM_REPORTER: 'false'
       # Required by the envVars fixture in _test.setup.ts, which validates all
       # four and fails every test if any is unset. idle, data-explorer and editors
-      # never start a kernel, so these only have to be present there; the session
-      # and notebook scenarios start one explicitly and need real values. Every
-      # matrix job sets them.
+      # never start a kernel, so these only have to be present there; session,
+      # notebook and console-output start one explicitly and need real values.
+      # Every matrix job sets them.
       POSITRON_PY_VER_SEL: "3.10.12"
       POSITRON_R_VER_SEL: 4.5.2
       POSITRON_PY_ALT_VER_SEL: "3.13.0"

--- a/.github/workflows/test-memory-metrics.yml
+++ b/.github/workflows/test-memory-metrics.yml
@@ -189,7 +189,7 @@ jobs:
       # for a later job to append to this one's summary, so all four links are
       # printed by summarize-memory instead, and appear on the run's Summary page.
 
-  # Combines the three matrix jobs' per-scenario reports into one
+  # Combines the matrix jobs' per-scenario reports into one
   # cross-scenario view: the per-role numbers are 20-50x quieter than the
   # tree TOTAL and are the useful signal, but nothing compared them side by
   # side before this job existed.

--- a/test/e2e/fixtures/test-setup/options.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/options.fixtures.ts
@@ -12,6 +12,7 @@ import { ROOT_PATH, TEMP_DIR } from './constants';
 import { copyUserSettings } from './shared-utils.js';
 import { shouldUseCustomTracing } from './reporting.fixtures.js';
 import { isMemoryScenario } from '../../utils/memory/scenarios.js';
+import { SHARED_PROCESS_INSPECT_PORT } from '../../utils/memory/gc.js';
 
 export interface CustomTestOptions {
 	artifactDir: string;
@@ -86,7 +87,14 @@ export function OptionsFixture() {
 			} : {}),
 			// --- End Positron ---
 			useExternalServer: project.useExternalServer,
-			externalServerUrl: project.externalServerUrl
+			externalServerUrl: project.externalServerUrl,
+			// --- Start Positron ---
+			// Memory runs force a GC in the shared process through this inspector port
+			// before sampling; see utils/memory/gc.ts.
+			...(isMemoryScenario(process.env.MEMORY_SCENARIO) && !browser
+				? { extraArgs: [`--inspect-sharedprocess=${SHARED_PROCESS_INSPECT_PORT}`] }
+				: {})
+			// --- End Positron ---
 		};
 
 		options.userDataDir = getRandomUserDataDir(options);

--- a/test/e2e/fixtures/test-setup/options.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/options.fixtures.ts
@@ -12,7 +12,7 @@ import { ROOT_PATH, TEMP_DIR } from './constants';
 import { copyUserSettings } from './shared-utils.js';
 import { shouldUseCustomTracing } from './reporting.fixtures.js';
 import { isMemoryScenario } from '../../utils/memory/scenarios.js';
-import { SHARED_PROCESS_INSPECT_PORT } from '../../utils/memory/gc.js';
+import { GC_TARGETS } from '../../utils/memory/gc.js';
 
 export interface CustomTestOptions {
 	artifactDir: string;
@@ -89,10 +89,10 @@ export function OptionsFixture() {
 			useExternalServer: project.useExternalServer,
 			externalServerUrl: project.externalServerUrl,
 			// --- Start Positron ---
-			// Memory runs force a GC in the shared process through this inspector port
-			// before sampling; see utils/memory/gc.ts.
+			// Memory runs force a GC in the shared process and extension host through
+			// these inspector ports before sampling; see utils/memory/gc.ts.
 			...(isMemoryScenario(process.env.MEMORY_SCENARIO) && !browser
-				? { extraArgs: [`--inspect-sharedprocess=${SHARED_PROCESS_INSPECT_PORT}`] }
+				? { extraArgs: GC_TARGETS.map(t => `${t.flag}=${t.port}`) }
 				: {})
 			// --- End Positron ---
 		};

--- a/test/e2e/tests/performance/memory-console-output.test.ts
+++ b/test/e2e/tests/performance/memory-console-output.test.ts
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test } from '../_test.setup';
+import { defineMemoryScenario } from './memory-scenario';
+
+test.use({
+	suiteId: __filename
+});
+
+/**
+ * Enough output that retaining it is measurable, and nothing bounds it: the
+ * console keeps every line it has ever printed. The only `slice(-N)` limits in
+ * positronConsole are on resource-usage history and *input* history, so output
+ * history grows for the life of the session.
+ */
+const LINES = 10_000;
+
+// Runs against a Python session, so the figure of interest is this scenario minus
+// session-python: what holding 10k lines of output costs on top of a session that
+// already exists. The cross-scenario summary deltas against idle, so that
+// subtraction is by eye until #15495.
+defineMemoryScenario({
+	scenario: 'console-output',
+	prepare: async ({ app, sessions }) => {
+		const { console } = app.workbench;
+
+		await sessions.startAndSkipMetadata({ language: 'Python', waitForReady: true });
+
+		// One print rather than a loop of 10k prints. Both end up as 10k lines in the
+		// console's model, but a loop is 10k separate stream messages over the comm,
+		// which is slow enough to risk the scenario timing out for reasons that have
+		// nothing to do with memory. The existing console performance spec emits 3000
+		// lines the same way.
+		//
+		// pasteCodeToConsole rather than executeCode: executeCode defaults
+		// maximizeConsole to true, and a maximized console is a different layout from
+		// the one session-python measured, which would land in this delta as if it
+		// were the cost of the output.
+		await console.clearInput();
+		await console.pasteCodeToConsole(`print("\\n".join(f"scrollback {i}" for i in range(${LINES})))`, true);
+
+		// The last line only exists if every line before it was emitted and rendered,
+		// so this is the whole output arriving rather than just some of it. Generous
+		// timeout because rendering 10k lines is the slow part and the default 15s is
+		// tuned for ordinary assertions.
+		await console.waitForConsoleContents(`scrollback ${LINES - 1}`, { timeout: 90_000 });
+	},
+	// Same gate as session-python: kernel only exists once a session really started,
+	// so it is what stops a failed run from publishing an idle-shaped number.
+	expectRoles: ['kernel', 'kernel_supervisor']
+});

--- a/test/e2e/tests/performance/memory-data-explorer.test.ts
+++ b/test/e2e/tests/performance/memory-data-explorer.test.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test } from '../_test.setup';
+import { defineMemoryScenario } from './memory-scenario';
+
+test.use({
+	suiteId: __filename
+});
+
+// No session, so this is measured against idle rather than session-python. The
+// duckdb worker backs CSVs opened straight from the explorer with no interpreter
+// involved; opening a dataframe out of a Python session is a different path that
+// never touches the worker, and its number would blend kernel memory, the
+// dataframe, and the explorer UI. settingsMemory.json's manual startup behavior
+// keeps every kernel out of the tree.
+defineMemoryScenario({
+	scenario: 'data-explorer',
+	prepare: async ({ app, openDataFile }) => {
+		const { dataExplorer } = app.workbench;
+
+		// The worker spawns on the first query rather than on activation, so opening
+		// the file is what brings it into existence.
+		//
+		// A deliberately tiny CSV, measured rather than guessed. Running this scenario
+		// against flights.csv (36 MB, 336k rows) instead puts the worker at 279 MB,
+		// but only 110 MB of that is the native binding and duckdb runtime; the other
+		// 168 MB is buffer pool sized to the data. That cache is also all of the
+		// noise: tree-total spread across three launches was 52 MB on flights.csv
+		// against 15 MB here, and the worker's own spread 66 MB against 1.6 MB. A
+		// regression in what the worker costs to *exist* -- the thing #13998 caused
+		// and this scenario is here to catch -- would hide inside that. Buffer pool
+		// also moves with duckdb upgrades and runner RAM rather than with Positron,
+		// so trending it would mean alerting on nothing.
+		await openDataFile('data-files/small_file.csv');
+		await dataExplorer.waitForIdle();
+
+		// Rows present, not merely an editor tab: the state assertion the scenario
+		// selection design asks for. A grid that never loaded would otherwise
+		// snapshot as a suspiciously cheap CSV instead of failing.
+		await dataExplorer.expectStatusBarToHaveText(/10\s+rows\s+10\s+columns/);
+	},
+	// Deliberately not `expectRoles: ['extension_child']`: pet holds that role at
+	// idle, so it would pass on a run where the CSV never opened. Loose on the
+	// worker's filename because the build emits `duckdbWorker.js` while label.ts
+	// renders it through deriveExtensionName, and neither spelling is this
+	// scenario's business.
+	//
+	// The editor stays open for the whole snapshot on purpose. The worker
+	// self-terminates 120s after the LAST data explorer closes (IDLE_SHUTDOWN_MS in
+	// extensions/positron-duckdb/src/extension.ts) and settling plus sampling can
+	// outlast that, so closing the tab to tidy up would delete the process being
+	// measured and leave this gate as the only thing that noticed.
+	expectProcesses: [/duckdb/i]
+});

--- a/test/e2e/tests/performance/memory-editors.test.ts
+++ b/test/e2e/tests/performance/memory-editors.test.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { basename } from 'path';
+import { expect, test } from '../_test.setup';
+import { defineMemoryScenario } from './memory-scenario';
+
+test.use({
+	suiteId: __filename
+});
+
+/**
+ * A plausible working set rather than a stress test: ten files a real project
+ * would have open at once.
+ *
+ * Mixed types on purpose, though it matters less than it looks. The fixture
+ * workspace's `workspaceContains` events already start ruff, air, and Quarto at
+ * idle, so this measures Monaco models plus per-file language-server document
+ * state, not language-server startup.
+ *
+ * Basenames must stay unique across this list: the tab assertion below matches a
+ * tab by accessible name, and two files called README.md would fail Playwright's
+ * strict mode rather than fail informatively.
+ */
+const FILES = [
+	'workspaces/generate-data-frames-py/simple-data-frames.py',
+	'workspaces/python-plots/altair-plots.py',
+	'workspaces/polars-dataframe-py/polars_basic.py',
+	'workspaces/sparklines/sparklines.r',
+	'workspaces/nyc-flights-data-r/flights-data-frame.r',
+	'workspaces/shiny-r-example/gen_table.R',
+	'workspaces/quarto_python/report.qmd',
+	'workspaces/visual-mode/visual-mode.qmd',
+	'workspaces/visual-mode/visual-mode.md',
+	'workspaces/assistant/positron.md'
+];
+
+// No session, so this is measured against idle. Ten open editors is a state idle
+// cannot see at all -- it opens none -- and open editors are a classic place for
+// memory to creep, since each one is a Monaco model that lives until it is closed.
+defineMemoryScenario({
+	scenario: 'editors',
+	prepare: async ({ app, openFile }) => {
+		const { editors } = app.workbench;
+
+		for (const file of FILES) {
+			await openFile(file);
+		}
+
+		// Every tab asserted individually, not just a count: if one file failed to
+		// open, the failure should name it. This is also the scenario's ONLY state
+		// gate -- unlike data-explorer, opening editors starts no new process, so
+		// neither expectRoles nor expectProcesses can prove the state was reached.
+		// The gap that leaves is narrow: a tab closing between here and sampling
+		// would go unnoticed.
+		for (const file of FILES) {
+			await expect(editors.editorTab(basename(file)),
+				`${file} did not open; the scenario is measuring fewer editors than it claims`).toBeVisible();
+		}
+	}
+});

--- a/test/e2e/tests/performance/memory-editors.test.ts
+++ b/test/e2e/tests/performance/memory-editors.test.ts
@@ -50,14 +50,17 @@ defineMemoryScenario({
 		}
 
 		// Every tab asserted individually, not just a count: if one file failed to
-		// open, the failure should name it. This is also the scenario's ONLY state
-		// gate -- unlike data-explorer, opening editors starts no new process, so
-		// neither expectRoles nor expectProcesses can prove the state was reached.
-		// The gap that leaves is narrow: a tab closing between here and sampling
-		// would go unnoticed.
+		// open, the failure should name it. expectProcesses below covers the window
+		// between here and sampling, but only for the markdown files, so these
+		// assertions are still what proves the other eight opened.
 		for (const file of FILES) {
 			await expect(editors.editorTab(basename(file)),
 				`${file} did not open; the scenario is measuring fewer editors than it claims`).toBeVisible();
 		}
-	}
+	},
+	// Opening the two .md files starts the markdown language server, which is 41 MB
+	// of this scenario's cost and is absent at idle -- so unlike a bare tab count,
+	// it is checkable at snapshot time. A partial gate rather than a complete one:
+	// it proves markdown opened, not that all ten files did.
+	expectProcesses: [/markdown-language-features/]
 });

--- a/test/e2e/tests/performance/memory-notebook.test.ts
+++ b/test/e2e/tests/performance/memory-notebook.test.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test } from '../_test.setup';
+import { defineMemoryScenario } from './memory-scenario';
+
+test.use({
+	suiteId: __filename
+});
+
+// Runs against a Python session, so the interesting figure is this scenario minus
+// session-python, not minus idle: what the notebook editor and its renderer path
+// cost on top of a session that already exists. The cross-scenario summary deltas
+// everything against idle today, so that subtraction is by eye until #15495.
+defineMemoryScenario({
+	scenario: 'notebook',
+	prepare: async ({ app }) => {
+		const { notebooks, notebooksPositron } = app.workbench;
+
+		await notebooks.createNewNotebook();
+
+		// Fails loudly if `positron.notebook.enabled` ever stops defaulting to true.
+		// This scenario exists to measure the Positron notebook editor, and the legacy
+		// one would publish a different app state under the same series name. Asserted
+		// rather than pinned in settingsMemory.json, which is shared with idle and
+		// would move the idle baseline.
+		await notebooksPositron.expectToBeVisible();
+
+		// Selected explicitly because settingsMemory.json pins startup behavior to
+		// manual for every memory scenario, so nothing auto-starts. waitForReady
+		// defaults on, which is the settle point before the collector takes over.
+		await notebooksPositron.kernel.select('Python');
+		await notebooksPositron.addCodeToCell(0, 'print("hello")', { run: true });
+
+		// Output present, not just a cell that stopped spinning: a cell can finish
+		// without ever having rendered anything, and the renderer path is the point.
+		await notebooksPositron.expectOutputAtIndex(0, ['hello']);
+	},
+	// Same gate as session-python: kernel only exists once a session really started,
+	// so it is what stops a failed run from publishing an idle-shaped number.
+	expectRoles: ['kernel', 'kernel_supervisor']
+});

--- a/test/e2e/tests/performance/memory-notebook.test.ts
+++ b/test/e2e/tests/performance/memory-notebook.test.ts
@@ -10,33 +10,55 @@ test.use({
 	suiteId: __filename
 });
 
+/**
+ * 30 cells: 19 code, 11 markdown, and 19 of them carrying stored outputs (19
+ * stream, 8 execute_result, 1 display_data).
+ *
+ * Chosen over building cells up through the POM, and over an empty notebook: a
+ * one-cell notebook measured only +31 MB over session-python, which says almost
+ * nothing about the renderer and webview path this scenario exists to watch.
+ */
+const NOTEBOOK = 'workspaces/pokemon/ds-workflow2.ipynb';
+const CELL_COUNT = 30;
+
 // Runs against a Python session, so the interesting figure is this scenario minus
-// session-python, not minus idle: what the notebook editor and its renderer path
-// cost on top of a session that already exists. The cross-scenario summary deltas
-// everything against idle today, so that subtraction is by eye until #15495.
+// session-python, not minus idle: what the notebook editor, its cell editors, and
+// its rendered outputs cost on top of a session that already exists. The
+// cross-scenario summary deltas everything against idle today, so that subtraction
+// is by eye until #15495.
 defineMemoryScenario({
 	scenario: 'notebook',
 	prepare: async ({ app }) => {
-		const { notebooks, notebooksPositron } = app.workbench;
+		const { notebooksPositron } = app.workbench;
 
-		await notebooks.createNewNotebook();
+		// openNotebook, not the openFile fixture: openFile ends in
+		// editors.selectTab -> waitForEditorFocus, which waits for a focused
+		// `.monaco-editor[data-uri$=...] .native-edit-context`. A notebook editor has
+		// no such text-editor context, so openFile times out on an .ipynb.
+		await notebooksPositron.openNotebook(NOTEBOOK);
 
-		// Fails loudly if `positron.notebook.enabled` ever stops defaulting to true.
-		// This scenario exists to measure the Positron notebook editor, and the legacy
-		// one would publish a different app state under the same series name. Asserted
-		// rather than pinned in settingsMemory.json, which is shared with idle and
-		// would move the idle baseline.
+		// Fails loudly if that default ever flips. This scenario exists to measure the
+		// Positron notebook editor, and the legacy one would publish a different app
+		// state under the same series name. Asserted rather than pinned in
+		// settingsMemory.json, which is shared with idle and would move idle's baseline.
 		await notebooksPositron.expectToBeVisible();
+
+		// Proves the whole notebook parsed and rendered, not just that an editor
+		// opened. Without it a partial render would publish as a cheap notebook.
+		await notebooksPositron.expectCellCountToBe(CELL_COUNT);
 
 		// Selected explicitly because settingsMemory.json pins startup behavior to
 		// manual for every memory scenario, so nothing auto-starts. waitForReady
 		// defaults on, which is the settle point before the collector takes over.
 		await notebooksPositron.kernel.select('Python');
-		await notebooksPositron.addCodeToCell(0, 'print("hello")', { run: true });
 
-		// Output present, not just a cell that stopped spinning: a cell can finish
-		// without ever having rendered anything, and the renderer path is the point.
-		await notebooksPositron.expectOutputAtIndex(0, ['hello']);
+		// One trivial cell appended and run, rather than running the notebook's own
+		// 30: those execute real analysis code with third-party imports, so a missing
+		// dependency in the container would turn a memory job into a red herring and
+		// the runtime would be unbounded. The stored outputs above already give the
+		// render cost; this only has to prove the kernel really executes.
+		await notebooksPositron.addCodeToCell(CELL_COUNT, 'print("hello")', { run: true });
+		await notebooksPositron.expectOutputAtIndex(CELL_COUNT, ['hello']);
 	},
 	// Same gate as session-python: kernel only exists once a session really started,
 	// so it is what stops a failed run from publishing an idle-shaped number.

--- a/test/e2e/tests/performance/memory-scenario.ts
+++ b/test/e2e/tests/performance/memory-scenario.ts
@@ -153,10 +153,24 @@ export function defineMemoryScenario(options: {
 			expect(impossible.map(p => `${p.processName} (pid ${p.pid})`),
 				'PSS exceeded RSS, which is impossible within one sample').toEqual([]);
 
-			// Sampling now waits for per-process quiescence, so a moving process means
-			// it gave up at the cap. Asserted rather than logged: a plausible-looking
-			// number that describes no actual state is worse than a failed job, since
-			// only the failure is visible.
+			// The sampling loop breaks only when treeHasSettled, so reaching the cap
+			// means it never settled and this is a mid-load number.
+			//
+			// Asserted on sampledMs directly because the `moving` check below cannot
+			// stand in for it, though it was written as if it could. Only the last
+			// TAIL_LENGTH samples are retained, so a launch that spent the full 90s
+			// unsettled still hands unstableProcesses a flat tail and passes: an
+			// `editors` launch did exactly that, discarding 15 samples and publishing a
+			// total 100 MB below its two siblings, with every gate green.
+			expect(snapshot.sampledMs,
+				`sampling ran to its ${SAMPLING_CAP_MS / 1000}s cap without the tree settling, so this is a mid-load number`)
+				.toBeLessThan(SAMPLING_CAP_MS);
+
+			// Per-process quiescence, which is a weaker condition than the tree
+			// settling: this catches a process still visibly moving within the
+			// retained tail. Asserted rather than logged: a plausible-looking number
+			// that describes no actual state is worse than a failed job, since only
+			// the failure is visible.
 			const moving = unstableProcesses(snapshot.processes);
 			for (const proc of moving) {
 				console.log(`[memory] ${scenario} launch ${snapshot.launchIndex}: ${proc.processName} (${proc.processRole}) was still moving: ` +

--- a/test/e2e/tests/performance/memory-scenario.ts
+++ b/test/e2e/tests/performance/memory-scenario.ts
@@ -8,7 +8,7 @@ import { join } from 'path';
 import { expect, tags, test } from '../_test.setup';
 import { Application, Sessions } from '../../infra';
 import { readActivatedExtensions } from '../../utils/memory/extensions.js';
-import { collectAllGarbage } from '../../utils/memory/gc.js';
+import { collectAllGarbage, GC_TARGETS } from '../../utils/memory/gc.js';
 import { fetchBaseline, publishSnapshots } from '../../utils/memory/publish.js';
 import { renderHtml, renderMarkdown } from '../../utils/memory/render.js';
 import { captureSnapshot, SAMPLING_CAP_MS, SETTLE_CAP_MS, unstableProcesses } from '../../utils/memory/snapshot.js';
@@ -117,6 +117,16 @@ export function defineMemoryScenario(options: {
 				extensions,
 				forceGc: () => collectAllGarbage()
 			});
+
+			// --- TEMP DIAGNOSTIC: revert before merge ---
+			// The notebook scenario's ext host is bimodal (+~40 MB on half of
+			// launches, surviving the forced GC). Dump the loaded-module list and a
+			// heap snapshot per launch into the artifact dir so a fat and a thin
+			// launch can be diffed offline.
+			if (scenario === 'notebook') {
+				await dumpExtHostDiagnostics(SNAPSHOT_DIR, Number(process.env.MEMORY_LAUNCH_INDEX ?? 0));
+			}
+			// --- END TEMP DIAGNOSTIC ---
 
 			expect(snapshot.processes.length, 'no processes found in the tree').toBeGreaterThan(3);
 			expect(snapshot.treeTotalPssBytes, 'total PSS was zero; smaps_rollup is probably unreadable').toBeGreaterThan(0);
@@ -241,3 +251,44 @@ export function defineMemoryScenario(options: {
 		});
 	});
 }
+
+// --- TEMP DIAGNOSTIC: revert before merge ---
+// Dumps the ext host's loaded-module list and a V8 heap snapshot into the
+// artifact dir. process.getBuiltinModule is used because the ext host's
+// evaluated context has no global require.
+async function dumpExtHostDiagnostics(dir: string, launchIndex: number): Promise<void> {
+	const port = GC_TARGETS.find(t => t.role === 'extension_host')!.port;
+	const targets = await (await fetch(`http://127.0.0.1:${port}/json`)).json() as { webSocketDebuggerUrl?: string }[];
+	const ws = new WebSocket(targets[0].webSocketDebuggerUrl!);
+	await new Promise<void>((resolve, reject) => {
+		ws.onopen = () => resolve();
+		ws.onerror = () => reject(new Error('diagnostic ws connection failed'));
+	});
+	let nextId = 1;
+	const pending = new Map<number, (msg: any) => void>();
+	ws.onmessage = (ev: any) => {
+		const msg = JSON.parse(String(ev.data));
+		pending.get(msg.id)?.(msg);
+		pending.delete(msg.id);
+	};
+	const evaluate = (expression: string, timeoutMs: number): Promise<string> => new Promise((resolve, reject) => {
+		const id = nextId++;
+		const timer = setTimeout(() => reject(new Error(`diagnostic evaluate timed out after ${timeoutMs}ms`)), timeoutMs);
+		pending.set(id, msg => {
+			clearTimeout(timer);
+			msg.error ? reject(new Error(JSON.stringify(msg.error))) : resolve(msg.result?.result?.value);
+		});
+		ws.send(JSON.stringify({ id, method: 'Runtime.evaluate', params: { expression, returnByValue: true } }));
+	});
+	try {
+		mkdirSync(dir, { recursive: true });
+		const modules = await evaluate(
+			`JSON.stringify(Object.keys(process.getBuiltinModule('module')._cache ?? {}))`, 15_000);
+		writeFileSync(join(dir, `exthost-modules-${launchIndex}.json`), String(modules));
+		const snapPath = join(dir, `exthost-${launchIndex}.heapsnapshot`);
+		await evaluate(`process.getBuiltinModule('v8').writeHeapSnapshot(${JSON.stringify(snapPath)})`, 240_000);
+	} finally {
+		ws.close();
+	}
+}
+// --- END TEMP DIAGNOSTIC ---

--- a/test/e2e/tests/performance/memory-scenario.ts
+++ b/test/e2e/tests/performance/memory-scenario.ts
@@ -47,16 +47,32 @@ function snapshotDir(scenario: MemoryScenario): string {
 export function defineMemoryScenario(options: {
 	scenario: MemoryScenario;
 	/** Drives the app into the state being measured. Omitted for idle. */
-	prepare?: (fixtures: { app: Application; sessions: Sessions }) => Promise<void>;
+	prepare?: (fixtures: {
+		app: Application;
+		sessions: Sessions;
+		openDataFile: (filePath: string) => Promise<void>;
+	}) => Promise<void>;
 	/** Roles that must be present, proving the scenario reached its state. */
 	expectRoles?: ProcessRole[];
+	/**
+	 * Process names that must be present, for scenarios whose process is not
+	 * distinguishable by role alone.
+	 *
+	 * `expectRoles` is enough when the scenario adds a role that idle lacks, as
+	 * the session scenarios do with `kernel`. It is useless when the role is
+	 * already occupied: the duckdb worker is an `extension_child`, but so is pet,
+	 * which runs at idle, so requiring that role would pass on a run where the
+	 * CSV never opened. Matched against the process name and the command
+	 * basename, either of which identifies the worker.
+	 */
+	expectProcesses?: RegExp[];
 }): void {
-	const { scenario, prepare, expectRoles = [] } = options;
+	const { scenario, prepare, expectRoles = [], expectProcesses = [] } = options;
 	const SNAPSHOT_DIR = snapshotDir(scenario);
 
 	test.describe(`Memory: ${scenario}`, { tag: [tags.PERFORMANCE] }, () => {
 
-		test(`Memory footprint of the Positron process tree: ${scenario}`, async function ({ app, sessions, logsPath }) {
+		test(`Memory footprint of the Positron process tree: ${scenario}`, async function ({ app, sessions, logsPath, openDataFile }) {
 			// Derived rather than a round number, because the default 2 minutes is
 			// now too short: a run that waits out both caps would time out before it
 			// could report which one it hit, turning a diagnosable result into a
@@ -73,7 +89,7 @@ export function defineMemoryScenario(options: {
 			expect(mainPid, 'no Electron main pid; this spec only runs against Electron').toBeTruthy();
 
 			if (prepare) {
-				await prepare({ app, sessions });
+				await prepare({ app, sessions, openDataFile });
 			}
 
 			// Deterministic readiness gate, not a memory heuristic: waits out startup
@@ -109,6 +125,18 @@ export function defineMemoryScenario(options: {
 			const roles = new Set(snapshot.processes.map(p => p.processRole));
 			for (const role of expectRoles) {
 				expect(roles, `scenario ${scenario} expected a ${role} process; the app never reached the state being measured`).toContain(role);
+			}
+
+			// Same argument as expectRoles, for the processes a role cannot single
+			// out. Reported with the names that were present, because "no duckdb
+			// worker" and "the worker is there under a name this regex misses" need
+			// different fixes and the failure text is the only place to tell them apart.
+			for (const pattern of expectProcesses) {
+				const matched = snapshot.processes.some(p =>
+					pattern.test(p.processName) || pattern.test(p.cmdBasename));
+				expect(matched,
+					`scenario ${scenario} expected a process matching ${pattern}; the app never reached the state being measured. ` +
+					`Present: ${snapshot.processes.map(p => p.processName).join(', ')}`).toBe(true);
 			}
 
 			// waitForSettle gives up at its cap regardless of whether the tree

--- a/test/e2e/tests/performance/memory-scenario.ts
+++ b/test/e2e/tests/performance/memory-scenario.ts
@@ -8,6 +8,7 @@ import { join } from 'path';
 import { expect, tags, test } from '../_test.setup';
 import { Application, Sessions } from '../../infra';
 import { readActivatedExtensions } from '../../utils/memory/extensions.js';
+import { collectSharedProcessGarbage } from '../../utils/memory/gc.js';
 import { fetchBaseline, publishSnapshots } from '../../utils/memory/publish.js';
 import { renderHtml, renderMarkdown } from '../../utils/memory/render.js';
 import { captureSnapshot, SAMPLING_CAP_MS, SETTLE_CAP_MS, unstableProcesses } from '../../utils/memory/snapshot.js';
@@ -113,7 +114,8 @@ export function defineMemoryScenario(options: {
 				buildRoot: buildRoot!,
 				userDataDir: app.userDataPath,
 				launchIndex: Number(process.env.MEMORY_LAUNCH_INDEX ?? 0),
-				extensions
+				extensions,
+				forceGc: () => collectSharedProcessGarbage()
 			});
 
 			expect(snapshot.processes.length, 'no processes found in the tree').toBeGreaterThan(3);

--- a/test/e2e/tests/performance/memory-scenario.ts
+++ b/test/e2e/tests/performance/memory-scenario.ts
@@ -51,6 +51,7 @@ export function defineMemoryScenario(options: {
 		app: Application;
 		sessions: Sessions;
 		openDataFile: (filePath: string) => Promise<void>;
+		openFile: (filePath: string, waitForFocus?: boolean) => Promise<void>;
 	}) => Promise<void>;
 	/** Roles that must be present, proving the scenario reached its state. */
 	expectRoles?: ProcessRole[];
@@ -72,7 +73,7 @@ export function defineMemoryScenario(options: {
 
 	test.describe(`Memory: ${scenario}`, { tag: [tags.PERFORMANCE] }, () => {
 
-		test(`Memory footprint of the Positron process tree: ${scenario}`, async function ({ app, sessions, logsPath, openDataFile }) {
+		test(`Memory footprint of the Positron process tree: ${scenario}`, async function ({ app, sessions, logsPath, openDataFile, openFile }) {
 			// Derived rather than a round number, because the default 2 minutes is
 			// now too short: a run that waits out both caps would time out before it
 			// could report which one it hit, turning a diagnosable result into a
@@ -89,7 +90,7 @@ export function defineMemoryScenario(options: {
 			expect(mainPid, 'no Electron main pid; this spec only runs against Electron').toBeTruthy();
 
 			if (prepare) {
-				await prepare({ app, sessions, openDataFile });
+				await prepare({ app, sessions, openDataFile, openFile });
 			}
 
 			// Deterministic readiness gate, not a memory heuristic: waits out startup

--- a/test/e2e/tests/performance/memory-scenario.ts
+++ b/test/e2e/tests/performance/memory-scenario.ts
@@ -8,7 +8,7 @@ import { join } from 'path';
 import { expect, tags, test } from '../_test.setup';
 import { Application, Sessions } from '../../infra';
 import { readActivatedExtensions } from '../../utils/memory/extensions.js';
-import { collectSharedProcessGarbage } from '../../utils/memory/gc.js';
+import { collectAllGarbage } from '../../utils/memory/gc.js';
 import { fetchBaseline, publishSnapshots } from '../../utils/memory/publish.js';
 import { renderHtml, renderMarkdown } from '../../utils/memory/render.js';
 import { captureSnapshot, SAMPLING_CAP_MS, SETTLE_CAP_MS, unstableProcesses } from '../../utils/memory/snapshot.js';
@@ -115,7 +115,7 @@ export function defineMemoryScenario(options: {
 				userDataDir: app.userDataPath,
 				launchIndex: Number(process.env.MEMORY_LAUNCH_INDEX ?? 0),
 				extensions,
-				forceGc: () => collectSharedProcessGarbage()
+				forceGc: () => collectAllGarbage()
 			});
 
 			expect(snapshot.processes.length, 'no processes found in the tree').toBeGreaterThan(3);

--- a/test/e2e/tests/performance/memory-scenario.ts
+++ b/test/e2e/tests/performance/memory-scenario.ts
@@ -8,7 +8,7 @@ import { join } from 'path';
 import { expect, tags, test } from '../_test.setup';
 import { Application, Sessions } from '../../infra';
 import { readActivatedExtensions } from '../../utils/memory/extensions.js';
-import { collectAllGarbage, GC_TARGETS } from '../../utils/memory/gc.js';
+import { collectAllGarbage } from '../../utils/memory/gc.js';
 import { fetchBaseline, publishSnapshots } from '../../utils/memory/publish.js';
 import { renderHtml, renderMarkdown } from '../../utils/memory/render.js';
 import { captureSnapshot, SAMPLING_CAP_MS, SETTLE_CAP_MS, unstableProcesses } from '../../utils/memory/snapshot.js';
@@ -117,16 +117,6 @@ export function defineMemoryScenario(options: {
 				extensions,
 				forceGc: () => collectAllGarbage()
 			});
-
-			// --- TEMP DIAGNOSTIC: revert before merge ---
-			// The notebook scenario's ext host is bimodal (+~40 MB on half of
-			// launches, surviving the forced GC). Dump the loaded-module list and a
-			// heap snapshot per launch into the artifact dir so a fat and a thin
-			// launch can be diffed offline.
-			if (scenario === 'notebook') {
-				await dumpExtHostDiagnostics(SNAPSHOT_DIR, Number(process.env.MEMORY_LAUNCH_INDEX ?? 0));
-			}
-			// --- END TEMP DIAGNOSTIC ---
 
 			expect(snapshot.processes.length, 'no processes found in the tree').toBeGreaterThan(3);
 			expect(snapshot.treeTotalPssBytes, 'total PSS was zero; smaps_rollup is probably unreadable').toBeGreaterThan(0);
@@ -251,44 +241,3 @@ export function defineMemoryScenario(options: {
 		});
 	});
 }
-
-// --- TEMP DIAGNOSTIC: revert before merge ---
-// Dumps the ext host's loaded-module list and a V8 heap snapshot into the
-// artifact dir. process.getBuiltinModule is used because the ext host's
-// evaluated context has no global require.
-async function dumpExtHostDiagnostics(dir: string, launchIndex: number): Promise<void> {
-	const port = GC_TARGETS.find(t => t.role === 'extension_host')!.port;
-	const targets = await (await fetch(`http://127.0.0.1:${port}/json`)).json() as { webSocketDebuggerUrl?: string }[];
-	const ws = new WebSocket(targets[0].webSocketDebuggerUrl!);
-	await new Promise<void>((resolve, reject) => {
-		ws.onopen = () => resolve();
-		ws.onerror = () => reject(new Error('diagnostic ws connection failed'));
-	});
-	let nextId = 1;
-	const pending = new Map<number, (msg: any) => void>();
-	ws.onmessage = (ev: any) => {
-		const msg = JSON.parse(String(ev.data));
-		pending.get(msg.id)?.(msg);
-		pending.delete(msg.id);
-	};
-	const evaluate = (expression: string, timeoutMs: number): Promise<string> => new Promise((resolve, reject) => {
-		const id = nextId++;
-		const timer = setTimeout(() => reject(new Error(`diagnostic evaluate timed out after ${timeoutMs}ms`)), timeoutMs);
-		pending.set(id, msg => {
-			clearTimeout(timer);
-			msg.error ? reject(new Error(JSON.stringify(msg.error))) : resolve(msg.result?.result?.value);
-		});
-		ws.send(JSON.stringify({ id, method: 'Runtime.evaluate', params: { expression, returnByValue: true } }));
-	});
-	try {
-		mkdirSync(dir, { recursive: true });
-		const modules = await evaluate(
-			`JSON.stringify(Object.keys(process.getBuiltinModule('module')._cache ?? {}))`, 15_000);
-		writeFileSync(join(dir, `exthost-modules-${launchIndex}.json`), String(modules));
-		const snapPath = join(dir, `exthost-${launchIndex}.heapsnapshot`);
-		await evaluate(`process.getBuiltinModule('v8').writeHeapSnapshot(${JSON.stringify(snapPath)})`, 240_000);
-	} finally {
-		ws.close();
-	}
-}
-// --- END TEMP DIAGNOSTIC ---

--- a/test/e2e/tests/performance/memory-scenario.ts
+++ b/test/e2e/tests/performance/memory-scenario.ts
@@ -153,18 +153,14 @@ export function defineMemoryScenario(options: {
 			expect(impossible.map(p => `${p.processName} (pid ${p.pid})`),
 				'PSS exceeded RSS, which is impossible within one sample').toEqual([]);
 
-			// The sampling loop breaks only when treeHasSettled, so reaching the cap
-			// means it never settled and this is a mid-load number.
-			//
-			// Asserted on sampledMs directly because the `moving` check below cannot
-			// stand in for it, though it was written as if it could. Only the last
-			// TAIL_LENGTH samples are retained, so a launch that spent the full 90s
-			// unsettled still hands unstableProcesses a flat tail and passes: an
-			// `editors` launch did exactly that, discarding 15 samples and publishing a
-			// total 100 MB below its two siblings, with every gate green.
-			expect(snapshot.sampledMs,
+			// False means sampling gave up at the cap, so the figures are mid-load. The
+			// `moving` check below cannot stand in for this, though it was written as if
+			// it could: only the tail is retained, so an `editors` launch that spent the
+			// full 90s unsettled passed every gate while publishing a tree total 100 MB
+			// below its two siblings.
+			expect(snapshot.treeSettled,
 				`sampling ran to its ${SAMPLING_CAP_MS / 1000}s cap without the tree settling, so this is a mid-load number`)
-				.toBeLessThan(SAMPLING_CAP_MS);
+				.toBe(true);
 
 			// Per-process quiescence, which is a weaker condition than the tree
 			// settling: this catches a process still visibly moving within the

--- a/test/e2e/utils/memory/gc.ts
+++ b/test/e2e/utils/memory/gc.ts
@@ -1,0 +1,180 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Forces a garbage collection in Positron's shared process over the Chrome
+ * DevTools Protocol, before a memory snapshot samples it.
+ *
+ * The shared process swings 114-144 MB launch to launch depending on whether V8
+ * happened to have collected its startup garbage by the time sampling ran.
+ * Forcing a GC before sampling converges every launch to within ~3 MB, which is
+ * the only way to make the figure comparable across launches at all.
+ */
+
+/** `--inspect-sharedprocess` port opened on memory-scenario launches so this module can reach it. */
+export const SHARED_PROCESS_INSPECT_PORT = 5879;
+
+export interface SharedProcessGcStats {
+	pid: number;
+	preRssBytes: number;
+	postRssBytes: number;
+	preHeapTotalBytes: number;
+	postHeapTotalBytes: number;
+}
+
+/** Minimal structural slice of the DOM/Node WebSocket this module actually uses. */
+export interface WebSocketLike {
+	send(data: string): void;
+	close(): void;
+	onmessage: ((event: { data: string }) => void) | null;
+	onerror: ((event: unknown) => void) | null;
+}
+
+export type WsConnect = (url: string) => Promise<WebSocketLike>;
+
+/** Opens a real WebSocket, resolving once it has connected. */
+const defaultConnect: WsConnect = (url: string) => new Promise((resolve, reject) => {
+	const ws = new WebSocket(url);
+	ws.onopen = () => resolve(ws as unknown as WebSocketLike);
+	ws.onerror = (event) => reject(new Error(`WebSocket connection to ${url} failed: ${String(event)}`));
+});
+
+/** How long any single CDP round trip may take before this module gives up on the whole GC pass. */
+const MESSAGE_TIMEOUT_MS = 10_000;
+
+/** The two collectGarbage passes are spaced out so the second can catch what the first's finalizers freed. */
+const FIRST_PASS_SETTLE_MS = 3_000;
+const SECOND_PASS_SETTLE_MS = 2_000;
+
+type MemoryUsagePayload = { pid: number; mem: { rss: number; heapTotal: number } };
+
+class CdpClient {
+	private nextId = 1;
+	private readonly pending = new Map<number, { resolve: (value: any) => void; reject: (error: Error) => void }>();
+
+	constructor(private readonly ws: WebSocketLike, private readonly port: number) {
+		this.ws.onmessage = (event) => this.handleMessage(event.data);
+		this.ws.onerror = (event) => this.rejectAllPending(new Error(
+			`Shared process inspector on port ${this.port} errored while forcing a GC: ${String(event)}`));
+	}
+
+	private handleMessage(raw: string): void {
+		let message: any;
+		try {
+			message = JSON.parse(raw);
+		} catch {
+			return;
+		}
+		const pending = this.pending.get(message.id);
+		if (!pending) {
+			return;
+		}
+		this.pending.delete(message.id);
+		if (message.error) {
+			pending.reject(new Error(
+				`Shared process inspector on port ${this.port} rejected a GC request: ${message.error.message ?? JSON.stringify(message.error)}`));
+		} else {
+			pending.resolve(message.result);
+		}
+	}
+
+	private rejectAllPending(error: Error): void {
+		for (const { reject } of this.pending.values()) {
+			reject(error);
+		}
+		this.pending.clear();
+	}
+
+	send<T = any>(method: string, params?: object): Promise<T> {
+		const id = this.nextId++;
+		return new Promise<T>((resolve, reject) => {
+			const timeout = setTimeout(() => {
+				this.pending.delete(id);
+				reject(new Error(
+					`Shared process inspector on port ${this.port} did not reply to ${method} within ${MESSAGE_TIMEOUT_MS}ms`));
+			}, MESSAGE_TIMEOUT_MS);
+			this.pending.set(id, {
+				resolve: (value) => { clearTimeout(timeout); resolve(value); },
+				reject: (error) => { clearTimeout(timeout); reject(error); }
+			});
+			this.ws.send(JSON.stringify({ id, method, params }));
+		});
+	}
+
+	close(): void {
+		this.ws.close();
+	}
+}
+
+async function readMemoryUsage(client: CdpClient, port: number): Promise<MemoryUsagePayload> {
+	const result = await client.send<{ result: { value: string } }>('Runtime.evaluate', {
+		expression: 'JSON.stringify({ pid: process.pid, mem: process.memoryUsage() })',
+		returnByValue: true
+	});
+	try {
+		return JSON.parse(result.result.value);
+	} catch (error) {
+		throw new Error(`Shared process inspector on port ${port} returned an unparseable memoryUsage payload: ${error}`);
+	}
+}
+
+function wait(ms: number): Promise<void> {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Forces two garbage collection passes in the shared process reachable at
+ * `port`'s CDP endpoint and returns its RSS/heap before and after.
+ *
+ * Never returns without a real GC having run: any failure along the way
+ * (unreachable inspector, a websocket error, a 10s message timeout) throws
+ * rather than skipping, because a launch this couldn't reach is not a launch
+ * whose shared process figure can be trusted.
+ */
+export async function collectSharedProcessGarbage(
+	port = SHARED_PROCESS_INSPECT_PORT,
+	connect: WsConnect = defaultConnect,
+	fetchImpl: typeof fetch = fetch
+): Promise<SharedProcessGcStats> {
+	try {
+		const targetsResponse = await fetchImpl(`http://127.0.0.1:${port}/json`);
+		const targets = await targetsResponse.json() as { webSocketDebuggerUrl?: string }[];
+		const target = targets[0];
+		if (!target?.webSocketDebuggerUrl) {
+			throw new Error(`Shared process inspector on port ${port} listed no debuggable target`);
+		}
+
+		const ws = await connect(target.webSocketDebuggerUrl);
+		const client = new CdpClient(ws, port);
+		try {
+			const pre = await readMemoryUsage(client, port);
+
+			await client.send('HeapProfiler.enable');
+			await client.send('HeapProfiler.collectGarbage');
+			await wait(FIRST_PASS_SETTLE_MS);
+			// A second pass catches objects only freed by the first pass's finalizers.
+			await client.send('HeapProfiler.collectGarbage');
+			await wait(SECOND_PASS_SETTLE_MS);
+
+			const post = await readMemoryUsage(client, port);
+
+			return {
+				pid: pre.pid,
+				preRssBytes: pre.mem.rss,
+				postRssBytes: post.mem.rss,
+				preHeapTotalBytes: pre.mem.heapTotal,
+				postHeapTotalBytes: post.mem.heapTotal
+			};
+		} finally {
+			client.close();
+		}
+	} catch (error) {
+		if (error instanceof Error && error.message.includes(`port ${port}`)) {
+			throw error;
+		}
+		throw new Error(
+			`Shared process inspector on port ${port} was unreachable, or forcing a GC through it failed: ${error}`);
+	}
+}

--- a/test/e2e/utils/memory/gc.ts
+++ b/test/e2e/utils/memory/gc.ts
@@ -4,19 +4,31 @@
  *--------------------------------------------------------------------------------------------*/
 
 /**
- * Forces a garbage collection in Positron's shared process over the Chrome
- * DevTools Protocol, before a memory snapshot samples it.
+ * Forces a garbage collection in Positron's Node/V8 processes over the Chrome
+ * DevTools Protocol, before a memory snapshot samples them.
  *
- * The shared process swings 114-144 MB launch to launch depending on whether V8
- * happened to have collected its startup garbage by the time sampling ran.
- * Forcing a GC before sampling converges every launch to within ~3 MB, which is
- * the only way to make the figure comparable across launches at all.
+ * Both the shared process and the extension host idle after startup with no
+ * further allocation, so whether V8 happened to have collected their startup
+ * garbage by sampling time is down to GC timing, not the launch itself. That
+ * swings the shared process 114-144 MB and the extension host ~40 MB launch to
+ * launch. Forcing a GC before sampling converges every launch to within a few
+ * MB, which is the only way to make either figure comparable across launches.
  */
 
-/** `--inspect-sharedprocess` port opened on memory-scenario launches so this module can reach it. */
-export const SHARED_PROCESS_INSPECT_PORT = 5879;
+export interface GcTarget {
+	role: 'shared' | 'extension_host';
+	label: string;
+	port: number;
+	flag: string;
+}
 
-export interface SharedProcessGcStats {
+export const GC_TARGETS: GcTarget[] = [
+	{ role: 'shared', label: 'shared process', port: 5879, flag: '--inspect-sharedprocess' },
+	{ role: 'extension_host', label: 'extension host', port: 5870, flag: '--inspect-extensions' }
+];
+
+export interface ForcedGcStats {
+	role: GcTarget['role'];
 	pid: number;
 	preRssBytes: number;
 	postRssBytes: number;
@@ -54,10 +66,10 @@ class CdpClient {
 	private nextId = 1;
 	private readonly pending = new Map<number, { resolve: (value: any) => void; reject: (error: Error) => void }>();
 
-	constructor(private readonly ws: WebSocketLike, private readonly port: number) {
+	constructor(private readonly ws: WebSocketLike, private readonly target: GcTarget) {
 		this.ws.onmessage = (event) => this.handleMessage(event.data);
 		this.ws.onerror = (event) => this.rejectAllPending(new Error(
-			`Shared process inspector on port ${this.port} errored while forcing a GC: ${String(event)}`));
+			`${this.target.label} inspector on port ${this.target.port} errored while forcing a GC: ${String(event)}`));
 	}
 
 	private handleMessage(raw: string): void {
@@ -74,7 +86,7 @@ class CdpClient {
 		this.pending.delete(message.id);
 		if (message.error) {
 			pending.reject(new Error(
-				`Shared process inspector on port ${this.port} rejected a GC request: ${message.error.message ?? JSON.stringify(message.error)}`));
+				`${this.target.label} inspector on port ${this.target.port} rejected a GC request: ${message.error.message ?? JSON.stringify(message.error)}`));
 		} else {
 			pending.resolve(message.result);
 		}
@@ -93,7 +105,7 @@ class CdpClient {
 			const timeout = setTimeout(() => {
 				this.pending.delete(id);
 				reject(new Error(
-					`Shared process inspector on port ${this.port} did not reply to ${method} within ${MESSAGE_TIMEOUT_MS}ms`));
+					`${this.target.label} inspector on port ${this.target.port} did not reply to ${method} within ${MESSAGE_TIMEOUT_MS}ms`));
 			}, MESSAGE_TIMEOUT_MS);
 			this.pending.set(id, {
 				resolve: (value) => { clearTimeout(timeout); resolve(value); },
@@ -108,7 +120,7 @@ class CdpClient {
 	}
 }
 
-async function readMemoryUsage(client: CdpClient, port: number): Promise<MemoryUsagePayload> {
+async function readMemoryUsage(client: CdpClient, target: GcTarget): Promise<MemoryUsagePayload> {
 	const result = await client.send<{ result: { value: string } }>('Runtime.evaluate', {
 		expression: 'JSON.stringify({ pid: process.pid, mem: process.memoryUsage() })',
 		returnByValue: true
@@ -116,7 +128,7 @@ async function readMemoryUsage(client: CdpClient, port: number): Promise<MemoryU
 	try {
 		return JSON.parse(result.result.value);
 	} catch (error) {
-		throw new Error(`Shared process inspector on port ${port} returned an unparseable memoryUsage payload: ${error}`);
+		throw new Error(`${target.label} inspector on port ${target.port} returned an unparseable memoryUsage payload: ${error}`);
 	}
 }
 
@@ -125,31 +137,32 @@ function wait(ms: number): Promise<void> {
 }
 
 /**
- * Forces two garbage collection passes in the shared process reachable at
- * `port`'s CDP endpoint and returns its RSS/heap before and after.
+ * Forces two garbage collection passes in the process reachable at `target`'s
+ * CDP endpoint and returns its RSS/heap before and after.
  *
  * Never returns without a real GC having run: any failure along the way
  * (unreachable inspector, a websocket error, a 10s message timeout) throws
  * rather than skipping, because a launch this couldn't reach is not a launch
- * whose shared process figure can be trusted.
+ * whose figure can be trusted.
  */
-export async function collectSharedProcessGarbage(
-	port = SHARED_PROCESS_INSPECT_PORT,
+export async function collectGarbageIn(
+	target: GcTarget,
 	connect: WsConnect = defaultConnect,
 	fetchImpl: typeof fetch = fetch
-): Promise<SharedProcessGcStats> {
+): Promise<ForcedGcStats> {
+	const { port } = target;
 	try {
 		const targetsResponse = await fetchImpl(`http://127.0.0.1:${port}/json`);
 		const targets = await targetsResponse.json() as { webSocketDebuggerUrl?: string }[];
-		const target = targets[0];
-		if (!target?.webSocketDebuggerUrl) {
-			throw new Error(`Shared process inspector on port ${port} listed no debuggable target`);
+		const debugTarget = targets[0];
+		if (!debugTarget?.webSocketDebuggerUrl) {
+			throw new Error(`${target.label} inspector on port ${port} listed no debuggable target`);
 		}
 
-		const ws = await connect(target.webSocketDebuggerUrl);
-		const client = new CdpClient(ws, port);
+		const ws = await connect(debugTarget.webSocketDebuggerUrl);
+		const client = new CdpClient(ws, target);
 		try {
-			const pre = await readMemoryUsage(client, port);
+			const pre = await readMemoryUsage(client, target);
 
 			await client.send('HeapProfiler.enable');
 			await client.send('HeapProfiler.collectGarbage');
@@ -158,9 +171,10 @@ export async function collectSharedProcessGarbage(
 			await client.send('HeapProfiler.collectGarbage');
 			await wait(SECOND_PASS_SETTLE_MS);
 
-			const post = await readMemoryUsage(client, port);
+			const post = await readMemoryUsage(client, target);
 
 			return {
+				role: target.role,
 				pid: pre.pid,
 				preRssBytes: pre.mem.rss,
 				postRssBytes: post.mem.rss,
@@ -175,6 +189,18 @@ export async function collectSharedProcessGarbage(
 			throw error;
 		}
 		throw new Error(
-			`Shared process inspector on port ${port} was unreachable, or forcing a GC through it failed: ${error}`);
+			`${target.label} inspector on port ${port} was unreachable, or forcing a GC through it failed: ${error}`);
 	}
+}
+
+/**
+ * Runs {@link collectGarbageIn} against every target in parallel, so the
+ * 3s/2s GC-settle waits are paid once per launch rather than once per target.
+ *
+ * A failure in any one target rejects the whole call: the hard gate stays,
+ * because a launch this couldn't reach for one process is not a launch either
+ * process's figure can be trusted from.
+ */
+export async function collectAllGarbage(targets: GcTarget[] = GC_TARGETS): Promise<ForcedGcStats[]> {
+	return Promise.all(targets.map(target => collectGarbageIn(target)));
 }

--- a/test/e2e/utils/memory/gc.vitest.ts
+++ b/test/e2e/utils/memory/gc.vitest.ts
@@ -1,0 +1,84 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { collectSharedProcessGarbage, WebSocketLike } from './gc.js';
+
+/** Records every method sent, and lets the test script a reply per call. */
+class ScriptedSocket implements WebSocketLike {
+	sent: string[] = [];
+	onmessage: ((event: { data: string }) => void) | null = null;
+	onerror: ((event: unknown) => void) | null = null;
+
+	constructor(private readonly reply: (method: string, id: number) => object) { }
+
+	send(data: string): void {
+		const { id, method } = JSON.parse(data);
+		this.sent.push(method);
+		// Real CDP replies arrive asynchronously; queue on a microtask so callers
+		// have already registered their pending promise before it resolves.
+		queueMicrotask(() => this.onmessage?.({ data: JSON.stringify(this.reply(method, id)) }));
+	}
+
+	close(): void { }
+}
+
+function fakeFetch(port: number): typeof fetch {
+	const response = { json: async () => [{ webSocketDebuggerUrl: 'ws://127.0.0.1/target' }] };
+	return vi.fn(async (url: string | URL) => {
+		expect(String(url)).toBe(`http://127.0.0.1:${port}/json`);
+		return response;
+	}) as unknown as typeof fetch;
+}
+
+describe('collectSharedProcessGarbage', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	test('happy path returns pid and pre/post stats, and issues two collectGarbage calls', async () => {
+		let memCall = 0;
+		const socket = new ScriptedSocket((method, id) => {
+			if (method === 'Runtime.evaluate') {
+				memCall++;
+				const mem = memCall === 1
+					? { rss: 200_000_000, heapTotal: 100_000_000 }
+					: { rss: 150_000_000, heapTotal: 80_000_000 };
+				return { id, result: { result: { value: JSON.stringify({ pid: 4242, mem }) } } };
+			}
+			return { id, result: {} };
+		});
+		const connect = vi.fn(async () => socket);
+
+		const promise = collectSharedProcessGarbage(5879, connect, fakeFetch(5879));
+		// Flush the two 3s/2s waits between GC passes.
+		await vi.runAllTimersAsync();
+		const stats = await promise;
+
+		expect(stats).toEqual({
+			pid: 4242,
+			preRssBytes: 200_000_000,
+			postRssBytes: 150_000_000,
+			preHeapTotalBytes: 100_000_000,
+			postHeapTotalBytes: 80_000_000
+		});
+		expect(socket.sent.filter(m => m === 'HeapProfiler.collectGarbage')).toHaveLength(2);
+		expect(socket.sent).toEqual([
+			'Runtime.evaluate', 'HeapProfiler.enable', 'HeapProfiler.collectGarbage', 'HeapProfiler.collectGarbage', 'Runtime.evaluate'
+		]);
+	});
+
+	test('an error reply rejects with a message naming the port', async () => {
+		const socket = new ScriptedSocket((method, id) => ({ id, error: { message: 'boom' } }));
+		const connect = vi.fn(async () => socket);
+
+		// Rejects on the first message, before any GC-pacing timer is set, so no
+		// timer flush is needed here.
+		await expect(collectSharedProcessGarbage(5879, connect, fakeFetch(5879))).rejects.toThrow(/5879/);
+	});
+});

--- a/test/e2e/utils/memory/gc.vitest.ts
+++ b/test/e2e/utils/memory/gc.vitest.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { collectSharedProcessGarbage, WebSocketLike } from './gc.js';
+import { collectAllGarbage, collectGarbageIn, GcTarget, WebSocketLike } from './gc.js';
 
 /** Records every method sent, and lets the test script a reply per call. */
 class ScriptedSocket implements WebSocketLike {
@@ -33,7 +33,10 @@ function fakeFetch(port: number): typeof fetch {
 	}) as unknown as typeof fetch;
 }
 
-describe('collectSharedProcessGarbage', () => {
+const SHARED_TARGET: GcTarget = { role: 'shared', label: 'shared process', port: 5879, flag: '--inspect-sharedprocess' };
+const EXT_HOST_TARGET: GcTarget = { role: 'extension_host', label: 'extension host', port: 5870, flag: '--inspect-extensions' };
+
+describe('collectGarbageIn', () => {
 	beforeEach(() => {
 		vi.useFakeTimers();
 	});
@@ -41,7 +44,7 @@ describe('collectSharedProcessGarbage', () => {
 		vi.useRealTimers();
 	});
 
-	test('happy path returns pid and pre/post stats, and issues two collectGarbage calls', async () => {
+	test('happy path returns role, pid and pre/post stats, and issues two collectGarbage calls', async () => {
 		let memCall = 0;
 		const socket = new ScriptedSocket((method, id) => {
 			if (method === 'Runtime.evaluate') {
@@ -55,12 +58,13 @@ describe('collectSharedProcessGarbage', () => {
 		});
 		const connect = vi.fn(async () => socket);
 
-		const promise = collectSharedProcessGarbage(5879, connect, fakeFetch(5879));
+		const promise = collectGarbageIn(SHARED_TARGET, connect, fakeFetch(5879));
 		// Flush the two 3s/2s waits between GC passes.
 		await vi.runAllTimersAsync();
 		const stats = await promise;
 
 		expect(stats).toEqual({
+			role: 'shared',
 			pid: 4242,
 			preRssBytes: 200_000_000,
 			postRssBytes: 150_000_000,
@@ -73,12 +77,86 @@ describe('collectSharedProcessGarbage', () => {
 		]);
 	});
 
-	test('an error reply rejects with a message naming the port', async () => {
+	test('an error reply rejects with a message naming the target\'s port', async () => {
 		const socket = new ScriptedSocket((method, id) => ({ id, error: { message: 'boom' } }));
 		const connect = vi.fn(async () => socket);
 
 		// Rejects on the first message, before any GC-pacing timer is set, so no
 		// timer flush is needed here.
-		await expect(collectSharedProcessGarbage(5879, connect, fakeFetch(5879))).rejects.toThrow(/5879/);
+		await expect(collectGarbageIn(EXT_HOST_TARGET, connect, fakeFetch(5870))).rejects.toThrow(/5870/);
+	});
+});
+
+/**
+ * `collectAllGarbage` takes no connect/fetch overrides (it is the real entry
+ * point memory-scenario.ts calls), so these tests stub the globals its default
+ * `connect`/`fetch` read from, keyed by port so each target reaches its own
+ * fake socket.
+ */
+class GlobalFakeSocket {
+	onopen: (() => void) | null = null;
+	onmessage: ((event: { data: string }) => void) | null = null;
+	onerror: ((event: unknown) => void) | null = null;
+
+	constructor(private readonly url: string) {
+		queueMicrotask(() => this.onopen?.());
+	}
+
+	private pidForUrl(): number {
+		return Number(new URL(this.url).searchParams.get('pid'));
+	}
+
+	send(data: string): void {
+		const { id, method } = JSON.parse(data);
+		queueMicrotask(() => {
+			const result = method === 'Runtime.evaluate'
+				? { result: { value: JSON.stringify({ pid: this.pidForUrl(), mem: { rss: 1, heapTotal: 1 } }) } }
+				: {};
+			this.onmessage?.({ data: JSON.stringify({ id, result }) });
+		});
+	}
+
+	close(): void { }
+}
+
+describe('collectAllGarbage', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.unstubAllGlobals();
+	});
+
+	function stubGlobals(fetchMock: typeof fetch): void {
+		vi.stubGlobal('fetch', fetchMock);
+		vi.stubGlobal('WebSocket', GlobalFakeSocket);
+	}
+
+	test('collects both targets in parallel and returns results in target order', async () => {
+		stubGlobals(vi.fn(async (url: string) => {
+			const port = Number(new URL(url).port);
+			return { json: async () => [{ webSocketDebuggerUrl: `ws://127.0.0.1/target?pid=${port}` }] };
+		}) as unknown as typeof fetch);
+
+		const promise = collectAllGarbage([SHARED_TARGET, EXT_HOST_TARGET]);
+		await vi.runAllTimersAsync();
+		const results = await promise;
+
+		expect(results.map(r => r.role)).toEqual(['shared', 'extension_host']);
+		expect(results.map(r => r.pid)).toEqual([SHARED_TARGET.port, EXT_HOST_TARGET.port]);
+	});
+
+	test('a failure in one target rejects the whole call', async () => {
+		stubGlobals(vi.fn(async (url: string) => {
+			const port = Number(new URL(url).port);
+			// The extension host's inspector never lists a debuggable target.
+			return { json: async () => (port === EXT_HOST_TARGET.port ? [] : [{ webSocketDebuggerUrl: `ws://127.0.0.1/target?pid=${port}` }]) };
+		}) as unknown as typeof fetch);
+
+		// Rejects on the first message from the broken target, before any GC-pacing
+		// timer is set, so no timer flush is needed and the rejection is attached
+		// before the microtask that produces it runs.
+		await expect(collectAllGarbage([SHARED_TARGET, EXT_HOST_TARGET])).rejects.toThrow(/5870/);
 	});
 });

--- a/test/e2e/utils/memory/label.vitest.ts
+++ b/test/e2e/utils/memory/label.vitest.ts
@@ -11,7 +11,7 @@ import { deriveExtensionName, normalizeProcessName, resolveRole } from './label.
  * Real shapes, with the paths shortened to the parts the rules actually read.
  */
 const QUARTO_LSP = '/build/bundled/node /home/u/.positron-server/extensions/quarto.quarto-1.135.0-universal/out/lsp/lsp.js --stdio';
-const DUCKDB_WORKER = '/build/bundled/node /build/bundled/extensions/positron-duckdb/dist/duckdb-worker.js';
+const DUCKDB_WORKER = '/build/bundled/node /build/bundled/extensions/positron-duckdb/out/duckdbWorker.js';
 const PET_SERVER = '/build/bundled/extensions/positron-python/python-env-tools/pet server';
 const AIR_LSP = '/home/u/.positron-server/extensions/posit.air-vscode-0.28.0-linux-x64/bundled/bin/air language-server';
 const RUFF_SERVER = '/tmp/extensions-dir/charliermarsh.ruff-2026.70.0-linux-x64/bundled/libs/bin/ruff server';
@@ -152,7 +152,7 @@ describe('deriveExtensionName', () => {
 	// the report as an anonymous share of `language_server` or `extension_child`.
 	test.each([
 		[QUARTO_LSP, 'quarto.quarto (lsp)'],
-		[DUCKDB_WORKER, 'positron-duckdb (duckdb-worker)'],
+		[DUCKDB_WORKER, 'positron-duckdb (duckdbWorker)'],
 		[PET_SERVER, 'positron-python (pet)'],
 	])('names the extension that spawned the process', (cmd, expected) => {
 		expect(deriveExtensionName(cmd)).toBe(expected);

--- a/test/e2e/utils/memory/render.ts
+++ b/test/e2e/utils/memory/render.ts
@@ -581,7 +581,7 @@ export function renderHtml(snapshots: MemorySnapshot[], baseline?: MemorySnapsho
 	${instabilityCard}
 
 	<div class="card">
-		<h2>By role</h2>
+		<h2>Memory by role</h2>
 		<table>
 			<tr><th>Role</th><th align="right">PSS</th><th></th><th align="right">Change</th></tr>
 			${roleRows}

--- a/test/e2e/utils/memory/render.ts
+++ b/test/e2e/utils/memory/render.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { deltaHtml, escapeHtml, formatBytes, notSteadyStateCardHtml, REPORT_CSS, signed } from './report-shell.js';
+import { deltaHtml, escapeHtml, formatBytes, GC_NOTE, notSteadyStateCardHtml, REPORT_CSS, signed } from './report-shell.js';
 import { unstableProcesses } from './snapshot.js';
 import { ActivatedExtension, LabeledProcess, MemorySnapshot, ProcessRole } from './types.js';
 
@@ -575,6 +575,7 @@ export function renderHtml(snapshots: MemorySnapshot[], baseline?: MemorySnapsho
 		<div class="hero">${formatBytes(total)}</div>
 		${baseline ? `<div class="meta">${deltaHtml(total, baseline.treeTotalPssBytes)} vs previous nightly</div>` : ''}
 		<div class="meta">${escapeHtml(samplingSummary(snapshots))}</div>
+		${snapshots.some(s => s.sharedProcessGc !== undefined) ? `<div class="meta">${GC_NOTE}</div>` : ''}
 	</div>
 
 	${instabilityCard}

--- a/test/e2e/utils/memory/render.ts
+++ b/test/e2e/utils/memory/render.ts
@@ -575,7 +575,7 @@ export function renderHtml(snapshots: MemorySnapshot[], baseline?: MemorySnapsho
 		<div class="hero">${formatBytes(total)}</div>
 		${baseline ? `<div class="meta">${deltaHtml(total, baseline.treeTotalPssBytes)} vs previous nightly</div>` : ''}
 		<div class="meta">${escapeHtml(samplingSummary(snapshots))}</div>
-		${snapshots.some(s => s.sharedProcessGc !== undefined) ? `<div class="meta">${GC_NOTE}</div>` : ''}
+		${snapshots.some(s => (s.forcedGc?.length ?? 0) > 0) ? `<div class="meta">${GC_NOTE}</div>` : ''}
 	</div>
 
 	${instabilityCard}

--- a/test/e2e/utils/memory/render.vitest.ts
+++ b/test/e2e/utils/memory/render.vitest.ts
@@ -285,18 +285,19 @@ describe('renderHtml', () => {
 		expect(output).toContain('&lt;script&gt;');
 	});
 
-	test('renders a delta with both a glyph and a signed number, not color alone', () => {
+	test('renders a delta with a glyph, not color alone', () => {
 		const current = snapshot([proc({ pssBytes: 150 * MB })]);
 		const baseline = snapshot([proc({ pssBytes: 100 * MB })]);
 		const output = renderHtml([current], baseline);
-		expect(output).toMatch(/&#9650;[^<]*\+50\.0 MB/);
+		expect(output).toMatch(/&#9650;[^<]*50\.0 MB/);
 	});
 
-	test('renders a decrease with the down glyph and a negative number', () => {
+	test('renders a decrease with the down glyph, the only thing marking direction', () => {
 		const current = snapshot([proc({ pssBytes: 80 * MB })]);
 		const baseline = snapshot([proc({ pssBytes: 100 * MB })]);
 		const output = renderHtml([current], baseline);
-		expect(output).toMatch(/&#9660;[^<]*-20\.0 MB/);
+		expect(output).toMatch(/&#9660;[^<]*20\.0 MB/);
+		expect(output).not.toMatch(/&#9660;[^<]*-20\.0 MB/);
 	});
 
 	test('sizes the magnitude bar proportionally to PSS', () => {
@@ -353,7 +354,7 @@ describe('renderHtml', () => {
 		const output = renderHtml([snapshot(tree)], baseline);
 		// Both processes share the `language_server` role, so a role-level delta
 		// could not say which one moved. The per-process row must.
-		expect(treeSection(output)).toMatch(/quarto\.quarto \(lsp\)[\s\S]*&#9650;[^<]*\+20\.0 MB/);
+		expect(treeSection(output)).toMatch(/quarto\.quarto \(lsp\)[\s\S]*&#9650;[^<]*20\.0 MB/);
 	});
 
 	test('marks a process absent from the baseline as new in the tree, not a fabricated delta', () => {

--- a/test/e2e/utils/memory/render.vitest.ts
+++ b/test/e2e/utils/memory/render.vitest.ts
@@ -146,7 +146,7 @@ describe('renderMarkdown', () => {
 	test('shows the GC note only when a snapshot carries a forced-GC reading', () => {
 		expect(renderHtml([snapshot([proc()])])).not.toContain('forced garbage collection');
 
-		const gcSnapshot = { ...snapshot([proc()]), sharedProcessGc: { pid: 1, preRssBytes: 1, postRssBytes: 1, preHeapTotalBytes: 1, postHeapTotalBytes: 1 } };
+		const gcSnapshot = { ...snapshot([proc()]), forcedGc: [{ role: 'extension_host' as const, pid: 1, preRssBytes: 1, postRssBytes: 1, preHeapTotalBytes: 1, postHeapTotalBytes: 1 }] };
 		expect(renderHtml([gcSnapshot])).toContain('forced garbage collection');
 	});
 

--- a/test/e2e/utils/memory/render.vitest.ts
+++ b/test/e2e/utils/memory/render.vitest.ts
@@ -143,6 +143,13 @@ describe('renderMarkdown', () => {
 		expect(html).toContain('vs previous nightly');
 	});
 
+	test('shows the GC note only when a snapshot carries a forced-GC reading', () => {
+		expect(renderHtml([snapshot([proc()])])).not.toContain('forced garbage collection');
+
+		const gcSnapshot = { ...snapshot([proc()]), sharedProcessGc: { pid: 1, preRssBytes: 1, postRssBytes: 1, preHeapTotalBytes: 1, postHeapTotalBytes: 1 } };
+		expect(renderHtml([gcSnapshot])).toContain('forced garbage collection');
+	});
+
 	test('works with no baseline', () => {
 		expect(() => renderMarkdown([snapshot([proc()])])).not.toThrow();
 	});

--- a/test/e2e/utils/memory/report-shell.ts
+++ b/test/e2e/utils/memory/report-shell.ts
@@ -41,14 +41,18 @@ export function escapeHtml(text: string): string {
 }
 
 /**
- * Up/down triangle plus a signed number, so a delta is never conveyed by color
- * alone. Near-zero (under 1 MB) gets neither color nor glyph, just a plain
- * number, since a swing that small is noise rather than signal.
+ * Up/down triangle plus a number, so a delta is never conveyed by color alone.
+ *
+ * The glyph carries the direction, so the sign would only repeat it. Near-zero
+ * (under 1 MB) gets neither color nor glyph, just a plain number, since a swing
+ * that small is noise rather than signal -- and there the sign is the only thing
+ * saying which way it went, so it stays.
  */
 export function deltaHtmlFromDiff(diff: number): string {
-	const cls = Math.abs(diff) < MB ? 'delta-flat' : diff > 0 ? 'delta-up' : 'delta-down';
-	const glyph = Math.abs(diff) < MB ? '' : diff > 0 ? '&#9650; ' : '&#9660; ';
-	return `<span class="${cls}">${glyph}${signed(diff)}</span>`;
+	const flat = Math.abs(diff) < MB;
+	const cls = flat ? 'delta-flat' : diff > 0 ? 'delta-up' : 'delta-down';
+	const glyph = flat ? '' : diff > 0 ? '&#9650; ' : '&#9660; ';
+	return `<span class="${cls}">${glyph}${flat ? signed(diff) : formatBytes(Math.abs(diff))}</span>`;
 }
 
 /** Same as {@link deltaHtmlFromDiff}, computing the diff from two absolute values. */
@@ -101,6 +105,13 @@ export const REPORT_CSS = `
 		.card .meta { color: #6b7280; font-size: 0.9rem; margin-bottom: 12px; }
 		table { border-collapse: collapse; width: 100%; }
 		td, th { padding: 4px 8px; text-align: left; }
+		/* Both reports mark numeric cells with align="right", which the rule above was
+		silently overriding -- CSS beats a presentational attribute -- so every figure
+		rendered left-aligned and the decimal points did not line up to compare. */
+		td[align="right"], th[align="right"] { text-align: right; }
+		/* Proportional digits are not the same width, so even right-aligned figures put
+		their decimal points in slightly different places down a column. */
+		td[align="right"] { font-variant-numeric: tabular-nums; }
 		/* Bolder and darker than the values are, but smaller: size keeps the header from
 		competing with the data while weight still marks it as the label band. At 500 in
 		light gray it read as just another row. */

--- a/test/e2e/utils/memory/report-shell.ts
+++ b/test/e2e/utils/memory/report-shell.ts
@@ -15,6 +15,9 @@
 
 const MB = 1024 * 1024;
 
+/** Shown by both reports whenever a snapshot carries a forced-GC reading, so live usage is not mistaken for it. */
+export const GC_NOTE = 'Shared process figures are taken after a forced garbage collection so launches compare cleanly; live usage can sit higher.';
+
 /**
  * Always MB, never GB. Every scenario in the report sits in the hundreds to
  * low thousands of MB, and a GB branch collapses exactly the resolution the

--- a/test/e2e/utils/memory/report-shell.ts
+++ b/test/e2e/utils/memory/report-shell.ts
@@ -16,7 +16,7 @@
 const MB = 1024 * 1024;
 
 /** Shown by both reports whenever a snapshot carries a forced-GC reading, so live usage is not mistaken for it. */
-export const GC_NOTE = 'Shared process figures are taken after a forced garbage collection so launches compare cleanly; live usage can sit higher.';
+export const GC_NOTE = 'Shared process and extension host are measured after a forced garbage collection; live usage can sit higher.';
 
 /**
  * Always MB, never GB. Every scenario in the report sits in the hundreds to

--- a/test/e2e/utils/memory/scenarios.ts
+++ b/test/e2e/utils/memory/scenarios.ts
@@ -12,7 +12,7 @@
  * that adding a scenario here and forgetting it everywhere else is a compile
  * error, not a silent gap.
  */
-export const MEMORY_SCENARIOS = ['idle', 'session-python', 'session-r'] as const;
+export const MEMORY_SCENARIOS = ['idle', 'session-python', 'session-r', 'data-explorer', 'notebook'] as const;
 
 export type MemoryScenario = typeof MEMORY_SCENARIOS[number];
 
@@ -30,7 +30,9 @@ export function isMemoryScenario(value: string | undefined): value is MemoryScen
 const SPEC_BY_SCENARIO: Record<MemoryScenario, string> = {
 	'idle': '**/performance/memory-idle.test.ts',
 	'session-python': '**/performance/memory-session-python.test.ts',
-	'session-r': '**/performance/memory-session-r.test.ts'
+	'session-r': '**/performance/memory-session-r.test.ts',
+	'data-explorer': '**/performance/memory-data-explorer.test.ts',
+	'notebook': '**/performance/memory-notebook.test.ts'
 };
 
 /**

--- a/test/e2e/utils/memory/scenarios.ts
+++ b/test/e2e/utils/memory/scenarios.ts
@@ -12,7 +12,7 @@
  * that adding a scenario here and forgetting it everywhere else is a compile
  * error, not a silent gap.
  */
-export const MEMORY_SCENARIOS = ['idle', 'session-python', 'session-r', 'data-explorer', 'notebook', 'editors'] as const;
+export const MEMORY_SCENARIOS = ['idle', 'session-python', 'session-r', 'data-explorer', 'notebook', 'editors', 'console-output'] as const;
 
 export type MemoryScenario = typeof MEMORY_SCENARIOS[number];
 
@@ -33,7 +33,8 @@ const SPEC_BY_SCENARIO: Record<MemoryScenario, string> = {
 	'session-r': '**/performance/memory-session-r.test.ts',
 	'data-explorer': '**/performance/memory-data-explorer.test.ts',
 	'notebook': '**/performance/memory-notebook.test.ts',
-	'editors': '**/performance/memory-editors.test.ts'
+	'editors': '**/performance/memory-editors.test.ts',
+	'console-output': '**/performance/memory-console-output.test.ts'
 };
 
 /**

--- a/test/e2e/utils/memory/scenarios.ts
+++ b/test/e2e/utils/memory/scenarios.ts
@@ -12,7 +12,7 @@
  * that adding a scenario here and forgetting it everywhere else is a compile
  * error, not a silent gap.
  */
-export const MEMORY_SCENARIOS = ['idle', 'session-python', 'session-r', 'data-explorer', 'notebook'] as const;
+export const MEMORY_SCENARIOS = ['idle', 'session-python', 'session-r', 'data-explorer', 'notebook', 'editors'] as const;
 
 export type MemoryScenario = typeof MEMORY_SCENARIOS[number];
 
@@ -32,7 +32,8 @@ const SPEC_BY_SCENARIO: Record<MemoryScenario, string> = {
 	'session-python': '**/performance/memory-session-python.test.ts',
 	'session-r': '**/performance/memory-session-r.test.ts',
 	'data-explorer': '**/performance/memory-data-explorer.test.ts',
-	'notebook': '**/performance/memory-notebook.test.ts'
+	'notebook': '**/performance/memory-notebook.test.ts',
+	'editors': '**/performance/memory-editors.test.ts'
 };
 
 /**

--- a/test/e2e/utils/memory/scenarios.vitest.ts
+++ b/test/e2e/utils/memory/scenarios.vitest.ts
@@ -30,7 +30,8 @@ describe('memorySpecsToIgnore', () => {
 			'**/performance/memory-session-r.test.ts',
 			'**/performance/memory-data-explorer.test.ts',
 			'**/performance/memory-notebook.test.ts',
-			'**/performance/memory-editors.test.ts'
+			'**/performance/memory-editors.test.ts',
+			'**/performance/memory-console-output.test.ts'
 		]);
 	});
 
@@ -40,7 +41,8 @@ describe('memorySpecsToIgnore', () => {
 			'**/performance/memory-session-python.test.ts',
 			'**/performance/memory-data-explorer.test.ts',
 			'**/performance/memory-notebook.test.ts',
-			'**/performance/memory-editors.test.ts'
+			'**/performance/memory-editors.test.ts',
+			'**/performance/memory-console-output.test.ts'
 		]);
 	});
 

--- a/test/e2e/utils/memory/scenarios.vitest.ts
+++ b/test/e2e/utils/memory/scenarios.vitest.ts
@@ -27,18 +27,22 @@ describe('memorySpecsToIgnore', () => {
 		expect(memorySpecsToIgnore(undefined)).toEqual([
 			'**/performance/memory-idle.test.ts',
 			'**/performance/memory-session-python.test.ts',
-			'**/performance/memory-session-r.test.ts'
+			'**/performance/memory-session-r.test.ts',
+			'**/performance/memory-data-explorer.test.ts',
+			'**/performance/memory-notebook.test.ts'
 		]);
 	});
 
 	test('keeps only the running scenario, so one job measures one state', () => {
 		expect(memorySpecsToIgnore('session-r')).toEqual([
 			'**/performance/memory-idle.test.ts',
-			'**/performance/memory-session-python.test.ts'
+			'**/performance/memory-session-python.test.ts',
+			'**/performance/memory-data-explorer.test.ts',
+			'**/performance/memory-notebook.test.ts'
 		]);
 	});
 
 	test('ignores everything when the scenario is a typo, rather than running the wrong spec', () => {
-		expect(memorySpecsToIgnore('session_r')).toHaveLength(3);
+		expect(memorySpecsToIgnore('session_r')).toHaveLength(MEMORY_SCENARIOS.length);
 	});
 });

--- a/test/e2e/utils/memory/scenarios.vitest.ts
+++ b/test/e2e/utils/memory/scenarios.vitest.ts
@@ -29,7 +29,8 @@ describe('memorySpecsToIgnore', () => {
 			'**/performance/memory-session-python.test.ts',
 			'**/performance/memory-session-r.test.ts',
 			'**/performance/memory-data-explorer.test.ts',
-			'**/performance/memory-notebook.test.ts'
+			'**/performance/memory-notebook.test.ts',
+			'**/performance/memory-editors.test.ts'
 		]);
 	});
 
@@ -38,7 +39,8 @@ describe('memorySpecsToIgnore', () => {
 			'**/performance/memory-idle.test.ts',
 			'**/performance/memory-session-python.test.ts',
 			'**/performance/memory-data-explorer.test.ts',
-			'**/performance/memory-notebook.test.ts'
+			'**/performance/memory-notebook.test.ts',
+			'**/performance/memory-editors.test.ts'
 		]);
 	});
 

--- a/test/e2e/utils/memory/snapshot.ts
+++ b/test/e2e/utils/memory/snapshot.ts
@@ -260,8 +260,13 @@ export function treeHasSettled(samples: RawProcess[][]): boolean {
  * Processes whose samples moved too much for their median to mean anything.
  *
  * Reported rather than thrown on: a caller decides whether an unstable process
- * invalidates the run. With the sampling loop waiting on {@link isSteady}, this
- * should now be empty unless a launch hit {@link SAMPLING_CAP_MS}.
+ * invalidates the run.
+ *
+ * Do NOT read this as a proxy for "the launch hit {@link SAMPLING_CAP_MS}", which
+ * an earlier version of this comment claimed. Only the last {@link TAIL_LENGTH}
+ * samples are retained, so a launch that sampled to the cap without ever settling
+ * still presents a flat tail here and comes back empty. Assert on
+ * `snapshot.sampledMs` for that, as memory-scenario.ts does.
  */
 export function unstableProcesses(processes: LabeledProcess[]): LabeledProcess[] {
 	return processes.filter(proc => proc.pssBytes > 0 && !isSteady(proc.pssSamples));

--- a/test/e2e/utils/memory/snapshot.ts
+++ b/test/e2e/utils/memory/snapshot.ts
@@ -5,6 +5,7 @@
 
 import { basename } from 'path';
 import { getPositronVersion } from '../../infra/test-runner/positron-version.js';
+import { SharedProcessGcStats } from './gc.js';
 import { deriveExtensionName, isGenericName, normalizeProcessName, resolveRole } from './label.js';
 import { readProcessNames } from './positron-status.js';
 import { readProcessTree } from './process-tree.js';
@@ -325,8 +326,13 @@ export async function captureSnapshot(input: {
 	userDataDir: string;
 	launchIndex: number;
 	extensions: ActivatedExtension[];
+	forceGc?: () => Promise<SharedProcessGcStats>;
 }): Promise<MemorySnapshot> {
 	const { settleMs, peakTotalPss } = await waitForSettle(input.rootPid);
+
+	// Must land after settle, so startup allocation is already done, and before
+	// sampling starts, so the reported tail reflects the collected state.
+	const sharedProcessGc = input.forceGc ? await input.forceGc() : undefined;
 
 	const samples: RawProcess[][] = [];
 	const startedSampling = Date.now();
@@ -357,6 +363,7 @@ export async function captureSnapshot(input: {
 		settleMs,
 		sampledMs,
 		treeSettled,
+		sharedProcessGc,
 		discardedSamples: samples.length - reported.length,
 		treeTotalPssBytes: processes.reduce((sum, p) => sum + p.pssBytes, 0),
 		processes,

--- a/test/e2e/utils/memory/snapshot.ts
+++ b/test/e2e/utils/memory/snapshot.ts
@@ -280,7 +280,7 @@ export function treeHasSettled(samples: RawProcess[][], peakBeforeSampling = 0):
  * an earlier version of this comment claimed. Only the last {@link TAIL_LENGTH}
  * samples are retained, so a launch that sampled to the cap without ever settling
  * still presents a flat tail here and comes back empty. Assert on
- * `snapshot.sampledMs` for that, as memory-scenario.ts does.
+ * `snapshot.treeSettled` for that, as memory-scenario.ts does.
  */
 export function unstableProcesses(processes: LabeledProcess[]): LabeledProcess[] {
 	return processes.filter(proc => proc.pssBytes > 0 && !isSteady(proc.pssSamples));
@@ -330,12 +330,14 @@ export async function captureSnapshot(input: {
 
 	const samples: RawProcess[][] = [];
 	const startedSampling = Date.now();
+	let treeSettled = false;
 	while (Date.now() - startedSampling < SAMPLING_CAP_MS) {
 		if (samples.length > 0) {
 			await new Promise(resolve => setTimeout(resolve, SAMPLE_INTERVAL_MS));
 		}
 		samples.push(await readProcessTree(input.rootPid));
 		if (treeHasSettled(samples, peakTotalPss)) {
+			treeSettled = true;
 			break;
 		}
 	}
@@ -354,6 +356,7 @@ export async function captureSnapshot(input: {
 		launchIndex: input.launchIndex,
 		settleMs,
 		sampledMs,
+		treeSettled,
 		discardedSamples: samples.length - reported.length,
 		treeTotalPssBytes: processes.reduce((sum, p) => sum + p.pssBytes, 0),
 		processes,

--- a/test/e2e/utils/memory/snapshot.ts
+++ b/test/e2e/utils/memory/snapshot.ts
@@ -135,12 +135,17 @@ export const SETTLE_CAP_MS = 90_000;
 
 /**
  * Wait until the process tree stops growing, rather than sleeping a fixed
- * amount. Returns how long that took, which is worth recording on its own.
+ * amount.
+ *
+ * Returns how long that took, which is worth recording on its own, and the
+ * highest total it saw. The peak matters because the startup reclaim can land
+ * inside this window rather than after it: see {@link treeHasSettled}, which
+ * cannot detect a drop it never observed.
  */
 export async function waitForSettle(
 	rootPid: number,
 	options: { pollMs?: number; capMs?: number } = {}
-): Promise<number> {
+): Promise<{ settleMs: number; peakTotalPss: number }> {
 	const pollMs = options.pollMs ?? 1000;
 	const capMs = options.capMs ?? SETTLE_CAP_MS;
 	const started = Date.now();
@@ -153,7 +158,10 @@ export async function waitForSettle(
 		}
 		await new Promise(resolve => setTimeout(resolve, pollMs));
 	}
-	return Date.now() - started;
+	return {
+		settleMs: Date.now() - started,
+		peakTotalPss: readings.length > 0 ? Math.max(...readings) : 0
+	};
 }
 
 /**
@@ -232,12 +240,18 @@ const RECLAIM_DROP_FRACTION = 0.05;
  * flatness per process, because summing hides it (the renderer's step is 45% of
  * the renderer but 13% of the tree). An empty tree is settled: the root is gone.
  */
-export function treeHasSettled(samples: RawProcess[][]): boolean {
+export function treeHasSettled(samples: RawProcess[][], peakBeforeSampling = 0): boolean {
 	if (samples.length < TAIL_LENGTH) {
 		return false;
 	}
 	const totals = samples.map(totalPss);
-	const peak = Math.max(...totals);
+	// Includes the peak waitForSettle saw, because the reclaim does not reliably
+	// wait for sampling to start. An `editors` launch took 11.4s to stop growing
+	// (siblings took 4.2s), reclaimed inside that window, and then presented a
+	// dead-flat tree for 90s: with the peak taken from sampling alone, latest was
+	// the peak, no drop was visible, and the launch burned the cap with every
+	// process motionless. Measuring against the earlier peak sees the drop.
+	const peak = Math.max(peakBeforeSampling, ...totals);
 	const latest = totals[totals.length - 1];
 	if (latest > peak * (1 - RECLAIM_DROP_FRACTION)) {
 		return false;
@@ -312,7 +326,7 @@ export async function captureSnapshot(input: {
 	launchIndex: number;
 	extensions: ActivatedExtension[];
 }): Promise<MemorySnapshot> {
-	const settleMs = await waitForSettle(input.rootPid);
+	const { settleMs, peakTotalPss } = await waitForSettle(input.rootPid);
 
 	const samples: RawProcess[][] = [];
 	const startedSampling = Date.now();
@@ -321,7 +335,7 @@ export async function captureSnapshot(input: {
 			await new Promise(resolve => setTimeout(resolve, SAMPLE_INTERVAL_MS));
 		}
 		samples.push(await readProcessTree(input.rootPid));
-		if (treeHasSettled(samples)) {
+		if (treeHasSettled(samples, peakTotalPss)) {
 			break;
 		}
 	}

--- a/test/e2e/utils/memory/snapshot.ts
+++ b/test/e2e/utils/memory/snapshot.ts
@@ -5,7 +5,7 @@
 
 import { basename } from 'path';
 import { getPositronVersion } from '../../infra/test-runner/positron-version.js';
-import { SharedProcessGcStats } from './gc.js';
+import { ForcedGcStats } from './gc.js';
 import { deriveExtensionName, isGenericName, normalizeProcessName, resolveRole } from './label.js';
 import { readProcessNames } from './positron-status.js';
 import { readProcessTree } from './process-tree.js';
@@ -326,13 +326,13 @@ export async function captureSnapshot(input: {
 	userDataDir: string;
 	launchIndex: number;
 	extensions: ActivatedExtension[];
-	forceGc?: () => Promise<SharedProcessGcStats>;
+	forceGc?: () => Promise<ForcedGcStats[]>;
 }): Promise<MemorySnapshot> {
 	const { settleMs, peakTotalPss } = await waitForSettle(input.rootPid);
 
 	// Must land after settle, so startup allocation is already done, and before
 	// sampling starts, so the reported tail reflects the collected state.
-	const sharedProcessGc = input.forceGc ? await input.forceGc() : undefined;
+	const forcedGc = input.forceGc ? await input.forceGc() : undefined;
 
 	const samples: RawProcess[][] = [];
 	const startedSampling = Date.now();
@@ -363,7 +363,7 @@ export async function captureSnapshot(input: {
 		settleMs,
 		sampledMs,
 		treeSettled,
-		sharedProcessGc,
+		forcedGc,
 		discardedSamples: samples.length - reported.length,
 		treeTotalPssBytes: processes.reduce((sum, p) => sum + p.pssBytes, 0),
 		processes,

--- a/test/e2e/utils/memory/snapshot.vitest.ts
+++ b/test/e2e/utils/memory/snapshot.vitest.ts
@@ -197,6 +197,24 @@ describe('treeHasSettled', () => {
 		))).toBe(true);
 	});
 
+	// The measured failure this argument exists for: an `editors` launch took 11.4s
+	// to stop growing where its siblings took 4.2s, reclaimed inside that window,
+	// and then held dead flat. With the peak taken from sampling alone there is no
+	// drop left to see, so it burned the 90s cap with every process motionless.
+	test('is false when the reclaim happened before sampling and is invisible here', () => {
+		expect(treeHasSettled(tree(renderer(413, 413, 413, 413)))).toBe(false);
+	});
+
+	test('is true when the drop is only visible against the peak seen while settling', () => {
+		expect(treeHasSettled(tree(renderer(413, 413, 413, 413)), 600 * MB)).toBe(true);
+	});
+
+	test('ignores a settle-phase peak lower than what sampling saw, so the old behaviour stands', () => {
+		// A reclaim landing during sampling is the ordinary case, and a smaller
+		// earlier peak must not make the startup plateau look reclaimed.
+		expect(treeHasSettled(tree(renderer(565, 559, 559, 559)), 100 * MB)).toBe(false);
+	});
+
 	test('too few samples is never settled', () => {
 		expect(treeHasSettled(tree(renderer(559, 287)))).toBe(false);
 	});
@@ -238,5 +256,22 @@ describe('isSettled', () => {
 
 	test('growth resuming after a plateau is not settled', () => {
 		expect(isSettled([500 * MB, 501 * MB, 502 * MB, 700 * MB])).toBe(false);
+	});
+});
+
+describe('the 50 MB floor on flatness', () => {
+	const MB = 1048576;
+
+	// Counterintuitive and worth pinning: isSteady needs the spread to clear
+	// UNSTABLE_SPREAD_BYTES as well as 5%, so a double-digit percentage drop on a
+	// mid-sized process still counts as flat. A Quarto language server releasing
+	// 8.5 MB (11% of itself) at the sampling cap therefore looked like the reason a
+	// launch never settled while being entirely innocent of it.
+	test('counts an 11% drop as flat when it is only 8 MB', () => {
+		expect(tailIsFlat([74 * MB, 74 * MB, 74 * MB, 66 * MB])).toBe(true);
+	});
+
+	test('counts the same fractional drop as moving once it clears 50 MB', () => {
+		expect(tailIsFlat([740 * MB, 740 * MB, 740 * MB, 660 * MB])).toBe(false);
 	});
 });

--- a/test/e2e/utils/memory/summarize-cli.ts
+++ b/test/e2e/utils/memory/summarize-cli.ts
@@ -143,7 +143,9 @@ function renderMarkdownTable(matrix: SummaryMatrix): string {
 	const lines: string[] = [];
 	lines.push('## Memory: cross-scenario summary', '');
 	lines.push(`| Role | ${matrix.scenarios.join(' | ')} |`);
-	lines.push(`| --- | ${matrix.scenarios.map(() => '---').join(' | ')} |`);
+	// Right-aligned figures, matching the HTML report: the decimal points line up, so a
+	// column can be compared down its length without reading each number.
+	lines.push(`| --- | ${matrix.scenarios.map(() => '---:').join(' | ')} |`);
 
 	for (const row of matrix.rows) {
 		const cells = matrix.scenarios.map(scenario => {

--- a/test/e2e/utils/memory/summary.ts
+++ b/test/e2e/utils/memory/summary.ts
@@ -15,7 +15,7 @@
  * real memory run.
  */
 
-import { deltaHtmlFromDiff, escapeHtml, formatBytes, notSteadyStateCardHtml, REPORT_CSS } from './report-shell.js';
+import { deltaHtmlFromDiff, escapeHtml, formatBytes, GC_NOTE, notSteadyStateCardHtml, REPORT_CSS } from './report-shell.js';
 import { byRole } from './render.js';
 import { unstableProcesses } from './snapshot.js';
 import { MemoryScenario } from './scenarios.js';
@@ -73,6 +73,8 @@ export type SummaryMatrix = {
 	 * may have been moving, and this is what says which.
 	 */
 	unstable: UnstableEntry[];
+	/** Whether any snapshot behind this matrix carries a forced-GC reading, so the legend can gate on it. */
+	hasSharedProcessGc: boolean;
 };
 
 /**
@@ -224,7 +226,9 @@ export function buildSummaryMatrix(entries: ScenarioSnapshots[]): SummaryMatrix 
 	const others = scenarios.filter(s => s !== 'idle').sort((a, b) => totalDeltaVsIdle.get(a)! - totalDeltaVsIdle.get(b)!);
 	const sortedScenarios = scenarios.includes('idle') ? ['idle' as MemoryScenario, ...others] : others;
 
-	return { scenarios: sortedScenarios, rows, totals, totalEmphasisThreshold, unstable };
+	const hasSharedProcessGc = entries.some(({ snapshots }) => snapshots.some(s => s.sharedProcessGc !== undefined));
+
+	return { scenarios: sortedScenarios, rows, totals, totalEmphasisThreshold, unstable, hasSharedProcessGc };
 }
 
 /** Muted em-dash: a role that did not exist in this scenario, never a fabricated zero. */
@@ -366,7 +370,7 @@ export function renderSummaryHtml(matrix: SummaryMatrix): string {
 
 	<div class="card">
 		<h2>By role</h2>
-		<div class="meta">${DELTA_LEGEND}</div>
+		<div class="meta">${DELTA_LEGEND}${matrix.hasSharedProcessGc ? ` ${GC_NOTE}` : ''}</div>
 		<table class="matrix">
 			<tr><th>Role</th>${scenarioHeaderHtml(matrix.scenarios)}</tr>
 			${rows}

--- a/test/e2e/utils/memory/summary.ts
+++ b/test/e2e/utils/memory/summary.ts
@@ -74,7 +74,7 @@ export type SummaryMatrix = {
 	 */
 	unstable: UnstableEntry[];
 	/** Whether any snapshot behind this matrix carries a forced-GC reading, so the legend can gate on it. */
-	hasSharedProcessGc: boolean;
+	hasForcedGc: boolean;
 };
 
 /**
@@ -226,9 +226,9 @@ export function buildSummaryMatrix(entries: ScenarioSnapshots[]): SummaryMatrix 
 	const others = scenarios.filter(s => s !== 'idle').sort((a, b) => totalDeltaVsIdle.get(a)! - totalDeltaVsIdle.get(b)!);
 	const sortedScenarios = scenarios.includes('idle') ? ['idle' as MemoryScenario, ...others] : others;
 
-	const hasSharedProcessGc = entries.some(({ snapshots }) => snapshots.some(s => s.sharedProcessGc !== undefined));
+	const hasForcedGc = entries.some(({ snapshots }) => snapshots.some(s => (s.forcedGc?.length ?? 0) > 0));
 
-	return { scenarios: sortedScenarios, rows, totals, totalEmphasisThreshold, unstable, hasSharedProcessGc };
+	return { scenarios: sortedScenarios, rows, totals, totalEmphasisThreshold, unstable, hasForcedGc };
 }
 
 /** Muted em-dash: a role that did not exist in this scenario, never a fabricated zero. */
@@ -313,8 +313,8 @@ function instabilityHtml(unstable: UnstableEntry[]): string {
  * than a flat "5 MB or more": the real bar is per role and usually higher, and a
  * legend that understated it would invite reading an unmarked 8 MB move as a bug.
  */
-const DELTA_LEGEND = `Deltas appear only when changes exceed launch-to-launch noise, with a
-	${formatBytes(MIN_EMPHASIS_BYTES)} minimum. Blank cells are within noise.`;
+const DELTA_LEGEND = `Deltas appear only when a change beats launch-to-launch noise
+	(${formatBytes(MIN_EMPHASIS_BYTES)} minimum); cells without one are within noise.`;
 
 /**
  * Renders the matrix as a standalone HTML document, using the same shell
@@ -370,7 +370,7 @@ export function renderSummaryHtml(matrix: SummaryMatrix): string {
 
 	<div class="card">
 		<h2>By role</h2>
-		<div class="meta">${DELTA_LEGEND}${matrix.hasSharedProcessGc ? ` ${GC_NOTE}` : ''}</div>
+		<div class="meta">${DELTA_LEGEND}${matrix.hasForcedGc ? ` ${GC_NOTE}` : ''}</div>
 		<table class="matrix">
 			<tr><th>Role</th>${scenarioHeaderHtml(matrix.scenarios)}</tr>
 			${rows}

--- a/test/e2e/utils/memory/summary.ts
+++ b/test/e2e/utils/memory/summary.ts
@@ -201,22 +201,29 @@ export function buildSummaryMatrix(entries: ScenarioSnapshots[]): SummaryMatrix 
 /** Muted em-dash: a role that did not exist in this scenario, never a fabricated zero. */
 const ABSENT_MARKER = '<span class="muted">&mdash;</span>';
 
+/** Marks the column every delta is measured from, so the table reads baseline -> comparisons. */
+function baselineClass(scenario: MemoryScenario): string {
+	return scenario === 'idle' ? ' class="baseline"' : '';
+}
+
 function scenarioHeaderHtml(scenarios: MemoryScenario[]): string {
-	return scenarios.map(s => `<th align="right">${escapeHtml(s)}</th>`).join('');
+	return scenarios.map(s => `<th align="right"${baselineClass(s)}>${escapeHtml(s)}</th>`).join('');
 }
 
 /** One scenario's cell: the PSS value, plus (for a non-idle scenario) its delta against idle underneath. */
 function cellHtml(scenario: MemoryScenario, value: number | undefined, delta: number | undefined, threshold: number): string {
 	if (value === undefined) {
-		return `<td align="right">${ABSENT_MARKER}</td>`;
+		return `<td align="right"${baselineClass(scenario)}>${ABSENT_MARKER}</td>`;
 	}
 	// Below the threshold nothing renders: a column of muted `-0.0 MB` spends a line
 	// per row saying nothing happened, crowding the figures that did move.
 	const emphasized = scenario === 'idle' || delta === undefined || Math.abs(delta) < threshold
 		? ''
 		: deltaHtmlFromDiff(delta);
-	const deltaLine = emphasized === '' ? '' : `<br><span style="font-size:0.85em">${emphasized}</span>`;
-	return `<td align="right">${formatBytes(value)}${deltaLine}</td>`;
+	// The delta is the point of the table, so the value it is measured from steps back
+	// a little rather than competing with it at equal weight.
+	const deltaLine = emphasized === '' ? '' : `<span class="delta-line">${emphasized}</span>`;
+	return `<td align="right"${baselineClass(scenario)}><span class="value">${formatBytes(value)}</span>${deltaLine}</td>`;
 }
 
 function rowHtml(row: SummaryRow, scenarios: MemoryScenario[]): string {
@@ -263,6 +270,21 @@ function instabilityHtml(unstable: UnstableEntry[]): string {
 }
 
 /**
+ * Says why some cells carry a delta and others do not, which is otherwise the
+ * table's most obvious unexplained rule.
+ *
+ * Leads with why the rule exists, because "bigger than the noise" means nothing to
+ * a reader who has not been told the same scenario measures differently each launch.
+ *
+ * Built from {@link MIN_EMPHASIS_BYTES} rather than repeating the number, so the
+ * floor named here cannot drift from the one applied. Deliberately not phrased as
+ * a flat "5 MB or more": the real bar is per role and usually higher, and a legend
+ * that understated it would invite reading an unmarked 8 MB move as a bug.
+ */
+const DELTA_LEGEND = `Each launch measures a little differently, so a delta shows only when the change
+	beats that noise, never under ${formatBytes(MIN_EMPHASIS_BYTES)}. Blank cells moved less.`;
+
+/**
  * Renders the matrix as a standalone HTML document, using the same shell
  * (CSS, escaping, delta glyphs) as the per-scenario report so the two cannot
  * drift apart visually.
@@ -278,11 +300,31 @@ export function renderSummaryHtml(matrix: SummaryMatrix): string {
 	<meta charset="utf-8">
 	<title>Positron memory: cross-scenario summary</title>
 	<style>${REPORT_CSS}
-		.total-row td { border-top: 2px solid #e5e7eb; font-weight: 600; }
+		/* Reads as a summary rather than one more row: a darker rule than the hairlines
+		between roles, and air above it that the hairlines do not get. */
+		.total-row td { border-top: 2px solid #d1d5db; font-weight: 600; padding-top: 10px; }
 		/* Only some cells carry a delta on a second line. Centering would then drop a bare
 		value half a line below its emphasized neighbour, so the row no longer reads
 		across. Top-aligned, every PSS figure shares a baseline and the deltas hang below. */
 		.matrix td { vertical-align: top; }
+		/* The delta is what the table is for, so the figure it is measured from gives up a
+		little size and contrast instead of competing with it. */
+		.matrix .value { font-size: 0.95em; color: #6b7280; }
+		.matrix .total-row .value { font-size: 1em; color: inherit; }
+		.matrix .delta-line { display: block; font-size: 0.82em; line-height: 1.2; margin-top: 1px; }
+		/* idle is where every delta is measured from, not a seventh scenario. */
+		.matrix .baseline { background: #f6f7f9; border-right: 2px solid #e5e7eb; }
+		/* Follows one role across every scenario. Scoped to td so the header row, which
+		holds th, does not light up as though it were data, and past .baseline so the idle
+		cell keeps its own tint: the two values are close enough that the hovered row still
+		reads as one band. */
+		.matrix tr:hover td:not(.baseline) { background: #f8f9fa; }
+		@media (prefers-color-scheme: dark) {
+			.total-row td { border-top-color: #4b5563; }
+			.matrix .value { color: #9ca3af; }
+			.matrix .baseline { background: #201f1e; border-right-color: #3a3a38; }
+			.matrix tr:hover td:not(.baseline) { background: rgba(255, 255, 255, 0.04); }
+		}
 	</style>
 </head>
 <body>
@@ -296,6 +338,7 @@ export function renderSummaryHtml(matrix: SummaryMatrix): string {
 
 	<div class="card">
 		<h2>By role</h2>
+		<div class="meta">${DELTA_LEGEND}</div>
 		<table class="matrix">
 			<tr><th>Role</th>${scenarioHeaderHtml(matrix.scenarios)}</tr>
 			${rows}

--- a/test/e2e/utils/memory/summary.ts
+++ b/test/e2e/utils/memory/summary.ts
@@ -369,7 +369,7 @@ export function renderSummaryHtml(matrix: SummaryMatrix): string {
 	${instabilityCard}
 
 	<div class="card">
-		<h2>By role</h2>
+		<h2>Memory by role</h2>
 		<div class="meta">${DELTA_LEGEND}${matrix.hasForcedGc ? ` ${GC_NOTE}` : ''}</div>
 		<table class="matrix">
 			<tr><th>Role</th>${scenarioHeaderHtml(matrix.scenarios)}</tr>

--- a/test/e2e/utils/memory/summary.ts
+++ b/test/e2e/utils/memory/summary.ts
@@ -87,16 +87,15 @@ export type SummaryMatrix = {
 const MIN_EMPHASIS_BYTES = 5 * 1024 * 1024;
 
 /**
- * Per role, because the noise is not uniform: `renderer` holds to 1.5 MB across
- * launches while `shared` swings 10.8 MB. A flat 5 MB rule drew a red arrow on
- * `extension_host` at +8.8 MB, inside that role's own scatter.
+ * Per role, because the noise is not uniform: `kernel` holds to 0.6 MB across
+ * launches while `extension_host` swings 37.7 MB, so one flat rule either marks
+ * noise on the shaky roles or misses real moves on the steady ones.
  *
  * Scoped to the two scenarios the delta is actually between, since a delta is only
  * as good as the shakier of its two. Reading the bar from every scenario instead
- * let one scenario's bad launch silence a real change everywhere else: a single
- * `data-explorer` launch 72 MB above its neighbours put the `extension_host` bar at
- * 73.9 MB, which hid `notebook` at +67.9 MB even though `notebook` itself only
- * swung 30 MB.
+ * let one scenario's bad launch silence a real change everywhere else: one noisy
+ * `data-explorer` launch once set an `extension_host` bar of 73.9 MB, hiding a
+ * steady +67.9 MB on `notebook`.
  */
 function emphasisThreshold(spreads: number[]): number {
 	return Math.max(MIN_EMPHASIS_BYTES, ...spreads);

--- a/test/e2e/utils/memory/summary.ts
+++ b/test/e2e/utils/memory/summary.ts
@@ -42,8 +42,11 @@ export type SummaryRow = {
 	values: Partial<Record<MemoryScenario, number>>;
 	/** current - idle, present only when both the scenario and idle have this role. */
 	deltaVsIdle: Partial<Record<MemoryScenario, number>>;
-	/** How big a delta has to be before this role's row earns emphasis. See {@link emphasisThreshold}. */
-	emphasisThreshold: number;
+	/**
+	 * Per scenario, how big that scenario's delta against idle has to be to earn
+	 * emphasis. See {@link emphasisThreshold}.
+	 */
+	emphasisThreshold: Partial<Record<MemoryScenario, number>>;
 };
 
 /** One process that was still moving when it was sampled, named for the warning banner. */
@@ -62,8 +65,8 @@ export type SummaryMatrix = {
 	rows: SummaryRow[];
 	/** Median tree total per scenario, for the TOTAL row. */
 	totals: Partial<Record<MemoryScenario, number>>;
-	/** The TOTAL row's own emphasis bar, calibrated from tree-total spread rather than any one role's. */
-	totalEmphasisThreshold: number;
+	/** The TOTAL row's own emphasis bar per scenario, from tree-total spread rather than any one role's. */
+	totalEmphasisThreshold: Partial<Record<MemoryScenario, number>>;
 	/**
 	 * Carried on the matrix so `renderSummaryHtml` can warn without also taking
 	 * the raw snapshots: every figure in the matrix is derived from processes that
@@ -84,8 +87,14 @@ const MIN_EMPHASIS_BYTES = 5 * 1024 * 1024;
 /**
  * Per role, because the noise is not uniform: `renderer` holds to 1.5 MB across
  * launches while `shared` swings 10.8 MB. A flat 5 MB rule drew a red arrow on
- * `extension_host` at +8.8 MB, inside that role's own scatter. Taken from the
- * noisiest scenario, since a delta is only as good as the shakier of its two.
+ * `extension_host` at +8.8 MB, inside that role's own scatter.
+ *
+ * Scoped to the two scenarios the delta is actually between, since a delta is only
+ * as good as the shakier of its two. Reading the bar from every scenario instead
+ * let one scenario's bad launch silence a real change everywhere else: a single
+ * `data-explorer` launch 72 MB above its neighbours put the `extension_host` bar at
+ * 73.9 MB, which hid `notebook` at +67.9 MB even though `notebook` itself only
+ * swung 30 MB.
  */
 function emphasisThreshold(spreads: number[]): number {
 	return Math.max(MIN_EMPHASIS_BYTES, ...spreads);
@@ -156,12 +165,15 @@ export function buildSummaryMatrix(entries: ScenarioSnapshots[]): SummaryMatrix 
 	const rows: SummaryRow[] = [...allRoles].map(role => {
 		const values: Partial<Record<MemoryScenario, number>> = {};
 		const deltaVsIdle: Partial<Record<MemoryScenario, number>> = {};
+		const threshold: Partial<Record<MemoryScenario, number>> = {};
+		const idleSpread = spreadsByScenario.get('idle')?.get(role) ?? 0;
 
 		for (const scenario of scenarios) {
 			const value = rolesByScenario.get(scenario)!.get(role);
 			if (value !== undefined) {
 				values[scenario] = value;
 			}
+			threshold[scenario] = emphasisThreshold([idleSpread, spreadsByScenario.get(scenario)!.get(role) ?? 0]);
 			if (idleRoles && scenario !== 'idle') {
 				const idleValue = idleRoles.get(role);
 				if (value !== undefined && idleValue !== undefined) {
@@ -170,18 +182,25 @@ export function buildSummaryMatrix(entries: ScenarioSnapshots[]): SummaryMatrix 
 			}
 		}
 
-		const spreads = [...spreadsByScenario.values()].map(byRoleSpread => byRoleSpread.get(role) ?? 0);
-		return { role, values, deltaVsIdle, emphasisThreshold: emphasisThreshold(spreads) };
+		return { role, values, deltaVsIdle, emphasisThreshold: threshold };
 	});
 
 	rows.sort((a, b) => rowMagnitude(b) - rowMagnitude(a));
 
 	const totals: Partial<Record<MemoryScenario, number>> = {};
-	const totalSpreads: number[] = [];
+	const totalSpreadByScenario = new Map<MemoryScenario, number>();
 	for (const { scenario, snapshots } of entries) {
 		const perLaunch = snapshots.map(s => s.treeTotalPssBytes);
 		totals[scenario] = median(perLaunch);
-		totalSpreads.push(Math.max(...perLaunch) - Math.min(...perLaunch));
+		totalSpreadByScenario.set(scenario, Math.max(...perLaunch) - Math.min(...perLaunch));
+	}
+
+	// Same two-scenario scoping as the role rows above: the TOTAL bar for a scenario
+	// is set by that scenario and idle, not by whichever scenario shook the most.
+	const idleTotalSpread = totalSpreadByScenario.get('idle') ?? 0;
+	const totalEmphasisThreshold: Partial<Record<MemoryScenario, number>> = {};
+	for (const scenario of scenarios) {
+		totalEmphasisThreshold[scenario] = emphasisThreshold([idleTotalSpread, totalSpreadByScenario.get(scenario) ?? 0]);
 	}
 
 	const unstable: UnstableEntry[] = entries.flatMap(({ scenario, snapshots }) =>
@@ -195,7 +214,7 @@ export function buildSummaryMatrix(entries: ScenarioSnapshots[]): SummaryMatrix 
 			reported: proc.pssBytes
 		}))));
 
-	return { scenarios, rows, totals, totalEmphasisThreshold: emphasisThreshold(totalSpreads), unstable };
+	return { scenarios, rows, totals, totalEmphasisThreshold, unstable };
 }
 
 /** Muted em-dash: a role that did not exist in this scenario, never a fabricated zero. */
@@ -211,13 +230,15 @@ function scenarioHeaderHtml(scenarios: MemoryScenario[]): string {
 }
 
 /** One scenario's cell: the PSS value, plus (for a non-idle scenario) its delta against idle underneath. */
-function cellHtml(scenario: MemoryScenario, value: number | undefined, delta: number | undefined, threshold: number): string {
+function cellHtml(scenario: MemoryScenario, value: number | undefined, delta: number | undefined, threshold: number | undefined): string {
 	if (value === undefined) {
 		return `<td align="right"${baselineClass(scenario)}>${ABSENT_MARKER}</td>`;
 	}
 	// Below the threshold nothing renders: a column of muted `-0.0 MB` spends a line
 	// per row saying nothing happened, crowding the figures that did move.
-	const emphasized = scenario === 'idle' || delta === undefined || Math.abs(delta) < threshold
+	// An absent threshold cannot mean "emphasize everything": a scenario with no bar
+	// computed for it has nothing to say a delta cleared anything.
+	const emphasized = scenario === 'idle' || delta === undefined || threshold === undefined || Math.abs(delta) < threshold
 		? ''
 		: deltaHtmlFromDiff(delta);
 	// The delta is the point of the table, so the value it is measured from steps back
@@ -227,7 +248,7 @@ function cellHtml(scenario: MemoryScenario, value: number | undefined, delta: nu
 }
 
 function rowHtml(row: SummaryRow, scenarios: MemoryScenario[]): string {
-	const cells = scenarios.map(scenario => cellHtml(scenario, row.values[scenario], row.deltaVsIdle[scenario], row.emphasisThreshold)).join('');
+	const cells = scenarios.map(scenario => cellHtml(scenario, row.values[scenario], row.deltaVsIdle[scenario], row.emphasisThreshold[scenario])).join('');
 	return `<tr>
 		<td><code>${escapeHtml(row.role)}</code></td>
 		${cells}
@@ -241,7 +262,7 @@ function totalRowHtml(matrix: SummaryMatrix): string {
 		const delta = scenario !== 'idle' && value !== undefined && idleValue !== undefined
 			? value - idleValue
 			: undefined;
-		return cellHtml(scenario, value, delta, matrix.totalEmphasisThreshold);
+		return cellHtml(scenario, value, delta, matrix.totalEmphasisThreshold[scenario]);
 	}).join('');
 	return `<tr class="total-row">
 		<td><strong>TOTAL</strong></td>

--- a/test/e2e/utils/memory/summary.ts
+++ b/test/e2e/utils/memory/summary.ts
@@ -294,16 +294,13 @@ function instabilityHtml(unstable: UnstableEntry[]): string {
  * Says why some cells carry a delta and others do not, which is otherwise the
  * table's most obvious unexplained rule.
  *
- * Leads with why the rule exists, because "bigger than the noise" means nothing to
- * a reader who has not been told the same scenario measures differently each launch.
- *
  * Built from {@link MIN_EMPHASIS_BYTES} rather than repeating the number, so the
- * floor named here cannot drift from the one applied. Deliberately not phrased as
- * a flat "5 MB or more": the real bar is per role and usually higher, and a legend
- * that understated it would invite reading an unmarked 8 MB move as a bug.
+ * floor named here cannot drift from the one applied. Deliberately a minimum rather
+ * than a flat "5 MB or more": the real bar is per role and usually higher, and a
+ * legend that understated it would invite reading an unmarked 8 MB move as a bug.
  */
-const DELTA_LEGEND = `Each launch measures a little differently, so a delta shows only when the change
-	beats that noise, never under ${formatBytes(MIN_EMPHASIS_BYTES)}. Blank cells moved less.`;
+const DELTA_LEGEND = `Deltas appear only when changes exceed launch-to-launch noise, with a
+	${formatBytes(MIN_EMPHASIS_BYTES)} minimum. Blank cells are within noise.`;
 
 /**
  * Renders the matrix as a standalone HTML document, using the same shell

--- a/test/e2e/utils/memory/summary.ts
+++ b/test/e2e/utils/memory/summary.ts
@@ -137,11 +137,12 @@ function rowMagnitude(row: SummaryRow): number {
 /**
  * Builds the per-role x per-scenario matrix.
  *
- * Order of `entries` becomes the column order. Rows are sorted biggest first
- * (summed across the scenarios that have them) so the roles worth reading
- * about come before the ones that do not matter. `deltaVsIdle` degrades to
- * an empty object per row when `idle` is not among `entries` -- there is
- * nothing to diff against, not a NaN.
+ * Columns are `idle` first (the baseline), then the rest ascending by TOTAL
+ * delta vs idle, so the biggest total increase lands at the far right. Rows
+ * are sorted biggest first (summed across the scenarios that have them) so
+ * the roles worth reading about come before the ones that do not matter.
+ * `deltaVsIdle` degrades to an empty object per row when `idle` is not among
+ * `entries` -- there is nothing to diff against, not a NaN.
  */
 export function buildSummaryMatrix(entries: ScenarioSnapshots[]): SummaryMatrix {
 	const scenarios = entries.map(e => e.scenario);
@@ -214,7 +215,16 @@ export function buildSummaryMatrix(entries: ScenarioSnapshots[]): SummaryMatrix 
 			reported: proc.pssBytes
 		}))));
 
-	return { scenarios, rows, totals, totalEmphasisThreshold, unstable };
+	const idleTotal = totals['idle'];
+	const totalDeltaVsIdle = new Map<MemoryScenario, number>();
+	for (const scenario of scenarios) {
+		const value = totals[scenario];
+		totalDeltaVsIdle.set(scenario, idleTotal !== undefined && value !== undefined ? value - idleTotal : 0);
+	}
+	const others = scenarios.filter(s => s !== 'idle').sort((a, b) => totalDeltaVsIdle.get(a)! - totalDeltaVsIdle.get(b)!);
+	const sortedScenarios = scenarios.includes('idle') ? ['idle' as MemoryScenario, ...others] : others;
+
+	return { scenarios: sortedScenarios, rows, totals, totalEmphasisThreshold, unstable };
 }
 
 /** Muted em-dash: a role that did not exist in this scenario, never a fabricated zero. */

--- a/test/e2e/utils/memory/summary.vitest.ts
+++ b/test/e2e/utils/memory/summary.vitest.ts
@@ -193,6 +193,27 @@ describe('delta emphasis', () => {
 		]));
 		expect(html).not.toContain('class="delta-up"');
 	});
+
+	// A third scenario's bad launch used to set the bar for every scenario: one
+	// data-explorer launch 72 MB above its neighbours put the extension_host bar at
+	// 73.9 MB and hid notebook at +67.9 MB, which is the size of change this report
+	// exists to catch.
+	test('does not let an unrelated scenario noise floor hide a steady scenario delta', () => {
+		const matrix = buildSummaryMatrix([
+			noisyEntry('idle', 'extension_host', [332, 332, 335]),
+			noisyEntry('notebook', 'extension_host', [400, 400, 400]),
+			noisyEntry('data-explorer', 'extension_host', [336, 408, 334])
+		]);
+
+		// The bar notebook is judged against comes from notebook and idle only, so the
+		// jumpy data-explorer launches cannot raise it.
+		const row = matrix.rows.find(r => r.role === 'extension_host')!;
+		expect(row.emphasisThreshold['notebook']).toBe(5 * MB);
+		expect(row.emphasisThreshold['data-explorer']).toBe(74 * MB);
+
+		const html = renderSummaryHtml(matrix);
+		expect(html).toContain('<span class="delta-up">&#9650; 68.0 MB</span>');
+	});
 });
 
 describe('renderSummaryHtml', () => {

--- a/test/e2e/utils/memory/summary.vitest.ts
+++ b/test/e2e/utils/memory/summary.vitest.ts
@@ -157,7 +157,7 @@ describe('delta emphasis', () => {
 			noisyEntry('idle', 'renderer', [284, 285, 284]),
 			noisyEntry('session-python', 'renderer', [306, 307, 306])
 		]));
-		expect(html).toContain('<span class="delta-up">&#9650; +22.0 MB</span>');
+		expect(html).toContain('<span class="delta-up">&#9650; 22.0 MB</span>');
 	});
 
 	// The real case: session-r's extension_host read +8.8 MB against idle while the
@@ -234,13 +234,13 @@ describe('renderSummaryHtml', () => {
 		expect(kernelRowHtml).toContain('&mdash;');
 	});
 
-	test('renders a delta with a glyph and a signed number, not color alone', () => {
+	test('renders a delta with a glyph, not color alone', () => {
 		const entries: ScenarioSnapshots[] = [
 			scenarioEntry('idle', [proc({ processRole: 'extension_child', pssBytes: 30 * MB })]),
 			scenarioEntry('session-python', [proc({ processRole: 'extension_child', pssBytes: 45 * MB })]),
 		];
 		const html = renderSummaryHtml(buildSummaryMatrix(entries));
-		expect(html).toMatch(/&#9650;[^<]*\+15\.0 MB/);
+		expect(html).toMatch(/&#9650;[^<]*15\.0 MB/);
 	});
 
 	test('is a self-contained document', () => {

--- a/test/e2e/utils/memory/summary.vitest.ts
+++ b/test/e2e/utils/memory/summary.vitest.ts
@@ -305,7 +305,11 @@ describe('renderSummaryHtml', () => {
 		const withoutGc = renderSummaryHtml(buildSummaryMatrix([scenarioEntry('idle', [proc()])]));
 		expect(withoutGc).not.toContain('forced garbage collection');
 
-		const gcSnapshot = { ...snapshot('idle', [proc()], 0), sharedProcessGc: { pid: 1, preRssBytes: 1, postRssBytes: 1, preHeapTotalBytes: 1, postHeapTotalBytes: 1 } };
+		const emptyGcSnapshot = { ...snapshot('idle', [proc()], 0), forcedGc: [] };
+		const withEmptyGc = renderSummaryHtml(buildSummaryMatrix([{ scenario: 'idle', snapshots: [emptyGcSnapshot] }]));
+		expect(withEmptyGc).not.toContain('forced garbage collection');
+
+		const gcSnapshot = { ...snapshot('idle', [proc()], 0), forcedGc: [{ role: 'shared' as const, pid: 1, preRssBytes: 1, postRssBytes: 1, preHeapTotalBytes: 1, postHeapTotalBytes: 1 }] };
 		const withGc = renderSummaryHtml(buildSummaryMatrix([{ scenario: 'idle', snapshots: [gcSnapshot] }]));
 		expect(withGc).toContain('forced garbage collection');
 	});

--- a/test/e2e/utils/memory/summary.vitest.ts
+++ b/test/e2e/utils/memory/summary.vitest.ts
@@ -300,4 +300,13 @@ describe('renderSummaryHtml', () => {
 		const html = renderSummaryHtml(buildSummaryMatrix(entries));
 		expect(html).toContain('TOTAL');
 	});
+
+	test('shows the GC note when a snapshot carries a forced-GC reading, not otherwise', () => {
+		const withoutGc = renderSummaryHtml(buildSummaryMatrix([scenarioEntry('idle', [proc()])]));
+		expect(withoutGc).not.toContain('forced garbage collection');
+
+		const gcSnapshot = { ...snapshot('idle', [proc()], 0), sharedProcessGc: { pid: 1, preRssBytes: 1, postRssBytes: 1, preHeapTotalBytes: 1, postHeapTotalBytes: 1 } };
+		const withGc = renderSummaryHtml(buildSummaryMatrix([{ scenario: 'idle', snapshots: [gcSnapshot] }]));
+		expect(withGc).toContain('forced garbage collection');
+	});
 });

--- a/test/e2e/utils/memory/summary.vitest.ts
+++ b/test/e2e/utils/memory/summary.vitest.ts
@@ -130,6 +130,19 @@ describe('buildSummaryMatrix', () => {
 		expect(matrix.rows.map(r => r.role)).toEqual(['shared', 'main', 'gpu']);
 	});
 
+	test('orders columns idle first, then ascending by TOTAL delta vs idle', () => {
+		const entries: ScenarioSnapshots[] = [
+			scenarioEntry('idle', [proc({ pssBytes: 100 * MB })]),
+			// Input order is the opposite of the expected sort, so the test only
+			// passes if buildSummaryMatrix actually sorts rather than echoing input order.
+			scenarioEntry('data-explorer', [proc({ pssBytes: 160 * MB })]), // +60 MB
+			scenarioEntry('notebook', [proc({ pssBytes: 120 * MB })]), // +20 MB
+		];
+
+		const matrix = buildSummaryMatrix(entries);
+		expect(matrix.scenarios).toEqual(['idle', 'notebook', 'data-explorer']);
+	});
+
 	test('records a median TOTAL per scenario', () => {
 		const entries: ScenarioSnapshots[] = [
 			{

--- a/test/e2e/utils/memory/types.ts
+++ b/test/e2e/utils/memory/types.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { SharedProcessGcStats } from './gc.js';
+import { ForcedGcStats } from './gc.js';
 import { MemoryScenario } from './scenarios.js';
 
 /**
@@ -96,10 +96,11 @@ export type MemorySnapshot = {
 	 */
 	treeSettled?: boolean;
 	/**
-	 * Figures from a forced GC in the shared process, taken after settle and before
-	 * sampling. Pre/post pairs preserve what the un-collected process looked like.
+	 * Forced-GC readings for the Node-side processes (shared process, extension
+	 * host), taken after settle and before sampling. Pre/post pairs preserve the
+	 * un-collected state.
 	 */
-	sharedProcessGc?: SharedProcessGcStats;
+	forcedGc?: ForcedGcStats[];
 	/**
 	 * Samples taken before the tail and thrown away: the startup plateau, before
 	 * Chromium reclaimed its startup memory. Non-zero is normal and healthy.

--- a/test/e2e/utils/memory/types.ts
+++ b/test/e2e/utils/memory/types.ts
@@ -88,6 +88,13 @@ export type MemorySnapshot = {
 	/** How long sampling ran after settling, waiting for every large process to hold steady. */
 	sampledMs?: number;
 	/**
+	 * Whether sampling stopped because the tree settled rather than because it hit
+	 * its cap. Recorded rather than inferred from `sampledMs`, which cannot tell the
+	 * two apart: an iteration starting just under the cap sleeps past it before
+	 * settling. Undefined on a baseline, which carries neither field.
+	 */
+	treeSettled?: boolean;
+	/**
 	 * Samples taken before the tail and thrown away: the startup plateau, before
 	 * Chromium reclaimed its startup memory. Non-zero is normal and healthy.
 	 */

--- a/test/e2e/utils/memory/types.ts
+++ b/test/e2e/utils/memory/types.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { SharedProcessGcStats } from './gc.js';
 import { MemoryScenario } from './scenarios.js';
 
 /**
@@ -94,6 +95,11 @@ export type MemorySnapshot = {
 	 * settling. Undefined on a baseline, which carries neither field.
 	 */
 	treeSettled?: boolean;
+	/**
+	 * Figures from a forced GC in the shared process, taken after settle and before
+	 * sampling. Pre/post pairs preserve what the un-collected process looked like.
+	 */
+	sharedProcessGc?: SharedProcessGcStats;
 	/**
 	 * Samples taken before the tail and thrown away: the startup plateau, before
 	 * Chromium reclaimed its startup memory. Non-zero is normal and healthy.


### PR DESCRIPTION
Refs #15492

### Summary

Adds four feature scenarios from the scenario-selection design: `data-explorer` (a CSV opened, no session), `notebook` (one cell run against a Python session), `editors` (10 mixed-type files open) and `console-output`. All reuse the existing collector and report. Sampling also forces a garbage collection in the shared process and extension host first, so figures reflect what a scenario retains rather than whether V8 had swept its startup garbage yet.

See updated [generated report](https://d38p2avprg8il3.cloudfront.net/playwright-report-31837039692-1-memory-ubuntu/index.html).

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

These specs only collect when `MEMORY_SCENARIO` is set, so they are `testIgnore`d in ordinary e2e lanes and no PR tag runs them. Real verification is a `workflow_dispatch` of `Test: Memory Metrics` on this branch.

Verified: `vitest run test/e2e/utils/memory/` (225 pass), both `prepare` bodies against a dev build, and three full green dispatches of all seven scenarios -- [run 31821811858](https://github.com/posit-dev/positron/actions/runs/31821811858) (pre-GC), [run 31831107588](https://github.com/posit-dev/positron/actions/runs/31831107588) (`treeSettled` gate + shared-process GC; shared spread fell from up to 20.8 MB to at most 2.9 MB across 21 launches) and [run 31833835801](https://github.com/posit-dev/positron/actions/runs/31833835801) (ext-host GC; ext host spread at most 4.5 MB in every scenario except notebook, whose one 37.7 MB outlier survives the GC: the PyPI index cached by the missing-packages race, filed as #15558). `expectProcesses` matched the real forked worker.

Note: the forced GC drops the shared process's reported level by ~60 MB, so the first comparison against an older nightly baseline will show a one-time methodological drop in that role, not a real regression fix.

Medians of 3 cold launches, delta vs idle (1,492 MB / 21 procs): `data-explorer` +136, `session-r` +137, `session-python` +199, `editors` +237, `console-output` +279, `notebook` +340. Attribution for `data-explorer` on the large CSV was duckdb worker +279, renderer +37, ext host +7; a second dispatch against the small CSV put the worker at 110.5 MB, which is the fixed cost this series now trends.



