### PR TITLE
Quarto virtual notebook: expose cell symbols as a command

### DIFF
--- a/src/vs/workbench/api/common/extHostApiCommands.ts
+++ b/src/vs/workbench/api/common/extHostApiCommands.ts
@@ -27,6 +27,7 @@ import type { IExtensionPromptFileResult } from '../../contrib/chat/common/promp
 
 // --- Start Positron ---
 import { onUnexpectedExternalError } from '../../../base/common/errors.js';
+import { IQuartoCellSymbols } from '../../contrib/positronQuarto/common/quartoCellSymbols.js';
 import type * as positron from 'positron';
 import * as extHostTypes from './positron/extHostTypes.positron.js';
 // --- End Positron ---
@@ -588,19 +589,19 @@ const newCommands: ApiCommand[] = [
 		ApiCommandResult.Void
 	),
 	// -- quarto cell symbols
-	// The result type below is written out structurally rather than imported from
-	// `IQuartoCellSymbols`, because `api/common/` cannot import from
-	// `positronQuarto/browser/` under the layering rules. Keeping this shape in
-	// step with `IQuartoCellSymbols` is a manual obligation, not one the compiler
-	// enforces: `ApiCommand` takes `result: ApiCommandResult<any, any>` and the
-	// internal command is looked up by string id, so nothing here would fail to
-	// compile if the two shapes drifted apart.
+	// The answer shape is imported from `positronQuarto/common` rather than
+	// written out here, so a change to it is a compile error in this converter
+	// instead of a silent drift. What the compiler still cannot check is the
+	// pairing itself: `ApiCommand` takes `result: ApiCommandResult<any, any>` and
+	// the internal command is looked up by a string id, so nothing here would
+	// fail to compile if `_executeQuartoCellSymbolProvider` began answering with
+	// a different shape altogether.
 	new ApiCommand(
 		'positron.executeQuartoCellSymbolProvider', '_executeQuartoCellSymbolProvider',
 		'Execute the document symbol providers of a Quarto document\'s code cells, grouped by cell.',
 		[ApiCommandArgument.Uri],
 		new ApiCommandResult<
-			{ range: IRange; symbols: languages.DocumentSymbol[] }[],
+			IQuartoCellSymbols[],
 			{ range: types.Range; symbols: vscode.DocumentSymbol[] }[]
 		>('A promise that resolves to one entry per code cell that has symbols, in document order.', value => {
 			const toVscodeSymbols = (symbols: languages.DocumentSymbol[]): vscode.DocumentSymbol[] => {

--- a/src/vs/workbench/api/common/extHostApiCommands.ts
+++ b/src/vs/workbench/api/common/extHostApiCommands.ts
@@ -26,6 +26,7 @@ import { PromptsType } from '../../contrib/chat/common/promptSyntax/promptTypes.
 import type { IExtensionPromptFileResult } from '../../contrib/chat/common/promptSyntax/chatPromptFilesContribution.js';
 
 // --- Start Positron ---
+import { onUnexpectedExternalError } from '../../../base/common/errors.js';
 import type * as positron from 'positron';
 import * as extHostTypes from './positron/extHostTypes.positron.js';
 // --- End Positron ---
@@ -585,6 +586,39 @@ const newCommands: ApiCommand[] = [
 			ApiCommandArgument.String.with('viewId', 'Custom editor view id. This should be the viewType string for custom editors or the notebookType string for notebooks. Use \'default\' to use VS Code\'s default text editor'),
 		],
 		ApiCommandResult.Void
+	),
+	// -- quarto cell symbols
+	// The result type below is written out structurally rather than imported from
+	// `IQuartoCellSymbols`, because `api/common/` cannot import from
+	// `positronQuarto/browser/` under the layering rules. Keeping this shape in
+	// step with `IQuartoCellSymbols` is a manual obligation, not one the compiler
+	// enforces: `ApiCommand` takes `result: ApiCommandResult<any, any>` and the
+	// internal command is looked up by string id, so nothing here would fail to
+	// compile if the two shapes drifted apart.
+	new ApiCommand(
+		'positron.executeQuartoCellSymbolProvider', '_executeQuartoCellSymbolProvider',
+		'Execute the document symbol providers of a Quarto document\'s code cells, grouped by cell.',
+		[ApiCommandArgument.Uri],
+		new ApiCommandResult<
+			{ range: IRange; symbols: languages.DocumentSymbol[] }[],
+			{ range: types.Range; symbols: vscode.DocumentSymbol[] }[]
+		>('A promise that resolves to one entry per code cell that has symbols, in document order.', value => {
+			const toVscodeSymbols = (symbols: languages.DocumentSymbol[]): vscode.DocumentSymbol[] => {
+				const converted: vscode.DocumentSymbol[] = [];
+				for (const symbol of symbols) {
+					try {
+						converted.push(typeConverters.DocumentSymbol.to(symbol));
+					} catch (error) {
+						onUnexpectedExternalError(error);
+					}
+				}
+				return converted;
+			};
+			return value.map(cell => ({
+				range: typeConverters.Range.to(cell.range),
+				symbols: toVscodeSymbols(cell.symbols),
+			}));
+		})
 	),
 	// --- End Positron ---
 

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoEmbeddedLanguageFeatures.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoEmbeddedLanguageFeatures.ts
@@ -6,6 +6,8 @@
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { onUnexpectedExternalError } from '../../../../base/common/errors.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { assertType } from '../../../../base/common/types.js';
+import { Constants } from '../../../../base/common/uint.js';
 import { URI } from '../../../../base/common/uri.js';
 import { Position } from '../../../../editor/common/core/position.js';
 import { IRange } from '../../../../editor/common/core/range.js';
@@ -35,6 +37,7 @@ import {
 } from '../../../../editor/common/languages.js';
 import { ILanguageFeaturesService } from '../../../../editor/common/services/languageFeatures.js';
 import { localize } from '../../../../nls.js';
+import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ILogService, LogLevel } from '../../../../platform/log/common/log.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
@@ -171,6 +174,27 @@ function mapDocumentSymbol(cell: ICellLineSpan, symbol: DocumentSymbol): Documen
 }
 
 /**
+ * The source range of a cell's code, fences excluded.
+ *
+ * Built from the line span rather than from the cell's text model, because a
+ * sync can dispose that model while a request is out and the only consumer
+ * matches on lines. `MAX_SAFE_SMALL_INTEGER` is the codebase's way of saying
+ * "to the end of the line".
+ *
+ * An empty chunk produces `codeStartLine > codeEndLine`, which would build an
+ * inverted range here, but that case cannot arrive: an empty cell has no
+ * symbols, and a cell with no symbols is omitted before its range is ever built.
+ */
+function cellSourceRange(span: ICellLineSpan): IRange {
+	return {
+		startLineNumber: span.codeStartLine,
+		startColumn: 1,
+		endLineNumber: span.codeEndLine,
+		endColumn: Constants.MAX_SAFE_SMALL_INTEGER,
+	};
+}
+
+/**
  * Remap a statement range result into source coordinates.
  *
  * The two outcomes carry their coordinates differently. A success carries a
@@ -185,6 +209,17 @@ function mapStatementRange(cell: ICellLineSpan, result: IStatementRange): IState
 	return result.line === undefined
 		? result
 		: { ...result, line: cellZeroBasedLineToSource(cell, result.line) };
+}
+
+/**
+ * The providers to ask about a cell, in order, with our own filtered out.
+ *
+ * See `QuartoEmbeddedProvider._downstream` for why callers take the first
+ * usable answer rather than merging every provider's.
+ */
+function downstreamProviders<T>(registry: LanguageFeatureRegistry<T>, textModel: ITextModel): T[] {
+	return registry.ordered(textModel)
+		.filter(provider => !(provider instanceof QuartoEmbeddedProvider));
 }
 
 /**
@@ -221,7 +256,7 @@ abstract class QuartoEmbeddedProvider {
 
 	/** Whether anybody is reading the trace, so a message is worth building. */
 	protected get _tracing(): boolean {
-		return this._logService.getLevel() <= LogLevel.Trace;
+		return this._logService.getLevel() === LogLevel.Trace;
 	}
 
 	/**
@@ -279,8 +314,7 @@ abstract class QuartoEmbeddedProvider {
 	 * runs against the slowness this routing exists to fix.
 	 */
 	protected _downstream<T>(registry: LanguageFeatureRegistry<T>, textModel: ITextModel): T[] {
-		return registry.ordered(textModel)
-			.filter(provider => !(provider instanceof QuartoEmbeddedProvider));
+		return downstreamProviders(registry, textModel);
 	}
 
 	/**
@@ -511,6 +545,108 @@ class QuartoEmbeddedDefinitionProvider extends QuartoEmbeddedProvider implements
 	}
 }
 
+/** The first usable answer for one cell, already in source coordinates. */
+async function symbolsForCell(
+	languageFeatures: ILanguageFeaturesService,
+	textModel: ITextModel,
+	span: ICellLineSpan,
+	token: CancellationToken
+): Promise<DocumentSymbol[] | undefined> {
+	// A rebuild disposes the models it replaced, so a model read before the
+	// requests went out can be gone by the time this runs.
+	if (textModel.isDisposed()) {
+		return undefined;
+	}
+	for (const provider of downstreamProviders(languageFeatures.documentSymbolProvider, textModel)) {
+		try {
+			const result = await provider.provideDocumentSymbols(textModel, token);
+			if (result && result.length > 0) {
+				return result.map(symbol => mapDocumentSymbol(span, symbol));
+			}
+		} catch (error) {
+			// One provider failing must not discard the other cells' symbols, so
+			// report it and move on to the next provider for this cell.
+			onUnexpectedExternalError(error);
+		}
+	}
+	return undefined;
+}
+
+/** One cell's symbols, and where that cell's code sits in the source document. */
+export interface IQuartoCellSymbols {
+	readonly range: IRange;
+	readonly symbols: DocumentSymbol[];
+}
+
+/**
+ * The symbols of every code cell in a Quarto document, grouped by the cell they
+ * came from and already in source coordinates.
+ *
+ * Two consumers: the Outline provider below, which flattens this, and the
+ * `_executeQuartoCellSymbolProvider` command, which hands the grouping to the
+ * Quarto extension so it can nest each cell's symbols under that chunk in the
+ * tree it already builds. Grouped rather than flat because only the extension
+ * knows which heading a chunk sits under.
+ *
+ * A cell with nothing to report is omitted rather than returned empty, and an
+ * unknown document answers with an empty array rather than undefined, so a
+ * caller has one shape to handle.
+ */
+export async function provideQuartoCellSymbols(
+	virtualNotebooks: IQuartoVirtualNotebookService,
+	languageFeatures: ILanguageFeaturesService,
+	logService: ILogService,
+	uri: URI,
+	token: CancellationToken
+): Promise<IQuartoCellSymbols[]> {
+	// Notebook creation is asynchronous so a request that arrives during
+	// creation would see no cells at all.
+	await virtualNotebooks.whenReady(uri);
+
+	virtualNotebooks.ensureSynchronized(uri);
+
+	// Snapshot before the requests go out, since a sync rebuilds the cells. The
+	// spans are a copy, not a guarantee: an edit that leaves the chunk structure
+	// alone updates them in place, and the next pass corrects what this missed.
+	const cells = virtualNotebooks.getCells(uri).map(cell => ({
+		textModel: cell.textModel,
+		span: { codeStartLine: cell.codeStartLine, codeEndLine: cell.codeEndLine },
+	}));
+
+	if (token.isCancellationRequested) {
+		return [];
+	}
+
+	// Ask every cell at once. Cells are independent and each request is a round
+	// trip to a language server, so asking them one at a time makes the walk
+	// cost the sum of those trips instead of the longest one. On the 45 chunks
+	// of posit-dev/positron#14512 that was the difference between 5049 ms and
+	// 63 ms.
+	const perCell = await Promise.all(cells.map(
+		({ textModel, span }) => symbolsForCell(languageFeatures, textModel, span, token)));
+
+	// Cancelling cannot un-ask a request that already went out. What it must do
+	// is keep a superseded pass from reaching the Outline.
+	if (token.isCancellationRequested) {
+		return [];
+	}
+
+	const grouped: IQuartoCellSymbols[] = [];
+	for (let index = 0; index < cells.length; index++) {
+		const symbols = perCell[index];
+		if (symbols) {
+			grouped.push({ range: cellSourceRange(cells[index].span), symbols });
+		}
+	}
+
+	if (logService.getLevel() === LogLevel.Trace) {
+		logService.trace('[QuartoEmbedded] document symbols answered from ' +
+			`${grouped.length} of ${cells.length} cell(s)`);
+	}
+
+	return grouped;
+}
+
 /**
  * Serves the Outline for a Quarto document from its code cells. Asked about the
  * whole document rather than a position, so it walks every cell.
@@ -520,79 +656,25 @@ class QuartoEmbeddedDefinitionProvider extends QuartoEmbeddedProvider implements
  * second and redoes the whole set. These cells are already open models, so there
  * is no retry and nothing to wait for.
  *
- * Until the Quarto extension defers to us it also nests each cell's symbols
- * under the heading above them, so expect every code symbol twice.
+ * This produces a second, flat Outline group alongside the Quarto extension's
+ * own nested one, so expect every code symbol twice until this provider's
+ * registration is removed. The extension gets the nested contents it builds its
+ * own tree from through `_executeQuartoCellSymbolProvider` instead, not from
+ * this provider.
  */
 class QuartoEmbeddedDocumentSymbolProvider extends QuartoEmbeddedProvider implements DocumentSymbolProvider {
 	/** Names this group in the Outline. */
 	readonly displayName = localize('positron.quarto.outlineProvider', "Quarto Code Cells");
 
 	async provideDocumentSymbols(model: ITextModel, token: CancellationToken): Promise<DocumentSymbol[] | undefined> {
-		this._virtualNotebooks.ensureSynchronized(model.uri);
-
-		// Snapshot before the requests go out, since a sync rebuilds the cells. The
-		// spans are a copy, not a guarantee: an edit that leaves the chunk structure
-		// alone updates them in place, and the next pass corrects what this missed.
-		const cells = this._virtualNotebooks.getCells(model.uri).map(cell => ({
-			textModel: cell.textModel,
-			span: { codeStartLine: cell.codeStartLine, codeEndLine: cell.codeEndLine },
-		}));
-
-		if (token.isCancellationRequested) {
-			return undefined;
-		}
-
-		// Ask every cell at once. Cells are independent and each request is a round
-		// trip to a language server, so asking them one at a time makes the walk
-		// cost the sum of those trips instead of the longest one. On the 45 chunks
-		// of posit-dev/positron#14512 that was the difference between 5049 ms and
-		// 63 ms.
-		const perCell = await Promise.all(cells.map(
-			({ textModel, span }) => this._symbolsForCell(textModel, span, token)));
-
-		// Cancelling cannot un-ask a request that already went out. What it must do
-		// is keep a superseded pass from contributing to the Outline.
-		if (token.isCancellationRequested) {
-			return undefined;
-		}
-
-		const symbols = perCell.flatMap(cellSymbols => cellSymbols ?? []);
-		const answered = perCell.filter(cellSymbols => cellSymbols !== undefined).length;
-
-		if (this._tracing) {
-			this._logService.trace('[QuartoEmbedded] document symbols answered from ' +
-				`${answered} of ${cells.length} cell(s)`);
-		}
+		const grouped = await provideQuartoCellSymbols(
+			this._virtualNotebooks, this._languageFeatures, this._logService, model.uri, token);
+		const symbols = grouped.flatMap(entry => entry.symbols);
 
 		// An empty list would still build a group in the Outline, which is noise
-		// beside the Quarto server's headings.
+		// beside the Quarto server's headings. It is also what a cancelled
+		// request produces, which must not replace the results it superseded.
 		return symbols.length > 0 ? symbols : undefined;
-	}
-
-	/** The first usable answer for one cell, already in source coordinates. */
-	private async _symbolsForCell(
-		textModel: ITextModel,
-		span: ICellLineSpan,
-		token: CancellationToken
-	): Promise<DocumentSymbol[] | undefined> {
-		// A rebuild disposes the models it replaced, so a model read before the
-		// requests went out can be gone by the time this runs.
-		if (textModel.isDisposed()) {
-			return undefined;
-		}
-		for (const provider of this._downstream(this._languageFeatures.documentSymbolProvider, textModel)) {
-			try {
-				const result = await provider.provideDocumentSymbols(textModel, token);
-				if (result && result.length > 0) {
-					return result.map(symbol => mapDocumentSymbol(span, symbol));
-				}
-			} catch (error) {
-				// One provider failing must not discard the other cells' symbols, so
-				// report it and move on to the next provider for this cell.
-				onUnexpectedExternalError(error);
-			}
-		}
-		return undefined;
 	}
 }
 
@@ -705,3 +787,28 @@ export class QuartoEmbeddedLanguageFeatures extends Disposable implements IWorkb
 			QUARTO_SELECTOR, new QuartoEmbeddedHelpTopicProvider(...args)));
 	}
 }
+
+/**
+ * Answers the symbols of a Quarto document's code cells, grouped by cell.
+ *
+ * Exposed to extensions as `positron.executeQuartoCellSymbolProvider`, which is
+ * how the Quarto extension gets code symbols without building a temporary file
+ * per cell. It nests them into the Outline tree itself, under the chunk each one
+ * came from, which is why the answer is grouped rather than flat.
+ *
+ * Registered unconditionally, unlike the providers above. It needs no setting
+ * gate: virtual notebooks only exist while `quarto.embeddedLanguageFeatures.native`
+ * is on, so with the setting off there are no cells and the answer is empty.
+ */
+CommandsRegistry.registerCommand('_executeQuartoCellSymbolProvider', async (accessor, ...args: [URI]) => {
+	const [uri] = args;
+	assertType(URI.isUri(uri));
+
+	return await provideQuartoCellSymbols(
+		accessor.get(IQuartoVirtualNotebookService),
+		accessor.get(ILanguageFeaturesService),
+		accessor.get(ILogService),
+		uri,
+		CancellationToken.None
+	);
+});

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoEmbeddedLanguageFeatures.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoEmbeddedLanguageFeatures.ts
@@ -52,6 +52,7 @@ import {
 	ICellLineSpan,
 	sourcePositionToCell,
 } from '../common/quartoCellPositionMapping.js';
+import { IQuartoCellSymbols } from '../common/quartoCellSymbols.js';
 import { IQuartoVirtualNotebookService } from './quartoVirtualNotebookService.js';
 
 /**
@@ -570,12 +571,6 @@ async function symbolsForCell(
 		}
 	}
 	return undefined;
-}
-
-/** One cell's symbols, and where that cell's code sits in the source document. */
-export interface IQuartoCellSymbols {
-	readonly range: IRange;
-	readonly symbols: DocumentSymbol[];
 }
 
 /**

--- a/src/vs/workbench/contrib/positronQuarto/common/quartoCellSymbols.ts
+++ b/src/vs/workbench/contrib/positronQuarto/common/quartoCellSymbols.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IRange } from '../../../../editor/common/core/range.js';
+import { DocumentSymbol } from '../../../../editor/common/languages.js';
+
+/**
+ * One cell's symbols, and where that cell's code sits in the source document.
+ *
+ * This is the answer shape of `_executeQuartoCellSymbolProvider`, so it lives in
+ * `common` rather than beside the implementation: the extension host converter
+ * behind `positron.executeQuartoCellSymbolProvider` has to describe the same
+ * shape, and `api/common` cannot import from `positronQuarto/browser`.
+ */
+export interface IQuartoCellSymbols {
+	/** The cell's code span in source coordinates, fences excluded. */
+	readonly range: IRange;
+
+	/** Already remapped into source coordinates. Never empty. */
+	readonly symbols: DocumentSymbol[];
+}

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoEmbeddedLanguageFeatures.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoEmbeddedLanguageFeatures.vitest.ts
@@ -42,7 +42,8 @@ import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { Constants } from '../../../../../base/common/uint.js';
 import { QUARTO_NATIVE_LANGUAGE_FEATURES_KEY } from '../../common/positronQuartoConfig.js';
 import { IQuartoVirtualCell, IQuartoVirtualNotebookService } from '../../browser/quartoVirtualNotebookService.js';
-import { QuartoEmbeddedLanguageFeatures, provideQuartoCellSymbols, IQuartoCellSymbols } from '../../browser/quartoEmbeddedLanguageFeatures.js';
+import { QuartoEmbeddedLanguageFeatures, provideQuartoCellSymbols } from '../../browser/quartoEmbeddedLanguageFeatures.js';
+import { IQuartoCellSymbols } from '../../common/quartoCellSymbols.js';
 
 // The source document, with the R chunk's code on lines 4 and 5:
 //

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoEmbeddedLanguageFeatures.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoEmbeddedLanguageFeatures.vitest.ts
@@ -12,6 +12,7 @@ import { Position } from '../../../../../editor/common/core/position.js';
 import { IRange } from '../../../../../editor/common/core/range.js';
 import { ITextModel } from '../../../../../editor/common/model.js';
 import { createTextModel } from '../../../../../editor/test/common/testTextModel.js';
+import { TestCommandService } from '../../../../../editor/test/browser/editorTestServices.js';
 import { LanguageFeaturesService } from '../../../../../editor/common/services/languageFeaturesService.js';
 import {
 	CompletionItemKind,
@@ -33,13 +34,15 @@ import {
 	StatementRangeRejectionKind,
 	SymbolKind,
 } from '../../../../../editor/common/languages.js';
-import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { ILanguageFeaturesService } from '../../../../../editor/common/services/languageFeatures.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { Constants } from '../../../../../base/common/uint.js';
 import { QUARTO_NATIVE_LANGUAGE_FEATURES_KEY } from '../../common/positronQuartoConfig.js';
 import { IQuartoVirtualCell, IQuartoVirtualNotebookService } from '../../browser/quartoVirtualNotebookService.js';
-import { QuartoEmbeddedLanguageFeatures } from '../../browser/quartoEmbeddedLanguageFeatures.js';
+import { QuartoEmbeddedLanguageFeatures, provideQuartoCellSymbols, IQuartoCellSymbols } from '../../browser/quartoEmbeddedLanguageFeatures.js';
 
 // The source document, with the R chunk's code on lines 4 and 5:
 //
@@ -69,6 +72,7 @@ describe('QuartoEmbeddedLanguageFeatures', () => {
 	let cellModel: ITextModel;
 	let cell: IQuartoVirtualCell;
 	let calls: string[];
+	let virtualNotebooksStub: IQuartoVirtualNotebookService;
 
 	beforeEach(async () => {
 		calls = [];
@@ -100,7 +104,8 @@ describe('QuartoEmbeddedLanguageFeatures', () => {
 	 */
 	function createFeatures(options: { alwaysFindCell?: IQuartoVirtualCell; cells?: IQuartoVirtualCell[] } = {}): void {
 		const cells = options.cells ?? [cell];
-		const virtualNotebooks = stubInterface<IQuartoVirtualNotebookService>({
+		virtualNotebooksStub = stubInterface<IQuartoVirtualNotebookService>({
+			whenReady: () => Promise.resolve(),
 			ensureSynchronized: () => { calls.push('ensureSynchronized'); },
 			getCellAtLine: (_uri, lineNumber) => {
 				calls.push(`getCellAtLine:${lineNumber}`);
@@ -110,12 +115,12 @@ describe('QuartoEmbeddedLanguageFeatures', () => {
 				return lineNumber >= cell.codeStartLine && lineNumber <= cell.codeEndLine ? cell : undefined;
 			},
 			getAllCells: () => cells,
-			getCells: () => cells,
+			getCells: (u) => u.toString() === SOURCE_URI.toString() ? cells : [],
 			getSourceUriForCell: (uri) =>
 				cells.some(c => c.cellUri.toString() === uri.toString()) ? SOURCE_URI : undefined,
 		});
 		ctx.disposables.add(new QuartoEmbeddedLanguageFeatures(
-			virtualNotebooks, languageFeatures, configurationService, new NullLogService()));
+			virtualNotebooksStub, languageFeatures, configurationService, new NullLogService()));
 	}
 
 	function completionProvider(): CompletionItemProvider {
@@ -908,6 +913,118 @@ describe('QuartoEmbeddedLanguageFeatures', () => {
 		const result = await symbolProvider().provideDocumentSymbols(sourceModel, CancellationToken.None);
 
 		expect(result).toBeUndefined();
+	});
+
+	it('groups symbols by cell and reports each cell span in source coordinates', async () => {
+		// The Outline flattens this, but the Quarto extension needs to know which
+		// chunk each symbol came from so it can nest it under that chunk's heading.
+		const second = makeCell(CELL2_URI, 'f <- function() {\n  1\n}', 20);
+		registerSymbols('downstream', uri => uri === CELL_URI.toString()
+			? [symbol('x', 1)]
+			: [symbol('f', 1)]);
+		createFeatures({ cells: [cell, second] });
+
+		const grouped = await provideQuartoCellSymbols(
+			virtualNotebooksStub, languageFeatures, new NullLogService(),
+			SOURCE_URI, CancellationToken.None);
+
+		expect(grouped.map(entry => ({
+			range: entry.range,
+			names: entry.symbols.map(s => s.name),
+			lines: entry.symbols.map(s => s.range.startLineNumber),
+		}))).toEqual([
+			{
+				// Lines 4 to 5 of the source, which is the code inside the fences.
+				range: { startLineNumber: 4, startColumn: 1, endLineNumber: 5, endColumn: Constants.MAX_SAFE_SMALL_INTEGER },
+				names: ['x'],
+				lines: [4],
+			},
+			{
+				range: { startLineNumber: 20, startColumn: 1, endLineNumber: 22, endColumn: Constants.MAX_SAFE_SMALL_INTEGER },
+				names: ['f'],
+				lines: [20],
+			},
+		]);
+	});
+
+	it('omits a cell that has no symbols rather than returning it empty', async () => {
+		const second = makeCell(CELL2_URI, 'y <- 2', 20);
+		registerSymbols('downstream', uri => uri === CELL_URI.toString() ? [symbol('x', 1)] : []);
+		createFeatures({ cells: [cell, second] });
+
+		const grouped = await provideQuartoCellSymbols(
+			virtualNotebooksStub, languageFeatures, new NullLogService(),
+			SOURCE_URI, CancellationToken.None);
+
+		expect(grouped.map(entry => entry.range.startLineNumber)).toEqual([4]);
+	});
+
+	it('answers with an empty array for a document that has no cells', async () => {
+		registerSymbols('downstream', () => [symbol('x', 1)]);
+		createFeatures({ cells: [] });
+
+		const grouped = await provideQuartoCellSymbols(
+			virtualNotebooksStub, languageFeatures, new NullLogService(),
+			SOURCE_URI, CancellationToken.None);
+
+		expect(grouped).toEqual([]);
+	});
+
+	it('waits for the virtual notebook to finish initializing before reading its cells', async () => {
+		registerSymbols('downstream', () => [symbol('x', 1)]);
+		let notebookReady = false;
+		let resolveWhenReady!: () => void;
+		const whenReady = new Promise<void>(resolve => { resolveWhenReady = resolve; });
+		const stub = stubInterface<IQuartoVirtualNotebookService>({
+			whenReady: () => whenReady,
+			ensureSynchronized: () => { calls.push('ensureSynchronized'); },
+			getCells: (u) => {
+				calls.push('getCells');
+				return u.toString() === SOURCE_URI.toString() && notebookReady ? [cell] : [];
+			},
+		});
+
+		const resultPromise = provideQuartoCellSymbols(
+			stub, languageFeatures, new NullLogService(), SOURCE_URI, CancellationToken.None);
+
+		// The notebook finishes initializing only after the call has already gone
+		// out. If `provideQuartoCellSymbols` read the cells before awaiting
+		// `whenReady`, `getCells` above would already have run and returned `[]`.
+		notebookReady = true;
+		resolveWhenReady();
+		const grouped = await resultPromise;
+
+		expect(grouped.map(entry => entry.symbols.map(s => s.name))).toEqual([['x']]);
+	});
+
+	it('answers the cell symbol command from the registry', async () => {
+		// The Quarto extension reaches this through positron.executeQuartoCellSymbolProvider,
+		// so the registration and the service lookups are the part worth covering here.
+		registerSymbols('downstream', () => [symbol('x', 1)]);
+		createFeatures();
+
+		// These stubs persist on ctx.instantiationService for the rest of this file.
+		// That is safe here because every other test in this file constructs
+		// QuartoEmbeddedLanguageFeatures with explicit constructor arguments rather
+		// than resolving it from the container, so nothing downstream reads them.
+		ctx.instantiationService.stub(IQuartoVirtualNotebookService, virtualNotebooksStub);
+		ctx.instantiationService.stub(ILanguageFeaturesService, languageFeatures);
+		ctx.instantiationService.stub(ILogService, new NullLogService());
+
+		// TestCommandService resolves through CommandsRegistry and invokeFunction
+		// exactly as production does, but executeCommand is generic, so this needs
+		// no cast the way going through CommandsRegistry.getCommand directly would.
+		const commands = new TestCommandService(ctx.instantiationService);
+		const result = await commands.executeCommand<IQuartoCellSymbols[]>(
+			'_executeQuartoCellSymbolProvider', SOURCE_URI);
+
+		expect(result.map(entry => ({
+			range: entry.range,
+			names: entry.symbols.map(s => s.name),
+		}))).toEqual([{
+			range: { startLineNumber: 4, startColumn: 1, endLineNumber: 5, endColumn: Constants.MAX_SAFE_SMALL_INTEGER },
+			names: ['x'],
+		}]);
 	});
 
 	it('forwards a statement range and remaps the result into source coordinates', async () => {


### PR DESCRIPTION
Related to:

- #14540
- #15486

With this PR Positron can now answer "which symbols are in this Quarto document's code cells" through a command. The Quarto extension will call this command instead of writing a temporary file for each code cell.

The change has three parts:

- `provideQuartoCellSymbols()` is a new exported function. It returns the symbols grouped by the cell they came from. The cell walk that #15486 put inside `QuartoEmbeddedDocumentSymbolProvider` moved into this function, and the provider is now a flatten over it.
- `_executeQuartoCellSymbolProvider` is a new internal command over that function.
- `positron.executeQuartoCellSymbolProvider` is the extension-facing command. It converts the core types to `vscode` types.

**Why the result is grouped by cell.** The Outline shows one group for each document symbol provider. #15486 added a second provider, so the Outline now shows a flat list of code symbols beside the Quarto extension's nested tree. The fix is for the extension to keep its own tree and ask Positron for the contents, because only the extension knows which heading a chunk sits under. A later PR will remove the provider registration in Positron, and the Outline becomes a single nested tree again.

**Nothing calls the new command yet.** The consumer is a PR in the `quarto-dev/quarto` repository. This PR is additive on purpose, so it can land first and give that work something real to build against.

**The Outline does not change in this PR.** It still shows two groups.

### Notes for reviewers

- **`provideQuartoCellSymbols` awaits `whenReady()` before it reads the cells.** Notebook creation is asynchronous, and `ensureSynchronized` does nothing while creation is in flight, so a request that arrives early used to get no cells. The Outline hid this, because a language server that registers its provider makes the Outline recompute. The command's consumer has no such hook, so it needed the wait. A test covers it, and that test fails when the `await` is removed.
- **One malformed symbol no longer discards the rest.** `types.DocumentSymbol` validates in its constructor and throws on an empty name, or on a `selectionRange` that its `range` does not contain. The core type does not validate, and the symbols come from third-party language servers. The converter now handles each symbol separately, so a bad symbol costs only itself.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:quarto @:outline

This PR changes nothing that a user can see, so those suites are regression guards for the Outline and the Quarto features that share this code.

In terms of what will ship, the manual validation is that everything is the same as what you can see https://github.com/posit-dev/positron/pull/15486.

If you want to manually verify the command yourself, temporarily register is as something that, say, the R extension can call and send the output to the Developer Tools console. You can then verify that you see output like:

```
[Extension Host] [CellSymbolProbe] on first activation of /Users/juliasilge/Work/posit/scratch/quarto_basic.qmd
    returned 2 cell(s)
    cell lines 8-16 (0-based; add 1 for editor line numbers), 1 symbol(s)
      smaller kind=12 (Variable) detail="" line=13 sel=13
    cell lines 36-42 (0-based; add 1 for editor line numbers), 2 symbol(s)
      mod kind=12 (Variable) detail="" line=38 sel=38
      my_func kind=11 (Function) detail="function(x)" line=40 sel=40
```

