### PR TITLE
Retry Python interpreter resolution after a refresh

### DIFF
--- a/extensions/positron-python/src/client/positron/manager.ts
+++ b/extensions/positron-python/src/client/positron/manager.ts
@@ -26,7 +26,7 @@ import { JupyterKernelSpec } from '../positron-supervisor.d';
 import { IEnvironmentVariablesProvider } from '../common/variables/types';
 import { getConfiguration } from '../common/vscodeApis/workspaceApis';
 import { shouldIncludeInterpreter, getUserDefaultInterpreter } from './interpreterSettings';
-import { hasFiles } from './util';
+import { hasFiles, resolveInterpreterWithRetry } from './util';
 import { isCondaEnvironment } from '../pythonEnvironments/common/environmentManagers/conda';
 import { untildify } from '../common/helpers';
 import {
@@ -320,18 +320,16 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
 
         if (interpreterPath) {
             interpreterPath = untildify(interpreterPath);
-            let interpreter = await this.interpreterService.getInterpreterDetails(interpreterPath, workspaceUri);
-
             // This runs during startup, before interpreter discovery has necessarily
             // resolved this path. A cold resolve returns undefined, which would drop the
             // workspace default entirely, since it is never re-queried after discovery.
-            // Trigger a refresh and retry once so the default is recommended reliably.
-            // Mirrors the retry in selectLanguageRuntimeFromPath.
-            if (!interpreter) {
-                traceInfo(`Recommended interpreter ${interpreterPath} not resolved yet, triggering refresh...`);
-                await this.interpreterService.triggerRefresh().ignoreErrors();
-                interpreter = await this.interpreterService.getInterpreterDetails(interpreterPath, workspaceUri);
-            }
+            // The helper triggers a refresh and retries once so the default is
+            // recommended reliably.
+            const interpreter = await resolveInterpreterWithRetry(
+                this.interpreterService,
+                interpreterPath,
+                workspaceUri,
+            );
 
             if (interpreter) {
                 const metadata = await createPythonRuntimeMetadata(interpreter, this.serviceContainer, isImmediate);
@@ -577,6 +575,7 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
 
         // Replace the metadata if we can find the runtime in the registered runtimes
         let registeredMetadata = this.registeredPythonRuntimes.get(extraData.pythonPath);
+        let resolvePath = extraData.pythonPath;
 
         if (!registeredMetadata) {
             // It's possible that the interpreter is located at pythonPath/bin/python.
@@ -586,11 +585,20 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
             const binPythonExists = await fs.pathExists(binPythonPath);
             if (binPythonExists) {
                 registeredMetadata = this.registeredPythonRuntimes.get(binPythonPath);
+                resolvePath = binPythonPath;
             }
         }
 
-        // Metadata is valid
-        return registeredMetadata ?? metadata;
+        if (registeredMetadata) {
+            // Discovery already resolved this interpreter; its metadata is fresh.
+            return registeredMetadata;
+        }
+
+        const interpreter = await resolveInterpreterWithRetry(this.interpreterService, resolvePath);
+        if (!interpreter) {
+            throw new Error(`Failed to resolve interpreter ${resolvePath}; the environment may no longer be usable`);
+        }
+        return createPythonRuntimeMetadata(interpreter, this.serviceContainer, false);
     }
 
     /**

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -38,7 +38,7 @@ import { showErrorMessage } from '../common/vscodeApis/windowApis';
 import { Console } from '../common/utils/localize';
 import { Architecture } from '../common/utils/platform';
 import { getIpykernelBundle, IpykernelBundle } from './ipykernel';
-import { getActiveInterpreterConfigTarget, whenTimeout } from './util';
+import { getActiveInterpreterConfigTarget, resolveInterpreterWithRetry, whenTimeout } from './util';
 import { PackageManagerFactory } from './packages/packageManagerFactory';
 import { IPackageManager } from './packages/types';
 import { listMissingPythonPackages, pythonMissingPackageProbe } from './missingPackages';
@@ -529,7 +529,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
     }
 
     async start(): Promise<positron.LanguageRuntimeInfo> {
-        const interpreter = await this._interpreterService.getInterpreterDetails(this._pythonPath);
+        const interpreter = await resolveInterpreterWithRetry(this._interpreterService, this._pythonPath);
         if (!interpreter) {
             throw new Error(`Could not start runtime: failed to resolve interpreter ${this._pythonPath}`);
         }

--- a/extensions/positron-python/src/client/positron/util.ts
+++ b/extensions/positron-python/src/client/positron/util.ts
@@ -5,8 +5,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { traceVerbose } from '../logging';
+import { traceInfo, traceVerbose, traceWarn } from '../logging';
 import { IWorkspaceService } from '../common/application/types';
+import { IInterpreterService } from '../interpreter/contracts';
+import { PythonEnvironment } from '../pythonEnvironments/info';
 
 export class PromiseHandles<T> {
     resolve!: (value: T | Promise<T>) => void;
@@ -63,4 +65,85 @@ export async function hasFiles(includes: string[]): Promise<boolean> {
     traceVerbose(`Found _files_: ${files.map((file) => file.fsPath)}`);
 
     return files.length > 0;
+}
+
+/** Time budget for a single PET interpreter resolve request. */
+export const RESOLVE_TIMEOUT_MS = 15_000;
+
+/** Time budget for the interpreter refresh between resolve attempts. */
+export const REFRESH_TIMEOUT_MS = 60_000;
+
+/**
+ * Race a promise against a timeout. Clears the timer once the race settles so
+ * callers (and unit test runs) do not accumulate pending timers.
+ */
+async function raceWithTimeout<T>(promise: Promise<T>, ms: number, onTimeout: () => void): Promise<T | undefined> {
+    let timer: NodeJS.Timeout | undefined;
+    try {
+        return await Promise.race([
+            promise,
+            new Promise<undefined>((resolve) => {
+                timer = setTimeout(() => {
+                    onTimeout();
+                    resolve(undefined);
+                }, ms);
+            }),
+        ]);
+    } finally {
+        if (timer !== undefined) {
+            clearTimeout(timer);
+        }
+    }
+}
+
+/** A single bounded resolve attempt; errors and timeouts count as unresolved. */
+async function resolveInterpreterOnce(
+    interpreterService: IInterpreterService,
+    pythonPath: string,
+    resource?: vscode.Uri,
+): Promise<PythonEnvironment | undefined> {
+    try {
+        return await raceWithTimeout(
+            interpreterService.getInterpreterDetails(pythonPath, resource),
+            RESOLVE_TIMEOUT_MS,
+            () => traceWarn(`Timed out resolving interpreter ${pythonPath} after ${RESOLVE_TIMEOUT_MS}ms`),
+        );
+    } catch (err) {
+        traceWarn(`Error resolving interpreter ${pythonPath}: ${err}`);
+        return undefined;
+    }
+}
+
+/**
+ * Resolve an interpreter path to a PythonEnvironment, retrying once after an
+ * interpreter refresh if the first attempt fails.
+ *
+ * A single resolve can transiently fail (or hang) when PET is under load or
+ * has not yet discovered the environment, even for an interpreter that is
+ * perfectly valid; see https://github.com/posit-dev/positron/issues/15128.
+ * Each attempt is bounded by RESOLVE_TIMEOUT_MS and the refresh by
+ * REFRESH_TIMEOUT_MS so a non-responsive PET cannot stall the caller
+ * indefinitely. Returns undefined if the interpreter still does not resolve;
+ * callers decide whether that is fatal.
+ */
+export async function resolveInterpreterWithRetry(
+    interpreterService: IInterpreterService,
+    pythonPath: string,
+    resource?: vscode.Uri,
+): Promise<PythonEnvironment | undefined> {
+    const interpreter = await resolveInterpreterOnce(interpreterService, pythonPath, resource);
+    if (interpreter) {
+        return interpreter;
+    }
+
+    traceInfo(`Interpreter ${pythonPath} did not resolve; triggering an interpreter refresh and retrying...`);
+    try {
+        await raceWithTimeout(interpreterService.triggerRefresh(), REFRESH_TIMEOUT_MS, () =>
+            traceWarn(`Timed out waiting for interpreter refresh after ${REFRESH_TIMEOUT_MS}ms`),
+        );
+    } catch (err) {
+        traceWarn(`Interpreter refresh failed: ${err}`);
+    }
+
+    return resolveInterpreterOnce(interpreterService, pythonPath, resource);
 }

--- a/extensions/positron-python/src/test/positron/manager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/manager.unit.test.ts
@@ -68,6 +68,11 @@ suite('Python runtime manager', () => {
         interpreterService
             .setup((i) => i.getInterpreterDetails(TypeMoq.It.isAny()))
             .returns(() => Promise.resolve(interpreter.object));
+        // resolveInterpreterWithRetry passes a resource argument, so the two-argument
+        // call needs its own setup for TypeMoq to match it.
+        interpreterService
+            .setup((i) => i.getInterpreterDetails(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve(interpreter.object));
 
         serviceContainer.setup((s) => s.get(IConfigurationService)).returns(() => configService.object);
         serviceContainer.setup((s) => s.get(IEnvironmentVariablesProvider)).returns(() => envVarsProvider.object);
@@ -133,12 +138,16 @@ suite('Python runtime manager', () => {
     // test('discoverRuntimes', async () => {
     // });
 
-    test('validateMetadata: returns the validated metadata', async () => {
+    test('validateMetadata: rehydrates metadata for an unregistered but resolvable interpreter', async () => {
         sinon.stub(fs, 'pathExists').resolves(true);
+        const rehydrated = createTypeMoq<positron.LanguageRuntimeMetadata>();
+        const createStub = sinon.stub(runtime, 'createPythonRuntimeMetadata').resolves(rehydrated.object);
 
         const validated = await pythonRuntimeManager.validateMetadata(runtimeMetadata.object);
 
-        assert.deepStrictEqual(validated, runtimeMetadata.object);
+        assert.strictEqual(validated, rehydrated.object);
+        sinon.assert.calledOnceWithExactly(createStub, interpreter.object, serviceContainer.object, false);
+        interpreterService.verify((i) => i.triggerRefresh(), TypeMoq.Times.never());
     });
 
     test('validateMetadata: returns the full metadata when a metadata fragment is provided', async () => {
@@ -155,6 +164,12 @@ suite('Python runtime manager', () => {
 
         // The validated metadata should be the full metadata.
         assert.deepStrictEqual(validated, runtimeMetadata.object);
+
+        // A registered runtime takes the fast path: no PET resolve.
+        interpreterService.verify(
+            (i) => i.getInterpreterDetails(TypeMoq.It.isAny(), TypeMoq.It.isAny()),
+            TypeMoq.Times.never(),
+        );
     });
 
     test('validateMetadata: throws if extra data is missing', async () => {
@@ -165,6 +180,41 @@ suite('Python runtime manager', () => {
     test('validateMetadata: throws if interpreter path does not exist', async () => {
         sinon.stub(fs, 'pathExists').resolves(false);
         assert.rejects(() => pythonRuntimeManager.validateMetadata(runtimeMetadata.object));
+    });
+
+    test('validateMetadata: refreshes and retries when the interpreter does not resolve at first', async () => {
+        sinon.stub(fs, 'pathExists').resolves(true);
+        const rehydrated = createTypeMoq<positron.LanguageRuntimeMetadata>();
+        sinon.stub(runtime, 'createPythonRuntimeMetadata').resolves(rehydrated.object);
+
+        let resolveCalls = 0;
+        interpreterService.reset();
+        interpreterService
+            .setup((i) => i.getInterpreterDetails(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .returns(() => {
+                resolveCalls += 1;
+                return Promise.resolve(resolveCalls === 1 ? undefined : interpreter.object);
+            });
+        interpreterService.setup((i) => i.triggerRefresh()).returns(() => Promise.resolve());
+
+        const validated = await pythonRuntimeManager.validateMetadata(runtimeMetadata.object);
+
+        assert.strictEqual(validated, rehydrated.object);
+        interpreterService.verify((i) => i.triggerRefresh(), TypeMoq.Times.once());
+    });
+
+    test('validateMetadata: throws when the interpreter cannot be resolved after a refresh', async () => {
+        sinon.stub(fs, 'pathExists').resolves(true);
+        interpreterService.reset();
+        interpreterService
+            .setup((i) => i.getInterpreterDetails(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve(undefined));
+        interpreterService.setup((i) => i.triggerRefresh()).returns(() => Promise.resolve());
+
+        await assert.rejects(
+            () => pythonRuntimeManager.validateMetadata(runtimeMetadata.object),
+            /Failed to resolve interpreter/,
+        );
     });
 
     test('registerLanguageRuntimeFromPath: registers a runtime with the corresponding runtime metadata', async () => {

--- a/extensions/positron-python/src/test/positron/session.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/session.unit.test.ts
@@ -44,6 +44,7 @@ suite('Python Runtime Session', () => {
     let applicationShell: IApplicationShell;
     let installerSpy: sinon.SinonSpiedInstance<IInstaller>;
     let interpreterPathService: IInterpreterPathService;
+    let interpreterService: IInterpreterService;
     let envVarsServiceSpy: sinon.SinonSpiedInstance<IEnvironmentVariablesService>;
     let interpreter: PythonEnvironment;
     let serviceContainer: IServiceContainer;
@@ -70,8 +71,9 @@ suite('Python Runtime Session', () => {
             implementation: 'cpython',
         });
 
-        const interpreterService = mock<IInterpreterService>({
+        interpreterService = mock<IInterpreterService>({
             getInterpreterDetails: (_pythonPath, _resource) => Promise.resolve(interpreter),
+            triggerRefresh: () => Promise.resolve(),
         });
 
         const installer = mock<IInstaller>({
@@ -261,6 +263,27 @@ suite('Python Runtime Session', () => {
 
         // Should try to use ipykernel from the environment.
         sinon.assert.called(installerSpy.isProductVersionCompatible);
+    });
+
+    test('Start: retries interpreter resolution after a refresh when the first resolve fails', async () => {
+        const getDetails = sinon.stub(interpreterService, 'getInterpreterDetails');
+        getDetails.onFirstCall().resolves(undefined);
+        getDetails.onSecondCall().resolves(interpreter);
+        const triggerRefresh = sinon.spy(interpreterService, 'triggerRefresh');
+
+        const session = createSession(positron.LanguageRuntimeSessionMode.Console);
+        await session.start();
+
+        sinon.assert.calledOnce(triggerRefresh);
+        sinon.assert.calledTwice(getDetails);
+    });
+
+    test('Start: throws when the interpreter cannot be resolved after a refresh', async () => {
+        sinon.stub(interpreterService, 'getInterpreterDetails').resolves(undefined);
+        sinon.stub(interpreterService, 'triggerRefresh').resolves();
+
+        const session = createSession(positron.LanguageRuntimeSessionMode.Console);
+        await assert.rejects(() => session.start(), /failed to resolve interpreter/);
     });
 
     test('Execute: dont uninstall bundled packages', async () => {

--- a/extensions/positron-python/src/test/positron/util.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/util.unit.test.ts
@@ -4,10 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import { WorkspaceFolder } from 'vscode';
 import { IWorkspaceService } from '../../client/common/application/types';
-import { getActiveInterpreterConfigTarget } from '../../client/positron/util';
+import { IInterpreterService } from '../../client/interpreter/contracts';
+import { PythonEnvironment } from '../../client/pythonEnvironments/info';
+import {
+    getActiveInterpreterConfigTarget,
+    resolveInterpreterWithRetry,
+    RESOLVE_TIMEOUT_MS,
+} from '../../client/positron/util';
 import { mock } from './utils';
 
 suite('getActiveInterpreterConfigTarget', () => {
@@ -51,5 +58,119 @@ suite('getActiveInterpreterConfigTarget', () => {
             configTarget: vscode.ConfigurationTarget.WorkspaceFolder,
             folderUri,
         });
+    });
+});
+
+suite('resolveInterpreterWithRetry', () => {
+    const pythonPath = '/path/to/python';
+    let interpreter: PythonEnvironment;
+
+    setup(() => {
+        interpreter = mock<PythonEnvironment>({ path: pythonPath });
+    });
+
+    teardown(() => {
+        sinon.restore();
+    });
+
+    test('returns the interpreter without refreshing when the first resolve succeeds', async () => {
+        const getDetails = sinon.stub().resolves(interpreter);
+        const triggerRefresh = sinon.stub().resolves();
+        const interpreterService = mock<IInterpreterService>({
+            getInterpreterDetails: getDetails,
+            triggerRefresh,
+        });
+
+        const result = await resolveInterpreterWithRetry(interpreterService, pythonPath);
+
+        assert.strictEqual(result, interpreter);
+        sinon.assert.calledOnce(getDetails);
+        sinon.assert.notCalled(triggerRefresh);
+    });
+
+    test('refreshes and retries when the first resolve returns undefined', async () => {
+        const getDetails = sinon.stub();
+        getDetails.onFirstCall().resolves(undefined);
+        getDetails.onSecondCall().resolves(interpreter);
+        const triggerRefresh = sinon.stub().resolves();
+        const interpreterService = mock<IInterpreterService>({
+            getInterpreterDetails: getDetails,
+            triggerRefresh,
+        });
+
+        const result = await resolveInterpreterWithRetry(interpreterService, pythonPath);
+
+        assert.strictEqual(result, interpreter);
+        sinon.assert.calledTwice(getDetails);
+        sinon.assert.calledOnce(triggerRefresh);
+    });
+
+    test('returns undefined when the resolve still fails after a refresh', async () => {
+        const getDetails = sinon.stub().resolves(undefined);
+        const triggerRefresh = sinon.stub().resolves();
+        const interpreterService = mock<IInterpreterService>({
+            getInterpreterDetails: getDetails,
+            triggerRefresh,
+        });
+
+        const result = await resolveInterpreterWithRetry(interpreterService, pythonPath);
+
+        assert.strictEqual(result, undefined);
+        sinon.assert.calledTwice(getDetails);
+        sinon.assert.calledOnce(triggerRefresh);
+    });
+
+    test('treats a rejected resolve as unresolved and retries', async () => {
+        const getDetails = sinon.stub();
+        getDetails.onFirstCall().rejects(new Error('PET hiccup'));
+        getDetails.onSecondCall().resolves(interpreter);
+        const triggerRefresh = sinon.stub().resolves();
+        const interpreterService = mock<IInterpreterService>({
+            getInterpreterDetails: getDetails,
+            triggerRefresh,
+        });
+
+        const result = await resolveInterpreterWithRetry(interpreterService, pythonPath);
+
+        assert.strictEqual(result, interpreter);
+        sinon.assert.calledOnce(triggerRefresh);
+    });
+
+    test('ignores a rejected refresh and still retries the resolve', async () => {
+        const getDetails = sinon.stub();
+        getDetails.onFirstCall().resolves(undefined);
+        getDetails.onSecondCall().resolves(interpreter);
+        const triggerRefresh = sinon.stub().rejects(new Error('refresh failed'));
+        const interpreterService = mock<IInterpreterService>({
+            getInterpreterDetails: getDetails,
+            triggerRefresh,
+        });
+
+        const result = await resolveInterpreterWithRetry(interpreterService, pythonPath);
+
+        assert.strictEqual(result, interpreter);
+    });
+
+    test('times out a hung resolve and falls through to refresh and retry', async () => {
+        const clock = sinon.useFakeTimers();
+        try {
+            const getDetails = sinon.stub();
+            getDetails.onFirstCall().returns(new Promise(() => {})); // never settles
+            getDetails.onSecondCall().resolves(interpreter);
+            const triggerRefresh = sinon.stub().resolves();
+            const interpreterService = mock<IInterpreterService>({
+                getInterpreterDetails: getDetails,
+                triggerRefresh,
+            });
+
+            const resultPromise = resolveInterpreterWithRetry(interpreterService, pythonPath);
+            await clock.tickAsync(RESOLVE_TIMEOUT_MS);
+            const result = await resultPromise;
+
+            assert.strictEqual(result, interpreter);
+            sinon.assert.calledOnce(triggerRefresh);
+        } finally {
+            clock.restore();
+        }
     });
 });


### PR DESCRIPTION
Fixes #15128

A single PET interpreter resolve can fail or hang for a moment, even when the interpreter is valid. Today one failed resolve permanently stops a Python session from starting. This PR adds a shared `resolveInterpreterWithRetry` helper. The helper bounds each resolve attempt with a timeout. If the first attempt fails, the helper triggers an interpreter refresh and resolves one more time.

The helper is wired into three places:

- `PythonRuntimeSession.start()` retries the resolve before it throws. Core skips `validateMetadata` for a runtime that is already registered, so this path needs its own retry.
- `PythonRuntimeManager.validateMetadata()` now resolves an unregistered interpreter against the live environment and rebuilds its metadata. This matches the R runtime manager. A runtime that discovery already registered keeps the fast path and makes no PET call.
- `recommendedWorkspaceRuntime()` now uses the shared helper in place of its own inline retry. This also gives it the timeouts.

Each resolve attempt has a 15 second budget. The refresh has a 60 second budget. Both values are exported constants.

The main behavior change to review is that `validateMetadata` now throws when an unregistered interpreter does not resolve after a full refresh. Before this change, it returned the stored metadata, and the error appeared later at session start. Core treats a validation error as "evict from the cache and fail early". This is the intended contract, and it matches the R implementation.

This change also hardens the race in #13521, which is the same problem in an earlier form.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Retry Python interpreter resolution after a refresh, so a temporary resolve error no longer stops a session from starting (#15128)

### Validation Steps

@:interpreter @:sessions @:console @:remote-ssh

The failure in #15128 is a timing race between the extension and PET. It is not reproducible on demand, so the new retry, timeout, and give-up paths are covered by unit tests: 10 new tests and 1 rewritten test across `util.unit.test.ts`, `session.unit.test.ts`, and `manager.unit.test.ts`. The full positron-python unit suite passes with 5715 tests.

The manual steps below are regression checks. This PR changes code on the normal startup path, so the risk to review is a break in ordinary interpreter selection and session start.

Open **Output > Python Language Pack** and keep it open for every step.

1. Open a folder that contains a `.venv`. Make sure that Positron recommends the interpreter from that `.venv`.
2. Start a Python console. Make sure that it starts and runs code.
3. Start a console for a conda environment from the interpreter picker. Make sure that it starts. This also covers the conda directory path in `validateMetadata`.
4. Start a console for a pyenv environment. Make sure that it starts.
5. Close the folder and open it again. Make sure that the affiliated runtime starts on its own.
6. Restart the session from the console. Make sure that it restarts.
7. Open a folder with no `.venv`, but with `python.defaultInterpreterPath` set. Make sure that Positron recommends that interpreter.
8. Read the output channel. Make sure that no `failed to resolve interpreter` message and no `Failed to resolve interpreter` message appear.

I believe step 8 is the important one. Both messages are the failure this PR corrects, and neither must appear during normal use.
