### PR TITLE
Add Agent Layout that opens Posit Assistant in the editor area

### DIFF
--- a/src/vs/workbench/services/positronLayout/browser/layouts/positronAgentLayout.ts
+++ b/src/vs/workbench/services/positronLayout/browser/layouts/positronAgentLayout.ts
@@ -1,0 +1,82 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize2 } from '../../../../../nls.js';
+import { registerAction2 } from '../../../../../platform/actions/common/actions.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
+import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
+import { Parts } from '../../../layout/browser/layoutService.js';
+import { IPositronLayoutService } from '../interfaces/positronLayoutService.js';
+import { PositronLayoutAction, PositronLayoutInfo } from './layoutAction.js';
+import { AI_ENABLED_KEY } from '../../../../contrib/positronAssistant/common/positronAIConfigurationKeys.js';
+
+
+export const positronAgentLayout: PositronLayoutInfo = {
+	id: 'workbench.action.positronAgentLayout',
+	codicon: 'sparkle',
+	label: localize2('choseLayout.agent', 'Agent Layout'),
+	// Requires Posit Assistant: the layout opens the Assistant in the editor
+	// area via a posit-assistant command, so there is no legacy-chat fallback.
+	// Gate on the config values directly (not ChatContextKeys.aiFeaturesEnabled):
+	// that context key is only bound once ChatAgentService is instantiated, so
+	// it can be absent when the palette or layout picker evaluates this.
+	precondition: ContextKeyExpr.and(
+		ContextKeyExpr.has(`config.${AI_ENABLED_KEY}`),
+		ContextKeyExpr.has('config.assistant.enabled'),
+	)!,
+	layoutDescriptor: {
+		[Parts.PANEL_PART]: {
+			hidden: true,
+			alignment: 'center'
+		},
+		[Parts.SIDEBAR_PART]: {
+			hidden: true
+		},
+		[Parts.AUXILIARYBAR_PART]: {
+			hidden: false,
+			size: '30%',
+			viewContainers: [
+				{
+					id: 'workbench.panel.positronSession',
+					opened: true,
+					views: [
+						{
+							// Collapsed on entry; running code pops it open
+							id: 'workbench.panel.positronConsole',
+							collapsed: true,
+						},
+						{
+							id: 'workbench.panel.positronVariables',
+						},
+						{
+							id: 'workbench.panel.positronPlots',
+						},
+					]
+				},
+				{
+					id: 'terminal',
+				}
+			]
+		},
+	},
+};
+
+
+registerAction2(class extends PositronLayoutAction {
+	constructor() {
+		super(positronAgentLayout);
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		accessor.get(IPositronLayoutService).setLayout(positronAgentLayout.layoutDescriptor);
+
+		// The layout descriptor only covers the panel, sidebar, and auxiliary
+		// bar; the big Assistant pane in the editor area comes from Posit
+		// Assistant's own command, which carries over the sidebar conversation
+		// if one exists (and activates the extension if needed).
+		await accessor.get(ICommandService).executeCommand('posit-assistant.moveToEditorPanel');
+	}
+});

--- a/src/vs/workbench/services/positronLayout/browser/positronCustomViews.ts
+++ b/src/vs/workbench/services/positronLayout/browser/positronCustomViews.ts
@@ -9,6 +9,7 @@ import { positronFourPaneDsLayout } from './layouts/positronFourPaneDsLayout.js'
 import { positronTwoPaneLayout } from './layouts/positronTwoPaneLayout.js';
 import { positronNotebookLayout } from './layouts/positronNotebookLayout.js';
 import { positronAssistantLayout } from './layouts/positronAssistantLayout.js';
+import { positronAgentLayout } from './layouts/positronAgentLayout.js';
 import { PositronLayoutInfo } from './layouts/layoutAction.js';
 
 // Imports needed to register the layout service and non-primary layouts. (Otherwise the scripts
@@ -27,7 +28,8 @@ export const positronCustomLayoutOptions: LayoutPick[] = [
 	positronFourPaneDsLayout,
 	positronTwoPaneLayout,
 	positronNotebookLayout,
-	positronAssistantLayout
+	positronAssistantLayout,
+	positronAgentLayout
 ].map(function positronLayoutInfoToQuickPick(layoutInfo: PositronLayoutInfo): LayoutPick {
 	return {
 		id: layoutInfo.id,

--- a/test/e2e/pages/layouts.ts
+++ b/test/e2e/pages/layouts.ts
@@ -22,6 +22,7 @@ const positronLayoutPresets = {
 	side_by_side: 'workbench.action.positronTwoPaneDataScienceLayout',
 	notebook: 'workbench.action.positronNotebookLayout',
 	assistant: 'workbench.action.positronAssistantLayout',
+	agent: 'workbench.action.positronAgentLayout',
 	dockedHelp: 'workbench.action.positronHelpPaneDocked',
 	fullSizedAuxBar: 'workbench.action.fullSizedAuxiliaryBar',
 	fullSizedSidebar: 'workbench.action.fullSizedSidebar',

--- a/test/e2e/tests/layouts/layouts.test.ts
+++ b/test/e2e/tests/layouts/layouts.test.ts
@@ -211,4 +211,64 @@ test.describe('Layouts', { tag: [tags.LAYOUTS, tags.WIN] }, () => {
 			await app.workbench.positAssistant.expectViewOpen();
 		});
 	});
+
+	test.describe('Agent Layout', { tag: [tags.ASSISTANT] }, () => {
+
+		test.afterEach('Reset Layout', async function ({ app }) {
+			// Close the Posit Assistant editor tab(s) with the mouse BEFORE any
+			// keyboard-driven cleanup. While the webview is open it is not safe to
+			// drive the keyboard: when its content finishes loading it focuses its
+			// own chat input, dismissing an open quick input mid-command, and with
+			// the webview focused the Cmd+K of the close-all-editors chord is
+			// swallowed while the following Cmd+W closes the whole app window.
+			const assistantTabs = app.code.driver.currentPage
+				.locator('.tabs-container .tab[data-resource-name^="webview-posit-assistant"]');
+			while (await assistantTabs.count() > 0) {
+				await assistantTabs.first().locator('.action-label.codicon-close').click();
+			}
+			await app.workbench.layouts.enterLayout('stacked');
+		});
+
+		// Intentionally untagged for every browser-based project: like the Posit
+		// Assistant test above, this opens the webview-backed Posit Assistant,
+		// which is unreliable on web (#13933). Runs on desktop only.
+		//
+		// No settings setup: the layout's precondition needs `assistant.enabled`,
+		// which defaults to true and registers from the extension manifest at scan
+		// time. Setting it explicitly mid-test makes the extension activate right
+		// then, and that activation steals focus from the open quick input.
+		test('Verify Agent Layout hides Sidebar and Panel and opens Posit Assistant in the editor area', async function ({ app }) {
+			const layouts = app.workbench.layouts;
+
+			// Enter agent layout
+			await layouts.enterLayout('agent');
+
+			// ------ Panel and Sidebar -------
+			// Both should be collapsed
+			await expect(layouts.panelContent).not.toBeVisible();
+			await expect(layouts.sidebar).not.toBeVisible();
+
+			// ------ Auxiliary Bar -------
+			// First view should be the session view, second should be terminal
+			await expect(layouts.auxBar).toBeVisible();
+			await expect(layouts.auxBarViewsTab.nth(0)).toHaveText('Session');
+			await expect(layouts.auxBarViewsTab.nth(1)).toHaveText('Terminal');
+
+			// Console starts collapsed (it pops open on first code run);
+			// Variables and Plots start expanded
+			const consoleSection = layouts.auxBar.getByLabel(/console section/i);
+			const variablesSection = layouts.auxBar.getByLabel(/variables section/i);
+			const plotsSection = layouts.auxBar.getByLabel(/plots section/i);
+			await expect(consoleSection).toHaveAttribute('aria-expanded', 'false');
+			await expect(variablesSection).toHaveAttribute('aria-expanded', 'true');
+			await expect(plotsSection).toHaveAttribute('aria-expanded', 'true');
+
+			// ------ Editor area -------
+			// The layout opens Posit Assistant as a webview editor tab whose
+			// data-resource-name is webview-posit-assistant-<uuid>. Match on that
+			// prefix; matching the "Posit Assistant" label would also hit the
+			// activity bar icon (role=tab too).
+			await app.workbench.editors.waitForActiveTab(/^webview-posit-assistant/);
+		});
+	});
 });


### PR DESCRIPTION
This PR adds a new "Agent Layout" preset for agentic workflows. The layout opens Posit Assistant as a large pane in the editor area (about 70% of the window) and puts a compact Session pane (30%) in the auxiliary bar:


<img width="1400" height="973" alt="Screenshot 2026-08-14 at 12 50 32 PM" src="https://github.com/user-attachments/assets/734376f1-648e-4bb5-a28b-118e88ccaf4a" />

The Session pane shows Variables and Plots expanded, with the Console collapsed. The Console expands when a session starts or code runs. The sidebar and the bottom panel are hidden.

We are going to use this layout for the in-person demos at conf, and it also sets up first steps for moving into more "data science agent" UX directions moving forward. cc @nealrichardson 

Implementation notes:

- The preset lives in `positronAgentLayout.ts`, next to the other layout presets. Because the layout description format only covers the panel, sidebar, and auxiliary bar, the action has a `run()` override: it applies the layout, then runs `posit-assistant.moveToEditorPanel` to open the Assistant in the editor area.

- The layout only appears when AI features are on. The precondition gates on `config.ai.enabled` and `config.assistant.enabled`. It does not use the `chatAiFeaturesEnabled` context key: that key is only bound after `ChatAgentService` is instantiated, so it can be absent when the Command Palette or the layout picker evaluates the precondition, which hides the action.

- There is no legacy-chat fallback. The layout requires Posit Assistant.

- The picker icon is the built-in `sparkle` codicon for now. A bespoke layout glyph would be a positron-codicons follow-up, if we want to try to represent this in a different way:

<img width="619" height="371" alt="Screenshot 2026-08-14 at 12 52 11 PM" src="https://github.com/user-attachments/assets/bd348bf8-448d-498b-8f02-f5fe36683cd8" />

- The new e2e test runs on desktop only, like the other Posit Assistant coverage, because the webview is unreliable on web (#13933). The test also avoids keyboard-driven steps while the Assistant webview is open: the webview takes focus when its content loads, which dismisses an open quick input, and it swallows the first half of keyboard chords.

### Release Notes

#### New Features

- Added an "Agent Layout" that opens Posit Assistant in the editor area with a compact Session pane, available when AI features are enabled

#### Bug Fixes

- N/A

### Validation Steps

@:layouts @:assistant

1. Make sure that `ai.enabled` is on (the default) and that Posit Assistant is installed and enabled.
2. Open the Command Palette (<kbd>Cmd+Shift+P</kbd>) and run _View: Agent Layout_. Also make sure that the layout appears in the _Customize Layout_ picker with a sparkle icon.
3. Make sure that Posit Assistant opens as the active editor tab, the auxiliary bar shows the Session pane at about 30% width, the Console section is collapsed, the Variables and Plots sections are expanded, and the sidebar and bottom panel are hidden.
4. Start an interpreter session or run some code. Make sure that the Console section expands.
5. Set `ai.enabled` to false. Make sure that the layout disappears from the Command Palette and the _Customize Layout_ picker.
