### PR TITLE
python: change health check CTAs from New Folder to Open Folder

### DIFF
--- a/extensions/positron-python/src/client/positron/environmentHealth.ts
+++ b/extensions/positron-python/src/client/positron/environmentHealth.ts
@@ -304,10 +304,16 @@ export function buildCreateEnvFix(deps: {
     };
 }
 
-export function buildNewFolderFix(): HealthItemFix {
+/**
+ * The CTA for every no-folder-open outcome. Opening a folder is the one step that unblocks the
+ * rest of the check: once a folder is open, the check re-runs against it and surfaces the real
+ * next step (create an environment, install ipykernel, and so on). Only offer it when no folder
+ * is open - with a folder already open it addresses nothing.
+ */
+export function buildOpenFolderFix(): HealthItemFix {
     return {
-        commandId: 'positron.workbench.action.newFolderFromTemplate',
-        label: vscode.l10n.t('New Folder from Template'),
+        commandId: 'workbench.action.files.openFolder',
+        label: vscode.l10n.t('Open Folder'),
     };
 }
 
@@ -315,8 +321,8 @@ export function probeDedicatedEnvironment(deps: {
     workspaceOpen: boolean;
     interpreterDedicated: boolean;
     anyDedicatedDiscovered: boolean;
-    createEnvFix: HealthItemFix;
-    newFolderFix: HealthItemFix;
+    createEnvFix?: HealthItemFix;
+    openFolderFix: HealthItemFix;
 }): HealthItem {
     const id = 'dedicatedEnvironment';
     const summary = itemSummary(id);
@@ -342,9 +348,9 @@ export function probeDedicatedEnvironment(deps: {
             status: 'warn',
             summary,
             detail: vscode.l10n.t(
-                'A dedicated environment exists but no folder is open. Open a folder (or create one) to use it; full green means an open folder using a dedicated environment.',
+                'A dedicated environment exists but no folder is open. Open a folder to use it; full green means an open folder using a dedicated environment.',
             ),
-            fix: deps.newFolderFix,
+            fix: deps.openFolderFix,
         };
     }
 
@@ -353,9 +359,9 @@ export function probeDedicatedEnvironment(deps: {
         status: 'fail',
         summary,
         detail: vscode.l10n.t(
-            'No dedicated Python environment was found and no folder is open. Create a folder with a dedicated environment to get started.',
+            'No dedicated Python environment was found and no folder is open. Open a folder to get started; you can create a dedicated environment in it.',
         ),
-        fix: deps.newFolderFix,
+        fix: deps.openFolderFix,
     };
 }
 
@@ -364,7 +370,7 @@ export function probeEnvironmentReady(deps: {
     versionSupported: boolean;
     kernelReady: boolean;
     isRosetta: boolean;
-    recreateFix: HealthItemFix;
+    recreateFix?: HealthItemFix;
     installIpykernelFix: HealthItemFix;
     // Omitted when python.allowUvPythonInstall is off; the Rosetta warn then has no fix button.
     installNativePythonFix?: HealthItemFix;
@@ -561,21 +567,20 @@ async function evaluateDedicated(ctx: {
     uvInstalled: boolean;
     allowUvPythonInstall: boolean;
 }): Promise<HealthItem> {
-    const createEnvFix =
-        (ctx.workspaceUri &&
-            buildCreateEnvFix({
-                workspaceUri: ctx.workspaceUri,
-                uvInstalled: ctx.uvInstalled,
-                allowUvPythonInstall: ctx.allowUvPythonInstall,
-                baseInterpreterPath: bestSupportedGlobalPython(ctx.interpreters)?.path,
-            })) ||
-        buildNewFolderFix();
+    const createEnvFix = ctx.workspaceUri
+        ? buildCreateEnvFix({
+              workspaceUri: ctx.workspaceUri,
+              uvInstalled: ctx.uvInstalled,
+              allowUvPythonInstall: ctx.allowUvPythonInstall,
+              baseInterpreterPath: bestSupportedGlobalPython(ctx.interpreters)?.path,
+          })
+        : undefined;
     return probeDedicatedEnvironment({
         workspaceOpen: ctx.workspaceUri !== undefined,
         interpreterDedicated: ctx.interp !== undefined && isDedicatedEnvironment(ctx.interp),
         anyDedicatedDiscovered: ctx.interpreters.some((i) => isDedicatedEnvironment(i)),
         createEnvFix,
-        newFolderFix: buildNewFolderFix(),
+        openFolderFix: buildOpenFolderFix(),
     });
 }
 
@@ -616,15 +621,15 @@ async function evaluateReady(
         isRosetta = os.arch() === 'arm64' && bundle.architecture === Architecture.x64;
     }
 
-    const recreateFix =
-        (ctx.workspaceUri &&
-            buildCreateEnvFix({
-                workspaceUri: ctx.workspaceUri,
-                uvInstalled: ctx.uvInstalled,
-                allowUvPythonInstall: ctx.allowUvPythonInstall,
-                baseInterpreterPath: bestSupportedGlobalPython(ctx.interpreters)?.path,
-            })) ||
-        buildNewFolderFix();
+    // With no folder open there is nothing to create an environment in, so the CTA is to open one.
+    const recreateFix = ctx.workspaceUri
+        ? buildCreateEnvFix({
+              workspaceUri: ctx.workspaceUri,
+              uvInstalled: ctx.uvInstalled,
+              allowUvPythonInstall: ctx.allowUvPythonInstall,
+              baseInterpreterPath: bestSupportedGlobalPython(ctx.interpreters)?.path,
+          })
+        : buildOpenFolderFix();
 
     return probeEnvironmentReady({
         resolvesAndRuns,

--- a/extensions/positron-python/src/test/positron/environmentHealth.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/environmentHealth.unit.test.ts
@@ -250,7 +250,7 @@ import { probeDedicatedEnvironment } from '../../client/positron/environmentHeal
 
 suite('Python Environment Health - dedicatedEnvironment (item 4)', () => {
     const createEnvFix = { commandId: 'python.createEnvironmentAndRegister', label: 'c', args: [{}] };
-    const newFolderFix = { commandId: 'positron.workbench.action.newFolderFromTemplate', label: 'n' };
+    const openFolderFix = { commandId: 'workbench.action.files.openFolder', label: 'o' };
 
     test('workspace open + dedicated interpreter => pass', () => {
         const item = probeDedicatedEnvironment({
@@ -258,7 +258,7 @@ suite('Python Environment Health - dedicatedEnvironment (item 4)', () => {
             interpreterDedicated: true,
             anyDedicatedDiscovered: true,
             createEnvFix,
-            newFolderFix,
+            openFolderFix,
         });
         assert.strictEqual(item.status, 'pass');
         assert.isUndefined(item.fix);
@@ -270,34 +270,46 @@ suite('Python Environment Health - dedicatedEnvironment (item 4)', () => {
             interpreterDedicated: false,
             anyDedicatedDiscovered: true,
             createEnvFix,
-            newFolderFix,
+            openFolderFix,
         });
         assert.strictEqual(item.status, 'fail');
         assert.strictEqual(item.fix, createEnvFix);
     });
 
-    test('no workspace + a dedicated env exists => warn + New Folder fix', () => {
+    test('workspace open + no creatable environment => fail without a fix', () => {
+        const item = probeDedicatedEnvironment({
+            workspaceOpen: true,
+            interpreterDedicated: false,
+            anyDedicatedDiscovered: true,
+            createEnvFix: undefined,
+            openFolderFix,
+        });
+        assert.strictEqual(item.status, 'fail');
+        assert.isUndefined(item.fix);
+    });
+
+    test('no workspace + a dedicated env exists => warn + Open Folder fix', () => {
         const item = probeDedicatedEnvironment({
             workspaceOpen: false,
             interpreterDedicated: false,
             anyDedicatedDiscovered: true,
             createEnvFix,
-            newFolderFix,
+            openFolderFix,
         });
         assert.strictEqual(item.status, 'warn');
-        assert.strictEqual(item.fix, newFolderFix);
+        assert.strictEqual(item.fix, openFolderFix);
     });
 
-    test('no workspace + no dedicated env => fail + New Folder fix', () => {
+    test('no workspace + no dedicated env => fail + Open Folder fix', () => {
         const item = probeDedicatedEnvironment({
             workspaceOpen: false,
             interpreterDedicated: false,
             anyDedicatedDiscovered: false,
             createEnvFix,
-            newFolderFix,
+            openFolderFix,
         });
         assert.strictEqual(item.status, 'fail');
-        assert.strictEqual(item.fix, newFolderFix);
+        assert.strictEqual(item.fix, openFolderFix);
     });
 });
 
@@ -345,6 +357,12 @@ suite('Python Environment Health - environmentReady (item 3)', () => {
     test('Rosetta warns without a fix when native-Python install is disabled', () => {
         const item = probeEnvironmentReady({ ...green, isRosetta: true, installNativePythonFix: undefined });
         assert.strictEqual(item.status, 'warn');
+        assert.isUndefined(item.fix);
+    });
+
+    test('broken env fails without a fix when no environment can be created', () => {
+        const item = probeEnvironmentReady({ ...green, resolvesAndRuns: false, recreateFix: undefined });
+        assert.strictEqual(item.status, 'fail');
         assert.isUndefined(item.fix);
     });
 


### PR DESCRIPTION
Fixes #15131. Changes most instances of the Python health check's fix being New Folder From Template to the fix being Open Folder instead.

Once a folder is open, the check re-runs against it and surfaces the real next step, such as creating an environment. 

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

@:interpreter

We can't check this by hand since we don't print the JSON anymore, but we'll QA the upcoming UI later.