### PR TITLE
Make the new provider modal the default

### DIFF
--- a/src/vs/workbench/contrib/positronAssistant/browser/configureLLMProvidersModal.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/configureLLMProvidersModal.tsx
@@ -28,16 +28,6 @@ const OPEN_PROVIDERS_JSON_COMMAND = 'workbench.action.positronAssistant.openAiPr
 
 type OnAction = (source: IPositronLanguageModelSource, config: IPositronLanguageModelConfig, action: string) => Promise<void>;
 
-/**
- * Hidden feature switch that selects the new "Configure LLM Providers" modal
- * over the legacy language model provider dialog.
- *
- * This key is intentionally NOT contributed to the configuration registry, so
- * it does not appear in the Settings editor. Set it manually in `settings.json`
- * to opt in to the in-progress modal. It defaults to `false` (legacy dialog).
- */
-export const NEW_PROVIDER_MODAL_KEY = 'assistant.newProviderModal';
-
 export const showConfigureLLMProvidersModal = (
 	sources: IPositronLanguageModelSource[],
 	onAction: OnAction,

--- a/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
@@ -10,7 +10,8 @@ import { IPositronPlotsService } from '../../../services/positronPlots/common/po
 import { ITerminalService } from '../../terminal/browser/terminal.js';
 import { IChatRequestData, IPositronAssistantService, IPositronAssistantConfigurationService, IPositronChatContext, IPositronLanguageModelConfig, IPositronLanguageModelSource, IShowLanguageModelConfigOptions } from '../common/interfaces/positronAssistantService.js';
 import { showLanguageModelModalDialog } from './languageModelModalDialog.js';
-import { NEW_PROVIDER_MODAL_KEY, showConfigureLLMProvidersModal } from './configureLLMProvidersModal.js';
+import { showConfigureLLMProvidersModal } from './configureLLMProvidersModal.js';
+import { NEW_PROVIDER_MODAL_KEY } from '../common/positronAIConfigurationKeys.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
@@ -328,8 +329,9 @@ export class PositronAssistantService extends Disposable implements IPositronAss
 				onClose();
 				return;
 			}
-			// Feature switch: the new "Configure LLM Providers" modal
-			const useNewModal = this._configurationService.getValue<boolean>(NEW_PROVIDER_MODAL_KEY) === true;
+			// The "Configure LLM Providers" modal is the default; the setting is
+			// the way back to the legacy dialog, so only an explicit false counts.
+			const useNewModal = this._configurationService.getValue<boolean>(NEW_PROVIDER_MODAL_KEY) !== false;
 			const showModal = useNewModal ? showConfigureLLMProvidersModal : showLanguageModelModalDialog;
 			showModal(
 				sources,

--- a/src/vs/workbench/contrib/positronAssistant/common/positronAIConfiguration.ts
+++ b/src/vs/workbench/contrib/positronAssistant/common/positronAIConfiguration.ts
@@ -36,9 +36,9 @@ configurationRegistry.registerConfiguration({
 		[NEW_PROVIDER_MODAL_KEY]: {
 			type: 'boolean',
 			default: true,
-			description: localize(
+			markdownDescription: localize(
 				'positron.assistant.newProviderModal',
-				"Use the Configure LLM Providers modal to connect to language model providers. It groups providers by connection state, so you can see which are connected and which need attention without selecting each one. When disabled, the Configure Providers command opens the previous dialog."
+				"Use the Configure LLM Providers modal to connect to language model providers. It groups providers by connection state, so you can see which are connected and which need attention without selecting each one. When disabled, the _Configure Language Model Providers_ command opens the previous dialog."
 			),
 			scope: ConfigurationScope.WINDOW,
 		}

--- a/src/vs/workbench/contrib/positronAssistant/common/positronAIConfiguration.ts
+++ b/src/vs/workbench/contrib/positronAssistant/common/positronAIConfiguration.ts
@@ -10,7 +10,7 @@ import {
 	IConfigurationRegistry,
 } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
-import { AI_ENABLED_KEY } from './positronAIConfigurationKeys.js';
+import { AI_ENABLED_KEY, NEW_PROVIDER_MODAL_KEY } from './positronAIConfigurationKeys.js';
 
 // Re-exported so existing importers do not have to move. New callers outside
 // the workbench (e.g. the extension host) should import the keys module
@@ -30,6 +30,15 @@ configurationRegistry.registerConfiguration({
 			description: localize(
 				'positron.ai.enabled',
 				"Enable Positron's AI features, such as Posit Assistant, Posit AI Next Edit Suggestions and AI features in notebooks and the console. When disabled, all of Positron's AI features are turned off."
+			),
+			scope: ConfigurationScope.WINDOW,
+		},
+		[NEW_PROVIDER_MODAL_KEY]: {
+			type: 'boolean',
+			default: true,
+			description: localize(
+				'positron.assistant.newProviderModal',
+				"Use the Configure LLM Providers modal to connect to language model providers. It groups providers by connection state, so you can see which are connected and which need attention without selecting each one. When disabled, the Configure Providers command opens the previous dialog."
 			),
 			scope: ConfigurationScope.WINDOW,
 		}

--- a/src/vs/workbench/contrib/positronAssistant/common/positronAIConfigurationKeys.ts
+++ b/src/vs/workbench/contrib/positronAssistant/common/positronAIConfigurationKeys.ts
@@ -4,6 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 /**
+ * Setting keys for Positron-owned AI configuration.
+ *
+ * This module is deliberately free of imports and side effects so processes
+ * without a Settings UI - notably the extension host - can read a key without
+ * pulling in the configuration registry or re-registering the `ai` node. The
+ * registrations themselves live in `positronAIConfiguration.ts`.
+ */
+
+/**
  * Main switch for Positron's AI features. When off, all of Positron's AI
  * features (Next Edit Suggestions, notebook AI, console Fix/Explain, etc.) are
  * turned off.
@@ -13,10 +22,16 @@
  * `ai.enabled`, so when it's off the assistant is off regardless of
  * `assistant.enabled`. This setting seeds the `ai.*` namespace for
  * Positron-owned AI configuration.
- *
- * This module is deliberately free of imports and side effects so processes
- * without a Settings UI - notably the extension host - can read the key without
- * pulling in the configuration registry or re-registering the `ai` node. The
- * registration itself lives in `positronAIConfiguration.ts`.
  */
 export const AI_ENABLED_KEY = 'ai.enabled';
+
+/**
+ * Chooses which dialog the Configure Providers command opens. On, it opens the
+ * Configure LLM Providers modal. Off, it opens the older Configure Language
+ * Model Providers dialog.
+ *
+ * Defaults to on. The older dialog stays available as a way back: if something
+ * in the current modal does not work for a user, they can turn this off and
+ * carry on.
+ */
+export const NEW_PROVIDER_MODAL_KEY = 'assistant.newProviderModal';

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/positronAssistantService.vitest.ts
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/positronAssistantService.vitest.ts
@@ -34,7 +34,6 @@ vi.mock('../../browser/languageModelModalDialog.js', () => ({ showLanguageModelM
 
 const { mockShowNewModal } = vi.hoisted(() => ({ mockShowNewModal: vi.fn() }));
 vi.mock('../../browser/configureLLMProvidersModal.js', () => ({
-	NEW_PROVIDER_MODAL_KEY: 'assistant.newProviderModal',
 	showConfigureLLMProvidersModal: mockShowNewModal,
 }));
 
@@ -188,15 +187,15 @@ describe('PositronAssistantService showLanguageModelModalDialog', () => {
 
 		// Nothing shown yet: whenInitialized has not resolved.
 		expect(prompt).not.toHaveBeenCalled();
-		expect(mockShowDialog).not.toHaveBeenCalled();
+		expect(mockShowNewModal).not.toHaveBeenCalled();
 
 		whenInitializedDeferred.complete();
 		await whenInitializedDeferred.p;
 		// Allow the .then() continuation to run.
 		await Promise.resolve();
 
-		expect(mockShowDialog).toHaveBeenCalledTimes(1);
-		expect(mockShowDialog.mock.calls[0][0]).toBe(sources);
+		expect(mockShowNewModal).toHaveBeenCalledTimes(1);
+		expect(mockShowNewModal.mock.calls[0][0]).toBe(sources);
 	});
 
 	it('invokes onClose (never hangs) when initialization ends in error status', async () => {
@@ -213,7 +212,7 @@ describe('PositronAssistantService showLanguageModelModalDialog', () => {
 
 		expect(prompt).toHaveBeenCalledTimes(1);
 		expect(onClose).toHaveBeenCalledTimes(1);
-		expect(mockShowDialog).not.toHaveBeenCalled();
+		expect(mockShowNewModal).not.toHaveBeenCalled();
 	});
 
 	it('notifies and closes without rendering when no providers are enabled', async () => {
@@ -230,7 +229,7 @@ describe('PositronAssistantService showLanguageModelModalDialog', () => {
 		expect(prompt.mock.calls[0][0]).toBe(Severity.Info);
 		expect(prompt.mock.calls[0][1]).toBe('No language model providers are enabled. Enable at least one provider in providers.json.');
 		expect(onClose).toHaveBeenCalledTimes(1);
-		expect(mockShowDialog).not.toHaveBeenCalled();
+		expect(mockShowNewModal).not.toHaveBeenCalled();
 	});
 
 	it('the no-providers prompt opens providers.json in an editor', async () => {
@@ -249,7 +248,7 @@ describe('PositronAssistantService showLanguageModelModalDialog', () => {
 		}));
 	});
 
-	it('renders the dialog with the registered sources when providers are enabled', async () => {
+	it('renders the new provider modal with the registered sources when providers are enabled', async () => {
 		const sources = [makeSource('prov-a')];
 		getRegisteredSources.mockReturnValue(sources);
 		const onAction = vi.fn();
@@ -261,24 +260,24 @@ describe('PositronAssistantService showLanguageModelModalDialog', () => {
 		await Promise.resolve();
 
 		expect(prompt).not.toHaveBeenCalled();
-		expect(mockShowDialog).toHaveBeenCalledTimes(1);
-		expect(mockShowDialog.mock.calls[0][0]).toBe(sources);
-		expect(mockShowNewModal).not.toHaveBeenCalled();
+		expect(mockShowNewModal).toHaveBeenCalledTimes(1);
+		expect(mockShowNewModal.mock.calls[0][0]).toBe(sources);
+		expect(mockShowDialog).not.toHaveBeenCalled();
 	});
 
-	it('renders the new provider modal when the feature switch is enabled', async () => {
+	it('renders the legacy dialog when the new provider modal is turned off', async () => {
 		const sources = [makeSource('prov-a')];
 		getRegisteredSources.mockReturnValue(sources);
-		(ctx.get(IConfigurationService) as TestConfigurationService).setUserConfiguration('assistant.newProviderModal', true);
+		(ctx.get(IConfigurationService) as TestConfigurationService).setUserConfiguration('assistant.newProviderModal', false);
 
 		service.showLanguageModelModalDialog(vi.fn(), vi.fn());
 		whenInitializedDeferred.complete();
 		await whenInitializedDeferred.p;
 		await Promise.resolve();
 
-		expect(mockShowNewModal).toHaveBeenCalledTimes(1);
-		expect(mockShowNewModal.mock.calls[0][0]).toBe(sources);
-		expect(mockShowDialog).not.toHaveBeenCalled();
+		expect(mockShowDialog).toHaveBeenCalledTimes(1);
+		expect(mockShowDialog.mock.calls[0][0]).toBe(sources);
+		expect(mockShowNewModal).not.toHaveBeenCalled();
 	});
 });
 

--- a/test/e2e/pages/modelProviderModal.ts
+++ b/test/e2e/pages/modelProviderModal.ts
@@ -21,7 +21,8 @@ import {
 	completeOAuthDeviceCodeLogin,
 } from './modelProviderShared.js';
 
-// New "Configure LLM Providers" modal (behind assistant.newProviderModal).
+// The "Configure LLM Providers" modal, which the Configure Providers command
+// opens by default (`assistant.newProviderModal`).
 // Same public surface as ModelProviderAuth so the sign-in test body is drop-in.
 // The testid sits on a zero-size layout wrapper (its child dialog container is
 // position:absolute, so the wrapper collapses and Playwright reports it hidden).
@@ -45,10 +46,11 @@ const REMOVE_BUTTON = `${MODAL} button.positron-button:has-text("Remove")`;
 const CLOSE_BUTTON = `${MODAL} button.positron-button:has-text("Close")`;
 
 /**
- * Page object for the new "Configure LLM Providers" modal. Exposes the same
+ * Page object for the "Configure LLM Providers" modal. Exposes the same
  * loginModelProvider / logoutModelProvider surface as ModelProviderAuth, so the
- * legacy sign-in test body can be reused unchanged. The caller is responsible
- * for enabling `assistant.newProviderModal` before use.
+ * legacy sign-in test body can be reused unchanged. This modal is what the
+ * Configure Providers command opens unless a suite pins
+ * `assistant.newProviderModal` to false.
  */
 export class ModelProviderModal {
 	private hotKeys: HotKeys;

--- a/test/e2e/release-screenshots/notebooks/positron-notebook.screenshot.ts
+++ b/test/e2e/release-screenshots/notebooks/positron-notebook.screenshot.ts
@@ -16,6 +16,10 @@ const ANNOTATION_COLOR = '#dc2626';
 // these screenshots run against, so no settings override is needed here.
 test.use({
 	suiteId: __filename,
+	// The assistant screenshot signs in through the legacy provider dialog
+	// (pages/positronAssistant.ts), which is no longer the default. Remove the
+	// pin when that page object is ported to the new modal.
+	extraSettings: { 'assistant.newProviderModal': false },
 });
 
 test.afterEach(async ({ page, hotKeys, cleanup }) => {

--- a/test/e2e/tests/assistant-eval/hallucination/eval-hallucination.test.ts
+++ b/test/e2e/tests/assistant-eval/hallucination/eval-hallucination.test.ts
@@ -8,7 +8,13 @@ import { evalTests, tags } from '../_helpers/eval-runner';
 import { rForestedHallucination } from './r-forested-hallucination';
 import { pythonNoExecutionHallucination } from './python-no-execution-hallucination';
 
-test.use({ suiteId: __filename });
+test.use({
+	suiteId: __filename,
+	// The eval runner signs in through the legacy provider dialog
+	// (pages/positronAssistant.ts), which is no longer the default. Remove the
+	// pin when that page object is ported to the new modal.
+	extraSettings: { 'assistant.newProviderModal': false },
+});
 
 test.describe('Assistant Eval: Hallucination', { tag: [tags.ASSISTANT_EVAL] }, () => {
 	evalTests(test, [

--- a/test/e2e/tests/assistant-eval/notebooks/eval-notebooks.test.ts
+++ b/test/e2e/tests/assistant-eval/notebooks/eval-notebooks.test.ts
@@ -11,7 +11,13 @@ import { rNotebookRunCells } from './r-notebook-run-cells';
 import { rNotebookCreate } from './r-notebook-create';
 import { pyNotebookGetCells } from './py-notebook-get-cells';
 
-test.use({ suiteId: __filename });
+test.use({
+	suiteId: __filename,
+	// The eval runner signs in through the legacy provider dialog
+	// (pages/positronAssistant.ts), which is no longer the default. Remove the
+	// pin when that page object is ported to the new modal.
+	extraSettings: { 'assistant.newProviderModal': false },
+});
 
 test.describe('Assistant Eval: Notebooks', { tag: [tags.ASSISTANT_EVAL, tags.POSITRON_NOTEBOOKS] }, () => {
 	evalTests(test, [

--- a/test/e2e/tests/assistant-eval/tools/eval-tools.test.ts
+++ b/test/e2e/tests/assistant-eval/tools/eval-tools.test.ts
@@ -8,7 +8,13 @@ import { evalTests, tags } from '../_helpers/eval-runner';
 import { pythonEditFile } from './python-edit-file';
 import { pythonTableSummary } from './python-table-summary';
 
-test.use({ suiteId: __filename });
+test.use({
+	suiteId: __filename,
+	// The eval runner signs in through the legacy provider dialog
+	// (pages/positronAssistant.ts), which is no longer the default. Remove the
+	// pin when that page object is ported to the new modal.
+	extraSettings: { 'assistant.newProviderModal': false },
+});
 
 test.describe('Assistant Eval: Tools', { tag: [tags.ASSISTANT_EVAL] }, () => {
 	evalTests(test, [

--- a/test/e2e/tests/assistant/positron-assistant-tool-calls.test.ts
+++ b/test/e2e/tests/assistant/positron-assistant-tool-calls.test.ts
@@ -6,7 +6,11 @@
 import { test, expect, tags } from '../_test.setup';
 
 test.use({
-	suiteId: __filename
+	suiteId: __filename,
+	// Signs in through the legacy provider dialog (pages/positronAssistant.ts),
+	// which is no longer the default. Remove the pin when that page object is
+	// ported to the new modal.
+	extraSettings: { 'assistant.newProviderModal': false },
 });
 
 /**

--- a/test/e2e/tests/assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/assistant/positron-assistant.test.ts
@@ -7,7 +7,11 @@ import { test, expect, tags } from '../_test.setup';
 import { join } from 'path';
 
 test.use({
-	suiteId: __filename
+	suiteId: __filename,
+	// Signs in through the legacy provider dialog (pages/positronAssistant.ts),
+	// which is no longer the default. Remove the pin when that page object is
+	// ported to the new modal.
+	extraSettings: { 'assistant.newProviderModal': false },
 });
 
 /**

--- a/test/e2e/tests/notebooks-positron/notebook-assistant-features.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-assistant-features.test.ts
@@ -7,7 +7,11 @@ import { expect, tags } from '../_test.setup';
 import { test } from './_test.setup.js';
 
 test.use({
-	suiteId: __filename
+	suiteId: __filename,
+	// Signs in through the legacy provider dialog (pages/positronAssistant.ts),
+	// which is no longer the default. Remove the pin when that page object is
+	// ported to the new modal.
+	extraSettings: { 'assistant.newProviderModal': false },
 });
 
 test.describe('Notebook Assistant: Feature Toggle', {

--- a/test/e2e/tests/posit-assistant/posit-assistant-mcp.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant-mcp.test.ts
@@ -9,7 +9,11 @@ import { test, tags } from '../_test.setup';
 import { ModelProvider } from '../../pages/positronAssistant';
 
 test.use({
-	suiteId: __filename
+	suiteId: __filename,
+	// Signs in through the legacy provider dialog (pages/positronAssistant.ts),
+	// which is no longer the default. Remove the pin when that page object is
+	// ported to the new modal.
+	extraSettings: { 'assistant.newProviderModal': false },
 });
 
 const POSIT_ASSISTANT_PROVIDERS: ModelProvider[] = ['anthropic-api'];

--- a/test/e2e/tests/posit-assistant/posit-assistant.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant.test.ts
@@ -7,7 +7,11 @@ import { test, expect, tags } from '../_test.setup';
 import { ModelProvider } from '../../pages/positronAssistant';
 
 test.use({
-	suiteId: __filename
+	suiteId: __filename,
+	// Signs in through the legacy provider dialog (pages/positronAssistant.ts),
+	// which is no longer the default. Remove the pin when that page object is
+	// ported to the new modal.
+	extraSettings: { 'assistant.newProviderModal': false },
 });
 
 const POSIT_ASSISTANT_PROVIDERS: ModelProvider[] = ['anthropic-api'];

--- a/test/e2e/tests/remote-ssh/remote-ssh-assistant.test.ts
+++ b/test/e2e/tests/remote-ssh/remote-ssh-assistant.test.ts
@@ -7,7 +7,11 @@ import { test, expect, tags } from '../_test.setup';
 import { connectToRemoteHost, sshKeyscan } from './connect';
 
 test.use({
-	suiteId: __filename
+	suiteId: __filename,
+	// This suite drives the legacy provider dialog, which is no longer the
+	// default, so pin it. Remove the pin when this suite is ported to the new
+	// modal (posit-dev/positron#15537).
+	extraSettings: { 'assistant.newProviderModal': false },
 });
 
 // Only the remote-ssh tag: the lane that runs this suite is the one that

--- a/test/e2e/tests/workbench/posit-assistant/posit-assistant-signin.test.ts
+++ b/test/e2e/tests/workbench/posit-assistant/posit-assistant-signin.test.ts
@@ -25,7 +25,11 @@ import { expect, test, tags } from '../../_test.setup';
 import { ModelProvider } from '../../../pages/modelProviderAuth';
 
 test.use({
-	suiteId: __filename
+	suiteId: __filename,
+	// This suite drives the legacy provider dialog, which is no longer the
+	// default, so pin it. Remove the pin when the Workbench suite is ported to
+	// the new modal (posit-dev/positron#15537).
+	extraSettings: { 'assistant.newProviderModal': false },
 });
 
 const SIGNIN_PROVIDERS: ModelProvider[] = ['anthropic-api', 'openai-api', 'posit-ai'];


### PR DESCRIPTION
Fixes #13425, fixes #14818

This PR turns the new Configure LLM Providers modal on by default.

I'm keeping the old modal around in case we've missed any gaps with the new modal. We can remove it once we've got the UX for the new modal all ironed out.

`assistant.newProviderModal` is now a contributed setting in the Settings editor that defaults to `true`.  The `assistant.newProviderModal`  setting is the way back to the old modal if something in the new modal does not work for someone. A user needs to explicitly set `assistant.newProviderModal` to `false` to opt out of the new modal. 

**What this PR does not do:** the Workbench and remote SSH sign-in suites still drive the legacy dialog. This PR pins those tests to the old modal for now. We've got #15537 that tracks the work of porting those e2e tests over.

The same pin turned out to be needed in seven more suites. `pages/positronAssistant.ts` also signs in through the old dialog -- it opens Configure Providers with the hotkey and then uses that dialog's own selectors -- so every suite calling `assistant.loginModelProvider` needs it: the assistant and posit-assistant suites, the notebook assistant features, the notebook release screenshot, and the three assistant-eval suites through their shared runner. Nine suites are pinned in total, and the pins all come out when that page object is ported.

The new modal's own suite of e2e tests also still pins the setting on rather than leaning on the new default; that pin should come out when the legacy modal is deleted.

### Screenshots

<img width="2374" height="1676" alt="settings-editor-new-provider-modal" src="https://github.com/user-attachments/assets/b8739685-2162-410b-ae56-0daa81a8c6dc" />

https://github.com/user-attachments/assets/2e63eb4a-a75c-4313-ad3c-a4471df9e929

### Release Notes

<!--
Optionally, replace `N/A` with text to be included in the next release notes.
The `N/A` bullets are ignored. If you refer to one or more Positron issues,
these issues are used to collect information about the feature or bugfix, such
as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Configuring language model providers now opens the new Configure LLM Providers modal, which groups providers by connection state. Set `assistant.newProviderModal` to `false` to go back to the previous dialog.

#### Bug Fixes

- N/A

### Validation Steps

@:assistant @:workbench @:remote-ssh @:positron-notebooks

The Workbench and remote SSH tags are here because this PR writes a provider setting in those suites for the first time. The Workbench one reads settings from inside the container rather than the host, so its pin travels through `dockerSettingsOverrides`, and that path has not carried this setting before.

SETUP: use a profile with no `assistant.newProviderModal` in `settings.json`, so you are testing the default and not a leftover value.

1. Run **Authentication: Configure Language Model Providers** (or the Accounts menu item, or Cmd+J R). The **Configure LLM Providers** modal opens, with providers grouped under **Connected Providers** / **Needs Attention** / **Model Providers**. Close it.
2. Open the Settings editor and search for `new provider modal`. **Assistant: New Provider Modal** is listed and **checked**.
3. Uncheck it. Do not reload the window.
4. Run Configure Providers again. The previous **Configure Language Model Providers** dialog opens instead, with the row of provider buttons.
5. Check the setting again, and run Configure Providers once more. The Configure LLM Providers modal is back.
6. Confirm the same switch works from `settings.json`: set `"assistant.newProviderModal": false`, save, and run Configure Providers. The previous dialog opens.

