### PR TITLE
Clear webview view badge when set to undefined

### DIFF
--- a/src/vs/workbench/contrib/webviewView/browser/webviewViewPane.ts
+++ b/src/vs/workbench/contrib/webviewView/browser/webviewViewPane.ts
@@ -253,6 +253,8 @@ export class WebviewViewPane extends ViewPane {
 				priority: 150
 			};
 			this.activity.value = this.activityService.showViewActivity(this.id, activity);
+		} else {
+			this.activity.clear();
 		}
 	}
 


### PR DESCRIPTION
`WebviewViewPane.updateBadge` registers the view activity (the numeric badge on the view container) when a badge is assigned, but never disposes it when the badge is set back to `undefined`. The badge therefore stays visible on the activity bar after the extension has cleared it.

The tree view badge setter in `src/vs/workbench/browser/parts/views/treeView.ts` handles this correctly with an `else { this._activity.clear(); }` branch; the webview view pane is simply missing the equivalent.

Discovered while implementing a needs-input badge in Posit Assistant (posit-dev/assistant#2094): extension-side logging confirmed `webviewView.badge = undefined` was assigned, yet the badge remained visible.

## Notes

- The same omission exists upstream in microsoft/vscode's `webviewViewPane.ts`; which I upstreamed at https://github.com/microsoft/vscode/pull/331019
- Manual verification: assign a badge to a webview view via `webviewView.badge = { value: 1, tooltip: '...' }`, then set `webviewView.badge = undefined` — before this change the badge persists; after, it clears.