### PR TITLE
Quarto virtual notebook: replace only the cells that changed

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoVirtualNotebookService.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoVirtualNotebookService.ts
@@ -7,14 +7,15 @@ import { localize } from '../../../../nls.js';
 import { URI } from '../../../../base/common/uri.js';
 import { VSBuffer } from '../../../../base/common/buffer.js';
 import { Schemas } from '../../../../base/common/network.js';
+import { basename } from '../../../../base/common/resources.js';
 import { Disposable, DisposableMap } from '../../../../base/common/lifecycle.js';
-import { ITextModel } from '../../../../editor/common/model.js';
+import { EndOfLinePreference, ITextModel } from '../../../../editor/common/model.js';
 import { IModelService } from '../../../../editor/common/services/model.js';
 import { ILanguageService } from '../../../../editor/common/languages/language.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ExtensionIdentifier } from '../../../../platform/extensions/common/extensions.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
-import { ILogService } from '../../../../platform/log/common/log.js';
+import { ILogService, LogLevel } from '../../../../platform/log/common/log.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
 import { NotebookTextModel } from '../../notebook/common/model/notebookTextModel.js';
 import { CellEditType, CellKind, ICellDto2, NotebookData } from '../../notebook/common/notebookCommon.js';
@@ -25,8 +26,9 @@ import {
 	isQuartoOrRmdFile,
 	usingNativeEmbeddedFeatures,
 } from '../common/positronQuartoConfig.js';
-import { IQuartoDocumentModel } from '../common/quartoTypes.js';
+import { IQuartoDocumentModel, QuartoCodeCell } from '../common/quartoTypes.js';
 import { QUARTO_CELLS_SCHEME, QUARTO_CELLS_VIEW_TYPE } from '../common/quartoVirtualNotebookTypes.js';
+import { diffCellRuns, ICellRun, ICellSplice } from '../common/quartoCellDiff.js';
 import { IQuartoDocumentModelService } from './quartoDocumentModelService.js';
 
 /**
@@ -195,7 +197,7 @@ class QuartoVirtualNotebook extends Disposable {
 		}
 
 		this._notebook = notebook;
-		this._rebuildCells();
+		this._sync();
 		this._logService.debug(
 			`[QuartoVirtualNotebook] Created ${this.notebookUri.toString()} with ${this._cells.length} cells`);
 	}
@@ -208,13 +210,24 @@ class QuartoVirtualNotebook extends Disposable {
 		this._sync();
 	}
 
+	/** How a cell looks to the diff. A disposed model has no code, so it matches nothing. */
+	private static _runOf(cell: IQuartoVirtualCell): ICellRun {
+		return {
+			language: cell.language,
+			// EndOfLinePreference.LF: the model's own EOL is platform dependent (a
+			// single-line model created on Windows defaults to CRLF), but
+			// getCellCode always joins with LF. Reading with the model's own EOL
+			// here would compare CRLF against LF forever for such a cell, so
+			// sameCell would never match it and every edit would replace it.
+			code: cell.textModel.isDisposed() ? undefined : cell.textModel.getValue(EndOfLinePreference.LF),
+		};
+	}
+
 	/**
-	 * Reconcile the cells with the source document. Cells are matched by
-	 * position, so a document whose chunks kept their shape gets its cell text
-	 * edited in place and LSP clients see a cheap didChange rather than
-	 * close/open churn. Anything else rebuilds: matching cells across a
-	 * structural change is ambiguous, and a wrong guess silently misplaces every
-	 * position mapped through the cell.
+	 * Reconcile the cells with the source document, replacing only the cells
+	 * whose position or language changed. The rest keep their handle, URI, and
+	 * text model, so a language server sees a didChange rather than a close and
+	 * reopen of every cell.
 	 */
 	private _sync(): void {
 		if (!this._notebook || this._store.isDisposed) {
@@ -222,20 +235,37 @@ class QuartoVirtualNotebook extends Disposable {
 		}
 
 		const sourceCells = this._documentModel.cells;
-		const structureChanged =
-			sourceCells.length !== this._cells.length ||
-			sourceCells.some((sourceCell, index) => sourceCell.language !== this._cells[index].language) ||
-			this._cells.some(cell => cell.textModel.isDisposed());
+		const codes = sourceCells.map(cell => this._documentModel.getCellCode(cell));
 
-		if (structureChanged) {
-			this._rebuildCells();
-			return;
+		// An unchanged count and language at every index means position alone
+		// identifies each cell, so any content difference is an edit rather than a
+		// different chunk. diffCellRuns matches on (language, code) with no notion
+		// of position, and would read that edit as a remove plus an insert,
+		// recreating the text model on every keystroke. Let the refresh below take
+		// the new text across in place instead.
+		const sameShape = sourceCells.length === this._cells.length
+			&& this._cells.every(cell => !cell.textModel.isDisposed())
+			&& sourceCells.every((sourceCell, index) => sourceCell.language === this._cells[index].language);
+
+		if (!sameShape) {
+			const runs: ICellRun[] = sourceCells.map((cell, index) => ({
+				language: cell.language,
+				code: codes[index],
+			}));
+
+			const splice = diffCellRuns(this._cells.map(QuartoVirtualNotebook._runOf), runs);
+			if (splice.removeCount > 0 || splice.insertCount > 0) {
+				this._spliceCells(this._notebook, splice, sourceCells, codes);
+			}
 		}
 
+		// Spans go stale whenever a chunk moves, which happens whenever anything
+		// above it changes size, so every surviving cell is refreshed here. Content
+		// comes across too, for the cells the splice did not rewrite.
 		this._cells = this._cells.map((cell, index) => {
 			const sourceCell = sourceCells[index];
-			const code = this._documentModel.getCellCode(sourceCell);
-			if (cell.textModel.getValue() !== code) {
+			const code = codes[index];
+			if (!cell.textModel.isDisposed() && cell.textModel.getValue(EndOfLinePreference.LF) !== code) {
 				cell.textModel.applyEdits([{ range: cell.textModel.getFullModelRange(), text: code }]);
 			}
 			return {
@@ -247,55 +277,102 @@ class QuartoVirtualNotebook extends Disposable {
 	}
 
 	/**
-	 * Replace every cell. Used to populate the notebook and whenever cells are
-	 * added or removed, where matching old cells to new ones is ambiguous.
+	 * Apply one contiguous replacement to the notebook and to `_cells`. The
+	 * notebook comes from the caller, which has already narrowed it, rather
+	 * than being re-read from `this._notebook`: `_sync` cannot survive this
+	 * returning without splicing, since it assumes afterwards that `this._cells`
+	 * and `sourceCells` line up index for index.
 	 */
-	private _rebuildCells(): void {
-		const notebook = this._notebook;
-		if (!notebook || this._store.isDisposed) {
-			return;
+	private _spliceCells(
+		notebook: NotebookTextModel,
+		splice: ICellSplice,
+		sourceCells: readonly QuartoCodeCell[],
+		codes: readonly string[]
+	): void {
+		const dtos: ICellDto2[] = [];
+		for (let index = splice.prefix; index < splice.prefix + splice.insertCount; index++) {
+			const sourceCell = sourceCells[index];
+			dtos.push({
+				source: codes[index],
+				language: sourceCell.language,
+				mime: undefined,
+				cellKind: CellKind.Code,
+				outputs: [],
+			});
 		}
 
-		const sourceCells = this._documentModel.cells;
-		const dtos: ICellDto2[] = sourceCells.map(cell => ({
-			source: this._documentModel.getCellCode(cell),
-			language: cell.language,
-			mime: undefined,
-			cellKind: CellKind.Code,
-			outputs: [],
-		}));
+		// Drop the outgoing cells from `_cells` before disposing their models, so
+		// that a listener woken by the dispose below, or by the notebook edit
+		// after it, can never read `_cells` back to a model that is already gone.
+		// `applyEdits` and `createModel` both fire their change events inline, so
+		// there is no later point at which removing them would still be in time.
+		const removed = this._cells.slice(splice.prefix, splice.prefix + splice.removeCount);
+		const kept = this._cells.length - splice.removeCount;
+		this._cells = [
+			...this._cells.slice(0, splice.prefix),
+			...this._cells.slice(splice.prefix + splice.removeCount),
+		];
 
-		// Drop the old cells before the edit, not after. A notebook edit fires
-		// its change events synchronously, so any window where `_cells` still
-		// points at models belonging to removed cells is a window in which a
-		// listener can read a model we are about to dispose.
-		this._disposeCells();
+		// The whole point of this class is how few cells it touches, and that is
+		// invisible from the editor: the only other evidence is didOpen/didClose
+		// traffic in a language server log, interleaved with the Quarto
+		// extension's own virtual document churn. One line per structural change
+		// says what was decided. Nothing is logged for a content-only edit, which
+		// takes the in-place path and would otherwise log on every keystroke.
+		//
+		// `=== LogLevel.Trace` rather than `<=`, because LogLevel.Off is 0 and
+		// Trace is 1, so `<=` is also true when logging is turned off.
+		if (this._logService.getLevel() === LogLevel.Trace) {
+			this._logService.trace(
+				`[QuartoVirtualNotebook] ${basename(this.sourceUri)}: spliced at ${splice.prefix}, ` +
+				`removed ${splice.removeCount}, inserted ${splice.insertCount}, kept ${kept}`);
+		}
+
+		for (const cell of removed) {
+			if (!cell.textModel.isDisposed()) {
+				cell.textModel.dispose();
+			}
+		}
 
 		notebook.applyEdits(
-			[{ editType: CellEditType.Replace, index: 0, count: notebook.cells.length, cells: dtos }],
+			[{
+				editType: CellEditType.Replace,
+				index: splice.prefix,
+				count: splice.removeCount,
+				cells: dtos,
+			}],
 			true, undefined, () => undefined, undefined, false
 		);
 
-		// Creating a text model at the cell URI is what binds it to the notebook
-		// cell: NotebookTextModel watches IModelService.onModelAdded and adopts
-		// any model whose URI parses as one of its cells. That binding is what
-		// makes the extension host see a real cell TextDocument.
-		this._cells = notebook.cells.map((notebookCell, index) => {
-			const sourceCell = sourceCells[index];
-			const textModel = this._modelService.createModel(
-				notebookCell.getValue(),
-				this._languageService.createById(sourceCell.language),
-				notebookCell.uri
-			);
-			return {
-				cellUri: notebookCell.uri,
-				handle: notebookCell.handle,
-				language: sourceCell.language,
-				codeStartLine: sourceCell.codeStartLine,
-				codeEndLine: sourceCell.codeEndLine,
-				textModel,
-			};
-		});
+		// Creating a model at the cell URI is what binds it: NotebookTextModel
+		// watches onModelAdded and adopts any model whose URI parses as one of its
+		// cells, which is what makes the extension host see a real TextDocument.
+		const inserted = notebook.cells
+			.slice(splice.prefix, splice.prefix + splice.insertCount)
+			.map((notebookCell, offset) => {
+				const sourceCell = sourceCells[splice.prefix + offset];
+				const textModel = this._modelService.createModel(
+					notebookCell.getValue(),
+					this._languageService.createById(sourceCell.language),
+					notebookCell.uri
+				);
+				return {
+					cellUri: notebookCell.uri,
+					handle: notebookCell.handle,
+					language: sourceCell.language,
+					codeStartLine: sourceCell.codeStartLine,
+					codeEndLine: sourceCell.codeEndLine,
+					textModel,
+				};
+			});
+
+		// The removed cells are already gone from `_cells` (see above), so the tail
+		// to keep starts at `splice.prefix`, not `splice.prefix + splice.removeCount`.
+		this._cells = [
+			...this._cells.slice(0, splice.prefix),
+			...inserted,
+			...this._cells.slice(splice.prefix),
+		];
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronQuarto/common/quartoCellDiff.ts
+++ b/src/vs/workbench/contrib/positronQuarto/common/quartoCellDiff.ts
@@ -1,0 +1,59 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export interface ICellRun {
+	readonly language: string;
+	/** The cell's code, or undefined when its text model is gone. */
+	readonly code: string | undefined;
+}
+
+export interface ICellSplice {
+	/** Leading cells that matched and are kept as they are. */
+	readonly prefix: number;
+	/** Old cells to remove, starting at `prefix`. */
+	readonly removeCount: number;
+	/** New cells to insert at `prefix`. */
+	readonly insertCount: number;
+}
+
+/** A cell with no text model matches nothing: it cannot be carried across a splice. */
+function sameCell(a: ICellRun, b: ICellRun): boolean {
+	return a.code !== undefined && b.code !== undefined
+		&& a.language === b.language
+		&& a.code === b.code;
+}
+
+/**
+ * The one contiguous region that has to be replaced to turn `oldCells` into
+ * `newCells`, found by matching in from both ends so that every cell outside it
+ * keeps its handle, its URI, and its extension host document.
+ *
+ * Matching cannot use the document model's cell id: that id embeds the index and
+ * a content hash, so it changes under exactly the edits we need to match across.
+ *
+ * A content edit and a structural change arriving in the same parse widen the
+ * region, which replaces more cells than necessary and is still correct.
+ */
+export function diffCellRuns(oldCells: readonly ICellRun[], newCells: readonly ICellRun[]): ICellSplice {
+	const maxCommon = Math.min(oldCells.length, newCells.length);
+
+	let prefix = 0;
+	while (prefix < maxCommon && sameCell(oldCells[prefix], newCells[prefix])) {
+		prefix++;
+	}
+
+	// Bounded by what the prefix left, so no cell is claimed by both ends.
+	let suffix = 0;
+	while (suffix < maxCommon - prefix
+		&& sameCell(oldCells[oldCells.length - 1 - suffix], newCells[newCells.length - 1 - suffix])) {
+		suffix++;
+	}
+
+	return {
+		prefix,
+		removeCount: oldCells.length - prefix - suffix,
+		insertCount: newCells.length - prefix - suffix,
+	};
+}

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoVirtualNotebookService.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoVirtualNotebookService.vitest.ts
@@ -496,22 +496,242 @@ describe('QuartoVirtualNotebookService', () => {
 		});
 	});
 
-	it('rebuilds cells when a chunk is added, without leaving disposed models behind', async () => {
+	it('keeps the existing cells when a chunk is appended', async () => {
 		const service = createService();
 		const source = createSourceModel(R_AND_PYTHON);
 		await service.whenReady(source.uri);
 
+		const before = service.getCells(source.uri).map(cell => ({
+			uri: cell.cellUri.toString(),
+			handle: cell.handle,
+			model: cell.textModel,
+		}));
+
 		source.setValue(R_AND_PYTHON + '```{r}\nmean(x)\n```\n');
 		service.ensureSynchronized(source.uri);
 
-		expect(service.getCells(source.uri).map(cell => ({
-			text: cell.textModel.getValue(),
-			disposed: cell.textModel.isDisposed(),
-		}))).toEqual([
-			{ text: 'x <- 1', disposed: false },
-			{ text: 'import os', disposed: false },
-			{ text: 'mean(x)', disposed: false },
-		]);
+		const after = service.getCells(source.uri);
+
+		expect({
+			text: after.map(cell => cell.textModel.getValue()),
+			// Surprise F from the spike: cell models were disposed while `_cells`
+			// still referenced them.
+			allAlive: after.every(cell => !cell.textModel.isDisposed()),
+			// The point of the splice: the two cells that did not change are the
+			// same cells afterwards, so no language server sees a close and reopen.
+			preserved: after.slice(0, 2).map((cell, index) => ({
+				uri: cell.cellUri.toString() === before[index].uri,
+				handle: cell.handle === before[index].handle,
+				model: cell.textModel === before[index].model,
+			})),
+		}).toEqual({
+			text: ['x <- 1', 'import os', 'mean(x)'],
+			allAlive: true,
+			preserved: [
+				{ uri: true, handle: true, model: true },
+				{ uri: true, handle: true, model: true },
+			],
+		});
+	});
+
+	it('keeps the surrounding cells when a chunk is inserted between two others', async () => {
+		const service = createService();
+		const source = createSourceModel(R_AND_PYTHON);
+		await service.whenReady(source.uri);
+
+		const before = service.getCells(source.uri).map(cell => cell.textModel);
+
+		// A new chunk between the existing R and Python ones. Everything below it
+		// shifts index, which is what a rebuild would take as licence to replace.
+		source.setValue([
+			'# Intro',
+			'',
+			'```{r}',
+			'x <- 1',
+			'```',
+			'',
+			'```{r}',
+			'mean(x)',
+			'```',
+			'',
+			'```{python}',
+			'import os',
+			'```',
+			'',
+		].join('\n'));
+		service.ensureSynchronized(source.uri);
+
+		const after = service.getCells(source.uri);
+
+		expect({
+			text: after.map(cell => cell.textModel.getValue()),
+			spans: after.map(cell => [cell.codeStartLine, cell.codeEndLine]),
+			firstPreserved: after[0].textModel === before[0],
+			// The Python cell moved from index 1 to index 2 and must still be the
+			// same document to the language server that has it open.
+			pythonPreserved: after[2].textModel === before[1],
+			pythonAlive: !before[1].isDisposed(),
+		}).toEqual({
+			text: ['x <- 1', 'mean(x)', 'import os'],
+			spans: [[4, 4], [8, 8], [12, 12]],
+			firstPreserved: true,
+			pythonPreserved: true,
+			pythonAlive: true,
+		});
+	});
+
+	it('disposes only the cell that was deleted', async () => {
+		const service = createService();
+		const source = createSourceModel(R_AND_PYTHON);
+		await service.whenReady(source.uri);
+
+		const before = service.getCells(source.uri).map(cell => cell.textModel);
+
+		// Drop the R chunk, keep the Python one.
+		source.setValue([
+			'# Intro',
+			'',
+			'```{python}',
+			'import os',
+			'```',
+			'',
+		].join('\n'));
+		service.ensureSynchronized(source.uri);
+
+		const after = service.getCells(source.uri);
+
+		expect({
+			text: after.map(cell => cell.textModel.getValue()),
+			survivorPreserved: after[0].textModel === before[1],
+			deletedDisposed: before[0].isDisposed(),
+			survivorAlive: !before[1].isDisposed(),
+		}).toEqual({
+			text: ['import os'],
+			survivorPreserved: true,
+			deletedDisposed: true,
+			survivorAlive: true,
+		});
+	});
+
+	it('replaces only the cell whose language changed', async () => {
+		// A cell's language is fixed when it is created, so this one genuinely has
+		// to close and reopen. The cell beside it does not.
+		const service = createService();
+		const source = createSourceModel(R_AND_PYTHON);
+		await service.whenReady(source.uri);
+
+		const before = service.getCells(source.uri).map(cell => cell.textModel);
+
+		source.setValue([
+			'# Intro',
+			'',
+			'```{python}',
+			'x = 1',
+			'```',
+			'',
+			'```{python}',
+			'import os',
+			'```',
+			'',
+		].join('\n'));
+		service.ensureSynchronized(source.uri);
+
+		const after = service.getCells(source.uri);
+
+		expect({
+			languages: after.map(cell => cell.language),
+			text: after.map(cell => cell.textModel.getValue()),
+			changedCellReplaced: after[0].textModel !== before[0],
+			oldModelDisposed: before[0].isDisposed(),
+			untouchedCellPreserved: after[1].textModel === before[1],
+		}).toEqual({
+			languages: ['python', 'python'],
+			text: ['x = 1', 'import os'],
+			changedCellReplaced: true,
+			oldModelDisposed: true,
+			untouchedCellPreserved: true,
+		});
+	});
+
+	it('does not expose a disposed cell while splicing', async () => {
+		// The real ModelService fires onModelAdded synchronously and inline from
+		// inside createModel, which _spliceCells calls to bind the inserted cell's
+		// model. That call lands in the window between disposing the outgoing
+		// cell's model and rebuilding `_cells`, so a listener woken by it, or by
+		// anything else it triggers, is the closest thing to that bug in a test:
+		// if `_cells` still held the disposed cell at that point, every getter
+		// below would hand it back.
+		const service = createService();
+		const source = createSourceModel(R_AND_PYTHON);
+		await service.whenReady(source.uri);
+
+		const modelService = ctx.instantiationService.get(IModelService);
+
+		// Capture what the handler saw rather than asserting inside it: an
+		// exception thrown inside an event handler can be swallowed by the
+		// emitter instead of failing the test. Accumulate into an array rather
+		// than a single variable: the regression this test guards has "several
+		// cells inserted in one splice" as its natural shape, and with a single
+		// variable a later successful invocation would overwrite an earlier
+		// failure, silently defeating the test the moment a splice inserts more
+		// than one cell. An empty array (the handler never ran at all) is itself
+		// a failure, which the assertion below checks for.
+		const observations: { cellAtLineFound: boolean; error: unknown }[] = [];
+		const subscription = modelService.onModelAdded(() => {
+			try {
+				// Touch every cell the service hands back from its public getters,
+				// the way a real consumer would. isDisposed() alone would not
+				// reproduce the bug: it is a flag read, not the assertion that
+				// throws "Model is disposed!" on a real access such as getValue().
+				for (const cell of service.getCells(source.uri)) {
+					cell.textModel.getValue();
+				}
+				for (const cell of service.getAllCells()) {
+					cell.textModel.getValue();
+				}
+				// Optional chaining would let a transient window where the cell is
+				// missing read as a pass, so a missing cell is its own recorded
+				// observation instead of a silent skip.
+				const atLine4 = service.getCellAtLine(source.uri, 4);
+				if (atLine4) {
+					atLine4.textModel.getValue();
+				}
+				observations.push({ cellAtLineFound: atLine4 !== undefined, error: undefined });
+			} catch (error) {
+				observations.push({ cellAtLineFound: false, error });
+			}
+		});
+		ctx.disposables.add(subscription);
+
+		// Changing the first chunk's language removes that cell and inserts a
+		// replacement while the second cell survives untouched, so the splice has
+		// both a removal and an insertion in the same pass. A pure append only
+		// inserts and would never reach createModel with a removal already having
+		// happened.
+		source.setValue([
+			'# Intro',
+			'',
+			'```{python}',
+			'x = 1',
+			'```',
+			'',
+			'```{python}',
+			'import os',
+			'```',
+			'',
+		].join('\n'));
+		service.ensureSynchronized(source.uri);
+
+		// A missing cell at line 4 during a transient window is not itself a
+		// failure (the surviving cell's span has not been refreshed yet, and the
+		// inserted cell is not spliced into `_cells` until every inserted model
+		// in the splice has been created), so `cellAtLineFound` is recorded for
+		// visibility rather than asserted true. What must hold for every
+		// invocation is that no access threw: a disposed cell still reachable
+		// through `_cells` is exactly what `error` would catch.
+		expect(observations.length > 0).toBe(true);
+		expect(observations.map(observation => observation.error)).toEqual(
+			observations.map(() => undefined));
 	});
 
 	it('tracks cell text and line spans through repeated churn', async () => {
@@ -618,4 +838,81 @@ describe('QuartoVirtualNotebookService', () => {
 
 		expect(service.getNotebookUri(source.uri)).toBeUndefined();
 	});
+
+	// 75 steps at a 100ms parse debounce is about 7.5s of wall clock, against
+	// the 60000ms timeout below: 8x headroom, so a loaded CI runner does not
+	// flake. Fixing that headroom by forcing a sync instead of awaiting the
+	// real debounce would defeat the point of the test (see the whenParsed
+	// comment below), so the step count and timeout are what moved instead.
+	it('matches a fresh parse after any sequence of chunk edits', async () => {
+		// A deterministic generator, so a failure is reproducible from the seed
+		// printed in the assertion below rather than being a one-off.
+		let seed = 20260816;
+		const random = (bound: number): number => {
+			seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+			return seed % bound;
+		};
+
+		const chunk = (language: string, code: string): string =>
+			['```{' + language + '}', code, '```', ''].join('\n');
+
+		// Chunks are drawn from a small pool on purpose: repeats are what make
+		// duplicate content, and duplicate content is what a hash-keyed match
+		// gets wrong.
+		const pool = [
+			chunk('r', 'a <- 1'),
+			chunk('r', 'b <- 2'),
+			chunk('r', 'a <- 1'),
+			chunk('python', 'import os'),
+			chunk('python', 'x = 1'),
+		];
+
+		const service = createService();
+		const source = createSourceModel('# Intro\n\n');
+		await service.whenReady(source.uri);
+
+		const chunks: string[] = [];
+		for (let step = 0; step < 75; step++) {
+			// Insert, delete, or replace at a random position, so the splice sees
+			// changes at both ends and in the middle rather than only appends.
+			// The insert branch draws its position from chunks.length + 1 rather
+			// than chunks.length, so an insert at the very end (append) is
+			// reachable; delete and replace draw from chunks.length since those
+			// need an existing index.
+			const action = chunks.length === 0 ? 0 : random(3);
+			const at = action === 0 ? random(chunks.length + 1) : random(chunks.length);
+			if (action === 0) {
+				chunks.splice(at, 0, pool[random(pool.length)]);
+			} else if (action === 1) {
+				chunks.splice(at, 1);
+			} else {
+				chunks[at] = pool[random(pool.length)];
+			}
+
+			source.setValue('# Intro\n\n' + chunks.join(''));
+			await documentModels.get(source.uri.toString())!.whenParsed();
+
+			const cells = service.getCells(source.uri);
+
+			// The document model is the reference: whatever the edits did, the
+			// cells have to agree with the same document model's own parsed
+			// state, the state the service consumed to update them.
+			const documentModel = documentModels.get(source.uri.toString())!;
+			expect({
+				step,
+				seed,
+				text: cells.map(cell => cell.textModel.getValue()),
+				spans: cells.map(cell => [cell.codeStartLine, cell.codeEndLine]),
+				languages: cells.map(cell => cell.language),
+				anyDisposed: cells.some(cell => cell.textModel.isDisposed()),
+			}).toEqual({
+				step,
+				seed,
+				text: documentModel.cells.map(cell => documentModel.getCellCode(cell)),
+				spans: documentModel.cells.map(cell => [cell.codeStartLine, cell.codeEndLine]),
+				languages: documentModel.cells.map(cell => cell.language),
+				anyDisposed: false,
+			});
+		}
+	}, 60000);
 });

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoVirtualNotebookService.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoVirtualNotebookService.vitest.ts
@@ -514,8 +514,7 @@ describe('QuartoVirtualNotebookService', () => {
 
 		expect({
 			text: after.map(cell => cell.textModel.getValue()),
-			// Surprise F from the spike: cell models were disposed while `_cells`
-			// still referenced them.
+			// Cell models can be disposed while `_cells` still reference them.
 			allAlive: after.every(cell => !cell.textModel.isDisposed()),
 			// The point of the splice: the two cells that did not change are the
 			// same cells afterwards, so no language server sees a close and reopen.

--- a/src/vs/workbench/contrib/positronQuarto/test/common/quartoCellDiff.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/common/quartoCellDiff.vitest.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { diffCellRuns, ICellRun } from '../../common/quartoCellDiff.js';
+
+describe('diffCellRuns', () => {
+	const r = (code: string): ICellRun => ({ language: 'r', code });
+
+	it('reports no work when the cells are unchanged', () => {
+		expect(diffCellRuns([r('a'), r('b')], [r('a'), r('b')]))
+			.toEqual({ prefix: 2, removeCount: 0, insertCount: 0 });
+	});
+
+	it('splices in a chunk inserted in the middle, keeping both sides', () => {
+		// The reviewer's case: inserting one chunk must not disturb the others.
+		expect(diffCellRuns(
+			[r('a'), r('b'), r('c')],
+			[r('a'), r('x'), r('b'), r('c')]
+		)).toEqual({ prefix: 1, removeCount: 0, insertCount: 1 });
+	});
+
+	it('splices out a chunk deleted from the middle', () => {
+		expect(diffCellRuns(
+			[r('a'), r('b'), r('c')],
+			[r('a'), r('c')]
+		)).toEqual({ prefix: 1, removeCount: 1, insertCount: 0 });
+	});
+
+	it('replaces only the cell whose language changed', () => {
+		expect(diffCellRuns(
+			[r('a'), r('b')],
+			[{ language: 'python', code: 'a' }, r('b')]
+		)).toEqual({ prefix: 0, removeCount: 1, insertCount: 1 });
+	});
+
+	it('does not confuse chunks that hold identical code', () => {
+		// Content is an equality test at a known position, not a lookup key, so
+		// duplicates cannot cross-match the way the document model's hash map does.
+		expect(diffCellRuns([r('a'), r('a')], [r('a')]))
+			.toEqual({ prefix: 1, removeCount: 1, insertCount: 0 });
+		expect(diffCellRuns([r('a')], [r('a'), r('a')]))
+			.toEqual({ prefix: 1, removeCount: 0, insertCount: 1 });
+	});
+
+	it('treats a cell with no text model as matching nothing', () => {
+		// A disposed model cannot be reused, so that one cell is replaced rather
+		// than the whole document being rebuilt around it.
+		expect(diffCellRuns(
+			[r('a'), { language: 'r', code: undefined }, r('c')],
+			[r('a'), r('b'), r('c')]
+		)).toEqual({ prefix: 1, removeCount: 1, insertCount: 1 });
+	});
+
+	it('handles the empty document at both ends', () => {
+		expect(diffCellRuns([], [r('a')])).toEqual({ prefix: 0, removeCount: 0, insertCount: 1 });
+		expect(diffCellRuns([r('a')], [])).toEqual({ prefix: 0, removeCount: 1, insertCount: 0 });
+		expect(diffCellRuns([], [])).toEqual({ prefix: 0, removeCount: 0, insertCount: 0 });
+	});
+});


### PR DESCRIPTION
Related to:

- #14540
- #15415 and particularly https://github.com/posit-dev/positron/pull/15415#discussion_r3752702171


Positron core keeps a hidden in-memory notebook for each open Quarto document, with one cell text model per code chunk. Until now, any structural change to a document threw away every cell and rebuilt it. Insert one chunk into a 45 chunk document, and every language server that watches those cells saw 45 closes and 46 opens. Each one then re-indexed what it had just dropped.

This PR makes the sync incremental. The diff matches old cells to new ones from both ends of the document. It compares language and code, and replaces only the changed run. Every other cell keeps its handle, its URI, and its extension host document. An inserted chunk now creates one cell instead of N.

A few things about the approach you might want to know before you read the diff:

- **Cell IDs cannot do this job, although it might look like they can.** `QuartoCodeCell.id` is built as `"{index}-{hash8}-{label}"`, so it changes when the content changes, and when anything above it is inserted. That is exactly the set of edits the match has to survive. A match on the ID marks every cell below an insertion point as removed and added. That is the full rebuild this PR removes.

- **A same-shape check runs before the diff, and it is load-bearing.** `diffCellRuns` has no notion of position. A cell edited in place therefore looks identical to one cell removed and a different one inserted at the same index. Without the guard, one character typed in a chunk disposes that cell's text model and creates a new one. That happens on every keystroke. When the cell count and the language at every index are unchanged, the old in-place path still runs. This guard is the negation of the `structureChanged` check that this file already had.

- **Line endings made this a no-op on Windows.** `getCellCode` always joins lines with LF (`quartoDocumentModel.ts:186`), but a text model's own end-of-line is platform dependent. `DEFAULT_EOL` is CRLF on Windows (`modelService.ts:69`), and the buffer builder returns that default when the content has no line break at all. So a chunk that is a single line when its model is created gets a CRLF model on Windows. When the user adds a second line, `applyEdits` normalizes the new text to the buffer end-of-line, and `getValue()` returns CRLF text against an LF comparison string, permanently. Both comparison sites now read with `EndOfLinePreference.LF`. Without this, `sameCell` never matches such a cell, so every structural edit replaces it, and the feature does nothing on Windows while it looks correct everywhere else. Half of this is pre-existing: the old `_sync` compared the same way, so it already rewrote those cells on every parse. This PR adds a second and more consequential use of the same comparison, which is what turns a small waste into a silent no-op.


### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

Nothing here is user visible yet. The whole feature is still behind `quarto.embeddedLanguageFeatures.native`, which defaults to off.

### Validation Steps

@:quarto @:r-markdown

The e2e suites are regression cover only. The setting defaults to off, so none of this code runs in them.

The unit tests check the behavior: 13 new cases, and 298 green across the new feature here.

- `quartoCellDiff.vitest.ts`: 7 cases over the splice arithmetic. These include chunks with identical content, and a cell whose text model is gone.
- `quartoVirtualNotebookService.vitest.ts`: 4 cases that assert handles, URIs, and text models survive an append, a middle insert, a delete, and a language change.
- The same file adds a 75 step seeded fuzz test. It compares the service's cells against the document model's own parsed state.
- The same file adds one regression test for the disposal window described below.
- The pre-existing churn test passes unedited. That is the evidence that the splice behaves the same as the rebuild it replaces! 🤞 

No unit test can show the _improvement_ though. Core reports each structural change at trace level, so you can read it in the Window output channel:

```
[QuartoVirtualNotebook] doc.qmd: spliced at 2, removed 0, inserted 1, kept 45
```

1. Set `quarto.embeddedLanguageFeatures.native` to `true`, and `positron.logLevel` to `trace`.
2. Open a Quarto document with many chunks, and start an R session.
3. Filter the Window output channel to `QuartoVirtualNotebook`.
4. Insert a new chunk in the middle, not at the end. An append is the one shape that can pass by accident.
5. Expect `inserted 1`, `removed 0`, and a `kept` count equal to the chunks that were already there. `kept` is the claim this PR makes, stated per edit.
6. Type inside an existing chunk. Expect no line at all. A content-only edit takes the in-place path and never splices.
7. Delete a chunk from the middle. Expect `removed 1, inserted 0`.
8. Make sure that the Outline still lists every chunk's symbols. A mis-spliced cell appears there as a chunk with missing or doubled symbols.

If you want protocol-level evidence, set `positron.r.trace.server` to `messages` and filter the R Language Server channel for `vscode-notebook-cell`. Those URIs come only from this path, so they are distinguishable from the Quarto extension's virtual document traffic. However, this is VERY VERY BUSY and I found it hard to parse.

You might want to revisit the 45 chunk repro from #14512, inserting a chunk mid-document:

```
[QuartoVirtualNotebook] positron-outline-demo.qmd: spliced at 24, removed 0, inserted 1, kept 45
```

Position 24 of 45 is mid-document, so this is not the append case that can pass by accident. Nothing was disposed, one cell was created, and all 45 existing cells kept their handle, their URI, and their extension host document. The same edit before this change disposed 45 cells and created 46.

### Known and deferred

`_spliceCells` composes the final `_cells` from a snapshot taken before `applyEdits` and `createModel`, both of which fire their events inline. A listener woken by either one that re-enters `ensureSynchronized` sees a short `_cells`, repairs it, and then has that repair overwritten. No synchronous path from a model or notebook event into that method exists today: the callers in `quartoEmbeddedLanguageFeatures.ts` are ext-host driven and async. Recorded rather than guarded, because a structural change to this function carries more risk than the latent fault.
