### PR TITLE
Add a Workbench (Rocky Linux 9) option to the full-suite workflow

### DIFF
--- a/.github/workflows/test-full-suite.yml
+++ b/.github/workflows/test-full-suite.yml
@@ -64,6 +64,11 @@ on:
         required: false
         default: false
         type: boolean
+      run_e2e_workbench_rocky:
+        description: "E2E Tests / Workbench (Rocky Linux 9)"
+        required: false
+        default: false
+        type: boolean
       run_e2e_pyrefly:
         description: "E2E Tests / Pyrefly (Ubuntu)"
         required: false
@@ -336,7 +341,7 @@ jobs:
   build-workbench:
     name: build
     needs: [validate-commit]
-    if: ${{ !failure() && !cancelled() && (github.event_name == 'schedule' || inputs.run_e2e_workbench || inputs.run_e2e_workbench_stable) }}
+    if: ${{ !failure() && !cancelled() && (github.event_name == 'schedule' || inputs.run_e2e_workbench || inputs.run_e2e_workbench_stable || inputs.run_e2e_workbench_rocky) }}
     uses: ./.github/workflows/build-workbench-linux.yml
     secrets: inherit
     with:
@@ -371,6 +376,26 @@ jobs:
       upload_logs: false
       allow_soft_fail: false
       install_mode: "ci-stable"
+      enable_diagnostic_logging: ${{ inputs.enable_diagnostic_logging }}
+
+  # Same test set as the workbench lane, run against a Rocky Linux 9 container.
+  # A separate job so the two OSes run in parallel. `grep` is pinned to
+  # "@:workbench" rather than the run's grep input: @:workbench-rocky selects the
+  # lane, never individual tests, so no test carries it.
+  e2e-workbench-rocky:
+    name: e2e
+    needs: [build-workbench]
+    if: ${{ !failure() && !cancelled() && (github.event_name == 'schedule' || inputs.run_e2e_workbench_rocky) }}
+    uses: ./.github/workflows/test-e2e-workbench-linux.yml
+    secrets: inherit
+    with:
+      commit: ${{ inputs.commit != 'latest' && inputs.commit || '' }}
+      os: "rocky9"
+      grep: "@:workbench"
+      display_name: "workbench-rocky"
+      install_license: false
+      upload_logs: false
+      allow_soft_fail: false
       enable_diagnostic_logging: ${{ inputs.enable_diagnostic_logging }}
 
   e2e-pyrefly:
@@ -475,7 +500,7 @@ jobs:
   slack-notify:
     if: always()
     needs:
-      [validate-commit, e2e-electron, e2e-windows, e2e-macos-arm64, e2e-macos-x64, e2e-chromium, e2e-chromium-rhel, e2e-chromium-suse, e2e-chromium-sles, e2e-chromium-debian, e2e-workbench, e2e-workbench-stable, e2e-pyrefly, e2e-connect, e2e-jupyter, e2e-remote-ssh, unit-tests, ext-host-tests]
+      [validate-commit, e2e-electron, e2e-windows, e2e-macos-arm64, e2e-macos-x64, e2e-chromium, e2e-chromium-rhel, e2e-chromium-suse, e2e-chromium-sles, e2e-chromium-debian, e2e-workbench, e2e-workbench-stable, e2e-workbench-rocky, e2e-pyrefly, e2e-connect, e2e-jupyter, e2e-remote-ssh, unit-tests, ext-host-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
The `@:workbench-rocky` lane (Workbench e2e against a Rocky Linux 9 container) is
wired into `test-pull-request.yml` but there was no way to start it from
**Test: Full Suite**. This adds it:

- a new `run_e2e_workbench_rocky` input, "E2E Tests / Workbench (Rocky Linux 9)",
  defaulting to `false` like the other secondary OS lanes;
- an `e2e-workbench-rocky` job that reuses the same `build-workbench` artifact as
  the Ubuntu lanes (both OSes consume the one `vscode-reh-web-pwb-linux-x64`
  tarball), with `os: rocky9` and `display_name: "workbench-rocky"`;
- `build-workbench` now also runs when only the Rocky box is checked, and the job
  is added to `slack-notify`'s `needs`.

As in the PR workflow, `grep` is pinned to `@:workbench` rather than the run's
`grep` input: `@:workbench-rocky` selects the lane, never individual tests, so no
test carries that tag. The reusable workflow already restricts the Rocky lane to
the `default` shard, so this adds one job, not four.

### Doubling as a verification run

This PR is tagged `@:workbench-rocky`, which also gives us a signal we want
independently of the workflow change.

Until now the Rocky lane had exactly one known failure: the Python case of
`workbench/environment-modules`, filed as #15509 (positron-python probes a
module-provided interpreter as a bare `python`, which does not exist on EL9, so
the bundled ipykernel is disabled and the session dies on a misleading
"sqlite3 extension is required" error). #14746 is the same probe gap described
from the other end: the pre-launch validation probes never apply the module
activation that Positron computes for the session.

#15501 ("Set up module environment in Positron terminals in addition to
consoles") landed since that lane last ran and touched the module locator and
activation plumbing, so the expectation is that the Python environment-modules
test now passes on Rocky. The Rocky lane on this PR runs the PR's Positron build
inside Workbench, so a green `workbench-rocky (default)` here is direct evidence
that #14746 / #15509 are fixed, and a red one tells us the probe path is still
broken. If it is green, the follow-up is to close those issues and update the
"one expected failure" note in `docker/environments/wb-local/ROCKY-PLAN.md`.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

CI-only change; nothing user-facing. Two things to look at:

1. The `workbench-rocky (default)` job on this PR, per the section above.
2. After merge, **Test: Full Suite** should show the new "E2E Tests / Workbench
   (Rocky Linux 9)" checkbox, and checking it alone should schedule
   `build-workbench` followed by one `workbench-rocky (default)` job.

@:workbench-rocky
