### PR TITLE
Make the drive-positron skill work on Windows

### DIFF
--- a/.claude/skills/drive-positron/SKILL.md
+++ b/.claude/skills/drive-positron/SKILL.md
@@ -37,6 +37,21 @@ npm run electron
 
 Do not interrupt the script while it reports that it is running pre-launch.
 
+## Platform support
+
+These scripts run on macOS, Linux, and Windows. On Windows, run them from Git
+Bash; they are bash scripts and will not work from PowerShell or `cmd`.
+
+Tools they expect on `PATH`:
+
+| Tool | Used by | Notes |
+|---|---|---|
+| `node`, `npx` | all | `@playwright/cli` resolves from the repo's `node_modules` |
+| `curl` | `launch.sh`, `stop.sh` | CDP readiness and liveness probes |
+| `rsync` or `tar` | `launch.sh` | `rsync` preferred; `tar` is the fallback, and is what Git Bash has |
+| `jq` | `monaco-paste.sh` | not present in a bare Git Bash; install it separately |
+| `cygpath` | `launch.sh` on Windows | ships with Git Bash |
+
 ## Launch Positron
 
 Run:
@@ -58,18 +73,19 @@ Wait for the script to print one JSON object. Record at least:
 
 The launcher:
 
-- copies the source profile from `$POSITRON_DEV_USER_DATA_DIR` or `~/.positron-dev`;
+- copies the source profile from `$POSITRON_DEV_USER_DATA_DIR` or `~/.positron-dev`, using `rsync` when present and `tar` otherwise;
 - writes only to the disposable copy;
 - creates an isolated shared-data directory;
 - uses a short run directory under `/tmp` by default;
 - assigns unique ports for CDP and the debug endpoints;
+- converts the profile paths for the native binary on Windows;
 - waits for CDP and verifies that the app remains alive before returning.
 
 ### Required launch arguments
 
 | Argument | Purpose |
 |---|---|
-| `--folder-uri file:///private/tmp/myworkspace` | Open a workspace reliably. Do not pass a bare positional folder: Positron may discard it. On macOS, use the canonical `/private/tmp` path rather than `/tmp`. |
+| `--folder-uri file:///private/tmp/myworkspace` | Open a workspace reliably. Do not pass a bare positional folder: Positron may discard it. On macOS, use the canonical `/private/tmp` path rather than `/tmp`. On Windows the URI needs a drive letter, so build it with `cygpath -m`: `--folder-uri "file:///$(cygpath -m /tmp/myworkspace)"`. |
 | `--disable-workspace-trust` | Prevent a modal trust dialog from blocking automation when the seed profile has no trust state. |
 | `--use-mock-keychain` | Avoid using the per-user OS keychain from the disposable instance. A `GitHubLoginFailed` message in the log is expected. |
 | `--skip-welcome` | Keep the Welcome editor from receiving the initial focus. |
@@ -185,37 +201,32 @@ Always stop the disposable instance; Positron can retain several gigabytes of me
 
 ```bash
 npx @playwright/cli -s=positron close
-kill "$PID"
+.claude/skills/drive-positron/scripts/stop.sh \
+	--cdp-port "$CDP_PORT" --run-dir "$RUN_DIR"
 ```
 
-Before deleting anything, verify that `RUN_DIR` is the exact `runDir` reported by the launcher and points to a generated `positron-dev-launch` directory:
+`stop.sh` kills the process tree that owns the CDP port, waits for the port to stop answering, and then removes the run directory. It exits non-zero if the instance is still reachable, so a silent failure to clean up is not possible.
 
-```bash
-case "${RUN_DIR:-}" in
-	*/positron-dev-launch/*)
-		rm -rf -- "${RUN_DIR:?}"
-		;;
-	*)
-		echo "Refusing to remove unexpected run directory: ${RUN_DIR:-<empty>}" >&2
-		exit 1
-		;;
-esac
-```
+Pass `--run-dir` only when it is the exact `runDir` the launcher reported. The script refuses any path that does not contain a generated `positron-dev-launch` component, and stops the instance without deleting anything when `--run-dir` is omitted.
+
+Do not use `kill "$PID"` on its own. On Windows the reported `pid` belongs to the MSYS shell that exec'd the native Electron binary, so killing it can leave the application running. `stop.sh` locates the real process through the CDP port on every platform.
 
 Remove `.playwright-cli` only if it is the session directory created in the intended workspace.
 
-Confirm that no process remains:
+To confirm independently that no process remains, check that the CDP port no longer answers:
 
 ```bash
-pgrep -f "remote-debugging-port=$CDP_PORT"
+curl -sf -o /dev/null "http://127.0.0.1:$CDP_PORT/json/version" \
+	&& echo "still running" || echo "stopped"
 ```
 
-An empty result means cleanup succeeded.
+This works on every platform. `pgrep -f "remote-debugging-port=$CDP_PORT"` is equivalent on macOS and Linux, but `pgrep` is absent from Git Bash on Windows.
 
 ## Troubleshoot failures
 
 - **Attach reports `connect ECONNREFUSED`:** The application exited after opening CDP. Inspect the path reported as `logFile`.
-- **The log reports `listen EINVAL` or an IPC path longer than 103 characters:** The run-directory base is too long. Unset `$POSITRON_LAUNCH_TMP` or point it at a shorter directory.
+- **The log reports `listen EINVAL` or an IPC path longer than 103 characters:** The run-directory base is too long. Unset `$POSITRON_LAUNCH_TMP` or point it at a shorter directory. This affects macOS and Linux only; Windows uses named pipes and has no such limit.
+- **`rsync: command not found` (Windows):** You are on an older copy of `launch.sh`. The current script falls back to `tar` when `rsync` is absent.
 - **Snapshot references disappear:** Look for a modal dialog with a screenshot, then take a new snapshot.
 - **A built-in extension does not load:** Compile extensions with:
 

--- a/.claude/skills/drive-positron/SKILL.md
+++ b/.claude/skills/drive-positron/SKILL.md
@@ -205,7 +205,9 @@ npx @playwright/cli -s=positron close
 	--cdp-port "$CDP_PORT" --run-dir "$RUN_DIR"
 ```
 
-`stop.sh` kills the process tree that owns the CDP port, waits for the port to stop answering, and then removes the run directory. It exits non-zero if the instance is still reachable, so a silent failure to clean up is not possible.
+`stop.sh` signals the process that owns the CDP port, waits for the port to stop answering, forces the stop if it does not, and then removes the run directory. It exits non-zero if the instance is still reachable, so a silent failure to clean up is not possible.
+
+Do not signal the Electron helper processes yourself. Positron reads a terminated renderer as a window crash: it respawns the helpers, shows a "window terminated unexpectedly" dialog, and then ignores the signal sent to the main process, leaving the instance running.
 
 Pass `--run-dir` only when it is the exact `runDir` the launcher reported. The script refuses any path that does not contain a generated `positron-dev-launch` component, and stops the instance without deleting anything when `--run-dir` is omitted.
 

--- a/.claude/skills/drive-positron/scripts/launch.sh
+++ b/.claude/skills/drive-positron/scripts/launch.sh
@@ -10,6 +10,8 @@
 #   2. Seeds the profile from $POSITRON_DEV_USER_DATA_DIR or ~/.positron-dev.
 #   3. Provides an isolated shared-data directory and unique debug ports.
 #   4. Rechecks process liveness after CDP starts, catching late startup crashes.
+#   5. Runs on Windows (Git Bash) as well as macOS and Linux: falls back to tar
+#      where rsync is absent, and converts paths for the native Electron binary.
 #
 # Prints connection details as JSON on stdout and diagnostics on stderr.
 #
@@ -30,6 +32,65 @@
 
 set -euo pipefail
 umask 077
+
+# Platform and tool detection. Git Bash on Windows (MSYS) ships neither rsync
+# nor pgrep, and Electron there cannot read MSYS-style paths such as /tmp/x.
+case "$(uname -s)" in
+	MINGW*|MSYS*|CYGWIN*) IS_WINDOWS=1 ;;
+	*) IS_WINDOWS=0 ;;
+esac
+if command -v rsync >/dev/null 2>&1; then
+	HAVE_RSYNC=1
+else
+	HAVE_RSYNC=0
+fi
+
+# Convert a path for the Electron binary. On Windows the app is a native
+# executable that cannot read MSYS paths, and MSYS argument translation does not
+# reliably rewrite them inside --flag=value pairs. Elsewhere this is a no-op.
+to_native_path() {
+	if [[ "$IS_WINDOWS" == "1" ]]; then
+		cygpath -m "$1"
+	else
+		printf '%s\n' "$1"
+	fi
+}
+
+# Copy a directory tree, honoring rsync-style exclude patterns.
+#
+# Prefers rsync where it exists so the established macOS and Linux behavior is
+# unchanged, and falls back to a streaming tar pipe on Windows. The tar path
+# skips excluded directories rather than copying and then deleting them, which
+# matters because the caches being excluded can run to gigabytes.
+#
+# Exclude patterns use rsync semantics: a leading slash anchors the pattern at
+# the transfer root, anything else matches at any depth. GNU tar's default
+# non-anchored matching produces the same result once a leading slash has been
+# rewritten to './'.
+copy_tree() {
+	local src="$1" dst="$2"
+	shift 2
+	mkdir -p "$dst"
+
+	local excl=()
+	local pattern
+	if [[ "$HAVE_RSYNC" == "1" ]]; then
+		for pattern in "$@"; do
+			excl+=("--exclude=$pattern")
+		done
+		rsync -a "${excl[@]}" "$src/" "$dst/"
+		return
+	fi
+
+	for pattern in "$@"; do
+		if [[ "$pattern" == /* ]]; then
+			excl+=("--exclude=.$pattern")
+		else
+			excl+=("--exclude=$pattern")
+		fi
+	done
+	( cd "$src" && tar -cf - "${excl[@]}" . ) | ( cd "$dst" && tar -xf - )
+}
 
 AGENTS=0
 SOURCE_UDD="${POSITRON_DEV_USER_DATA_DIR:-$HOME/.positron-dev}"
@@ -79,7 +140,8 @@ MAIN_PORT=$(pick_port)
 AGENTHOST_PORT=$(pick_port)
 
 STAMP=$(date +%Y%m%d-%H%M%S)-$$
-# Keep the run directory short enough for the main-process Unix socket.
+# Keep the run directory short enough for the main-process Unix socket. Windows
+# uses named pipes instead, so the length limit does not apply there.
 RUN_DIR="${POSITRON_LAUNCH_TMP:-/tmp}/positron-dev-launch/$STAMP"
 DEST_UDD="$RUN_DIR/user-data"
 SHARED_DATA_DIR="$RUN_DIR/shared-data"
@@ -101,14 +163,13 @@ EXCLUDES=(
 	'*.lock' '*.sock'
 )
 
+COPY_TOOL=$([[ "$HAVE_RSYNC" == "1" ]] && echo rsync || echo tar)
 if [[ "$FULL" == "1" ]]; then
-	echo "[launch.sh] full copy: $SOURCE_UDD -> $DEST_UDD" >&2
-	rsync -a "$SOURCE_UDD/" "$DEST_UDD/"
+	echo "[launch.sh] full copy ($COPY_TOOL): $SOURCE_UDD -> $DEST_UDD" >&2
+	copy_tree "$SOURCE_UDD" "$DEST_UDD"
 else
-	echo "[launch.sh] slim copy: $SOURCE_UDD -> $DEST_UDD" >&2
-	RSYNC_ARGS=(-a)
-	for e in "${EXCLUDES[@]}"; do RSYNC_ARGS+=(--exclude="$e"); done
-	rsync "${RSYNC_ARGS[@]}" "$SOURCE_UDD/" "$DEST_UDD/"
+	echo "[launch.sh] slim copy ($COPY_TOOL): $SOURCE_UDD -> $DEST_UDD" >&2
+	copy_tree "$SOURCE_UDD" "$DEST_UDD" "${EXCLUDES[@]}"
 fi
 
 # Prepare extensions according to the selected profile-copy mode.
@@ -116,7 +177,7 @@ EXT_DIR="$DEST_UDD/extensions"
 mkdir -p "$EXT_DIR"
 if [[ "$FULL" != "1" && "$CLONE_EXTENSIONS" == "1" ]]; then
 	echo "[launch.sh] copying extensions: $SOURCE_UDD/extensions -> $EXT_DIR" >&2
-	rsync -a "$SOURCE_UDD/extensions/" "$EXT_DIR/"
+	copy_tree "$SOURCE_UDD/extensions" "$EXT_DIR"
 fi
 
 # Force the quick-input file dialog because CDP cannot control native dialogs.
@@ -191,9 +252,9 @@ if [[ ! -x "$CODE_SH" ]]; then
 fi
 
 ARGS=(
-	"--user-data-dir=$DEST_UDD"
-	"--extensions-dir=$EXT_DIR"
-	"--shared-data-dir=$SHARED_DATA_DIR"
+	"--user-data-dir=$(to_native_path "$DEST_UDD")"
+	"--extensions-dir=$(to_native_path "$EXT_DIR")"
+	"--shared-data-dir=$(to_native_path "$SHARED_DATA_DIR")"
 	"--remote-debugging-port=$CDP_PORT"
 	"--inspect-extensions=$EXTHOST_PORT"
 	"--inspect=$MAIN_PORT"

--- a/.claude/skills/drive-positron/scripts/stop.sh
+++ b/.claude/skills/drive-positron/scripts/stop.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Stops a disposable Positron instance started by launch.sh and optionally
+# removes its run directory.
+#
+# `kill $PID` is not sufficient on every platform. On Windows the PID that
+# launch.sh reports belongs to the MSYS shell that exec'd the native Electron
+# binary; killing it leaves the application running and holding several
+# gigabytes. Locating the process that owns the CDP port works everywhere, so
+# this script does that instead of trusting the reported PID.
+#
+# Usage:
+#   stop.sh --cdp-port <port> [--run-dir <dir>] [--timeout <seconds>]
+#
+# Exits non-zero when the instance is still reachable after the timeout, or when
+# --run-dir does not look like a launch.sh run directory.
+
+set -euo pipefail
+
+CDP_PORT=""
+RUN_DIR=""
+TIMEOUT=15
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--cdp-port) CDP_PORT="$2"; shift 2 ;;
+		--run-dir) RUN_DIR="$2"; shift 2 ;;
+		--timeout) TIMEOUT="$2"; shift 2 ;;
+		*) echo "Unknown arg: $1" >&2; exit 2 ;;
+	esac
+done
+
+if [[ -z "$CDP_PORT" ]]; then
+	echo "Usage: stop.sh --cdp-port <port> [--run-dir <dir>] [--timeout <seconds>]" >&2
+	exit 2
+fi
+
+case "$(uname -s)" in
+	MINGW*|MSYS*|CYGWIN*) IS_WINDOWS=1 ;;
+	*) IS_WINDOWS=0 ;;
+esac
+
+cdp_alive() {
+	curl -sf -o /dev/null --max-time 2 "http://127.0.0.1:$CDP_PORT/json/version" 2>/dev/null
+}
+
+# Report every PID listening on the CDP port. netstat is the only listener query
+# available in a bare Git Bash; lsof covers macOS and Linux.
+listener_pids() {
+	if [[ "$IS_WINDOWS" == "1" ]]; then
+		netstat -ano \
+			| awk -v port=":$CDP_PORT" '$1 == "TCP" && $2 ~ (port "$") && $4 == "LISTENING" { print $5 }' \
+			| sort -u
+	else
+		lsof -ti "tcp:$CDP_PORT" -sTCP:LISTEN 2>/dev/null | sort -u
+	fi
+}
+
+# Kill a process and its children. Electron spawns a tree, and orphaned renderer
+# or utility processes keep holding memory.
+kill_tree() {
+	local pid="$1"
+	if [[ "$IS_WINDOWS" == "1" ]]; then
+		# Double slashes keep MSYS from rewriting the flags as paths.
+		taskkill //F //T //PID "$pid" >/dev/null 2>&1 || true
+	else
+		pkill -TERM -P "$pid" 2>/dev/null || true
+		kill -TERM "$pid" 2>/dev/null || true
+	fi
+}
+
+if ! cdp_alive; then
+	echo "[stop.sh] nothing listening on CDP port $CDP_PORT" >&2
+else
+	PIDS=$(listener_pids || true)
+	if [[ -z "$PIDS" ]]; then
+		echo "[stop.sh] CDP port $CDP_PORT answers but no listening PID was found." >&2
+		echo "[stop.sh] Stop the instance by hand before reusing the port." >&2
+		exit 1
+	fi
+	echo "[stop.sh] stopping PID(s) on CDP port $CDP_PORT: $(echo "$PIDS" | tr '\n' ' ')" >&2
+	for pid in $PIDS; do
+		kill_tree "$pid"
+	done
+
+	for _ in $(seq 1 "$TIMEOUT"); do
+		if ! cdp_alive; then
+			break
+		fi
+		sleep 1
+	done
+
+	if cdp_alive; then
+		echo "[stop.sh] CDP port $CDP_PORT is still answering after ${TIMEOUT}s." >&2
+		exit 1
+	fi
+	echo "[stop.sh] instance stopped" >&2
+fi
+
+# Remove the run directory only when it looks like one launch.sh generated. The
+# path may be POSIX or Windows form, and the glob matches either.
+if [[ -n "$RUN_DIR" ]]; then
+	case "$RUN_DIR" in
+		*/positron-dev-launch/*)
+			rm -rf -- "${RUN_DIR:?}"
+			echo "[stop.sh] removed run directory $RUN_DIR" >&2
+			;;
+		*)
+			echo "[stop.sh] refusing to remove unexpected run directory: $RUN_DIR" >&2
+			exit 1
+			;;
+	esac
+fi

--- a/.claude/skills/drive-positron/scripts/stop.sh
+++ b/.claude/skills/drive-positron/scripts/stop.sh
@@ -55,16 +55,38 @@ listener_pids() {
 	fi
 }
 
-# Kill a process and its children. Electron spawns a tree, and orphaned renderer
-# or utility processes keep holding memory.
-kill_tree() {
+# Ask the instance to stop. Electron spawns a process tree, but the children are
+# the main process's responsibility: they exit with it.
+#
+# Do not signal the children first on macOS or Linux. The main process reads a
+# terminated renderer as a window crash, respawns the helpers, shows the "window
+# terminated unexpectedly" dialog, and then does not act on the signal that
+# follows -- the instance survives the timeout and keeps holding memory.
+stop_tree() {
 	local pid="$1"
 	if [[ "$IS_WINDOWS" == "1" ]]; then
 		# Double slashes keep MSYS from rewriting the flags as paths.
 		taskkill //F //T //PID "$pid" >/dev/null 2>&1 || true
 	else
-		pkill -TERM -P "$pid" 2>/dev/null || true
 		kill -TERM "$pid" 2>/dev/null || true
+	fi
+}
+
+# Last resort for a main process that ignored SIGTERM. Collect the children
+# first: once the parent is gone they are reparented and no longer findable
+# through it.
+force_stop_tree() {
+	local pid="$1"
+	if [[ "$IS_WINDOWS" == "1" ]]; then
+		taskkill //F //T //PID "$pid" >/dev/null 2>&1 || true
+	else
+		local children
+		children=$(pgrep -P "$pid" 2>/dev/null || true)
+		kill -KILL "$pid" 2>/dev/null || true
+		if [[ -n "$children" ]]; then
+			# shellcheck disable=SC2086 # deliberate word splitting: one PID per line
+			kill -KILL $children 2>/dev/null || true
+		fi
 	fi
 }
 
@@ -79,7 +101,7 @@ else
 	fi
 	echo "[stop.sh] stopping PID(s) on CDP port $CDP_PORT: $(echo "$PIDS" | tr '\n' ' ')" >&2
 	for pid in $PIDS; do
-		kill_tree "$pid"
+		stop_tree "$pid"
 	done
 
 	for _ in $(seq 1 "$TIMEOUT"); do
@@ -89,8 +111,23 @@ else
 		sleep 1
 	done
 
+	# Escalate rather than report failure while the app still holds memory. A
+	# modal dialog can keep a graceful shutdown from completing.
 	if cdp_alive; then
-		echo "[stop.sh] CDP port $CDP_PORT is still answering after ${TIMEOUT}s." >&2
+		echo "[stop.sh] still answering after ${TIMEOUT}s; forcing" >&2
+		for pid in $PIDS; do
+			force_stop_tree "$pid"
+		done
+		for _ in $(seq 1 5); do
+			if ! cdp_alive; then
+				break
+			fi
+			sleep 1
+		done
+	fi
+
+	if cdp_alive; then
+		echo "[stop.sh] CDP port $CDP_PORT is still answering after a forced stop." >&2
 		exit 1
 	fi
 	echo "[stop.sh] instance stopped" >&2


### PR DESCRIPTION
The `drive-positron` skill could not launch Positron at all on Windows. Git Bash
ships neither `rsync` nor `pgrep`, and the skill used both. Everything downstream
of the launch (`@playwright/cli` attach, snapshot, eval, press, screenshot) already
worked -- only launching and cleaning up were broken.

Found while verifying an unrelated build change on Windows.

### What changed

**`scripts/launch.sh`**

- Replace the three `rsync` calls with a `copy_tree` helper. `rsync` is still used
  where it exists, so macOS and Linux behavior is unchanged; Windows falls back to
  a streaming `tar` pipe. The tar path skips excluded directories rather than
  copying and then deleting them, which matters because the excluded caches can run
  to gigabytes. Exclude patterns keep rsync semantics, so a leading slash still
  anchors at the transfer root.
- Convert the profile paths to native form for the Electron binary. The app cannot
  read MSYS paths, and MSYS argument translation does not reliably rewrite them
  inside `--flag=value` pairs.

**`scripts/stop.sh`** (new)

`kill $PID` is not sufficient on Windows: the PID `launch.sh` reports belongs to the
MSYS shell that `exec`'d the native binary, so killing it can leave the application
running and holding several gigabytes -- the exact outcome the cleanup section
exists to prevent. This was reproduced, not theorized.

`stop.sh` finds the process tree that owns the CDP port, which works on every
platform, waits for the port to stop answering, and exits non-zero if the instance
survives. It removes the run directory only when the path contains a generated
`positron-dev-launch` component.

**`SKILL.md`**

- Add a platform-support section listing the tools each script needs.
- Point cleanup at `stop.sh` and explain why the bare `kill` is insufficient.
- Replace the `pgrep` liveness check with a CDP probe that works everywhere.
- Give the Windows form of `--folder-uri`, built with `cygpath`.
- Note that the 103-character IPC path limit is macOS and Linux only.

### QA Notes

No product code changed, so there are no e2e tags on this PR.

Verified on Windows 11 / Git Bash against a dev build (Electron 42.6.0,
code-oss-dev 1.130.0), running the documented workflow end to end:

| Step | Result |
|---|---|
| `launch.sh` | slim copy (tar), CDP ready in 2s, JSON emitted |
| `--folder-uri` via `cygpath` | workspace opened (`myworkspace - Positron Dev`) |
| attach + snapshot | 210 element refs |
| `stop.sh` | killed the PID tree, port dead, run directory removed, exit 0 |
| after cleanup | zero `Positron.exe` processes, zero run directories |

The macOS and Linux `rsync` path is unchanged and was not re-tested; a spot check
there before merge would be welcome.

Not fixed here: `monaco-paste.sh` clears the target editor but fails to insert, so
it reports a read-back mismatch. A wrong-element selector, a focus problem, and a
missing `jq` were all ruled out; the likely cause is Monaco's EditContext input path
no longer honoring a synthetic untrusted `ClipboardEvent`, which would make it a
general regression rather than a Windows one. Left out deliberately since it cannot
be attributed from Windows alone.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A