### PR TITLE
Add a Disconnect option to the Data Connections context menu

### DIFF
--- a/src/vs/workbench/contrib/positronDataConnections/browser/classes/dataConnectionsTreeInstance.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/classes/dataConnectionsTreeInstance.tsx
@@ -164,6 +164,27 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 	}
 
 	/**
+	 * Disconnects an entry's connection outright, at the user's explicit request, and collapses the
+	 * entry: with the connection gone there is nothing under it to browse, so leaving it expanded
+	 * would show an empty or re-connecting subtree. The Data Explorers previewed from it close too,
+	 * because their backends die with the connection.
+	 *
+	 * Collapsing goes straight to the base implementation rather than through this class's collapse:
+	 * that override means the conditional, wait-for-the-previews close a user-driven collapse asks
+	 * for, which is the opposite of what is wanted here. The loaded subtree is dropped by the roots
+	 * refresh in the constructor once the connection is actually gone.
+	 * @param id The node id of the entry to disconnect.
+	 */
+	async disconnectEntry(id: string): Promise<void> {
+		const node = this._findEntryNode(id);
+		if (node === undefined) {
+			return;
+		}
+		super.collapse(id);
+		await this._service.disconnect(node.entry.profile.id);
+	}
+
+	/**
 	 * Fetches children for a node. For an entry node without a live instance, opens the
 	 * connection first, then fetches the top-level DTOs against the new handle. Running this
 	 * inside the base class's _fetchChildren means the loading state (twisty spinner) covers
@@ -210,6 +231,10 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 		// visible change there isn't the silent no-op it would be on an expanded one.
 		const onRefresh = () => { void this.reload(id); };
 
+		// Fire-and-forget for the same reason as refresh: the row has nothing to await. The entry's
+		// connected indicator and subtree follow from the instance change the disconnect fires.
+		const onDisconnect = () => { void this.disconnectEntry(id); };
+
 		// Rows announce their context menu here rather than selecting themselves directly, so the
 		// tree owns what opening a menu means: select the row the menu belongs to (as a left click
 		// would), and keep the tree looking focused while the menu holds DOM focus. The returned
@@ -222,7 +247,7 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 		switch (data.kind) {
 			case 'entry':
 				// Entries are roots, so no ancestor can be refreshing them out from under the row.
-				return <DataConnectionEntryRow entry={data.entry} onMenuOpening={onMenuOpening} onRefresh={onRefresh} />;
+				return <DataConnectionEntryRow entry={data.entry} onDisconnect={onDisconnect} onMenuOpening={onMenuOpening} onRefresh={onRefresh} />;
 			case 'dto':
 				return <DataConnectionNodeRow dto={data.dto} handle={data.handle} stale={visible.stale} onMenuOpening={onMenuOpening} onRefresh={onRefresh} />;
 		}

--- a/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionEntryRow.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionEntryRow.tsx
@@ -32,6 +32,10 @@ interface DataConnectionEntryRowProps {
 	// The data connection entry to render.
 	entry: DataConnectionEntry;
 
+	// Closes this connection and the Data Explorers previewed from it, and collapses the row.
+	// Supplied by the tree, which binds it to this row's node id.
+	onDisconnect: () => void;
+
 	// Reloads this connection's subtree. Supplied by the tree, which binds it to this row's node id.
 	onRefresh: () => void;
 
@@ -45,9 +49,9 @@ interface DataConnectionEntryRowProps {
  * connected, a live-status indicator. Twistie click (handled by PositronTree) opens the connection;
  * collapsing closes it only when nothing else is using it (see DataConnectionsTreeInstance). The
  * actions menu -- reachable from the actions button or by right-clicking the row -- exposes
- * refresh, runtime-language connect options, and edit/remove.
+ * refresh, edit, runtime-language connect options, and disconnect (when connected) / remove.
  */
-export const DataConnectionEntryRow = ({ entry, onMenuOpening, onRefresh }: DataConnectionEntryRowProps) => {
+export const DataConnectionEntryRow = ({ entry, onDisconnect, onMenuOpening, onRefresh }: DataConnectionEntryRowProps) => {
 	// Services.
 	const { notificationService, positronDataConnectionsService } = usePositronReactServicesContext();
 
@@ -235,8 +239,18 @@ export const DataConnectionEntryRow = ({ entry, onMenuOpening, onRefresh }: Data
 			}
 		}
 
-		// Finally, add a separator and the remove option.
+		// Finally, add a separator and the options that take something away: disconnect (only while
+		// there is a live connection to close), then remove. Only remove is marked destructive --
+		// disconnecting gives up the connection but keeps the saved profile, and nothing about it is
+		// unrecoverable.
 		entries.push(new CustomContextMenuSeparator());
+		if (entry.instance) {
+			entries.push(new CustomContextMenuItem({
+				icon: 'positron-disconnect-connection',
+				label: localize('positron.dataConnections.disconnect', "Disconnect"),
+				onSelected: onDisconnect,
+			}));
+		}
 		entries.push(
 			new CustomContextMenuItem({
 				destructive: true,

--- a/src/vs/workbench/contrib/positronDataConnections/test/browser/dataConnectionEntryRow.vitest.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/test/browser/dataConnectionEntryRow.vitest.tsx
@@ -6,13 +6,26 @@
 /// <reference types="vitest/globals" />
 
 import { screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { IDisposable } from '../../../../../base/common/lifecycle.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { CustomContextMenuItem } from '../../../../browser/positronComponents/customContextMenu/customContextMenuItem.js';
+import { CustomContextMenuSeparator } from '../../../../browser/positronComponents/customContextMenu/customContextMenuSeparator.js';
 import { IDataConnectionInstance } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionInstance.js';
-import { IDataConnectionProfile } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
+import { IDataConnectionDriver, IDataConnectionProfile } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
+import { IDataConnectionsDriverManager } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionsDriverManager.js';
+import { IPositronDataConnectionsService } from '../../../../services/positronDataConnections/common/interfaces/positronDataConnectionsService.js';
 import { DataConnectionEntryRow } from '../../browser/components/dataConnectionEntryRow.js';
+
+// showCustomContextMenu renders a modal popup into the workbench DOM, which isn't what these tests
+// are about -- the behavior under test is which entries the row decides to offer. Mocking the one
+// module lets us read the entries straight off the call.
+const { showCustomContextMenu } = vi.hoisted(() => ({ showCustomContextMenu: vi.fn() }));
+vi.mock('../../../../browser/positronComponents/customContextMenu/customContextMenu.js', () => ({
+	showCustomContextMenu,
+}));
 
 const profile: IDataConnectionProfile = {
 	id: 'conn-1',
@@ -27,27 +40,142 @@ const profile: IDataConnectionProfile = {
 	parameterValues: {},
 };
 
+// The row needs its driver to build a menu at all. This one supports no languages, so the menu
+// leaves out the Connect With group and the entries under test stand alone.
+const driver = stubInterface<IDataConnectionDriver>({
+	id: 'test-driver',
+	metadata: {
+		id: 'test-driver',
+		name: 'Test Driver',
+		description: '',
+		iconSvg: '',
+		mechanisms: [{ id: 'test-mechanism', label: 'Test Mechanism', description: '', parameters: [] }],
+		supportedLanguageIds: [],
+	},
+});
+
 describe('DataConnectionEntryRow', () => {
-	const ctx = createTestContainer().withReactServices().build();
+	const ctx = createTestContainer()
+		.withReactServices()
+		.stub(IPositronDataConnectionsService, {
+			driverManager: stubInterface<IDataConnectionsDriverManager>({ getDriver: () => driver }),
+		})
+		.build();
 	const rtl = setupRTLRenderer(() => ctx.reactServices);
 
-	// The tree supplies these; neither is exercised here, where the indicator is what's under test.
+	// The tree supplies these; the indicator tests don't exercise either.
+	const onDisconnect = vi.fn();
 	const onRefresh = vi.fn();
 	const onMenuOpening = vi.fn((): IDisposable => ({ dispose: vi.fn() }));
+
+	/**
+	 * Renders a row -- connected unless told otherwise -- and right-clicks it. Returns the row's
+	 * callbacks, the menu call, and the labels of the entries the row offered ('---' for a separator).
+	 */
+	async function rightClickRow(connected = true) {
+		const instance = connected
+			? stubInterface<IDataConnectionInstance>({ id: 'instance-1', profileId: profile.id })
+			: undefined;
+		const onDisconnectRow = vi.fn();
+
+		rtl.render(
+			<DataConnectionEntryRow
+				entry={{ profile, instance }}
+				onDisconnect={onDisconnectRow}
+				onMenuOpening={onMenuOpening}
+				onRefresh={onRefresh}
+			/>
+		);
+
+		const user = userEvent.setup();
+		// The row is a structural div with no role or label, so target its name instead -- pointer
+		// events there bubble up to the row's handlers, which is what a real click does too.
+		await user.pointer({ keys: '[MouseRight]', target: screen.getByText('My Connection', { exact: false }) });
+
+		const call = showCustomContextMenu.mock.calls.at(-1)?.[0];
+		const items: CustomContextMenuItem[] = call?.entries.filter(
+			(entry: unknown) => entry instanceof CustomContextMenuItem
+		);
+		const labels = call?.entries.map((entry: unknown) =>
+			entry instanceof CustomContextMenuSeparator ? '---' : (entry as CustomContextMenuItem).options.label
+		);
+
+		// Items are located by label rather than index, so a menu the row grows another entry in
+		// doesn't move the one under test out from under the assertion.
+		const itemByLabel = (label: string) => items.find(item => item.options.label === label);
+
+		return { labels, itemByLabel, onDisconnectRow };
+	}
 
 	it('shows the connected indicator for a profile with a live connection', () => {
 		const instance = stubInterface<IDataConnectionInstance>({ id: 'instance-1', profileId: profile.id });
 
-		rtl.render(<DataConnectionEntryRow entry={{ profile, instance }} onMenuOpening={onMenuOpening} onRefresh={onRefresh} />);
+		rtl.render(<DataConnectionEntryRow entry={{ profile, instance }} onDisconnect={onDisconnect} onMenuOpening={onMenuOpening} onRefresh={onRefresh} />);
 
 		// The indicator is a bare dot, so its accessible name is the only thing to query it by.
 		expect(screen.getByRole('img', { name: 'Connected' })).toBeInTheDocument();
 	});
 
 	it('shows no connected indicator for a saved profile that is not connected', () => {
-		rtl.render(<DataConnectionEntryRow entry={{ profile }} onMenuOpening={onMenuOpening} onRefresh={onRefresh} />);
+		rtl.render(<DataConnectionEntryRow entry={{ profile }} onDisconnect={onDisconnect} onMenuOpening={onMenuOpening} onRefresh={onRefresh} />);
 
 		expect(screen.queryByRole('img', { name: 'Connected' })).not.toBeInTheDocument();
 		expect(screen.getByText('My Connection', { exact: false })).toBeInTheDocument();
+	});
+
+	it('offers Disconnect above Remove for a connected profile', async () => {
+		const { labels } = await rightClickRow();
+
+		expect(labels).toMatchInlineSnapshot(`
+			[
+			  "Refresh",
+			  "---",
+			  "Edit Connection",
+			  "---",
+			  "Disconnect",
+			  "Remove",
+			]
+		`);
+	});
+
+	// Nothing to close on a saved-but-closed profile, so the item would be dead weight.
+	it('offers no Disconnect for a profile that is not connected', async () => {
+		const { labels } = await rightClickRow(false);
+
+		expect(labels).toMatchInlineSnapshot(`
+			[
+			  "Refresh",
+			  "---",
+			  "Edit Connection",
+			  "---",
+			  "Remove",
+			]
+		`);
+	});
+
+	it('invokes the tree-supplied disconnect when Disconnect is selected', async () => {
+		const { itemByLabel, onDisconnectRow } = await rightClickRow();
+
+		itemByLabel('Disconnect')?.options.onSelected({ altKey: false, ctrlKey: false, metaKey: false, shiftKey: false });
+
+		// The tree owns what disconnecting means -- closing the connection's Data Explorers and
+		// collapsing the row -- so the row's job is done once it has handed the request over.
+		expect(onDisconnectRow).toHaveBeenCalledOnce();
+	});
+
+	// Disconnect shares the bottom group with Remove but not its styling: giving up a connection
+	// leaves the saved profile intact, so nothing about it is unrecoverable.
+	it('marks Remove destructive but not Disconnect', async () => {
+		const { itemByLabel } = await rightClickRow();
+
+		expect({
+			disconnect: itemByLabel('Disconnect')?.options.destructive,
+			remove: itemByLabel('Remove')?.options.destructive,
+		}).toMatchInlineSnapshot(`
+			{
+			  "disconnect": undefined,
+			  "remove": true,
+			}
+		`);
 	});
 });

--- a/src/vs/workbench/contrib/positronDataConnections/test/browser/dataConnectionsTreeInstance.vitest.ts
+++ b/src/vs/workbench/contrib/positronDataConnections/test/browser/dataConnectionsTreeInstance.vitest.ts
@@ -147,6 +147,9 @@ describe('DataConnectionsTreeInstance', () => {
 	// The tree's id for the single profile these tests use.
 	const ENTRY_ID = 'entry:conn-1';
 
+	// The tree's id for the one node under that profile: `dto:<connection handle>:<node handle>`.
+	const DTO_ID = 'dto:1:7';
+
 	const profile = createProfile({
 		connectionName: 'Test Connection',
 		driverMetadata: {
@@ -168,12 +171,25 @@ describe('DataConnectionsTreeInstance', () => {
 	 * disconnecting it.
 	 */
 	function createTree(connected = true) {
-		const getChildren = vi.fn(async () => []);
+		// One leaf under the connection, so a test has a real non-entry node to act on. Its node id is
+		// DTO_ID below.
+		const getChildren = vi.fn(async () => [{
+			nodeHandle: 7,
+			name: 'flights',
+			kind: 'table',
+			hasGetChildren: false,
+			hasPreview: true,
+		}]);
 		const instance = stubInterface<IDataConnectionInstance>({
 			id: 'instance-1',
 			profileId: profile.id,
 			connectionHandle: stubInterface<IDataConnectionHandle>({ handle: 1, getChildren }),
 		});
+
+		// Held as locals as well as on the stub, so a test can read their call lists (the stub is typed
+		// as the interface, where they are plain functions rather than mocks).
+		const disconnect = vi.fn(async () => { });
+		const disconnectWhenUnused = vi.fn();
 
 		let liveInstance = connected ? instance : undefined;
 		const service = stubInterface<IPositronDataConnectionsService>({
@@ -182,7 +198,8 @@ describe('DataConnectionsTreeInstance', () => {
 			getProfiles: () => [profile],
 			getInstanceForProfile: () => liveInstance,
 			connect: async () => instance,
-			disconnectWhenUnused: vi.fn(),
+			disconnect,
+			disconnectWhenUnused,
 			cancelDisconnectWhenUnused: vi.fn(),
 		});
 
@@ -194,7 +211,7 @@ describe('DataConnectionsTreeInstance', () => {
 			onDidChangeInstances.fire(nowConnected ? [instance] : []);
 		};
 
-		return { tree, service, getChildren, setConnected };
+		return { tree, service, getChildren, setConnected, disconnect, disconnectWhenUnused };
 	}
 
 	it('gives up its use of the connection when a connected entry is collapsed', async () => {
@@ -241,6 +258,45 @@ describe('DataConnectionsTreeInstance', () => {
 
 		// The node handles in the loaded subtree are still valid, so re-expanding costs no round trip.
 		expect(getChildren).toHaveBeenCalledTimes(1);
+	});
+
+	it('closes the connection and collapses the row when an entry is disconnected', async () => {
+		const { tree, disconnect, disconnectWhenUnused } = createTree();
+		await tree.refresh();
+		await tree.expand(ENTRY_ID);
+
+		await tree.disconnectEntry(ENTRY_ID);
+
+		// An explicit disconnect doesn't wait on the previews the way a collapse does, so it must not
+		// route through disconnectWhenUnused; the row collapses because there's nothing left to browse.
+		expect({
+			closed: disconnect.mock.calls,
+			deferred: disconnectWhenUnused.mock.calls.length,
+			expanded: tree.isExpanded(ENTRY_ID),
+		}).toMatchInlineSnapshot(`
+			{
+			  "closed": [
+			    [
+			      "conn-1",
+			    ],
+			  ],
+			  "deferred": 0,
+			  "expanded": false,
+			}
+		`);
+	});
+
+	// Only an entry owns a connection, so a node id that resolves to something else -- or to nothing
+	// at all -- must not take one down.
+	it('does nothing when asked to disconnect a node that is not an entry', async () => {
+		const { tree, disconnect } = createTree();
+		await tree.refresh();
+		await tree.expand(ENTRY_ID);
+
+		await tree.disconnectEntry(DTO_ID);
+		await tree.disconnectEntry('entry:no-such-profile');
+
+		expect(disconnect).not.toHaveBeenCalled();
 	});
 
 	it('drops the loaded subtree once the connection closes', async () => {

--- a/src/vs/workbench/services/positronDataConnections/browser/positronDataConnectionsService.ts
+++ b/src/vs/workbench/services/positronDataConnections/browser/positronDataConnectionsService.ts
@@ -305,11 +305,11 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 			return;
 		}
 
-		// Close the profile's Data Explorers and its connection. Removing the profile takes its row
+		// Close the profile's connection and its Data Explorers. Removing the profile takes its row
 		// out of the Data Connections panel, so a connection left open here would stay open and
 		// unreachable for the rest of the session. Fire-and-forget: the removal shouldn't wait on the
 		// round trips that close the editors and the channel.
-		void this._closeConnectionAndDataExplorers(id);
+		void this.disconnect(id);
 
 		// Remove the data connection profile.
 		this._profiles.splice(index, 1);
@@ -381,8 +381,9 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 	}
 
 	/**
-	 * Closes the live connection for the given profile (if one exists). Calls disconnect() on
-	 * the underlying handle, releases ext host resources, and removes the instance.
+	 * Closes the live connection for the given profile (if one exists), along with the Data Explorers
+	 * previewed from it. Calls disconnect() on the underlying handle, releases ext host resources, and
+	 * removes the instance.
 	 */
 	async disconnect(profileId: string): Promise<void> {
 		const index = this._instances.findIndex(i => i.profileId === profileId);
@@ -393,11 +394,29 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 		const instance = this._instances[index];
 		this._instances.splice(index, 1);
 
+		// The Data Explorers previewed from the connection close with it, because their backends die
+		// with it: a tab left open would show a grid that errors on the next scroll or filter rather
+		// than any useful data. Read the list while the record below is still intact.
+		const editors = this._openDataExplorers(profileId);
+
 		// The connection is going away, so its previewed datasets are no longer meaningful: the
 		// driver tears their backends down, and a later reconnect mints fresh dataset ids. Any
 		// pending close is moot for the same reason, whichever route brought us here.
 		this._previewedDatasetIds.delete(profileId);
 		this._disconnectWhenUnused.delete(profileId);
+
+		// Closing an editor fires onDidCloseEditor, which drains the pending closes and can land back
+		// here for this same profile. The splice above is what makes that a no-op, so it has to happen
+		// before this await. A failure to close is logged and teardown continues: the instance is
+		// already out of _instances, so bailing out here would leak the handle and leave the entry row
+		// showing a connection nothing can reach.
+		if (editors.length > 0) {
+			try {
+				await this._editorService.closeEditors(editors);
+			} catch (err) {
+				this._logService.error(`[DataConnections] Failed to close Data Explorers for profile ${profileId}: ${err}`);
+			}
+		}
 
 		try {
 			await instance.connectionHandle.disconnect();
@@ -521,19 +540,6 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 		return [...datasetIds].flatMap(datasetId =>
 			this._editorService.findEditors(PositronDataExplorerUri.generate(datasetId))
 		);
-	}
-
-	/**
-	 * Closes the Data Explorers previewed from the given profile's connection, then the connection
-	 * itself. The Data Explorers go first because their backends die with the connection: a tab left
-	 * open would show a grid that errors on the next scroll or filter rather than any useful data.
-	 */
-	private async _closeConnectionAndDataExplorers(profileId: string): Promise<void> {
-		const editors = this._openDataExplorers(profileId);
-		if (editors.length > 0) {
-			await this._editorService.closeEditors(editors);
-		}
-		await this.disconnect(profileId);
 	}
 
 	//#endregion Private Methods

--- a/src/vs/workbench/services/positronDataConnections/common/interfaces/positronDataConnectionsService.ts
+++ b/src/vs/workbench/services/positronDataConnections/common/interfaces/positronDataConnectionsService.ts
@@ -118,6 +118,10 @@ export interface IPositronDataConnectionsService extends IDisposable {
 	 * Closes the live connection for the given profile (if one exists). Calls disconnect() on
 	 * the underlying handle, releases ext host resources, and removes the instance from the
 	 * service. No-op if no instance exists for the profile.
+	 *
+	 * The Data Explorers previewed from the connection close with it: their backends die with the
+	 * connection, so leaving one open would leave a grid that errors on the next scroll or filter.
+	 * Use {@link disconnectWhenUnused} instead to give up a connection without cutting those off.
 	 * @param profileId The data connection profile id to disconnect.
 	 */
 	disconnect(profileId: string): Promise<void>;

--- a/src/vs/workbench/services/positronDataConnections/test/browser/positronDataConnectionsService.vitest.ts
+++ b/src/vs/workbench/services/positronDataConnections/test/browser/positronDataConnectionsService.vitest.ts
@@ -177,6 +177,10 @@ describe('PositronDataConnectionsService', () => {
 	});
 
 	describe('open Data Explorers', () => {
+		// How many times the driver's connection handle has been torn down, so a test can tell a
+		// single teardown from a double one. Reset by connectProfile.
+		let handleDisconnects = 0;
+
 		/**
 		 * Connects 'conn-1' through a driver that opens a Data Explorer per preview, the way a real
 		 * driver does, reporting `datasetIds` in order -- one per preview. An undefined entry stands
@@ -184,6 +188,7 @@ describe('PositronDataConnectionsService', () => {
 		 */
 		async function connectProfile(datasetIds: readonly (string | undefined)[]) {
 			const remainingDatasetIds = [...datasetIds];
+			handleDisconnects = 0;
 			const handle = stubInterface<IDataConnectionHandle>({
 				handle: 1,
 				nodePreview: async () => {
@@ -193,7 +198,7 @@ describe('PositronDataConnectionsService', () => {
 					}
 					return datasetId;
 				},
-				disconnect: async () => { },
+				disconnect: async () => { handleDisconnects++; },
 				release: () => { },
 			});
 			service.driverManager.registerDriver(stubInterface<IDataConnectionDriver>({
@@ -231,15 +236,16 @@ describe('PositronDataConnectionsService', () => {
 			expect(service.countOpenDataExplorers('conn-1')).toBe(0);
 		});
 
-		it('forgets a profile\'s previews once it disconnects', async () => {
+		it('closes and forgets a profile\'s previews when it disconnects', async () => {
 			const instance = await connectProfile(['sqlite:conn-1:table:flights']);
 			await service.previewNode(instance.connectionHandle, 7);
 
 			await service.disconnect('conn-1');
 
-			// The editor outlives the connection, but the connection's record of it does not: a
-			// reconnect mints fresh dataset ids, so the old ones must not carry over.
-			expect(openDatasetIds.size).toBe(1);
+			// The Data Explorer's backend died with the connection, so its tab goes too; the record of
+			// it goes with it, since a reconnect mints fresh dataset ids that must not collide with
+			// the old ones.
+			expect(openDatasetIds.size).toBe(0);
 			expect(service.countOpenDataExplorers('conn-1')).toBe(0);
 		});
 
@@ -310,6 +316,57 @@ describe('PositronDataConnectionsService', () => {
 				service.addUpdateProfile(createProfile('conn-1'));
 
 				expect(() => service.disconnectWhenUnused('conn-1')).not.toThrow();
+			});
+		});
+
+		describe('disconnect', () => {
+			it('closes every Data Explorer previewed from the connection, without waiting for them', async () => {
+				const instance = await connectProfile([
+					'sqlite:conn-1:table:flights',
+					'sqlite:conn-1:table:airports',
+				]);
+				await service.previewNode(instance.connectionHandle, 7);
+				await service.previewNode(instance.connectionHandle, 8);
+
+				await service.disconnect('conn-1');
+
+				// Unlike disconnectWhenUnused, open Data Explorers don't hold the connection up here:
+				// the user asked to disconnect, and their backends die with the connection anyway.
+				expect({
+					openDataExplorers: openDatasetIds.size,
+					connected: service.getInstanceForProfile('conn-1') !== undefined,
+				}).toMatchInlineSnapshot(`
+					{
+					  "connected": false,
+					  "openDataExplorers": 0,
+					}
+				`);
+			});
+
+			it('is a no-op for a profile with no live connection', async () => {
+				service.addUpdateProfile(createProfile('conn-1'));
+
+				await expect(service.disconnect('conn-1')).resolves.toBeUndefined();
+			});
+
+			// The reentrancy guard: closing the editors fires onDidCloseEditor, which drains the
+			// pending-close set. The profile must already look disconnected to that handler, or it
+			// would disconnect the same connection a second time underneath this one.
+			it('disconnects once when a pending close is already waiting on the Data Explorer', async () => {
+				const instance = await connectProfile(['sqlite:conn-1:table:flights']);
+				await service.previewNode(instance.connectionHandle, 7);
+
+				// The tree gave up its use of the connection first (a collapse), leaving the close
+				// waiting on the preview. The user then disconnects outright.
+				service.disconnectWhenUnused('conn-1');
+				await service.disconnect('conn-1');
+
+				expect({ handleDisconnects, openDataExplorers: openDatasetIds.size }).toMatchInlineSnapshot(`
+					{
+					  "handleDisconnects": 1,
+					  "openDataExplorers": 0,
+					}
+				`);
 			});
 		});
 


### PR DESCRIPTION
Fixes #14623

### Summary

Adds a **Disconnect** option to the actions menu for a data connection in the Data Connections panel, reachable both from the `...` button and by right-clicking the row. Disconnecting closes the connection, closes any Data Explorers that were previewed from it, and collapses the row.

Disconnect sits in the bottom group of the menu, alongside Remove. It appears only while the profile has a live connection.

Before this, the only ways to close a connection were to collapse the row -- which intentionally defers the close while Data Explorers previewed from it are still open -- or to remove the profile outright, which is the gap the issue describes.

### Implementation notes

`disconnect()` now closes the Data Explorers previewed from a connection, not just the connection itself. That teardown previously lived on the profile-removal path only, so a connection closed by any other route left its previews behind -- and their backends die with the connection, so a tab left open would show a grid that errors on the next scroll or filter.

`disconnectWhenUnused()` is unchanged and remains the way to give up a connection *without* cutting those off -- that is what collapsing a row does, and it still waits for the last Data Explorer to close before the connection goes.

Two ordering details inside `disconnect()` are load-bearing and commented as such: the instance leaves `_instances` before the `closeEditors()` await, so the `onDidCloseEditor` handler cannot re-enter and tear the same handle down twice; and a failure to close an editor is logged rather than propagated, so the handle is still released instead of leaking behind a row that shows a connection nothing can reach.

### Screenshot

<img width="163" height="215" alt="Disconnect" src="https://github.com/user-attachments/assets/5c2ae338-d594-4054-a7c5-3d36019a31cc" />

### Release Notes

#### New Features

- Added a Disconnect option to the Data Connections context menu, which closes the connection and any Data Explorers opened from it (#14623)

#### Bug Fixes

- N/A

### Validation Steps

@:connections @:data-explorer

Unit coverage is in `dataConnectionEntryRow.vitest.tsx` (which entries the menu offers, and that only Remove is destructive), `dataConnectionsTreeInstance.vitest.ts` (disconnect closes the connection, collapses the row, and does not route through the deferred-close path), and `positronDataConnectionsService.vitest.ts` (the previews close and are forgotten, and a pending deferred close cannot cause a double teardown). Run them with:

```
npx vitest run src/vs/workbench/contrib/positronDataConnections/test/browser src/vs/workbench/services/positronDataConnections/test/browser
```

Manually, in the Data Connections panel:

1. Create and expand a connection (SQLite is the quickest), then double-click a table to open it in the Data Explorer.
2. Right-click the connection row -- or click its `...` button -- and choose **Disconnect**.
3. Verify the Data Explorer tab closes, the row collapses, and the green connected indicator disappears.
4. Re-expand the row and verify it reconnects and the tree repopulates.
5. Verify **Disconnect** is absent from the menu for a saved connection that is not currently connected, and that **Remove** is still the only red item and still prompts for confirmation.

Then confirm collapsing still behaves as before:

6. Expand a connection, open a table in the Data Explorer, then collapse the row.
7. Verify the connected indicator stays lit and the Data Explorer keeps working (scroll it, apply a filter).
8. Close that Data Explorer tab and verify the connection then closes on its own.
