### PR TITLE
Add a header with the Positron badge and a Help button to the welcome page

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -794,6 +794,7 @@
 		"--vscode-positronWelcome-environmentSetupTitleHoverBackground",
 		"--vscode-positronWelcome-environmentSetupWarningIcon",
 		"--vscode-positronWelcome-foreground",
+		"--vscode-positronWelcome-headerButtonBorder",
 		"--vscode-positronWelcome-hoverBackground",
 		"--vscode-positronWelcome-secondaryForeground",
 		"--vscode-problemsErrorIcon-foreground",

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/environmentHealthSection.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/environmentHealthSection.css
@@ -44,10 +44,28 @@
 	background-color: var(--vscode-positronWelcome-environmentSetupTitleBackground);
 	color: var(--vscode-positronWelcome-environmentSetupTitleForeground);
 	display: flex;
+	flex-wrap: wrap;
 	gap: 8px;
 	padding: 8px 16px;
 	/* The progress line is positioned against this. */
 	position: relative;
+}
+
+/*
+ * The recheck and settings buttons move as a pair: at the card's narrowest
+ * widths there is not enough room beside the title for both, and wrapping
+ * them individually would strand one button alone on its own line. This
+ * wraps the pair below the title instead. No horizontal alignment is set
+ * here: the title's `flex: 1 1 auto` already grows to fill the row and
+ * pushes this flush right when they share it with the title, and leaving
+ * this at the flex default keeps it flush left, under the title's text,
+ * once it wraps onto its own row.
+ */
+.positron-welcome-page-environment-setup .environment-health-header-buttons {
+	align-items: center;
+	display: flex;
+	flex: 0 0 auto;
+	gap: 8px;
 }
 
 /* An h3 for structure only; the button inside it is what you see. */

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/environmentHealthSection.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/environmentHealthSection.css
@@ -148,22 +148,30 @@
 .positron-welcome-page-environment-setup .environment-health-item-main {
 	align-items: flex-start;
 	display: flex;
+	gap: 8px;
+}
+
+.positron-welcome-page-environment-setup .environment-health-item-content {
+	display: flex;
+	flex-direction: column;
+	flex: 1 1 auto;
+	gap: 4px;
+	min-width: 0;
+}
+
+.positron-welcome-page-environment-setup .environment-health-item-summary-row {
+	align-items: flex-start;
+	display: flex;
 	flex-wrap: wrap;
 	gap: 8px;
 }
 
-/*
- * Nothing sits beside the detail, so it takes the full width rather than
- * inheriting the column the summary shares with the fix button. Indented to
- * line up under the summary, past the status icon.
- */
 .positron-welcome-page-environment-setup .environment-health-item-secondary {
 	/*
 	 * A detail often carries a file path, which has nothing to break on. Without
 	 * this it runs past the edge of the card instead of wrapping.
 	 */
 	overflow-wrap: anywhere;
-	padding-left: 24px;
 }
 
 /* Divides the checks from each other and from the summary line above them. */

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/environmentHealthSection.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/environmentHealthSection.css
@@ -148,6 +148,7 @@
 .positron-welcome-page-environment-setup .environment-health-item-main {
 	align-items: flex-start;
 	display: flex;
+	flex-wrap: wrap;
 	gap: 8px;
 }
 
@@ -171,9 +172,17 @@
 }
 
 .positron-welcome-page-environment-setup .environment-health-item-summary {
-	flex: 1 1 auto;
+	/*
+	 * 20ch is how much of this the row would like to keep beside the fix
+	 * button (see `flex-wrap` above): below that, the button drops to its
+	 * own line rather than squeezing both into an unreadable sliver. It is
+	 * the preferred size, not a floor -- `min-width: 0` still lets this
+	 * shrink narrower once even that is more than the row has, so a card
+	 * too small for 20ch wraps the text onto more lines instead of
+	 * overflowing the row.
+	 */
+	flex: 1 1 20ch;
 	line-height: var(--_item-line-height);
-	/* Lets the text wrap rather than force the row wider than the card. */
 	min-width: 0;
 }
 
@@ -262,12 +271,18 @@
 		 * ellipsis to apply to.
 		 */
 		display: inline-block;
-		/* Takes the width its label needs; the text beside it reflows. */
+		/*
+		 * Takes the width its label needs, up to the whole row: when there is
+		 * room beside the summary it shares the line, and once there is not
+		 * (see the summary's own `flex-basis`) it wraps below and can use
+		 * the full width there. Either way this caps it so a pathological
+		 * label ellipsizes instead of overflowing.
+		 */
 		flex: 0 0 auto;
 		font-size: 12px;
 		line-height: 16px;
 		margin: 0;
-		max-width: 50%;
+		max-width: 100%;
 		overflow: hidden;
 		padding: 4px 8px;
 		text-align: center;

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/environmentHealthSection.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/environmentHealthSection.css
@@ -50,7 +50,7 @@
 	position: relative;
 }
 
-/* An h4 for structure only; the button inside it is what you see. */
+/* An h3 for structure only; the button inside it is what you see. */
 .positron-welcome-page-environment-setup .environment-health-group-heading {
 	margin: 0;
 }
@@ -86,10 +86,30 @@
 	flex: 1 1 auto;
 }
 
-/* Right-aligned, taking whatever width the language name does not need. */
+/*
+ * gettingStarted.css sets every h2 in the container to 1.5em, weight 400 and
+ * line-height: initial, so this selector repeats the container chain to win on
+ * specificity and keep the title reading like the rest of the card.
+ */
+.monaco-workbench .part.editor > .content .gettingStartedContainer
+.gettingStartedSlideCategories
+.positron-welcome-page-environment-setup .environment-health-header-title {
+	font-size: 13px;
+	font-weight: 600;
+	line-height: var(--_line-height);
+	margin: 0;
+}
+
+/*
+ * Right-aligned, taking whatever width the language name does not need. Sets
+ * its own font-size and font-weight because it now sits inside the group's h3
+ * and would otherwise inherit the browser's bold, larger default heading style.
+ */
 .positron-welcome-page-environment-setup .environment-health-group-summary {
 	color: var(--vscode-descriptionForeground);
 	flex: 1 1 auto;
+	font-size: 13px;
+	font-weight: normal;
 	min-width: 0;
 	overflow: hidden;
 	text-align: right;

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/environmentHealthSection.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/environmentHealthSection.css
@@ -359,6 +359,33 @@
 	}
 
 	/*
+	 * The row spans the card's full width, and the card clips overflow to keep
+	 * its rounded corners. The button's default focus ring draws outside its
+	 * edge with no offset, so on this row that means straddling the clipped
+	 * boundary -- the left and right sides disappear, only top and bottom
+	 * survive. A negative offset pulls the ring inside the row instead. The
+	 * radius resets to match the row's own square corners, not the button's.
+	 */
+	& .environment-health-group-header:focus-visible {
+		border-radius: 0;
+		outline-offset: -1px;
+	}
+
+	/*
+	 * The last language row's bottom corners are not actually square when it is
+	 * collapsed: the card clips them to its own radius (6px, minus the 1px
+	 * border) because nothing renders below to cover the curve. Expanded, the
+	 * row is never last -- its checks list sits below it -- so it keeps the
+	 * square ring above. This selector isolates exactly that collapsed-and-last
+	 * case: the heading is only its group's last child when there is no list
+	 * after it.
+	 */
+	& .environment-health-group:last-child > .environment-health-group-heading:last-child .environment-health-group-header:focus-visible {
+		border-bottom-left-radius: 5px;
+		border-bottom-right-radius: 5px;
+	}
+
+	/*
 	 * Styled as a link although it is a button, because it navigates to the
 	 * Settings editor rather than changing anything on the page.
 	 */

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/environmentHealthSection.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/environmentHealthSection.css
@@ -345,6 +345,16 @@
 		 */
 		border: none;
 		border-top: 1px solid var(--vscode-positronWelcome-environmentSetupBorder);
+		/*
+		 * This row is a button when its language has a body to expand, and a
+		 * plain div when it does not (an unavailable or errored language, which
+		 * says all it has to say in the header). A button's padding is included
+		 * in its width by default; a div's is not, which pushed the div variant
+		 * 32px past the card's edge and hard-clipped the summary text against
+		 * the card's own `overflow: hidden`. Setting this explicitly keeps both
+		 * variants the same width.
+		 */
+		box-sizing: border-box;
 		color: inherit;
 		display: flex;
 		font-size: inherit;

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/environmentHealthSection.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/environmentHealthSection.tsx
@@ -87,37 +87,43 @@ export const EnvironmentHealthSection = ({ environmentHealthService, expandedByL
 				<h2 className='environment-health-header-title' id={titleId}>
 					{localize('positron.welcome.environmentSetupTitle', "Environment setup")}
 				</h2>
-				{!allChecksDisabled &&
-					<Button
-						ariaDisabled={busy}
-						ariaLabel={localize('positron.welcome.environmentSetupCheckRerunTooltip', "Run the environment setup checks again")}
-						className='environment-health-header-button'
-						hoverManager={hoverManager}
-						// While anything is running this says why it cannot be pressed.
-						// A control that looks pressable and silently does nothing is
-						// worse than one that explains itself.
-						tooltip={busy
-							? localize('positron.welcome.environmentSetupCheckRerunBusyTooltip', "Waiting for the current check to finish")
-							: localize('positron.welcome.environmentSetupCheckRerunTooltip', "Run the environment setup checks again")}
-						onPressed={() => languages.forEach(language => environmentHealthService.rerunCheckForLanguage(language.language))}
-					>
-						<span aria-hidden='true' className='codicon codicon-refresh' />
-					</Button>}
 				{/*
-					An icon beside the recheck control rather than a link under the card.
-					The link read as a call to action for turning the feature off, which
-					put it in competition with the fix buttons.
+					Grouped so the pair moves as a unit: see environmentHealthSection.css
+					for how the header wraps them below the title, rather than squeezing
+					both buttons into whatever sliver is left beside the wrapping text.
 				*/}
 				{!allChecksDisabled &&
-					<Button
-						ariaLabel={localize('positron.welcome.environmentSetupSettingsTooltip', "Choose which languages are checked")}
-						className='environment-health-header-button'
-						hoverManager={hoverManager}
-						tooltip={localize('positron.welcome.environmentSetupSettingsTooltip', "Choose which languages are checked")}
-						onPressed={openSetting}
-					>
-						<span aria-hidden='true' className='codicon codicon-gear' />
-					</Button>}
+					<div className='environment-health-header-buttons'>
+						<Button
+							ariaDisabled={busy}
+							ariaLabel={localize('positron.welcome.environmentSetupCheckRerunTooltip', "Run the environment setup checks again")}
+							className='environment-health-header-button'
+							hoverManager={hoverManager}
+							// While anything is running this says why it cannot be pressed.
+							// A control that looks pressable and silently does nothing is
+							// worse than one that explains itself.
+							tooltip={busy
+								? localize('positron.welcome.environmentSetupCheckRerunBusyTooltip', "Waiting for the current check to finish")
+								: localize('positron.welcome.environmentSetupCheckRerunTooltip', "Run the environment setup checks again")}
+							onPressed={() => languages.forEach(language => environmentHealthService.rerunCheckForLanguage(language.language))}
+						>
+							<span aria-hidden='true' className='codicon codicon-refresh' />
+						</Button>
+						{/*
+							An icon beside the recheck control rather than a link under the
+							card. The link read as a call to action for turning the feature
+							off, which put it in competition with the fix buttons.
+						*/}
+						<Button
+							ariaLabel={localize('positron.welcome.environmentSetupSettingsTooltip', "Choose which languages are checked")}
+							className='environment-health-header-button'
+							hoverManager={hoverManager}
+							tooltip={localize('positron.welcome.environmentSetupSettingsTooltip', "Choose which languages are checked")}
+							onPressed={openSetting}
+						>
+							<span aria-hidden='true' className='codicon codicon-gear' />
+						</Button>
+					</div>}
 				{/*
 					Sits on the header's bottom edge, outside the text flow, so starting
 					a check cannot shift anything below it. A spinner inside the button

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/environmentHealthSection.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/environmentHealthSection.tsx
@@ -145,6 +145,7 @@ export const EnvironmentHealthSection = ({ environmentHealthService, expandedByL
 						busy={environmentHealthService.isBusy(language.language)}
 						expandedByLanguage={expandedByLanguage}
 						health={language}
+						hoverManager={hoverManager}
 						onRunFix={fix => environmentHealthService.runFix(language.language, fix)}
 					/>)}
 		</section>

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/environmentHealthSection.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/environmentHealthSection.tsx
@@ -84,9 +84,9 @@ export const EnvironmentHealthSection = ({ environmentHealthService, expandedByL
 	return (
 		<section aria-labelledby={titleId} className='positron-welcome-page-environment-setup'>
 			<div className='environment-health-header'>
-				<h3 className='environment-health-header-title' id={titleId}>
+				<h2 className='environment-health-header-title' id={titleId}>
 					{localize('positron.welcome.environmentSetupTitle', "Environment setup")}
-				</h3>
+				</h2>
 				{!allChecksDisabled &&
 					<Button
 						ariaDisabled={busy}

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/healthItemRow.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/healthItemRow.tsx
@@ -62,29 +62,33 @@ export const HealthItemRow = ({ item, busy, hoverManager, onRunFix }: HealthItem
 			<div className='environment-health-item-main'>
 				<span aria-hidden='true' className={`environment-health-item-icon environment-health-item-icon-${item.status} codicon ${status.codicon}`} />
 				<span className='visually-hidden'>{status.label}</span>
-				<span className='environment-health-item-summary'>{item.summary}</span>
-				{item.fix &&
-					<Button
-						ariaDisabled={busy}
-						className='environment-health-item-fix'
-						hoverManager={hoverManager}
-						tooltip={item.fix.label}
-						onPressed={() => onRunFix(item.fix!)}
-					>
-						{item.fix.label}
-					</Button>}
+				<div className='environment-health-item-content'>
+					<div className='environment-health-item-summary-row'>
+						<span className='environment-health-item-summary'>{item.summary}</span>
+						{item.fix &&
+							<Button
+								ariaDisabled={busy}
+								className='environment-health-item-fix'
+								hoverManager={hoverManager}
+								tooltip={item.fix.label}
+								onPressed={() => onRunFix(item.fix!)}
+							>
+								{item.fix.label}
+							</Button>}
+					</div>
+					{(item.detail || item.learnMoreUrl) &&
+						<div className='environment-health-item-secondary'>
+							{item.detail && <p className='environment-health-item-detail'>{item.detail}</p>}
+							{item.learnMoreUrl &&
+								<a
+									href={item.learnMoreUrl}
+									onClick={openLearnMore}
+								>
+									{localize('positron.welcome.environmentSetupLearnMore', "Learn more")}
+								</a>}
+						</div>}
+				</div>
 			</div>
-			{(item.detail || item.learnMoreUrl) &&
-				<div className='environment-health-item-secondary'>
-					{item.detail && <p className='environment-health-item-detail'>{item.detail}</p>}
-					{item.learnMoreUrl &&
-						<a
-							href={item.learnMoreUrl}
-							onClick={openLearnMore}
-						>
-							{localize('positron.welcome.environmentSetupLearnMore', "Learn more")}
-						</a>}
-				</div>}
 		</li>
 	);
 };

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/healthItemRow.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/healthItemRow.tsx
@@ -14,6 +14,7 @@ import { localize } from '../../../../../../nls.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { Button } from '../../../../../../base/browser/ui/positronComponents/button/button.js';
 import { usePositronReactServicesContext } from '../../../../../../base/browser/positronReactRendererContext.js';
+import { IHoverManager } from '../../../../../../platform/hover/browser/hoverManager.js';
 import { HealthItemStatus, IHealthItem, IHealthItemFix } from '../environmentHealth.js';
 
 /** Icon and screen reader text for each outcome. */
@@ -32,6 +33,8 @@ export interface HealthItemRowProps {
 	 * second environment.
 	 */
 	readonly busy: boolean;
+	/** See EnvironmentHealthSection: one hover manager per welcome page. */
+	readonly hoverManager?: IHoverManager;
 	readonly onRunFix: (fix: IHealthItemFix) => void;
 }
 
@@ -40,7 +43,7 @@ export interface HealthItemRowProps {
  * @param props A HealthItemRowProps that contains the component properties.
  * @returns The rendered component.
  */
-export const HealthItemRow = ({ item, busy, onRunFix }: HealthItemRowProps) => {
+export const HealthItemRow = ({ item, busy, hoverManager, onRunFix }: HealthItemRowProps) => {
 	const services = usePositronReactServicesContext();
 	const status = STATUS_PRESENTATION[item.status];
 
@@ -61,7 +64,13 @@ export const HealthItemRow = ({ item, busy, onRunFix }: HealthItemRowProps) => {
 				<span className='visually-hidden'>{status.label}</span>
 				<span className='environment-health-item-summary'>{item.summary}</span>
 				{item.fix &&
-					<Button ariaDisabled={busy} className='environment-health-item-fix' onPressed={() => onRunFix(item.fix!)}>
+					<Button
+						ariaDisabled={busy}
+						className='environment-health-item-fix'
+						hoverManager={hoverManager}
+						tooltip={item.fix.label}
+						onPressed={() => onRunFix(item.fix!)}
+					>
 						{item.fix.label}
 					</Button>}
 			</div>

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/languageHealthGroup.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/languageHealthGroup.tsx
@@ -11,6 +11,7 @@ import { localize } from '../../../../../../nls.js';
 import { status } from '../../../../../../base/browser/ui/aria/aria.js';
 import { Button } from '../../../../../../base/browser/ui/positronComponents/button/button.js';
 import { getIconClassesForLanguageId } from '../../../../../../editor/common/services/getIconClasses.js';
+import { IHoverManager } from '../../../../../../platform/hover/browser/hoverManager.js';
 import { EnvironmentHealthLanguage, IHealthItemFix } from '../environmentHealth.js';
 import { IEnvironmentHealthEntry } from '../environmentHealthService.js';
 import { HealthItemRow } from './healthItemRow.js';
@@ -70,6 +71,8 @@ export interface LanguageHealthGroupProps {
 	readonly expandedByLanguage: Map<EnvironmentHealthLanguage, boolean>;
 	/** Whether this language has a check or a fix running. */
 	readonly busy: boolean;
+	/** See EnvironmentHealthSection: one hover manager per welcome page. */
+	readonly hoverManager?: IHoverManager;
 	readonly onRunFix: (fix: IHealthItemFix) => void;
 }
 
@@ -79,7 +82,7 @@ export interface LanguageHealthGroupProps {
  * @param props A LanguageHealthGroupProps that contains the component properties.
  * @returns The rendered component.
  */
-export const LanguageHealthGroup = ({ health, expandedByLanguage, busy, onRunFix }: LanguageHealthGroupProps) => {
+export const LanguageHealthGroup = ({ health, expandedByLanguage, busy, hoverManager, onRunFix }: LanguageHealthGroupProps) => {
 	const headerId = useId();
 	// Undefined until the user decides for themselves, so a group opens itself
 	// when its results land with something to act on, and stays where the user
@@ -92,6 +95,19 @@ export const LanguageHealthGroup = ({ health, expandedByLanguage, busy, onRunFix
 	};
 
 	const summary = summaryText(health);
+
+	// The summary is right-aligned and ellipsized, so a long one loses its tail
+	// with no way to read the rest. The header wraps a `<Button>` when it has a
+	// body to expand, and that already knows how to show `tooltip` on hover; a
+	// language with no body renders a plain `<div>` instead, which needs its
+	// own hover wiring for the same effect.
+	const headerRef = useRef<HTMLDivElement>(undefined!);
+	const [headerHovering, setHeaderHovering] = useState(false);
+	useEffect(() => {
+		if (headerHovering) {
+			hoverManager?.showHover(headerRef.current, summary);
+		}
+	}, [headerHovering, hoverManager, summary]);
 
 	// `status` speaks through the workbench's polite live region. In an effect
 	// because results land seconds after the page paints, and it speaks the line
@@ -149,13 +165,32 @@ export const LanguageHealthGroup = ({ health, expandedByLanguage, busy, onRunFix
 					? <Button
 						ariaExpanded={expanded}
 						className='environment-health-group-header'
+						hoverManager={hoverManager}
 						id={headerId}
+						tooltip={summary}
 						onPressed={toggle}
 					>
 						{headerContent}
 						<span aria-hidden='true' className={`environment-health-group-chevron codicon codicon-chevron-${expanded ? 'down' : 'right'}`} />
 					</Button>
-					: <div className='environment-health-group-header' id={headerId}>{headerContent}</div>}
+					/*
+					 * This div only pops up a tooltip on mouse hover. It does nothing
+					 * when clicked, so someone who can't use a mouse loses nothing, and
+					 * a screen reader already reads the full text without it.
+					 */
+					// eslint-disable-next-line jsx-a11y/no-static-element-interactions
+					: <div
+						ref={headerRef}
+						className='environment-health-group-header'
+						id={headerId}
+						onMouseEnter={() => setHeaderHovering(true)}
+						onMouseLeave={() => {
+							setHeaderHovering(false);
+							hoverManager?.hideHover();
+						}}
+					>
+						{headerContent}
+					</div>}
 			</h3>
 			{hasBody(health) && expanded && body()}
 		</div>

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/languageHealthGroup.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/languageHealthGroup.tsx
@@ -144,7 +144,7 @@ export const LanguageHealthGroup = ({ health, expandedByLanguage, busy, onRunFix
 				button's content model has no room for a heading, and this is the
 				shape assistive technology expects from a disclosure.
 			*/}
-			<h4 className='environment-health-group-heading'>
+			<h3 className='environment-health-group-heading'>
 				{hasBody(health)
 					? <Button
 						ariaExpanded={expanded}
@@ -156,7 +156,7 @@ export const LanguageHealthGroup = ({ health, expandedByLanguage, busy, onRunFix
 						<span aria-hidden='true' className={`environment-health-group-chevron codicon codicon-chevron-${expanded ? 'down' : 'right'}`} />
 					</Button>
 					: <div className='environment-health-group-header' id={headerId}>{headerContent}</div>}
-			</h4>
+			</h3>
 			{hasBody(health) && expanded && body()}
 		</div>
 	);

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/languageHealthGroup.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/languageHealthGroup.tsx
@@ -95,6 +95,11 @@ export const LanguageHealthGroup = ({ health, expandedByLanguage, busy, hoverMan
 	};
 
 	const summary = summaryText(health);
+	// Some summaries read fine alone ("You have successfully set up Python"),
+	// but others don't name the language ("3 of 5 checks passed"), so the
+	// tooltip leads with the label every time rather than only when the
+	// summary happens to need it.
+	const tooltip = summary && `${health.label}: ${summary}`;
 
 	// The summary is right-aligned and ellipsized, so a long one loses its tail
 	// with no way to read the rest. The header wraps a `<Button>` when it has a
@@ -105,9 +110,9 @@ export const LanguageHealthGroup = ({ health, expandedByLanguage, busy, hoverMan
 	const [headerHovering, setHeaderHovering] = useState(false);
 	useEffect(() => {
 		if (headerHovering) {
-			hoverManager?.showHover(headerRef.current, summary);
+			hoverManager?.showHover(headerRef.current, tooltip);
 		}
-	}, [headerHovering, hoverManager, summary]);
+	}, [headerHovering, hoverManager, tooltip]);
 
 	// `status` speaks through the workbench's polite live region. In an effect
 	// because results land seconds after the page paints, and it speaks the line
@@ -167,7 +172,7 @@ export const LanguageHealthGroup = ({ health, expandedByLanguage, busy, hoverMan
 						className='environment-health-group-header'
 						hoverManager={hoverManager}
 						id={headerId}
-						tooltip={summary}
+						tooltip={tooltip}
 						onPressed={toggle}
 					>
 						{headerContent}

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/languageHealthGroup.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/languageHealthGroup.tsx
@@ -109,10 +109,22 @@ export const LanguageHealthGroup = ({ health, expandedByLanguage, busy, hoverMan
 	const headerRef = useRef<HTMLDivElement>(undefined!);
 	const [headerHovering, setHeaderHovering] = useState(false);
 	useEffect(() => {
-		if (headerHovering) {
+		if (headerHovering && headerRef.current) {
 			hoverManager?.showHover(headerRef.current, tooltip);
 		}
 	}, [headerHovering, hoverManager, tooltip]);
+
+	// A result can land, or a recheck can fail, while the mouse is still over
+	// the header. Either swaps the div for a button or back again with no
+	// onMouseLeave to clear the flag, so this resets it on the swap rather than
+	// leaving a stale "hovering" flag pointed at whichever element shows up next.
+	const previousHasBody = useRef(hasBody(health));
+	useEffect(() => {
+		if (previousHasBody.current !== hasBody(health)) {
+			previousHasBody.current = hasBody(health);
+			setHeaderHovering(false);
+		}
+	}, [health]);
 
 	// `status` speaks through the workbench's polite live region. In an effect
 	// because results land seconds after the page paints, and it speaks the line

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/languageHealthGroup.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/languageHealthGroup.tsx
@@ -137,7 +137,7 @@ export const LanguageHealthGroup = ({ health, expandedByLanguage, busy, hoverMan
 		return (
 			<ul className='environment-health-item-list'>
 				{health.state.result.items.map(i =>
-					<HealthItemRow key={i.id} busy={busy} item={i} onRunFix={onRunFix} />)}
+					<HealthItemRow key={i.id} busy={busy} hoverManager={hoverManager} item={i} onRunFix={onRunFix} />)}
 			</ul>
 		);
 	};

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/walkthroughBanner.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/walkthroughBanner.css
@@ -52,6 +52,19 @@
 	text-transform: uppercase;
 }
 
+/*
+ * gettingStarted.css sets every h2 in the container to 1.5em, weight 400 and
+ * line-height: initial, so this selector repeats the container chain to win on
+ * specificity and keep the label reading like the small caps it is designed as.
+ */
+.monaco-workbench .part.editor > .content .gettingStartedContainer
+.positron-welcome-page-walkthrough-banner .walkthrough-banner-label {
+	font-size: 11px;
+	font-weight: 600;
+	line-height: normal;
+	margin: 0;
+}
+
 .positron-welcome-page-walkthrough-banner .walkthrough-banner-description {
 	margin: 0;
 }

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/walkthroughBanner.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/walkthroughBanner.tsx
@@ -52,9 +52,9 @@ export const WalkthroughBanner = () => {
 		<section aria-labelledby={headingId} className='positron-welcome-page-walkthrough-banner'>
 			<span aria-hidden='true' className='walkthrough-banner-icon codicon codicon-mortar-board' />
 			<div className='walkthrough-banner-text'>
-				<h3 className='walkthrough-banner-label' id={headingId}>
+				<h2 className='walkthrough-banner-label' id={headingId}>
 					{localize('positron.welcome.learn', "Learn")}
-				</h3>
+				</h2>
 				<p className='walkthrough-banner-description'>
 					{localize(
 						'positron.welcome.walkthroughBannerDescription',

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/welcomeHeader.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/welcomeHeader.css
@@ -1,0 +1,112 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/*
+ * The badge and name on the left, the Help button on the right. They swap to
+ * stacked rows once there is no room for both, which is what flex-wrap buys:
+ * the button drops below the name rather than crushing it.
+ */
+.positron-welcome-page-header {
+	align-items: center;
+	column-gap: 24px;
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	/* Only seen once the button has wrapped onto its own row. */
+	row-gap: 12px;
+}
+
+/* The badge and the two lines of text move together as one unit. */
+.positron-welcome-page-header .welcome-header-brand {
+	align-items: center;
+	column-gap: 12px;
+	display: flex;
+	/* Lets the text wrap on a narrow page instead of pushing past the edge. */
+	min-width: 0;
+}
+
+/*
+ * The product badge. One file for both themes: it is a solid colored tile, so
+ * it reads on a light and a dark background alike.
+ */
+.positron-welcome-page-header .welcome-header-icon {
+	background-image: url('../../../../../browser/media/positron-icon.svg');
+	background-position: center;
+	background-repeat: no-repeat;
+	background-size: contain;
+	/* Square, and about as tall as the two lines of text beside it. */
+	flex: 0 0 auto;
+	height: 40px;
+	width: 40px;
+}
+
+.positron-welcome-page-header .welcome-header-text {
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+}
+
+/*
+ * gettingStarted.css sets 2.7em, normal weight and white-space: nowrap on every
+ * h1 in this container, so these rules need that same container chain to win on
+ * specificity rather than reaching for !important. The nowrap in particular has
+ * to go, or the name runs past the edge instead of wrapping.
+ */
+.monaco-workbench .part.editor > .content .gettingStartedContainer
+.gettingStartedSlideCategories
+.positron-welcome-page-header {
+	& .welcome-header-title {
+		font-size: 20px;
+		font-weight: 600;
+		line-height: 26px;
+		margin: 0;
+		padding: 0;
+		white-space: normal;
+	}
+
+	& .welcome-header-tagline {
+		color: var(--vscode-descriptionForeground);
+		font-size: 12px;
+		line-height: 16px;
+		margin: 0;
+	}
+
+	/*
+	 * Restores button styling. gettingStarted.css strips the border, forces
+	 * color: inherit and sets 16px padding on every button in the container.
+	 *
+	 * An outline rather than a fill, following Start Session in the top action
+	 * bar (.action-bar-button.border): no background, a thin border, a 4px
+	 * radius and a 12px label. A filled button here would outweigh the fix
+	 * buttons in the environment setup card, which are the only controls on the
+	 * page worth pressing.
+	 */
+	& .welcome-header-help {
+		align-items: center;
+		background-color: transparent;
+		border: 1px solid var(--vscode-positronWelcome-headerButtonBorder);
+		border-radius: 4px;
+		color: var(--vscode-foreground);
+		column-gap: 6px;
+		display: flex;
+		/* Keeps its label's width; the name beside it is what gives way. */
+		flex: 0 0 auto;
+		font-size: 12px;
+		line-height: 16px;
+		margin: 0;
+		padding: 3px 8px;
+		white-space: nowrap;
+	}
+
+	& .welcome-header-help:hover {
+		background-color: var(--vscode-toolbar-hoverBackground);
+	}
+
+	/* The icon takes its color from the button rather than the container. */
+	& .welcome-header-help-icon.codicon {
+		color: inherit;
+		font-size: 14px;
+	}
+}

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/welcomeHeader.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/welcomeHeader.tsx
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import './welcomeHeader.css';
+
+// Other dependencies.
+import { localize } from '../../../../../../nls.js';
+import { Button } from '../../../../../../base/browser/ui/positronComponents/button/button.js';
+import { usePositronReactServicesContext } from '../../../../../../base/browser/positronReactRendererContext.js';
+import { IProductService } from '../../../../../../platform/product/common/productService.js';
+import type { GettingStartedActionClassification, GettingStartedActionEvent } from '../../gettingStarted.js';
+
+/**
+ * The command the Help view registers to open itself. Reaching the view through
+ * its command rather than through IViewsService keeps this page from depending
+ * on the positronHelp contribution.
+ */
+const OPEN_HELP_COMMAND_ID = 'workbench.action.positron.openHelp';
+
+/**
+ * WelcomeHeader component. The Positron badge and name, and a button that opens
+ * the Help pane.
+ * @returns The rendered component.
+ */
+export const WelcomeHeader = () => {
+	const services = usePositronReactServicesContext();
+	const productName = services.get(IProductService).nameLong;
+
+	const openHelp = () => {
+		services.telemetryService.publicLog2<GettingStartedActionEvent, GettingStartedActionClassification>(
+			'gettingStarted.ActionExecuted',
+			{
+				command: 'welcomeHeaderOpenHelp',
+				argument: undefined,
+				walkthroughId: undefined,
+			});
+
+		services.commandService.executeCommand(OPEN_HELP_COMMAND_ID);
+	};
+
+	// Render.
+	return (
+		<header className='positron-welcome-page-header'>
+			<div className='welcome-header-brand'>
+				{/*
+					Hidden from screen readers because the heading beside it already
+					says the product name.
+				*/}
+				<div aria-hidden='true' className='welcome-header-icon' />
+				<div className='welcome-header-text'>
+					{/*
+						The page's first heading. The cards below start at h3, so this
+						gives the welcome page a top level for a screen reader to land on.
+					*/}
+					<h1 className='welcome-header-title'>
+						{localize('positron.welcome.title', "Welcome to {0}", productName)}
+					</h1>
+					<p className='welcome-header-tagline'>
+						{localize('positron.welcome.tagline', "an IDE for data science from Posit")}
+					</p>
+				</div>
+			</div>
+			<Button className='welcome-header-help' onPressed={openHelp}>
+				<span aria-hidden='true' className='welcome-header-help-icon codicon codicon-question' />
+				{localize('positron.welcome.help', "Help")}
+			</Button>
+		</header>
+	);
+};

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/welcomeHeader.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/welcomeHeader.tsx
@@ -43,7 +43,7 @@ export const WelcomeHeader = () => {
 
 	// Render.
 	return (
-		<header className='positron-welcome-page-header'>
+		<div className='positron-welcome-page-header'>
 			<div className='welcome-header-brand'>
 				{/*
 					Hidden from screen readers because the heading beside it already
@@ -52,7 +52,7 @@ export const WelcomeHeader = () => {
 				<div aria-hidden='true' className='welcome-header-icon' />
 				<div className='welcome-header-text'>
 					{/*
-						The page's first heading. The cards below start at h3, so this
+						The page's first heading. The cards below start at h2, so this
 						gives the welcome page a top level for a screen reader to land on.
 					*/}
 					<h1 className='welcome-header-title'>
@@ -67,6 +67,6 @@ export const WelcomeHeader = () => {
 				<span aria-hidden='true' className='welcome-header-help-icon codicon codicon-question' />
 				{localize('positron.welcome.help', "Help")}
 			</Button>
-		</header>
+		</div>
 	);
 };

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/positronWelcomePage.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/positronWelcomePage.tsx
@@ -14,6 +14,7 @@ import { PositronReactRenderer } from '../../../../../base/browser/positronReact
 import { DomSlot } from './components/domSlot.js';
 import { EnvironmentHealthSection } from './components/environmentHealthSection.js';
 import { WalkthroughBanner } from './components/walkthroughBanner.js';
+import { WelcomeHeader } from './components/welcomeHeader.js';
 import { EnvironmentHealthLanguage } from './environmentHealth.js';
 import { IEnvironmentHealthService } from './environmentHealthService.js';
 
@@ -81,6 +82,7 @@ export const PositronWelcomePage = (props: PositronWelcomePageProps) => {
 	// layout lives on one element instead of two nested ones.
 	return (
 		<>
+			<WelcomeHeader />
 			<EnvironmentHealthSection environmentHealthService={props.environmentHealthService} expandedByLanguage={props.expandedByLanguage} />
 			<WalkthroughBanner />
 			<DomSlot element={props.recentList} />

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePageColors.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePageColors.ts
@@ -22,6 +22,14 @@ import { welcomePageTileBackground, welcomePageTileBorder } from './gettingStart
 // Colors for the redesigned welcome page, behind the `welcomePage.experimental`
 // setting.
 
+// The Help button in the header is an outline: no fill, so it stays quieter than
+// the fix buttons in the environment setup card, which are the only controls on
+// the page worth pressing. Sharing the tile border keeps it in line with the card
+// and the banner below it.
+export const POSITRON_WELCOME_HEADER_BUTTON_BORDER = registerColor('positronWelcome.headerButtonBorder',
+	welcomePageTileBorder,
+	localize('positronWelcome.headerButtonBorder', "Border color of the Help button in the header of the Positron welcome page."));
+
 // The default follows the tiles on the original page, which every theme already
 // tunes, so the banner looks native in a theme nobody here has seen. Positron's
 // own light theme paints it a pale blue instead; a theme wanting that look sets

--- a/src/vs/workbench/contrib/welcomeGettingStarted/test/browser/positronWelcomePage.vitest.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/test/browser/positronWelcomePage.vitest.tsx
@@ -72,7 +72,7 @@ describe('PositronWelcomePage', () => {
 		.build();
 	const rtl = setupRTLRenderer(() => ctx.reactServices);
 
-	it('renders the banner, then the recent list, the connect action and the footer', () => {
+	it('renders the header, the banner, then the recent list, the connect action and the footer', () => {
 		const { recentList, connectAction, footer } = slottedDom();
 		const { container } = rtl.render(
 			<PositronWelcomePage
@@ -84,7 +84,7 @@ describe('PositronWelcomePage', () => {
 			/>
 		);
 
-		expect(container).toHaveTextContent(/Environment setup.*Learn.*Recent.*Connect to\.\.\..*Show welcome page on startup/);
+		expect(container).toHaveTextContent(/Welcome to .*Help.*Environment setup.*Learn.*Recent.*Connect to\.\.\..*Show welcome page on startup/);
 	});
 
 	it('omits the connect action when there is none, as on web', () => {

--- a/src/vs/workbench/contrib/welcomeGettingStarted/test/browser/welcomeHeader.vitest.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/test/browser/welcomeHeader.vitest.tsx
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
+import { WelcomeHeader } from '../../browser/positronWelcomePage/components/welcomeHeader.js';
+
+describe('WelcomeHeader', () => {
+	const executeCommand = vi.fn();
+	const publicLog2 = vi.fn();
+
+	const ctx = createTestContainer()
+		.withReactServices()
+		.stub(ICommandService, { executeCommand })
+		.stub(ITelemetryService, { publicLog2 })
+		// A build-variant name, so a hardcoded "Positron" would fail this.
+		.stub(IProductService, { nameLong: 'Positron Dev' })
+		.build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
+
+	it('greets with the product name, and gives the page its top heading', () => {
+		rtl.render(<WelcomeHeader />);
+
+		expect(screen.getByRole('heading', { level: 1, name: 'Welcome to Positron Dev' })).toBeInTheDocument();
+	});
+
+	it('says what Positron is', () => {
+		rtl.render(<WelcomeHeader />);
+
+		expect(screen.getByText('an IDE for data science from Posit')).toBeInTheDocument();
+	});
+
+	it('opens the help pane and logs the press', async () => {
+		const user = userEvent.setup();
+		rtl.render(<WelcomeHeader />);
+
+		await user.click(screen.getByRole('button', { name: 'Help' }));
+
+		expect(executeCommand).toHaveBeenCalledWith('workbench.action.positron.openHelp');
+		expect(publicLog2).toHaveBeenCalledWith('gettingStarted.ActionExecuted', {
+			command: 'welcomeHeaderOpenHelp',
+			argument: undefined,
+			walkthroughId: undefined,
+		});
+	});
+});


### PR DESCRIPTION
Addresses #14934

Stacked on https://github.com/posit-dev/positron/pull/15564

This PR adds the header to the new welcome page: the Positron badge, the product name and tagline, and a Help button.

A primer on the logo assets, because the choice here is not obvious:

- `positron-header.svg` is the SVG the original welcome page shows. It contains the positron icon + product name + tagline
- `positron-icon.svg` is the positron icon on its own.

I started with the original SVG but found that it was hard to scale so it looked good next to the help button. I decided to recreate the parts that make the SVG. This is what the welcome page originally did. https://github.com/posit-dev/positron/pull/8118 dropped the HTML text, but only because the SVG contained the same words (keeping both would have printed the name and tagline twice). Using the badge removes the duplication and the reason with it. The original welcome page is untouched and still shows the old SVG.

A few smaller points:

- The name comes from `IProductService`, so a dev build says "Welcome to Positron Dev" rather than claiming to be a release.
- The Help button runs `workbench.action.positron.openHelp`, the command the Help view registers for itself, so the welcome page does not have to depend on the `positronHelp` contribution.

Note: the tagline is now a localizable string rather than baked-in artwork, so it will translate where the SVG never could.

### Screenshots


https://github.com/user-attachments/assets/80eec8b2-96ec-4189-9d00-0ae3efeb9f84



### Release Notes

<!-- Add each release note as a bullet point in the appropriate section below. -->
<!-- Use the format: - Description of the change (#issue-number) -->

#### New Features

- The welcome page shows the Positron badge and name, with a Help button that opens the Help pane. (#14934)

#### Bug Fixes

- N/A

### Validation Steps

@:welcome

SETUP: Run **Preferences: Open User Settings (JSON)** and add `"welcomePage.experimental": true`, then open the welcome page.

1. **The header renders.** The badge, "Welcome to Positron" (or "Welcome to Positron Dev" on a dev build), and the tagline underneath. The Help button sits at the right, level with the middle of the badge.
2. **Press Help.** The Help pane opens in the auxiliary bar. `Cmd/Ctrl+Shift+H` does the same thing.
3. **Tab to the Help button and press Enter.** Same result, and focus is visible on the button.
4. **Switch to a dark theme, then a high contrast theme.** The badge stays legible on every background, and the button's outline stays visible.
5. **Narrow the editor.** The Help button drops onto its own row before anything is crushed, then the name and tagline wrap. Nothing overflows the page at any width.
6. **Turn `welcomePage.experimental` back off.** The original welcome page comes back with its wordmark logo, unchanged.
