### PR TITLE
Allow dataConnections.enabled to be set per workspace

### DIFF
--- a/src/vs/workbench/contrib/positronDataConnections/browser/positronDataConnections.contribution.ts
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/positronDataConnections.contribution.ts
@@ -37,7 +37,6 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			),
 			tags: ['preview'],
 			scope: ConfigurationScope.WINDOW,
-			restricted: true,
 			included: true,
 		},
 	},

--- a/src/vs/workbench/contrib/positronDataConnections/browser/positronDataConnections.contribution.ts
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/positronDataConnections.contribution.ts
@@ -33,10 +33,11 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			default: false,
 			markdownDescription: localize(
 				'positron.dataConnections.enabled',
-				'Enable the Data Connections panel. Requires a reload to take effect.'
+				'Enable the Data Connections panel. Requires a reload to take effect. Can be set per workspace.'
 			),
 			tags: ['preview'],
-			scope: ConfigurationScope.APPLICATION,
+			scope: ConfigurationScope.WINDOW,
+			restricted: true,
 			included: true,
 		},
 	},


### PR DESCRIPTION
`dataConnections.enabled` was registered with `ConfigurationScope.APPLICATION`. Workspace settings files are parsed with `WORKSPACE_SCOPES`, which does not include `APPLICATION`, so the setting was silently ignored in a workspace `.vscode/settings.json`. The Settings editor also refused to write it on the Workspace tab. This PR changes the scope to `WINDOW`. A repository can now enable the Data Connections panel for anyone who opens it, which is useful for demo and workshop repos, such as the ones we are prepping for posit::conf! 🎉 

The setting is also `restricted` now, so Positron reads it only from a trusted workspace. The panel connects to databases and generates connection code, so an untrusted clone should not be able to turn it on. `restricted` applies only to workspace and folder settings. User settings are not affected, and neither is the e2e harness, which writes the flag into user settings.

Two notes for reviewers:

- Anyone who enabled the flag while running a non-default profile must set it again. With `APPLICATION` scope, Positron read the value only from the default profile settings file. With `WINDOW` scope, it reads the value from the current profile settings file. I think this is fine during our preview time period here.
- In a multi-root workspace, the value must go in the `settings` block of the `.code-workspace` file. Folder-level `.vscode/settings.json` is parsed with `FOLDER_SCOPES`, which does not include `WINDOW`. Again, I think this is a fine change to make during our preview period.

### Release Notes

#### New Features

- N/A (the Data Connections panel is still behind a preview flag)

#### Bug Fixes

- N/A

### Validation Steps

@:connections

The connections suite exercises the flag end to end. It writes `dataConnections.enabled` into user settings, then drives the panel. This confirms the panel still appears after the scope change.

Then check the new workspace behavior by hand:

1. Make a folder that contains `.vscode/settings.json` with `{ "dataConnections.enabled": true }`.
2. Open the folder in Positron and trust it. Run _Developer: Reload Window_.
3. Confirm the Data Connections panel appears in the sidebar.
4. Run _Workspaces: Manage Workspace Trust_, remove trust for the folder, and reload. Confirm the panel does not appear.
5. Remove the workspace setting. Set `dataConnections.enabled` to `true` in user settings, reload, and confirm the panel appears again.
