### PR TITLE
Bump ai-lib to 047038d

### DIFF
--- a/extensions/authentication/package-lock.json
+++ b/extensions/authentication/package-lock.json
@@ -24,6 +24,7 @@
 			"version": "0.0.1",
 			"license": "MIT",
 			"dependencies": {
+				"jsonc-parser": "^3.3.1",
 				"proper-lockfile": "^4.1.2",
 				"zod": "^4.4.3"
 			},

--- a/extensions/authentication/src/migration/migrateToProvidersJson.ts
+++ b/extensions/authentication/src/migration/migrateToProvidersJson.ts
@@ -42,11 +42,9 @@ export function hasMigratableSettings(
 
 /**
  * True when the user's providers.json file already carries provider config,
- * or holds content the migration must not silently replace. ai-config's read
- * path coerces unparseable or schema-invalid files to an empty config, which
- * would make a hand-edited file with one typo look unpopulated; this check
- * deliberately reads the raw file and validates it with ai-config's schema
- * so such files count as populated.
+ * or holds content the migration must not silently replace. This check reads
+ * the raw file and validates it with ai-config's schema, so a hand-edited file
+ * with one typo counts as populated rather than looking empty.
  */
 export async function userProvidersFileIsPopulated(configPath?: string): Promise<boolean> {
 	const { PROVIDERS_CONFIG_PATH, providersConfigSchema } = await import('ai-config/node');
@@ -78,14 +76,13 @@ export async function userProvidersFileIsPopulated(configPath?: string): Promise
 
 /**
  * One-shot migration: writes the mapped config through mutateProvidersConfig.
- * The populated-file check runs BEFORE the mutator so unparseable files (which
- * the mutator's read coerces to an empty config) and no-op skips never touch
- * the file, and again INSIDE the mutator so the parseable case stays guarded
- * under ai-config's cross-process lock.
+ * The populated-file check runs BEFORE the mutator so unparseable files and
+ * no-op skips never touch the file, and again INSIDE the mutator so the
+ * parseable case stays guarded under ai-config's cross-process lock.
  */
 export async function runMigration(opts: RunMigrationOptions): Promise<MigrationResult> {
 	const reader = opts.reader ?? createGlobalSettingsReader();
-	const { mutateProvidersConfig, providersConfigSchema } = await import('ai-config/node');
+	const { mutateProvidersConfig, providersConfigSchema, PROVIDERS_CONFIG_PATH } = await import('ai-config/node');
 	const mapped = buildProvidersConfigFromSettings(reader, {
 		debug: (m: string) => log.debug(m),
 		warn: (m: string) => log.warn(m),
@@ -106,7 +103,7 @@ export async function runMigration(opts: RunMigrationOptions): Promise<Migration
 	}
 
 	let skippedPopulated = false;
-	await mutateProvidersConfig(
+	const mutate = () => mutateProvidersConfig(
 		current => {
 			if (!opts.overwrite && current.providers && Object.keys(current.providers).length > 0) {
 				skippedPopulated = true;
@@ -119,6 +116,20 @@ export async function runMigration(opts: RunMigrationOptions): Promise<Migration
 			logger: { debug: (m: string) => log.debug(m), warn: (m: string) => log.warn(m) },
 		}
 	);
+
+	try {
+		await mutate();
+	} catch (error) {
+		// ai-config refuses to mutate a file it can't parse so it never discards
+		// config the user may still want. An explicit overwrite is the one case
+		// where discarding is the point, so drop the unusable file and retry.
+		if (!opts.overwrite) {
+			throw error;
+		}
+		log.warn(`[migration] providers.json is unparseable; replacing it as confirmed: ${error}`);
+		await fs.rm(opts.configPath ?? PROVIDERS_CONFIG_PATH, { force: true });
+		await mutate();
+	}
 
 	if (skippedPopulated) {
 		log.info('[migration] providers.json already has provider config; skipped');

--- a/extensions/authentication/src/test/activationOrdering.test.ts
+++ b/extensions/authentication/src/test/activationOrdering.test.ts
@@ -83,13 +83,15 @@ suite('activation ordering', () => {
 
 		// envVars: {} keeps ambient AWS_PROFILE/AWS_REGION out of the
 		// connection-env layer, so only the (absent) legacy layer could
-		// contribute a profile; the region falls back to the built-in default.
+		// contribute either value. ai-config preserves provenance and does not
+		// stamp its default region onto the connection, so both stay undefined;
+		// a legacy read would show up here as eu-west-1.
 		await migrateSettingsAndPrimeCatalog(context, { configPath, envVars: {} }, [], noopAutoMigrate);
 
 		const aws = getCachedProvider('bedrock')?.connection.aws;
 		assert.deepStrictEqual(
 			{ profile: aws?.profile, region: aws?.region },
-			{ profile: undefined, region: 'us-east-1' },
+			{ profile: undefined, region: undefined },
 			'legacy settings must reach the catalog only via the providers.json migration'
 		);
 	});

--- a/package-lock.json
+++ b/package-lock.json
@@ -245,6 +245,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "jsonc-parser": "^3.3.1",
         "proper-lockfile": "^4.1.2",
         "zod": "^4.4.3"
       },
@@ -1254,6 +1255,7 @@
         "@aws-sdk/credential-providers": "^3.981.0",
         "@github/copilot-sdk": "^0.2.2",
         "@openrouter/ai-sdk-provider": "^2.8.0",
+        "@smithy/core": "^3.25.1",
         "ai": "^6.0.68",
         "ai-config": "*",
         "ai-credentials": "*",
@@ -21589,7 +21591,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsonfile": {


### PR DESCRIPTION
Bumps the `ai-lib` submodule from `d04e8c6` (posit-dev/ai-lib#47) to `047038d` (posit-dev/ai-lib#68). This is a prerequisite for #15502 and #15503, and a step toward #12747.

### Summary

`ai-config`'s `BUILTIN_PROVIDER_IDS` now includes `litellm` and `portkey`, which is the thing #15502 and #15503 are blocked on. Nothing new shows up in the provider modal yet: the list users see is built from the authentication extension's own `PROVIDER_METADATA`, and the catalog is only consulted by id lookup. Sign-in for both providers lands in those issues.

Toward #12747, the range brings registrars and credential seams for all custom provider kinds (posit-dev/ai-lib#56), hardens custom provider editing and discovery (posit-dev/ai-lib#59), and adds a batch custom provider entry reader, `readUserCustomProviderEntries` (posit-dev/ai-lib#68), which also starts tracking Snowflake selection-clear provenance in the resolved catalog.

The range also updates `ai-provider-bridge`, which Positron's headless language model engine loads: Gemini model discovery (posit-dev/ai-lib#65), Databricks routing over native vendor APIs (posit-dev/ai-lib#61), Bedrock inference profiles and credential handling (posit-dev/ai-lib#49, posit-dev/ai-lib#50), tool-call ID sanitizing on the Anthropic Messages wire (posit-dev/ai-lib#52), and per-model output token limits for Posit AI models (posit-dev/ai-lib#67), which drops the blanket 16k `maxOutputTokens` default so a model without a capability entry sends no `max_tokens` and uses the server default.

Two lockfile entries move as a result:

- `jsonc-parser` becomes a runtime dependency of `ai-config` (posit-dev/ai-lib#53, posit-dev/ai-lib#55). This is how `providers.json` gained comment support and comment-preserving edits.
- `@smithy/core` joins `ai-provider-bridge` (posit-dev/ai-lib#60), for the Bedrock FIPS transport policy.

posit-dev/ai-lib#67 and posit-dev/ai-lib#68 add no dependencies, so extending the range to `047038d` left both lockfiles alone.

#### Positron-side fixes the bump required

The bump is not a no-op. The authentication extension-host suite caught two things:

1. **The migration's overwrite path broke.** `migrateToProvidersJson` assumed ai-config coerced an unparseable `providers.json` to an empty config. New ai-config refuses to mutate a file it can't parse, so it never silently discards user config. That is the right default, but it also meant the "Overwrite" confirmation in the migration command threw instead of replacing a corrupt file. `runMigration` now removes the unusable file and retries, and only when the user has explicitly confirmed the overwrite.

2. **A Bedrock region expectation went stale.** posit-dev/ai-lib#50 preserves AWS region provenance and no longer stamps its default region onto the resolved connection, so `connection.aws.region` is `undefined` rather than `us-east-1`. Production already falls back (`aws?.region ?? DEFAULT_AWS_REGION` in `credentials/aws.ts`), so this was a test expectation to update rather than a behaviour change to chase.

### Release Notes

#### New Features

- `providers.json` now accepts comments, and comments survive edits Positron makes to the file.

#### Bug Fixes

- N/A

### Validation Steps

@:assistant

The real coverage here is the authentication extension-host suite, which is what caught both problems above (195 passing locally):

```
npm run test-extension -- -l authentication
```

To check the migration fix by hand:

1. Corrupt `~/.posit/ai/providers.json`, e.g. write `{ this is not JSON` into it.
2. Set a legacy provider setting, e.g. `authentication.anthropic.baseUrl`.
3. Run the providers.json migration command and confirm **Overwrite** when prompted.
4. The file should be replaced with a valid `providers.json` carrying the migrated setting. Before this PR the command failed with "Mutation aborted until the file is fixed."

Also worth a smoke check that sign-in still works for a provider you already use (Anthropic or Copilot), since the catalog read path moved underneath it.

