### PR TITLE
Rename the RHEL e2e lane to Rocky

### DIFF
--- a/.claude/skills/positron-pr-helper/scripts/fetch-test-tags.sh
+++ b/.claude/skills/positron-pr-helper/scripts/fetch-test-tags.sh
@@ -31,8 +31,8 @@ categorize_tags() {
 
     # Platform tags
     if [[ "$tag" == "@:web" ]] || [[ "$tag" == "@:web-only" ]] || [[ "$tag" == "@:win" ]] || \
-       [[ "$tag" == "@:workbench" ]] || [[ "$tag" == "@:rhel-electron" ]] || \
-       [[ "$tag" == "@:rhel-web" ]] || [[ "$tag" == "@:remote-ssh" ]]; then
+       [[ "$tag" == "@:workbench" ]] || [[ "$tag" == "@:rocky-electron" ]] || \
+       [[ "$tag" == "@:rocky-web" ]] || [[ "$tag" == "@:remote-ssh" ]]; then
         echo "platform"
     # Performance tags
     elif [[ "$tag" == "@:performance" ]]; then

--- a/.github/actions/gen-report-dir/action.yml
+++ b/.github/actions/gen-report-dir/action.yml
@@ -49,7 +49,7 @@ runs:
               OS_ID=$(grep "^ID=" /etc/os-release | cut -d= -f2 | tr -d '"')
               case "$OS_ID" in
                 ubuntu|debian) OS_SUFFIX="$OS_ID" ;;
-                rhel|rocky|centos|fedora|almalinux) OS_SUFFIX="rhel" ;;
+                rhel|rocky|centos|fedora|almalinux) OS_SUFFIX="rocky" ;;
                 opensuse|opensuse-leap|opensuse-tumbleweed) OS_SUFFIX="opensuse" ;;
                 sles) OS_SUFFIX="sles" ;;
                 *) OS_SUFFIX="linux" ;;

--- a/.github/actions/restore-build-caches/action.yml
+++ b/.github/actions/restore-build-caches/action.yml
@@ -18,7 +18,7 @@ description: "Restores caches for npm dependencies and built-in extensions. Work
 
 inputs:
   distro:
-    description: "Distribution identifier for cache key (default: ubuntu for Linux). Use 'rhel' for RHEL/Rocky Linux. Windows auto-detects to 'windows'."
+    description: "Distribution identifier for cache key (default: ubuntu for Linux). Use 'rocky' for Rocky Linux. Windows auto-detects to 'windows'."
     required: false
     default: 'ubuntu'
   restore-npm-core:

--- a/.github/actions/save-build-caches/action.yml
+++ b/.github/actions/save-build-caches/action.yml
@@ -25,7 +25,7 @@ description: "Saves caches for npm dependencies and built-in extensions. Works o
 
 inputs:
   distro:
-    description: "Distribution identifier for cache key (default: ubuntu for Linux). Use 'rhel' for RHEL/Rocky Linux. Windows auto-detects to 'windows'."
+    description: "Distribution identifier for cache key (default: ubuntu for Linux). Use 'rocky' for Rocky Linux. Windows auto-detects to 'windows'."
     required: false
     default: 'ubuntu'
   cache-npm-core-hit:

--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -3,7 +3,7 @@ description: "Restores caches, installs dependencies, compiles Positron, and set
 
 inputs:
   distro:
-    description: "Distribution identifier (ubuntu, rhel, suse, windows)"
+    description: "Distribution identifier (ubuntu, rocky, suse, windows)"
     required: false
     default: 'ubuntu'
   skip-cache:

--- a/.github/workflows/test-e2e-rocky.yml
+++ b/.github/workflows/test-e2e-rocky.yml
@@ -1,4 +1,4 @@
-name: "Test: E2E (RHEL)"
+name: "Test: E2E (Rocky)"
 
 on:
   workflow_call:
@@ -31,7 +31,7 @@ on:
       display_name:
         required: false
         description: "The name of the job as it will appear in the GitHub Actions UI."
-        default: "e2e-rhel"
+        default: "e2e-rocky"
         type: string
       install_undetectable_interpreters:
         required: false
@@ -86,8 +86,8 @@ permissions:
   packages: read
 
 jobs:
-  e2e-rhel:
-    name: ${{ inputs.display_name || 'e2e-rhel' }}
+  e2e-rocky:
+    name: ${{ inputs.display_name || 'e2e-rocky' }}
     timeout-minutes: 150
     runs-on: ubuntu-latest-8x
     container:
@@ -161,7 +161,7 @@ jobs:
         id: setup-build
         uses: ./.github/actions/setup-build-env
         with:
-          distro: rhel
+          distro: rocky
           skip-cache: ${{ inputs.skip_cache }}
           install-playwright: 'true'
           github-token: ${{ github.token }}
@@ -201,7 +201,7 @@ jobs:
           COMMIT_INFO_MESSAGE: ${{ github.event.head_commit.message }}
           PWTEST_BLOB_DO_NOT_REMOVE: 1
           CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
-          PW_JSON_FILE: test-results/rhel.json
+          PW_JSON_FILE: test-results/rocky.json
           ALLOW_SOFT_FAIL: ${{ inputs.allow_soft_fail }}
           GH_SUMMARY_REPORT: true
           ENABLE_DIAGNOSTIC_LOGGING: ${{ inputs.enable_diagnostic_logging }}
@@ -243,14 +243,14 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ inputs.project }}-rhel-json-results
-          path: test-results/rhel.json
+          name: ${{ inputs.project }}-rocky-json-results
+          path: test-results/rocky.json
           if-no-files-found: ignore
 
       - name: Upload Test Logs
         if: ${{ always() && inputs.upload_logs }}
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ inputs.project }}-rhel-logs
+          name: ${{ inputs.project }}-rocky-logs
           path: test-logs
           if-no-files-found: ignore

--- a/.github/workflows/test-full-suite.yml
+++ b/.github/workflows/test-full-suite.yml
@@ -34,8 +34,8 @@ on:
         required: false
         default: true
         type: boolean
-      run_e2e_browser_rhel:
-        description: "E2E Tests / Chromium (RHEL)"
+      run_e2e_browser_rocky:
+        description: "E2E Tests / Chromium (Rocky)"
         required: false
         default: false
         type: boolean
@@ -270,18 +270,18 @@ jobs:
       max_failures: 6  # 20 max failures / 4 shards = 5, rounded to 6 to avoid premature failure of the entire suite
       enable_diagnostic_logging: ${{ inputs.enable_diagnostic_logging }}
 
-  e2e-chromium-rhel:
+  e2e-chromium-rocky:
     name: e2e
     needs: [validate-commit]
-    if: ${{ !failure() && !cancelled() && (github.event_name == 'schedule' || inputs.run_e2e_browser_rhel) }}
-    uses: ./.github/workflows/test-e2e-rhel.yml
+    if: ${{ !failure() && !cancelled() && (github.event_name == 'schedule' || inputs.run_e2e_browser_rocky) }}
+    uses: ./.github/workflows/test-e2e-rocky.yml
     secrets: inherit
     with:
       commit: ${{ inputs.commit != 'latest' && inputs.commit || '' }}
       skip_cache: ${{ inputs.commit != 'latest' }}
       grep: ${{ inputs.grep || '' }}
       project: "e2e-chromium"
-      display_name: "chromium (rhel)"
+      display_name: "chromium (rocky)"
       install_undetectable_interpreters: true
       install_license: true
       allow_soft_fail: false
@@ -500,7 +500,7 @@ jobs:
   slack-notify:
     if: always()
     needs:
-      [validate-commit, e2e-electron, e2e-windows, e2e-macos-arm64, e2e-macos-x64, e2e-chromium, e2e-chromium-rhel, e2e-chromium-suse, e2e-chromium-sles, e2e-chromium-debian, e2e-workbench, e2e-workbench-stable, e2e-workbench-rocky, e2e-pyrefly, e2e-connect, e2e-jupyter, e2e-remote-ssh, unit-tests, ext-host-tests]
+      [validate-commit, e2e-electron, e2e-windows, e2e-macos-arm64, e2e-macos-x64, e2e-chromium, e2e-chromium-rocky, e2e-chromium-suse, e2e-chromium-sles, e2e-chromium-debian, e2e-workbench, e2e-workbench-stable, e2e-workbench-rocky, e2e-pyrefly, e2e-connect, e2e-jupyter, e2e-remote-ssh, unit-tests, ext-host-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -19,8 +19,8 @@ jobs:
       tags: ${{ steps.pr-tags.outputs.tags }}
       win_tag_found: ${{ steps.pr-tags.outputs.win_tag_found }}
       web_tag_found: ${{ steps.pr-tags.outputs.web_tag_found }}
-      rhel_electron_tag_found: ${{ steps.pr-tags.outputs.rhel_electron_tag_found }}
-      rhel_web_tag_found: ${{ steps.pr-tags.outputs.rhel_web_tag_found }}
+      rocky_electron_tag_found: ${{ steps.pr-tags.outputs.rocky_electron_tag_found }}
+      rocky_web_tag_found: ${{ steps.pr-tags.outputs.rocky_web_tag_found }}
       suse_electron_tag_found: ${{ steps.pr-tags.outputs.suse_electron_tag_found }}
       suse_web_tag_found: ${{ steps.pr-tags.outputs.suse_web_tag_found }}
       sles_electron_tag_found: ${{ steps.pr-tags.outputs.sles_electron_tag_found }}
@@ -104,28 +104,28 @@ jobs:
       allow_soft_fail: false
     secrets: inherit
 
-  e2e-rhel-electron:
+  e2e-rocky-electron:
     name: e2e
-    uses: ./.github/workflows/test-e2e-rhel.yml
+    uses: ./.github/workflows/test-e2e-rocky.yml
     needs: pr-tags
-    if: ${{ needs.pr-tags.outputs.rhel_electron_tag_found == 'true' }}
+    if: ${{ needs.pr-tags.outputs.rocky_electron_tag_found == 'true' }}
     with:
       grep: ${{ needs.pr-tags.outputs.tags }}
-      display_name: "electron (RHEL)"
+      display_name: "electron (Rocky)"
       install_undetectable_interpreters: false
       install_license: false
       upload_logs: false
       allow_soft_fail: false
     secrets: inherit
 
-  e2e-rhel-chromium:
+  e2e-rocky-chromium:
     needs: pr-tags
-    if: ${{ needs.pr-tags.outputs.rhel_web_tag_found == 'true' }}
+    if: ${{ needs.pr-tags.outputs.rocky_web_tag_found == 'true' }}
     name: e2e
-    uses: ./.github/workflows/test-e2e-rhel.yml
+    uses: ./.github/workflows/test-e2e-rocky.yml
     with:
       grep: ${{ needs.pr-tags.outputs.tags }}
-      display_name: "chromium (RHEL)"
+      display_name: "chromium (Rocky)"
       project: "e2e-chromium"
       install_undetectable_interpreters: false
       install_license: true

--- a/docker/environments/wb-local/ROCKY-PLAN.md
+++ b/docker/environments/wb-local/ROCKY-PLAN.md
@@ -29,13 +29,13 @@ expect exactly one test, #15509's. The lane is PR-tag-triggered, so it blocks
 nobody meanwhile. Full evidence in
 [Step 5's results](#step-5----run-the-real-suite-locally-against-rocky-done).
 
-`test-e2e-rhel.yml` still pins `positron-rocky8:24.15.0`; repointing it is a
+`test-e2e-rocky.yml` still pins `positron-rocky8:24.15.0`; repointing it is a
 separate PR.
 
 ## Target: Rocky 9, not Rocky 8
 
 We already have `docker/images/rocky_8/` (published as
-`ghcr.io/posit-dev/positron-rocky8:24.15.0`, used by `test-e2e-rhel.yml`), so
+`ghcr.io/posit-dev/positron-rocky8:24.15.0`, used by `test-e2e-rocky.yml`), so
 Rocky 8 looks like the path of least resistance. It isn't, for one reason:
 
 **Posit publishes no arm64 Workbench package for RHEL 8.** The dailies feed has
@@ -52,7 +52,7 @@ for, because Step 4 (triaging the real suite) is where the calendar time goes an
 it is the step that needs a fast loop.
 
 So the project starts with a new `docker/images/rocky_9/` image, ported from
-`rocky_8/`. `positron-rocky8` and `test-e2e-rhel.yml` are left untouched.
+`rocky_8/`. `positron-rocky8` and `test-e2e-rocky.yml` are left untouched.
 
 ## What already exists (and what that buys us)
 
@@ -1017,7 +1017,7 @@ Surfaced by this work, roughly in order of value:
 - **Teach `update-ci-images` to bump consumers of a published tag**, not just
   `NODE_VERSION` in the image-build compose files. `wb_os_image` drifting from the
   Compose default (24.15.0 vs 24.18.0) came from exactly that gap, and the same
-  gap covers `test-e2e-rhel.yml`'s pin and the ci-arm lab images.
+  gap covers `test-e2e-rocky.yml`'s pin and the ci-arm lab images.
 - **Track [#15509](https://github.com/posit-dev/positron/issues/15509)** and drop
   the `@:environment-modules` Python failure from the expected-failures list once
   it lands. The issue carries two comments on how to test it so it fails on Ubuntu
@@ -1029,5 +1029,5 @@ From the original plan:
 - The Rocky 9 Dockerfile simplifications (drop the source GEOS/GDAL/libgit2
   builds and `gcc-toolset-13`).
 - Add the credential shards to the Rocky lane.
-- Consider migrating `test-e2e-rhel.yml` from `positron-rocky8` to
+- Consider migrating `test-e2e-rocky.yml` from `positron-rocky8` to
   `positron-rocky9` so we maintain one Rocky image, not two.

--- a/docker/images/rocky_9/README.md
+++ b/docker/images/rocky_9/README.md
@@ -11,7 +11,7 @@ arm64 Workbench package for RHEL 8** (the dailies feed has `rhel8-x86_64` only),
 so a Rocky 8 Workbench stack can only run emulated on Apple Silicon. RHEL 9 has
 both arches on both channels, which keeps the local development loop native.
 
-`rocky_8/` and `test-e2e-rhel.yml` are unaffected.
+`rocky_8/` and `test-e2e-rocky.yml` are unaffected.
 
 ## What this image includes
 

--- a/scripts/pr-tags-parse.sh
+++ b/scripts/pr-tags-parse.sh
@@ -45,13 +45,13 @@ if echo "$PR_BODY" | grep -q "@:web"; then
 	echo "Found web tag in PR body. Setting to run web tests."
 	echo "web_tag_found=true" >> "$GITHUB_OUTPUT"
 fi
-if echo "$PR_BODY" | grep -q "@:rhel-electron"; then
-	echo "Found RHEL electron tag in PR body. Setting to run RHEL electron tests."
-	echo "rhel_electron_tag_found=true" >> "$GITHUB_OUTPUT"
+if echo "$PR_BODY" | grep -q "@:rocky-electron"; then
+	echo "Found Rocky electron tag in PR body. Setting to run Rocky electron tests."
+	echo "rocky_electron_tag_found=true" >> "$GITHUB_OUTPUT"
 fi
-if echo "$PR_BODY" | grep -q "@:rhel-web"; then
-	echo "Found RHEL web tag in PR body. Setting to run RHEL web tests."
-	echo "rhel_web_tag_found=true" >> "$GITHUB_OUTPUT"
+if echo "$PR_BODY" | grep -q "@:rocky-web"; then
+	echo "Found Rocky web tag in PR body. Setting to run Rocky web tests."
+	echo "rocky_web_tag_found=true" >> "$GITHUB_OUTPUT"
 fi
 if echo "$PR_BODY" | grep -q "@:suse-electron"; then
 	echo "Found SUSE electron tag in PR body. Setting to run SUSE electron tests."

--- a/test/e2e/infra/test-runner/test-tags.ts
+++ b/test/e2e/infra/test-runner/test-tags.ts
@@ -102,8 +102,8 @@ export enum FeatureTags {
 // newly-added-tag scan). Excluded from the auto test-change tag derivation.
 export enum PlatformTags {
 	CROSS_BROWSER = '@:cross-browser',
-	RHEL_ELECTRON = '@:rhel-electron',
-	RHEL_WEB = '@:rhel-web',
+	ROCKY_ELECTRON = '@:rocky-electron',
+	ROCKY_WEB = '@:rocky-web',
 	SUSE_ELECTRON = '@:suse-electron',
 	SUSE_WEB = '@:suse-web',
 	SLES_ELECTRON = '@:sles-electron',


### PR DESCRIPTION
### Summary

The e2e container for this lane has always been Rocky (`positron-rocky8`). We
called it "rhel" back when Rocky looked temporary, and since we've decided to
stay on Rocky the naming is now just inconsistent. This aligns it.

Renamed:

- **Workflow**: `test-e2e-rhel.yml` -> `test-e2e-rocky.yml` (tracked rename), title `Test: E2E (Rocky)`, job id and default display name `e2e-rocky`, `PW_JSON_FILE: test-results/rocky.json`, artifacts `*-rocky-json-results` / `*-rocky-logs`.
- **Call sites**: `test-pull-request.yml` jobs `e2e-rocky-electron` / `e2e-rocky-chromium`, outputs `rocky_electron_tag_found` / `rocky_web_tag_found`, display names `electron (Rocky)` / `chromium (Rocky)` (matching the existing `(Debian)` casing). `test-full-suite.yml` dispatch input `run_e2e_browser_rocky`, job `e2e-chromium-rocky`, and the `slack-notify` needs list.
- **PR tags**: the `rhel-electron` and `rhel-web` tags become `rocky-electron` and `rocky-web`, in `test-tags.ts`, `pr-tags-parse.sh`, and the `positron-pr-helper` tag classifier.
- **Identifiers**: `distro: rocky` and the `distro` input docs in `setup-build-env` / `save-build-caches` / `restore-build-caches`; `OS_SUFFIX="rocky"` in `gen-report-dir`.

No back-compat aliases for the old tags: no open PR used either spelling, and an
old tag now surfaces as an "unrecognized tag" warning on the PR rather than
silently selecting nothing.

Deliberately left alone -- names that come from outside Positron and genuinely
are RHEL: the `/etc/os-release` ID match lists (`rhel|rocky|centos|fedora|almalinux`
in `gen-report-dir`, and the same list in `sandboxHelper.ts`), the Workbench /
PPM / R vocabulary (`rstudio-workbench-rhel-`, feed keys `rhel8`/`rhel9`,
`__linux__/rhel9`, `cdn.posit.co/r/rhel-9`), and prose about the RHEL family.

### Two operational notes

- The `distro` change rotates the npm and builtins cache keys for this lane, so its first run is a cold build.
- The report URL suffix becomes `-rocky`. Historic report URLs are unaffected.
- If any ruleset lists `electron (RHEL)` / `chromium (RHEL)` as a required check, it needs the new name. These are opt-in tag lanes, so probably not, but worth a glance.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:rocky-web

CI is the validation here: this PR body's tag exercises the renamed chromium
lane end to end -- tag parsing, the renamed workflow, the new cache key, and the
report/artifact names. Confirm the job shows up as `chromium (Rocky)` and its
report URL ends in `-rocky`.

Locally verified: all four changed YAML files parse, `scripts/test/pr-tags-lib-test.sh`
passes, `npm run precommit` is clean, and tag validation against the enum accepts
the two new tags while flagging the old `rhel` spelling as unrecognized.
