### PR TITLE
Unpin bqplot now that bqplot@0.6.1 is published on npm

### DIFF
--- a/test/e2e/test-files/requirements.txt
+++ b/test/e2e/test-files/requirements.txt
@@ -15,7 +15,7 @@ plotly
 ridgeplot
 ipyleaflet
 ipywidgets
-bqplot==0.12.47
+bqplot
 ipydatagrid
 ipympl
 ipytree


### PR DESCRIPTION
Removes the `bqplot==0.12.47` pin from `test/e2e/test-files/requirements.txt`.

The pin went in because `bqplot` Python 0.13.0/0.13.1 set `__frontend_version__`
to `^0.6.1` while the `bqplot` JS package on npm was still at 0.6.0, so the CDN
404'd on `bqplot@^0.6.1/dist/index.js` and the widget failed to render with
`Error: Script error for "bqplot"`.

That skew is resolved. Both upstream conditions from #13482 now pass:

- npm `dist-tags.latest` is `0.6.1`, published 2026-07-15.
- Latest PyPI `bqplot` (0.13.1) declares `__frontend_version__ = '^0.6.1'`, and
  `https://cdn.jsdelivr.net/npm/bqplot@^0.6.1/dist/index.js` returns
  `HTTP/1.1 200 OK` with `x-jsd-version: 0.6.1`.

Closes #13482

## Release Notes

### New Features

- N/A

### Bug Fixes

- N/A

## QA Notes

@:plots @:win @:web

CI is the validation here -- there are no product code changes, only the Python
environment the e2e suite installs. `Python - Verify bqplot Python widget` in
`test/e2e/tests/plots/plots.test.ts` should render `.svg-figure` without the
broken-image / "Click to show javascript error" placeholder.

**Windows is the lane that exercises this change.** It installs from
`test/e2e/test-files/requirements.txt`, so it resolves `bqplot` fresh from PyPI
and will pick up 0.13.1. macOS resolves the same way but is covered by the
merge/daily lane rather than the PR lane.

The chromium lane runs the same test against the container-baked `/root/.venv`
and never reads this requirements file, so it stays on the older `bqplot` until
the CI images are rebuilt -- most likely at the next upstream merge, which will
pick this up for free. That is fine and not worth a dedicated image bump for a
change this small: the pin only ever affected the lanes that resolve deps fresh
from PyPI, and those are the ones validated here. A green chromium run just
confirms nothing regressed on the older version.
