### PR TITLE
Quarto virtual notebook: show cell diagnostics on the source document

### DIFF
--- a/.github/workflows/test-tag-paths-map.json
+++ b/.github/workflows/test-tag-paths-map.json
@@ -128,6 +128,7 @@
   "src/vs/platform/extensionManagement/node/positronBootstrapExtensionsInitializer.ts": ["@:extensions"],
   "src/vs/platform/extensions/": [],
   "src/vs/platform/extensions/common/positronExtensionValidator.ts": ["@:extensions"],
+  "src/vs/platform/markers/": ["@:problems"],
   "src/vs/platform/positronActionBar/": [],
   "src/vs/platform/positronAiProvider/": ["@:assistant"],
   "src/vs/platform/positronDocs/": [],

--- a/src/vs/platform/markers/common/markerService.ts
+++ b/src/vs/platform/markers/common/markerService.ts
@@ -161,6 +161,12 @@ export class MarkerService implements IMarkerService {
 	private readonly _stats = new MarkerStats(this);
 	private readonly _filteredResources = new ResourceMap<string[]>();
 
+	// --- Start Positron ---
+	// Reference counted rather than a set: several holders can exclude the same
+	// resource, and the last one to let go is the one that reveals it again.
+	private readonly _excludedResources = new ResourceMap<number>();
+	// --- End Positron ---
+
 	dispose(): void {
 		this._stats.dispose();
 		this._onMarkerChanged.dispose();
@@ -224,6 +230,39 @@ export class MarkerService implements IMarkerService {
 			}
 		});
 	}
+
+	// --- Start Positron ---
+	installResourceExclusion(resource: URI): IDisposable {
+		this._excludedResources.set(resource, (this._excludedResources.get(resource) ?? 0) + 1);
+		this._onMarkerChanged.fire([resource]);
+
+		let released = false;
+		return toDisposable(() => {
+			// Guarded because releasing the same exclusion twice would otherwise
+			// count off someone else's hold on the resource.
+			if (released) {
+				return;
+			}
+			released = true;
+
+			const holds = this._excludedResources.get(resource);
+			if (holds === undefined) {
+				return;
+			}
+			if (holds > 1) {
+				this._excludedResources.set(resource, holds - 1);
+			} else {
+				this._excludedResources.delete(resource);
+			}
+			this._onMarkerChanged.fire([resource]);
+		});
+	}
+
+	/** Whether a read should behave as though a resource had no markers at all. */
+	private _isExcluded(resource: URI, options: IMarkerReadOptions): boolean {
+		return !options.ignoreResourceFilters && this._excludedResources.has(resource);
+	}
+	// --- End Positron ---
 
 	private static _toMarker(owner: string, resource: URI, data: IMarkerData): IMarker | undefined {
 		let {
@@ -338,6 +377,11 @@ export class MarkerService implements IMarkerService {
 		}
 
 		if (owner && resource) {
+			// --- Start Positron ---
+			if (this._isExcluded(resource, filter)) {
+				return [];
+			}
+			// --- End Positron ---
 			// exactly one owner AND resource
 			const reasons = !filter.ignoreResourceFilters ? this._filteredResources.get(resource) : undefined;
 			if (reasons?.length) {
@@ -382,6 +426,14 @@ export class MarkerService implements IMarkerService {
 					if (take > 0 && result.length === take) {
 						break;
 					}
+					// --- Start Positron ---
+					// Recorded as filtered so the rest of this resource's markers
+					// are skipped by the check above rather than re-tested.
+					if (this._isExcluded(data.resource, filter)) {
+						filtered.add(data.resource);
+						continue;
+					}
+					// --- End Positron ---
 					const reasons = !filter.ignoreResourceFilters ? this._filteredResources.get(data.resource) : undefined;
 					if (reasons?.length) {
 						result.push(this._createFilteredMarker(data.resource, reasons));

--- a/src/vs/platform/markers/common/markers.ts
+++ b/src/vs/platform/markers/common/markers.ts
@@ -33,6 +33,20 @@ export interface IMarkerService {
 
 	installResourceFilter(resource: URI, reason: string): IDisposable;
 
+	// --- Start Positron ---
+	/**
+	 * Leave a resource out of `read()` results, and out of the statistics, until
+	 * the returned disposable is disposed. A read that passes
+	 * `ignoreResourceFilters` still reports its markers, so whoever owns them can
+	 * keep working with them.
+	 *
+	 * For a resource whose markers are shown somewhere else. Use
+	 * `installResourceFilter` instead when the user should be told that the
+	 * problems of a resource they can see are paused.
+	 */
+	installResourceExclusion(resource: URI): IDisposable;
+	// --- End Positron ---
+
 	readonly onMarkerChanged: Event<readonly URI[]>;
 }
 

--- a/src/vs/platform/markers/test/common/positronMarkerExclusion.vitest.ts
+++ b/src/vs/platform/markers/test/common/positronMarkerExclusion.vitest.ts
@@ -1,0 +1,170 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { URI } from '../../../../base/common/uri.js';
+import { IMarkerData, MarkerSeverity } from '../../common/markers.js';
+import { MarkerService } from '../../common/markerService.js';
+
+/**
+ * Marker changes are delivered on a microtask, so nothing that reacts to one has
+ * happened yet when `changeOne` returns.
+ */
+function flushMarkerChanges(): Promise<void> {
+	return new Promise<void>(resolve => queueMicrotask(resolve));
+}
+
+function marker(message: string): IMarkerData {
+	return {
+		severity: MarkerSeverity.Error,
+		message,
+		startLineNumber: 1,
+		startColumn: 1,
+		endLineNumber: 1,
+		endColumn: 5,
+	};
+}
+
+describe('MarkerService resource exclusion', () => {
+	let service: MarkerService;
+
+	/** Stands in for a hidden Quarto cell: a resource the user cannot open. */
+	const cell = URI.parse('vscode-notebook-cell:///test/doc.qmd#ch1');
+	const source = URI.file('/test/doc.qmd');
+
+	beforeEach(() => {
+		service = new MarkerService();
+	});
+
+	afterEach(() => {
+		service.dispose();
+	});
+
+	it('leaves an excluded resource out of every read, and only that resource', () => {
+		service.changeOne('ark', cell, [marker('cell problem')]);
+		service.changeOne('ark', source, [marker('source problem')]);
+
+		service.installResourceExclusion(cell);
+
+		expect({
+			all: service.read().map(m => m.message),
+			byOwner: service.read({ owner: 'ark' }).map(m => m.message),
+			byResource: service.read({ resource: cell }).map(m => m.message),
+			byOwnerAndResource: service.read({ owner: 'ark', resource: cell }).map(m => m.message),
+			otherResource: service.read({ resource: source }).map(m => m.message),
+		}).toEqual({
+			all: ['source problem'],
+			byOwner: ['source problem'],
+			byResource: [],
+			byOwnerAndResource: [],
+			otherResource: ['source problem'],
+		});
+	});
+
+	it('still reports the markers to a read that ignores resource filters', () => {
+		service.changeOne('ark', cell, [marker('cell problem')]);
+
+		service.installResourceExclusion(cell);
+
+		// This is the read the owner of the markers uses, so excluding a resource
+		// never costs anyone the markers themselves.
+		expect({
+			all: service.read({ ignoreResourceFilters: true }).map(m => m.message),
+			byResource: service.read({ resource: cell, ignoreResourceFilters: true })
+				.map(m => m.message),
+			byOwnerAndResource: service.read({ owner: 'ark', resource: cell, ignoreResourceFilters: true })
+				.map(m => m.message),
+		}).toEqual({
+			all: ['cell problem'],
+			byResource: ['cell problem'],
+			byOwnerAndResource: ['cell problem'],
+		});
+	});
+
+	it('reports no placeholder marker, which is what separates it from a resource filter', () => {
+		const paused = URI.file('/test/paused.ts');
+		service.changeOne('ark', cell, [marker('cell problem')]);
+		service.changeOne('ark', paused, [marker('paused problem')]);
+
+		service.installResourceExclusion(cell);
+		service.installResourceFilter(paused, 'Test filter');
+
+		// A filtered resource keeps an entry in the Problems pane, explaining that
+		// its problems are paused. An excluded one has nothing to explain: the
+		// markers are shown somewhere else, on a resource of their own.
+		expect({
+			excluded: service.read({ resource: cell }).map(m => m.owner),
+			filtered: service.read({ resource: paused }).map(m => m.owner),
+		}).toEqual({
+			excluded: [],
+			filtered: ['markersFilter'],
+		});
+	});
+
+	it('stays excluded until every exclusion is disposed', () => {
+		service.changeOne('ark', cell, [marker('cell problem')]);
+		const first = service.installResourceExclusion(cell);
+		const second = service.installResourceExclusion(cell);
+
+		const whileBoth = service.read({ resource: cell }).length;
+		first.dispose();
+		const whileOne = service.read({ resource: cell }).length;
+		second.dispose();
+		const whileNone = service.read({ resource: cell }).length;
+
+		expect({ whileBoth, whileOne, whileNone })
+			.toEqual({ whileBoth: 0, whileOne: 0, whileNone: 1 });
+	});
+
+	it('ignores a repeated dispose of the same exclusion', () => {
+		service.changeOne('ark', cell, [marker('cell problem')]);
+		const first = service.installResourceExclusion(cell);
+		const second = service.installResourceExclusion(cell);
+
+		// Disposing one exclusion twice must not release the other one's hold.
+		first.dispose();
+		first.dispose();
+
+		expect({
+			afterRepeat: service.read({ resource: cell }).length,
+			afterSecond: (second.dispose(), service.read({ resource: cell }).length),
+		}).toEqual({
+			afterRepeat: 0,
+			afterSecond: 1,
+		});
+	});
+
+	it('fires a marker change for the resource when installed and when released', async () => {
+		const changes: string[][] = [];
+		const listener = service.onMarkerChanged(
+			resources => changes.push(resources.map(resource => resource.toString())));
+
+		const exclusion = service.installResourceExclusion(cell);
+		await flushMarkerChanges();
+		exclusion.dispose();
+		await flushMarkerChanges();
+		listener.dispose();
+
+		// Whatever is showing the markers has to be told to read again, in both
+		// directions, or it keeps rendering the state from before.
+		expect(changes).toEqual([[cell.toString()], [cell.toString()]]);
+	});
+
+	it('keeps the markers of an excluded resource out of the statistics', async () => {
+		service.changeOne('ark', cell, [marker('cell problem')]);
+		service.changeOne('ark', source, [marker('source problem')]);
+		await flushMarkerChanges();
+		const before = service.getStatistics().errors;
+
+		service.installResourceExclusion(cell);
+		await flushMarkerChanges();
+
+		// The status bar counts read through the same statistics, so an excluded
+		// resource must not be counted there either.
+		expect({ before, after: service.getStatistics().errors })
+			.toEqual({ before: 2, after: 1 });
+	});
+});

--- a/src/vs/workbench/contrib/positronQuarto/browser/positronQuarto.contribution.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/positronQuarto.contribution.ts
@@ -28,6 +28,7 @@ import { QuartoImagePreviewContribution } from './quartoImagePreview.js';
 import { QuartoEquationPreviewContribution } from './quartoEquationPreview.js';
 import { IQuartoVirtualNotebookService, QuartoVirtualNotebookContribution, QuartoVirtualNotebookService } from './quartoVirtualNotebookService.js';
 import { QuartoEmbeddedLanguageFeatures } from './quartoEmbeddedLanguageFeatures.js';
+import { QuartoEmbeddedDiagnostics } from './quartoEmbeddedDiagnostics.js';
 import {
 	IS_QUARTO_DOCUMENT,
 	POSITRON_QUARTO_INLINE_OUTPUT_KEY,
@@ -345,6 +346,15 @@ registerWorkbenchContribution2(
 registerWorkbenchContribution2(
 	QuartoEmbeddedLanguageFeatures.ID,
 	QuartoEmbeddedLanguageFeatures,
+	WorkbenchPhase.AfterRestored
+);
+
+// Moves the diagnostics published against the hidden cells onto the document.
+// Deliberately not gated on the setting: the cells only exist while it is on, so
+// with it off there is no cell for a marker to belong to and this does nothing.
+registerWorkbenchContribution2(
+	QuartoEmbeddedDiagnostics.ID,
+	QuartoEmbeddedDiagnostics,
 	WorkbenchPhase.AfterRestored
 );
 

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoEmbeddedDiagnostics.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoEmbeddedDiagnostics.ts
@@ -135,10 +135,14 @@ export class QuartoEmbeddedDiagnostics extends Disposable implements IWorkbenchC
 			cellUri: cell.cellUri,
 			span: { codeStartLine: cell.codeStartLine, codeEndLine: cell.codeEndLine },
 		}));
-		if (cells.length === 0) {
-			// The document closed, or its chunks are all gone. Clearing the source
-			// document belongs to whoever is taking the cells away, which knows
-			// whether this is a document that still exists.
+		if (cells.length === 0 && !this._virtualNotebooks.getNotebookUri(sourceUri)) {
+			// No notebook, so the document has closed or the setting has gone off.
+			// Disposing the notebook cleared the remapped set already.
+			//
+			// A document that is still open and has lost its last chunk reaches
+			// here too, with no cells and a notebook. That one must fall through:
+			// the markers of the chunk that went are still on the document, and
+			// nothing but a republish of the empty set takes them off.
 			return;
 		}
 
@@ -247,21 +251,28 @@ export class QuartoEmbeddedDiagnostics extends Disposable implements IWorkbenchC
 	private _toSourceRelatedInformation(
 		relatedInformation: IRelatedInformation[] | undefined
 	): IRelatedInformation[] | undefined {
-		return relatedInformation?.map(related => {
+		return relatedInformation?.flatMap(related => {
 			const sourceUri = this._virtualNotebooks.getSourceUriForCell(related.resource);
 			if (!sourceUri) {
-				return related;
+				return [related];
 			}
 			const cell = this._virtualNotebooks.getCells(sourceUri)
 				.find(candidate => candidate.cellUri.toString() === related.resource.toString());
 			if (!cell) {
-				return related;
+				return [related];
 			}
-			return {
+			if (!fitsCell(cell, related)) {
+				// Stale for the same reason a primary range is, and dropped for the
+				// same reason: mapping it would point the peek at the prose below
+				// the chunk. One related location is worth less than the marker
+				// itself, so the marker is kept and this entry goes.
+				return [];
+			}
+			return [{
 				resource: sourceUri,
 				message: related.message,
 				...cellRangeToSource(cell, related),
-			};
+			}];
 		});
 	}
 }

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoEmbeddedDiagnostics.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoEmbeddedDiagnostics.ts
@@ -5,6 +5,7 @@
 
 import { Disposable, DisposableMap, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { ResourceSet } from '../../../../base/common/map.js';
+import { Schemas } from '../../../../base/common/network.js';
 import { basename } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IModelService } from '../../../../editor/common/services/model.js';
@@ -16,8 +17,12 @@ import {
 	IRelatedInformation,
 } from '../../../../platform/markers/common/markers.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
+import { CellUri } from '../../notebook/common/notebookCommon.js';
 import { cellRangeToSource, ICellLineSpan } from '../common/quartoCellPositionMapping.js';
-import { QUARTO_EMBEDDED_DIAGNOSTICS_OWNER } from '../common/quartoVirtualNotebookTypes.js';
+import {
+	QUARTO_CELLS_SCHEME,
+	QUARTO_EMBEDDED_DIAGNOSTICS_OWNER,
+} from '../common/quartoVirtualNotebookTypes.js';
 import { IQuartoDocumentModelService } from './quartoDocumentModelService.js';
 import { IQuartoVirtualNotebookService } from './quartoVirtualNotebookService.js';
 
@@ -51,6 +56,19 @@ function fitsCell(span: ICellLineSpan, range: { startLineNumber: number; endLine
 }
 
 /**
+ * Whether a URI is a cell of one of our hidden notebooks, whoever holds it now.
+ *
+ * The notebook's own scheme is encoded in a cell's fragment, so this still
+ * recognizes a cell that the service has already spliced out. That is the case
+ * it exists for: the service can no longer answer for such a cell, and a cell of
+ * a real notebook must not be mistaken for one.
+ */
+function isQuartoCellUri(resource: URI): boolean {
+	return resource.scheme === Schemas.vscodeNotebookCell
+		&& CellUri.parse(resource)?.notebook.scheme === QUARTO_CELLS_SCHEME;
+}
+
+/**
  * Republishes the diagnostics of a Quarto document's hidden notebook cells onto
  * the document itself.
  *
@@ -65,6 +83,8 @@ export class QuartoEmbeddedDiagnostics extends Disposable implements IWorkbenchC
 
 	/** Source documents waiting to be republished, and whether that is scheduled. */
 	private readonly _pendingSources = new ResourceSet();
+	/** Cells that outlived their notebook and need their markers taken off. */
+	private readonly _pendingOrphans = new ResourceSet();
 	private _flushScheduled = false;
 
 	/** Parse subscriptions, one per source document, keyed by its URI. */
@@ -84,6 +104,9 @@ export class QuartoEmbeddedDiagnostics extends Disposable implements IWorkbenchC
 				const sourceUri = this._virtualNotebooks.getSourceUriForCell(resource);
 				if (sourceUri) {
 					this._scheduleRepublish(sourceUri);
+				} else if (isQuartoCellUri(resource)) {
+					this._pendingOrphans.add(resource);
+					this._scheduleFlush();
 				}
 			}
 		}));
@@ -103,6 +126,10 @@ export class QuartoEmbeddedDiagnostics extends Disposable implements IWorkbenchC
 	 */
 	private _scheduleRepublish(sourceUri: URI): void {
 		this._pendingSources.add(sourceUri);
+		this._scheduleFlush();
+	}
+
+	private _scheduleFlush(): void {
 		if (this._flushScheduled) {
 			return;
 		}
@@ -113,12 +140,37 @@ export class QuartoEmbeddedDiagnostics extends Disposable implements IWorkbenchC
 			if (this._store.isDisposed) {
 				return;
 			}
+			const orphans = [...this._pendingOrphans];
+			this._pendingOrphans.clear();
+			for (const cellUri of orphans) {
+				this._clearOrphanedCell(cellUri);
+			}
 			const sources = [...this._pendingSources];
 			this._pendingSources.clear();
 			for (const sourceUri of sources) {
 				this._republish(sourceUri);
 			}
 		});
+	}
+
+	/**
+	 * Take the markers off a cell that no longer exists, whoever published them.
+	 *
+	 * The notebook clears a cell's markers once, as it retires it, and releases
+	 * the exclusion that kept them out of the Problems pane at the same time. A
+	 * publish that was already on its way from the extension host lands after
+	 * both, on a URI nobody can open. Ark publishes an empty set when it sees the
+	 * close and so heals this on its own, but a server that does not would leave
+	 * the entry there for the rest of the session.
+	 */
+	private _clearOrphanedCell(cellUri: URI): void {
+		const owners = new Set<string>();
+		for (const marker of this._markerService.read({ resource: cellUri, ignoreResourceFilters: true })) {
+			owners.add(marker.owner);
+		}
+		for (const owner of owners) {
+			this._markerService.changeOne(owner, cellUri, []);
+		}
 	}
 
 	/**
@@ -226,6 +278,13 @@ export class QuartoEmbeddedDiagnostics extends Disposable implements IWorkbenchC
 	 * they belong to the marker service, which sets them from the arguments to
 	 * `changeOne`, and `modelVersionId` because it refers to a version of the cell
 	 * model rather than of the document.
+	 *
+	 * `origin` is dropped for a different reason: it is not something the server
+	 * said. `MainThreadDiagnostics` stamps it with the id of the extension host
+	 * that published, and uses it to skip its own markers when it tells the
+	 * extension host what changed. Copying it would hide these markers from
+	 * `vscode.languages.getDiagnostics`, and would start showing them again as
+	 * soon as a restart changed the id.
 	 */
 	private _toSourceMarker(span: ICellLineSpan, marker: IMarker): IMarkerData {
 		return {
@@ -235,7 +294,6 @@ export class QuartoEmbeddedDiagnostics extends Disposable implements IWorkbenchC
 			source: marker.source,
 			code: marker.code,
 			tags: marker.tags,
-			origin: marker.origin,
 			relatedInformation: this._toSourceRelatedInformation(marker.relatedInformation),
 		};
 	}

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoEmbeddedDiagnostics.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoEmbeddedDiagnostics.ts
@@ -69,6 +69,26 @@ function isQuartoCellUri(resource: URI): boolean {
 }
 
 /**
+ * Everything the remap carries, as one string, for telling two remapped sets
+ * apart.
+ *
+ * Serialized rather than compared field by field. A field left out of a
+ * hand-written comparison reads as "unchanged", which leaves a stale diagnostic
+ * on the document, and that is the failure this comparison exists to avoid. A
+ * document carries a handful of markers, so the cost does not signify.
+ */
+function markerSignature(marker: IMarkerData): string {
+	return JSON.stringify([
+		marker.startLineNumber, marker.startColumn, marker.endLineNumber, marker.endColumn,
+		marker.severity, marker.message, marker.source, marker.code, marker.tags,
+		marker.relatedInformation?.map(related => [
+			related.resource.toString(), related.message,
+			related.startLineNumber, related.startColumn, related.endLineNumber, related.endColumn,
+		]),
+	]);
+}
+
+/**
  * Republishes the diagnostics of a Quarto document's hidden notebook cells onto
  * the document itself.
  *
@@ -191,6 +211,12 @@ export class QuartoEmbeddedDiagnostics extends Disposable implements IWorkbenchC
 			// No notebook, so the document has closed or the setting has gone off.
 			// Disposing the notebook cleared the remapped set already.
 			//
+			// Turning the setting off leaves the document open, so the text model
+			// stays and its parse subscription would go on waking this for the rest
+			// of the document's life. Drop it here. Turning the setting back on
+			// builds cells again, and the first republish subscribes again.
+			this._reoffsetting.deleteAndDispose(sourceUri.toString());
+
 			// A document that is still open and has lost its last chunk reaches
 			// here too, with no cells and a notebook. That one must fall through:
 			// the markers of the chunk that went are still on the document, and
@@ -220,6 +246,10 @@ export class QuartoEmbeddedDiagnostics extends Disposable implements IWorkbenchC
 			if (remapped.length > before) {
 				cellsWithMarkers++;
 			}
+		}
+
+		if (this._isAlreadyPublished(sourceUri, remapped)) {
+			return;
 		}
 
 		this._markerService.changeOne(QUARTO_EMBEDDED_DIAGNOSTICS_OWNER, sourceUri, remapped);
@@ -267,6 +297,19 @@ export class QuartoEmbeddedDiagnostics extends Disposable implements IWorkbenchC
 			.onDidParse(() => this._scheduleRepublish(sourceUri)));
 		store.add(textModel.onWillDispose(() => this._reoffsetting.deleteAndDispose(key)));
 		this._reoffsetting.set(key, store);
+	}
+
+	/** Whether the document already carries exactly this remapped set. */
+	private _isAlreadyPublished(sourceUri: URI, remapped: IMarkerData[]): boolean {
+		const published = this._markerService.read({
+			resource: sourceUri,
+			owner: QUARTO_EMBEDDED_DIAGNOSTICS_OWNER,
+		});
+		// Both sets are in cell order, and the marker service keeps the order it
+		// was given, so this compares like for like.
+		return published.length === remapped.length
+			&& published.every((marker, index) =>
+				markerSignature(marker) === markerSignature(remapped[index]));
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoEmbeddedDiagnostics.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoEmbeddedDiagnostics.ts
@@ -1,0 +1,267 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, DisposableMap, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { ResourceSet } from '../../../../base/common/map.js';
+import { basename } from '../../../../base/common/resources.js';
+import { URI } from '../../../../base/common/uri.js';
+import { IModelService } from '../../../../editor/common/services/model.js';
+import { ILogService, LogLevel } from '../../../../platform/log/common/log.js';
+import {
+	IMarker,
+	IMarkerData,
+	IMarkerService,
+	IRelatedInformation,
+} from '../../../../platform/markers/common/markers.js';
+import { IWorkbenchContribution } from '../../../common/contributions.js';
+import { cellRangeToSource, ICellLineSpan } from '../common/quartoCellPositionMapping.js';
+import { QUARTO_EMBEDDED_DIAGNOSTICS_OWNER } from '../common/quartoVirtualNotebookTypes.js';
+import { IQuartoDocumentModelService } from './quartoDocumentModelService.js';
+import { IQuartoVirtualNotebookService } from './quartoVirtualNotebookService.js';
+
+/**
+ * One cell, reduced to what remapping needs.
+ *
+ * The span is copied rather than read off the cell as needed. Syncing a document
+ * rebuilds its cells, and a republish has to finish in the coordinates it
+ * started with.
+ */
+interface ICellSnapshot {
+	readonly cellUri: URI;
+	readonly span: ICellLineSpan;
+}
+
+/** How many lines of code a cell holds. A chunk with no code holds none. */
+function cellLineCount(span: ICellLineSpan): number {
+	return span.codeEndLine - span.codeStartLine + 1;
+}
+
+/**
+ * Whether a range published against a cell still fits inside it.
+ *
+ * A server computes a range against the version of a cell it last saw, and an
+ * edit can arrive before its diagnostics do. Mapping a range from a longer
+ * version of the cell would put a squiggle in the prose below the chunk, so it
+ * is dropped instead, and the server's next publish replaces it.
+ */
+function fitsCell(span: ICellLineSpan, range: { startLineNumber: number; endLineNumber: number }): boolean {
+	return range.startLineNumber >= 1 && range.endLineNumber <= cellLineCount(span);
+}
+
+/**
+ * Republishes the diagnostics of a Quarto document's hidden notebook cells onto
+ * the document itself.
+ *
+ * A language server is given the cells, so it publishes against cell URIs, in
+ * cell coordinates. Nobody can open those URIs, so the squiggles and the Problems
+ * entries have to be moved onto the `.qmd` before the user sees any of it. The
+ * cell URIs themselves are kept out of the Problems pane by the virtual notebook,
+ * which excludes each cell resource for as long as the cell exists.
+ */
+export class QuartoEmbeddedDiagnostics extends Disposable implements IWorkbenchContribution {
+	static readonly ID = 'workbench.contrib.positronQuartoEmbeddedDiagnostics';
+
+	/** Source documents waiting to be republished, and whether that is scheduled. */
+	private readonly _pendingSources = new ResourceSet();
+	private _flushScheduled = false;
+
+	/** Parse subscriptions, one per source document, keyed by its URI. */
+	private readonly _reoffsetting = this._register(new DisposableMap<string>());
+
+	constructor(
+		@IMarkerService private readonly _markerService: IMarkerService,
+		@IQuartoVirtualNotebookService private readonly _virtualNotebooks: IQuartoVirtualNotebookService,
+		@IModelService private readonly _modelService: IModelService,
+		@IQuartoDocumentModelService private readonly _documentModelService: IQuartoDocumentModelService,
+		@ILogService private readonly _logService: ILogService,
+	) {
+		super();
+
+		this._register(this._markerService.onMarkerChanged(resources => {
+			for (const resource of resources) {
+				const sourceUri = this._virtualNotebooks.getSourceUriForCell(resource);
+				if (sourceUri) {
+					this._scheduleRepublish(sourceUri);
+				}
+			}
+		}));
+	}
+
+	/**
+	 * Republish a source document once the current round of marker changes is
+	 * over.
+	 *
+	 * Deferred rather than done in the listener, for two reasons. Marker changes
+	 * are delivered from a `MicrotaskEmitter`, which clears its queue after
+	 * delivering, so an event fired during delivery is pushed onto that queue and
+	 * then thrown away: the republish would happen, but nothing reading the
+	 * Problems pane or drawing the squiggles would ever hear about it. Deferring
+	 * also means the cells have finished syncing, whatever order the listeners of
+	 * the parse ran in, so the spans a republish reads are the current ones.
+	 */
+	private _scheduleRepublish(sourceUri: URI): void {
+		this._pendingSources.add(sourceUri);
+		if (this._flushScheduled) {
+			return;
+		}
+
+		this._flushScheduled = true;
+		queueMicrotask(() => {
+			this._flushScheduled = false;
+			if (this._store.isDisposed) {
+				return;
+			}
+			const sources = [...this._pendingSources];
+			this._pendingSources.clear();
+			for (const sourceUri of sources) {
+				this._republish(sourceUri);
+			}
+		});
+	}
+
+	/**
+	 * Rebuild the whole remapped set for one source document.
+	 *
+	 * The whole set rather than the markers of the cell that changed: a cell whose
+	 * diagnostics were cleared contributes nothing, and publishing the result is
+	 * what makes that clearing reach the document. Patching per cell would need a
+	 * record of which source markers came from which cell, and would leave the
+	 * ones whose cell has since gone behind.
+	 */
+	private _republish(sourceUri: URI): void {
+		const cells: ICellSnapshot[] = this._virtualNotebooks.getCells(sourceUri).map(cell => ({
+			cellUri: cell.cellUri,
+			span: { codeStartLine: cell.codeStartLine, codeEndLine: cell.codeEndLine },
+		}));
+		if (cells.length === 0) {
+			// The document closed, or its chunks are all gone. Clearing the source
+			// document belongs to whoever is taking the cells away, which knows
+			// whether this is a document that still exists.
+			return;
+		}
+
+		this._ensureReoffsetting(sourceUri);
+
+		const remapped: IMarkerData[] = [];
+		let cellsWithMarkers = 0;
+		let skipped = 0;
+
+		for (const { cellUri, span } of cells) {
+			// `ignoreResourceFilters`, because the virtual notebook excludes every
+			// cell resource from the Problems pane, and these are the markers it is
+			// excluding them for.
+			const markers = this._markerService.read({ resource: cellUri, ignoreResourceFilters: true });
+			const before = remapped.length;
+			for (const marker of markers) {
+				if (fitsCell(span, marker)) {
+					remapped.push(this._toSourceMarker(span, marker));
+				} else {
+					skipped++;
+				}
+			}
+			if (remapped.length > before) {
+				cellsWithMarkers++;
+			}
+		}
+
+		this._markerService.changeOne(QUARTO_EMBEDDED_DIAGNOSTICS_OWNER, sourceUri, remapped);
+
+		// The remapped markers are indistinguishable from the ones the Quarto
+		// extension publishes for the same problem, so until that path is turned
+		// off this line is the only way to tell which one the user is looking at.
+		//
+		// `=== LogLevel.Trace` rather than `<=`, because LogLevel.Off is 0 and
+		// Trace is 1, so `<=` is also true when logging is turned off.
+		if (this._logService.getLevel() === LogLevel.Trace) {
+			this._logService.trace(
+				`[QuartoEmbedded] diagnostics remapped ${remapped.length} marker(s) from ` +
+				`${cellsWithMarkers} cell(s) for ${basename(sourceUri)}` +
+				(skipped > 0 ? `, skipped ${skipped} outside their cell` : ''));
+		}
+	}
+
+	/**
+	 * Start republishing a source document whenever it is parsed again, so that
+	 * markers follow their chunk when it moves.
+	 *
+	 * Prose growing above a chunk shifts its code down without changing it. The
+	 * server has nothing new to say, so it may not publish again, and the
+	 * coordinates the markers were mapped to are now the wrong lines.
+	 *
+	 * Subscribed here, on the first republish, rather than when the document
+	 * opens. A document nothing has published against has nothing to re-offset,
+	 * and a first republish is proof that the notebook exists, which saves this
+	 * from having to work out when it was created.
+	 */
+	private _ensureReoffsetting(sourceUri: URI): void {
+		const key = sourceUri.toString();
+		if (this._reoffsetting.has(key)) {
+			return;
+		}
+
+		const textModel = this._modelService.getModel(sourceUri);
+		if (!textModel) {
+			return;
+		}
+
+		const store = new DisposableStore();
+		store.add(this._documentModelService.getModel(textModel)
+			.onDidParse(() => this._scheduleRepublish(sourceUri)));
+		store.add(textModel.onWillDispose(() => this._reoffsetting.deleteAndDispose(key)));
+		this._reoffsetting.set(key, store);
+	}
+
+	/**
+	 * A cell's marker as a marker on the source document.
+	 *
+	 * Only the coordinates change. Everything the server said about the problem
+	 * itself is carried across untouched, so a remapped entry reads exactly as it
+	 * would have on a plain script. `resource` and `owner` are dropped because
+	 * they belong to the marker service, which sets them from the arguments to
+	 * `changeOne`, and `modelVersionId` because it refers to a version of the cell
+	 * model rather than of the document.
+	 */
+	private _toSourceMarker(span: ICellLineSpan, marker: IMarker): IMarkerData {
+		return {
+			...cellRangeToSource(span, marker),
+			severity: marker.severity,
+			message: marker.message,
+			source: marker.source,
+			code: marker.code,
+			tags: marker.tags,
+			origin: marker.origin,
+			relatedInformation: this._toSourceRelatedInformation(marker.relatedInformation),
+		};
+	}
+
+	/**
+	 * Move the related information that points into a cell onto the document
+	 * holding that cell, and leave everything else as it is.
+	 *
+	 * Any of our cells, not only the ones of the document being republished: a
+	 * name defined in one Quarto document and used in another is the same kind of
+	 * reference, and the lookup costs nothing extra.
+	 */
+	private _toSourceRelatedInformation(
+		relatedInformation: IRelatedInformation[] | undefined
+	): IRelatedInformation[] | undefined {
+		return relatedInformation?.map(related => {
+			const sourceUri = this._virtualNotebooks.getSourceUriForCell(related.resource);
+			if (!sourceUri) {
+				return related;
+			}
+			const cell = this._virtualNotebooks.getCells(sourceUri)
+				.find(candidate => candidate.cellUri.toString() === related.resource.toString());
+			if (!cell) {
+				return related;
+			}
+			return {
+				resource: sourceUri,
+				message: related.message,
+				...cellRangeToSource(cell, related),
+			};
+		});
+	}
+}

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoVirtualNotebookService.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoVirtualNotebookService.ts
@@ -8,7 +8,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { VSBuffer } from '../../../../base/common/buffer.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { basename } from '../../../../base/common/resources.js';
-import { Disposable, DisposableMap } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableMap, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { EndOfLinePreference, ITextModel } from '../../../../editor/common/model.js';
 import { IModelService } from '../../../../editor/common/services/model.js';
 import { ILanguageService } from '../../../../editor/common/languages/language.js';
@@ -16,6 +16,7 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { ExtensionIdentifier } from '../../../../platform/extensions/common/extensions.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService, LogLevel } from '../../../../platform/log/common/log.js';
+import { IMarkerService } from '../../../../platform/markers/common/markers.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
 import { NotebookTextModel } from '../../notebook/common/model/notebookTextModel.js';
 import { CellEditType, CellKind, ICellDto2, NotebookData } from '../../notebook/common/notebookCommon.js';
@@ -27,7 +28,11 @@ import {
 	usingNativeEmbeddedFeatures,
 } from '../common/positronQuartoConfig.js';
 import { IQuartoDocumentModel, QuartoCodeCell } from '../common/quartoTypes.js';
-import { QUARTO_CELLS_SCHEME, QUARTO_CELLS_VIEW_TYPE } from '../common/quartoVirtualNotebookTypes.js';
+import {
+	QUARTO_CELLS_SCHEME,
+	QUARTO_CELLS_VIEW_TYPE,
+	QUARTO_EMBEDDED_DIAGNOSTICS_OWNER,
+} from '../common/quartoVirtualNotebookTypes.js';
 import { diffCellRuns, ICellRun, ICellSplice } from '../common/quartoCellDiff.js';
 import { IQuartoDocumentModelService } from './quartoDocumentModelService.js';
 
@@ -58,6 +63,15 @@ export interface IQuartoVirtualCell {
 	readonly codeEndLine: number;
 	/** The text model bound to this notebook cell. */
 	readonly textModel: ITextModel;
+}
+
+/**
+ * A cell as the notebook holds it, with the disposables that live exactly as
+ * long as it does. Internal, because what is registered there is nobody else's
+ * business: a cell hands out its URI and its span, not its lifetime.
+ */
+interface IQuartoVirtualCellRecord extends IQuartoVirtualCell {
+	readonly store: DisposableStore;
 }
 
 export interface IQuartoVirtualNotebookService {
@@ -152,7 +166,7 @@ function quartoNotebookUri(sourceUri: URI): URI {
  * keeps it in sync with the source text model.
  */
 class QuartoVirtualNotebook extends Disposable {
-	private _cells: IQuartoVirtualCell[] = [];
+	private _cells: IQuartoVirtualCellRecord[] = [];
 	private _notebook: NotebookTextModel | undefined;
 
 	readonly notebookUri: URI;
@@ -163,6 +177,7 @@ class QuartoVirtualNotebook extends Disposable {
 		private readonly _modelService: IModelService,
 		private readonly _notebookService: INotebookService,
 		private readonly _languageService: ILanguageService,
+		private readonly _markerService: IMarkerService,
 		private readonly _logService: ILogService,
 	) {
 		super();
@@ -329,9 +344,7 @@ class QuartoVirtualNotebook extends Disposable {
 		}
 
 		for (const cell of removed) {
-			if (!cell.textModel.isDisposed()) {
-				cell.textModel.dispose();
-			}
+			this._retireCell(cell);
 		}
 
 		notebook.applyEdits(
@@ -356,6 +369,8 @@ class QuartoVirtualNotebook extends Disposable {
 					this._languageService.createById(sourceCell.language),
 					notebookCell.uri
 				);
+				const store = new DisposableStore();
+				store.add(this._markerService.installResourceExclusion(notebookCell.uri));
 				return {
 					cellUri: notebookCell.uri,
 					handle: notebookCell.handle,
@@ -363,6 +378,7 @@ class QuartoVirtualNotebook extends Disposable {
 					codeStartLine: sourceCell.codeStartLine,
 					codeEndLine: sourceCell.codeEndLine,
 					textModel,
+					store,
 				};
 			});
 
@@ -376,15 +392,44 @@ class QuartoVirtualNotebook extends Disposable {
 	}
 
 	/**
-	 * Dispose the cell text models. We own them: a notebook cell holds only a
-	 * weak reference to its text model and drops it on disposal rather than
-	 * disposing it.
+	 * Clear whatever was published against a cell URI, whoever published it.
+	 *
+	 * Required because nothing else ever will. The marker service keeps a
+	 * resource's markers when its text model is disposed, and the extension that
+	 * published them saw its document close rather than its problems go away, so
+	 * its diagnostic collection holds on to them. Left alone they would sit on a
+	 * dead cell URI for the rest of the session.
 	 */
+	private _clearCellMarkers(cellUri: URI): void {
+		const owners = new Set<string>();
+		for (const marker of this._markerService.read({ resource: cellUri, ignoreResourceFilters: true })) {
+			owners.add(marker.owner);
+		}
+		for (const owner of owners) {
+			this._markerService.changeOne(owner, cellUri, []);
+		}
+	}
+
+	/**
+	 * Take a cell out of service. We own its text model: a notebook cell holds
+	 * only a weak reference to one and drops it on disposal rather than disposing
+	 * it.
+	 *
+	 * The markers go before the exclusion that hides them, so that a Problems pane
+	 * reading in between cannot catch the diagnostics of a cell that is already
+	 * gone.
+	 */
+	private _retireCell(cell: IQuartoVirtualCellRecord): void {
+		this._clearCellMarkers(cell.cellUri);
+		cell.store.dispose();
+		if (!cell.textModel.isDisposed()) {
+			cell.textModel.dispose();
+		}
+	}
+
 	private _disposeCells(): void {
 		for (const cell of this._cells) {
-			if (!cell.textModel.isDisposed()) {
-				cell.textModel.dispose();
-			}
+			this._retireCell(cell);
 		}
 		this._cells = [];
 	}
@@ -392,6 +437,7 @@ class QuartoVirtualNotebook extends Disposable {
 	override dispose(): void {
 		super.dispose();
 		this._disposeCells();
+		this._markerService.changeOne(QUARTO_EMBEDDED_DIAGNOSTICS_OWNER, this.sourceUri, []);
 		this._notebook?.dispose();
 		this._notebook = undefined;
 		this._logService.debug(
@@ -418,6 +464,7 @@ export class QuartoVirtualNotebookService extends Disposable implements IQuartoV
 		@IQuartoDocumentModelService private readonly _documentModelService: IQuartoDocumentModelService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@ILanguageService private readonly _languageService: ILanguageService,
+		@IMarkerService private readonly _markerService: IMarkerService,
 		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
@@ -503,6 +550,7 @@ export class QuartoVirtualNotebookService extends Disposable implements IQuartoV
 			this._modelService,
 			this._notebookService,
 			this._languageService,
+			this._markerService,
 			this._logService,
 		);
 		this._notebooks.set(key, notebook);

--- a/src/vs/workbench/contrib/positronQuarto/common/quartoVirtualNotebookTypes.ts
+++ b/src/vs/workbench/contrib/positronQuarto/common/quartoVirtualNotebookTypes.ts
@@ -29,3 +29,14 @@ export const QUARTO_CELLS_VIEW_TYPE = 'quarto-cells';
  * and a notebook document at the same URI.
  */
 export const QUARTO_CELLS_SCHEME = 'quarto-cells';
+
+/**
+ * Marker owner the diagnostics of the hidden cells are republished under, on the
+ * source document.
+ *
+ * A language server publishes against the cell it was given, so its diagnostics
+ * land on a URI the user cannot open. They are copied onto the document itself
+ * under this owner, which keeps them apart from the owners of the diagnostics
+ * that were published against the document in the first place.
+ */
+export const QUARTO_EMBEDDED_DIAGNOSTICS_OWNER = 'quartoEmbedded';

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoEmbeddedDiagnostics.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoEmbeddedDiagnostics.vitest.ts
@@ -461,6 +461,56 @@ describe('QuartoEmbeddedDiagnostics', () => {
 		});
 	});
 
+	it('stops re-offsetting when the notebook goes but the document stays open', async () => {
+		const diagnostics = createDiagnostics();
+		markerService.changeOne('ark', R_CELL_URI, [marker()]);
+		await settle();
+		const subscribedWhileLive = onDidParse.hasListeners();
+
+		// Turning the setting off disposes every notebook and leaves the documents
+		// open, so nothing disposes the text model and nothing tells this
+		// contribution. The subscription has nothing left to do.
+		notebookExists = false;
+		cells = [];
+		onDidParse.fire();
+		await settle();
+		// Read before disposing the contribution, which unsubscribes on its own
+		// and would make this pass whatever the code under test does.
+		const subscribedAfterNotebookGone = onDidParse.hasListeners();
+		diagnostics.dispose();
+
+		expect({ subscribedWhileLive, subscribedAfterNotebookGone })
+			.toEqual({ subscribedWhileLive: true, subscribedAfterNotebookGone: false });
+	});
+
+	it('does not report a change when the remapped set is the same as the published one', async () => {
+		const diagnostics = createDiagnostics();
+		markerService.changeOne('ark', R_CELL_URI, [marker()]);
+		await settle();
+
+		const changed: string[] = [];
+		const listener = markerService.onMarkerChanged(
+			resources => changed.push(...resources.map(resource => resource.scheme)));
+
+		// A parse with nothing moved, and then a server republishing what it
+		// already said. Both recompute a set the document already carries. A
+		// language server republishes on every edit, so this is the common case
+		// rather than an unusual one.
+		onDidParse.fire();
+		await settle();
+		markerService.changeOne('ark', R_CELL_URI, [marker()]);
+		await settle();
+		listener.dispose();
+		diagnostics.dispose();
+
+		// The cell's own change is still reported. The document's is not, because
+		// nothing about the document changed, and every reader of this event does
+		// real work: the Problems pane rebuilds the file's entry, the statistics
+		// recount, the decorations redraw, and the markers cross to the extension
+		// host.
+		expect(changed).toEqual(['vscode-notebook-cell']);
+	});
+
 	it('stops re-offsetting when the source document closes', async () => {
 		const diagnostics = createDiagnostics();
 		markerService.changeOne('ark', R_CELL_URI, [marker()]);

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoEmbeddedDiagnostics.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoEmbeddedDiagnostics.vitest.ts
@@ -19,6 +19,7 @@ import {
 } from '../../../../../platform/markers/common/markers.js';
 import { MarkerService } from '../../../../../platform/markers/common/markerService.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { CellUri } from '../../../notebook/common/notebookCommon.js';
 import { IQuartoDocumentModel } from '../../common/quartoTypes.js';
 import { IQuartoDocumentModelService } from '../../browser/quartoDocumentModelService.js';
 import { QUARTO_EMBEDDED_DIAGNOSTICS_OWNER } from '../../common/quartoVirtualNotebookTypes.js';
@@ -41,8 +42,8 @@ import { QuartoEmbeddedDiagnostics } from '../../browser/quartoEmbeddedDiagnosti
 //   12  ```
 const SOURCE_URI = URI.file('/test/doc.qmd');
 const NOTEBOOK_URI = URI.parse('quarto-cells:/test/doc.qmd');
-const R_CELL_URI = URI.parse('vscode-notebook-cell:/test/doc.qmd#ch0');
-const PYTHON_CELL_URI = URI.parse('vscode-notebook-cell:/test/doc.qmd#ch1');
+const R_CELL_URI = CellUri.generate(NOTEBOOK_URI, 0);
+const PYTHON_CELL_URI = CellUri.generate(NOTEBOOK_URI, 1);
 /** A file that has nothing to do with any Quarto document. */
 const OTHER_URI = URI.file('/test/other.R');
 
@@ -383,6 +384,50 @@ describe('QuartoEmbeddedDiagnostics', () => {
 		expect(sourceMarkers()[0].relatedInformation?.map(summarize)).toEqual([
 			{ resource: SOURCE_URI.path, message: 'current', range: [9, 1, 9, 6] },
 		]);
+	});
+
+	it('clears diagnostics that arrive for a cell after it was spliced out', async () => {
+		const diagnostics = createDiagnostics();
+		const goneCellUri = cells[0].cellUri;
+
+		// The chunk was deleted, so the cell is out of the service, but its server
+		// had a publish in flight. It lands on a URI nobody can open, with the
+		// exclusion already released. The notebook clears a cell's markers once,
+		// as it retires it, so nothing else takes these off.
+		cells = [cells[1]];
+		markerService.changeOne('ark', goneCellUri, [marker()]);
+		await settle();
+		diagnostics.dispose();
+
+		expect(markerService.read({ resource: goneCellUri, ignoreResourceFilters: true }))
+			.toEqual([]);
+	});
+
+	it('leaves the cells of a real notebook alone', async () => {
+		const diagnostics = createDiagnostics();
+		// Same scheme, a notebook that is not ours. Clearing this would be taking
+		// another editor's diagnostics away.
+		const ipynbCellUri = CellUri.generate(URI.file('/test/analysis.ipynb'), 0);
+
+		markerService.changeOne('pyright', ipynbCellUri, [marker()]);
+		await settle();
+		diagnostics.dispose();
+
+		expect(markerService.read({ resource: ipynbCellUri, ignoreResourceFilters: true })
+			.map(m => m.message)).toEqual(['object not found']);
+	});
+
+	it('does not carry the publishing extension host across as the marker origin', async () => {
+		const diagnostics = createDiagnostics();
+		// `origin` is stamped by MainThreadDiagnostics with the id of the host that
+		// published, not by the server. Copying it makes the remapped markers look
+		// like that host's own, so it never hears about them, and the value goes
+		// stale the moment the host restarts.
+		markerService.changeOne('ark', R_CELL_URI, [marker({ origin: 'extHost1' })]);
+		await settle();
+		diagnostics.dispose();
+
+		expect(sourceMarkers().map(m => m.origin)).toEqual([undefined]);
 	});
 
 	it('re-offsets the remapped markers when the chunks move', async () => {

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoEmbeddedDiagnostics.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoEmbeddedDiagnostics.vitest.ts
@@ -40,6 +40,7 @@ import { QuartoEmbeddedDiagnostics } from '../../browser/quartoEmbeddedDiagnosti
 //   11  c = 3
 //   12  ```
 const SOURCE_URI = URI.file('/test/doc.qmd');
+const NOTEBOOK_URI = URI.parse('quarto-cells:/test/doc.qmd');
 const R_CELL_URI = URI.parse('vscode-notebook-cell:/test/doc.qmd#ch0');
 const PYTHON_CELL_URI = URI.parse('vscode-notebook-cell:/test/doc.qmd#ch1');
 /** A file that has nothing to do with any Quarto document. */
@@ -91,6 +92,8 @@ describe('QuartoEmbeddedDiagnostics', () => {
 	let cells: IQuartoVirtualCell[];
 	let sourceTextModel: ITextModel;
 	let onDidParse: Emitter<void>;
+	/** Whether the document still has a virtual notebook, cells or not. */
+	let notebookExists: boolean;
 
 	function cell(cellUri: URI, language: string, codeStartLine: number, codeEndLine: number): IQuartoVirtualCell {
 		return {
@@ -116,6 +119,7 @@ describe('QuartoEmbeddedDiagnostics', () => {
 		// re-offsetting subscription is meant to end.
 		sourceTextModel = createTextModel('', 'quarto', undefined, SOURCE_URI);
 		onDidParse = new Emitter<void>();
+		notebookExists = true;
 	});
 
 	afterEach(() => {
@@ -128,6 +132,8 @@ describe('QuartoEmbeddedDiagnostics', () => {
 
 	function createDiagnostics(): QuartoEmbeddedDiagnostics {
 		const virtualNotebooks = stubInterface<IQuartoVirtualNotebookService>({
+			getNotebookUri: uri =>
+				notebookExists && uri.toString() === SOURCE_URI.toString() ? NOTEBOOK_URI : undefined,
 			getCells: uri => uri.toString() === SOURCE_URI.toString() ? cells : [],
 			getSourceUriForCell: uri =>
 				cells.some(c => c.cellUri.toString() === uri.toString()) ? SOURCE_URI : undefined,
@@ -300,10 +306,11 @@ describe('QuartoEmbeddedDiagnostics', () => {
 		markerService.changeOne('ark', R_CELL_URI, [marker()]);
 		await settle();
 
-		// The document closed, so its cells are gone from the service. Whatever is
-		// on the source document is the closing notebook's to clear, and a
-		// republish here would be working from cells that no longer exist.
+		// The document closed, so the notebook and its cells are gone from the
+		// service. Whatever is on the source document is the closing notebook's to
+		// clear, and a republish here would work from cells that no longer exist.
 		cells = [];
+		notebookExists = false;
 		markerService.changeOne('ark', R_CELL_URI, []);
 		await settle();
 		diagnostics.dispose();
@@ -333,6 +340,49 @@ describe('QuartoEmbeddedDiagnostics', () => {
 		// pane and the editor decorations both read on this event, so losing it
 		// means the squiggle never appears.
 		expect(changed).toEqual([R_CELL_URI.path, SOURCE_URI.path]);
+	});
+
+	it('clears the remapped set when the document loses its last chunk', async () => {
+		const diagnostics = createDiagnostics();
+		markerService.changeOne('ark', R_CELL_URI, [marker()]);
+		await settle();
+		const before = sourceMarkers().length;
+
+		// Every chunk deleted, but the document is still open, so the notebook is
+		// still there with no cells in it. Nothing else clears the remapped set in
+		// this case: the notebook clears it on dispose, and it is not disposed.
+		cells = [];
+		onDidParse.fire();
+		await settle();
+		diagnostics.dispose();
+
+		expect({ before, after: sourceMarkers().length }).toEqual({ before: 1, after: 0 });
+	});
+
+	it('skips relatedInformation that does not fit its cell', async () => {
+		const diagnostics = createDiagnostics();
+		// The Python chunk holds three lines. The same staleness that the primary
+		// range is checked for reaches a related location too, and mapping it
+		// would point the peek at the prose below that chunk.
+		const relatedInformation: IRelatedInformation[] = [
+			{
+				resource: PYTHON_CELL_URI,
+				message: 'stale',
+				startLineNumber: 99, startColumn: 1, endLineNumber: 99, endColumn: 6,
+			},
+			{
+				resource: PYTHON_CELL_URI,
+				message: 'current',
+				startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 6,
+			},
+		];
+		markerService.changeOne('ark', R_CELL_URI, [marker({ relatedInformation })]);
+		await settle();
+		diagnostics.dispose();
+
+		expect(sourceMarkers()[0].relatedInformation?.map(summarize)).toEqual([
+			{ resource: SOURCE_URI.path, message: 'current', range: [9, 1, 9, 6] },
+		]);
 	});
 
 	it('re-offsets the remapped markers when the chunks move', async () => {

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoEmbeddedDiagnostics.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoEmbeddedDiagnostics.vitest.ts
@@ -1,0 +1,392 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { Emitter } from '../../../../../base/common/event.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ITextModel } from '../../../../../editor/common/model.js';
+import { IModelService } from '../../../../../editor/common/services/model.js';
+import { createTextModel } from '../../../../../editor/test/common/testTextModel.js';
+import { ILogService, LogLevel } from '../../../../../platform/log/common/log.js';
+import {
+	IMarker,
+	IMarkerData,
+	IRelatedInformation,
+	MarkerSeverity,
+} from '../../../../../platform/markers/common/markers.js';
+import { MarkerService } from '../../../../../platform/markers/common/markerService.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { IQuartoDocumentModel } from '../../common/quartoTypes.js';
+import { IQuartoDocumentModelService } from '../../browser/quartoDocumentModelService.js';
+import { QUARTO_EMBEDDED_DIAGNOSTICS_OWNER } from '../../common/quartoVirtualNotebookTypes.js';
+import { IQuartoVirtualCell, IQuartoVirtualNotebookService } from '../../browser/quartoVirtualNotebookService.js';
+import { QuartoEmbeddedDiagnostics } from '../../browser/quartoEmbeddedDiagnostics.js';
+
+// The source document, with two chunks:
+//
+//    1  # Intro
+//    2
+//    3  ```{r}
+//    4  x <- 1
+//    5  y <- 2
+//    6  z <- 3
+//    7  ```
+//    8  ```{python}
+//    9  a = 1
+//   10  b = 2
+//   11  c = 3
+//   12  ```
+const SOURCE_URI = URI.file('/test/doc.qmd');
+const R_CELL_URI = URI.parse('vscode-notebook-cell:/test/doc.qmd#ch0');
+const PYTHON_CELL_URI = URI.parse('vscode-notebook-cell:/test/doc.qmd#ch1');
+/** A file that has nothing to do with any Quarto document. */
+const OTHER_URI = URI.file('/test/other.R');
+
+/**
+ * Waits for everything a marker change sets off. Marker changes are delivered on
+ * a microtask and the republish is deferred onto another one, so a macrotask is
+ * the reliable way to be past both.
+ */
+function settle(): Promise<void> {
+	return new Promise<void>(resolve => setTimeout(resolve, 0));
+}
+
+function marker(overrides: Partial<IMarkerData> = {}): IMarkerData {
+	return {
+		severity: MarkerSeverity.Error,
+		message: 'object not found',
+		source: 'ark',
+		code: 'E1',
+		// Line 2 of the cell, which is line 5 of the source for the R chunk.
+		startLineNumber: 2,
+		startColumn: 3,
+		endLineNumber: 2,
+		endColumn: 8,
+		...overrides,
+	};
+}
+
+/** The fields worth comparing, in the order a reader wants them. */
+function summarize(m: IMarker | IRelatedInformation) {
+	const asMarker = m as IMarker;
+	return {
+		resource: m.resource.path,
+		message: m.message,
+		...(asMarker.owner === undefined ? {} : {
+			owner: asMarker.owner,
+			severity: asMarker.severity,
+			source: asMarker.source,
+			code: asMarker.code,
+		}),
+		range: [m.startLineNumber, m.startColumn, m.endLineNumber, m.endColumn],
+	};
+}
+
+describe('QuartoEmbeddedDiagnostics', () => {
+	let markerService: MarkerService;
+	let traces: string[];
+	let cells: IQuartoVirtualCell[];
+	let sourceTextModel: ITextModel;
+	let onDidParse: Emitter<void>;
+
+	function cell(cellUri: URI, language: string, codeStartLine: number, codeEndLine: number): IQuartoVirtualCell {
+		return {
+			cellUri,
+			handle: 0,
+			language,
+			codeStartLine,
+			codeEndLine,
+			// The remapper works off the line spans alone. A stub that throws on
+			// every read is what holds it to that.
+			textModel: stubInterface<ITextModel>(),
+		};
+	}
+
+	beforeEach(() => {
+		markerService = new MarkerService();
+		traces = [];
+		cells = [
+			cell(R_CELL_URI, 'r', 4, 6),
+			cell(PYTHON_CELL_URI, 'python', 9, 11),
+		];
+		// A real model, for a real onWillDispose: closing the document is how the
+		// re-offsetting subscription is meant to end.
+		sourceTextModel = createTextModel('', 'quarto', undefined, SOURCE_URI);
+		onDidParse = new Emitter<void>();
+	});
+
+	afterEach(() => {
+		onDidParse.dispose();
+		if (!sourceTextModel.isDisposed()) {
+			sourceTextModel.dispose();
+		}
+		markerService.dispose();
+	});
+
+	function createDiagnostics(): QuartoEmbeddedDiagnostics {
+		const virtualNotebooks = stubInterface<IQuartoVirtualNotebookService>({
+			getCells: uri => uri.toString() === SOURCE_URI.toString() ? cells : [],
+			getSourceUriForCell: uri =>
+				cells.some(c => c.cellUri.toString() === uri.toString()) ? SOURCE_URI : undefined,
+		});
+		const logService = stubInterface<ILogService>({
+			getLevel: () => LogLevel.Trace,
+			trace: (message: string) => { traces.push(message); },
+		});
+		const modelService = stubInterface<IModelService>({
+			getModel: uri => uri.toString() === SOURCE_URI.toString() ? sourceTextModel : null,
+		});
+		const documentModelService = stubInterface<IQuartoDocumentModelService>({
+			getModel: () => stubInterface<IQuartoDocumentModel>({ onDidParse: onDidParse.event }),
+		});
+		return new QuartoEmbeddedDiagnostics(
+			markerService, virtualNotebooks, modelService, documentModelService, logService);
+	}
+
+	/** What the Problems pane would show for the source document. */
+	function sourceMarkers(): IMarker[] {
+		return markerService
+			.read({ resource: SOURCE_URI, owner: QUARTO_EMBEDDED_DIAGNOSTICS_OWNER })
+			.slice()
+			.sort((a, b) => a.startLineNumber - b.startLineNumber);
+	}
+
+	it('remaps a cell marker onto the source document', async () => {
+		const diagnostics = createDiagnostics();
+		markerService.changeOne('ark', R_CELL_URI, [marker()]);
+		await settle();
+		diagnostics.dispose();
+
+		expect(sourceMarkers().map(summarize)).toEqual([{
+			resource: SOURCE_URI.path,
+			message: 'object not found',
+			owner: QUARTO_EMBEDDED_DIAGNOSTICS_OWNER,
+			severity: MarkerSeverity.Error,
+			source: 'ark',
+			code: 'E1',
+			// Cell line 2 of a chunk whose code starts on source line 4.
+			range: [5, 3, 5, 8],
+		}]);
+	});
+
+	it('aggregates markers from every cell of the document, across owners', async () => {
+		const diagnostics = createDiagnostics();
+		markerService.changeOne('ark', R_CELL_URI, [marker({ message: 'r problem', startLineNumber: 1, endLineNumber: 1 })]);
+		markerService.changeOne('ruff', PYTHON_CELL_URI, [marker({ message: 'python problem', startLineNumber: 3, endLineNumber: 3 })]);
+		await settle();
+		diagnostics.dispose();
+
+		// Nothing here names an owner: whatever publishes on a cell is remapped,
+		// so a linter nobody planned for works the same as the language server.
+		expect(sourceMarkers().map(m => [m.message, m.startLineNumber])).toEqual([
+			['r problem', 4],
+			['python problem', 11],
+		]);
+	});
+
+	it('republishes the whole set, so cleared cell markers disappear from the source', async () => {
+		const diagnostics = createDiagnostics();
+		markerService.changeOne('ark', R_CELL_URI, [
+			marker({ message: 'first', startLineNumber: 1, endLineNumber: 1 }),
+			marker({ message: 'second', startLineNumber: 2, endLineNumber: 2 }),
+		]);
+		await settle();
+		const both = sourceMarkers().map(m => m.message);
+
+		markerService.changeOne('ark', R_CELL_URI, [marker({ message: 'first', startLineNumber: 1, endLineNumber: 1 })]);
+		await settle();
+		const remaining = sourceMarkers().map(m => m.message);
+
+		markerService.changeOne('ark', R_CELL_URI, []);
+		await settle();
+		const none = sourceMarkers().map(m => m.message);
+		diagnostics.dispose();
+
+		expect({ both, remaining, none }).toEqual({
+			both: ['first', 'second'],
+			remaining: ['first'],
+			none: [],
+		});
+	});
+
+	it('still reads cell markers when the cell URI is excluded from the Problems pane', async () => {
+		const diagnostics = createDiagnostics();
+		// This is what the virtual notebook does for every cell it creates, and
+		// the remapper has to see straight through it.
+		markerService.installResourceExclusion(R_CELL_URI);
+		markerService.changeOne('ark', R_CELL_URI, [marker()]);
+		await settle();
+		diagnostics.dispose();
+
+		expect({
+			cell: markerService.read({ resource: R_CELL_URI }).length,
+			source: sourceMarkers().map(m => m.startLineNumber),
+		}).toEqual({
+			cell: 0,
+			source: [5],
+		});
+	});
+
+	it('ignores markers on URIs that are not our cells, and does not remap its own output', async () => {
+		const diagnostics = createDiagnostics();
+		markerService.changeOne('eslint', OTHER_URI, [marker({ message: 'unrelated' })]);
+		// A marker under our own owner on the source document is what a loop would
+		// feed back in. Remapping it would clear it, since the cells hold nothing.
+		markerService.changeOne(QUARTO_EMBEDDED_DIAGNOSTICS_OWNER, SOURCE_URI, [marker({ message: 'ours' })]);
+		await settle();
+		diagnostics.dispose();
+
+		expect({
+			republishes: traces.length,
+			source: sourceMarkers().map(m => m.message),
+		}).toEqual({
+			republishes: 0,
+			source: ['ours'],
+		});
+	});
+
+	it('skips a marker that does not fit its cell, and says so', async () => {
+		const diagnostics = createDiagnostics();
+		// The R chunk holds three lines. A marker past them was computed against a
+		// version of the cell that is already gone, and mapping it would put a
+		// squiggle in the prose below the chunk.
+		markerService.changeOne('ark', R_CELL_URI, [
+			marker({ message: 'stale', startLineNumber: 99, endLineNumber: 99 }),
+			marker({ message: 'current', startLineNumber: 3, endLineNumber: 3 }),
+		]);
+		await settle();
+		diagnostics.dispose();
+
+		expect({
+			source: sourceMarkers().map(m => [m.message, m.startLineNumber]),
+			trace: traces,
+		}).toEqual({
+			source: [['current', 6]],
+			trace: ['[QuartoEmbedded] diagnostics remapped 1 marker(s) from 1 cell(s) for doc.qmd, skipped 1 outside their cell'],
+		});
+	});
+
+	it('remaps relatedInformation that points at another cell, and leaves the rest alone', async () => {
+		const diagnostics = createDiagnostics();
+		const relatedInformation: IRelatedInformation[] = [
+			{
+				resource: PYTHON_CELL_URI,
+				message: 'defined here',
+				startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 6,
+			},
+			{
+				resource: OTHER_URI,
+				message: 'and here',
+				startLineNumber: 3, startColumn: 1, endLineNumber: 3, endColumn: 4,
+			},
+		];
+		markerService.changeOne('ark', R_CELL_URI, [marker({ relatedInformation })]);
+		await settle();
+		diagnostics.dispose();
+
+		expect(sourceMarkers()[0].relatedInformation?.map(summarize)).toEqual([
+			// Cell line 1 of the Python chunk, whose code starts on source line 9.
+			{ resource: SOURCE_URI.path, message: 'defined here', range: [9, 1, 9, 6] },
+			// A real file keeps its own coordinates.
+			{ resource: OTHER_URI.path, message: 'and here', range: [3, 1, 3, 4] },
+		]);
+	});
+
+	it('leaves the source document alone when the changed URI belongs to no notebook', async () => {
+		const diagnostics = createDiagnostics();
+		markerService.changeOne('ark', R_CELL_URI, [marker()]);
+		await settle();
+
+		// The document closed, so its cells are gone from the service. Whatever is
+		// on the source document is the closing notebook's to clear, and a
+		// republish here would be working from cells that no longer exist.
+		cells = [];
+		markerService.changeOne('ark', R_CELL_URI, []);
+		await settle();
+		diagnostics.dispose();
+
+		expect({
+			republishes: traces.length,
+			source: sourceMarkers().map(m => m.startLineNumber),
+		}).toEqual({
+			republishes: 1,
+			source: [5],
+		});
+	});
+
+	it('notifies marker listeners about the source document, not only the cell', async () => {
+		const diagnostics = createDiagnostics();
+		const changed: string[] = [];
+		const listener = markerService.onMarkerChanged(
+			resources => changed.push(...resources.map(resource => resource.path)));
+
+		markerService.changeOne('ark', R_CELL_URI, [marker()]);
+		await settle();
+		listener.dispose();
+		diagnostics.dispose();
+
+		// A republish made from inside the marker-changed delivery is swallowed by
+		// MicrotaskEmitter, which clears its queue after delivering. The Problems
+		// pane and the editor decorations both read on this event, so losing it
+		// means the squiggle never appears.
+		expect(changed).toEqual([R_CELL_URI.path, SOURCE_URI.path]);
+	});
+
+	it('re-offsets the remapped markers when the chunks move', async () => {
+		const diagnostics = createDiagnostics();
+		markerService.changeOne('ark', R_CELL_URI, [marker()]);
+		await settle();
+		const before = sourceMarkers().map(m => m.startLineNumber);
+
+		// Two prose lines added above the R chunk, so its code starts two lines
+		// further down. The server has nothing new to say, and a server that never
+		// republishes would leave the squiggle where the chunk used to be.
+		cells = [
+			cell(R_CELL_URI, 'r', 6, 8),
+			cell(PYTHON_CELL_URI, 'python', 11, 13),
+		];
+		onDidParse.fire();
+		await settle();
+		const after = sourceMarkers().map(m => m.startLineNumber);
+		diagnostics.dispose();
+
+		expect({
+			before,
+			after,
+			// One republish for the marker and one for the parse. More than that
+			// means the document was subscribed to more than once.
+			republishes: traces.length,
+		}).toEqual({
+			before: [5],
+			after: [7],
+			republishes: 2,
+		});
+	});
+
+	it('stops re-offsetting when the source document closes', async () => {
+		const diagnostics = createDiagnostics();
+		markerService.changeOne('ark', R_CELL_URI, [marker()]);
+		await settle();
+
+		sourceTextModel.dispose();
+		onDidParse.fire();
+		await settle();
+		diagnostics.dispose();
+
+		expect(traces.length).toBe(1);
+	});
+
+	it('stops remapping once disposed', async () => {
+		const diagnostics = createDiagnostics();
+		diagnostics.dispose();
+
+		markerService.changeOne('ark', R_CELL_URI, [marker()]);
+		await settle();
+
+		expect({ republishes: traces.length, source: sourceMarkers().length })
+			.toEqual({ republishes: 0, source: 0 });
+	});
+});

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoVirtualNotebookService.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoVirtualNotebookService.vitest.ts
@@ -15,13 +15,19 @@ import { ILanguageService } from '../../../../../editor/common/languages/languag
 import { NullLogService } from '../../../../../platform/log/common/log.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IMarkerData, IMarkerService, MarkerSeverity } from '../../../../../platform/markers/common/markers.js';
+import { MarkerService } from '../../../../../platform/markers/common/markerService.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { INotebookService } from '../../../notebook/common/notebookService.js';
 import { NotebookTextModel } from '../../../notebook/common/model/notebookTextModel.js';
 import { NotebookProviderInfo } from '../../../notebook/common/notebookProvider.js';
 import { QUARTO_NATIVE_LANGUAGE_FEATURES_KEY } from '../../common/positronQuartoConfig.js';
-import { QUARTO_CELLS_SCHEME, QUARTO_CELLS_VIEW_TYPE } from '../../common/quartoVirtualNotebookTypes.js';
+import {
+	QUARTO_CELLS_SCHEME,
+	QUARTO_CELLS_VIEW_TYPE,
+	QUARTO_EMBEDDED_DIAGNOSTICS_OWNER,
+} from '../../common/quartoVirtualNotebookTypes.js';
 import { IQuartoDocumentModel } from '../../common/quartoTypes.js';
 import { IQuartoDocumentModelService } from '../../browser/quartoDocumentModelService.js';
 import { QuartoDocumentModel } from '../../browser/quartoDocumentModel.js';
@@ -157,9 +163,22 @@ const CHURN_STEPS: readonly {
 		},
 	];
 
+/** A diagnostic as a language server would publish it against a cell. */
+function marker(message: string): IMarkerData {
+	return {
+		severity: MarkerSeverity.Error,
+		message,
+		startLineNumber: 1,
+		startColumn: 1,
+		endLineNumber: 1,
+		endColumn: 5,
+	};
+}
+
 describe('QuartoVirtualNotebookService', () => {
 	const logService = new NullLogService();
 	const configurationService = new TestConfigurationService();
+	const markerService = new MarkerService();
 
 	// The real NotebookService installs a process-global handler for the
 	// `notebooks` extension point, so it cannot be rebuilt per test. This fake
@@ -225,6 +244,7 @@ describe('QuartoVirtualNotebookService', () => {
 		.stub(INotebookService, notebookService)
 		.stub(IConfigurationService, configurationService)
 		.stub(IQuartoDocumentModelService, documentModelService)
+		.stub(IMarkerService, markerService)
 		.build();
 
 	beforeEach(async () => {
@@ -238,6 +258,9 @@ describe('QuartoVirtualNotebookService', () => {
 		}
 		documentModels.clear();
 		notebooks.clear();
+		for (const leftover of markerService.read({ ignoreResourceFilters: true })) {
+			markerService.changeOne(leftover.owner, leftover.resource, []);
+		}
 	});
 
 	function createService(): QuartoVirtualNotebookService {
@@ -801,6 +824,89 @@ describe('QuartoVirtualNotebookService', () => {
 			notebook: undefined,
 			cells: [],
 			cellModelsDisposed: [true, true],
+		});
+	});
+
+	it('excludes every cell it creates from the Problems pane', async () => {
+		const service = createService();
+		const source = createSourceModel(R_AND_PYTHON);
+		await service.whenReady(source.uri);
+		const [rCell] = service.getCells(source.uri);
+
+		markerService.changeOne('ark', rCell.cellUri, [marker('object not found')]);
+
+		// Nobody can open a cell URI, so an entry pointing at one is a dead end.
+		// The diagnostics contribution shows these on the document instead, and
+		// reads them with `ignoreResourceFilters` to get at them.
+		expect({
+			visible: markerService.read({ resource: rCell.cellUri }).length,
+			raw: markerService.read({ resource: rCell.cellUri, ignoreResourceFilters: true })
+				.map(m => m.message),
+		}).toEqual({
+			visible: 0,
+			raw: ['object not found'],
+		});
+	});
+
+	it('clears the markers of a spliced-out cell, under every owner, and stops excluding it', async () => {
+		const service = createService();
+		const source = createSourceModel(R_AND_PYTHON);
+		await service.whenReady(source.uri);
+		const [rCell] = service.getCells(source.uri);
+
+		markerService.changeOne('ark', rCell.cellUri, [marker('from the language server')]);
+		markerService.changeOne('lintr', rCell.cellUri, [marker('from a linter')]);
+
+		// Drop the R chunk, keep the Python one.
+		source.setValue([
+			'# Intro',
+			'',
+			'```{python}',
+			'import os',
+			'```',
+			'',
+		].join('\n'));
+		service.ensureSynchronized(source.uri);
+
+		const cleared = markerService.read({ resource: rCell.cellUri, ignoreResourceFilters: true });
+		// Nothing else would ever clear these: the marker service keeps markers
+		// when a text model is disposed, and the extension that published them saw
+		// its document close rather than its problems go away.
+		markerService.changeOne('ark', rCell.cellUri, [marker('published after the cell died')]);
+
+		expect({
+			cleared: cleared.map(m => m.message),
+			// Visible again, which is how a released exclusion shows: holding one
+			// for every cell the document ever had would pile up all session.
+			exclusionReleased: markerService.read({ resource: rCell.cellUri }).length,
+		}).toEqual({
+			cleared: [],
+			exclusionReleased: 1,
+		});
+	});
+
+	it('leaves no markers anywhere when the notebook is disposed', async () => {
+		const service = createService();
+		const source = createSourceModel(R_AND_PYTHON);
+		await service.whenReady(source.uri);
+		const cellUris = service.getCells(source.uri).map(cell => cell.cellUri);
+
+		markerService.changeOne('ark', cellUris[0], [marker('r problem')]);
+		markerService.changeOne('pyright', cellUris[1], [marker('python problem')]);
+		// The remapped set, as the diagnostics contribution leaves it on the
+		// document. The cells are about to go, so no republish can clear it.
+		markerService.changeOne(
+			QUARTO_EMBEDDED_DIAGNOSTICS_OWNER, source.uri, [marker('remapped problem')]);
+
+		ctx.instantiationService.get(IModelService).destroyModel(source.uri);
+
+		expect({
+			cells: cellUris.flatMap(
+				uri => markerService.read({ resource: uri, ignoreResourceFilters: true })),
+			source: markerService.read({ resource: source.uri, ignoreResourceFilters: true }),
+		}).toEqual({
+			cells: [],
+			source: [],
 		});
 	});
 

--- a/src/vs/workbench/test/common/workbenchTestServices.ts
+++ b/src/vs/workbench/test/common/workbenchTestServices.ts
@@ -521,6 +521,11 @@ export class TestMarkerService implements IMarkerService {
 	installResourceFilter(resource: URI, reason: string): IDisposable {
 		return { dispose: () => { /* TODO: Implement cleanup logic */ } };
 	}
+	// --- Start Positron ---
+	installResourceExclusion(resource: URI): IDisposable {
+		return { dispose: () => { } };
+	}
+	// --- End Positron ---
 }
 
 export class TestFileService implements IFileService {


### PR DESCRIPTION
Related to:

- #14540
- #12837

Positron now can keep a hidden in-memory notebook for each open Quarto document, with one cell text model per code chunk. A language server sees those cells as ordinary notebook cells, so it publishes diagnostics against cell URIs, in cell coordinates. Nobody can open one of those URIs, so until now those diagnostics never reached the user.

This PR republishes them onto the `.qmd` itself, in document coordinates, and also keeps the cell URIs out of the Problems pane.

### What this changes per language

**R: new behavior.** `positron-r` drops diagnostics for Quarto virtual documents (`lsp.ts`, for quarto-dev/quarto#855). Nothing ever landed on the vdoc URI, so the Quarto extension had nothing to remap. R diagnostics in a `.qmd` start here, and they do not duplicate.

**Python: unchanged for now.** Positron's own Python server publishes no diagnostics at all by design. Python diagnostics in a `.qmd` currently come from Pyrefly through the vdoc path, and will continue to do so for now. Pyrefly's server cannot open a `vscode-notebook-cell` URI, so nothing reaches our cells for this PR to remap. We're going to submit a PR to Pyrefly on this; the fix is very small. 🤞 The on-disk vdoc approach will keep working in the meantime.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

Nothing here is user visible yet. The feature is behind `quarto.embeddedLanguageFeatures.native`, which defaults to off.

### Validation Steps

@:quarto @:r-markdown @:problems

The problems suite is regression cover for the marker service change, which is workbench wide. The Quarto suites are regression cover only, because the setting defaults to off.

29 new unit tests, and 332 green across the touched areas:

- `positronMarkerExclusion.vitest.ts`: 7 cases against a real `MarkerService`, including the one that separates an exclusion from a filter, and one that keeps excluded markers out of the statistics.
- `quartoEmbeddedDiagnostics.vitest.ts`: 19 cases over the remap, the whole-set republish, out-of-span skipping, related information, the notification, the re-offset, the document that loses its last chunk, a diagnostic that arrives for a cell already spliced out, and the short circuit that keeps an unchanged set quiet.
- `quartoVirtualNotebookService.vitest.ts`: 3 cases over the exclusion lifecycle and the cleanup.
- The 18 upstream `markerService.test.ts` Mocha cases pass unedited, including all 7 resource-filter cases.

Value mutation of the remap, one field at a time (`severity`, `message`, `source`, `code`, `relatedInformation`), turns a test red in every case.

To check by hand:

1. Set `quarto.embeddedLanguageFeatures.native` to `true` and `positron.logLevel` to `trace`.
2. Open a Quarto document with an R chunk. Then start an R session and make it the active one. A running background session is not enough: only the foreground R console runs the language server that serves these cells, so every step below produces nothing without it, and shows no error.
3. Break something in an R chunk, for example `x <-` on a line of its own.
4. Expect a squiggle on the matching line, one Problems entry, and this line in the Window output channel. The line appears only when the remapped set really changes, so a document at rest stays quiet:

```
[QuartoEmbedded] diagnostics remapped 1 marker(s) from 1 cell(s) for doc.qmd
```

5. Fix the error. The entry clears.
6. Delete a chunk that has a diagnostic. Its entry goes with it.
7. Add prose lines above a chunk that has a diagnostic. The squiggle follows the chunk down.
8. Look for a second Problems group named after your file. (There should not be one.) That group is the cell URIs, and the marker service change exists to keep them out.

