### PR TITLE
Await the providers.json migration before the PWB Posit AI default

### DIFF
--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -47,7 +47,7 @@ import * as fs from 'fs';
 import { log } from './log';
 import { migrateAwsSettings } from './migration/aws';
 import { migrateSnowflakeSettings } from './migration/snowflake';
-import { registerProvidersJsonMigration } from './migration/providersJsonUi';
+import { autoMigrateProvidersJson, registerProvidersJsonMigration } from './migration/providersJsonUi';
 import { AuthProviderLogger } from './authProviderLogger';
 import { applyPwbPositAIDefault } from './pwbDefaults';
 import {
@@ -73,26 +73,31 @@ const SETTINGS_MIGRATIONS: readonly SettingsMigration[] = [
 ];
 
 /**
- * Runs the settings migrations, then primes the cached provider catalog.
+ * Runs the settings migrations, migrates them into providers.json, then primes
+ * the cached provider catalog.
  *
- * The order matters: the legacy-settings reader hands the catalog the same
- * `authentication.aws.credentials` / `authentication.snowflake.credentials`
- * keys these migrations write, so a catalog primed first misses migrated
- * AWS/Snowflake connections on the first run and resolves credentials against
- * the wrong profile until the debounced catalog watch catches up.
+ * The order is load-bearing in both directions: the providers.json migration
+ * reads the `authentication.aws.credentials` /
+ * `authentication.snowflake.credentials` keys the settings migrations write, and
+ * the catalog reads no legacy settings, so anything not in providers.json by
+ * prime time is missing when providers resolve credentials.
  *
- * `catalogOptions` and `migrations` are test seams; production passes neither.
+ * `catalogOptions`, `migrations` and `autoMigrate` are test seams; production
+ * passes none of them.
  */
 export async function migrateSettingsAndPrimeCatalog(
 	context: vscode.ExtensionContext,
 	catalogOptions: ProviderCatalogOptions = {},
 	migrations: readonly SettingsMigration[] = SETTINGS_MIGRATIONS,
+	autoMigrate: () => Promise<void> = autoMigrateProvidersJson,
 ): Promise<void> {
 	for (const { name, run } of migrations) {
 		await run().catch(err =>
 			log.error(`${name} settings migration failed: ${err}`)
 		);
 	}
+
+	await autoMigrate();
 
 	// Prime the cached provider catalog before registering providers so
 	// registration callbacks resolve connection config from it synchronously.

--- a/extensions/authentication/src/migration/providersJsonUi.ts
+++ b/extensions/authentication/src/migration/providersJsonUi.ts
@@ -14,13 +14,16 @@ import {
 
 export const MIGRATE_COMMAND_ID = 'authentication.migrateSettingsToProvidersJson';
 
-/** Registers the migration command and runs the one-time automatic migration. */
+/** Registers the migration command. */
 export function registerProvidersJsonMigration(context: vscode.ExtensionContext): void {
 	context.subscriptions.push(
 		vscode.commands.registerCommand(MIGRATE_COMMAND_ID, () => runMigrationCommand())
 	);
-	// Fire-and-forget: never block activation on the migration.
-	maybeAutoMigrate().catch(err =>
+}
+
+/** Runs the one-time automatic migration, resolving once providers.json is written. */
+export async function autoMigrateProvidersJson(): Promise<void> {
+	await maybeAutoMigrate().catch(err =>
 		log.error(`providers.json automatic migration failed: ${err}`)
 	);
 }
@@ -68,10 +71,12 @@ async function maybeAutoMigrate(): Promise<void> {
 	}
 
 	log.info('[migration] Auto-migration: migratable settings found and providers.json is empty; migrating');
-	await migrateAndReport({ overwrite: false });
+	await migrateAndReport({ overwrite: false, awaitNotification: false });
 }
 
-async function migrateAndReport(opts: { overwrite: boolean }): Promise<void> {
+async function migrateAndReport(
+	opts: { overwrite: boolean; awaitNotification?: boolean }
+): Promise<void> {
 	let result: MigrationResult;
 	try {
 		result = await runMigration(opts);
@@ -91,20 +96,13 @@ async function migrateAndReport(opts: { overwrite: boolean }): Promise<void> {
 	log.info(`[migration] Migration finished with outcome: ${result.outcome}`);
 	switch (result.outcome) {
 		case 'migrated': {
-			const viewFileAction = vscode.l10n.t('View File');
-			const showLogAction = vscode.l10n.t('Show Log');
-			const choice = await vscode.window.showInformationMessage(
-				vscode.l10n.t('Migrated {0} setting(s) to ~/.posit/ai/providers.json. Positron now reads Posit Assistant providers from this file; your original settings were not removed.', result.settingCount),
-				viewFileAction,
-				showLogAction
+			const notified = reportMigrated(result.settingCount).catch(err =>
+				log.error(`providers.json migration notification failed: ${err}`)
 			);
-			if (choice === viewFileAction) {
-				log.info('[migration] Opening providers.json in an editor');
-				const { PROVIDERS_CONFIG_PATH } = await import('ai-config/node');
-				const doc = await vscode.workspace.openTextDocument(PROVIDERS_CONFIG_PATH);
-				await vscode.window.showTextDocument(doc);
-			} else if (choice === showLogAction) {
-				log.show();
+			// The auto-migration is awaited before the catalog primes, so waiting
+			// on an action the user may never click would stall activation.
+			if (opts.awaitNotification !== false) {
+				await notified;
 			}
 			break;
 		}
@@ -118,6 +116,24 @@ async function migrateAndReport(opts: { overwrite: boolean }): Promise<void> {
 				vscode.l10n.t('No provider settings to migrate.')
 			);
 			break;
+	}
+}
+
+async function reportMigrated(settingCount: number): Promise<void> {
+	const viewFileAction = vscode.l10n.t('View File');
+	const showLogAction = vscode.l10n.t('Show Log');
+	const choice = await vscode.window.showInformationMessage(
+		vscode.l10n.t('Migrated {0} setting(s) to ~/.posit/ai/providers.json. Positron now reads Posit Assistant providers from this file; your original settings were not removed.', settingCount),
+		viewFileAction,
+		showLogAction
+	);
+	if (choice === viewFileAction) {
+		log.info('[migration] Opening providers.json in an editor');
+		const { PROVIDERS_CONFIG_PATH } = await import('ai-config/node');
+		const doc = await vscode.workspace.openTextDocument(PROVIDERS_CONFIG_PATH);
+		await vscode.window.showTextDocument(doc);
+	} else if (choice === showLogAction) {
+		log.show();
 	}
 }
 

--- a/extensions/authentication/src/test/activationOrdering.test.ts
+++ b/extensions/authentication/src/test/activationOrdering.test.ts
@@ -9,11 +9,18 @@ import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { migrateSettingsAndPrimeCatalog } from '../extension';
+import { migrateAwsSettings } from '../migration/aws';
+import { migrateSnowflakeSettings } from '../migration/snowflake';
 import { getCachedProvider } from '../providerCatalog';
 
 /** Minimal ExtensionContext stub: only `subscriptions` is read by initProviderCatalog. */
 function fakeContext(): vscode.ExtensionContext {
 	return { subscriptions: [] } as unknown as vscode.ExtensionContext;
+}
+
+/** Stands in for the providers.json auto-migration; the real one reads live settings. */
+function noopAutoMigrate(): Promise<void> {
+	return Promise.resolve();
 }
 
 /**
@@ -70,6 +77,7 @@ suite('activation ordering', () => {
 				{ name: 'first', run: async () => { order.push('first'); } },
 				{ name: 'second', run: async () => { order.push('second'); } },
 			],
+			noopAutoMigrate,
 		);
 
 		assert.deepStrictEqual(order, ['first', 'second', 'prime']);
@@ -85,6 +93,7 @@ suite('activation ordering', () => {
 				{ name: 'throws', run: async () => { throw new Error('boom'); } },
 				{ name: 'after', run: async () => { order.push('after'); } },
 			],
+			noopAutoMigrate,
 		);
 
 		assert.deepStrictEqual(order, ['after'], 'a rejected migration must not skip the ones after it');
@@ -101,7 +110,12 @@ suite('activation ordering', () => {
 			vscode.ConfigurationTarget.Global
 		);
 
-		await migrateSettingsAndPrimeCatalog(context, { configPath });
+		await migrateSettingsAndPrimeCatalog(
+			context,
+			{ configPath },
+			[{ name: 'AWS', run: migrateAwsSettings }],
+			noopAutoMigrate,
+		);
 
 		const aws = getCachedProvider('bedrock')?.connection.aws;
 		assert.deepStrictEqual(
@@ -117,7 +131,12 @@ suite('activation ordering', () => {
 			vscode.ConfigurationTarget.Global
 		);
 
-		await migrateSettingsAndPrimeCatalog(context, { configPath });
+		await migrateSettingsAndPrimeCatalog(
+			context,
+			{ configPath },
+			[{ name: 'Snowflake', run: migrateSnowflakeSettings }],
+			noopAutoMigrate,
+		);
 
 		assert.strictEqual(
 			getCachedProvider('snowflake-cortex')?.connection.snowflake?.account,

--- a/extensions/authentication/src/test/providersJsonMigrationRace.test.ts
+++ b/extensions/authentication/src/test/providersJsonMigrationRace.test.ts
@@ -1,0 +1,82 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { runMigration } from '../migration/migrateToProvidersJson';
+import { applyPwbPositAIDefault } from '../pwbDefaults';
+
+function makeContext(): vscode.ExtensionContext {
+	const globalState = new Map<string, unknown>();
+	return {
+		globalState: {
+			get: <T>(key: string) => globalState.get(key) as T | undefined,
+			update: (key: string, value: unknown) => {
+				globalState.set(key, value);
+				return Promise.resolve();
+			},
+		},
+	} as unknown as vscode.ExtensionContext;
+}
+
+const LEGACY_SETTINGS: Record<string, unknown> = {
+	'positron.assistant.provider.amazonBedrock.enable': true,
+	'positron.assistant.provider.positAI.enable': false,
+};
+
+/**
+ * `applyPwbPositAIDefault` writes `positai` into the same providers.json, so a
+ * migration that has not finished writing first sees a populated `providers`
+ * block and skips for good.
+ */
+suite('providers.json migration vs the PWB Posit AI default', () => {
+	let dir: string;
+	let configPath: string;
+
+	setup(() => {
+		dir = fs.mkdtempSync(path.join(os.tmpdir(), 'migration-race-'));
+		configPath = path.join(dir, 'providers.json');
+	});
+
+	teardown(() => {
+		fs.rmSync(dir, { recursive: true, force: true });
+	});
+
+	test('an awaited migration writes every provider before the PWB default runs', async () => {
+		await runMigration({
+			overwrite: false,
+			configPath,
+			reader: { globalValue: <T,>(key: string) => LEGACY_SETTINGS[key] as T | undefined },
+		});
+		await applyPwbPositAIDefault(makeContext(), true, { configPath });
+
+		const providers = JSON.parse(fs.readFileSync(configPath, 'utf8')).providers;
+		assert.deepStrictEqual(
+			{ bedrock: providers.bedrock?.enabled, positai: providers.positai?.enabled },
+			{ bedrock: true, positai: false },
+			'the migrated Bedrock block must survive the PWB default'
+		);
+	});
+
+	test('the PWB default winning the race blocks the migration', async () => {
+		await applyPwbPositAIDefault(makeContext(), true, { configPath });
+
+		const result = await runMigration({
+			overwrite: false,
+			configPath,
+			reader: { globalValue: <T,>(key: string) => LEGACY_SETTINGS[key] as T | undefined },
+		});
+
+		assert.strictEqual(result.outcome, 'skipped-populated');
+		assert.strictEqual(
+			JSON.parse(fs.readFileSync(configPath, 'utf8')).providers.bedrock,
+			undefined,
+			'this is the data loss the awaited ordering prevents'
+		);
+	});
+});


### PR DESCRIPTION
Fixes #15618

On Workbench, the Posit AI default and the providers.json migration both write `~/.posit/ai/providers.json` during activation, and neither waited for the other. The default ran first, created the file with only `positai` disabled, and the migration then found a populated providers block and skipped. Once the file has any provider the migration never runs again, so a user's configured models were left behind.

Positron now finishes the migration before Posit AI registers.

Only users who did not launch a 2026.07 Positron session are affected. A 2026.07 session recorded the Posit AI default, so the default is a no-op on upgrade and the migration runs unopposed.

Workbench Managed Credentials are configured in the session and ai-lib reads them first, so provider connections still work for an affected user. Their model overrides do not carry over.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Configured models now migrate to `~/.posit/ai/providers.json` on Posit Workbench. (#15618)

### Validation Steps

@:assistant

Add a Bedrock model override to your user settings:

```json
"positron.assistant.models.overrides.amazonBedrock": [
    {
        "identifier": "arn:aws:bedrock:us-east-2:654654567442:inference-profile/us.anthropic.claude-haiku-4-5-20251001-v1:0",
        "name": "Claude Haiku 4.5"
    }
]
```

Then simulate a user who has not launched a 2026.07 or 2026.08 Positron session:

1. On the Workbench homepage, open your browser's developer tools and go to the Application tab.
2. Under IndexedDB, open `positron-web-state-db-global` and delete the `positron.authentication` field.
3. Delete `~/.posit/ai/providers.json`.
4. Launch a Positron session.

Confirm `~/.posit/ai/providers.json` contains Claude Haiku 4.5 under the `bedrock` block, and that the migration notification appears.
