### PR TITLE
Add an e2e test for running a Workbench job

### DIFF
--- a/test/e2e/infra/workbench-pwb.ts
+++ b/test/e2e/infra/workbench-pwb.ts
@@ -7,11 +7,13 @@ import { Code } from './code';
 import { Workbench } from './workbench';
 import { DashboardPage } from '../pages/workbench/dashboard.page.js';
 import { AuthPage } from '../pages/workbench/auth.page.js';
+import { JobsPage } from '../pages/workbench/jobs.page.js';
 
 export class PositWorkbench extends Workbench {
 
-	readonly auth: AuthPage
+	readonly auth: AuthPage;
 	readonly dashboard: DashboardPage;
+	readonly jobs: JobsPage;
 
 
 	constructor(code: Code) {
@@ -21,5 +23,6 @@ export class PositWorkbench extends Workbench {
 		// Add workbench specific pages
 		this.auth = new AuthPage(code);
 		this.dashboard = new DashboardPage(code, this.quickInput);
+		this.jobs = new JobsPage(code, this.quickaccess);
 	}
 }

--- a/test/e2e/pages/output.ts
+++ b/test/e2e/pages/output.ts
@@ -5,6 +5,7 @@
 
 
 import * as os from 'os';
+import { expect } from '@playwright/test';
 import { Code } from '../infra/code';
 import { QuickAccess } from './quickaccess';
 import { QuickInput } from './quickInput';
@@ -37,6 +38,16 @@ export class Output {
 		const outputPane = this.code.driver.currentPage.locator(OUTPUT_PANE);
 		const outputLine = outputPane.locator(OUTPUT_LINE);
 		await outputLine.getByText(fragment).first().isVisible();
+	}
+
+	/**
+	 * Verify the output pane renders a line containing the given text. Unlike
+	 * `waitForOutContaining`, this retries until the text appears (or the timeout elapses), so it
+	 * is safe to call on output that is still streaming in.
+	 */
+	async expectOutputToContain(fragment: string, timeout = 15000): Promise<void> {
+		const outputLine = this.code.driver.currentPage.locator(OUTPUT_PANE).locator(OUTPUT_LINE);
+		await expect(outputLine.getByText(fragment).first()).toBeVisible({ timeout });
 	}
 
 	/**

--- a/test/e2e/pages/workbench/jobs.page.ts
+++ b/test/e2e/pages/workbench/jobs.page.ts
@@ -1,0 +1,142 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import test, { expect, FrameLocator, Locator } from '@playwright/test';
+import { Code } from '../../infra/code.js';
+import { QuickAccess } from '../quickaccess.js';
+
+/**
+ * Status labels the Workbench Jobs tree renders for a job. The extension labels the job row with
+ * the launcher status, except for a finished job, which it relabels "Succeeded" or "Failed" based
+ * on the exit code.
+ */
+export type WorkbenchJobStatus = 'Pending' | 'Running' | 'Succeeded' | 'Failed';
+
+/**
+ * The Workbench Jobs view (contributed by the rstudio.rstudio-workbench extension) and the
+ * "Run Workbench Job" launcher editor it opens.
+ *
+ * The launcher is a webview whose Script/Working Directory fields are read-only divs populated by
+ * the extension -- they can't be typed into. The extension seeds the Script field from the active
+ * editor, so the flow is: open the script, then open the launcher.
+ */
+export class JobsPage {
+	private get page() { return this.code.driver.currentPage; }
+
+	// Workbench Jobs view. While no job has been launched the pane renders its welcome content in
+	// place of the tree, so the section header -- not the tree -- is what says the view is open.
+	get activityBarIcon(): Locator { return this.page.locator('.activitybar').getByRole('tab', { name: 'Posit Workbench' }); }
+	get jobsSection(): Locator { return this.page.getByRole('button', { name: 'Workbench Jobs Section' }); }
+	get jobsTree(): Locator { return this.page.getByRole('tree', { name: 'Workbench Jobs' }); }
+	get runJobWelcomeButton(): Locator { return this.page.getByRole('button', { name: 'Run Job', exact: true }); }
+
+	// Run Workbench Job launcher (webview)
+	get launcherFrame(): FrameLocator { return this.page.frameLocator('iframe.webview.ready').frameLocator('iframe#active-frame'); }
+	get scriptPath(): Locator { return this.launcherFrame.locator('#launcher-script-path'); }
+	get workingDirectory(): Locator { return this.launcherFrame.locator('#launcher-workdir-path'); }
+	get jobName(): Locator { return this.launcherFrame.locator('#rstudio_label_job_name'); }
+	get startButton(): Locator { return this.launcherFrame.locator('#submit'); }
+
+	/**
+	 * The job rows in the tree. Level 1 rows are the scripts and level 2 rows are their jobs, which
+	 * the extension labels with the job's status rather than its name.
+	 */
+	get jobRows(): Locator { return this.jobsTree.locator('[role="treeitem"][aria-level="2"]'); }
+
+	/**
+	 * The row for the most recently submitted job. The extension sorts a script's jobs by
+	 * submission time descending, so this is the job the test just started -- matching on the
+	 * status label alone would also match a completed job left over from an earlier run.
+	 */
+	get latestJobRow(): Locator { return this.jobRows.first(); }
+
+	constructor(private code: Code, private quickaccess: QuickAccess) { }
+
+	// #region Actions
+
+	/**
+	 * Open the Posit Workbench view container from the activity bar. No-op when it is already the
+	 * active container, since clicking the icon again would collapse the side bar.
+	 */
+	async openView(): Promise<void> {
+		await test.step('Open Posit Workbench view', async () => {
+			if (!await this.jobsSection.isVisible()) {
+				await this.activityBarIcon.click();
+			}
+			await expect(this.jobsSection).toBeVisible();
+		});
+	}
+
+	/**
+	 * Open the "Run Workbench Job" launcher editor.
+	 *
+	 * Uses the view's welcome "Run Job" button, which is only rendered while the tree is empty; a
+	 * session that has already run a job replaces the welcome content with the job list, so fall
+	 * back to the command the view's title action runs.
+	 */
+	async openLauncher(): Promise<void> {
+		await test.step('Open Run Workbench Job launcher', async () => {
+			if (await this.runJobWelcomeButton.isVisible()) {
+				await this.runJobWelcomeButton.click();
+			} else {
+				await this.quickaccess.runCommand('workbenchJobs.run');
+			}
+			await expect(this.startButton).toBeVisible();
+		});
+	}
+
+	/**
+	 * Submit the job from the launcher. The Start button carries a `disabled` class until the
+	 * launcher has a job name and a script with a supported extension, so wait it out rather than
+	 * clicking into a no-op click handler.
+	 */
+	async startJob(): Promise<void> {
+		await test.step('Start Workbench job', async () => {
+			await expect(this.startButton).not.toHaveClass(/disabled/);
+			await this.startButton.click();
+		});
+	}
+
+	/**
+	 * Open the job's output channel via the tree row's inline "View Workbench Job" action. The
+	 * extension creates the channel on demand, so there is no channel to pick until this runs, and
+	 * the row's action bar only renders while the row is hovered.
+	 */
+	async openJobOutput(): Promise<void> {
+		await test.step('Open Workbench job output', async () => {
+			await this.latestJobRow.hover();
+			await this.latestJobRow.getByRole('button', { name: 'View Workbench Job' }).click();
+		});
+	}
+
+	// #endregion
+
+	// #region Verifications
+
+	/**
+	 * Verify the launcher opened seeded from the active editor: the script path, the job name it
+	 * derives from the script, and the working directory the extension resolves for the script.
+	 */
+	async expectLauncherToBeSeededWith(scriptName: string): Promise<void> {
+		await test.step(`Verify launcher is seeded with: ${scriptName}`, async () => {
+			await expect(this.scriptPath).toContainText(scriptName);
+			await expect(this.jobName).toHaveValue(scriptName.replace(/\.[^.]+$/, ''));
+			await expect(this.workingDirectory).not.toBeEmpty();
+		});
+	}
+
+	/**
+	 * Verify the Workbench Jobs tree lists the script and that its most recent job is in the given
+	 * state.
+	 */
+	async expectJobStatus(scriptName: string, status: WorkbenchJobStatus, timeout = 15000): Promise<void> {
+		await test.step(`Verify job for ${scriptName} is ${status}`, async () => {
+			await expect(this.jobsTree.getByRole('treeitem', { name: scriptName })).toBeVisible({ timeout });
+			await expect(this.latestJobRow).toContainText(status, { timeout });
+		});
+	}
+
+	// #endregion
+}

--- a/test/e2e/test-files/workspaces/README.md
+++ b/test/e2e/test-files/workspaces/README.md
@@ -59,3 +59,5 @@ A collection of Projects for testing and demos.  Please keep these organized and
    - Quarto python sample
 * diagrammeR-sample
    - Sample DiagrammeR plot
+* workbench-job
+   - R script that sleeps, run as a Posit Workbench job by the @:workbench run-job test

--- a/test/e2e/test-files/workspaces/workbench-job/sleep-job.R
+++ b/test/e2e/test-files/workspaces/workbench-job/sleep-job.R
@@ -1,0 +1,8 @@
+# Script for the Workbench job e2e test. It sleeps long enough for the test to
+# observe the job in the Running state, then prints a marker the test looks for
+# in the job output to confirm the script actually ran to completion.
+sleep_seconds <- 20
+
+cat("Workbench job started\n")
+Sys.sleep(sleep_seconds)
+cat(sprintf("Workbench job finished after %d seconds\n", sleep_seconds))

--- a/test/e2e/tests/workbench/run-job/run-job.test.ts
+++ b/test/e2e/tests/workbench/run-job/run-job.test.ts
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test, tags } from '../../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+const SCRIPT = 'sleep-job.R';
+// The marker sleep-job.R prints once its sleep is over.
+const FINISHED_MARKER = 'Workbench job finished after 20 seconds';
+
+test.describe('Workbench Jobs', {
+	tag: [tags.WORKBENCH],
+}, () => {
+
+	// The R session is what makes the job runnable: the launcher defaults its R Version to the
+	// foreground session's interpreter, and with no session it falls back to "(System Default)",
+	// which is the bare command `R` -- unresolvable in the job's environment (exit code 127).
+	test('Run an R script as a Workbench job', async function ({ app, openFile, r }) {
+		// The launcher's Script field is read-only and seeded from the active editor, so open the
+		// script first.
+		await openFile(`workspaces/workbench-job/${SCRIPT}`);
+
+		await app.positWorkbench.jobs.openView();
+		await app.positWorkbench.jobs.openLauncher();
+		await app.positWorkbench.jobs.expectLauncherToBeSeededWith(SCRIPT);
+		await app.positWorkbench.jobs.startJob();
+
+		// The script sleeps for 20s, so the job is observable in the Running state before it
+		// reaches Succeeded.
+		await app.positWorkbench.jobs.expectJobStatus(SCRIPT, 'Running', 30000);
+		await app.positWorkbench.jobs.expectJobStatus(SCRIPT, 'Succeeded', 60000);
+
+		// A zero exit code alone would not prove the script body ran, so check the job's streamed
+		// output for the marker it prints on the way out.
+		await app.positWorkbench.jobs.openJobOutput();
+		await app.workbench.output.expectOutputToContain(FINISHED_MARKER);
+	});
+});


### PR DESCRIPTION
### Summary

Adds e2e coverage for running a Workbench job, a flow that had none. The test opens an R script, opens the Posit Workbench view from the activity bar, clicks **Run Job**, starts the job from the Run Workbench Job launcher, and verifies it reaches Succeeded with the expected output.

Three details of the Workbench extension shaped the test:

- **The launcher's Script and Working Directory fields are read-only `div`s**, not inputs -- only the Browse dialog or the extension itself can fill them. The extension seeds them from the active editor, so the test opens the script first and asserts the launcher arrives pre-filled with the script, the derived job name, and a resolved working directory. That avoids driving a file-picker quick input.
- **The test starts an R session.** The launcher defaults its R Version to the foreground session's interpreter; with no session it falls back to `(System Default)`, which `RuntimeManager` defines as the bare command `R`. The job environment (`HOME`/`USER` only) cannot resolve that, and the job dies with exit 127. Worth a follow-up issue -- a user who opens an `.R` file in a fresh session and hits Run Job gets a silent failure -- but out of scope here.
- **Job rows are matched by position, not by status label.** The tree labels a job row with its status rather than its name, and the launcher keeps a user's job history across sessions. Matching on the label found a completed job from an earlier run and passed in 7.5s without ever waiting on the new one. The rows are level-2 tree items sorted newest-first, so the test asserts against the first one.

Supporting changes: `JobsPage` is exposed as `app.positWorkbench.jobs`, and `Output` gains `expectOutputToContain()` -- a retrying assertion, unlike the existing `waitForOutContaining()`, which calls `isVisible()` without awaiting an expectation and so never actually waits. Existing callers are untouched.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:workbench @:workbench-rocky

Verified locally against a Workbench container: passes in ~27s, including the script's 20s sleep. Re-run against a session already holding four completed `sleep-job` rows to confirm the test tracks the newly submitted job rather than a leftover one.

```bash
npx playwright test test/e2e/tests/workbench/run-job/run-job.test.ts --project e2e-workbench
```
