### PR TITLE
python: change global venv to ~/.virtualenvs/positron

### DIFF
--- a/extensions/positron-python/src/client/common/utils/localize.ts
+++ b/extensions/positron-python/src/client/common/utils/localize.ts
@@ -339,8 +339,27 @@ export namespace InterpreterQuickPickList {
         export const refreshingEnvironments = l10n.t('Refreshing environments');
         export const globalVenvCreated = (path: string) => l10n.t('Virtual environment created at {0}', path);
     }
-    // --- End Positron ---
 }
+
+/**
+ * Messages for the global environment Positron creates when no folder is open.
+ * There is exactly one global environment path, and Positron never manages an
+ * environment that is already there, so both failure modes just name the path.
+ */
+export namespace GlobalEnvironment {
+    export const occupied = (venvPath: string) =>
+        l10n.t(
+            'Could not create the global Python environment because something already exists at {0}. Move or remove it and try again.',
+            venvPath,
+        );
+    export const creationFailed = (venvPath: string) =>
+        l10n.t('Failed to create the global Python environment at {0}.', venvPath);
+    export const unsupported = () =>
+        l10n.t(
+            'Could not create the global Python environment because no home directory was found. Set WORKON_HOME to a directory to use for it.',
+        );
+}
+// --- End Positron ---
 
 export namespace OutputChannelNames {
     export const languageServer = l10n.t('Python Language Server');

--- a/extensions/positron-python/src/client/positron/discoveryRootSignature.ts
+++ b/extensions/positron-python/src/client/positron/discoveryRootSignature.ts
@@ -11,6 +11,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 import { getPyenvDir } from '../pythonEnvironments/common/environmentManagers/pyenv';
+import { getGlobalEnvironmentParent } from '../pythonEnvironments/common/environmentManagers/globalEnvironment';
 import { getUserHomeDir } from '../common/utils/platform';
 
 /**
@@ -170,6 +171,9 @@ function getDefaultInterpreterParent(): string | undefined {
  *   - uv-managed Python install dir (UV_PYTHON_INSTALL_DIR / UV_STATE_DIR /
  *     `<data>/uv/python`).
  *   - Hatch virtual-env root (per-OS data dir).
+ *   - Global virtualenv parents: $WORKON_HOME when set, and `~/.virtualenvs`
+ *     (which the global virtualenv locator scans either way). This is where
+ *     Positron puts the environment it creates with no folder open.
  *   - Windows-known Python install roots (LOCALAPPDATA / ProgramFiles).
  *   - The parent of `python.defaultInterpreterPath`.
  *   - Discovery-gating settings (`python.interpreters.include` / `.exclude` /
@@ -223,6 +227,14 @@ export async function getPythonDiscoveryRootSignature(): Promise<positron.Runtim
     addAll([getHatchVirtualEnvRoot()]);
     addAll(getWindowsKnownRoots());
     addAll([getDefaultInterpreterParent()]);
+
+    // Parent of the environment Positron creates when no folder is open
+    // ($WORKON_HOME, default ~/.virtualenvs). Also catches environments users
+    // create there by hand: virtualenvwrapper, reticulate, a manual `uv venv`.
+    // The global virtualenv locator scans ~/.virtualenvs whether or not
+    // WORKON_HOME is set, so sign both; the dedupe below collapses them when
+    // they are the same directory.
+    addAll([getGlobalEnvironmentParent(), home ? path.join(home, '.virtualenvs') : undefined]);
 
     // Dedupe by resolved path -- two settings/defaults may both land at the
     // same physical location (e.g. PYENV_ROOT explicitly set to ~/.pyenv).

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/globalEnvironment.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/globalEnvironment.ts
@@ -1,0 +1,134 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as path from 'path';
+import { untildify } from '../../../common/helpers';
+import { getEnvironmentVariable, getUserHomeDir } from '../../../common/utils/platform';
+import * as fsapi from '../../../common/platform/fs-paths';
+import { traceError, traceInfo } from '../../../logging';
+import { execUv } from './uv';
+
+/**
+ * Directory name of the environment Positron creates when no folder is open.
+ * Doubles as the name shown in the interpreter picker, e.g. "Python 3.13 ('positron')".
+ */
+export const GLOBAL_ENVIRONMENT_NAME = 'positron';
+
+/**
+ * Parent directory the global environment lives in.
+ *
+ * `$WORKON_HOME` when set, otherwise `~/.virtualenvs`. This deliberately mirrors
+ * `getGlobalVirtualEnvDirs()` in `globalVirtualEnvronmentLocator.ts` (including the
+ * tilde expansion and `getUserHomeDir()` rather than `os.homedir()`), and the
+ * equivalent list in PET's `pet-global-virtualenvs` pass, so the directory we create
+ * is one that discovery already scans on every OS.
+ *
+ * @returns The parent directory, or `undefined` when there is no `$WORKON_HOME` and
+ *   no home directory. Falling back to `os.homedir()` there would put the environment
+ *   somewhere the locator does not look, so there is deliberately no global
+ *   environment at all in that case.
+ */
+export function getGlobalEnvironmentParent(): string | undefined {
+    const workonHome = getEnvironmentVariable('WORKON_HOME');
+    if (workonHome) {
+        return untildify(workonHome);
+    }
+    const home = getUserHomeDir();
+    return home ? path.join(home, '.virtualenvs') : undefined;
+}
+
+/**
+ * Full path to the global environment. This is the venv itself: `pyvenv.cfg` and
+ * `bin/` (or `Scripts/`) sit directly inside it. It is never a `.venv` nested one
+ * level deeper, because locators enumerate only the immediate children of the
+ * parent and would not see a nested layout.
+ */
+export function getGlobalEnvironmentDir(): string | undefined {
+    const parent = getGlobalEnvironmentParent();
+    return parent ? path.join(parent, GLOBAL_ENVIRONMENT_NAME) : undefined;
+}
+
+/**
+ * Path to a venv's Python executable.
+ *
+ * Deliberately duplicated from the workspace `.venv` helpers rather than shared:
+ * those live in upstream Microsoft files, take a `WorkspaceFolder`, and hard-code
+ * `<folder>/.venv`. Keeping the global path out of them is what structurally
+ * prevents the nested `.venv` layout.
+ */
+export function getGlobalEnvironmentPython(venvDir: string): string {
+    return process.platform === 'win32'
+        ? path.join(venvDir, 'Scripts', 'python.exe')
+        : path.join(venvDir, 'bin', 'python');
+}
+
+/**
+ * Outcome of trying to create the global environment.
+ *
+ * There is no `reused` outcome by design: Positron never inspects, reuses,
+ * upgrades, or deletes an environment that is already at the global path. A user
+ * who needs several Python versions should open a folder, or manage the parent
+ * directory by hand.
+ */
+export type GlobalEnvironmentResult =
+    | { outcome: 'created'; venvDir: string; pythonPath: string }
+    | { outcome: 'occupied'; venvDir: string }
+    | { outcome: 'failed'; venvDir: string }
+    | { outcome: 'unsupported' };
+
+/**
+ * Creates the global environment at `$WORKON_HOME/positron`.
+ *
+ * @param base What uv should build the environment from: either a `major.minor`
+ *   version string or the path to a base interpreter. Every calling surface has
+ *   one in hand, so there is no default-version path here.
+ * @returns `created` with the new environment's Python, `occupied` if anything is
+ *   already at the path, `failed` if creation did not succeed, or `unsupported` if
+ *   there is no directory discovery would scan (no `$WORKON_HOME`, no home dir).
+ *   Callers surface the matching message from the `GlobalEnvironment` localize
+ *   namespace and fall back to their base interpreter.
+ */
+export async function createGlobalEnvironment(base: string): Promise<GlobalEnvironmentResult> {
+    const parentDir = getGlobalEnvironmentParent();
+    if (!parentDir) {
+        traceError('Cannot create the global environment: no WORKON_HOME and no home directory.');
+        return { outcome: 'unsupported' };
+    }
+
+    const venvDir = path.join(parentDir, GLOBAL_ENVIRONMENT_NAME);
+    const pythonPath = getGlobalEnvironmentPython(venvDir);
+
+    try {
+        // Existence is the only check: no pyvenv.cfg parse, no version comparison.
+        if (await fsapi.pathExists(venvDir)) {
+            traceError(`Global environment path is already occupied: ${venvDir}`);
+            return { outcome: 'occupied', venvDir };
+        }
+
+        // Neither ~/.virtualenvs nor a custom WORKON_HOME is guaranteed to exist,
+        // and PET only scans directories that do.
+        await fsapi.mkdirp(parentDir);
+
+        traceInfo(`Creating global environment at ${venvDir} from ${base}...`);
+        // --seed installs pip/setuptools for compatibility. --no-project matches the
+        // workspace flow in uvCreationProvider and keeps whatever pyproject.toml happens
+        // to sit above the extension host's cwd from constraining the environment.
+        await execUv('uv', ['venv', venvDir, '--no-project', '--seed', '-p', base], { throwOnStdErr: false });
+
+        // execUv resolves on a nonzero exit when throwOnStdErr is false, so a
+        // resolved call is not proof that uv built anything. The interpreter
+        // existing on disk is.
+        if (!(await fsapi.pathExists(pythonPath))) {
+            traceError(`Global environment creation left no interpreter at ${pythonPath}`);
+            return { outcome: 'failed', venvDir };
+        }
+    } catch (error) {
+        traceError(`Failed to create global environment at ${venvDir}: ${error}`);
+        return { outcome: 'failed', venvDir };
+    }
+
+    traceInfo(`Global environment created at ${pythonPath}`);
+    return { outcome: 'created', venvDir, pythonPath };
+}

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uvPythonInstaller.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uvPythonInstaller.ts
@@ -3,21 +3,35 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as os from 'os';
-import * as path from 'path';
 import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { traceError, traceInfo } from '../../../logging';
 import { exec } from '../externalDependencies';
 import { isUvInstalled, getAvailablePythonVersions, resetUvCache, isWindowsArm64, execUv } from './uv';
 import { Commands } from '../../../common/constants';
-import { Common, InterpreterQuickPickList } from '../../../common/utils/localize';
+import { Common, GlobalEnvironment, InterpreterQuickPickList } from '../../../common/utils/localize';
 import { getWorkspaceFolders } from '../../../common/vscodeApis/workspaceApis';
 import { createUvVenv } from '../../creation/provider/uvCreationProvider';
 import { ExistingVenvAction, deleteEnvironment, pickExistingVenvAction } from '../../creation/provider/venvUtils';
 import { getVenvExecutable, hasVenv } from '../../creation/common/commonUtils';
 import { MultiStepAction } from '../../../common/vscodeApis/windowApis';
 import { refreshEnvironments } from '../../../envExt/api.internal';
+import { createGlobalEnvironment, GlobalEnvironmentResult } from './globalEnvironment';
+
+/**
+ * Message to show when the global environment could not be created.
+ * @param result A non-`created` outcome from `createGlobalEnvironment()`.
+ */
+function globalEnvironmentErrorMessage(result: Exclude<GlobalEnvironmentResult, { outcome: 'created' }>): string {
+    switch (result.outcome) {
+        case 'occupied':
+            return GlobalEnvironment.occupied(result.venvDir);
+        case 'unsupported':
+            return GlobalEnvironment.unsupported();
+        default:
+            return GlobalEnvironment.creationFailed(result.venvDir);
+    }
+}
 
 /**
  * Shows an error notification for the uv Python install flow with a button that
@@ -127,56 +141,11 @@ async function installPythonVersionAndGetPath(version: string, identifier?: stri
 }
 
 /**
- * Gets the path to the global venv in the user's home directory.
- * @returns The path to ~/.venv (or equivalent on Windows)
- */
-function getGlobalVenvPath(): string {
-    return path.join(os.homedir(), '.venv');
-}
-
-/**
- * Creates a global virtual environment for use when no workspace is open.
- * The venv is created at ~/.venv so that `uv pip install` works from the home directory.
- * @param version The Python version (e.g., "3.13")
- * @param progress Progress reporter
- * @returns The path to the venv's Python executable, or undefined if creation failed
- */
-async function createGlobalVenv(
-    version: string,
-    progress: vscode.Progress<{ message?: string }>,
-): Promise<string | undefined> {
-    const venvPath = getGlobalVenvPath();
-
-    traceInfo(`Creating global venv at ${venvPath}...`);
-    progress.report({ message: InterpreterQuickPickList.UvInstall.creatingVenv });
-
-    try {
-        // Create the venv using uv
-        // --seed installs pip/setuptools for compatibility
-        const args = ['venv', venvPath, '--seed', '-p', version];
-        await execUv('uv', args, { throwOnStdErr: false });
-
-        // Return the path to the Python executable
-        const pythonPath =
-            process.platform === 'win32'
-                ? path.join(venvPath, 'Scripts', 'python.exe')
-                : path.join(venvPath, 'bin', 'python');
-
-        traceInfo(`Global venv created at ${pythonPath}`);
-        return pythonPath;
-    } catch (error) {
-        traceError(`Failed to create global venv: ${error}`);
-        return undefined;
-    }
-}
-
-/**
  * Creates a uv venv at the given folder, reusing the Create Environment "use
  * existing / delete and recreate" flow when a `.venv` already exists there. uv
  * fails outright if a `.venv` already exists, so this collision must be handled.
  *
- * @param folder The folder to create the venv in (the open workspace, or a
- *   home-directory stand-in for the global `~/.venv` case).
+ * @param folder The open workspace folder to create the venv in.
  * @param create Creates the venv once any existing one has been resolved.
  * @returns `venvPython` is the venv's Python executable (from a fresh create or
  *   an existing env the user chose to keep), or undefined if creation failed or
@@ -383,22 +352,16 @@ export async function installPythonViaUv(): Promise<InstallPythonResult> {
                         }
                     }
                 } else {
-                    // No workspace - create (or reuse) a global venv at ~/.venv. The existing-venv
-                    // helpers are workspace-folder based, so wrap the home directory in a
-                    // WorkspaceFolder to reuse the same use-existing / recreate handling.
-                    const homeFolder: vscode.WorkspaceFolder = {
-                        uri: vscode.Uri.file(os.homedir()),
-                        name: 'home',
-                        index: 0,
-                    };
-                    const venvResult = await createVenvHandlingExisting(homeFolder, () =>
-                        createGlobalVenv(selected.version, progress),
-                    );
-                    if (venvResult.venvPython) {
-                        resolvedPath = venvResult.venvPython;
-                        venvWasCreated = venvResult.attempted;
-                    } else if (venvResult.attempted) {
-                        progress.report({ message: InterpreterQuickPickList.UvInstall.venvCreationFailed });
+                    // No workspace - create the global environment at $WORKON_HOME/positron
+                    // (default ~/.virtualenvs/positron), a directory every locator already scans.
+                    // Nothing already at that path is reused, upgraded, or deleted.
+                    progress.report({ message: InterpreterQuickPickList.UvInstall.creatingVenv });
+                    const globalResult = await createGlobalEnvironment(selected.version);
+                    if (globalResult.outcome === 'created') {
+                        resolvedPath = globalResult.pythonPath;
+                        venvWasCreated = true;
+                    } else {
+                        await showUvInstallError(globalEnvironmentErrorMessage(globalResult));
                     }
                 }
 

--- a/extensions/positron-python/src/test/positron/discoveryRootSignature.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/discoveryRootSignature.unit.test.ts
@@ -1,0 +1,83 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import * as typemoq from 'typemoq';
+import { WorkspaceConfiguration } from 'vscode';
+import { anything, when } from 'ts-mockito';
+import * as platformApis from '../../client/common/utils/platform';
+import { getPythonDiscoveryRootSignature } from '../../client/positron/discoveryRootSignature';
+import { mockedVSCodeNamespaces } from '../vscode-mock';
+
+suite('Python discovery root signature', () => {
+    // A home directory that does not exist on disk, so every entry is recorded
+    // verbatim (an existing path would be replaced by its realpath).
+    const homeDir = path.join('/', 'nonexistent-home-for-tests');
+    let getEnvironmentVariableStub: sinon.SinonStub;
+    let getUserHomeDirStub: sinon.SinonStub;
+
+    setup(() => {
+        getUserHomeDirStub = sinon.stub(platformApis, 'getUserHomeDir').returns(homeDir);
+        getEnvironmentVariableStub = sinon.stub(platformApis, 'getEnvironmentVariable');
+        getEnvironmentVariableStub.returns(undefined);
+
+        const configMock = typemoq.Mock.ofType<WorkspaceConfiguration>();
+        configMock.setup((c) => c.get(typemoq.It.isAnyString())).returns(() => undefined);
+        when(mockedVSCodeNamespaces.workspace!.getConfiguration(anything())).thenReturn(configMock.object);
+    });
+
+    teardown(() => {
+        sinon.restore();
+    });
+
+    test('Includes ~/.virtualenvs so environments created there are noticed on a warm start', async () => {
+        const signature = await getPythonDiscoveryRootSignature();
+
+        const paths = signature.entries.map((e) => e.path);
+        assert.ok(
+            paths.includes(path.join(homeDir, '.virtualenvs')),
+            `expected ~/.virtualenvs among roots, got ${JSON.stringify(paths)}`,
+        );
+    });
+
+    test('Records both WORKON_HOME and ~/.virtualenvs when WORKON_HOME is set, matching the locator', async () => {
+        const workonHome = path.join('/', 'nonexistent-workon-for-tests');
+        getEnvironmentVariableStub.withArgs('WORKON_HOME').returns(workonHome);
+
+        const signature = await getPythonDiscoveryRootSignature();
+
+        const paths = signature.entries.map((e) => e.path);
+        assert.ok(paths.includes(workonHome), `expected ${workonHome} among roots, got ${JSON.stringify(paths)}`);
+        assert.ok(
+            paths.includes(path.join(homeDir, '.virtualenvs')),
+            `the locator scans ~/.virtualenvs even with WORKON_HOME set, got ${JSON.stringify(paths)}`,
+        );
+    });
+
+    test('Signs no global environment parent when HOME and USERPROFILE are unset', async () => {
+        // The global virtualenv locator skips ~/.virtualenvs entirely without a home
+        // directory, and Positron creates no global environment there either, so there
+        // is nothing to sign. Signing os.homedir() instead would track a directory
+        // discovery never scans.
+        getUserHomeDirStub.returns(undefined);
+
+        const signature = await getPythonDiscoveryRootSignature();
+
+        const paths = signature.entries.map((e) => e.path);
+        assert.ok(
+            !paths.some((p) => p.endsWith('.virtualenvs')),
+            `expected no ~/.virtualenvs root without a home dir, got ${JSON.stringify(paths)}`,
+        );
+    });
+
+    test('Records each root once', async () => {
+        const signature = await getPythonDiscoveryRootSignature();
+
+        const paths = signature.entries.map((e) => e.path);
+        assert.strictEqual(new Set(paths).size, paths.length, `duplicate roots in ${JSON.stringify(paths)}`);
+    });
+});

--- a/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/globalEnvironment.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/globalEnvironment.unit.test.ts
@@ -1,0 +1,209 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as os from 'os';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import * as platformApis from '../../../../client/common/utils/platform';
+import * as fsapi from '../../../../client/common/platform/fs-paths';
+import * as externalDependencies from '../../../../client/pythonEnvironments/common/externalDependencies';
+import * as logging from '../../../../client/logging';
+import {
+    getGlobalEnvironmentDir,
+    getGlobalEnvironmentParent,
+    getGlobalEnvironmentPython,
+    createGlobalEnvironment,
+} from '../../../../client/pythonEnvironments/common/environmentManagers/globalEnvironment';
+
+suite('Global environment path', () => {
+    const homeDir = path.join('/', 'home', 'testuser');
+    let getEnvironmentVariableStub: sinon.SinonStub;
+    let getUserHomeDirStub: sinon.SinonStub;
+
+    setup(() => {
+        getUserHomeDirStub = sinon.stub(platformApis, 'getUserHomeDir').returns(homeDir);
+        getEnvironmentVariableStub = sinon.stub(platformApis, 'getEnvironmentVariable');
+        getEnvironmentVariableStub.returns(undefined);
+    });
+
+    teardown(() => {
+        sinon.restore();
+    });
+
+    test('Defaults the parent to ~/.virtualenvs when WORKON_HOME is unset', () => {
+        assert.strictEqual(getGlobalEnvironmentParent(), path.join(homeDir, '.virtualenvs'));
+    });
+
+    test('Falls through to the default when WORKON_HOME is empty', () => {
+        getEnvironmentVariableStub.withArgs('WORKON_HOME').returns('');
+
+        assert.strictEqual(getGlobalEnvironmentParent(), path.join(homeDir, '.virtualenvs'));
+    });
+
+    test('Has no default parent when HOME and USERPROFILE are unset', () => {
+        // The global virtualenv locator skips ~/.virtualenvs entirely without a home
+        // directory. Falling back to os.homedir() here would create an environment
+        // discovery could never find.
+        getUserHomeDirStub.returns(undefined);
+
+        assert.strictEqual(getGlobalEnvironmentParent(), undefined);
+        assert.strictEqual(getGlobalEnvironmentDir(), undefined);
+    });
+
+    test('Still uses WORKON_HOME when there is no home directory', () => {
+        getUserHomeDirStub.returns(undefined);
+        getEnvironmentVariableStub.withArgs('WORKON_HOME').returns(path.join('/', 'custom', 'workon'));
+
+        assert.strictEqual(getGlobalEnvironmentDir(), path.join('/', 'custom', 'workon', 'positron'));
+    });
+
+    test('Uses WORKON_HOME as the parent when it is set', () => {
+        getEnvironmentVariableStub.withArgs('WORKON_HOME').returns(path.join('/', 'custom', 'workon'));
+
+        assert.strictEqual(getGlobalEnvironmentParent(), path.join('/', 'custom', 'workon'));
+    });
+
+    test('Expands a leading tilde in WORKON_HOME, matching the global virtualenv locator', () => {
+        getEnvironmentVariableStub.withArgs('WORKON_HOME').returns('~/workon');
+
+        // untildify only swaps the leading ~ for the home directory and leaves the rest of
+        // the string alone, so the separator the user typed survives even on Windows.
+        assert.strictEqual(getGlobalEnvironmentParent(), `${os.homedir()}/workon`);
+    });
+
+    test('Places the environment directly under the parent, never in a nested .venv', () => {
+        // Discovery scans only the children of the parent, so a nested layout would be
+        // invisible to PET and to every other locator.
+        assert.strictEqual(getGlobalEnvironmentDir(), path.join(homeDir, '.virtualenvs', 'positron'));
+    });
+
+    test('Resolves the venv Python executable for the current platform', () => {
+        const venvDir = path.join(homeDir, '.virtualenvs', 'positron');
+        const expected =
+            process.platform === 'win32'
+                ? path.join(venvDir, 'Scripts', 'python.exe')
+                : path.join(venvDir, 'bin', 'python');
+
+        assert.strictEqual(getGlobalEnvironmentPython(venvDir), expected);
+    });
+});
+
+suite('createGlobalEnvironment', () => {
+    const homeDir = path.join('/', 'home', 'testuser');
+    const parentDir = path.join(homeDir, '.virtualenvs');
+    const venvDir = path.join(parentDir, 'positron');
+    const pythonPath = getGlobalEnvironmentPython(venvDir);
+
+    let execStub: sinon.SinonStub;
+    let pathExistsStub: sinon.SinonStub;
+    let mkdirpStub: sinon.SinonStub;
+    let getUserHomeDirStub: sinon.SinonStub;
+
+    setup(() => {
+        getUserHomeDirStub = sinon.stub(platformApis, 'getUserHomeDir').returns(homeDir);
+        sinon.stub(platformApis, 'getEnvironmentVariable').returns(undefined);
+        sinon.stub(logging, 'traceInfo');
+        sinon.stub(logging, 'traceError');
+        execStub = sinon.stub(externalDependencies, 'exec').resolves({ stdout: '' });
+        // The venv path is free; uv leaves an interpreter behind.
+        pathExistsStub = sinon.stub(fsapi, 'pathExists').resolves(false);
+        pathExistsStub.withArgs(pythonPath).resolves(true);
+        mkdirpStub = sinon.stub(fsapi, 'mkdirp').resolves();
+    });
+
+    teardown(() => {
+        sinon.restore();
+    });
+
+    test('Creates the environment and returns its Python when the path is free', async () => {
+        const result = await createGlobalEnvironment('3.13');
+
+        assert.deepStrictEqual(result, { outcome: 'created', venvDir, pythonPath });
+        assert.ok(
+            execStub.calledWith('uv', ['--color', 'never', 'venv', venvDir, '--no-project', '--seed', '-p', '3.13'], {
+                throwOnStdErr: false,
+            }),
+            'uv venv should be invoked with --seed and the requested base',
+        );
+    });
+
+    test('Creates the parent directory first, since PET only scans directories that exist', async () => {
+        await createGlobalEnvironment('3.13');
+
+        assert.ok(mkdirpStub.calledOnceWithExactly(parentDir));
+        assert.ok(mkdirpStub.calledBefore(execStub), 'the parent must exist before uv venv runs');
+    });
+
+    test('Accepts a base interpreter path as well as a version', async () => {
+        await createGlobalEnvironment('/usr/local/bin/python3.13');
+
+        assert.ok(
+            execStub.calledWith(
+                'uv',
+                ['--color', 'never', 'venv', venvDir, '--no-project', '--seed', '-p', '/usr/local/bin/python3.13'],
+                { throwOnStdErr: false },
+            ),
+        );
+    });
+
+    test('Reports occupied without touching anything when the path already exists', async () => {
+        pathExistsStub.withArgs(venvDir).resolves(true);
+
+        const result = await createGlobalEnvironment('3.13');
+
+        assert.deepStrictEqual(result, { outcome: 'occupied', venvDir });
+        // Never inspect, reuse, upgrade, or delete what is already there.
+        assert.ok(!execStub.called, 'uv should not run against an occupied path');
+        assert.ok(!mkdirpStub.called, 'nothing should be created when the path is occupied');
+    });
+
+    test('Reports failed when uv venv fails', async () => {
+        execStub.rejects(new Error('uv venv exploded'));
+
+        const result = await createGlobalEnvironment('3.13');
+
+        assert.deepStrictEqual(result, { outcome: 'failed', venvDir });
+    });
+
+    test('Reports failed when the parent directory cannot be created', async () => {
+        mkdirpStub.rejects(new Error('EACCES'));
+
+        const result = await createGlobalEnvironment('3.13');
+
+        assert.deepStrictEqual(result, { outcome: 'failed', venvDir });
+        assert.ok(!execStub.called);
+    });
+
+    test('Reports failed when uv resolves but leaves no interpreter behind', async () => {
+        // exec resolves on a nonzero exit when throwOnStdErr is false, so a resolved
+        // call is not proof that the environment exists.
+        execStub.resolves({ stdout: '', stderr: 'error: no interpreter found for 3.13' });
+        pathExistsStub.withArgs(pythonPath).resolves(false);
+
+        const result = await createGlobalEnvironment('3.13');
+
+        assert.deepStrictEqual(result, { outcome: 'failed', venvDir });
+    });
+
+    test('Reports unsupported without creating anything when there is nowhere discovery scans', async () => {
+        getUserHomeDirStub.returns(undefined);
+
+        const result = await createGlobalEnvironment('3.13');
+
+        assert.deepStrictEqual(result, { outcome: 'unsupported' });
+        assert.ok(!mkdirpStub.called, 'nothing should be created outside a discovered directory');
+        assert.ok(!execStub.called);
+    });
+
+    test('Reports failed when the occupancy check itself fails', async () => {
+        pathExistsStub.withArgs(venvDir).rejects(new Error('EACCES'));
+
+        const result = await createGlobalEnvironment('3.13');
+
+        assert.deepStrictEqual(result, { outcome: 'failed', venvDir });
+        assert.ok(!execStub.called);
+    });
+});

--- a/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uvPythonInstaller.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uvPythonInstaller.unit.test.ts
@@ -17,19 +17,20 @@ import * as uvCreationProvider from '../../../../client/pythonEnvironments/creat
 import * as commonCreationUtils from '../../../../client/pythonEnvironments/creation/common/commonUtils';
 import * as venvUtils from '../../../../client/pythonEnvironments/creation/provider/venvUtils';
 import * as apiInternal from '../../../../client/envExt/api.internal';
+import * as platformApis from '../../../../client/common/utils/platform';
+import * as fsapi from '../../../../client/common/platform/fs-paths';
 import { getAvailablePythonVersions } from '../../../../client/pythonEnvironments/common/environmentManagers/uv';
 import {
     installPythonViaUv,
     showUvInstallError,
 } from '../../../../client/pythonEnvironments/common/environmentManagers/uvPythonInstaller';
 import { mockedPositronNamespaces, mockedVSCodeNamespaces } from '../../../vscode-mock';
-import { Common, InterpreterQuickPickList } from '../../../../client/common/utils/localize';
+import { Common, GlobalEnvironment, InterpreterQuickPickList } from '../../../../client/common/utils/localize';
 import { Commands } from '../../../../client/common/constants';
 
-// Helper to get expected global venv path
-function getExpectedGlobalVenvPython(): string {
-    const homeDir = os.homedir();
-    const venvPath = path.join(homeDir, '.venv');
+// Helper to get expected global environment path
+function getExpectedGlobalEnvPython(): string {
+    const venvPath = path.join(os.homedir(), '.virtualenvs', 'positron');
     return process.platform === 'win32'
         ? path.join(venvPath, 'Scripts', 'python.exe')
         : path.join(venvPath, 'bin', 'python');
@@ -411,6 +412,18 @@ suite('UV Python Installer Tests', () => {
             sinon.stub(apiInternal, 'refreshEnvironments').resolves();
             sinon.stub(logging, 'traceInfo');
 
+            // The global environment path reads WORKON_HOME; pin it so a developer's own
+            // virtualenvwrapper setup cannot change what these tests expect.
+            sinon.stub(platformApis, 'getEnvironmentVariable').returns(undefined);
+            sinon.stub(platformApis, 'getUserHomeDir').returns(os.homedir());
+            // Global environment creation checks for an existing directory, creates the
+            // parent, then checks that uv left an interpreter behind. All must be stubbed:
+            // unstubbed, these hit the real home directory. The default is a free path
+            // where creation succeeds.
+            sinon.stub(fsapi, 'pathExists').resolves(false);
+            (fsapi.pathExists as sinon.SinonStub).withArgs(getExpectedGlobalEnvPython()).resolves(true);
+            sinon.stub(fsapi, 'mkdirp').resolves();
+
             quickPickCallCount = 0;
             quickPickResponses = [];
 
@@ -433,6 +446,7 @@ suite('UV Python Installer Tests', () => {
             });
 
             when(mockedVSCodeNamespaces.window!.showErrorMessage(anything())).thenResolve(undefined);
+            when(mockedVSCodeNamespaces.window!.showErrorMessage(anything(), anything())).thenResolve(undefined);
             // Default: user confirms uv installation when prompted (4 args: message, options, install button, learn more)
             when(
                 mockedVSCodeNamespaces.window!.showInformationMessage(anything(), anything(), anything(), anything()),
@@ -542,28 +556,52 @@ suite('UV Python Installer Tests', () => {
             // Error message shown via vscode.window.showErrorMessage
         });
 
-        test('Creates global venv when no workspace is open', async () => {
+        test('Creates the global environment at ~/.virtualenvs/positron when no workspace is open', async () => {
             isUvInstalledStub.resolves(true);
-            // Return available versions via stub
             getAvailablePythonVersionsStub.resolves([
                 { version: '3.13', isInstalled: false, identifier: 'cpython-3.13.1-macos-aarch64-none' },
             ]);
-            // User selects version
             quickPickResponses = [{ version: '3.13', label: 'Python 3.13' }];
-            // uv python install succeeds
-            execStub.onFirstCall().resolves({ stdout: '' });
-            // uv python find returns path
-            execStub.onSecondCall().resolves({ stdout: '/usr/local/bin/python3.13' });
-            // uv venv creation succeeds (for global venv)
-            execStub.onThirdCall().resolves({ stdout: '' });
-            // No workspace open
+            execStub.onFirstCall().resolves({ stdout: '' }); // uv python install
+            execStub.onSecondCall().resolves({ stdout: '/usr/local/bin/python3.13' }); // uv python find
+            execStub.onThirdCall().resolves({ stdout: '' }); // uv venv
             getWorkspaceFoldersStub.returns(undefined);
 
             const result = await installPythonViaUv();
 
             assert.strictEqual(result.success, true);
-            // Should return the global venv path
-            assert.strictEqual(result.pythonPath, getExpectedGlobalVenvPython());
+            assert.strictEqual(result.pythonPath, getExpectedGlobalEnvPython());
+            // The venv is the "positron" directory itself. A nested .venv would be
+            // invisible to every locator, which is the bug this replaces.
+            assert.ok(
+                !result.pythonPath?.includes(`${path.sep}.venv${path.sep}`),
+                'the global environment must not be nested in a .venv',
+            );
+            // The old flow never consulted the workspace .venv helpers for this branch.
+            assert.ok(!hasVenvStub.called, 'the workspace .venv helpers must not be used for the global path');
+        });
+
+        test('Falls back to base Python and reports an error when the global path is occupied', async () => {
+            isUvInstalledStub.resolves(true);
+            getAvailablePythonVersionsStub.resolves([
+                { version: '3.13', isInstalled: false, identifier: 'cpython-3.13.1-macos-aarch64-none' },
+            ]);
+            quickPickResponses = [{ version: '3.13', label: 'Python 3.13' }];
+            execStub.onFirstCall().resolves({ stdout: '' }); // uv python install
+            execStub.onSecondCall().resolves({ stdout: '/usr/local/bin/python3.13' }); // uv python find
+            getWorkspaceFoldersStub.returns(undefined);
+            const venvDir = path.join(os.homedir(), '.virtualenvs', 'positron');
+            (fsapi.pathExists as sinon.SinonStub).withArgs(venvDir).resolves(true);
+
+            const result = await installPythonViaUv();
+
+            assert.strictEqual(result.success, true);
+            assert.strictEqual(result.pythonPath, '/usr/local/bin/python3.13');
+            // Only install + find. Nothing is created, deleted, or inspected.
+            assert.strictEqual(execStub.callCount, 2);
+            verify(
+                mockedVSCodeNamespaces.window!.showErrorMessage(GlobalEnvironment.occupied(venvDir), anything()),
+            ).once();
         });
 
         test('Succeeds with venv creation when user accepts', async () => {
@@ -728,28 +766,6 @@ suite('UV Python Installer Tests', () => {
                 assert.ok(!createUvVenvStub.called);
             });
 
-            test('Global use existing: returns existing ~/.venv Python without creating', async () => {
-                isUvInstalledStub.resolves(true);
-                getAvailablePythonVersionsStub.resolves([
-                    { version: '3.13', isInstalled: false, identifier: 'cpython-3.13.1-macos-aarch64-none' },
-                ]);
-                quickPickResponses = [{ version: '3.13', label: 'Python 3.13' }];
-                execStub.onFirstCall().resolves({ stdout: '' }); // uv python install
-                execStub.onSecondCall().resolves({ stdout: '/usr/local/bin/python3.13' }); // uv python find
-                getWorkspaceFoldersStub.returns(undefined);
-                hasVenvStub.resolves(true);
-                pickExistingVenvActionStub.resolves(venvUtils.ExistingVenvAction.UseExisting);
-                getVenvExecutableStub.returns(getExpectedGlobalVenvPython());
-
-                const result = await installPythonViaUv();
-
-                assert.strictEqual(result.success, true);
-                assert.strictEqual(result.pythonPath, getExpectedGlobalVenvPython());
-                assert.ok(!deleteEnvironmentStub.called);
-                // Only install + find — no venv creation exec call
-                assert.strictEqual(execStub.callCount, 2);
-            });
-
             test('Recreate: detects existing venv, prompts, then deletes before recreating', async () => {
                 arrangeWorkspaceInstall();
                 hasVenvStub.resolves(true);
@@ -802,32 +818,6 @@ suite('UV Python Installer Tests', () => {
                 assert.ok(!pickExistingVenvActionStub.called, 'should not prompt when no venv exists');
                 assert.ok(!deleteEnvironmentStub.called, 'should not delete when no venv exists');
                 assert.ok(createUvVenvStub.calledOnce, 'createUvVenv should be called once');
-            });
-
-            test('Global recreate: deletes existing ~/.venv before recreating', async () => {
-                isUvInstalledStub.resolves(true);
-                getAvailablePythonVersionsStub.resolves([
-                    { version: '3.13', isInstalled: false, identifier: 'cpython-3.13.1-macos-aarch64-none' },
-                ]);
-                quickPickResponses = [{ version: '3.13', label: 'Python 3.13' }];
-                execStub.onCall(0).resolves({ stdout: '' }); // uv python install
-                execStub.onCall(1).resolves({ stdout: '/usr/local/bin/python3.13' }); // uv python find
-                execStub.onCall(2).resolves({ stdout: '' }); // uv venv (global) recreate
-                // No workspace -> global ~/.venv path
-                getWorkspaceFoldersStub.returns(undefined);
-
-                hasVenvStub.resolves(true);
-                pickExistingVenvActionStub.resolves(venvUtils.ExistingVenvAction.Recreate);
-
-                const result = await installPythonViaUv();
-
-                assert.strictEqual(result.success, true);
-                assert.strictEqual(result.pythonPath, getExpectedGlobalVenvPython());
-                assert.ok(deleteEnvironmentStub.calledOnce, 'deleteEnvironment should be called once');
-                assert.ok(
-                    pickExistingVenvActionStub.calledBefore(deleteEnvironmentStub),
-                    'action prompt should run before delete',
-                );
             });
         });
 
@@ -934,7 +924,7 @@ suite('UV Python Installer Tests', () => {
             const result = await installPythonViaUv();
 
             assert.strictEqual(result.success, true);
-            assert.strictEqual(result.pythonPath, getExpectedGlobalVenvPython());
+            assert.strictEqual(result.pythonPath, getExpectedGlobalEnvPython());
             // Only one exec call - for global venv creation (no install or find)
             assert.strictEqual(execStub.callCount, 1);
         });
@@ -988,7 +978,7 @@ suite('UV Python Installer Tests', () => {
 
             assert.strictEqual(result.success, true);
             // Should return the global venv path
-            assert.strictEqual(result.pythonPath, getExpectedGlobalVenvPython());
+            assert.strictEqual(result.pythonPath, getExpectedGlobalEnvPython());
         });
 
         test('Passes --color never to uv install and find so the parsed path is not ANSI-wrapped', async () => {
@@ -1038,6 +1028,58 @@ suite('UV Python Installer Tests', () => {
             assert.strictEqual(result.success, true);
             // Should fall back to base Python path
             assert.strictEqual(result.pythonPath, '/usr/local/bin/python3.13');
+            verify(
+                mockedVSCodeNamespaces.window!.showErrorMessage(
+                    GlobalEnvironment.creationFailed(path.join(os.homedir(), '.virtualenvs', 'positron')),
+                    anything(),
+                ),
+            ).once();
+        });
+
+        test('Falls back to base Python when uv venv resolves but creates no interpreter', async () => {
+            isUvInstalledStub.resolves(true);
+            getAvailablePythonVersionsStub.resolves([
+                { version: '3.13', isInstalled: false, identifier: 'cpython-3.13.1-macos-aarch64-none' },
+            ]);
+            quickPickResponses = [{ version: '3.13', label: 'Python 3.13' }];
+            execStub.onFirstCall().resolves({ stdout: '' }); // uv python install
+            execStub.onSecondCall().resolves({ stdout: '/usr/local/bin/python3.13' }); // uv python find
+            // exec resolves on a nonzero exit when throwOnStdErr is false, so uv can
+            // "succeed" here without building anything.
+            execStub.onThirdCall().resolves({ stdout: '', stderr: 'error: no interpreter found' });
+            (fsapi.pathExists as sinon.SinonStub).withArgs(getExpectedGlobalEnvPython()).resolves(false);
+            getWorkspaceFoldersStub.returns(undefined);
+
+            const result = await installPythonViaUv();
+
+            assert.strictEqual(result.success, true);
+            assert.strictEqual(result.pythonPath, '/usr/local/bin/python3.13');
+            verify(
+                mockedVSCodeNamespaces.window!.showErrorMessage(
+                    GlobalEnvironment.creationFailed(path.join(os.homedir(), '.virtualenvs', 'positron')),
+                    anything(),
+                ),
+            ).once();
+        });
+
+        test('Falls back to base Python when there is no directory discovery scans', async () => {
+            isUvInstalledStub.resolves(true);
+            getAvailablePythonVersionsStub.resolves([
+                { version: '3.13', isInstalled: false, identifier: 'cpython-3.13.1-macos-aarch64-none' },
+            ]);
+            quickPickResponses = [{ version: '3.13', label: 'Python 3.13' }];
+            execStub.onFirstCall().resolves({ stdout: '' }); // uv python install
+            execStub.onSecondCall().resolves({ stdout: '/usr/local/bin/python3.13' }); // uv python find
+            (platformApis.getUserHomeDir as sinon.SinonStub).returns(undefined);
+            getWorkspaceFoldersStub.returns(undefined);
+
+            const result = await installPythonViaUv();
+
+            assert.strictEqual(result.success, true);
+            assert.strictEqual(result.pythonPath, '/usr/local/bin/python3.13');
+            // Only install + find: nothing is created outside a discovered directory.
+            assert.strictEqual(execStub.callCount, 2);
+            verify(mockedVSCodeNamespaces.window!.showErrorMessage(GlobalEnvironment.unsupported(), anything())).once();
         });
     });
 });


### PR DESCRIPTION
Part of #14887. This is the first of several PRs on that issue, so it doesn't close it: it moves the environment and teaches discovery about it, but adds no prompts yet.

### Summary

When you run "Install Python via uv" with no folder open, Positron created a virtual environment at `~/.venv`. Nothing ever finds that environment again.

The environment now goes to `$WORKON_HOME/positron`, defaulting to `~/.virtualenvs/positron`. That path is the same on macOS, Linux, and Windows, it's a directory the locators already scan, and the `positron` directory name gives it clear provenance in the interpreter picker. The parent directory is created if it isn't there yet.

An environment that's already at the global path is never inspected, reused, upgraded, or deleted; the flow just reports it and falls back to the base interpreter. The workspace branch is untouched.

Existing `~/.venv` directories are left alone, and sessions already running on them keep working.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- The Python environment that Positron creates with no folder open is now at `~/.virtualenvs/positron` instead of `~/.venv`, so it's still in the interpreter picker after a restart (#14887)

### Validation Steps

@:interpreter @:win

On Windows and on one of macOS or Linux:

1. Launch Positron with no folder open.
2. Run "Install Python via uv" and finish the flow.
3. Confirm `~/.virtualenvs/positron/pyvenv.cfg` exists, and that there's no `~/.virtualenvs/positron/.venv`.
4. Restart Positron with no folder open. The environment should be in the interpreter picker as a virtual environment named `positron`, not as a system or global interpreter.