### PR TITLE
Remove normal style for new dynamic modal dialogs

### DIFF
--- a/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/components/titleBar.css
+++ b/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/components/titleBar.css
@@ -4,12 +4,19 @@
  *--------------------------------------------------------------------------------------------*/
 
 .positron-dynamic-modal-dialog-box .title-bar {
-	flex: 0 0 32px;
+	/*
+		Grow past the 48px single-line height when a title description adds a second line, keeping
+		symmetric vertical padding so two lines aren't crammed into the single-line space.
+	*/
+	flex: 0 0 auto;
 	display: flex;
-	padding: 0 16px;
+	min-height: 48px;
+	box-sizing: border-box;
+	padding: 10px 16px;
 	align-items: center;
 	color: var(--vscode-positronModalDialog-foreground);
-	background: var(--vscode-positronModalDialog-titleBarBackground);
+	background: var(--vscode-positronModalDialog-background);
+	border-bottom: solid 1px var(--vscode-positronModalDialog-border);
 }
 
 .positron-dynamic-modal-dialog-box .title-bar .title-bar-titles {
@@ -26,7 +33,8 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	color: var(--vscode-positronModalDialog-titleBarForeground);
+	font-size: 16px;
+	color: var(--vscode-descriptionForeground);
 }
 
 .positron-dynamic-modal-dialog-box .title-bar .title-bar-title-description {
@@ -57,23 +65,4 @@
 
 .positron-dynamic-modal-dialog-box .title-bar .title-bar-close-button:hover {
 	background: var(--vscode-toolbar-hoverBackground);
-}
-
-.positron-dynamic-modal-dialog-box .title-bar.large {
-	/*
-		Grow past the 48px single-line height when a title description adds a second line, keeping
-		symmetric vertical padding so two lines aren't crammed into the single-line space.
-	*/
-	flex: 0 0 auto;
-	min-height: 48px;
-	box-sizing: border-box;
-	padding-top: 10px;
-	padding-bottom: 10px;
-	background: var(--vscode-positronModalDialog-background);
-	border-bottom: solid 1px var(--vscode-positronModalDialog-border);
-}
-
-.positron-dynamic-modal-dialog-box .title-bar.large .title-bar-title {
-	font-size: 16px;
-	color: var(--vscode-descriptionForeground);
 }

--- a/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/components/titleBar.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/components/titleBar.tsx
@@ -13,7 +13,6 @@ import { MouseEvent } from 'react';
 import * as DOM from '../../../../../base/browser/dom.js';
 import { localize } from '../../../../../nls.js';
 import { useStateRef } from '../../../../../base/browser/ui/react/useStateRef.js';
-import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
 import { Button } from '../../../../../base/browser/ui/positronComponents/button/button.js';
 
 /**
@@ -22,7 +21,6 @@ import { Button } from '../../../../../base/browser/ui/positronComponents/button
 interface TitleBarProps {
 	title: string;
 	titleDescription?: string;
-	size?: 'normal' | 'large';
 	onStartDrag: () => void;
 	onDrag: (x: number, y: number) => void;
 	onStopDrag: (x: number, y: number) => void;
@@ -113,7 +111,7 @@ export const TitleBar = (props: TitleBarProps) => {
 		// keyboard semantics (the dialog already handles Escape/Tab/Enter at a higher level).
 		// Disable jsx-a11y/no-static-element-interactions.
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
-		<div className={positronClassNames('title-bar', { 'large': props.size === 'large' })} onMouseDown={mouseDownHandler}>
+		<div className='title-bar' onMouseDown={mouseDownHandler}>
 			<div className='title-bar-titles'>
 				<div className='title-bar-title'>
 					{props.title}

--- a/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.tsx
@@ -26,7 +26,6 @@ export interface PositronDynamicModalDialogProps {
 	renderer: PositronModalDialogReactRenderer;
 	title: string;
 	titleDescription?: string;
-	titleSize?: 'normal' | 'large';
 	width: number;
 	content: ReactNode;
 	contentMinHeight?: number;
@@ -232,7 +231,7 @@ export const PositronDynamicModalDialog = (props: PositronDynamicModalDialogProp
 				top: dialogBoxState.top,
 				width: props.width,
 			}}>
-				<TitleBar size={props.titleSize} title={props.title} titleDescription={props.titleDescription} onClose={props.onCancel} onDrag={dragHandler} onStartDrag={startDragHandler} onStopDrag={stopDragHandler} />
+				<TitleBar title={props.title} titleDescription={props.titleDescription} onClose={props.onCancel} onDrag={dragHandler} onStartDrag={startDragHandler} onStopDrag={stopDragHandler} />
 				{/*
 					The content area and footer are always wrapped in a <form>. Enter-key implicit
 					submission only activates when a submit target exists -- i.e. when the footer

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnection.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnection.tsx
@@ -369,7 +369,6 @@ export const ConfigureDataConnection = (props: ConfigureDataConnectionProps) => 
 				"Configure Data Connection \u00B7 {0}",
 				props.driver.metadata.name
 			)}
-			titleSize='large'
 			width={530}
 			onCancel={cancelHandler}
 			onSubmit={saveHandler}

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/connectDataConnectionWith.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/connectDataConnectionWith.tsx
@@ -305,7 +305,6 @@ export const ConnectDataConnectionWith = (props: PropsWithChildren<ConnectDataCo
 			}
 			renderer={props.renderer}
 			title={localize('positron.connectDataConnectionWith.summary', "Connect {0} · {1} with {2}", props.connectionName, props.driver.metadata.name, languageName)}
-			titleSize='large'
 			width={CONNECT_DATA_CONNECTION_WITH_WIDTH}
 			onCancel={cancelHandler}
 		/>

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/includeSecretsConfirmation.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/includeSecretsConfirmation.tsx
@@ -79,7 +79,6 @@ const IncludeSecretsConfirmation = (props: IncludeSecretsConfirmationProps) => {
 			}
 			renderer={props.renderer}
 			title={localize('positron.includeSecretsConfirmation.title', "Include Secrets?")}
-			titleSize='large'
 			width={INCLUDE_SECRETS_CONFIRMATION_WIDTH}
 			onCancel={props.onCancel}
 		/>

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/removeDataConnectionConfirmation.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/removeDataConnectionConfirmation.tsx
@@ -113,7 +113,6 @@ const RemoveDataConnectionConfirmation = (props: RemoveDataConnectionConfirmatio
 			}
 			renderer={props.renderer}
 			title={localize('positron.removeDataConnectionConfirmation.title', "Remove Connection?")}
-			titleSize='large'
 			width={REMOVE_CONNECTION_CONFIRMATION_WIDTH}
 			onCancel={props.onCancel}
 		/>

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/selectDataConnectionMechanism.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/selectDataConnectionMechanism.tsx
@@ -133,7 +133,6 @@ export const SelectDataConnectionMechanism = (props: SelectDataConnectionMechani
 				'positron.selectDataConnectionMechanism.selectMechanism',
 				"Select how to connect"
 			)}
-			titleSize='large'
 			width={492}
 			onCancel={cancelHandler}
 			onSubmit={nextHandler}

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/selectDataConnectionProvider.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/selectDataConnectionProvider.tsx
@@ -255,7 +255,6 @@ export const SelectDataConnectionProvider = (props: SelectDataConnectionProvider
 				'positron.selectDataConnectionProvider.selectProvider',
 				"Select a provider"
 			)}
-			titleSize='large'
 			width={492}
 			onCancel={cancelHandler}
 			onSubmit={nextHandler}


### PR DESCRIPTION
Had a discussion with @softwarenerd about the new modal and we both realized that we don't want to support the "normal" title bar styling based off discussions with our designers. We want to use the "large" title bar style everywhere. This removes the "normal" header style completely.

This PR removes the `titleSize` prop on `PositronDynamicModalDialog` and the `size` prop on its `TitleBar`, standardizing every dynamic modal dialog on the "large" title bar style (bigger title, background/border, room for a second line). All 6 `positronDataConnections` dialogs already used this style; the other 7 dialogs (notebook AI panels, missing packages, etc.) previously used the plain "normal" style and now pick up the same look.

### Release Notes

<!-- PLEASE KEEP entries in the order of Added, Fixed, Changed -->
<!-- delete unused sections -->

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

1. Open any dynamic modal dialog (e.g. **Data Connections: Configure Connection**, notebook AI assistant panel, or a missing-packages install prompt) and confirm the title bar shows the larger title font with a background/border below it, consistent across all dialogs.