### PR TITLE
Fix the quick input flake at its source: Quarto test kernels that never exit

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/positron/executeInlineCell.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/positron/executeInlineCell.test.ts
@@ -147,7 +147,22 @@ class TestLanguageRuntimeSession implements positron.LanguageRuntimeSession {
 
 	async restart(): Promise<void> { }
 
-	async shutdown(_exitReason: positron.RuntimeExitReason): Promise<void> { }
+	async shutdown(exitReason: positron.RuntimeExitReason): Promise<void> {
+		// Report that the session has exited. Without this the workbench waits the
+		// full `onDidEndSession` timeout (5s, runtimeSession.ts) on every shutdown,
+		// then runs its failure cleanup in whatever suite happens to be executing
+		// by then -- which is how this suite's kernels came to disturb unrelated
+		// tests. See https://github.com/posit-dev/positron/issues/15536.
+		this._onDidChangeRuntimeState.fire(positron.RuntimeState.Exiting);
+		this._onDidChangeRuntimeState.fire(positron.RuntimeState.Exited);
+		this._onDidEndSession.fire({
+			runtime_name: this.runtimeMetadata.runtimeName,
+			session_name: this.dynState.sessionName,
+			exit_code: 0,
+			reason: exitReason,
+			message: '',
+		});
+	}
 
 	async forceQuit(): Promise<void> { }
 

--- a/extensions/vscode-api-tests/src/singlefolder-tests/quickInput.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/quickInput.test.ts
@@ -26,10 +26,13 @@ suite('vscode API - quick input', function () {
 	});
 
 	test('createQuickPick, select second', function (_done) {
-		let done = (err?: any) => {
-			done = () => { };
-			_done(err);
-		};
+		// --- Start Positron ---
+		// let done = (err?: any) => {
+		// 	done = () => { };
+		// 	_done(err);
+		// };
+		const { done, isFinished } = onceDone(_done);
+		// --- End Positron ---
 
 		const quickPick = createQuickPick({
 			events: ['active', 'active', 'selection', 'accept', 'hide'],
@@ -44,18 +47,28 @@ suite('vscode API - quick input', function () {
 		quickPick.items = ['eins', 'zwei', 'drei'].map(label => ({ label }));
 		quickPick.show();
 
-		(async () => {
-			await commands.executeCommand('workbench.action.quickOpenSelectNext');
-			await commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
-		})()
+		// --- Start Positron ---
+		// (async () => {
+		// 	await commands.executeCommand('workbench.action.quickOpenSelectNext');
+		// 	await commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
+		// })()
+		// 	.catch(err => done(err));
+		runCommands([
+			'workbench.action.quickOpenSelectNext',
+			'workbench.action.acceptSelectedQuickOpenItem',
+		], isFinished)
 			.catch(err => done(err));
+		// --- End Positron ---
 	});
 
 	test('createQuickPick, focus second', function (_done) {
-		let done = (err?: any) => {
-			done = () => { };
-			_done(err);
-		};
+		// --- Start Positron ---
+		// let done = (err?: any) => {
+		// 	done = () => { };
+		// 	_done(err);
+		// };
+		const { done, isFinished } = onceDone(_done);
+		// --- End Positron ---
 
 		const quickPick = createQuickPick({
 			events: ['active', 'selection', 'accept', 'hide'],
@@ -71,17 +84,24 @@ suite('vscode API - quick input', function () {
 		quickPick.activeItems = [quickPick.items[1]];
 		quickPick.show();
 
-		(async () => {
-			await commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
-		})()
+		// --- Start Positron ---
+		// (async () => {
+		// 	await commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
+		// })()
+		// 	.catch(err => done(err));
+		runCommands(['workbench.action.acceptSelectedQuickOpenItem'], isFinished)
 			.catch(err => done(err));
+		// --- End Positron ---
 	});
 
 	test('createQuickPick, select first and second', function (_done) {
-		let done = (err?: any) => {
-			done = () => { };
-			_done(err);
-		};
+		// --- Start Positron ---
+		// let done = (err?: any) => {
+		// 	done = () => { };
+		// 	_done(err);
+		// };
+		const { done, isFinished } = onceDone(_done);
+		// --- End Positron ---
 
 		const quickPick = createQuickPick({
 			events: ['active', 'selection', 'active', 'selection', 'accept', 'hide'],
@@ -97,14 +117,24 @@ suite('vscode API - quick input', function () {
 		quickPick.items = ['eins', 'zwei', 'drei'].map(label => ({ label }));
 		quickPick.show();
 
-		(async () => {
-			await commands.executeCommand('workbench.action.quickOpenSelectNext');
-			await commands.executeCommand('workbench.action.quickPickManyToggle');
-			await commands.executeCommand('workbench.action.quickOpenSelectNext');
-			await commands.executeCommand('workbench.action.quickPickManyToggle');
-			await commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
-		})()
+		// --- Start Positron ---
+		// (async () => {
+		// 	await commands.executeCommand('workbench.action.quickOpenSelectNext');
+		// 	await commands.executeCommand('workbench.action.quickPickManyToggle');
+		// 	await commands.executeCommand('workbench.action.quickOpenSelectNext');
+		// 	await commands.executeCommand('workbench.action.quickPickManyToggle');
+		// 	await commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
+		// })()
+		// 	.catch(err => done(err));
+		runCommands([
+			'workbench.action.quickOpenSelectNext',
+			'workbench.action.quickPickManyToggle',
+			'workbench.action.quickOpenSelectNext',
+			'workbench.action.quickPickManyToggle',
+			'workbench.action.acceptSelectedQuickOpenItem',
+		], isFinished)
 			.catch(err => done(err));
+		// --- End Positron ---
 	});
 
 	test('createQuickPick, selection events', function (_done) {
@@ -133,10 +163,13 @@ suite('vscode API - quick input', function () {
 	});
 
 	test('createQuickPick, continue after first accept', function (_done) {
-		let done = (err?: any) => {
-			done = () => { };
-			_done(err);
-		};
+		// --- Start Positron ---
+		// let done = (err?: any) => {
+		// 	done = () => { };
+		// 	_done(err);
+		// };
+		const { done, isFinished } = onceDone(_done);
+		// --- End Positron ---
 
 		const quickPick = createQuickPick({
 			events: ['active', 'selection', 'accept', 'active', 'selection', 'accept', 'hide'],
@@ -152,11 +185,24 @@ suite('vscode API - quick input', function () {
 		quickPick.show();
 
 		(async () => {
-			await commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
+			// --- Start Positron ---
+			// await commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
+			await runCommands(['workbench.action.acceptSelectedQuickOpenItem'], isFinished);
+			// --- End Positron ---
 			await timeout(async () => {
+				// --- Start Positron ---
+				// Don't touch the pick once the test is over: by then the visible quick
+				// input belongs to the next test.
+				if (isFinished()) {
+					return;
+				}
+				// --- End Positron ---
 				quickPick.items = ['drei', 'vier'].map(label => ({ label }));
 				await timeout(async () => {
-					await commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
+					// --- Start Positron ---
+					// await commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
+					await runCommands(['workbench.action.acceptSelectedQuickOpenItem'], isFinished);
+					// --- End Positron ---
 				}, 0);
 			}, 0);
 		})()
@@ -250,10 +296,13 @@ suite('vscode API - quick input', function () {
 	});
 
 	test('createQuickPick, match item by label derived from resourceUri', function (_done) {
-		let done = (err?: any) => {
-			done = () => { };
-			_done(err);
-		};
+		// --- Start Positron ---
+		// let done = (err?: any) => {
+		// 	done = () => { };
+		// 	_done(err);
+		// };
+		const { done, isFinished } = onceDone(_done);
+		// --- End Positron ---
 
 		const quickPick = createQuickPick({
 			events: ['active', 'selection', 'accept', 'hide'],
@@ -275,17 +324,24 @@ suite('vscode API - quick input', function () {
 		quickPick.value = 'test2.txt';
 		quickPick.show();
 
-		(async () => {
-			await commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
-		})()
+		// --- Start Positron ---
+		// (async () => {
+		// 	await commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
+		// })()
+		// 	.catch(err => done(err));
+		runCommands(['workbench.action.acceptSelectedQuickOpenItem'], isFinished)
 			.catch(err => done(err));
+		// --- End Positron ---
 	});
 
 	test('createQuickPick, match item by description derived from resourceUri', function (_done) {
-		let done = (err?: any) => {
-			done = () => { };
-			_done(err);
-		};
+		// --- Start Positron ---
+		// let done = (err?: any) => {
+		// 	done = () => { };
+		// 	_done(err);
+		// };
+		const { done, isFinished } = onceDone(_done);
+		// --- End Positron ---
 
 		const quickPick = createQuickPick({
 			events: ['active', 'selection', 'accept', 'hide'],
@@ -308,15 +364,27 @@ suite('vscode API - quick input', function () {
 		quickPick.value = 'test2.txt';
 		quickPick.show();
 
-		(async () => {
-			await commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
-		})()
+		// --- Start Positron ---
+		// (async () => {
+		// 	await commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
+		// })()
+		// 	.catch(err => done(err));
+		runCommands(['workbench.action.acceptSelectedQuickOpenItem'], isFinished)
 			.catch(err => done(err));
+		// --- End Positron ---
 	});
 });
 
 function createQuickPick(expected: QuickPickExpected, done: (err?: any) => void, record = false) {
 	const quickPick = window.createQuickPick();
+	// --- Start Positron ---
+	// These tests assert an exact event sequence and none of them exercise focus-out
+	// behaviour. With the default (false), any unrelated workbench activity that moves
+	// DOM focus while the pick is open closes it, and the resulting onDidHide lands in
+	// the middle of the expected sequence.
+	// See https://github.com/posit-dev/positron/issues/15536.
+	quickPick.ignoreFocusOut = true;
+	// --- End Positron ---
 	let eventIndex = -1;
 	quickPick.onDidChangeActive(items => {
 		if (record) {
@@ -374,7 +442,12 @@ function createQuickPick(expected: QuickPickExpected, done: (err?: any) => void,
 			return;
 		}
 		try {
-			assert.strictEqual('hide', expected.events.shift());
+			// --- Start Positron ---
+			// Name the event: a bare `'hide' !== 'active'` gives no hint that an
+			// unexpected hide interrupted the sequence.
+			// assert.strictEqual('hide', expected.events.shift());
+			assert.strictEqual('hide', expected.events.shift(), `onDidHide (remaining expected events after this one: [${expected.events.join(', ')}])`);
+			// --- End Positron ---
 			done();
 		} catch (err) {
 			done(err);
@@ -387,3 +460,41 @@ function createQuickPick(expected: QuickPickExpected, done: (err?: any) => void,
 async function timeout<T>(run: () => Promise<T> | T, ms: number): Promise<T> {
 	return new Promise<T>(resolve => setTimeout(() => resolve(run()), ms));
 }
+
+// --- Start Positron ---
+/**
+ * Wrap mocha's `done` so that it fires at most once (as the inline wrappers this
+ * replaces did) and also reports whether the test has finished. See runCommands.
+ */
+function onceDone(_done: (err?: any) => void) {
+	let finished = false;
+	return {
+		done: (err?: any) => {
+			if (finished) {
+				return;
+			}
+			finished = true;
+			_done(err);
+		},
+		isFinished: () => finished,
+	};
+}
+
+/**
+ * Execute commands in order, stopping as soon as the test has finished.
+ *
+ * These commands act on whichever quick input is currently visible, not on a
+ * particular one. When a test ends early -- an unexpected hide, a failed assertion --
+ * mocha moves straight on, so a command still queued here would be delivered to the
+ * *next* test's quick pick and fail that test too, for reasons that have nothing to
+ * do with it. See https://github.com/posit-dev/positron/issues/15536.
+ */
+async function runCommands(ids: string[], isFinished: () => boolean): Promise<void> {
+	for (const id of ids) {
+		if (isFinished()) {
+			return;
+		}
+		await commands.executeCommand(id);
+	}
+}
+// --- End Positron ---

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -1313,6 +1313,13 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			if (this._shuttingDownNotebooksByNotebookUri.get(notebookUri) === shutdownPromise) {
 				this._shuttingDownNotebooksByNotebookUri.delete(notebookUri);
 			}
+		}).catch(() => {
+			// `finally` returns a *new* promise that rejects along with
+			// `shutdownPromise.p`. Nothing awaited it, so every notebook shutdown
+			// failure was also reported as an unhandled rejection -- logging the same
+			// error a second time through onUnexpectedError, stackless and without the
+			// notebook URI. The failure itself still reaches the caller through the
+			// returned promise, and is logged with context in the catch below.
 		});
 
 		// Get the session to shutdown.


### PR DESCRIPTION
Addresses #15536 at two levels. Neither is a workaround.

The `vscode API - quick input` tests flake in the `Run Extension Host Tests (Remote)` step: a workbench-originated hide arrives mid-sequence and fails whichever pick is open, and the affected run reports *two* failures.

There are three things going on, and this PR takes the two that can be pinned down:

| | Fixed here? |
|---|---|
| 1. A Quarto kernel shutdown times out and runs its cleanup 5s later, inside an unrelated suite | **Yes** -- cause identified, timeouts eliminated |
| 2. Something in that window closes the open quick pick, and the test fails | **Probably** -- `ignoreFocusOut` closes the only silent path |
| 3. The failing test's in-flight command chain then corrupts the *next* test | **Yes** -- reproduced on demand, then fixed |

## 1. The disturbance's anchor was a test bug (commit 2)

`TestLanguageRuntimeSession.shutdown()` in `executeInlineCell.test.ts` was `async shutdown(_exitReason) { }` -- it never fired `onDidEndSession`. `doShutdownRuntimeSession` waits for that event with a 5s timeout ([runtimeSession.ts:627](https://github.com/posit-dev/positron/blob/main/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts#L627)), so the timeout expired on **every** Quarto kernel shutdown in the suite, and its failure path then ran inside whichever suite was executing 5s later.

That explains a standing oddity in the logs: the three `Timed out waiting for runtime Session <file>.qmd ... to finish exiting` errors in every ext-host run trail the inline-cell tests by exactly 5s and land in the middle of unrelated suites. #15536's strongest lead is a disturbance anchored 2.09s +/- 0.08s (n=33) after the last of them. This is the test-isolation defect the issue's step 3 guessed at, now with a named cause.

Local A/B over the CI suite window:

| `shutdown()` | Timeout log lines |
|---|---|
| no-op (before) | **6** |
| reports the exit (after) | **0** |

Full `api-folder` suite: 323 passing, zero timeouts.

Also in commit 2: notebook shutdown failures were reported twice. The `finally` on the deferred shutdown promise returns a *new* promise that rejects alongside it, and nothing awaited that one, so every failure surfaced again as an unhandled rejection -- stackless, without the notebook URI, through `onUnexpectedError`. That is the duplicate stack in the CI logs, and part of why these were undebuggable. Verified by forcing the timeouts back: each now logs once, with context.

## 2. The pick closing on focus loss (commit 1)

`quickPick.ignoreFocusOut = true` in the shared `createQuickPick` helper. The ext host initialises `_ignoreFocusOut = true` ([extHostQuickOpen.ts:280](https://github.com/posit-dev/positron/blob/main/src/vs/workbench/api/common/extHostQuickOpen.ts#L280)) but only transmits explicitly assigned properties -- `show()` sends `{ id, visible: true }` -- so the main-thread default of `false` ([quickInput.ts:164](https://github.com/posit-dev/positron/blob/main/src/vs/platform/quickinput/browser/quickInput.ts#L164)) applies and these picks really do close on focus loss.

Blur is also the only one of the five hide paths that unrelated background activity can trigger silently: `Gesture` needs a key or mouse event, "a different quick input was shown" would leave RPC traces, the Positron modal MutationObserver needs a modal open, and these tests never call `hide()`. None of those four left evidence across the 39 runs examined on the issue.

Scoped to these picks rather than the run-wide `workbench.quickOpen.closeOnFocusLost` setting, so focus-out behaviour is untouched for every other api test.

## 3. The cascade (commit 1)

The affected tests drive their pick through a detached async chain of `executeCommand` calls. Those commands act on **whichever quick input is currently visible**, not on a particular one. When the hide fails the test at its first assertion, mocha moves straight on while the chain is still mid-`await`, and the remaining commands are delivered to the *next* test's pick: `quickPickManyToggle` / `acceptSelectedQuickOpenItem` land on `selection events`, whose active item is `eins`, so its selection becomes `['eins']` where the test expected `['drei']`.

Reproduced by simulating the disturbance -- one line, `setTimeout(() => commands.executeCommand('workbench.action.closeQuickOpen'), 1)`, which uses the same `$onDidHide` path as the flake:

| Chains | Result |
|---|---|
| Unguarded (before) | 9 passing, **2 failing** -- CI signature exactly, down to `['eins']` vs `['drei']` |
| Guarded (`runCommands`) | 10 passing, **1 failing** -- `selection events` passes |

Commit 1 also names the event in the hide assertion; `'hide' !== 'active'` gave no hint that an unexpected hide had interrupted the sequence.

## What this does not claim

I did not reproduce the hide itself locally, so the link from "shutdown-timeout aftermath" to "quick pick hides" is still the issue's correlation (2.09s +/- 0.08s, n=33, with 3 counterexamples among passing runs). Removing the anchor is the most likely fix; `ignoreFocusOut` covers the mechanism if some other disturbance remains. Between them the flake should be gone, but I'd leave #15536 open until a few weeks of ext-host runs confirm it.

Usefully, the two are separable diagnostics. If occurrences continue, `ignoreFocusOut` being in place disproves blur and points at one of the remaining four hide paths.

## Release notes

### New features

- N/A

### Bug fixes

- N/A

## QA notes

Test-only except for the one-line unhandled-rejection fix in `runtimeSession.ts`. `ext-host` runs on every PR, so CI exercises all of this here.

Locally:

```
# quick input alone -- expect 11 passing
VSCODE_MOCHA_GREP='vscode API - quick input' ./scripts/test-integration.sh --suite api-folder

# whole suite -- expect no "Timed out waiting for runtime Session" lines at all
./scripts/test-integration.sh --suite api-folder
```

(Two `chat - run_in_terminal` failures on my machine are a local artifact -- they assert on terminal output and capture the shell prompt. Unrelated, and they fail the same way without these changes.)
