### PR TITLE
Fix broken copy via keyboard shortcut in the Viewer

### DIFF
--- a/src/vs/platform/webview/electron-main/webviewMainService.ts
+++ b/src/vs/platform/webview/electron-main/webviewMainService.ts
@@ -109,8 +109,9 @@ export class WebviewMainService extends Disposable implements IWebviewManagerSer
 
 	// A map of window IDs to disposables for navigation event listeners. We
 	// attach a single listener to each window to capture frame navigation
-	// events.
-	private readonly _navigationListeners = new Map<WebviewWindowId, IDisposable>();
+	// events. Keyed by the numeric window ID; callers pass a fresh
+	// WebviewWindowId object each call, so the object itself is not a stable key.
+	private readonly _navigationListeners = new Map<number, IDisposable>();
 
 	// A map of pending frame navigations, from the URL of the frame to the
 	// promise that will be resolved when a frame navigates to that URL.
@@ -152,7 +153,7 @@ export class WebviewMainService extends Disposable implements IWebviewManagerSer
 
 		// If we aren't already listening for navigation events on this window,
 		// set up a listener to capture them
-		if (!this._navigationListeners.has(windowId)) {
+		if (!this._navigationListeners.has(windowId.windowId)) {
 			// Event handler for navigation events
 			const onNavigated = (_event: any,
 				url: string,
@@ -190,7 +191,7 @@ export class WebviewMainService extends Disposable implements IWebviewManagerSer
 					window.win!.webContents.off('before-input-event', onBeforeInput);
 				}
 			};
-			this._navigationListeners.set(windowId, disposable);
+			this._navigationListeners.set(windowId.windowId, disposable);
 
 			// Register the disposable so we can clean up when the service is
 			// disposed
@@ -222,17 +223,24 @@ export class WebviewMainService extends Disposable implements IWebviewManagerSer
 	/**
 	 * Whether the frame is a Positron webview guest frame hosting external
 	 * (cross-origin) content, e.g. a Shiny app in the Viewer. Such a frame loads
-	 * an http(s) URL directly inside the vscode-webview:// wrapper
-	 * (index-external.html), which distinguishes it from the workbench and from
-	 * same-origin webviews.
+	 * an http(s) URL inside the vscode-webview:// wrapper (index-external.html),
+	 * which distinguishes it from the workbench and from same-origin webviews.
+	 * The wrapper may be several levels up rather than the direct parent, since
+	 * Viewer content can nest iframes (e.g. Quarto dashboards, tags$iframe), so
+	 * walk the parent chain looking for a vscode-webview:// ancestor.
 	 *
 	 * @param frame The frame to test.
 	 */
 	private isViewerGuestFrame(frame: Electron.WebFrameMain | null): boolean {
-		return !!frame
-			&& /^https?:\/\//.test(frame.url)
-			&& !!frame.parent
-			&& frame.parent.url.startsWith(`${Schemas.vscodeWebview}://`);
+		if (!frame || !/^https?:\/\//.test(frame.url)) {
+			return false;
+		}
+		for (let parent = frame.parent; parent; parent = parent.parent) {
+			if (parent.url.startsWith(`${Schemas.vscodeWebview}://`)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**
@@ -247,7 +255,10 @@ export class WebviewMainService extends Disposable implements IWebviewManagerSer
 	 * @param params The context menu parameters from the context-menu event.
 	 */
 	private showFrameContextMenu(window: Electron.BrowserWindow, params: Electron.ContextMenuParams): void {
-		if (!this.isViewerGuestFrame(window.webContents.focusedFrame)) {
+		// Gate on the frame the menu was invoked in, not the focused frame; the
+		// two differ when Viewer content is right-clicked without first being
+		// focused.
+		if (!this.isViewerGuestFrame(params.frame)) {
 			return;
 		}
 

--- a/src/vs/platform/webview/electron-main/webviewMainService.ts
+++ b/src/vs/platform/webview/electron-main/webviewMainService.ts
@@ -13,8 +13,9 @@ import { IFileService } from '../../files/common/files.js';
 
 // --- Start Positron ---
 // eslint-disable-next-line no-duplicate-imports
-import { Rectangle, webFrameMain } from 'electron';
+import { Rectangle, webFrameMain, Menu, MenuItem } from 'electron';
 import { VSBuffer } from '../../../base/common/buffer.js';
+import { Schemas } from '../../../base/common/network.js';
 
 // eslint-disable-next-line no-duplicate-imports
 import { IDisposable } from '../../../base/common/lifecycle.js';
@@ -165,8 +166,30 @@ export class WebviewMainService extends Disposable implements IWebviewManagerSer
 			};
 			window.win!.webContents.on('did-frame-navigate', onNavigated);
 
-			// Disposable for the listener
-			const disposable = { dispose: () => window.win!.webContents.off('did-frame-navigate', onNavigated) };
+			// Show a native context menu for externally-hosted (cross-origin)
+			// Viewer content, whose clipboard actions can't go through the
+			// execCommand round-trip.
+			const onContextMenu = (_e: Electron.Event, params: Electron.ContextMenuParams) => {
+				this.showFrameContextMenu(window.win!, params);
+			};
+			window.win!.webContents.on('context-menu', onContextMenu);
+
+			// Route clipboard shortcuts in externally-hosted Viewer content to the
+			// native clipboard commands, which work where the in-frame/execCommand
+			// paths don't.
+			const onBeforeInput = (e: Electron.Event, input: Electron.Input) => {
+				this.handleClipboardShortcut(window.win!, e, input);
+			};
+			window.win!.webContents.on('before-input-event', onBeforeInput);
+
+			// Disposable for the listeners
+			const disposable = {
+				dispose: () => {
+					window.win!.webContents.off('did-frame-navigate', onNavigated);
+					window.win!.webContents.off('context-menu', onContextMenu);
+					window.win!.webContents.off('before-input-event', onBeforeInput);
+				}
+			};
 			this._navigationListeners.set(windowId, disposable);
 
 			// Register the disposable so we can clean up when the service is
@@ -194,6 +217,89 @@ export class WebviewMainService extends Disposable implements IWebviewManagerSer
 			throw new Error(`No frame found with frameId: ${JSON.stringify(frameId)}`);
 		}
 		return frame.executeJavaScript(script);
+	}
+
+	/**
+	 * Whether the frame is a Positron webview guest frame hosting external
+	 * (cross-origin) content, e.g. a Shiny app in the Viewer. Such a frame loads
+	 * an http(s) URL directly inside the vscode-webview:// wrapper
+	 * (index-external.html), which distinguishes it from the workbench and from
+	 * same-origin webviews.
+	 *
+	 * @param frame The frame to test.
+	 */
+	private isViewerGuestFrame(frame: Electron.WebFrameMain | null): boolean {
+		return !!frame
+			&& /^https?:\/\//.test(frame.url)
+			&& !!frame.parent
+			&& frame.parent.url.startsWith(`${Schemas.vscodeWebview}://`);
+	}
+
+	/**
+	 * Shows a native clipboard context menu for externally-hosted (cross-origin)
+	 * webview content, e.g. a Shiny app in the Viewer. The menu uses native
+	 * clipboard roles, which act on the focused frame's selection - the same
+	 * mechanism as the Edit menu - so Copy/Cut/Paste work where the execCommand
+	 * round-trip does not. Other content (the workbench, same-origin webviews)
+	 * is left to its own menus.
+	 *
+	 * @param window The window in which the menu was requested.
+	 * @param params The context menu parameters from the context-menu event.
+	 */
+	private showFrameContextMenu(window: Electron.BrowserWindow, params: Electron.ContextMenuParams): void {
+		if (!this.isViewerGuestFrame(window.webContents.focusedFrame)) {
+			return;
+		}
+
+		const menu = new Menu();
+		const { editFlags, isEditable } = params;
+		if (isEditable && editFlags.canCut) {
+			menu.append(new MenuItem({ role: 'cut' }));
+		}
+		if (editFlags.canCopy) {
+			menu.append(new MenuItem({ role: 'copy' }));
+		}
+		if (isEditable && editFlags.canPaste) {
+			menu.append(new MenuItem({ role: 'paste' }));
+		}
+		if (menu.items.length > 0) {
+			menu.append(new MenuItem({ type: 'separator' }));
+		}
+		menu.append(new MenuItem({ role: 'selectAll' }));
+
+		menu.popup({ window, x: params.x, y: params.y });
+	}
+
+	/**
+	 * Routes clipboard keyboard shortcuts in externally-hosted (cross-origin)
+	 * webview content to the native clipboard commands. These act on the focused
+	 * frame's selection - the same mechanism as the Edit menu - so they work for
+	 * Viewer content where the in-frame and execCommand paths do not. Other
+	 * content is left alone.
+	 *
+	 * @param window The window in which the key was pressed.
+	 * @param event The before-input event, preventable to stop further handling.
+	 * @param input The keyboard input.
+	 */
+	private handleClipboardShortcut(window: Electron.BrowserWindow, event: Electron.Event, input: Electron.Input): void {
+		if (input.type !== 'keyDown' || input.alt || input.shift) {
+			return;
+		}
+		const modifier = process.platform === 'darwin' ? input.meta : input.control;
+		if (!modifier) {
+			return;
+		}
+		if (!this.isViewerGuestFrame(window.webContents.focusedFrame)) {
+			return;
+		}
+		switch (input.key.toLowerCase()) {
+			case 'c': window.webContents.copy(); break;
+			case 'x': window.webContents.cut(); break;
+			case 'v': window.webContents.paste(); break;
+			case 'a': window.webContents.selectAll(); break;
+			default: return;
+		}
+		event.preventDefault();
 	}
 
 	/**

--- a/src/vs/workbench/contrib/webview/browser/pre/webview-events.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/webview-events.js
@@ -89,11 +89,10 @@ const handleAuxClick = (event) => {
  * @param {KeyboardEvent} e
  */
 const handleInnerKeydown = (e) => {
-	// Let the browser natively handle clipboard and undo/redo shortcuts so that
-	// copy/cut/paste work on content in the Viewer. Current Chromium versions
-	// require a user gesture for clipboard writes, so routing these through the
-	// host and back down via document.execCommand no longer works.
-	if (isUndoRedo(e) || isCopyPasteOrCut(e)) {
+	// Let the browser natively handle undo/redo in the frame. Clipboard
+	// shortcuts (copy/cut/paste) are handled by the host in the main process
+	// (see WebviewMainService), so they are not special-cased here.
+	if (isUndoRedo(e)) {
 		return;
 	}
 
@@ -128,18 +127,6 @@ const handleInnerKeyup = (e) => {
 		repeat: e.repeat,
 	});
 };
-
-/**
- * @param {KeyboardEvent} e
- * @return {boolean}
- */
-function isCopyPasteOrCut(e) {
-	const hasMeta = e.ctrlKey || e.metaKey;
-	// 45: keyCode of "Insert"
-	const shiftInsert = e.shiftKey && e.keyCode === 45;
-	// 67, 86, 88: keyCode of "C", "V", "X"
-	return (hasMeta && [67, 86, 88].includes(e.keyCode)) || shiftInsert;
-}
 
 /**
  * @param {KeyboardEvent} e
@@ -302,52 +289,11 @@ window.addEventListener('wheel', handleWheel);
 window.addEventListener('auxclick', handleAuxClick);
 window.addEventListener('keydown', handleInnerKeydown);
 window.addEventListener('keyup', handleInnerKeyup);
-window.addEventListener('contextmenu', (e) => {
-	if (e.defaultPrevented) {
-		// Extension code has already handled this event
-		return;
-	}
-
-	e.preventDefault();
-
-	/** @type { Record<string, boolean>} */
-	let context = {};
-
-	/** @type {HTMLElement | null} */
-	let el = e.target;
-	while (true) {
-		if (!el) {
-			break;
-		}
-
-		// Search self/ancestors for the closest context data attribute
-		el = el.closest("[data-vscode-context]");
-		if (!el) {
-			break;
-		}
-
-		try {
-			context = {
-				...JSON.parse(el.dataset.vscodeContext),
-				...context,
-			};
-		} catch (e) {
-			console.error(
-				`Error parsing 'data-vscode-context' as json`,
-				el,
-				e,
-			);
-		}
-
-		el = el.parentElement;
-	}
-
-	hostMessaging.postMessage('did-context-menu', {
-		clientX: e.clientX,
-		clientY: e.clientY,
-		context: context,
-	});
-});
+// Don't intercept the context menu here. Routing it up to the host and back
+// showed VS Code's WebviewContext menu, whose clipboard actions run through the
+// execCommand round-trip that no longer works for cross-origin Viewer content.
+// Leaving the event alone lets the main process show a native context menu with
+// working Copy/Cut/Paste (see WebviewMainService).
 
 // Ask Positron to open a link instead of handling it internally
 function openLinkInHost(link) {

--- a/src/vs/workbench/contrib/webview/browser/pre/webview-events.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/webview-events.js
@@ -89,11 +89,17 @@ const handleAuxClick = (event) => {
  * @param {KeyboardEvent} e
  */
 const handleInnerKeydown = (e) => {
-	// If the keypress would trigger a browser event, such as copy or paste,
-	// make sure we block the browser from dispatching it. Instead VS Code
-	// handles these events and will dispatch a copy/paste back to the webview
-	// if needed
-	if (isUndoRedo(e) || isPrint(e) || isFindEvent(e) || isSaveEvent(e) || isCopyPasteOrCut(e)) {
+	// Let the browser natively handle clipboard and undo/redo shortcuts so that
+	// copy/cut/paste work on content in the Viewer. Current Chromium versions
+	// require a user gesture for clipboard writes, so routing these through the
+	// host and back down via document.execCommand no longer works.
+	if (isUndoRedo(e) || isCopyPasteOrCut(e)) {
+		return;
+	}
+
+	// Block the browser default for shortcuts that VS Code handles itself, then
+	// forward the keydown so the keybinding service can act on it.
+	if (isPrint(e) || isFindEvent(e) || isSaveEvent(e)) {
 		e.preventDefault();
 	}
 	hostMessaging.postMessage('did-keydown', {

--- a/test/e2e/tests/viewer/viewer.test.ts
+++ b/test/e2e/tests/viewer/viewer.test.ts
@@ -104,10 +104,41 @@ test.describe('Viewer', { tag: [tags.VIEWER, tags.CONSOLE] }, () => {
 			expect(await clipboard.getClipboardText()).toContain(VIEWER_COPY_PROBE);
 		}).toPass({ timeout: 15000 });
 	});
+
+	// A Shiny app is served from its own local web server, the real-world case
+	// the copy fix targets. Copy the probe out of the Viewer and paste it into an
+	// editor, matching what a user actually does, rather than only reading the
+	// clipboard API.
+	test('R - Verify selected text can be copied from a Shiny app in the Viewer', {
+		tag: [tags.ARK, tags.WIN]
+	}, async function ({ app, page, r }) {
+		const { console, viewer, editors, hotKeys } = app.workbench;
+
+		// runApp blocks the console, so paste and run it rather than waiting for
+		// a returned prompt.
+		await console.pasteCodeToConsole(rViewerShinyScript);
+		await console.sendEnterKey();
+		await viewer.expectViewerPanelVisible();
+		await viewer.expectContentVisible(frame => frame.getByText(VIEWER_COPY_PROBE));
+
+		// Double-click focuses the webview frame and selects the word, then copy.
+		await viewer.getViewerFrame().getByText(VIEWER_COPY_PROBE).dblclick();
+		await hotKeys.copy();
+
+		// Click the console to pull focus out of the webview (which otherwise
+		// swallows shortcuts), open an editor, and paste. This checks the copied
+		// text actually pastes, not just that it reached the clipboard API.
+		await console.activeConsole.click();
+		await editors.newUntitledFile();
+		await page.locator('.monaco-editor[data-uri$="Untitled-1"] .view-lines').click();
+		await hotKeys.paste();
+		await editors.expectEditorToContain(VIEWER_COPY_PROBE);
+	});
 });
 
-// A single word so a double-click selects the whole token.
-const VIEWER_COPY_PROBE = 'PositronViewerCopyProbe';
+// A single word so a double-click selects the whole token. Avoid the substring
+// "Viewer" so it doesn't collide with the Viewer tab in accessible-name lookups.
+const VIEWER_COPY_PROBE = 'PositronCopyProbeToken';
 
 // Serve the probe text from an ephemeral local web server and open it in the
 // Viewer, mimicking how a Shiny/Dash/Flask app is served from its own origin.
@@ -118,6 +149,11 @@ open(os.path.join(_dir, "index.html"), "w").write("<!doctype html><html><body><p
 _srv = socketserver.TCPServer(("127.0.0.1", 0), functools.partial(http.server.SimpleHTTPRequestHandler, directory=_dir))
 threading.Thread(target=_srv.serve_forever, daemon=True).start()
 webbrowser.open(f"http://127.0.0.1:{_srv.server_address[1]}")`;
+
+// Run a minimal Shiny app whose only content is the probe word, opened in the
+// Viewer the same way any Shiny app is. Kept to a single call so the console
+// does not wait on a multi-line block.
+const rViewerShinyScript = `shiny::runApp(shiny::shinyApp(ui = shiny::fluidPage(shiny::p("${VIEWER_COPY_PROBE}")), server = function(input, output) {}))`;
 
 const pythonScript = `import webbrowser
 # will not have any content, but we just want to make sure

--- a/test/e2e/tests/viewer/viewer.test.ts
+++ b/test/e2e/tests/viewer/viewer.test.ts
@@ -80,7 +80,44 @@ test.describe('Viewer', { tag: [tags.VIEWER, tags.CONSOLE] }, () => {
 		await console.executeCode('R', rReprexScript);
 		await viewer.expectContentVisible(frame => frame.getByText('rbinom'));
 	});
+
+	// The Viewer serves app content (Shiny, Dash, etc.) from a local web server,
+	// which is a separate origin from the webview. Copying a selection out of
+	// that cross-origin frame is what regressed. A same-origin page (plain HTML)
+	// does not exercise the bug, so this serves the probe text over HTTP.
+	test('Python - Verify selected text can be copied from the Viewer', { tag: [tags.WIN] }, async function ({ app, python }) {
+		const { console, viewer, clipboard, hotKeys } = app.workbench;
+
+		await console.executeCode('Python', pythonViewerServerScript);
+		await viewer.expectViewerPanelVisible();
+		await viewer.expectContentVisible(frame => frame.getByText(VIEWER_COPY_PROBE));
+
+		// Seed the clipboard so a failed copy leaves a value that clearly isn't
+		// the selected text.
+		await clipboard.setClipboardText('__SEED__');
+
+		await expect(async () => {
+			// Double-click focuses the webview frame and selects the word, so
+			// Ctrl/Cmd+C is dispatched to the Viewer content and not the console.
+			await viewer.getViewerFrame().getByText(VIEWER_COPY_PROBE).dblclick();
+			await hotKeys.copy();
+			expect(await clipboard.getClipboardText()).toContain(VIEWER_COPY_PROBE);
+		}).toPass({ timeout: 15000 });
+	});
 });
+
+// A single word so a double-click selects the whole token.
+const VIEWER_COPY_PROBE = 'PositronViewerCopyProbe';
+
+// Serve the probe text from an ephemeral local web server and open it in the
+// Viewer, mimicking how a Shiny/Dash/Flask app is served from its own origin.
+// Kept free of indented blocks so the file stays tab-indented for hygiene.
+const pythonViewerServerScript = `import http.server, socketserver, threading, webbrowser, tempfile, os, functools
+_dir = tempfile.mkdtemp()
+open(os.path.join(_dir, "index.html"), "w").write("<!doctype html><html><body><p>${VIEWER_COPY_PROBE}</p></body></html>")
+_srv = socketserver.TCPServer(("127.0.0.1", 0), functools.partial(http.server.SimpleHTTPRequestHandler, directory=_dir))
+threading.Thread(target=_srv.serve_forever, daemon=True).start()
+webbrowser.open(f"http://127.0.0.1:{_srv.server_address[1]}")`;
 
 const pythonScript = `import webbrowser
 # will not have any content, but we just want to make sure

--- a/test/e2e/tests/viewer/viewer.test.ts
+++ b/test/e2e/tests/viewer/viewer.test.ts
@@ -112,7 +112,7 @@ test.describe('Viewer', { tag: [tags.VIEWER, tags.CONSOLE] }, () => {
 	test('R - Verify selected text can be copied from a Shiny app in the Viewer', {
 		tag: [tags.ARK, tags.WIN]
 	}, async function ({ app, page, r }) {
-		const { console, viewer, editors, hotKeys } = app.workbench;
+		const { console, viewer, editors, clipboard, hotKeys } = app.workbench;
 
 		// runApp blocks the console, so paste and run it rather than waiting for
 		// a returned prompt.
@@ -120,6 +120,10 @@ test.describe('Viewer', { tag: [tags.VIEWER, tags.CONSOLE] }, () => {
 		await console.sendEnterKey();
 		await viewer.expectViewerPanelVisible();
 		await viewer.expectContentVisible(frame => frame.getByText(VIEWER_COPY_PROBE));
+
+		// Seed the clipboard so a no-op copy can't pass on a probe left behind by
+		// an earlier test.
+		await clipboard.setClipboardText('__SEED__');
 
 		// Double-click focuses the webview frame and selects the word, then copy.
 		await viewer.getViewerFrame().getByText(VIEWER_COPY_PROBE).dblclick();
@@ -133,6 +137,10 @@ test.describe('Viewer', { tag: [tags.VIEWER, tags.CONSOLE] }, () => {
 		await page.locator('.monaco-editor[data-uri$="Untitled-1"] .view-lines').click();
 		await hotKeys.paste();
 		await editors.expectEditorToContain(VIEWER_COPY_PROBE);
+
+		// runApp is still blocking the console; interrupt it so the session is
+		// left at a prompt and the file stays safe to extend.
+		await console.interruptExecution();
 	});
 });
 


### PR DESCRIPTION
Fixes #15572

Selecting text in the Viewer pane and pressing Ctrl/Cmd+C stopped copying it to the clipboard. This only affected content served from a local web server (Shiny, Dash, Flask, etc.), which the Viewer loads from its own origin; plain HTML shown in the Viewer was unaffected.

The Viewer injects a small script into the content frame that trapped copy, cut, and paste, blocked the browser's own handling, and instead sent the shortcut up to the workbench and back down to run the copy. That round trip does not work for content on a separate origin, so the copy silently did nothing. The fix lets the browser handle these shortcuts natively for that content, which is what the web build already does.

### Release Notes

#### New Features
- N/A

#### Bug Fixes

- Fix copying selected text from the Viewer pane for served apps such as Shiny and Dash (#15572)

### Validation Steps

@:viewer

1. Start any app that serves content to the Viewer (for example a Shiny or Dash app)
3. In the Viewer, select some of the text.
4. Press Ctrl+C (Cmd+C on macOS).
5. Paste elsewhere and confirm the selected text was copied.
