### PR TITLE
Mock electron in the quit-and-install unit test

### DIFF
--- a/src/vs/platform/update/test/electron-main/positronQuitAndInstall.vitest.ts
+++ b/src/vs/platform/update/test/electron-main/positronQuitAndInstall.vitest.ts
@@ -21,6 +21,35 @@ import { ensureNoLeakedDisposables } from '../../../../test/vitest/vitestUtils.j
 import { AbstractUpdateService } from '../../electron-main/abstractUpdateService.js';
 import { State, StateType } from '../../common/update.js';
 
+// The interfaces above come from `electron-main` files whose import chain pulls in the real
+// `electron` package, and requiring that package runs a postinstall shim that downloads the
+// Electron binary (and throws when it cannot). The unit-test CI container has no binary and no
+// download, so without this mock the whole file fails to load there. Nothing in these tests
+// reaches electron -- every collaborator is a stub -- so inert placeholders are enough. Match
+// the other `electron-main` vitest files and keep the mock.
+vi.mock('electron', () => {
+	const nodeEventEmitter = () => ({ on: () => { }, removeListener: () => { } });
+	return {
+		default: { app: nodeEventEmitter(), ipcMain: nodeEventEmitter() },
+		app: nodeEventEmitter(),
+		ipcMain: nodeEventEmitter(),
+		powerMonitor: nodeEventEmitter(),
+		screen: nodeEventEmitter(),
+		session: {},
+		webContents: { fromId: () => undefined },
+		BrowserWindow: {},
+		Menu: {},
+		Notification: class { },
+		clipboard: {},
+		contentTracing: {},
+		dialog: {},
+		nativeImage: {},
+		powerSaveBlocker: {},
+		shell: {},
+		systemPreferences: {},
+	};
+});
+
 /**
  * The Windows installer reads the update flag file as soon as the app mutex clears, and that mutex
  * is released during `onWillShutdown`, i.e. before `lifecycleMainService.quit()` resolves. So


### PR DESCRIPTION
`positronQuitAndInstall.vitest.ts` fails in the `test / unit` job. It looks like a
flake, but it is deterministic per-machine: it passes wherever an Electron binary
happens to be unpacked and fails wherever one is not.

The failure is at collection, not on an assertion:

```
stdout | .../positronQuitAndInstall.vitest.ts
Downloading Electron binary...
❯ .../positronQuitAndInstall.vitest.ts (0 test)
FAIL  Error: Electron failed to install correctly...
 ❯ getElectronPath node_modules/electron/index.js:43:13
```

The test imports service interfaces from `electron-main` files, and that import
chain reaches `import electron from 'electron'` in 15 modules
(`lifecycleMainService`, `nativeHostMainService`, `ipcMain`, `windowImpl`, ...).
Requiring the `electron` package runs `getElectronPath()` in
`node_modules/electron/index.js`, which shells out to download the Electron
binary when it is not already unpacked and throws when that download fails. The
unit-test container has no binary, so the whole file never loads.

This was also the only `electron-main` vitest file without an electron mock --
`nativeHostMainService.vitest.ts` and `positronStandaloneModeMainService.vitest.ts`
both mock it, which is why they passed in the same run.

Fix: add `vi.mock('electron', ...)` with inert placeholders, matching the existing
convention. Nothing in these tests reaches electron -- every collaborator is a
stub and only the `AbstractUpdateService` subclass runs -- so no real behavior is
needed. The only module-eval-time side effect in the chain is
`new ValidatedIpcMain()` in `ipcMain.ts`, whose constructor does not touch electron.

Mocking is preferable to installing Electron in the unit-test image: these are
unit tests and should not depend on a 293MB binary download to import a service
interface.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

Reproduced the CI condition locally by hiding `node_modules/electron/dist` and
`path.txt`:

- **With the mock:** 3 tests pass in 968ms and no Electron install is triggered.
- **Without the mock** (same hidden state, via `git stash`): the run silently
  re-installed Electron from the local cache -- `dist/` and `path.txt` reappeared.
  That is the same `getElectronPath()` -> `downloadElectron()` path CI takes; CI
  just has no cache to fall back on, so it throws instead.

Also green: `npx vitest run src/vs/platform/{update,native,positronStandaloneMode}`
(5 files / 54 tests), `npx eslint --max-warnings 0`, `npm run precommit`, and
`npm run test:positron:check-ts` (no errors in this file).

Note for anyone who has run this test locally before this change: it downloads
~293MB of Electron into `node_modules` if you did not already have it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
