### PR TITLE
Feature - Data Connections ODBC driver

### DIFF
--- a/.github/workflows/test-tag-paths-map.json
+++ b/.github/workflows/test-tag-paths-map.json
@@ -83,6 +83,7 @@
   "extensions/positron-data-driver-databricks/": ["@:connections"],
   "extensions/positron-data-driver-duckdb/": ["@:connections"],
   "extensions/positron-data-driver-pins/": ["@:connect", "@:connections"],
+  "extensions/positron-data-driver-odbc/": ["@:connections"],
   "extensions/positron-data-driver-postgresql/": ["@:connections"],
   "extensions/positron-data-driver-redshift/": ["@:connections"],
   "extensions/positron-data-driver-snowflake/": ["@:connections"],

--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -129,6 +129,11 @@ const extensions = [
 		mocha: { timeout: 60_000 }
 	},
 	{
+		label: 'positron-data-driver-odbc',
+		workspaceFolder: path.join(os.tmpdir(), `positron-data-driver-odbc-${Math.floor(Math.random() * 100000)}`),
+		mocha: { timeout: 60_000 }
+	},
+	{
 		label: 'positron-data-driver-snowflake',
 		workspaceFolder: path.join(os.tmpdir(), `positron-data-driver-snowflake-${Math.floor(Math.random() * 100000)}`),
 		mocha: { timeout: 60_000 }

--- a/build/gulpfile.extensions.ts
+++ b/build/gulpfile.extensions.ts
@@ -69,6 +69,7 @@ const compilations = [
 	'extensions/positron-environment/tsconfig.json',
 	'extensions/positron-data-driver-databricks/tsconfig.json',
 	'extensions/positron-data-driver-duckdb/tsconfig.json',
+	'extensions/positron-data-driver-odbc/tsconfig.json',
 	'extensions/positron-data-driver-pins/tsconfig.json',
 	'extensions/positron-data-driver-postgresql/tsconfig.json',
 	'extensions/positron-data-driver-redshift/tsconfig.json',

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -317,6 +317,7 @@ function fromLocalEsbuild(extensionPath: string, esbuildConfigFileName: string):
 			'positron-pdf-server',
 			'positron-data-driver-databricks',
 			'positron-data-driver-duckdb',
+			'positron-data-driver-odbc',
 			'positron-data-driver-pins',
 			'positron-data-driver-postgresql',
 			'positron-data-driver-redshift',

--- a/build/npm/dirs.ts
+++ b/build/npm/dirs.ts
@@ -36,6 +36,7 @@ export let dirs = [
 	'extensions/positron-data-explorer-duckdb',
 	'extensions/positron-data-driver-databricks',
 	'extensions/positron-data-driver-duckdb',
+	'extensions/positron-data-driver-odbc',
 	'extensions/positron-data-driver-pins',
 	'extensions/positron-data-driver-postgresql',
 	'extensions/positron-data-driver-redshift',

--- a/extensions/positron-data-driver-odbc/esbuild.mts
+++ b/extensions/positron-data-driver-odbc/esbuild.mts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+import * as path from 'node:path';
+import { run } from '../esbuild-extension-common.mts';
+
+const srcDir = path.join(import.meta.dirname, 'src');
+const outDir = path.join(import.meta.dirname, 'dist');
+
+run({
+	platform: 'node',
+	entryPoints: {
+		'extension': path.join(srcDir, 'extension.ts'),
+		// The ODBC connection runs in this child process (forked by odbcWorkerClient.ts) so a fault
+		// in a third-party vendor driver cannot take down the extension host. It is emitted next to
+		// extension.js and located at runtime via __dirname.
+		'odbcWorker': path.join(srcDir, 'odbcWorker.ts'),
+	},
+	srcDir,
+	outdir: outDir,
+	additionalOptions: {
+		// odbc is a native module; externalize so it's loaded from node_modules at runtime
+		// (positron-data-driver-odbc is registered in extensionsWithNpmDeps so its dependencies are
+		// packaged). Only odbcWorker.ts imports it; the extension host bundle never loads the
+		// native binding.
+		external: ['vscode', 'positron', 'odbc'],
+	},
+}, process.argv);

--- a/extensions/positron-data-driver-odbc/media/logo/odbc.svg
+++ b/extensions/positron-data-driver-odbc/media/logo/odbc.svg
@@ -1,0 +1,14 @@
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+	<!--
+		Placeholder mark for ODBC connections: a database cylinder with a connector stem. There is no
+		ODBC logo Positron can ship, and an ODBC connection is not tied to any one vendor, so this is
+		deliberately generic. Replace with a designed mark when one exists.
+	-->
+	<g fill="none" stroke="#6b8fb5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+		<ellipse cx="12" cy="7" rx="8" ry="3.5" />
+		<path d="M4 7v11c0 1.9 3.6 3.5 8 3.5s8-1.6 8-3.5V7" />
+		<path d="M4 12.5c0 1.9 3.6 3.5 8 3.5s8-1.6 8-3.5" />
+		<path d="M20 15h4a4 4 0 0 1 4 4v6" />
+		<path d="M25.5 22.5h5v4h-5z" fill="#6b8fb5" stroke="none" />
+	</g>
+</svg>

--- a/extensions/positron-data-driver-odbc/package-lock.json
+++ b/extensions/positron-data-driver-odbc/package-lock.json
@@ -1,0 +1,6610 @@
+{
+  "name": "positron-data-driver-odbc",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "positron-data-driver-odbc",
+      "version": "0.0.1",
+      "dependencies": {
+        "odbc": "^2.5.0"
+      },
+      "devDependencies": {
+        "@types/mocha": "^9.1.0",
+        "@types/node": "14.x",
+        "@typescript-eslint/eslint-plugin": "^5.12.1",
+        "@typescript-eslint/parser": "^5.12.1",
+        "@vscode/test-electron": "^2.1.2",
+        "@vscode/vsce": "^3.3.2",
+        "eslint": "^8.9.0",
+        "mocha": "^9.2.1",
+        "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
+        "ts-node": "^10.9.1",
+        "typescript": "^4.5.5"
+      },
+      "engines": {
+        "vscode": "^1.65.0"
+      }
+    },
+    "../positron-data-explorer-protocol": {
+      "version": "0.0.1",
+      "dev": true,
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/@azu/format-text": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@azu/format-text/-/format-text-1.0.2.tgz",
+      "integrity": "sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@azu/style-format": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@azu/style-format/-/style-format-1.0.1.tgz",
+      "integrity": "sha512-AHcTojlNBdD/3/KxIKlg8sxIWHfOtQszLvOpagLTO+bjC3u7SAszu1lf//u7JJC50aUSH+BVWDD/KvaA6Gfn5g==",
+      "dev": true,
+      "license": "WTFPL",
+      "dependencies": {
+        "@azu/format-text": "^1.0.1"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.2.0.tgz",
+      "integrity": "sha512-fNAjWnA/nZ2jz31kxR/AqRaUT8ewHBw/WuBIosK0moMy1C9e5ValbDfFdIxJzVOOYaYkV/b2F1S4H/aHiqfVQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.11.0.tgz",
+      "integrity": "sha512-IUZydyTUkDnYdstOW9pFOOUQlBjAepK5teihDE3x6yxsPJs/hsAaaYpeGxdxrgtOiJbBKSjKW7MDk7AEhb4LRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.11.0.tgz",
+      "integrity": "sha512-JjQWO6akOck45PH/XBrxzsQGAiKrfFl4m5iggJ0ItMIz5omRufOXWpqCPpdjKN3vKDzlSUvFjaMb7Zwf0gvAdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-process": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-process/-/core-process-1.0.0.tgz",
+      "integrity": "sha512-/shnJ+ooO8WPxDhPEeI/2oRQuubn16gZ6CvlbpWbEswZfzwI9tI/sMAHmF3x1LuQ9yZYXfLW3TjzGMLEC5blKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.25.0.tgz",
+      "integrity": "sha512-bMs8ekJLjX8wPV+9IPBges1SLPyuDtE9g5gLDWOpxzKcoOFQnpLGkbcT1tdw3FaAmDS1gnPmMmJ6y/T5B96kIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.4.0.tgz",
+      "integrity": "sha512-eGwxD0AtncrxeBM4tG8R55Pc3rdX1hNW2WibJAgYpCVA6E93mvvVH+LcssoVjOBrSKWS55yEIHsk0X8ctHmfOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.14.0.tgz",
+      "integrity": "sha512-9n2pWK61veAuN0V20t9lOuoV4CFMdyAZ1ygZzvBGk/pBBJRib/PjL9PLXa/aI2CcPpyHfqVsxxqLCYl6uZlfDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/identity": {
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.2.tgz",
+      "integrity": "sha512-NXL2/pCJctLxgw8bvrwwgge743kEq8LBT+O1pmV0vyUwetzFPH9auP6jhkU/cgZCPPtWoewAe3ncaGCgPo07fA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-process": "^1.0.0",
+        "@azure/core-rest-pipeline": "^1.17.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "@azure/msal-browser": "^5.5.0",
+        "@azure/msal-node": "^5.1.5",
+        "open": "^10.1.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.4.0.tgz",
+      "integrity": "sha512-rbAE25KUfjU/s3XHUdJgceoCP5dEOpMx85J04kF+QMdta73XkuG9JGHHinch+XIoKpBdqljin+KqURpJriSzLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.18.0.tgz",
+      "integrity": "sha512-SPTeHYZghdEdRddJzNjhH+CI5MSQtquNYwGJnYXfOHIBRXCmrWimBS85OhwXpXFIlrCtNTbBPm5mPAWRNEoktA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.12.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.12.0.tgz",
+      "integrity": "sha512-hgLgfRdbG2AmhXPygebf1KYJEvse86+ZZLWufdiTKaGRYEUqOzHdlf6AS1IiuUCHWbynkgbHc451jSNkbfhWlg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.5.0.tgz",
+      "integrity": "sha512-A/2WIsuH0vsC6JVkkafjS4kHpi2LDR4AzDT0kJ+oIRtXYeYtvGQ2pwN2X88thQPhSek+82ela3MprsKXWQRrhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.12.0",
+        "jsonwebtoken": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-2.0.3.tgz",
+      "integrity": "sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "consola": "^3.2.3",
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^7.0.5",
+        "node-fetch": "^2.6.7",
+        "nopt": "^8.0.0",
+        "semver": "^7.5.3",
+        "tar": "^7.4.0"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@secretlint/config-creator": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/config-creator/-/config-creator-10.2.2.tgz",
+      "integrity": "sha512-BynOBe7Hn3LJjb3CqCHZjeNB09s/vgf0baBaHVw67w7gHF0d25c3ZsZ5+vv8TgwSchRdUCRrbbcq5i2B1fJ2QQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/types": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/config-loader": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/config-loader/-/config-loader-10.2.2.tgz",
+      "integrity": "sha512-ndjjQNgLg4DIcMJp4iaRD6xb9ijWQZVbd9694Ol2IszBIbGPPkwZHzJYKICbTBmh6AH/pLr0CiCaWdGJU7RbpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/profiler": "^10.2.2",
+        "@secretlint/resolver": "^10.2.2",
+        "@secretlint/types": "^10.2.2",
+        "ajv": "^8.17.1",
+        "debug": "^4.4.1",
+        "rc-config-loader": "^4.1.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/core": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/core/-/core-10.2.2.tgz",
+      "integrity": "sha512-6rdwBwLP9+TO3rRjMVW1tX+lQeo5gBbxl1I5F8nh8bgGtKwdlCMhMKsBWzWg1ostxx/tIG7OjZI0/BxsP8bUgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/profiler": "^10.2.2",
+        "@secretlint/types": "^10.2.2",
+        "debug": "^4.4.1",
+        "structured-source": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/formatter": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/formatter/-/formatter-10.2.2.tgz",
+      "integrity": "sha512-10f/eKV+8YdGKNQmoDUD1QnYL7TzhI2kzyx95vsJKbEa8akzLAR5ZrWIZ3LbcMmBLzxlSQMMccRmi05yDQ5YDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/resolver": "^10.2.2",
+        "@secretlint/types": "^10.2.2",
+        "@textlint/linter-formatter": "^15.2.0",
+        "@textlint/module-interop": "^15.2.0",
+        "@textlint/types": "^15.2.0",
+        "chalk": "^5.4.1",
+        "debug": "^4.4.1",
+        "pluralize": "^8.0.0",
+        "strip-ansi": "^7.1.0",
+        "table": "^6.9.0",
+        "terminal-link": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/formatter/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@secretlint/node": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/node/-/node-10.2.2.tgz",
+      "integrity": "sha512-eZGJQgcg/3WRBwX1bRnss7RmHHK/YlP/l7zOQsrjexYt6l+JJa5YhUmHbuGXS94yW0++3YkEJp0kQGYhiw1DMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/config-loader": "^10.2.2",
+        "@secretlint/core": "^10.2.2",
+        "@secretlint/formatter": "^10.2.2",
+        "@secretlint/profiler": "^10.2.2",
+        "@secretlint/source-creator": "^10.2.2",
+        "@secretlint/types": "^10.2.2",
+        "debug": "^4.4.1",
+        "p-map": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/profiler": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/profiler/-/profiler-10.2.2.tgz",
+      "integrity": "sha512-qm9rWfkh/o8OvzMIfY8a5bCmgIniSpltbVlUVl983zDG1bUuQNd1/5lUEeWx5o/WJ99bXxS7yNI4/KIXfHexig==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@secretlint/resolver": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/resolver/-/resolver-10.2.2.tgz",
+      "integrity": "sha512-3md0cp12e+Ae5V+crPQYGd6aaO7ahw95s28OlULGyclyyUtf861UoRGS2prnUrKh7MZb23kdDOyGCYb9br5e4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@secretlint/secretlint-formatter-sarif": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/secretlint-formatter-sarif/-/secretlint-formatter-sarif-10.2.2.tgz",
+      "integrity": "sha512-ojiF9TGRKJJw308DnYBucHxkpNovDNu1XvPh7IfUp0A12gzTtxuWDqdpuVezL7/IP8Ua7mp5/VkDMN9OLp1doQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-sarif-builder": "^3.2.0"
+      }
+    },
+    "node_modules/@secretlint/secretlint-rule-no-dotenv": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-no-dotenv/-/secretlint-rule-no-dotenv-10.2.2.tgz",
+      "integrity": "sha512-KJRbIShA9DVc5Va3yArtJ6QDzGjg3PRa1uYp9As4RsyKtKSSZjI64jVca57FZ8gbuk4em0/0Jq+uy6485wxIdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/types": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/secretlint-rule-preset-recommend": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-preset-recommend/-/secretlint-rule-preset-recommend-10.2.2.tgz",
+      "integrity": "sha512-K3jPqjva8bQndDKJqctnGfwuAxU2n9XNCPtbXVI5JvC7FnQiNg/yWlQPbMUlBXtBoBGFYp08A94m6fvtc9v+zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/source-creator": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/source-creator/-/source-creator-10.2.2.tgz",
+      "integrity": "sha512-h6I87xJfwfUTgQ7irWq7UTdq/Bm1RuQ/fYhA3dtTIAop5BwSFmZyrchph4WcoEvbN460BWKmk4RYSvPElIIvxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/types": "^10.2.2",
+        "istextorbinary": "^9.5.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/types": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/types/-/types-10.2.2.tgz",
+      "integrity": "sha512-Nqc90v4lWCXyakD6xNyNACBJNJ0tNCwj2WNk/7ivyacYHxiITVgmLUFXTBOeCdy79iz6HtN9Y31uw/jbLrdOAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@textlint/ast-node-types": {
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.8.0.tgz",
+      "integrity": "sha512-5CiH9COYmovWmExQgs7763DzX6Gy9zjkjJ7JxCC95wyTcjwQn/8poNF6fv3qzRlmx8CRRde8DHr9FcgAAiPzgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@textlint/linter-formatter": {
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-15.8.0.tgz",
+      "integrity": "sha512-+oU3A235NATv6Lzi4xa4kJ65PuNJlIxesaO4AvDhDWA9FWm7y4XKWaoQCW1esgaQQ6dwnUiFKArQ8TcJ86mC4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azu/format-text": "^1.0.2",
+        "@azu/style-format": "^1.0.1",
+        "@textlint/module-interop": "15.8.0",
+        "@textlint/resolver": "15.8.0",
+        "@textlint/types": "15.8.0",
+        "debug": "^4.4.3",
+        "js-yaml": "^4.3.0",
+        "lodash": "^4.18.1",
+        "pluralize": "^2.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "table": "^6.9.0",
+        "text-table": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      }
+    },
+    "node_modules/@textlint/linter-formatter/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@textlint/linter-formatter/node_modules/pluralize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-2.0.0.tgz",
+      "integrity": "sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@textlint/linter-formatter/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@textlint/module-interop": {
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-15.8.0.tgz",
+      "integrity": "sha512-rt+OR1WYGoLOY8HkA/aBPrqufF6yUUEsKEAh7XohTsT3lp9IyZFT6zOIbjul9P4FAzsmSPkcrYjVx3Bz/IUfkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@textlint/resolver": {
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@textlint/resolver/-/resolver-15.8.0.tgz",
+      "integrity": "sha512-E88tzfX3K8Jykk+38aJ9cy8RquD8ABVOPTO2rFEESq0wcg8x6/ypdAS8ZgR7OKiGqlRF0hkO/m5PbQwVfKM3VA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@textlint/types": {
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-15.8.0.tgz",
+      "integrity": "sha512-Anhc6y5736YIsvqae0U6k0YmB2M/QVHkEeOv2aydAn/WIkdI69dCOiDbe3/+RagS3qstFTSFWJzNRA2lUjv19w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/ast-node-types": "15.8.0"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.13.tgz",
+      "integrity": "sha512-gcLdvR9HO1ZJBypsOGqaP6TFEzb6vIta0KSTLt9NAQ6pXQO3cRgSVyCN6pzYqI9DlJgY71XKO0dpDhCf08b3pg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mocha": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/sarif": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
+      "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
+      "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.4.0",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/type-utils": "5.62.0",
+        "@typescript-eslint/utils": "5.62.0",
+        "debug": "^4.3.4",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
+      "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
+      "integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "@typescript-eslint/utils": "5.62.0",
+        "debug": "^4.3.4",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.8.tgz",
+      "integrity": "sha512-bLMpVcWZNzq6lYOybwFwOAR1IXKcHnhUNqYeHjl1bET/qE3jFPFH+p8Wrh3rU4xwdnifPxmKNESBYnvnmc75aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@vscode/test-electron": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
+      "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "jszip": "^3.10.1",
+        "ora": "^8.1.0",
+        "semver": "^7.6.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@vscode/vsce": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.9.2.tgz",
+      "integrity": "sha512-XSxMosEEDO6vLxELAHVkwmhC0qe0ijZni2jB9Rcs8kQsW4lhTDQ/wMzmwFs/buotAWSnpmUp/dRWD2ufG3UYKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/identity": "^4.1.0",
+        "@secretlint/node": "^10.1.2",
+        "@secretlint/secretlint-formatter-sarif": "^10.1.2",
+        "@secretlint/secretlint-rule-no-dotenv": "^10.1.2",
+        "@secretlint/secretlint-rule-preset-recommend": "^10.1.2",
+        "@vscode/vsce-sign": "^2.0.0",
+        "azure-devops-node-api": "^12.5.0",
+        "chalk": "^4.1.2",
+        "cheerio": "^1.0.0-rc.9",
+        "cockatiel": "^3.1.2",
+        "commander": "^12.1.0",
+        "form-data": "^4.0.0",
+        "glob": "^13.0.6",
+        "hosted-git-info": "^4.0.2",
+        "jsonc-parser": "^3.2.0",
+        "leven": "^3.1.0",
+        "markdown-it": "^14.1.0",
+        "mime": "^1.3.4",
+        "minimatch": "^10.2.2",
+        "parse-semver": "^1.1.1",
+        "read": "^1.0.7",
+        "secretlint": "^10.1.2",
+        "semver": "^7.5.2",
+        "tmp": "^0.2.3",
+        "typed-rest-client": "^1.8.4",
+        "url-join": "^4.0.1",
+        "xml2js": "^0.5.0",
+        "yauzl": "^3.2.1",
+        "yazl": "^2.2.2"
+      },
+      "bin": {
+        "vsce": "vsce"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "keytar": "^7.7.0"
+      }
+    },
+    "node_modules/@vscode/vsce-sign": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign/-/vsce-sign-2.1.0.tgz",
+      "integrity": "sha512-9AQrqazrBgTgRSuwleLVXUrIUphY02/SFCh2TKYoLV/xifJAdblhdmEmw5gUrYSPQ3sRwNs9iyCMD14sATEE6g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optionalDependencies": {
+        "@vscode/vsce-sign-alpine-arm64": "2.0.6",
+        "@vscode/vsce-sign-alpine-x64": "2.0.6",
+        "@vscode/vsce-sign-darwin-arm64": "2.0.6",
+        "@vscode/vsce-sign-darwin-x64": "2.0.6",
+        "@vscode/vsce-sign-linux-arm": "2.0.6",
+        "@vscode/vsce-sign-linux-arm64": "2.0.6",
+        "@vscode/vsce-sign-linux-x64": "2.0.6",
+        "@vscode/vsce-sign-win32-arm64": "2.0.6",
+        "@vscode/vsce-sign-win32-x64": "2.0.6"
+      }
+    },
+    "node_modules/@vscode/vsce-sign-alpine-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.6.tgz",
+      "integrity": "sha512-wKkJBsvKF+f0GfsUuGT0tSW0kZL87QggEiqNqK6/8hvqsXvpx8OsTEc3mnE1kejkh5r+qUyQ7PtF8jZYN0mo8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "alpine"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-alpine-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.6.tgz",
+      "integrity": "sha512-YoAGlmdK39vKi9jA18i4ufBbd95OqGJxRvF3n6ZbCyziwy3O+JgOpIUPxv5tjeO6gQfx29qBivQ8ZZTUF2Ba0w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "alpine"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-darwin-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-arm64/-/vsce-sign-darwin-arm64-2.0.6.tgz",
+      "integrity": "sha512-5HMHaJRIQuozm/XQIiJiA0W9uhdblwwl2ZNDSSAeXGO9YhB9MH5C4KIHOmvyjUnKy4UCuiP43VKpIxW1VWP4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-darwin-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.6.tgz",
+      "integrity": "sha512-25GsUbTAiNfHSuRItoQafXOIpxlYj+IXb4/qarrXu7kmbH94jlm5sdWSCKrrREs8+GsXF1b+l3OB7VJy5jsykw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-arm": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.6.tgz",
+      "integrity": "sha512-UndEc2Xlq4HsuMPnwu7420uqceXjs4yb5W8E2/UkaHBB9OWCwMd3/bRe/1eLe3D8kPpxzcaeTyXiK3RdzS/1CA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.6.tgz",
+      "integrity": "sha512-cfb1qK7lygtMa4NUl2582nP7aliLYuDEVpAbXJMkDq1qE+olIw/es+C8j1LJwvcRq1I2yWGtSn3EkDp9Dq5FdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.6.tgz",
+      "integrity": "sha512-/olerl1A4sOqdP+hjvJ1sbQjKN07Y3DVnxO4gnbn/ahtQvFrdhUi0G1VsZXDNjfqmXw57DmPi5ASnj/8PGZhAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-win32-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.6.tgz",
+      "integrity": "sha512-ivM/MiGIY0PJNZBoGtlRBM/xDpwbdlCWomUWuLmIxbi1Cxe/1nooYrEQoaHD8ojVRgzdQEUzMsRbyF5cJJgYOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-win32-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.6.tgz",
+      "integrity": "sha512-mgth9Kvze+u8CruYMmhHw6Zgy3GRX2S+Ed5oSokDEK5vPEwGGKnmuXua9tmFhomeAnhgJnL4DCna3TiNuGrBTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/abbrev": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
+      "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/azure-devops-node-api": {
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz",
+      "integrity": "sha512-R5eFskGvOm3U/GzeAuxRkUsAl0hrAwGgWn6zAd2KrZmrEhWZVqLew4OOupbQlXUuojUzpGtq62SmdhJ06N88og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "0.0.6",
+        "typed-rest-client": "^1.8.4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/binaryextensions": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-6.11.0.tgz",
+      "integrity": "sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw==",
+      "dev": true,
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "editions": "^6.21.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/boundary": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/boundary/-/boundary-2.0.0.tgz",
+      "integrity": "sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cockatiel": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/cockatiel/-/cockatiel-3.2.1.tgz",
+      "integrity": "sha512-gfrHV6ZPkquExvMh9IOkKsBzNDk6sDuZ6DdBGUBkvFnTCqCxzpuq48RySgP0AnaqQkw2zynOFj9yly6T1Q2G5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
+      "integrity": "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/editions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-6.22.0.tgz",
+      "integrity": "sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ==",
+      "dev": true,
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "version-range": "^4.15.0"
+      },
+      "engines": {
+        "ecmascript": ">= es5",
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esquery/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esrecurse/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "license": "(MIT OR WTFPL)",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fs-extra": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.x"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/index-to-position": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istextorbinary": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-9.5.0.tgz",
+      "integrity": "sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==",
+      "dev": true,
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "binaryextensions": "^6.11.0",
+        "editions": "^6.21.0",
+        "textextensions": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/keytar": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
+      "integrity": "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^4.3.0",
+        "prebuild-install": "^7.0.1"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/markdown-it": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+      "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/mocha": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ungap/promise-all-settled": "1.1.2",
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.3",
+        "debug": "4.3.3",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.2.0",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "4.2.1",
+        "ms": "2.1.3",
+        "nanoid": "3.3.1",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "which": "2.0.2",
+        "workerpool": "6.2.0",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mochajs"
+      }
+    },
+    "node_modules/mocha/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mocha/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/mocha/node_modules/debug": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mocha/node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mocha/node_modules/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mocha/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+      "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mocha/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-sarif-builder": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-3.4.0.tgz",
+      "integrity": "sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sarif": "^2.1.7",
+        "fs-extra": "^11.1.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
+      "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^3.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/normalize-package-data": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/hosted-git-info": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/odbc": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/odbc/-/odbc-2.5.0.tgz",
+      "integrity": "sha512-vzAzh73dymeMhtuTylJyB6hzkgSh4EVgtQfJhF4LQ4yKHVY2V4n86L1alf8rQ3A/0oR4Dty+paisH8grkmmvZw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^2.0.0",
+        "async": "^3.0.1",
+        "node-addon-api": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/odbc/node_modules/node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+      "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ora/node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
+      "integrity": "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-json/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-semver": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/parse-semver/-/parse-semver-1.1.1.tgz",
+      "integrity": "sha512-Eg1OuNntBMH0ojvEKSrvDSnwLmvVuUOSdylH/pSCPNMIspLlweJyIWXCE+k/5hm3cj/EBUYwmWkjhBALNP4LXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^5.1.0"
+      }
+    },
+    "node_modules/parse-semver/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/positron-data-explorer-protocol": {
+      "resolved": "../positron-data-explorer-protocol",
+      "link": true
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc-config-loader": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-4.1.4.tgz",
+      "integrity": "sha512-3GiwEzklkbXTDp52UR5nT8iXgYAx1V9ZG/kDZT7p60u2GCv2XTwQq4NzinMoMpNtXhmt3WkhYXcj6HH8HdwCEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "js-yaml": "^4.1.1",
+        "json5": "^2.2.3",
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "mute-stream": "~0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+      "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.3",
+        "normalize-package-data": "^6.0.0",
+        "parse-json": "^8.0.0",
+        "type-fest": "^4.6.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/secretlint": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/secretlint/-/secretlint-10.2.2.tgz",
+      "integrity": "sha512-xVpkeHV/aoWe4vP4TansF622nBEImzCY73y/0042DuJ29iKIaqgoJ8fGxre3rVSHHbxar4FdJobmTnLp9AU0eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/config-creator": "^10.2.2",
+        "@secretlint/formatter": "^10.2.2",
+        "@secretlint/node": "^10.2.2",
+        "@secretlint/profiler": "^10.2.2",
+        "debug": "^4.4.1",
+        "globby": "^14.1.0",
+        "read-pkg": "^9.0.1"
+      },
+      "bin": {
+        "secretlint": "bin/secretlint.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/secretlint/node_modules/globby": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
+      "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.3",
+        "path-type": "^6.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/secretlint/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/secretlint/node_modules/path-type": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
+      "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/secretlint/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/secretlint/node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/structured-source": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/structured-source/-/structured-source-4.0.0.tgz",
+      "integrity": "sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boundary": "^2.0.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+      "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/table": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+      "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/table/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/terminal-link": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-4.0.0.tgz",
+      "integrity": "sha512-lk+vH+MccxNqgVqSnkMVKx4VLJfnLjDBGzH16JVZjKE2DoxP57s6/vt6JmXV5I3jBcfGrxNrYtC+mPtU7WJztA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "supports-hyperlinks": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/textextensions": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-6.11.0.tgz",
+      "integrity": "sha512-tXJwSr9355kFJI3lbCkPpUH5cP8/M0GGy2xLO34aZCjMXBaK3SoPnZwr/oWmo1FdCnELcs4npdCIOFtq9W3ruQ==",
+      "dev": true,
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "editions": "^6.21.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/tsutils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-rest-client": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
+      "integrity": "sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "qs": "^6.9.1",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/version-range": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/version-range/-/version-range-4.15.0.tgz",
+      "integrity": "sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==",
+      "dev": true,
+      "license": "Artistic-2.0",
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/workerpool": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yazl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/extensions/positron-data-driver-odbc/package.json
+++ b/extensions/positron-data-driver-odbc/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "positron-data-driver-odbc",
+  "displayName": "%displayName%",
+  "description": "%description%",
+  "version": "0.0.1",
+  "publisher": "positron",
+  "private": true,
+  "engines": {
+    "vscode": "^1.65.0"
+  },
+  "activationEvents": [
+    "onView:workbench.panel.positronDataConnections"
+  ],
+  "main": "./out/extension.js",
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "pretest": "npm run compile && npm run lint",
+    "lint": "eslint src --ext ts"
+  },
+  "contributes": {},
+  "dependencies": {
+    "odbc": "^2.5.0"
+  },
+  "devDependencies": {
+    "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
+    "@types/mocha": "^9.1.0",
+    "@types/node": "14.x",
+    "@typescript-eslint/eslint-plugin": "^5.12.1",
+    "@typescript-eslint/parser": "^5.12.1",
+    "@vscode/test-electron": "^2.1.2",
+    "@vscode/vsce": "^3.3.2",
+    "eslint": "^8.9.0",
+    "mocha": "^9.2.1",
+    "ts-node": "^10.9.1",
+    "typescript": "^4.5.5"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/posit-dev/positron"
+  }
+}

--- a/extensions/positron-data-driver-odbc/package.nls.json
+++ b/extensions/positron-data-driver-odbc/package.nls.json
@@ -1,0 +1,4 @@
+{
+	"displayName": "Positron ODBC Data Connection Driver",
+	"description": "Provides ODBC data connection drivers for the Data Connections panel, using the ODBC drivers configured on this machine."
+}

--- a/extensions/positron-data-driver-odbc/src/extension.ts
+++ b/extensions/positron-data-driver-odbc/src/extension.ts
@@ -1,0 +1,127 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as path from 'path';
+import * as positron from 'positron';
+import * as vscode from 'vscode';
+import { createNodeConfigHost } from './odbcConfigHost';
+import { OdbcDataExplorerRpcHandler } from './odbcDataExplorerRpcHandler';
+import { createOdbcDrivers } from './odbcDriver';
+import { discoverOdbcConfiguration, IOdbcConfigHost, resolveUnixConfigPaths } from './odbcinst';
+
+/**
+ * Activates the extension by discovering the machine's ODBC configuration and registering a driver
+ * for it -- the generic ODBC driver, plus one per recognized database whose ODBC driver is
+ * installed.
+ */
+export function activate(context: vscode.ExtensionContext) {
+	// Log to a per-driver output channel, created by core on first use. Nothing may log during
+	// activation: the Data Connections pane activates every driver at once, so an activation-time
+	// log would add this channel for users who never opened a connection.
+	const logger = positron.dataConnections.createDriverLogger('ODBC');
+	context.subscriptions.push(logger);
+
+	// Services Data Explorer RPCs for tables/views previewed from an ODBC connection.
+	const dataExplorerHandler = new OdbcDataExplorerRpcHandler(logger);
+	context.subscriptions.push(dataExplorerHandler);
+
+	const host = createNodeConfigHost();
+
+	// The registered drivers, replaced wholesale whenever the configuration changes. Held in a
+	// disposable store of its own rather than on context.subscriptions, which only unwinds at
+	// shutdown and would accumulate a stale registration on every reload.
+	let registrations: vscode.Disposable[] = [];
+
+	/**
+	 * Rebuilds the registered drivers from the machine's current ODBC configuration.
+	 *
+	 * @param log Whether to report what was found. False on the initial registration: the Data
+	 * Connections pane activates every driver at once, so logging there would create this
+	 * extension's output channel for every user who opens the pane, including those who never use
+	 * ODBC. The logger is lazy precisely so that channel appears only once ODBC is actually used --
+	 * on a configuration change, or on a connection.
+	 */
+	const register = (log: boolean) => {
+		for (const registration of registrations) {
+			registration.dispose();
+		}
+
+		const config = discoverOdbcConfiguration(host);
+		if (log) {
+			logger.info(`Discovered ${config.drivers.length} ODBC driver(s) and ${config.dsns.length} data source(s) from: ${config.sources.join(', ') || '(no configuration found)'}`);
+		}
+
+		registrations = createOdbcDrivers(context, config, dataExplorerHandler, logger)
+			.map(driver => positron.dataConnections.registerDriver(driver));
+	};
+
+	register(false);
+
+	// ODBC configuration is edited outside Positron -- by an installer, an admin, or the user with
+	// a text editor -- so the drivers are rebuilt when those files change rather than only at
+	// startup. Driver metadata is otherwise fixed at registration time, so re-registering is how it
+	// is refreshed.
+	context.subscriptions.push(watchConfiguration(host, () => register(true), logger));
+
+	context.subscriptions.push(new vscode.Disposable(() => {
+		for (const registration of registrations) {
+			registration.dispose();
+		}
+		registrations = [];
+	}));
+}
+
+/**
+ * Watches the ODBC configuration files for changes.
+ *
+ * The files sit outside any workspace folder, so this uses absolute-path watchers rather than a
+ * workspace-relative glob. Windows keeps its configuration in the registry, which has no file to
+ * watch and no change notification available here; a Windows user who installs a driver while
+ * Positron is running picks it up on the next window reload.
+ */
+function watchConfiguration(
+	host: IOdbcConfigHost,
+	onChange: () => void,
+	logger: positron.DataConnectionLogger
+): vscode.Disposable {
+	if (host.platform === 'win32') {
+		return new vscode.Disposable(() => { });
+	}
+
+	const paths = resolveUnixConfigPaths(host);
+	const watched = [
+		...paths.systemDrivers,
+		...paths.systemDsns,
+		...paths.userDrivers,
+		...paths.userDsns,
+	];
+
+	const watchers = watched.map(filePath => {
+		// A watcher is created per file rather than per directory: /etc and the home directory are
+		// both busy, and a correlated watcher on the exact path is far cheaper than filtering a
+		// directory's worth of events.
+		const watcher = vscode.workspace.createFileSystemWatcher(
+			new vscode.RelativePattern(vscode.Uri.file(path.dirname(filePath)), path.basename(filePath)));
+		const reload = () => {
+			logger.info(`ODBC configuration changed (${filePath}); reloading drivers.`);
+			onChange();
+		};
+		watcher.onDidCreate(reload);
+		watcher.onDidChange(reload);
+		watcher.onDidDelete(reload);
+		return watcher;
+	});
+
+	return new vscode.Disposable(() => {
+		for (const watcher of watchers) {
+			watcher.dispose();
+		}
+	});
+}
+
+/** Deactivation is handled by disposing context subscriptions. */
+export function deactivate() {
+	// Nothing to do.
+}

--- a/extensions/positron-data-driver-odbc/src/odbcConfigHost.ts
+++ b/extensions/positron-data-driver-odbc/src/odbcConfigHost.ts
@@ -1,0 +1,136 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// The real IOdbcConfigHost: reads ini files from disk on unix-like platforms, and the ODBC hives
+// out of the Windows registry via reg.exe. Kept separate from odbcinst.ts so that module stays a
+// pure, fixture-testable parser.
+
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import { IOdbcConfigHost, OdbcRegistrySnapshot } from './odbcinst';
+
+/**
+ * Parses the output of `reg.exe query <key> /s` into a map of subkey name -> values. Only the leaf
+ * segment of each key path is kept, which is exactly what ODBC needs: under ODBCINST.INI the
+ * subkeys are driver names, and under ODBC.INI they are DSN names.
+ *
+ * A `reg query` dump looks like:
+ *
+ *     HKEY_LOCAL_MACHINE\SOFTWARE\ODBC\ODBCINST.INI\PostgreSQL Unicode
+ *         Driver    REG_SZ    C:\Program Files\psqlODBC\psqlodbc35w.dll
+ *
+ * Exported for tests.
+ */
+export function parseRegQueryOutput(output: string, rootKey: string): Record<string, Record<string, string>> {
+	const result: Record<string, Record<string, string>> = {};
+	// reg.exe echoes the full hive name in its output, whatever abbreviation the query used, so the
+	// root has to be expanded before it will match.
+	const expandedRoot = rootKey
+		.replace(/^HKLM\\/i, 'HKEY_LOCAL_MACHINE\\')
+		.replace(/^HKCU\\/i, 'HKEY_CURRENT_USER\\');
+	const rootPrefix = `${expandedRoot.toLowerCase()}\\`;
+	let current: Record<string, string> | undefined;
+
+	for (const rawLine of output.split(/\r?\n/)) {
+		if (rawLine.trim().length === 0) {
+			continue;
+		}
+
+		// Key paths start at column zero; values are indented.
+		if (!/^\s/.test(rawLine)) {
+			const keyPath = rawLine.trim();
+			current = undefined;
+			if (keyPath.toLowerCase().startsWith(rootPrefix)) {
+				const relative = keyPath.slice(expandedRoot.length + 1);
+				// Only direct children are entries; anything deeper belongs to a driver's own
+				// subkeys, which ODBC does not use for discovery.
+				if (relative.length > 0 && !relative.includes('\\')) {
+					current = result[relative] ??= {};
+				}
+			}
+			continue;
+		}
+
+		if (current === undefined) {
+			continue;
+		}
+
+		// "    Name    REG_SZ    value". The name and the value may both contain spaces, so split
+		// on the type token rather than on whitespace.
+		const match = /^\s+(?<name>.*?)\s{4}(?<type>REG_[A-Z_]+)\s{4}(?<value>.*)$/.exec(rawLine);
+		if (match?.groups) {
+			current[match.groups.name.trim()] = match.groups.value;
+		}
+	}
+
+	return result;
+}
+
+/** Runs `reg.exe query <key> /s`, returning undefined when the key is absent or reg.exe fails. */
+function queryRegistry(key: string): Record<string, Record<string, string>> | undefined {
+	try {
+		const output = execFileSync('reg.exe', ['query', key, '/s'], {
+			encoding: 'utf-8',
+			windowsHide: true,
+			// A machine with many DSNs still produces a small dump; this is only a guard against a
+			// pathological registry.
+			maxBuffer: 8 * 1024 * 1024,
+		});
+		return parseRegQueryOutput(output, key);
+	} catch {
+		// The key does not exist (no ODBC drivers or no DSNs of that scope), or reg.exe is
+		// unavailable. Both are "nothing to report" rather than errors.
+		return undefined;
+	}
+}
+
+/**
+ * Creates the production configuration host.
+ * @param platform The platform to resolve for. Defaults to the current one; injectable so a test
+ * can exercise the Windows paths from a unix machine.
+ */
+export function createNodeConfigHost(platform: NodeJS.Platform = process.platform): IOdbcConfigHost {
+	return {
+		platform,
+
+		readFile(filePath: string): string | undefined {
+			try {
+				return fs.readFileSync(filePath, 'utf-8');
+			} catch {
+				// Missing, unreadable, or a directory. All mean "no configuration here".
+				return undefined;
+			}
+		},
+
+		exists(filePath: string): boolean {
+			try {
+				return fs.existsSync(filePath);
+			} catch {
+				return false;
+			}
+		},
+
+		homeDir(): string {
+			return os.homedir();
+		},
+
+		env(name: string): string | undefined {
+			const value = process.env[name];
+			return value !== undefined && value.length > 0 ? value : undefined;
+		},
+
+		readRegistry(): OdbcRegistrySnapshot | undefined {
+			if (platform !== 'win32') {
+				return undefined;
+			}
+			return {
+				drivers: queryRegistry('HKLM\\SOFTWARE\\ODBC\\ODBCINST.INI') ?? {},
+				systemDsns: queryRegistry('HKLM\\SOFTWARE\\ODBC\\ODBC.INI') ?? {},
+				userDsns: queryRegistry('HKCU\\SOFTWARE\\ODBC\\ODBC.INI') ?? {},
+			};
+		},
+	};
+}

--- a/extensions/positron-data-driver-odbc/src/odbcConnection.ts
+++ b/extensions/positron-data-driver-odbc/src/odbcConnection.ts
@@ -1,0 +1,202 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as positron from 'positron';
+import { OdbcDialect } from './odbcDatabases';
+import { redactConnectionString } from './odbcConnectionString';
+import { IOdbcDataExplorerHost, ODBC_DATA_EXPLORER_PROVIDER_ID } from './odbcDataExplorerRpcHandler';
+import { createRootNodes, fetchTables, IOdbcPreviewHost, OdbcTableRef } from './odbcNodes';
+import { OdbcError, OdbcWorkerClient } from './odbcWorkerClient';
+
+/** Monotonically increasing id so each connection's previewed datasets get a unique key. */
+let nextConnectionId = 1;
+
+/**
+ * Turns a worker failure into something a user can act on.
+ *
+ * The case worth special-casing is the driver manager being absent: on macOS and Linux the binding
+ * links against unixODBC, and without it every connection fails at dlopen with a message about a
+ * missing shared library, which reads as a Positron bug rather than a missing prerequisite.
+ * Everything else is passed through -- ODBC drivers report their own diagnostics, and those are
+ * more specific than anything this layer could substitute.
+ */
+export function describeConnectError(error: unknown): string {
+	const odbcError = error as OdbcError;
+
+	if (odbcError?.driverManagerMissing) {
+		switch (process.platform) {
+			case 'darwin':
+				return 'The unixODBC driver manager is not installed. Install it with "brew install unixodbc" and try again.';
+			case 'win32':
+				// Windows ships a driver manager, so reaching this means something stranger.
+				return `The ODBC driver manager could not be loaded: ${odbcError.message}`;
+			default:
+				return 'The unixODBC driver manager is not installed. Install your distribution\'s unixODBC package (e.g. "apt install unixodbc" or "dnf install unixODBC") and try again.';
+		}
+	}
+
+	return odbcError?.message ?? String(error);
+}
+
+/**
+ * A live ODBC connection implementing the DataConnection interface.
+ *
+ * The native ODBC connection runs in a separate child process via OdbcWorkerClient, so a fault in a
+ * third-party vendor driver takes down only that child rather than the extension host. This class
+ * is a thin host-side facade over the worker client; schema browsing is provided via getChildren().
+ */
+export class OdbcConnection implements positron.DataConnection, IOdbcPreviewHost {
+	/** The worker client, or undefined before connect() / after disconnect(). */
+	private _client: OdbcWorkerClient | undefined;
+
+	/** Unique id for this connection, used to key its previewed datasets. */
+	private readonly _connectionId = `odbc-${nextConnectionId++}`;
+
+	/** Dataset ids opened via preview, so they can be released on disconnect. */
+	private readonly _openedDatasets = new Set<string>();
+
+	/**
+	 * The table list, fetched once on first expansion. SQLTables is a single round trip that returns
+	 * every table on the connection (see odbcNodes.ts), so it is fetched once and the tree is built
+	 * from it for the life of the connection.
+	 */
+	private _tables: OdbcTableRef[] | undefined;
+
+	/**
+	 * @param _connectionString The full ODBC connection string.
+	 * @param _dialect How to write SQL for this backend, resolved from the ODBC driver name.
+	 * @param _dataExplorerHandler Hosts table views previewed in the Data Explorer.
+	 * @param _logger Optional diagnostic log sink for connection lifecycle events.
+	 */
+	constructor(
+		private readonly _connectionString: string,
+		private readonly _dialect: OdbcDialect,
+		private readonly _dataExplorerHandler: IOdbcDataExplorerHost,
+		private readonly _logger?: positron.DataConnectionLogger
+	) { }
+
+	/**
+	 * Opens the connection in the worker process. Must be called before any other method. Rejects
+	 * with a descriptive error if the connection cannot be established.
+	 */
+	async connect(): Promise<void> {
+		// The connection string is logged redacted: it routinely embeds a password, and the driver
+		// log is a file the user may well share when reporting a problem.
+		this._logger?.info(`Connecting: ${redactConnectionString(this._connectionString)}`);
+
+		const client = new OdbcWorkerClient(this._connectionString);
+		try {
+			// Establish the connection here so a failure surfaces from connect() rather than from
+			// the first expansion of the tree.
+			await client.connect();
+			this._client = client;
+		} catch (error) {
+			client.dispose();
+			const message = describeConnectError(error);
+			this._logger?.error(`Failed to connect: ${message}`);
+			throw new Error(message);
+		}
+
+		// A worker that dies later leaves the tree pointing at a connection that no longer exists.
+		// Log it; the next request respawns the worker and reconnects.
+		client.onDidCrash(() => this._logger?.warn('The ODBC process terminated unexpectedly; it will be restarted on the next request.'));
+
+		this._logger?.info('Connected');
+	}
+
+	/**
+	 * Returns the top-level nodes. The shape depends on what the backend uses -- catalogs, schemas,
+	 * or neither -- so it is derived from the table list rather than fixed.
+	 */
+	async getChildren(): Promise<positron.DataConnectionNode[]> {
+		this._ensureConnected();
+		this._tables ??= await fetchTables(this._client!);
+		return createRootNodes(this._tables, this._client!, this);
+	}
+
+	/**
+	 * Opens the given table or view in the Data Explorer. Registers a table view with the RPC
+	 * handler under a stable per-connection dataset id, then asks Positron to open (or focus) the
+	 * explorer backed by this extension's RPC command. Returns the dataset id it was opened under,
+	 * which Positron uses to tell that this connection has a Data Explorer open on it.
+	 */
+	async previewObject(ref: OdbcTableRef): Promise<string> {
+		this._ensureConnected();
+		const datasetId = `odbc:${this._connectionId}:${qualifiedKey(ref)}`;
+		await this._dataExplorerHandler.openTableView(datasetId, this._client!, ref, this._dialect);
+		this._openedDatasets.add(datasetId);
+		await positron.dataExplorer.open({
+			providerId: ODBC_DATA_EXPLORER_PROVIDER_ID,
+			datasetId,
+			displayName: ref.name,
+		});
+		return datasetId;
+	}
+
+	/**
+	 * Opens a single column of the given table or view in the Data Explorer as a one-column grid.
+	 * Uses a dataset id distinct from the table's so both can be open at once. Returns the dataset
+	 * id it was opened under.
+	 */
+	async previewColumn(ref: OdbcTableRef, columnName: string): Promise<string> {
+		this._ensureConnected();
+		const datasetId = `odbc:${this._connectionId}:column:${qualifiedKey(ref)}.${columnName}`;
+		await this._dataExplorerHandler.openColumnView(datasetId, this._client!, ref, this._dialect, columnName);
+		this._openedDatasets.add(datasetId);
+		await positron.dataExplorer.open({
+			providerId: ODBC_DATA_EXPLORER_PROVIDER_ID,
+			datasetId,
+			displayName: `${ref.name}.${columnName}`,
+		});
+		return datasetId;
+	}
+
+	/**
+	 * ODBC exposes the connection's read-only state through SQLGetInfo, which node-odbc does not
+	 * surface, so there is nothing to report it from. Connections are treated as writable; Positron
+	 * uses this only to decide whether to offer write affordances, and this driver offers none.
+	 */
+	async isReadOnly(): Promise<boolean> {
+		return false;
+	}
+
+	/** Closes the connection and releases any previewed table views. Idempotent. */
+	async disconnect(): Promise<void> {
+		for (const datasetId of this._openedDatasets) {
+			this._dataExplorerHandler.closeTableView(datasetId);
+		}
+		this._openedDatasets.clear();
+		this._client?.dispose();
+		this._client = undefined;
+		this._tables = undefined;
+	}
+
+	/** Checks whether the connection is still open and operational. */
+	async isConnected(): Promise<boolean> {
+		// A crashed worker leaves the client present but not alive; don't respawn just to answer
+		// this question.
+		if (!this._client || !this._client.isAlive) {
+			return false;
+		}
+		try {
+			await this._client.tables(null, null, '', '');
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	/** Throws if the connection has been closed. */
+	private _ensureConnected(): void {
+		if (!this._client) {
+			throw new Error('The ODBC connection is closed');
+		}
+	}
+}
+
+/** A stable, collision-free key for a table within a connection, used to build dataset ids. */
+function qualifiedKey(ref: OdbcTableRef): string {
+	return [ref.catalog, ref.schema, ref.name].filter(part => part !== undefined).join('.');
+}

--- a/extensions/positron-data-driver-odbc/src/odbcConnectionString.ts
+++ b/extensions/positron-data-driver-odbc/src/odbcConnectionString.ts
@@ -1,0 +1,151 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Building, parsing, and redacting ODBC connection strings.
+//
+// The format is `KEY=VALUE;KEY=VALUE`, which looks trivial and is not: a value containing a
+// semicolon has to be brace-wrapped, and a brace inside a brace-wrapped value has to be doubled.
+// Passwords routinely contain both. Everything that assembles a connection string goes through
+// buildConnectionString so the escaping is done once, correctly.
+
+/** The attribute names that hold a secret. Used when redacting for display. */
+const SECRET_KEYS = ['PWD', 'PASSWORD'];
+
+/** The mask substituted for a password when redacting a connection string. */
+const REDACTED_PASSWORD = '****';
+
+/**
+ * The characters that oblige a connection string value to be brace-wrapped, from the ODBC
+ * specification. Driver names routinely contain several of them -- "PostgreSQL Unicode(x64)" has
+ * parentheses, and a password is free to contain anything at all.
+ */
+const VALUE_NEEDS_BRACES = /[[\]{}(),;?*=!@]/;
+
+/**
+ * The attribute names always written brace-wrapped, whatever their value.
+ *
+ * Only the driver name. It is quoted this way universally -- every vendor's documentation shows
+ * `Driver={...}` -- and some drivers parse it loosely enough that an unbraced name containing a
+ * space goes wrong. A DSN name is conventionally written bare (`DSN=Pagila`) and only needs bracing
+ * when it contains something from VALUE_NEEDS_BRACES, which the general rule already covers.
+ */
+const ALWAYS_BRACED_KEYS = new Set(['driver']);
+
+/**
+ * Escapes one connection string value. A closing brace inside a brace-wrapped value is doubled,
+ * which is how the ODBC specification says to escape it.
+ * @param value The raw value, unbraced.
+ * @param forceBraces Whether to wrap even when the value contains nothing that requires it.
+ */
+function escapeValue(value: string, forceBraces: boolean): string {
+	const needsBraces = forceBraces || VALUE_NEEDS_BRACES.test(value) || value !== value.trim();
+	if (!needsBraces) {
+		return value;
+	}
+	return `{${value.replace(/\}/g, '}}')}}`;
+}
+
+/**
+ * Builds a connection string from attributes, skipping any whose value is undefined or empty. Order
+ * is preserved, so callers can put `DSN` or `Driver` first, where drivers expect it.
+ *
+ * Values are passed in raw -- callers must not pre-wrap them in braces, or they will be wrapped
+ * twice.
+ * @param attributes The attribute name/value pairs, in the order they should appear.
+ */
+export function buildConnectionString(attributes: ReadonlyArray<readonly [string, string | number | undefined]>): string {
+	return attributes
+		.filter((entry): entry is [string, string | number] => {
+			const value = entry[1];
+			return value !== undefined && String(value).length > 0;
+		})
+		.map(([key, value]) => `${key}=${escapeValue(String(value), ALWAYS_BRACED_KEYS.has(key.toLowerCase()))}`)
+		.join(';');
+}
+
+/**
+ * Parses a connection string into its attributes, keyed by lowercased name. Understands the
+ * brace-wrapped form produced by buildConnectionString. Malformed input yields whatever could be
+ * read rather than throwing: this is used to *describe* a string the user pasted, and a partial
+ * description beats none.
+ *
+ * Exported for tests.
+ */
+export function parseConnectionString(connectionString: string): Record<string, string> {
+	const attributes: Record<string, string> = {};
+	let index = 0;
+
+	while (index < connectionString.length) {
+		// Read the key up to '='.
+		const equals = connectionString.indexOf('=', index);
+		if (equals === -1) {
+			break;
+		}
+		const key = connectionString.slice(index, equals).trim().toLowerCase();
+		index = equals + 1;
+
+		let value: string;
+		if (connectionString[index] === '{') {
+			// Brace-wrapped: scan to the closing brace, treating '}}' as an escaped '}'.
+			index++;
+			let scanned = '';
+			while (index < connectionString.length) {
+				if (connectionString[index] === '}') {
+					if (connectionString[index + 1] === '}') {
+						scanned += '}';
+						index += 2;
+						continue;
+					}
+					index++;
+					break;
+				}
+				scanned += connectionString[index++];
+			}
+			value = scanned;
+			// Skip the separator after the closing brace.
+			const semicolon = connectionString.indexOf(';', index);
+			index = semicolon === -1 ? connectionString.length : semicolon + 1;
+		} else {
+			const semicolon = connectionString.indexOf(';', index);
+			const end = semicolon === -1 ? connectionString.length : semicolon;
+			value = connectionString.slice(index, end).trim();
+			index = semicolon === -1 ? connectionString.length : semicolon + 1;
+		}
+
+		if (key.length > 0) {
+			attributes[key] = value;
+		}
+	}
+
+	return attributes;
+}
+
+/**
+ * Produces a display-safe form of a connection string by masking the embedded password, used as
+ * the field placeholder when editing a saved connection-string connection. Everything else is
+ * preserved verbatim, so the user can still read back what they pasted.
+ */
+export function redactConnectionString(connectionString: string): string {
+	// Masked in place rather than by parsing and rebuilding: this is shown back to the user as the
+	// field's placeholder, so the rest of the string should read exactly as they typed it, keeping
+	// their own capitalization, spacing, and bracing.
+	// A value is either brace-wrapped (with `}}` for an embedded brace) or runs to the next semicolon.
+	const secretValue = new RegExp(`(^|;)(\\s*(?:${SECRET_KEYS.join('|')})\\s*=\\s*)(\\{(?:[^}]|\\}\\})*\\}|[^;]*)`, 'gi');
+	return connectionString.replace(
+		secretValue,
+		(_match, separator: string, keyAndEquals: string) => `${separator}${keyAndEquals}${REDACTED_PASSWORD}`
+	);
+}
+
+/**
+ * Extracts the ODBC driver name a connection string will use, for resolving the SQL dialect. A
+ * string built against a DSN names the DSN rather than the driver, so the DSN's own `Driver` has to
+ * be looked up separately by the caller; this returns the `Driver` attribute when the string
+ * carries one, and the `DSN` name otherwise.
+ */
+export function describeConnectionTarget(connectionString: string): { driverName?: string; dsnName?: string } {
+	const attributes = parseConnectionString(connectionString);
+	return { driverName: attributes['driver'], dsnName: attributes['dsn'] };
+}

--- a/extensions/positron-data-driver-odbc/src/odbcDataExplorerRpcHandler.ts
+++ b/extensions/positron-data-driver-odbc/src/odbcDataExplorerRpcHandler.ts
@@ -12,7 +12,7 @@ import * as vscode from 'vscode';
 import { OdbcDialect } from './odbcDatabases';
 import { OdbcTableRef } from './odbcNodes';
 import { IOdbcQueryClient } from './odbcWorkerClient';
-import { odbcDisplayType, OdbcSchemaEntry, OdbcTableView } from './odbcTableView';
+import { isBinarySqlType, odbcDisplayType, OdbcSchemaEntry, OdbcTableView } from './odbcTableView';
 import {
 	ConvertToCodeParams,
 	DataExplorerBackendRequest,
@@ -185,14 +185,16 @@ export async function buildOdbcSchema(
 		.map(row => {
 			const typeName = String(row['TYPE_NAME'] ?? '');
 			const dataType = typeof row['DATA_TYPE'] === 'number' ? row['DATA_TYPE'] : Number(row['DATA_TYPE']);
+			const code = Number.isFinite(dataType) ? dataType : undefined;
 			return {
 				column_name: String(row['COLUMN_NAME'] ?? ''),
 				column_type: typeName,
-				type_display: odbcDisplayType(Number.isFinite(dataType) ? dataType : undefined, typeName),
+				type_display: odbcDisplayType(code, typeName),
+				is_binary: isBinarySqlType(code),
 				ordinal: Number(row['ORDINAL_POSITION'] ?? 0),
 			};
 		})
 		.filter(entry => entry.column_name.length > 0)
 		.sort((a, b) => a.ordinal - b.ordinal)
-		.map(({ column_name, column_type, type_display }) => ({ column_name, column_type, type_display }));
+		.map(({ column_name, column_type, type_display, is_binary }) => ({ column_name, column_type, type_display, is_binary }));
 }

--- a/extensions/positron-data-driver-odbc/src/odbcDataExplorerRpcHandler.ts
+++ b/extensions/positron-data-driver-odbc/src/odbcDataExplorerRpcHandler.ts
@@ -12,7 +12,7 @@ import * as vscode from 'vscode';
 import { OdbcDialect } from './odbcDatabases';
 import { OdbcTableRef } from './odbcNodes';
 import { IOdbcQueryClient } from './odbcWorkerClient';
-import { isBinarySqlType, odbcDisplayType, OdbcSchemaEntry, OdbcTableView } from './odbcTableView';
+import { isBinarySqlType, odbcDisplayType, OdbcSchemaEntry, OdbcTableView, resolveOdbcRowIdentity } from './odbcTableView';
 import {
 	ConvertToCodeParams,
 	DataExplorerBackendRequest,
@@ -78,8 +78,11 @@ export class OdbcDataExplorerRpcHandler implements vscode.Disposable, IOdbcDataE
 		ref: OdbcTableRef,
 		dialect: OdbcDialect,
 	): Promise<void> {
-		const schema = await buildOdbcSchema(client, ref);
-		this._views.set(datasetId, new OdbcTableView(client, ref, dialect, schema));
+		const [schema, rowIdentity] = await Promise.all([
+			buildOdbcSchema(client, ref),
+			resolveOdbcRowIdentity(client, ref),
+		]);
+		this._views.set(datasetId, new OdbcTableView(client, ref, dialect, schema, rowIdentity));
 	}
 
 	/**
@@ -93,12 +96,17 @@ export class OdbcDataExplorerRpcHandler implements vscode.Disposable, IOdbcDataE
 		dialect: OdbcDialect,
 		columnName: string,
 	): Promise<void> {
-		const schema = await buildOdbcSchema(client, ref);
+		const [schema, rowIdentity] = await Promise.all([
+			buildOdbcSchema(client, ref),
+			resolveOdbcRowIdentity(client, ref),
+		]);
 		const column = schema.find(c => c.column_name === columnName);
 		if (!column) {
 			throw new Error(`Column '${columnName}' not found in '${ref.name}'`);
 		}
-		this._views.set(datasetId, new OdbcTableView(client, ref, dialect, [column]));
+		// The key columns are outside this view's one-column schema, but ORDER BY may name a column
+		// the SELECT list omits, so they still serve as the tiebreaker.
+		this._views.set(datasetId, new OdbcTableView(client, ref, dialect, [column], rowIdentity));
 	}
 
 	/** Drops a dataset's view, e.g. when its connection is disconnected. */

--- a/extensions/positron-data-driver-odbc/src/odbcDataExplorerRpcHandler.ts
+++ b/extensions/positron-data-driver-odbc/src/odbcDataExplorerRpcHandler.ts
@@ -1,0 +1,198 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Structurally mirrors positron-data-driver-sqlite's sqliteDataExplorerRpcHandler.ts; differs only
+// in how the column schema is read (SQLColumns rather than a PRAGMA) and in threading the dialect
+// through to the table view.
+
+import * as positron from 'positron';
+import * as vscode from 'vscode';
+import { OdbcDialect } from './odbcDatabases';
+import { OdbcTableRef } from './odbcNodes';
+import { IOdbcQueryClient } from './odbcWorkerClient';
+import { odbcDisplayType, OdbcSchemaEntry, OdbcTableView } from './odbcTableView';
+import {
+	ConvertToCodeParams,
+	DataExplorerBackendRequest,
+	DataExplorerFrontendEvent,
+	DataExplorerResponse,
+	DataExplorerRpc,
+	DataExplorerUiEvent,
+	ExportDataSelectionParams,
+	GetColumnProfilesParams,
+	GetDataValuesParams,
+	GetSchemaParams,
+	SearchSchemaParams,
+	SetRowFiltersParams,
+	SetSortColumnsParams,
+} from 'positron-data-explorer-protocol';
+
+/** The provider id this extension registers its Data Explorer RPC handler under. */
+export const ODBC_DATA_EXPLORER_PROVIDER_ID = 'positron-data-driver-odbc';
+
+/**
+ * The slice of the RPC handler a connection needs to preview its tables. Kept as an interface so a
+ * connection can be tested without registering the real Data Explorer provider.
+ */
+export interface IOdbcDataExplorerHost {
+	/** Builds and registers a table view for a table or view under the given dataset id. */
+	openTableView(datasetId: string, client: IOdbcQueryClient, ref: OdbcTableRef, dialect: OdbcDialect): Promise<void>;
+	/** Builds and registers a single-column view of a table or view under the given dataset id. */
+	openColumnView(datasetId: string, client: IOdbcQueryClient, ref: OdbcTableRef, dialect: OdbcDialect, columnName: string): Promise<void>;
+	/** Drops a dataset's view. */
+	closeTableView(datasetId: string): void;
+}
+
+/**
+ * Hosts ODBC-backed Data Explorer table views and dispatches Data Explorer RPCs to them.
+ *
+ * A data connection node registers a table view via `openTableView` (from its preview action) and
+ * then asks Positron to open an explorer keyed by the same dataset id. Positron routes every RPC
+ * for that dataset to this handler (registered via `positron.dataExplorer.registerRpcHandler`).
+ * Async column profiles are delivered back through the registration session's `sendUiEvent`.
+ */
+export class OdbcDataExplorerRpcHandler implements vscode.Disposable, IOdbcDataExplorerHost {
+	private readonly _views = new Map<string, OdbcTableView>();
+	private readonly _session: positron.DataExplorerRpcSession;
+
+	constructor(private readonly _logger?: positron.DataConnectionLogger) {
+		this._session = positron.dataExplorer.registerRpcHandler(ODBC_DATA_EXPLORER_PROVIDER_ID, {
+			handleRpc: (request) => this.handleRequest(request as DataExplorerRpc)
+		});
+	}
+
+	dispose(): void {
+		this._session.dispose();
+		this._views.clear();
+	}
+
+	/**
+	 * Builds and registers a table view for a table or view, replacing any prior view for the same
+	 * dataset id.
+	 */
+	async openTableView(
+		datasetId: string,
+		client: IOdbcQueryClient,
+		ref: OdbcTableRef,
+		dialect: OdbcDialect,
+	): Promise<void> {
+		const schema = await buildOdbcSchema(client, ref);
+		this._views.set(datasetId, new OdbcTableView(client, ref, dialect, schema));
+	}
+
+	/**
+	 * Builds and registers a single-column view: an OdbcTableView whose schema is restricted to the
+	 * one requested column, so the Data Explorer shows just that column.
+	 */
+	async openColumnView(
+		datasetId: string,
+		client: IOdbcQueryClient,
+		ref: OdbcTableRef,
+		dialect: OdbcDialect,
+		columnName: string,
+	): Promise<void> {
+		const schema = await buildOdbcSchema(client, ref);
+		const column = schema.find(c => c.column_name === columnName);
+		if (!column) {
+			throw new Error(`Column '${columnName}' not found in '${ref.name}'`);
+		}
+		this._views.set(datasetId, new OdbcTableView(client, ref, dialect, [column]));
+	}
+
+	/** Drops a dataset's view, e.g. when its connection is disconnected. */
+	closeTableView(datasetId: string): void {
+		this._views.delete(datasetId);
+	}
+
+	async handleRequest(rpc: DataExplorerRpc): Promise<DataExplorerResponse> {
+		try {
+			return { result: await this._dispatch(rpc) };
+		} catch (error) {
+			const message = error instanceof Error ? error.message : `Unknown error handling ${rpc.method}`;
+			return { error_message: message };
+		}
+	}
+
+	private async _dispatch(rpc: DataExplorerRpc): Promise<unknown> {
+		if (rpc.uri === undefined) {
+			throw new Error(`A dataset identifier is required for ${rpc.method}`);
+		}
+		const view = this._views.get(rpc.uri);
+		if (!view) {
+			throw new Error(`No ODBC data explorer is open for ${rpc.uri}`);
+		}
+
+		switch (rpc.method) {
+			case DataExplorerBackendRequest.GetState:
+				return view.getState();
+			case DataExplorerBackendRequest.GetSchema:
+				return view.getSchema(rpc.params as GetSchemaParams);
+			case DataExplorerBackendRequest.SearchSchema:
+				return view.searchSchema(rpc.params as SearchSchemaParams);
+			case DataExplorerBackendRequest.GetDataValues:
+				return view.getDataValues(rpc.params as GetDataValuesParams);
+			case DataExplorerBackendRequest.SetRowFilters:
+				return view.setRowFilters(rpc.params as SetRowFiltersParams);
+			case DataExplorerBackendRequest.SetSortColumns:
+				return view.setSortColumns(rpc.params as SetSortColumnsParams);
+			case DataExplorerBackendRequest.ExportDataSelection:
+				return view.exportDataSelection(rpc.params as ExportDataSelectionParams);
+			case DataExplorerBackendRequest.ConvertToCode:
+				return view.convertToCode(rpc.params as ConvertToCodeParams);
+			case DataExplorerBackendRequest.SuggestCodeSyntax:
+				return view.suggestCodeSyntax();
+			case DataExplorerBackendRequest.GetColumnProfiles:
+				return this._getColumnProfiles(view, rpc.uri, rpc.params as GetColumnProfilesParams);
+			default:
+				throw new Error(`Unsupported data explorer method: ${rpc.method}`);
+		}
+	}
+
+	/**
+	 * Column profiles are computed asynchronously: acknowledge the request immediately, then push
+	 * the results to the frontend via the shared sendUiEvent command.
+	 */
+	private _getColumnProfiles(view: OdbcTableView, datasetId: string, params: GetColumnProfilesParams): void {
+		void (async () => {
+			try {
+				const profiles = await view.computeColumnProfiles(params);
+				this._session.sendUiEvent({
+					uri: datasetId,
+					method: DataExplorerFrontendEvent.ReturnColumnProfiles,
+					params: profiles,
+				} satisfies DataExplorerUiEvent);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : 'unknown error';
+				this._logger?.error(`Failed to compute ODBC column profiles: ${message}`);
+			}
+		})();
+	}
+}
+
+/**
+ * Reads a table or view's column schema via SQLColumns, resolving each column's display type from
+ * the ODBC SQL type code. Columns come back in ordinal position, which is the order the Data
+ * Explorer shows them in.
+ */
+export async function buildOdbcSchema(
+	client: IOdbcQueryClient,
+	ref: OdbcTableRef,
+): Promise<OdbcSchemaEntry[]> {
+	const rows = await client.columns(ref.catalog ?? null, ref.schema ?? null, ref.name, null);
+	return rows
+		.map(row => {
+			const typeName = String(row['TYPE_NAME'] ?? '');
+			const dataType = typeof row['DATA_TYPE'] === 'number' ? row['DATA_TYPE'] : Number(row['DATA_TYPE']);
+			return {
+				column_name: String(row['COLUMN_NAME'] ?? ''),
+				column_type: typeName,
+				type_display: odbcDisplayType(Number.isFinite(dataType) ? dataType : undefined, typeName),
+				ordinal: Number(row['ORDINAL_POSITION'] ?? 0),
+			};
+		})
+		.filter(entry => entry.column_name.length > 0)
+		.sort((a, b) => a.ordinal - b.ordinal)
+		.map(({ column_name, column_type, type_display }) => ({ column_name, column_type, type_display }));
+}

--- a/extensions/positron-data-driver-odbc/src/odbcDatabases.ts
+++ b/extensions/positron-data-driver-odbc/src/odbcDatabases.ts
@@ -113,7 +113,10 @@ export const ODBC_DATABASE_PROFILES: readonly OdbcDatabaseProfile[] = [
 		// "ODBC Driver 18 for SQL Server", "SQL Server Native Client 11.0", "Posit SQL Server".
 		driverNamePatterns: [/sql\s*server/i, /msodbcsql/i],
 		dialect: { identifierQuote: '"', pagination: 'offset-fetch' },
-		defaultPort: 1433,
+		// No port key and no defaultPort: Microsoft's driver has no Port connection-string keyword.
+		// The port goes inside Server, comma-separated -- `Server=myhost,1433`. A port key here
+		// would emit an attribute the driver ignores, failing the connection with nothing in the
+		// form to explain why.
 		attributeKeys: { server: 'Server', database: 'Database', user: 'UID', password: 'PWD' },
 		registerDriver: true,
 	},

--- a/extensions/positron-data-driver-odbc/src/odbcDatabases.ts
+++ b/extensions/positron-data-driver-odbc/src/odbcDatabases.ts
@@ -1,0 +1,268 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// A curated map from ODBC driver names to the database behind them.
+//
+// It does two jobs. It tells the Data Explorer how to write SQL for a connection (quoting and
+// row-limiting differ per backend, and node-odbc exposes no SQLGetInfo to ask at runtime), and it
+// lets the extension offer a per-database entry -- "MySQL" rather than "ODBC" -- for each
+// recognized ODBC driver installed on the machine.
+//
+// Matching is on the ODBC driver's *name* as it appears in odbcinst.ini, because that is all we
+// have. Vendors are not consistent about it ("MySQL ODBC 8.0 Unicode Driver", "Simba Snowflake",
+// "Posit Snowflake"), so each entry carries several patterns and an unrecognized driver simply
+// falls back to the conservative default.
+
+import { OdbcDriverEntry } from './odbcinst';
+
+/** How to write SQL for a backend. */
+export interface OdbcDialect {
+	/**
+	 * The character delimiting an identifier. SQL-92 says `"`; MySQL and the Hive family use a
+	 * backtick unless configured otherwise.
+	 */
+	readonly identifierQuote: string;
+
+	/**
+	 * How the backend spells "rows m..m+n of this result".
+	 * - `limit-offset`: `LIMIT n OFFSET m` (MySQL, PostgreSQL, Snowflake, Hive).
+	 * - `offset-fetch`: `OFFSET m ROWS FETCH NEXT n ROWS ONLY`, the SQL:2008 form (SQL Server
+	 *   2012+, Oracle 12c+, DB2, Teradata). The default for unrecognized drivers, being the
+	 *   standard one.
+	 */
+	readonly pagination: 'limit-offset' | 'offset-fetch';
+}
+
+/** The conservative dialect used for any ODBC driver we do not recognize. */
+export const DEFAULT_DIALECT: OdbcDialect = {
+	identifierQuote: '"',
+	pagination: 'offset-fetch',
+};
+
+/** A database reachable over ODBC, and how to talk to it. */
+export interface OdbcDatabaseProfile {
+	/** Stable id, used to build the per-database Positron driver id. */
+	readonly id: string;
+
+	/** The user-facing database name, e.g. "MySQL". */
+	readonly name: string;
+
+	/** Patterns matched case-insensitively against the ODBC driver name. */
+	readonly driverNamePatterns: readonly RegExp[];
+
+	/** The dialect the Data Explorer writes SQL in. */
+	readonly dialect: OdbcDialect;
+
+	/** The default TCP port, offered as the port parameter's default. */
+	readonly defaultPort?: number;
+
+	/**
+	 * The connection-string attribute names this database's ODBC drivers expect. Not standardized
+	 * across vendors -- SQL Server wants `Server`, PostgreSQL wants `Servername`, and so on.
+	 */
+	readonly attributeKeys: {
+		readonly server: string;
+		readonly port?: string;
+		readonly database?: string;
+		readonly user: string;
+		readonly password: string;
+	};
+
+	/**
+	 * Whether to register a per-database Positron driver for this database when its ODBC driver is
+	 * installed. False where Positron already ships a native driver (PostgreSQL, Snowflake,
+	 * Databricks, Redshift, SQLite): a second entry with the same name in the New Connection list
+	 * would be worse than useless. Those databases still get a dialect, since they are reachable
+	 * through the generic ODBC entry.
+	 */
+	readonly registerDriver: boolean;
+}
+
+const LIMIT_OFFSET: OdbcDialect = { identifierQuote: '"', pagination: 'limit-offset' };
+const BACKTICK_LIMIT_OFFSET: OdbcDialect = { identifierQuote: '`', pagination: 'limit-offset' };
+
+/**
+ * The curated list. Order matters: the first profile whose pattern matches wins, so more specific
+ * patterns must precede more general ones (MariaDB before MySQL, since MariaDB's driver name
+ * frequently mentions both).
+ */
+export const ODBC_DATABASE_PROFILES: readonly OdbcDatabaseProfile[] = [
+	{
+		id: 'mariadb',
+		name: 'MariaDB',
+		driverNamePatterns: [/mariadb/i],
+		dialect: BACKTICK_LIMIT_OFFSET,
+		defaultPort: 3306,
+		attributeKeys: { server: 'Server', port: 'Port', database: 'Database', user: 'User', password: 'Password' },
+		registerDriver: true,
+	},
+	{
+		id: 'mysql',
+		name: 'MySQL',
+		driverNamePatterns: [/mysql/i],
+		dialect: BACKTICK_LIMIT_OFFSET,
+		defaultPort: 3306,
+		attributeKeys: { server: 'Server', port: 'Port', database: 'Database', user: 'User', password: 'Password' },
+		registerDriver: true,
+	},
+	{
+		id: 'sqlserver',
+		name: 'SQL Server',
+		// "ODBC Driver 18 for SQL Server", "SQL Server Native Client 11.0", "Posit SQL Server".
+		driverNamePatterns: [/sql\s*server/i, /msodbcsql/i],
+		dialect: { identifierQuote: '"', pagination: 'offset-fetch' },
+		defaultPort: 1433,
+		attributeKeys: { server: 'Server', database: 'Database', user: 'UID', password: 'PWD' },
+		registerDriver: true,
+	},
+	{
+		id: 'oracle',
+		name: 'Oracle',
+		driverNamePatterns: [/oracle/i],
+		dialect: { identifierQuote: '"', pagination: 'offset-fetch' },
+		defaultPort: 1521,
+		attributeKeys: { server: 'Server', port: 'Port', database: 'Database', user: 'UID', password: 'PWD' },
+		registerDriver: true,
+	},
+	{
+		id: 'teradata',
+		name: 'Teradata',
+		driverNamePatterns: [/teradata/i],
+		dialect: { identifierQuote: '"', pagination: 'offset-fetch' },
+		attributeKeys: { server: 'DBCName', database: 'Database', user: 'UID', password: 'PWD' },
+		registerDriver: true,
+	},
+	{
+		id: 'hive',
+		name: 'Hive',
+		driverNamePatterns: [/hive/i],
+		dialect: BACKTICK_LIMIT_OFFSET,
+		defaultPort: 10000,
+		attributeKeys: { server: 'Host', port: 'Port', database: 'Schema', user: 'UID', password: 'PWD' },
+		registerDriver: true,
+	},
+	{
+		id: 'impala',
+		name: 'Impala',
+		driverNamePatterns: [/impala/i],
+		dialect: BACKTICK_LIMIT_OFFSET,
+		defaultPort: 21050,
+		attributeKeys: { server: 'Host', port: 'Port', database: 'Schema', user: 'UID', password: 'PWD' },
+		registerDriver: true,
+	},
+	{
+		id: 'db2',
+		name: 'Db2',
+		driverNamePatterns: [/\bdb2\b/i],
+		dialect: { identifierQuote: '"', pagination: 'offset-fetch' },
+		defaultPort: 50000,
+		attributeKeys: { server: 'Hostname', port: 'Port', database: 'Database', user: 'UID', password: 'PWD' },
+		registerDriver: true,
+	},
+	{
+		id: 'bigquery',
+		name: 'BigQuery',
+		driverNamePatterns: [/bigquery/i],
+		dialect: LIMIT_OFFSET,
+		attributeKeys: { server: 'Server', database: 'Catalog', user: 'UID', password: 'PWD' },
+		registerDriver: true,
+	},
+
+	// --- Databases Positron already has a native driver for. Dialect only; no second entry in the
+	// New Connection list. ---
+	{
+		id: 'postgresql',
+		name: 'PostgreSQL',
+		driverNamePatterns: [/postgres/i, /psqlodbc/i],
+		dialect: LIMIT_OFFSET,
+		defaultPort: 5432,
+		attributeKeys: { server: 'Servername', port: 'Port', database: 'Database', user: 'UID', password: 'PWD' },
+		registerDriver: false,
+	},
+	{
+		id: 'redshift',
+		name: 'Redshift',
+		driverNamePatterns: [/redshift/i],
+		dialect: LIMIT_OFFSET,
+		defaultPort: 5439,
+		attributeKeys: { server: 'Server', port: 'Port', database: 'Database', user: 'UID', password: 'PWD' },
+		registerDriver: false,
+	},
+	{
+		id: 'snowflake',
+		name: 'Snowflake',
+		driverNamePatterns: [/snowflake/i],
+		dialect: LIMIT_OFFSET,
+		attributeKeys: { server: 'Server', database: 'Database', user: 'UID', password: 'PWD' },
+		registerDriver: false,
+	},
+	{
+		id: 'databricks',
+		name: 'Databricks',
+		driverNamePatterns: [/databricks/i, /spark/i],
+		dialect: BACKTICK_LIMIT_OFFSET,
+		defaultPort: 443,
+		attributeKeys: { server: 'Host', port: 'Port', database: 'Schema', user: 'UID', password: 'PWD' },
+		registerDriver: false,
+	},
+	{
+		id: 'sqlite',
+		name: 'SQLite',
+		driverNamePatterns: [/sqlite/i],
+		dialect: LIMIT_OFFSET,
+		attributeKeys: { server: 'Server', database: 'Database', user: 'UID', password: 'PWD' },
+		registerDriver: false,
+	},
+];
+
+/**
+ * Finds the database profile for an ODBC driver name, or undefined when the name matches none of
+ * the curated patterns.
+ * @param driverName The ODBC driver name as it appears in odbcinst.ini.
+ */
+export function findDatabaseProfile(driverName: string | undefined): OdbcDatabaseProfile | undefined {
+	if (driverName === undefined) {
+		return undefined;
+	}
+	return ODBC_DATABASE_PROFILES.find(profile =>
+		profile.driverNamePatterns.some(pattern => pattern.test(driverName)));
+}
+
+/**
+ * Resolves the dialect for an ODBC driver name, falling back to the SQL-92 / SQL:2008 default for
+ * anything unrecognized.
+ * @param driverName The ODBC driver name as it appears in odbcinst.ini.
+ */
+export function resolveDialect(driverName: string | undefined): OdbcDialect {
+	return findDatabaseProfile(driverName)?.dialect ?? DEFAULT_DIALECT;
+}
+
+/**
+ * Groups the installed ODBC drivers by the database they serve, for the per-database Positron
+ * drivers. Only profiles marked `registerDriver` are returned, and only when at least one matching
+ * ODBC driver is actually installed -- the New Connection list should offer a database only when
+ * the machine can reach it.
+ * @param drivers The ODBC drivers discovered on this machine.
+ */
+export function groupDriversByDatabase(
+	drivers: readonly OdbcDriverEntry[]
+): Array<{ profile: OdbcDatabaseProfile; drivers: OdbcDriverEntry[] }> {
+	const grouped = new Map<string, { profile: OdbcDatabaseProfile; drivers: OdbcDriverEntry[] }>();
+
+	for (const driver of drivers) {
+		const profile = findDatabaseProfile(driver.name);
+		if (profile === undefined || !profile.registerDriver) {
+			continue;
+		}
+		const existing = grouped.get(profile.id);
+		if (existing) {
+			existing.drivers.push(driver);
+		} else {
+			grouped.set(profile.id, { profile, drivers: [driver] });
+		}
+	}
+
+	return [...grouped.values()].sort((a, b) => a.profile.name.localeCompare(b.profile.name));
+}

--- a/extensions/positron-data-driver-odbc/src/odbcDriver.ts
+++ b/extensions/positron-data-driver-odbc/src/odbcDriver.ts
@@ -1,0 +1,491 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// The Positron drivers this extension registers.
+//
+// There is always a generic "ODBC" driver, which can reach anything the machine has an ODBC driver
+// or DSN for. On top of that, one driver is registered per *recognized* database whose ODBC driver
+// is installed -- so a machine with the MySQL connector gets a "MySQL" entry in the New Connection
+// list, and the user never has to know it is ODBC underneath. See odbcDatabases.ts for the mapping
+// and for why the databases Positron already has a native driver for are excluded.
+
+import { readFileSync } from 'fs';
+import * as path from 'path';
+import * as positron from 'positron';
+import * as vscode from 'vscode';
+import { buildConnectionString, describeConnectionTarget, redactConnectionString } from './odbcConnectionString';
+import { OdbcConnection } from './odbcConnection';
+import { IOdbcDataExplorerHost } from './odbcDataExplorerRpcHandler';
+import { findDatabaseProfile, groupDriversByDatabase, OdbcDatabaseProfile, resolveDialect } from './odbcDatabases';
+import { OdbcConfiguration, OdbcDriverEntry, summarizeDsn } from './odbcinst';
+
+/** The id of the generic ODBC driver. */
+export const GENERIC_ODBC_DRIVER_ID = 'positron-data-driver-odbc';
+
+/**
+ * The id of the DSN mechanism: connect to a data source already configured on this machine. Used
+ * both in the mechanism list and in the connect/generate switches, so they stay in sync.
+ */
+const DSN_MECHANISM_ID = 'dsn';
+
+/**
+ * The id of the driver mechanism: pick an installed ODBC driver and supply the connection details
+ * directly, for a server that has no DSN configured.
+ */
+const DRIVER_MECHANISM_ID = 'driver';
+
+/**
+ * The id of the connection-string mechanism. The user pastes a full ODBC connection string, which
+ * is handed to the driver manager verbatim. Always available, and the only mechanism offered when
+ * nothing could be discovered on the machine.
+ */
+const CONNECTION_STRING_MECHANISM_ID = 'connectionString';
+
+/** Type guard for a non-empty string. */
+function isNonEmptyString(value: unknown): value is string {
+	return typeof value === 'string' && value.length > 0;
+}
+
+/** Escapes a value for embedding in a double-quoted Python or R string literal. */
+function escapeDoubleQuoted(value: string): string {
+	return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+// --- Parameter fragments ---
+//
+// Built as functions rather than constants because they call vscode.l10n.t, which must run after
+// the l10n bundle is initialized.
+
+/** The user parameter. Optional: many DSNs carry credentials, and some backends use SSO. */
+function userParam(label?: string): positron.DataConnectionParameter {
+	return {
+		id: 'user',
+		label: label ?? vscode.l10n.t('User'),
+		description: vscode.l10n.t('Leave empty to use the credentials stored with the data source.'),
+		type: positron.DataConnectionParameterType.String,
+	};
+}
+
+/** The password parameter. Optional, for the same reason as the user. */
+function passwordParam(): positron.DataConnectionParameter {
+	return {
+		id: 'password',
+		label: vscode.l10n.t('Password'),
+		description: vscode.l10n.t('Leave empty if the data source does not require a password.'),
+		type: positron.DataConnectionParameterType.Password,
+		secret: true,
+	};
+}
+
+/** The single connection-string parameter. */
+function connectionStringParam(): positron.DataConnectionParameter {
+	return {
+		// Secret: an ODBC connection string almost always embeds a password, so it belongs in
+		// secret storage rather than in settings.
+		id: 'connectionString',
+		label: vscode.l10n.t('Connection String'),
+		description: vscode.l10n.t('A full ODBC connection string, naming either a DSN or a driver.'),
+		type: positron.DataConnectionParameterType.String,
+		secret: true,
+		// Rendered in plaintext so the user can read back what they pasted. It still goes to secret
+		// storage because it typically embeds a password.
+		masked: false,
+		required: true,
+		placeholder: 'Driver={PostgreSQL Unicode};Servername=localhost;Port=5432;Database=mydb',
+	};
+}
+
+/**
+ * Builds the endpoint parameters for the driver mechanism. The parameter *ids* are fixed so the
+ * connect and code-generation paths can read them, but each is written into the connection string
+ * under whatever attribute name the target database's ODBC driver expects (see
+ * OdbcDatabaseProfile.attributeKeys) -- ODBC never standardized these, so `Server` for one driver
+ * is `Servername` or `Host` for another.
+ */
+function endpointParams(profile: OdbcDatabaseProfile | undefined): positron.DataConnectionParameter[] {
+	const params: positron.DataConnectionParameter[] = [
+		{
+			id: 'server',
+			label: vscode.l10n.t('Server'),
+			type: positron.DataConnectionParameterType.String,
+			required: true,
+			defaultValue: 'localhost',
+		},
+	];
+
+	if (profile === undefined || profile.attributeKeys.port !== undefined) {
+		params.push({
+			id: 'port',
+			label: vscode.l10n.t('Port'),
+			type: positron.DataConnectionParameterType.Number,
+			...(profile?.defaultPort !== undefined ? { defaultValue: profile.defaultPort } : {}),
+		});
+	}
+
+	if (profile === undefined || profile.attributeKeys.database !== undefined) {
+		params.push({
+			id: 'database',
+			label: vscode.l10n.t('Database'),
+			type: positron.DataConnectionParameterType.String,
+		});
+	}
+
+	return [...params, userParam(), passwordParam()];
+}
+
+// --- Connection string assembly ---
+
+/**
+ * Builds the connection string for the DSN mechanism. `DSN` comes first, as drivers expect, and
+ * the credentials are appended only when supplied so a DSN that already carries them still works.
+ */
+function buildDsnConnectionString(params: positron.DataConnectionParameterValues): string {
+	return buildConnectionString([
+		['DSN', asString(params.dsn)],
+		['UID', asString(params.user)],
+		['PWD', asString(params.password)],
+	]);
+}
+
+/**
+ * Builds the connection string for the driver mechanism, mapping the fixed parameter ids onto the
+ * attribute names the selected database's ODBC drivers expect.
+ */
+function buildDriverConnectionString(
+	driverName: string,
+	profile: OdbcDatabaseProfile | undefined,
+	params: positron.DataConnectionParameterValues
+): string {
+	// The generic fallback uses the most widely accepted spellings: `Server`, `Port`, `Database`,
+	// and the ODBC-standard `UID`/`PWD`.
+	const keys = profile?.attributeKeys ?? {
+		server: 'Server',
+		port: 'Port',
+		database: 'Database',
+		user: 'UID',
+		password: 'PWD',
+	};
+
+	return buildConnectionString([
+		// Passed raw: buildConnectionString brace-wraps a driver name itself.
+		['Driver', driverName],
+		[keys.server, asString(params.server)],
+		...(keys.port ? [[keys.port, asNumber(params.port)] as const] : []),
+		...(keys.database ? [[keys.database, asString(params.database)] as const] : []),
+		[keys.user, asString(params.user)],
+		[keys.password, asString(params.password)],
+	]);
+}
+
+function asString(value: unknown): string | undefined {
+	return isNonEmptyString(value) ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+	return typeof value === 'number' ? value : undefined;
+}
+
+/**
+ * Resolves the connection string for a mechanism and its parameter values, or undefined when a
+ * required parameter is missing. Shared by connect() and generateConnectionCode() so the code shown
+ * to the user connects the same way Positron does.
+ */
+function resolveConnectionString(
+	mechanismId: string,
+	params: positron.DataConnectionParameterValues,
+	options: DriverOptions
+): string | undefined {
+	switch (mechanismId) {
+		case DSN_MECHANISM_ID: {
+			return isNonEmptyString(params.dsn) ? buildDsnConnectionString(params) : undefined;
+		}
+		case DRIVER_MECHANISM_ID: {
+			// A per-database driver with exactly one matching ODBC driver has no picker, so the
+			// driver name comes from the options rather than from a parameter.
+			const driverName = asString(params.odbcDriver) ?? options.odbcDrivers[0]?.name;
+			if (driverName === undefined || !isNonEmptyString(params.server)) {
+				return undefined;
+			}
+			// The generic driver has no fixed database, so the attribute names come from whichever
+			// ODBC driver the user picked. Without this the endpoint would be written as `Server=`
+			// for every backend, which psqlodbc (which wants `Servername`) and others ignore.
+			const profile = options.profile ?? findDatabaseProfile(driverName);
+			return buildDriverConnectionString(driverName, profile, params);
+		}
+		case CONNECTION_STRING_MECHANISM_ID:
+			return asString(params.connectionString);
+		default:
+			return undefined;
+	}
+}
+
+// --- Connection code generation ---
+
+/**
+ * Renders R code using the odbc package. Both variants are offered because they suit different
+ * habits: naming the DSN or driver as arguments is the readable form, while `.connection_string`
+ * is what a user pastes when they already have a string from their DBA.
+ */
+function renderRCode(connectionString: string): positron.ConnectionCodeVariant[] {
+	return [{
+		id: 'dbi',
+		label: 'DBI',
+		code: `library(DBI)\n\ncon <- dbConnect(\n\todbc::odbc(),\n\t.connection_string = "${escapeDoubleQuoted(connectionString)}"\n)\n`,
+	}];
+}
+
+/** Renders Python code using pyodbc, and the SQLAlchemy wrapper around it. */
+function renderPythonCode(connectionString: string): positron.ConnectionCodeVariant[] {
+	const escaped = escapeDoubleQuoted(connectionString);
+	return [
+		{
+			id: 'pyodbc',
+			label: 'pyodbc',
+			code: `import pyodbc\n\nconn = pyodbc.connect("${escaped}")\n`,
+		},
+		{
+			id: 'sqlalchemy',
+			label: 'SQLAlchemy',
+			// SQLAlchemy takes the ODBC string as a single percent-encoded query parameter, which
+			// avoids having to re-express the connection in SQLAlchemy's own URL grammar.
+			code: `import sqlalchemy as sa\nfrom urllib.parse import quote_plus\n\nengine = sa.create_engine(\n\t"mssql+pyodbc:///?odbc_connect=" + quote_plus("${escaped}")\n)\n`,
+		},
+	];
+}
+
+// --- Driver construction ---
+
+/** What distinguishes one registered Positron driver from another. */
+interface DriverOptions {
+	/** The registered driver id. */
+	readonly id: string;
+
+	/** The user-facing name: "ODBC", or a database name such as "MySQL". */
+	readonly name: string;
+
+	readonly description: string;
+
+	/** The ODBC drivers this Positron driver offers. All of them for the generic driver. */
+	readonly odbcDrivers: readonly OdbcDriverEntry[];
+
+	/** The database profile, when this is a per-database driver. Undefined for the generic one. */
+	readonly profile: OdbcDatabaseProfile | undefined;
+
+	/** The discovered configuration, used to resolve a DSN's dialect and to list data sources. */
+	readonly config: OdbcConfiguration;
+
+	/** Whether to offer the DSN mechanism. Only the generic driver does. */
+	readonly offerDsns: boolean;
+}
+
+/**
+ * Builds one Positron driver from its options.
+ */
+function createDriver(
+	options: DriverOptions,
+	iconSvg: string,
+	dataExplorerHandler: IOdbcDataExplorerHost,
+	logger?: positron.DataConnectionLogger
+): positron.DataConnectionDriver {
+	const mechanisms: positron.DataConnectionMechanism[] = [];
+
+	// DSN mechanism, offered only when the machine actually has data sources configured. An option
+	// parameter with an empty list would be a picker the user cannot pick anything from.
+	if (options.offerDsns && options.config.dsns.length > 0) {
+		mechanisms.push({
+			id: DSN_MECHANISM_ID,
+			label: vscode.l10n.t('Data Source (DSN)'),
+			description: vscode.l10n.t('Connect to a data source already configured on this computer.'),
+			parameters: [
+				{
+					id: 'dsn',
+					label: vscode.l10n.t('Data Source'),
+					type: positron.DataConnectionParameterType.Option,
+					options: options.config.dsns.map(dsn => dsn.name),
+					required: true,
+				},
+				userParam(),
+				passwordParam(),
+			],
+		});
+	}
+
+	// Driver mechanism, offered only when there is an ODBC driver to use.
+	if (options.odbcDrivers.length > 0) {
+		const parameters: positron.DataConnectionParameter[] = [];
+
+		// With more than one matching ODBC driver installed (e.g. the ANSI and Unicode builds of
+		// the same connector), the user picks; with exactly one there is nothing to choose.
+		if (options.odbcDrivers.length > 1) {
+			parameters.push({
+				id: 'odbcDriver',
+				label: vscode.l10n.t('ODBC Driver'),
+				type: positron.DataConnectionParameterType.Option,
+				options: options.odbcDrivers.map(driver => driver.name),
+				defaultValue: options.odbcDrivers[0].name,
+				required: true,
+			});
+		}
+
+		mechanisms.push({
+			id: DRIVER_MECHANISM_ID,
+			label: options.profile
+				? vscode.l10n.t('Server')
+				: vscode.l10n.t('ODBC Driver'),
+			description: options.profile
+				? vscode.l10n.t('Connect to a server by supplying its address and your credentials.')
+				: vscode.l10n.t('Connect using an installed ODBC driver by supplying the connection details.'),
+			parameters: [...parameters, ...endpointParams(options.profile)],
+		});
+	}
+
+	// Always available, and the only mechanism when nothing was discovered.
+	mechanisms.push({
+		id: CONNECTION_STRING_MECHANISM_ID,
+		label: vscode.l10n.t('Connection String'),
+		description: vscode.l10n.t('Connect by pasting a full ODBC connection string.'),
+		parameters: [connectionStringParam()],
+	});
+
+	/**
+	 * Resolves the SQL dialect for a connection. The dialect follows the ODBC driver, which is
+	 * named directly by the driver and connection-string mechanisms but only indirectly by a DSN --
+	 * a DSN names itself, so its driver has to be looked up in the discovered configuration.
+	 */
+	const dialectFor = (mechanismId: string, params: positron.DataConnectionParameterValues) => {
+		if (options.profile !== undefined) {
+			return options.profile.dialect;
+		}
+		switch (mechanismId) {
+			case DSN_MECHANISM_ID: {
+				const dsn = options.config.dsns.find(candidate => candidate.name === params.dsn);
+				return resolveDialect(dsn?.driverName);
+			}
+			case DRIVER_MECHANISM_ID:
+				return resolveDialect(asString(params.odbcDriver) ?? options.odbcDrivers[0]?.name);
+			default: {
+				const target = describeConnectionTarget(asString(params.connectionString) ?? '');
+				// A pasted string may name a driver directly, or a DSN whose driver we can look up.
+				const dsn = options.config.dsns.find(candidate => candidate.name === target.dsnName);
+				return resolveDialect(target.driverName ?? dsn?.driverName);
+			}
+		}
+	};
+
+	return {
+		id: options.id,
+		name: options.name,
+		description: options.description,
+		iconSvg,
+		supportedLanguageIds: ['python', 'r'],
+		mechanisms,
+
+		async connect(mechanismId: string, params: positron.DataConnectionParameterValues): Promise<positron.DataConnection> {
+			const connectionString = resolveConnectionString(mechanismId, params, options);
+			if (connectionString === undefined) {
+				throw new Error(vscode.l10n.t('The connection details are incomplete.'));
+			}
+			const connection = new OdbcConnection(
+				connectionString,
+				dialectFor(mechanismId, params),
+				dataExplorerHandler,
+				logger
+			);
+			await connection.connect();
+			return connection;
+		},
+
+		async generateConnectionCode(mechanismId: string, languageId: string, params: positron.DataConnectionParameterValues): Promise<positron.ConnectionCodeVariant[]> {
+			const connectionString = resolveConnectionString(mechanismId, params, options);
+			if (connectionString === undefined) {
+				return [];
+			}
+			switch (languageId) {
+				case 'r':
+					return renderRCode(connectionString);
+				case 'python':
+					return renderPythonCode(connectionString);
+				default:
+					return [];
+			}
+		},
+
+		redactParameterValue(mechanismId: string, parameterId: string, value: string): string | undefined {
+			// The connection string is the only parameter shown in plaintext while embedding a
+			// secret, so it is the only one with a meaningful redacted preview.
+			if (mechanismId === CONNECTION_STRING_MECHANISM_ID && parameterId === 'connectionString') {
+				return redactConnectionString(value);
+			}
+			return undefined;
+		},
+
+		/**
+		 * Every DSN configured on this machine, surfaced in the pane without the user configuring
+		 * anything. This is what makes an ODBC setup that RStudio already shows -- a Workbench user
+		 * with the Professional Drivers installed, say -- visible in Positron too.
+		 *
+		 * Only the generic driver reports these. A per-database driver reporting the same DSNs
+		 * would put every data source in the pane once per database entry that matched it.
+		 */
+		async discoverConnections(): Promise<positron.DiscoveredDataConnection[]> {
+			if (!options.offerDsns) {
+				return [];
+			}
+			return options.config.dsns.map(dsn => ({
+				// Stable across restarts, so a discovered connection keeps its identity (and its
+				// expansion state in the pane) from session to session.
+				id: `odbc-dsn:${dsn.name}`,
+				name: dsn.name,
+				description: summarizeDsn(dsn),
+				mechanismId: DSN_MECHANISM_ID,
+				parameters: { dsn: dsn.name },
+			}));
+		},
+	};
+}
+
+/**
+ * Creates every Positron driver this extension registers: the generic ODBC driver, plus one per
+ * recognized database whose ODBC driver is installed.
+ *
+ * @param context The extension context, used to locate the icon asset.
+ * @param config The ODBC configuration discovered on this machine.
+ * @param dataExplorerHandler Hosts table views previewed from these connections.
+ * @param logger Diagnostic log sink.
+ */
+export function createOdbcDrivers(
+	context: vscode.ExtensionContext,
+	config: OdbcConfiguration,
+	dataExplorerHandler: IOdbcDataExplorerHost,
+	logger?: positron.DataConnectionLogger
+): positron.DataConnectionDriver[] {
+	// Load the SVG icon once at registration time.
+	const iconPath = path.join(context.extensionPath, 'media', 'logo', 'odbc.svg');
+	const iconSvg = readFileSync(iconPath, 'utf-8');
+
+	const generic = createDriver({
+		id: GENERIC_ODBC_DRIVER_ID,
+		name: 'ODBC',
+		description: vscode.l10n.t('Connect to a database using an ODBC driver'),
+		odbcDrivers: config.drivers,
+		profile: undefined,
+		config,
+		offerDsns: true,
+	}, iconSvg, dataExplorerHandler, logger);
+
+	const perDatabase = groupDriversByDatabase(config.drivers).map(({ profile, drivers }) =>
+		createDriver({
+			id: `${GENERIC_ODBC_DRIVER_ID}-${profile.id}`,
+			name: profile.name,
+			description: vscode.l10n.t('Connect to a {0} database over ODBC', profile.name),
+			odbcDrivers: drivers,
+			profile,
+			config,
+			// Data sources belong to the generic driver; see discoverConnections above.
+			offerDsns: false,
+		}, iconSvg, dataExplorerHandler, logger));
+
+	return [generic, ...perDatabase];
+}

--- a/extensions/positron-data-driver-odbc/src/odbcNodes.ts
+++ b/extensions/positron-data-driver-odbc/src/odbcNodes.ts
@@ -1,0 +1,304 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// The schema tree, built from ODBC's catalog functions rather than from SQL.
+//
+// Every other Positron data driver queries its backend's information schema, which means writing
+// dialect-specific SQL. ODBC cannot: the whole point is that the backend is unknown. SQLTables and
+// SQLColumns are the driver-agnostic equivalent, and every conforming ODBC driver implements them,
+// so the same code here browses SQL Server, MySQL, Snowflake, and Teradata alike.
+//
+// The one structural consequence is that the table list is fetched in a single SQLTables call and
+// grouped in memory, rather than a query per level. ODBC has no portable way to ask "what schemas
+// exist" -- the SQL_ALL_SCHEMAS form of SQLTables is optional and unevenly implemented -- so one
+// call plus in-memory grouping is the approach that behaves the same everywhere. On a server with
+// very many tables that is a large first response; the list is fetched once per connection and
+// reused for the whole session.
+
+import * as positron from 'positron';
+import { IOdbcQueryClient } from './odbcWorkerClient';
+import { OdbcRow } from './odbcWorkerProtocol';
+
+/** A table or view, identified the way ODBC identifies it. */
+export interface OdbcTableRef {
+	/** The catalog, when the backend uses them (SQL Server databases, Snowflake catalogs). */
+	readonly catalog?: string;
+
+	/** The schema, when the backend uses them. */
+	readonly schema?: string;
+
+	readonly name: string;
+
+	/** Whether it is a base table or a view, which decides the icon and the node's children. */
+	readonly kind: 'table' | 'view';
+}
+
+/**
+ * The capability a table/view/column node needs to open itself in the Data Explorer. Implemented by
+ * OdbcConnection, which owns the dataset registration.
+ */
+export interface IOdbcPreviewHost {
+	/** Opens the given table or view in the Data Explorer, returning its dataset id. */
+	previewObject(ref: OdbcTableRef): Promise<string>;
+
+	/** Opens a single column of the given table or view in the Data Explorer, returning its dataset id. */
+	previewColumn(ref: OdbcTableRef, columnName: string): Promise<string>;
+}
+
+/**
+ * Reads the table list via SQLTables. Views are requested alongside tables so both appear under
+ * their schema; ODBC reports the distinction in TABLE_TYPE.
+ *
+ * Some drivers report types beyond TABLE and VIEW (SYSTEM TABLE, GLOBAL TEMPORARY, ALIAS, ...).
+ * Asking for the two we render keeps the response to what the tree can show, and keeps system
+ * catalogs out of the user's way.
+ */
+export async function fetchTables(client: IOdbcQueryClient): Promise<OdbcTableRef[]> {
+	const rows = await client.tables(null, null, null, 'TABLE,VIEW');
+	return rows.map(row => ({
+		catalog: optionalString(row['TABLE_CAT']),
+		schema: optionalString(row['TABLE_SCHEM']),
+		name: String(row['TABLE_NAME'] ?? ''),
+		kind: /view/i.test(String(row['TABLE_TYPE'] ?? '')) ? 'view' as const : 'table' as const,
+	})).filter(ref => ref.name.length > 0);
+}
+
+/** Coerces an ODBC catalog value to a string, treating null and empty as "not applicable". */
+function optionalString(value: unknown): string | undefined {
+	if (value === null || value === undefined) {
+		return undefined;
+	}
+	const text = String(value);
+	return text.length > 0 ? text : undefined;
+}
+
+/**
+ * Builds the top-level nodes for a connection.
+ *
+ * The shape adapts to what the backend actually uses, because ODBC backends disagree about how many
+ * levels of namespace they have. A catalog level appears only when the tables span more than one
+ * catalog, and likewise for schemas; a backend with a single unnamed schema (MySQL, SQLite) drops
+ * straight to Tables and Views. Rendering an "Unknown" catalog containing one "Unknown" schema
+ * would be noise on exactly the backends that are simplest.
+ */
+export function createRootNodes(
+	tables: readonly OdbcTableRef[],
+	client: IOdbcQueryClient,
+	host: IOdbcPreviewHost
+): positron.DataConnectionNode[] {
+	const catalogs = distinct(tables.map(table => table.catalog));
+
+	// More than one catalog: a Catalogs group, each expanding to its schemas.
+	if (catalogs.length > 1) {
+		return [{
+			name: 'Catalogs',
+			kind: positron.DataConnectionNodeKind.GroupCatalogs,
+			getChildren: async () => catalogs.map(catalog => ({
+				name: catalog ?? '(default)',
+				kind: positron.DataConnectionNodeKind.Catalog,
+				getChildren: async () => createSchemaLevel(
+					tables.filter(table => table.catalog === catalog), client, host),
+			})),
+		}];
+	}
+
+	return createSchemaLevel(tables, client, host);
+}
+
+/**
+ * Builds the schema level for a set of tables that already share a catalog. Collapses to the
+ * Tables/Views groups when there is nothing meaningful to distinguish schemas by.
+ */
+function createSchemaLevel(
+	tables: readonly OdbcTableRef[],
+	client: IOdbcQueryClient,
+	host: IOdbcPreviewHost
+): positron.DataConnectionNode[] {
+	const schemas = distinct(tables.map(table => table.schema));
+
+	if (schemas.length > 1 || (schemas.length === 1 && schemas[0] !== undefined)) {
+		return [{
+			name: 'Schemas',
+			kind: positron.DataConnectionNodeKind.GroupSchemas,
+			getChildren: async () => schemas.map(schema => ({
+				name: schema ?? '(default)',
+				kind: positron.DataConnectionNodeKind.Schema,
+				getChildren: async () => createObjectGroups(
+					tables.filter(table => table.schema === schema), client, host),
+			})),
+		}];
+	}
+
+	return createObjectGroups(tables, client, host);
+}
+
+/**
+ * Builds the Tables and Views groups for a set of tables that already share a namespace. A group
+ * with nothing in it is omitted rather than shown empty -- a backend with no views should not
+ * display a "Views" node that expands to nothing.
+ */
+function createObjectGroups(
+	tables: readonly OdbcTableRef[],
+	client: IOdbcQueryClient,
+	host: IOdbcPreviewHost
+): positron.DataConnectionNode[] {
+	const groups: positron.DataConnectionNode[] = [];
+
+	const baseTables = tables.filter(table => table.kind === 'table');
+	if (baseTables.length > 0) {
+		groups.push({
+			name: 'Tables',
+			kind: positron.DataConnectionNodeKind.GroupTables,
+			getChildren: async () => baseTables.map(table => createTableNode(table, client, host)),
+		});
+	}
+
+	const views = tables.filter(table => table.kind === 'view');
+	if (views.length > 0) {
+		groups.push({
+			name: 'Views',
+			kind: positron.DataConnectionNodeKind.GroupViews,
+			getChildren: async () => views.map(view => createTableNode(view, client, host)),
+		});
+	}
+
+	return groups;
+}
+
+/**
+ * Creates a table or view node. Both expand to a single Columns group -- ODBC exposes indexes via
+ * SQLStatistics, which node-odbc does not surface, so unlike the PostgreSQL driver there is no
+ * Indexes group to offer.
+ *
+ * Exported so unit tests can build a node directly against a fake client.
+ */
+export function createTableNode(
+	ref: OdbcTableRef,
+	client: IOdbcQueryClient,
+	host: IOdbcPreviewHost
+): positron.DataConnectionNode {
+	return {
+		name: ref.name,
+		kind: ref.kind === 'view'
+			? positron.DataConnectionNodeKind.View
+			: positron.DataConnectionNodeKind.Table,
+		getChildren: async () => [createColumnsGroupNode(ref, client, host)],
+		preview: () => host.previewObject(ref),
+	};
+}
+
+/**
+ * Creates the Columns group inside a table or view, listing its columns with their data types.
+ * Primary keys are looked up only for base tables: views have none, and asking a driver for the
+ * primary keys of a view is an error on some backends rather than an empty result.
+ */
+function createColumnsGroupNode(
+	ref: OdbcTableRef,
+	client: IOdbcQueryClient,
+	host: IOdbcPreviewHost
+): positron.DataConnectionNode {
+	return {
+		name: 'Columns',
+		kind: positron.DataConnectionNodeKind.GroupColumns,
+		async getChildren() {
+			const catalog = ref.catalog ?? null;
+			const schema = ref.schema ?? null;
+
+			const primaryKeys = ref.kind === 'table'
+				? await fetchPrimaryKeys(client, catalog, schema, ref.name)
+				: new Set<string>();
+
+			const rows = await client.columns(catalog, schema, ref.name, null);
+			return rows.map(row => {
+				const columnName = String(row['COLUMN_NAME'] ?? '');
+				return {
+					name: columnName,
+					kind: positron.DataConnectionNodeKind.Field,
+					dataType: formatDataType(row),
+					isPrimaryKey: primaryKeys.has(columnName) || undefined,
+					preview: () => host.previewColumn(ref, columnName),
+				};
+			}).filter(node => node.name.length > 0);
+		},
+	};
+}
+
+/**
+ * Returns the column names making up a table's primary key. A driver that does not implement
+ * SQLPrimaryKeys reports an error rather than an empty set, and a missing key marker is not worth
+ * failing the whole Columns expansion over, so failures degrade to "no primary key".
+ */
+async function fetchPrimaryKeys(
+	client: IOdbcQueryClient,
+	catalog: string | null,
+	schema: string | null,
+	table: string
+): Promise<Set<string>> {
+	try {
+		const rows = await client.primaryKeys(catalog, schema, table);
+		return new Set(rows.map(row => String(row['COLUMN_NAME'] ?? '')));
+	} catch {
+		return new Set();
+	}
+}
+
+/**
+ * Formats a column's type for display, from the SQLColumns result. TYPE_NAME is the backend's own
+ * name for the type ("varchar", "int4", "NUMBER"), which is what a user of that backend expects to
+ * see; size and scale are appended where they carry information.
+ *
+ * Exported for tests.
+ */
+export function formatDataType(row: OdbcRow): string {
+	const typeName = String(row['TYPE_NAME'] ?? '').trim();
+	if (typeName.length === 0) {
+		return '';
+	}
+
+	// A driver that already spells out the parameters (e.g. "varchar(255)") needs nothing added.
+	if (typeName.includes('(')) {
+		return typeName;
+	}
+
+	const size = toNumber(row['COLUMN_SIZE']);
+	const scale = toNumber(row['DECIMAL_DIGITS']);
+
+	if (size !== undefined && scale !== undefined && scale > 0) {
+		return `${typeName}(${size},${scale})`;
+	}
+	// Size is reported for every type, including ones where it is an artifact of the ODBC type
+	// mapping (an integer's "size" is its digit count). Only append it for the types where it is
+	// something the user set.
+	if (size !== undefined && /char|binary|string/i.test(typeName)) {
+		return `${typeName}(${size})`;
+	}
+	return typeName;
+}
+
+function toNumber(value: unknown): number | undefined {
+	if (typeof value === 'number' && Number.isFinite(value)) {
+		return value;
+	}
+	if (typeof value === 'bigint') {
+		return Number(value);
+	}
+	return undefined;
+}
+
+/**
+ * Distinct values in first-seen order, preserving `undefined` as its own value (it means "this
+ * backend does not use this level", which is different from any named catalog or schema).
+ */
+function distinct(values: readonly (string | undefined)[]): (string | undefined)[] {
+	const seen = new Set<string | undefined>();
+	const result: (string | undefined)[] = [];
+	for (const value of values) {
+		if (!seen.has(value)) {
+			seen.add(value);
+			result.push(value);
+		}
+	}
+	return result.sort((a, b) => (a ?? '').localeCompare(b ?? ''));
+}

--- a/extensions/positron-data-driver-odbc/src/odbcTableView.ts
+++ b/extensions/positron-data-driver-odbc/src/odbcTableView.ts
@@ -1,0 +1,1066 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Structurally mirrors positron-data-driver-sqlite's sqliteTableView.ts (the canonical template).
+// Two things differ, and both come from the backend being unknown at compile time:
+//
+//  - Identifier quoting and row-limiting syntax come from the OdbcDialect resolved from the ODBC
+//    driver name (see odbcDatabases.ts). node-odbc exposes no SQLGetInfo, so the backend cannot be
+//    interrogated at runtime; an unrecognized driver gets the SQL-92 / SQL:2008 default.
+//  - Display types are derived from ODBC's own SQL type codes rather than from the backend's type
+//    names. The codes are fixed by the ODBC specification, so this is the one piece of type
+//    handling here that is genuinely portable.
+
+import { OdbcDialect } from './odbcDatabases';
+import { OdbcTableRef } from './odbcNodes';
+import { IOdbcQueryClient } from './odbcWorkerClient';
+import {
+	ArraySelection,
+	BackendState,
+	CodeSyntaxName,
+	ColumnDisplayType,
+	ColumnFilterType,
+	ColumnFrequencyTable,
+	ColumnFrequencyTableParams,
+	ColumnHistogram,
+	ColumnHistogramParams,
+	ColumnHistogramParamsMethod,
+	ColumnProfileRequest,
+	ColumnProfileResult,
+	ColumnProfileType,
+	ColumnSortKey,
+	ColumnSummaryStats,
+	ColumnValue,
+	ConvertedCode,
+	ConvertToCodeParams,
+	DataSelectionCellIndices,
+	DataSelectionCellRange,
+	DataSelectionIndices,
+	DataSelectionRange,
+	DataSelectionSingleCell,
+	ExportDataSelectionParams,
+	ExportedData,
+	ExportFormat,
+	FilterBetween,
+	FilterComparison,
+	FilterComparisonOp,
+	FilterMatchDataTypes,
+	FilterResult,
+	FilterSetMembership,
+	FilterTextSearch,
+	FormatOptions,
+	GetColumnProfilesParams,
+	GetDataValuesParams,
+	GetSchemaParams,
+	ReturnColumnProfilesEvent,
+	RowFilter,
+	RowFilterType,
+	SearchSchemaParams,
+	SearchSchemaResult,
+	SearchSchemaSortOrder,
+	SetRowFiltersParams,
+	SetSortColumnsParams,
+	SupportStatus,
+	TableData,
+	TableSchema,
+	TableSelectionKind,
+	TextSearchType,
+} from 'positron-data-explorer-protocol';
+
+/** Sentinel codes for special cell values, matching the Data Explorer wire protocol. */
+const SENTINEL_NULL = 0;
+const SENTINEL_NAN = 2;
+const SENTINEL_INF = 10;
+const SENTINEL_NEGINF = 11;
+
+/**
+ * The ODBC SQL type codes, from the ODBC specification. They are the same integers for every
+ * driver, which makes them a far better basis for display types than each backend's own type names.
+ */
+const SQL_CHAR = 1;
+const SQL_NUMERIC = 2;
+const SQL_DECIMAL = 3;
+const SQL_INTEGER = 4;
+const SQL_SMALLINT = 5;
+const SQL_FLOAT = 6;
+const SQL_REAL = 7;
+const SQL_DOUBLE = 8;
+const SQL_DATETIME = 9;
+const SQL_VARCHAR = 12;
+const SQL_TYPE_DATE = 91;
+const SQL_TYPE_TIME = 92;
+const SQL_TYPE_TIMESTAMP = 93;
+const SQL_LONGVARCHAR = -1;
+const SQL_BINARY = -2;
+const SQL_VARBINARY = -3;
+const SQL_LONGVARBINARY = -4;
+const SQL_BIGINT = -5;
+const SQL_TINYINT = -6;
+const SQL_BIT = -7;
+const SQL_WCHAR = -8;
+const SQL_WVARCHAR = -9;
+const SQL_WLONGVARCHAR = -10;
+const SQL_GUID = -11;
+
+/** A column in an ODBC table or view, with its backend type name and resolved display type. */
+export interface OdbcSchemaEntry {
+	column_name: string;
+	/** The backend's own name for the type ("varchar", "NUMBER"), shown in the schema panel. */
+	column_type: string;
+	type_display: ColumnDisplayType;
+}
+
+/**
+ * Maps an ODBC SQL type code to a Data Explorer display type. `typeName` is only consulted for the
+ * codes that are genuinely ambiguous: SQL_BIT is the closest ODBC has to a boolean but some drivers
+ * use it for a one-bit integer, and a driver that reports an unknown code still usually has a
+ * recognizable type name.
+ *
+ * Exported for tests.
+ */
+export function odbcDisplayType(dataType: number | undefined, typeName: string): ColumnDisplayType {
+	switch (dataType) {
+		case SQL_CHAR:
+		case SQL_VARCHAR:
+		case SQL_LONGVARCHAR:
+		case SQL_WCHAR:
+		case SQL_WVARCHAR:
+		case SQL_WLONGVARCHAR:
+		case SQL_GUID:
+			return ColumnDisplayType.String;
+		case SQL_TINYINT:
+		case SQL_SMALLINT:
+		case SQL_INTEGER:
+		case SQL_BIGINT:
+			return ColumnDisplayType.Integer;
+		case SQL_REAL:
+		case SQL_FLOAT:
+		case SQL_DOUBLE:
+			return ColumnDisplayType.Floating;
+		case SQL_DECIMAL:
+		case SQL_NUMERIC:
+			return ColumnDisplayType.Decimal;
+		case SQL_BIT:
+			return ColumnDisplayType.Boolean;
+		case SQL_TYPE_DATE:
+			return ColumnDisplayType.Date;
+		case SQL_TYPE_TIME:
+			return ColumnDisplayType.Time;
+		case SQL_TYPE_TIMESTAMP:
+		case SQL_DATETIME:
+			return ColumnDisplayType.Datetime;
+		case SQL_BINARY:
+		case SQL_VARBINARY:
+		case SQL_LONGVARBINARY:
+			return ColumnDisplayType.Object;
+		default:
+			break;
+	}
+
+	// An unrecognized code (a driver's own extension type). Fall back to the type name, which is
+	// usually descriptive even when the code is not.
+	const name = typeName.toUpperCase();
+	if (name.includes('BOOL')) { return ColumnDisplayType.Boolean; }
+	if (name.includes('TIMESTAMP') || name.includes('DATETIME')) { return ColumnDisplayType.Datetime; }
+	if (name.includes('DATE')) { return ColumnDisplayType.Date; }
+	if (name.includes('TIME')) { return ColumnDisplayType.Time; }
+	if (name.includes('INT')) { return ColumnDisplayType.Integer; }
+	if (name.includes('CHAR') || name.includes('TEXT') || name.includes('STRING')) { return ColumnDisplayType.String; }
+	if (name.includes('DEC') || name.includes('NUMER')) { return ColumnDisplayType.Decimal; }
+	if (name.includes('FLOAT') || name.includes('DOUBLE') || name.includes('REAL')) { return ColumnDisplayType.Floating; }
+	return ColumnDisplayType.Object;
+}
+
+/** Escapes a value for use inside a single-quoted SQL string literal. */
+function quoteLiteral(value: string): string {
+	return value.replace(/'/g, '\'\'');
+}
+
+const COMPARISON_OPS = new Map<FilterComparisonOp, string>([
+	[FilterComparisonOp.Eq, '='],
+	[FilterComparisonOp.NotEq, '<>'],
+	[FilterComparisonOp.Gt, '>'],
+	[FilterComparisonOp.GtEq, '>='],
+	[FilterComparisonOp.Lt, '<'],
+	[FilterComparisonOp.LtEq, '<=']
+]);
+
+/**
+ * Serves Data Explorer requests for a single table or view reached over ODBC. Translates each
+ * protocol method into SQL run through the connection's worker client, in the dialect resolved for
+ * the backend.
+ */
+export class OdbcTableView {
+	private sortKeys: Array<ColumnSortKey> = [];
+	private rowFilters: Array<RowFilter> = [];
+
+	private _whereClause: string = '';
+	private _sortClause: string = '';
+
+	private _unfilteredRows: Promise<number>;
+	private _filteredRows: Promise<number>;
+
+	/**
+	 * @param client The query client for the owning connection.
+	 * @param ref The table or view this view serves.
+	 * @param dialect How to write SQL for this backend.
+	 * @param schema The resolved column schema.
+	 */
+	constructor(
+		private readonly client: IOdbcQueryClient,
+		private readonly ref: OdbcTableRef,
+		private readonly dialect: OdbcDialect,
+		private readonly schema: Array<OdbcSchemaEntry>,
+	) {
+		this._sortClause = this._buildSortClause([], true);
+		this._unfilteredRows = this._countRows('');
+		this._filteredRows = this._unfilteredRows;
+	}
+
+	/** Quotes and escapes an identifier, doubling the dialect's quote character where embedded. */
+	private _quote(name: string): string {
+		const quote = this.dialect.identifierQuote;
+		return quote + name.split(quote).join(quote + quote) + quote;
+	}
+
+	/** The fully qualified, quoted table reference for use in FROM clauses. */
+	private get _quotedTable(): string {
+		return [this.ref.catalog, this.ref.schema, this.ref.name]
+			.filter((part): part is string => part !== undefined && part.length > 0)
+			.map(part => this._quote(part))
+			.join('.');
+	}
+
+	/**
+	 * Renders a windowed read in the backend's dialect.
+	 *
+	 * `OFFSET ... FETCH NEXT` (the SQL:2008 form) requires an ORDER BY on SQL Server, and paging
+	 * without one is not reproducible on any backend -- two requests for consecutive pages can
+	 * return overlapping or missing rows. The sort clause always carries an ordering for that
+	 * reason; see _buildSortClause.
+	 */
+	private _paginate(limit: number, offset: number): string {
+		return this.dialect.pagination === 'limit-offset'
+			? ` LIMIT ${limit} OFFSET ${offset}`
+			: ` OFFSET ${offset} ROWS FETCH NEXT ${limit} ROWS ONLY`;
+	}
+
+	private async _countRows(whereClause: string): Promise<number> {
+		const rows = await this.client.runQuery(`SELECT count(*) AS n FROM ${this._quotedTable}${whereClause}`);
+		return Number(firstValue(rows[0], 'n') ?? 0);
+	}
+
+	/**
+	 * Builds a SQL WHERE expression for a single row filter.
+	 *
+	 * Regex is the one filter with no portable spelling: the operator is `~` on PostgreSQL,
+	 * `REGEXP` on MySQL, `RLIKE` on the Hive family, and simply absent on SQL Server. Rather than
+	 * approximate it with LIKE -- which would silently return the wrong rows -- an explicit error is
+	 * raised, and the Data Explorer surfaces it.
+	 */
+	private _makeWhereExpr(rowFilter: RowFilter): string {
+		const schema = rowFilter.column_schema;
+		const quotedName = this._quote(schema.column_name);
+		const formatLiteral = (value: string): string =>
+			schema.type_display === ColumnDisplayType.String ? `'${quoteLiteral(value)}'` : value;
+
+		switch (rowFilter.filter_type) {
+			case RowFilterType.Compare: {
+				const params = rowFilter.params as FilterComparison;
+				const op: string = COMPARISON_OPS.get(params.op) ?? params.op;
+				return `${quotedName} ${op} ${formatLiteral(params.value)}`;
+			}
+			case RowFilterType.NotBetween:
+			case RowFilterType.Between: {
+				const params = rowFilter.params as FilterBetween;
+				const expr = `${quotedName} BETWEEN ${formatLiteral(params.left_value)} AND ${formatLiteral(params.right_value)}`;
+				return rowFilter.filter_type === RowFilterType.NotBetween ? `(NOT (${expr}))` : expr;
+			}
+			case RowFilterType.IsEmpty:
+				return `${quotedName} = ''`;
+			case RowFilterType.NotEmpty:
+				return `${quotedName} <> ''`;
+			case RowFilterType.IsFalse:
+				// ODBC reports booleans as SQL_BIT, and every backend that has one accepts 0/1.
+				return `${quotedName} = 0`;
+			case RowFilterType.IsTrue:
+				return `${quotedName} <> 0`;
+			case RowFilterType.IsNull:
+				return `${quotedName} IS NULL`;
+			case RowFilterType.NotNull:
+				return `${quotedName} IS NOT NULL`;
+			case RowFilterType.Search: {
+				const params = rowFilter.params as FilterTextSearch;
+				// LOWER is in every SQL dialect; a case-insensitive LIKE is not.
+				const searchArg = params.case_sensitive ? quotedName : `LOWER(${quotedName})`;
+				const term = quoteLiteral(params.case_sensitive ? params.term : params.term.toLowerCase());
+				const pattern = escapeLikePattern(term);
+				switch (params.search_type) {
+					case TextSearchType.Contains:
+						return `${searchArg} LIKE '%${pattern}%' ${LIKE_ESCAPE_CLAUSE}`;
+					case TextSearchType.NotContains:
+						return `${searchArg} NOT LIKE '%${pattern}%' ${LIKE_ESCAPE_CLAUSE}`;
+					case TextSearchType.StartsWith:
+						return `${searchArg} LIKE '${pattern}%' ${LIKE_ESCAPE_CLAUSE}`;
+					case TextSearchType.EndsWith:
+						return `${searchArg} LIKE '%${pattern}' ${LIKE_ESCAPE_CLAUSE}`;
+					case TextSearchType.RegexMatch:
+						throw new Error('Regular expression filters are not available over ODBC, because ODBC backends have no common regular expression syntax.');
+				}
+				return '1=1';
+			}
+			case RowFilterType.SetMembership: {
+				const params = rowFilter.params as FilterSetMembership;
+				const op = params.inclusive ? 'IN' : 'NOT IN';
+				return `${quotedName} ${op} (${params.values.map(formatLiteral).join(', ')})`;
+			}
+		}
+		return '1=1';
+	}
+
+	async getSchema(params: GetSchemaParams): Promise<TableSchema> {
+		return {
+			columns: params.column_indices.map(index => {
+				const entry = this.schema[index];
+				return {
+					column_name: entry.column_name,
+					column_index: index,
+					type_name: entry.column_type,
+					type_display: entry.type_display,
+				};
+			}),
+		};
+	}
+
+	async searchSchema(params: SearchSchemaParams): Promise<SearchSchemaResult> {
+		let indices = this.schema.map((_, i) => i);
+
+		if (params.filters && params.filters.length > 0) {
+			indices = indices.filter(index => {
+				const entry = this.schema[index];
+				return params.filters.every(filter => {
+					switch (filter.filter_type) {
+						case ColumnFilterType.TextSearch: {
+							const tf = filter.params as FilterTextSearch;
+							const term = tf.case_sensitive ? tf.term : tf.term.toLowerCase();
+							const name = tf.case_sensitive ? entry.column_name : entry.column_name.toLowerCase();
+							switch (tf.search_type) {
+								case TextSearchType.Contains: return name.includes(term);
+								case TextSearchType.NotContains: return !name.includes(term);
+								case TextSearchType.StartsWith: return name.startsWith(term);
+								case TextSearchType.EndsWith: return name.endsWith(term);
+								case TextSearchType.RegexMatch:
+									// Schema search runs in TypeScript, not SQL, so regex is fine here
+									// even though it is unavailable as a row filter.
+									try {
+										return new RegExp(tf.term, tf.case_sensitive ? '' : 'i').test(entry.column_name);
+									} catch {
+										return false;
+									}
+								default: return false;
+							}
+						}
+						case ColumnFilterType.MatchDataTypes: {
+							const df = filter.params as FilterMatchDataTypes;
+							return df.display_types.includes(entry.type_display);
+						}
+						default: return false;
+					}
+				});
+			});
+		}
+
+		const byName = (a: number, b: number) =>
+			this.schema[a].column_name.toLowerCase().localeCompare(this.schema[b].column_name.toLowerCase());
+		const byType = (a: number, b: number) =>
+			this.schema[a].column_type.toLowerCase().localeCompare(this.schema[b].column_type.toLowerCase());
+		switch (params.sort_order) {
+			case SearchSchemaSortOrder.AscendingName: indices.sort(byName); break;
+			case SearchSchemaSortOrder.DescendingName: indices.sort((a, b) => byName(b, a)); break;
+			case SearchSchemaSortOrder.AscendingType: indices.sort(byType); break;
+			case SearchSchemaSortOrder.DescendingType: indices.sort((a, b) => byType(b, a)); break;
+			default: break;
+		}
+
+		return { matches: indices };
+	}
+
+	async getDataValues(params: GetDataValuesParams): Promise<TableData> {
+		const filteredRows = await this._filteredRows;
+		if (filteredRows === 0 || params.columns.length === 0) {
+			return { columns: Array.from({ length: params.columns.length }, () => []) };
+		}
+
+		// Find the overall row range covering every requested column selection.
+		let lowerLimit = Infinity;
+		let upperLimit = -Infinity;
+		for (const column of params.columns) {
+			if (isSelectionRange(column.spec)) {
+				lowerLimit = Math.min(lowerLimit, column.spec.first_index);
+				upperLimit = Math.max(upperLimit, column.spec.last_index);
+			} else {
+				lowerLimit = Math.min(lowerLimit, ...column.spec.indices);
+				upperLimit = Math.max(upperLimit, ...column.spec.indices);
+			}
+		}
+		if (!isFinite(lowerLimit) || !isFinite(upperLimit)) {
+			return { columns: Array.from({ length: params.columns.length }, () => []) };
+		}
+		const numRows = upperLimit - lowerLimit + 1;
+
+		// Select each requested column under a positional alias so duplicates are unambiguous.
+		const selectors = params.columns.map((column, i) =>
+			`${this._quote(this.schema[column.column_index].column_name)} AS c${i}`);
+		const query = `SELECT ${selectors.join(', ')} FROM ${this._quotedTable}` +
+			`${this._whereClause}${this._sortClause}${this._paginate(numRows, lowerLimit)}`;
+		const rows = await this.client.runQuery(query);
+
+		const result: TableData = { columns: [] };
+		for (let i = 0; i < params.columns.length; i++) {
+			const column = params.columns[i];
+			const displayType = this.schema[column.column_index].type_display;
+			const format = (absIndex: number): ColumnValue => {
+				const row = rows[absIndex - lowerLimit];
+				return row === undefined
+					? SENTINEL_NULL
+					: this._formatValue(firstValue(row, `c${i}`), displayType, params.format_options);
+			};
+
+			const spec = column.spec;
+			if (isSelectionRange(spec)) {
+				const lastIndex = Math.min(spec.last_index, lowerLimit + rows.length - 1);
+				const values: ColumnValue[] = [];
+				for (let r = spec.first_index; r <= lastIndex; r++) {
+					values.push(format(r));
+				}
+				result.columns.push(values);
+			} else {
+				result.columns.push(spec.indices.map(format));
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Formats a raw ODBC value into the Data Explorer cell encoding: a sentinel number for
+	 * null/NaN/+-Inf, otherwise a formatted string.
+	 */
+	private _formatValue(value: unknown, displayType: ColumnDisplayType, opts: FormatOptions): ColumnValue {
+		if (value === null || value === undefined) {
+			return SENTINEL_NULL;
+		}
+
+		switch (displayType) {
+			case ColumnDisplayType.Floating:
+			case ColumnDisplayType.Decimal: {
+				const num = typeof value === 'number' ? value : Number(value);
+				if (Number.isNaN(num)) { return SENTINEL_NAN; }
+				if (num === Infinity) { return SENTINEL_INF; }
+				if (num === -Infinity) { return SENTINEL_NEGINF; }
+				return formatFloat(num, opts);
+			}
+			case ColumnDisplayType.Integer: {
+				const num = typeof value === 'bigint' ? value : Number(value);
+				return formatInteger(num, opts);
+			}
+			case ColumnDisplayType.Boolean:
+				// Drivers differ: some map SQL_BIT to a JavaScript boolean, others to 0/1.
+				if (typeof value === 'boolean') { return value ? 'true' : 'false'; }
+				if (typeof value === 'number') { return value ? 'true' : 'false'; }
+				return truncate(String(value), opts);
+			case ColumnDisplayType.Object:
+				if (value instanceof Uint8Array) {
+					return `[BINARY ${value.byteLength} bytes]`;
+				}
+				return truncate(String(value), opts);
+			default:
+				return truncate(String(value), opts);
+		}
+	}
+
+	async setRowFilters(params: SetRowFiltersParams): Promise<FilterResult> {
+		this.rowFilters = params.filters;
+		if (this.rowFilters.length === 0) {
+			this._whereClause = '';
+			this._filteredRows = this._unfilteredRows;
+		} else {
+			this._whereClause = `\nWHERE ${this.rowFilters.map(filter => this._makeWhereExpr(filter)).join(' AND ')}`;
+			this._filteredRows = this._countRows(this._whereClause);
+		}
+		return { selected_num_rows: await this._filteredRows };
+	}
+
+	async setSortColumns(params: SetSortColumnsParams): Promise<void> {
+		this.sortKeys = params.sort_keys;
+		this._sortClause = this._buildSortClause(this.sortKeys, true);
+	}
+
+	/**
+	 * Builds an ORDER BY clause for the given sort keys.
+	 *
+	 * Unlike SQLite's `rowid`, ODBC exposes no portable row identity to use as a tiebreaker, so the
+	 * table's first column stands in: appended after the user's sort keys it makes paging
+	 * reproducible, and on its own it gives an unsorted view a deterministic order. Rows that tie
+	 * on that column can still swap between pages, but the alternative -- no ordering at all -- lets
+	 * the backend return a different arrangement for every page, and is invalid outright for the
+	 * `OFFSET ... FETCH` dialects.
+	 */
+	private _buildSortClause(sortKeys: Array<ColumnSortKey>, includeTiebreaker: boolean): string {
+		const exprs = sortKeys.map(key =>
+			`${this._quote(this.schema[key.column_index].column_name)}${key.ascending ? '' : ' DESC'}`);
+
+		if (includeTiebreaker && this.schema.length > 0) {
+			const tiebreaker = this._quote(this.schema[0].column_name);
+			if (!exprs.some(expr => expr.startsWith(tiebreaker))) {
+				exprs.push(tiebreaker);
+			}
+		}
+
+		return exprs.length > 0 ? `\nORDER BY ${exprs.join(', ')}` : '';
+	}
+
+	async getState(): Promise<BackendState> {
+		const [unfilteredRows, filteredRows] = await Promise.all([this._unfilteredRows, this._filteredRows]);
+		const numColumns = this.schema.length;
+		return {
+			display_name: this.ref.name,
+			table_shape: { num_rows: filteredRows, num_columns: numColumns },
+			table_unfiltered_shape: { num_rows: unfilteredRows, num_columns: numColumns },
+			has_row_labels: false,
+			column_filters: [],
+			row_filters: this.rowFilters,
+			sort_keys: this.sortKeys,
+			supported_features: {
+				get_column_profiles: {
+					support_status: SupportStatus.Supported,
+					supported_types: [
+						{ profile_type: ColumnProfileType.NullCount, support_status: SupportStatus.Supported },
+						{ profile_type: ColumnProfileType.SummaryStats, support_status: SupportStatus.Supported },
+						{ profile_type: ColumnProfileType.SmallFrequencyTable, support_status: SupportStatus.Supported },
+						{ profile_type: ColumnProfileType.LargeFrequencyTable, support_status: SupportStatus.Supported },
+						{ profile_type: ColumnProfileType.SmallHistogram, support_status: SupportStatus.Supported },
+						{ profile_type: ColumnProfileType.LargeHistogram, support_status: SupportStatus.Supported },
+					],
+				},
+				search_schema: {
+					support_status: SupportStatus.Supported,
+					supported_types: [
+						{ column_filter_type: ColumnFilterType.TextSearch, support_status: SupportStatus.Supported },
+						{ column_filter_type: ColumnFilterType.MatchDataTypes, support_status: SupportStatus.Supported },
+					],
+				},
+				set_column_filters: { support_status: SupportStatus.Unsupported, supported_types: [] },
+				set_row_filters: {
+					support_status: SupportStatus.Supported,
+					supports_conditions: SupportStatus.Unsupported,
+					supported_types: [
+						{ row_filter_type: RowFilterType.Between, support_status: SupportStatus.Supported },
+						{ row_filter_type: RowFilterType.Compare, support_status: SupportStatus.Supported },
+						{ row_filter_type: RowFilterType.IsEmpty, support_status: SupportStatus.Supported },
+						{ row_filter_type: RowFilterType.IsFalse, support_status: SupportStatus.Supported },
+						{ row_filter_type: RowFilterType.IsNull, support_status: SupportStatus.Supported },
+						{ row_filter_type: RowFilterType.IsTrue, support_status: SupportStatus.Supported },
+						{ row_filter_type: RowFilterType.NotBetween, support_status: SupportStatus.Supported },
+						{ row_filter_type: RowFilterType.NotEmpty, support_status: SupportStatus.Supported },
+						{ row_filter_type: RowFilterType.NotNull, support_status: SupportStatus.Supported },
+						{ row_filter_type: RowFilterType.Search, support_status: SupportStatus.Supported },
+						{ row_filter_type: RowFilterType.SetMembership, support_status: SupportStatus.Supported },
+					],
+				},
+				set_sort_columns: { support_status: SupportStatus.Supported },
+				export_data_selection: {
+					support_status: SupportStatus.Supported,
+					supported_formats: [ExportFormat.Csv, ExportFormat.Tsv, ExportFormat.Html],
+				},
+				convert_to_code: {
+					support_status: SupportStatus.Supported,
+					code_syntaxes: [{ code_syntax_name: 'SQL' }],
+				},
+			},
+		};
+	}
+
+	async convertToCode(_params: ConvertToCodeParams): Promise<ConvertedCode> {
+		const result = ['SELECT *', `FROM ${this._quotedTable}`];
+		if (this._whereClause) {
+			result.push(this._whereClause.replace(/\n/g, ' ').trim());
+		}
+		// The generated SQL is for the user to run themselves, so it carries only the ordering they
+		// actually chose -- the tiebreaker exists to make Positron's own paging reproducible and
+		// would just be noise here.
+		const sortClause = this._buildSortClause(this.sortKeys, false).replace(/\n/g, ' ').trim();
+		if (sortClause) {
+			result.push(sortClause);
+		}
+		return { converted_code: result };
+	}
+
+	async suggestCodeSyntax(): Promise<CodeSyntaxName> {
+		return { code_syntax_name: 'SQL' };
+	}
+
+	async exportDataSelection(params: ExportDataSelectionParams): Promise<ExportedData> {
+		const kind = params.selection.kind;
+		const order = this._sortClause;
+
+		const runExport = async (query: string, columns: Array<OdbcSchemaEntry>): Promise<ExportedData> => {
+			const rows = await this.client.runQuery(query);
+			const matrix = [
+				columns.map(c => c.column_name),
+				...rows.map(row => columns.map((_, i) => stringifyExportCell(firstValue(row, `c${i}`)))),
+			];
+			return { data: formatExport(matrix, params.format), format: params.format };
+		};
+
+		const selectorsFor = (columns: Array<OdbcSchemaEntry>) =>
+			columns.map((c, i) => `${this._quote(c.column_name)} AS c${i}`).join(', ');
+
+		switch (kind) {
+			case TableSelectionKind.SingleCell: {
+				const sel = params.selection.selection as DataSelectionSingleCell;
+				const column = this.schema[sel.column_index];
+				const query = `SELECT ${this._quote(column.column_name)} AS c0 FROM ${this._quotedTable}` +
+					`${this._whereClause}${order}${this._paginate(1, sel.row_index)}`;
+				const rows = await this.client.runQuery(query);
+				return { data: stringifyExportCell(firstValue(rows[0], 'c0')), format: params.format };
+			}
+			case TableSelectionKind.CellRange: {
+				const sel = params.selection.selection as DataSelectionCellRange;
+				const columns = this.schema.slice(sel.first_column_index, sel.last_column_index + 1);
+				const query = `SELECT ${selectorsFor(columns)} FROM ${this._quotedTable}` +
+					`${this._whereClause}${order}${this._paginate(sel.last_row_index - sel.first_row_index + 1, sel.first_row_index)}`;
+				return runExport(query, columns);
+			}
+			case TableSelectionKind.RowRange: {
+				const sel = params.selection.selection as DataSelectionRange;
+				const query = `SELECT ${selectorsFor(this.schema)} FROM ${this._quotedTable}` +
+					`${this._whereClause}${order}${this._paginate(sel.last_index - sel.first_index + 1, sel.first_index)}`;
+				return runExport(query, this.schema);
+			}
+			case TableSelectionKind.ColumnRange: {
+				const sel = params.selection.selection as DataSelectionRange;
+				const columns = this.schema.slice(sel.first_index, sel.last_index + 1);
+				const query = `SELECT ${selectorsFor(columns)} FROM ${this._quotedTable}${this._whereClause}${order}`;
+				return runExport(query, columns);
+			}
+			case TableSelectionKind.ColumnIndices: {
+				const sel = params.selection.selection as DataSelectionIndices;
+				const columns = sel.indices.map(i => this.schema[i]);
+				const query = `SELECT ${selectorsFor(columns)} FROM ${this._quotedTable}${this._whereClause}${order}`;
+				return runExport(query, columns);
+			}
+			case TableSelectionKind.RowIndices: {
+				const sel = params.selection.selection as DataSelectionIndices;
+				return runExport(this._rowIndexQuery(selectorsFor(this.schema), sel.indices), this.schema);
+			}
+			case TableSelectionKind.CellIndices: {
+				const sel = params.selection.selection as DataSelectionCellIndices;
+				const columns = sel.column_indices.map(i => this.schema[i]);
+				return runExport(this._rowIndexQuery(selectorsFor(columns), sel.row_indices), columns);
+			}
+		}
+	}
+
+	/**
+	 * Builds a query that selects specific (post-sort, post-filter) row positions in the requested
+	 * order, using a ROW_NUMBER() window. Window functions are in SQL:2003 and supported by every
+	 * backend Positron is likely to reach over ODBC; older ones will report a syntax error, which is
+	 * the honest outcome for a selection that cannot be expressed.
+	 */
+	private _rowIndexQuery(selectors: string, rowIndices: number[]): string {
+		const ordering = this._sortClause.replace(/^\n/, '');
+		const numbered = `SELECT *, ROW_NUMBER() OVER (${ordering}) - 1 AS __row_index ` +
+			`FROM ${this._quotedTable}${this._whereClause}`;
+		const order = rowIndices.map((rowIdx, i) => `WHEN ${rowIdx} THEN ${i}`).join(' ');
+		const inList = rowIndices.join(', ');
+		// The derived table is aliased: SQL Server and Oracle both require a name for a subquery in
+		// FROM, where SQLite does not.
+		return `SELECT ${selectors} FROM (${numbered}) AS __numbered WHERE __row_index IN (${inList}) ` +
+			`ORDER BY CASE __row_index ${order} END`;
+	}
+
+	/**
+	 * Computes the requested column profiles. Returns the event payload to send to the frontend;
+	 * the caller is responsible for delivering it (so this class stays free of vscode APIs).
+	 */
+	async computeColumnProfiles(params: GetColumnProfilesParams): Promise<ReturnColumnProfilesEvent> {
+		const filteredRows = await this._filteredRows;
+		const profiles: ColumnProfileResult[] = [];
+		for (const request of params.profiles) {
+			profiles.push(await this._computeOneColumnProfile(request, filteredRows, params.format_options));
+		}
+		return { callback_id: params.callback_id, profiles };
+	}
+
+	private async _computeOneColumnProfile(
+		request: ColumnProfileRequest,
+		filteredRows: number,
+		formatOptions: FormatOptions,
+	): Promise<ColumnProfileResult> {
+		const entry = this.schema[request.column_index];
+		const quotedName = this._quote(entry.column_name);
+		const result: ColumnProfileResult = {};
+
+		for (const spec of request.profiles) {
+			switch (spec.profile_type) {
+				case ColumnProfileType.NullCount:
+					result.null_count = await this._nullCount(quotedName);
+					break;
+				case ColumnProfileType.SummaryStats:
+					result.summary_stats = filteredRows === 0
+						? this._emptySummaryStats(entry)
+						: await this._summaryStats(entry, quotedName, formatOptions);
+					break;
+				case ColumnProfileType.SmallFrequencyTable:
+				case ColumnProfileType.LargeFrequencyTable:
+					result[spec.profile_type] = await this._frequencyTable(
+						quotedName, (spec.params as ColumnFrequencyTableParams).limit, filteredRows);
+					break;
+				case ColumnProfileType.SmallHistogram:
+				case ColumnProfileType.LargeHistogram:
+					result[spec.profile_type] = await this._histogram(
+						entry, quotedName, spec.params as ColumnHistogramParams, filteredRows);
+					break;
+				default:
+					break;
+			}
+		}
+		return result;
+	}
+
+	private async _nullCount(quotedName: string): Promise<number> {
+		const rows = await this.client.runQuery(
+			`SELECT count(*) - count(${quotedName}) AS n FROM ${this._quotedTable}${this._whereClause}`);
+		return Number(firstValue(rows[0], 'n') ?? 0);
+	}
+
+	private _wherePlus(predicate: string): string {
+		return this._whereClause ? `${this._whereClause} AND ${predicate}` : `\nWHERE ${predicate}`;
+	}
+
+	private async _summaryStats(
+		entry: OdbcSchemaEntry,
+		quotedName: string,
+		formatOptions: FormatOptions,
+	): Promise<ColumnSummaryStats> {
+		const display = entry.type_display;
+		if (display === ColumnDisplayType.Integer || display === ColumnDisplayType.Floating || display === ColumnDisplayType.Decimal) {
+			// One pass for the moment-based stats; a second query for the median. Multiplying by
+			// 1.0 forces floating-point accumulation on backends where SUM over an integer column
+			// stays integral and would overflow.
+			const rows = await this.client.runQuery(
+				`SELECT count(${quotedName}) AS n, min(${quotedName}) AS lo, max(${quotedName}) AS hi, ` +
+				`sum(${quotedName} * 1.0) AS s, sum(${quotedName} * 1.0 * ${quotedName}) AS ss ` +
+				`FROM ${this._quotedTable}${this._whereClause}`);
+			const row = rows[0];
+			const n = Number(firstValue(row, 'n') ?? 0);
+			const sum = Number(firstValue(row, 's') ?? 0);
+			const sumsq = Number(firstValue(row, 'ss') ?? 0);
+			const mean = n > 0 ? sum / n : 0;
+			// Sample standard deviation from the sums of values and squares.
+			const variance = n > 1 ? Math.max(0, (sumsq - n * mean * mean) / (n - 1)) : 0;
+			const median = await this._quantile(quotedName, 0.5, n);
+			const fmt = (v: number) => formatFloat(v, formatOptions);
+			const lo = firstValue(row, 'lo');
+			const hi = firstValue(row, 'hi');
+			return {
+				type_display: display,
+				number_stats: {
+					min_value: lo === null || lo === undefined ? undefined : String(lo),
+					max_value: hi === null || hi === undefined ? undefined : String(hi),
+					mean: n > 0 ? fmt(mean) : undefined,
+					median: median === undefined ? undefined : fmt(median),
+					stdev: n > 1 ? fmt(Math.sqrt(variance)) : undefined,
+				},
+			};
+		}
+		if (display === ColumnDisplayType.String) {
+			const rows = await this.client.runQuery(
+				`SELECT count(DISTINCT ${quotedName}) AS nunique, ` +
+				`count(CASE WHEN ${quotedName} = '' THEN 1 END) AS nempty ` +
+				`FROM ${this._quotedTable}${this._whereClause}`);
+			return {
+				type_display: ColumnDisplayType.String,
+				string_stats: {
+					num_unique: Number(firstValue(rows[0], 'nunique') ?? 0),
+					num_empty: Number(firstValue(rows[0], 'nempty') ?? 0),
+				},
+			};
+		}
+		if (display === ColumnDisplayType.Boolean) {
+			const rows = await this.client.runQuery(
+				`SELECT count(CASE WHEN ${quotedName} <> 0 THEN 1 END) AS ntrue, ` +
+				`count(CASE WHEN ${quotedName} = 0 THEN 1 END) AS nfalse ` +
+				`FROM ${this._quotedTable}${this._whereClause}`);
+			return {
+				type_display: ColumnDisplayType.Boolean,
+				boolean_stats: {
+					true_count: Number(firstValue(rows[0], 'ntrue') ?? 0),
+					false_count: Number(firstValue(rows[0], 'nfalse') ?? 0),
+				},
+			};
+		}
+		if (display === ColumnDisplayType.Date || display === ColumnDisplayType.Datetime) {
+			const rows = await this.client.runQuery(
+				`SELECT min(${quotedName}) AS lo, max(${quotedName}) AS hi, count(DISTINCT ${quotedName}) AS nunique ` +
+				`FROM ${this._quotedTable}${this._whereClause}`);
+			const lo = firstValue(rows[0], 'lo');
+			const hi = firstValue(rows[0], 'hi');
+			const stats = {
+				num_unique: Number(firstValue(rows[0], 'nunique') ?? 0),
+				min_date: lo === null || lo === undefined ? undefined : String(lo),
+				max_date: hi === null || hi === undefined ? undefined : String(hi),
+			};
+			return display === ColumnDisplayType.Date
+				? { type_display: display, date_stats: stats }
+				: { type_display: display, datetime_stats: stats };
+		}
+		const rows = await this.client.runQuery(
+			`SELECT count(DISTINCT ${quotedName}) AS nunique FROM ${this._quotedTable}${this._whereClause}`);
+		return { type_display: display, other_stats: { num_unique: Number(firstValue(rows[0], 'nunique') ?? 0) } };
+	}
+
+	private _emptySummaryStats(entry: OdbcSchemaEntry): ColumnSummaryStats {
+		switch (entry.type_display) {
+			case ColumnDisplayType.Integer:
+			case ColumnDisplayType.Floating:
+			case ColumnDisplayType.Decimal:
+				return { type_display: entry.type_display, number_stats: {} };
+			case ColumnDisplayType.String:
+				return { type_display: ColumnDisplayType.String, string_stats: { num_unique: 0, num_empty: 0 } };
+			case ColumnDisplayType.Boolean:
+				return { type_display: ColumnDisplayType.Boolean, boolean_stats: { true_count: 0, false_count: 0 } };
+			case ColumnDisplayType.Date:
+				return { type_display: ColumnDisplayType.Date, date_stats: { num_unique: 0 } };
+			case ColumnDisplayType.Datetime:
+				return { type_display: ColumnDisplayType.Datetime, datetime_stats: { num_unique: 0 } };
+			default:
+				return { type_display: entry.type_display, other_stats: { num_unique: 0 } };
+		}
+	}
+
+	/**
+	 * Computes a quantile (0..1) by ordering the non-null values and reading the value at the
+	 * corresponding offset. `n` is the count of non-null values.
+	 */
+	private async _quantile(quotedName: string, q: number, n: number): Promise<number | undefined> {
+		if (n === 0) {
+			return undefined;
+		}
+		const offset = Math.min(n - 1, Math.max(0, Math.floor(q * (n - 1))));
+		const rows = await this.client.runQuery(
+			`SELECT ${quotedName} AS v FROM ${this._quotedTable}${this._wherePlus(`${quotedName} IS NOT NULL`)} ` +
+			`ORDER BY ${quotedName}${this._paginate(1, offset)}`);
+		const value = firstValue(rows[0], 'v');
+		return value === null || value === undefined ? undefined : Number(value);
+	}
+
+	private async _frequencyTable(quotedName: string, limit: number, filteredRows: number): Promise<ColumnFrequencyTable> {
+		// count(*) is aliased and then ordered by the alias; ordering by the aggregate expression
+		// itself is what SQL Server requires, and repeating it satisfies both.
+		const rows = await this.client.runQuery(
+			`SELECT ${quotedName} AS value, count(*) AS freq FROM ${this._quotedTable}` +
+			`${this._wherePlus(`${quotedName} IS NOT NULL`)} GROUP BY ${quotedName} ` +
+			`ORDER BY count(*) DESC, ${quotedName} ASC${this._paginate(limit, 0)}`);
+		const values: ColumnValue[] = [];
+		const counts: number[] = [];
+		let total = 0;
+		for (const row of rows) {
+			values.push(String(firstValue(row, 'value')));
+			const freq = Number(firstValue(row, 'freq'));
+			counts.push(freq);
+			total += freq;
+		}
+		const nullCount = await this._nullCount(quotedName);
+		return { values, counts, other_count: Math.max(0, filteredRows - total - nullCount) };
+	}
+
+	private async _histogram(
+		entry: OdbcSchemaEntry,
+		quotedName: string,
+		params: ColumnHistogramParams,
+		filteredRows: number,
+	): Promise<ColumnHistogram> {
+		const nullCount = await this._nullCount(quotedName);
+		const nonNull = filteredRows - nullCount;
+		if (nonNull <= 0) {
+			return { bin_edges: ['NULL', 'NULL'], bin_counts: [nullCount], quantiles: [] };
+		}
+
+		const rows = await this.client.runQuery(
+			`SELECT min(${quotedName}) AS lo, max(${quotedName}) AS hi FROM ${this._quotedTable}${this._whereClause}`);
+		const minValue = Number(firstValue(rows[0], 'lo'));
+		const maxValue = Number(firstValue(rows[0], 'hi'));
+		const peakToPeak = maxValue - minValue;
+
+		// A degenerate range (single distinct value) collapses to one bin.
+		if (!isFinite(peakToPeak) || peakToPeak === 0) {
+			return { bin_edges: [String(minValue), String(maxValue)], bin_counts: [nonNull], quantiles: [] };
+		}
+
+		let binWidth = 0;
+		switch (params.method) {
+			case ColumnHistogramParamsMethod.Fixed:
+				binWidth = peakToPeak / params.num_bins;
+				break;
+			case ColumnHistogramParamsMethod.FreedmanDiaconis: {
+				const q1 = await this._quantile(quotedName, 0.25, nonNull);
+				const q3 = await this._quantile(quotedName, 0.75, nonNull);
+				const iqr = (q3 ?? 0) - (q1 ?? 0);
+				if (iqr > 0) {
+					binWidth = 2 * iqr * Math.pow(nonNull, -1 / 3);
+				}
+				break;
+			}
+			case ColumnHistogramParamsMethod.Sturges:
+			case ColumnHistogramParamsMethod.Scott:
+			default:
+				binWidth = peakToPeak / (Math.log2(nonNull) + 1);
+				break;
+		}
+		if (binWidth <= 0) {
+			binWidth = peakToPeak / params.num_bins;
+		}
+
+		let numBins = Math.ceil(peakToPeak / binWidth);
+		if (numBins > params.num_bins) {
+			numBins = params.num_bins;
+			binWidth = peakToPeak / numBins;
+		}
+		if (entry.type_display === ColumnDisplayType.Integer && peakToPeak <= numBins) {
+			numBins = peakToPeak + 1;
+			binWidth = peakToPeak / numBins;
+		}
+
+		// FLOOR is standard SQL and available everywhere, unlike a CAST to an integer type whose
+		// name differs per backend (INTEGER, INT, SIGNED). Values are >= minValue, so the bin id is
+		// non-negative and FLOOR and truncation agree. The expression is repeated in GROUP BY
+		// rather than referenced by alias, which SQL Server does not allow there.
+		const binExpr = `FLOOR((${quotedName} * 1.0 - ${minValue}) / ${binWidth})`;
+		const binRows = await this.client.runQuery(
+			`SELECT ${binExpr} AS bin_id, count(*) AS bin_count ` +
+			`FROM ${this._quotedTable}${this._wherePlus(`${quotedName} IS NOT NULL`)} GROUP BY ${binExpr}`);
+		const histEntries = new Map<number, number>(
+			binRows.map(row => [Number(firstValue(row, 'bin_id')), Number(firstValue(row, 'bin_count'))]));
+
+		const histogram: ColumnHistogram = { bin_edges: [], bin_counts: [], quantiles: [] };
+		for (let i = 0; i < numBins; i++) {
+			histogram.bin_edges.push(String(minValue + binWidth * i));
+			histogram.bin_counts.push(histEntries.get(i) ?? 0);
+		}
+		// The final bin edge is exclusive, so fold the overflow bin into the last bin.
+		histogram.bin_counts[numBins - 1] += histEntries.get(numBins) ?? 0;
+		histogram.bin_edges.push(String(minValue + binWidth * numBins));
+		return histogram;
+	}
+}
+
+/**
+ * Reads a value from a result row by the alias it was selected under.
+ *
+ * ODBC drivers do not agree on the case of returned column names: some echo the alias as written,
+ * others uppercase it (Oracle, Db2, Snowflake). Rather than force every alias to one case and hope,
+ * the lookup tries the exact name first and then falls back to a case-insensitive match.
+ */
+function firstValue(row: Record<string, unknown> | undefined, alias: string): unknown {
+	if (row === undefined) {
+		return undefined;
+	}
+	if (Object.prototype.hasOwnProperty.call(row, alias)) {
+		return row[alias];
+	}
+	const lower = alias.toLowerCase();
+	for (const key of Object.keys(row)) {
+		if (key.toLowerCase() === lower) {
+			return row[key];
+		}
+	}
+	return undefined;
+}
+
+/**
+ * The escape character used for LIKE patterns, and the clause declaring it.
+ *
+ * Backslash would be the conventional choice, but MySQL treats backslash as an escape inside string
+ * literals too, so `'\%'` reaches the pattern matcher as a bare `%` and the escaping silently does
+ * nothing. `!` has no special meaning in a string literal on any backend. The bracket form SQL
+ * Server accepts (`[%]`) is not an option either -- it is SQL Server's alone.
+ */
+const LIKE_ESCAPE_CHAR = '!';
+const LIKE_ESCAPE_CLAUSE = `ESCAPE '${LIKE_ESCAPE_CHAR}'`;
+
+/**
+ * Escapes the LIKE wildcards in a search term, so a user searching for "100%" matches that text
+ * rather than every row beginning "100". Paired with the ESCAPE clause the callers append.
+ */
+function escapeLikePattern(term: string): string {
+	return term.replace(/[%_!]/g, match => `${LIKE_ESCAPE_CHAR}${match}`);
+}
+
+/** Type guard distinguishing a contiguous index range from an explicit index set. */
+function isSelectionRange(spec: ArraySelection): spec is DataSelectionRange {
+	return (spec as DataSelectionRange).first_index !== undefined;
+}
+
+/** Applies a thousands separator to the integer part of an already-formatted number string. */
+function applyThousandsSep(formatted: string, sep: string): string {
+	const negative = formatted.startsWith('-');
+	const body = negative ? formatted.slice(1) : formatted;
+	const [intPart, fracPart] = body.split('.');
+	const grouped = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, sep);
+	const result = fracPart === undefined ? grouped : `${grouped}.${fracPart}`;
+	return negative ? `-${result}` : result;
+}
+
+/** Formats a floating-point value following the Data Explorer FormatOptions. */
+function formatFloat(value: number, opts: FormatOptions): string {
+	const sciLimit = Math.pow(10, opts.max_integral_digits);
+	let formatted: string;
+	const abs = Math.abs(value);
+	if (abs !== 0 && abs >= sciLimit) {
+		return value.toExponential(opts.large_num_digits);
+	} else if (abs !== 0 && abs < 1) {
+		formatted = value.toFixed(opts.small_num_digits);
+	} else {
+		formatted = value.toFixed(opts.large_num_digits);
+	}
+	return opts.thousands_sep ? applyThousandsSep(formatted, opts.thousands_sep) : formatted;
+}
+
+/** Formats an integer value (number or bigint), optionally with a thousands separator. */
+function formatInteger(value: number | bigint, opts: FormatOptions): string {
+	const formatted = value.toString();
+	return opts.thousands_sep ? applyThousandsSep(formatted, opts.thousands_sep) : formatted;
+}
+
+/** Truncates a string to the configured maximum formatted length. */
+function truncate(value: string, opts: FormatOptions): string {
+	return value.length > opts.max_value_length ? value.slice(0, opts.max_value_length) : value;
+}
+
+/** Stringifies a raw ODBC value for export, rendering null as 'NULL' and binary compactly. */
+function stringifyExportCell(value: unknown): string {
+	if (value === null || value === undefined) {
+		return 'NULL';
+	}
+	if (value instanceof Uint8Array) {
+		return `[BINARY ${value.byteLength} bytes]`;
+	}
+	return String(value);
+}
+
+/** Renders an export matrix (header row + data rows) into the requested format. */
+function formatExport(matrix: string[][], format: ExportFormat): string {
+	switch (format) {
+		case ExportFormat.Csv:
+			return matrix.map(row => row.join(',')).join('\n');
+		case ExportFormat.Tsv:
+			return matrix.map(row => row.join('\t')).join('\n');
+		case ExportFormat.Html:
+			return matrix.map(row => `<tr><td>${row.join('</td><td>')}</td></tr>`).join('\n');
+		default:
+			throw new Error(`Unknown export format: ${format}`);
+	}
+}

--- a/extensions/positron-data-driver-odbc/src/odbcTableView.ts
+++ b/extensions/positron-data-driver-odbc/src/odbcTableView.ts
@@ -201,6 +201,36 @@ const COMPARISON_OPS = new Map<FilterComparisonOp, string>([
 ]);
 
 /**
+ * Resolves the columns that uniquely identify a row, for use as the pagination tiebreaker.
+ *
+ * SQLPrimaryKeys is the portable way to ask: ODBC offers no equivalent of PostgreSQL's `ctid` or
+ * SQLite's `rowid`, and the key is the next best thing. KEY_SEQ orders the columns within a
+ * composite key, so it decides the order they are appended in.
+ *
+ * Views have no primary key, and a driver that does not implement SQLPrimaryKeys reports an error
+ * rather than an empty set. Both degrade to "no row identity", which the table view handles by
+ * falling back to the first column.
+ */
+export async function resolveOdbcRowIdentity(
+	client: IOdbcQueryClient,
+	ref: OdbcTableRef,
+): Promise<string[]> {
+	if (ref.kind !== 'table') {
+		return [];
+	}
+	try {
+		const rows = await client.primaryKeys(ref.catalog ?? null, ref.schema ?? null, ref.name);
+		return rows
+			.slice()
+			.sort((a, b) => Number(a['KEY_SEQ'] ?? 0) - Number(b['KEY_SEQ'] ?? 0))
+			.map(row => String(row['COLUMN_NAME'] ?? ''))
+			.filter(name => name.length > 0);
+	} catch {
+		return [];
+	}
+}
+
+/**
  * Serves Data Explorer requests for a single table or view reached over ODBC. Translates each
  * protocol method into SQL run through the connection's worker client, in the dialect resolved for
  * the backend.
@@ -227,12 +257,16 @@ export class OdbcTableView {
 	 * @param ref The table or view this view serves.
 	 * @param dialect How to write SQL for this backend.
 	 * @param schema The resolved column schema.
+	 * @param rowIdentity Unquoted names of the columns that uniquely identify a row, used as the
+	 * pagination tiebreaker. Empty where none could be resolved -- a view, or a table with no
+	 * primary key -- in which case the first column stands in. See `resolveOdbcRowIdentity`.
 	 */
 	constructor(
 		private readonly client: IOdbcQueryClient,
 		private readonly ref: OdbcTableRef,
 		private readonly dialect: OdbcDialect,
 		private readonly schema: Array<OdbcSchemaEntry>,
+		private readonly rowIdentity: ReadonlyArray<string> = [],
 	) {
 		this._sortClause = this._buildSortClause([], true);
 		this._unfilteredRows = this._countRows('');
@@ -600,27 +634,46 @@ export class OdbcTableView {
 	}
 
 	/**
-	 * Builds an ORDER BY clause for the given sort keys.
-	 *
-	 * Unlike SQLite's `rowid`, ODBC exposes no portable row identity to use as a tiebreaker, so the
-	 * table's first column stands in: appended after the user's sort keys it makes paging
-	 * reproducible, and on its own it gives an unsorted view a deterministic order. Rows that tie
-	 * on that column can still swap between pages, but the alternative -- no ordering at all -- lets
-	 * the backend return a different arrangement for every page, and is invalid outright for the
-	 * `OFFSET ... FETCH` dialects.
+	 * Builds an ORDER BY clause for the given sort keys, with a tiebreaker appended so that paging
+	 * is reproducible. The user's sort keys alone are only a partial order: rows tied on them may
+	 * come back in a different arrangement for every page, so a page boundary inside a tie group
+	 * repeats or drops rows. An unsorted view has no order at all, which is worse still, and is
+	 * invalid outright for the `OFFSET ... FETCH` dialects.
 	 */
 	private _buildSortClause(sortKeys: Array<ColumnSortKey>, includeTiebreaker: boolean): string {
 		const exprs = sortKeys.map(key =>
 			`${this._quote(this.schema[key.column_index].column_name)}${key.ascending ? '' : ' DESC'}`);
 
-		if (includeTiebreaker && this.schema.length > 0) {
-			const tiebreaker = this._quote(this.schema[0].column_name);
-			if (!exprs.some(expr => expr.startsWith(tiebreaker))) {
-				exprs.push(tiebreaker);
+		if (includeTiebreaker) {
+			for (const name of this._tiebreakerColumns()) {
+				const tiebreaker = this._quote(name);
+				if (!exprs.some(expr => expr.startsWith(tiebreaker))) {
+					exprs.push(tiebreaker);
+				}
 			}
 		}
 
 		return exprs.length > 0 ? `\nORDER BY ${exprs.join(', ')}` : '';
+	}
+
+	/**
+	 * The columns to append as a pagination tiebreaker.
+	 *
+	 * ODBC exposes no portable row identity of the kind PostgreSQL's `ctid` or SQLite's `rowid`
+	 * provide, so the primary key stands in: where the backend enforces one it is unique by
+	 * definition, which is exactly what LIMIT/OFFSET paging needs. Backends reached over ODBC that
+	 * treat a declared key as advisory rather than enforcing it (Snowflake, the Hive family) get a
+	 * better order than an arbitrary column but still not a guaranteed one.
+	 *
+	 * With no key to be had -- a view, or a table without one -- the first column stands in. That is
+	 * not unique, so rows tied on it can still swap between pages; it is a floor rather than a fix,
+	 * and those cases want a materialized snapshot instead.
+	 */
+	private _tiebreakerColumns(): ReadonlyArray<string> {
+		if (this.rowIdentity.length > 0) {
+			return this.rowIdentity;
+		}
+		return this.schema.length > 0 ? [this.schema[0].column_name] : [];
 	}
 
 	async getState(): Promise<BackendState> {

--- a/extensions/positron-data-driver-odbc/src/odbcTableView.ts
+++ b/extensions/positron-data-driver-odbc/src/odbcTableView.ts
@@ -16,6 +16,7 @@
 import { OdbcDialect } from './odbcDatabases';
 import { OdbcTableRef } from './odbcNodes';
 import { IOdbcQueryClient } from './odbcWorkerClient';
+import { OdbcRow } from './odbcWorkerProtocol';
 import {
 	ArraySelection,
 	BackendState,
@@ -110,6 +111,18 @@ export interface OdbcSchemaEntry {
 	/** The backend's own name for the type ("varchar", "NUMBER"), shown in the schema panel. */
 	column_type: string;
 	type_display: ColumnDisplayType;
+	/**
+	 * Whether the column holds raw bytes (bytea, BLOB, VARBINARY, IMAGE, ...). Tracked separately
+	 * from `type_display` because that reports Object for binary columns *and* for any type code
+	 * the specification does not define, and the two must not be treated alike -- see
+	 * {@link OdbcTableView._columnSelector} for why binary values are never fetched.
+	 */
+	is_binary: boolean;
+}
+
+/** Whether an ODBC SQL type code denotes raw bytes. */
+export function isBinarySqlType(dataType: number | undefined): boolean {
+	return dataType === SQL_BINARY || dataType === SQL_VARBINARY || dataType === SQL_LONGVARBINARY;
 }
 
 /**
@@ -203,6 +216,13 @@ export class OdbcTableView {
 	private _filteredRows: Promise<number>;
 
 	/**
+	 * Whether the backend accepted the ODBC `{fn OCTET_LENGTH(...)}` escape for measuring a binary
+	 * column. Set false the first time a read of a binary column fails, after which those columns
+	 * report only whether a value is present. See {@link _columnSelector}.
+	 */
+	private _binaryLengthSupported = true;
+
+	/**
 	 * @param client The query client for the owning connection.
 	 * @param ref The table or view this view serves.
 	 * @param dialect How to write SQL for this backend.
@@ -217,6 +237,77 @@ export class OdbcTableView {
 		this._sortClause = this._buildSortClause([], true);
 		this._unfilteredRows = this._countRows('');
 		this._filteredRows = this._unfilteredRows;
+	}
+
+	/**
+	 * Builds the SELECT expression for a column, aliased so duplicate names stay unambiguous.
+	 *
+	 * Binary columns are never fetched as bytes. node-odbc materializes them with
+	 * `napi_create_external_arraybuffer`, which Electron refuses -- V8's memory cage forbids
+	 * external array buffers -- and the refusal is a fatal native error that kills the worker rather
+	 * than an exception anything can catch. It is only fatal in the desktop extension host; the
+	 * server one is real Node and unaffected. Rather than have the Data Explorer work on Workbench
+	 * and crash on Desktop, no binary value is ever requested.
+	 *
+	 * Nothing is lost by it: a binary cell renders as `[BINARY n bytes]`, so the bytes were only
+	 * ever fetched to be measured and discarded. `{fn OCTET_LENGTH(...)}` is ODBC's portable escape
+	 * for that measurement, and where a driver rejects it the fallback asks only whether the value
+	 * is null, which is plain SQL every backend accepts.
+	 */
+	private _columnSelector(entry: OdbcSchemaEntry, alias: string): string {
+		const quoted = this._quote(entry.column_name);
+		if (!entry.is_binary) {
+			return `${quoted} AS ${alias}`;
+		}
+		return this._binaryLengthSupported
+			? `{fn OCTET_LENGTH(${quoted})} AS ${alias}`
+			// 0 for null, 1 for present -- enough to tell an absent value from a binary one without
+			// naming a type or a function.
+			: `CASE WHEN ${quoted} IS NULL THEN 0 ELSE 1 END AS ${alias}`;
+	}
+
+	/**
+	 * Stringifies a cell for export. Binary columns carry a measurement rather than their bytes
+	 * (see {@link _columnSelector}), so they are rendered from that rather than from content.
+	 */
+	private _stringifyExportCell(value: unknown, entry: OdbcSchemaEntry): string {
+		if (!entry.is_binary) {
+			return stringifyExportCell(value);
+		}
+		if (value === null || value === undefined) {
+			return 'NULL';
+		}
+		const measure = Number(value);
+		if (!this._binaryLengthSupported) {
+			return measure === 0 ? 'NULL' : '[BINARY]';
+		}
+		return Number.isFinite(measure) ? `[BINARY ${measure} bytes]` : '[BINARY]';
+	}
+
+	/** Whether any of the given columns is binary, i.e. whether a read of them can be retried. */
+	private _hasBinary(columns: readonly OdbcSchemaEntry[]): boolean {
+		return columns.some(column => column.is_binary);
+	}
+
+	/**
+	 * Runs a read, retrying once without the `{fn OCTET_LENGTH(...)}` escape if the backend rejected
+	 * it. Only the first failure costs a round trip: the fallback is remembered for the view's life.
+	 * @param columns The columns the query selects, used to decide whether a retry could help.
+	 * @param buildQuery Builds the SQL, called again after the fallback is engaged.
+	 */
+	private async _readWithBinaryFallback(
+		columns: readonly OdbcSchemaEntry[],
+		buildQuery: () => string
+	): Promise<OdbcRow[]> {
+		try {
+			return await this.client.runQuery(buildQuery());
+		} catch (error) {
+			if (!this._binaryLengthSupported || !this._hasBinary(columns)) {
+				throw error;
+			}
+			this._binaryLengthSupported = false;
+			return this.client.runQuery(buildQuery());
+		}
 	}
 
 	/** Quotes and escapes an identifier, doubling the dialect's quote character where embedded. */
@@ -411,21 +502,21 @@ export class OdbcTableView {
 		const numRows = upperLimit - lowerLimit + 1;
 
 		// Select each requested column under a positional alias so duplicates are unambiguous.
-		const selectors = params.columns.map((column, i) =>
-			`${this._quote(this.schema[column.column_index].column_name)} AS c${i}`);
-		const query = `SELECT ${selectors.join(', ')} FROM ${this._quotedTable}` +
-			`${this._whereClause}${this._sortClause}${this._paginate(numRows, lowerLimit)}`;
-		const rows = await this.client.runQuery(query);
+		const selected = params.columns.map(column => this.schema[column.column_index]);
+		const rows = await this._readWithBinaryFallback(selected, () =>
+			`SELECT ${selected.map((entry, i) => this._columnSelector(entry, `c${i}`)).join(', ')} ` +
+			`FROM ${this._quotedTable}` +
+			`${this._whereClause}${this._sortClause}${this._paginate(numRows, lowerLimit)}`);
 
 		const result: TableData = { columns: [] };
 		for (let i = 0; i < params.columns.length; i++) {
 			const column = params.columns[i];
-			const displayType = this.schema[column.column_index].type_display;
+			const entry = this.schema[column.column_index];
 			const format = (absIndex: number): ColumnValue => {
 				const row = rows[absIndex - lowerLimit];
 				return row === undefined
 					? SENTINEL_NULL
-					: this._formatValue(firstValue(row, `c${i}`), displayType, params.format_options);
+					: this._formatValue(firstValue(row, `c${i}`), entry, params.format_options);
 			};
 
 			const spec = column.spec;
@@ -447,12 +538,23 @@ export class OdbcTableView {
 	 * Formats a raw ODBC value into the Data Explorer cell encoding: a sentinel number for
 	 * null/NaN/+-Inf, otherwise a formatted string.
 	 */
-	private _formatValue(value: unknown, displayType: ColumnDisplayType, opts: FormatOptions): ColumnValue {
+	private _formatValue(value: unknown, entry: OdbcSchemaEntry, opts: FormatOptions): ColumnValue {
 		if (value === null || value === undefined) {
 			return SENTINEL_NULL;
 		}
 
-		switch (displayType) {
+		// A binary column never carries its bytes here (see _columnSelector): the value is the byte
+		// count, or -- once the length escape has been rejected by this backend -- 0 for null and 1
+		// for present.
+		if (entry.is_binary) {
+			const measure = Number(value);
+			if (!this._binaryLengthSupported) {
+				return measure === 0 ? SENTINEL_NULL : '[BINARY]';
+			}
+			return Number.isFinite(measure) ? `[BINARY ${measure} bytes]` : '[BINARY]';
+		}
+
+		switch (entry.type_display) {
 			case ColumnDisplayType.Floating:
 			case ColumnDisplayType.Decimal: {
 				const num = typeof value === 'number' ? value : Number(value);
@@ -605,60 +707,58 @@ export class OdbcTableView {
 		const kind = params.selection.kind;
 		const order = this._sortClause;
 
-		const runExport = async (query: string, columns: Array<OdbcSchemaEntry>): Promise<ExportedData> => {
-			const rows = await this.client.runQuery(query);
+		// The query is built lazily so it can be rebuilt if the backend rejects the binary-length
+		// escape; see _readWithBinaryFallback.
+		const runExport = async (buildQuery: () => string, columns: Array<OdbcSchemaEntry>): Promise<ExportedData> => {
+			const rows = await this._readWithBinaryFallback(columns, buildQuery);
 			const matrix = [
 				columns.map(c => c.column_name),
-				...rows.map(row => columns.map((_, i) => stringifyExportCell(firstValue(row, `c${i}`)))),
+				...rows.map(row => columns.map((entry, i) => this._stringifyExportCell(firstValue(row, `c${i}`), entry))),
 			];
 			return { data: formatExport(matrix, params.format), format: params.format };
 		};
 
 		const selectorsFor = (columns: Array<OdbcSchemaEntry>) =>
-			columns.map((c, i) => `${this._quote(c.column_name)} AS c${i}`).join(', ');
+			columns.map((c, i) => this._columnSelector(c, `c${i}`)).join(', ');
 
 		switch (kind) {
 			case TableSelectionKind.SingleCell: {
 				const sel = params.selection.selection as DataSelectionSingleCell;
 				const column = this.schema[sel.column_index];
-				const query = `SELECT ${this._quote(column.column_name)} AS c0 FROM ${this._quotedTable}` +
-					`${this._whereClause}${order}${this._paginate(1, sel.row_index)}`;
-				const rows = await this.client.runQuery(query);
-				return { data: stringifyExportCell(firstValue(rows[0], 'c0')), format: params.format };
+				const rows = await this._readWithBinaryFallback([column], () =>
+					`SELECT ${this._columnSelector(column, 'c0')} FROM ${this._quotedTable}` +
+					`${this._whereClause}${order}${this._paginate(1, sel.row_index)}`);
+				return { data: this._stringifyExportCell(firstValue(rows[0], 'c0'), column), format: params.format };
 			}
 			case TableSelectionKind.CellRange: {
 				const sel = params.selection.selection as DataSelectionCellRange;
 				const columns = this.schema.slice(sel.first_column_index, sel.last_column_index + 1);
-				const query = `SELECT ${selectorsFor(columns)} FROM ${this._quotedTable}` +
-					`${this._whereClause}${order}${this._paginate(sel.last_row_index - sel.first_row_index + 1, sel.first_row_index)}`;
-				return runExport(query, columns);
+				return runExport(() => `SELECT ${selectorsFor(columns)} FROM ${this._quotedTable}` +
+					`${this._whereClause}${order}${this._paginate(sel.last_row_index - sel.first_row_index + 1, sel.first_row_index)}`, columns);
 			}
 			case TableSelectionKind.RowRange: {
 				const sel = params.selection.selection as DataSelectionRange;
-				const query = `SELECT ${selectorsFor(this.schema)} FROM ${this._quotedTable}` +
-					`${this._whereClause}${order}${this._paginate(sel.last_index - sel.first_index + 1, sel.first_index)}`;
-				return runExport(query, this.schema);
+				return runExport(() => `SELECT ${selectorsFor(this.schema)} FROM ${this._quotedTable}` +
+					`${this._whereClause}${order}${this._paginate(sel.last_index - sel.first_index + 1, sel.first_index)}`, this.schema);
 			}
 			case TableSelectionKind.ColumnRange: {
 				const sel = params.selection.selection as DataSelectionRange;
 				const columns = this.schema.slice(sel.first_index, sel.last_index + 1);
-				const query = `SELECT ${selectorsFor(columns)} FROM ${this._quotedTable}${this._whereClause}${order}`;
-				return runExport(query, columns);
+				return runExport(() => `SELECT ${selectorsFor(columns)} FROM ${this._quotedTable}${this._whereClause}${order}`, columns);
 			}
 			case TableSelectionKind.ColumnIndices: {
 				const sel = params.selection.selection as DataSelectionIndices;
 				const columns = sel.indices.map(i => this.schema[i]);
-				const query = `SELECT ${selectorsFor(columns)} FROM ${this._quotedTable}${this._whereClause}${order}`;
-				return runExport(query, columns);
+				return runExport(() => `SELECT ${selectorsFor(columns)} FROM ${this._quotedTable}${this._whereClause}${order}`, columns);
 			}
 			case TableSelectionKind.RowIndices: {
 				const sel = params.selection.selection as DataSelectionIndices;
-				return runExport(this._rowIndexQuery(selectorsFor(this.schema), sel.indices), this.schema);
+				return runExport(() => this._rowIndexQuery(selectorsFor(this.schema), sel.indices), this.schema);
 			}
 			case TableSelectionKind.CellIndices: {
 				const sel = params.selection.selection as DataSelectionCellIndices;
 				const columns = sel.column_indices.map(i => this.schema[i]);
-				return runExport(this._rowIndexQuery(selectorsFor(columns), sel.row_indices), columns);
+				return runExport(() => this._rowIndexQuery(selectorsFor(columns), sel.row_indices), columns);
 			}
 		}
 	}
@@ -715,8 +815,13 @@ export class OdbcTableView {
 					break;
 				case ColumnProfileType.SmallFrequencyTable:
 				case ColumnProfileType.LargeFrequencyTable:
-					result[spec.profile_type] = await this._frequencyTable(
-						quotedName, (spec.params as ColumnFrequencyTableParams).limit, filteredRows);
+					// A frequency table over a binary column would have to select the bytes as the
+					// group key, which is the read that kills the worker (see _columnSelector) --
+					// and "the most common blob" is not a question worth answering anyway.
+					result[spec.profile_type] = entry.is_binary
+						? { values: [], counts: [], other_count: filteredRows }
+						: await this._frequencyTable(
+							quotedName, (spec.params as ColumnFrequencyTableParams).limit, filteredRows);
 					break;
 				case ColumnProfileType.SmallHistogram:
 				case ColumnProfileType.LargeHistogram:
@@ -1044,9 +1149,6 @@ function truncate(value: string, opts: FormatOptions): string {
 function stringifyExportCell(value: unknown): string {
 	if (value === null || value === undefined) {
 		return 'NULL';
-	}
-	if (value instanceof Uint8Array) {
-		return `[BINARY ${value.byteLength} bytes]`;
 	}
 	return String(value);
 }

--- a/extensions/positron-data-driver-odbc/src/odbcWorker.ts
+++ b/extensions/positron-data-driver-odbc/src/odbcWorker.ts
@@ -1,0 +1,171 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// This module is the entry point for the ODBC child process. It owns the native `odbc` connection
+// and runs requests on its behalf.
+//
+// Running ODBC out-of-process is not a nicety. An ODBC connection loads a third-party vendor
+// library into the process and calls into it; the quality of those libraries varies, and a bad one
+// segfaults or calls abort(). Neither can be caught in-process, so isolating them in a child that
+// the host can watch die and respawn is the only way to keep the extension host stable. This is
+// the same reasoning as positron-data-driver-sqlite's worker, with more cause.
+
+import type { Connection } from 'odbc';
+import {
+	OdbcErrorDetail,
+	OdbcRow,
+	WorkerConnectConfig,
+	WorkerRequest,
+	WorkerResponse
+} from './odbcWorkerProtocol';
+
+/** Send a response to the host, narrowed so TypeScript knows IPC is available. */
+function send(response: WorkerResponse): void {
+	process.send?.(response);
+}
+
+// The connect configuration is supplied by the host as the first fork argument (JSON encoded).
+const config: WorkerConnectConfig = JSON.parse(process.argv[2] ?? '{}');
+
+/**
+ * Loads the native binding. Phase-0 spike confirmed the published `napi-v8` binary is Node-API and
+ * loads unchanged under both Electron (the desktop worker, forked with ELECTRON_RUN_AS_NODE) and
+ * plain Node (the server extension host), so unlike better-sqlite3 there is no ABI-specific binary
+ * to select here.
+ *
+ * The failure that does need distinguishing is the driver manager being absent: on macOS and Linux
+ * the binding links against unixODBC's libodbc, and a machine without it fails at dlopen with a
+ * message the user cannot act on. That is reported separately so the host can offer install
+ * guidance rather than a stack trace.
+ */
+type LoadResult =
+	| { kind: 'loaded'; odbc: typeof import('odbc') }
+	| { kind: 'failed'; message: string };
+
+function loadOdbc(): LoadResult {
+	try {
+		return { kind: 'loaded', odbc: require('odbc') };
+	} catch (error) {
+		return { kind: 'failed', message: error instanceof Error ? error.message : String(error) };
+	}
+}
+
+const loaded = loadOdbc();
+
+/**
+ * Whether a load failure looks like a missing unixODBC rather than a broken install of our own
+ * binding. dlopen reports the library it could not find, so the libodbc mention is the signal.
+ */
+function isDriverManagerMissing(message: string): boolean {
+	return /libodbc/i.test(message) || /odbc32/i.test(message);
+}
+
+/** Flattens node-odbc's diagnostic records into one message, falling back to the Error's own. */
+function describeError(error: unknown): { message: string; odbcErrors?: OdbcErrorDetail[] } {
+	const odbcErrors = (error as { odbcErrors?: OdbcErrorDetail[] })?.odbcErrors;
+	if (Array.isArray(odbcErrors) && odbcErrors.length > 0) {
+		const message = odbcErrors
+			.map(diagnostic => diagnostic.message?.trim())
+			.filter((text): text is string => !!text)
+			.join('; ');
+		if (message.length > 0) {
+			return { message, odbcErrors };
+		}
+	}
+	return { message: error instanceof Error ? error.message : String(error), odbcErrors };
+}
+
+let connection: Connection | undefined;
+let connecting: Promise<Connection> | undefined;
+
+/**
+ * Opens the connection, at most once. Held as a promise so requests that arrive while the connect
+ * is still in flight await the same attempt rather than opening a second connection.
+ */
+function ensureConnected(): Promise<Connection> {
+	if (connection !== undefined) {
+		return Promise.resolve(connection);
+	}
+	if (connecting === undefined) {
+		if (loaded.kind === 'failed') {
+			return Promise.reject(new Error(loaded.message));
+		}
+		connecting = loaded.odbc
+			.connect({
+				connectionString: config.connectionString,
+				connectionTimeout: config.connectionTimeout,
+				loginTimeout: config.loginTimeout,
+			})
+			.then(opened => {
+				connection = opened;
+				return opened;
+			})
+			.catch(error => {
+				// Allow a later request to retry rather than latching the first failure forever.
+				connecting = undefined;
+				throw error;
+			});
+	}
+	return connecting;
+}
+
+/** Runs one request against the connection. */
+async function handle(request: WorkerRequest): Promise<OdbcRow[]> {
+	if (request.kind === 'close') {
+		const open = connection;
+		connection = undefined;
+		connecting = undefined;
+		await open?.close();
+		return [];
+	}
+
+	const conn = await ensureConnected();
+
+	switch (request.kind) {
+		case 'ping':
+			return [];
+		case 'query':
+			// node-odbc types the bind array as (string | number)[], but the driver manager accepts
+			// a null bind for a nullable parameter, which the protocol allows and the types do not.
+			return (await conn.query(request.sql, (request.params ?? []) as (string | number)[])) as unknown as OdbcRow[];
+		case 'tables':
+			return (await conn.tables(request.catalog, request.schema, request.table, request.type)) as unknown as OdbcRow[];
+		case 'columns':
+			return (await conn.columns(request.catalog, request.schema, request.table, request.column)) as unknown as OdbcRow[];
+		case 'primaryKeys':
+			return (await conn.primaryKeys(request.catalog, request.schema, request.table)) as unknown as OdbcRow[];
+	}
+}
+
+// Requests are serialized onto a single chain. Driving one ODBC connection handle from several
+// statements concurrently is not safe in general, and what a driver does when you try is
+// vendor-specific, so the worker never has more than one request in flight.
+let queue: Promise<void> = Promise.resolve();
+
+process.on('message', (request: WorkerRequest) => {
+	queue = queue.then(async () => {
+		try {
+			const rows = await handle(request);
+			send({ kind: 'result', id: request.id, rows });
+		} catch (error) {
+			const { message, odbcErrors } = describeError(error);
+			send({
+				kind: 'error',
+				id: request.id,
+				error: message,
+				odbcErrors,
+				driverManagerMissing: isDriverManagerMissing(message) || undefined,
+			});
+		}
+	});
+});
+
+// If the host goes away, there is nothing left to serve. Close the connection so the server sees a
+// clean disconnect rather than an abandoned session, then exit.
+process.on('disconnect', () => {
+	const open = connection;
+	connection = undefined;
+	void Promise.resolve(open?.close()).catch(() => undefined).then(() => process.exit(0));
+});

--- a/extensions/positron-data-driver-odbc/src/odbcWorkerClient.ts
+++ b/extensions/positron-data-driver-odbc/src/odbcWorkerClient.ts
@@ -1,0 +1,205 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ChildProcess, fork } from 'child_process';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import {
+	OdbcBindValue,
+	OdbcErrorDetail,
+	OdbcRow,
+	WorkerConnectConfig,
+	WorkerRequest,
+	WorkerResponse
+} from './odbcWorkerProtocol';
+import { createWorkerEnv } from './workerEnv';
+
+/** An Error carrying the ODBC driver's own diagnostics, when it supplied any. */
+export type OdbcError = Error & {
+	odbcErrors?: OdbcErrorDetail[];
+	/** Set when the failure was the ODBC driver manager failing to load, not a connection problem. */
+	driverManagerMissing?: boolean;
+};
+
+/**
+ * The request surface the connection and schema-browsing code depends on. Implemented by
+ * OdbcWorkerClient; kept as an interface so the node builders and the table view can be
+ * unit-tested against a fake without forking a process.
+ */
+export interface IOdbcQueryClient {
+	/** Runs a SQL query with optional positional (`?`) parameters and returns its rows. */
+	runQuery(sql: string, params?: OdbcBindValue[]): Promise<OdbcRow[]>;
+
+	/** SQLTables. Nulls mean "any"; `type` is a comma-separated list such as `'TABLE,VIEW'`. */
+	tables(catalog: string | null, schema: string | null, table: string | null, type: string | null): Promise<OdbcRow[]>;
+
+	/** SQLColumns. */
+	columns(catalog: string | null, schema: string | null, table: string | null, column: string | null): Promise<OdbcRow[]>;
+
+	/** SQLPrimaryKeys. */
+	primaryKeys(catalog: string | null, schema: string | null, table: string): Promise<OdbcRow[]>;
+}
+
+/** How long to wait for a connection before giving up, in seconds. */
+const CONNECTION_TIMEOUT_SECONDS = 30;
+
+/**
+ * Host-side proxy for an ODBC connection. The native connection runs in a separate child process
+ * (`odbcWorker.ts`); this class forks it, forwards requests over IPC, and reconstructs results.
+ *
+ * Isolating the native binding means a faulty vendor driver takes down only the child. A native
+ * abort cannot be caught in-process, so the child dying is the only thing that keeps the extension
+ * host alive. When the worker dies, in-flight requests reject with a clear error, `onDidCrash`
+ * fires, and the next request transparently respawns it -- which also re-establishes the ODBC
+ * connection, since the worker connects on its first request.
+ */
+export class OdbcWorkerClient implements IOdbcQueryClient {
+	/** Resolved path to the bundled worker entry, emitted next to this module. */
+	private static readonly defaultWorkerPath = path.join(__dirname, 'odbcWorker.js');
+
+	private _worker: ChildProcess | undefined;
+	private _nextId = 0;
+	private readonly _pending = new Map<number, { resolve: (rows: OdbcRow[]) => void; reject: (error: Error) => void }>();
+	private _disposed = false;
+
+	private readonly _onDidCrash = new vscode.EventEmitter<void>();
+	/** Fires when the worker process terminates unexpectedly (e.g. a native abort in a driver). */
+	readonly onDidCrash: vscode.Event<void> = this._onDidCrash.event;
+
+	/**
+	 * @param _connectionString The full ODBC connection string the worker connects with.
+	 * @param _workerPath Overrides the worker entry point; exists only for tests (to exercise
+	 * crash recovery with a stub worker).
+	 */
+	constructor(
+		private readonly _connectionString: string,
+		private readonly _workerPath: string = OdbcWorkerClient.defaultWorkerPath
+	) { }
+
+	/** Whether a worker process is currently running. */
+	get isAlive(): boolean {
+		return !this._disposed && this._worker !== undefined;
+	}
+
+	private spawnWorker(): void {
+		// "advanced" serialization uses the V8 structured-clone algorithm, which preserves the
+		// bigint and Buffer values ODBC drivers return for large integer and binary columns. The
+		// connect config is passed as the first argument so the worker can connect immediately.
+		const config: WorkerConnectConfig = {
+			connectionString: this._connectionString,
+			connectionTimeout: CONNECTION_TIMEOUT_SECONDS,
+			loginTimeout: CONNECTION_TIMEOUT_SECONDS,
+		};
+		const worker = fork(
+			this._workerPath,
+			[JSON.stringify(config)],
+			{ serialization: 'advanced', execArgv: [], env: createWorkerEnv() }
+		);
+		worker.on('message', (message: unknown) => {
+			const response = message as WorkerResponse;
+			const pending = this._pending.get(response.id);
+			if (!pending) {
+				return;
+			}
+			this._pending.delete(response.id);
+			if (response.kind === 'result') {
+				pending.resolve(response.rows);
+			} else {
+				const error: OdbcError = new Error(response.error);
+				if (response.odbcErrors) {
+					error.odbcErrors = response.odbcErrors;
+				}
+				if (response.driverManagerMissing) {
+					error.driverManagerMissing = true;
+				}
+				pending.reject(error);
+			}
+		});
+		worker.on('exit', (code, signal) => this.onWorkerGone(`exited (code=${code}, signal=${signal})`));
+		worker.on('error', (error) => this.onWorkerGone(`failed to start: ${error.message}`));
+		this._worker = worker;
+	}
+
+	/**
+	 * Handle the worker process going away. Reject every in-flight request so callers fail
+	 * gracefully rather than hanging, and notify listeners. The worker is respawned lazily on the
+	 * next request.
+	 */
+	private onWorkerGone(detail: string): void {
+		if (this._worker === undefined) {
+			// Already handled (e.g. both 'error' and 'exit' fired), or disposed.
+			return;
+		}
+		this._worker = undefined;
+
+		const reason = new Error(`The ODBC process terminated unexpectedly (${detail}). This usually means the ODBC driver encountered a native fault.`);
+		for (const pending of this._pending.values()) {
+			pending.reject(reason);
+		}
+		this._pending.clear();
+
+		if (!this._disposed) {
+			this._onDidCrash.fire();
+		}
+	}
+
+	/** Closes the worker process and rejects any in-flight requests. */
+	dispose(): void {
+		this._disposed = true;
+		const worker = this._worker;
+		this._worker = undefined;
+		// Ask the worker to close the ODBC connection cleanly before it goes; the child exits on
+		// its own once the IPC channel is gone, and is killed below if it does not.
+		worker?.send({ kind: 'close', id: this._nextId++ } satisfies WorkerRequest);
+		worker?.disconnect();
+		worker?.kill();
+		for (const pending of this._pending.values()) {
+			pending.reject(new Error('The ODBC connection was disposed.'));
+		}
+		this._pending.clear();
+		this._onDidCrash.dispose();
+	}
+
+	/**
+	 * Sends a request, lazily (re)spawning the worker, e.g. after a crash. The caller supplies a
+	 * factory rather than a request so the id this class mints is part of the literal, which keeps
+	 * the request typed as a genuine WorkerRequest without an assertion.
+	 */
+	private send(makeRequest: (id: number) => WorkerRequest): Promise<OdbcRow[]> {
+		if (this._disposed) {
+			return Promise.reject(new Error('The ODBC connection was disposed.'));
+		}
+		if (this._worker === undefined) {
+			this.spawnWorker();
+		}
+
+		const id = this._nextId++;
+		return new Promise<OdbcRow[]>((resolve, reject) => {
+			this._pending.set(id, { resolve, reject });
+			this._worker!.send(makeRequest(id));
+		});
+	}
+
+	/** Establishes the connection, so connect() can fail fast with a real error. */
+	connect(): Promise<void> {
+		return this.send(id => ({ kind: 'ping', id })).then(() => undefined);
+	}
+
+	runQuery(sql: string, params?: OdbcBindValue[]): Promise<OdbcRow[]> {
+		return this.send(id => ({ kind: 'query', id, sql, params }));
+	}
+
+	tables(catalog: string | null, schema: string | null, table: string | null, type: string | null): Promise<OdbcRow[]> {
+		return this.send(id => ({ kind: 'tables', id, catalog, schema, table, type }));
+	}
+
+	columns(catalog: string | null, schema: string | null, table: string | null, column: string | null): Promise<OdbcRow[]> {
+		return this.send(id => ({ kind: 'columns', id, catalog, schema, table, column }));
+	}
+
+	primaryKeys(catalog: string | null, schema: string | null, table: string): Promise<OdbcRow[]> {
+		return this.send(id => ({ kind: 'primaryKeys', id, catalog, schema, table }));
+	}
+}

--- a/extensions/positron-data-driver-odbc/src/odbcWorkerProtocol.ts
+++ b/extensions/positron-data-driver-odbc/src/odbcWorkerProtocol.ts
@@ -1,0 +1,111 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Message shapes exchanged between the extension host and the ODBC child process (see
+// `odbcWorker.ts`). Messages use Node's "advanced" (V8 structured clone) serialization, so values
+// may include bigint and Buffer -- both of which ODBC drivers return for large integer and binary
+// columns.
+
+/**
+ * Worker connect configuration, passed to the child via fork argv (JSON encoded) so it can open
+ * the connection the moment it starts.
+ */
+export interface WorkerConnectConfig {
+	/** The full ODBC connection string, e.g. `DSN=Pagila;UID=brian`. */
+	connectionString: string;
+
+	/**
+	 * Milliseconds to wait for the connection to be established. ODBC's own default is "wait
+	 * forever", which would hang the pane on an unreachable server with no way back.
+	 */
+	connectionTimeout: number;
+
+	/** Milliseconds a single statement may run before the driver aborts it. */
+	loginTimeout: number;
+}
+
+/** A value that can be bound to a positional (`?`) parameter. */
+export type OdbcBindValue = string | number | null;
+
+/** A materialized result row, keyed by column name. */
+export type OdbcRow = Record<string, unknown>;
+
+/**
+ * Host -> worker. Every request carries an `id` the response echoes back. The worker serializes
+ * requests: an ODBC connection handle is not safe to drive from several statements at once, and
+ * the driver's behavior when you try is vendor-specific.
+ */
+export type WorkerRequest =
+	| {
+		kind: 'query';
+		id: number;
+		sql: string;
+		/** Positional parameters bound to `?` placeholders in the SQL, in order. */
+		params?: OdbcBindValue[];
+	}
+	| {
+		// SQLTables. Nulls mean "any"; the empty string means "those with no catalog/schema".
+		kind: 'tables';
+		id: number;
+		catalog: string | null;
+		schema: string | null;
+		table: string | null;
+		/** Comma-separated table types, e.g. `'TABLE,VIEW'`. Null means every type. */
+		type: string | null;
+	}
+	| {
+		// SQLColumns.
+		kind: 'columns';
+		id: number;
+		catalog: string | null;
+		schema: string | null;
+		table: string | null;
+		column: string | null;
+	}
+	| {
+		// SQLPrimaryKeys, used to mark primary key columns in the tree.
+		kind: 'primaryKeys';
+		id: number;
+		catalog: string | null;
+		schema: string | null;
+		table: string;
+	}
+	| {
+		/** Establishes the connection if it is not up yet, and reports whether it is usable. */
+		kind: 'ping';
+		id: number;
+	}
+	| {
+		kind: 'close';
+		id: number;
+	};
+
+/** One diagnostic record from the ODBC driver, as node-odbc surfaces them. */
+export interface OdbcErrorDetail {
+	state?: string;
+	code?: number;
+	message?: string;
+}
+
+/** Worker -> host: the result (or failure) for the request with the matching `id`. */
+export type WorkerResponse =
+	| {
+		kind: 'result';
+		id: number;
+		rows: OdbcRow[];
+	}
+	| {
+		kind: 'error';
+		id: number;
+		/** Human-readable message, already flattened from the ODBC diagnostic records. */
+		error: string;
+		/** The raw ODBC diagnostics, for the driver log. */
+		odbcErrors?: OdbcErrorDetail[];
+		/**
+		 * Set when the failure was the ODBC driver manager itself failing to load, rather than a
+		 * connection problem. The host turns this into install guidance instead of a SQL error.
+		 */
+		driverManagerMissing?: boolean;
+	};

--- a/extensions/positron-data-driver-odbc/src/odbcinst.ts
+++ b/extensions/positron-data-driver-odbc/src/odbcinst.ts
@@ -1,0 +1,382 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Discovery of the ODBC configuration on this machine: which ODBC drivers are installed, and
+// which data sources (DSNs) are defined.
+//
+// "Driver" is overloaded here. Throughout this extension, an *ODBC driver* is the vendor library
+// (libsnowflakeodbc.dylib, psqlodbcw.so, ...) named in odbcinst.ini; a *Positron driver* is what
+// odbcDriver.ts registers with positron.dataConnections. This module only deals in the former.
+//
+// Everything here is a pure function over an injected IOdbcConfigHost, so the parsing and the
+// precedence rules can be unit-tested against fixtures without touching the real filesystem or
+// registry.
+
+import * as path from 'path';
+
+/** An ODBC driver installed on this machine, as declared in odbcinst.ini (or the registry). */
+export interface OdbcDriverEntry {
+	/** The section name, which is what a DSN's `Driver=` refers to (e.g. "PostgreSQL Unicode"). */
+	readonly name: string;
+
+	/** The driver's `Description`, when it declares one. */
+	readonly description?: string;
+
+	/** The path to the driver library. Absent when the entry declares no `Driver` key. */
+	readonly driverPath?: string;
+
+	/** Where the entry came from. User entries shadow system entries of the same name. */
+	readonly scope: OdbcConfigScope;
+
+	/** Every key/value in the section, keys lowercased. Retained for the mechanisms to draw on. */
+	readonly attributes: Readonly<Record<string, string>>;
+}
+
+/** A data source defined in odbc.ini (or the registry). */
+export interface OdbcDsnEntry {
+	/** The DSN name, which is what `DSN=` in a connection string refers to. */
+	readonly name: string;
+
+	/** The DSN's `Description`, when it declares one. */
+	readonly description?: string;
+
+	/** The name of the ODBC driver this DSN uses, from its `Driver` key. */
+	readonly driverName?: string;
+
+	/** Where the entry came from. User entries shadow system entries of the same name. */
+	readonly scope: OdbcConfigScope;
+
+	/** Every key/value in the section, keys lowercased. Used to summarize the DSN in the pane. */
+	readonly attributes: Readonly<Record<string, string>>;
+}
+
+/**
+ * Whether an entry came from the per-user configuration or the machine-wide one. A user entry
+ * shadows a system entry with the same name, matching unixODBC's own lookup order.
+ */
+export type OdbcConfigScope = 'user' | 'system';
+
+/** The discovered ODBC configuration. */
+export interface OdbcConfiguration {
+	readonly drivers: readonly OdbcDriverEntry[];
+	readonly dsns: readonly OdbcDsnEntry[];
+
+	/** The files and registry keys the configuration was read from, in order. For logging. */
+	readonly sources: readonly string[];
+}
+
+/**
+ * The host services discovery needs. Injected so tests can supply fixtures; `createNodeConfigHost`
+ * returns the real implementation.
+ */
+export interface IOdbcConfigHost {
+	/** The platform to resolve configuration for. */
+	readonly platform: NodeJS.Platform;
+
+	/** Reads a file, returning undefined when it does not exist or cannot be read. */
+	readFile(filePath: string): string | undefined;
+
+	/** Whether a path exists. Used to drop entries whose driver library is gone. */
+	exists(filePath: string): boolean;
+
+	/** The current user's home directory, where the per-user ini files live. */
+	homeDir(): string;
+
+	/** Reads an environment variable. */
+	env(name: string): string | undefined;
+
+	/**
+	 * Enumerates the Windows ODBC registry. Returns undefined off Windows, or when the registry
+	 * could not be read.
+	 */
+	readRegistry(): OdbcRegistrySnapshot | undefined;
+}
+
+/**
+ * The shape discovery needs out of the Windows registry: the two index keys ("ODBC Drivers" and
+ * "ODBC Data Sources") plus the per-entry attribute keys beneath each hive.
+ */
+export interface OdbcRegistrySnapshot {
+	/** Driver name -> its attributes, from HKLM\SOFTWARE\ODBC\ODBCINST.INI. */
+	readonly drivers: Record<string, Record<string, string>>;
+
+	/** DSN name -> its attributes, from HKCU (user) and HKLM (system) SOFTWARE\ODBC\ODBC.INI. */
+	readonly userDsns: Record<string, Record<string, string>>;
+	readonly systemDsns: Record<string, Record<string, string>>;
+}
+
+// --- INI parsing ---
+
+/**
+ * Parses an ODBC ini file into sections. The format is the usual `[Section]` / `key = value`, with
+ * `;` and `#` starting a comment. Keys are lowercased because ODBC treats them case-insensitively
+ * (a DSN may spell it `Driver`, `DRIVER`, or `driver`); section names are preserved as written,
+ * since they are the user-facing driver and DSN names.
+ *
+ * Exported for tests.
+ */
+export function parseIni(contents: string): Record<string, Record<string, string>> {
+	const sections: Record<string, Record<string, string>> = {};
+	let current: Record<string, string> | undefined;
+
+	for (const rawLine of contents.split(/\r?\n/)) {
+		const line = rawLine.trim();
+		if (line.length === 0 || line.startsWith(';') || line.startsWith('#')) {
+			continue;
+		}
+
+		const sectionMatch = /^\[(?<name>[^\]]*)\]$/.exec(line);
+		if (sectionMatch) {
+			const name = (sectionMatch.groups?.name ?? '').trim();
+			// A repeated section merges into the first, which is what unixODBC does.
+			current = sections[name] ??= {};
+			continue;
+		}
+
+		// A key/value outside any section is not meaningful in an ODBC ini; skip it.
+		if (current === undefined) {
+			continue;
+		}
+
+		const separator = line.indexOf('=');
+		if (separator === -1) {
+			continue;
+		}
+		const key = line.slice(0, separator).trim().toLowerCase();
+		if (key.length > 0) {
+			current[key] = line.slice(separator + 1).trim();
+		}
+	}
+
+	return sections;
+}
+
+/**
+ * The section names unixODBC uses for its own bookkeeping rather than for a driver or a DSN.
+ * `[ODBC Data Sources]` and `[ODBC Drivers]` are indexes of the other sections, and `[ODBC]` holds
+ * driver-manager settings such as tracing. None of them describe something connectable.
+ */
+const RESERVED_SECTIONS = new Set(['odbc', 'odbc data sources', 'odbc drivers', 'default']);
+
+function isReservedSection(name: string): boolean {
+	return RESERVED_SECTIONS.has(name.trim().toLowerCase());
+}
+
+// --- unix path resolution ---
+
+/**
+ * Candidate directories for the machine-wide ini files when `ODBCSYSINI` is unset. unixODBC bakes
+ * its SYSCONFDIR in at compile time, so the right directory depends on how it was installed:
+ * `/etc` for a distribution package (and for the Workbench `rstudio-drivers` install), and the
+ * Homebrew prefixes on macOS. All of them are checked, nearest-first, rather than guessing one.
+ */
+const SYSTEM_CONFIG_DIRS = ['/etc', '/usr/local/etc', '/opt/homebrew/etc'];
+
+/**
+ * Resolves the ini files to read on a unix-like platform, in the order their entries should be
+ * applied (system first, then user, so user entries win).
+ *
+ * Honors the three unixODBC environment variables:
+ * - `ODBCSYSINI` overrides the directory holding the system `odbc.ini` and `odbcinst.ini`.
+ * - `ODBCINSTINI` overrides the system driver file; relative values resolve against ODBCSYSINI.
+ * - `ODBCINI` overrides the *user* DSN file outright, and is an absolute path.
+ *
+ * Exported for tests.
+ */
+export function resolveUnixConfigPaths(host: IOdbcConfigHost): {
+	systemDrivers: string[];
+	systemDsns: string[];
+	userDrivers: string[];
+	userDsns: string[];
+} {
+	const sysIni = host.env('ODBCSYSINI');
+	const systemDirs = sysIni ? [sysIni] : SYSTEM_CONFIG_DIRS;
+
+	const instIni = host.env('ODBCINSTINI');
+	const systemDrivers = instIni
+		? (path.isAbsolute(instIni) ? [instIni] : systemDirs.map(dir => path.join(dir, instIni)))
+		: systemDirs.map(dir => path.join(dir, 'odbcinst.ini'));
+
+	const systemDsns = systemDirs.map(dir => path.join(dir, 'odbc.ini'));
+
+	const home = host.homeDir();
+	const userDsnOverride = host.env('ODBCINI');
+
+	return {
+		systemDrivers,
+		systemDsns,
+		// There is no environment override for the per-user driver file.
+		userDrivers: [path.join(home, '.odbcinst.ini')],
+		userDsns: userDsnOverride ? [userDsnOverride] : [path.join(home, '.odbc.ini')],
+	};
+}
+
+// --- Discovery ---
+
+/**
+ * Reads the ODBC configuration for this machine.
+ *
+ * Entries whose driver library no longer exists are dropped: a driver uninstalled without its
+ * odbcinst.ini entry being cleaned up is common, and offering it would produce a connection that
+ * can only fail. DSNs are kept even when their driver is missing, so the pane can explain why one
+ * it used to be able to reach no longer works.
+ */
+export function discoverOdbcConfiguration(host: IOdbcConfigHost): OdbcConfiguration {
+	return host.platform === 'win32' ? discoverWindows(host) : discoverUnix(host);
+}
+
+function discoverUnix(host: IOdbcConfigHost): OdbcConfiguration {
+	const paths = resolveUnixConfigPaths(host);
+	const sources: string[] = [];
+
+	// Later reads overwrite earlier ones, so system is read before user.
+	const driverSections = new Map<string, { section: Record<string, string>; scope: OdbcConfigScope }>();
+	const dsnSections = new Map<string, { section: Record<string, string>; scope: OdbcConfigScope }>();
+
+	const readInto = (
+		target: Map<string, { section: Record<string, string>; scope: OdbcConfigScope }>,
+		filePaths: readonly string[],
+		scope: OdbcConfigScope
+	) => {
+		for (const filePath of filePaths) {
+			const contents = host.readFile(filePath);
+			if (contents === undefined) {
+				continue;
+			}
+			sources.push(filePath);
+			for (const [name, section] of Object.entries(parseIni(contents))) {
+				if (!isReservedSection(name)) {
+					target.set(name, { section, scope });
+				}
+			}
+		}
+	};
+
+	readInto(driverSections, paths.systemDrivers, 'system');
+	readInto(driverSections, paths.userDrivers, 'user');
+	readInto(dsnSections, paths.systemDsns, 'system');
+	readInto(dsnSections, paths.userDsns, 'user');
+
+	const drivers = buildDrivers(host, driverSections);
+	const dsns = buildDsns(dsnSections);
+
+	return { drivers, dsns, sources };
+}
+
+function discoverWindows(host: IOdbcConfigHost): OdbcConfiguration {
+	const registry = host.readRegistry();
+	if (registry === undefined) {
+		return { drivers: [], dsns: [], sources: [] };
+	}
+
+	const driverSections = new Map<string, { section: Record<string, string>; scope: OdbcConfigScope }>();
+	for (const [name, section] of Object.entries(registry.drivers)) {
+		if (!isReservedSection(name)) {
+			// Windows has no per-user driver registration in practice; drivers are machine-wide.
+			driverSections.set(name, { section: lowercaseKeys(section), scope: 'system' });
+		}
+	}
+
+	const dsnSections = new Map<string, { section: Record<string, string>; scope: OdbcConfigScope }>();
+	for (const [name, section] of Object.entries(registry.systemDsns)) {
+		if (!isReservedSection(name)) {
+			dsnSections.set(name, { section: lowercaseKeys(section), scope: 'system' });
+		}
+	}
+	// User DSNs shadow system DSNs of the same name, as they do on unix.
+	for (const [name, section] of Object.entries(registry.userDsns)) {
+		if (!isReservedSection(name)) {
+			dsnSections.set(name, { section: lowercaseKeys(section), scope: 'user' });
+		}
+	}
+
+	return {
+		drivers: buildDrivers(host, driverSections),
+		dsns: buildDsns(dsnSections),
+		sources: ['HKLM\\SOFTWARE\\ODBC\\ODBCINST.INI', 'HKLM\\SOFTWARE\\ODBC\\ODBC.INI', 'HKCU\\SOFTWARE\\ODBC\\ODBC.INI'],
+	};
+}
+
+function lowercaseKeys(section: Record<string, string>): Record<string, string> {
+	const result: Record<string, string> = {};
+	for (const [key, value] of Object.entries(section)) {
+		result[key.toLowerCase()] = value;
+	}
+	return result;
+}
+
+function buildDrivers(
+	host: IOdbcConfigHost,
+	sections: Map<string, { section: Record<string, string>; scope: OdbcConfigScope }>
+): OdbcDriverEntry[] {
+	const drivers: OdbcDriverEntry[] = [];
+	for (const [name, { section, scope }] of sections) {
+		const driverPath = section['driver'];
+
+		// Drop entries whose library is gone. A driver uninstalled without its odbcinst.ini entry
+		// being removed is common enough that offering it would mostly produce failed connections.
+		if (driverPath !== undefined && !host.exists(driverPath)) {
+			continue;
+		}
+
+		drivers.push({
+			name,
+			description: section['description'],
+			driverPath,
+			scope,
+			attributes: section,
+		});
+	}
+	return drivers.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function buildDsns(
+	sections: Map<string, { section: Record<string, string>; scope: OdbcConfigScope }>
+): OdbcDsnEntry[] {
+	const dsns: OdbcDsnEntry[] = [];
+	for (const [name, { section, scope }] of sections) {
+		dsns.push({
+			name,
+			description: section['description'],
+			driverName: section['driver'],
+			scope,
+			attributes: section,
+		});
+	}
+	return dsns.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+// --- Summaries ---
+
+/**
+ * Builds a one-line summary of where a DSN points, for the pane to show beneath its name (e.g.
+ * "localhost:5432/pagila"). DSN attribute names are not standardized across ODBC drivers, so each
+ * field is looked up under the several spellings drivers actually use. Returns undefined when the
+ * DSN declares nothing recognizable.
+ */
+export function summarizeDsn(dsn: OdbcDsnEntry): string | undefined {
+	const attribute = (...keys: string[]): string | undefined => {
+		for (const key of keys) {
+			const value = dsn.attributes[key];
+			if (value !== undefined && value.length > 0) {
+				return value;
+			}
+		}
+		return undefined;
+	};
+
+	const server = attribute('server', 'servername', 'host', 'hostname');
+	const port = attribute('port', 'portnumber');
+	const database = attribute('database', 'databasename', 'db');
+
+	const endpoint = server === undefined
+		? undefined
+		: port === undefined ? server : `${server}:${port}`;
+
+	if (endpoint !== undefined && database !== undefined) {
+		return `${endpoint}/${database}`;
+	}
+	return endpoint ?? database ?? dsn.description;
+}

--- a/extensions/positron-data-driver-odbc/src/test/README.md
+++ b/extensions/positron-data-driver-odbc/src/test/README.md
@@ -1,0 +1,7 @@
+Launch tests by running this from the repository root:
+
+    npm run test-extension -- -l positron-data-driver-odbc
+
+These tests use fixtures throughout: discovery runs against an injected `IOdbcConfigHost`, and the
+driver is built from a synthetic `OdbcConfiguration`. Nothing here needs unixODBC installed or a
+database to connect to.

--- a/extensions/positron-data-driver-odbc/src/test/dataConnectionIntegration.test.ts
+++ b/extensions/positron-data-driver-odbc/src/test/dataConnectionIntegration.test.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Exercises the real registration path: the extension activates, discovers whatever ODBC
+// configuration this machine has, and registers its drivers through positron.dataConnections.
+//
+// What this machine has is not something a test can assume -- a CI runner has no ODBC drivers and
+// no data sources, a developer's laptop may have several -- so the assertions here are about the
+// shape the driver always presents, not about any particular driver or DSN being present. The
+// fixture-driven tests in odbcinst.test.ts cover the discovery logic itself.
+
+import * as assert from 'assert';
+import * as positron from 'positron';
+import * as vscode from 'vscode';
+
+const GENERIC_ODBC_DRIVER_ID = 'positron-data-driver-odbc';
+
+suite('Data Connection Integration', () => {
+	setup(async () => {
+		// Ensure the extension is activated so its drivers are registered.
+		await vscode.extensions.getExtension('positron.positron-data-driver-odbc')?.activate();
+	});
+
+	test('registers the generic ODBC driver', async () => {
+		const drivers = await positron.dataConnections.getDrivers();
+		const odbc = drivers.find(driver => driver.id === GENERIC_ODBC_DRIVER_ID);
+
+		assert.ok(odbc, 'the generic ODBC driver should be registered');
+		assert.deepStrictEqual(
+			{ name: odbc.name, languages: odbc.supportedLanguageIds },
+			{ name: 'ODBC', languages: ['python', 'r'] }
+		);
+	});
+
+	test('always offers the connection-string mechanism, whatever this machine has configured', async () => {
+		const drivers = await positron.dataConnections.getDrivers();
+		const odbc = drivers.find(driver => driver.id === GENERIC_ODBC_DRIVER_ID)!;
+
+		// The DSN and driver mechanisms depend on the machine; the connection-string mechanism is
+		// the one that is always available, and is all a machine with no ODBC configuration gets.
+		const connectionString = odbc.mechanisms.find(mechanism => mechanism.id === 'connectionString');
+		assert.ok(connectionString, 'the connection-string mechanism should always be offered');
+		assert.deepStrictEqual(
+			connectionString.parameters.map(parameter => ({ id: parameter.id, required: parameter.required })),
+			[{ id: 'connectionString', required: true }]
+		);
+	});
+
+	test('offers no mechanism with an empty picker', async () => {
+		const drivers = await positron.dataConnections.getDrivers();
+
+		// A machine with no data sources must not be shown a "Data Source" dropdown with nothing in
+		// it, and likewise for ODBC drivers. Whichever mechanisms this machine ended up with, none
+		// of their option parameters may be empty.
+		for (const driver of drivers.filter(candidate => candidate.id.startsWith(GENERIC_ODBC_DRIVER_ID))) {
+			for (const mechanism of driver.mechanisms) {
+				for (const parameter of mechanism.parameters) {
+					if (parameter.type === positron.DataConnectionParameterType.Option) {
+						assert.ok(
+							parameter.options.length > 0,
+							`${driver.id}/${mechanism.id}/${parameter.id} offers an empty picker`
+						);
+					}
+				}
+			}
+		}
+	});
+});

--- a/extensions/positron-data-driver-odbc/src/test/odbcDriver.test.ts
+++ b/extensions/positron-data-driver-odbc/src/test/odbcDriver.test.ts
@@ -1,0 +1,242 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { buildConnectionString, parseConnectionString, redactConnectionString } from '../odbcConnectionString.js';
+import { createOdbcDrivers, GENERIC_ODBC_DRIVER_ID } from '../odbcDriver.js';
+import { DEFAULT_DIALECT, findDatabaseProfile, groupDriversByDatabase, resolveDialect } from '../odbcDatabases.js';
+import { OdbcConfiguration } from '../odbcinst.js';
+
+// A no-op Data Explorer host: these tests exercise driver construction and code generation, not
+// previewing, and a real handler would register a provider that collides with the activated
+// extension's.
+const noopHost = {
+	openTableView: async () => { },
+	openColumnView: async () => { },
+	closeTableView: () => { },
+};
+
+/** The extension context, needed only so the driver can read its icon off disk. */
+function testContext(): vscode.ExtensionContext {
+	const extension = vscode.extensions.getExtension('positron.positron-data-driver-odbc');
+	assert.ok(extension, 'the ODBC driver extension should be present');
+	// eslint-disable-next-line local/code-no-any-casts
+	return { extensionPath: extension.extensionPath } as any;
+}
+
+function driverEntry(name: string) {
+	return { name, driverPath: `/usr/lib/${name}.so`, scope: 'system' as const, attributes: {} };
+}
+
+function dsnEntry(name: string, driverName: string, attributes: Record<string, string> = {}) {
+	return { name, driverName, scope: 'user' as const, attributes: { driver: driverName, ...attributes } };
+}
+
+const CONFIG: OdbcConfiguration = {
+	drivers: [
+		driverEntry('PostgreSQL Unicode'),
+		driverEntry('MySQL ODBC 8.0 Unicode Driver'),
+		driverEntry('MySQL ODBC 8.0 ANSI Driver'),
+	],
+	dsns: [dsnEntry('Pagila', 'PostgreSQL Unicode', { servername: 'localhost', port: '5432', database: 'pagila' })],
+	sources: ['/etc/odbcinst.ini'],
+};
+
+suite('connection strings', () => {
+	test('brace-wraps the driver name and any value that needs it, and round-trips them', () => {
+		const connectionString = buildConnectionString([
+			['Driver', 'PostgreSQL Unicode'],
+			['Servername', 'localhost'],
+			['PWD', 'p;a}ss'],
+			['Empty', ''],
+			['Missing', undefined],
+		]);
+
+		assert.strictEqual(connectionString, 'Driver={PostgreSQL Unicode};Servername=localhost;PWD={p;a}}ss}');
+		assert.deepStrictEqual(parseConnectionString(connectionString), {
+			driver: 'PostgreSQL Unicode',
+			servername: 'localhost',
+			pwd: 'p;a}ss',
+		});
+	});
+
+	test('braces a value carrying an ODBC special character, and never braces twice', () => {
+		// "(x64)" is the case that matters: 64-bit Windows driver names routinely carry it, and the
+		// parentheses oblige the value to be brace-wrapped.
+		const connectionString = buildConnectionString([
+			['Driver', 'PostgreSQL Unicode(x64)'],
+			['DSN', 'Plain'],
+			['Extra', 'a=b'],
+		]);
+
+		assert.strictEqual(connectionString, 'Driver={PostgreSQL Unicode(x64)};DSN=Plain;Extra={a=b}');
+		assert.deepStrictEqual(parseConnectionString(connectionString), {
+			driver: 'PostgreSQL Unicode(x64)',
+			dsn: 'Plain',
+			extra: 'a=b',
+		});
+	});
+
+	test('redacts an embedded password in place, leaving the rest of the string as typed', () => {
+		assert.deepStrictEqual(
+			{
+				withPassword: redactConnectionString('DSN=Pagila;UID=brian;PWD=hunter2'),
+				withoutPassword: redactConnectionString('DSN=Pagila;UID=brian'),
+				// The surrounding text keeps its own capitalization, spacing, and bracing, and a
+				// brace-wrapped password is consumed whole rather than up to the first semicolon.
+				verbatim: redactConnectionString('Driver={PostgreSQL Unicode}; uid = brian ; Password={p;a}}ss};Extra=1'),
+			},
+			{
+				withPassword: 'DSN=Pagila;UID=brian;PWD=****',
+				withoutPassword: 'DSN=Pagila;UID=brian',
+				verbatim: 'Driver={PostgreSQL Unicode}; uid = brian ; Password=****;Extra=1',
+			}
+		);
+	});
+});
+
+suite('database profiles', () => {
+	test('matches driver names to databases, preferring the more specific pattern', () => {
+		assert.deepStrictEqual(
+			[
+				'MySQL ODBC 8.0 Unicode Driver',
+				'MariaDB ODBC 3.1 Driver',
+				'ODBC Driver 18 for SQL Server',
+				'Simba Snowflake ODBC Driver',
+				'Some Unknown Driver',
+			].map(name => findDatabaseProfile(name)?.id),
+			['mysql', 'mariadb', 'sqlserver', 'snowflake', undefined]
+		);
+	});
+
+	test('resolves dialects, falling back to the SQL standard for an unknown driver', () => {
+		assert.deepStrictEqual(
+			{
+				mysql: resolveDialect('MySQL ODBC 8.0 Unicode Driver'),
+				sqlserver: resolveDialect('ODBC Driver 18 for SQL Server'),
+				postgres: resolveDialect('PostgreSQL Unicode'),
+				unknown: resolveDialect('Some Unknown Driver'),
+			},
+			{
+				mysql: { identifierQuote: '`', pagination: 'limit-offset' },
+				sqlserver: { identifierQuote: '"', pagination: 'offset-fetch' },
+				postgres: { identifierQuote: '"', pagination: 'limit-offset' },
+				unknown: DEFAULT_DIALECT,
+			}
+		);
+	});
+
+	test('groups installed drivers by database, excluding those with a native Positron driver', () => {
+		assert.deepStrictEqual(
+			groupDriversByDatabase(CONFIG.drivers).map(group => ({
+				id: group.profile.id,
+				drivers: group.drivers.map(driver => driver.name),
+			})),
+			// PostgreSQL is excluded: Positron ships a native driver for it, and a second
+			// "PostgreSQL" entry in the New Connection list would be worse than useless.
+			[{ id: 'mysql', drivers: ['MySQL ODBC 8.0 Unicode Driver', 'MySQL ODBC 8.0 ANSI Driver'] }]
+		);
+	});
+});
+
+suite('createOdbcDrivers', () => {
+	test('registers the generic driver plus one per recognized database', () => {
+		const drivers = createOdbcDrivers(testContext(), CONFIG, noopHost);
+
+		assert.deepStrictEqual(
+			drivers.map(driver => ({ id: driver.id, name: driver.name, mechanisms: driver.mechanisms.map(m => m.id) })),
+			[
+				{ id: GENERIC_ODBC_DRIVER_ID, name: 'ODBC', mechanisms: ['dsn', 'driver', 'connectionString'] },
+				// The per-database driver offers no DSN mechanism: data sources belong to the
+				// generic driver, so they appear in the pane exactly once.
+				{ id: `${GENERIC_ODBC_DRIVER_ID}-mysql`, name: 'MySQL', mechanisms: ['driver', 'connectionString'] },
+			]
+		);
+	});
+
+	test('offers only the connection-string mechanism when nothing was discovered', () => {
+		const drivers = createOdbcDrivers(testContext(), { drivers: [], dsns: [], sources: [] }, noopHost);
+
+		assert.deepStrictEqual(
+			drivers.map(driver => ({ id: driver.id, mechanisms: driver.mechanisms.map(m => m.id) })),
+			[{ id: GENERIC_ODBC_DRIVER_ID, mechanisms: ['connectionString'] }]
+		);
+	});
+
+	test('reports every DSN as a discovered connection, from the generic driver only', async () => {
+		const drivers = createOdbcDrivers(testContext(), CONFIG, noopHost);
+
+		assert.deepStrictEqual(
+			await Promise.all(drivers.map(async driver => ({
+				id: driver.id,
+				discovered: await driver.discoverConnections!(),
+			}))),
+			[
+				{
+					id: GENERIC_ODBC_DRIVER_ID,
+					discovered: [{
+						id: 'odbc-dsn:Pagila',
+						name: 'Pagila',
+						description: 'localhost:5432/pagila',
+						mechanismId: 'dsn',
+						parameters: { dsn: 'Pagila' },
+					}],
+				},
+				{ id: `${GENERIC_ODBC_DRIVER_ID}-mysql`, discovered: [] },
+			]
+		);
+	});
+
+	test('generates R and Python code from each mechanism', async () => {
+		const [generic] = createOdbcDrivers(testContext(), CONFIG, noopHost);
+
+		const rFromDsn = await generic.generateConnectionCode!('dsn', 'r', { dsn: 'Pagila', user: 'brian' });
+		const pythonFromDriver = await generic.generateConnectionCode!('driver', 'python', {
+			odbcDriver: 'PostgreSQL Unicode',
+			server: 'localhost',
+			port: 5432,
+			database: 'pagila',
+			user: 'brian',
+			password: 'hunter2',
+		});
+
+		assert.deepStrictEqual(
+			{
+				rVariants: rFromDsn.map(variant => variant.id),
+				rCode: rFromDsn[0].code,
+				pythonVariants: pythonFromDriver.map(variant => variant.id),
+				pythonCode: pythonFromDriver[0].code,
+			},
+			{
+				rVariants: ['dbi'],
+				rCode: 'library(DBI)\n\ncon <- dbConnect(\n\todbc::odbc(),\n\t.connection_string = "DSN=Pagila;UID=brian"\n)\n',
+				pythonVariants: ['pyodbc', 'sqlalchemy'],
+				// The PostgreSQL profile's attribute names are used, not the generic fallback:
+				// psqlodbc wants Servername, not Server.
+				pythonCode: 'import pyodbc\n\nconn = pyodbc.connect("Driver={PostgreSQL Unicode};Servername=localhost;Port=5432;Database=pagila;UID=brian;PWD=hunter2")\n',
+			}
+		);
+	});
+
+	test('generates nothing when a required parameter is missing, and redacts only the connection string', async () => {
+		const [generic] = createOdbcDrivers(testContext(), CONFIG, noopHost);
+
+		assert.deepStrictEqual(
+			{
+				noServer: await generic.generateConnectionCode!('driver', 'r', { odbcDriver: 'PostgreSQL Unicode' }),
+				unsupportedLanguage: await generic.generateConnectionCode!('dsn', 'julia', { dsn: 'Pagila' }),
+				redactedString: generic.redactParameterValue!('connectionString', 'connectionString', 'DSN=Pagila;PWD=hunter2'),
+				redactedOther: generic.redactParameterValue!('dsn', 'password', 'hunter2'),
+			},
+			{
+				noServer: [],
+				unsupportedLanguage: [],
+				redactedString: 'DSN=Pagila;PWD=****',
+				redactedOther: undefined,
+			}
+		);
+	});
+});

--- a/extensions/positron-data-driver-odbc/src/test/odbcDriver.test.ts
+++ b/extensions/positron-data-driver-odbc/src/test/odbcDriver.test.ts
@@ -190,6 +190,36 @@ suite('createOdbcDrivers', () => {
 		);
 	});
 
+	test('offers no Port field for SQL Server, whose driver has no Port keyword', async () => {
+		// Microsoft's driver takes the port inside Server (`Server=myhost,1433`) and has no Port
+		// connection-string keyword, so offering one would emit an attribute it ignores and produce
+		// a failing connection with nothing in the form to explain it. Guards the profile against a
+		// well-meaning "the default port is missing" fix.
+		const config: OdbcConfiguration = {
+			drivers: [driverEntry('ODBC Driver 18 for SQL Server'), driverEntry('MySQL ODBC 8.0 Unicode Driver')],
+			dsns: [],
+			sources: [],
+		};
+		const drivers = createOdbcDrivers(testContext(), config, noopHost);
+
+		const parameterIds = (driverId: string) => drivers
+			.find(driver => driver.id === driverId)!
+			.mechanisms.find(mechanism => mechanism.id === 'driver')!
+			.parameters.map(parameter => parameter.id);
+
+		assert.deepStrictEqual(
+			{
+				sqlServer: parameterIds(`${GENERIC_ODBC_DRIVER_ID}-sqlserver`),
+				// MySQL does take a separate Port, so the difference is per-database, not global.
+				mysql: parameterIds(`${GENERIC_ODBC_DRIVER_ID}-mysql`),
+			},
+			{
+				sqlServer: ['server', 'database', 'user', 'password'],
+				mysql: ['server', 'port', 'database', 'user', 'password'],
+			}
+		);
+	});
+
 	test('generates R and Python code from each mechanism', async () => {
 		const [generic] = createOdbcDrivers(testContext(), CONFIG, noopHost);
 

--- a/extensions/positron-data-driver-odbc/src/test/odbcNodes.test.ts
+++ b/extensions/positron-data-driver-odbc/src/test/odbcNodes.test.ts
@@ -1,0 +1,229 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as positron from 'positron';
+import { createRootNodes, fetchTables, formatDataType, OdbcTableRef } from '../odbcNodes.js';
+import { buildOdbcSchema } from '../odbcDataExplorerRpcHandler.js';
+import { IOdbcQueryClient } from '../odbcWorkerClient.js';
+import { OdbcRow } from '../odbcWorkerProtocol.js';
+
+/** A fake query client backed by fixed SQLTables / SQLColumns rows. */
+function createFakeClient(options: {
+	tables?: OdbcRow[];
+	columns?: OdbcRow[];
+	primaryKeys?: OdbcRow[] | 'unsupported';
+}): IOdbcQueryClient {
+	return {
+		runQuery: async () => [],
+		tables: async () => options.tables ?? [],
+		columns: async () => options.columns ?? [],
+		primaryKeys: async () => {
+			if (options.primaryKeys === 'unsupported') {
+				throw new Error('SQLPrimaryKeys is not supported by this driver');
+			}
+			return options.primaryKeys ?? [];
+		},
+	};
+}
+
+/** Walks a node tree into a compact `name (kind)` outline, so one assertion covers the shape. */
+async function outline(nodes: readonly positron.DataConnectionNode[], depth = 0): Promise<string[]> {
+	const lines: string[] = [];
+	for (const node of nodes) {
+		lines.push(`${'  '.repeat(depth)}${node.name} (${node.kind})${node.dataType ? `: ${node.dataType}` : ''}${node.isPrimaryKey ? ' [pk]' : ''}`);
+		if (node.getChildren) {
+			lines.push(...await outline(await node.getChildren(), depth + 1));
+		}
+	}
+	return lines;
+}
+
+const noopPreviewHost = {
+	previewObject: async () => 'noop-dataset',
+	previewColumn: async () => 'noop-dataset',
+};
+
+function tableRow(cat: string | null, schema: string | null, name: string, type = 'TABLE'): OdbcRow {
+	return { TABLE_CAT: cat, TABLE_SCHEM: schema, TABLE_NAME: name, TABLE_TYPE: type };
+}
+
+suite('fetchTables', () => {
+	test('normalizes catalog and schema, classifies views, and drops nameless rows', async () => {
+		const client = createFakeClient({
+			tables: [
+				tableRow('pagila', 'public', 'actor'),
+				tableRow(null, '', 'orphan'),
+				tableRow('pagila', 'public', 'actor_info', 'VIEW'),
+				tableRow('pagila', 'public', '', 'TABLE'),
+			],
+		});
+
+		assert.deepStrictEqual(await fetchTables(client), [
+			{ catalog: 'pagila', schema: 'public', name: 'actor', kind: 'table' },
+			// An empty catalog/schema means "this backend does not use that level", so both
+			// normalize to undefined rather than to an empty string.
+			{ catalog: undefined, schema: undefined, name: 'orphan', kind: 'table' },
+			{ catalog: 'pagila', schema: 'public', name: 'actor_info', kind: 'view' },
+		]);
+	});
+});
+
+suite('createRootNodes', () => {
+	test('collapses the catalog and schema levels a backend does not use', async () => {
+		const tables: OdbcTableRef[] = [
+			{ name: 'orders', kind: 'table' },
+			{ name: 'customers', kind: 'table' },
+		];
+		const client = createFakeClient({ columns: [] });
+
+		assert.deepStrictEqual(
+			await outline(createRootNodes(tables, client, noopPreviewHost)),
+			[
+				// No catalogs, no schemas, and no views: straight to Tables.
+				'Tables (group-tables)',
+				'  orders (table)',
+				'    Columns (group-columns)',
+				'  customers (table)',
+				'    Columns (group-columns)',
+			]
+		);
+	});
+
+	test('shows a schema level when the backend has one, and omits the empty Views group', async () => {
+		const tables: OdbcTableRef[] = [
+			{ schema: 'public', name: 'actor', kind: 'table' },
+			{ schema: 'staging', name: 'raw_actor', kind: 'table' },
+		];
+		const client = createFakeClient({ columns: [] });
+
+		assert.deepStrictEqual(
+			await outline(createRootNodes(tables, client, noopPreviewHost)),
+			[
+				'Schemas (group-schemas)',
+				'  public (schema)',
+				'    Tables (group-tables)',
+				'      actor (table)',
+				'        Columns (group-columns)',
+				'  staging (schema)',
+				'    Tables (group-tables)',
+				'      raw_actor (table)',
+				'        Columns (group-columns)',
+			]
+		);
+	});
+
+	test('shows a catalog level when tables span more than one catalog', async () => {
+		const tables: OdbcTableRef[] = [
+			{ catalog: 'sales', schema: 'dbo', name: 'orders', kind: 'table' },
+			{ catalog: 'hr', schema: 'dbo', name: 'staff', kind: 'view' },
+		];
+		const client = createFakeClient({ columns: [] });
+
+		assert.deepStrictEqual(
+			await outline(createRootNodes(tables, client, noopPreviewHost)),
+			[
+				'Catalogs (group-catalogs)',
+				'  hr (catalog)',
+				'    Schemas (group-schemas)',
+				'      dbo (schema)',
+				// Only a view under hr, so no Tables group is offered.
+				'        Views (group-views)',
+				'          staff (view)',
+				'            Columns (group-columns)',
+				'  sales (catalog)',
+				'    Schemas (group-schemas)',
+				'      dbo (schema)',
+				'        Tables (group-tables)',
+				'          orders (table)',
+				'            Columns (group-columns)',
+			]
+		);
+	});
+
+	test('marks primary key columns on tables and tolerates a driver without SQLPrimaryKeys', async () => {
+		const columns = [
+			{ COLUMN_NAME: 'actor_id', TYPE_NAME: 'int4', COLUMN_SIZE: 10, ORDINAL_POSITION: 1, DATA_TYPE: 4 },
+			{ COLUMN_NAME: 'first_name', TYPE_NAME: 'varchar', COLUMN_SIZE: 45, ORDINAL_POSITION: 2, DATA_TYPE: 12 },
+		];
+
+		const withKeys = createFakeClient({ columns, primaryKeys: [{ COLUMN_NAME: 'actor_id' }] });
+		const withoutKeys = createFakeClient({ columns, primaryKeys: 'unsupported' });
+		const table: OdbcTableRef[] = [{ schema: 'public', name: 'actor', kind: 'table' }];
+		const view: OdbcTableRef[] = [{ schema: 'public', name: 'actor', kind: 'view' }];
+
+		assert.deepStrictEqual(
+			{
+				table: await outline(createRootNodes(table, withKeys, noopPreviewHost)),
+				// A driver that errors on SQLPrimaryKeys degrades to "no primary key" rather than
+				// failing the whole Columns expansion.
+				driverWithoutPrimaryKeys: await outline(createRootNodes(table, withoutKeys, noopPreviewHost)),
+				// Views have no primary key, so they are never asked for one.
+				view: await outline(createRootNodes(view, withKeys, noopPreviewHost)),
+			},
+			{
+				table: [
+					'Schemas (group-schemas)', '  public (schema)', '    Tables (group-tables)', '      actor (table)',
+					'        Columns (group-columns)',
+					'          actor_id (field): int4 [pk]',
+					'          first_name (field): varchar(45)',
+				],
+				driverWithoutPrimaryKeys: [
+					'Schemas (group-schemas)', '  public (schema)', '    Tables (group-tables)', '      actor (table)',
+					'        Columns (group-columns)',
+					'          actor_id (field): int4',
+					'          first_name (field): varchar(45)',
+				],
+				view: [
+					'Schemas (group-schemas)', '  public (schema)', '    Views (group-views)', '      actor (view)',
+					'        Columns (group-columns)',
+					'          actor_id (field): int4',
+					'          first_name (field): varchar(45)',
+				],
+			}
+		);
+	});
+});
+
+suite('formatDataType', () => {
+	test('appends size only where the user chose it, and leaves parameterized names alone', () => {
+		assert.deepStrictEqual(
+			[
+				{ TYPE_NAME: 'varchar', COLUMN_SIZE: 255 },
+				{ TYPE_NAME: 'int4', COLUMN_SIZE: 10 },
+				{ TYPE_NAME: 'numeric', COLUMN_SIZE: 12, DECIMAL_DIGITS: 4 },
+				{ TYPE_NAME: 'varchar(50)', COLUMN_SIZE: 50 },
+				{ TYPE_NAME: '' },
+			].map(formatDataType),
+			// int4's "size" is an artifact of the ODBC type mapping, not something anyone set.
+			['varchar(255)', 'int4', 'numeric(12,4)', 'varchar(50)', '']
+		);
+	});
+});
+
+suite('buildOdbcSchema', () => {
+	test('orders columns by ordinal position and maps ODBC type codes to display types', async () => {
+		const client = createFakeClient({
+			columns: [
+				{ COLUMN_NAME: 'last_update', TYPE_NAME: 'timestamptz', DATA_TYPE: 93, ORDINAL_POSITION: 3 },
+				{ COLUMN_NAME: 'actor_id', TYPE_NAME: 'int4', DATA_TYPE: 4, ORDINAL_POSITION: 1 },
+				{ COLUMN_NAME: 'first_name', TYPE_NAME: 'varchar', DATA_TYPE: 12, ORDINAL_POSITION: 2 },
+				{ COLUMN_NAME: 'weird', TYPE_NAME: 'GEOGRAPHY', DATA_TYPE: 5432, ORDINAL_POSITION: 4 },
+			],
+		});
+
+		assert.deepStrictEqual(
+			await buildOdbcSchema(client, { schema: 'public', name: 'actor', kind: 'table' }),
+			[
+				{ column_name: 'actor_id', column_type: 'int4', type_display: 'integer' },
+				{ column_name: 'first_name', column_type: 'varchar', type_display: 'string' },
+				{ column_name: 'last_update', column_type: 'timestamptz', type_display: 'datetime' },
+				// An unrecognized type code falls back to the type name, which here says nothing
+				// useful either, so the column is opaque.
+				{ column_name: 'weird', column_type: 'GEOGRAPHY', type_display: 'object' },
+			]
+		);
+	});
+});

--- a/extensions/positron-data-driver-odbc/src/test/odbcNodes.test.ts
+++ b/extensions/positron-data-driver-odbc/src/test/odbcNodes.test.ts
@@ -211,18 +211,22 @@ suite('buildOdbcSchema', () => {
 				{ COLUMN_NAME: 'actor_id', TYPE_NAME: 'int4', DATA_TYPE: 4, ORDINAL_POSITION: 1 },
 				{ COLUMN_NAME: 'first_name', TYPE_NAME: 'varchar', DATA_TYPE: 12, ORDINAL_POSITION: 2 },
 				{ COLUMN_NAME: 'weird', TYPE_NAME: 'GEOGRAPHY', DATA_TYPE: 5432, ORDINAL_POSITION: 4 },
+				{ COLUMN_NAME: 'picture', TYPE_NAME: 'bytea', DATA_TYPE: -3, ORDINAL_POSITION: 5 },
 			],
 		});
 
 		assert.deepStrictEqual(
 			await buildOdbcSchema(client, { schema: 'public', name: 'actor', kind: 'table' }),
 			[
-				{ column_name: 'actor_id', column_type: 'int4', type_display: 'integer' },
-				{ column_name: 'first_name', column_type: 'varchar', type_display: 'string' },
-				{ column_name: 'last_update', column_type: 'timestamptz', type_display: 'datetime' },
+				{ column_name: 'actor_id', column_type: 'int4', type_display: 'integer', is_binary: false },
+				{ column_name: 'first_name', column_type: 'varchar', type_display: 'string', is_binary: false },
+				{ column_name: 'last_update', column_type: 'timestamptz', type_display: 'datetime', is_binary: false },
 				// An unrecognized type code falls back to the type name, which here says nothing
-				// useful either, so the column is opaque.
-				{ column_name: 'weird', column_type: 'GEOGRAPHY', type_display: 'object' },
+				// useful either, so the column is opaque -- but opaque is not binary, and only a
+				// binary column may skip having its value fetched.
+				{ column_name: 'weird', column_type: 'GEOGRAPHY', type_display: 'object', is_binary: false },
+				// SQL_VARBINARY: the flag that keeps its bytes from ever being fetched.
+				{ column_name: 'picture', column_type: 'bytea', type_display: 'object', is_binary: true },
 			]
 		);
 	});

--- a/extensions/positron-data-driver-odbc/src/test/odbcPaging.test.ts
+++ b/extensions/positron-data-driver-odbc/src/test/odbcPaging.test.ts
@@ -1,0 +1,272 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { OdbcDialect } from '../odbcDatabases.js';
+import { OdbcTableRef } from '../odbcNodes.js';
+import { OdbcSchemaEntry, OdbcTableView, resolveOdbcRowIdentity } from '../odbcTableView.js';
+import { IOdbcQueryClient } from '../odbcWorkerClient.js';
+import { OdbcRow } from '../odbcWorkerProtocol.js';
+import {
+	ColumnDisplayType,
+	ExportFormat,
+	FormatOptions,
+	TableSelectionKind,
+} from 'positron-data-explorer-protocol';
+
+const FORMAT: FormatOptions = {
+	large_num_digits: 2,
+	small_num_digits: 4,
+	max_integral_digits: 7,
+	max_value_length: 100,
+};
+
+const LIMIT_OFFSET: OdbcDialect = { identifierQuote: '"', pagination: 'limit-offset' };
+const OFFSET_FETCH: OdbcDialect = { identifierQuote: '"', pagination: 'offset-fetch' };
+
+/**
+ * A low-cardinality first column, so the fallback tiebreaker is the weakest one a real table could
+ * offer, followed by a unique key column. Paging is checked against `id`, which appears second on
+ * purpose: a driver that reaches for column zero picks `status` and tears.
+ */
+const SCHEMA: OdbcSchemaEntry[] = [
+	{ column_name: 'status', column_type: 'varchar', type_display: ColumnDisplayType.String, is_binary: false },
+	{ column_name: 'id', column_type: 'int4', type_display: ColumnDisplayType.Integer, is_binary: false },
+];
+
+const REF: OdbcTableRef = { schema: 'public', name: 'x', kind: 'table' };
+const ROWS = 1000;
+const PAGE = 100;
+const STATUSES = 3;
+
+const statusOf = (id: number) => `s${id % STATUSES}`;
+
+/**
+ * A fake query client standing in for a backend that returns tied rows in any order it likes,
+ * because the ORDER BY does not distinguish them. The order is stable within one statement and
+ * re-permuted for each new statement.
+ *
+ * The permutation is a rotation by one, the smallest total re-ordering there is: a paged sweep then
+ * drops precisely one row per page boundary, so a failure is unambiguous rather than a scrambled
+ * diff.
+ */
+class UnstableOrderClient implements IOdbcQueryClient {
+	/** Reads that scan the base relation, i.e. the expensive ones a snapshot should not multiply. */
+	baseRelationReads = 0;
+
+	private rotation = 0;
+
+	constructor(private readonly rowCount: number) { }
+
+	async runQuery(sql: string): Promise<OdbcRow[]> {
+		if (sql.includes('count(*)')) {
+			return [{ n: this.rowCount }];
+		}
+		if (sql.includes('"x"')) {
+			this.baseRelationReads++;
+		}
+
+		// Ordering by the unique key column pins the order completely, as would a row number over a
+		// materialized snapshot. Without one, rows the ORDER BY leaves tied may come back in a
+		// different order on every statement.
+		const pinned = /ORDER BY[^)]*(?:"id"|__rn)/.test(sql);
+		if (!pinned) {
+			this.rotation++;
+		}
+
+		// Rows the ORDER BY cannot tell apart form one tie group. Ordering by `status` alone leaves
+		// three large groups; with no ORDER BY at all the whole table is a single group.
+		const groups = /ORDER BY\s+"status"/.test(sql) ? this._statusGroups() : [this._allRows()];
+		const order: number[] = [];
+		for (const group of groups) {
+			const by = pinned ? 0 : this.rotation % group.length;
+			order.push(...group.slice(by), ...group.slice(0, by));
+		}
+
+		// Both dialects the driver emits: LIMIT/OFFSET and the SQL:2008 OFFSET ... FETCH form.
+		const window = /LIMIT (\d+) OFFSET (\d+)/.exec(sql);
+		const fetch = /OFFSET (\d+) ROWS FETCH NEXT (\d+) ROWS ONLY/.exec(sql);
+		let offset = 0;
+		let limit = this.rowCount;
+		if (window) {
+			[offset, limit] = [Number(window[2]), Number(window[1])];
+		} else if (fetch) {
+			[offset, limit] = [Number(fetch[1]), Number(fetch[2])];
+		}
+		// Selectors are aliased by request position rather than schema position, so the row has to be
+		// keyed the way the caller actually asked for it.
+		const selected = [...sql.matchAll(/"(\w+)" AS (c\d+)/g)]
+			.map(match => ({ name: match[1], alias: match[2] }));
+		return order.slice(offset, offset + limit).map(id => {
+			const row: OdbcRow = {};
+			for (const { name, alias } of selected) {
+				row[alias] = name === 'id' ? id : statusOf(id);
+			}
+			return row;
+		});
+	}
+
+	private _allRows(): number[] {
+		return Array.from({ length: this.rowCount }, (_, i) => i);
+	}
+
+	private _statusGroups(): number[][] {
+		return Array.from({ length: STATUSES },
+			(_, s) => this._allRows().filter(id => statusOf(id) === `s${s}`));
+	}
+
+	async tables(): Promise<OdbcRow[]> { return []; }
+	async columns(): Promise<OdbcRow[]> { return []; }
+	async primaryKeys(): Promise<OdbcRow[]> { return [{ COLUMN_NAME: 'id', KEY_SEQ: 1 }]; }
+}
+
+/** Reads one page of the `id` column through the Data Explorer data path. */
+async function readPage(view: OdbcTableView, first: number, count: number): Promise<number[]> {
+	const data = await view.getDataValues({
+		columns: [{ column_index: 1, spec: { first_index: first, last_index: first + count - 1 } }],
+		format_options: FORMAT,
+	});
+	return data.columns[0].map(Number);
+}
+
+/** Pages through the whole table the way scrolling from top to bottom does. */
+async function sweep(view: OdbcTableView): Promise<number[]> {
+	const seen: number[] = [];
+	for (let first = 0; first < ROWS; first += PAGE) {
+		seen.push(...await readPage(view, first, PAGE));
+	}
+	return seen;
+}
+
+/** Summarizes read ids against the rows that should have been returned exactly once. */
+function coverage(seen: number[]) {
+	const counts = new Map<number, number>();
+	for (const id of seen) {
+		counts.set(id, (counts.get(id) ?? 0) + 1);
+	}
+	return {
+		total: seen.length,
+		duplicated: [...counts].filter(([, n]) => n > 1).map(([id]) => id),
+		missing: Array.from({ length: ROWS }, (_, i) => i).filter(id => !counts.has(id)),
+	};
+}
+
+/**
+ * The paging invariants, run for one dialect and row identity. Every name is shared verbatim with
+ * the sibling drivers' paging suites, so `grep` across the drivers shows which of them assert which
+ * invariant.
+ */
+function pagingInvariants(dialect: OdbcDialect, rowIdentity: ReadonlyArray<string>): void {
+	const open = () => new OdbcTableView(
+		new UnstableOrderClient(ROWS), REF, dialect, SCHEMA, rowIdentity);
+
+	test('a full sequential sweep returns every row exactly once', async () => {
+		assert.deepStrictEqual(
+			coverage(await sweep(open())),
+			{ total: ROWS, duplicated: [], missing: [] },
+		);
+	});
+
+	test('re-reading a range returns the same rows', async () => {
+		const view = open();
+		// The rows at a position must be a property of the table, not of how it was reached.
+		const before = await readPage(view, 500, PAGE);
+		await readPage(view, 0, PAGE);
+
+		assert.deepStrictEqual(await readPage(view, 500, PAGE), before);
+	});
+
+	test('an exported range matches the rows shown for that range', async () => {
+		const view = open();
+		const shown = await readPage(view, 500, PAGE);
+
+		const exported = await view.exportDataSelection({
+			selection: {
+				kind: TableSelectionKind.RowRange,
+				selection: { first_index: 500, last_index: 500 + PAGE - 1 },
+			},
+			format: ExportFormat.Csv,
+		});
+		// Drop the header row, then read the trailing id column back out of each line.
+		const ids = exported.data.trim().split('\n').slice(1)
+			.map(line => Number(line.split(',')[1]));
+
+		assert.deepStrictEqual(ids, shown);
+	});
+
+	test('a sweep sorted by a low-cardinality column returns every row exactly once', async () => {
+		const view = open();
+		// Sorting by `status` groups the rows correctly but leaves ~333 of them tied at a time, so
+		// a page boundary inside a tie group needs a tiebreaker to stay exact.
+		await view.setSortColumns({ sort_keys: [{ column_index: 0, ascending: true }] });
+
+		assert.deepStrictEqual(
+			coverage(await sweep(view)),
+			{ total: ROWS, duplicated: [], missing: [] },
+		);
+	});
+}
+
+/** A client whose SQLPrimaryKeys answer is supplied by the test. */
+function keyClient(primaryKeys: OdbcRow[] | 'unsupported'): IOdbcQueryClient {
+	return {
+		runQuery: async () => [],
+		tables: async () => [],
+		columns: async () => [],
+		primaryKeys: async () => {
+			if (primaryKeys === 'unsupported') {
+				throw new Error('[odbc] SQLPrimaryKeys is not supported by this driver');
+			}
+			return primaryKeys;
+		},
+	};
+}
+
+suite('ODBC paging stability', () => {
+	suite('resolveOdbcRowIdentity', () => {
+		test('returns a composite key in KEY_SEQ order, and nothing where there is no key', async () => {
+			const composite = keyClient([
+				{ COLUMN_NAME: 'line_no', KEY_SEQ: 2 },
+				{ COLUMN_NAME: 'order_id', KEY_SEQ: 1 },
+			]);
+
+			assert.deepStrictEqual(
+				{
+					composite: await resolveOdbcRowIdentity(composite, REF),
+					view: await resolveOdbcRowIdentity(composite, { ...REF, kind: 'view' }),
+					keyless: await resolveOdbcRowIdentity(keyClient([]), REF),
+					unsupported: await resolveOdbcRowIdentity(keyClient('unsupported'), REF),
+				},
+				{
+					composite: ['order_id', 'line_no'],
+					view: [],
+					keyless: [],
+					unsupported: [],
+				}
+			);
+		});
+	});
+
+	suite('primary key tiebreaker, LIMIT/OFFSET', () => {
+		pagingInvariants(LIMIT_OFFSET, ['id']);
+	});
+
+	suite('primary key tiebreaker, OFFSET/FETCH', () => {
+		pagingInvariants(OFFSET_FETCH, ['id']);
+	});
+
+	// A composite key appends every column, so paging stays exact even when the leading key column
+	// is not unique on its own.
+	suite('composite key tiebreaker', () => {
+		pagingInvariants(LIMIT_OFFSET, ['status', 'id']);
+	});
+
+	// With no key to be had -- a view, or a table without one -- the first column stands in, which is
+	// not unique, so rows tied on it still swap between pages. Pending the materialized-snapshot
+	// work; see https://github.com/posit-dev/positron/issues/15361.
+	suite.skip('no row identity', () => {
+		pagingInvariants(LIMIT_OFFSET, []);
+	});
+});

--- a/extensions/positron-data-driver-odbc/src/test/odbcTableView.test.ts
+++ b/extensions/positron-data-driver-odbc/src/test/odbcTableView.test.ts
@@ -1,0 +1,199 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { OdbcDialect } from '../odbcDatabases.js';
+import { OdbcTableRef } from '../odbcNodes.js';
+import { odbcDisplayType, OdbcSchemaEntry, OdbcTableView } from '../odbcTableView.js';
+import { IOdbcQueryClient } from '../odbcWorkerClient.js';
+import { OdbcRow } from '../odbcWorkerProtocol.js';
+import {
+	ColumnDisplayType,
+	FilterComparisonOp,
+	FormatOptions,
+	RowFilter,
+	RowFilterCondition,
+	RowFilterParams,
+	RowFilterType,
+	TextSearchType,
+} from 'positron-data-explorer-protocol';
+
+/** Format options for the data reads below; the exact numbers do not matter to these assertions. */
+const FORMAT_OPTIONS: FormatOptions = {
+	large_num_digits: 2,
+	small_num_digits: 4,
+	max_integral_digits: 7,
+	max_value_length: 100,
+};
+
+const LIMIT_OFFSET: OdbcDialect = { identifierQuote: '"', pagination: 'limit-offset' };
+const OFFSET_FETCH: OdbcDialect = { identifierQuote: '"', pagination: 'offset-fetch' };
+const BACKTICK: OdbcDialect = { identifierQuote: '`', pagination: 'limit-offset' };
+
+const SCHEMA: OdbcSchemaEntry[] = [
+	{ column_name: 'actor_id', column_type: 'int4', type_display: ColumnDisplayType.Integer },
+	{ column_name: 'first_name', column_type: 'varchar', type_display: ColumnDisplayType.String },
+];
+
+/** A client that records the SQL it is asked to run and answers counts so construction settles. */
+function createRecordingClient(): IOdbcQueryClient & { queries: string[] } {
+	const queries: string[] = [];
+	return {
+		queries,
+		runQuery: async (sql: string): Promise<OdbcRow[]> => {
+			queries.push(sql);
+			// Every query in these tests is either a count or a data read; a single row keyed for
+			// both is enough for the view to make progress.
+			return [{ n: 3, c0: 1, c1: 'Penelope' }];
+		},
+		tables: async () => [],
+		columns: async () => [],
+		primaryKeys: async () => [],
+	};
+}
+
+/** The most recent query a recording client was asked to run. */
+function lastQuery(client: { queries: string[] }): string {
+	return client.queries[client.queries.length - 1];
+}
+
+function createView(dialect: OdbcDialect, ref?: Partial<OdbcTableRef>) {
+	const client = createRecordingClient();
+	const view = new OdbcTableView(
+		client,
+		{ schema: 'public', name: 'actor', kind: 'table', ...ref },
+		dialect,
+		SCHEMA
+	);
+	return { client, view };
+}
+
+/** The row filter shape the protocol requires, with the column schema the view reads back. */
+function rowFilter(filterType: RowFilterType, columnIndex: number, params: RowFilterParams): RowFilter {
+	const entry = SCHEMA[columnIndex];
+	return {
+		filter_id: `filter-${filterType}`,
+		filter_type: filterType,
+		column_schema: {
+			column_name: entry.column_name,
+			column_index: columnIndex,
+			type_name: entry.column_type,
+			type_display: entry.type_display,
+		},
+		condition: RowFilterCondition.And,
+		params,
+	};
+}
+
+suite('odbcDisplayType', () => {
+	test('maps the ODBC SQL type codes, which are the same for every driver', () => {
+		assert.deepStrictEqual(
+			[
+				[12, 'varchar'], [-9, 'nvarchar'], [4, 'int'], [-5, 'bigint'], [8, 'double'],
+				[3, 'decimal'], [-7, 'bit'], [91, 'date'], [92, 'time'], [93, 'timestamp'],
+				[-3, 'varbinary'],
+			].map(([code, name]) => odbcDisplayType(code as number, name as string)),
+			['string', 'string', 'integer', 'integer', 'floating', 'decimal', 'boolean', 'date', 'time', 'datetime', 'object']
+		);
+	});
+
+	test('falls back to the type name for a code the specification does not define', () => {
+		assert.deepStrictEqual(
+			[
+				odbcDisplayType(9999, 'BOOLEAN'),
+				odbcDisplayType(undefined, 'BIGINT UNSIGNED'),
+				odbcDisplayType(9999, 'VARIANT'),
+			],
+			['boolean', 'integer', 'object']
+		);
+	});
+});
+
+suite('OdbcTableView SQL', () => {
+	test('writes the row window in the backend\'s own syntax', async () => {
+		const limitOffset = createView(LIMIT_OFFSET);
+		const offsetFetch = createView(OFFSET_FETCH);
+		const request = {
+			columns: [{ column_index: 0, spec: { first_index: 10, last_index: 12 } }],
+			format_options: FORMAT_OPTIONS,
+		};
+
+		await limitOffset.view.getDataValues(request);
+		await offsetFetch.view.getDataValues(request);
+
+		assert.deepStrictEqual(
+			{
+				limitOffset: lastQuery(limitOffset.client),
+				offsetFetch: lastQuery(offsetFetch.client),
+			},
+			{
+				// The first column is appended as a tiebreaker so paging is reproducible; ODBC has
+				// no portable row identity to use instead.
+				limitOffset: 'SELECT "actor_id" AS c0 FROM "public"."actor"\nORDER BY "actor_id" LIMIT 3 OFFSET 10',
+				offsetFetch: 'SELECT "actor_id" AS c0 FROM "public"."actor"\nORDER BY "actor_id" OFFSET 10 ROWS FETCH NEXT 3 ROWS ONLY',
+			}
+		);
+	});
+
+	test('quotes identifiers with the dialect\'s character and qualifies the table', async () => {
+		const backtick = createView(BACKTICK, { catalog: 'sales', schema: undefined, name: 'or`ders' });
+		await backtick.view.setRowFilters({ filters: [rowFilter(RowFilterType.IsNull, 0, {} as RowFilterParams)] });
+
+		assert.strictEqual(
+			lastQuery(backtick.client),
+			// The embedded backtick is doubled, and the absent schema drops out of the reference.
+			'SELECT count(*) AS n FROM `sales`.`or``ders`\nWHERE `actor_id` IS NULL'
+		);
+	});
+
+	test('builds portable WHERE expressions, escaping LIKE wildcards', async () => {
+		const { client, view } = createView(LIMIT_OFFSET);
+
+		const filters = [
+			rowFilter(RowFilterType.Compare, 0, { op: FilterComparisonOp.GtEq, value: '5' }),
+			rowFilter(RowFilterType.Search, 1, { search_type: TextSearchType.Contains, term: '100%_x', case_sensitive: false }),
+			rowFilter(RowFilterType.SetMembership, 1, { values: ['a', 'O\'Brien'], inclusive: true }),
+		];
+		await view.setRowFilters({ filters });
+
+		assert.strictEqual(
+			lastQuery(client),
+			'SELECT count(*) AS n FROM "public"."actor"\nWHERE "actor_id" >= 5 AND ' +
+			// LOWER rather than a case-insensitive LIKE, which is not portable; the wildcards in the
+			// term are escaped with ! so "100%" matches that text and not every row starting "100".
+			'LOWER("first_name") LIKE \'%100!%!_x%\' ESCAPE \'!\' AND ' +
+			'"first_name" IN (\'a\', \'O\'\'Brien\')'
+		);
+	});
+
+	test('refuses a regex filter rather than approximating it', async () => {
+		const { view } = createView(LIMIT_OFFSET);
+		const filters = [rowFilter(RowFilterType.Search, 1, {
+			search_type: TextSearchType.RegexMatch, term: '^Pen', case_sensitive: true,
+		})];
+
+		await assert.rejects(
+			() => view.setRowFilters({ filters }),
+			/no common regular expression syntax/
+		);
+	});
+
+	test('omits the paging tiebreaker from the SQL it hands the user', async () => {
+		const { view } = createView(OFFSET_FETCH);
+		await view.setSortColumns({ sort_keys: [{ column_index: 1, ascending: false }] });
+
+		assert.deepStrictEqual(
+			(await view.convertToCode({
+				column_filters: [],
+				row_filters: [],
+				sort_keys: [],
+				code_syntax_name: { code_syntax_name: 'SQL' },
+			})).converted_code,
+			// Only the ordering the user actually chose; the tiebreaker exists for Positron's own
+			// paging and would be noise in code the user runs.
+			['SELECT *', 'FROM "public"."actor"', 'ORDER BY "first_name" DESC']
+		);
+	});
+});

--- a/extensions/positron-data-driver-odbc/src/test/odbcTableView.test.ts
+++ b/extensions/positron-data-driver-odbc/src/test/odbcTableView.test.ts
@@ -10,6 +10,7 @@ import { odbcDisplayType, OdbcSchemaEntry, OdbcTableView } from '../odbcTableVie
 import { IOdbcQueryClient } from '../odbcWorkerClient.js';
 import { OdbcRow } from '../odbcWorkerProtocol.js';
 import {
+	ColumnProfileType,
 	ColumnDisplayType,
 	FilterComparisonOp,
 	FormatOptions,
@@ -33,20 +34,37 @@ const OFFSET_FETCH: OdbcDialect = { identifierQuote: '"', pagination: 'offset-fe
 const BACKTICK: OdbcDialect = { identifierQuote: '`', pagination: 'limit-offset' };
 
 const SCHEMA: OdbcSchemaEntry[] = [
-	{ column_name: 'actor_id', column_type: 'int4', type_display: ColumnDisplayType.Integer },
-	{ column_name: 'first_name', column_type: 'varchar', type_display: ColumnDisplayType.String },
+	{ column_name: 'actor_id', column_type: 'int4', type_display: ColumnDisplayType.Integer, is_binary: false },
+	{ column_name: 'first_name', column_type: 'varchar', type_display: ColumnDisplayType.String, is_binary: false },
 ];
 
-/** A client that records the SQL it is asked to run and answers counts so construction settles. */
-function createRecordingClient(): IOdbcQueryClient & { queries: string[] } {
+/** A schema with a binary column, for the reads that must never fetch bytes. */
+const BINARY_SCHEMA: OdbcSchemaEntry[] = [
+	{ column_name: 'category_id', column_type: 'int2', type_display: ColumnDisplayType.Integer, is_binary: false },
+	{ column_name: 'picture', column_type: 'bytea', type_display: ColumnDisplayType.Object, is_binary: true },
+];
+
+/**
+ * A client that records the SQL it is asked to run and answers counts so construction settles.
+ * @param options.rejectOctetLength Fails any query using the `{fn OCTET_LENGTH(...)}` escape, the
+ * way a driver that does not implement it would, so the fallback can be exercised.
+ * @param options.rows Overrides the row the client answers with.
+ */
+function createRecordingClient(options: { rejectOctetLength?: boolean; rows?: OdbcRow[] } = {}): IOdbcQueryClient & { queries: string[] } {
 	const queries: string[] = [];
 	return {
 		queries,
 		runQuery: async (sql: string): Promise<OdbcRow[]> => {
 			queries.push(sql);
-			// Every query in these tests is either a count or a data read; a single row keyed for
-			// both is enough for the view to make progress.
-			return [{ n: 3, c0: 1, c1: 'Penelope' }];
+			if (options.rejectOctetLength && sql.includes('OCTET_LENGTH')) {
+				throw new Error('[odbc] scalar function OCTET_LENGTH is not supported');
+			}
+			// Row counts are answered separately from data reads, so a test can supply its own data
+			// rows without starving the view of the count it needs to think the table is non-empty.
+			if (sql.includes('count(*) AS n')) {
+				return [{ n: 3 }];
+			}
+			return options.rows ?? [{ c0: 1, c1: 'Penelope' }];
 		},
 		tables: async () => [],
 		columns: async () => [],
@@ -59,13 +77,17 @@ function lastQuery(client: { queries: string[] }): string {
 	return client.queries[client.queries.length - 1];
 }
 
-function createView(dialect: OdbcDialect, ref?: Partial<OdbcTableRef>) {
-	const client = createRecordingClient();
+function createView(
+	dialect: OdbcDialect,
+	ref?: Partial<OdbcTableRef>,
+	options: { schema?: OdbcSchemaEntry[]; client?: IOdbcQueryClient & { queries: string[] } } = {}
+) {
+	const client = options.client ?? createRecordingClient();
 	const view = new OdbcTableView(
 		client,
 		{ schema: 'public', name: 'actor', kind: 'table', ...ref },
 		dialect,
-		SCHEMA
+		options.schema ?? SCHEMA
 	);
 	return { client, view };
 }
@@ -177,6 +199,76 @@ suite('OdbcTableView SQL', () => {
 		await assert.rejects(
 			() => view.setRowFilters({ filters }),
 			/no common regular expression syntax/
+		);
+	});
+
+	test('never selects a binary column\'s bytes, measuring it instead', async () => {
+		// node-odbc materializes binary values with napi_create_external_arraybuffer, which Electron
+		// refuses outright -- a fatal native error that kills the worker rather than an exception.
+		// The bytes are only ever rendered as a size, so the size is all that is fetched.
+		const { client, view } = createView(LIMIT_OFFSET, { name: 'categories' }, {
+			schema: BINARY_SCHEMA,
+			client: createRecordingClient({ rows: [{ c0: 1, c1: 11626 }] }),
+		});
+
+		const data = await view.getDataValues({
+			columns: [
+				{ column_index: 0, spec: { first_index: 0, last_index: 0 } },
+				{ column_index: 1, spec: { first_index: 0, last_index: 0 } },
+			],
+			format_options: FORMAT_OPTIONS,
+		});
+
+		assert.deepStrictEqual(
+			{ sql: lastQuery(client), values: data.columns },
+			{
+				sql: 'SELECT "category_id" AS c0, {fn OCTET_LENGTH("picture")} AS c1 FROM "public"."categories"\nORDER BY "category_id" LIMIT 1 OFFSET 0',
+				values: [['1'], ['[BINARY 11626 bytes]']],
+			}
+		);
+	});
+
+	test('falls back to a presence check when the backend rejects the length escape', async () => {
+		const { client, view } = createView(LIMIT_OFFSET, { name: 'categories' }, {
+			schema: BINARY_SCHEMA,
+			client: createRecordingClient({ rejectOctetLength: true, rows: [{ c0: 1 }] }),
+		});
+
+		const data = await view.getDataValues({
+			columns: [{ column_index: 1, spec: { first_index: 0, last_index: 0 } }],
+			format_options: FORMAT_OPTIONS,
+		});
+
+		assert.deepStrictEqual(
+			{ sql: lastQuery(client), values: data.columns },
+			{
+				// Plain SQL every backend accepts: 0 for null, 1 for present.
+				sql: 'SELECT CASE WHEN "picture" IS NULL THEN 0 ELSE 1 END AS c0 FROM "public"."categories"\nORDER BY "category_id" LIMIT 1 OFFSET 0',
+				values: [['[BINARY]']],
+			}
+		);
+	});
+
+	test('reports an empty frequency table for a binary column without querying it', async () => {
+		const { client, view } = createView(LIMIT_OFFSET, { name: 'categories' }, { schema: BINARY_SCHEMA });
+		const before = client.queries.length;
+
+		const profiles = await view.computeColumnProfiles({
+			callback_id: 'cb',
+			profiles: [{
+				column_index: 1,
+				profiles: [{ profile_type: ColumnProfileType.SmallFrequencyTable, params: { limit: 10 } }],
+			}],
+			format_options: FORMAT_OPTIONS,
+		});
+
+		assert.deepStrictEqual(
+			{
+				profile: profiles.profiles[0].small_frequency_table,
+				// Grouping by a binary column would have to select the bytes as the group key.
+				queriesIssued: client.queries.length - before,
+			},
+			{ profile: { values: [], counts: [], other_count: 3 }, queriesIssued: 0 }
 		);
 	});
 

--- a/extensions/positron-data-driver-odbc/src/test/odbcTableView.test.ts
+++ b/extensions/positron-data-driver-odbc/src/test/odbcTableView.test.ts
@@ -151,8 +151,9 @@ suite('OdbcTableView SQL', () => {
 				offsetFetch: lastQuery(offsetFetch.client),
 			},
 			{
-				// The first column is appended as a tiebreaker so paging is reproducible; ODBC has
-				// no portable row identity to use instead.
+				// These views are built without a resolved row identity, so the first column stands
+				// in as the paging tiebreaker. Where SQLPrimaryKeys reports a key, its columns are
+				// used instead -- see odbcPaging.test.ts.
 				limitOffset: 'SELECT "actor_id" AS c0 FROM "public"."actor"\nORDER BY "actor_id" LIMIT 3 OFFSET 10',
 				offsetFetch: 'SELECT "actor_id" AS c0 FROM "public"."actor"\nORDER BY "actor_id" OFFSET 10 ROWS FETCH NEXT 3 ROWS ONLY',
 			}

--- a/extensions/positron-data-driver-odbc/src/test/odbcWorkerClient.test.ts
+++ b/extensions/positron-data-driver-odbc/src/test/odbcWorkerClient.test.ts
@@ -1,0 +1,103 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { OdbcWorkerClient } from '../odbcWorkerClient.js';
+
+/**
+ * A stand-in for the real worker, with no ODBC and no native binding in it. It answers a `pid`
+ * query with its own process id -- which is how a test gets hold of the child in order to kill it
+ * -- and deliberately answers nothing else, so a request can be left in flight while the process
+ * dies underneath it.
+ *
+ * Written to a temp file and passed to the client's `_workerPath`, which exists for exactly this:
+ * the crash path cannot be exercised against the real worker without a driver that faults.
+ */
+const STUB_WORKER = `
+process.on('message', (request) => {
+	if (request.kind === 'query' && request.sql === 'pid') {
+		process.send({ kind: 'result', id: request.id, rows: [{ pid: process.pid }] });
+	}
+	// Anything else is swallowed, leaving the host waiting on it forever.
+});
+`;
+
+/** The sql the stub never answers, used whenever a test needs a request still in flight. */
+const UNANSWERED = 'never answered';
+
+suite('OdbcWorkerClient crash recovery', () => {
+	let stubDir: string;
+	let stubPath: string;
+	const clients: OdbcWorkerClient[] = [];
+
+	suiteSetup(() => {
+		stubDir = fs.mkdtempSync(path.join(os.tmpdir(), 'odbc-worker-stub-'));
+		stubPath = path.join(stubDir, 'stubWorker.js');
+		fs.writeFileSync(stubPath, STUB_WORKER);
+	});
+
+	suiteTeardown(() => {
+		fs.rmSync(stubDir, { recursive: true, force: true });
+	});
+
+	// Disposing kills the worker, so a test that leaves one running does not leak a process.
+	teardown(() => {
+		while (clients.length > 0) {
+			clients.pop()!.dispose();
+		}
+	});
+
+	/**
+	 * Starts a client on the stub worker and returns it along with the process id of the child it
+	 * forked. Waiting on a real answer means the worker is up and talking before a test kills it.
+	 */
+	async function startClient(): Promise<{ client: OdbcWorkerClient; pid: number }> {
+		const client = new OdbcWorkerClient('DSN=Stub', stubPath);
+		clients.push(client);
+
+		const rows = await client.runQuery('pid');
+		const pid = Number(rows[0]?.pid);
+		assert.ok(pid > 0, 'the stub worker should have reported its process id');
+
+		return { client, pid };
+	}
+
+	test('a worker that dies rejects the request in flight and reports the crash', async () => {
+		const { client, pid } = await startClient();
+
+		let crashes = 0;
+		client.onDidCrash(() => crashes++);
+
+		const inFlight = client.runQuery(UNANSWERED);
+		process.kill(pid, 'SIGKILL');
+
+		// A native abort inside a vendor driver looks like this from the host's side: the child is
+		// simply gone. The rejection is the only thing standing between that and a caller that
+		// hangs forever, and the event is how the connection learns to tear its state down.
+		await assert.rejects(inFlight, /terminated unexpectedly/);
+		assert.strictEqual(crashes, 1, 'onDidCrash should have fired once');
+		assert.strictEqual(client.isAlive, false);
+	});
+
+	test('the next request respawns the worker after a crash', async () => {
+		const { client, pid } = await startClient();
+
+		const inFlight = client.runQuery(UNANSWERED);
+		process.kill(pid, 'SIGKILL');
+		await assert.rejects(inFlight);
+
+		// Recovery is transparent: the caller simply makes another request and gets a live worker,
+		// running in a new process. Nothing has to be replayed to reconnect, because the worker
+		// opens its ODBC connection on the first request it is given.
+		const rows = await client.runQuery('pid');
+		const respawnedPid = Number(rows[0]?.pid);
+		assert.ok(respawnedPid > 0, 'the respawned worker should have reported its process id');
+		assert.notStrictEqual(respawnedPid, pid, 'the respawned worker should be a new process');
+		assert.strictEqual(client.isAlive, true);
+	});
+});

--- a/extensions/positron-data-driver-odbc/src/test/odbcinst.test.ts
+++ b/extensions/positron-data-driver-odbc/src/test/odbcinst.test.ts
@@ -1,0 +1,246 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import {
+	discoverOdbcConfiguration,
+	IOdbcConfigHost,
+	OdbcRegistrySnapshot,
+	parseIni,
+	resolveUnixConfigPaths,
+	summarizeDsn,
+} from '../odbcinst.js';
+import { parseRegQueryOutput } from '../odbcConfigHost.js';
+
+/**
+ * Builds a test host over a map of path -> file contents. Every path present in the map exists;
+ * driver library paths are declared separately via `existingPaths` so a fixture can model an
+ * odbcinst.ini entry whose library has been uninstalled.
+ */
+function createTestHost(options: {
+	files?: Record<string, string>;
+	existingPaths?: string[];
+	env?: Record<string, string>;
+	home?: string;
+	platform?: NodeJS.Platform;
+	registry?: OdbcRegistrySnapshot;
+}): IOdbcConfigHost {
+	const files = options.files ?? {};
+	const existing = new Set([...Object.keys(files), ...(options.existingPaths ?? [])]);
+	return {
+		platform: options.platform ?? 'linux',
+		readFile: (filePath) => files[filePath],
+		exists: (filePath) => existing.has(filePath),
+		homeDir: () => options.home ?? '/home/brian',
+		env: (name) => options.env?.[name],
+		readRegistry: () => options.registry,
+	};
+}
+
+suite('parseIni', () => {
+	test('parses sections, lowercases keys, and ignores comments', () => {
+		const parsed = parseIni([
+			'; a comment',
+			'# another comment',
+			'[PostgreSQL Unicode]',
+			'Description = PostgreSQL driver',
+			'DRIVER = /usr/lib/psqlodbcw.so',
+			'',
+			'[Pagila]',
+			'  Servername  =  localhost  ',
+			'Port=5432',
+		].join('\n'));
+
+		assert.deepStrictEqual(parsed, {
+			'PostgreSQL Unicode': {
+				description: 'PostgreSQL driver',
+				driver: '/usr/lib/psqlodbcw.so',
+			},
+			'Pagila': {
+				servername: 'localhost',
+				port: '5432',
+			},
+		});
+	});
+
+	test('keeps a value containing an equals sign intact and merges repeated sections', () => {
+		const parsed = parseIni([
+			'[Snowflake]',
+			'Driver = /opt/snowflake/lib/libSnowflake.dylib',
+			'[Snowflake]',
+			'Options = a=1;b=2',
+			'no-equals-line',
+		].join('\n'));
+
+		assert.deepStrictEqual(parsed, {
+			Snowflake: {
+				driver: '/opt/snowflake/lib/libSnowflake.dylib',
+				options: 'a=1;b=2',
+			},
+		});
+	});
+});
+
+suite('resolveUnixConfigPaths', () => {
+	test('defaults to the standard system directories and the per-user dotfiles', () => {
+		const paths = resolveUnixConfigPaths(createTestHost({ home: '/home/brian' }));
+
+		assert.deepStrictEqual(paths, {
+			systemDrivers: ['/etc/odbcinst.ini', '/usr/local/etc/odbcinst.ini', '/opt/homebrew/etc/odbcinst.ini'],
+			systemDsns: ['/etc/odbc.ini', '/usr/local/etc/odbc.ini', '/opt/homebrew/etc/odbc.ini'],
+			userDrivers: ['/home/brian/.odbcinst.ini'],
+			userDsns: ['/home/brian/.odbc.ini'],
+		});
+	});
+
+	test('honors ODBCSYSINI, ODBCINSTINI, and ODBCINI', () => {
+		const paths = resolveUnixConfigPaths(createTestHost({
+			home: '/home/brian',
+			env: {
+				ODBCSYSINI: '/opt/odbc',
+				ODBCINSTINI: 'drivers.ini',
+				ODBCINI: '/opt/odbc/mine.ini',
+			},
+		}));
+
+		assert.deepStrictEqual(paths, {
+			systemDrivers: ['/opt/odbc/drivers.ini'],
+			systemDsns: ['/opt/odbc/odbc.ini'],
+			userDrivers: ['/home/brian/.odbcinst.ini'],
+			userDsns: ['/opt/odbc/mine.ini'],
+		});
+	});
+
+	test('treats an absolute ODBCINSTINI as the driver file outright', () => {
+		const paths = resolveUnixConfigPaths(createTestHost({
+			env: { ODBCSYSINI: '/opt/odbc', ODBCINSTINI: '/etc/elsewhere/drivers.ini' },
+		}));
+
+		assert.deepStrictEqual(paths.systemDrivers, ['/etc/elsewhere/drivers.ini']);
+	});
+});
+
+suite('discoverOdbcConfiguration (unix)', () => {
+	test('reads drivers and DSNs, drops entries whose library is gone, and lets user entries win', () => {
+		const config = discoverOdbcConfiguration(createTestHost({
+			env: { ODBCSYSINI: '/etc' },
+			home: '/home/brian',
+			files: {
+				'/etc/odbcinst.ini': [
+					'[PostgreSQL Unicode]',
+					'Description = System PostgreSQL',
+					'Driver = /usr/lib/psqlodbcw.so',
+					'',
+					'[Uninstalled Driver]',
+					'Driver = /gone/libgone.so',
+					'',
+					'[ODBC Drivers]',
+					'PostgreSQL Unicode = Installed',
+				].join('\n'),
+				'/home/brian/.odbcinst.ini': [
+					'[PostgreSQL Unicode]',
+					'Description = My PostgreSQL',
+					'Driver = /usr/lib/psqlodbcw.so',
+				].join('\n'),
+				'/etc/odbc.ini': [
+					'[Pagila]',
+					'Driver = PostgreSQL Unicode',
+					'Servername = localhost',
+					'Port = 5432',
+					'Database = pagila',
+				].join('\n'),
+				'/home/brian/.odbc.ini': [
+					'[Mine]',
+					'Driver = PostgreSQL Unicode',
+					'Servername = db.example.com',
+					'Database = analytics',
+				].join('\n'),
+			},
+			existingPaths: ['/usr/lib/psqlodbcw.so'],
+		}));
+
+		assert.deepStrictEqual(
+			config.drivers.map(driver => ({ name: driver.name, description: driver.description, scope: driver.scope })),
+			// "Uninstalled Driver" is dropped: its library does not exist. "PostgreSQL Unicode"
+			// carries the user file's description, since a user entry shadows the system one.
+			[{ name: 'PostgreSQL Unicode', description: 'My PostgreSQL', scope: 'user' }]
+		);
+
+		assert.deepStrictEqual(
+			config.dsns.map(dsn => ({ name: dsn.name, driverName: dsn.driverName, scope: dsn.scope, summary: summarizeDsn(dsn) })),
+			[
+				{ name: 'Mine', driverName: 'PostgreSQL Unicode', scope: 'user', summary: 'db.example.com/analytics' },
+				{ name: 'Pagila', driverName: 'PostgreSQL Unicode', scope: 'system', summary: 'localhost:5432/pagila' },
+			]
+		);
+	});
+
+	test('keeps a driverless entry and reports no configuration when nothing is readable', () => {
+		const withoutDriverKey = discoverOdbcConfiguration(createTestHost({
+			env: { ODBCSYSINI: '/etc' },
+			files: { '/etc/odbcinst.ini': '[Odd Entry]\nDescription = No driver key\n' },
+		}));
+		// An entry with no Driver= has no library to check, so it is not dropped.
+		assert.deepStrictEqual(withoutDriverKey.drivers.map(d => d.name), ['Odd Entry']);
+
+		const empty = discoverOdbcConfiguration(createTestHost({ env: { ODBCSYSINI: '/etc' } }));
+		assert.deepStrictEqual(
+			{ drivers: empty.drivers, dsns: empty.dsns, sources: empty.sources },
+			{ drivers: [], dsns: [], sources: [] }
+		);
+	});
+});
+
+suite('discoverOdbcConfiguration (windows)', () => {
+	test('reads the registry snapshot and lets user DSNs shadow system DSNs', () => {
+		const config = discoverOdbcConfiguration(createTestHost({
+			platform: 'win32',
+			existingPaths: ['C:\\Windows\\System32\\psqlodbc35w.dll'],
+			registry: {
+				drivers: {
+					'PostgreSQL Unicode(x64)': { Driver: 'C:\\Windows\\System32\\psqlodbc35w.dll', Description: 'PostgreSQL' },
+					'ODBC Drivers': { 'PostgreSQL Unicode(x64)': 'Installed' },
+				},
+				systemDsns: { Shared: { Driver: 'PostgreSQL Unicode(x64)', Server: 'shared.example.com' } },
+				userDsns: { Shared: { Driver: 'PostgreSQL Unicode(x64)', Server: 'mine.example.com' } },
+			},
+		}));
+
+		assert.deepStrictEqual(
+			{
+				drivers: config.drivers.map(d => d.name),
+				dsns: config.dsns.map(d => ({ name: d.name, scope: d.scope, summary: summarizeDsn(d) })),
+			},
+			{
+				// The "ODBC Drivers" index key is bookkeeping, not a driver.
+				drivers: ['PostgreSQL Unicode(x64)'],
+				dsns: [{ name: 'Shared', scope: 'user', summary: 'mine.example.com' }],
+			}
+		);
+	});
+});
+
+suite('parseRegQueryOutput', () => {
+	test('extracts direct child keys and their values, ignoring deeper subkeys', () => {
+		const output = [
+			'',
+			'HKEY_LOCAL_MACHINE\\SOFTWARE\\ODBC\\ODBCINST.INI\\ODBC Drivers',
+			'    SQL Server    REG_SZ    Installed',
+			'',
+			'HKEY_LOCAL_MACHINE\\SOFTWARE\\ODBC\\ODBCINST.INI\\SQL Server',
+			'    Driver    REG_SZ    C:\\WINDOWS\\system32\\SQLSRV32.dll',
+			'    APILevel    REG_SZ    2',
+			'',
+			'HKEY_LOCAL_MACHINE\\SOFTWARE\\ODBC\\ODBCINST.INI\\SQL Server\\Nested',
+			'    Ignored    REG_SZ    yes',
+			'',
+		].join('\r\n');
+
+		assert.deepStrictEqual(parseRegQueryOutput(output, 'HKLM\\SOFTWARE\\ODBC\\ODBCINST.INI'), {
+			'ODBC Drivers': { 'SQL Server': 'Installed' },
+			'SQL Server': { Driver: 'C:\\WINDOWS\\system32\\SQLSRV32.dll', APILevel: '2' },
+		});
+	});
+});

--- a/extensions/positron-data-driver-odbc/src/workerEnv.ts
+++ b/extensions/positron-data-driver-odbc/src/workerEnv.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Builds a clean environment for the forked worker process.
+ *
+ * The worker is forked from the extension host and run as Node via ELECTRON_RUN_AS_NODE, which
+ * means it executes the Electron binary. If the extension host's own bootstrap variables are
+ * inherited, the child re-runs VS Code's fork bootstrap instead of the worker entry point: in a
+ * dev build, `VSCODE_ESM_ENTRYPOINT` causes the child to load
+ * `vs/workbench/api/node/extensionHostProcess` (see `src/bootstrap-fork.ts`), so it tries to
+ * become a second extension host and hangs forever -- the worker never loads its native binding
+ * and never answers a request.
+ *
+ * Strip those variables before forking so the child boots straight into the worker script. Mirrors
+ * positron-data-driver-sqlite's `workerEnv.ts`.
+ *
+ * Note that the ODBC environment variables (`ODBCSYSINI`, `ODBCINI`, `ODBCINSTINI`) deliberately
+ * survive this scrub: the driver manager in the child reads them to find the same configuration
+ * the extension host discovered, so the DSN the user picked resolves to the same thing.
+ */
+export function createWorkerEnv(): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = { ...process.env };
+	delete env['NODE_OPTIONS'];
+	for (const key of Object.keys(env)) {
+		if (key.startsWith('VSCODE_') || key.startsWith('ELECTRON_')) {
+			delete env[key];
+		}
+	}
+	return { ...env, ELECTRON_RUN_AS_NODE: '1' };
+}

--- a/extensions/positron-data-driver-odbc/tsconfig.json
+++ b/extensions/positron-data-driver-odbc/tsconfig.json
@@ -1,0 +1,30 @@
+{
+	"compilerOptions": {
+		"module": "nodenext",
+		"target": "ES2020",
+		"moduleResolution": "nodenext",
+		"outDir": "out",
+		"lib": [
+			"ES2020"
+		],
+		"rootDir": "src",
+		"sourceMap": true,
+		"strict": false,
+		"skipLibCheck": true,
+		"allowSyntheticDefaultImports": true,
+		"noImplicitAny": false,
+		"esModuleInterop": true,
+		"types": [
+			"node",
+			"mocha"
+		],
+		"typeRoots": [
+			"./node_modules/@types"
+		]
+	},
+	"include": [
+		"src/**/*",
+		"../../src/positron-dts/positron.d.ts",
+		"../../src/vscode-dts/vscode.d.ts"
+	]
+}

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2333,6 +2333,48 @@ declare module 'positron' {
 		 * @returns The redacted string to display, or undefined to show no placeholder.
 		 */
 		redactParameterValue?(mechanismId: string, parameterId: string, value: string): vscode.ProviderResult<string>;
+
+		/**
+		 * Reports connections this driver already knows about on this machine, without the user
+		 * having configured anything -- ODBC data sources declared in `odbc.ini`, for example.
+		 *
+		 * Positron shows these in the Data Connections pane alongside saved connections, so a data
+		 * source the machine is already set up for is connectable straight away. They are not
+		 * persisted: a discovered connection that stops being reported simply stops appearing, and
+		 * one the user saves becomes an ordinary saved connection from then on (and is no longer
+		 * shown as discovered).
+		 *
+		 * Called when the driver registers and whenever the set of registered drivers changes, so a
+		 * driver whose discoveries change should re-register to have them re-read.
+		 *
+		 * @returns The connections found on this machine, or an empty array if there are none.
+		 */
+		discoverConnections?(): Thenable<DiscoveredDataConnection[]>;
+	}
+
+	/**
+	 * A connection a driver found already configured on this machine, reported by
+	 * {@link DataConnectionDriver.discoverConnections}.
+	 */
+	export interface DiscoveredDataConnection {
+		/**
+		 * An identifier for this connection, unique within the driver and stable across sessions
+		 * (so the pane can keep a discovered connection's expansion state). Positron namespaces it
+		 * by driver, so it need not be globally unique.
+		 */
+		id: string;
+
+		/** The name to show in the pane. */
+		name: string;
+
+		/** An optional one-line summary of where the connection points, shown beneath the name. */
+		description?: string;
+
+		/** The id of the mechanism to connect with. One of this driver's `mechanisms`. */
+		mechanismId: string;
+
+		/** The parameter values to connect with, for the parameters that mechanism defines. */
+		parameters: DataConnectionParameterValues;
 	}
 
 	/**

--- a/src/vs/workbench/api/browser/positron/mainThreadDataConnections.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadDataConnections.ts
@@ -6,7 +6,7 @@
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { extHostNamedCustomer, IExtHostContext } from '../../../services/extensions/common/extHostCustomers.js';
 import { IPositronDataConnectionsService } from '../../../services/positronDataConnections/common/interfaces/positronDataConnectionsService.js';
-import { DataConnectionParameterValues, IDataConnectionCodeVariant, IDataConnectionDriver, IDataConnectionDriverMetadata, IDataConnectionHandle, IDataConnectionMechanism, IDataConnectionParameter } from '../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
+import { DataConnectionParameterValues, IDataConnectionCodeVariant, IDataConnectionDriver, IDataConnectionDriverMetadata, IDataConnectionHandle, IDataConnectionMechanism, IDataConnectionParameter, IDiscoveredDataConnection } from '../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
 import { IDataConnectionDriverMetadataDTO, IDataConnectionDriverSummaryDTO, IDataConnectionMechanismDTO, IDataConnectionNodeDTO, IDataConnectionParameterDTO } from '../../../services/positronDataConnections/common/interfaces/dataConnectionDTOs.js';
 import { ExtHostDataConnectionsShape, ExtHostPositronContext, MainPositronContext, MainThreadDataConnectionsShape } from '../../common/positron/extHost.positron.protocol.js';
 
@@ -296,6 +296,22 @@ class MainThreadDataConnectionDriverAdapter implements IDataConnectionDriver {
 	 */
 	async redactParameterValue(mechanismId: string, parameterId: string, value: string): Promise<string | undefined> {
 		return this._proxy.$redactParameterValue(this.id, mechanismId, parameterId, value);
+	}
+
+	/**
+	 * Asks the ext host to run driver.discoverConnections() via RPC, listing the connections already
+	 * configured on this machine. Resolves to an empty array for a driver that does not implement
+	 * discovery.
+	 */
+	async discoverConnections(): Promise<IDiscoveredDataConnection[]> {
+		const discovered = await this._proxy.$discoverConnections(this.id);
+		return discovered.map(connection => ({
+			id: connection.id,
+			name: connection.name,
+			description: connection.description,
+			mechanismId: connection.mechanismId,
+			parameterValues: connection.parameters,
+		}));
 	}
 }
 

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -17,7 +17,7 @@ import { ActiveRuntimeSessionMetadata, EnvironmentVariableAction, LanguageRuntim
 import { IDriverMetadata, Input } from '../../../services/positronConnections/common/interfaces/positronConnectionsDriver.js';
 import { IAvailableDriverMethods } from '../../browser/positron/mainThreadConnections.js';
 import { IChatRequestData, IGenerateAssistantPromptRequest, IPositronChatContext, IPositronLanguageModelConfig, IPositronLanguageModelSource, IShowLanguageModelConfigOptions } from '../../../contrib/positronAssistant/common/interfaces/positronAssistantService.js';
-import { DataConnectionParameterValuesDTO, IDataConnectionCodeVariantDTO, IDataConnectionDriverMetadataDTO, IDataConnectionDriverSummaryDTO, IDataConnectionNodeDTO } from '../../../services/positronDataConnections/common/interfaces/dataConnectionDTOs.js';
+import { DataConnectionParameterValuesDTO, IDataConnectionCodeVariantDTO, IDataConnectionDriverMetadataDTO, IDataConnectionDriverSummaryDTO, IDataConnectionNodeDTO, IDiscoveredDataConnectionDTO } from '../../../services/positronDataConnections/common/interfaces/dataConnectionDTOs.js';
 import { IDataExplorerRpcDto, IDataExplorerResponseDto, IDataExplorerUiEventDto } from '../../../services/positronDataExplorer/common/dataExplorerRpcTransport.js';
 import { IChatAgentData } from '../../../contrib/chat/common/participants/chatAgents.js';
 import { PlotRenderSettings } from '../../../services/positronPlots/common/positronPlots.js';
@@ -345,6 +345,7 @@ export interface ExtHostDataConnectionsShape {
 	$driverConnect(driverId: string, mechanismId: string, params: DataConnectionParameterValuesDTO): Promise<number>;
 	$generateConnectionCode(driverId: string, mechanismId: string, languageId: string, params: DataConnectionParameterValuesDTO): Promise<IDataConnectionCodeVariantDTO[]>;
 	$redactParameterValue(driverId: string, mechanismId: string, parameterId: string, value: string): Promise<string | undefined>;
+	$discoverConnections(driverId: string): Promise<IDiscoveredDataConnectionDTO[]>;
 	$connectionIsReadOnly(connectionHandle: number): Promise<boolean>;
 	$connectionGetChildren(connectionHandle: number): Promise<IDataConnectionNodeDTO[]>;
 	$connectionDisconnect(connectionHandle: number): Promise<void>;

--- a/src/vs/workbench/api/common/positron/extHostDataConnections.ts
+++ b/src/vs/workbench/api/common/positron/extHostDataConnections.ts
@@ -5,7 +5,7 @@
 
 import * as positron from 'positron';
 import * as extHostProtocol from './extHost.positron.protocol.js';
-import { IDataConnectionCodeVariantDTO, IDataConnectionDriverMetadataDTO, IDataConnectionDriverSummaryDTO, IDataConnectionNodeDTO, IDataConnectionParameterDTO } from '../../../services/positronDataConnections/common/interfaces/dataConnectionDTOs.js';
+import { IDataConnectionCodeVariantDTO, IDataConnectionDriverMetadataDTO, IDataConnectionDriverSummaryDTO, IDataConnectionNodeDTO, IDataConnectionParameterDTO, IDiscoveredDataConnectionDTO } from '../../../services/positronDataConnections/common/interfaces/dataConnectionDTOs.js';
 import { Disposable } from '../extHostTypes.js';
 
 /**
@@ -194,6 +194,28 @@ export class ExtHostDataConnections implements extHostProtocol.ExtHostDataConnec
 		}
 
 		return (await driver.redactParameterValue(mechanismId, parameterId, value)) ?? undefined;
+	}
+
+	/**
+	 * Calls the extension's driver.discoverConnections() to list the connections already configured
+	 * on this machine. Returns an empty array for a driver that does not implement discovery, which
+	 * is most of them -- the main thread asks every driver rather than tracking which ones opted in.
+	 * @param driverId The unique identifier of the driver.
+	 */
+	async $discoverConnections(driverId: string): Promise<IDiscoveredDataConnectionDTO[]> {
+		const driver = this._drivers.get(driverId);
+		if (!driver?.discoverConnections) {
+			return [];
+		}
+
+		const discovered = await driver.discoverConnections();
+		return discovered.map(connection => ({
+			id: connection.id,
+			name: connection.name,
+			description: connection.description,
+			mechanismId: connection.mechanismId,
+			parameters: connection.parameters,
+		}));
 	}
 
 	/**

--- a/src/vs/workbench/api/test/browser/positron/mainThreadDataConnections.vitest.ts
+++ b/src/vs/workbench/api/test/browser/positron/mainThreadDataConnections.vitest.ts
@@ -11,7 +11,7 @@ import { IExtHostContext } from '../../../../services/extensions/common/extHostC
 import { IPositronDataConnectionsService } from '../../../../services/positronDataConnections/common/interfaces/positronDataConnectionsService.js';
 import { IDataConnectionsDriverManager } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionsDriverManager.js';
 import { IDataConnectionDriver } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
-import { IDataConnectionDriverMetadataDTO } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDTOs.js';
+import { IDataConnectionDriverMetadataDTO, IDiscoveredDataConnectionDTO } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDTOs.js';
 import { ExtHostDataConnectionsShape } from '../../../common/positron/extHost.positron.protocol.js';
 import { MainThreadDataConnections } from '../../../browser/positron/mainThreadDataConnections.js';
 
@@ -43,6 +43,10 @@ describe('MainThreadDataConnections', () => {
 		}],
 	};
 
+	// The ext host end of $discoverConnections, wired into the proxy below. The discovery test sets
+	// what it answers with; the others never call it.
+	const $discoverConnections = vi.fn<() => Promise<IDiscoveredDataConnectionDTO[]>>();
+
 	let registeredDrivers: IDataConnectionDriver[];
 	let mainThread: MainThreadDataConnections;
 
@@ -54,7 +58,7 @@ describe('MainThreadDataConnections', () => {
 		});
 		const dataConnectionsService = stubInterface<IPositronDataConnectionsService>({ driverManager });
 		const extHostContext = stubInterface<IExtHostContext>({
-			getProxy: (<T>() => stubInterface<ExtHostDataConnectionsShape>({}) as T) as IExtHostContext['getProxy'],
+			getProxy: (<T>() => stubInterface<ExtHostDataConnectionsShape>({ $discoverConnections }) as T) as IExtHostContext['getProxy'],
 		});
 		mainThread = disposables.add(new MainThreadDataConnections(extHostContext, dataConnectionsService));
 	});
@@ -101,6 +105,54 @@ describe('MainThreadDataConnections', () => {
 		// The summary must equal what the extension declared: the FileFilter array flattens back
 		// to the label -> extensions dictionary and non-file parameters pass through untouched.
 		expect(summaries[0].mechanisms).toEqual(metadataDto.mechanisms);
+	});
+
+	it('maps a discovered connection onto the service shape, renaming parameters to parameterValues', async () => {
+		mainThread.$registerDataConnectionDriver('duckdb', metadataDto);
+		$discoverConnections.mockResolvedValue([{
+			id: 'pagila',
+			name: 'Pagila',
+			description: 'localhost:5432/pagila',
+			mechanismId: 'file',
+			parameters: { databasePath: '/data/pagila.duckdb', readOnly: true },
+		}]);
+
+		const discovered = await registeredDrivers[0].discoverConnections();
+
+		// The one field that changes name across the boundary is `parameters` -> `parameterValues`.
+		// A rename that silently stops landing leaves the connection with nothing to connect with,
+		// which reaches the user as a failure on empty credentials rather than as a mapping bug --
+		// so the whole mapped shape is pinned here, description included.
+		expect(discovered).toMatchInlineSnapshot(`
+			[
+			  {
+			    "description": "localhost:5432/pagila",
+			    "id": "pagila",
+			    "mechanismId": "file",
+			    "name": "Pagila",
+			    "parameterValues": {
+			      "databasePath": "/data/pagila.duckdb",
+			      "readOnly": true,
+			    },
+			  },
+			]
+		`);
+	});
+
+	// A driver that reports no summary must not invent one: the pane falls back to the driver name,
+	// and an empty string would render as a bare separator with nothing after it.
+	it('leaves a discovered connection description undefined when the driver reports none', async () => {
+		mainThread.$registerDataConnectionDriver('duckdb', metadataDto);
+		$discoverConnections.mockResolvedValue([{
+			id: 'pagila',
+			name: 'Pagila',
+			mechanismId: 'file',
+			parameters: {},
+		}]);
+
+		const discovered = await registeredDrivers[0].discoverConnections();
+
+		expect(discovered[0].description).toBeUndefined();
 	});
 
 	it('leaves filters undefined across the boundary when the file parameter declares none', async () => {

--- a/src/vs/workbench/contrib/positronDataConnections/browser/classes/dataConnectionsTreeInstance.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/classes/dataConnectionsTreeInstance.tsx
@@ -130,6 +130,7 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 		};
 		this._register(this._service.onDidChangeProfiles(refreshRoots));
 		this._register(this._service.onDidChangeInstances(refreshRoots));
+		this._register(this._service.onDidChangeDiscoveredProfiles(refreshRoots));
 	}
 
 	/**
@@ -265,10 +266,14 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 
 /**
  * Builds the entries from the service's current profile + instance collections. One entry per
- * saved profile; the entry's instance is set when a live connection exists for that profile.
+ * saved profile, followed by one per discovered connection; the entry's instance is set when a live
+ * connection exists for that profile.
+ *
+ * Discovered connections come last so a user's own saved connections keep the top of the pane: on a
+ * machine with a large odbc.ini the discoveries can outnumber them several times over.
  */
 function buildEntries(service: IPositronDataConnectionsService): DataConnectionEntry[] {
-	return service.getProfiles().map(profile => ({
+	return [...service.getProfiles(), ...service.getDiscoveredProfiles()].map(profile => ({
 		profile,
 		instance: service.getInstanceForProfile(profile.id),
 	}));

--- a/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionEntryRow.css
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionEntryRow.css
@@ -37,6 +37,26 @@
 	background-color: var(--vscode-charts-green);
 }
 
+/*
+ * Badge on a connection detected from the machine's ODBC configuration rather than saved by the
+ * user. Quiet by design: it labels the row's provenance and must not compete with the connection
+ * name beside it, so it takes the badge tier's muted surface rather than an accent.
+ */
+.data-connection-entry-discovered {
+	flex: 0 0 auto;
+	margin: 0 5px;
+	padding: 0 5px;
+	border-radius: 3px;
+	font-size: 9px;
+	line-height: 14px;
+	text-transform: uppercase;
+	letter-spacing: 0.4px;
+	white-space: nowrap;
+	color: var(--vscode-badge-foreground);
+	background-color: var(--vscode-badge-background);
+	opacity: 0.8;
+}
+
 .data-connection-entry-actions {
 	display: flex;
 	width: 20px;

--- a/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionEntryRow.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionEntryRow.tsx
@@ -23,7 +23,7 @@ import { CustomContextMenuItem } from '../../../../browser/positronComponents/cu
 import { CustomContextMenuSeparator } from '../../../../browser/positronComponents/customContextMenu/customContextMenuSeparator.js';
 import { CustomContextMenuEntry, showCustomContextMenu } from '../../../../browser/positronComponents/customContextMenu/customContextMenu.js';
 import { AnchorPoint } from '../../../../browser/positronComponents/positronModalPopup/positronModalPopup.js';
-import { resolveDataConnectionMechanism } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
+import { IDataConnectionDriver, IDataConnectionProfile, resolveDataConnectionMechanism } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDriver.js';
 
 /**
  * DataConnectionEntryRowProps interface.
@@ -84,6 +84,10 @@ export const DataConnectionEntryRow = ({ entry, onDisconnect, onMenuOpening, onR
 
 	/**
 	 * Opens the edit dialog for this connection profile.
+	 *
+	 * Editing a discovered connection saves it first. A discovery is derived from the machine's ODBC
+	 * configuration and is rebuilt from it on every refresh, so there is nowhere for an edit to be
+	 * kept; saving turns it into an ordinary profile that the edit can then be written to.
 	 */
 	const editProfile = () => {
 		const driver = positronDataConnectionsService.driverManager.getDriver(profile.driverMetadata.id);
@@ -92,9 +96,27 @@ export const DataConnectionEntryRow = ({ entry, onDisconnect, onMenuOpening, onR
 			return;
 		}
 
+		if (profile.discovered) {
+			const savedId = positronDataConnectionsService.saveDiscoveredProfile(profile.id);
+			const saved = savedId === undefined ? undefined : positronDataConnectionsService.getProfile(savedId);
+			if (!saved) {
+				return;
+			}
+			// The saved profile replaces this row, and the edit dialog opens on it instead.
+			editSavedProfile(driver, saved);
+			return;
+		}
+
+		editSavedProfile(driver, profile);
+	};
+
+	/**
+	 * Opens the edit dialog for a saved profile.
+	 */
+	const editSavedProfile = (driver: IDataConnectionDriver, target: IDataConnectionProfile) => {
 		// Resolve the mechanism the profile was configured with (falling back to the first for
 		// pre-mechanisms profiles); its parameters drive the form.
-		const mechanism = resolveDataConnectionMechanism(driver.metadata, profile.mechanismId);
+		const mechanism = resolveDataConnectionMechanism(driver.metadata, target.mechanismId);
 		if (!mechanism) {
 			reportDriverAccessError();
 			return;
@@ -106,7 +128,7 @@ export const DataConnectionEntryRow = ({ entry, onDisconnect, onMenuOpening, onR
 			<ConfigureDataConnection
 				driver={driver}
 				mechanism={mechanism}
-				profile={profile}
+				profile={target}
 				renderer={renderer}
 				onSave={updatedProfile => {
 					positronDataConnectionsService.addUpdateProfile(updatedProfile);
@@ -239,10 +261,8 @@ export const DataConnectionEntryRow = ({ entry, onDisconnect, onMenuOpening, onR
 			}
 		}
 
-		// Finally, add a separator and the options that take something away: disconnect (only while
-		// there is a live connection to close), then remove. Only remove is marked destructive --
-		// disconnecting gives up the connection but keeps the saved profile, and nothing about it is
-		// unrecoverable.
+		// Finally, add a separator and the options that change what the pane holds: disconnect (only
+		// while there is a live connection to close), then save or remove.
 		entries.push(new CustomContextMenuSeparator());
 		if (entry.instance) {
 			entries.push(new CustomContextMenuItem({
@@ -251,13 +271,26 @@ export const DataConnectionEntryRow = ({ entry, onDisconnect, onMenuOpening, onR
 				onSelected: onDisconnect,
 			}));
 		}
-		entries.push(
-			new CustomContextMenuItem({
+
+		// A discovered connection is not the user's to remove -- it comes from the machine's own
+		// configuration and would simply reappear -- so it offers Save instead, which turns it into
+		// an ordinary saved connection that can then be edited and removed like any other. Only
+		// Remove is marked destructive; disconnecting gives up the connection but keeps the saved
+		// profile, and saving takes nothing away.
+		if (profile.discovered) {
+			entries.push(new CustomContextMenuItem({
+				icon: 'save',
+				label: localize('positron.dataConnections.saveConnection', "Save Connection"),
+				onSelected: () => positronDataConnectionsService.saveDiscoveredProfile(profile.id),
+			}));
+		} else {
+			entries.push(new CustomContextMenuItem({
 				destructive: true,
 				icon: 'trash',
 				label: localize('positron.dataConnections.remove', "Remove"),
 				onSelected: () => confirmRemoveProfile(),
 			}));
+		}
 
 		// Announced before the menu shows so the row is already selected and the tree still reads
 		// as focused when the menu paints over it. Acquired here rather than on entry to the
@@ -302,6 +335,12 @@ export const DataConnectionEntryRow = ({ entry, onDisconnect, onMenuOpening, onR
 	// The connected indicator's label, used as both its tooltip and its accessible name.
 	const connectedLabel = localize('positron.dataConnections.connected', "Connected");
 
+	// The discovered badge's label, used as both its tooltip and its accessible name.
+	const discoveredLabel = localize(
+		'positron.dataConnections.discovered',
+		"Detected from this computer's configuration. Save it to keep and edit it."
+	);
+
 	// Render.
 	return (
 		// The row is a presentational element inside a tree that owns focus and keyboard
@@ -313,8 +352,24 @@ export const DataConnectionEntryRow = ({ entry, onDisconnect, onMenuOpening, onR
 			<div className='data-connection-entry-text'>
 				{profile.connectionName}
 				{' · '}
-				{profile.driverMetadata.name}
+				{/*
+					A discovered connection's summary ("localhost:5432/pagila") says more than the
+					driver name would: every discovered row in the pane comes from the same driver,
+					so the name is the one thing that cannot tell them apart.
+				*/}
+				{(profile.discovered && profile.description) || profile.driverMetadata.name}
 			</div>
+			{profile.discovered && (
+				// Marks a connection the machine's own configuration provides rather than one the
+				// user saved, so it is clear why it is there and why it offers Save over Remove.
+				<div
+					aria-label={discoveredLabel}
+					className='data-connection-entry-discovered'
+					title={discoveredLabel}
+				>
+					{localize('positron.dataConnections.discoveredBadge', "Detected")}
+				</div>
+			)}
 			{entry.instance && (
 				// Shown whenever the profile has a live connection, including while the entry is
 				// collapsed -- collapsing does not necessarily disconnect, so this is how the user

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnection.css
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnection.css
@@ -130,8 +130,14 @@
 	outline: 1px solid var(--vscode-focusBorder) !important;
 }
 
+/*
+ * The select sits inside a .select-container, whose pseudo-element draws the workbench dropdown
+ * chevron over the right edge. Keep the text clear of it so a long option (an ODBC driver name,
+ * say) is truncated rather than running underneath.
+ */
 .configure-data-connection .parameter-select {
 	height: 26px;
+	padding-right: 24px;
 }
 
 .configure-data-connection .parameter-checkbox {

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnectionParameters.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnectionParameters.tsx
@@ -161,20 +161,27 @@ export const ConfigureDataConnectionParameters = ({
 						return (
 							<div key={parameter.id} className='parameter-field'>
 								<ParameterLabel htmlFor={fieldId} label={parameter.label} optional={!parameter.required} />
-								<select
-									aria-required={parameter.required || undefined}
-									className={positronClassNames(
-										'parameter-input', 'parameter-select',
-										{ 'error': parameterFieldStates[parameter.id].error }
-									)}
-									id={fieldId}
-									value={parameterFieldStates[parameter.id].value as string}
-									onChange={e => onParameterChanged(parameter.id, e.target.value)}
-								>
-									{parameter.options?.map(option => (
-										<option key={option} value={option}>{option}</option>
-									))}
-								</select>
+								{/*
+								 * The workbench strips the native dropdown arrow from every select and
+								 * restores it with a pseudo-element on this wrapper, so a select without
+								 * it is indistinguishable from a text input.
+								 */}
+								<div className='select-container'>
+									<select
+										aria-required={parameter.required || undefined}
+										className={positronClassNames(
+											'parameter-input', 'parameter-select',
+											{ 'error': parameterFieldStates[parameter.id].error }
+										)}
+										id={fieldId}
+										value={parameterFieldStates[parameter.id].value as string}
+										onChange={e => onParameterChanged(parameter.id, e.target.value)}
+									>
+										{parameter.options?.map(option => (
+											<option key={option} value={option}>{option}</option>
+										))}
+									</select>
+								</div>
 								<ParameterDescription text={parameter.description} />
 							</div>
 						);

--- a/src/vs/workbench/contrib/positronDataConnections/test/browser/dataConnectionEntryRow.vitest.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/test/browser/dataConnectionEntryRow.vitest.tsx
@@ -27,6 +27,17 @@ vi.mock('../../../../browser/positronComponents/customContextMenu/customContextM
 	showCustomContextMenu,
 }));
 
+// The edit dialog is opened through a renderer that drives a native <dialog> via showModal(), which
+// the test DOM doesn't implement -- and the dialog itself isn't what these tests are about. Mocking
+// the renderer lets us read the profile the row handed the dialog straight off the render call.
+const { modalRender } = vi.hoisted(() => ({ modalRender: vi.fn() }));
+vi.mock('../../../../../base/browser/positronModalDialogReactRenderer.js', () => ({
+	PositronModalDialogReactRenderer: class {
+		render = modalRender;
+		dispose = vi.fn();
+	},
+}));
+
 const profile: IDataConnectionProfile = {
 	id: 'conn-1',
 	driverMetadata: {
@@ -39,6 +50,27 @@ const profile: IDataConnectionProfile = {
 	mechanismId: 'test-mechanism',
 	parameterValues: {},
 };
+
+// A discovered profile: built from the machine's own configuration rather than saved by the user,
+// so it carries the discovered flag and a summary of where it points instead of a saved identity.
+const discoveredProfile: IDataConnectionProfile = {
+	...profile,
+	id: 'discovered-1',
+	connectionName: 'Discovered Connection',
+	description: 'localhost:5432/pagila',
+	discovered: true,
+};
+
+// What saving the discovered profile turns it into -- the same connection, now the user's to edit.
+const savedDiscoveredProfile: IDataConnectionProfile = {
+	...discoveredProfile,
+	id: 'saved-discovered-1',
+	description: undefined,
+	discovered: undefined,
+};
+
+// The badge's aria-label, which is also its tooltip; the visible text is just "Detected".
+const DISCOVERED_LABEL = 'Detected from this computer\'s configuration. Save it to keep and edit it.';
 
 // The row needs its driver to build a menu at all. This one supports no languages, so the menu
 // leaves out the Connect With group and the entries under test stand alone.
@@ -55,10 +87,17 @@ const driver = stubInterface<IDataConnectionDriver>({
 });
 
 describe('DataConnectionEntryRow', () => {
+	// Saving a discovered profile hands back the id of the ordinary profile it became, which the row
+	// then looks up. Declared here so the tests can assert against the calls.
+	const saveDiscoveredProfile = vi.fn((_id: string) => savedDiscoveredProfile.id);
+	const getProfile = vi.fn((id: string) => id === savedDiscoveredProfile.id ? savedDiscoveredProfile : undefined);
+
 	const ctx = createTestContainer()
 		.withReactServices()
 		.stub(IPositronDataConnectionsService, {
 			driverManager: stubInterface<IDataConnectionsDriverManager>({ getDriver: () => driver }),
+			getProfile,
+			saveDiscoveredProfile,
 		})
 		.build();
 	const rtl = setupRTLRenderer(() => ctx.reactServices);
@@ -69,18 +108,19 @@ describe('DataConnectionEntryRow', () => {
 	const onMenuOpening = vi.fn((): IDisposable => ({ dispose: vi.fn() }));
 
 	/**
-	 * Renders a row -- connected unless told otherwise -- and right-clicks it. Returns the row's
-	 * callbacks, the menu call, and the labels of the entries the row offered ('---' for a separator).
+	 * Renders a row -- the saved profile, connected, unless told otherwise -- and right-clicks it.
+	 * Returns the row's callbacks, the menu call, and the labels of the entries the row offered
+	 * ('---' for a separator).
 	 */
-	async function rightClickRow(connected = true) {
+	async function rightClickRow({ connected = true, rowProfile = profile } = {}) {
 		const instance = connected
-			? stubInterface<IDataConnectionInstance>({ id: 'instance-1', profileId: profile.id })
+			? stubInterface<IDataConnectionInstance>({ id: 'instance-1', profileId: rowProfile.id })
 			: undefined;
 		const onDisconnectRow = vi.fn();
 
 		rtl.render(
 			<DataConnectionEntryRow
-				entry={{ profile, instance }}
+				entry={{ profile: rowProfile, instance }}
 				onDisconnect={onDisconnectRow}
 				onMenuOpening={onMenuOpening}
 				onRefresh={onRefresh}
@@ -90,7 +130,7 @@ describe('DataConnectionEntryRow', () => {
 		const user = userEvent.setup();
 		// The row is a structural div with no role or label, so target its name instead -- pointer
 		// events there bubble up to the row's handlers, which is what a real click does too.
-		await user.pointer({ keys: '[MouseRight]', target: screen.getByText('My Connection', { exact: false }) });
+		await user.pointer({ keys: '[MouseRight]', target: screen.getByText(rowProfile.connectionName, { exact: false }) });
 
 		const call = showCustomContextMenu.mock.calls.at(-1)?.[0];
 		const items: CustomContextMenuItem[] = call?.entries.filter(
@@ -123,6 +163,20 @@ describe('DataConnectionEntryRow', () => {
 		expect(screen.getByText('My Connection', { exact: false })).toBeInTheDocument();
 	});
 
+	it('badges a discovered profile as Detected', () => {
+		rtl.render(<DataConnectionEntryRow entry={{ profile: discoveredProfile }} onDisconnect={onDisconnect} onMenuOpening={onMenuOpening} onRefresh={onRefresh} />);
+
+		// The badge has no role, so its aria-label -- which explains why the row is there, where the
+		// visible word alone would not -- is what there is to query it by.
+		expect(screen.getByLabelText(DISCOVERED_LABEL)).toHaveTextContent('Detected');
+	});
+
+	it('shows no Detected badge for a saved profile', () => {
+		rtl.render(<DataConnectionEntryRow entry={{ profile }} onDisconnect={onDisconnect} onMenuOpening={onMenuOpening} onRefresh={onRefresh} />);
+
+		expect(screen.queryByLabelText(DISCOVERED_LABEL)).not.toBeInTheDocument();
+	});
+
 	it('offers Disconnect above Remove for a connected profile', async () => {
 		const { labels } = await rightClickRow();
 
@@ -140,7 +194,7 @@ describe('DataConnectionEntryRow', () => {
 
 	// Nothing to close on a saved-but-closed profile, so the item would be dead weight.
 	it('offers no Disconnect for a profile that is not connected', async () => {
-		const { labels } = await rightClickRow(false);
+		const { labels } = await rightClickRow({ connected: false });
 
 		expect(labels).toMatchInlineSnapshot(`
 			[
@@ -150,6 +204,43 @@ describe('DataConnectionEntryRow', () => {
 			  "---",
 			  "Remove",
 			]
+		`);
+	});
+
+	// A discovered connection comes from the machine's own configuration, so removing it would only
+	// have it reappear on the next refresh. Saving is the way out of it instead.
+	it('offers Save Connection instead of Remove for a discovered profile', async () => {
+		const { labels } = await rightClickRow({ connected: false, rowProfile: discoveredProfile });
+
+		expect(labels).toMatchInlineSnapshot(`
+			[
+			  "Refresh",
+			  "---",
+			  "Edit Connection",
+			  "---",
+			  "Save Connection",
+			]
+		`);
+	});
+
+	it('saves a discovered profile before opening the edit dialog on it', async () => {
+		const { itemByLabel } = await rightClickRow({ connected: false, rowProfile: discoveredProfile });
+
+		itemByLabel('Edit Connection')?.options.onSelected({ altKey: false, ctrlKey: false, metaKey: false, shiftKey: false });
+
+		// A discovery is rebuilt from the machine's configuration on every refresh, so an edit has
+		// nowhere to be kept until it has been saved -- and the dialog has to open on the saved
+		// profile that replaces the row, not on the discovered one.
+		expect({
+			savedProfileIds: saveDiscoveredProfile.mock.calls.flat(),
+			dialogProfileId: modalRender.mock.lastCall?.[0].props.profile.id,
+		}).toMatchInlineSnapshot(`
+			{
+			  "dialogProfileId": "saved-discovered-1",
+			  "savedProfileIds": [
+			    "discovered-1",
+			  ],
+			}
 		`);
 	});
 

--- a/src/vs/workbench/contrib/positronDataConnections/test/browser/dataConnectionsTreeInstance.vitest.ts
+++ b/src/vs/workbench/contrib/positronDataConnections/test/browser/dataConnectionsTreeInstance.vitest.ts
@@ -170,7 +170,7 @@ describe('DataConnectionsTreeInstance', () => {
 	 * flips the profile's live state and notifies the tree, standing in for the service connecting or
 	 * disconnecting it.
 	 */
-	function createTree(connected = true) {
+	function createTree(connected = true, discoveredProfiles: IDataConnectionProfile[] = []) {
 		// One leaf under the connection, so a test has a real non-entry node to act on. Its node id is
 		// DTO_ID below.
 		const getChildren = vi.fn(async () => [{
@@ -195,7 +195,9 @@ describe('DataConnectionsTreeInstance', () => {
 		const service = stubInterface<IPositronDataConnectionsService>({
 			onDidChangeProfiles: Event.None,
 			onDidChangeInstances: onDidChangeInstances.event,
+			onDidChangeDiscoveredProfiles: Event.None,
 			getProfiles: () => [profile],
+			getDiscoveredProfiles: () => discoveredProfiles,
 			getInstanceForProfile: () => liveInstance,
 			connect: async () => instance,
 			disconnect,
@@ -213,6 +215,23 @@ describe('DataConnectionsTreeInstance', () => {
 
 		return { tree, service, getChildren, setConnected, disconnect, disconnectWhenUnused };
 	}
+
+	it('lists discovered connections after the saved ones', async () => {
+		const discovered = createProfile({
+			id: 'discovered:odbc:Pagila',
+			connectionName: 'Pagila',
+			discovered: true,
+		});
+		const { tree } = createTree(true, [discovered]);
+		await tree.refresh();
+
+		// Saved first, then discovered: on a machine with a large odbc.ini the discoveries can
+		// outnumber the user's own connections several times over.
+		expect(tree.visibleNodes.map(visible => visible.node.id)).toEqual([
+			ENTRY_ID,
+			'entry:discovered:odbc:Pagila',
+		]);
+	});
 
 	it('gives up its use of the connection when a connected entry is collapsed', async () => {
 		const { tree, service } = createTree();

--- a/src/vs/workbench/services/positronDataConnections/browser/positronDataConnectionsService.ts
+++ b/src/vs/workbench/services/positronDataConnections/browser/positronDataConnectionsService.ts
@@ -73,6 +73,14 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 	// Fires when data connection instances change.
 	private readonly _onDidChangeInstancesEmitter = this._register(new Emitter<IDataConnectionInstance[]>());
 
+	// Ephemeral profiles for the connections drivers report as already configured on this machine.
+	// Rebuilt whenever the registered drivers change and never persisted; see
+	// _refreshDiscoveredProfiles.
+	private _discoveredProfiles: IDataConnectionProfile[] = [];
+
+	// Fires when the discovered data connections change.
+	private readonly _onDidChangeDiscoveredProfilesEmitter = this._register(new Emitter<IDataConnectionProfile[]>());
+
 	//#endregion Private Properties
 
 	//#region Constructor & Dispose
@@ -105,6 +113,12 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 		// A closing editor may have been the last Data Explorer holding a connection open. The event
 		// fires after the editor leaves its group, so the count below already reflects the close.
 		this._register(this._editorService.onDidCloseEditor(() => this._disconnectUnusedProfiles()));
+
+		// Discovery is a property of the registered drivers, so it is re-read whenever they change:
+		// when a driver's extension activates, and when a driver re-registers because what it can
+		// see changed (the ODBC driver does this when odbc.ini is edited).
+		this._register(this.driverManager.onDidChangeDrivers(() => this._refreshDiscoveredProfiles()));
+		this._refreshDiscoveredProfiles();
 	}
 
 	//#endregion Constructor & Dispose
@@ -122,6 +136,48 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 
 	// Fires when data connection instances change.
 	readonly onDidChangeInstances: Event<IDataConnectionInstance[]> = this._onDidChangeInstancesEmitter.event;
+
+	// Fires when the discovered data connections change.
+	readonly onDidChangeDiscoveredProfiles: Event<IDataConnectionProfile[]> = this._onDidChangeDiscoveredProfilesEmitter.event;
+
+	/**
+	 * Gets the connections drivers report as already configured on this machine, as ephemeral
+	 * profiles. Discoveries matching a saved profile are filtered out here rather than at refresh
+	 * time, so saving or removing a profile takes effect without waiting for a re-discovery.
+	 */
+	getDiscoveredProfiles(): readonly IDataConnectionProfile[] {
+		return this._discoveredProfiles.filter(discovered =>
+			!this._profiles.some(saved => this._isSameConnection(saved, discovered)));
+	}
+
+	/**
+	 * Saves a discovered connection as an ordinary profile. The saved profile gets a fresh id: the
+	 * discovered id is scoped to the driver's discovery namespace, and reusing it would tie the
+	 * saved profile's identity to a discovery that may later disappear.
+	 * @param id The discovered profile id.
+	 */
+	saveDiscoveredProfile(id: string): string | undefined {
+		const discovered = this._discoveredProfiles.find(_ => _.id === id);
+		if (!discovered) {
+			return undefined;
+		}
+
+		// Drop `discovered` and `description`: from here on this is an ordinary saved profile, and
+		// leaving the marker on would keep the pane treating it as ephemeral.
+		const { discovered: _discovered, description: _description, ...rest } = discovered;
+		const profile: IDataConnectionProfile = {
+			...rest,
+			id: generateUuid(),
+			createdAt: Date.now(),
+		};
+
+		this.addUpdateProfile(profile);
+
+		// The discovery is now shadowed by the saved profile, so the pane needs to drop its row.
+		this._onDidChangeDiscoveredProfilesEmitter.fire([...this.getDiscoveredProfiles()]);
+
+		return profile.id;
+	}
 
 	/**
 	 * Adds or updates a data connection profile.
@@ -170,7 +226,9 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 	 * @returns The matching data connection profile, or undefined if not found.
 	 */
 	getProfile(id: string): IDataConnectionProfile | undefined {
-		return this._profiles.find(p => p.id === id);
+		// Discovered profiles are addressable by id too, so a caller holding an id from the pane can
+		// resolve it without caring whether the row it came from was saved or discovered.
+		return this._profiles.find(p => p.id === id) ?? this._discoveredProfiles.find(p => p.id === id);
 	}
 
 	/**
@@ -184,7 +242,10 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 		// Look up the data connection profile by id. If not found, return undefined.
 		const profile = this._profiles.find(_ => _.id === id);
 		if (!profile) {
-			return undefined;
+			// A discovered profile has nothing in secret storage -- it was never saved -- so its
+			// parameter values are already complete. Whatever credentials the connection needs are
+			// the data source's own (an ODBC DSN carries them, or the driver prompts).
+			return this._discoveredProfiles.find(_ => _.id === id);
 		}
 
 		// The persisted data connection profile tells us which parameter ids are secrets for this
@@ -513,6 +574,63 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 	//#endregion IPositronDataConnectionsService Implementation
 
 	//#region Private Methods
+
+	/**
+	 * Re-reads every registered driver's discovered connections and republishes them as ephemeral
+	 * profiles.
+	 *
+	 * Discovery ids are namespaced by driver, so two drivers reporting a data source of the same
+	 * name do not collide. Failures are logged and treated as "this driver found nothing": a driver
+	 * whose discovery throws should not take the other drivers' discoveries down with it.
+	 */
+	private async _refreshDiscoveredProfiles(): Promise<void> {
+		const drivers = this.driverManager.getDrivers();
+		const results = await Promise.all(drivers.map(async driver => {
+			try {
+				const discovered = await driver.discoverConnections();
+				return discovered.map((connection): IDataConnectionProfile => ({
+					id: `discovered:${driver.id}:${connection.id}`,
+					driverMetadata: {
+						id: driver.metadata.id,
+						name: driver.metadata.name,
+						iconSvg: driver.metadata.iconSvg,
+						supportedLanguageIds: driver.metadata.supportedLanguageIds,
+					},
+					connectionName: connection.name,
+					description: connection.description,
+					mechanismId: connection.mechanismId,
+					parameterValues: connection.parameterValues,
+					discovered: true,
+				}));
+			} catch (err) {
+				this._logService.error(`[DataConnections] discoverConnections() threw for driver ${driver.id}: ${err}`);
+				return [];
+			}
+		}));
+
+		this._discoveredProfiles = results.flat();
+		this._logService.trace(`[DataConnections] Discovered ${this._discoveredProfiles.length} connection(s) across ${drivers.length} driver(s)`);
+		this._onDidChangeDiscoveredProfilesEmitter.fire([...this.getDiscoveredProfiles()]);
+	}
+
+	/**
+	 * Whether two profiles describe the same connection: the same driver, configured the same way,
+	 * with the same values. Used to suppress a discovery the user has already saved.
+	 *
+	 * Only the public parameter values are compared, which is all a saved profile holds in memory --
+	 * its secrets live in secret storage. A discovery carries no secrets either (an ODBC data source
+	 * names itself and leaves the credentials to the DSN), so the comparison is like for like.
+	 */
+	private _isSameConnection(saved: IDataConnectionProfile, discovered: IDataConnectionProfile): boolean {
+		if (saved.driverMetadata.id !== discovered.driverMetadata.id || saved.mechanismId !== discovered.mechanismId) {
+			return false;
+		}
+
+		const savedKeys = Object.keys(saved.parameterValues);
+		const discoveredKeys = Object.keys(discovered.parameterValues);
+		return savedKeys.length === discoveredKeys.length
+			&& savedKeys.every(key => saved.parameterValues[key] === discovered.parameterValues[key]);
+	}
 
 	/**
 	 * Closes the connections of any profiles waiting on their last Data Explorer, now that one has

--- a/src/vs/workbench/services/positronDataConnections/common/interfaces/dataConnectionDTOs.ts
+++ b/src/vs/workbench/services/positronDataConnections/common/interfaces/dataConnectionDTOs.ts
@@ -91,6 +91,29 @@ export interface IDataConnectionCodeVariantDTO {
 }
 
 /**
+ * Serializable form of a connection a driver found already configured on this machine (e.g. an
+ * ODBC data source declared in odbc.ini). Converted to an ephemeral IDataConnectionProfile at the
+ * main-thread boundary; never persisted unless the user saves it.
+ */
+export interface IDiscoveredDataConnectionDTO {
+	// Unique within the driver and stable across sessions. Namespaced by driver id on the main
+	// thread, so it need not be globally unique.
+	id: string;
+
+	// The name to show in the pane.
+	name: string;
+
+	// An optional one-line summary of where the connection points.
+	description?: string;
+
+	// The id of the mechanism to connect with. One of the driver's mechanisms.
+	mechanismId: string;
+
+	// The parameter values to connect with.
+	parameters: DataConnectionParameterValuesDTO;
+}
+
+/**
  * A lightweight summary of a registered driver, returned to the ext host
  * for the positron.dataConnections.getDrivers() API.
  */

--- a/src/vs/workbench/services/positronDataConnections/common/interfaces/dataConnectionDriver.ts
+++ b/src/vs/workbench/services/positronDataConnections/common/interfaces/dataConnectionDriver.ts
@@ -52,6 +52,16 @@ export interface IDataConnectionProfile {
 	// and languages the user has never picked a variant for are absent. Callers fall back to
 	// variants[0] when a language has no stored preference.
 	preferredCodeVariants?: Record<string, string>;
+
+	// Set when this profile was reported by a driver's discoverConnections rather than saved by the
+	// user. A discovered profile is ephemeral: it is not persisted, it disappears when the driver
+	// stops reporting it, and the pane offers to save it rather than to remove it. Absent on every
+	// saved profile.
+	readonly discovered?: true;
+
+	// A one-line summary of where a discovered connection points, supplied by the driver. Only ever
+	// set alongside `discovered`.
+	readonly description?: string;
 }
 
 /**
@@ -175,6 +185,35 @@ export interface IDataConnectionDriver {
 	 * @param value The stored cleartext parameter value.
 	 */
 	redactParameterValue(mechanismId: string, parameterId: string, value: string): Promise<string | undefined>;
+
+	/**
+	 * Lists the connections this driver found already configured on the machine (e.g. ODBC data
+	 * sources). Resolves to an empty array for the drivers that do not implement discovery, which is
+	 * most of them.
+	 */
+	discoverConnections(): Promise<IDiscoveredDataConnection[]>;
+}
+
+/**
+ * Service-level form of a connection a driver found already configured on this machine. Converted
+ * to an ephemeral IDataConnectionProfile by the service, which owns the id namespacing and the
+ * deduplication against saved profiles.
+ */
+export interface IDiscoveredDataConnection {
+	// Unique within the driver and stable across sessions.
+	id: string;
+
+	// The name to show in the pane.
+	name: string;
+
+	// An optional one-line summary of where the connection points.
+	description?: string;
+
+	// The id of the mechanism to connect with. One of the driver's mechanisms.
+	mechanismId: string;
+
+	// The parameter values to connect with.
+	parameterValues: DataConnectionParameterValues;
 }
 
 /**

--- a/src/vs/workbench/services/positronDataConnections/common/interfaces/positronDataConnectionsService.ts
+++ b/src/vs/workbench/services/positronDataConnections/common/interfaces/positronDataConnectionsService.ts
@@ -31,6 +31,27 @@ export interface IPositronDataConnectionsService extends IDisposable {
 	// Fires when data connection instances change.
 	onDidChangeInstances: Event<IDataConnectionInstance[]>;
 
+	// Fires when the discovered data connections change.
+	onDidChangeDiscoveredProfiles: Event<IDataConnectionProfile[]>;
+
+	/**
+	 * Gets the connections drivers report as already configured on this machine (e.g. ODBC data
+	 * sources), as ephemeral profiles. These are not persisted and are never returned by
+	 * {@link getProfiles}. A discovery that matches a saved profile -- same driver, mechanism, and
+	 * parameter values -- is omitted, so a data source the user has already configured appears once.
+	 * @returns The discovered data connection profiles.
+	 */
+	getDiscoveredProfiles(): readonly IDataConnectionProfile[];
+
+	/**
+	 * Saves a discovered connection as an ordinary profile, so it persists across sessions and can
+	 * be edited and removed. The discovered entry stops being reported separately once saved, since
+	 * the saved profile matches it. A no-op if the id is not a current discovery.
+	 * @param id The discovered profile id.
+	 * @returns The id of the saved profile, or undefined if the discovery was not found.
+	 */
+	saveDiscoveredProfile(id: string): string | undefined;
+
 	/**
 	 * Adds or updates a data connection profile.
 	 * @param profile The data connection profile to add or update.

--- a/src/vs/workbench/services/positronDataConnections/test/browser/positronDataConnectionsService.vitest.ts
+++ b/src/vs/workbench/services/positronDataConnections/test/browser/positronDataConnectionsService.vitest.ts
@@ -409,4 +409,126 @@ describe('PositronDataConnectionsService', () => {
 			});
 		});
 	});
+
+	describe('discovered connections', () => {
+		// Registers a driver reporting the given discoveries and waits for the service to publish
+		// them. Registration fires onDidChangeDrivers, which is what triggers the refresh.
+		const registerDiscoveringDriver = async (
+			discovered: Array<{ id: string; name: string; description?: string; mechanismId: string; parameterValues: Record<string, string> }>
+		) => {
+			service.driverManager.registerDriver(stubInterface<IDataConnectionDriver>({
+				id: 'test-driver',
+				metadata: createDriverMetadata(),
+				discoverConnections: async () => discovered,
+			}));
+			await vi.waitFor(() => {
+				expect(service.getDiscoveredProfiles().length).toBe(discovered.length);
+			});
+		};
+
+		const pagila = {
+			id: 'odbc-dsn:Pagila',
+			name: 'Pagila',
+			description: 'localhost:5432/pagila',
+			mechanismId: 'test-mechanism',
+			parameterValues: { dsn: 'Pagila' },
+		};
+
+		it('publishes a driver\'s discoveries as ephemeral profiles, namespaced by driver', async () => {
+			await registerDiscoveringDriver([pagila]);
+
+			expect(service.getDiscoveredProfiles()).toEqual([{
+				id: 'discovered:test-driver:odbc-dsn:Pagila',
+				driverMetadata: {
+					id: 'test-driver',
+					name: 'Test Driver',
+					iconSvg: '',
+					supportedLanguageIds: [],
+				},
+				connectionName: 'Pagila',
+				description: 'localhost:5432/pagila',
+				mechanismId: 'test-mechanism',
+				parameterValues: { dsn: 'Pagila' },
+				discovered: true,
+			}]);
+
+			// Discoveries are never persisted, so they must not show up among the saved profiles.
+			expect(service.getProfiles()).toEqual([]);
+		});
+
+		it('hides a discovery that matches a saved profile, so a configured data source appears once', async () => {
+			await registerDiscoveringDriver([pagila]);
+
+			service.addUpdateProfile({
+				...createProfile('saved-1'),
+				mechanismId: 'test-mechanism',
+				parameterValues: { dsn: 'Pagila' },
+			});
+			expect(service.getDiscoveredProfiles()).toEqual([]);
+
+			// A profile whose values differ does not shadow it.
+			service.removeProfile('saved-1');
+			service.addUpdateProfile({
+				...createProfile('saved-2'),
+				mechanismId: 'test-mechanism',
+				parameterValues: { dsn: 'Elsewhere' },
+			});
+			expect(service.getDiscoveredProfiles().map(profile => profile.connectionName)).toEqual(['Pagila']);
+		});
+
+		it('saves a discovery as an ordinary profile under a fresh id, and stops reporting it', async () => {
+			await registerDiscoveringDriver([pagila]);
+
+			const savedId = service.saveDiscoveredProfile('discovered:test-driver:odbc-dsn:Pagila');
+			const saved = service.getProfile(savedId!);
+
+			// The saved profile keeps the connection's identity but sheds every trace of having
+			// been discovered -- both marker fields are gone, not merely undefined -- so the pane
+			// treats it as the user's own from here on. Its id is fresh, since the discovered id
+			// belongs to a discovery that may later disappear.
+			expect({
+				...saved,
+				id: savedId === 'discovered:test-driver:odbc-dsn:Pagila' ? savedId : '<fresh-id>',
+				createdAt: typeof saved?.createdAt,
+			}).toEqual({
+				id: '<fresh-id>',
+				createdAt: 'number',
+				driverMetadata: {
+					id: 'test-driver',
+					name: 'Test Driver',
+					iconSvg: '',
+					supportedLanguageIds: [],
+				},
+				connectionName: 'Pagila',
+				mechanismId: 'test-mechanism',
+				parameterValues: { dsn: 'Pagila' },
+			});
+			expect(service.getDiscoveredProfiles()).toEqual([]);
+		});
+
+		it('resolves a discovery by id so it can be connected without being saved first', async () => {
+			await registerDiscoveringDriver([pagila]);
+
+			const id = 'discovered:test-driver:odbc-dsn:Pagila';
+			expect(service.getProfile(id)?.connectionName).toBe('Pagila');
+			// A discovery holds no secrets, so resolving it with secrets is the same profile.
+			await expect(service.getProfileWithSecrets(id)).resolves.toMatchObject({ connectionName: 'Pagila' });
+		});
+
+		it('is a no-op when the id is not a current discovery', () => {
+			expect(service.saveDiscoveredProfile('discovered:test-driver:missing')).toBeUndefined();
+			expect(service.getProfiles()).toEqual([]);
+		});
+
+		it('keeps other drivers\' discoveries when one driver\'s discovery fails', async () => {
+			service.driverManager.registerDriver(stubInterface<IDataConnectionDriver>({
+				id: 'broken-driver',
+				metadata: { ...createDriverMetadata(), id: 'broken-driver' },
+				discoverConnections: async () => { throw new Error('odbc.ini is unreadable'); },
+			}));
+			await registerDiscoveringDriver([pagila]);
+
+			expect(service.getDiscoveredProfiles().map(profile => profile.connectionName)).toEqual(['Pagila']);
+		});
+	});
 });

--- a/test/e2e/tests/data-connections/driver-logging.test.ts
+++ b/test/e2e/tests/data-connections/driver-logging.test.ts
@@ -13,11 +13,17 @@ test.use({
 
 const connectionName = 'driverLoggingSQLite';
 
-// The display name each driver registers via `registerDriver`, which is the last statement in
-// every driver's `activate()`. Waiting for all seven provider cards to render is therefore proof
-// that every driver's activation has fully run (including any illegal logging before that call),
-// not just that the extension host has started loading the module.
-const allDriverNames = ['DuckDB', 'Databricks', 'PostgreSQL', 'Posit Connect Pins', 'Redshift', 'SQLite', 'Snowflake'];
+// The display name each driver registers via `registerDriver`. Waiting for all eight provider
+// cards to render is proof that every driver's activation has run past the point where it could
+// have logged illegally, not just that the extension host has started loading the module: for
+// seven of the eight, `registerDriver` is the last statement in `activate()`. ODBC registers its
+// drivers and then installs watchers on the machine's ODBC configuration files, which log when a
+// file changes and not when the watcher is set up, so its card means the same thing.
+//
+// Only the generic 'ODBC' card is listed. That extension also registers one driver per recognized
+// database whose ODBC driver is installed, so the rest of its cards depend on what the machine has
+// configured -- nothing a test can wait for.
+const allDriverNames = ['DuckDB', 'Databricks', 'ODBC', 'PostgreSQL', 'Posit Connect Pins', 'Redshift', 'SQLite', 'Snowflake'];
 
 test.describe('Data connection driver logging', {
 	tag: [tags.WEB, tags.WIN, tags.CONNECTIONS, tags.WORKBENCH]
@@ -28,7 +34,7 @@ test.describe('Data connection driver logging', {
 	// `suiteId: __filename` gives this file, and `fullyParallel: false` keeps tests within a file
 	// running in declared order, so this ordering is guaranteed as long as no earlier test connects.
 	test('creates no output channels until a connection is made', async function ({ app }) {
-		// Opening the pane activates all seven driver extensions at once. None of them may log
+		// Opening the pane activates all eight driver extensions at once. None of them may log
 		// during activation, so none of their channels may exist yet.
 		const { dataConnections } = app.workbench;
 		await dataConnections.openDataConnectionsView();


### PR DESCRIPTION
Fixes #14855
Fixes #13007

Part of #14854.

### Summary

Adds `positron-data-driver-odbc`, a data connection driver that reaches any database with an ODBC driver installed on the machine. It offers three ways to connect -- a data source already configured in `odbc.ini`, a server address plus credentials against an installed ODBC driver, or a full connection string pasted in -- and surfaces every DSN it discovers in the Connections pane without the user configuring anything, so an ODBC setup that RStudio already shows is visible in Positron too.

Beyond the generic "ODBC" entry, the extension registers a per-database entry for each recognized ODBC driver it finds, so the New Connection list offers "MySQL" or "SQL Server" rather than making the user know that ODBC is how they get there. Entries appear for MySQL, MariaDB, SQL Server, Oracle, Db2, Hive, Impala, Teradata, and BigQuery. Databases Positron already ships a native driver for (PostgreSQL, Snowflake, Databricks, Redshift, SQLite) deliberately do not get a second entry, but are still reachable through the generic one.

The schema tree is built from ODBC's `SQLTables` and `SQLColumns` catalog functions rather than from information schema queries, because the whole point of ODBC is that the backend is unknown. Catalog and schema levels render only when the backend actually uses them, so MySQL drops straight to Tables and Views while a backend with real namespaces shows them.

For the Data Explorer, quoting and row-limiting are the two things that genuinely differ per backend and `node-odbc` exposes no `SQLGetInfo` to ask at runtime, so a small curated map from ODBC driver name to dialect supplies them. An unrecognized driver falls back to SQL-92 identifier quoting and the SQL:2008 `OFFSET ... FETCH NEXT` form. Sorting, row filters, and column profiles are supported; regular expression filters are not, since ODBC backends have no common regex syntax.

Binary columns (`bytea`, `BLOB`, `VARBINARY`, `IMAGE`) are reported with their type but their values are never fetched, because fetching them crashes the ODBC worker under Electron.

The core-side changes add the driver-supplied discovered connection API to `positron.d.ts` and thread it through the extension host, the data connections service, and the tree.

### Testing

Manually tested end to end against three backends:

- **PostgreSQL** (`psqlodbc`) -- Pagila and Northwind, including multi-schema trees and `bytea` columns
- **MySQL and MariaDB** (MariaDB Connector/ODBC) -- Sakila on both servers
- **SQL Server** (Microsoft ODBC Driver 18) -- multi-database catalogs, the full span of `SQL_*` type codes, binary columns, and `OFFSET`/`FETCH` paging over 100k rows

Automated coverage is extension-host tests over injected fixtures (`IOdbcConfigHost`, a synthetic `OdbcConfiguration`), so they need neither unixODBC nor a database, plus vitest coverage for the data connections service and tree.

No new e2e tests. Exercising this driver end to end requires ODBC drivers and live database servers on the runner, which CI does not have; the fixtured extension-host suite covers discovery, driver construction, dialect selection, tree shaping, and SQL generation, and the manual matrix above covers real driver behavior.

### Known limitations

Discovered DSN entries pass only the data source name when connecting, which works for drivers that read `UID` and `PWD` out of `odbc.ini` (psqlodbc, MariaDB Connector/ODBC) but not for drivers that ignore stored credentials (Microsoft's, notably). Expanding such a DSN directly from the pane fails to authenticate; connecting through New Connection and supplying credentials works. Not addressed here.

### Release Notes

#### New Features

- Added an ODBC data connection driver, so any database with an installed ODBC driver can be browsed in the Connections pane and opened in the Data Explorer (#14855)
- Data sources already configured on the machine now appear in the Connections pane automatically, and installed ODBC drivers are offered as dedicated database entries in New Connection (#13007)

#### Bug Fixes

- N/A

### Validation Steps

@:connections @:data-explorer

Requires an ODBC driver and a reachable database. The steps below use SQL Server; PostgreSQL, MySQL, or MariaDB work equally well.

1. Install a driver, e.g. `brew tap microsoft/mssql-release && brew install msodbcsql18`, and confirm it registers with `odbcinst -q -d`.
2. Start a server and add a DSN to `~/.odbc.ini` pointing at it.
3. Open the Connections pane and verify the DSN appears on its own, with a summary line showing its endpoint and database.
4. Open New Connection and verify a "SQL Server" entry is offered alongside the generic "ODBC" entry, and that PostgreSQL is **not** offered twice.
5. Connect through the Data Source (DSN) mechanism, supplying a user and password. Expand the connection and confirm the tree shows catalogs and schemas where the backend has them, and drops straight to Tables and Views where it does not.
6. Double-click a table to open it in the Data Explorer. Sort by several columns, apply row filters, and scroll well past the first page to exercise paging.
7. Open a table with a binary column and confirm the column appears with no values and does not take down the connection.
8. Uninstall a driver without removing its `odbcinst.ini` entry, reload, and confirm it is no longer offered in New Connection.

Run the extension's own tests with:

npm run test-extension -- -l positron-data-driver-odbc
