### PR TITLE
Environment health check shows raw exception messages instead of a generic one

### DIFF
--- a/extensions/positron-python/src/client/positron/environmentHealth.ts
+++ b/extensions/positron-python/src/client/positron/environmentHealth.ts
@@ -435,29 +435,39 @@ function skipped(id: HealthItemId): HealthItem {
     return { id, status: 'skipped', summary: itemSummary(id) };
 }
 
-async function runItem(id: HealthItemId, produce: () => HealthItem | Promise<HealthItem>): Promise<HealthItem> {
+async function runItem(
+    id: HealthItemId,
+    produce: () => HealthItem | Promise<HealthItem>,
+    logUnexpectedError: (message: string, error?: unknown) => void,
+): Promise<HealthItem> {
     try {
         return await produce();
     } catch (ex) {
+        // The specific cause goes to the log; there is no curated action to offer for an
+        // unexpected probe failure, so the user sees a generic sentence instead.
+        logUnexpectedError(`Environment health check '${id}' failed`, ex);
         return {
             id,
             status: 'fail',
             summary: itemSummary(id),
-            detail: vscode.l10n.t('Health check failed: {0}', ex instanceof Error ? ex.message : String(ex)),
+            detail: vscode.l10n.t('This check could not be completed.'),
         };
     }
 }
 
-export async function assembleItems(producers: ItemProducers): Promise<EnvironmentHealthResult> {
+export async function assembleItems(
+    producers: ItemProducers,
+    logUnexpectedError: (message: string, error?: unknown) => void = () => {},
+): Promise<EnvironmentHealthResult> {
     const items: HealthItem[] = [];
-    const discovery = await runItem('discovery', producers.discovery);
+    const discovery = await runItem('discovery', producers.discovery, logUnexpectedError);
     items.push(discovery);
     if (discovery.status === 'fail') {
         items.push(skipped('pythonInstalled'), skipped('environmentReady'), skipped('dedicatedEnvironment'));
         return finalize(items);
     }
 
-    const pythonInstalled = await runItem('pythonInstalled', producers.pythonInstalled);
+    const pythonInstalled = await runItem('pythonInstalled', producers.pythonInstalled, logUnexpectedError);
     items.push(pythonInstalled);
     if (pythonInstalled.status === 'fail') {
         items.push(skipped('environmentReady'), skipped('dedicatedEnvironment'));
@@ -470,14 +480,14 @@ export async function assembleItems(producers: ItemProducers): Promise<Environme
     // envType and would be misclassified as non-dedicated, so skip dedicatedEnvironment on a
     // readiness failure and let the recreate fix stand alone rather than emit a misleading
     // "use a dedicated environment" verdict alongside it.
-    const ready = await runItem('environmentReady', producers.ready);
+    const ready = await runItem('environmentReady', producers.ready, logUnexpectedError);
     items.push(ready);
     if (ready.status === 'fail') {
         items.push(skipped('dedicatedEnvironment'));
         return finalize(items);
     }
 
-    items.push(await runItem('dedicatedEnvironment', producers.dedicated));
+    items.push(await runItem('dedicatedEnvironment', producers.dedicated, logUnexpectedError));
     return finalize(items);
 }
 
@@ -491,6 +501,7 @@ function finalize(items: HealthItem[]): EnvironmentHealthResult {
 export async function getEnvironmentHealth(
     serviceContainer: IServiceContainer,
     args?: { workspaceFolder?: string },
+    logUnexpectedError: (message: string, error?: unknown) => void = () => {},
 ): Promise<EnvironmentHealthResult> {
     const interpreterService = serviceContainer.get<IInterpreterService>(IInterpreterService);
     const comparer = serviceContainer.get<IInterpreterComparer>(IInterpreterComparer);
@@ -521,26 +532,29 @@ export async function getEnvironmentHealth(
         return snapshot;
     };
 
-    const result = await assembleItems({
-        discovery: () => probeDiscovery(getNativePythonFinder()),
-        pythonInstalled: () =>
-            probePythonInstalled({
-                getInterpreters: () => interpreterService.getInterpreters(workspaceUri),
-                refreshPromise: interpreterService.getRefreshPromise(),
-                lastDiscoveryError: () => getNativePythonFinder().lastDiscoveryError,
-                allowUvPythonInstall,
-                waitMs: DISCOVERY_WAIT_MS,
-            }),
-        ready: async () =>
-            evaluateReady(serviceContainer, {
-                workspaceUri,
-                uvInstalled,
-                allowUvPythonInstall,
-                ...(await resolveSnapshot()),
-            }),
-        dedicated: async () =>
-            evaluateDedicated({ workspaceUri, uvInstalled, allowUvPythonInstall, ...(await resolveSnapshot()) }),
-    });
+    const result = await assembleItems(
+        {
+            discovery: () => probeDiscovery(getNativePythonFinder()),
+            pythonInstalled: () =>
+                probePythonInstalled({
+                    getInterpreters: () => interpreterService.getInterpreters(workspaceUri),
+                    refreshPromise: interpreterService.getRefreshPromise(),
+                    lastDiscoveryError: () => getNativePythonFinder().lastDiscoveryError,
+                    allowUvPythonInstall,
+                    waitMs: DISCOVERY_WAIT_MS,
+                }),
+            ready: async () =>
+                evaluateReady(serviceContainer, {
+                    workspaceUri,
+                    uvInstalled,
+                    allowUvPythonInstall,
+                    ...(await resolveSnapshot()),
+                }),
+            dedicated: async () =>
+                evaluateDedicated({ workspaceUri, uvInstalled, allowUvPythonInstall, ...(await resolveSnapshot()) }),
+        },
+        logUnexpectedError,
+    );
     // Read the memoized snapshot directly rather than calling resolveSnapshot() again.
     // When discovery or pythonInstalled failed, the cascade skipped environmentReady before it
     // could resolve the snapshot, so it stays undefined and interpreterPath is omitted. (A

--- a/extensions/positron-python/src/client/positron/environmentHealth.ts
+++ b/extensions/positron-python/src/client/positron/environmentHealth.ts
@@ -6,10 +6,7 @@
 import * as os from 'os';
 import * as vscode from 'vscode';
 import * as fs from '../common/platform/fs-paths';
-import {
-    NativePythonFinder,
-    getNativePythonFinder,
-} from '../pythonEnvironments/base/locators/common/nativePythonFinder';
+import { getNativePythonFinder } from '../pythonEnvironments/base/locators/common/nativePythonFinder';
 import {
     isVersionSupported,
     isBaseCondaEnvironment,
@@ -29,6 +26,7 @@ import { Architecture } from '../common/utils/platform';
 import { getConfiguration } from '../common/vscodeApis/workspaceApis';
 import { getIpykernelBundle } from './ipykernel';
 import { isUvInstalled } from '../pythonEnvironments/common/environmentManagers/uv';
+import { noop } from '../common/utils/misc';
 
 // Human-readable inclusive supported range (e.g. "3.9-3.14") for user-facing messages, derived from
 // the version bounds so it stays in sync when they change. The exclusive maximum is set at a minor
@@ -91,18 +89,44 @@ export function itemSummary(id: HealthItemId): string {
     return summaries[id];
 }
 
-export function probeDiscovery(finder: Pick<NativePythonFinder, 'lastDiscoveryError'>): HealthItem {
+/**
+ * Where the developer-facing text behind a failed check goes. The report shows a generic sentence,
+ * so this is the only place the real message survives.
+ */
+export type LogError = (message: string, error?: unknown) => void;
+
+// Keep in sync with positron-r's environmentHealth.ts.
+function diagnosticsFix(): HealthItemFix {
+    return {
+        commandId: 'positron.startupDiagnostics.show',
+        label: vscode.l10n.t('Show Runtime Startup Diagnostics'),
+    };
+}
+
+/**
+ * Reduces the locator's recorded error to the flag the probes take, logging the message on the way.
+ * The probes never receive the message, so this is the only chance to record it.
+ */
+export function readDiscoveryFailure(
+    lastDiscoveryError: string | undefined,
+    context: string,
+    logError: LogError,
+): boolean {
+    if (lastDiscoveryError) {
+        logError(`${context}: ${lastDiscoveryError}`);
+    }
+    return Boolean(lastDiscoveryError);
+}
+
+export function probeDiscovery(deps: { discoveryFailed: boolean }): HealthItem {
     const summary = itemSummary('discovery');
-    if (finder.lastDiscoveryError) {
+    if (deps.discoveryFailed) {
         return {
             id: 'discovery',
             status: 'fail',
             summary,
-            detail: vscode.l10n.t('Python environment discovery could not start: {0}', finder.lastDiscoveryError),
-            fix: {
-                commandId: 'positron.startupDiagnostics.show',
-                label: vscode.l10n.t('Show Runtime Startup Diagnostics'),
-            },
+            detail: vscode.l10n.t('Python environment discovery could not start.'),
+            fix: diagnosticsFix(),
         };
     }
     return { id: 'discovery', status: 'pass', summary };
@@ -136,7 +160,7 @@ async function discoveryFinishedWithin(refreshPromise: Promise<void>, waitMs: nu
 export async function probePythonInstalled(deps: {
     getInterpreters: () => PythonEnvironment[];
     refreshPromise: Promise<void> | undefined;
-    lastDiscoveryError: () => string | undefined;
+    discoveryFailed: () => boolean;
     allowUvPythonInstall: boolean;
     waitMs: number;
 }): Promise<HealthItem> {
@@ -169,25 +193,18 @@ export async function probePythonInstalled(deps: {
         };
     }
 
-    // The discovery probe (item 1) samples lastDiscoveryError once, before this bounded wait.
-    // A locator failure that only surfaces during the wait (e.g. the initial refresh rejecting)
-    // is set on the finder afterwards, so re-check it here: no supported Python plus a discovery
-    // error means the locator is broken, not that Python is missing. Point at diagnostics rather
-    // than offer an install-Python fix that would not resolve a broken locator.
-    const discoveryError = deps.lastDiscoveryError();
-    if (discoveryError) {
+    // The discovery probe (item 1) samples the locator once, before this bounded wait. A locator
+    // failure that only surfaces during the wait (e.g. the initial refresh rejecting) is recorded
+    // afterwards, so re-check it here: no supported Python plus a discovery failure means the
+    // locator is broken, not that Python is missing. Point at diagnostics rather than offer an
+    // install-Python fix that would not resolve a broken locator.
+    if (deps.discoveryFailed()) {
         return {
             id: 'pythonInstalled',
             status: 'fail',
             summary,
-            detail: vscode.l10n.t(
-                'A supported Python could not be confirmed because environment discovery failed: {0}',
-                discoveryError,
-            ),
-            fix: {
-                commandId: 'positron.startupDiagnostics.show',
-                label: vscode.l10n.t('Show Runtime Startup Diagnostics'),
-            },
+            detail: vscode.l10n.t('A supported Python could not be confirmed because environment discovery failed.'),
+            fix: diagnosticsFix(),
         };
     }
 
@@ -438,14 +455,13 @@ function skipped(id: HealthItemId): HealthItem {
 async function runItem(
     id: HealthItemId,
     produce: () => HealthItem | Promise<HealthItem>,
-    logUnexpectedError: (message: string, error?: unknown) => void,
+    logError: LogError,
 ): Promise<HealthItem> {
     try {
         return await produce();
     } catch (ex) {
-        // The specific cause goes to the log; there is no curated action to offer for an
-        // unexpected probe failure, so the user sees a generic sentence instead.
-        logUnexpectedError(`Environment health check '${id}' failed`, ex);
+        // No curated action to offer for an unexpected probe failure, so this item carries no fix.
+        logError(`Environment health check '${id}' failed`, ex);
         return {
             id,
             status: 'fail',
@@ -457,17 +473,17 @@ async function runItem(
 
 export async function assembleItems(
     producers: ItemProducers,
-    logUnexpectedError: (message: string, error?: unknown) => void = () => {},
+    logError: LogError = noop,
 ): Promise<EnvironmentHealthResult> {
     const items: HealthItem[] = [];
-    const discovery = await runItem('discovery', producers.discovery, logUnexpectedError);
+    const discovery = await runItem('discovery', producers.discovery, logError);
     items.push(discovery);
     if (discovery.status === 'fail') {
         items.push(skipped('pythonInstalled'), skipped('environmentReady'), skipped('dedicatedEnvironment'));
         return finalize(items);
     }
 
-    const pythonInstalled = await runItem('pythonInstalled', producers.pythonInstalled, logUnexpectedError);
+    const pythonInstalled = await runItem('pythonInstalled', producers.pythonInstalled, logError);
     items.push(pythonInstalled);
     if (pythonInstalled.status === 'fail') {
         items.push(skipped('environmentReady'), skipped('dedicatedEnvironment'));
@@ -480,14 +496,14 @@ export async function assembleItems(
     // envType and would be misclassified as non-dedicated, so skip dedicatedEnvironment on a
     // readiness failure and let the recreate fix stand alone rather than emit a misleading
     // "use a dedicated environment" verdict alongside it.
-    const ready = await runItem('environmentReady', producers.ready, logUnexpectedError);
+    const ready = await runItem('environmentReady', producers.ready, logError);
     items.push(ready);
     if (ready.status === 'fail') {
         items.push(skipped('dedicatedEnvironment'));
         return finalize(items);
     }
 
-    items.push(await runItem('dedicatedEnvironment', producers.dedicated, logUnexpectedError));
+    items.push(await runItem('dedicatedEnvironment', producers.dedicated, logError));
     return finalize(items);
 }
 
@@ -500,8 +516,8 @@ function finalize(items: HealthItem[]): EnvironmentHealthResult {
 
 export async function getEnvironmentHealth(
     serviceContainer: IServiceContainer,
+    logError: LogError,
     args?: { workspaceFolder?: string },
-    logUnexpectedError: (message: string, error?: unknown) => void = () => {},
 ): Promise<EnvironmentHealthResult> {
     const interpreterService = serviceContainer.get<IInterpreterService>(IInterpreterService);
     const comparer = serviceContainer.get<IInterpreterComparer>(IInterpreterComparer);
@@ -534,12 +550,26 @@ export async function getEnvironmentHealth(
 
     const result = await assembleItems(
         {
-            discovery: () => probeDiscovery(getNativePythonFinder()),
+            discovery: () =>
+                probeDiscovery({
+                    discoveryFailed: readDiscoveryFailure(
+                        getNativePythonFinder().lastDiscoveryError,
+                        'Python environment discovery could not start',
+                        logError,
+                    ),
+                }),
             pythonInstalled: () =>
                 probePythonInstalled({
                     getInterpreters: () => interpreterService.getInterpreters(workspaceUri),
                     refreshPromise: interpreterService.getRefreshPromise(),
-                    lastDiscoveryError: () => getNativePythonFinder().lastDiscoveryError,
+                    // Read per call, not once up front: probePythonInstalled asks again after its
+                    // bounded wait, which is when a late locator failure first becomes visible.
+                    discoveryFailed: () =>
+                        readDiscoveryFailure(
+                            getNativePythonFinder().lastDiscoveryError,
+                            'Python environment discovery failed during the health check',
+                            logError,
+                        ),
                     allowUvPythonInstall,
                     waitMs: DISCOVERY_WAIT_MS,
                 }),
@@ -553,7 +583,7 @@ export async function getEnvironmentHealth(
             dedicated: async () =>
                 evaluateDedicated({ workspaceUri, uvInstalled, allowUvPythonInstall, ...(await resolveSnapshot()) }),
         },
-        logUnexpectedError,
+        logError,
     );
     // Read the memoized snapshot directly rather than calling resolveSnapshot() again.
     // When discovery or pythonInstalled failed, the cascade skipped environmentReady before it

--- a/extensions/positron-python/src/client/positron/extension.ts
+++ b/extensions/positron-python/src/client/positron/extension.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import { IDisposableRegistry, IInstaller, InstallerResponse, Product } from '../common/types';
 import { IInterpreterService } from '../interpreter/contracts';
 import { IServiceContainer } from '../ioc/types';
-import { traceError, traceInfo } from '../logging';
+import { traceError, traceInfo, traceWarn } from '../logging';
 import { MINIMUM_PYTHON_VERSION, Commands } from '../common/constants';
 import { getIpykernelBundle } from './ipykernel';
 import { getEnvironmentHealth } from './environmentHealth';
@@ -86,15 +86,16 @@ export async function activatePositron(serviceContainer: IServiceContainer): Pro
                 printInterpreterDebugInfo(interpreters);
             }),
         );
-        // Returns a machine-readable Python environment health report for the welcome page. Running
-        // it writes nothing to the output channel and reveals no panel. It has no
-        // contributes.commands entry, which keeps it off the Command Palette but also costs the
-        // implicit onCommand activation event, so package.json lists that event explicitly: the
-        // welcome page can call this before onStartupFinished has woken the extension.
+        // Returns a machine-readable Python environment health report for the welcome page. It
+        // reveals no panel; the only thing it writes to the output channel is a warning when a
+        // probe throws unexpectedly. It has no contributes.commands entry, which keeps it off the
+        // Command Palette but also costs the implicit onCommand activation event, so package.json
+        // lists that event explicitly: the welcome page can call this before onStartupFinished has
+        // woken the extension.
         disposables.push(
             vscode.commands.registerCommand(
                 Commands.Get_Environment_Health,
-                async (args?: { workspaceFolder?: string }) => getEnvironmentHealth(serviceContainer, args),
+                async (args?: { workspaceFolder?: string }) => getEnvironmentHealth(serviceContainer, args, traceWarn),
             ),
         );
 

--- a/extensions/positron-python/src/client/positron/extension.ts
+++ b/extensions/positron-python/src/client/positron/extension.ts
@@ -87,15 +87,14 @@ export async function activatePositron(serviceContainer: IServiceContainer): Pro
             }),
         );
         // Returns a machine-readable Python environment health report for the welcome page. It
-        // reveals no panel; the only thing it writes to the output channel is a warning when a
-        // probe throws unexpectedly. It has no contributes.commands entry, which keeps it off the
-        // Command Palette but also costs the implicit onCommand activation event, so package.json
-        // lists that event explicitly: the welcome page can call this before onStartupFinished has
-        // woken the extension.
+        // reveals no panel, and writes to the output channel only when a check fails. It has no
+        // contributes.commands entry, which keeps it off the Command Palette but also costs the
+        // implicit onCommand activation event, so package.json lists that event explicitly: the
+        // welcome page can call this before onStartupFinished has woken the extension.
         disposables.push(
             vscode.commands.registerCommand(
                 Commands.Get_Environment_Health,
-                async (args?: { workspaceFolder?: string }) => getEnvironmentHealth(serviceContainer, args, traceWarn),
+                async (args?: { workspaceFolder?: string }) => getEnvironmentHealth(serviceContainer, traceWarn, args),
             ),
         );
 

--- a/extensions/positron-python/src/test/positron/environmentHealth.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/environmentHealth.unit.test.ts
@@ -454,17 +454,29 @@ suite('Python Environment Health - orchestration', () => {
     });
 
     test('a probe that throws becomes a fail, not a rejection', async () => {
-        const result = await assembleItems({
-            discovery: () => pass('discovery'),
-            pythonInstalled: async () => {
-                throw new Error('boom');
+        const logUnexpectedError = sinon.stub();
+        const thrown = new Error('boom');
+        const result = await assembleItems(
+            {
+                discovery: () => pass('discovery'),
+                pythonInstalled: async () => {
+                    throw thrown;
+                },
+                ready: async () => pass('environmentReady'),
+                dedicated: async () => pass('dedicatedEnvironment'),
             },
-            ready: async () => pass('environmentReady'),
-            dedicated: async () => pass('dedicatedEnvironment'),
-        });
+            logUnexpectedError,
+        );
         assert.strictEqual(result.items[1].status, 'fail');
-        assert.include(result.items[1].detail ?? '', 'boom');
         assert.strictEqual(result.items[1].summary, 'A supported Python is installed');
+        // The error goes to the log, not to the user. It is passed as the error
+        // argument rather than interpolated, so the log keeps the stack.
+        assert.notInclude(result.items[1].detail ?? '', 'boom');
+        assert.isTrue(logUnexpectedError.calledOnce);
+        assert.deepStrictEqual(logUnexpectedError.firstCall.args, [
+            `Environment health check 'pythonInstalled' failed`,
+            thrown,
+        ]);
     });
 
     test('skipped items carry the check summary, not the machine id', async () => {

--- a/extensions/positron-python/src/test/positron/environmentHealth.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/environmentHealth.unit.test.ts
@@ -5,25 +5,53 @@
 
 import * as sinon from 'sinon';
 import { assert } from 'chai';
-import { probeDiscovery, probePythonInstalled, DISCOVERY_WAIT_MS } from '../../client/positron/environmentHealth';
+import {
+    probeDiscovery,
+    probePythonInstalled,
+    readDiscoveryFailure,
+    DISCOVERY_WAIT_MS,
+} from '../../client/positron/environmentHealth';
 import { PythonEnvironment } from '../../client/pythonEnvironments/info';
 
 suite('Python Environment Health - discovery (item 1)', () => {
     teardown(() => sinon.restore());
 
     test('passes when discovery is operational', () => {
-        const item = probeDiscovery({ lastDiscoveryError: undefined });
+        const item = probeDiscovery({ discoveryFailed: false });
         assert.strictEqual(item.id, 'discovery');
         assert.strictEqual(item.status, 'pass');
         assert.isUndefined(item.fix);
     });
 
     test('fails with a diagnostics link-out on fatal discovery error', () => {
-        const item = probeDiscovery({ lastDiscoveryError: 'spawn ENOENT' });
+        // The probe takes a flag, not the locator's message, so it has no developer text to leak.
+        const item = probeDiscovery({ discoveryFailed: true });
         assert.strictEqual(item.status, 'fail');
         assert.strictEqual(item.fix?.commandId, 'positron.startupDiagnostics.show');
         assert.isUndefined(item.fix?.args);
-        assert.include(item.detail ?? '', 'spawn ENOENT');
+        assert.isDefined(item.detail);
+    });
+});
+
+suite('Python Environment Health - readDiscoveryFailure', () => {
+    test('no recorded error means no failure and nothing logged', () => {
+        const logError = sinon.stub();
+        assert.isFalse(readDiscoveryFailure(undefined, 'context', logError));
+        assert.isTrue(logError.notCalled);
+    });
+
+    test('a recorded error is logged with its context and reported as a failure', () => {
+        const logError = sinon.stub();
+        assert.isTrue(readDiscoveryFailure('spawn ENOENT', 'Discovery could not start', logError));
+        assert.deepStrictEqual(logError.firstCall.args, ['Discovery could not start: spawn ENOENT']);
+    });
+
+    test('an empty message is not a failure', () => {
+        // The locator clears lastDiscoveryError by assigning undefined, but an empty string would
+        // otherwise fail the check with nothing to log.
+        const logError = sinon.stub();
+        assert.isFalse(readDiscoveryFailure('', 'context', logError));
+        assert.isTrue(logError.notCalled);
     });
 });
 
@@ -38,7 +66,7 @@ suite('Python Environment Health - pythonInstalled (item 2)', () => {
         const item = await probePythonInstalled({
             getInterpreters: () => [unsupported, supported],
             refreshPromise: undefined,
-            lastDiscoveryError: () => undefined,
+            discoveryFailed: () => false,
             allowUvPythonInstall: true,
             waitMs: 10,
         });
@@ -51,7 +79,7 @@ suite('Python Environment Health - pythonInstalled (item 2)', () => {
         const item = await probePythonInstalled({
             getInterpreters: () => list,
             refreshPromise,
-            lastDiscoveryError: () => undefined,
+            discoveryFailed: () => false,
             allowUvPythonInstall: true,
             waitMs: 50,
         });
@@ -62,23 +90,23 @@ suite('Python Environment Health - pythonInstalled (item 2)', () => {
     test('reports a broken locator, not a missing Python, when discovery errors during the wait', async () => {
         // The discovery probe (item 1) already passed because the error had not surfaced yet.
         // The refresh rejects during the bounded wait; the finder records the error afterwards.
-        let discoveryError: string | undefined;
+        let discoveryFailed = false;
         const refreshPromise = new Promise<void>((r) =>
             setTimeout(() => {
-                discoveryError = 'Refresh error: spawn ENOENT';
+                discoveryFailed = true;
                 r();
             }, 1),
         );
         const item = await probePythonInstalled({
             getInterpreters: () => [],
             refreshPromise,
-            lastDiscoveryError: () => discoveryError,
+            discoveryFailed: () => discoveryFailed,
             allowUvPythonInstall: true,
             waitMs: 50,
         });
         assert.strictEqual(item.status, 'fail');
         assert.strictEqual(item.fix?.commandId, 'positron.startupDiagnostics.show');
-        assert.include(item.detail ?? '', 'spawn ENOENT');
+        assert.isDefined(item.detail);
     });
 
     test('times out with no fix when discovery does not finish in time', async () => {
@@ -86,7 +114,7 @@ suite('Python Environment Health - pythonInstalled (item 2)', () => {
         const item = await probePythonInstalled({
             getInterpreters: () => [],
             refreshPromise: neverResolves,
-            lastDiscoveryError: () => undefined,
+            discoveryFailed: () => false,
             allowUvPythonInstall: true,
             waitMs: 10,
         });
@@ -98,7 +126,7 @@ suite('Python Environment Health - pythonInstalled (item 2)', () => {
         const item = await probePythonInstalled({
             getInterpreters: () => [],
             refreshPromise: undefined,
-            lastDiscoveryError: () => undefined,
+            discoveryFailed: () => false,
             allowUvPythonInstall: false,
             waitMs: 10,
         });
@@ -454,7 +482,7 @@ suite('Python Environment Health - orchestration', () => {
     });
 
     test('a probe that throws becomes a fail, not a rejection', async () => {
-        const logUnexpectedError = sinon.stub();
+        const logError = sinon.stub();
         const thrown = new Error('boom');
         const result = await assembleItems(
             {
@@ -465,18 +493,15 @@ suite('Python Environment Health - orchestration', () => {
                 ready: async () => pass('environmentReady'),
                 dedicated: async () => pass('dedicatedEnvironment'),
             },
-            logUnexpectedError,
+            logError,
         );
         assert.strictEqual(result.items[1].status, 'fail');
         assert.strictEqual(result.items[1].summary, 'A supported Python is installed');
         // The error goes to the log, not to the user. It is passed as the error
         // argument rather than interpolated, so the log keeps the stack.
         assert.notInclude(result.items[1].detail ?? '', 'boom');
-        assert.isTrue(logUnexpectedError.calledOnce);
-        assert.deepStrictEqual(logUnexpectedError.firstCall.args, [
-            `Environment health check 'pythonInstalled' failed`,
-            thrown,
-        ]);
+        assert.isTrue(logError.calledOnce);
+        assert.deepStrictEqual(logError.firstCall.args, [`Environment health check 'pythonInstalled' failed`, thrown]);
     });
 
     test('skipped items carry the check summary, not the machine id', async () => {

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -261,7 +261,7 @@ export async function registerCommands(context: vscode.ExtensionContext, runtime
 		// Returns a JSON report on whether the current R setup can start a
 		// session. Internal: consumed by a frontend, not surfaced in the palette.
 		vscode.commands.registerCommand('r.getEnvironmentHealth',
-			async () => getEnvironmentHealth()),
+			async () => getEnvironmentHealth((message, error) => LOGGER.warn(message, error))),
 
 		// Commands used in RStudio migration walkthrough
 		vscode.commands.registerCommand('r.walkthrough.updateRStudioKeybindings', async () => {

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -18,7 +18,7 @@ import { MINIMUM_RENV_VERSION, MINIMUM_R_VERSION } from './constants';
 import { RRuntimeManager } from './runtime-manager';
 import { RMetadataExtra } from './r-installation';
 import { onDidDiscoverTestFiles } from './testing/testing';
-import { getEnvironmentHealth } from './environmentHealth';
+import { getEnvironmentHealth, logErrorTo } from './environmentHealth';
 import { LOGGER } from './extension.js';
 import { printInterpreterSettingsInfo } from './interpreter-settings.js';
 
@@ -261,7 +261,7 @@ export async function registerCommands(context: vscode.ExtensionContext, runtime
 		// Returns a JSON report on whether the current R setup can start a
 		// session. Internal: consumed by a frontend, not surfaced in the palette.
 		vscode.commands.registerCommand('r.getEnvironmentHealth',
-			async () => getEnvironmentHealth((message, error) => LOGGER.warn(message, error))),
+			async () => getEnvironmentHealth(logErrorTo(LOGGER))),
 
 		// Commands used in RStudio migration walkthrough
 		vscode.commands.registerCommand('r.walkthrough.updateRStudioKeybindings', async () => {

--- a/extensions/positron-r/src/environmentHealth.ts
+++ b/extensions/positron-r/src/environmentHealth.ts
@@ -91,6 +91,32 @@ export interface RInstallationLike {
 const R_INSTALL_DOCS = 'https://positron.posit.co/r-installations';
 
 /**
+ * Where the developer-facing text behind a failed check goes. The report shows a
+ * generic sentence, so this is the only place the real message survives.
+ *
+ * Keep in sync with positron-python's `environmentHealth.ts`.
+ */
+export type LogError = (message: string, error?: unknown) => void;
+
+/**
+ * Sends the text to an output channel at warn level, with the stack when there is
+ * one.
+ *
+ * `warn()` renders an Error to its message alone: it calls `format()` without the
+ * verbose flag, which drops the stack (see `log.ts`). The stack is the part that
+ * says which line threw, so pass it as the argument instead of the Error.
+ */
+export function logErrorTo(channel: Pick<vscode.LogOutputChannel, 'warn'>): LogError {
+	return (message, error) => {
+		if (error === undefined) {
+			channel.warn(message);
+			return;
+		}
+		channel.warn(message, error instanceof Error ? error.stack ?? error.message : error);
+	};
+}
+
+/**
  * The claim a check makes, phrased so it reads the same whatever the outcome is:
  * the UI uses it as the row title and shows `status` separately. Callers that
  * never ran the probe (a skipped item, a probe that threw) still need the text,
@@ -115,13 +141,13 @@ function diagnosticsFix(): HealthItemFix {
 	};
 }
 
-export function probeDiscovery(deps: { binaryCount: number; error?: string }): HealthItem {
+export function probeDiscovery(deps: { binaryCount: number; discoveryFailed?: boolean }): HealthItem {
 	const id = 'discovery';
 	const summary = itemSummary(id);
-	if (deps.error) {
+	if (deps.discoveryFailed) {
 		return {
 			id, status: 'fail', summary,
-			detail: vscode.l10n.t('R discovery could not complete: {0}', deps.error),
+			detail: vscode.l10n.t('R discovery could not complete.'),
 			fix: diagnosticsFix(),
 			learnMoreUrl: R_INSTALL_DOCS,
 		};
@@ -316,14 +342,13 @@ function skipped(id: HealthItemId): HealthItem {
 async function runItem(
 	id: HealthItemId,
 	produce: () => HealthItem | Promise<HealthItem>,
-	logUnexpectedError: (message: string, error?: unknown) => void
+	logError: LogError
 ): Promise<HealthItem> {
 	try {
 		return await produce();
 	} catch (ex) {
-		// The specific cause goes to the log; there is no curated action to offer for an
-		// unexpected probe failure, so the user sees a generic sentence instead.
-		logUnexpectedError(`Environment health check '${id}' failed`, ex);
+		// No curated action to offer for an unexpected probe failure, so this item carries no fix.
+		logError(`Environment health check '${id}' failed`, ex);
 		return {
 			id, status: 'fail', summary: itemSummary(id),
 			detail: vscode.l10n.t('This check could not be completed.'),
@@ -341,25 +366,25 @@ export async function assembleItems(
 		rInstalled: () => HealthItem | Promise<HealthItem>;
 		ready: () => HealthItem | Promise<HealthItem>;
 	},
-	logUnexpectedError: (message: string, error?: unknown) => void = () => { }
+	logError: LogError = () => { }
 ): Promise<REnvironmentHealthResult> {
 	const items: HealthItem[] = [];
 
-	const discovery = await runItem('discovery', producers.discovery, logUnexpectedError);
+	const discovery = await runItem('discovery', producers.discovery, logError);
 	items.push(discovery);
 	if (discovery.status === 'fail') {
 		items.push(skipped('rInstalled'), skipped('environmentReady'));
 		return finalize(items);
 	}
 
-	const rInstalled = await runItem('rInstalled', producers.rInstalled, logUnexpectedError);
+	const rInstalled = await runItem('rInstalled', producers.rInstalled, logError);
 	items.push(rInstalled);
 	if (rInstalled.status === 'fail') {
 		items.push(skipped('environmentReady'));
 		return finalize(items);
 	}
 
-	items.push(await runItem('environmentReady', producers.ready, logUnexpectedError));
+	items.push(await runItem('environmentReady', producers.ready, logError));
 	return finalize(items);
 }
 
@@ -379,24 +404,38 @@ function arkArchitecture(arkPath: string | undefined): ArkArch | undefined {
 	return undefined;
 }
 
+/**
+ * Turns a thrown discovery error into the flag probeDiscovery takes. The exception is developer
+ * text, so it goes to the log; probeDiscovery never receives it. A failure yields an empty list,
+ * which is what the probes below read.
+ *
+ * Generic over the installation type so a test can supply plain stand-ins.
+ */
+export async function discoverInstallations<T>(
+	discover: () => Promise<T[]>,
+	logError: LogError
+): Promise<{ installations: T[]; discoveryFailed: boolean }> {
+	try {
+		return { installations: await discover(), discoveryFailed: false };
+	} catch (ex) {
+		logError('R installation discovery failed', ex);
+		return { installations: [], discoveryFailed: true };
+	}
+}
+
 export async function getEnvironmentHealth(
-	logUnexpectedError: (message: string, error?: unknown) => void = () => { }
+	logError: LogError
 ): Promise<REnvironmentHealthResult> {
 	// Discovery runs once per invocation and every probe below reads that one
 	// snapshot. Nothing is cached across calls; each call re-runs full discovery.
-	let all: RInstallation[] = [];
-	let discoveryError: string | undefined;
-	try {
-		all = await discoverRInstallations();
-	} catch (ex) {
-		discoveryError = ex instanceof Error ? ex.message : String(ex);
-	}
+	const { installations: all, discoveryFailed } = await discoverInstallations<RInstallation>(
+		discoverRInstallations, logError);
 
 	const preferred = await positron.runtime.getPreferredRuntime('r');
 	const target = selectTargetInstallation(all, preferred?.runtimePath);
 
 	const result = await assembleItems({
-		discovery: () => probeDiscovery({ binaryCount: all.length, error: discoveryError }),
+		discovery: () => probeDiscovery({ binaryCount: all.length, discoveryFailed }),
 		rInstalled: () => probeRInstalled({ installations: all }),
 		ready: () => {
 			if (!target) {
@@ -424,7 +463,7 @@ export async function getEnvironmentHealth(
 				arkArch,
 			});
 		},
-	}, logUnexpectedError);
+	}, logError);
 
 	result.rBinPath = target?.binpath;
 	result.rHome = target?.homepath;

--- a/extensions/positron-r/src/environmentHealth.ts
+++ b/extensions/positron-r/src/environmentHealth.ts
@@ -315,15 +315,18 @@ function skipped(id: HealthItemId): HealthItem {
 
 async function runItem(
 	id: HealthItemId,
-	produce: () => HealthItem | Promise<HealthItem>
+	produce: () => HealthItem | Promise<HealthItem>,
+	logUnexpectedError: (message: string, error?: unknown) => void
 ): Promise<HealthItem> {
 	try {
 		return await produce();
 	} catch (ex) {
+		// The specific cause goes to the log; there is no curated action to offer for an
+		// unexpected probe failure, so the user sees a generic sentence instead.
+		logUnexpectedError(`Environment health check '${id}' failed`, ex);
 		return {
 			id, status: 'fail', summary: itemSummary(id),
-			detail: vscode.l10n.t(
-				'Health check failed: {0}', ex instanceof Error ? ex.message : String(ex)),
+			detail: vscode.l10n.t('This check could not be completed.'),
 		};
 	}
 }
@@ -332,28 +335,31 @@ function finalize(items: HealthItem[]): REnvironmentHealthResult {
 	return { ok: !items.some((i) => i.status === 'fail'), items };
 }
 
-export async function assembleItems(producers: {
-	discovery: () => HealthItem | Promise<HealthItem>;
-	rInstalled: () => HealthItem | Promise<HealthItem>;
-	ready: () => HealthItem | Promise<HealthItem>;
-}): Promise<REnvironmentHealthResult> {
+export async function assembleItems(
+	producers: {
+		discovery: () => HealthItem | Promise<HealthItem>;
+		rInstalled: () => HealthItem | Promise<HealthItem>;
+		ready: () => HealthItem | Promise<HealthItem>;
+	},
+	logUnexpectedError: (message: string, error?: unknown) => void = () => { }
+): Promise<REnvironmentHealthResult> {
 	const items: HealthItem[] = [];
 
-	const discovery = await runItem('discovery', producers.discovery);
+	const discovery = await runItem('discovery', producers.discovery, logUnexpectedError);
 	items.push(discovery);
 	if (discovery.status === 'fail') {
 		items.push(skipped('rInstalled'), skipped('environmentReady'));
 		return finalize(items);
 	}
 
-	const rInstalled = await runItem('rInstalled', producers.rInstalled);
+	const rInstalled = await runItem('rInstalled', producers.rInstalled, logUnexpectedError);
 	items.push(rInstalled);
 	if (rInstalled.status === 'fail') {
 		items.push(skipped('environmentReady'));
 		return finalize(items);
 	}
 
-	items.push(await runItem('environmentReady', producers.ready));
+	items.push(await runItem('environmentReady', producers.ready, logUnexpectedError));
 	return finalize(items);
 }
 
@@ -373,7 +379,9 @@ function arkArchitecture(arkPath: string | undefined): ArkArch | undefined {
 	return undefined;
 }
 
-export async function getEnvironmentHealth(): Promise<REnvironmentHealthResult> {
+export async function getEnvironmentHealth(
+	logUnexpectedError: (message: string, error?: unknown) => void = () => { }
+): Promise<REnvironmentHealthResult> {
 	// Discovery runs once per invocation and every probe below reads that one
 	// snapshot. Nothing is cached across calls; each call re-runs full discovery.
 	let all: RInstallation[] = [];
@@ -416,7 +424,7 @@ export async function getEnvironmentHealth(): Promise<REnvironmentHealthResult> 
 				arkArch,
 			});
 		},
-	});
+	}, logUnexpectedError);
 
 	result.rBinPath = target?.binpath;
 	result.rHome = target?.homepath;

--- a/extensions/positron-r/src/test/environmentHealth.unit.test.ts
+++ b/extensions/positron-r/src/test/environmentHealth.unit.test.ts
@@ -11,6 +11,8 @@ import './mocha-setup';
 import {
 	archesMismatch,
 	assembleItems,
+	discoverInstallations,
+	logErrorTo,
 	HealthItem,
 	HealthItemId,
 	probeDiscovery,
@@ -117,12 +119,65 @@ suite('environment health: probeDiscovery', () => {
 		assert.strictEqual(item.fix?.commandId, 'positron.startupDiagnostics.show');
 	});
 
-	test('fails and reports the error when discovery threw', () => {
-		const item = probeDiscovery({ binaryCount: 0, error: 'boom' });
+	test('fails without exposing the cause when discovery threw', () => {
+		const item = probeDiscovery({ binaryCount: 0, discoveryFailed: true });
 		assert.strictEqual(item.status, 'fail');
-		assert.ok(item.detail?.includes('boom'));
+		assert.ok(item.detail);
+		assert.strictEqual(item.fix?.commandId, 'positron.startupDiagnostics.show');
 		// Both discovery failure modes point at the same docs.
 		assert.strictEqual(item.learnMoreUrl, 'https://positron.posit.co/r-installations');
+	});
+});
+
+suite('environment health: logErrorTo', () => {
+	test('an Error is logged as its stack, not its message', () => {
+		// warn() renders an Error to its message alone, so the stack has to be passed
+		// as the argument. The stack is what says which line threw.
+		const warn = sinon.stub();
+		const thrown = new Error('kaboom');
+		logErrorTo({ warn })('Discovery failed', thrown);
+		assert.deepStrictEqual(warn.firstCall.args, ['Discovery failed', thrown.stack]);
+	});
+
+	test('an Error with no stack falls back to its message', () => {
+		const warn = sinon.stub();
+		const thrown = new Error('kaboom');
+		thrown.stack = undefined;
+		logErrorTo({ warn })('Discovery failed', thrown);
+		assert.deepStrictEqual(warn.firstCall.args, ['Discovery failed', 'kaboom']);
+	});
+
+	test('a thrown non-Error is passed through', () => {
+		const warn = sinon.stub();
+		logErrorTo({ warn })('Discovery failed', 'a bare string');
+		assert.deepStrictEqual(warn.firstCall.args, ['Discovery failed', 'a bare string']);
+	});
+
+	test('no error logs the message alone, with no trailing undefined', () => {
+		const warn = sinon.stub();
+		logErrorTo({ warn })('Discovery failed');
+		assert.deepStrictEqual(warn.firstCall.args, ['Discovery failed']);
+	});
+});
+
+suite('environment health: discoverInstallations', () => {
+	test('passes the discovered installations through on success', async () => {
+		const logError = sinon.stub();
+		const result = await discoverInstallations(async () => ['r-4.4.1', 'r-4.3.2'], logError);
+		assert.deepStrictEqual(result, { installations: ['r-4.4.1', 'r-4.3.2'], discoveryFailed: false });
+		assert.ok(logError.notCalled);
+	});
+
+	test('a thrown error is logged and becomes an empty list plus the flag', async () => {
+		const logError = sinon.stub();
+		const thrown = new Error('no such directory');
+		const result = await discoverInstallations<string>(async () => {
+			throw thrown;
+		}, logError);
+		assert.deepStrictEqual(result, { installations: [], discoveryFailed: true });
+		// The error object reaches the logger intact rather than flattened into the message;
+		// logErrorTo is what turns it into a stack. probeDiscovery never sees it.
+		assert.deepStrictEqual(logError.firstCall.args, ['R installation discovery failed', thrown]);
 	});
 });
 
@@ -339,24 +394,24 @@ suite('environment health: assembleItems cascade', () => {
 	});
 
 	test('a throwing producer becomes a fail item rather than rejecting', async () => {
-		const logUnexpectedError = sinon.stub();
+		const logError = sinon.stub();
 		const thrown = new Error('kaboom');
 		const result = await assembleItems(
 			{
 				...allPass,
 				ready: () => { throw thrown; },
 			},
-			logUnexpectedError,
+			logError,
 		);
 		assert.strictEqual(result.items[2].status, 'fail');
 		// The summary stays the check's own claim.
 		assert.strictEqual(result.items[2].summary,
 			'The R installation is ready to use with Positron');
-		// The error goes to the log, not to the user. It is passed as the error
-		// argument rather than interpolated, so the log keeps the stack.
+		// The error goes to the log, not to the user, and reaches the logger intact
+		// rather than flattened into the message.
 		assert.ok(!result.items[2].detail?.includes('kaboom'));
-		assert.ok(logUnexpectedError.calledOnce);
-		assert.deepStrictEqual(logUnexpectedError.firstCall.args, [
+		assert.ok(logError.calledOnce);
+		assert.deepStrictEqual(logError.firstCall.args, [
 			`Environment health check 'environmentReady' failed`, thrown,
 		]);
 	});

--- a/extensions/positron-r/src/test/environmentHealth.unit.test.ts
+++ b/extensions/positron-r/src/test/environmentHealth.unit.test.ts
@@ -6,6 +6,7 @@
 import * as assert from 'assert';
 import * as path from 'path';
 import * as semver from 'semver';
+import * as sinon from 'sinon';
 import './mocha-setup';
 import {
 	archesMismatch,
@@ -338,14 +339,25 @@ suite('environment health: assembleItems cascade', () => {
 	});
 
 	test('a throwing producer becomes a fail item rather than rejecting', async () => {
-		const result = await assembleItems({
-			...allPass,
-			ready: () => { throw new Error('kaboom'); },
-		});
+		const logUnexpectedError = sinon.stub();
+		const thrown = new Error('kaboom');
+		const result = await assembleItems(
+			{
+				...allPass,
+				ready: () => { throw thrown; },
+			},
+			logUnexpectedError,
+		);
 		assert.strictEqual(result.items[2].status, 'fail');
-		assert.ok(result.items[2].detail?.includes('kaboom'));
-		// The raw error goes in detail; the summary stays the check's own claim.
+		// The summary stays the check's own claim.
 		assert.strictEqual(result.items[2].summary,
 			'The R installation is ready to use with Positron');
+		// The error goes to the log, not to the user. It is passed as the error
+		// argument rather than interpolated, so the log keeps the stack.
+		assert.ok(!result.items[2].detail?.includes('kaboom'));
+		assert.ok(logUnexpectedError.calledOnce);
+		assert.deepStrictEqual(logUnexpectedError.firstCall.args, [
+			`Environment health check 'environmentReady' failed`, thrown,
+		]);
 	});
 });


### PR DESCRIPTION
This PR fixes a problem with the welcome page's environment health check, found while testing #15596 (which turns on the redesigned welcome page).

Both Python and R's environment health probes catch any unexpected exception from an individual check, and were showing the raw exception message (`Health check failed: <exception message>`) directly to the user in the failed check's detail text. That's developer text, not something a user can act on, and it isn't localized. `runItem()` in both extensions now logs the real message to the extension's output channel at warn level and shows a generic "This check could not be completed." instead.

Following @austin3dickey's review, the same treatment now applies to the three other places that interpolated an error into a detail string: `probeDiscovery()` and `probePythonInstalled()` on the Python side, and `probeDiscovery()` on the R side. Those probes no longer receive the error text at all -- they take a boolean, and reading the locator moved up into `getEnvironmentHealth()` -- so a probe cannot leak developer text even by accident.

Every curated failure message -- "No supported Python was found", "The R installation at X is version Y" -- is untouched; those already show real, actionable, localized detail.

### Screenshots

**Python - the readiness probe throws**

<img width="1506" height="985" alt="Screenshot 2026-08-20 at 12 56 41 PM" src="https://github.com/user-attachments/assets/a62941c4-465b-4f7f-84ca-e8195cc3791f" />

**R - the readiness probe throws**

<img width="1506" height="985" alt="Screenshot 2026-08-20 at 12 57 09 PM" src="https://github.com/user-attachments/assets/d6ae288a-867f-4662-a618-1b7818c5b7ac" />

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

1. Enable the redesigned welcome page (`welcomePage.experimental`) and open it.
2. Make an individual step throw: temporarily `throw` from the `ready` producer in `extensions/positron-r/src/environmentHealth.ts`, or from the `ready` producer in `extensions/positron-python/src/client/positron/environmentHealth.ts`. The failing item's detail should read **"This check could not be completed."** with no exception text.
3. Open the Output panel and pick the **R Language Pack** channel (or **Python Language Pack** for Python). The real exception should be there at warn level, following `Environment health check 'environmentReady' failed`, with a stack.
4. Check the discovery paths too. In the Python file, replace `getNativePythonFinder().lastDiscoveryError` in the `discovery` producer with a literal string; the row should read **"Python environment discovery could not start."** with the diagnostics button, and the literal should appear only in the log. In the R file, replace `discoverRInstallations` in the `discoverInstallations(...)` call with `async () => { throw new Error('boom'); }`; the row should read **"R discovery could not complete."**

@:welcome

