### PR TITLE
Show the resolved interpreter path on the environment health check

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/environmentHealthSection.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/environmentHealthSection.css
@@ -212,9 +212,15 @@
 	min-width: 0;
 }
 
-.positron-welcome-page-environment-setup .environment-health-item-detail {
+.positron-welcome-page-environment-setup .environment-health-item-detail,
+.positron-welcome-page-environment-setup .environment-health-item-path {
 	color: var(--vscode-descriptionForeground);
 	margin: 0;
+}
+
+.positron-welcome-page-environment-setup .environment-health-item-path {
+	font-family: var(--monaco-monospace-font);
+	font-size: 11px;
 }
 
 /*

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/healthItemRow.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/healthItemRow.tsx
@@ -7,7 +7,7 @@
 import './environmentHealthSection.css';
 
 // React.
-import React from 'react';
+import React, { useRef } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../../../nls.js';
@@ -15,6 +15,8 @@ import { URI } from '../../../../../../base/common/uri.js';
 import { Button } from '../../../../../../base/browser/ui/positronComponents/button/button.js';
 import { usePositronReactServicesContext } from '../../../../../../base/browser/positronReactRendererContext.js';
 import { IHoverManager } from '../../../../../../platform/hover/browser/hoverManager.js';
+import { CustomContextMenuItem } from '../../../../../browser/positronComponents/customContextMenu/customContextMenuItem.js';
+import { showCustomContextMenu } from '../../../../../browser/positronComponents/customContextMenu/customContextMenu.js';
 import { HealthItemStatus, IHealthItem, IHealthItemFix } from '../environmentHealth.js';
 
 /** Icon and screen reader text for each outcome. */
@@ -25,8 +27,16 @@ const STATUS_PRESENTATION: Record<HealthItemStatus, { codicon: string; label: st
 	skipped: { codicon: 'codicon-circle-outline', label: localize('positron.welcome.environmentSetupStatusSkipped', "Not checked") },
 };
 
+const positronCopyPath = localize('positron.welcome.environmentSetupCopyPath', "Copy");
+
 export interface HealthItemRowProps {
 	readonly item: IHealthItem;
+	/**
+	 * The resolved interpreter or installation path for this item, or undefined
+	 * when there is none to show. Only ever set for the "a supported X is
+	 * installed" item, and only when it passed.
+	 */
+	readonly path?: string;
 	/**
 	 * Whether this language has a check or a fix running. A fix command can run
 	 * for minutes, and pressing it again runs it again -- a second install, or a
@@ -43,9 +53,10 @@ export interface HealthItemRowProps {
  * @param props A HealthItemRowProps that contains the component properties.
  * @returns The rendered component.
  */
-export const HealthItemRow = ({ item, busy, hoverManager, onRunFix }: HealthItemRowProps) => {
+export const HealthItemRow = ({ item, path, busy, hoverManager, onRunFix }: HealthItemRowProps) => {
 	const services = usePositronReactServicesContext();
 	const status = STATUS_PRESENTATION[item.status];
+	const pathRef = useRef<HTMLParagraphElement>(undefined!);
 
 	// The workbench does not intercept a plain anchor click: on desktop the
 	// main process blocks the navigation outright, and on web it would
@@ -54,6 +65,28 @@ export const HealthItemRow = ({ item, busy, hoverManager, onRunFix }: HealthItem
 	const openLearnMore = (e: React.MouseEvent<HTMLAnchorElement>) => {
 		e.preventDefault();
 		services.openerService.open(URI.parse(item.learnMoreUrl!));
+	};
+
+	// Mirrors currentWorkingDirectory.tsx's own right-click-to-copy handler.
+	const copyPathOnRightClick = async (e: React.MouseEvent<HTMLElement>) => {
+		e.stopPropagation();
+		if (e.button !== 2 || !path) {
+			return;
+		}
+		await showCustomContextMenu({
+			anchorElement: pathRef.current,
+			anchorPoint: { clientX: e.clientX, clientY: e.clientY },
+			popupPosition: 'auto',
+			popupAlignment: 'auto',
+			width: 'auto',
+			entries: [
+				new CustomContextMenuItem({
+					icon: 'copy',
+					label: positronCopyPath,
+					onSelected: async () => await services.clipboardService.writeText(path)
+				})
+			]
+		});
 	};
 
 	// Render.
@@ -76,9 +109,17 @@ export const HealthItemRow = ({ item, busy, hoverManager, onRunFix }: HealthItem
 								{item.fix.label}
 							</Button>}
 					</div>
-					{(item.detail || item.learnMoreUrl) &&
+					{(item.detail || path || item.learnMoreUrl) &&
 						<div className='environment-health-item-secondary'>
 							{item.detail && <p className='environment-health-item-detail'>{item.detail}</p>}
+							{path &&
+								<p
+									ref={pathRef}
+									className='environment-health-item-path'
+									onMouseDown={copyPathOnRightClick}
+								>
+									{path}
+								</p>}
 							{item.learnMoreUrl &&
 								<a
 									href={item.learnMoreUrl}

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/languageHealthGroup.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/components/languageHealthGroup.tsx
@@ -12,7 +12,7 @@ import { status } from '../../../../../../base/browser/ui/aria/aria.js';
 import { Button } from '../../../../../../base/browser/ui/positronComponents/button/button.js';
 import { getIconClassesForLanguageId } from '../../../../../../editor/common/services/getIconClasses.js';
 import { IHoverManager } from '../../../../../../platform/hover/browser/hoverManager.js';
-import { EnvironmentHealthLanguage, IHealthItemFix } from '../environmentHealth.js';
+import { EnvironmentHealthLanguage, IHealthItemFix, pathForItem } from '../environmentHealth.js';
 import { IEnvironmentHealthEntry } from '../environmentHealthService.js';
 import { HealthItemRow } from './healthItemRow.js';
 
@@ -151,10 +151,17 @@ export const LanguageHealthGroup = ({ health, expandedByLanguage, busy, hoverMan
 		if (health.state.kind !== 'result') {
 			return null;
 		}
+		const result = health.state.result;
 		return (
 			<ul className='environment-health-item-list'>
-				{health.state.result.items.map(i =>
-					<HealthItemRow key={i.id} busy={busy} hoverManager={hoverManager} item={i} onRunFix={onRunFix} />)}
+				{result.items.map(i =>
+					<HealthItemRow
+						key={i.id}
+						busy={busy}
+						hoverManager={hoverManager}
+						item={i}
+						path={pathForItem(health.language, i, result)}
+						onRunFix={onRunFix} />)}
 			</ul>
 		);
 	};

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/environmentHealth.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/environmentHealth.ts
@@ -52,6 +52,8 @@ export interface IEnvironmentHealthResult {
 	readonly ok: boolean;
 	/** The full set, in dependency order, with skipped items after the first failure. */
 	readonly items: readonly IHealthItem[];
+	readonly interpreterPath?: string;
+	readonly rBinPath?: string;
 }
 
 export type EnvironmentHealthLanguage = 'python' | 'r';
@@ -131,4 +133,30 @@ export function isEnvironmentHealthResult(value: unknown): value is IEnvironment
 		&& Array.isArray(result.items)
 		&& result.items.length > 0
 		&& result.items.every(isHealthItem);
+}
+
+/**
+ * The path to show next to the "a supported X is installed" step, or undefined
+ * when there is nothing to show.
+ *
+ * Only shown on a passing item: Python's failure details never have a path to
+ * point at (there is no supported interpreter yet), so showing one only on
+ * success keeps both languages consistent rather than inventing a path for one
+ * and not the other.
+ */
+export function pathForItem(
+	language: EnvironmentHealthLanguage,
+	item: IHealthItem,
+	result: IEnvironmentHealthResult
+): string | undefined {
+	if (item.status !== 'pass') {
+		return undefined;
+	}
+	if (language === 'python' && item.id === 'pythonInstalled') {
+		return typeof result.interpreterPath === 'string' ? result.interpreterPath : undefined;
+	}
+	if (language === 'r' && item.id === 'rInstalled') {
+		return typeof result.rBinPath === 'string' ? result.rBinPath : undefined;
+	}
+	return undefined;
 }

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/positronWelcomePage.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/positronWelcomePage.css
@@ -26,6 +26,42 @@
 }
 
 /*
+ * Lets the user select and copy the text on this page.
+ *
+ * The workbench turns selection off for everything (`user-select: none` on
+ * `body` in workbench/browser/media/style.css). gettingStarted.css tries to undo
+ * that with `user-select: initial` on .gettingStartedContainer, but `initial`
+ * means `auto`, and `auto` on a non-editable element resolves to whatever the
+ * parent ended up with -- still `none`. `text` is the value that actually turns
+ * selection back on, which is what editorplaceholder.css uses.
+ *
+ * Listed section by section rather than on .positron-welcome-page, because this
+ * inherits: on the page container it would also reach the recent list and the
+ * startup checkbox, which the editor pane builds and this folder does not own.
+ */
+.positron-welcome-page-header,
+.positron-welcome-page-environment-setup,
+.positron-welcome-page-walkthrough-banner {
+	user-select: text;
+	-webkit-user-select: text;
+}
+
+/*
+ * Buttons stay unselectable. A button is something to press, not text to copy,
+ * and dragging across one leaves its label highlighted instead of pressing it.
+ * The rule above inherits into them, so each one has to opt back out.
+ *
+ * This targets the element, not a class, so it also covers the buttons here that
+ * are styled to look like links -- those are still actions.
+ */
+.positron-welcome-page-header button,
+.positron-welcome-page-environment-setup button,
+.positron-welcome-page-walkthrough-banner button {
+	user-select: none;
+	-webkit-user-select: none;
+}
+
+/*
  * Pins the footer to the bottom of the page. The min-height above leaves free
  * space when the content is short, and this margin takes all of it.
  */

--- a/src/vs/workbench/contrib/welcomeGettingStarted/test/browser/environmentHealth.vitest.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/test/browser/environmentHealth.vitest.ts
@@ -5,7 +5,7 @@
 
 /// <reference types="vitest/globals" />
 
-import { ENVIRONMENT_HEALTH_SOURCES, isEnvironmentHealthResult } from '../../browser/positronWelcomePage/environmentHealth.js';
+import { ENVIRONMENT_HEALTH_SOURCES, isEnvironmentHealthResult, pathForItem } from '../../browser/positronWelcomePage/environmentHealth.js';
 
 describe('isEnvironmentHealthResult', () => {
 	const item = { id: 'discovery', status: 'pass', summary: 'Positron can discover Python environments' };
@@ -59,5 +59,45 @@ describe('ENVIRONMENT_HEALTH_SOURCES', () => {
 			['python', 'ms-python.python', 'python.getEnvironmentHealth'],
 			['r', 'positron.positron-r', 'r.getEnvironmentHealth'],
 		]);
+	});
+});
+
+describe('pathForItem', () => {
+	const passingPythonInstalled = { id: 'pythonInstalled', status: 'pass', summary: 'A supported Python is installed' } as const;
+	const failingPythonInstalled = { id: 'pythonInstalled', status: 'fail', summary: 'A supported Python is installed' } as const;
+	const passingRInstalled = { id: 'rInstalled', status: 'pass', summary: 'A supported R is installed' } as const;
+	const otherItem = { id: 'environmentReady', status: 'pass', summary: 'The environment is ready to use with Positron' } as const;
+
+	it('returns the interpreter path for a passing pythonInstalled item', () => {
+		const result = { ok: true, items: [passingPythonInstalled], interpreterPath: '/usr/bin/python3' };
+		expect(pathForItem('python', passingPythonInstalled, result)).toBe('/usr/bin/python3');
+	});
+
+	it('returns the R binary path for a passing rInstalled item', () => {
+		const result = { ok: true, items: [passingRInstalled], rBinPath: '/usr/lib/R/bin/R' };
+		expect(pathForItem('r', passingRInstalled, result)).toBe('/usr/lib/R/bin/R');
+	});
+
+	it('returns undefined when the item did not pass', () => {
+		const result = { ok: false, items: [failingPythonInstalled], interpreterPath: '/usr/bin/python3' };
+		expect(pathForItem('python', failingPythonInstalled, result)).toBeUndefined();
+	});
+
+	it('returns undefined for an item that is not the installed-check for its language', () => {
+		const result = { ok: true, items: [otherItem], interpreterPath: '/usr/bin/python3' };
+		expect(pathForItem('python', otherItem, result)).toBeUndefined();
+	});
+
+	it('returns undefined when the language and item id are mismatched', () => {
+		// rInstalled only carries a path for R, even if a Python result somehow had it.
+		const result = { ok: true, items: [passingRInstalled], rBinPath: '/usr/lib/R/bin/R' };
+		expect(pathForItem('python', passingRInstalled, result)).toBeUndefined();
+	});
+
+	it('returns undefined when the path field is present but not a string', () => {
+		// A payload that crossed the extension host as JSON can be any shape; a
+		// wrong type must not reach a JSX text node as-is.
+		const result = { ok: true, items: [passingPythonInstalled], interpreterPath: 42 as unknown as string };
+		expect(pathForItem('python', passingPythonInstalled, result)).toBeUndefined();
 	});
 });

--- a/src/vs/workbench/contrib/welcomeGettingStarted/test/browser/healthItemRow.vitest.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/test/browser/healthItemRow.vitest.tsx
@@ -8,11 +8,20 @@
 import { screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { URI } from '../../../../../base/common/uri.js';
+import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
 import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
 import { IHealthItem } from '../../browser/positronWelcomePage/environmentHealth.js';
 import { HealthItemRow } from '../../browser/positronWelcomePage/components/healthItemRow.js';
+
+// showCustomContextMenu renders a modal popup into the workbench DOM, which isn't what these
+// tests are about -- the behavior under test is which entry the row offers and what it does when
+// selected. Mocking the one module lets us read the entries straight off the call.
+const { showCustomContextMenu } = vi.hoisted(() => ({ showCustomContextMenu: vi.fn() }));
+vi.mock('../../../../browser/positronComponents/customContextMenu/customContextMenu.js', () => ({
+	showCustomContextMenu,
+}));
 
 const item = (overrides: Partial<IHealthItem> = {}): IHealthItem => ({
 	id: 'environmentReady',
@@ -23,10 +32,15 @@ const item = (overrides: Partial<IHealthItem> = {}): IHealthItem => ({
 
 describe('HealthItemRow', () => {
 	const open = vi.fn();
-	const ctx = createTestContainer().withReactServices().stub(IOpenerService, { open }).build();
+	const writeText = vi.fn();
+	const ctx = createTestContainer().withReactServices()
+		.stub(IOpenerService, { open })
+		.stub(IClipboardService, { writeText })
+		.build();
 	const rtl = setupRTLRenderer(() => ctx.reactServices);
 
 	beforeEach(() => {
+		showCustomContextMenu.mockClear();
 	});
 
 	it.each([
@@ -95,5 +109,34 @@ describe('HealthItemRow', () => {
 		expect(button).toBeEnabled();
 		await userEvent.setup().click(button);
 		expect(onRunFix).not.toHaveBeenCalled();
+	});
+
+	it('renders no path when none is given', () => {
+		rtl.render(<HealthItemRow busy={false} item={item()} onRunFix={vi.fn()} />);
+		expect(screen.queryByText('/usr/bin/python3')).not.toBeInTheDocument();
+	});
+
+	it('renders the path when one is given', () => {
+		rtl.render(<HealthItemRow busy={false} item={item()} path='/usr/bin/python3' onRunFix={vi.fn()} />);
+		expect(screen.getByText('/usr/bin/python3')).toBeInTheDocument();
+	});
+
+	it('copies the path to the clipboard from its context menu', async () => {
+		rtl.render(<HealthItemRow busy={false} item={item()} path='/usr/bin/python3' onRunFix={vi.fn()} />);
+		const path = screen.getByText('/usr/bin/python3');
+		await userEvent.setup().pointer({ keys: '[MouseRight]', target: path });
+
+		const call = showCustomContextMenu.mock.calls.at(-1)?.[0];
+		const copyEntry = call?.entries.find((entry: { options?: { label?: string } }) => entry.options?.label === 'Copy');
+		expect(copyEntry).toBeDefined();
+		await copyEntry.options.onSelected({ altKey: false, ctrlKey: false, metaKey: false, shiftKey: false });
+
+		expect(writeText).toHaveBeenCalledWith('/usr/bin/python3');
+	});
+
+	it('leaves a left click on the path alone', async () => {
+		rtl.render(<HealthItemRow busy={false} item={item()} path='/usr/bin/python3' onRunFix={vi.fn()} />);
+		await userEvent.setup().click(screen.getByText('/usr/bin/python3'));
+		expect(showCustomContextMenu).not.toHaveBeenCalled();
 	});
 });

--- a/src/vs/workbench/contrib/welcomeGettingStarted/test/browser/languageHealthGroup.vitest.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/test/browser/languageHealthGroup.vitest.tsx
@@ -62,6 +62,18 @@ describe('LanguageHealthGroup', () => {
 		expect(screen.getAllByRole('listitem')).toHaveLength(2);
 	});
 
+	it('passes the resolved path through to the matching item only', async () => {
+		const rInstalled = { id: 'rInstalled', status: 'pass', summary: 'A supported R is installed' } as const;
+		const other = { id: 'environmentReady', status: 'pass', summary: 'The R installation is ready to use with Positron' } as const;
+		const state = {
+			kind: 'result',
+			result: { ok: true, items: [rInstalled, other], rBinPath: '/usr/lib/R/bin/R' },
+		} as const;
+		rtl.render(<LanguageHealthGroup busy={false} expandedByLanguage={overrides} health={{ language: 'r', label: 'R', state }} onRunFix={vi.fn()} />);
+		await userEvent.setup().click(screen.getByRole('button', { name: /^R/ }));
+		expect(screen.getByText('/usr/lib/R/bin/R')).toBeInTheDocument();
+	});
+
 	it('lets the user overrule what it chose for them', async () => {
 		render(failing);
 		await userEvent.setup().click(header());


### PR DESCRIPTION
The welcome page's environment health card checks that a supported Python/R is installed, but never showed you _which_ one. Found while testing #15596 (which turns on the redesigned welcome page).

This PR:

- Shows the resolved interpreter/installation path under the "A supported Python/R is installed" check, when that check passes. Right-click it for a **Copy** entry.
- Makes the welcome page's own sections selectable. You couldn't select or copy _any_ text on the page before this. Buttons stay unselectable.

### Screenshots

https://github.com/user-attachments/assets/a4a6c692-1348-4074-839b-b76162f30052

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

SETUP: enable the redesigned welcome page (`welcomePage.experimental`) and open it.

1. **Path shown on success:** expand a language group whose "A supported X is installed" check passes. The path should render under that check, in a monospace font.
2. **Copy support:** right-click the path. A menu with a single **Copy** entry should appear, and selecting it should put the path on the clipboard.
3. **No path on failure:** set `"positron.r.interpreters.override": ["/tmp/no-r-here"]` and press the refresh button in the card header. The R discovery check should fail and no path should render.
4. **Text is selectable:** drag across the path, a check summary, and the card title. All three should highlight and Cmd/Ctrl+C should copy.
5. **Buttons are not:** drag across a language group header. Its label should not highlight, and clicking it should still expand and collapse the group.

@:welcome
