### PR TITLE
Upstream merge from vscode-server to fix slow configuration reads

### DIFF
--- a/src/vs/platform/configuration/common/configurationModels.ts
+++ b/src/vs/platform/configuration/common/configurationModels.ts
@@ -726,6 +726,9 @@ export class Configuration {
 
 	private _workspaceConsolidatedConfiguration: ConfigurationModel | null = null;
 	private _foldersConsolidatedConfigurations = new ResourceMap<ConfigurationModel>();
+	// --- Start PWB: Cache the policy overlay, keyed by the consolidated model it was built from ---
+	private _policyOverlaidConfigurations = new WeakMap<ConfigurationModel, ConfigurationModel>();
+	// --- End PWB ---
 
 	constructor(
 		private _defaultConfiguration: ConfigurationModel,
@@ -825,6 +828,14 @@ export class Configuration {
 
 	updatePolicyConfiguration(policyConfiguration: ConfigurationModel): void {
 		this._policyConfiguration = policyConfiguration;
+		// --- Start PWB: Discard overlays built from the previous policy configuration ---
+		// Every other update method replaces the consolidated models, so their overlays fall out of the
+		// WeakMap on their own. A policy change leaves those models in place, so it has to invalidate here.
+		// The caller must treat `policyConfiguration` as immutable from here on, because the overlay is
+		// built from it only once. `PolicyConfiguration.update` satisfies this: it always builds a new
+		// model instead of changing the installed one.
+		this._policyOverlaidConfigurations = new WeakMap<ConfigurationModel, ConfigurationModel>();
+		// --- End PWB ---
 	}
 
 	updateApplicationConfiguration(applicationConfiguration: ConfigurationModel): void {
@@ -992,11 +1003,7 @@ export class Configuration {
 		// --- Start PWB: Apply policy before overrides so language-scoped policy keys participate in override flattening ---
 		// if (!this._policyConfiguration.isEmpty() && this._policyConfiguration.getValue(section) !== undefined) {
 		if (!this._policyConfiguration.isEmpty()) {
-			// clone by merging
-			configurationModel = configurationModel.merge();
-			for (const key of this._policyConfiguration.keys) {
-				configurationModel.setValue(key, this._policyConfiguration.getValue(key));
-			}
+			configurationModel = this.getPolicyOverlaidConfigurationModel(configurationModel);
 		}
 		if (overrides.overrideIdentifier) {
 			configurationModel = configurationModel.override(overrides.overrideIdentifier);
@@ -1004,6 +1011,30 @@ export class Configuration {
 		// --- End PWB ---
 		return configurationModel;
 	}
+
+	// --- Start PWB: Apply policy before overrides so language-scoped policy keys participate in override flattening ---
+	/**
+	 * Returns the given consolidated model with the policy configuration stamped on top of it.
+	 *
+	 * The upstream guard `this._policyConfiguration.getValue(section) !== undefined` cannot see
+	 * language-scoped policy keys such as `[r]`, so it is gone and this runs for every read while any
+	 * policy is set. Building the overlay deep-clones the whole configuration tree, which is far too
+	 * expensive per read, so the result is cached against the model it was built from. Reads then also
+	 * share one overlay instance, which lets `override()` reuse its own per-identifier cache.
+	 */
+	private getPolicyOverlaidConfigurationModel(configurationModel: ConfigurationModel): ConfigurationModel {
+		let policyOverlaidConfigurationModel = this._policyOverlaidConfigurations.get(configurationModel);
+		if (!policyOverlaidConfigurationModel) {
+			// clone by merging
+			policyOverlaidConfigurationModel = configurationModel.merge();
+			for (const key of this._policyConfiguration.keys) {
+				policyOverlaidConfigurationModel.setValue(key, this._policyConfiguration.getValue(key));
+			}
+			this._policyOverlaidConfigurations.set(configurationModel, policyOverlaidConfigurationModel);
+		}
+		return policyOverlaidConfigurationModel;
+	}
+	// --- End PWB ---
 
 	private getConsolidatedConfigurationModelForResource({ resource }: IConfigurationOverrides, workspace: Workspace | undefined): ConfigurationModel {
 		let consolidateConfiguration = this.getWorkspaceConsolidatedConfiguration();

--- a/src/vs/platform/configuration/test/common/configurationModels.test.ts
+++ b/src/vs/platform/configuration/test/common/configurationModels.test.ts
@@ -870,6 +870,59 @@ suite('Configuration', () => {
 		assert.strictEqual(testObject.getValue('editor.formatOnSave', { overrideIdentifier: 'r' }, undefined), true);
 		assert.strictEqual(testObject.getValue('editor.formatOnSave', {}, undefined), false);
 	});
+
+	test('getValue picks up a policy configuration change after a read', () => {
+		const testObject: Configuration = new TestConfiguration(
+			ConfigurationModel.createEmptyModel(new NullLogService()),
+			parseConfigurationModel({ '[r]': { 'editor.formatOnSave': true }, 'editor.tabSize': 2 }),
+			ConfigurationModel.createEmptyModel(new NullLogService()),
+			parseConfigurationModel({ 'editor.formatOnSave': false, 'editor.tabSize': 8 }),
+		);
+		testObject.getValue('editor.formatOnSave', { overrideIdentifier: 'r' }, undefined);
+
+		testObject.updatePolicyConfiguration(parseConfigurationModel({ '[r]': { 'editor.formatOnSave': false }, 'editor.tabSize': 4 }));
+
+		assert.deepStrictEqual([
+			testObject.getValue('editor.formatOnSave', { overrideIdentifier: 'r' }, undefined),
+			testObject.getValue('editor.tabSize', {}, undefined),
+		], [false, 4]);
+	});
+
+	test('getValue picks up a user configuration change while a policy is set', () => {
+		const testObject: Configuration = new TestConfiguration(
+			ConfigurationModel.createEmptyModel(new NullLogService()),
+			parseConfigurationModel({ '[r]': { 'editor.formatOnSave': true } }),
+			ConfigurationModel.createEmptyModel(new NullLogService()),
+			parseConfigurationModel({ 'editor.tabSize': 8 }),
+		);
+		testObject.getValue('editor.formatOnSave', { overrideIdentifier: 'r' }, undefined);
+
+		testObject.updateLocalUserConfiguration(parseConfigurationModel({ 'editor.tabSize': 4 }));
+
+		assert.deepStrictEqual([
+			testObject.getValue('editor.formatOnSave', { overrideIdentifier: 'r' }, undefined),
+			testObject.getValue('editor.tabSize', {}, undefined),
+		], [true, 4]);
+	});
+
+	test('getValue does not rebuild the policy overlay for each read', () => {
+		const policyConfigurationModel = parseConfigurationModel({ '[r]': { 'editor.formatOnSave': true } });
+		const testObject: Configuration = new TestConfiguration(
+			ConfigurationModel.createEmptyModel(new NullLogService()),
+			policyConfigurationModel,
+			ConfigurationModel.createEmptyModel(new NullLogService()),
+			parseConfigurationModel({ 'editor.formatOnSave': false }),
+		);
+		testObject.getValue('editor.formatOnSave', { overrideIdentifier: 'r' }, undefined);
+
+		// An installed policy model must be treated as immutable, because the overlay is built from it
+		// only once. This changes it in place to prove that the second read reuses the first overlay.
+		// Production code replaces the model through `updatePolicyConfiguration` instead, which the test
+		// above covers.
+		policyConfigurationModel.setValue('[r]', { 'editor.formatOnSave': false });
+
+		assert.strictEqual(testObject.getValue('editor.formatOnSave', { overrideIdentifier: 'r' }, undefined), true);
+	});
 	// --- End PWB ---
 
 	test('Test update value', () => {


### PR DESCRIPTION
- Addresses #15427
- Upstream merge from vscode-server, bringing in rstudio/vscode-server#405.

The base branch is `release/2026.08` here, not `main`, so merging this does not close #15427. I'm adding this for the patch release we're going to do, but will still need to bring this to `main` for 2026.09.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed slow scrolling in the Data Explorer when an enforced setting or policy is set (#15427)

### Considered but not included

Other commits on `upstream/main` since the last pull (#15335) were triaged and left out:

| Reason | Commits |
| --- | --- |
| Scoped out; a release branch takes the targeted fix only | <ul><li>rstudio/vscode-server#404 (clean exit on SIGTERM/SIGINT)</li><li>rstudio/vscode-server#408 (static asset URL prefix)</li></ul> |
| Already implemented in Positron (#15335) | <ul><li>rstudio/vscode-server#365</li><li>rstudio/vscode-server#366</li><li>rstudio/vscode-server#369</li><li>rstudio/vscode-server#372</li><li>rstudio/vscode-server#377</li><li>rstudio/vscode-server#385</li><li>rstudio/vscode-server#389</li><li>rstudio/vscode-server#390</li><li>rstudio/vscode-server#393</li></ul> |
| rstudio.rstudio-workbench bumps; `release/2026.08` pins 2026.8.6 on purpose | <ul><li>rstudio/vscode-server#363</li><li>rstudio/vscode-server#370</li><li>rstudio/vscode-server#381</li><li>rstudio/vscode-server#387</li><li>rstudio/vscode-server#396</li><li>rstudio/vscode-server#397</li><li>rstudio/vscode-server#401</li></ul> |
| CI automation and vscode-server version bumps only | <ul><li>rstudio/vscode-server#395</li><li>rstudio/vscode-server#398</li><li>rstudio/vscode-server#399</li><li>rstudio/vscode-server#406</li></ul> |

### Validation Steps

@:workbench @:web @:jupyter @:data-explorer @:vscode-settings

The port adds three tests to `src/vs/platform/configuration/test/common/configurationModels.test.ts`. Run them with:

```sh
./scripts/test.sh --run src/vs/platform/configuration/test/common/configurationModels.test.ts
```

For manual verification, start the server with enforced settings:

```sh
POSITRON_ENFORCED_SETTINGS='{"[markdown]":{"editor.lineNumbers":"off"},"workbench.colorTheme":"Default High Contrast"}' \
  ./scripts/code-server.sh --port 9888 --without-connection-token
```

Open `http://localhost:9888`. Then:

1. Open a `.md` file. It has no line numbers. Open a `.js` file. It has line numbers. This is the language-scoped enforced setting.
2. Make sure that the theme is High Contrast. Top-level enforced settings still work.
3. Set `editor.lineNumbers` to `relative` in your user settings. The `.js` file changes to relative numbering, and the markdown file still has no line numbers. A user configuration change invalidates the cached overlay.
4. Add `"[markdown]": {"editor.lineNumbers": "on"}` to your user settings. The markdown file still has no line numbers, because the policy wins.
5. Open a large data frame in the Data Explorer and scroll it. Scrolling is smooth.
