### PR TITLE
Cherry-pick #15635 into release/2026.08

### DIFF
--- a/extensions/positron-python/src/client/common/stringUtils.ts
+++ b/extensions/positron-python/src/client/common/stringUtils.ts
@@ -48,10 +48,20 @@ export function replaceAll(source: string, substr: string, newSubstr: string): s
 // --- Start Positron ---
 /**
  * Returns the shortest string from an array of strings.
+ *
+ * Equal-length strings are broken lexicographically so that the result depends
+ * only on the set of inputs, not on their order. Callers use this to pick a
+ * single winner among equivalent interpreter paths; an order-dependent result
+ * lets two equal-length paths each displace the other indefinitely.
  * @param strings - The strings to compare.
- * @returns The shortest string.
+ * @returns The shortest string, or the lexicographically first of the shortest.
  */
 export function getShortestString(strings: string[]): string {
-    return strings.reduce((a, b) => (a.length <= b.length ? a : b));
+    return strings.reduce((a, b) => {
+        if (a.length !== b.length) {
+            return a.length < b.length ? a : b;
+        }
+        return a <= b ? a : b;
+    });
 }
 // --- End Positron ---

--- a/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
@@ -392,6 +392,12 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
     // resolveEnv(). Only successful resolutions are cached. Entries are
     // invalidated in addEnv()/removeEnv() so a late-arriving discovery
     // immediately supersedes any cached state.
+    //
+    // A single env can be reachable through several paths (symlinks, or a
+    // `python3.11` alias beside `python`), and PET reports its own canonical
+    // path rather than the one that was asked about. Both the requested path
+    // and the resolved path are cached, so an alias path doesn't miss the
+    // cache forever and spawn PET on every call.
     private _resolveEnvCache = new Map<string, { info: PythonEnvInfo; expiry: number }>();
 
     // In-flight promise deduplication for resolveEnv(). Concurrent callers for
@@ -401,6 +407,30 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
     private _resolveEnvInFlight = new Map<string, Promise<PythonEnvInfo | undefined>>();
 
     private static readonly _resolveEnvCacheMs = 30_000;
+
+    /**
+     * Caches a resolved env under the given path.
+     */
+    private cacheResolvedEnv(envPath: string, info: PythonEnvInfo): void {
+        this._resolveEnvCache.set(envPath, {
+            info,
+            expiry: Date.now() + NativePythonEnvironments._resolveEnvCacheMs,
+        });
+    }
+
+    /**
+     * Drops every cache entry for an env, including entries cached under an
+     * alias path. Keying alone isn't enough to find them, so the entries are
+     * also matched by the env they point at.
+     */
+    private evictResolvedEnv(filename: string): void {
+        this._resolveEnvCache.delete(filename);
+        for (const [key, entry] of this._resolveEnvCache) {
+            if (entry.info.executable.filename === filename) {
+                this._resolveEnvCache.delete(key);
+            }
+        }
+    }
     // --- End Positron ---
 
     constructor(private readonly finder: NativePythonFinder) {
@@ -519,7 +549,13 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
             if (native.executable && version && version.major >= 0 && version.minor >= 0 && version.micro >= 0) {
                 // --- Start Positron ---
                 // added await
-                return (await this.addEnv(native))?.executable.filename;
+                const added = await this.addEnv(native);
+                // Report the path this refresh actually found, not the path of the
+                // env addEnv settled on. When an equivalent env already holds this
+                // interpreter, addEnv reports that existing env; treating it as
+                // re-discovered would keep it alive after it has been deleted from
+                // disk, because its longer equivalent would keep vouching for it.
+                return added ? native.executable : undefined;
                 // --- End Positron ---
             }
             traceError(`Failed to process environment: ${JSON.stringify(native)}`);
@@ -614,7 +650,12 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
                         traceVerbose(
                             `[addEnv] Not adding ${info.executable.filename} because it's equivalent to ${existingEnv.executable.filename}`,
                         );
-                        return undefined;
+                        // Return the surviving env rather than undefined. The caller asked about an
+                        // equivalent path and there is a real env behind it, so reporting nothing
+                        // makes the path permanently unresolvable: resolveEnv() only caches
+                        // successful resolutions, so every call would spawn PET again, and
+                        // registration would reject the path as invalid.
+                        return existingEnv;
                     case ExistingEnvAction.AddNewEnv:
                         // Proceed to add the 'info' env because we truly do not have an 'old' env.
                         break;
@@ -644,7 +685,7 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
                 this._envIdentities.delete(oldFilename);
                 // Drop any stale resolveEnv cache entry for the replaced path
                 // so late callers don't see the superseded env.
-                this._resolveEnvCache.delete(oldFilename);
+                this.evictResolvedEnv(oldFilename);
                 this._envs = this._envs.filter(
                     (item) =>
                         item.executable.filename !== info.executable.filename &&
@@ -662,10 +703,7 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
             // --- Start Positron ---
             // Publish the freshly resolved env to the resolveEnv cache so later
             // callers hit it without spawning another PET round-trip.
-            this._resolveEnvCache.set(info.executable.filename, {
-                info,
-                expiry: Date.now() + NativePythonEnvironments._resolveEnvCacheMs,
-            });
+            this.cacheResolvedEnv(info.executable.filename, info);
             // --- End Positron ---
         }
 
@@ -678,7 +716,7 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
             this._envs = this._envs.filter((item) => item.executable.filename !== env);
             // --- Start Positron ---
             this._envIdentities.delete(env);
-            this._resolveEnvCache.delete(env);
+            this.evictResolvedEnv(env);
             // --- End Positron ---
             this._onChanged.fire({ type: FileChangeType.Deleted, old });
             return;
@@ -686,7 +724,7 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
         this._envs = this._envs.filter((item) => item.executable.filename !== env.executable.filename);
         // --- Start Positron ---
         this._envIdentities.delete(env.executable.filename);
-        this._resolveEnvCache.delete(env.executable.filename);
+        this.evictResolvedEnv(env.executable.filename);
         // --- End Positron ---
         this._onChanged.fire({ type: FileChangeType.Deleted, old: env });
     }
@@ -747,7 +785,15 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
                 }
                 // --- Start Positron ---
                 // added await
-                return await this.addEnv(native);
+                const info = await this.addEnv(native);
+                if (info && info.executable.filename !== envPath) {
+                    // PET reported a different path than the one asked about, or an
+                    // equivalent env already won the path. Cache under the requested
+                    // path too, so the caller's next lookup hits instead of spawning
+                    // PET again for the life of this alias.
+                    this.cacheResolvedEnv(envPath, info);
+                }
+                return info;
                 // --- End Positron ---
             }
             return undefined;

--- a/extensions/positron-python/src/test/common/stringUtils.unit.test.ts
+++ b/extensions/positron-python/src/test/common/stringUtils.unit.test.ts
@@ -3,7 +3,9 @@
 
 import { expect } from 'chai';
 import '../../client/common/extensions';
-import { replaceAll } from '../../client/common/stringUtils';
+// --- Start Positron ---
+import { getShortestString, replaceAll } from '../../client/common/stringUtils';
+// --- End Positron ---
 
 suite('String Extensions', () => {
     test('String should replace all substrings with new substring', () => {
@@ -21,3 +23,33 @@ suite('String Extensions', () => {
         expect(replaceAll(oldString4, '\\', '\\\\')).to.be.equal(expectedString4);
     });
 });
+
+// --- Start Positron ---
+suite('getShortestString', () => {
+    test('returns the shortest string', () => {
+        expect(getShortestString(['aaa', 'a', 'aa'])).to.be.equal('a');
+    });
+
+    test('returns the only string', () => {
+        expect(getShortestString(['aaa'])).to.be.equal('aaa');
+    });
+
+    test('breaks equal-length ties lexicographically', () => {
+        expect(getShortestString(['bbb', 'aaa'])).to.be.equal('aaa');
+    });
+
+    test('equal-length result does not depend on argument order', () => {
+        // Two interpreter paths of the same length that reach the same
+        // interpreter. An order-dependent winner here lets each path displace
+        // the other indefinitely, which spins the locator forever.
+        const a = '/opt/python/default/bin/python';
+        const b = '/opt/python/3.11.13/bin/python';
+        expect(a.length).to.be.equal(b.length);
+        expect(getShortestString([a, b])).to.be.equal(getShortestString([b, a]));
+    });
+
+    test('prefers a shorter path over a lexicographically earlier one', () => {
+        expect(getShortestString(['/opt/z/python', '/opt/aaaa/python'])).to.be.equal('/opt/z/python');
+    });
+});
+// --- End Positron ---

--- a/extensions/positron-python/src/test/pythonEnvironments/nativeAPI.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/nativeAPI.unit.test.ts
@@ -554,6 +554,274 @@ suite('Native Python API', () => {
         assert.equal(envs[0].executable.filename, shorterPath);
     });
 
+    test('a de-duplicated env that disappears is not kept alive by its longer equivalent', async () => {
+        // The winning (shortest) path is deleted from disk, so the refresh only
+        // reports the longer equivalent. Refresh bookkeeping tracks which paths
+        // the refresh actually reported, so the stale winner must still be
+        // removed rather than being re-confirmed by its equivalent.
+        const additionalDir = '/opt/python';
+        const shorterPath = '/opt/python/bin/python';
+        const longerPath = '/opt/python/3.11/bin/python';
+        const symlinkTarget = '/opt/python/3.11/bin/python3.11';
+
+        sinon.stub(nativeFinder, 'getAdditionalEnvDirs').resolves([additionalDir]);
+        const toTarget = async (p: string) =>
+            p === shorterPath || p === longerPath || p === symlinkTarget ? symlinkTarget : p;
+        sinon.stub(externalDeps, 'resolveSymbolicLink').callsFake(toTarget);
+        sinon.stub(externalDeps, 'canonicalizePath').callsFake(toTarget);
+
+        function envAt(executable: string): NativeEnvInfo {
+            return {
+                displayName: 'Python 3.11',
+                name: 'python',
+                executable,
+                kind: NativePythonEnvironmentKind.LinuxGlobal,
+                version: '3.11.13',
+                prefix: '/opt/python/3.11',
+            };
+        }
+
+        let shorterExists = true;
+        mockFinder
+            .setup((f) => f.refresh())
+            .returns(() => {
+                async function* generator() {
+                    yield* shorterExists ? [envAt(shorterPath), envAt(longerPath)] : [envAt(longerPath)];
+                }
+                return generator();
+            });
+
+        await api.triggerRefresh();
+        assert.deepEqual(
+            api.getEnvs().map((e) => e.executable.filename),
+            [shorterPath],
+            'the shorter path should win the first refresh',
+        );
+
+        // The shorter path is deleted, so the next refresh only reports the longer one.
+        shorterExists = false;
+        await api.triggerRefresh();
+        assert.notInclude(
+            api.getEnvs().map((e) => e.executable.filename),
+            shorterPath,
+            'the deleted path must not survive because its equivalent was reported',
+        );
+
+        // The surviving path is picked up once the stale winner is gone.
+        await api.triggerRefresh();
+        assert.deepEqual(
+            api.getEnvs().map((e) => e.executable.filename),
+            [longerPath],
+            'the remaining path should be discovered',
+        );
+    });
+
+    suite('equal-length equivalent paths', () => {
+        // Two interpreter paths of the same length that reach the same
+        // interpreter, as on a Workbench image that carries both a versioned
+        // directory and a `default` symlink beside it. `default` and `3.11.13`
+        // are both 7 characters, so neither path is shorter.
+        const additionalDir = '/opt/python';
+        const defaultPath = '/opt/python/default/bin/python';
+        const versionPath = '/opt/python/3.11.13/bin/python';
+        const symlinkTarget = '/opt/python/3.11.13/bin/python3.11';
+
+        function envAt(executable: string): NativeEnvInfo {
+            return {
+                displayName: 'Python 3.11',
+                name: 'python',
+                executable,
+                kind: NativePythonEnvironmentKind.LinuxGlobal,
+                version: '3.11.13',
+                prefix: '/opt/python/3.11.13',
+            };
+        }
+
+        setup(() => {
+            assert.equal(defaultPath.length, versionPath.length, 'test premise: the two paths tie on length');
+            sinon.stub(nativeFinder, 'getAdditionalEnvDirs').resolves([additionalDir]);
+            const toTarget = async (p: string) =>
+                p === defaultPath || p === versionPath || p === symlinkTarget ? symlinkTarget : p;
+            sinon.stub(externalDeps, 'resolveSymbolicLink').callsFake(toTarget);
+            sinon.stub(externalDeps, 'canonicalizePath').callsFake(toTarget);
+        });
+
+        test('a tie keeps one env and picks the same winner regardless of arrival order', async () => {
+            // Whichever path arrives second must not displace the first, or each
+            // arrival fires a path-changing event that forces another resolve,
+            // and the two paths resolve each other forever.
+            async function envsAfterRefreshOrder(order: NativeEnvInfo[]): Promise<string[]> {
+                const finder = typemoq.Mock.ofType<NativePythonFinder>();
+                finder
+                    .setup((f) => f.refresh())
+                    .returns(() => {
+                        async function* generator() {
+                            yield* order;
+                        }
+                        return generator();
+                    });
+                const scoped = nativeAPI.createNativeEnvironmentsApi(finder.object);
+                await scoped.triggerRefresh();
+                return scoped.getEnvs().map((e) => e.executable.filename);
+            }
+
+            const defaultFirst = await envsAfterRefreshOrder([envAt(defaultPath), envAt(versionPath)]);
+            const versionFirst = await envsAfterRefreshOrder([envAt(versionPath), envAt(defaultPath)]);
+
+            assert.equal(defaultFirst.length, 1, 'equivalent envs should collapse to one');
+            assert.equal(versionFirst.length, 1, 'equivalent envs should collapse to one');
+            assert.deepEqual(defaultFirst, versionFirst, 'the winner must not depend on arrival order');
+        });
+
+        test('resolving the losing path returns the surviving env', async () => {
+            // The losing path still names a real interpreter. Returning nothing
+            // leaves it uncacheable (only successes are cached) and unregisterable.
+            mockFinder
+                .setup((f) => f.refresh())
+                .returns(() => {
+                    async function* generator() {
+                        yield* [envAt(versionPath), envAt(defaultPath)];
+                    }
+                    return generator();
+                });
+
+            await api.triggerRefresh();
+            const survivor = api.getEnvs()[0].executable.filename;
+            const loser = survivor === defaultPath ? versionPath : defaultPath;
+
+            let resolveCount = 0;
+            mockFinder
+                .setup((f) => f.resolve(loser))
+                .returns(() => {
+                    resolveCount += 1;
+                    return Promise.resolve(envAt(loser));
+                });
+
+            const resolved = await api.resolveEnv(loser);
+            assert.isDefined(resolved, 'the losing path should resolve to the surviving env');
+            assert.equal(resolved?.executable.filename, survivor);
+
+            // And the result is cached under the losing path, so repeated calls
+            // don't spawn PET again.
+            await api.resolveEnv(loser);
+            assert.equal(resolveCount, 1, 'the losing path should be cached after the first resolve');
+        });
+    });
+
+    suite('three equal-length paths', () => {
+        // Three interpreter paths that all tie on length, where only some of them
+        // are equivalent: `/opt/python` holds two real versioned installs plus
+        // `default`, a symlink to one of them. `3.11.11`, `3.11.13`, `current` and
+        // `default` are all 7 characters, so no path is ever shorter than another
+        // and every comparison between them is a tie.
+        const additionalDir = '/opt/python';
+        const olderPath = '/opt/python/3.11.11/bin/python';
+        const newerPath = '/opt/python/3.11.13/bin/python';
+        const defaultPath = '/opt/python/default/bin/python';
+        const currentPath = '/opt/python/current/bin/python';
+
+        // `default` and `current` both point at the 3.11.13 install; `3.11.11` is
+        // its own interpreter. Directories are resolved as well as executables, so
+        // an alias reached through a symlinked *directory* canonicalizes too.
+        const aliasDirs = ['/opt/python/default', '/opt/python/current'];
+        async function canonicalize(p: string): Promise<string> {
+            let resolved = p;
+            for (const aliasDir of aliasDirs) {
+                if (p === aliasDir || p.startsWith(`${aliasDir}/`)) {
+                    resolved = p.replace(aliasDir, '/opt/python/3.11.13');
+                    break;
+                }
+            }
+            return resolved.endsWith('/bin/python') ? `${resolved}3.11` : resolved;
+        }
+
+        function envAt(executable: string, version = '3.11.13'): NativeEnvInfo {
+            return {
+                displayName: `Python ${version}`,
+                name: 'python',
+                executable,
+                kind: NativePythonEnvironmentKind.LinuxGlobal,
+                version,
+                // PET reports the prefix as the path it walked, alias and all.
+                prefix: path.dirname(path.dirname(executable)),
+            };
+        }
+
+        async function envsAfterRefreshOrder(order: NativeEnvInfo[]): Promise<string[]> {
+            const finder = typemoq.Mock.ofType<NativePythonFinder>();
+            finder
+                .setup((f) => f.refresh())
+                .returns(() => {
+                    async function* generator() {
+                        yield* order;
+                    }
+                    return generator();
+                });
+            const scoped = nativeAPI.createNativeEnvironmentsApi(finder.object);
+            await scoped.triggerRefresh();
+            return scoped
+                .getEnvs()
+                .map((e) => e.executable.filename)
+                .sort();
+        }
+
+        /** Every arrival order of the given envs. */
+        function permutations(envs: NativeEnvInfo[]): NativeEnvInfo[][] {
+            if (envs.length <= 1) {
+                return [envs];
+            }
+            const result: NativeEnvInfo[][] = [];
+            for (let i = 0; i < envs.length; i += 1) {
+                const rest = [...envs.slice(0, i), ...envs.slice(i + 1)];
+                for (const tail of permutations(rest)) {
+                    result.push([envs[i], ...tail]);
+                }
+            }
+            return result;
+        }
+
+        setup(() => {
+            for (const p of [olderPath, newerPath, defaultPath, currentPath]) {
+                assert.equal(p.length, newerPath.length, 'test premise: all four paths tie on length');
+            }
+            sinon.stub(nativeFinder, 'getAdditionalEnvDirs').resolves([additionalDir]);
+            sinon.stub(externalDeps, 'resolveSymbolicLink').callsFake(canonicalize);
+            sinon.stub(externalDeps, 'canonicalizePath').callsFake(canonicalize);
+        });
+
+        test('a distinct interpreter is not dropped by a tie between two others', async () => {
+            // Issue reported on PR #15635: with `3.11.11`, `3.11.13` and a
+            // same-length `default` symlinked to `3.11.13`, only the alias may be
+            // de-duplicated. `3.11.11` ties on length but is a different
+            // interpreter, so it must survive in every arrival order.
+            const envs = [envAt(olderPath, '3.11.11'), envAt(newerPath), envAt(defaultPath)];
+            for (const order of permutations(envs)) {
+                const filenames = await envsAfterRefreshOrder(order);
+                assert.deepEqual(
+                    filenames,
+                    [olderPath, newerPath],
+                    `both interpreters should survive, order: ${order.map((e) => e.executable).join(', ')}`,
+                );
+            }
+        });
+
+        test('a three-way tie collapses to one env regardless of arrival order', async () => {
+            // All three paths reach the same interpreter and all three tie on
+            // length, so the winner comes from the lexicographic tiebreak alone.
+            // An order-dependent winner would let the paths displace each other
+            // indefinitely.
+            const envs = [envAt(newerPath), envAt(defaultPath), envAt(currentPath)];
+            for (const order of permutations(envs)) {
+                const filenames = await envsAfterRefreshOrder(order);
+                assert.deepEqual(
+                    filenames,
+                    [newerPath],
+                    `the tie should resolve to one winner, order: ${order.map((e) => e.executable).join(', ')}`,
+                );
+            }
+        });
+    });
+
     test('Issue #14489: a uv interpreter reached through a symlinked version directory is de-duplicated', async () => {
         // uv installs a real `cpython-3.14.6-*` directory alongside a
         // `cpython-3.14-*` symlink pointing at it. The ~/.local/bin shim reaches
@@ -878,6 +1146,61 @@ suite('Native Python API', () => {
             assert.equal(first?.executable.filename, pythonPath);
             assert.equal(second?.executable.filename, pythonPath);
             assert.equal(resolveCount, 1, 'concurrent calls should share a single finder.resolve');
+        });
+
+        test('caches under the requested path when PET reports a different one', async () => {
+            // PET reports its own canonical path, not the alias that was asked
+            // about. Caching only under the reported path leaves the alias
+            // missing the cache forever, so every call spawns PET again.
+            const aliasPath = '/usr/bin/python3';
+            let resolveCount = 0;
+            mockFinder
+                .setup((f) => f.resolve(aliasPath))
+                .returns(() => {
+                    resolveCount += 1;
+                    return Promise.resolve(basicEnv);
+                });
+
+            const first = await api.resolveEnv(aliasPath);
+            assert.equal(first?.executable.filename, pythonPath, 'should report the path PET returned');
+
+            const second = await api.resolveEnv(aliasPath);
+            assert.equal(second?.executable.filename, pythonPath);
+            assert.equal(resolveCount, 1, 'second call for the alias should hit the cache');
+        });
+
+        test('removeEnv invalidates entries cached under an alias path', async () => {
+            const aliasPath = '/usr/bin/python3';
+            let resolveCount = 0;
+            let yieldEnv = true;
+            mockFinder
+                .setup((f) => f.resolve(aliasPath))
+                .returns(() => {
+                    resolveCount += 1;
+                    return Promise.resolve(basicEnv);
+                });
+            mockFinder
+                .setup((f) => f.refresh())
+                .returns(() => {
+                    async function* generator() {
+                        if (yieldEnv) {
+                            yield* [basicEnv];
+                        }
+                    }
+                    return generator();
+                });
+
+            await api.resolveEnv(aliasPath);
+            assert.equal(resolveCount, 1);
+
+            // The env disappears, so removeEnv must drop the alias entry too,
+            // not just the one keyed by the reported path.
+            yieldEnv = false;
+            await api.triggerRefresh();
+            assert.equal(api.getEnvs().length, 0);
+
+            await api.resolveEnv(aliasPath);
+            assert.equal(resolveCount, 2, 'alias cache entry should be cleared by removeEnv');
         });
     });
     // --- End Positron ---


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Reference the associated issue with a closing keyword such as
  "Fixes #123" so GitHub automatically closes the issue when this PR
  is merged. If there are any details about your approach that are
  unintuitive or you want to draw attention to, please describe them
  here.
-->
Cherry-pick #15635 into release/2026.08

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix an endless interpreter resolution loop when two symlinked Python interpreter paths have the same length (https://github.com/posit-dev/positron/issues/15620)


### Validation Steps

<!--
  Positron team members: e2e feature tags are auto-added based on your changed
  files, so tests run automatically when you open this pull request. Add tags
  here yourself to run more.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information on how to validate the change, paying
  special attention to the level of risk, adjacent areas that could
  be affected by the change, and any important contextual information
  not present in the linked issues.
-->
