### PR TITLE
Contribute `"python.analysis.completeFunctionParens": true` for Pyrefly

### DIFF
--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -1037,7 +1037,8 @@
             },
             "pyright.disableLanguageServices": true,
             "pyright.disableOrganizeImports": true,
-            "pyrefly.commentFoldingRanges": true
+            "pyrefly.commentFoldingRanges": true,
+            "python.analysis.completeFunctionParens": true
         },
         "debuggers": [
             {


### PR DESCRIPTION
Addresses #5556.

This PR contributes a `true` default for the Pylance-compatible setting `python.analysis.completeFunctionParens`, which Pyrefly has handling for. When you accept a completion for a function, Positron inserts the parentheses and puts the cursor between them.

This follows the pattern of the default for `pyrefly.commentFoldingRanges` in #11785. Users can still turn the feature off in their own settings.

One note for review is that the two settings reach the language server by different routes. Pyrefly gets `pyrefly.commentFoldingRanges` in the `initialize` request, because the extension sends the whole `pyrefly` section as `initializationOptions`. It gets `python.analysis.completeFunctionParens` later, when the server requests the `python` section with `workspace/configuration`. In full disclosure, I cannot get this behavior to work for me in a dev build at all, although I can get the parentheses added if I put this setting in my user `settings.json` in a release build, once I made a change similar to https://github.com/posit-dev/positron/issues/5556#issuecomment-5360312367.

### Release Notes

#### New Features

- Python function completions now insert parentheses by default (#5556)

#### Bug Fixes

- N/A

### Validation Steps

@:pyrefly

Somebody else really needs to confirm this does actually work, as things seem like a bit of a mess to me:

1. Open a Python file. Do not set `python.analysis.completeFunctionParens` in your own settings.
2. Type `pri` and accept the `print` completion with <kbd>Tab</kbd>. The editor inserts `print()` and puts the cursor between the parentheses.
3. Add `import pandas as pd`. Type `pd.read_c` and accept `read_csv`. The editor inserts `pd.read_csv()`.
4. Add `df = pd.DataFrame({"a": [1]})`. Type `df.sha` and accept `shape`. The editor inserts no parentheses, because `shape` is not callable.
5. Set `"python.analysis.completeFunctionParens": false` in your settings. Run _Developer: Reload Window_. The completions no longer insert parentheses.

This change sets one default value in a manifest, so it adds no tests. The existing autocomplete e2e tests cover Python completions.
