### PR TITLE
python: stop hang for invalid interpreter settings

### DIFF
--- a/extensions/positron-python/src/client/positron/interpreterSettings.ts
+++ b/extensions/positron-python/src/client/positron/interpreterSettings.ts
@@ -4,9 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import path from 'path';
-import { traceError, traceInfo, traceVerbose } from '../logging';
+import { traceError, traceInfo, traceVerbose, traceWarn } from '../logging';
 import { getConfiguration } from '../common/vscodeApis/workspaceApis';
-import { arePathsSame, isDirectorySync, isParentPath } from '../pythonEnvironments/common/externalDependencies';
+import {
+    arePathsSame,
+    isDirectorySync,
+    isParentPath,
+    pathExistsSync,
+} from '../pythonEnvironments/common/externalDependencies';
 import {
     INTERPRETERS_EXCLUDE_SETTING_KEY,
     INTERPRETERS_INCLUDE_SETTING_KEY,
@@ -300,54 +305,108 @@ export function printInterpreterDebugInfo(interpreters: PythonEnvironment[]): vo
 }
 
 /**
- * Maps a list of interpreter paths to their installation directories.
+ * Maps a list of interpreter paths to their installation directories. Paths that
+ * don't exist are dropped: there is nothing for the locators to scan, and
+ * mapping one would send them somewhere the user never named.
  * @param interpreterPaths List of interpreter paths to map to their installation directories.
  * @returns List of unique installation directories.
  */
 function mapInterpretersToInstallDirs(interpreterPaths: string[]): string[] {
-    return Array.from(
-        new Set(
-            interpreterPaths.map((interpreterPath) => {
-                // If it's already a directory, return it as-is.
-                if (isDirectorySync(interpreterPath)) {
-                    return interpreterPath;
-                }
+    const installDirs: string[] = [];
+    for (const interpreterPath of interpreterPaths) {
+        const installDir = mapInterpreterToInstallDir(interpreterPath);
+        if (installDir) {
+            installDirs.push(installDir);
+        }
+    }
+    return Array.from(new Set(installDirs));
+}
 
-                // If it's a file, we need to return the installation directory so that the Python locators can find it.
-                // e.g. ~/scratch/3.10.4/bin/python -> ~/scratch/3.10.4
-                let parentDir: string | undefined;
-                let installDir: string | undefined;
-                try {
-                    parentDir = path.dirname(interpreterPath);
-                    installDir = path.dirname(parentDir);
-                } catch (error) {
-                    traceError(
-                        `[mapInterpretersToInterpreterDirs]: Failed to get install directory for Python interpreter ${interpreterPath}`,
-                        error,
-                    );
-                }
+/**
+ * Configured paths already reported as missing. The mapping runs on every
+ * discovery refresh and once per resolved environment, so an unfiltered log line
+ * would repeat dozens of times per refresh and bury the rest of the output.
+ */
+const reportedMissingInterpreterPaths = new Set<string>();
 
-                if (installDir) {
-                    traceVerbose(
-                        `[mapInterpretersToInterpreterDirs]: Mapped ${interpreterPath} to installation directory ${installDir}`,
-                    );
-                    return installDir;
-                }
-
-                if (parentDir) {
-                    traceInfo(
-                        `[mapInterpretersToInterpreterDirs]: Expected ${interpreterPath} to be located in a Python installation directory. It may not be discoverable.`,
-                    );
-                    return parentDir;
-                }
-
-                traceInfo(
-                    `[mapInterpretersToInterpreterDirs]: Unable to map ${interpreterPath} to an installation directory. It may not be discoverable.`,
-                );
-                return interpreterPath;
-            }),
-        ),
+/**
+ * Logs a configured interpreter path that doesn't exist, once per path. A typo in
+ * `interpreters.include` or `interpreters.override` is otherwise invisible: the
+ * setting silently matches nothing.
+ * @param interpreterPath The configured path that doesn't exist.
+ */
+function reportMissingInterpreterPath(interpreterPath: string): void {
+    if (reportedMissingInterpreterPaths.has(interpreterPath)) {
+        return;
+    }
+    reportedMissingInterpreterPaths.add(interpreterPath);
+    traceWarn(
+        `[mapInterpretersToInterpreterDirs]: Python interpreter ${interpreterPath} does not exist...ignoring. Check the ${INTERPRETERS_INCLUDE_SETTING_KEY} and ${INTERPRETERS_OVERRIDE_SETTING_KEY} settings.`,
     );
+}
+
+/**
+ * Maps one interpreter path to the directory the Python locators should scan for
+ * it, or undefined when there is no such directory.
+ * @param interpreterPath The interpreter path to map.
+ */
+function mapInterpreterToInstallDir(interpreterPath: string): string | undefined {
+    // If it's already a directory, return it as-is.
+    if (isDirectorySync(interpreterPath)) {
+        return interpreterPath;
+    }
+
+    // A path that doesn't exist has no installation directory. Mapping it anyway
+    // would hand the locators an unrelated ancestor.
+    if (!pathExistsSync(interpreterPath)) {
+        reportMissingInterpreterPath(interpreterPath);
+        return undefined;
+    }
+
+    // If it's a file, we need to return the installation directory so that the Python locators can find it.
+    // e.g. ~/scratch/3.10.4/bin/python -> ~/scratch/3.10.4
+    let parentDir: string | undefined;
+    let installDir: string | undefined;
+    try {
+        parentDir = path.dirname(interpreterPath);
+        installDir = path.dirname(parentDir);
+    } catch (error) {
+        traceError(
+            `[mapInterpretersToInterpreterDirs]: Failed to get install directory for Python interpreter ${interpreterPath}`,
+            error,
+        );
+    }
+
+    // The root is every path's ancestor, so scanning it would treat every
+    // interpreter on the machine as a user-specified one. This rules out both
+    // candidates: an interpreter directly under the root (e.g. /python) has the
+    // root as its parent directory too.
+    const root = path.parse(interpreterPath).root;
+    if (installDir && installDir !== root) {
+        traceVerbose(
+            `[mapInterpretersToInterpreterDirs]: Mapped ${interpreterPath} to installation directory ${installDir}`,
+        );
+        return installDir;
+    }
+
+    if (parentDir && parentDir !== root) {
+        traceInfo(
+            `[mapInterpretersToInterpreterDirs]: Expected ${interpreterPath} to be located in a Python installation directory. It may not be discoverable.`,
+        );
+        return parentDir;
+    }
+
+    if (parentDir === root) {
+        traceWarn(
+            `[mapInterpretersToInterpreterDirs]: Python interpreter ${interpreterPath} is directly under the filesystem root...ignoring. Scanning the root would treat every interpreter on the machine as user-specified.`,
+        );
+        return undefined;
+    }
+
+    traceInfo(
+        `[mapInterpretersToInterpreterDirs]: Unable to map ${interpreterPath} to an installation directory. It may not be discoverable.`,
+    );
+    return interpreterPath;
 }
 
 /**

--- a/extensions/positron-python/src/client/pythonEnvironments/base/locators/common/nativePythonFinder.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/locators/common/nativePythonFinder.ts
@@ -245,7 +245,11 @@ class NativePythonFinderImpl extends DisposableBase implements NativePythonFinde
         // refresh so no PET server spawns at startup; discovery still works
         // lazily when explicitly requested.
         if (!isPythonStartupDisabled()) {
-            void this.configure();
+            // configure() rejects when the configuration cannot be assembled; it has
+            // already logged and recorded the failure, and the first refresh below
+            // reports it too, so swallow it here rather than raising an unhandled
+            // rejection.
+            this.configure().catch(() => undefined);
             this.firstRefreshResults = this.refreshFirstTime();
         }
         // --- End Positron ---
@@ -658,26 +662,39 @@ class NativePythonFinderImpl extends DisposableBase implements NativePythonFinde
             refreshOptions.searchKind = options;
         }
         trackPromiseAndNotifyOnCompletion(
-            this.configure().then(() =>
+            this.configure()
+                .then(() =>
+                    // --- Start Positron ---
+                    // this.connection
+                    connection
+                        // --- End Positron ---
+                        .sendRequest<{ duration: number }>('refresh', refreshOptions)
+                        .then(({ duration }) => {
+                            this.outputChannel.info(`Refresh completed in ${duration}ms`);
+                            this.initialRefreshMetrics.timeToRefresh = stopWatch.elapsedTime;
+                            // --- Start Positron ---
+                            this._lastDiscoveryError = undefined;
+                            // --- End Positron ---
+                        })
+                        .catch((ex) => {
+                            this.outputChannel.error('Refresh error', ex);
+                            // --- Start Positron ---
+                            this._lastDiscoveryError = `Refresh error: ${
+                                ex instanceof Error ? ex.message : String(ex)
+                            }`;
+                            // --- End Positron ---
+                        }),
+                )
                 // --- Start Positron ---
-                // this.connection
-                connection
-                    // --- End Positron ---
-                    .sendRequest<{ duration: number }>('refresh', refreshOptions)
-                    .then(({ duration }) => {
-                        this.outputChannel.info(`Refresh completed in ${duration}ms`);
-                        this.initialRefreshMetrics.timeToRefresh = stopWatch.elapsedTime;
-                        // --- Start Positron ---
-                        this._lastDiscoveryError = undefined;
-                        // --- End Positron ---
-                    })
-                    .catch((ex) => {
-                        this.outputChannel.error('Refresh error', ex);
-                        // --- Start Positron ---
-                        this._lastDiscoveryError = `Refresh error: ${ex instanceof Error ? ex.message : String(ex)}`;
-                        // --- End Positron ---
-                    }),
-            ),
+                // A rejection here would be swallowed by the `catch(noop)` in
+                // notifyUponCompletion, leaving `completed` pending forever and
+                // hanging discovery for the lifetime of the window. Report the
+                // failure and let this refresh finish empty instead.
+                .catch((ex) => {
+                    this.outputChannel.error('Configure error', ex);
+                    this._lastDiscoveryError = `Configure error: ${ex instanceof Error ? ex.message : String(ex)}`;
+                }),
+            // --- End Positron ---
         );
 
         // --- Start Positron ---
@@ -722,18 +739,20 @@ class NativePythonFinderImpl extends DisposableBase implements NativePythonFinde
     }
 
     private async configureImpl() {
+        // Assembling the options reads settings and the filesystem, so it can
+        // throw. Report it and rethrow: the caller must not go on to send
+        // `refresh` against a stale or absent configuration, and a successful
+        // refresh would clear `_lastDiscoveryError` and hide this failure. The
+        // caller's catch settles the operation without hanging discovery.
+        let options: ConfigurationOptions;
+        try {
+            options = await this.configurationOptions();
+        } catch (ex) {
+            this.outputChannel.error('Failed to assemble the Python Locator configuration', ex);
+            this._lastDiscoveryError = `Configure error: ${ex instanceof Error ? ex.message : String(ex)}`;
+            throw ex;
+        }
         // --- End Positron ---
-        const options: ConfigurationOptions = {
-            workspaceDirectories: getWorkspaceFolderPaths(),
-            // We do not want to mix this with `search_paths`
-            // --- Start Positron ---
-            // environmentDirectories: getCustomVirtualEnvDirs(),
-            environmentDirectories: await getEnvironmentDirs(),
-            // --- End Positron ---
-            condaExecutable: getPythonSettingAndUntildify<string>(CONDAPATH_SETTING_KEY),
-            poetryExecutable: getPythonSettingAndUntildify<string>('poetryPath'),
-            cacheDirectory: this.cacheDirectory?.fsPath,
-        };
         // No need to send a configuration request, is there are no changes.
         if (JSON.stringify(options) === JSON.stringify(this.lastConfiguration || {})) {
             return;
@@ -752,6 +771,23 @@ class NativePythonFinderImpl extends DisposableBase implements NativePythonFinde
     }
 
     // --- Start Positron ---
+    /**
+     * The configuration to send to the Python Locator server. Extracted from
+     * `configureImpl` so that a failure while it is assembled can be handled
+     * there without the throw reaching the caller's refresh.
+     */
+    private async configurationOptions(): Promise<ConfigurationOptions> {
+        return {
+            workspaceDirectories: getWorkspaceFolderPaths(),
+            // We do not want to mix this with `search_paths`
+            // environmentDirectories: getCustomVirtualEnvDirs(),
+            environmentDirectories: await getEnvironmentDirs(),
+            condaExecutable: getPythonSettingAndUntildify<string>(CONDAPATH_SETTING_KEY),
+            poetryExecutable: getPythonSettingAndUntildify<string>('poetryPath'),
+            cacheDirectory: this.cacheDirectory?.fsPath,
+        };
+    }
+
     // Positron wrapper, as for resolve() above.
     getCondaInfo(): Promise<NativeCondaInfo> {
         return this.trackRequest(() => this.getCondaInfoImpl());

--- a/extensions/positron-python/src/client/pythonEnvironments/common/externalDependencies.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/externalDependencies.ts
@@ -92,9 +92,19 @@ export async function isDirectory(filename: string): Promise<boolean> {
 }
 
 // --- Start Positron ---
+/**
+ * Whether `filename` is a directory. Returns false when it cannot be stat'ed at
+ * all -- it does not exist, or it is unreadable. Callers treat this as a
+ * question about a path they did not choose (a user setting, for instance), so a
+ * throw here becomes a failure far from the cause.
+ */
 export function isDirectorySync(filename: string): boolean {
-    const stat = fsapi.statSync(filename);
-    return stat.isDirectory();
+    try {
+        return fsapi.statSync(filename).isDirectory();
+    } catch (error) {
+        traceVerbose(`[isDirectorySync]: Failed to stat ${filename}`, error);
+        return false;
+    }
 }
 // --- End Positron ---
 

--- a/extensions/positron-python/src/test/positron/interpreterSettings.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/interpreterSettings.unit.test.ts
@@ -4,11 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { assert } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
 import * as sinon from 'sinon';
 import * as typemoq from 'typemoq';
 import { WorkspaceConfiguration } from 'vscode';
 import * as workspaceApis from '../../client/common/vscodeApis/workspaceApis';
-import { isPythonStartupDisabled } from '../../client/positron/interpreterSettings';
+import * as externalDependencies from '../../client/pythonEnvironments/common/externalDependencies';
+import { getCustomEnvDirs, isPythonStartupDisabled } from '../../client/positron/interpreterSettings';
 
 suite('isPythonStartupDisabled', () => {
     let getConfigurationStub: sinon.SinonStub;
@@ -47,5 +50,65 @@ suite('isPythonStartupDisabled', () => {
         startupBehavior = 'disabled';
         isPythonStartupDisabled();
         assert.deepStrictEqual(getConfigurationStub.firstCall.args, ['interpreters', { languageId: 'python' }]);
+    });
+});
+
+suite('getCustomEnvDirs', () => {
+    const fsRoot = path.parse(process.cwd()).root;
+    const missingPath = path.join(fsRoot, 'asdalsk-positron-does-not-exist');
+    let override: string[];
+    let include: string[];
+
+    setup(() => {
+        override = [];
+        include = [];
+
+        const configMock = typemoq.Mock.ofType<WorkspaceConfiguration>();
+        configMock.setup((c) => c.get<string[]>('interpreters.override')).returns(() => override);
+        configMock.setup((c) => c.get<string[]>('interpreters.include')).returns(() => include);
+        sinon.stub(workspaceApis, 'getConfiguration').returns(configMock.object);
+    });
+
+    teardown(() => {
+        sinon.restore();
+    });
+
+    test('skips a configured interpreter path that does not exist', () => {
+        override = [missingPath];
+        assert.deepStrictEqual(getCustomEnvDirs(), []);
+    });
+
+    test('skips a nonexistent included path alongside a real directory', () => {
+        include = [missingPath, __dirname];
+        assert.deepStrictEqual(getCustomEnvDirs(), [__dirname]);
+    });
+
+    test('maps an interpreter path to its installation directory', () => {
+        // This file stands in for the interpreter binary: <install dir>/positron/<file>.
+        override = [__filename];
+        assert.deepStrictEqual(getCustomEnvDirs(), [path.dirname(__dirname)]);
+    });
+
+    test('never maps an interpreter path up to the filesystem root', () => {
+        // A file one level under the root has no installation directory above its
+        // parent, and the root must never become a search directory.
+        const fileUnderRoot = process.platform === 'win32' ? path.join(fsRoot, 'Windows', 'notepad.exe') : '/etc/hosts';
+        if (!fs.existsSync(fileUnderRoot)) {
+            // No suitable file on this machine; the mapping rule is covered by the
+            // other cases.
+            return;
+        }
+        override = [fileUnderRoot];
+        assert.deepStrictEqual(getCustomEnvDirs(), [path.dirname(fileUnderRoot)]);
+    });
+
+    test('skips an interpreter that sits directly under the filesystem root', () => {
+        // Both the parent and the install directory of such a path are the root
+        // itself, so there is nothing to scan short of the whole filesystem.
+        const fileAtRoot = path.join(fsRoot, 'python');
+        sinon.stub(externalDependencies, 'isDirectorySync').returns(false);
+        sinon.stub(externalDependencies, 'pathExistsSync').returns(true);
+        override = [fileAtRoot];
+        assert.deepStrictEqual(getCustomEnvDirs(), []);
     });
 });

--- a/extensions/positron-python/src/test/pythonEnvironments/common/externalDependencies.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/common/externalDependencies.unit.test.ts
@@ -7,7 +7,11 @@ import * as assert from 'assert';
 import * as path from 'path';
 import * as sinon from 'sinon';
 import * as fsapi from '../../../client/common/platform/fs-paths';
-import { canonicalizePath, checkParentDirs } from '../../../client/pythonEnvironments/common/externalDependencies';
+import {
+    canonicalizePath,
+    checkParentDirs,
+    isDirectorySync,
+} from '../../../client/pythonEnvironments/common/externalDependencies';
 
 suite('checkParentDirs tests', () => {
     let pathExistsSyncStub: sinon.SinonStub;
@@ -70,5 +74,20 @@ suite('canonicalizePath tests', () => {
         const actual = await canonicalizePath(input);
 
         assert.strictEqual(actual, path.normalize(input));
+    });
+});
+
+suite('isDirectorySync tests', () => {
+    test('returns true for a directory', () => {
+        assert.strictEqual(isDirectorySync(__dirname), true);
+    });
+
+    test('returns false for a file', () => {
+        assert.strictEqual(isDirectorySync(__filename), false);
+    });
+
+    test('returns false instead of throwing for a path that does not exist', () => {
+        const missing = path.join(__dirname, 'asdalsk-positron-does-not-exist');
+        assert.strictEqual(isDirectorySync(missing), false);
     });
 });

--- a/extensions/positron-python/src/test/pythonEnvironments/nativePythonFinderConfigure.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/nativePythonFinderConfigure.unit.test.ts
@@ -1,0 +1,116 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * A refresh must always settle. The `configure` request runs before `refresh` is
+ * sent, so anything that throws while the configuration is assembled used to
+ * leave the refresh awaiting a promise that could never resolve: discovery hung
+ * for the lifetime of the window and no interpreter was ever registered.
+ */
+
+import { assert } from 'chai';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import * as typemoq from 'typemoq';
+import { WorkspaceConfiguration } from 'vscode';
+import {
+    createNativePythonFinder,
+    NativeEnvInfo,
+    NativePythonFinder,
+} from '../../client/pythonEnvironments/base/locators/common/nativePythonFinder';
+import * as windowsApis from '../../client/common/vscodeApis/windowApis';
+import * as workspaceApis from '../../client/common/vscodeApis/workspaceApis';
+import { MockOutputChannel } from '../mockClasses';
+
+suite('Native Python Finder - configuration failures must not hang discovery', () => {
+    let configMock: typemoq.IMock<WorkspaceConfiguration>;
+    let getWorkspaceFolderPathsStub: sinon.SinonStub;
+    let override: string[];
+
+    setup(() => {
+        sinon.stub(windowsApis, 'createLogOutputChannel').returns(new MockOutputChannel('locator'));
+        getWorkspaceFolderPathsStub = sinon.stub(workspaceApis, 'getWorkspaceFolderPaths').returns([]);
+
+        override = [];
+
+        configMock = typemoq.Mock.ofType<WorkspaceConfiguration>();
+        configMock.setup((c) => c.get<string>('venvPath')).returns(() => undefined);
+        configMock.setup((c) => c.get<string[]>('venvFolders')).returns(() => []);
+        configMock.setup((c) => c.get<string>('condaPath')).returns(() => '');
+        configMock.setup((c) => c.get<string>('poetryPath')).returns(() => '');
+        configMock.setup((c) => c.get('locatorIdleTimeout', 180)).returns(() => 0);
+        configMock.setup((c) => c.get<string[]>('interpreters.override')).returns(() => override);
+        configMock.setup((c) => c.get<string[]>('interpreters.include')).returns(() => []);
+
+        const interpretersConfigMock = typemoq.Mock.ofType<WorkspaceConfiguration>();
+        interpretersConfigMock.setup((c) => c.get<string>('startupBehavior')).returns(() => undefined);
+
+        sinon
+            .stub(workspaceApis, 'getConfiguration')
+            .callsFake((section?: string) =>
+                section === 'interpreters' ? interpretersConfigMock.object : configMock.object,
+            );
+    });
+
+    teardown(() => {
+        sinon.restore();
+    });
+
+    async function drainRefresh(finder: NativePythonFinder): Promise<(NativeEnvInfo | unknown)[]> {
+        const envs = [];
+        for await (const env of finder.refresh()) {
+            envs.push(env);
+        }
+        return envs;
+    }
+
+    /**
+     * Fails fast when a refresh hangs. Without this the test would sit until the
+     * suite timeout, which reports a timeout rather than the behavior at fault.
+     */
+    async function refreshWithin(finder: NativePythonFinder, timeoutMs: number): Promise<(NativeEnvInfo | unknown)[]> {
+        let timer: NodeJS.Timeout | undefined;
+        try {
+            return await Promise.race([
+                drainRefresh(finder),
+                new Promise<never>((_resolve, reject) => {
+                    timer = setTimeout(
+                        () => reject(new Error(`refresh did not finish within ${timeoutMs}ms`)),
+                        timeoutMs,
+                    );
+                }),
+            ]);
+        } finally {
+            if (timer) {
+                clearTimeout(timer);
+            }
+        }
+    }
+
+    test('refresh finishes when an interpreter setting names a path that does not exist', async () => {
+        override = [path.join(path.parse(process.cwd()).root, 'asdalsk-positron-does-not-exist')];
+        const finder = createNativePythonFinder();
+        try {
+            assert.isNotEmpty(await refreshWithin(finder, 60_000));
+        } finally {
+            finder.dispose();
+        }
+    });
+
+    test('refresh finishes when assembling the configuration throws', async () => {
+        getWorkspaceFolderPathsStub.throws(new Error('workspace folders unavailable'));
+        const finder = createNativePythonFinder();
+        try {
+            // The refresh cannot discover anything without a configured server, but
+            // it must end rather than hang so a later refresh can succeed.
+            assert.isEmpty(await refreshWithin(finder, 60_000));
+            // The refresh request must not go out against a stale configuration; if
+            // it did, its success would clear the error and hide the failure.
+            assert.match(finder.lastDiscoveryError ?? '', /workspace folders unavailable/);
+        } finally {
+            finder.dispose();
+        }
+    });
+});


### PR DESCRIPTION
Fixes #15622. This PR fixes a discovery hang when a path in `python.interpreters.override` or `python.interpreters.include` doesn't exist on disk.

Three bugs combined:

- A missing path threw an error in the `isDirectorySync` helper function. It now returns false for any path it can't stat.
- That rejection was swallowed, so the refresh operation never settled and discovery never finished. Now configuration failures are reported as a discovery error and the refresh finishes with no results.
- A configured path that doesn't exist has no installation directory to scan, so those paths are now dropped with a warning.

This code might be more easily reviewed if you hide whitespace.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed Python interpreter discovery hanging forever when `python.interpreters.override` or `python.interpreters.include` names a path that doesn't exist (#15622)

### Validation Steps

@:interpreter

1. Set `"python.interpreters.override": ["/asdalsk"]` in user settings.
2. Start Positron.
3. Discovery finishes and no Python interpreters are listed. The interpreter picker isn't stuck on "Discovering interpreters...".
4. In the Python Language Pack output, `Native locator: Refresh started` is followed by `Native locator: Refresh finished`.
5. The output warns that `/asdalsk` doesn't exist and names the two settings.
6. Repeat with `python.interpreters.include` instead of `python.interpreters.override`, and with a valid interpreter path added alongside the bad one. The valid interpreter is still discovered.
