### PR TITLE
Step 1: Stabilize unsorted table pagination in the PostgreSQL, SQLite, and DuckDB drivers

### DIFF
--- a/extensions/positron-data-driver-duckdb/src/test/duckdbPaging.test.ts
+++ b/extensions/positron-data-driver-duckdb/src/test/duckdbPaging.test.ts
@@ -1,0 +1,200 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import {
+	DuckDBRow,
+	DuckDBSchemaEntry,
+	DuckDBTableView,
+	IDuckDBQueryClient,
+} from 'positron-data-explorer-duckdb';
+import {
+	ColumnDisplayType,
+	ExportFormat,
+	FormatOptions,
+	TableSelectionKind,
+} from 'positron-data-explorer-protocol';
+
+const FORMAT: FormatOptions = {
+	large_num_digits: 2,
+	small_num_digits: 4,
+	max_integral_digits: 7,
+	max_value_length: 100,
+};
+
+/**
+ * A unique integer column, so a paged read can be checked against the row set exactly, plus a
+ * low-cardinality column to sort by. Sorting by `status` leaves large groups of rows tied, which is
+ * where a partial ORDER BY stops being enough.
+ */
+const SCHEMA: DuckDBSchemaEntry[] = [
+	{ column_name: 'id', column_type: 'INTEGER', type_display: ColumnDisplayType.Integer },
+	{ column_name: 'status', column_type: 'VARCHAR', type_display: ColumnDisplayType.String },
+];
+
+const TABLE = '"main"."x"';
+const ROWS = 1000;
+const PAGE = 100;
+const STATUSES = 3;
+
+const statusOf = (id: number) => `s${id % STATUSES}`;
+
+/**
+ * A fake query client standing in for an engine that returns tied rows in any order it likes,
+ * because the ORDER BY does not distinguish them. The order is stable within one statement and
+ * re-permuted for each new statement.
+ *
+ * DuckDB really does this: scans are parallelized across row groups, so an unordered read genuinely
+ * interleaves differently between statements.
+ */
+class UnstableOrderClient implements IDuckDBQueryClient {
+	/** Reads that scan the base relation, i.e. the expensive ones a snapshot should not multiply. */
+	baseRelationReads = 0;
+
+	private rotation = 0;
+
+	constructor(private readonly rowCount: number) { }
+
+	async runQuery(sql: string, _params?: Record<string, string>): Promise<DuckDBRow[]> {
+		if (sql.includes('count(*)')) {
+			return [{ n: this.rowCount }];
+		}
+		if (sql.includes(TABLE)) {
+			this.baseRelationReads++;
+		}
+
+		// A unique tiebreaker -- a row identity, or a row number over a materialized snapshot --
+		// pins the order completely. Without one, rows the ORDER BY leaves tied may come back in a
+		// different order on every statement.
+		const pinned = /ORDER BY[^)]*\b(?:rowid|__rn)\b/.test(sql);
+		if (!pinned) {
+			this.rotation++;
+		}
+
+		// Rows that the ORDER BY cannot tell apart form one tie group. With no ORDER BY at all every
+		// row is tied with every other, so the whole table is a single group.
+		const groups = /ORDER BY\s+"status"/.test(sql) ? this._statusGroups() : [this._allRows()];
+		const order: number[] = [];
+		for (const group of groups) {
+			const by = pinned ? 0 : this.rotation % group.length;
+			order.push(...group.slice(by), ...group.slice(0, by));
+		}
+
+		const window = /LIMIT (\d+) OFFSET (\d+)/.exec(sql);
+		const [offset, limit] = window
+			? [Number(window[2]), Number(window[1])]
+			: [0, this.rowCount];
+		return order.slice(offset, offset + limit)
+			.map(id => ({ c0: id, c1: statusOf(id) }));
+	}
+
+	private _allRows(): number[] {
+		return Array.from({ length: this.rowCount }, (_, i) => i);
+	}
+
+	private _statusGroups(): number[][] {
+		return Array.from({ length: STATUSES },
+			(_, s) => this._allRows().filter(id => statusOf(id) === `s${s}`));
+	}
+}
+
+/** Reads one page through the Data Explorer data path and returns the ids it produced. */
+async function readPage(view: DuckDBTableView, first: number, count: number): Promise<number[]> {
+	const data = await view.getDataValues({
+		columns: [{ column_index: 0, spec: { first_index: first, last_index: first + count - 1 } }],
+		format_options: FORMAT,
+	});
+	return data.columns[0].map(Number);
+}
+
+/** Pages through the whole table the way scrolling from top to bottom does. */
+async function sweep(view: DuckDBTableView): Promise<number[]> {
+	const seen: number[] = [];
+	for (let first = 0; first < ROWS; first += PAGE) {
+		seen.push(...await readPage(view, first, PAGE));
+	}
+	return seen;
+}
+
+/** Summarizes read ids against the rows that should have been returned exactly once. */
+function coverage(seen: number[]) {
+	const counts = new Map<number, number>();
+	for (const id of seen) {
+		counts.set(id, (counts.get(id) ?? 0) + 1);
+	}
+	return {
+		total: seen.length,
+		duplicated: [...counts].filter(([, n]) => n > 1).map(([id]) => id),
+		missing: Array.from({ length: ROWS }, (_, i) => i).filter(id => !counts.has(id)),
+	};
+}
+
+/**
+ * The paging invariants, run against a table or a view. Every name is shared verbatim with the
+ * sibling drivers' paging suites, so `grep` across the drivers shows which of them assert which
+ * invariant.
+ */
+function pagingInvariants(objectKind: 'table' | 'view'): void {
+	const open = () => new DuckDBTableView(
+		new UnstableOrderClient(ROWS), TABLE, 'x', objectKind, SCHEMA);
+
+	test('a full sequential sweep returns every row exactly once', async () => {
+		assert.deepStrictEqual(
+			coverage(await sweep(open())),
+			{ total: ROWS, duplicated: [], missing: [] },
+		);
+	});
+
+	test('re-reading a range returns the same rows', async () => {
+		const view = open();
+		// The rows at a position must be a property of the table, not of how it was reached.
+		const before = await readPage(view, 500, PAGE);
+		await readPage(view, 0, PAGE);
+
+		assert.deepStrictEqual(await readPage(view, 500, PAGE), before);
+	});
+
+	test('an exported range matches the rows shown for that range', async () => {
+		const view = open();
+		const shown = await readPage(view, 500, PAGE);
+
+		const exported = await view.exportDataSelection({
+			selection: {
+				kind: TableSelectionKind.RowRange,
+				selection: { first_index: 500, last_index: 500 + PAGE - 1 },
+			},
+			format: ExportFormat.Csv,
+		});
+		// Drop the header row, then read the leading id column back out of each line.
+		const ids = exported.data.trim().split('\n').slice(1)
+			.map(line => Number(line.split(',')[0]));
+
+		assert.deepStrictEqual(ids, shown);
+	});
+
+	test('a sweep sorted by a low-cardinality column returns every row exactly once', async () => {
+		const view = open();
+		// Sorting by `status` groups the rows correctly but leaves ~333 of them tied at a time, so
+		// a page boundary inside a tie group needs a tiebreaker to stay exact.
+		await view.setSortColumns({ sort_keys: [{ column_index: 1, ascending: true }] });
+
+		assert.deepStrictEqual(
+			coverage(await sweep(view)),
+			{ total: ROWS, duplicated: [], missing: [] },
+		);
+	});
+}
+
+suite('DuckDB paging stability', () => {
+	suite('table', () => {
+		pagingInvariants('table');
+	});
+
+	// Views have no rowid, so there is no tiebreaker to make LIMIT/OFFSET total. Pending the
+	// materialized-snapshot work; see https://github.com/posit-dev/positron/issues/15361.
+	suite.skip('view', () => {
+		pagingInvariants('view');
+	});
+});

--- a/extensions/positron-data-driver-postgresql/src/postgresqlTableView.ts
+++ b/extensions/positron-data-driver-postgresql/src/postgresqlTableView.ts
@@ -271,6 +271,10 @@ export class PostgresTableView {
 		private readonly objectKind: 'table' | 'view',
 		private readonly schema: Array<PostgresSchemaEntry>,
 	) {
+		// Seed the ORDER BY before any data is read. The frontend only sends set_sort_columns when the
+		// user sorts, so without this a freshly opened table pages with no ORDER BY at all and the
+		// ctid tiebreaker below never applies -- leaving LIMIT/OFFSET free to repeat and drop rows.
+		this._sortClause = this._buildSortClause(this.sortKeys, true);
 		this._unfilteredRows = this._countRows('');
 		this._filteredRows = this._unfilteredRows;
 	}

--- a/extensions/positron-data-driver-postgresql/src/test/postgresqlPaging.test.ts
+++ b/extensions/positron-data-driver-postgresql/src/test/postgresqlPaging.test.ts
@@ -1,0 +1,212 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { IPostgresQueryClient, PostgresSchemaEntry, PostgresTableView } from '../postgresqlTableView.js';
+import {
+	ColumnDisplayType,
+	ExportFormat,
+	FormatOptions,
+	TableSelectionKind,
+} from 'positron-data-explorer-protocol';
+
+const FORMAT: FormatOptions = {
+	large_num_digits: 2,
+	small_num_digits: 4,
+	max_integral_digits: 7,
+	max_value_length: 100,
+};
+
+/**
+ * A unique integer column, so a paged read can be checked against the row set exactly, plus a
+ * low-cardinality column to sort by. Sorting by `status` leaves large groups of rows tied, which is
+ * where a partial ORDER BY stops being enough.
+ */
+const SCHEMA: PostgresSchemaEntry[] = [
+	{ column_name: 'id', column_type: 'integer', type_display: ColumnDisplayType.Integer },
+	{ column_name: 'status', column_type: 'text', type_display: ColumnDisplayType.String },
+];
+
+const TABLE = '"public"."x"';
+const ROWS = 1000;
+const PAGE = 100;
+const STATUSES = 3;
+
+const statusOf = (id: number) => `s${id % STATUSES}`;
+
+/**
+ * A fake query client standing in for a server that returns tied rows in any order it likes,
+ * because the ORDER BY does not distinguish them. The order is stable within one statement and
+ * re-permuted for each new statement -- exactly the latitude PostgreSQL has here.
+ *
+ * The permutation is a rotation by one, the smallest total re-ordering there is: a LIMIT/OFFSET
+ * sweep then drops precisely one row per page boundary, so a failure is unambiguous rather than a
+ * scrambled diff.
+ */
+class UnstableOrderClient implements IPostgresQueryClient {
+	/** Reads that scan the base relation, i.e. the expensive ones a snapshot should not multiply. */
+	baseRelationReads = 0;
+
+	private rotation = 0;
+
+	constructor(private readonly rowCount: number) { }
+
+	async runQuery(sql: string): Promise<Array<Record<string, unknown>>> {
+		if (sql.includes('count(*)')) {
+			return [{ n: this.rowCount }];
+		}
+		if (sql.includes(TABLE)) {
+			this.baseRelationReads++;
+		}
+
+		// A unique tiebreaker -- a row identity, or a row number over a materialized snapshot --
+		// pins the order completely. Without one, rows the ORDER BY leaves tied may come back in a
+		// different order on every statement.
+		const pinned = /ORDER BY[^)]*\b(?:ctid|__rn)\b/.test(sql);
+		if (!pinned) {
+			this.rotation++;
+		}
+
+		// Rows that the ORDER BY cannot tell apart form one tie group. With no ORDER BY at all every
+		// row is tied with every other, so the whole table is a single group.
+		const groups = /ORDER BY\s+"status"/.test(sql) ? this._statusGroups() : [this._allRows()];
+		const order: number[] = [];
+		for (const group of groups) {
+			const by = pinned ? 0 : this.rotation % group.length;
+			order.push(...group.slice(by), ...group.slice(0, by));
+		}
+
+		const window = /LIMIT (\d+) OFFSET (\d+)/.exec(sql);
+		const [offset, limit] = window
+			? [Number(window[2]), Number(window[1])]
+			: [0, this.rowCount];
+		return order.slice(offset, offset + limit)
+			.map(id => ({ c0: id, c1: statusOf(id) }));
+	}
+
+	private _allRows(): number[] {
+		return Array.from({ length: this.rowCount }, (_, i) => i);
+	}
+
+	private _statusGroups(): number[][] {
+		return Array.from({ length: STATUSES },
+			(_, s) => this._allRows().filter(id => statusOf(id) === `s${s}`));
+	}
+}
+
+/** Reads one page through the Data Explorer data path and returns the ids it produced. */
+async function readPage(view: PostgresTableView, first: number, count: number): Promise<number[]> {
+	const data = await view.getDataValues({
+		columns: [{ column_index: 0, spec: { first_index: first, last_index: first + count - 1 } }],
+		format_options: FORMAT,
+	});
+	return data.columns[0].map(Number);
+}
+
+/** Pages through the whole table the way scrolling from top to bottom does. */
+async function sweep(view: PostgresTableView): Promise<number[]> {
+	const seen: number[] = [];
+	for (let first = 0; first < ROWS; first += PAGE) {
+		seen.push(...await readPage(view, first, PAGE));
+	}
+	return seen;
+}
+
+/** Summarizes read ids against the rows that should have been returned exactly once. */
+function coverage(seen: number[]) {
+	const counts = new Map<number, number>();
+	for (const id of seen) {
+		counts.set(id, (counts.get(id) ?? 0) + 1);
+	}
+	return {
+		total: seen.length,
+		duplicated: [...counts].filter(([, n]) => n > 1).map(([id]) => id),
+		missing: Array.from({ length: ROWS }, (_, i) => i).filter(id => !counts.has(id)),
+	};
+}
+
+/**
+ * The paging invariants, run against a table or a view. Every name is shared verbatim with the
+ * sibling drivers' paging suites, so `grep` across the drivers shows which of them assert which
+ * invariant.
+ */
+function pagingInvariants(objectKind: 'table' | 'view'): void {
+	const open = () => new PostgresTableView(
+		new UnstableOrderClient(ROWS), TABLE, 'x', objectKind, SCHEMA);
+
+	test('a full sequential sweep returns every row exactly once', async () => {
+		assert.deepStrictEqual(
+			coverage(await sweep(open())),
+			{ total: ROWS, duplicated: [], missing: [] },
+		);
+	});
+
+	test('re-reading a range returns the same rows', async () => {
+		const view = open();
+		// The rows at a position must be a property of the table, not of how it was reached.
+		const before = await readPage(view, 500, PAGE);
+		await readPage(view, 0, PAGE);
+
+		assert.deepStrictEqual(await readPage(view, 500, PAGE), before);
+	});
+
+	test('an exported range matches the rows shown for that range', async () => {
+		const view = open();
+		const shown = await readPage(view, 500, PAGE);
+
+		const exported = await view.exportDataSelection({
+			selection: {
+				kind: TableSelectionKind.RowRange,
+				selection: { first_index: 500, last_index: 500 + PAGE - 1 },
+			},
+			format: ExportFormat.Csv,
+		});
+		// Drop the header row, then read the leading id column back out of each line.
+		const ids = exported.data.trim().split('\n').slice(1)
+			.map(line => Number(line.split(',')[0]));
+
+		assert.deepStrictEqual(ids, shown);
+	});
+
+	test('a sweep sorted by a low-cardinality column returns every row exactly once', async () => {
+		const view = open();
+		// Sorting by `status` groups the rows correctly but leaves ~333 of them tied at a time, so
+		// a page boundary inside a tie group needs a tiebreaker to stay exact.
+		await view.setSortColumns({ sort_keys: [{ column_index: 1, ascending: true }] });
+
+		assert.deepStrictEqual(
+			coverage(await sweep(view)),
+			{ total: ROWS, duplicated: [], missing: [] },
+		);
+	});
+}
+
+suite('PostgreSQL paging stability', () => {
+	suite('table', () => {
+		pagingInvariants('table');
+	});
+
+	// Views have no ctid, so there is no tiebreaker to make LIMIT/OFFSET total. Pending the
+	// materialized-snapshot work; see https://github.com/posit-dev/positron/issues/15361.
+	suite.skip('view', () => {
+		pagingInvariants('view');
+	});
+
+	// A cost invariant rather than a correctness one, and only achievable once reads are served from
+	// a snapshot instead of re-scanning the source per page. Pending the same work.
+	suite.skip('snapshot', () => {
+		test('a full sequential sweep scans the base relation at most once', async () => {
+			const client = new UnstableOrderClient(ROWS);
+			const view = new PostgresTableView(client, TABLE, 'x', 'table', SCHEMA);
+
+			await sweep(view);
+
+			assert.ok(
+				client.baseRelationReads <= 1,
+				`scanned the source ${client.baseRelationReads} times to read ${ROWS / PAGE} pages`,
+			);
+		});
+	});
+});

--- a/extensions/positron-data-driver-sqlite/src/sqliteDataExplorerRpcHandler.ts
+++ b/extensions/positron-data-driver-sqlite/src/sqliteDataExplorerRpcHandler.ts
@@ -6,7 +6,7 @@
 import * as positron from 'positron';
 import * as vscode from 'vscode';
 import { ISqliteQueryClient } from './sqliteWorkerClient.js';
-import { SqliteSchemaEntry, SqliteTableView, sqliteDisplayType } from './sqliteTableView.js';
+import { SqliteSchemaEntry, SqliteTableView, quoteIdentifier, sqliteDisplayType } from './sqliteTableView.js';
 import {
 	ConvertToCodeParams,
 	DataExplorerBackendRequest,
@@ -72,8 +72,11 @@ export class SqliteDataExplorerRpcHandler implements vscode.Disposable, ISqliteD
 		tableName: string,
 		kind: 'table' | 'view',
 	): Promise<void> {
-		const schema = await buildSqliteSchema(client, tableName);
-		this._views.set(datasetId, new SqliteTableView(client, tableName, kind, schema));
+		const [schema, rowIdentity] = await Promise.all([
+			buildSqliteSchema(client, tableName),
+			resolveSqliteRowIdentity(client, tableName, kind),
+		]);
+		this._views.set(datasetId, new SqliteTableView(client, tableName, kind, schema, rowIdentity));
 	}
 
 	/**
@@ -87,12 +90,15 @@ export class SqliteDataExplorerRpcHandler implements vscode.Disposable, ISqliteD
 		kind: 'table' | 'view',
 		columnName: string,
 	): Promise<void> {
-		const schema = await buildSqliteSchema(client, tableName);
+		const [schema, rowIdentity] = await Promise.all([
+			buildSqliteSchema(client, tableName),
+			resolveSqliteRowIdentity(client, tableName, kind),
+		]);
 		const column = schema.find(c => c.column_name === columnName);
 		if (!column) {
 			throw new Error(`Column '${columnName}' not found in '${tableName}'`);
 		}
-		this._views.set(datasetId, new SqliteTableView(client, tableName, kind, [column]));
+		this._views.set(datasetId, new SqliteTableView(client, tableName, kind, [column], rowIdentity));
 	}
 
 	/** Drops a dataset's view, e.g. when its connection is disconnected. */
@@ -169,6 +175,47 @@ export class SqliteDataExplorerRpcHandler implements vscode.Disposable, ISqliteD
  * Reads a table or view's column schema via PRAGMA table_info and resolves each column's display
  * type. PRAGMA does not support bound parameters, so the name is double-quote escaped inline.
  */
+/**
+ * Resolves the ORDER BY expression that uniquely identifies a row, used as the pagination
+ * tiebreaker.
+ *
+ * An ordinary table uses `rowid`, which matches SQLite's own storage order and so costs nothing to
+ * sort by. A WITHOUT ROWID table has no `rowid` column -- ordering by it fails outright with "no
+ * such column: rowid" -- but such a table is required to have a primary key, whose columns identify
+ * a row just as well. Views have no row identity, so they get no tiebreaker.
+ */
+export async function resolveSqliteRowIdentity(
+	client: ISqliteQueryClient,
+	tableName: string,
+	kind: 'table' | 'view',
+): Promise<string | undefined> {
+	if (kind !== 'table') {
+		return undefined;
+	}
+
+	const created = await client.runQuery(
+		`SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?`,
+		[tableName]
+	);
+	if (!/WITHOUT\s+ROWID/i.test(String(created[0]?.sql ?? ''))) {
+		return 'rowid';
+	}
+
+	// PRAGMA table_info reports `pk` as the 1-based position within the primary key, or 0 if the
+	// column is not part of it. PRAGMA does not support bound parameters, so the name is
+	// double-quote escaped inline.
+	const safeName = tableName.replace(/"/g, '""');
+	const columns = await client.runQuery(`PRAGMA table_info("${safeName}")`);
+	const keyColumns = columns
+		.filter(row => Number(row.pk ?? 0) > 0)
+		.sort((a, b) => Number(a.pk) - Number(b.pk))
+		.map(row => quoteIdentifier(String(row.name)));
+
+	// A WITHOUT ROWID table always has a primary key, but fall back to no tiebreaker rather than
+	// emitting an empty expression if the catalog ever says otherwise.
+	return keyColumns.length > 0 ? keyColumns.join(', ') : undefined;
+}
+
 export async function buildSqliteSchema(
 	client: ISqliteQueryClient,
 	tableName: string,

--- a/extensions/positron-data-driver-sqlite/src/sqliteTableView.ts
+++ b/extensions/positron-data-driver-sqlite/src/sqliteTableView.ts
@@ -116,7 +116,7 @@ export function sqliteDisplayType(declaredType: string): ColumnDisplayType {
 }
 
 /** Quotes and escapes an identifier for SQLite by doubling embedded double-quotes. */
-function quoteIdentifier(name: string): string {
+export function quoteIdentifier(name: string): string {
 	return '"' + name.replace(/"/g, '""') + '"';
 }
 
@@ -229,13 +229,23 @@ export class SqliteTableView {
 	 * @param tableName The unquoted table/view name.
 	 * @param objectKind Whether this is a table (has a stable rowid) or a view.
 	 * @param schema The resolved column schema.
+	 * @param rowIdentity An ORDER BY expression that uniquely identifies a row, used as the
+	 * pagination tiebreaker. Defaults to `rowid`, which every ordinary table has. A WITHOUT ROWID
+	 * table has no such column -- ordering by it is an error -- so its caller passes the primary key
+	 * columns instead; see `resolveSqliteRowIdentity`. Views have no row identity at all.
 	 */
 	constructor(
 		private readonly client: ISqliteQueryClient,
 		private readonly tableName: string,
 		private readonly objectKind: 'table' | 'view',
 		private readonly schema: Array<SqliteSchemaEntry>,
+		private readonly rowIdentity: string | undefined =
+			objectKind === 'table' ? 'rowid' : undefined,
 	) {
+		// Seed the ORDER BY before any data is read. The frontend only sends set_sort_columns when the
+		// user sorts, so without this a freshly opened table pages with no ORDER BY at all and the
+		// tiebreaker below never applies -- leaving LIMIT/OFFSET free to repeat and drop rows.
+		this._sortClause = this._buildSortClause(this.sortKeys, true);
 		this._unfilteredRows = this._countRows('');
 		this._filteredRows = this._unfilteredRows;
 	}
@@ -424,16 +434,18 @@ export class SqliteTableView {
 	}
 
 	/**
-	 * Builds an ORDER BY clause for the given sort keys. For tables a trailing `rowid` is appended
-	 * as a stable tiebreaker so pagination is deterministic; views have no rowid, so they omit it.
+	 * Builds an ORDER BY clause for the given sort keys. A trailing row identity is appended as a
+	 * stable tiebreaker so pagination is deterministic: the user's sort keys alone leave tied rows
+	 * free to come back in a different order on every statement. Views have no row identity, so they
+	 * omit it.
 	 */
 	private _buildSortClause(sortKeys: Array<ColumnSortKey>, includeRowidTiebreaker: boolean): string {
 		const exprs = sortKeys.map(key => {
 			const quotedName = quoteIdentifier(this.schema[key.column_index].column_name);
 			return `${quotedName}${key.ascending ? '' : ' DESC'}`;
 		});
-		if (includeRowidTiebreaker && this.objectKind === 'table') {
-			exprs.push('rowid');
+		if (includeRowidTiebreaker && this.rowIdentity) {
+			exprs.push(this.rowIdentity);
 		}
 		return exprs.length > 0 ? `\nORDER BY ${exprs.join(', ')}` : '';
 	}

--- a/extensions/positron-data-driver-sqlite/src/test/sqlitePaging.test.ts
+++ b/extensions/positron-data-driver-sqlite/src/test/sqlitePaging.test.ts
@@ -1,0 +1,205 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { SqliteSchemaEntry, SqliteTableView } from '../sqliteTableView.js';
+import { ISqliteQueryClient, SqliteRow } from '../sqliteWorkerClient.js';
+import { SqliteBindValue } from '../sqliteWorkerProtocol.js';
+import {
+	ColumnDisplayType,
+	ExportFormat,
+	FormatOptions,
+	TableSelectionKind,
+} from 'positron-data-explorer-protocol';
+
+const FORMAT: FormatOptions = {
+	large_num_digits: 2,
+	small_num_digits: 4,
+	max_integral_digits: 7,
+	max_value_length: 100,
+};
+
+/**
+ * A unique integer column, so a paged read can be checked against the row set exactly, plus a
+ * low-cardinality column to sort by. Sorting by `status` leaves large groups of rows tied, which is
+ * where a partial ORDER BY stops being enough.
+ */
+const SCHEMA: SqliteSchemaEntry[] = [
+	{ column_name: 'id', column_type: 'INTEGER', type_display: ColumnDisplayType.Integer },
+	{ column_name: 'status', column_type: 'TEXT', type_display: ColumnDisplayType.String },
+];
+
+const TABLE = 'x';
+const ROWS = 1000;
+const PAGE = 100;
+const STATUSES = 3;
+
+const statusOf = (id: number) => `s${id % STATUSES}`;
+
+/**
+ * A fake query client standing in for an engine that returns tied rows in any order it likes,
+ * because the ORDER BY does not distinguish them. The order is stable within one statement and
+ * re-permuted for each new statement.
+ *
+ * SQLite scans a single B-tree in a single thread, so in practice it is far more stable than this
+ * fake -- but the guarantee is absent either way, and these are the invariants the paging code has
+ * to hold regardless of how forgiving the engine happens to be.
+ */
+class UnstableOrderClient implements ISqliteQueryClient {
+	/** Reads that scan the base relation, i.e. the expensive ones a snapshot should not multiply. */
+	baseRelationReads = 0;
+
+	private rotation = 0;
+
+	constructor(private readonly rowCount: number) { }
+
+	async runQuery(sql: string, _params?: SqliteBindValue[]): Promise<SqliteRow[]> {
+		if (sql.includes('count(*)')) {
+			return [{ n: this.rowCount }];
+		}
+		if (sql.includes(`"${TABLE}"`)) {
+			this.baseRelationReads++;
+		}
+
+		// A unique tiebreaker pins the order completely. Without one, rows the ORDER BY leaves tied
+		// may come back in a different order on every statement. Here that means `rowid`, a snapshot
+		// row number, or `"id"` -- which is unique in this fixture, and is what a WITHOUT ROWID
+		// table's primary key resolves to.
+		const pinned = /ORDER BY[^)]*(?:\browid\b|\b__rn\b|"id")/.test(sql);
+		if (!pinned) {
+			this.rotation++;
+		}
+
+		// Rows that the ORDER BY cannot tell apart form one tie group. With no ORDER BY at all every
+		// row is tied with every other, so the whole table is a single group.
+		const groups = /ORDER BY\s+"status"/.test(sql) ? this._statusGroups() : [this._allRows()];
+		const order: number[] = [];
+		for (const group of groups) {
+			const by = pinned ? 0 : this.rotation % group.length;
+			order.push(...group.slice(by), ...group.slice(0, by));
+		}
+
+		const window = /LIMIT (\d+) OFFSET (\d+)/.exec(sql);
+		const [offset, limit] = window
+			? [Number(window[2]), Number(window[1])]
+			: [0, this.rowCount];
+		return order.slice(offset, offset + limit)
+			.map(id => ({ c0: id, c1: statusOf(id) }));
+	}
+
+	private _allRows(): number[] {
+		return Array.from({ length: this.rowCount }, (_, i) => i);
+	}
+
+	private _statusGroups(): number[][] {
+		return Array.from({ length: STATUSES },
+			(_, s) => this._allRows().filter(id => statusOf(id) === `s${s}`));
+	}
+}
+
+/** Reads one page through the Data Explorer data path and returns the ids it produced. */
+async function readPage(view: SqliteTableView, first: number, count: number): Promise<number[]> {
+	const data = await view.getDataValues({
+		columns: [{ column_index: 0, spec: { first_index: first, last_index: first + count - 1 } }],
+		format_options: FORMAT,
+	});
+	return data.columns[0].map(Number);
+}
+
+/** Pages through the whole table the way scrolling from top to bottom does. */
+async function sweep(view: SqliteTableView): Promise<number[]> {
+	const seen: number[] = [];
+	for (let first = 0; first < ROWS; first += PAGE) {
+		seen.push(...await readPage(view, first, PAGE));
+	}
+	return seen;
+}
+
+/** Summarizes read ids against the rows that should have been returned exactly once. */
+function coverage(seen: number[]) {
+	const counts = new Map<number, number>();
+	for (const id of seen) {
+		counts.set(id, (counts.get(id) ?? 0) + 1);
+	}
+	return {
+		total: seen.length,
+		duplicated: [...counts].filter(([, n]) => n > 1).map(([id]) => id),
+		missing: Array.from({ length: ROWS }, (_, i) => i).filter(id => !counts.has(id)),
+	};
+}
+
+/**
+ * The paging invariants, run against a given row identity. Every name is shared verbatim with the
+ * sibling drivers' paging suites, so `grep` across the drivers shows which of them assert which
+ * invariant.
+ */
+function pagingInvariants(objectKind: 'table' | 'view', rowIdentity: string | undefined): void {
+	const open = () => new SqliteTableView(
+		new UnstableOrderClient(ROWS), TABLE, objectKind, SCHEMA, rowIdentity);
+
+	test('a full sequential sweep returns every row exactly once', async () => {
+		assert.deepStrictEqual(
+			coverage(await sweep(open())),
+			{ total: ROWS, duplicated: [], missing: [] },
+		);
+	});
+
+	test('re-reading a range returns the same rows', async () => {
+		const view = open();
+		// The rows at a position must be a property of the table, not of how it was reached.
+		const before = await readPage(view, 500, PAGE);
+		await readPage(view, 0, PAGE);
+
+		assert.deepStrictEqual(await readPage(view, 500, PAGE), before);
+	});
+
+	test('an exported range matches the rows shown for that range', async () => {
+		const view = open();
+		const shown = await readPage(view, 500, PAGE);
+
+		const exported = await view.exportDataSelection({
+			selection: {
+				kind: TableSelectionKind.RowRange,
+				selection: { first_index: 500, last_index: 500 + PAGE - 1 },
+			},
+			format: ExportFormat.Csv,
+		});
+		// Drop the header row, then read the leading id column back out of each line.
+		const ids = exported.data.trim().split('\n').slice(1)
+			.map(line => Number(line.split(',')[0]));
+
+		assert.deepStrictEqual(ids, shown);
+	});
+
+	test('a sweep sorted by a low-cardinality column returns every row exactly once', async () => {
+		const view = open();
+		// Sorting by `status` groups the rows correctly but leaves ~333 of them tied at a time, so
+		// a page boundary inside a tie group needs a tiebreaker to stay exact.
+		await view.setSortColumns({ sort_keys: [{ column_index: 1, ascending: true }] });
+
+		assert.deepStrictEqual(
+			coverage(await sweep(view)),
+			{ total: ROWS, duplicated: [], missing: [] },
+		);
+	});
+}
+
+suite('SQLite paging stability', () => {
+	suite('table', () => {
+		pagingInvariants('table', 'rowid');
+	});
+
+	// A WITHOUT ROWID table has no rowid column at all, so its primary key stands in as the row
+	// identity. See resolveSqliteRowIdentity.
+	suite('table without rowid', () => {
+		pagingInvariants('table', '"id"');
+	});
+
+	// Views have no row identity, so there is no tiebreaker to make LIMIT/OFFSET total. Pending the
+	// materialized-snapshot work; see https://github.com/posit-dev/positron/issues/15361.
+	suite.skip('view', () => {
+		pagingInvariants('view', undefined);
+	});
+});

--- a/extensions/positron-data-driver-sqlite/src/test/sqliteTableView.test.ts
+++ b/extensions/positron-data-driver-sqlite/src/test/sqliteTableView.test.ts
@@ -142,7 +142,7 @@ suite('SQLite Data Explorer Tests', () => {
 			]);
 		});
 
-		test('paginates with LIMIT/OFFSET and a rowid tiebreaker once sorted', async () => {
+		test('paginates with LIMIT/OFFSET and appends a rowid tiebreaker after the sort keys', async () => {
 			const client = new FakeQueryClient(sql => (sql.includes('count(*)') ? [{ n: 10 }] : [{ c0: 5 }]));
 			const view = new SqliteTableView(client, 'people', 'table', schema);
 			await view.setSortColumns({ sort_keys: [{ column_index: 0, ascending: false }] });

--- a/extensions/positron-data-explorer-duckdb/src/duckdbTableView.ts
+++ b/extensions/positron-data-explorer-duckdb/src/duckdbTableView.ts
@@ -261,6 +261,11 @@ export class DuckDBTableView {
 		private readonly schema: Array<DuckDBSchemaEntry>,
 		private readonly codeGenerator?: IDuckDBTableCodeGenerator,
 	) {
+		// Seed the ORDER BY before any data is read. The frontend only sends set_sort_columns when the
+		// user sorts, so without this a freshly opened table pages with no ORDER BY at all and the
+		// rowid tiebreaker below never applies. DuckDB parallelizes scans across row groups, so an
+		// unordered LIMIT/OFFSET sweep is genuinely free to repeat and drop rows.
+		this._sortClause = this._buildSortClause(this.sortKeys, true);
 		this._unfilteredRows = this._countRows('');
 		this._filteredRows = this._unfilteredRows;
 	}


### PR DESCRIPTION
Part of #15361

Every SQL driver's table view builds its data query as `<where> <order> LIMIT n OFFSET m`, and the `<order>` fragment was only ever populated by `setSortColumns`. The Data Explorer frontend only sends `set_sort_columns` when the user actively sorts -- on a fresh tab it mirrors whatever `sort_keys` the backend reports in `get_state` and pushes nothing. So a freshly opened table paged with no `ORDER BY` at all, and the `ctid` / `rowid` tiebreaker that `_buildSortClause` already appends never applied. No engine guarantees row order between separate statements, so consecutive page fetches could interleave differently: scrolling showed some rows twice and silently omitted others, while the row count (from a separate `count(*)`) stayed correct.

This seeds the sort clause at construction, so the tiebreaker applies from the first read. PostgreSQL now pages with `ORDER BY ctid` and DuckDB with `ORDER BY rowid`; the DuckDB change also covers the Pins driver, since both route through the same table view and Pins materializes its data as a real DuckDB table.

SQLite needed one extra piece. Its tiebreaker was a hardcoded `rowid`, which does not exist on a `WITHOUT ROWID` table -- ordering by it fails outright with "no such column: rowid" -- so enabling the clause unconditionally would have turned a latent instability into a hard error. The tiebreaker is now a resolved expression, and `resolveSqliteRowIdentity` checks `sqlite_master` and falls back to the table's primary key columns, which such a table is required to have.

One fix falls out for free: `_rowIndexQuery` reads the same clause, so multi-row-selection exports now number rows over a total order (`ROW_NUMBER() OVER (ORDER BY ctid)`) rather than an arbitrary one. That path writes a file the user keeps, so it mattered more than the grid.

Scope is deliberately tables only. Views have no row identity on any engine, and Snowflake, Redshift, and Databricks have none for tables either, so those cases need materialized snapshots and are left for follow-up work on the same issue. Rather than omit tests for them, each driver's new paging suite records the unfixed cases as skipped suites pointing at the issue, including the cost invariant a snapshot would have to satisfy.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed rows being duplicated or omitted when scrolling an unsorted table in the Data Explorer over a PostgreSQL, SQLite, or DuckDB connection (#15361)
- Fixed exports of a multi-row selection returning the wrong rows for the same reason (#15361)

### Validation Steps

@:data-explorer @:connections @:duck-db

The defect is a missing guarantee rather than a deterministic fault, so a real engine may well look fine on any given run. The new unit suites make it deterministic with a fake client that re-permutes row order on any statement lacking a total ordering, by a rotation of one -- so a paged sweep drops exactly one row per page boundary:

```bash
cd extensions/positron-data-driver-postgresql && npx tsc -p . && npx mocha --ui tdd out/test/postgresqlPaging.test.js
```

Same for `positron-data-driver-sqlite` / `out/test/sqlitePaging.test.js`. The DuckDB suite (`positron-data-driver-duckdb/src/test/duckdbPaging.test.ts`) only runs under the extension host, since it imports from the `positron-data-explorer-duckdb` package index.

Manual checks:

1. Open a PostgreSQL table in the Data Explorer without sorting it, and confirm the emitted data query carries `ORDER BY ctid` from the very first page rather than only after a sort is applied. Repeat for a SQLite or DuckDB table and look for `ORDER BY rowid`.
2. The riskiest new path is SQLite's `WITHOUT ROWID` fallback, so exercise it directly:

```sql
CREATE TABLE kv (k TEXT PRIMARY KEY, v INTEGER) WITHOUT ROWID;
INSERT INTO kv VALUES ('a', 1), ('b', 2), ('c', 3);
```

   Open `kv` in the Data Explorer and confirm it opens and scrolls normally. Before this change the tiebreaker was dormant so this worked by accident; it must now resolve to the primary key rather than erroring on a missing `rowid`.

3. Select a non-contiguous set of rows in any of the three drivers, export the selection, and confirm the exported rows are the ones that were selected.
4. Scroll a large unsorted table top to bottom in each driver and confirm no rows visibly repeat or vanish.