### PR TITLE
server: rollback verifier for single-license placement

### DIFF
--- a/.github/actions/setup-jupyter-docker/action.yml
+++ b/.github/actions/setup-jupyter-docker/action.yml
@@ -16,10 +16,6 @@ inputs:
     description: 'Host path to a pre-built positron-server tarball to install instead of downloading a published release'
     required: false
     default: ''
-  signing-key:
-    description: 'License-token signing key'
-    required: false
-    default: ''
 
 runs:
   using: 'composite'
@@ -75,24 +71,6 @@ runs:
         # script installs it instead of downloading a published positron-builds release.
         docker cp "$SERVER_TARBALL" jupyter-test:/opt/positron-server-branch.tar.gz
         echo "Staged branch server tarball at /opt/positron-server-branch.tar.gz"
-
-    - name: Stage license signing key
-      shell: bash
-      if: inputs.signing-key != ''
-      env:
-        # Pass the secret via env rather than interpolating it into the script
-        # body, so the private key is never embedded in the rendered command.
-        SIGNING_KEY: ${{ inputs.signing-key }}
-      run: |
-        # Copy the signing key into the container at the path the install script
-        # expects (/opt/signing-key.pem). The Hub minting service reads this to
-        # sign per-session license tokens; the install script fails without it.
-        # Must run before the install step below.
-        trap 'rm -f signing-key.pem' EXIT
-        printf '%s' "$SIGNING_KEY" > signing-key.pem
-        chmod 600 signing-key.pem
-        docker cp signing-key.pem jupyter-test:/opt/signing-key.pem
-        echo "Staged license signing key at /opt/signing-key.pem"
 
     - name: Install Jupyter with Positron in container
       shell: bash

--- a/.github/actions/setup-jupyter-docker/action.yml
+++ b/.github/actions/setup-jupyter-docker/action.yml
@@ -91,12 +91,13 @@ runs:
         # Create license file from secret
         echo "${{ inputs.positron-license }}" > positron.lic
 
-        # Copy license into container at arch specific location (expected by install script)
+        # Copy license into container at the POSITRON_LICENSE_KEY_FILE path the
+        # install script configured for sessions (license.lic next to license-manager)
         ARCH=$(docker exec jupyter-test uname -m)
         if [[ "$ARCH" == "aarch64" ]]; then
-          docker cp positron.lic jupyter-test:/opt/positron-server/resources/activation/linux/aarch64/positron.lic
+          docker cp positron.lic jupyter-test:/opt/positron-server/resources/activation/linux/aarch64/license.lic
         else
-          docker cp positron.lic jupyter-test:/opt/positron-server/resources/activation/linux/x86_64/positron.lic
+          docker cp positron.lic jupyter-test:/opt/positron-server/resources/activation/linux/x86_64/license.lic
         fi
 
         # Clean up local copy

--- a/.github/workflows/test-e2e-jupyter-ubuntu.yml
+++ b/.github/workflows/test-e2e-jupyter-ubuntu.yml
@@ -103,7 +103,6 @@ jobs:
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"
-          POSITRON_SIGNING_KEY: "op://Positron/Positron Server private key/notesPlain"
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -134,7 +133,6 @@ jobs:
           run-id: ${{ github.run_id }}
           positron-license: ${{ secrets.POSITRON_LICENSE }}
           server-tarball: /tmp/artifacts/positron-server-linux-x64-branch.tar.gz
-          signing-key: ${{ env.POSITRON_SIGNING_KEY }}
 
       - name: Setup test dependencies and compile tests
         uses: ./.github/actions/setup-e2e-test-dependencies

--- a/docker/environments/jupyter-local/.gitignore
+++ b/docker/environments/jupyter-local/.gitignore
@@ -1,3 +1,4 @@
 .env
 positron.lic
+signing-key.pem
 *.tar.gz

--- a/docker/environments/jupyter-local/.gitignore
+++ b/docker/environments/jupyter-local/.gitignore
@@ -1,4 +1,3 @@
 .env
 positron.lic
-signing-key.pem
 *.tar.gz

--- a/docker/environments/jupyter-local/connect.sh
+++ b/docker/environments/jupyter-local/connect.sh
@@ -72,21 +72,6 @@ if [ -f "./positron.lic" ]; then
   fi
 fi
 
-# Copy signing key to staging area if it exists. The install script moves it to
-# /etc/positron/signing-key.pem for the Hub minting service. Required for the
-# minting flow: positron-server no longer reads a raw .lic, so without the key
-# (and its matching embedded public key) sessions fail closed.
-if [ -f "./signing-key.pem" ]; then
-  echo "Copying signing key to container staging area..."
-  if docker cp "./signing-key.pem" "jupyter-test:/opt/signing-key.pem"; then
-    echo "  ✓ Signing key staged at /opt/signing-key.pem"
-  else
-    echo "  ✗ Failed to copy signing key to staging area"
-  fi
-else
-  echo "  ⚠ No ./signing-key.pem found; the minting service cannot start and Positron sessions will fail closed"
-fi
-
 # Show current status
 echo ""
 echo "=== Status ==="

--- a/docker/environments/jupyter-local/install-jupyter-positron.sh
+++ b/docker/environments/jupyter-local/install-jupyter-positron.sh
@@ -177,11 +177,10 @@ case "$(uname -m)" in
 esac
 
 # Move staged license file to final location if it exists.
-# NOTE: the .lic is now ENTITLEMENT only. It is read by the Hub-side verifier (via
-# license-manager), NOT by user sessions. positron-server no longer reads a raw .lic;
-# it validates a short-lived signed token minted per session (see minting setup below).
+# positron-server validates this .lic itself at startup (via the bundled
+# license-manager binary), so it lives next to that binary and must be
+# readable by user sessions.
 LICENSE_DEST="/opt/positron-server/resources/activation/linux/${LICENSE_ARCH}/license.lic"
-LICENSE_MANAGER_DIR="/opt/positron-server/resources/activation/linux/${LICENSE_ARCH}"
 if [ -f "/opt/positron.lic" ]; then
     echo "Installing license file..."
     if sudo mv /opt/positron.lic "${LICENSE_DEST}"; then
@@ -191,83 +190,26 @@ if [ -f "/opt/positron.lic" ]; then
     fi
 elif [ ! -f "${LICENSE_DEST}" ]; then
     echo "⚠️  WARNING: License file not found at ${LICENSE_DEST}"
-    echo "   The minting service cannot verify entitlement and Positron will fail to start."
+    echo "   Positron will fail to start without a license."
 fi
-# Tighten the .lic so only root (the Hub/verifier) can read it; user sessions must not.
+# User sessions run license-manager verify against the .lic, so it must be readable.
 if [ -f "${LICENSE_DEST}" ]; then
-    sudo chmod 600 "${LICENSE_DEST}" || log_error "Failed to chmod 600 ${LICENSE_DEST}"
+    sudo chmod 644 "${LICENSE_DEST}" || log_error "Failed to chmod 644 ${LICENSE_DEST}"
 fi
 
-# ---------------------------------------------------------------------------
-# License token minting (replaces handing the raw .lic to user sessions).
-# jupyter-positron-verifier runs in the Hub env (privileged), holds the signing
-# key, verifies entitlement via license-manager, and mints short-lived per-session
-# license tokens. Users never see the signing key or the raw .lic.
-# ---------------------------------------------------------------------------
-echo "Installing jupyter-positron-verifier (Hub minting service)..."
-TLJH_HUB_ENV="/opt/tljh/hub"
-if [ -d "${TLJH_HUB_ENV}" ]; then
-    if ! sudo "${TLJH_HUB_ENV}/bin/python3" -m pip install git+https://github.com/posit-dev/jupyter-positron-verifier.git; then
-        log_error "Failed to install jupyter-positron-verifier in TLJH hub environment"
-    fi
-else
-    log_error "TLJH hub environment not found at ${TLJH_HUB_ENV}; cannot install minting service"
-fi
-
-# Install the signing key the verifier uses to mint tokens. It must pair with the
-# OrchestratorPublicKey embedded in positron-server. Provided out-of-band (never committed):
-# staged at /opt/signing-key.pem by the caller (docker cp in CI, or volume locally).
-echo "Installing signing key..."
-sudo mkdir -p /etc/positron
-if [ -f "/opt/signing-key.pem" ]; then
-    if sudo mv /opt/signing-key.pem /etc/positron/signing-key.pem && sudo chmod 600 /etc/positron/signing-key.pem; then
-        echo "  ✓ Signing key installed at /etc/positron/signing-key.pem"
-    else
-        log_error "Failed to install signing key to /etc/positron/signing-key.pem"
-    fi
-elif [ ! -f "/etc/positron/signing-key.pem" ]; then
-    log_error "Signing key not found at /opt/signing-key.pem; minting service cannot start"
-fi
-
-# Write JupyterHub config: register the minting service and point user sessions at it.
-echo "Writing Positron minting JupyterHub config..."
+# Write JupyterHub config: put positron-server on PATH and point sessions at the license.
+echo "Writing Positron JupyterHub config..."
 TLJH_CONFIG_D="/opt/tljh/config/jupyterhub_config.d"
 sudo mkdir -p "${TLJH_CONFIG_D}"
 
-sudo tee "${TLJH_CONFIG_D}/positron-env.py" >/dev/null <<'EOF'
+sudo tee "${TLJH_CONFIG_D}/positron-env.py" >/dev/null <<EOF
 import os
 
 path = os.environ.get("PATH", "/bin:/usr/bin")
 c.SystemdSpawner.environment = {
     "PATH": f"/opt/positron-server/bin:/usr/local/bin:/opt/tljh/user/bin:{path}",
-    "POSITRON_LICENSE_MINTING_ENDPOINT": "http://127.0.0.1:10101/services/positron-license/mint",
+    "POSITRON_LICENSE_KEY_FILE": "${LICENSE_DEST}",
 }
-EOF
-
-sudo tee "${TLJH_CONFIG_D}/positron-minting.py" >/dev/null <<EOF
-# Register jupyter-positron-verifier as a managed JupyterHub service. It runs in
-# the Hub context (privileged), holds the signing key, verifies entitlement via
-# license-manager, and mints short-lived license tokens for each Positron session.
-c.JupyterHub.services = [
-    {
-        "name": "positron-license",
-        "url": "http://127.0.0.1:10101",
-        "command": ["${TLJH_HUB_ENV}/bin/positron-verifier"],
-        "environment": {
-            "POSITRON_MINTING_KEY_FILE": "/etc/positron/signing-key.pem",
-            "POSITRON_LICENSE_MANAGER_PATH": "${LICENSE_MANAGER_DIR}/license-manager",
-            "PORT": "10101",
-        },
-    }
-]
-
-c.JupyterHub.load_roles = [
-    {
-        "name": "positron-license-service",
-        "services": ["positron-license"],
-        "scopes": ["read:users"],
-    }
-]
 EOF
 
 # Set access permissions for TLJH users

--- a/src/vs/server/node/localLicense.ts
+++ b/src/vs/server/node/localLicense.ts
@@ -115,23 +115,38 @@ class LocalLicenseManager {
 	async activateLicenseFile(licenseFilePath: string): Promise<ILicenseValidationResult> {
 		const licenseManagerDir = path.dirname(this.licenseManagerPath);
 
-		let localLic: string | undefined;
-		try {
-			localLic = fs.readdirSync(licenseManagerDir).find(f => f.endsWith('.lic'));
-		} catch {
-			throw new Error(`Cannot read license-manager directory: ${licenseManagerDir}`);
+		if (!fs.existsSync(licenseFilePath)) {
+			throw new Error(`License file not found: ${licenseFilePath}`);
 		}
 
-		if (localLic) {
-			// A .lic file already exists next to the binary; the provided
-			// licenseFilePath is not copied. Verify the existing one.
-			console.log(`Using existing license file: ${path.join(licenseManagerDir, localLic)}`);
-		} else {
+		const localLic = fs.readdirSync(licenseManagerDir).find(f => f.endsWith('.lic'));
+		if (!localLic) {
 			// No .lic next to the binary -- copy the provided file there.
-			if (!fs.existsSync(licenseFilePath)) {
-				throw new Error(`License file not found: ${licenseFilePath}`);
-			}
 			fs.copyFileSync(licenseFilePath, path.join(licenseManagerDir, path.basename(licenseFilePath)));
+		} else {
+			const localLicPath = path.join(licenseManagerDir, localLic);
+			// Compare contents rather than paths: the provided path may be the
+			// local file itself, and copying a file onto itself truncates it.
+			let sameContents: boolean | undefined;
+			try {
+				sameContents = fs.readFileSync(licenseFilePath).equals(fs.readFileSync(localLicPath));
+			} catch {
+				// One of the files is unreadable; leave the existing file in
+				// place and let verification report its state.
+			}
+			if (sameContents === false) {
+				// The provided license differs from the local one -- overwrite
+				// the local file in place so a renewal takes effect. Sessions
+				// without write access keep using the existing file.
+				try {
+					fs.copyFileSync(licenseFilePath, localLicPath);
+					console.log(`Replaced license file: ${localLicPath}`);
+				} catch (e) {
+					console.warn(`Cannot replace license file at ${localLicPath}: ${e}; using the existing license file.`);
+				}
+			} else {
+				console.log(`Using existing license file: ${localLicPath}`);
+			}
 		}
 
 		return this.verify();

--- a/src/vs/server/node/localLicense.ts
+++ b/src/vs/server/node/localLicense.ts
@@ -1,0 +1,222 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs';
+import * as os from 'os';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import * as path from '../../base/common/path.js';
+import type { ILicenseValidationResult } from './remoteLicenseKey.js';
+
+const execFileAsync = promisify(execFile);
+
+const LicError = {
+	OK: 0,
+	FAIL: 1,
+	TRIAL_EXPIRED: 2,
+	VM: 3,
+	ALREADY_ACTIVATED: 4,
+	FILE_NOT_FOUND: 41,
+	ROOT_REQUIRED: 44,
+} as const;
+
+interface LicenseCommandResult {
+	result: number;
+	message?: string;
+	status?: string;
+	'days-left'?: number;
+	'has-key'?: boolean;
+	'has-trial'?: boolean;
+	'license-file'?: string;
+	licensee?: string;
+	initialized?: boolean;
+	expiration?: number;
+}
+
+function validatedResult(result: LicenseCommandResult): ILicenseValidationResult {
+	const status = result.status?.toLowerCase() || '';
+	if (status === 'expired') {
+		throw new Error('License has expired. Please renew your license.');
+	}
+	if (status !== 'activated' && status !== 'evaluation') {
+		throw new Error(`Invalid license result: ${JSON.stringify(result)}`);
+	}
+	return { valid: true, licensee: result.licensee };
+}
+
+type LicErrorCode = typeof LicError[keyof typeof LicError];
+const knownResultCodes = new Set(Object.values(LicError) as LicErrorCode[]);
+function knownResultCode(code: unknown): code is LicErrorCode {
+	return typeof code === 'number' && knownResultCodes.has(code as LicErrorCode);
+}
+
+// The `verify` command prefixes its JSON output with a signature hash line.
+// If stdout contains no '{', returns as-is; JSON.parse will throw upstream.
+function extractJson(stdout: string): string {
+	const jsonStart = stdout.indexOf('{');
+	return jsonStart > 0 ? stdout.slice(jsonStart) : stdout;
+}
+
+/**
+ * Wrapper for executing classic `license-manager` binary commands (the binary bundled
+ * under `resources/activation/`). Not to be confused with `licenseManager.ts`, which
+ * supervises the AWS License Manager client.
+ */
+class LocalLicenseManager {
+	constructor(private readonly licenseManagerPath: string) { }
+
+	private async runJsonCommand(command: string, args: string[] = []): Promise<LicenseCommandResult> {
+		const licenseManagerDir = path.dirname(this.licenseManagerPath);
+		const env = {
+			...process.env,
+			LD_LIBRARY_PATH: licenseManagerDir,
+		};
+
+		let stdout = '';
+		try {
+			const result = await execFileAsync(
+				this.licenseManagerPath,
+				[command, ...args, '--output=json'],
+				{ maxBuffer: 1024 * 1024, timeout: 10000, env }
+			);
+			if (result.stderr && result.stderr.length > 0) {
+				console.warn(`license-manager stderr: ${result.stderr}`);
+			}
+			stdout = result.stdout;
+		} catch (error) {
+			const execError = error as { stdout?: string; message?: string };
+			stdout = execError.stdout ?? '';
+			if (!stdout) {
+				throw new Error(execError.message || 'Unknown error');
+			}
+		}
+
+		const jsonStr = extractJson(stdout);
+		const parsed = JSON.parse(jsonStr);
+		if (!knownResultCode(parsed?.result)) {
+			throw new Error(`Unexpected license-manager response: ${stdout}`);
+		}
+		return parsed;
+	}
+
+	async verify(): Promise<ILicenseValidationResult> {
+		const result = await this.runJsonCommand('verify');
+		if (result.result !== LicError.OK) {
+			throw new Error(`License verification failed: ${result.message || `code ${result.result}`}`);
+		}
+
+		const validated = validatedResult(result);
+		console.log(`Positron license verified: ${JSON.stringify(result)}`);
+		return validated;
+	}
+
+	async activateLicenseFile(licenseFilePath: string): Promise<ILicenseValidationResult> {
+		const licenseManagerDir = path.dirname(this.licenseManagerPath);
+
+		let localLic: string | undefined;
+		try {
+			localLic = fs.readdirSync(licenseManagerDir).find(f => f.endsWith('.lic'));
+		} catch {
+			throw new Error(`Cannot read license-manager directory: ${licenseManagerDir}`);
+		}
+
+		if (localLic) {
+			// A .lic file already exists next to the binary; the provided
+			// licenseFilePath is not copied. Verify the existing one.
+			console.log(`Using existing license file: ${path.join(licenseManagerDir, localLic)}`);
+		} else {
+			// No .lic next to the binary -- copy the provided file there.
+			if (!fs.existsSync(licenseFilePath)) {
+				throw new Error(`License file not found: ${licenseFilePath}`);
+			}
+			fs.copyFileSync(licenseFilePath, path.join(licenseManagerDir, path.basename(licenseFilePath)));
+		}
+
+		return this.verify();
+	}
+}
+
+/**
+ * Activates a Positron Server license file using the license-manager binary.
+ */
+export async function activateWithManager(
+	installPath: string,
+	licenseFilePath: string,
+): Promise<ILicenseValidationResult> {
+	const licenseManagerPath = findLicenseManagerPath(installPath);
+	const licenseManager = new LocalLicenseManager(licenseManagerPath);
+	return licenseManager.activateLicenseFile(licenseFilePath);
+}
+
+/**
+ * Checks for a .lic file next to the license-manager binary and verifies it.
+ * Returns undefined if no .lic file is found or the binary doesn't exist.
+ */
+export async function verifyLocalLicense(
+	installPath: string,
+): Promise<ILicenseValidationResult | undefined> {
+	let licenseManagerPath: string;
+	try {
+		licenseManagerPath = findLicenseManagerPath(installPath);
+	} catch {
+		return undefined;
+	}
+
+	const licenseManagerDir = path.dirname(licenseManagerPath);
+	let localLic: string | undefined;
+	try {
+		localLic = fs.readdirSync(licenseManagerDir).find(f => f.endsWith('.lic'));
+	} catch {
+		return undefined;
+	}
+	if (!localLic) {
+		return undefined;
+	}
+
+	const licenseManager = new LocalLicenseManager(licenseManagerPath);
+	return licenseManager.verify();
+}
+
+/**
+ * Gets the platform-specific subdirectory for the license-manager binary.
+ * @returns The platform subdirectory path
+ */
+function getPlatformSubdir(): string {
+	const platform = os.platform();
+	if (platform === 'linux') {
+		const arch = os.arch();
+		// Map Node.js arch names to the directory names used by the build
+		const archMap: Record<string, string> = {
+			'x64': 'x86_64',
+			'arm64': 'aarch64',
+		};
+		const archDir = archMap[arch] || arch;
+		return path.join('linux', archDir);
+	}
+	// No other platforms are currently supported
+	throw new Error(`Platform not supported: ${platform}`);
+}
+
+/**
+ * Locates the license-manager binary relative to the Positron installation.
+ * @param installPath The root installation path of Positron
+ * @returns The absolute path to the license-manager binary
+ */
+function findLicenseManagerPath(installPath: string): string {
+	const platformSubdir = getPlatformSubdir();
+	const licenseManagerPath = path.join(installPath, 'resources', 'activation', platformSubdir, 'license-manager');
+
+	if (!fs.existsSync(licenseManagerPath)) {
+		throw new Error(`License manager binary not found at: ${licenseManagerPath}`);
+	}
+
+	try {
+		fs.accessSync(licenseManagerPath, fs.constants.X_OK);
+	} catch {
+		throw new Error(`License manager binary is not executable: ${licenseManagerPath}`);
+	}
+
+	return licenseManagerPath;
+}

--- a/src/vs/server/node/remoteLicenseKey.ts
+++ b/src/vs/server/node/remoteLicenseKey.ts
@@ -8,7 +8,9 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from '../../base/common/path.js';
 import * as crypto from 'crypto';
+import { FileAccess } from '../../base/common/network.js';
 import { LicenseManager } from './licenseManager.js';
+import { activateWithManager, verifyLocalLicense } from './localLicense.js';
 
 /**
  * The result of validating a license.
@@ -22,15 +24,17 @@ export interface ILicenseValidationResult {
 	issuer?: string;
 	/**
 	 * Whether this license grants Positron's Education License Rider terms (drives the
-	 * academic license banner and P3M telemetry). Left undefined (falsy) for validation
-	 * paths that have no way to determine this, such as the external license manager.
+	 * academic license banner and P3M telemetry). True for licenses validated from a raw
+	 * license file, which is every deployment that is neither Posit Workbench (signed
+	 * token, always false) nor the AWS license manager (left undefined, i.e. falsy).
 	 */
 	academic?: boolean;
 }
 
 /**
  * This file validates Positron license keys. Positron requires a license key to
- * be provided in order to run in a hosted or managed environment.
+ * be provided in order to run in a hosted or managed environment. Raw .lic license
+ * files are also accepted and are validated with the bundled license-manager binary.
  *
  * Positron license keys are JSON objects naming the connection token, issuer,
  * licensee, timestamp, and a PKCS1 v1.5 cryptographic signature of all of the
@@ -85,24 +89,6 @@ vAb1iFBg5jrsvhZzzZbIah1XHYAT+X43WaExwme18pzBAgMBAAE=
 -----END PUBLIC KEY-----`;
 
 /**
- * A RSA-4096 public key used to verify license keys in Positron Server deployments
- */
-const OrchestratorPublicKey = `-----BEGIN PUBLIC KEY-----
-MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAvL/qcnvIj+A7cXhUgism
-MYfMzg6wrPgVOp3AezejarPGF+t9qwX1BRQZT176PLoujmZsD92wwh9yEK31TnVD
-YENhtUymnNLvt5UbMoWI+dlttruTOYvoiBMUMajPqTF3jr0TE39YhLgc5fKidvLR
-ZX4u0DQ0YVaJqfV7SUUAp9j6APtPuiP4SsJxIjlZo0Hvw+EZ5Y6TmgwfHhAwEBoP
-5L9CwVjRAg34HP5wGl/znipXb3drMyUgpVuhyN+GrCXz30GXbWJcfoVw7y7G46Z4
-En2Z/2Rs9P4wd6FeybSNOceit+5mnI5amvpaDrCSq1BnOm6NemdoNMYEuUI+0WSJ
-2eYAI2x36wXFE+6zPkqZYEuFxN4L8xvZvu/LYBd1qyLjSEN9yoLekRzAAa1n222n
-JKiTum02wdrvcjnBHZyB+OVLAySeM7JElh79A6OYe32ENSXvA3ZT+vUGbsptdggq
-NjfOoqWxWVO3L8Gvx+0SjiczLt8c9Wp9dW7xiiAO6CMgy8wgnQircW00ZjadYPbI
-J96J0myarwU9s46B9SbyWKzcTpEvHgD47/rRcMx64PlmtS6hxgIdyIKNFjWrGt5g
-5AzUF63cLtv+he4d4CtfPo9TCbqLbaUop0g/3aqPAOAz/7wPLPnzURJGfiUYB/gx
-jv4RUEuRUo3aePrbcc3Wfl8CAwEAAQ==
------END PUBLIC KEY-----`;
-
-/**
  * Validates a license key. If any errors are encountered, they are logged to
  * the console.
  *
@@ -111,68 +97,95 @@ jv4RUEuRUo3aePrbcc3Wfl8CAwEAAQ==
  * - As a file path with the --license-key-file flag.
  * - As an environment variable named POSITRON_LICENSE_KEY.
  * - As a file path in an environment variable named POSITRON_LICENSE_KEY_FILE.
+ * - As a .lic file next to the bundled license-manager binary.
+ *
+ * A provided license that does not validate falls back to the local .lic file, so
+ * an environment that still injects retired verifier-minted tokens keeps working
+ * off its license file.
  *
  * @param connectionToken The token to validate the license key against.
  * @param args The parsed command-line arguments.
+ * @param verifyLocal Checks for a .lic next to the bundled license-manager binary.
+ * Test-only, like `validateLicense`'s `publicKeys`.
  * @returns A promise that resolves to the license validation result.
  */
-export async function validateLicenseKey(connectionToken: string, args: ServerParsedArgs): Promise<ILicenseValidationResult> {
+export async function validateLicenseKey(connectionToken: string, args: ServerParsedArgs, verifyLocal: typeof verifyLocalLicense = verifyLocalLicense): Promise<ILicenseValidationResult> {
 
 	if (isRemoteLicenseManagerMode()) {
 		console.log('Acquiring a Positron license through the license manager named by POSITRON_LICENSE_MANAGER_PATH.');
 		return validateWithLicenseManager(process.env.POSITRON_LICENSE_MANAGER_PATH!);
 	}
 
-	// Check the command-line arguments for a license key.
+	// Check the provided license sources in order.
+	let provided: ILicenseValidationResult | undefined;
 	if (args['license-key']) {
 		console.log('Checking Positron license key from the --license-key argument.');
-		return validateLicense(connectionToken, args['license-key']);
-	}
-
-	// Check to see if a license key file is provided as a command-line
-	// argument.
-	if (args['license-key-file']) {
+		provided = await validateLicense(connectionToken, args['license-key']);
+	} else if (args['license-key-file']) {
 		console.log('Checking Positron license key from the file in the --license-key-file argument.');
-		return validateLicenseFile(connectionToken, args['license-key-file']);
-	}
-
-	// Check the POSITRON_LICENSE_KEY environment variable.
-	if (process.env.POSITRON_LICENSE_KEY) {
+		provided = await validateLicenseFile(connectionToken, args['license-key-file']);
+	} else if (process.env.POSITRON_LICENSE_KEY) {
 		console.log('Checking Positron license key from the POSITRON_LICENSE_KEY environment variable.');
-		return validateLicense(connectionToken, process.env.POSITRON_LICENSE_KEY);
-	}
-
-	// Check the POSITRON_LICENSE_KEY_FILE environment variable.
-	if (process.env.POSITRON_LICENSE_KEY_FILE) {
+		provided = await validateLicense(connectionToken, process.env.POSITRON_LICENSE_KEY);
+	} else if (process.env.POSITRON_LICENSE_KEY_FILE) {
 		console.log('Checking Positron license key from the file in the POSITRON_LICENSE_KEY_FILE environment variable.');
-		return validateLicenseFile(connectionToken, process.env.POSITRON_LICENSE_KEY_FILE);
-	}
-
-	// If none of these were specified, check the user data directory for a
-	// license key file. It is expected to live alongside the connection token.
-	if (args['user-data-dir']) {
+		provided = await validateLicenseFile(connectionToken, process.env.POSITRON_LICENSE_KEY_FILE);
+	} else if (args['user-data-dir']) {
+		// If none of these were specified, check the user data directory for a
+		// license key file. It is expected to live alongside the connection token.
 		const storageLocation = path.join(args['user-data-dir'], 'license-key');
 		if (fs.existsSync(storageLocation)) {
-			return validateLicenseFile(connectionToken, storageLocation);
+			provided = await validateLicenseFile(connectionToken, storageLocation);
 		}
 	}
 
-	// We need at least one signed license token to proceed. There is no fallback
-	// to a raw license file: if no signed token is provided, validation fails closed.
-	console.error('No license key provided. A signed license token is required to use Positron in a hosted environment. Provide one with the --license-key or --license-key-file command-line arguments, or set the POSITRON_LICENSE_KEY or POSITRON_LICENSE_KEY_FILE environment variables.');
+	if (provided?.valid) {
+		return provided;
+	}
+
+	// No license was provided, or the provided one did not validate (for example a
+	// token minted by a retired jupyter-positron-verifier). Look for a .lic next to
+	// the license-manager binary; file-based licenses mark the deployment academic
+	// (see ILicenseValidationResult.academic).
+	try {
+		const installPath = path.join(FileAccess.asFileUri('').fsPath, '..');
+		const localResult = await verifyLocal(installPath);
+		if (localResult?.valid) {
+			if (provided) {
+				console.log('The provided license key did not validate; using the license file next to the license-manager binary instead.');
+			} else {
+				console.log('Verified license from license-manager directory.');
+			}
+			return { ...localResult, academic: true };
+		}
+	} catch (e) {
+		console.error('Error verifying local license file: ', e);
+	}
+
+	if (provided) {
+		// The provided license failed and there is no usable local license; the
+		// failure was already logged by the validation path above.
+		return provided;
+	}
+
+	// We need at least one license key to proceed.
+	console.error('No license key provided. A license key is required to use Positron in a hosted environment. Provide a license key with the --license-key or --license-key-file command-line arguments, or set the POSITRON_LICENSE_KEY or POSITRON_LICENSE_KEY_FILE environment variables.');
 
 	return { valid: false };
 }
 
 /**
- * Validates a license file. The file must contain a signed JSON license token;
- * raw license files are not accepted.
+ * Validates a license file. Signed JSON license tokens are verified in-process; raw
+ * RSTUDIO/Posit license files are activated and verified with the bundled
+ * license-manager binary and mark the deployment academic.
  *
  * @param connectionToken The connection token.
  * @param licenseFile The path to the license file.
+ * @param activate Activates a raw license file with the license-manager binary.
+ * Test-only, like `validateLicense`'s `publicKeys`.
  * @returns The license validation result.
  */
-export async function validateLicenseFile(connectionToken: string, licenseFile: string): Promise<ILicenseValidationResult> {
+export async function validateLicenseFile(connectionToken: string, licenseFile: string, activate: typeof activateWithManager = activateWithManager): Promise<ILicenseValidationResult> {
 	if (!fs.existsSync(licenseFile)) {
 		console.error('License file does not exist: ', licenseFile);
 		return { valid: false };
@@ -180,12 +193,21 @@ export async function validateLicenseFile(connectionToken: string, licenseFile: 
 	// Read the contents of the license file into a string.
 	try {
 		const contents = fs.readFileSync(licenseFile, 'utf8');
-		// Only signed JSON license tokens are accepted; raw license files are not.
-		if (contents.trim().startsWith('{')) {
+		const trimmedContents = contents.trim();
+		if (trimmedContents.startsWith('{')) {
+			// A signed JSON license token, minted by Posit Workbench.
 			return validateLicense(connectionToken, contents);
+		} else if (trimmedContents.startsWith('-----BEGIN RSTUDIO LICENSE-----')) {
+			// A raw license file; activate and verify it with the license-manager
+			// binary. File-based licenses mark the deployment academic; see
+			// ILicenseValidationResult.academic.
+			const installPath = path.join(FileAccess.asFileUri('').fsPath, '..');
+			const result = await activate(installPath, licenseFile);
+			return result.valid ? { ...result, academic: true } : result;
+		} else {
+			console.error('Unrecognized license file format. Expected a JSON license key or an RSA license file.');
+			return { valid: false };
 		}
-		console.error('Unrecognized license file format. Expected a signed JSON license token.');
-		return { valid: false };
 	} catch (e) {
 		console.error('Error reading license file: ', licenseFile);
 		console.error(e);
@@ -199,12 +221,9 @@ export async function validateLicenseFile(connectionToken: string, licenseFile: 
  * @param connectionToken The connection token.
  * @param license The license key.
  * @param publicKeys Keys to verify against. Test-only; production uses the built-in keys.
- * @param orchestratorKey The key whose match marks the license `academic`. Test-only, like
- * `publicKeys`: the real orchestrator private key is held by the minting service, not this
- * repo, so tests substitute their own pair.
  * @returns A promise that resolves to the license validation result.
  */
-export async function validateLicense(connectionToken: string, license: string, publicKeys?: readonly string[], orchestratorKey: string = OrchestratorPublicKey): Promise<ILicenseValidationResult> {
+export async function validateLicense(connectionToken: string, license: string, publicKeys?: readonly string[]): Promise<ILicenseValidationResult> {
 	// Parse the license key JSON.
 	let licenseKey: LicenseKey;
 	try {
@@ -236,9 +255,9 @@ export async function validateLicense(connectionToken: string, license: string, 
 	}
 
 	// Try each supplied public key; accept the license if any key verifies.
-	const keysToTry = publicKeys ?? [PublicKey, OrchestratorPublicKey];
+	const keysToTry = publicKeys ?? [PublicKey];
 	const signature = Buffer.from(licenseKey.signature, 'base64');
-	let matchedKey: string | undefined;
+	let signatureValid = false;
 	for (const keyPem of keysToTry) {
 		if (!keyPem.trim()) {
 			continue;
@@ -259,7 +278,7 @@ export async function validateLicense(connectionToken: string, license: string, 
 			verifier.update(licenseKey.licensee);
 			verifier.update(licenseKey.timestamp);
 			if (verifier.verify(key, signature)) {
-				matchedKey = keyPem;
+				signatureValid = true;
 				break;
 			}
 		} catch {
@@ -267,7 +286,7 @@ export async function validateLicense(connectionToken: string, license: string, 
 		}
 	}
 
-	if (!matchedKey) {
+	if (!signatureValid) {
 		console.error('Invalid license key; signature is invalid: ', licenseKey.signature);
 		return { valid: false };
 	}
@@ -277,10 +296,9 @@ export async function validateLicense(connectionToken: string, license: string, 
 		valid: true,
 		licensee: licenseKey.licensee,
 		issuer: licenseKey.issuer,
-		// The orchestrator key is used exclusively by the JupyterHub/TLJH academic minting
-		// flow (jupyter-positron-verifier); Server Pro and other primary-key deployments are
-		// not academic.
-		academic: matchedKey === orchestratorKey,
+		// Signed tokens are minted by Posit Workbench, which is never an academic
+		// deployment. Academic status comes from the raw-license-file paths.
+		academic: false,
 	};
 }
 

--- a/src/vs/server/node/remoteLicenseKey.ts
+++ b/src/vs/server/node/remoteLicenseKey.ts
@@ -223,7 +223,7 @@ export async function validateLicenseFile(connectionToken: string, licenseFile: 
 			return { valid: false };
 		}
 	} catch (e) {
-		console.error('Error reading license file: ', licenseFile);
+		console.error('Error validating license file: ', licenseFile);
 		console.error(e);
 	}
 	return { valid: false };

--- a/src/vs/server/node/remoteLicenseKey.ts
+++ b/src/vs/server/node/remoteLicenseKey.ts
@@ -27,6 +27,8 @@ export interface ILicenseValidationResult {
 	 * academic license banner and P3M telemetry). True for licenses validated from a raw
 	 * license file, which is every deployment that is neither Posit Workbench (signed
 	 * token, always false) nor the AWS license manager (left undefined, i.e. falsy).
+	 * Note for Positron Server Pro: this license miust carry its own signal,
+	 * or it will inherit `academic` as true
 	 */
 	academic?: boolean;
 }
@@ -145,8 +147,10 @@ export async function validateLicenseKey(connectionToken: string, args: ServerPa
 
 	// No license was provided, or the provided one did not validate (for example a
 	// token minted by a retired jupyter-positron-verifier). Look for a .lic next to
-	// the license-manager binary; file-based licenses mark the deployment academic
-	// (see ILicenseValidationResult.academic).
+	// the license-manager binary; file-based licenses mark the deployment academic.
+	// A license file that exists but does not verify (expired, tampered with) throws
+	// rather than returning; hold onto the reason so the failure below can name it.
+	let localError: unknown;
 	try {
 		const installPath = path.join(FileAccess.asFileUri('').fsPath, '..');
 		const localResult = await verifyLocal(installPath);
@@ -159,13 +163,23 @@ export async function validateLicenseKey(connectionToken: string, args: ServerPa
 			return { ...localResult, academic: true };
 		}
 	} catch (e) {
-		console.error('Error verifying local license file: ', e);
+		localError = e;
+	}
+
+	if (localError) {
+		console.error('The license file next to the license-manager binary was rejected: ', localError);
 	}
 
 	if (provided) {
 		// The provided license failed and there is no usable local license; the
 		// failure was already logged by the validation path above.
 		return provided;
+	}
+
+	if (localError) {
+		// A license file was found and rejected. Saying "no license key provided" here
+		// would send operators looking for a missing license instead of a bad one.
+		return { valid: false };
 	}
 
 	// We need at least one license key to proceed.

--- a/src/vs/server/test/node/remoteLicenseKey.vitest.ts
+++ b/src/vs/server/test/node/remoteLicenseKey.vitest.ts
@@ -6,8 +6,16 @@
 /// <reference types="vitest/globals" />
 
 import * as crypto from 'crypto';
-import { validateLicense, validateLicenseKey } from '../../node/remoteLicenseKey.js';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from '../../../base/common/path.js';
+import { validateLicense, validateLicenseFile, validateLicenseKey } from '../../node/remoteLicenseKey.js';
 import type { ServerParsedArgs } from '../../node/serverEnvironmentService.js';
+
+// remoteLicenseKey.ts locates the license-manager binary with FileAccess.asFileUri(''), which
+// requires globalThis._VSCODE_FILE_ROOT. That's normally set by a bootstrap entry point (see
+// agentHostServerMain.ts), which this plain Vitest run doesn't go through -- set it ourselves.
+globalThis._VSCODE_FILE_ROOT = new URL('../../../../..', import.meta.url).pathname;
 
 function createServerArgs(): ServerParsedArgs {
 	return {
@@ -109,47 +117,7 @@ describe('validateLicense', () => {
 		expect(result.valid).toBe(false);
 	});
 
-	it('validates against a second key when the first fails', async () => {
-		const { privateKey: orchestratorPrivKey, publicKey: orchestratorPubKeyPem } =
-			crypto.generateKeyPairSync('rsa', {
-				modulusLength: 2048,
-				publicKeyEncoding: { type: 'spki', format: 'pem' },
-				privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
-			});
-
-		const token = 'test-token-orchestrator';
-		const timestamp = new Date().toISOString();
-		const license = mintLicense(token, 'JupyterHub', 'Acme Corp', timestamp, orchestratorPrivKey);
-
-		// testPubKeyPem fails, orchestratorPubKeyPem succeeds.
-		const result = await validateLicense(token, license, [testPubKeyPem, orchestratorPubKeyPem]);
-
-		expect(result.valid).toBe(true);
-		expect(result.issuer).toBe('JupyterHub');
-		expect(result.licensee).toBe('Acme Corp');
-	});
-
-	it('marks the license academic when it validates against the orchestrator key', async () => {
-		// The real OrchestratorPublicKey's private key is held by the minting service, not
-		// this repo, so a throwaway pair stands in as the orchestrator key.
-		const { privateKey: orchestratorPrivKey, publicKey: orchestratorPubKeyPem } =
-			crypto.generateKeyPairSync('rsa', {
-				modulusLength: 2048,
-				publicKeyEncoding: { type: 'spki', format: 'pem' },
-				privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
-			});
-
-		const token = 'test-token-academic';
-		const timestamp = new Date().toISOString();
-		const license = mintLicense(token, 'JupyterHub', 'Acme University', timestamp, orchestratorPrivKey);
-
-		const result = await validateLicense(token, license, [testPubKeyPem, orchestratorPubKeyPem], orchestratorPubKeyPem);
-
-		expect(result.valid).toBe(true);
-		expect(result.academic).toBe(true);
-	});
-
-	it('does not mark the license academic when it validates against the primary key', async () => {
+	it('marks a signed token not academic', async () => {
 		const token = 'test-token-not-academic';
 		const timestamp = new Date().toISOString();
 		const license = mintLicense(token, 'Test Hub', 'Test Corp', timestamp);
@@ -195,8 +163,66 @@ describe('validateLicense', () => {
 	});
 });
 
+describe('validateLicenseFile', () => {
+	function writeTempLicense(contents: string): string {
+		const licPath = path.join(os.tmpdir(), `positron-test-${Date.now()}-${Math.random().toString(36).slice(2)}.lic`);
+		fs.writeFileSync(licPath, contents);
+		return licPath;
+	}
+
+	it('marks a raw license file academic when the license manager verifies it', async () => {
+		const licPath = writeTempLicense('-----BEGIN RSTUDIO LICENSE-----\nabc123\n-----END RSTUDIO LICENSE-----\n');
+		try {
+			const result = await validateLicenseFile('any-token', licPath, async () => ({ valid: true, licensee: 'Acme University' }));
+			expect(result).toEqual({ valid: true, licensee: 'Acme University', academic: true });
+		} finally {
+			fs.unlinkSync(licPath);
+		}
+	});
+
+	it('does not mark a rejected raw license file academic', async () => {
+		const licPath = writeTempLicense('-----BEGIN RSTUDIO LICENSE-----\nabc123\n-----END RSTUDIO LICENSE-----\n');
+		try {
+			const result = await validateLicenseFile('any-token', licPath, async () => ({ valid: false }));
+			expect(result).toEqual({ valid: false });
+		} finally {
+			fs.unlinkSync(licPath);
+		}
+	});
+
+	it('rejects an unrecognized license file format without invoking the license manager', async () => {
+		const licPath = writeTempLicense('this is not a license\n');
+		try {
+			let activateCalled = false;
+			const result = await validateLicenseFile('any-token', licPath, async () => {
+				activateCalled = true;
+				return { valid: true };
+			});
+			expect({ valid: result.valid, activateCalled }).toEqual({ valid: false, activateCalled: false });
+		} finally {
+			fs.unlinkSync(licPath);
+		}
+	});
+});
+
 describe('validateLicenseKey', () => {
-	it('fails closed when no signed token is available (no raw-license fallback)', async () => {
+	/** Runs fn with the license env vars cleared, restoring them afterwards. */
+	async function withCleanLicenseEnv(fn: () => Promise<void>): Promise<void> {
+		const saved: Record<string, string | undefined> = {};
+		for (const name of ['POSITRON_LICENSE_KEY', 'POSITRON_LICENSE_KEY_FILE', 'POSITRON_LICENSE_MANAGER_PATH']) {
+			saved[name] = process.env[name];
+			delete process.env[name];
+		}
+		try {
+			await fn();
+		} finally {
+			for (const [name, value] of Object.entries(saved)) {
+				if (value !== undefined) { process.env[name] = value; }
+			}
+		}
+	}
+
+	it('fails closed when no license is available anywhere', async () => {
 		const prevKey = process.env.POSITRON_LICENSE_KEY;
 		const prevFile = process.env.POSITRON_LICENSE_KEY_FILE;
 		const prevManager = process.env.POSITRON_LICENSE_MANAGER_PATH;
@@ -205,7 +231,7 @@ describe('validateLicenseKey', () => {
 		delete process.env.POSITRON_LICENSE_MANAGER_PATH;
 		try {
 			const args = createServerArgs();
-			const result = await validateLicenseKey('some-token', args);
+			const result = await validateLicenseKey('some-token', args, async () => undefined);
 			expect(result.valid).toBe(false);
 		} finally {
 			if (prevKey !== undefined) { process.env.POSITRON_LICENSE_KEY = prevKey; }
@@ -230,5 +256,37 @@ describe('validateLicenseKey', () => {
 			if (prevKey === undefined) { delete process.env.POSITRON_LICENSE_KEY; } else { process.env.POSITRON_LICENSE_KEY = prevKey; }
 			if (prevManager === undefined) { delete process.env.POSITRON_LICENSE_MANAGER_PATH; } else { process.env.POSITRON_LICENSE_MANAGER_PATH = prevManager; }
 		}
+	});
+
+	it('marks a local .lic license academic', async () => {
+		await withCleanLicenseEnv(async () => {
+			const result = await validateLicenseKey('some-token', createServerArgs(), async () => ({ valid: true, licensee: 'Acme University' }));
+			expect(result).toEqual({ valid: true, licensee: 'Acme University', academic: true });
+		});
+	});
+
+	it('falls back to the local .lic when the provided license does not validate', async () => {
+		// A lingering jupyter-positron-verifier deployment injects a minted token
+		// that is no longer accepted; the session must still license off the local
+		// .lic and stay academic.
+		await withCleanLicenseEnv(async () => {
+			process.env.POSITRON_LICENSE_KEY = JSON.stringify({
+				connection_token: 'some-token',
+				issuer: 'JupyterHub',
+				licensee: 'Acme University',
+				timestamp: new Date().toISOString(),
+				signature: 'bm90LWEtcmVhbC1zaWduYXR1cmU=',
+			});
+			const result = await validateLicenseKey('some-token', createServerArgs(), async () => ({ valid: true, licensee: 'Acme University' }));
+			expect(result).toEqual({ valid: true, licensee: 'Acme University', academic: true });
+		});
+	});
+
+	it('fails closed when the provided license is invalid and there is no local license', async () => {
+		await withCleanLicenseEnv(async () => {
+			process.env.POSITRON_LICENSE_KEY = 'not-valid-json{{{';
+			const result = await validateLicenseKey('some-token', createServerArgs(), async () => undefined);
+			expect(result.valid).toBe(false);
+		});
 	});
 });

--- a/src/vs/server/test/node/remoteLicenseKey.vitest.ts
+++ b/src/vs/server/test/node/remoteLicenseKey.vitest.ts
@@ -69,10 +69,10 @@ describe('validateLicense', () => {
 	});
 
 	it('validates a token with empty issuer and licensee', async () => {
-		// The minting service legitimately issues tokens with empty issuer/licensee
-		// (e.g. dev mode, or a license-manager whose verify output omits issuer).
-		// The empty strings are still part of the signed payload, so the token must
-		// validate rather than be rejected as "missing fields".
+		// Signed tokens may legitimately carry empty issuer/licensee (e.g. dev
+		// tokens, or an issuer that omits them). The empty strings are still part
+		// of the signed payload, so the token must validate rather than be
+		// rejected as "missing fields".
 		const token = 'test-token-empty-fields';
 		const timestamp = new Date().toISOString();
 		const license = mintLicense(token, '', '', timestamp);
@@ -217,7 +217,7 @@ describe('validateLicenseKey', () => {
 			await fn();
 		} finally {
 			for (const [name, value] of Object.entries(saved)) {
-				if (value !== undefined) { process.env[name] = value; }
+				if (value === undefined) { delete process.env[name]; } else { process.env[name] = value; }
 			}
 		}
 	}

--- a/src/vs/server/test/node/remoteLicenseKey.vitest.ts
+++ b/src/vs/server/test/node/remoteLicenseKey.vitest.ts
@@ -289,4 +289,28 @@ describe('validateLicenseKey', () => {
 			expect(result.valid).toBe(false);
 		});
 	});
+
+	it('names the reason a local license was rejected rather than claiming none was provided', async () => {
+		// A .lic that exists but does not verify makes the license-manager throw. The
+		// operator needs to hear that the license was rejected; "no license key provided"
+		// would send them looking for a missing file instead of an expired one.
+		await withCleanLicenseEnv(async () => {
+			const errors: string[] = [];
+			const spy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+				errors.push(args.map(String).join(' '));
+			});
+			try {
+				const result = await validateLicenseKey('some-token', createServerArgs(), async () => {
+					throw new Error('License has expired. Please renew your license.');
+				});
+				expect({
+					valid: result.valid,
+					namedTheRejection: errors.some(e => e.includes('License has expired')),
+					claimedMissing: errors.some(e => e.includes('No license key provided')),
+				}).toEqual({ valid: false, namedTheRejection: true, claimedMissing: false });
+			} finally {
+				spy.mockRestore();
+			}
+		});
+	});
 });


### PR DESCRIPTION
Closes https://github.com/posit-dev/positron-builds/issues/1156

Rolls back the jupyter-positron-verifier token-minting flow in favor of the classic single-license placement: positron-server validates a raw .lic itself via the bundled license-manager binary, same as before #14260. Per the decision on positron-builds#1156, this trades the per-session signed-token binding for the simpler, previously-shipped file check.

- `localLicense.ts` restores the pre-#14260 license-manager wrapper (renamed to avoid clashing with the AWS License Manager client added in #15538).
- `remoteLicenseKey.ts` drops the orchestrator public key, adds a raw-.lic branch to `validateLicenseFile`, and falls back to the local .lic when a provided license (e.g. a token minted by a now-retired verifier) fails to validate, so a lingering deployment keeps working.
- CI and the jupyter-local docker scripts drop the signing-key staging step and place the license as `license.lic` next to `license-manager`, readable by user sessions.
- A raw-license-file deployment is marked `academic`, since education is the only shipped surface that presents a `.lic` today (Workbench uses signed tokens, SageMaker goes through the AWS license manager). Positron Server Pro doesn't ship yet; when it does it will need its own signal here rather than inheriting `academic`.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

@:jupyter

Unit coverage:

```
npx vitest run src/vs/server/test/node/remoteLicenseKey.vitest.ts
```

Manual, needs a real jupyter-local docker environment:

1. Drop a raw RSTUDIO license .lic at `docker/environments/jupyter-local/positron.lic`, run `./install-jupyter-positron.sh`, and confirm the server starts and shows the academic banner.
2. Confirm a stale POSITRON_LICENSE_KEY (e.g. a leftover verifier-minted token) in the session environment still falls back to the local .lic instead of failing the session closed.
