### PR TITLE
Use more traditional exthost routing

### DIFF
--- a/src/vs/workbench/api/browser/positron/mainThreadDataExplorer.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadDataExplorer.ts
@@ -27,8 +27,8 @@ export class MainThreadDataExplorer implements MainThreadDataExplorerShape, IDat
 		@IPositronDataExplorerService private readonly _dataExplorerService: IPositronDataExplorerService
 	) {
 		this._proxy = extHostContext.getProxy(ExtHostPositronContext.ExtHostDataExplorer);
-		// Register this host's transport so its provider claims are cleared if the host disconnects.
-		this._disposables.add(this._dataExplorerService.registerRpcTransport(this));
+		// Register this host so its provider claims are cleared if the host disconnects.
+		this._disposables.add(this._dataExplorerService.registerRpcHost(this));
 	}
 
 	// --- IDataExplorerRpcTransport ---

--- a/src/vs/workbench/api/browser/positron/mainThreadDataExplorer.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadDataExplorer.ts
@@ -5,55 +5,37 @@
 
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { extHostNamedCustomer, IExtHostContext } from '../../../services/extensions/common/extHostCustomers.js';
-import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { IPositronDataExplorerService } from '../../../services/positronDataExplorer/browser/interfaces/positronDataExplorerService.js';
-import { IDataExplorerHostTransport, IDataExplorerRpcDto, IDataExplorerResponseDto, IDataExplorerUiEventDto } from '../../../services/positronDataExplorer/common/dataExplorerRpcTransport.js';
+import { IDataExplorerRpcDto, IDataExplorerResponseDto, IDataExplorerRpcTransport, IDataExplorerUiEventDto } from '../../../services/positronDataExplorer/common/dataExplorerRpcTransport.js';
 import { ExtHostDataExplorerShape, ExtHostPositronContext, MainPositronContext, MainThreadDataExplorerShape } from '../../common/positron/extHost.positron.protocol.js';
 
 /**
- * Activation event a Data Explorer backend extension declares so it activates lazily when a dataset
- * it owns is first accessed, rather than eagerly at startup. The provider id is the suffix, e.g.
- * `onPositronDataExplorerBackend:positron-duckdb`.
- */
-function dataExplorerBackendActivationEvent(providerId: string): string {
-	return `onPositronDataExplorerBackend:${providerId}`;
-}
-
-/**
- * Main thread counterpart to ExtHostDataExplorer. Acts as the {@link IDataExplorerHostTransport} for
- * core Data Explorer backends -- forwarding each RPC over the typed ext-host channel to the
- * providing extension -- and routes the extension's frontend UI events and open requests into the
- * IPositronDataExplorerService. Registers itself as the service's transport for its lifetime.
+ * Main thread counterpart to ExtHostDataExplorer, one per extension host. Acts as this host's
+ * {@link IDataExplorerRpcTransport} for core Data Explorer backends -- forwarding each RPC over the
+ * typed ext-host channel to the providing extension -- routes the extension's frontend UI events and
+ * open requests into the IPositronDataExplorerService, and tells the service which providers this
+ * host owns as their handlers register. The service triggers activation and routes RPCs to the owner.
  */
 @extHostNamedCustomer(MainPositronContext.MainThreadDataExplorer)
-export class MainThreadDataExplorer implements MainThreadDataExplorerShape, IDataExplorerHostTransport {
+export class MainThreadDataExplorer implements MainThreadDataExplorerShape, IDataExplorerRpcTransport {
 
 	private readonly _proxy: ExtHostDataExplorerShape;
 	private readonly _disposables = new DisposableStore();
 
 	constructor(
 		extHostContext: IExtHostContext,
-		@IPositronDataExplorerService private readonly _dataExplorerService: IPositronDataExplorerService,
-		@IExtensionService private readonly _extensionService: IExtensionService
+		@IPositronDataExplorerService private readonly _dataExplorerService: IPositronDataExplorerService
 	) {
 		this._proxy = extHostContext.getProxy(ExtHostPositronContext.ExtHostDataExplorer);
-		// Become the transport core backends use to reach extensions for the ext host's lifetime.
+		// Register this host's transport so its provider claims are cleared if the host disconnects.
 		this._disposables.add(this._dataExplorerService.registerRpcTransport(this));
 	}
 
-	// --- IDataExplorerHostTransport ---
-
-	async activateProvider(providerId: string): Promise<void> {
-		// Backends declare `onPositronDataExplorerBackend:<providerId>` so they stay dormant until a
-		// dataset they own is accessed. Idempotent, resolves immediately once activated, and a no-op
-		// in hosts the extension isn't installed in.
-		await this._extensionService.activateByEvent(dataExplorerBackendActivationEvent(providerId));
-	}
+	// --- IDataExplorerRpcTransport ---
 
 	handleRpc(providerId: string, rpc: IDataExplorerRpcDto): Promise<IDataExplorerResponseDto> {
-		// The service activates the provider before resolving this transport, so the extension is
-		// already active here; `$handleRpc` additionally waits for the provider to register, covering
-		// the window between activation returning and the handler landing.
+		// The service resolves this transport only once the provider has registered here, so the
+		// extension is already active; `$handleRpc` also waits for the handler as a safety net.
 		return this._proxy.$handleRpc(providerId, rpc);
 	}
 

--- a/src/vs/workbench/api/test/browser/positron/mainThreadDataExplorerRouting.vitest.ts
+++ b/src/vs/workbench/api/test/browser/positron/mainThreadDataExplorerRouting.vitest.ts
@@ -41,9 +41,31 @@ const NO_FEATURES: SupportedFeatures = {
  * that registered the provider rather than whichever host connected most recently.
  */
 describe('Data Explorer RPC transport routing', () => {
+	// Provider id -> the host whose extension owns it, populated by createExtensionHost, reset per test.
+	const hostsByProvider = new Map<string, { mainThread: MainThreadDataExplorer; deferRegistration: boolean }>();
+
+	// One core extension service shared by every host, as in the real workbench: activateByEvent fans
+	// out to all hosts, and the host that owns the provider registers its handler in response -- either
+	// during activation, or a tick later when the extension awaits work inside activate().
+	const extensionService = stubInterface<IExtensionService>({
+		activateByEvent: async (event: string) => {
+			for (const [providerId, host] of hostsByProvider) {
+				if (event !== `onPositronDataExplorerBackend:${providerId}`) {
+					continue;
+				}
+				if (host.deferRegistration) {
+					void timeout(0).then(() => host.mainThread.$registerRpcHandler(providerId));
+				} else {
+					host.mainThread.$registerRpcHandler(providerId);
+				}
+			}
+		},
+	});
+
 	const ctx = createTestContainer()
 		.withReactServices()
 		.stub(IConfigurationService, new TestConfigurationService())
+		.stub(IExtensionService, extensionService)
 		.stub(IRuntimeSessionService, {
 			activeSessions: [],
 			onWillStartSession: Event.None,
@@ -56,6 +78,7 @@ describe('Data Explorer RPC transport routing', () => {
 	let service: PositronDataExplorerService;
 
 	beforeEach(() => {
+		hostsByProvider.clear();
 		// PositronDataExplorerInstance reads the singleton in its constructor.
 		PositronReactServices.services = ctx.reactServices;
 		service = ctx.disposables.add(ctx.instantiationService.createInstance(PositronDataExplorerService));
@@ -76,7 +99,7 @@ describe('Data Explorer RPC transport routing', () => {
 	/**
 	 * Stands up one extension host's MainThreadDataExplorer over the service, recording its RPCs.
 	 * @param providers Provider ids whose extensions are installed in this host; each registers its
-	 * RPC handler when activated, as the real backends do.
+	 * RPC handler when the shared extension service activates it, as the real backends do.
 	 * @param deferRegistration Register the handler after activation resolves rather than during it,
 	 * as an extension that awaits work inside `activate()` does.
 	 */
@@ -94,29 +117,11 @@ describe('Data Explorer RPC transport routing', () => {
 		const extHostContext = stubInterface<IExtHostContext>({
 			getProxy: (<T>() => proxy as T) as IExtHostContext['getProxy'],
 		});
-		// The activation stub reaches back into the customer it belongs to, which doesn't exist yet.
-		const host: { mainThread?: MainThreadDataExplorer } = {};
-		const registerAfterActivation = async (providerId: string) => {
-			await timeout(0);
-			host.mainThread?.$registerRpcHandler(providerId);
-		};
-		const extensionService = stubInterface<IExtensionService>({
-			activateByEvent: async (event: string) => {
-				// Activating a backend extension registers its RPC handler; a host that doesn't have the
-				// extension installed just resolves.
-				const providerId = providers.find(p => event === `onPositronDataExplorerBackend:${p}`);
-				if (!providerId) {
-					return;
-				}
-				if (deferRegistration) {
-					registerAfterActivation(providerId);
-				} else {
-					host.mainThread?.$registerRpcHandler(providerId);
-				}
-			},
-		});
-		host.mainThread = ctx.disposables.add(new MainThreadDataExplorer(extHostContext, service, extensionService));
-		return { mainThread: host.mainThread, calls };
+		const mainThread = ctx.disposables.add(new MainThreadDataExplorer(extHostContext, service));
+		for (const providerId of providers) {
+			hostsByProvider.set(providerId, { mainThread, deferRegistration });
+		}
+		return { mainThread, calls };
 	}
 
 	it('sends RPCs to the host that registered the provider, not the host that connected last', async () => {

--- a/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService.ts
@@ -8,7 +8,7 @@ import { IDisposable } from '../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IPositronDataExplorerInstance } from './positronDataExplorerInstance.js';
-import { IDataExplorerHostTransport, IDataExplorerUiEventDto } from '../../common/dataExplorerRpcTransport.js';
+import { IDataExplorerRpcTransport, IDataExplorerUiEventDto } from '../../common/dataExplorerRpcTransport.js';
 
 // Create the decorator for the Positron data explorer service (used in dependency injection).
 export const IPositronDataExplorerService = createDecorator<IPositronDataExplorerService>('positronDataExplorerService');
@@ -101,7 +101,7 @@ export interface IPositronDataExplorerService {
 	 * @param transport The transport.
 	 * @returns A disposable that unregisters the transport and any providers it owns.
 	 */
-	registerRpcTransport(transport: IDataExplorerHostTransport): IDisposable;
+	registerRpcTransport(transport: IDataExplorerRpcTransport): IDisposable;
 
 	/**
 	 * Records that a provider's RPC handler registered in `transport`'s extension host, so RPCs for
@@ -109,14 +109,14 @@ export interface IPositronDataExplorerService {
 	 * @param providerId The provider id (e.g. 'positron-duckdb').
 	 * @param transport The transport for the host the handler registered in.
 	 */
-	registerRpcProvider(providerId: string, transport: IDataExplorerHostTransport): void;
+	registerRpcProvider(providerId: string, transport: IDataExplorerRpcTransport): void;
 
 	/**
 	 * Undoes {@link registerRpcProvider}. Ignored if another host now owns the provider.
 	 * @param providerId The provider id.
 	 * @param transport The transport that previously registered it.
 	 */
-	unregisterRpcProvider(providerId: string, transport: IDataExplorerHostTransport): void;
+	unregisterRpcProvider(providerId: string, transport: IDataExplorerRpcTransport): void;
 
 	/**
 	 * Routes a frontend UI event from a backend-providing extension to the matching backend.

--- a/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService.ts
@@ -96,12 +96,14 @@ export interface IPositronDataExplorerService {
 	openWithExtensionBackend(payload: OpenExtensionBackendPayload): Promise<void>;
 
 	/**
-	 * Registers the transport core backends use to reach backend-providing extensions. Called by
-	 * the main-thread Data Explorer channel actor, once per extension host.
-	 * @param transport The transport.
-	 * @returns A disposable that unregisters the transport and any providers it owns.
+	 * Ties a host's provider claims to its connection. There is nothing to record up front -- a host
+	 * matters only once it claims a provider via {@link registerRpcProvider} -- so disposing the
+	 * result is the point: it drops any claims still routed to the host, stopping its RPCs when it
+	 * disconnects. Called by the main-thread Data Explorer channel actor, once per extension host.
+	 * @param transport The host's transport.
+	 * @returns A disposable that drops the host's remaining provider claims.
 	 */
-	registerRpcTransport(transport: IDataExplorerRpcTransport): IDisposable;
+	registerRpcHost(transport: IDataExplorerRpcTransport): IDisposable;
 
 	/**
 	 * Records that a provider's RPC handler registered in `transport`'s extension host, so RPCs for

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
@@ -257,13 +257,12 @@ export class PositronDataExplorerService extends Disposable implements IPositron
 	}
 
 	/**
-	 * Registers the transport that core Data Explorer backends use to reach backend-providing
-	 * extensions. Called by MainThreadDataExplorer for the extension host's lifetime, so one
-	 * transport is registered per host.
-	 * @param transport The transport.
-	 * @returns A disposable that unregisters the transport and any providers it owns.
+	 * Ties a host's provider claims to its connection. Called by MainThreadDataExplorer for the
+	 * extension host's lifetime.
+	 * @param transport The host's transport.
+	 * @returns A disposable that drops the host's remaining provider claims.
 	 */
-	registerRpcTransport(transport: IDataExplorerRpcTransport): IDisposable {
+	registerRpcHost(transport: IDataExplorerRpcTransport): IDisposable {
 		// Nothing to record up front: a host is only interesting once it claims a provider. Disposal
 		// drops any claims it still owns, so a disconnecting host stops receiving RPCs.
 		return toDisposable(() => {

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
@@ -20,7 +20,8 @@ import { IPositronDataExplorerInstance } from './interfaces/positronDataExplorer
 import { DataExplorerBackendRequest, PositronDataExplorerComm } from '../../languageRuntime/common/positronDataExplorerComm.js';
 import { PositronDataExplorerDuckDBBackend } from '../common/positronDataExplorerDuckDBBackend.js';
 import { PositronDataExplorerExtensionBackend } from '../common/positronDataExplorerExtensionBackend.js';
-import { IDataExplorerHostTransport, IDataExplorerRpcTransport, IDataExplorerUiEventDto } from '../common/dataExplorerRpcTransport.js';
+import { IDataExplorerRpcTransport, IDataExplorerUiEventDto } from '../common/dataExplorerRpcTransport.js';
+import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { URI } from '../../../../base/common/uri.js';
 import { RuntimeState } from '../../languageRuntime/common/languageRuntimeService.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
@@ -135,6 +136,15 @@ class DataExplorerRuntime extends Disposable {
 const PROVIDER_REGISTRATION_TIMEOUT_MS = 30_000;
 
 /**
+ * Activation event a Data Explorer backend extension declares so it activates lazily when a dataset
+ * it owns is first accessed. The provider id is the suffix, e.g.
+ * `onPositronDataExplorerBackend:positron-duckdb`.
+ */
+function dataExplorerBackendActivationEvent(providerId: string): string {
+	return `onPositronDataExplorerBackend:${providerId}`;
+}
+
+/**
  * PositronDataExplorerService class.
  */
 export class PositronDataExplorerService extends Disposable implements IPositronDataExplorerService {
@@ -170,16 +180,11 @@ export class PositronDataExplorerService extends Disposable implements IPositron
 	>();
 
 	/**
-	 * The transports that reach backend-providing extensions, one per extension host, registered by
-	 * MainThreadDataExplorer. The web workbench has two: the web-worker host and the remote host.
-	 */
-	private readonly _rpcTransports = new Set<IDataExplorerHostTransport>();
-
-	/**
 	 * The transport for the extension host each provider's RPC handler registered in. A provider only
-	 * ever exists in one host (positron-duckdb is native, so it is always the remote one in web).
+	 * ever exists in one host (positron-duckdb is native, so it is always the remote one in web). This
+	 * is the routing table: a host announces its providers as they register, and RPCs go to the owner.
 	 */
-	private readonly _providerTransports = new Map<string, IDataExplorerHostTransport>();
+	private readonly _providerTransports = new Map<string, IDataExplorerRpcTransport>();
 
 	/**
 	 * Fires the provider id whenever a host claims one, so a resolution in flight can pick up a
@@ -216,6 +221,7 @@ export class PositronDataExplorerService extends Disposable implements IPositron
 	constructor(
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IEditorService private readonly _editorService: IEditorService,
+		@IExtensionService private readonly _extensionService: IExtensionService,
 		@ILogService private readonly _logService: ILogService,
 		@INotificationService private readonly _notificationService: INotificationService,
 		@IRuntimeSessionService private readonly _runtimeSessionService: IRuntimeSessionService
@@ -257,10 +263,10 @@ export class PositronDataExplorerService extends Disposable implements IPositron
 	 * @param transport The transport.
 	 * @returns A disposable that unregisters the transport and any providers it owns.
 	 */
-	registerRpcTransport(transport: IDataExplorerHostTransport): IDisposable {
-		this._rpcTransports.add(transport);
+	registerRpcTransport(transport: IDataExplorerRpcTransport): IDisposable {
+		// Nothing to record up front: a host is only interesting once it claims a provider. Disposal
+		// drops any claims it still owns, so a disconnecting host stops receiving RPCs.
 		return toDisposable(() => {
-			this._rpcTransports.delete(transport);
 			for (const [providerId, registered] of this._providerTransports) {
 				if (registered === transport) {
 					this._providerTransports.delete(providerId);
@@ -274,7 +280,7 @@ export class PositronDataExplorerService extends Disposable implements IPositron
 	 * @param providerId The provider id.
 	 * @param transport The transport for that host.
 	 */
-	registerRpcProvider(providerId: string, transport: IDataExplorerHostTransport): void {
+	registerRpcProvider(providerId: string, transport: IDataExplorerRpcTransport): void {
 		this._providerTransports.set(providerId, transport);
 		this._onDidRegisterRpcProviderEmitter.fire(providerId);
 	}
@@ -284,7 +290,7 @@ export class PositronDataExplorerService extends Disposable implements IPositron
 	 * @param providerId The provider id.
 	 * @param transport The transport that previously registered it.
 	 */
-	unregisterRpcProvider(providerId: string, transport: IDataExplorerHostTransport): void {
+	unregisterRpcProvider(providerId: string, transport: IDataExplorerRpcTransport): void {
 		if (this._providerTransports.get(providerId) === transport) {
 			this._providerTransports.delete(providerId);
 		}
@@ -488,18 +494,15 @@ export class PositronDataExplorerService extends Disposable implements IPositron
 	}
 
 	/**
-	 * Resolves the transport for the extension host that can service `providerId`. Activating the
-	 * provider in every host is what identifies the owner: only the host the extension is installed
-	 * in does anything, and it registers its handler as it activates.
+	 * Resolves the transport for the extension host that can service `providerId`, activating the
+	 * provider if no host has claimed it yet. `activateByEvent` fans out to every extension host;
+	 * only the host the extension is installed in does anything, and it registers its handler as it
+	 * activates, which is what identifies the owning transport.
 	 */
-	private async _resolveRpcTransport(providerId: string): Promise<IDataExplorerHostTransport> {
+	private async _resolveRpcTransport(providerId: string): Promise<IDataExplorerRpcTransport> {
 		const registered = this._providerTransports.get(providerId);
 		if (registered) {
 			return registered;
-		}
-
-		if (this._rpcTransports.size === 0) {
-			throw new Error('The Data Explorer RPC transport is not available.');
 		}
 
 		// Subscribe before activating, so a registration that lands while activation is still settling
@@ -510,7 +513,7 @@ export class PositronDataExplorerService extends Disposable implements IPositron
 		);
 
 		try {
-			await Promise.all([...this._rpcTransports].map(transport => transport.activateProvider(providerId)));
+			await this._extensionService.activateByEvent(dataExplorerBackendActivationEvent(providerId));
 			if (!this._providerTransports.has(providerId)) {
 				await raceTimeout(registration, PROVIDER_REGISTRATION_TIMEOUT_MS);
 			}

--- a/src/vs/workbench/services/positronDataExplorer/common/dataExplorerRpcTransport.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/dataExplorerRpcTransport.ts
@@ -37,7 +37,9 @@ export interface IDataExplorerUiEventDto {
 }
 
 /**
- * The transport a core Data Explorer backend uses to reach the providing extension.
+ * One extension host's transport to its backend-providing extensions, implemented by
+ * `MainThreadDataExplorer`. There is one per host, so a web workbench with a web-worker and a remote
+ * host has two, and only one of them has any given provider.
  */
 export interface IDataExplorerRpcTransport {
 	/**
@@ -54,19 +56,4 @@ export interface IDataExplorerRpcTransport {
 	 * @param datasetId The dataset identifier (the RPC `uri`) that was closed.
 	 */
 	disposeBackend(providerId: string, datasetId: string): void;
-}
-
-/**
- * One extension host's transport, implemented by `MainThreadDataExplorer`. There is one per host, so
- * a web workbench with a web-worker and a remote host has two, and only one of them has any given
- * provider.
- */
-export interface IDataExplorerHostTransport extends IDataExplorerRpcTransport {
-	/**
-	 * Activates the extension providing `providerId` in this host, if it runs here. Resolves without
-	 * doing anything in a host the extension isn't installed in, so calling it on every host is how
-	 * the owner of a provider is found.
-	 * @param providerId The provider to activate (e.g. 'positron-duckdb').
-	 */
-	activateProvider(providerId: string): Promise<void>;
 }

--- a/src/vs/workbench/services/positronDataExplorer/common/dataExplorerRpcTransport.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/dataExplorerRpcTransport.ts
@@ -37,9 +37,10 @@ export interface IDataExplorerUiEventDto {
 }
 
 /**
- * One extension host's transport to its backend-providing extensions, implemented by
- * `MainThreadDataExplorer`. There is one per host, so a web workbench with a web-worker and a remote
- * host has two, and only one of them has any given provider.
+ * The transport a core Data Explorer backend uses to reach the extension providing its dataset. Two
+ * things implement it: `MainThreadDataExplorer`, one per extension host, which forwards each RPC over
+ * the typed ext-host channel to the providing extension; and the service's internal router, which
+ * resolves the host that owns a provider and delegates to that host's transport.
  */
 export interface IDataExplorerRpcTransport {
 	/**


### PR DESCRIPTION
This is an alternative to the routing approach in the base PR. It fixes the same bug (Data Explorer RPCs going to the wrong extension host in web), but reshapes the fix so the ext-host-facing part is reactive, like every other main-thread bridge.

The core extension service's activateByEvent already fans an activation out to every extension host, and only the host that actually has the extension responds. The base PR re-implemented that fan-out a layer up, holding a set of all host transports and calling activate on each one. Since each of those transports just forwards to the same core extension service, that loop was doing the same work twice.

So this version:

- Moves activation into the data explorer service, which asks the core extension service once instead of looping over per-host transports.
- Makes the per-host customer purely reactive. It no longer takes an extension service or knows how to activate anything; it just forwards RPCs and tells the service which providers its host owns as their handlers register.
- Drops the extra host-transport interface (and its activate method) that only existed so the service's router could avoid implementing it, plus the set of all transports.

The result is one fewer interface, one fewer method, one fewer dependency, and no hand-rolled fan-out. 
