### PR TITLE
Run the local Workbench stack (npm run pwb) on Windows x64

### DIFF
--- a/docker/environments/wb-local/README.md
+++ b/docker/environments/wb-local/README.md
@@ -11,7 +11,8 @@ pick, in one command.
   `WB_PASSWORD` if it is unset.
 - Optional: `fzf` for arrow-key pickers (without it you get a numbered prompt).
   Install with `brew install fzf` (macOS), `sudo apt install fzf` (Debian/Ubuntu),
-  or `conda install -c conda-forge fzf`.
+  `winget install junegunn.fzf` (Windows), or `conda install -c conda-forge fzf`.
+- Windows: one extra setup step, see [Windows](#windows).
 
 ## Quick start
 
@@ -27,6 +28,33 @@ pick, in one command.
 
 First run asks which Positron and Workbench you want, installs them, and brings
 the stack up. Open http://localhost:8787 and log in as `user1` and password as set in `WB_PASSWORD`.
+
+## Windows
+
+Works on Windows x64 (the same amd64 packages CI installs). Run the commands from
+PowerShell or Windows Terminal like anywhere else; the script itself executes
+under Git Bash, and you never need a Git Bash window.
+
+That last part is the one setup step. npm has to be pointed at Git Bash:
+
+```bash
+npm config set script-shell "C:\Program Files\Git\bin\bash.exe"
+```
+
+Without it npm runs scripts through `cmd.exe`, where bare `bash` resolves to
+`C:\Windows\System32\bash.exe` -- the WSL launcher -- so the script would run
+inside a Linux distro that typically has no reachable Docker daemon and no `gh`.
+It detects that case and tells you rather than failing obscurely.
+
+Two things behave differently than on macOS or Linux:
+
+- Prefer PowerShell or Windows Terminal over a mintty (Git Bash) window.
+  `npm run pwb -- shell` runs `docker exec -it`, and the `fzf` pickers both want
+  a real Windows console; mintty is not one.
+- The license files must be LF, not CRLF. Connect refuses to parse a CRLF
+  license and just answers 402 forever, and rstudio-server rejects one outright.
+  Both are staged through a CR strip now, so a license saved on Windows is
+  handled, but see [Troubleshooting](#troubleshooting) if you hit it another way.
 
 ## Commands
 
@@ -152,3 +180,13 @@ install; re-run with `--reinstall --credentials=<type>` to switch.
   versions, `down` one and bring up the other.
 - **Apple Silicon**: the Connect service runs emulated (amd64) and is slow to
   start.
+- **`dependency failed to start: container connect is unhealthy`**: usually the
+  Connect license. Connect starts either way, so check what it thinks it has:
+
+  ```bash
+  docker exec connect /opt/rstudio-connect/bin/license-manager status
+  ```
+
+  An empty "License file status" with `Has-Key: No` means the file was not parsed
+  at all, and every request answers 402. A CRLF license does exactly this (see
+  [Windows](#windows)); so does a missing or expired one.

--- a/docker/environments/wb-local/connect/.gitignore
+++ b/docker/environments/wb-local/connect/.gitignore
@@ -1,2 +1,2 @@
-# Ignore Connect license file
-connect.lic
+# Ignore Connect license file (and the temp file it is staged through)
+connect.lic*

--- a/docker/environments/wb-local/workbench-local.sh
+++ b/docker/environments/wb-local/workbench-local.sh
@@ -540,7 +540,14 @@ cmd_up() {
 		# to the same file, and leaves a half-written one behind on any failure.
 		# mktemp is 0600, and this gets bind-mounted into the connect container,
 		# which does not necessarily read it as our uid -- so set the mode.
-		local lic_tmp; lic_tmp="$(mktemp)"
+		#
+		# The temp file goes in the destination directory, not $TMPDIR: only a
+		# same-filesystem mv is an atomic rename, and /tmp is frequently a
+		# separate filesystem (tmpfs on Linux), where mv falls back to
+		# copy-then-unlink and can leave exactly the half-written license this
+		# is meant to rule out. A template with six X's satisfies both GNU and
+		# BSD mktemp. connect/ is created earlier in cmd_up.
+		local lic_tmp; lic_tmp="$(mktemp "${SCRIPT_DIR}/connect/connect.lic.XXXXXX")"
 		tr -d $'\r' < "${SCRIPT_DIR}/connect.lic" > "$lic_tmp"
 		chmod 0644 "$lic_tmp"
 		mv "$lic_tmp" "${SCRIPT_DIR}/connect/connect.lic"

--- a/docker/environments/wb-local/workbench-local.sh
+++ b/docker/environments/wb-local/workbench-local.sh
@@ -531,8 +531,19 @@ cmd_up() {
 		# you see is 'test' failing on its depends_on, which points nowhere near
 		# the license. (license-manager status shows an empty "License file
 		# status" and Has-Key: No.) tr, not `sed -i 's/\r$//'`: BSD sed on macOS
-		# reads '\r' as a literal 'r' and would eat a trailing r instead.
-		tr -d $'\r' < "${SCRIPT_DIR}/connect.lic" > "${SCRIPT_DIR}/connect/connect.lic"
+		# reads '\r' as a literal 'r' and would eat a trailing r instead. The CR
+		# is expanded by the shell, so BSD and GNU tr behave the same here.
+		#
+		# Convert through a temp file rather than redirecting onto the
+		# destination: a redirect truncates the target before tr reads a byte,
+		# which would destroy the license outright if the two paths ever resolve
+		# to the same file, and leaves a half-written one behind on any failure.
+		# mktemp is 0600, and this gets bind-mounted into the connect container,
+		# which does not necessarily read it as our uid -- so set the mode.
+		local lic_tmp; lic_tmp="$(mktemp)"
+		tr -d $'\r' < "${SCRIPT_DIR}/connect.lic" > "$lic_tmp"
+		chmod 0644 "$lic_tmp"
+		mv "$lic_tmp" "${SCRIPT_DIR}/connect/connect.lic"
 	fi
 	# 'test' depends on connect being healthy; a missing license makes connect exit
 	# and the wait loop below just times out. Warn clearly up front. (Connect's

--- a/docker/environments/wb-local/workbench-local.sh
+++ b/docker/environments/wb-local/workbench-local.sh
@@ -25,6 +25,29 @@ wb_stack_up() { wb_compose ps --services --filter status=running 2>/dev/null | g
 # Fail fast with a friendly message when a command needs a running stack.
 wb_require_stack() { wb_stack_up || { echo "Stack not running. Start with: npm run pwb" >&2; exit 1; }; }
 
+# On Windows this script is meant to run under Git Bash, which is what npm uses
+# when script-shell points at it. Run bare (`bash workbench-local.sh`) from
+# PowerShell or cmd instead and `bash` resolves to C:\Windows\System32\bash.exe --
+# the WSL launcher -- so everything below executes inside a Linux distro that
+# usually has no reachable Docker daemon (Docker Desktop's WSL integration is
+# per-distro and off by default) and no gh. The raw daemon error gives no hint
+# that the shell is the problem, so name it. A WSL setup that CAN reach Docker is
+# perfectly fine and passes straight through. Git Bash never matches: its
+# /proc/version reads "MINGW64_NT-...", not "microsoft".
+wb_check_shell() {
+	grep -qi microsoft /proc/version 2>/dev/null || return 0
+	docker info >/dev/null 2>&1 && return 0
+	echo "Docker is not reachable from this WSL distro (${WSL_DISTRO_NAME:-unknown})." >&2
+	echo "This script ran under WSL, which happens when 'bash' is invoked from PowerShell" >&2
+	echo "or cmd (System32\\bash.exe is the WSL launcher). Either:" >&2
+	echo "  - run it through npm, with npm's shell set to Git Bash:" >&2
+	echo "      npm config set script-shell \"C:\\Program Files\\Git\\bin\\bash.exe\"" >&2
+	echo "      npm run pwb" >&2
+	echo "  - or enable Docker Desktop -> Settings -> Resources -> WSL integration" >&2
+	echo "    for this distro (you will also need gh installed inside it)." >&2
+	exit 1
+}
+
 # Cancel a pending auto-stop timer from a previous run, if any.
 wb_cancel_ttl() {
 	[ -f "$WB_TTL_PIDFILE" ] || return 0
@@ -242,14 +265,32 @@ wb_bootstrap_env() {
 	export E2E_POSTGRES_USER E2E_POSTGRES_PASSWORD
 }
 
+# MSYS_NO_PATHCONV=1 on the two `docker exec`s below (and on the installer exec in
+# cmd_install): under Git Bash the MSYS runtime rewrites a bare absolute path in
+# argv into a Windows path before docker.exe sees it, so `docker exec test chmod
+# +x /tmp/x` arrives in the container as `C:/Users/.../Temp/x` and fails -- which
+# aborts the run here, right after the containers come up and before anything is
+# installed. Only args that are *whole* paths are affected, which is why the
+# `docker exec test bash -c '...'` calls elsewhere need nothing.
+#
+# Scope it to those calls; do NOT export it. `docker cp` below takes a HOST path
+# and `docker compose -f` takes the compose file, and both depend on that same
+# conversion to hand docker.exe a Windows path. The variable is meaningless off
+# Windows, so this is a no-op on Linux and macOS.
 wb_fetch_scripts() {
 	# The installer scripts live alongside this one (docker/environments/wb-local).
 	for s in "${WB_SCRIPTS[@]}"; do
 		docker cp "${WB_SCRIPTS_DIR}/${s}" "test:/tmp/${s}" >/dev/null
-		docker exec test sed -i 's/\r$//' "/tmp/${s}"
-		docker exec test chmod +x "/tmp/${s}"
+		MSYS_NO_PATHCONV=1 docker exec test sed -i 's/\r$//' "/tmp/${s}"
+		MSYS_NO_PATHCONV=1 docker exec test chmod +x "/tmp/${s}"
 	done
-	[ -f "${SCRIPT_DIR}/workbench.lic" ] && docker cp "${SCRIPT_DIR}/workbench.lic" test:/tmp/workbench.lic >/dev/null || true
+	if [ -f "${SCRIPT_DIR}/workbench.lic" ]; then
+		docker cp "${SCRIPT_DIR}/workbench.lic" test:/tmp/workbench.lic >/dev/null
+		# Same CRLF strip the scripts get above, and for the same reason a
+		# Windows-saved connect.lic needs one (see cmd_up): rstudio-server
+		# rejects a CRLF license outright.
+		MSYS_NO_PATHCONV=1 docker exec test sed -i 's/\r$//' /tmp/workbench.lic
+	fi
 }
 
 # Channel (Release/Daily) -> version list. Sets POSITRON_TAG (downloaded from
@@ -378,12 +419,14 @@ cmd_install() {
 	# real arg (not interpolated into bash -c) so it can't be word-split/injected.
 	# DOCKER_CLI_HINTS=false drops Docker's "What's next / Try Docker Debug" hint;
 	# -i (no -t) because piping the output precludes a usable container TTY.
+	# MSYS_NO_PATHCONV=1 keeps Git Bash from rewriting `/bin/bash` and the script
+	# path into Windows paths -- see the note above wb_fetch_scripts.
 	local wb_build; wb_build="$(basename "$WB_URL")"
 	# The credential vars below use the inherit form (-e VAR, no value): docker
 	# exec forwards them only when set. wb_bootstrap_env exported them by sourcing
 	# .env under `set -a`, so configure-datasources.sh (run by the installer when
 	# --credentials is passed) can read whichever set the chosen provider needs.
-	DOCKER_CLI_HINTS=false docker exec -i \
+	DOCKER_CLI_HINTS=false MSYS_NO_PATHCONV=1 docker exec -i \
 		-e GITHUB_TOKEN="${GITHUB_TOKEN}" \
 		-e WB_URL="${WB_URL}" \
 		-e POSITRON_TAG="${POSITRON_TAG}" \
@@ -482,7 +525,14 @@ cmd_up() {
 		rm -rf "${SCRIPT_DIR}/connect/connect.lic"
 	fi
 	if [ -f "${SCRIPT_DIR}/connect.lic" ]; then
-		cp "${SCRIPT_DIR}/connect.lic" "${SCRIPT_DIR}/connect/connect.lic"
+		# Strip CR on the way in. A license saved or copied on Windows arrives
+		# CRLF, and Connect then refuses to parse it at all -- it starts fine,
+		# answers 402 on every request, never goes healthy, and the only error
+		# you see is 'test' failing on its depends_on, which points nowhere near
+		# the license. (license-manager status shows an empty "License file
+		# status" and Has-Key: No.) tr, not `sed -i 's/\r$//'`: BSD sed on macOS
+		# reads '\r' as a literal 'r' and would eat a trailing r instead.
+		tr -d $'\r' < "${SCRIPT_DIR}/connect.lic" > "${SCRIPT_DIR}/connect/connect.lic"
 	fi
 	# 'test' depends on connect being healthy; a missing license makes connect exit
 	# and the wait loop below just times out. Warn clearly up front. (Connect's
@@ -690,6 +740,8 @@ EOF
 
 main() {
 	local sub="${1:-up}"; shift || true
+	# --help stays answerable without Docker; everything else needs a daemon.
+	case "$sub" in -h|--help) : ;; *) wb_check_shell ;; esac
 	case "$sub" in
 		up)          cmd_up "$@" ;;
 		# Flag-style invocations (no explicit "up") route to cmd_up with the flag.


### PR DESCRIPTION
`npm run pwb` did not work on Windows. It resolved the right packages -- x64 is
the arch CI installs, and the arm64 paths are the special-cased ones -- but the
run died in `wb_fetch_scripts`, right after the containers came up and before
anything was installed. Three host-side things were in the way. Nothing that
runs inside the containers changed, and CI never invokes `workbench-local.sh`,
so the CI lanes are untouched.

**1. Git Bash mangles container paths.** The MSYS runtime rewrites a bare
absolute path in argv into a Windows path before `docker.exe` sees it, so
`docker exec test chmod +x /tmp/x` arrived in the container as
`C:/Users/.../Temp/x`, and `docker exec test /bin/bash ...` asked for
`C:/Program Files/Git/usr/bin/bash`. `MSYS_NO_PATHCONV=1` on the three affected
calls, scoped rather than exported: `docker cp` takes a host path and
`docker compose -f` takes the compose file, and both depend on that same
conversion. The variable is meaningless off Windows, so this is inert elsewhere.

**2. A license saved on Windows arrives CRLF, and Connect then refuses to parse
it at all.** It starts, answers 402 forever, never goes healthy, and the only
visible error is `test` failing on its `depends_on` -- which points nowhere near
the license. `license-manager status` shows an empty "License file status" with
`Has-Key: No`. rstudio-server rejects a CRLF license too. Both are now staged
through a CR strip, leaving the file you dropped in untouched. The Connect one
goes through a temp file created in the destination directory so the `mv` is an
atomic same-filesystem rename.

**3. Run bare from PowerShell rather than through npm and `bash` resolves to
`System32\bash.exe`**, the WSL launcher, so the script executes in a distro that
typically has no reachable Docker daemon and no `gh`. The raw daemon error gives
no hint that the shell is the problem, so `wb_check_shell` names it. It can only
fail when Docker is already unreachable, so it cannot break a working setup --
including a WSL setup that does have Docker integration enabled.

README gets a `Windows` section (PowerShell is the preferred terminal, the one
`script-shell` setup step, the mintty caveat for `pwb -- shell` and the `fzf`
pickers) and a troubleshooting entry for the unhealthy-Connect symptom.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

Developer tooling only, under `docker/environments/wb-local`. No product code,
so no e2e tags.

Verified on Windows 11 x64, driven from PowerShell:

- A full `npm run pwb -- --workbench=daily --positron=daily` install comes up
  healthy: Workbench `2026.09.0-daily+97.pro1`, Positron `2026.09.0-124`,
  `:8787` returns 302 and `:3939` returns 307, `rserver` and the session
  launcher both running.
- CRLF licenses: with CRLF `connect.lic` and `workbench.lic` in place, the
  staged copies come out LF and `0644`, the sources are left as-is, Connect
  stays healthy, and no temp file is left behind.
- `wb_check_shell` fires when run under WSL (Docker unreachable there) and stays
  silent under Git Bash, whose `/proc/version` reads `MINGW64_NT-...`.
- `scripts/test/workbench-local-lib-test.sh` passes under Git Bash.

macOS/Linux review, since that is the path the team uses:

- Only `workbench-local.sh`, the README, and `connect/.gitignore` change. The
  container-side and CI-shared scripts (`install-workbench.sh`,
  `positronDownload.sh`, `configure-datasources.sh`, `get-latest-wb-url.sh`,
  `workbench-local-lib.sh`) are untouched.
- `wb_check_shell` returns immediately where `/proc/version` does not exist
  (`grep` exits 2), so no Docker call and no output.
- The CR strip is byte-identical on LF input (verified with `cmp`), and the CR is
  expanded by the shell, so BSD and GNU `tr` behave the same -- no host `sed`,
  whose BSD build reads `\r` as a literal `r`.
- `$'\r'` needs bash 2.0+; the script already uses `printf -v` (3.1+), so
  macOS's `/bin/bash` 3.2 is unaffected and there is no new version floor.

One behavior change worth flagging: the `workbench.lic` copy moved from
`[ -f x ] && docker cp ... || true` to `if/fi`. The `|| true` was there to stop
the `&&` chain aborting under `set -e` when the license is absent, which `if/fi`
handles structurally; a genuine `docker cp` failure now aborts instead of being
swallowed, matching the scripts loop above it.

Not verified by me: a real macOS run, and `pwb -- shell` from an interactive
console (needs a TTY). A `npm run pwb -- status` on a Mac should print exactly
what it printed before.
