### PR TITLE
Render workbench dialogs inside the open Positron modal dialog

### DIFF
--- a/src/vs/base/browser/positronModalDialogReactRenderer.tsx
+++ b/src/vs/base/browser/positronModalDialogReactRenderer.tsx
@@ -17,6 +17,7 @@ import { Disposable } from '../common/lifecycle.js';
 import { KeyCode } from '../common/keyCodes.js';
 import { StandardKeyboardEvent } from './keyboardEvent.js';
 import { PositronReactServices } from './positronReactServices.js';
+import { hostsWorkbenchDialog, releaseWorkbenchDialogs } from './positronTopLayerDialog.js';
 import { PositronReactServicesProvider } from './positronReactRendererContext.js';
 import { ResultKind } from '../../platform/keybinding/common/keybindingResolver.js';
 
@@ -145,6 +146,11 @@ export class PositronModalDialogReactRenderer extends Disposable {
 		this._eventHandlerCleanup?.();
 		this._eventHandlerCleanup = undefined;
 
+		// A workbench dialog may have been rendered inside this one so it could paint above it and
+		// stay clickable. Move it back out to the container first: it is a child of this dialog, so
+		// removing this dialog would delete it unanswered and leave its caller waiting forever.
+		releaseWorkbenchDialogs(this._dialog, this._options.container!);
+
 		// Close the dialog first, if it's open, so its focus trap is released before we restore
 		// focus.
 		if (this._dialog.open) {
@@ -235,6 +241,14 @@ export class PositronModalDialogReactRenderer extends Disposable {
 		 */
 		const keydownHandler = (e: KeyboardEvent) => {
 			const event = new StandardKeyboardEvent(e);
+			// A workbench dialog rendered inside this one handles its own Escape. Escape is a
+			// default action on a native <dialog>, so without preventing it here the browser would
+			// close this dialog and take the workbench dialog down with it, unanswered. Propagation
+			// is left alone so the workbench dialog's own handler still sees the key.
+			if (event.keyCode === KeyCode.Escape && this._dialog && hostsWorkbenchDialog(this._dialog)) {
+				e.preventDefault();
+				return;
+			}
 			const resolutionResult = PositronReactServices.services.keybindingService.softDispatch(
 				event,
 				PositronReactServices.services.workbenchLayoutService.activeContainer

--- a/src/vs/base/browser/positronTopLayerDialog.ts
+++ b/src/vs/base/browser/positronTopLayerDialog.ts
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from './dom.js';
+
+/**
+ * The class upstream's Dialog widget puts on its outermost element (see dialog.ts). Positron uses
+ * it to recognise a workbench dialog that has been parented into a Positron modal dialog.
+ */
+export const WORKBENCH_DIALOG_CLASS = 'monaco-dialog-modal-block';
+
+/**
+ * Finds the Positron modal dialog that a workbench dialog should be rendered inside, if one is
+ * open.
+ *
+ * A <dialog> opened with showModal() is promoted to the browser's top layer. Content there paints
+ * above every z-index, and everything that is not a descendant of it cannot be clicked or focused.
+ * A workbench dialog is an ordinary z-indexed element, so while a Positron modal dialog is open the
+ * only way for it to be visible and usable is to be a child of that dialog.
+ *
+ * @param container The container to search, normally the active workbench container.
+ * @returns The dialog to render into, or undefined when no Positron modal dialog is open.
+ */
+export function findTopMostPositronModalDialog(container: HTMLElement): HTMLDialogElement | undefined {
+	// Where dialogs are nested, the last one in DOM order is the one on top of the top layer, and
+	// so the only one whose descendants escape being inert.
+	// eslint-disable-next-line no-restricted-syntax -- the modal DOM is built by a separate renderer, so it must be located by selector rather than dom.ts h()
+	const dialogs = container.querySelectorAll('dialog.positron-modal-dialog[open]');
+	const topMost = dialogs.length ? dialogs[dialogs.length - 1] : undefined;
+	// The selector already pins this to a <dialog>, so the element check is only here to rule out
+	// a stray match from another document.
+	return dom.isHTMLElement(topMost) ? topMost as HTMLDialogElement : undefined;
+}
+
+/**
+ * Whether a workbench dialog is currently parented inside the given element.
+ *
+ * @param element The element to check, normally a Positron modal <dialog>.
+ * @returns True when a workbench dialog is rendered inside it.
+ */
+export function hostsWorkbenchDialog(element: HTMLElement): boolean {
+	// eslint-disable-next-line no-restricted-syntax -- the dialog DOM is built by the upstream widget, so it must be located by selector rather than dom.ts h()
+	return element.querySelector(`.${WORKBENCH_DIALOG_CLASS}`) !== null;
+}
+
+/**
+ * Moves any workbench dialogs parented inside the given element back out to a container that will
+ * outlive it. Without this, closing a Positron modal dialog would delete an unanswered workbench
+ * dialog along with it, and whoever was waiting on that dialog's answer would wait forever.
+ *
+ * @param element The element to move dialogs out of, normally a Positron modal <dialog>.
+ * @param container The container to move them to.
+ */
+export function releaseWorkbenchDialogs(element: HTMLElement, container: HTMLElement): void {
+	// eslint-disable-next-line no-restricted-syntax -- the dialog DOM is built by the upstream widget, so it must be located by selector rather than dom.ts h()
+	for (const workbenchDialog of Array.from(element.querySelectorAll(`.${WORKBENCH_DIALOG_CLASS}`))) {
+		container.appendChild(workbenchDialog);
+	}
+}

--- a/src/vs/base/browser/test/positronModalDialogReactRenderer.vitest.ts
+++ b/src/vs/base/browser/test/positronModalDialogReactRenderer.vitest.ts
@@ -6,7 +6,11 @@
 /// <reference types="vitest/globals" />
 
 import { KeyCode } from '../../common/keyCodes.js';
-import { applyModalKeydownSuppression } from '../positronModalDialogReactRenderer.js';
+import { findTopMostPositronModalDialog, WORKBENCH_DIALOG_CLASS } from '../positronTopLayerDialog.js';
+import { createElement } from 'react';
+import { createTestContainer } from '../../../test/vitest/positronTestContainer.js';
+import { PositronReactServices } from '../positronReactServices.js';
+import { applyModalKeydownSuppression, PositronModalDialogReactRenderer } from '../positronModalDialogReactRenderer.js';
 
 /** A keyboard event with only the members applyModalKeydownSuppression touches. */
 function fakeEvent(keyCode: KeyCode) {
@@ -40,5 +44,98 @@ describe('applyModalKeydownSuppression', () => {
 		applyModalKeydownSuppression('workbench.action.showCommands', event);
 		expect(event.preventDefault).toHaveBeenCalledTimes(1);
 		expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('workbench dialogs inside a Positron modal dialog', () => {
+	// Stands in for the DOM upstream's Dialog widget builds. Only the class matters here: it is how
+	// the renderer recognises a workbench dialog that has been parented into it.
+	function appendWorkbenchDialog(parent: HTMLElement) {
+		const workbenchDialog = document.createElement('div');
+		workbenchDialog.classList.add(WORKBENCH_DIALOG_CLASS);
+		parent.appendChild(workbenchDialog);
+		return workbenchDialog;
+	}
+
+	const ctx = createTestContainer().withReactServices().build();
+
+	let rendered: PositronModalDialogReactRenderer[];
+
+	beforeEach(() => {
+		// The renderer reads the services singleton in its constructor to find its container.
+		PositronReactServices.services = ctx.reactServices;
+		rendered = [];
+	});
+
+	afterEach(() => {
+		// Tear down here rather than at the end of each test. A failing assertion would skip an
+		// in-test dispose() and leave the <dialog> in the document, where the next test's
+		// querySelector would find it instead of its own.
+		rendered.forEach(renderer => renderer.dispose());
+		document.body.replaceChildren();
+		vi.restoreAllMocks();
+	});
+
+	function renderDialog(onDisposed?: () => void) {
+		const renderer = new PositronModalDialogReactRenderer({ container: document.body, onDisposed });
+		rendered.push(renderer);
+		renderer.render(createElement('div', null, 'dialog content'));
+		// eslint-disable-next-line no-restricted-syntax -- getByRole throws once a test opens a second dialog, and these tests need exactly that case
+		const dialogs = document.body.querySelectorAll('dialog');
+		const dialog = dialogs[dialogs.length - 1] as HTMLDialogElement;
+		return { renderer, dialog };
+	}
+
+	describe('findTopMostPositronModalDialog', () => {
+		it('finds nothing when no dialog is open', () => {
+			expect(findTopMostPositronModalDialog(document.body)).toBeUndefined();
+		});
+
+		it('finds the open dialog, which is where a workbench dialog has to render to be usable', () => {
+			const { dialog } = renderDialog();
+			expect(findTopMostPositronModalDialog(document.body)).toBe(dialog);
+		});
+
+		it('picks the last of several, because that is the one on top of the top layer', () => {
+			renderDialog();
+			const { dialog: second } = renderDialog();
+			expect(findTopMostPositronModalDialog(document.body)).toBe(second);
+		});
+	});
+
+	describe('Escape', () => {
+		it('closes the dialog when nothing is rendered inside it', () => {
+			const onDisposed = vi.fn();
+			renderDialog(onDisposed);
+
+			const event = new KeyboardEvent('keydown', { key: 'Escape', keyCode: 27, cancelable: true });
+			window.dispatchEvent(event);
+
+			expect(event.defaultPrevented).toBe(false);
+		});
+
+		it('is left to the workbench dialog when one is rendered inside, so both do not close at once', () => {
+			const { dialog } = renderDialog();
+			appendWorkbenchDialog(dialog);
+
+			const event = new KeyboardEvent('keydown', { key: 'Escape', keyCode: 27, cancelable: true });
+			window.dispatchEvent(event);
+
+			// preventDefault stops the browser closing this dialog, which would take the workbench
+			// dialog down with it before the user could answer it.
+			expect(event.defaultPrevented).toBe(true);
+		});
+	});
+
+	describe('disposal', () => {
+		it('moves a workbench dialog back out rather than deleting it, so its caller is not left waiting', () => {
+			const { renderer, dialog } = renderDialog();
+			const workbenchDialog = appendWorkbenchDialog(dialog);
+
+			renderer.dispose();
+
+			expect(workbenchDialog.isConnected).toBe(true);
+			expect(workbenchDialog.parentElement).toBe(document.body);
+		});
 	});
 });

--- a/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
+++ b/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
@@ -17,6 +17,9 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { IMarkdownRendererService, openLinkFromMarkdown } from '../../../../platform/markdown/browser/markdownRenderer.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { createWorkbenchDialogOptions } from './dialog.js';
+// --- Start Positron ---
+import { findTopMostPositronModalDialog } from '../../../../base/browser/positronTopLayerDialog.js';
+// --- End Positron ---
 import { IHostService } from '../../../services/host/browser/host.js';
 
 export class BrowserDialogHandler extends AbstractDialogHandler {
@@ -108,7 +111,15 @@ export class BrowserDialogHandler extends AbstractDialogHandler {
 		} : undefined;
 
 		const dialog = new Dialog(
-			this.layoutService.activeContainer,
+			// --- Start Positron ---
+			// A Positron modal <dialog> is opened with showModal(), which puts it in the browser's
+			// top layer. Anything that is not one of its descendants paints behind it and cannot be
+			// clicked or focused, so render into the dialog when one is open. Without this, an
+			// extension's sign-in consent prompt is invisible and unanswerable, and the sign-in
+			// never completes.
+			// this.layoutService.activeContainer,
+			findTopMostPositronModalDialog(this.layoutService.activeContainer) ?? this.layoutService.activeContainer,
+			// --- End Positron ---
 			message,
 			buttons,
 			createWorkbenchDialogOptions({


### PR DESCRIPTION
Addresses #15632. That issue is being done in three PRs; this is the first of them. It is groundwork, so nothing visibly changes yet. The change it unblocks is moving the Configure LLM Providers modal onto Positron's newer dialog renderer.

## The problem

Positron has two modal dialog renderers. The older one, `PositronModalReactRenderer`, draws a plain `<div>` and positions it with `z-index: 2500`, picked so VS Code's own dialogs (at 2575) land on top of it. The newer one, `PositronModalDialogReactRenderer`, draws a real `<dialog>` element and opens it by calling `showModal()`.

`showModal()` puts that dialog in the browser's **top layer**. Two things follow, and neither can be undone with CSS:

- It paints above everything else, whatever any other element's `z-index` is.
- Everything that is **not a descendant of it** becomes inert: it cannot be clicked or focused.

VS Code's dialogs on web are ordinary HTML at `z-index: 2575`, so while a Positron `<dialog>` is open they are stuck behind it and dead to input. No number is high enough, because the comparison is not happening on numbers.

The case that hits users is signing in to GitHub Copilot from a Positron dialog on a web build. VS Code shows a consent prompt ("The extension 'X' wants to sign in using Y"), the user can never reach it, and the sign-in sits on "Connecting..." forever.

SEE BEFORE SCREENSHOT FOR ILLUSTRATION OF PROBLEM

## The fix

Render the VS Code dialog **inside** the Positron dialog, so it is a child rather than a sibling.

```
before                                  after
.monaco-workbench                       .monaco-workbench
├── <dialog>            (top layer)     └── <dialog>              (top layer)
└── <div> z-index 2575  (trapped)           └── <div> z-index 2575  (visible, usable)
```

The browser decides what is inert by ancestry, so a child of the dialog never is. Inside the dialog its `z-index: 2575` puts it above the React content. Being visible and clickable falls out of where it sits in the DOM, so there is no state to keep in sync between the two renderers.

`quickInputController.ts:190` already does this to get the quick input above these dialogs. `dialogHandler.ts` takes its container as a constructor argument, so the upstream change is one expression and the rest lives in a new Positron file.

There is a way to do this without touching upstream at all: let the Positron dialog drop out of the top layer while a VS Code dialog is showing, then put it back afterwards. That was tried first, and it breaks as soon as two VS Code dialogs are waiting their turn - the second one opens with no signal for us to drop out again, so it lands underneath the Positron dialog where it cannot be answered, and the window has to be reloaded.

Two things follow from being a child:

- **Escape** would close the Positron dialog and take the VS Code dialog down with it, so while one is inside, the renderer prevents that and leaves Escape to the VS Code dialog's own handler.
- **Closing the Positron dialog** would delete the VS Code dialog with it and leave its caller waiting forever, so it is moved back out first. Nothing can trigger this today; it guards against a future caller closing the modal while a prompt is open.

Positron's own prompts do not go through VS Code's dialog service, so this change does not reach them. A follow-up PR moves those onto the same dialog element.

## Screenshots

Both clips are recorded with `dhruvi/provider-modal-dynamic-dialog` in the tree, the not-yet-merged change that puts the Configure LLM Providers modal on the newer renderer. On `main` alone there is nothing to show, because no dialog using that renderer has a VS Code dialog raised over it yet.

**BEFORE - the consent prompt is drawn behind the provider dialog, so the sign-in never completes**

https://github.com/user-attachments/assets/c5d85af2-8306-46e2-9388-e47c72626911

**AFTER - the consent prompt renders inside the provider dialog and can be answered**

https://github.com/user-attachments/assets/80363306-b168-40a2-af13-cfc4d032d4a0

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

@:modal @:assistant @:web

Testing this by hand needs to be done in a _special_ branch because this problem only appears after we switch the Configure LLM Providers modal over to the new dialog component. We need this fix first before we do the migration so we DO NOT BREAK the existing Github Copilot Oauth flow.

To test the AFTER changes, you will want to use the test branch I created called `dhruvi/yield-top-layer-demo` which refactors the Configure LLM Providers to the new dialog component AND contains the changes in this PR. Once you've got that branch checked out you can: 

1. Run a **web** build: `npm run watch-web`, then `./scripts/code-web.sh`, then open `http://localhost:8080/?tkn=dev-token`. Desktop only shows the bug if `window.dialogStyle` is set to `custom`; at the default `native` the OS draws the dialog in its own window, which the top layer does not cover.
2. Run **Positron Assistant: Configure Providers**, pick **GitHub Copilot**, and click **Sign in**.
3. The consent prompt ("The extension 'GitHub Copilot Chat' wants to sign in using GitHub") should appear **on top of** the provider dialog and be clickable. Without this change it is drawn behind it and cannot be clicked.
4. Finish the sign-in. It should complete.
5. With the consent prompt showing, press **Escape**. It should close **only** the consent prompt and leave the provider dialog open.



