### PR TITLE
Unpin starlette in e2e Python requirements

### DIFF
--- a/test/e2e/test-files/requirements.txt
+++ b/test/e2e/test-files/requirements.txt
@@ -23,12 +23,6 @@ leafmap
 matplotlib
 streamlit-aggrid
 streamlit
-# starlette 1.4.0 made `thread_minimum_size` a required keyword-only argument on
-# GZipResponder. Streamlit's _MediaAwareGZipResponder subclass does not pass it, so
-# every gzip-encoded response 500s and the Streamlit app tests fail on the platforms
-# that resolve Python deps fresh from PyPI (macOS, Windows). Remove this pin once
-# Streamlit releases the fix: https://github.com/streamlit/streamlit/pull/16344
-starlette<1.4.0
 click
 bokeh==3.8.2
 altair


### PR DESCRIPTION
Closes #15357

Removes the `starlette<1.4.0` pin from `test/e2e/test-files/requirements.txt`. The pin landed in #15356 to unblock the Streamlit `python-apps` e2e tests on macOS and Windows, which resolve Python deps fresh from PyPI on every run (Ubuntu e2e runs in a container with a pre-baked venv, so it was never affected).

Streamlit 1.62.0 (released 2026-08-19) ships the upstream fix from streamlit/streamlit#16344. The fix is not "pass `thread_minimum_size`" -- 1.62.0 drops the `_MediaAwareGZipResponder` subclass of starlette's internal `GZipResponder` entirely and wraps the stock `GZipMiddleware` instead, so the internal-API dependency that broke is gone.

### Verification

With the pin removed, `uv pip compile test/e2e/test-files/requirements.txt --python-version 3.12` resolves to `streamlit==1.62.0` and `starlette==1.6.0`. `streamlit-aggrid` 1.2.1.post2 only requires `streamlit>=1.2`, so it does not cap us to an older Streamlit.

Ran the `streamlit-py-example` fixture against that pair and polled the health endpoint the tests use, with a known-broken pair as a control:

| streamlit + starlette | `Accept-Encoding: gzip` health | plain health |
| --- | --- | --- |
| 1.62.0 + 1.6.0 | 200 | 200 |
| 1.61.0 + 1.4.0 (control) | 500 | 200 |

The control matters here. Streamlit bypasses gzip on `/` and `/static/` by design and sets `minimum_size=1000`, so a bare 200 on the health endpoint could just as easily mean the middleware never ran. The broken pair 500s on that exact endpoint, which proves the middleware does execute there, so the 200 on the fixed pair is meaningful.

Also worth noting: Streamlit 1.61.1 (published hours after #15356) caps `starlette<1.4.0` on its own, so this pin has been redundant since then and the broken combination is no longer installable.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:apps @:viewer @:win @:web

The Streamlit case in `test/e2e/tests/apps/python-apps.test.ts` is the test this pin was protecting. Confirm it passes on Windows and web, where deps resolve fresh from PyPI.

To check by hand, run the Streamlit example and hit the health endpoint *with* the gzip header -- bare `curl` omits `Accept-Encoding`, bypasses the middleware, and returns 200 even when broken:

```bash
curl -s -o /dev/null -w "%{http_code}" -H "Accept-Encoding: gzip" http://localhost:8501/_stcore/health
```
