### PR TITLE
Wait for skill root providers before reading the agent skill roots

### DIFF
--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -4241,6 +4241,10 @@ declare module 'positron' {
 		 * `SKILL.md` per subdirectory. Resolved on whichever machine the extension
 		 * host runs on, so the paths are valid for an extension reading them.
 		 *
+		 * Waits for the extensions that contribute roots to finish activating
+		 * before resolving, so an early caller does not race their registration
+		 * and see an empty list.
+		 *
 		 * @returns A Thenable resolving to absolute paths, empty when no skill
 		 * roots are registered.
 		 */

--- a/src/vs/workbench/api/browser/positron/mainThreadAiFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadAiFeatures.ts
@@ -26,6 +26,11 @@ import { PromptRenderer } from '../../../contrib/positronAssistant/browser/promp
 import { getPositronContextPrompts } from '../../../contrib/positronAssistant/browser/prompts/positronContextPrompts.js';
 import { getForegroundSessionInfo } from '../../../contrib/positronAssistant/browser/prompts/promptSessions.js';
 import * as xml from '../../../contrib/positronAssistant/common/xml.js';
+import { IExtensionService } from '../../../services/extensions/common/extensions.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { AI_ENABLED_KEY } from '../../../contrib/positronAssistant/common/positronAIConfiguration.js';
+import { AI_ENABLED_ACTIVATION_EVENT } from '../../../contrib/positronAssistant/browser/aiExtensionActivation.js';
 
 @extHostNamedCustomer(MainPositronContext.MainThreadAiFeatures)
 export class MainThreadAiFeatures extends Disposable implements MainThreadAiFeaturesShape {
@@ -46,6 +51,9 @@ export class MainThreadAiFeatures extends Disposable implements MainThreadAiFeat
 		@IFileService private readonly _fileService: IFileService,
 		@IAgentAllowedCommandsService private readonly _agentAllowedCommandsService: IAgentAllowedCommandsService,
 		@IAiProviderService private readonly _aiProviderService: IAiProviderService,
+		@IExtensionService private readonly _extensionService: IExtensionService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
 		// Create the proxy for the extension host.
@@ -294,6 +302,38 @@ export class MainThreadAiFeatures extends Disposable implements MainThreadAiFeat
 		// not observe the pre-initialization snapshot.
 		await this._aiProviderService.whenInitialized;
 		return this._aiProviderService.isEnabled(id);
+	}
+
+	/**
+	 * Activates the extensions that contribute agent skill roots and resolves once
+	 * they have finished activating, so a caller reading the roots cannot race
+	 * their registration.
+	 *
+	 * Skill roots are registered from extension activation (see the bundled
+	 * `positron-skills`), which happens on `onAiEnabled` -- fired from a
+	 * `LifecyclePhase.Eventually` contribution, so several seconds after the
+	 * extension host comes up. A consumer that reads the roots earlier than that
+	 * used to see an empty list and, because it reads them once, stay without
+	 * skills for the life of the window.
+	 *
+	 * Never rejects: a contributor that fails to activate leaves the caller with
+	 * whatever roots did register, rather than failing the read outright.
+	 *
+	 * Callers must not be extensions that themselves activate on `onAiEnabled`
+	 * and read the roots from their own `activate()`: that would wait on their
+	 * own in-flight activation. No extension does this today.
+	 */
+	async $activateSkillRootProviders(): Promise<void> {
+		// Same gate as the activation event itself: with AI off there is nothing to
+		// activate, and an unset value already reads through as the `true` default.
+		if (this._configurationService.getValue<boolean>(AI_ENABLED_KEY) !== true) {
+			return;
+		}
+		try {
+			await this._extensionService.activateByEvent(AI_ENABLED_ACTIVATION_EVENT);
+		} catch (error) {
+			this._logService.error('[MainThreadAiFeatures] Failed to activate skill root providers', error);
+		}
 	}
 
 	/**

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -446,6 +446,7 @@ export interface MainThreadAiFeaturesShape {
 	$getEnabledProviders(): Thenable<string[]>;
 	$isProviderEnabled(id: string): Thenable<boolean>;
 	$getAgentAllowedCommands(options?: { includeDisabled?: boolean }): Promise<ISerializedAgentCommand[]>;
+	$activateSkillRootProviders(): Promise<void>;
 	$validateAndExecuteCommand(
 		commandId: string,
 		args: unknown[] | undefined,

--- a/src/vs/workbench/api/common/positron/extHostAiFeatures.ts
+++ b/src/vs/workbench/api/common/positron/extHostAiFeatures.ts
@@ -205,8 +205,8 @@ export class ExtHostAiFeatures implements extHostProtocol.ExtHostAiFeaturesShape
 	/**
 	 * Skill roots registered at runtime via {@link registerAgentSkillRoot}.
 	 * Held in the extension host because both the registering extension and the
-	 * reading consumer (the assistant) live here, so no main-thread round-trip
-	 * is needed and registration is observable immediately.
+	 * reading consumer (the assistant) live here, so registration is observable
+	 * immediately once the registering extension has activated.
 	 */
 	private readonly _registeredSkillRoots = new Set<string>();
 
@@ -216,6 +216,11 @@ export class ExtHostAiFeatures implements extHostProtocol.ExtHostAiFeaturesShape
 	 * when none are registered.
 	 */
 	async getAgentSkillRoots(): Promise<string[]> {
+		// Wait for the extensions that contribute roots to finish activating before
+		// reading the set. They register from activation, which happens later than
+		// the extension host itself comes up, so an unguarded read can land first
+		// and return nothing -- and consumers typically read once per window.
+		await this._proxy.$activateSkillRootProviders();
 		return [...this._registeredSkillRoots];
 	}
 

--- a/src/vs/workbench/api/test/browser/positron/mainThreadAiFeatures.vitest.ts
+++ b/src/vs/workbench/api/test/browser/positron/mainThreadAiFeatures.vitest.ts
@@ -19,6 +19,9 @@ import { IViewsService } from '../../../../services/views/common/viewsService.js
 import { IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
 import { IAgentAllowedCommandsService } from '../../../../contrib/positronAiFeatures/common/agentAllowedCommandsService.js';
+import { IExtensionService } from '../../../../services/extensions/common/extensions.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
 import { ExtHostAiFeaturesShape } from '../../../common/positron/extHost.positron.protocol.js';
 import { MainThreadAiFeatures } from '../../../browser/positron/mainThreadAiFeatures.js';
 
@@ -43,6 +46,8 @@ describe('MainThreadAiFeatures', () => {
 	let onChangeProviderConfig: Emitter<never>;
 	let onDidChangeProviderEnablement: ReturnType<typeof vi.fn<(id: string, enabled: boolean) => void>>;
 	let getRegisteredSources: ReturnType<typeof vi.fn<() => IPositronLanguageModelSource[]>>;
+	let activateByEvent: ReturnType<typeof vi.fn<(event: string) => Promise<void>>>;
+	let aiEnabled: boolean | undefined;
 
 	/**
 	 * Constructs a MainThreadAiFeatures with the given initial catalog and returns it. The
@@ -51,6 +56,8 @@ describe('MainThreadAiFeatures', () => {
 	 */
 	async function createMainThread(initialCatalog: IResolvedProviderData[], whenInitialized: Promise<void> = Promise.resolve()): Promise<MainThreadAiFeatures> {
 		catalog = initialCatalog;
+		aiEnabled = true;
+		activateByEvent = vi.fn<(event: string) => Promise<void>>(() => Promise.resolve());
 		onDidChangeProviders = disposables.add(new Emitter<IProviderCatalogChangeData>());
 		onChangeProviderConfig = disposables.add(new Emitter<never>());
 		onDidChangeProviderEnablement = vi.fn<(id: string, enabled: boolean) => void>();
@@ -84,6 +91,9 @@ describe('MainThreadAiFeatures', () => {
 			stubInterface<IFileService>({}),
 			stubInterface<IAgentAllowedCommandsService>({}),
 			aiProviderService,
+			stubInterface<IExtensionService>({ activateByEvent }),
+			stubInterface<IConfigurationService>({ getValue: (() => aiEnabled) as IConfigurationService['getValue'] }),
+			stubInterface<ILogService>({ error: () => { } }),
 		));
 
 		// Let the whenInitialized microtask (which captures the enablement baseline) settle.
@@ -141,5 +151,27 @@ describe('MainThreadAiFeatures', () => {
 		onDidChangeProviders.fire({ catalog, enabledChanged: false, connectionChanged: true, modelsChanged: false });
 
 		expect(onDidChangeProviderEnablement).not.toHaveBeenCalled();
+	});
+	it('$activateSkillRootProviders activates the AI extensions so a roots read cannot race registration', async () => {
+		const mainThread = await createMainThread([]);
+
+		await expect(mainThread.$activateSkillRootProviders()).resolves.toBeUndefined();
+		expect(activateByEvent).toHaveBeenCalledExactlyOnceWith('onAiEnabled');
+	});
+
+	it('$activateSkillRootProviders activates nothing when AI is disabled', async () => {
+		const mainThread = await createMainThread([]);
+		aiEnabled = false;
+
+		await mainThread.$activateSkillRootProviders();
+
+		expect(activateByEvent).not.toHaveBeenCalled();
+	});
+
+	it('$activateSkillRootProviders resolves when a contributor fails to activate', async () => {
+		const mainThread = await createMainThread([]);
+		activateByEvent.mockRejectedValue(new Error('activation blew up'));
+
+		await expect(mainThread.$activateSkillRootProviders()).resolves.toBeUndefined();
 	});
 });

--- a/src/vs/workbench/api/test/common/positron/extHostAiFeatures.vitest.ts
+++ b/src/vs/workbench/api/test/common/positron/extHostAiFeatures.vitest.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { ExtHostCommands } from '../../../common/extHostCommands.js';
+import { IExtHostWorkspace } from '../../../common/extHostWorkspace.js';
+import { MainThreadAiFeaturesShape } from '../../../common/positron/extHost.positron.protocol.js';
+import { ExtHostAiFeatures } from '../../../common/positron/extHostAiFeatures.js';
+import { SingleProxyRPCProtocol } from '../testRPCProtocol.js';
+
+/**
+ * Builds an ExtHostAiFeatures whose `$activateSkillRootProviders` runs `onActivate` before
+ * resolving, standing in for the contributing extensions registering their roots from
+ * `activate()`.
+ */
+function createAiFeatures(onActivate: (aiFeatures: ExtHostAiFeatures) => void = () => { }): ExtHostAiFeatures {
+	const shape = stubInterface<MainThreadAiFeaturesShape>({
+		$activateSkillRootProviders: async () => onActivate(aiFeatures),
+	});
+	const aiFeatures = new ExtHostAiFeatures(
+		SingleProxyRPCProtocol(shape),
+		stubInterface<ExtHostCommands>({}),
+		stubInterface<IExtHostWorkspace>({}),
+	);
+	return aiFeatures;
+}
+
+describe('ExtHostAiFeatures', () => {
+	it('getAgentSkillRoots waits for the providers to activate before reading the roots', async () => {
+		// The root is registered from within the activation the read awaits, so it is only
+		// observed if the snapshot is taken after that activation completes.
+		const aiFeatures = createAiFeatures((features) => features.registerAgentSkillRoot('/skills/platform'));
+
+		expect(await aiFeatures.getAgentSkillRoots()).toEqual(['/skills/platform']);
+	});
+
+	it('registerAgentSkillRoot adds a root to later reads and its disposable removes it', async () => {
+		const aiFeatures = createAiFeatures();
+
+		const registration = aiFeatures.registerAgentSkillRoot('/skills/extension');
+		expect(await aiFeatures.getAgentSkillRoots()).toEqual(['/skills/extension']);
+
+		registration.dispose();
+		expect(await aiFeatures.getAgentSkillRoots()).toEqual([]);
+	});
+});


### PR DESCRIPTION
Agent skill roots are registered from extension activation: the bundled `positron-skills` extension activates on `onAiEnabled` -- fired from a `LifecyclePhase.Eventually` contribution -- and its `activate()` registers the root and generates the skill files. That lands several seconds after the extension host comes up.

A consumer that read the roots earlier saw an empty list. Because the assistant reads them once, when it creates the conversation host for the window, losing that race left the window without platform skills for good: the generated positron-commands skill was absent from the assistant's skill listing whenever the chat view was restored at startup, and present when the chat was opened a few seconds later.

### Summary

`getAgentSkillRoots()` now waits for the contributors instead of racing them. It awaits a new `$activateSkillRootProviders` on the main thread, which activates `onAiEnabled` and resolves once those activations complete. Since `positron-skills` awaits generation inside `activate()`, this also closes the narrower window where the root was registered but its files were not yet written.

The barrier is gated on `ai.enabled` (the same gate as the activation event) and never rejects, so a contributor that fails to activate leaves the caller with whatever roots did register rather than failing the read.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed the generated Positron commands skill being missing from the assistant when the chat view was restored at startup.

### Validation Steps

@:assistant

Automated coverage:

- `npx vitest run src/vs/workbench/api/test/common/positron/extHostAiFeatures.vitest.ts` -- `getAgentSkillRoots()` observes a root registered from within the activation it awaits (fails if the `await` is removed), plus registration/disposal of a root.
- `npx vitest run src/vs/workbench/api/test/browser/positron/mainThreadAiFeatures.vitest.ts` -- `$activateSkillRootProviders` activates `onAiEnabled` once, short-circuits when `ai.enabled` is false, and resolves when a contributor's activation throws.

Manual check for the reported symptom:

1. With the assistant chat view open, reload the window so the chat view is restored at startup (this is the case that used to lose the race).
2. Ask the assistant to list its available skills.
3. Verify the generated positron-commands skill is present. Before this change it was missing on a restored-at-startup chat view and only appeared if you closed the chat and reopened it a few seconds after launch.
4. Set `ai.enabled` to false, reload, and confirm nothing AI-related activates on account of a roots read.
