### PR TITLE
Reveal the matching line when notebook find navigates to a match

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -66,6 +66,45 @@ export interface ICellRevealOptions {
 	 * The direction of keyboard navigation (only applicable when reason is 'keyboardNavigation')
 	 */
 	direction?: CellNavigationDirection;
+	/**
+	 * Optional editor range to reveal within the cell (e.g. a find match).
+	 * When set and the cell's editor is attached, the notebook scrolls so the
+	 * range's lines are visible (centered when outside the viewport) instead
+	 * of just the cell.
+	 */
+	range?: Range;
+}
+
+/**
+ * Computes the scroll position needed to reveal a vertical pixel range inside
+ * a scroll viewport, mirroring Monaco's "reveal in center if outside viewport"
+ * behavior. `rangeTop`/`rangeBottom` are in the scrollable content's
+ * coordinate space (i.e. comparable against `scrollTop`).
+ *
+ * @returns The scrollTop that centers the range, aligned to the range top when
+ * the range is taller than the viewport, or undefined when the range is
+ * already fully visible.
+ */
+export function computeRangeRevealScrollTop(options: {
+	scrollTop: number;
+	viewportHeight: number;
+	rangeTop: number;
+	rangeBottom: number;
+}): number | undefined {
+	const { scrollTop, viewportHeight, rangeTop, rangeBottom } = options;
+
+	// Already fully visible -- don't move the viewport.
+	if (rangeTop >= scrollTop && rangeBottom <= scrollTop + viewportHeight) {
+		return undefined;
+	}
+
+	// A range taller than the viewport can't be centered; show its start.
+	if (rangeBottom - rangeTop > viewportHeight) {
+		return Math.max(0, rangeTop);
+	}
+
+	// Center the range in the viewport.
+	return Math.max(0, (rangeTop + rangeBottom - viewportHeight) / 2);
 }
 
 export abstract class PositronNotebookCellGeneral extends Disposable implements IPositronNotebookCell {
@@ -491,6 +530,18 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 			return false;
 		}
 
+		// Line-level reveal: when a range is provided and the editor is
+		// attached, scroll the notebook so the range's lines are visible
+		// rather than just the cell. Cell editors auto-grow to fit their
+		// content and never scroll internally, so the cells container is the
+		// only viewport that can bring a specific line into view (e.g. a find
+		// match deep inside a cell taller than the viewport).
+		const editor = this.currentEditor;
+		if (resolvedOptions.range && editor && editor.hasModel()) {
+			this._revealEditorRange(editor, resolvedOptions.range);
+			return true;
+		}
+
 		// Two scroll strategies depending on how the reveal was triggered:
 		//
 		// Keyboard navigation uses an instant jump. The user is driving the
@@ -526,6 +577,38 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		}
 
 		return true;
+	}
+
+	/**
+	 * Scrolls the cells container so the given editor range is visible,
+	 * centering it when it is outside the viewport.
+	 */
+	private _revealEditorRange(editor: ICodeEditor, range: Range): void {
+		const container = this._instance.cellsContainer;
+		if (!container) {
+			return;
+		}
+
+		// Top of the editor within the scrollable content of the cells container.
+		const editorTop = editor.getContainerDomNode().getBoundingClientRect().top
+			- container.getBoundingClientRect().top
+			+ container.scrollTop;
+
+		// The editor is sized to its content so its own scroll offset is
+		// normally zero; subtract it anyway to stay correct if the editor ever
+		// scrolls internally.
+		const rangeTop = editorTop + editor.getTopForLineNumber(range.startLineNumber) - editor.getScrollTop();
+		const rangeBottom = editorTop + editor.getBottomForLineNumber(range.endLineNumber) - editor.getScrollTop();
+
+		const scrollTop = computeRangeRevealScrollTop({
+			scrollTop: container.scrollTop,
+			viewportHeight: container.clientHeight,
+			rangeTop,
+			rangeBottom,
+		});
+		if (scrollTop !== undefined) {
+			container.scrollTo({ top: scrollTop, behavior: 'smooth' });
+		}
 	}
 
 	async highlightTemporarily(operationType?: 'add' | 'delete' | 'modify', maxWaitMs?: number): Promise<boolean> {

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/find/controller.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/find/controller.ts
@@ -3,7 +3,8 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable, DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
+import { ICodeEditor } from '../../../../../../editor/browser/editorBrowser.js';
 import { CONTEXT_FIND_INPUT_FOCUSED, CONTEXT_FIND_WIDGET_VISIBLE, CONTEXT_REPLACE_INPUT_FOCUSED } from '../../../../../../editor/contrib/find/browser/findModel.js';
 import { localize } from '../../../../../../nls.js';
 import { IPositronNotebookInstance } from '../../IPositronNotebookInstance.js';
@@ -90,6 +91,13 @@ export class PositronNotebookFindController extends Disposable implements IPosit
 	}, 20));
 
 	private readonly _notebookModelDisposables = this._register(new DisposableStore());
+
+	/**
+	 * Watches for a match's cell editor to attach so the match selection and
+	 * line reveal can be applied once it does. Replaced on each navigation and
+	 * cleared when the find widget is hidden.
+	 */
+	private readonly _pendingMatchReveal = this._register(new MutableDisposable());
 
 	constructor(
 		private readonly _notebook: IPositronNotebookInstance,
@@ -221,6 +229,7 @@ export class PositronNotebookFindController extends Disposable implements IPosit
 					replaceInputFocused.reset();
 
 					// Clear state
+					this._pendingMatchReveal.clear();
 					transaction((tx) => {
 						this._matches.set([], tx);
 						this._currentMatch.set(undefined, tx);
@@ -509,21 +518,10 @@ export class PositronNotebookFindController extends Disposable implements IPosit
 		}
 
 		const cellMatch = cellMatches[matchIndex];
-		const { cell, cellRange } = cellMatch;
 
-		// Select the cell and reveal it
-		this._notebook.selectionStateMachine.selectCell(cell);
-		this._notebook.revealInCenterIfOutsideViewport(cell).catch((error) => {
-			this._logService.error('Error revealing cell for find match:', error);
-		});
-
-		// Select the match in the editor
-		if (cell.currentEditor) {
-			// Set the selection to the match range
-			cell.currentEditor.setSelection(cellRange.range);
-			// Reveal the range in the editor
-			cell.currentEditor.revealRangeInCenter(cellRange.range);
-		}
+		// Select the cell and reveal the match
+		this._notebook.selectionStateMachine.selectCell(cellMatch.cell);
+		this._revealMatch(cellMatch);
 
 		transaction((tx) => {
 			// Update the match index
@@ -531,6 +529,49 @@ export class PositronNotebookFindController extends Disposable implements IPosit
 
 			// Update current match tracking
 			this._currentMatch.set({ cellMatch, matchIndex: matchIndex }, tx);
+		});
+	}
+
+	/**
+	 * Selects the match in the cell's editor and scrolls the notebook so the
+	 * match's line is visible. Cells whose editor is not attached yet (e.g. a
+	 * rendered markdown cell, or a code cell React has not mounted) are
+	 * revealed at cell granularity now, and the selection + line reveal are
+	 * applied once the editor attaches.
+	 */
+	private _revealMatch(cellMatch: PositronCellFindMatch): void {
+		const { cell, cellRange } = cellMatch;
+
+		const applyEditorReveal = (editor: ICodeEditor) => {
+			// Select the match and reveal its line within the notebook viewport
+			editor.setSelection(cellRange.range);
+			cell.reveal({ reason: 'programmatic', range: cellRange.range }).catch((error) => {
+				this._logService.error('Error revealing find match:', error);
+			});
+		};
+
+		const editor = cell.currentEditor;
+		if (editor) {
+			this._pendingMatchReveal.clear();
+			applyEditorReveal(editor);
+			return;
+		}
+
+		// No editor yet: reveal the cell itself now, then apply the selection
+		// and line reveal once the editor attaches.
+		cell.reveal({ reason: 'programmatic' }).catch((error) => {
+			this._logService.error('Error revealing cell for find match:', error);
+		});
+		this._pendingMatchReveal.value = autorun(reader => {
+			const attachedEditor = cell.editor.read(reader);
+			if (!attachedEditor) {
+				return;
+			}
+			// Skip if navigation moved on to another match while waiting.
+			// Untracked read: navigation changes must not re-trigger this autorun.
+			if (this._currentMatch.read(undefined)?.cellMatch === cellMatch) {
+				applyEditorReveal(attachedEditor);
+			}
 		});
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronNotebookFind.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronNotebookFind.vitest.ts
@@ -464,40 +464,46 @@ describe('PositronNotebookFindController', () => {
 			expect(getCellSelection(notebook.cells.get()[0])).toEqual([3, 1, 3, 7]);
 		});
 
-		it('navigating to a match requests an editor reveal of the match line', () => {
+		// Cell editors auto-grow to fit their content and never scroll
+		// internally, so a Monaco-level reveal can't bring a match line into
+		// view. The reveal must go through cell.reveal() with the match range
+		// so the notebook's scroll container scrolls to the line instead
+		// (https://github.com/posit-dev/positron/issues/14130).
+		it('navigating to a match requests a cell reveal of the match range', () => {
 			const { notebook, controller, find } = findFixture([
 				['line one\nline two\ntarget here', 'python', CellKind.Code],
 			]);
-			const revealSpy = vi.spyOn(notebook.cells.get()[0].currentEditor!, 'revealRangeInCenter');
+			const revealSpy = vi.spyOn(notebook.cells.get()[0], 'reveal');
 			find.searchString.set('target', undefined);
 
 			controller.findNext();
 
-			expect(revealSpy).toHaveBeenCalledWith(expect.objectContaining({ startLineNumber: 3 }));
+			expect(revealSpy).toHaveBeenCalledWith(expect.objectContaining({
+				range: expect.objectContaining({ startLineNumber: 3 }),
+			}));
 		});
 
-		it('navigating to a match in another cell requests a cell reveal', () => {
+		it('navigating to a match in another cell requests a reveal of that cell', () => {
 			const { notebook, controller, find } = findFixture([
 				['alpha', 'python', CellKind.Code],
 				['target', 'python', CellKind.Code],
 			]);
-			const revealSpy = vi.spyOn(notebook, 'revealInCenterIfOutsideViewport');
+			const revealSpy = vi.spyOn(notebook.cells.get()[1], 'reveal');
 			find.searchString.set('target', undefined);
 
 			controller.findNext();
 
-			expect(revealSpy).toHaveBeenCalledWith(notebook.cells.get()[1]);
+			expect(revealSpy).toHaveBeenCalledWith(expect.objectContaining({
+				range: expect.objectContaining({ startLineNumber: 1 }),
+			}));
 		});
 
-		// https://github.com/posit-dev/positron/issues/14130: find jumps to the
-		// right cell but not the matching line. `navigateToMatch()` only sets the
-		// selection and reveals the line when the cell already has an attached
-		// editor; for a cell whose editor attaches late (e.g. it was outside the
-		// viewport when the search navigated to it), the line reveal is skipped
-		// and never retried. These tests document the expected behavior and are
-		// marked `fails` until the bug is fixed -- flip them to `it` then.
+		// https://github.com/posit-dev/positron/issues/14130: for a cell whose
+		// editor attaches late (e.g. a rendered markdown cell, or a code cell
+		// React has not mounted yet), the selection and line reveal must be
+		// applied once the editor becomes available.
 
-		it.fails('applies the match selection once a late-attaching editor attaches', () => {
+		it('applies the match selection once a late-attaching editor attaches', () => {
 			const { notebook, controller, find } = findFixture([
 				['alpha', 'python', CellKind.Code],
 				['line one\nline two\ntarget here', 'python', CellKind.Code],
@@ -513,21 +519,41 @@ describe('PositronNotebookFindController', () => {
 			expect(getCellSelection(cell)).toEqual([3, 1, 3, 7]);
 		});
 
-		it.fails('requests an editor reveal once a late-attaching editor attaches', () => {
+		it('requests an editor reveal once a late-attaching editor attaches', () => {
 			const { notebook, controller, find } = findFixture([
 				['alpha', 'python', CellKind.Code],
 				['line one\nline two\ntarget here', 'python', CellKind.Code],
 			]);
 			const cell = notebook.cells.get()[1];
 			const editor = cell.currentEditor!;
-			const revealSpy = vi.spyOn(editor, 'revealRangeInCenter');
+			const revealSpy = vi.spyOn(cell, 'reveal');
 			cell.detachEditor();
 
 			find.searchString.set('target', undefined);
 			controller.findNext();
+			revealSpy.mockClear(); // Ignore the cell-granularity reveal that runs before the editor attaches
 			cell.attachEditor(editor);
 
-			expect(revealSpy).toHaveBeenCalledWith(expect.objectContaining({ startLineNumber: 3 }));
+			expect(revealSpy).toHaveBeenCalledWith(expect.objectContaining({
+				range: expect.objectContaining({ startLineNumber: 3 }),
+			}));
+		});
+
+		it('does not apply a stale selection when navigation moved on before the editor attached', () => {
+			const { notebook, controller, find } = findFixture([
+				['line one\nline two\ntarget here', 'python', CellKind.Code],
+				['target', 'python', CellKind.Code],
+			]);
+			const cell = notebook.cells.get()[0];
+			const editor = cell.currentEditor!;
+			cell.detachEditor();
+
+			find.searchString.set('target', undefined);
+			controller.findNext(); // match 0 (cell 0, editor detached -- reveal pending)
+			controller.findNext(); // match 1 (cell 1) -- match 0 is now stale
+			cell.attachEditor(editor);
+
+			expect(getCellSelection(cell), 'stale pending reveal must not select the old match').toEqual([1, 1, 1, 1]);
 		});
 
 	});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.vitest.ts
@@ -15,6 +15,7 @@ import { TestConfigurationService } from '../../../../../platform/configuration/
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { DATA_EXPLORER_MIME_TYPE } from '../../browser/getOutputContents.js';
 import { POSITRON_NOTEBOOK_INLINE_DATA_EXPLORER_ENABLED_KEY } from '../../common/positronNotebookConfig.js';
+import { computeRangeRevealScrollTop } from '../../browser/PositronNotebookCells/PositronNotebookCell.js';
 
 describe('PositronNotebookCell', () => {
 	const ctx = createTestContainer().withNotebookEditorServices().build();
@@ -314,6 +315,53 @@ describe('PositronNotebookCell tags', () => {
 		notebook.toggleCellTagsHidden();
 		expect(cell.tagUIVisible.get()).toBe(false);
 		expect(cell.tags.get()).toEqual(['tag']);
+	});
+});
+
+describe('computeRangeRevealScrollTop', () => {
+	it('returns undefined when the range is already fully visible', () => {
+		expect(computeRangeRevealScrollTop({
+			scrollTop: 100, viewportHeight: 500, rangeTop: 200, rangeBottom: 220,
+		})).toBe(undefined);
+	});
+
+	it('returns undefined when the range exactly spans the viewport edges', () => {
+		expect(computeRangeRevealScrollTop({
+			scrollTop: 100, viewportHeight: 500, rangeTop: 100, rangeBottom: 600,
+		})).toBe(undefined);
+	});
+
+	it('centers a range below the viewport', () => {
+		// Range center is 2010; viewport height 500 -> scrollTop 2010 - 250 = 1760
+		expect(computeRangeRevealScrollTop({
+			scrollTop: 0, viewportHeight: 500, rangeTop: 2000, rangeBottom: 2020,
+		})).toBe(1760);
+	});
+
+	it('centers a range above the viewport', () => {
+		// Range center is 60; viewport height 500 -> centering would need -190, clamped to 0
+		expect(computeRangeRevealScrollTop({
+			scrollTop: 1000, viewportHeight: 500, rangeTop: 50, rangeBottom: 70,
+		})).toBe(0);
+	});
+
+	it('centers a partially visible range at the bottom edge', () => {
+		// Range [590, 610] straddles the bottom edge of viewport [100, 600]
+		expect(computeRangeRevealScrollTop({
+			scrollTop: 100, viewportHeight: 500, rangeTop: 590, rangeBottom: 610,
+		})).toBe(350);
+	});
+
+	it('aligns to the range top when the range is taller than the viewport', () => {
+		expect(computeRangeRevealScrollTop({
+			scrollTop: 0, viewportHeight: 500, rangeTop: 2000, rangeBottom: 2800,
+		})).toBe(2000);
+	});
+
+	it('never returns a negative scrollTop', () => {
+		expect(computeRangeRevealScrollTop({
+			scrollTop: 500, viewportHeight: 800, rangeTop: 10, rangeBottom: 30,
+		})).toBe(0);
 	});
 });
 


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/14130

### Summary

In the Positron Notebook Editor, find/replace navigation jumped to the correct cell but not to the matching line: with a cell taller than the viewport, the active match could stay off-screen. Three things conspired:

- Cell editors auto-grow to fit their content (`CellEditorMonacoWidget` lays the editor out at its content height), so the editor never scrolls internally and the `editor.revealRangeInCenter()` call in `navigateToMatch()` could not move anything.
- The notebook-level reveal was cell-granularity only: `cell.reveal()` scrolls the cell's container into view (`scrollIntoView({ block: 'center' })`), which for an oversized cell shows the middle of the cell regardless of where the match is.
- For a cell whose editor was not attached yet (e.g. a rendered markdown cell), the selection and reveal were skipped entirely and never retried (documented by the two `it.fails` tests added in #14214).

The fix reveals at line granularity through the notebook's scroll container, which is the only viewport that can bring a line into view:

- `ICellRevealOptions` gains an optional `range`. When set and the cell's editor is attached, `cell.reveal()` computes the match lines' pixel range within the cells container (editor DOM offset + `getTopForLineNumber`/`getBottomForLineNumber`) and scrolls so the range is centered when outside the viewport, mirroring Monaco's "reveal in center if outside viewport" behavior. The viewport math lives in an exported pure function, `computeRangeRevealScrollTop`.
- The find controller's `navigateToMatch()` now selects the match and calls `cell.reveal()` with the match range. When the editor is not attached yet, it reveals the cell immediately and applies the selection + line reveal once the editor attaches (one pending watcher, staleness-guarded, replaced on each navigation and cleared on hide).

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Positron Notebooks: find/replace now scrolls to the matching line within a cell, not just to the cell (#14130)

### Validation Steps

@:positron-notebooks @:web @:win

Viewport geometry isn't observable in the unit-test DOM, so the scroll math is unit-tested as a pure function and the wiring via reveal/selection contracts (the two `it.fails` tests from #14214 are flipped to passing). Manual verification (repro from #14130):

1. Open `qa-example-content/workspaces/pokemon/ds-workflow1.ipynb` in the Positron Notebook Editor.
2. Scroll so that the first `base_total_arr` in the long "4. Feature Engineering" code cell is off-screen but a later instance is visible.
3. Cmd/Ctrl+F, search `base_total_arr`, and navigate with the up/down arrows: each navigation should scroll the matching line into view (centered) with the match selected, including inside cells taller than the viewport.
4. Matches in rendered markdown cells still reveal the cell; the line reveal applies once the cell's editor opens.
