### PR TITLE
Build e2e macOS Electron for the target arch, not always x64

### DIFF
--- a/.github/workflows/release-screenshots.yml
+++ b/.github/workflows/release-screenshots.yml
@@ -168,7 +168,7 @@ jobs:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
         run: |
           npm ci --fetch-timeout 120000
-          npm exec -- npm-run-all --max-old-space-size=8192 -p compile "electron x64"
+          npm exec -- npm-run-all --max-old-space-size=8192 -p compile "electron arm64"
           npm run prelaunch
 
       - name: Pre-warm matplotlib font cache

--- a/.github/workflows/test-e2e-macos-build.yml
+++ b/.github/workflows/test-e2e-macos-build.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           npm_config_arch: ${{ inputs.arch }}
         run: |
-          npm exec -- npm-run-all --max-old-space-size=8192 -p compile "electron x64"
+          npm exec -- npm-run-all --max-old-space-size=8192 -p compile "electron ${{ inputs.arch }}"
 
       - name: Download built-in extensions (prelaunch)
         run: |


### PR DESCRIPTION
## Summary

All four `macos-arm64` e2e shards fail on whichever test launches the app first,
with:

```
Failed to launch Electron within 60000ms. The Electron process likely crashed or
hung during startup ... Original error: electronApplication.waitForEvent: Target
page, context or browser has been closed
```

The macOS e2e build job sets `npm_config_arch` from its `arch` input (default
`arm64`), so `npm ci` compiles native modules for arm64 -- but it then hardcodes
`electron x64`. On the arm64 lane that ships arm64 native modules inside an x64
Electron shell, and every native module load fails the dlopen arch check.

## Root cause

Reproduced locally by running `bootstrap-extensions.test.ts` against the
`positron-build-macos-arm64` artifact from
[run 32488856620](https://github.com/posit-dev/positron/actions/runs/32488856620/job/96796788274),
then launching the app by hand with the same argv:

```
Error: dlopen(.../node_modules/@vscode/policy-watcher/build/Release/vscode-policy-watcher.node, 0x0001):
  (mach-o file, but is an incompatible architecture (have 'arm64', need 'x86_64'))
    at NativePolicyService._updatePolicyDefinitions (out/vs/platform/policy/node/nativePolicyService.js:26)
    at PolicyConfiguration.initialize (out/vs/platform/configuration/common/configurations.js:113)
    at ConfigurationService.initialize (out/vs/platform/configuration/common/configurationService.js:47)
    at CodeMain.initServices (out/vs/code/electron-main/main.js:230)
    at CodeMain.startup (out/vs/code/electron-main/main.js:85)
Lifecycle#kill()
EXIT CODE: 1
```

Confirmed in the artifact itself: `Positron.app/Contents/MacOS/Positron` is
`Mach-O x86_64`, while `policy-watcher.node`, `watcher.node`, `iselevated.node`
and friends are all `arm64`.

### Why it used to pass

The mismatch has been present since `test-e2e-macos-build.yml` was added in
#13701 (2026-05-21), but it was harmless -- nothing dlopened a native module on
a fatal macOS startup path. The 1.118.0 upstream merge (#13572, 3ce43af343,
2026-05-28) added an `isMacintosh` branch instantiating `NativePolicyService` in
`electron-main/main.ts`. That import is awaited inside `initServices`, so a
latent arch mismatch became a hard startup abort.

It also explains the confusing CI signature: `playwright-electron#launch`
*succeeds* (the process starts and Playwright attaches) and then `firstWindow`
fails 1-2s later, with no minidump -- because this is a clean JS-error shutdown,
not a native crash.

## Changes

- `test-e2e-macos-build.yml`: `electron x64` -> `electron ${{ inputs.arch }}`.
- `release-screenshots.yml`: `electron x64` -> `electron arm64`. It pairs the
  same hardcoded x64 Electron with `npm_config_arch: arm64` on
  `macos-latest-xlarge`, and its comment says it mirrors
  `test-e2e-macos-build.yml`, so it would break the same way whenever
  `BUILD_FROM_SOURCE` is true.

`build/lib/electron.ts` reads the arch from `process.argv[2]` and defaults to
`process.arch`, so passing the input through is all that is needed.

I audited the remaining `electron x64` call sites (`test-unit.yml`,
`test-ext-host.yml`, `test-e2e-ubuntu.yml`, `test-e2e-windows-run.yml`) -- all
run on x64 runners, so they are correct as-is and untouched.

## Verification

Against the same arm64 artifact, swapping in an arm64 Electron
(`npm run electron -- arm64`) and re-running the test takes the app from dying
before its first window to a fully restored workbench:

```
Finished operation 'Application#checkPositronReady: wait for monaco workbench' successfully
Finished operation 'Application#checkPositronReady: wait for workbench restored' successfully
[driver] Workbench contributions created.
Language runtime ... (language: Python name: Python 3.10.12 (Pyenv)) successfully registered.
```

@:extensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
