### PR TITLE
Upstream merge from vscode-server for #15177,  #13719, #15427

### DIFF
--- a/src/server-main.ts
+++ b/src/server-main.ts
@@ -60,6 +60,13 @@ const parsedArgs = minimist(process.argv.slice(2), {
 	}
 });
 
+// --- Start PWB ---
+// Set while the graceful SIGTERM/SIGINT shutdown (installed in the server
+// branch below) owns the process exit; the exit-diagnostics signal listener
+// checks it so the two handlers do not both call process.exit.
+let shuttingDownGracefully = false;
+// --- End PWB ---
+
 const extensionLookupArgs = ['list-extensions', 'locate-extension'];
 const extensionInstallArgs = ['install-extension', 'install-builtin-extension', 'uninstall-extension', 'update-extensions'];
 
@@ -212,6 +219,44 @@ if (shouldSpawnCli) {
 			_remoteExtensionHostAgentServer.dispose();
 		}
 	});
+
+	// --- Start PWB ---
+	// Shut down cleanly on SIGTERM/SIGINT so that terminating a session (for
+	// example quitting it from the Posit Workbench home page, which arrives as
+	// SIGTERM on Kubernetes and Slurm) reports exit code 0 instead of
+	// 128+signal. A non-zero exit marks the Kubernetes session pod Error and
+	// its Job Failed (posit-dev/positron#13719). Setting
+	// RSTUDIO_FORCE_NON_ZERO_EXIT_CODE=1 restores the 128+signal exit codes,
+	// matching the escape hatch rsession honors. prependListener + a deferred
+	// exit lets the exit-diagnostics signal listener (registered earlier,
+	// smoke tests only) still log the signal without double-exiting.
+	for (const shutdownSignal of ['SIGTERM', 'SIGINT'] as NodeJS.Signals[]) {
+		process.prependListener(shutdownSignal, () => {
+			if (shuttingDownGracefully) {
+				return;
+			}
+			shuttingDownGracefully = true;
+			const signalNumber = (os.constants.signals as Record<string, number>)[shutdownSignal];
+			const exitCode = process.env['RSTUDIO_FORCE_NON_ZERO_EXIT_CODE'] === '1' && typeof signalNumber === 'number'
+				? 128 + signalNumber
+				: 0;
+			console.log(`Received ${shutdownSignal}; shutting down (exit code ${exitCode}).`);
+			try {
+				server.close();
+				_remoteExtensionHostAgentServer?.dispose();
+			} catch (err) {
+				// Keep the shutdown path self-contained. `DisposableStore` rethrows
+				// errors from its children, and without this the throw would escape
+				// into the global `uncaughtException` handler that `ErrorTelemetry`
+				// installs, which reports a clean shutdown as an unexpected server
+				// error. The exit code is unaffected either way.
+				console.error(`Error during graceful shutdown; exiting ${exitCode} anyway.`, err);
+			} finally {
+				setImmediate(() => process.exit(exitCode));
+			}
+		});
+	}
+	// --- End PWB ---
 }
 
 function sanitizeStringArg(val: unknown): string | undefined {
@@ -331,6 +376,12 @@ function installServerProcessExitDiagnostics(): void {
 		try {
 			process.on(signal, () => {
 				log(`received signal '${signal}' — terminating. ${describeState()}`);
+				// --- Start PWB ---
+				if (shuttingDownGracefully) {
+					// The graceful shutdown handler owns the exit; we only log.
+					return;
+				}
+				// --- End PWB ---
 				// Preserve default termination semantics after logging.
 				const signalNumber = (os.constants.signals as Record<string, number>)[signal];
 				process.exit(typeof signalNumber === 'number' ? 128 + signalNumber : 1);

--- a/src/vs/platform/configuration/common/configurationModels.ts
+++ b/src/vs/platform/configuration/common/configurationModels.ts
@@ -726,6 +726,9 @@ export class Configuration {
 
 	private _workspaceConsolidatedConfiguration: ConfigurationModel | null = null;
 	private _foldersConsolidatedConfigurations = new ResourceMap<ConfigurationModel>();
+	// --- Start PWB: Cache the policy overlay, keyed by the consolidated model it was built from ---
+	private _policyOverlaidConfigurations = new WeakMap<ConfigurationModel, ConfigurationModel>();
+	// --- End PWB ---
 
 	constructor(
 		private _defaultConfiguration: ConfigurationModel,
@@ -825,6 +828,14 @@ export class Configuration {
 
 	updatePolicyConfiguration(policyConfiguration: ConfigurationModel): void {
 		this._policyConfiguration = policyConfiguration;
+		// --- Start PWB: Discard overlays built from the previous policy configuration ---
+		// Every other update method replaces the consolidated models, so their overlays fall out of the
+		// WeakMap on their own. A policy change leaves those models in place, so it has to invalidate here.
+		// The caller must treat `policyConfiguration` as immutable from here on, because the overlay is
+		// built from it only once. `PolicyConfiguration.update` satisfies this: it always builds a new
+		// model instead of changing the installed one.
+		this._policyOverlaidConfigurations = new WeakMap<ConfigurationModel, ConfigurationModel>();
+		// --- End PWB ---
 	}
 
 	updateApplicationConfiguration(applicationConfiguration: ConfigurationModel): void {
@@ -992,11 +1003,7 @@ export class Configuration {
 		// --- Start PWB: Apply policy before overrides so language-scoped policy keys participate in override flattening ---
 		// if (!this._policyConfiguration.isEmpty() && this._policyConfiguration.getValue(section) !== undefined) {
 		if (!this._policyConfiguration.isEmpty()) {
-			// clone by merging
-			configurationModel = configurationModel.merge();
-			for (const key of this._policyConfiguration.keys) {
-				configurationModel.setValue(key, this._policyConfiguration.getValue(key));
-			}
+			configurationModel = this.getPolicyOverlaidConfigurationModel(configurationModel);
 		}
 		if (overrides.overrideIdentifier) {
 			configurationModel = configurationModel.override(overrides.overrideIdentifier);
@@ -1004,6 +1011,30 @@ export class Configuration {
 		// --- End PWB ---
 		return configurationModel;
 	}
+
+	// --- Start PWB: Apply policy before overrides so language-scoped policy keys participate in override flattening ---
+	/**
+	 * Returns the given consolidated model with the policy configuration stamped on top of it.
+	 *
+	 * The upstream guard `this._policyConfiguration.getValue(section) !== undefined` cannot see
+	 * language-scoped policy keys such as `[r]`, so it is gone and this runs for every read while any
+	 * policy is set. Building the overlay deep-clones the whole configuration tree, which is far too
+	 * expensive per read, so the result is cached against the model it was built from. Reads then also
+	 * share one overlay instance, which lets `override()` reuse its own per-identifier cache.
+	 */
+	private getPolicyOverlaidConfigurationModel(configurationModel: ConfigurationModel): ConfigurationModel {
+		let policyOverlaidConfigurationModel = this._policyOverlaidConfigurations.get(configurationModel);
+		if (!policyOverlaidConfigurationModel) {
+			// clone by merging
+			policyOverlaidConfigurationModel = configurationModel.merge();
+			for (const key of this._policyConfiguration.keys) {
+				policyOverlaidConfigurationModel.setValue(key, this._policyConfiguration.getValue(key));
+			}
+			this._policyOverlaidConfigurations.set(configurationModel, policyOverlaidConfigurationModel);
+		}
+		return policyOverlaidConfigurationModel;
+	}
+	// --- End PWB ---
 
 	private getConsolidatedConfigurationModelForResource({ resource }: IConfigurationOverrides, workspace: Workspace | undefined): ConfigurationModel {
 		let consolidateConfiguration = this.getWorkspaceConsolidatedConfiguration();

--- a/src/vs/platform/configuration/test/common/configurationModels.test.ts
+++ b/src/vs/platform/configuration/test/common/configurationModels.test.ts
@@ -870,6 +870,59 @@ suite('Configuration', () => {
 		assert.strictEqual(testObject.getValue('editor.formatOnSave', { overrideIdentifier: 'r' }, undefined), true);
 		assert.strictEqual(testObject.getValue('editor.formatOnSave', {}, undefined), false);
 	});
+
+	test('getValue picks up a policy configuration change after a read', () => {
+		const testObject: Configuration = new TestConfiguration(
+			ConfigurationModel.createEmptyModel(new NullLogService()),
+			parseConfigurationModel({ '[r]': { 'editor.formatOnSave': true }, 'editor.tabSize': 2 }),
+			ConfigurationModel.createEmptyModel(new NullLogService()),
+			parseConfigurationModel({ 'editor.formatOnSave': false, 'editor.tabSize': 8 }),
+		);
+		testObject.getValue('editor.formatOnSave', { overrideIdentifier: 'r' }, undefined);
+
+		testObject.updatePolicyConfiguration(parseConfigurationModel({ '[r]': { 'editor.formatOnSave': false }, 'editor.tabSize': 4 }));
+
+		assert.deepStrictEqual([
+			testObject.getValue('editor.formatOnSave', { overrideIdentifier: 'r' }, undefined),
+			testObject.getValue('editor.tabSize', {}, undefined),
+		], [false, 4]);
+	});
+
+	test('getValue picks up a user configuration change while a policy is set', () => {
+		const testObject: Configuration = new TestConfiguration(
+			ConfigurationModel.createEmptyModel(new NullLogService()),
+			parseConfigurationModel({ '[r]': { 'editor.formatOnSave': true } }),
+			ConfigurationModel.createEmptyModel(new NullLogService()),
+			parseConfigurationModel({ 'editor.tabSize': 8 }),
+		);
+		testObject.getValue('editor.formatOnSave', { overrideIdentifier: 'r' }, undefined);
+
+		testObject.updateLocalUserConfiguration(parseConfigurationModel({ 'editor.tabSize': 4 }));
+
+		assert.deepStrictEqual([
+			testObject.getValue('editor.formatOnSave', { overrideIdentifier: 'r' }, undefined),
+			testObject.getValue('editor.tabSize', {}, undefined),
+		], [true, 4]);
+	});
+
+	test('getValue does not rebuild the policy overlay for each read', () => {
+		const policyConfigurationModel = parseConfigurationModel({ '[r]': { 'editor.formatOnSave': true } });
+		const testObject: Configuration = new TestConfiguration(
+			ConfigurationModel.createEmptyModel(new NullLogService()),
+			policyConfigurationModel,
+			ConfigurationModel.createEmptyModel(new NullLogService()),
+			parseConfigurationModel({ 'editor.formatOnSave': false }),
+		);
+		testObject.getValue('editor.formatOnSave', { overrideIdentifier: 'r' }, undefined);
+
+		// An installed policy model must be treated as immutable, because the overlay is built from it
+		// only once. This changes it in place to prove that the second read reuses the first overlay.
+		// Production code replaces the model through `updatePolicyConfiguration` instead, which the test
+		// above covers.
+		policyConfigurationModel.setValue('[r]', { 'editor.formatOnSave': false });
+
+		assert.strictEqual(testObject.getValue('editor.formatOnSave', { overrideIdentifier: 'r' }, undefined), true);
+	});
 	// --- End PWB ---
 
 	test('Test update value', () => {

--- a/src/vs/platform/localTranscription/common/localTranscription.ts
+++ b/src/vs/platform/localTranscription/common/localTranscription.ts
@@ -66,6 +66,10 @@ export interface ILocalTranscriptionProxyConfig {
 	readonly strictSSL?: boolean;
 	/** Value of `http.proxyAuthorization`, when configured. */
 	readonly authorization?: string;
+	// --- Start PWB: honor http.noProxy and NO_PROXY in node requests ---
+	/** Value of `http.noProxy`, when configured. */
+	readonly noProxy?: string[];
+	// --- End PWB ---
 }
 
 /**

--- a/src/vs/platform/localTranscription/node/nemotronTranscriber.ts
+++ b/src/vs/platform/localTranscription/node/nemotronTranscriber.ts
@@ -304,8 +304,15 @@ export class NemotronTranscriber {
 		// Route the download through the same proxy machinery `RequestService`
 		// uses (`@vscode/proxy-agent`), so corporate proxies and strict-SSL are
 		// honoured even though this utility process has no `IRequestService`.
-		const agent = await getProxyAgent(base, process.env, { proxyUrl: proxy?.url, strictSSL: proxy?.strictSSL });
-		const request: IDownloadRequestOptions = { agent, strictSSL: proxy?.strictSSL, authorization: proxy?.authorization };
+		// --- Start PWB: honor http.noProxy and NO_PROXY in node requests ---
+		// const agent = await getProxyAgent(base, process.env, { proxyUrl: proxy?.url, strictSSL: proxy?.strictSSL, noProxy: proxy?.noProxy });
+		const request: IDownloadRequestOptions = {
+			resolveProxyAgent: url => getProxyAgent(url, process.env, { proxyUrl: proxy?.url, strictSSL: proxy?.strictSSL, noProxy: proxy?.noProxy }),
+			strictSSL: proxy?.strictSSL,
+			authorization: proxy?.authorization
+		};
+		// const request: IDownloadRequestOptions = { agent, strictSSL: proxy?.strictSSL, authorization: proxy?.authorization };
+		// --- End PWB ---
 
 		// Determine total bytes up front so progress can be reported as a single
 		// 0..1 value across all files (the .data blobs dominate). The HEAD
@@ -697,6 +704,10 @@ function melToHz(mel: number): number {
 interface IDownloadRequestOptions {
 	/** Proxy agent from `getProxyAgent`, or `null`/`undefined` for a direct connection. */
 	readonly agent?: Agent;
+	// --- Start PWB: honor noProxy and re-evaluate proxy per redirect ---
+	/** Per-request proxy-agent resolver used to re-evaluate redirect targets. */
+	readonly resolveProxyAgent?: (url: string) => Promise<Agent>;
+	// --- End PWB ---
 	/** When `false`, disables certificate validation; strict (secure) by default. */
 	readonly strictSSL?: boolean;
 	/** `Proxy-Authorization` header value, when configured. */
@@ -720,8 +731,14 @@ function toHttpsOptions(options: IDownloadRequestOptions, method: 'HEAD' | 'GET'
 /** Resolve the final content-length of a URL (following redirects). */
 async function headContentLength(url: string, options: IDownloadRequestOptions): Promise<number> {
 	const https = await import('https');
+	// --- Start PWB: honor noProxy and re-evaluate proxy per redirect ---
+	const requestOptions = options.resolveProxyAgent ? await toHttpsOptionsForPwb(url, options, 'HEAD') : toHttpsOptions(options, 'HEAD');
+	// --- End PWB ---
 	return new Promise<number>((resolve, reject) => {
-		const req = https.request(url, toHttpsOptions(options, 'HEAD'), res => {
+		// --- Start PWB: honor noProxy and re-evaluate proxy per redirect ---
+		// const req = https.request(url, toHttpsOptions(options, 'HEAD'), res => {
+		const req = https.request(url, requestOptions, res => {
+			// --- End PWB ---
 			if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
 				res.resume();
 				headContentLength(new URL(res.headers.location, url).toString(), options).then(resolve, reject);
@@ -745,8 +762,14 @@ async function headContentLength(url: string, options: IDownloadRequestOptions):
 /** Stream a URL to `dest` (following redirects), reporting received bytes. */
 async function downloadFile(url: string, dest: string, options: IDownloadRequestOptions, onBytes: (received: number) => void): Promise<void> {
 	const https = await import('https');
+	// --- Start PWB: honor noProxy and re-evaluate proxy per redirect ---
+	const requestOptions = options.resolveProxyAgent ? await toHttpsOptionsForPwb(url, options, 'GET') : toHttpsOptions(options, 'GET');
+	// --- End PWB ---
 	return new Promise<void>((resolve, reject) => {
-		const req = https.request(url, toHttpsOptions(options, 'GET'), res => {
+		// --- Start PWB: honor noProxy and re-evaluate proxy per redirect ---
+		// const req = https.request(url, toHttpsOptions(options, 'GET'), res => {
+		const req = https.request(url, requestOptions, res => {
+			// --- End PWB ---
 			if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
 				res.resume();
 				downloadFile(new URL(res.headers.location, url).toString(), dest, options, onBytes).then(resolve, reject);
@@ -795,3 +818,19 @@ async function downloadFile(url: string, dest: string, options: IDownloadRequest
 		req.end();
 	});
 }
+
+// --- Start PWB: honor noProxy and re-evaluate proxy per redirect ---
+async function toHttpsOptionsForPwb(url: string, options: IDownloadRequestOptions, method: 'HEAD' | 'GET'): Promise<import('https').RequestOptions> {
+	const resolveProxyAgent = options.resolveProxyAgent;
+	if (!resolveProxyAgent) {
+		return toHttpsOptions(options, method);
+	}
+	const agent = await resolveProxyAgent(url);
+	return {
+		method,
+		agent: agent ?? undefined,
+		rejectUnauthorized: options.strictSSL !== false,
+		headers: options.authorization && agent ? { 'Proxy-Authorization': options.authorization } : undefined,
+	};
+}
+// --- End PWB ---

--- a/src/vs/platform/request/node/proxy.ts
+++ b/src/vs/platform/request/node/proxy.ts
@@ -18,9 +18,86 @@ function getSystemProxyURI(requestURL: Url, env: typeof process.env): string | n
 	return null;
 }
 
+// --- Start PWB: honor http.noProxy and NO_PROXY in node requests ---
+// This replicates the proxy bypass semantics of @vscode/proxy-agent
+// (shouldBypassProxy, noProxyFromEnv, noProxyFromConfig), which the extension
+// host proxy resolver uses, so that `http.noProxy` and the NO_PROXY
+// environment variables are interpreted the same way on both paths. (The
+// resolver additionally short-circuits localhost/127.0.0.1/::1 to DIRECT
+// before any proxy logic; that pre-existing difference is out of scope here.)
+// Those helpers are not exported from @vscode/proxy-agent, so they are
+// reimplemented here.
+//
+// Known quirks are preserved deliberately for parity with upstream
+// (verified against @vscode/proxy-agent v0.44.0): a `*` wildcard only
+// matches as an exact, untrimmed entry, so it is lost in
+// `NO_PROXY="localhost, *"`; IPv6 literals are mangled by `split(':', 2)`;
+// and glob (`*.example.com`) or CIDR (`10.0.0.0/8`) entries never match.
+// Fix these upstream rather than diverging locally.
+
+type NoProxyMatcher = (hostname: string, port: string) => boolean;
+
+function shouldBypassProxy(value: string[]): NoProxyMatcher {
+	if (value.includes('*')) {
+		return () => true;
+	}
+	const filters = value
+		.map(s => s.trim().split(':', 2))
+		.map(([name, port]) => ({ name, port }))
+		.filter(filter => !!filter.name)
+		.map(({ name, port }) => {
+			const domain = name[0] === '.' ? name : `.${name}`;
+			return { domain, port };
+		});
+	if (!filters.length) {
+		return () => false;
+	}
+	return (hostname, port) => filters.some(({ domain, port: filterPort }) => {
+		return `.${hostname.toLowerCase()}`.endsWith(domain) && (!filterPort || port === filterPort);
+	});
+}
+
+function noProxyFromEnv(envValue?: string): NoProxyMatcher {
+	const value = (envValue || '')
+		.trim()
+		.toLowerCase()
+		.split(',');
+	return shouldBypassProxy(value);
+}
+
+function noProxyFromConfig(noProxy: string[]): NoProxyMatcher {
+	const value = noProxy
+		.map(item => item.trim().toLowerCase());
+	return shouldBypassProxy(value);
+}
+
+function shouldBypassProxyForURL(requestURL: Url, env: typeof process.env, noProxyConfig: string[] | undefined): boolean {
+	const hostname = requestURL.hostname;
+	if (!hostname) {
+		return false;
+	}
+	const defaultPort = requestURL.protocol === 'https:' ? '443' : '80';
+	const port = String(requestURL.port || defaultPort);
+	// `http.noProxy` comes from user or admin settings with no schema-type
+	// validation, so a mistyped value (a plain string, or non-string array
+	// items) must be ignored rather than crash every request.
+	const configEntries = Array.isArray(noProxyConfig) ? noProxyConfig.filter(item => typeof item === 'string') : [];
+	// Same precedence as the extension host proxy resolver: when any
+	// `http.noProxy` entries are present, the environment variables are
+	// ignored.
+	if (configEntries.length) {
+		return noProxyFromConfig(configEntries)(hostname, port);
+	}
+	return noProxyFromEnv(env.no_proxy || env.NO_PROXY)(hostname, port);
+}
+// --- End PWB ---
+
 export interface IOptions {
 	proxyUrl?: string;
 	strictSSL?: boolean;
+	// --- Start PWB: honor http.noProxy and NO_PROXY in node requests ---
+	noProxy?: string[];
+	// --- End PWB ---
 }
 
 export async function getProxyAgent(rawRequestURL: string, env: typeof process.env, options: IOptions = {}): Promise<Agent> {
@@ -30,6 +107,16 @@ export async function getProxyAgent(rawRequestURL: string, env: typeof process.e
 	if (!proxyURL) {
 		return null;
 	}
+
+	// --- Start PWB: honor http.noProxy and NO_PROXY in node requests ---
+	// The bypass list wins over both `http.proxy` and the proxy environment
+	// variables, matching the extension host proxy resolver's precedence.
+	// Checked after the guard above so the matcher is only built when a
+	// proxy is actually configured.
+	if (shouldBypassProxyForURL(requestURL, env, options.noProxy)) {
+		return null;
+	}
+	// --- End PWB ---
 
 	const proxyEndpoint = parseUrl(proxyURL);
 

--- a/src/vs/platform/request/node/requestService.ts
+++ b/src/vs/platform/request/node/requestService.ts
@@ -48,6 +48,9 @@ export interface IRawRequestFunction {
 export interface NodeRequestOptions extends IRequestOptions {
 	agent?: Agent;
 	strictSSL?: boolean;
+	// --- Start PWB: honor noProxy and re-evaluate proxy per redirect ---
+	resolveProxyAgent?(url: string): Promise<Agent>;
+	// --- End PWB ---
 	isChromiumNetwork?: boolean;
 	getRawRequest?(options: IRequestOptions): IRawRequestFunction;
 }
@@ -63,6 +66,9 @@ export class RequestService extends AbstractRequestService implements IRequestSe
 	private proxyUrl?: string;
 	private strictSSL: boolean | undefined;
 	private authorization?: string;
+	// --- Start PWB: honor http.noProxy and NO_PROXY in node requests ---
+	private noProxy?: string[];
+	// --- End PWB ---
 	private shellEnvErrorLogged?: boolean;
 
 	constructor(
@@ -84,10 +90,16 @@ export class RequestService extends AbstractRequestService implements IRequestSe
 		this.proxyUrl = this.getConfigValue<string>('http.proxy');
 		this.strictSSL = !!this.getConfigValue<boolean>('http.proxyStrictSSL');
 		this.authorization = this.getConfigValue<string>('http.proxyAuthorization');
+		// --- Start PWB: honor http.noProxy and NO_PROXY in node requests ---
+		this.noProxy = this.getConfigValue<string[]>('http.noProxy');
+		// --- End PWB ---
 	}
 
 	async request(options: NodeRequestOptions, token: CancellationToken): Promise<IRequestContext> {
-		const { proxyUrl, strictSSL } = this;
+		// --- Start PWB: honor http.noProxy and NO_PROXY in node requests ---
+		// const { proxyUrl, strictSSL } = this;
+		const { proxyUrl, strictSSL, noProxy } = this;
+		// --- End PWB ---
 
 		let shellEnv: typeof process.env | undefined = undefined;
 		try {
@@ -103,17 +115,32 @@ export class RequestService extends AbstractRequestService implements IRequestSe
 			...process.env,
 			...shellEnv
 		};
-		const agent = options.agent ? options.agent : await getProxyAgent(options.url || '', env, { proxyUrl, strictSSL });
+		// --- Start PWB: honor noProxy and re-evaluate proxy per redirect ---
+		// const agent = options.agent ? options.agent : await getProxyAgent(options.url || '', env, { proxyUrl, strictSSL, noProxy });
+		const hasCustomAgent = !!options.agent;
+		const agent = options.agent ? options.agent : await getProxyAgent(options.url || '', env, { proxyUrl, strictSSL, noProxy });
+		if (!hasCustomAgent) {
+			options.resolveProxyAgent = url => getProxyAgent(url, env, { proxyUrl, strictSSL, noProxy });
+		}
+		// --- End PWB ---
 
 		options.agent = agent;
 		options.strictSSL = strictSSL;
 
-		if (this.authorization) {
+		// --- Start PWB: only send Proxy-Authorization when proxied ---
+		// if (this.authorization) {
+		if (!options.proxyAuthorization) {
+			options.proxyAuthorization = this.authorization;
+		}
+		if (options.proxyAuthorization && options.agent) {
 			options.headers = {
 				...(options.headers || {}),
-				'Proxy-Authorization': this.authorization
+				// 'Proxy-Authorization': this.authorization
+				'Proxy-Authorization': options.proxyAuthorization
 			};
 		}
+		// }
+		// --- End PWB ---
 
 		return this.logAndRequest(options, () => nodeRequest(options, token));
 	}
@@ -225,10 +252,50 @@ async function nodeRequestAttempt(options: NodeRequestOptions, token: Cancellati
 
 		const req = rawRequest(opts, (res: http.IncomingMessage) => {
 			const followRedirects: number = isNumber(options.followRedirects) ? options.followRedirects : 3;
-			if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && followRedirects > 0 && res.headers['location']) {
+			// --- Start PWB: honor noProxy and re-evaluate proxy per redirect ---
+			// if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && followRedirects > 0 && res.headers['location']) {
+			const redirectLocation = Array.isArray(res.headers['location']) ? res.headers['location'][0] : res.headers['location'];
+			let redirectUrl = redirectLocation;
+			if (redirectLocation && options.url) {
+				try {
+					redirectUrl = new URL(redirectLocation, options.url).toString();
+				} catch {
+					redirectUrl = redirectLocation;
+				}
+			}
+			if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && followRedirects > 0 && redirectUrl) {
+				if (options.resolveProxyAgent && options.url) {
+					const from = new URL(options.url);
+					const to = new URL(redirectUrl);
+					const fromPort = from.port || (from.protocol === 'https:' ? '443' : '80');
+					const toPort = to.port || (to.protocol === 'https:' ? '443' : '80');
+					const isCrossOrigin = from.protocol !== to.protocol || from.hostname !== to.hostname || fromPort !== toPort;
+					if (isCrossOrigin) {
+						options.resolveProxyAgent(redirectUrl).then(redirectAgent => {
+							const headers = { ...(options.headers || {}) };
+							if (options.proxyAuthorization && redirectAgent) {
+								headers['Proxy-Authorization'] = options.proxyAuthorization;
+							} else {
+								delete headers['Proxy-Authorization'];
+							}
+							nodeRequest({
+								...options,
+								url: redirectUrl,
+								agent: redirectAgent,
+								headers: Object.keys(headers).length ? headers : undefined,
+								followRedirects: followRedirects - 1
+							}, token).then(resolve, reject);
+						}, reject);
+						return;
+					}
+				}
+				// --- End PWB ---
 				nodeRequest({
 					...options,
-					url: res.headers['location'],
+					// --- Start PWB: honor noProxy and re-evaluate proxy per redirect ---
+					// url: res.headers['location'],
+					url: redirectUrl,
+					// --- End PWB ---
 					followRedirects: followRedirects - 1
 				}, token).then(resolve, reject);
 			} else {

--- a/src/vs/platform/request/test/node/proxy.test.ts
+++ b/src/vs/platform/request/test/node/proxy.test.ts
@@ -1,0 +1,190 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// --- Start PWB: honor http.noProxy and NO_PROXY in node requests ---
+// Tests for the proxy bypass behavior added to getProxyAgent. The whole file
+// is a PWB addition.
+
+import assert from 'assert';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { Agent, getProxyAgent } from '../../node/proxy.js';
+import { IRawRequestFunction, nodeRequest } from '../../node/requestService.js';
+
+suite('Proxy - noProxy bypass', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const proxyEnv = {
+		HTTP_PROXY: 'http://proxy.corp.example:3128',
+		HTTPS_PROXY: 'http://proxy.corp.example:3128'
+	};
+
+	test('proxies when no bypass list matches', async () => {
+		const agent = await getProxyAgent('https://gallery.internal/manifest', { ...proxyEnv });
+		assert.ok(agent, 'expected a proxy agent when no bypass is configured');
+	});
+
+	test('bypasses via env NO_PROXY (uppercase)', async () => {
+		const agent = await getProxyAgent('https://gallery.internal/manifest', { ...proxyEnv, NO_PROXY: 'gallery.internal' });
+		assert.strictEqual(agent, null);
+	});
+
+	test('bypasses via env no_proxy (lowercase)', async () => {
+		const agent = await getProxyAgent('https://gallery.internal/manifest', { ...proxyEnv, no_proxy: 'gallery.internal' });
+		assert.strictEqual(agent, null);
+	});
+
+	test('bypasses via http.noProxy config', async () => {
+		const agent = await getProxyAgent('https://gallery.internal/manifest', { ...proxyEnv }, { noProxy: ['gallery.internal'] });
+		assert.strictEqual(agent, null);
+	});
+
+	test('bypass list entries are case-insensitive', async () => {
+		const agent = await getProxyAgent('https://gallery.internal/manifest', { ...proxyEnv }, { noProxy: ['GALLERY.INTERNAL'] });
+		assert.strictEqual(agent, null);
+	});
+
+	test('host:port entry matches only that port', async () => {
+		const bypassed = await getProxyAgent('https://gallery.internal:8443/manifest', { ...proxyEnv, NO_PROXY: 'gallery.internal:8443' });
+		assert.strictEqual(bypassed, null);
+
+		const proxied = await getProxyAgent('https://gallery.internal/manifest', { ...proxyEnv, NO_PROXY: 'gallery.internal:8443' });
+		assert.ok(proxied, 'expected a proxy agent when the port does not match');
+	});
+
+	test('host:port entry matches the implied default port', async () => {
+		const agent = await getProxyAgent('https://gallery.internal/manifest', { ...proxyEnv, NO_PROXY: 'gallery.internal:443' });
+		assert.strictEqual(agent, null);
+	});
+
+	test('leading-dot entry matches the domain and its subdomains', async () => {
+		const subdomain = await getProxyAgent('https://gallery.internal/manifest', { ...proxyEnv, NO_PROXY: '.internal' });
+		assert.strictEqual(subdomain, null);
+
+		const exact = await getProxyAgent('https://gallery.internal/manifest', { ...proxyEnv, NO_PROXY: '.gallery.internal' });
+		assert.strictEqual(exact, null);
+	});
+
+	test('entry without leading dot also matches subdomains', async () => {
+		const agent = await getProxyAgent('https://sub.gallery.internal/manifest', { ...proxyEnv, NO_PROXY: 'gallery.internal' });
+		assert.strictEqual(agent, null);
+	});
+
+	test('does not bypass a non-matching host', async () => {
+		const agent = await getProxyAgent('https://gallery.internal/manifest', { ...proxyEnv, NO_PROXY: 'other.host,another.host:8080' });
+		assert.ok(agent, 'expected a proxy agent for a host not in the bypass list');
+	});
+
+	test('does not treat a suffix without a label boundary as a match', async () => {
+		const agent = await getProxyAgent('https://evilgallery.internal.example/manifest', { ...proxyEnv, NO_PROXY: 'internal' });
+		assert.ok(agent, 'expected a proxy agent when the entry only matches a partial label');
+	});
+
+	test('bypass wins over http.proxy setting', async () => {
+		const agent = await getProxyAgent('https://gallery.internal/manifest', { NO_PROXY: 'gallery.internal' }, { proxyUrl: 'http://proxy.corp.example:3128' });
+		assert.strictEqual(agent, null);
+	});
+
+	test('config entries take precedence: env NO_PROXY is ignored when http.noProxy is set', async () => {
+		const agent = await getProxyAgent('https://gallery.internal/manifest', { ...proxyEnv, NO_PROXY: 'gallery.internal' }, { noProxy: ['other.host'] });
+		assert.ok(agent, 'expected a proxy agent: config list replaces the env list');
+	});
+
+	test('a non-array http.noProxy value is ignored instead of crashing', async () => {
+		const proxied = await getProxyAgent('https://gallery.internal/manifest', { ...proxyEnv }, { noProxy: 'gallery.internal' as unknown as string[] });
+		assert.ok(proxied, 'expected a proxy agent: a mistyped config value must not bypass');
+
+		const bypassed = await getProxyAgent('https://gallery.internal/manifest', { ...proxyEnv, NO_PROXY: 'gallery.internal' }, { noProxy: 'other.host' as unknown as string[] });
+		assert.strictEqual(bypassed, null, 'expected fallback to env NO_PROXY when the config value is mistyped');
+	});
+
+	test('non-string entries in http.noProxy are ignored', async () => {
+		const agent = await getProxyAgent('https://gallery.internal/manifest', { ...proxyEnv }, { noProxy: [123, null, 'gallery.internal'] as unknown as string[] });
+		assert.strictEqual(agent, null, 'expected the valid entry to still match');
+	});
+
+	test('a sole * entry bypasses every host', async () => {
+		const fromEnv = await getProxyAgent('https://gallery.internal/manifest', { ...proxyEnv, NO_PROXY: '*' });
+		assert.strictEqual(fromEnv, null);
+
+		const fromConfig = await getProxyAgent('https://gallery.internal/manifest', { ...proxyEnv }, { noProxy: ['*'] });
+		assert.strictEqual(fromConfig, null);
+	});
+
+	test('proxies http URLs with HTTP_PROXY and bypasses them with NO_PROXY', async () => {
+		const proxied = await getProxyAgent('http://gallery.internal/manifest', { ...proxyEnv });
+		assert.ok(proxied, 'expected a proxy agent for http with HTTP_PROXY set');
+
+		const bypassed = await getProxyAgent('http://gallery.internal/manifest', { ...proxyEnv, NO_PROXY: 'gallery.internal' });
+		assert.strictEqual(bypassed, null);
+	});
+
+	test('re-evaluates proxy and proxy-authorization on redirect targets', async () => {
+		const seenRequests: Array<{ url: string; agent: Agent; proxyAuthorization: string | undefined }> = [];
+		const proxiedAgent = {} as Agent;
+		const resolvedProxyUrls: string[] = [];
+		const mockRawRequest = (_opts: { protocol?: string; hostname?: string; path?: string; headers?: { 'Proxy-Authorization'?: string }; agent: Agent }, callback: Function) => {
+			const url = `${_opts.protocol}//${_opts.hostname}${_opts.path}`;
+			seenRequests.push({
+				url,
+				agent: _opts.agent,
+				proxyAuthorization: _opts.headers?.['Proxy-Authorization']
+			});
+			const attempt = seenRequests.length;
+			const mockReq: any = {
+				on: (_event: string, _handler: Function) => { },
+				end: () => {
+					if (attempt === 1) {
+						setTimeout(() => callback({
+							statusCode: 302,
+							headers: { location: 'https://cdn.example.com/file.tgz' },
+							on: () => { },
+							pipe: () => ({ on: () => { } }),
+							resume: () => { }
+						}), 0);
+						return;
+					}
+					setTimeout(() => callback({
+						statusCode: 200,
+						headers: {},
+						on: () => { },
+						pipe: () => ({ on: () => { } })
+					}), 0);
+				},
+				abort: () => { },
+				setTimeout: () => { }
+			};
+			return mockReq;
+		};
+
+		await nodeRequest({
+			url: 'https://marketplace.example.com/manifest',
+			type: 'GET',
+			agent: null,
+			proxyAuthorization: 'Basic test-token',
+			resolveProxyAgent: async url => {
+				resolvedProxyUrls.push(url);
+				return url.includes('cdn.example.com') ? proxiedAgent : null;
+			},
+			getRawRequest: () => mockRawRequest as IRawRequestFunction,
+			callSite: 'proxy.test.redirectProxyReevaluation'
+		}, CancellationToken.None);
+
+		assert.deepStrictEqual(resolvedProxyUrls, ['https://cdn.example.com/file.tgz']);
+		assert.deepStrictEqual(seenRequests.map(request => ({ url: request.url, proxyAuthorization: request.proxyAuthorization })), [
+			{
+				url: 'https://marketplace.example.com/manifest',
+				proxyAuthorization: undefined
+			},
+			{
+				url: 'https://cdn.example.com/file.tgz',
+				proxyAuthorization: 'Basic test-token'
+			}
+		]);
+		assert.strictEqual(seenRequests[0].agent, null);
+		assert.strictEqual(seenRequests[1].agent, proxiedAgent);
+	});
+});
+// --- End PWB ---

--- a/src/vs/workbench/services/localTranscription/electron-browser/localTranscriptionService.ts
+++ b/src/vs/workbench/services/localTranscription/electron-browser/localTranscriptionService.ts
@@ -93,7 +93,11 @@ export class LocalTranscriptionService {
 		return {
 			url: inspectLocal<string>('http.proxy'),
 			strictSSL: !!inspectLocal<boolean>('http.proxyStrictSSL'),
-			authorization: inspectLocal<string>('http.proxyAuthorization')
+			// --- Start PWB: honor http.noProxy and NO_PROXY in node requests ---
+			// authorization: inspectLocal<string>('http.proxyAuthorization')
+			authorization: inspectLocal<string>('http.proxyAuthorization'),
+			noProxy: inspectLocal<string[]>('http.noProxy')
+			// --- End PWB ---
 		};
 	}
 }


### PR DESCRIPTION
Fixes #15427
Fixes #15177
Fixes #13719

This is a targeted upstream merge from vscode-server. It brings three merged upstream PRs to `main`.

### What is included

| vscode-server PR | Positron issue | What it does |
| --- | --- | --- |
| rstudio/vscode-server#402 | #15177 | The node request path now honors `http.noProxy` and the `NO_PROXY` environment variables. Extension gallery requests and update checks no longer fail with `Server returned 403` when an administrator exempts the gallery host from a corporate proxy. |
| rstudio/vscode-server#404 | #13719 | The server exits 0 on SIGTERM and SIGINT. A user can quit a session from the Posit Workbench home page, and the session pod no longer stays in `Error` with its Job in `Failed`. |
| rstudio/vscode-server#405 | #15427 | Configuration reads build the policy overlay one time for each configuration change, instead of one time for each read. Data Explorer scrolling is smooth again when an enforced setting or a policy is set. |

Each upstream PR is a separate commit, applied in upstream chronological order.

### Merge notes

Positron and vscode-server have no common ancestor. I applied each commit with `git cherry-pick -n`, which is the same shape as earlier upstream merges in this repository. All three applied with no conflicts.

### Considered but not included

| Reason | Upstream PRs |
| --- | --- |
| Out of scope for this PR. It changes PWB product code (`pwbConstants.ts`, `webClientServer.ts`) and needs its own review, so it deserves a follow-up merge. | rstudio/vscode-server#408 (serve resource URLs from nginx) |
| Positron pins its own `rstudio.rstudio-workbench` version in `product.json`, and is already at 2026.9.2. | rstudio/vscode-server#396, rstudio/vscode-server#397, rstudio/vscode-server#401 |
| CI automation and vscode-server version bumps only. Positron does not use upstream GitHub workflows. | rstudio/vscode-server#395, rstudio/vscode-server#398, rstudio/vscode-server#406 |
| Already implemented in Positron by #15335. | rstudio/vscode-server#365, rstudio/vscode-server#366, rstudio/vscode-server#369, rstudio/vscode-server#372, rstudio/vscode-server#377, rstudio/vscode-server#385, rstudio/vscode-server#389, rstudio/vscode-server#390, rstudio/vscode-server#393 |

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed slow scrolling in the Data Explorer when an enforced setting or a policy is set (#15427)
- Extension installs now honor `http.noProxy` and `NO_PROXY`, so an administrator can exempt the extension gallery from a corporate proxy (#15177)
- The session pod no longer goes to an error state when a user quits a Posit Workbench session (#13719)

### Validation Steps

@:workbench @:web @:vscode-settings @:data-explorer @:extensions

#### Automated tests

Both new suites are Mocha:

```sh
./scripts/test.sh --run src/vs/platform/configuration/test/common/configurationModels.test.ts
npm run test-node -- --run out/vs/platform/request/test/node/proxy.test.js
```

The first gives 90 passing, and it includes the three new overlay tests from rstudio/vscode-server#405. The second gives 19 passing, all new in rstudio/vscode-server#402.

The rstudio/vscode-server#404 change adds no test. `src/server-main.ts` binds a port and installs process handlers as import side effects, so the exit code is observable only from a real process.

#### Local results

- `npm run build-check`: 0 errors.
- `npm run precommit`: passes.
- `npm run test:positron`: 4207 passed, 0 failing.
- `npm run test:core`: 26700 passing, 1 failing. The failure is a `WebSocketNodeSocket` timeout in `vs/base/parts/ipc/test/node/ipc.net.test`, which passes in 54ms on its own. It is a load flake in an area that this PR does not touch.
- `npm run gulp vscode-darwin-arm64`: succeeds.

If you build this branch and see `TS2688: Cannot find type definition file for 'mocha'` in `extensions/positron-data-driver-odbc`, run `npm install`. That extension is new on `main` in #15630, and the error is unrelated to this PR.
