### PR TITLE
Fix notifications rendering twice after the notifications center is hidden and shown

### DIFF
--- a/src/vs/workbench/browser/parts/notifications/notificationsList.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsList.ts
@@ -195,9 +195,20 @@ export class NotificationsList extends Disposable {
 	}
 
 	hide(): void {
-		if (!this.isVisible || !this.list) {
+		// --- Start Positron ---
+		// `updateNotificationsList` above hides this list whenever the view model
+		// becomes empty, which happens when the notifications center is shown
+		// while there is nothing to show. That leaves `isVisible` false while the
+		// center still considers itself visible, so items added afterwards land in
+		// the view model of a list that believes it is hidden. Bailing out here
+		// then skips clearing them, and the center's next `show()` splices the same
+		// items in a second time, rendering every notification twice. Clear
+		// unconditionally so `hide()` always leaves the list empty.
+		// if (!this.isVisible || !this.list) {
+		if (!this.list) {
 			return; // already hidden
 		}
+		// --- End Positron ---
 
 		// Hide
 		this.isVisible = false;

--- a/src/vs/workbench/browser/parts/notifications/notificationsViewer.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsViewer.ts
@@ -12,7 +12,7 @@ import { ButtonBar, IButtonOptions } from '../../../../base/browser/ui/button/bu
 import { ActionBar } from '../../../../base/browser/ui/actionbar/actionbar.js';
 import { ActionRunner, IAction, IActionRunner, Separator, toAction } from '../../../../base/common/actions.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
-import { dispose, DisposableStore, Disposable } from '../../../../base/common/lifecycle.js';
+import { dispose, DisposableStore, Disposable, markAsSingleton } from '../../../../base/common/lifecycle.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 import { INotificationViewItem, NotificationViewItem, NotificationViewItemContentChangeKind, INotificationMessage, ChoiceAction, NotificationsSettings, getNotificationsPosition } from '../../../common/notifications.js';
 import { ClearNotificationAction, ExpandNotificationAction, CollapseNotificationAction, ConfigureNotificationAction, getNotificationExpandIcon, getNotificationCollapseIcon } from './notificationsActions.js';
@@ -358,9 +358,18 @@ export class NotificationTemplateRenderer extends Disposable {
 		super();
 
 		if (!NotificationTemplateRenderer.closeNotificationAction) {
-			NotificationTemplateRenderer.closeNotificationAction = instantiationService.createInstance(ClearNotificationAction, ClearNotificationAction.ID, ClearNotificationAction.LABEL);
-			NotificationTemplateRenderer.expandNotificationAction = instantiationService.createInstance(ExpandNotificationAction, ExpandNotificationAction.ID, ExpandNotificationAction.LABEL);
-			NotificationTemplateRenderer.collapseNotificationAction = instantiationService.createInstance(CollapseNotificationAction, CollapseNotificationAction.ID, CollapseNotificationAction.LABEL);
+			// --- Start Positron ---
+			// These actions are process-wide statics that are intentionally never
+			// disposed, so mark them as singletons. Otherwise the leak detector
+			// reports them against whichever test first renders a notification row,
+			// which makes rendered notifications untestable.
+			// NotificationTemplateRenderer.closeNotificationAction = instantiationService.createInstance(ClearNotificationAction, ClearNotificationAction.ID, ClearNotificationAction.LABEL);
+			// NotificationTemplateRenderer.expandNotificationAction = instantiationService.createInstance(ExpandNotificationAction, ExpandNotificationAction.ID, ExpandNotificationAction.LABEL);
+			// NotificationTemplateRenderer.collapseNotificationAction = instantiationService.createInstance(CollapseNotificationAction, CollapseNotificationAction.ID, CollapseNotificationAction.LABEL);
+			NotificationTemplateRenderer.closeNotificationAction = markAsSingleton(instantiationService.createInstance(ClearNotificationAction, ClearNotificationAction.ID, ClearNotificationAction.LABEL));
+			NotificationTemplateRenderer.expandNotificationAction = markAsSingleton(instantiationService.createInstance(ExpandNotificationAction, ExpandNotificationAction.ID, ExpandNotificationAction.LABEL));
+			NotificationTemplateRenderer.collapseNotificationAction = markAsSingleton(instantiationService.createInstance(CollapseNotificationAction, CollapseNotificationAction.ID, CollapseNotificationAction.LABEL));
+			// --- End Positron ---
 			NotificationTemplateRenderer.updateExpandCollapseIcons(configurationService);
 		}
 

--- a/src/vs/workbench/test/browser/notificationsList.test.ts
+++ b/src/vs/workbench/test/browser/notificationsList.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { NotificationAccessibilityProvider } from '../../browser/parts/notifications/notificationsList.js';
+import { NotificationAccessibilityProvider, NotificationsList } from '../../browser/parts/notifications/notificationsList.js';
 import { NotificationViewItem, INotificationsFilter, INotificationViewItem } from '../../common/notifications.js';
 import { Severity, NotificationsFilter } from '../../../platform/notification/common/notification.js';
 import { IKeybindingService } from '../../../platform/keybinding/common/keybinding.js';
@@ -12,6 +12,8 @@ import { IConfigurationService } from '../../../platform/configuration/common/co
 import { TestConfigurationService } from '../../../platform/configuration/test/common/testConfigurationService.js';
 import { MockKeybindingService } from '../../../platform/keybinding/test/common/mockKeybindingService.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../base/test/common/utils.js';
+import { workbenchInstantiationService } from './workbenchTestServices.js';
+import { mainWindow } from '../../../base/browser/window.js';
 
 suite('NotificationsList AccessibilityProvider', () => {
 
@@ -100,3 +102,41 @@ suite('NotificationsList AccessibilityProvider', () => {
 		assert.ok(infoLabel.includes('Info: Info message'), 'Info notifications should have Info prefix');
 	});
 });
+
+// --- Start Positron ---
+// Regression coverage for notifications rendering twice in the notifications
+// center after it is shown while empty, a notification arrives, and it is then
+// hidden and shown again. See the `hide()` comment in notificationsList.ts.
+suite('NotificationsList', () => {
+
+	const noFilter: INotificationsFilter = { global: NotificationsFilter.OFF, sources: new Map() };
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('showing again does not duplicate items added while the view model was empty', () => {
+		const instantiationService = workbenchInstantiationService(undefined, disposables);
+
+		const container = mainWindow.document.createElement('div');
+		mainWindow.document.body.appendChild(container);
+		disposables.add({ dispose: () => container.remove() });
+
+		const list = disposables.add(instantiationService.createInstance(NotificationsList, container, {}));
+		const notification = NotificationViewItem.create({ severity: Severity.Info, message: 'Update available' }, noFilter)!;
+		disposables.add({ dispose: () => notification.close() });
+
+		// The center shows while there is nothing to show: the list empties itself
+		list.show();
+		list.updateNotificationsList(0, 0, []);
+
+		// A notification arrives while the center considers itself visible
+		list.updateNotificationsList(0, 0, [notification]);
+
+		// The center is hidden and shown again, re-seeding the list from the model
+		list.hide();
+		list.show();
+		list.updateNotificationsList(0, 0, [notification]);
+		list.layout(450, 400);
+
+		assert.strictEqual(container.querySelectorAll('.notification-list-item').length, 1);
+	});
+});
+// --- End Positron ---


### PR DESCRIPTION
## Summary

Notifications could render twice in the notifications center. `NotificationsList.updateNotificationsList` hides the list whenever its view model becomes empty, which happens when the center is shown while there is nothing to show. That leaves `NotificationsList.isVisible` false while `NotificationsCenter._isVisible` stays true, so:

1. A notification arriving afterwards is still spliced into the list's view model.
2. The center's next `hide()` calls `NotificationsList.hide()`, which bails out as "already hidden" and never clears the view model.
3. The next `show()` re-seeds the list from the model, splicing the same items in a second time.

`hide()` now clears unconditionally, so it always leaves the list empty.

Repro in the product, no test harness needed:

1. Clear all notifications, then open the Notifications Center (it opens empty).
2. Leave it open and trigger any notification.
3. Press `Escape`, then reopen the center. The notification is listed twice; a third open lists it three times.

## Why this showed up in CI

`anthropic-api - Open Posit Assistant and verify welcome page` has been failing on chromium with:

```
strict mode violation: locator('.notifications-center').getByRole('button', { name: 'Update Now' }) resolved to 2 elements
```

The e2e helper does exactly the sequence above: `Toasts.waitForAppear` opens the center *before* the "newer Posit Assistant dev build is available" notification exists, closes it, and then `clickButton` reopens it to click "Update Now" — finding two. Trace frame snapshots from run 32491725238 show the center list going from `aria-setsize: 1` to `aria-setsize: 2` across the close/reopen, with the notification model unchanged, so the extension only ever raised one notification.

## Also in this PR

`NotificationTemplateRenderer`'s three static notification actions are now wrapped in `markAsSingleton()`. They are process-wide statics that are intentionally never disposed, so the leak detector attributed them to whichever test first rendered a notification row — which made rendered notifications untestable. No behavior change.

## Tests

New `NotificationsList` suite in `src/vs/workbench/test/browser/notificationsList.test.ts` replays the show-empty / add / hide / show sequence and asserts a single rendered row. Verified both directions locally:

- with the fix: 7 passing
- with the `hide()` guard restored: 1 failing, `actual 2, expected 1`

The e2e test above is the end-to-end signal.

### QA Notes

@:assistant @:web
