### PR TITLE
Add Databricks e2e coverage for the assistant, and trust its OAuth hosts

### DIFF
--- a/.env.e2e.example
+++ b/.env.e2e.example
@@ -21,3 +21,16 @@ E2E_INSIGHTS_API_KEY=your_e2e_insights_api_key_here
 REDSHIFT_TEST_HOST=your_host_here
 REDSHIFT_TEST_USERNAME=your_username_here
 REDSHIFT_TEST_PASSWORD=your_password_here
+
+# Databricks LLM provider used by the posit-assistant Databricks tests.
+# DATABRICKS_URL is the workspace the OAuth (desktop-only) test signs in to, via the
+# shared IDE service account's Okta SSO. The API-key test uses DATABRICKS_WORKSPACE and
+# DATABRICKS_PAT, which the catalog-explorer tests already rely on.
+# op://Positron/Databricks-WB-Auto/url
+# op://Positron/RStudioIDE_Service_Account/{service-account-email,service-account-password,service-account-otp-secret}
+DATABRICKS_URL=
+IDE_SERVICE_ACCOUNT_EMAIL=
+IDE_SERVICE_ACCOUNT_PASSWORD=
+IDE_SERVICE_ACCOUNT_OTP_SECRET=
+DATABRICKS_WORKSPACE=
+DATABRICKS_PAT=

--- a/.github/workflows/test-e2e-ubuntu-run.yml
+++ b/.github/workflows/test-e2e-ubuntu-run.yml
@@ -173,6 +173,13 @@ jobs:
           REDSHIFT_TEST_HOST: "op://Positron/Redshift_Test_Environment/hostname"
           REDSHIFT_TEST_USERNAME: "op://Positron/Redshift_Test_Environment/username"
           REDSHIFT_TEST_PASSWORD: "op://Positron/Redshift_Test_Environment/password"
+          # Databricks LLM provider OAuth sign-in (posit-assistant). Desktop only: the
+          # flow redirects to a loopback server on this machine. The same workspace and
+          # service account the Workbench managed-credentials lane uses.
+          DATABRICKS_URL: "op://Positron/Databricks-WB-Auto/url"
+          IDE_SERVICE_ACCOUNT_EMAIL: "op://Positron/RStudioIDE_Service_Account/service-account-email"
+          IDE_SERVICE_ACCOUNT_PASSWORD: "op://Positron/RStudioIDE_Service_Account/service-account-password"
+          IDE_SERVICE_ACCOUNT_OTP_SECRET: "op://Positron/RStudioIDE_Service_Account/service-account-otp-secret"
           TS_OAUTH_CLIENT_ID: "op://Positron/Tailscale_OAuth/client_id"
           TS_OAUTH_SECRET: "op://Positron/Tailscale_OAuth/client_secret"
 

--- a/product.json
+++ b/product.json
@@ -339,7 +339,10 @@
 		"https://login.staging.posit.cloud",
 		"https://staging.connect.posit.cloud",
 		"https://posit.co",
-		"https://support.posit.co"
+		"https://support.posit.co",
+		"https://*.cloud.databricks.com",
+		"https://*.azuredatabricks.net",
+		"https://*.gcp.databricks.com"
 	],
 	"defaultChatAgent": {
 		"extensionId": "GitHub.copilot-chat",

--- a/test/e2e/pages/modelProviderModal.ts
+++ b/test/e2e/pages/modelProviderModal.ts
@@ -19,6 +19,7 @@ import {
 	getProviderEnvKey,
 	getProviderEnvVarName,
 	completeOAuthDeviceCodeLogin,
+	completeDatabricksLoopbackOAuth,
 } from './modelProviderShared.js';
 
 // The "Configure LLM Providers" modal, which the Configure Providers command
@@ -34,6 +35,11 @@ const CONNECT_VIEW = '[data-testid="provider-connect-view"]';
 const CONNECTED_VIEW = '[data-testid="provider-connected-view"]';
 const APIKEY_INPUT = '#connect-provider-apikey-input';
 const BASEURL_INPUT = '#connect-provider-baseurl-input';
+// The auth-method radios, rendered only when a provider advertises more than one method
+// (Databricks on desktop: OAuth or API Key). They carry no testid or id, so they are
+// addressed by name and value, which come from the AuthMethod enum.
+const AUTH_METHOD_RADIO = (method: 'oauth' | 'apiKey') =>
+	`input[name="connect-provider-auth-method"][value="${method}"]`;
 
 // Footer buttons are rendered by the shared action bar; scope by text within the modal.
 // Substring match: also matches the in-flight "Connecting..." label, which is
@@ -129,7 +135,22 @@ export class ModelProviderModal {
 				await this.action(provider).click();
 				await expect(this.code.driver.currentPage.locator(CONNECT_VIEW)).toBeVisible({ timeout });
 
-				const authType = getProviderAuthType(provider);
+				// Providers that offer a choice preselect their default (OAuth for
+				// Databricks); only touch the radios when a test asked for the other one.
+				// On web and remote the group is not rendered at all, since those builds
+				// advertise a single method.
+				let authType = getProviderAuthType(provider);
+				if (options.authMethod) {
+					// A missing radio group means the provider advertises a single method here
+					// (Databricks on web and remote offers only the API key), so there is
+					// nothing to select -- honour the requested method and carry on.
+					const radio = this.code.driver.currentPage.locator(AUTH_METHOD_RADIO(options.authMethod));
+					if (await radio.isVisible()) {
+						await radio.check();
+					}
+					authType = options.authMethod === 'apiKey' ? 'apiKey' : authType;
+				}
+
 				switch (authType) {
 					case 'apiKey': {
 						const apiKey = options.apiKey ?? getProviderEnvKey(provider);
@@ -162,6 +183,24 @@ export class ModelProviderModal {
 						// The OAuth "Connect" button carries the same label; click, then drive the device flow.
 						await this.clickConnectButton();
 						await completeOAuthDeviceCodeLogin(this.code, oauthConfig, options);
+						break;
+					}
+					case 'oauthLoopback': {
+						// Databricks needs the workspace URL before Connect: it discovers the
+						// workspace's OIDC endpoints from it. Unlike the API key path, the
+						// Connect button is enabled whether or not the field is filled, so an
+						// empty value here fails later and less legibly.
+						const baseUrlEnvVar = getProviderBaseUrlEnvVarName(provider);
+						const baseUrl = options.baseUrl ?? process.env[baseUrlEnvVar];
+						if (!baseUrl) {
+							throw new Error(
+								`No workspace URL provided for ${provider}. Set the ${baseUrlEnvVar} environment variable or pass baseUrl in options.`
+							);
+						}
+						await fillSecretValue(this.code.driver.currentPage.locator(BASEURL_INPUT), baseUrl);
+						// Interception has to be armed before the click, so the click is passed in
+						// rather than made here.
+						await completeDatabricksLoopbackOAuth(this.code, () => this.clickConnectButton(), options);
 						break;
 					}
 					default:

--- a/test/e2e/pages/modelProviderShared.ts
+++ b/test/e2e/pages/modelProviderShared.ts
@@ -5,6 +5,8 @@
 
 import { expect, chromium, Browser, BrowserContext, Locator, Page } from '@playwright/test';
 import { Code } from '../infra/code';
+import { completeDatabricksOktaSignIn } from '../utils/databricksOAuth.js';
+import { armExternalUrlCapture, waitForExternalUrl } from '../utils/externalUrl.js';
 
 // Modal-agnostic helpers for authenticating against model providers, kept free
 // of any particular modal's selectors. These backed both the legacy provider
@@ -53,6 +55,7 @@ const POSIT_LOGIN_BUTTON = 'button[type="submit"]:has-text("Log in")';
 export type ModelProvider =
 	| 'anthropic-api'
 	| 'amazon-bedrock'
+	| 'databricks'
 	| 'echo'
 	| 'error'
 	| 'ms-foundry'
@@ -62,7 +65,7 @@ export type ModelProvider =
 /**
  * Authentication types for model providers.
  */
-export type ProviderAuthType = 'none' | 'apiKey' | 'aws' | 'oauth';
+export type ProviderAuthType = 'none' | 'apiKey' | 'aws' | 'oauth' | 'oauthLoopback';
 
 /**
  * Supported OAuth providers for device code flow.
@@ -99,6 +102,12 @@ export interface LoginModelProviderOptions {
 	timeout?: number;
 	/** Whether to run the OAuth browser in headless mode (default: false) */
 	headless?: boolean;
+	/**
+	 * Which authentication method to pick when the provider offers a choice
+	 * (currently Databricks: OAuth or API Key). Defaults to the provider's own
+	 * default, which is whatever the modal preselects.
+	 */
+	authMethod?: 'oauth' | 'apiKey';
 }
 
 export function getProviderAuthType(provider: ModelProvider): ProviderAuthType {
@@ -114,6 +123,10 @@ export function getProviderAuthType(provider: ModelProvider): ProviderAuthType {
 			return 'aws';
 		case 'posit-ai':
 			return 'oauth';
+		case 'databricks':
+			// Authorization code + PKCE against a loopback server, not a device code
+			// flow, and only offered on desktop (see completeDatabricksLoopbackOAuth).
+			return 'oauthLoopback';
 		default:
 			throw new Error(`Unknown provider: ${provider}`);
 	}
@@ -123,12 +136,21 @@ export function getProviderAuthType(provider: ModelProvider): ProviderAuthType {
  * Whether the provider requires a Base URL alongside its API key (e.g.
  * Microsoft Foundry's Azure endpoint). These providers expose a "Base URL"
  * field in the Configure Providers modal in addition to the API key field.
+ *
+ * Databricks labels the same field "Workspace URL" and needs it under both auth
+ * methods -- OAuth discovers the workspace's OIDC endpoints from it.
  */
 export function providerRequiresBaseUrl(provider: ModelProvider): boolean {
-	return provider.toLowerCase() === 'ms-foundry';
+	const id = provider.toLowerCase();
+	return id === 'ms-foundry' || id === 'databricks';
 }
 
 export function getProviderBaseUrlEnvVarName(provider: ModelProvider): string {
+	// Databricks reuses the workspace URL the catalog-explorer tests already run
+	// against, rather than introducing a DATABRICKS_BASE_URL alias for it.
+	if (provider.toLowerCase() === 'databricks') {
+		return 'DATABRICKS_WORKSPACE';
+	}
 	return `${provider.toUpperCase().replace(/-/g, '_')}_BASE_URL`;
 }
 
@@ -155,6 +177,9 @@ export function getProviderEnvVarName(provider: ModelProvider): string {
 			return 'ANTHROPIC_KEY';
 		case 'openai-api':
 			return 'OPENAI_KEY';
+		case 'databricks':
+			// Databricks calls its API key a personal access token.
+			return 'DATABRICKS_PAT';
 		default:
 			return `${provider.toUpperCase().replace(/-/g, '_')}_KEY`;
 	}
@@ -271,6 +296,72 @@ export async function completeOAuthDeviceCodeLogin(code: Code, config: OAuthDevi
 		context = await browser.newContext();
 		page = await context.newPage();
 		await completePositLogin(page, config, finalVerificationUrl);
+	} finally {
+		if (context) { await context.close(); }
+		if (browser) { await browser.close(); }
+	}
+}
+
+/**
+ * Completes Databricks' OAuth sign-in, which is authorization code + PKCE against a
+ * loopback server on the machine running Positron -- not a device code flow, and so
+ * offered on desktop only (see `supportedOptions` in the authentication extension's
+ * providerSources.ts).
+ *
+ * The extension hands the authorize URL to the system browser via
+ * `vscode.env.openExternal`, and the URL carries a one-time state and PKCE challenge
+ * the test cannot reconstruct. So the URL is intercepted in the Electron main process
+ * and replayed in a browser Playwright controls; the extension's loopback server
+ * receives the redirect and finishes the token exchange on its own.
+ *
+ * @param code The running app, used for its Electron handle and logger.
+ * @param trigger Starts the sign-in (clicks Connect). Called after interception is armed.
+ */
+export async function completeDatabricksLoopbackOAuth(
+	code: Code,
+	trigger: () => Promise<void>,
+	options: LoginModelProviderOptions = {}
+): Promise<void> {
+	// Headed by default, matching the Posit device-code flow: these IdP pages are not
+	// reliably renderable headless.
+	const { headless = false } = options;
+
+	const electronApp = code.electronApp;
+	if (!electronApp) {
+		throw new Error(
+			'Databricks OAuth sign-in requires the Electron build: the flow redirects to a loopback '
+			+ 'server on the machine running the extension host, and the provider only advertises '
+			+ 'OAuth on desktop. Use the API key (PAT) method on web and remote.'
+		);
+	}
+
+	await armExternalUrlCapture(electronApp);
+	await trigger();
+
+	// The workspace's OIDC authorize endpoint. Databricks serves it under /oidc on the
+	// workspace host itself, whether discovered or fallen back to.
+	const authorizeUrl = await waitForExternalUrl(electronApp, /\/oidc\/.*authorize/);
+
+	// The redirect the loopback server is listening on (ports 8020-8040). Waiting for the
+	// browser to land there is what tells us Databricks completed the handoff.
+	const redirectUri = new URL(authorizeUrl).searchParams.get('redirect_uri');
+	if (!redirectUri) {
+		throw new Error('Databricks authorize URL carried no redirect_uri');
+	}
+	const loopbackHost = new URL(redirectUri).host;
+
+	let browser: Browser | undefined;
+	let context: BrowserContext | undefined;
+	try {
+		browser = await chromium.launch({ headless });
+		context = await browser.newContext();
+		const page = await context.newPage();
+		await page.goto(authorizeUrl);
+		await completeDatabricksOktaSignIn(page, {
+			completionUrl: new RegExp(loopbackHost.replace(/\./g, '\\.')),
+			logger: code.logger,
+			label: 'Desktop',
+		});
 	} finally {
 		if (context) { await context.close(); }
 		if (browser) { await browser.close(); }

--- a/test/e2e/pages/positAssistant.ts
+++ b/test/e2e/pages/positAssistant.ts
@@ -59,6 +59,7 @@ const INLINE_MODEL_TRIGGER = '[data-slot="dropdown-menu-trigger"]:has(svg.lucide
 const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
 	'anthropic-api': 'Anthropic',
 	'amazon-bedrock': 'AWS Bedrock',
+	'databricks': 'Databricks',
 	'openai-api': 'OpenAI',
 	'ms-foundry': 'Microsoft Foundry',
 	'posit-ai': 'Posit AI',

--- a/test/e2e/pages/workbench/dashboard.page.ts
+++ b/test/e2e/pages/workbench/dashboard.page.ts
@@ -3,11 +3,10 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect, BrowserContext, Locator } from '@playwright/test';
+import { expect, BrowserContext } from '@playwright/test';
 import { Code } from '../../infra/code.js';
 import { QuickInput } from '../quickInput.js';
-import { generateTOTP } from '../../utils/totp.js';
-import { isOktaLockedOut, otpRetryDelayMs } from '../../utils/otpRetry.js';
+import { completeDatabricksOktaSignIn } from '../../utils/databricksOAuth.js';
 
 export class DashboardPage {
 	get title() { return this.code.driver.currentPage.getByRole('link', { name: 'Workbench projects' }); }
@@ -202,99 +201,23 @@ export class DashboardPage {
 
 		this.code.logger.log('Setting up Databricks OAuth...');
 
-		const serviceAccountEmail = process.env.IDE_SERVICE_ACCOUNT_EMAIL!;
-		const serviceAccountPassword = process.env.IDE_SERVICE_ACCOUNT_PASSWORD!;
-		const otpSecret = process.env.IDE_SERVICE_ACCOUNT_OTP_SECRET!;
-
 		// Click Databricks sign in - opens OAuth in new tab
 		const [oauthPage] = await Promise.all([
 			context.waitForEvent('page'),
 			page.locator('[aria-label*="Databricks"]').first().click(),
 		]);
 
-		// Navigate to Okta SSO via Databricks
-		await oauthPage.waitForURL(/cloud\.databricks\.com\/login\.html/, { timeout: 15000 });
-		const ssoButton = oauthPage.locator('a:has-text("Continue with SSO")');
-		await expect(ssoButton).toBeVisible({ timeout: 10000 });
-		await ssoButton.click();
-		await oauthPage.waitForURL(/okta\.com/, { timeout: 15000 });
-
-		// Enter Okta credentials
-		const usernameField = oauthPage.locator('#input28');
-		const passwordField = oauthPage.locator('input[type="password"]');
-		const nextButton = oauthPage.locator('input[value="Next"]');
-		const verifyButton = oauthPage.locator('input[value="Verify"]');
-
-		await expect(usernameField).toBeVisible({ timeout: 10000 });
-		await usernameField.fill(serviceAccountEmail);
-		await expect(nextButton).toBeVisible({ timeout: 10000 });
-		await nextButton.click();
-		await expect(passwordField).toBeVisible({ timeout: 5000 });
-		await passwordField.fill(serviceAccountPassword);
-		await expect(verifyButton).toBeVisible({ timeout: 10000 });
-		await verifyButton.click();
-
-		// Complete 2FA authentication. TOTPs roll every 30s and Okta rejects reused codes, so a
-		// parallel shard (e.g. Azure) consuming the same code seconds earlier can knock us out, or
-		// rapid duplicate submissions can lock the account ("too many attempts"). Retry up to 3
-		// times, backing off with jitter between attempts so we de-align from the competing shard
-		// and land in a different TOTP window (and back off longer on lockout). See otpRetry.ts.
-		await oauthPage.waitForLoadState('networkidle', { timeout: 10000 });
-		const otpField = oauthPage.locator('input[type="text"], input[type="tel"], input[autocomplete="one-time-code"]').first();
-		const verifyOtpButton = oauthPage.locator('button:has-text("Verify"), input[value="Verify"]');
-
-		const maxOtpAttempts = 3;
-		let otpAccepted = false;
-		for (let attempt = 1; attempt <= maxOtpAttempts; attempt++) {
-			await expect(otpField).toBeVisible({ timeout: 15000 });
-			await otpField.fill('');
-			await otpField.fill(generateTOTP(otpSecret));
-			this.code.logger.log(`Submitted TOTP code for Databricks (attempt ${attempt}/${maxOtpAttempts})`);
-			await expect(verifyOtpButton).toBeVisible({ timeout: 10000 });
-			await verifyOtpButton.click();
-
-			try {
-				// After Okta accepts the OTP it redirects back to Databricks, which walks
-				// through up to two OAuth consent screens before completing the redirect to
-				// our callback:
-				//   1. "Authorize as" -- account picker with a Continue control
-				//      (<a data-component-id="oauth.select-group.continue">).
-				//   2. "Permission Requested" -- consent screen with an Authorize control.
-				// Both render as du-bois links (role "link"), not buttons, and either may be
-				// skipped when the account has already granted consent. Click each if shown.
-				await this.clickDatabricksConsentControl(
-					oauthPage.locator('[data-component-id="oauth.select-group.continue"]'),
-					'Authorize as / Continue',
-				);
-				await this.clickDatabricksConsentControl(
-					oauthPage.getByText('Authorize', { exact: true }),
-					'Permission Requested / Authorize',
-				);
-
-				await oauthPage.waitForURL(/oauth_redirect_callback|localhost:8787/, { timeout: 20000 });
-				otpAccepted = true;
-				break;
-			} catch {
-				// The OAuth tab sometimes closes itself on success (or on certain Okta errors).
-				// A closed tab here is more likely "OAuth completed" than "OTP rejected" — bail
-				// out of the retry loop and let the enabledWidget check below decide success.
-				if (oauthPage.isClosed()) {
-					this.code.logger.log('OAuth page closed before URL match; treating as completed and deferring to widget check');
-					break;
-				}
-				if (attempt === maxOtpAttempts) {
-					this.code.logger.log(`OTP not accepted after ${maxOtpAttempts} attempts; falling through to widget-state check`);
-					break;
-				}
-				const lockedOut = await isOktaLockedOut(oauthPage);
-				const delay = otpRetryDelayMs(lockedOut);
-				this.code.logger.log(`Databricks OTP not accepted (attempt ${attempt}/${maxOtpAttempts}, lockedOut=${lockedOut}); backing off ${delay}ms before retry`);
-				await oauthPage.waitForTimeout(delay);
-			}
-		}
+		// From here the flow is the same Okta-fronted sign-in the desktop provider drives,
+		// so it lives in a shared helper. Workbench completes by redirecting back to its
+		// own callback on the dashboard origin.
+		const reachedCallback = await completeDatabricksOktaSignIn(oauthPage, {
+			completionUrl: /oauth_redirect_callback|localhost:8787/,
+			logger: this.code.logger,
+			label: 'Workbench',
+		});
 
 		try {
-			if (otpAccepted) {
+			if (reachedCallback) {
 				await oauthPage.waitForTimeout(2000);
 			}
 			if (!oauthPage.isClosed()) {
@@ -307,24 +230,6 @@ export class DashboardPage {
 		// Verify credentials are enabled
 		await expect(enabledWidget).toBeVisible({ timeout: 30000 });
 		this.code.logger.log('Databricks OAuth setup complete');
-	}
-
-	/**
-	 * Clicks a Databricks OAuth consent control if it appears within a short window.
-	 * These screens ("Authorize as", "Permission Requested") are optional -- Databricks
-	 * skips them once the account has granted consent -- so a control that never shows
-	 * is treated as "already past this step" rather than a failure.
-	 * @param control Locator for the Continue/Authorize control on the consent screen
-	 * @param label Human-readable label for logging which screen was handled
-	 */
-	private async clickDatabricksConsentControl(control: Locator, label: string): Promise<void> {
-		try {
-			await expect(control).toBeVisible({ timeout: 8000 });
-			await control.click();
-			this.code.logger.log(`Clicked Databricks consent control: ${label}`);
-		} catch {
-			this.code.logger.log(`Databricks consent control not shown, skipping: ${label}`);
-		}
 	}
 
 	/**

--- a/test/e2e/tests/posit-assistant/posit-assistant-databricks.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant-databricks.test.ts
@@ -1,0 +1,112 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test, tags } from '../_test.setup';
+
+const provider = 'databricks';
+
+test.use({
+	suiteId: __filename,
+	// Keep the credential chain out of the way. `createSession` resolves a
+	// DATABRICKS_TOKEN (+ DATABRICKS_HOST) session before it ever reaches the browser
+	// flow or the stored PAT, so a polluted environment would leave the row already
+	// connected and neither test below would exercise anything.
+	extraEnv: { DATABRICKS_TOKEN: undefined, DATABRICKS_HOST: undefined },
+});
+
+// Databricks is the one provider whose sign-in differs by build, so it gets its own
+// file rather than joining the provider loop in posit-assistant-signin.test.ts:
+//
+//   - Desktop advertises OAuth (authorization code + PKCE against a loopback server
+//     on ports 8020-8040) and API Key.
+//   - Web and remote advertise API Key only -- the loopback redirect cannot reach an
+//     extension host on another machine. See `supportedOptions` in the authentication
+//     extension's providerSources.ts.
+//
+// So the OAuth case is tagged for desktop lanes only, and the API-key case carries WEB
+// so the chromium lane covers the path that build actually offers. Tags cannot be
+// subtracted per-test, which is the other reason these are not in the signin suite.
+
+// The OAuth case additionally depends on the Databricks workspace hosts being in
+// product.json's `linkProtectionTrustedDomains`. Without that, the opener service's
+// trusted-domains validator prompts before handing the authorize URL to the browser, and
+// under the e2e driver Positron refuses to show prompts at all (dialogService.ts), so
+// sign-in fails before it starts rather than showing a dialog a test could answer.
+
+test.describe('Posit Assistant - Databricks OAuth', {
+	tag: [tags.ASSISTANT],
+}, () => {
+	test('Sign in with OAuth, send hello, sign out', async function ({ app }) {
+		// The Okta credentials are wired per lane, so skip rather than fail where they
+		// are absent (the same convention the Redshift data-connection tests follow).
+		test.skip(!process.env.DATABRICKS_URL || !process.env.IDE_SERVICE_ACCOUNT_OTP_SECRET,
+			'Databricks OAuth requires DATABRICKS_URL and the IDE service account credentials');
+
+		// Okta's TOTP is shared with other shards, and a rejected code costs a 31-46s
+		// backoff before the retry (see otpRetry.ts). Two of those blow the default
+		// 2-minute budget on their own.
+		test.slow();
+
+		await app.workbench.modelProviderModal.loginModelProvider(provider, {
+			authMethod: 'oauth',
+			baseUrl: process.env.DATABRICKS_URL,
+		});
+
+		try {
+			await app.workbench.positAssistant.open();
+			await app.workbench.positAssistant.waitForReady();
+			await app.workbench.positAssistant.startNewConversation();
+
+			// Select the Databricks model explicitly: other providers can be signed in at
+			// the same time (AWS Bedrock auto-signs-in from the environment) and model
+			// names repeat across providers, so an auto-selected default may belong to
+			// another one. `newConversation: false` keeps the selection.
+			await app.workbench.positAssistant.selectProviderModel(provider);
+			await app.workbench.positAssistant.sendMessage('Say hello', true, { newConversation: false });
+			await app.workbench.positAssistant.expectResponseVisible();
+
+			const responseText = await app.workbench.positAssistant.getLastResponseText();
+			test.expect(responseText.length).toBeGreaterThan(0);
+		} finally {
+			await app.workbench.modelProviderModal.logoutModelProvider(provider);
+		}
+	});
+});
+
+// WIN covers the Windows lane and, because the e2e-macOS-ci project greps /@:win/, the
+// macOS one too. Both already export DATABRICKS_WORKSPACE and DATABRICKS_PAT for the
+// catalog-explorer suite, so the API-key case runs there for free. The OAuth case stays
+// off those lanes deliberately: it would need the Okta secrets added to two more
+// workflows and would put two more consumers on the shared TOTP.
+test.describe('Posit Assistant - Databricks API Key', {
+	tag: [tags.ASSISTANT, tags.WEB, tags.WIN],
+}, () => {
+	test('Sign in with a personal access token, send hello, sign out', async function ({ app }) {
+		test.skip(!process.env.DATABRICKS_PAT || !process.env.DATABRICKS_WORKSPACE,
+			'Databricks API key sign-in requires DATABRICKS_WORKSPACE and DATABRICKS_PAT');
+
+		// DATABRICKS_PAT / DATABRICKS_WORKSPACE, resolved by the page object from the
+		// provider's env var names. Both are already present in the desktop lanes for
+		// the catalog-explorer suite.
+		await app.workbench.modelProviderModal.loginModelProvider(provider, {
+			authMethod: 'apiKey',
+		});
+
+		try {
+			await app.workbench.positAssistant.open();
+			await app.workbench.positAssistant.waitForReady();
+			await app.workbench.positAssistant.startNewConversation();
+
+			await app.workbench.positAssistant.selectProviderModel(provider);
+			await app.workbench.positAssistant.sendMessage('Say hello', true, { newConversation: false });
+			await app.workbench.positAssistant.expectResponseVisible();
+
+			const responseText = await app.workbench.positAssistant.getLastResponseText();
+			test.expect(responseText.length).toBeGreaterThan(0);
+		} finally {
+			await app.workbench.modelProviderModal.logoutModelProvider(provider);
+		}
+	});
+});

--- a/test/e2e/utils/databricksOAuth.ts
+++ b/test/e2e/utils/databricksOAuth.ts
@@ -1,0 +1,177 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect, Locator, Page } from '@playwright/test';
+import { Logger } from '../infra/logger.js';
+import { generateTOTP } from './totp.js';
+import { isOktaLockedOut, otpRetryDelayMs } from './otpRetry.js';
+
+// The Okta-fronted Databricks sign-in for the shared IDE service account, driven on a
+// page the caller already put in front of the Databricks authorize endpoint. Two callers
+// reach this point by different routes and neither one's plumbing belongs here:
+//
+//   - Posit Workbench's Session Credentials widget opens the authorize URL in a new tab
+//     of the workbench's own browser context (see dashboard.page.ts).
+//   - Positron Desktop's Databricks LLM provider hands the URL to the system browser via
+//     vscode.env.openExternal, so the e2e test intercepts it and replays it in a browser
+//     it controls (see modelProviderShared.ts).
+//
+// Everything between "we are on the workspace login page" and "the provider redirected
+// back to the callback" is identical, and that is what lives here.
+
+const MAX_OTP_ATTEMPTS = 3;
+
+export interface DatabricksOktaSignInOptions {
+	/**
+	 * Pattern the OAuth page lands on once Databricks redirects back to whoever started
+	 * the flow -- the workbench's callback, or the extension's loopback server.
+	 */
+	completionUrl: RegExp;
+	/** Where to report progress; callers pass `code.logger`. */
+	logger: Logger;
+	/** Prefix for log lines, so interleaved shards stay readable (e.g. 'Workbench'). */
+	label: string;
+}
+
+/**
+ * Reads the shared IDE service account credentials, failing with the missing variable
+ * names rather than letting an undefined value reach a form field (where it surfaces
+ * much later as an opaque Okta error).
+ */
+function readServiceAccountCredentials(): { email: string; password: string; otpSecret: string } {
+	const email = process.env.IDE_SERVICE_ACCOUNT_EMAIL;
+	const password = process.env.IDE_SERVICE_ACCOUNT_PASSWORD;
+	const otpSecret = process.env.IDE_SERVICE_ACCOUNT_OTP_SECRET;
+
+	const missing = [
+		['IDE_SERVICE_ACCOUNT_EMAIL', email],
+		['IDE_SERVICE_ACCOUNT_PASSWORD', password],
+		['IDE_SERVICE_ACCOUNT_OTP_SECRET', otpSecret],
+	].filter(([, value]) => !value).map(([name]) => name);
+
+	if (missing.length > 0) {
+		throw new Error(`Databricks OAuth requires the IDE service account credentials. Missing: ${missing.join(', ')}`);
+	}
+
+	return { email: email!, password: password!, otpSecret: otpSecret! };
+}
+
+/**
+ * Clicks a Databricks OAuth consent control if it appears within a short window.
+ * These screens ("Authorize as", "Permission Requested") are optional -- Databricks
+ * skips them once the account has granted consent -- so a control that never shows
+ * is treated as "already past this step" rather than a failure.
+ */
+async function clickConsentControl(control: Locator, label: string, logger: Logger): Promise<void> {
+	try {
+		await expect(control).toBeVisible({ timeout: 8000 });
+		await control.click();
+		logger.log(`Clicked Databricks consent control: ${label}`);
+	} catch {
+		logger.log(`Databricks consent control not shown, skipping: ${label}`);
+	}
+}
+
+/**
+ * Completes the Databricks OAuth sign-in on `page`, which must already be showing the
+ * workspace login page (or the Okta page it redirects to).
+ *
+ * Callers verify success through their own signed-in state rather than this return value:
+ * the OAuth tab sometimes closes itself on completion, so "we never saw the callback URL"
+ * is not the same as "sign-in failed".
+ *
+ * @returns true if the flow was observed reaching `completionUrl`.
+ */
+export async function completeDatabricksOktaSignIn(page: Page, options: DatabricksOktaSignInOptions): Promise<boolean> {
+	const { completionUrl, logger, label } = options;
+	const { email, password, otpSecret } = readServiceAccountCredentials();
+
+	// Navigate to Okta SSO via Databricks. The workspace login page offers the SSO hop;
+	// an authorize endpoint that redirects straight to the IdP skips it, so a missing
+	// button is not a failure -- the waitForURL below is what actually gates progress.
+	const ssoButton = page.locator('a:has-text("Continue with SSO")');
+	try {
+		await expect(ssoButton).toBeVisible({ timeout: 15000 });
+		await ssoButton.click();
+	} catch {
+		logger.log(`[${label}] No "Continue with SSO" button; assuming the authorize endpoint redirected to the IdP directly`);
+	}
+	await page.waitForURL(/okta\.com/, { timeout: 15000 });
+
+	// Enter Okta credentials
+	const usernameField = page.locator('#input28');
+	const passwordField = page.locator('input[type="password"]');
+	const nextButton = page.locator('input[value="Next"]');
+	const verifyButton = page.locator('input[value="Verify"]');
+
+	await expect(usernameField).toBeVisible({ timeout: 10000 });
+	await usernameField.fill(email);
+	await expect(nextButton).toBeVisible({ timeout: 10000 });
+	await nextButton.click();
+	await expect(passwordField).toBeVisible({ timeout: 5000 });
+	await passwordField.fill(password);
+	await expect(verifyButton).toBeVisible({ timeout: 10000 });
+	await verifyButton.click();
+
+	// Complete 2FA authentication. TOTPs roll every 30s and Okta rejects reused codes, so a
+	// parallel shard (e.g. Azure) consuming the same code seconds earlier can knock us out, or
+	// rapid duplicate submissions can lock the account ("too many attempts"). Retry up to 3
+	// times, backing off with jitter between attempts so we de-align from the competing shard
+	// and land in a different TOTP window (and back off longer on lockout). See otpRetry.ts.
+	await page.waitForLoadState('networkidle', { timeout: 10000 });
+	const otpField = page.locator('input[type="text"], input[type="tel"], input[autocomplete="one-time-code"]').first();
+	const verifyOtpButton = page.locator('button:has-text("Verify"), input[value="Verify"]');
+
+	for (let attempt = 1; attempt <= MAX_OTP_ATTEMPTS; attempt++) {
+		await expect(otpField).toBeVisible({ timeout: 15000 });
+		await otpField.fill('');
+		await otpField.fill(generateTOTP(otpSecret));
+		logger.log(`[${label}] Submitted TOTP code for Databricks (attempt ${attempt}/${MAX_OTP_ATTEMPTS})`);
+		await expect(verifyOtpButton).toBeVisible({ timeout: 10000 });
+		await verifyOtpButton.click();
+
+		try {
+			// After Okta accepts the OTP it redirects back to Databricks, which walks
+			// through up to two OAuth consent screens before completing the redirect to
+			// our callback:
+			//   1. "Authorize as" -- account picker with a Continue control
+			//      (<a data-component-id="oauth.select-group.continue">).
+			//   2. "Permission Requested" -- consent screen with an Authorize control.
+			// Both render as du-bois links (role "link"), not buttons, and either may be
+			// skipped when the account has already granted consent. Click each if shown.
+			await clickConsentControl(
+				page.locator('[data-component-id="oauth.select-group.continue"]'),
+				'Authorize as / Continue',
+				logger,
+			);
+			await clickConsentControl(
+				page.getByText('Authorize', { exact: true }),
+				'Permission Requested / Authorize',
+				logger,
+			);
+
+			await page.waitForURL(completionUrl, { timeout: 20000 });
+			return true;
+		} catch {
+			// The OAuth tab sometimes closes itself on success (or on certain Okta errors).
+			// A closed tab here is more likely "OAuth completed" than "OTP rejected" -- bail
+			// out of the retry loop and let the caller's signed-in check decide success.
+			if (page.isClosed()) {
+				logger.log(`[${label}] OAuth page closed before URL match; treating as completed and deferring to the caller's state check`);
+				return false;
+			}
+			if (attempt === MAX_OTP_ATTEMPTS) {
+				logger.log(`[${label}] OTP not accepted after ${MAX_OTP_ATTEMPTS} attempts; falling through to the caller's state check`);
+				return false;
+			}
+			const lockedOut = await isOktaLockedOut(page);
+			const delay = otpRetryDelayMs(lockedOut);
+			logger.log(`[${label}] Databricks OTP not accepted (attempt ${attempt}/${MAX_OTP_ATTEMPTS}, lockedOut=${lockedOut}); backing off ${delay}ms before retry`);
+			await page.waitForTimeout(delay);
+		}
+	}
+
+	return false;
+}

--- a/test/e2e/utils/externalUrl.ts
+++ b/test/e2e/utils/externalUrl.ts
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect, ElectronApplication } from '@playwright/test';
+
+// Captures the URLs Positron hands to the system browser.
+//
+// `vscode.env.openExternal` ends up at `shell.openExternal` in the Electron main process
+// (nativeHostMainService.ts), which launches the OS default browser -- a process Playwright
+// has no handle on. A test that needs to *drive* what opens there (an OAuth authorize URL
+// carrying state and a PKCE challenge it cannot reconstruct) has to intercept the call
+// instead. Patching the main process is an established pattern in this suite; see
+// dialog-contextMenu.ts, which reaches into `app` the same way.
+//
+// Swallowing the call is deliberate: nothing should spawn a real browser on a CI machine.
+
+/** Key on the main process's globalThis where intercepted URLs accumulate. */
+type UrlStore = typeof globalThis & { __e2eExternalUrls?: string[] };
+
+/**
+ * Starts recording (and suppressing) `shell.openExternal` calls, clearing anything a
+ * previous arm captured. Call this *before* the action that triggers the open.
+ *
+ * The patch is not reverted: it stays in place for the life of the app instance, so any
+ * later external open in the same suite is swallowed too. That is the intended trade --
+ * restoring it would race with an in-flight sign-in, and nothing in the suite wants a real
+ * browser window anyway.
+ */
+export async function armExternalUrlCapture(electronApp: ElectronApplication): Promise<void> {
+	await electronApp.evaluate(({ shell }) => {
+		const store = globalThis as UrlStore;
+		if (store.__e2eExternalUrls) {
+			// Already patched by an earlier arm; just reset the buffer. Re-patching would
+			// stack wrappers and leak the previous one for the life of the app.
+			store.__e2eExternalUrls.length = 0;
+			return;
+		}
+		store.__e2eExternalUrls = [];
+		shell.openExternal = async (url: string) => {
+			(globalThis as UrlStore).__e2eExternalUrls?.push(url);
+		};
+	});
+}
+
+/**
+ * Waits for a captured URL matching `pattern` and returns it.
+ *
+ * @param pattern Matched against each captured URL.
+ * @param timeout How long to wait for a match (default 30s).
+ */
+export async function waitForExternalUrl(
+	electronApp: ElectronApplication,
+	pattern: RegExp,
+	timeout = 30000
+): Promise<string> {
+	let match: string | undefined;
+
+	await expect.poll(async () => {
+		const urls = await electronApp.evaluate(() => (globalThis as UrlStore).__e2eExternalUrls ?? []);
+		match = urls.find(url => pattern.test(url));
+		return match !== undefined;
+	}, {
+		timeout,
+		// Do not report the captured URLs on failure: they can carry auth state.
+		message: `Timed out waiting for an external URL matching ${pattern}`,
+	}).toBe(true);
+
+	return match!;
+}


### PR DESCRIPTION
### Summary

Adds e2e coverage for the Databricks LLM provider in the Configure LLM Providers modal, and trusts Databricks workspace hosts so its OAuth sign-in stops prompting mid-flow.

Databricks sign-in differs by build, so the tests are split accordingly:

- **Desktop** advertises OAuth (authorization code + PKCE against a loopback server on ports 8020-8040) and API Key.
- **Web and remote** advertise API Key only -- the loopback redirect cannot reach an extension host on another machine. See `supportedOptions` in the authentication extension's `providerSources.ts`.

**Link protection.** `vscode.env.openExternal` runs through the opener service's trusted-domains validator before dispatch, and `mainThreadWindow` does not pass `skipValidation`. A Databricks workspace host was not in `product.json`'s `linkProtectionTrustedDomains`, so signing in raised "Do you want Positron to open the external website?" partway through the flow -- the prompt that `https://github.com/login/device` and `https://login.posit.cloud` are on that list to avoid. Under the e2e driver it is fatal rather than merely annoying: `dialogService.skipDialogs()` returns true for any smoke-test run and `prompt()` throws, so the validator rejects and `shell.openExternal` is never called. This PR adds `https://*.cloud.databricks.com`, `https://*.azuredatabricks.net`, and `https://*.gcp.databricks.com`; workspaces on custom vanity domains will still prompt.

**Shared Okta flow.** The Workbench dashboard page object already drove this provider's Okta sign-in for managed credentials. The middle of that flow -- the SSO hop, credentials, TOTP retry with jittered backoff, and the two Databricks consent screens -- moves into `test/e2e/utils/databricksOAuth.ts`, which both callers use. What stays in `dashboard.page.ts` is workbench-specific: the Session Credentials widget and its enabled-state assertions (net -94 lines).

**Authorize-URL capture.** The extension hands the authorize URL to the system browser, and it carries a one-time state and PKCE challenge no test can reconstruct, so `test/e2e/utils/externalUrl.ts` intercepts `shell.openExternal` in the Electron main process (the same main-process instrumentation pattern `dialog-contextMenu.ts` uses) and suppresses it, so nothing spawns a real browser on a CI machine. The captured URL is replayed in a Playwright-controlled Chromium; the extension's loopback server receives the redirect and completes the token exchange itself.

**Secrets.** The API-key case reuses `DATABRICKS_WORKSPACE` and `DATABRICKS_PAT`, which every desktop lane already exports for the catalog-explorer suite -- no new plumbing. The OAuth case needs `DATABRICKS_URL` and the shared IDE service account, added to `test-e2e-ubuntu-run.yml` only; it is kept off the other lanes on purpose, since each one running the Okta flow adds a consumer to the single shared TOTP secret and a lockout there also breaks the workbench managed-credentials tests. Both cases skip with a stated reason where their secrets are absent, following the convention the Redshift data-connection tests use.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Signing in to Databricks in the assistant no longer interrupts the flow with an external-website confirmation prompt.

### Validation Steps

@:assistant @:web @:win @:workbench

The workbench tag is the one that matters most for regressions here: it exercises the refactored Okta helper through the Databricks managed-credentials path, which is pre-existing behavior this PR moved.

Verified locally on `e2e-electron` with four probe runs against the real app (no credentials spent):

1. The main-process interception installs and captures a direct `shell.openExternal` call.
2. Before the `product.json` change, a Databricks connect attempt produced no external URL and no dialog -- the refusal described above.
3. After it, connecting with `not-a-real-workspace.cloud.databricks.com` yields `path=/oidc/v1/authorize`, `redirect_uri=http://localhost:8020`, and both `state` and `code_challenge` present -- everything the test's browser leg consumes.

The Okta browser leg itself is unchanged code that the workbench lane has been running all along. Manual check worth doing on a real workspace: connect Databricks via OAuth on desktop and confirm no external-website prompt appears.
