### PR TITLE
Document the package commands in the positron-commands skill

### DIFF
--- a/extensions/positron-skills/templates/positron-commands/SKILL.md
+++ b/extensions/positron-skills/templates/positron-commands/SKILL.md
@@ -4,17 +4,15 @@ description: >
   Running Positron IDE commands: changing the window layout, focusing panes
   (Console, Variables, Plots, Help, Packages), clearing the console, listing or
   discovering registered interpreters, restarting or interrupting a stuck
-  session, and refreshing or updating packages. Use when the user wants Positron
-  itself to do something, rather than to run R or Python code. Load this skill,
-  then read the reference file for the area: layout and pane focus in
-  references/ui.md; listing interpreters in references/interpreters.md; sessions
-  and packages in references/troubleshooting.md; installing Python, creating an
-  environment, and finding the active interpreter in references/python-setup.md.
-  Triggers: "switch to the data science layout", "show the variables pane",
-  "clear the console", "what interpreters are available", "my R interpreter
-  isn't showing up", "my session is stuck", "update all my packages", "I don't
-  have Python installed", "set up a Python environment", "which Python am I
-  using".
+  session, setting up Python, and reading, installing or updating the packages
+  in a session. Use when the user wants Positron itself to do something, or
+  wants to know what is installed, rather than to run R or Python code. Load
+  this skill, then read the reference file for the area in question. Triggers:
+  "switch to the data science layout", "show the variables pane", "clear the
+  console", "what interpreters are available", "my R interpreter isn't showing
+  up", "my session is stuck", "is pandas installed?", "install dplyr", "update
+  all my packages", "do I have any vulnerable packages?", "I don't have Python
+  installed", "set up a Python environment", "which Python am I using".
 ---
 
 # Positron IDE commands
@@ -61,11 +59,17 @@ interpreters listed (Python, R, or another language), or needs Positron to
 rescan for newly installed environments. Also the place to find a base
 interpreter before creating an environment.
 
-**Sessions and packages** -- [references/troubleshooting.md]({{skill_dir}}/references/troubleshooting.md)
-Read when the user asks about: an interpreter that isn't showing up or won't
-start, startup diagnostics, a session that is stuck or needs restarting, or
-installed packages that need refreshing or updating. Also covers looking up a
-help topic for a function or symbol.
+**Sessions** -- [references/troubleshooting.md]({{skill_dir}}/references/troubleshooting.md)
+Read when the user asks about a session that is stuck, needs interrupting, or
+needs restarting. Also covers looking up a help topic for a function or symbol.
+
+**Packages** -- [references/packages.md]({{skill_dir}}/references/packages.md)
+Read when the user asks about: what is installed in a session and at which
+version, whether a package is available, out of date or affected by a known
+security advisory, or installing and updating packages. Read it **before**
+answering any question about what the session has -- it documents the command
+that reports the installed packages, which is always the right way to find out,
+rather than running code to check.
 
 **Python environment setup** -- [references/python-setup.md]({{skill_dir}}/references/python-setup.md)
 Read when the user is getting Python set up: installing a Python interpreter when

--- a/extensions/positron-skills/templates/positron-commands/references/packages.md
+++ b/extensions/positron-skills/templates/positron-commands/references/packages.md
@@ -63,6 +63,61 @@ callable, and tells you in its payload when it has nothing to say. So a
 
 {{command:positronPackages.getPackages}}
 
+## Security advisories
+
+The same payload carries known security advisories against each installed
+version, so a question about vulnerable packages is answered by `getPackages`
+too -- not by a web search, and not by running an auditing tool.
+
+**The three states of `vulnerabilities` are all meaningful, and conflating
+them is the easiest mistake to make here:**
+
+- A non-empty array -- this installed version is affected.
+- An **empty** array -- the advisory host was asked and reports nothing
+  against this version. That is a genuine all-clear; say so.
+- **Absent** -- there is no advisory data for this package. Nothing can be
+  concluded either way. Do not report it as clean.
+
+**Reading an advisory:** entries are pre-sorted worst-first, so the first one
+is the headline and matches what the Packages pane shows the user. `severity`
+is always present (`critical`/`high`/`medium`/`low`/`unscored`) and is the
+field to rank by. `unscored` means the advisory carries no CVSS score, which
+is common for CRAN's RSEC records -- it means "vulnerable, severity unknown",
+not "probably fine". `id` is the CVE when one exists, otherwise the OSV id.
+
+**`vulnerabilityStatus`** is tracked separately from `metadataStatus` because
+the two come from different places: outdated state from the runtime's package
+manager, advisories from Posit Package Manager. Either can fail while the
+other answers, so check the one that matches the claim you are making. On
+`disabled`, `unavailable` or `timed-out`, do not tell the user they have no
+vulnerabilities -- you did not find out.
+
+**Whether to call again** -- the status tells you, and only one value is worth
+a second call:
+
+- `fresh` or `cached` -- the advisory data is as complete as it gets. A package
+  with none was already looked up for you, so calling again returns the same
+  thing. Don't.
+- `timed-out` -- the lookup ran out of time partway. The package list is
+  complete, but some packages carry only what was cached, possibly nothing.
+  Calling again resumes where it stopped, so this is the one case where a
+  second call adds information.
+- `disabled` or `unavailable` -- no advisory data is coming. `disabled` means
+  the user turned advisory lookups off in settings; `unavailable` means the
+  lookup ran and produced nothing, because either no Package Manager here
+  reports advisories or the lookup failed. Neither is worth retrying: say what
+  you could not determine and stop.
+
+**Attribution:** when `vulnerabilitySource` is present, say where the data
+came from (`host`) and when (`fetchedAt`). Advisory data has a date; presenting
+it as timeless fact overstates it.
+
+**Fixing one:** `fixedIn` is display text, and may name fixes on several
+release branches (`"1.26.5, 2.0.2"`). It is deliberately not
+machine-comparable, so do not pass it to `updatePackage` as a version. Pick
+one with the user, then update to that exact version. Do not reach for
+`updateAllPackages` to fix a single advisory.
+
 ## Installing, updating and refreshing
 
 `installPackage` and `updatePackage` take the same argument pair: `name`, then

--- a/extensions/positron-skills/templates/positron-commands/references/packages.md
+++ b/extensions/positron-skills/templates/positron-commands/references/packages.md
@@ -1,0 +1,151 @@
+# Positron package commands
+
+Reading, installing and updating the packages in an interpreter session. See
+[SKILL.md]({{skill_dir}}/SKILL.md) for how to call these commands and how to
+handle failures.
+
+The **Arguments** and **Returns** entries below are generated from the running
+build's command metadata, so they always match this Positron. The surrounding
+guidance is hand-written.
+
+## Read the environment, never probe it
+
+To find out what is installed, what version it is, or whether something newer
+is available, call `positronPackages.getPackages`. **Do not run code to find
+out.** Writing `import pandas` in a try/except, calling `pip list`,
+`installed.packages()`, `importlib.metadata.version()`, or anything similar
+through `executeCode` is the wrong move every time: it runs code the user did
+not ask for, it can have side effects (an import executes module-level code),
+it only answers for the one package you thought to test, and it tells you
+nothing about whether a newer version exists.
+
+`getPackages` has none of those problems. It changes nothing, shows the user
+nothing, needs no pane open, and answers for every installed package at once.
+Reach for it before any package operation, and before answering any question
+about what the session has.
+
+## Reading what's installed
+
+### `positronPackages.getPackages`
+
+Reports the packages installed in the foreground session, each with its
+installed version and whether a newer one is available. Read-only and quiet.
+
+Unlike the write commands below, this has **no precondition** -- it is always
+callable, and tells you in its payload when it has nothing to say. So a
+`disabled` failure from a write command does not mean you cannot read.
+
+**Reading the payload:**
+
+- `available: false` comes with a `reason`, and each one calls for a different
+  response:
+  - `disabled` -- the user turned the Packages pane off in settings. Say so;
+    do not offer to turn it on by running code.
+  - `no-session` -- nothing is running, so there is no environment to
+    describe. Ask the user to start an interpreter.
+  - `session-not-ready` -- a session is starting up (or has exited). This one
+    is worth retrying shortly; the others are not.
+  - `unsupported` -- this runtime has no package manager. Nothing here will
+    work for it.
+  - `failed` -- the read itself failed; relay `message` rather than guessing.
+- `metadataStatus` says how far `outdated` can be trusted. Only `fresh` means
+  the repositories were queried just now. On `cached`, `timed-out` or
+  `fetch-failed`, report update information as possibly stale rather than
+  telling the user they are up to date. On `unsupported`, no package has
+  `outdated` at all, so its absence means nothing.
+- `session` names the session the answer describes. It is one session's
+  environment, not the machine's -- do not carry an answer across a session
+  switch or apply it to a different language.
+- `attached` is not the same as installed. A package can be installed but not
+  attached (not `library()`d in R, not imported in Python). "Is pandas
+  available?" is answered by the package appearing in the list at all;
+  `attached` only says whether it is on the search path right now.
+
+{{command:positronPackages.getPackages}}
+
+## Installing, updating and refreshing
+
+`installPackage` and `updatePackage` take the same argument pair: `name`, then
+`version`. For `version`, pass an exact version when the user named one,
+`'latest'` when they just want the newest. Read `version` back off the result
+to learn what `'latest'` actually resolved to, rather than predicting it or
+telling the user a version you did not confirm.
+
+Never invent a package name from a partial request. If the user says "install
+the plotting one", ask which.
+
+### `positronPackages.installPackage`
+
+Installs a package that is not there yet. If the package is **already
+installed, this does nothing at all**, whatever `version` says -- it will not
+move an installed package to a different version. Use `updatePackage` for
+that. So check `getPackages` first: it tells you which of the two commands the
+user actually needs.
+
+Base R installs ignore `version` entirely and always take the current release
+from the repository. Do not promise a specific version on an R session using
+the base installer.
+
+{{command:positronPackages.installPackage}}
+
+### `positronPackages.updatePackage`
+
+Moves an already-installed package to a different version. Returns
+`updated: false` with a `message` when the installed version is already the
+newest available -- that is a normal outcome, not an error; relay it rather
+than retrying.
+
+As with install, base R updates ignore `version`.
+
+{{command:positronPackages.updatePackage}}
+
+### `positronPackages.updateAllPackages`
+
+Updates every installed package in the session to its latest available
+version. Use when the user asks to update all their packages. This can take a
+while for a large environment -- say so before starting.
+
+Prefer `updatePackage` when the user named specific packages. Updating
+everything to fix one package is a much larger change than they asked for.
+
+{{command:positronPackages.updateAllPackages}}
+
+### `positronPackages.refreshPackages`
+
+Refreshes the Packages pane's list. Use when a package was installed or
+removed outside Positron (from a terminal, say) and the pane looks stale.
+
+This is for the *pane*. To read the installed list yourself, use
+`getPackages`, which reads live and does not need this first.
+
+{{command:positronPackages.refreshPackages}}
+
+## Preconditions, and what a failure means
+
+`installPackage`, `updatePackage`, `updateAllPackages` and `refreshPackages`
+all share one precondition: the Packages pane must be enabled in settings,
+**and** a session must be active, **and** no package operation may already be
+running.
+
+That last clause is the one to watch. A `disabled` failure does not
+necessarily mean the feature is off or the session is missing -- it may simply
+mean an install or update is in flight. Wait and tell the user an operation is
+already running; do not retry in a loop, and do not conclude packages are
+unavailable. `getPackages` still works while an operation runs, so use it to
+tell the cases apart.
+
+## After installing or updating
+
+A newly installed or upgraded package often cannot be loaded until the session
+restarts, because the old version may already be loaded in memory. Positron
+prompts the user about this itself, so do not pre-empt it.
+
+If the user does ask you to restart, use
+`workbench.action.language.runtime.restartActiveSession` from
+[troubleshooting.md]({{skill_dir}}/references/troubleshooting.md) -- and tell
+them first that a restart **discards all session state** (variables, loaded
+packages, history). Never restart silently as a cleanup step.
+
+To show the user the result, focus the Packages pane with
+`workbench.view.positronPackages.view.focus` from
+[ui.md]({{skill_dir}}/references/ui.md).

--- a/extensions/positron-skills/templates/positron-commands/references/troubleshooting.md
+++ b/extensions/positron-skills/templates/positron-commands/references/troubleshooting.md
@@ -1,9 +1,11 @@
-# Positron session and package commands
+# Positron session commands
 
-Recovering interpreter sessions (Python, R, or another language), managing
-packages, and looking up help topics. See [SKILL.md]({{skill_dir}}/SKILL.md) for how to call these commands and how
+Recovering interpreter sessions (Python, R, or another language) and looking up
+help topics. See [SKILL.md]({{skill_dir}}/SKILL.md) for how to call these commands and how
 to handle failures. To list the available interpreters or rescan for a newly
 installed one, see [interpreters.md]({{skill_dir}}/references/interpreters.md).
+For the packages installed in a session, see
+[packages.md]({{skill_dir}}/references/packages.md).
 
 The **Arguments** and **Returns** entries below are generated from the running
 build's command metadata, so they always match this Positron. The surrounding
@@ -29,35 +31,6 @@ lost. Always tell the user this will happen before calling it, and prefer
 to get a clean session. No precondition -- always enabled.
 
 {{command:workbench.action.language.runtime.restartActiveSession}}
-
-## Managing packages
-
-### `positronPackages.refreshPackages`
-
-Refreshes the list of installed packages in the active runtime session. Use
-when a package was installed or removed outside of Positron (e.g., from a
-terminal) and the Packages pane looks stale.
-
-Precondition: the Packages pane must be enabled by configuration, and a
-package operation must currently be able to run (in practice, this generally
-requires an active runtime session).
-
-{{command:positronPackages.refreshPackages}}
-
-### `positronPackages.updateAllPackages`
-
-Updates every installed package in the active runtime session to its latest
-available version. Use when the user asks to update all their packages.
-Updating can take a while for large environments -- say so. If code that's
-already running in the session doesn't reflect an update afterward, a session
-restart may be needed for it to take effect; mention that possibility and, if
-the user wants to proceed, use `workbench.action.language.runtime.restartActiveSession`
-with the state-loss warning above.
-
-Precondition: same as `refreshPackages` -- Packages pane enabled and a package
-operation currently able to run.
-
-{{command:positronPackages.updateAllPackages}}
 
 ## Looking up help topics
 

--- a/extensions/positron-skills/templates/positron-commands/references/ui.md
+++ b/extensions/positron-skills/templates/positron-commands/references/ui.md
@@ -60,7 +60,9 @@ the guidance below fills that gap.
 ### `workbench.view.positronPackages.view.focus`
 
 Focuses the Packages pane. Use after installing, updating, or removing
-packages, or whenever the user asks to see what's installed.
+packages, so the user can see the result. This shows the pane; it is not how
+you find out what is installed -- for that, read `positronPackages.getPackages`
+in [packages.md]({{skill_dir}}/references/packages.md).
 
 {{command:workbench.view.positronPackages.view.focus}}
 

--- a/src/vs/workbench/contrib/positronAiFeatures/test/browser/agentSkillTemplates.vitest.ts
+++ b/src/vs/workbench/contrib/positronAiFeatures/test/browser/agentSkillTemplates.vitest.ts
@@ -1,0 +1,157 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+/**
+ * Guards the frontmatter of every skill template against the limits Posit
+ * Assistant enforces when it loads a skill.
+ *
+ * Why this exists: Assistant validates frontmatter in
+ * `packages/core/src/skill/skill-loader.ts` and throws `SkillValidationError`
+ * on a violation. Its registry catches that error *per skill*, logs it at warn
+ * level, and carries on. So a template that breaks one of these rules does not
+ * fail loudly -- the skill silently does not exist, and the only symptom is a
+ * line in Assistant's log. Nothing else on the Positron side would notice, so
+ * the check has to live here.
+ *
+ * The limits below mirror that file. They are duplicated rather than imported
+ * because Assistant is a separate repository; if they drift, this test gets
+ * stricter or looser than reality, which is why the numbers carry their source.
+ */
+
+const TEST_FILE_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(TEST_FILE_DIR, '../../../../../../..');
+const SKILLS_ROOT = path.join(REPO_ROOT, 'extensions', 'positron-skills', 'templates');
+
+/** Mirrors `MAX_NAME_LENGTH` in Assistant's skill-loader.ts. */
+const MAX_NAME_LENGTH = 64;
+/** Mirrors `MAX_DESCRIPTION_LENGTH` in Assistant's skill-loader.ts. */
+const MAX_DESCRIPTION_LENGTH = 1024;
+/** Mirrors `SKILL_NAME_REGEX` in Assistant's skill-loader.ts. */
+const SKILL_NAME_REGEX = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+interface SkillFrontmatter {
+	/** Directory name under the templates root, e.g. `positron-commands`. */
+	readonly directoryName: string;
+	/** Path relative to the repo root, for failure messages. */
+	readonly relativePath: string;
+	readonly name?: string;
+	readonly description?: string;
+}
+
+/**
+ * Extracts `name` and `description` from a SKILL.md's frontmatter the way
+ * Assistant's parser does, which is not the way YAML does.
+ *
+ * Assistant hand-rolls its frontmatter parsing. For a block scalar it treats
+ * `>` and `|` identically: continuation lines are collected *raw* and joined
+ * with a newline, with no folding and no dedent (contrary to the YAML spec, but
+ * it is what runs). The upshot is that every line's leading indentation counts
+ * against `MAX_DESCRIPTION_LENGTH`, so measuring folded prose would understate
+ * the length by the size of the indentation and let a template through that
+ * Assistant then rejects. Hence this deliberately literal re-implementation.
+ * @param content The template's full text.
+ */
+function parseFrontmatter(content: string): { name?: string; description?: string } {
+	const lines = content.replace(/\r\n?/g, '\n').split('\n');
+	if (lines[0]?.trim() !== '---') {
+		return {};
+	}
+
+	const fields: Record<string, string> = {};
+	let currentKey: string | undefined;
+	let blockLines: string[] = [];
+
+	const flush = () => {
+		if (currentKey !== undefined) {
+			fields[currentKey] = blockLines.join('\n');
+		}
+		currentKey = undefined;
+		blockLines = [];
+	};
+
+	for (const line of lines.slice(1)) {
+		if (line.trim() === '---') {
+			break;
+		}
+		const keyValue = /^(\w[\w-]*):\s*(.*)$/.exec(line);
+		if (keyValue) {
+			flush();
+			const [, key, rawValue] = keyValue;
+			const value = rawValue.trim();
+			if (value === '>' || value === '|' || value === '') {
+				currentKey = key;
+			} else {
+				fields[key] = value.replace(/^["']|["']$/g, '');
+			}
+			continue;
+		}
+		if (currentKey !== undefined && line.trim()) {
+			blockLines.push(line);
+		}
+	}
+	flush();
+
+	return { name: fields['name'], description: fields['description'] };
+}
+
+/** Every `<name>/SKILL.md` one level under the templates root. */
+const skills: SkillFrontmatter[] = fs.existsSync(SKILLS_ROOT)
+	? fs.readdirSync(SKILLS_ROOT, { withFileTypes: true })
+		.filter(entry => entry.isDirectory())
+		.map(entry => path.join(SKILLS_ROOT, entry.name, 'SKILL.md'))
+		.filter(skillPath => fs.existsSync(skillPath))
+		.map(skillPath => ({
+			directoryName: path.basename(path.dirname(skillPath)),
+			relativePath: path.relative(REPO_ROOT, skillPath),
+			...parseFrontmatter(fs.readFileSync(skillPath, 'utf8')),
+		}))
+	: [];
+
+describe('agent skill templates', () => {
+	// Guards against a broken path calculation making every test below pass
+	// vacuously, the same way the drift test guards its own corpus.
+	it('found at least one skill template', () => {
+		expect(skills.length).toBeGreaterThan(0);
+	});
+
+	it.each(skills)('$directoryName has a description within Assistant\'s limit', skill => {
+		expect(skill.description, `${skill.relativePath} has no description`).toBeDefined();
+		const length = skill.description!.length;
+		expect(
+			length,
+			`${skill.relativePath}: description is ${length} characters, over Assistant's ` +
+			`${MAX_DESCRIPTION_LENGTH}-character limit, so the skill would silently fail to ` +
+			`load. Note this counts the indentation of each line in the block scalar, ` +
+			`not just the prose.`,
+		).toBeLessThanOrEqual(MAX_DESCRIPTION_LENGTH);
+	});
+
+	it.each(skills)('$directoryName has a name matching its directory', skill => {
+		// Assistant rejects a mismatch outright, so a rename that misses one of
+		// the two sides takes the skill out of service.
+		expect(skill.name, `${skill.relativePath} has no name`).toBe(skill.directoryName);
+		expect(skill.name!.length).toBeLessThanOrEqual(MAX_NAME_LENGTH);
+		expect(skill.name).toMatch(SKILL_NAME_REGEX);
+	});
+
+	it.each(skills)('$directoryName expands no directives inside its frontmatter', skill => {
+		// The length check above measures the template, but Assistant measures
+		// the generated output. Those are the same only while no `{{...}}`
+		// directive appears in frontmatter -- one that expanded to command
+		// metadata could push a passing template over the limit at runtime.
+		const frontmatter = `${skill.name ?? ''}\n${skill.description ?? ''}`;
+		expect(
+			frontmatter,
+			`${skill.relativePath}: frontmatter contains a {{...}} directive. The length ` +
+			`check above measures the template, so it no longer bounds the generated output.`,
+		).not.toMatch(/\{\{/);
+	});
+});


### PR DESCRIPTION
Closes #15344
Closes #15576

### Summary

Documents the package commands in the `positron-commands` agent skill. Package management moves out of `references/troubleshooting.md` into a new `references/packages.md`, which covers all five commands.

Three of them were undocumented: `positronPackages.getPackages` (added in #15594), `installPackage` and `updatePackage` (#15137). `refreshPackages` and `updateAllPackages` move over from the troubleshooting file.

The file leads with the correction from #15344, where Assistant ran `import pandas` in a try/except through `executeCode` to find out whether pandas was installed. The rule is: to learn what is installed, call `getPackages`; never probe the session with code. That is also why this closes #15576 as well -- the read command and the write commands have to be documented together for the "check what is installed before installing" flow to read as one rule rather than two disconnected facts.

Package management is also no longer a good fit for a file about troubleshooting, and with the `getPackages` payload to explain it is now the largest area in the skill.

Alongside that:

- **Rewrites the `SKILL.md` frontmatter description.** It now routes three reference files instead of two. Assistant caps a skill description at 1024 characters and rejects the skill outright above that, so the per-file routing enumeration is dropped -- the body's router says it better and is not length-capped. Net effect is a description that covers three areas in fewer characters than the old two-area one.
- **Corrects the Packages pane focus entry in `references/ui.md`**, which claimed to answer "what's installed". That is `getPackages`' job, not the pane's.
- **Adds `agentSkillTemplates.vitest.ts`**, asserting every template's frontmatter stays inside the limits Assistant enforces. Worth having because the failure mode is silent: Assistant throws `SkillValidationError`, catches it per skill, logs at warn level, and carries on -- so an over-long description does not break the build, it just makes the skill quietly not exist. The check re-implements Assistant's block-scalar parsing deliberately, because that parser does not fold or dedent, so each line's indentation counts against the limit and measuring the prose alone would understate it.

The five command ids added here are already covered by the existing `agentSkillDrift.vitest.ts`, which scans the templates directory recursively.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

Agent-facing skill content. Platform skill discovery and the command tool are both behind `assistant.experimentalFeatures`, which is off by default, so nothing changes for users on a default install.

### Validation Steps

No e2e tags. Deliberate, and worth a sentence since the convention is to include at least one: this change is skill template content plus a test, with no runtime code, and platform skill discovery is gated behind `assistant.experimentalFeatures` (default off). No existing e2e test loads the skill, so no e2e suite can observe this change -- tagging one would spend CI without producing signal. Happy to add a tag if a reviewer disagrees.

Unit coverage:

```
npx vitest run src/vs/workbench/contrib/positronAiFeatures/test/browser/
```

#### Setup

1. Set `assistant.experimentalFeatures` to `true`, confirm `ai.enabled` is on, and reload the window.
2. Start a Python session and install something with a known advisory: `pip install "jinja2==2.10"` (pure Python, installs on any 3.x).

**You will usually have to tell Assistant to use the `positron-commands` skill at least once.** Some models don't reach for it on their own -- noticeably more of a problem with Python than with R. That's a model/prompting gap rather than something this skill content can fix, and it's being addressed separately in Assistant. Without that nudge it's easy to conclude the skill is broken when it was simply never loaded.

#### Then ask Assistant

1. **"Is pandas installed?"** -- should answer from the package list. It should **not** run `import pandas` in your session to find out. This is the behavior the file exists to correct (see #15344).
2. **"What packages do I have, and are any out of date?"** -- should report versions and outdated state, and hedge rather than declaring you up to date if the metadata isn't fresh.
3. **"Do I have any packages with known security vulnerabilities?"** -- should name jinja2, lead with the worst advisory, and say which host the advisory data came from and when.
4. **"What should I do about it?"** -- should propose updating jinja2 to a specific version. It should **not** paste the `fixedIn` text in as a version (it can name several release branches), and should **not** reach for Update All Packages to fix one package.
5. **"Install `<some package you don't have>`"**, then **"install jinja2"** -- the first should install; the second should recognise jinja2 is already present and update rather than install, since installing an existing package is a no-op.

#### Negative cases

6. Set `packages.vulnerabilities.enabled` to `false` and re-ask (3). It should say it **couldn't determine** whether you have vulnerabilities -- not that you have none.
7. Shut down the session and ask (1) again. It should say no interpreter is running, rather than guessing or reading files to answer.

#### R

Repeat (1)-(3) in an R session. CRAN advisory coverage is sparser than PyPI's, so an empty advisory result in R is an environment fact rather than a bug -- (1) and (2) are the meaningful checks there.

#### If Assistant seems unaware of these commands

Check the skill actually generated: `<globalStorage>/positron.positron-skills/skills/positron-commands/references/packages.md` should exist and contain a "Security advisories" section. If it's missing, the skill didn't load and nothing above is a fair test.

### Notes for reviewers

- **Question: when do we split this into separate skills?** This came up for real while rebasing. The cap is on the frontmatter `description` field (1024 characters), not the file as a whole, and #15650 landed it at **1019 -- five characters of headroom** while adding `interpreters.md` and `python-setup.md`. Adding a fifth area on top of that was impossible without cutting, and going over doesn't fail loudly: Assistant throws `SkillValidationError`, catches it per skill, logs at warn level, and the entire `positron-commands` skill silently stops existing.

  I bought the room back by dropping the per-file routing enumeration from the description again -- the body's router says the same thing better and isn't length-capped. The merged result is **926 with 98 to spare, covering five areas**, where main used 1019 for four. So this is resolved for now, but the pattern is clear: each new area costs 60-100 characters, the enumeration is the only fat left, and it has now been re-added and re-removed once.

  Options are one skill with a reference file per area, or per-area skills that each get their own 1024. Splitting buys budget and gives each area a more specific description, which might also help with the under-triggering noted in Validation Steps; the cost is that the model has to pick the right skill up front instead of loading one router and being pointed at a file. My inclination is still to hold at one skill and revisit once Assistant reaches for these reliably -- splitting while triggering is unreliable changes two variables at once. But whoever adds the sixth area will face this again with less room than I had.

- **Large payloads can still be truncated.** posit-dev/assistant#2194 raised the cap on command results and made the truncation structure-aware, but a big environment -- especially with advisory data attached to every package -- can still exceed it. The difference is that the result is now well-formed JSON that states the list may be incomplete, rather than a string cut mid-token. Previously the model discarded the broken payload and fell back to running code in the session, which is the exact behavior this skill exists to prevent. Note that `references/packages.md` does not yet tell the model what to do with a *partial* list; that guidance depends on the final shape of the truncation marker and is worth a follow-up.
- The skill still leaves five agent-compatible commands undocumented (`vscode.open`, `startNewConsoleSession`, `selectSession`, and the two data connections commands), each tracked by its own open issue. A reverse-coverage assertion in the drift test would make that list self-closing; left out here as out of scope.





