### PR TITLE
Fire an event when agent skill roots change

### DIFF
--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -4289,6 +4289,16 @@ declare module 'positron' {
 		export function getAgentSkillRoots(): Thenable<string[]>;
 
 		/**
+		 * Fires when a skill root is added or removed.
+		 *
+		 * Roots are registered from extension activation, so they frequently
+		 * land after a consumer has taken its first {@link getAgentSkillRoots}
+		 * snapshot. Observe this event and re-read rather than trusting that
+		 * initial result.
+		 */
+		export const onDidChangeAgentSkillRoots: vscode.Event<void>;
+
+		/**
 		 * Validate and execute a Positron command.
 		 *
 		 * Unlike `vscode.commands.executeCommand`, this call first checks that

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -570,6 +570,9 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			registerAgentSkillRoot(root: string): vscode.Disposable {
 				return extHostAiFeatures.registerAgentSkillRoot(root);
 			},
+			get onDidChangeAgentSkillRoots(): vscode.Event<void> {
+				return extHostAiFeatures.onDidChangeAgentSkillRoots;
+			},
 			validateAndExecuteCommand(
 				commandId: string,
 				args?: unknown[],

--- a/src/vs/workbench/api/common/positron/extHostAiFeatures.ts
+++ b/src/vs/workbench/api/common/positron/extHostAiFeatures.ts
@@ -29,9 +29,11 @@ export class ExtHostAiFeatures implements extHostProtocol.ExtHostAiFeaturesShape
 	private readonly _dialogSessions = new Map<string, { resolve: () => void }>();
 	private readonly _onDidChangeProviderConfigEmitter = this._disposables.add(new Emitter<IPositronLanguageModelSource>());
 	private readonly _onDidChangeProviderEnablementEmitter = this._disposables.add(new Emitter<{ id: string; enabled: boolean }>());
+	private readonly _onDidChangeAgentSkillRootsEmitter = this._disposables.add(new Emitter<void>());
 
 	readonly onDidChangeProviderConfig = this._onDidChangeProviderConfigEmitter.event;
 	readonly onDidChangeProviderEnablement = this._onDidChangeProviderEnablementEmitter.event;
+	readonly onDidChangeAgentSkillRoots = this._onDidChangeAgentSkillRootsEmitter.event;
 
 	constructor(
 		mainContext: extHostProtocol.IMainPositronContext,
@@ -221,8 +223,10 @@ export class ExtHostAiFeatures implements extHostProtocol.ExtHostAiFeaturesShape
 
 	registerAgentSkillRoot(root: string): Disposable {
 		this._registeredSkillRoots.add(root);
+		this._onDidChangeAgentSkillRootsEmitter.fire();
 		return new Disposable(() => {
 			this._registeredSkillRoots.delete(root);
+			this._onDidChangeAgentSkillRootsEmitter.fire();
 		});
 	}
 

--- a/src/vs/workbench/api/test/common/positron/extHostAiFeatures.vitest.ts
+++ b/src/vs/workbench/api/test/common/positron/extHostAiFeatures.vitest.ts
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { mock } from '../../../../../base/test/common/mock.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { ExtHostCommands } from '../../../common/extHostCommands.js';
+import { IExtHostWorkspace } from '../../../common/extHostWorkspace.js';
+import { MainThreadAiFeaturesShape } from '../../../common/positron/extHost.positron.protocol.js';
+import { ExtHostAiFeatures } from '../../../common/positron/extHostAiFeatures.js';
+import { SingleProxyRPCProtocol } from '../testRPCProtocol.js';
+
+/**
+ * Builds the object under test. Skill roots are extension-host-local state, so
+ * none of these collaborators are touched by the code exercised here: the
+ * `mock`/`stubInterface` doubles throw loudly if that ever stops being true.
+ */
+function createAiFeatures(): ExtHostAiFeatures {
+	const shape = new class extends mock<MainThreadAiFeaturesShape>() { };
+	const commands = new class extends mock<ExtHostCommands>() { };
+	return new ExtHostAiFeatures(
+		SingleProxyRPCProtocol(shape),
+		commands,
+		stubInterface<IExtHostWorkspace>(),
+	);
+}
+
+describe('ExtHostAiFeatures skill roots', () => {
+	it('fires onDidChangeAgentSkillRoots when a root is registered', () => {
+		const aiFeatures = createAiFeatures();
+		let fired = 0;
+		const listener = aiFeatures.onDidChangeAgentSkillRoots(() => fired++);
+
+		aiFeatures.registerAgentSkillRoot('/skills');
+
+		expect(fired).toBe(1);
+		listener.dispose();
+	});
+
+	// The consumer's contract: the assistant re-reads the roots from inside its
+	// listener, so a root registered before the event must already be readable
+	// when the event arrives.
+	it('has the new root readable from within the listener', async () => {
+		const aiFeatures = createAiFeatures();
+		let rootsSeenByListener: string[] | undefined;
+		const listener = aiFeatures.onDidChangeAgentSkillRoots(async () => {
+			rootsSeenByListener = await aiFeatures.getAgentSkillRoots();
+		});
+
+		aiFeatures.registerAgentSkillRoot('/skills');
+		await Promise.resolve();
+
+		expect(rootsSeenByListener).toEqual(['/skills']);
+		listener.dispose();
+	});
+
+	it('fires onDidChangeAgentSkillRoots when a registered root is disposed', () => {
+		const aiFeatures = createAiFeatures();
+		const registration = aiFeatures.registerAgentSkillRoot('/skills');
+		let fired = 0;
+		const listener = aiFeatures.onDidChangeAgentSkillRoots(() => fired++);
+
+		registration.dispose();
+
+		expect(fired).toBe(1);
+		listener.dispose();
+	});
+});


### PR DESCRIPTION
Positron ships a generated `positron-commands` skill and registers its directory with `positron.ai.registerAgentSkillRoot`. I am observing that the consumer that reads the roots at startup can miss that registration, and nothing tells it to read again.

### Summary

The `positron-skills` extension activates on `onAiEnabled`, which a `LifecyclePhase.Eventually` contribution fires. That registration lands seconds after the extension host starts. Posit Assistant reads the roots one time, when it creates the conversation host for the window. If the chat view is restored at startup, the assistant reads an empty list, and the window has no platform skills until a reload. The model then reports that no `positron-commands` skill exists. That report is accurate, because the skill never reached its prompt.

This adds `positron.ai.onDidChangeAgentSkillRoots`. It fires when an extension registers a root, and when it disposes one. The event fires after the set of roots changes, so a listener that re-reads inside its callback sees the new root.

Posit Assistant already has the consumer side. posit-dev/assistant#2152 subscribes to this exact member and re-reads the roots. It feature-detects the member, because older Positron builds lack it. Positron never provided the event, so that subscription was a no-op and the assistant kept its one-shot read. Were we already going to implement this somewhere else? Did I miss something?

Skill roots are extension-host-local state, so this needs no protocol change and no main-thread work. 

Related: 
- #15341
- #15342 
- #15343

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed the generated Positron commands skill being absent from Posit Assistant when the chat view was restored at startup.

### Validation Steps

@:assistant

Automated coverage:

`npx vitest run src/vs/workbench/api/test/common/positron/extHostAiFeatures.vitest.ts` covers three cases, and all three fail on `main`:

- the event fires when a root is registered
- the new root is readable from inside the listener, which fails if the event fires before the set is updated
- the event fires when the registration is disposed

Manual check. This needs a Posit Assistant build that contains posit-dev/assistant#2152, so check the installed version first:

1. Open the assistant chat, then reload the window with _Developer: Reload Window_, so the chat view is restored at startup. This is the case that lost the race.
2. Ask the assistant to list its available skills.
3. Make sure that `positron-commands` is in the list. Before this change it was absent here, and it appeared only if you opened the chat a few seconds after launch.
