### PR TITLE
Update ai-lib to 74bc81d8

### DIFF
--- a/extensions/authentication/src/providerCatalog.ts
+++ b/extensions/authentication/src/providerCatalog.ts
@@ -90,7 +90,6 @@ function applyCatalog(next: readonly ResolvedProvider[]): void {
 async function loadCatalog(options: ProviderCatalogOptions): Promise<readonly ResolvedProvider[]> {
 	const { loadResolvedProviderCatalog } = await import('ai-config/node');
 	return loadResolvedProviderCatalog({
-		baseline: { defaultEnabled: true },
 		configPath: options.configPath,
 		envVars: options.envVars,
 		// PROVIDER-SETTINGS-MIGRATION(legacy-positron): keep the legacy
@@ -124,7 +123,6 @@ export async function initProviderCatalog(
 	watcher = watchResolvedProviderCatalog(
 		(change: ProviderCatalogChange) => applyCatalog(change.catalog),
 		{
-			baseline: { defaultEnabled: true },
 			configPath: options.configPath,
 			envVars: options.envVars,
 			// PROVIDER-SETTINGS-MIGRATION(legacy-positron): same opt-in as

--- a/src/vs/platform/positronAiProvider/node/aiProviderCatalog.ts
+++ b/src/vs/platform/positronAiProvider/node/aiProviderCatalog.ts
@@ -33,7 +33,6 @@ export class AiProviderCatalog extends Disposable implements IAiProviderCatalog 
 
 	private loadOptions(): import('ai-config/node').LoadCatalogOptions {
 		return {
-			baseline: { defaultEnabled: true },
 			configPath: this._options?.configPath,
 			envVars: this._options?.envVars,
 			// PROVIDER-SETTINGS-MIGRATION(legacy-positron): keep the legacy


### PR DESCRIPTION
This pull request updates ai-lib to 74bc81d8, which is the current `main`. The purpose is to bring in the changes from https://github.com/posit-dev/ai-lib/pull/74. That PR removes an obsolete public API from ai-lib, so this PR also updates call sites in Positron which used that API.