### PR TITLE
Stabilize Data Explorer paging for SQLite and DuckDB tables and views

### DIFF
--- a/extensions/positron-data-driver-duckdb/src/test/duckdbPaging.test.ts
+++ b/extensions/positron-data-driver-duckdb/src/test/duckdbPaging.test.ts
@@ -1,0 +1,228 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import {
+	DuckDBRow,
+	DuckDBSchemaEntry,
+	DuckDBTableView,
+	createDuckDBReadPlan,
+} from 'positron-data-explorer-duckdb';
+import { ColumnDisplayType, FormatOptions, TableSelectionKind } from 'positron-data-explorer-protocol';
+
+const FORMAT: FormatOptions = {
+	large_num_digits: 2,
+	small_num_digits: 4,
+	max_integral_digits: 7,
+	max_value_length: 100,
+};
+
+const SCHEMA: DuckDBSchemaEntry[] = [
+	{ column_name: 'id', column_type: 'BIGINT', type_display: ColumnDisplayType.Integer },
+];
+
+const COLUMNS = SCHEMA.map(c => c.column_name);
+
+const TABLE_REF = '"main"."events"';
+const VIEW_REF = '"main"."sales_by_region"';
+const ROW_COUNT = 500;
+const PAGE_SIZE = 25;
+
+/**
+ * A fake engine modelling the ordering guarantees DuckDB actually gives, measured against DuckDB
+ * 1.5.5 and pinned by `preserve_insertion_order` in `duckdbWorker.ts`:
+ *
+ * - Scanning a base table or a TEMP table returns rows in insertion order, every time, with or
+ *   without an ORDER BY. Sweeping 2M rows over 2,000 pages that way repeated and dropped nothing.
+ * - Reading a view whose plan is built from hash operators (a join, an aggregate, a DISTINCT, a
+ *   window) does not: there is no input order to preserve, so each statement may permute the rows.
+ *   Sweeping a 500,000-row join view that way repeated 170,032 rows and missed 170,032 others.
+ * - A ROW_NUMBER() window does not inherit the scan's insertion order either. Numbering rows with a
+ *   constant window order disagreed with the displayed order on all 171,429 rows of one relation.
+ *
+ * So this fake permutes exactly the statements DuckDB is entitled to permute, and only those. A
+ * sweep that comes back exact is a sweep that never relied on an order DuckDB does not promise.
+ */
+class DuckDBEngine {
+	readonly queries: string[] = [];
+	private _statements = 0;
+
+	private readonly _canonical = Array.from({ length: ROW_COUNT }, (_, i) => i + 1);
+
+	async runQuery(sql: string, _params?: Record<string, string>): Promise<DuckDBRow[]> {
+		this.queries.push(sql);
+		const flat = sql.replace(/\s+/g, ' ');
+
+		if (flat.startsWith('CREATE TEMP TABLE')) {
+			return [];
+		}
+		if (flat.includes('count(*)')) {
+			return [{ n: ROW_COUNT }];
+		}
+
+		const ordered = this._order(flat);
+
+		const rowIndices = /__row_index IN \(([\d, ]+)\)/.exec(flat);
+		if (rowIndices) {
+			const wanted = rowIndices[1].split(',').map(part => Number(part.trim()));
+			return wanted.map(index => ({ c0: ordered[index] }));
+		}
+
+		const window = /LIMIT (\d+) OFFSET (\d+)/.exec(flat);
+		if (window) {
+			const offset = Number(window[2]);
+			return ordered.slice(offset, offset + Number(window[1])).map(id => ({ c0: id }));
+		}
+		return ordered.map(id => ({ c0: id }));
+	}
+
+	/** Returns the rows in the order this statement is entitled to see them. */
+	private _order(flat: string): number[] {
+		this._statements++;
+
+		// A ROW_NUMBER() window is ordered by what is inside its OVER clause, and by nothing else.
+		const over = /ROW_NUMBER\(\) OVER \((.*?)\)/.exec(flat);
+		if (over) {
+			return over[1].includes('rowid') ? this._canonical : this._permuted();
+		}
+
+		// Otherwise an explicit total order pins it, and failing that a scan of a table or snapshot
+		// still comes back in insertion order. Only reading the view directly is unordered.
+		const orderBy = /ORDER BY (.+?)(?: LIMIT|$)/.exec(flat);
+		if (orderBy?.[1].includes('rowid')) {
+			return this._canonical;
+		}
+		return flat.includes(VIEW_REF) ? this._permuted() : this._canonical;
+	}
+
+	/** The smallest permutation that exposes the defect: one row lost per page boundary. */
+	private _permuted(): number[] {
+		const shift = this._statements % ROW_COUNT;
+		return [...this._canonical.slice(shift), ...this._canonical.slice(0, shift)];
+	}
+}
+
+/** Reads every page in sequence and reports which rows were repeated or never seen. */
+async function sweep(view: DuckDBTableView): Promise<{ duplicated: number; missing: number }> {
+	const seen = new Map<number, number>();
+	for (let offset = 0; offset < ROW_COUNT; offset += PAGE_SIZE) {
+		const page = await view.getDataValues({
+			columns: [{ column_index: 0, spec: { first_index: offset, last_index: offset + PAGE_SIZE - 1 } }],
+			format_options: FORMAT,
+		});
+		for (const value of page.columns[0]) {
+			const id = Number(value);
+			seen.set(id, (seen.get(id) ?? 0) + 1);
+		}
+	}
+	let duplicated = 0;
+	for (const count of seen.values()) {
+		duplicated += count - 1;
+	}
+	return { duplicated, missing: ROW_COUNT - seen.size };
+}
+
+suite('DuckDB paging Tests', () => {
+	test('an unsorted table is paged exactly once per row, without an ORDER BY', async () => {
+		// Both halves of this matter. The rows have to be exact, and the paging queries have to stay
+		// free of ORDER BY: DuckDB cannot tell that `rowid` order is the scan order it was already
+		// going to produce, so adding the clause makes it sort the whole relation on every page --
+		// 7.4x over a measured 2M-row sweep -- to buy back an order it never lost.
+		const engine = new DuckDBEngine();
+		const plan = createDuckDBReadPlan(engine, TABLE_REF, 'table', COLUMNS);
+		const view = new DuckDBTableView(engine, TABLE_REF, 'events', plan, SCHEMA);
+
+		const result = await sweep(view);
+		const pagingQueries = engine.queries.filter(q => q.includes('OFFSET'));
+
+		assert.deepStrictEqual(
+			{ ...result, sortsAnyPage: pagingQueries.some(q => q.includes('ORDER BY')) },
+			{ duplicated: 0, missing: 0, sortsAnyPage: false });
+	});
+
+	test('a sorted table breaks ties on rowid', async () => {
+		// Sort keys alone are not a total order: rows tied on the key are free to move between
+		// statements. Here the sort is paid for regardless, so the tiebreaker is nearly free.
+		const engine = new DuckDBEngine();
+		const plan = createDuckDBReadPlan(engine, TABLE_REF, 'table', COLUMNS);
+		const view = new DuckDBTableView(engine, TABLE_REF, 'events', plan, SCHEMA);
+		await view.setSortColumns({ sort_keys: [{ column_index: 0, ascending: false }] });
+
+		const result = await sweep(view);
+		const dataQuery = engine.queries.find(q => q.includes('OFFSET'))!;
+
+		assert.deepStrictEqual(
+			{ ...result, ordersBy: /ORDER BY "id" DESC, rowid/.test(dataQuery) },
+			{ duplicated: 0, missing: 0, ordersBy: true });
+	});
+
+	test('a view is paged exactly once per row, from a snapshot built once', async () => {
+		// Without the snapshot this is the live defect: the view's hash operators give a different
+		// permutation per page, and `rowid` does not exist on a view to order by instead.
+		const engine = new DuckDBEngine();
+		const plan = createDuckDBReadPlan(engine, VIEW_REF, 'view', COLUMNS);
+		const view = new DuckDBTableView(engine, VIEW_REF, 'sales_by_region', plan, SCHEMA);
+
+		const result = await sweep(view);
+		const snapshots = engine.queries.filter(q => q.startsWith('CREATE TEMP TABLE'));
+		const readsView = engine.queries.some(q => q.includes('OFFSET') && q.includes(VIEW_REF));
+
+		assert.deepStrictEqual(
+			{ ...result, snapshots: snapshots.length, readsView },
+			// One snapshot for the whole sweep, and no page reads the view: its join runs once here,
+			// rather than once per page, which is why this is cheaper than reading it directly.
+			{ duplicated: 0, missing: 0, snapshots: 1, readsView: false });
+	});
+
+	test('the row count and the rows come from the same relation', async () => {
+		// The grid's total comes from a separate count(*). Counting the live view while displaying a
+		// snapshot would let the total disagree with what the rows add up to.
+		const engine = new DuckDBEngine();
+		const plan = createDuckDBReadPlan(engine, VIEW_REF, 'view', COLUMNS);
+		const view = new DuckDBTableView(engine, VIEW_REF, 'sales_by_region', plan, SCHEMA);
+		await view.getState();
+
+		const countQuery = engine.queries.find(q => q.includes('count(*)'))!;
+		assert.match(countQuery, /FROM temp\."positron_snapshot_\d+"/);
+	});
+
+	test('an index-based export returns the rows the grid displayed at those positions', async () => {
+		// The half of the defect that leaves a lasting artifact. This path writes a file the user
+		// keeps, and unlike a paging query it cannot leave the order unstated, because a window
+		// operator does not inherit the scan order.
+		const engine = new DuckDBEngine();
+		const plan = createDuckDBReadPlan(engine, TABLE_REF, 'table', COLUMNS);
+		const view = new DuckDBTableView(engine, TABLE_REF, 'events', plan, SCHEMA);
+
+		const positions = [0, 7, 199, 498];
+		const displayed: number[] = [];
+		for (const position of positions) {
+			const page = await view.getDataValues({
+				columns: [{ column_index: 0, spec: { first_index: position, last_index: position } }],
+				format_options: FORMAT,
+			});
+			displayed.push(Number(page.columns[0][0]));
+		}
+
+		const exported = await view.exportDataSelection({
+			selection: { kind: TableSelectionKind.RowIndices, selection: { indices: positions } },
+			format: 'csv' as never,
+		});
+		const exportedIds = exported.data.trim().split('\n').slice(1).map(Number);
+
+		assert.deepStrictEqual(exportedIds, displayed);
+	});
+
+	test('generated code names the user\'s relation, not the snapshot', async () => {
+		const engine = new DuckDBEngine();
+		const plan = createDuckDBReadPlan(engine, VIEW_REF, 'view', COLUMNS);
+		const view = new DuckDBTableView(engine, VIEW_REF, 'sales_by_region', plan, SCHEMA);
+		await view.getState();
+
+		const code = await view.convertToCode({} as never);
+
+		assert.deepStrictEqual(code.converted_code, ['SELECT *', `FROM ${VIEW_REF}`]);
+	});
+});

--- a/extensions/positron-data-driver-duckdb/src/test/duckdbReadPlan.test.ts
+++ b/extensions/positron-data-driver-duckdb/src/test/duckdbReadPlan.test.ts
@@ -1,0 +1,156 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { DuckDBRow, createDuckDBReadPlan } from 'positron-data-explorer-duckdb';
+
+/** A fake client that records SQL and stands in for one DuckDB connection. */
+class FakeClient {
+	readonly queries: string[] = [];
+	private _crashListener: (() => void) | undefined;
+
+	async runQuery(sql: string, _params?: Record<string, string>): Promise<DuckDBRow[]> {
+		this.queries.push(sql);
+		return [];
+	}
+
+	/** Stands in for `DuckDBWorkerClient.onDidCrash`. */
+	onDidCrash = (listener: () => void) => {
+		this._crashListener = listener;
+		return { dispose: () => { this._crashListener = undefined; } };
+	};
+
+	/** Simulates the worker dying and being replaced, which empties the `temp` catalog. */
+	crash(): void {
+		this._crashListener?.();
+	}
+}
+
+suite('DuckDB read plan Tests', () => {
+	test('a table is read in place, with rowid as its row order', async () => {
+		const client = new FakeClient();
+		const plan = createDuckDBReadPlan(client, '"main"."people"', 'table', ['id', 'label']);
+
+		assert.deepStrictEqual(
+			{ relation: await plan.relation(), rowOrder: plan.rowOrder, queries: client.queries },
+			// Nothing is created and nothing is asked: a scan of a base table already comes back in
+			// insertion order, so there is no setup to do.
+			{ relation: '"main"."people"', rowOrder: 'rowid', queries: [] });
+	});
+
+	test('a view is read through a snapshot, materialized once', async () => {
+		const client = new FakeClient();
+		const plan = createDuckDBReadPlan(client, '"main"."sales_by_region"', 'view', ['id', 'label']);
+
+		// Nothing is created until the first read, so opening a view costs nothing extra.
+		assert.deepStrictEqual(client.queries, []);
+
+		const first = await plan.relation();
+		const second = await plan.relation();
+
+		assert.deepStrictEqual(
+			{
+				reusesOneSnapshot: first === second,
+				readsFromTempCatalog: /^temp\."positron_snapshot_\d+"$/.test(first),
+				rowOrder: plan.rowOrder,
+				creates: client.queries,
+			},
+			{
+				reusesOneSnapshot: true,
+				readsFromTempCatalog: true,
+				rowOrder: 'rowid',
+				// Materialized exactly once, however many reads follow. The CREATE names the snapshot
+				// unqualified, because DuckDB rejects a catalog-qualified name there.
+				creates: [
+					`CREATE TEMP TABLE ${first.replace('temp.', '')} AS SELECT * FROM "main"."sales_by_region"`,
+				],
+			});
+	});
+
+	test('a view that emits a rowid column is numbered explicitly, not ordered by that column', async () => {
+		// `SELECT *` copies the view's columns verbatim, so a view emitting `rowid` puts a column of
+		// that name into the snapshot, where it shadows the snapshot's own rowid. Ordering by the name
+		// would then read the copied column, which carries no uniqueness once a join has fanned the
+		// view out -- paging would drift again, and an index-based export would write rows the user
+		// never selected. DuckDB has no second spelling of the rowid, so the rows get their own column.
+		const client = new FakeClient();
+		const plan = createDuckDBReadPlan(client, '"main"."v"', 'view', ['rowid', 'total']);
+
+		const relation = await plan.relation();
+
+		assert.deepStrictEqual(
+			{ rowOrder: plan.rowOrder, creates: client.queries },
+			{
+				rowOrder: '"__positron_row_order"',
+				creates: [
+					`CREATE TEMP TABLE ${relation.replace('temp.', '')} AS ` +
+					`SELECT ROW_NUMBER() OVER () AS "__positron_row_order", * FROM "main"."v"`,
+				],
+			});
+	});
+
+	test('dispose drops the snapshot', async () => {
+		const client = new FakeClient();
+		const plan = createDuckDBReadPlan(client, '"main"."v"', 'view', ['id', 'label']);
+		const relation = await plan.relation();
+		client.queries.length = 0;
+
+		await plan.dispose();
+
+		assert.deepStrictEqual(client.queries, [`DROP TABLE IF EXISTS ${relation}`]);
+	});
+
+	test('dispose drops nothing when the snapshot was never materialized', async () => {
+		const client = new FakeClient();
+		const plan = createDuckDBReadPlan(client, '"main"."v"', 'view', ['id', 'label']);
+
+		await plan.dispose();
+
+		assert.deepStrictEqual(client.queries, []);
+	});
+
+	test('a read after dispose is refused rather than leaking a fresh snapshot', async () => {
+		// A queued column profile can outlive the tab that asked for it. Materializing again here would
+		// build a snapshot with nothing left to drop it, so it would sit in `temp` for the rest of the
+		// connection's life.
+		const client = new FakeClient();
+		const plan = createDuckDBReadPlan(client, '"main"."v"', 'view', ['id', 'label']);
+		await plan.relation();
+		await plan.dispose();
+		client.queries.length = 0;
+
+		await assert.rejects(() => plan.relation(), /disposed/);
+		assert.deepStrictEqual(client.queries, []);
+	});
+
+	test('the snapshot is rebuilt after the worker is replaced', async () => {
+		// A replacement worker starts with an empty `temp` catalog. Without this, every later read
+		// would fail until the user reopened the tab.
+		const client = new FakeClient();
+		const plan = createDuckDBReadPlan(client, '"main"."v"', 'view', ['id', 'label']);
+		await plan.relation();
+		const createsBefore = client.queries.filter(q => q.startsWith('CREATE TEMP TABLE')).length;
+
+		client.crash();
+		await plan.relation();
+
+		assert.deepStrictEqual(
+			{
+				createsBefore,
+				createsAfter: client.queries.filter(q => q.startsWith('CREATE TEMP TABLE')).length,
+			},
+			{ createsBefore: 1, createsAfter: 2 });
+	});
+
+	test('concurrently open views get distinct snapshots', async () => {
+		// One worker serves every connection to the same file, so two open views share a `temp`
+		// catalog and must not both claim the same snapshot name.
+		const client = new FakeClient();
+		const first = createDuckDBReadPlan(client, '"main"."a"', 'view', ['id', 'label']);
+		const second = createDuckDBReadPlan(client, '"main"."b"', 'view', ['id', 'label']);
+
+		assert.notStrictEqual(await first.relation(), await second.relation());
+	});
+});

--- a/extensions/positron-data-driver-duckdb/src/test/duckdbReadPlan.test.ts
+++ b/extensions/positron-data-driver-duckdb/src/test/duckdbReadPlan.test.ts
@@ -40,6 +40,28 @@ suite('DuckDB read plan Tests', () => {
 			{ relation: '"main"."people"', rowOrder: 'rowid', queries: [] });
 	});
 
+	test('a table that declares a rowid column is snapshotted, not read in place', async () => {
+		// The declared column shadows the table's real rowid, and DuckDB has no second spelling to reach
+		// past it, so reading in place would order by user data: `('b',1),('a',2),('c',3)` displays 1, 2,
+		// 3 in scan order while an export numbering by `rowid` returns 2, 1, 3. Snapshotting numbers the
+		// rows in a column of the snapshot's own instead. Matched without regard to case, as DuckDB
+		// resolves unquoted identifiers that way.
+		const client = new FakeClient();
+		const plan = createDuckDBReadPlan(client, '"main"."imported"', 'table', ['ROWID', 'v']);
+
+		const relation = await plan.relation();
+
+		assert.deepStrictEqual(
+			{ rowOrder: plan.rowOrder, creates: client.queries },
+			{
+				rowOrder: '"__positron_row_order"',
+				creates: [
+					`CREATE TEMP TABLE ${relation.replace('temp.', '')} AS ` +
+					`SELECT ROW_NUMBER() OVER () AS "__positron_row_order", * FROM "main"."imported"`,
+				],
+			});
+	});
+
 	test('a view is read through a snapshot, materialized once', async () => {
 		const client = new FakeClient();
 		const plan = createDuckDBReadPlan(client, '"main"."sales_by_region"', 'view', ['id', 'label']);

--- a/extensions/positron-data-driver-duckdb/src/test/duckdbTableView.test.ts
+++ b/extensions/positron-data-driver-duckdb/src/test/duckdbTableView.test.ts
@@ -9,6 +9,7 @@ import {
 	DuckDBRow,
 	DuckDBSchemaEntry,
 	DuckDBTableView,
+	IDuckDBReadPlan,
 	duckdbDisplayType,
 	makeWhereExpr
 } from 'positron-data-explorer-duckdb';
@@ -25,6 +26,14 @@ import {
 	RowFilterType,
 	TextSearchType,
 } from 'positron-data-explorer-protocol';
+
+/**
+ * The read plan of a DuckDB base table: read in place, with `rowid` available as the row order for
+ * sorted paging and for numbering export rows. `duckdbReadPlan` covers the plan choice itself.
+ */
+function rowidReadPlan(tableRef: string): IDuckDBReadPlan {
+	return { relation: async () => tableRef, rowOrder: 'rowid', dispose: async () => { } };
+}
 
 /** A fake query client that records SQL and answers from a caller-supplied responder. */
 class FakeQueryClient {
@@ -125,7 +134,7 @@ suite('DuckDB Data Explorer Tests', () => {
 					{ c0: 3, c1: Infinity },
 				];
 			});
-			const view = new DuckDBTableView(client, '"main"."people"', 'people', 'table', schema);
+			const view = new DuckDBTableView(client, '"main"."people"', 'people', rowidReadPlan('"main"."people"'), schema);
 			const data = await view.getDataValues({
 				columns: [
 					{ column_index: 0, spec: { first_index: 0, last_index: 2 } },
@@ -157,7 +166,7 @@ suite('DuckDB Data Explorer Tests', () => {
 			];
 			const client = new FakeQueryClient(sql =>
 				sql.includes('count(*)') ? [{ n: 2 }] : [{ c0: 1.5 }, { c0: 2.5 }]);
-			const view = new DuckDBTableView(client, '"main"."people"', 'people', 'table', oneColumn);
+			const view = new DuckDBTableView(client, '"main"."people"', 'people', rowidReadPlan('"main"."people"'), oneColumn);
 
 			const state = await view.getState();
 			const data = await view.getDataValues({
@@ -181,7 +190,7 @@ suite('DuckDB Data Explorer Tests', () => {
 		const idleClient = new FakeQueryClient(() => [{ n: 0 }]);
 
 		test('without a generator, advertises SQL and emits a SELECT over the table', async () => {
-			const view = new DuckDBTableView(idleClient, '"main"."people"', 'people', 'table', schema);
+			const view = new DuckDBTableView(idleClient, '"main"."people"', 'people', rowidReadPlan('"main"."people"'), schema);
 			const state = await view.getState();
 			assert.deepStrictEqual(state.supported_features.convert_to_code.code_syntaxes, [{ code_syntax_name: 'SQL' }]);
 			assert.deepStrictEqual(await view.suggestCodeSyntax(), { code_syntax_name: 'SQL' });
@@ -195,7 +204,7 @@ suite('DuckDB Data Explorer Tests', () => {
 				defaultSyntaxName: 'R',
 				generate: (syntax: string) => [`# ${syntax} code`],
 			};
-			const view = new DuckDBTableView(idleClient, '"main"."people"', 'people', 'table', schema, generator);
+			const view = new DuckDBTableView(idleClient, '"main"."people"', 'people', rowidReadPlan('"main"."people"'), schema, generator);
 
 			const state = await view.getState();
 			assert.deepStrictEqual(state.supported_features.convert_to_code.code_syntaxes, [

--- a/extensions/positron-data-driver-sqlite/src/sqliteDataExplorerRpcHandler.ts
+++ b/extensions/positron-data-driver-sqlite/src/sqliteDataExplorerRpcHandler.ts
@@ -5,6 +5,8 @@
 
 import * as positron from 'positron';
 import * as vscode from 'vscode';
+import { createSqliteReadPlan } from './sqliteReadPlan.js';
+import { quoteIdentifier } from './sqliteSql.js';
 import { ISqliteQueryClient } from './sqliteWorkerClient.js';
 import { SqliteSchemaEntry, SqliteTableView, sqliteDisplayType } from './sqliteTableView.js';
 import {
@@ -59,7 +61,9 @@ export class SqliteDataExplorerRpcHandler implements vscode.Disposable, ISqliteD
 
 	dispose(): void {
 		this._session.dispose();
-		this._views.clear();
+		for (const datasetId of [...this._views.keys()]) {
+			this.closeTableView(datasetId);
+		}
 	}
 
 	/**
@@ -72,8 +76,12 @@ export class SqliteDataExplorerRpcHandler implements vscode.Disposable, ISqliteD
 		tableName: string,
 		kind: 'table' | 'view',
 	): Promise<void> {
+		// Sequenced, not concurrent: a plan that has already taken a snapshot has nothing to dispose it
+		// if the schema query then fails, so nothing is created until the schema is in hand.
 		const schema = await buildSqliteSchema(client, tableName);
-		this._views.set(datasetId, new SqliteTableView(client, tableName, kind, schema));
+		const readPlan = await createSqliteReadPlan(
+			client, tableName, kind, schema.map(c => c.column_name));
+		this._setView(datasetId, new SqliteTableView(client, tableName, readPlan, schema));
 	}
 
 	/**
@@ -92,12 +100,29 @@ export class SqliteDataExplorerRpcHandler implements vscode.Disposable, ISqliteD
 		if (!column) {
 			throw new Error(`Column '${columnName}' not found in '${tableName}'`);
 		}
-		this._views.set(datasetId, new SqliteTableView(client, tableName, kind, [column]));
+		// The plan is given every column the relation has, not just the requested one: what it needs to
+		// know is whether the relation shadows a rowid alias, which the restricted schema would hide.
+		const readPlan = await createSqliteReadPlan(
+			client, tableName, kind, schema.map(c => c.column_name));
+		this._setView(datasetId, new SqliteTableView(client, tableName, readPlan, [column]));
+	}
+
+	/**
+	 * Registers a view, disposing any view the same dataset id already had so that reopening a
+	 * dataset does not leave its predecessor's snapshot behind.
+	 */
+	private _setView(datasetId: string, view: SqliteTableView): void {
+		this.closeTableView(datasetId);
+		this._views.set(datasetId, view);
 	}
 
 	/** Drops a dataset's view, e.g. when its connection is disconnected. */
 	closeTableView(datasetId: string): void {
+		const view = this._views.get(datasetId);
 		this._views.delete(datasetId);
+		// Dropping the snapshot is best-effort cleanup of a private temp table, so nothing waits on
+		// it and a failure (typically a worker that is already gone) must not surface to the caller.
+		void view?.dispose().catch(() => { });
 	}
 
 	async handleRequest(rpc: DataExplorerRpc): Promise<DataExplorerResponse> {
@@ -173,8 +198,7 @@ export async function buildSqliteSchema(
 	client: ISqliteQueryClient,
 	tableName: string,
 ): Promise<SqliteSchemaEntry[]> {
-	const safeName = tableName.replace(/"/g, '""');
-	const rows = await client.runQuery(`PRAGMA table_info("${safeName}")`);
+	const rows = await client.runQuery(`PRAGMA table_info(${quoteIdentifier(tableName)})`);
 	return rows.map(row => {
 		const declaredType = row.type ? String(row.type) : '';
 		return {

--- a/extensions/positron-data-driver-sqlite/src/sqliteDataExplorerRpcHandler.ts
+++ b/extensions/positron-data-driver-sqlite/src/sqliteDataExplorerRpcHandler.ts
@@ -55,7 +55,11 @@ export class SqliteDataExplorerRpcHandler implements vscode.Disposable, ISqliteD
 
 	constructor(private readonly _logger?: positron.DataConnectionLogger) {
 		this._session = positron.dataExplorer.registerRpcHandler(SQLITE_DATA_EXPLORER_PROVIDER_ID, {
-			handleRpc: (request) => this.handleRequest(request as DataExplorerRpc)
+			handleRpc: (request) => this.handleRequest(request as DataExplorerRpc),
+			// Without this, closing a tab leaves its view registered and its snapshot in the `temp`
+			// schema until the connection disconnects or the same dataset is reopened. That was a
+			// bounded waste when a view held nothing but state; now it holds a copy of the relation.
+			closeDataset: (datasetId) => this.closeTableView(datasetId),
 		});
 	}
 

--- a/extensions/positron-data-driver-sqlite/src/sqliteReadPlan.ts
+++ b/extensions/positron-data-driver-sqlite/src/sqliteReadPlan.ts
@@ -42,11 +42,13 @@ export interface ISqliteReadPlan {
 /**
  * Chooses how to read a table or view so that paging it is stable.
  *
- * An ordinary table is read in place and ordered by its rowid. That is SQLite's own storage order,
- * so the guarantee is free: the query plan is identical with and without the clause. A WITHOUT ROWID
- * table has no rowid column at all -- ordering by it fails with "no such column: rowid" -- but its
- * primary key is a clustered index whose columns SQLite implicitly marks NOT NULL, so it is both a
- * genuine total order and equally free to sort by.
+ * An ordinary table is read in place and ordered by its rowid, which is SQLite's own storage order,
+ * so an unfiltered page fetch plans identically with and without the clause. A WITHOUT ROWID table
+ * has no rowid column at all -- ordering by it fails with "no such column: rowid" -- but its primary
+ * key is a clustered index whose columns SQLite implicitly marks NOT NULL, so it is a genuine total
+ * order and plans the same way. Once a row filter is in play the clause can cost a plan rather than
+ * come free; `_buildSortClause` in `sqliteTableView.ts` measures where and says why it is still
+ * stated.
  *
  * Anything else is read through a snapshot: a view has no row identity, and neither does a table
  * whose identity cannot be established.

--- a/extensions/positron-data-driver-sqlite/src/sqliteReadPlan.ts
+++ b/extensions/positron-data-driver-sqlite/src/sqliteReadPlan.ts
@@ -183,6 +183,23 @@ let snapshotCount = 0;
  * makes paging substantially cheaper than reading the view directly, because the join runs once
  * instead of once per page.
  *
+ * What that costs is worth stating plainly:
+ *
+ * - It is built when the tab opens, not on first scroll. `SqliteTableView`'s constructor asks for a
+ *   row count, the count reads through this plan, so the copy is made before the first row renders.
+ *   Deferring it would only relocate the cost, since the grid fetches its first page as soon as it
+ *   has the count.
+ * - It holds the relation's full result for the life of the tab, with no row cap -- on disk rather
+ *   than in memory. better-sqlite3 builds SQLite without overriding `SQLITE_TEMP_STORE`, so it takes
+ *   the default of 1 and a TEMP table lives in a temporary file; nothing here sets `temp_store` to
+ *   change that. So the cost is disk, and a snapshot far larger than RAM is still openable.
+ * - What it adds is holding the rows, not producing them. The row count runs `count(*)` over the
+ *   relation, so a view's joins and aggregates were already being computed at open before any
+ *   snapshot existed.
+ *
+ * Uncapped is deliberate. Past any cap the only options are paging the relation unstably, which is
+ * the defect this class exists to prevent, or refusing to open it.
+ *
  * The copy lives in the `temp` schema, which is private to this connection and invisible to `main`,
  * so it cannot collide with the user's own objects. It is created even when the database was opened
  * read-only, because `temp` is a separate database that is always writable.

--- a/extensions/positron-data-driver-sqlite/src/sqliteReadPlan.ts
+++ b/extensions/positron-data-driver-sqlite/src/sqliteReadPlan.ts
@@ -1,0 +1,283 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { quoteIdentifier } from './sqliteSql.js';
+import { ISqliteQueryClient } from './sqliteWorkerClient.js';
+
+/**
+ * How a Data Explorer view reads one relation so that its LIMIT/OFFSET paging is stable.
+ *
+ * The Data Explorer fetches each page with a separate statement, and SQLite returns rows in
+ * whatever order the chosen query plan produces. That plan is not fixed for the life of a tab:
+ * another connection creating an index, or running ANALYZE, is enough to change it between two page
+ * fetches. Once it changes, the pages stop partitioning the relation -- some rows come back on two
+ * pages and others never arrive -- while the row count, which comes from a separate `count(*)`,
+ * stays correct and hides the damage.
+ *
+ * A read plan pins down a total order that survives such a change. Relations that have no row
+ * identity to order by are read through a materialized snapshot that does.
+ */
+export interface ISqliteReadPlan {
+	/**
+	 * The quoted relation every read should target, materializing the snapshot first if this plan
+	 * uses one. Called before each read, so it must stay cheap once the snapshot is in place.
+	 */
+	relation(): Promise<string>;
+
+	/**
+	 * An ORDER BY expression that totally orders {@link relation}.
+	 *
+	 * Paging queries append it, so LIMIT/OFFSET is reproducible. Index-based exports also use it as
+	 * their `ROW_NUMBER()` window order, so the rows an export returns are the rows the grid
+	 * displayed at those positions.
+	 */
+	readonly rowOrder: string;
+
+	/** Drops any snapshot this plan created. Safe to call more than once. */
+	dispose(): Promise<void>;
+}
+
+/**
+ * Chooses how to read a table or view so that paging it is stable.
+ *
+ * An ordinary table is read in place and ordered by its rowid. That is SQLite's own storage order,
+ * so the guarantee is free: the query plan is identical with and without the clause. A WITHOUT ROWID
+ * table has no rowid column at all -- ordering by it fails with "no such column: rowid" -- but its
+ * primary key is a clustered index whose columns SQLite implicitly marks NOT NULL, so it is both a
+ * genuine total order and equally free to sort by.
+ *
+ * Anything else is read through a snapshot: a view has no row identity, and neither does a table
+ * whose identity cannot be established.
+ *
+ * @param columnNames Every column the relation emits. Consulted only on the snapshot path, and only
+ * to find a rowid alias the relation does not shadow, so it must be the relation's full column list
+ * rather than whichever subset a caller means to display.
+ */
+export async function createSqliteReadPlan(
+	client: ISqliteQueryClient,
+	tableName: string,
+	kind: 'table' | 'view',
+	columnNames: readonly string[],
+): Promise<ISqliteReadPlan> {
+	const quotedTable = quoteIdentifier(tableName);
+	if (kind === 'table') {
+		const identity = await resolveRowIdentity(client, quotedTable);
+		if (identity !== undefined) {
+			return new DirectRead(quotedTable, identity);
+		}
+	}
+	return new SnapshotRead(client, quotedTable, columnNames);
+}
+
+/** SQLite's interchangeable spellings of the implicit rowid, in the order to prefer them. */
+const ROWID_ALIASES = ['rowid', '_rowid_', 'oid'];
+
+/** Names a snapshot's own ordering column, for a source that leaves no rowid alias unshadowed. */
+const SNAPSHOT_ORDER_COLUMN = '__positron_row_order';
+
+/**
+ * Resolves an ORDER BY expression that uniquely identifies a row of the given table, or undefined
+ * if the table has none.
+ */
+async function resolveRowIdentity(
+	client: ISqliteQueryClient,
+	quotedTable: string,
+): Promise<string | undefined> {
+	// PRAGMA table_info reports one row per declared column, with `pk` as the 1-based position of the
+	// column within the primary key, or 0 when the column is not part of it. PRAGMA takes no bound
+	// parameters, so the table name is escaped inline.
+	const columns = await client.runQuery(`PRAGMA table_info(${quotedTable})`);
+
+	// A declared column is allowed to take the name of a rowid alias, and it then shadows the rowid:
+	// given `CREATE TABLE t(rowid TEXT, v INTEGER)`, `SELECT rowid` returns that TEXT column, which
+	// carries no uniqueness whatsoever. Because SQLite keeps three spellings of the rowid, a shadowed
+	// one only means preferring the next. Names are compared case-insensitively, since that is how
+	// SQLite resolves identifiers.
+	const declared = new Set(columns.map(row => String(row.name).toLowerCase()));
+	const alias = ROWID_ALIASES.find(candidate => !declared.has(candidate));
+	if (alias === undefined) {
+		// All three spellings are taken, so nothing can name this table's rowid. Its declared primary
+		// key is no substitute -- see below -- so the table is read through a snapshot.
+		return undefined;
+	}
+
+	try {
+		// Selecting no rows makes this a bind-time check, so it costs nothing to run. It is also the
+		// only exact test available: no pragma reports whether a table is WITHOUT ROWID, and the
+		// CREATE statement in sqlite_master cannot be trusted, because a string literal or a comment
+		// can contain the words (`note TEXT DEFAULT 'migrated without rowid'` is an ordinary table).
+		await client.runQuery(`SELECT ${alias} FROM ${quotedTable} LIMIT 0`);
+		return alias;
+	} catch (error) {
+		if (!isNoSuchColumn(error)) {
+			// A dead worker or a disposed connection landed here, not a WITHOUT ROWID table. The
+			// primary key below is only a total order for a table that genuinely has no rowid, so
+			// treating this as one risks paging an ordinary table by a nullable key. Fail the open
+			// instead, which the user can retry, rather than opening a tab that silently loses rows.
+			throw error;
+		}
+	}
+
+	const keyColumns = columns
+		.filter(row => Number(row.pk ?? 0) > 0)
+		.sort((a, b) => Number(a.pk) - Number(b.pk))
+		.map(row => quoteIdentifier(String(row.name)));
+	if (keyColumns.length === 0) {
+		return undefined;
+	}
+
+	// Reached only for a WITHOUT ROWID table, whose primary key is a clustered index over columns
+	// SQLite implicitly marks NOT NULL: a genuine total order, and free to sort by. An ordinary
+	// table's declared primary key would not do, because SQLite allows NULLs in a PRIMARY KEY column
+	// unless it is INTEGER PRIMARY KEY, and a unique index treats every NULL as distinct, so several
+	// rows can tie.
+	return keyColumns.join(', ');
+}
+
+/**
+ * Whether an error is SQLite reporting an unresolvable column, which is how a WITHOUT ROWID table
+ * answers a rowid probe ("no such column: rowid").
+ *
+ * The message is matched because the code cannot be: better-sqlite3 reports every statement error as
+ * SQLITE_ERROR. Should SQLite ever reword this, a WITHOUT ROWID table would fail to open rather than
+ * open with unstable paging, which is the safe direction for this to be wrong in.
+ */
+function isNoSuchColumn(error: unknown): boolean {
+	return error instanceof Error && /no such column/i.test(error.message);
+}
+
+/** Reads a relation in place, ordered by an expression that uniquely identifies one of its rows. */
+class DirectRead implements ISqliteReadPlan {
+	constructor(
+		private readonly _quotedTable: string,
+		readonly rowOrder: string,
+	) { }
+
+	async relation(): Promise<string> {
+		return this._quotedTable;
+	}
+
+	async dispose(): Promise<void> {
+		// Nothing was created, so nothing to release.
+	}
+}
+
+/**
+ * Distinguishes the snapshots of concurrently open views within one worker's `temp` schema. Every
+ * view served by a given worker is created through this module, so the counter covers them all; and
+ * because the CREATE below is not `IF NOT EXISTS`, a name that did somehow repeat would fail loudly
+ * rather than let two views quietly read each other's rows.
+ */
+let snapshotCount = 0;
+
+/**
+ * Reads a relation through a TEMP table holding a point-in-time copy of its rows.
+ *
+ * A snapshot both supplies the missing row identity -- a TEMP table has a rowid that records the
+ * order rows were inserted, reachable under whichever of its names the copied columns leave free --
+ * and stops the relation being recomputed on every page. For a view over a join or an aggregate that
+ * makes paging substantially cheaper than reading the view directly, because the join runs once
+ * instead of once per page.
+ *
+ * The copy lives in the `temp` schema, which is private to this connection and invisible to `main`,
+ * so it cannot collide with the user's own objects. It is created even when the database was opened
+ * read-only, because `temp` is a separate database that is always writable.
+ */
+class SnapshotRead implements ISqliteReadPlan {
+	readonly rowOrder: string;
+
+	/** Unqualified and quoted, for CREATE, which does not accept a schema-qualified name. */
+	private readonly _quotedName: string;
+	/** Schema-qualified, so a same-named table in `main` cannot be read by mistake. */
+	private readonly _qualifiedName: string;
+	/** The snapshot's select list, which numbers rows explicitly only when it has to. */
+	private readonly _selectList: string;
+
+	private _materialized: Promise<string> | undefined;
+	private _disposed = false;
+	private readonly _crashSubscription: { dispose(): void } | undefined;
+
+	constructor(
+		private readonly _client: ISqliteQueryClient,
+		private readonly _quotedSource: string,
+		sourceColumns: readonly string[],
+	) {
+		this._quotedName = quoteIdentifier(`positron_snapshot_${++snapshotCount}`);
+		this._qualifiedName = `temp.${this._quotedName}`;
+
+		// `SELECT *` copies the source's columns verbatim, so a source that emits a column named like a
+		// rowid alias shadows the snapshot's own rowid. `CREATE VIEW v AS SELECT rowid, name FROM t` is
+		// idiomatic enough to expect, and while the rowid it copies happens to be unique, a join that
+		// fans that view out, or anything aliased `AS rowid`, is not: measured against SQLite 3.51, the
+		// snapshot of such a view read 1, 1, 2, 3, 3 under `rowid` and 1, 2, 3, 4, 5 under `_rowid_`.
+		// Ordering by the shadowed name would leave paging exactly as unstable as it was before any of
+		// this, with nothing to show for it.
+		// Preferring the next alias keeps the free path: a TEMP table's rowid is its storage order, so
+		// SQLite sorts nothing to apply it.
+		const taken = new Set(sourceColumns.map(name => name.toLowerCase()));
+		const alias = ROWID_ALIASES.find(candidate => !taken.has(candidate));
+		if (alias !== undefined) {
+			this.rowOrder = alias;
+			this._selectList = '*';
+		} else {
+			// The source emits all three spellings, so no name reaches the snapshot's rowid. Number the
+			// rows in a column of our own instead. That column is unindexed, so each page pays a sort to
+			// apply it, which is worth accepting for a shape this rare. Reads never see it: every one of
+			// them projects an explicit column list taken from the schema.
+			const ordinal = quoteIdentifier(SNAPSHOT_ORDER_COLUMN);
+			this.rowOrder = ordinal;
+			this._selectList = `ROW_NUMBER() OVER () AS ${ordinal}, *`;
+		}
+
+		// A replacement worker starts with an empty `temp` schema, so the snapshot is gone even
+		// though this object still holds a resolved promise for it. Forget it, so the next read
+		// rebuilds instead of failing with "no such table" until the user reopens the tab.
+		this._crashSubscription = this._client.onDidCrash?.(() => {
+			this._materialized = undefined;
+		});
+	}
+
+	relation(): Promise<string> {
+		// A read can outlive the view that issued it -- closing a tab mid column-profile disposes this
+		// plan while that profile is still awaiting its turn on the worker. Materializing again here
+		// would create a snapshot that nothing is left to drop, so it stays for the life of the
+		// connection.
+		if (this._disposed) {
+			return Promise.reject(new Error('Cannot read through a disposed SQLite read plan'));
+		}
+		return this._materialized ??= this._materialize();
+	}
+
+	private async _materialize(): Promise<string> {
+		try {
+			await this._client.runQuery(
+				`CREATE TEMP TABLE ${this._quotedName} AS ` +
+				`SELECT ${this._selectList} FROM ${this._quotedSource}`);
+			return this._qualifiedName;
+		} catch (error) {
+			// Clear the memo so a later read retries, rather than leaving the tab permanently broken
+			// by one transient failure.
+			this._materialized = undefined;
+			throw error;
+		}
+	}
+
+	async dispose(): Promise<void> {
+		this._disposed = true;
+		this._crashSubscription?.dispose();
+		const materialized = this._materialized;
+		this._materialized = undefined;
+		if (materialized === undefined) {
+			return;
+		}
+		try {
+			await materialized;
+			await this._client.runQuery(`DROP TABLE IF EXISTS ${this._qualifiedName}`);
+		} catch {
+			// The snapshot is discarded with the connection's `temp` schema in any case, so a failure
+			// here (a dead worker, a snapshot that never finished materializing) leaks nothing.
+		}
+	}
+}

--- a/extensions/positron-data-driver-sqlite/src/sqliteReadPlan.ts
+++ b/extensions/positron-data-driver-sqlite/src/sqliteReadPlan.ts
@@ -87,10 +87,20 @@ async function resolveRowIdentity(
 	client: ISqliteQueryClient,
 	quotedTable: string,
 ): Promise<string | undefined> {
-	// PRAGMA table_info reports one row per declared column, with `pk` as the 1-based position of the
-	// column within the primary key, or 0 when the column is not part of it. PRAGMA takes no bound
+	// PRAGMA table_xinfo reports one row per column, with `pk` as the 1-based position of the column
+	// within the primary key, or 0 when the column is not part of it. PRAGMA takes no bound
 	// parameters, so the table name is escaped inline.
-	const columns = await client.runQuery(`PRAGMA table_info(${quotedTable})`);
+	//
+	// `table_xinfo` rather than `table_info`, which omits generated columns -- and a generated column
+	// shadows a rowid alias exactly as a stored one does. Given
+	// `CREATE TABLE g(v INTEGER, rowid TEXT GENERATED ALWAYS AS ('x'||v) VIRTUAL)`, measured against
+	// SQLite 3.51.3, `table_info` reports only `v` while `table_xinfo` reports both, and `SELECT rowid`
+	// returns 'x1', 'x2', 'x3' where `SELECT _rowid_` returns 1, 2, 3. Reading the declared columns
+	// through `table_info` would leave `rowid` looking free, and the probe below would confirm it,
+	// because binding succeeds against the generated column. Paging would then order by a text
+	// expression with no uniqueness. The `pk` column is identical in both pragmas, including for a
+	// WITHOUT ROWID table's composite key, so the primary key handling below is unaffected.
+	const columns = await client.runQuery(`PRAGMA table_xinfo(${quotedTable})`);
 
 	// A declared column is allowed to take the name of a rowid alias, and it then shadows the rowid:
 	// given `CREATE TABLE t(rowid TEXT, v INTEGER)`, `SELECT rowid` returns that TEXT column, which

--- a/extensions/positron-data-driver-sqlite/src/sqliteSql.ts
+++ b/extensions/positron-data-driver-sqlite/src/sqliteSql.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/** Quotes and escapes an identifier for SQLite by doubling embedded double-quotes. */
+export function quoteIdentifier(name: string): string {
+	return '"' + name.replace(/"/g, '""') + '"';
+}
+
+/** Escapes a value for use inside a single-quoted SQLite string literal. */
+export function quoteLiteral(value: string): string {
+	return value.replace(/'/g, '\'\'');
+}

--- a/extensions/positron-data-driver-sqlite/src/sqliteTableView.ts
+++ b/extensions/positron-data-driver-sqlite/src/sqliteTableView.ts
@@ -440,9 +440,29 @@ export class SqliteTableView {
 	 *
 	 * The tiebreaker matters just as much with no sort keys as with them. Sort keys alone leave tied
 	 * rows free to come back in a different order on each statement, and with no sort keys at all
-	 * every row is tied. Ordering by the row order is free for the relations that reach here: it is
-	 * SQLite's storage order for an ordinary table, the clustered primary key for a WITHOUT ROWID
-	 * table, and the insertion order of a snapshot.
+	 * every row is tied. Unlike DuckDB, SQLite promises no order of its own to fall back on: rows
+	 * arrive in whatever order the chosen plan yields, and that plan can change between two page
+	 * fetches. So the clause is stated unconditionally, rather than only once the user has sorted.
+	 *
+	 * What that costs depends on the plan it displaces.
+	 *
+	 * - Unfiltered, it is free. `rowid` is SQLite's storage order, so the plan is `SCAN t` either
+	 *   way. The same holds for the clustered primary key of a WITHOUT ROWID table and for the
+	 *   insertion order of a snapshot.
+	 * - Sorting on an indexed column, it is free. A SQLite index is ordered by its columns and then
+	 *   by rowid, so appending the tiebreaker asks for an order the index already has:
+	 *   `ORDER BY a, rowid` keeps `SEARCH t USING INDEX ia (a<?)`.
+	 * - Filtering with no sort is where it is not free. An index serving `WHERE a < ?` returns rows
+	 *   in `a` order, which the tiebreaker overrides, so the planner abandons the index and
+	 *   `SEARCH t USING INDEX ia (a<?)` becomes `SCAN t`. Measured on a 2M-row table with 1,000
+	 *   matching rows, a 40-page sweep went from 0.9 ms to 415 ms of CPU with those rows spread
+	 *   through the table. Clustered at its front, where a scan meets them immediately and LIMIT
+	 *   stops early, the same sweep stayed at 0.5 ms -- the cost tracks how far the scan has to go,
+	 *   not the filter itself.
+	 *
+	 * That last case is paid deliberately. A filtered page fetch is the one most exposed to a plan
+	 * change -- an index appearing or ANALYZE running mid-sweep is what flips it -- so dropping the
+	 * tiebreaker there would remove the guarantee exactly where it is doing the most work.
 	 *
 	 * @param includeTiebreaker False only for generated code, which should show the user their own
 	 * sort rather than an internal ordering column.

--- a/extensions/positron-data-driver-sqlite/src/sqliteTableView.ts
+++ b/extensions/positron-data-driver-sqlite/src/sqliteTableView.ts
@@ -3,6 +3,8 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { ISqliteReadPlan } from './sqliteReadPlan.js';
+import { quoteIdentifier, quoteLiteral } from './sqliteSql.js';
 import { ISqliteQueryClient } from './sqliteWorkerClient.js';
 import {
 	ArraySelection,
@@ -115,16 +117,6 @@ export function sqliteDisplayType(declaredType: string): ColumnDisplayType {
 	return ColumnDisplayType.Floating;
 }
 
-/** Quotes and escapes an identifier for SQLite by doubling embedded double-quotes. */
-function quoteIdentifier(name: string): string {
-	return '"' + name.replace(/"/g, '""') + '"';
-}
-
-/** Escapes a value for use inside a single-quoted SQLite string literal. */
-function quoteLiteral(value: string): string {
-	return value.replace(/'/g, '\'\'');
-}
-
 const COMPARISON_OPS = new Map<FilterComparisonOp, string>([
 	[FilterComparisonOp.Eq, '='],
 	[FilterComparisonOp.NotEq, '<>'],
@@ -227,26 +219,45 @@ export class SqliteTableView {
 	/**
 	 * @param client The query client for the owning connection.
 	 * @param tableName The unquoted table/view name.
-	 * @param objectKind Whether this is a table (has a stable rowid) or a view.
+	 * @param readPlan How this relation is read so that its LIMIT/OFFSET paging is stable.
 	 * @param schema The resolved column schema.
 	 */
 	constructor(
 		private readonly client: ISqliteQueryClient,
 		private readonly tableName: string,
-		private readonly objectKind: 'table' | 'view',
+		private readonly readPlan: ISqliteReadPlan,
 		private readonly schema: Array<SqliteSchemaEntry>,
 	) {
+		// Seed the ORDER BY before anything is read. The frontend only sends set_sort_columns once
+		// the user sorts -- on a fresh tab it mirrors back whatever sort_keys get_state reports and
+		// pushes nothing -- so without this the first pages would run with no total order at all.
+		this._sortClause = this._buildSortClause(this.sortKeys, true);
 		this._unfilteredRows = this._countRows('');
 		this._filteredRows = this._unfilteredRows;
 	}
 
-	/** The quoted table name for use in FROM clauses. */
+	/**
+	 * The quoted relation that reads should target. This is the snapshot rather than the original
+	 * relation whenever the read plan uses one, so the row count, the displayed rows, the exports,
+	 * and the column profiles all describe the same set of rows.
+	 */
+	private _relation(): Promise<string> {
+		return this.readPlan.relation();
+	}
+
+	/** The user's own relation, for generated code that has to name what they opened. */
 	private get _quotedTable(): string {
 		return quoteIdentifier(this.tableName);
 	}
 
+	/** Releases the read plan's resources; call when the dataset's view is dropped. */
+	async dispose(): Promise<void> {
+		await this.readPlan.dispose();
+	}
+
 	private async _countRows(whereClause: string): Promise<number> {
-		const rows = await this.client.runQuery(`SELECT count(*) AS n FROM ${this._quotedTable}${whereClause}`);
+		const rows = await this.client.runQuery(
+			`SELECT count(*) AS n FROM ${await this._relation()}${whereClause}`);
 		return Number(rows[0]?.n ?? 0);
 	}
 
@@ -341,7 +352,7 @@ export class SqliteTableView {
 		// Select each requested column under a positional alias so duplicates are unambiguous.
 		const selectors = params.columns.map((column, i) =>
 			`${quoteIdentifier(this.schema[column.column_index].column_name)} AS c${i}`);
-		const query = `SELECT ${selectors.join(', ')} FROM ${this._quotedTable}` +
+		const query = `SELECT ${selectors.join(', ')} FROM ${await this._relation()}` +
 			`${this._whereClause}${this._orderClause()} LIMIT ${numRows} OFFSET ${lowerLimit}`;
 		const rows = await this.client.runQuery(query);
 
@@ -424,16 +435,25 @@ export class SqliteTableView {
 	}
 
 	/**
-	 * Builds an ORDER BY clause for the given sort keys. For tables a trailing `rowid` is appended
-	 * as a stable tiebreaker so pagination is deterministic; views have no rowid, so they omit it.
+	 * Builds an ORDER BY clause for the given sort keys, with the read plan's row order appended as
+	 * a tiebreaker so that paging is reproducible.
+	 *
+	 * The tiebreaker matters just as much with no sort keys as with them. Sort keys alone leave tied
+	 * rows free to come back in a different order on each statement, and with no sort keys at all
+	 * every row is tied. Ordering by the row order is free for the relations that reach here: it is
+	 * SQLite's storage order for an ordinary table, the clustered primary key for a WITHOUT ROWID
+	 * table, and the insertion order of a snapshot.
+	 *
+	 * @param includeTiebreaker False only for generated code, which should show the user their own
+	 * sort rather than an internal ordering column.
 	 */
-	private _buildSortClause(sortKeys: Array<ColumnSortKey>, includeRowidTiebreaker: boolean): string {
+	private _buildSortClause(sortKeys: Array<ColumnSortKey>, includeTiebreaker: boolean): string {
 		const exprs = sortKeys.map(key => {
 			const quotedName = quoteIdentifier(this.schema[key.column_index].column_name);
 			return `${quotedName}${key.ascending ? '' : ' DESC'}`;
 		});
-		if (includeRowidTiebreaker && this.objectKind === 'table') {
-			exprs.push('rowid');
+		if (includeTiebreaker) {
+			exprs.push(this.readPlan.rowOrder);
 		}
 		return exprs.length > 0 ? `\nORDER BY ${exprs.join(', ')}` : '';
 	}
@@ -523,6 +543,7 @@ export class SqliteTableView {
 	async exportDataSelection(params: ExportDataSelectionParams): Promise<ExportedData> {
 		const kind = params.selection.kind;
 		const order = this._orderClause();
+		const relation = await this._relation();
 
 		const runExport = async (query: string, columns: Array<SqliteSchemaEntry>): Promise<ExportedData> => {
 			const rows = await this.client.runQuery(query);
@@ -540,7 +561,7 @@ export class SqliteTableView {
 			case TableSelectionKind.SingleCell: {
 				const sel = params.selection.selection as DataSelectionSingleCell;
 				const column = this.schema[sel.column_index];
-				const query = `SELECT ${quoteIdentifier(column.column_name)} AS c0 FROM ${this._quotedTable}` +
+				const query = `SELECT ${quoteIdentifier(column.column_name)} AS c0 FROM ${relation}` +
 					`${this._whereClause}${order} LIMIT 1 OFFSET ${sel.row_index}`;
 				const rows = await this.client.runQuery(query);
 				return { data: stringifyExportCell(rows[0]?.c0), format: params.format };
@@ -548,37 +569,37 @@ export class SqliteTableView {
 			case TableSelectionKind.CellRange: {
 				const sel = params.selection.selection as DataSelectionCellRange;
 				const columns = this.schema.slice(sel.first_column_index, sel.last_column_index + 1);
-				const query = `SELECT ${selectorsFor(columns)} FROM ${this._quotedTable}` +
+				const query = `SELECT ${selectorsFor(columns)} FROM ${relation}` +
 					`${this._whereClause}${order} LIMIT ${sel.last_row_index - sel.first_row_index + 1} OFFSET ${sel.first_row_index}`;
 				return runExport(query, columns);
 			}
 			case TableSelectionKind.RowRange: {
 				const sel = params.selection.selection as DataSelectionRange;
-				const query = `SELECT ${selectorsFor(this.schema)} FROM ${this._quotedTable}` +
+				const query = `SELECT ${selectorsFor(this.schema)} FROM ${relation}` +
 					`${this._whereClause}${order} LIMIT ${sel.last_index - sel.first_index + 1} OFFSET ${sel.first_index}`;
 				return runExport(query, this.schema);
 			}
 			case TableSelectionKind.ColumnRange: {
 				const sel = params.selection.selection as DataSelectionRange;
 				const columns = this.schema.slice(sel.first_index, sel.last_index + 1);
-				const query = `SELECT ${selectorsFor(columns)} FROM ${this._quotedTable}${this._whereClause}${order}`;
+				const query = `SELECT ${selectorsFor(columns)} FROM ${relation}${this._whereClause}${order}`;
 				return runExport(query, columns);
 			}
 			case TableSelectionKind.ColumnIndices: {
 				const sel = params.selection.selection as DataSelectionIndices;
 				const columns = sel.indices.map(i => this.schema[i]);
-				const query = `SELECT ${selectorsFor(columns)} FROM ${this._quotedTable}${this._whereClause}${order}`;
+				const query = `SELECT ${selectorsFor(columns)} FROM ${relation}${this._whereClause}${order}`;
 				return runExport(query, columns);
 			}
 			case TableSelectionKind.RowIndices: {
 				const sel = params.selection.selection as DataSelectionIndices;
-				const query = this._rowIndexQuery(selectorsFor(this.schema), sel.indices);
+				const query = this._rowIndexQuery(relation, selectorsFor(this.schema), sel.indices);
 				return runExport(query, this.schema);
 			}
 			case TableSelectionKind.CellIndices: {
 				const sel = params.selection.selection as DataSelectionCellIndices;
 				const columns = sel.column_indices.map(i => this.schema[i]);
-				const query = this._rowIndexQuery(selectorsFor(columns), sel.row_indices);
+				const query = this._rowIndexQuery(relation, selectorsFor(columns), sel.row_indices);
 				return runExport(query, columns);
 			}
 		}
@@ -586,13 +607,18 @@ export class SqliteTableView {
 
 	/**
 	 * Builds a query that selects specific (post-sort, post-filter) row positions in the requested
-	 * order. Uses a ROW_NUMBER() window so it works for both tables and views without relying on
-	 * rowid, mirroring the requested-row ordering.
+	 * order, using a ROW_NUMBER() window to number the rows.
+	 *
+	 * The window has to be ordered the same way the pages were, or the positions the frontend asks
+	 * for refer to rows the user never saw at those positions -- and this path writes a file the user
+	 * keeps, so a wrong row here is worse than a wrong row in the grid. `_sortClause` already ends in
+	 * the read plan's row order, which makes it a total order, so reusing it is what keeps the
+	 * numbering and the display in agreement.
 	 */
-	private _rowIndexQuery(selectors: string, rowIndices: number[]): string {
-		const ordering = this._sortClause ? this._sortClause.replace(/^\n/, '') : 'ORDER BY (SELECT 1)';
+	private _rowIndexQuery(relation: string, selectors: string, rowIndices: number[]): string {
+		const ordering = this._sortClause.replace(/^\n/, '');
 		const numbered = `SELECT *, ROW_NUMBER() OVER (${ordering}) - 1 AS __row_index ` +
-			`FROM ${this._quotedTable}${this._whereClause}`;
+			`FROM ${relation}${this._whereClause}`;
 		const order = rowIndices.map((rowIdx, i) => `WHEN ${rowIdx} THEN ${i}`).join(' ');
 		const inList = rowIndices.join(', ');
 		return `SELECT ${selectors} FROM (${numbered}) WHERE __row_index IN (${inList}) ` +
@@ -650,7 +676,7 @@ export class SqliteTableView {
 
 	private async _nullCount(quotedName: string): Promise<number> {
 		const rows = await this.client.runQuery(
-			`SELECT count(*) - count(${quotedName}) AS n FROM ${this._quotedTable}${this._whereClause}`);
+			`SELECT count(*) - count(${quotedName}) AS n FROM ${await this._relation()}${this._whereClause}`);
 		return Number(rows[0]?.n ?? 0);
 	}
 
@@ -664,12 +690,13 @@ export class SqliteTableView {
 		formatOptions: FormatOptions,
 	): Promise<ColumnSummaryStats> {
 		const display = entry.type_display;
+		const relation = await this._relation();
 		if (display === ColumnDisplayType.Integer || display === ColumnDisplayType.Floating || display === ColumnDisplayType.Decimal) {
 			// One pass for the moment-based stats; a second query for the median.
 			const rows = await this.client.runQuery(
 				`SELECT count(${quotedName}) AS n, min(${quotedName}) AS lo, max(${quotedName}) AS hi, ` +
 				`sum(${quotedName} * 1.0) AS s, sum(${quotedName} * 1.0 * ${quotedName}) AS ss ` +
-				`FROM ${this._quotedTable}${this._whereClause}`);
+				`FROM ${relation}${this._whereClause}`);
 			const n = Number(rows[0]?.n ?? 0);
 			const sum = Number(rows[0]?.s ?? 0);
 			const sumsq = Number(rows[0]?.ss ?? 0);
@@ -693,7 +720,7 @@ export class SqliteTableView {
 			const rows = await this.client.runQuery(
 				`SELECT count(DISTINCT ${quotedName}) AS nunique, ` +
 				`count(CASE WHEN ${quotedName} = '' THEN 1 END) AS nempty ` +
-				`FROM ${this._quotedTable}${this._whereClause}`);
+				`FROM ${relation}${this._whereClause}`);
 			return {
 				type_display: ColumnDisplayType.String,
 				string_stats: { num_unique: Number(rows[0]?.nunique ?? 0), num_empty: Number(rows[0]?.nempty ?? 0) },
@@ -703,7 +730,7 @@ export class SqliteTableView {
 			const rows = await this.client.runQuery(
 				`SELECT count(CASE WHEN ${quotedName} <> 0 THEN 1 END) AS ntrue, ` +
 				`count(CASE WHEN ${quotedName} = 0 THEN 1 END) AS nfalse ` +
-				`FROM ${this._quotedTable}${this._whereClause}`);
+				`FROM ${relation}${this._whereClause}`);
 			return {
 				type_display: ColumnDisplayType.Boolean,
 				boolean_stats: { true_count: Number(rows[0]?.ntrue ?? 0), false_count: Number(rows[0]?.nfalse ?? 0) },
@@ -712,7 +739,7 @@ export class SqliteTableView {
 		if (display === ColumnDisplayType.Date || display === ColumnDisplayType.Datetime) {
 			const rows = await this.client.runQuery(
 				`SELECT min(${quotedName}) AS lo, max(${quotedName}) AS hi, count(DISTINCT ${quotedName}) AS nunique ` +
-				`FROM ${this._quotedTable}${this._whereClause}`);
+				`FROM ${relation}${this._whereClause}`);
 			const stats = {
 				num_unique: Number(rows[0]?.nunique ?? 0),
 				min_date: rows[0]?.lo === null || rows[0]?.lo === undefined ? undefined : String(rows[0].lo),
@@ -723,7 +750,7 @@ export class SqliteTableView {
 				: { type_display: display, datetime_stats: stats };
 		}
 		const rows = await this.client.runQuery(
-			`SELECT count(DISTINCT ${quotedName}) AS nunique FROM ${this._quotedTable}${this._whereClause}`);
+			`SELECT count(DISTINCT ${quotedName}) AS nunique FROM ${relation}${this._whereClause}`);
 		return { type_display: display, other_stats: { num_unique: Number(rows[0]?.nunique ?? 0) } };
 	}
 
@@ -756,7 +783,7 @@ export class SqliteTableView {
 		}
 		const offset = Math.min(n - 1, Math.max(0, Math.floor(q * (n - 1))));
 		const rows = await this.client.runQuery(
-			`SELECT ${quotedName} AS v FROM ${this._quotedTable}${this._wherePlus(`${quotedName} IS NOT NULL`)} ` +
+			`SELECT ${quotedName} AS v FROM ${await this._relation()}${this._wherePlus(`${quotedName} IS NOT NULL`)} ` +
 			`ORDER BY ${quotedName} LIMIT 1 OFFSET ${offset}`);
 		const value = rows[0]?.v;
 		return value === null || value === undefined ? undefined : Number(value);
@@ -764,7 +791,7 @@ export class SqliteTableView {
 
 	private async _frequencyTable(quotedName: string, limit: number, filteredRows: number): Promise<ColumnFrequencyTable> {
 		const rows = await this.client.runQuery(
-			`SELECT ${quotedName} AS value, count(*) AS freq FROM ${this._quotedTable}` +
+			`SELECT ${quotedName} AS value, count(*) AS freq FROM ${await this._relation()}` +
 			`${this._wherePlus(`${quotedName} IS NOT NULL`)} GROUP BY ${quotedName} ` +
 			`ORDER BY freq DESC, value ASC LIMIT ${limit}`);
 		const values: ColumnValue[] = [];
@@ -793,7 +820,7 @@ export class SqliteTableView {
 		}
 
 		const rows = await this.client.runQuery(
-			`SELECT min(${quotedName}) AS lo, max(${quotedName}) AS hi FROM ${this._quotedTable}${this._whereClause}`);
+			`SELECT min(${quotedName}) AS lo, max(${quotedName}) AS hi FROM ${await this._relation()}${this._whereClause}`);
 		const minValue = Number(rows[0]?.lo);
 		const maxValue = Number(rows[0]?.hi);
 		const peakToPeak = maxValue - minValue;
@@ -840,7 +867,7 @@ export class SqliteTableView {
 		// SQLite truncates toward zero on CAST; values are >= minValue so the bin id is non-negative.
 		const binRows = await this.client.runQuery(
 			`SELECT CAST((${quotedName} * 1.0 - ${minValue}) / ${binWidth} AS INTEGER) AS bin_id, count(*) AS bin_count ` +
-			`FROM ${this._quotedTable}${this._wherePlus(`${quotedName} IS NOT NULL`)} GROUP BY bin_id`);
+			`FROM ${await this._relation()}${this._wherePlus(`${quotedName} IS NOT NULL`)} GROUP BY bin_id`);
 		const histEntries = new Map<number, number>(
 			binRows.map(row => [Number(row.bin_id), Number(row.bin_count)]));
 

--- a/extensions/positron-data-driver-sqlite/src/sqliteWorker.ts
+++ b/extensions/positron-data-driver-sqlite/src/sqliteWorker.ts
@@ -103,7 +103,19 @@ process.on('message', (request: WorkerQueryRequest) => {
 		return;
 	}
 	try {
-		const rows = db.prepare(request.sql).all(...(request.params ?? [])) as Array<Record<string, unknown>>;
+		const statement = db.prepare(request.sql);
+		const params = request.params ?? [];
+		// `all()` throws "This statement does not return data. Use run() instead" on a statement that
+		// returns no rows, so the two have to be dispatched separately. Statements that return nothing
+		// are part of the Data Explorer's normal work, not an edge case: a view is paged through a
+		// TEMP table (see sqliteReadPlan.ts), which means a CREATE when it opens and a DROP when it
+		// closes. `reader` is better-sqlite3's own answer for which kind this is.
+		let rows: Array<Record<string, unknown>> = [];
+		if (statement.reader) {
+			rows = statement.all(...params) as Array<Record<string, unknown>>;
+		} else {
+			statement.run(...params);
+		}
 		send({ kind: 'result', id: request.id, rows });
 	} catch (error) {
 		const err = error as NodeJS.ErrnoException;

--- a/extensions/positron-data-driver-sqlite/src/sqliteWorkerClient.ts
+++ b/extensions/positron-data-driver-sqlite/src/sqliteWorkerClient.ts
@@ -28,6 +28,13 @@ export type SqliteError = Error & { code?: string };
 export interface ISqliteQueryClient {
 	/** Run a SQL query with optional positional (?) parameters and return its rows. */
 	runQuery(sql: string, params?: SqliteBindValue[]): Promise<SqliteRow[]>;
+
+	/**
+	 * Fires when the worker dies and is replaced. A replacement worker starts with an empty `temp`
+	 * schema, so anything cached there -- see `ISqliteReadPlan` -- has to be rebuilt. Optional, so a
+	 * fake that only answers queries still satisfies this interface.
+	 */
+	readonly onDidCrash?: vscode.Event<void>;
 }
 
 /**

--- a/extensions/positron-data-driver-sqlite/src/test/sqlitePaging.test.ts
+++ b/extensions/positron-data-driver-sqlite/src/test/sqlitePaging.test.ts
@@ -1,0 +1,237 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { createSqliteReadPlan } from '../sqliteReadPlan.js';
+import { SqliteRow } from '../sqliteWorkerClient.js';
+import { SqliteBindValue } from '../sqliteWorkerProtocol.js';
+import { SqliteSchemaEntry, SqliteTableView } from '../sqliteTableView.js';
+import { ColumnDisplayType, FormatOptions, TableSelectionKind } from 'positron-data-explorer-protocol';
+
+const FORMAT: FormatOptions = {
+	large_num_digits: 2,
+	small_num_digits: 4,
+	max_integral_digits: 7,
+	max_value_length: 100,
+};
+
+const SCHEMA: SqliteSchemaEntry[] = [
+	{ column_name: 'id', column_type: 'INTEGER', type_display: ColumnDisplayType.Integer },
+];
+
+const COLUMNS = SCHEMA.map(c => c.column_name);
+
+const ROW_COUNT = 500;
+const PAGE_SIZE = 25;
+
+/**
+ * A fake engine that answers only what this suite needs, and that deliberately re-orders any
+ * statement whose ORDER BY does not determine a unique order.
+ *
+ * That re-ordering is not an invention. SQLite returns rows in whatever order the chosen query plan
+ * produces, and the plan is free to change between two statements: measured against SQLite 3.51, a
+ * paged sweep of a filtered table dropped 60,000 of 250,000 rows and repeated 60,000 others when
+ * another connection created an index partway through, because the plan flipped from `SCAN t` to
+ * `SEARCH t USING COVERING INDEX`. The fake stands in for that by rotating the rows by one more on
+ * each statement, which is the smallest permutation that makes the defect show up: every page
+ * boundary then loses exactly one row and repeats another.
+ *
+ * A statement that states a total order is answered from the canonical order instead, because the
+ * engine has no freedom left. So a sweep that comes back exact is a sweep that never relied on
+ * unspecified ordering.
+ */
+class ReorderingEngine {
+	readonly queries: string[] = [];
+	private _statements = 0;
+
+	/** The canonical order of `id` values, which is what a total ordering must reproduce. */
+	private readonly _canonical = Array.from({ length: ROW_COUNT }, (_, i) => i + 1);
+
+	/**
+	 * @param _totalOrder The ORDER BY text this engine accepts as a total order.
+	 * @param _primaryKey Primary key columns to report from PRAGMA table_info. Supplying them also
+	 * makes the `rowid` probe fail, which is how a real WITHOUT ROWID table presents itself.
+	 */
+	constructor(
+		private readonly _totalOrder: string,
+		private readonly _primaryKey?: readonly string[],
+	) { }
+
+	async runQuery(sql: string, _params?: SqliteBindValue[]): Promise<SqliteRow[]> {
+		this.queries.push(sql);
+		const flat = sql.replace(/\s+/g, ' ');
+
+		if (flat.startsWith('SELECT rowid FROM')) {
+			if (this._primaryKey) {
+				throw new Error('no such column: rowid');
+			}
+			return [];
+		}
+		if (flat.startsWith('PRAGMA table_info')) {
+			return (this._primaryKey ?? []).map((name, i) => ({ name, pk: i + 1 }));
+		}
+		if (flat.includes('count(*)')) {
+			return [{ n: ROW_COUNT }];
+		}
+
+		const ordered = this._order(flat);
+
+		// The export path numbers rows with a window function and then filters on those numbers,
+		// rather than using LIMIT/OFFSET.
+		const rowIndices = /__row_index IN \(([\d, ]+)\)/.exec(flat);
+		if (rowIndices) {
+			const wanted = rowIndices[1].split(',').map(part => Number(part.trim()));
+			return wanted.map(index => ({ c0: ordered[index] }));
+		}
+
+		const window = /LIMIT (\d+) OFFSET (\d+)/.exec(flat);
+		if (window) {
+			const offset = Number(window[2]);
+			return ordered.slice(offset, offset + Number(window[1])).map(id => ({ c0: id }));
+		}
+		return ordered.map(id => ({ c0: id }));
+	}
+
+	/**
+	 * Returns the rows in the order this statement is entitled to. A statement carrying the total
+	 * order gets the canonical order; anything else gets a fresh permutation.
+	 */
+	private _order(flat: string): number[] {
+		this._statements++;
+		const orderBy = /ORDER BY (.+?)(?: LIMIT|\)|$)/.exec(flat);
+		if (orderBy?.[1].includes(this._totalOrder)) {
+			return this._canonical;
+		}
+		const shift = this._statements % ROW_COUNT;
+		return [...this._canonical.slice(shift), ...this._canonical.slice(0, shift)];
+	}
+}
+
+/** Reads every page in sequence and reports which rows were repeated or never seen. */
+async function sweep(view: SqliteTableView): Promise<{ duplicated: number; missing: number }> {
+	const seen = new Map<number, number>();
+	for (let offset = 0; offset < ROW_COUNT; offset += PAGE_SIZE) {
+		const page = await view.getDataValues({
+			columns: [{ column_index: 0, spec: { first_index: offset, last_index: offset + PAGE_SIZE - 1 } }],
+			format_options: FORMAT,
+		});
+		for (const value of page.columns[0]) {
+			const id = Number(value);
+			seen.set(id, (seen.get(id) ?? 0) + 1);
+		}
+	}
+	let duplicated = 0;
+	for (const count of seen.values()) {
+		duplicated += count - 1;
+	}
+	return { duplicated, missing: ROW_COUNT - seen.size };
+}
+
+suite('SQLite paging Tests', () => {
+	test('an unsorted table is paged exactly once per row', async () => {
+		// The case the Data Explorer actually opens in: the frontend sends no set_sort_columns until
+		// the user sorts, so the very first pages have to carry the tiebreaker on their own.
+		const engine = new ReorderingEngine('rowid');
+		const plan = await createSqliteReadPlan(engine, 'events', 'table', COLUMNS);
+		const view = new SqliteTableView(engine, 'events', plan, SCHEMA);
+
+		assert.deepStrictEqual(await sweep(view), { duplicated: 0, missing: 0 });
+	});
+
+	test('the first page already carries the tiebreaker', async () => {
+		const engine = new ReorderingEngine('rowid');
+		const plan = await createSqliteReadPlan(engine, 'events', 'table', COLUMNS);
+		const view = new SqliteTableView(engine, 'events', plan, SCHEMA);
+
+		await view.getDataValues({
+			columns: [{ column_index: 0, spec: { first_index: 0, last_index: 9 } }],
+			format_options: FORMAT,
+		});
+
+		const dataQuery = engine.queries.find(q => q.includes('OFFSET'))!;
+		assert.match(dataQuery, /ORDER BY rowid\s+LIMIT 10 OFFSET 0/);
+	});
+
+	test('a sorted table is paged exactly once per row', async () => {
+		// Sort keys alone are not a total order: rows that tie on the key are still free to move
+		// between statements, so the tiebreaker has to survive sorting too.
+		const engine = new ReorderingEngine('rowid');
+		const plan = await createSqliteReadPlan(engine, 'events', 'table', COLUMNS);
+		const view = new SqliteTableView(engine, 'events', plan, SCHEMA);
+		await view.setSortColumns({ sort_keys: [{ column_index: 0, ascending: true }] });
+
+		assert.deepStrictEqual(await sweep(view), { duplicated: 0, missing: 0 });
+	});
+
+	test('a WITHOUT ROWID table is paged exactly once per row', async () => {
+		const engine = new ReorderingEngine('"k"', ['k']);
+		const plan = await createSqliteReadPlan(engine, 'kv', 'table', COLUMNS);
+		const view = new SqliteTableView(engine, 'kv', plan, SCHEMA);
+
+		assert.deepStrictEqual(await sweep(view), { duplicated: 0, missing: 0 });
+	});
+
+	test('a view is paged exactly once per row, from its snapshot', async () => {
+		const engine = new ReorderingEngine('rowid');
+		const plan = await createSqliteReadPlan(engine, 'sales_by_region', 'view', COLUMNS);
+		const view = new SqliteTableView(engine, 'sales_by_region', plan, SCHEMA);
+
+		const result = await sweep(view);
+		const snapshots = engine.queries.filter(q => q.startsWith('CREATE TEMP TABLE'));
+
+		assert.deepStrictEqual(
+			{ ...result, snapshots: snapshots.length },
+			// One snapshot for the whole sweep: the view's own query runs once, not once per page.
+			{ duplicated: 0, missing: 0, snapshots: 1 });
+	});
+
+	test('the row count and the rows come from the same relation', async () => {
+		// The grid's total comes from a separate count(*). When a view is read through a snapshot but
+		// counted against the live view, the total can disagree with what the rows add up to.
+		const engine = new ReorderingEngine('rowid');
+		const plan = await createSqliteReadPlan(engine, 'sales_by_region', 'view', COLUMNS);
+		const view = new SqliteTableView(engine, 'sales_by_region', plan, SCHEMA);
+		await view.getState();
+
+		const countQuery = engine.queries.find(q => q.includes('count(*)'))!;
+		assert.match(countQuery, /FROM temp\."positron_snapshot_\d+"/);
+	});
+
+	test('an index-based export returns the rows the grid displayed at those positions', async () => {
+		// The half of the defect that leaves a lasting artifact: this path writes a file the user
+		// keeps, so a row numbered against a different order than the grid used is silently wrong.
+		const engine = new ReorderingEngine('rowid');
+		const plan = await createSqliteReadPlan(engine, 'events', 'table', COLUMNS);
+		const view = new SqliteTableView(engine, 'events', plan, SCHEMA);
+
+		const positions = [0, 7, 199, 498];
+		const displayed: number[] = [];
+		for (const position of positions) {
+			const page = await view.getDataValues({
+				columns: [{ column_index: 0, spec: { first_index: position, last_index: position } }],
+				format_options: FORMAT,
+			});
+			displayed.push(Number(page.columns[0][0]));
+		}
+
+		const exported = await view.exportDataSelection({
+			selection: { kind: TableSelectionKind.RowIndices, selection: { indices: positions } },
+			format: 'csv' as never,
+		});
+		const exportedIds = exported.data.trim().split('\n').slice(1).map(Number);
+
+		assert.deepStrictEqual(exportedIds, displayed);
+	});
+
+	test('generated code names the user\'s relation, not the snapshot', async () => {
+		const engine = new ReorderingEngine('rowid');
+		const plan = await createSqliteReadPlan(engine, 'sales_by_region', 'view', COLUMNS);
+		const view = new SqliteTableView(engine, 'sales_by_region', plan, SCHEMA);
+
+		const code = await view.convertToCode({} as never);
+
+		assert.deepStrictEqual(code.converted_code, ['SELECT *', 'FROM "sales_by_region"']);
+	});
+});

--- a/extensions/positron-data-driver-sqlite/src/test/sqlitePaging.test.ts
+++ b/extensions/positron-data-driver-sqlite/src/test/sqlitePaging.test.ts
@@ -51,7 +51,7 @@ class ReorderingEngine {
 
 	/**
 	 * @param _totalOrder The ORDER BY text this engine accepts as a total order.
-	 * @param _primaryKey Primary key columns to report from PRAGMA table_info. Supplying them also
+	 * @param _primaryKey Primary key columns to report from PRAGMA table_xinfo. Supplying them also
 	 * makes the `rowid` probe fail, which is how a real WITHOUT ROWID table presents itself.
 	 */
 	constructor(
@@ -69,7 +69,7 @@ class ReorderingEngine {
 			}
 			return [];
 		}
-		if (flat.startsWith('PRAGMA table_info')) {
+		if (flat.startsWith('PRAGMA table_xinfo')) {
 			return (this._primaryKey ?? []).map((name, i) => ({ name, pk: i + 1 }));
 		}
 		if (flat.includes('count(*)')) {

--- a/extensions/positron-data-driver-sqlite/src/test/sqlitePagingIntegration.test.ts
+++ b/extensions/positron-data-driver-sqlite/src/test/sqlitePagingIntegration.test.ts
@@ -1,0 +1,243 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as os from 'os';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as assert from 'assert';
+import Database from 'better-sqlite3';
+import { createSqliteReadPlan } from '../sqliteReadPlan.js';
+import { buildSqliteSchema } from '../sqliteDataExplorerRpcHandler.js';
+import { SqliteTableView } from '../sqliteTableView.js';
+import { SqliteWorkerClient } from '../sqliteWorkerClient.js';
+import { ColumnDisplayType, FormatOptions, TableSelectionKind } from 'positron-data-explorer-protocol';
+
+/**
+ * The read path exercised against a real SQLite file through the real worker, rather than a fake
+ * that answers whatever SQL it is handed.
+ *
+ * `sqlitePaging.test.ts` covers which SQL the driver emits and that paging it partitions the rows.
+ * It cannot tell whether SQLite and better-sqlite3 will actually accept that SQL -- and they did
+ * not: the worker ran every statement through `all()`, which throws "This statement does not return
+ * data. Use run() instead" on the CREATE that materializes a view's snapshot, so opening any view
+ * failed outright. These tests close that gap.
+ */
+suite('SQLite paging integration Tests', () => {
+	const FORMAT: FormatOptions = {
+		large_num_digits: 2,
+		small_num_digits: 4,
+		max_integral_digits: 7,
+		max_value_length: 100,
+	};
+
+	const ROWS = 1000;
+	const PAGE = 50;
+
+	let tmpDir: string;
+	const clients: SqliteWorkerClient[] = [];
+
+	setup(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'positron-sqlite-paging-'));
+	});
+
+	teardown(() => {
+		for (const client of clients.splice(0)) {
+			client.dispose();
+		}
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	/** Builds a database holding each relation shape the read plan has to handle. */
+	function createTestDb(name: string): string {
+		const dbPath = path.join(tmpDir, name);
+		const db = new Database(dbPath);
+		db.exec(`
+			CREATE TABLE t (id INTEGER PRIMARY KEY, k INTEGER, payload TEXT);
+			CREATE TABLE dim (k INTEGER PRIMARY KEY, nm TEXT);
+			CREATE VIEW v AS SELECT t.id, dim.nm FROM t JOIN dim ON dim.k = t.k;
+			CREATE TABLE kv (k TEXT PRIMARY KEY, v INTEGER) WITHOUT ROWID;
+			CREATE TABLE decoy (id TEXT PRIMARY KEY, note TEXT DEFAULT 'migrated without rowid');
+		`);
+		const insertT = db.prepare('INSERT INTO t VALUES (?, ?, ?)');
+		const insertKv = db.prepare('INSERT INTO kv VALUES (?, ?)');
+		const insertDim = db.prepare('INSERT INTO dim VALUES (?, ?)');
+		const insertDecoy = db.prepare('INSERT INTO decoy VALUES (?, ?)');
+		db.transaction(() => {
+			for (let i = 1; i <= ROWS; i++) {
+				insertT.run(i, i % 100, `p${i}`);
+				insertKv.run(`k${i}`, i);
+				insertDecoy.run(`d${i}`, 'x');
+			}
+			for (let i = 0; i < 100; i++) {
+				insertDim.run(i, `n${i}`);
+			}
+		})();
+		db.close();
+		return dbPath;
+	}
+
+	function openClient(dbPath: string, readOnly = false): SqliteWorkerClient {
+		const client = new SqliteWorkerClient({ databasePath: dbPath, readOnly });
+		clients.push(client);
+		return client;
+	}
+
+	/** Builds a table view over a relation exactly as the RPC handler does. */
+	async function openView(
+		client: SqliteWorkerClient,
+		relation: string,
+		kind: 'table' | 'view',
+	): Promise<SqliteTableView> {
+		const schema = await buildSqliteSchema(client, relation);
+		const readPlan = await createSqliteReadPlan(
+			client, relation, kind, schema.map(c => c.column_name));
+		return new SqliteTableView(client, relation, readPlan, schema);
+	}
+
+	/** Pages the whole relation and reports the first column's values, in page order. */
+	async function sweep(view: SqliteTableView, total: number): Promise<Array<string | number>> {
+		const values: Array<string | number> = [];
+		for (let offset = 0; offset < total; offset += PAGE) {
+			const page = await view.getDataValues({
+				columns: [{ column_index: 0, spec: { first_index: offset, last_index: offset + PAGE - 1 } }],
+				format_options: FORMAT,
+			});
+			values.push(...page.columns[0] as Array<string | number>);
+		}
+		return values;
+	}
+
+	test('a table pages exactly once per row', async () => {
+		const client = openClient(createTestDb('table.db'));
+		const view = await openView(client, 't', 'table');
+
+		const values = await sweep(view, ROWS);
+
+		assert.deepStrictEqual(
+			{ count: values.length, distinct: new Set(values).size },
+			{ count: ROWS, distinct: ROWS });
+	});
+
+	test('a view opens and pages exactly once per row', async () => {
+		// The case that failed in the product: materializing the snapshot needs a statement that
+		// returns no rows, and the worker rejected those.
+		const client = openClient(createTestDb('view.db'));
+		const view = await openView(client, 'v', 'view');
+
+		const state = await view.getState();
+		const values = await sweep(view, state.table_shape.num_rows);
+
+		assert.deepStrictEqual(
+			{ rows: state.table_shape.num_rows, count: values.length, distinct: new Set(values).size },
+			{ rows: ROWS, count: ROWS, distinct: ROWS });
+	});
+
+	test('a view opens and pages on a read-only database', async () => {
+		// `temp` is a separate database that stays writable, so the snapshot is legal here -- but only
+		// a real connection can confirm that better-sqlite3 agrees.
+		const client = openClient(createTestDb('view-ro.db'), true);
+		const view = await openView(client, 'v', 'view');
+
+		const state = await view.getState();
+		const values = await sweep(view, state.table_shape.num_rows);
+
+		assert.deepStrictEqual(
+			{ rows: state.table_shape.num_rows, distinct: new Set(values).size },
+			{ rows: ROWS, distinct: ROWS });
+	});
+
+	test('a WITHOUT ROWID table pages exactly once per row', async () => {
+		// Ordering this relation by `rowid` is a hard error, so it has to resolve to the primary key.
+		const client = openClient(createTestDb('without-rowid.db'));
+		const view = await openView(client, 'kv', 'table');
+
+		const values = await sweep(view, ROWS);
+
+		assert.deepStrictEqual(
+			{ count: values.length, distinct: new Set(values).size },
+			{ count: ROWS, distinct: ROWS });
+	});
+
+	test('a table whose DDL mentions the words WITHOUT ROWID still pages by rowid', async () => {
+		// `decoy` is an ordinary table whose DEFAULT literal contains the words. Reading the stored
+		// CREATE statement would misclassify it; probing cannot.
+		const client = openClient(createTestDb('decoy.db'));
+		// `decoy` is read in place, so the column list the snapshot path would consult is not involved.
+		const plan = await createSqliteReadPlan(client, 'decoy', 'table', []);
+		const view = await openView(client, 'decoy', 'table');
+
+		const values = await sweep(view, ROWS);
+
+		assert.deepStrictEqual(
+			{ rowOrder: plan.rowOrder, distinct: new Set(values).size },
+			{ rowOrder: 'rowid', distinct: ROWS });
+	});
+
+	test('an index-based export returns the rows shown at those positions', async () => {
+		const client = openClient(createTestDb('export.db'));
+		const view = await openView(client, 'v', 'view');
+
+		const displayed = await sweep(view, ROWS);
+		const positions = [0, 1, 49, 50, 517, ROWS - 1];
+		const exported = await view.exportDataSelection({
+			selection: { kind: TableSelectionKind.RowIndices, selection: { indices: positions } },
+			format: 'csv' as never,
+		});
+		// The CSV carries a header row, then one line per requested position, in request order.
+		const exportedFirstColumn = exported.data.trim().split('\n').slice(1)
+			.map(line => line.split(',')[0]);
+
+		assert.deepStrictEqual(exportedFirstColumn, positions.map(p => String(displayed[p])));
+	});
+
+	test('the snapshot is dropped when the view is disposed', async () => {
+		const client = openClient(createTestDb('dispose.db'));
+		const view = await openView(client, 'v', 'view');
+		await view.getState();
+
+		const before = await client.runQuery(
+			`SELECT count(*) AS n FROM temp.sqlite_master WHERE type = 'table'`);
+		await view.dispose();
+		const after = await client.runQuery(
+			`SELECT count(*) AS n FROM temp.sqlite_master WHERE type = 'table'`);
+
+		assert.deepStrictEqual(
+			{ before: Number(before[0].n), after: Number(after[0].n) },
+			{ before: 1, after: 0 });
+	});
+
+	test('a column profile describes the same rows the grid shows', async () => {
+		// Profiles run against the snapshot too, so a view's null count cannot be computed from a
+		// different pass over the live view than the one the grid displayed.
+		const client = openClient(createTestDb('profile.db'));
+		const view = await openView(client, 'v', 'view');
+		await view.getState();
+
+		const profiles = await view.computeColumnProfiles({
+			callback_id: 'c',
+			profiles: [{ column_index: 0, profiles: [{ profile_type: 'null_count' as never }] }],
+			format_options: FORMAT,
+		});
+
+		assert.strictEqual(profiles.profiles[0].null_count, 0);
+	});
+
+	test('display type mapping survives the round trip', async () => {
+		// A guard that openView's schema and the read plan agree on column order, since the read plan
+		// resolution and the schema build run concurrently.
+		const client = openClient(createTestDb('schema.db'));
+		const view = await openView(client, 't', 'table');
+
+		const schema = await view.getSchema({ column_indices: [0, 1, 2] });
+
+		assert.deepStrictEqual(
+			schema.columns.map(c => [c.column_name, c.type_display]),
+			[
+				['id', ColumnDisplayType.Integer],
+				['k', ColumnDisplayType.Integer],
+				['payload', ColumnDisplayType.String],
+			]);
+	});
+});

--- a/extensions/positron-data-driver-sqlite/src/test/sqliteReadPlan.test.ts
+++ b/extensions/positron-data-driver-sqlite/src/test/sqliteReadPlan.test.ts
@@ -26,10 +26,16 @@ class FakeClient {
 	constructor(
 		private readonly options: {
 			readonly rowidTables?: readonly string[];
-			/** Primary key columns per table, in key order, as PRAGMA table_info would report them. */
+			/** Primary key columns per table, in key order, as PRAGMA table_xinfo would report them. */
 			readonly primaryKeys?: Readonly<Record<string, readonly string[]>>;
-			/** Non-key columns per table, as PRAGMA table_info would report them. */
+			/** Non-key columns per table, as PRAGMA table_xinfo would report them. */
 			readonly declaredColumns?: Readonly<Record<string, readonly string[]>>;
+			/**
+			 * Generated columns per table. SQLite reports these from `table_xinfo` but not from
+			 * `table_info`, and the two pragmas below model that difference, so a read plan that asked
+			 * the wrong one would not see them.
+			 */
+			readonly generatedColumns?: Readonly<Record<string, readonly string[]>>;
 			/** Raised by the rowid probe, to stand in for a failure that is not "no such column". */
 			readonly probeError?: Error;
 		} = {}
@@ -52,12 +58,16 @@ class FakeClient {
 			return [];
 		}
 
-		const pragma = /^PRAGMA table_info\("(.+)"\)$/.exec(sql);
+		const pragma = /^PRAGMA table_(x?)info\("(.+)"\)$/.exec(sql);
 		if (pragma) {
-			const keyColumns = this.options.primaryKeys?.[pragma[1]] ?? [];
+			const [, x, table] = pragma;
+			const keyColumns = this.options.primaryKeys?.[table] ?? [];
+			// Only `table_xinfo` reports generated columns; `table_info` leaves them out entirely.
+			const generated = x === 'x' ? (this.options.generatedColumns?.[table] ?? []) : [];
 			return [
 				...keyColumns.map((name, i) => ({ name, pk: i + 1 })),
-				...(this.options.declaredColumns?.[pragma[1]] ?? []).map(name => ({ name, pk: 0 })),
+				...(this.options.declaredColumns?.[table] ?? []).map(name => ({ name, pk: 0 })),
+				...generated.map(name => ({ name, pk: 0 })),
 				{ name: 'payload', pk: 0 },
 			];
 		}
@@ -69,6 +79,9 @@ class FakeClient {
 		return [
 			...(this.options.primaryKeys?.[table] ?? []),
 			...(this.options.declaredColumns?.[table] ?? []),
+			// Generated columns shadow a rowid alias exactly as stored ones do, so the probe binds to
+			// them and succeeds.
+			...(this.options.generatedColumns?.[table] ?? []),
 		];
 	}
 
@@ -100,7 +113,7 @@ suite('SQLite read plan Tests', () => {
 					rowOrder: 'rowid',
 					// Two checks and no setup: the column list, to confirm nothing shadows the rowid, and
 					// the probe. Neither reads a row.
-					queries: ['PRAGMA table_info("people")', 'SELECT rowid FROM "people" LIMIT 0'],
+					queries: ['PRAGMA table_xinfo("people")', 'SELECT rowid FROM "people" LIMIT 0'],
 				});
 		});
 
@@ -141,6 +154,23 @@ suite('SQLite read plan Tests', () => {
 				declaredColumns: { shadow: ['rowid'] },
 			});
 			const plan = await createSqliteReadPlan(client, 'shadow', 'table', COLUMNS);
+
+			assert.strictEqual(plan.rowOrder, '_rowid_');
+		});
+
+		test('a generated column named rowid shadows the rowid and is seen anyway', async () => {
+			// `table_info` omits generated columns, so reading the schema through it would leave `rowid`
+			// looking free -- and the probe would agree, because binding succeeds against the generated
+			// column. Measured against SQLite 3.51.3 on
+			// `CREATE TABLE g(v INTEGER, rowid TEXT GENERATED ALWAYS AS ('x'||v) VIRTUAL)`, `SELECT rowid`
+			// returns 'x1', 'x2', 'x3' while `SELECT _rowid_` returns 1, 2, 3. Ordering by the first is
+			// exactly the drift this change exists to prevent, so the schema is read through
+			// `table_xinfo`, which reports the column.
+			const client = new FakeClient({
+				rowidTables: ['gen'],
+				generatedColumns: { gen: ['rowid'] },
+			});
+			const plan = await createSqliteReadPlan(client, 'gen', 'table', ['v', 'rowid']);
 
 			assert.strictEqual(plan.rowOrder, '_rowid_');
 		});

--- a/extensions/positron-data-driver-sqlite/src/test/sqliteReadPlan.test.ts
+++ b/extensions/positron-data-driver-sqlite/src/test/sqliteReadPlan.test.ts
@@ -1,0 +1,340 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { createSqliteReadPlan } from '../sqliteReadPlan.js';
+import { SqliteRow } from '../sqliteWorkerClient.js';
+import { SqliteBindValue } from '../sqliteWorkerProtocol.js';
+
+/**
+ * A fake client standing in for one SQLite database.
+ *
+ * `rowidTables` are ordinary tables, whose rowid probe succeeds. Anything else is treated as a
+ * relation with no rowid, so the probe raises the same error SQLite does -- which is what tells the
+ * read plan it is looking at a WITHOUT ROWID table.
+ *
+ * `declaredColumns` names ordinary columns the table declares, which matters when one of them is
+ * spelled like a rowid alias: SQLite resolves the name to that column, so the probe succeeds even on
+ * a table with no rowid. Modelling that faithfully is what makes the shadowing tests meaningful.
+ */
+class FakeClient {
+	readonly queries: string[] = [];
+	private _crashListener: (() => void) | undefined;
+
+	constructor(
+		private readonly options: {
+			readonly rowidTables?: readonly string[];
+			/** Primary key columns per table, in key order, as PRAGMA table_info would report them. */
+			readonly primaryKeys?: Readonly<Record<string, readonly string[]>>;
+			/** Non-key columns per table, as PRAGMA table_info would report them. */
+			readonly declaredColumns?: Readonly<Record<string, readonly string[]>>;
+			/** Raised by the rowid probe, to stand in for a failure that is not "no such column". */
+			readonly probeError?: Error;
+		} = {}
+	) { }
+
+	async runQuery(sql: string, _params?: SqliteBindValue[]): Promise<SqliteRow[]> {
+		this.queries.push(sql);
+
+		const probe = /^SELECT (rowid|_rowid_|oid) FROM "(.+)" LIMIT 0$/.exec(sql);
+		if (probe) {
+			const [, alias, table] = probe;
+			if (this.options.probeError) {
+				throw this.options.probeError;
+			}
+			// A declared column of the same name shadows the rowid, and the probe then resolves to it.
+			const shadowed = this._columnsOf(table).some(name => name.toLowerCase() === alias);
+			if (!shadowed && !this.options.rowidTables?.includes(table)) {
+				throw new Error(`no such column: ${alias}`);
+			}
+			return [];
+		}
+
+		const pragma = /^PRAGMA table_info\("(.+)"\)$/.exec(sql);
+		if (pragma) {
+			const keyColumns = this.options.primaryKeys?.[pragma[1]] ?? [];
+			return [
+				...keyColumns.map((name, i) => ({ name, pk: i + 1 })),
+				...(this.options.declaredColumns?.[pragma[1]] ?? []).map(name => ({ name, pk: 0 })),
+				{ name: 'payload', pk: 0 },
+			];
+		}
+
+		return [];
+	}
+
+	private _columnsOf(table: string): readonly string[] {
+		return [
+			...(this.options.primaryKeys?.[table] ?? []),
+			...(this.options.declaredColumns?.[table] ?? []),
+		];
+	}
+
+	/** Stands in for `SqliteWorkerClient.onDidCrash`. */
+	onDidCrash = (listener: () => void) => {
+		this._crashListener = listener;
+		return { dispose: () => { this._crashListener = undefined; } };
+	};
+
+	/** Simulates the worker dying and being replaced, which empties the `temp` schema. */
+	crash(): void {
+		this._crashListener?.();
+	}
+}
+
+/** Stands in for a relation's full column list, none of which shadows a rowid alias. */
+const COLUMNS = ['id', 'payload'];
+
+suite('SQLite read plan Tests', () => {
+	suite('row identity', () => {
+		test('an ordinary table is read in place, ordered by rowid', async () => {
+			const client = new FakeClient({ rowidTables: ['people'] });
+			const plan = await createSqliteReadPlan(client, 'people', 'table', COLUMNS);
+
+			assert.deepStrictEqual(
+				{ relation: await plan.relation(), rowOrder: plan.rowOrder, queries: client.queries },
+				{
+					relation: '"people"',
+					rowOrder: 'rowid',
+					// Two checks and no setup: the column list, to confirm nothing shadows the rowid, and
+					// the probe. Neither reads a row.
+					queries: ['PRAGMA table_info("people")', 'SELECT rowid FROM "people" LIMIT 0'],
+				});
+		});
+
+		test('a WITHOUT ROWID table falls back to its primary key, in key order', async () => {
+			// `kv` is absent from rowidTables, so the probe fails exactly as it does on a real
+			// WITHOUT ROWID table, whose primary key columns are implicitly NOT NULL.
+			const client = new FakeClient({ primaryKeys: { kv: ['tenant', 'k'] } });
+			const plan = await createSqliteReadPlan(client, 'kv', 'table', COLUMNS);
+
+			assert.deepStrictEqual(
+				{ relation: await plan.relation(), rowOrder: plan.rowOrder },
+				{ relation: '"kv"', rowOrder: '"tenant", "k"' });
+		});
+
+		test('a table whose DDL merely mentions the words WITHOUT ROWID still uses rowid', async () => {
+			// A regression guard for reading the stored CREATE statement instead of probing: the DDL
+			// `note TEXT DEFAULT 'migrated without rowid'` describes an ordinary rowid table. Reading it
+			// as WITHOUT ROWID would silently order by a declared primary key, which an ordinary table
+			// may hold NULLs in -- so rows could tie and paging would drift again, with nothing to show
+			// that the tiebreaker had stopped working.
+			const client = new FakeClient({
+				rowidTables: ['migrated'],
+				primaryKeys: { migrated: ['id'] },
+			});
+			const plan = await createSqliteReadPlan(client, 'migrated', 'table', COLUMNS);
+
+			assert.strictEqual(plan.rowOrder, 'rowid');
+		});
+
+		test('a table that declares its own rowid column orders by an unshadowed alias', async () => {
+			// SQLite lets a table declare a column named `rowid`, and that column then shadows the real
+			// rowid: on `CREATE TABLE t(rowid TEXT, v INTEGER)`, `SELECT rowid` hands back the TEXT
+			// column, which carries no uniqueness -- three rows of it verifiably read 'a', 'a', 'a'.
+			// Ordering by it would put paging right back where this whole change started, and silently,
+			// because the probe still succeeds. `_rowid_` names the real rowid instead.
+			const client = new FakeClient({
+				rowidTables: ['shadow'],
+				declaredColumns: { shadow: ['rowid'] },
+			});
+			const plan = await createSqliteReadPlan(client, 'shadow', 'table', COLUMNS);
+
+			assert.strictEqual(plan.rowOrder, '_rowid_');
+		});
+
+		test('a table that declares all three rowid aliases is read through a snapshot', async () => {
+			// Nothing can name this table's rowid, and its declared primary key is no substitute: an
+			// ordinary table admits NULLs in a PRIMARY KEY column, and a unique index treats every NULL
+			// as distinct, so rows can tie.
+			const client = new FakeClient({
+				rowidTables: ['pathological'],
+				primaryKeys: { pathological: ['oid'] },
+				declaredColumns: { pathological: ['rowid', '_rowid_'] },
+			});
+			const plan = await createSqliteReadPlan(
+				client, 'pathological', 'table', ['oid', 'rowid', '_rowid_']);
+
+			// The snapshot inherits the same problem -- `SELECT *` copies all three names into it -- so it
+			// numbers the rows in a column of its own instead.
+			assert.deepStrictEqual(
+				{
+					readsSnapshot: /^temp\."positron_snapshot_\d+"$/.test(await plan.relation()),
+					rowOrder: plan.rowOrder,
+				},
+				{ readsSnapshot: true, rowOrder: '"__positron_row_order"' });
+		});
+
+		test('a probe failure that is not "no such column" is raised, not treated as WITHOUT ROWID', async () => {
+			// A dead worker must not be read as evidence that a table has no rowid. Doing so would fall
+			// through to the primary key, which is only a total order on a table that genuinely has none
+			// -- so an ordinary table with a nullable TEXT primary key would page unstably. Failing the
+			// open is recoverable; the user reopens the tab.
+			const client = new FakeClient({
+				probeError: new Error('The SQLite process terminated unexpectedly (signal SIGKILL).'),
+				primaryKeys: { people: ['email'] },
+			});
+
+			await assert.rejects(
+				() => createSqliteReadPlan(client, 'people', 'table', COLUMNS),
+				/terminated unexpectedly/);
+		});
+
+		test('quotes an identifier that contains a double quote', async () => {
+			const client = new FakeClient({ primaryKeys: { odd: ['we"ird'] } });
+			const plan = await createSqliteReadPlan(client, 'odd', 'table', COLUMNS);
+
+			assert.strictEqual(plan.rowOrder, '"we""ird"');
+		});
+	});
+
+	suite('snapshot', () => {
+		test('a view is read through a snapshot, materialized once and ordered by rowid', async () => {
+			const client = new FakeClient();
+			const plan = await createSqliteReadPlan(client, 'sales_by_region', 'view', COLUMNS);
+
+			// Nothing is created until the first read, so opening a view costs nothing extra.
+			assert.deepStrictEqual(client.queries, []);
+
+			const first = await plan.relation();
+			const second = await plan.relation();
+
+			assert.deepStrictEqual(
+				{
+					reusesOneSnapshot: first === second,
+					readsFromTempSchema: /^temp\."positron_snapshot_\d+"$/.test(first),
+					rowOrder: plan.rowOrder,
+					creates: client.queries,
+				},
+				{
+					reusesOneSnapshot: true,
+					readsFromTempSchema: true,
+					rowOrder: 'rowid',
+					// Materialized exactly once, however many reads follow. The CREATE names the
+					// snapshot unqualified, because SQLite rejects a schema-qualified name there.
+					creates: [`CREATE TEMP TABLE ${first.replace('temp.', '')} AS SELECT * FROM "sales_by_region"`],
+				});
+		});
+
+		test('a view that emits a rowid column is snapshotted under an unshadowed alias', async () => {
+			// `SELECT *` copies the view's columns verbatim, so a view emitting `rowid` puts a column of
+			// that name into the snapshot, where it shadows the snapshot's own rowid. Ordering by the
+			// name would read the copied column, which carries no uniqueness once a join has fanned the
+			// view out. `CREATE VIEW v AS SELECT rowid, name FROM t` is idiomatic enough to expect.
+			const client = new FakeClient();
+			const plan = await createSqliteReadPlan(client, 'v', 'view', ['rowid', 'total']);
+
+			const relation = await plan.relation();
+
+			assert.deepStrictEqual(
+				{ rowOrder: plan.rowOrder, creates: client.queries },
+				{
+					// Still free: a TEMP table's rowid is its storage order under any of its names.
+					rowOrder: '_rowid_',
+					creates: [`CREATE TEMP TABLE ${relation.replace('temp.', '')} AS SELECT * FROM "v"`],
+				});
+		});
+
+		test('a view that emits every rowid alias is numbered explicitly', async () => {
+			const client = new FakeClient();
+			const plan = await createSqliteReadPlan(
+				client, 'v', 'view', ['rowid', '_rowid_', 'oid', 'total']);
+
+			const relation = await plan.relation();
+
+			assert.deepStrictEqual(
+				{ rowOrder: plan.rowOrder, creates: client.queries },
+				{
+					rowOrder: '"__positron_row_order"',
+					creates: [
+						`CREATE TEMP TABLE ${relation.replace('temp.', '')} AS ` +
+						`SELECT ROW_NUMBER() OVER () AS "__positron_row_order", * FROM "v"`,
+					],
+				});
+		});
+
+		test('a table with neither a rowid nor a primary key is read through a snapshot', async () => {
+			// Not reachable on a real database -- SQLite requires a primary key on a WITHOUT ROWID
+			// table -- but the fallback has to be a stable order rather than no order at all.
+			const client = new FakeClient();
+			const plan = await createSqliteReadPlan(client, 'exotic', 'table', COLUMNS);
+
+			assert.match(await plan.relation(), /^temp\."positron_snapshot_\d+"$/);
+		});
+
+		test('dispose drops the snapshot', async () => {
+			const client = new FakeClient();
+			const plan = await createSqliteReadPlan(client, 'v', 'view', COLUMNS);
+			const relation = await plan.relation();
+			client.queries.length = 0;
+
+			await plan.dispose();
+
+			assert.deepStrictEqual(client.queries, [`DROP TABLE IF EXISTS ${relation}`]);
+		});
+
+		test('dispose drops nothing when the snapshot was never materialized', async () => {
+			const client = new FakeClient();
+			const plan = await createSqliteReadPlan(client, 'v', 'view', COLUMNS);
+
+			await plan.dispose();
+
+			assert.deepStrictEqual(client.queries, []);
+		});
+
+		test('a read after dispose is refused rather than leaking a fresh snapshot', async () => {
+			// A queued column profile can outlive the tab that asked for it. Materializing again here
+			// would build a snapshot with nothing left to drop it, so it would sit in `temp` for the
+			// rest of the connection's life.
+			const client = new FakeClient();
+			const plan = await createSqliteReadPlan(client, 'v', 'view', COLUMNS);
+			await plan.relation();
+			await plan.dispose();
+			client.queries.length = 0;
+
+			await assert.rejects(() => plan.relation(), /disposed/);
+			assert.deepStrictEqual(client.queries, []);
+		});
+
+		test('the snapshot is rebuilt after the worker is replaced', async () => {
+			// A replacement worker starts with an empty `temp` schema. Without this, every later read
+			// would fail with "no such table" until the user reopened the tab.
+			const client = new FakeClient();
+			const plan = await createSqliteReadPlan(client, 'v', 'view', COLUMNS);
+			await plan.relation();
+			const createsBefore = client.queries.filter(q => q.startsWith('CREATE TEMP TABLE')).length;
+
+			client.crash();
+			await plan.relation();
+
+			assert.deepStrictEqual(
+				{
+					createsBefore,
+					createsAfter: client.queries.filter(q => q.startsWith('CREATE TEMP TABLE')).length,
+				},
+				{ createsBefore: 1, createsAfter: 2 });
+		});
+
+		test('a failed materialization is retried rather than cached', async () => {
+			let attempts = 0;
+			const client = new FakeClient();
+			const failing = {
+				...client,
+				runQuery: async (sql: string) => {
+					if (sql.startsWith('CREATE TEMP TABLE') && ++attempts === 1) {
+						throw new Error('database or disk is full');
+					}
+					return client.runQuery(sql);
+				},
+			};
+			const plan = await createSqliteReadPlan(failing, 'v', 'view', COLUMNS);
+
+			await assert.rejects(() => plan.relation(), /disk is full/);
+			await plan.relation();
+
+			assert.strictEqual(attempts, 2);
+		});
+	});
+});

--- a/extensions/positron-data-driver-sqlite/src/test/sqliteTableView.test.ts
+++ b/extensions/positron-data-driver-sqlite/src/test/sqliteTableView.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import { ISqliteReadPlan } from '../sqliteReadPlan.js';
 import { SqliteRow } from '../sqliteWorkerClient.js';
 import { SqliteBindValue } from '../sqliteWorkerProtocol.js';
 import { SqliteSchemaEntry, SqliteTableView, makeWhereExpr, sqliteDisplayType } from '../sqliteTableView.js';
@@ -25,6 +26,15 @@ class FakeQueryClient {
 		this.queries.push(sql);
 		return this.responder(sql);
 	}
+}
+
+/**
+ * The read plan of an ordinary rowid table: read in place, ordered by `rowid`. Stubbed rather than
+ * resolved through `createSqliteReadPlan` so that the probe it issues does not appear among the
+ * queries these tests assert on; `sqliteReadPlan.test.ts` covers the resolution itself.
+ */
+function rowidReadPlan(quotedTable: string): ISqliteReadPlan {
+	return { relation: async () => quotedTable, rowOrder: 'rowid', dispose: async () => { } };
 }
 
 const FORMAT: FormatOptions = {
@@ -128,7 +138,7 @@ suite('SQLite Data Explorer Tests', () => {
 					{ c0: 3, c1: Infinity },
 				];
 			});
-			const view = new SqliteTableView(client, 'people', 'table', schema);
+			const view = new SqliteTableView(client, 'people', rowidReadPlan('"people"'), schema);
 			const data = await view.getDataValues({
 				columns: [
 					{ column_index: 0, spec: { first_index: 0, last_index: 2 } },
@@ -142,9 +152,9 @@ suite('SQLite Data Explorer Tests', () => {
 			]);
 		});
 
-		test('paginates with LIMIT/OFFSET and a rowid tiebreaker once sorted', async () => {
+		test('paginates with LIMIT/OFFSET and a rowid tiebreaker after the sort keys', async () => {
 			const client = new FakeQueryClient(sql => (sql.includes('count(*)') ? [{ n: 10 }] : [{ c0: 5 }]));
-			const view = new SqliteTableView(client, 'people', 'table', schema);
+			const view = new SqliteTableView(client, 'people', rowidReadPlan('"people"'), schema);
 			await view.setSortColumns({ sort_keys: [{ column_index: 0, ascending: false }] });
 			await view.getDataValues({
 				columns: [{ column_index: 0, spec: { first_index: 2, last_index: 2 } }],
@@ -162,7 +172,7 @@ suite('SQLite Data Explorer Tests', () => {
 			];
 			const client = new FakeQueryClient(sql =>
 				sql.includes('count(*)') ? [{ n: 2 }] : [{ c0: 1.5 }, { c0: 2.5 }]);
-			const view = new SqliteTableView(client, 'people', 'table', oneColumn);
+			const view = new SqliteTableView(client, 'people', rowidReadPlan('"people"'), oneColumn);
 
 			const state = await view.getState();
 			const data = await view.getDataValues({

--- a/extensions/positron-data-explorer-duckdb/src/duckdbDataExplorerRpcHandler.ts
+++ b/extensions/positron-data-explorer-duckdb/src/duckdbDataExplorerRpcHandler.ts
@@ -8,6 +8,7 @@
 
 import * as positron from 'positron';
 import * as vscode from 'vscode';
+import { createDuckDBReadPlan } from './duckdbReadPlan.js';
 import { IDuckDBQueryClient } from './duckdbWorkerClient.js';
 import { DuckDBSchemaEntry, DuckDBTableView, duckdbDisplayType, IDuckDBTableCodeGenerator } from './duckdbTableView.js';
 import {
@@ -91,7 +92,9 @@ export class DuckDBDataExplorerRpcHandler implements vscode.Disposable, IDuckDBD
 
 	dispose(): void {
 		this._session.dispose();
-		this._views.clear();
+		for (const datasetId of [...this._views.keys()]) {
+			this._dropView(datasetId);
+		}
 		this._onClose.clear();
 	}
 
@@ -108,7 +111,9 @@ export class DuckDBDataExplorerRpcHandler implements vscode.Disposable, IDuckDBD
 		options: OpenTableViewOptions = {},
 	): Promise<void> {
 		const schema = await buildDuckDBSchema(client, schemaName, tableName);
-		this._views.set(datasetId, new DuckDBTableView(client, tableRef(schemaName, tableName), options.displayName ?? tableName, kind, schema, options.codeGenerator));
+		const readPlan = createDuckDBReadPlan(
+			client, tableRef(schemaName, tableName), kind, schema.map(c => c.column_name));
+		this._setView(datasetId, new DuckDBTableView(client, tableRef(schemaName, tableName), options.displayName ?? tableName, readPlan, schema, options.codeGenerator));
 		if (options.onClose) {
 			this._onClose.set(datasetId, options.onClose);
 		} else {
@@ -133,7 +138,29 @@ export class DuckDBDataExplorerRpcHandler implements vscode.Disposable, IDuckDBD
 		if (!column) {
 			throw new Error(`Column '${columnName}' not found in '${schemaName}.${tableName}'`);
 		}
-		this._views.set(datasetId, new DuckDBTableView(client, tableRef(schemaName, tableName), tableName, kind, [column]));
+		// The plan is given every column the relation has, not just the requested one: what it needs to
+		// know is whether the relation emits a column named `rowid`, which the restricted schema hides.
+		const readPlan = createDuckDBReadPlan(
+			client, tableRef(schemaName, tableName), kind, schema.map(c => c.column_name));
+		this._setView(datasetId, new DuckDBTableView(client, tableRef(schemaName, tableName), tableName, readPlan, [column]));
+	}
+
+	/**
+	 * Registers a view, disposing any view the same dataset id already had so that reopening a
+	 * dataset does not leave its predecessor's snapshot behind.
+	 */
+	private _setView(datasetId: string, view: DuckDBTableView): void {
+		this._dropView(datasetId);
+		this._views.set(datasetId, view);
+	}
+
+	/** Forgets a dataset's view and releases whatever its read plan holds. */
+	private _dropView(datasetId: string): void {
+		const view = this._views.get(datasetId);
+		this._views.delete(datasetId);
+		// Dropping the snapshot is best-effort cleanup of a private temp table, so nothing waits on
+		// it and a failure (typically a worker that is already gone) must not surface to the caller.
+		void view?.dispose().catch(() => { });
 	}
 
 	/**
@@ -142,7 +169,7 @@ export class DuckDBDataExplorerRpcHandler implements vscode.Disposable, IDuckDBD
 	 * that wholesale cleanup.
 	 */
 	closeTableView(datasetId: string): void {
-		this._views.delete(datasetId);
+		this._dropView(datasetId);
 		this._onClose.delete(datasetId);
 	}
 
@@ -152,7 +179,7 @@ export class DuckDBDataExplorerRpcHandler implements vscode.Disposable, IDuckDBD
 	 * release that dataset's resources.
 	 */
 	closeDataset(datasetId: string): void {
-		this._views.delete(datasetId);
+		this._dropView(datasetId);
 		const onClose = this._onClose.get(datasetId);
 		this._onClose.delete(datasetId);
 		onClose?.();

--- a/extensions/positron-data-explorer-duckdb/src/duckdbReadPlan.ts
+++ b/extensions/positron-data-explorer-duckdb/src/duckdbReadPlan.ts
@@ -51,9 +51,18 @@ export interface IDuckDBReadPlan {
  * back in insertion order. A view has no `rowid` and no guaranteed order, so it is read through a
  * snapshot.
  *
- * @param columnNames Every column the relation emits. Consulted only on the snapshot path, and only
- * to detect a column named `rowid` that would shadow the snapshot's own, so it must be the
- * relation's full column list rather than whichever subset a caller means to display.
+ * A table that declares its own column named `rowid` is the exception. That column shadows the
+ * table's real rowid, and DuckDB has no second spelling to reach past it, so `rowid` as a row order
+ * would silently order by user data: a table of `(rowid VARCHAR, v INTEGER)` holding
+ * `('b',1),('a',2),('c',3)` displays `v` as 1, 2, 3 in scan order while an index-based export
+ * numbering by `rowid` returns 2, 1, 3, writing rows the user never selected. Such a table is read
+ * through a snapshot too, which numbers the rows in a column of its own. Copying it is the cost of
+ * having a unique key at all; the shape shows up mainly in data imported from SQLite, which carries
+ * a `rowid` column through CSV and Parquet exports.
+ *
+ * @param columnNames Every column the relation emits, used to detect a column named `rowid` that
+ * would shadow the rowid a plan would otherwise order by, so it must be the relation's full column
+ * list rather than whichever subset a caller means to display.
  */
 export function createDuckDBReadPlan(
 	client: IDuckDBQueryClient,
@@ -61,9 +70,18 @@ export function createDuckDBReadPlan(
 	kind: 'table' | 'view',
 	columnNames: readonly string[],
 ): IDuckDBReadPlan {
-	return kind === 'table'
+	return kind === 'table' && !shadowsRowId(columnNames)
 		? new DirectRead(tableRef)
 		: new SnapshotRead(client, tableRef, columnNames);
+}
+
+/**
+ * Whether a relation emits a column named `rowid`, which shadows the rowid DuckDB supplies. Matched
+ * without regard to case, because DuckDB resolves unquoted identifiers that way, so `ROWID` shadows
+ * just as `rowid` does.
+ */
+function shadowsRowId(columnNames: readonly string[]): boolean {
+	return columnNames.some(name => name.toLowerCase() === 'rowid');
 }
 
 /** Reads a relation in place, relying on DuckDB to return a scan in insertion order. */
@@ -135,12 +153,11 @@ class SnapshotRead implements IDuckDBReadPlan {
 		// instead: measured against DuckDB 1.5.5, the snapshot of a join view that emits `rowid` read
 		// 0, 0, 1, 2, 2 under that name, three distinct values across five rows. Unlike SQLite, DuckDB
 		// has no second spelling of the rowid to fall back on, so the rows are numbered in a column of
-		// our own. That column is unindexed, so each page pays a sort to apply it -- worth accepting for
-		// a shape this rare, and paid only by the views that hit it. Reads
-		// never see the column: every one of them projects an explicit column list from the schema, and
-		// the export path's `SELECT *` is confined to a subquery the outer projection filters.
-		const shadowed = sourceColumns.some(name => name.toLowerCase() === 'rowid');
-		if (shadowed) {
+		// our own. That column is unindexed, so each page pays a sort to apply it, paid only by the
+		// relations that emit `rowid` themselves. Reads never see the column: every one of them projects
+		// an explicit column list from the schema, and the export path's `SELECT *` is confined to a
+		// subquery the outer projection filters.
+		if (shadowsRowId(sourceColumns)) {
 			const ordinal = quoteIdentifier(SNAPSHOT_ORDER_COLUMN);
 			this.rowOrder = ordinal;
 			this._selectList = `ROW_NUMBER() OVER () AS ${ordinal}, *`;

--- a/extensions/positron-data-explorer-duckdb/src/duckdbReadPlan.ts
+++ b/extensions/positron-data-explorer-duckdb/src/duckdbReadPlan.ts
@@ -1,0 +1,201 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { quoteIdentifier } from './duckdbSql.js';
+import { IDuckDBQueryClient } from './duckdbWorkerClient.js';
+
+/**
+ * How a Data Explorer view reads one relation so that its LIMIT/OFFSET paging is stable.
+ *
+ * The Data Explorer fetches each page with a separate statement, which is only safe while every one
+ * of those statements sees the relation in the same order. DuckDB gives that guarantee for a scan,
+ * through `preserve_insertion_order` (pinned in `duckdbWorker.ts`), so paging a table needs no
+ * ORDER BY at all -- and must not add one, because DuckDB cannot tell that `rowid` order is already
+ * the scan order and would sort the whole relation on every page instead.
+ *
+ * The guarantee does not extend to a relation whose order is not derived from a scan. A view over a
+ * join, an aggregate, a DISTINCT, or a window function is built by hash operators that have no input
+ * order to preserve, so each statement can emit a different permutation. Measured against DuckDB
+ * 1.5.5, sweeping a 500,000-row join view a page at a time repeated 170,032 rows and missed 170,032
+ * others. Those relations are read through a snapshot, which gives them a scan to page over.
+ */
+export interface IDuckDBReadPlan {
+	/**
+	 * The quoted relation every read should target, materializing the snapshot first if this plan
+	 * uses one. Called before each read, so it must stay cheap once the snapshot is in place.
+	 */
+	relation(): Promise<string>;
+
+	/**
+	 * An ORDER BY expression that totally orders {@link relation}, matching the order pages come
+	 * back in.
+	 *
+	 * Paging queries only state it once the user has sorted, where the sort is paid for anyway and
+	 * the expression breaks ties between equal keys. Index-based exports always state it, because a
+	 * ROW_NUMBER() window does not inherit the scan's insertion order -- numbering rows without it
+	 * disagreed with the displayed order on every row of a measured 171,429-row relation, so the
+	 * exported file held rows the user never selected.
+	 */
+	readonly rowOrder: string;
+
+	/** Drops any snapshot this plan created. Safe to call more than once. */
+	dispose(): Promise<void>;
+}
+
+/**
+ * Chooses how to read a table or view so that paging it is stable.
+ *
+ * A table is read in place: every DuckDB base table has a `rowid`, and a scan of it already comes
+ * back in insertion order. A view has no `rowid` and no guaranteed order, so it is read through a
+ * snapshot.
+ *
+ * @param columnNames Every column the relation emits. Consulted only on the snapshot path, and only
+ * to detect a column named `rowid` that would shadow the snapshot's own, so it must be the
+ * relation's full column list rather than whichever subset a caller means to display.
+ */
+export function createDuckDBReadPlan(
+	client: IDuckDBQueryClient,
+	tableRef: string,
+	kind: 'table' | 'view',
+	columnNames: readonly string[],
+): IDuckDBReadPlan {
+	return kind === 'table'
+		? new DirectRead(tableRef)
+		: new SnapshotRead(client, tableRef, columnNames);
+}
+
+/** Reads a relation in place, relying on DuckDB to return a scan in insertion order. */
+class DirectRead implements IDuckDBReadPlan {
+	readonly rowOrder = 'rowid';
+
+	constructor(private readonly _tableRef: string) { }
+
+	async relation(): Promise<string> {
+		return this._tableRef;
+	}
+
+	async dispose(): Promise<void> {
+		// Nothing was created, so nothing to release.
+	}
+}
+
+/**
+ * Distinguishes the snapshots of concurrently open views within one worker's `temp` catalog.
+ *
+ * One worker serves every connection that a given extension opens to the same file, and all of
+ * those views are created through this module, so the counter covers them. A second extension
+ * bundles its own copy of this package and gets its own worker process, hence its own `temp`
+ * catalog, so its numbering cannot reach this one. And because the CREATE below is not
+ * `IF NOT EXISTS`, a name that did somehow repeat would fail loudly rather than let two views
+ * quietly read each other's rows.
+ */
+let snapshotCount = 0;
+
+/** Names a snapshot's own ordering column, for a view that emits a column named `rowid`. */
+const SNAPSHOT_ORDER_COLUMN = '__positron_row_order';
+
+/**
+ * Reads a relation through a TEMP table holding a point-in-time copy of its rows.
+ *
+ * A snapshot turns a relation with no inherent order into one with a scan order, and it stops the
+ * relation being recomputed per page. For a view over a join that makes paging cheaper than reading
+ * the view directly, because the join runs once rather than once per page: a measured 500,000-row
+ * join view swept in 392 ms through a snapshot against 840 ms directly, after a 6 ms build.
+ *
+ * The copy lives in the `temp` catalog, which is private to this connection, so it cannot collide
+ * with the user's own objects. It is created even when the database was opened read-only, because
+ * `temp` is a separate catalog that stays writable.
+ */
+class SnapshotRead implements IDuckDBReadPlan {
+	readonly rowOrder: string;
+
+	/** Unqualified, for CREATE, which does not accept a catalog-qualified name. */
+	private readonly _quotedName: string;
+	/** Catalog-qualified, so a same-named table in `main` cannot be read by mistake. */
+	private readonly _qualifiedName: string;
+	/** The snapshot's select list, which numbers rows explicitly only when it has to. */
+	private readonly _selectList: string;
+
+	private _materialized: Promise<string> | undefined;
+	private _disposed = false;
+	private readonly _crashSubscription: { dispose(): void } | undefined;
+
+	constructor(
+		private readonly _client: IDuckDBQueryClient,
+		private readonly _viewRef: string,
+		sourceColumns: readonly string[],
+	) {
+		this._quotedName = quoteIdentifier(`positron_snapshot_${++snapshotCount}`);
+		this._qualifiedName = `temp.${this._quotedName}`;
+
+		// `SELECT *` copies the view's columns verbatim, so a view that emits a column named `rowid`
+		// shadows the snapshot's own rowid, and ordering by that name silently reads the copied column
+		// instead: measured against DuckDB 1.5.5, the snapshot of a join view that emits `rowid` read
+		// 0, 0, 1, 2, 2 under that name, three distinct values across five rows. Unlike SQLite, DuckDB
+		// has no second spelling of the rowid to fall back on, so the rows are numbered in a column of
+		// our own. That column is unindexed, so each page pays a sort to apply it -- worth accepting for
+		// a shape this rare, and paid only by the views that hit it. Reads
+		// never see the column: every one of them projects an explicit column list from the schema, and
+		// the export path's `SELECT *` is confined to a subquery the outer projection filters.
+		const shadowed = sourceColumns.some(name => name.toLowerCase() === 'rowid');
+		if (shadowed) {
+			const ordinal = quoteIdentifier(SNAPSHOT_ORDER_COLUMN);
+			this.rowOrder = ordinal;
+			this._selectList = `ROW_NUMBER() OVER () AS ${ordinal}, *`;
+		} else {
+			this.rowOrder = 'rowid';
+			this._selectList = '*';
+		}
+
+		// A replacement worker starts with an empty `temp` catalog, so the snapshot is gone even
+		// though this object still holds a resolved promise for it. Forget it, so the next read
+		// rebuilds instead of failing until the user reopens the tab.
+		this._crashSubscription = this._client.onDidCrash?.(() => {
+			this._materialized = undefined;
+		});
+	}
+
+	relation(): Promise<string> {
+		// A read can outlive the view that issued it -- closing a tab mid column-profile disposes this
+		// plan while that profile is still awaiting its turn on the worker. Materializing again here
+		// would create a snapshot that nothing is left to drop, so it stays for the life of the
+		// connection.
+		if (this._disposed) {
+			return Promise.reject(new Error('Cannot read through a disposed DuckDB read plan'));
+		}
+		return this._materialized ??= this._materialize();
+	}
+
+	private async _materialize(): Promise<string> {
+		try {
+			await this._client.runQuery(
+				`CREATE TEMP TABLE ${this._quotedName} AS ` +
+				`SELECT ${this._selectList} FROM ${this._viewRef}`);
+			return this._qualifiedName;
+		} catch (error) {
+			// Clear the memo so a later read retries, rather than leaving the tab permanently broken
+			// by one transient failure.
+			this._materialized = undefined;
+			throw error;
+		}
+	}
+
+	async dispose(): Promise<void> {
+		this._disposed = true;
+		this._crashSubscription?.dispose();
+		const materialized = this._materialized;
+		this._materialized = undefined;
+		if (materialized === undefined) {
+			return;
+		}
+		try {
+			await materialized;
+			await this._client.runQuery(`DROP TABLE IF EXISTS ${this._qualifiedName}`);
+		} catch {
+			// The snapshot goes away with the connection's `temp` catalog in any case, so a failure
+			// here (a dead worker, a snapshot that never finished materializing) leaks nothing.
+		}
+	}
+}

--- a/extensions/positron-data-explorer-duckdb/src/duckdbReadPlan.ts
+++ b/extensions/positron-data-explorer-duckdb/src/duckdbReadPlan.ts
@@ -122,6 +122,23 @@ const SNAPSHOT_ORDER_COLUMN = '__positron_row_order';
  * the view directly, because the join runs once rather than once per page: a measured 500,000-row
  * join view swept in 392 ms through a snapshot against 840 ms directly, after a 6 ms build.
  *
+ * What that costs, stated plainly, because the numbers above are one view's and bound nothing:
+ *
+ * - It is built when the tab opens, not on first scroll. `DuckDBTableView`'s constructor asks for a
+ *   row count, the count reads through this plan, so the copy is made before the first row renders.
+ *   Deferring it would only relocate the cost, since the grid fetches its first page as soon as it
+ *   has the count.
+ * - It holds the relation's full result for the life of the tab, with no row cap. A snapshot of a
+ *   2M-row relation with a 200-byte payload measured 437 MiB.
+ * - What it adds is holding the rows, not producing them. The row count runs `count(*)` over the
+ *   relation, so a view's joins and aggregates were already being computed at open before any
+ *   snapshot existed.
+ *
+ * Uncapped is deliberate. Past any cap the only options are paging the relation unstably, which is
+ * the defect this class exists to prevent, or refusing to open it. Under real memory pressure DuckDB
+ * spills to `temp_directory`, which defaults to `.tmp` even for an in-memory database, so the
+ * failure mode is disk use rather than exhaustion.
+ *
  * The copy lives in the `temp` catalog, which is private to this connection, so it cannot collide
  * with the user's own objects. It is created even when the database was opened read-only, because
  * `temp` is a separate catalog that stays writable.

--- a/extensions/positron-data-explorer-duckdb/src/duckdbSql.ts
+++ b/extensions/positron-data-explorer-duckdb/src/duckdbSql.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/** Quotes and escapes an identifier for DuckDB by doubling embedded double-quotes. */
+export function quoteIdentifier(name: string): string {
+	return '"' + name.replace(/"/g, '""') + '"';
+}
+
+/** Escapes a value for use inside a single-quoted DuckDB string literal. */
+export function quoteLiteral(value: string): string {
+	return value.replace(/'/g, '\'\'');
+}

--- a/extensions/positron-data-explorer-duckdb/src/duckdbTableView.ts
+++ b/extensions/positron-data-explorer-duckdb/src/duckdbTableView.ts
@@ -7,6 +7,8 @@
 // only the dialect-specific parts differ (display-type mapping, schema-qualified table reference,
 // regexp_matches for regex filters, boolean literals, FLOOR cast for histogram bins).
 
+import { IDuckDBReadPlan } from './duckdbReadPlan.js';
+import { quoteIdentifier, quoteLiteral } from './duckdbSql.js';
 import { IDuckDBQueryClient } from './duckdbWorkerClient.js';
 import {
 	ArraySelection,
@@ -137,16 +139,6 @@ export function duckdbDisplayType(dataType: string): ColumnDisplayType {
 	return ColumnDisplayType.String;
 }
 
-/** Quotes and escapes an identifier for DuckDB by doubling embedded double-quotes. */
-function quoteIdentifier(name: string): string {
-	return '"' + name.replace(/"/g, '""') + '"';
-}
-
-/** Escapes a value for use inside a single-quoted DuckDB string literal. */
-function quoteLiteral(value: string): string {
-	return value.replace(/'/g, '\'\'');
-}
-
 const COMPARISON_OPS = new Map<FilterComparisonOp, string>([
 	[FilterComparisonOp.Eq, '='],
 	[FilterComparisonOp.NotEq, '<>'],
@@ -239,6 +231,12 @@ export class DuckDBTableView {
 	private rowFilters: Array<RowFilter> = [];
 
 	private _whereClause: string = '';
+
+	/**
+	 * The ORDER BY for data and export queries. Empty until the user sorts, and deliberately so:
+	 * DuckDB returns a scan of the relation in insertion order on its own, and the relations that
+	 * cannot promise that are read through a snapshot that can. See {@link _buildSortClause}.
+	 */
 	private _sortClause: string = '';
 
 	private _unfilteredRows: Promise<number>;
@@ -248,7 +246,7 @@ export class DuckDBTableView {
 	 * @param client The query client for the owning connection.
 	 * @param tableRef The schema-qualified, already-quoted table reference (e.g. `"main"."t"`).
 	 * @param displayName The unqualified table/view name for display.
-	 * @param objectKind Whether this is a table (has a stable rowid) or a view.
+	 * @param readPlan How this relation is read so that its LIMIT/OFFSET paging is stable.
 	 * @param schema The resolved column schema.
 	 * @param codeGenerator Optional Convert-to-Code override; when omitted, Convert-to-Code emits
 	 * DuckDB SQL over the table reference.
@@ -257,7 +255,7 @@ export class DuckDBTableView {
 		private readonly client: IDuckDBQueryClient,
 		private readonly tableRef: string,
 		private readonly displayName: string,
-		private readonly objectKind: 'table' | 'view',
+		private readonly readPlan: IDuckDBReadPlan,
 		private readonly schema: Array<DuckDBSchemaEntry>,
 		private readonly codeGenerator?: IDuckDBTableCodeGenerator,
 	) {
@@ -265,13 +263,28 @@ export class DuckDBTableView {
 		this._filteredRows = this._unfilteredRows;
 	}
 
-	/** The (schema-qualified, quoted) table reference for use in FROM clauses. */
+	/**
+	 * The quoted relation that reads should target. This is the snapshot rather than the original
+	 * relation whenever the read plan uses one, so the row count, the displayed rows, the exports,
+	 * and the column profiles all describe the same set of rows.
+	 */
+	private _relation(): Promise<string> {
+		return this.readPlan.relation();
+	}
+
+	/** The user's own relation, for generated code that has to name what they opened. */
 	private get _quotedTable(): string {
 		return this.tableRef;
 	}
 
+	/** Releases the read plan's resources; call when the dataset's view is dropped. */
+	async dispose(): Promise<void> {
+		await this.readPlan.dispose();
+	}
+
 	private async _countRows(whereClause: string): Promise<number> {
-		const rows = await this.client.runQuery(`SELECT count(*) AS n FROM ${this._quotedTable}${whereClause}`);
+		const rows = await this.client.runQuery(
+			`SELECT count(*) AS n FROM ${await this._relation()}${whereClause}`);
 		return Number(rows[0]?.n ?? 0);
 	}
 
@@ -366,7 +379,7 @@ export class DuckDBTableView {
 		// Select each requested column under a positional alias so duplicates are unambiguous.
 		const selectors = params.columns.map((column, i) =>
 			`${quoteIdentifier(this.schema[column.column_index].column_name)} AS c${i}`);
-		const query = `SELECT ${selectors.join(', ')} FROM ${this._quotedTable}` +
+		const query = `SELECT ${selectors.join(', ')} FROM ${await this._relation()}` +
 			`${this._whereClause}${this._orderClause()} LIMIT ${numRows} OFFSET ${lowerLimit}`;
 		const rows = await this.client.runQuery(query);
 
@@ -449,16 +462,26 @@ export class DuckDBTableView {
 	}
 
 	/**
-	 * Builds an ORDER BY clause for the given sort keys. For tables a trailing `rowid` is appended
-	 * as a stable tiebreaker so pagination is deterministic; views have no rowid, so they omit it.
+	 * Builds an ORDER BY clause for the given sort keys, appending the read plan's row order as a
+	 * tiebreaker so that sorting cannot leave tied rows free to move between pages.
+	 *
+	 * With no sort keys this deliberately emits no ORDER BY at all. DuckDB already returns a scan in
+	 * insertion order, and it cannot tell that `rowid` order is that same order, so stating the
+	 * tiebreaker anyway would sort the whole relation on every page to reproduce an order it was
+	 * going to give for free -- measured at 7.4x over a 2M-row paged sweep, and 14x at a deep
+	 * offset. Relations that have no such order are read through a snapshot that does; see
+	 * {@link IDuckDBReadPlan}.
+	 *
+	 * @param includeTiebreaker False only for generated code, which should show the user their own
+	 * sort rather than an internal ordering column.
 	 */
-	private _buildSortClause(sortKeys: Array<ColumnSortKey>, includeRowidTiebreaker: boolean): string {
+	private _buildSortClause(sortKeys: Array<ColumnSortKey>, includeTiebreaker: boolean): string {
 		const exprs = sortKeys.map(key => {
 			const quotedName = quoteIdentifier(this.schema[key.column_index].column_name);
 			return `${quotedName}${key.ascending ? '' : ' DESC'}`;
 		});
-		if (includeRowidTiebreaker && this.objectKind === 'table') {
-			exprs.push('rowid');
+		if (includeTiebreaker && exprs.length > 0) {
+			exprs.push(this.readPlan.rowOrder);
 		}
 		return exprs.length > 0 ? `\nORDER BY ${exprs.join(', ')}` : '';
 	}
@@ -559,6 +582,7 @@ export class DuckDBTableView {
 	async exportDataSelection(params: ExportDataSelectionParams): Promise<ExportedData> {
 		const kind = params.selection.kind;
 		const order = this._orderClause();
+		const relation = await this._relation();
 
 		const runExport = async (query: string, columns: Array<DuckDBSchemaEntry>): Promise<ExportedData> => {
 			const rows = await this.client.runQuery(query);
@@ -576,7 +600,7 @@ export class DuckDBTableView {
 			case TableSelectionKind.SingleCell: {
 				const sel = params.selection.selection as DataSelectionSingleCell;
 				const column = this.schema[sel.column_index];
-				const query = `SELECT ${quoteIdentifier(column.column_name)} AS c0 FROM ${this._quotedTable}` +
+				const query = `SELECT ${quoteIdentifier(column.column_name)} AS c0 FROM ${relation}` +
 					`${this._whereClause}${order} LIMIT 1 OFFSET ${sel.row_index}`;
 				const rows = await this.client.runQuery(query);
 				return { data: stringifyExportCell(rows[0]?.c0), format: params.format };
@@ -584,37 +608,37 @@ export class DuckDBTableView {
 			case TableSelectionKind.CellRange: {
 				const sel = params.selection.selection as DataSelectionCellRange;
 				const columns = this.schema.slice(sel.first_column_index, sel.last_column_index + 1);
-				const query = `SELECT ${selectorsFor(columns)} FROM ${this._quotedTable}` +
+				const query = `SELECT ${selectorsFor(columns)} FROM ${relation}` +
 					`${this._whereClause}${order} LIMIT ${sel.last_row_index - sel.first_row_index + 1} OFFSET ${sel.first_row_index}`;
 				return runExport(query, columns);
 			}
 			case TableSelectionKind.RowRange: {
 				const sel = params.selection.selection as DataSelectionRange;
-				const query = `SELECT ${selectorsFor(this.schema)} FROM ${this._quotedTable}` +
+				const query = `SELECT ${selectorsFor(this.schema)} FROM ${relation}` +
 					`${this._whereClause}${order} LIMIT ${sel.last_index - sel.first_index + 1} OFFSET ${sel.first_index}`;
 				return runExport(query, this.schema);
 			}
 			case TableSelectionKind.ColumnRange: {
 				const sel = params.selection.selection as DataSelectionRange;
 				const columns = this.schema.slice(sel.first_index, sel.last_index + 1);
-				const query = `SELECT ${selectorsFor(columns)} FROM ${this._quotedTable}${this._whereClause}${order}`;
+				const query = `SELECT ${selectorsFor(columns)} FROM ${relation}${this._whereClause}${order}`;
 				return runExport(query, columns);
 			}
 			case TableSelectionKind.ColumnIndices: {
 				const sel = params.selection.selection as DataSelectionIndices;
 				const columns = sel.indices.map(i => this.schema[i]);
-				const query = `SELECT ${selectorsFor(columns)} FROM ${this._quotedTable}${this._whereClause}${order}`;
+				const query = `SELECT ${selectorsFor(columns)} FROM ${relation}${this._whereClause}${order}`;
 				return runExport(query, columns);
 			}
 			case TableSelectionKind.RowIndices: {
 				const sel = params.selection.selection as DataSelectionIndices;
-				const query = this._rowIndexQuery(selectorsFor(this.schema), sel.indices);
+				const query = this._rowIndexQuery(relation, selectorsFor(this.schema), sel.indices);
 				return runExport(query, this.schema);
 			}
 			case TableSelectionKind.CellIndices: {
 				const sel = params.selection.selection as DataSelectionCellIndices;
 				const columns = sel.column_indices.map(i => this.schema[i]);
-				const query = this._rowIndexQuery(selectorsFor(columns), sel.row_indices);
+				const query = this._rowIndexQuery(relation, selectorsFor(columns), sel.row_indices);
 				return runExport(query, columns);
 			}
 		}
@@ -622,13 +646,20 @@ export class DuckDBTableView {
 
 	/**
 	 * Builds a query that selects specific (post-sort, post-filter) row positions in the requested
-	 * order. Uses a ROW_NUMBER() window so it works for both tables and views without relying on
-	 * rowid, mirroring the requested-row ordering.
+	 * order, using a ROW_NUMBER() window to number the rows.
+	 *
+	 * The window has to be ordered the same way the pages were, or the positions the frontend asks
+	 * for refer to rows the user never saw there -- and this path writes a file the user keeps. It
+	 * cannot be left unordered the way a paging query can: a window operator does not inherit the
+	 * scan's insertion order, and numbering rows with a constant ORDER BY disagreed with the
+	 * displayed order on all 171,429 rows of a measured relation.
 	 */
-	private _rowIndexQuery(selectors: string, rowIndices: number[]): string {
-		const ordering = this._sortClause ? this._sortClause.replace(/^\n/, '') : 'ORDER BY (SELECT 1)';
+	private _rowIndexQuery(relation: string, selectors: string, rowIndices: number[]): string {
+		const ordering = this._sortClause
+			? this._sortClause.replace(/^\n/, '')
+			: `ORDER BY ${this.readPlan.rowOrder}`;
 		const numbered = `SELECT *, ROW_NUMBER() OVER (${ordering}) - 1 AS __row_index ` +
-			`FROM ${this._quotedTable}${this._whereClause}`;
+			`FROM ${relation}${this._whereClause}`;
 		const order = rowIndices.map((rowIdx, i) => `WHEN ${rowIdx} THEN ${i}`).join(' ');
 		const inList = rowIndices.join(', ');
 		return `SELECT ${selectors} FROM (${numbered}) WHERE __row_index IN (${inList}) ` +
@@ -686,7 +717,7 @@ export class DuckDBTableView {
 
 	private async _nullCount(quotedName: string): Promise<number> {
 		const rows = await this.client.runQuery(
-			`SELECT count(*) - count(${quotedName}) AS n FROM ${this._quotedTable}${this._whereClause}`);
+			`SELECT count(*) - count(${quotedName}) AS n FROM ${await this._relation()}${this._whereClause}`);
 		return Number(rows[0]?.n ?? 0);
 	}
 
@@ -700,12 +731,13 @@ export class DuckDBTableView {
 		formatOptions: FormatOptions,
 	): Promise<ColumnSummaryStats> {
 		const display = entry.type_display;
+		const relation = await this._relation();
 		if (display === ColumnDisplayType.Integer || display === ColumnDisplayType.Floating || display === ColumnDisplayType.Decimal) {
 			// One pass for the moment-based stats; a second query for the median.
 			const rows = await this.client.runQuery(
 				`SELECT count(${quotedName}) AS n, min(${quotedName}) AS lo, max(${quotedName}) AS hi, ` +
 				`sum(${quotedName} * 1.0) AS s, sum(${quotedName} * 1.0 * ${quotedName}) AS ss ` +
-				`FROM ${this._quotedTable}${this._whereClause}`);
+				`FROM ${relation}${this._whereClause}`);
 			const n = Number(rows[0]?.n ?? 0);
 			const sum = Number(rows[0]?.s ?? 0);
 			const sumsq = Number(rows[0]?.ss ?? 0);
@@ -729,7 +761,7 @@ export class DuckDBTableView {
 			const rows = await this.client.runQuery(
 				`SELECT count(DISTINCT ${quotedName}) AS nunique, ` +
 				`count(CASE WHEN ${quotedName} = '' THEN 1 END) AS nempty ` +
-				`FROM ${this._quotedTable}${this._whereClause}`);
+				`FROM ${relation}${this._whereClause}`);
 			return {
 				type_display: ColumnDisplayType.String,
 				string_stats: { num_unique: Number(rows[0]?.nunique ?? 0), num_empty: Number(rows[0]?.nempty ?? 0) },
@@ -740,7 +772,7 @@ export class DuckDBTableView {
 			const rows = await this.client.runQuery(
 				`SELECT count(CASE WHEN ${quotedName} THEN 1 END) AS ntrue, ` +
 				`count(CASE WHEN NOT ${quotedName} THEN 1 END) AS nfalse ` +
-				`FROM ${this._quotedTable}${this._whereClause}`);
+				`FROM ${relation}${this._whereClause}`);
 			return {
 				type_display: ColumnDisplayType.Boolean,
 				boolean_stats: { true_count: Number(rows[0]?.ntrue ?? 0), false_count: Number(rows[0]?.nfalse ?? 0) },
@@ -749,7 +781,7 @@ export class DuckDBTableView {
 		if (display === ColumnDisplayType.Date || display === ColumnDisplayType.Datetime) {
 			const rows = await this.client.runQuery(
 				`SELECT min(${quotedName}) AS lo, max(${quotedName}) AS hi, count(DISTINCT ${quotedName}) AS nunique ` +
-				`FROM ${this._quotedTable}${this._whereClause}`);
+				`FROM ${relation}${this._whereClause}`);
 			const stats = {
 				num_unique: Number(rows[0]?.nunique ?? 0),
 				min_date: rows[0]?.lo === null || rows[0]?.lo === undefined ? undefined : String(rows[0].lo),
@@ -760,7 +792,7 @@ export class DuckDBTableView {
 				: { type_display: display, datetime_stats: stats };
 		}
 		const rows = await this.client.runQuery(
-			`SELECT count(DISTINCT ${quotedName}) AS nunique FROM ${this._quotedTable}${this._whereClause}`);
+			`SELECT count(DISTINCT ${quotedName}) AS nunique FROM ${relation}${this._whereClause}`);
 		return { type_display: display, other_stats: { num_unique: Number(rows[0]?.nunique ?? 0) } };
 	}
 
@@ -793,7 +825,7 @@ export class DuckDBTableView {
 		}
 		const offset = Math.min(n - 1, Math.max(0, Math.floor(q * (n - 1))));
 		const rows = await this.client.runQuery(
-			`SELECT ${quotedName} AS v FROM ${this._quotedTable}${this._wherePlus(`${quotedName} IS NOT NULL`)} ` +
+			`SELECT ${quotedName} AS v FROM ${await this._relation()}${this._wherePlus(`${quotedName} IS NOT NULL`)} ` +
 			`ORDER BY ${quotedName} LIMIT 1 OFFSET ${offset}`);
 		const value = rows[0]?.v;
 		return value === null || value === undefined ? undefined : Number(value);
@@ -801,7 +833,7 @@ export class DuckDBTableView {
 
 	private async _frequencyTable(quotedName: string, limit: number, filteredRows: number): Promise<ColumnFrequencyTable> {
 		const rows = await this.client.runQuery(
-			`SELECT ${quotedName} AS value, count(*) AS freq FROM ${this._quotedTable}` +
+			`SELECT ${quotedName} AS value, count(*) AS freq FROM ${await this._relation()}` +
 			`${this._wherePlus(`${quotedName} IS NOT NULL`)} GROUP BY ${quotedName} ` +
 			`ORDER BY freq DESC, value ASC LIMIT ${limit}`);
 		const values: ColumnValue[] = [];
@@ -830,7 +862,7 @@ export class DuckDBTableView {
 		}
 
 		const rows = await this.client.runQuery(
-			`SELECT min(${quotedName}) AS lo, max(${quotedName}) AS hi FROM ${this._quotedTable}${this._whereClause}`);
+			`SELECT min(${quotedName}) AS lo, max(${quotedName}) AS hi FROM ${await this._relation()}${this._whereClause}`);
 		const minValue = Number(rows[0]?.lo);
 		const maxValue = Number(rows[0]?.hi);
 		const peakToPeak = maxValue - minValue;
@@ -876,7 +908,7 @@ export class DuckDBTableView {
 
 		const binRows = await this.client.runQuery(
 			`SELECT CAST(FLOOR((${quotedName} * 1.0 - ${minValue}) / ${binWidth}) AS INTEGER) AS bin_id, count(*) AS bin_count ` +
-			`FROM ${this._quotedTable}${this._wherePlus(`${quotedName} IS NOT NULL`)} GROUP BY bin_id`);
+			`FROM ${await this._relation()}${this._wherePlus(`${quotedName} IS NOT NULL`)} GROUP BY bin_id`);
 		const histEntries = new Map<number, number>(
 			binRows.map(row => [Number(row.bin_id), Number(row.bin_count)]));
 

--- a/extensions/positron-data-explorer-duckdb/src/duckdbWorker.ts
+++ b/extensions/positron-data-explorer-duckdb/src/duckdbWorker.ts
@@ -35,7 +35,19 @@ let initError: Error | undefined;
 // crashing, so the host can surface a clean error from connect().
 const ready: Promise<void> = (async () => {
 	try {
-		const options = config.readOnly ? { access_mode: 'READ_ONLY' } : undefined;
+		const options: Record<string, string> = {
+			// The Data Explorer pages with a fresh LIMIT/OFFSET statement per page and states no
+			// ORDER BY unless the user sorts, so its correctness rests on DuckDB returning a relation
+			// in the same order every time. That is exactly what preserve_insertion_order buys, and
+			// it is DuckDB's default -- but leaving it implicit means a future default change, or a
+			// stray SET, would silently start duplicating and dropping rows as the user scrolls.
+			// Measured with it off: a 2,000-page sweep of a 2M-row table repeated 751,752 rows and
+			// missed 751,752 others. Stating it here makes the dependency explicit and pins it.
+			preserve_insertion_order: 'true',
+		};
+		if (config.readOnly) {
+			options.access_mode = 'READ_ONLY';
+		}
 		const instance = await DuckDBInstance.create(config.databasePath, options);
 		connection = await instance.connect();
 	} catch (error) {

--- a/extensions/positron-data-explorer-duckdb/src/duckdbWorkerClient.ts
+++ b/extensions/positron-data-explorer-duckdb/src/duckdbWorkerClient.ts
@@ -24,6 +24,13 @@ export type DuckDBRow = Record<string, unknown>;
 export interface IDuckDBQueryClient {
 	/** Run a SQL query with optional named ($name) parameters and return its rows. */
 	runQuery(sql: string, params?: Record<string, string>): Promise<DuckDBRow[]>;
+
+	/**
+	 * Fires when the worker dies and is replaced. A replacement worker starts with an empty `temp`
+	 * schema, so anything cached there -- see `IDuckDBReadPlan` -- has to be rebuilt. Optional, so a
+	 * fake that only answers queries still satisfies this interface.
+	 */
+	readonly onDidCrash?: vscode.Event<void>;
 }
 
 /**

--- a/extensions/positron-data-explorer-duckdb/src/index.ts
+++ b/extensions/positron-data-explorer-duckdb/src/index.ts
@@ -9,6 +9,7 @@
 // the consumer's esbuild into its own dist so the runtime __dirname lookup resolves).
 
 export { DuckDBTableView, DuckDBSchemaEntry, IDuckDBTableCodeGenerator, duckdbDisplayType, makeWhereExpr } from './duckdbTableView.js';
+export { IDuckDBReadPlan, createDuckDBReadPlan } from './duckdbReadPlan.js';
 export { DuckDBDataExplorerRpcHandler, IDuckDBDataExplorerHost, OpenTableViewOptions, buildDuckDBSchema } from './duckdbDataExplorerRpcHandler.js';
 export { DuckDBWorkerClient, IDuckDBQueryClient, DuckDBRow } from './duckdbWorkerClient.js';
 export { DuckDBWorkerPool, duckDBWorkerPool, IDuckDBWorkerLease } from './duckdbWorkerPool.js';


### PR DESCRIPTION
Related to #15361, which audited the cloud data drivers and explicitly left the file-based ones for later: "The file-based drivers (DuckDB, SQLite) were not audited here; both underlying engines do expose a rowid, so they may already be safe." They were not safe. This PR audits and fixes SQLite and DuckDB. The cloud drivers (PostgreSQL views, Redshift, Snowflake, Databricks) are untouched, so #15361 stays open.

### Summary

The Data Explorer fetches each page with a separate `SELECT ... LIMIT/OFFSET` statement. Neither engine promises that two such statements see the relation in the same order, so the pages stop partitioning it: some rows come back on two pages and others never arrive. The grid's total comes from a separate `count(*)`, so it stays correct and hides the damage. `exportDataSelection` builds on the same path, so an exported CSV can repeat or omit a row -- the more serious half, since the user keeps the file and has no way to notice.

Measured before the fix:

- **SQLite**, paged sweep of a filtered 250,000-row table while another connection created an index partway through: 60,000 rows dropped and 60,000 repeated, as the plan flipped from `SCAN t` to `SEARCH t USING COVERING INDEX`.
- **DuckDB**, paged sweep of a 500,000-row join view: 170,032 rows repeated and 170,032 missed.
- **DuckDB**, index-based export of a 171,429-row relation: disagreed with the displayed order on every row.

Every read now goes through a *read plan* that pins down a total order, chosen per relation:

| Relation | How it is read |
|---|---|
| SQLite ordinary table | In place, ordered by rowid. Free: that is SQLite's own storage order, so the query plan is identical with and without the clause. |
| SQLite `WITHOUT ROWID` table | In place, ordered by the primary key, a clustered index whose columns SQLite implicitly marks `NOT NULL`. |
| DuckDB base table | In place, with no `ORDER BY`. `preserve_insertion_order` already guarantees a scan's order, and stating it would force a sort per page. |
| Views, both engines | Through a `TEMP` table snapshot, which supplies the row identity they lack. |

The snapshot is also *faster* than reading a view directly, because the view's own query runs once instead of once per page: a 500,000-row join view swept in 392 ms through a snapshot against 840 ms directly, after a 6 ms build.

### Notes for review

Three decisions that look arbitrary but are not:

- **Why not `ORDER BY <first sortable column>`.** It is not a unique key, so ties still break arbitrarily between statements. That converts a reproducible bug into a rare, hard-to-diagnose one -- the same reasoning as #15361's "why the obvious fix is not enough."
- **Why DuckDB tables state no `ORDER BY` while SQLite tables do.** DuckDB cannot tell that rowid order already *is* scan order, so stating it sorts the whole relation on every page; SQLite's rowid order is free. Same guarantee, opposite syntax.
- **Why the two extensions get parallel modules instead of one shared one.** Different extensions, different engines, and genuinely different rowid semantics: SQLite has three interchangeable spellings of the rowid and DuckDB has none, which is exactly what the shadowing handling below turns on.

Detecting row identity has sharp edges, each covered by a test:

- No pragma reports whether a table is `WITHOUT ROWID`, and the stored `CREATE` statement cannot be trusted -- `note TEXT DEFAULT 'migrated without rowid'` describes an ordinary table -- so it is probed with a `LIMIT 0` bind-time check that reads no rows.
- A relation can declare or emit its own column named `rowid`, which *shadows* the real one. Verified: `CREATE TABLE t(rowid TEXT, v INTEGER)` answers `SELECT rowid` with `'a','a','a'`. A snapshot of a join view emitting `rowid` reads `1,1,2,3,3` under that name and `1,2,3,4,5` under `_rowid_` on SQLite, and `0,0,1,2,2` on DuckDB. SQLite prefers the next unshadowed alias; DuckDB, which has none, numbers the rows in a column of its own.
- A probe failure that is not "no such column" (dead worker, disposed connection) is raised rather than misread as `WITHOUT ROWID`, which would otherwise page an ordinary table by a possibly-nullable primary key.
- A snapshot is dropped on dispose, rebuilt if the worker is replaced, retried if materialization fails, and refuses reads after dispose so a queued column profile cannot leak a temp table that nothing is left to drop.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed the Data Explorer repeating or dropping rows when scrolling or exporting unsorted SQLite and DuckDB tables and views (#15361)

### Validation Steps

@:data-explorer @:duck-db @:connections

Automated coverage: 65 SQLite and 45 DuckDB extension tests pass, including real-engine integration sweeps that page whole relations and assert every row is seen exactly once, and an export test asserting the exported rows are the rows the grid displayed at those positions.

Manual check:

1. Open a `.sqlite` or `.duckdb` file with a large table (100k+ rows) from the Explorer.
2. Without sorting, scroll the grid from top to bottom and back. No row should repeat or disappear.
3. Create a view over a join, open it, and scroll it the same way.
4. Select a discontiguous set of rows, copy to the clipboard, and confirm the exported rows match what the grid showed at those positions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
