### PR TITLE
Escape on a confirmation dialog leaves its caller hanging

### DIFF
--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/includeSecretsConfirmation.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/includeSecretsConfirmation.tsx
@@ -18,9 +18,6 @@ const INCLUDE_SECRETS_CONFIRMATION_WIDTH = 460;
  * @returns A promise that resolves to true if the user confirmed, or false if they cancelled.
  */
 export const showIncludeSecretsConfirmation = (): Promise<boolean> => {
-	// Create the renderer.
-	const renderer = new PositronModalDialogReactRenderer();
-
 	return new Promise<boolean>(resolve => {
 		// Settle once: dispose the renderer and resolve with the user's choice. Guards against the
 		// dialog's onCancel firing again after an explicit OK or Cancel.
@@ -33,6 +30,12 @@ export const showIncludeSecretsConfirmation = (): Promise<boolean> => {
 			renderer.dispose();
 			resolve(confirmed);
 		};
+
+		// Escape closes the native <dialog> without going through onCancel, so settle from
+		// onDisposed too or the caller waits forever.
+		const renderer = new PositronModalDialogReactRenderer({
+			onDisposed: () => settle(false)
+		});
 
 		// Render the dialog.
 		renderer.render(

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/removeDataConnectionConfirmation.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/removeDataConnectionConfirmation.tsx
@@ -28,9 +28,6 @@ export const showRemoveDataConnectionConfirmation = (
 	connectionName: string,
 	openDataExplorerCount: number
 ): Promise<boolean> => {
-	// Create the renderer.
-	const renderer = new PositronModalDialogReactRenderer();
-
 	return new Promise<boolean>(resolve => {
 		// Settle once: dispose the renderer and resolve with the user's choice. Guards against the
 		// dialog's onCancel firing again after an explicit Remove or Cancel.
@@ -43,6 +40,12 @@ export const showRemoveDataConnectionConfirmation = (
 			renderer.dispose();
 			resolve(confirmed);
 		};
+
+		// Escape closes the native <dialog> without going through onCancel, so settle from
+		// onDisposed too or the caller waits forever.
+		const renderer = new PositronModalDialogReactRenderer({
+			onDisposed: () => settle(false)
+		});
 
 		// Render the dialog.
 		renderer.render(

--- a/src/vs/workbench/contrib/positronDataConnections/test/browser/includeSecretsConfirmation.vitest.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/test/browser/includeSecretsConfirmation.vitest.tsx
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { PositronReactServices } from '../../../../../base/browser/positronReactServices.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
+import { showIncludeSecretsConfirmation } from '../../browser/dialogs/includeSecretsConfirmation.js';
+
+describe('showIncludeSecretsConfirmation', () => {
+	const ctx = createTestContainer().withReactServices().build();
+
+	// The dialog renders itself through its own PositronModalDialogReactRenderer rather than being
+	// handed to rtl.render, so this only establishes the services context it renders into.
+	setupRTLRenderer(() => ctx.reactServices);
+
+	beforeEach(() => {
+		// PositronModalDialogReactRenderer reads the services singleton in its constructor to find the
+		// container to render into, so the container's services have to be reachable from there.
+		PositronReactServices.services = ctx.reactServices;
+	});
+
+	it('warns that the secrets end up in the connection code', async () => {
+		const confirmation = showIncludeSecretsConfirmation();
+
+		expect(await screen.findByText(/written into the connection code/)).toBeInTheDocument();
+
+		await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+		expect(await confirmation).toBe(false);
+	});
+
+	it('resolves false when the dialog is dismissed without a choice, as Escape does', async () => {
+		const confirmation = showIncludeSecretsConfirmation();
+		expect(await screen.findByText(/written into the connection code/)).toBeInTheDocument();
+
+		// Escape closes the native <dialog>, which fires its close event and disposes the renderer
+		// without ever calling onCancel. jsdom does not wire Escape to that default action, so close
+		// the dialog directly, which is the same path.
+		// eslint-disable-next-line no-restricted-syntax
+		document.querySelector<HTMLDialogElement>('dialog.positron-modal-dialog')!.close();
+
+		expect(await confirmation).toBe(false);
+	});
+});

--- a/src/vs/workbench/contrib/positronDataConnections/test/browser/removeDataConnectionConfirmation.vitest.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/test/browser/removeDataConnectionConfirmation.vitest.tsx
@@ -76,6 +76,19 @@ describe('showRemoveDataConnectionConfirmation', () => {
 		expect(await confirmation).toBe(false);
 	});
 
+	it('resolves false when the dialog is dismissed without a choice, as Escape does', async () => {
+		const confirmation = showRemoveDataConnectionConfirmation('My Connection', 0);
+		expect(await screen.findByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+
+		// Escape closes the native <dialog>, which fires its close event and disposes the renderer
+		// without ever calling onCancel. jsdom does not wire Escape to that default action, so close
+		// the dialog directly, which is the same path.
+		// eslint-disable-next-line no-restricted-syntax
+		document.querySelector<HTMLDialogElement>('dialog.positron-modal-dialog')!.close();
+
+		expect(await confirmation).toBe(false);
+	});
+
 	it('warns about several open Data Explorers', async () => {
 		const confirmation = showRemoveDataConnectionConfirmation('My Connection', 3);
 

--- a/src/vs/workbench/contrib/positronMissingPackages/browser/missingPackagesInstallModal.tsx
+++ b/src/vs/workbench/contrib/positronMissingPackages/browser/missingPackagesInstallModal.tsx
@@ -66,7 +66,11 @@ const MissingPackagesInstallModal = (props: MissingPackagesInstallModalProps) =>
  */
 export function showMissingPackagesInstallModal(fileName: string, languageName: string | null, packageNames: string[], installLabel: string): Promise<boolean> {
 	return new Promise<boolean>(resolve => {
-		const renderer = new PositronModalDialogReactRenderer();
+		// Escape closes the native <dialog> without going through onCancel, so settle from
+		// onDisposed too or the caller waits forever. A settled promise ignores the second call.
+		const renderer = new PositronModalDialogReactRenderer({
+			onDisposed: () => resolve(false)
+		});
 		renderer.render(
 			<MissingPackagesInstallModal
 				fileName={fileName}

--- a/src/vs/workbench/contrib/positronMissingPackages/browser/missingPackagesPreflightModal.tsx
+++ b/src/vs/workbench/contrib/positronMissingPackages/browser/missingPackagesPreflightModal.tsx
@@ -91,7 +91,11 @@ export const MissingPackagesPreflightModal = (props: MissingPackagesPreflightMod
  */
 export function showMissingPackagesPreflightModal(fileName: string, languageName: string | null, packageNames: string[]): Promise<PreflightModalResult> {
 	return new Promise<PreflightModalResult>(resolve => {
-		const renderer = new PositronModalDialogReactRenderer();
+		// Escape closes the native <dialog> without going through onCancel, so settle from
+		// onDisposed too or the caller waits forever. A settled promise ignores the second call.
+		const renderer = new PositronModalDialogReactRenderer({
+			onDisposed: () => resolve({ decision: 'cancel', dontShowAgain: false })
+		});
 		renderer.render(
 			<MissingPackagesPreflightModal
 				fileName={fileName}

--- a/src/vs/workbench/contrib/positronMissingPackages/test/browser/missingPackagesEscape.vitest.tsx
+++ b/src/vs/workbench/contrib/positronMissingPackages/test/browser/missingPackagesEscape.vitest.tsx
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { screen } from '@testing-library/react';
+import { PositronReactServices } from '../../../../../base/browser/positronReactServices.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
+import { showMissingPackagesInstallModal } from '../../browser/missingPackagesInstallModal.js';
+import { showMissingPackagesPreflightModal } from '../../browser/missingPackagesPreflightModal.js';
+
+/**
+ * Dismisses the open modal the way Escape does. Escape closes the native <dialog>, which fires its
+ * close event and disposes the renderer without ever calling onCancel. jsdom does not wire Escape
+ * to that default action, so close the dialog directly, which is the same path.
+ */
+function dismissTheOpenDialog() {
+	// eslint-disable-next-line no-restricted-syntax
+	document.querySelector<HTMLDialogElement>('dialog.positron-modal-dialog')!.close();
+}
+
+describe('missing packages modals settle when dismissed with Escape', () => {
+	const ctx = createTestContainer().withReactServices().build();
+
+	// The modals render themselves through their own PositronModalDialogReactRenderer rather than
+	// being handed to rtl.render, so this only establishes the services context they render into.
+	setupRTLRenderer(() => ctx.reactServices);
+
+	beforeEach(() => {
+		// PositronModalDialogReactRenderer reads the services singleton in its constructor to find the
+		// container to render into, so the container's services have to be reachable from there.
+		PositronReactServices.services = ctx.reactServices;
+	});
+
+	it('the install modal resolves false', async () => {
+		const decision = showMissingPackagesInstallModal('a.py', 'Python', ['numpy'], 'Install');
+		expect(await screen.findByRole('button', { name: 'Install' })).toBeInTheDocument();
+
+		dismissTheOpenDialog();
+
+		expect(await decision).toBe(false);
+	});
+
+	it('the preflight modal resolves the same result as Cancel', async () => {
+		const decision = showMissingPackagesPreflightModal('a.py', 'Python', ['numpy']);
+		expect(await screen.findByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+
+		dismissTheOpenDialog();
+
+		expect(await decision).toEqual({ decision: 'cancel', dontShowAgain: false });
+	});
+});


### PR DESCRIPTION
Four dialogs hang their caller when you dismiss them with Escape.

Escape closes a native `<dialog>` through the browser's own default action. That fires the renderer's `close` listener, which calls `dispose()`, and `dispose()` invokes the `onDisposed` option and nothing else. It never goes through the component's `onCancel`. So a call site that resolves its promise from `onCancel` never resolves, and whoever awaited it waits forever with no error and nothing in the UI to explain it.

This PR passes `onDisposed` at the four call sites that had this shape, so dismissing settles the same value the Cancel button produces. `showThreeButtonModalDialogPrompt` in `positronModalDialogs.tsx` already did this and was the template.

| Where | What you see today |
|---|---|
| `missingPackagesPreflightModal.tsx` | **Live and user-visible.** Run a file that imports a package you do not have, press Escape on "these packages are missing", and the run silently never happens. |
| `missingPackagesInstallModal.tsx` | The install offer hangs. |
| `includeSecretsConfirmation.tsx` | The Include Secrets action does nothing, forever. |
| `removeDataConnectionConfirmation.tsx` | Same shape. |

The preflight modal settles with `{ decision: 'cancel', dontShowAgain: false }`. Dismissing a dialog without choosing should not quietly persist "don't show again".

Each of the four gets a test that opens the dialog for real, dismisses it, and asserts the promise settles. All four timed out before the fix, which is the bug reproduced. The tests call `dialog.close()` rather than pressing Escape, because jsdom does not wire Escape to a native dialog's default action -- `close()` is the same code path the browser takes, and it is the disposal that was untested, not the keystroke.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Dismissing a confirmation dialog with Escape no longer leaves the action it was confirming stuck forever. Most visibly, pressing Escape on the missing-packages prompt now cancels the run instead of silently doing nothing.

### Validation Steps

SETUP: you need a Python interpreter and a file that imports a package it does not have installed.

1. Create `preflight.py` containing `import some_package_you_do_not_have`.
2. Run the file. **The "Install Missing Packages" dialog appears.**
3. Press <kbd>Escape</kbd>. **The dialog closes and the console reports the run was cancelled, the same as clicking Cancel.** Before this change nothing happened at all: no run, no error, no output.
4. Run the file again and click **Cancel** instead. **Same result**, confirming Escape and Cancel agree.
5. Run the file again, tick **Don't show this again**, then press <kbd>Escape</kbd>. **Run the file once more: the dialog appears again**, because a dismissed dialog does not save that preference.

@:modal
