### PR TITLE
Add unixODBC-devel to rocky8 build image for the odbc npm module

### DIFF
--- a/docker/images/rocky_8/Dockerfile.positron-builds.rocky_8
+++ b/docker/images/rocky_8/Dockerfile.positron-builds.rocky_8
@@ -44,6 +44,7 @@ RUN dnf install -y \
     python39 \
     rpm-build \
     rpm-sign \
+    unixODBC-devel \
     vim \
     xorg-x11-server-Xvfb \
     xz


### PR DESCRIPTION
### Summary
The nightly Linux build is failing because the new `odbc` npm dependency (#15630) has no linux-arm64 prebuilt binary and falls back to compiling from source, which needs headers this image doesn't have.
- Adds `unixODBC-devel` to `docker/images/rocky_8/Dockerfile.positron-builds.rocky_8`
- Fixes `fatal error: sql.h: No such file or directory` when node-gyp compiles `node_modules/odbc` on arm64
- x64 was unaffected because node-odbc ships a linux-x64 prebuilt binary; arm64 has none upstream

#### Bug Fixes

- Fixed nightly Linux build failures on arm64 caused by missing unixODBC headers needed to compile the new `odbc` npm dependency from source.

### Validation Steps
Confirmed root cause against the failing run (posit-dev/positron-builds#50): `sql.h: No such file or directory` during `npm ci` in every arm64 `linux-binaries` job, traced to `docker/images/rocky_8/Dockerfile.positron-builds.rocky_8` never installing unixODBC dev headers.

### QA Notes
After merge, need to trigger `ci-images-build-builder.yml` (workflow_dispatch) to rebuild/push a new `positron-builds-rocky8` tag, then bump the tag in `build-workbench-linux.yml`, `build-jupyter-linux.yml`, `build-remote-ssh-linux.yml`, and `build-connect-linux.yml`.