### PR TITLE
ci: fill missing test-tag-map entries and fail PRs on new drift

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -59,12 +59,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
-      # Hard gate, scoped to dirs THIS PR touches -- not the tree-wide weekly
-      # sweep, which stays warn-only because unrelated drift shouldn't fail an
-      # unrelated PR (see check-test-tag-map.sh). A dir this PR itself
-      # introduces or edits with no map entry is the one drift case that's
-      # always the current PR's to fix, so it fails here instead of only
-      # showing up as a comment/Slack ping after the fact.
+      # Scoped to dirs THIS PR touches, unlike the tree-wide weekly sweep
+      # (check-test-tag-map.sh), which stays warn-only so unrelated drift
+      # can't fail an unrelated PR.
       - name: Fail if this PR touches an unmapped Positron dir
         if: ${{ steps.pr-tags.outputs.unmapped_dirs != '' }}
         run: |

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -59,6 +59,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+      # Hard gate, scoped to dirs THIS PR touches -- not the tree-wide weekly
+      # sweep, which stays warn-only because unrelated drift shouldn't fail an
+      # unrelated PR (see check-test-tag-map.sh). A dir this PR itself
+      # introduces or edits with no map entry is the one drift case that's
+      # always the current PR's to fix, so it fails here instead of only
+      # showing up as a comment/Slack ping after the fact.
+      - name: Fail if this PR touches an unmapped Positron dir
+        if: ${{ steps.pr-tags.outputs.unmapped_dirs != '' }}
+        run: |
+          echo "This PR touches a Positron source dir with no entry in test-tag-paths-map.json:"
+          echo "${{ steps.pr-tags.outputs.unmapped_dirs }}" | tr ',' '\n' | sed 's/^/  - /'
+          echo ""
+          echo "Add each dir to .github/workflows/test-tag-paths-map.json: a feature tag list (e.g. [\"@:console\"]) or [] if it has no e2e coverage."
+          exit 1
       # The advisory comment (no-match / unmapped-dir warnings) is posted from
       # the pr-e2e-comment workflow, folded into the single "E2E Tests" comment.
 

--- a/.github/workflows/test-tag-paths-map.json
+++ b/.github/workflows/test-tag-paths-map.json
@@ -44,6 +44,7 @@
   "extensions/positron-run-app/": ["@:apps"],
   "extensions/positron-viewer/": ["@:viewer"],
   "extensions/positron-duckdb/": ["@:duck-db"],
+  "extensions/positron-skills/": [],
 
   "src/vs/workbench/contrib/positronTelemetry/": [],
   "src/vs/workbench/contrib/positronIdleReporter/": [],
@@ -64,6 +65,7 @@
   "src/vs/workbench/contrib/positronPreview/": ["@:viewer"],
   "src/vs/workbench/contrib/positronPreviewEditor/": ["@:viewer"],
   "src/vs/workbench/contrib/positronWebviewPreloads/": ["@:positron-notebooks"],
+  "src/vs/workbench/contrib/positronCanvas/": [],
 
   "src/vs/workbench/services/positronDataConnections/": ["@:connections"],
   "src/vs/workbench/services/positronDocs/": ["@:help"],
@@ -77,6 +79,7 @@
   "src/vs/workbench/services/positronNewFolder/": ["@:new-folder-flow"],
   "src/vs/workbench/services/positronTopActionBar/": ["@:top-action-bar"],
   "src/vs/workbench/services/positronWebviewPreloads/": ["@:positron-notebooks"],
+  "src/vs/workbench/services/positronLicense/": [],
 
   "extensions/positron-catalog-explorer/": ["@:catalog-explorer"],
   "extensions/positron-code-cells/": [],
@@ -123,6 +126,7 @@
 
   "src/vs/editor/contrib/positronEditorActions/": ["@:editor-action-bar"],
   "src/vs/editor/contrib/positronHelp/": ["@:help"],
+  "src/vs/editor/contrib/positronInputBoundaries/": ["@:console"],
   "src/vs/editor/contrib/positronStatementRange/": [],
   "src/vs/platform/extensionManagement/": [],
   "src/vs/platform/extensionManagement/common/positronGalleryTelemetry.ts": ["@:extensions"],
@@ -135,7 +139,9 @@
   "src/vs/platform/positronDocs/": [],
   "src/vs/platform/positronHeadlessLanguageModel/": ["@:positron-notebooks"],
   "src/vs/platform/positronIdleTracking/": [],
+  "src/vs/platform/positronLicense/": [],
   "src/vs/platform/positronMemoryUsage/": ["@:variables"],
+  "src/vs/platform/positronStandaloneMode/": [],
   "src/vs/platform/update/": [],
   "src/vs/workbench/browser/actions/": [],
   "src/vs/workbench/browser/actions/positronActions.ts": ["@:new-folder-flow"],


### PR DESCRIPTION
### Summary
Fills the test-tag-map dirs the weekly drift check flagged, and turns the per-PR unmapped-dir check into a hard CI gate instead of a comment-only warning.
- Mapped 6 missing dirs: positron-skills, positronCanvas, positronLicense (platform + services), positronStandaloneMode, positronInputBoundaries
- test-pull-request.yml now fails a PR that touches a dir missing from test-tag-paths-map.json
- Gate is scoped to dirs the PR itself touches; the tree-wide weekly sweep stays warn-only so unrelated drift can't fail an unrelated PR
- pr-e2e-comment.yml is unchanged, so the advisory comment still posts

### QA Notes
CI/tooling-only change, no e2e tags apply. Verified locally with `scripts/check-test-tag-map.sh --json` (drift now clean) and `scripts/test/pr-tags-lib-test.sh` (all pass). Not verified: this PR doesn't itself touch an unmapped dir, so the new failing step hasn't been observed firing on a real CI run -- only exercised via the `if:` condition being false here.
