### PR TITLE
e2e: report an explicit settled flag from waitForSettle

### DIFF
--- a/test/e2e/tests/performance/memory-scenario.ts
+++ b/test/e2e/tests/performance/memory-scenario.ts
@@ -142,10 +142,13 @@ export function defineMemoryScenario(options: {
 					`Present: ${snapshot.processes.map(p => p.processName).join(', ')}`).toBe(true);
 			}
 
-			// waitForSettle gives up at its cap regardless of whether the tree
-			// actually stopped growing. A settleMs near the cap means this snapshot
-			// is a mid-load number, not the steady state the scenario claims.
-			expect(snapshot.settleMs, 'the tree never settled before the cap, so this is a mid-load number rather than a steady state').toBeLessThan(SETTLE_CAP_MS - 5_000);
+			// waitForSettle gives up at its cap regardless of whether the tree actually
+			// stopped growing, so a snapshot taken at the cap is a mid-load number, not
+			// the steady state the scenario claims. Asserted on the reported flag, not
+			// on settleMs, which cannot distinguish the two.
+			expect(snapshot.stoppedGrowing,
+				`the tree never stopped growing within the ${SETTLE_CAP_MS / 1000}s cap, so this is a mid-load number rather than a steady state`)
+				.toBe(true);
 
 			// PSS can never exceed RSS at one instant, so a violation means procfs
 			// was misparsed or the two figures came from different samples -- the

--- a/test/e2e/utils/memory/snapshot.ts
+++ b/test/e2e/utils/memory/snapshot.ts
@@ -138,28 +138,38 @@ export const SETTLE_CAP_MS = 90_000;
  * Wait until the process tree stops growing, rather than sleeping a fixed
  * amount.
  *
- * Returns how long that took, which is worth recording on its own, and the
- * highest total it saw. The peak matters because the startup reclaim can land
- * inside this window rather than after it: see {@link treeHasSettled}, which
- * cannot detect a drop it never observed.
+ * Returns whether it actually stopped, how long that took, which is worth
+ * recording on its own, and the highest total it saw. The peak matters because
+ * the startup reclaim can land inside this window rather than after it: see
+ * {@link treeHasSettled}, which cannot detect a drop it never observed.
+ *
+ * `stoppedGrowing` is reported rather than left to the caller to infer from
+ * `settleMs`, which cannot express it: see {@link MemorySnapshot.stoppedGrowing}.
+ *
+ * `options.readTree` exists so the loop can be tested without a live process
+ * tree; production callers leave it unset.
  */
 export async function waitForSettle(
 	rootPid: number,
-	options: { pollMs?: number; capMs?: number } = {}
-): Promise<{ settleMs: number; peakTotalPss: number }> {
+	options: { pollMs?: number; capMs?: number; readTree?: (pid: number) => Promise<RawProcess[]> } = {}
+): Promise<{ stoppedGrowing: boolean; settleMs: number; peakTotalPss: number }> {
 	const pollMs = options.pollMs ?? 1000;
 	const capMs = options.capMs ?? SETTLE_CAP_MS;
+	const readTree = options.readTree ?? readProcessTree;
 	const started = Date.now();
 	const readings: number[] = [];
+	let stoppedGrowing = false;
 
 	while (Date.now() - started < capMs) {
-		readings.push(totalPss(await readProcessTree(rootPid)));
+		readings.push(totalPss(await readTree(rootPid)));
 		if (isSettled(readings)) {
+			stoppedGrowing = true;
 			break;
 		}
 		await new Promise(resolve => setTimeout(resolve, pollMs));
 	}
 	return {
+		stoppedGrowing,
 		settleMs: Date.now() - started,
 		peakTotalPss: readings.length > 0 ? Math.max(...readings) : 0
 	};
@@ -328,7 +338,7 @@ export async function captureSnapshot(input: {
 	extensions: ActivatedExtension[];
 	forceGc?: () => Promise<ForcedGcStats[]>;
 }): Promise<MemorySnapshot> {
-	const { settleMs, peakTotalPss } = await waitForSettle(input.rootPid);
+	const { stoppedGrowing, settleMs, peakTotalPss } = await waitForSettle(input.rootPid);
 
 	// Must land after settle, so startup allocation is already done, and before
 	// sampling starts, so the reported tail reflects the collected state.
@@ -360,6 +370,7 @@ export async function captureSnapshot(input: {
 		capturedAt: new Date().toISOString(),
 		positronVersion: readPositronVersion(input.buildRoot),
 		launchIndex: input.launchIndex,
+		stoppedGrowing,
 		settleMs,
 		sampledMs,
 		treeSettled,

--- a/test/e2e/utils/memory/snapshot.vitest.ts
+++ b/test/e2e/utils/memory/snapshot.vitest.ts
@@ -287,12 +287,14 @@ describe('waitForSettle', () => {
 		expect(result.stoppedGrowing).toBe(false);
 	});
 
-	test('a tree that settles as the cap expires is still settled', async () => {
-		// Why the flag exists rather than a settleMs threshold: this returns a
-		// settleMs at the cap, which the old clock-based check read as never settling.
+	test('a tree that settles late in the window is still settled', async () => {
+		// Why the flag exists rather than a settleMs threshold: settling takes most of
+		// the window here, which is what the old clock-based check read as never
+		// settling. The cap has to stay well clear of the four readings isSettled
+		// needs (three polls, so 90 ms nominal) or the test itself races the cap.
 		const result = await waitForSettle(100, {
 			pollMs: 30,
-			capMs: 100,
+			capMs: 200,
 			readTree: treeReader([500 * MB, 500 * MB, 500 * MB, 500 * MB])
 		});
 		expect(result.stoppedGrowing).toBe(true);

--- a/test/e2e/utils/memory/snapshot.vitest.ts
+++ b/test/e2e/utils/memory/snapshot.vitest.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { describe, expect, test } from 'vitest';
-import { isSettled, joinProcesses, tailIsFlat, treeHasSettled, unstableProcesses } from './snapshot.js';
+import { isSettled, joinProcesses, tailIsFlat, treeHasSettled, unstableProcesses, waitForSettle } from './snapshot.js';
 import { LabeledProcess, RawProcess } from './types.js';
 
 const proc = (pid: number, ppid: number, cmd: string, pss: number): RawProcess =>
@@ -256,6 +256,62 @@ describe('isSettled', () => {
 
 	test('growth resuming after a plateau is not settled', () => {
 		expect(isSettled([500 * MB, 501 * MB, 502 * MB, 700 * MB])).toBe(false);
+	});
+});
+
+describe('waitForSettle', () => {
+	const MB = 1048576;
+
+	/** Feeds `waitForSettle` a scripted sequence of tree totals, one per poll. */
+	const treeReader = (totals: number[]) => {
+		let index = 0;
+		return async () => {
+			const total = totals[Math.min(index++, totals.length - 1)];
+			return [proc(100, 1, 'positron', total)];
+		};
+	};
+
+	test('reports stoppedGrowing once the tree goes flat', async () => {
+		const result = await waitForSettle(100, {
+			pollMs: 0,
+			readTree: treeReader([100 * MB, 300 * MB, 500 * MB, 501 * MB, 502 * MB, 503 * MB])
+		});
+		expect(result.stoppedGrowing).toBe(true);
+	});
+
+	test('reports stoppedGrowing false when it gives up at the cap', async () => {
+		// The gate in memory-scenario.ts rests entirely on this: a tree that grew for
+		// the whole window must not be reported as a steady state.
+		const growing = Array.from({ length: 200 }, (_, i) => (100 + i * 50) * MB);
+		const result = await waitForSettle(100, { pollMs: 0, capMs: 50, readTree: treeReader(growing) });
+		expect(result.stoppedGrowing).toBe(false);
+	});
+
+	test('a tree that settles as the cap expires is still settled', async () => {
+		// Why the flag exists rather than a settleMs threshold: this returns a
+		// settleMs at the cap, which the old clock-based check read as never settling.
+		const result = await waitForSettle(100, {
+			pollMs: 30,
+			capMs: 100,
+			readTree: treeReader([500 * MB, 500 * MB, 500 * MB, 500 * MB])
+		});
+		expect(result.stoppedGrowing).toBe(true);
+		expect(result.settleMs).toBeGreaterThan(50);
+	});
+
+	test('reports the peak it saw, not the last reading', async () => {
+		// captureSnapshot needs the peak because a reclaim landing inside this window
+		// is invisible to treeHasSettled otherwise.
+		const result = await waitForSettle(100, {
+			pollMs: 0,
+			readTree: treeReader([900 * MB, 500 * MB, 500 * MB, 500 * MB, 500 * MB])
+		});
+		expect(result.peakTotalPss).toBe(900 * MB);
+	});
+
+	test('an empty window reports no peak and no settle', async () => {
+		const result = await waitForSettle(100, { capMs: 0, readTree: treeReader([500 * MB]) });
+		expect(result).toMatchObject({ stoppedGrowing: false, peakTotalPss: 0 });
 	});
 });
 

--- a/test/e2e/utils/memory/types.ts
+++ b/test/e2e/utils/memory/types.ts
@@ -85,14 +85,22 @@ export type MemorySnapshot = {
 	/** e.g. `2026.09.0-35`: version plus build number, from the build's product.json. */
 	positronVersion: string;
 	launchIndex: number;
+	/**
+	 * Whether the tree stopped growing before `waitForSettle` hit its cap. Recorded
+	 * rather than inferred from `settleMs`, which cannot tell the two apart: the cap
+	 * is only checked before a reading, so a tree going flat just under it returns
+	 * the same `settleMs` as one that never settled. Undefined on a baseline.
+	 */
+	stoppedGrowing?: boolean;
+	/** How long the tree took to stop growing. */
 	settleMs: number;
 	/** How long sampling ran after settling, waiting for every large process to hold steady. */
 	sampledMs?: number;
 	/**
-	 * Whether sampling stopped because the tree settled rather than because it hit
-	 * its cap. Recorded rather than inferred from `sampledMs`, which cannot tell the
-	 * two apart: an iteration starting just under the cap sleeps past it before
-	 * settling. Undefined on a baseline, which carries neither field.
+	 * The same outcome for the sampling phase: whether it stopped because every large
+	 * process held steady rather than because it hit its cap. `sampledMs` cannot tell
+	 * those apart either, since an iteration starting just under the cap sleeps past
+	 * it before settling.
 	 */
 	treeSettled?: boolean;
 	/**


### PR DESCRIPTION
Refs #15001, follows PR #15550

### Summary

Before measuring memory, the scenarios check that the app has stopped growing. That check was reading the clock: if the settle phase finished well before its 90s cap, call it settled. But the cap is only checked before a reading, so a launch that went flat on its very last reading looked exactly like one that never settled, and got failed for it.

`waitForSettle` now reports whether it settled, and the check reads that instead. The sampling phase beside it already worked this way.

- `waitForSettle` returns `stoppedGrowing`; the gate asserts on it, not on `settleMs`
- Adds a `readTree` seam so the settle loop can be unit-tested
- Five new vitest cases covering settled, capped, and settled-at-the-cap

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

These specs only collect when `MEMORY_SCENARIO` is set, so no PR tag runs them. Real verification is a `workflow_dispatch` of `Test: Memory Metrics` on this branch: [run 32737315598](https://github.com/posit-dev/positron/actions/runs/32737315598).

Also verified: 230 vitest pass, `tsc -p test/e2e/tsconfig.json` clean, and both new gate tests fail when `stoppedGrowing` is forced true.
