### PR TITLE
ci: bump positron-builds-rocky8 image to :5 in Linux build workflows

### DIFF
--- a/.github/workflows/build-connect-linux.yml
+++ b/.github/workflows/build-connect-linux.yml
@@ -30,7 +30,7 @@ jobs:
     outputs:
       artifact-name: positron-deb-connect-x64
     container:
-      image: ghcr.io/posit-dev/positron-builds-rocky8:3
+      image: ghcr.io/posit-dev/positron-builds-rocky8:4
       credentials:
         username: ${{ secrets.POSITRON_GITHUB_RO_USER }}
         password: ${{ secrets.POSITRON_GITHUB_RO_PAT }}

--- a/.github/workflows/build-connect-linux.yml
+++ b/.github/workflows/build-connect-linux.yml
@@ -30,7 +30,7 @@ jobs:
     outputs:
       artifact-name: positron-deb-connect-x64
     container:
-      image: ghcr.io/posit-dev/positron-builds-rocky8:4
+      image: ghcr.io/posit-dev/positron-builds-rocky8:5
       credentials:
         username: ${{ secrets.POSITRON_GITHUB_RO_USER }}
         password: ${{ secrets.POSITRON_GITHUB_RO_PAT }}

--- a/.github/workflows/build-jupyter-linux.yml
+++ b/.github/workflows/build-jupyter-linux.yml
@@ -25,7 +25,7 @@ jobs:
     outputs:
       artifact-name: positron-server-linux-x64
     container:
-      image: ghcr.io/posit-dev/positron-builds-rocky8:4
+      image: ghcr.io/posit-dev/positron-builds-rocky8:5
       credentials:
         username: ${{ secrets.POSITRON_GITHUB_RO_USER }}
         password: ${{ secrets.POSITRON_GITHUB_RO_PAT }}

--- a/.github/workflows/build-jupyter-linux.yml
+++ b/.github/workflows/build-jupyter-linux.yml
@@ -25,7 +25,7 @@ jobs:
     outputs:
       artifact-name: positron-server-linux-x64
     container:
-      image: ghcr.io/posit-dev/positron-builds-rocky8:2
+      image: ghcr.io/posit-dev/positron-builds-rocky8:4
       credentials:
         username: ${{ secrets.POSITRON_GITHUB_RO_USER }}
         password: ${{ secrets.POSITRON_GITHUB_RO_PAT }}

--- a/.github/workflows/build-remote-ssh-linux.yml
+++ b/.github/workflows/build-remote-ssh-linux.yml
@@ -28,7 +28,7 @@ jobs:
     outputs:
       artifact-name: positron-deb-remote-ssh-x64
     container:
-      image: ghcr.io/posit-dev/positron-builds-rocky8:4
+      image: ghcr.io/posit-dev/positron-builds-rocky8:5
       credentials:
         username: ${{ secrets.POSITRON_GITHUB_RO_USER }}
         password: ${{ secrets.POSITRON_GITHUB_RO_PAT }}
@@ -126,7 +126,7 @@ jobs:
     outputs:
       artifact-name: positron-reh-remote-ssh-x64
     container:
-      image: ghcr.io/posit-dev/positron-builds-rocky8:4
+      image: ghcr.io/posit-dev/positron-builds-rocky8:5
       credentials:
         username: ${{ secrets.POSITRON_GITHUB_RO_USER }}
         password: ${{ secrets.POSITRON_GITHUB_RO_PAT }}

--- a/.github/workflows/build-remote-ssh-linux.yml
+++ b/.github/workflows/build-remote-ssh-linux.yml
@@ -28,7 +28,7 @@ jobs:
     outputs:
       artifact-name: positron-deb-remote-ssh-x64
     container:
-      image: ghcr.io/posit-dev/positron-builds-rocky8:3
+      image: ghcr.io/posit-dev/positron-builds-rocky8:4
       credentials:
         username: ${{ secrets.POSITRON_GITHUB_RO_USER }}
         password: ${{ secrets.POSITRON_GITHUB_RO_PAT }}
@@ -126,7 +126,7 @@ jobs:
     outputs:
       artifact-name: positron-reh-remote-ssh-x64
     container:
-      image: ghcr.io/posit-dev/positron-builds-rocky8:3
+      image: ghcr.io/posit-dev/positron-builds-rocky8:4
       credentials:
         username: ${{ secrets.POSITRON_GITHUB_RO_USER }}
         password: ${{ secrets.POSITRON_GITHUB_RO_PAT }}

--- a/.github/workflows/build-workbench-linux.yml
+++ b/.github/workflows/build-workbench-linux.yml
@@ -25,7 +25,7 @@ jobs:
     outputs:
       artifact-name: positron-workbench-linux-x64
     container:
-      image: ghcr.io/posit-dev/positron-builds-rocky8:4
+      image: ghcr.io/posit-dev/positron-builds-rocky8:5
       credentials:
         username: ${{ secrets.POSITRON_GITHUB_RO_USER }}
         password: ${{ secrets.POSITRON_GITHUB_RO_PAT }}

--- a/.github/workflows/build-workbench-linux.yml
+++ b/.github/workflows/build-workbench-linux.yml
@@ -25,7 +25,7 @@ jobs:
     outputs:
       artifact-name: positron-workbench-linux-x64
     container:
-      image: ghcr.io/posit-dev/positron-builds-rocky8:2
+      image: ghcr.io/posit-dev/positron-builds-rocky8:4
       credentials:
         username: ${{ secrets.POSITRON_GITHUB_RO_USER }}
         password: ${{ secrets.POSITRON_GITHUB_RO_PAT }}


### PR DESCRIPTION
### Summary
Points the Linux build workflows at the rebuilt `positron-builds-rocky8:5` image so they pick up both fixes needed for the arm64 nightly build.
- Bumps `build-workbench-linux.yml` and `build-jupyter-linux.yml` from `:2` to `:5`
- Bumps `build-remote-ssh-linux.yml` and `build-connect-linux.yml` from `:3` to `:5`
- `:5` was built from #15687 (unixODBC-devel) and #15694 (gcc-toolset-14), and pushed for both amd64 and arm64

### QA Notes
Depends on #15694 merging first. Validated via direct `build-release-linux.yml`/`build-release.yml` dispatch against `posit-dev/positron-builds` rather than `test-full-suite.yml`, whose workbench/connect/jupyter/remote-ssh lanes hit an unrelated pre-existing issue unrelated to this change.
