### PR TITLE
Add gcc-toolset-14 and prune node-pre-gyp's build-tmp scratch dir

### DIFF
--- a/build/lib/positron-path-budget.ts
+++ b/build/lib/positron-path-budget.ts
@@ -105,6 +105,13 @@ const EXTENSION_NODE_MODULES_EXCLUDES = [
 	// scopes, because many other packages ship `dist-es` as their only build.
 	'node_modules/@aws-sdk/**/dist-es/**',
 	'node_modules/@smithy/**/dist-es/**',
+	// node-pre-gyp's scratch directory from a source build. A platform with no
+	// prebuilt binary (e.g. linux-arm64 for `odbc`) falls back to compiling
+	// with node-gyp, which leaves this directory behind. Its `.deps` files
+	// encode the build's absolute path in the file name, which is the longest
+	// path in the tree. Only the compiled `lib/bindings/**/*.node` the package
+	// resolves at runtime; this directory is never read again.
+	'node_modules/**/build-tmp-napi-v*/**',
 ];
 
 /**

--- a/build/lib/positron-path-budget.ts
+++ b/build/lib/positron-path-budget.ts
@@ -105,12 +105,9 @@ const EXTENSION_NODE_MODULES_EXCLUDES = [
 	// scopes, because many other packages ship `dist-es` as their only build.
 	'node_modules/@aws-sdk/**/dist-es/**',
 	'node_modules/@smithy/**/dist-es/**',
-	// node-pre-gyp's scratch directory from a source build. A platform with no
-	// prebuilt binary (e.g. linux-arm64 for `odbc`) falls back to compiling
-	// with node-gyp, which leaves this directory behind. Its `.deps` files
-	// encode the build's absolute path in the file name, which is the longest
-	// path in the tree. Only the compiled `lib/bindings/**/*.node` the package
-	// resolves at runtime; this directory is never read again.
+	// node-pre-gyp's scratch dir from a source-build fallback (e.g. odbc has
+	// no linux-arm64 prebuilt). Its .deps files bake in the absolute build
+	// path, which is the longest path in the tree.
 	'node_modules/**/build-tmp-napi-v*/**',
 ];
 

--- a/build/lib/test/positron-path-budget.test.ts
+++ b/build/lib/test/positron-path-budget.test.ts
@@ -64,13 +64,9 @@ suite('positron-path-budget', () => {
 				// extension.
 				'dist/extension.js',
 				'src/extension.ts',
-				// node-pre-gyp's scratch directory from a source build, e.g.
-				// `odbc` on linux-arm64, which has no prebuilt binary. Its
-				// `.deps` files encode the build's absolute path in the file
-				// name.
+				// node-pre-gyp's scratch dir from a source-build fallback.
 				'node_modules/odbc/build-tmp-napi-v8/Release/.deps/x.d',
-				// The compiled binary the package actually resolves at
-				// runtime stays.
+				// The compiled binary the package resolves at runtime stays.
 				'node_modules/odbc/lib/bindings/napi-v8/odbc.node',
 			];
 

--- a/build/lib/test/positron-path-budget.test.ts
+++ b/build/lib/test/positron-path-budget.test.ts
@@ -64,6 +64,14 @@ suite('positron-path-budget', () => {
 				// extension.
 				'dist/extension.js',
 				'src/extension.ts',
+				// node-pre-gyp's scratch directory from a source build, e.g.
+				// `odbc` on linux-arm64, which has no prebuilt binary. Its
+				// `.deps` files encode the build's absolute path in the file
+				// name.
+				'node_modules/odbc/build-tmp-napi-v8/Release/.deps/x.d',
+				// The compiled binary the package actually resolves at
+				// runtime stays.
+				'node_modules/odbc/lib/bindings/napi-v8/odbc.node',
 			];
 
 			assert.deepStrictEqual(paths.map(isPruned), [
@@ -71,6 +79,8 @@ suite('positron-path-budget', () => {
 				false, false, false, false, false,
 				false,
 				false, false,
+				true,
+				false,
 			]);
 		});
 

--- a/docker/images/rocky_8/Dockerfile.positron-builds.rocky_8
+++ b/docker/images/rocky_8/Dockerfile.positron-builds.rocky_8
@@ -26,6 +26,7 @@ RUN dnf install -y \
     gcc \
     gcc-c++ \
     gcc-plugin-annobin \
+    gcc-toolset-14 \
     git \
     gtk3 \
     krb5-devel \


### PR DESCRIPTION
### Summary
Two fixes needed to get a working Linux arm64 nightly build image, both discovered while rebuilding `positron-builds-rocky8` for #15687 (the arm64 `odbc` build failure fix).
- The rocky8 build image's Dockerfile has never installed `gcc-toolset-14`, even though `build-release-linux.yml`'s "Execute npm" step requires it (`scl enable gcc-toolset-14 -- bash`) for a newer GCC. The currently published `:3` tag has it anyway from some undocumented process; a fresh rebuild from the committed Dockerfile does not, breaking `Execute npm` on every arch immediately.
- `odbc` has no linux-arm64 prebuilt binary, so npm falls back to compiling it from source with node-gyp there, leaving a `build-tmp-napi-v8/` scratch directory whose `.deps` file name encodes the build's absolute path, blowing the Windows path-length budget (#14702) and failing packaging.
- Adds `gcc-toolset-14` to the Dockerfile package list
- Adds `node_modules/**/build-tmp-napi-v*/**` to `EXTENSION_NODE_MODULES_EXCLUDES` in `positron-path-budget.ts`, generalized to any package hitting the same node-pre-gyp fallback
- Adds a test case covering both the pruned scratch file and the kept runtime binary

### QA Notes
Second and third of a chain of fixes for the arm64 Linux nightly build failure, after #15687 (unixODBC-devel). Rebuilt image is `positron-builds-rocky8:5`; `posit-dev/positron-builds#1201` bumps the nightly workflow to it.
- Could not run `node --test build/lib/test/positron-path-budget.test.ts` in this environment (no `node_modules`). Verified the new glob against the repo's pinned `minimatch@3.1.5` in an isolated sandbox instead.
- Direct `build-release-linux.yml` dispatches got past `Execute npm` and into the packaging step successfully with both fixes; a later attempt hit an unrelated Ark-submodule-prebuild race (from a separate main-branch commit, #15691) rather than anything in this diff.
