### PR TITLE
Prune node-pre-gyp's build-tmp scratch dir from packaged extensions

### DIFF
--- a/build/lib/positron-path-budget.ts
+++ b/build/lib/positron-path-budget.ts
@@ -105,6 +105,13 @@ const EXTENSION_NODE_MODULES_EXCLUDES = [
 	// scopes, because many other packages ship `dist-es` as their only build.
 	'node_modules/@aws-sdk/**/dist-es/**',
 	'node_modules/@smithy/**/dist-es/**',
+	// node-pre-gyp's scratch directory from a source build. A platform with no
+	// prebuilt binary (e.g. linux-arm64 for `odbc`) falls back to compiling
+	// with node-gyp, which leaves this directory behind. Its `.deps` files
+	// encode the build's absolute path in the file name, which is the longest
+	// path in the tree. Only the compiled `lib/bindings/**/*.node` the package
+	// resolves at runtime; this directory is never read again.
+	'node_modules/**/build-tmp-napi-v*/**',
 ];
 
 /**

--- a/build/lib/positron-path-budget.ts
+++ b/build/lib/positron-path-budget.ts
@@ -105,12 +105,9 @@ const EXTENSION_NODE_MODULES_EXCLUDES = [
 	// scopes, because many other packages ship `dist-es` as their only build.
 	'node_modules/@aws-sdk/**/dist-es/**',
 	'node_modules/@smithy/**/dist-es/**',
-	// node-pre-gyp's scratch directory from a source build. A platform with no
-	// prebuilt binary (e.g. linux-arm64 for `odbc`) falls back to compiling
-	// with node-gyp, which leaves this directory behind. Its `.deps` files
-	// encode the build's absolute path in the file name, which is the longest
-	// path in the tree. Only the compiled `lib/bindings/**/*.node` the package
-	// resolves at runtime; this directory is never read again.
+	// node-pre-gyp's scratch dir from a source-build fallback (e.g. odbc has
+	// no linux-arm64 prebuilt). Its .deps files bake in the absolute build
+	// path, which is the longest path in the tree.
 	'node_modules/**/build-tmp-napi-v*/**',
 ];
 

--- a/build/lib/test/positron-path-budget.test.ts
+++ b/build/lib/test/positron-path-budget.test.ts
@@ -64,13 +64,9 @@ suite('positron-path-budget', () => {
 				// extension.
 				'dist/extension.js',
 				'src/extension.ts',
-				// node-pre-gyp's scratch directory from a source build, e.g.
-				// `odbc` on linux-arm64, which has no prebuilt binary. Its
-				// `.deps` files encode the build's absolute path in the file
-				// name.
+				// node-pre-gyp's scratch dir from a source-build fallback.
 				'node_modules/odbc/build-tmp-napi-v8/Release/.deps/x.d',
-				// The compiled binary the package actually resolves at
-				// runtime stays.
+				// The compiled binary the package resolves at runtime stays.
 				'node_modules/odbc/lib/bindings/napi-v8/odbc.node',
 			];
 

--- a/build/lib/test/positron-path-budget.test.ts
+++ b/build/lib/test/positron-path-budget.test.ts
@@ -64,6 +64,14 @@ suite('positron-path-budget', () => {
 				// extension.
 				'dist/extension.js',
 				'src/extension.ts',
+				// node-pre-gyp's scratch directory from a source build, e.g.
+				// `odbc` on linux-arm64, which has no prebuilt binary. Its
+				// `.deps` files encode the build's absolute path in the file
+				// name.
+				'node_modules/odbc/build-tmp-napi-v8/Release/.deps/x.d',
+				// The compiled binary the package actually resolves at
+				// runtime stays.
+				'node_modules/odbc/lib/bindings/napi-v8/odbc.node',
 			];
 
 			assert.deepStrictEqual(paths.map(isPruned), [
@@ -71,6 +79,8 @@ suite('positron-path-budget', () => {
 				false, false, false, false, false,
 				false,
 				false, false,
+				true,
+				false,
 			]);
 		});
 


### PR DESCRIPTION
### Summary
`odbc` has no linux-arm64 prebuilt binary, so npm falls back to compiling it from source with node-gyp there. That leaves a `build-tmp-napi-v8/` scratch directory in `node_modules/odbc` whose `.deps` file encodes the build's absolute path in its file name, which blows the Windows path-length budget (#14702) and fails packaging.
- Adds `node_modules/**/build-tmp-napi-v*/**` to `EXTENSION_NODE_MODULES_EXCLUDES` in `positron-path-budget.ts`, generalized to any package that hits the same node-pre-gyp source-build fallback, not just odbc
- Only the compiled `lib/bindings/**/*.node` the package actually resolves at runtime; this scratch directory is never read again
- Adds a test case covering both the pruned scratch file and the kept runtime binary

### QA Notes
Third and last of a chain of fixes for the arm64 Linux nightly build failure: #15687 (unixODBC-devel), #15694 (gcc-toolset-14), this one.
- Could not run `node --test build/lib/test/positron-path-budget.test.ts` in this environment (no `node_modules`). Verified the new glob against the repo's pinned `minimatch@3.1.5` in an isolated sandbox instead of the project's test runner.
- End-to-end validation in progress via direct `build-release-linux.yml` dispatch in `positron-builds` (arm64 leg through the actual packaging step); will report the result before merge.
