### PR TITLE
Add Databricks OAuth e2e coverage for data connections

### DIFF
--- a/.env.e2e.example
+++ b/.env.e2e.example
@@ -26,9 +26,14 @@ REDSHIFT_TEST_PASSWORD=your_password_here
 # DATABRICKS_URL is the workspace the OAuth (desktop-only) test signs in to, via the
 # shared IDE service account's Okta SSO. The API-key test uses DATABRICKS_WORKSPACE and
 # DATABRICKS_PAT, which the catalog-explorer tests already rely on.
+# DATABRICKS_HTTP_PATH is that workspace's SQL warehouse, used by the data-connections
+# Databricks test. Not a credential (it is a warehouse id), but it is stored with the
+# workspace it belongs to so the two rotate together.
 # op://Positron/Databricks-WB-Auto/url
+# op://Positron/Databricks-WB-Auto/http-path
 # op://Positron/RStudioIDE_Service_Account/{service-account-email,service-account-password,service-account-otp-secret}
 DATABRICKS_URL=
+DATABRICKS_HTTP_PATH=
 IDE_SERVICE_ACCOUNT_EMAIL=
 IDE_SERVICE_ACCOUNT_PASSWORD=
 IDE_SERVICE_ACCOUNT_OTP_SECRET=

--- a/.github/workflows/test-e2e-ubuntu-run.yml
+++ b/.github/workflows/test-e2e-ubuntu-run.yml
@@ -173,10 +173,13 @@ jobs:
           REDSHIFT_TEST_HOST: "op://Positron/Redshift_Test_Environment/hostname"
           REDSHIFT_TEST_USERNAME: "op://Positron/Redshift_Test_Environment/username"
           REDSHIFT_TEST_PASSWORD: "op://Positron/Redshift_Test_Environment/password"
-          # Databricks LLM provider OAuth sign-in (posit-assistant). Desktop only: the
-          # flow redirects to a loopback server on this machine. The same workspace and
-          # service account the Workbench managed-credentials lane uses.
+          # Databricks OAuth sign-in, shared by the posit-assistant LLM provider test and
+          # the data-connections driver test. Desktop only: both flows redirect to a
+          # loopback server on this machine. The same workspace and service account the
+          # Workbench managed-credentials lane uses. DATABRICKS_HTTP_PATH is the SQL
+          # warehouse in that workspace, needed only by the data-connections test.
           DATABRICKS_URL: "op://Positron/Databricks-WB-Auto/url"
+          DATABRICKS_HTTP_PATH: "op://Positron/Databricks-WB-Auto/http-path"
           IDE_SERVICE_ACCOUNT_EMAIL: "op://Positron/RStudioIDE_Service_Account/service-account-email"
           IDE_SERVICE_ACCOUNT_PASSWORD: "op://Positron/RStudioIDE_Service_Account/service-account-password"
           IDE_SERVICE_ACCOUNT_OTP_SECRET: "op://Positron/RStudioIDE_Service_Account/service-account-otp-secret"

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -153,6 +153,17 @@ jobs:
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"
+          # Databricks OAuth sign-in, shared by the posit-assistant LLM provider test and
+          # the data-connections driver test. Both are desktop-only and skip themselves
+          # when these are absent -- which is why they belong here and not only on the
+          # merge lane: a PR carrying @:connections or @:assistant should actually run
+          # them rather than silently skip. DATABRICKS_HTTP_PATH is the SQL warehouse in
+          # the workspace DATABRICKS_URL points at.
+          DATABRICKS_URL: "op://Positron/Databricks-WB-Auto/url"
+          DATABRICKS_HTTP_PATH: "op://Positron/Databricks-WB-Auto/http-path"
+          IDE_SERVICE_ACCOUNT_EMAIL: "op://Positron/RStudioIDE_Service_Account/service-account-email"
+          IDE_SERVICE_ACCOUNT_PASSWORD: "op://Positron/RStudioIDE_Service_Account/service-account-password"
+          IDE_SERVICE_ACCOUNT_OTP_SECRET: "op://Positron/RStudioIDE_Service_Account/service-account-otp-secret"
 
       - name: Transform to Playwright tags $PW_TAGS
         run: bash scripts/pr-tags-transform.sh ${{ inputs.project}} "${{ inputs.grep }}"

--- a/test/e2e/tests/data-connections/databricks.test.ts
+++ b/test/e2e/tests/data-connections/databricks.test.ts
@@ -1,0 +1,171 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test, expect, tags } from '../_test.setup';
+import { createBrowserLaunchShim } from '../../utils/browserLaunchShim';
+import { completeDatabricksSdkOAuth } from '../../utils/databricksOAuth';
+
+// Intercepts the browser launch the Databricks SDK makes during OAuth sign-in. Created at module
+// scope because `test.use({ extraEnv })` below is evaluated when this file is collected, so the
+// PATH value has to exist by then.
+const shim = createBrowserLaunchShim();
+
+test.use({
+	suiteId: __filename,
+	// The Data Connections panel is a preview feature gated behind `dataConnections.enabled`. This
+	// bakes the setting into the app (and the Workbench/Jupyter containers) at startup, since those
+	// read settings copied in at launch rather than the host settings file written at runtime.
+	enableDataConnections: true,
+	// Put the shim ahead of the real browser opener for the launched app. The extension host
+	// inherits this, which is where @databricks/sql runs.
+	extraEnv: shim.env,
+});
+
+// Databricks connection details. The workspace and warehouse come from the environment (the
+// project's .env file locally, 1Password in CI); the sign-in itself uses the shared IDE service
+// account, the same one the assistant's Databricks OAuth test and the Workbench managed-credentials
+// tests use.
+//
+// The env-backed values are read at runtime inside beforeAll, not here: `.env.e2e` is applied by the
+// auto `envVars` worker fixture, which runs after this file is evaluated during test collection, so a
+// top-level `process.env` read would always be empty (and the suite would skip).
+const connectionName = 'databricks';
+
+// `samples` is the read-only catalog Databricks provisions in every workspace, so its contents are
+// stable ground truth in a way `main` or a workspace's own catalogs are not.
+const catalog = 'samples';
+const schema = 'accuweather';
+
+// The tables in samples.accuweather, in the order the tree renders them.
+const accuweatherTables = [
+	'forecast_daily_calendar_imperial',
+	'forecast_daily_calendar_metric',
+	'forecast_daynight_imperial',
+	'forecast_daynight_metric',
+	'forecast_hourly_imperial',
+	'forecast_hourly_metric',
+	'historical_daily_calendar_imperial',
+	'historical_daily_calendar_metric',
+	'historical_daynight_imperial',
+	'historical_daynight_metric',
+	'historical_hourly_imperial',
+	'historical_hourly_metric',
+];
+
+// The table opened in the Data Explorer, and how wide it is. The count is asserted rather than
+// the 88 column names: the forecast columns belong to Databricks' sample dataset and can change,
+// and an 88-entry snapshot would be noise in a suite whose subject is the OAuth connection. The
+// Redshift suite covers column-level Data Explorer fidelity in depth.
+const accuweatherTable = accuweatherTables[0];
+const accuweatherTableColumnCount = 88;
+
+// Desktop only, and not Windows. Both limits come from how the browser launch is intercepted, not
+// from the OAuth flow itself, which is the same everywhere:
+//
+//   - Web and Workbench: the shim reaches the extension host through `extraEnv`, and only the
+//     Electron launch path applies that (infra/electron.ts). playwrightBrowser.ts and
+//     playwrightExternalServer.ts build the server's env from process.env alone, so the shim never
+//     reaches the process running @databricks/sql -- it would launch a real browser instead.
+//     Plumbing extraEnv through those paths would make a web variant possible.
+//   - Windows: the shim cannot work at all. `open` invokes PowerShell by absolute path and never
+//     consults PATH, so there is nothing to put ourselves ahead of.
+//
+// See browserLaunchShim.ts.
+test.describe('Data Connections - Databricks (OAuth U2M)', {
+	tag: [tags.CONNECTIONS]
+}, () => {
+
+	// Signing in is a one-time, stateful action and it spends a code from the shared TOTP secret, so
+	// it happens exactly once for the whole suite rather than per test. The app is worker-scoped, so
+	// the connection persists across every test here. Per-test state that must not leak (an open Data
+	// Explorer tab) is reset in afterEach.
+	test.beforeAll(async function ({ app }) {
+		// Read the env-backed connection details now (not at module scope): `.env.e2e` is applied by
+		// the auto `envVars` worker fixture, which has run by the time this hook executes.
+		const host = process.env.DATABRICKS_URL || '';
+		const httpPath = process.env.DATABRICKS_HTTP_PATH || '';
+
+		// The workspace, the warehouse, and the service account are all secrets. Where they are not
+		// provisioned (no .env locally, no 1Password in a given CI rig) the sign-in cannot happen, so
+		// skip the whole suite rather than fail. Follows the convention the Redshift tests use.
+		test.skip(!host || !httpPath, 'Databricks test credentials not configured (DATABRICKS_URL / DATABRICKS_HTTP_PATH unset)');
+
+		// The budget here covers the interactive sign-in end to end: the Okta SSO hop, a TOTP that may
+		// be retried with backoff when a parallel consumer of the shared secret takes the same code,
+		// two Databricks consent screens, the token exchange, and the warehouse's first metadata query
+		// (which can cold-start).
+		test.setTimeout(600_000);
+
+		const { dataConnections } = app.workbench;
+		dataConnections.actionTimeout = 240_000;
+
+		await dataConnections.openDataConnectionsView();
+		await dataConnections.clickAddConnection();
+		await dataConnections.selectProvider('Databricks');
+		await dataConnections.selectConnectionMechanism('OAuth User-to-Machine (U2M)');
+		// `host` is passed through as-is, including its scheme: parseDatabricksHost strips the scheme,
+		// path, query, and port, and the field's helper text invites pasting a full workspace URL. So
+		// this is the value a real user supplies, not a pre-trimmed one.
+		await dataConnections.fillConnectionInputs({
+			'Connection Name': connectionName,
+			'Server Hostname': host,
+			'HTTP Path': httpPath,
+		});
+
+		// Saving only persists the profile -- no connection is made and no browser opens yet.
+		await dataConnections.save();
+		await dataConnections.expectConnectionInTree(connectionName);
+
+		// Expanding the entry is what connects, and the driver connects eagerly, so this is where the
+		// SDK runs OAuth. The expand cannot be awaited until sign-in finishes; the helper starts it,
+		// drives the browser, then awaits it.
+		await completeDatabricksSdkOAuth(
+			shim,
+			() => dataConnections.expandConnection(connectionName),
+			{ logger: app.code.logger },
+		);
+
+		await test.step('Expand the tree down to tables', async () => {
+			await dataConnections.expandNode('Catalogs');
+			await dataConnections.expandNode(catalog, 'database');
+			await dataConnections.expandNode('Schemas');
+			await dataConnections.expandNode(schema, 'schema');
+			await dataConnections.expandNode('Tables');
+		});
+	});
+
+	// Each preview test opens a Data Explorer tab. Close it so the next test starts from a clean
+	// editor state rather than depending on what the previous test left open. The connection and its
+	// expanded tree remain in the worker-scoped app.
+	test.afterEach(async function ({ app }) {
+		await app.workbench.hotKeys.closeAllEditors();
+	});
+
+	test.afterAll(async function () {
+		shim.dispose();
+	});
+
+	test('Verify the workspace catalogs are listed', async function ({ app }) {
+		// The catalogs a workspace holds are partly up to whoever administers it, so assert on the
+		// two Databricks always provisions rather than pinning the whole list.
+		await app.workbench.dataConnections.expectNodeVisible(catalog, 'database');
+		await app.workbench.dataConnections.expectNodeVisible('hive_metastore', 'database');
+	});
+
+	test('Verify the tables in samples.accuweather are listed', async function ({ app }) {
+		for (const table of accuweatherTables) {
+			await app.workbench.dataConnections.expectNodeVisible(table, 'table');
+		}
+	});
+
+	test('Verify a table opens in the Data Explorer', { tag: [tags.DATA_EXPLORER] }, async function ({ app }) {
+		const { dataConnections, dataExplorer } = app.workbench;
+
+		await dataConnections.doubleClickNode(accuweatherTable, 'table');
+
+		await dataExplorer.waitForIdle();
+		expect(await dataExplorer.grid.getColumnCount()).toBe(accuweatherTableColumnCount);
+	});
+});

--- a/test/e2e/tests/data-connections/databricks.test.ts
+++ b/test/e2e/tests/data-connections/databricks.test.ts
@@ -94,12 +94,18 @@ test.describe('Data Connections - Databricks (OAuth U2M)', {
 
 		// The budget here covers the interactive sign-in end to end: the Okta SSO hop, a TOTP that may
 		// be retried with backoff when a parallel consumer of the shared secret takes the same code,
-		// two Databricks consent screens, the token exchange, and the warehouse's first metadata query
-		// (which can cold-start).
-		test.setTimeout(600_000);
+		// two Databricks consent screens, and the token exchange.
+		//
+		// It also has to absorb a cold SQL warehouse. The warehouse auto-stops when idle, and the
+		// first metadata query restarts it, which for serverless routinely takes several minutes --
+		// long enough that a 240s budget flaked in CI while the same chain took ~70s once warm. Note
+		// where that latency lands: `Catalogs` is a static container whose twisty flips with no query
+		// behind it, so expanding it returns immediately and the whole cold-start wait falls on the
+		// *next* expand, the one that lists catalogs.
+		test.setTimeout(900_000);
 
 		const { dataConnections } = app.workbench;
-		dataConnections.actionTimeout = 240_000;
+		dataConnections.actionTimeout = 420_000;
 
 		await dataConnections.openDataConnectionsView();
 		await dataConnections.clickAddConnection();
@@ -134,6 +140,10 @@ test.describe('Data Connections - Databricks (OAuth U2M)', {
 			await dataConnections.expandNode(schema, 'schema');
 			await dataConnections.expandNode('Tables');
 		});
+
+		// The cold-start budget above is only needed for that first chain. Drop back to a normal
+		// wait so a genuine failure in the tests below surfaces in seconds rather than minutes.
+		dataConnections.actionTimeout = 60_000;
 	});
 
 	// Each preview test opens a Data Explorer tab. Close it so the next test starts from a clean

--- a/test/e2e/utils/browserLaunchShim.ts
+++ b/test/e2e/utils/browserLaunchShim.ts
@@ -1,0 +1,121 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from '@playwright/test';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { delimiter, join } from 'path';
+
+// Captures the URLs a *bundled SDK* hands to the system browser, for flows Positron itself
+// does not own.
+//
+// This is the sibling of externalUrl.ts, and the choice between them is about who opens the
+// browser. When Positron runs the flow, `vscode.env.openExternal` reaches `shell.openExternal`
+// in the Electron main process and externalUrl.ts patches it there. But a dependency running
+// its own OAuth never touches that path: @databricks/sql's AuthorizationCode calls the `open`
+// npm package directly, and its OAuthManager.getTokenU2M never passes the `openAuthUrl`
+// override the SDK supports -- so there is no seam inside the process to patch.
+//
+// What `open` does expose is PATH. It spawns `open` (macOS) or `xdg-open` (Linux) with no
+// shell, so PATH decides which binary runs; on Linux the bundled copy is skipped whenever
+// `process.versions.electron` is set, which it is in the extension host. Putting our own
+// executables ahead of the real ones therefore intercepts the launch.
+//
+// The shim records and swallows: nothing should spawn a real browser on a CI machine.
+//
+// Not supported on Windows, where `open` invokes PowerShell by absolute path and never
+// consults PATH. Suites using this must leave off tags.WIN.
+
+/** The shell shim. `open` detaches the child with stdio ignored, so record to a file, not stdout. */
+const SHIM_SCRIPT = [
+	'#!/bin/sh',
+	'# Installed by browserLaunchShim.ts. Stands in for the OS browser opener so an SDK-owned',
+	'# OAuth flow can be intercepted; records argv and exits without launching anything.',
+	'printf \'%s\\n\' "$@" >> "$E2E_BROWSER_SHIM_CAPTURE"',
+	'exit 0',
+	'',
+].join('\n');
+
+export interface BrowserLaunchShim {
+	/**
+	 * Environment to merge into the launched app via `test.use({ extraEnv })`. Prepends the
+	 * shim directory to PATH and points the shim at its capture file.
+	 */
+	readonly env: Record<string, string>;
+
+	/**
+	 * Discards anything a previous arm captured. Call this *before* the action that triggers
+	 * the browser launch, so a URL from an earlier step cannot satisfy the next wait.
+	 */
+	arm(): void;
+
+	/**
+	 * Waits for a captured URL matching `pattern` and returns it.
+	 *
+	 * @param pattern Matched against each captured argument.
+	 * @param timeout How long to wait for a match (default 60s -- this covers app startup and
+	 * the driver's connect, which is slower than the in-process patch externalUrl.ts uses).
+	 */
+	waitForUrl(pattern: RegExp, timeout?: number): Promise<string>;
+
+	/** Removes the shim directory. Safe to call more than once. */
+	dispose(): void;
+}
+
+/**
+ * Creates the shim on disk and returns a handle to it.
+ *
+ * Call this at module scope in the test file: `test.use({ extraEnv })` is evaluated when the
+ * file is collected, so the PATH value has to exist by then. Each worker imports the file
+ * separately and so gets its own directory, which is what we want -- two workers sharing one
+ * capture file would read each other's URLs.
+ */
+export function createBrowserLaunchShim(): BrowserLaunchShim {
+	const dir = mkdtempSync(join(tmpdir(), 'e2e-browser-shim-'));
+	const capture = join(dir, 'captured-urls.txt');
+
+	// Both names, so one shim covers macOS and Linux without branching on platform.
+	for (const name of ['open', 'xdg-open']) {
+		const shimPath = join(dir, name);
+		writeFileSync(shimPath, SHIM_SCRIPT);
+		chmodSync(shimPath, 0o755);
+	}
+
+	return {
+		env: {
+			PATH: `${dir}${delimiter}${process.env.PATH ?? ''}`,
+			E2E_BROWSER_SHIM_CAPTURE: capture,
+		},
+
+		arm(): void {
+			rmSync(capture, { force: true });
+		},
+
+		async waitForUrl(pattern: RegExp, timeout = 60_000): Promise<string> {
+			let match: string | undefined;
+
+			await expect.poll(() => {
+				if (!existsSync(capture)) {
+					return false;
+				}
+				match = readFileSync(capture, 'utf-8')
+					.split('\n')
+					.map(line => line.trim())
+					.find(line => pattern.test(line));
+				return match !== undefined;
+			}, {
+				timeout,
+				// Do not report what was captured on failure: these URLs carry auth state.
+				message: `Timed out waiting for a shimmed browser launch matching ${pattern}`,
+			}).toBe(true);
+
+			return match!;
+		},
+
+		dispose(): void {
+			rmSync(dir, { recursive: true, force: true });
+		},
+	};
+}

--- a/test/e2e/utils/databricksOAuth.ts
+++ b/test/e2e/utils/databricksOAuth.ts
@@ -3,8 +3,9 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect, Locator, Page } from '@playwright/test';
+import { Browser, BrowserContext, chromium, expect, Locator, Page } from '@playwright/test';
 import { Logger } from '../infra/logger.js';
+import { BrowserLaunchShim } from './browserLaunchShim.js';
 import { generateTOTP } from './totp.js';
 import { isOktaLockedOut, otpRetryDelayMs } from './otpRetry.js';
 
@@ -17,6 +18,9 @@ import { isOktaLockedOut, otpRetryDelayMs } from './otpRetry.js';
 //   - Positron Desktop's Databricks LLM provider hands the URL to the system browser via
 //     vscode.env.openExternal, so the e2e test intercepts it and replays it in a browser
 //     it controls (see modelProviderShared.ts).
+//   - The data connections Databricks driver hands off to @databricks/sql, which runs its own
+//     OAuth and launches the browser through the `open` npm package -- intercepted with a PATH
+//     shim instead (see completeDatabricksSdkOAuth below).
 //
 // Everything between "we are on the workspace login page" and "the provider redirected
 // back to the callback" is identical, and that is what lives here.
@@ -174,4 +178,78 @@ export async function completeDatabricksOktaSignIn(page: Page, options: Databric
 	}
 
 	return false;
+}
+
+/**
+ * Completes the Databricks OAuth sign-in for a flow the *SDK* runs, rather than one Positron
+ * runs -- currently the data connections driver's OAuth User-to-Machine mechanism.
+ *
+ * The distinction matters because it decides where the authorize URL is intercepted. The
+ * assistant's Databricks provider is Positron's own OAuth, so its URL is captured by patching
+ * `shell.openExternal` (see completeDatabricksLoopbackOAuth in modelProviderShared.ts). Here
+ * the driver only hands connection options to @databricks/sql, which runs authorization code
+ * + PKCE itself against its own loopback server on port 8030 and launches the browser through
+ * the `open` npm package -- nothing goes through Positron's opener service. So the capture
+ * point is a PATH shim instead; see browserLaunchShim.ts.
+ *
+ * `trigger` must be the action that establishes the connection, and note that it does *not*
+ * resolve until sign-in completes: the driver connects eagerly, and Positron only calls it
+ * lazily on the first expand of the connection entry, inside the tree's _fetchChildren. So the
+ * trigger is started and deliberately left pending while the browser leg runs, then awaited at
+ * the end. Awaiting it up front would deadlock.
+ *
+ * @param shim The armed PATH shim capturing the SDK's browser launch.
+ * @param trigger Starts the connect (expands the connection entry). Started, not awaited.
+ * @param options.logger Where to report progress; callers pass `code.logger`.
+ * @param options.headless Whether to run the OAuth browser headless. Defaults to false,
+ * matching the other IdP flows: these pages are not reliably renderable headless.
+ */
+export async function completeDatabricksSdkOAuth(
+	shim: BrowserLaunchShim,
+	trigger: () => Promise<void>,
+	options: { logger: Logger; headless?: boolean }
+): Promise<void> {
+	const { logger, headless = false } = options;
+
+	shim.arm();
+
+	// Start the connect and leave it pending. Attach a no-op catch now so that a failure while
+	// we are busy with the browser does not surface as an unhandled rejection; the awaited
+	// `pending` below is what actually reports it.
+	const pending = trigger();
+	pending.catch(() => { /* reported by the await at the end */ });
+
+	// The workspace's OIDC authorize endpoint. The SDK uses /oidc/oauth2/v2.0/authorize, which
+	// is a different endpoint from the /oidc/v1/authorize the assistant's provider discovers,
+	// so match the shared prefix rather than either exact path.
+	const authorizeUrl = await shim.waitForUrl(/\/oidc\/.*authorize/);
+
+	// The SDK's own callback (http://localhost:8030 by default -- DatabricksOAuthManager's
+	// defaultCallbackPorts). Landing there is what tells us Databricks completed the handoff.
+	const redirectUri = new URL(authorizeUrl).searchParams.get('redirect_uri');
+	if (!redirectUri) {
+		throw new Error('Databricks authorize URL carried no redirect_uri');
+	}
+	const loopbackHost = new URL(redirectUri).host;
+
+	let browser: Browser | undefined;
+	let context: BrowserContext | undefined;
+	try {
+		browser = await chromium.launch({ headless });
+		context = await browser.newContext();
+		const page = await context.newPage();
+		await page.goto(authorizeUrl);
+		await completeDatabricksOktaSignIn(page, {
+			completionUrl: new RegExp(loopbackHost.replace(/\./g, '\\.')),
+			logger,
+			label: 'DataConnections',
+		});
+	} finally {
+		if (context) { await context.close(); }
+		if (browser) { await browser.close(); }
+	}
+
+	// The SDK's loopback server has the code by now; awaiting the trigger lets the token
+	// exchange, the connect, and the tree's first metadata query finish (or report a failure).
+	await pending;
 }


### PR DESCRIPTION
### Summary

Adds e2e coverage for the data connections Databricks driver's **OAuth User-to-Machine** mechanism: create the connection, browse the catalog tree, and preview a table in the Data Explorer. Companion to #15669, which covered the same provider in the assistant.

**This is not the same OAuth flow, despite looking identical to a user.** The assistant's Databricks provider is Positron's own OAuth, so #15669 captures its authorize URL by patching `shell.openExternal` in the Electron main process. The data connections driver has no such seam: it hands connection options to `@databricks/sql`, which runs authorization code + PKCE itself against its own loopback server and launches the browser through the `open` npm package. Nothing reaches `vscode.env.openExternal`. Confirmed empirically -- the captured URL carries `client_id=databricks-sql-connector` and `redirect_uri=http://localhost:8030`, the SDK's `defaultClientId` and `defaultCallbackPorts`, not Positron's.

Two consequences, one of them convenient:

- The URL is captured with a **PATH shim** instead (`test/e2e/utils/browserLaunchShim.ts`). `open` spawns `open` / `xdg-open` without a shell, and skips its bundled copy whenever `process.versions.electron` is set -- which it is in the extension host -- so PATH decides which binary runs. The shim records argv and exits, so nothing spawns a real browser on a CI machine. `OAuthManager.getTokenU2M` never passes the SDK's own `openAuthUrl` override, so there is no in-process seam to use instead.
- **None of #15669's link-protection work is load-bearing here.** Nothing goes through the opener service, so the trusted-domains validator never runs and no `product.json` change is needed.

**Connection timing.** Saving only persists the profile. The driver connects eagerly, but Positron only calls it lazily on the first expand of the connection entry, inside the tree's `_fetchChildren` (`dataConnectionsTreeInstance.tsx`). So the expand *is* the sign-in, and it does not resolve until OAuth completes -- `completeDatabricksSdkOAuth` starts it, leaves it pending while driving the browser, then awaits it. Awaiting it up front would deadlock.

**Shared Okta flow.** The browser leg is genuinely identical to the assistant's and is reused unchanged from `test/e2e/utils/databricksOAuth.ts` -- SSO hop, credentials, TOTP with jittered backoff, the two Databricks consent screens. Only the capture point and the trigger differ. (The SDK uses `/oidc/oauth2/v2.0/authorize` rather than the `/oidc/v1/authorize` the assistant discovers, so the URL pattern matches the shared prefix.)

**Secrets.** Adds `DATABRICKS_HTTP_PATH`, the SQL warehouse in the workspace `DATABRICKS_URL` already points at, stored as a field on the existing `Databricks-WB-Auto` item. A warehouse id is not a credential, but it is meaningless without its workspace and is kept alongside it so the two rotate together. The suite skips with a stated reason where the secrets are absent, following the Redshift convention.

**Also runs the OAuth tests on PRs (second commit).** #15669 put the OAuth secrets on the merge lane (`test-e2e-ubuntu-run.yml`) only, so the assistant's Databricks OAuth test has been silently skipping on every PR since it landed -- and this suite would have done the same. The first CI run on this PR shows both: its OAuth case skipped while its API-key case passed, the latter because `DATABRICKS_WORKSPACE`/`DATABRICKS_PAT` are plain repo secrets available on the PR lane.

A PR carrying `@:connections` or `@:assistant` should run those tests rather than skip them, so the same secrets are now loaded in `test-e2e-ubuntu.yml`. That means the shared TOTP secret is exercised by PR runs carrying those tags -- deliberate, and the tradeoff for tags that mean what they say. `otpRetry.ts` already exists for exactly this contention: its own comment notes the account is shared across parallel shards and workflows, and it backs off with jitter to de-align competing consumers. The Windows lane needs no change; neither suite is tagged `@:win`.

**TOTP budget.** Sign-in happens once in `beforeAll`, so the suite spends exactly one code no matter how many tests it grows. Each run does sign in fresh -- the SDK's token cache does not survive the throwaway user-data-dir -- so this adds one consumer per CI run to a secret already shared with the assistant Databricks test and the Workbench managed-credentials lane. If Okta lockouts appear after this lands, the mechanism is two suites racing for the same 30-second window, and the fix is scheduling rather than the retry logic.

### Tags

Deliberately narrower than the sibling Redshift suite, for technical reasons rather than TOTP ones:

- **No `@:web` / `@:workbench`** -- the shim reaches the extension host via `extraEnv`, which only the Electron launch path applies (`infra/electron.ts`). `playwrightBrowser.ts` and `playwrightExternalServer.ts` build the server env from `process.env` alone, so the shim would be silently ignored and a real browser would launch. Plumbing `extraEnv` through those paths would make a web variant possible; that is a reasonable follow-up.
- **No `@:win`** -- `open` invokes PowerShell by absolute path and never consults PATH, so there is nothing to put ourselves ahead of.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:connections @:assistant @:workbench

`@:connections` covers the new suite. `@:assistant` and `@:workbench` are the regression surface: this PR adds to `databricksOAuth.ts`, whose existing `completeDatabricksOktaSignIn` both of those lanes already drive. That function is unmodified, but it is worth proving.

Verified locally on `e2e-electron` across **four consecutive full runs, 3 passed each** (~50s per run), against the real workspace with a real Okta sign-in. TOTP accepted on attempt 1/3 every time. An earlier probe confirmed the capture mechanism in isolation before any test was built on it.

The final run used the value stored in 1Password rather than a canonical path supplied by hand, so it also covers `parseDatabricksHttpPath` rewriting the UI's `/sql/warehouses/` to the API's `/sql/1.0/warehouses/` and preserving the `?o=` workspace query.

Note the assertion on the Data Explorer is the table's column count (88) rather than a snapshot of all 88 names: the `samples` dataset is Databricks' to change, and this suite's subject is the OAuth connection. The Redshift suite covers column-level Data Explorer fidelity in depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
