### PR TITLE
Move the Configure LLM Providers modal to the dynamic modal dialog

### DIFF
--- a/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.css
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.css
@@ -7,7 +7,6 @@
 	display: flex;
 	flex-direction: column;
 	gap: 16px;
-	height: 100%;
 }
 
 .connect-provider-header {

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.css
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.css
@@ -99,7 +99,6 @@
 	display: flex;
 	flex-direction: column;
 	gap: 2px;
-	flex-grow: 1;
 }
 
 .connect-provider-detail-label {

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.css
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.css
@@ -54,10 +54,6 @@
 	color: var(--vscode-descriptionForeground);
 }
 
-.connect-provider-divider {
-	border-top: 1px solid var(--vscode-widget-border, rgba(128, 128, 128, 0.2));
-}
-
 .connect-provider-banner {
 	display: flex;
 	align-items: center;
@@ -163,8 +159,6 @@
 }
 
 .connect-provider-notice {
-	border-top: 1px solid var(--vscode-widget-border, rgba(128, 128, 128, 0.2));
-	padding-top: 12px;
 	font-size: 12px;
 	color: var(--vscode-descriptionForeground);
 }

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
@@ -329,7 +329,6 @@ export const ConnectProviderView = (props: ConnectProviderViewProps) => {
 			title={props.title}
 			width={props.width}
 			onCancel={() => props.renderer.dispose()}
-			onSubmit={onConnect}
 		/>
 	);
 };

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
@@ -155,10 +155,14 @@ export const ConnectProviderView = (props: ConnectProviderViewProps) => {
 	const cancelSignInRef = useRef(cancelSignIn);
 	cancelSignInRef.current = cancelSignIn;
 
-	// While an OAuth sign-in is in progress, report a cancel handler so dismissing
-	// the modal aborts the flow, and clear it once the sign-in finishes. The modal
-	// clears it on leaving this view; an unmount cleanup here would also run when the
-	// dialog closes, wiping the handler before the close could use it.
+
+	// While an OAuth sign-in is in progress, register the cancellation function
+	// with the modal controller (showConfigureLLMProvidersModal). It uses this
+	// function when the user tries to close the modal via the Escape key or the
+	// close button.
+	// We do not want to clear the cancellation function reference for the modal
+	// controller (useEffect cleanup) because we want the modal controller to do
+	// the actual cancellation if needed, even after this component unmounts.
 	const onPendingSignInChange = props.onPendingSignInChange;
 	useEffect(() => {
 		const signInPending = authMethod === AuthMethod.OAUTH && inFlight;

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
@@ -13,7 +13,8 @@ import { IPositronCustomModel, IPositronLanguageModelConfig, IPositronLanguageMo
 import { AuthMethod, AuthStatus } from '../types.js';
 import { availableAuthMethods, deriveAuthMethod, deriveAuthStatus, deriveConnectAction } from '../providerConnection.js';
 import { getProviderGettingStartedText, getProviderTermsOfServiceText, getProviderUsageDisclaimerText } from '../providerLegalText.js';
-import { ContentArea } from '../../../../browser/positronComponents/positronModalDialog/components/contentArea.js';
+import { PositronDynamicModalDialog } from '../../../../browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.js';
+import { PositronModalReactRenderer } from '../../../../../base/browser/positronModalReactRenderer.js';
 import { DropDownListBox } from '../../../../browser/positronComponents/dropDownListBox/dropDownListBox.js';
 import { DropDownListBoxItem } from '../../../../browser/positronComponents/dropDownListBox/dropDownListBoxItem.js';
 import { LanguageModelIcon } from './languageModelButton.js';
@@ -61,12 +62,16 @@ const CUSTOM_MODEL_DEFAULTS = {
 } satisfies Omit<IPositronCustomModel, 'id' | 'name'>;
 
 export interface ConnectProviderViewProps {
+	/** The renderer this view draws its dialog box into. */
+	renderer: PositronModalReactRenderer;
+	/** The dialog title, computed by the modal so every view titles itself the same way. */
+	title: string;
+	/** The dialog width, set by the modal so every view is the same size. */
+	width: number;
 	source: IPositronLanguageModelSource;
 	onAction: (source: IPositronLanguageModelSource, config: IPositronLanguageModelConfig, action: string) => Promise<void>;
 	/** Invoked by the footer Back button. */
 	onBack: () => void;
-	/** Invoked by the footer Close button. */
-	onClose: () => void;
 	/**
 	 * Report a way to cancel an in-flight OAuth sign-in (or `undefined` when none
 	 * is pending), so dismissing the modal aborts the device flow instead of
@@ -151,13 +156,14 @@ export const ConnectProviderView = (props: ConnectProviderViewProps) => {
 	cancelSignInRef.current = cancelSignIn;
 
 	// While an OAuth sign-in is in progress, report a cancel handler so dismissing
-	// the modal aborts the flow; clear it otherwise and when this view unmounts.
+	// the modal aborts the flow, and clear it once the sign-in finishes. The modal
+	// clears it on leaving this view; an unmount cleanup here would also run when the
+	// dialog closes, wiping the handler before the close could use it.
 	const onPendingSignInChange = props.onPendingSignInChange;
 	useEffect(() => {
 		const signInPending = authMethod === AuthMethod.OAUTH && inFlight;
 		onPendingSignInChange?.(signInPending ? () => cancelSignInRef.current() : undefined);
 	}, [onPendingSignInChange, authMethod, inFlight]);
-	useEffect(() => () => onPendingSignInChange?.(undefined), [onPendingSignInChange]);
 
 	const cancelButton = props.source.status === 'error' ? {
 		title: pending === 'remove'
@@ -182,8 +188,8 @@ export const ConnectProviderView = (props: ConnectProviderViewProps) => {
 	} : undefined;
 
 	return (
-		<>
-			<ContentArea>
+		<PositronDynamicModalDialog
+			content={
 				<div className='connect-provider-view' data-testid='provider-connect-view'>
 					<ConnectProviderHeader source={props.source} />
 					{methods.length > 1 && !props.source.signedIn &&
@@ -301,24 +307,30 @@ export const ConnectProviderView = (props: ConnectProviderViewProps) => {
 						</div>
 					}
 					{errorMessage && <ProviderErrorBanner message={errorMessage} />}
-					<div style={{ flexGrow: 1 }}>&nbsp;</div>
 					<ProviderNotice source={props.source} />
 				</div>
-			</ContentArea>
-			<ProviderModalFooter
-				cancelButton={cancelButton}
-				primaryButton={{
-					title: pending === 'connect'
-						? localize('positron.connectProvider.connecting', "Connecting...")
-						: localize('positron.connectProvider.connect', "Connect"),
-					disable: connectDisabled || inFlight,
-					loading: pending === 'connect',
-					onClick: onConnect,
-				}}
-				onBack={props.onBack}
-				onClose={props.onClose}
-			/>
-		</>
+			}
+			footer={
+				<ProviderModalFooter
+					cancelButton={cancelButton}
+					primaryButton={{
+						title: pending === 'connect'
+							? localize('positron.connectProvider.connecting', "Connecting...")
+							: localize('positron.connectProvider.connect', "Connect"),
+						disable: connectDisabled || inFlight,
+						loading: pending === 'connect',
+						submit: true,
+						onClick: onConnect,
+					}}
+					onBack={props.onBack}
+				/>
+			}
+			renderer={props.renderer}
+			title={props.title}
+			width={props.width}
+			onCancel={() => props.renderer.dispose()}
+			onSubmit={onConnect}
+		/>
 	);
 };
 

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
@@ -155,14 +155,10 @@ export const ConnectProviderView = (props: ConnectProviderViewProps) => {
 	const cancelSignInRef = useRef(cancelSignIn);
 	cancelSignInRef.current = cancelSignIn;
 
-
-	// While an OAuth sign-in is in progress, register the cancellation function
-	// with the modal controller (showConfigureLLMProvidersModal). It uses this
-	// function when the user tries to close the modal via the Escape key or the
-	// close button.
-	// We do not want to clear the cancellation function reference for the modal
-	// controller (useEffect cleanup) because we want the modal controller to do
-	// the actual cancellation if needed, even after this component unmounts.
+	// While an OAuth sign-in is in progress, report a cancel handler so dismissing
+	// the modal aborts the flow, and clear it once the sign-in finishes. The modal
+	// clears it on leaving this view; an unmount cleanup here would also run when the
+	// dialog closes, wiping the handler before the close could use it.
 	const onPendingSignInChange = props.onPendingSignInChange;
 	useEffect(() => {
 		const signInPending = authMethod === AuthMethod.OAUTH && inFlight;

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
@@ -151,14 +151,13 @@ export const ConnectProviderView = (props: ConnectProviderViewProps) => {
 	const cancelSignInRef = useRef(cancelSignIn);
 	cancelSignInRef.current = cancelSignIn;
 
-	// Keep track of whether an OAuth sign-in is currently in progress so the
-	// unmount cleanup can cancel it using the latest state.
+	// Whether an OAuth sign-in is running, read by the unmount cleanup below.
 	const oauthSignInInProgressRef = useRef(false);
 	oauthSignInInProgressRef.current = authMethod === AuthMethod.OAUTH && inFlight;
 
-	// Cancel an OAuth sign-in if this view is unmounted while the sign-in is still
-	// in progress. This handles the modal being dismissed via Escape or its close
-	// button, as well as any other way this view might be unmounted.
+	// Every way out of this view unmounts it: Back, the title bar close button, and
+	// Escape, which the browser handles itself without going through React. Hanging
+	// the cancel off the unmount covers all of them once.
 	useEffect(() => {
 		return () => {
 			if (oauthSignInInProgressRef.current) {
@@ -166,14 +165,6 @@ export const ConnectProviderView = (props: ConnectProviderViewProps) => {
 			}
 		};
 	}, []);
-
-	// When the user navigates back from the connect view, cancel any in-flight OAuth sign-in.
-	const handleBack = () => {
-		if (oauthSignInInProgressRef.current) {
-			cancelSignInRef.current();
-		}
-		props.onBack();
-	};
 
 	const removeButton = props.source.status === 'error' ? {
 		title: pending === 'remove'
@@ -332,7 +323,7 @@ export const ConnectProviderView = (props: ConnectProviderViewProps) => {
 						onClick: onConnect,
 					}}
 					secondaryButton={removeButton}
-					onBack={handleBack}
+					onBack={props.onBack}
 				/>
 			}
 			renderer={props.renderer}

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
@@ -73,12 +73,6 @@ export interface ConnectProviderViewProps {
 	/** Invoked by the footer Back button. */
 	onBack: () => void;
 	/**
-	 * Report a way to cancel an in-flight OAuth sign-in (or `undefined` when none
-	 * is pending), so dismissing the modal aborts the device flow instead of
-	 * orphaning it.
-	 */
-	onPendingSignInChange?: (cancel: (() => void) | undefined) => void;
-	/**
 	 * Open providers.json for advanced editing. Closes the modal (so the editor
 	 * is visible), which discards any unsaved form input, so the affordance says
 	 * as much. Only wired for the custom provider create flow.
@@ -149,21 +143,37 @@ export const ConnectProviderView = (props: ConnectProviderViewProps) => {
 		? authStatus === AuthStatus.SIGNING_IN
 		: authStatus !== AuthStatus.SIGN_IN_PENDING;
 
-	// Cancel an in-flight OAuth sign-in (the Posit device flow). Kept in a ref so
-	// the reported handler stays stable while dispatching against the latest state.
-	const cancelSignIn = () => { props.onAction(props.source, configRef.current, 'cancel'); };
+	// Cancel an in-flight OAuth sign-in.
+	const cancelSignIn = () => {
+		props.onAction(props.source, configRef.current, 'cancel');
+	};
+
 	const cancelSignInRef = useRef(cancelSignIn);
 	cancelSignInRef.current = cancelSignIn;
 
-	// While an OAuth sign-in is in progress, report a cancel handler so dismissing
-	// the modal aborts the flow, and clear it once the sign-in finishes. The modal
-	// clears it on leaving this view; an unmount cleanup here would also run when the
-	// dialog closes, wiping the handler before the close could use it.
-	const onPendingSignInChange = props.onPendingSignInChange;
+	// Keep track of whether an OAuth sign-in is currently in progress so the
+	// unmount cleanup can cancel it using the latest state.
+	const oauthSignInInProgressRef = useRef(false);
+	oauthSignInInProgressRef.current = authMethod === AuthMethod.OAUTH && inFlight;
+
+	// Cancel an OAuth sign-in if this view is unmounted while the sign-in is still
+	// in progress. This handles the modal being dismissed via Escape or its close
+	// button, as well as any other way this view might be unmounted.
 	useEffect(() => {
-		const signInPending = authMethod === AuthMethod.OAUTH && inFlight;
-		onPendingSignInChange?.(signInPending ? () => cancelSignInRef.current() : undefined);
-	}, [onPendingSignInChange, authMethod, inFlight]);
+		return () => {
+			if (oauthSignInInProgressRef.current) {
+				cancelSignInRef.current();
+			}
+		};
+	}, []);
+
+	// When the user navigates back from the connect view, cancel any in-flight OAuth sign-in.
+	const handleBack = () => {
+		if (oauthSignInInProgressRef.current) {
+			cancelSignInRef.current();
+		}
+		props.onBack();
+	};
 
 	const removeButton = props.source.status === 'error' ? {
 		title: pending === 'remove'
@@ -322,7 +332,7 @@ export const ConnectProviderView = (props: ConnectProviderViewProps) => {
 						onClick: onConnect,
 					}}
 					secondaryButton={removeButton}
-					onBack={props.onBack}
+					onBack={handleBack}
 				/>
 			}
 			renderer={props.renderer}

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
@@ -165,7 +165,7 @@ export const ConnectProviderView = (props: ConnectProviderViewProps) => {
 		onPendingSignInChange?.(signInPending ? () => cancelSignInRef.current() : undefined);
 	}, [onPendingSignInChange, authMethod, inFlight]);
 
-	const cancelButton = props.source.status === 'error' ? {
+	const removeButton = props.source.status === 'error' ? {
 		title: pending === 'remove'
 			? localize('positron.connectedProvider.removing', "Removing...")
 			: localize('positron.connectedProvider.remove', "Remove"),
@@ -312,7 +312,6 @@ export const ConnectProviderView = (props: ConnectProviderViewProps) => {
 			}
 			footer={
 				<ProviderModalFooter
-					cancelButton={cancelButton}
 					primaryButton={{
 						title: pending === 'connect'
 							? localize('positron.connectProvider.connecting', "Connecting...")
@@ -322,6 +321,7 @@ export const ConnectProviderView = (props: ConnectProviderViewProps) => {
 						submit: true,
 						onClick: onConnect,
 					}}
+					secondaryButton={removeButton}
 					onBack={props.onBack}
 				/>
 			}

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/connectedProviderView.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/connectedProviderView.tsx
@@ -13,17 +13,22 @@ import { IPositronLanguageModelConfig, IPositronLanguageModelSource, LanguageMod
 import { AuthMethod } from '../types.js';
 import { deriveAuthMethod, deriveDisconnectAction } from '../providerConnection.js';
 import { getBaseUrlLabel } from '../providerFieldLabels.js';
-import { ContentArea } from '../../../../browser/positronComponents/positronModalDialog/components/contentArea.js';
+import { PositronDynamicModalDialog } from '../../../../browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.js';
+import { PositronModalReactRenderer } from '../../../../../base/browser/positronModalReactRenderer.js';
 import { ConnectProviderHeader, ProviderErrorBanner, ProviderNotice } from './connectProviderView.js';
 import { ProviderModalFooter } from './providerModalFooter.js';
 
 export interface ConnectedProviderViewProps {
+	/** The renderer this view draws its dialog box into. */
+	renderer: PositronModalReactRenderer;
+	/** The dialog title, computed by the modal so every view titles itself the same way. */
+	title: string;
+	/** The dialog width, set by the modal so every view is the same size. */
+	width: number;
 	source: IPositronLanguageModelSource;
 	onAction: (source: IPositronLanguageModelSource, config: IPositronLanguageModelConfig, action: string) => Promise<void>;
 	/** Invoked by the footer Back button. */
 	onBack: () => void;
-	/** Invoked by the footer Close button. */
-	onClose: () => void;
 }
 
 export const ConnectedProviderView = (props: ConnectedProviderViewProps) => {
@@ -79,14 +84,14 @@ export const ConnectedProviderView = (props: ConnectedProviderViewProps) => {
 		?? localize('positron.connectedProvider.error', "This provider reported a problem with its configuration or credentials.");
 
 
-	const title = authMethod === AuthMethod.OAUTH ? localize('positron.connectedProvider.signOut', "Sign Out") : localize('positron.connectedProvider.remove', "Remove");
-	const loadingTitle = authMethod === AuthMethod.OAUTH
+	const actionTitle = authMethod === AuthMethod.OAUTH ? localize('positron.connectedProvider.signOut', "Sign Out") : localize('positron.connectedProvider.remove', "Remove");
+	const actionLoadingTitle = authMethod === AuthMethod.OAUTH
 		? localize('positron.connectedProvider.signingOut', "Signing Out...")
 		: localize('positron.connectedProvider.removing', "Removing...");
 
 	return (
-		<>
-			<ContentArea>
+		<PositronDynamicModalDialog
+			content={
 				<div className='connect-provider-view' data-testid='provider-connected-view'>
 					<ConnectProviderHeader source={current} subtitle={subtitle} />
 					<div className='connect-provider-divider' />
@@ -111,17 +116,22 @@ export const ConnectedProviderView = (props: ConnectedProviderViewProps) => {
 					<ProviderNotice source={current} />
 					{errorMessage && <div className='connect-provider-error'>{errorMessage}</div>}
 				</div>
-			</ContentArea>
-			<ProviderModalFooter
-				primaryButton={isAutoAuth ? undefined : {
-					title: pending ? loadingTitle : title,
-					disable: pending,
-					loading: pending,
-					onClick: onSignOut,
-				}}
-				onBack={props.onBack}
-				onClose={props.onClose}
-			/>
-		</>
+			}
+			footer={
+				<ProviderModalFooter
+					primaryButton={isAutoAuth ? undefined : {
+						title: pending ? actionLoadingTitle : actionTitle,
+						disable: pending,
+						loading: pending,
+						onClick: onSignOut,
+					}}
+					onBack={props.onBack}
+				/>
+			}
+			renderer={props.renderer}
+			title={props.title}
+			width={props.width}
+			onCancel={() => props.renderer.dispose()}
+		/>
 	);
 };

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/connectedProviderView.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/connectedProviderView.tsx
@@ -94,7 +94,6 @@ export const ConnectedProviderView = (props: ConnectedProviderViewProps) => {
 			content={
 				<div className='connect-provider-view' data-testid='provider-connected-view'>
 					<ConnectProviderHeader source={current} subtitle={subtitle} />
-					<div className='connect-provider-divider' />
 					{hasError && <ProviderErrorBanner message={errorBannerMessage} />}
 					{isCopilot && isAutoAuth &&
 						<EmbeddedLink>

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/connectedProviderView.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/connectedProviderView.tsx
@@ -99,19 +99,15 @@ export const ConnectedProviderView = (props: ConnectedProviderViewProps) => {
 						<EmbeddedLink>
 							{localize('positron.connectedProvider.copilotSignOut', "To sign out of GitHub, use the [Accounts: Manage Accounts]({0}) command. This signs you out of GitHub for every extension in Positron.", 'command:workbench.action.manageAccounts')}
 						</EmbeddedLink>
-
 					}
-					<p className='connect-provider-detail'>
-						{current.supportedOptions.includes('baseUrl') && current.defaults.baseUrl &&
-							<>
-								<span className='connect-provider-detail-label'>
-									{getBaseUrlLabel(current.provider.id)}
-								</span>
-								<span className='connect-provider-detail-value'>{current.defaults.baseUrl}</span>
-							</>
-						}
-					</p>
-
+					{current.supportedOptions.includes('baseUrl') && current.defaults.baseUrl &&
+						<p className='connect-provider-detail' data-testid='provider-base-url'>
+							<span className='connect-provider-detail-label'>
+								{getBaseUrlLabel(current.provider.id)}
+							</span>
+							<span className='connect-provider-detail-value'>{current.defaults.baseUrl}</span>
+						</p>
+					}
 					<ProviderNotice source={current} />
 					{errorMessage && <div className='connect-provider-error'>{errorMessage}</div>}
 				</div>

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/providerListItem.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/providerListItem.tsx
@@ -7,8 +7,6 @@ import { localize } from '../../../../../nls.js';
 import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
 import { IPositronLanguageModelSource, LanguageModelAutoconfigureType } from '../../common/interfaces/positronAssistantService.js';
 import { ProviderSectionId } from '../../common/providerGrouping.js';
-import { deriveAuthMethod } from '../providerConnection.js';
-import { AuthMethod } from '../types.js';
 import { LanguageModelIcon, getStatusLabel } from './languageModelButton.js';
 
 interface ProviderListItemProps {
@@ -21,7 +19,7 @@ interface ProviderListItemProps {
 	onAction?: () => void;
 }
 
-/** How a connected provider authenticated, shown as a badge. */
+/** Where an autoconfigured provider's credentials came from, shown as a badge. */
 function authBadgeLabel(source: IPositronLanguageModelSource): string | undefined {
 	const autoconfigure = source.defaults.autoconfigure;
 	if (autoconfigure?.type === LanguageModelAutoconfigureType.EnvVariable && autoconfigure.signedIn) {
@@ -30,9 +28,6 @@ function authBadgeLabel(source: IPositronLanguageModelSource): string | undefine
 	if (autoconfigure?.type === LanguageModelAutoconfigureType.Custom && autoconfigure.signedIn &&
 		autoconfigure.isPositWorkbench) {
 		return localize('positron.configureLLMProvidersModal.badge.pwbManaged', "PWB Managed");
-	}
-	if (deriveAuthMethod(source) === AuthMethod.OAUTH) {
-		return localize('positron.configureLLMProvidersModal.badge.oauth', "OAuth");
 	}
 	return undefined;
 }

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/providerModalFooter.css
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/providerModalFooter.css
@@ -3,15 +3,18 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-/* Matches the dynamic modal dialog's own three-button footer. Scoped to that
-dialog's box because FooterButton's colors and sizing are scoped there too. */
+/* Matches the dynamic modal dialog's own three-button footer in its bordered
+form, so this footer sits at the same height as the Add Data Connection wizard's.
+Scoped to the dialog's box because FooterButton's colors and sizing are too. The
+rule above the buttons is the only one below the title bar: the views draw none
+of their own. */
 .positron-dynamic-modal-dialog-box .provider-modal-footer {
-	height: 48px;
 	display: flex;
-	padding: 0 16px;
+	padding: 16px;
 	flex: 0 0 auto;
 	justify-content: space-between;
 	align-items: flex-start;
+	border-top: solid 1px var(--vscode-positronModalDialog-border);
 }
 
 .positron-dynamic-modal-dialog-box .provider-modal-footer .provider-modal-footer-right {

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/providerModalFooter.css
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/providerModalFooter.css
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Matches the dynamic modal dialog's own three-button footer. Scoped to that
+dialog's box because FooterButton's colors and sizing are scoped there too. */
+.positron-dynamic-modal-dialog-box .provider-modal-footer {
+	height: 48px;
+	display: flex;
+	padding: 0 16px;
+	flex: 0 0 auto;
+	justify-content: space-between;
+	align-items: flex-start;
+}
+
+.positron-dynamic-modal-dialog-box .provider-modal-footer .provider-modal-footer-right {
+	gap: 10px;
+	display: flex;
+	align-items: flex-start;
+}
+
+/* Lay out the in-button spinner beside the label, and keep a longer in-flight
+label (e.g. "Signing Out...") on one line. Sizing and centering come from
+footerButton.css and the shared .dialog-button rule. */
+.positron-dynamic-modal-dialog-box .provider-modal-footer .footer-button {
+	gap: 6px;
+	white-space: nowrap;
+}

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/providerModalFooter.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/providerModalFooter.tsx
@@ -3,30 +3,90 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+// CSS.
+import './providerModalFooter.css';
+
+// Other dependencies.
 import { localize } from '../../../../../nls.js';
-import { ActionBarButtonConfig, OKCancelBackNextActionBar } from '../../../../browser/positronComponents/positronModalDialog/components/okCancelBackNextActionBar.js';
+import * as platform from '../../../../../base/common/platform.js';
+import { FooterButton } from '../../../../browser/positronComponents/positronDynamicModalDialog/components/footerButton.js';
 
-export interface ProviderModalFooterProps {
-	/** Renders a Back button (returning to the provider list) when provided. */
-	onBack?: () => void;
-	/** Invoked by the Close button. */
-	onClose: () => void;
-	/** The view's primary action button, if it has one. */
-	primaryButton?: ActionBarButtonConfig;
-	/** The view's optional cancel button configuration. */
-	cancelButton?: ActionBarButtonConfig;
-
+/**
+ * ProviderFooterButtonConfig interface.
+ */
+export interface ProviderFooterButtonConfig {
+	title: string;
+	disable?: boolean;
+	/** When true, the button shows an in-button spinner and is disabled. */
+	loading?: boolean;
+	/**
+	 * When true, this button becomes the dialog form's submit target, so pressing
+	 * Enter in a field activates it. Only one button per footer may set this.
+	 */
+	submit?: boolean;
+	onClick: () => void;
 }
 
 /**
- * The footer action bar shared by the Configure LLM Providers modal views:
- * an optional Back button, a Close button, and the view's optional primary
- * action button, which reads the view's own state directly.
+ * ProviderModalFooterProps interface.
  */
-export const ProviderModalFooter = ({ onBack, onClose, primaryButton, cancelButton }: ProviderModalFooterProps) => (
-	<OKCancelBackNextActionBar
-		backButtonConfig={onBack ? { onClick: onBack } : undefined}
-		cancelButtonConfig={cancelButton ?? { title: localize('positron.configureLLMProvidersModal.close', "Close"), onClick: onClose }}
-		nextButtonConfig={primaryButton}
-	/>
-);
+export interface ProviderModalFooterProps {
+	/** Renders a Back button (returning to the provider list) when provided. */
+	onBack?: () => void;
+	/** The view's primary action button, if it has one. */
+	primaryButton?: ProviderFooterButtonConfig;
+	/** The view's optional secondary button, e.g. Remove on an errored provider. */
+	cancelButton?: ProviderFooterButtonConfig;
+}
+
+/**
+ * Renders one footer button from its config, showing a spinner (and forcing the
+ * disabled state) while the button's action is loading.
+ */
+const footerButton = (config: ProviderFooterButtonConfig | undefined, isDefault: boolean) => {
+	if (!config) {
+		return null;
+	}
+	return (
+		<FooterButton
+			default={isDefault}
+			disabled={(config.disable ?? false) || (config.loading ?? false)}
+			type={config.submit ? 'submit' : 'button'}
+			onPressed={config.onClick}
+		>
+			{config.loading && <span aria-hidden='true' className='codicon codicon-loading codicon-modifier-spin' />}
+			{config.title}
+		</FooterButton>
+	);
+};
+
+/**
+ * The footer shared by the Configure LLM Providers modal views: an optional Back
+ * button on the left, and the view's optional secondary and primary buttons on
+ * the right. There is no Close button, because the dialog's title bar carries the
+ * close control.
+ * @param props A ProviderModalFooterProps that contains the component properties.
+ * @returns The rendered component.
+ */
+export const ProviderModalFooter = ({ onBack, primaryButton, cancelButton }: ProviderModalFooterProps) => {
+	const primary = footerButton(primaryButton, true);
+	const secondary = footerButton(cancelButton, false);
+
+	return (
+		<div className='provider-modal-footer'>
+			{onBack
+				? <FooterButton onPressed={onBack}>
+					{localize('positron.configureLLMProvidersModal.back', "Back")}
+				</FooterButton>
+				: <div />
+			}
+			<div className='provider-modal-footer-right'>
+				{/* On Windows, the primary button comes first; on macOS/Linux, the secondary button comes first. */}
+				{platform.isWindows
+					? <>{primary}{secondary}</>
+					: <>{secondary}{primary}</>
+				}
+			</div>
+		</div>
+	);
+};

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/providerModalFooter.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/providerModalFooter.tsx
@@ -35,8 +35,8 @@ export interface ProviderModalFooterProps {
 	onBack?: () => void;
 	/** The view's primary action button, if it has one. */
 	primaryButton?: ProviderFooterButtonConfig;
-	/** The view's optional secondary button, e.g. Remove on an errored provider. */
-	cancelButton?: ProviderFooterButtonConfig;
+	/** A second right-hand button, e.g. Remove on an errored provider. */
+	secondaryButton?: ProviderFooterButtonConfig;
 }
 
 /**
@@ -68,9 +68,9 @@ const footerButton = (config: ProviderFooterButtonConfig | undefined, isDefault:
  * @param props A ProviderModalFooterProps that contains the component properties.
  * @returns The rendered component.
  */
-export const ProviderModalFooter = ({ onBack, primaryButton, cancelButton }: ProviderModalFooterProps) => {
+export const ProviderModalFooter = ({ onBack, primaryButton, secondaryButton }: ProviderModalFooterProps) => {
 	const primary = footerButton(primaryButton, true);
-	const secondary = footerButton(cancelButton, false);
+	const secondary = footerButton(secondaryButton, false);
 
 	return (
 		<div className='provider-modal-footer'>

--- a/src/vs/workbench/contrib/positronAssistant/browser/configureLLMProvidersModal.css
+++ b/src/vs/workbench/contrib/positronAssistant/browser/configureLLMProvidersModal.css
@@ -133,17 +133,3 @@
 	background-color: var(--vscode-button-secondaryHoverBackground);
 }
 
-/* Let the modal's action bar buttons grow to fit longer in-flight labels
-(e.g. "Signing Out...") and lay out the in-button spinner beside the label.
-Scoped to this modal (extra .positron-modal-dialog-box qualifier raises
-specificity above the shared width:80px rule) so other dialogs are unaffected. */
-.configure-llm-providers-modal .positron-modal-dialog-box .ok-cancel-back-action-bar .action-bar-button {
-	width: auto;
-	min-width: 80px;
-	padding: 0 12px;
-	display: inline-flex;
-	gap: 6px;
-	align-items: center;
-	justify-content: center;
-	white-space: nowrap;
-}

--- a/src/vs/workbench/contrib/positronAssistant/browser/configureLLMProvidersModal.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/configureLLMProvidersModal.tsx
@@ -115,6 +115,13 @@ export const ConfigureLLMProviders = (props: ConfigureLLMProvidersProps) => {
 			return;
 		}
 		if (view === 'connect' && signedIn) {
+			// The sign-in succeeded, so drop the cancel handler instead of running it.
+			// The connect view reports the handler while the sign-in is in flight and
+			// clears it when the sign-in settles, but that clear never happens here:
+			// this transition unmounts the view first, so the state update it would
+			// react to lands on an unmounted component. Left set, the handler would
+			// cancel a completed sign-in the next time Back or Close reached it.
+			props.pendingSignIn.cancel = undefined;
 			setView('connected');
 		} else if (view === 'connected' && !signedIn) {
 			setView('list');

--- a/src/vs/workbench/contrib/positronAssistant/browser/configureLLMProvidersModal.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/configureLLMProvidersModal.tsx
@@ -115,13 +115,6 @@ export const ConfigureLLMProviders = (props: ConfigureLLMProvidersProps) => {
 			return;
 		}
 		if (view === 'connect' && signedIn) {
-			// The sign-in succeeded, so drop the cancel handler instead of running it.
-			// The connect view reports the handler while the sign-in is in flight and
-			// clears it when the sign-in settles, but that clear never happens here:
-			// this transition unmounts the view first, so the state update it would
-			// react to lands on an unmounted component. Left set, the handler would
-			// cancel a completed sign-in the next time Back or Close reached it.
-			props.pendingSignIn.cancel = undefined;
 			setView('connected');
 		} else if (view === 'connected' && !signedIn) {
 			setView('list');

--- a/src/vs/workbench/contrib/positronAssistant/browser/configureLLMProvidersModal.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/configureLLMProvidersModal.tsx
@@ -41,15 +41,6 @@ const LIST_CONTENT_MAX_HEIGHT = 412;
 
 type OnAction = (source: IPositronLanguageModelSource, config: IPositronLanguageModelConfig, action: string) => Promise<void>;
 
-/**
- * Where the connect view leaves a way to cancel an OAuth sign-in that is still
- * running. This is a plain object rather than React state because the renderer's
- * teardown has to read it after the component has unmounted.
- */
-export interface PendingSignIn {
-	cancel?: () => void;
-}
-
 export const showConfigureLLMProvidersModal = (
 	sources: IPositronLanguageModelSource[],
 	onAction: OnAction,
@@ -130,8 +121,7 @@ export const ConfigureLLMProviders = (props: ConfigureLLMProvidersProps) => {
 	const selectedSource = sources.find(s => s.provider.id === selectedProviderId);
 	const activeView = (view === 'connect' || view === 'connected') && !selectedSource ? 'list' : view;
 
-	// Disposing runs the teardown the show function installed, which cancels an
-	// in-flight sign-in and reports the modal closed.
+	// Disposing unmounts the React tree and reports the modal closed.
 	const close = () => {
 		props.renderer.dispose();
 	};

--- a/src/vs/workbench/contrib/positronAssistant/browser/configureLLMProvidersModal.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/configureLLMProvidersModal.tsx
@@ -31,10 +31,11 @@ const MODAL_WIDTH = 600;
  * How tall the provider list grows before it scrolls: a section heading plus
  * seven rows, at 52px a row with a 4px gap (20 + 4 + 7 * 52 + 6 * 4). Adding the
  * title bar, the footer and the content padding puts the dialog a little over
- * 500px, which clears the gutters on a 640px-tall window. Nothing caps the
- * dialog itself, so without this the full list would draw a box taller than the
- * window and strand the title bar above the top edge. There is no minimum: a
- * short list shrinks the box, as it does on the connect and connected views.
+ * 500px, which clears the gutters on a 640px-tall window. The box already stops
+ * at the window height less its gutters, so this is not what keeps it on screen;
+ * it stops a long list from stretching the box to fill a tall one. There is no
+ * minimum: a short list shrinks the box, as it does on the connect and connected
+ * views.
  */
 const LIST_CONTENT_MAX_HEIGHT = 412;
 

--- a/src/vs/workbench/contrib/positronAssistant/browser/configureLLMProvidersModal.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/configureLLMProvidersModal.tsx
@@ -7,7 +7,7 @@
 import './configureLLMProvidersModal.css';
 
 // React.
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../nls.js';
@@ -56,25 +56,39 @@ export const showConfigureLLMProvidersModal = (
 	onClose: () => void,
 	options?: IShowLanguageModelConfigOptions,
 ) => {
-	// Disposing the renderer is the one thing every way out of the modal does: the
-	// title bar's close button, and Escape, which the browser handles itself on a
-	// native <dialog> without going through React. So the teardown hangs off the
-	// renderer rather than the component.
-	const pendingSignIn: PendingSignIn = {};
+	// Function to cancel a pending sign-in, if one exists.
+	let cancelPendingSignIn: (() => void) | undefined;
+	// Function to set the cancel callback.
+	const setCancelPendingSignIn = (cancel: (() => void) | undefined) => {
+		cancelPendingSignIn = cancel;
+	};
+	// Function that does the actual cancellation of the pending sign-in, if one exists.
+	const doCancelPendingSignIn = () => {
+		// Save the current cancel function and clear it before invoking it.
+		// We clear the cancel function before invoking it because we don't
+		// want it to be called again accidentally during the cancellation process.
+		const cancel = cancelPendingSignIn;
+		cancelPendingSignIn = undefined;
+		cancel?.();
+	};
+
 	const renderer = new PositronModalReactRenderer({
 		onDisposed: () => {
-			pendingSignIn.cancel?.();
+			// Disposing the modal should cancel any OAuth sign-in that is still running,
+			// regardless of what caused the disposal (esc key, close button, back button, etc).
+			doCancelPendingSignIn();
 			onClose();
 		},
 	});
 	renderer.render(
 		<div className='configure-llm-providers-modal' data-testid='configure-llm-providers-modal'>
 			<ConfigureLLMProviders
-				pendingSignIn={pendingSignIn}
 				preselectedProviderId={options?.preselectedProviderId}
 				renderer={renderer}
 				sources={sources}
 				onAction={onAction}
+				onCancelPendingSignIn={doCancelPendingSignIn}
+				onSetCancelPendingSignIn={setCancelPendingSignIn}
 			/>
 		</div>
 	);
@@ -82,12 +96,14 @@ export const showConfigureLLMProvidersModal = (
 
 export interface ConfigureLLMProvidersProps {
 	renderer: PositronModalReactRenderer;
-	/** Where the connect view's cancel handler is left for the renderer's teardown to find. */
-	pendingSignIn: PendingSignIn;
 	sources: IPositronLanguageModelSource[];
 	/** Provider to open on, skipping the list. Ignored if it is not in `sources`. */
 	preselectedProviderId?: string;
 	onAction: OnAction;
+	/** Cancels an in-flight OAuth sign-in, if one exists. */
+	onCancelPendingSignIn: () => void;
+	/** Sets the cancellation function for an in-flight OAuth sign-in. */
+	onSetCancelPendingSignIn: (cancel: (() => void) | undefined) => void;
 }
 
 export const ConfigureLLMProviders = (props: ConfigureLLMProvidersProps) => {
@@ -139,18 +155,6 @@ export const ConfigureLLMProviders = (props: ConfigureLLMProvidersProps) => {
 	const selectedSource = sources.find(s => s.provider.id === selectedProviderId);
 	const activeView = (view === 'connect' || view === 'connected') && !selectedSource ? 'list' : view;
 
-	// A cancel handler reported by the connect view while an OAuth sign-in is in
-	// flight. Written straight into the shared handle so it does not re-render the
-	// modal as the sign-in progresses.
-	const pendingSignIn = props.pendingSignIn;
-	const setPendingCancel = useCallback((cancel: (() => void) | undefined) => {
-		pendingSignIn.cancel = cancel;
-	}, [pendingSignIn]);
-
-	const cancelPendingSignIn = () => {
-		pendingSignIn.cancel?.();
-	};
-
 	// Disposing runs the teardown the show function installed, which cancels an
 	// in-flight sign-in and reports the modal closed.
 	const close = () => {
@@ -167,8 +171,7 @@ export const ConfigureLLMProviders = (props: ConfigureLLMProvidersProps) => {
 	// Leaving the connect view cancels any sign-in it started and drops the handler,
 	// so a later close does not try to cancel a flow that has already gone.
 	const backToList = () => {
-		cancelPendingSignIn();
-		setPendingCancel(undefined);
+		props.onCancelPendingSignIn();
 		setView('list');
 	};
 
@@ -204,7 +207,7 @@ export const ConfigureLLMProviders = (props: ConfigureLLMProvidersProps) => {
 					onAction={props.onAction}
 					onBack={backToList}
 					onEditRawConfig={editRawConfig}
-					onPendingSignInChange={setPendingCancel}
+					onPendingSignInChange={props.onSetCancelPendingSignIn}
 				/>
 			}
 			{activeView === 'connected' && selectedSource &&

--- a/src/vs/workbench/contrib/positronAssistant/browser/configureLLMProvidersModal.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/configureLLMProvidersModal.tsx
@@ -56,9 +56,10 @@ export const showConfigureLLMProvidersModal = (
 	onClose: () => void,
 	options?: IShowLanguageModelConfigOptions,
 ) => {
-	// Disposing the renderer is the one thing every way out of the modal does, whether
-	// that is the title bar's close button or Escape, and it outlives whichever view
-	// was on screen. So the teardown hangs off the renderer rather than the component.
+	// Disposing the renderer is the one thing every way out of the modal does: the
+	// title bar's close button, and Escape, which the browser handles itself on a
+	// native <dialog> without going through React. So the teardown hangs off the
+	// renderer rather than the component.
 	const pendingSignIn: PendingSignIn = {};
 	const renderer = new PositronModalReactRenderer({
 		onDisposed: () => {

--- a/src/vs/workbench/contrib/positronAssistant/browser/configureLLMProvidersModal.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/configureLLMProvidersModal.tsx
@@ -7,18 +7,16 @@
 import './configureLLMProvidersModal.css';
 
 // React.
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../nls.js';
 import { IPositronLanguageModelConfig, IPositronLanguageModelSource, IShowLanguageModelConfigOptions } from '../common/interfaces/positronAssistantService.js';
-import { PositronModalDialog } from '../../../browser/positronComponents/positronModalDialog/positronModalDialog.js';
-import { ContentArea } from '../../../browser/positronComponents/positronModalDialog/components/contentArea.js';
+import { PositronDynamicModalDialog } from '../../../browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.js';
 import { PositronModalReactRenderer } from '../../../../base/browser/positronModalReactRenderer.js';
 import { ProviderList } from './components/providerList.js';
 import { ConnectProviderView } from './components/connectProviderView.js';
 import { ConnectedProviderView } from './components/connectedProviderView.js';
-import { ProviderModalFooter } from './components/providerModalFooter.js';
 import { selectProviderView } from './providerConnection.js';
 import { useProviderUpdates } from './useProviderUpdates.js';
 import { usePositronReactServicesContext } from '../../../../base/browser/positronReactRendererContext.js';
@@ -26,7 +24,30 @@ import { usePositronReactServicesContext } from '../../../../base/browser/positr
 /** Command that opens providers.json in an editor (registered in the contribution). */
 const OPEN_PROVIDERS_JSON_COMMAND = 'workbench.action.positronAssistant.openAiProviderSettingsJson';
 
+/** The width every view's dialog box is drawn at. */
+const MODAL_WIDTH = 600;
+
+/**
+ * How tall the provider list grows before it scrolls: a section heading plus
+ * seven rows, at 52px a row with a 4px gap (20 + 4 + 7 * 52 + 6 * 4). Adding the
+ * title bar, the footer and the content padding puts the dialog a little over
+ * 500px, which clears the gutters on a 640px-tall window. Nothing caps the
+ * dialog itself, so without this the full list would draw a box taller than the
+ * window and strand the title bar above the top edge. There is no minimum: a
+ * short list shrinks the box, as it does on the connect and connected views.
+ */
+const LIST_CONTENT_MAX_HEIGHT = 412;
+
 type OnAction = (source: IPositronLanguageModelSource, config: IPositronLanguageModelConfig, action: string) => Promise<void>;
+
+/**
+ * Where the connect view leaves a way to cancel an OAuth sign-in that is still
+ * running. This is a plain object rather than React state because the renderer's
+ * teardown has to read it after the component has unmounted.
+ */
+export interface PendingSignIn {
+	cancel?: () => void;
+}
 
 export const showConfigureLLMProvidersModal = (
 	sources: IPositronLanguageModelSource[],
@@ -34,15 +55,25 @@ export const showConfigureLLMProvidersModal = (
 	onClose: () => void,
 	options?: IShowLanguageModelConfigOptions,
 ) => {
-	const renderer = new PositronModalReactRenderer();
+	// Disposing the renderer is the one thing every way out of the modal does: the
+	// title bar's close button, and Escape, which the browser handles itself on a
+	// native <dialog> without going through React. So the teardown hangs off the
+	// renderer rather than the component.
+	const pendingSignIn: PendingSignIn = {};
+	const renderer = new PositronModalReactRenderer({
+		onDisposed: () => {
+			pendingSignIn.cancel?.();
+			onClose();
+		},
+	});
 	renderer.render(
 		<div className='configure-llm-providers-modal' data-testid='configure-llm-providers-modal'>
 			<ConfigureLLMProviders
+				pendingSignIn={pendingSignIn}
 				preselectedProviderId={options?.preselectedProviderId}
 				renderer={renderer}
 				sources={sources}
 				onAction={onAction}
-				onClose={onClose}
 			/>
 		</div>
 	);
@@ -50,11 +81,12 @@ export const showConfigureLLMProvidersModal = (
 
 export interface ConfigureLLMProvidersProps {
 	renderer: PositronModalReactRenderer;
+	/** Where the connect view's cancel handler is left for the renderer's teardown to find. */
+	pendingSignIn: PendingSignIn;
 	sources: IPositronLanguageModelSource[];
 	/** Provider to open on, skipping the list. Ignored if it is not in `sources`. */
 	preselectedProviderId?: string;
 	onAction: OnAction;
-	onClose: () => void;
 }
 
 export const ConfigureLLMProviders = (props: ConfigureLLMProvidersProps) => {
@@ -107,22 +139,20 @@ export const ConfigureLLMProviders = (props: ConfigureLLMProvidersProps) => {
 	const activeView = (view === 'connect' || view === 'connected') && !selectedSource ? 'list' : view;
 
 	// A cancel handler reported by the connect view while an OAuth sign-in is in
-	// flight. Held in a ref (read only at close time) so it does not re-render the
+	// flight. Written straight into the shared handle so it does not re-render the
 	// modal as the sign-in progresses.
-	const pendingCancelRef = useRef<(() => void) | undefined>(undefined);
+	const pendingSignIn = props.pendingSignIn;
 	const setPendingCancel = useCallback((cancel: (() => void) | undefined) => {
-		pendingCancelRef.current = cancel;
-	}, []);
+		pendingSignIn.cancel = cancel;
+	}, [pendingSignIn]);
 
-	// Unmounting the connect view drops its cancel handler, so Back and Close
-	// both cancel an in-flight sign-in before leaving.
 	const cancelPendingSignIn = () => {
-		pendingCancelRef.current?.();
+		pendingSignIn.cancel?.();
 	};
 
+	// Disposing runs the teardown the show function installed, which cancels an
+	// in-flight sign-in and reports the modal closed.
 	const close = () => {
-		cancelPendingSignIn();
-		props.onClose();
 		props.renderer.dispose();
 	};
 
@@ -133,8 +163,11 @@ export const ConfigureLLMProviders = (props: ConfigureLLMProvidersProps) => {
 		close();
 	};
 
+	// Leaving the connect view cancels any sign-in it started and drops the handler,
+	// so a later close does not try to cancel a flow that has already gone.
 	const backToList = () => {
 		cancelPendingSignIn();
+		setPendingCancel(undefined);
 		setView('list');
 	};
 
@@ -145,42 +178,44 @@ export const ConfigureLLMProviders = (props: ConfigureLLMProvidersProps) => {
 			: selectedSource.provider.displayName;
 
 	return (
-		<PositronModalDialog
-			height={500}
-			renderer={props.renderer}
-			title={title}
-			width={600}
-			onCancel={close}
-		>
+		<>
 			{activeView === 'list' &&
-				<>
-					<ContentArea>
+				<PositronDynamicModalDialog
+					content={
 						<ProviderList
 							sources={sources}
 							onSelectProvider={source => { setSelectedProviderId(source.provider.id); setView(selectProviderView(source)); }}
 						/>
-					</ContentArea>
-					<ProviderModalFooter onClose={close} />
-				</>
+					}
+					contentMaxHeight={LIST_CONTENT_MAX_HEIGHT}
+					renderer={props.renderer}
+					title={title}
+					width={MODAL_WIDTH}
+					onCancel={close}
+				/>
 			}
 			{activeView === 'connect' && selectedSource &&
 				<ConnectProviderView
+					renderer={props.renderer}
 					source={selectedSource}
+					title={title}
+					width={MODAL_WIDTH}
 					onAction={props.onAction}
 					onBack={backToList}
-					onClose={close}
 					onEditRawConfig={editRawConfig}
 					onPendingSignInChange={setPendingCancel}
 				/>
 			}
 			{activeView === 'connected' && selectedSource &&
 				<ConnectedProviderView
+					renderer={props.renderer}
 					source={selectedSource}
+					title={title}
+					width={MODAL_WIDTH}
 					onAction={props.onAction}
 					onBack={backToList}
-					onClose={close}
 				/>
 			}
-		</PositronModalDialog>
+		</>
 	);
 };

--- a/src/vs/workbench/contrib/positronAssistant/browser/configureLLMProvidersModal.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/configureLLMProvidersModal.tsx
@@ -7,7 +7,7 @@
 import './configureLLMProvidersModal.css';
 
 // React.
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../nls.js';
@@ -56,39 +56,25 @@ export const showConfigureLLMProvidersModal = (
 	onClose: () => void,
 	options?: IShowLanguageModelConfigOptions,
 ) => {
-	// Function to cancel a pending sign-in, if one exists.
-	let cancelPendingSignIn: (() => void) | undefined;
-	// Function to set the cancel callback.
-	const setCancelPendingSignIn = (cancel: (() => void) | undefined) => {
-		cancelPendingSignIn = cancel;
-	};
-	// Function that does the actual cancellation of the pending sign-in, if one exists.
-	const doCancelPendingSignIn = () => {
-		// Save the current cancel function and clear it before invoking it.
-		// We clear the cancel function before invoking it because we don't
-		// want it to be called again accidentally during the cancellation process.
-		const cancel = cancelPendingSignIn;
-		cancelPendingSignIn = undefined;
-		cancel?.();
-	};
-
+	// Disposing the renderer is the one thing every way out of the modal does: the
+	// title bar's close button, and Escape, which the browser handles itself on a
+	// native <dialog> without going through React. So the teardown hangs off the
+	// renderer rather than the component.
+	const pendingSignIn: PendingSignIn = {};
 	const renderer = new PositronModalReactRenderer({
 		onDisposed: () => {
-			// Disposing the modal should cancel any OAuth sign-in that is still running,
-			// regardless of what caused the disposal (esc key, close button, back button, etc).
-			doCancelPendingSignIn();
+			pendingSignIn.cancel?.();
 			onClose();
 		},
 	});
 	renderer.render(
 		<div className='configure-llm-providers-modal' data-testid='configure-llm-providers-modal'>
 			<ConfigureLLMProviders
+				pendingSignIn={pendingSignIn}
 				preselectedProviderId={options?.preselectedProviderId}
 				renderer={renderer}
 				sources={sources}
 				onAction={onAction}
-				onCancelPendingSignIn={doCancelPendingSignIn}
-				onSetCancelPendingSignIn={setCancelPendingSignIn}
 			/>
 		</div>
 	);
@@ -96,14 +82,12 @@ export const showConfigureLLMProvidersModal = (
 
 export interface ConfigureLLMProvidersProps {
 	renderer: PositronModalReactRenderer;
+	/** Where the connect view's cancel handler is left for the renderer's teardown to find. */
+	pendingSignIn: PendingSignIn;
 	sources: IPositronLanguageModelSource[];
 	/** Provider to open on, skipping the list. Ignored if it is not in `sources`. */
 	preselectedProviderId?: string;
 	onAction: OnAction;
-	/** Cancels an in-flight OAuth sign-in, if one exists. */
-	onCancelPendingSignIn: () => void;
-	/** Sets the cancellation function for an in-flight OAuth sign-in. */
-	onSetCancelPendingSignIn: (cancel: (() => void) | undefined) => void;
 }
 
 export const ConfigureLLMProviders = (props: ConfigureLLMProvidersProps) => {
@@ -155,6 +139,18 @@ export const ConfigureLLMProviders = (props: ConfigureLLMProvidersProps) => {
 	const selectedSource = sources.find(s => s.provider.id === selectedProviderId);
 	const activeView = (view === 'connect' || view === 'connected') && !selectedSource ? 'list' : view;
 
+	// A cancel handler reported by the connect view while an OAuth sign-in is in
+	// flight. Written straight into the shared handle so it does not re-render the
+	// modal as the sign-in progresses.
+	const pendingSignIn = props.pendingSignIn;
+	const setPendingCancel = useCallback((cancel: (() => void) | undefined) => {
+		pendingSignIn.cancel = cancel;
+	}, [pendingSignIn]);
+
+	const cancelPendingSignIn = () => {
+		pendingSignIn.cancel?.();
+	};
+
 	// Disposing runs the teardown the show function installed, which cancels an
 	// in-flight sign-in and reports the modal closed.
 	const close = () => {
@@ -171,7 +167,8 @@ export const ConfigureLLMProviders = (props: ConfigureLLMProvidersProps) => {
 	// Leaving the connect view cancels any sign-in it started and drops the handler,
 	// so a later close does not try to cancel a flow that has already gone.
 	const backToList = () => {
-		props.onCancelPendingSignIn();
+		cancelPendingSignIn();
+		setPendingCancel(undefined);
 		setView('list');
 	};
 
@@ -207,7 +204,7 @@ export const ConfigureLLMProviders = (props: ConfigureLLMProvidersProps) => {
 					onAction={props.onAction}
 					onBack={backToList}
 					onEditRawConfig={editRawConfig}
-					onPendingSignInChange={props.onSetCancelPendingSignIn}
+					onPendingSignInChange={setPendingCancel}
 				/>
 			}
 			{activeView === 'connected' && selectedSource &&

--- a/src/vs/workbench/contrib/positronAssistant/browser/configureLLMProvidersModal.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/configureLLMProvidersModal.tsx
@@ -55,10 +55,9 @@ export const showConfigureLLMProvidersModal = (
 	onClose: () => void,
 	options?: IShowLanguageModelConfigOptions,
 ) => {
-	// Disposing the renderer is the one thing every way out of the modal does: the
-	// title bar's close button, and Escape, which the browser handles itself on a
-	// native <dialog> without going through React. So the teardown hangs off the
-	// renderer rather than the component.
+	// Disposing the renderer is the one thing every way out of the modal does, whether
+	// that is the title bar's close button or Escape, and it outlives whichever view
+	// was on screen. So the teardown hangs off the renderer rather than the component.
 	const pendingSignIn: PendingSignIn = {};
 	const renderer = new PositronModalReactRenderer({
 		onDisposed: () => {

--- a/src/vs/workbench/contrib/positronAssistant/browser/configureLLMProvidersModal.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/configureLLMProvidersModal.tsx
@@ -7,7 +7,7 @@
 import './configureLLMProvidersModal.css';
 
 // React.
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../nls.js';
@@ -56,21 +56,14 @@ export const showConfigureLLMProvidersModal = (
 	onClose: () => void,
 	options?: IShowLanguageModelConfigOptions,
 ) => {
-	// Disposing the renderer is the one thing every way out of the modal does: the
-	// title bar's close button, and Escape, which the browser handles itself on a
-	// native <dialog> without going through React. So the teardown hangs off the
-	// renderer rather than the component.
-	const pendingSignIn: PendingSignIn = {};
 	const renderer = new PositronModalReactRenderer({
 		onDisposed: () => {
-			pendingSignIn.cancel?.();
 			onClose();
 		},
 	});
 	renderer.render(
 		<div className='configure-llm-providers-modal' data-testid='configure-llm-providers-modal'>
 			<ConfigureLLMProviders
-				pendingSignIn={pendingSignIn}
 				preselectedProviderId={options?.preselectedProviderId}
 				renderer={renderer}
 				sources={sources}
@@ -82,8 +75,6 @@ export const showConfigureLLMProvidersModal = (
 
 export interface ConfigureLLMProvidersProps {
 	renderer: PositronModalReactRenderer;
-	/** Where the connect view's cancel handler is left for the renderer's teardown to find. */
-	pendingSignIn: PendingSignIn;
 	sources: IPositronLanguageModelSource[];
 	/** Provider to open on, skipping the list. Ignored if it is not in `sources`. */
 	preselectedProviderId?: string;
@@ -139,18 +130,6 @@ export const ConfigureLLMProviders = (props: ConfigureLLMProvidersProps) => {
 	const selectedSource = sources.find(s => s.provider.id === selectedProviderId);
 	const activeView = (view === 'connect' || view === 'connected') && !selectedSource ? 'list' : view;
 
-	// A cancel handler reported by the connect view while an OAuth sign-in is in
-	// flight. Written straight into the shared handle so it does not re-render the
-	// modal as the sign-in progresses.
-	const pendingSignIn = props.pendingSignIn;
-	const setPendingCancel = useCallback((cancel: (() => void) | undefined) => {
-		pendingSignIn.cancel = cancel;
-	}, [pendingSignIn]);
-
-	const cancelPendingSignIn = () => {
-		pendingSignIn.cancel?.();
-	};
-
 	// Disposing runs the teardown the show function installed, which cancels an
 	// in-flight sign-in and reports the modal closed.
 	const close = () => {
@@ -164,11 +143,7 @@ export const ConfigureLLMProviders = (props: ConfigureLLMProvidersProps) => {
 		close();
 	};
 
-	// Leaving the connect view cancels any sign-in it started and drops the handler,
-	// so a later close does not try to cancel a flow that has already gone.
 	const backToList = () => {
-		cancelPendingSignIn();
-		setPendingCancel(undefined);
 		setView('list');
 	};
 
@@ -204,7 +179,6 @@ export const ConfigureLLMProviders = (props: ConfigureLLMProvidersProps) => {
 					onAction={props.onAction}
 					onBack={backToList}
 					onEditRawConfig={editRawConfig}
-					onPendingSignInChange={setPendingCancel}
 				/>
 			}
 			{activeView === 'connected' && selectedSource &&

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/configureLLMProvidersModal.vitest.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/configureLLMProvidersModal.vitest.tsx
@@ -13,7 +13,7 @@ import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { IPositronAssistantConfigurationService, IPositronLanguageModelConfig, IPositronLanguageModelSource, PositronLanguageModelType } from '../../common/interfaces/positronAssistantService.js';
 import { AuthenticationSession, AuthenticationSessionsChangeEvent, IAuthenticationService } from '../../../../services/authentication/common/authentication.js';
-import { ConfigureLLMProviders, PendingSignIn } from '../../browser/configureLLMProvidersModal.js';
+import { ConfigureLLMProviders } from '../../browser/configureLLMProvidersModal.js';
 import { PositronModalReactRenderer } from '../../../../../base/browser/positronModalReactRenderer.js';
 import { makeDialogRenderer } from './providerModalTestUtils.js';
 
@@ -51,12 +51,10 @@ describe('ConfigureLLMProviders', () => {
 		sources: IPositronLanguageModelSource[],
 		preselectedProviderId?: string,
 		onAction: (source: IPositronLanguageModelSource, config: IPositronLanguageModelConfig, action: string) => Promise<void> = async () => { },
-		pendingSignIn: PendingSignIn = {},
 		renderer: PositronModalReactRenderer = makeDialogRenderer(),
 	) {
 		return rtl.render(
 			<ConfigureLLMProviders
-				pendingSignIn={pendingSignIn}
 				preselectedProviderId={preselectedProviderId}
 				renderer={renderer}
 				sources={sources}
@@ -168,33 +166,34 @@ describe('ConfigureLLMProviders', () => {
 		expect(screen.getByRole('button', { name: 'Close' })).toHaveClass('title-bar-close-button');
 	});
 
-	// The renderer unmounts the React tree before it runs the teardown that cancels
-	// an in-flight sign-in, so the handler has to outlive this component.
-	it('leaves the pending sign-in handler in place when the modal unmounts', async () => {
-		const pendingSignIn: PendingSignIn = {};
+	// Closing the modal unmounts the React tree, which is what the connect view
+	// hangs its cancel off, so dismissal aborts the device flow rather than
+	// orphaning it.
+	it('cancels an in-flight OAuth sign-in when the modal unmounts', async () => {
 		let resolveSignIn = () => { };
 		const onAction = vi.fn().mockImplementation((_source, _config, action) =>
 			action === 'oauth-signin' ? new Promise<void>(resolve => { resolveSignIn = resolve; }) : Promise.resolve());
 		const user = userEvent.setup();
-		const { unmount } = renderModal([positAi], undefined, onAction, pendingSignIn);
+		const { unmount } = renderModal([positAi], undefined, onAction);
 
 		// The list row opens the connect view; its footer button starts the sign-in.
 		await user.click(screen.getByRole('button', { name: /connect/i }));
 		await user.click(screen.getByRole('button', { name: 'Connect' }));
-		expect(pendingSignIn.cancel).toBeTypeOf('function');
+		expect(onAction.mock.calls.map(([, , action]) => action)).toStrictEqual(['oauth-signin']);
 
 		unmount();
 
-		expect(pendingSignIn.cancel).toBeTypeOf('function');
-		pendingSignIn.cancel!();
+		expect(onAction.mock.calls.map(([, , action]) => action)).toStrictEqual(['oauth-signin', 'cancel']);
 		expect(onAction).toHaveBeenCalledWith(positAi, expect.anything(), 'cancel');
 		await act(async () => { resolveSignIn(); });
 	});
 
-	it('cancels an in-flight OAuth sign-in when Back returns to the list', async () => {
+	// Back unmounts the connect view, so it cancels through the same path a close
+	// does. The count matters: cancelling twice sends a second cancel to the provider.
+	it('cancels an in-flight OAuth sign-in exactly once when Back returns to the list', async () => {
 		const user = userEvent.setup();
 		const actions: string[] = [];
-		// Leave the sign-in pending so the connect view keeps reporting its cancel handler.
+		// Leave the sign-in pending so it is still in flight when Back is clicked.
 		const onAction = (_s: IPositronLanguageModelSource, _c: IPositronLanguageModelConfig, action: string) => {
 			actions.push(action);
 			return action === 'oauth-signin' ? new Promise<void>(() => { }) : Promise.resolve();

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/configureLLMProvidersModal.vitest.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/configureLLMProvidersModal.vitest.tsx
@@ -191,50 +191,6 @@ describe('ConfigureLLMProviders', () => {
 		await act(async () => { resolveSignIn(); });
 	});
 
-	// A successful sign-in unmounts the connect view before it can clear its own
-	// handler, so the modal has to drop it as it routes to the connected view.
-	it('drops the pending sign-in handler when the sign-in succeeds', async () => {
-		const pendingSignIn: PendingSignIn = {};
-		const actions: string[] = [];
-		let resolveSignIn = () => { };
-		const onAction = (_s: IPositronLanguageModelSource, _c: IPositronLanguageModelConfig, action: string) => {
-			actions.push(action);
-			return action === 'oauth-signin'
-				? new Promise<void>(resolve => { resolveSignIn = resolve; })
-				: Promise.resolve();
-		};
-		const user = userEvent.setup();
-		renderModal([positAi], undefined, onAction, pendingSignIn);
-
-		await user.click(screen.getByRole('button', { name: /connect/i }));
-		await user.click(screen.getByRole('button', { name: 'Connect' }));
-		expect(pendingSignIn.cancel).toBeTypeOf('function');
-
-		// The provider reports the sign-in before the action promise settles, which
-		// is what routes the modal to the connected view.
-		await act(async () => { onChange.fire({ ...positAi, signedIn: true }); });
-		await act(async () => { resolveSignIn(); });
-
-		expect(pendingSignIn.cancel).toBeUndefined();
-		await user.click(screen.getByRole('button', { name: 'Back' }));
-		expect(actions).toStrictEqual(['oauth-signin']);
-	});
-
-	// Each view mounts its own dialog, so arriving at one is a fresh dialog taking focus. It takes
-	// focus on the box rather than on the first control, which is the title bar's close button, so
-	// Enter straight after a view change does not dismiss the modal.
-	it('does not close when Enter follows a view change', async () => {
-		const user = userEvent.setup();
-		let disposeCount = 0;
-		renderModal([anthropic], undefined, undefined, undefined, makeDialogRenderer(() => { disposeCount++; }));
-
-		await user.click(screen.getByTestId('provider-action-anthropic-api'));
-		await user.keyboard('{Enter}');
-
-		expect({ disposeCount, onConnectView: !!screen.queryByTestId('provider-connect-view') })
-			.toStrictEqual({ disposeCount: 0, onConnectView: true });
-	});
-
 	it('cancels an in-flight OAuth sign-in when Back returns to the list', async () => {
 		const user = userEvent.setup();
 		const actions: string[] = [];

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/configureLLMProvidersModal.vitest.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/configureLLMProvidersModal.vitest.tsx
@@ -189,6 +189,35 @@ describe('ConfigureLLMProviders', () => {
 		await act(async () => { resolveSignIn(); });
 	});
 
+	// A successful sign-in unmounts the connect view before it can clear its own
+	// handler, so the modal has to drop it as it routes to the connected view.
+	it('drops the pending sign-in handler when the sign-in succeeds', async () => {
+		const pendingSignIn: PendingSignIn = {};
+		const actions: string[] = [];
+		let resolveSignIn = () => { };
+		const onAction = (_s: IPositronLanguageModelSource, _c: IPositronLanguageModelConfig, action: string) => {
+			actions.push(action);
+			return action === 'oauth-signin'
+				? new Promise<void>(resolve => { resolveSignIn = resolve; })
+				: Promise.resolve();
+		};
+		const user = userEvent.setup();
+		renderModal([positAi], undefined, onAction, pendingSignIn);
+
+		await user.click(screen.getByRole('button', { name: /connect/i }));
+		await user.click(screen.getByRole('button', { name: 'Connect' }));
+		expect(pendingSignIn.cancel).toBeTypeOf('function');
+
+		// The provider reports the sign-in before the action promise settles, which
+		// is what routes the modal to the connected view.
+		await act(async () => { onChange.fire({ ...positAi, signedIn: true }); });
+		await act(async () => { resolveSignIn(); });
+
+		expect(pendingSignIn.cancel).toBeUndefined();
+		await user.click(screen.getByRole('button', { name: 'Back' }));
+		expect(actions).toStrictEqual(['oauth-signin']);
+	});
+
 	it('cancels an in-flight OAuth sign-in when Back returns to the list', async () => {
 		const user = userEvent.setup();
 		const actions: string[] = [];

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/configureLLMProvidersModal.vitest.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/configureLLMProvidersModal.vitest.tsx
@@ -14,6 +14,7 @@ import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { IPositronAssistantConfigurationService, IPositronLanguageModelConfig, IPositronLanguageModelSource, PositronLanguageModelType } from '../../common/interfaces/positronAssistantService.js';
 import { AuthenticationSession, AuthenticationSessionsChangeEvent, IAuthenticationService } from '../../../../services/authentication/common/authentication.js';
 import { ConfigureLLMProviders, PendingSignIn } from '../../browser/configureLLMProvidersModal.js';
+import { PositronModalReactRenderer } from '../../../../../base/browser/positronModalReactRenderer.js';
 import { makeDialogRenderer } from './providerModalTestUtils.js';
 
 const positAi: IPositronLanguageModelSource = {
@@ -51,12 +52,13 @@ describe('ConfigureLLMProviders', () => {
 		preselectedProviderId?: string,
 		onAction: (source: IPositronLanguageModelSource, config: IPositronLanguageModelConfig, action: string) => Promise<void> = async () => { },
 		pendingSignIn: PendingSignIn = {},
+		renderer: PositronModalReactRenderer = makeDialogRenderer(),
 	) {
 		return rtl.render(
 			<ConfigureLLMProviders
 				pendingSignIn={pendingSignIn}
 				preselectedProviderId={preselectedProviderId}
-				renderer={makeDialogRenderer()}
+				renderer={renderer}
 				sources={sources}
 				onAction={onAction}
 			/>
@@ -216,6 +218,21 @@ describe('ConfigureLLMProviders', () => {
 		expect(pendingSignIn.cancel).toBeUndefined();
 		await user.click(screen.getByRole('button', { name: 'Back' }));
 		expect(actions).toStrictEqual(['oauth-signin']);
+	});
+
+	// Each view mounts its own dialog, so arriving at one is a fresh dialog taking focus. It takes
+	// focus on the box rather than on the first control, which is the title bar's close button, so
+	// Enter straight after a view change does not dismiss the modal.
+	it('does not close when Enter follows a view change', async () => {
+		const user = userEvent.setup();
+		let disposeCount = 0;
+		renderModal([anthropic], undefined, undefined, undefined, makeDialogRenderer(() => { disposeCount++; }));
+
+		await user.click(screen.getByTestId('provider-action-anthropic-api'));
+		await user.keyboard('{Enter}');
+
+		expect({ disposeCount, onConnectView: !!screen.queryByTestId('provider-connect-view') })
+			.toStrictEqual({ disposeCount: 0, onConnectView: true });
 	});
 
 	it('cancels an in-flight OAuth sign-in when Back returns to the list', async () => {

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/configureLLMProvidersModal.vitest.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/configureLLMProvidersModal.vitest.tsx
@@ -11,10 +11,10 @@ import { Emitter } from '../../../../../base/common/event.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
-import { PositronModalReactRenderer } from '../../../../../base/browser/positronModalReactRenderer.js';
 import { IPositronAssistantConfigurationService, IPositronLanguageModelConfig, IPositronLanguageModelSource, PositronLanguageModelType } from '../../common/interfaces/positronAssistantService.js';
 import { AuthenticationSession, AuthenticationSessionsChangeEvent, IAuthenticationService } from '../../../../services/authentication/common/authentication.js';
-import { ConfigureLLMProviders } from '../../browser/configureLLMProvidersModal.js';
+import { ConfigureLLMProviders, PendingSignIn } from '../../browser/configureLLMProvidersModal.js';
+import { makeDialogRenderer } from './providerModalTestUtils.js';
 
 const positAi: IPositronLanguageModelSource = {
 	type: PositronLanguageModelType.Chat,
@@ -46,27 +46,19 @@ describe('ConfigureLLMProviders', () => {
 		.build();
 	const rtl = setupRTLRenderer(() => ctx.reactServices);
 
-	// PositronModalDialog only uses onKeyDown/onResize from the renderer; close() calls dispose().
-	function makeRenderer(): PositronModalReactRenderer {
-		return stubInterface<PositronModalReactRenderer>({
-			onKeyDown: new Emitter<KeyboardEvent>().event,
-			onResize: new Emitter<UIEvent>().event,
-			dispose: () => { },
-		});
-	}
-
 	function renderModal(
 		sources: IPositronLanguageModelSource[],
 		preselectedProviderId?: string,
 		onAction: (source: IPositronLanguageModelSource, config: IPositronLanguageModelConfig, action: string) => Promise<void> = async () => { },
+		pendingSignIn: PendingSignIn = {},
 	) {
 		return rtl.render(
 			<ConfigureLLMProviders
+				pendingSignIn={pendingSignIn}
 				preselectedProviderId={preselectedProviderId}
-				renderer={makeRenderer()}
+				renderer={makeDialogRenderer()}
 				sources={sources}
 				onAction={onAction}
-				onClose={() => { }}
 			/>
 		);
 	}
@@ -161,13 +153,40 @@ describe('ConfigureLLMProviders', () => {
 		expect(screen.queryByText(/connected via/i)).not.toBeInTheDocument();
 	});
 
-	it('shows Close without Back on the list view, and Back on the connect view', async () => {
+	it('shows no Back on the list view, and Back on the connect view', async () => {
 		const user = userEvent.setup();
 		renderModal([anthropic]);
-		expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
 		expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument();
 		await user.click(screen.getByRole('button', { name: /connect/i }));
 		expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
+	});
+
+	it('gives the list view no footer, so dismissal is the title bar close button', () => {
+		renderModal([anthropic]);
+		expect(screen.getByRole('button', { name: 'Close' })).toHaveClass('title-bar-close-button');
+	});
+
+	// The renderer unmounts the React tree before it runs the teardown that cancels
+	// an in-flight sign-in, so the handler has to outlive this component.
+	it('leaves the pending sign-in handler in place when the modal unmounts', async () => {
+		const pendingSignIn: PendingSignIn = {};
+		let resolveSignIn = () => { };
+		const onAction = vi.fn().mockImplementation((_source, _config, action) =>
+			action === 'oauth-signin' ? new Promise<void>(resolve => { resolveSignIn = resolve; }) : Promise.resolve());
+		const user = userEvent.setup();
+		const { unmount } = renderModal([positAi], undefined, onAction, pendingSignIn);
+
+		// The list row opens the connect view; its footer button starts the sign-in.
+		await user.click(screen.getByRole('button', { name: /connect/i }));
+		await user.click(screen.getByRole('button', { name: 'Connect' }));
+		expect(pendingSignIn.cancel).toBeTypeOf('function');
+
+		unmount();
+
+		expect(pendingSignIn.cancel).toBeTypeOf('function');
+		pendingSignIn.cancel!();
+		expect(onAction).toHaveBeenCalledWith(positAi, expect.anything(), 'cancel');
+		await act(async () => { resolveSignIn(); });
 	});
 
 	it('cancels an in-flight OAuth sign-in when Back returns to the list', async () => {

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/connectProviderView.vitest.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/connectProviderView.vitest.tsx
@@ -11,6 +11,7 @@ import { createTestContainer } from '../../../../../test/vitest/positronTestCont
 import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
 import { IPositronLanguageModelSource, PositronLanguageModelType } from '../../common/interfaces/positronAssistantService.js';
 import { ConnectProviderView } from '../../browser/components/connectProviderView.js';
+import { dialogProps } from './providerModalTestUtils.js';
 
 const positAi: IPositronLanguageModelSource = {
 	type: PositronLanguageModelType.Chat,
@@ -77,7 +78,7 @@ describe('ConnectProviderView', () => {
 	const rtl = setupRTLRenderer(() => ctx.reactServices);
 
 	it('renders a Connect footer button and legal text for Posit AI', () => {
-		rtl.render(<ConnectProviderView source={positAi} onAction={async () => { }} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectProviderView {...dialogProps()} source={positAi} onAction={async () => { }} onBack={vi.fn()} />);
 		expect(screen.getByRole('button', { name: 'Connect' })).toBeEnabled();
 		expect(screen.getByTestId('provider-notice')).toBeInTheDocument();
 	});
@@ -85,20 +86,26 @@ describe('ConnectProviderView', () => {
 	it('dispatches oauth-signin when Connect is clicked', async () => {
 		const onAction = vi.fn().mockResolvedValue(undefined);
 		const user = userEvent.setup();
-		rtl.render(<ConnectProviderView source={positAi} onAction={onAction} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectProviderView {...dialogProps()} source={positAi} onAction={onAction} onBack={vi.fn()} />);
 		await user.click(screen.getByRole('button', { name: 'Connect' }));
 		expect(onAction).toHaveBeenCalledWith(positAi, expect.anything(), 'oauth-signin');
 	});
 
-	it('invokes onBack and onClose from the footer buttons', async () => {
+	it('invokes onBack from the footer, and leaves Close to the title bar', async () => {
 		const onBack = vi.fn();
-		const onClose = vi.fn();
 		const user = userEvent.setup();
-		rtl.render(<ConnectProviderView source={positAi} onAction={async () => { }} onBack={onBack} onClose={onClose} />);
+		rtl.render(<ConnectProviderView {...dialogProps()} source={positAi} onAction={async () => { }} onBack={onBack} />);
 		await user.click(screen.getByRole('button', { name: 'Back' }));
-		await user.click(screen.getByRole('button', { name: 'Close' }));
 		expect(onBack).toHaveBeenCalled();
-		expect(onClose).toHaveBeenCalled();
+		expect(screen.getByRole('button', { name: 'Close' })).toHaveClass('title-bar-close-button');
+	});
+
+	it('connects when Enter is pressed in the API key field', async () => {
+		const onAction = vi.fn().mockResolvedValue(undefined);
+		const user = userEvent.setup();
+		rtl.render(<ConnectProviderView {...dialogProps()} source={anthropic} onAction={onAction} onBack={vi.fn()} />);
+		await user.type(screen.getByLabelText(/api key/i), 'sk-test{Enter}');
+		expect(onAction).toHaveBeenCalledWith(anthropic, expect.objectContaining({ apiKey: 'sk-test' }), expect.anything());
 	});
 
 	it('reports a cancel handler while an OAuth sign-in is in progress that dispatches cancel', async () => {
@@ -107,7 +114,7 @@ describe('ConnectProviderView', () => {
 			action === 'oauth-signin' ? new Promise<void>(resolve => { resolveSignIn = resolve; }) : Promise.resolve());
 		let reportedCancel: (() => void) | undefined;
 		const user = userEvent.setup();
-		rtl.render(<ConnectProviderView source={positAi} onAction={onAction} onBack={vi.fn()} onClose={vi.fn()} onPendingSignInChange={cancel => { reportedCancel = cancel; }} />);
+		rtl.render(<ConnectProviderView {...dialogProps()} source={positAi} onAction={onAction} onBack={vi.fn()} onPendingSignInChange={cancel => { reportedCancel = cancel; }} />);
 		expect(reportedCancel).toBeUndefined();
 		await user.click(screen.getByRole('button', { name: 'Connect' }));
 		expect(reportedCancel).toBeTypeOf('function');
@@ -119,19 +126,19 @@ describe('ConnectProviderView', () => {
 	it('shows a failed sign-in in the error banner', async () => {
 		const onAction = vi.fn().mockRejectedValue(new Error('Bad key'));
 		const user = userEvent.setup();
-		rtl.render(<ConnectProviderView source={positAi} onAction={onAction} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectProviderView {...dialogProps()} source={positAi} onAction={onAction} onBack={vi.fn()} />);
 		await user.click(screen.getByRole('button', { name: 'Connect' }));
 		expect(await screen.findByText('Bad key')).toBeInTheDocument();
 	});
 
 	it('renders an API key input for an API-key provider', () => {
-		rtl.render(<ConnectProviderView source={anthropic} onAction={async () => { }} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectProviderView {...dialogProps()} source={anthropic} onAction={async () => { }} onBack={vi.fn()} />);
 		expect(screen.getByLabelText(/api key/i)).toBeInTheDocument();
 	});
 
 	it('disables Connect until an API key is entered', async () => {
 		const user = userEvent.setup();
-		rtl.render(<ConnectProviderView source={anthropic} onAction={async () => { }} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectProviderView {...dialogProps()} source={anthropic} onAction={async () => { }} onBack={vi.fn()} />);
 		expect(screen.getByRole('button', { name: 'Connect' })).toBeDisabled();
 		await user.type(screen.getByLabelText(/api key/i), 'sk-test');
 		expect(screen.getByRole('button', { name: 'Connect' })).toBeEnabled();
@@ -140,21 +147,21 @@ describe('ConnectProviderView', () => {
 	it('collects an API key and dispatches save when Connect is clicked', async () => {
 		const onAction = vi.fn().mockResolvedValue(undefined);
 		const user = userEvent.setup();
-		rtl.render(<ConnectProviderView source={anthropic} onAction={onAction} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectProviderView {...dialogProps()} source={anthropic} onAction={onAction} onBack={vi.fn()} />);
 		await user.type(screen.getByLabelText(/api key/i), 'sk-test');
 		await user.click(screen.getByRole('button', { name: 'Connect' }));
 		expect(onAction).toHaveBeenCalledWith(anthropic, expect.objectContaining({ apiKey: 'sk-test' }), 'save');
 	});
 
 	it('renders a base URL input prefilled with the current value', () => {
-		rtl.render(<ConnectProviderView source={anthropic} onAction={async () => { }} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectProviderView {...dialogProps()} source={anthropic} onAction={async () => { }} onBack={vi.fn()} />);
 		expect(screen.getByLabelText(/base url/i)).toHaveValue('https://api.anthropic.com');
 	});
 
 	it('includes an edited base URL in the dispatched config', async () => {
 		const onAction = vi.fn().mockResolvedValue(undefined);
 		const user = userEvent.setup();
-		rtl.render(<ConnectProviderView source={anthropic} onAction={onAction} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectProviderView {...dialogProps()} source={anthropic} onAction={onAction} onBack={vi.fn()} />);
 		await user.type(screen.getByLabelText(/api key/i), 'sk-test');
 		const baseUrlInput = screen.getByLabelText(/base url/i);
 		await user.clear(baseUrlInput);
@@ -168,19 +175,19 @@ describe('ConnectProviderView', () => {
 	});
 
 	it('shows the base URL input and no API key for a base-URL-only provider', () => {
-		rtl.render(<ConnectProviderView source={lmstudio} onAction={async () => { }} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectProviderView {...dialogProps()} source={lmstudio} onAction={async () => { }} onBack={vi.fn()} />);
 		expect(screen.getByLabelText(/base url/i)).toHaveValue('http://localhost:1234/v1');
 		expect(screen.queryByLabelText(/api key/i)).not.toBeInTheDocument();
 	});
 
 	it('labels the Databricks base URL input as the workspace URL', () => {
-		rtl.render(<ConnectProviderView source={databricks} onAction={async () => { }} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectProviderView {...dialogProps()} source={databricks} onAction={async () => { }} onBack={vi.fn()} />);
 		expect(screen.getByLabelText('Workspace URL')).toHaveValue('https://workspace.example.com');
 		expect(screen.queryByLabelText('Base URL')).not.toBeInTheDocument();
 	});
 
 	it('labels the Snowflake base URL input as the account identifier', () => {
-		rtl.render(<ConnectProviderView source={snowflake} onAction={async () => { }} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectProviderView {...dialogProps()} source={snowflake} onAction={async () => { }} onBack={vi.fn()} />);
 		expect(screen.getByLabelText('Account Identifier')).toHaveValue('myorg-account1');
 		expect(screen.queryByLabelText('Base URL')).not.toBeInTheDocument();
 	});
@@ -188,7 +195,7 @@ describe('ConnectProviderView', () => {
 	it('dispatches save with the base URL for a base-URL-only provider', async () => {
 		const onAction = vi.fn().mockResolvedValue(undefined);
 		const user = userEvent.setup();
-		rtl.render(<ConnectProviderView source={lmstudio} onAction={onAction} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectProviderView {...dialogProps()} source={lmstudio} onAction={onAction} onBack={vi.fn()} />);
 		const baseUrlInput = screen.getByLabelText(/base url/i);
 		await user.clear(baseUrlInput);
 		await user.type(baseUrlInput, 'http://localhost:4321/v1');
@@ -197,14 +204,14 @@ describe('ConnectProviderView', () => {
 	});
 
 	it('does not render the API Type selector while it is deferred (#13817)', () => {
-		rtl.render(<ConnectProviderView source={custom} onAction={async () => { }} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectProviderView {...dialogProps()} source={custom} onAction={async () => { }} onBack={vi.fn()} />);
 		expect(screen.queryByText('OpenAI Chat Completions')).not.toBeInTheDocument();
 	});
 
 	it('dispatches OpenAI Chat Completions as the API type', async () => {
 		const onAction = vi.fn().mockResolvedValue(undefined);
 		const user = userEvent.setup();
-		rtl.render(<ConnectProviderView source={custom} onAction={onAction} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectProviderView {...dialogProps()} source={custom} onAction={onAction} onBack={vi.fn()} />);
 		await user.type(screen.getByLabelText(/api key/i), 'sk-test');
 		await user.click(screen.getByRole('button', { name: 'Connect' }));
 		expect(onAction).toHaveBeenCalledWith(custom, expect.objectContaining({ protocol: 'openai-chat' }), 'save');
@@ -213,7 +220,7 @@ describe('ConnectProviderView', () => {
 	it('builds schema-valid custom models from the entered ids, defaulting capabilities', async () => {
 		const onAction = vi.fn().mockResolvedValue(undefined);
 		const user = userEvent.setup();
-		rtl.render(<ConnectProviderView source={custom} onAction={onAction} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectProviderView {...dialogProps()} source={custom} onAction={onAction} onBack={vi.fn()} />);
 		await user.type(screen.getByLabelText(/api key/i), 'sk-test');
 		await user.type(screen.getByPlaceholderText('Model ID'), 'my-model-1');
 		await user.click(screen.getByRole('button', { name: 'Add Model' }));
@@ -235,7 +242,7 @@ describe('ConnectProviderView', () => {
 	it('invokes onEditRawConfig from the edit-providers.json link', async () => {
 		const onEditRawConfig = vi.fn();
 		const user = userEvent.setup();
-		rtl.render(<ConnectProviderView source={custom} onAction={async () => { }} onBack={vi.fn()} onClose={vi.fn()} onEditRawConfig={onEditRawConfig} />);
+		rtl.render(<ConnectProviderView {...dialogProps()} source={custom} onAction={async () => { }} onBack={vi.fn()} onEditRawConfig={onEditRawConfig} />);
 		await user.click(screen.getByRole('button', { name: /edit providers\.json/i }));
 		expect(onEditRawConfig).toHaveBeenCalledOnce();
 	});
@@ -243,7 +250,7 @@ describe('ConnectProviderView', () => {
 	it('drops a removed model row from the dispatched config', async () => {
 		const onAction = vi.fn().mockResolvedValue(undefined);
 		const user = userEvent.setup();
-		rtl.render(<ConnectProviderView source={custom} onAction={onAction} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectProviderView {...dialogProps()} source={custom} onAction={onAction} onBack={vi.fn()} />);
 		await user.type(screen.getByLabelText(/api key/i), 'sk-test');
 		await user.type(screen.getByPlaceholderText('Model ID'), 'keep-me');
 		await user.click(screen.getByRole('button', { name: 'Add Model' }));
@@ -261,7 +268,7 @@ describe('ConnectProviderView', () => {
 		let resolveSignIn = () => { };
 		const onAction = vi.fn().mockImplementation(() => new Promise<void>(resolve => { resolveSignIn = resolve; }));
 		const user = userEvent.setup();
-		rtl.render(<ConnectProviderView source={positAi} onAction={onAction} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectProviderView {...dialogProps()} source={positAi} onAction={onAction} onBack={vi.fn()} />);
 		await user.click(screen.getByRole('button', { name: 'Connect' }));
 		const connecting = screen.getByRole('button', { name: 'Connecting...' });
 		expect(connecting).toBeDisabled();
@@ -276,7 +283,7 @@ describe('ConnectProviderView', () => {
 		let resolveRemove = () => { };
 		const onAction = vi.fn().mockImplementation(() => new Promise<void>(resolve => { resolveRemove = resolve; }));
 		const user = userEvent.setup();
-		rtl.render(<ConnectProviderView source={erroredAnthropic} onAction={onAction} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectProviderView {...dialogProps()} source={erroredAnthropic} onAction={onAction} onBack={vi.fn()} />);
 		await user.click(screen.getByRole('button', { name: 'Remove' }));
 		expect(screen.getByRole('button', { name: 'Removing...' })).toBeDisabled();
 		expect(screen.getByRole('button', { name: 'Connect' })).toBeInTheDocument();
@@ -288,7 +295,7 @@ describe('ConnectProviderView', () => {
 		let resolveRemove = () => { };
 		const onAction = vi.fn().mockImplementation(() => new Promise<void>(resolve => { resolveRemove = resolve; }));
 		const user = userEvent.setup();
-		rtl.render(<ConnectProviderView source={erroredPositAi} onAction={onAction} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectProviderView {...dialogProps()} source={erroredPositAi} onAction={onAction} onBack={vi.fn()} />);
 		await user.click(screen.getByRole('button', { name: 'Remove' }));
 		expect(screen.getByRole('button', { name: 'Connect' })).toBeDisabled();
 		await act(async () => { resolveRemove(); });
@@ -298,7 +305,7 @@ describe('ConnectProviderView', () => {
 		let resolve = () => { };
 		const onAction = vi.fn().mockImplementation(() => new Promise<void>(r => { resolve = r; }));
 		const user = userEvent.setup();
-		rtl.render(<ConnectProviderView source={positAi} onAction={onAction} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectProviderView {...dialogProps()} source={positAi} onAction={onAction} onBack={vi.fn()} />);
 		await user.click(screen.getByRole('button', { name: 'Connect' }));
 		expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
 		await act(async () => { resolve(); });
@@ -306,12 +313,12 @@ describe('ConnectProviderView', () => {
 
 	describe('with multiple auth methods (Databricks)', () => {
 		it('names the auth method radio group', () => {
-			rtl.render(<ConnectProviderView source={databricksOAuth} onAction={async () => { }} onBack={vi.fn()} onClose={vi.fn()} />);
+			rtl.render(<ConnectProviderView {...dialogProps()} source={databricksOAuth} onAction={async () => { }} onBack={vi.fn()} />);
 			expect(screen.getByRole('radiogroup', { name: 'Authentication Method' })).toBeInTheDocument();
 		});
 
 		it('renders both radios with OAuth checked by default', () => {
-			rtl.render(<ConnectProviderView source={databricksOAuth} onAction={async () => { }} onBack={vi.fn()} onClose={vi.fn()} />);
+			rtl.render(<ConnectProviderView {...dialogProps()} source={databricksOAuth} onAction={async () => { }} onBack={vi.fn()} />);
 			expect(screen.getByRole('radio', { name: 'OAuth' })).toBeChecked();
 			expect(screen.getByRole('radio', { name: 'API Key' })).not.toBeChecked();
 			expect(screen.queryByLabelText(/api key/i, { selector: 'input[type="password"]' })).not.toBeInTheDocument();
@@ -319,7 +326,7 @@ describe('ConnectProviderView', () => {
 
 		it('reveals the API key input after selecting API Key', async () => {
 			const user = userEvent.setup();
-			rtl.render(<ConnectProviderView source={databricksOAuth} onAction={async () => { }} onBack={vi.fn()} onClose={vi.fn()} />);
+			rtl.render(<ConnectProviderView {...dialogProps()} source={databricksOAuth} onAction={async () => { }} onBack={vi.fn()} />);
 			await user.click(screen.getByRole('radio', { name: 'API Key' }));
 			expect(screen.getByRole('radio', { name: 'API Key' })).toBeChecked();
 			expect(screen.getByLabelText(/api key/i, { selector: 'input[type="password"]' })).toBeInTheDocument();
@@ -327,7 +334,7 @@ describe('ConnectProviderView', () => {
 
 		it('keeps the workspace URL field visible under both methods', async () => {
 			const user = userEvent.setup();
-			rtl.render(<ConnectProviderView source={databricksOAuth} onAction={async () => { }} onBack={vi.fn()} onClose={vi.fn()} />);
+			rtl.render(<ConnectProviderView {...dialogProps()} source={databricksOAuth} onAction={async () => { }} onBack={vi.fn()} />);
 			expect(screen.getByLabelText('Workspace URL')).toBeInTheDocument();
 			await user.click(screen.getByRole('radio', { name: 'API Key' }));
 			expect(screen.getByLabelText('Workspace URL')).toBeInTheDocument();
@@ -336,7 +343,7 @@ describe('ConnectProviderView', () => {
 		it('dispatches oauth-signin by default', async () => {
 			const onAction = vi.fn().mockResolvedValue(undefined);
 			const user = userEvent.setup();
-			rtl.render(<ConnectProviderView source={databricksOAuth} onAction={onAction} onBack={vi.fn()} onClose={vi.fn()} />);
+			rtl.render(<ConnectProviderView {...dialogProps()} source={databricksOAuth} onAction={onAction} onBack={vi.fn()} />);
 			await user.click(screen.getByRole('button', { name: 'Connect' }));
 			expect(onAction).toHaveBeenCalledWith(databricksOAuth, expect.anything(), 'oauth-signin');
 		});
@@ -344,7 +351,7 @@ describe('ConnectProviderView', () => {
 		it('dispatches save with the API key after selecting API Key', async () => {
 			const onAction = vi.fn().mockResolvedValue(undefined);
 			const user = userEvent.setup();
-			rtl.render(<ConnectProviderView source={databricksOAuth} onAction={onAction} onBack={vi.fn()} onClose={vi.fn()} />);
+			rtl.render(<ConnectProviderView {...dialogProps()} source={databricksOAuth} onAction={onAction} onBack={vi.fn()} />);
 			await user.click(screen.getByRole('radio', { name: 'API Key' }));
 			await user.type(screen.getByLabelText(/api key/i, { selector: 'input[type="password"]' }), 'placeholder-key');
 			await user.click(screen.getByRole('button', { name: 'Connect' }));
@@ -352,7 +359,7 @@ describe('ConnectProviderView', () => {
 		});
 
 		it('hides the picker while signed in', () => {
-			rtl.render(<ConnectProviderView source={{ ...databricksOAuth, signedIn: true }} onAction={async () => { }} onBack={vi.fn()} onClose={vi.fn()} />);
+			rtl.render(<ConnectProviderView {...dialogProps()} source={{ ...databricksOAuth, signedIn: true }} onAction={async () => { }} onBack={vi.fn()} />);
 			expect(screen.queryByRole('radio', { name: 'OAuth' })).not.toBeInTheDocument();
 		});
 
@@ -360,7 +367,7 @@ describe('ConnectProviderView', () => {
 			let resolveSignIn = () => { };
 			const onAction = vi.fn().mockImplementation(() => new Promise<void>(resolve => { resolveSignIn = resolve; }));
 			const user = userEvent.setup();
-			rtl.render(<ConnectProviderView source={databricksOAuth} onAction={onAction} onBack={vi.fn()} onClose={vi.fn()} />);
+			rtl.render(<ConnectProviderView {...dialogProps()} source={databricksOAuth} onAction={onAction} onBack={vi.fn()} />);
 			await user.click(screen.getByRole('button', { name: 'Connect' }));
 			expect(screen.getByRole('radio', { name: 'OAuth' })).toBeDisabled();
 			expect(screen.getByRole('radio', { name: 'API Key' })).toBeDisabled();

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/connectProviderView.vitest.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/connectProviderView.vitest.tsx
@@ -108,19 +108,31 @@ describe('ConnectProviderView', () => {
 		expect(onAction).toHaveBeenCalledWith(anthropic, expect.objectContaining({ apiKey: 'sk-test' }), expect.anything());
 	});
 
-	it('reports a cancel handler while an OAuth sign-in is in progress that dispatches cancel', async () => {
+	it('cancels an in-flight OAuth sign-in when the view unmounts', async () => {
 		let resolveSignIn = () => { };
 		const onAction = vi.fn().mockImplementation((_source, _config, action) =>
 			action === 'oauth-signin' ? new Promise<void>(resolve => { resolveSignIn = resolve; }) : Promise.resolve());
-		let reportedCancel: (() => void) | undefined;
 		const user = userEvent.setup();
-		rtl.render(<ConnectProviderView {...dialogProps()} source={positAi} onAction={onAction} onBack={vi.fn()} onPendingSignInChange={cancel => { reportedCancel = cancel; }} />);
-		expect(reportedCancel).toBeUndefined();
+		const { unmount } = rtl.render(<ConnectProviderView {...dialogProps()} source={positAi} onAction={onAction} onBack={vi.fn()} />);
 		await user.click(screen.getByRole('button', { name: 'Connect' }));
-		expect(reportedCancel).toBeTypeOf('function');
-		reportedCancel!();
+		expect(onAction.mock.calls.map(([, , action]) => action)).toStrictEqual(['oauth-signin']);
+
+		unmount();
+
+		expect(onAction.mock.calls.map(([, , action]) => action)).toStrictEqual(['oauth-signin', 'cancel']);
 		expect(onAction).toHaveBeenCalledWith(positAi, expect.anything(), 'cancel');
 		await act(async () => { resolveSignIn(); });
+	});
+
+	it('leaves a finished OAuth sign-in alone when the view unmounts', async () => {
+		const onAction = vi.fn().mockResolvedValue(undefined);
+		const user = userEvent.setup();
+		const { unmount } = rtl.render(<ConnectProviderView {...dialogProps()} source={positAi} onAction={onAction} onBack={vi.fn()} />);
+		await user.click(screen.getByRole('button', { name: 'Connect' }));
+
+		unmount();
+
+		expect(onAction.mock.calls.map(([, , action]) => action)).toStrictEqual(['oauth-signin']);
 	});
 
 	it('shows a failed sign-in in the error banner', async () => {

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/connectedProviderView.vitest.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/connectedProviderView.vitest.tsx
@@ -11,6 +11,7 @@ import { createTestContainer } from '../../../../../test/vitest/positronTestCont
 import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
 import { IPositronLanguageModelSource, LanguageModelAutoconfigureType, PositronLanguageModelType } from '../../common/interfaces/positronAssistantService.js';
 import { ConnectedProviderView } from '../../browser/components/connectedProviderView.js';
+import { dialogProps } from './providerModalTestUtils.js';
 
 const positAi: IPositronLanguageModelSource = {
 	type: PositronLanguageModelType.Chat,
@@ -27,7 +28,7 @@ describe('ConnectedProviderView', () => {
 	const rtl = setupRTLRenderer(() => ctx.reactServices);
 
 	it('shows how the provider is connected and reports a Sign Out footer action', () => {
-		rtl.render(<ConnectedProviderView source={positAi} onAction={async () => { }} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectedProviderView {...dialogProps()} source={positAi} onAction={async () => { }} onBack={vi.fn()} />);
 		expect(screen.getByText(/connected via oauth/i)).toBeInTheDocument();
 		expect(screen.getByRole('button', { name: 'Sign Out' })).toBeInTheDocument();
 	});
@@ -35,7 +36,7 @@ describe('ConnectedProviderView', () => {
 	it('dispatches oauth-signout when the footer action runs', async () => {
 		const onAction = vi.fn().mockResolvedValue(undefined);
 		const user = userEvent.setup();
-		rtl.render(<ConnectedProviderView source={positAi} onAction={onAction} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectedProviderView {...dialogProps()} source={positAi} onAction={onAction} onBack={vi.fn()} />);
 		await user.click(screen.getByRole('button', { name: 'Sign Out' }));
 		expect(onAction).toHaveBeenCalledWith(positAi, expect.anything(), 'oauth-signout');
 	});
@@ -48,7 +49,7 @@ describe('ConnectedProviderView', () => {
 			signedIn: true,
 			defaults: { baseUrl: 'https://proxy.example/v1' },
 		};
-		rtl.render(<ConnectedProviderView source={anthropic} onAction={async () => { }} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectedProviderView {...dialogProps()} source={anthropic} onAction={async () => { }} onBack={vi.fn()} />);
 		expect(screen.getByText('https://proxy.example/v1')).toBeInTheDocument();
 	});
 
@@ -60,13 +61,13 @@ describe('ConnectedProviderView', () => {
 			signedIn: true,
 			defaults: { baseUrl: 'https://workspace.example.com' },
 		};
-		rtl.render(<ConnectedProviderView source={databricks} onAction={async () => { }} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectedProviderView {...dialogProps()} source={databricks} onAction={async () => { }} onBack={vi.fn()} />);
 		expect(screen.getByText('Workspace URL')).toBeInTheDocument();
 		expect(screen.queryByText('Base URL')).not.toBeInTheDocument();
 	});
 
 	it('omits the base URL row when the provider does not support it', () => {
-		rtl.render(<ConnectedProviderView source={positAi} onAction={async () => { }} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectedProviderView {...dialogProps()} source={positAi} onAction={async () => { }} onBack={vi.fn()} />);
 		expect(screen.queryByText(/base url/i)).not.toBeInTheDocument();
 	});
 
@@ -80,7 +81,7 @@ describe('ConnectedProviderView', () => {
 			statusMessage: 'Bad base URL',
 			defaults: {},
 		};
-		rtl.render(<ConnectedProviderView source={broken} onAction={async () => { }} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectedProviderView {...dialogProps()} source={broken} onAction={async () => { }} onBack={vi.fn()} />);
 		expect(screen.getByText('Bad base URL')).toBeInTheDocument();
 		expect(screen.queryByText(/connected to anthropic/i)).not.toBeInTheDocument();
 	});
@@ -95,7 +96,7 @@ describe('ConnectedProviderView', () => {
 				autoconfigure: { type: LanguageModelAutoconfigureType.EnvVariable, key: 'ANTHROPIC_API_KEY', signedIn: true },
 			},
 		};
-		rtl.render(<ConnectedProviderView source={envAnthropic} onAction={async () => { }} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectedProviderView {...dialogProps()} source={envAnthropic} onAction={async () => { }} onBack={vi.fn()} />);
 		expect(screen.getByText(/connected via ANTHROPIC_API_KEY/i)).toBeInTheDocument();
 		expect(screen.queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument();
 	});
@@ -110,7 +111,7 @@ describe('ConnectedProviderView', () => {
 				autoconfigure: { type: LanguageModelAutoconfigureType.Custom, message: 'OAuth (Workbench Managed Credentials)', signedIn: true },
 			},
 		};
-		rtl.render(<ConnectedProviderView source={managedDatabricks} onAction={async () => { }} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectedProviderView {...dialogProps()} source={managedDatabricks} onAction={async () => { }} onBack={vi.fn()} />);
 		expect(screen.getByText(/connected via oauth \(workbench managed credentials\)/i)).toBeInTheDocument();
 		expect(screen.queryByRole('button', { name: 'Sign Out' })).not.toBeInTheDocument();
 		expect(screen.queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument();
@@ -126,7 +127,7 @@ describe('ConnectedProviderView', () => {
 				autoconfigure: { type: LanguageModelAutoconfigureType.Custom, message: 'the Accounts menu.', signedIn: true },
 			},
 		};
-		rtl.render(<ConnectedProviderView source={copilot} onAction={async () => { }} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectedProviderView {...dialogProps()} source={copilot} onAction={async () => { }} onBack={vi.fn()} />);
 		expect(screen.getByRole('link', { name: /manage accounts/i })).toBeInTheDocument();
 		expect(screen.queryByRole('button', { name: 'Sign Out' })).not.toBeInTheDocument();
 	});
@@ -135,7 +136,7 @@ describe('ConnectedProviderView', () => {
 		let resolveSignOut = () => { };
 		const onAction = vi.fn().mockImplementation(() => new Promise<void>(resolve => { resolveSignOut = resolve; }));
 		const user = userEvent.setup();
-		rtl.render(<ConnectedProviderView source={positAi} onAction={onAction} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectedProviderView {...dialogProps()} source={positAi} onAction={onAction} onBack={vi.fn()} />);
 		await user.click(screen.getByRole('button', { name: 'Sign Out' }));
 		const signingOut = screen.getByRole('button', { name: 'Signing Out...' });
 		expect(signingOut).toBeDisabled();
@@ -155,7 +156,7 @@ describe('ConnectedProviderView', () => {
 		let resolveRemove = () => { };
 		const onAction = vi.fn().mockImplementation(() => new Promise<void>(resolve => { resolveRemove = resolve; }));
 		const user = userEvent.setup();
-		rtl.render(<ConnectedProviderView source={anthropic} onAction={onAction} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectedProviderView {...dialogProps()} source={anthropic} onAction={onAction} onBack={vi.fn()} />);
 		await user.click(screen.getByRole('button', { name: 'Remove' }));
 		expect(screen.getByRole('button', { name: 'Removing...' })).toBeDisabled();
 		await act(async () => { resolveRemove(); });
@@ -165,7 +166,7 @@ describe('ConnectedProviderView', () => {
 		let resolve = () => { };
 		const onAction = vi.fn().mockImplementation(() => new Promise<void>(r => { resolve = r; }));
 		const user = userEvent.setup();
-		rtl.render(<ConnectedProviderView source={positAi} onAction={onAction} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectedProviderView {...dialogProps()} source={positAi} onAction={onAction} onBack={vi.fn()} />);
 		await user.click(screen.getByRole('button', { name: 'Sign Out' }));
 		expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
 		await act(async () => { resolve(); });
@@ -182,7 +183,7 @@ describe('ConnectedProviderView', () => {
 		};
 		const onAction = vi.fn().mockResolvedValue(undefined);
 		const user = userEvent.setup();
-		rtl.render(<ConnectedProviderView source={databricksApiKey} onAction={onAction} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectedProviderView {...dialogProps()} source={databricksApiKey} onAction={onAction} onBack={vi.fn()} />);
 		expect(screen.getByText(/connected via api key/i)).toBeInTheDocument();
 		const removeButton = screen.getByRole('button', { name: 'Remove' });
 		expect(removeButton).toBeInTheDocument();
@@ -199,7 +200,7 @@ describe('ConnectedProviderView', () => {
 			authMethods: ['oauth'],
 			defaults: { baseUrl: 'https://workspace.example.com' },
 		};
-		rtl.render(<ConnectedProviderView source={databricksOAuth} onAction={async () => { }} onBack={vi.fn()} onClose={vi.fn()} />);
+		rtl.render(<ConnectedProviderView {...dialogProps()} source={databricksOAuth} onAction={async () => { }} onBack={vi.fn()} />);
 		expect(screen.getByText(/connected via oauth/i)).toBeInTheDocument();
 		expect(screen.getByRole('button', { name: 'Sign Out' })).toBeInTheDocument();
 	});

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/connectedProviderView.vitest.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/connectedProviderView.vitest.tsx
@@ -69,6 +69,9 @@ describe('ConnectedProviderView', () => {
 	it('omits the base URL row when the provider does not support it', () => {
 		rtl.render(<ConnectedProviderView {...dialogProps()} source={positAi} onAction={async () => { }} onBack={vi.fn()} />);
 		expect(screen.queryByText(/base url/i)).not.toBeInTheDocument();
+		// The row's element goes too, not just its text. It used to render empty
+		// and grow to fill the body, pushing the notice down against the footer.
+		expect(screen.queryByTestId('provider-base-url')).not.toBeInTheDocument();
 	});
 
 	it('shows an error banner (and not the connected line) when the provider status is error', () => {

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/providerListItem.vitest.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/providerListItem.vitest.tsx
@@ -52,14 +52,13 @@ describe('ProviderListItem', () => {
 		expect(screen.getByText('PWB Managed')).toBeInTheDocument();
 	});
 
-	it('shows an OAuth badge, not PWB Managed, for a connected copilot-auth provider', () => {
+	it('does not show PWB Managed for a connected copilot-auth provider', () => {
 		render(<ProviderListItem section='connected' source={source({
 			id: 'copilot-auth',
 			signedIn: true,
 			supportedOptions: [AuthMethod.OAUTH],
 			defaults: { autoconfigure: { type: LanguageModelAutoconfigureType.Custom, message: 'the Accounts menu.', signedIn: true } },
 		})} />);
-		expect(screen.getByText('OAuth')).toBeInTheDocument();
 		expect(screen.queryByText('PWB Managed')).not.toBeInTheDocument();
 	});
 
@@ -88,29 +87,14 @@ describe('ProviderListItem', () => {
 		expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
 	});
 
-	it('shows an OAuth badge for an oauth connected provider', () => {
-		render(<ProviderListItem section='connected' source={source({ id: 'a', signedIn: true, supportedOptions: [AuthMethod.OAUTH] })} />);
-		expect(screen.getByText('OAuth')).toBeInTheDocument();
-	});
-
-	it('shows no OAuth badge when a dual-method provider connected with an API key', () => {
-		render(<ProviderListItem section='connected' source={source({
-			id: 'databricks',
-			signedIn: true,
-			authMethods: [AuthMethod.API_KEY],
-			supportedOptions: [AuthMethod.OAUTH, AuthMethod.API_KEY],
-		})} />);
-		expect(screen.queryByText('OAuth')).not.toBeInTheDocument();
-	});
-
-	it('shows an OAuth badge when a dual-method provider connected with OAuth', () => {
+	it('badges nothing for an oauth connected provider, whose credentials the user entered here', () => {
 		render(<ProviderListItem section='connected' source={source({
 			id: 'databricks',
 			signedIn: true,
 			authMethods: [AuthMethod.OAUTH],
 			supportedOptions: [AuthMethod.OAUTH, AuthMethod.API_KEY],
 		})} />);
-		expect(screen.getByText('OAuth')).toBeInTheDocument();
+		expect(screen.queryByText('OAuth')).not.toBeInTheDocument();
 	});
 
 	it('shows an Error badge, the error message, and a Fix Connection action in needs-attention', () => {

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/providerModalTestUtils.ts
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/providerModalTestUtils.ts
@@ -10,12 +10,15 @@ import { PositronModalReactRenderer } from '../../../../../base/browser/positron
 /**
  * A renderer for view tests. PositronDynamicModalDialog reads onResize and onKeyDown from it
  * while mounted; dispose is there for the close paths.
+ *
+ * @param onDispose Called instead of the no-op when the modal disposes the renderer, for a test
+ * that asserts whether a given interaction closes the modal.
  */
-export function makeDialogRenderer(): PositronModalReactRenderer {
+export function makeDialogRenderer(onDispose: () => void = () => { }): PositronModalReactRenderer {
 	return stubInterface<PositronModalReactRenderer>({
 		onKeyDown: new Emitter<KeyboardEvent>().event,
 		onResize: new Emitter<UIEvent>().event,
-		dispose: () => { },
+		dispose: onDispose,
 	});
 }
 

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/providerModalTestUtils.ts
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/providerModalTestUtils.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Emitter } from '../../../../../base/common/event.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { PositronModalReactRenderer } from '../../../../../base/browser/positronModalReactRenderer.js';
+
+/**
+ * A renderer for view tests. PositronDynamicModalDialog reads onResize and onKeyDown from it
+ * while mounted; dispose is there for the close paths.
+ */
+export function makeDialogRenderer(): PositronModalReactRenderer {
+	return stubInterface<PositronModalReactRenderer>({
+		onKeyDown: new Emitter<KeyboardEvent>().event,
+		onResize: new Emitter<UIEvent>().event,
+		dispose: () => { },
+	});
+}
+
+/** The dialog props each provider modal view needs to draw its own box. */
+export function dialogProps() {
+	return {
+		renderer: makeDialogRenderer(),
+		title: 'Test Title',
+		width: 600,
+	};
+}

--- a/test/e2e/infra/workbench.ts
+++ b/test/e2e/infra/workbench.ts
@@ -162,7 +162,7 @@ export class Workbench {
 		this.assistant = new Assistant(code, this.quickaccess, this.toasts, this.modals);
 		this.positConnect = new PositConnect(code);
 		this.positAssistant = new PositAssistant(code);
-		this.modelProviderModal = new ModelProviderModal(code, this.modals, this.toasts);
+		this.modelProviderModal = new ModelProviderModal(code, this.toasts);
 		this.inlineDataExplorer = new InlineDataExplorer(code.driver.currentPage);
 		this.inlineQuarto = new InlineQuarto(code, this.quickaccess, this.hotKeys);
 		this.publisher = new Publisher(this.quickInput);

--- a/test/e2e/pages/dialog-dynamic-modals.ts
+++ b/test/e2e/pages/dialog-dynamic-modals.ts
@@ -13,10 +13,17 @@ import { Code } from '../infra/code.js';
  */
 export class DynamicModals {
 
-	constructor(private code: Code) { }
+	/**
+	 * @param scope Selector for a wrapper around one particular dialog, for a page object
+	 * that drives a single modal. Left off, `dialogBox` matches any dynamic modal on screen,
+	 * so two open at once fail Playwright's strict mode.
+	 */
+	constructor(private code: Code, private scope?: string) { }
 
 	get dialogBox(): Locator {
-		return this.code.driver.currentPage.locator('.positron-dynamic-modal-dialog-box');
+		const page = this.code.driver.currentPage;
+		const root = this.scope ? page.locator(this.scope) : page;
+		return root.locator('.positron-dynamic-modal-dialog-box');
 	}
 	get title(): Locator { return this.dialogBox.locator('.title-bar-title'); }
 	get message(): Locator { return this.dialogBox.locator('.content-area'); }

--- a/test/e2e/pages/modelProviderModal.ts
+++ b/test/e2e/pages/modelProviderModal.ts
@@ -5,8 +5,8 @@
 
 import { expect, test } from '@playwright/test';
 import { Code } from '../infra/code';
-import { Modals } from './dialog-modals.js';
 import { Toasts } from './dialog-toasts.js';
+import { DynamicModals } from './dialog-dynamic-modals.js';
 import { HotKeys } from './hotKeys.js';
 import {
 	ModelProvider,
@@ -23,14 +23,11 @@ import {
 } from './modelProviderShared.js';
 
 // The "Configure LLM Providers" modal, which the Configure Providers command
-// opens by default (`assistant.newProviderModal`).
-// The testid sits on a zero-size layout wrapper (its child dialog container is
-// position:absolute, so the wrapper collapses and Playwright reports it hidden).
-// Scope to the actual visible dialog box inside it, so visibility gates and
-// footer-button lookups target a real bounding box. The testid prefix keeps this
-// distinct from the OAuth device-code dialog, which is also a
-// .positron-modal-dialog-box.
-const MODAL = '[data-testid="configure-llm-providers-modal"] .positron-modal-dialog-box';
+// opens by default (`assistant.newProviderModal`). The testid sits on a zero-size
+// layout wrapper -- its child dialog container is position:absolute, so the wrapper
+// collapses and Playwright reports it hidden -- so DynamicModals is scoped to the
+// wrapper and finds the visible dialog box inside it.
+const MODAL_SCOPE = '[data-testid="configure-llm-providers-modal"]';
 const CONNECT_VIEW = '[data-testid="provider-connect-view"]';
 const CONNECTED_VIEW = '[data-testid="provider-connected-view"]';
 const APIKEY_INPUT = '#connect-provider-apikey-input';
@@ -41,15 +38,6 @@ const BASEURL_INPUT = '#connect-provider-baseurl-input';
 const AUTH_METHOD_RADIO = (method: 'oauth' | 'apiKey') =>
 	`input[name="connect-provider-auth-method"][value="${method}"]`;
 
-// Footer buttons are rendered by the shared action bar; scope by text within the modal.
-// Substring match: also matches the in-flight "Connecting..." label, which is
-// harmless here - the click lands while the button still reads "Connect", and
-// there is only one primary button so there is no strict-mode collision.
-const CONNECT_BUTTON = `${MODAL} button.positron-button:has-text("Connect")`;
-const SIGN_OUT_BUTTON = `${MODAL} button.positron-button:has-text("Sign out")`;
-const REMOVE_BUTTON = `${MODAL} button.positron-button:has-text("Remove")`;
-const CLOSE_BUTTON = `${MODAL} button.positron-button:has-text("Close")`;
-
 /**
  * Page object for the "Configure LLM Providers" modal. This is what the
  * Configure Providers command opens unless a suite pins
@@ -59,9 +47,21 @@ const CLOSE_BUTTON = `${MODAL} button.positron-button:has-text("Close")`;
  */
 export class ModelProviderModal {
 	private hotKeys: HotKeys;
+	private modal: DynamicModals;
 
-	constructor(private code: Code, private modals: Modals, private toasts: Toasts) {
+	constructor(private code: Code, private toasts: Toasts) {
 		this.hotKeys = new HotKeys(code);
+		this.modal = new DynamicModals(code, MODAL_SCOPE);
+	}
+
+	/**
+	 * A footer button by its label, matched as a substring. That also matches the
+	 * in-flight "Connecting..." label, which is harmless here: the click lands while
+	 * the button still reads "Connect", and there is only one primary button so there
+	 * is no strict-mode collision.
+	 */
+	private footerButton(label: string) {
+		return this.modal.dialogBox.locator(`button.positron-button:has-text("${label}")`);
 	}
 
 	async runConfigureProviders() {
@@ -91,13 +91,13 @@ export class ModelProviderModal {
 	 * in the file, not just this one: the app is shared across a suite, and the
 	 * Configure Providers command renders a fresh dialog every time it runs without
 	 * checking for one that is already open. A second dialog carries the same
-	 * testid, so MODAL then matches two elements and Playwright fails on strict
-	 * mode instead of on whatever the test was actually doing.
+	 * testid, so the modal locator then matches two elements and Playwright fails on
+	 * strict mode instead of on whatever the test was actually doing.
 	 */
 	private async withModal(timeout: number, body: () => Promise<void>) {
 		try {
 			await this.runConfigureProviders();
-			await expect(this.code.driver.currentPage.locator(MODAL)).toBeVisible({ timeout });
+			await this.modal.expectToBeVisible(undefined, { timeout });
 			await body();
 		} catch (e) {
 			await this.closeQuietly();
@@ -231,8 +231,8 @@ export class ModelProviderModal {
 
 				// Env / credential-chain authenticated providers cannot be signed out from
 				// the modal (no Sign out / Remove button); treat that as a no-op close.
-				const signOut = this.code.driver.currentPage.locator(SIGN_OUT_BUTTON);
-				const remove = this.code.driver.currentPage.locator(REMOVE_BUTTON);
+				const signOut = this.footerButton('Sign out');
+				const remove = this.footerButton('Remove');
 				const disconnect = (await signOut.isVisible()) ? signOut : (await remove.isVisible()) ? remove : undefined;
 				if (!disconnect) {
 					await this.clickCloseButton();
@@ -248,13 +248,14 @@ export class ModelProviderModal {
 	}
 
 	async clickConnectButton() {
-		await this.code.driver.currentPage.locator(CONNECT_BUTTON).click();
+		await this.footerButton('Connect').click();
 	}
 
+	/** Dismisses the modal through the title bar's X; the footer has no Close button. */
 	async clickCloseButton() {
-		// Sign-in/out can surface toasts overlapping the footer; dismiss them first.
+		// Sign-in/out can surface toasts overlapping the title bar; dismiss them first.
 		await this.toasts.closeAll();
-		await this.code.driver.currentPage.locator(CLOSE_BUTTON).click();
-		await this.modals.expectToBeVisible(undefined, { visible: false });
+		await this.modal.clickCloseButton();
+		await this.modal.expectNotToBeVisible({ timeout: 15000 });
 	}
 }


### PR DESCRIPTION
Fixes #15632.

Stacked on #15679, which has to land first: this modal cannot move to the dynamic modal dialog while that dialog is still a native `<dialog>`.

Each view now renders its own `PositronDynamicModalDialog` and the modal stays the router, mirroring `NewDataConnectionFlow`. The box follows its content instead of being pinned at 500px, so a provider with nothing to fill in no longer shows an empty band above the footer. The provider list is the one view that stays bounded: it stops growing after a section heading and seven rows and scrolls from there, so a long list does not stretch the box to fill a tall window. Keeping the box clear of the gutters is the dialog's own `max-height`, which #15679 adds.

The footer's Close button goes away, because the new title bar carries an X and the old `DraggableTitleBar` had none. That makes the renderer the only thing every dismissal reaches, so the cleanup that cancels an in-flight OAuth sign-in moves onto its `onDisposed` hook. Escape and the X both cancel a running device flow, the same as the old footer Close did.

One wrinkle, for anyone reading the commits. The connect view used to clear its own cancel handler when it unmounted. That cleanup would now also run when the dialog closes, wiping the handler before `onDisposed` could use it, so it had to go, and the router drops the handler on a successful sign-in instead. Nothing changes against `main`: 61b3380b72 repairs something 1eb9d4c53c introduced, it is _not_ a bug you can hit today.

The Connect button also becomes the form's submit target, so Enter in the API key field connects.

### Screenshots

**Resize modal**


https://github.com/user-attachments/assets/3b1ab6b4-2c74-4178-af2e-5b84bb4930d8



**Signed In w/ API Key**

<img width="717" height="486" alt="image" src="https://github.com/user-attachments/assets/9ce4f673-46ff-4b7c-a64a-5f40accb038d" />

**OAuth Provider - Connect view** 

<img width="741" height="464" alt="image" src="https://github.com/user-attachments/assets/25d23220-531f-4151-9d8f-17aff496f7f8" />

**Provider list**

<img width="770" height="613" alt="image" src="https://github.com/user-attachments/assets/edaa7ff9-6dfe-4344-b3ae-2dd148d95f87" />

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

1. Open **Configure LLM Providers**. **The dialog has an X in its title bar and no Close button in the footer.**
2. Pick a provider that needs no fields. **The box fits its content**, with no empty band above the footer.
3. Go back to the provider list on a tall window. **The list stops after seven rows and scrolls** rather than stretching the dialog down the screen.
4. Pick a provider that takes an API key, type one, press <kbd>Enter</kbd>. **It connects**, the same as clicking **Connect**.
5. Start an OAuth sign-in, then dismiss the dialog mid-flow with <kbd>Escape</kbd> and again with the title bar's **X**. **The device flow is cancelled** both ways.
6. Complete an OAuth sign-in successfully, then click **Back**, then close the dialog. **The provider stays signed in.**

@:assistant @:modal

