### PR TITLE
Add Snowflake External Browser e2e coverage for data connections

### DIFF
--- a/.env.e2e.example
+++ b/.env.e2e.example
@@ -39,3 +39,9 @@ IDE_SERVICE_ACCOUNT_PASSWORD=
 IDE_SERVICE_ACCOUNT_OTP_SECRET=
 DATABRICKS_WORKSPACE=
 DATABRICKS_PAT=
+
+# Snowflake account for the data-connections Snowflake test. Its External Browser mechanism
+# federates to Okta, so the sign-in itself uses the IDE service account variables above -- this
+# is the only Snowflake-specific value the suite needs (SNOWFLAKE_USER / SNOWFLAKE_USERNAME are
+# used by other suites, not this one). Already provided on both Ubuntu CI lanes.
+SNOWFLAKE_ACCOUNT=

--- a/test/e2e/tests/data-connections/snowflake.test.ts
+++ b/test/e2e/tests/data-connections/snowflake.test.ts
@@ -1,0 +1,180 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test, expect, tags } from '../_test.setup';
+import { createBrowserLaunchShim } from '../../utils/browserLaunchShim';
+import { completeSnowflakeSdkOAuth } from '../../utils/snowflakeOAuth';
+
+// Intercepts the browser launch snowflake-sdk makes during External Browser sign-in. Created at
+// module scope because `test.use({ extraEnv })` below is evaluated when this file is collected, so
+// the PATH value has to exist by then.
+const shim = createBrowserLaunchShim();
+
+test.use({
+	suiteId: __filename,
+	// The Data Connections panel is a preview feature gated behind `dataConnections.enabled`. This
+	// bakes the setting into the app (and the Workbench/Jupyter containers) at startup, since those
+	// read settings copied in at launch rather than the host settings file written at runtime.
+	enableDataConnections: true,
+	// Put the shim ahead of the real browser opener for the launched app. The extension host
+	// inherits this, which is where snowflake-sdk runs.
+	extraEnv: shim.env,
+});
+
+// Snowflake connection details. The account comes from the environment (the project's .env file
+// locally, 1Password in CI). The sign-in credentials are the shared IDE service account's, because
+// this account federates to Okta -- see snowflakeOAuth.ts.
+//
+// The env-backed values are read at runtime inside beforeAll, not here: `.env.e2e` is applied by the
+// auto `envVars` worker fixture, which runs after this file is evaluated during test collection, so a
+// top-level `process.env` read would always be empty (and the suite would skip).
+const connectionName = 'snowflake';
+
+// The warehouse queries run on. Not a secret -- it is the CI warehouse's name, fixed for this
+// account the way the Redshift suite's port and database are fixed for its cluster.
+const warehouse = 'CI_WH';
+
+// Ground truth for the tree assertions. This is a Snowflake Marketplace share rather than anything
+// a person created in the account, so its shape is stable; the existing connections-snowflake test
+// has been exercising the same database and schema in CI.
+const database = 'FINANCIAL__ECONOMIC_ESSENTIALS';
+const schema = 'CYBERSYN';
+
+// The share exposes secure views and no tables at all -- its `Tables` node exists but is empty, so
+// only `Views` is expanded below. A handful of the 48 views, chosen as the catalog/index ones least
+// likely to be reshaped by an upstream data refresh.
+const views = [
+	'CYBERSYN_DATA_CATALOG',
+	'CYBERSYN_DATA_DICTIONARY',
+	'COMPANY_INDEX',
+];
+
+// The view opened in the Data Explorer, and how wide it is. As with the Databricks suite, the count
+// is asserted rather than the column names: the dataset is upstream and this suite's subject is the
+// External Browser connection, not grid fidelity.
+const previewView = 'BANK_FOR_INTERNATIONAL_SETTLEMENTS_ATTRIBUTES';
+const previewViewColumnCount = 10;
+
+// Desktop only, and not Windows. Both limits come from how the browser launch is intercepted, not
+// from the sign-in itself, which is the same everywhere:
+//
+//   - Web and Workbench: the shim reaches the extension host through `extraEnv`, and only the
+//     Electron launch path applies that (infra/electron.ts). playwrightBrowser.ts and
+//     playwrightExternalServer.ts build the server's env from process.env alone, so the shim never
+//     reaches the process running snowflake-sdk -- it would launch a real browser instead.
+//   - Windows: the shim cannot work at all. `open` invokes PowerShell by absolute path and never
+//     consults PATH, so there is nothing to put ourselves ahead of.
+//
+// See browserLaunchShim.ts.
+test.describe('Data Connections - Snowflake (External Browser)', {
+	tag: [tags.CONNECTIONS]
+}, () => {
+
+	// Configuring the connection and signing in is a one-time, stateful action, and the app is
+	// worker-scoped, so it happens once for the whole suite. Per-test state that must not leak (an
+	// open Data Explorer tab) is reset in afterEach.
+	test.beforeAll(async function ({ app }) {
+		// Read the env-backed connection details now (not at module scope): `.env.e2e` is applied by
+		// the auto `envVars` worker fixture, which has run by the time this hook executes.
+		const account = process.env.SNOWFLAKE_ACCOUNT || '';
+		// The sign-in is Okta's, not Snowflake's: the account federates, so the browser leg uses the
+		// shared IDE service account rather than any SNOWFLAKE_USER/SNOWFLAKE_USERNAME value. Guard on
+		// what is actually consumed, so a rig with the account but no Okta credentials skips instead
+		// of failing halfway through the browser flow.
+		const otpSecret = process.env.IDE_SERVICE_ACCOUNT_OTP_SECRET || '';
+
+		// These are secrets. Where they are not provisioned (no .env locally, no 1Password in a given
+		// CI rig) the sign-in cannot happen, so skip the whole suite rather than fail. Follows the
+		// convention the Redshift tests use.
+		test.skip(!account || !otpSecret, 'Snowflake test credentials not configured (SNOWFLAKE_ACCOUNT / IDE_SERVICE_ACCOUNT_OTP_SECRET unset)');
+
+		// The budget covers the interactive sign-in plus a warehouse that may be resuming from idle:
+		// the first metadata query restarts a suspended warehouse, which takes appreciably longer than
+		// a warm one. Note where that latency lands -- `Databases` is a static container whose twisty
+		// flips with no query behind it, so expanding it returns immediately and the wait falls on the
+		// *next* expand, the one that lists databases.
+		test.setTimeout(900_000);
+
+		const { dataConnections } = app.workbench;
+		dataConnections.actionTimeout = 420_000;
+
+		await dataConnections.openDataConnectionsView();
+		await dataConnections.clickAddConnection();
+		await dataConnections.selectProvider('Snowflake');
+		await dataConnections.selectConnectionMechanism('External Browser');
+		// User is left unset: for External Browser the identity comes from the browser sign-in, and
+		// the field is optional. Account is passed through as-is -- the driver accepts a bare
+		// identifier or a full account URL.
+		await dataConnections.fillConnectionInputs([
+			['Connection Name', connectionName],
+			['Account', account],
+			[/^Warehouse/, warehouse],
+		]);
+
+		// Saving only persists the profile -- no connection is made and no browser opens yet.
+		await dataConnections.save();
+		await dataConnections.expectConnectionInTree(connectionName);
+
+		// Expanding the entry is what connects, and the driver connects eagerly, so this is where the
+		// SDK runs its External Browser flow. The helper starts the expand and drives the browser while
+		// it is in flight; the expand call itself resolves as soon as the twisty starts loading, so the
+		// step below -- which cannot render until the metadata query returns -- is what proves it
+		// connected.
+		await completeSnowflakeSdkOAuth(
+			shim,
+			() => dataConnections.expandConnection(connectionName),
+			{ logger: app.code.logger },
+		);
+
+		await test.step('Expand the tree down to tables', async () => {
+			await dataConnections.expandNode('Databases');
+			await dataConnections.expandNode(database, 'database');
+			await dataConnections.expandNode('Schemas');
+			await dataConnections.expandNode(schema, 'schema');
+			await dataConnections.expandNode('Views');
+		});
+
+		// The cold-start budget above is only needed for that first chain. Drop back to a normal wait
+		// so a genuine failure in the tests below surfaces in seconds rather than minutes.
+		dataConnections.actionTimeout = 60_000;
+	});
+
+	// Each preview test opens a Data Explorer tab. Close it so the next test starts from a clean
+	// editor state rather than depending on what the previous test left open. The connection and its
+	// expanded tree remain in the worker-scoped app.
+	test.afterEach(async function ({ app }) {
+		await app.workbench.hotKeys.closeAllEditors();
+	});
+
+	test.afterAll(async function () {
+		shim.dispose();
+	});
+
+	test('Verify the account databases are listed', async function ({ app }) {
+		// The databases in this account are largely people-created and come and go, so assert on the
+		// Marketplace share the suite navigates rather than pinning the whole list.
+		await app.workbench.dataConnections.expectNodeVisible(database, 'database');
+	});
+
+	test('Verify the schemas in the database are listed', async function ({ app }) {
+		await app.workbench.dataConnections.expectNodeVisible(schema, 'schema');
+		await app.workbench.dataConnections.expectNodeVisible('INFORMATION_SCHEMA', 'schema');
+	});
+
+	test('Verify the views in the schema are listed', async function ({ app }) {
+		for (const view of views) {
+			await app.workbench.dataConnections.expectNodeVisible(view, 'view');
+		}
+	});
+
+	test('Verify a view opens in the Data Explorer', { tag: [tags.DATA_EXPLORER] }, async function ({ app }) {
+		const { dataConnections, dataExplorer } = app.workbench;
+
+		await dataConnections.doubleClickNode(previewView, 'view');
+
+		await dataExplorer.waitForIdle();
+		expect(await dataExplorer.grid.getColumnCount()).toBe(previewViewColumnCount);
+	});
+});

--- a/test/e2e/utils/databricksOAuth.ts
+++ b/test/e2e/utils/databricksOAuth.ts
@@ -6,8 +6,7 @@
 import { Browser, BrowserContext, chromium, expect, Locator, Page } from '@playwright/test';
 import { Logger } from '../infra/logger.js';
 import { BrowserLaunchShim } from './browserLaunchShim.js';
-import { generateTOTP } from './totp.js';
-import { isOktaLockedOut, otpRetryDelayMs } from './otpRetry.js';
+import { completeOktaSignIn } from './oktaSignIn.js';
 
 // The Okta-fronted Databricks sign-in for the shared IDE service account, driven on a
 // page the caller already put in front of the Databricks authorize endpoint. Two callers
@@ -25,8 +24,6 @@ import { isOktaLockedOut, otpRetryDelayMs } from './otpRetry.js';
 // Everything between "we are on the workspace login page" and "the provider redirected
 // back to the callback" is identical, and that is what lives here.
 
-const MAX_OTP_ATTEMPTS = 3;
-
 export interface DatabricksOktaSignInOptions {
 	/**
 	 * Pattern the OAuth page lands on once Databricks redirects back to whoever started
@@ -37,29 +34,6 @@ export interface DatabricksOktaSignInOptions {
 	logger: Logger;
 	/** Prefix for log lines, so interleaved shards stay readable (e.g. 'Workbench'). */
 	label: string;
-}
-
-/**
- * Reads the shared IDE service account credentials, failing with the missing variable
- * names rather than letting an undefined value reach a form field (where it surfaces
- * much later as an opaque Okta error).
- */
-function readServiceAccountCredentials(): { email: string; password: string; otpSecret: string } {
-	const email = process.env.IDE_SERVICE_ACCOUNT_EMAIL;
-	const password = process.env.IDE_SERVICE_ACCOUNT_PASSWORD;
-	const otpSecret = process.env.IDE_SERVICE_ACCOUNT_OTP_SECRET;
-
-	const missing = [
-		['IDE_SERVICE_ACCOUNT_EMAIL', email],
-		['IDE_SERVICE_ACCOUNT_PASSWORD', password],
-		['IDE_SERVICE_ACCOUNT_OTP_SECRET', otpSecret],
-	].filter(([, value]) => !value).map(([name]) => name);
-
-	if (missing.length > 0) {
-		throw new Error(`Databricks OAuth requires the IDE service account credentials. Missing: ${missing.join(', ')}`);
-	}
-
-	return { email: email!, password: password!, otpSecret: otpSecret! };
 }
 
 /**
@@ -90,94 +64,32 @@ async function clickConsentControl(control: Locator, label: string, logger: Logg
  */
 export async function completeDatabricksOktaSignIn(page: Page, options: DatabricksOktaSignInOptions): Promise<boolean> {
 	const { completionUrl, logger, label } = options;
-	const { email, password, otpSecret } = readServiceAccountCredentials();
 
-	// Navigate to Okta SSO via Databricks. The workspace login page offers the SSO hop;
-	// an authorize endpoint that redirects straight to the IdP skips it, so a missing
-	// button is not a failure -- the waitForURL below is what actually gates progress.
-	const ssoButton = page.locator('a:has-text("Continue with SSO")');
-	try {
-		await expect(ssoButton).toBeVisible({ timeout: 15000 });
-		await ssoButton.click();
-	} catch {
-		logger.log(`[${label}] No "Continue with SSO" button; assuming the authorize endpoint redirected to the IdP directly`);
-	}
-	await page.waitForURL(/okta\.com/, { timeout: 15000 });
-
-	// Enter Okta credentials
-	const usernameField = page.locator('#input28');
-	const passwordField = page.locator('input[type="password"]');
-	const nextButton = page.locator('input[value="Next"]');
-	const verifyButton = page.locator('input[value="Verify"]');
-
-	await expect(usernameField).toBeVisible({ timeout: 10000 });
-	await usernameField.fill(email);
-	await expect(nextButton).toBeVisible({ timeout: 10000 });
-	await nextButton.click();
-	await expect(passwordField).toBeVisible({ timeout: 5000 });
-	await passwordField.fill(password);
-	await expect(verifyButton).toBeVisible({ timeout: 10000 });
-	await verifyButton.click();
-
-	// Complete 2FA authentication. TOTPs roll every 30s and Okta rejects reused codes, so a
-	// parallel shard (e.g. Azure) consuming the same code seconds earlier can knock us out, or
-	// rapid duplicate submissions can lock the account ("too many attempts"). Retry up to 3
-	// times, backing off with jitter between attempts so we de-align from the competing shard
-	// and land in a different TOTP window (and back off longer on lockout). See otpRetry.ts.
-	await page.waitForLoadState('networkidle', { timeout: 10000 });
-	const otpField = page.locator('input[type="text"], input[type="tel"], input[autocomplete="one-time-code"]').first();
-	const verifyOtpButton = page.locator('button:has-text("Verify"), input[value="Verify"]');
-
-	for (let attempt = 1; attempt <= MAX_OTP_ATTEMPTS; attempt++) {
-		await expect(otpField).toBeVisible({ timeout: 15000 });
-		await otpField.fill('');
-		await otpField.fill(generateTOTP(otpSecret));
-		logger.log(`[${label}] Submitted TOTP code for Databricks (attempt ${attempt}/${MAX_OTP_ATTEMPTS})`);
-		await expect(verifyOtpButton).toBeVisible({ timeout: 10000 });
-		await verifyOtpButton.click();
-
-		try {
-			// After Okta accepts the OTP it redirects back to Databricks, which walks
-			// through up to two OAuth consent screens before completing the redirect to
-			// our callback:
-			//   1. "Authorize as" -- account picker with a Continue control
-			//      (<a data-component-id="oauth.select-group.continue">).
-			//   2. "Permission Requested" -- consent screen with an Authorize control.
-			// Both render as du-bois links (role "link"), not buttons, and either may be
-			// skipped when the account has already granted consent. Click each if shown.
+	return completeOktaSignIn(page, {
+		logger,
+		label,
+		// After Okta accepts the OTP, Databricks walks through up to two OAuth consent screens before
+		// completing the redirect to our callback:
+		//   1. "Authorize as" -- account picker with a Continue control
+		//      (<a data-component-id="oauth.select-group.continue">).
+		//   2. "Permission Requested" -- consent screen with an Authorize control.
+		// Both render as du-bois links (role "link"), not buttons, and either may be skipped when the
+		// account has already granted consent. Click each if shown, then wait for the callback -- that
+		// wait is what tells completeOktaSignIn the code was actually accepted.
+		afterOtp: async (signInPage: Page) => {
 			await clickConsentControl(
-				page.locator('[data-component-id="oauth.select-group.continue"]'),
+				signInPage.locator('[data-component-id="oauth.select-group.continue"]'),
 				'Authorize as / Continue',
 				logger,
 			);
 			await clickConsentControl(
-				page.getByText('Authorize', { exact: true }),
+				signInPage.getByText('Authorize', { exact: true }),
 				'Permission Requested / Authorize',
 				logger,
 			);
-
-			await page.waitForURL(completionUrl, { timeout: 20000 });
-			return true;
-		} catch {
-			// The OAuth tab sometimes closes itself on success (or on certain Okta errors).
-			// A closed tab here is more likely "OAuth completed" than "OTP rejected" -- bail
-			// out of the retry loop and let the caller's signed-in check decide success.
-			if (page.isClosed()) {
-				logger.log(`[${label}] OAuth page closed before URL match; treating as completed and deferring to the caller's state check`);
-				return false;
-			}
-			if (attempt === MAX_OTP_ATTEMPTS) {
-				logger.log(`[${label}] OTP not accepted after ${MAX_OTP_ATTEMPTS} attempts; falling through to the caller's state check`);
-				return false;
-			}
-			const lockedOut = await isOktaLockedOut(page);
-			const delay = otpRetryDelayMs(lockedOut);
-			logger.log(`[${label}] Databricks OTP not accepted (attempt ${attempt}/${MAX_OTP_ATTEMPTS}, lockedOut=${lockedOut}); backing off ${delay}ms before retry`);
-			await page.waitForTimeout(delay);
-		}
-	}
-
-	return false;
+			await signInPage.waitForURL(completionUrl, { timeout: 20000 });
+		},
+	});
 }
 
 /**
@@ -249,7 +161,10 @@ export async function completeDatabricksSdkOAuth(
 		if (browser) { await browser.close(); }
 	}
 
-	// The SDK's loopback server has the code by now; awaiting the trigger lets the token
-	// exchange, the connect, and the tree's first metadata query finish (or report a failure).
+	// Surface a trigger failure if there was one. Note this does not wait for the connection:
+	// `expandConnection` resolved back when the row's twisty flipped from `collapsed` to `loading`
+	// (see positronTreeInstance.tsx), which happens the instant expansion begins. What actually
+	// proves the connect succeeded is the caller's next expand, which cannot render until the
+	// metadata query returns.
 	await pending;
 }

--- a/test/e2e/utils/oktaSignIn.ts
+++ b/test/e2e/utils/oktaSignIn.ts
@@ -1,0 +1,142 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect, Page } from '@playwright/test';
+import { Logger } from '../infra/logger.js';
+import { generateTOTP } from './totp.js';
+import { isOktaLockedOut, otpRetryDelayMs } from './otpRetry.js';
+
+// The Okta sign-in for the shared IDE service account, driven on a page the caller has already
+// pointed at a provider's login (or at Okta directly).
+//
+// Several providers federate to the same Okta tenant, and everything between "we are on the login
+// page" and "Okta accepted the one-time code" is identical for all of them. What differs is only
+// what happens *after* the code is accepted -- Databricks walks through OAuth consent screens
+// before redirecting to its loopback server, while Snowflake posts a SAML assertion back and
+// redirects to the SDK's. That tail is supplied by the caller as `afterOtp`.
+//
+// `afterOtp` runs inside the OTP retry loop on purpose. A rejected code and a stalled post-OTP
+// redirect are indistinguishable from the outside, so a failure there re-enters the loop with a
+// fresh code rather than failing the run.
+
+const MAX_OTP_ATTEMPTS = 3;
+
+export interface OktaSignInOptions {
+	/**
+	 * Runs once Okta has accepted the one-time code, and must reject (or throw) until the flow has
+	 * demonstrably completed -- typically by waiting for the provider's callback URL. Called inside
+	 * the retry loop, so it may run more than once.
+	 */
+	afterOtp: (page: Page) => Promise<void>;
+	/** Where to report progress; callers pass `code.logger`. */
+	logger: Logger;
+	/** Prefix for log lines, so interleaved shards stay readable (e.g. 'Workbench'). */
+	label: string;
+}
+
+/**
+ * Reads the shared IDE service account credentials, failing with the missing variable names rather
+ * than letting an undefined value reach a form field (where it surfaces much later as an opaque
+ * Okta error).
+ */
+export function readServiceAccountCredentials(): { email: string; password: string; otpSecret: string } {
+	const email = process.env.IDE_SERVICE_ACCOUNT_EMAIL;
+	const password = process.env.IDE_SERVICE_ACCOUNT_PASSWORD;
+	const otpSecret = process.env.IDE_SERVICE_ACCOUNT_OTP_SECRET;
+
+	const missing = [
+		['IDE_SERVICE_ACCOUNT_EMAIL', email],
+		['IDE_SERVICE_ACCOUNT_PASSWORD', password],
+		['IDE_SERVICE_ACCOUNT_OTP_SECRET', otpSecret],
+	].filter(([, value]) => !value).map(([name]) => name);
+
+	if (missing.length > 0) {
+		throw new Error(`Okta sign-in requires the IDE service account credentials. Missing: ${missing.join(', ')}`);
+	}
+
+	return { email: email!, password: password!, otpSecret: otpSecret! };
+}
+
+/**
+ * Completes the Okta sign-in on `page`, then hands off to `afterOtp`.
+ *
+ * Callers verify success through their own signed-in state rather than this return value: the
+ * sign-in tab sometimes closes itself on completion, so "we never saw the callback" is not the same
+ * as "sign-in failed".
+ *
+ * @returns true if `afterOtp` completed without throwing.
+ */
+export async function completeOktaSignIn(page: Page, options: OktaSignInOptions): Promise<boolean> {
+	const { afterOtp, logger, label } = options;
+	const { email, password, otpSecret } = readServiceAccountCredentials();
+
+	// Some providers show their own login page first, offering an SSO hop; others (or an authorize
+	// endpoint that redirects straight to the IdP) land on Okta directly. A missing button is not a
+	// failure -- the waitForURL below is what actually gates progress.
+	const ssoButton = page.locator('a:has-text("Continue with SSO")');
+	try {
+		await expect(ssoButton).toBeVisible({ timeout: 15000 });
+		await ssoButton.click();
+	} catch {
+		logger.log(`[${label}] No "Continue with SSO" button; assuming the login page redirected to the IdP directly`);
+	}
+	await page.waitForURL(/okta\.com/, { timeout: 15000 });
+
+	// Enter Okta credentials
+	const usernameField = page.locator('#input28');
+	const passwordField = page.locator('input[type="password"]');
+	const nextButton = page.locator('input[value="Next"]');
+	const verifyButton = page.locator('input[value="Verify"]');
+
+	await expect(usernameField).toBeVisible({ timeout: 10000 });
+	await usernameField.fill(email);
+	await expect(nextButton).toBeVisible({ timeout: 10000 });
+	await nextButton.click();
+	await expect(passwordField).toBeVisible({ timeout: 5000 });
+	await passwordField.fill(password);
+	await expect(verifyButton).toBeVisible({ timeout: 10000 });
+	await verifyButton.click();
+
+	// Complete 2FA authentication. TOTPs roll every 30s and Okta rejects reused codes, so a parallel
+	// shard consuming the same code seconds earlier can knock us out, or rapid duplicate submissions
+	// can lock the account ("too many attempts"). Retry up to 3 times, backing off with jitter
+	// between attempts so we de-align from the competing shard and land in a different TOTP window
+	// (and back off longer on lockout). See otpRetry.ts.
+	await page.waitForLoadState('networkidle', { timeout: 10000 });
+	const otpField = page.locator('input[type="text"], input[type="tel"], input[autocomplete="one-time-code"]').first();
+	const verifyOtpButton = page.locator('button:has-text("Verify"), input[value="Verify"]');
+
+	for (let attempt = 1; attempt <= MAX_OTP_ATTEMPTS; attempt++) {
+		await expect(otpField).toBeVisible({ timeout: 15000 });
+		await otpField.fill('');
+		await otpField.fill(generateTOTP(otpSecret));
+		logger.log(`[${label}] Submitted TOTP code (attempt ${attempt}/${MAX_OTP_ATTEMPTS})`);
+		await expect(verifyOtpButton).toBeVisible({ timeout: 10000 });
+		await verifyOtpButton.click();
+
+		try {
+			await afterOtp(page);
+			return true;
+		} catch {
+			// The sign-in tab sometimes closes itself on success (or on certain Okta errors). A closed
+			// tab here is more likely "flow completed" than "OTP rejected" -- bail out of the retry
+			// loop and let the caller's state check decide success.
+			if (page.isClosed()) {
+				logger.log(`[${label}] Sign-in page closed before completion; treating as completed and deferring to the caller's state check`);
+				return false;
+			}
+			if (attempt === MAX_OTP_ATTEMPTS) {
+				logger.log(`[${label}] OTP not accepted after ${MAX_OTP_ATTEMPTS} attempts; falling through to the caller's state check`);
+				return false;
+			}
+			const lockedOut = await isOktaLockedOut(page);
+			const delay = otpRetryDelayMs(lockedOut);
+			logger.log(`[${label}] OTP not accepted (attempt ${attempt}/${MAX_OTP_ATTEMPTS}, lockedOut=${lockedOut}); backing off ${delay}ms before retry`);
+			await page.waitForTimeout(delay);
+		}
+	}
+
+	return false;
+}

--- a/test/e2e/utils/snowflakeOAuth.ts
+++ b/test/e2e/utils/snowflakeOAuth.ts
@@ -1,0 +1,106 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Browser, BrowserContext, chromium } from '@playwright/test';
+import { Logger } from '../infra/logger.js';
+import { BrowserLaunchShim } from './browserLaunchShim.js';
+import { completeOktaSignIn } from './oktaSignIn.js';
+
+// The data connections Snowflake driver's External Browser sign-in.
+//
+// Despite the name, this is not Snowflake's own login form. The account federates to Okta, so the
+// SSO URL the SDK requests redirects to an Okta SAML endpoint and the credentials entered are the
+// shared IDE service account's -- the same identity, and the same TOTP secret, the Databricks flows
+// use. The Okta steps themselves live in oktaSignIn.ts; what is Snowflake-specific is only which
+// URL is captured and what "done" looks like.
+//
+// (Posit Workbench's Session Credentials widget reaches Snowflake by a different route -- an OAuth
+// client against Snowflake, which does show Snowflake's native username/password form. That flow
+// lives in dashboard.page.ts and shares nothing with this one.)
+
+/**
+ * Completes the sign-in for the data connections driver's External Browser mechanism, which
+ * snowflake-sdk runs itself rather than Positron running it.
+ *
+ * The driver only hands connection options to snowflake-sdk; `auth_web.js` then stands up a
+ * loopback server on an ephemeral port, asks Snowflake for an SSO URL bound to that port, and
+ * launches the browser through the `open` npm package. Nothing reaches Positron's opener service,
+ * so the URL is captured with a PATH shim (browserLaunchShim.ts) and replayed in a browser
+ * Playwright controls. The SDK's own server receives the token and finishes the handshake.
+ *
+ * Note which URL that is: `auth_web.js` has two branches, and `disableConsoleLogin` defaults to
+ * true, so the live one is `ssoUrlProvider.getSSOURL(...)` -- an opaque, account-specific SSO URL.
+ * The `/console/login` URL built by `getLoginUrl` is the *other* branch and is not what ships. So
+ * match any launched URL rather than a shape, and let the awaited connect below be the verdict on
+ * whether sign-in actually worked.
+ *
+ * (snowflake-sdk does expose an `openExternalBrowserCallback` connection option, but it is not
+ * surfaced by the driver, and adding a test-only hook to production code would be the wrong trade.)
+ *
+ * `trigger` must be the action that establishes the connection, and note that it does *not*
+ * resolve until sign-in completes: the driver connects eagerly, and Positron only calls it lazily
+ * on the first expand of the connection entry. So the trigger is started and deliberately left
+ * pending while the browser leg runs, then awaited at the end. Awaiting it up front would deadlock.
+ *
+ * @param shim The PATH shim capturing the SDK's browser launch.
+ * @param trigger Starts the connect (expands the connection entry). Started, not awaited.
+ * @param options.logger Where to report progress; callers pass `code.logger`.
+ * @param options.headless Whether to run the sign-in browser headless. Defaults to false, matching
+ * the other IdP flows: these pages are not reliably renderable headless.
+ */
+export async function completeSnowflakeSdkOAuth(
+	shim: BrowserLaunchShim,
+	trigger: () => Promise<void>,
+	options: { logger: Logger; headless?: boolean }
+): Promise<void> {
+	const { logger, headless = false } = options;
+
+	shim.arm();
+
+	// Start the connect and leave it pending. Attach a no-op catch now so that a failure while we
+	// are busy with the browser does not surface as an unhandled rejection; the awaited `pending`
+	// below is what actually reports it.
+	const pending = trigger();
+	pending.catch(() => { /* reported by the race and the await below */ });
+
+	// Race the capture against the connect *failing*. Without this, a connect that fails before ever
+	// reaching the browser (a bad account, an unreachable host) is reported as "no browser launch was
+	// captured" -- a timeout that describes the symptom and hides the cause.
+	//
+	// Only a rejection is meaningful here. `expandConnection` resolves as soon as the row's twisty
+	// flips from `collapsed` to `loading` (see positronTreeInstance.tsx), which happens the instant
+	// expansion begins and long before the connect finishes -- so treating a fulfilment as "already
+	// connected" bails out before the browser is ever launched. Map it to a promise that never
+	// settles and let the capture decide.
+	const loginUrl = await Promise.race([
+		shim.waitForUrl(/^https?:\/\//),
+		pending.then(() => new Promise<string>(() => { /* never settles; see above */ })),
+	]);
+
+	let browser: Browser | undefined;
+	let context: BrowserContext | undefined;
+	try {
+		browser = await chromium.launch({ headless });
+		context = await browser.newContext();
+		const page = await context.newPage();
+		await page.goto(loginUrl);
+		await completeOktaSignIn(page, {
+			logger,
+			label: 'DataConnections/Snowflake',
+			// Okta posts the SAML assertion back to Snowflake, which redirects to the SDK's loopback
+			// server on an ephemeral port. Landing on localhost is what tells us the handoff completed;
+			// the port is not in the SSO URL, so match the host and let the port be whatever it is.
+			afterOtp: signInPage => signInPage.waitForURL(/localhost:\d+/, { timeout: 30000 }),
+		});
+	} finally {
+		if (context) { await context.close(); }
+		if (browser) { await browser.close(); }
+	}
+
+	// Surface a trigger failure if there was one. Note this does not wait for the connection: the
+	// trigger resolved back when the twisty began loading. What actually proves the connect
+	// succeeded is the caller's next expand, which cannot render until the metadata query returns.
+	await pending;
+}


### PR DESCRIPTION
### Summary

Adds e2e coverage for the data connections Snowflake driver's **External Browser** mechanism: create the connection, browse the catalog tree, and preview a view in the Data Explorer. Companion to #15696, which did the same for Databricks OAuth.

Same interception as #15696, for the same reason: the driver only hands connection options to `snowflake-sdk`, which runs the sign-in itself and launches the browser through the `open` npm package (`auth_web.js:37`). Nothing reaches `vscode.env.openExternal`, so the URL is captured with the PATH shim from `browserLaunchShim.ts` rather than by patching `shell.openExternal`.

**Two things about this flow are not obvious from the driver, and cost me a couple of wrong turns:**

- **This account federates to Okta.** Despite the mechanism's name, the SSO URL the SDK requests redirects to an Okta SAML endpoint (`posit.okta.com/app/snowflake/.../sso/saml`). So the credentials are the shared IDE service account's -- *not* `SNOWFLAKE_USER` / `SNOWFLAKE_USERNAME`, which other suites use for password auth against the same account. I initially assumed the opposite, based on the Workbench dashboard's Snowflake flow, which really does show Snowflake's native form because it arrives by a different route (an OAuth client rather than SSO).
- **`auth_web.js` has two login-URL branches**, and `disableConsoleLogin` defaults to `true`, so the live one is the opaque SSO URL from `getSSOURL` -- never the `/console/login` URL that `getLoginUrl` builds. Match any launched URL rather than a shape.

**Shared Okta flow.** The generic steps (SSO hop, credentials, TOTP with jittered retry) move to `test/e2e/utils/oktaSignIn.ts`, with each provider supplying its own post-OTP tail: Databricks clicks its two consent controls and waits for its loopback callback, Snowflake waits for the SAML post to land back on `localhost`. That tail runs *inside* the retry loop on purpose -- a rejected code and a stalled redirect are indistinguishable from outside, so a failure there retries with a fresh code rather than failing the run. `completeDatabricksOktaSignIn` becomes a thin wrapper; its behaviour is unchanged.

**Assertion targets.** `FINANCIAL__ECONOMIC_ESSENTIALS.CYBERSYN` is a Marketplace share, so it exposes 48 secure **views** and no tables -- its `Tables` node exists but is empty, which is why only `Views` is expanded. The three views asserted are catalog/index ones, chosen as least likely to be reshaped by an upstream data refresh. The Data Explorer test asserts the view's column count rather than its column names, matching #15696: the dataset is upstream and this suite's subject is the connection, not grid fidelity.

**No CI changes.** `SNOWFLAKE_ACCOUNT` and the `IDE_SERVICE_ACCOUNT_*` variables are already present on both Ubuntu lanes (the latter courtesy of #15696), so this suite runs on PRs as-is. `.env.e2e.example` gains `SNOWFLAKE_ACCOUNT` for local runs.

**TOTP budget.** Sign-in happens once in `beforeAll`, so the suite spends one code per run. This does make it a fourth consumer of the shared secret alongside the two Databricks OAuth suites and the Workbench managed-credentials lane, which is a deliberate trade -- a `@:connections` PR that silently skipped its OAuth coverage would be worse. If Okta lockouts appear, the mechanism is suites racing for the same 30-second window and the fix is scheduling, not the retry logic.

### Tags

Same limits as #15696, and for the same reason -- the shim reaches the extension host via `extraEnv`, which only the Electron launch path applies:

- **No `@:web` / `@:workbench`** -- `playwrightBrowser.ts` and `playwrightExternalServer.ts` build the server env from `process.env` alone, so the shim would be silently ignored and a real browser would launch.
- **No `@:win`** -- `open` invokes PowerShell by absolute path and never consults PATH.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:connections @:assistant @:workbench

`@:connections` covers the new suite. `@:assistant` and `@:workbench` are the regression surface for the `oktaSignIn.ts` extraction, which `completeDatabricksOktaSignIn` now routes through.

Verified locally on `e2e-electron`:

- **Snowflake: 4 passed (55.8s)** in its final shipping form.
- **Databricks: 3 passed** in the same run as a Snowflake pass (6 passed, 7.4m), confirming the Okta extraction is non-regressive against a real sign-in rather than only typechecking. That run also cleared a genuinely cold Databricks warehouse in ~3 minutes against the 420s budget added in #15696 -- the first real-world validation of that number.
- Two sequential Okta sign-ins in one run, both accepted on the first code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
