### PR TITLE
Stop retrying commands that failed for a non-retryable reason

### DIFF
--- a/scripts/run-with-retry.ps1
+++ b/scripts/run-with-retry.ps1
@@ -7,7 +7,12 @@
 
 param (
     [int]$maxAttempts = 3,
-    [string]$command
+    [string]$command,
+    # Output matching this pattern indicates a failure that retrying cannot fix,
+    # such as a credential Github has rejected. Replaying an npm install that
+    # takes the better part of an hour turns a fast failure into a job timeout,
+    # so stop as soon as we see one. Pass an empty string to always retry.
+    [string]$fatalPattern = 'HTTP 401|HTTP 403|Bad credentials|code E401|code E403'
 )
 
 if (-not $command) {
@@ -19,13 +24,18 @@ $attempt = 0
 $success = $false
 
 while ($attempt -lt $maxAttempts -and -not $success) {
-    try {
-        $attempt++
+    $attempt++
+    $output = @()
 
+    try {
         # Reset the exit code to 0 before running the command
         $global:LASTEXITCODE = 0
 
-        Invoke-Expression $command
+        # Tee the output so it still streams to the log while we keep a copy to
+        # check for failures that are not worth retrying. The redirection has to
+        # be inside the expression so that it applies to the command itself;
+        # redirecting Invoke-Expression would miss the child process's stderr.
+        Invoke-Expression "$command 2>&1" | Tee-Object -Variable output
 
         # Check the return value of the command and set $success to $true if it is successful
         if ($LASTEXITCODE -eq 0) {
@@ -33,19 +43,33 @@ while ($attempt -lt $maxAttempts -and -not $success) {
             Write-Host "Command '$command' succeeded"
         } else {
             Write-Host "Command '$command' had exit code $LASTEXITCODE on attempt $attempt of $maxAttempts"
-
-            # Wait 30 seconds before retrying to allow file locks to release
-            Start-Sleep -Seconds 30
         }
     }
     catch {
         # If the command fails, output an error message
         Write-Host "Command '$command' failed on attempt $attempt of $maxAttempts"
     }
+
+    if ($success) {
+        break
+    }
+
+    # Coerce each record to a string; a single-line result would otherwise
+    # enumerate as individual characters.
+    $joinedOutput = (@($output) | ForEach-Object { [string]$_ }) -join "`n"
+    if ($fatalPattern -and ($joinedOutput -match $fatalPattern)) {
+        Write-Host "Command '$command' failed with a non-retryable error (matched '$fatalPattern'); not retrying."
+        break
+    }
+
+    if ($attempt -lt $maxAttempts) {
+        # Wait 30 seconds before retrying to allow file locks to release
+        Start-Sleep -Seconds 30
+    }
 }
 
 # Check if the command was successful after the maximum attempts
 if (-not $success) {
-    Write-Host "Command '$command' failed after $maxAttempts attempts"
+    Write-Host "Command '$command' failed after $attempt attempt(s)"
+    exit 1
 }
-


### PR DESCRIPTION
The Windows build steps retry `npm clean-install` up to 5 times. Each attempt takes roughly 45 minutes, so a failure no retry can fix consumed the whole 120-minute job timeout and the job was cancelled mid-attempt rather than reporting the error. That is how a `HTTP 401` from `install-pet` turned into a 2-hour timeout in [this run](https://github.com/posit-dev/positron-builds/actions/runs/32821163078).

The 401 itself is fixed in posit-dev/positron-builds#1206. This change bounds the blast radius the next time something non-retryable breaks in that step.

- Break out of the retry loop when output matches a credential-rejection pattern
- Capture output with `Tee-Object` so it still streams to the log
- Put the redirection inside the expression string; redirecting `Invoke-Expression` misses the child process's stderr, which is where npm writes the error
- Skip the 30-second backoff after the final attempt
- `exit 1` explicitly instead of relying on `LASTEXITCODE` passthrough

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

Tested under `pwsh` 7.6.5 with `$ErrorActionPreference='stop'`:

| Case | Result |
| --- | --- |
| Command succeeds | exit 0, one attempt |
| 401 in output | Stops after 1 attempt in 0s (was 5 attempts over ~2h), exit 1 |
| Transient failure, all attempts fail | Still retries, exit 1, no trailing sleep |
| Transient failure then success | Recovers, exit 0 |
| Command with arguments | Arguments preserved, no redirection leakage into argv |
| `-fatalPattern ''` | Restores the previous always-retry behavior |

Only callers are the four `npm clean-install` invocations in `build-release-windows.yml`, so the pattern default only affects those.
