### PR TITLE
Make e2e notification helper tolerant of duplicate notifications

### DIFF
--- a/test/e2e/pages/dialog-toasts.ts
+++ b/test/e2e/pages/dialog-toasts.ts
@@ -65,7 +65,7 @@ export class Toasts {
 			: this.notificationsCenter.locator('.notification-list-item');
 
 		await Promise.race([
-			toastLocator.waitFor({ state: 'attached', timeout }),
+			toastLocator.first().waitFor({ state: 'attached', timeout }),
 			centerLocator.first().waitFor({ state: 'attached', timeout }),
 		]);
 
@@ -86,7 +86,9 @@ export class Toasts {
 			const scopedToast = notificationFilter
 				? this.toastNotification.filter({ hasText: notificationFilter })
 				: this.toastNotification;
-			const toastButton = scopedToast.getByRole('button', { name: button });
+			// Use first() so a duplicated or same-labelled notification cannot trigger
+			// a strict mode violation.
+			const toastButton = scopedToast.getByRole('button', { name: button }).first();
 			if (await toastButton.isVisible()) {
 				await toastButton.click();
 				return;
@@ -98,7 +100,7 @@ export class Toasts {
 			const scopedCenter = notificationFilter
 				? this.notificationsCenter.locator('.notification-list-item').filter({ hasText: notificationFilter })
 				: this.notificationsCenter;
-			const notificationCenterButton = scopedCenter.getByRole('button', { name: button });
+			const notificationCenterButton = scopedCenter.getByRole('button', { name: button }).first();
 			if (await notificationCenterButton.isVisible()) {
 				await notificationCenterButton.click();
 				await this.closeNotificationCenter();

--- a/test/e2e/pages/positAssistant.ts
+++ b/test/e2e/pages/positAssistant.ts
@@ -829,11 +829,11 @@ export class PositAssistant {
 			return;
 		}
 
-		await toasts.clickButton('Update Now');
+		await toasts.clickButton('Update Now', { notificationFilter: /newer Posit Assistant dev build is available/i });
 
 		// 4. Wait for the follow-up "reload to apply changes" toast and click "Reload".
 		await toasts.waitForAppear(/Posit Assistant has been updated\. You must reload Positron/i, { timeout: toastTimeout });
-		await toasts.clickButton('Reload');
+		await toasts.clickButton('Reload', { notificationFilter: /Posit Assistant has been updated\. You must reload Positron/i });
 
 		// 5. Clicking Reload reloads the window natively. Wait for the
 		//    workbench to come back up.


### PR DESCRIPTION
Test-only resilience fix for the e2e notification helper: a duplicated (or
merely same-labelled) notification should not be able to fail a test with a
Playwright strict-mode violation.

`anthropic-api - Open Posit Assistant and verify welcome page` has been failing
on chromium in its `beforeAll`:

```
Error: locator.isVisible: Error: strict mode violation:
locator('.notifications-center').getByRole('button', { name: 'Update Now' })
resolved to 2 elements
```

(example run:
https://github.com/posit-dev/positron/actions/runs/32491725238)

The duplicate itself is a product bug in the notifications center
(`NotificationsList` view-model bookkeeping across a hide/show), fixed
separately in #15668. This PR is the independent test-side mitigation and
touches no `src/` code: the helper should not break when more than one
notification matches, whatever the reason.

### Changes

`test/e2e/pages/dialog-toasts.ts` - `Toasts.clickButton()` resolved its toast
button and its notifications-center button as potentially-multi-element
locators, so `.isVisible()` / `.click()` threw under strict mode. Both now use
`.first()`. The toast branch of `waitForAppear()` gets the same treatment, for
consistency with the center branch which already used `.first()`.

Note that `notificationFilter` alone does *not* buy duplicate tolerance here:
the two duplicate rows are byte-identical (same message, same `Source:`, same
button labels), so a text filter still matches both. The tolerance comes from
`.first()`.

`test/e2e/pages/positAssistant.ts` - `checkForDevBuildUpdate()` called
`clickButton('Update Now')` and `clickButton('Reload')` unscoped, so they
searched the whole notifications center and would happily match an unrelated
notification carrying a button with the same label. Both now pass the
`notificationFilter` option that `clickButton` already supports, reusing the
same patterns as the adjacent `waitForAppear` calls.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

@:assistant @:web @:vscode-settings

`@:assistant` exercises the changed `checkForDevBuildUpdate()` path directly.
`@:vscode-settings` is the other heavy user of the notifications-center path
(`Toasts.expectImportSettingsToastToBeVisible` /
`Toasts.clickButton('Accept' | 'Reject' | "Don't Show Again")`), so it is the
regression check on the helper change.

What CI does and does not prove: #15668 has not merged as of opening this PR,
so `main` can still produce the duplicate - but the duplicate is intermittent,
so a green assistant run is consistent with the fix working *and* with the
duplicate simply not occurring in that run. Once #15668 lands, a green run is
purely a no-regression smoke check. The duplicate tolerance itself is
established by reading the locators, not by the run.

I could not run the posit-assistant e2e locally: it needs provider credentials
and there is no `.env` in the repo. Verified locally: `npm --prefix test/e2e
run compile` and `npm run precommit` on both changed files.
