### PR TITLE
Add e2e coverage for Packages pane security advisories

### DIFF
--- a/test/e2e/pages/packages.ts
+++ b/test/e2e/pages/packages.ts
@@ -22,6 +22,7 @@ export class Packages {
 	filterButton: Locator;
 	filterOptionsMenu: Locator;
 	filterOptionsSubmenu: Locator;
+	packageDetail: Locator;
 
 	constructor(private code: Code, private contextMenu: ContextMenu, private quickInput: QuickInput, private toasts: Toasts, private help: Help) {
 		this.packagesButton = this.code.driver.currentPage.locator('a.action-label.codicon-package');
@@ -42,6 +43,9 @@ export class Packages {
 			.locator('.positron-modal-popup-container .custom-context-menu-items');
 		this.filterOptionsMenu = popupItems.first();
 		this.filterOptionsSubmenu = popupItems.nth(1);
+		// The package editor's detail view. It opens in the editor area, not the
+		// pane, so it hangs off the page rather than off `packagesContainer`.
+		this.packageDetail = this.code.driver.currentPage.locator('.positron-package-detail');
 	}
 
 	/**
@@ -95,6 +99,27 @@ export class Packages {
 	async searchPackages(text: string): Promise<void> {
 		await this.clickPackagesButton();
 		await this.packagesContainer.getByPlaceholder('Filter packages').fill(text);
+		await this.scrollListToTop();
+	}
+
+	/**
+	 * Scrolls the packages list back to the top.
+	 *
+	 * Called after filtering because the list is a virtualized grid that tracks
+	 * its own vertical offset, and that offset is not clamped when the row count
+	 * shrinks (`PositronListInstance.setEntries` only fires an update; the clamp
+	 * against `maximumVerticalScrollOffset` lives in `DataGridInstance.setSize`,
+	 * which runs on resize). So a list scrolled even one row down -- which the
+	 * post-install scroll-and-flash does on its own -- renders *zero* rows once a
+	 * filter narrows it, because the render window sits past the new end of the
+	 * content. Scrolling to the top first puts the offset somewhere always valid.
+	 *
+	 * A wheel event rather than setting `scrollTop`: the grid's offset is internal
+	 * state, not the element's native scroll position.
+	 */
+	private async scrollListToTop(): Promise<void> {
+		await this.packagesContainer.hover({ position: { x: 20, y: 100 } });
+		await this.code.driver.currentPage.mouse.wheel(0, -20_000);
 	}
 
 	/**
@@ -253,13 +278,17 @@ export class Packages {
 		await this.quickInput.waitForQuickInputOpened();
 
 		if (options?.version) {
-			// Type the specific version
+			// Filter the version list down to the requested version, then click that
+			// row. Submitting the input box instead would accept whichever row the
+			// picker happens to have active, and the click below would then be left
+			// waiting on a picker that has already closed.
 			await this.quickInput.type(options.version);
-			await this.quickInput.submitInputBox();
+			await this.quickInput.selectQuickInputElementExact(options.version);
+		} else {
+			// Accept the first item: the version list is sorted descending, so this
+			// installs the newest version.
+			await this.quickInput.selectQuickInputElement(0);
 		}
-
-		// Press Enter to confirm version selection (select first item)
-		await this.quickInput.selectQuickInputElement(0);
 
 		await this.quickInput.waitForQuickInputClosed();
 
@@ -296,5 +325,115 @@ export class Packages {
 			menuTriggerButton: 'right',
 			exact: true
 		});
+	}
+
+	/**
+	 * Locates a package's whole row in the currently filtered list, so callers can
+	 * reach the badges that sit alongside the name rather than just the name cell.
+	 * The list is virtualized, so filter down to the package first.
+	 * @param packageName The exact package name whose row to return.
+	 */
+	private packageRow(packageName: string): Locator {
+		return this.packagesContainer.locator('.packages-list-item', {
+			// Anchored: a substring match would also accept 'bottleneck' when asked
+			// for 'bottle'.
+			has: this.code.driver.currentPage.locator('.packages-list-item-name', {
+				hasText: new RegExp(`^${packageName}$`),
+			}),
+		}).first();
+	}
+
+	/**
+	 * Locates the security advisory badge on a package row. Rendered only once
+	 * Package Manager has reported advisories for the installed version, so use
+	 * {@link expectVulnerabilityBadge} to wait for it.
+	 * @param packageName The exact package name whose badge to return.
+	 */
+	vulnerabilityBadge(packageName: string): Locator {
+		return this.packageRow(packageName).locator('.packages-list-item-vulnerable');
+	}
+
+	/**
+	 * Filters the list to a package and asserts its row carries a security
+	 * advisory badge for the expected advisory and severity. Asserts against the
+	 * badge's accessible name, which names the worst advisory and either its CVSS
+	 * score and band or -- for an advisory published without a score, as every
+	 * CRAN advisory is -- "Severity unknown".
+	 *
+	 * The default timeout is generous: the badge appears when the pane's metadata
+	 * stage completes, and that stage waits for the runtime's own outdated-version
+	 * fetch alongside the Package Manager round trip (whose budget is
+	 * `TOTAL_BUDGET_MS` in packageVulnerabilityLookup.ts) before it merges either
+	 * one. So the badge lands well after the row does.
+	 * @param packageName The exact package name whose badge to check.
+	 * @param expected The advisory id the badge should lead with, and the severity
+	 * band it should report ('unscored' for an advisory with no CVSS score).
+	 * @param timeout Max time to wait for the advisory data to land.
+	 */
+	async expectVulnerabilityBadge(
+		packageName: string,
+		expected: { advisoryId: string; severity: 'Critical' | 'High' | 'Medium' | 'Low' | 'unscored' },
+		timeout = 120_000,
+	): Promise<void> {
+		await this.searchPackages(packageName);
+		// Assert the row before the badge. Both a missing row and a missing badge
+		// fail the badge locator with "element(s) not found", and they have nothing
+		// to do with each other: no row means the filter or the list is the problem,
+		// no badge on a present row means the advisory data never arrived.
+		await expect(this.packageRow(packageName)).toBeVisible({ timeout: 60_000 });
+		const highest = expected.severity === 'unscored'
+			? 'Severity unknown'
+			// The score itself is deliberately loose: NVD rescores advisories, and
+			// PPM can start reporting a newer CVSS revision for the same one.
+			: `CVSS \\d+\\.\\d, ${expected.severity}`;
+		await expect(this.vulnerabilityBadge(packageName)).toHaveAttribute(
+			'aria-label',
+			new RegExp(`Highest: ${expected.advisoryId} \\(${highest}\\)`),
+			{ timeout },
+		);
+	}
+
+	/**
+	 * Opens a package's detail view by selecting its row, which opens the package
+	 * editor as a preview tab. Filters the list to the package first, since the
+	 * list is virtualized.
+	 * @param packageName The exact package name to open.
+	 */
+	async openPackageDetail(packageName: string): Promise<void> {
+		await this.searchPackages(packageName);
+		// The list is a virtualized grid whose rows are recreated whenever a
+		// refresh lands, and a freshly installed row also carries a transient
+		// 'recently-changed' class. A single click loses the race ("element was
+		// detached from the DOM"), so retry the click together with its outcome.
+		await expect(async () => {
+			await this.packageRow(packageName).click({ timeout: 5_000 });
+			await expect(
+				this.packageDetail.getByRole('heading', { name: packageName })
+			).toBeVisible({ timeout: 5_000 });
+		}).toPass({ timeout: 60_000 });
+	}
+
+	/**
+	 * Selects the Security tab in the open package detail view. The tab is offered
+	 * only when the runtime has advisory data for the package, so assert the row's
+	 * badge first.
+	 */
+	async clickSecurityTab(): Promise<void> {
+		// The tab's accessible name carries the advisory count ("Security, 1 known
+		// vulnerability"), so match on the leading word.
+		const tab = this.packageDetail.getByRole('tab', { name: /^Security/ });
+		await tab.click();
+		await expect(tab).toHaveAttribute('aria-selected', 'true');
+	}
+
+	/**
+	 * Asserts an advisory is listed in the open package detail view. Matches the
+	 * advisory's link, whose accessible name names the advisory.
+	 * @param advisoryId The advisory id as displayed, e.g. 'CVE-2022-31799'.
+	 */
+	async expectAdvisoryListed(advisoryId: string): Promise<void> {
+		await expect(
+			this.packageDetail.getByRole('button', { name: `Open advisory ${advisoryId}` })
+		).toBeVisible();
 	}
 }

--- a/test/e2e/tests/packages-pane/packages-pane-vulnerabilities.test.ts
+++ b/test/e2e/tests/packages-pane/packages-pane-vulnerabilities.test.ts
@@ -1,0 +1,115 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test, tags } from '../_test.setup';
+
+test.use({
+	suiteId: __filename,
+	extraSettings: {
+		'packages.enabled': true,
+		// On by default, but stated so the suite doesn't quietly stop testing
+		// anything if that default ever changes.
+		'packages.vulnerabilities.enabled': true,
+	},
+});
+
+/**
+ * Security advisories in the Packages pane.
+ *
+ * Both tests install a package whose *installed version* is permanently
+ * vulnerable, rather than asserting that something in the interpreter image
+ * happens to have an open advisory. The images are rebuilt from
+ * test-files/requirements.txt and test-files/DESCRIPTION, so ambient advisories
+ * come and go with each rebuild -- as of this writing not one package in
+ * DESCRIPTION has an open advisory at its latest version, and the whole CRAN
+ * advisory database is 14 records. An "at least one package is flagged" test
+ * would go red on a rebuild and read as a product regression.
+ *
+ * The data comes from a real Package Manager instance (the public one at
+ * packagemanager.posit.co unless the environment configures its own), so these
+ * tests need network access, same as the installs themselves.
+ */
+test.describe('Packages Pane - Security Advisories', {
+	tag: [tags.PACKAGES_PANE, tags.WEB]
+}, () => {
+
+	// Well past the 2 minute default. An install costs up to ~50s (the install
+	// helper spends 30s of that waiting out an "Installing packages..." toast that
+	// a fast install can clear before it is ever observed) and another ~20s before
+	// the new package reaches the list, and only then does the advisory lookup
+	// start -- with a budget of its own.
+	test.describe.configure({ timeout: 300_000 });
+
+	test.afterEach(async function ({ app, hotKeys }) {
+		await hotKeys.closeAllEditors();
+		await app.workbench.packages.clearFilter();
+		await app.workbench.packages.closePackagesPane();
+		// The Python package manager runs in the terminal, leaving it focused.
+		// Click the console label to take focus off the terminal so the next
+		// test's console interactions aren't typed into the terminal instead.
+		await app.workbench.console.clickConsoleLabel();
+	});
+
+	test('Python - Flags an installed package with a known CVE', async function ({ app, python: _python }) {
+		const { packages } = app.workbench;
+
+		// bottle 0.12.19 is affected by CVE-2022-31799, fixed in 0.12.20, so the
+		// advisory can never age out from under this test. It is a pure-Python
+		// wheel with no dependencies and nothing in the image depends on it, so
+		// installing and removing it perturbs nothing else.
+		await packages.verifyPackagesList();
+		await packages.installPackage('bottle', { version: '0.12.19' });
+		await packages.expectPackageInList('bottle');
+
+		// Refresh explicitly rather than relying on the refresh the install itself
+		// triggers, so the advisory data can't depend on whether the new package
+		// had reached the list by the time that refresh ran its metadata stage.
+		// This forces a live recompute for every installed package, so the badge
+		// can take a while to arrive.
+		await packages.clickRefreshPackagesButton();
+		await packages.expectVulnerabilityBadge('bottle', {
+			advisoryId: 'CVE-2022-31799',
+			severity: 'Critical',
+		});
+
+		// The Vulnerable filter keeps it.
+		await packages.searchPackages('@vulnerable bottle');
+		await packages.expectPackageInList('bottle');
+
+		await packages.openPackageDetail('bottle');
+		await packages.clickSecurityTab();
+		await packages.expectAdvisoryListed('CVE-2022-31799');
+
+		await packages.uninstallPackage('bottle');
+		await packages.expectPackageNotInList('bottle');
+	});
+
+	test('R - Flags an installed package with an unscored CRAN advisory', async function ({ app, r: _r }) {
+		const { packages } = app.workbench;
+
+		// widgetframe is affected by RSEC-2026-0 with no fixed version, so its
+		// latest release is vulnerable and no version pin (and no source build) is
+		// needed. CRAN advisories carry no CVSS score, so this also covers the
+		// unscored rendering: a shield with no number, reported as
+		// "Severity unknown" rather than a band.
+		await packages.verifyPackagesList();
+		await packages.installPackage('widgetframe');
+		await packages.expectPackageInList('widgetframe');
+
+		// Same forced refresh as the Python test, to keep both on one path.
+		await packages.clickRefreshPackagesButton();
+		await packages.expectVulnerabilityBadge('widgetframe', {
+			advisoryId: 'RSEC-2026-0',
+			severity: 'unscored',
+		});
+
+		await packages.openPackageDetail('widgetframe');
+		await packages.clickSecurityTab();
+		await packages.expectAdvisoryListed('RSEC-2026-0');
+
+		await packages.uninstallPackage('widgetframe');
+		await packages.expectPackageNotInList('widgetframe');
+	});
+});


### PR DESCRIPTION
Adds e2e coverage for the Packages pane's security advisory (CVE) indicators, for Python and R.

### Summary

The interpreter images are rebuilt monthly from `test/e2e/test-files/requirements.txt` and `test/e2e/test-files/DESCRIPTION`, so a test that asserts "some installed package has an advisory" changes meaning with every rebuild. That approach also does not work today: of the 50 latest-version packages I queried against Package Manager (including every package in `DESCRIPTION`), **none** has an open advisory, and the entire OSV CRAN database is 14 records across 10 packages.

So each test installs a package whose *installed version* is permanently vulnerable:

- **Python** — `bottle==0.12.19`, affected by CVE-2022-31799 and fixed in 0.12.20, so the advisory cannot age out from under the test. Zero dependencies, pure-Python wheel, and nothing in the image depends on it, so installing and removing it perturbs nothing else. Covers the scored/banded rendering (Critical, with a CVSS score on the badge).
- **R** — `widgetframe` at its latest version. Its advisory RSEC-2026-0 has no fixed version, so the current release is affected and no version pin (and no source build) is needed. That matters because R cannot install a historical version through the pane at all — `searchPackageVersions` returns only the current version from configured repos, with a `TODO` for archives. Every CRAN advisory is also unscored, so this covers the "Severity unknown" rendering path.

Badge assertions read the accessible name and match the score loosely (`CVSS \d+\.\d`), so an NVD rescore within the same severity band will not break them.

### Page object changes

`test/e2e/pages/packages.ts` gains badge, row, detail-view and Security-tab helpers, plus two fixes to existing methods that the new tests exercise:

- **`installPackage({ version })` was broken.** No test had used the `version` option. It typed the version, pressed Enter (accepting whichever quick-pick row was active), and then called `selectQuickInputElement(0)`, which waited on a picker that had already closed. It now filters and clicks the exact version row.
- **`searchPackages` now scrolls the list to the top,** working around #15714: filtering a scrolled Positron list renders an empty pane, because `PositronListInstance.setEntries()` does not clamp the grid's vertical scroll offset when the row count shrinks. The helper carries a comment explaining why it exists so it can be deleted when that issue is fixed.

The list bug was found by this work: the advisory data was correct throughout, the matching row was simply never rendered.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:packages-pane @:web

Both new tests pass locally on Electron, as do the six pre-existing packages-pane tests — the latter being the check that matters, since this PR touches two shared page object methods:

```
✓ Python - Flags an installed package with a known CVE (54.0s)
✓ R - Flags an installed package with an unscored CRAN advisory (9.6s)
✓ Python - Install, search, and uninstall package (python) (34.1s)
✓ Python - Install, search, and uninstall package (pythonAlt) (14.2s)
✓ R - Install, search, and uninstall package (8.9s)
✓ R - Opens package help in Help pane (1.6s)
✓ Python - Opens package help in Help pane (2.7s)
✓ Python - Shows external link for a package with a homepage (2.0s)

8 passed (2.9m)
```

The new tests reach a real Package Manager instance (the public one at packagemanager.posit.co unless the environment configures its own), so they need network access — as the installs themselves already do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
