### PR TITLE
drive-positron skill: launch out-of-process on Windows so R sessions start

### DIFF
--- a/.claude/skills/drive-positron/SKILL.md
+++ b/.claude/skills/drive-positron/SKILL.md
@@ -51,6 +51,25 @@ Tools they expect on `PATH`:
 | `rsync` or `tar` | `launch.sh` | `rsync` preferred; `tar` is the fallback, and is what Git Bash has |
 | `jq` | `monaco-paste.sh` | not present in a bare Git Bash; install it separately |
 | `cygpath` | `launch.sh` on Windows | ships with Git Bash |
+| `tasklist`, `powershell` | `launch.sh` on Windows | liveness check and the WMI launch below |
+
+### Windows launches the app out-of-process on purpose
+
+On Windows `launch.sh` does not spawn the app directly. It writes
+`launch-app.cmd` and `launch-app.ps1` into the run directory and has WMI
+(`Win32_Process.Create`) start the app, which reparents it to `WmiPrvSE` while
+keeping it in the interactive session. Do not "simplify" this back to a direct
+background spawn.
+
+The reason is Ark, the R kernel. It statically links a ZeroMQ built with the
+`wepoll` poller, which opens `\Device\Afd` directly, and that call fails for any
+process inside an agent session's process tree. A directly spawned app therefore
+starts, but every R session dies immediately with `exit code 1073741845` and
+`not a socket (...epoll.cpp:73)`. Python is unaffected, because its ZeroMQ uses
+the `select` poller -- so the symptom looks like an R-specific bug and is not.
+
+macOS and Linux keep the plain background spawn: their ZeroMQ uses kqueue and
+kernel epoll, neither of which opens a device handle.
 
 ## Launch Positron
 

--- a/.claude/skills/drive-positron/scripts/launch.sh
+++ b/.claude/skills/drive-positron/scripts/launch.sh
@@ -56,6 +56,20 @@ to_native_path() {
 	fi
 }
 
+# Whether a process is still running. On Windows the launch PID is a native
+# Windows PID (see the launch block below), which MSYS `kill` does not
+# reliably address, so ask Windows instead. Elsewhere this is `kill -0`.
+#
+# CSV output is matched on the quoted PID field so the digits cannot also match
+# the memory column: plain output for PID 268 would match "4,268 K".
+is_process_alive() {
+	if [[ "$IS_WINDOWS" == "1" ]]; then
+		tasklist //FI "PID eq $1" //FO CSV //NH 2>/dev/null | grep -q "\"$1\""
+	else
+		kill -0 "$1" 2>/dev/null
+	fi
+}
+
 # Copy a directory tree, honoring rsync-style exclude patterns.
 #
 # Prefers rsync where it exists so the established macOS and Linux behavior is
@@ -288,19 +302,68 @@ if ! ( cd "$REPO" && node build/lib/preLaunch.ts ) >>"$LOG_FILE" 2>&1; then
 	exit 1
 fi
 
-# Detach code.sh after pre-launch. Once CDP responds, Electron has established
+# Detach the app after pre-launch. Once CDP responds, Electron has established
 # its independent process tree.
-nohup env VSCODE_SKIP_PRELAUNCH=1 "$CODE_SH" "${ARGS[@]}" \
-	</dev/null >>"$LOG_FILE" 2>&1 &
-PID=$!
-disown $PID 2>/dev/null || true
+#
+# On Windows the app must not be a descendant of this script's process tree.
+# Ark (the R kernel) statically links a ZeroMQ built with the `wepoll` poller,
+# which opens \Device\Afd directly; that call fails for any process inside an
+# agent session's process tree, so every R session dies at startup with
+# "not a socket (...epoll.cpp:73)" and exit code 1073741845. Handing the launch
+# to WMI reparents the app to WmiPrvSE, still in the interactive session, which
+# clears it. Python is unaffected (its ZeroMQ uses the `select` poller), so the
+# symptom reads as an R-specific bug. Do not "simplify" this back to a direct
+# spawn. macOS and Linux use kqueue and kernel epoll, need no device handle,
+# and keep the plain background spawn below.
+if [[ "$IS_WINDOWS" == "1" ]]; then
+	# Route through generated wrapper scripts rather than inline quoting: the
+	# command line crosses bash -> PowerShell -> cmd, and each layer would
+	# otherwise need its own escaping. Both files stay in $RUN_DIR for
+	# debugging.
+	APP_CMD="$RUN_DIR/launch-app.cmd"
+	{
+		echo "@echo off"
+		echo "set VSCODE_SKIP_PRELAUNCH=1"
+		printf 'cd /d "%s"\n' "$(to_native_path "$REPO")"
+		printf 'call scripts\\code.bat'
+		for arg in "${ARGS[@]}"; do
+			printf ' "%s"' "$arg"
+		done
+		printf ' >> "%s" 2>&1\n' "$(to_native_path "$LOG_FILE")"
+	} >"$APP_CMD"
+
+	APP_PS1="$RUN_DIR/launch-app.ps1"
+	cat >"$APP_PS1" <<-PSEOF
+		\$result = Invoke-CimMethod -ClassName Win32_Process -MethodName Create \`
+			-Arguments @{ CommandLine = 'cmd.exe /c "$(to_native_path "$APP_CMD")"' }
+		if (\$result.ReturnValue -ne 0) {
+			Write-Error "Win32_Process.Create failed with ReturnValue \$(\$result.ReturnValue)."
+			exit 1
+		}
+		\$result.ProcessId
+	PSEOF
+
+	PID=$(powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass \
+		-File "$(to_native_path "$APP_PS1")" 2>>"$LOG_FILE" | tr -d '\r' | tail -n 1)
+	if [[ ! "$PID" =~ ^[0-9]+$ ]]; then
+		echo "[launch.sh] WMI launch did not return a PID. Log tail:" >&2
+		tail -n 80 "$LOG_FILE" >&2
+		exit 1
+	fi
+	echo "[launch.sh] launched out-of-tree via WMI (wrapper PID $PID)" >&2
+else
+	nohup env VSCODE_SKIP_PRELAUNCH=1 "$CODE_SH" "${ARGS[@]}" \
+		</dev/null >>"$LOG_FILE" 2>&1 &
+	PID=$!
+	disown $PID 2>/dev/null || true
+fi
 
 # Wait until CDP responds, reporting an early exit or timeout with the log tail.
 echo "[launch.sh] waiting for CDP on port $CDP_PORT (timeout 90s)..." >&2
 READY=0
 for i in $(seq 1 90); do
-	if ! kill -0 "$PID" 2>/dev/null; then
-		echo "[launch.sh] code.sh (PID $PID) exited before CDP came up. Log tail:" >&2
+	if ! is_process_alive "$PID"; then
+		echo "[launch.sh] launcher (PID $PID) exited before CDP came up. Log tail:" >&2
 		tail -n 80 "$LOG_FILE" >&2
 		exit 1
 	fi
@@ -320,7 +383,7 @@ fi
 # CDP can become available immediately before a main-process socket failure.
 # Recheck liveness after a short delay before reporting success.
 sleep 2
-if ! kill -0 "$PID" 2>/dev/null; then
+if ! is_process_alive "$PID"; then
 	echo "[launch.sh] app exited immediately after CDP came up. Log tail:" >&2
 	tail -n 80 "$LOG_FILE" >&2
 	exit 1

--- a/.claude/skills/drive-positron/scripts/launch.sh
+++ b/.claude/skills/drive-positron/scripts/launch.sh
@@ -70,6 +70,17 @@ is_process_alive() {
 	fi
 }
 
+# Escape a value for literal use inside a generated batch file. cmd.exe expands
+# `%` when it runs the wrapper, and `%1`-`%9` are positional parameters, so a
+# percent-encoded path silently loses characters: `file:///c%3A/my%20dir` would
+# reach the app as `file:///cA/my0dir`. Doubling `%` makes cmd emit one.
+#
+# This assumes exactly one expansion pass, which holds only because the wrapper
+# invokes code.bat without `call`. See the note at the write site.
+cmd_escape() {
+	printf '%s' "${1//%/%%}"
+}
+
 # Copy a directory tree, honoring rsync-style exclude patterns.
 #
 # Prefers rsync where it exists so the established macOS and Linux behavior is
@@ -324,18 +335,27 @@ if [[ "$IS_WINDOWS" == "1" ]]; then
 	{
 		echo "@echo off"
 		echo "set VSCODE_SKIP_PRELAUNCH=1"
-		printf 'cd /d "%s"\n' "$(to_native_path "$REPO")"
-		printf 'call scripts\\code.bat'
+		printf 'cd /d "%s"\n' "$(cmd_escape "$(to_native_path "$REPO")")"
+		# Deliberately not `call`: `call` performs an extra round of percent
+		# expansion, which would consume the escaping applied below (an
+		# argument containing %20 would arrive as "0"). Nothing follows this
+		# line, so there is no need to return to the wrapper.
+		printf 'scripts\\code.bat'
 		for arg in "${ARGS[@]}"; do
-			printf ' "%s"' "$arg"
+			printf ' "%s"' "$(cmd_escape "$arg")"
 		done
-		printf ' >> "%s" 2>&1\n' "$(to_native_path "$LOG_FILE")"
+		printf ' >> "%s" 2>&1\n' "$(cmd_escape "$(to_native_path "$LOG_FILE")")"
 	} >"$APP_CMD"
+
+	# The wrapper path lands inside a single-quoted PowerShell string, where a
+	# literal quote is escaped by doubling it.
+	APP_CMD_NATIVE="$(to_native_path "$APP_CMD")"
+	APP_CMD_NATIVE="${APP_CMD_NATIVE//\'/\'\'}"
 
 	APP_PS1="$RUN_DIR/launch-app.ps1"
 	cat >"$APP_PS1" <<-PSEOF
 		\$result = Invoke-CimMethod -ClassName Win32_Process -MethodName Create \`
-			-Arguments @{ CommandLine = 'cmd.exe /c "$(to_native_path "$APP_CMD")"' }
+			-Arguments @{ CommandLine = 'cmd.exe /c "$APP_CMD_NATIVE"' }
 		if (\$result.ReturnValue -ne 0) {
 			Write-Error "Win32_Process.Create failed with ReturnValue \$(\$result.ReturnValue)."
 			exit 1


### PR DESCRIPTION
On Windows, an Ark (R) kernel started by the `drive-positron` skill always died
immediately with `exit code 1073741845` and
`not a socket (...zeromq-src-0.3.6+4.3.5\vendor\src\epoll.cpp:73)`.

The cause is not Positron, Ark, or a stale ark binary. Ark statically links a
ZeroMQ built with the `wepoll` poller, which opens `\Device\Afd` directly, and
that call fails for any process inside an agent session's process tree. Because
the skill spawned the app as a direct child, every R session it started
inherited the constraint. Reproduced with no Positron involved at all -- running
`ark.exe --connection_file` directly dies at its first ZeroMQ poller
registration, before R loads -- and the same binary succeeds when launched
outside the tree.

This is why nobody has hit it in CI or a release build: it needs Windows **and**
an agent-launched dev build **and** an R session. Python is unaffected, because
its ZeroMQ uses the `select` poller -- which is exactly what made this read as an
R-specific bug and cost a couple of sessions chasing Ark and the ark submodule.

### What changed

`scripts/launch.sh`, Windows-only in effect:

- Hand the app launch to WMI (`Win32_Process.Create`), which reparents it to
  `WmiPrvSE` while keeping it in the interactive session. The command line
  crosses bash -> PowerShell -> cmd, so it goes through generated
  `launch-app.cmd` / `launch-app.ps1` wrappers in the run directory rather than
  inline quoting at each layer. Both files stay put for debugging.
- Add `is_process_alive()`. The WMI PID is a native Windows PID, which MSYS
  `kill -0` does not reliably address, so Windows asks `tasklist`, matched on the
  quoted CSV PID field so the digits cannot also match the memory column
  (`"Positron.exe","17924","Console","1","975,452 K"` -- PID `452` would
  otherwise match). Everything else keeps the original `kill -0`.
- Escape `%` when generating the batch wrapper. `%1`-`%9` are batch positional
  parameters, so an unescaped percent-encoded path lost characters silently: a
  workspace at `...\Temp\pct%20test%3Adir` opened `...\Temp\pct0testAdir`.
  Reachable through any `--` passthrough argument and through any workspace path
  containing `%`, which is legal in Windows filenames.

The second commit also drops the `call` before `code.bat`, because `call` adds a
second percent-expansion pass that consumes the escaping. Measured, forwarding an
argument through a nested batch file's `%*`:

| variant | result |
|---|---|
| `call` + `%%` | `pct0test` (wrong) |
| `call` + `%%%%` | `pct%20test` (right) |
| no `call` + `%%` | `pct%20test` (right) |
| no `call` + `%%%%` | `pct%%20test` (wrong) |

Dropping `call` was preferred over quadrupling the escaping so correctness does
not depend on knowing how many expansion passes the invocation happens to make.

`SKILL.md` documents why the Windows launch is indirect, so a future reader does
not "simplify" it back to a direct spawn.

`stop.sh` needed no change -- it already resolves PIDs from the CDP port listener
and uses `taskkill //T` on Windows.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

<!-- Dev tooling only; no shipped product code is touched. -->

### Validation Steps

No e2e tags: this changes an agent-invoked development skill, not product code,
so CI does not exercise it.

Verified on Windows 11 through the patched skill:

- R 4.4.1 starts and `sum(1:10)` returns `[1] 55`.
- The app's parent chain is `Positron <- cmd <- WmiPrvSE <- svchost`, clear of
  the agent chain (`pwsh <- claude <- claude`), and the wrapper PID reported by
  `launch.sh` is the one it tracks.
- A workspace at `...\Temp\pct%20test%3Adir` yields a window titled
  `pct%20test%3Adir` and an explorer root of `Temp\pct%20test%3Adir\probe`
  (before: `pct0testAdir`).
- `stop.sh` tears down the whole tree including `kcserver`, and removes the run
  directory.
- `bash -n` clean; `npm run precommit` passes.

**Reviewer note on risk:** the macOS and Linux path is byte-identical, moved
verbatim into the `else` branch of the existing `IS_WINDOWS` check, and
`is_process_alive()` falls through to the original `kill -0`. I could not execute
that branch on Windows, so its safety rests on the code being unchanged rather
than on a test run -- a single `launch.sh` run on macOS would confirm it.
