### PR TITLE
Recolor LLM provider icons to theme foreground in the new provider modal

### DIFF
--- a/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
@@ -333,7 +333,7 @@ const ApiTypeEntry = (props: { option: ApiTypeOption }) => (
 export const ConnectProviderHeader = (props: { source: IPositronLanguageModelSource; subtitle?: string }) => (
 	<div className='connect-provider-header'>
 		<div className='connect-provider-icon'>
-			<LanguageModelIcon logoUrl={props.source.provider.logoUrl} provider={props.source.provider.id} />
+			<LanguageModelIcon monochrome logoUrl={props.source.provider.logoUrl} provider={props.source.provider.id} />
 		</div>
 		<div className='connect-provider-header-text'>
 			<span className='connect-provider-name'>{props.source.provider.displayName}</span>

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelButton.css
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelButton.css
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/*
+ * Recolor the built-in provider SVGs to the theme's icon foreground so they stay
+ * legible on every theme (see #15321). Gated on the `monochrome` class, which the
+ * component only adds when the caller opts in (the new provider modal); the
+ * legacy dialog leaves icons in their original brand colors. Cover every
+ * fillable shape element, since some marks (e.g. Posit AI) use a `rect` beside
+ * `path`. The URL-logo path recolors itself via a mask in the component.
+ */
+.language-model.icon.monochrome path,
+.language-model.icon.monochrome rect,
+.language-model.icon.monochrome circle,
+.language-model.icon.monochrome ellipse,
+.language-model.icon.monochrome polygon,
+.language-model.icon.monochrome polyline {
+	fill: var(--vscode-icon-foreground);
+}

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelButton.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelButton.tsx
@@ -3,6 +3,8 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import './languageModelButton.css';
+
 import * as React from 'react';
 
 import { localize } from '../../../../../nls.js';
@@ -68,35 +70,57 @@ export const LanguageModelButton = React.forwardRef<HTMLDivElement, LanguageMode
 	);
 });
 
-export const LanguageModelIcon = (props: { provider: string; logoUrl?: string }) => {
+export const LanguageModelIcon = (props: { provider: string; logoUrl?: string; monochrome?: boolean }) => {
+	// When `monochrome`, recolor the icon to the theme's icon foreground so it stays
+	// legible on every theme (see #15321). Only the new provider modal opts in;
+	// the legacy dialog renders icons in their original brand colors.
+	const iconClassName = positronClassNames('language-model icon', { monochrome: props.monochrome });
 	function getIcon() {
 		if (props.logoUrl) {
-			return <img className='language-model icon' src={props.logoUrl} />;
+			// A plain <img> can't be recolored, so when monochrome we paint the theme
+			// color and clip it to the logo shape with a CSS mask. Otherwise the
+			// logo renders as-is.
+			return props.monochrome
+				? <div className={iconClassName}
+					style={{
+						flex: 'none',
+						backgroundColor: 'var(--vscode-icon-foreground)',
+						WebkitMaskImage: `url(${props.logoUrl})`,
+						maskImage: `url(${props.logoUrl})`,
+						WebkitMaskSize: 'contain',
+						maskSize: 'contain',
+						WebkitMaskRepeat: 'no-repeat',
+						maskRepeat: 'no-repeat',
+						WebkitMaskPosition: 'center',
+						maskPosition: 'center',
+					}}
+				/>
+				: <img className={iconClassName} src={props.logoUrl} />;
 		}
 		switch (props.provider) {
 			case 'anthropic-api':
-				return <Claude className='language-model icon' />;
+				return <Claude className={iconClassName} />;
 			case 'google':
-				return <Gemini className='language-model icon' />;
+				return <Gemini className={iconClassName} />;
 			case 'google-cloud':
-				return <Geap className='language-model icon' />;
+				return <Geap className={iconClassName} />;
 			case 'copilot':
 			case 'copilot-auth':
-				return <GithubCopilot className='language-model icon' />;
+				return <GithubCopilot className={iconClassName} />;
 			case 'amazon-bedrock': // Vercel API uses this as an id
-				return <Bedrock className='language-model icon' />;
+				return <Bedrock className={iconClassName} />;
 			case 'deepseek-api':
-				return <DeepSeek className='language-model icon' />;
+				return <DeepSeek className={iconClassName} />;
 			case 'openai-api':
-				return <OpenAI className='language-model icon' />;
+				return <OpenAI className={iconClassName} />;
 			case 'ms-foundry':
-				return <MicrosoftFoundry className='language-model icon' />;
+				return <MicrosoftFoundry className={iconClassName} />;
 			case 'posit-ai':
-				return <PositAi className='language-model icon' />;
+				return <PositAi className={iconClassName} />;
 			case 'snowflake-cortex':
-				return <Snowflake className='language-model icon' />;
+				return <Snowflake className={iconClassName} />;
 			case 'databricks':
-				return <Databricks className='language-model icon' />;
+				return <Databricks className={iconClassName} />;
 			case 'openai-compatible':
 				return <div className={`language-model icon button-icon codicon codicon-wrench`} />;
 			case 'error':

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelButton.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelButton.tsx
@@ -78,15 +78,21 @@ export const LanguageModelIcon = (props: { provider: string; logoUrl?: string; m
 	function getIcon() {
 		if (props.logoUrl) {
 			// A plain <img> can't be recolored, so when monochrome we paint the theme
-			// color and clip it to the logo shape with a CSS mask. Otherwise the
-			// logo renders as-is.
-			return props.monochrome
-				? <div className={iconClassName} data-testid='language-model-icon'
+			// color and clip it to the logo shape with a CSS mask (logoUrl is a
+			// transparent-background icon; see IPositronProviderMetadata).
+			// Otherwise the logo renders as-is.
+			if (props.monochrome) {
+				// Quote and escape the URL: an unquoted CSS url() token can't hold
+				// whitespace, quotes, or parens, which some values (e.g. inline SVG
+				// data URIs) contain -- an invalid declaration would drop the mask
+				// and leave a solid theme-colored square.
+				const maskUrl = `url("${props.logoUrl.replace(/["\\]/g, '\\$&')}")`;
+				return <div className={iconClassName} data-testid='language-model-icon'
 					style={{
 						flex: 'none',
 						backgroundColor: 'var(--vscode-icon-foreground)',
-						WebkitMaskImage: `url(${props.logoUrl})`,
-						maskImage: `url(${props.logoUrl})`,
+						WebkitMaskImage: maskUrl,
+						maskImage: maskUrl,
 						WebkitMaskSize: 'contain',
 						maskSize: 'contain',
 						WebkitMaskRepeat: 'no-repeat',
@@ -94,8 +100,9 @@ export const LanguageModelIcon = (props: { provider: string; logoUrl?: string; m
 						WebkitMaskPosition: 'center',
 						maskPosition: 'center',
 					}}
-				/>
-				: <img className={iconClassName} data-testid='language-model-icon' src={props.logoUrl} />;
+				/>;
+			}
+			return <img className={iconClassName} data-testid='language-model-icon' src={props.logoUrl} />;
 		}
 		switch (props.provider) {
 			case 'anthropic-api':

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelButton.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelButton.tsx
@@ -81,7 +81,7 @@ export const LanguageModelIcon = (props: { provider: string; logoUrl?: string; m
 			// color and clip it to the logo shape with a CSS mask. Otherwise the
 			// logo renders as-is.
 			return props.monochrome
-				? <div className={iconClassName}
+				? <div className={iconClassName} data-testid='language-model-icon'
 					style={{
 						flex: 'none',
 						backgroundColor: 'var(--vscode-icon-foreground)',
@@ -95,39 +95,39 @@ export const LanguageModelIcon = (props: { provider: string; logoUrl?: string; m
 						maskPosition: 'center',
 					}}
 				/>
-				: <img className={iconClassName} src={props.logoUrl} />;
+				: <img className={iconClassName} data-testid='language-model-icon' src={props.logoUrl} />;
 		}
 		switch (props.provider) {
 			case 'anthropic-api':
-				return <Claude className={iconClassName} />;
+				return <Claude className={iconClassName} data-testid='language-model-icon' />;
 			case 'google':
-				return <Gemini className={iconClassName} />;
+				return <Gemini className={iconClassName} data-testid='language-model-icon' />;
 			case 'google-cloud':
-				return <Geap className={iconClassName} />;
+				return <Geap className={iconClassName} data-testid='language-model-icon' />;
 			case 'copilot':
 			case 'copilot-auth':
-				return <GithubCopilot className={iconClassName} />;
+				return <GithubCopilot className={iconClassName} data-testid='language-model-icon' />;
 			case 'amazon-bedrock': // Vercel API uses this as an id
-				return <Bedrock className={iconClassName} />;
+				return <Bedrock className={iconClassName} data-testid='language-model-icon' />;
 			case 'deepseek-api':
-				return <DeepSeek className={iconClassName} />;
+				return <DeepSeek className={iconClassName} data-testid='language-model-icon' />;
 			case 'openai-api':
-				return <OpenAI className={iconClassName} />;
+				return <OpenAI className={iconClassName} data-testid='language-model-icon' />;
 			case 'ms-foundry':
-				return <MicrosoftFoundry className={iconClassName} />;
+				return <MicrosoftFoundry className={iconClassName} data-testid='language-model-icon' />;
 			case 'posit-ai':
-				return <PositAi className={iconClassName} />;
+				return <PositAi className={iconClassName} data-testid='language-model-icon' />;
 			case 'snowflake-cortex':
-				return <Snowflake className={iconClassName} />;
+				return <Snowflake className={iconClassName} data-testid='language-model-icon' />;
 			case 'databricks':
-				return <Databricks className={iconClassName} />;
+				return <Databricks className={iconClassName} data-testid='language-model-icon' />;
 			case 'openai-compatible':
-				return <div className={`language-model icon button-icon codicon codicon-wrench`} />;
+				return <div className={`language-model icon button-icon codicon codicon-wrench`} data-testid='language-model-icon' />;
 			case 'error':
-				return <div className={`language-model icon button-icon codicon codicon-error`} />;
+				return <div className={`language-model icon button-icon codicon codicon-error`} data-testid='language-model-icon' />;
 			case 'echo':
 			case 'test':
-				return <div className={`language-model icon button-icon codicon codicon-info`} />;
+				return <div className={`language-model icon button-icon codicon codicon-info`} data-testid='language-model-icon' />;
 			default:
 				return null;
 		}

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/providerListItem.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/providerListItem.tsx
@@ -62,7 +62,7 @@ export const ProviderListItem = (props: ProviderListItemProps) => {
 	return (
 		<div className='provider-list-item' data-provider-section={section} data-testid={`provider-row-${source.provider.id}`}>
 			<div className='provider-list-item-icon'>
-				<LanguageModelIcon logoUrl={source.provider.logoUrl} provider={source.provider.id} />
+				<LanguageModelIcon monochrome logoUrl={source.provider.logoUrl} provider={source.provider.id} />
 			</div>
 			<div className='provider-list-item-text'>
 				<div className='provider-list-item-name'>

--- a/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
@@ -86,7 +86,12 @@ export interface IPositronProviderMetadata {
 	 * 'preview', then 'experimental'.
 	 */
 	status?: 'preview' | 'experimental';
-	/** Optional data URL for the provider icon (e.g., data:image/svg+xml;base64,...) */
+	/**
+	 * Optional URL for the provider icon (e.g., data:image/svg+xml;base64,...).
+	 * It must be an icon with a transparent background (like a codicon): the new
+	 * provider modal recolors it to the theme foreground by using it as a CSS
+	 * mask, so an opaque image would mask to a solid theme-colored square.
+	 */
 	logoUrl?: string;
 }
 

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/languageModelIcon.vitest.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/languageModelIcon.vitest.tsx
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+/// <reference types="@testing-library/jest-dom/vitest" />
+
+import { render, screen } from '@testing-library/react';
+import { LanguageModelIcon } from '../../browser/components/languageModelButton.js';
+
+const LOGO_URL = 'https://example.com/logo.svg';
+
+describe('LanguageModelIcon', () => {
+	describe('URL logo', () => {
+		it('renders a plain <img> with the logo src and no monochrome class when not monochrome', () => {
+			render(<LanguageModelIcon logoUrl={LOGO_URL} provider='custom' />);
+
+			const img = screen.getByRole('img');
+			expect(img).toHaveAttribute('src', LOGO_URL);
+			expect(img).toHaveClass('language-model', 'icon');
+			expect(img).not.toHaveClass('monochrome');
+		});
+
+		it('renders a masked element (not an <img>) with the monochrome class when monochrome', () => {
+			render(<LanguageModelIcon monochrome logoUrl={LOGO_URL} provider='custom' />);
+
+			// The theme-recolored logo is painted via a CSS mask on a div, so there
+			// must be no raw <img> (which would show the un-recolored logo -- the bug).
+			expect(screen.queryByRole('img')).not.toBeInTheDocument();
+			expect(screen.getByTestId('language-model-icon')).toHaveClass('monochrome');
+		});
+	});
+
+	describe('built-in provider icon', () => {
+		it('adds the monochrome class to a built-in provider icon when monochrome', () => {
+			render(<LanguageModelIcon monochrome provider='anthropic-api' />);
+
+			expect(screen.getByTestId('language-model-icon')).toHaveClass('monochrome');
+		});
+
+		it('omits the monochrome class from a built-in provider icon by default', () => {
+			render(<LanguageModelIcon provider='anthropic-api' />);
+
+			expect(screen.getByTestId('language-model-icon')).not.toHaveClass('monochrome');
+		});
+
+		it('leaves a codicon fallback icon un-monochromed even when monochrome', () => {
+			// Codicon fallbacks (e.g. the custom-provider wrench) are font glyphs
+			// colored by `currentColor`, so they are already theme-legible and are
+			// deliberately not recolored -- the monochrome class would be a no-op.
+			render(<LanguageModelIcon monochrome provider='openai-compatible' />);
+
+			expect(screen.getByTestId('language-model-icon')).not.toHaveClass('monochrome');
+		});
+	});
+});


### PR DESCRIPTION
Fixes #15321

Some LLM provider icons were hard to see on certain themes (Tomorrow Blue, Dark, Dark 2026, High Contrast Dark) because their brand colors clashed with the background. In the redesigned provider modal, provider icons are now recolored to the theme's icon foreground so they stay legible on every theme: built-in brand SVGs via a `fill` override on all fillable shapes, and URL-based logos via a CSS mask that paints the theme color and clips it to the logo shape. The recolor is opt-in per call site (a `monochrome` prop), so the legacy provider dialog keeps its original brand-colored icons.

### Screenshots

<img width="316" height="130" alt="Screenshot 2026-08-25 at 3 43 14 PM" src="https://github.com/user-attachments/assets/c0f92707-3883-4c47-b0d6-246cf190b524" />
<img width="271" height="132" alt="Screenshot 2026-08-25 at 3 19 56 PM" src="https://github.com/user-attachments/assets/ac170693-ecdd-4b4a-a2ab-c71d27ac4fd9" />
<img width="293" height="113" alt="Screenshot 2026-08-25 at 3 19 53 PM" src="https://github.com/user-attachments/assets/0918f272-b0fa-4862-a2ee-48fc5863a621" />
<img width="265" height="104" alt="Screenshot 2026-08-25 at 3 19 38 PM" src="https://github.com/user-attachments/assets/7453b011-3b3d-404e-9c8e-4169e7b307af" />
<img width="278" height="87" alt="Screenshot 2026-08-25 at 3 19 36 PM" src="https://github.com/user-attachments/assets/9eca5690-803c-49b3-8fd1-149a53d31ad4" />
<img width="314" height="89" alt="Screenshot 2026-08-25 at 3 19 27 PM" src="https://github.com/user-attachments/assets/9cadd57e-00e1-460b-88e2-632bb1ff0b56" />
<img width="326" height="100" alt="Screenshot 2026-08-25 at 3 19 24 PM" src="https://github.com/user-attachments/assets/db0d95a9-e288-46ef-a46d-e3d4c5ba45e3" />
<img width="663" height="549" alt="Screenshot 2026-08-25 at 3 19 09 PM" src="https://github.com/user-attachments/assets/2a7ded03-bfe5-403f-8a2f-55153f94183b" />
<img width="640" height="539" alt="Screenshot 2026-08-25 at 3 19 05 PM" src="https://github.com/user-attachments/assets/9fdbd141-ed90-4204-b0c6-b9533eb5abc9" />
<img width="721" height="563" alt="Screenshot 2026-08-25 at 3 18 18 PM" src="https://github.com/user-attachments/assets/a0aec506-c7dd-4c6a-956a-992207378168" />


<!-- Before/after across Dark, Tomorrow Blue, Dark 2026, and High Contrast Dark. -->

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Improve LLM provider icon legibility across themes in the provider modal (#15321)

### Validation Steps

@:assistant

1. Open the Assistant provider modal (Configure language model providers).
2. Switch between Dark, Tomorrow Blue, Dark 2026, and High Contrast Dark.
3. Confirm every provider icon -- built-in brand icons and any custom provider with a logo URL -- is legible on each theme, rendered in the theme's icon foreground color.
4. Open a provider's connect/detail screen; confirm its header icon is legible and correctly sized on each theme.
5. Regression: open the legacy provider dialog and confirm its icons remain in their original brand colors -- the recolor must not leak there.
