### PR TITLE
App Launcher: keep the app running when URL detection times out

### DIFF
--- a/extensions/positron-run-app/src/api-utils.ts
+++ b/extensions/positron-run-app/src/api-utils.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as positron from 'positron';
 import * as vscode from 'vscode';
 import { log } from './extension.js';
 import { IS_POSITRON_WEB, IS_RUNNING_ON_PWB, APP_URL_PLACEHOLDER, URL_LIKE_REGEX, HTTP_URL_REGEX } from './constants.js';
@@ -83,32 +84,46 @@ export async function showShellIntegrationNotSupportedMessage(): Promise<void> {
 }
 
 /**
- * Show a message explaining that the app's URL was not found in the console output.
+ * Show a message explaining that the app's URL has not appeared in the console
+ * output yet.
  *
- * The app itself is left running, so this is a warning rather than an error: the
- * app may simply be slower to start than the URL detection timeout allows.
+ * The app itself is left running and we keep watching for its URL, so this is a
+ * warning rather than an error: the app may simply be slower to start than the
+ * URL detection timeout allows.
  * @param appName The name of the app e.g. `'Shiny'`.
- * @param timeoutSetting The setting that governed the timeout, if it was one of
- *  ours. Omit when the caller passed an explicit timeout, since we can't know
- *  which of the caller's settings (if any) produced it, and pointing at our own
- *  setting would be wrong: an explicit timeout takes precedence over it.
+ * @param options.sessionId The console session running the app, if known. Used
+ *  to offer to focus the session, which is where the app's own output is.
+ * @param options.timeoutSetting The setting that governed the timeout, if it was
+ *  one of ours. Omit when the caller passed an explicit timeout, since we can't
+ *  know which of the caller's settings (if any) produced it, and pointing at our
+ *  own setting would be wrong: an explicit timeout takes precedence over it.
  */
-export async function showUrlDetectionTimedOutMessage(appName: string, timeoutSetting?: string): Promise<void> {
+export async function showUrlDetectionTimedOutMessage(
+	appName: string,
+	options?: { sessionId?: string; timeoutSetting?: string },
+): Promise<void> {
+	const showConsole = vscode.l10n.t('Show Console');
 	const changeTimeout = vscode.l10n.t('Change Timeout');
 	const showLog = vscode.l10n.t('Show Log');
-	const actions = timeoutSetting ? [changeTimeout, showLog] : [showLog];
+	const actions = [
+		...(options?.sessionId ? [showConsole] : []),
+		...(options?.timeoutSetting ? [changeTimeout] : []),
+		showLog,
+	];
 
 	const selection = await vscode.window.showWarningMessage(
 		vscode.l10n.t(
-			'Could not find the {0} app URL in the console output, so the app was not previewed. ' +
-			'The app is still running and may need more time to start.',
+			'Could not find the {0} app URL in the console output yet, so the app has not been previewed. ' +
+			'The app is still running, and Positron will preview it as soon as its URL appears.',
 			appName,
 		),
 		...actions,
 	);
 
-	if (selection === changeTimeout && timeoutSetting) {
-		await vscode.commands.executeCommand('workbench.action.openSettings', `@id:${timeoutSetting}`);
+	if (selection === showConsole && options?.sessionId) {
+		positron.runtime.focusSession(options.sessionId);
+	} else if (selection === changeTimeout && options?.timeoutSetting) {
+		await vscode.commands.executeCommand('workbench.action.openSettings', `@id:${options.timeoutSetting}`);
 	} else if (selection === showLog) {
 		log.show();
 	}

--- a/extensions/positron-run-app/src/api-utils.ts
+++ b/extensions/positron-run-app/src/api-utils.ts
@@ -83,6 +83,38 @@ export async function showShellIntegrationNotSupportedMessage(): Promise<void> {
 }
 
 /**
+ * Show a message explaining that the app's URL was not found in the console output.
+ *
+ * The app itself is left running, so this is a warning rather than an error: the
+ * app may simply be slower to start than the URL detection timeout allows.
+ * @param appName The name of the app e.g. `'Shiny'`.
+ * @param timeoutSetting The setting that governed the timeout, if it was one of
+ *  ours. Omit when the caller passed an explicit timeout, since we can't know
+ *  which of the caller's settings (if any) produced it, and pointing at our own
+ *  setting would be wrong: an explicit timeout takes precedence over it.
+ */
+export async function showUrlDetectionTimedOutMessage(appName: string, timeoutSetting?: string): Promise<void> {
+	const changeTimeout = vscode.l10n.t('Change Timeout');
+	const showLog = vscode.l10n.t('Show Log');
+	const actions = timeoutSetting ? [changeTimeout, showLog] : [showLog];
+
+	const selection = await vscode.window.showWarningMessage(
+		vscode.l10n.t(
+			'Could not find the {0} app URL in the console output, so the app was not previewed. ' +
+			'The app is still running and may need more time to start.',
+			appName,
+		),
+		...actions,
+	);
+
+	if (selection === changeTimeout && timeoutSetting) {
+		await vscode.commands.executeCommand('workbench.action.openSettings', `@id:${timeoutSetting}`);
+	} else if (selection === showLog) {
+		log.show();
+	}
+}
+
+/**
  * Check if the Positron proxy should be used for the given app.
  * Generally, we should avoid skipping the proxy unless there is a good reason to do so, as the
  * proxy gives us the ability to intercept requests and responses to the app, which is useful for

--- a/extensions/positron-run-app/src/api.ts
+++ b/extensions/positron-run-app/src/api.ts
@@ -11,7 +11,7 @@ import { log } from './extension';
 import { DebugAppOptions, PositronRunApp, PreviewMode, RunAppOptions, RunConsoleAppOptions } from './positron-run-app';
 import { AppUrlDetector } from './appUrlDetector';
 import { buildCommandLine, raceTimeout, SequencerByKey } from './utils';
-import { DAP_CONFIGURATION_TIMEOUT, IS_POSITRON_WEB, IS_RUNNING_ON_PWB, SHELL_INTEGRATION_TIMEOUT } from './constants.js';
+import { DAP_CONFIGURATION_TIMEOUT, IS_POSITRON_WEB, IS_RUNNING_ON_PWB, LATE_URL_DETECTION_TIMEOUT, SHELL_INTEGRATION_TIMEOUT } from './constants.js';
 import { AppPreviewOptions, Config, PositronProxyInfo } from './types.js';
 import { shouldUsePositronProxy, showShellIntegrationNotSupportedMessage, showEnableShellIntegrationMessage, showUrlDetectionTimedOutMessage } from './api-utils.js';
 
@@ -419,9 +419,11 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 				onError: (data) => detector.processOutput(data),
 			};
 
-			// Execute the code in the console session.
-			// Don't await: the Thenable resolves only when the app stops.
-			positron.runtime.executeCode(
+			// Execute the code in the console session. Don't await: the Thenable
+			// resolves only when the app stops. `executionFinished` never
+			// rejects, so an execution error is logged and treated the same as
+			// the app stopping.
+			const executionFinished = Promise.resolve(positron.runtime.executeCode(
 				document.languageId,
 				consoleCode.code,
 				true,
@@ -430,7 +432,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 				positron.RuntimeErrorBehavior.Continue,
 				observer,
 				sessionId,
-			).then(undefined, (error: Error) => {
+			)).then(() => { }, (error: Error) => {
 				log.error(`Console execution error: ${error.message}`);
 			});
 
@@ -452,12 +454,27 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 								options.name,
 							));
 						}
-						// Only offer to change our own timeout setting when it was
-						// the one in effect. A caller-supplied timeout overrides it.
-						showUrlDetectionTimedOutMessage(
-							options.name,
-							options.urlDetectionTimeout === undefined ? Config.UrlDetectionTimeout : undefined,
-						).catch(() => { });
+						// Keep watching for the URL. The observer has no cancellation
+						// token, so `detector.found` still resolves if the app prints
+						// its URL later. Don't await: holding the run task open would
+						// block a re-run (see `getDocumentForRun`) and would pin the
+						// progress notification.
+						this.watchForLateAppUrl(detector.found, executionFinished, {
+							appName: options.name,
+							preview,
+							proxyInfo,
+							urlPath: options.urlPath,
+							sessionId,
+						});
+
+						showUrlDetectionTimedOutMessage(options.name, {
+							sessionId,
+							// Only offer to change our own timeout setting when it was
+							// the one in effect. A caller-supplied timeout overrides it.
+							timeoutSetting: options.urlDetectionTimeout === undefined
+								? Config.UrlDetectionTimeout
+								: undefined,
+						}).catch(() => { });
 						break;
 					}
 
@@ -755,6 +772,59 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 				? { type: positron.PreviewSourceType.Terminal, id: String(options.terminalPid) }
 				: undefined,
 		});
+	}
+
+	/**
+	 * Keep watching for an app's URL after URL detection timed out, and preview
+	 * the app if the URL eventually appears.
+	 *
+	 * Bounded by the console execution: an app that stops without ever printing
+	 * a URL is never going to print one. Also capped, so a running session with
+	 * a URL we will never match does not leave a preview armed indefinitely.
+	 *
+	 * Nothing awaits this, so it must never reject.
+	 *
+	 * @param found Resolves with the app's URL if it appears in the output.
+	 * @param executionFinished Resolves when the console execution ends.
+	 */
+	private async watchForLateAppUrl(
+		found: Promise<URL>,
+		executionFinished: Promise<void>,
+		options: {
+			appName: string;
+			preview: Exclude<PreviewMode, 'none'>;
+			proxyInfo?: PositronProxyInfo;
+			urlPath?: string;
+			sessionId: string;
+		},
+	): Promise<void> {
+		try {
+			const url = await raceTimeout(
+				Promise.race([found, executionFinished.then(() => undefined)]),
+				LATE_URL_DETECTION_TIMEOUT,
+				() => log.debug(`Stopped waiting for the ${options.appName} app URL in console output`),
+			);
+
+			if (!url) {
+				// Either the app stopped without printing a URL, or the cap
+				// expired. Either way there is nothing left to preview.
+				log.debug(`No late ${options.appName} app URL found in console output`);
+				return;
+			}
+
+			log.info(`Found the ${options.appName} app URL in console output after detection timed out`);
+			await this.previewApp(url, {
+				preview: options.preview,
+				proxyInfo: options.proxyInfo,
+				urlPath: options.urlPath,
+				previewSource: {
+					type: positron.PreviewSourceType.Runtime,
+					id: options.sessionId,
+				},
+			});
+		} catch (error) {
+			log.error(`Error previewing the ${options.appName} app URL found after detection timed out: ${error}`);
+		}
 	}
 
 	private async previewApp(url: URL, options: {

--- a/extensions/positron-run-app/src/api.ts
+++ b/extensions/positron-run-app/src/api.ts
@@ -13,7 +13,7 @@ import { AppUrlDetector } from './appUrlDetector';
 import { buildCommandLine, raceTimeout, SequencerByKey } from './utils';
 import { DAP_CONFIGURATION_TIMEOUT, IS_POSITRON_WEB, IS_RUNNING_ON_PWB, SHELL_INTEGRATION_TIMEOUT } from './constants.js';
 import { AppPreviewOptions, Config, PositronProxyInfo } from './types.js';
-import { shouldUsePositronProxy, showShellIntegrationNotSupportedMessage, showEnableShellIntegrationMessage } from './api-utils.js';
+import { shouldUsePositronProxy, showShellIntegrationNotSupportedMessage, showEnableShellIntegrationMessage, showUrlDetectionTimedOutMessage } from './api-utils.js';
 
 function readDefaultPreviewMode(): PreviewMode {
 	const setting = vscode.workspace.getConfiguration().get<string>(Config.PreviewMode);
@@ -410,11 +410,11 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 			// Set up URL detection via an observer for the output of our execute request.
 			// Always created but only consumed when `preview` is not `'none'`.
 			const detector = new AppUrlDetector(options.appUrlStrings, options.appReadyMessage);
-			const cancellation = new vscode.CancellationTokenSource();
-			cleanup.push(cancellation);
 
+			// Deliberately no cancellation token: cancelling an execution
+			// observer's token interrupts the session, which would kill the
+			// user's app. The app outlives URL detection, so we never cancel.
 			const observer: positron.runtime.ExecutionObserver = {
-				token: cancellation.token,
 				onOutput: (data) => detector.processOutput(data),
 				onError: (data) => detector.processOutput(data),
 			};
@@ -442,13 +442,26 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 					const url = await raceTimeout(
 						detector.found,
 						options.urlDetectionTimeout ?? readUrlDetectionTimeout(),
-						() => {
-							cancellation.cancel();
-							throw new Error(vscode.l10n.t('Timed out waiting for {0} app URL in console output.', options.name));
-						},
+						() => log.warn(`Timed out waiting for ${options.name} app URL in console output`),
 					);
 
-					const previewUri = await this.previewApp(url!, {
+					if (!url) {
+						if (preview === 'manual') {
+							throw new Error(vscode.l10n.t(
+								'Could not find the {0} app URL in the console output. The app is still running in the console session.',
+								options.name,
+							));
+						}
+						// Only offer to change our own timeout setting when it was
+						// the one in effect. A caller-supplied timeout overrides it.
+						showUrlDetectionTimedOutMessage(
+							options.name,
+							options.urlDetectionTimeout === undefined ? Config.UrlDetectionTimeout : undefined,
+						).catch(() => { });
+						break;
+					}
+
+					const previewUri = await this.previewApp(url, {
 						preview,
 						proxyInfo,
 						urlPath: options.urlPath,

--- a/extensions/positron-run-app/src/constants.ts
+++ b/extensions/positron-run-app/src/constants.ts
@@ -23,3 +23,11 @@ export const DAP_CONFIGURATION_TIMEOUT = 10_000;
 
 /** Time between creating a terminal and receiving its onDidChangeTerminalShellIntegration event. */
 export const SHELL_INTEGRATION_TIMEOUT = 5_000;
+
+/**
+ * Time to keep watching a console session for an app's URL after URL detection
+ * has already timed out. The real bound is the execution ending; this cap only
+ * stops a long-lived session whose URL we will never match from leaving a
+ * preview armed indefinitely.
+ */
+export const LATE_URL_DETECTION_TIMEOUT = 5 * 60_000;

--- a/extensions/positron-run-app/src/test/api.test.ts
+++ b/extensions/positron-run-app/src/test/api.test.ts
@@ -191,10 +191,12 @@ suite('PositronRunApp', () => {
 		};
 
 		let observer: positron.runtime.ExecutionObserver | undefined;
+		let finishExecution: (() => void) | undefined;
 		let showWarningMessageStub: sinon.SinonStub;
 
 		setup(() => {
 			observer = undefined;
+			finishExecution = undefined;
 
 			// Always start a fresh console session rather than reusing a
 			// persisted one from an earlier test.
@@ -204,11 +206,14 @@ suite('PositronRunApp', () => {
 			sinon.stub(positron.runtime, 'focusSession');
 
 			// Capture the observer so the test can drive console output, and
-			// never resolve: the real Thenable only resolves once the app stops.
+			// capture a resolver so a test can end the execution: the real
+			// Thenable only resolves once the app stops.
 			sinon.stub(positron.runtime, 'executeCode')
 				.callsFake((..._args) => {
 					observer = _args[6] as positron.runtime.ExecutionObserver;
-					return new Promise(() => { });
+					return new Promise<Record<string, any>>(resolve => {
+						finishExecution = () => resolve({});
+					});
 				});
 
 			showWarningMessageStub = sinon.stub(vscode.window, 'showWarningMessage').resolves(undefined);
@@ -270,8 +275,52 @@ suite('PositronRunApp', () => {
 			sinon.assert.calledOnceWithExactly(
 				showWarningMessageStub,
 				sinon.match.string,
+				'Show Console',
 				'Show Log',
 			);
+		});
+
+		test('previews the app URL that appears after the detection timeout', async () => {
+			// A slow app prints its URL after we have given up waiting. Detection
+			// keeps listening, so the app is still previewed without the user
+			// having to do anything.
+			const runPromise = runAppApi.runApplicationInConsole({
+				...consoleAppOptions,
+				urlDetectionTimeout: 500,
+			});
+
+			await waitFor(() => observer !== undefined, 'Timed out waiting for code execution');
+
+			// The run task ends at the timeout so that a re-run is never blocked.
+			// The watch for the app's URL outlives it.
+			await runPromise;
+
+			observer!.onOutput!('Listening on http://localhost:1234\n');
+
+			await waitFor(() => previewUrlStub.called, 'Timed out waiting for the app to be previewed');
+			sinon.assert.calledOnceWithMatch(previewUrlStub, localhostUriMatch);
+		});
+
+		test('stops watching when the console execution finishes without a URL', async () => {
+			// An app that stopped without ever printing a URL is never going to
+			// print one, so the watch must end with the execution rather than
+			// previewing whatever a later session happens to print.
+			const runPromise = runAppApi.runApplicationInConsole({
+				...consoleAppOptions,
+				urlDetectionTimeout: 500,
+			});
+
+			await waitFor(() => observer !== undefined, 'Timed out waiting for code execution');
+			await runPromise;
+
+			// End the execution, as if the app stopped, then print a URL anyway.
+			assert.ok(finishExecution, 'The execution resolver should have been captured');
+			finishExecution();
+			await new Promise(resolve => setTimeout(resolve, 100));
+			observer!.onOutput!('Listening on http://localhost:1234\n');
+			await new Promise(resolve => setTimeout(resolve, 500));
+
+			sinon.assert.notCalled(previewUrlStub);
 		});
 	});
 

--- a/extensions/positron-run-app/src/test/api.test.ts
+++ b/extensions/positron-run-app/src/test/api.test.ts
@@ -7,7 +7,7 @@ import assert = require('assert');
 import * as positron from 'positron';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
-import { DebugAppOptions, RunAppOptions } from '../positron-run-app';
+import { DebugAppOptions, RunAppOptions, RunConsoleAppOptions } from '../positron-run-app';
 import { raceTimeout } from '../utils';
 import { PositronRunAppApiImpl } from '../api';
 import { log } from '../extension.js';
@@ -98,6 +98,17 @@ suite('PositronRunApp', () => {
 		disposables.splice(0, disposables.length);
 	});
 
+	/** Poll until `condition` holds, or fail the test after `timeout` ms. */
+	async function waitFor(condition: () => boolean, message: string, timeout = 5_000): Promise<void> {
+		const deadline = Date.now() + timeout;
+		while (!condition()) {
+			if (Date.now() > deadline) {
+				assert.fail(message);
+			}
+			await new Promise(resolve => setTimeout(resolve, 10));
+		}
+	}
+
 	async function getRunAppApi(): Promise<PositronRunAppApiImpl> {
 		const extension = vscode.extensions.getExtension<PositronRunAppApiImpl>('positron.positron-run-app');
 		if (!extension) {
@@ -164,6 +175,104 @@ suite('PositronRunApp', () => {
 			vscode.workspace.getConfiguration('terminal.integrated.shellIntegration').get('enabled'),
 			'Shell integration not enabled',
 		);
+	});
+
+	suite('runApplicationInConsole', () => {
+		const consoleAppOptions: RunConsoleAppOptions = {
+			name: 'Test Console App',
+			getConsoleCode() {
+				return { code: 'run_the_app()' };
+			},
+			appUrlStrings: ['Listening on {{APP_URL}}'],
+			// Generous by default: the success test has to wait for `executeCode`
+			// before it can emit output, and a loaded CI machine must not race the
+			// detection clock. The timeout test overrides this with a short value.
+			urlDetectionTimeout: 30_000,
+		};
+
+		let observer: positron.runtime.ExecutionObserver | undefined;
+		let showWarningMessageStub: sinon.SinonStub;
+
+		setup(() => {
+			observer = undefined;
+
+			// Always start a fresh console session rather than reusing a
+			// persisted one from an earlier test.
+			sinon.stub(positron.runtime, 'getSession').resolves(undefined);
+			sinon.stub(positron.runtime, 'startLanguageRuntime')
+				.resolves({ metadata: { sessionId: 'test-session' } } as positron.LanguageRuntimeSession);
+			sinon.stub(positron.runtime, 'focusSession');
+
+			// Capture the observer so the test can drive console output, and
+			// never resolve: the real Thenable only resolves once the app stops.
+			sinon.stub(positron.runtime, 'executeCode')
+				.callsFake((..._args) => {
+					observer = _args[6] as positron.runtime.ExecutionObserver;
+					return new Promise(() => { });
+				});
+
+			showWarningMessageStub = sinon.stub(vscode.window, 'showWarningMessage').resolves(undefined);
+		});
+
+		test('previews the app URL found in console output', async () => {
+			const runPromise = runAppApi.runApplicationInConsole(consoleAppOptions);
+
+			// Wait for the execution to start, then emit the app's URL.
+			await waitFor(() => observer !== undefined, 'Timed out waiting for code execution');
+			observer!.onOutput!('Listening on http://localhost:1234\n');
+
+			await runPromise;
+
+			sinon.assert.calledOnceWithMatch(previewUrlStub, localhostUriMatch);
+		});
+
+		test('leaves the app running when URL detection times out', async () => {
+			// Regression test for #15601: the URL detection timeout used to
+			// cancel the execution observer's token. Cancelling that token
+			// interrupts the session, which killed apps that were merely slower
+			// to start than the timeout allowed, so the app's port was never
+			// forwarded.
+			let didCancelExecution = false;
+
+			// Short timeout so this test doesn't slow the suite down.
+			const runPromise = runAppApi.runApplicationInConsole({
+				...consoleAppOptions,
+				urlDetectionTimeout: 500,
+			});
+
+			await waitFor(() => observer !== undefined, 'Timed out waiting for code execution');
+			observer!.token?.onCancellationRequested(() => {
+				didCancelExecution = true;
+			});
+
+			// Never emit a URL, so detection times out.
+			await runPromise;
+
+			// Stated directly rather than relying on the listener above: with no
+			// token there is nothing to cancel, so an optional-chained listener
+			// alone would pass no matter what the code did.
+			assert.strictEqual(
+				observer!.token,
+				undefined,
+				'The execution observer must not carry a cancellation token: cancelling it ' +
+				'interrupts the session and kills the app',
+			);
+			assert.ok(
+				!didCancelExecution,
+				'URL detection timing out must not cancel the execution, which would interrupt the ' +
+				'session and kill the app',
+			);
+			sinon.assert.notCalled(previewUrlStub);
+
+			// These options set `urlDetectionTimeout`, which overrides
+			// `positron.runApp.urlDetectionTimeout`, so the warning must not offer
+			// to change that setting: changing it would have no effect.
+			sinon.assert.calledOnceWithExactly(
+				showWarningMessageStub,
+				sinon.match.string,
+				'Show Log',
+			);
+		});
 	});
 
 	test('debugApplication: shell integration supported', async () => {


### PR DESCRIPTION
Part of #15601. This is the Positron half. The companion PR is posit-dev/shiny-vscode#118, which needs no further code change from this work.

### Summary

This PR makes the **console** path for App Launcher handle a URL detection timeout the way the terminal path already does:

<img width="1375" height="981" alt="Screenshot 2026-08-26 at 3 29 28 PM" src="https://github.com/user-attachments/assets/cb793133-6c5a-462e-b14b-00086ff515a7" />

Both paths watch output for the app's URL, then give up after `positron.runApp.urlDetectionTimeout`. Before this PR, they handled giving up very differently:

| | `previewUrlInExecutionOutput` (terminal, unchanged) | `doRunApplicationInConsole` (console, before this PR) |
|---|---|---|
| On timeout | `log.error`, return `undefined` | `cancellation.cancel()`, then `throw` |
| App survives | Yes | **No** |
| User feedback | None | Error toast saying it timed out |

That cancel is the bug that the user is experiencing in #15601. On the terminal path there is nothing to cancel, because a terminal is not a runtime session. On the console path the token belongs to a `positron.runtime.ExecutionObserver`, and cancelling it reaches `interruptSession` in `extHostLanguageRuntime.ts`. So the timeout interrupted the R session and stopped an app whose only fault was starting slower than the timeout allowed. Because `previewApp` never ran, `asExternalUri` never ran either, so no port was forwarded and the Ports view stayed empty. That is the reported symptom: the app appears nowhere and there is no port binding.

Only Shiny for R reaches this code path today as it is the sole caller of `runApplicationInConsole`. Dash, FastAPI, Flask, Gradio, and Streamlit go through `runApplication` or `debugApplication`, and Shiny for Python builds its own terminal; nothing on the terminal path changes with this PR.

The Shiny extension passes its own `shiny.timeoutOpenBrowser` (default 10 seconds) as the timeout, which silently overrides the 25 second default here. posit-dev/shiny-vscode#118 will stop imposing that default, so the App Launcher setting applies unless the user set the Shiny one themselves.

### Keeping the app previewable after the timeout

Review feedback on posit-dev/shiny-vscode#118 asked for the console path to match the terminal path in the Shiny extension. That path shows an error with two actions, _Show Shiny process_ and _Keep waiting_. _Keep waiting_ retries with a longer budget, and it can repeat.

The observer no longer carries a cancellation token, so `detector.found` still resolves when the app prints `Listening on ...`, however late that is. So this PR keeps waiting by default, rather than adding a _Keep waiting_ button:

- After the timeout, a detached watch races URL detection against the end of the console execution, with a cap of 5 minutes. When a URL arrives, the watch calls the same `previewApp` that the happy path calls. The Viewer, the proxy on Positron Server Web and PWB, and the Ports view registration are all identical to a normal run.
- The watch is detached from the run task, which now ends immediately. `runApplicationInConsole` runs inside `queueRunApplication`, which holds an entry in `_runApplicationSequencerByName` for the whole task. `getDocumentForRun` refuses a new run while that entry exists. An awaited notification response therefore blocks every re-run until the user answers, and keeps the progress notification spinning. A user who ignores the notification cannot run the app at all.
- The bound on the execution matters. If the app crashes, or if the user stops it before it prints a URL, the watch ends. It does not wait for output that will never come.
- The warning now says that the app is still starting, and that Positron will preview it when its URL appears. It offers _Show Console_, the console analogue of _Show Shiny process_, next to _Change Timeout_ and _Show Log_.

`preview: 'manual'` keeps its current contract. That mode returns the URI to the caller, so a detached watch cannot satisfy it. It still throws on timeout, unchanged.

This also closes the proxy gap noted in the first version of this PR. `previewApp` now runs on the late path, so `finishProxySetup` runs too. The proxy is no longer left pending on Positron Server Web and Workbench.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Shiny for R apps that take longer to start than the URL detection timeout are no longer stopped before they finish starting, and are previewed when their URL finally appears (#15601)

### Validation Steps

@:apps @:viewer

`runApplicationInConsole` had no tests at all, so this adds four to `extensions/positron-run-app/src/test/api.test.ts`: the happy path, a regression test for the timeout, a test that the app is previewed when its URL appears after the timeout, and a test that the watch stops when the console execution ends without a URL. The full App Launcher suite is 19 passing.

Note that suite is commented out in `scripts/test-integration.sh` as flaky, so these cases do not gate CI yet.

To check by hand (no container needed):

1. Create `app.R` with a delay before the server starts listening:

```r
library(shiny)
Sys.sleep(40)
ui <- fluidPage(h1("Slow Shiny App"))
server <- function(input, output, session) { }
shinyApp(ui, server)
```

2. Open the folder, open `app.R`, and click _Run Shiny App_.
3. At about 25 seconds, a warning appears saying that the app is still starting.
4. At about 40 seconds, `Listening on http://127.0.0.1:PORT` appears in the console, the Viewer opens the app, and the app appears in the Ports view. No click is needed:

<img width="1375" height="981" alt="Screenshot 2026-08-26 at 3 29 43 PM" src="https://github.com/user-attachments/assets/958c18f9-535b-41e4-9e20-20d1118855f2" />

5. Click _Show Console_ on the warning. The R session gets focus.
6. Click _Run Shiny App_ again while the warning is still showing. A new run starts, rather than reporting "Shiny application is already starting."

On `main`, step 3 is an error toast, the console is interrupted, and step 4 never happens.

