### PR TITLE
Add session & console commands and documentation to positron-commands skill

### DIFF
--- a/extensions/positron-skills/templates/positron-commands/SKILL.md
+++ b/extensions/positron-skills/templates/positron-commands/SKILL.md
@@ -3,18 +3,18 @@ name: positron-commands
 description: >
   Running Positron IDE commands: changing the window layout, focusing panes
   (Console, Variables, Plots, Help, Packages), clearing the console, opening a
-  file or data file in the right editor, listing or discovering registered
-  interpreters, listing running sessions, switching or starting a session,
-  restarting or interrupting a stuck one, setting up Python, and reading,
-  installing or updating the packages in a session. Use when the user wants
-  Positron itself to do something, or wants to know what is installed, rather
-  than to run R or Python code. Triggers: "switch to the data science layout",
-  "show the variables pane", "clear the console", "open data.csv", "what
-  interpreters are available", "switch to my R session", "start a new Python
-  session", "my R interpreter isn't showing up", "my session is stuck", "is
-  pandas installed?", "install dplyr", "update all my packages", "do I have any
-  vulnerable packages?", "I don't have Python
-  installed", "set up a Python environment", "which Python am I using".
+  file or data file in the right editor, listing or discovering interpreters,
+  listing running sessions, switching or starting a session, restarting or
+  interrupting a stuck one, setting up Python, and reading, installing or
+  updating the packages in a session. Use when the user wants Positron itself
+  to act, or to know what is installed, rather than to run R or Python code.
+  Triggers: "switch to the data science layout", "show the variables pane",
+  "clear the console", "open data.csv", "what interpreters are available",
+  "switch to my R session", "start a new Python session", "my R interpreter
+  isn't showing up", "my session is stuck", "is pandas installed?", "install
+  dplyr", "update all my packages", "do I have any vulnerable packages?", "I
+  don't have Python installed", "set up a Python environment", "which Python am
+  I using".
 ---
 
 # Positron IDE commands

--- a/extensions/positron-skills/templates/positron-commands/SKILL.md
+++ b/extensions/positron-skills/templates/positron-commands/SKILL.md
@@ -3,18 +3,18 @@ name: positron-commands
 description: >
   Running Positron IDE commands: changing the window layout, focusing panes
   (Console, Variables, Plots, Help, Packages), clearing the console, listing or
-  discovering registered interpreters, restarting or interrupting a stuck
-  session, and refreshing or updating packages. Use when the user wants Positron
-  itself to do something, rather than to run R or Python code. Load this skill,
-  then read the reference file for the area: layout and pane focus in
-  references/ui.md; listing interpreters in references/interpreters.md; sessions
-  and packages in references/troubleshooting.md; installing Python, creating an
-  environment, and finding the active interpreter in references/python-setup.md.
+  discovering registered interpreters, listing running sessions, switching or
+  starting a session, restarting or interrupting a stuck one, and refreshing or
+  updating packages. Use when the user wants Positron itself to do something,
+  rather than to run R or Python code. Load this skill, then read the reference
+  file for the area: layout and pane focus in references/ui.md; listing
+  interpreters in references/interpreters.md; sessions and packages in
+  references/troubleshooting.md; installing Python, creating an environment, and
+  finding the active interpreter in references/python-setup.md.
   Triggers: "switch to the data science layout", "show the variables pane",
-  "clear the console", "what interpreters are available", "my R interpreter
-  isn't showing up", "my session is stuck", "update all my packages", "I don't
-  have Python installed", "set up a Python environment", "which Python am I
-  using".
+  "clear the console", "what interpreters are available", "switch to my R
+  session", "start a new Python session", "my session is stuck", "update all my
+  packages", "set up a Python environment".
 ---
 
 # Positron IDE commands
@@ -32,6 +32,12 @@ given under that command's "Arguments" entry. Omit `args` entirely for commands
 that take none -- do not pass an empty object or array. Never invent an argument
 value the user hasn't given you or that isn't documented; if a required value is
 unknown, ask the user first.
+
+Some commands take or return an internal id -- a runtime id or a session id.
+These are opaque handles you pass back into another command; they are not shown
+anywhere in the Positron UI, so a user won't recognize one and it would only
+confuse them. Use ids to make the call, but never repeat one to the user. Refer
+to a session or interpreter by its name instead.
 
 ## When a command doesn't work
 
@@ -63,9 +69,10 @@ interpreter before creating an environment.
 
 **Sessions and packages** -- [references/troubleshooting.md]({{skill_dir}}/references/troubleshooting.md)
 Read when the user asks about: an interpreter that isn't showing up or won't
-start, startup diagnostics, a session that is stuck or needs restarting, or
-installed packages that need refreshing or updating. Also covers looking up a
-help topic for a function or symbol.
+start, startup diagnostics, listing the running sessions, switching to a
+different session or starting a new one, a session that is stuck or needs
+restarting, or installed packages that need refreshing or updating. Also covers
+looking up a help topic for a function or symbol.
 
 **Python environment setup** -- [references/python-setup.md]({{skill_dir}}/references/python-setup.md)
 Read when the user is getting Python set up: installing a Python interpreter when

--- a/extensions/positron-skills/templates/positron-commands/SKILL.md
+++ b/extensions/positron-skills/templates/positron-commands/SKILL.md
@@ -7,10 +7,10 @@ description: >
   starting a session, restarting or interrupting a stuck one, and refreshing or
   updating packages. Use when the user wants Positron itself to do something,
   rather than to run R or Python code. Load this skill, then read the reference
-  file for the area: layout and pane focus in references/ui.md; listing
-  interpreters in references/interpreters.md; sessions and packages in
-  references/troubleshooting.md; installing Python, creating an environment, and
-  finding the active interpreter in references/python-setup.md.
+  file for the area: panes and layout in references/ui.md; interpreters in
+  references/interpreters.md; sessions in references/sessions.md; stuck sessions,
+  packages, and help in references/troubleshooting.md; Python setup in
+  references/python-setup.md.
   Triggers: "switch to the data science layout", "show the variables pane",
   "clear the console", "what interpreters are available", "switch to my R
   session", "start a new Python session", "my session is stuck", "update all my
@@ -67,12 +67,16 @@ interpreters listed (Python, R, or another language), or needs Positron to
 rescan for newly installed environments. Also the place to find a base
 interpreter before creating an environment.
 
-**Sessions and packages** -- [references/troubleshooting.md]({{skill_dir}}/references/troubleshooting.md)
-Read when the user asks about: an interpreter that isn't showing up or won't
-start, startup diagnostics, listing the running sessions, switching to a
-different session or starting a new one, a session that is stuck or needs
-restarting, or installed packages that need refreshing or updating. Also covers
-looking up a help topic for a function or symbol.
+**Sessions** -- [references/sessions.md]({{skill_dir}}/references/sessions.md)
+Read when the user asks about: which sessions are running, switching to a
+different session, or starting a new one. Also explains the difference between
+console sessions and notebook sessions, which decides whether a session can be
+selected.
+
+**Stuck sessions, packages, and help** -- [references/troubleshooting.md]({{skill_dir}}/references/troubleshooting.md)
+Read when the user asks about: a session that is stuck or needs interrupting or
+restarting, installed packages that need refreshing or updating, or looking up a
+help topic for a function or symbol.
 
 **Python environment setup** -- [references/python-setup.md]({{skill_dir}}/references/python-setup.md)
 Read when the user is getting Python set up: installing a Python interpreter when

--- a/extensions/positron-skills/templates/positron-commands/references/interpreters.md
+++ b/extensions/positron-skills/templates/positron-commands/references/interpreters.md
@@ -25,6 +25,12 @@ you expected one to be there, force a rescan with
 `workbench.action.language.runtime.discoverAllRuntimes` (below) and list again
 before concluding it's missing.
 
+Each entry's `runtimeId` is the internal id you pass to
+`workbench.action.language.runtime.startNewConsoleSession` (see
+[troubleshooting.md]({{skill_dir}}/references/troubleshooting.md)) to start a session
+for that interpreter. It appears nowhere in the Positron UI, so use it to make
+the call but never show it to the user -- refer to the interpreter by name.
+
 {{command:workbench.action.language.runtime.getRegisteredRuntimes}}
 
 ## Diagnosing why an interpreter isn't showing up

--- a/extensions/positron-skills/templates/positron-commands/references/interpreters.md
+++ b/extensions/positron-skills/templates/positron-commands/references/interpreters.md
@@ -6,9 +6,9 @@ appeared yet. See [SKILL.md]({{skill_dir}}/SKILL.md) for how to call these comma
 how to handle failures.
 
 An interpreter being *registered* means Positron knows about it and can start a
-session for it; it does not mean a session is running. To start or switch a
-session, or to recover one that's misbehaving, see
-[troubleshooting.md]({{skill_dir}}/references/troubleshooting.md).
+session for it; it does not mean a session is running. To list, start, or switch
+a session, see [sessions.md]({{skill_dir}}/references/sessions.md); to recover one
+that's misbehaving, see [troubleshooting.md]({{skill_dir}}/references/troubleshooting.md).
 
 ## Listing available interpreters
 
@@ -27,9 +27,9 @@ before concluding it's missing.
 
 Each entry's `runtimeId` is the internal id you pass to
 `workbench.action.language.runtime.startNewConsoleSession` (see
-[troubleshooting.md]({{skill_dir}}/references/troubleshooting.md)) to start a session
-for that interpreter. It appears nowhere in the Positron UI, so use it to make
-the call but never show it to the user -- refer to the interpreter by name.
+[sessions.md]({{skill_dir}}/references/sessions.md)) to start a session for that
+interpreter. It appears nowhere in the Positron UI, so use it to make the call
+but never show it to the user -- refer to the interpreter by name.
 
 {{command:workbench.action.language.runtime.getRegisteredRuntimes}}
 

--- a/extensions/positron-skills/templates/positron-commands/references/python-setup.md
+++ b/extensions/positron-skills/templates/positron-commands/references/python-setup.md
@@ -12,7 +12,7 @@ guidance is hand-written.
 These commands come from the Python extension, so they only exist once it is
 active -- expect `not-found` if Python support isn't loaded yet. To start or
 switch a session once an interpreter exists, use the session commands in
-[troubleshooting.md]({{skill_dir}}/references/troubleshooting.md).
+[sessions.md]({{skill_dir}}/references/sessions.md).
 
 ## Finding the active interpreter
 

--- a/extensions/positron-skills/templates/positron-commands/references/sessions.md
+++ b/extensions/positron-skills/templates/positron-commands/references/sessions.md
@@ -1,0 +1,91 @@
+# Positron session commands
+
+Listing the interpreter sessions that are running, switching between them, and
+starting a new one. See [SKILL.md]({{skill_dir}}/SKILL.md) for how to call these
+commands and how to handle failures. To interrupt or restart a stuck session,
+see [troubleshooting.md]({{skill_dir}}/references/troubleshooting.md).
+
+The **Arguments** and **Returns** entries below are generated from the running
+build's command metadata, so they always match this Positron. The surrounding
+guidance is hand-written.
+
+## Console sessions vs notebook sessions
+
+A *session* is one running instance of an interpreter. Positron has two kinds,
+and the difference decides which command applies:
+
+- **Console sessions** back a console in the Console pane. These are the
+  interactive R and Python sessions a user runs code in at the prompt. One of
+  them is the *foreground* session -- the one the console shows and the one the
+  interrupt, restart, and clear-console commands act on. "Switch to my R
+  session", "start a new Python session", and "which session is active" are all
+  about console sessions.
+- **Notebook sessions** are the kernels behind notebooks open in the editor --
+  one per open notebook. They are not consoles; a user works in a notebook
+  session by editing its notebook, not by typing at the console prompt.
+
+`getActiveSessions` reports both kinds, tagged by `sessionMode` (`console` or
+`notebook`). The commands here that change the active session are for **console
+sessions only**:
+
+- To switch the active console, pick an entry whose `sessionMode` is `console`
+  and pass it to `selectSession`.
+- You cannot make a notebook session the foreground session this way. A notebook
+  session is tied to its open notebook, so the way to work in it is to switch to
+  that notebook's editor tab -- not `selectSession`. If the user asks to switch
+  to a notebook's session, tell them to open or click that notebook's tab; don't
+  pass a notebook `sessionId` to `selectSession`.
+
+Only `selectSession` is console-only. Interrupting and restarting (see
+[troubleshooting.md]({{skill_dir}}/references/troubleshooting.md)) act on whichever
+session is the foreground, so they work on a notebook session too once its
+editor tab is focused.
+
+Session ids and runtime ids are internal handles that appear nowhere in the
+Positron UI. Use them to make a call, but never show one to the user -- refer to
+a session or interpreter by its name. See the id rule in
+[SKILL.md]({{skill_dir}}/SKILL.md).
+
+## Listing sessions
+
+### `workbench.action.language.runtime.getActiveSessions`
+
+Lists the sessions currently running -- both console and notebook. This is how
+you find the `sessionId` for `selectSession`, and how you confirm a session
+exists before interrupting or restarting. Read-only and always enabled. Pass a
+`languageId` (e.g. `"python"` or `"r"`) to narrow the results to one language;
+omit it for every language. In each entry, `sessionMode` tells console from
+notebook, `foreground: true` marks the active console session, and `sessionName`
+is the name to use when talking to the user. An empty array means nothing is
+running.
+
+{{command:workbench.action.language.runtime.getActiveSessions}}
+
+## Switching the active session
+
+### `workbench.action.language.runtime.selectSession`
+
+Makes an already-running **console** session the foreground session. Use when
+the user wants to switch to a console session they already have open. Call
+`getActiveSessions` first, pick the entry whose `sessionMode` is `console` and
+whose name matches what the user asked for, and pass its `sessionId`. Don't pass
+a notebook session's id (see the distinction above), and don't call this without
+an id -- that opens a picker and waits on the user. A `selected: false` result
+means the picker was dismissed; report that rather than retrying.
+
+{{command:workbench.action.language.runtime.selectSession}}
+
+## Starting a new session
+
+### `workbench.action.language.runtime.startNewConsoleSession`
+
+Starts a brand-new console session for a registered interpreter. Use when the
+user wants a fresh session rather than switching to one they already have. It
+needs the `runtimeId` of a registered interpreter, which comes from
+`workbench.action.language.runtime.getRegisteredRuntimes` in
+[interpreters.md]({{skill_dir}}/references/interpreters.md) -- list the interpreters,
+match the one the user asked for, and pass its `runtimeId`. Don't call this
+without an id -- that opens a picker and waits on the user. A `started: false`
+result means the picker was dismissed; report that rather than retrying.
+
+{{command:workbench.action.language.runtime.startNewConsoleSession}}

--- a/extensions/positron-skills/templates/positron-commands/references/troubleshooting.md
+++ b/extensions/positron-skills/templates/positron-commands/references/troubleshooting.md
@@ -1,9 +1,12 @@
-# Positron session and package commands
+# Positron session recovery and package commands
 
-Recovering interpreter sessions (Python, R, or another language), managing
-packages, and looking up help topics. See [SKILL.md]({{skill_dir}}/SKILL.md) for how to call these commands and how
-to handle failures. To list the available interpreters or rescan for a newly
-installed one, see [interpreters.md]({{skill_dir}}/references/interpreters.md).
+Recovering a stuck interpreter session (Python, R, or another language),
+managing packages, and looking up help topics. See [SKILL.md]({{skill_dir}}/SKILL.md)
+for how to call these commands and how to handle failures. To list the running
+sessions, switch between them, or start a new one, see
+[sessions.md]({{skill_dir}}/references/sessions.md). To list the available
+interpreters or rescan for a newly installed one, see
+[interpreters.md]({{skill_dir}}/references/interpreters.md).
 
 The **Arguments** and **Returns** entries below are generated from the running
 build's command metadata, so they always match this Positron. The surrounding
@@ -11,13 +14,17 @@ guidance is hand-written.
 
 ## Controlling the active interpreter session
 
-Both commands below act on the *foreground* session -- the one currently
-selected. Neither has a precondition, so both are always enabled; but when no
-session is running they do nothing and return no value rather than reporting
-`disabled`. So don't infer from a successful call that something happened: if
-you're not sure a session is running, list sessions first (see below) and, if
-the list is empty, tell the user there's no session to act on instead of
-claiming you interrupted or restarted one.
+Both commands below act on the *foreground* session -- whichever session is
+active right now. That can be a console session or a notebook session (a
+notebook's session is the foreground while its editor tab is focused), so these
+work for notebooks just as well as consoles. Neither has a precondition, so both
+are always enabled; but when no session is running they do nothing and return no
+value rather than reporting `disabled`. So don't infer from a successful call
+that something happened: if you're not sure a session is running, list sessions
+first (`getActiveSessions` in [sessions.md]({{skill_dir}}/references/sessions.md))
+and, if the list is empty, tell the user there's no session to act on instead of
+claiming you interrupted or restarted one. To switch to a different session or
+start a new one, see [sessions.md]({{skill_dir}}/references/sessions.md).
 
 ### `workbench.action.languageRuntime.interrupt`
 
@@ -37,53 +44,6 @@ lost. Always tell the user this will happen before calling it, and prefer
 to get a clean session.
 
 {{command:workbench.action.language.runtime.restartActiveSession}}
-
-## Listing, switching, and starting sessions
-
-An interpreter *session* is a running instance of an interpreter. There can be
-several at once (e.g. an R console and two Python consoles); one is the
-foreground session that the console and the interrupt/restart commands act on.
-
-Both switching and starting take an internal id (a session id, a runtime id).
-Those ids appear nowhere in the Positron UI, so never show one to the user --
-list first to find the id, use it to make the call, then refer to the session
-or interpreter by its name. See the id rule in [SKILL.md]({{skill_dir}}/SKILL.md).
-
-### `workbench.action.language.runtime.getActiveSessions`
-
-Lists the interpreter sessions currently running. This is how you find the
-`sessionId` to hand to `selectSession`, and how you confirm a session exists
-before interrupting or restarting. Read-only and always enabled. Pass a
-`languageId` (e.g. `"python"` or `"r"`) to narrow the results to one language;
-omit it for every language. Each entry's `foreground: true` marks the currently
-active session, and `sessionName` is the name to use when talking to the user.
-An empty array means nothing is running.
-
-{{command:workbench.action.language.runtime.getActiveSessions}}
-
-### `workbench.action.language.runtime.selectSession`
-
-Makes an already-running session the foreground session. Use when the user
-wants to switch to a different session they already have open. Call
-`getActiveSessions` first and pass the `sessionId` of the session the user
-named; do not call this without an id, which opens a picker and waits on the
-user. A `selected: false` result means the picker was dismissed; report that
-rather than retrying.
-
-{{command:workbench.action.language.runtime.selectSession}}
-
-### `workbench.action.language.runtime.startNewConsoleSession`
-
-Starts a brand-new console session for a registered interpreter. Use when the
-user wants a fresh session rather than switching to an existing one. It needs
-the `runtimeId` of a registered interpreter, which comes from
-`workbench.action.language.runtime.getRegisteredRuntimes` in
-[interpreters.md]({{skill_dir}}/references/interpreters.md) -- list the interpreters,
-match the one the user asked for, and pass its `runtimeId`. Do not call this
-without an id, which opens a picker and waits on the user. A `started: false`
-result means the picker was dismissed; report that rather than retrying.
-
-{{command:workbench.action.language.runtime.startNewConsoleSession}}
 
 ## Managing packages
 

--- a/extensions/positron-skills/templates/positron-commands/references/troubleshooting.md
+++ b/extensions/positron-skills/templates/positron-commands/references/troubleshooting.md
@@ -11,12 +11,20 @@ guidance is hand-written.
 
 ## Controlling the active interpreter session
 
+Both commands below act on the *foreground* session -- the one currently
+selected. Neither has a precondition, so both are always enabled; but when no
+session is running they do nothing and return no value rather than reporting
+`disabled`. So don't infer from a successful call that something happened: if
+you're not sure a session is running, list sessions first (see below) and, if
+the list is empty, tell the user there's no session to act on instead of
+claiming you interrupted or restarted one.
+
 ### `workbench.action.languageRuntime.interrupt`
 
 Interrupts the active interpreter runtime session -- e.g., stops a running
 computation. Non-destructive: session state (variables, loaded packages) is
 preserved. Try this first when code appears stuck (an infinite loop, a
-long-running call the user wants to cancel). No precondition -- always enabled.
+long-running call the user wants to cancel).
 
 {{command:workbench.action.languageRuntime.interrupt}}
 
@@ -26,9 +34,56 @@ Restarts the active interpreter runtime session. **This discards all session
 state** -- variables, loaded packages, and command history in that session are
 lost. Always tell the user this will happen before calling it, and prefer
 `interrupt` first when the goal is just to stop something running rather than
-to get a clean session. No precondition -- always enabled.
+to get a clean session.
 
 {{command:workbench.action.language.runtime.restartActiveSession}}
+
+## Listing, switching, and starting sessions
+
+An interpreter *session* is a running instance of an interpreter. There can be
+several at once (e.g. an R console and two Python consoles); one is the
+foreground session that the console and the interrupt/restart commands act on.
+
+Both switching and starting take an internal id (a session id, a runtime id).
+Those ids appear nowhere in the Positron UI, so never show one to the user --
+list first to find the id, use it to make the call, then refer to the session
+or interpreter by its name. See the id rule in [SKILL.md]({{skill_dir}}/SKILL.md).
+
+### `workbench.action.language.runtime.getActiveSessions`
+
+Lists the interpreter sessions currently running. This is how you find the
+`sessionId` to hand to `selectSession`, and how you confirm a session exists
+before interrupting or restarting. Read-only and always enabled. Pass a
+`languageId` (e.g. `"python"` or `"r"`) to narrow the results to one language;
+omit it for every language. Each entry's `foreground: true` marks the currently
+active session, and `sessionName` is the name to use when talking to the user.
+An empty array means nothing is running.
+
+{{command:workbench.action.language.runtime.getActiveSessions}}
+
+### `workbench.action.language.runtime.selectSession`
+
+Makes an already-running session the foreground session. Use when the user
+wants to switch to a different session they already have open. Call
+`getActiveSessions` first and pass the `sessionId` of the session the user
+named; do not call this without an id, which opens a picker and waits on the
+user. A `selected: false` result means the picker was dismissed; report that
+rather than retrying.
+
+{{command:workbench.action.language.runtime.selectSession}}
+
+### `workbench.action.language.runtime.startNewConsoleSession`
+
+Starts a brand-new console session for a registered interpreter. Use when the
+user wants a fresh session rather than switching to an existing one. It needs
+the `runtimeId` of a registered interpreter, which comes from
+`workbench.action.language.runtime.getRegisteredRuntimes` in
+[interpreters.md]({{skill_dir}}/references/interpreters.md) -- list the interpreters,
+match the one the user asked for, and pass its `runtimeId`. Do not call this
+without an id, which opens a picker and waits on the user. A `started: false`
+result means the picker was dismissed; report that rather than retrying.
+
+{{command:workbench.action.language.runtime.startNewConsoleSession}}
 
 ## Managing packages
 

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -1644,6 +1644,9 @@ export function registerLanguageRuntimeActions() {
 			const foregroundSessionId = runtimeSessionService.foregroundSession?.sessionId;
 			return runtimeSessionService.activeSessions
 				.filter(isActiveSessionState)
+				// Background sessions have no console or notebook behind them, so
+				// they can't be selected or shown to the user; leave them out.
+				.filter(session => session.metadata.sessionMode !== LanguageRuntimeSessionMode.Background)
 				.filter(session => !filter || session.runtimeMetadata.languageId === filter)
 				.map(session => summarizeActiveSession(session, foregroundSessionId));
 		}

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -72,6 +72,7 @@ export const LANGUAGE_RUNTIME_RENAME_SESSION_ID = 'workbench.action.language.run
 export const LANGUAGE_RUNTIME_RENAME_ACTIVE_SESSION_ID = 'workbench.action.language.runtime.renameActiveSession';
 export const LANGUAGE_RUNTIME_DISCOVER_RUNTIMES_ID = 'workbench.action.language.runtime.discoverAllRuntimes';
 export const LANGUAGE_RUNTIME_GET_REGISTERED_RUNTIMES_ID = 'workbench.action.language.runtime.getRegisteredRuntimes';
+export const LANGUAGE_RUNTIME_GET_ACTIVE_SESSIONS_ID = 'workbench.action.language.runtime.getActiveSessions';
 export const LANGUAGE_RUNTIME_CLEAR_INTERPRETER_CACHE_ID = 'workbench.action.language.runtime.clearInterpreterCache';
 
 // Console Session Specific Action IDs
@@ -124,6 +125,45 @@ export function summarizeRegisteredRuntime(metadata: ILanguageRuntimeMetadata): 
 		runtimePath: getRuntimeDisplayPath(metadata),
 		startupBehavior: metadata.startupBehavior,
 		extensionId: metadata.extensionId.value,
+	};
+}
+
+/**
+ * A live interpreter session as reported to AI agents by the
+ * {@link LANGUAGE_RUNTIME_GET_ACTIVE_SESSIONS_ID} command. Carries the sessionId
+ * an agent needs to pass to `selectSession`, alongside the human-readable name
+ * and state it needs to describe the session to the user.
+ */
+export interface IActiveSessionSummary {
+	readonly sessionId: string;
+	readonly sessionName: string;
+	readonly runtimeId: string;
+	readonly languageId: string;
+	readonly languageName: string;
+	readonly runtimeName: string;
+	readonly sessionMode: string;
+	readonly state: string;
+	readonly foreground: boolean;
+}
+
+/**
+ * Projects a live session down to the fields useful to an AI agent.
+ *
+ * @param session The active session.
+ * @param foregroundSessionId The id of the current foreground session, if any.
+ * @returns A slim summary of the session.
+ */
+export function summarizeActiveSession(session: ILanguageRuntimeSession, foregroundSessionId: string | undefined): IActiveSessionSummary {
+	return {
+		sessionId: session.sessionId,
+		sessionName: session.dynState.sessionName,
+		runtimeId: session.runtimeMetadata.runtimeId,
+		languageId: session.runtimeMetadata.languageId,
+		languageName: session.runtimeMetadata.languageName,
+		runtimeName: session.runtimeMetadata.runtimeName,
+		sessionMode: session.metadata.sessionMode,
+		state: session.getRuntimeState(),
+		foreground: session.sessionId === foregroundSessionId,
 	};
 }
 
@@ -1573,6 +1613,39 @@ export function registerLanguageRuntimeActions() {
 			return languageRuntimeService.registeredRuntimes
 				.filter(runtime => !filter || runtime.languageId === filter)
 				.map(summarizeRegisteredRuntime);
+		}
+	});
+
+	registerAction2(class extends Action2 {
+		constructor() {
+			super({
+				id: LANGUAGE_RUNTIME_GET_ACTIVE_SESSIONS_ID,
+				title: localize2('workbench.action.language.runtime.getActiveSessions', "Get Active Sessions"),
+				category,
+				metadata: {
+					description: localize('positron.languageRuntime.getActiveSessions.description', "List the interpreter sessions currently running in Positron. Use before selecting a session to see which sessions exist and which one is active."),
+					agentCompatible: true,
+					args: [
+						{
+							name: 'languageId',
+							isOptional: true,
+							description: 'Restrict the results to a single language, e.g. "python" or "r". Omit to return sessions for every language.',
+							schema: { type: 'string' },
+						},
+					],
+					returns: 'An array of running sessions. Each entry has sessionId, sessionName, runtimeId, languageId, languageName, runtimeName, sessionMode (console or notebook), state, and foreground (true for the currently active session). An empty array means no session is running.',
+				},
+			});
+		}
+
+		async run(accessor: ServicesAccessor, languageId?: string): Promise<IActiveSessionSummary[]> {
+			const runtimeSessionService = accessor.get(IRuntimeSessionService);
+			const filter = typeof languageId === 'string' && languageId.length > 0 ? languageId : undefined;
+			const foregroundSessionId = runtimeSessionService.foregroundSession?.sessionId;
+			return runtimeSessionService.activeSessions
+				.filter(isActiveSessionState)
+				.filter(session => !filter || session.runtimeMetadata.languageId === filter)
+				.map(session => summarizeActiveSession(session, foregroundSessionId));
 		}
 	});
 

--- a/src/vs/workbench/contrib/languageRuntime/test/browser/languageRuntimeActions.vitest.ts
+++ b/src/vs/workbench/contrib/languageRuntime/test/browser/languageRuntimeActions.vitest.ts
@@ -12,7 +12,7 @@ import { IRuntimeStartupService } from '../../../../services/runtimeStartup/comm
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { TestQuickPick } from '../../../../../test/vitest/testQuickPick.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
-import { DuplicateActiveConsoleSessionAction, EvaluateCodeAction, SelectSessionAction, StartNewConsoleSessionAction, selectLanguageRuntimeSession, selectNewLanguageRuntime, summarizeRegisteredRuntime } from '../../browser/languageRuntimeActions.js';
+import { DuplicateActiveConsoleSessionAction, EvaluateCodeAction, SelectSessionAction, StartNewConsoleSessionAction, selectLanguageRuntimeSession, selectNewLanguageRuntime, summarizeActiveSession, summarizeRegisteredRuntime } from '../../browser/languageRuntimeActions.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
@@ -75,6 +75,60 @@ describe('summarizeRegisteredRuntime', () => {
 	test('falls back to the raw path when there is no display path', () => {
 		const summary = summarizeRegisteredRuntime(makeRuntime({ runtimePath: '/usr/bin/python3' }));
 		expect(summary.runtimePath).toBe('/usr/bin/python3');
+	});
+});
+
+describe('summarizeActiveSession', () => {
+	function makeSession(sessionId: string, sessionName: string, runtimeId: string): ILanguageRuntimeSession {
+		return stubInterface<ILanguageRuntimeSession>({
+			sessionId,
+			runtimeMetadata: makeRuntime({ runtimeId }),
+			dynState: stubInterface<ILanguageRuntimeSession['dynState']>({ sessionName }),
+			metadata: {
+				sessionId,
+				sessionMode: LanguageRuntimeSessionMode.Console,
+				notebookUri: undefined,
+				createdTimestamp: 0,
+				startReason: 'test',
+			},
+			getRuntimeState: () => RuntimeState.Idle,
+		});
+	}
+
+	test('projects the fields an agent needs and flags only the foreground session', () => {
+		const sessions = [
+			makeSession('py-session-1', 'Python 3.12', 'py-abc'),
+			makeSession('py-session-2', 'Python 3.12 (2)', 'py-abc'),
+		];
+
+		const summaries = sessions.map(session => summarizeActiveSession(session, 'py-session-1'));
+
+		expect(summaries).toMatchInlineSnapshot(`
+			[
+			  {
+			    "foreground": true,
+			    "languageId": "python",
+			    "languageName": "Python",
+			    "runtimeId": "py-abc",
+			    "runtimeName": "Python 3.12 (System)",
+			    "sessionId": "py-session-1",
+			    "sessionMode": "console",
+			    "sessionName": "Python 3.12",
+			    "state": "idle",
+			  },
+			  {
+			    "foreground": false,
+			    "languageId": "python",
+			    "languageName": "Python",
+			    "runtimeId": "py-abc",
+			    "runtimeName": "Python 3.12 (System)",
+			    "sessionId": "py-session-2",
+			    "sessionMode": "console",
+			    "sessionName": "Python 3.12 (2)",
+			    "state": "idle",
+			  },
+			]
+		`);
 	});
 });
 


### PR DESCRIPTION
Gives Assistant the console and session commands from the `positron-commands` skill, including adding the missing ids: `selectSession` needs the id of a session that exists and `startNewConsoleSession` needs the id of a registered runtime; the model had no way to learn valid session ids, so it either couldn't run the command or guessed.

Most of these commands were already agent-compatible (restart, interrupt, clear console, focus console, select session, start new console session). This PR adds the missing listing path and the documentation:

- **A command to list running sessions.** `workbench.action.language.runtime.getActiveSessions` returns a slim, agent-friendly summary of each live session: session id, name, runtime id, language, mode, state, and which one is in the foreground. Background sessions, which have no console or notebook behind them, are left out. This is where valid session ids for `selectSession` come from; runtime ids for `startNewConsoleSession` already come from `getRegisteredRuntimes`.
- **A dedicated `sessions.md` reference** covering listing, switching, and starting sessions, split out from `troubleshooting.md`, which now keeps only stuck-session recovery, packages, and help.
- **Console vs notebook guidance.** The reference explains the difference: `selectSession` is for console sessions only, and a notebook's session is brought to the foreground by focusing its editor tab, not by selecting it. Interrupt and restart still act on whichever session is the foreground, so they keep working on notebook sessions too.
- **Internal ids stay internal.** Session ids and runtime ids appear nowhere in the Positron UI, so the skill tells the model to use them only to make calls and to refer to sessions and interpreters by name when talking to the user.

Closes #15346

### Release Notes

#### New Features

- Assistant can now list the running interpreter sessions, switch between them, and start a new one (#15346)

#### Bug Fixes

- N/A

### Validation Steps

@:assistant

1. Start an R console session and a Python console session.
2. Ask Assistant "what sessions do I have running?" Confirm it lists both by name (not by an id) and knows which one is active.
3. Ask Assistant to "switch to my R session." Confirm the foreground console switches to R.
4. Ask Assistant to "start a new Python session." Confirm a fresh Python console starts.

Unit coverage for `summarizeActiveSession` is included in `languageRuntimeActions.vitest.ts`.
