### PR TITLE
python: prompt when creating venv with no workspace

### DIFF
--- a/extensions/positron-python/src/client/common/utils/localize.ts
+++ b/extensions/positron-python/src/client/common/utils/localize.ts
@@ -358,6 +358,14 @@ export namespace GlobalEnvironment {
         l10n.t(
             'Could not create the global Python environment because no home directory was found. Set WORKON_HOME to a directory to use for it.',
         );
+    export const promptTitle = l10n.t('Create a Python Environment');
+    export const promptMessage = (venvPath: string) =>
+        l10n.t(
+            'Opening a folder lets Positron create an environment for that project. Otherwise, Positron can create a shared environment at {0} for use outside of projects.',
+            venvPath,
+        );
+    export const createButton = l10n.t('Create Global Environment');
+    export const notNow = l10n.t('Not Now');
 }
 // --- End Positron ---
 

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/globalEnvironment.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/globalEnvironment.ts
@@ -9,6 +9,9 @@ import { getEnvironmentVariable, getUserHomeDir } from '../../../common/utils/pl
 import * as fsapi from '../../../common/platform/fs-paths';
 import { traceError, traceInfo } from '../../../logging';
 import { execUv } from './uv';
+import { executeCommand } from '../../../common/vscodeApis/commandApis';
+import { Common, GlobalEnvironment } from '../../../common/utils/localize';
+import { showThreeButtonModalDialogPrompt } from '../../../positron/positronApis';
 
 /**
  * Directory name of the environment Positron creates when no folder is open.
@@ -131,4 +134,66 @@ export async function createGlobalEnvironment(base: string): Promise<GlobalEnvir
 
     traceInfo(`Global environment created at ${pythonPath}`);
     return { outcome: 'created', venvDir, pythonPath };
+}
+
+/**
+ * Message to show when the global environment could not be created.
+ * @param result A non-`created` outcome from `createGlobalEnvironment()`.
+ */
+export function globalEnvironmentErrorMessage(
+    result: Exclude<GlobalEnvironmentResult, { outcome: 'created' }>,
+): string {
+    switch (result.outcome) {
+        case 'occupied':
+            return GlobalEnvironment.occupied(result.venvDir);
+        case 'unsupported':
+            return GlobalEnvironment.unsupported();
+        default:
+            return GlobalEnvironment.creationFailed(result.venvDir);
+    }
+}
+
+/** What the user asked for in the global environment modal. */
+export type GlobalEnvironmentChoice = 'openFolder' | 'create' | 'dismiss';
+
+/**
+ * Asks whether to open a folder, create the global environment, or do neither.
+ *
+ * "Open Folder..." is the primary action because the question these surfaces are
+ * really asking is where the environment should live, and a project folder is the
+ * better answer. Escape and the close button land on `dismiss`: a dialog the user
+ * did not answer is never consent to create anything.
+ *
+ * `openFolder` means the user asked to open a folder and the picker was shown. If a
+ * folder is actually opened the extension host reloads, ending whatever flow called
+ * this, so callers must return rather than carry on. A cancelled picker also comes
+ * back as `openFolder`; the flow has already ended either way.
+ *
+ * When there is no directory discovery would scan (no `$WORKON_HOME`, no home dir),
+ * there is no environment to offer, so no dialog is shown and the answer is `dismiss`.
+ *
+ * @returns The user's choice.
+ */
+export async function promptForGlobalEnvironment(): Promise<GlobalEnvironmentChoice> {
+    const venvDir = getGlobalEnvironmentDir();
+    if (!venvDir) {
+        traceError('Not offering a global environment: no WORKON_HOME and no home directory.');
+        return 'dismiss';
+    }
+
+    const choice = await showThreeButtonModalDialogPrompt({
+        title: GlobalEnvironment.promptTitle,
+        message: GlobalEnvironment.promptMessage(venvDir),
+        primaryButtonTitle: Common.openFolder,
+        secondaryButtonTitle: GlobalEnvironment.createButton,
+        tertiaryButtonTitle: GlobalEnvironment.notNow,
+    });
+    if (choice === GlobalEnvironment.createButton) {
+        return 'create';
+    }
+    if (choice === Common.openFolder) {
+        await executeCommand('workbench.action.files.openFolder');
+        return 'openFolder';
+    }
+    return 'dismiss';
 }

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uvPythonInstaller.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uvPythonInstaller.ts
@@ -9,29 +9,18 @@ import { traceError, traceInfo } from '../../../logging';
 import { exec } from '../externalDependencies';
 import { isUvInstalled, getAvailablePythonVersions, resetUvCache, isWindowsArm64, execUv } from './uv';
 import { Commands } from '../../../common/constants';
-import { Common, GlobalEnvironment, InterpreterQuickPickList } from '../../../common/utils/localize';
+import { Common, InterpreterQuickPickList } from '../../../common/utils/localize';
 import { getWorkspaceFolders } from '../../../common/vscodeApis/workspaceApis';
 import { createUvVenv } from '../../creation/provider/uvCreationProvider';
 import { ExistingVenvAction, deleteEnvironment, pickExistingVenvAction } from '../../creation/provider/venvUtils';
 import { getVenvExecutable, hasVenv } from '../../creation/common/commonUtils';
 import { MultiStepAction } from '../../../common/vscodeApis/windowApis';
 import { refreshEnvironments } from '../../../envExt/api.internal';
-import { createGlobalEnvironment, GlobalEnvironmentResult } from './globalEnvironment';
-
-/**
- * Message to show when the global environment could not be created.
- * @param result A non-`created` outcome from `createGlobalEnvironment()`.
- */
-function globalEnvironmentErrorMessage(result: Exclude<GlobalEnvironmentResult, { outcome: 'created' }>): string {
-    switch (result.outcome) {
-        case 'occupied':
-            return GlobalEnvironment.occupied(result.venvDir);
-        case 'unsupported':
-            return GlobalEnvironment.unsupported();
-        default:
-            return GlobalEnvironment.creationFailed(result.venvDir);
-    }
-}
+import {
+    createGlobalEnvironment,
+    globalEnvironmentErrorMessage,
+    promptForGlobalEnvironment,
+} from './globalEnvironment';
 
 /**
  * Shows an error notification for the uv Python install flow with a button that
@@ -104,6 +93,47 @@ async function installUv(): Promise<boolean> {
         traceError(`Failed to install uv: ${error}`);
         return false;
     }
+}
+
+/**
+ * Outcome of making sure uv is available.
+ *
+ * `error` is a message the caller should surface; it is absent when the user simply
+ * declined the install, which is not a failure worth a notification. Callers differ
+ * in how they show it -- `installPythonViaUv()` returns it upward for
+ * `handleInstallPythonResult` to display -- so this deliberately shows nothing itself.
+ */
+export type EnsureUvResult = { ok: true } | { ok: false; error?: string };
+
+/**
+ * Makes sure uv is available, prompting for consent and installing it if it is not.
+ *
+ * @param onInstalling Called only when uv is actually missing and about to be
+ *   installed, so callers can report progress without claiming to install uv that
+ *   is already there.
+ */
+export async function ensureUvInstalled(onInstalling?: () => void): Promise<EnsureUvResult> {
+    if (await isUvInstalled()) {
+        return { ok: true };
+    }
+
+    onInstalling?.();
+
+    if (!(await installUv())) {
+        // User declined or installation failed - exit silently
+        return { ok: false };
+    }
+
+    // Verify uv is now reachable. The installer drops the binary at a known
+    // location and updates shell rc files, but those PATH changes don't reach
+    // the running extension host. isUvInstalled() also probes uv's known
+    // install locations; if it still can't be found, surface an actionable
+    // message instead of the misleading "no versions available" error later.
+    if (!(await isUvInstalled())) {
+        return { ok: false, error: InterpreterQuickPickList.UvInstall.uvNotFoundAfterInstall };
+    }
+
+    return { ok: true };
 }
 
 /**
@@ -277,20 +307,11 @@ export async function installPythonViaUv(): Promise<InstallPythonResult> {
         async (progress) => {
             try {
                 // Install uv if needed
-                if (!(await isUvInstalled())) {
-                    progress.report({ message: InterpreterQuickPickList.UvInstall.installingUv });
-                    if (!(await installUv())) {
-                        // User declined or installation failed - exit silently
-                        return { success: false };
-                    }
-                    // Verify uv is now reachable. The installer drops the binary at a known
-                    // location and updates shell rc files, but those PATH changes don't reach
-                    // the running extension host. isUvInstalled() also probes uv's known
-                    // install locations; if it still can't be found, surface an actionable
-                    // message instead of the misleading "no versions available" error later.
-                    if (!(await isUvInstalled())) {
-                        return { success: false, error: InterpreterQuickPickList.UvInstall.uvNotFoundAfterInstall };
-                    }
+                const uvReady = await ensureUvInstalled(() =>
+                    progress.report({ message: InterpreterQuickPickList.UvInstall.installingUv }),
+                );
+                if (!uvReady.ok) {
+                    return { success: false, error: uvReady.error };
                 }
 
                 // Select and install Python version
@@ -352,17 +373,35 @@ export async function installPythonViaUv(): Promise<InstallPythonResult> {
                         }
                     }
                 } else {
-                    // No workspace - create the global environment at $WORKON_HOME/positron
-                    // (default ~/.virtualenvs/positron), a directory every locator already scans.
-                    // Nothing already at that path is reused, upgraded, or deleted.
-                    progress.report({ message: InterpreterQuickPickList.UvInstall.creatingVenv });
-                    const globalResult = await createGlobalEnvironment(selected.version);
-                    if (globalResult.outcome === 'created') {
-                        resolvedPath = globalResult.pythonPath;
-                        venvWasCreated = true;
-                    } else {
-                        await showUvInstallError(globalEnvironmentErrorMessage(globalResult));
+                    // No folder open. The question this flow is really asking is where the
+                    // environment should live, so lead with "Open Folder..." and only create
+                    // the global environment at $WORKON_HOME/positron (default
+                    // ~/.virtualenvs/positron) when the user asks for it. Nothing already at
+                    // that path is reused, upgraded, or deleted.
+                    const choice = await promptForGlobalEnvironment();
+
+                    if (choice === 'openFolder') {
+                        // The user asked to open a folder, so this window is done: if they
+                        // pick one, the window reloads. Registering the interpreter here
+                        // would start a session in a window they are leaving. The Python
+                        // just installed persists on disk, so the folder's window picks it
+                        // up. 'Cancelled' suppresses the error toast.
+                        return { success: false, error: 'Cancelled' };
                     }
+
+                    if (choice === 'create') {
+                        progress.report({ message: InterpreterQuickPickList.UvInstall.creatingVenv });
+                        const globalResult = await createGlobalEnvironment(selected.version);
+                        if (globalResult.outcome === 'created') {
+                            resolvedPath = globalResult.pythonPath;
+                            venvWasCreated = true;
+                        } else {
+                            await showUvInstallError(globalEnvironmentErrorMessage(globalResult));
+                        }
+                    }
+
+                    // 'dismiss' leaves resolvedPath on the base uv interpreter, which is the
+                    // same fallback a failed creation takes.
                 }
 
                 // Trigger a refresh of Python environments so the new interpreter is discovered

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
@@ -34,14 +34,22 @@ import * as positron from 'positron';
 import { getCondaPythonVersions } from './provider/condaUtils';
 import { IPythonRuntimeManager } from '../../positron/manager';
 import { Conda } from '../common/environmentManagers/conda';
-import { getUvPythonVersions } from './provider/uvUtils';
-import { isUvInstalled } from '../common/environmentManagers/uv';
-import { UvCreationProvider } from './provider/uvCreationProvider';
+import { getUvPythonVersions, pickPythonVersion } from './provider/uvUtils';
+import { getAvailablePythonVersions, isUvInstalled } from '../common/environmentManagers/uv';
+import { UV_PROVIDER_ID, UvCreationProvider } from './provider/uvCreationProvider';
 import {
+    ensureUvInstalled,
     installPythonViaUv,
     InstallPythonResult,
     showUvInstallError,
 } from '../common/environmentManagers/uvPythonInstaller';
+import {
+    createGlobalEnvironment,
+    getGlobalEnvironmentDir,
+    globalEnvironmentErrorMessage,
+    promptForGlobalEnvironment,
+} from '../common/environmentManagers/globalEnvironment';
+import { MultiStepAction } from '../../common/vscodeApis/windowApis';
 import {
     createEnvironmentAndRegister,
     CreateEnvironmentAndRegisterOptions,
@@ -50,7 +58,7 @@ import {
     isGlobalPython,
 } from '../../positron/createEnvApi';
 import { traceError, traceLog } from '../../logging';
-import { getConfiguration } from '../../common/vscodeApis/workspaceApis';
+import { getConfiguration, getWorkspaceFolders } from '../../common/vscodeApis/workspaceApis';
 import { InterpreterQuickPickList } from '../../common/utils/localize';
 // --- End Positron ---
 
@@ -135,6 +143,87 @@ async function handleInstallPythonResult(
     return undefined;
 }
 
+/**
+ * Runs Create Environment with no folder open.
+ *
+ * The provider ladder dead-ends at `pickWorkspaceFolder()` here, so offer the global
+ * environment instead of the "open a folder" error. No provider is selected on this
+ * path: outside a workspace the global environment is uv-backed by definition, and
+ * conda users already have a global named-env model through conda itself, whose
+ * environments are discovered independently. The caller only runs this for a request
+ * that asked for uv or did not name a provider, so being uv-backed is never a surprise.
+ *
+ * The command handler's `showBackButton` option is ignored here: the version picker
+ * runs on its own rather than as a step in the provider flow's `MultiStepNode` chain,
+ * so there is no earlier step for Back to return to. `selectEnvironment` is honored by
+ * the caller, since it says what to do with whatever environment came back rather than
+ * how to build one.
+ *
+ * @param uvPythonVersion A `major.minor` version to build from, or `'auto'` to take
+ *   uv's newest available version, matching `uvCreationProvider`. When undefined the
+ *   user picks a version.
+ * @returns The new environment's Python path, or undefined if nothing was created.
+ */
+async function createGlobalEnvironmentFromCommand(uvPythonVersion?: string): Promise<string | undefined> {
+    // The version picker always shows a Back button, and the modal is the step behind
+    // it, so Back reopens the modal instead of ending the command.
+    let version: string | undefined;
+    for (;;) {
+        if ((await promptForGlobalEnvironment()) !== 'create') {
+            // 'openFolder' reloads the extension host if a folder is opened, ending this
+            // command with it.
+            return undefined;
+        }
+
+        const uvReady = await ensureUvInstalled();
+        if (!uvReady.ok) {
+            if (uvReady.error) {
+                await showUvInstallError(uvReady.error);
+            }
+            return undefined;
+        }
+
+        if (uvPythonVersion) {
+            if (uvPythonVersion === 'auto') {
+                const versions = await getAvailablePythonVersions();
+                if (versions.length === 0) {
+                    traceError('No Python versions available from uv for auto-selection.');
+                    return undefined;
+                }
+                version = versions[0].version;
+                traceLog(`Auto-selected Python version ${version} for the global environment.`);
+            } else {
+                version = uvPythonVersion;
+            }
+            break;
+        }
+
+        try {
+            version = await pickPythonVersion();
+            break;
+        } catch (ex) {
+            if (ex === MultiStepAction.Back) {
+                continue;
+            }
+            if (ex === MultiStepAction.Cancel) {
+                return undefined;
+            }
+            throw ex;
+        }
+    }
+    if (!version) {
+        return undefined;
+    }
+
+    const result = await createGlobalEnvironment(version);
+    if (result.outcome !== 'created') {
+        await showUvInstallError(globalEnvironmentErrorMessage(result));
+        return undefined;
+    }
+
+    return result.pythonPath;
+}
+
 // Changed this function to be async
 export async function registerCreateEnvironmentFeatures(
     // --- End Positron ---
@@ -152,6 +241,41 @@ export async function registerCreateEnvironmentFeatures(
             async (
                 options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal,
             ): Promise<CreateEnvironmentResult | undefined> => {
+                // --- Start Positron ---
+                // With no folder open every provider dead-ends at pickWorkspaceFolder(),
+                // so offer the global environment before provider selection runs. The
+                // global environment is uv-backed, so a user who turned the uv provider
+                // off through python.environmentProviders.enable does not get it, and
+                // neither does a caller that explicitly asked for another provider: both
+                // fall through to the provider ladder's own open-a-folder error rather
+                // than being handed a uv environment they did not ask for. So does a user
+                // with nowhere to put the global environment (no WORKON_HOME, no home dir).
+                //
+                // This path deliberately skips the started/exited creation events: the
+                // folder-scoped exit handler below cannot apply without a folder, so the
+                // notification is shown here instead.
+                const requestedProviderId = options?.providerId;
+                if (
+                    !getWorkspaceFolders()?.length &&
+                    getGlobalEnvironmentDir() &&
+                    isEnvProviderEnabled(UV_PROVIDER_ID) &&
+                    (requestedProviderId === undefined || requestedProviderId === UV_PROVIDER_ID)
+                ) {
+                    const path = await createGlobalEnvironmentFromCommand(options?.uvPythonVersion);
+                    if (!path) {
+                        return undefined;
+                    }
+                    showInformationMessage(`${CreateEnv.informEnvCreation} ${pathUtils.getDisplayName(path)}`);
+                    // Registers the runtime and retries behind an interpreter refresh, which
+                    // a freshly created environment needs. Selecting is the default here as
+                    // it is on the workspace path below, but a caller that explicitly opts
+                    // out gets the path back without a runtime being started.
+                    if (options?.selectEnvironment !== false) {
+                        await pythonRuntimeManager.selectLanguageRuntimeFromPath(path, true);
+                    }
+                    return { path };
+                }
+                // --- End Positron ---
                 if (useEnvExtension()) {
                     try {
                         sendTelemetryEvent(EventName.ENVIRONMENT_CREATING, undefined, {

--- a/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/globalEnvironment.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/globalEnvironment.unit.test.ts
@@ -11,11 +11,16 @@ import * as platformApis from '../../../../client/common/utils/platform';
 import * as fsapi from '../../../../client/common/platform/fs-paths';
 import * as externalDependencies from '../../../../client/pythonEnvironments/common/externalDependencies';
 import * as logging from '../../../../client/logging';
+import * as commandApis from '../../../../client/common/vscodeApis/commandApis';
+import * as positronApis from '../../../../client/positron/positronApis';
+import { Common, GlobalEnvironment } from '../../../../client/common/utils/localize';
 import {
     getGlobalEnvironmentDir,
     getGlobalEnvironmentParent,
     getGlobalEnvironmentPython,
     createGlobalEnvironment,
+    globalEnvironmentErrorMessage,
+    promptForGlobalEnvironment,
 } from '../../../../client/pythonEnvironments/common/environmentManagers/globalEnvironment';
 
 suite('Global environment path', () => {
@@ -205,5 +210,88 @@ suite('createGlobalEnvironment', () => {
 
         assert.deepStrictEqual(result, { outcome: 'failed', venvDir });
         assert.ok(!execStub.called);
+    });
+});
+
+suite('promptForGlobalEnvironment', () => {
+    let getUserHomeDirStub: sinon.SinonStub;
+    let showPromptStub: sinon.SinonStub;
+    let executeCommandStub: sinon.SinonStub;
+
+    setup(() => {
+        sinon.stub(platformApis, 'getEnvironmentVariable').returns(undefined);
+        getUserHomeDirStub = sinon.stub(platformApis, 'getUserHomeDir').returns('/home/user');
+        sinon.stub(logging, 'traceError');
+        showPromptStub = sinon.stub(positronApis, 'showThreeButtonModalDialogPrompt').resolves(undefined);
+        executeCommandStub = sinon.stub(commandApis, 'executeCommand').resolves(undefined);
+    });
+
+    teardown(() => {
+        sinon.restore();
+    });
+
+    test('Leads with Open Folder and names the global path', async () => {
+        await promptForGlobalEnvironment();
+
+        assert.deepStrictEqual(showPromptStub.firstCall.args[0], {
+            title: GlobalEnvironment.promptTitle,
+            message: GlobalEnvironment.promptMessage(path.join('/home/user', '.virtualenvs', 'positron')),
+            primaryButtonTitle: Common.openFolder,
+            secondaryButtonTitle: GlobalEnvironment.createButton,
+            tertiaryButtonTitle: GlobalEnvironment.notNow,
+        });
+    });
+
+    test('Open Folder opens the folder picker', async () => {
+        showPromptStub.resolves(Common.openFolder);
+
+        assert.strictEqual(await promptForGlobalEnvironment(), 'openFolder');
+        assert.ok(executeCommandStub.calledOnceWithExactly('workbench.action.files.openFolder'));
+    });
+
+    test('Create Global Environment asks the caller to create', async () => {
+        showPromptStub.resolves(GlobalEnvironment.createButton);
+
+        assert.strictEqual(await promptForGlobalEnvironment(), 'create');
+        assert.ok(executeCommandStub.notCalled);
+    });
+
+    test('Not Now creates nothing', async () => {
+        showPromptStub.resolves(GlobalEnvironment.notNow);
+
+        assert.strictEqual(await promptForGlobalEnvironment(), 'dismiss');
+    });
+
+    test('Dismissal is not consent', async () => {
+        showPromptStub.resolves(undefined);
+
+        assert.strictEqual(await promptForGlobalEnvironment(), 'dismiss');
+    });
+
+    test('Shows nothing when there is nowhere to put the environment', async () => {
+        getUserHomeDirStub.returns(undefined);
+
+        assert.strictEqual(await promptForGlobalEnvironment(), 'dismiss');
+        assert.ok(showPromptStub.notCalled, 'there is no environment to offer creating');
+    });
+});
+
+suite('globalEnvironmentErrorMessage', () => {
+    test('Occupied names the path', () => {
+        assert.strictEqual(
+            globalEnvironmentErrorMessage({ outcome: 'occupied', venvDir: '/venvs/positron' }),
+            GlobalEnvironment.occupied('/venvs/positron'),
+        );
+    });
+
+    test('Failed names the path', () => {
+        assert.strictEqual(
+            globalEnvironmentErrorMessage({ outcome: 'failed', venvDir: '/venvs/positron' }),
+            GlobalEnvironment.creationFailed('/venvs/positron'),
+        );
+    });
+
+    test('Unsupported explains there is nowhere to put it', () => {
+        assert.strictEqual(globalEnvironmentErrorMessage({ outcome: 'unsupported' }), GlobalEnvironment.unsupported());
     });
 });

--- a/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uvPythonInstaller.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uvPythonInstaller.unit.test.ts
@@ -19,10 +19,12 @@ import * as venvUtils from '../../../../client/pythonEnvironments/creation/provi
 import * as apiInternal from '../../../../client/envExt/api.internal';
 import * as platformApis from '../../../../client/common/utils/platform';
 import * as fsapi from '../../../../client/common/platform/fs-paths';
+import * as globalEnvironment from '../../../../client/pythonEnvironments/common/environmentManagers/globalEnvironment';
 import { getAvailablePythonVersions } from '../../../../client/pythonEnvironments/common/environmentManagers/uv';
 import {
     installPythonViaUv,
     showUvInstallError,
+    ensureUvInstalled,
 } from '../../../../client/pythonEnvironments/common/environmentManagers/uvPythonInstaller';
 import { mockedPositronNamespaces, mockedVSCodeNamespaces } from '../../../vscode-mock';
 import { Common, GlobalEnvironment, InterpreterQuickPickList } from '../../../../client/common/utils/localize';
@@ -73,6 +75,62 @@ suite('UV Python Installer Tests', () => {
             await showUvInstallError('something went wrong');
 
             verify(mockedVSCodeNamespaces.commands!.executeCommand(Commands.ViewOutput)).never();
+        });
+    });
+
+    suite('ensureUvInstalled Tests', () => {
+        let isUvInstalledStub: sinon.SinonStub;
+
+        setup(() => {
+            isUvInstalledStub = sinon.stub(uv, 'isUvInstalled');
+            sinon.stub(uv, 'resetUvCache');
+        });
+
+        test('Already installed does not prompt or report installing', async () => {
+            isUvInstalledStub.resolves(true);
+            const onInstalling = sinon.stub();
+
+            assert.deepStrictEqual(await ensureUvInstalled(onInstalling), { ok: true });
+            assert.strictEqual(onInstalling.called, false);
+            verify(
+                mockedVSCodeNamespaces.window!.showInformationMessage(anything(), anything(), anything(), anything()),
+            ).never();
+        });
+
+        test('Declining the consent prompt exits without an error', async () => {
+            isUvInstalledStub.resolves(false);
+            when(
+                mockedVSCodeNamespaces.window!.showInformationMessage(anything(), anything(), anything(), anything()),
+            ).thenReturn(Promise.resolve(undefined) as any);
+
+            assert.deepStrictEqual(await ensureUvInstalled(), { ok: false });
+        });
+
+        test('Reports uv still being unreachable after a successful install', async () => {
+            isUvInstalledStub.onFirstCall().resolves(false);
+            isUvInstalledStub.onSecondCall().resolves(false);
+            when(
+                mockedVSCodeNamespaces.window!.showInformationMessage(anything(), anything(), anything(), anything()),
+            ).thenReturn(Promise.resolve(InterpreterQuickPickList.UvInstall.confirmUvInstallYes) as any);
+            execStub.resolves({ stdout: '', stderr: '' });
+
+            assert.deepStrictEqual(await ensureUvInstalled(), {
+                ok: false,
+                error: InterpreterQuickPickList.UvInstall.uvNotFoundAfterInstall,
+            });
+        });
+
+        test('A successful install reports ok and reports installing', async () => {
+            isUvInstalledStub.onFirstCall().resolves(false);
+            isUvInstalledStub.onSecondCall().resolves(true);
+            when(
+                mockedVSCodeNamespaces.window!.showInformationMessage(anything(), anything(), anything(), anything()),
+            ).thenReturn(Promise.resolve(InterpreterQuickPickList.UvInstall.confirmUvInstallYes) as any);
+            execStub.resolves({ stdout: '', stderr: '' });
+            const onInstalling = sinon.stub();
+
+            assert.deepStrictEqual(await ensureUvInstalled(onInstalling), { ok: true });
+            assert.strictEqual(onInstalling.calledOnce, true);
         });
     });
 
@@ -374,6 +432,7 @@ suite('UV Python Installer Tests', () => {
         let pickExistingVenvActionStub: sinon.SinonStub;
         let deleteEnvironmentStub: sinon.SinonStub;
         let getVenvExecutableStub: sinon.SinonStub;
+        let promptForGlobalEnvironmentStub: sinon.SinonStub;
 
         const mockProgress = {
             report: sinon.stub(),
@@ -423,6 +482,9 @@ suite('UV Python Installer Tests', () => {
             sinon.stub(fsapi, 'pathExists').resolves(false);
             (fsapi.pathExists as sinon.SinonStub).withArgs(getExpectedGlobalEnvPython()).resolves(true);
             sinon.stub(fsapi, 'mkdirp').resolves();
+            promptForGlobalEnvironmentStub = sinon
+                .stub(globalEnvironment, 'promptForGlobalEnvironment')
+                .resolves('create');
 
             quickPickCallCount = 0;
             quickPickResponses = [];
@@ -1080,6 +1142,70 @@ suite('UV Python Installer Tests', () => {
             // Only install + find: nothing is created outside a discovered directory.
             assert.strictEqual(execStub.callCount, 2);
             verify(mockedVSCodeNamespaces.window!.showErrorMessage(GlobalEnvironment.unsupported(), anything())).once();
+        });
+
+        suite('No workspace prompt', () => {
+            setup(() => {
+                isUvInstalledStub.resolves(true);
+                getWorkspaceFoldersStub.returns(undefined);
+                getAvailablePythonVersionsStub.resolves([{ version: '3.13', identifier: 'cpython-3.13' }]);
+                when(mockedVSCodeNamespaces.window!.showQuickPick(anything(), anything())).thenReturn(
+                    Promise.resolve({ label: 'Python 3.13', version: '3.13', isInstalled: false }) as any,
+                );
+                execStub.onFirstCall().resolves({ stdout: '' }); // uv python install
+                execStub.onSecondCall().resolves({ stdout: '/usr/local/bin/python3.13' }); // uv python find
+                execStub.onThirdCall().resolves({ stdout: '' }); // uv venv, when creation is requested
+            });
+
+            test('Asks before creating anything', async () => {
+                await installPythonViaUv();
+
+                assert.ok(promptForGlobalEnvironmentStub.calledOnce);
+            });
+
+            test('Open Folder ends the flow without creating an environment', async () => {
+                // The user asked to open a folder, so this window is reloading or abandoned;
+                // registering an interpreter into it would start a session the user left.
+                promptForGlobalEnvironmentStub.resolves('openFolder');
+
+                const result = await installPythonViaUv();
+
+                assert.strictEqual(result.success, false);
+                assert.strictEqual(result.error, 'Cancelled');
+                assert.ok(!execStub.getCalls().some((c) => c.args[1]?.[0] === 'venv'));
+            });
+
+            test('Not Now falls back to the base interpreter', async () => {
+                promptForGlobalEnvironmentStub.resolves('dismiss');
+
+                const result = await installPythonViaUv();
+
+                assert.strictEqual(result.success, true);
+                assert.strictEqual(result.pythonPath, '/usr/local/bin/python3.13');
+                assert.ok(!execStub.getCalls().some((c) => c.args[1]?.[0] === 'venv'));
+            });
+
+            test('Create Global Environment creates it and uses it', async () => {
+                promptForGlobalEnvironmentStub.resolves('create');
+
+                const result = await installPythonViaUv();
+
+                assert.strictEqual(result.success, true);
+                assert.strictEqual(result.pythonPath, getExpectedGlobalEnvPython());
+            });
+
+            test('A failed creation falls back to the base interpreter', async () => {
+                promptForGlobalEnvironmentStub.resolves('create');
+                sinon.stub(globalEnvironment, 'createGlobalEnvironment').resolves({
+                    outcome: 'occupied',
+                    venvDir: '/venvs/positron',
+                });
+
+                const result = await installPythonViaUv();
+
+                assert.strictEqual(result.success, true);
+                assert.strictEqual(result.pythonPath, '/usr/local/bin/python3.13');
+            });
         });
     });
 });

--- a/extensions/positron-python/src/test/pythonEnvironments/creation/createEnvApi.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/creation/createEnvApi.unit.test.ts
@@ -21,7 +21,13 @@ import {
 import { registerCreateEnvironmentFeatures } from '../../../client/pythonEnvironments/creation/createEnvApi';
 import * as windowApis from '../../../client/common/vscodeApis/windowApis';
 import { handleCreateEnvironmentCommand } from '../../../client/pythonEnvironments/creation/createEnvironment';
-import { CreateEnvironmentProvider } from '../../../client/pythonEnvironments/creation/proposed.createEnvApis';
+import {
+    CreateEnvironmentProvider,
+    // --- Start Positron ---
+    CreateEnvironmentOptions,
+    CreateEnvironmentResult,
+    // --- End Positron ---
+} from '../../../client/pythonEnvironments/creation/proposed.createEnvApis';
 
 // --- Start Positron ---
 import { WorkspaceConfiguration } from 'vscode';
@@ -32,6 +38,13 @@ import { capture, when } from 'ts-mockito';
 import * as positron from 'positron';
 import { mockedPositronNamespaces } from '../../vscode-mock';
 import { Commands } from '../../../client/common/constants';
+import * as uvUtils from '../../../client/pythonEnvironments/creation/provider/uvUtils';
+import * as uvPythonInstaller from '../../../client/pythonEnvironments/common/environmentManagers/uvPythonInstaller';
+import * as globalEnvironment from '../../../client/pythonEnvironments/common/environmentManagers/globalEnvironment';
+import * as uv from '../../../client/pythonEnvironments/common/environmentManagers/uv';
+import { UV_PROVIDER_ID } from '../../../client/pythonEnvironments/creation/provider/uvCreationProvider';
+import { CONDA_PROVIDER_ID } from '../../../client/pythonEnvironments/creation/provider/condaCreationProvider';
+import { CreateEnvironmentOptionsInternal } from '../../../client/pythonEnvironments/creation/types';
 // --- End Positron ---
 
 chaiUse(chaiAsPromised.default);
@@ -223,6 +236,233 @@ suite('Create Environment APIs', () => {
             const result = await capturedContribution().onDidSelectItem('create-python-env');
 
             assert.strictEqual(result, undefined);
+        });
+    });
+
+    suite('Create Environment with no folder open', () => {
+        let getWorkspaceFoldersStub: sinon.SinonStub;
+        let getGlobalEnvironmentDirStub: sinon.SinonStub;
+        let promptStub: sinon.SinonStub;
+        let ensureUvInstalledStub: sinon.SinonStub;
+        let pickPythonVersionStub: sinon.SinonStub;
+        let createGlobalEnvironmentStub: sinon.SinonStub;
+        let showUvInstallErrorStub: sinon.SinonStub;
+        let getAvailablePythonVersionsStub: sinon.SinonStub;
+
+        function runCommand(
+            options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal,
+        ): Promise<CreateEnvironmentResult | undefined> {
+            const call = registerCommandStub.getCalls().find((c) => c.args[0] === Commands.Create_Environment);
+            assert.ok(call, 'python.createEnvironment was not registered');
+            return call!.args[1](options);
+        }
+
+        setup(() => {
+            getWorkspaceFoldersStub = sinon.stub(workspaceApis, 'getWorkspaceFolders').returns(undefined);
+            getGlobalEnvironmentDirStub = sinon
+                .stub(globalEnvironment, 'getGlobalEnvironmentDir')
+                .returns('/venvs/positron');
+            promptStub = sinon.stub(globalEnvironment, 'promptForGlobalEnvironment').resolves('create');
+            ensureUvInstalledStub = sinon.stub(uvPythonInstaller, 'ensureUvInstalled').resolves({ ok: true });
+            pickPythonVersionStub = sinon.stub(uvUtils, 'pickPythonVersion').resolves('3.13');
+            createGlobalEnvironmentStub = sinon.stub(globalEnvironment, 'createGlobalEnvironment').resolves({
+                outcome: 'created',
+                venvDir: '/venvs/positron',
+                pythonPath: '/venvs/positron/bin/python',
+            });
+            showUvInstallErrorStub = sinon.stub(uvPythonInstaller, 'showUvInstallError').resolves();
+            getAvailablePythonVersionsStub = sinon.stub(uv, 'getAvailablePythonVersions').resolves([
+                { version: '3.14', isInstalled: false, identifier: 'cpython-3.14.0' },
+                { version: '3.13', isInstalled: true, identifier: 'cpython-3.13.1' },
+            ]);
+        });
+
+        test('Offers the global environment instead of dead-ending', async () => {
+            const result = await runCommand();
+
+            assert.ok(promptStub.calledOnce);
+            assert.deepStrictEqual(result, { path: '/venvs/positron/bin/python' });
+        });
+
+        test('Selects the environment it created', async () => {
+            pythonRuntimeManager
+                .setup((m) => m.selectLanguageRuntimeFromPath('/venvs/positron/bin/python', true))
+                .returns(() => Promise.resolve('runtime-id'))
+                .verifiable(typemoq.Times.once());
+
+            await runCommand();
+
+            pythonRuntimeManager.verifyAll();
+        });
+
+        test('Notifies without a folder-scoped interpreter update', async () => {
+            await runCommand();
+
+            assert.strictEqual(showInformationMessageStub.callCount, 1);
+            interpreterPathService.verify(
+                (p) =>
+                    p.updatePythonPath(typemoq.It.isAny(), typemoq.It.isAny(), typemoq.It.isAny(), typemoq.It.isAny()),
+                typemoq.Times.never(),
+            );
+        });
+
+        test('Leaves the environment unselected when the caller opts out', async () => {
+            const result = await runCommand({ selectEnvironment: false });
+
+            assert.deepStrictEqual(result, { path: '/venvs/positron/bin/python' });
+            pythonRuntimeManager.verify(
+                (m) => m.selectLanguageRuntimeFromPath(typemoq.It.isAny(), typemoq.It.isAny()),
+                typemoq.Times.never(),
+            );
+        });
+
+        test('Builds from the version the user picked', async () => {
+            pickPythonVersionStub.resolves('3.12');
+
+            await runCommand();
+
+            assert.ok(createGlobalEnvironmentStub.calledOnceWithExactly('3.12'));
+        });
+
+        test('Not Now creates nothing', async () => {
+            promptStub.resolves('dismiss');
+
+            assert.strictEqual(await runCommand(), undefined);
+            assert.ok(createGlobalEnvironmentStub.notCalled);
+        });
+
+        test('Open Folder creates nothing', async () => {
+            promptStub.resolves('openFolder');
+
+            assert.strictEqual(await runCommand(), undefined);
+            assert.ok(createGlobalEnvironmentStub.notCalled);
+            assert.ok(ensureUvInstalledStub.notCalled);
+        });
+
+        test('Backing out of the version pick creates nothing', async () => {
+            pickPythonVersionStub.resolves(undefined);
+
+            assert.strictEqual(await runCommand(), undefined);
+            assert.ok(createGlobalEnvironmentStub.notCalled);
+        });
+
+        test('The Back button reopens the global environment prompt', async () => {
+            pickPythonVersionStub.onFirstCall().callsFake(() => Promise.reject(windowApis.MultiStepAction.Back));
+            promptStub.onSecondCall().resolves('dismiss');
+
+            assert.strictEqual(await runCommand(), undefined);
+            assert.strictEqual(promptStub.callCount, 2);
+            assert.ok(createGlobalEnvironmentStub.notCalled);
+        });
+
+        test('Back followed by a version pick still creates the environment', async () => {
+            pickPythonVersionStub.onFirstCall().callsFake(() => Promise.reject(windowApis.MultiStepAction.Back));
+            pickPythonVersionStub.onSecondCall().resolves('3.12');
+
+            assert.deepStrictEqual(await runCommand(), { path: '/venvs/positron/bin/python' });
+            assert.ok(createGlobalEnvironmentStub.calledOnceWithExactly('3.12'));
+        });
+
+        test('Cancelling the version pick creates nothing', async () => {
+            pickPythonVersionStub.callsFake(() => Promise.reject(windowApis.MultiStepAction.Cancel));
+
+            assert.strictEqual(await runCommand(), undefined);
+            assert.strictEqual(promptStub.callCount, 1);
+            assert.ok(createGlobalEnvironmentStub.notCalled);
+        });
+
+        test('Declining the uv install creates nothing and says nothing', async () => {
+            ensureUvInstalledStub.resolves({ ok: false });
+
+            assert.strictEqual(await runCommand(), undefined);
+            assert.ok(createGlobalEnvironmentStub.notCalled);
+            assert.ok(showUvInstallErrorStub.notCalled);
+        });
+
+        test('An unreachable uv is reported', async () => {
+            ensureUvInstalledStub.resolves({ ok: false, error: 'uv is not on the PATH' });
+
+            assert.strictEqual(await runCommand(), undefined);
+            assert.ok(showUvInstallErrorStub.calledOnceWithExactly('uv is not on the PATH'));
+        });
+
+        test('An occupied path is reported and nothing is selected', async () => {
+            createGlobalEnvironmentStub.resolves({ outcome: 'occupied', venvDir: '/venvs/positron' });
+
+            assert.strictEqual(await runCommand(), undefined);
+            assert.ok(
+                showUvInstallErrorStub.calledOnceWithExactly(
+                    globalEnvironment.globalEnvironmentErrorMessage({
+                        outcome: 'occupied',
+                        venvDir: '/venvs/positron',
+                    }),
+                ),
+            );
+        });
+
+        test('With the uv provider disabled the interception does not fire', async () => {
+            workspaceConfig
+                .setup((c) => c.get<Record<string, boolean>>('environmentProviders.enable'))
+                .returns(() => ({ venv: true, conda: true, uv: false }));
+            showQuickPickStub.resolves(undefined);
+
+            assert.strictEqual(await runCommand(), undefined);
+            assert.ok(promptStub.notCalled);
+            assert.ok(ensureUvInstalledStub.notCalled);
+            assert.ok(createGlobalEnvironmentStub.notCalled);
+        });
+
+        test('A caller asking for uv gets the global environment', async () => {
+            assert.deepStrictEqual(await runCommand({ providerId: UV_PROVIDER_ID }), {
+                path: '/venvs/positron/bin/python',
+            });
+        });
+
+        test('A caller asking for another provider does not get a uv environment', async () => {
+            showQuickPickStub.resolves(undefined);
+
+            assert.strictEqual(await runCommand({ providerId: CONDA_PROVIDER_ID }), undefined);
+            assert.ok(promptStub.notCalled);
+            assert.ok(createGlobalEnvironmentStub.notCalled);
+        });
+
+        test('A requested version is used without asking again', async () => {
+            await runCommand({ uvPythonVersion: '3.11' });
+
+            assert.ok(pickPythonVersionStub.notCalled);
+            assert.ok(createGlobalEnvironmentStub.calledOnceWithExactly('3.11'));
+        });
+
+        test("A version of 'auto' builds from uv's newest version", async () => {
+            await runCommand({ uvPythonVersion: 'auto' });
+
+            assert.ok(pickPythonVersionStub.notCalled);
+            assert.ok(createGlobalEnvironmentStub.calledOnceWithExactly('3.14'));
+        });
+
+        test("A version of 'auto' with nothing available creates nothing", async () => {
+            getAvailablePythonVersionsStub.resolves([]);
+
+            assert.strictEqual(await runCommand({ uvPythonVersion: 'auto' }), undefined);
+            assert.ok(createGlobalEnvironmentStub.notCalled);
+        });
+
+        test('With nowhere to put the environment the interception does not fire', async () => {
+            getGlobalEnvironmentDirStub.returns(undefined);
+            showQuickPickStub.resolves(undefined);
+
+            assert.strictEqual(await runCommand(), undefined);
+            assert.ok(promptStub.notCalled);
+            assert.ok(createGlobalEnvironmentStub.notCalled);
+        });
+
+        test('With a folder open the interception does not fire', async () => {
+            getWorkspaceFoldersStub.returns([{ uri: Uri.file('/project'), name: 'project', index: 0 }]);
+            showQuickPickStub.resolves(undefined);
+
+            await runCommand();
+
+            assert.ok(promptStub.notCalled);
         });
     });
     // --- End Positron ---


### PR DESCRIPTION
Part of #14887. Two of the three modals in that issue are done after this one, so it doesn't close it yet.

### Summary

With no folder open, "Install Python via uv" created the global environment as soon as Python finished installing, without asking. It now asks first, with "Open Folder..." as the primary action, "Create Global Environment" naming the literal path as the secondary, and "Not Now" as the third.

We also now show this modal for the "Create Environment" command with no folder open. Previously, every provider dead-ended at the workspace folder picker and the user got an "open a folder" error.

### Screenshot

<img width="499" height="201" alt="image" src="https://github.com/user-attachments/assets/2127844d-6c7d-445a-a999-c185d256403c" />


### Release Notes

#### New Features
- N/A

#### Bug Fixes
- With no folder open, Positron now asks before creating a Python environment in your home directory, and recommends opening a folder instead (#14887)
- The Create Environment command no longer dead-ends with an "open a folder" error when no folder is open (#14887)

### Validation Steps

@:interpreter @:win

With no folder open, and with no `~/.virtualenvs/positron` present:

1. Run "Install Python via uv" and finish the version pick. Confirm the prompt appears and names `~/.virtualenvs/positron`.
2. Choose "Not Now". Confirm nothing is created and the session starts on the base interpreter.
3. Repeat and choose "Create Global Environment". Confirm the environment is created at that path and gets selected.
4. Delete `~/.virtualenvs/positron`, then run "Python: Create Environment". Confirm you get the same prompt instead of an "open a folder" error, that "Create Global Environment" leads to a version pick, and that Back from the version pick reopens the prompt.
5. Confirm "Open Folder..." opens the folder picker and creates nothing.
