### PR TITLE
e2e: measure console width atomically in the output-wrap test

### DIFF
--- a/test/e2e/tests/console/console-output.test.ts
+++ b/test/e2e/tests/console/console-output.test.ts
@@ -23,7 +23,10 @@ test.describe('Console Output', { tag: [tags.WIN, tags.CONSOLE, tags.WEB] }, () 
 		await app.workbench.console.waitForReady('>>>');
 		await app.workbench.console.pasteCodeToConsole(pyCode);
 		await app.workbench.console.sendEnterKey();
-		await app.workbench.console.waitForReady('>>>');
+		// Gate on the output itself, not the prompt: the active line reads '>>>' both
+		// before and after execution, so waiting on it can pass with an empty console
+		// and the width assertion below would then trivially succeed.
+		await app.workbench.console.waitForConsoleContents(/^'(Blah){300}'$/);
 
 		const el = app.workbench.console.activeConsole;
 		// Measure both dimensions in one evaluate: read separately, the vertical

--- a/test/e2e/tests/console/console-output.test.ts
+++ b/test/e2e/tests/console/console-output.test.ts
@@ -23,15 +23,11 @@ test.describe('Console Output', { tag: [tags.WIN, tags.CONSOLE, tags.WEB] }, () 
 		await app.workbench.console.waitForReady('>>>');
 		await app.workbench.console.pasteCodeToConsole(pyCode);
 		await app.workbench.console.sendEnterKey();
-		// Gate on the output itself, not the prompt: the active line reads '>>>' both
-		// before and after execution, so waiting on it can pass with an empty console
-		// and the width assertion below would then trivially succeed.
+		// '>>>' shows before and after execution, so gate on the output itself.
 		await app.workbench.console.waitForConsoleContents(/^'(Blah){300}'$/);
 
 		const el = app.workbench.console.activeConsole;
-		// Measure both dimensions in one evaluate: read separately, the vertical
-		// scrollbar can appear between the two reads and shrink clientWidth by its
-		// own width, reporting overflow that never existed at any single instant.
+		// One evaluate: a scrollbar appearing between two reads fakes overflow.
 		await expect.poll(async () => el.evaluate((e) => e.scrollWidth - e.clientWidth)).toBeLessThanOrEqual(0);
 	});
 });

--- a/test/e2e/tests/console/console-output.test.ts
+++ b/test/e2e/tests/console/console-output.test.ts
@@ -26,7 +26,10 @@ test.describe('Console Output', { tag: [tags.WIN, tags.CONSOLE, tags.WEB] }, () 
 		await app.workbench.console.waitForReady('>>>');
 
 		const el = app.workbench.console.activeConsole;
-		expect(await el.evaluate((el) => el.scrollWidth)).toBeLessThanOrEqual(await el.evaluate((el) => el.clientWidth));
+		// Measure both dimensions in one evaluate: read separately, the vertical
+		// scrollbar can appear between the two reads and shrink clientWidth by its
+		// own width, reporting overflow that never existed at any single instant.
+		await expect.poll(async () => el.evaluate((e) => e.scrollWidth - e.clientWidth)).toBeLessThanOrEqual(0);
 	});
 });
 


### PR DESCRIPTION
### Summary
`Console Output > Python - Ensure long console output wraps appropriately` flaked at 12.8% on ubuntu/chromium (also sles/chromium, never electron). The width assertion read `scrollWidth` and `clientWidth` in two separate `evaluate` round-trips, so the vertical scrollbar appearing between them shrank `clientWidth` and reported overflow that never existed at any single instant.

- Read the difference in one `evaluate`, wrapped in `expect.poll`
- Observed failure was `scrollWidth 442` vs `clientWidth 428` -- exactly the 14px `::-webkit-scrollbar` width from `consoleInstance.css`
- Failure screenshots show the output correctly wrapped across ~26 lines, so this is not a product wrapping bug
- Web-lane-only because each `evaluate` there is a remote round-trip, widening the gap between the two reads
- Assertion strength is unchanged: a genuine wrap failure keeps the delta positive for the full poll and still fails
- Also replaced the post-execution `waitForReady('>>>')` gate with a wait on the output text: the active line reads `>>>` both before and after execution, so an empty console would have satisfied the width assertion trivially

### QA Notes
@:console @:web


### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- Test bug: scrollWidth and clientWidth are read in two separate evaluate round-trips, so the vertical scrollbar appearing between them produces a torn measurement that fails by exactly the 14px scrollbar width.</summary>

- **Test:** [Console Output > Python - Ensure long console output wraps appropriately](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Console%20Output%20%3E%20Python%20-%20Ensure%20long%20console%20output%20wraps%20appropriately%7C%7C%7Ctest%2Fe2e%2Ftests%2Fconsole%2Fconsole-output.test.ts)
- **Targeted failure:** expect(received).toBeLessThanOrEqual(expected) - scrollWidth 442 vs clientWidth 428
- **Signal:** Delta is exactly 14px, matching ::-webkit-scrollbar{width:14px} in consoleInstance.css; failure screenshots show output wrapped across ~26 lines with no horizontal overflow and no horizontal scrollbar; pattern is chromium web lanes only, never electron, where the two reads are far closer together.
- **Frequency:** 15/117 runs (12.8%) on main, ubuntu/chromium
- **Hypothesis:** Reading both dimensions in a single in-page evaluate, retried via expect.poll, removes the tear and the transient-reflow window, dropping the 12.8% ubuntu/chromium failure rate to zero.

</details>

