### PR TITLE
e2e: cover Posit Assistant on Databricks and Snowflake managed credentials

### DIFF
--- a/test/e2e/pages/positAssistant.ts
+++ b/test/e2e/pages/positAssistant.ts
@@ -63,6 +63,7 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
 	'openai-api': 'OpenAI',
 	'ms-foundry': 'Microsoft Foundry',
 	'posit-ai': 'Posit AI',
+	'snowflake-cortex': 'Snowflake Cortex',
 };
 
 // Chat message elements

--- a/test/e2e/tests/workbench/posit-assistant/posit-assistant-databricks.test.ts
+++ b/test/e2e/tests/workbench/posit-assistant/posit-assistant-databricks.test.ts
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Posit Assistant against Databricks Foundation Models on Posit Workbench, using
+ * the Workbench-managed Databricks credential.
+ *
+ * Its own file (and its own shard tag) because the credential is provisioned per
+ * container: the Databricks stack has to be the one running, which the
+ * `@:workbench-databricks` tag selects. Snowflake Cortex gets the same treatment
+ * in `posit-assistant-snowflake.test.ts`, and Microsoft Foundry in
+ * `posit-assistant-foundry.test.ts`.
+ */
+
+import { expect, test, tags } from '../../_test.setup';
+
+test.use({
+	suiteId: __filename,
+	managedCredentials: 'databricks',
+});
+
+// Pins the reply to a single known word so the response assertion can check for
+// it. A bare "Say hello" leaves the model free to answer with a greeting that
+// never contains the word.
+const HELLO_PROMPT = 'Reply with only the word hello.';
+
+test.describe('Posit Assistant - Databricks (Workbench managed credentials)', {
+	tag: [tags.WORKBENCH_DATABRICKS, tags.ASSISTANT],
+}, () => {
+	test('Databricks model responds when authenticated via Workbench managed credentials', async function ({ app }) {
+		// No interactive sign-in: the Workbench dashboard's Databricks credential
+		// (set up by the fixture before the session launches) writes a
+		// posit-workbench-managed profile and points DATABRICKS_CONFIG_FILE at it.
+		// The authentication extension's Databricks credential chain reads that
+		// profile on activation (registerDatabricksProvider ->
+		// resolveChainCredentials), so a session already exists here -- which is
+		// exactly the path a Workbench user gets and the desktop OAuth/PAT tests
+		// cannot reach.
+		await app.workbench.positAssistant.open();
+		await app.workbench.positAssistant.waitForReady();
+		await app.workbench.positAssistant.startNewConversation();
+
+		// Other base-fixture providers stay enabled but unauthenticated on this
+		// shard, and model display names repeat across providers, so scope the
+		// choice to the Databricks group rather than relying on an auto-selected
+		// default. `newConversation: false` keeps the model we just picked instead
+		// of resetting to a fresh chat.
+		await app.workbench.positAssistant.selectProviderModel('databricks');
+		await app.workbench.positAssistant.sendMessage(HELLO_PROMPT, true, { newConversation: false });
+		await app.workbench.positAssistant.expectResponseVisible();
+
+		// Assert the model answered the prompt, not merely that some text
+		// rendered: a length check also passes on an error or a refusal shown in
+		// the response body. The match stays case-insensitive because
+		// capitalization and trailing punctuation are still the model's to choose.
+		const responseText = await app.workbench.positAssistant.getLastResponseText();
+		expect(responseText).toMatch(/hello/i);
+	});
+});

--- a/test/e2e/tests/workbench/posit-assistant/posit-assistant-snowflake.test.ts
+++ b/test/e2e/tests/workbench/posit-assistant/posit-assistant-snowflake.test.ts
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Posit Assistant against Snowflake Cortex on Posit Workbench, using the
+ * Workbench-managed Snowflake credential.
+ *
+ * Its own file (and its own shard tag) because the credential is provisioned per
+ * container: the Snowflake stack has to be the one running, which the
+ * `@:workbench-snowflake` tag selects. Databricks gets the same treatment in
+ * `posit-assistant-databricks.test.ts`, and Microsoft Foundry in
+ * `posit-assistant-foundry.test.ts`.
+ */
+
+import { expect, test, tags } from '../../_test.setup';
+
+test.use({
+	suiteId: __filename,
+	managedCredentials: 'snowflake',
+});
+
+// Pins the reply to a single known word so the response assertion can check for
+// it. A bare "Say hello" leaves the model free to answer with a greeting that
+// never contains the word.
+const HELLO_PROMPT = 'Reply with only the word hello.';
+
+test.describe('Posit Assistant - Snowflake Cortex (Workbench managed credentials)', {
+	tag: [tags.WORKBENCH_SNOWFLAKE, tags.ASSISTANT],
+}, () => {
+	test('Snowflake Cortex model responds when authenticated via Workbench managed credentials', async function ({ app }) {
+		// No interactive sign-in: the Workbench dashboard's Snowflake credential
+		// (set up by the fixture before the session launches) writes a
+		// posit-workbench-managed connections.toml and points SNOWFLAKE_HOME at it.
+		// The authentication extension's Snowflake credential chain reads that
+		// file on activation (registerSnowflakeProvider -> resolveChainCredentials)
+		// and syncs the detected account into the provider catalog, from which the
+		// Cortex base URL is derived -- so a session already exists here. That is
+		// the path a Workbench user gets, and no desktop sign-in test reaches it.
+		await app.workbench.positAssistant.open();
+		await app.workbench.positAssistant.waitForReady();
+		await app.workbench.positAssistant.startNewConversation();
+
+		// Other base-fixture providers stay enabled but unauthenticated on this
+		// shard, and model display names repeat across providers, so scope the
+		// choice to the Snowflake Cortex group rather than relying on an
+		// auto-selected default. `newConversation: false` keeps the model we just
+		// picked instead of resetting to a fresh chat.
+		await app.workbench.positAssistant.selectProviderModel('snowflake-cortex');
+		await app.workbench.positAssistant.sendMessage(HELLO_PROMPT, true, { newConversation: false });
+		await app.workbench.positAssistant.expectResponseVisible();
+
+		// Assert the model answered the prompt, not merely that some text
+		// rendered: a length check also passes on an error or a refusal shown in
+		// the response body. The match stays case-insensitive because
+		// capitalization and trailing punctuation are still the model's to choose.
+		const responseText = await app.workbench.positAssistant.getLastResponseText();
+		expect(responseText).toMatch(/hello/i);
+	});
+});


### PR DESCRIPTION
Adds Posit Assistant coverage on the two Workbench managed-credential shards that had none: Databricks and Snowflake Cortex.

### Summary

Microsoft Foundry already has a managed-credential assistant test on the Azure shard (`posit-assistant-foundry.test.ts`). Databricks and Snowflake Cortex authenticate the same way -- silently, from a credential Posit Workbench provisions -- and nothing exercised that. This adds one hello-world test for each.

Each provider needs its own file because the credential is provisioned per container: the workbench-databricks and workbench-snowflake tags select the shard whose stack carries the matching credential.

Neither test drives a sign-in, and neither needs a settings override. Both providers' credential chains resolve at extension activation off `DATABRICKS_CONFIG_FILE` / `SNOWFLAKE_HOME` pointing at a `posit-workbench` path (`registerDatabricksProvider` / `registerSnowflakeProvider` -> `resolveChainCredentials`), so a session already exists by the time the chat opens. That is the path a Workbench user gets, and the desktop OAuth/PAT sign-in tests cannot reach it -- the provider catalog, the credential store, and the egress to the model all live in the container's server-side extension host.

Both tests use `selectProviderModel()` rather than a pinned model name. Other base-fixture providers stay enabled-but-unauthenticated on these shards and model display names repeat across providers, so scoping to the provider's group header is what guarantees the intended provider is the one exercised; it also survives churn in Databricks serving endpoints and the Cortex model list. The one page-object change adds the Snowflake Cortex display name to that map, sourced from the assistant's provider registry.

### Local verification

Run against real stacks (`npm run pwb -- --credentials=<type>`):

| Test | Runs | Result |
| --- | --- | --- |
| `posit-assistant-databricks.test.ts` | 2 | passed (7.6s, 6.1s) |
| `posit-assistant-snowflake.test.ts` | 2 | passed (11.2s, 6.5s) |

Snowflake's managed-credential path is confirmed by the extension host log from the passing run, not just a green tick:

```
[Snowflake Auth] Using Posit Workbench managed credentials for account: duloftf-posit-software-pbc-dev
[Snowflake Cortex] Credential resolution resolved
[Snowflake Cortex] Registered auth provider
```

### Note for anyone verifying locally

Switching credential types on an existing local stack needs a full `npm run pwb -- down`, not `--reinstall`. The dashboard fixture only calls `setupManagedCredentialsIfNeeded` from `createNewProject`, so if the `test-files` project survives the reinstall the credential OAuth is silently skipped and the session comes up with no credential at all (plus a stale provider host left in `~/.posit/ai/providers.json`). CI is unaffected -- every shard gets a fresh container -- so this PR leaves the fixture alone.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

@:workbench @:assistant

The workbench lane fans out to all four shards on ubuntu (default, snowflake, databricks, azure), each with its own hardcoded grep in `test-e2e-workbench-linux.yml` -- so the bare workbench tag above is what actually runs these two new tests. The per-shard tags are `PlatformTags` and are never auto-derived, and `pr-tags-parse.sh` matches only the bare workbench form (explicitly excluding the longer variants), so writing a per-shard tag in a PR body triggers nothing on its own.

The assistant tag is included because this also touches `test/e2e/pages/positAssistant.ts`, which the desktop assistant suite shares.
