### PR TITLE
Exit notebook cell edit mode with Escape in vim normal mode

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -585,14 +585,8 @@ export class ExitEditModeAction extends NotebookAction2 {
 					weight: KeybindingWeight.EditorContrib,
 					primary: KeyCode.Escape
 				},
-				// Vim emulation extensions bind Escape at extension weight, which
-				// outranks any core weight, so the rule above never fires while a
-				// vim extension owns the editor and users get stuck in edit mode.
-				// These rules reclaim Escape only in vim Normal mode (Insert/Visual
-				// still escape to Normal first, matching Jupyter vim conventions)
-				// by outweighing the extensions' bindings. They reference the
-				// extensions' own context keys, which are undefined (never equal)
-				// when the extension isn't installed, so the rules are inert then.
+				// Vim extensions bind Escape at extension weight, outranking the rule
+				// above. These higher-weight rules reclaim Escape in vim Normal mode.
 				{
 					// VSCodeVim (vscodevim.vim)
 					when: ContextKeyExpr.and(

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -565,22 +565,55 @@ registerAction2(EnterEditModeAction);
  */
 export class ExitEditModeAction extends NotebookAction2 {
 	constructor() {
+		const escapeGuards = [
+			// Don't exit when multiple selections are active (escape should cancel multi selection first #10385)
+			EditorContextKeys.hasMultipleSelections.toNegated(),
+			// Don't exit when text is selected (escape should deselect first)
+			EditorContextKeys.hasNonEmptySelection.toNegated(),
+			// Don't exit when a hover tooltip is shown (escape should dismiss hover first)
+			EditorContextKeys.hoverVisible.toNegated()
+		];
 		super({
 			id: 'positronNotebook.cell.quitEdit',
 			title: localize2('positronNotebook.cell.quitEdit', "Exit Cell Edit Mode"),
-			keybinding: {
-				when: ContextKeyExpr.and(
-					NotebookContextKeys.cellEditorFocused,
-					// Don't exit when multiple selections are active (escape should cancel multi selection first #10385)
-					EditorContextKeys.hasMultipleSelections.toNegated(),
-					// Don't exit when text is selected (escape should deselect first)
-					EditorContextKeys.hasNonEmptySelection.toNegated(),
-					// Don't exit when a hover tooltip is shown (escape should dismiss hover first)
-					EditorContextKeys.hoverVisible.toNegated()
-				),
-				weight: KeybindingWeight.EditorContrib,
-				primary: KeyCode.Escape
-			}
+			keybinding: [
+				{
+					when: ContextKeyExpr.and(
+						NotebookContextKeys.cellEditorFocused,
+						...escapeGuards
+					),
+					weight: KeybindingWeight.EditorContrib,
+					primary: KeyCode.Escape
+				},
+				// Vim emulation extensions bind Escape at extension weight, which
+				// outranks any core weight, so the rule above never fires while a
+				// vim extension owns the editor and users get stuck in edit mode.
+				// These rules reclaim Escape only in vim Normal mode (Insert/Visual
+				// still escape to Normal first, matching Jupyter vim conventions)
+				// by outweighing the extensions' bindings. They reference the
+				// extensions' own context keys, which are undefined (never equal)
+				// when the extension isn't installed, so the rules are inert then.
+				{
+					// VSCodeVim (vscodevim.vim)
+					when: ContextKeyExpr.and(
+						NotebookContextKeys.cellEditorFocused,
+						ContextKeyExpr.equals('vim.mode', 'Normal'),
+						...escapeGuards
+					),
+					weight: KeybindingWeight.ExternalExtension + 1,
+					primary: KeyCode.Escape
+				},
+				{
+					// vscode-neovim (asvetliakov.vscode-neovim)
+					when: ContextKeyExpr.and(
+						NotebookContextKeys.cellEditorFocused,
+						ContextKeyExpr.equals('neovim.mode', 'normal'),
+						...escapeGuards
+					),
+					weight: KeybindingWeight.ExternalExtension + 1,
+					primary: KeyCode.Escape
+				}
+			]
 		});
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/jupyterLabShortcuts.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/jupyterLabShortcuts.vitest.ts
@@ -261,7 +261,7 @@ describe('Positron Notebook keyboard shortcuts', () => {
 				// `when` is a composite ContextKeyExpr.and(...), so check it includes the cell-editor key.
 				expect(keybinding.when?.keys()).toContain(NotebookContextKeys.cellEditorFocused.key);
 			}
-			// The vim overrides are gated on the vim extensions' mode context keys.
+			// The vim overrides only apply when the vim extensions' mode context keys match.
 			const allKeys = keybindings.flatMap(kb => kb.when?.keys() ?? []);
 			expect(allKeys).toContain('vim.mode');
 			expect(allKeys).toContain('neovim.mode');

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/jupyterLabShortcuts.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/jupyterLabShortcuts.vitest.ts
@@ -251,9 +251,20 @@ describe('Positron Notebook keyboard shortcuts', () => {
 	describe('Escape (Exit Edit Mode)', () => {
 		it('declares Escape scoped to cell editor focused', () => {
 			const action = new ExitEditModeAction();
-			expect(action.desc.keybinding?.primary).toBe(KeyCode.Escape);
-			// `when` is a composite ContextKeyExpr.and(...), so check it includes the cell-editor key.
-			expect(action.desc.keybinding?.when?.keys()).toContain(NotebookContextKeys.cellEditorFocused.key);
+			// The action declares multiple Escape rules: the base rule plus
+			// vim-extension overrides (VSCodeVim and vscode-neovim).
+			const keybindings = action.desc.keybinding;
+			expect(Array.isArray(keybindings)).toBe(true);
+			if (!Array.isArray(keybindings)) { return; }
+			for (const keybinding of keybindings) {
+				expect(keybinding.primary).toBe(KeyCode.Escape);
+				// `when` is a composite ContextKeyExpr.and(...), so check it includes the cell-editor key.
+				expect(keybinding.when?.keys()).toContain(NotebookContextKeys.cellEditorFocused.key);
+			}
+			// The vim overrides are gated on the vim extensions' mode context keys.
+			const allKeys = keybindings.flatMap(kb => kb.when?.keys() ?? []);
+			expect(allKeys).toContain('vim.mode');
+			expect(allKeys).toContain('neovim.mode');
 		});
 
 		it('calls exitEditor when in editing state for code cell', () => {


### PR DESCRIPTION
Closes #15739

With a vim emulation extension installed, Escape never exits notebook cell edit mode: the extensions bind Escape at extension keybinding weight, which outranks the quitEdit rule's `EditorContrib` weight.

This PR adds two extra Escape rules on `positronNotebook.cell.quitEdit` at `KeybindingWeight.ExternalExtension + 1` that apply only in vim Normal mode (VSCodeVim's `vim.mode == 'Normal'`, vscode-neovim's `neovim.mode == 'normal'`).

Escape then moves one level outward per press - Insert -> Normal -> notebook command mode - matching Jupyter vim-bindings conventions. Without a vim extension, the mode context keys are undefined and the new rules never match.

There is upstream precedent for out-weighing extension keybindings this way (chat and terminal contribs use `ExternalExtension + 1/+2`).

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Escape now exits notebook cell edit mode when using vim emulation extensions (VSCodeVim, vscode-neovim) (#15739)

### Validation Steps

@:positron-notebooks

Unit coverage: `jupyterLabShortcuts.vitest.ts` asserts the Escape rules and their vim mode context keys. The vim-extension interaction itself needs manual QA (extensions aren't installed in CI):

1. Install the VSCodeVim extension, open a Positron notebook, press Enter on a cell, and type some text (Insert mode).
2. Press Escape: drops to vim Normal mode, still in the cell.
3. Press Escape again: exits to notebook command mode (previously did nothing).
4. Guards: a visual selection (`v` + motion) is cleared by Escape without leaving the cell; an open hover is dismissed first.
5. Repeat with vscode-neovim (disable VSCodeVim first).
6. Without any vim extension, a single Escape exits the cell as before.