### PR TITLE
e2e: cover Posit Assistant on Snowflake Cortex with an API key

### DIFF
--- a/.env.e2e.example
+++ b/.env.e2e.example
@@ -44,4 +44,8 @@ DATABRICKS_PAT=
 # federates to Okta, so the sign-in itself uses the IDE service account variables above -- this
 # is the only Snowflake-specific value the suite needs (SNOWFLAKE_USER / SNOWFLAKE_USERNAME are
 # used by other suites, not this one). Already provided on both Ubuntu CI lanes.
+# SNOWFLAKE_ACCOUNT is also the "Account Identifier" the posit-assistant Snowflake Cortex
+# test types alongside SNOWFLAKE_API_KEY, a programmatic access token on that same account.
+# op://Positron/Snowflake-API-key/credential
 SNOWFLAKE_ACCOUNT=
+SNOWFLAKE_API_KEY=

--- a/.github/workflows/test-e2e-macos-run.yml
+++ b/.github/workflows/test-e2e-macos-run.yml
@@ -72,6 +72,10 @@ jobs:
       AWS_S3_BUCKET: positron-test-reports
       DATABRICKS_WORKSPACE: ${{ secrets.DATABRICKS_WORKSPACE }}
       DATABRICKS_PAT: ${{ secrets.DATABRICKS_PAT }}
+      # Account identifier for the posit-assistant Snowflake Cortex test, which types it
+      # into the modal alongside SNOWFLAKE_API_KEY (loaded from 1Password below). The
+      # Linux lanes set this from the same secret for the data-connections suite.
+      SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
       LANG: "en_US.UTF-8"
     steps:
       - uses: actions/checkout@v7
@@ -111,6 +115,9 @@ jobs:
           REDSHIFT_TEST_PASSWORD: "op://Positron/Redshift_Test_Environment/password"
           TS_OAUTH_CLIENT_ID: "op://Positron/Tailscale_OAuth/client_id"
           TS_OAUTH_SECRET: "op://Positron/Tailscale_OAuth/client_secret"
+          # Snowflake programmatic access token for the posit-assistant Snowflake Cortex
+          # test. Pairs with the SNOWFLAKE_ACCOUNT env var set on the job above.
+          SNOWFLAKE_API_KEY: "op://Positron/Snowflake-API-key/credential"
 
       # Bring up Tailscale so tests can reach private test infrastructure (e.g. the serverless
       # Redshift workgroup used by the data-connections e2e tests). OAuth creds are loaded from

--- a/.github/workflows/test-e2e-ubuntu-run.yml
+++ b/.github/workflows/test-e2e-ubuntu-run.yml
@@ -183,6 +183,10 @@ jobs:
           IDE_SERVICE_ACCOUNT_EMAIL: "op://Positron/RStudioIDE_Service_Account/service-account-email"
           IDE_SERVICE_ACCOUNT_PASSWORD: "op://Positron/RStudioIDE_Service_Account/service-account-password"
           IDE_SERVICE_ACCOUNT_OTP_SECRET: "op://Positron/RStudioIDE_Service_Account/service-account-otp-secret"
+          # Snowflake programmatic access token for the posit-assistant Snowflake Cortex
+          # test. Pairs with the SNOWFLAKE_ACCOUNT secret already exported above, which
+          # doubles as the account identifier that test types into the modal.
+          SNOWFLAKE_API_KEY: "op://Positron/Snowflake-API-key/credential"
           TS_OAUTH_CLIENT_ID: "op://Positron/Tailscale_OAuth/client_id"
           TS_OAUTH_SECRET: "op://Positron/Tailscale_OAuth/client_secret"
 

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -164,6 +164,10 @@ jobs:
           IDE_SERVICE_ACCOUNT_EMAIL: "op://Positron/RStudioIDE_Service_Account/service-account-email"
           IDE_SERVICE_ACCOUNT_PASSWORD: "op://Positron/RStudioIDE_Service_Account/service-account-password"
           IDE_SERVICE_ACCOUNT_OTP_SECRET: "op://Positron/RStudioIDE_Service_Account/service-account-otp-secret"
+          # Snowflake programmatic access token for the posit-assistant Snowflake Cortex
+          # test. Pairs with the SNOWFLAKE_ACCOUNT secret already exported above, which
+          # doubles as the account identifier that test types into the modal.
+          SNOWFLAKE_API_KEY: "op://Positron/Snowflake-API-key/credential"
 
       - name: Transform to Playwright tags $PW_TAGS
         run: bash scripts/pr-tags-transform.sh ${{ inputs.project}} "${{ inputs.grep }}"

--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -105,6 +105,10 @@ jobs:
       AWS_S3_BUCKET: positron-test-reports
       DATABRICKS_WORKSPACE: ${{ secrets.DATABRICKS_WORKSPACE }}
       DATABRICKS_PAT: ${{ secrets.DATABRICKS_PAT }}
+      # Account identifier for the posit-assistant Snowflake Cortex test, which types it
+      # into the modal alongside SNOWFLAKE_API_KEY (loaded from 1Password below). The
+      # Linux lanes set this from the same secret for the data-connections suite.
+      SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
       # Consumed by the Postgres e2e tests (connections-postgres / data-connections postgres).
       # The Linux Ubuntu job sets these from the same secrets; mirror them here so the
       # connection inputs match the user/password baked into the postgres container.
@@ -141,6 +145,9 @@ jobs:
           REDSHIFT_TEST_PASSWORD: "op://Positron/Redshift_Test_Environment/password"
           TS_OAUTH_CLIENT_ID: "op://Positron/Tailscale_OAuth/client_id"
           TS_OAUTH_SECRET: "op://Positron/Tailscale_OAuth/client_secret"
+          # Snowflake programmatic access token for the posit-assistant Snowflake Cortex
+          # test. Pairs with the SNOWFLAKE_ACCOUNT env var set on the job above.
+          SNOWFLAKE_API_KEY: "op://Positron/Snowflake-API-key/credential"
 
       # Bring up Tailscale so tests can reach private test infrastructure (e.g. the serverless
       # Redshift workgroup used by the data-connections e2e tests). OAuth creds are loaded from

--- a/test/e2e/pages/modelProviderShared.ts
+++ b/test/e2e/pages/modelProviderShared.ts
@@ -60,7 +60,8 @@ export type ModelProvider =
 	| 'error'
 	| 'ms-foundry'
 	| 'openai-api'
-	| 'posit-ai';
+	| 'posit-ai'
+	| 'snowflake-cortex';
 
 /**
  * Authentication types for model providers.
@@ -118,6 +119,7 @@ export function getProviderAuthType(provider: ModelProvider): ProviderAuthType {
 		case 'anthropic-api':
 		case 'openai-api':
 		case 'ms-foundry':
+		case 'snowflake-cortex':
 			return 'apiKey';
 		case 'amazon-bedrock':
 			return 'aws';
@@ -138,11 +140,14 @@ export function getProviderAuthType(provider: ModelProvider): ProviderAuthType {
  * field in the Configure Providers modal in addition to the API key field.
  *
  * Databricks labels the same field "Workspace URL" and needs it under both auth
- * methods -- OAuth discovers the workspace's OIDC endpoints from it.
+ * methods -- OAuth discovers the workspace's OIDC endpoints from it. Snowflake
+ * labels it "Account Identifier" and stores the bare account rather than a URL,
+ * deriving the Cortex endpoint from it (see getBaseUrlLabel in
+ * src/vs/workbench/contrib/positronAssistant/browser/providerFieldLabels.ts).
  */
 export function providerRequiresBaseUrl(provider: ModelProvider): boolean {
 	const id = provider.toLowerCase();
-	return id === 'ms-foundry' || id === 'databricks';
+	return id === 'ms-foundry' || id === 'databricks' || id === 'snowflake-cortex';
 }
 
 export function getProviderBaseUrlEnvVarName(provider: ModelProvider): string {
@@ -150,6 +155,12 @@ export function getProviderBaseUrlEnvVarName(provider: ModelProvider): string {
 	// against, rather than introducing a DATABRICKS_BASE_URL alias for it.
 	if (provider.toLowerCase() === 'databricks') {
 		return 'DATABRICKS_WORKSPACE';
+	}
+	// Snowflake's "base URL" is the bare account identifier, so it reuses the
+	// SNOWFLAKE_ACCOUNT the data-connections suite already runs against rather
+	// than a SNOWFLAKE_CORTEX_BASE_URL alias for it.
+	if (provider.toLowerCase() === 'snowflake-cortex') {
+		return 'SNOWFLAKE_ACCOUNT';
 	}
 	return `${provider.toUpperCase().replace(/-/g, '_')}_BASE_URL`;
 }
@@ -180,6 +191,10 @@ export function getProviderEnvVarName(provider: ModelProvider): string {
 		case 'databricks':
 			// Databricks calls its API key a personal access token.
 			return 'DATABRICKS_PAT';
+		case 'snowflake-cortex':
+			// The default derivation would ask for SNOWFLAKE_CORTEX_KEY; the account's
+			// programmatic access token is stored under the platform's own name.
+			return 'SNOWFLAKE_API_KEY';
 		default:
 			return `${provider.toUpperCase().replace(/-/g, '_')}_KEY`;
 	}

--- a/test/e2e/tests/posit-assistant/posit-assistant-snowflake.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant-snowflake.test.ts
@@ -31,8 +31,12 @@ test.use({
 // assertion would pass on the error text that a rejected token renders.
 const HELLO_PROMPT = 'Reply with only the word hello.';
 
+// WIN covers the Windows lane and, because the e2e-macOS-ci project greps /@:win/, the
+// macOS one too. Unlike Databricks -- which rides on the DATABRICKS_* vars those lanes
+// already export for the catalog-explorer suite -- Snowflake had no credentials there, so
+// SNOWFLAKE_ACCOUNT and SNOWFLAKE_API_KEY were added to both workflows for this test.
 test.describe('Posit Assistant - Snowflake Cortex API Key', {
-	tag: [tags.ASSISTANT, tags.WEB],
+	tag: [tags.ASSISTANT, tags.WEB, tags.WIN],
 }, () => {
 	test('Sign in with an API key, send hello, sign out', async function ({ app }) {
 		test.skip(!process.env.SNOWFLAKE_API_KEY || !process.env.SNOWFLAKE_ACCOUNT,
@@ -40,7 +44,8 @@ test.describe('Posit Assistant - Snowflake Cortex API Key', {
 
 		// SNOWFLAKE_API_KEY / SNOWFLAKE_ACCOUNT, resolved by the page object from the
 		// provider's env var names. SNOWFLAKE_ACCOUNT is already present on the Linux
-		// lanes for the data-connections Snowflake suite.
+		// lanes for the data-connections Snowflake suite; both are exported on the
+		// Windows and macOS lanes for this test.
 		await app.workbench.modelProviderModal.loginModelProvider(provider);
 
 		try {

--- a/test/e2e/tests/posit-assistant/posit-assistant-snowflake.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant-snowflake.test.ts
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test, tags } from '../_test.setup';
+
+const provider = 'snowflake-cortex';
+
+test.use({
+	suiteId: __filename,
+});
+
+// Snowflake Cortex advertises a single sign-in method everywhere -- an API key (a
+// Snowflake programmatic access token) plus the bare account identifier, from which the
+// extension derives the Cortex URL (#13750). So there is no auth-method radio group to
+// pick from and no build-specific split: the same case runs on desktop and web.
+//
+// The Workbench-managed credential path is a different provider source (SNOWFLAKE_HOME
+// pointing at a posit-workbench connections.toml) and is covered separately in
+// tests/workbench/posit-assistant/posit-assistant-snowflake.test.ts. It cannot leak into
+// this test: hasManagedCredentials() in the authentication extension is gated on
+// IS_RUNNING_ON_PWB, so no env scrubbing is needed here (unlike the Databricks suite,
+// which has to unset DATABRICKS_TOKEN).
+
+// Pins the reply to a single known word so the response assertion can check for it,
+// matching the Workbench Snowflake test. This matters more here than for the other
+// desktop providers: Snowflake has no lightweight key-validation endpoint, so
+// validateSnowflakeApiKey only checks the account's *format* and Connect succeeds even
+// with a bad token. The first real credential check is this message, and a length-only
+// assertion would pass on the error text that a rejected token renders.
+const HELLO_PROMPT = 'Reply with only the word hello.';
+
+test.describe('Posit Assistant - Snowflake Cortex API Key', {
+	tag: [tags.ASSISTANT, tags.WEB],
+}, () => {
+	test('Sign in with an API key, send hello, sign out', async function ({ app }) {
+		test.skip(!process.env.SNOWFLAKE_API_KEY || !process.env.SNOWFLAKE_ACCOUNT,
+			'Snowflake Cortex sign-in requires SNOWFLAKE_ACCOUNT and SNOWFLAKE_API_KEY');
+
+		// SNOWFLAKE_API_KEY / SNOWFLAKE_ACCOUNT, resolved by the page object from the
+		// provider's env var names. SNOWFLAKE_ACCOUNT is already present on the Linux
+		// lanes for the data-connections Snowflake suite.
+		await app.workbench.modelProviderModal.loginModelProvider(provider);
+
+		try {
+			await app.workbench.positAssistant.open();
+			await app.workbench.positAssistant.waitForReady();
+			await app.workbench.positAssistant.startNewConversation();
+
+			// Select the Snowflake Cortex model explicitly: other providers can be signed
+			// in at the same time (AWS Bedrock auto-signs-in from the environment) and
+			// model names repeat across providers, so an auto-selected default may belong
+			// to another one. `newConversation: false` keeps the selection.
+			await app.workbench.positAssistant.selectProviderModel(provider);
+			await app.workbench.positAssistant.sendMessage(HELLO_PROMPT, true, { newConversation: false });
+			await app.workbench.positAssistant.expectResponseVisible();
+
+			const responseText = await app.workbench.positAssistant.getLastResponseText();
+			test.expect(responseText).toMatch(/hello/i);
+		} finally {
+			await app.workbench.modelProviderModal.logoutModelProvider(provider);
+		}
+	});
+});


### PR DESCRIPTION
### Summary

Snowflake Cortex had no desktop sign-in coverage in the assistant suite. The only Snowflake assistant test drives the Workbench-managed credential path, which is a different provider source (`SNOWFLAKE_HOME` pointing at a `posit-workbench` `connections.toml`) and runs on its own Workbench shard.

This adds the API-key case, modelled on the Databricks API-key test: connect through the Configure LLM Providers modal, send a prompt, assert the reply, sign out in a `finally`.

Wiring in `modelProviderShared.ts`:

- `snowflake-cortex` joins the `ModelProvider` union as an `apiKey` provider that also needs the base-URL field.
- That field is the **bare account identifier**, not a URL (the extension derives the Cortex endpoint from it), so it reuses the existing `SNOWFLAKE_ACCOUNT` rather than adding a `SNOWFLAKE_CORTEX_BASE_URL` alias.
- The token maps to `SNOWFLAKE_API_KEY`, which the default derivation would otherwise have asked for as `SNOWFLAKE_CORTEX_KEY`.

CI credentials: `SNOWFLAKE_ACCOUNT` was already exported on the Linux lanes for the data-connections Snowflake suite. This adds `SNOWFLAKE_API_KEY` from 1Password on both Ubuntu lanes, and both variables on the Windows and macOS lanes. Databricks' API-key case gets those lanes for free off the `DATABRICKS_*` vars the catalog-explorer suite already exports; Snowflake had nothing there, so without this the platform tag would only have bought a skip.

Two deliberate choices worth review:

- **The assertion matches a pinned reply, not a length.** Snowflake has no lightweight key-validation endpoint, so `validateSnowflakeApiKey` only checks the account's *format* and Connect succeeds even with a bad token. The first real credential check is the message itself, and a length-only assertion would pass on the error text a rejected token renders.
- **No environment scrubbing.** The Databricks suite has to unset `DATABRICKS_TOKEN`, but `hasManagedCredentials()` is gated on `IS_RUNNING_ON_PWB`, so the managed-credential path cannot pre-connect the row on desktop or web.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:assistant @:web @:win

Test-only change; no product code touched. Passes locally against the real Snowflake account:

```
1 passed (37.8s)
```

Note for anyone running it locally: `test/e2e/tests/posit-assistant/` needs the `posit.assistant` bootstrap extension in `.build/bootstrapExtensions/`, which only `npm run prelaunch` fetches. Without it the test fails as a 30s timeout waiting on the activity-bar button, well after sign-in has already succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
