### PR TITLE
ci: disable pak sysreqs in the SUSE test images

### DIFF
--- a/docker/images/SLES15_6/Dockerfile.SLES15_6
+++ b/docker/images/SLES15_6/Dockerfile.SLES15_6
@@ -231,6 +231,17 @@ ENV PATH="/root/.venv/bin:/root/.local/bin:$PATH"
 # Configure R for root user - using openSUSE repository
 RUN echo -e 'options(\n  repos = c(RSPM = "https://packagemanager.posit.co/cran/__linux__/opensuse156/latest"),\n  HTTPUserAgent = sprintf("R/%s (opensuse-leap-156)", getRversion())\n)' > ~/.Rprofile
 
+# Disable pak's system-requirements step. When PPM has no binary for a package
+# on this distro, pak builds it from source and first shells out to
+# `zypper --non-interactive install ...`. zypper cannot rebuild its repo caches
+# in this container (repo2solv: "rpmmd repo type is not supported"), so that
+# command exits non-zero and pak aborts the install -- even though every
+# requirement is already baked into the image. This is the same cache breakage
+# that makes R itself install via rpm above. The build-time installs below
+# already pass pkg.sysreqs=FALSE; PKG_SYSREQS carries it into the R sessions
+# the e2e tests drive.
+ENV PKG_SYSREQS=false
+
 # Stable CRAN mirror for openSUSE
 ENV RSPM=https://packagemanager.posit.co/cran/__linux__/opensuse156/latest
 

--- a/docker/images/openSUSE15_6/Dockerfile.openSUSE15_6
+++ b/docker/images/openSUSE15_6/Dockerfile.openSUSE15_6
@@ -205,6 +205,17 @@ ENV PATH="/root/.venv/bin:/root/.local/bin:$PATH"
 # Configure R for root user - using openSUSE repository
 RUN echo -e 'options(\n  repos = c(RSPM = "https://packagemanager.posit.co/cran/__linux__/opensuse156/latest"),\n  HTTPUserAgent = sprintf("R/%s (opensuse-leap-156)", getRversion())\n)' > ~/.Rprofile
 
+# Disable pak's system-requirements step. When PPM has no binary for a package
+# on this distro, pak builds it from source and first shells out to
+# `zypper --non-interactive install ...`. zypper cannot rebuild its repo caches
+# in this container (repo2solv: "rpmmd repo type is not supported"), so that
+# command exits non-zero and pak aborts the install -- even though every
+# requirement is already baked into the image. This is the same cache breakage
+# that makes R itself install via rpm above. The build-time installs below
+# already pass pkg.sysreqs=FALSE; PKG_SYSREQS carries it into the R sessions
+# the e2e tests drive.
+ENV PKG_SYSREQS=false
+
 # Stable CRAN mirror for openSUSE
 ENV RSPM=https://packagemanager.posit.co/cran/__linux__/opensuse156/latest
 


### PR DESCRIPTION
### Problem

`Packages Pane - Security Advisories > R - Flags an installed package with an unscored CRAN advisory` fails on the openSUSE and SLES web lanes, and only those two -- deterministically, on both attempts, in the [2026-08-26 daily build](https://github.com/posit-dev/positron-builds/actions/runs/32967112628).

It reads as a wait that is too short (`expect(row).toBeVisible()` times out after 60s), but the install never happens. From the R console in the failure snapshot:

```
+ widgetframe 0.3.1 [bld][dl]          <- source build; PPM has no opensuse156 binary
i Installing system requirements
i Executing `sh -c zypper --non-interactive install cmake make libuv-devel pandoc`
  ... repo2solv ... rpmmd repo type is not supported
  Warning: Skipping repository 'Main Repository' because of the above error   (x7 repos)
  'pandoc' is already installed. ... 'cmake' is already installed. ...
Error: ! error in pak subprocess
Caused by error in `processx::run(sh, ...)`: ! System command 'sh' failed
```

zypper cannot rebuild its repo caches in these containers, so it exits non-zero and pak aborts -- even though all four requirements are already baked into the image. This is the same breakage the images already work around by installing R itself with `rpm`.

The other distros never notice: on rhel9/noble/debian13 PPM serves a `widgetframe` binary, so pak skips the sysreqs step entirely. `cowsay` passes on SUSE in the same worker for the same reason (no system requirements).

### Fix

Both SUSE images already pass `pkg.sysreqs=FALSE` to their build-time `Rscript` invocations, but their runtime `~/.Rprofile` sets only `repos` and `HTTPUserAgent`, so any source install a *test* triggers walks into the broken zypper path. Set `PKG_SYSREQS=false` as an image env var, which covers every R session in the container (including workspaces whose own `.Rprofile` shadows the user one).

### Verification

The `24.18.0` tags for `positron-opensuse156` and `positron-sles156` are being rebuilt from this branch, so the next daily build exercises the fix on the real lanes.