### PR TITLE
ci: load SNOWFLAKE_API_KEY on the remaining Linux e2e lanes

### DIFF
--- a/.github/workflows/test-e2e-debian.yml
+++ b/.github/workflows/test-e2e-debian.yml
@@ -152,6 +152,9 @@ jobs:
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"
+          # Snowflake programmatic access token for the posit-assistant Snowflake Cortex
+          # test. Pairs with the SNOWFLAKE_ACCOUNT env var set on the job above.
+          SNOWFLAKE_API_KEY: "op://Positron/Snowflake-API-key/credential"
 
       - name: Transform to Playwright tags $PW_TAGS
         run: bash scripts/pr-tags-transform.sh ${{ inputs.project}} "${{ inputs.grep }}"

--- a/.github/workflows/test-e2e-rocky.yml
+++ b/.github/workflows/test-e2e-rocky.yml
@@ -152,6 +152,9 @@ jobs:
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"
+          # Snowflake programmatic access token for the posit-assistant Snowflake Cortex
+          # test. Pairs with the SNOWFLAKE_ACCOUNT env var set on the job above.
+          SNOWFLAKE_API_KEY: "op://Positron/Snowflake-API-key/credential"
 
       - name: Transform to Playwright tags $PW_TAGS
         run: bash scripts/pr-tags-transform.sh ${{ inputs.project}} "${{ inputs.grep }}"

--- a/.github/workflows/test-e2e-sles.yml
+++ b/.github/workflows/test-e2e-sles.yml
@@ -152,6 +152,9 @@ jobs:
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"
+          # Snowflake programmatic access token for the posit-assistant Snowflake Cortex
+          # test. Pairs with the SNOWFLAKE_ACCOUNT env var set on the job above.
+          SNOWFLAKE_API_KEY: "op://Positron/Snowflake-API-key/credential"
 
       - name: Transform to Playwright tags $PW_TAGS
         run: bash scripts/pr-tags-transform.sh ${{ inputs.project}} "${{ inputs.grep }}"

--- a/.github/workflows/test-e2e-suse.yml
+++ b/.github/workflows/test-e2e-suse.yml
@@ -152,6 +152,9 @@ jobs:
           POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"
+          # Snowflake programmatic access token for the posit-assistant Snowflake Cortex
+          # test. Pairs with the SNOWFLAKE_ACCOUNT env var set on the job above.
+          SNOWFLAKE_API_KEY: "op://Positron/Snowflake-API-key/credential"
 
       - name: Transform to Playwright tags $PW_TAGS
         run: bash scripts/pr-tags-transform.sh ${{ inputs.project}} "${{ inputs.grep }}"


### PR DESCRIPTION
Follow-up to #15745, which added `SNOWFLAKE_API_KEY` to the two Ubuntu lanes plus Windows and macOS, but missed the four OS-compatibility lanes.

### Summary

Debian, Rocky, SLES and SUSE default to running the whole suite and are already credentialed for Anthropic, OpenAI, Foundry, Posit AI and Databricks. So the new Snowflake Cortex test was the lone provider test silently skipping on all four. `SNOWFLAKE_ACCOUNT` was already exported there for the data-connections Snowflake suite; only the token was missing.

Full audit of every lane carrying `ANTHROPIC_KEY` or `SNOWFLAKE_ACCOUNT`, so this doesn't need a third pass:

| Lane | Before | Action |
|---|---|---|
| ubuntu, ubuntu-run | key present | none (#15745) |
| windows-run, macos-run | key present | none (#15745) |
| **debian, rocky, sles, suse** | **account only** | **key added** |
| remote-ssh | no Snowflake vars | none needed -- `e2e-remote-ssh` filters to the remote-ssh tag at the Playwright project level |
| jupyter | no Snowflake vars | none needed -- `e2e-jupyter` filters to the jupyter tag the same way |
| workbench-linux | account only | none needed -- exercises the managed-credential path, which reads a `connections.toml` rather than an API key |
| ubuntu-build | account only | none needed -- build lane, no assistant credentials at all |

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:assistant

CI-config only; no test or product code changed. The four lanes are opt-in platform lanes, so the real confirmation is the Snowflake Cortex test reporting a result instead of a skip the next time one of them runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
