### PR TITLE
e2e: add marimo to Python test requirements

### DIFF
--- a/test/e2e/test-files/requirements.txt
+++ b/test/e2e/test-files/requirements.txt
@@ -32,6 +32,7 @@ pydot
 vetiver
 great-tables
 gradio
+marimo
 fastapi
 dash
 flask


### PR DESCRIPTION
## Summary

Adds `marimo` to `test/e2e/test-files/requirements.txt`.

Split out of #15723 (marimo app-launcher support) so the CI image rebuild it
depends on is not blocked on review of that PR.

## Why this is its own PR

The container-based e2e lanes never pip-install at test time -- they use the
`/root/.venv` baked into `ghcr.io/posit-dev/positron-ubuntu24:<tag>`. That venv
is built in `docker/images/*/Dockerfile*` by curling this file **from `main`**:

```dockerfile
RUN curl -O https://raw.githubusercontent.com/posit-dev/positron/main/test/e2e/test-files/requirements.txt && \
    uv pip install --python /root/.venv/bin/python --break-system-packages -r requirements.txt
```

Because the Dockerfile reads `main` rather than `COPY`ing from the build
context, a dependency added on a branch cannot reach any image -- not even one
built from that branch. So this line has to land on `main` first.

## Follow-up needed after merge

1. Dispatch **CI Images: Build OS test images** with a new tag (e.g. `24.19.0`).
   `ubuntu24_04` unblocks the PR e2e lane; the other OS images want it too,
   since the distro lanes default to `grep: "@:critical"` and the marimo test
   carries `@:critical`.
2. Bump `24.18.0` -> the new tag across the workflow files that pin it.

Until then `Python - Verify Basic Marimo App` fails with `No module named
marimo`.

## QA Notes

No test or product behavior changes in this PR. Verified locally that the
package this unblocks works as #15723 expects: `marimo run <file> --headless`
prints an arrow glyph followed by exactly two spaces, then `URL: http://localhost:2719` -- matching
that PR's terminal pattern. The served page exposes `heading "Hello
marimo"` in the accessibility tree, matching the test's locator.


### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- marimo is absent from the Ubuntu CI container venv, so `python -m marimo run` exits in 41ms with No module named marimo and no URL is ever served for the viewer</summary>

- **Test:** Python Applications > Python - Verify Basic Marimo App
- **Targeted failure:** expect(locator).toBeVisible() failed -- locator(.webview).contentFrame().locator(#active-frame).contentFrame().getByRole(heading, { name: Hello marimo }); element(s) not found; Timeout 60000ms exceeded while waiting on the predicate
- **Signal:** Framework detection succeeded (Detected web app framework: marimo (with app creation)) and python.execMarimoInTerminal dispatched the correct invocation /root/.venv/bin/python -m marimo run <file> --headless, which then exited after 41ms with a single stdout line `No module named marimo` and shell-integration exit code 1 (]633;D;1), zero ESC bytes so no banner at all. App Launcher logged `Attempting to match URL with: ["  URL: {{APP_URL}}"]` against that string, waited 20s, then `Cannot preview URL`. No webview was ever created (DOM presence: webview NEVER present in any snapshot). Identical across 3 attempts.
- **Frequency:** see dashboard
- **Hypothesis:** infra

</details>
