### PR TITLE
Recover an expired AWS SSO session from the provider modal

### DIFF
--- a/extensions/authentication/src/authProvider.ts
+++ b/extensions/authentication/src/authProvider.ts
@@ -211,6 +211,8 @@ export class AuthProvider
 	): Promise<vscode.AuthenticationSession> {
 		if (this.credentialChain) {
 			let session: vscode.AuthenticationSession | undefined;
+			// Stays undefined when the chain produced nothing without failing,
+			// which is why the chaining below is conditional.
 			let cause: unknown;
 			try {
 				session = await this.resolveChainCredentialsOrThrow();
@@ -221,8 +223,6 @@ export class AuthProvider
 				// Keep the actionable message the user sees, but chain the real
 				// failure beneath it so a caller that can recover from a specific
 				// cause -- an expired AWS SSO session, say -- can still find it.
-				// `cause` stays undefined when the chain simply produced nothing.
-				// `lib: es2020` has no `new Error(msg, { cause })`.
 				const error = new Error(
 					vscode.l10n.t(
 						'No credentials found for {0}. Configure credentials ' +
@@ -230,7 +230,18 @@ export class AuthProvider
 						this.displayName
 					)
 				);
-				(error as { cause?: unknown }).cause = cause;
+				if (cause !== undefined) {
+					// `lib: es2020` has no `new Error(msg, { cause })`, so define
+					// the property by hand. Not a plain assignment: the native
+					// `cause` is non-enumerable, and matching that keeps the chain
+					// failure out of anything that walks own enumerable keys --
+					// `JSON.stringify`, a spread, `assert.deepStrictEqual`. It
+					// would otherwise be the only visible key on the error, since
+					// `message` and `stack` are non-enumerable themselves.
+					Object.defineProperty(error, 'cause', {
+						value: cause, writable: true, configurable: true,
+					});
+				}
 				throw error;
 			}
 			return session;
@@ -383,6 +394,11 @@ export class AuthProvider
 	 * Resolve credentials from the chain, update cache, and start the
 	 * background refresh timer. Fires `added`, `changed`, or `removed`
 	 * depending on how the resolved token compares to the cached one.
+	 *
+	 * Never rejects: a chain failure is logged where it happens and reported
+	 * here as an absent session, so callers need no rejection handler. Use
+	 * `resolveChainCredentialsOrThrow` when the reason a credential did not
+	 * resolve is something the caller can act on.
 	 */
 	async resolveChainCredentials(
 	): Promise<vscode.AuthenticationSession | undefined> {

--- a/extensions/authentication/src/authProvider.ts
+++ b/extensions/authentication/src/authProvider.ts
@@ -210,27 +210,28 @@ export class AuthProvider
 		_options?: vscode.AuthenticationProviderSessionOptions
 	): Promise<vscode.AuthenticationSession> {
 		if (this.credentialChain) {
-			const noCredentials = () => new Error(
-				vscode.l10n.t(
-					'No credentials found for {0}. Configure credentials ' +
-					'using the provider CLI or environment variables.',
-					this.displayName
-				)
-			);
 			let session: vscode.AuthenticationSession | undefined;
+			let cause: unknown;
 			try {
 				session = await this.resolveChainCredentialsOrThrow();
 			} catch (err) {
+				cause = err;
+			}
+			if (!session) {
 				// Keep the actionable message the user sees, but chain the real
 				// failure beneath it so a caller that can recover from a specific
 				// cause -- an expired AWS SSO session, say -- can still find it.
+				// `cause` stays undefined when the chain simply produced nothing.
 				// `lib: es2020` has no `new Error(msg, { cause })`.
-				const error = noCredentials();
-				(error as { cause?: unknown }).cause = err;
+				const error = new Error(
+					vscode.l10n.t(
+						'No credentials found for {0}. Configure credentials ' +
+						'using the provider CLI or environment variables.',
+						this.displayName
+					)
+				);
+				(error as { cause?: unknown }).cause = cause;
 				throw error;
-			}
-			if (!session) {
-				throw noCredentials();
 			}
 			return session;
 		}

--- a/extensions/authentication/src/authProvider.ts
+++ b/extensions/authentication/src/authProvider.ts
@@ -210,15 +210,27 @@ export class AuthProvider
 		_options?: vscode.AuthenticationProviderSessionOptions
 	): Promise<vscode.AuthenticationSession> {
 		if (this.credentialChain) {
-			const session = await this.resolveChainCredentials();
+			const noCredentials = () => new Error(
+				vscode.l10n.t(
+					'No credentials found for {0}. Configure credentials ' +
+					'using the provider CLI or environment variables.',
+					this.displayName
+				)
+			);
+			let session: vscode.AuthenticationSession | undefined;
+			try {
+				session = await this.resolveChainCredentialsOrThrow();
+			} catch (err) {
+				// Keep the actionable message the user sees, but chain the real
+				// failure beneath it so a caller that can recover from a specific
+				// cause -- an expired AWS SSO session, say -- can still find it.
+				// `lib: es2020` has no `new Error(msg, { cause })`.
+				const error = noCredentials();
+				(error as { cause?: unknown }).cause = err;
+				throw error;
+			}
 			if (!session) {
-				throw new Error(
-					vscode.l10n.t(
-						'No credentials found for {0}. Configure credentials ' +
-						'using the provider CLI or environment variables.',
-						this.displayName
-					)
-				);
+				throw noCredentials();
 			}
 			return session;
 		}
@@ -373,15 +385,30 @@ export class AuthProvider
 	 */
 	async resolveChainCredentials(
 	): Promise<vscode.AuthenticationSession | undefined> {
+		return this.resolveChainCredentialsOrThrow().catch(() => undefined);
+	}
+
+	/**
+	 * As `resolveChainCredentials`, but surfaces the chain's own failure instead
+	 * of reporting it as an absent session. Callers that can act on the reason a
+	 * credential did not resolve -- `createSession`, which chains it beneath its
+	 * own message -- use this; callers that only care whether a session exists
+	 * use the swallowing form above.
+	 */
+	private async resolveChainCredentialsOrThrow(
+	): Promise<vscode.AuthenticationSession | undefined> {
 		if (!this.credentialChain) {
 			return undefined;
 		}
 		const resolution = this.doResolveChainCredentials();
-		this._chainResolution = resolution;
+		// `getSessions` and the refresh timer await this without a rejection
+		// handler, so publish the swallowing form of the same resolution.
+		const swallowed = resolution.catch(() => undefined);
+		this._chainResolution = swallowed;
 		try {
 			return await resolution;
 		} finally {
-			if (this._chainResolution === resolution) {
+			if (this._chainResolution === swallowed) {
 				this._chainResolution = undefined;
 			}
 		}
@@ -449,7 +476,7 @@ export class AuthProvider
 				});
 				this.logger.logCredentialResolution('invalidated', 'Cached session invalidated');
 			}
-			return undefined;
+			throw err;
 		}
 	}
 

--- a/extensions/authentication/src/awsRecovery.ts
+++ b/extensions/authentication/src/awsRecovery.ts
@@ -1,0 +1,102 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { AuthProviderLogger } from './authProviderLogger';
+import {
+	classifyAwsChainError,
+	ExpiredSsoError,
+	runSsoLogin,
+	SsoLoginError,
+} from './credentials/awsSso';
+
+const logger = new AuthProviderLogger('AWS');
+
+export interface AwsSsoRecovery {
+	/**
+	 * Record a credential-chain failure. `resolveChainCredentials` swallows the
+	 * chain's error and `createSession` throws a generic one in its place, so
+	 * the real cause has to be kept here for `recover` to classify.
+	 */
+	noteFailure(err: unknown): void;
+
+	/**
+	 * Re-run the SSO login when the failure warrants it. Returns true when the
+	 * caller should retry the connect, false when there was nothing to recover
+	 * or the user cancelled. Throws a user-facing error when the login was
+	 * attempted and failed.
+	 */
+	recover(err: unknown): Promise<boolean>;
+}
+
+export interface AwsSsoRecoveryDeps {
+	/** The AWS profile from the provider catalog, when one is configured. */
+	getProfile: () => string | undefined;
+	/** Runs the login. Injected by tests so no process is spawned. */
+	login?: (
+		profile: string | undefined,
+		token: vscode.CancellationToken
+	) => Promise<void>;
+}
+
+export function createAwsSsoRecovery(deps: AwsSsoRecoveryDeps): AwsSsoRecovery {
+	const login = deps.login ?? runSsoLogin;
+	let noted: unknown;
+	let inFlight: Promise<boolean> | undefined;
+
+	const attempt = async (expired: ExpiredSsoError): Promise<boolean> => {
+		const profile = deps.getProfile() ?? expired.profile;
+		try {
+			await vscode.window.withProgress(
+				{
+					location: vscode.ProgressLocation.Notification,
+					title: vscode.l10n.t(
+						'Signing in to AWS -- approve the request in your browser'
+					),
+					cancellable: true,
+				},
+				(_progress, token) => login(profile, token)
+			);
+			noted = undefined;
+			logger.info('SSO login completed; retrying credential resolution');
+			return true;
+		} catch (err) {
+			if (err instanceof SsoLoginError) {
+				if (err.reason === 'cancelled') {
+					logger.info(`SSO login not completed: ${err.message}`);
+					return false;
+				}
+				if (err.reason === 'cli-missing') {
+					throw new Error(vscode.l10n.t(
+						'The AWS CLI is required to refresh your AWS SSO session. Install it and try again.'
+					));
+				}
+				throw new Error(vscode.l10n.t(
+					'AWS sign-in failed: {0}', err.message
+				));
+			}
+			throw err;
+		}
+	};
+
+	return {
+		noteFailure(err: unknown): void {
+			noted = err;
+		},
+
+		async recover(err: unknown): Promise<boolean> {
+			const expired = classifyAwsChainError(err)
+				?? classifyAwsChainError(noted);
+			if (!expired) {
+				return false;
+			}
+			if (!inFlight) {
+				inFlight = attempt(expired)
+					.finally(() => { inFlight = undefined; });
+			}
+			return inFlight;
+		},
+	};
+}

--- a/extensions/authentication/src/awsRecovery.ts
+++ b/extensions/authentication/src/awsRecovery.ts
@@ -18,7 +18,10 @@ export interface AwsSsoRecovery {
 	/**
 	 * Record a credential-chain failure. `resolveChainCredentials` swallows the
 	 * chain's error and `createSession` throws a generic one in its place, so
-	 * the real cause has to be kept here for `recover` to classify.
+	 * the real cause has to be kept here for `recover` to classify. Pass
+	 * `undefined` to clear a previously noted failure once resolution has
+	 * gone on to succeed, so a later unrelated failure cannot be classified
+	 * against a stale note.
 	 */
 	noteFailure(err: unknown): void;
 
@@ -58,7 +61,7 @@ export function createAwsSsoRecovery(deps: AwsSsoRecoveryDeps): AwsSsoRecovery {
 				{
 					location: vscode.ProgressLocation.Notification,
 					title: vscode.l10n.t(
-						'Signing in to AWS -- approve the request in your browser'
+						'Signing in to AWS: approve the request in your browser'
 					),
 					cancellable: true,
 				},

--- a/extensions/authentication/src/awsRecovery.ts
+++ b/extensions/authentication/src/awsRecovery.ts
@@ -91,15 +91,19 @@ export function createAwsSsoRecovery(deps: AwsSsoRecoveryDeps): AwsSsoRecovery {
 		},
 
 		async recover(err: unknown): Promise<boolean> {
+			// A recovery already in flight is the answer for any concurrent
+			// caller: join it. Classifying again here would fail, because
+			// `attempt` consumes and clears the note synchronously.
+			if (inFlight) {
+				return inFlight;
+			}
 			const expired = classifyAwsChainError(err)
 				?? classifyAwsChainError(noted);
 			if (!expired) {
 				return false;
 			}
-			if (!inFlight) {
-				inFlight = attempt(expired)
-					.finally(() => { inFlight = undefined; });
-			}
+			inFlight = attempt(expired)
+				.finally(() => { inFlight = undefined; });
 			return inFlight;
 		},
 	};

--- a/extensions/authentication/src/awsRecovery.ts
+++ b/extensions/authentication/src/awsRecovery.ts
@@ -47,6 +47,11 @@ export function createAwsSsoRecovery(deps: AwsSsoRecoveryDeps): AwsSsoRecovery {
 	let inFlight: Promise<boolean> | undefined;
 
 	const attempt = async (expired: ExpiredSsoError): Promise<boolean> => {
+		// The note has been consumed. Clear it before the attempt so a cancelled
+		// or failed login cannot leave a stale note behind that makes the next
+		// unrelated failure look like a lapsed SSO session. A repeat attempt
+		// re-resolves the chain, which notes the failure again if it recurs.
+		noted = undefined;
 		const profile = deps.getProfile() ?? expired.profile;
 		try {
 			await vscode.window.withProgress(
@@ -59,7 +64,6 @@ export function createAwsSsoRecovery(deps: AwsSsoRecoveryDeps): AwsSsoRecovery {
 				},
 				(_progress, token) => login(profile, token)
 			);
-			noted = undefined;
 			logger.info('SSO login completed; retrying credential resolution');
 			return true;
 		} catch (err) {

--- a/extensions/authentication/src/awsRecovery.ts
+++ b/extensions/authentication/src/awsRecovery.ts
@@ -16,16 +16,6 @@ const logger = new AuthProviderLogger('AWS');
 
 export interface AwsSsoRecovery {
 	/**
-	 * Record a credential-chain failure. `resolveChainCredentials` swallows the
-	 * chain's error and `createSession` throws a generic one in its place, so
-	 * the real cause has to be kept here for `recover` to classify. Pass
-	 * `undefined` to clear a previously noted failure once resolution has
-	 * gone on to succeed, so a later unrelated failure cannot be classified
-	 * against a stale note.
-	 */
-	noteFailure(err: unknown): void;
-
-	/**
 	 * Re-run the SSO login when the failure warrants it. Returns true when the
 	 * caller should retry the connect, false when there was nothing to recover
 	 * or the user cancelled. Throws a user-facing error when the login was
@@ -46,15 +36,9 @@ export interface CreateAwsSsoRecoveryOptions {
 
 export function createAwsSsoRecovery(options: CreateAwsSsoRecoveryOptions): AwsSsoRecovery {
 	const login = options.login ?? runSsoLogin;
-	let noted: unknown;
 	let inFlight: Promise<boolean> | undefined;
 
 	const attempt = async (expired: ExpiredSsoError): Promise<boolean> => {
-		// The note has been consumed. Clear it before the attempt so a cancelled
-		// or failed login cannot leave a stale note behind that makes the next
-		// unrelated failure look like a lapsed SSO session. A repeat attempt
-		// re-resolves the chain, which notes the failure again if it recurs.
-		noted = undefined;
 		const profile = options.getProfile() ?? expired.profile;
 		try {
 			await vscode.window.withProgress(
@@ -89,21 +73,15 @@ export function createAwsSsoRecovery(options: CreateAwsSsoRecoveryOptions): AwsS
 	};
 
 	return {
-		noteFailure(err: unknown): void {
-			noted = err;
-		},
-
 		async recover(err: unknown): Promise<boolean> {
-			// A recovery already in flight is the answer for any concurrent
-			// caller: join it. Classifying again here would fail, because
-			// `attempt` consumes and clears the note synchronously.
-			if (inFlight) {
-				return inFlight;
-			}
-			const expired = classifyAwsChainError(err)
-				?? classifyAwsChainError(noted);
+			const expired = classifyAwsChainError(err);
 			if (!expired) {
 				return false;
+			}
+			// A login already in flight is the answer for any concurrent caller
+			// with the same diagnosis: join it rather than spawning a second one.
+			if (inFlight) {
+				return inFlight;
 			}
 			inFlight = attempt(expired)
 				.finally(() => { inFlight = undefined; });

--- a/extensions/authentication/src/awsRecovery.ts
+++ b/extensions/authentication/src/awsRecovery.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode';
 import { AuthProviderLogger } from './authProviderLogger';
+import type { RecoverCallback } from './configDialog';
 import {
 	classifyAwsChainError,
 	ExpiredSsoError,
@@ -13,16 +14,6 @@ import {
 } from './awsSso';
 
 const logger = new AuthProviderLogger('AWS');
-
-export interface AwsSsoRecovery {
-	/**
-	 * Re-run the SSO login when the failure warrants it. Returns true when the
-	 * caller should retry the connect, false when there was nothing to recover
-	 * or the user cancelled. Throws a user-facing error when the login was
-	 * attempted and failed.
-	 */
-	recover(err: unknown): Promise<boolean>;
-}
 
 export interface CreateAwsSsoRecoveryOptions {
 	/** The AWS profile from the provider catalog, when one is configured. */
@@ -34,7 +25,13 @@ export interface CreateAwsSsoRecoveryOptions {
 	) => Promise<void>;
 }
 
-export function createAwsSsoRecovery(options: CreateAwsSsoRecoveryOptions): AwsSsoRecovery {
+/**
+ * Build the `recover` hook for the AWS provider: it re-runs the SSO login when
+ * the failure warrants it, returning true when the caller should retry the
+ * connect and false when there was nothing to recover or the user cancelled. It
+ * throws a user-facing error when the login was attempted and failed.
+ */
+export function createAwsSsoRecovery(options: CreateAwsSsoRecoveryOptions): RecoverCallback {
 	const login = options.login ?? runSsoLogin;
 	let inFlight: Promise<boolean> | undefined;
 
@@ -72,20 +69,18 @@ export function createAwsSsoRecovery(options: CreateAwsSsoRecoveryOptions): AwsS
 		}
 	};
 
-	return {
-		async recover(err: unknown): Promise<boolean> {
-			const expired = classifyAwsChainError(err);
-			if (!expired) {
-				return false;
-			}
-			// A login already in flight is the answer for any concurrent caller
-			// with the same diagnosis: join it rather than spawning a second one.
-			if (inFlight) {
-				return inFlight;
-			}
-			inFlight = attempt(expired)
-				.finally(() => { inFlight = undefined; });
+	return async (err: unknown): Promise<boolean> => {
+		const expired = classifyAwsChainError(err);
+		if (!expired) {
+			return false;
+		}
+		// A login already in flight is the answer for any concurrent caller
+		// with the same diagnosis: join it rather than spawning a second one.
+		if (inFlight) {
 			return inFlight;
-		},
+		}
+		inFlight = attempt(expired)
+			.finally(() => { inFlight = undefined; });
+		return inFlight;
 	};
 }

--- a/extensions/authentication/src/awsRecovery.ts
+++ b/extensions/authentication/src/awsRecovery.ts
@@ -34,7 +34,7 @@ export interface AwsSsoRecovery {
 	recover(err: unknown): Promise<boolean>;
 }
 
-export interface AwsSsoRecoveryDeps {
+export interface CreateAwsSsoRecoveryOptions {
 	/** The AWS profile from the provider catalog, when one is configured. */
 	getProfile: () => string | undefined;
 	/** Runs the login. Injected by tests so no process is spawned. */
@@ -44,8 +44,8 @@ export interface AwsSsoRecoveryDeps {
 	) => Promise<void>;
 }
 
-export function createAwsSsoRecovery(deps: AwsSsoRecoveryDeps): AwsSsoRecovery {
-	const login = deps.login ?? runSsoLogin;
+export function createAwsSsoRecovery(options: CreateAwsSsoRecoveryOptions): AwsSsoRecovery {
+	const login = options.login ?? runSsoLogin;
 	let noted: unknown;
 	let inFlight: Promise<boolean> | undefined;
 
@@ -55,7 +55,7 @@ export function createAwsSsoRecovery(deps: AwsSsoRecoveryDeps): AwsSsoRecovery {
 		// unrelated failure look like a lapsed SSO session. A repeat attempt
 		// re-resolves the chain, which notes the failure again if it recurs.
 		noted = undefined;
-		const profile = deps.getProfile() ?? expired.profile;
+		const profile = options.getProfile() ?? expired.profile;
 		try {
 			await vscode.window.withProgress(
 				{

--- a/extensions/authentication/src/awsRecovery.ts
+++ b/extensions/authentication/src/awsRecovery.ts
@@ -10,7 +10,7 @@ import {
 	ExpiredSsoError,
 	runSsoLogin,
 	SsoLoginError,
-} from './credentials/awsSso';
+} from './awsSso';
 
 const logger = new AuthProviderLogger('AWS');
 

--- a/extensions/authentication/src/awsSso.ts
+++ b/extensions/authentication/src/awsSso.ts
@@ -5,7 +5,7 @@
 
 import { spawn } from 'child_process';
 import type { CancellationToken } from 'vscode';
-import { AuthProviderLogger } from '../authProviderLogger';
+import { AuthProviderLogger } from './authProviderLogger';
 
 /**
  * Two AWS SDK packages append this sentence to every token error that

--- a/extensions/authentication/src/awsSso.ts
+++ b/extensions/authentication/src/awsSso.ts
@@ -110,10 +110,34 @@ export class SsoLoginError extends Error {
 }
 
 /**
+ * Classify a spawn failure. `spawn` reports these two ways -- an `'error'` event,
+ * or a synchronous throw, which is how Node refuses to run a `.bat`/`.cmd` shim
+ * without a shell (the CVE-2024-27980 mitigation) -- and both have to reach the
+ * caller as the same actionable reason.
+ */
+function toSsoLoginError(err: unknown): SsoLoginError {
+	const code = (err as NodeJS.ErrnoException | undefined)?.code;
+	// ENOENT: nothing named `aws` on PATH -- note Windows CreateProcess only
+	// appends `.exe`, so a shim-only install lands here too. EACCES: found but
+	// not executable. EINVAL: the `.bat`/`.cmd` refusal above. All three mean
+	// there is no usable CLI to run, not that the login itself failed.
+	const reason = code === 'ENOENT' || code === 'EACCES' || code === 'EINVAL'
+		? 'cli-missing'
+		: 'login-failed';
+	return new SsoLoginError(
+		reason,
+		err instanceof Error ? err.message : String(err)
+	);
+}
+
+/**
  * Run `aws sso login`, resolving when the CLI exits cleanly. The CLI opens the
  * user's browser and polls for approval itself, so there is nothing to drive
  * here beyond watching the process. Output is logged to the AWS channel;
  * failures carry a `reason` the caller turns into a user-facing message.
+ *
+ * Never passes `shell: true`: the profile name comes from the provider catalog,
+ * so a shell would make it a command-injection vector.
  */
 export function runSsoLogin(
 	profile: string | undefined,
@@ -126,7 +150,15 @@ export function runSsoLogin(
 	logger.info(`Running: aws ${args.join(' ')}`);
 
 	return new Promise<void>((resolve, reject) => {
-		const child = spawnFn('aws', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+		let child: SsoLoginProcess;
+		try {
+			child = spawnFn('aws', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+		} catch (err) {
+			// Thrown before any timer or listener exists, so reject directly
+			// rather than going through `finish`.
+			reject(toSsoLoginError(err));
+			return;
+		}
 		let stderrText = '';
 		let settled = false;
 
@@ -175,17 +207,7 @@ export function runSsoLogin(
 			}
 		});
 		child.on('error', (err: NodeJS.ErrnoException) => {
-			const code = err.code;
-			// ENOENT: no `aws` on PATH. EACCES: found but not executable.
-			// EINVAL: Windows spawning a .cmd/.bat shim without a shell, which
-			// Node refuses by default as of the CVE-2024-27980 fix. All three
-			// mean there is no usable CLI to run, not that the login itself
-			// failed.
-			finish(new SsoLoginError(
-				code === 'ENOENT' || code === 'EACCES' || code === 'EINVAL'
-					? 'cli-missing' : 'login-failed',
-				err.message
-			));
+			finish(toSsoLoginError(err));
 		});
 		child.on('close', (code: number | null) => {
 			if (code === 0) {

--- a/extensions/authentication/src/awsSso.ts
+++ b/extensions/authentication/src/awsSso.ts
@@ -72,8 +72,31 @@ const logger = new AuthProviderLogger('AWS');
 /** How long to let the CLI run. Matches the SSO device-code expiry. */
 const LOGIN_TIMEOUT_MS = 10 * 60 * 1000;
 
+/** One of a child process's output streams. */
+export interface SsoLoginOutput {
+	on(event: 'data', listener: (chunk: unknown) => void): unknown;
+}
+
+/**
+ * The parts of a spawned child process this module uses. Declaring the shape we
+ * depend on, rather than aliasing Node's fully overloaded `spawn`, keeps the
+ * real `spawn` assignable while letting a test fake satisfy the type directly
+ * instead of asserting it through a cast.
+ */
+export interface SsoLoginProcess {
+	readonly stdout: SsoLoginOutput | null;
+	readonly stderr: SsoLoginOutput | null;
+	on(event: 'error', listener: (err: NodeJS.ErrnoException) => void): unknown;
+	on(event: 'close', listener: (code: number | null) => void): unknown;
+	kill(): void;
+}
+
 /** Injection point so tests do not spawn a real process. */
-export type SpawnFn = typeof spawn;
+export type SpawnFn = (
+	command: string,
+	args: readonly string[],
+	options: { stdio: ['ignore', 'pipe', 'pipe'] },
+) => SsoLoginProcess;
 
 /** Why an `aws sso login` attempt did not produce credentials. */
 export class SsoLoginError extends Error {
@@ -151,10 +174,8 @@ export function runSsoLogin(
 				logger.warn(`aws sso login: ${text}`);
 			}
 		});
-		// Typed as Error to match the ChildProcess overload under
-		// strictFunctionTypes; the errno lives behind a cast.
-		child.on('error', (err: Error) => {
-			const code = (err as NodeJS.ErrnoException).code;
+		child.on('error', (err: NodeJS.ErrnoException) => {
+			const code = err.code;
 			// ENOENT: no `aws` on PATH. EACCES: found but not executable.
 			// EINVAL: Windows spawning a .cmd/.bat shim without a shell, which
 			// Node refuses by default as of the CVE-2024-27980 fix. All three

--- a/extensions/authentication/src/awsSso.ts
+++ b/extensions/authentication/src/awsSso.ts
@@ -73,7 +73,7 @@ const logger = new AuthProviderLogger('AWS');
 const LOGIN_TIMEOUT_MS = 10 * 60 * 1000;
 
 /** One of a child process's output streams. */
-export interface SsoLoginOutput {
+interface SsoLoginOutput {
 	on(event: 'data', listener: (chunk: unknown) => void): unknown;
 }
 
@@ -83,7 +83,7 @@ export interface SsoLoginOutput {
  * real `spawn` assignable while letting a test fake satisfy the type directly
  * instead of asserting it through a cast.
  */
-export interface SsoLoginProcess {
+interface SsoLoginProcess {
 	readonly stdout: SsoLoginOutput | null;
 	readonly stderr: SsoLoginOutput | null;
 	on(event: 'error', listener: (err: NodeJS.ErrnoException) => void): unknown;

--- a/extensions/authentication/src/configDialog.ts
+++ b/extensions/authentication/src/configDialog.ts
@@ -18,16 +18,24 @@ export type OnSaveCallback = (config: positron.ai.LanguageModelConfig) => Promis
 
 export type OnDeleteCallback = () => Promise<void>;
 
+export type RecoverCallback = (err: unknown) => Promise<boolean>;
+
 export interface RegisterAuthProviderOptions {
 	validateApiKey?: ApiKeyValidator;
 	onSave?: OnSaveCallback;
 	onDelete?: OnDeleteCallback;
+	/**
+	 * Attempt to recover from a failed connect -- for example by re-running an
+	 * external sign-in. Return true when the connect is worth retrying once.
+	 */
+	recover?: RecoverCallback;
 }
 
 export const authProviders = new Map<string, AuthProvider>();
 const apiKeyValidators = new Map<string, ApiKeyValidator>();
 const onSaveCallbacks = new Map<string, OnSaveCallback>();
 const onDeleteCallbacks = new Map<string, OnDeleteCallback>();
+const recoverCallbacks = new Map<string, RecoverCallback>();
 
 /**
  * Register an auth provider so the config dialog can store/remove
@@ -53,6 +61,11 @@ export function registerAuthProvider(
 		onDeleteCallbacks.set(providerId, options.onDelete);
 	} else {
 		onDeleteCallbacks.delete(providerId);
+	}
+	if (options?.recover) {
+		recoverCallbacks.set(providerId, options.recover);
+	} else {
+		recoverCallbacks.delete(providerId);
 	}
 }
 
@@ -259,8 +272,31 @@ async function handleSave(
 		await onSave(config);
 	}
 
-	const session = await provider.createSession([], {});
+	const session = await createSessionWithRecovery(providerId, provider);
 	return session.account.id;
+}
+
+/**
+ * Resolve a session, giving the provider one chance to recover from a failure
+ * first -- AWS uses this to re-run `aws sso login` when the SSO session has
+ * lapsed. Exactly one retry: a recovery that succeeds while the chain still
+ * fails (wrong region, missing model permission) must surface that failure
+ * rather than loop.
+ */
+async function createSessionWithRecovery(
+	providerId: string,
+	provider: AuthProvider
+): Promise<vscode.AuthenticationSession> {
+	try {
+		return await provider.createSession([], {});
+	} catch (err) {
+		const recover = recoverCallbacks.get(providerId);
+		if (!recover || !await recover(err)) {
+			throw err;
+		}
+		log.info(`Recovered credentials for provider "${providerId}"; retrying connect`);
+		return provider.createSession([], {});
+	}
 }
 
 async function handleApiKeySave(

--- a/extensions/authentication/src/credentials/awsSso.ts
+++ b/extensions/authentication/src/credentials/awsSso.ts
@@ -3,6 +3,10 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { spawn } from 'child_process';
+import type { CancellationToken } from 'vscode';
+import { AuthProviderLogger } from '../authProviderLogger';
+
 /**
  * The AWS SDK appends this sentence to every token error that running
  * `aws sso login` would fix, and omits it from failures a login cannot fix
@@ -56,4 +60,106 @@ function errorMessages(err: unknown): string[] {
 		current = (current as { cause?: unknown }).cause;
 	}
 	return messages;
+}
+
+const logger = new AuthProviderLogger('AWS');
+
+/** How long to let the CLI run. Matches the SSO device-code expiry. */
+const LOGIN_TIMEOUT_MS = 10 * 60 * 1000;
+
+/** Injection point so tests do not spawn a real process. */
+export type SpawnFn = typeof spawn;
+
+/** Why an `aws sso login` attempt did not produce credentials. */
+export class SsoLoginError extends Error {
+	constructor(
+		readonly reason: 'cli-missing' | 'login-failed' | 'cancelled',
+		message: string,
+	) {
+		super(message);
+		this.name = 'SsoLoginError';
+	}
+}
+
+/**
+ * Run `aws sso login`, resolving when the CLI exits cleanly. The CLI opens the
+ * user's browser and polls for approval itself, so there is nothing to drive
+ * here beyond watching the process. Output is logged to the AWS channel;
+ * failures carry a `reason` the caller turns into a user-facing message.
+ */
+export function runSsoLogin(
+	profile: string | undefined,
+	token: CancellationToken,
+	spawnFn: SpawnFn = spawn,
+): Promise<void> {
+	const args = profile
+		? ['sso', 'login', '--profile', profile]
+		: ['sso', 'login'];
+	logger.info(`Running: aws ${args.join(' ')}`);
+
+	return new Promise<void>((resolve, reject) => {
+		const child = spawnFn('aws', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+		let lastStderrLine = '';
+		let settled = false;
+
+		const finish = (err?: SsoLoginError) => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			clearTimeout(timer);
+			cancelListener.dispose();
+			if (err) {
+				reject(err);
+			} else {
+				resolve();
+			}
+		};
+
+		const abort = (message: string) => {
+			child.kill();
+			finish(new SsoLoginError('cancelled', message));
+		};
+
+		const timer = setTimeout(
+			() => abort('aws sso login timed out'),
+			LOGIN_TIMEOUT_MS
+		);
+		const cancelListener = token.onCancellationRequested(
+			() => abort('aws sso login cancelled')
+		);
+
+		child.stdout?.on('data', (data: unknown) => {
+			const text = String(data).trim();
+			if (text) {
+				logger.info(`aws sso login: ${text}`);
+			}
+		});
+		child.stderr?.on('data', (data: unknown) => {
+			const text = String(data).trim();
+			if (text) {
+				lastStderrLine = text.split('\n').pop() ?? text;
+				logger.warn(`aws sso login: ${text}`);
+			}
+		});
+		// Typed as Error to match the ChildProcess overload under
+		// strictFunctionTypes; the errno lives behind a cast.
+		child.on('error', (err: Error) => {
+			const code = (err as NodeJS.ErrnoException).code;
+			finish(new SsoLoginError(
+				code === 'ENOENT' ? 'cli-missing' : 'login-failed',
+				err.message
+			));
+		});
+		child.on('close', (code: number | null) => {
+			if (code === 0) {
+				finish();
+				return;
+			}
+			finish(new SsoLoginError(
+				'login-failed',
+				lastStderrLine || `aws sso login exited with code ${code}`
+			));
+		});
+	});
 }

--- a/extensions/authentication/src/credentials/awsSso.ts
+++ b/extensions/authentication/src/credentials/awsSso.ts
@@ -1,0 +1,59 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * The AWS SDK appends this sentence to every token error that running
+ * `aws sso login` would fix, and omits it from failures a login cannot fix
+ * (no credentials configured, profile missing from the config file). Matching
+ * it is how we tell a lapsed SSO session apart from every other credential
+ * failure, without parsing `~/.aws/config` ourselves.
+ */
+const REFRESH_MARKER = /To refresh this SSO session run 'aws sso login'/i;
+
+/** A credential-chain failure recognized as a lapsed AWS SSO session. */
+export interface ExpiredSsoError {
+	readonly kind: 'expired-sso';
+	/** The profile the SDK named in the error, when it named one. */
+	readonly profile?: string;
+}
+
+/**
+ * Recognize a lapsed SSO session in a credential-chain failure. Returns
+ * undefined for anything else, so callers gated on this keep their existing
+ * behavior for every unrecognized failure.
+ */
+export function classifyAwsChainError(err: unknown): ExpiredSsoError | undefined {
+	for (const message of errorMessages(err)) {
+		if (!REFRESH_MARKER.test(message)) {
+			continue;
+		}
+		const profile = /profile=(\S+)/.exec(message)?.[1];
+		return profile ? { kind: 'expired-sso', profile } : { kind: 'expired-sso' };
+	}
+	return undefined;
+}
+
+/**
+ * Messages from an error and its `cause` chain, outermost first. The chain
+ * matters because the credential chain wraps the token provider's error in a
+ * generic one before it reaches us.
+ */
+function errorMessages(err: unknown): string[] {
+	const messages: string[] = [];
+	let current: unknown = err;
+	for (let depth = 0; depth < 5 && current !== undefined && current !== null; depth++) {
+		if (typeof current === 'string') {
+			messages.push(current);
+			break;
+		}
+		if (!(current instanceof Error)) {
+			messages.push(String(current));
+			break;
+		}
+		messages.push(current.message);
+		current = (current as { cause?: unknown }).cause;
+	}
+	return messages;
+}

--- a/extensions/authentication/src/credentials/awsSso.ts
+++ b/extensions/authentication/src/credentials/awsSso.ts
@@ -8,13 +8,18 @@ import type { CancellationToken } from 'vscode';
 import { AuthProviderLogger } from '../authProviderLogger';
 
 /**
- * The AWS SDK appends this sentence to every token error that running
- * `aws sso login` would fix, and omits it from failures a login cannot fix
- * (no credentials configured, profile missing from the config file). Matching
- * it is how we tell a lapsed SSO session apart from every other credential
- * failure, without parsing `~/.aws/config` ourselves.
+ * Two AWS SDK packages append this sentence to every token error that
+ * running `aws sso login` would fix, and omit it from failures a login
+ * cannot fix (no credentials configured, profile missing from the config
+ * file). They differ in whether `aws sso login` is quoted:
+ * `@aws-sdk/token-providers` quotes it (the `[sso-session]` profile shape),
+ * while `@aws-sdk/credential-provider-sso` does not (the legacy profile shape
+ * with `sso_start_url` etc. directly on the profile, no `[sso-session]`
+ * block). The optional quotes match both. Matching this sentence is how we
+ * tell a lapsed SSO session apart from every other credential failure,
+ * without parsing `~/.aws/config` ourselves.
  */
-const REFRESH_MARKER = /To refresh this SSO session run 'aws sso login'/i;
+const REFRESH_MARKER = /To refresh this SSO session run '?aws sso login'?/i;
 
 /** A credential-chain failure recognized as a lapsed AWS SSO session. */
 export interface ExpiredSsoError {
@@ -99,7 +104,7 @@ export function runSsoLogin(
 
 	return new Promise<void>((resolve, reject) => {
 		const child = spawnFn('aws', args, { stdio: ['ignore', 'pipe', 'pipe'] });
-		let lastStderrLine = '';
+		let stderrText = '';
 		let settled = false;
 
 		const finish = (err?: SsoLoginError) => {
@@ -136,9 +141,13 @@ export function runSsoLogin(
 			}
 		});
 		child.stderr?.on('data', (data: unknown) => {
-			const text = String(data).trim();
+			// Accumulate the raw chunk (not the trimmed one) so a line split
+			// across two chunks is rejoined correctly; only the logged copy
+			// is trimmed.
+			const raw = String(data);
+			stderrText += raw;
+			const text = raw.trim();
 			if (text) {
-				lastStderrLine = text.split('\n').pop() ?? text;
 				logger.warn(`aws sso login: ${text}`);
 			}
 		});
@@ -146,8 +155,14 @@ export function runSsoLogin(
 		// strictFunctionTypes; the errno lives behind a cast.
 		child.on('error', (err: Error) => {
 			const code = (err as NodeJS.ErrnoException).code;
+			// ENOENT: no `aws` on PATH. EACCES: found but not executable.
+			// EINVAL: Windows spawning a .cmd/.bat shim without a shell, which
+			// Node refuses by default as of the CVE-2024-27980 fix. All three
+			// mean there is no usable CLI to run, not that the login itself
+			// failed.
 			finish(new SsoLoginError(
-				code === 'ENOENT' ? 'cli-missing' : 'login-failed',
+				code === 'ENOENT' || code === 'EACCES' || code === 'EINVAL'
+					? 'cli-missing' : 'login-failed',
 				err.message
 			));
 		});
@@ -156,9 +171,10 @@ export function runSsoLogin(
 				finish();
 				return;
 			}
+			const lastLine = stderrText.split('\n').map(line => line.trim()).filter(line => line).pop();
 			finish(new SsoLoginError(
 				'login-failed',
-				lastStderrLine || `aws sso login exited with code ${code}`
+				lastLine || `aws sso login exited with code ${code}`
 			));
 		});
 	});

--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -345,31 +345,18 @@ async function registerAwsProvider(
 		undefined,
 		{
 			resolve: async () => {
-				try {
-					const aws = getCachedProvider(PROVIDER_METADATA.amazonBedrock.catalogId!)?.connection.aws;
-					const chainInit = resolveAwsChainInit(aws, process.env);
-					const credentialProvider = fromNodeProviderChain(chainInit);
-					const resolved = await credentialProvider();
-					// Clear any note left by an earlier failure now that resolution
-					// has succeeded, so a later failure raised after this closure
-					// returns (e.g. in the caller's own post-resolve checks) is not
-					// misclassified against a stale note.
-					recovery.noteFailure(undefined);
-					return {
-						token: JSON.stringify({
-							accessKeyId: resolved.accessKeyId,
-							secretAccessKey: resolved.secretAccessKey,
-							sessionToken: resolved.sessionToken,
-						}),
-						expiration: resolved.expiration,
-					};
-				} catch (err) {
-					// resolveChainCredentials swallows this error and createSession
-					// throws a generic one in its place, so the recover hook would
-					// have nothing to classify. Keep the real cause here.
-					recovery.noteFailure(err);
-					throw err;
-				}
+				const aws = getCachedProvider(PROVIDER_METADATA.amazonBedrock.catalogId!)?.connection.aws;
+				const chainInit = resolveAwsChainInit(aws, process.env);
+				const credentialProvider = fromNodeProviderChain(chainInit);
+				const resolved = await credentialProvider();
+				return {
+					token: JSON.stringify({
+						accessKeyId: resolved.accessKeyId,
+						secretAccessKey: resolved.secretAccessKey,
+						sessionToken: resolved.sessionToken,
+					}),
+					expiration: resolved.expiration,
+				};
 			},
 		}
 	);

--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -299,12 +299,7 @@ async function registerAnthropicProvider(
 
 	// Eagerly resolve env var credentials so the session is
 	// available before positron-assistant registers models.
-	await provider.resolveChainCredentials().catch(err =>
-		logger.logCredentialResolution(
-			'failed',
-			`Initial credential resolution: ${err}`
-		)
-	);
+	await provider.resolveChainCredentials();
 
 	logger.info('Registered auth provider');
 }
@@ -368,12 +363,7 @@ async function registerAwsProvider(
 			)?.connection.aws?.profile,
 		}),
 	});
-	await provider.resolveChainCredentials().catch(err =>
-		logger.logCredentialResolution(
-			'failed',
-			`Initial credential resolution failed: ${err}`
-		)
-	);
+	await provider.resolveChainCredentials();
 	logger.info('Registered auth provider');
 }
 
@@ -502,12 +492,7 @@ async function registerSnowflakeProvider(context: vscode.ExtensionContext): Prom
 			}
 		},
 	});
-	await provider.resolveChainCredentials().catch(err =>
-		logger.logCredentialResolution(
-			'failed',
-			`Initial credential resolution failed: ${err}`
-		)
-	);
+	await provider.resolveChainCredentials();
 	logger.info('Registered auth provider');
 }
 
@@ -546,9 +531,7 @@ async function registerOpenaiProvider(
 		},
 	});
 
-	await provider.resolveChainCredentials().catch(err =>
-		log.debug(`[OpenAI] Initial credential resolution: ${err}`)
-	);
+	await provider.resolveChainCredentials();
 
 	log.info(`Registered auth provider: ${OPENAI_AUTH_PROVIDER_ID}`);
 }
@@ -591,9 +574,7 @@ async function registerGeminiProvider(
 		},
 	});
 
-	await provider.resolveChainCredentials().catch(err =>
-		log.debug(`[Gemini] Initial credential resolution: ${err}`)
-	);
+	await provider.resolveChainCredentials();
 
 	log.info(`Registered auth provider: ${GEMINI_AUTH_PROVIDER_ID}`);
 }
@@ -629,9 +610,7 @@ async function registerGeapProvider(
 		},
 	});
 
-	await provider.resolveChainCredentials().catch(err =>
-		logger.debug(`Initial credential resolution: ${err}`)
-	);
+	await provider.resolveChainCredentials();
 
 	logger.info(`Registered auth provider: ${GOOGLE_CLOUD_AUTH_PROVIDER_ID}`);
 }
@@ -671,9 +650,7 @@ async function registerDeepSeekProvider(
 		},
 	});
 
-	await provider.resolveChainCredentials().catch(err =>
-		log.debug(`[DeepSeek] Initial credential resolution: ${err}`)
-	);
+	await provider.resolveChainCredentials();
 
 	log.info(`Registered auth provider: ${DEEPSEEK_AUTH_PROVIDER_ID}`);
 }
@@ -762,9 +739,7 @@ async function registerDatabricksProvider(
 		},
 	});
 
-	await provider.resolveChainCredentials().catch(err =>
-		logger.logCredentialResolution('failed', `Initial credential resolution failed: ${err}`)
-	);
+	await provider.resolveChainCredentials();
 	logger.info('Registered auth provider');
 }
 

--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -35,6 +35,7 @@ import {
 } from './validation';
 import { FOUNDRY_MANAGED_CREDENTIALS, hasManagedCredentials } from './managedCredentials';
 import { resolveAwsChainInit } from './credentials/aws';
+import { createAwsSsoRecovery } from './awsRecovery';
 import { resolveGeapCredential } from './credentials/geap';
 import {
 	detectSnowflakeCredentials,
@@ -333,23 +334,36 @@ async function registerAwsProvider(
 ): Promise<void> {
 	const logger = new AuthProviderLogger('AWS');
 
+	const getProfile = () => getCachedProvider(
+		PROVIDER_METADATA.amazonBedrock.catalogId!
+	)?.connection.aws?.profile;
+	const recovery = createAwsSsoRecovery({ getProfile });
+
 	const provider = new AuthProvider(
 		AWS_AUTH_PROVIDER_ID, 'AWS', context,
 		undefined,
 		{
 			resolve: async () => {
-				const aws = getCachedProvider(PROVIDER_METADATA.amazonBedrock.catalogId!)?.connection.aws;
-				const chainInit = resolveAwsChainInit(aws, process.env);
-				const credentialProvider = fromNodeProviderChain(chainInit);
-				const resolved = await credentialProvider();
-				return {
-					token: JSON.stringify({
-						accessKeyId: resolved.accessKeyId,
-						secretAccessKey: resolved.secretAccessKey,
-						sessionToken: resolved.sessionToken,
-					}),
-					expiration: resolved.expiration,
-				};
+				try {
+					const aws = getCachedProvider(PROVIDER_METADATA.amazonBedrock.catalogId!)?.connection.aws;
+					const chainInit = resolveAwsChainInit(aws, process.env);
+					const credentialProvider = fromNodeProviderChain(chainInit);
+					const resolved = await credentialProvider();
+					return {
+						token: JSON.stringify({
+							accessKeyId: resolved.accessKeyId,
+							secretAccessKey: resolved.secretAccessKey,
+							sessionToken: resolved.sessionToken,
+						}),
+						expiration: resolved.expiration,
+					};
+				} catch (err) {
+					// resolveChainCredentials swallows this error and createSession
+					// throws a generic one in its place, so the recover hook would
+					// have nothing to classify. Keep the real cause here.
+					recovery.noteFailure(err);
+					throw err;
+				}
 			},
 		}
 	);
@@ -360,7 +374,9 @@ async function registerAwsProvider(
 		),
 		provider
 	);
-	registerAuthProvider(AWS_AUTH_PROVIDER_ID, provider);
+	registerAuthProvider(AWS_AUTH_PROVIDER_ID, provider, {
+		recover: recovery.recover,
+	});
 	await provider.resolveChainCredentials().catch(err =>
 		logger.logCredentialResolution(
 			'failed',

--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -334,12 +334,6 @@ async function registerAwsProvider(
 ): Promise<void> {
 	const logger = new AuthProviderLogger('AWS');
 
-	const recovery = createAwsSsoRecovery({
-		getProfile: () => getCachedProvider(
-			PROVIDER_METADATA.amazonBedrock.catalogId!
-		)?.connection.aws?.profile,
-	});
-
 	const provider = new AuthProvider(
 		AWS_AUTH_PROVIDER_ID, 'AWS', context,
 		undefined,
@@ -368,7 +362,11 @@ async function registerAwsProvider(
 		provider
 	);
 	registerAuthProvider(AWS_AUTH_PROVIDER_ID, provider, {
-		recover: recovery.recover,
+		recover: createAwsSsoRecovery({
+			getProfile: () => getCachedProvider(
+				PROVIDER_METADATA.amazonBedrock.catalogId!
+			)?.connection.aws?.profile,
+		}),
 	});
 	await provider.resolveChainCredentials().catch(err =>
 		logger.logCredentialResolution(

--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -334,10 +334,11 @@ async function registerAwsProvider(
 ): Promise<void> {
 	const logger = new AuthProviderLogger('AWS');
 
-	const getProfile = () => getCachedProvider(
-		PROVIDER_METADATA.amazonBedrock.catalogId!
-	)?.connection.aws?.profile;
-	const recovery = createAwsSsoRecovery({ getProfile });
+	const recovery = createAwsSsoRecovery({
+		getProfile: () => getCachedProvider(
+			PROVIDER_METADATA.amazonBedrock.catalogId!
+		)?.connection.aws?.profile,
+	});
 
 	const provider = new AuthProvider(
 		AWS_AUTH_PROVIDER_ID, 'AWS', context,

--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -349,6 +349,11 @@ async function registerAwsProvider(
 					const chainInit = resolveAwsChainInit(aws, process.env);
 					const credentialProvider = fromNodeProviderChain(chainInit);
 					const resolved = await credentialProvider();
+					// Clear any note left by an earlier failure now that resolution
+					// has succeeded, so a later failure raised after this closure
+					// returns (e.g. in the caller's own post-resolve checks) is not
+					// misclassified against a stale note.
+					recovery.noteFailure(undefined);
 					return {
 						token: JSON.stringify({
 							accessKeyId: resolved.accessKeyId,

--- a/extensions/authentication/src/test/authProvider.test.ts
+++ b/extensions/authentication/src/test/authProvider.test.ts
@@ -265,6 +265,30 @@ suite('AuthProvider (credential chain)', () => {
 		assert.strictEqual(session.accessToken, resolveResult);
 	});
 
+	test('createSession chains the chain failure beneath its own message', async () => {
+		resolveShouldFail = true;
+
+		const err = await chainProvider.createSession([], {})
+			.then(() => undefined, (e: unknown) => e);
+
+		// The actionable message is what the user sees; the real cause rides
+		// underneath so a caller that can recover from a specific failure -- an
+		// expired AWS SSO session, say -- can still find it.
+		assert.deepStrictEqual(
+			[
+				/^No credentials found for Test Chain\./.test((err as Error).message),
+				((err as { cause?: Error }).cause)?.message,
+			],
+			[true, 'chain failed']
+		);
+	});
+
+	test('resolveChainCredentials still reports a failure as no session', async () => {
+		resolveShouldFail = true;
+
+		assert.strictEqual(await chainProvider.resolveChainCredentials(), undefined);
+	});
+
 	test('resolveChainCredentials invalidates cached session on failure', async () => {
 		await chainProvider.resolveChainCredentials();
 		let sessions = await chainProvider.getSessions();

--- a/extensions/authentication/src/test/awsRecovery.test.ts
+++ b/extensions/authentication/src/test/awsRecovery.test.ts
@@ -26,12 +26,12 @@ const CHAINED = wrapped(
 suite('createAwsSsoRecovery', () => {
 	test('ignores a failure that no login would fix', async () => {
 		let logins = 0;
-		const recovery = createAwsSsoRecovery({
+		const recover = createAwsSsoRecovery({
 			getProfile: () => undefined,
 			login: async () => { logins++; },
 		});
 
-		const recovered = await recovery.recover(
+		const recovered = await recover(
 			wrapped('No credentials found for AWS.', new Error('Could not load credentials from any providers'))
 		);
 
@@ -40,12 +40,12 @@ suite('createAwsSsoRecovery', () => {
 
 	test('classifies the cause chained beneath the generic message', async () => {
 		const profiles: Array<string | undefined> = [];
-		const recovery = createAwsSsoRecovery({
+		const recover = createAwsSsoRecovery({
 			getProfile: () => 'sso-dev',
 			login: async (profile) => { profiles.push(profile); },
 		});
 
-		const recovered = await recovery.recover(CHAINED);
+		const recovered = await recover(CHAINED);
 
 		assert.deepStrictEqual([recovered, profiles], [true, ['sso-dev']]);
 	});
@@ -54,13 +54,13 @@ suite('createAwsSsoRecovery', () => {
 		let logins = 0;
 		let release = () => { };
 		const gate = new Promise<void>(resolve => { release = resolve; });
-		const recovery = createAwsSsoRecovery({
+		const recover = createAwsSsoRecovery({
 			getProfile: () => undefined,
 			login: async () => { logins++; await gate; },
 		});
 
-		const first = recovery.recover(CHAINED);
-		const second = recovery.recover(CHAINED);
+		const first = recover(CHAINED);
+		const second = recover(CHAINED);
 		release();
 		const [firstResult, secondResult] = await Promise.all([first, second]);
 
@@ -73,48 +73,48 @@ suite('createAwsSsoRecovery', () => {
 		let logins = 0;
 		let release = () => { };
 		const gate = new Promise<void>(resolve => { release = resolve; });
-		const recovery = createAwsSsoRecovery({
+		const recover = createAwsSsoRecovery({
 			getProfile: () => undefined,
 			login: async () => { logins++; await gate; },
 		});
 
-		const sso = recovery.recover(CHAINED);
+		const sso = recover(CHAINED);
 		// Classification happens before the in-flight check, so a failure with no
 		// SSO cause is reported as unrecoverable rather than inheriting this
 		// login's outcome.
-		const unrelated = await recovery.recover(new Error('Could not load credentials from any providers'));
+		const unrelated = await recover(new Error('Could not load credentials from any providers'));
 		release();
 
 		assert.deepStrictEqual([unrelated, await sso, logins], [false, true, 1]);
 	});
 
 	test('cancellation reports no recovery without throwing', async () => {
-		const recovery = createAwsSsoRecovery({
+		const recover = createAwsSsoRecovery({
 			getProfile: () => undefined,
 			login: async () => { throw new SsoLoginError('cancelled', 'cancelled'); },
 		});
 
-		assert.strictEqual(await recovery.recover(CHAINED), false);
+		assert.strictEqual(await recover(CHAINED), false);
 	});
 
 	test('surfaces a missing CLI as an actionable error', async () => {
-		const recovery = createAwsSsoRecovery({
+		const recover = createAwsSsoRecovery({
 			getProfile: () => undefined,
 			login: async () => { throw new SsoLoginError('cli-missing', 'spawn aws ENOENT'); },
 		});
 
-		const err = await recovery.recover(CHAINED).then(() => undefined, (e: unknown) => e);
+		const err = await recover(CHAINED).then(() => undefined, (e: unknown) => e);
 
 		assert.match((err as Error).message, /AWS CLI/);
 	});
 
 	test('surfaces a failed login with the CLI reason', async () => {
-		const recovery = createAwsSsoRecovery({
+		const recover = createAwsSsoRecovery({
 			getProfile: () => undefined,
 			login: async () => { throw new SsoLoginError('login-failed', 'AccessDenied'); },
 		});
 
-		const err = await recovery.recover(CHAINED).then(() => undefined, (e: unknown) => e);
+		const err = await recover(CHAINED).then(() => undefined, (e: unknown) => e);
 
 		assert.match((err as Error).message, /AccessDenied/);
 	});

--- a/extensions/authentication/src/test/awsRecovery.test.ts
+++ b/extensions/authentication/src/test/awsRecovery.test.ts
@@ -95,6 +95,20 @@ suite('createAwsSsoRecovery', () => {
 		assert.match((err as Error).message, /AccessDenied/);
 	});
 
+	test('a cleared note no longer classifies', async () => {
+		let logins = 0;
+		const recovery = createAwsSsoRecovery({
+			getProfile: () => undefined,
+			login: async () => { logins++; },
+		});
+
+		recovery.noteFailure(EXPIRED);
+		recovery.noteFailure(undefined);
+		const recovered = await recovery.recover(GENERIC);
+
+		assert.deepStrictEqual([recovered, logins], [false, 0]);
+	});
+
 	test('a cancelled attempt leaves no stale note behind', async () => {
 		let logins = 0;
 		const recovery = createAwsSsoRecovery({

--- a/extensions/authentication/src/test/awsRecovery.test.ts
+++ b/extensions/authentication/src/test/awsRecovery.test.ts
@@ -5,7 +5,7 @@
 
 import * as assert from 'assert';
 import { createAwsSsoRecovery } from '../awsRecovery';
-import { SsoLoginError } from '../credentials/awsSso';
+import { SsoLoginError } from '../awsSso';
 
 const REFRESH = `To refresh this SSO session run 'aws sso login' with the corresponding profile.`;
 const EXPIRED = new Error(`Token is expired. ${REFRESH}`);

--- a/extensions/authentication/src/test/awsRecovery.test.ts
+++ b/extensions/authentication/src/test/awsRecovery.test.ts
@@ -8,10 +8,20 @@ import { createAwsSsoRecovery } from '../awsRecovery';
 import { SsoLoginError } from '../awsSso';
 
 const REFRESH = `To refresh this SSO session run 'aws sso login' with the corresponding profile.`;
-const EXPIRED = new Error(`Token is expired. ${REFRESH}`);
-// What AuthProvider.createSession actually throws: the chain swallows the real
-// cause, so this generic message is all the recover hook is handed.
-const GENERIC = new Error('No credentials found for AWS.');
+
+/** An error carrying another as its `cause`, the way `createSession` does. */
+function wrapped(message: string, cause: Error): Error {
+	const err = new Error(message);
+	(err as { cause?: unknown }).cause = cause;
+	return err;
+}
+
+// What AuthProvider.createSession throws: its own actionable message with the
+// real chain failure chained beneath it.
+const CHAINED = wrapped(
+	'No credentials found for AWS.',
+	new Error(`Token is expired. ${REFRESH}`)
+);
 
 suite('createAwsSsoRecovery', () => {
 	test('ignores a failure that no login would fix', async () => {
@@ -22,21 +32,20 @@ suite('createAwsSsoRecovery', () => {
 		});
 
 		const recovered = await recovery.recover(
-			new Error('Could not load credentials from any providers')
+			wrapped('No credentials found for AWS.', new Error('Could not load credentials from any providers'))
 		);
 
 		assert.deepStrictEqual([recovered, logins], [false, 0]);
 	});
 
-	test('classifies the noted failure when handed the generic error', async () => {
+	test('classifies the cause chained beneath the generic message', async () => {
 		const profiles: Array<string | undefined> = [];
 		const recovery = createAwsSsoRecovery({
 			getProfile: () => 'sso-dev',
 			login: async (profile) => { profiles.push(profile); },
 		});
 
-		recovery.noteFailure(EXPIRED);
-		const recovered = await recovery.recover(GENERIC);
+		const recovered = await recovery.recover(CHAINED);
 
 		assert.deepStrictEqual([recovered, profiles], [true, ['sso-dev']]);
 	});
@@ -49,10 +58,9 @@ suite('createAwsSsoRecovery', () => {
 			getProfile: () => undefined,
 			login: async () => { logins++; await gate; },
 		});
-		recovery.noteFailure(EXPIRED);
 
-		const first = recovery.recover(GENERIC);
-		const second = recovery.recover(GENERIC);
+		const first = recovery.recover(CHAINED);
+		const second = recovery.recover(CHAINED);
 		release();
 		const [firstResult, secondResult] = await Promise.all([first, second]);
 
@@ -61,14 +69,32 @@ suite('createAwsSsoRecovery', () => {
 		assert.deepStrictEqual([firstResult, secondResult, logins], [true, true, 1]);
 	});
 
+	test('an unrelated failure during a login does not join it', async () => {
+		let logins = 0;
+		let release = () => { };
+		const gate = new Promise<void>(resolve => { release = resolve; });
+		const recovery = createAwsSsoRecovery({
+			getProfile: () => undefined,
+			login: async () => { logins++; await gate; },
+		});
+
+		const sso = recovery.recover(CHAINED);
+		// Classification happens before the in-flight check, so a failure with no
+		// SSO cause is reported as unrecoverable rather than inheriting this
+		// login's outcome.
+		const unrelated = await recovery.recover(new Error('Could not load credentials from any providers'));
+		release();
+
+		assert.deepStrictEqual([unrelated, await sso, logins], [false, true, 1]);
+	});
+
 	test('cancellation reports no recovery without throwing', async () => {
 		const recovery = createAwsSsoRecovery({
 			getProfile: () => undefined,
 			login: async () => { throw new SsoLoginError('cancelled', 'cancelled'); },
 		});
-		recovery.noteFailure(EXPIRED);
 
-		assert.strictEqual(await recovery.recover(GENERIC), false);
+		assert.strictEqual(await recovery.recover(CHAINED), false);
 	});
 
 	test('surfaces a missing CLI as an actionable error', async () => {
@@ -76,9 +102,8 @@ suite('createAwsSsoRecovery', () => {
 			getProfile: () => undefined,
 			login: async () => { throw new SsoLoginError('cli-missing', 'spawn aws ENOENT'); },
 		});
-		recovery.noteFailure(EXPIRED);
 
-		const err = await recovery.recover(GENERIC).then(() => undefined, (e: unknown) => e);
+		const err = await recovery.recover(CHAINED).then(() => undefined, (e: unknown) => e);
 
 		assert.match((err as Error).message, /AWS CLI/);
 	});
@@ -88,40 +113,9 @@ suite('createAwsSsoRecovery', () => {
 			getProfile: () => undefined,
 			login: async () => { throw new SsoLoginError('login-failed', 'AccessDenied'); },
 		});
-		recovery.noteFailure(EXPIRED);
 
-		const err = await recovery.recover(GENERIC).then(() => undefined, (e: unknown) => e);
+		const err = await recovery.recover(CHAINED).then(() => undefined, (e: unknown) => e);
 
 		assert.match((err as Error).message, /AccessDenied/);
-	});
-
-	test('a cleared note no longer classifies', async () => {
-		let logins = 0;
-		const recovery = createAwsSsoRecovery({
-			getProfile: () => undefined,
-			login: async () => { logins++; },
-		});
-
-		recovery.noteFailure(EXPIRED);
-		recovery.noteFailure(undefined);
-		const recovered = await recovery.recover(GENERIC);
-
-		assert.deepStrictEqual([recovered, logins], [false, 0]);
-	});
-
-	test('a cancelled attempt leaves no stale note behind', async () => {
-		let logins = 0;
-		const recovery = createAwsSsoRecovery({
-			getProfile: () => undefined,
-			login: async () => { logins++; throw new SsoLoginError('cancelled', 'cancelled'); },
-		});
-		recovery.noteFailure(EXPIRED);
-		await recovery.recover(GENERIC);
-
-		// A later failure that does not itself classify must not be treated as
-		// a lapsed SSO session on the strength of the consumed note.
-		const second = await recovery.recover(GENERIC);
-
-		assert.deepStrictEqual([second, logins], [false, 1]);
 	});
 });

--- a/extensions/authentication/src/test/awsRecovery.test.ts
+++ b/extensions/authentication/src/test/awsRecovery.test.ts
@@ -94,4 +94,20 @@ suite('createAwsSsoRecovery', () => {
 
 		assert.match((err as Error).message, /AccessDenied/);
 	});
+
+	test('a cancelled attempt leaves no stale note behind', async () => {
+		let logins = 0;
+		const recovery = createAwsSsoRecovery({
+			getProfile: () => undefined,
+			login: async () => { logins++; throw new SsoLoginError('cancelled', 'cancelled'); },
+		});
+		recovery.noteFailure(EXPIRED);
+		await recovery.recover(GENERIC);
+
+		// A later failure that does not itself classify must not be treated as
+		// a lapsed SSO session on the strength of the consumed note.
+		const second = await recovery.recover(GENERIC);
+
+		assert.deepStrictEqual([second, logins], [false, 1]);
+	});
 });

--- a/extensions/authentication/src/test/awsRecovery.test.ts
+++ b/extensions/authentication/src/test/awsRecovery.test.ts
@@ -1,0 +1,97 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { createAwsSsoRecovery } from '../awsRecovery';
+import { SsoLoginError } from '../credentials/awsSso';
+
+const REFRESH = `To refresh this SSO session run 'aws sso login' with the corresponding profile.`;
+const EXPIRED = new Error(`Token is expired. ${REFRESH}`);
+// What AuthProvider.createSession actually throws: the chain swallows the real
+// cause, so this generic message is all the recover hook is handed.
+const GENERIC = new Error('No credentials found for AWS.');
+
+suite('createAwsSsoRecovery', () => {
+	test('ignores a failure that no login would fix', async () => {
+		let logins = 0;
+		const recovery = createAwsSsoRecovery({
+			getProfile: () => undefined,
+			login: async () => { logins++; },
+		});
+
+		const recovered = await recovery.recover(
+			new Error('Could not load credentials from any providers')
+		);
+
+		assert.deepStrictEqual([recovered, logins], [false, 0]);
+	});
+
+	test('classifies the noted failure when handed the generic error', async () => {
+		const profiles: Array<string | undefined> = [];
+		const recovery = createAwsSsoRecovery({
+			getProfile: () => 'sso-dev',
+			login: async (profile) => { profiles.push(profile); },
+		});
+
+		recovery.noteFailure(EXPIRED);
+		const recovered = await recovery.recover(GENERIC);
+
+		assert.deepStrictEqual([recovered, profiles], [true, ['sso-dev']]);
+	});
+
+	test('runs one login for concurrent recover calls', async () => {
+		let logins = 0;
+		let release = () => { };
+		const gate = new Promise<void>(resolve => { release = resolve; });
+		const recovery = createAwsSsoRecovery({
+			getProfile: () => undefined,
+			login: async () => { logins++; await gate; },
+		});
+		recovery.noteFailure(EXPIRED);
+
+		const first = recovery.recover(GENERIC);
+		const second = recovery.recover(GENERIC);
+		release();
+		const [firstResult, secondResult] = await Promise.all([first, second]);
+
+		// `logins` must be read after both settle, not inside Promise.all --
+		// the login may not have been called yet when the array is built.
+		assert.deepStrictEqual([firstResult, secondResult, logins], [true, true, 1]);
+	});
+
+	test('cancellation reports no recovery without throwing', async () => {
+		const recovery = createAwsSsoRecovery({
+			getProfile: () => undefined,
+			login: async () => { throw new SsoLoginError('cancelled', 'cancelled'); },
+		});
+		recovery.noteFailure(EXPIRED);
+
+		assert.strictEqual(await recovery.recover(GENERIC), false);
+	});
+
+	test('surfaces a missing CLI as an actionable error', async () => {
+		const recovery = createAwsSsoRecovery({
+			getProfile: () => undefined,
+			login: async () => { throw new SsoLoginError('cli-missing', 'spawn aws ENOENT'); },
+		});
+		recovery.noteFailure(EXPIRED);
+
+		const err = await recovery.recover(GENERIC).then(() => undefined, (e: unknown) => e);
+
+		assert.match((err as Error).message, /AWS CLI/);
+	});
+
+	test('surfaces a failed login with the CLI reason', async () => {
+		const recovery = createAwsSsoRecovery({
+			getProfile: () => undefined,
+			login: async () => { throw new SsoLoginError('login-failed', 'AccessDenied'); },
+		});
+		recovery.noteFailure(EXPIRED);
+
+		const err = await recovery.recover(GENERIC).then(() => undefined, (e: unknown) => e);
+
+		assert.match((err as Error).message, /AccessDenied/);
+	});
+});

--- a/extensions/authentication/src/test/awsRecovery.test.ts
+++ b/extensions/authentication/src/test/awsRecovery.test.ts
@@ -9,10 +9,17 @@ import { SsoLoginError } from '../awsSso';
 
 const REFRESH = `To refresh this SSO session run 'aws sso login' with the corresponding profile.`;
 
-/** An error carrying another as its `cause`, the way `createSession` does. */
+/**
+ * An error carrying another as its `cause`, the way `createSession` does --
+ * non-enumerable, matching the native `cause` this `lib: es2020` target cannot
+ * pass to the `Error` constructor. Classification must not depend on the
+ * property being enumerable.
+ */
 function wrapped(message: string, cause: Error): Error {
 	const err = new Error(message);
-	(err as { cause?: unknown }).cause = cause;
+	Object.defineProperty(err, 'cause', {
+		value: cause, writable: true, configurable: true,
+	});
 	return err;
 }
 

--- a/extensions/authentication/src/test/awsSso.test.ts
+++ b/extensions/authentication/src/test/awsSso.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import { EventEmitter } from 'events';
 import * as vscode from 'vscode';
-import { classifyAwsChainError, runSsoLogin, SpawnFn, SsoLoginError } from '../credentials/awsSso';
+import { classifyAwsChainError, runSsoLogin, SpawnFn, SsoLoginError } from '../awsSso';
 
 // The sentence the AWS SDK appends to every token error an `aws sso login`
 // would fix. Copied verbatim from @aws-sdk/token-providers.

--- a/extensions/authentication/src/test/awsSso.test.ts
+++ b/extensions/authentication/src/test/awsSso.test.ts
@@ -96,10 +96,10 @@ suite('runSsoLogin', () => {
 	setup(() => {
 		child = fakeChild();
 		spawnArgs = undefined;
-		spawnFn = ((command: string, args: readonly string[]) => {
+		spawnFn = (command: string, args: readonly string[]) => {
 			spawnArgs = { command, args };
 			return child;
-		}) as unknown as SpawnFn;
+		};
 		cancellation = new vscode.CancellationTokenSource();
 	});
 
@@ -155,7 +155,7 @@ suite('runSsoLogin', () => {
 	test('reports a missing or unusable CLI distinctly, regardless of errno', async () => {
 		const results = await Promise.all((['ENOENT', 'EACCES', 'EINVAL'] as const).map(async code => {
 			const errnoChild = fakeChild();
-			const errnoSpawnFn = ((_command: string, _args: readonly string[]) => errnoChild) as unknown as SpawnFn;
+			const errnoSpawnFn: SpawnFn = (_command: string, _args: readonly string[]) => errnoChild;
 			const pending = runSsoLogin(undefined, cancellation.token, errnoSpawnFn);
 			const spawnError: NodeJS.ErrnoException = new Error(`spawn aws ${code}`);
 			spawnError.code = code;

--- a/extensions/authentication/src/test/awsSso.test.ts
+++ b/extensions/authentication/src/test/awsSso.test.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { classifyAwsChainError } from '../credentials/awsSso';
+
+// The sentence the AWS SDK appends to every token error an `aws sso login`
+// would fix. Copied verbatim from @aws-sdk/token-providers.
+const REFRESH = `To refresh this SSO session run 'aws sso login' with the corresponding profile.`;
+
+/** An error wrapping another as its `cause`, the way the chain wraps ours. */
+function wrapped(message: string, cause: Error): Error {
+	const err = new Error(message);
+	(err as { cause?: unknown }).cause = cause;
+	return err;
+}
+
+suite('classifyAwsChainError', () => {
+	test('recognizes the recoverable SSO errors and rejects the rest', () => {
+		const results = [
+			// Expired cached token, no profile named.
+			classifyAwsChainError(new Error(`Token is expired. ${REFRESH}`)),
+			// Missing or invalid token, profile named.
+			classifyAwsChainError(new Error(
+				`The SSO session token associated with profile=default was not found or is invalid. ${REFRESH}`
+			)),
+			// Non-default profile name.
+			classifyAwsChainError(new Error(
+				`The SSO session token associated with profile=sso-dev was not found or is invalid. ${REFRESH}`
+			)),
+			// Wrapped in the generic error the credential chain throws.
+			// `new Error(msg, { cause })` is ES2022 and this extension compiles
+			// against lib es2020, so attach the cause by assignment.
+			classifyAwsChainError(wrapped('No credentials found for AWS.', new Error(`Token is expired. ${REFRESH}`))),
+			// Not recoverable by a login: nothing configured at all.
+			classifyAwsChainError(new Error('Could not load credentials from any providers')),
+			// Not recoverable by a login: the profile does not exist.
+			classifyAwsChainError(new Error(`Profile 'dev' could not be found in shared credentials file.`)),
+			// Not an error object at all.
+			classifyAwsChainError(undefined),
+		];
+
+		assert.deepStrictEqual(results, [
+			{ kind: 'expired-sso' },
+			{ kind: 'expired-sso', profile: 'default' },
+			{ kind: 'expired-sso', profile: 'sso-dev' },
+			{ kind: 'expired-sso' },
+			undefined,
+			undefined,
+			undefined,
+		]);
+	});
+});

--- a/extensions/authentication/src/test/awsSso.test.ts
+++ b/extensions/authentication/src/test/awsSso.test.ts
@@ -167,6 +167,25 @@ suite('runSsoLogin', () => {
 		assert.deepStrictEqual(results, ['cli-missing', 'cli-missing', 'cli-missing']);
 	});
 
+	test('classifies a synchronous spawn throw the same as an error event', async () => {
+		// Node refuses to spawn a .bat/.cmd shim without a shell by throwing
+		// rather than emitting 'error', so the classification cannot live only
+		// in the event handler.
+		const throwingSpawnFn: SpawnFn = () => {
+			const spawnError: NodeJS.ErrnoException = new Error('spawn aws EINVAL');
+			spawnError.code = 'EINVAL';
+			throw spawnError;
+		};
+
+		const err = await runSsoLogin('sso-dev', cancellation.token, throwingSpawnFn)
+			.then(() => undefined, (e: unknown) => e);
+
+		assert.deepStrictEqual(
+			[(err as SsoLoginError).reason, (err as SsoLoginError).name],
+			['cli-missing', 'SsoLoginError']
+		);
+	});
+
 	test('cancellation kills the child and reports cancelled', async () => {
 		const pending = runSsoLogin(undefined, cancellation.token, spawnFn);
 		cancellation.cancel();

--- a/extensions/authentication/src/test/awsSso.test.ts
+++ b/extensions/authentication/src/test/awsSso.test.ts
@@ -12,6 +12,11 @@ import { classifyAwsChainError, runSsoLogin, SpawnFn, SsoLoginError } from '../c
 // would fix. Copied verbatim from @aws-sdk/token-providers.
 const REFRESH = `To refresh this SSO session run 'aws sso login' with the corresponding profile.`;
 
+// The unquoted twin of REFRESH, copied verbatim from
+// @aws-sdk/credential-provider-sso. Legacy profiles (sso_start_url etc.
+// directly on the profile, no [sso-session] block) produce this spelling.
+const LEGACY_REFRESH = `To refresh this SSO session run aws sso login with the corresponding profile.`;
+
 /** An error wrapping another as its `cause`, the way the chain wraps ours. */
 function wrapped(message: string, cause: Error): Error {
 	const err = new Error(message);
@@ -42,6 +47,15 @@ suite('classifyAwsChainError', () => {
 			classifyAwsChainError(new Error(`Profile 'dev' could not be found in shared credentials file.`)),
 			// Not an error object at all.
 			classifyAwsChainError(undefined),
+			// Legacy profile shape (no [sso-session] block): invalid session,
+			// unquoted refresh sentence from @aws-sdk/credential-provider-sso.
+			classifyAwsChainError(new Error(
+				`The SSO session associated with this profile is invalid. ${LEGACY_REFRESH}`
+			)),
+			// Legacy profile shape: expired session, same unquoted sentence.
+			classifyAwsChainError(new Error(
+				`The SSO session associated with this profile has expired. ${LEGACY_REFRESH}`
+			)),
 		];
 
 		assert.deepStrictEqual(results, [
@@ -52,6 +66,8 @@ suite('classifyAwsChainError', () => {
 			undefined,
 			undefined,
 			undefined,
+			{ kind: 'expired-sso' },
+			{ kind: 'expired-sso' },
 		]);
 	});
 });
@@ -125,15 +141,30 @@ suite('runSsoLogin', () => {
 		);
 	});
 
-	test('reports a missing CLI distinctly', async () => {
+	test('reports the last stderr line even when it is split across chunks', async () => {
 		const pending = runSsoLogin(undefined, cancellation.token, spawnFn);
-		const spawnError: NodeJS.ErrnoException = new Error('spawn aws ENOENT');
-		spawnError.code = 'ENOENT';
-		child.emit('error', spawnError);
+		child.stderr.emit('data', 'first problem\nAn err');
+		child.stderr.emit('data', 'or occurred: AccessDenied\n');
+		child.emit('close', 1);
 
 		const err = await pending.then(() => undefined, (e: unknown) => e);
 
-		assert.strictEqual((err as SsoLoginError).reason, 'cli-missing');
+		assert.strictEqual((err as SsoLoginError).message, 'An error occurred: AccessDenied');
+	});
+
+	test('reports a missing or unusable CLI distinctly, regardless of errno', async () => {
+		const results = await Promise.all((['ENOENT', 'EACCES', 'EINVAL'] as const).map(async code => {
+			const errnoChild = fakeChild();
+			const errnoSpawnFn = ((_command: string, _args: readonly string[]) => errnoChild) as unknown as SpawnFn;
+			const pending = runSsoLogin(undefined, cancellation.token, errnoSpawnFn);
+			const spawnError: NodeJS.ErrnoException = new Error(`spawn aws ${code}`);
+			spawnError.code = code;
+			errnoChild.emit('error', spawnError);
+			const err = await pending.then(() => undefined, (e: unknown) => e);
+			return (err as SsoLoginError).reason;
+		}));
+
+		assert.deepStrictEqual(results, ['cli-missing', 'cli-missing', 'cli-missing']);
 	});
 
 	test('cancellation kills the child and reports cancelled', async () => {

--- a/extensions/authentication/src/test/awsSso.test.ts
+++ b/extensions/authentication/src/test/awsSso.test.ts
@@ -4,7 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { classifyAwsChainError } from '../credentials/awsSso';
+import { EventEmitter } from 'events';
+import * as vscode from 'vscode';
+import { classifyAwsChainError, runSsoLogin, SpawnFn, SsoLoginError } from '../credentials/awsSso';
 
 // The sentence the AWS SDK appends to every token error an `aws sso login`
 // would fix. Copied verbatim from @aws-sdk/token-providers.
@@ -51,5 +53,98 @@ suite('classifyAwsChainError', () => {
 			undefined,
 			undefined,
 		]);
+	});
+});
+
+/** A stand-in for ChildProcess carrying only what runSsoLogin touches. */
+function fakeChild() {
+	const child = new EventEmitter() as EventEmitter & {
+		stdout: EventEmitter;
+		stderr: EventEmitter;
+		kill: () => void;
+		killed: boolean;
+	};
+	child.stdout = new EventEmitter();
+	child.stderr = new EventEmitter();
+	child.killed = false;
+	child.kill = () => { child.killed = true; };
+	return child;
+}
+
+suite('runSsoLogin', () => {
+	let child: ReturnType<typeof fakeChild>;
+	let spawnArgs: { command: string; args: readonly string[] } | undefined;
+	let spawnFn: SpawnFn;
+	let cancellation: vscode.CancellationTokenSource;
+
+	setup(() => {
+		child = fakeChild();
+		spawnArgs = undefined;
+		spawnFn = ((command: string, args: readonly string[]) => {
+			spawnArgs = { command, args };
+			return child;
+		}) as unknown as SpawnFn;
+		cancellation = new vscode.CancellationTokenSource();
+	});
+
+	teardown(() => {
+		cancellation.dispose();
+	});
+
+	test('passes the profile through and resolves on a clean exit', async () => {
+		const pending = runSsoLogin('sso-dev', cancellation.token, spawnFn);
+		child.emit('close', 0);
+
+		await pending;
+
+		assert.deepStrictEqual(spawnArgs, {
+			command: 'aws',
+			args: ['sso', 'login', '--profile', 'sso-dev'],
+		});
+	});
+
+	test('omits --profile when no profile is configured', async () => {
+		const pending = runSsoLogin(undefined, cancellation.token, spawnFn);
+		child.emit('close', 0);
+
+		await pending;
+
+		assert.deepStrictEqual(spawnArgs?.args, ['sso', 'login']);
+	});
+
+	test('reports the last stderr line when the CLI exits non-zero', async () => {
+		const pending = runSsoLogin(undefined, cancellation.token, spawnFn);
+		child.stderr.emit('data', 'first problem\nAn error occurred: AccessDenied\n');
+		child.emit('close', 1);
+
+		const err = await pending.then(() => undefined, (e: unknown) => e);
+
+		assert.deepStrictEqual(
+			[(err as SsoLoginError).reason, (err as SsoLoginError).message],
+			['login-failed', 'An error occurred: AccessDenied']
+		);
+	});
+
+	test('reports a missing CLI distinctly', async () => {
+		const pending = runSsoLogin(undefined, cancellation.token, spawnFn);
+		const spawnError: NodeJS.ErrnoException = new Error('spawn aws ENOENT');
+		spawnError.code = 'ENOENT';
+		child.emit('error', spawnError);
+
+		const err = await pending.then(() => undefined, (e: unknown) => e);
+
+		assert.strictEqual((err as SsoLoginError).reason, 'cli-missing');
+	});
+
+	test('cancellation kills the child and reports cancelled', async () => {
+		const pending = runSsoLogin(undefined, cancellation.token, spawnFn);
+		cancellation.cancel();
+
+		const err = await pending.then(() => undefined, (e: unknown) => e);
+
+		assert.deepStrictEqual(
+			[(err as SsoLoginError).reason, child.killed],
+			['cancelled', true]
+		);
 	});
 });

--- a/extensions/authentication/src/test/configDialog.test.ts
+++ b/extensions/authentication/src/test/configDialog.test.ts
@@ -490,4 +490,98 @@ suite('configDialog', () => {
 			});
 		});
 	});
+
+	/**
+	 * A chain provider whose resolve fails the given number of times before
+	 * succeeding, for exercising the recover-and-retry path.
+	 */
+	function makeFlakyChainProvider(failures: number) {
+		let attempts = 0;
+		const chainProvider = new AuthProvider(
+			'test-chain', 'Test Chain',
+			{
+				secrets: {
+					get: () => Promise.resolve(undefined),
+					store: () => Promise.resolve(),
+					delete: () => Promise.resolve(),
+				},
+				globalState: {
+					get: () => undefined,
+					update: () => Promise.resolve(),
+				},
+			} as unknown as vscode.ExtensionContext,
+			undefined,
+			{
+				resolve: async () => {
+					attempts++;
+					if (attempts <= failures) {
+						throw new Error('chain unavailable');
+					}
+					return JSON.stringify({ accessKeyId: 'AKIA', secretAccessKey: 'secret' });
+				},
+			}
+		);
+		return { chainProvider, attempts: () => attempts };
+	}
+
+	const chainSource = {
+		type: positron.PositronLanguageModelType.Chat,
+		provider: { id: 'test-chain', displayName: 'Test Chain' },
+		supportedOptions: [],
+		defaults: {},
+	} as positron.ai.LanguageModelSource;
+
+	test('retries the connect once when recover succeeds', async () => {
+		const { chainProvider, attempts } = makeFlakyChainProvider(1);
+		let recoverCalls = 0;
+		registerAuthProvider('test-chain', chainProvider, {
+			recover: async () => { recoverCalls++; return true; },
+		});
+
+		await providerAction(chainSource, { model: 'test-model' }, 'save');
+
+		const sessions = await chainProvider.getSessions();
+		assert.deepStrictEqual(
+			[recoverCalls, attempts(), sessions.length],
+			[1, 2, 1]
+		);
+		chainProvider.dispose();
+	});
+
+	test('propagates the original error when recover declines', async () => {
+		const { chainProvider } = makeFlakyChainProvider(Number.MAX_SAFE_INTEGER);
+		registerAuthProvider('test-chain', chainProvider, {
+			recover: async () => false,
+		});
+
+		const err = await providerAction(chainSource, { model: 'test-model' }, 'save')
+			.then(() => undefined, (e: unknown) => e);
+
+		assert.match((err as Error).message, /No credentials found for Test Chain/);
+		chainProvider.dispose();
+	});
+
+	test('surfaces the recover error in place of the generic one', async () => {
+		const { chainProvider } = makeFlakyChainProvider(Number.MAX_SAFE_INTEGER);
+		registerAuthProvider('test-chain', chainProvider, {
+			recover: async () => { throw new Error('the AWS CLI is required'); },
+		});
+
+		const err = await providerAction(chainSource, { model: 'test-model' }, 'save')
+			.then(() => undefined, (e: unknown) => e);
+
+		assert.match((err as Error).message, /the AWS CLI is required/);
+		chainProvider.dispose();
+	});
+
+	test('does not retry when no recover hook is registered', async () => {
+		const { chainProvider, attempts } = makeFlakyChainProvider(1);
+		registerAuthProvider('test-chain', chainProvider);
+
+		const err = await providerAction(chainSource, { model: 'test-model' }, 'save')
+			.then(() => undefined, (e: unknown) => e);
+
+		assert.deepStrictEqual([attempts(), err !== undefined], [1, true]);
+		chainProvider.dispose();
+	});
 });


### PR DESCRIPTION
Fixes #15272

### Summary

When an AWS SSO session lapses while Positron is closed, the next launch resolves no Bedrock credentials and the provider modal's **Connect** button re-runs the same failing chain resolution, re-throwing raw AWS SDK text. The user had to read the message, switch to a terminal, run `aws sso login`, switch back, and retry.

**Connect** now performs that recovery itself: it classifies the failure, runs `aws sso login` behind a cancellable progress notification while the CLI opens the browser, and retries the connect once on success.

Two implementation notes worth a reviewer's attention:

- **Two AWS SDK packages emit the "run `aws sso login`" sentence with different quoting.** `@aws-sdk/token-providers` quotes the command and handles profiles referencing an `[sso-session]` block; `@aws-sdk/credential-provider-sso` does not quote it and handles the legacy shape (`sso_start_url` / `sso_region` / `sso_account_id` / `sso_role_name` inline in the profile, i.e. anything predating AWS CLI v2.9). The matcher accepts both, or legacy-profile users would get no recovery and no indication why.
- **`AuthProvider.createSession` now chains the real chain failure beneath its own message.** `resolveChainCredentials` swallows the failure and reports an absent session, so the reason never reached the caller. A new private `resolveChainCredentialsOrThrow` surfaces it while the public method keeps its never-rejects contract for `getSessions`, the refresh timer, and every existing call site. This affects all chain providers -- Anthropic, Snowflake, Foundry, GEAP, Databricks, AWS -- additively: the message is unchanged and nothing reads `cause` today.

Anything not classified as a lapsed SSO session takes exactly the previous path, so the deliberately out-of-scope cases cannot regress: no credentials configured at all, expiry mid-session, and non-SSO AWS auth (static keys, web identity). Posit Workbench is unaffected -- Bedrock has no managed-credentials entry, and only SSO failures carry the marker, so no browser sign-in can be triggered in a server session.

### Release Notes

#### New Features

- Amazon Bedrock: an expired AWS SSO session can now be renewed from the provider modal instead of requiring `aws sso login` in a terminal (#15272)

#### Bug Fixes

- N/A

### Validation Steps

@:assistant

Automated coverage is extension-host unit tests (`npm run test-extension -- -l authentication`, 242 passing). The sign-in flow itself has no e2e coverage and cannot get any -- it needs a real identity provider and a browser approval.

Manual verification, on a machine with a real AWS SSO profile. **Run it twice: once with a profile that references an `[sso-session]` block, and once with a legacy profile.** Those two shapes fail through different SDK packages with differently-spelled messages, so a matcher that handles one can silently miss the other.

To configure your profile you will need to set the `AWS_PROFILE` env var, which can be done in the launch configuration on line ~321. Alternatively, you can configure it in your own environment's `PATH` (e.g. in your `~/.zshrc`) and restart VSCode so it is picked up. Issue #15697 will allow users to set it in the product itself.

1. Confirm Bedrock is connected and working.
2. `aws sso logout`, then reload the window.
3. Confirm the toast reads `Amazon Bedrock: Authentication expired` with a **Configure** button (unchanged from `main`).
4. Click **Configure**, select Bedrock under **Needs Attention**, then click **Connect**.
5. Confirm a cancellable *"Signing in to AWS: approve the request in your browser"* notification appears, the browser opens, and after approval the provider shows as connected.
6. Confirm the model picker repopulates without a window reload.
7. Cancel the notification mid-login and confirm no error banner appears and the provider is unchanged.
8. With a non-SSO profile (static keys) or no AWS config at all, confirm behavior is identical to `main`: no notification, same error as before.

#### Windows

The command is the same on every platform: AWS CLI v2 installs `aws.exe` via MSI and puts it on `PATH`, and `spawn('aws', ...)` resolves it because `CreateProcess` appends `.exe` to an extensionless command. Three notes:

- The realistic failure is `ENOENT` -- no `aws` on the extension host's `PATH` -- which reports *"The AWS CLI is required to refresh your AWS SSO session."* `EACCES` and `EINVAL` are classified the same way defensively; neither has been observed.
- `CreateProcess` appends only `.exe`, never `.cmd` or `.bat`. An install providing only a `aws.cmd` shim therefore reports "CLI is required" even though the CLI is present. Not fixable with `shell: true`, deliberately: the profile name comes from the provider catalog, so a shell would make it a command-injection vector (the CVE-2024-27980 shape).
- `resolveShellEnv` is skipped on Windows (`src/vs/platform/shell/node/shellEnv.ts:43-45`), so the extension host uses the `PATH` Positron inherited at launch. Installing the AWS CLI while Positron is running requires a restart before recovery can find it.

All three paths are unit-tested, including a synchronous `spawn` throw, which Node uses for the `.bat`/`.cmd` refusal. None are manually verified on Windows.
