### PR TITLE
Document the file open command in the positron-commands skill

### DIFF
--- a/extensions/positron-skills/templates/positron-commands/SKILL.md
+++ b/extensions/positron-skills/templates/positron-commands/SKILL.md
@@ -2,24 +2,25 @@
 name: positron-commands
 description: >
   Running Positron IDE commands: changing the window layout, focusing panes
-  (Console, Variables, Plots, Help, Packages), clearing the console, listing or
-  discovering registered interpreters, restarting or interrupting a stuck
-  session, setting up Python, and reading, installing or updating the packages
-  in a session. Use when the user wants Positron itself to do something, or
-  wants to know what is installed, rather than to run R or Python code. Load
-  this skill, then read the reference file for the area in question. Triggers:
-  "switch to the data science layout", "show the variables pane", "clear the
-  console", "what interpreters are available", "my R interpreter isn't showing
-  up", "my session is stuck", "is pandas installed?", "install dplyr", "update
-  all my packages", "do I have any vulnerable packages?", "I don't have Python
-  installed", "set up a Python environment", "which Python am I using".
+  (Console, Variables, Plots, Help, Packages), clearing the console, opening a
+  file or a data file in the right editor, listing or discovering registered
+  interpreters, restarting or interrupting a stuck session, setting up Python,
+  and reading, installing or updating the packages in a session. Use when the
+  user wants Positron itself to do something, or wants to know what is
+  installed, rather than to run R or Python code. Triggers: "switch to the data
+  science layout", "show the variables pane", "clear the console", "open
+  data.csv", "let's look at this parquet file", "what interpreters are
+  available", "my R interpreter isn't showing up", "my session is stuck", "is
+  pandas installed?", "install dplyr", "update all my packages", "do I have any
+  vulnerable packages?", "I don't have Python installed", "set up a Python
+  environment", "which Python am I using".
 ---
 
 # Positron IDE commands
 
-These commands act on the Positron workbench itself -- layout, panes, interpreter
-sessions, and packages. They do not run interpreter code; use `executeCode` for
-that.
+These commands act on the Positron workbench itself -- layout, panes, editors,
+interpreter sessions, and packages. They do not run interpreter code; use
+`executeCode` for that.
 
 ## Calling these commands
 
@@ -30,6 +31,16 @@ given under that command's "Arguments" entry. Omit `args` entirely for commands
 that take none -- do not pass an empty object or array. Never invent an argument
 value the user hasn't given you or that isn't documented; if a required value is
 unknown, ask the user first.
+
+**Find the id here before you run it.** Positron is built on VS Code, so a
+plausible-sounding VS Code command id usually does exist and will usually run --
+which makes recalling one from memory the most expensive mistake available. Some
+ids that read like they do the thing directly instead open a dialog or a
+quick-pick and wait for the user to choose, so the command "succeeds" while
+handing the task straight back to them. Read the relevant reference file first
+and use the id and arguments it gives you. If what the user wants is not covered
+by any file below, say so rather than reaching for an id from general VS Code
+knowledge.
 
 ## When a command doesn't work
 
@@ -52,6 +63,13 @@ Read when the user asks about: switching the workbench layout (four-pane,
 notebook, two-pane), bringing a pane into focus (Console, Variables, Help,
 Plots, Packages), clearing console output, or expanding/collapsing the Data
 Explorer's column summary panel.
+
+**Opening files** -- [references/files.md]({{skill_dir}}/references/files.md)
+Read when the user wants a file open in Positron: "open data.csv", "show me
+that file", "let's look at this CSV/Parquet/Excel file", or anything that should
+land in the Data Explorer. Read it **before** opening anything -- it documents
+the one command that opens a known path, and names the similar-looking ids that
+open a file picker instead and hand the task back to the user.
 
 **Registered interpreters** -- [references/interpreters.md]({{skill_dir}}/references/interpreters.md)
 Read when the user asks what interpreters are available, wants the registered

--- a/extensions/positron-skills/templates/positron-commands/references/files.md
+++ b/extensions/positron-skills/templates/positron-commands/references/files.md
@@ -1,0 +1,76 @@
+# Positron file commands
+
+Opening a file in an editor. See [SKILL.md]({{skill_dir}}/SKILL.md) for how to
+call these commands and how to handle failures.
+
+The **Arguments** and **Returns** entries below are generated from the running
+build's command metadata, so they always match this Positron. The surrounding
+guidance is hand-written.
+
+## Open the path, don't open a picker
+
+When the user names a file, open that file. **Do not call a command that opens
+a file picker.** `workbench.action.files.openFile`,
+`workbench.action.files.openFileFolder` and `workbench.action.quickOpen` all
+put a dialog or quick-pick in front of the user and wait for them to choose,
+which hands the task straight back to the person who asked you to do it. None
+of them are agent-compatible, and none of them appear anywhere in this skill --
+if you are reaching for one, you are working from general VS Code knowledge
+rather than from this file.
+
+`vscode.open` is the only file-opening command this skill documents. If the
+user has not given you a path and you cannot work one out from the workspace,
+ask them which file they mean rather than opening a picker so they can browse.
+
+## `vscode.open`
+
+Opens a file in whichever editor Positron associates with that file type. No
+precondition -- always enabled.
+
+{{command:vscode.open}}
+
+### Building the argument
+
+The path must be absolute. A bare relative path is not resolved against the
+workspace: it is parsed as a URI and ends up rooted at the filesystem root, so
+`data.csv` becomes `/data.csv` and silently opens the wrong thing (or nothing).
+Resolve it against the workspace folder yourself and pass the absolute result.
+
+On Windows a bare drive-letter path is worse than wrong-looking -- it does not
+parse as a path at all. In `C:/Users/me/data.csv` the leading `C:` is read as a
+URI scheme, so pass `file:///C:/Users/me/data.csv` instead.
+
+Never guess at a filename. If you are not sure the file exists, check first:
+the command reports success either way, and a path that does not exist opens an
+editor showing a file-not-found error rather than failing the call.
+
+### Which editor a file opens in
+
+This is the reason `vscode.open` is worth reaching for rather than reading the
+file yourself -- the right editor for the file type is a Positron feature the
+user may not know about.
+
+| File | Opens in |
+| --- | --- |
+| `.csv`, `.tsv`, `.parquet`, `.parq`, `.xlsx` | Data Explorer |
+| The `.gz` form of any of those, e.g. `data.csv.gz` | Data Explorer |
+| `.ipynb` | A notebook editor |
+| Anything else | A text editor |
+
+Extensions are matched lowercase, so `DATA.CSV` gets a text editor, not the
+Data Explorer. A user can also redirect any of these with the
+`workbench.editorAssociations` setting, so treat the table as the default
+rather than a guarantee -- say "this should open in the Data Explorer", and let
+what the user sees settle it.
+
+Opening a tabular file is also how you get a Data Explorer editor in the first
+place, which the summary-panel commands in
+[ui.md]({{skill_dir}}/references/ui.md) require as the active editor.
+
+### What it does not do
+
+- **It is not how you read a file.** The command shows the file to the user; it
+  returns nothing about the contents. If you need the data, read the file
+  yourself or run code in the session.
+- **http and https URLs do not open an editor.** They go to the user's external
+  browser. Say that is what you are about to do before doing it.

--- a/extensions/positron-skills/templates/positron-commands/references/ui.md
+++ b/extensions/positron-skills/templates/positron-commands/references/ui.md
@@ -2,7 +2,8 @@
 
 Layout, pane focus, and view state in the running Positron workbench. See
 [SKILL.md]({{skill_dir}}/SKILL.md) for how to call these commands and how to handle
-failures.
+failures. To open a file in an editor, see
+[files.md]({{skill_dir}}/references/files.md).
 
 The **Arguments** and **Returns** entries below are generated from the running
 build's command metadata, so they always match this Positron. The surrounding
@@ -97,6 +98,10 @@ was just generated, or asks to switch to the plots view.
 {{command:workbench.panel.positronPlots.focus}}
 
 ## Console and Data Explorer view state
+
+The two Data Explorer commands here need a Data Explorer editor already active.
+Opening a tabular file is how one gets there -- see
+[files.md]({{skill_dir}}/references/files.md).
 
 ### `workbench.action.positronConsole.clearConsole`
 

--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -458,10 +458,10 @@ function registerOpenEditorAPICommands(): void {
 			agentCompatible: true,
 			// args: [{ name: 'Uri' }]
 			args: [{
-			  name: 'Uri',
-			  description: 'Absolute path or file URI of the file to open. Relative paths resolve against the filesystem root, not the workspace, so always pass an absolute path; on Windows pass a file:///C:/... URI rather than a bare drive-letter path. Tabular files (.csv, .tsv, .parquet, .xlsx, and .gz variants, lowercase extension) open in Data Explorer. http/https URLs open in an external browser, not an editor.',
-			schema: { type: 'string' }
-  }]
+				name: 'Uri',
+				description: 'Absolute path or file URI of the file to open. Relative paths resolve against the filesystem root, not the workspace, so always pass an absolute path; on Windows pass a file:///C:/... URI rather than a bare drive-letter path. Tabular files (.csv, .tsv, .parquet, .parq, .xlsx, and .gz variants, lowercase extension) open in Data Explorer. http/https URLs open in an external browser, not an editor.',
+				schema: { type: 'string' }
+			}]
 			// --- End Positron ---
 		}
 	});

--- a/src/vs/workbench/contrib/positronAiFeatures/test/browser/agentSkillDrift.vitest.ts
+++ b/src/vs/workbench/contrib/positronAiFeatures/test/browser/agentSkillDrift.vitest.ts
@@ -41,7 +41,10 @@ const SKILLS_ROOT = path.join(REPO_ROOT, 'extensions', 'positron-skills', 'templ
 
 /** Dotted-identifier shape, e.g. `workbench.action.foo` or `positron.help.lookupHelpTopic`. */
 const CANDIDATE_ID_PATTERN = /^[A-Za-z][A-Za-z0-9]*(?:\.[A-Za-z][A-Za-z0-9]*)+$/;
-const ALLOWED_PREFIXES = ['positron.', 'positronVariables.', 'workbench.'];
+// `vscode.` is here because the skill documents `vscode.open`: not every command
+// the skill names is Positron's own, and an upstream rename would break the
+// skill just as surely as a Positron one.
+const ALLOWED_PREFIXES = ['positron.', 'positronVariables.', 'vscode.', 'workbench.'];
 
 function escapeRegExp(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/src/vs/workbench/contrib/positronAiFeatures/test/browser/agentSkillTemplates.vitest.ts
+++ b/src/vs/workbench/contrib/positronAiFeatures/test/browser/agentSkillTemplates.vitest.ts
@@ -115,6 +115,57 @@ const skills: SkillFrontmatter[] = fs.existsSync(SKILLS_ROOT)
 		}))
 	: [];
 
+/** Matches the target of a `{{skill_dir}}/...` link, capturing the path after the slash. */
+const SKILL_DIR_LINK = /\{\{skill_dir\}\}\/([^)\s]+)/g;
+
+interface SkillLinks {
+	readonly directoryName: string;
+	/** Every markdown file in the skill, relative to its directory, POSIX-separated. */
+	readonly presentPaths: readonly string[];
+	/** Every `{{skill_dir}}` target named anywhere in the skill, with the file that named it. */
+	readonly links: readonly { readonly target: string; readonly from: string }[];
+	/** The `{{skill_dir}}` targets named by `SKILL.md` itself -- the router. */
+	readonly routedPaths: readonly string[];
+}
+
+/** Recursively collects markdown paths under `dir`, relative to it, POSIX-separated. */
+function collectMarkdownPaths(dir: string, prefix = ''): string[] {
+	const result: string[] = [];
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const relative = prefix ? `${prefix}/${entry.name}` : entry.name;
+		if (entry.isDirectory()) {
+			result.push(...collectMarkdownPaths(path.join(dir, entry.name), relative));
+		} else if (entry.name.endsWith('.md')) {
+			result.push(relative);
+		}
+	}
+	return result;
+}
+
+function readLinks(target: string): string[] {
+	const found: string[] = [];
+	let match: RegExpExecArray | null;
+	SKILL_DIR_LINK.lastIndex = 0;
+	while ((match = SKILL_DIR_LINK.exec(target))) {
+		found.push(match[1]);
+	}
+	return found;
+}
+
+const skillLinks: SkillLinks[] = skills.map(skill => {
+	const skillDir = path.join(SKILLS_ROOT, skill.directoryName);
+	const presentPaths = collectMarkdownPaths(skillDir);
+	const links = presentPaths.flatMap(from =>
+		readLinks(fs.readFileSync(path.join(skillDir, from), 'utf8')).map(target => ({ target, from })),
+	);
+	return {
+		directoryName: skill.directoryName,
+		presentPaths,
+		links,
+		routedPaths: links.filter(link => link.from === 'SKILL.md').map(link => link.target),
+	};
+});
+
 describe('agent skill templates', () => {
 	// Guards against a broken path calculation making every test below pass
 	// vacuously, the same way the drift test guards its own corpus.
@@ -153,5 +204,32 @@ describe('agent skill templates', () => {
 			`${skill.relativePath}: frontmatter contains a {{...}} directive. The length ` +
 			`check above measures the template, so it no longer bounds the generated output.`,
 		).not.toMatch(/\{\{/);
+	});
+
+	it.each(skillLinks)('$directoryName links only to files that exist', skill => {
+		// A `{{skill_dir}}` link expands to a real path on disk that the model is
+		// told to read. If the file isn't there the read simply returns nothing,
+		// so a typo or a rename costs the model a whole reference file with no
+		// error anywhere.
+		const present = new Set(skill.presentPaths);
+		const broken = skill.links.filter(link => !present.has(link.target));
+		expect(
+			broken.map(link => `${link.target} (linked from ${link.from})`),
+			`${skill.directoryName}: link target(s) missing from the skill directory`,
+		).toEqual([]);
+	});
+
+	it.each(skillLinks)('$directoryName routes to every one of its reference files', skill => {
+		// SKILL.md is the only file the model reads before choosing where to go
+		// next, so a reference file it does not name is a file the model never
+		// learns exists.
+		const routed = new Set(skill.routedPaths);
+		const unrouted = skill.presentPaths.filter(
+			file => file !== 'SKILL.md' && !routed.has(file),
+		);
+		expect(
+			unrouted,
+			`${skill.directoryName}: reference file(s) present but not linked from SKILL.md`,
+		).toEqual([]);
 	});
 });


### PR DESCRIPTION
Closes #15348

### Summary

Documents `vscode.open` in the `positron-commands` agent skill. Adds
`references/files.md` -- the sixth area -- covering the one agent-compatible
command that opens a file, how to build its argument, and which editor each file
type lands in. The command work itself was already done in #15141 (metadata
only, no behavior change), so this is documentation plus a test.

The file leads with the correction from this issue: Assistant reached for
`workbench.action.files.openFile`, which opens a file picker and hands the task
straight back to the person who asked. So the file names that id along with the
two other tempting ones (`openFileFolder`, `quickOpen`), confirms none of the
three are agent-compatible, and states that `vscode.open` is the only
file-opening command the skill documents.

The editor-association table is read from the registration in
`positronDataExplorerEditor.contribution.ts` rather than copied from the
command's own metadata description. The real list is `parquet, parq, csv, tsv,
gz, xlsx`, with `.gz` stripping to the inner extension -- the description was
missing `.parq`, so this adds it. Worth fixing rather than working around,
because that string renders verbatim into the reference file through the
`{{command:vscode.open}}` directive *and* reaches the model through
`positron.ai.getAgentAllowedCommands` whether or not the skill ever loads.

Alongside that:

- **`SKILL.md` gains the general form of the "don't guess an id" rule**, which
  is the durable version of what went wrong here: Positron is built on VS Code,
  so a plausible-sounding VS Code id usually does exist and usually runs, which
  makes recalling one from memory the most expensive mistake available. Some of
  those ids open a dialog and wait, so the command "succeeds" while handing the
  task back. This is the skill-side half of the second comment on #15348; the
  Assistant-side nudge is separate work in that repo.
- **Adds `vscode.` to `agentSkillDrift.vitest.ts`'s allowed prefixes.** Without
  it the new id was not covered at all -- the prefix list was Positron-only, and
  not every command the skill names is Positron's own.
- **Adds two link-integrity assertions to `agentSkillTemplates.vitest.ts`.** A
  broken `{{skill_dir}}` link and a reference file `SKILL.md` never routes to
  both fail silently at runtime: the model simply reads nothing. Verified
  non-vacuous by breaking the link and watching both fail.
- **Fixes the indentation of the `vscode.open` metadata block** from #15141,
  which landed space-indented inside the Positron markers.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

Agent-facing skill content. Platform skill discovery and the command tool are
both behind `assistant.experimentalFeatures`, which is off by default, so
nothing changes for users on a default install.

### Validation Steps

No e2e tags. Same call as #15671 and for the same reason: this is skill template
content plus a unit test, with no runtime behavior change, and platform skill
discovery is gated behind `assistant.experimentalFeatures` (default off). No
existing e2e test loads the skill, so no suite can observe this change. I plan to add such a test once we have completed all this postiron-command skill work.

Unit coverage:

```
npx vitest run src/vs/workbench/contrib/positronAiFeatures/test/browser/
```

#### Setup

1. Set `assistant.experimentalFeatures` to `true`, confirm `ai.enabled` is on,
   and reload the window.
2. Open a workspace containing a `.csv` and a plain `.py` or `.txt`.

**You will usually have to tell Assistant to use the `positron-commands` skill
at least once.** Some models don't reach for it on their own. That's a
model/prompting gap rather than something skill content can fix, and it's being
addressed separately in Assistant. Without the nudge it's easy to conclude the
skill is broken when it was simply never loaded.

#### Then ask Assistant

1. **"Open `<name>.csv`"** -- should land in the Data Explorer. It should **not**
   open a file picker, and should **not** read the file itself and summarise it
   instead of showing it.
2. **"Open `<name>.py`"** -- should land in a text editor.
3. **"Open the CSV"** in a workspace with several, without naming one -- should
   ask which file, not open a picker for you to browse.
4. **"Open `docs/notes.txt`"** (a relative path) -- should pass an absolute path.
   On Windows specifically, watch for a `file:///C:/...` URI rather than a bare
   `C:\` path; a bare drive letter parses `C:` as a URI scheme and silently
   opens nothing.
5. **"Collapse the column summary"** with no Data Explorer open -- should report
   the precondition plainly, and ideally offer to open a tabular file first
   (that cross-link is new in `ui.md`).

#### Negative case

6. **"Open a file that does not exist"** -- the command reports success either
   way, so the check is that Assistant does not claim the file opened fine when
   the editor is showing a file-not-found error.

#### If Assistant seems unaware of the file

Check the skill actually generated:
`<globalStorage>/positron.positron-skills/skills/positron-commands/references/files.md`
should exist and contain a "Which editor a file opens in" section. If it is
missing, the skill did not load and nothing above is a fair test.

### Notes for reviewers

- **Most models found `vscode.open` without the skill.** In practice they
  identified the right command on their own and called the command tool
  directly, reasoning from general VS Code knowledge, without loading
  `positron-commands` at all. So the *command id* here is largely
  self-discoverable, and the argument shape already reaches the model through
  `getAgentAllowedCommands` regardless of whether the skill loads. What is not
  self-discoverable is the picker antipattern -- which is the failure actually
  observed on this issue -- and the editor-association table.

- **Given that, this is the first area I would cut if we need the room.** The
  description budget is real: 959/1024 with six areas, 65 characters to spare. I
  bought this area's room by dropping the "load this skill, then read the
  reference file" sentence, which the body's uncapped router already says
  better, so the sixth area cost only 33 net characters against main's 926 for
  five. But the enumeration fat is now gone, and whoever adds a seventh area has
  no comparable source of reclaimed budget -- they will be choosing between
  cutting trigger phrases and splitting the skill. If that moment arrives before
  we have split, `files.md` is the cheapest thing to drop, precisely because it
  is the one area where the model mostly gets there anyway. The `SKILL.md`
  "don't guess an id" paragraph should survive that cut, though -- it is
  general, it is not in the capped description, and it is the part that
  addresses the observed failure.

- **`vscode.open` is upstream, not ours.** That is why the drift test needed a
  new prefix, and it is worth knowing an upstream rename would break this skill
  as surely as a Positron one. The drift check for this id is weaker than for
  the others, incidentally: it passes on a literal substring match anywhere in
  `src/vs/workbench`, and `vscode.open` happens to appear in unrelated files, so
  a rename of the actual registration would not be caught. Pre-existing property
  of the corpus approach; not worth reworking here.

