### PR TITLE
Enable workbench users to add MCP servers for Copilot

### DIFF
--- a/src/vs/base/common/oauth.ts
+++ b/src/vs/base/common/oauth.ts
@@ -943,7 +943,7 @@ const grantTypesSupported = ['authorization_code', 'refresh_token', 'urn:ietf:pa
 export const DEFAULT_AUTH_FLOW_PORT = 33418;
 // --- Start Positron ---
 export async function fetchDynamicRegistration(serverMetadata: IAuthorizationServerMetadata, clientName: string, scopes?: string[],
-	additionalRedirectUris?: string[]
+	redirectUriOverride?: string
 ): Promise<IAuthorizationDynamicClientRegistrationResponse> {
 	// --- End Positron ---
 	if (!serverMetadata.registration_endpoint) {
@@ -960,7 +960,7 @@ export async function fetchDynamicRegistration(serverMetadata: IAuthorizationSer
 			: grantTypesSupported,
 		response_types: ['code'],
 		// --- Start Positron ---
-		redirect_uris: additionalRedirectUris?.length ? additionalRedirectUris : [
+		redirect_uris: redirectUriOverride ? [redirectUriOverride] : [
 			'https://insiders.vscode.dev/redirect',
 			'https://vscode.dev/redirect',
 			'http://127.0.0.1/',

--- a/src/vs/base/common/oauth.ts
+++ b/src/vs/base/common/oauth.ts
@@ -950,21 +950,6 @@ export async function fetchDynamicRegistration(serverMetadata: IAuthorizationSer
 		throw new Error('Server does not support dynamic registration');
 	}
 
-	// --- Start Positron ---
-	const redirectUris = additionalRedirectUris?.length
-		? additionalRedirectUris
-		: [
-			'https://insiders.vscode.dev/redirect',
-			'https://vscode.dev/redirect',
-			'http://127.0.0.1/',
-			// Added these for any server that might do
-			// only exact match on the redirect URI even
-			// though the spec says it should not care
-			// about the port.
-			`http://127.0.0.1:${DEFAULT_AUTH_FLOW_PORT}/`,
-		];
-	// --- End Positron ---
-
 	const requestBody: IAuthorizationDynamicClientRegistrationRequest = {
 		client_name: clientName,
 		// --- Start Positron ---
@@ -974,7 +959,18 @@ export async function fetchDynamicRegistration(serverMetadata: IAuthorizationSer
 			? serverMetadata.grant_types_supported.filter(gt => grantTypesSupported.includes(gt))
 			: grantTypesSupported,
 		response_types: ['code'],
-		redirect_uris: redirectUris,
+		// --- Start Positron ---
+		redirect_uris: additionalRedirectUris?.length ? additionalRedirectUris : [
+			'https://insiders.vscode.dev/redirect',
+			'https://vscode.dev/redirect',
+			'http://127.0.0.1/',
+			// Added these for any server that might do
+			// only exact match on the redirect URI even
+			// though the spec says it should not care
+			// about the port.
+			`http://127.0.0.1:${DEFAULT_AUTH_FLOW_PORT}/`,
+		],
+		// --- End Positron ---
 		scope: scopes?.join(AUTH_SCOPE_SEPARATOR),
 		token_endpoint_auth_method: 'none',
 		application_type: 'native'

--- a/src/vs/base/common/oauth.ts
+++ b/src/vs/base/common/oauth.ts
@@ -950,14 +950,10 @@ export async function fetchDynamicRegistration(serverMetadata: IAuthorizationSer
 		throw new Error('Server does not support dynamic registration');
 	}
 
-	const requestBody: IAuthorizationDynamicClientRegistrationRequest = {
-		client_name: clientName,
-		client_uri: 'https://code.visualstudio.com',
-		grant_types: serverMetadata.grant_types_supported
-			? serverMetadata.grant_types_supported.filter(gt => grantTypesSupported.includes(gt))
-			: grantTypesSupported,
-		response_types: ['code'],
-		redirect_uris: [
+	// --- Start Positron ---
+	const redirectUris = additionalRedirectUris?.length
+		? additionalRedirectUris
+		: [
 			'https://insiders.vscode.dev/redirect',
 			'https://vscode.dev/redirect',
 			'http://127.0.0.1/',
@@ -966,10 +962,19 @@ export async function fetchDynamicRegistration(serverMetadata: IAuthorizationSer
 			// though the spec says it should not care
 			// about the port.
 			`http://127.0.0.1:${DEFAULT_AUTH_FLOW_PORT}/`,
-			// --- Start Positron ---
-			...(additionalRedirectUris ?? [])
-			// --- End Positron ---
-		],
+		];
+	// --- End Positron ---
+
+	const requestBody: IAuthorizationDynamicClientRegistrationRequest = {
+		client_name: clientName,
+		// --- Start Positron ---
+		client_uri: 'https://positron.posit.co',
+		// --- End Positron ---
+		grant_types: serverMetadata.grant_types_supported
+			? serverMetadata.grant_types_supported.filter(gt => grantTypesSupported.includes(gt))
+			: grantTypesSupported,
+		response_types: ['code'],
+		redirect_uris: redirectUris,
 		scope: scopes?.join(AUTH_SCOPE_SEPARATOR),
 		token_endpoint_auth_method: 'none',
 		application_type: 'native'

--- a/src/vs/base/test/common/oauth.test.ts
+++ b/src/vs/base/test/common/oauth.test.ts
@@ -483,7 +483,7 @@ suite('OAuth', () => {
 			// Verify request body
 			const requestBody = JSON.parse(options.body as string);
 			assert.strictEqual(requestBody.client_name, 'Test Client');
-			assert.strictEqual(requestBody.client_uri, 'https://code.visualstudio.com');
+			assert.strictEqual(requestBody.client_uri, 'https://positron.posit.co');
 			assert.deepStrictEqual(requestBody.grant_types, ['authorization_code', 'refresh_token', 'urn:ietf:params:oauth:grant-type:device_code']);
 			assert.deepStrictEqual(requestBody.response_types, ['code']);
 			assert.deepStrictEqual(requestBody.redirect_uris, [
@@ -498,7 +498,7 @@ suite('OAuth', () => {
 		});
 
 		// --- Start Positron ---
-		test('fetchDynamicRegistration should append additional redirect URIs to the request', async () => {
+		test('fetchDynamicRegistration uses the supplied callback route as the redirect URI list', async () => {
 			fetchStub.resolves({
 				ok: true,
 				json: async () => ({
@@ -517,19 +517,16 @@ suite('OAuth', () => {
 				serverMetadata,
 				'Test Client',
 				undefined,
-				['https://workbench.example.com/positron/callback']
+				['https://workbench.example.com/positron-static/callback-0/static/out/vs/code/browser/workbench/callback.html']
 			);
 
 			const [, options] = fetchStub.firstCall.args;
 			const requestBody = JSON.parse(options.body as string);
 			assert.deepStrictEqual(requestBody.redirect_uris, [
-				'https://insiders.vscode.dev/redirect',
-				'https://vscode.dev/redirect',
-				'http://127.0.0.1/',
-				`http://127.0.0.1:${DEFAULT_AUTH_FLOW_PORT}/`,
-				'https://workbench.example.com/positron/callback'
+				'https://workbench.example.com/positron-static/callback-0/static/out/vs/code/browser/workbench/callback.html'
 			]);
 		});
+
 		// --- End Positron ---
 
 		test('fetchDynamicRegistration should throw error on non-OK response', async () => {

--- a/src/vs/base/test/common/oauth.test.ts
+++ b/src/vs/base/test/common/oauth.test.ts
@@ -483,7 +483,9 @@ suite('OAuth', () => {
 			// Verify request body
 			const requestBody = JSON.parse(options.body as string);
 			assert.strictEqual(requestBody.client_name, 'Test Client');
+			// --- Start Positron ---
 			assert.strictEqual(requestBody.client_uri, 'https://positron.posit.co');
+			// --- End Positron ---
 			assert.deepStrictEqual(requestBody.grant_types, ['authorization_code', 'refresh_token', 'urn:ietf:params:oauth:grant-type:device_code']);
 			assert.deepStrictEqual(requestBody.response_types, ['code']);
 			assert.deepStrictEqual(requestBody.redirect_uris, [
@@ -517,7 +519,7 @@ suite('OAuth', () => {
 				serverMetadata,
 				'Test Client',
 				undefined,
-				['https://workbench.example.com/positron-static/callback-0/static/out/vs/code/browser/workbench/callback.html']
+				'https://workbench.example.com/positron-static/callback-0/static/out/vs/code/browser/workbench/callback.html'
 			);
 
 			const [, options] = fetchStub.firstCall.args;

--- a/src/vs/server/node/positronStaticRoute.ts
+++ b/src/vs/server/node/positronStaticRoute.ts
@@ -7,3 +7,7 @@
 export function shouldUseSessionLessStaticRoute(isWorkbench: boolean, hasStaticRoute: boolean, quality: string | undefined): boolean {
 	return isWorkbench && hasStaticRoute && quality !== 'dailies';
 }
+
+export function shouldUseSessionLessStaticCallbackRoute(isWorkbench: boolean, hasStaticRoute: boolean): boolean {
+	return isWorkbench && hasStaticRoute;
+}

--- a/src/vs/server/node/pwbConstants.ts
+++ b/src/vs/server/node/pwbConstants.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 import { existsSync, readFileSync } from 'fs';
-import { dirname, join } from '../../base/common/path.js';
+import { dirname, join, posix } from '../../base/common/path.js';
 import { fileURLToPath } from 'url';
 export const kProxyRegex = new RegExp('\/proxy\/[0-9]+[^a-zA-Z](\/)?');
 
@@ -87,6 +87,18 @@ export function computeDeploymentPrefix(sessionUrl: string | undefined): string 
 }
 
 export const WORKBENCH_DEPLOYMENT_PREFIX = computeDeploymentPrefix(process.env['RS_SESSION_URL']);
+
+const OAUTH_CALLBACK_STATIC_SEGMENT = 'callback-0';
+
+export function resolveSessionlessStaticCallbackRoute(): string {
+	return posix.join(
+		WORKBENCH_DEPLOYMENT_PREFIX,
+		VSCODE_STATIC_PREFIX,
+		OAUTH_CALLBACK_STATIC_SEGMENT,
+		'static',
+		'out/vs/code/browser/workbench/callback.html'
+	);
+}
 // --- End PWB ---
 
 // --- Start PWB: Workbench 2026.05+ ships the nginx route for /<product-label>-static/...; ---

--- a/src/vs/server/node/webClientServer.ts
+++ b/src/vs/server/node/webClientServer.ts
@@ -34,13 +34,12 @@ import { ICSSDevelopmentService } from '../../platform/cssDev/node/cssDevService
 import httpProxy from 'http-proxy';
 // eslint-disable-next-line no-duplicate-imports
 import { existsSync } from 'fs';
-import { kProxyRegex, VSCODE_STATIC_PREFIX, WORKBENCH_DEPLOYMENT_PREFIX } from './pwbConstants.js';
+import { HAS_STATIC_ROUTE, kProxyRegex, resolveSessionlessStaticCallbackRoute, VSCODE_STATIC_PREFIX, WORKBENCH_DEPLOYMENT_PREFIX } from './pwbConstants.js';
 import { getListeningPortUid, isProxyPortOwnershipEnforced, ISocketOwnershipCheck } from './socketOwnership.js';
 import type * as net from 'net';
 // --- End PWB ---
 // --- Start Positron ---
-import { HAS_STATIC_ROUTE } from './pwbConstants.js';
-import { shouldUseSessionLessStaticRoute } from './positronStaticRoute.js';
+import { shouldUseSessionLessStaticCallbackRoute, shouldUseSessionLessStaticRoute } from './positronStaticRoute.js';
 import { IPositronAcademicLicenseService, licenseMarkerScript } from '../../platform/positronLicense/common/positronAcademicLicenseService.js';
 import { isSageMakerSession, sageMakerMarkerScript } from '../../platform/positronLicense/common/positronSageMakerSession.js';
 // --- End Positron ---
@@ -220,6 +219,10 @@ export class WebClientServer {
 	private get _useSessionLessStaticRoute(): boolean {
 		return shouldUseSessionLessStaticRoute(isWorkbench, HAS_STATIC_ROUTE, this._productService.quality);
 	}
+
+	private get _useSessionLessStaticCallbackRoute(): boolean {
+		return shouldUseSessionLessStaticCallbackRoute(isWorkbench, HAS_STATIC_ROUTE);
+	}
 	// --- End Positron ---
 
 	/**
@@ -231,19 +234,21 @@ export class WebClientServer {
 	 */
 	async handle(req: http.IncomingMessage, res: http.ServerResponse, parsedUrl: url.UrlWithParsedQuery, pathname: string): Promise<void> {
 		try {
+			// --- Start PWB ---
+			const sessionlessStaticCallbackRoute = resolveSessionlessStaticCallbackRoute();
+			const sessionlessStaticCallbackPath = sessionlessStaticCallbackRoute.substring(WORKBENCH_DEPLOYMENT_PREFIX.length);
+			if (this._useSessionLessStaticCallbackRoute && (pathname === sessionlessStaticCallbackRoute || pathname === sessionlessStaticCallbackPath)) {
+				return this._handleCallback(res);
+			}
+			// --- End PWB ---
 			// --- Start PWB: session-less static path (nginx serves these in prod; this is the dev fallback) ---
-			// URL shape: /<product-label>-static/<quality>-<commit>/static/<path>  →  serve APP_ROOT/<path>
-			// Only active when running under Workbench; standalone/dev code-server keeps the
-			// session-scoped /static/ route below.
 			if (this._useSessionLessStaticRoute && pathname.startsWith(VSCODE_STATIC_PREFIX) && pathname.charCodeAt(VSCODE_STATIC_PREFIX.length) === CharCode.Slash) {
-				const afterPrefix = pathname.substring(VSCODE_STATIC_PREFIX.length + 1); // strip "/<product-label>-static/"
+				const afterPrefix = pathname.substring(VSCODE_STATIC_PREFIX.length + 1);
 				const versionSlash = afterPrefix.indexOf('/');
 				if (versionSlash === -1) {
 					return serveError(req, res, 404, 'Not found.');
 				}
-				const afterVersion = afterPrefix.substring(versionSlash); // strip "<quality>-<commit>" → "/static/<path>"
-				// Mirror the validation the `/static/` route below uses: the remainder must start
-				// with `/static/` before we hand off to _handleStatic, which resolves relative to APP_ROOT.
+				const afterVersion = afterPrefix.substring(versionSlash);
 				if (afterVersion.startsWith(STATIC_PATH) && afterVersion.charCodeAt(STATIC_PATH.length) === CharCode.Slash) {
 					return this._handleStatic(req, res, afterVersion.substring(STATIC_PATH.length));
 				}
@@ -547,7 +552,11 @@ export class WebClientServer {
 		}
 
 		const staticRoute = posix.join(basePath, this._productPath, STATIC_PATH);
-		const callbackRoute = posix.join(basePath, this._productPath, CALLBACK_PATH);
+		// --- Start PWB ---
+		const callbackRoute = this._useSessionLessStaticCallbackRoute
+			? resolveSessionlessStaticCallbackRoute()
+			: posix.join(basePath, this._productPath, CALLBACK_PATH);
+		// --- End PWB ---
 		// --- Start PWB ---
 		// const webExtensionRoute = posix.join(basePath, this._productPath, WEB_EXTENSION_PATH);
 		// --- End PWB ---
@@ -826,6 +835,7 @@ export class WebClientServer {
 
 		res.writeHead(200, {
 			'Content-Type': 'text/html',
+			'Cache-Control': 'no-store',
 			'Content-Security-Policy': cspDirectives
 		});
 		return void res.end(data);

--- a/src/vs/server/test/node/pwbConstants.vitest.ts
+++ b/src/vs/server/test/node/pwbConstants.vitest.ts
@@ -6,6 +6,7 @@
 /// <reference types="vitest/globals" />
 
 import { computeDeploymentPrefix } from '../../node/pwbConstants.js';
+import { shouldUseSessionLessStaticCallbackRoute, shouldUseSessionLessStaticRoute } from '../../node/positronStaticRoute.js';
 
 describe('PWB computeDeploymentPrefix', () => {
 
@@ -41,5 +42,71 @@ describe('PWB computeDeploymentPrefix', () => {
 		expect(computeDeploymentPrefix('helio.local/s/a0b7e3c9ab5a7e6d5aeef/')).toBe('');
 		expect(computeDeploymentPrefix('https://helio.local')).toBe('');
 		expect(computeDeploymentPrefix('not-a-session-url')).toBe('');
+	});
+});
+
+type PwbConstantsModule = typeof import('../../node/pwbConstants.js');
+
+async function withSessionUrl<T>(sessionUrl: string | undefined, fn: (constants: PwbConstantsModule) => T | Promise<T>): Promise<T> {
+	const original = process.env['RS_SESSION_URL'];
+	if (sessionUrl === undefined) {
+		delete process.env['RS_SESSION_URL'];
+	} else {
+		process.env['RS_SESSION_URL'] = sessionUrl;
+	}
+	vi.resetModules();
+	try {
+		return await fn(await import('../../node/pwbConstants.js'));
+	} finally {
+		if (original === undefined) {
+			delete process.env['RS_SESSION_URL'];
+		} else {
+			process.env['RS_SESSION_URL'] = original;
+		}
+		vi.resetModules();
+	}
+}
+
+describe('resolveSessionlessStaticCallbackRoute', () => {
+	it('uses the existing sessionless static route with a stable callback segment', async () => {
+		await withSessionUrl(undefined, constants => {
+			expect(constants.resolveSessionlessStaticCallbackRoute())
+				.toBe('/positron-static/callback-0/static/out/vs/code/browser/workbench/callback.html');
+		});
+	});
+
+	it('keeps the Workbench deployment prefix', async () => {
+		await withSessionUrl('/rstudio/s/8791a6ae9dc1b037e055c/', constants => {
+			expect(constants.resolveSessionlessStaticCallbackRoute())
+				.toBe('/rstudio/positron-static/callback-0/static/out/vs/code/browser/workbench/callback.html');
+		});
+	});
+
+	it('does not include the Workbench session id', async () => {
+		const first = await withSessionUrl('/s/aaaaaaaaaaaaaaaaaaaaa/', constants => constants.resolveSessionlessStaticCallbackRoute());
+		const second = await withSessionUrl('/s/bbbbbbbbbbbbbbbbbbbbb/', constants => constants.resolveSessionlessStaticCallbackRoute());
+
+		expect({ first, second }).toEqual({
+			first: '/positron-static/callback-0/static/out/vs/code/browser/workbench/callback.html',
+			second: '/positron-static/callback-0/static/out/vs/code/browser/workbench/callback.html'
+		});
+	});
+});
+
+describe('sessionless static route gates', () => {
+	it('uses the static callback route for Workbench when the route is available', () => {
+		expect(shouldUseSessionLessStaticCallbackRoute(true, true)).toBe(true);
+		expect(shouldUseSessionLessStaticCallbackRoute(true, false)).toBe(false);
+		expect(shouldUseSessionLessStaticCallbackRoute(false, true)).toBe(false);
+	});
+
+	it('keeps the daily-build exception scoped to cacheable assets', () => {
+		expect({
+			callback: shouldUseSessionLessStaticCallbackRoute(true, true),
+			asset: shouldUseSessionLessStaticRoute(true, true, 'dailies')
+		}).toEqual({
+			callback: true,
+			asset: false
+		});
 	});
 });

--- a/src/vs/server/test/node/webClientServer.vitest.ts
+++ b/src/vs/server/test/node/webClientServer.vitest.ts
@@ -17,7 +17,7 @@ const originalEnv = vi.hoisted(() => {
 	};
 	globalThis._VSCODE_FILE_ROOT = new URL('../../../../..', import.meta.url).pathname;
 	process.env['RS_SERVER_URL'] = 'http://workbench.example.com';
-	process.env['RSTUDIO_VERSION'] = '2026.05.0';
+	process.env['RSTUDIO_VERSION'] = '2026.08.0';
 	return env;
 });
 

--- a/src/vs/server/test/node/webClientServer.vitest.ts
+++ b/src/vs/server/test/node/webClientServer.vitest.ts
@@ -10,15 +10,24 @@
 // agentHostServerMain.ts), which this plain Vitest run doesn't go through -- set it ourselves,
 // hoisted above the import so it's in place before webClientServer.ts's top-level code runs.
 // Avoids importing the `url` module here since vi.hoisted runs before this file's own imports.
-vi.hoisted(() => {
+const originalEnv = vi.hoisted(() => {
+	const env = {
+		RS_SERVER_URL: process.env['RS_SERVER_URL'],
+		RSTUDIO_VERSION: process.env['RSTUDIO_VERSION'],
+	};
 	globalThis._VSCODE_FILE_ROOT = new URL('../../../../..', import.meta.url).pathname;
+	process.env['RS_SERVER_URL'] = 'http://workbench.example.com';
+	process.env['RSTUDIO_VERSION'] = '2026.05.0';
+	return env;
 });
 
 // eslint-disable-next-line local/code-no-http-import
 import * as http from 'http';
 import * as net from 'net';
 import * as url from 'url';
+import { FileAccess } from '../../../base/common/network.js';
 import { mock, mockObject, upcastPartial } from '../../../base/test/common/mock.js';
+import { URI } from '../../../base/common/uri.js';
 import { ILogService, NullLogService } from '../../../platform/log/common/log.js';
 import { IServerEnvironmentService, ServerParsedArgs } from '../../node/serverEnvironmentService.js';
 import { IRequestService } from '../../../platform/request/common/request.js';
@@ -28,6 +37,19 @@ import { NoneServerConnectionToken } from '../../node/serverConnectionToken.js';
 import { WebClientServer } from '../../node/webClientServer.js';
 import { ISocketOwnershipCheck } from '../../node/socketOwnership.js';
 import { IPositronAcademicLicenseService } from '../../../platform/positronLicense/common/positronAcademicLicenseService.js';
+
+afterAll(() => {
+	if (originalEnv.RS_SERVER_URL === undefined) {
+		delete process.env['RS_SERVER_URL'];
+	} else {
+		process.env['RS_SERVER_URL'] = originalEnv.RS_SERVER_URL;
+	}
+	if (originalEnv.RSTUDIO_VERSION === undefined) {
+		delete process.env['RSTUDIO_VERSION'];
+	} else {
+		process.env['RSTUDIO_VERSION'] = originalEnv.RSTUDIO_VERSION;
+	}
+});
 
 // None of the tests below exercise real /proc reads -- getListeningPortUid/isProxyPortOwnershipEnforced
 // are stubbed via WebClientServer#setSocketOwnershipCheckForTesting -- so, unlike socketOwnership.vitest.ts,
@@ -65,13 +87,59 @@ function listen(server: http.Server | net.Server, port: number, host: string): P
 	});
 }
 
-describe('WebClientServer /proxy/ port ownership gate', () => {
+async function requestPath(webClientServer: WebClientServer, pathname: string): Promise<{ status: number | undefined; headers: http.IncomingHttpHeaders; body: string }> {
+	const frontServer = http.createServer((req, res) => {
+		const parsedUrl = url.parse(req.url!, true);
+		webClientServer.handle(req, res, parsedUrl, parsedUrl.pathname!);
+	});
+	try {
+		await listen(frontServer, 0, '127.0.0.1');
+		const { port } = frontServer.address() as net.AddressInfo;
+		return await new Promise((resolve, reject) => {
+			http.get(`http://127.0.0.1:${port}${pathname}`, res => {
+				let body = '';
+				res.on('data', chunk => body += chunk);
+				res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body }));
+			}).on('error', reject);
+		});
+	} finally {
+		frontServer.close();
+	}
+}
 
+describe('WebClientServer /proxy/ port ownership gate', () => {
 	beforeEach(() => {
 		vi.spyOn(process, 'getuid').mockReturnValue(ourUid);
 	});
 
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	describe('handle()', () => {
+
+		it('serves the sessionless static callback through the callback handler', async () => {
+			const webClientServer = createWebClientServer({
+				getListeningPortUid: vi.fn(),
+				isProxyPortOwnershipEnforced: vi.fn().mockReturnValue(false),
+			});
+			const callbackFile = URI.file(`${process.cwd()}/src/vs/code/browser/workbench/callback.html`);
+			vi.spyOn(FileAccess, 'asFileUri').mockReturnValue(callbackFile);
+
+			const response = await requestPath(webClientServer, '/positron-static/callback-0/static/out/vs/code/browser/workbench/callback.html');
+
+			expect({
+				status: response.status,
+				cacheControl: response.headers['cache-control'],
+				hasCallbackCsp: typeof response.headers['content-security-policy'] === 'string',
+				hasCallbackBody: response.body.includes('vscode-web.url-callbacks'),
+			}).toEqual({
+				status: 200,
+				cacheControl: 'no-store',
+				hasCallbackCsp: true,
+				hasCallbackBody: true,
+			});
+		});
 
 		it('rejects with 403 when the port is owned by another uid, and logs a warning', async () => {
 			const ownershipCheck: ISocketOwnershipCheck = {

--- a/src/vs/workbench/api/common/extHostAuthentication.ts
+++ b/src/vs/workbench/api/common/extHostAuthentication.ts
@@ -277,7 +277,7 @@ export class ExtHostAuthentication implements ExtHostAuthenticationShape {
 					// forward to hosts outside its allowlist).
 					// const registration = await fetchDynamicRegistration(serverMetadata, this._initData.environment.appName, resourceMetadata?.scopes_supported);
 					const registrationRedirectUri = await getRegistrationRedirectUri(this._extHostUrls, this._initData.environment.appUriScheme, this._logService);
-					const registration = await fetchDynamicRegistration(serverMetadata, this._initData.environment.appName, resourceMetadata?.scopes_supported, registrationRedirectUri ? [registrationRedirectUri] : undefined);
+					const registration = await fetchDynamicRegistration(serverMetadata, this._initData.environment.appName, resourceMetadata?.scopes_supported, registrationRedirectUri);
 					// --- End Positron ---
 					clientId = registration.client_id;
 					clientSecret = registration.client_secret;
@@ -871,7 +871,7 @@ export class DynamicAuthProvider implements vscode.AuthenticationProvider {
 			// $registerDynamicAuthProvider.
 			// const registration = await fetchDynamicRegistration(this._serverMetadata, this._initData.environment.appName, this._resourceMetadata?.scopes_supported);
 			const registrationRedirectUri = await getRegistrationRedirectUri(this._extHostUrls, this._initData.environment.appUriScheme, this._logger);
-			const registration = await fetchDynamicRegistration(this._serverMetadata, this._initData.environment.appName, this._resourceMetadata?.scopes_supported, registrationRedirectUri ? [registrationRedirectUri] : undefined);
+			const registration = await fetchDynamicRegistration(this._serverMetadata, this._initData.environment.appName, this._resourceMetadata?.scopes_supported, registrationRedirectUri);
 			// --- End Positron ---
 			this._clientId = registration.client_id;
 			this._clientSecret = registration.client_secret;


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/15448

Fixes fixes MCP server OAuth sign-in on Posit Workbench when the MCP server uses Dynamic Client Registration.

Do not close the issue on merge.  Full validation requires this change to land in a Positron daily on `https://workbench.agave.pwb.posit.it/`, because our test Atlassian MCP server can only be configured for that site. After validation, i'll backport relevant changes to vscode-server.

### Summary

MCP servers that use DCR require the authorization `redirect_uri` to match one of the redirect URIs registered for the client. In Workbench, Positron's OAuth flow needed to redirect back to a Workbench-hosted callback URL, but DCR still advertised the existing default redirect URIs instead of a valid Workbench callback. OAuth servers that validate redirect URIs therefore rejected the flow, causing MCP authorization to fail.

This PR gives Workbench MCP OAuth a stable same-origin callback URL and registers that same URL during DCR. That makes the registered MCP client and the authorization request agree on the callback URL, and lets the registration remain valid across Workbench sessions.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed MCP server OAuth sign-in failures on Posit Workbench when Dynamic Client Registration requires an exact callback URL match.

### Validation Steps

@:workbench @:web

Automated checks:

```bash
npx vitest run src/vs/server/test/node/webClientServer.vitest.ts src/vs/server/test/node/pwbConstants.vitest.ts src/vs/workbench/api/test/common/positron/extHostOAuthRedirect.vitest.ts
./scripts/test.sh --run src/vs/base/test/common/oauth.test.ts --grep "fetchDynamicRegistration"
```

Manual Workbench verification:

1. Start Positron in Workbench
2. Confirm the web configuration callback route is `/positron-static/callback-0/static/out/vs/code/browser/workbench/callback.html`, with any deployment prefix before `/positron-static`.
3. Open that callback route directly and confirm it serves the OAuth callback page without a session prefix.
4. Authorize an MCP server.
5. Start a new Workbench session on the same origin and authorize the same MCP server again.
6. Confirm the cached dynamic client registration is reused without `redirect_uri_mismatch`.

Post-merge daily verification:

1. Wait for a Positron daily containing this change to be available on `https://workbench.agave.pwb.posit.it/`.
2. In that environment, authorize an Atlassian MCP server.
3. Start a new Workbench session on the same origin and authorize the same Atlassian MCP server again.
4. Confirm the cached dynamic client registration is reused without `redirect_uri_mismatch`.

Manual standalone web verification:

1. Start Positron Server outside Workbench
2. Confirm dynamic registration uses the server's own callback URL rather than a Workbench static route.
3. Authorize an MCP server and confirm the OAuth redirect returns to the active Positron Server session.
