### PR TITLE
Remove the Databricks workspace URL prompt and clear stale connect errors

### DIFF
--- a/extensions/authentication/src/databricksAuthProvider.ts
+++ b/extensions/authentication/src/databricksAuthProvider.ts
@@ -97,7 +97,7 @@ export class DatabricksAuthProvider extends AuthProvider {
 			return chainSessionBeforeHost;
 		}
 
-		const host = normalizeHost(await this.resolveHost());
+		const host = normalizeHost(this.resolveHost());
 		await this.persistHostSetting(host);
 
 		// If the chain failed only because no host was configured (e.g.
@@ -290,32 +290,21 @@ export class DatabricksAuthProvider extends AuthProvider {
 	// --- Helpers ---
 
 	/**
-	 * Resolve the workspace host from the provider catalog, then prompt the
-	 * user. The catalog already folds in the DATABRICKS_HOST env var and the
-	 * legacy `authentication.databricks.credentials` setting, so both are
-	 * covered by the single read.
+	 * Resolve the workspace host from the provider catalog. The catalog already
+	 * folds in the DATABRICKS_HOST env var and the legacy
+	 * `authentication.databricks.credentials` setting, so both are covered by the
+	 * single read, and the config dialog persists the Workspace URL the user
+	 * typed before it calls createSession. So by this point the host has been
+	 * supplied or it is not coming, and a missing one is an error to report
+	 * rather than something to ask for.
 	 */
-	private async resolveHost(): Promise<string> {
+	private resolveHost(): string {
 		const configuredHost = getCachedProvider('databricks')
 			?.connection.databricks?.host?.trim();
-		if (configuredHost) {
-			return configuredHost;
-		}
-
-		const input = await vscode.window.showInputBox({
-			prompt: vscode.l10n.t(
-				'Enter your Databricks workspace URL (e.g. https://adb-1234567890123456.7.azuredatabricks.net)'
-			),
-			ignoreFocusOut: true,
-			validateInput: value => value.trim()
-				? undefined
-				: vscode.l10n.t('A workspace URL is required'),
-		});
-		const host = input?.trim();
-		if (!host) {
+		if (!configuredHost) {
 			throw new Error(vscode.l10n.t('A Databricks workspace URL is required'));
 		}
-		return host;
+		return configuredHost;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
@@ -115,6 +115,13 @@ export const ConnectProviderView = (props: ConnectProviderViewProps) => {
 
 	const methods = availableAuthMethods(props.source);
 	const [selectedMethod, setSelectedMethod] = useState<AuthMethod | undefined>(undefined);
+
+	// Switching method drops the last failure, which belonged to the method the user
+	// just moved away from. The field values stay: the user may be coming back.
+	const onSelectMethod = (method: AuthMethod) => {
+		setSelectedMethod(method);
+		setErrorMessage(undefined);
+	};
 	const authMethod = deriveAuthMethod(props.source, selectedMethod);
 	const authStatus = deriveAuthStatus(props.source, { showProgress: inFlight, apiKey, selected: selectedMethod });
 
@@ -207,7 +214,7 @@ export const ConnectProviderView = (props: ConnectProviderViewProps) => {
 										name='connect-provider-auth-method'
 										type='radio'
 										value={method}
-										onChange={() => setSelectedMethod(method)}
+										onChange={() => onSelectMethod(method)}
 									/>
 									{method === AuthMethod.OAUTH
 										? localize('positron.connectProvider.oauth', "OAuth")

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/connectProviderView.vitest.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/connectProviderView.vitest.tsx
@@ -344,6 +344,21 @@ describe('ConnectProviderView', () => {
 			expect(screen.getByLabelText(/api key/i, { selector: 'input[type="password"]' })).toBeInTheDocument();
 		});
 
+		it('clears a failed sign-in message when the method changes, keeping what was typed', async () => {
+			const onAction = vi.fn().mockRejectedValue(new Error('Bad workspace URL'));
+			const user = userEvent.setup();
+			rtl.render(<ConnectProviderView {...dialogProps()} source={databricksOAuth} onAction={onAction} onBack={vi.fn()} />);
+			await user.type(screen.getByLabelText('Workspace URL'), '/typed');
+			await user.click(screen.getByRole('button', { name: 'Connect' }));
+			expect(await screen.findByText('Bad workspace URL')).toBeInTheDocument();
+
+			// The failure belonged to the method the user just left, so it goes; the
+			// workspace URL is still theirs.
+			await user.click(screen.getByRole('radio', { name: 'API Key' }));
+			expect(screen.queryByText('Bad workspace URL')).not.toBeInTheDocument();
+			expect(screen.getByLabelText('Workspace URL')).toHaveValue('https://workspace.example.com/typed');
+		});
+
 		it('keeps the workspace URL field visible under both methods', async () => {
 			const user = userEvent.setup();
 			rtl.render(<ConnectProviderView {...dialogProps()} source={databricksOAuth} onAction={async () => { }} onBack={vi.fn()} />);


### PR DESCRIPTION
Two bugs in the Databricks connect flow, both found while testing the modal changes in the PR below this one.

- Connecting without a workspace URL opened a prompt asking for one, and that prompt could not be dismissed. It should never have been part of the flow: the dialog already has a Workspace URL field. A missing URL is now reported in the dialog instead.
- Switching between OAuth and API Key left the previous attempt's error message on screen.

Note: the prompt being impossible to dismiss is a separate bug that this PR does not fix. It stops this flow from reaching it.

### Screenshots

**BEFORE**


https://github.com/user-attachments/assets/15dab9b9-48d8-4a82-9cee-64219793673c


**AFTER - no quickpick and errors get cleared when login method changes**


https://github.com/user-attachments/assets/420ab08c-e360-47a4-8503-8afdb02129b6





### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Connecting to Databricks no longer prompts for a workspace URL
- The Configure LLM Providers dialog clears its error when you switch authentication method


### Validation Steps

1. Run **Configure Language Model Providers**, select **Databricks**, leave **Workspace URL** empty and press **Connect**. No prompt appears, and the dialog reports "A Databricks workspace URL is required".
2. With that error showing, select **API Key**. The error clears and the Workspace URL keeps what you typed.
