### PR TITLE
Add link to tutorials on Help home page

### DIFF
--- a/src/vs/workbench/contrib/positronHelp/browser/resources/welcome.html
+++ b/src/vs/workbench/contrib/positronHelp/browser/resources/welcome.html
@@ -50,6 +50,9 @@
 			<div>
 				<ul>
 					<li><a href="__positronDocsUrl__">Positron Documentation</a></li>
+					<!-- Absolute URL on purpose: the tutorials are excluded from the self-hosted
+					Workbench docs bundle, so this cannot follow the configured docs base URL. -->
+					<li><a href="https://positron.posit.co/tutorials.html">Positron Tutorials</a></li>
 					<li><a href="https://github.com/posit-dev/positron/discussions">Positron Community Forum</a></li>
 					<li><a href="command:workbench.action.openIssueReporter">Report a Bug in Positron</a></li>
 					<li><a href="https://posit.co/positron-updates-signup/">Sign Up for Positron Updates</a></li>


### PR DESCRIPTION
The Help pane welcome page now has a link to the Positron tutorials.

The link uses the absolute public URL `https://positron.posit.co/tutorials.html`. The Positron Documentation link on the same page works differently. It follows the configured docs base URL, which Posit Workbench can override with `POSITRON_DOCS_URL` to serve a local docs bundle. The tutorials are not in that bundle (see the render list in `_quarto-workbench.yml` in the positron-website repo) because the videos in those tutorials are considered too important to their content, and the Workbench bundles don't include videos. A base-relative link _here_ therefore returns a 404 for Workbench users. A comment in the HTML records this reason, so a later change does not switch the link to the placeholder.

The new link is directly below Positron Documentation, in the group of Positron resources above the divider:

<img width="1375" height="981" alt="Screenshot 2026-08-26 at 2 59 35 PM" src="https://github.com/user-attachments/assets/8ca73e89-19b2-40ba-84f2-4002ed7b7fca" />

### Release Notes

#### New Features
- Added a link to the Positron tutorials on the Help pane welcome page.

#### Bug Fixes
- N/A

### Validation Steps

@:help @:web

1. Open the Help pane.
2. Make sure that the welcome page shows a "Positron Tutorials" link below "Positron Documentation".
3. Click the link. Make sure that it opens https://positron.posit.co/tutorials.html in a browser.

This PR adds no tests. The existing landing page test in `test/e2e/tests/help/help.test.ts` makes assertions about the name and href of two other links. It does not count list items, so the new link does not change the result.
