### PR TITLE
Fix Assistant provider validation custom headers

### DIFF
--- a/extensions/authentication/src/test/anthropic.test.ts
+++ b/extensions/authentication/src/test/anthropic.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import * as positron from 'positron';
 import { validateAnthropicApiKey } from '../validation/anthropic';
-import { initializeValidationCatalog } from './validationTestUtils';
+import { stubValidationCatalog } from './validationTestUtils';
 
 suite('validateAnthropicApiKey', () => {
 	let originalFetch: typeof globalThis.fetch;
@@ -65,7 +65,7 @@ suite('validateAnthropicApiKey', () => {
 	});
 
 	test('sends configured headers on the initial request and retry', async () => {
-		const catalog = await initializeValidationCatalog({
+		const catalog = stubValidationCatalog({
 			anthropic: {
 				customHeaders: { 'X-Gateway-Token': 'gateway-key' },
 			},
@@ -84,7 +84,7 @@ suite('validateAnthropicApiKey', () => {
 				makeConfig('https://api.anthropic.com')
 			);
 		} finally {
-			await catalog.dispose();
+			catalog.restore();
 		}
 
 		assert.deepStrictEqual(

--- a/extensions/authentication/src/test/anthropic.test.ts
+++ b/extensions/authentication/src/test/anthropic.test.ts
@@ -6,6 +6,7 @@
 import * as assert from 'assert';
 import * as positron from 'positron';
 import { validateAnthropicApiKey } from '../validation/anthropic';
+import { initializeValidationCatalog } from './validationTestUtils';
 
 suite('validateAnthropicApiKey', () => {
 	let originalFetch: typeof globalThis.fetch;
@@ -61,6 +62,35 @@ suite('validateAnthropicApiKey', () => {
 		assert.strictEqual(requestedUrls.length, 2);
 		assert.strictEqual(requestedUrls[0], 'https://api.anthropic.com/models');
 		assert.strictEqual(requestedUrls[1], 'https://api.anthropic.com/v1/models');
+	});
+
+	test('sends configured headers on the initial request and retry', async () => {
+		const catalog = await initializeValidationCatalog({
+			anthropic: {
+				customHeaders: { 'X-Gateway-Token': 'gateway-key' },
+			},
+		});
+		const requestedHeaders: Record<string, string>[] = [];
+		let callCount = 0;
+		globalThis.fetch = async (_url, init) => {
+			requestedHeaders.push(init?.headers as Record<string, string>);
+			callCount++;
+			return { ok: callCount > 1, status: callCount === 1 ? 404 : 200 } as Response;
+		};
+
+		try {
+			await validateAnthropicApiKey(
+				'sk-ant-valid',
+				makeConfig('https://api.anthropic.com')
+			);
+		} finally {
+			await catalog.dispose();
+		}
+
+		assert.deepStrictEqual(
+			requestedHeaders.map(headers => headers['X-Gateway-Token']),
+			['gateway-key', 'gateway-key']
+		);
 	});
 
 	test('does not fall back on 401 auth error', async () => {

--- a/extensions/authentication/src/test/customProvider.test.ts
+++ b/extensions/authentication/src/test/customProvider.test.ts
@@ -8,7 +8,7 @@ import * as sinon from 'sinon';
 import * as positron from 'positron';
 import { validateCustomProviderApiKey } from '../validation/customProvider';
 import { log } from '../log';
-import { initializeValidationCatalog } from './validationTestUtils';
+import { stubValidationCatalog } from './validationTestUtils';
 
 suite('validateCustomProviderApiKey', () => {
 	let originalFetch: typeof globalThis.fetch;
@@ -56,7 +56,7 @@ suite('validateCustomProviderApiKey', () => {
 	});
 
 	test('merges configured headers without replacing base headers', async () => {
-		const catalog = await initializeValidationCatalog({
+		const catalog = stubValidationCatalog({
 			'openai-compatible': {
 				customHeaders: {
 					'Ocp-Apim-Subscription-Key': 'gateway-key',
@@ -69,7 +69,7 @@ suite('validateCustomProviderApiKey', () => {
 		try {
 			await validateCustomProviderApiKey('sk-test', makeConfig());
 		} finally {
-			await catalog.dispose();
+			catalog.restore();
 		}
 
 		assert.deepStrictEqual(requestedHeaders[0], {

--- a/extensions/authentication/src/test/customProvider.test.ts
+++ b/extensions/authentication/src/test/customProvider.test.ts
@@ -8,15 +8,18 @@ import * as sinon from 'sinon';
 import * as positron from 'positron';
 import { validateCustomProviderApiKey } from '../validation/customProvider';
 import { log } from '../log';
+import { initializeValidationCatalog } from './validationTestUtils';
 
 suite('validateCustomProviderApiKey', () => {
 	let originalFetch: typeof globalThis.fetch;
 	let requestedBodies: string[];
+	let requestedHeaders: Record<string, string>[];
 	let logWarnStub: sinon.SinonStub;
 
 	setup(() => {
 		originalFetch = globalThis.fetch;
 		requestedBodies = [];
+		requestedHeaders = [];
 		logWarnStub = sinon.stub(log, 'warn');
 	});
 
@@ -32,6 +35,7 @@ suite('validateCustomProviderApiKey', () => {
 	function stubFetch(status: number, body = ''): void {
 		globalThis.fetch = async (_url, init) => {
 			requestedBodies.push((init?.body as string) ?? '');
+			requestedHeaders.push(init?.headers as Record<string, string>);
 			return {
 				ok: status >= 200 && status < 300,
 				status,
@@ -49,6 +53,36 @@ suite('validateCustomProviderApiKey', () => {
 			model: 'positron-connectivity-check',
 			messages: [],
 		});
+	});
+
+	test('merges configured headers without replacing base headers', async () => {
+		const catalog = await initializeValidationCatalog({
+			'openai-compatible': {
+				customHeaders: {
+					'Ocp-Apim-Subscription-Key': 'gateway-key',
+					authorization: 'configured-auth',
+				},
+			},
+		});
+		stubFetch(200);
+
+		try {
+			await validateCustomProviderApiKey('sk-test', makeConfig());
+		} finally {
+			await catalog.dispose();
+		}
+
+		assert.deepStrictEqual(requestedHeaders[0], {
+			'Content-Type': 'application/json',
+			'Authorization': 'Bearer sk-test',
+			'Ocp-Apim-Subscription-Key': 'gateway-key',
+		});
+		assert.deepStrictEqual(
+			logWarnStub.args.map(args => args[0]),
+			[
+				'[Validation] Skipping configured header "authorization" for provider "openai-compatible" because the validation request already defines it.',
+			]
+		);
 	});
 
 	test('rejects a 401 whose body points at the key', async () => {

--- a/extensions/authentication/src/test/deepseek.test.ts
+++ b/extensions/authentication/src/test/deepseek.test.ts
@@ -9,7 +9,7 @@ import * as positron from 'positron';
 import { validateDeepSeekApiKey } from '../validation/deepseek';
 import { KEY_VALIDATION_TIMEOUT_MS } from '../constants';
 import { log } from '../log';
-import { initializeValidationCatalog } from './validationTestUtils';
+import { stubValidationCatalog } from './validationTestUtils';
 
 suite('validateDeepSeekApiKey', () => {
 	let originalFetch: typeof globalThis.fetch;
@@ -70,7 +70,7 @@ suite('validateDeepSeekApiKey', () => {
 	});
 
 	test('uses the deepseek catalog id and matches collisions case-insensitively', async () => {
-		const catalog = await initializeValidationCatalog({
+		const catalog = stubValidationCatalog({
 			deepseek: {
 				customHeaders: {
 					'X-Gateway-Token': 'gateway-key',
@@ -87,7 +87,7 @@ suite('validateDeepSeekApiKey', () => {
 		try {
 			await validateDeepSeekApiKey('sk-valid', makeConfig());
 		} finally {
-			await catalog.dispose();
+			catalog.restore();
 		}
 
 		assert.deepStrictEqual(requestedHeaders[0], {

--- a/extensions/authentication/src/test/deepseek.test.ts
+++ b/extensions/authentication/src/test/deepseek.test.ts
@@ -8,6 +8,8 @@ import * as sinon from 'sinon';
 import * as positron from 'positron';
 import { validateDeepSeekApiKey } from '../validation/deepseek';
 import { KEY_VALIDATION_TIMEOUT_MS } from '../constants';
+import { log } from '../log';
+import { initializeValidationCatalog } from './validationTestUtils';
 
 suite('validateDeepSeekApiKey', () => {
 	let originalFetch: typeof globalThis.fetch;
@@ -65,6 +67,37 @@ suite('validateDeepSeekApiKey', () => {
 		await validateDeepSeekApiKey('sk-valid', makeConfig('https://proxy.example.com/v1'));
 
 		assert.strictEqual(requestedUrls[0], 'https://proxy.example.com/v1/models');
+	});
+
+	test('uses the deepseek catalog id and matches collisions case-insensitively', async () => {
+		const catalog = await initializeValidationCatalog({
+			deepseek: {
+				customHeaders: {
+					'X-Gateway-Token': 'gateway-key',
+					AUTHORIZATION: 'configured-auth',
+				},
+			},
+		});
+		const warn = sinon.stub(log, 'warn');
+		globalThis.fetch = async (_url, init) => {
+			requestedHeaders.push(init?.headers as Record<string, string>);
+			return { ok: true, status: 200 } as Response;
+		};
+
+		try {
+			await validateDeepSeekApiKey('sk-valid', makeConfig());
+		} finally {
+			await catalog.dispose();
+		}
+
+		assert.deepStrictEqual(requestedHeaders[0], {
+			'Authorization': 'Bearer sk-valid',
+			'X-Gateway-Token': 'gateway-key',
+		});
+		assert.strictEqual(
+			warn.firstCall.args[0],
+			'[Validation] Skipping configured header "AUTHORIZATION" for provider "deepseek" because the validation request already defines it.'
+		);
 	});
 
 	test('strips trailing slashes from baseUrl', async () => {

--- a/extensions/authentication/src/test/gemini.test.ts
+++ b/extensions/authentication/src/test/gemini.test.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { validateGeminiApiKey } from '../validation/gemini';
+import { initializeValidationCatalog } from './validationTestUtils';
+
+suite('validateGeminiApiKey custom headers', () => {
+	test('sends configured headers from the gemini catalog entry', async () => {
+		const catalog = await initializeValidationCatalog({
+			gemini: {
+				customHeaders: { 'Ocp-Apim-Subscription-Key': 'gateway-key' },
+			},
+		});
+		const originalFetch = globalThis.fetch;
+		let requestedHeaders: Record<string, string> | undefined;
+		globalThis.fetch = async (_url, init) => {
+			requestedHeaders = init?.headers as Record<string, string>;
+			return { ok: true, status: 200 } as Response;
+		};
+
+		try {
+			await validateGeminiApiKey('gemini-key', {});
+		} finally {
+			globalThis.fetch = originalFetch;
+			await catalog.dispose();
+		}
+
+		assert.strictEqual(
+			requestedHeaders?.['Ocp-Apim-Subscription-Key'],
+			'gateway-key'
+		);
+	});
+});

--- a/extensions/authentication/src/test/gemini.test.ts
+++ b/extensions/authentication/src/test/gemini.test.ts
@@ -5,11 +5,11 @@
 
 import * as assert from 'assert';
 import { validateGeminiApiKey } from '../validation/gemini';
-import { initializeValidationCatalog } from './validationTestUtils';
+import { stubValidationCatalog } from './validationTestUtils';
 
 suite('validateGeminiApiKey custom headers', () => {
 	test('sends configured headers from the gemini catalog entry', async () => {
-		const catalog = await initializeValidationCatalog({
+		const catalog = stubValidationCatalog({
 			gemini: {
 				customHeaders: { 'Ocp-Apim-Subscription-Key': 'gateway-key' },
 			},
@@ -25,7 +25,7 @@ suite('validateGeminiApiKey custom headers', () => {
 			await validateGeminiApiKey('gemini-key', {});
 		} finally {
 			globalThis.fetch = originalFetch;
-			await catalog.dispose();
+			catalog.restore();
 		}
 
 		assert.strictEqual(

--- a/extensions/authentication/src/test/openai.test.ts
+++ b/extensions/authentication/src/test/openai.test.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { validateOpenaiApiKey } from '../validation/openai';
+import { initializeValidationCatalog } from './validationTestUtils';
+
+suite('validateOpenaiApiKey custom headers', () => {
+	test('sends configured headers from the openai catalog entry', async () => {
+		const catalog = await initializeValidationCatalog({
+			openai: {
+				customHeaders: { 'X-Gateway-Token': 'gateway-key' },
+			},
+		});
+		const originalFetch = globalThis.fetch;
+		let requestedHeaders: Record<string, string> | undefined;
+		globalThis.fetch = async (_url, init) => {
+			requestedHeaders = init?.headers as Record<string, string>;
+			return { ok: true, status: 200 } as Response;
+		};
+
+		try {
+			await validateOpenaiApiKey('openai-key', {});
+		} finally {
+			globalThis.fetch = originalFetch;
+			await catalog.dispose();
+		}
+
+		assert.strictEqual(requestedHeaders?.['X-Gateway-Token'], 'gateway-key');
+	});
+});

--- a/extensions/authentication/src/test/openai.test.ts
+++ b/extensions/authentication/src/test/openai.test.ts
@@ -5,11 +5,11 @@
 
 import * as assert from 'assert';
 import { validateOpenaiApiKey } from '../validation/openai';
-import { initializeValidationCatalog } from './validationTestUtils';
+import { stubValidationCatalog } from './validationTestUtils';
 
 suite('validateOpenaiApiKey custom headers', () => {
 	test('sends configured headers from the openai catalog entry', async () => {
-		const catalog = await initializeValidationCatalog({
+		const catalog = stubValidationCatalog({
 			openai: {
 				customHeaders: { 'X-Gateway-Token': 'gateway-key' },
 			},
@@ -25,7 +25,7 @@ suite('validateOpenaiApiKey custom headers', () => {
 			await validateOpenaiApiKey('openai-key', {});
 		} finally {
 			globalThis.fetch = originalFetch;
-			await catalog.dispose();
+			catalog.restore();
 		}
 
 		assert.strictEqual(requestedHeaders?.['X-Gateway-Token'], 'gateway-key');

--- a/extensions/authentication/src/test/validationTestUtils.ts
+++ b/extensions/authentication/src/test/validationTestUtils.ts
@@ -13,6 +13,11 @@ interface ValidationCatalogFixture {
 	dispose(): Promise<void>;
 }
 
+/** Minimal ExtensionContext stub: only `subscriptions` is read by initProviderCatalog. */
+function fakeContext(): vscode.ExtensionContext {
+	return { subscriptions: [] } as unknown as vscode.ExtensionContext;
+}
+
 export async function initializeValidationCatalog(
 	providers: Record<string, unknown>
 ): Promise<ValidationCatalogFixture> {
@@ -20,8 +25,7 @@ export async function initializeValidationCatalog(
 	const configPath = path.join(directory, 'providers.json');
 	fs.writeFileSync(configPath, JSON.stringify({ version: 1, providers }));
 
-	// eslint-disable-next-line local/code-no-dangerous-type-assertions
-	const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+	const context = fakeContext();
 	await initProviderCatalog(context, { configPath });
 
 	return {
@@ -31,8 +35,7 @@ export async function initializeValidationCatalog(
 			}
 
 			fs.writeFileSync(configPath, JSON.stringify({ version: 1, providers: {} }));
-			// eslint-disable-next-line local/code-no-dangerous-type-assertions
-			const resetContext = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+			const resetContext = fakeContext();
 			await initProviderCatalog(resetContext, { configPath });
 			for (const disposable of resetContext.subscriptions) {
 				disposable.dispose();

--- a/extensions/authentication/src/test/validationTestUtils.ts
+++ b/extensions/authentication/src/test/validationTestUtils.ts
@@ -3,44 +3,25 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
-import * as vscode from 'vscode';
-import { initProviderCatalog } from '../providerCatalog';
+import * as sinon from 'sinon';
+import * as providerCatalog from '../providerCatalog';
 
-interface ValidationCatalogFixture {
-	dispose(): Promise<void>;
+interface ValidationProvider {
+	readonly customHeaders?: Record<string, string>;
 }
 
-/** Minimal ExtensionContext stub: only `subscriptions` is read by initProviderCatalog. */
-function fakeContext(): vscode.ExtensionContext {
-	return { subscriptions: [] } as unknown as vscode.ExtensionContext;
-}
-
-export async function initializeValidationCatalog(
-	providers: Record<string, unknown>
-): Promise<ValidationCatalogFixture> {
-	const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'validation-headers-'));
-	const configPath = path.join(directory, 'providers.json');
-	fs.writeFileSync(configPath, JSON.stringify({ version: 1, providers }));
-
-	const context = fakeContext();
-	await initProviderCatalog(context, { configPath });
-
-	return {
-		async dispose() {
-			for (const disposable of context.subscriptions) {
-				disposable.dispose();
-			}
-
-			fs.writeFileSync(configPath, JSON.stringify({ version: 1, providers: {} }));
-			const resetContext = fakeContext();
-			await initProviderCatalog(resetContext, { configPath });
-			for (const disposable of resetContext.subscriptions) {
-				disposable.dispose();
-			}
-			fs.rmSync(directory, { recursive: true, force: true });
-		},
-	};
+export function stubValidationCatalog(
+	providers: Record<string, ValidationProvider>
+): sinon.SinonStub {
+	return sinon.stub(providerCatalog, 'getCachedProvider').callsFake(catalogId => {
+		const provider = providers[catalogId];
+		if (!provider) {
+			return undefined;
+		}
+		return {
+			id: catalogId,
+			enabled: true,
+			connection: { customHeaders: provider.customHeaders },
+		};
+	});
 }

--- a/extensions/authentication/src/test/validationTestUtils.ts
+++ b/extensions/authentication/src/test/validationTestUtils.ts
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { initProviderCatalog } from '../providerCatalog';
+
+interface ValidationCatalogFixture {
+	dispose(): Promise<void>;
+}
+
+export async function initializeValidationCatalog(
+	providers: Record<string, unknown>
+): Promise<ValidationCatalogFixture> {
+	const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'validation-headers-'));
+	const configPath = path.join(directory, 'providers.json');
+	fs.writeFileSync(configPath, JSON.stringify({ version: 1, providers }));
+
+	// eslint-disable-next-line local/code-no-dangerous-type-assertions
+	const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+	await initProviderCatalog(context, { configPath });
+
+	return {
+		async dispose() {
+			for (const disposable of context.subscriptions) {
+				disposable.dispose();
+			}
+
+			fs.writeFileSync(configPath, JSON.stringify({ version: 1, providers: {} }));
+			// eslint-disable-next-line local/code-no-dangerous-type-assertions
+			const resetContext = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+			await initProviderCatalog(resetContext, { configPath });
+			for (const disposable of resetContext.subscriptions) {
+				disposable.dispose();
+			}
+			fs.rmSync(directory, { recursive: true, force: true });
+		},
+	};
+}

--- a/extensions/authentication/src/validation/anthropic.ts
+++ b/extensions/authentication/src/validation/anthropic.ts
@@ -16,6 +16,15 @@ class ApiKeyValidationError extends Error {
 	}
 }
 
+async function getAnthropicErrorMessage(response: Response): Promise<string | undefined> {
+	try {
+		const body = await response.json() as { error?: { message?: string } };
+		return body?.error?.message;
+	} catch {
+		return undefined;
+	}
+}
+
 export async function validateAnthropicApiKey(apiKey: string, config: positron.ai.LanguageModelConfig): Promise<void> {
 	const baseUrl = (config.baseUrl?.trim() || ANTHROPIC_DEFAULT_BASE_URL).replace(/\/+$/, '');
 	const modelsEndpoint = `${baseUrl}/models`;
@@ -57,7 +66,8 @@ export async function validateAnthropicApiKey(apiKey: string, config: positron.a
 		// Skip the retry if the URL already ends with /v1 to avoid /v1/v1/models.
 		if (baseUrl.endsWith('/v1')) {
 			if (firstResponse) {
-				throw new ApiKeyValidationError(vscode.l10n.t(
+				const errorMessage = await getAnthropicErrorMessage(firstResponse);
+				throw new ApiKeyValidationError(errorMessage ?? vscode.l10n.t(
 					'Unable to validate Anthropic API key (HTTP {0})',
 					String(firstResponse.status)
 				));
@@ -78,7 +88,8 @@ export async function validateAnthropicApiKey(apiKey: string, config: positron.a
 			throw new ApiKeyValidationError(vscode.l10n.t('Invalid Anthropic API key'));
 		}
 
-		throw new ApiKeyValidationError(vscode.l10n.t(
+		const errorMessage = await getAnthropicErrorMessage(response);
+		throw new ApiKeyValidationError(errorMessage ?? vscode.l10n.t(
 			'Unable to validate Anthropic API key (HTTP {0})',
 			String(response.status)
 		));

--- a/extensions/authentication/src/validation/anthropic.ts
+++ b/extensions/authentication/src/validation/anthropic.ts
@@ -6,6 +6,8 @@
 import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { ANTHROPIC_API_VERSION, ANTHROPIC_DEFAULT_BASE_URL, KEY_VALIDATION_TIMEOUT_MS } from '../constants';
+import { PROVIDER_METADATA } from '../providerSources';
+import { getProviderCatalogId, getValidationHeaders } from './validationHeaders';
 
 class ApiKeyValidationError extends Error {
 	constructor(message: string) {
@@ -17,6 +19,13 @@ class ApiKeyValidationError extends Error {
 export async function validateAnthropicApiKey(apiKey: string, config: positron.ai.LanguageModelConfig): Promise<void> {
 	const baseUrl = (config.baseUrl?.trim() || ANTHROPIC_DEFAULT_BASE_URL).replace(/\/+$/, '');
 	const modelsEndpoint = `${baseUrl}/models`;
+	const headers = getValidationHeaders(
+		getProviderCatalogId(PROVIDER_METADATA.anthropic),
+		{
+			'x-api-key': apiKey,
+			'anthropic-version': ANTHROPIC_API_VERSION,
+		}
+	);
 
 	const controller = new AbortController();
 	const timeout = setTimeout(() => controller.abort(), KEY_VALIDATION_TIMEOUT_MS);
@@ -25,10 +34,7 @@ export async function validateAnthropicApiKey(apiKey: string, config: positron.a
 		try {
 			firstResponse = await fetch(modelsEndpoint, {
 				method: 'GET',
-				headers: {
-					'x-api-key': apiKey,
-					'anthropic-version': ANTHROPIC_API_VERSION,
-				},
+				headers,
 				signal: controller.signal,
 			});
 		} catch (err) {
@@ -60,10 +66,7 @@ export async function validateAnthropicApiKey(apiKey: string, config: positron.a
 		}
 		const response = await fetch(`${baseUrl}/v1/models`, {
 			method: 'GET',
-			headers: {
-				'x-api-key': apiKey,
-				'anthropic-version': ANTHROPIC_API_VERSION,
-			},
+			headers,
 			signal: controller.signal,
 		});
 

--- a/extensions/authentication/src/validation/anthropic.ts
+++ b/extensions/authentication/src/validation/anthropic.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { ANTHROPIC_API_VERSION, ANTHROPIC_DEFAULT_BASE_URL, KEY_VALIDATION_TIMEOUT_MS } from '../constants';
 import { PROVIDER_METADATA } from '../providerSources';
-import { getProviderCatalogId, getValidationHeaders } from './validationHeaders';
+import { getValidationHeaders } from './validationHeaders';
 
 class ApiKeyValidationError extends Error {
 	constructor(message: string) {
@@ -20,7 +20,7 @@ export async function validateAnthropicApiKey(apiKey: string, config: positron.a
 	const baseUrl = (config.baseUrl?.trim() || ANTHROPIC_DEFAULT_BASE_URL).replace(/\/+$/, '');
 	const modelsEndpoint = `${baseUrl}/models`;
 	const headers = getValidationHeaders(
-		getProviderCatalogId(PROVIDER_METADATA.anthropic),
+		PROVIDER_METADATA.anthropic.catalogId!,
 		{
 			'x-api-key': apiKey,
 			'anthropic-version': ANTHROPIC_API_VERSION,

--- a/extensions/authentication/src/validation/customProvider.ts
+++ b/extensions/authentication/src/validation/customProvider.ts
@@ -7,6 +7,8 @@ import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { KEY_VALIDATION_TIMEOUT_MS } from '../constants';
 import { log } from '../log';
+import { PROVIDER_METADATA } from '../providerSources';
+import { getProviderCatalogId, getValidationHeaders } from './validationHeaders';
 
 /**
  * Placeholder model sent with the validation request. We only want to probe
@@ -62,6 +64,10 @@ export async function validateCustomProviderApiKey(
 	if (apiKey?.trim()) {
 		headers['Authorization'] = `Bearer ${apiKey}`;
 	}
+	const validationHeaders = getValidationHeaders(
+		getProviderCatalogId(PROVIDER_METADATA.customProvider),
+		headers
+	);
 
 	const controller = new AbortController();
 	const timeout = setTimeout(
@@ -70,7 +76,7 @@ export async function validateCustomProviderApiKey(
 	try {
 		const response = await fetch(endpoint, {
 			method: 'POST',
-			headers,
+			headers: validationHeaders,
 			body: JSON.stringify({ model: VALIDATION_MODEL, messages: [] }),
 			signal: controller.signal,
 		});

--- a/extensions/authentication/src/validation/customProvider.ts
+++ b/extensions/authentication/src/validation/customProvider.ts
@@ -8,7 +8,7 @@ import * as positron from 'positron';
 import { KEY_VALIDATION_TIMEOUT_MS } from '../constants';
 import { log } from '../log';
 import { PROVIDER_METADATA } from '../providerSources';
-import { getProviderCatalogId, getValidationHeaders } from './validationHeaders';
+import { getValidationHeaders } from './validationHeaders';
 
 /**
  * Placeholder model sent with the validation request. We only want to probe
@@ -65,7 +65,7 @@ export async function validateCustomProviderApiKey(
 		headers['Authorization'] = `Bearer ${apiKey}`;
 	}
 	const validationHeaders = getValidationHeaders(
-		getProviderCatalogId(PROVIDER_METADATA.customProvider),
+		PROVIDER_METADATA.customProvider.catalogId!,
 		headers
 	);
 

--- a/extensions/authentication/src/validation/databricks.ts
+++ b/extensions/authentication/src/validation/databricks.ts
@@ -8,6 +8,8 @@ import * as positron from 'positron';
 import { KEY_VALIDATION_TIMEOUT_MS } from '../constants';
 import { normalizeHost } from '../databricksOAuth';
 import { getCachedProvider } from '../providerCatalog';
+import { PROVIDER_METADATA } from '../providerSources';
+import { getProviderCatalogId, getValidationHeaders } from './validationHeaders';
 
 class DatabricksValidationError extends Error {
 	constructor(message: string) {
@@ -53,9 +55,12 @@ export async function validateDatabricksApiKey(
 	try {
 		const response = await fetch(meEndpoint, {
 			method: 'GET',
-			headers: {
-				'Authorization': `Bearer ${apiKey}`,
-			},
+			headers: getValidationHeaders(
+				getProviderCatalogId(PROVIDER_METADATA.databricks),
+				{
+					'Authorization': `Bearer ${apiKey}`,
+				}
+			),
 			signal: controller.signal,
 		});
 

--- a/extensions/authentication/src/validation/databricks.ts
+++ b/extensions/authentication/src/validation/databricks.ts
@@ -49,18 +49,19 @@ export async function validateDatabricksApiKey(
 	}
 	const host = normalizeHost(rawHost);
 	const meEndpoint = `${host}/api/2.0/preview/scim/v2/Me`;
+	const headers = getValidationHeaders(
+		getProviderCatalogId(PROVIDER_METADATA.databricks),
+		{
+			'Authorization': `Bearer ${apiKey}`,
+		}
+	);
 
 	const controller = new AbortController();
 	const timeout = setTimeout(() => controller.abort(), KEY_VALIDATION_TIMEOUT_MS);
 	try {
 		const response = await fetch(meEndpoint, {
 			method: 'GET',
-			headers: getValidationHeaders(
-				getProviderCatalogId(PROVIDER_METADATA.databricks),
-				{
-					'Authorization': `Bearer ${apiKey}`,
-				}
-			),
+			headers,
 			signal: controller.signal,
 		});
 

--- a/extensions/authentication/src/validation/databricks.ts
+++ b/extensions/authentication/src/validation/databricks.ts
@@ -9,7 +9,7 @@ import { KEY_VALIDATION_TIMEOUT_MS } from '../constants';
 import { normalizeHost } from '../databricksOAuth';
 import { getCachedProvider } from '../providerCatalog';
 import { PROVIDER_METADATA } from '../providerSources';
-import { getProviderCatalogId, getValidationHeaders } from './validationHeaders';
+import { getValidationHeaders } from './validationHeaders';
 
 class DatabricksValidationError extends Error {
 	constructor(message: string) {
@@ -50,7 +50,7 @@ export async function validateDatabricksApiKey(
 	const host = normalizeHost(rawHost);
 	const meEndpoint = `${host}/api/2.0/preview/scim/v2/Me`;
 	const headers = getValidationHeaders(
-		getProviderCatalogId(PROVIDER_METADATA.databricks),
+		PROVIDER_METADATA.databricks.catalogId!,
 		{
 			'Authorization': `Bearer ${apiKey}`,
 		}

--- a/extensions/authentication/src/validation/deepseek.ts
+++ b/extensions/authentication/src/validation/deepseek.ts
@@ -6,6 +6,8 @@
 import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { DEEPSEEK_DEFAULT_BASE_URL, KEY_VALIDATION_TIMEOUT_MS } from '../constants';
+import { PROVIDER_METADATA } from '../providerSources';
+import { getProviderCatalogId, getValidationHeaders } from './validationHeaders';
 
 class DeepSeekValidationError extends Error {
 	constructor(message: string) {
@@ -28,9 +30,12 @@ export async function validateDeepSeekApiKey(
 	try {
 		const response = await fetch(modelsEndpoint, {
 			method: 'GET',
-			headers: {
-				'Authorization': `Bearer ${apiKey}`,
-			},
+			headers: getValidationHeaders(
+				getProviderCatalogId(PROVIDER_METADATA.deepseek),
+				{
+					'Authorization': `Bearer ${apiKey}`,
+				}
+			),
 			signal: controller.signal,
 		});
 

--- a/extensions/authentication/src/validation/deepseek.ts
+++ b/extensions/authentication/src/validation/deepseek.ts
@@ -24,18 +24,19 @@ export async function validateDeepSeekApiKey(
 		config.baseUrl?.trim() || DEEPSEEK_DEFAULT_BASE_URL
 	).replace(/\/+$/, '');
 	const modelsEndpoint = `${baseUrl}/models`;
+	const headers = getValidationHeaders(
+		getProviderCatalogId(PROVIDER_METADATA.deepseek),
+		{
+			'Authorization': `Bearer ${apiKey}`,
+		}
+	);
 
 	const controller = new AbortController();
 	const timeout = setTimeout(() => controller.abort(), KEY_VALIDATION_TIMEOUT_MS);
 	try {
 		const response = await fetch(modelsEndpoint, {
 			method: 'GET',
-			headers: getValidationHeaders(
-				getProviderCatalogId(PROVIDER_METADATA.deepseek),
-				{
-					'Authorization': `Bearer ${apiKey}`,
-				}
-			),
+			headers,
 			signal: controller.signal,
 		});
 

--- a/extensions/authentication/src/validation/deepseek.ts
+++ b/extensions/authentication/src/validation/deepseek.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { DEEPSEEK_DEFAULT_BASE_URL, KEY_VALIDATION_TIMEOUT_MS } from '../constants';
 import { PROVIDER_METADATA } from '../providerSources';
-import { getProviderCatalogId, getValidationHeaders } from './validationHeaders';
+import { getValidationHeaders } from './validationHeaders';
 
 class DeepSeekValidationError extends Error {
 	constructor(message: string) {
@@ -25,7 +25,7 @@ export async function validateDeepSeekApiKey(
 	).replace(/\/+$/, '');
 	const modelsEndpoint = `${baseUrl}/models`;
 	const headers = getValidationHeaders(
-		getProviderCatalogId(PROVIDER_METADATA.deepseek),
+		PROVIDER_METADATA.deepseek.catalogId!,
 		{
 			'Authorization': `Bearer ${apiKey}`,
 		}

--- a/extensions/authentication/src/validation/foundry.ts
+++ b/extensions/authentication/src/validation/foundry.ts
@@ -6,6 +6,8 @@
 import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { KEY_VALIDATION_TIMEOUT_MS } from '../constants';
+import { PROVIDER_METADATA } from '../providerSources';
+import { getProviderCatalogId, getValidationHeaders } from './validationHeaders';
 
 class FoundryValidationError extends Error {
 	constructor(message: string) {
@@ -66,10 +68,13 @@ export async function validateFoundryApiKey(
 	try {
 		const response = await fetch(endpoint, {
 			method: 'POST',
-			headers: {
-				'Authorization': `Bearer ${apiKey}`,
-				'Content-Type': 'application/json',
-			},
+			headers: getValidationHeaders(
+				getProviderCatalogId(PROVIDER_METADATA.foundry),
+				{
+					'Authorization': `Bearer ${apiKey}`,
+					'Content-Type': 'application/json',
+				}
+			),
 			body: JSON.stringify({ model: '', messages: [] }),
 			signal: controller.signal,
 		});

--- a/extensions/authentication/src/validation/foundry.ts
+++ b/extensions/authentication/src/validation/foundry.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { KEY_VALIDATION_TIMEOUT_MS } from '../constants';
 import { PROVIDER_METADATA } from '../providerSources';
-import { getProviderCatalogId, getValidationHeaders } from './validationHeaders';
+import { getValidationHeaders } from './validationHeaders';
 
 class FoundryValidationError extends Error {
 	constructor(message: string) {
@@ -63,7 +63,7 @@ export async function validateFoundryApiKey(
 	const baseUrl = normalizeToV1Url(rawBaseUrl);
 	const endpoint = `${baseUrl}/chat/completions`;
 	const headers = getValidationHeaders(
-		getProviderCatalogId(PROVIDER_METADATA.foundry),
+		PROVIDER_METADATA.foundry.catalogId!,
 		{
 			'Authorization': `Bearer ${apiKey}`,
 			'Content-Type': 'application/json',

--- a/extensions/authentication/src/validation/foundry.ts
+++ b/extensions/authentication/src/validation/foundry.ts
@@ -62,19 +62,20 @@ export async function validateFoundryApiKey(
 
 	const baseUrl = normalizeToV1Url(rawBaseUrl);
 	const endpoint = `${baseUrl}/chat/completions`;
+	const headers = getValidationHeaders(
+		getProviderCatalogId(PROVIDER_METADATA.foundry),
+		{
+			'Authorization': `Bearer ${apiKey}`,
+			'Content-Type': 'application/json',
+		}
+	);
 
 	const controller = new AbortController();
 	const timeout = setTimeout(() => controller.abort(), KEY_VALIDATION_TIMEOUT_MS);
 	try {
 		const response = await fetch(endpoint, {
 			method: 'POST',
-			headers: getValidationHeaders(
-				getProviderCatalogId(PROVIDER_METADATA.foundry),
-				{
-					'Authorization': `Bearer ${apiKey}`,
-					'Content-Type': 'application/json',
-				}
-			),
+			headers,
 			body: JSON.stringify({ model: '', messages: [] }),
 			signal: controller.signal,
 		});

--- a/extensions/authentication/src/validation/gemini.ts
+++ b/extensions/authentication/src/validation/gemini.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { GEMINI_DEFAULT_BASE_URL, KEY_VALIDATION_TIMEOUT_MS } from '../constants';
 import { PROVIDER_METADATA } from '../providerSources';
-import { getProviderCatalogId, getValidationHeaders } from './validationHeaders';
+import { getValidationHeaders } from './validationHeaders';
 
 class GeminiValidationError extends Error {
 	constructor(message: string) {
@@ -25,7 +25,7 @@ export async function validateGeminiApiKey(
 	).replace(/\/+$/, '');
 	const modelsEndpoint = `${baseUrl}/models`;
 	const headers = getValidationHeaders(
-		getProviderCatalogId(PROVIDER_METADATA.google),
+		PROVIDER_METADATA.google.catalogId!,
 		{
 			'x-goog-api-key': apiKey,
 		}

--- a/extensions/authentication/src/validation/gemini.ts
+++ b/extensions/authentication/src/validation/gemini.ts
@@ -6,6 +6,8 @@
 import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { GEMINI_DEFAULT_BASE_URL, KEY_VALIDATION_TIMEOUT_MS } from '../constants';
+import { PROVIDER_METADATA } from '../providerSources';
+import { getProviderCatalogId, getValidationHeaders } from './validationHeaders';
 
 class GeminiValidationError extends Error {
 	constructor(message: string) {
@@ -28,9 +30,12 @@ export async function validateGeminiApiKey(
 	try {
 		const response = await fetch(modelsEndpoint, {
 			method: 'GET',
-			headers: {
-				'x-goog-api-key': apiKey,
-			},
+			headers: getValidationHeaders(
+				getProviderCatalogId(PROVIDER_METADATA.google),
+				{
+					'x-goog-api-key': apiKey,
+				}
+			),
 			signal: controller.signal,
 		});
 

--- a/extensions/authentication/src/validation/gemini.ts
+++ b/extensions/authentication/src/validation/gemini.ts
@@ -24,18 +24,19 @@ export async function validateGeminiApiKey(
 		config.baseUrl?.trim() || GEMINI_DEFAULT_BASE_URL
 	).replace(/\/+$/, '');
 	const modelsEndpoint = `${baseUrl}/models`;
+	const headers = getValidationHeaders(
+		getProviderCatalogId(PROVIDER_METADATA.google),
+		{
+			'x-goog-api-key': apiKey,
+		}
+	);
 
 	const controller = new AbortController();
 	const timeout = setTimeout(() => controller.abort(), KEY_VALIDATION_TIMEOUT_MS);
 	try {
 		const response = await fetch(modelsEndpoint, {
 			method: 'GET',
-			headers: getValidationHeaders(
-				getProviderCatalogId(PROVIDER_METADATA.google),
-				{
-					'x-goog-api-key': apiKey,
-				}
-			),
+			headers,
 			signal: controller.signal,
 		});
 

--- a/extensions/authentication/src/validation/openai.ts
+++ b/extensions/authentication/src/validation/openai.ts
@@ -6,6 +6,8 @@
 import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { KEY_VALIDATION_TIMEOUT_MS, OPENAI_DEFAULT_BASE_URL } from '../constants';
+import { PROVIDER_METADATA } from '../providerSources';
+import { getProviderCatalogId, getValidationHeaders } from './validationHeaders';
 
 class OpenaiValidationError extends Error {
 	constructor(message: string) {
@@ -27,9 +29,12 @@ export async function validateOpenaiApiKey(
 	try {
 		const response = await fetch(modelsEndpoint, {
 			method: 'GET',
-			headers: {
-				'Authorization': `Bearer ${apiKey}`,
-			},
+			headers: getValidationHeaders(
+				getProviderCatalogId(PROVIDER_METADATA.openai),
+				{
+					'Authorization': `Bearer ${apiKey}`,
+				}
+			),
 			signal: controller.signal,
 		});
 

--- a/extensions/authentication/src/validation/openai.ts
+++ b/extensions/authentication/src/validation/openai.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { KEY_VALIDATION_TIMEOUT_MS, OPENAI_DEFAULT_BASE_URL } from '../constants';
 import { PROVIDER_METADATA } from '../providerSources';
-import { getProviderCatalogId, getValidationHeaders } from './validationHeaders';
+import { getValidationHeaders } from './validationHeaders';
 
 class OpenaiValidationError extends Error {
 	constructor(message: string) {
@@ -24,7 +24,7 @@ export async function validateOpenaiApiKey(
 		.replace(/\/+$/, '');
 	const modelsEndpoint = `${baseUrl}/models`;
 	const headers = getValidationHeaders(
-		getProviderCatalogId(PROVIDER_METADATA.openai),
+		PROVIDER_METADATA.openai.catalogId!,
 		{
 			'Authorization': `Bearer ${apiKey}`,
 		}

--- a/extensions/authentication/src/validation/openai.ts
+++ b/extensions/authentication/src/validation/openai.ts
@@ -23,18 +23,19 @@ export async function validateOpenaiApiKey(
 	const baseUrl = (config.baseUrl?.trim() || OPENAI_DEFAULT_BASE_URL)
 		.replace(/\/+$/, '');
 	const modelsEndpoint = `${baseUrl}/models`;
+	const headers = getValidationHeaders(
+		getProviderCatalogId(PROVIDER_METADATA.openai),
+		{
+			'Authorization': `Bearer ${apiKey}`,
+		}
+	);
 
 	const controller = new AbortController();
 	const timeout = setTimeout(() => controller.abort(), KEY_VALIDATION_TIMEOUT_MS);
 	try {
 		const response = await fetch(modelsEndpoint, {
 			method: 'GET',
-			headers: getValidationHeaders(
-				getProviderCatalogId(PROVIDER_METADATA.openai),
-				{
-					'Authorization': `Bearer ${apiKey}`,
-				}
-			),
+			headers,
 			signal: controller.signal,
 		});
 

--- a/extensions/authentication/src/validation/validationHeaders.ts
+++ b/extensions/authentication/src/validation/validationHeaders.ts
@@ -5,14 +5,6 @@
 
 import { log } from '../log';
 import { getCachedProvider } from '../providerCatalog';
-import type { ProviderMetadata } from '../providerSources';
-
-export function getProviderCatalogId(metadata: ProviderMetadata): string {
-	if (!metadata.catalogId) {
-		throw new Error(`Provider "${metadata.id}" does not have a catalog id`);
-	}
-	return metadata.catalogId;
-}
 
 export function getValidationHeaders(
 	catalogId: string,

--- a/extensions/authentication/src/validation/validationHeaders.ts
+++ b/extensions/authentication/src/validation/validationHeaders.ts
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { log } from '../log';
+import { getCachedProvider } from '../providerCatalog';
+import type { ProviderMetadata } from '../providerSources';
+
+export function getProviderCatalogId(metadata: ProviderMetadata): string {
+	if (!metadata.catalogId) {
+		throw new Error(`Provider "${metadata.id}" does not have a catalog id`);
+	}
+	return metadata.catalogId;
+}
+
+export function getValidationHeaders(
+	catalogId: string,
+	baseHeaders: Readonly<Record<string, string>>
+): Record<string, string> {
+	const provider = getCachedProvider(catalogId);
+	if (!provider) {
+		log.warn(`[Validation] Provider "${catalogId}" is not available in the catalog; proceeding without custom headers.`);
+		return { ...baseHeaders };
+	}
+
+	const headers = { ...baseHeaders };
+	const baseHeaderNames = new Set(
+		Object.keys(baseHeaders).map(name => name.toLowerCase())
+	);
+	for (const [name, value] of Object.entries(
+		provider.connection.customHeaders ?? {}
+	)) {
+		if (baseHeaderNames.has(name.toLowerCase())) {
+			log.warn(`[Validation] Skipping configured header "${name}" for provider "${catalogId}" because the validation request already defines it.`);
+			continue;
+		}
+		headers[name] = value;
+	}
+	return headers;
+}


### PR DESCRIPTION
Fixes #15248

This PR fixes Assistant provider sign-in validation requests so they include custom headers configured in the provider catalog. Validation now resolves headers before each request, preserves the built-in authentication/content headers, and warns if a configured header would collide with a validation-required header.

This also includes a fix to surface the actual error message we receive from Anthropic on validation:
<img width="603" height="504" alt="image" src="https://github.com/user-attachments/assets/16e1d6b0-591e-4ac5-8f76-cc51b767a66a" />


### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed Assistant provider sign-in validation when a configured provider requires custom request headers. (#15248)

### Validation Steps

@:assistant

1. Configure a Custom Provider a custom header.
2. Add the required header under the provider customHeaders configuration.
3. Sign in through the language model provider dialog and verify validation contains header.

Run the authentication extension validation tests:

```bash
npm run test-extension -- -l authentication --grep "validate"
```
