### PR TITLE
Fix cli's runnable code links in the R console after an extension host restart 

### DIFF
--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -64,10 +64,14 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	private readonly _encounteredLanguagesByLanguageId = new Set<string>();
 
 	/**
-	 * The foreground session. This is the session that is currently active in
-	 * the Console view.
+	 * The ID of the foreground session. This is the session that is currently
+	 * active in the Console view.
+	 *
+	 * Stored as an ID rather than a session object: reconnecting replaces the
+	 * session object, and anything holding the old one talks to a disposed
+	 * extension host.
 	 */
-	private _foregroundSession?: ILanguageRuntimeSession;
+	private _foregroundSessionId?: string;
 
 	// A map of the currently active sessions. This is keyed by the session ID.
 	private readonly _activeSessionsBySessionId = new Map<string, ActiveRuntimeSession>();
@@ -100,14 +104,14 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	// This map is keyed by the runtimeId (metadata.runtimeId) of the session.
 	private readonly _consoleSessionsByRuntimeId = new Map<string, ILanguageRuntimeSession[]>();
 
-	// A map of the last active console session per langauge.
+	// A map of the last active console session ID per langauge.
 	// We can have multiple console sessions per language,
 	// and this map provides access to the session that was
 	// last active per language.
-	private readonly _lastActiveConsoleSessionByLanguageId = new Map<string, ILanguageRuntimeSession>();
+	private readonly _lastActiveConsoleSessionIdByLanguageId = new Map<string, string>();
 
-	// The last active console session, regardless of language.
-	private _lastActiveConsoleSession: ILanguageRuntimeSession | undefined;
+	// The ID of the last active console session, regardless of language.
+	private _lastActiveConsoleSessionId: string | undefined;
 
 	// A map of the currently active notebook sessions. This is keyed by the notebook URI
 	// owning the session.
@@ -421,7 +425,8 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			return this.foregroundSession;
 		}
 		// Otherwise, return the last active console session for the languageId if there is one
-		return this._lastActiveConsoleSessionByLanguageId.get(languageId);
+		const lastActiveSessionId = this._lastActiveConsoleSessionIdByLanguageId.get(languageId);
+		return lastActiveSessionId ? this.getSession(lastActiveSessionId) : undefined;
 	}
 
 	/**
@@ -856,32 +861,46 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	}
 
 	/**
+	 * The foreground session, resolved from its ID.
+	 */
+	private get _foregroundSession(): ILanguageRuntimeSession | undefined {
+		return this._foregroundSessionId ?
+			this.getSession(this._foregroundSessionId) : undefined;
+	}
+
+	/**
+	 * The last active console session, resolved from its ID.
+	 */
+	private get _lastActiveConsoleSession(): ILanguageRuntimeSession | undefined {
+		return this._lastActiveConsoleSessionId ?
+			this.getSession(this._lastActiveConsoleSessionId) : undefined;
+	}
+
+	/**
 	 * Sets the foreground session.
 	 */
 	set foregroundSession(session: ILanguageRuntimeSession | undefined) {
 		// If there's nothing to do, return.
-		if (!session && !this._foregroundSession) {
+		if (!session && !this._foregroundSessionId) {
 			return;
 		}
 
-		// Check if the session is already the foreground session. This compares
-		// object identity, not session ID: a reconnected session carries the
-		// same ID as the disposed object it replaces, and treating that as "no
-		// change" would leave the stale object in place.
-		if (session && session === this._foregroundSession) {
+		// Check if the session is already the foreground session
+		if (session && session.sessionId === this._foregroundSessionId) {
 			return; // No change, don't update or fire events
 		}
 
-		this._foregroundSession = session;
+		this._foregroundSessionId = session?.sessionId;
 
 		if (session && session.metadata.sessionMode === LanguageRuntimeSessionMode.Console) {
 			// Update the map of active console sessions per language.
 			// Only track Console sessions here; notebook sessions should not
 			// replace the last active console session, as that would cause
 			// getConsoleSessionForLanguage() to return the wrong session.
-			this._lastActiveConsoleSessionByLanguageId.set(session.runtimeMetadata.languageId, session);
+			this._lastActiveConsoleSessionIdByLanguageId.set(
+				session.runtimeMetadata.languageId, session.sessionId);
 			// Update the global last active console session
-			this._lastActiveConsoleSession = session;
+			this._lastActiveConsoleSessionId = session.sessionId;
 		}
 
 		// Keep the foreground session display info in sync
@@ -1419,8 +1438,8 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			this.updateSessionMapsAfterExit(session);
 
 			// Clear the last active console session if it is the session being deleted.
-			if (this._lastActiveConsoleSession?.sessionId === sessionId) {
-				this._lastActiveConsoleSession = undefined;
+			if (this._lastActiveConsoleSessionId === sessionId) {
+				this._lastActiveConsoleSessionId = undefined;
 			}
 
 			// Remove stale display-state entries for the deleted session.
@@ -1612,7 +1631,11 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 
 		// Enumerate the last known active console sessions per language and attempt to open
 		// the resource.
-		for (const session of this._lastActiveConsoleSessionByLanguageId.values()) {
+		for (const sessionId of this._lastActiveConsoleSessionIdByLanguageId.values()) {
+			const session = this.getSession(sessionId);
+			if (!session) {
+				continue;
+			}
 			try {
 				if (await session.openResource(resource)) {
 					return true;
@@ -1978,9 +2001,6 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		// Clean up any previous active session info for this session.
 		const oldSession = this._activeSessionsBySessionId.get(session.sessionId);
 		if (oldSession) {
-			// The old session object is about to be disposed; move any cached
-			// references onto the replacement before that happens.
-			this.replaceCachedSessionReferences(oldSession.session, session);
 			oldSession.dispose();
 		}
 
@@ -2333,58 +2353,6 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			session.metadata.notebookUri,
 			new RuntimeSessionDisplayInfo(session),
 		);
-	}
-
-	/**
-	 * Swaps every cached reference to a session object for its replacement.
-	 *
-	 * A reconnect (such as after an extension host restart) builds a new
-	 * session object bound to the new extension host proxy and disposes the old
-	 * one. The caches below hold the session object itself rather than its ID,
-	 * so without this they keep pointing at the disposed object and every call
-	 * made through them is cancelled by the dead RPC protocol.
-	 *
-	 * @param oldSession The session object being replaced.
-	 * @param newSession The session object replacing it.
-	 */
-	private replaceCachedSessionReferences(
-		oldSession: ILanguageRuntimeSession,
-		newSession: ILanguageRuntimeSession): void {
-		if (oldSession === newSession) {
-			return;
-		}
-
-		if (this._foregroundSession === oldSession) {
-			this._foregroundSession = newSession;
-			this.foregroundSessionDisplayInfo =
-				this._createRuntimeSessionDisplayInfo(newSession);
-		}
-
-		if (this._lastActiveConsoleSession === oldSession) {
-			this._lastActiveConsoleSession = newSession;
-		}
-
-		for (const [languageId, session] of this._lastActiveConsoleSessionByLanguageId) {
-			if (session === oldSession) {
-				this._lastActiveConsoleSessionByLanguageId.set(languageId, newSession);
-			}
-		}
-
-		for (const [runtimeId, sessions] of this._consoleSessionsByRuntimeId) {
-			const index = sessions.indexOf(oldSession);
-			if (index !== -1) {
-				const updated = [...sessions];
-				updated[index] = newSession;
-				this._consoleSessionsByRuntimeId.set(runtimeId, updated);
-			}
-		}
-
-		if (isNotebookLanguageRuntimeSession(newSession)) {
-			const notebookUri = newSession.metadata.notebookUri;
-			if (this._notebookSessionsByNotebookUri.get(notebookUri) === oldSession) {
-				this._notebookSessionsByNotebookUri.set(notebookUri, newSession);
-			}
-		}
 	}
 
 	/**

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -864,8 +864,11 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			return;
 		}
 
-		// Check if the session is already the foreground session
-		if (session && this._foregroundSession && session.sessionId === this._foregroundSession.sessionId) {
+		// Check if the session is already the foreground session. This compares
+		// object identity, not session ID: a reconnected session carries the
+		// same ID as the disposed object it replaces, and treating that as "no
+		// change" would leave the stale object in place.
+		if (session && session === this._foregroundSession) {
 			return; // No change, don't update or fire events
 		}
 
@@ -1975,6 +1978,9 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		// Clean up any previous active session info for this session.
 		const oldSession = this._activeSessionsBySessionId.get(session.sessionId);
 		if (oldSession) {
+			// The old session object is about to be disposed; move any cached
+			// references onto the replacement before that happens.
+			this.replaceCachedSessionReferences(oldSession.session, session);
 			oldSession.dispose();
 		}
 
@@ -2327,6 +2333,58 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			session.metadata.notebookUri,
 			new RuntimeSessionDisplayInfo(session),
 		);
+	}
+
+	/**
+	 * Swaps every cached reference to a session object for its replacement.
+	 *
+	 * A reconnect (such as after an extension host restart) builds a new
+	 * session object bound to the new extension host proxy and disposes the old
+	 * one. The caches below hold the session object itself rather than its ID,
+	 * so without this they keep pointing at the disposed object and every call
+	 * made through them is cancelled by the dead RPC protocol.
+	 *
+	 * @param oldSession The session object being replaced.
+	 * @param newSession The session object replacing it.
+	 */
+	private replaceCachedSessionReferences(
+		oldSession: ILanguageRuntimeSession,
+		newSession: ILanguageRuntimeSession): void {
+		if (oldSession === newSession) {
+			return;
+		}
+
+		if (this._foregroundSession === oldSession) {
+			this._foregroundSession = newSession;
+			this.foregroundSessionDisplayInfo =
+				this._createRuntimeSessionDisplayInfo(newSession);
+		}
+
+		if (this._lastActiveConsoleSession === oldSession) {
+			this._lastActiveConsoleSession = newSession;
+		}
+
+		for (const [languageId, session] of this._lastActiveConsoleSessionByLanguageId) {
+			if (session === oldSession) {
+				this._lastActiveConsoleSessionByLanguageId.set(languageId, newSession);
+			}
+		}
+
+		for (const [runtimeId, sessions] of this._consoleSessionsByRuntimeId) {
+			const index = sessions.indexOf(oldSession);
+			if (index !== -1) {
+				const updated = [...sessions];
+				updated[index] = newSession;
+				this._consoleSessionsByRuntimeId.set(runtimeId, updated);
+			}
+		}
+
+		if (isNotebookLanguageRuntimeSession(newSession)) {
+			const notebookUri = newSession.metadata.notebookUri;
+			if (this._notebookSessionsByNotebookUri.get(notebookUri) === oldSession) {
+				this._notebookSessionsByNotebookUri.set(notebookUri, newSession);
+			}
+		}
 	}
 
 	/**

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.vitest.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.vitest.ts
@@ -10,6 +10,7 @@ import { Event } from '../../../../../base/common/event.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IOpener } from '../../../../../platform/opener/common/opener.js';
 import { IWorkspaceTrustManagementService } from '../../../../../platform/workspace/common/workspaceTrust.js';
 import { formatLanguageRuntimeMetadata, formatLanguageRuntimeSession, ILanguageRuntimeMetadata, ILanguageRuntimeService, LanguageRuntimeSessionLocation, LanguageRuntimeSessionMode, LanguageStartupBehavior, RuntimeExitReason, RuntimeState } from '../../../languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, IRuntimeSessionMetadata, IRuntimeSessionService, IRuntimeSessionWillStartEvent, RuntimeClientType, RuntimeStartMode } from '../../common/runtimeSessionService.js';
@@ -185,9 +186,9 @@ describe('Positron - RuntimeSessionService', () => {
 	}
 
 	async function restoreSession(
-		sessionMetadata: IRuntimeSessionMetadata, runtime: ILanguageRuntimeMetadata,
+		sessionMetadata: IRuntimeSessionMetadata, runtime: ILanguageRuntimeMetadata, activate = true,
 	) {
-		await runtimeSessionService.restoreRuntimeSession(runtime, sessionMetadata, sessionName, true, true);
+		await runtimeSessionService.restoreRuntimeSession(runtime, sessionMetadata, sessionName, true, activate);
 
 		// Ensure that the session gets disposed after the test.
 		const session = runtimeSessionService.getSession(sessionMetadata.sessionId);
@@ -1593,6 +1594,80 @@ describe('Positron - RuntimeSessionService', () => {
 
 			// Not queued for reconnection, so deletion proceeds normally.
 			expect(await runtimeSessionService.deleteSession(session.sessionId)).toBe(true);
+		});
+
+		// Reconnecting brings the same session id back as a *new* session object,
+		// bound to the new extension host. The old object's RPC protocol is
+		// disposed, so anything still holding it talks to a dead extension host.
+		// `activate` is false to match the reconnect in the extension-activation
+		// handler.
+		async function disconnectAndReconnect() {
+			const workspaceRuntime = createTestLanguageRuntimeMetadata(
+				ctx.instantiationService, ctx.disposables, LanguageRuntimeSessionLocation.Workspace);
+			const replaced = await startConsole(workspaceRuntime);
+			await waitForRuntimeState(replaced, RuntimeState.Ready);
+			runtimeSessionService.foregroundSession = replaced;
+
+			await disconnectViaExtensionHost(replaced);
+			const reconnected = await restoreSession(
+				replaced.metadata, replaced.runtimeMetadata, /* activate */ false);
+
+			// Without a replacement there is nothing stale to catch, and every
+			// case below would pass vacuously.
+			expect(reconnected, 'Expected reconnect to replace the session object').not.toBe(replaced);
+
+			return { runtime: workspaceRuntime, replaced, reconnected };
+		}
+
+		function openHelpResource() {
+			return (runtimeSessionService as unknown as IOpener)
+				.open(URI.parse('x-r-help:utils::sessionInfo'));
+		}
+
+		it('opens a resource with the reconnected session, not the replaced one', async () => {
+			const { replaced, reconnected } = await disconnectAndReconnect();
+			const replacedOpen = vi.spyOn(replaced, 'openResource').mockResolvedValue(true);
+			const reconnectedOpen = vi.spyOn(reconnected, 'openResource').mockResolvedValue(true);
+
+			expect(await openHelpResource(), 'Expected the resource to be opened').toBe(true);
+			expect(reconnectedOpen, 'Expected the reconnected session to open the resource')
+				.toHaveBeenCalled();
+			expect(replacedOpen, 'Expected the replaced session not to be used')
+				.not.toHaveBeenCalled();
+		});
+
+		it('opens a resource with the reconnected session after it is set as foreground', async () => {
+			const { replaced, reconnected } = await disconnectAndReconnect();
+			const replacedOpen = vi.spyOn(replaced, 'openResource').mockResolvedValue(true);
+			const reconnectedOpen = vi.spyOn(reconnected, 'openResource').mockResolvedValue(true);
+
+			// The console pane does this whenever it gains focus, so a stale
+			// reference should not outlive the next click in the console.
+			runtimeSessionService.foregroundSession = reconnected;
+
+			expect(await openHelpResource(), 'Expected the resource to be opened').toBe(true);
+			expect(reconnectedOpen, 'Expected the reconnected session to open the resource')
+				.toHaveBeenCalled();
+			expect(replacedOpen, 'Expected the replaced session not to be used')
+				.not.toHaveBeenCalled();
+		});
+
+		it('returns the reconnected session from getConsoleSessionForLanguage', async () => {
+			const { runtime: workspaceRuntime, reconnected } = await disconnectAndReconnect();
+
+			expect(
+				runtimeSessionService.getConsoleSessionForLanguage(workspaceRuntime.languageId) === reconnected,
+				'Expected the console session for the language to be the reconnected session, not the replaced one'
+			).toBe(true);
+		});
+
+		it('returns the reconnected session from getLastActiveConsoleSession', async () => {
+			const { reconnected } = await disconnectAndReconnect();
+
+			expect(
+				runtimeSessionService.getLastActiveConsoleSession() === reconnected,
+				'Expected the last active console session to be the reconnected session, not the replaced one'
+			).toBe(true);
 		});
 	});
 

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.vitest.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.vitest.ts
@@ -1656,18 +1656,18 @@ describe('Positron - RuntimeSessionService', () => {
 			const { runtime: workspaceRuntime, reconnected } = await disconnectAndReconnect();
 
 			expect(
-				runtimeSessionService.getConsoleSessionForLanguage(workspaceRuntime.languageId) === reconnected,
+				runtimeSessionService.getConsoleSessionForLanguage(workspaceRuntime.languageId),
 				'Expected the console session for the language to be the reconnected session, not the replaced one'
-			).toBe(true);
+			).toBe(reconnected);
 		});
 
 		it('returns the reconnected session from getLastActiveConsoleSession', async () => {
 			const { reconnected } = await disconnectAndReconnect();
 
 			expect(
-				runtimeSessionService.getLastActiveConsoleSession() === reconnected,
+				runtimeSessionService.getLastActiveConsoleSession(),
 				'Expected the last active console session to be the reconnected session, not the replaced one'
-			).toBe(true);
+			).toBe(reconnected);
 		});
 	});
 


### PR DESCRIPTION
Progress towards #15726

Some of the links from the cli R package have stopped working, sometimes, in the R Console. It happens after an extension host restart and can be "fixed" with a window reload (in the sense of a workaround, not a real fix!).

Specifically, the breakage affects the links using the `x-r-help:` / `x-r-run:` / `x-r-vignette:` schemes.  These go through the runtime session service's opener, which looks for the last active session for the language:

https://github.com/posit-dev/positron/blob/4837bc1356742490a89b73e7f231fd660f3c5487/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts#L1610-L1620

If there's been an extension host restart, we're looping over stale sessions and this fails.

Good ways to tickle. Try these in a fresh Positron window vs. after an extension host restart.

* `cli::cli_text("{.run rlang::abort('oh no')}")` should give you a clickable `rlang::abort()` call that runs the code.
* `cli::cli_text("{.help stats::lm}")` should give you a clickable `stats::lm` that open the help topic.
* `cli::cli_text("{.vignette dplyr::grouping}")` should give you a clickable `dplyr::grouping` that navigates to the vignette.

Instead, with Positron 2026.09.0 build 146 (and I think for lots of previous versions), you get this:

<img width="492" height="189" alt="Screenshot 2026-08-26 at 4 36 47 PM" src="https://github.com/user-attachments/assets/35ed0dc9-4d70-4e1b-a8b7-b7d978e4ec6a" />

All three link types (`.run`, `.help`, `.vignette`) share one dispatch path, so all three were broken by the stale session. This PR repairs that dispatch: `{.run}` now works end to end. `{.help}` and `{.vignette}` get as far as the live session and a correct URL, then hit a second, unrelated bug (the Help pane caches a proxy server origin belonging to the dead extension host), tracked separately in #15776.

Approach taken: `RuntimeSessionService` currently holds session objects rather than IDs, so a reconnect leaves the foreground pointer and the console/notebook lookup maps on the disposed object. I've taken @jmcphers's advice to pivot towards session IDs.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Clickable `{.run}` links from the cli package work again in the R Console after the extension host restarts (#15726).

### Validation Steps

See above for how to tickle this bug and fix. Remember only `{.run}` is fully fixed by this PR.