### PR TITLE
Quarto virtual notebook: format code cells

### DIFF
--- a/extensions/positron-python/src/client/positron/lsp.ts
+++ b/extensions/positron-python/src/client/positron/lsp.ts
@@ -37,19 +37,13 @@ const QUARTO_CELLS_NOTEBOOK_TYPE = 'quarto-cells';
 // Matches the path of a Quarto or R Markdown document.
 const QUARTO_PATH_PATTERN = /\.(qmd|rmd)$/i;
 
-// Selector for the cells of Quarto virtual notebooks. A cell URI keeps the path
-// of the Quarto document the notebook was built from, so restricting the pattern
-// to Quarto extensions keeps the cells of real notebooks (.ipynb) out.
-//
-// `.Rmd` belongs here as much as `.qmd` does. R Markdown runs more than one
-// engine, so a Python chunk in an `.Rmd` is ordinary (see
-// test/e2e/test-files/workspaces/visual-mode/visual-mode.rmd). This never claims
-// the `.Rmd` document itself: that is `file` scheme with the `quarto` language,
-// and all three filters here have to match.
+// Selector for the cells of Quarto virtual notebooks. Matching the notebook's
+// type keeps the cells of real notebooks (.ipynb) out, since no other notebook
+// carries this type. This covers `.Rmd` documents as well as `.qmd` ones: core
+// builds a hidden notebook for both, so both arrive here.
 const QUARTO_CELL_SELECTOR = {
+    notebook: { notebookType: QUARTO_CELLS_NOTEBOOK_TYPE },
     language: 'python',
-    scheme: 'vscode-notebook-cell',
-    pattern: '**/*.{qmd,QMD,rmd,Rmd,RMD}',
 };
 
 /**
@@ -60,7 +54,9 @@ function isQuartoVirtualCell(document: vscode.TextDocument): boolean {
         return false;
     }
     return vscode.workspace.notebookDocuments.some(
-        (notebook) => notebook.notebookType === QUARTO_CELLS_NOTEBOOK_TYPE && notebook.uri.path === document.uri.path,
+        (notebook) =>
+            notebook.notebookType === QUARTO_CELLS_NOTEBOOK_TYPE &&
+            notebook.getCells().some((cell) => cell.document.uri.toString() === document.uri.toString()),
     );
 }
 
@@ -156,8 +152,8 @@ export class PythonLsp implements vscode.Disposable {
 
         // Matches the cells of this client's own notebook.
         //
-        // Skipped for Quarto sessions, whose notebook URI is the path of the .qmd
-        // document. The only Python documents with that path are the cells of the
+        // Skipped for Quarto sessions, whose session URI is the .qmd document.
+        // The only Python documents under that path are the cells of the
         // document's virtual notebook, and the console client serves those, so
         // matching them here would only duplicate it. For a real notebook (.ipynb)
         // this is what matches the notebook's own cells.

--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -49,13 +49,12 @@ const QUARTO_PATH_PATTERN = /\.(qmd|rmd)$/i;
 //
 // Ark declares no `notebookDocumentSync` capability, so the language client
 // syncs these cells as ordinary text documents and the document selector is the
-// only gate. A cell URI keeps the path of the Quarto document the notebook was
-// built from, so restricting the pattern to Quarto extensions keeps the cells of
-// real notebooks (.ipynb) out.
+// only gate. Matching the notebook's type keeps the cells of real notebooks
+// (.ipynb) out, since no other notebook carries this type, and it cannot be
+// fooled by a document whose name resembles a Quarto one.
 const QUARTO_CELL_SELECTOR = {
+	notebook: { notebookType: QUARTO_CELLS_NOTEBOOK_TYPE },
 	language: 'r',
-	scheme: 'vscode-notebook-cell',
-	pattern: '**/*.{qmd,QMD,rmd,Rmd,RMD}',
 };
 
 /**
@@ -67,7 +66,8 @@ function isQuartoVirtualCell(document: vscode.TextDocument): boolean {
 	}
 	return vscode.workspace.notebookDocuments.some(
 		notebook => notebook.notebookType === QUARTO_CELLS_NOTEBOOK_TYPE &&
-			notebook.uri.path === document.uri.path
+			notebook.getCells().some(
+				cell => cell.document.uri.toString() === document.uri.toString())
 	);
 }
 
@@ -175,11 +175,11 @@ export class ArkLsp implements vscode.Disposable {
 
 		// Matches the cells of this client's own notebook.
 		//
-		// Skipped for Quarto sessions, whose notebook URI is the path of the
-		// .qmd document. The only R documents with that path are the cells of
-		// the document's virtual notebook, and the console client serves those,
-		// so matching them here would only duplicate it. For a real notebook
-		// (.ipynb) this is what matches the notebook's own cells.
+		// Skipped for Quarto sessions, whose session URI is the .qmd document.
+		// The only R documents under that path are the cells of the document's
+		// virtual notebook, and the console client serves those, so matching
+		// them here would only duplicate it. For a real notebook (.ipynb) this
+		// is what matches the notebook's own cells.
 		const ownNotebookCellSelectors = notebookUri && !QUARTO_PATH_PATTERN.test(notebookUri.path)
 			? [{ language: 'r', pattern: notebookUri.fsPath }]
 			: [];

--- a/src/vs/workbench/api/common/extHostApiCommands.ts
+++ b/src/vs/workbench/api/common/extHostApiCommands.ts
@@ -28,6 +28,7 @@ import type { IExtensionPromptFileResult } from '../../contrib/chat/common/promp
 // --- Start Positron ---
 import { onUnexpectedExternalError } from '../../../base/common/errors.js';
 import { IQuartoCellSymbols } from '../../contrib/positronQuarto/common/quartoCellSymbols.js';
+import { IQuartoCellFormattingResult } from '../../contrib/positronQuarto/common/quartoCellFormatting.js';
 import type * as positron from 'positron';
 import * as extHostTypes from './positron/extHostTypes.positron.js';
 // --- End Positron ---
@@ -620,6 +621,36 @@ const newCommands: ApiCommand[] = [
 				symbols: toVscodeSymbols(cell.symbols),
 			}));
 		})
+	),
+	// -- quarto cell formatting
+	// Two commands rather than a formatting provider. The Quarto extension's LSP
+	// server declares the formatting capabilities for a `.qmd`, so `quarto.quarto`
+	// is the one formatter a Quarto document has. A second one would make the
+	// choice ambiguous, which turns an explicit format into a "Configure Default
+	// Formatter" modal and makes format-on-save silently do nothing.
+	new ApiCommand(
+		'positron.executeQuartoCellFormattingProvider', '_executeQuartoCellFormattingProvider',
+		'Execute the formatting providers of a Quarto document\'s code cells.',
+		[ApiCommandArgument.Uri],
+		new ApiCommandResult<
+			IQuartoCellFormattingResult,
+			{ edits: types.TextEdit[]; vetoedCells: number }
+		>('A promise that resolves to edits in document coordinates. When vetoedCells is above zero the format was abandoned and edits is empty.', value => ({
+			edits: value.edits.map(typeConverters.TextEdit.to),
+			vetoedCells: value.vetoedCells,
+		}))
+	),
+	new ApiCommand(
+		'positron.executeQuartoCellRangeFormattingProvider', '_executeQuartoCellRangeFormattingProvider',
+		'Execute the range formatting providers of the Quarto code cell a range sits in.',
+		[ApiCommandArgument.Uri, ApiCommandArgument.Range],
+		new ApiCommandResult<
+			IQuartoCellFormattingResult,
+			{ edits: types.TextEdit[]; vetoedCells: number }
+		>('A promise that resolves to edits in document coordinates, or to no edits when the range leaves the cell.', value => ({
+			edits: value.edits.map(typeConverters.TextEdit.to),
+			vetoedCells: value.vetoedCells,
+		}))
 	),
 	// --- End Positron ---
 

--- a/src/vs/workbench/contrib/positronQuarto/browser/positronQuarto.contribution.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/positronQuarto.contribution.ts
@@ -54,6 +54,7 @@ import '../common/positronQuartoConfig.js';
 
 // Import commands to ensure they're registered
 import './quartoCommands.js';
+import './quartoEmbeddedFormatting.js';
 
 // Import editor action bar menu wiring to ensure it's registered
 import './quartoEditorActionBar.js';

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoEmbeddedFormatting.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoEmbeddedFormatting.ts
@@ -1,0 +1,364 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { onUnexpectedExternalError } from '../../../../base/common/errors.js';
+import { assertType } from '../../../../base/common/types.js';
+import { URI } from '../../../../base/common/uri.js';
+import { IRange, Range } from '../../../../editor/common/core/range.js';
+import { ITextModel } from '../../../../editor/common/model.js';
+import { TextEdit } from '../../../../editor/common/languages.js';
+import { ILanguageConfigurationService } from '../../../../editor/common/languages/languageConfigurationRegistry.js';
+import { ILanguageFeaturesService } from '../../../../editor/common/services/languageFeatures.js';
+import { IEditorWorkerService } from '../../../../editor/common/services/editorWorker.js';
+import {
+	getDocumentFormattingEditsUntilResult,
+	getDocumentRangeFormattingEditsUntilResult,
+} from '../../../../editor/contrib/format/browser/format.js';
+import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
+import { ILogService, LogLevel } from '../../../../platform/log/common/log.js';
+import {
+	editsWithinCell,
+	IQuartoCellFormattingResult,
+	resolveProtectedLineEdits,
+	withoutNoOpEdits,
+	withoutTrailingNewlineAtCellEnd,
+} from '../common/quartoCellFormatting.js';
+import { cellRangeToSource, ICellLineSpan, sourceRangeToCell } from '../common/quartoCellPositionMapping.js';
+import { IQuartoVirtualCell, IQuartoVirtualNotebookService } from './quartoVirtualNotebookService.js';
+
+/**
+ * Everything about a cell that formatting it needs, copied before any request
+ * goes out.
+ *
+ * A sync rebuilds the cells, so holding a cell across an await risks reading a
+ * span that has moved or a model that has been disposed. The span is a copy; it
+ * is not a guarantee, since an edit that leaves the chunk structure alone
+ * updates it in place, and the next pass corrects whatever this one missed.
+ */
+interface ICellFormattingRequest {
+	readonly textModel: ITextModel;
+	readonly span: ICellLineSpan;
+	/** The cell's text, for deciding whether the option lines survived. */
+	readonly cellText: string;
+	/**
+	 * Lines the cell's span holds, which is what an edit has to fit inside. Not
+	 * the model's line count: a chunk with no code has a span of no lines while
+	 * its model still has one, and an edit on that line would map onto the
+	 * closing fence.
+	 */
+	readonly spanLineCount: number;
+	/** Last line of the model, and its end column, for the newline invariant. */
+	readonly lastLineNumber: number;
+	readonly lastLineMaxColumn: number;
+	/** The cell language's line comment token, for finding its option lines. */
+	readonly lineCommentToken: string | undefined;
+}
+
+/** What formatting one cell produced. */
+type CellFormattingOutcome =
+	| { readonly kind: 'edits'; readonly edits: TextEdit[] }
+	/** The answer had to be rejected, which abandons the whole document format. */
+	| { readonly kind: 'veto' }
+	/** No formatter, nothing to change, or nothing left after the guards. */
+	| { readonly kind: 'none' };
+
+function noEdits(): IQuartoCellFormattingResult {
+	return { edits: [], vetoedCells: 0 };
+}
+
+function snapshotCell(
+	languageConfiguration: ILanguageConfigurationService,
+	cell: IQuartoVirtualCell
+): ICellFormattingRequest | undefined {
+	const textModel = cell.textModel;
+	if (textModel.isDisposed()) {
+		// Reading a disposed model throws, and that would cost every other cell
+		// its formatting rather than this one. The service drops such a cell on
+		// its next sync.
+		return undefined;
+	}
+
+	const lastLineNumber = textModel.getLineCount();
+	const comments = languageConfiguration
+		.getLanguageConfiguration(textModel.getLanguageId()).comments;
+
+	return {
+		textModel,
+		span: { codeStartLine: cell.codeStartLine, codeEndLine: cell.codeEndLine },
+		cellText: textModel.getValue(),
+		spanLineCount: cell.codeEndLine - cell.codeStartLine + 1,
+		lastLineNumber,
+		lastLineMaxColumn: textModel.getLineMaxColumn(lastLineNumber),
+		lineCommentToken: comments?.lineCommentToken,
+	};
+}
+
+/**
+ * Put one cell's answer through the guards, and map what survives into source
+ * coordinates.
+ *
+ * Order matters. Every count and emptiness test runs after the drops, because a
+ * guard that ran first would judge edits that are no longer there: the trailing
+ * newline is removed before the bounds check, and the bounds check runs before
+ * the option lines are considered.
+ */
+function resolveCellEdits(
+	request: ICellFormattingRequest,
+	rawEdits: TextEdit[] | undefined
+): CellFormattingOutcome {
+	if (!rawEdits || rawEdits.length === 0) {
+		// No formatter for this language, or nothing it wanted to change. The
+		// Quarto extension skips such a block silently and so do we.
+		return { kind: 'none' };
+	}
+
+	if (request.spanLineCount <= 0) {
+		// A chunk with no code. Anything offered for it would land on a fence,
+		// and there is nothing in it to format, so drop rather than veto.
+		return { kind: 'none' };
+	}
+
+	const trimmed = withoutTrailingNewlineAtCellEnd(
+		withoutNoOpEdits(rawEdits), request.lastLineNumber, request.lastLineMaxColumn);
+
+	if (!editsWithinCell(trimmed, request.spanLineCount)) {
+		return { kind: 'veto' };
+	}
+
+	const resolved = resolveProtectedLineEdits(
+		request.cellText, trimmed, request.lineCommentToken);
+	if (resolved === undefined) {
+		return { kind: 'veto' };
+	}
+	if (resolved.length === 0) {
+		return { kind: 'none' };
+	}
+
+	// `eol` is dropped rather than carried over: it applies to a whole document,
+	// so one cell's opinion of the line ending would retarget the source file.
+	return {
+		kind: 'edits',
+		edits: resolved.map(edit => ({
+			range: cellRangeToSource(request.span, edit.range),
+			text: edit.text,
+		})),
+	};
+}
+
+/** Ask one cell's formatters, containing anything they throw. */
+async function formatCell(
+	languageFeatures: ILanguageFeaturesService,
+	workerService: IEditorWorkerService,
+	request: ICellFormattingRequest,
+	token: CancellationToken
+): Promise<TextEdit[] | undefined> {
+	try {
+		return await getDocumentFormattingEditsUntilResult(
+			workerService,
+			languageFeatures,
+			request.textModel,
+			// The cell model's own options, which `ModelService` resolves with the
+			// language as the override identifier. That is the same answer the
+			// Quarto extension computes by hand from the per-language settings.
+			request.textModel.getFormattingOptions(),
+			token
+		);
+	} catch (error) {
+		// One cell's formatter failing must not cost the other cells theirs.
+		onUnexpectedExternalError(error);
+		return undefined;
+	}
+}
+
+/**
+ * Format every code cell of a Quarto document, answering in source coordinates.
+ *
+ * Exposed to extensions as `positron.executeQuartoCellFormattingProvider`, which
+ * is how the Quarto extension formats chunks without writing a temporary file
+ * per block. Core registers no formatting provider of its own: a second
+ * formatter for `.qmd` would make `quarto.quarto` ambiguous, which turns an
+ * explicit format into a "Configure Default Formatter" modal and makes
+ * format-on-save do nothing at all.
+ *
+ * All or nothing, matching the extension: if any cell's answer has to be
+ * rejected, nothing is returned and `vetoedCells` says how many. The message to
+ * the user stays on the extension side, which already has one.
+ */
+export async function provideQuartoCellFormattingEdits(
+	virtualNotebooks: IQuartoVirtualNotebookService,
+	languageFeatures: ILanguageFeaturesService,
+	languageConfiguration: ILanguageConfigurationService,
+	workerService: IEditorWorkerService,
+	logService: ILogService,
+	uri: URI,
+	token: CancellationToken
+): Promise<IQuartoCellFormattingResult> {
+	// Notebook creation is asynchronous, so a request arriving during creation
+	// would otherwise see no cells at all.
+	await virtualNotebooks.whenReady(uri);
+
+	virtualNotebooks.ensureSynchronized(uri);
+
+	const requests = virtualNotebooks.getCells(uri)
+		.map(cell => snapshotCell(languageConfiguration, cell))
+		.filter((request): request is ICellFormattingRequest => request !== undefined);
+
+	if (token.isCancellationRequested) {
+		return noEdits();
+	}
+
+	// Every cell at once. Each request is a round trip to a language server, so
+	// a serial walk would cost their sum instead of the longest of them; on the
+	// 45 chunks of posit-dev/positron#14512 that difference was 5049 ms to 63 ms.
+	const answers = await Promise.all(requests.map(
+		request => formatCell(languageFeatures, workerService, request, token)));
+
+	// Cancelling cannot un-ask a request that already went out. What it must do
+	// is keep a superseded pass from reaching the document.
+	if (token.isCancellationRequested) {
+		return noEdits();
+	}
+
+	const edits: TextEdit[] = [];
+	let vetoedCells = 0;
+	let answeredCells = 0;
+
+	for (let index = 0; index < requests.length; index++) {
+		const outcome = resolveCellEdits(requests[index], answers[index]);
+		if (outcome.kind === 'veto') {
+			vetoedCells++;
+		} else if (outcome.kind === 'edits') {
+			answeredCells++;
+			edits.push(...outcome.edits);
+		}
+	}
+
+	const tracing = logService.getLevel() === LogLevel.Trace;
+
+	if (vetoedCells > 0) {
+		if (tracing) {
+			logService.trace(`[QuartoEmbedded] formatting vetoed by ${vetoedCells} cell(s)`);
+		}
+		return { edits: [], vetoedCells };
+	}
+
+	if (tracing) {
+		logService.trace(`[QuartoEmbedded] formatting answered from ${answeredCells} of ` +
+			`${requests.length} cell(s) with ${edits.length} edit(s)`);
+	}
+
+	return { edits, vetoedCells: 0 };
+}
+
+/**
+ * Format the part of one code cell a range covers.
+ *
+ * Declines a range that leaves the cell, which covers a selection reaching a
+ * fence, the prose around it, or a second chunk. The Quarto extension declines
+ * the same cases today.
+ */
+export async function provideQuartoCellRangeFormattingEdits(
+	virtualNotebooks: IQuartoVirtualNotebookService,
+	languageFeatures: ILanguageFeaturesService,
+	languageConfiguration: ILanguageConfigurationService,
+	workerService: IEditorWorkerService,
+	logService: ILogService,
+	uri: URI,
+	range: IRange,
+	token: CancellationToken
+): Promise<IQuartoCellFormattingResult> {
+	await virtualNotebooks.whenReady(uri);
+
+	virtualNotebooks.ensureSynchronized(uri);
+
+	const cell = virtualNotebooks.getCellAtLine(uri, range.startLineNumber);
+	if (!cell) {
+		return noEdits();
+	}
+
+	const request = snapshotCell(languageConfiguration, cell);
+	if (!request) {
+		return noEdits();
+	}
+
+	const cellRange = sourceRangeToCell(request.span, range);
+	if (!cellRange) {
+		return noEdits();
+	}
+
+	if (token.isCancellationRequested) {
+		return noEdits();
+	}
+
+	let rawEdits: TextEdit[] | undefined;
+	try {
+		rawEdits = await getDocumentRangeFormattingEditsUntilResult(
+			workerService,
+			languageFeatures,
+			request.textModel,
+			Range.lift(cellRange),
+			request.textModel.getFormattingOptions(),
+			token
+		);
+	} catch (error) {
+		onUnexpectedExternalError(error);
+		return noEdits();
+	}
+
+	if (token.isCancellationRequested) {
+		return noEdits();
+	}
+
+	const outcome = resolveCellEdits(request, rawEdits);
+
+	if (logService.getLevel() === LogLevel.Trace) {
+		logService.trace(`[QuartoEmbedded] range formatting ${outcome.kind} for cell ` +
+			`${request.span.codeStartLine}-${request.span.codeEndLine}`);
+	}
+
+	if (outcome.kind === 'veto') {
+		return { edits: [], vetoedCells: 1 };
+	}
+	return outcome.kind === 'edits' ? { edits: outcome.edits, vetoedCells: 0 } : noEdits();
+}
+
+/**
+ * Registered unconditionally, like `_executeQuartoCellSymbolProvider`. No
+ * setting gate is needed: virtual notebooks only exist while
+ * `quarto.embeddedLanguageFeatures.native` is on, so with the setting off there
+ * are no cells and the answer is empty.
+ */
+CommandsRegistry.registerCommand('_executeQuartoCellFormattingProvider', async (accessor, ...args: [URI]) => {
+	const [uri] = args;
+	assertType(URI.isUri(uri));
+
+	return await provideQuartoCellFormattingEdits(
+		accessor.get(IQuartoVirtualNotebookService),
+		accessor.get(ILanguageFeaturesService),
+		accessor.get(ILanguageConfigurationService),
+		accessor.get(IEditorWorkerService),
+		accessor.get(ILogService),
+		uri,
+		CancellationToken.None
+	);
+});
+
+CommandsRegistry.registerCommand('_executeQuartoCellRangeFormattingProvider', async (accessor, ...args: [URI, IRange]) => {
+	const [uri, range] = args;
+	assertType(URI.isUri(uri));
+	assertType(Range.isIRange(range));
+
+	return await provideQuartoCellRangeFormattingEdits(
+		accessor.get(IQuartoVirtualNotebookService),
+		accessor.get(ILanguageFeaturesService),
+		accessor.get(ILanguageConfigurationService),
+		accessor.get(IEditorWorkerService),
+		accessor.get(ILogService),
+		uri,
+		range,
+		CancellationToken.None
+	);
+});

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoVirtualNotebookService.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoVirtualNotebookService.ts
@@ -147,17 +147,24 @@ class QuartoCellsSerializer implements INotebookSerializer {
  * own scheme, since the extension host cannot hold a text document and a notebook
  * document at the same URI.
  *
- * The path is kept because a cell URI carries the path of the notebook it belongs
- * to, and that path is how a language client tells our cells from the cells of a
- * real notebook: both clients select on `**\/*.{qmd,rmd}`. An untitled document
- * has no extension to select on ("Untitled-1", from _Quarto: New Document_), so
- * it gets a Quarto one. Otherwise its cells reach no language server and the
- * document silently has no language features.
+ * The path ends in `.ipynb` because a server that is told about a notebook over
+ * the notebook channel may still decide from the URI whether to index it at all.
+ *
+ * The source document's own extension is kept in front of it so the URI still says
+ * where it came from, and an untitled document, which has none to keep
+ * ("Untitled-1", from _Quarto: New Document_), is given a Quarto one.
+ *
+ * The path is not how anything tells our cells from a real notebook's. That is the
+ * notebook's type, `quarto-cells`, which no other notebook has and which a document
+ * selector matches directly through `notebookType`.
  */
 function quartoNotebookUri(sourceUri: URI): URI {
+	const quartoPath = isQuartoOrRmdFile(sourceUri.path)
+		? sourceUri.path
+		: `${sourceUri.path}.qmd`;
 	return sourceUri.with({
 		scheme: QUARTO_CELLS_SCHEME,
-		path: isQuartoOrRmdFile(sourceUri.path) ? sourceUri.path : `${sourceUri.path}.qmd`,
+		path: `${quartoPath}.ipynb`,
 	});
 }
 

--- a/src/vs/workbench/contrib/positronQuarto/common/quartoCellFormatting.ts
+++ b/src/vs/workbench/contrib/positronQuarto/common/quartoCellFormatting.ts
@@ -1,0 +1,285 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { escapeRegExpCharacters } from '../../../../base/common/strings.js';
+import { Range } from '../../../../editor/common/core/range.js';
+import { TextEdit as CoreTextEdit, TextReplacement } from '../../../../editor/common/core/edits/textEdit.js';
+import { StringText } from '../../../../editor/common/core/text/abstractText.js';
+import { ensureDependenciesAreSet } from '../../../../editor/common/core/text/positionToOffset.js';
+import { TextEdit } from '../../../../editor/common/languages.js';
+
+/**
+ * The answer of a cell formatting command. Edits are in source coordinates.
+ *
+ * This is the shape the extension host converter behind
+ * `positron.executeQuartoCellFormattingProvider` has to describe, so it lives in
+ * `common`: `api/common` cannot import from `positronQuarto/browser`.
+ */
+export interface IQuartoCellFormattingResult {
+	/** Already remapped into source coordinates. Empty when a cell was vetoed. */
+	readonly edits: TextEdit[];
+
+	/**
+	 * Cells whose formatter answer was rejected. Nonzero means the whole document
+	 * format was abandoned, which is what the Quarto extension does today when a
+	 * block's edits are out of range.
+	 */
+	readonly vetoedCells: number;
+}
+
+/**
+ * How many leading lines of a cell are Quarto option directives.
+ *
+ * Mirrors `optionCommentPattern` in the Quarto extension, `^<comment>\s*\| ?`,
+ * so every spelling Quarto's own cell-option parser accepts is counted here:
+ * `#| label`, `#|label`, `# | label`. The count stops at the first line that
+ * does not match, including an empty one, which is also where the extension
+ * stops.
+ *
+ * The pattern is anchored, so an indented `#|` is not an option line. Quarto
+ * does not read it as one either, which is what makes a formatter free to
+ * reindent it.
+ */
+export function countProtectedLeadingLines(
+	cellLines: readonly string[],
+	lineCommentToken: string | undefined
+): number {
+	// `#` is the default in the extension's `langCommentChars`, and the language
+	// configuration of a language without line comments gives nothing to match.
+	const comment = lineCommentToken || '#';
+	const optionPattern = new RegExp(`^${escapeRegExpCharacters(comment)}\\s*\\| ?`);
+
+	let count = 0;
+	for (const line of cellLines) {
+		if (!optionPattern.test(line)) {
+			break;
+		}
+		count++;
+	}
+	return count;
+}
+
+/**
+ * Whether every edit sits inside the cell's own lines.
+ *
+ * Both bounds are checked, like the sibling `fitsCell` the diagnostics path
+ * uses. An answer reaching past the end of the cell would land on the closing
+ * fence or in the prose below it once mapped, and one starting before the
+ * beginning would map to a column of zero, which the extension host rejects
+ * outright when it converts the range.
+ *
+ * `cellLineCount` is the number of lines the cell's **span** holds, not the
+ * line count of its text model. They differ for a chunk with no code, whose
+ * fences are on consecutive lines: the span holds no lines while the model
+ * still has one.
+ */
+export function editsWithinCell(edits: readonly TextEdit[], cellLineCount: number): boolean {
+	return edits.every(edit =>
+		edit.range.startLineNumber >= 1
+		&& edit.range.startColumn >= 1
+		&& edit.range.endLineNumber <= cellLineCount);
+}
+
+/**
+ * Edits that would change nothing removed.
+ *
+ * The editor worker appends one of these to every minimized answer whose input
+ * carried an end-of-line change: `{ eol, text: '', range: 0,0,0,0 }`
+ * (`EditorWorker.$computeMoreMinimalEdits`). The line ending is not ours to
+ * forward, since it belongs to the whole source document rather than to one
+ * cell, so what is left is an edit with no text and no range. Dropping it here
+ * rather than letting the bounds check see it matters: its zero range would
+ * otherwise veto the document format of anyone whose formatter sets an
+ * end-of-line, and the veto would be for an edit that does nothing.
+ */
+export function withoutNoOpEdits(edits: readonly TextEdit[]): TextEdit[] {
+	return edits.filter(
+		edit => edit.text.length > 0 || !Range.lift(edit.range).isEmpty());
+}
+
+/**
+ * Edits with any newline they would leave at the very end of the cell removed.
+ *
+ * A cell's text model carries no trailing newline, because the closing fence
+ * supplies that break in the source document. A formatter that believes it is
+ * looking at a file adds one, and mapped back that grows the chunk by a blank
+ * line on every single format.
+ *
+ * This is an invariant rather than a shape match, because the newline usually
+ * arrives inside a replacement that also reformats code: ruff answers a dirty
+ * cell with one replacement ending `'x = 1\nprint(x)\n'`, and air with a
+ * replacement ending `'x)\n'`. Only when the trim empties a pure insertion is
+ * the edit dropped altogether.
+ */
+export function withoutTrailingNewlineAtCellEnd(
+	edits: readonly TextEdit[],
+	lastLineNumber: number,
+	lastLineMaxColumn: number
+): TextEdit[] {
+	const kept: TextEdit[] = [];
+
+	for (const edit of edits) {
+		const endsCell = edit.range.endLineNumber === lastLineNumber
+			&& edit.range.endColumn === lastLineMaxColumn;
+		if (!endsCell) {
+			kept.push(edit);
+			continue;
+		}
+
+		const trimmed = edit.text.replace(/(\r?\n)+$/, '');
+		if (trimmed.length === 0 && Range.lift(edit.range).isEmpty()) {
+			// Nothing but the newline, and nothing replaced: an artifact.
+			continue;
+		}
+		kept.push(trimmed === edit.text ? edit : { ...edit, text: trimmed });
+	}
+
+	return kept;
+}
+
+/** The first `count` lines of a text, as one string. */
+function firstLines(text: string, count: number): string {
+	return text.split('\n').slice(0, count).join('\n');
+}
+
+/** Lines a range covers, and lines a replacement text occupies. */
+function spannedLineCount(edit: TextEdit): number {
+	return edit.range.endLineNumber - edit.range.startLineNumber + 1;
+}
+
+function textLineCount(text: string): number {
+	return text.split('\n').length;
+}
+
+/**
+ * Apply edits to a text, or answer `undefined` if they cannot be applied.
+ *
+ * Overlap is tested here rather than left to core, whose constructor reports an
+ * overlap through `assertFn`. That may only log, which would leave a garbled
+ * string looking like a successful application.
+ */
+function tryApply(text: string, edits: readonly TextEdit[]): string | undefined {
+	const ranges = edits.map(edit => Range.lift(edit.range))
+		.sort(Range.compareRangesUsingStarts);
+	for (let index = 1; index < ranges.length; index++) {
+		if (!ranges[index - 1].getEndPosition().isBeforeOrEqual(ranges[index].getStartPosition())) {
+			return undefined;
+		}
+	}
+
+	// `StringText` reaches the position transformer, whose dependencies are wired
+	// by a module nothing in this import chain pulls in. Upstream exposes this
+	// call for that, and the diff computer and the editor worker both make it
+	// before using the same machinery. It is a noop after the first call.
+	ensureDependenciesAreSet();
+
+	try {
+		const replacements = edits.map(
+			edit => new TextReplacement(Range.lift(edit.range), edit.text));
+		return CoreTextEdit.fromParallelReplacementsUnsorted(replacements)
+			.apply(new StringText(text));
+	} catch (error) {
+		// An out-of-bounds range, which a provider should not send and which is
+		// not worth losing the rest of the document's format over.
+		return undefined;
+	}
+}
+
+/**
+ * Whether the cell's leading option block came through the edits intact.
+ *
+ * Two things have to hold. The block's own lines must be byte-identical, and no
+ * new directive may have appeared directly below it: Quarto reads a contiguous
+ * run from the top of the cell, so a formatter that promotes the next line into
+ * the run silently gives the chunk another option. Only growth is possible once
+ * the lines above are known identical, so comparing the counts catches it.
+ *
+ * The promotion is not hypothetical. ruff dedents an indented comment, and an
+ * indented `#|` is not an option line to Quarto, so `  #| echo: false` sitting
+ * under the block becomes `#| echo: false` and starts taking effect.
+ */
+function protectedBlockSurvives(
+	before: string,
+	after: string,
+	protectedLineCount: number,
+	lineCommentToken: string | undefined
+): boolean {
+	if (firstLines(after, protectedLineCount) !== firstLines(before, protectedLineCount)) {
+		return false;
+	}
+	return countProtectedLeadingLines(after.split('\n'), lineCommentToken) === protectedLineCount;
+}
+
+/**
+ * The edits that may be forwarded without changing the cell's leading option
+ * lines, decided by applying them rather than by inspecting their ranges.
+ *
+ * Three outcomes, in order:
+ *
+ * 1. The option block survives the whole edit list, so everything is forwarded.
+ *    This is what well-behaved formatters produce; ruff 0.16 and air both leave
+ *    `#|` lines alone.
+ * 2. It does not, but dropping the edits wholly inside the block saves it. Those
+ *    dropped edits must not change the block's line count: an in-place rewrite of
+ *    an option line can be dropped on its own, while a deletion is half of a move
+ *    whose other half would then duplicate the line. This is the
+ *    posit-dev/positron#9432 case, where a formatter normalizes `#|` to `# |`
+ *    while reformatting the code below it.
+ * 3. Neither, so the caller vetoes the cell. Geometry is never trusted on its
+ *    own, because quarto-dev/quarto#655 showed that filtering edits by range can
+ *    keep one half of a pair that only makes sense together.
+ *
+ * The option lines are counted here rather than passed in, so the count and the
+ * text they were counted from cannot disagree.
+ */
+export function resolveProtectedLineEdits(
+	cellText: string,
+	edits: readonly TextEdit[],
+	lineCommentToken: string | undefined
+): readonly TextEdit[] | undefined {
+	const protectedLineCount = countProtectedLeadingLines(cellText.split('\n'), lineCommentToken);
+
+	// Applied even when the cell has no option lines at all. That case still has
+	// to confirm the edits are applicable, since overlap is what core may only
+	// log rather than reject, and that a directive has not appeared at the top.
+	const applied = tryApply(cellText, edits);
+	if (applied !== undefined
+		&& protectedBlockSurvives(cellText, applied, protectedLineCount, lineCommentToken)) {
+		return edits;
+	}
+
+	if (protectedLineCount === 0) {
+		// No block, so nothing sits wholly inside one, so there is nothing to drop
+		// and nothing further to try.
+		return undefined;
+	}
+
+	const kept: TextEdit[] = [];
+	let dropped = 0;
+	for (const edit of edits) {
+		if (edit.range.endLineNumber > protectedLineCount) {
+			kept.push(edit);
+			continue;
+		}
+		if (textLineCount(edit.text) !== spannedLineCount(edit)) {
+			// Adds or removes a line inside the block, so it cannot be an
+			// in-place rewrite, and dropping it would forward the rest of a move.
+			return undefined;
+		}
+		dropped++;
+	}
+
+	if (dropped === 0) {
+		// Nothing to drop, so nothing left to try.
+		return undefined;
+	}
+
+	const reapplied = tryApply(cellText, kept);
+	if (reapplied === undefined
+		|| !protectedBlockSurvives(cellText, reapplied, protectedLineCount, lineCommentToken)) {
+		return undefined;
+	}
+	return kept;
+}

--- a/src/vs/workbench/contrib/positronQuarto/common/quartoVirtualNotebookTypes.ts
+++ b/src/vs/workbench/contrib/positronQuarto/common/quartoVirtualNotebookTypes.ts
@@ -23,10 +23,15 @@ export const QUARTO_CELLS_VIEW_TYPE = 'quarto-cells';
 /**
  * URI scheme of the hidden notebooks.
  *
- * A notebook URI is its source document's URI with the scheme swapped, so the
- * path is preserved and path-pattern LSP selectors still match. The source file
- * URI cannot be reused as-is: the extension host cannot hold a text document
- * and a notebook document at the same URI.
+ * A notebook URI is its source document's URI with the scheme swapped and an
+ * `.ipynb` suffix added, because a server can refuse a notebook on the strength
+ * of its path alone (see `quartoNotebookUri`). The source file URI cannot be
+ * reused as-is: the extension host cannot hold a text document and a notebook
+ * document at the same URI.
+ *
+ * The path is not a way to recognize these cells. An LSP client selects them by
+ * the notebook's type, and code holding a cell URI matches this scheme out of the
+ * cell's fragment.
  */
 export const QUARTO_CELLS_SCHEME = 'quarto-cells';
 

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoEmbeddedFormatting.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoEmbeddedFormatting.vitest.ts
@@ -1,0 +1,478 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { CancellationToken, CancellationTokenSource } from '../../../../../base/common/cancellation.js';
+import { errorHandler } from '../../../../../base/common/errors.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { IRange } from '../../../../../editor/common/core/range.js';
+import { EndOfLineSequence, ITextModel } from '../../../../../editor/common/model.js';
+import { createTextModel } from '../../../../../editor/test/common/testTextModel.js';
+import { LanguageFeaturesService } from '../../../../../editor/common/services/languageFeaturesService.js';
+import {
+	DocumentFormattingEditProvider,
+	DocumentRangeFormattingEditProvider,
+	FormattingOptions,
+	TextEdit,
+} from '../../../../../editor/common/languages.js';
+import { ILanguageConfigurationService, ResolvedLanguageConfiguration } from '../../../../../editor/common/languages/languageConfigurationRegistry.js';
+import { IEditorWorkerService } from '../../../../../editor/common/services/editorWorker.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { IQuartoVirtualCell, IQuartoVirtualNotebookService } from '../../browser/quartoVirtualNotebookService.js';
+import {
+	provideQuartoCellFormattingEdits,
+	provideQuartoCellRangeFormattingEdits,
+} from '../../browser/quartoEmbeddedFormatting.js';
+
+// The source document, with two Python chunks:
+//
+//    1  # Intro
+//    2
+//    3  ```{python}
+//    4  #| label: a
+//    5  import os
+//    6  x  =  1
+//    7  ```
+//    8
+//    9  ```{python}
+//   10  y  =  2
+//   11  ```
+const SOURCE_URI = URI.file('/test/doc.qmd');
+const CELL1_URI = URI.parse('vscode-notebook-cell:/test/doc.qmd#ch0');
+const CELL2_URI = URI.parse('vscode-notebook-cell:/test/doc.qmd#ch1');
+
+const CELL1_TEXT = '#| label: a\nimport os\nx  =  1';
+const CELL2_TEXT = 'y  =  2';
+
+/** An edit as a formatter hands one over. */
+function edit(
+	startLineNumber: number, startColumn: number,
+	endLineNumber: number, endColumn: number,
+	text: string
+): TextEdit {
+	return { range: { startLineNumber, startColumn, endLineNumber, endColumn }, text };
+}
+
+/** Edit list as strings, so an assertion reads without range boilerplate. */
+function shapes(edits: readonly TextEdit[]): string[] {
+	return edits.map(item =>
+		`(${item.range.startLineNumber},${item.range.startColumn})-` +
+		`(${item.range.endLineNumber},${item.range.endColumn}) -> ${JSON.stringify(item.text)}`);
+}
+
+describe('quartoEmbeddedFormatting', () => {
+	const ctx = createTestContainer().build();
+	const logService = new NullLogService();
+
+	let languageFeatures: LanguageFeaturesService;
+	let virtualNotebooks: IQuartoVirtualNotebookService;
+	let languageConfiguration: ILanguageConfigurationService;
+	let workerService: IEditorWorkerService;
+	let calls: string[];
+	let cells: IQuartoVirtualCell[];
+
+	beforeEach(() => {
+		calls = [];
+		languageFeatures = new LanguageFeaturesService();
+
+		// Formatter answers are minimized by the editor worker in production.
+		// Edits pass through unchanged, so a failure points at the guards rather
+		// than at a diff algorithm, with one exception copied faithfully from
+		// `EditorWorker.$computeMoreMinimalEdits`: when any incoming edit carries
+		// `eol`, the real worker appends a sentinel edit with a zero range. A
+		// pass-through stub hides that, and a zero range is exactly what the
+		// extension host refuses to convert.
+		workerService = stubInterface<IEditorWorkerService>({
+			computeMoreMinimalEdits: (_uri, edits) => {
+				const carryingEol = edits?.find(candidate => typeof candidate.eol === 'number');
+				const minimal: TextEdit[] = (edits ?? [])
+					.map(candidate => ({ range: candidate.range, text: candidate.text }));
+				if (carryingEol) {
+					minimal.push({
+						eol: carryingEol.eol,
+						text: '',
+						range: { startLineNumber: 0, startColumn: 0, endLineNumber: 0, endColumn: 0 },
+					});
+				}
+				return Promise.resolve(minimal);
+			},
+		});
+
+		languageConfiguration = stubInterface<ILanguageConfigurationService>({
+			getLanguageConfiguration: () => stubInterface<ResolvedLanguageConfiguration>({
+				comments: { lineCommentToken: '#' },
+			}),
+		});
+
+		cells = [
+			makeCell(CELL1_URI, 'python', CELL1_TEXT, 4, 6),
+			makeCell(CELL2_URI, 'python', CELL2_TEXT, 10, 10),
+		];
+
+		virtualNotebooks = stubInterface<IQuartoVirtualNotebookService>({
+			whenReady: () => Promise.resolve(),
+			ensureSynchronized: () => { calls.push('ensureSynchronized'); },
+			getCells: uri => uri.toString() === SOURCE_URI.toString() ? cells : [],
+			getCellAtLine: (_uri, lineNumber) => cells.find(
+				cell => lineNumber >= cell.codeStartLine && lineNumber <= cell.codeEndLine),
+		});
+	});
+
+	function makeCell(
+		cellUri: URI, language: string, text: string,
+		codeStartLine: number, codeEndLine: number,
+		options?: { indentSize: number }
+	): IQuartoVirtualCell {
+		const textModel: ITextModel = createTextModel(text, language, options, cellUri);
+		ctx.disposables.add(textModel);
+		return { cellUri, handle: 0, language, codeStartLine, codeEndLine, textModel };
+	}
+
+	/** Registers a document formatter that answers with `edits` for `language`. */
+	function registerFormatter(
+		language: string,
+		name: string,
+		answer: (model: ITextModel, options: FormattingOptions) => TextEdit[] | undefined
+	): void {
+		const provider: DocumentFormattingEditProvider = {
+			provideDocumentFormattingEdits(model, options) {
+				calls.push(name);
+				return answer(model, options);
+			},
+		};
+		ctx.disposables.add(
+			languageFeatures.documentFormattingEditProvider.register({ language }, provider));
+	}
+
+	function registerRangeFormatter(
+		language: string,
+		name: string,
+		answer: (model: ITextModel, range: IRange) => TextEdit[] | undefined
+	): void {
+		const provider: DocumentRangeFormattingEditProvider = {
+			provideDocumentRangeFormattingEdits(model, range) {
+				calls.push(name);
+				return answer(model, range);
+			},
+		};
+		ctx.disposables.add(
+			languageFeatures.documentRangeFormattingEditProvider.register({ language }, provider));
+	}
+
+	function format(token: CancellationToken = CancellationToken.None) {
+		return provideQuartoCellFormattingEdits(
+			virtualNotebooks, languageFeatures, languageConfiguration,
+			workerService, logService, SOURCE_URI, token);
+	}
+
+	function formatRange(range: IRange, token: CancellationToken = CancellationToken.None) {
+		return provideQuartoCellRangeFormattingEdits(
+			virtualNotebooks, languageFeatures, languageConfiguration,
+			workerService, logService, SOURCE_URI, range, token);
+	}
+
+	describe('document formatting', () => {
+		it('maps every cell answer into source coordinates, in document order', async () => {
+			registerFormatter('python', 'formatter', model =>
+				model.uri.toString() === CELL1_URI.toString()
+					? [edit(3, 1, 3, 8, 'x = 1')]
+					: [edit(1, 1, 1, 8, 'y = 2')]);
+
+			const result = await format();
+
+			expect({ edits: shapes(result.edits), vetoedCells: result.vetoedCells })
+				.toEqual({
+					edits: [
+						// Cell 1 line 3 is source line 6, cell 2 line 1 is source line 10.
+						'(6,1)-(6,8) -> "x = 1"',
+						'(10,1)-(10,8) -> "y = 2"',
+					],
+					vetoedCells: 0,
+				});
+		});
+
+		it('passes edit text through untouched and drops the worker\'s eol sentinel', async () => {
+			// `eol` retargets a whole document's line endings, so one cell's
+			// opinion of it must not reach the source file. The worker turns it into
+			// a separate zero-range edit, which would map to column zero and make
+			// the extension host reject the whole answer.
+			registerFormatter('python', 'formatter', model =>
+				model.uri.toString() === CELL1_URI.toString()
+					? [{ ...edit(3, 1, 3, 8, 'x\t=\t1'), eol: EndOfLineSequence.CRLF }]
+					: undefined);
+
+			const result = await format();
+
+			expect(result.edits).toMatchInlineSnapshot(`
+				[
+				  {
+				    "range": {
+				      "endColumn": 8,
+				      "endLineNumber": 6,
+				      "startColumn": 1,
+				      "startLineNumber": 6,
+				    },
+				    "text": "x	=	1",
+				  },
+				]
+			`);
+		});
+
+		it('skips a cell with no formatter without vetoing the others', async () => {
+			cells = [
+				makeCell(CELL1_URI, 'python', CELL1_TEXT, 4, 6),
+				// No formatter is registered for R.
+				makeCell(CELL2_URI, 'r', 'z<-1', 10, 10),
+			];
+			registerFormatter('python', 'python-formatter', () => [edit(3, 1, 3, 8, 'x = 1')]);
+
+			const result = await format();
+
+			expect({ edits: shapes(result.edits), vetoedCells: result.vetoedCells })
+				.toEqual({ edits: ['(6,1)-(6,8) -> "x = 1"'], vetoedCells: 0 });
+		});
+
+		it('drops option-line rewrites and keeps the code edits beside them', async () => {
+			// The shape posit-dev/positron#9432 is about: a formatter that
+			// normalizes `#|` to `# |` while reformatting the code below it.
+			registerFormatter('python', 'formatter', model =>
+				model.uri.toString() === CELL1_URI.toString()
+					? [edit(1, 2, 1, 2, ' '), edit(3, 1, 3, 8, 'x = 1')]
+					: undefined);
+
+			const result = await format();
+
+			expect({ edits: shapes(result.edits), vetoedCells: result.vetoedCells })
+				.toEqual({ edits: ['(6,1)-(6,8) -> "x = 1"'], vetoedCells: 0 });
+		});
+
+		it('vetoes the whole document when one cell would lose an option line', async () => {
+			registerFormatter('python', 'formatter', model =>
+				model.uri.toString() === CELL1_URI.toString()
+					// Reaches from the option line into the code below it.
+					? [edit(1, 1, 2, 1, '')]
+					: [edit(1, 1, 1, 8, 'y = 2')]);
+
+			const result = await format();
+
+			// The healthy cell's edits are withheld too: a partial format is what
+			// the Quarto extension refuses to apply as well.
+			expect(result).toEqual({ edits: [], vetoedCells: 1 });
+		});
+
+		it('vetoes an answer that reaches past the end of the cell', async () => {
+			registerFormatter('python', 'formatter', model =>
+				model.uri.toString() === CELL2_URI.toString()
+					// Cell 2 holds one line, so line 2 is the closing fence.
+					? [edit(1, 1, 2, 1, 'y = 2\n')]
+					: undefined);
+
+			const result = await format();
+
+			expect(result).toEqual({ edits: [], vetoedCells: 1 });
+		});
+
+		it('drops a trailing newline at the end of a cell and keeps its siblings', async () => {
+			registerFormatter('python', 'formatter', model =>
+				model.uri.toString() === CELL2_URI.toString()
+					? [edit(1, 1, 1, 8, 'y = 2'), edit(1, 8, 1, 8, '\n')]
+					: undefined);
+
+			const result = await format();
+
+			expect({ edits: shapes(result.edits), vetoedCells: result.vetoedCells })
+				.toEqual({ edits: ['(10,1)-(10,8) -> "y = 2"'], vetoedCells: 0 });
+		});
+
+		it('contributes nothing, and does not veto, when only a trailing newline was offered', async () => {
+			// The common case for an already-formatted chunk. Forwarding it would
+			// grow the chunk by a blank line on every format.
+			registerFormatter('python', 'formatter', model =>
+				model.uri.toString() === CELL2_URI.toString()
+					? [edit(1, 8, 1, 8, '\n')]
+					: undefined);
+
+			const result = await format();
+
+			expect(result).toEqual({ edits: [], vetoedCells: 0 });
+		});
+
+		it('reaches a formatter that only registered for ranges', async () => {
+			// TypeScript registers a range formatter and nothing else, and core
+			// lifts such a provider to document scope. Without that lift those
+			// chunks would format today and stop formatting natively.
+			registerRangeFormatter('python', 'range-formatter', (model, range) => {
+				expect(range).toEqual(model.getFullModelRange());
+				return model.uri.toString() === CELL2_URI.toString()
+					? [edit(1, 1, 1, 8, 'y = 2')]
+					: undefined;
+			});
+
+			const result = await format();
+
+			expect(shapes(result.edits)).toEqual(['(10,1)-(10,8) -> "y = 2"']);
+		});
+
+		it('takes the first answer for a cell and leaves the next provider alone', async () => {
+			// One cell, and one with no option lines, so the answer is not touched
+			// by the guards and this measures only which provider was asked.
+			cells = [makeCell(CELL2_URI, 'python', CELL2_TEXT, 10, 10)];
+			registerFormatter('python', 'second', () => [edit(1, 1, 1, 8, 'second')]);
+			registerFormatter('python', 'first', () => [edit(1, 1, 1, 8, 'first')]);
+
+			const result = await format();
+
+			// `ordered()` puts the most recently registered provider first.
+			expect({ edits: shapes(result.edits), called: calls.filter(c => c !== 'ensureSynchronized') })
+				.toEqual({ edits: ['(10,1)-(10,8) -> "first"'], called: ['first'] });
+		});
+
+		it('formats each cell with that cell model\'s own options', async () => {
+			// Per-language editor settings reach the cell model at creation, which
+			// is where the Quarto extension has to read them by hand instead.
+			//
+			// `indentSize` rather than `tabSize`, because `getFormattingOptions`
+			// reports the model's indent size as the formatter's tab size.
+			cells = [makeCell(CELL1_URI, 'python', CELL1_TEXT, 4, 6, { indentSize: 7 })];
+			const seen: number[] = [];
+			registerFormatter('python', 'formatter', (_model, options) => {
+				seen.push(options.tabSize);
+				return undefined;
+			});
+
+			await format();
+
+			expect(seen).toEqual([7]);
+		});
+
+		it('consults the next provider for a cell when one rejects', async () => {
+			const previous = errorHandler.getUnexpectedErrorHandler();
+			errorHandler.setUnexpectedErrorHandler(() => { });
+			try {
+				cells = [makeCell(CELL2_URI, 'python', CELL2_TEXT, 10, 10)];
+				registerFormatter('python', 'good', () => [edit(1, 1, 1, 8, 'ok')]);
+				// Registered last, so asked first. A rejected promise is what
+				// core's per-provider catch handles, so the walk continues.
+				ctx.disposables.add(languageFeatures.documentFormattingEditProvider.register(
+					{ language: 'python' },
+					{
+						provideDocumentFormattingEdits: () => {
+							calls.push('rejects');
+							return Promise.reject(new Error('provider failed'));
+						},
+					}));
+
+				const result = await format();
+
+				expect({
+					edits: shapes(result.edits),
+					called: calls.filter(call => call !== 'ensureSynchronized'),
+				}).toEqual({ edits: ['(10,1)-(10,8) -> "ok"'], called: ['rejects', 'good'] });
+			} finally {
+				errorHandler.setUnexpectedErrorHandler(previous);
+			}
+		});
+
+		it('contains a provider that throws synchronously, costing only its own cell', async () => {
+			const previous = errorHandler.getUnexpectedErrorHandler();
+			errorHandler.setUnexpectedErrorHandler(() => { });
+			try {
+				registerFormatter('python', 'formatter', model => {
+					if (model.uri.toString() === CELL1_URI.toString()) {
+						throw new Error('provider failed');
+					}
+					return [edit(1, 1, 1, 8, 'y = 2')];
+				});
+
+				const result = await format();
+
+				// Core calls each provider outside its own catch, so a synchronous
+				// throw ends the walk for that cell rather than falling through to
+				// the next provider. The other cell still formats, and a formatter
+				// failing is not grounds for vetoing the document.
+				expect({ edits: shapes(result.edits), vetoedCells: result.vetoedCells })
+					.toEqual({ edits: ['(10,1)-(10,8) -> "y = 2"'], vetoedCells: 0 });
+			} finally {
+				errorHandler.setUnexpectedErrorHandler(previous);
+			}
+		});
+
+		it('contributes nothing for a chunk that holds no code', async () => {
+			// Consecutive fences give a span of no lines while the model still has
+			// one, so an edit on cell line 1 would map onto the closing fence.
+			cells = [makeCell(CELL2_URI, 'python', '', 5, 4)];
+			registerFormatter('python', 'formatter', () => [edit(1, 1, 1, 1, 'x = 1')]);
+
+			const result = await format();
+
+			expect(result).toEqual({ edits: [], vetoedCells: 0 });
+		});
+
+		it('skips a cell whose model was disposed and formats the rest', async () => {
+			const doomed = makeCell(CELL1_URI, 'python', CELL1_TEXT, 4, 6);
+			doomed.textModel.dispose();
+			cells = [doomed, makeCell(CELL2_URI, 'python', CELL2_TEXT, 10, 10)];
+			registerFormatter('python', 'formatter', () => [edit(1, 1, 1, 8, 'y = 2')]);
+
+			const result = await format();
+
+			// Reading a disposed model throws, so getting here at all is the point.
+			expect({ edits: shapes(result.edits), vetoedCells: result.vetoedCells })
+				.toEqual({ edits: ['(10,1)-(10,8) -> "y = 2"'], vetoedCells: 0 });
+		});
+
+		it('answers empty without vetoing when the request is cancelled', async () => {
+			registerFormatter('python', 'formatter', () => [edit(1, 1, 1, 2, 'x')]);
+			const source = new CancellationTokenSource();
+			source.cancel();
+
+			const result = await format(source.token);
+
+			expect({ result, formattersCalled: calls.filter(c => c === 'formatter') })
+				.toEqual({ result: { edits: [], vetoedCells: 0 }, formattersCalled: [] });
+		});
+	});
+
+	describe('range formatting', () => {
+		it('maps a range inside one cell in both directions', async () => {
+			registerRangeFormatter('python', 'range-formatter', (_model, range) => {
+				// Source line 6 is line 3 of the cell.
+				expect(range).toMatchObject({ startLineNumber: 3, endLineNumber: 3 });
+				return [edit(3, 1, 3, 8, 'x = 1')];
+			});
+
+			const result = await formatRange({
+				startLineNumber: 6, startColumn: 1, endLineNumber: 6, endColumn: 8,
+			});
+
+			expect(shapes(result.edits)).toEqual(['(6,1)-(6,8) -> "x = 1"']);
+		});
+
+		it('declines a range that reaches the closing fence', async () => {
+			registerRangeFormatter('python', 'range-formatter', () => [edit(1, 1, 1, 2, 'x')]);
+
+			const result = await formatRange({
+				startLineNumber: 6, startColumn: 1, endLineNumber: 7, endColumn: 1,
+			});
+
+			expect({ result, called: calls.filter(c => c === 'range-formatter') })
+				.toEqual({ result: { edits: [], vetoedCells: 0 }, called: [] });
+		});
+
+		it('declines a range in the prose, where no cell exists', async () => {
+			registerRangeFormatter('python', 'range-formatter', () => [edit(1, 1, 1, 2, 'x')]);
+
+			const result = await formatRange({
+				startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 3,
+			});
+
+			expect({ result, called: calls.filter(c => c === 'range-formatter') })
+				.toEqual({ result: { edits: [], vetoedCells: 0 }, called: [] });
+		});
+	});
+});

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoVirtualNotebookService.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoVirtualNotebookService.vitest.ts
@@ -305,7 +305,7 @@ describe('QuartoVirtualNotebookService', () => {
 		return model;
 	}
 
-	it('creates a hidden notebook whose URI keeps the source path', async () => {
+	it('creates a hidden notebook whose URI keeps the source path, under an .ipynb suffix', async () => {
 		const service = createService();
 		const source = createSourceModel(R_AND_PYTHON);
 		await service.whenReady(source.uri);
@@ -321,38 +321,41 @@ describe('QuartoVirtualNotebookService', () => {
 			cellCount: notebook?.cells.length,
 		}).toEqual({
 			scheme: QUARTO_CELLS_SCHEME,
-			path: source.uri.path,
+			// The suffix is what makes a server willing to index the notebook at
+			// all: ruff refuses any notebook whose path ends in anything else,
+			// which would leave Python cells with no formatter and no linter.
+			path: `${source.uri.path}.ipynb`,
 			viewType: QUARTO_CELLS_VIEW_TYPE,
 			cellCount: 2,
 		});
 	});
 
-	it('gives an untitled document a Quarto path, so the LSP clients match its cells', async () => {
+	it('gives an untitled document a Quarto path, so the URI says where its cells came from', async () => {
 		const service = createService();
 		const source = createUntitledSourceModel(R_AND_PYTHON);
 		await service.whenReady(source.uri);
 
-		// A cell URI carries the path of the notebook it belongs to, and both LSP
-		// clients gate on that path ending in `.qmd` or `.rmd`, which is what
-		// keeps the cells of real notebooks out. A bare untitled path would match
-		// nothing, so the cells would reach no language server.
+		// A cell URI carries the path of the notebook it belongs to. Nothing gates
+		// on that path any more, since a document selector matches these cells by
+		// the notebook's type, but keeping the source extension is what makes a
+		// cell URI in a log or a server trace say which document it belongs to.
 		expect({
 			sourcePath: source.uri.path,
 			notebookPath: service.getNotebookUri(source.uri)?.path,
 			cellPaths: service.getCells(source.uri).map(cell => cell.cellUri.path),
 		}).toEqual({
 			sourcePath: 'Untitled-1',
-			notebookPath: 'Untitled-1.qmd',
-			cellPaths: ['Untitled-1.qmd', 'Untitled-1.qmd'],
+			notebookPath: 'Untitled-1.qmd.ipynb',
+			cellPaths: ['Untitled-1.qmd.ipynb', 'Untitled-1.qmd.ipynb'],
 		});
 	});
 
-	it('leaves an untitled document that already has a Quarto path alone', async () => {
+	it('does not add a second Quarto extension to an untitled document that has one', async () => {
 		const service = createService();
 		const source = createUntitledSourceModel(R_AND_PYTHON, 'Untitled-1.qmd');
 		await service.whenReady(source.uri);
 
-		expect(service.getNotebookUri(source.uri)?.path).toBe('Untitled-1.qmd');
+		expect(service.getNotebookUri(source.uri)?.path).toBe('Untitled-1.qmd.ipynb');
 	});
 
 	it('creates one bound cell text model per code cell, holding only the code', async () => {
@@ -370,7 +373,7 @@ describe('QuartoVirtualNotebookService', () => {
 		}))).toEqual([
 			{
 				scheme: Schemas.vscodeNotebookCell,
-				path: source.uri.path,
+				path: `${source.uri.path}.ipynb`,
 				language: 'r',
 				text: 'x <- 1',
 				codeStartLine: 4,
@@ -378,7 +381,7 @@ describe('QuartoVirtualNotebookService', () => {
 			},
 			{
 				scheme: Schemas.vscodeNotebookCell,
-				path: source.uri.path,
+				path: `${source.uri.path}.ipynb`,
 				language: 'python',
 				text: 'import os',
 				codeStartLine: 8,

--- a/src/vs/workbench/contrib/positronQuarto/test/common/quartoCellFormatting.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/common/quartoCellFormatting.vitest.ts
@@ -1,0 +1,275 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { TextEdit } from '../../../../../editor/common/languages.js';
+import {
+	countProtectedLeadingLines,
+	editsWithinCell,
+	resolveProtectedLineEdits,
+	withoutNoOpEdits,
+	withoutTrailingNewlineAtCellEnd,
+} from '../../common/quartoCellFormatting.js';
+
+/** A text edit, written the way a formatter hands one over. */
+function edit(
+	startLineNumber: number, startColumn: number,
+	endLineNumber: number, endColumn: number,
+	text: string
+): TextEdit {
+	return { range: { startLineNumber, startColumn, endLineNumber, endColumn }, text };
+}
+
+/** The shape of an edit list, for comparing without the range boilerplate. */
+function shapes(edits: readonly TextEdit[] | undefined): string[] | undefined {
+	return edits?.map(item =>
+		`(${item.range.startLineNumber},${item.range.startColumn})-` +
+		`(${item.range.endLineNumber},${item.range.endColumn}) -> ${JSON.stringify(item.text)}`);
+}
+
+describe('countProtectedLeadingLines', () => {
+	it('counts the option-line spellings Quarto recognizes, and stops at the first other line', () => {
+		// Every variant `optionCommentPattern` accepts, which is
+		// `^<comment>\s*\| ?` in the Quarto extension.
+		expect({
+			spaced: countProtectedLeadingLines(['#| label: a', 'x = 1'], '#'),
+			noSpaceAfterPipe: countProtectedLeadingLines(['#|label: a', 'x = 1'], '#'),
+			spaceBeforePipe: countProtectedLeadingLines(['# | label: a', 'x = 1'], '#'),
+			severalThenCode: countProtectedLeadingLines(
+				['#| label: a', '#| echo: false', 'x = 1'], '#'),
+			// An empty line ends the run, as it does in the extension: the count
+			// stops at the first line that does not match, whatever it is.
+			blankLineStops: countProtectedLeadingLines(
+				['#| label: a', '', '#| echo: false'], '#'),
+			allOptionLines: countProtectedLeadingLines(['#| label: a', '#| echo: false'], '#'),
+			noOptionLines: countProtectedLeadingLines(['x = 1', 'y = 2'], '#'),
+			empty: countProtectedLeadingLines([], '#'),
+		}).toMatchInlineSnapshot(`
+			{
+			  "allOptionLines": 2,
+			  "blankLineStops": 1,
+			  "empty": 0,
+			  "noOptionLines": 0,
+			  "noSpaceAfterPipe": 1,
+			  "severalThenCode": 2,
+			  "spaceBeforePipe": 1,
+			  "spaced": 1,
+			}
+		`);
+	});
+
+	it('does not count an indented option line, which is not one to Quarto either', () => {
+		// The pattern is anchored at column 0, so Quarto does not read this as a
+		// cell option and neither do we. It matters because ruff dedents such a
+		// line, and that edit must not be treated as touching a protected line.
+		expect(countProtectedLeadingLines(['  #| label: a', 'x = 1'], '#')).toBe(0);
+	});
+
+	it('takes the comment token from the language, and only counts leading lines', () => {
+		expect({
+			doubleSlash: countProtectedLeadingLines(['//| label: a', 'const x = 1;'], '//'),
+			hashDoesNotMatchSlashLanguage: countProtectedLeadingLines(['#| label: a'], '//'),
+			// No language configuration: `#` is the default in `langCommentChars`.
+			fallsBackToHash: countProtectedLeadingLines(['#| label: a', 'x = 1'], undefined),
+			// Below code, so not leading, so not protected.
+			belowCode: countProtectedLeadingLines(['x = 1', '#| label: a'], '#'),
+		}).toEqual({
+			doubleSlash: 1,
+			hashDoesNotMatchSlashLanguage: 0,
+			fallsBackToHash: 1,
+			belowCode: 0,
+		});
+	});
+});
+
+describe('editsWithinCell', () => {
+	it('accepts an edit ending on the last line and rejects one past it', () => {
+		expect({
+			onLastLine: editsWithinCell([edit(3, 1, 3, 6, 'x = 1')], 3),
+			pastLastLine: editsWithinCell([edit(3, 1, 4, 1, 'x = 1')], 3),
+			// A span with no lines at all, which is what an empty chunk gives.
+			emptyCell: editsWithinCell([edit(1, 1, 1, 1, 'x')], 0),
+		}).toEqual({ onLastLine: true, pastLastLine: false, emptyCell: false });
+	});
+
+	it('rejects an edit that starts before the beginning of the cell', () => {
+		// The lower bound is what stops a zero range reaching `cellRangeToSource`,
+		// whose answer would carry column zero. The extension host throws on that
+		// rather than dropping the edit, which would fail the whole format.
+		expect({
+			lineZero: editsWithinCell([edit(0, 1, 1, 1, 'x')], 3),
+			columnZero: editsWithinCell([edit(1, 0, 1, 1, 'x')], 3),
+			zeroRange: editsWithinCell([edit(0, 0, 0, 0, '')], 3),
+		}).toEqual({ lineZero: false, columnZero: false, zeroRange: false });
+	});
+});
+
+describe('withoutNoOpEdits', () => {
+	it('drops the editor worker\'s end-of-line sentinel and keeps real edits', () => {
+		// `EditorWorker.$computeMoreMinimalEdits` appends exactly this whenever an
+		// incoming edit carried `eol`. The line ending belongs to the source
+		// document rather than to a cell, so what is left changes nothing.
+		const sentinel: TextEdit = { ...edit(0, 0, 0, 0, ''), eol: 1 };
+
+		expect(shapes(withoutNoOpEdits([edit(1, 1, 1, 8, 'x = 1'), sentinel])))
+			.toEqual(['(1,1)-(1,8) -> "x = 1"']);
+	});
+
+	it('keeps a deletion, which has no text but does have a range', () => {
+		expect(shapes(withoutNoOpEdits([edit(1, 1, 2, 1, '')])))
+			.toEqual(['(1,1)-(2,1) -> ""']);
+	});
+});
+
+describe('withoutTrailingNewlineAtCellEnd', () => {
+	// A cell whose last line is line 3, `print(y)`, so its end is (3, 9).
+	const lastLineNumber = 3;
+	const lastLineMaxColumn = 9;
+
+	it('drops a newline-only insertion at the end of the cell', () => {
+		// air's real answer for a cell that only lacks a final newline.
+		expect(shapes(withoutTrailingNewlineAtCellEnd(
+			[edit(3, 9, 3, 9, '\n')], lastLineNumber, lastLineMaxColumn))).toEqual([]);
+	});
+
+	it('keeps the code of a replacement that ends the cell, and trims its trailing newline', () => {
+		// ruff's real answer: the newline arrives inside a replacement that also
+		// reformats code, so a rule matching only pure insertions would forward
+		// it and grow the chunk by a blank line on every format.
+		expect(shapes(withoutTrailingNewlineAtCellEnd(
+			[edit(2, 1, 3, 9, 'y = 1\nprint(y)\n')], lastLineNumber, lastLineMaxColumn)))
+			.toEqual(['(2,1)-(3,9) -> "y = 1\\nprint(y)"']);
+	});
+
+	it('leaves newlines alone when they are not at the end of the cell', () => {
+		expect(shapes(withoutTrailingNewlineAtCellEnd([
+			// Mid-cell insertion of a blank line: a real formatting decision.
+			edit(2, 1, 2, 1, '\n'),
+			// At the end of the cell, but carrying content, so not an artifact.
+			edit(3, 9, 3, 9, '\nz = 2'),
+		], lastLineNumber, lastLineMaxColumn))).toEqual([
+			'(2,1)-(2,1) -> "\\n"',
+			'(3,9)-(3,9) -> "\\nz = 2"',
+		]);
+	});
+
+	it('trims a CRLF ending as well', () => {
+		expect(shapes(withoutTrailingNewlineAtCellEnd(
+			[edit(3, 1, 3, 9, 'print(y)\r\n')], lastLineNumber, lastLineMaxColumn)))
+			.toEqual(['(3,1)-(3,9) -> "print(y)"']);
+	});
+});
+
+describe('resolveProtectedLineEdits', () => {
+	// Two option lines, a blank line, then two lines of code.
+	const cellText = '#| label: a\n#| echo: false\n\nx  =  1\nprint( x )';
+
+	it('returns the edits untouched when the cell has no option lines', () => {
+		const edits = [edit(1, 1, 1, 8, 'x = 1')];
+		expect(resolveProtectedLineEdits('x  =  1', edits, '#')).toBe(edits);
+	});
+
+	it('forwards every edit when they all sit below the option block', () => {
+		expect(shapes(resolveProtectedLineEdits(cellText, [
+			edit(4, 1, 4, 8, 'x = 1'),
+			edit(5, 1, 5, 11, 'print(x)'),
+		], '#'))).toEqual([
+			'(4,1)-(4,8) -> "x = 1"',
+			'(5,1)-(5,11) -> "print(x)"',
+		]);
+	});
+
+	it('drops in-place option-line rewrites and keeps the code edits', () => {
+		// The posit-dev/positron#9432 shape: a formatter that normalizes `#|` to
+		// `# |` while also reformatting the code below. Dropping the two
+		// normalizations restores the option lines byte for byte, so the code
+		// edits are safe to forward.
+		expect(shapes(resolveProtectedLineEdits(cellText, [
+			edit(1, 2, 1, 2, ' '),
+			edit(2, 2, 2, 2, ' '),
+			edit(4, 1, 4, 8, 'x = 1'),
+		], '#'))).toEqual(['(4,1)-(4,8) -> "x = 1"']);
+	});
+
+	it('vetoes an edit that deletes an option line', () => {
+		// Reaches from the start of the last option line into the line below it,
+		// so there is nothing wholly inside the block to drop and no way to save
+		// the line.
+		expect(resolveProtectedLineEdits(
+			cellText, [edit(2, 1, 3, 1, '')], '#')).toBeUndefined();
+	});
+
+	it('vetoes an edit that merges an option line into the code below', () => {
+		expect(resolveProtectedLineEdits(
+			cellText, [edit(2, 15, 4, 1, ' ')], '#')).toBeUndefined();
+	});
+
+	it('vetoes an in-block edit that changes the line count instead of dropping it', () => {
+		// A formatter moving an option line below the code: a deletion wholly
+		// inside the block, plus the reinsertion under it. Dropping the deletion
+		// on its own would leave the option lines byte-identical and forward the
+		// insertion, so the line would appear twice. Line count is what separates
+		// a move from an in-place rewrite, so this vetoes instead.
+		expect(resolveProtectedLineEdits(cellText, [
+			edit(1, 1, 2, 1, ''),
+			edit(4, 1, 4, 1, '#| label: a\n'),
+		], '#')).toBeUndefined();
+	});
+
+	it('forwards a straddling edit that leaves the option lines byte-identical', () => {
+		// Reaches from inside the block to below it, but rewrites only what comes
+		// after. Verifying the outcome forwards this; vetoing on geometry alone
+		// would have rejected it.
+		expect(shapes(resolveProtectedLineEdits(cellText, [
+			edit(2, 15, 4, 8, '\n\nx = 1'),
+		], '#'))).toEqual(['(2,15)-(4,8) -> "\\n\\nx = 1"']);
+	});
+
+	it('vetoes an edit that promotes the line below the block into an option', () => {
+		// ruff dedents an indented comment, and an indented `#|` is not an option
+		// line to Quarto. Dedenting one that sits directly under the block adds a
+		// directive to the cell, which changes how the chunk executes, while the
+		// block's own lines come through untouched.
+		const withIndentedDirective = '#| label: a\n  #| echo: false\nx = 1';
+
+		expect(resolveProtectedLineEdits(
+			withIndentedDirective, [edit(2, 1, 2, 3, '')], '#')).toBeUndefined();
+	});
+
+	it('vetoes an edit that promotes the first line of a cell that had no block', () => {
+		// The same hazard with nothing to protect yet: the dedent gives the chunk
+		// its first option line.
+		expect(resolveProtectedLineEdits(
+			'  #| echo: false\nx = 1', [edit(1, 1, 1, 3, '')], '#')).toBeUndefined();
+	});
+
+	it('forwards an edit that leaves an indented directive further down alone', () => {
+		// Only the line directly below the block can join it, so a dedent deeper
+		// in the cell is an ordinary comment change.
+		const edits = [edit(3, 1, 3, 3, '')];
+		expect(shapes(resolveProtectedLineEdits(
+			'#| label: a\nx = 1\n  #| not an option\n', edits, '#')))
+			.toEqual(['(3,1)-(3,3) -> ""']);
+	});
+
+	it('vetoes overlapping edits even when there are no option lines to protect', () => {
+		// The early return for zero protected lines still has to confirm the
+		// answer can be applied at all.
+		expect(resolveProtectedLineEdits('x  =  1\nprint( x )', [
+			edit(1, 1, 1, 8, 'x = 1'),
+			edit(1, 3, 2, 11, 'nonsense'),
+		], '#')).toBeUndefined();
+	});
+
+	it('vetoes overlapping edits rather than throwing', () => {
+		// Core's edit machinery rejects replacements that overlap, and a
+		// misbehaving provider is not a reason to lose the whole format.
+		expect(resolveProtectedLineEdits(cellText, [
+			edit(4, 1, 4, 8, 'x = 1'),
+			edit(4, 3, 5, 11, 'nonsense'),
+		], '#')).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Addresses: 

- #12837
- #14540

This PR has two changes that together let Positron format the code cells of a Quarto document with the language formatters those cells already reach via the virtual notebook. Neither is user-visible yet; the Quarto extension still formats through temporary files, and pointing its middleware at the new commands is a follow-up in that repository.

We are getting _very close_ to being able to run this for real!!!

**The hidden notebook is now named with an `.ipynb` suffix.** Positron builds a hidden notebook for each open Quarto document so that language servers see its chunks as ordinary notebook cells. ruff refuses any notebook whose URI path does not end in `.ipynb`, so it dropped these notebooks at open, and Python cells reached no formatter and no linter.

That path was also how the R and Python language clients recognized our cells, with the glob `**/*.{qmd,QMD,rmd,Rmd,RMD}`. Both clients now match the notebook's **type** instead. I think this is better because the type is exact where the glob was a proxy, and now a real notebook that a user names `analysis.qmd.ipynb` cannot fool it. The selectors are written in the protocol's notebook-cell form, `{ notebook: { notebookType }, language }`, because `vscode-languageclient` rebuilds each filter through `asDocumentSelector` before matching and drops a bare `notebookType`, which would widen the filter to every R or Python document.

**Two commands format the cells.** `positron.executeQuartoCellFormattingProvider` takes a document and `positron.executeQuartoCellRangeFormattingProvider` takes a range. Core registers no formatting provider of its own. The Quarto extension's LSP server declares the formatting capabilities for a `.qmd`, so `quarto.quarto` is the one formatter such a document has. A second formatter would make the choice ambiguous, and format-on-save could never return anything at all.

Each cell goes through `getDocumentFormattingEditsUntilResult`. Cells are asked in parallel, and each formats with its own model options, which core resolves per language.  I am estimating from some benchmarking that this is going to be 5x to 10x faster than the old approach, and maybe much more on very long documents.

Because nothing calls the new commands yet, I validated them with a throwaway probe extension that calls them on the active document and prints the answer. On a five-chunk test document, ruff produced nine edits, each on code inside a chunk, with the `#|` lines untouched, the `{mermaid}` chunks skipped, and no vetoes:

<img width="1566" height="1165" alt="Screenshot 2026-08-26 at 9 01 15 PM" src="https://github.com/user-attachments/assets/61cf5678-e7ea-41e8-ae97-1de69e20fe1b" />


### QA Notes

Automated coverage is 39 new unit tests over the two new modules, and every guard was checked by breaking it and confirming a test fails. Nothing automated exercises a real formatter, though. Those fixtures are recorded ruff and air output rather than live runs. 

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

@:quarto @:r-markdown @:notebooks @:pyrefly

The first three steps are the regression checks for the selector rewrite, and matter more than the rest.

1. With `quarto.embeddedLanguageFeatures.native` on, open a `.qmd` with an R chunk and a Python chunk. Completions and hover work in both chunks.
2. Open a plain `.R` script and a plain `.py` script. Completions still work, and nothing from the Quarto path leaks in.
3. Open a real `.ipynb` with a kernel running and complete inside a cell. Completions appear once, not twice. A duplicate here means a cell selector widened to every document of that language.
4. Trace level, Output panel, **Window** channel: opening the `.qmd` logs `[QuartoVirtualNotebook] Created quarto-cells:/.../doc.qmd.ipynb with N cells`.
5. Run _Quarto: New Document_, paste an R chunk, and confirm completions work there too. An untitled document is the one case that synthesizes an extension.
6. _Format Document_ on the `.qmd` still formats through the Quarto extension exactly as before, since this PR does not change that path.
