### PR TITLE
Add prune-ci-images skill for GHCR image cleanup

### DIFF
--- a/.claude/skills/prune-ci-images/SKILL.md
+++ b/.claude/skills/prune-ci-images/SKILL.md
@@ -11,6 +11,8 @@ Two-phase, human-gated cleanup of stale container versions in
 1. **Audit** (read-only) -> a markdown review list of deletion candidates.
 2. **Human review** -> the reviewer removes rows they want to KEEP.
 3. **Prune** -> batch-delete exactly the rows that remain.
+4. **Delete emptied packages** (optional, separate approval) -> clear packages
+   that are down to a last tagged version GHCR will not remove.
 
 `<dir>` below means `.claude/skills/prune-ci-images`.
 
@@ -98,8 +100,10 @@ tagged image.
 ### Reading the report
 
 - **"Packages that would be emptied completely"** -- every version of these is a
-  candidate, so GHCR will hide the package entirely. Surface this list to the
-  user explicitly and confirm the image is retired before deleting.
+  candidate. **GHCR refuses to delete a package's last tagged version**, so the
+  prune step deletes all but one and reports the final version as a failure.
+  That is expected, not a bug; clearing them needs phase 4. Surface this list to
+  the user explicitly and confirm the image is retired.
 - **"Warning: manifests that could not be resolved"** -- registry reads failed,
   so the protected set may be incomplete. Do not proceed on a list with this
   section; fix access and re-run.
@@ -161,6 +165,44 @@ Then, only after explicit user approval:
 
 It deletes one version at a time, prints a line per deletion, and exits non-zero
 with a failure summary if any call fails.
+
+## Phase 4 -- Delete emptied packages (optional)
+
+Only for packages the audit listed under "would be emptied completely" and whose
+last version the prune step could not delete. GHCR reports that block two ways,
+and **the second message is misleading**:
+
+```
+You cannot delete the last tagged version of a package. You must delete the
+package instead. (HTTP 400)
+
+Publicly visible package versions with more than 5000 downloads cannot be
+deleted. Contact GitHub support for further assistance. (HTTP 400)
+```
+
+The second appears verbatim even for `private` and `internal` packages, where
+"publicly visible" is simply false. Do not chase it or open a support ticket --
+treat both as "this is the last tagged version". `ghcr-prune.sh` classifies them
+together and prints the follow-up command.
+
+This is a **bigger action than deleting versions** and needs its own explicit
+approval: the package disappears from the org package list, and restore is less
+reliable for a whole package than for a single version. Get the user to confirm
+the specific list, then:
+
+```bash
+<dir>/scripts/ghcr-delete-packages.sh --org posit-dev --repo-path "$REPO" \
+  --package <name> --package <name> ...
+```
+
+Dry run unless given `--confirm`. It prints each package's visibility, version
+count, and tags first, and aborts if a package cannot be read (already deleted,
+or a typo) or if `--repo-path` still mentions the package **by name** anywhere
+under `.github/`, `docker/`, `test/`, `scripts/`, or `build/`. That name check is
+stricter than the tag check used in phases 1 and 3, which is what you want when
+removing a whole image.
+
+Package deletion needs admin rights on the package, not just `delete:packages`.
 
 ## After pruning
 

--- a/.claude/skills/prune-ci-images/SKILL.md
+++ b/.claude/skills/prune-ci-images/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: prune-ci-images
+description: Audit old container images in the posit-dev GHCR registry and delete them in a reviewed batch. Produces a review list of every positron-<os>* / positron-postgres-* image version older than a cutoff (default 90 days), excluding anything a live tag or multi-arch manifest still points at; the human deletes rows they want to keep, then this drives the batch delete. Use when asked to clean up, prune, or garbage-collect old GHCR packages/images.
+---
+
+# Prune old CI images from GHCR
+
+Two-phase, human-gated cleanup of stale container versions in
+`https://github.com/orgs/posit-dev/packages`:
+
+1. **Audit** (read-only) -> a markdown review list of deletion candidates.
+2. **Human review** -> the reviewer removes rows they want to KEEP.
+3. **Prune** -> batch-delete exactly the rows that remain.
+
+`<dir>` below means `.claude/skills/prune-ci-images`.
+
+**Deletion is irreversible.** A deleted version cannot be restored, and any
+workflow or branch pinning that tag breaks. Never run the prune step with
+`--confirm` until the human has explicitly approved the reviewed list.
+
+## Preflight
+
+```bash
+gh auth status          # needs read:packages AND delete:packages
+```
+
+`read:packages` alone is enough for the audit. The prune step checks for
+`delete:packages` itself and refuses to run without it. To add it:
+
+```bash
+gh auth refresh -h github.com -s read:packages -s delete:packages
+```
+
+The token also needs to be for an account with admin rights on the packages;
+org member read access is not sufficient to delete.
+
+## Phase 1 -- Audit
+
+```bash
+<dir>/scripts/ghcr-audit.sh \
+  --repo-path "$REPO" \
+  --out /tmp/ghcr-review-list.md
+```
+
+Options:
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--org` | `posit-dev` | Org that owns the packages |
+| `--age-days` | `90` | Candidates must be older than this |
+| `--pattern` | see below | ERE matched against package names |
+| `--repo-path` | none | Checkout to scan for in-use image tags |
+| `--protect-tag` | none | Extra tag to treat as in-use (repeatable) |
+| `--out` | stdout | Where to write the review list |
+
+Default pattern:
+
+```
+^positron-(postgres|ubuntu|rocky|debian|opensuse|sles|windows|amazonlinux|fedora|alpine|centos)
+```
+
+This deliberately covers the OS images and postgres images (both the multi-arch
+index packages like `positron-rocky8` and the per-arch ones like
+`positron-rocky8-amd64`), and deliberately **excludes** other `positron-*`
+packages that are not OS images: `positron-builds-rocky8`, `positron-ci`,
+`positron-sagemaker`, `positron-debian13` variants are covered, but
+build/tooling images are not. Widen with `--pattern` only on request.
+
+Always pass `--repo-path`. Without it nothing is treated as in-use and live
+tags land in the candidate list.
+
+### What the audit protects automatically
+
+A version is **retained** (never listed) when:
+
+- it is newer than the cutoff, or
+- one of its tags is referenced as `ghcr.io/<owner>/<pkg>:<tag>` under
+  `.github/`, `docker/`, `test/`, `scripts/`, or `build/` in `--repo-path`, or
+- it is a child manifest of a retained multi-arch index. The audit resolves
+  every retained version against the ghcr.io registry API and protects the
+  per-arch digests it points at. These appear in an
+  "Excluded: children of retained images" section of the report.
+
+That last rule is the one that matters most. The multi-arch build pushes an
+index plus two **untagged** per-arch manifests into the same package, all in the
+same second. The untagged rows look like garbage but deleting them breaks the
+tagged image.
+
+### Reading the report
+
+- **"Packages that would be emptied completely"** -- every version of these is a
+  candidate, so GHCR will hide the package entirely. Surface this list to the
+  user explicitly and confirm the image is retired before deleting.
+- **"Warning: manifests that could not be resolved"** -- registry reads failed,
+  so the protected set may be incomplete. Do not proceed on a list with this
+  section; fix access and re-run.
+- **`kind` column** -- `tagged`, `untagged` (an orphaned index whose tag moved
+  away), or `arch child` (a per-arch manifest under a candidate index).
+- **`group` column** -- ties an index to its children. Rows sharing a group must
+  be kept or deleted together.
+
+## Phase 2 -- Human review
+
+Hand the file to the user and state plainly:
+
+- how many candidates there are and the cutoff used,
+- which packages would be emptied entirely,
+- that **every row listed will be deleted**, and they should **delete the rows
+  they want to keep**,
+- that rows sharing a `group` must be kept or removed as a unit,
+- that `id` and `group` columns must not be edited.
+
+Wait for the user to confirm the reviewed file. Do not guess at approval.
+
+## Phase 3 -- Prune
+
+Dry run first, always:
+
+```bash
+<dir>/scripts/ghcr-prune.sh --list /tmp/ghcr-review-list.md
+```
+
+It parses the table, re-resolves every listed version against the registry, and
+**aborts** if a listed index has a child that is no longer listed (a split
+group). Fix the list rather than reaching for `--allow-split-group`.
+
+Then, only after explicit user approval:
+
+```bash
+<dir>/scripts/ghcr-prune.sh --list /tmp/ghcr-review-list.md --confirm
+```
+
+It deletes one version at a time, prints a line per deletion, and exits non-zero
+with a failure summary if any call fails. Failures are safe to retry -- already
+deleted ids return 404 and are reported as failures, so re-run with a list
+trimmed to what remains, or just report the failures.
+
+## After pruning
+
+Report deleted/failed counts per package. If a package was emptied, note that it
+no longer appears in the org package list. Nothing in the repo needs updating --
+the audit already refused to touch tags the repo references.
+
+## Known limits
+
+- The in-use scan reads the **working tree only**. Tags referenced solely by an
+  older release branch, a reverted commit, or an external repo are invisible to
+  it. For anything load-bearing, pass `--protect-tag` or keep the row.
+- GHCR reports no pull statistics through this API, so "last pulled" cannot
+  inform the cutoff. Age is the only signal available.
+- Untagged versions in *per-arch* packages (`positron-rocky8-amd64`) are not
+  cross-repo children of the index packages; OCI indexes reference digests in
+  their own repository. Deleting old per-arch versions does not break the
+  corresponding `positron-rocky8:<tag>` index.

--- a/.claude/skills/prune-ci-images/SKILL.md
+++ b/.claude/skills/prune-ci-images/SKILL.md
@@ -14,8 +14,17 @@ Two-phase, human-gated cleanup of stale container versions in
 
 `<dir>` below means `.claude/skills/prune-ci-images`.
 
-**Deletion is irreversible.** A deleted version cannot be restored, and any
-workflow or branch pinning that tag breaks. Never run the prune step with
+**Deletion is disruptive and only conditionally recoverable.** GitHub can
+usually restore a deleted package version within **30 days**, provided the
+package still exists and that version/tag has not been re-pushed:
+
+```bash
+gh api -X POST /orgs/<org>/packages/container/<pkg>/versions/<id>/restore
+```
+
+Do not rely on that. Restoring is manual and per-version, and it does nothing
+about the immediate breakage: any workflow or branch pinning a deleted tag
+fails as soon as the version goes away. Never run the prune step with
 `--confirm` until the human has explicitly approved the reviewed list.
 
 ## Preflight
@@ -114,26 +123,44 @@ Wait for the user to confirm the reviewed file. Do not guess at approval.
 
 ## Phase 3 -- Prune
 
-Dry run first, always:
+Dry run first, always. Pass the **same** `--repo-path` used for the audit:
 
 ```bash
-<dir>/scripts/ghcr-prune.sh --list /tmp/ghcr-review-list.md
+<dir>/scripts/ghcr-prune.sh --list /tmp/ghcr-review-list.md --repo-path "$REPO"
 ```
 
-It parses the table, re-resolves every listed version against the registry, and
-**aborts** if a listed index has a child that is no longer listed (a split
-group). Fix the list rather than reaching for `--allow-split-group`.
+The prune step does not trust the review list. Time passes between the audit and
+the human's approval, so it re-derives safety from the live registry and
+**aborts** on any of:
+
+1. **Unreadable state** -- a package's versions or any manifest in an involved
+   package cannot be read. Every check **fails closed**: an unresolvable
+   manifest is never treated as "has no children", because that is exactly how
+   a live per-arch manifest would get deleted.
+2. **Tag drift** -- a listed version's tags no longer match what the audit
+   recorded. This is the retag case: a digest that was garbage at audit time has
+   since been given a tag and put back into use.
+3. **Now in use** -- a listed version's tag is referenced in `--repo-path` (or
+   `--protect-tag`). Catches a tag that became load-bearing after the audit.
+4. **Still referenced by a retained index** -- the protected set is recomputed
+   from scratch as the children of every version *not* listed for deletion.
+5. **Split group** -- a listed index has a child that is no longer listed. Fix
+   the list rather than reaching for `--allow-split-group`.
+
+Versions that no longer exist are reported and skipped, not treated as errors,
+so a partially completed run is safe to re-run with the same list.
+
+If it aborts, relay the reason and re-run `ghcr-audit.sh` to regenerate the list
+rather than hand-editing around the check.
 
 Then, only after explicit user approval:
 
 ```bash
-<dir>/scripts/ghcr-prune.sh --list /tmp/ghcr-review-list.md --confirm
+<dir>/scripts/ghcr-prune.sh --list /tmp/ghcr-review-list.md --repo-path "$REPO" --confirm
 ```
 
 It deletes one version at a time, prints a line per deletion, and exits non-zero
-with a failure summary if any call fails. Failures are safe to retry -- already
-deleted ids return 404 and are reported as failures, so re-run with a list
-trimmed to what remains, or just report the failures.
+with a failure summary if any call fails.
 
 ## After pruning
 
@@ -146,6 +173,13 @@ the audit already refused to touch tags the repo references.
 - The in-use scan reads the **working tree only**. Tags referenced solely by an
   older release branch, a reverted commit, or an external repo are invisible to
   it. For anything load-bearing, pass `--protect-tag` or keep the row.
+- The scan matches **literal** `ghcr.io/<owner>/<pkg>:<tag>` text. Image
+  references assembled at runtime are not detected, and this repo has several,
+  e.g. `ci-images-build-os.yml` builds
+  `ghcr.io/${OWNER}/positron-${OS_TAG}-${ARCHITECTURE}:${{ inputs.tag }}`.
+  Those happen to be push targets rather than pins, so they do not put an old
+  version at risk -- but a consumer built the same way would be missed. If a tag
+  is referenced only through a variable, pass `--protect-tag`.
 - GHCR reports no pull statistics through this API, so "last pulled" cannot
   inform the cutoff. Age is the only signal available.
 - Untagged versions in *per-arch* packages (`positron-rocky8-amd64`) are not

--- a/.claude/skills/prune-ci-images/scripts/ghcr-audit.sh
+++ b/.claude/skills/prune-ci-images/scripts/ghcr-audit.sh
@@ -185,7 +185,13 @@ cand = [v for v in versions if not v["keep_reason"]]
 child_of_cand = {}
 for v in cand:
 	ch = children(v["pkg"], v["digest"])
-	v["children"] = ch or []
+	if ch is None:
+		# Never assume "no children" on a failed read -- that would let an
+		# index be listed without its per-arch manifests.
+		unresolved.append(v)
+		v["children"] = []
+		continue
+	v["children"] = ch
 	for c in v["children"]:
 		child_of_cand[(v["pkg"], c)] = v["digest"]
 
@@ -261,9 +267,11 @@ if skipped_protected:
 if unresolved:
 	w("## Warning: manifests that could not be resolved")
 	w("")
-	w("These retained versions could not be read from the registry, so their child")
-	w("manifests may be missing from the protected set. Review the candidate list")
-	w("with extra care, or re-run after fixing registry access:")
+	w("**Do not prune this list.** These versions could not be read from the")
+	w("registry, so their child manifests may be missing from the protected set")
+	w("and a live image could be broken. Fix registry access and re-run the audit.")
+	w("(ghcr-prune.sh independently re-resolves every manifest and will refuse to")
+	w("run while any of them are unreadable.)")
 	w("")
 	for v in unresolved:
 		w(f"- `{v['pkg']}` `{v['digest'][:19]}` (tags: {','.join(v['tags']) or 'none'})")

--- a/.claude/skills/prune-ci-images/scripts/ghcr-audit.sh
+++ b/.claude/skills/prune-ci-images/scripts/ghcr-audit.sh
@@ -247,11 +247,22 @@ w("")
 if emptied:
 	w("## Packages that would be emptied completely")
 	w("")
-	w("Deleting every version of a package leaves it empty (GHCR then hides it).")
-	w("Confirm these images are genuinely retired:")
+	w("Every version of these packages is a candidate. **GHCR refuses to delete")
+	w("the last tagged version of a package**, so the prune step will delete all")
+	w("but one and report the final version as a failure. Clearing them needs a")
+	w("package-level delete, which is a separate decision -- it removes the")
+	w("package from the org list entirely:")
 	w("")
+	w("```bash")
 	for p in emptied:
-		w(f"- `{p}` ({by_pkg_del[p]} of {by_pkg_total[p]} versions)")
+		w(f"# {p} ({by_pkg_del[p]} of {by_pkg_total[p]} versions)")
+	w(f"scripts/ghcr-delete-packages.sh --org {org} \\")
+	for i, p in enumerate(emptied):
+		cont = " \\" if i < len(emptied) - 1 else ""
+		w(f"  --package {p}{cont}")
+	w("```")
+	w("")
+	w("Confirm these images are genuinely retired first.")
 	w("")
 if skipped_protected:
 	w("## Excluded: children of retained images (do not delete)")

--- a/.claude/skills/prune-ci-images/scripts/ghcr-audit.sh
+++ b/.claude/skills/prune-ci-images/scripts/ghcr-audit.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# Build a human-reviewable deletion candidate list for old GHCR container images.
+# Read-only: never deletes anything.
+set -euo pipefail
+
+ORG="posit-dev"
+AGE_DAYS=90
+PATTERN='^positron-(postgres|ubuntu|rocky|debian|opensuse|sles|windows|amazonlinux|fedora|alpine|centos)'
+REPO_PATH=""
+OUT=""
+PROTECT_TAGS=""
+
+usage() {
+	cat <<'EOF'
+Usage: ghcr-audit.sh [options]
+
+  --org ORG            GitHub org that owns the packages (default: posit-dev)
+  --age-days N         Candidates must be older than N days (default: 90)
+  --pattern REGEX      ERE matched against package names
+  --repo-path PATH     Repo checkout to scan for in-use image tags (default: none)
+  --protect-tag TAG    Extra tag to treat as in-use (repeatable)
+  --out FILE           Write the review list here (default: stdout)
+EOF
+}
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--org) ORG="$2"; shift 2 ;;
+		--age-days) AGE_DAYS="$2"; shift 2 ;;
+		--pattern) PATTERN="$2"; shift 2 ;;
+		--repo-path) REPO_PATH="$2"; shift 2 ;;
+		--protect-tag) PROTECT_TAGS="$PROTECT_TAGS $2"; shift 2 ;;
+		--out) OUT="$2"; shift 2 ;;
+		-h|--help) usage; exit 0 ;;
+		*) echo "unknown option: $1" >&2; usage; exit 2 ;;
+	esac
+done
+
+command -v gh >/dev/null || { echo "gh not found" >&2; exit 1; }
+command -v python3 >/dev/null || { echo "python3 not found" >&2; exit 1; }
+gh auth status >/dev/null 2>&1 || { echo "gh not authenticated" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+GH_USER="$(gh api user --jq .login)"
+GH_TOKEN_VAL="$(gh auth token)"
+
+echo "==> Listing container packages in $ORG" >&2
+gh api "/orgs/$ORG/packages?package_type=container&per_page=100" --paginate --jq '.[].name' \
+	| grep -E "$PATTERN" | sort > "$WORK/pkgs.txt" || true
+
+PKG_COUNT=$(wc -l < "$WORK/pkgs.txt" | tr -d ' ')
+if [ "$PKG_COUNT" = "0" ]; then
+	echo "No packages matched pattern: $PATTERN" >&2
+	exit 1
+fi
+echo "==> $PKG_COUNT packages matched" >&2
+
+# --- Fetch every version of every matched package -------------------------
+: > "$WORK/versions.jsonl"
+while read -r pkg; do
+	[ -n "$pkg" ] || continue
+	enc="${pkg//\//%2F}"
+	gh api "/orgs/$ORG/packages/container/$enc/versions?per_page=100" --paginate \
+		--jq ".[] | {pkg:\"$pkg\", id:.id, digest:.name, tags:(.metadata.container.tags // []), updated:.updated_at, url:.html_url}" \
+		>> "$WORK/versions.jsonl" 2>/dev/null || echo "  ! could not read versions for $pkg" >&2
+done < "$WORK/pkgs.txt"
+echo "==> $(wc -l < "$WORK/versions.jsonl" | tr -d ' ') versions fetched" >&2
+
+# --- Scan the repo for in-use "<pkg>:<tag>" references --------------------
+: > "$WORK/inuse.txt"
+if [ -n "$REPO_PATH" ]; then
+	echo "==> Scanning $REPO_PATH for in-use image tags" >&2
+	for d in .github docker test scripts build; do
+		[ -d "$REPO_PATH/$d" ] || continue
+		grep -rhoE "ghcr\.io/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+:[A-Za-z0-9_.-]+" "$REPO_PATH/$d" 2>/dev/null \
+			| sed -E 's#^ghcr\.io/[^/]+/##' >> "$WORK/inuse.txt" || true
+	done
+	sort -u -o "$WORK/inuse.txt" "$WORK/inuse.txt"
+	echo "==> $(wc -l < "$WORK/inuse.txt" | tr -d ' ') distinct in-use tag refs found" >&2
+fi
+for t in $PROTECT_TAGS; do echo "*:$t" >> "$WORK/inuse.txt"; done
+
+# --- Classify, then resolve manifest children of everything we keep -------
+export WORK ORG AGE_DAYS GH_USER GH_TOKEN_VAL OUT
+python3 <<'EOPY'
+import json, os, subprocess, sys, urllib.request, urllib.error, base64
+from datetime import datetime, timezone, timedelta
+
+work = os.environ["WORK"]
+org = os.environ["ORG"]
+age_days = int(os.environ["AGE_DAYS"])
+gh_user = os.environ["GH_USER"]
+gh_token = os.environ["GH_TOKEN_VAL"]
+
+cutoff = datetime.now(timezone.utc) - timedelta(days=age_days)
+
+versions = []
+with open(f"{work}/versions.jsonl") as fh:
+	for line in fh:
+		line = line.strip()
+		if line:
+			versions.append(json.loads(line))
+
+inuse = set()
+try:
+	with open(f"{work}/inuse.txt") as fh:
+		inuse = {l.strip() for l in fh if l.strip()}
+except FileNotFoundError:
+	pass
+inuse_any_pkg = {r.split(":", 1)[1] for r in inuse if r.startswith("*:")}
+
+def tag_in_use(pkg, tags):
+	for t in tags:
+		if f"{pkg}:{t}" in inuse or t in inuse_any_pkg:
+			return t
+	return None
+
+# Pass 1: provisional keep/candidate decision.
+for v in versions:
+	v["dt"] = datetime.strptime(v["updated"], "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+	v["age_days"] = (datetime.now(timezone.utc) - v["dt"]).days
+	v["inuse_tag"] = tag_in_use(v["pkg"], v["tags"])
+	v["keep_reason"] = None
+	if v["inuse_tag"]:
+		v["keep_reason"] = f"tag `{v['inuse_tag']}` referenced in repo"
+	elif v["dt"] >= cutoff:
+		v["keep_reason"] = f"newer than {age_days}d"
+
+# Registry token cache, for resolving manifest lists to their children.
+_tok = {}
+def bearer(pkg):
+	if pkg in _tok:
+		return _tok[pkg]
+	url = f"https://ghcr.io/token?service=ghcr.io&scope=repository:{org}/{pkg}:pull"
+	req = urllib.request.Request(url)
+	basic = base64.b64encode(f"{gh_user}:{gh_token}".encode()).decode()
+	req.add_header("Authorization", f"Basic {basic}")
+	try:
+		with urllib.request.urlopen(req, timeout=30) as r:
+			_tok[pkg] = json.load(r)["token"]
+	except Exception:
+		_tok[pkg] = None
+	return _tok[pkg]
+
+ACCEPT = ",".join([
+	"application/vnd.oci.image.index.v1+json",
+	"application/vnd.docker.distribution.manifest.list.v2+json",
+	"application/vnd.oci.image.manifest.v1+json",
+	"application/vnd.docker.distribution.manifest.v2+json",
+])
+
+def children(pkg, digest):
+	"""Return child digests if this version is a manifest list/index, else []."""
+	tok = bearer(pkg)
+	if not tok:
+		return None
+	req = urllib.request.Request(f"https://ghcr.io/v2/{org}/{pkg}/manifests/{digest}")
+	req.add_header("Authorization", f"Bearer {tok}")
+	req.add_header("Accept", ACCEPT)
+	try:
+		with urllib.request.urlopen(req, timeout=30) as r:
+			m = json.load(r)
+	except Exception:
+		return None
+	return [x["digest"] for x in m.get("manifests", [])]
+
+# Pass 2: any child of a KEPT index is itself protected. Resolve kept versions only.
+kept = [v for v in versions if v["keep_reason"]]
+print(f"==> Resolving manifests for {len(kept)} retained versions", file=sys.stderr)
+protected = {}   # (pkg, digest) -> parent description
+unresolved = []
+for v in kept:
+	ch = children(v["pkg"], v["digest"])
+	if ch is None:
+		unresolved.append(v)
+		continue
+	for c in ch:
+		tagdesc = ",".join(v["tags"]) or v["digest"][:19]
+		protected[(v["pkg"], c)] = tagdesc
+
+# Pass 3: group candidates with their own children so a group is deleted atomically.
+cand = [v for v in versions if not v["keep_reason"]]
+child_of_cand = {}
+for v in cand:
+	ch = children(v["pkg"], v["digest"])
+	v["children"] = ch or []
+	for c in v["children"]:
+		child_of_cand[(v["pkg"], c)] = v["digest"]
+
+rows = []
+skipped_protected = []
+for v in cand:
+	key = (v["pkg"], v["digest"])
+	if key in protected:
+		v["protected_by"] = protected[key]
+		skipped_protected.append(v)
+		continue
+	parent = child_of_cand.get(key)
+	group = (parent or v["digest"])[:19]
+	if v["tags"]:
+		kind = "tagged"
+	elif parent:
+		kind = "arch child"
+	else:
+		kind = "untagged"
+	rows.append({**v, "group": group, "kind": kind})
+
+# Warn when a package would be emptied entirely.
+by_pkg_total = {}
+by_pkg_del = {}
+for v in versions:
+	by_pkg_total[v["pkg"]] = by_pkg_total.get(v["pkg"], 0) + 1
+for v in rows:
+	by_pkg_del[v["pkg"]] = by_pkg_del.get(v["pkg"], 0) + 1
+emptied = sorted(p for p in by_pkg_del if by_pkg_del[p] == by_pkg_total[p])
+
+rows.sort(key=lambda v: (v["pkg"], -v["age_days"]))
+
+out = []
+w = out.append
+now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+w(f"# GHCR image deletion review list")
+w("")
+w(f"- Generated: {now}")
+w(f"- Org: `{org}`")
+w(f"- Cutoff: older than **{age_days} days** (before {cutoff.strftime('%Y-%m-%d')})")
+w(f"- Packages scanned: {len(by_pkg_total)}; versions scanned: {len(versions)}")
+w(f"- **Deletion candidates: {len(rows)}**; retained: {len(versions) - len(rows)}")
+w("")
+w("## How to review")
+w("")
+w("Every row below is scheduled for deletion. **Delete any row you want to KEEP.**")
+w("Leave the table formatting intact; do not edit the `id` or `group` columns.")
+w("Then hand the file back for the batch delete.")
+w("")
+w("`group` ties a multi-arch index to its per-arch child manifests. Rows sharing a")
+w("group must be kept or deleted together -- the prune step aborts on a split group.")
+w("")
+if emptied:
+	w("## Packages that would be emptied completely")
+	w("")
+	w("Deleting every version of a package leaves it empty (GHCR then hides it).")
+	w("Confirm these images are genuinely retired:")
+	w("")
+	for p in emptied:
+		w(f"- `{p}` ({by_pkg_del[p]} of {by_pkg_total[p]} versions)")
+	w("")
+if skipped_protected:
+	w("## Excluded: children of retained images (do not delete)")
+	w("")
+	w(f"{len(skipped_protected)} old-but-referenced manifests were excluded because a")
+	w("retained tag still points at them:")
+	w("")
+	w("| package | digest | age (d) | referenced by |")
+	w("|---|---|---|---|")
+	for v in sorted(skipped_protected, key=lambda x: x["pkg"]):
+		w(f"| `{v['pkg']}` | `{v['digest'][:19]}` | {v['age_days']} | `{v['protected_by']}` |")
+	w("")
+if unresolved:
+	w("## Warning: manifests that could not be resolved")
+	w("")
+	w("These retained versions could not be read from the registry, so their child")
+	w("manifests may be missing from the protected set. Review the candidate list")
+	w("with extra care, or re-run after fixing registry access:")
+	w("")
+	for v in unresolved:
+		w(f"- `{v['pkg']}` `{v['digest'][:19]}` (tags: {','.join(v['tags']) or 'none'})")
+	w("")
+w("## Deletion candidates")
+w("")
+w("| package | id | tags | age (d) | updated | kind | group |")
+w("|---|---|---|---|---|---|---|")
+for v in rows:
+	tags = ", ".join(f"`{t}`" for t in v["tags"]) or "_untagged_"
+	w(f"| `{v['pkg']}` | {v['id']} | {tags} | {v['age_days']} | {v['updated'][:10]} | {v['kind']} | `{v['group']}` |")
+w("")
+
+text = "\n".join(out)
+outfile = os.environ.get("OUT") or None
+if outfile:
+	with open(outfile, "w") as fh:
+		fh.write(text)
+	print(f"==> Wrote {outfile} ({len(rows)} candidates)", file=sys.stderr)
+else:
+	print(text)
+EOPY

--- a/.claude/skills/prune-ci-images/scripts/ghcr-delete-packages.sh
+++ b/.claude/skills/prune-ci-images/scripts/ghcr-delete-packages.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Delete whole GHCR container packages. Use only for packages that the audit
+# reported under "would be emptied completely" and whose last tagged version
+# ghcr-prune.sh could not delete.
+#
+# This is a bigger action than deleting versions: the package disappears from
+# the org package list, and the 30-day restore path is less reliable for a
+# whole package than for a single version. Dry run unless given --confirm.
+set -euo pipefail
+
+ORG="posit-dev"
+CONFIRM=0
+REPO_PATH=""
+PKGS=()
+
+usage() {
+	cat <<'EOF'
+Usage: ghcr-delete-packages.sh --package NAME [--package NAME ...] [options]
+
+  --package NAME   Package to delete (repeatable)
+  --org ORG        GitHub org that owns the packages (default: posit-dev)
+  --repo-path PATH Checkout to scan; aborts if a package is mentioned anywhere
+                   under .github/, docker/, test/, scripts/, or build/
+  --confirm        Actually delete. Without this it is a dry run.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--package) PKGS+=("$2"); shift 2 ;;
+		--org) ORG="$2"; shift 2 ;;
+		--repo-path) REPO_PATH="$2"; shift 2 ;;
+		--confirm) CONFIRM=1; shift ;;
+		-h|--help) usage; exit 0 ;;
+		*) echo "unknown option: $1" >&2; usage; exit 2 ;;
+	esac
+done
+
+[ "${#PKGS[@]}" -gt 0 ] || { echo "at least one --package is required" >&2; usage; exit 2; }
+command -v gh >/dev/null || { echo "gh not found" >&2; exit 1; }
+gh auth status >/dev/null 2>&1 || { echo "gh not authenticated" >&2; exit 1; }
+
+if ! gh auth status 2>&1 | grep -q 'delete:packages'; then
+	echo "! The active gh token lacks the delete:packages scope." >&2
+	echo "  Run: gh auth refresh -h github.com -s read:packages -s delete:packages" >&2
+	exit 1
+fi
+
+# --- Report what each package currently holds, and fail closed on unknowns --
+echo "Packages targeted for deletion:"
+printf '%-42s %-9s %-6s %s\n' "PACKAGE" "VIS" "VERS" "TAGS"
+BAD=0
+for p in "${PKGS[@]}"; do
+	if ! meta=$(gh api "/orgs/$ORG/packages/container/${p//\//%2F}" 2>/dev/null); then
+		printf '%-42s %s\n' "$p" "NOT FOUND (already deleted?)"
+		BAD=1
+		continue
+	fi
+	vis=$(printf '%s' "$meta" | python3 -c 'import sys,json;print(json.load(sys.stdin)["visibility"])')
+	vers=$(gh api "/orgs/$ORG/packages/container/${p//\//%2F}/versions?per_page=100" --paginate \
+		--jq '.[] | (.metadata.container.tags // []) | join(",")' 2>/dev/null || true)
+	n=$(printf '%s\n' "$vers" | grep -c . || true)
+	tags=$(printf '%s' "$vers" | tr '\n' ' ')
+	printf '%-42s %-9s %-6s %s\n' "$p" "$vis" "$n" "${tags:-<untagged>}"
+done
+
+if [ "$BAD" = "1" ]; then
+	echo ""
+	echo "! Some packages could not be read. Nothing was deleted." >&2
+	exit 1
+fi
+
+# --- Refuse if the repo still mentions the package by name -----------------
+if [ -n "$REPO_PATH" ]; then
+	HITS=0
+	for p in "${PKGS[@]}"; do
+		for d in .github docker test scripts build; do
+			[ -d "$REPO_PATH/$d" ] || continue
+			if grep -rl "$p" "$REPO_PATH/$d" 2>/dev/null | head -5 | grep -q .; then
+				echo "! $p is still mentioned in $REPO_PATH/$d:" >&2
+				grep -rl "$p" "$REPO_PATH/$d" 2>/dev/null | sed 's/^/    /' >&2
+				HITS=1
+			fi
+		done
+	done
+	if [ "$HITS" = "1" ]; then
+		echo "" >&2
+		echo "Remove those references first. Nothing was deleted." >&2
+		exit 1
+	fi
+	echo ""
+	echo "==> No references to these packages found under $REPO_PATH"
+else
+	echo ""
+	echo "! --repo-path not given: skipping the repo reference check." >&2
+fi
+
+echo ""
+if [ "$CONFIRM" = "0" ]; then
+	echo "DRY RUN -- nothing deleted. Re-run with --confirm to delete these ${#PKGS[@]} packages."
+	exit 0
+fi
+
+OK=0; FAIL=0
+for p in "${PKGS[@]}"; do
+	if err=$(gh api -X DELETE "/orgs/$ORG/packages/container/${p//\//%2F}" 2>&1); then
+		OK=$((OK+1)); printf '  deleted  %s\n' "$p"
+	else
+		FAIL=$((FAIL+1)); printf '  FAILED   %s -- %s\n' "$p" "$(printf '%s' "$err" | head -1)" >&2
+	fi
+done
+
+echo ""
+echo "==> Deleted $OK, failed $FAIL of ${#PKGS[@]} packages"
+echo "Package deletion may be restorable within 30 days, but is less reliable"
+echo "than version restore. See the GitHub Packages docs for restore limits."
+[ "$FAIL" = "0" ] || exit 1

--- a/.claude/skills/prune-ci-images/scripts/ghcr-prune.sh
+++ b/.claude/skills/prune-ci-images/scripts/ghcr-prune.sh
@@ -333,8 +333,32 @@ echo ""
 echo "==> Deleted $OK, failed $FAIL of $ROWS"
 echo "A deleted version can usually be restored within 30 days:"
 echo "  gh api -X POST /orgs/$ORG/packages/container/<pkg>/versions/<id>/restore"
+
 if [ "$FAIL" -gt 0 ]; then
-	echo "Failures:" >&2
-	cat "$WORK/failed.tsv" >&2
+	# GHCR will not delete a package's last tagged version. It reports this two
+	# different ways, and the second is misleading -- it claims the version is
+	# "publicly visible" with >5000 downloads even for private/internal
+	# packages. Both mean the same thing: only a package-level delete clears it.
+	grep -E 'last tagged version|more than 5000 downloads' "$WORK/failed.tsv" 		| cut -f1 | sort -u > "$WORK/lastver.txt" || true
+	grep -vE 'last tagged version|more than 5000 downloads' "$WORK/failed.tsv" 		> "$WORK/otherfail.tsv" || true
+
+	if [ -s "$WORK/lastver.txt" ]; then
+		echo ""
+		echo "$(wc -l < "$WORK/lastver.txt" | tr -d ' ') package(s) are down to their last"
+		echo "tagged version, which GHCR will not delete. This is expected for a"
+		echo "package the audit listed under \"would be emptied completely\"."
+		echo ""
+		echo "To clear them, delete the packages themselves (a separate decision --"
+		echo "this removes them from the org package list):"
+		echo ""
+		echo "  $(dirname "$0")/ghcr-delete-packages.sh --org $ORG \\"
+		sed 's/^/    --package /; s/$/ \\/' "$WORK/lastver.txt"
+		echo ""
+	fi
+
+	if [ -s "$WORK/otherfail.tsv" ]; then
+		echo "Unexpected failures:" >&2
+		cat "$WORK/otherfail.tsv" >&2
+	fi
 	exit 1
 fi

--- a/.claude/skills/prune-ci-images/scripts/ghcr-prune.sh
+++ b/.claude/skills/prune-ci-images/scripts/ghcr-prune.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Delete the GHCR container versions listed in a reviewed audit file.
+# Defaults to a dry run; requires --confirm to actually delete.
+set -euo pipefail
+
+ORG="posit-dev"
+LIST=""
+CONFIRM=0
+ALLOW_SPLIT=0
+
+usage() {
+	cat <<'EOF'
+Usage: ghcr-prune.sh --list FILE [options]
+
+  --list FILE     Reviewed review-list markdown produced by ghcr-audit.sh
+  --org ORG       GitHub org that owns the packages (default: posit-dev)
+  --confirm       Actually delete. Without this it is a dry run.
+  --allow-split-group
+                  Proceed even if a multi-arch group is only partially listed.
+                  Dangerous: can orphan a manifest index. Default is to abort.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--list) LIST="$2"; shift 2 ;;
+		--org) ORG="$2"; shift 2 ;;
+		--confirm) CONFIRM=1; shift ;;
+		--allow-split-group) ALLOW_SPLIT=1; shift ;;
+		-h|--help) usage; exit 0 ;;
+		*) echo "unknown option: $1" >&2; usage; exit 2 ;;
+	esac
+done
+
+[ -n "$LIST" ] || { echo "--list is required" >&2; usage; exit 2; }
+[ -f "$LIST" ] || { echo "no such file: $LIST" >&2; exit 1; }
+command -v gh >/dev/null || { echo "gh not found" >&2; exit 1; }
+gh auth status >/dev/null 2>&1 || { echo "gh not authenticated" >&2; exit 1; }
+
+if ! gh auth status 2>&1 | grep -q 'delete:packages'; then
+	echo "! The active gh token lacks the delete:packages scope." >&2
+	echo "  Run: gh auth refresh -h github.com -s delete:packages" >&2
+	exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# --- Parse the reviewed table --------------------------------------------
+# Rows look like: | `pkg` | 12345 | `tag` | 120 | 2026-01-01 | untagged | `sha256:...` |
+awk -F'|' '
+	/^\|/ {
+		pkg = $2; id = $3; grp = $8
+		gsub(/[ `]/, "", pkg); gsub(/[ `]/, "", id); gsub(/[ `]/, "", grp)
+		if (id ~ /^[0-9]+$/) { print pkg "\t" id "\t" grp }
+	}
+' "$LIST" > "$WORK/rows.tsv"
+
+ROWS=$(wc -l < "$WORK/rows.tsv" | tr -d ' ')
+if [ "$ROWS" = "0" ]; then
+	echo "No deletion rows found in $LIST -- nothing to do." >&2
+	exit 0
+fi
+echo "==> $ROWS rows parsed from $LIST"
+
+# --- Group integrity check ------------------------------------------------
+# Re-derive each listed group's full membership from the ORIGINAL audit table
+# is not possible here, so instead verify internal consistency: every group
+# present must have all of its rows still listed. We detect a split group by
+# comparing against the audit file's own record of group sizes, recomputed
+# from the untouched "Deletion candidates" section is gone once edited -- so
+# we verify against the registry instead: for each listed index, all of its
+# children must also be listed.
+GH_USER="$(gh api user --jq .login)"
+GH_TOKEN_VAL="$(gh auth token)"
+
+SPLIT=$(WORK="$WORK" ORG="$ORG" GH_USER="$GH_USER" GH_TOKEN_VAL="$GH_TOKEN_VAL" python3 <<'EOPY'
+import base64, json, os, urllib.request
+
+work, org = os.environ["WORK"], os.environ["ORG"]
+gh_user, gh_token = os.environ["GH_USER"], os.environ["GH_TOKEN_VAL"]
+
+rows = []
+with open(f"{work}/rows.tsv") as fh:
+	for line in fh:
+		p = line.rstrip("\n").split("\t")
+		if len(p) == 3:
+			rows.append({"pkg": p[0], "id": p[1], "group": p[2]})
+
+# Map version id -> digest so we can resolve manifests.
+digests = {}
+for pkg in {r["pkg"] for r in rows}:
+	enc = pkg.replace("/", "%2F")
+	import subprocess
+	try:
+		out = subprocess.run(
+			["gh", "api", f"/orgs/{org}/packages/container/{enc}/versions?per_page=100",
+			 "--paginate", "--jq", ".[] | \"\\(.id)\\t\\(.name)\""],
+			capture_output=True, text=True, check=True).stdout
+	except subprocess.CalledProcessError:
+		continue
+	for line in out.splitlines():
+		if "\t" in line:
+			i, d = line.split("\t", 1)
+			digests[(pkg, i)] = d
+
+_tok = {}
+def bearer(pkg):
+	if pkg in _tok:
+		return _tok[pkg]
+	req = urllib.request.Request(
+		f"https://ghcr.io/token?service=ghcr.io&scope=repository:{org}/{pkg}:pull")
+	basic = base64.b64encode(f"{gh_user}:{gh_token}".encode()).decode()
+	req.add_header("Authorization", f"Basic {basic}")
+	try:
+		with urllib.request.urlopen(req, timeout=30) as r:
+			_tok[pkg] = json.load(r)["token"]
+	except Exception:
+		_tok[pkg] = None
+	return _tok[pkg]
+
+ACCEPT = ",".join([
+	"application/vnd.oci.image.index.v1+json",
+	"application/vnd.docker.distribution.manifest.list.v2+json",
+	"application/vnd.oci.image.manifest.v1+json",
+	"application/vnd.docker.distribution.manifest.v2+json",
+])
+
+def children(pkg, digest):
+	tok = bearer(pkg)
+	if not tok:
+		return []
+	req = urllib.request.Request(f"https://ghcr.io/v2/{org}/{pkg}/manifests/{digest}")
+	req.add_header("Authorization", f"Bearer {tok}")
+	req.add_header("Accept", ACCEPT)
+	try:
+		with urllib.request.urlopen(req, timeout=30) as r:
+			return [x["digest"] for x in json.load(r).get("manifests", [])]
+	except Exception:
+		return []
+
+listed = {(r["pkg"], digests.get((r["pkg"], r["id"]), "")) for r in rows}
+problems = []
+for r in rows:
+	d = digests.get((r["pkg"], r["id"]))
+	if not d:
+		continue
+	for c in children(r["pkg"], d):
+		if (r["pkg"], c) not in listed:
+			problems.append(f"{r['pkg']} index {d[:19]} is listed but its child {c[:19]} is not")
+
+for p in problems:
+	print(p)
+EOPY
+)
+
+if [ -n "$SPLIT" ]; then
+	echo "" >&2
+	echo "! Split multi-arch group detected:" >&2
+	echo "$SPLIT" | sed 's/^/    /' >&2
+	echo "" >&2
+	if [ "$ALLOW_SPLIT" = "0" ]; then
+		echo "  Deleting an index without its children (or vice versa) can leave a" >&2
+		echo "  broken image. Either add the missing rows back to the list, remove" >&2
+		echo "  the whole group, or re-run with --allow-split-group." >&2
+		exit 1
+	fi
+	echo "  --allow-split-group given; continuing anyway." >&2
+fi
+
+# --- Summary --------------------------------------------------------------
+echo ""
+echo "Versions to delete, by package:"
+cut -f1 "$WORK/rows.tsv" | sort | uniq -c | sort -rn | sed 's/^/  /'
+echo ""
+
+if [ "$CONFIRM" = "0" ]; then
+	echo "DRY RUN -- nothing deleted. Re-run with --confirm to delete these $ROWS versions."
+	exit 0
+fi
+
+# --- Delete ---------------------------------------------------------------
+OK=0; FAIL=0
+: > "$WORK/failed.tsv"
+while IFS=$'\t' read -r pkg id grp; do
+	[ -n "$id" ] || continue
+	enc="${pkg//\//%2F}"
+	if gh api -X DELETE "/orgs/$ORG/packages/container/$enc/versions/$id" >/dev/null 2>"$WORK/err"; then
+		OK=$((OK+1))
+		printf '  deleted %s %s\n' "$pkg" "$id"
+	else
+		FAIL=$((FAIL+1))
+		printf '%s\t%s\t%s\n' "$pkg" "$id" "$(tr -d '\n' < "$WORK/err")" >> "$WORK/failed.tsv"
+		printf '  FAILED  %s %s -- %s\n' "$pkg" "$id" "$(head -c 200 "$WORK/err")" >&2
+	fi
+done < "$WORK/rows.tsv"
+
+echo ""
+echo "==> Deleted $OK, failed $FAIL of $ROWS"
+if [ "$FAIL" -gt 0 ]; then
+	echo "Failures:" >&2
+	cat "$WORK/failed.tsv" >&2
+	exit 1
+fi

--- a/.claude/skills/prune-ci-images/scripts/ghcr-prune.sh
+++ b/.claude/skills/prune-ci-images/scripts/ghcr-prune.sh
@@ -1,23 +1,32 @@
 #!/usr/bin/env bash
 # Delete the GHCR container versions listed in a reviewed audit file.
 # Defaults to a dry run; requires --confirm to actually delete.
+#
+# Every safety check in this script FAILS CLOSED: if any version or manifest
+# cannot be read, the run aborts rather than assuming the deletion is safe.
 set -euo pipefail
 
 ORG="posit-dev"
 LIST=""
 CONFIRM=0
 ALLOW_SPLIT=0
+REPO_PATH=""
+PROTECT_TAGS=""
 
 usage() {
 	cat <<'EOF'
 Usage: ghcr-prune.sh --list FILE [options]
 
-  --list FILE     Reviewed review-list markdown produced by ghcr-audit.sh
-  --org ORG       GitHub org that owns the packages (default: posit-dev)
-  --confirm       Actually delete. Without this it is a dry run.
+  --list FILE      Reviewed review-list markdown produced by ghcr-audit.sh
+  --org ORG        GitHub org that owns the packages (default: posit-dev)
+  --repo-path PATH Checkout to re-scan for in-use tags. Pass the SAME path
+                   used for the audit; without it the in-use recheck is
+                   skipped and the script warns.
+  --protect-tag T  Extra tag to treat as in-use (repeatable)
+  --confirm        Actually delete. Without this it is a dry run.
   --allow-split-group
-                  Proceed even if a multi-arch group is only partially listed.
-                  Dangerous: can orphan a manifest index. Default is to abort.
+                   Proceed even if a multi-arch group is only partially
+                   listed. Dangerous: can orphan a manifest index.
 EOF
 }
 
@@ -25,6 +34,8 @@ while [ $# -gt 0 ]; do
 	case "$1" in
 		--list) LIST="$2"; shift 2 ;;
 		--org) ORG="$2"; shift 2 ;;
+		--repo-path) REPO_PATH="$2"; shift 2 ;;
+		--protect-tag) PROTECT_TAGS="$PROTECT_TAGS $2"; shift 2 ;;
 		--confirm) CONFIRM=1; shift ;;
 		--allow-split-group) ALLOW_SPLIT=1; shift ;;
 		-h|--help) usage; exit 0 ;;
@@ -35,76 +46,157 @@ done
 [ -n "$LIST" ] || { echo "--list is required" >&2; usage; exit 2; }
 [ -f "$LIST" ] || { echo "no such file: $LIST" >&2; exit 1; }
 command -v gh >/dev/null || { echo "gh not found" >&2; exit 1; }
+command -v python3 >/dev/null || { echo "python3 not found" >&2; exit 1; }
 gh auth status >/dev/null 2>&1 || { echo "gh not authenticated" >&2; exit 1; }
 
 if ! gh auth status 2>&1 | grep -q 'delete:packages'; then
 	echo "! The active gh token lacks the delete:packages scope." >&2
-	echo "  Run: gh auth refresh -h github.com -s delete:packages" >&2
+	echo "  Run: gh auth refresh -h github.com -s read:packages -s delete:packages" >&2
 	exit 1
 fi
 
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
-# --- Parse the reviewed table --------------------------------------------
-# Rows look like: | `pkg` | 12345 | `tag` | 120 | 2026-01-01 | untagged | `sha256:...` |
-awk -F'|' '
-	/^\|/ {
-		pkg = $2; id = $3; grp = $8
-		gsub(/[ `]/, "", pkg); gsub(/[ `]/, "", id); gsub(/[ `]/, "", grp)
-		if (id ~ /^[0-9]+$/) { print pkg "\t" id "\t" grp }
-	}
-' "$LIST" > "$WORK/rows.tsv"
-
-ROWS=$(wc -l < "$WORK/rows.tsv" | tr -d ' ')
-if [ "$ROWS" = "0" ]; then
-	echo "No deletion rows found in $LIST -- nothing to do." >&2
-	exit 0
+# --- Re-scan the repo for in-use "<pkg>:<tag>" references -----------------
+: > "$WORK/inuse.txt"
+if [ -n "$REPO_PATH" ]; then
+	for d in .github docker test scripts build; do
+		[ -d "$REPO_PATH/$d" ] || continue
+		grep -rhoE "ghcr\.io/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+:[A-Za-z0-9_.-]+" "$REPO_PATH/$d" 2>/dev/null \
+			| sed -E 's#^ghcr\.io/[^/]+/##' >> "$WORK/inuse.txt" || true
+	done
+	sort -u -o "$WORK/inuse.txt" "$WORK/inuse.txt"
+else
+	echo "! --repo-path not given: skipping the in-use tag recheck." >&2
+	echo "  A tag that became referenced since the audit will NOT be caught." >&2
 fi
-echo "==> $ROWS rows parsed from $LIST"
+for t in $PROTECT_TAGS; do echo "*:$t" >> "$WORK/inuse.txt"; done
 
-# --- Group integrity check ------------------------------------------------
-# Re-derive each listed group's full membership from the ORIGINAL audit table
-# is not possible here, so instead verify internal consistency: every group
-# present must have all of its rows still listed. We detect a split group by
-# comparing against the audit file's own record of group sizes, recomputed
-# from the untouched "Deletion candidates" section is gone once edited -- so
-# we verify against the registry instead: for each listed index, all of its
-# children must also be listed.
 GH_USER="$(gh api user --jq .login)"
 GH_TOKEN_VAL="$(gh auth token)"
 
-SPLIT=$(WORK="$WORK" ORG="$ORG" GH_USER="$GH_USER" GH_TOKEN_VAL="$GH_TOKEN_VAL" python3 <<'EOPY'
-import base64, json, os, urllib.request
+# --- Validate the reviewed list against the CURRENT registry state --------
+set +e
+WORK="$WORK" ORG="$ORG" LIST="$LIST" ALLOW_SPLIT="$ALLOW_SPLIT" \
+GH_USER="$GH_USER" GH_TOKEN_VAL="$GH_TOKEN_VAL" python3 <<'EOPY'
+import base64, json, os, re, subprocess, sys, urllib.request
+from concurrent.futures import ThreadPoolExecutor
 
-work, org = os.environ["WORK"], os.environ["ORG"]
+work = os.environ["WORK"]
+org = os.environ["ORG"]
+list_path = os.environ["LIST"]
+allow_split = os.environ["ALLOW_SPLIT"] == "1"
 gh_user, gh_token = os.environ["GH_USER"], os.environ["GH_TOKEN_VAL"]
 
+def die(msg, detail=()):
+	print(f"\n! {msg}", file=sys.stderr)
+	for d in detail:
+		print(f"    {d}", file=sys.stderr)
+	sys.exit(1)
+
+# --- Parse the reviewed table -----------------------------------------
+# A deletion row has exactly 7 columns and a numeric id. The "Excluded"
+# table has 4 columns and is therefore ignored.
 rows = []
-with open(f"{work}/rows.tsv") as fh:
-	for line in fh:
-		p = line.rstrip("\n").split("\t")
-		if len(p) == 3:
-			rows.append({"pkg": p[0], "id": p[1], "group": p[2]})
-
-# Map version id -> digest so we can resolve manifests.
-digests = {}
-for pkg in {r["pkg"] for r in rows}:
-	enc = pkg.replace("/", "%2F")
-	import subprocess
-	try:
-		out = subprocess.run(
-			["gh", "api", f"/orgs/{org}/packages/container/{enc}/versions?per_page=100",
-			 "--paginate", "--jq", ".[] | \"\\(.id)\\t\\(.name)\""],
-			capture_output=True, text=True, check=True).stdout
-	except subprocess.CalledProcessError:
+for line in open(list_path):
+	line = line.rstrip("\n")
+	if not line.startswith("|"):
 		continue
-	for line in out.splitlines():
-		if "\t" in line:
-			i, d = line.split("\t", 1)
-			digests[(pkg, i)] = d
+	cells = [c.strip() for c in line.strip().strip("|").split("|")]
+	if len(cells) != 7 or not cells[1].isdigit():
+		continue
+	tags = set() if "_untagged_" in cells[2] else set(re.findall(r"`([^`]+)`", cells[2]))
+	rows.append({
+		"pkg": cells[0].strip("`"),
+		"id": cells[1],
+		"tags": tags,
+		"group": cells[6].strip("`"),
+	})
 
-_tok = {}
+if not rows:
+	print(f"No deletion rows found in {list_path} -- nothing to do.", file=sys.stderr)
+	open(f"{work}/todelete.tsv", "w").close()
+	sys.exit(0)
+print(f"==> {len(rows)} rows parsed from {list_path}")
+
+pkgs = sorted({r["pkg"] for r in rows})
+
+# --- Re-fetch current state of every involved package (fail closed) ----
+def fetch_versions(pkg):
+	enc = pkg.replace("/", "%2F")
+	p = subprocess.run(
+		["gh", "api", f"/orgs/{org}/packages/container/{enc}/versions?per_page=100",
+		 "--paginate", "--jq",
+		 '.[] | {id:.id, digest:.name, tags:(.metadata.container.tags // [])} | @json'],
+		capture_output=True, text=True)
+	if p.returncode != 0:
+		return pkg, None, p.stderr.strip()
+	out = {}
+	for line in p.stdout.splitlines():
+		if line.strip():
+			v = json.loads(line)
+			out[str(v["id"])] = {"digest": v["digest"], "tags": set(v["tags"])}
+	return pkg, out, None
+
+print(f"==> Re-reading {len(pkgs)} packages from the API")
+current, errors = {}, []
+with ThreadPoolExecutor(max_workers=8) as ex:
+	for pkg, out, err in ex.map(fetch_versions, pkgs):
+		if out is None:
+			errors.append(f"{pkg}: {err}")
+		else:
+			current[pkg] = out
+if errors:
+	die("Could not re-read these packages, so the deletion cannot be validated:",
+	    errors + ["", "Fix API access and re-run. Nothing was deleted."])
+
+# --- Drift check: has anything changed since the audit? ---------------
+gone, drift = [], []
+for r in rows:
+	cur = current[r["pkg"]].get(r["id"])
+	if cur is None:
+		gone.append(r)
+		continue
+	r["digest"] = cur["digest"]
+	if cur["tags"] != r["tags"]:
+		was = ", ".join(sorted(r["tags"])) or "untagged"
+		now = ", ".join(sorted(cur["tags"])) or "untagged"
+		drift.append(f"{r['pkg']} {r['id']}: audit recorded [{was}], registry now has [{now}]")
+if drift:
+	die("Tags changed since the audit ran (a digest may have been retagged "
+	    "and put back into use):",
+	    drift + ["", "Re-run ghcr-audit.sh to regenerate the list. Nothing was deleted."])
+
+if gone:
+	print(f"==> {len(gone)} listed versions no longer exist (already deleted); skipping them")
+	ids_gone = {(r["pkg"], r["id"]) for r in gone}
+	rows = [r for r in rows if (r["pkg"], r["id"]) not in ids_gone]
+	if not rows:
+		print("Nothing left to delete.", file=sys.stderr)
+		open(f"{work}/todelete.tsv", "w").close()
+		sys.exit(0)
+
+# --- In-use recheck against the current tags --------------------------
+inuse = set()
+try:
+	inuse = {l.strip() for l in open(f"{work}/inuse.txt") if l.strip()}
+except FileNotFoundError:
+	pass
+inuse_any = {r.split(":", 1)[1] for r in inuse if r.startswith("*:")}
+
+nowused = []
+for r in rows:
+	for t in sorted(r["tags"]):
+		if f"{r['pkg']}:{t}" in inuse or t in inuse_any:
+			nowused.append(f"{r['pkg']}:{t} (version {r['id']}) is referenced in the repo")
+if nowused:
+	die("Listed versions are referenced by the repo and must not be deleted:",
+	    nowused + ["", "Remove these rows from the list, or re-run the audit. "
+	               "Nothing was deleted."])
+
+# --- Resolve every manifest in the involved packages (fail closed) -----
+_tok, _tok_err = {}, {}
 def bearer(pkg):
 	if pkg in _tok:
 		return _tok[pkg]
@@ -115,8 +207,9 @@ def bearer(pkg):
 	try:
 		with urllib.request.urlopen(req, timeout=30) as r:
 			_tok[pkg] = json.load(r)["token"]
-	except Exception:
+	except Exception as e:
 		_tok[pkg] = None
+		_tok_err[pkg] = str(e)
 	return _tok[pkg]
 
 ACCEPT = ",".join([
@@ -126,52 +219,93 @@ ACCEPT = ",".join([
 	"application/vnd.docker.distribution.manifest.v2+json",
 ])
 
-def children(pkg, digest):
+def children(args):
+	"""(pkg, digest) -> (key, child_digests, error). Never guesses on failure."""
+	pkg, digest = args
 	tok = bearer(pkg)
 	if not tok:
-		return []
+		return (pkg, digest), None, f"no registry token for {pkg}: {_tok_err.get(pkg)}"
 	req = urllib.request.Request(f"https://ghcr.io/v2/{org}/{pkg}/manifests/{digest}")
 	req.add_header("Authorization", f"Bearer {tok}")
 	req.add_header("Accept", ACCEPT)
 	try:
 		with urllib.request.urlopen(req, timeout=30) as r:
-			return [x["digest"] for x in json.load(r).get("manifests", [])]
-	except Exception:
-		return []
+			m = json.load(r)
+	except Exception as e:
+		return (pkg, digest), None, f"{pkg} {digest[:19]}: {e}"
+	return (pkg, digest), [x["digest"] for x in m.get("manifests", [])], None
 
-listed = {(r["pkg"], digests.get((r["pkg"], r["id"]), "")) for r in rows}
-problems = []
-for r in rows:
-	d = digests.get((r["pkg"], r["id"]))
-	if not d:
-		continue
-	for c in children(r["pkg"], d):
-		if (r["pkg"], c) not in listed:
-			problems.append(f"{r['pkg']} index {d[:19]} is listed but its child {c[:19]} is not")
+targets = [(pkg, v["digest"]) for pkg in pkgs for v in current[pkg].values()]
+print(f"==> Resolving {len(targets)} manifests in {len(pkgs)} packages")
+kids, mf_errors = {}, []
+with ThreadPoolExecutor(max_workers=8) as ex:
+	for key, ch, err in ex.map(children, targets):
+		if ch is None:
+			mf_errors.append(err)
+		else:
+			kids[key] = ch
+if mf_errors:
+	die("Could not resolve these manifests, so multi-arch safety cannot be "
+	    "verified:",
+	    mf_errors[:20]
+	    + ([f"... and {len(mf_errors) - 20} more"] if len(mf_errors) > 20 else [])
+	    + ["", "Deleting a manifest child breaks the tagged image that points "
+	       "at it. Fix registry access and re-run. Nothing was deleted."])
 
-for p in problems:
-	print(p)
+# --- Re-derive the protected set: children of everything NOT listed ----
+listed = {(r["pkg"], r["digest"]) for r in rows}
+protected = {}
+for pkg in pkgs:
+	for vid, v in current[pkg].items():
+		if (pkg, v["digest"]) in listed:
+			continue
+		for c in kids.get((pkg, v["digest"]), []):
+			tagdesc = ", ".join(sorted(v["tags"])) or v["digest"][:19]
+			protected[(pkg, c)] = f"{pkg} version {vid} [{tagdesc}]"
+
+violations = [
+	f"{r['pkg']} {r['id']} ({r['digest'][:19]}) is a manifest child of {protected[(r['pkg'], r['digest'])]}"
+	for r in rows if (r["pkg"], r["digest"]) in protected
+]
+if violations:
+	die("Listed versions are still referenced by a retained multi-arch index:",
+	    violations + ["", "Deleting them would break that image. Remove these "
+	                  "rows, or re-run the audit. Nothing was deleted."])
+
+# --- Group integrity: a listed index needs all its children listed -----
+split = [
+	f"{r['pkg']} index {r['digest'][:19]} is listed but its child {c[:19]} is not"
+	for r in rows for c in kids.get((r["pkg"], r["digest"]), [])
+	if (r["pkg"], c) not in listed
+]
+if split:
+	if not allow_split:
+		die("Split multi-arch group detected:",
+		    split + ["", "Deleting an index without its children (or vice versa) "
+		             "can leave a broken image. Add the missing rows back, remove "
+		             "the whole group, or re-run with --allow-split-group. "
+		             "Nothing was deleted."])
+	print("\n! Split multi-arch group detected:", file=sys.stderr)
+	for s in split:
+		print(f"    {s}", file=sys.stderr)
+	print("  --allow-split-group given; continuing anyway.", file=sys.stderr)
+
+with open(f"{work}/todelete.tsv", "w") as fh:
+	for r in rows:
+		fh.write(f"{r['pkg']}\t{r['id']}\n")
+
+print("==> All safety checks passed")
 EOPY
-)
+RC=$?
+set -e
+[ "$RC" = "0" ] || exit "$RC"
+[ -s "$WORK/todelete.tsv" ] || exit 0
 
-if [ -n "$SPLIT" ]; then
-	echo "" >&2
-	echo "! Split multi-arch group detected:" >&2
-	echo "$SPLIT" | sed 's/^/    /' >&2
-	echo "" >&2
-	if [ "$ALLOW_SPLIT" = "0" ]; then
-		echo "  Deleting an index without its children (or vice versa) can leave a" >&2
-		echo "  broken image. Either add the missing rows back to the list, remove" >&2
-		echo "  the whole group, or re-run with --allow-split-group." >&2
-		exit 1
-	fi
-	echo "  --allow-split-group given; continuing anyway." >&2
-fi
+ROWS=$(wc -l < "$WORK/todelete.tsv" | tr -d ' ')
 
-# --- Summary --------------------------------------------------------------
 echo ""
 echo "Versions to delete, by package:"
-cut -f1 "$WORK/rows.tsv" | sort | uniq -c | sort -rn | sed 's/^/  /'
+cut -f1 "$WORK/todelete.tsv" | sort | uniq -c | sort -rn | sed 's/^/  /'
 echo ""
 
 if [ "$CONFIRM" = "0" ]; then
@@ -182,7 +316,7 @@ fi
 # --- Delete ---------------------------------------------------------------
 OK=0; FAIL=0
 : > "$WORK/failed.tsv"
-while IFS=$'\t' read -r pkg id grp; do
+while IFS=$'\t' read -r pkg id; do
 	[ -n "$id" ] || continue
 	enc="${pkg//\//%2F}"
 	if gh api -X DELETE "/orgs/$ORG/packages/container/$enc/versions/$id" >/dev/null 2>"$WORK/err"; then
@@ -193,10 +327,12 @@ while IFS=$'\t' read -r pkg id grp; do
 		printf '%s\t%s\t%s\n' "$pkg" "$id" "$(tr -d '\n' < "$WORK/err")" >> "$WORK/failed.tsv"
 		printf '  FAILED  %s %s -- %s\n' "$pkg" "$id" "$(head -c 200 "$WORK/err")" >&2
 	fi
-done < "$WORK/rows.tsv"
+done < "$WORK/todelete.tsv"
 
 echo ""
 echo "==> Deleted $OK, failed $FAIL of $ROWS"
+echo "A deleted version can usually be restored within 30 days:"
+echo "  gh api -X POST /orgs/$ORG/packages/container/<pkg>/versions/<id>/restore"
 if [ "$FAIL" -gt 0 ]; then
 	echo "Failures:" >&2
 	cat "$WORK/failed.tsv" >&2


### PR DESCRIPTION
Adds a skill for cleaning up stale container images in [posit-dev's GHCR registry](https://github.com/orgs/posit-dev/packages). There is no retention policy on these packages today, so old CI image versions accumulate indefinitely.

## How it works

Three phases, with a human gate in the middle:

1. `scripts/ghcr-audit.sh` (read-only) emits a markdown review list of every `positron-<os>*` / `positron-postgres-*` version older than a cutoff, default 90 days.
2. A human deletes the rows they want to **keep**. Everything left in the table is scheduled for deletion.
3. `scripts/ghcr-prune.sh` deletes exactly the remaining rows. Dry run unless given `--confirm`.

## Why this is more than a date filter

The multi-arch build pushes an index **plus two untagged per-arch manifests** into the same package, all within the same second:

```
positron-postgres  2026-08-26T19:58:14Z  [24.18.0]   <- live tag
positron-postgres  2026-08-26T19:58:14Z  []          <- amd64 child
positron-postgres  2026-08-26T19:58:13Z  []          <- arm64 child
```

Those untagged rows look like garbage, but deleting them breaks the tagged image. So a version is retained when it is newer than the cutoff, **or** one of its tags is referenced as `ghcr.io/<owner>/<pkg>:<tag>` under `.github/`, `docker/`, `test/`, `scripts/`, or `build/`, **or** it is a child manifest of a retained multi-arch index (resolved against the ghcr.io registry API).

The report also calls out packages that would be emptied entirely, and warns when a manifest could not be resolved so the protected set may be incomplete.

## Verification

Run against the real `posit-dev` org; **nothing was deleted**.

- 37 packages / 330 versions scanned at the 90-day cutoff: 145 candidates, 185 retained.
- All in-use tags (`:24.18.0` across 8 images, plus `positron-rocky8:24.15.0`) were correctly retained, not listed.
- Manifest-child protection exercised by tightening the cutoff so an index was retained only by its in-use tag: both arch children of `positron-rocky8:24.15.0` were correctly excluded.
- Split-group guard: removing one arch-child row from a reviewed list aborts with exit 1 and names the missing child. Intact list exits 0, empty list is a no-op.
- Dry run on the full 145-row list parses cleanly and deletes nothing.

## Notes for review

- The default pattern deliberately scopes to OS + postgres images and excludes build/tooling images (`positron-builds-*`, `positron-ci`, `positron-sagemaker`). Widen via `--pattern`.
- Requires `delete:packages` for phase 3; the prune script checks the scope itself and refuses to run without it.
- Known limit, documented in the skill: the in-use scan reads the working tree only, so a tag referenced solely by an older release branch is invisible to it. `--protect-tag` covers that case.
- Docs-and-scripts only. No product code, no e2e impact.

Complements the existing `update-ci-images` skill, which builds new images at a new tag; this one retires the old ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)