### PR TITLE
Add a per-license hash to P3M gallery telemetry

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
@@ -802,6 +802,7 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 			getPositronSessionType(),
 			formatPositronVersion(this.productService.positronVersion, this.productService.positronBuildNumber),
 			this.academicLicenseService.isAcademic,
+			this.academicLicenseService.licenseHash,
 			sendUsageData,
 		);
 		resourceApi = {
@@ -1478,6 +1479,7 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 			getPositronSessionType(),
 			formatPositronVersion(this.productService.positronVersion, this.productService.positronBuildNumber),
 			this.academicLicenseService.isAcademic,
+			this.academicLicenseService.licenseHash,
 			sendUsageData,
 		);
 		// --- End Positron ---

--- a/src/vs/platform/extensionManagement/common/positronGalleryTelemetry.ts
+++ b/src/vs/platform/extensionManagement/common/positronGalleryTelemetry.ts
@@ -95,8 +95,9 @@ export function isP3MGalleryUrl(url: string): boolean {
  * `User-Agent` overrides, so a header-based approach would not work uniformly.
  *
  * `checkTrigger` is omitted from the URL when undefined (browse / non-update-check
- * traffic). `positron-session-type`, `positron-version`, and `positron-is-academic`
- * are always sent.
+ * traffic), and `positron-license-hash` when the session has no license file behind it
+ * (desktop, and the license paths with nothing meaningful to hash). `positron-session-type`,
+ * `positron-version`, and `positron-is-academic` are always sent.
  */
 export function appendPositronGalleryParams(
 	url: string,
@@ -104,6 +105,7 @@ export function appendPositronGalleryParams(
 	sessionType: PositronSessionType,
 	positronVersion: string,
 	isAcademic: boolean,
+	licenseHash: string | undefined,
 	sendUsageData: boolean,
 ): string {
 	if (!sendUsageData || !isP3MGalleryUrl(url)) {
@@ -116,6 +118,9 @@ export function appendPositronGalleryParams(
 	params.push(`positron-session-type=${encodeURIComponent(sessionType)}`);
 	params.push(`positron-version=${encodeURIComponent(positronVersion)}`);
 	params.push(`positron-is-academic=${isAcademic}`);
+	if (licenseHash) {
+		params.push(`positron-license-hash=${encodeURIComponent(licenseHash)}`);
+	}
 	const separator = url.includes('?') ? '&' : '?';
 	return `${url}${separator}${params.join('&')}`;
 }

--- a/src/vs/platform/extensionManagement/test/common/positronGalleryTelemetry.vitest.ts
+++ b/src/vs/platform/extensionManagement/test/common/positronGalleryTelemetry.vitest.ts
@@ -5,7 +5,7 @@
 
 /// <reference types="vitest/globals" />
 
-import { appendPositronGalleryParams, formatPositronVersion, isP3MGalleryUrl } from '../../common/positronGalleryTelemetry.js';
+import { appendPositronGalleryParams, formatPositronVersion, isP3MGalleryUrl, PositronCheckTrigger, PositronSessionType } from '../../common/positronGalleryTelemetry.js';
 
 describe('positronGalleryTelemetry', function () {
 	describe('formatPositronVersion', function () {
@@ -21,71 +21,112 @@ describe('positronGalleryTelemetry', function () {
 	describe('appendPositronGalleryParams', function () {
 		const baseUrl = 'https://p3m.dev/openvsx/latest/vscode/gallery/extensionquery';
 
+		/**
+		 * Calls `appendPositronGalleryParams` by name. The real signature is positional and
+		 * ends in two booleans plus an optional hash, which at a call site reads as a row of
+		 * bare literals; naming them keeps each test to the one field it is about.
+		 */
+		function appendParams(overrides: {
+			url?: string;
+			checkTrigger?: PositronCheckTrigger;
+			sessionType?: PositronSessionType;
+			version?: string;
+			isAcademic?: boolean;
+			licenseHash?: string;
+			sendUsageData?: boolean;
+		} = {}): string {
+			const args = {
+				url: baseUrl,
+				sessionType: 'desktop' as PositronSessionType,
+				version: '2026.06.0-42',
+				isAcademic: true,
+				sendUsageData: true,
+				...overrides,
+			};
+			return appendPositronGalleryParams(args.url, args.checkTrigger, args.sessionType, args.version, args.isAcademic, args.licenseHash, args.sendUsageData);
+		}
+
 		it('always appends session-type, version, and is-academic', () => {
-			const result = appendPositronGalleryParams(baseUrl, undefined, 'desktop', '2026.06.0-42', true, true);
-			expect(result).toBe(`${baseUrl}?positron-session-type=desktop&positron-version=2026.06.0-42&positron-is-academic=true`);
+			expect(appendParams()).toBe(`${baseUrl}?positron-session-type=desktop&positron-version=2026.06.0-42&positron-is-academic=true`);
 		});
 
 		it('includes check-trigger when provided', () => {
-			const result = appendPositronGalleryParams(baseUrl, 'startup', 'desktop', '2026.06.0-42', true, true);
-			expect(result).toBe(`${baseUrl}?positron-check-trigger=startup&positron-session-type=desktop&positron-version=2026.06.0-42&positron-is-academic=true`);
+			expect(appendParams({ checkTrigger: 'startup' })).toBe(`${baseUrl}?positron-check-trigger=startup&positron-session-type=desktop&positron-version=2026.06.0-42&positron-is-academic=true`);
 		});
 
 		it('uses & separator when URL already has a query string', () => {
-			const result = appendPositronGalleryParams(`${baseUrl}?foo=1`, 'periodic', 'workbench', '2026.06.0-42', true, true);
-			expect(result).toBe(`${baseUrl}?foo=1&positron-check-trigger=periodic&positron-session-type=workbench&positron-version=2026.06.0-42&positron-is-academic=true`);
+			expect(appendParams({ url: `${baseUrl}?foo=1`, checkTrigger: 'periodic', sessionType: 'workbench' }))
+				.toBe(`${baseUrl}?foo=1&positron-check-trigger=periodic&positron-session-type=workbench&positron-version=2026.06.0-42&positron-is-academic=true`);
 		});
 
 		it('encodes special characters in version', () => {
-			const result = appendPositronGalleryParams(baseUrl, 'positron-updated', 'positron-server', '2026.06.0+dev', true, true);
-			expect(result).toContain('positron-version=2026.06.0%2Bdev');
+			expect(appendParams({ version: '2026.06.0+dev' })).toContain('positron-version=2026.06.0%2Bdev');
 		});
 
-		it('emits every session-type value without alteration', () => {
-			for (const sessionType of ['desktop', 'workbench', 'workbench-server', 'positron-server', 'remote-server'] as const) {
-				const result = appendPositronGalleryParams(baseUrl, undefined, sessionType, '2026.06.0', true, true);
-				expect(result).toContain(`positron-session-type=${sessionType}`);
-			}
-		});
+		it.each(['desktop', 'workbench', 'workbench-server', 'positron-server', 'remote-server'] as const)(
+			'emits session-type %s without alteration',
+			sessionType => {
+				expect(appendParams({ sessionType })).toContain(`positron-session-type=${sessionType}`);
+			});
 
 		it('appends positron-is-academic=false when the session is not academic', () => {
-			const result = appendPositronGalleryParams(baseUrl, undefined, 'positron-server', '2026.06.0', false, true);
-			expect(result).toContain('positron-is-academic=false');
+			expect(appendParams({ isAcademic: false })).toContain('positron-is-academic=false');
+		});
+
+		it('appends the license hash after is-academic when the session has one', () => {
+			expect(appendParams({ checkTrigger: 'startup', licenseHash: 'a1b2c3d4e5f60718' }))
+				.toBe(`${baseUrl}?positron-check-trigger=startup&positron-session-type=desktop&positron-version=2026.06.0-42&positron-is-academic=true&positron-license-hash=a1b2c3d4e5f60718`);
+		});
+
+		it('omits the license hash param rather than sending it empty', () => {
+			// The param is gated on the hash being truthy, not merely defined, so a license
+			// path that produced an empty string reports nothing at all.
+			expect(appendParams({ licenseHash: '' })).not.toContain('positron-license-hash');
+		});
+
+		it('encodes a license hash that is not a plain hex digest', () => {
+			// The browser reads the hash off an injected global and only checks that it is a
+			// string, so an unexpected value must not be able to add params of its own.
+			expect(appendParams({ licenseHash: 'a b&c=d' })).toContain('positron-license-hash=a%20b%26c%3Dd');
+		});
+
+		it('suppresses the license hash when sendUsageData is false', () => {
+			// Redundant with the opt-out tests below, since the opt-out returns before any
+			// param is built; kept to state the privacy contract for the most identifying
+			// param explicitly.
+			expect(appendParams({ checkTrigger: 'startup', licenseHash: 'a1b2c3d4e5f60718', sendUsageData: false })).toBe(baseUrl);
 		});
 
 		it('returns the URL unchanged for non-P3M galleries', () => {
 			const openVsx = 'https://open-vsx.org/vscode/gallery/extensionquery';
-			expect(appendPositronGalleryParams(openVsx, 'startup', 'desktop', '2026.06.0', true, true)).toBe(openVsx);
-
 			const internal = 'https://gallery.internal.example.com/extensionquery';
-			expect(appendPositronGalleryParams(internal, 'periodic', 'workbench', '2026.06.0', true, true)).toBe(internal);
+			expect([
+				appendParams({ url: openVsx, checkTrigger: 'startup' }),
+				appendParams({ url: internal, checkTrigger: 'periodic', sessionType: 'workbench' }),
+			]).toEqual([openVsx, internal]);
 		});
 
 		it('tags P3M subdomains (e.g. staging)', () => {
 			const staging = 'https://staging.p3m.dev/openvsx/latest/vscode/gallery/extensionquery';
-			const result = appendPositronGalleryParams(staging, 'startup', 'desktop', '2026.06.0', true, true);
-			expect(result).toContain('positron-check-trigger=startup');
+			expect(appendParams({ url: staging, checkTrigger: 'startup' })).toContain('positron-check-trigger=startup');
 		});
 
 		it('does not tag URLs that merely contain p3m.dev as substring', () => {
 			const spoof = 'https://p3m.dev.attacker.com/extensionquery';
-			expect(appendPositronGalleryParams(spoof, 'startup', 'desktop', '2026.06.0', true, true)).toBe(spoof);
+			expect(appendParams({ url: spoof, checkTrigger: 'startup' })).toBe(spoof);
 		});
 
 		it('tolerates URI template placeholders in the path', () => {
 			const template = 'https://p3m.dev/openvsx/latest/vscode/gallery/{publisher}/{name}/latest';
-			const result = appendPositronGalleryParams(template, 'startup', 'desktop', '2026.06.0', true, true);
-			expect(result).toContain('positron-check-trigger=startup');
+			expect(appendParams({ url: template, checkTrigger: 'startup' })).toContain('positron-check-trigger=startup');
 		});
 
 		it('returns the URL unchanged when sendUsageData is false', () => {
-			const result = appendPositronGalleryParams(baseUrl, 'startup', 'desktop', '2026.06.0', true, false);
-			expect(result).toBe(baseUrl);
+			expect(appendParams({ checkTrigger: 'startup', sendUsageData: false })).toBe(baseUrl);
 		});
 
 		it('respects sendUsageData=false even on a P3M URL with a trigger', () => {
-			const result = appendPositronGalleryParams(baseUrl, 'periodic', 'workbench-server', '2026.06.0-42', true, false);
-			expect(result).toBe(baseUrl);
+			expect(appendParams({ checkTrigger: 'periodic', sessionType: 'workbench-server', sendUsageData: false })).toBe(baseUrl);
 		});
 	});
 

--- a/src/vs/platform/positronLicense/common/positronAcademicLicenseService.ts
+++ b/src/vs/platform/positronLicense/common/positronAcademicLicenseService.ts
@@ -8,29 +8,65 @@ import { createDecorator } from '../../instantiation/common/instantiation.js';
 export const IPositronAcademicLicenseService = createDecorator<IPositronAcademicLicenseService>('positronAcademicLicenseService');
 
 /**
- * Reports whether this Positron session is running under a license that grants the
- * Education License Rider terms.
+ * Reports what Positron knows about the license behind this session: whether it grants the
+ * Education License Rider terms, and a hash identifying the license file it came from.
  *
  * Node/server: derived from the validated license (see `remoteLicenseKey.ts`'s
- * `ILicenseValidationResult.academic`) at server startup. Browser: derived from the
- * global injected by `webClientServer.ts` (see {@link academicMarkerScript}). Desktop:
- * always false, since desktop installs never go through a license check.
+ * `ILicenseValidationResult`) at server startup. Browser: derived from the globals
+ * injected by `webClientServer.ts` (see {@link licenseMarkerScript}). Desktop: academic is
+ * always false and there is no hash, since desktop installs never go through a license
+ * check.
  */
 export interface IPositronAcademicLicenseService {
 	readonly _serviceBrand: undefined;
 
 	/** Whether this session is running under an academic license. */
 	readonly isAcademic: boolean;
+
+	/**
+	 * A short, stable hash of the license file backing this session, sent to P3M as
+	 * `positron-license-hash` so Posit can count session starts per license it issued.
+	 * Undefined when the session has no license file to hash: desktop, a signed Posit
+	 * Workbench token (per-connection, so hashing it would say nothing), and the AWS
+	 * license manager (no key material). See `hashLicenseContents` in `localLicense.ts`.
+	 */
+	readonly licenseHash: string | undefined;
 }
 
-/** Name of the injected global that marks a browser session academic; see {@link academicMarkerScript}. */
+/** Name of the injected global that marks a browser session academic; see {@link licenseMarkerScript}. */
 export const POSITRON_IS_ACADEMIC_GLOBAL = '_POSITRON_IS_ACADEMIC';
 
+/** Name of the injected global carrying the license hash; see {@link licenseMarkerScript}. */
+export const POSITRON_LICENSE_HASH_GLOBAL = '_POSITRON_LICENSE_HASH';
+
+/** Shape of a license hash as `hashLicenseContents` in `localLicense.ts` produces it. */
+const LICENSE_HASH_PATTERN = /^[0-9a-f]{16}$/;
+
 /**
- * Builds the inline `<script>` that tells the browser this session is academic, for injection
- * into the served workbench HTML by `webClientServer.ts`. Empty when the session is not
- * academic: the absence of the global means false, which is the common case.
+ * Whether a value is a license hash as Positron produces them.
+ *
+ * Checked on both sides of the injected global: the server refuses to write a value that
+ * is not one of ours into the served HTML, and the browser refuses to read one back out.
+ * The browser check is what keeps an unexpected value out of outgoing P3M gallery URLs, so
+ * neither side relies on the other having looked.
  */
-export function academicMarkerScript(isAcademic: boolean): string {
-	return isAcademic ? `<script>globalThis.${POSITRON_IS_ACADEMIC_GLOBAL} = true;</script>` : '';
+export function isLicenseHash(value: unknown): value is string {
+	return typeof value === 'string' && LICENSE_HASH_PATTERN.test(value);
+}
+
+/**
+ * Builds the inline `<script>` that tells the browser what license this session runs under,
+ * for injection into the served workbench HTML by `webClientServer.ts`. Each global is
+ * emitted only when it has something to say, and the script is empty when neither does:
+ * an absent academic global means false, and an absent hash global means no license file.
+ */
+export function licenseMarkerScript(isAcademic: boolean, licenseHash?: string): string {
+	const assignments: string[] = [];
+	if (isAcademic) {
+		assignments.push(`globalThis.${POSITRON_IS_ACADEMIC_GLOBAL} = true;`);
+	}
+	if (isLicenseHash(licenseHash)) {
+		assignments.push(`globalThis.${POSITRON_LICENSE_HASH_GLOBAL} = '${licenseHash}';`);
+	}
+	return assignments.length > 0 ? `<script>${assignments.join(' ')}</script>` : '';
 }

--- a/src/vs/platform/positronLicense/node/positronAcademicLicenseService.ts
+++ b/src/vs/platform/positronLicense/node/positronAcademicLicenseService.ts
@@ -6,12 +6,13 @@
 import { IPositronAcademicLicenseService } from '../common/positronAcademicLicenseService.js';
 
 /**
- * Takes the academic status as a plain constructor value: on the server it comes from an
+ * Takes the license facts as plain constructor values: on the server they come from an
  * async license check that completes before services are registered (see `createServer()`
- * in `remoteExtensionHostAgentServer.ts`); processes with no license check pass `false`.
+ * in `remoteExtensionHostAgentServer.ts`); processes with no license check pass `false`
+ * and omit the hash.
  */
 export class PositronAcademicLicenseService implements IPositronAcademicLicenseService {
 	declare readonly _serviceBrand: undefined;
 
-	constructor(readonly isAcademic: boolean) { }
+	constructor(readonly isAcademic: boolean, readonly licenseHash: string | undefined = undefined) { }
 }

--- a/src/vs/platform/positronLicense/test/common/positronAcademicLicenseService.vitest.ts
+++ b/src/vs/platform/positronLicense/test/common/positronAcademicLicenseService.vitest.ts
@@ -5,15 +5,39 @@
 
 /// <reference types="vitest/globals" />
 
-import { academicMarkerScript } from '../../common/positronAcademicLicenseService.js';
+import { licenseMarkerScript } from '../../common/positronAcademicLicenseService.js';
 
-describe('academicMarkerScript', () => {
+describe('licenseMarkerScript', () => {
 
 	it('emits a script setting the academic global', () => {
-		expect(academicMarkerScript(true)).toBe('<script>globalThis._POSITRON_IS_ACADEMIC = true;</script>');
+		expect(licenseMarkerScript(true)).toBe('<script>globalThis._POSITRON_IS_ACADEMIC = true;</script>');
+	});
+
+	it('emits both globals when the session is academic and has a license hash', () => {
+		expect(licenseMarkerScript(true, 'a1b2c3d4e5f60718')).toBe(
+			`<script>globalThis._POSITRON_IS_ACADEMIC = true; globalThis._POSITRON_LICENSE_HASH = 'a1b2c3d4e5f60718';</script>`
+		);
+	});
+
+	it('emits the hash alone for a licensed session that is not academic', () => {
+		// The shape a future Positron Server Pro would take: a license file to hash, but
+		// its own signal saying the Education License Rider does not apply.
+		expect(licenseMarkerScript(false, 'a1b2c3d4e5f60718')).toBe(
+			`<script>globalThis._POSITRON_LICENSE_HASH = 'a1b2c3d4e5f60718';</script>`
+		);
 	});
 
 	it('emits nothing when the session is not academic', () => {
-		expect(academicMarkerScript(false)).toBe('');
+		expect(licenseMarkerScript(false)).toBe('');
 	});
+
+	// Nothing should be able to reach the inline script through the hash, so anything that
+	// is not a plain hex digest of the expected width is refused outright. Asserted with an
+	// academic session so the expectation names what survives: dropping the bad hash must
+	// not take the academic global (and with it the license banner) down too.
+	it.each(['', 'a1b2c3d4e5f6071', 'a1b2c3d4e5f607189', 'A1B2C3D4E5F60718', `x';alert(1);//`])(
+		'drops the hash %j and still emits the academic global',
+		notAHash => {
+			expect(licenseMarkerScript(true, notAHash)).toBe('<script>globalThis._POSITRON_IS_ACADEMIC = true;</script>');
+		});
 });

--- a/src/vs/server/node/localLicense.ts
+++ b/src/vs/server/node/localLicense.ts
@@ -63,21 +63,36 @@ function extractJson(stdout: string): string {
 /**
  * Hashes the contents of a license file into the short, stable identifier that P3M
  * telemetry reports as `positron-license-hash`, so Posit can count session starts per
- * license it issued. SHA-256 over the trimmed license text, truncated to 16 hex
+ * license it issued. SHA-256 over the trimmed license bytes, truncated to 16 hex
  * characters: wide enough that collisions across the issued licenses are negligible,
  * short enough to stay readable in URLs and logs.
  *
- * Surrounding whitespace is the only thing normalized away, so a license that picks up or
- * loses a trailing newline still hashes the same. Everything between the first and last
- * non-whitespace byte is hashed exactly as it appears, interior line endings included: the
- * Posit-side script that hashes the issued licenses has to do the same, and must not
- * normalize CRLF to LF, or the two sides will not join.
+ * Surrounding ASCII whitespace is the only thing normalized away. Everything between the
+ * first and last non-ASCII-whitespace byte is hashed exactly as it appears, interior line
+ * endings included; the Posit-side script must use the same byte-level contract.
  *
  * The hash identifies a deployment's license, not a user, and is meaningless to anyone
  * without Posit's own records of the licenses it issued.
  */
-export function hashLicenseContents(contents: string): string {
-	return crypto.createHash('sha256').update(contents.trim()).digest('hex').slice(0, 16);
+export function hashLicenseContents(contents: Buffer): string | undefined {
+	let start = 0;
+	while (start < contents.length && isAsciiWhitespace(contents[start])) {
+		start++;
+	}
+
+	let end = contents.length;
+	while (end > start && isAsciiWhitespace(contents[end - 1])) {
+		end--;
+	}
+
+	if (start === end) {
+		return undefined;
+	}
+	return crypto.createHash('sha256').update(contents.subarray(start, end)).digest('hex').slice(0, 16);
+}
+
+function isAsciiWhitespace(byte: number): boolean {
+	return byte === 0x20 || (byte >= 0x09 && byte <= 0x0d);
 }
 
 /**
@@ -103,9 +118,9 @@ export function licenseFileHash(licenseManagerDir: string, reportedPath?: string
 		// Directory unreadable; whatever the binary reported is all we have.
 	}
 	for (const candidate of candidates) {
-		let contents: string;
+		let contents: Buffer;
 		try {
-			contents = fs.readFileSync(candidate, 'utf8');
+			contents = fs.readFileSync(candidate);
 		} catch {
 			// Unreadable candidate; try the next one.
 			continue;
@@ -114,8 +129,9 @@ export function licenseFileHash(licenseManagerDir: string, reportedPath?: string
 		// identifies no license at all, and every deployment with a truncated or
 		// placeholder .lic would report that same value. Skip it: a collapsed group in
 		// Posit's per-license counts is far worse than a missing one.
-		if (contents.trim().length > 0) {
-			return hashLicenseContents(contents);
+		const licenseHash = hashLicenseContents(contents);
+		if (licenseHash) {
+			return licenseHash;
 		}
 	}
 	return undefined;

--- a/src/vs/server/node/localLicense.ts
+++ b/src/vs/server/node/localLicense.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as os from 'os';
 import { execFile } from 'child_process';
@@ -60,6 +61,67 @@ function extractJson(stdout: string): string {
 }
 
 /**
+ * Hashes the contents of a license file into the short, stable identifier that P3M
+ * telemetry reports as `positron-license-hash`, so Posit can count session starts per
+ * license it issued. SHA-256 over the trimmed license text, truncated to 16 hex
+ * characters: wide enough that collisions across the issued licenses are negligible,
+ * short enough to stay readable in URLs and logs.
+ *
+ * Surrounding whitespace is the only thing normalized away, so a license that picks up or
+ * loses a trailing newline still hashes the same. Everything between the first and last
+ * non-whitespace byte is hashed exactly as it appears, interior line endings included: the
+ * Posit-side script that hashes the issued licenses has to do the same, and must not
+ * normalize CRLF to LF, or the two sides will not join.
+ *
+ * The hash identifies a deployment's license, not a user, and is meaningless to anyone
+ * without Posit's own records of the licenses it issued.
+ */
+export function hashLicenseContents(contents: string): string {
+	return crypto.createHash('sha256').update(contents.trim()).digest('hex').slice(0, 16);
+}
+
+/**
+ * Hashes the license file backing a verified license. Prefers the path the license-manager
+ * binary reported; falls back to the .lic in its own directory, which is where both
+ * `activateLicenseFile` and `verifyLocalLicense` leave the effective license.
+ *
+ * Returns undefined when no candidate yields a hash. The hash is telemetry only, so a
+ * failure to compute it must never fail an otherwise valid license check; reporting nothing
+ * is always better than reporting a hash that does not identify a license Posit issued.
+ */
+export function licenseFileHash(licenseManagerDir: string, reportedPath?: string): string | undefined {
+	// Only an absolute reported path is usable. A relative one would resolve against the
+	// server process's working directory rather than the binary's, which could read an
+	// unrelated same-named file; the directory scan below is the better guess in that case.
+	const candidates: string[] = reportedPath && path.isAbsolute(reportedPath) ? [reportedPath] : [];
+	try {
+		const localLic = fs.readdirSync(licenseManagerDir).find(f => f.endsWith('.lic'));
+		if (localLic) {
+			candidates.push(path.join(licenseManagerDir, localLic));
+		}
+	} catch {
+		// Directory unreadable; whatever the binary reported is all we have.
+	}
+	for (const candidate of candidates) {
+		let contents: string;
+		try {
+			contents = fs.readFileSync(candidate, 'utf8');
+		} catch {
+			// Unreadable candidate; try the next one.
+			continue;
+		}
+		// An empty or whitespace-only file hashes to a perfectly well-formed value that
+		// identifies no license at all, and every deployment with a truncated or
+		// placeholder .lic would report that same value. Skip it: a collapsed group in
+		// Posit's per-license counts is far worse than a missing one.
+		if (contents.trim().length > 0) {
+			return hashLicenseContents(contents);
+		}
+	}
+	return undefined;
+}
+
+/**
  * Wrapper for executing classic `license-manager` binary commands (the binary bundled
  * under `resources/activation/`). Not to be confused with `licenseManager.ts`, which
  * supervises the AWS License Manager client.
@@ -109,7 +171,11 @@ class LocalLicenseManager {
 
 		const validated = validatedResult(result);
 		console.log(`Positron license verified: ${JSON.stringify(result)}`);
-		return validated;
+		// Hash the verified file here rather than at the call sites: this is the one
+		// place both the activated and the pre-existing local .lic converge, so the
+		// hash always names the license that was actually accepted.
+		const licenseHash = licenseFileHash(path.dirname(this.licenseManagerPath), result['license-file']);
+		return licenseHash ? { ...validated, licenseHash } : validated;
 	}
 
 	async activateLicenseFile(licenseFilePath: string): Promise<ILicenseValidationResult> {

--- a/src/vs/server/node/remoteExtensionHostAgentServer.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentServer.ts
@@ -753,7 +753,7 @@ export async function createServer(address: string | net.AddressInfo | null, arg
 		issuer: licenseValidationResult.issuer,
 		academic: licenseValidationResult.academic === true,
 	} : undefined;
-	const { socketServer, instantiationService } = await setupServerServices(connectionToken, args, REMOTE_DATA_FOLDER, disposables, positronLicenseeInfo);
+	const { socketServer, instantiationService } = await setupServerServices(connectionToken, args, REMOTE_DATA_FOLDER, disposables, positronLicenseeInfo, licenseValidationResult?.licenseHash);
 	// --- End Positron ---
 
 	// --- Start Positron ---

--- a/src/vs/server/node/remoteLicenseKey.ts
+++ b/src/vs/server/node/remoteLicenseKey.ts
@@ -31,6 +31,14 @@ export interface ILicenseValidationResult {
 	 * or it will inherit `academic` as true
 	 */
 	academic?: boolean;
+	/**
+	 * A short, stable hash of the license file that licensed this deployment, reported to
+	 * P3M as `positron-license-hash` so Posit can count session starts per license it
+	 * issued. Computed by `hashLicenseContents` in `localLicense.ts` and carried up
+	 * through the raw-license-file paths; a signed Workbench token is per-connection and
+	 * the AWS license manager exposes no key material, so neither of those sets it.
+	 */
+	licenseHash?: string;
 }
 
 /**

--- a/src/vs/server/node/serverServices.ts
+++ b/src/vs/server/node/serverServices.ts
@@ -131,7 +131,7 @@ import { AiProviderCatalogChannel } from '../../platform/positronAiProvider/node
 const eventPrefix = 'monacoworkbench';
 
 // --- Start Positron ---
-export async function setupServerServices(connectionToken: ServerConnectionToken, args: ServerParsedArgs, REMOTE_DATA_FOLDER: string, disposables: DisposableStore, positronLicenseeInfo?: IPositronLicenseeInfo) {
+export async function setupServerServices(connectionToken: ServerConnectionToken, args: ServerParsedArgs, REMOTE_DATA_FOLDER: string, disposables: DisposableStore, positronLicenseeInfo?: IPositronLicenseeInfo, licenseHash?: string) {
 	// --- End Positron ---
 	const services = new ServiceCollection();
 	const socketServer = new SocketServer<RemoteAgentConnectionContext>();
@@ -358,7 +358,10 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 	services.set(IEphemeralStateService, ephemeralStateService);
 	const idleTrackingService = new PositronIdleTrackingService();
 	services.set(IPositronIdleTrackingService, idleTrackingService);
-	services.set(IPositronAcademicLicenseService, new PositronAcademicLicenseService(positronLicenseeInfo?.academic === true));
+	// The hash is a separate argument rather than a field on the licensee info because that
+	// object goes out to clients over the remote agent channel and the hash has no business
+	// there; it is only ever read back out by the gallery telemetry in this process.
+	services.set(IPositronAcademicLicenseService, new PositronAcademicLicenseService(positronLicenseeInfo?.academic === true, licenseHash));
 	// --- End Positron ---
 
 	instantiationService.invokeFunction(accessor => {

--- a/src/vs/server/node/webClientServer.ts
+++ b/src/vs/server/node/webClientServer.ts
@@ -41,7 +41,7 @@ import type * as net from 'net';
 // --- Start Positron ---
 import { HAS_STATIC_ROUTE } from './pwbConstants.js';
 import { shouldUseSessionLessStaticRoute } from './positronStaticRoute.js';
-import { academicMarkerScript, IPositronAcademicLicenseService } from '../../platform/positronLicense/common/positronAcademicLicenseService.js';
+import { IPositronAcademicLicenseService, licenseMarkerScript } from '../../platform/positronLicense/common/positronAcademicLicenseService.js';
 // --- End Positron ---
 
 const textMimeType: { [ext: string]: string | undefined } = {
@@ -687,10 +687,10 @@ export class WebClientServer {
 		const pwbWorkbenchMarker = isWorkbench ? '<script>globalThis._PWB_IS_WORKBENCH = true;</script>' : '';
 		// --- End PWB ---
 
-		// --- Start Positron: browser-side academic marker ---
+		// --- Start Positron: browser-side license markers ---
 		// Same early-injection trick as the Workbench marker above, reusing the PWB_WORKBENCH_MARKER
 		// slot so no template changes are needed.
-		const academicMarker = academicMarkerScript(this._academicLicenseService.isAcademic);
+		const licenseMarker = licenseMarkerScript(this._academicLicenseService.isAcademic, this._academicLicenseService.licenseHash);
 		// --- End Positron ---
 
 		const values: { [key: string]: string } = {
@@ -705,7 +705,7 @@ export class WebClientServer {
 			BASE: base,
 			VS_BASE: vscodeBase,
 			RS_LOGIN_CHECK_SCRIPT: rsLoginCheckScript,
-			PWB_WORKBENCH_MARKER: pwbWorkbenchMarker + academicMarker,
+			PWB_WORKBENCH_MARKER: pwbWorkbenchMarker + licenseMarker,
 			// --- End PWB ---
 		};
 

--- a/src/vs/server/node/webClientServer.ts
+++ b/src/vs/server/node/webClientServer.ts
@@ -693,7 +693,6 @@ export class WebClientServer {
 		// slot so no template changes are needed.
 		const licenseMarker = licenseMarkerScript(this._academicLicenseService.isAcademic, this._academicLicenseService.licenseHash);
 		const sageMakerMarker = sageMakerMarkerScript(isSageMakerSession());
-		const licenseMarker = licenseMarkerScript(this._academicLicenseService.isAcademic, this._academicLicenseService.licenseHash);
 		// --- End Positron ---
 
 		const values: { [key: string]: string } = {

--- a/src/vs/server/test/node/localLicense.vitest.ts
+++ b/src/vs/server/test/node/localLicense.vitest.ts
@@ -10,8 +10,9 @@ import * as os from 'os';
 import * as path from '../../../base/common/path.js';
 import { hashLicenseContents, licenseFileHash } from '../../node/localLicense.js';
 
-const license = '-----BEGIN RSTUDIO LICENSE-----\nabc123\n-----END RSTUDIO LICENSE-----';
-const renewedLicense = license.replace('abc123', 'def456');
+const licenseText = '-----BEGIN RSTUDIO LICENSE-----\nabc123\n-----END RSTUDIO LICENSE-----';
+const license = Buffer.from(licenseText);
+const renewedLicense = Buffer.from(licenseText.replace('abc123', 'def456'));
 
 describe('hashLicenseContents', () => {
 
@@ -27,9 +28,19 @@ describe('hashLicenseContents', () => {
 		// A license file can gain or lose a trailing newline in transit; a deployment must
 		// not look like a different license because of it.
 		expect([
-			hashLicenseContents(`${license}\n`),
-			hashLicenseContents(`\n\n${license}\n  \n`),
+			hashLicenseContents(Buffer.concat([license, Buffer.from('\n')])),
+			hashLicenseContents(Buffer.concat([Buffer.from('\t\r\n '), license, Buffer.from(' \v\f\r\n')])),
 		]).toEqual(['c12b6949758226a4', 'c12b6949758226a4']);
+	});
+
+	it('keeps a UTF-8 BOM as part of the license', () => {
+		const byteOrderMark = Buffer.from([0xef, 0xbb, 0xbf]);
+		expect(hashLicenseContents(Buffer.concat([byteOrderMark, license]))).toBe('74a890b11e2de8e5');
+	});
+
+	it('keeps interior CRLF bytes as part of the license', () => {
+		const crlfLicense = Buffer.from(licenseText.replaceAll('\n', '\r\n'));
+		expect(hashLicenseContents(crlfLicense)).toBe('0498f64a7fcce766');
 	});
 
 	it('gives different licenses different hashes', () => {
@@ -49,7 +60,7 @@ describe('licenseFileHash', () => {
 	});
 
 	/** Writes a file into the license-manager directory and returns its path. */
-	function writeInDir(name: string, contents: string): string {
+	function writeInDir(name: string, contents: string | Buffer): string {
 		const filePath = path.join(dir, name);
 		fs.writeFileSync(filePath, contents);
 		return filePath;
@@ -61,6 +72,11 @@ describe('licenseFileHash', () => {
 		writeInDir('stale.lic', license);
 		const reported = writeInDir('verified.txt', renewedLicense);
 		expect(licenseFileHash(dir, reported)).toBe(hashLicenseContents(renewedLicense));
+	});
+
+	it('hashes the reported license file when the manager directory is unreadable', () => {
+		const reported = writeInDir('verified.lic', license);
+		expect(licenseFileHash(path.join(dir, 'no-such-dir'), reported)).toBe('c12b6949758226a4');
 	});
 
 	it('falls back to the .lic in the directory when the binary reports no path', () => {

--- a/src/vs/server/test/node/localLicense.vitest.ts
+++ b/src/vs/server/test/node/localLicense.vitest.ts
@@ -1,0 +1,112 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from '../../../base/common/path.js';
+import { hashLicenseContents, licenseFileHash } from '../../node/localLicense.js';
+
+const license = '-----BEGIN RSTUDIO LICENSE-----\nabc123\n-----END RSTUDIO LICENSE-----';
+const renewedLicense = license.replace('abc123', 'def456');
+
+describe('hashLicenseContents', () => {
+
+	it('hashes a license to a short hex digest', () => {
+		// Pinned rather than pattern-matched: Posit hashes the licenses it issued the same
+		// way and joins on the result, so the algorithm, the truncation, and the encoding
+		// are all part of the contract. A different digest or a different slice would still
+		// look like a hash while silently breaking that join.
+		expect(hashLicenseContents(license)).toBe('c12b6949758226a4');
+	});
+
+	it('ignores surrounding whitespace so the same license always hashes the same', () => {
+		// A license file can gain or lose a trailing newline in transit; a deployment must
+		// not look like a different license because of it.
+		expect([
+			hashLicenseContents(`${license}\n`),
+			hashLicenseContents(`\n\n${license}\n  \n`),
+		]).toEqual(['c12b6949758226a4', 'c12b6949758226a4']);
+	});
+
+	it('gives different licenses different hashes', () => {
+		expect(hashLicenseContents(renewedLicense)).not.toBe(hashLicenseContents(license));
+	});
+});
+
+describe('licenseFileHash', () => {
+	let dir: string;
+
+	beforeEach(() => {
+		dir = fs.mkdtempSync(path.join(os.tmpdir(), 'positron-license-'));
+	});
+
+	afterEach(() => {
+		fs.rmSync(dir, { recursive: true, force: true });
+	});
+
+	/** Writes a file into the license-manager directory and returns its path. */
+	function writeInDir(name: string, contents: string): string {
+		const filePath = path.join(dir, name);
+		fs.writeFileSync(filePath, contents);
+		return filePath;
+	}
+
+	it('hashes the reported license file in preference to the one in the directory', () => {
+		// The binary names the license it actually verified; the directory scan is only a
+		// fallback, so a stale sibling .lic must not win.
+		writeInDir('stale.lic', license);
+		const reported = writeInDir('verified.txt', renewedLicense);
+		expect(licenseFileHash(dir, reported)).toBe(hashLicenseContents(renewedLicense));
+	});
+
+	it('falls back to the .lic in the directory when the binary reports no path', () => {
+		writeInDir('license.lic', license);
+		expect(licenseFileHash(dir)).toBe('c12b6949758226a4');
+	});
+
+	it('falls back to the .lic in the directory when the reported path is gone', () => {
+		writeInDir('license.lic', license);
+		expect(licenseFileHash(dir, path.join(dir, 'does-not-exist.lic'))).toBe('c12b6949758226a4');
+	});
+
+	it('skips an empty reported file and falls back to the license in the directory', () => {
+		writeInDir('license.lic', license);
+		const reported = writeInDir('truncated.txt', '');
+		expect(licenseFileHash(dir, reported)).toBe('c12b6949758226a4');
+	});
+
+	it('reports nothing rather than the hash of an empty license file', () => {
+		// A truncated or placeholder .lic hashes to a perfectly well-formed value that
+		// identifies no license, and every deployment with one would report that same
+		// value. A collapsed group in Posit's per-license counts is worse than a missing
+		// one, so this fails closed.
+		writeInDir('placeholder.lic', '   \n\n  ');
+		expect(licenseFileHash(dir)).toBeUndefined();
+	});
+
+	it('ignores a relative reported path instead of resolving it against the process cwd', () => {
+		// A relative path from the license-manager binary resolves against the server
+		// process's working directory, not the binary's, so it can name some entirely
+		// unrelated file. `package.json` stands in for one: it exists in the working
+		// directory, and accepting the relative path would report a hash of it as this
+		// deployment's license. `dir` holds no .lic, so the only way to get a hash here is
+		// the bug.
+		expect(fs.existsSync(path.join(process.cwd(), 'package.json'))).toBe(true);
+		expect(licenseFileHash(dir, 'package.json')).toBeUndefined();
+	});
+
+	it('returns undefined rather than throwing when there is nothing to hash', () => {
+		// The hash is telemetry. An unreadable directory or a missing license file must
+		// leave a legitimately licensed deployment licensed, so this reports nothing
+		// instead of letting an exception escape the license check.
+		expect([
+			licenseFileHash(dir),
+			licenseFileHash(path.join(dir, 'no-such-dir')),
+			licenseFileHash(path.join(dir, 'no-such-dir'), path.join(dir, 'no-such-file.lic')),
+		]).toEqual([undefined, undefined, undefined]);
+	});
+});

--- a/src/vs/server/test/node/remoteLicenseKey.vitest.ts
+++ b/src/vs/server/test/node/remoteLicenseKey.vitest.ts
@@ -117,15 +117,17 @@ describe('validateLicense', () => {
 		expect(result.valid).toBe(false);
 	});
 
-	it('marks a signed token not academic', async () => {
+	it('marks a signed token not academic and gives it no license hash', async () => {
+		// A signed token is minted per connection, so hashing it would identify the
+		// connection rather than a license Posit issued.
 		const token = 'test-token-not-academic';
 		const timestamp = new Date().toISOString();
 		const license = mintLicense(token, 'Test Hub', 'Test Corp', timestamp);
 
 		const result = await validateLicense(token, license, [testPubKeyPem]);
 
-		expect(result.valid).toBe(true);
-		expect(result.academic).toBe(false);
+		expect({ valid: result.valid, academic: result.academic, licenseHash: result.licenseHash })
+			.toEqual({ valid: true, academic: false, licenseHash: undefined });
 	});
 
 	it('rejects malformed JSON', async () => {
@@ -170,15 +172,20 @@ describe('validateLicenseFile', () => {
 		return licPath;
 	}
 
-	it('marks a raw license file academic when the license manager verifies it', async () => {
-		const licPath = writeTempLicense('-----BEGIN RSTUDIO LICENSE-----\nabc123\n-----END RSTUDIO LICENSE-----\n');
-		try {
-			const result = await validateLicenseFile('any-token', licPath, async () => ({ valid: true, licensee: 'Acme University' }));
-			expect(result).toEqual({ valid: true, licensee: 'Acme University', academic: true });
-		} finally {
-			fs.unlinkSync(licPath);
-		}
-	});
+	// The hash is computed where the verified file lives (localLicense.ts), so this path
+	// only has to mark the deployment academic and pass the hash through untouched,
+	// whether the license manager reported one or not.
+	it.each([undefined, 'a1b2c3d4e5f60718'])(
+		'marks a verified raw license file academic, carrying licenseHash %s',
+		async licenseHash => {
+			const licPath = writeTempLicense('-----BEGIN RSTUDIO LICENSE-----\nabc123\n-----END RSTUDIO LICENSE-----\n');
+			try {
+				const result = await validateLicenseFile('any-token', licPath, async () => ({ valid: true, licensee: 'Acme University', licenseHash }));
+				expect(result).toEqual({ valid: true, licensee: 'Acme University', academic: true, licenseHash });
+			} finally {
+				fs.unlinkSync(licPath);
+			}
+		});
 
 	it('does not mark a rejected raw license file academic', async () => {
 		const licPath = writeTempLicense('-----BEGIN RSTUDIO LICENSE-----\nabc123\n-----END RSTUDIO LICENSE-----\n');
@@ -258,12 +265,14 @@ describe('validateLicenseKey', () => {
 		}
 	});
 
-	it('marks a local .lic license academic', async () => {
-		await withCleanLicenseEnv(async () => {
-			const result = await validateLicenseKey('some-token', createServerArgs(), async () => ({ valid: true, licensee: 'Acme University' }));
-			expect(result).toEqual({ valid: true, licensee: 'Acme University', academic: true });
+	it.each([undefined, 'a1b2c3d4e5f60718'])(
+		'marks a local .lic license academic, carrying licenseHash %s',
+		async licenseHash => {
+			await withCleanLicenseEnv(async () => {
+				const result = await validateLicenseKey('some-token', createServerArgs(), async () => ({ valid: true, licensee: 'Acme University', licenseHash }));
+				expect(result).toEqual({ valid: true, licensee: 'Acme University', academic: true, licenseHash });
+			});
 		});
-	});
 
 	it('falls back to the local .lic when the provided license does not validate', async () => {
 		// A lingering jupyter-positron-verifier deployment injects a minted token

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -206,7 +206,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 			// --- Start Positron ---
 			'extensions.gallery.sendUsageData': {
 				type: 'boolean',
-				description: localize('positron.extensions.gallery.sendUsageData', "When enabled, sends Positron distribution type, version, and update-check trigger as query parameters on extension gallery requests. No user-identifying data is sent. Disable this to stop sending these parameters."),
+				description: localize('positron.extensions.gallery.sendUsageData', "When enabled, sends the Positron distribution type, version, update-check trigger, and whether the session runs under an academic license as query parameters on extension gallery requests. Sessions licensed with a license file also send a hash that identifies that license. No user-identifying data is sent. Disable this to stop sending these parameters."),
 				default: true,
 				scope: ConfigurationScope.APPLICATION,
 				tags: ['usesOnlineServices']

--- a/src/vs/workbench/services/positronLicense/browser/positronAcademicLicenseService.ts
+++ b/src/vs/workbench/services/positronLicense/browser/positronAcademicLicenseService.ts
@@ -4,17 +4,28 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
-import { IPositronAcademicLicenseService, POSITRON_IS_ACADEMIC_GLOBAL } from '../../../../platform/positronLicense/common/positronAcademicLicenseService.js';
+import { IPositronAcademicLicenseService, isLicenseHash, POSITRON_IS_ACADEMIC_GLOBAL, POSITRON_LICENSE_HASH_GLOBAL } from '../../../../platform/positronLicense/common/positronAcademicLicenseService.js';
 
 /**
- * The implementation of `IPositronAcademicLicenseService` for the browser. Reads the global
- * that `webClientServer.ts` injects into the served HTML when the server's own license
- * validation found the session academic. The injected script runs before any module loads,
- * so the global is already set (or absent, meaning not academic) by construction time.
+ * Reads the injected license hash, ignoring a global that does not hold one. This side does
+ * the checking that matters: the value read here is what ends up on outgoing P3M gallery
+ * URLs, so it is validated rather than trusted because the server validated it on the way in.
+ */
+function licenseHashFromGlobal(): string | undefined {
+	const value = (globalThis as Record<string, unknown>)[POSITRON_LICENSE_HASH_GLOBAL];
+	return isLicenseHash(value) ? value : undefined;
+}
+
+/**
+ * The implementation of `IPositronAcademicLicenseService` for the browser. Reads the globals
+ * that `webClientServer.ts` injects into the served HTML from the server's own license
+ * validation. The injected script runs before any module loads, so the globals are already
+ * set (or absent, meaning not academic and no license file) by construction time.
  */
 export class BrowserPositronAcademicLicenseService implements IPositronAcademicLicenseService {
 	declare readonly _serviceBrand: undefined;
 	readonly isAcademic = (globalThis as Record<string, unknown>)[POSITRON_IS_ACADEMIC_GLOBAL] === true;
+	readonly licenseHash = licenseHashFromGlobal();
 }
 
 registerSingleton(IPositronAcademicLicenseService, BrowserPositronAcademicLicenseService, InstantiationType.Delayed);

--- a/src/vs/workbench/services/positronLicense/electron-browser/positronAcademicLicenseService.ts
+++ b/src/vs/workbench/services/positronLicense/electron-browser/positronAcademicLicenseService.ts
@@ -9,11 +9,13 @@ import { IPositronAcademicLicenseService } from '../../../../platform/positronLi
 /**
  * The implementation of `IPositronAcademicLicenseService` for the Electron desktop app.
  * Desktop installs never go through a license check (see `hasWebUi` in
- * `remoteExtensionHostAgentServer.ts`), so this is always false.
+ * `remoteExtensionHostAgentServer.ts`), so there is no academic status and no license file
+ * to hash.
  */
 export class ElectronPositronAcademicLicenseService implements IPositronAcademicLicenseService {
 	declare readonly _serviceBrand: undefined;
 	readonly isAcademic = false;
+	readonly licenseHash = undefined;
 }
 
 registerSingleton(IPositronAcademicLicenseService, ElectronPositronAcademicLicenseService, InstantiationType.Delayed);

--- a/src/vs/workbench/services/positronLicense/test/browser/positronAcademicLicenseService.vitest.ts
+++ b/src/vs/workbench/services/positronLicense/test/browser/positronAcademicLicenseService.vitest.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { POSITRON_LICENSE_HASH_GLOBAL } from '../../../../../platform/positronLicense/common/positronAcademicLicenseService.js';
+import { BrowserPositronAcademicLicenseService } from '../../browser/positronAcademicLicenseService.js';
+
+describe('BrowserPositronAcademicLicenseService', () => {
+	const globals = globalThis as Record<string, unknown>;
+
+	afterEach(() => {
+		delete globals[POSITRON_LICENSE_HASH_GLOBAL];
+	});
+
+	it('reports the license hash the server injected', () => {
+		globals[POSITRON_LICENSE_HASH_GLOBAL] = 'a1b2c3d4e5f60718';
+		expect(new BrowserPositronAcademicLicenseService().licenseHash).toBe('a1b2c3d4e5f60718');
+	});
+
+	it('reports no hash when the server injected none', () => {
+		expect(new BrowserPositronAcademicLicenseService().licenseHash).toBeUndefined();
+	});
+
+	it.each([true, 42, {}, '', 'not-a-hash', 'A1B2C3D4E5F60718', `x';alert(1);//`])(
+		'reports no hash when the global holds %j instead of one',
+		value => {
+			// The global is page-level state, so it can hold anything by the time this runs,
+			// and this side is what puts the value on outgoing gallery URLs. Anything that is
+			// not a hash we produced must read as "no license hash".
+			globals[POSITRON_LICENSE_HASH_GLOBAL] = value;
+			expect(new BrowserPositronAcademicLicenseService().licenseHash).toBeUndefined();
+		});
+});


### PR DESCRIPTION
Fixes posit-dev/positron-builds#1207

This PR adds a `positron-license-hash` query parameter to the params Positron already sends to P3M on extension gallery requests. The hash is SHA-256 over the trimmed contents of the verified `.lic` file, hex-encoded and truncated to 16 characters. Only the license-file path produces a hash. A Posit Workbench token is minted per connection, so a hash of it would identify the connection and not a license. AWS License Manager exposes no key material. Desktop does no license check. The parameter is absent in all three cases.

The existing `extensions.gallery.sendUsageData` opt-out and `p3m.dev` host gate also apply to the new parameter. There is no new setting.

The hash identifies a deployment; it does not identify a user. It is visible in the served HTML and in P3M query strings, and it has no meaning without license records on our side. #13738 promised no new user-correlatable data on gallery requests, and this change keeps that promise. The `extensions.gallery.sendUsageData` description now names all of the params, including `positron-is-academic`, which it did not name before.

### Test coverage

76 Vitest tests in five files. Two files are new: `localLicense.vitest.ts` for the hash and the choice of file to hash, and `positronLicense/test/browser/positronAcademicLicenseService.vitest.ts` for the read side of the injected global.

There is no e2e coverage, as none is possible currently. The parameter only appears on a licensed Positron Server deployment, where the bundled `license-manager` binary verifies a real `.lic` file.

### Validation Steps

@:extensions @:web

The tags cover the blast radius rather than the new parameter. Both P3M chokepoints in `extensionGalleryService.ts` changed, and the served HTML and its CSP hash list changed.

To check the new parameter, you need a licensed Positron Server:

1. Place a `.lic` file at `/opt/positron-server/resources/activation/linux/<arch>/license.lic` and start a session.
2. View the page source. Confirm that `_POSITRON_LICENSE_HASH` holds 16 hexadecimal characters.
3. Open the network panel and start an extension update check. Confirm that requests to `p3m.dev` carry `positron-license-hash` with that same value.
4. Set `extensions.gallery.sendUsageData` to `false`. Confirm that the parameter is gone, together with the other Positron params.
5. Point the gallery at Open VSX. Confirm that no Positron params are added.

On desktop there is nothing to check. Desktop does no license check, so it sends no hash.
