### PR TITLE
server: mark if launched in sagemaker

### DIFF
--- a/src/vs/platform/extensionManagement/common/positronGalleryTelemetry.ts
+++ b/src/vs/platform/extensionManagement/common/positronGalleryTelemetry.ts
@@ -27,12 +27,13 @@ export type PositronCheckTrigger =
 
 /** Which Positron distribution / process the request is coming from. */
 export type PositronSessionType =
-	| 'desktop'           // Electron app (user's local machine).
-	| 'workbench'         // PWB-hosted Positron, browser tab side.
-	| 'workbench-server'  // PWB-hosted Positron, Node backend (RS_SERVER_URL set).
-	| 'positron-server'   // Positron Server such as JupyterHub, browser tab side.
-	| 'positron-sagemaker'  // Positron Server on Amazon SageMaker, browser tab and Node backend.
-	| 'remote-server';    // Non-PWB Node backend: JupyterHub, remote SSH / WSL / dev container backend.
+	| 'desktop'                    // Electron app (user's local machine).
+	| 'workbench'                  // PWB-hosted Positron, browser tab side.
+	| 'workbench-server'           // PWB-hosted Positron, Node backend (RS_SERVER_URL set).
+	| 'positron-server'            // Positron Server such as JupyterHub, browser tab side.
+	| 'positron-sagemaker'         // Positron Server on Amazon SageMaker, browser tab side.
+	| 'positron-sagemaker-server'  // Positron Server on Amazon SageMaker, Node backend.
+	| 'remote-server';             // Non-PWB Node backend: JupyterHub, remote SSH / WSL / dev container backend.
 
 /**
  * Detects which Positron process is making the gallery request.
@@ -41,16 +42,16 @@ export type PositronSessionType =
  * process; both can independently hit the gallery, and we tag them separately so P3M
  * can correlate or count them as needed.
  *
- * SageMaker is the exception to that split: both sides report `positron-sagemaker`, so the
- * deployment counts as one thing instead of landing in the generic `positron-server` and
- * `remote-server` buckets. See {@link isSageMakerSession} for where the signal comes from.
+ * SageMaker splits the same way, rather than landing in the generic `positron-server` and
+ * `remote-server` buckets. Counting the server side alone counts deployments; counting both
+ * counts traffic. See {@link isSageMakerSession} for where the signal comes from.
  */
 export function getPositronSessionType(): PositronSessionType {
 	if (isWorkbench) {
 		return isWeb ? 'workbench' : 'workbench-server';
 	}
 	if (isSageMakerSession()) {
-		return 'positron-sagemaker';
+		return isWeb ? 'positron-sagemaker' : 'positron-sagemaker-server';
 	}
 	if (isWeb) {
 		return 'positron-server';

--- a/src/vs/platform/extensionManagement/common/positronGalleryTelemetry.ts
+++ b/src/vs/platform/extensionManagement/common/positronGalleryTelemetry.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { isElectron, isWeb, isWorkbench } from '../../../base/common/platform.js';
+import { isSageMakerSession } from '../../positronLicense/common/positronSageMakerSession.js';
 
 /**
  * Setting key for opting out of P3M gallery telemetry. Boolean; defaults to true.
@@ -30,6 +31,7 @@ export type PositronSessionType =
 	| 'workbench'         // PWB-hosted Positron, browser tab side.
 	| 'workbench-server'  // PWB-hosted Positron, Node backend (RS_SERVER_URL set).
 	| 'positron-server'   // Positron Server such as JupyterHub, browser tab side.
+	| 'positron-sagemaker'  // Positron Server on Amazon SageMaker, browser tab and Node backend.
 	| 'remote-server';    // Non-PWB Node backend: JupyterHub, remote SSH / WSL / dev container backend.
 
 /**
@@ -39,10 +41,16 @@ export type PositronSessionType =
  * process; both can independently hit the gallery, and we tag them separately so P3M
  * can correlate or count them as needed.
  *
+ * SageMaker is the exception to that split: both sides report `positron-sagemaker`, so the
+ * deployment counts as one thing instead of landing in the generic `positron-server` and
+ * `remote-server` buckets. See {@link isSageMakerSession} for where the signal comes from.
  */
 export function getPositronSessionType(): PositronSessionType {
 	if (isWorkbench) {
 		return isWeb ? 'workbench' : 'workbench-server';
+	}
+	if (isSageMakerSession()) {
+		return 'positron-sagemaker';
 	}
 	if (isWeb) {
 		return 'positron-server';

--- a/src/vs/platform/extensionManagement/test/common/positronGalleryTelemetry.vitest.ts
+++ b/src/vs/platform/extensionManagement/test/common/positronGalleryTelemetry.vitest.ts
@@ -42,7 +42,7 @@ describe('positronGalleryTelemetry', function () {
 		});
 
 		it('emits every session-type value without alteration', () => {
-			for (const sessionType of ['desktop', 'workbench', 'workbench-server', 'positron-server', 'remote-server'] as const) {
+			for (const sessionType of ['desktop', 'workbench', 'workbench-server', 'positron-server', 'positron-sagemaker', 'remote-server'] as const) {
 				const result = appendPositronGalleryParams(baseUrl, undefined, sessionType, '2026.06.0', true, true);
 				expect(result).toContain(`positron-session-type=${sessionType}`);
 			}

--- a/src/vs/platform/extensionManagement/test/common/positronGalleryTelemetry.vitest.ts
+++ b/src/vs/platform/extensionManagement/test/common/positronGalleryTelemetry.vitest.ts
@@ -89,7 +89,7 @@ describe('positronGalleryTelemetry', function () {
 		});
 
 		it('emits every session-type value without alteration', () => {
-			for (const sessionType of ['desktop', 'workbench', 'workbench-server', 'positron-server', 'positron-sagemaker', 'remote-server'] as const) {
+			for (const sessionType of ['desktop', 'workbench', 'workbench-server', 'positron-server', 'positron-sagemaker', 'positron-sagemaker-server', 'remote-server'] as const) {
 				const result = appendPositronGalleryParams(baseUrl, undefined, sessionType, '2026.06.0', true, true);
 				expect(result).toContain(`positron-session-type=${sessionType}`);
 			}
@@ -173,11 +173,11 @@ describe('positronGalleryTelemetry', function () {
 			expect(await loadSessionType({ platform: { isWeb: true } })).toBe('positron-server');
 		});
 
-		it('reports a SageMaker-licensed Node backend as positron-sagemaker', async () => {
-			expect(await loadSessionType({ sageMaker: true })).toBe('positron-sagemaker');
+		it('reports a SageMaker-licensed Node backend as positron-sagemaker-server', async () => {
+			expect(await loadSessionType({ sageMaker: true })).toBe('positron-sagemaker-server');
 		});
 
-		it('reports a SageMaker browser tab as positron-sagemaker too', async () => {
+		it('reports a SageMaker browser tab as positron-sagemaker', async () => {
 			const globals = globalThis as Record<string, unknown>;
 			globals['_POSITRON_IS_SAGEMAKER'] = true;
 			try {

--- a/src/vs/platform/extensionManagement/test/common/positronGalleryTelemetry.vitest.ts
+++ b/src/vs/platform/extensionManagement/test/common/positronGalleryTelemetry.vitest.ts
@@ -7,6 +7,53 @@
 
 import { appendPositronGalleryParams, formatPositronVersion, isP3MGalleryUrl } from '../../common/positronGalleryTelemetry.js';
 
+/** Path to the platform module as resolved from this test file. */
+const PLATFORM_MODULE = '../../../../base/common/platform.js';
+type PlatformModule = typeof import('../../../../base/common/platform.js');
+
+/**
+ * Resolves the session type under a given deployment shape. The platform flags and the SageMaker
+ * flag are all captured when their modules first load, so each case re-imports rather than
+ * mutating modules already in memory. `workbench` goes through the real `RS_SERVER_URL`
+ * derivation; `platform` overrides the flags Node cannot produce on its own.
+ */
+async function loadSessionType(options: {
+	workbench?: boolean;
+	sageMaker?: boolean;
+	platform?: Partial<PlatformModule>;
+} = {}): Promise<string> {
+	const previousServerUrl = process.env.RS_SERVER_URL;
+	if (options.workbench) {
+		process.env.RS_SERVER_URL = 'https://workbench.example.com';
+	} else {
+		delete process.env.RS_SERVER_URL;
+	}
+	try {
+		vi.resetModules();
+		vi.doUnmock(PLATFORM_MODULE);
+		const overrides = options.platform;
+		if (overrides) {
+			// Spread the real module so only the named flags change; a bare object would turn
+			// every other export into `undefined`.
+			vi.doMock(PLATFORM_MODULE, async importOriginal => ({
+				...await importOriginal<PlatformModule>(),
+				...overrides,
+			}));
+		}
+		if (options.sageMaker) {
+			const session = await import('../../../positronLicense/common/positronSageMakerSession.js');
+			session.markSageMakerSession();
+		}
+		const { getPositronSessionType } = await import('../../common/positronGalleryTelemetry.js');
+		return getPositronSessionType();
+	} finally {
+		if (previousServerUrl === undefined) {
+			delete process.env.RS_SERVER_URL;
+		} else {
+			process.env.RS_SERVER_URL = previousServerUrl;
+		}
+	}
+}
 describe('positronGalleryTelemetry', function () {
 	describe('formatPositronVersion', function () {
 		it('appends build number when greater than zero', () => {
@@ -110,6 +157,38 @@ describe('positronGalleryTelemetry', function () {
 		it('returns false for malformed URLs', () => {
 			expect(isP3MGalleryUrl('not a url')).toBe(false);
 			expect(isP3MGalleryUrl('')).toBe(false);
+		});
+	});
+
+	describe('getPositronSessionType', function () {
+		it('reports a desktop build as desktop', async () => {
+			expect(await loadSessionType({ platform: { isElectron: true } })).toBe('desktop');
+		});
+
+		it('reports an unmarked Node backend as remote-server', async () => {
+			expect(await loadSessionType()).toBe('remote-server');
+		});
+
+		it('reports an unmarked browser tab as positron-server', async () => {
+			expect(await loadSessionType({ platform: { isWeb: true } })).toBe('positron-server');
+		});
+
+		it('reports a SageMaker-licensed Node backend as positron-sagemaker', async () => {
+			expect(await loadSessionType({ sageMaker: true })).toBe('positron-sagemaker');
+		});
+
+		it('reports a SageMaker browser tab as positron-sagemaker too', async () => {
+			const globals = globalThis as Record<string, unknown>;
+			globals['_POSITRON_IS_SAGEMAKER'] = true;
+			try {
+				expect(await loadSessionType({ platform: { isWeb: true } })).toBe('positron-sagemaker');
+			} finally {
+				delete globals['_POSITRON_IS_SAGEMAKER'];
+			}
+		});
+
+		it('prefers the Workbench label over SageMaker', async () => {
+			expect(await loadSessionType({ workbench: true, sageMaker: true })).toBe('workbench-server');
 		});
 	});
 });

--- a/src/vs/platform/positronLicense/common/positronSageMakerSession.ts
+++ b/src/vs/platform/positronLicense/common/positronSageMakerSession.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { isWeb } from '../../../base/common/platform.js';
+
+/** Name of the injected global that marks a browser session SageMaker-hosted. */
+export const POSITRON_IS_SAGEMAKER_GLOBAL = '_POSITRON_IS_SAGEMAKER';
+
+let sageMakerSession = false;
+
+/**
+ * Records a `sagemaker` license kind. Called from server startup once the license validates,
+ * before any request is served.
+ */
+export function markSageMakerSession(): void {
+	sageMakerSession = true;
+}
+
+/**
+ * Whether this Positron deployment is hosted on Amazon SageMaker.
+ *
+ * Node/server: set by {@link markSageMakerSession}. Browser: read from the global injected by
+ * `webClientServer.ts`. Desktop: always false, since desktop skips the license check.
+ */
+export function isSageMakerSession(): boolean {
+	return isWeb
+		? (globalThis as Record<string, unknown>)[POSITRON_IS_SAGEMAKER_GLOBAL] === true
+		: sageMakerSession;
+}
+
+/**
+ * Builds the inline `<script>` that carries {@link isSageMakerSession} to the browser, for
+ * injection into the served workbench HTML. Empty when false: an absent global reads as false.
+ */
+export function sageMakerMarkerScript(isSageMaker: boolean): string {
+	return isSageMaker ? `<script>globalThis.${POSITRON_IS_SAGEMAKER_GLOBAL} = true;</script>` : '';
+}

--- a/src/vs/platform/positronLicense/test/common/positronSageMakerSession.vitest.ts
+++ b/src/vs/platform/positronLicense/test/common/positronSageMakerSession.vitest.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { isSageMakerSession, markSageMakerSession, sageMakerMarkerScript } from '../../common/positronSageMakerSession.js';
+
+describe('positronSageMakerSession', () => {
+	describe('sageMakerMarkerScript', () => {
+		it('emits the marker script for a SageMaker session', () => {
+			expect(sageMakerMarkerScript(true)).toBe('<script>globalThis._POSITRON_IS_SAGEMAKER = true;</script>');
+		});
+
+		it('emits nothing for a session that is not SageMaker', () => {
+			expect(sageMakerMarkerScript(false)).toBe('');
+		});
+	});
+
+	// Vitest runs with a Node `process`, so `platform.isWeb` is false here and this covers the
+	// server side. Marking is one-way, so the transition is asserted in a single test.
+	it('reports SageMaker only once the license manager has confirmed the lease', () => {
+		expect(isSageMakerSession()).toBe(false);
+		markSageMakerSession();
+		expect(isSageMakerSession()).toBe(true);
+	});
+});

--- a/src/vs/platform/positronLicense/test/common/positronSageMakerSession.vitest.ts
+++ b/src/vs/platform/positronLicense/test/common/positronSageMakerSession.vitest.ts
@@ -5,7 +5,28 @@
 
 /// <reference types="vitest/globals" />
 
-import { isSageMakerSession, markSageMakerSession, sageMakerMarkerScript } from '../../common/positronSageMakerSession.js';
+import { sageMakerMarkerScript } from '../../common/positronSageMakerSession.js';
+
+const PLATFORM_MODULE = '../../../../base/common/platform.js';
+type PlatformModule = typeof import('../../../../base/common/platform.js');
+
+/**
+ * Loads a fresh copy of the module, optionally as the browser build. Marking is one-way module
+ * state and `isWeb` is read at import time, so neither can be varied without re-importing.
+ */
+async function loadSession(options: { web?: boolean } = {}) {
+	vi.resetModules();
+	vi.doUnmock(PLATFORM_MODULE);
+	if (options.web) {
+		// Spread the real module so only `isWeb` changes; a bare object would turn every other
+		// export into `undefined`.
+		vi.doMock(PLATFORM_MODULE, async importOriginal => ({
+			...await importOriginal<PlatformModule>(),
+			isWeb: true,
+		}));
+	}
+	return import('../../common/positronSageMakerSession.js');
+}
 
 describe('positronSageMakerSession', () => {
 	describe('sageMakerMarkerScript', () => {
@@ -18,11 +39,31 @@ describe('positronSageMakerSession', () => {
 		});
 	});
 
-	// Vitest runs with a Node `process`, so `platform.isWeb` is false here and this covers the
-	// server side. Marking is one-way, so the transition is asserted in a single test.
-	it('reports SageMaker only once the license manager has confirmed the lease', () => {
+	// Marking is one-way, so the transition is asserted in a single test.
+	it('reports SageMaker on the server only once the license manager has confirmed the lease', async () => {
+		const { isSageMakerSession, markSageMakerSession } = await loadSession();
+
 		expect(isSageMakerSession()).toBe(false);
 		markSageMakerSession();
 		expect(isSageMakerSession()).toBe(true);
+	});
+
+	// The browser never runs the license check; it only sees the global that the marker script
+	// injected, so the two halves have to agree on the name.
+	it('reports SageMaker in the browser from the injected marker global', async () => {
+		const { isSageMakerSession, markSageMakerSession, POSITRON_IS_SAGEMAKER_GLOBAL } = await loadSession({ web: true });
+		const globals = globalThis as Record<string, unknown>;
+
+		try {
+			expect(isSageMakerSession()).toBe(false);
+			// Server-side marking must not leak into the browser's answer.
+			markSageMakerSession();
+			expect(isSageMakerSession()).toBe(false);
+
+			globals[POSITRON_IS_SAGEMAKER_GLOBAL] = true;
+			expect(isSageMakerSession()).toBe(true);
+		} finally {
+			delete globals[POSITRON_IS_SAGEMAKER_GLOBAL];
+		}
 	});
 });

--- a/src/vs/server/node/remoteExtensionHostAgentServer.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentServer.ts
@@ -44,6 +44,7 @@ const require = createRequire(import.meta.url);
 
 // --- Start Positron ---
 import { validateLicenseKey, ILicenseValidationResult, isRemoteLicenseManagerMode } from './remoteLicenseKey.js';
+import { markSageMakerSession } from '../../platform/positronLicense/common/positronSageMakerSession.js';
 import { createUnlicensedServer } from './positronUnlicensedServer.js';
 // eslint-disable-next-line no-duplicate-imports
 import { MandatoryServerConnectionToken } from './serverConnectionToken.js';
@@ -751,8 +752,13 @@ export async function createServer(address: string | net.AddressInfo | null, arg
 	const positronLicenseeInfo = licenseValidationResult?.valid ? {
 		licensee: licenseValidationResult.licensee,
 		issuer: licenseValidationResult.issuer,
-		academic: licenseValidationResult.academic === true,
+		academic: licenseValidationResult.kind === 'academic',
 	} : undefined;
+	// The gallery session type is read from module scope rather than injected, so the
+	// SageMaker kind is recorded here, before any service can serve a request.
+	if (licenseValidationResult?.kind === 'sagemaker') {
+		markSageMakerSession();
+	}
 	const { socketServer, instantiationService } = await setupServerServices(connectionToken, args, REMOTE_DATA_FOLDER, disposables, positronLicenseeInfo);
 	// --- End Positron ---
 

--- a/src/vs/server/node/remoteLicenseKey.ts
+++ b/src/vs/server/node/remoteLicenseKey.ts
@@ -12,6 +12,11 @@ import { FileAccess } from '../../base/common/network.js';
 import { LicenseManager } from './licenseManager.js';
 import { activateWithManager, verifyLocalLicense } from './localLicense.js';
 
+/** How a validated license was issued, where that matters downstream. */
+export type PositronLicenseKind =
+	| 'academic'    // Raw .lic file; grants the Education License Rider terms.
+	| 'sagemaker';  // AWS license manager lease, i.e. Positron Server on SageMaker.
+
 /**
  * The result of validating a license.
  */
@@ -23,14 +28,13 @@ export interface ILicenseValidationResult {
 	/** The issuer name, if validation was successful. */
 	issuer?: string;
 	/**
-	 * Whether this license grants Positron's Education License Rider terms (drives the
-	 * academic license banner and P3M telemetry). True for licenses validated from a raw
-	 * license file, which is every deployment that is neither Posit Workbench (signed
-	 * token, always false) nor the AWS license manager (left undefined, i.e. falsy).
-	 * Note for Positron Server Pro: this license miust carry its own signal,
-	 * or it will inherit `academic` as true
+	 * How this license was issued; drives the academic banner and the P3M session type.
+	 * The kinds are mutually exclusive, since each comes from a different branch of
+	 * {@link validateLicenseKey}. Undefined for signed Posit Workbench tokens and for
+	 * anything else with no signal, so a new license path must set its own kind rather
+	 * than inherit one.
 	 */
-	academic?: boolean;
+	kind?: PositronLicenseKind;
 }
 
 /**
@@ -160,7 +164,7 @@ export async function validateLicenseKey(connectionToken: string, args: ServerPa
 			} else {
 				console.log('Verified license from license-manager directory.');
 			}
-			return { ...localResult, academic: true };
+			return { ...localResult, kind: 'academic' };
 		}
 	} catch (e) {
 		localError = e;
@@ -214,10 +218,10 @@ export async function validateLicenseFile(connectionToken: string, licenseFile: 
 		} else if (trimmedContents.startsWith('-----BEGIN RSTUDIO LICENSE-----')) {
 			// A raw license file; activate and verify it with the license-manager
 			// binary. File-based licenses mark the deployment academic; see
-			// ILicenseValidationResult.academic.
+			// ILicenseValidationResult.kind.
 			const installPath = path.join(FileAccess.asFileUri('').fsPath, '..');
 			const result = await activate(installPath, licenseFile);
-			return result.valid ? { ...result, academic: true } : result;
+			return result.valid ? { ...result, kind: 'academic' } : result;
 		} else {
 			console.error('Unrecognized license file format. Expected a JSON license key or an RSA license file.');
 			return { valid: false };
@@ -310,9 +314,8 @@ export async function validateLicense(connectionToken: string, license: string, 
 		valid: true,
 		licensee: licenseKey.licensee,
 		issuer: licenseKey.issuer,
-		// Signed tokens are minted by Posit Workbench, which is never an academic
-		// deployment. Academic status comes from the raw-license-file paths.
-		academic: false,
+		// No kind: signed tokens are minted by Posit Workbench, which is neither academic
+		// nor SageMaker.
 	};
 }
 
@@ -388,5 +391,6 @@ async function validateWithLicenseManager(binaryPath: string): Promise<ILicenseV
 		return { valid: false };
 	}
 
-	return { valid: true };
+	// The lease verified under the AWS license manager's key, so this deployment is on SageMaker.
+	return { valid: true, kind: 'sagemaker' };
 }

--- a/src/vs/server/node/webClientServer.ts
+++ b/src/vs/server/node/webClientServer.ts
@@ -42,6 +42,7 @@ import type * as net from 'net';
 import { HAS_STATIC_ROUTE } from './pwbConstants.js';
 import { shouldUseSessionLessStaticRoute } from './positronStaticRoute.js';
 import { academicMarkerScript, IPositronAcademicLicenseService } from '../../platform/positronLicense/common/positronAcademicLicenseService.js';
+import { isSageMakerSession, sageMakerMarkerScript } from '../../platform/positronLicense/common/positronSageMakerSession.js';
 // --- End Positron ---
 
 const textMimeType: { [ext: string]: string | undefined } = {
@@ -691,6 +692,7 @@ export class WebClientServer {
 		// Same early-injection trick as the Workbench marker above, reusing the PWB_WORKBENCH_MARKER
 		// slot so no template changes are needed.
 		const academicMarker = academicMarkerScript(this._academicLicenseService.isAcademic);
+		const sageMakerMarker = sageMakerMarkerScript(isSageMakerSession());
 		// --- End Positron ---
 
 		const values: { [key: string]: string } = {
@@ -705,7 +707,7 @@ export class WebClientServer {
 			BASE: base,
 			VS_BASE: vscodeBase,
 			RS_LOGIN_CHECK_SCRIPT: rsLoginCheckScript,
-			PWB_WORKBENCH_MARKER: pwbWorkbenchMarker + academicMarker,
+			PWB_WORKBENCH_MARKER: pwbWorkbenchMarker + academicMarker + sageMakerMarker,
 			// --- End PWB ---
 		};
 

--- a/src/vs/server/test/node/remoteLicenseKey.vitest.ts
+++ b/src/vs/server/test/node/remoteLicenseKey.vitest.ts
@@ -125,7 +125,7 @@ describe('validateLicense', () => {
 		const result = await validateLicense(token, license, [testPubKeyPem]);
 
 		expect(result.valid).toBe(true);
-		expect(result.academic).toBe(false);
+		expect(result.kind).toBeUndefined();
 	});
 
 	it('rejects malformed JSON', async () => {
@@ -174,7 +174,7 @@ describe('validateLicenseFile', () => {
 		const licPath = writeTempLicense('-----BEGIN RSTUDIO LICENSE-----\nabc123\n-----END RSTUDIO LICENSE-----\n');
 		try {
 			const result = await validateLicenseFile('any-token', licPath, async () => ({ valid: true, licensee: 'Acme University' }));
-			expect(result).toEqual({ valid: true, licensee: 'Acme University', academic: true });
+			expect(result).toEqual({ valid: true, licensee: 'Acme University', kind: 'academic' });
 		} finally {
 			fs.unlinkSync(licPath);
 		}
@@ -261,7 +261,7 @@ describe('validateLicenseKey', () => {
 	it('marks a local .lic license academic', async () => {
 		await withCleanLicenseEnv(async () => {
 			const result = await validateLicenseKey('some-token', createServerArgs(), async () => ({ valid: true, licensee: 'Acme University' }));
-			expect(result).toEqual({ valid: true, licensee: 'Acme University', academic: true });
+			expect(result).toEqual({ valid: true, licensee: 'Acme University', kind: 'academic' });
 		});
 	});
 
@@ -278,7 +278,7 @@ describe('validateLicenseKey', () => {
 				signature: 'bm90LWEtcmVhbC1zaWduYXR1cmU=',
 			});
 			const result = await validateLicenseKey('some-token', createServerArgs(), async () => ({ valid: true, licensee: 'Acme University' }));
-			expect(result).toEqual({ valid: true, licensee: 'Acme University', academic: true });
+			expect(result).toEqual({ valid: true, licensee: 'Acme University', kind: 'academic' });
 		});
 	});
 


### PR DESCRIPTION
Fixes posit-dev/positron-builds#1205

### Summary

Adds `positron-sagemaker` and `positron-sagemaker-server` session types to the
P3M gallery params, so SageMaker deployments are identifiable instead of landing
in the generic `positron-server` and `remote-server` buckets.

Like every other deployment, SageMaker splits into a browser tab and a Node
backend that each hit the gallery independently, so the two sides are labelled
separately, matching the existing `workbench` / `workbench-server` pair. Counting
the server side alone counts deployments; counting both counts traffic. A single
shared label would have supported neither, since the number of browser tabs per
deployment is not fixed.

The issue floated two possible signals: the `SAGEMAKER_APP_TYPE` environment
variable, or the license manager. This uses the license manager, because it is the
one that cannot be wrong. Only a binary holding the SageMaker key can produce an activated lease; an environment variable
is set by whoever launches the process.

While adding the second signal, `ILicenseValidationResult.academic?: boolean`
became `kind?: 'academic' | 'sagemaker'`. The two are mutually exclusive by
construction -- each is a distinct early return from `validateLicenseKey` -- so a
second boolean would have made an impossible `{academic: true, sageMaker: true}`
state representable. Consumers still derive a boolean at the
existing boundary, so `positronLicenseeInfo`, the academic license banner, and the
remote-agent channel are untouched.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:extensions

This is server-side labeling behind a license check, so the meaningful coverage is
unit-level and included in the PR:

- `getPositronSessionType` now covers all seven labels, including both SageMaker sides.
- `positronSageMakerSession` covers the server flag
- `remoteLicenseKey` assertions migrated from `academic` to `kind`.

To check manually on a SageMaker deployment: confirm gallery requests carry
`positron-session-type=positron-sagemaker` from the browser tab and
`positron-session-type=positron-sagemaker-server` from the backend, and that the
academic license banner still does not appear.
