### PR TITLE
fix: blank HTML previews after the first on Firefox web

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -7,7 +7,7 @@
 	<!-- Start PWB: serve same origin -->
 	<!-- Start Positron -->
 	<meta http-equiv="Content-Security-Policy"
-		content="default-src 'none'; script-src 'sha256-qUITkH/ymeyLH2q9+oOB7y9UndRxtlJwBAzpZtu7daM=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
+		content="default-src 'none'; script-src 'sha256-yLVYoz0ixpoKBQ9WjOFkVt9foXu+rht9iFTOJyDGH6k=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
 
 	<!-- Disable pinch zooming -->
 	<meta name="viewport"
@@ -244,6 +244,13 @@
 				`;
 		}
 
+		// --- Start Positron ---
+		// Wait for the worker to take control; long enough to cover registration plus an
+		// update download. Matches resolveTimeout in service-worker.js, which bounds an
+		// analogous wait on an external event.
+		const controllerChangeTimeout = 30_000;
+		// --- End Positron ---
+
 		/** @type {Promise<void>} */
 		const workerReady = new Promise((resolve, reject) => {
 			if (disableServiceWorker) {
@@ -280,19 +287,33 @@
 						// First ever load
 						|| !navigator.serviceWorker.controller
 					) {
-						await new Promise(r => {
-							navigator.serviceWorker.addEventListener('controllerchange', r, { once: true });
+						// --- Start Positron ---
+						// Firefox leaves a new webview iframe uncontrolled even when this worker is
+						// active, so `controllerchange` never fires; claiming makes it fire. Not claimed
+						// while a worker is installing or waiting, so the incoming one takes over. The
+						// timeout turns any remaining hang into a fatal error instead of a blank webview.
+						//
+						// Upstream:
+						// await new Promise(r => {
+						// 	navigator.serviceWorker.addEventListener('controllerchange', r, { once: true });
+						// });
+						await new Promise((resolveControlled, rejectControlled) => {
+							let timeout;
+							const onControllerChange = () => {
+								clearTimeout(timeout);
+								resolveControlled();
+							};
+							navigator.serviceWorker.addEventListener('controllerchange', onControllerChange, { once: true });
+							timeout = setTimeout(() => {
+								navigator.serviceWorker.removeEventListener('controllerchange', onControllerChange);
+								rejectControlled(new Error(`Timed out after ${controllerChangeTimeout}ms waiting for the service worker to take control`));
+							}, controllerChangeTimeout);
 
-							// --- Start Positron ---
-							// Firefox leaves a new webview iframe uncontrolled even when this worker is
-							// active, so `controllerchange` never fires and this hangs; claiming makes it
-							// fire. Skipped while a worker is installing or waiting, which needs the wait
-							// above so the incoming worker takes over instead of the current one.
-							if (!registration.installing && !registration.waiting && registration.active) {
+							if (isFirefox && !registration.installing && !registration.waiting && registration.active) {
 								registration.active.postMessage({ channel: 'claim' });
 							}
-							// --- End Positron ---
 						});
+						// --- End Positron ---
 					}
 
 					return resolve();

--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -7,7 +7,7 @@
 	<!-- Start PWB: serve same origin -->
 	<!-- Start Positron -->
 	<meta http-equiv="Content-Security-Policy"
-		content="default-src 'none'; script-src 'sha256-mXmbGZWc7y57qzxx5u1Cv1JgPhGq1xeU/qZdSKeBwIo=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
+		content="default-src 'none'; script-src 'sha256-kd0dWBJejWJWmOVXjRQoKCQ8/87IiHZ4xfo+bzXc+jo=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
 
 	<!-- Disable pinch zooming -->
 	<meta name="viewport"
@@ -282,6 +282,21 @@
 					) {
 						await new Promise(r => {
 							navigator.serviceWorker.addEventListener('controllerchange', r, { once: true });
+
+							// --- Start Positron ---
+							// Firefox does not automatically make a newly created webview iframe a
+							// controlled client, even when this worker is already active. When that
+							// happens nothing is installing or waiting, so `controllerchange` would
+							// never fire and this promise would hang forever, leaving every webview
+							// after the first one permanently blank. Ask the active worker to claim
+							// this client so the event does fire. The listener is registered first so
+							// a claim that lands immediately cannot be missed.
+							if (navigator.serviceWorker.controller) {
+								r();
+							} else if (registration.active) {
+								registration.active.postMessage({ channel: 'claim' });
+							}
+							// --- End Positron ---
 						});
 					}
 

--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -245,9 +245,7 @@
 		}
 
 		// --- Start Positron ---
-		// Wait for the worker to take control; long enough to cover registration plus an
-		// update download. Matches resolveTimeout in service-worker.js, which bounds an
-		// analogous wait on an external event.
+		// Bounds the controllerchange wait below; matches resolveTimeout in service-worker.js.
 		const controllerChangeTimeout = 30_000;
 		// --- End Positron ---
 
@@ -288,10 +286,9 @@
 						|| !navigator.serviceWorker.controller
 					) {
 						// --- Start Positron ---
-						// Firefox leaves a new webview iframe uncontrolled even when this worker is
-						// active, so `controllerchange` never fires; claiming makes it fire. Not claimed
-						// while a worker is installing or waiting, so the incoming one takes over. The
-						// timeout turns any remaining hang into a fatal error instead of a blank webview.
+						// Firefox can leave this worker uncontrolled, so controllerchange never fires
+						// without a claim. Skipped during install/waiting so the incoming worker takes
+						// over instead.
 						//
 						// Upstream:
 						// await new Promise(r => {

--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -7,7 +7,7 @@
 	<!-- Start PWB: serve same origin -->
 	<!-- Start Positron -->
 	<meta http-equiv="Content-Security-Policy"
-		content="default-src 'none'; script-src 'sha256-0D+AFCMmo481MDo+WkbCgb0FjhJ3F6emhV9yH79LGfk=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
+		content="default-src 'none'; script-src 'sha256-qUITkH/ymeyLH2q9+oOB7y9UndRxtlJwBAzpZtu7daM=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
 
 	<!-- Disable pinch zooming -->
 	<meta name="viewport"
@@ -284,17 +284,10 @@
 							navigator.serviceWorker.addEventListener('controllerchange', r, { once: true });
 
 							// --- Start Positron ---
-							// Firefox does not automatically make a newly created webview iframe a
-							// controlled client, even when this worker is already active. When that
-							// happens there is no worker installing or waiting, so `controllerchange`
-							// would never fire and this promise would hang forever, leaving every
-							// webview after the first one permanently blank. Ask the active worker to
-							// claim this client so the event does fire.
-							//
-							// Only ask when no new worker is on its way in: if one is installing or
-							// waiting, the wait above is what lets it take over, and claiming with the
-							// current worker would pull a stale one in ahead of it. The listener is
-							// registered first so a claim that lands immediately cannot be missed.
+							// Firefox leaves a new webview iframe uncontrolled even when this worker is
+							// active, so `controllerchange` never fires and this hangs; claiming makes it
+							// fire. Skipped while a worker is installing or waiting, which needs the wait
+							// above so the incoming worker takes over instead of the current one.
 							if (!registration.installing && !registration.waiting && registration.active) {
 								registration.active.postMessage({ channel: 'claim' });
 							}

--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -7,7 +7,7 @@
 	<!-- Start PWB: serve same origin -->
 	<!-- Start Positron -->
 	<meta http-equiv="Content-Security-Policy"
-		content="default-src 'none'; script-src 'sha256-kd0dWBJejWJWmOVXjRQoKCQ8/87IiHZ4xfo+bzXc+jo=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
+		content="default-src 'none'; script-src 'sha256-0D+AFCMmo481MDo+WkbCgb0FjhJ3F6emhV9yH79LGfk=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
 
 	<!-- Disable pinch zooming -->
 	<meta name="viewport"
@@ -286,14 +286,16 @@
 							// --- Start Positron ---
 							// Firefox does not automatically make a newly created webview iframe a
 							// controlled client, even when this worker is already active. When that
-							// happens nothing is installing or waiting, so `controllerchange` would
-							// never fire and this promise would hang forever, leaving every webview
-							// after the first one permanently blank. Ask the active worker to claim
-							// this client so the event does fire. The listener is registered first so
-							// a claim that lands immediately cannot be missed.
-							if (navigator.serviceWorker.controller) {
-								r();
-							} else if (registration.active) {
+							// happens there is no worker installing or waiting, so `controllerchange`
+							// would never fire and this promise would hang forever, leaving every
+							// webview after the first one permanently blank. Ask the active worker to
+							// claim this client so the event does fire.
+							//
+							// Only ask when no new worker is on its way in: if one is installing or
+							// waiting, the wait above is what lets it take over, and claiming with the
+							// current worker would pull a stale one in ahead of it. The listener is
+							// registered first so a claim that lands immediately cannot be missed.
+							if (!registration.installing && !registration.waiting && registration.active) {
 								registration.active.postMessage({ channel: 'claim' });
 							}
 							// --- End Positron ---

--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -7,7 +7,7 @@
 	<!-- Start PWB: serve same origin -->
 	<!-- Start Positron -->
 	<meta http-equiv="Content-Security-Policy"
-		content="default-src 'none'; script-src 'sha256-yLVYoz0ixpoKBQ9WjOFkVt9foXu+rht9iFTOJyDGH6k=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
+		content="default-src 'none'; script-src 'sha256-IzTIF1v3cAXQ2y983YdUVlTW3E3GiRdhqkjlkh5Md5Q=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
 
 	<!-- Disable pinch zooming -->
 	<meta name="viewport"

--- a/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
@@ -261,12 +261,16 @@ sw.addEventListener('message', async (event) => {
 		// --- Start Positron ---
 		case 'claim': {
 			// Requested by pre/index.html when Firefox leaves a webview iframe uncontrolled.
-			try {
-				await sw.clients.claim();
-			} catch (e) {
-				// The client is blocked on `controllerchange`, so surface the failure.
-				console.error(`Failed to claim webview clients: ${e}`);
-			}
+			// waitUntil keeps this worker alive until the claim settles, matching the
+			// activate handler below, which claims the same way.
+			event.waitUntil((async () => {
+				try {
+					await sw.clients.claim();
+				} catch (e) {
+					// The client is blocked on `controllerchange`, so surface the failure.
+					console.error(`Failed to claim webview clients: ${e}`);
+				}
+			})());
 			return;
 		}
 		// --- End Positron ---

--- a/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
@@ -263,7 +263,14 @@ sw.addEventListener('message', async (event) => {
 			// See the matching comment in pre/index.html: Firefox can leave a newly
 			// created webview iframe uncontrolled even though this worker is already
 			// active, which would otherwise hang the webview's content update.
-			await sw.clients.claim();
+			try {
+				await sw.clients.claim();
+			} catch (e) {
+				// The client is waiting on `controllerchange` and has no other signal
+				// that the claim failed, so make the failure visible instead of letting
+				// it hang silently.
+				console.error(`Failed to claim webview clients: ${e}`);
+			}
 			return;
 		}
 		// --- End Positron ---

--- a/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
@@ -261,13 +261,10 @@ sw.addEventListener('message', async (event) => {
 		// --- Start Positron ---
 		case 'claim': {
 			// Requested by pre/index.html when Firefox leaves a webview iframe uncontrolled.
-			// waitUntil keeps this worker alive until the claim settles, matching the
-			// activate handler below, which claims the same way.
 			event.waitUntil((async () => {
 				try {
 					await sw.clients.claim();
 				} catch (e) {
-					// The client is blocked on `controllerchange`, so surface the failure.
 					console.error(`Failed to claim webview clients: ${e}`);
 				}
 			})());

--- a/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
@@ -260,15 +260,11 @@ sw.addEventListener('message', async (event) => {
 	switch (event.data.channel) {
 		// --- Start Positron ---
 		case 'claim': {
-			// See the matching comment in pre/index.html: Firefox can leave a newly
-			// created webview iframe uncontrolled even though this worker is already
-			// active, which would otherwise hang the webview's content update.
+			// Requested by pre/index.html when Firefox leaves a webview iframe uncontrolled.
 			try {
 				await sw.clients.claim();
 			} catch (e) {
-				// The client is waiting on `controllerchange` and has no other signal
-				// that the claim failed, so make the failure visible instead of letting
-				// it hang silently.
+				// The client is blocked on `controllerchange`, so surface the failure.
 				console.error(`Failed to claim webview clients: ${e}`);
 			}
 			return;

--- a/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
@@ -258,6 +258,15 @@ sw.addEventListener('message', async (event) => {
 	/** @type {Client} */
 	const source = event.source;
 	switch (event.data.channel) {
+		// --- Start Positron ---
+		case 'claim': {
+			// See the matching comment in pre/index.html: Firefox can leave a newly
+			// created webview iframe uncontrolled even though this worker is already
+			// active, which would otherwise hang the webview's content update.
+			await sw.clients.claim();
+			return;
+		}
+		// --- End Positron ---
 		case 'did-load-resource': {
 			/** @type {ResourceResponse} */
 			const response = event.data.data;


### PR DESCRIPTION
Fixes #15779

On Firefox, only the first HTML preview in the Viewer rendered; every later one was blank for the rest of the session.

Firefox does not automatically make a newly created webview iframe a controlled service worker client, even when the worker is already active. In that state nothing is installing or waiting, so the `controllerchange` event the webview host waits on never fires, `workerReady` never settles, and the content handler stops before it builds the content frame. The webview is created, mounted and marked ready, but its document stays empty and no request is ever made for the content URL.

The first webview in a window escapes this because the worker calls `clients.claim()` while activating. Everything created afterwards is left uncontrolled.

- Ask the active worker to claim the client when the page finds itself uncontrolled, which makes `controllerchange` fire
- Register the listener before sending the request so a claim that lands immediately can't be missed
- Add a `claim` message channel to the service worker
- Recompute the CSP `script-src` hash in `index.html`, which is hand-maintained and pins the inline script

This is in the shared webview host, so it affects every webview consumer on web, not just the viewer.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix HTML previews after the first one showing blank in the Viewer on Positron Web in Firefox (#15779)


### Validation Steps

@:viewer @:cross-browser @:web @:help @:plots

The regression test already exists and needs no changes: `Viewer > R - Verify Viewer displays reactable table output` failed 100% of Firefox runs (4/4) for 28 days before this. It was reported as flaky rather than failing only because the CI retry re-runs the test alone, where it becomes the first preview in the session and passes.

To check by hand in Positron Web on Firefox:

```r
vf <- function(t) {
  f <- tempfile(fileext = ".html")
  writeLines(paste0("<html><body><h1>", t, "</h1></body></html>"), f)
  getOption("viewer")(f)
}
vf("FIRST")
vf("SECOND")
```

Before, `SECOND` left the Viewer blank while the toolbar filename updated. Both should now render, along with any number of previews after them.


### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- Product bug, Firefox/web only: the SECOND HTML preview shown in the Positron Viewer pane never renders. The webview element is created, mounted and marked ready, and the wrapper HTML is delivered, but the webview document stays empty and its inner iframe never requests the proxied content URL.</summary>

- **Test:** [Viewer > R - Verify Viewer displays reactable table output](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Viewer%20%3E%20R%20-%20Verify%20Viewer%20displays%20reactable%20table%20output%7C%7C%7Ctest%2Fe2e%2Ftests%2Fviewer%2Fviewer.test.ts)
- **Targeted failure:** expect(locator).toBeVisible() failed for the viewer content locator; 60s toPass budget exhausted. Reported by the dashboard as 'flaky' at 100% of ubuntu/firefox runs (4/4) over 14 days.
- **Signal:** Local repro on --project e2e-firefox: whichever viewer test runs SECOND fails, regardless of content. modelsummary(1)=PASS, reactable(2)=FAIL, reprex(3)=PASS, repeated 3/3. reactable alone = PASS in 8s. reactable(1)=PASS, reprex(2)=FAIL. Same ordering on --project e2e-chromium = both PASS. Instrumented overlayWebview/webviewElement/positronPreviewService/previewContainer: pass and fail cases are byte-identical through content delivery (setHtml len=1392, _show creates element, doUpdateContent htmlLen=1392 state=Initializing, mountTo async-init disposed=false, WebviewElement READY). Nothing is disposed during the test. Frame dump at failure: pre/index.html has iframes=0, bodyLen=0 and there is no proxy content frame; trace.network contains zero requests to the proxy URL. Passing case has the nested #active-frame plus a content frame at localhost:PORT/proxy/<hash>/index.html.
- **Frequency:** 4/4 runs (100%) on main, ubuntu/firefox
- **Hypothesis:** On the Firefox web path, the second webview created in the pane completes its ready handshake but the flushed 'content' message is never applied to the webview document, so the inner iframe is never created and no proxy request is issued. The only observed structural difference is that the first preview gets a second claim()/_show() cycle (the pane moves x=0,y=0 -> x=901,y=99, re-running PreviewContainer's effect whose deps include props.x/props.y), while later previews inherit the final position and are claimed exactly once. Likely lead: the per-origin webview service-worker / MessagePort handshake binding to a stale client in Firefox. Not proven.
- **Supersedes:** Earlier hypotheses that the webview was destroyed by a console-panel-maximize relayout, and that OverlayWebview._isDisposed latched after an onWillStop dispose. Both falsified by instrumentation: no dispose occurs during the test and content is delivered identically in the passing and failing cases.

</details>
