### PR TITLE
feat(e2e): record forced-GC and ark version provenance on memory and perf metrics

### DIFF
--- a/test/e2e/tests/performance/memory-scenario.ts
+++ b/test/e2e/tests/performance/memory-scenario.ts
@@ -257,6 +257,13 @@ export function defineMemoryScenario(options: {
 			const versions = [...new Set(snapshots.map(s => s.positronVersion))];
 			expect(versions, 'launches measured different builds; the median would be meaningless').toHaveLength(1);
 
+			// Absent is legitimate (a build with no ark sidecar) and filtered out
+			// first, so only an actual mismatch across launches trips this. Without
+			// it, a mid-run ark reinstall would publish one launch's value for all
+			// three with nothing to say the run wasn't self-consistent.
+			const arkVersions = [...new Set(snapshots.map(s => s.arkVersion).filter((v): v is string => v !== undefined))];
+			expect(arkVersions.length, 'launches measured different ark versions; the run is not self-consistent').toBeLessThanOrEqual(1);
+
 			// A mixed set would render one heading over two app states.
 			const scenarios = [...new Set(snapshots.map(s => s.scenario))];
 			expect(scenarios, `snapshots span more than one scenario: ${scenarios.join(', ')}`).toEqual([scenario]);

--- a/test/e2e/utils/ark-version.ts
+++ b/test/e2e/utils/ark-version.ts
@@ -67,10 +67,18 @@ const ARK_SIDECARS = ['VERSION', 'SUBMODULE_COMMIT'] as const;
  * and by the time this is called a memory run has already measured everything --
  * failing here would cost the measurement to gain nothing.
  */
-export function readArkVersion(buildRoot: string = process.env.BUILD ?? ''): string | undefined {
-	// No build means a dev-mode run, which publishes to the local URL and is not
-	// in the dataset. Deliberately does not fall back to the repo checkout: the
-	// path would have to be guessed from __dirname, and a wrong guess is silent.
+export function readArkVersion(buildRoot: string = process.env.BUILD || process.cwd()): string | undefined {
+	// `BUILD` is only set on the memory lane plus two hardcoded remote lanes
+	// (test-memory-metrics.yml), but the performance client decides prod vs.
+	// local by branch, not by `BUILD` (api.ts) -- so the nightly full suite that
+	// produces every performance row has no `BUILD` and would never resolve an
+	// ark version without a further fallback. That fallback is the checkout
+	// itself: `process.cwd()` is this repo's own existing convention (see
+	// `ROOT_PATH` in fixtures/test-setup/constants.ts), not a guess derived from
+	// `__dirname`, and `arkResourceDirs`'s build-root candidate already resolves
+	// a plain dev checkout's layout with no changes needed here. An explicit
+	// empty string (as opposed to an omitted argument) still short-circuits
+	// below, since a default parameter only applies to `undefined`.
 	if (!buildRoot) {
 		return undefined;
 	}

--- a/test/e2e/utils/ark-version.ts
+++ b/test/e2e/utils/ark-version.ts
@@ -1,0 +1,100 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Which ark the build under test bundles, so a step on the dashboard's `kernel`
+ * band or on Performance Trends can be attributed to an ark bump rather than
+ * read as a regression. Ark is not captured anywhere in the dashboard today.
+ *
+ * Shared by both pipelines -- the memory payload and the performance client --
+ * rather than living under `memory/`, so the two cannot start reporting
+ * different ark versions for the same run.
+ *
+ * Read from the build's own files rather than from the running kernel.
+ * `runtimeInfo.build_version` (what `arkVersionCheck.ts` compares against) only
+ * exists inside the extension host and is unreachable from the harness, and
+ * asking the kernel would leave the scenarios that never start a session --
+ * `idle`, `data-explorer`, `editors` -- unable to report anything.
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Where positron-r keeps its ark sidecars inside an extracted build, most
+ * likely first.
+ *
+ * Mirrors `getVersionFromBuild` in `infra/test-runner/positron-version.ts`: the
+ * desktop packagings differ by platform, and a positron-server build keeps its
+ * app files at the root rather than under `resources/app`. A candidate list
+ * rather than a branch on the memory lane, because the question here is only
+ * where this build put its extensions.
+ */
+export function arkResourceDirs(buildRoot: string, platform: NodeJS.Platform = process.platform): string[] {
+	const extensionDir = join('extensions', 'positron-r', 'resources', 'ark');
+	const appDir = platform === 'darwin'
+		? join('Contents', 'Resources', 'app')
+		: join('resources', 'app');
+	return [join(buildRoot, appDir, extensionDir), join(buildRoot, extensionDir)];
+}
+
+/**
+ * The sidecars `extensions/positron-r/scripts/install-kernel.ts` writes beside
+ * the installed ark binary, in preference order. Both ship in the packaged
+ * extension: `.vscodeignore` excludes the `ark/**` submodule but not
+ * `resources/ark/**`.
+ *
+ * `VERSION` holds the resolved build version, `0.1.252+209.885fac4`, which is
+ * `${Cargo version}+${commits since the tag}.${short sha}` and the same string
+ * the running kernel reports as `runtimeInfo.build_version`.
+ *
+ * `SUBMODULE_COMMIT` holds the short sha alone, and is the fallback rather than
+ * the primary because of an asymmetry in how the two are written: `main()`
+ * writes the commit up front on every resolution path, while `VERSION` is
+ * written only after a prebuild download, so a locally built ark leaves the
+ * commit and no version.
+ */
+const ARK_SIDECARS = ['VERSION', 'SUBMODULE_COMMIT'] as const;
+
+/**
+ * The ark version this build bundles, or `undefined` when it cannot be
+ * determined.
+ *
+ * Never returns a placeholder and never throws. A literal `'unknown'` reaching
+ * the dashboard would draw an ark marker on a date where no release happened,
+ * and by the time this is called a memory run has already measured everything --
+ * failing here would cost the measurement to gain nothing.
+ */
+export function readArkVersion(buildRoot: string = process.env.BUILD ?? ''): string | undefined {
+	// No build means a dev-mode run, which publishes to the local URL and is not
+	// in the dataset. Deliberately does not fall back to the repo checkout: the
+	// path would have to be guessed from __dirname, and a wrong guess is silent.
+	if (!buildRoot) {
+		return undefined;
+	}
+
+	const dirs = arkResourceDirs(buildRoot);
+	for (const dir of dirs) {
+		for (const sidecar of ARK_SIDECARS) {
+			const path = join(dir, sidecar);
+			try {
+				if (!existsSync(path)) {
+					continue;
+				}
+				const value = readFileSync(path, 'utf8').trim();
+				if (value) {
+					return value;
+				}
+			} catch (error) {
+				console.log(`[ark] could not read ${path}: ${error}`);
+			}
+		}
+	}
+
+	// Logged, not swallowed. Absence is indistinguishable from a build layout
+	// this does not know about, and only the log can tell them apart.
+	console.log(`[ark] no ark version sidecar found under ${dirs.join(' or ')}; publishing without one`);
+	return undefined;
+}

--- a/test/e2e/utils/ark-version.vitest.ts
+++ b/test/e2e/utils/ark-version.vitest.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
@@ -101,13 +101,20 @@ describe('readArkVersion', () => {
 	// is this repo's own convention (see ROOT_PATH in fixtures/test-setup/constants.ts),
 	// not a derived guess, and it is exactly the build root arkResourceDirs already
 	// knows how to search.
+	//
+	// The temp fixture stands in for the checkout rather than reading the real
+	// one: `resources/ark` only holds a sidecar after install-kernel has run, and
+	// the unit lane never runs it, so asserting against the real file passes on a
+	// developer machine and throws ENOENT in CI.
 	test('falls back to the checkout when BUILD is unset and no argument is given', () => {
 		const previousBuild = process.env.BUILD;
 		delete process.env.BUILD;
+		writeFileSync(join(arkDir, 'VERSION'), '0.1.252+209.885fac4\n');
+		const cwd = vi.spyOn(process, 'cwd').mockReturnValue(buildRoot);
 		try {
-			expect(readArkVersion()).toBe(
-				readFileSync(join(process.cwd(), 'extensions', 'positron-r', 'resources', 'ark', 'VERSION'), 'utf8').trim());
+			expect(readArkVersion()).toBe('0.1.252+209.885fac4');
 		} finally {
+			cwd.mockRestore();
 			if (previousBuild === undefined) {
 				delete process.env.BUILD;
 			} else {

--- a/test/e2e/utils/ark-version.vitest.ts
+++ b/test/e2e/utils/ark-version.vitest.ts
@@ -1,0 +1,102 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { arkResourceDirs, readArkVersion } from './ark-version.js';
+
+describe('arkResourceDirs', () => {
+	test('looks under the macOS app bundle first on darwin', () => {
+		const [first] = arkResourceDirs('/build', 'darwin');
+		expect(first).toBe('/build/Contents/Resources/app/extensions/positron-r/resources/ark');
+	});
+
+	test('looks under resources/app first on linux and windows', () => {
+		const expected = '/build/resources/app/extensions/positron-r/resources/ark';
+		expect(arkResourceDirs('/build', 'linux')[0]).toBe(expected);
+		expect(arkResourceDirs('/build', 'win32')[0]).toBe(expected);
+	});
+
+	// A positron-server build keeps its app files at the root rather than under
+	// resources/app, exactly as getVersionFromBuild in positron-version.ts has to
+	// allow for. Candidates rather than a branch on the memory lane: the question
+	// is only where this build put its extensions.
+	test('falls back to the build root, so the server lane resolves too', () => {
+		for (const platform of ['darwin', 'linux', 'win32'] as const) {
+			expect(arkResourceDirs('/build', platform)).toContain(
+				'/build/extensions/positron-r/resources/ark');
+		}
+	});
+});
+
+describe('readArkVersion', () => {
+	let buildRoot: string;
+	let arkDir: string;
+
+	beforeEach(() => {
+		buildRoot = mkdtempSync(join(tmpdir(), 'ark-version-'));
+		// The server-layout candidate, which is in the list on every platform, so
+		// these cases do not depend on which OS runs them.
+		arkDir = join(buildRoot, 'extensions', 'positron-r', 'resources', 'ark');
+		mkdirSync(arkDir, { recursive: true });
+	});
+
+	afterEach(() => { rmSync(buildRoot, { recursive: true, force: true }); });
+
+	test('reads the resolved build version from the VERSION sidecar', () => {
+		writeFileSync(join(arkDir, 'VERSION'), '0.1.252+209.885fac4\n');
+		expect(readArkVersion(buildRoot)).toBe('0.1.252+209.885fac4');
+	});
+
+	// The whole build version, not the bare semver. The dashboard marks a change,
+	// and an ark bump that moves the distance and sha without touching Cargo.toml
+	// would be invisible if this trimmed at the '+'.
+	test('keeps the distance and short sha rather than trimming to the semver', () => {
+		writeFileSync(join(arkDir, 'VERSION'), '0.1.252+209.885fac4');
+		expect(readArkVersion(buildRoot)).toContain('+209.885fac4');
+	});
+
+	test('prefers VERSION over SUBMODULE_COMMIT when both are present', () => {
+		writeFileSync(join(arkDir, 'VERSION'), '0.1.252+209.885fac4');
+		writeFileSync(join(arkDir, 'SUBMODULE_COMMIT'), '5564f48');
+		expect(readArkVersion(buildRoot)).toBe('0.1.252+209.885fac4');
+	});
+
+	// install-kernel writes SUBMODULE_COMMIT on every resolution path but writes
+	// VERSION only after a prebuild download, so a locally built ark leaves the
+	// commit and no version.
+	test('falls back to SUBMODULE_COMMIT when VERSION was never written', () => {
+		writeFileSync(join(arkDir, 'SUBMODULE_COMMIT'), '5564f48\n');
+		expect(readArkVersion(buildRoot)).toBe('5564f48');
+	});
+
+	test('treats a whitespace-only sidecar as absent and keeps looking', () => {
+		writeFileSync(join(arkDir, 'VERSION'), '   \n');
+		writeFileSync(join(arkDir, 'SUBMODULE_COMMIT'), '5564f48');
+		expect(readArkVersion(buildRoot)).toBe('5564f48');
+	});
+
+	// Never a placeholder. 'unknown' reaching the dashboard would draw an ark
+	// marker on a date where no release happened.
+	test('returns undefined rather than a placeholder when no sidecar exists', () => {
+		vi.spyOn(console, 'log').mockImplementation(() => { });
+		expect(readArkVersion(buildRoot)).toBeUndefined();
+	});
+
+	test('returns undefined with no build root, rather than searching the repo', () => {
+		expect(readArkVersion('')).toBeUndefined();
+	});
+
+	// An unreadable sidecar must not take a memory run down with it: the run has
+	// already measured everything by the time this is called.
+	test('returns undefined rather than throwing when a sidecar cannot be read', () => {
+		vi.spyOn(console, 'log').mockImplementation(() => { });
+		// A directory where the file should be: exists, cannot be read as a file.
+		mkdirSync(join(arkDir, 'VERSION'));
+		expect(readArkVersion(buildRoot)).toBeUndefined();
+	});
+});

--- a/test/e2e/utils/ark-version.vitest.ts
+++ b/test/e2e/utils/ark-version.vitest.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
@@ -87,8 +87,33 @@ describe('readArkVersion', () => {
 		expect(readArkVersion(buildRoot)).toBeUndefined();
 	});
 
-	test('returns undefined with no build root, rather than searching the repo', () => {
+	// An explicit empty string is not the same as omitting the argument: a
+	// default parameter only kicks in for `undefined`, so this still returns
+	// undefined rather than falling back to the checkout.
+	test('returns undefined with an explicit empty build root, rather than searching the repo', () => {
 		expect(readArkVersion('')).toBeUndefined();
+	});
+
+	// The performance pipeline decides prod vs. local by branch, not by `BUILD`
+	// (api.ts), and `BUILD` is only set on the memory lane plus two hardcoded
+	// remote lanes -- so the nightly full suite that produces every performance
+	// row would never resolve an ark version without this fallback. `process.cwd()`
+	// is this repo's own convention (see ROOT_PATH in fixtures/test-setup/constants.ts),
+	// not a derived guess, and it is exactly the build root arkResourceDirs already
+	// knows how to search.
+	test('falls back to the checkout when BUILD is unset and no argument is given', () => {
+		const previousBuild = process.env.BUILD;
+		delete process.env.BUILD;
+		try {
+			expect(readArkVersion()).toBe(
+				readFileSync(join(process.cwd(), 'extensions', 'positron-r', 'resources', 'ark', 'VERSION'), 'utf8').trim());
+		} finally {
+			if (previousBuild === undefined) {
+				delete process.env.BUILD;
+			} else {
+				process.env.BUILD = previousBuild;
+			}
+		}
 	});
 
 	// An unreadable sidecar must not take a memory run down with it: the run has

--- a/test/e2e/utils/memory/publish.ts
+++ b/test/e2e/utils/memory/publish.ts
@@ -322,6 +322,10 @@ export function baselineToSnapshot(body: BaselineResponse, scenario: MemoryScena
 			// fall through every switch downstream.
 			processRole: isProcessRole(p.process_role) ? p.process_role : 'unlabeled',
 			labeled: true, cmdBasename: '',
+			// The response carries no such field and the report reads it for neither
+			// side of the delta, so this is neutral rather than a claim -- the same
+			// reasoning as `labeled: true` above.
+			forcedGc: false,
 			pssBytes: p.pss_bytes, rssBytes: 0, pssMin: p.pss_bytes, pssMax: p.pss_bytes,
 			// One sample, because the response carries one figure per process. That
 			// also keeps a baseline out of the unstable-process report: a single

--- a/test/e2e/utils/memory/publish.ts
+++ b/test/e2e/utils/memory/publish.ts
@@ -79,6 +79,16 @@ export type MemoryPayload = {
 	platform_os: string;
 	platform_version: string;
 	container_image: string;
+	/**
+	 * Which ark the build bundles, e.g. `0.1.252+209.885fac4`. Run-level, so it
+	 * sits here rather than on a launch or a process: it is sent once, and the
+	 * three launches of a POST are the same scenario against the same build.
+	 *
+	 * Optional, and omitted rather than sent as 'unknown', when the build shipped
+	 * no sidecar. The dashboard draws a marker where this value changes, so a
+	 * placeholder would draw an ark release that never happened.
+	 */
+	ark_version?: string;
 	scenario: MemoryScenario;
 	lane: MemoryLane;
 	launches: {
@@ -97,6 +107,8 @@ export type MemoryPayload = {
 			rss_bytes: number;
 			pss_min: number;
 			pss_max: number;
+			/** Whether this process was sampled after a forced GC. See gc.ts. */
+			forced_gc: boolean;
 		}[];
 		extensions: {
 			extension_id: string;
@@ -161,6 +173,12 @@ export function buildPayload(snapshots: MemorySnapshot[], meta: RunMeta): Memory
 	if (first === undefined) {
 		throw new Error('cannot build a memory payload from no snapshots');
 	}
+	// Run-level, so it is reduced here rather than sent per launch. The report
+	// test already asserts a single positronVersion across the three launches, so
+	// they are one build; the first launch that read a sidecar speaks for the run.
+	// Undefined stays undefined: JSON.stringify drops the key and the API reads a
+	// missing one as NA.
+	const arkVersion = snapshots.find(snapshot => snapshot.arkVersion !== undefined)?.arkVersion;
 	return {
 		payload_version: 1,
 		timestamp: new Date().toISOString(),
@@ -172,6 +190,7 @@ export function buildPayload(snapshots: MemorySnapshot[], meta: RunMeta): Memory
 		platform_os: platformOs,
 		platform_version: platformVersion,
 		container_image: meta.containerImage,
+		ark_version: arkVersion,
 		scenario: first.scenario,
 		lane: first.lane,
 		launches: snapshots.map(snapshot => ({
@@ -183,7 +202,8 @@ export function buildPayload(snapshots: MemorySnapshot[], meta: RunMeta): Memory
 				process_name: redactProcessName(p.processName), process_role: p.processRole,
 				labeled: p.labeled, cmd_basename: p.cmdBasename,
 				pss_bytes: p.pssBytes, rss_bytes: p.rssBytes,
-				pss_min: p.pssMin, pss_max: p.pssMax
+				pss_min: p.pssMin, pss_max: p.pssMax,
+				forced_gc: p.forcedGc
 			})),
 			extensions: snapshot.extensions.map(e => ({
 				extension_id: e.extensionId,

--- a/test/e2e/utils/memory/publish.vitest.ts
+++ b/test/e2e/utils/memory/publish.vitest.ts
@@ -25,7 +25,8 @@ const process1: LabeledProcess = {
 	pid: 100, ppid: 1, depth: 0,
 	processName: 'window [1] (secret-client-project)',
 	processRole: 'renderer', labeled: true, cmdBasename: 'positron',
-	pssBytes: 300, rssBytes: 600, pssMin: 290, pssMax: 310
+	pssBytes: 300, rssBytes: 600, pssMin: 290, pssMax: 310,
+	forcedGc: false
 };
 
 const snapshot: MemorySnapshot = {

--- a/test/e2e/utils/memory/publish.vitest.ts
+++ b/test/e2e/utils/memory/publish.vitest.ts
@@ -103,8 +103,54 @@ describe('buildPayload', () => {
 			pid: 100, ppid: 1, depth: 0,
 			process_name: 'window [1]', process_role: 'renderer',
 			labeled: true, cmd_basename: 'positron',
-			pss_bytes: 300, rss_bytes: 600, pss_min: 290, pss_max: 310
+			pss_bytes: 300, rss_bytes: 600, pss_min: 290, pss_max: 310,
+			forced_gc: false
 		});
+	});
+
+	// Two of fifteen bands on the dashboard's Memory by Process Role chart are
+	// post-GC figures and thirteen are live, and until now nothing on the wire
+	// distinguished them. Per process, so a band is self-describing.
+	test('carries the forced-GC state of each process', () => {
+		const collected: LabeledProcess = { ...process1, pid: 101, processRole: 'shared', forcedGc: true };
+		const [launch] = buildPayload([{ ...snapshot, processes: [process1, collected] }], meta).launches;
+		expect(launch.processes.map(p => [p.process_role, p.forced_gc])).toEqual([
+			['renderer', false], ['shared', true]
+		]);
+	});
+
+	// Run-level, at the payload root: it is one value per run, not per launch and
+	// not per process. The API reads it from the root and copies it onto the trend
+	// row without reducing it.
+	test('sends the ark version once, at the payload root', () => {
+		const payload = buildPayload([{ ...snapshot, arkVersion: '0.1.252+209.885fac4' }], meta);
+		expect(payload.ark_version).toBe('0.1.252+209.885fac4');
+	});
+
+	test('takes the ark version from the launches rather than re-reading it', () => {
+		const payload = buildPayload([
+			{ ...snapshot, launchIndex: 0, arkVersion: undefined },
+			{ ...snapshot, launchIndex: 1, arkVersion: '0.1.252+209.885fac4' }
+		], meta);
+		expect(payload.ark_version).toBe('0.1.252+209.885fac4');
+	});
+
+	// Absent rather than 'unknown'. JSON.stringify drops an undefined value, the
+	// API reads a missing key as NA, and the dashboard renders no marker -- which
+	// is the pre-deploy history case and the reason the two repos can merge in
+	// either order.
+	test('omits the ark version entirely when the build reported none', () => {
+		const payload = buildPayload([snapshot], meta);
+		expect(payload.ark_version).toBeUndefined();
+		expect(JSON.parse(JSON.stringify(payload))).not.toHaveProperty('ark_version');
+	});
+
+	test('still pins payload_version at 1 with both fields present', () => {
+		// A bump would 400 every POST against an API that has not been updated in
+		// lockstep, because validate_memory_payload compares with !=. Additive
+		// optional fields at v1 are compatible in both directions.
+		const payload = buildPayload([{ ...snapshot, arkVersion: '0.1.252+209.885fac4' }], meta);
+		expect(payload.payload_version).toBe(1);
 	});
 
 	test('redacts window titles on the way out', () => {

--- a/test/e2e/utils/memory/publish.vitest.ts
+++ b/test/e2e/utils/memory/publish.vitest.ts
@@ -26,6 +26,7 @@ const process1: LabeledProcess = {
 	processName: 'window [1] (secret-client-project)',
 	processRole: 'renderer', labeled: true, cmdBasename: 'positron',
 	pssBytes: 300, rssBytes: 600, pssMin: 290, pssMax: 310,
+	pssSamples: [290, 300, 310], rssSamples: [580, 600, 620],
 	forcedGc: false
 };
 

--- a/test/e2e/utils/memory/render.vitest.ts
+++ b/test/e2e/utils/memory/render.vitest.ts
@@ -15,6 +15,7 @@ const proc = (overrides: Partial<LabeledProcess> = {}): LabeledProcess => ({
 	labeled: true, cmdBasename: 'positron', pssBytes: 100 * MB, rssBytes: 200 * MB,
 	pssMin: 100 * MB, pssMax: 100 * MB,
 	pssSamples: [100 * MB, 100 * MB, 100 * MB], rssSamples: [200 * MB, 200 * MB, 200 * MB],
+	forcedGc: false,
 	...overrides
 });
 

--- a/test/e2e/utils/memory/snapshot.ts
+++ b/test/e2e/utils/memory/snapshot.ts
@@ -104,20 +104,41 @@ export function joinProcesses(
 /**
  * Mark which processes were sampled after a forced garbage collection.
  *
- * By role rather than by pid, even though {@link ForcedGcStats} carries one. The
- * GC reaches a process through its role's inspector port, so every process of a
- * collected role is in the collected state; flagging only the pid that answered
- * would leave a sibling of the same role reading as live. The API's trend
- * summary aggregates this per role with `any()` on exactly that assumption.
+ * Primarily by role rather than by pid, even though {@link ForcedGcStats}
+ * carries one. The GC reaches a process through its role's inspector port, so
+ * every process of a collected role is in the collected state; flagging only
+ * the pid that answered would leave a sibling of the same role reading as
+ * live. The API's trend summary aggregates this per role with `any()` on
+ * exactly that assumption.
+ *
+ * Pid is an additional, fallback match for lanes where the role cannot be
+ * resolved at all: the server lane cannot answer `--status` (label.ts,
+ * memory-scenario.ts), so `shared` and `extension_host` never come from
+ * `NAME_RULES` there and the collected extension host resolves to
+ * `unlabeled`. Matching its pid against the stats identifies exactly the
+ * process the GC pass reached, which is strictly more truthful than leaving
+ * an unlabeled-but-collected process reading as live.
+ *
+ * Role matching errs toward over-claiming rather than under-claiming: if a
+ * role ever has two processes (two windows, two extension hosts), the GC
+ * reaches one inspector port but both get flagged. That is the safer
+ * direction -- a visible asterisk on a partly-collected role beats a silent
+ * absent one on a role that really was collected -- and moot today since every
+ * scenario runs a single window.
  *
  * Absent stats mean no GC pass ran, so every process keeps the `false`
  * {@link joinProcesses} set.
  */
 export function withForcedGc(processes: LabeledProcess[], forcedGc: ForcedGcStats[] | undefined): LabeledProcess[] {
+	const stats = forcedGc ?? [];
 	// Typed as strings rather than GcTarget['role'], so the lookup below can ask
 	// about any ProcessRole without a cast.
-	const collected = new Set<string>((forcedGc ?? []).map(stats => stats.role));
-	return processes.map(proc => ({ ...proc, forcedGc: collected.has(proc.processRole) }));
+	const collectedRoles = new Set<string>(stats.map(entry => entry.role));
+	const collectedPids = new Set<number>(stats.map(entry => entry.pid));
+	return processes.map(proc => ({
+		...proc,
+		forcedGc: collectedRoles.has(proc.processRole) || collectedPids.has(proc.pid)
+	}));
 }
 
 const totalPss = (procs: RawProcess[]): number => procs.reduce((sum, p) => sum + p.pssBytes, 0);

--- a/test/e2e/utils/memory/snapshot.ts
+++ b/test/e2e/utils/memory/snapshot.ts
@@ -92,9 +92,31 @@ export function joinProcesses(
 			pssMin: Math.min(...observed),
 			pssMax: Math.max(...observed),
 			pssSamples: observed,
-			rssSamples: observedRss
+			rssSamples: observedRss,
+			// Corrected by withForcedGc, which runs where the GC pass is in scope.
+			// False rather than undefined so the field can be required on the type.
+			forcedGc: false
 		};
 	});
+}
+
+/**
+ * Mark which processes were sampled after a forced garbage collection.
+ *
+ * By role rather than by pid, even though {@link ForcedGcStats} carries one. The
+ * GC reaches a process through its role's inspector port, so every process of a
+ * collected role is in the collected state; flagging only the pid that answered
+ * would leave a sibling of the same role reading as live. The API's trend
+ * summary aggregates this per role with `any()` on exactly that assumption.
+ *
+ * Absent stats mean no GC pass ran, so every process keeps the `false`
+ * {@link joinProcesses} set.
+ */
+export function withForcedGc(processes: LabeledProcess[], forcedGc: ForcedGcStats[] | undefined): LabeledProcess[] {
+	// Typed as strings rather than GcTarget['role'], so the lookup below can ask
+	// about any ProcessRole without a cast.
+	const collected = new Set<string>((forcedGc ?? []).map(stats => stats.role));
+	return processes.map(proc => ({ ...proc, forcedGc: collected.has(proc.processRole) }));
 }
 
 const totalPss = (procs: RawProcess[]): number => procs.reduce((sum, p) => sum + p.pssBytes, 0);
@@ -365,7 +387,10 @@ export async function captureSnapshot(input: {
 	// median taken across the step between them describes neither state.
 	const reported = samples.slice(-TAIL_LENGTH);
 	const names = await readProcessNames(input.buildRoot, input.userDataDir);
-	const processes = joinProcesses(samples[samples.length - 1], names, input.rootPid, reported);
+	const joined = joinProcesses(samples[samples.length - 1], names, input.rootPid, reported);
+	// Stamped here rather than inside joinProcesses, which is called from the
+	// baseline path too and has no view of the GC pass.
+	const processes = withForcedGc(joined, forcedGc);
 
 	return {
 		scenario: input.scenario,

--- a/test/e2e/utils/memory/snapshot.ts
+++ b/test/e2e/utils/memory/snapshot.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { basename } from 'path';
+import { readArkVersion } from '../ark-version.js';
 import { getPositronVersion } from '../../infra/test-runner/positron-version.js';
 import { ForcedGcStats } from './gc.js';
 import { deriveExtensionName, isGenericName, normalizeProcessName, resolveRole } from './label.js';
@@ -397,6 +398,7 @@ export async function captureSnapshot(input: {
 		lane: input.lane,
 		capturedAt: new Date().toISOString(),
 		positronVersion: readPositronVersion(input.buildRoot),
+		arkVersion: readArkVersion(input.buildRoot),
 		launchIndex: input.launchIndex,
 		stoppedGrowing,
 		settleMs,

--- a/test/e2e/utils/memory/snapshot.vitest.ts
+++ b/test/e2e/utils/memory/snapshot.vitest.ts
@@ -392,6 +392,28 @@ describe('withForcedGc', () => {
 		withForcedGc(input, [stats('shared', 1)]);
 		expect(input[0].forcedGc).toBe(false);
 	});
+
+	// The server lane cannot answer `--status` at all (label.ts), so `shared`
+	// and `extension_host` never resolve there and the collected extension host
+	// reads as `unlabeled`. Matching by pid as well identifies exactly the
+	// process the GC pass actually reached, which is strictly more truthful
+	// than leaving an unlabeled-but-collected process reading as live.
+	test('flags an unlabeled process whose pid matches, as on the server lane', () => {
+		const flagged = withForcedGc(
+			[proc(2, 'unlabeled')],
+			[stats('extension_host', 2)]);
+		expect(flagged.map(p => p.forcedGc)).toEqual([true]);
+	});
+
+	// Confirms pid matching is additive, not a replacement for role matching: a
+	// process whose pid does not match any stats entry still falls through to
+	// the role check rather than defaulting to false.
+	test('still flags by role when pids do not match', () => {
+		const flagged = withForcedGc(
+			[proc(1, 'extension_host')],
+			[stats('extension_host', 999)]);
+		expect(flagged.map(p => p.forcedGc)).toEqual([true]);
+	});
 });
 
 describe('joinProcesses forcedGc default', () => {

--- a/test/e2e/utils/memory/snapshot.vitest.ts
+++ b/test/e2e/utils/memory/snapshot.vitest.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { describe, expect, test } from 'vitest';
-import { isSettled, joinProcesses, tailIsFlat, treeHasSettled, unstableProcesses, waitForSettle } from './snapshot.js';
-import { LabeledProcess, RawProcess } from './types.js';
+import { ForcedGcStats } from './gc.js';
+import { isSettled, joinProcesses, tailIsFlat, treeHasSettled, unstableProcesses, waitForSettle, withForcedGc } from './snapshot.js';
+import { LabeledProcess, ProcessRole, RawProcess } from './types.js';
 
 const proc = (pid: number, ppid: number, cmd: string, pss: number): RawProcess =>
 	({ pid, ppid, cmd, pssBytes: pss, rssBytes: pss * 2 });
@@ -96,7 +97,7 @@ describe('unstableProcesses', () => {
 		labeled: true, cmdBasename: 'positron',
 		pssBytes: pss[Math.floor(pss.length / 2)], rssBytes: 0,
 		pssMin: Math.min(...pss), pssMax: Math.max(...pss),
-		pssSamples: pss, rssSamples: pss.map(v => v * 2)
+		pssSamples: pss, rssSamples: pss.map(v => v * 2), forcedGc: false
 	});
 
 	test('flags a process whose samples span more than the tolerance', () => {
@@ -331,5 +332,76 @@ describe('the 50 MB floor on flatness', () => {
 
 	test('counts the same fractional drop as moving once it clears 50 MB', () => {
 		expect(tailIsFlat([740 * MB, 740 * MB, 740 * MB, 660 * MB])).toBe(false);
+	});
+});
+
+describe('withForcedGc', () => {
+	// Shadows the module-scope `proc`, which is a RawProcess factory. Deliberate:
+	// this block only ever wants the labeled kind.
+	const proc = (pid: number, processRole: ProcessRole): LabeledProcess => ({
+		pid, ppid: 1, depth: 0, processName: `p${pid}`, processRole,
+		labeled: true, cmdBasename: 'positron',
+		pssBytes: 100, rssBytes: 200, pssMin: 100, pssMax: 100,
+		pssSamples: [100], rssSamples: [200], forcedGc: false
+	});
+
+	const stats = (role: 'shared' | 'extension_host', pid: number): ForcedGcStats => ({
+		role, pid,
+		preRssBytes: 200, postRssBytes: 100,
+		preHeapTotalBytes: 150, postHeapTotalBytes: 80
+	});
+
+	test('flags the collected roles and leaves the live ones alone', () => {
+		const flagged = withForcedGc(
+			[proc(1, 'shared'), proc(2, 'extension_host'), proc(3, 'renderer')],
+			[stats('shared', 1), stats('extension_host', 2)]);
+		expect(flagged.map(p => [p.processRole, p.forcedGc])).toEqual([
+			['shared', true], ['extension_host', true], ['renderer', false]
+		]);
+	});
+
+	// By role, not by pid, even though ForcedGcStats carries one. The GC reaches a
+	// role through its inspector port, so every process of a collected role is in
+	// the collected state -- and the API's trend row aggregates the flag per role
+	// with any(), which its own comment justifies by "every process of a collected
+	// role carries the flag, so any() and all() agree". Matching on pid would make
+	// that false the moment a role has two processes.
+	test('flags every process of a collected role, not only the pid that was read', () => {
+		const flagged = withForcedGc(
+			[proc(1, 'extension_host'), proc(2, 'extension_host')],
+			[stats('extension_host', 1)]);
+		expect(flagged.map(p => p.forcedGc)).toEqual([true, true]);
+	});
+
+	// The server lane collects only the extension host (gcTargetsFor). Nothing
+	// downstream needs a rule for that, because the flag says so per process.
+	test('follows the lane through the stats it was given', () => {
+		const flagged = withForcedGc(
+			[proc(1, 'shared'), proc(2, 'extension_host')],
+			[stats('extension_host', 2)]);
+		expect(flagged.map(p => p.forcedGc)).toEqual([false, true]);
+	});
+
+	test('leaves everything live when no GC pass ran', () => {
+		expect(withForcedGc([proc(1, 'shared')], undefined).map(p => p.forcedGc)).toEqual([false]);
+		expect(withForcedGc([proc(1, 'shared')], []).map(p => p.forcedGc)).toEqual([false]);
+	});
+
+	test('does not mutate its input', () => {
+		const input = [proc(1, 'shared')];
+		withForcedGc(input, [stats('shared', 1)]);
+		expect(input[0].forcedGc).toBe(false);
+	});
+});
+
+describe('joinProcesses forcedGc default', () => {
+	// joinProcesses has no view of the GC pass, so it reports every process live
+	// and withForcedGc flips the collected roles afterwards. The default is false
+	// rather than undefined so the field is required on the type and a process
+	// that never reached withForcedGc cannot compile.
+	test('reports every process as live, for withForcedGc to correct', () => {
+		const raw = [{ pid: 100, ppid: 1, cmd: '/opt/positron/positron', pssBytes: 10, rssBytes: 20 }];
+		const joined = joinProcesses(raw, new Map([[100, 'main']]), 100, [raw]);
+		expect(joined.map(p => p.forcedGc)).toEqual([false]);
 	});
 });

--- a/test/e2e/utils/memory/summary.vitest.ts
+++ b/test/e2e/utils/memory/summary.vitest.ts
@@ -20,6 +20,7 @@ const proc = (overrides: Partial<LabeledProcess> = {}): LabeledProcess => ({
 	labeled: true, cmdBasename: 'positron', pssBytes: 100 * MB, rssBytes: 200 * MB,
 	pssMin: 100 * MB, pssMax: 100 * MB,
 	pssSamples: [100 * MB, 100 * MB, 100 * MB], rssSamples: [200 * MB, 200 * MB, 200 * MB],
+	forcedGc: false,
 	...overrides
 });
 

--- a/test/e2e/utils/memory/types.ts
+++ b/test/e2e/utils/memory/types.ts
@@ -126,6 +126,15 @@ export type MemorySnapshot = {
 	 */
 	forcedGc?: ForcedGcStats[];
 	/**
+	 * Which ark the build bundles, e.g. `0.1.252+209.885fac4`. Undefined when the
+	 * build shipped no sidecar to read it from.
+	 *
+	 * On the snapshot rather than read at publish time because the report and
+	 * publish step is a separate `npx playwright test` invocation that reads these
+	 * files back off disk -- the app and its build are long gone by then.
+	 */
+	arkVersion?: string;
+	/**
 	 * Samples taken before the tail and thrown away: the startup plateau, before
 	 * Chromium reclaimed its startup memory. Non-zero is normal and healthy.
 	 */

--- a/test/e2e/utils/memory/types.ts
+++ b/test/e2e/utils/memory/types.ts
@@ -69,6 +69,19 @@ export type LabeledProcess = {
 	pssSamples: number[];
 	/** Index-aligned with `pssSamples`, so `pssSamples[i] <= rssSamples[i]` per instant. */
 	rssSamples: number[];
+	/**
+	 * Whether this process was sampled after a forced garbage collection (`gc.ts`).
+	 *
+	 * Per process rather than a role list on the snapshot, so every band on the
+	 * dashboard's Memory by Process Role chart is self-describing: the lane
+	 * difference -- the server lane collects only the extension host -- needs no
+	 * rule anywhere downstream, and the CSV export and any ad-hoc query get the
+	 * column for free. Matches how `labeled` already works on this type.
+	 *
+	 * Required rather than optional, so a process that never passed through
+	 * `withForcedGc` is a compile error rather than a silently un-flagged band.
+	 */
+	forcedGc: boolean;
 };
 
 export type ActivatedExtension = {

--- a/test/e2e/utils/metrics/api.ts
+++ b/test/e2e/utils/metrics/api.ts
@@ -84,7 +84,7 @@ export async function logMetric(
 		process.env.GITHUB_REF_NAME;   // Push, dispatch, etc.
 
 	const apiUrl = branch === 'main' ? PROD_API_URL : LOCAL_API_URL;
-	const payload = createMetricPayload(metric, isElectronApp);
+	const payload = createMetricPayload(metric, isElectronApp, arkVersion);
 
 	logger.log(`--- Log Metric ---`);
 	logger.log(`Current branch: ${branch || 'unknown'}`);
@@ -97,14 +97,15 @@ export async function logMetric(
 /**
  * Creates a metric payload from the provided metric data.
  *
- * `ark` is a parameter with a default rather than a direct read of the module
- * constant, so the payload builder is testable without a module mock. Production
- * callers leave it unset.
+ * The `ark` parameter is passed in rather than read from the module constant,
+ * so the payload builder is a pure function of its arguments and a test can pass
+ * `undefined` to mean "this build reported no ark version" — which a defaulted
+ * parameter cannot express, because a default fires on an explicit `undefined`.
  */
 export function createMetricPayload(
 	metric: PerfMetric,
 	isElectronApp: boolean,
-	ark: string | undefined = arkVersion
+	ark: string | undefined
 ): MetricPayload {
 	const {
 		feature_area,

--- a/test/e2e/utils/metrics/api.ts
+++ b/test/e2e/utils/metrics/api.ts
@@ -13,7 +13,8 @@ import {
 	platformVersion,
 	MetricResponse,
 	MetricContext,
-	positronVersion
+	positronVersion,
+	arkVersion
 } from './metric-base.js';
 import { SPEC_NAME } from '../../fixtures/test-setup/constants.js';
 import { type AssistantMetricContext } from './metric-assistant.js';
@@ -94,9 +95,17 @@ export async function logMetric(
 }
 
 /**
- * Creates a metric payload from the provided metric data
+ * Creates a metric payload from the provided metric data.
+ *
+ * `ark` is a parameter with a default rather than a direct read of the module
+ * constant, so the payload builder is testable without a module mock. Production
+ * callers leave it unset.
  */
-function createMetricPayload(metric: PerfMetric, isElectronApp: boolean): MetricPayload {
+export function createMetricPayload(
+	metric: PerfMetric,
+	isElectronApp: boolean,
+	ark: string | undefined = arkVersion
+): MetricPayload {
 	const {
 		feature_area,
 		action,
@@ -125,7 +134,11 @@ function createMetricPayload(metric: PerfMetric, isElectronApp: boolean): Metric
 		target_description,
 		variant,
 		spec_name: spec_name || SPEC_NAME,
-		context: JSON.stringify(context_json)
+		// Spread first, so a call site that set ark_version deliberately still
+		// wins over the build-wide read. Absent when there is nothing to report:
+		// never a placeholder, which would put a fake version into a column the
+		// dashboard promotes and marks changes on.
+		context: JSON.stringify({ ...(ark ? { ark_version: ark } : {}), ...context_json })
 	};
 }
 

--- a/test/e2e/utils/metrics/api.vitest.ts
+++ b/test/e2e/utils/metrics/api.vitest.ts
@@ -3,19 +3,8 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { createMetricPayload, PerfMetric } from './api.js';
-
-// createMetricPayload's `ark` parameter defaults to this module's `arkVersion`
-// constant, which is a real value whenever the checkout has an ark sidecar
-// (see ark-version.ts's checkout fallback) -- including this repo, while these
-// tests run. Forced to undefined here so 'omits ark_version when the build
-// reported none' exercises the no-ark path regardless of what this checkout
-// happens to have installed.
-vi.mock('./metric-base.js', async (importOriginal) => {
-	const actual = await importOriginal<typeof import('./metric-base.js')>();
-	return { ...actual, arkVersion: undefined };
-});
 
 const metric: PerfMetric = {
 	feature_area: 'data_explorer',

--- a/test/e2e/utils/metrics/api.vitest.ts
+++ b/test/e2e/utils/metrics/api.vitest.ts
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, test } from 'vitest';
+import { createMetricPayload, PerfMetric } from './api.js';
+
+const metric: PerfMetric = {
+	feature_area: 'data_explorer',
+	action: 'load_data',
+	target_type: 'file.parquet',
+	duration_ms: 1234,
+	context_json: { data_rows: 1000, data_cols: 12 }
+};
+
+const contextOf = (payload: { context: string }) => JSON.parse(payload.context);
+
+describe('createMetricPayload', () => {
+	// An ark bump moves Performance Trends and nothing on the chart attributes it.
+	// Set here rather than at a shortcut's call site because the API promotes this
+	// field for every feature area: on `sessions` rows only, the marker would
+	// disappear as soon as a reader filtered to another area.
+	test('merges the ark version into the serialized context', () => {
+		const payload = createMetricPayload(metric, true, '0.1.252+209.885fac4');
+		expect(contextOf(payload).ark_version).toBe('0.1.252+209.885fac4');
+	});
+
+	test('keeps the context the caller supplied', () => {
+		const payload = createMetricPayload(metric, true, '0.1.252+209.885fac4');
+		expect(contextOf(payload)).toMatchObject({ data_rows: 1000, data_cols: 12 });
+	});
+
+	test('works for a metric that supplied no context at all', () => {
+		const payload = createMetricPayload({ ...metric, context_json: undefined }, true, '0.1.252+209.885fac4');
+		expect(contextOf(payload)).toEqual({ ark_version: '0.1.252+209.885fac4' });
+	});
+
+	// Omitted rather than 'unknown'. The dashboard already skips 'unknown' in
+	// CHART_MARKER_SKIP_VALUES, but writing one would still put a literal string
+	// into a column the API promotes and a query could group on.
+	test('omits ark_version when the build reported none', () => {
+		const payload = createMetricPayload(metric, true, undefined);
+		expect(contextOf(payload)).not.toHaveProperty('ark_version');
+	});
+
+	test('lets an explicit caller-supplied ark_version win', () => {
+		const payload = createMetricPayload(
+			{ ...metric, context_json: { ark_version: '0.1.100+1.deadbee' } }, true, '0.1.252+209.885fac4');
+		expect(contextOf(payload).ark_version).toBe('0.1.100+1.deadbee');
+	});
+
+	test('leaves the rest of the payload alone', () => {
+		const payload = createMetricPayload(metric, true, '0.1.252+209.885fac4');
+		expect(payload.feature_area).toBe('data_explorer');
+		expect(payload.action).toBe('load_data');
+		expect(payload.duration_ms).toBe(1234);
+		expect(payload.runtime_env).toBe('electron');
+		expect(payload.status).toBe('success');
+	});
+});

--- a/test/e2e/utils/metrics/api.vitest.ts
+++ b/test/e2e/utils/metrics/api.vitest.ts
@@ -3,8 +3,19 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { createMetricPayload, PerfMetric } from './api.js';
+
+// createMetricPayload's `ark` parameter defaults to this module's `arkVersion`
+// constant, which is a real value whenever the checkout has an ark sidecar
+// (see ark-version.ts's checkout fallback) -- including this repo, while these
+// tests run. Forced to undefined here so 'omits ark_version when the build
+// reported none' exercises the no-ark path regardless of what this checkout
+// happens to have installed.
+vi.mock('./metric-base.js', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('./metric-base.js')>();
+	return { ...actual, arkVersion: undefined };
+});
 
 const metric: PerfMetric = {
 	feature_area: 'data_explorer',

--- a/test/e2e/utils/metrics/metric-base.ts
+++ b/test/e2e/utils/metrics/metric-base.ts
@@ -10,6 +10,7 @@ import type { ConsoleShortcutOptions } from './metric-console.js';
 // The leaf module, not test-setup: that one reaches electron.ts and its `ncp`
 // dependency, which does not resolve in the root vitest lane.
 import { getPositronVersion } from '../../infra/test-runner/positron-version.js';
+import { readArkVersion } from '../ark-version.js';
 
 export const CONNECT_API_KEY = process.env.CONNECT_API_KEY!;
 export const PROD_API_URL = 'https://connect.posit.it/e2e-test-insights-api/metrics';
@@ -33,6 +34,16 @@ export const platformVersion = os.release();
 
 export const positronVersion = getPositronVersion();
 
+/**
+ * Which ark the build under test bundles, or undefined when it shipped no
+ * sidecar to read it from.
+ *
+ * Read once at module load, beside positronVersion and from the same BUILD
+ * root, so every metric row of a run reports the same value and the read is not
+ * repeated per metric.
+ */
+export const arkVersion = readArkVersion();
+
 //-----------------------
 // Base Metric Types
 //-----------------------
@@ -53,6 +64,13 @@ export type MetricContext = {
 	// e2e-test-insights dashboard groups the Duration Distribution box plot by
 	// it. Keep values short, stable, snake_case, low-cardinality.
 	variant?: string;
+
+	// Which ark the build under test bundles, e.g. `0.1.252+209.885fac4`. Set
+	// centrally in api.ts for every feature area, so a call site does not have to
+	// remember it; the e2e-test-insights dashboard promotes it out of context_json
+	// and marks the date it changes on Performance Trends. A call site may still
+	// set it explicitly, and an explicit value wins.
+	ark_version?: string;
 
 	// Language runtime session fields
 	runtime_version?: string;


### PR DESCRIPTION
### Summary
Adds two provenance fields so a step on a dashboard memory or duration chart can be attributed instead of read as a regression. The dashboard API half is already merged (posit-dev/e2e-test-insights#223).

- New `test/e2e/utils/ark-version.ts` reads the bundled ark version from the build's `VERSION`/`SUBMODULE_COMMIT` sidecar, falling back to the checkout.
- Memory snapshots now stamp `forcedGc` per process, so the shared process and extension host are distinguishable from the ~13 live-sampled roles.
- Memory payload gains `ark_version` at the root and `forced_gc` on each process; `payload_version` stays `1`.
- Every performance metric's `context_json` gains `ark_version`, merged at the single `createMetricPayload` choke point.
- Absent values are omitted, never placeholders — the dashboard marks value changes.

### QA Notes
Test-only surface; no product code. 313 vitest tests pass, no new typecheck errors. Perf metrics only publish from `main`, so `ark_version` there needs a post-merge nightly to confirm.
