### PR TITLE
Stop caching stale help proxy info

### DIFF
--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
@@ -160,16 +160,6 @@ export class PositronHelpService extends Disposable implements IPositronHelpServ
 	private _helpEntryIndex = -1;
 
 	/**
-	 * Gets or sets a value which indicates whether the proxy server styles have been set.
-	 */
-	private _proxyServerStylesHaveBeenSet = false;
-
-	/**
-	 * Gets the proxy servers. Keyed by the target URL origin.
-	 */
-	private readonly _proxyServers = new Map<string, string>();
-
-	/**
 	 * Gets the help clients. Keyed by the runtime session ID.
 	 */
 	private readonly _helpClients = new Map<string, HelpClientInstance>();
@@ -453,26 +443,24 @@ export class PositronHelpService extends Disposable implements IPositronHelpServ
 	 */
 	private async setProxyServerStyles() {
 		// Create a webview theme data provider. It's a convenient way to get the styles we need for
-		// the help proxy server. Get the webview styles.
+		// the help proxy server.
 		const webviewThemeDataProvider = this._instantiationService.createInstance(
 			WebviewThemeDataProvider
 		);
-		const { styles } = webviewThemeDataProvider.getWebviewThemeData();
-		webviewThemeDataProvider.dispose();
 
-		// Try to set the proxy server styles.
+		// Try to set the proxy server styles. Styling is not worth failing a
+		// help navigation over, so nothing here is allowed to escape.
 		try {
-			// Set the proxy server styles.
+			const { styles } = webviewThemeDataProvider.getWebviewThemeData();
 			await this._commandService.executeCommand(
 				'positronProxy.setHelpProxyServerStyles',
 				styles
 			);
-
-			// Note that the proxy server styles have been set.
-			this._proxyServerStylesHaveBeenSet = true;
 		} catch (error) {
 			this._logService.error('PositronHelpService could not set the proxy server styles');
 			this._logService.error(error);
+		} finally {
+			webviewThemeDataProvider.dispose();
 		}
 	}
 
@@ -696,37 +684,31 @@ export class PositronHelpService extends Disposable implements IPositronHelpServ
 			return;
 		}
 
-		// Get the proxy server origin for the help URL. If one isn't found, ask the
-		// PositronProxy to start one.
-		let proxyServerOrigin = this._proxyServers.get(targetUrl.origin);
+		// Ask the PositronProxy for the proxy server origin for the help URL. It
+		// returns an existing server for the target origin if there is one, so
+		// there is nothing to cache here: the servers live in the extension
+		// host, and anything remembered on this side outlives them when the
+		// extension host restarts.
+		await this.setProxyServerStyles();
+
+		let proxyServerOrigin: string | undefined;
+		try {
+			proxyServerOrigin = await this._commandService.executeCommand<string>(
+				'positronProxy.startHelpProxyServer',
+				targetUrl.origin
+			);
+		} catch (error) {
+			this._logService.error(`PositronHelpService could not start the proxy server for ${targetUrl.origin}.`);
+			this._logService.error(error);
+		}
+
+		// If the help proxy server could not be started, notify the user, and return.
 		if (!proxyServerOrigin) {
-			// Ensure that the proxy server styles have been set.
-			if (!this._proxyServerStylesHaveBeenSet) {
-				await this.setProxyServerStyles();
-			}
-
-			// Try to start a help proxy server.
-			try {
-				proxyServerOrigin = await this._commandService.executeCommand<string>(
-					'positronProxy.startHelpProxyServer',
-					targetUrl.origin
-				);
-			} catch (error) {
-				this._logService.error(`PositronHelpService could not start the proxy server for ${targetUrl.origin}.`);
-				this._logService.error(error);
-			}
-
-			// If the help proxy server could not be started, notify the user, and return.
-			if (!proxyServerOrigin) {
-				this._notificationService.error(localize(
-					'positronHelpServiceUnavailable',
-					"The Positron help service is unavailable."
-				));
-				return;
-			}
-
-			// Add the proxy server.
-			this._proxyServers.set(targetUrl.origin, proxyServerOrigin);
+			this._notificationService.error(localize(
+				'positronHelpServiceUnavailable',
+				"The Positron help service is unavailable."
+			));
+			return;
 		}
 
 		// Create the source URL.

--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
@@ -136,7 +136,7 @@ export interface IPositronHelpService {
 /**
  * PositronHelpService class.
  */
-class PositronHelpService extends Disposable implements IPositronHelpService {
+export class PositronHelpService extends Disposable implements IPositronHelpService {
 	//#region Private Properties
 
 	/**

--- a/src/vs/workbench/contrib/positronHelp/test/browser/positronHelpService.vitest.ts
+++ b/src/vs/workbench/contrib/positronHelp/test/browser/positronHelpService.vitest.ts
@@ -1,0 +1,120 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { VSBuffer } from '../../../../../base/common/buffer.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { FileAccess } from '../../../../../base/common/network.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IFileContent, IFileService } from '../../../../../platform/files/common/files.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { HelpClientInstance } from '../../../../services/languageRuntime/common/languageRuntimeHelpClient.js';
+import { ILanguageRuntimeMetadata } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
+import { ShowHelpEvent, ShowHelpKind } from '../../../../services/languageRuntime/common/positronHelpComm.js';
+import { ILanguageRuntimeSession } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
+import { PositronHelpService } from '../../browser/positronHelpService.js';
+
+// R's help server lives in the R process and survives an extension host
+// restart, so the target origin is the one thing that does not change here.
+const TARGET_ORIGIN = 'http://127.0.0.1:54321';
+
+// The help proxy servers live in the extension host, so a restart replaces them
+// with new ones on new ports.
+const PROXY_ORIGIN_BEFORE_RESTART = 'http://127.0.0.1:12345';
+const PROXY_ORIGIN_AFTER_RESTART = 'http://127.0.0.1:23456';
+
+describe('PositronHelpService', () => {
+	// The origin the extension host would report right now. The test moves this
+	// to stand in for an extension host restart.
+	let proxyOrigin = PROXY_ORIGIN_BEFORE_RESTART;
+
+	// The help client emits show-help events; created at describe scope so the
+	// client stub can hand out its `.event` reference.
+	const onDidEmitHelpContent = new Emitter<ShowHelpEvent>();
+
+	const ctx = createTestContainer()
+		.withWorkbenchServices()
+		.stub(ICommandService, {
+			executeCommand: async (command: string) =>
+				command === 'positronProxy.startHelpProxyServer' ? proxyOrigin : undefined,
+		})
+		// The constructor reads the bundled help and welcome HTML on startup.
+		.stub(IFileService, {
+			readFile: async () => stubInterface<IFileContent>({
+				value: VSBuffer.fromString('<html></html>'),
+			}),
+		})
+		// WebviewThemeDataProvider reads the editor configuration to build the
+		// styles handed to the proxy server.
+		.stub(IConfigurationService, {
+			getValue: () => ({}),
+			onDidChangeConfiguration: Event.None,
+		})
+		.build();
+
+	beforeEach(() => {
+		proxyOrigin = PROXY_ORIGIN_BEFORE_RESTART;
+	});
+
+	function createHelpService() {
+		// The constructor resolves the bundled help HTML through FileAccess,
+		// which has no module id to resolve against under Vitest.
+		vi.spyOn(FileAccess, 'asFileUri').mockReturnValue(URI.file('/test/help.html'));
+
+		const helpService = ctx.instantiationService.createInstance(PositronHelpService);
+		ctx.disposables.add(helpService);
+		return helpService;
+	}
+
+	function attachHelpClient(helpService: PositronHelpService) {
+		const session = stubInterface<ILanguageRuntimeSession>({
+			sessionId: 'test-session-id',
+			runtimeMetadata: stubInterface<ILanguageRuntimeMetadata>({
+				languageId: 'r',
+				languageName: 'R',
+				runtimeId: 'test-runtime-id',
+			}),
+		});
+		const client = stubInterface<HelpClientInstance>({
+			onDidEmitHelpContent: onDidEmitHelpContent.event,
+			onDidClose: Event.None,
+			dispose: () => { },
+		});
+		helpService.attachClientInstance(session, client);
+	}
+
+	function showHelp(topicPath: string) {
+		onDidEmitHelpContent.fire({
+			content: `${TARGET_ORIGIN}${topicPath}`,
+			kind: ShowHelpKind.Url,
+			focus: false,
+		});
+	}
+
+	// The URL asserted here is the one handed to the Help pane's webview, so it
+	// is where the bug is visible: after an extension host restart the pane was
+	// sent a well-formed URL pointing at a proxy port nobody is listening on.
+	// Asserting the URL rather than "did we ask the proxy" leaves the choice of
+	// caching strategy open, as long as a dead origin never reaches the pane.
+	it('builds the help URL from the proxy origin the extension host reports now', async () => {
+		const helpService = createHelpService();
+		attachHelpClient(helpService);
+
+		showHelp('/library/stats/html/acf.html');
+		await vi.waitFor(() => expect(helpService.currentHelpEntry?.sourceUrl)
+			.toBe(`${PROXY_ORIGIN_BEFORE_RESTART}/library/stats/html/acf.html`));
+
+		// Stand in for an extension host restart: same R help server, new proxy.
+		proxyOrigin = PROXY_ORIGIN_AFTER_RESTART;
+
+		showHelp('/library/stats/html/lm.html');
+		await vi.waitFor(() => expect(helpService.currentHelpEntry?.sourceUrl)
+			.toBe(`${PROXY_ORIGIN_AFTER_RESTART}/library/stats/html/lm.html`));
+	});
+});


### PR DESCRIPTION
Closes #15726 by completing the fix for cli's `{.help}` and `{.vignette}`
Closes #15776 (best concrete demo of the problem is here)

The help proxy servers live in the extension host and die with it, but `PositronHelpService` remembered their origins in a map keyed by target origin, and remembered that it had handed them theme styles. Neither memory dies with the extension host. R's help server is inside the R process and survives, so the target origin is unchanged after a restart, the map hits, and we build a well-formed URL against a port nobody is listening on. The styles flag means the replacement proxy is never styled either.

The extension host already keeps at most one help proxy server per target origin: `startProxyServer` returns the existing server when it has one and starts a new server only when it doesn't. It has behaved that way since before the workbench-side map was added in #1328, so the two have been redundant from the start. The workbench copy only ever saved one command round trip per help event, which is exactly what dropping it costs. Its sole reader was the lookup at the top of `handleShowHelpEvent`, and proxy cleanup derives its origins from the help entries, so nothing else depended on it.

`setProxyServerStyles` runs on every help event now instead of just the first, so it disposes the `WebviewThemeDataProvider` in a `finally` rather than only on the happy path, and reads the styles inside the try so a failure there gets logged instead of dropping the help navigation. Neither of these has bitten us; it's housekeeping while the function was being rewritten.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Help topics and vignettes open again after an extension host restart. Previously the Help pane stayed blank until the window was reloaded.

### Validation Steps

<!--
  Positron team members: e2e feature tags are auto-added based on your changed
  files, so tests run automatically when you open this pull request. Add tags
  here yourself to run more.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->

See #15776 for explicit repro/validation steps.