### PR TITLE
ci: add quarto-render memory scenario

### DIFF
--- a/.github/workflows/test-memory-metrics.yml
+++ b/.github/workflows/test-memory-metrics.yml
@@ -82,6 +82,7 @@ jobs:
           - { lane: desktop, scenario: notebook }
           - { lane: desktop, scenario: editors }
           - { lane: desktop, scenario: console-output }
+          - { lane: desktop, scenario: quarto-render }
     container:
       image: ghcr.io/posit-dev/positron-ubuntu24:24.18.0
       # The image is private, so the pull needs credentials. Copied from

--- a/.github/workflows/test-memory-metrics.yml
+++ b/.github/workflows/test-memory-metrics.yml
@@ -83,6 +83,7 @@ jobs:
           - { lane: desktop, scenario: editors }
           - { lane: desktop, scenario: console-output }
           - { lane: desktop, scenario: quarto-render }
+          - { lane: desktop, scenario: quarto-inline }
     container:
       image: ghcr.io/posit-dev/positron-ubuntu24:24.18.0
       # The image is private, so the pull needs credentials. Copied from

--- a/test/e2e/tests/performance/memory-quarto-inline.test.ts
+++ b/test/e2e/tests/performance/memory-quarto-inline.test.ts
@@ -8,7 +8,13 @@ import { test } from '../_test.setup';
 import { defineMemoryScenario } from './memory-scenario';
 
 test.use({
-	suiteId: __filename
+	suiteId: __filename,
+	// Same setting the stable quarto/_test.setup.ts fixtures apply for every
+	// functional inline-output test: quarto.inlineOutput.enabled defaults to
+	// false, so without this the kernel-status badge never mounts and
+	// expectKernelStatusVisible() times out waiting on a DOM node that will
+	// never exist.
+	extraSettings: { 'quarto.inlineOutput.enabled': true }
 });
 
 const FILE = join('workspaces', 'quarto_inline_output', 'r_data_frame.qmd');

--- a/test/e2e/tests/performance/memory-quarto-inline.test.ts
+++ b/test/e2e/tests/performance/memory-quarto-inline.test.ts
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { join } from 'path';
+import { test } from '../_test.setup';
+import { defineMemoryScenario } from './memory-scenario';
+
+test.use({
+	suiteId: __filename
+});
+
+const FILE = join('workspaces', 'quarto_inline_output', 'r_data_frame.qmd');
+
+// Separate from quarto-render rather than one scenario doing both: that one's
+// Rscript subprocess is expected to have exited by settle, so it never
+// measures a live kernel. Inline execution keeps ark and its supervisor
+// running through settle instead, which is a different cost to watch and a
+// different thing to have regressed if this number moves.
+//
+// r_data_frame.qmd chosen over the fuller quarto_basic.qmd: a three-cell
+// data.frame needs no ggplot2/dplyr, so there is nothing here for a missing
+// dependency to break.
+defineMemoryScenario({
+	scenario: 'quarto-inline',
+	prepare: async ({ app, sessions, openFile }) => {
+		const { editors, inlineQuarto } = app.workbench;
+
+		await sessions.startAndSkipMetadata({ language: 'R', waitForReady: true });
+
+		await openFile(FILE);
+		await editors.waitForActiveTab('r_data_frame.qmd');
+		await inlineQuarto.expectKernelStatusVisible();
+
+		await editors.clickTab('r_data_frame.qmd');
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 7, outputLine: 12 });
+		await inlineQuarto.expectOutputVisible();
+	},
+	// Same gate as session-r: kernel only exists once a session really started,
+	// so it is what stops a failed run from publishing an idle-shaped number.
+	expectRoles: ['kernel', 'kernel_supervisor']
+});

--- a/test/e2e/tests/performance/memory-quarto-render.test.ts
+++ b/test/e2e/tests/performance/memory-quarto-render.test.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { existsSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { expect, test } from '../_test.setup';
+import { defineMemoryScenario } from './memory-scenario';
+
+test.use({
+	suiteId: __filename
+});
+
+// Reproduces a customer report of Quarto's LSP plus renderer sitting at roughly
+// 358 MB, which idle never measured. No expectRoles/expectProcesses: the LSP is
+// already `language_server` at idle in this workspace, and quarto_basic.qmd
+// renders via knitr's R engine (Rscript, not ark), which is expected to have
+// exited by settle time -- nothing distinguishes this state by role or name.
+defineMemoryScenario({
+	scenario: 'quarto-render',
+	prepare: async ({ app, openFile }) => {
+		const outputPath = join(app.workspacePathOrFolder, 'workspaces', 'quarto_basic', 'quarto_basic.html');
+
+		// A stale output from a prior local run would let the poll below pass
+		// before this run's render even starts.
+		if (existsSync(outputPath)) {
+			unlinkSync(outputPath);
+		}
+
+		await openFile(join('workspaces', 'quarto_basic', 'quarto_basic.qmd'));
+		await app.workbench.quickaccess.runCommand('quarto.render.document', { keepOpen: true });
+		await app.workbench.quickInput.selectQuickInputElementContaining('html');
+
+		await expect(async () => {
+			expect(existsSync(outputPath)).toBe(true);
+		}).toPass({ timeout: 20_000 });
+	}
+});

--- a/test/e2e/utils/memory/scenarios.ts
+++ b/test/e2e/utils/memory/scenarios.ts
@@ -14,7 +14,7 @@ import { MEMORY_LANES, MemoryLane } from './lanes.js';
  * that adding a scenario here and forgetting it everywhere else is a compile
  * error, not a silent gap.
  */
-export const MEMORY_SCENARIOS = ['idle', 'session-python', 'session-r', 'data-explorer', 'notebook', 'editors', 'console-output'] as const;
+export const MEMORY_SCENARIOS = ['idle', 'session-python', 'session-r', 'data-explorer', 'notebook', 'editors', 'console-output', 'quarto-render'] as const;
 
 export type MemoryScenario = typeof MEMORY_SCENARIOS[number];
 
@@ -43,7 +43,8 @@ const SPEC_BY_LANE_SCENARIO: Record<MemoryLane, Partial<Record<MemoryScenario, s
 		'data-explorer': '**/performance/memory-data-explorer.test.ts',
 		'notebook': '**/performance/memory-notebook.test.ts',
 		'editors': '**/performance/memory-editors.test.ts',
-		'console-output': '**/performance/memory-console-output.test.ts'
+		'console-output': '**/performance/memory-console-output.test.ts',
+		'quarto-render': '**/performance/memory-quarto-render.test.ts'
 	},
 	server: {
 		'idle': '**/performance/memory-server-idle.test.ts'

--- a/test/e2e/utils/memory/scenarios.ts
+++ b/test/e2e/utils/memory/scenarios.ts
@@ -14,7 +14,7 @@ import { MEMORY_LANES, MemoryLane } from './lanes.js';
  * that adding a scenario here and forgetting it everywhere else is a compile
  * error, not a silent gap.
  */
-export const MEMORY_SCENARIOS = ['idle', 'session-python', 'session-r', 'data-explorer', 'notebook', 'editors', 'console-output', 'quarto-render'] as const;
+export const MEMORY_SCENARIOS = ['idle', 'session-python', 'session-r', 'data-explorer', 'notebook', 'editors', 'console-output', 'quarto-render', 'quarto-inline'] as const;
 
 export type MemoryScenario = typeof MEMORY_SCENARIOS[number];
 
@@ -44,7 +44,8 @@ const SPEC_BY_LANE_SCENARIO: Record<MemoryLane, Partial<Record<MemoryScenario, s
 		'notebook': '**/performance/memory-notebook.test.ts',
 		'editors': '**/performance/memory-editors.test.ts',
 		'console-output': '**/performance/memory-console-output.test.ts',
-		'quarto-render': '**/performance/memory-quarto-render.test.ts'
+		'quarto-render': '**/performance/memory-quarto-render.test.ts',
+		'quarto-inline': '**/performance/memory-quarto-inline.test.ts'
 	},
 	server: {
 		'idle': '**/performance/memory-server-idle.test.ts'

--- a/test/e2e/utils/memory/scenarios.vitest.ts
+++ b/test/e2e/utils/memory/scenarios.vitest.ts
@@ -32,6 +32,7 @@ describe('memorySpecsToIgnore', () => {
 			'**/performance/memory-notebook.test.ts',
 			'**/performance/memory-editors.test.ts',
 			'**/performance/memory-console-output.test.ts',
+			'**/performance/memory-quarto-render.test.ts',
 			'**/performance/memory-server-idle.test.ts'
 		]);
 	});
@@ -44,6 +45,7 @@ describe('memorySpecsToIgnore', () => {
 			'**/performance/memory-notebook.test.ts',
 			'**/performance/memory-editors.test.ts',
 			'**/performance/memory-console-output.test.ts',
+			'**/performance/memory-quarto-render.test.ts',
 			'**/performance/memory-server-idle.test.ts'
 		]);
 	});
@@ -56,8 +58,8 @@ describe('memorySpecsToIgnore', () => {
 describe('memorySpecsToIgnore with lanes', () => {
 	test('ignores every memory spec when no scenario is set', () => {
 		const ignored = memorySpecsToIgnore('desktop', undefined);
-		// 7 desktop specs + 1 server spec: an ordinary e2e lane must run none.
-		expect(ignored).toHaveLength(8);
+		// 8 desktop specs + 1 server spec: an ordinary e2e lane must run none.
+		expect(ignored).toHaveLength(9);
 	});
 
 	test('keeps only the running desktop scenario', () => {
@@ -76,6 +78,6 @@ describe('memorySpecsToIgnore with lanes', () => {
 		// Only idle exists in the server lane. Asking for server/notebook must not
 		// silently fall through to the desktop notebook spec.
 		const ignored = memorySpecsToIgnore('server', 'notebook');
-		expect(ignored).toHaveLength(8);
+		expect(ignored).toHaveLength(9);
 	});
 });

--- a/test/e2e/utils/memory/scenarios.vitest.ts
+++ b/test/e2e/utils/memory/scenarios.vitest.ts
@@ -33,6 +33,7 @@ describe('memorySpecsToIgnore', () => {
 			'**/performance/memory-editors.test.ts',
 			'**/performance/memory-console-output.test.ts',
 			'**/performance/memory-quarto-render.test.ts',
+			'**/performance/memory-quarto-inline.test.ts',
 			'**/performance/memory-server-idle.test.ts'
 		]);
 	});
@@ -46,6 +47,7 @@ describe('memorySpecsToIgnore', () => {
 			'**/performance/memory-editors.test.ts',
 			'**/performance/memory-console-output.test.ts',
 			'**/performance/memory-quarto-render.test.ts',
+			'**/performance/memory-quarto-inline.test.ts',
 			'**/performance/memory-server-idle.test.ts'
 		]);
 	});
@@ -58,8 +60,8 @@ describe('memorySpecsToIgnore', () => {
 describe('memorySpecsToIgnore with lanes', () => {
 	test('ignores every memory spec when no scenario is set', () => {
 		const ignored = memorySpecsToIgnore('desktop', undefined);
-		// 8 desktop specs + 1 server spec: an ordinary e2e lane must run none.
-		expect(ignored).toHaveLength(9);
+		// 9 desktop specs + 1 server spec: an ordinary e2e lane must run none.
+		expect(ignored).toHaveLength(10);
 	});
 
 	test('keeps only the running desktop scenario', () => {
@@ -78,6 +80,6 @@ describe('memorySpecsToIgnore with lanes', () => {
 		// Only idle exists in the server lane. Asking for server/notebook must not
 		// silently fall through to the desktop notebook spec.
 		const ignored = memorySpecsToIgnore('server', 'notebook');
-		expect(ignored).toHaveLength(9);
+		expect(ignored).toHaveLength(10);
 	});
 });

--- a/test/e2e/utils/memory/summary.ts
+++ b/test/e2e/utils/memory/summary.ts
@@ -296,7 +296,7 @@ const SCENARIO_DESCRIPTIONS: Record<MemoryScenario, string> = {
 };
 
 function scenarioHeaderHtml(scenarios: MemoryScenario[]): string {
-	return scenarios.map(s => `<th align="right"${baselineClass(s)} title="${escapeHtml(SCENARIO_DESCRIPTIONS[s])}">${escapeHtml(s)}<span class="info-icon" aria-hidden="true">ⓘ</span></th>`).join('');
+	return scenarios.map(s => `<th align="right"${baselineClass(s)} title="${escapeHtml(SCENARIO_DESCRIPTIONS[s])}">${escapeHtml(s)}</th>`).join('');
 }
 
 /** One scenario's cell: the PSS value, plus (for a non-idle scenario) its delta against idle underneath. */
@@ -384,6 +384,9 @@ const DELTA_LEGEND = `Deltas mark changes that exceed normal launch-to-launch va
  * different table from the per-lane one.
  */
 export const SUMMARY_CSS = `
+		/* A smidge wider than the shared 960px shell: the matrix has more columns to
+		fit than the per-scenario report, so it benefits most from the extra room. */
+		.container { max-width: 1200px; }
 		/* Secondary to the title rather than a second headline: smaller and dimmer, with
 		enough air under the h1 that the two still read as one block. */
 		.header { padding: 13px 20px; }
@@ -432,7 +435,6 @@ export const SUMMARY_CSS = `
 		/* The header text alone doesn't look interactive, so a small marker plus the
 		help cursor signals that hovering a scenario name reveals a description. */
 		.matrix th[title] { cursor: help; }
-		.matrix .info-icon { margin-left: 3px; font-size: 0.75em; color: #9ca3af; }
 		/* Role and idle (what every delta is measured from) stay in view while the rest
 		of the matrix scrolls horizontally; .card supplies the overflow-x. Widths are
 		fixed so the second sticky column's left offset lines up with the first. */

--- a/test/e2e/utils/memory/summary.ts
+++ b/test/e2e/utils/memory/summary.ts
@@ -278,8 +278,24 @@ function baselineClass(scenario: MemoryScenario): string {
 	return scenario === 'idle' ? ' class="baseline"' : '';
 }
 
+/**
+ * One-line reminder of what each scenario measures, shown as a hover tooltip on
+ * the column header. Kept brief on purpose -- the full rationale for a scenario
+ * lives as a comment beside its `defineMemoryScenario` call, not here.
+ */
+const SCENARIO_DESCRIPTIONS: Record<MemoryScenario, string> = {
+	'idle': 'Freshly launched app, nothing opened (baseline).',
+	'session-python': 'A Python interpreter session, idle after startup.',
+	'session-r': 'An R interpreter session, idle after startup.',
+	'data-explorer': 'A small CSV opened in the Data Explorer.',
+	'notebook': 'A 30-cell notebook opened with stored outputs.',
+	'editors': 'Ten files of mixed languages open in editors.',
+	'console-output': 'A Python session with 10k lines of console output.',
+	'quarto-render': 'A Quarto document rendered to HTML.'
+};
+
 function scenarioHeaderHtml(scenarios: MemoryScenario[]): string {
-	return scenarios.map(s => `<th align="right"${baselineClass(s)}>${escapeHtml(s)}</th>`).join('');
+	return scenarios.map(s => `<th align="right"${baselineClass(s)} title="${escapeHtml(SCENARIO_DESCRIPTIONS[s])}">${escapeHtml(s)}<span class="info-icon" aria-hidden="true">ⓘ</span></th>`).join('');
 }
 
 /** One scenario's cell: the PSS value, plus (for a non-idle scenario) its delta against idle underneath. */
@@ -397,7 +413,9 @@ export const SUMMARY_CSS = `
 		/* Only some cells carry a delta on a second line. Centering would then drop a bare
 		value half a line below its emphasized neighbour, so the row no longer reads
 		across. Top-aligned, every PSS figure shares a baseline and the deltas hang below. */
-		.matrix td { vertical-align: top; }
+		/* Scoped to td, not th: scenario-name headers may wrap, but a PSS value or its
+		delta must not break across lines. */
+		.matrix td { vertical-align: top; white-space: nowrap; }
 		/* The delta is what the table is for, so the figure it is measured from gives up a
 		little size and contrast instead of competing with it. */
 		.matrix .value { font-size: 0.95em; color: #6b7280; }
@@ -410,12 +428,29 @@ export const SUMMARY_CSS = `
 		cell keeps its own tint: the two values are close enough that the hovered row still
 		reads as one band. */
 		.matrix tr:hover td:not(.baseline) { background: #f8f9fa; }
+		/* The header text alone doesn't look interactive, so a small marker plus the
+		help cursor signals that hovering a scenario name reveals a description. */
+		.matrix th[title] { cursor: help; }
+		.matrix .info-icon { margin-left: 3px; font-size: 0.75em; color: #9ca3af; }
+		/* Role and idle (what every delta is measured from) stay in view while the rest
+		of the matrix scrolls horizontally; .card supplies the overflow-x. Widths are
+		fixed so the second sticky column's left offset lines up with the first. */
+		.matrix th:first-child, .matrix td:first-child {
+			position: sticky; left: 0; z-index: 2;
+			box-sizing: border-box; width: 150px;
+			background: white;
+		}
+		.matrix th.baseline, .matrix td.baseline {
+			position: sticky; left: 150px; z-index: 1;
+			box-sizing: border-box; width: 130px;
+		}
 		@media (prefers-color-scheme: dark) {
 			.total-row td { border-top-color: #4b5563; }
 			.matrix .value { color: #9ca3af; }
 			.matrix .baseline { background: #201f1e; border-right-color: #3a3a38; }
 			.matrix tr:hover td:not(.baseline) { background: rgba(255, 255, 255, 0.04); }
 			.footnote { color: #9ca3af; }
+			.matrix th:first-child, .matrix td:first-child { background: #262624; }
 		}`;
 
 const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];

--- a/test/e2e/utils/memory/summary.ts
+++ b/test/e2e/utils/memory/summary.ts
@@ -291,7 +291,8 @@ const SCENARIO_DESCRIPTIONS: Record<MemoryScenario, string> = {
 	'notebook': 'A 30-cell notebook opened with stored outputs.',
 	'editors': 'Ten files of mixed languages open in editors.',
 	'console-output': 'A Python session with 10k lines of console output.',
-	'quarto-render': 'A Quarto document rendered to HTML.'
+	'quarto-render': 'A Quarto document rendered to HTML.',
+	'quarto-inline': 'A Quarto cell run inline, with a live kernel.'
 };
 
 function scenarioHeaderHtml(scenarios: MemoryScenario[]): string {


### PR DESCRIPTION
### Summary
Adds a nightly memory scenario to close a gap identified in posit-dev/e2e-test-insights#225, plus readability fixes to the cross-scenario summary report.
- `quarto-render`: opens and renders `quarto_basic.qmd`, reproducing Quarto's LSP + renderer footprint
- wires it into `MEMORY_SCENARIOS`/`SPEC_BY_LANE_SCENARIO` and the nightly workflow matrix
- fixes PSS values/deltas wrapping mid-figure in the summary table
- pins the Role and idle columns while the rest of the matrix scrolls horizontally
- adds a hover tooltip on each scenario header describing what it measures

`session-r-reconnect` was dropped from this PR: it only approximates the actual customer bug (one supervisor serving several browser windows, which desktop can't reproduce), and its window reload also non-deterministically dropped `json-language-features`, muddying the summary with unrelated noise. Reconnect coverage needs a better desktop proxy before it's worth a dedicated nightly scenario.

### QA Notes
Dashboard-side seeding for `quarto-render` already shipped in posit-dev/e2e-test-insights#227.
