### PR TITLE
e2e: replace fixed reload sleeps with deterministic navigation wait

### DIFF
--- a/test/e2e/fixtures/test-setup/settings.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/settings.fixtures.ts
@@ -23,6 +23,8 @@ export function SettingsFixture(app: Application) {
 			await settings.set(newSettings, { keepOpen });
 
 			if (reload === true || (reload === 'web' && app.web === true)) {
+				// reloadWindow waits deterministically for the new page (navigation +
+				// workbench restored), so no fixed sleep is needed here.
 				await app.workbench.hotKeys.reloadWindow(false);
 			}
 			if (waitMs) {
@@ -30,8 +32,6 @@ export function SettingsFixture(app: Application) {
 			}
 
 			if (waitForReady) {
-				await app.code.driver.currentPage.waitForTimeout(3000);
-				await app.code.driver.currentPage.locator('.monaco-workbench').waitFor({ state: 'visible' });
 				await app.workbench.sessions.expectNoStartUpMessaging();
 			}
 		},

--- a/test/e2e/pages/hotKeys.ts
+++ b/test/e2e/pages/hotKeys.ts
@@ -256,13 +256,31 @@ export class HotKeys {
 	}
 
 	public async reloadWindow(waitForReady = false) {
-		await this.pressHotKeys('Cmd+B R', 'Reload window');
+		const page = this.code.driver.currentPage;
 
-		// wait for workbench to disappear, reappear and be ready
-		await this.code.driver.currentPage.waitForTimeout(3000);
-		await this.code.driver.currentPage.locator('.monaco-workbench').waitFor({ state: 'visible' });
+		// Arm the navigation listener before triggering the reload: the old DOM stays
+		// visible (with no startup messaging) for a beat after the keypress, so any
+		// readiness gate that polls immediately would pass against the pre-reload page.
+		// The main frame navigating is the deterministic signal that the reload
+		// actually happened. (Filter to the main frame: webview iframes navigate too.)
+		const navigated = page.waitForEvent('framenavigated', frame => frame === page.mainFrame());
+		await this.pressHotKeys('Cmd+B R', 'Reload window');
+		await navigated;
+
+		await page.locator('.monaco-workbench').waitFor({ state: 'visible' });
+
+		// Wait for the workbench lifecycle to reach Restored (the same positive signal
+		// Application#checkPositronReady gates launch on). External browsers (Posit
+		// Workbench, Jupyter) don't run with --enable-smoke-test-driver, so window.driver
+		// is unavailable there.
+		if (!this.isExternalBrowser()) {
+			await this.code.whenWorkbenchRestored();
+		}
+
 		if (waitForReady) {
-			await expect(this.code.driver.currentPage.locator(STARTUP_MESSAGING_SELECTOR)).toHaveCount(0, { timeout: STARTUP_MESSAGING_TIMEOUT });
+			// Only after the restored gate above is this asserting "startup messaging has
+			// cleared" rather than trivially passing before it has rendered at all.
+			await expect(page.locator(STARTUP_MESSAGING_SELECTOR)).toHaveCount(0, { timeout: STARTUP_MESSAGING_TIMEOUT });
 		}
 	}
 


### PR DESCRIPTION
### Summary

`hotKeys.reloadWindow` and the settings fixture both relied on a fixed 3s sleep before their readiness gates. The gates check for the *absence* of startup messaging (`toHaveCount(0)`), which passes trivially in two windows where nothing matches for the wrong reason:

1. **Old-page race**: after the reload hotkey fires, the pre-reload DOM stays up for a beat. On that page `.monaco-workbench` is visible and no startup messaging exists, so every gate passes instantly against the window that is about to be torn down. The sleep was really "hopefully teardown has started by now."
2. **Fresh-page race**: even in the new renderer, the absence check can poll before "Starting..." / "Discovering interpreters" has rendered at all.

This PR replaces the sleeps with deterministic signals:

- `reloadWindow` arms a `framenavigated` wait on the main frame *before* pressing the hotkey, so the main frame navigating is the proof the reload actually happened (webview iframes are filtered out). It then waits for `.monaco-workbench` and `whenWorkbenchRestored()` - the same positive lifecycle signal `Application#checkPositronReady` gates app launch on. External browsers (Posit Workbench, Jupyter) skip the restored gate since they run without the smoke-test driver.
- The settings fixture drops its duplicated sleep/visible/absence block (it was a near-verbatim copy of what `reloadWindow` already did, costing 6s of fixed sleep per reloading `settings.set`). The reload path delegates to the now-synchronized `reloadWindow`; the ready path keeps `expectNoStartUpMessaging` for its titlebar/console-focus behavior.

With the restored gate in front of it, the absence check now asserts "startup messaging has cleared" rather than "hasn't rendered yet."

**Behavior change to be aware of**: on the non-reload path, `settings.set` no longer waits 3s before the readiness check. If a specific setting kicks off a slow async reaction, that caller should use the explicit `waitMs` option.

A full-suite run on this branch is in flight: https://github.com/posit-dev/positron/actions/runs/33186278340

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:sessions @:layouts @:positron-notebooks @:interpreter @:outline @:vscode-settings

Reload-heavy suites above exercise the new wait directly (session management, panel visibility, notebook editor, default interpreters, LSP outline, and settings import all call the reload helper). Also verify a local run of any test using the settings fixture with reload shows no regression in timing or flakiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)