### PR TITLE
Fix Interrupt button disappearing when switching back to a busy console

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
@@ -206,8 +206,8 @@ export const ActionBar = (props: ActionBarProps) => {
 				return;
 			}
 
-			// Set the initial state.
-			setInterruptible(session.dynState.busy);
+			// Seed interruptibility from the runtime state
+			setInterruptible(session.getRuntimeState() === RuntimeState.Busy);
 			setDirectoryLabel(session.dynState.currentWorkingDirectory);
 			setCanShutdown(session.getRuntimeState() !== RuntimeState.Exited && session.getRuntimeState() !== RuntimeState.Uninitialized);
 			setCanStart(session.getRuntimeState() === RuntimeState.Exited || session.getRuntimeState() === RuntimeState.Uninitialized);

--- a/src/vs/workbench/contrib/positronConsole/test/browser/actionBar.vitest.tsx
+++ b/src/vs/workbench/contrib/positronConsole/test/browser/actionBar.vitest.tsx
@@ -5,9 +5,10 @@
 
 /// <reference types="vitest/globals" />
 
-import { screen, waitFor } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Event } from '../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
 import { IReactComponentContainer } from '../../../../../base/browser/positronReactRenderer.js';
 import { DynamicActionBarAction } from '../../../../../platform/positronActionBar/browser/positronDynamicActionBar.js';
 
@@ -46,6 +47,46 @@ describe('ActionBar', () => {
 	const rtl = setupRTLRenderer(() => ctx.reactServices);
 
 	const container = stubInterface<IReactComponentContainer>();
+
+	// Disposes emitters created for busy sessions.
+	const disposables = new DisposableStore();
+	afterEach(() => disposables.clear());
+
+	// Adds a busy, attached console session whose runtime is executing a
+	// command. Returns a callback that fires the runtime's Busy state change,
+	// which is what surfaces the interrupt button.
+	function addBusyConsoleInstance(sessionId: string): { fireBusy: () => void } {
+		const sessionMetadata: IRuntimeSessionMetadata = {
+			sessionId,
+			sessionMode: LanguageRuntimeSessionMode.Console,
+			notebookUri: undefined,
+			createdTimestamp: 0,
+			startReason: 'test',
+		};
+		const runtimeMetadata = stubInterface<ILanguageRuntimeMetadata>({
+			languageName: 'Python',
+			languageId: 'python',
+			base64EncodedIconSvg: undefined,
+		});
+		const instance = new TestPositronConsoleInstance(sessionId, 'Python', sessionMetadata, runtimeMetadata);
+		const runtimeStateEmitter = disposables.add(new Emitter<RuntimeState>());
+		// The runtime reports Busy while executing, but dynState.busy stays
+		// false: it's a separate UI-comm signal that not every runtime emits
+		// (Python never does), so it can't gate the interrupt button.
+		const busySession = stubInterface<ILanguageRuntimeSession>({
+			sessionId,
+			getRuntimeState: () => RuntimeState.Busy,
+			onDidChangeRuntimeState: runtimeStateEmitter.event,
+			onDidReceiveRuntimeClientEvent: Event.None,
+			dynState: stubInterface<ILanguageRuntimeSession['dynState']>({ busy: false, currentWorkingDirectory: '' }),
+		});
+		instance.attachRuntimeSession(busySession, SessionAttachMode.Connected);
+		instance.setState(PositronConsoleState.Busy);
+
+		const consoleService = ctx.get(IPositronConsoleService) as TestPositronConsoleService;
+		consoleService.addTestConsoleInstance(instance);
+		return { fireBusy: () => runtimeStateEmitter.fire(RuntimeState.Busy) };
+	}
 
 	// Adds an idle, attached console session and makes it the active instance,
 	// so the restart button renders enabled.
@@ -101,5 +142,32 @@ describe('ActionBar', () => {
 
 		expect(restartSession).toHaveBeenCalledOnce();
 		await waitFor(() => expect(restartButton).toBeEnabled());
+	});
+
+	it('keeps the interrupt button after switching consoles and back', () => {
+		const consoleService = ctx.get(IPositronConsoleService) as TestPositronConsoleService;
+		const busy = addBusyConsoleInstance('busy');
+		addIdleConsoleInstance('idle');
+
+		// Start on the busy console.
+		act(() => consoleService.setActivePositronConsoleSession('busy'));
+
+		rtl.render(
+			<PositronConsoleContextProvider>
+				<ActionBar reactComponentContainer={container} />
+			</PositronConsoleContextProvider>
+		);
+
+		// The running command surfaces the interrupt button.
+		act(() => busy.fireBusy());
+		expect(screen.getByRole('button', { name: /Interrupt/ })).toBeInTheDocument();
+
+		// Switch to the idle console: no command running, no interrupt button.
+		act(() => consoleService.setActivePositronConsoleSession('idle'));
+		expect(screen.queryByRole('button', { name: /Interrupt/ })).not.toBeInTheDocument();
+
+		// Switch back to the still-busy console: the interrupt button must return.
+		act(() => consoleService.setActivePositronConsoleSession('busy'));
+		expect(screen.getByRole('button', { name: /Interrupt/ })).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
Fixes #15578

When a console is busy running a command and you switch to another console and back, the Interrupt button disappeared, leaving the console busy with no way to stop it.

The button follows the runtime's execution state: the console action bar turns on interruptibility when the runtime reports `Busy`. But the code that re-seeds this state whenever a session attaches (which happens each time you switch consoles) read a different signal instead. 

The fix seeds interruptibility from the same runtime state the rest of the action bar already uses, so switching consoles can no longer clear the button.

### Release Notes

#### New Features
- N/A

#### Bug Fixes

- Keep the Interrupt button visible after switching between busy consoles (#15578)

### Validation Steps

@:console

1. Start two consoles.
2. In the first console, run a long command, e.g. `Sys.sleep(50)` (R) or
   `import time; time.sleep(50)` (Python). Confirm the Interrupt button appears.
3. Switch to the second console, then switch back to the first.
4. Verify the Interrupt button is still present and can interrupt the command.

Covered by a unit test in `actionBar.vitest.tsx` that reproduces the switch-away-and-back sequence.
