### PR TITLE
Add AWS profile and region inputs to the Bedrock connect dialog

### DIFF
--- a/extensions/authentication/src/configDialog.ts
+++ b/extensions/authentication/src/configDialog.ts
@@ -291,8 +291,10 @@ async function handleSave(
 		return handleApiKeySave(source, config, provider);
 	}
 
-	// Persist settings (e.g. base URL) before resolving the chain
-	// so the chain validator uses the value the user just entered.
+	// Persist settings (e.g. base URL) before resolving the chain so the chain
+	// validator uses the value the user just entered -- the chain resolvers read
+	// their connection from the provider catalog, not from `config`, so an
+	// unsaved value would be validated against the previous one.
 	const onSave = onSaveCallbacks.get(providerId);
 	const baseUrlPersisted = onSave ? (await onSave(config)) !== false : true;
 

--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -24,7 +24,7 @@ import {
 import { AuthProvider } from './authProvider';
 import { registerAuthProvider, providerAction, updateProviderFromSessions, authProviders } from './configDialog';
 import { CustomProviderRegistry, isAddCustomProviderRequest, isRemoveCustomProviderRequest } from './customProviderRegistry';
-import { getRegistrableProviderSources, PROVIDER_METADATA } from './providerSources';
+import { getRegistrableProviderSources, getUserAwsSettings, PROVIDER_METADATA } from './providerSources';
 import {
 	normalizeToV1Url,
 	validateAnthropicApiKey,
@@ -65,6 +65,7 @@ import {
 	ProviderCatalogOptions,
 	removeProviderBlock,
 	saveCustomProviderModels,
+	saveAwsSettings,
 	saveDatabricksHost,
 	saveProviderBaseUrl,
 	saveSnowflakeAccount,
@@ -271,6 +272,25 @@ export async function activate(context: vscode.ExtensionContext) {
 					await authProviders.get(id)?.resolveChainCredentials();
 				}
 			}
+
+			// Refresh the profile/region the Bedrock dialog shows the next time
+			// it opens. `registerProvider` sent a one-time snapshot of
+			// `defaults` at startup and nothing updates it afterwards, so
+			// without this the dialog would still show startup values after a
+			// save. A stale box is worse than it looks: an empty one means
+			// "delete this setting" on Connect, so it would wipe the value that
+			// was just saved.
+			//
+			// Covers in-app writes, which reach here through
+			// refreshProviderCatalog. It does NOT cover every hand edit of
+			// providers.json: ai-config's watch only fires when the *resolved*
+			// catalog changed, so a file edit that AWS_PROFILE / AWS_REGION
+			// shadows is invisible to it and the dialog keeps the older value.
+			if (e.changedUserProviderIds.includes(PROVIDER_METADATA.amazonBedrock.catalogId!)) {
+				positron.ai.updateProvider(AWS_AUTH_PROVIDER_ID, {
+					defaults: { aws: getUserAwsSettings() },
+				});
+			}
 		})
 	);
 
@@ -414,6 +434,12 @@ async function registerAwsProvider(
 		provider
 	);
 	registerAuthProvider(AWS_AUTH_PROVIDER_ID, provider, {
+		onSave: async (config) => {
+			if (!config.aws) {
+				return;
+			}
+			await saveAwsSettings(config.aws);
+		},
 		recover: createAwsSsoRecovery({
 			getProfile: () => getCachedProvider(
 				PROVIDER_METADATA.amazonBedrock.catalogId!

--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -435,7 +435,11 @@ async function registerAwsProvider(
 	);
 	registerAuthProvider(AWS_AUTH_PROVIDER_ID, provider, {
 		onSave: async (config) => {
-			if (!config.aws) {
+			// An empty block means the form had nothing editable to submit --
+			// every field it offers is supplied by the environment, which
+			// outranks providers.json. Returning early keeps Connect from
+			// rewriting the config file with identical content.
+			if (!config.aws || Object.keys(config.aws).length === 0) {
 				return;
 			}
 			await saveAwsSettings(config.aws);

--- a/extensions/authentication/src/providerCatalog.ts
+++ b/extensions/authentication/src/providerCatalog.ts
@@ -26,15 +26,27 @@ export interface ResolvedProviderLike {
 }
 
 /**
- * Payload of {@link onDidChangeProviderCatalog}, carrying the per-provider
- * granularity the credential chain needs: `changedConnectionIds` (ids whose
- * connection JSON differs) and `disabledIds` (ids whose `enabled` flipped to
- * false). An id that has just appeared counts as a connection change, from
- * nothing to something, which is how a new custom provider surfaces.
+ * Payload of {@link onDidChangeProviderCatalog}. The first two fields name the
+ * part of a provider that changed in the *resolved* catalog, which is what the
+ * credential chain acts on; the third reports the same providers as the *user
+ * file* declares them, for UI that mirrors the file.
+ *
+ * An id that has just appeared counts as a connection change, from nothing to
+ * something, which is how a new custom provider surfaces.
  */
 export interface ProviderCatalogChangeEvent {
+	/** Ids whose resolved `connection` JSON differs. */
 	readonly changedConnectionIds: string[];
+	/** Ids whose resolved `enabled` flipped to false. */
 	readonly disabledIds: string[];
+	/**
+	 * Ids whose providers.json block differs. Reported separately because the
+	 * resolved and file views move independently: with an environment variable
+	 * outranking the file, saving a change leaves `changedConnectionIds` empty
+	 * while this is non-empty. Covers the whole block, not just connection
+	 * fields, so an `enabled` edit in the file lands here too.
+	 */
+	readonly changedUserProviderIds: string[];
 }
 
 /**
@@ -47,8 +59,11 @@ export interface ProviderCatalogOptions {
 }
 
 let cache = new Map<string, ResolvedProviderLike>();
+let userConfig = new Map<string, BuiltinProviderBlock>();
 let watcher: { dispose(): void } | undefined;
 let currentOptions: ProviderCatalogOptions | undefined;
+/** Serializes the watch handler's async applies so they land in arrival order. */
+let applyQueue: Promise<void> = Promise.resolve();
 
 const changeEmitter = new vscode.EventEmitter<ProviderCatalogChangeEvent>();
 
@@ -75,7 +90,7 @@ function toMap(catalog: readonly ResolvedProvider[]): Map<string, ResolvedProvid
  * helper's refresh produces the same per-provider diff an external file edit
  * would.
  */
-function applyCatalog(next: readonly ResolvedProvider[]): void {
+function applyCatalog(next: readonly ResolvedProvider[], changedUserProviderIds: string[] = []): void {
 	const previous = cache;
 	const nextMap = toMap(next);
 
@@ -96,10 +111,33 @@ function applyCatalog(next: readonly ResolvedProvider[]): void {
 
 	cache = nextMap;
 
-	if (changedConnectionIds.length === 0 && disabledIds.length === 0 && !removed) {
+	if (
+		changedConnectionIds.length === 0
+		&& disabledIds.length === 0
+		&& changedUserProviderIds.length === 0
+		&& !removed
+	) {
 		return;
 	}
-	changeEmitter.fire({ changedConnectionIds, disabledIds });
+	changeEmitter.fire({ changedConnectionIds, disabledIds, changedUserProviderIds });
+}
+
+/**
+ * Replaces the user-layer cache, returning the ids whose block changed. Kept
+ * separate from {@link applyCatalog} so the file view is already current when
+ * the event fires and a listener reads it back.
+ */
+function applyUserConfig(next: Map<string, BuiltinProviderBlock>): string[] {
+	const previous = userConfig;
+	userConfig = next;
+
+	const changed: string[] = [];
+	for (const id of new Set([...previous.keys(), ...next.keys()])) {
+		if (JSON.stringify(previous.get(id)) !== JSON.stringify(next.get(id))) {
+			changed.push(id);
+		}
+	}
+	return changed;
 }
 
 async function loadCatalog(options: ProviderCatalogOptions): Promise<readonly ResolvedProvider[]> {
@@ -119,6 +157,45 @@ async function loadCatalog(options: ProviderCatalogOptions): Promise<readonly Re
 }
 
 /**
+ * Loads the `user` layer -- providers.json alone, with no environment,
+ * enforced, or default layer merged in -- into {@link userConfig}.
+ *
+ * A configuration form has to show what the user durably controls, not the
+ * collated result: an `AWS_REGION` picked up from a shell profile is not
+ * something the next launch is guaranteed to see, so presenting it as a saved
+ * setting would promise persistence the value doesn't have.
+ *
+ * `loadConfigSources` is ai-config's "source-assembly compatibility seam" and
+ * the only public read that returns layers separately -- `loadProviderCatalog-
+ * Report`, the canonical read, returns just the resolved catalog and its
+ * issues. The seam flattens per-layer issues into logger warnings, so an
+ * unreadable file arrives here as an absent user source, indistinguishable
+ * from an empty one. If that distinction ever matters, the supported fix is an
+ * ai-config change exposing `loadConfigSourceReports`.
+ */
+async function loadUserConfig(options: ProviderCatalogOptions): Promise<Map<string, BuiltinProviderBlock>> {
+	const { loadConfigSources } = await import('ai-config/node');
+	const sources = await loadConfigSources({
+		configPath: options.configPath,
+		env: options.envVars,
+		logger: { debug: (m: string) => log.debug(m), warn: (m: string) => log.warn(m) },
+	});
+	const user = sources.find(source => source.kind === 'user');
+	const providers = new Map<string, BuiltinProviderBlock>();
+	for (const [id, block] of Object.entries(user?.config.providers ?? {})) {
+		// `default` (the baseline block) and `custom` (a nested map of custom
+		// entries) are siblings of the built-in ids in this map, not ids
+		// themselves -- see ai-config's providersMapSchema. Skipped so they
+		// can't be mistaken for providers; a custom provider's own block lives
+		// under `custom` and is not exposed here.
+		if (block && id !== 'default' && id !== 'custom') {
+			providers.set(id, block as BuiltinProviderBlock);
+		}
+	}
+	return providers;
+}
+
+/**
  * Loads the resolved provider catalog into the cache and starts watching for
  * external changes. Idempotent: a re-init disposes the previous watcher and
  * replaces the cache, so tests can re-init against fresh directories without a
@@ -134,9 +211,19 @@ export async function initProviderCatalog(
 
 	const { watchResolvedProviderCatalog } = await import('ai-config/node');
 	cache = toMap(await loadCatalog(options));
+	userConfig = await loadUserConfig(options);
 
 	watcher = watchResolvedProviderCatalog(
-		(change: ProviderCatalogChange) => applyCatalog(change.catalog),
+		// Serialized: the handler has to read the user layer before applying,
+		// and watchResolvedProviderCatalog invokes it fire-and-forget, so two
+		// rebuilds in quick succession could otherwise have their reads resolve
+		// out of order and apply the older catalog last -- leaving both caches
+		// stale until the next file change.
+		(change: ProviderCatalogChange) => {
+			applyQueue = applyQueue
+				.then(async () => applyCatalog(change.catalog, applyUserConfig(await loadUserConfig(options))))
+				.catch(err => log.warn(`Could not apply a provider catalog change: ${err}`));
+		},
 		{
 			configPath: options.configPath,
 			envVars: options.envVars,
@@ -155,6 +242,17 @@ export function getCachedProvider(catalogId: string): ResolvedProviderLike | und
 }
 
 /**
+ * Synchronous read of a *built-in* provider's block as providers.json alone
+ * declares it, for UI that must show only what the user set. Use
+ * {@link getCachedProvider} for anything that needs the value in effect.
+ * Custom providers are not covered: their entries live under
+ * `providers.custom`, which this view deliberately omits.
+ */
+export function getUserProviderBlock(catalogId: string): BuiltinProviderBlock | undefined {
+	return userConfig.get(catalogId);
+}
+
+/**
  * Reloads the catalog now and fires {@link onDidChangeProviderCatalog} when the
  * reload differs from the cache. `options` overrides the remembered options so a
  * write helper called with `{ configPath }` in a test never reads the real file;
@@ -166,7 +264,12 @@ export async function refreshProviderCatalog(options?: ProviderCatalogOptions): 
 	if (!opts) {
 		return;
 	}
-	applyCatalog(await loadCatalog(opts));
+	// Both loads complete before either cache is touched: applyUserConfig
+	// consumes its diff, so a loadCatalog rejection after that point would
+	// discard the change ids for good and leave listeners on stale defaults.
+	const nextCatalog = await loadCatalog(opts);
+	const nextUserConfig = await loadUserConfig(opts);
+	applyCatalog(nextCatalog, applyUserConfig(nextUserConfig));
 }
 
 function effectiveOptions(override?: ProviderCatalogOptions): ProviderCatalogOptions {
@@ -276,6 +379,76 @@ export async function saveCustomProviderModels(
 			block.models = { discovery: 'off', custom: [...customModels] };
 		}
 		providers[catalogId] = block;
+	}, opts);
+}
+
+/**
+ * Assigns a provider's block, or drops the entry when the block has no keys
+ * left. An empty block contributes nothing to resolution, so `"bedrock": {}` is
+ * just residue -- and it reads as configuration the user didn't write.
+ */
+function setOrPruneBlock(
+	providers: BuiltinBlockMap,
+	catalogId: string,
+	block: BuiltinProviderBlock
+): void {
+	if (Object.keys(block).length === 0) {
+		delete providers[catalogId];
+	} else {
+		providers[catalogId] = block;
+	}
+}
+
+/**
+ * Writes providers.bedrock.aws from the profile/region the connect dialog
+ * submitted. Both fields are optional, so each one carries three states and
+ * they are not interchangeable:
+ *
+ * - `undefined` -- the field was not submitted, so the saved value is left
+ *   alone. The connect dialog always submits both, so this is for callers that
+ *   set one field without disturbing the other.
+ * - `''` -- the user emptied the box, so the key is removed and the value
+ *   falls back to `AWS_PROFILE` / `AWS_REGION` or the ambient AWS defaults.
+ * - a value -- written, trimmed.
+ *
+ * An `aws` block left with no keys is removed rather than written as `{}`, and
+ * a `bedrock` entry with nothing left in it is removed too, so clearing both
+ * boxes returns providers.json to the state it had before Bedrock was ever
+ * configured.
+ *
+ * The write is unconditional: settings are saved before the credential chain is
+ * resolved with them (the chain reads its connection from the catalog, not from
+ * the submitted config), and a failed connect leaves them in place. That matches
+ * every other connection setting -- base URL, Snowflake account, Databricks host
+ * -- so a value that doesn't work is corrected by reopening the dialog.
+ */
+export async function saveAwsSettings(
+	aws: { profile?: string; region?: string },
+	options?: ProviderCatalogOptions
+): Promise<void> {
+	const opts = effectiveOptions(options);
+	await mutate(providers => {
+		const block = providers['bedrock'] ?? {};
+		const next = { ...block.aws };
+		for (const field of ['profile', 'region'] as const) {
+			const submitted = aws[field];
+			if (submitted === undefined) {
+				continue;
+			}
+			const trimmed = submitted.trim();
+			if (trimmed) {
+				next[field] = trimmed;
+			} else {
+				delete next[field];
+			}
+		}
+		const updated: BuiltinProviderBlock = { ...block, aws: next };
+		if (Object.keys(next).length === 0) {
+			// Removed rather than set to undefined: the config is written
+			// through a JSONC editor, so the key has to actually go away.
+			delete updated.aws;
+		}
+		setOrPruneBlock(providers, 'bedrock', updated);
 	}, opts);
 }
 

--- a/extensions/authentication/src/providerCatalog.ts
+++ b/extensions/authentication/src/providerCatalog.ts
@@ -253,6 +253,147 @@ export function getUserProviderBlock(catalogId: string): BuiltinProviderBlock | 
 }
 
 /**
+ * Reads connection environment variables through the same seam the catalog
+ * uses, so a test that passes `envVars` to {@link initProviderCatalog} sees
+ * those values here too and never the real shell.
+ *
+ * Env vars are how a *shadowed* form field is detected. ai-config ranks its
+ * internal `env` layer above `user`, so a variable that is set makes the
+ * corresponding providers.json value inert -- and detection has to be by
+ * *presence*, not by diffing resolved against user: when both layers hold the
+ * same value a diff is empty, the input would stay editable, and the next save
+ * would be silently discarded.
+ *
+ * `names` is consulted in order, first set wins, matching ai-config's
+ * `readEnv`.
+ */
+export function readConnectionEnv(names: readonly string[]): string | undefined {
+	const env = currentOptions?.envVars ?? process.env;
+	for (const name of names) {
+		const value = env[name];
+		if (value) {
+			return value;
+		}
+	}
+	return undefined;
+}
+
+/** An env var name, or names consulted in order so the first set one wins. */
+type EnvNames = readonly string[];
+
+/**
+ * Where one connection value came from, when it did not come from the layer the
+ * user controls.
+ *
+ * Named after ai-config's `ResolvedConnectionValueProvenance`, but carrying the
+ * value and the variable that supplied it rather than a bare
+ * `'configuration' | 'environment'` kind: a form has to be able to say which
+ * variable to change, which a kind alone cannot express.
+ */
+export interface ConnectionValueProvenance {
+	/** The value in effect. */
+	readonly value: string;
+	/** Name of the environment variable that supplied it. */
+	readonly name?: string;
+}
+
+/**
+ * Provenance for the connection values a form renders, held as a tree parallel
+ * to the connection rather than as wrapped values.
+ *
+ * Mirrors ai-config's `ResolvedConnectionProvenance`, including its reason for
+ * staying a separate tree: a `ResolvedConnection` is spread into a provider
+ * client's runtime options, so metadata must never live inside it. Only fields
+ * something can actually take over appear.
+ */
+export interface ConnectionProvenance {
+	baseUrl?: ConnectionValueProvenance;
+	apiKey?: ConnectionValueProvenance;
+	aws?: {
+		profile?: ConnectionValueProvenance;
+		region?: ConnectionValueProvenance;
+	};
+}
+
+/**
+ * Environment variables that take a connection value over, shaped like the
+ * provenance they produce: one entry per catalog id, then the field names a
+ * form renders, then the variables that supply them.
+ *
+ * This is the only faithful view of ai-config's `env` layer. That layer is
+ * synthesized privately inside `resolveProviderCatalogReport` and is absent
+ * from `loadConfigSources`, which returns only `user`, `enforced`, and
+ * `default` -- so the table is not enumeration overhead, it is the reader.
+ * Mirrors the subset of ai-config's private `CONNECTION_ENV_MAPPINGS` whose
+ * fields the modal renders as inputs, keeping that table's nesting so the two
+ * can be compared by eye.
+ *
+ * Only Bedrock is populated today; the other providers' variables
+ * (`ANTHROPIC_BASE_URL`, `DATABRICKS_HOST`, `SNOWFLAKE_ACCOUNT`, ...) shadow
+ * their inputs the same way, and enabling one is a line of data. Note the keys
+ * name the *form field*, not the config path: Databricks and Snowflake carry
+ * their value through the base URL input while persisting elsewhere, so
+ * `DATABRICKS_HOST` belongs under `baseUrl`.
+ *
+ * Duplicating a private table risks drift, so `providerSources.test.ts` asserts
+ * behaviorally that each variable named here really does reach the resolved
+ * catalog, which fails loudly if ai-config renames one or adds an alias.
+ */
+const OVERRIDING_ENV_VARS: Record<string, {
+	baseUrl?: EnvNames;
+	apiKey?: EnvNames;
+	aws?: { profile?: EnvNames; region?: EnvNames };
+}> = {
+	bedrock: {
+		aws: { profile: ['AWS_PROFILE'], region: ['AWS_REGION'] },
+	},
+};
+
+/**
+ * Resolves one field's variables to its provenance, or undefined when none is
+ * set. The reported name is the one that actually supplied the value, so a
+ * provider with alias variables names the one the user set.
+ */
+function readProvenance(names: EnvNames | undefined): ConnectionValueProvenance | undefined {
+	for (const name of names ?? []) {
+		const value = readConnectionEnv([name]);
+		if (value !== undefined) {
+			return { value, name };
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Connection values of `catalogId` that the environment supplies, so a form can
+ * show what is in effect and name what set it instead of offering an input
+ * whose value would be ignored. Undefined when the user controls every field.
+ */
+export function getConnectionProvenance(catalogId: string | undefined): ConnectionProvenance | undefined {
+	const mapping = catalogId ? OVERRIDING_ENV_VARS[catalogId] : undefined;
+	if (!mapping) {
+		return undefined;
+	}
+
+	const baseUrl = readProvenance(mapping.baseUrl);
+	const apiKey = readProvenance(mapping.apiKey);
+	const profile = readProvenance(mapping.aws?.profile);
+	const region = readProvenance(mapping.aws?.region);
+
+	// Spread so a field with nothing set leaves no key behind: a consumer reads
+	// presence as "not editable", so a shell of undefined keys would be
+	// indistinguishable from real provenance at the type level.
+	const provenance: ConnectionProvenance = {
+		...(baseUrl ? { baseUrl } : {}),
+		...(apiKey ? { apiKey } : {}),
+		...(profile || region
+			? { aws: { ...(profile ? { profile } : {}), ...(region ? { region } : {}) } }
+			: {}),
+	};
+	return Object.keys(provenance).length > 0 ? provenance : undefined;
+}
+
+/**
  * Reloads the catalog now and fires {@link onDidChangeProviderCatalog} when the
  * reload differs from the cache. `options` overrides the remembered options so a
  * write helper called with `{ configPath }` in a test never reads the real file;

--- a/extensions/authentication/src/providerSources.ts
+++ b/extensions/authentication/src/providerSources.ts
@@ -25,10 +25,29 @@ import {
 	VERTEX_DEFAULT_BASE_URL,
 } from './constants';
 import { getConfiguredSnowflakeAccount } from './credentials/snowflake';
-import { getCachedCustomProviders, getCachedProvider, type ResolvedProviderLike } from './providerCatalog';
+import { getCachedCustomProviders, getCachedProvider, getUserProviderBlock, type ResolvedProviderLike } from './providerCatalog';
 
 function getSavedBaseUrl(catalogId: string | undefined, fallback?: string): string | undefined {
 	return (catalogId && getCachedProvider(catalogId)?.connection.baseUrl) || fallback;
+}
+
+/**
+ * AWS profile/region to pre-fill the connect dialog with, read from
+ * providers.json alone rather than the resolved catalog.
+ *
+ * Deliberately excludes `AWS_PROFILE` / `AWS_REGION`. Whether those reach the
+ * extension host depends on how Positron was launched and on a shell profile
+ * nobody versions, so showing one as a saved setting would promise persistence
+ * it doesn't have -- the next launch may resolve a different region with
+ * nothing in the UI having changed. The form therefore shows only what the
+ * user controls, and the hint beneath it names the variables as the fallback.
+ */
+export function getUserAwsSettings(): { profile?: string; region?: string } {
+	const aws = getUserProviderBlock(PROVIDER_METADATA.amazonBedrock.catalogId!)?.aws;
+	return {
+		...(aws?.profile ? { profile: aws.profile } : {}),
+		...(aws?.region ? { region: aws.region } : {}),
+	};
 }
 
 export interface ProviderMetadata {
@@ -168,10 +187,11 @@ export function getProviderSources(): positron.ai.LanguageModelSource[] {
 		{
 			type: positron.PositronLanguageModelType.Chat,
 			provider: PROVIDER_METADATA.amazonBedrock,
-			supportedOptions: ['toolCalls'],
+			supportedOptions: ['toolCalls', 'aws'],
 			defaults: {
 				model: 'us.anthropic.claude-sonnet-4-20250514-v1:0',
 				toolCalls: true,
+				aws: getUserAwsSettings(),
 			},
 		},
 		{

--- a/extensions/authentication/src/providerSources.ts
+++ b/extensions/authentication/src/providerSources.ts
@@ -25,7 +25,7 @@ import {
 	VERTEX_DEFAULT_BASE_URL,
 } from './constants';
 import { getConfiguredSnowflakeAccount } from './credentials/snowflake';
-import { getCachedCustomProviders, getCachedProvider, getUserProviderBlock, type ResolvedProviderLike } from './providerCatalog';
+import { getCachedCustomProviders, getCachedProvider, getConnectionProvenance, getUserProviderBlock, type ResolvedProviderLike } from './providerCatalog';
 
 function getSavedBaseUrl(catalogId: string | undefined, fallback?: string): string | undefined {
 	return (catalogId && getCachedProvider(catalogId)?.connection.baseUrl) || fallback;
@@ -193,6 +193,10 @@ export function getProviderSources(): positron.ai.LanguageModelSource[] {
 				toolCalls: true,
 				aws: getUserAwsSettings(),
 			},
+			// Structurally identical to the catalog's ConnectionProvenance, so the
+			// tree passes straight through -- the catalog owns the environment seam
+			// and needs no dependency on the positron API types to do it.
+			overrides: getConnectionProvenance(PROVIDER_METADATA.amazonBedrock.catalogId),
 		},
 		{
 			type: positron.PositronLanguageModelType.Chat,

--- a/extensions/authentication/src/test/providerCatalog.test.ts
+++ b/extensions/authentication/src/test/providerCatalog.test.ts
@@ -13,6 +13,7 @@ import {
 	getUserProviderBlock,
 	initProviderCatalog,
 	onDidChangeProviderCatalog,
+	readConnectionEnv,
 	refreshProviderCatalog,
 	removeProviderBlock,
 	saveAwsSettings,
@@ -397,6 +398,27 @@ suite('providerCatalog', () => {
 			written.providers.bedrock,
 			{ enabled: true },
 			'an emptied block must go away, not linger as {}, and must not disturb sibling keys'
+		);
+	});
+
+	test('readConnectionEnv consults names in order and treats empty as unset', async () => {
+		// Aliased variables are how ai-config handles a provider with a legacy
+		// name (google-vertex has two per field), so the primary name has to win
+		// when both are set, and an empty value has to fall through rather than
+		// count as present.
+		writeConfig(configPath, {});
+		await initProviderCatalog(context, {
+			configPath,
+			envVars: { PRIMARY: 'first', LEGACY: 'second', BLANK: '' },
+		});
+
+		assert.deepStrictEqual(
+			[
+				readConnectionEnv(['PRIMARY', 'LEGACY']),
+				readConnectionEnv(['BLANK', 'LEGACY']),
+				readConnectionEnv(['MISSING']),
+			],
+			['first', 'second', undefined]
 		);
 	});
 });

--- a/extensions/authentication/src/test/providerCatalog.test.ts
+++ b/extensions/authentication/src/test/providerCatalog.test.ts
@@ -10,10 +10,12 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import {
 	getCachedProvider,
+	getUserProviderBlock,
 	initProviderCatalog,
 	onDidChangeProviderCatalog,
 	refreshProviderCatalog,
 	removeProviderBlock,
+	saveAwsSettings,
 	saveCustomProviderModels,
 	saveProviderBaseUrl,
 	saveProviderEnabled,
@@ -282,5 +284,119 @@ suite('providerCatalog', () => {
 		const written = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
 		assert.strictEqual(written.providers.anthropic.enabled, false, 'onlyIfUnset must not overwrite an existing value');
 		assert.strictEqual(getCachedProvider('anthropic')?.enabled, false);
+	});
+
+	test('getUserProviderBlock reads providers.json alone, with no environment merged in', async () => {
+		writeConfig(configPath, { bedrock: { aws: { region: 'us-east-1' } } });
+		await initProviderCatalog(context, { configPath, envVars: { AWS_REGION: 'us-east-2' } });
+
+		assert.deepStrictEqual(
+			getUserProviderBlock('bedrock')?.aws,
+			{ region: 'us-east-1' },
+			'the connect form must show the saved value, not the environment override'
+		);
+		assert.strictEqual(
+			getCachedProvider('bedrock')?.connection.aws?.region,
+			'us-east-2',
+			'the resolved catalog still reflects the environment, for the credential chain'
+		);
+	});
+
+	test('a user-layer change is reported even when the environment hides it from the resolved value', async () => {
+		// AWS_REGION outranks the file, so saving a different region leaves the
+		// resolved connection identical. Listeners that mirror the *file* (the
+		// connect dialog's pre-filled values) still have to hear about it.
+		const envOpts = { configPath, envVars: { AWS_REGION: 'us-east-2' } };
+		writeConfig(configPath, { bedrock: { aws: { region: 'us-east-1' } } });
+		await initProviderCatalog(context, envOpts);
+
+		const changePromise = nextCatalogChange();
+		await saveAwsSettings({ region: 'eu-west-1' }, envOpts);
+		const payload = await changePromise;
+
+		assert.deepStrictEqual(payload.changedUserProviderIds, ['bedrock']);
+		assert.deepStrictEqual(
+			payload.changedConnectionIds, [],
+			'the resolved connection is unchanged -- the environment still wins'
+		);
+	});
+
+	test('getUserProviderBlock reflects a write without waiting for the watcher', async () => {
+		writeConfig(configPath, { bedrock: {} });
+		await initProviderCatalog(context, { configPath });
+
+		await saveAwsSettings({ profile: 'data-team' }, { configPath });
+
+		assert.deepStrictEqual(getUserProviderBlock('bedrock')?.aws, { profile: 'data-team' });
+	});
+
+	test('a malformed providers.json leaves the user view empty rather than throwing', async () => {
+		// ai-config's loadConfigSources flattens per-layer issues into logger
+		// warnings, so an unreadable file arrives as an absent user source.
+		// The form renders blank; it cannot distinguish this from "nothing set".
+		fs.writeFileSync(configPath, '{ "providers": { "bedrock": ');
+		await initProviderCatalog(context, { configPath });
+
+		assert.strictEqual(getUserProviderBlock('bedrock'), undefined);
+	});
+
+	test('saveAwsSettings writes the submitted profile and region, trimmed', async () => {
+		writeConfig(configPath, { bedrock: {} });
+		await initProviderCatalog(context, { configPath });
+
+		await saveAwsSettings({ profile: '  data-team  ', region: 'eu-west-1' }, { configPath });
+
+		const written = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+		assert.deepStrictEqual(written.providers.bedrock.aws, { profile: 'data-team', region: 'eu-west-1' });
+		assert.deepStrictEqual(getCachedProvider('bedrock')?.connection.aws, { profile: 'data-team', region: 'eu-west-1' });
+	});
+
+	test('saveAwsSettings leaves an omitted field alone, so an env-pinned value survives', async () => {
+		writeConfig(configPath, { bedrock: { aws: { profile: 'data-team', region: 'eu-west-1' } } });
+		await initProviderCatalog(context, { configPath });
+
+		// The dialog omits a field pinned by AWS_PROFILE / AWS_REGION.
+		await saveAwsSettings({ region: 'us-west-2' }, { configPath });
+
+		const written = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+		assert.deepStrictEqual(written.providers.bedrock.aws, { profile: 'data-team', region: 'us-west-2' });
+	});
+
+	test('saveAwsSettings removes a field the user emptied', async () => {
+		writeConfig(configPath, { bedrock: { aws: { profile: 'data-team', region: 'eu-west-1' } } });
+		await initProviderCatalog(context, { configPath });
+
+		await saveAwsSettings({ profile: '', region: 'eu-west-1' }, { configPath });
+
+		const written = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+		assert.deepStrictEqual(written.providers.bedrock.aws, { region: 'eu-west-1' });
+	});
+
+	test('saveAwsSettings removes the whole bedrock entry when nothing is left in it', async () => {
+		writeConfig(configPath, { anthropic: {}, bedrock: { aws: { region: 'us-east-1' } } });
+		await initProviderCatalog(context, { configPath });
+
+		await saveAwsSettings({ profile: '', region: '' }, { configPath });
+
+		const written = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+		assert.deepStrictEqual(
+			written.providers,
+			{ anthropic: {} },
+			'clearing both boxes should leave no bedrock residue, not "bedrock": {}'
+		);
+	});
+
+	test('saveAwsSettings removes the aws block entirely once both fields are empty', async () => {
+		writeConfig(configPath, { bedrock: { enabled: true, aws: { profile: 'data-team', region: 'eu-west-1' } } });
+		await initProviderCatalog(context, { configPath });
+
+		await saveAwsSettings({ profile: '', region: '' }, { configPath });
+
+		const written = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+		assert.deepStrictEqual(
+			written.providers.bedrock,
+			{ enabled: true },
+			'an emptied block must go away, not linger as {}, and must not disturb sibling keys'
+		);
 	});
 });

--- a/extensions/authentication/src/test/providerSources.test.ts
+++ b/extensions/authentication/src/test/providerSources.test.ts
@@ -105,6 +105,33 @@ suite('getProviderSources baseUrl defaults from the catalog', () => {
 		);
 		assert.strictEqual(databricks?.defaults.baseUrl, 'https://adb-123.4.azuredatabricks.net');
 	});
+
+	test('the Bedrock AWS defaults come from providers.json', async () => {
+		writeConfig(configPath, { bedrock: { aws: { profile: 'data-team', region: 'eu-west-1' } } });
+		await initProviderCatalog(context, { configPath });
+
+		const bedrock = getProviderSources().find(
+			s => s.provider.id === PROVIDER_METADATA.amazonBedrock.id
+		);
+		assert.deepStrictEqual(bedrock?.defaults.aws, { profile: 'data-team', region: 'eu-west-1' });
+	});
+
+	test('an environment-supplied AWS region stays out of the Bedrock defaults', async () => {
+		// The form shows what the user durably controls. AWS_REGION outranks the
+		// file when credentials resolve, but whether it reaches the extension
+		// host at all depends on how Positron was launched -- so pre-filling it
+		// would present an ambient value as a saved setting.
+		writeConfig(configPath, {});
+		await initProviderCatalog(context, {
+			configPath,
+			envVars: { AWS_REGION: 'us-east-2' },
+		});
+
+		const bedrock = getProviderSources().find(
+			s => s.provider.id === PROVIDER_METADATA.amazonBedrock.id
+		);
+		assert.deepStrictEqual(bedrock?.defaults.aws, {});
+	});
 });
 
 suite('the legacy openai-compatible provider', () => {

--- a/extensions/authentication/src/test/providerSources.test.ts
+++ b/extensions/authentication/src/test/providerSources.test.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { getProviderSources, getRegistrableProviderSources, PROVIDER_METADATA } from '../providerSources';
 import { POSITRON_CUSTOM_AUTH_PROVIDER_ID } from '../constants';
-import { initProviderCatalog } from '../providerCatalog';
+import { getCachedProvider, initProviderCatalog } from '../providerCatalog';
 
 /**
  * Guards against drift between PROVIDER_METADATA in providerSources.ts and the
@@ -120,7 +120,8 @@ suite('getProviderSources baseUrl defaults from the catalog', () => {
 		// The form shows what the user durably controls. AWS_REGION outranks the
 		// file when credentials resolve, but whether it reaches the extension
 		// host at all depends on how Positron was launched -- so pre-filling it
-		// would present an ambient value as a saved setting.
+		// would present an ambient value as a saved setting. It arrives as an
+		// override instead, which the form renders read-only.
 		writeConfig(configPath, {});
 		await initProviderCatalog(context, {
 			configPath,
@@ -174,5 +175,114 @@ suite('the legacy openai-compatible provider', () => {
 
 		const ids = getProviderSources().map(s => s.provider.id);
 		assert.ok(ids.includes(PROVIDER_METADATA.customProvider.id));
+	});
+});
+
+// Exercises getConnectionProvenance (providerCatalog.ts) through the seam its
+// consumer uses, so these cover both the table and the source it lands on.
+suite('getProviderSources connection provenance', () => {
+	let dir: string;
+	let configPath: string;
+	let context: vscode.ExtensionContext;
+
+	setup(() => {
+		dir = fs.mkdtempSync(path.join(os.tmpdir(), 'provider-overrides-'));
+		configPath = path.join(dir, 'providers.json');
+		context = fakeContext();
+	});
+
+	teardown(() => {
+		for (const d of context.subscriptions) {
+			d.dispose();
+		}
+		fs.rmSync(dir, { recursive: true, force: true });
+	});
+
+	function bedrockSource() {
+		return getProviderSources().find(
+			s => s.provider.id === PROVIDER_METADATA.amazonBedrock.id
+		);
+	}
+
+	test('each set variable becomes an override naming itself', async () => {
+		writeConfig(configPath, {});
+		await initProviderCatalog(context, {
+			configPath,
+			envVars: { AWS_PROFILE: 'ci-runner', AWS_REGION: 'us-east-2' },
+		});
+
+		assert.deepStrictEqual(bedrockSource()?.overrides, {
+			aws: {
+				profile: { value: 'ci-runner', name: 'AWS_PROFILE' },
+				region: { value: 'us-east-2', name: 'AWS_REGION' },
+			},
+		});
+	});
+
+	test('only the set variable is reported, leaving its sibling editable', async () => {
+		writeConfig(configPath, {});
+		await initProviderCatalog(context, { configPath, envVars: { AWS_REGION: 'us-east-2' } });
+
+		assert.deepStrictEqual(bedrockSource()?.overrides, {
+			aws: { region: { value: 'us-east-2', name: 'AWS_REGION' } },
+		});
+	});
+
+	test('overrides are absent when no variable is set', async () => {
+		writeConfig(configPath, { bedrock: { aws: { region: 'eu-west-1' } } });
+		await initProviderCatalog(context, { configPath, envVars: {} });
+
+		assert.strictEqual(bedrockSource()?.overrides, undefined);
+	});
+
+	test('a variable matching the saved value is still reported as an override', async () => {
+		// The case a resolved-vs-user value diff cannot see. The variable
+		// outranks the file whether or not the two agree, so the field is not
+		// editable here -- detecting by presence rather than by difference is
+		// what keeps the next save from being silently discarded.
+		writeConfig(configPath, { bedrock: { aws: { region: 'us-east-2' } } });
+		await initProviderCatalog(context, { configPath, envVars: { AWS_REGION: 'us-east-2' } });
+
+		assert.deepStrictEqual(bedrockSource()?.overrides, {
+			aws: { region: { value: 'us-east-2', name: 'AWS_REGION' } },
+		});
+	});
+
+	test('an empty variable is treated as unset, matching ai-config', async () => {
+		writeConfig(configPath, {});
+		await initProviderCatalog(context, { configPath, envVars: { AWS_REGION: '' } });
+
+		assert.strictEqual(bedrockSource()?.overrides, undefined);
+	});
+
+	test('a provider with no overridable fields reports none', async () => {
+		writeConfig(configPath, {});
+		await initProviderCatalog(context, { configPath, envVars: { AWS_REGION: 'us-east-2' } });
+
+		const anthropic = getProviderSources().find(
+			s => s.provider.id === PROVIDER_METADATA.anthropic.id
+		);
+		assert.strictEqual(anthropic?.overrides, undefined);
+	});
+
+	// Drift guard for OVERRIDING_ENV_VARS, which mirrors the subset of
+	// ai-config's private CONNECTION_ENV_MAPPINGS whose fields the modal
+	// renders. A type can't catch a rename or an added alias upstream, so this
+	// asserts behaviorally that each variable we name really does reach the
+	// resolved catalog. If ai-config renames AWS_REGION, this fails rather than
+	// the form quietly showing an editable box for a shadowed field.
+	test('every variable named as an override really does reach the resolved catalog', async () => {
+		writeConfig(configPath, {});
+		await initProviderCatalog(context, {
+			configPath,
+			envVars: { AWS_PROFILE: 'ci-runner', AWS_REGION: 'us-east-2' },
+		});
+
+		const overrides = bedrockSource()?.overrides ?? {};
+		const resolved = getCachedProvider(PROVIDER_METADATA.amazonBedrock.catalogId!)?.connection.aws;
+		assert.deepStrictEqual(
+			{ profile: overrides.aws?.profile?.value, region: overrides.aws?.region?.value },
+			{ profile: resolved?.profile, region: resolved?.region },
+		);
 	});
 });

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -4051,6 +4051,13 @@ declare module 'positron' {
 			 */
 			customModels?: LanguageModelCustomModel[];
 			autoconfigure?: LanguageModelAutoconfigure;
+			/**
+			 * AWS profile and region for a provider authenticating through the
+			 * AWS credential chain. Both are optional; an omitted field falls
+			 * back to the ambient AWS configuration. An empty string means the
+			 * user cleared the field and any saved value should be removed.
+			 */
+			aws?: { profile?: string; region?: string };
 		}
 
 		/**

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -3997,6 +3997,43 @@ declare module 'positron' {
 		}
 
 		/**
+		 * Why a field cannot be set in the configuration form, and what value
+		 * applies instead. Today this is always an environment variable, which
+		 * ai-config ranks above the user's configuration file.
+		 *
+		 * Deliberately not part of `LanguageModelConfig`: that type is
+		 * bidirectional (it arrives as `defaults` and is submitted back on
+		 * save), and this is an inbound-only fact about the environment.
+		 */
+		export interface LanguageModelFieldOverride {
+			/** The value in effect, shown in place of the user's saved value. */
+			readonly value: string;
+			/**
+			 * Name of the environment variable supplying the value, e.g.
+			 * `AWS_REGION`, so the form can say what to change instead. Omit when
+			 * there is no single name to give.
+			 */
+			readonly name?: string;
+		}
+
+		/**
+		 * Which of a provider's form fields are supplied by a higher-precedence
+		 * layer, shaped to mirror `LanguageModelConfig` with each value replaced
+		 * by the reason it cannot be set.
+		 *
+		 * Only the fields something can actually take over appear, rather than
+		 * every config key.
+		 */
+		export interface LanguageModelFieldOverrides {
+			baseUrl?: LanguageModelFieldOverride;
+			apiKey?: LanguageModelFieldOverride;
+			aws?: {
+				profile?: LanguageModelFieldOverride;
+				region?: LanguageModelFieldOverride;
+			};
+		}
+
+		/**
 		 * Positron Language Model source, used for user configuration of language models.
 		 */
 		export interface LanguageModelSource {
@@ -4006,6 +4043,11 @@ declare module 'positron' {
 				[K in keyof LanguageModelConfig]: undefined extends LanguageModelConfig[K] ? K : never
 			}[keyof LanguageModelConfig], undefined>[];
 			defaults: LanguageModelConfig;
+			/**
+			 * Fields the user cannot set here because a higher-precedence config
+			 * layer supplies them. Absent when every supported field is editable.
+			 */
+			overrides?: LanguageModelFieldOverrides;
 			signedIn?: boolean;
 			authMethods?: string[];
 			/**

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.css
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.css
@@ -95,6 +95,16 @@
 	color: var(--vscode-charts-red);
 }
 
+/*
+ * The read-only detail rows, grouped so the whole set can be omitted when a
+ * provider has none.
+ */
+.connect-provider-details {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
 .connect-provider-detail {
 	display: flex;
 	flex-direction: column;
@@ -158,6 +168,18 @@
 }
 
 .connect-provider-notice {
+	font-size: 12px;
+	color: var(--vscode-descriptionForeground);
+}
+
+.connect-provider-aws {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.connect-provider-aws-hint {
+	margin: 0;
 	font-size: 12px;
 	color: var(--vscode-descriptionForeground);
 }

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.css
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.css
@@ -172,16 +172,59 @@
 	color: var(--vscode-descriptionForeground);
 }
 
+/*
+ * More than one field, so this needs a tier above a single-field group: the
+ * looser gap separates one field from the next, while each field closes up
+ * around its own label and override note.
+ */
 .connect-provider-aws {
 	display: flex;
 	flex-direction: column;
-	gap: 6px;
+	gap: 12px;
+}
+
+/* Matches .connect-provider-apikey, the single-field group elsewhere in the form. */
+.connect-provider-aws-field {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
 }
 
 .connect-provider-aws-hint {
 	margin: 0;
 	font-size: 12px;
 	color: var(--vscode-descriptionForeground);
+}
+
+/*
+ * A field the environment supplies. Dimmed to read as not-editable while
+ * staying legible, and selectable: the input is `readOnly`, not `disabled`, so
+ * the value in effect can be focused, announced, and copied.
+ */
+.connect-provider-apikey-input[readonly] {
+	color: var(--vscode-descriptionForeground);
+	background-color: var(--vscode-editorWidget-background);
+}
+
+.connect-provider-apikey-input[readonly]:focus {
+	outline-color: var(--vscode-descriptionForeground);
+}
+
+.connect-provider-field-override {
+	margin: 0;
+	font-size: 12px;
+	color: var(--vscode-descriptionForeground);
+}
+
+/*
+ * The shadowed value inside that note. Monospace so an arbitrary string reads
+ * as a value rather than running into the prose around it; sized down from the
+ * inherited 12px, since monospace runs visually larger at the same point size.
+ */
+.connect-provider-override-value {
+	font-family: var(--monaco-monospace-font);
+	font-size: 11px;
+	word-break: break-all;
 }
 
 .connect-provider-models {

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
@@ -93,11 +93,14 @@ export const ConnectProviderView = (props: ConnectProviderViewProps) => {
 	const [errorMessage, setErrorMessage] = useState<string>();
 	const [apiKey, setApiKey] = useState<string>(() => props.source.defaults.apiKey ?? '');
 	const [baseUrl, setBaseUrl] = useState<string>(() => props.source.defaults.baseUrl ?? '');
+	const [awsProfile, setAwsProfile] = useState<string>(() => props.source.defaults.aws?.profile ?? '');
+	const [awsRegion, setAwsRegion] = useState<string>(() => props.source.defaults.aws?.region ?? '');
 	const [protocol, setProtocol] = useState<string>(() => props.source.defaults.protocol ?? API_TYPE_CHAT);
 	const [modelIds, setModelIds] = useState<string[]>(() => props.source.defaults.customModels?.map(m => m.id) ?? ['']);
 	const supportsBaseUrl = props.source.supportedOptions.includes('baseUrl');
 	const supportsProtocol = props.source.supportedOptions.includes('protocol');
 	const supportsCustomModels = props.source.supportedOptions.includes('customModels');
+	const supportsAws = props.source.supportedOptions.includes('aws');
 
 	// Build schema-valid custom model entries from the entered ids, defaulting
 	// the capability fields the user didn't specify.
@@ -134,6 +137,11 @@ export const ConnectProviderView = (props: ConnectProviderViewProps) => {
 				...(supportsBaseUrl ? { baseUrl } : {}),
 				...(supportsProtocol ? { protocol } : {}),
 				...(supportsCustomModels ? { customModels } : {}),
+				// Both fields are always submitted, empty included: an empty box
+				// means "remove this saved value". Safe because the boxes are
+				// pre-filled from providers.json alone, so submitting them back
+				// can only ever write what the user set or cleared here.
+				...(supportsAws ? { aws: { profile: awsProfile.trim(), region: awsRegion.trim() } } : {}),
 			};
 			await props.onAction(props.source, dispatchConfig, deriveConnectAction(props.source, selectedMethod));
 		} catch (e) {
@@ -252,6 +260,37 @@ export const ConnectProviderView = (props: ConnectProviderViewProps) => {
 							</>
 						}
 					</ProviderConnectionFields>
+					{supportsAws &&
+						<div className='connect-provider-aws'>
+							<label className='connect-provider-apikey-label' htmlFor='connect-provider-aws-profile-input'>
+								{localize('positron.connectProvider.awsProfileLabel', "AWS Profile")}
+							</label>
+							<input
+								autoComplete='off'
+								className='connect-provider-apikey-input'
+								id='connect-provider-aws-profile-input'
+								spellCheck={false}
+								type='text'
+								value={awsProfile}
+								onChange={e => setAwsProfile(e.target.value)}
+							/>
+							<label className='connect-provider-apikey-label' htmlFor='connect-provider-aws-region-input'>
+								{localize('positron.connectProvider.awsRegionLabel', "AWS Region")}
+							</label>
+							<input
+								autoComplete='off'
+								className='connect-provider-apikey-input'
+								id='connect-provider-aws-region-input'
+								spellCheck={false}
+								type='text'
+								value={awsRegion}
+								onChange={e => setAwsRegion(e.target.value)}
+							/>
+							<p className='connect-provider-aws-hint'>
+								{localize('positron.connectProvider.awsHint', "Leave blank to use the AWS_PROFILE and AWS_REGION environment variables, or your AWS defaults. When set, environment variables take precedence over the values here.")}
+							</p>
+						</div>
+					}
 					{supportsCustomModels &&
 						<ProviderModelsSection
 							modelIds={modelIds}

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
@@ -385,21 +385,6 @@ export const ConnectProviderView = (props: ConnectProviderViewProps) => {
 								value={awsRegion}
 								onChange={setAwsRegion}
 							/>
-							{/* Only describes the boxes the user can still fill in. With
-								both editable neither variable is set, so naming them is
-								both accurate and the only place they're discoverable;
-								with one overridden its own note already names it, and
-								repeating the pair here would imply the set one is still
-								a fallback. With neither editable there is nothing to
-								leave blank, so the hint goes away entirely -- the
-								per-field notes carry the whole story. */}
-							{/* {(!awsProfileOverride || !awsRegionOverride) &&
-								<p className='connect-provider-aws-hint'>
-									{!awsProfileOverride && !awsRegionOverride
-										? localize('positron.connectProvider.awsHint', "Leave blank to use the AWS_PROFILE and AWS_REGION environment variables, or your AWS defaults.")
-										: localize('positron.connectProvider.awsHintDefaults', "Leave blank to use your AWS defaults.")}
-								</p>
-							} */}
 						</div>
 					}
 					{supportsCustomModels &&

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
@@ -9,7 +9,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import { localize } from '../../../../../nls.js';
 import { EmbeddedLink } from '../../../../../base/browser/ui/positronComponents/embeddedLink/EmbeddedLink.js';
-import { IPositronCustomModel, IPositronLanguageModelConfig, IPositronLanguageModelSource } from '../../common/interfaces/positronAssistantService.js';
+import { IPositronCustomModel, IPositronLanguageModelConfig, IPositronLanguageModelFieldOverride, IPositronLanguageModelSource } from '../../common/interfaces/positronAssistantService.js';
 import { AuthMethod, AuthStatus } from '../types.js';
 import { availableAuthMethods, deriveAuthMethod, deriveAuthStatus, deriveConnectAction } from '../providerConnection.js';
 import { getProviderGettingStartedText } from '../providerLegalText.js';
@@ -64,6 +64,88 @@ const CUSTOM_MODEL_DEFAULTS = {
 	supportsWebSearch: false,
 } satisfies Omit<IPositronCustomModel, 'id' | 'name'>;
 
+/** Props for {@link AwsField}. */
+interface AwsFieldProps {
+	/** Input element id, tied to the label and used by tests. */
+	id: string;
+	label: string;
+	/** `data-testid` for the override note, so a test can read the message. */
+	noteTestId: string;
+	/** The value saved in providers.json, shown when the field is editable. */
+	value: string;
+	/**
+	 * What AWS falls back to when the box is left empty. Not localized: it is an
+	 * identifier AWS matches literally, not prose. Never visible while the field
+	 * is overridden, since the box then holds the value in effect.
+	 */
+	placeholder?: string;
+	/** Set when a higher-precedence layer supplies the field; makes it read-only. */
+	override: IPositronLanguageModelFieldOverride | undefined;
+	onChange: (value: string) => void;
+}
+
+/**
+ * One AWS credential-chain input.
+ *
+ * When the environment supplies the field, the box shows the value in effect
+ * instead of the saved one and a note names the variable and how to get the
+ * saved value back. The input is kept rather than swapped for a plain value row
+ * because the removed affordance is the message: this is the field you would
+ * normally edit, and here is what took it over. Keeping it also holds the
+ * form's shape steady across launches instead of reflowing based on the user's
+ * shell.
+ *
+ * `readOnly` rather than `disabled`: a read-only input stays focusable and
+ * announced by a screen reader, and its text can be selected and copied --
+ * which matters for a value the user may want to paste into an AWS CLI call.
+ */
+const AwsField = (props: AwsFieldProps) => {
+	const override = props.override;
+	// A saved value only worth mentioning when something is standing over it.
+	const shadowedSavedValue = override ? props.value : '';
+	const source = override?.name
+		?? localize('positron.connectProvider.overrideSourceEnv', "an environment variable");
+
+	return (
+		// Grouped rather than returned as a fragment: as direct children of the
+		// section, a label sat no closer to its own input than to the next
+		// field's label, so nothing read as belonging together.
+		<div className='connect-provider-aws-field'>
+			<label className='connect-provider-apikey-label' htmlFor={props.id}>
+				{props.label}
+			</label>
+			<input
+				autoComplete='off'
+				className='connect-provider-apikey-input'
+				id={props.id}
+				placeholder={props.placeholder}
+				readOnly={!!override}
+				spellCheck={false}
+				type='text'
+				value={override?.value ?? props.value}
+				onChange={e => props.onChange(e.target.value)}
+			/>
+			{override &&
+				<p className='connect-provider-field-override' data-testid={props.noteTestId}>
+					{shadowedSavedValue
+						// The shadowed value is arbitrary user text, so it ends the
+						// note as a monospace element rather than being interpolated:
+						// "your saved value claude" gives no clue where the prose
+						// stops and the value starts. The variable name stays
+						// interpolated -- SCREAMING_CASE already reads as an
+						// identifier.
+						? <>
+							{localize('positron.connectProvider.usingEnvVarWithSaved', "Using {0}. Unset it to use your saved value:", source)}
+							{' '}
+							<code className='connect-provider-override-value'>{shadowedSavedValue}</code>
+						</>
+						: localize('positron.connectProvider.usingEnvVar', "Using {0}.", source)}
+				</p>
+			}
+		</div>
+	);
+};
+
 export interface ConnectProviderViewProps {
 	/** The renderer this view draws its dialog box into. */
 	renderer: PositronModalReactRenderer;
@@ -101,6 +183,10 @@ export const ConnectProviderView = (props: ConnectProviderViewProps) => {
 	const supportsProtocol = props.source.supportedOptions.includes('protocol');
 	const supportsCustomModels = props.source.supportedOptions.includes('customModels');
 	const supportsAws = props.source.supportedOptions.includes('aws');
+	// Environment variables outrank providers.json in ai-config's precedence
+	// stack, so a field named here is not something this form can set.
+	const awsProfileOverride = props.source.overrides?.aws?.profile;
+	const awsRegionOverride = props.source.overrides?.aws?.region;
 
 	// Build schema-valid custom model entries from the entered ids, defaulting
 	// the capability fields the user didn't specify.
@@ -127,6 +213,21 @@ export const ConnectProviderView = (props: ConnectProviderViewProps) => {
 	const authMethod = deriveAuthMethod(props.source, selectedMethod);
 	const authStatus = deriveAuthStatus(props.source, { showProgress: inFlight, apiKey, selected: selectedMethod });
 
+	// Editable AWS fields, empty boxes included: an empty box means "remove this
+	// saved value". Safe because the boxes are pre-filled from providers.json
+	// alone, so submitting them back can only ever write what the user set or
+	// cleared here.
+	//
+	// An overridden field is omitted rather than submitted, which the save
+	// helper reads as "leave alone". Submitting its displayed value would
+	// persist an environment variable that may not be set next launch, and
+	// submitting an empty string would delete whatever the user saved
+	// underneath it. With both overridden this is empty: nothing to write.
+	const awsToSave = {
+		...(supportsAws && !awsProfileOverride ? { profile: awsProfile.trim() } : {}),
+		...(supportsAws && !awsRegionOverride ? { region: awsRegion.trim() } : {}),
+	};
+
 	const onConnect = async () => {
 		setPending('connect');
 		setErrorMessage(undefined);
@@ -137,11 +238,11 @@ export const ConnectProviderView = (props: ConnectProviderViewProps) => {
 				...(supportsBaseUrl ? { baseUrl } : {}),
 				...(supportsProtocol ? { protocol } : {}),
 				...(supportsCustomModels ? { customModels } : {}),
-				// Both fields are always submitted, empty included: an empty box
-				// means "remove this saved value". Safe because the boxes are
-				// pre-filled from providers.json alone, so submitting them back
-				// can only ever write what the user set or cleared here.
-				...(supportsAws ? { aws: { profile: awsProfile.trim(), region: awsRegion.trim() } } : {}),
+				// Rebuilt rather than inherited: `defaults.aws` carries the saved
+				// values, and an overridden field must not ride along in the
+				// spread above. Empty when the environment supplies both, which
+				// the save handler reads as nothing to write.
+				...(supportsAws ? { aws: awsToSave } : {}),
 			};
 			await props.onAction(props.source, dispatchConfig, deriveConnectAction(props.source, selectedMethod));
 		} catch (e) {
@@ -262,33 +363,43 @@ export const ConnectProviderView = (props: ConnectProviderViewProps) => {
 					</ProviderConnectionFields>
 					{supportsAws &&
 						<div className='connect-provider-aws'>
-							<label className='connect-provider-apikey-label' htmlFor='connect-provider-aws-profile-input'>
-								{localize('positron.connectProvider.awsProfileLabel', "AWS Profile")}
-							</label>
-							<input
-								autoComplete='off'
-								className='connect-provider-apikey-input'
+							<AwsField
 								id='connect-provider-aws-profile-input'
-								spellCheck={false}
-								type='text'
+								label={localize('positron.connectProvider.awsProfileLabel', "AWS Profile")}
+								noteTestId='aws-profile-override'
+								override={awsProfileOverride}
+								// The profile AWS looks for in ~/.aws/config when none is
+								// given. A fixed convention, unlike the region, which has no
+								// default worth promising. Only what AWS *looks for*, not a
+								// guarantee: the credential chain tries environment keys
+								// first and may never read a profile at all.
+								placeholder='default'
 								value={awsProfile}
-								onChange={e => setAwsProfile(e.target.value)}
+								onChange={setAwsProfile}
 							/>
-							<label className='connect-provider-apikey-label' htmlFor='connect-provider-aws-region-input'>
-								{localize('positron.connectProvider.awsRegionLabel', "AWS Region")}
-							</label>
-							<input
-								autoComplete='off'
-								className='connect-provider-apikey-input'
+							<AwsField
 								id='connect-provider-aws-region-input'
-								spellCheck={false}
-								type='text'
+								label={localize('positron.connectProvider.awsRegionLabel', "AWS Region")}
+								noteTestId='aws-region-override'
+								override={awsRegionOverride}
 								value={awsRegion}
-								onChange={e => setAwsRegion(e.target.value)}
+								onChange={setAwsRegion}
 							/>
-							<p className='connect-provider-aws-hint'>
-								{localize('positron.connectProvider.awsHint', "Leave blank to use the AWS_PROFILE and AWS_REGION environment variables, or your AWS defaults. When set, environment variables take precedence over the values here.")}
-							</p>
+							{/* Only describes the boxes the user can still fill in. With
+								both editable neither variable is set, so naming them is
+								both accurate and the only place they're discoverable;
+								with one overridden its own note already names it, and
+								repeating the pair here would imply the set one is still
+								a fallback. With neither editable there is nothing to
+								leave blank, so the hint goes away entirely -- the
+								per-field notes carry the whole story. */}
+							{/* {(!awsProfileOverride || !awsRegionOverride) &&
+								<p className='connect-provider-aws-hint'>
+									{!awsProfileOverride && !awsRegionOverride
+										? localize('positron.connectProvider.awsHint', "Leave blank to use the AWS_PROFILE and AWS_REGION environment variables, or your AWS defaults.")
+										: localize('positron.connectProvider.awsHintDefaults', "Leave blank to use your AWS defaults.")}
+								</p>
+							} */}
 						</div>
 					}
 					{supportsCustomModels &&

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/connectedProviderView.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/connectedProviderView.tsx
@@ -19,6 +19,31 @@ import { ConnectProviderHeader, ProviderErrorBanner, ProviderNotice } from './co
 import { EditRawConfigLink } from './editRawConfigLink.js';
 import { ProviderModalFooter } from './providerModalFooter.js';
 
+/** Props for {@link DetailRow}. */
+interface DetailRowProps {
+	testId: string;
+	label: string;
+	value: string;
+	/**
+	 * Environment variable supplying the value, when one is. Named in the label
+	 * rather than on a line of its own: these rows are compact by design, and a
+	 * third line per row would treble the section's vertical weight.
+	 */
+	from?: string;
+}
+
+/** One read-only connection detail, with where the value came from if not the user. */
+const DetailRow = (props: DetailRowProps) => (
+	<div className='connect-provider-detail' data-testid={props.testId}>
+		<span className='connect-provider-detail-label'>
+			{props.from
+				? localize('positron.connectedProvider.labelFromEnv', "{0} (from {1})", props.label, props.from)
+				: props.label}
+		</span>
+		<span className='connect-provider-detail-value'>{props.value}</span>
+	</div>
+);
+
 export interface ConnectedProviderViewProps {
 	/** The renderer this view draws its dialog box into. */
 	renderer: PositronModalReactRenderer;
@@ -95,11 +120,21 @@ export const ConnectedProviderView = (props: ConnectedProviderViewProps) => {
 		? localize('positron.connectedProvider.signingOut', "Signing Out...")
 		: localize('positron.connectedProvider.disconnecting', "Disconnecting...");
 
-	// Which read-only detail rows this provider has a value for. Hoisted so the
-	// group wrapper can tell whether any row will render at all.
-	const showBaseUrl = current.supportedOptions.includes('baseUrl') && !!current.defaults.baseUrl;
-	const showAwsProfile = current.supportedOptions.includes('aws') && !!current.defaults.aws?.profile;
-	const showAwsRegion = current.supportedOptions.includes('aws') && !!current.defaults.aws?.region;
+	// The value each detail row reports: what the environment supplies if it
+	// does, otherwise what the user saved. `defaults` carries the user layer
+	// alone, so reading it by itself would show nothing for a provider whose
+	// values all come from the environment -- while the connect form for the
+	// same provider names them.
+	const overrides = current.overrides;
+	const baseUrlValue = overrides?.baseUrl?.value ?? current.defaults.baseUrl;
+	const awsProfileValue = overrides?.aws?.profile?.value ?? current.defaults.aws?.profile;
+	const awsRegionValue = overrides?.aws?.region?.value ?? current.defaults.aws?.region;
+
+	// Hoisted so the group wrapper can tell whether any row will render at all.
+	const supportsAws = current.supportedOptions.includes('aws');
+	const showBaseUrl = current.supportedOptions.includes('baseUrl') && !!baseUrlValue;
+	const showAwsProfile = supportsAws && !!awsProfileValue;
+	const showAwsRegion = supportsAws && !!awsRegionValue;
 	const hasDetails = showBaseUrl || showAwsProfile || showAwsRegion;
 
 	return (
@@ -115,34 +150,35 @@ export const ConnectedProviderView = (props: ConnectedProviderViewProps) => {
 					}
 					{/* Rendered only when there is something to show, since a flex gap
 						applies to an empty child too and would space the header off the
-						notice for every provider without details. AWS rows appear only when
-						saved in providers.json -- a value coming from AWS_PROFILE /
-						AWS_REGION is deliberately absent, matching the connect form. */}
+						notice for every provider without details. A row reports the value in
+						effect, naming the environment variable when that is where it came
+						from, so this view and the connect form agree on what the connection
+						is actually using. */}
 					{hasDetails &&
 						<div className='connect-provider-details' data-testid='provider-details'>
 							{showBaseUrl &&
-								<div className='connect-provider-detail' data-testid='provider-base-url'>
-									<span className='connect-provider-detail-label'>
-										{getBaseUrlLabel(current.provider.id)}
-									</span>
-									<span className='connect-provider-detail-value'>{current.defaults.baseUrl}</span>
-								</div>
+								<DetailRow
+									from={overrides?.baseUrl?.name}
+									label={getBaseUrlLabel(current.provider.id)}
+									testId='provider-base-url'
+									value={baseUrlValue!}
+								/>
 							}
 							{showAwsProfile &&
-								<div className='connect-provider-detail' data-testid='provider-aws-profile'>
-									<span className='connect-provider-detail-label'>
-										{localize('positron.connectedProvider.awsProfile', "AWS Profile")}
-									</span>
-									<span className='connect-provider-detail-value'>{current.defaults.aws?.profile}</span>
-								</div>
+								<DetailRow
+									from={overrides?.aws?.profile?.name}
+									label={localize('positron.connectedProvider.awsProfile', "AWS Profile")}
+									testId='provider-aws-profile'
+									value={awsProfileValue!}
+								/>
 							}
 							{showAwsRegion &&
-								<div className='connect-provider-detail' data-testid='provider-aws-region'>
-									<span className='connect-provider-detail-label'>
-										{localize('positron.connectedProvider.awsRegion', "AWS Region")}
-									</span>
-									<span className='connect-provider-detail-value'>{current.defaults.aws?.region}</span>
-								</div>
+								<DetailRow
+									from={overrides?.aws?.region?.name}
+									label={localize('positron.connectedProvider.awsRegion', "AWS Region")}
+									testId='provider-aws-region'
+									value={awsRegionValue!}
+								/>
 							}
 						</div>
 					}

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/connectedProviderView.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/connectedProviderView.tsx
@@ -95,6 +95,13 @@ export const ConnectedProviderView = (props: ConnectedProviderViewProps) => {
 		? localize('positron.connectedProvider.signingOut', "Signing Out...")
 		: localize('positron.connectedProvider.disconnecting', "Disconnecting...");
 
+	// Which read-only detail rows this provider has a value for. Hoisted so the
+	// group wrapper can tell whether any row will render at all.
+	const showBaseUrl = current.supportedOptions.includes('baseUrl') && !!current.defaults.baseUrl;
+	const showAwsProfile = current.supportedOptions.includes('aws') && !!current.defaults.aws?.profile;
+	const showAwsRegion = current.supportedOptions.includes('aws') && !!current.defaults.aws?.region;
+	const hasDetails = showBaseUrl || showAwsProfile || showAwsRegion;
+
 	return (
 		<PositronDynamicModalDialog
 			content={
@@ -106,13 +113,38 @@ export const ConnectedProviderView = (props: ConnectedProviderViewProps) => {
 							{localize('positron.connectedProvider.copilotSignOut', "To sign out of GitHub, use the [Accounts: Manage Accounts]({0}) command. This signs you out of GitHub for every extension in Positron.", 'command:workbench.action.manageAccounts')}
 						</EmbeddedLink>
 					}
-					{current.supportedOptions.includes('baseUrl') && current.defaults.baseUrl &&
-						<p className='connect-provider-detail' data-testid='provider-base-url'>
-							<span className='connect-provider-detail-label'>
-								{getBaseUrlLabel(current.provider.id)}
-							</span>
-							<span className='connect-provider-detail-value'>{current.defaults.baseUrl}</span>
-						</p>
+					{/* Rendered only when there is something to show, since a flex gap
+						applies to an empty child too and would space the header off the
+						notice for every provider without details. AWS rows appear only when
+						saved in providers.json -- a value coming from AWS_PROFILE /
+						AWS_REGION is deliberately absent, matching the connect form. */}
+					{hasDetails &&
+						<div className='connect-provider-details' data-testid='provider-details'>
+							{showBaseUrl &&
+								<div className='connect-provider-detail' data-testid='provider-base-url'>
+									<span className='connect-provider-detail-label'>
+										{getBaseUrlLabel(current.provider.id)}
+									</span>
+									<span className='connect-provider-detail-value'>{current.defaults.baseUrl}</span>
+								</div>
+							}
+							{showAwsProfile &&
+								<div className='connect-provider-detail' data-testid='provider-aws-profile'>
+									<span className='connect-provider-detail-label'>
+										{localize('positron.connectedProvider.awsProfile', "AWS Profile")}
+									</span>
+									<span className='connect-provider-detail-value'>{current.defaults.aws?.profile}</span>
+								</div>
+							}
+							{showAwsRegion &&
+								<div className='connect-provider-detail' data-testid='provider-aws-region'>
+									<span className='connect-provider-detail-label'>
+										{localize('positron.connectedProvider.awsRegion', "AWS Region")}
+									</span>
+									<span className='connect-provider-detail-value'>{current.defaults.aws?.region}</span>
+								</div>
+							}
+						</div>
 					}
 					<EditRawConfigLink onClick={props.onEditRawConfig} />
 					<ProviderNotice source={current} />

--- a/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
@@ -178,6 +178,13 @@ export interface IPositronLanguageModelConfig {
 	 */
 	customModels?: IPositronCustomModel[];
 	autoconfigure?: IPositronLanguageModelAutoconfigure;
+	/**
+	 * AWS profile and region for a provider authenticating through the AWS
+	 * credential chain. Both optional: an omitted field falls back to the
+	 * ambient AWS configuration, and an empty string means the user cleared the
+	 * box and any saved value should be removed.
+	 */
+	aws?: { profile?: string; region?: string };
 }
 
 // Equivalent in positron.d.ts API: ShowLanguageModelConfigOptions

--- a/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
@@ -65,6 +65,49 @@ export type PositronLanguageModelOptions = Exclude<{
 }[keyof IPositronLanguageModelConfig], undefined>;
 
 /**
+ * Why a field cannot be set in the configuration form, and what value applies
+ * instead. Today this is always an environment variable, which ai-config ranks
+ * above the user's configuration file.
+ *
+ * Deliberately not part of {@link IPositronLanguageModelConfig}: that type is
+ * bidirectional (it arrives as `defaults` and is submitted back on save), and
+ * this is an inbound-only fact about the environment the UI does not own.
+ */
+export interface IPositronLanguageModelFieldOverride {
+	/** The value in effect, shown in place of the user's saved value. */
+	readonly value: string;
+	/**
+	 * Name of the environment variable supplying the value, e.g. `AWS_REGION`,
+	 * so the form can say what to change instead. Omit when there is no single
+	 * name to give.
+	 */
+	readonly name?: string;
+}
+
+/**
+ * Which of a provider's form fields are supplied by a higher-precedence layer,
+ * shaped to mirror {@link IPositronLanguageModelConfig} with each value
+ * replaced by the reason it cannot be set.
+ *
+ * Only the fields that something can actually take over appear -- a mechanical
+ * mirror of the whole config would advertise override slots for `model`,
+ * `toolCalls` and the rest, which nothing supplies.
+ *
+ * Mirroring the *form's* config type rather than the on-disk one is deliberate:
+ * Databricks and Snowflake carry their value through the base URL input while
+ * persisting elsewhere, so an override for either belongs on `baseUrl` -- the
+ * input the user is actually looking at.
+ */
+export interface IPositronLanguageModelFieldOverrides {
+	baseUrl?: IPositronLanguageModelFieldOverride;
+	apiKey?: IPositronLanguageModelFieldOverride;
+	aws?: {
+		profile?: IPositronLanguageModelFieldOverride;
+		region?: IPositronLanguageModelFieldOverride;
+	};
+}
+
+/**
  * Metadata about a language model provider used for configuration.
  * Registered during extension activation, independent of sign-in state.
  */
@@ -107,6 +150,11 @@ export interface IPositronLanguageModelSource {
 	provider: IPositronProviderMetadata;
 	supportedOptions: PositronLanguageModelOptions[];
 	defaults: IPositronLanguageModelConfig;
+	/**
+	 * Fields the user cannot set here because a higher-precedence config layer
+	 * supplies them. Absent when every supported field is editable.
+	 */
+	overrides?: IPositronLanguageModelFieldOverrides;
 	signedIn?: boolean;
 	authMethods?: string[];
 	status?: 'ok' | 'error' | null;

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/connectProviderView.vitest.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/connectProviderView.vitest.tsx
@@ -63,6 +63,16 @@ const databricksOAuth: IPositronLanguageModelSource = {
 };
 
 
+// Bedrock authenticates through the AWS credential chain -- no API key, no base
+// URL -- so the only inputs are the optional profile and region.
+const bedrock: IPositronLanguageModelSource = {
+	type: PositronLanguageModelType.Chat,
+	provider: { id: 'amazon-bedrock', displayName: 'Amazon Bedrock' },
+	supportedOptions: ['toolCalls', 'aws'],
+	signedIn: false,
+	defaults: { aws: { profile: 'data-team', region: 'eu-west-1' } },
+};
+
 const custom: IPositronLanguageModelSource = {
 	type: PositronLanguageModelType.Chat,
 	provider: { id: 'openai-compatible', displayName: 'OpenAI Compatible', settingName: 'openai-compatible' },
@@ -399,6 +409,57 @@ describe('ConnectProviderView', () => {
 			expect(screen.getByRole('radio', { name: 'OAuth' })).toBeDisabled();
 			expect(screen.getByRole('radio', { name: 'API Key' })).toBeDisabled();
 			await act(async () => { resolveSignIn(); });
+		});
+	});
+
+	describe('AWS profile and region', () => {
+		it('renders both inputs prefilled from the saved values, with the precedence hint', () => {
+			rtl.render(<ConnectProviderView {...dialogProps()} source={bedrock} onAction={async () => { }} onBack={vi.fn()} />);
+			expect(screen.getByLabelText(/aws profile/i)).toHaveValue('data-team');
+			expect(screen.getByLabelText(/aws region/i)).toHaveValue('eu-west-1');
+			expect(screen.getByText(/take precedence over the values here/)).toBeInTheDocument();
+		});
+
+		it('renders neither input for a provider that does not support them', () => {
+			rtl.render(<ConnectProviderView {...dialogProps()} source={anthropic} onAction={async () => { }} onBack={vi.fn()} />);
+			expect(screen.queryByLabelText(/aws profile/i)).not.toBeInTheDocument();
+			expect(screen.queryByLabelText(/aws region/i)).not.toBeInTheDocument();
+		});
+
+		it('leaves Connect enabled with both boxes empty, since both fields are optional', async () => {
+			const user = userEvent.setup();
+			rtl.render(<ConnectProviderView {...dialogProps()} source={bedrock} onAction={async () => { }} onBack={vi.fn()} />);
+			await user.clear(screen.getByLabelText(/aws profile/i));
+			await user.clear(screen.getByLabelText(/aws region/i));
+			expect(screen.getByRole('button', { name: 'Connect' })).toBeEnabled();
+		});
+
+		it('dispatches edited values, trimmed', async () => {
+			const onAction = vi.fn().mockResolvedValue(undefined);
+			const user = userEvent.setup();
+			rtl.render(<ConnectProviderView {...dialogProps()} source={bedrock} onAction={onAction} onBack={vi.fn()} />);
+			const region = screen.getByLabelText(/aws region/i);
+			await user.clear(region);
+			await user.type(region, '  us-west-2  ');
+			await user.click(screen.getByRole('button', { name: 'Connect' }));
+			expect(onAction).toHaveBeenCalledWith(
+				bedrock,
+				expect.objectContaining({ aws: { profile: 'data-team', region: 'us-west-2' } }),
+				'save',
+			);
+		});
+
+		it('dispatches an emptied box as an empty string, the signal to remove the saved value', async () => {
+			const onAction = vi.fn().mockResolvedValue(undefined);
+			const user = userEvent.setup();
+			rtl.render(<ConnectProviderView {...dialogProps()} source={bedrock} onAction={onAction} onBack={vi.fn()} />);
+			await user.clear(screen.getByLabelText(/aws profile/i));
+			await user.click(screen.getByRole('button', { name: 'Connect' }));
+			expect(onAction).toHaveBeenCalledWith(
+				bedrock,
+				expect.objectContaining({ aws: { profile: '', region: 'eu-west-1' } }),
+				'save',
+			);
 		});
 	});
 });

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/connectProviderView.vitest.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/connectProviderView.vitest.tsx
@@ -73,6 +73,23 @@ const bedrock: IPositronLanguageModelSource = {
 	defaults: { aws: { profile: 'data-team', region: 'eu-west-1' } },
 };
 
+// AWS_REGION set in the extension host's environment, which outranks
+// providers.json -- so the region box is not something this form can set.
+const bedrockRegionFromEnv: IPositronLanguageModelSource = {
+	...bedrock,
+	overrides: { aws: { region: { value: 'us-east-2', name: 'AWS_REGION' } } },
+};
+
+const bedrockBothFromEnv: IPositronLanguageModelSource = {
+	...bedrock,
+	overrides: {
+		aws: {
+			profile: { value: 'ci-runner', name: 'AWS_PROFILE' },
+			region: { value: 'us-east-2', name: 'AWS_REGION' },
+		},
+	},
+};
+
 const custom: IPositronLanguageModelSource = {
 	type: PositronLanguageModelType.Chat,
 	provider: { id: 'openai-compatible', displayName: 'OpenAI Compatible', settingName: 'openai-compatible' },
@@ -413,11 +430,19 @@ describe('ConnectProviderView', () => {
 	});
 
 	describe('AWS profile and region', () => {
-		it('renders both inputs prefilled from the saved values, with the precedence hint', () => {
+		it('renders both inputs prefilled from the saved values', () => {
 			rtl.render(<ConnectProviderView {...dialogProps()} source={bedrock} onAction={async () => { }} onBack={vi.fn()} />);
 			expect(screen.getByLabelText(/aws profile/i)).toHaveValue('data-team');
 			expect(screen.getByLabelText(/aws region/i)).toHaveValue('eu-west-1');
-			expect(screen.getByText(/take precedence over the values here/)).toBeInTheDocument();
+		});
+
+		// Profile only: `default` is what AWS looks for when none is given, a fixed
+		// convention. The region has no equivalent worth promising, so its box
+		// stays bare rather than suggesting a value that may not apply.
+		it('hints the profile AWS falls back to, and hints nothing for the region', () => {
+			rtl.render(<ConnectProviderView {...dialogProps()} source={bedrock} onAction={async () => { }} onBack={vi.fn()} />);
+			expect(screen.getByLabelText(/aws profile/i)).toHaveAttribute('placeholder', 'default');
+			expect(screen.getByLabelText(/aws region/i)).not.toHaveAttribute('placeholder');
 		});
 
 		it('renders neither input for a provider that does not support them', () => {
@@ -460,6 +485,94 @@ describe('ConnectProviderView', () => {
 				expect.objectContaining({ aws: { profile: '', region: 'eu-west-1' } }),
 				'save',
 			);
+		});
+
+		describe('a field the environment overrides', () => {
+			it('shows the value in effect read-only, naming the variable and the value it shadows', () => {
+				rtl.render(<ConnectProviderView {...dialogProps()} source={bedrockRegionFromEnv} onAction={async () => { }} onBack={vi.fn()} />);
+				const region = screen.getByLabelText(/aws region/i);
+				expect(region).toHaveValue('us-east-2');
+				expect(region).toHaveAttribute('readonly');
+				expect(screen.getByTestId('aws-region-override')).toHaveTextContent(
+					'Using AWS_REGION. Unset it to use your saved value: eu-west-1'
+				);
+				// The shadowed value carries its own monospace element rather than
+				// being interpolated into the sentence, so it can't be mistaken for
+				// prose. `eu-west-1` is text only here -- the inputs hold it as a
+				// value, which getByText does not match.
+				expect(screen.getByText('eu-west-1')).toHaveClass('connect-provider-override-value');
+			});
+
+			it('omits the shadowed-value clause when the user has nothing saved underneath', () => {
+				const source: IPositronLanguageModelSource = {
+					...bedrockRegionFromEnv,
+					defaults: { aws: { profile: 'data-team' } },
+				};
+				rtl.render(<ConnectProviderView {...dialogProps()} source={source} onAction={async () => { }} onBack={vi.fn()} />);
+				expect(screen.getByTestId('aws-region-override')).toHaveTextContent(/^Using AWS_REGION\.$/);
+			});
+
+			it('names the layer generically when the override carries no variable name', () => {
+				const source: IPositronLanguageModelSource = {
+					...bedrock,
+					defaults: { aws: {} },
+					overrides: { aws: { region: { value: 'us-east-2' } } },
+				};
+				rtl.render(<ConnectProviderView {...dialogProps()} source={source} onAction={async () => { }} onBack={vi.fn()} />);
+				expect(screen.getByTestId('aws-region-override')).toHaveTextContent(/^Using an environment variable\.$/);
+			});
+
+			it('leaves the sibling field editable and unannotated', () => {
+				rtl.render(<ConnectProviderView {...dialogProps()} source={bedrockRegionFromEnv} onAction={async () => { }} onBack={vi.fn()} />);
+				expect(screen.getByLabelText(/aws profile/i)).not.toHaveAttribute('readonly');
+				expect(screen.queryByTestId('aws-profile-override')).not.toBeInTheDocument();
+			});
+
+			// Submitting the displayed value would persist a variable that may not
+			// be set next launch; submitting an empty string would delete what the
+			// user saved under it. Omitting the key leaves the saved value alone.
+			it('is left out of the dispatch while the editable sibling is submitted', async () => {
+				const onAction = vi.fn().mockResolvedValue(undefined);
+				const user = userEvent.setup();
+				rtl.render(<ConnectProviderView {...dialogProps()} source={bedrockRegionFromEnv} onAction={onAction} onBack={vi.fn()} />);
+				await user.click(screen.getByRole('button', { name: 'Connect' }));
+				expect(onAction).toHaveBeenCalledWith(
+					bedrockRegionFromEnv,
+					expect.objectContaining({ aws: { profile: 'data-team' } }),
+					'save',
+				);
+			});
+
+			// Empty rather than the saved values inherited from `defaults`, so the
+			// save handler can tell "nothing editable was submitted" from "the
+			// user cleared these boxes" and skip the write entirely.
+			it('submits an empty aws block when neither field is editable', async () => {
+				const onAction = vi.fn().mockResolvedValue(undefined);
+				const user = userEvent.setup();
+				rtl.render(<ConnectProviderView {...dialogProps()} source={bedrockBothFromEnv} onAction={onAction} onBack={vi.fn()} />);
+				await user.click(screen.getByRole('button', { name: 'Connect' }));
+				expect(onAction).toHaveBeenCalledWith(
+					bedrockBothFromEnv,
+					expect.objectContaining({ aws: {} }),
+					'save',
+				);
+			});
+
+			// Parked: the hint paragraph these cover is commented out in
+			// connectProviderView.tsx pending a decision on whether to keep it.
+			// Re-enable both alongside uncommenting it -- the first is vacuous
+			// while nothing renders, and the second asserts the reduced wording.
+			it.skip('drops the hint when neither field is editable, since there is nothing to leave blank', () => {
+				rtl.render(<ConnectProviderView {...dialogProps()} source={bedrockBothFromEnv} onAction={async () => { }} onBack={vi.fn()} />);
+				expect(screen.queryByText(/Leave blank/)).not.toBeInTheDocument();
+			});
+
+			// With one variable set, naming the pair would imply the set one is
+			// still a fallback; its own note already names it.
+			it.skip('reduces the hint to the AWS defaults when one field is still editable', () => {
+				rtl.render(<ConnectProviderView {...dialogProps()} source={bedrockRegionFromEnv} onAction={async () => { }} onBack={vi.fn()} />);
+				expect(screen.getByText('Leave blank to use your AWS defaults.')).toBeInTheDocument();
+			});
 		});
 	});
 });

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/connectedProviderView.vitest.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/connectedProviderView.vitest.tsx
@@ -225,13 +225,45 @@ describe('ConnectedProviderView', () => {
 		expect(screen.getByText('eu-west-1')).toBeInTheDocument();
 	});
 
-	it('omits an AWS row that has no saved value', () => {
-		// Nothing in providers.json for either field -- an ambient AWS_REGION is
-		// deliberately not surfaced here, matching the connect form.
+	it('omits an AWS row that has no value from any layer', () => {
 		const noneSaved = { ...bedrock, defaults: { aws: {} } };
 		rtl.render(<ConnectedProviderView {...dialogProps()} source={noneSaved} onAction={async () => { }} onBack={vi.fn()} />);
 		expect(screen.queryByText(/AWS Profile/)).not.toBeInTheDocument();
 		expect(screen.queryByText(/AWS Region/)).not.toBeInTheDocument();
+	});
+
+	// `defaults` carries the user layer alone, so reading it by itself showed
+	// nothing for a value the environment supplies -- while the connect form for
+	// the same provider named it. These two views have to agree on what the
+	// connection is actually using.
+	it('shows an environment-supplied value the user never saved, naming the variable', () => {
+		const fromEnv = {
+			...bedrock,
+			defaults: { aws: {} },
+			overrides: { aws: { region: { value: 'us-east-2', name: 'AWS_REGION' } } },
+		};
+		rtl.render(<ConnectedProviderView {...dialogProps()} source={fromEnv} onAction={async () => { }} onBack={vi.fn()} />);
+		expect(screen.getByTestId('provider-aws-region')).toHaveTextContent('AWS Region (from AWS_REGION)');
+		expect(screen.getByText('us-east-2')).toBeInTheDocument();
+	});
+
+	it('prefers the environment value over the saved one, since that is what the connection uses', () => {
+		const shadowed = {
+			...bedrock,
+			overrides: { aws: { region: { value: 'us-east-2', name: 'AWS_REGION' } } },
+		};
+		rtl.render(<ConnectedProviderView {...dialogProps()} source={shadowed} onAction={async () => { }} onBack={vi.fn()} />);
+		expect(screen.getByTestId('provider-aws-region')).toHaveTextContent('us-east-2');
+		expect(screen.queryByText('eu-west-1')).not.toBeInTheDocument();
+	});
+
+	it('leaves a row the user owns unannotated', () => {
+		const shadowed = {
+			...bedrock,
+			overrides: { aws: { region: { value: 'us-east-2', name: 'AWS_REGION' } } },
+		};
+		rtl.render(<ConnectedProviderView {...dialogProps()} source={shadowed} onAction={async () => { }} onBack={vi.fn()} />);
+		expect(screen.getByTestId('provider-aws-profile')).toHaveTextContent(/^AWS Profiledata-team$/);
 	});
 
 	it('omits the AWS rows for a provider that does not support them', () => {

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/connectedProviderView.vitest.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/connectedProviderView.vitest.tsx
@@ -207,4 +207,52 @@ describe('ConnectedProviderView', () => {
 		expect(screen.getByText(/connected via oauth/i)).toBeInTheDocument();
 		expect(screen.getByRole('button', { name: 'Sign Out' })).toBeInTheDocument();
 	});
+
+	// A connected Bedrock provider is where most users land, since the AWS chain
+	// usually resolves at activation -- so the values the connect form collects
+	// have to be visible here rather than only behind Remove.
+	const bedrock: IPositronLanguageModelSource = {
+		type: PositronLanguageModelType.Chat,
+		provider: { id: 'amazon-bedrock', displayName: 'Amazon Bedrock' },
+		supportedOptions: ['toolCalls', 'aws'],
+		signedIn: true,
+		defaults: { aws: { profile: 'data-team', region: 'eu-west-1' } },
+	};
+
+	it('shows the saved AWS profile and region for a connected Bedrock provider', () => {
+		rtl.render(<ConnectedProviderView {...dialogProps()} source={bedrock} onAction={async () => { }} onBack={vi.fn()} />);
+		expect(screen.getByText('data-team')).toBeInTheDocument();
+		expect(screen.getByText('eu-west-1')).toBeInTheDocument();
+	});
+
+	it('omits an AWS row that has no saved value', () => {
+		// Nothing in providers.json for either field -- an ambient AWS_REGION is
+		// deliberately not surfaced here, matching the connect form.
+		const noneSaved = { ...bedrock, defaults: { aws: {} } };
+		rtl.render(<ConnectedProviderView {...dialogProps()} source={noneSaved} onAction={async () => { }} onBack={vi.fn()} />);
+		expect(screen.queryByText(/AWS Profile/)).not.toBeInTheDocument();
+		expect(screen.queryByText(/AWS Region/)).not.toBeInTheDocument();
+	});
+
+	it('omits the AWS rows for a provider that does not support them', () => {
+		rtl.render(<ConnectedProviderView {...dialogProps()} source={positAi} onAction={async () => { }} onBack={vi.fn()} />);
+		expect(screen.queryByText(/AWS Profile/)).not.toBeInTheDocument();
+	});
+
+	it('omits the detail group entirely when a provider has no details to show', () => {
+		// The group is a flex child of a container with a 16px gap, so rendering
+		// it empty would add that gap between the header and the notice for every
+		// provider without details -- Posit AI here has neither baseUrl nor aws.
+		rtl.render(<ConnectedProviderView {...dialogProps()} source={positAi} onAction={async () => { }} onBack={vi.fn()} />);
+		expect(screen.queryByTestId('provider-details')).not.toBeInTheDocument();
+	});
+
+	it('groups the rows together when a provider has more than one detail', () => {
+		const withBoth = { ...bedrock, supportedOptions: ['toolCalls', 'aws', 'baseUrl'] as typeof bedrock.supportedOptions, defaults: { baseUrl: 'https://bedrock.example.com', aws: { profile: 'data-team', region: 'eu-west-1' } } };
+		rtl.render(<ConnectedProviderView {...dialogProps()} source={withBoth} onAction={async () => { }} onBack={vi.fn()} />);
+		const group = screen.getByTestId('provider-details');
+		expect(group).toContainElement(screen.getByTestId('provider-base-url'));
+		expect(group).toContainElement(screen.getByTestId('provider-aws-profile'));
+		expect(group).toContainElement(screen.getByTestId('provider-aws-region'));
+	});
 });


### PR DESCRIPTION
Fixes #15697

### Summary

Adds AWS Profile and AWS Region inputs to the Bedrock connect dialog. Both are optional, both persist to `providers.json`, and clearing one removes it rather than storing an empty value.

The larger part of this PR is that **a field the environment supplies is no longer offered as an editable box**. `AWS_PROFILE` and `AWS_REGION` outrank the user file in ai-config's precedence stack (`env` is ranked above `user`), so before this change a user could type a profile, hit Connect, watch it save, and see no effect on the connection. Such a field now renders read-only showing the value in effect, with a note naming the variable and the saved value it stands over:

> Using `AWS_PROFILE`. Unset it to use your saved value: `claude`

Worth flagging for reviewers: this precedence direction contradicts what posit-dev/assistant#2180's description says ("Positron resolves the region from providers.json, then the `AWS_REGION` environment variable"). Verified against the resolver -- with both set, the environment wins.

#### Implementation notes

- **Detection is by presence, not by diffing.** Comparing the resolved catalog against the user layer looks equivalent but has a blind spot: when both layers hold the same value the diff is empty, so the box would stay editable and the next save would be silently discarded. Reading the environment variable directly has no such gap.

- **The env-var table is a reader, not enumeration overhead.** ai-config synthesizes its `env` layer privately inside `resolveProviderCatalogReport` and omits it from `loadConfigSources`, which returns only `user`, `enforced`, and `default`. The table in `providerCatalog.ts` is therefore the only faithful view of that layer. It mirrors the subset of ai-config's private `CONNECTION_ENV_MAPPINGS` whose fields the modal renders, keeping that table's nesting so the two can be compared by eye, and a test asserts behaviorally that every variable named in it really does reach the resolved catalog.

- **An overridden field is omitted from the submitted config**, which the save helper's existing three-state contract reads as "leave alone". Submitting the displayed value would persist a variable that may not be set next launch; submitting an empty string would delete whatever the user saved underneath it.

- **`overrides` is a parallel tree, not wrapped values.** It hangs off `LanguageModelSource` rather than `LanguageModelConfig` because that config type is bidirectional -- it arrives as `defaults` and is submitted back on save -- and provenance is an inbound-only fact the UI does not own. Keeping it a sibling tree also follows ai-config's own reasoning for `ResolvedConnectionProvenance`: a resolved connection is spread into a provider client's runtime options, so metadata must never live inside it. Keys mirror the *form's* config type, so a value Databricks or Snowflake carries through the base URL input is reported under `baseUrl`.

- **`providerCatalog.ts` also gained a user-layer view** alongside the resolved cache, loaded through `loadConfigSources` and refreshed at the same points. The change event gained `changedUserProviderIds`, because the resolved and file views move independently: with `AWS_REGION` set, saving a different region leaves the resolved connection byte-identical, so a diff of the resolved catalog alone would never notify and the dialog would keep showing stale values.

- **The connected view now reports the value in effect** rather than the saved one, naming the variable in the row label when that is where it came from, so the two views agree on what the connection is actually using. Previously it read the user layer alone, so a provider whose values all came from the environment showed no rows at all while the connect form named them.

- **The profile input hints `default`**, the profile AWS looks for when none is given. The region box stays bare on purpose: `default` is a fixed AWS convention, whereas a region hint would suggest a value that may not apply.

### Screenshots

Connect dialog, both fields editable:

<img width="629" height="434" alt="Screenshot 2026-08-31 at 4 38 23 PM" src="https://github.com/user-attachments/assets/6ff2c0fd-a29d-4553-8e46-4860f50ed3e3" />

Connect dialog with `AWS_REGION` set (region read-only, profile still editable):

<img width="623" height="453" alt="Screenshot 2026-09-01 at 10 19 46 AM" src="https://github.com/user-attachments/assets/3cd042cb-baf8-4396-8722-ab87e5ce8691" />

Connected provider showing the value in effect:

<img width="638" height="420" alt="Screenshot 2026-08-31 at 4 35 55 PM" src="https://github.com/user-attachments/assets/6385602b-f3dd-4968-a0e5-772c8d2cecc6" />

Connected provider doesn't show absent, optional properties. Shows the env variable that sources the value.

<img width="638" height="377" alt="Screenshot 2026-09-01 at 10 19 18 AM" src="https://github.com/user-attachments/assets/86c8be4e-3530-4e43-baa2-06504a035821" />

### Release Notes

#### New Features

- Amazon Bedrock: the AWS profile and region can now be set in the provider configuration dialog instead of only through environment variables or a hand-edited `providers.json` (#15697)

### Not included

- **Only Bedrock's fields are wired up.** `ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`, `DATABRICKS_HOST`, `SNOWFLAKE_ACCOUNT` and roughly twenty more shadow their inputs on `main` exactly the same way. The schema and the reader already handle them, so enabling one is a line of data -- but it touches every provider's form and wants its own screenshots and QA.
- **Values enforced by Posit Workbench stay editable but ineffective.** Workbench pins settings through `POSITRON_ENFORCED_SETTINGS`, which ai-config translates into its `legacy-positron-enforced` layer internally; that layer is not returned by `loadConfigSources`, so it cannot be detected the way environment variables can. Only the value diff would catch it, with the blind spot described above.
- **No provider default is shown when a field is empty.** ai-config exports `BEDROCK_DEFAULTS` (`us-east-1`) and deliberately keeps it out of the resolved connection, so a region default could be surfaced -- but there is no truthful equivalent for the profile. `default` is the AWS SDK's shared-config convention, and the credential chain tries environment keys before any profile and may never read one, so displaying it as the effective profile would assert something often false. Rather than have the two rows behave inconsistently, neither shows a default. However, we do use `profile` as the placeholder.
- **Region is never validated by connecting.** `resolveAwsChainInit` passes the region to the SDK only for web-identity auth, so a typo'd region always connects and persists; it surfaces later at model-call time.
- **A malformed `providers.json` renders the form blank** rather than reporting an error. `loadConfigSources` flattens per-layer issues into logger warnings, so an unreadable file is indistinguishable from an empty one. Pinned by a test so the behavior is known rather than surprising; escaping it needs `loadConfigSourceReports` exported from ai-config (it is built but not re-exported).
- **Hand edits that an environment variable shadows don't refresh an open dialog.** ai-config's watch only fires when the resolved catalog changed, so a file-only edit that `AWS_REGION` shadows is invisible to it. In-app saves are unaffected.

### Validation Steps

@:assistant

No new e2e test. Exercising the flow end to end needs real AWS credentials in CI to get past the credential chain; what is testable without them -- that the inputs render, round-trip, persist, and go read-only -- is covered by the unit suites above.

Manual verification, on a machine with AWS credentials:

1. With no `bedrock` entry in `~/.posit/ai/providers.json` and neither variable exported, open the provider dialog and select Amazon Bedrock. Confirm both inputs are editable and empty, and that the profile shows a `default` placeholder while the region shows none.
2. Enter a valid profile and region, click Connect, and confirm `providers.json` gains `bedrock.aws` with both values.
3. Reopen the dialog. If Bedrock now shows as connected, confirm the profile and region appear as read-only rows. Click Remove, then reopen -- confirm the inputs are pre-filled with the saved values.
4. Clear both boxes and Connect. Confirm the `bedrock` entry is removed from `providers.json` entirely, not left as `"bedrock": {}`.
5. Enter a profile that doesn't exist and Connect. Confirm the error appears **and** `providers.json` is updated with the incorrect value -- there is no validation or rollback.
6. Export `AWS_REGION=us-west-2` and relaunch. Confirm the region box is read-only showing `us-west-2`, with a note naming `AWS_REGION` and the value it stands over; confirm the profile box is still editable; confirm Connect does not overwrite the saved region in `providers.json`.
7. With `AWS_REGION` still exported, connect and reopen. Confirm the connected view's region row reads `AWS Region (from AWS_REGION)` with `us-west-2`.
8. Export `AWS_REGION` set to exactly the value already saved in `providers.json`, relaunch, and confirm the box still goes read-only -- this is the case a resolved-vs-saved comparison would miss.
9. Hand-edit `providers.json` to a different region while Positron is running, with no `AWS_REGION` exported, then reopen the dialog and confirm it reflects the edit.
