### PR TITLE
python: guide to a venv when not in a workspace

### DIFF
--- a/extensions/positron-python/src/client/common/utils/localize.ts
+++ b/extensions/positron-python/src/client/common/utils/localize.ts
@@ -371,7 +371,7 @@ export namespace GlobalEnvironment {
     export const sessionPromptTitle = l10n.t('Create a global Python environment?');
     export const sessionPromptMessage = (interpreterLabel: string, venvPath: string) =>
         l10n.t(
-            '{0} is managed by your operating system or a package manager. Installing Python packages into it can break other software, so Positron can create a shared environment at {1} for use outside of projects.',
+            '{0} is managed by your operating system or a package manager. Installing Python packages into it can break other software. Positron can create a shared environment at {1} for use outside of projects.',
             interpreterLabel,
             venvPath,
         );

--- a/extensions/positron-python/src/client/common/utils/localize.ts
+++ b/extensions/positron-python/src/client/common/utils/localize.ts
@@ -366,6 +366,15 @@ export namespace GlobalEnvironment {
         );
     export const createButton = l10n.t('Create Global Environment');
     export const notNow = l10n.t('Not Now');
+    export const registrationFailed = (pythonPath: string) =>
+        l10n.t('Created the global Python environment at {0}, but could not start it.', pythonPath);
+    export const sessionPromptTitle = l10n.t('Create a global Python environment?');
+    export const sessionPromptMessage = (interpreterLabel: string, venvPath: string) =>
+        l10n.t(
+            '{0} is managed by your operating system or a package manager. Installing Python packages into it can break other software, so Positron can create a shared environment at {1} for use outside of projects.',
+            interpreterLabel,
+            venvPath,
+        );
 }
 // --- End Positron ---
 

--- a/extensions/positron-python/src/client/positron/createVirtualEnvironmentPrompt.ts
+++ b/extensions/positron-python/src/client/positron/createVirtualEnvironmentPrompt.ts
@@ -9,10 +9,19 @@ import * as positron from 'positron';
 import { isEnvProviderEnabled } from './createEnvApi';
 import { showThreeButtonModalDialogPrompt } from './positronApis';
 import { probeExternallyManagedEnvironment } from './externallyManagedEnvironment';
+import type { IPythonRuntimeManager } from './manager';
+import { shouldIncludeInterpreter } from './interpreterSettings';
 import { CONDA_PROVIDER_ID } from '../pythonEnvironments/creation/provider/condaCreationProvider';
 import { UV_PROVIDER_ID } from '../pythonEnvironments/creation/provider/uvCreationProvider';
 import { VenvCreationProviderId } from '../pythonEnvironments/creation/provider/venvCreationProvider';
 import { isUvInstalled } from '../pythonEnvironments/common/environmentManagers/uv';
+import {
+    createGlobalEnvironment,
+    getGlobalEnvironmentDir,
+    getGlobalEnvironmentPython,
+    globalEnvironmentErrorMessage,
+} from '../pythonEnvironments/common/environmentManagers/globalEnvironment';
+import { showUvInstallError } from '../pythonEnvironments/common/environmentManagers/uvPythonInstaller';
 import {
     autoCreateVenvWithDeps,
     detectAutoCreateContext,
@@ -24,7 +33,7 @@ import {
 import { Commands } from '../common/constants';
 import { getGlobalStorage, IPersistentStorage } from '../common/persistentState';
 import { IExtensionContext } from '../common/types';
-import { CreateEnv } from '../common/utils/localize';
+import { CreateEnv, GlobalEnvironment } from '../common/utils/localize';
 import { executeCommand } from '../common/vscodeApis/commandApis';
 import { getConfiguration, getWorkspaceFolders } from '../common/vscodeApis/workspaceApis';
 import { IInterpreterService } from '../interpreter/contracts';
@@ -106,6 +115,8 @@ export enum CreateVirtualEnvironmentPromptOutcome {
  *
  * @param serviceContainer Used for the extension context that backs suppression storage.
  * @param interpreterService Used to resolve the picked interpreter.
+ * @param runtimeManager Used by the no-workspace branch to select the runtime for the
+ *   global environment it creates.
  * @param interpreterPath The interpreter the session would start.
  * @param sessionMetadata The metadata for the session being created.
  *
@@ -114,6 +125,7 @@ export enum CreateVirtualEnvironmentPromptOutcome {
 export async function promptToCreateVirtualEnvironment(
     serviceContainer: IServiceContainer,
     interpreterService: IInterpreterService,
+    runtimeManager: IPythonRuntimeManager,
     interpreterPath: string,
     sessionMetadata: positron.RuntimeSessionMetadata,
 ): Promise<CreateVirtualEnvironmentPromptOutcome> {
@@ -128,9 +140,7 @@ export async function promptToCreateVirtualEnvironment(
     }
 
     const workspaceFolders = getWorkspaceFolders();
-    if (!workspaceFolders || workspaceFolders.length === 0) {
-        return CreateVirtualEnvironmentPromptOutcome.Proceed;
-    }
+    const hasWorkspace = (workspaceFolders?.length ?? 0) > 0;
 
     // Read the setting live so that turning it off takes effect without a reload.
     const pythonConfig = getConfiguration('python');
@@ -152,13 +162,17 @@ export async function promptToCreateVirtualEnvironment(
         return CreateVirtualEnvironmentPromptOutcome.Proceed;
     }
 
+    if (!hasWorkspace) {
+        return promptForGlobalEnvironmentOnSelect(serviceContainer, runtimeManager, interpreterPath, environment);
+    }
+
     const ladderInput: CreateEnvironmentLadderInput = {
         interpreterPath,
         versionMajorMinor: describeMajorMinor(environment),
         isCondaBase: environment !== undefined && isBaseCondaEnvironment(environment),
         uvInstalled: await isUvInstalled(),
         allowUvPythonInstall: pythonConfig?.get<boolean>('allowUvPythonInstall') ?? true,
-        workspaceFolder: workspaceFolders.length === 1 ? workspaceFolders[0] : undefined,
+        workspaceFolder: workspaceFolders?.length === 1 ? workspaceFolders[0] : undefined,
     };
     const createOptions = chooseCreateEnvironmentOptions(ladderInput);
     if (!createOptions) {
@@ -200,6 +214,118 @@ export async function promptToCreateVirtualEnvironment(
     // answer the question, so leave the startup notification free to ask it.
     clearCreateEnvModalShown();
     return CreateVirtualEnvironmentPromptOutcome.Abort;
+}
+
+/**
+ * The no-workspace arm of the prompt: offer the global environment instead of a
+ * workspace venv. There is no "Open Folder..." button here, unlike the other
+ * global-environment surfaces: this modal interrupts someone trying to run code who
+ * has already passed the environment-health check's "Open Folder" advice and needs a
+ * usable interpreter now.
+ *
+ * The prompt is only shown when the global environment could actually be created and
+ * then used: somewhere for it to live, a path the user's interpreter settings do not
+ * exclude, uv installed, and the uv provider enabled (the global environment is
+ * uv-backed by definition, and this surface never detours into the uv install-consent
+ * flow).
+ */
+async function promptForGlobalEnvironmentOnSelect(
+    serviceContainer: IServiceContainer,
+    runtimeManager: IPythonRuntimeManager,
+    interpreterPath: string,
+    environment: PythonEnvironment | undefined,
+): Promise<CreateVirtualEnvironmentPromptOutcome> {
+    const venvDir = getGlobalEnvironmentDir();
+    if (!venvDir || !isEnvProviderEnabled(UV_PROVIDER_ID) || !(await isUvInstalled())) {
+        traceInfo('Create venv prompt - The global environment is unavailable, skipping the prompt');
+        return CreateVirtualEnvironmentPromptOutcome.Proceed;
+    }
+
+    // An excluded path can be created but never registered as a runtime, so there would
+    // be nothing to switch to afterwards. `python.interpreters.override` reaches here on
+    // its own: it is an allowlist, and a global environment that does not exist yet
+    // cannot be on it.
+    if (!shouldIncludeInterpreter(getGlobalEnvironmentPython(venvDir))) {
+        traceInfo(`Create venv prompt - The global environment at ${venvDir} is excluded by user settings`);
+        return CreateVirtualEnvironmentPromptOutcome.Proceed;
+    }
+
+    // Marked before the modal opens so the startup notification cannot race in behind it,
+    // and undone again on the dismiss path below.
+    markCreateEnvModalShown();
+
+    const choice = await showThreeButtonModalDialogPrompt({
+        title: GlobalEnvironment.sessionPromptTitle,
+        message: GlobalEnvironment.sessionPromptMessage(describeInterpreter(environment, interpreterPath), venvDir),
+        primaryButtonTitle: GlobalEnvironment.createButton,
+        secondaryButtonTitle: GlobalEnvironment.notNow,
+        tertiaryButtonTitle: CreateEnv.InterpreterSelect.neverForThisInterpreter,
+    });
+
+    if (choice === CreateEnv.InterpreterSelect.neverForThisInterpreter) {
+        const suppressedInterpreters = getSuppressedInterpreters(serviceContainer);
+        await suppressedInterpreters.set([...suppressedInterpreters.get(), interpreterPath]);
+        return CreateVirtualEnvironmentPromptOutcome.Proceed;
+    }
+
+    if (choice === GlobalEnvironment.createButton) {
+        // Awaited, unlike the workspace branch's create flow: occupied and failed
+        // outcomes decide whether the pending session start proceeds.
+        const result = await createGlobalEnvironment(interpreterPath);
+        if (result.outcome !== 'created') {
+            await showUvInstallError(globalEnvironmentErrorMessage(result));
+            return CreateVirtualEnvironmentPromptOutcome.Proceed;
+        }
+        // Registration and selection are both awaited, and their failures caught, so the
+        // pending session is only aborted once the replacement has actually started;
+        // otherwise a failure here would leave the user with no session at all.
+        try {
+            const metadata = await registerGlobalEnvironmentRuntime(runtimeManager, result.pythonPath);
+            if (!metadata) {
+                traceError(`Create venv prompt - Could not register a runtime for ${result.pythonPath}`);
+                await showUvInstallError(GlobalEnvironment.registrationFailed(result.pythonPath));
+                return CreateVirtualEnvironmentPromptOutcome.Proceed;
+            }
+            const runtimeId = await runtimeManager.selectLanguageRuntimeFromPath(result.pythonPath);
+            if (!runtimeId) {
+                await showUvInstallError(GlobalEnvironment.registrationFailed(result.pythonPath));
+                return CreateVirtualEnvironmentPromptOutcome.Proceed;
+            }
+        } catch (error) {
+            traceError(`Create venv prompt - Failed to start the global environment: ${error}`);
+            await showUvInstallError(GlobalEnvironment.registrationFailed(result.pythonPath));
+            return CreateVirtualEnvironmentPromptOutcome.Proceed;
+        }
+        return CreateVirtualEnvironmentPromptOutcome.Abort;
+    }
+
+    if (choice === GlobalEnvironment.notNow) {
+        return CreateVirtualEnvironmentPromptOutcome.Proceed;
+    }
+
+    // Dismissed with the close button or Escape: not consent, so no environment. Unlike
+    // the workspace modal, the session still starts: with no folder open there is no
+    // alternate create flow to hand the user to, and they need a usable interpreter now.
+    clearCreateEnvModalShown();
+    return CreateVirtualEnvironmentPromptOutcome.Proceed;
+}
+
+/**
+ * Registers a runtime for a just-created global environment, retrying once behind an
+ * interpreter refresh: a brand new environment is not in the interpreter list yet, so
+ * the first attempt can come back empty.
+ */
+async function registerGlobalEnvironmentRuntime(
+    runtimeManager: IPythonRuntimeManager,
+    pythonPath: string,
+): Promise<positron.LanguageRuntimeMetadata | undefined> {
+    const metadata = await runtimeManager.registerLanguageRuntimeFromPath(pythonPath, /* recreateRuntime */ true);
+    if (metadata) {
+        return metadata;
+    }
+    traceInfo(`Create venv prompt - No runtime for ${pythonPath} yet, refreshing interpreters`);
+    await runtimeManager.triggerInterpreterRefresh();
+    return runtimeManager.registerLanguageRuntimeFromPath(pythonPath, /* recreateRuntime */ true);
 }
 
 /**

--- a/extensions/positron-python/src/client/positron/manager.ts
+++ b/extensions/positron-python/src/client/positron/manager.ts
@@ -435,6 +435,7 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
         const promptOutcome = await promptToCreateVirtualEnvironment(
             this.serviceContainer,
             this.interpreterService,
+            this,
             extraData.pythonPath,
             sessionMetadata,
         );

--- a/extensions/positron-python/src/test/positron/createVirtualEnvironmentPrompt.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/createVirtualEnvironmentPrompt.unit.test.ts
@@ -15,9 +15,12 @@ import * as commandApis from '../../client/common/vscodeApis/commandApis';
 import * as positronApis from '../../client/positron/positronApis';
 import * as persistentState from '../../client/common/persistentState';
 import * as externallyManaged from '../../client/positron/externallyManagedEnvironment';
+import * as interpreterSettings from '../../client/positron/interpreterSettings';
 import * as triggerUtils from '../../client/pythonEnvironments/creation/common/createEnvTriggerUtils';
 import * as uv from '../../client/pythonEnvironments/common/environmentManagers/uv';
 import * as autoCreateVenv from '../../client/pythonEnvironments/creation/provider/autoCreateVenv';
+import * as globalEnvironment from '../../client/pythonEnvironments/common/environmentManagers/globalEnvironment';
+import * as uvPythonInstaller from '../../client/pythonEnvironments/common/environmentManagers/uvPythonInstaller';
 import {
     CreateEnvironmentLadderInput,
     CreateVirtualEnvironmentPromptOutcome,
@@ -28,8 +31,9 @@ import { CONDA_PROVIDER_ID } from '../../client/pythonEnvironments/creation/prov
 import { UV_PROVIDER_ID } from '../../client/pythonEnvironments/creation/provider/uvCreationProvider';
 import { VenvCreationProviderId } from '../../client/pythonEnvironments/creation/provider/venvCreationProvider';
 import { Commands } from '../../client/common/constants';
-import { CreateEnv } from '../../client/common/utils/localize';
+import { CreateEnv, GlobalEnvironment } from '../../client/common/utils/localize';
 import { IExtensionContext } from '../../client/common/types';
+import { IPythonRuntimeManager } from '../../client/positron/manager';
 import { IInterpreterService } from '../../client/interpreter/contracts';
 import { IServiceContainer } from '../../client/ioc/types';
 import { EnvironmentType, PythonEnvironment } from '../../client/pythonEnvironments/info';
@@ -150,6 +154,7 @@ suite('Create virtual environment prompt - gate', () => {
 
     let serviceContainer: typemoq.IMock<IServiceContainer>;
     let interpreterService: typemoq.IMock<IInterpreterService>;
+    let runtimeManager: typemoq.IMock<IPythonRuntimeManager>;
     let pythonConfig: typemoq.IMock<import('vscode').WorkspaceConfiguration>;
     let suppressedPaths: string[];
     let setSuppressedPaths: sinon.SinonStub;
@@ -170,6 +175,7 @@ suite('Create virtual environment prompt - gate', () => {
         return promptToCreateVirtualEnvironment(
             serviceContainer.object,
             interpreterService.object,
+            runtimeManager.object,
             interpreterPath,
             metadata,
         );
@@ -180,6 +186,11 @@ suite('Create virtual environment prompt - gate', () => {
         interpreterService = createTypeMoq<IInterpreterService>();
         const context = createTypeMoq<IExtensionContext>();
         serviceContainer.setup((s) => s.get(IExtensionContext)).returns(() => context.object);
+
+        runtimeManager = createTypeMoq<IPythonRuntimeManager>();
+        runtimeManager
+            .setup((m) => m.selectLanguageRuntimeFromPath(typemoq.It.isAnyString(), typemoq.It.isAny()))
+            .returns(() => Promise.resolve('runtime-id'));
 
         pythonConfig = createTypeMoq<import('vscode').WorkspaceConfiguration>();
         pythonConfig.setup((c) => c.get('createEnvironment.promptOnInterpreterSelect')).returns(() => true);
@@ -373,17 +384,6 @@ suite('Create virtual environment prompt - gate', () => {
         );
     });
 
-    test('skips the modal when no workspace folder is open', async () => {
-        (workspaceApis.getWorkspaceFolders as sinon.SinonStub).returns(undefined);
-
-        const outcome = await run();
-
-        assert.deepStrictEqual(
-            { outcome, shown: showPromptStub.callCount },
-            { outcome: CreateVirtualEnvironmentPromptOutcome.Proceed, shown: 0 },
-        );
-    });
-
     test('skips the modal when the setting is off', async () => {
         pythonConfig.reset();
         pythonConfig.setup((c) => c.get('createEnvironment.promptOnInterpreterSelect')).returns(() => false);
@@ -440,6 +440,412 @@ suite('Create virtual environment prompt - gate', () => {
                 cleared: (triggerUtils.clearCreateEnvModalShown as sinon.SinonStub).callCount,
             },
             { marked: 1, cleared: 0 },
+        );
+    });
+});
+
+suite('Create virtual environment prompt - no workspace', () => {
+    const interpreterPath = '/usr/bin/python3';
+    const venvDir = '/home/user/.virtualenvs/positron';
+    const environment = {
+        path: interpreterPath,
+        architecture: Architecture.x64,
+        sysPrefix: '/usr',
+        version: { major: 3, minor: 12, patch: 3, raw: '3.12.3' },
+        envType: EnvironmentType.System,
+        displayName: 'Python 3.12.3 (System)',
+    } as PythonEnvironment;
+
+    let serviceContainer: typemoq.IMock<IServiceContainer>;
+    let interpreterService: typemoq.IMock<IInterpreterService>;
+    let runtimeManager: typemoq.IMock<IPythonRuntimeManager>;
+    let registeredRuntimes: (positron.LanguageRuntimeMetadata | undefined)[];
+    let selectLanguageRuntimeFromPath: () => Promise<string | undefined>;
+    let pythonConfig: typemoq.IMock<import('vscode').WorkspaceConfiguration>;
+    let suppressedPaths: string[];
+    let setSuppressedPaths: sinon.SinonStub;
+    let showPromptStub: sinon.SinonStub;
+    let probeStub: sinon.SinonStub;
+    let isUvInstalledStub: sinon.SinonStub;
+    let getGlobalEnvironmentDirStub: sinon.SinonStub;
+    let createGlobalEnvironmentStub: sinon.SinonStub;
+    let showUvInstallErrorStub: sinon.SinonStub;
+    let shouldIncludeInterpreterStub: sinon.SinonStub;
+
+    function run(metadata?: positron.RuntimeSessionMetadata) {
+        return promptToCreateVirtualEnvironment(
+            serviceContainer.object,
+            interpreterService.object,
+            runtimeManager.object,
+            interpreterPath,
+            metadata ??
+                ({
+                    sessionId: 'session-id',
+                    sessionMode: positron.LanguageRuntimeSessionMode.Console,
+                    userSelected: true,
+                } as positron.RuntimeSessionMetadata),
+        );
+    }
+
+    setup(() => {
+        serviceContainer = createTypeMoq<IServiceContainer>();
+        interpreterService = createTypeMoq<IInterpreterService>();
+        const context = createTypeMoq<IExtensionContext>();
+        serviceContainer.setup((s) => s.get(IExtensionContext)).returns(() => context.object);
+
+        runtimeManager = createTypeMoq<IPythonRuntimeManager>();
+        selectLanguageRuntimeFromPath = () => Promise.resolve('runtime-id');
+        runtimeManager
+            .setup((m) => m.selectLanguageRuntimeFromPath(typemoq.It.isAnyString(), typemoq.It.isAny()))
+            .returns(() => selectLanguageRuntimeFromPath());
+        registeredRuntimes = [{ runtimeId: 'runtime-id' } as positron.LanguageRuntimeMetadata];
+        runtimeManager
+            .setup((m) => m.registerLanguageRuntimeFromPath(typemoq.It.isAnyString(), typemoq.It.isAny()))
+            .returns(() => Promise.resolve(registeredRuntimes.shift()));
+        runtimeManager.setup((m) => m.triggerInterpreterRefresh()).returns(() => Promise.resolve());
+
+        pythonConfig = createTypeMoq<import('vscode').WorkspaceConfiguration>();
+        pythonConfig.setup((c) => c.get('createEnvironment.promptOnInterpreterSelect')).returns(() => true);
+        pythonConfig.setup((c) => c.get('allowUvPythonInstall')).returns(() => true);
+        sinon.stub(workspaceApis, 'getConfiguration').returns(pythonConfig.object);
+        sinon.stub(workspaceApis, 'getWorkspaceFolders').returns(undefined);
+
+        suppressedPaths = [];
+        setSuppressedPaths = sinon.stub().resolves();
+        sinon.stub(persistentState, 'getGlobalStorage').returns({
+            get: () => suppressedPaths,
+            set: setSuppressedPaths,
+        });
+
+        probeStub = sinon
+            .stub(externallyManaged, 'probeExternallyManagedEnvironment')
+            .resolves({ externallyManaged: true, environment });
+        sinon.stub(triggerUtils, 'markCreateEnvModalShown');
+        sinon.stub(triggerUtils, 'clearCreateEnvModalShown');
+        sinon.stub(positronCreateEnvApi, 'isEnvProviderEnabled').returns(true);
+        isUvInstalledStub = sinon.stub(uv, 'isUvInstalled').resolves(true);
+        getGlobalEnvironmentDirStub = sinon.stub(globalEnvironment, 'getGlobalEnvironmentDir').returns(venvDir);
+        shouldIncludeInterpreterStub = sinon.stub(interpreterSettings, 'shouldIncludeInterpreter').returns(true);
+        createGlobalEnvironmentStub = sinon.stub(globalEnvironment, 'createGlobalEnvironment').resolves({
+            outcome: 'created',
+            venvDir,
+            pythonPath: `${venvDir}/bin/python`,
+        });
+        showUvInstallErrorStub = sinon.stub(uvPythonInstaller, 'showUvInstallError').resolves();
+        showPromptStub = sinon.stub(positronApis, 'showThreeButtonModalDialogPrompt').resolves(undefined);
+        sinon.stub(commandApis, 'executeCommand').resolves(undefined);
+    });
+
+    teardown(() => {
+        sinon.restore();
+    });
+
+    test('shows the global-environment modal without an Open Folder button', async () => {
+        await run();
+
+        assert.deepStrictEqual(showPromptStub.firstCall.args, [
+            {
+                title: GlobalEnvironment.sessionPromptTitle,
+                message: GlobalEnvironment.sessionPromptMessage('Python 3.12.3 (System)', venvDir),
+                primaryButtonTitle: GlobalEnvironment.createButton,
+                secondaryButtonTitle: GlobalEnvironment.notNow,
+                tertiaryButtonTitle: CreateEnv.InterpreterSelect.neverForThisInterpreter,
+            },
+        ]);
+    });
+
+    test('Not Now starts the session on the picked interpreter', async () => {
+        showPromptStub.resolves(GlobalEnvironment.notNow);
+
+        const outcome = await run();
+
+        assert.deepStrictEqual(
+            {
+                outcome,
+                created: createGlobalEnvironmentStub.callCount,
+                suppressionWrites: setSuppressedPaths.callCount,
+            },
+            { outcome: CreateVirtualEnvironmentPromptOutcome.Proceed, created: 0, suppressionWrites: 0 },
+        );
+    });
+
+    test('Never for This Interpreter suppresses and starts the session', async () => {
+        suppressedPaths = ['/opt/other/bin/python3'];
+        showPromptStub.resolves(CreateEnv.InterpreterSelect.neverForThisInterpreter);
+
+        const outcome = await run();
+
+        assert.deepStrictEqual(
+            { outcome, written: setSuppressedPaths.firstCall.args[0] },
+            {
+                outcome: CreateVirtualEnvironmentPromptOutcome.Proceed,
+                written: ['/opt/other/bin/python3', interpreterPath],
+            },
+        );
+    });
+
+    test('Dismissing the dialog starts the session and frees the startup notification', async () => {
+        showPromptStub.resolves(undefined);
+
+        const outcome = await run();
+
+        assert.deepStrictEqual(
+            {
+                outcome,
+                created: createGlobalEnvironmentStub.callCount,
+                marked: (triggerUtils.markCreateEnvModalShown as sinon.SinonStub).callCount,
+                cleared: (triggerUtils.clearCreateEnvModalShown as sinon.SinonStub).callCount,
+            },
+            { outcome: CreateVirtualEnvironmentPromptOutcome.Proceed, created: 0, marked: 1, cleared: 1 },
+        );
+    });
+
+    test('Not Now leaves the once-per-window flag marked', async () => {
+        showPromptStub.resolves(GlobalEnvironment.notNow);
+
+        await run();
+
+        assert.deepStrictEqual(
+            {
+                marked: (triggerUtils.markCreateEnvModalShown as sinon.SinonStub).callCount,
+                cleared: (triggerUtils.clearCreateEnvModalShown as sinon.SinonStub).callCount,
+            },
+            { marked: 1, cleared: 0 },
+        );
+    });
+
+    test('skips the modal when there is nowhere to put the global environment', async () => {
+        getGlobalEnvironmentDirStub.returns(undefined);
+
+        const outcome = await run();
+
+        assert.deepStrictEqual(
+            { outcome, shown: showPromptStub.callCount },
+            { outcome: CreateVirtualEnvironmentPromptOutcome.Proceed, shown: 0 },
+        );
+    });
+
+    test('skips the modal when user settings exclude the global environment path', async () => {
+        shouldIncludeInterpreterStub.returns(false);
+
+        const outcome = await run();
+
+        assert.deepStrictEqual(
+            {
+                outcome,
+                shown: showPromptStub.callCount,
+                checked: shouldIncludeInterpreterStub.firstCall.args[0],
+            },
+            {
+                outcome: CreateVirtualEnvironmentPromptOutcome.Proceed,
+                shown: 0,
+                checked: globalEnvironment.getGlobalEnvironmentPython(venvDir),
+            },
+        );
+    });
+
+    test('skips the modal when uv is not installed', async () => {
+        isUvInstalledStub.resolves(false);
+
+        const outcome = await run();
+
+        assert.deepStrictEqual(
+            { outcome, shown: showPromptStub.callCount },
+            { outcome: CreateVirtualEnvironmentPromptOutcome.Proceed, shown: 0 },
+        );
+    });
+
+    test('skips the modal when the uv provider is disabled', async () => {
+        (positronCreateEnvApi.isEnvProviderEnabled as sinon.SinonStub).withArgs(UV_PROVIDER_ID).returns(false);
+
+        const outcome = await run();
+
+        assert.deepStrictEqual(
+            { outcome, shown: showPromptStub.callCount },
+            { outcome: CreateVirtualEnvironmentPromptOutcome.Proceed, shown: 0 },
+        );
+    });
+
+    test('skips the modal when the setting is off', async () => {
+        pythonConfig.reset();
+        pythonConfig.setup((c) => c.get('createEnvironment.promptOnInterpreterSelect')).returns(() => false);
+
+        const outcome = await run();
+
+        assert.deepStrictEqual(
+            { outcome, shown: showPromptStub.callCount, probed: probeStub.callCount },
+            { outcome: CreateVirtualEnvironmentPromptOutcome.Proceed, shown: 0, probed: 0 },
+        );
+    });
+
+    test('skips the modal when the interpreter is suppressed', async () => {
+        suppressedPaths = [interpreterPath];
+
+        const outcome = await run();
+
+        assert.deepStrictEqual(
+            { outcome, shown: showPromptStub.callCount },
+            { outcome: CreateVirtualEnvironmentPromptOutcome.Proceed, shown: 0 },
+        );
+    });
+
+    test('skips the modal when the interpreter is not externally managed', async () => {
+        probeStub.resolves({ externallyManaged: false, environment });
+
+        const outcome = await run();
+
+        assert.deepStrictEqual(
+            { outcome, shown: showPromptStub.callCount },
+            { outcome: CreateVirtualEnvironmentPromptOutcome.Proceed, shown: 0 },
+        );
+    });
+
+    test('skips the modal for notebook sessions', async () => {
+        const outcome = await run({
+            sessionId: 'session-id',
+            sessionMode: positron.LanguageRuntimeSessionMode.Notebook,
+            userSelected: true,
+        } as positron.RuntimeSessionMetadata);
+
+        assert.deepStrictEqual(
+            { outcome, shown: showPromptStub.callCount },
+            { outcome: CreateVirtualEnvironmentPromptOutcome.Proceed, shown: 0 },
+        );
+    });
+
+    test('skips the modal when the session was not user selected', async () => {
+        const outcome = await run({
+            sessionId: 'session-id',
+            sessionMode: positron.LanguageRuntimeSessionMode.Console,
+            userSelected: undefined,
+        } as positron.RuntimeSessionMetadata);
+
+        assert.deepStrictEqual(
+            { outcome, shown: showPromptStub.callCount },
+            { outcome: CreateVirtualEnvironmentPromptOutcome.Proceed, shown: 0 },
+        );
+    });
+
+    test('Create Global Environment builds from the picked interpreter and aborts the pending start', async () => {
+        showPromptStub.resolves(GlobalEnvironment.createButton);
+
+        const outcome = await run();
+
+        runtimeManager.verify(
+            (m) => m.registerLanguageRuntimeFromPath(`${venvDir}/bin/python`, true),
+            typemoq.Times.once(),
+        );
+        runtimeManager.verify(
+            (m) => m.selectLanguageRuntimeFromPath(`${venvDir}/bin/python`, typemoq.It.isAny()),
+            typemoq.Times.once(),
+        );
+        assert.deepStrictEqual(
+            {
+                outcome,
+                base: createGlobalEnvironmentStub.firstCall.args[0],
+                errorsShown: showUvInstallErrorStub.callCount,
+            },
+            { outcome: CreateVirtualEnvironmentPromptOutcome.Abort, base: interpreterPath, errorsShown: 0 },
+        );
+    });
+
+    test('a runtime that is not registered yet is retried behind an interpreter refresh', async () => {
+        showPromptStub.resolves(GlobalEnvironment.createButton);
+        registeredRuntimes = [undefined, { runtimeId: 'runtime-id' } as positron.LanguageRuntimeMetadata];
+
+        const outcome = await run();
+
+        runtimeManager.verify((m) => m.triggerInterpreterRefresh(), typemoq.Times.once());
+        runtimeManager.verify(
+            (m) => m.selectLanguageRuntimeFromPath(`${venvDir}/bin/python`, typemoq.It.isAny()),
+            typemoq.Times.once(),
+        );
+        assert.deepStrictEqual(
+            { outcome, errorsShown: showUvInstallErrorStub.callCount },
+            { outcome: CreateVirtualEnvironmentPromptOutcome.Abort, errorsShown: 0 },
+        );
+    });
+
+    test('a selection that never starts shows the error and starts the picked interpreter', async () => {
+        showPromptStub.resolves(GlobalEnvironment.createButton);
+        selectLanguageRuntimeFromPath = () => Promise.resolve(undefined);
+
+        const outcome = await run();
+
+        assert.deepStrictEqual(
+            { outcome, error: showUvInstallErrorStub.firstCall.args[0] },
+            {
+                outcome: CreateVirtualEnvironmentPromptOutcome.Proceed,
+                error: GlobalEnvironment.registrationFailed(`${venvDir}/bin/python`),
+            },
+        );
+    });
+
+    test('a selection that throws shows the error and starts the picked interpreter', async () => {
+        showPromptStub.resolves(GlobalEnvironment.createButton);
+        selectLanguageRuntimeFromPath = () => Promise.reject(new Error('boom'));
+
+        const outcome = await run();
+
+        assert.deepStrictEqual(
+            { outcome, error: showUvInstallErrorStub.firstCall.args[0] },
+            {
+                outcome: CreateVirtualEnvironmentPromptOutcome.Proceed,
+                error: GlobalEnvironment.registrationFailed(`${venvDir}/bin/python`),
+            },
+        );
+    });
+
+    test('a runtime that never registers shows the error and starts the picked interpreter', async () => {
+        showPromptStub.resolves(GlobalEnvironment.createButton);
+        registeredRuntimes = [];
+
+        const outcome = await run();
+
+        runtimeManager.verify(
+            (m) => m.selectLanguageRuntimeFromPath(typemoq.It.isAnyString(), typemoq.It.isAny()),
+            typemoq.Times.never(),
+        );
+        assert.deepStrictEqual(
+            { outcome, error: showUvInstallErrorStub.firstCall.args[0] },
+            {
+                outcome: CreateVirtualEnvironmentPromptOutcome.Proceed,
+                error: GlobalEnvironment.registrationFailed(`${venvDir}/bin/python`),
+            },
+        );
+    });
+
+    test('an occupied global path shows the error and starts the session on the picked interpreter', async () => {
+        showPromptStub.resolves(GlobalEnvironment.createButton);
+        createGlobalEnvironmentStub.resolves({ outcome: 'occupied', venvDir });
+
+        const outcome = await run();
+
+        runtimeManager.verify(
+            (m) => m.selectLanguageRuntimeFromPath(typemoq.It.isAnyString(), typemoq.It.isAny()),
+            typemoq.Times.never(),
+        );
+        assert.deepStrictEqual(
+            { outcome, error: showUvInstallErrorStub.firstCall.args[0] },
+            {
+                outcome: CreateVirtualEnvironmentPromptOutcome.Proceed,
+                error: GlobalEnvironment.occupied(venvDir),
+            },
+        );
+    });
+
+    test('a failed creation shows the error and starts the session on the picked interpreter', async () => {
+        showPromptStub.resolves(GlobalEnvironment.createButton);
+        createGlobalEnvironmentStub.resolves({ outcome: 'failed', venvDir });
+
+        const outcome = await run();
+
+        assert.deepStrictEqual(
+            { outcome, error: showUvInstallErrorStub.firstCall.args[0] },
+            {
+                outcome: CreateVirtualEnvironmentPromptOutcome.Proceed,
+                error: GlobalEnvironment.creationFailed(venvDir),
+            },
         );
     });
 });

--- a/extensions/positron-python/src/test/positron/manager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/manager.unit.test.ts
@@ -164,10 +164,11 @@ suite('Python runtime manager', () => {
 
         assert.deepStrictEqual(
             {
-                interpreterPath: promptToCreateVirtualEnvironmentStub.firstCall.args[2],
-                metadata: promptToCreateVirtualEnvironmentStub.firstCall.args[3],
+                runtimeManager: promptToCreateVirtualEnvironmentStub.firstCall.args[2],
+                interpreterPath: promptToCreateVirtualEnvironmentStub.firstCall.args[3],
+                metadata: promptToCreateVirtualEnvironmentStub.firstCall.args[4],
             },
-            { interpreterPath: pythonPath, metadata: sessionMetadata },
+            { runtimeManager: pythonRuntimeManager, interpreterPath: pythonPath, metadata: sessionMetadata },
         );
     });
 


### PR DESCRIPTION
Fixes #14887. Outside of a workspace, when starting a system python Console session, Positron now shows the same kind of modal it shows in a workspace, but offering the global environment at `~/.virtualenvs/positron` instead of a project venv.

There's no "Open Folder..." button here, unlike the other global-environment prompts. This modal interrupts someone who's trying to run code, has already seen the health check's advice to open a folder, ignored it, and needs a working interpreter now.

### Screenshot

<img width="498" height="218" alt="image" src="https://github.com/user-attachments/assets/1165c5a9-68f9-41c9-81a3-a84a647c0f90" />

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- With no folder open, Positron now offers to create a global Python environment when you pick a system Python for a session, instead of starting the system Python silently (#14887)

### Validation Steps

@:interpreter @:win

With no folder open, and with no `~/.virtualenvs/positron` present:

1. Start a Python console session on a system or package-manager Python. Confirm the modal appears, names that interpreter, and names `~/.virtualenvs/positron`.
2. Choose "Not Now". Confirm nothing is created and the session starts on the interpreter you picked.
3. Repeat and dismiss the modal with Escape. Confirm the same thing happens.
4. Repeat and choose "Never For This Interpreter". Confirm the session starts and the modal doesn't come back for that interpreter.
5. Repeat and choose "Create Global Environment". Confirm the environment is created at `~/.virtualenvs/positron`, gets selected, and the session starts on it rather than on the interpreter you picked.
6. Delete `~/.virtualenvs/positron`, create a plain directory at that path, and repeat step 5. Confirm you get an error and the session starts on the interpreter you picked.
7. Set `python.interpreters.exclude` to cover `~/.virtualenvs/positron` and repeat. Confirm no modal appears.
8. Open a folder and confirm the workspace venv prompt is unchanged.
