### PR TITLE
Resolve a help entry's source URL when it loads instead of when it is created

### DIFF
--- a/src/vs/workbench/contrib/positronHelp/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronHelp/browser/components/actionBars.tsx
@@ -77,7 +77,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 		for (let helpEntryIndex = helpEntries.length - 1; helpEntryIndex >= 0; helpEntryIndex--) {
 			actions.push({
 				id: generateUuid(),
-				label: helpEntries[helpEntryIndex].title || shortenUrl(helpEntries[helpEntryIndex].sourceUrl),
+				label: helpEntries[helpEntryIndex].title || shortenUrl(helpEntries[helpEntryIndex].targetUrl),
 				tooltip: '',
 				class: undefined,
 				enabled: true,

--- a/src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts
@@ -186,13 +186,25 @@ type PositronHelpMessage =
 	| PositronHelpMessageExecuteCommand;
 
 /**
+ * SourceUrlResolver type.
+ *
+ * Resolves a help entry's target URL to the source URL its overlay webview
+ * loads. A help entry can't do this itself: the source URL points at a help
+ * proxy server owned by the extension host. The help service supplies this.
+ */
+export type SourceUrlResolver = (targetUrl: string) => Promise<string | undefined>;
+
+/**
  * IHelpEntry interface.
  */
 export interface IHelpEntry {
 	/**
-	 * Gets the source URL.
+	 * Gets the target URL. This is the help topic's URL on the runtime's own
+	 * help server, and it is the stable identity of a help entry: the proxy
+	 * server that serves the topic to the webview is owned by the extension
+	 * host and is replaced whenever the extension host restarts.
 	 */
-	readonly sourceUrl: string;
+	readonly targetUrl: string;
 
 	/**
 	 * Gets the title.
@@ -274,6 +286,14 @@ export class HelpEntry extends Disposable implements IHelpEntry, WebviewFindDele
 	private _helpOverlayWebview?: IOverlayWebview;
 
 	/**
+	 * The source URL the help overlay webview was last loaded from. This is the
+	 * target URL as served by a help proxy server, and it is resolved each time
+	 * the webview is loaded rather than being remembered across loads. See
+	 * loadHelpOverlayWebview.
+	 */
+	private _sourceUrl?: string;
+
+	/**
 	 * Gets or sets the set title timeout. This timeout is used to default the title in case the
 	 * MessageHelpLoaded message is not received.
 	 */
@@ -336,8 +356,8 @@ export class HelpEntry extends Disposable implements IHelpEntry, WebviewFindDele
 	 * @param languageId The language ID.
 	 * @param sessionId The runtime session ID.
 	 * @param languageName The language name.
-	 * @param sourceUrl The source URL.
 	 * @param targetUrl The target URL.
+	 * @param _resolveSourceUrl Resolves the target URL to the source URL to load.
 	 * @param _clipboardService The IClipboardService.
 	 * @param _contextKeyService The IContextKeyService.
 	 * @param _contextMenuService The IContextMenuService.
@@ -351,8 +371,8 @@ export class HelpEntry extends Disposable implements IHelpEntry, WebviewFindDele
 		public readonly languageId: string,
 		public readonly sessionId: string,
 		public readonly languageName: string,
-		public readonly sourceUrl: string,
 		public readonly targetUrl: string,
+		private readonly _resolveSourceUrl: SourceUrlResolver,
 		@IClipboardService private readonly _clipboardService: IClipboardService,
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
 		@IContextMenuService private readonly _contextMenuService: IContextMenuService,
@@ -531,7 +551,9 @@ export class HelpEntry extends Disposable implements IHelpEntry, WebviewFindDele
 						// The source URL isn't always an absolute URL (e.g. the welcome page's
 						// 'welcome.html'), so parse it defensively. When it has no origin,
 						// treat the target as cross-origin so external links open externally.
-						const sourceOrigin = tryParseUrl(this.sourceUrl)?.origin;
+						const sourceOrigin = this._sourceUrl ?
+							tryParseUrl(this._sourceUrl)?.origin :
+							undefined;
 						if (url.pathname.toLowerCase().endsWith('.pdf') ||
 							(!isLocalhost(url.hostname) && url.origin !== sourceOrigin)) {
 							try {
@@ -545,7 +567,11 @@ export class HelpEntry extends Disposable implements IHelpEntry, WebviewFindDele
 								));
 							}
 						} else {
-							this._onDidNavigateEmitter.fire(message.url);
+							// Navigate to the target URL rather than the URL the
+							// webview reported. That one is served by a help proxy
+							// server, which won't exist after the extension host
+							// restarts; the target URL keeps working.
+							this._onDidNavigateEmitter.fire(this.toTargetUrl(url) ?? message.url);
 						}
 						break;
 					}
@@ -618,21 +644,17 @@ export class HelpEntry extends Disposable implements IHelpEntry, WebviewFindDele
 				}
 			}));
 
-			// Set the HTML of the help overlay webview.
-			this._helpOverlayWebview.setHtml(
-				this.helpHTML
-					.replaceAll('__nonce__', generateNonce())
-					.replaceAll('__sourceURL__', this.sourceUrl)
-					.replaceAll('__scrollX__', `${this._scrollX}`)
-					.replaceAll('__scrollY__', `${this._scrollY}`)
-			);
+			// Load the help overlay webview. This resolves the source URL, so it
+			// completes asynchronously; the claim and layout below don't depend
+			// on the content and run right away.
+			this.loadHelpOverlayWebview(this._helpOverlayWebview);
 
 			// Start the set title timeout. This timeout sets the title of the help entry to a
-			// shortened version of the source URL. We do this because there's no guarantee that the
+			// shortened version of the target URL. We do this because there's no guarantee that the
 			// document will load and send its title.
 			this._setTitleTimeout = setTimeout(() => {
 				this._setTitleTimeout = undefined;
-				this._title = shortenUrl(this.sourceUrl);
+				this._title = shortenUrl(this.targetUrl);
 				this._onDidChangeTitleEmitter.fire(this._title);
 			}, TITLE_TIMEOUT);
 		}
@@ -698,6 +720,83 @@ export class HelpEntry extends Disposable implements IHelpEntry, WebviewFindDele
 
 		// Run logic for animating cases.
 		ensureWebviewSizeCorrectWhenAnimating();
+	}
+
+	/**
+	 * Loads the help overlay webview with the help entry's content.
+	 *
+	 * The source URL is resolved here, at the moment the content is loaded,
+	 * rather than when the help entry was created. The source URL points at a
+	 * help proxy server that lives in the extension host, so an extension host
+	 * restart replaces it; a help entry, meanwhile, outlives that restart, and
+	 * its webview is rebuilt from scratch every time it is shown after being
+	 * hidden long enough to be disposed. Resolving here is what keeps a help
+	 * entry in the back/forward history from reloading a dead proxy server.
+	 *
+	 * @param helpOverlayWebview The help overlay webview to load.
+	 */
+	private async loadHelpOverlayWebview(helpOverlayWebview: IOverlayWebview) {
+		// Resolve the source URL to load.
+		const sourceUrl = await this._resolveSourceUrl(this.targetUrl);
+
+		// The help overlay webview can be disposed and replaced while the source
+		// URL is being resolved, so only load the webview we were asked to load.
+		if (this._helpOverlayWebview !== helpOverlayWebview) {
+			return;
+		}
+
+		// If the source URL could not be resolved, there's nothing to load. The
+		// resolver is responsible for telling the user why.
+		if (!sourceUrl) {
+			this._logService.error(`Positron Help could not resolve a source URL for ${this.targetUrl}.`);
+			return;
+		}
+
+		// Set the HTML of the help overlay webview.
+		this._sourceUrl = sourceUrl;
+		helpOverlayWebview.setHtml(
+			this.helpHTML
+				.replaceAll('__nonce__', generateNonce())
+				.replaceAll('__sourceURL__', sourceUrl)
+				.replaceAll('__scrollX__', `${this._scrollX}`)
+				.replaceAll('__scrollY__', `${this._scrollY}`)
+		);
+	}
+
+	/**
+	 * Converts a URL the help overlay webview navigated to into the equivalent
+	 * URL on the runtime's own help server.
+	 *
+	 * The webview loads from a help proxy server, so the URLs it navigates to
+	 * carry that server's origin, and on Positron Server its base path as well.
+	 * Both have to come back off, or the result can't be proxied again the next
+	 * time it is shown.
+	 *
+	 * @param navigatedUrl The URL the help overlay webview navigated to.
+	 * @returns The equivalent target URL, or undefined if it can't be converted.
+	 */
+	private toTargetUrl(navigatedUrl: URL): string | undefined {
+		const sourceUrl = this._sourceUrl ? tryParseUrl(this._sourceUrl) : undefined;
+		const targetUrl = tryParseUrl(this.targetUrl);
+		if (!sourceUrl || !targetUrl) {
+			return undefined;
+		}
+
+		// The source URL is this entry's target path served under the proxy's
+		// base path, so whatever precedes the target path is the base path.
+		const basePath = sourceUrl.pathname.endsWith(targetUrl.pathname) ?
+			sourceUrl.pathname.slice(0, sourceUrl.pathname.length - targetUrl.pathname.length) :
+			'';
+
+		const result = new URL(navigatedUrl);
+		result.protocol = targetUrl.protocol;
+		result.hostname = targetUrl.hostname;
+		result.port = targetUrl.port;
+		if (basePath && navigatedUrl.pathname.startsWith(basePath)) {
+			result.pathname = navigatedUrl.pathname.slice(basePath.length);
+		}
+
+		return result.toString();
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts
@@ -388,8 +388,12 @@ export class HelpEntry extends Disposable implements IHelpEntry, WebviewFindDele
 
 		// Register onDidColorThemeChange handler.
 		this._register(this._themeService.onDidColorThemeChange(_colorTheme => {
-			// Reload the help overlay webview.
-			this._helpOverlayWebview?.reload();
+			// Load the help overlay webview again rather than reloading it. A
+			// reload re-renders the HTML as it stands, source URL and all, which
+			// names a proxy server that is gone if the extension host restarted.
+			if (this._helpOverlayWebview) {
+				this.loadHelpOverlayWebview(this._helpOverlayWebview);
+			}
 		}));
 
 		this.helpFocusedContextKey = PositronHelpFocused.bindTo(this._contextKeyService);

--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
@@ -366,8 +366,8 @@ export class PositronHelpService extends Disposable implements IPositronHelpServ
 
 	/**
 	 * Navigates the help service.
-	 * @param fromUrl The from URL.
-	 * @param toUrl The to URL.
+	 * @param fromHelpEntry The help entry the navigation came from.
+	 * @param toTargetUrl The target URL to navigate to.
 	 */
 	navigate(fromHelpEntry: IHelpEntry, toTargetUrl: string) {
 		// Ignore navigations from anything but the current help entry. A hidden

--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
@@ -12,7 +12,7 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
-import { isLocalhost } from './utils.js';
+import { isLocalhost, tryParseUrl } from './utils.js';
 import { IViewsService } from '../../../services/views/common/viewsService.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { IOpenerService, OpenExternalOptions } from '../../../../platform/opener/common/opener.js';
@@ -107,10 +107,10 @@ export interface IPositronHelpService {
 
 	/**
 	 * Navigates the help service.
-	 * @param fromUrl The from URL.
-	 * @param toUrl The to URL.
+	 * @param fromHelpEntry The help entry the navigation came from.
+	 * @param toTargetUrl The target URL to navigate to.
 	 */
-	navigate(fromUrl: string, toUrl: string): void;
+	navigate(fromHelpEntry: IHelpEntry, toTargetUrl: string): void;
 
 	/**
 	 * Navigates backward.
@@ -136,7 +136,7 @@ export interface IPositronHelpService {
 /**
  * PositronHelpService class.
  */
-class PositronHelpService extends Disposable implements IPositronHelpService {
+export class PositronHelpService extends Disposable implements IPositronHelpService {
 	//#region Private Properties
 
 	/**
@@ -158,16 +158,6 @@ class PositronHelpService extends Disposable implements IPositronHelpService {
 	 * Gets or sets the help entry index.
 	 */
 	private _helpEntryIndex = -1;
-
-	/**
-	 * Gets or sets a value which indicates whether the proxy server styles have been set.
-	 */
-	private _proxyServerStylesHaveBeenSet = false;
-
-	/**
-	 * Gets the proxy servers. Keyed by the target URL origin.
-	 */
-	private readonly _proxyServers = new Map<string, string>();
 
 	/**
 	 * Gets the help clients. Keyed by the runtime session ID.
@@ -379,44 +369,22 @@ class PositronHelpService extends Disposable implements IPositronHelpService {
 	 * @param fromUrl The from URL.
 	 * @param toUrl The to URL.
 	 */
-	navigate(fromUrl: string, toUrl: string) {
+	navigate(fromHelpEntry: IHelpEntry, toTargetUrl: string) {
+		// Ignore navigations from anything but the current help entry. A hidden
+		// help entry's webview can still be alive and posting messages.
 		const currentHelpEntry = this._helpEntries[this._helpEntryIndex];
-		if (currentHelpEntry && currentHelpEntry.sourceUrl === fromUrl) {
-			// Create the target URL.
-			const currentTargetUrl = new URL(currentHelpEntry.targetUrl);
-			const targetUrl = new URL(toUrl);
-			targetUrl.protocol = currentTargetUrl.protocol;
-			targetUrl.hostname = currentTargetUrl.hostname;
-			targetUrl.port = currentTargetUrl.port;
-
-			// Create the help entry.
-			const helpEntry = this._instantiationService.createInstance(HelpEntry,
-				this._helpHTML,
-				currentHelpEntry.languageId,
-				currentHelpEntry.sessionId,
-				currentHelpEntry.languageName,
-				toUrl,
-				targetUrl.toString()
-			);
-
-			// Add the onDidNavigate event handler.
-			helpEntry.onDidNavigate(url => {
-				this.navigate(helpEntry.sourceUrl, url);
-			});
-
-			// Add the onDidNavigateBackward event handler.
-			helpEntry.onDidNavigateBackward(() => {
-				this.navigateBackward();
-			});
-
-			// Add the onDidNavigateForward event handler.
-			helpEntry.onDidNavigateForward(() => {
-				this.navigateForward();
-			});
-
-			// Add the help entry.
-			this.addHelpEntry(helpEntry);
+		if (currentHelpEntry !== fromHelpEntry) {
+			return;
 		}
+
+		// Create and add the help entry.
+		this.addHelpEntry(this.createHelpEntry(
+			this._helpHTML,
+			currentHelpEntry.languageId,
+			currentHelpEntry.sessionId,
+			currentHelpEntry.languageName,
+			toTargetUrl
+		));
 	}
 
 	/**
@@ -453,27 +421,122 @@ class PositronHelpService extends Disposable implements IPositronHelpService {
 	 */
 	private async setProxyServerStyles() {
 		// Create a webview theme data provider. It's a convenient way to get the styles we need for
-		// the help proxy server. Get the webview styles.
+		// the help proxy server.
 		const webviewThemeDataProvider = this._instantiationService.createInstance(
 			WebviewThemeDataProvider
 		);
-		const { styles } = webviewThemeDataProvider.getWebviewThemeData();
-		webviewThemeDataProvider.dispose();
 
-		// Try to set the proxy server styles.
+		// Push the styles to the proxy server. A failure here leaves the help
+		// topic unthemed, which isn't reason enough to fail the navigation, so
+		// the error is logged and swallowed rather than propagated.
 		try {
-			// Set the proxy server styles.
+			const { styles } = webviewThemeDataProvider.getWebviewThemeData();
 			await this._commandService.executeCommand(
 				'positronProxy.setHelpProxyServerStyles',
 				styles
 			);
-
-			// Note that the proxy server styles have been set.
-			this._proxyServerStylesHaveBeenSet = true;
 		} catch (error) {
 			this._logService.error('PositronHelpService could not set the proxy server styles');
 			this._logService.error(error);
+		} finally {
+			webviewThemeDataProvider.dispose();
 		}
+	}
+
+	/**
+	 * Resolves a help entry's target URL to the source URL its webview loads.
+	 *
+	 * Help topics reach the webview through a help proxy server that runs in
+	 * the extension host. Those servers don't survive an extension host
+	 * restart, so nothing is remembered here: a help entry calls this every
+	 * time it loads and gets back an origin that is live right now. Asking
+	 * every time is no more expensive than caching would be, because the
+	 * PositronProxy hands back the existing proxy server for a target origin
+	 * when there is one.
+	 *
+	 * @param targetUrl The target URL.
+	 * @returns The source URL to load, or undefined if it could not be resolved.
+	 */
+	async resolveSourceUrl(targetUrl: string): Promise<string | undefined> {
+		// Help entries that a runtime's help server doesn't serve - the welcome
+		// page, for one - are loaded as they are.
+		const targetUrlObject = tryParseUrl(targetUrl);
+		if (!targetUrlObject || !isLocalhost(targetUrlObject.hostname)) {
+			return targetUrl;
+		}
+
+		// Push the current styles to the proxy. A proxy server started after an
+		// extension host restart has never been styled, so this can't be done
+		// once per window.
+		await this.setProxyServerStyles();
+
+		// Ask the PositronProxy for the proxy server origin serving the target
+		// origin, starting a server if one isn't running yet.
+		let proxyServerOrigin: string | undefined;
+		try {
+			proxyServerOrigin = await this._commandService.executeCommand<string>(
+				'positronProxy.startHelpProxyServer',
+				targetUrlObject.origin
+			);
+		} catch (error) {
+			this._logService.error(`PositronHelpService could not start the proxy server for ${targetUrlObject.origin}.`);
+			this._logService.error(error);
+		}
+
+		// If the help proxy server could not be started, notify the user.
+		if (!proxyServerOrigin) {
+			this._notificationService.error(localize(
+				'positronHelpServiceUnavailable',
+				"The Positron help service is unavailable."
+			));
+			return undefined;
+		}
+
+		// Create the source URL.
+		const sourceUrl = new URL(targetUrlObject);
+		const proxyServerOriginUrl = new URL(proxyServerOrigin);
+		sourceUrl.protocol = proxyServerOriginUrl.protocol;
+		sourceUrl.hostname = proxyServerOriginUrl.hostname;
+		sourceUrl.port = proxyServerOriginUrl.port;
+		sourceUrl.pathname = join(proxyServerOriginUrl.pathname, targetUrlObject.pathname);
+
+		return sourceUrl.toString();
+	}
+
+	/**
+	 * Creates a help entry.
+	 * @param helpHTML The help HTML.
+	 * @param languageId The language ID.
+	 * @param sessionId The runtime session ID.
+	 * @param languageName The language name.
+	 * @param targetUrl The target URL.
+	 * @returns The help entry.
+	 */
+	private createHelpEntry(
+		helpHTML: string,
+		languageId: string,
+		sessionId: string,
+		languageName: string,
+		targetUrl: string
+	) {
+		// Create the help entry. The entry resolves the source URL it loads
+		// through the service, every time it loads; see resolveSourceUrl.
+		const helpEntry = this._instantiationService.createInstance(HelpEntry,
+			helpHTML,
+			languageId,
+			sessionId,
+			languageName,
+			targetUrl,
+			target => this.resolveSourceUrl(target)
+		);
+
+		// Add the navigation event handlers. The emitters behind these events
+		// belong to the help entry, so the listeners go away when it does.
+		helpEntry.onDidNavigate(toTargetUrl => this.navigate(helpEntry, toTargetUrl));
+		helpEntry.onDidNavigateBackward(() => this.navigateBackward());
+		helpEntry.onDidNavigateForward(() => this.navigateForward());
+
+		return helpEntry;
 	}
 
 	/**
@@ -482,7 +545,10 @@ class PositronHelpService extends Disposable implements IPositronHelpService {
 	 */
 	private addHelpEntry(helpEntry: HelpEntry) {
 		// If the help entry being added matches the current help entry, don't open it again.
-		if (this._helpEntries[this._helpEntryIndex]?.sourceUrl === helpEntry.sourceUrl) {
+		// Help entries are identified by their target URL: the source URL they
+		// load from isn't resolved until the entry loads, and it changes when
+		// the extension host restarts.
+		if (this._helpEntries[this._helpEntryIndex]?.targetUrl === helpEntry.targetUrl) {
 			return;
 		}
 
@@ -646,21 +712,9 @@ class PositronHelpService extends Disposable implements IPositronHelpService {
 	}
 
 	showWelcomePage() {
-		// Add the help entry.
-		const helpEntry = this._instantiationService.createInstance(HelpEntry,
-			this._welcomeHTML,
-			'',
-			'',
-			'',
-			'welcome.html',
-			'welcome.html'
-		);
-
-		// Add the onDidNavigate event handler.
-		helpEntry.onDidNavigate(url => {
-			this.navigate(helpEntry.sourceUrl, url);
-		});
-		this.addHelpEntry(helpEntry);
+		// Add the help entry. The welcome page is bundled rather than served by
+		// a runtime's help server, so its target URL is loaded as-is.
+		this.addHelpEntry(this.createHelpEntry(this._welcomeHTML, '', '', '', 'welcome.html'));
 	}
 
 	private async handleShowHelpEvent(
@@ -696,47 +750,6 @@ class PositronHelpService extends Disposable implements IPositronHelpService {
 			return;
 		}
 
-		// Get the proxy server origin for the help URL. If one isn't found, ask the
-		// PositronProxy to start one.
-		let proxyServerOrigin = this._proxyServers.get(targetUrl.origin);
-		if (!proxyServerOrigin) {
-			// Ensure that the proxy server styles have been set.
-			if (!this._proxyServerStylesHaveBeenSet) {
-				await this.setProxyServerStyles();
-			}
-
-			// Try to start a help proxy server.
-			try {
-				proxyServerOrigin = await this._commandService.executeCommand<string>(
-					'positronProxy.startHelpProxyServer',
-					targetUrl.origin
-				);
-			} catch (error) {
-				this._logService.error(`PositronHelpService could not start the proxy server for ${targetUrl.origin}.`);
-				this._logService.error(error);
-			}
-
-			// If the help proxy server could not be started, notify the user, and return.
-			if (!proxyServerOrigin) {
-				this._notificationService.error(localize(
-					'positronHelpServiceUnavailable',
-					"The Positron help service is unavailable."
-				));
-				return;
-			}
-
-			// Add the proxy server.
-			this._proxyServers.set(targetUrl.origin, proxyServerOrigin);
-		}
-
-		// Create the source URL.
-		const sourceUrl = new URL(targetUrl);
-		const proxyServerOriginUrl = new URL(proxyServerOrigin);
-		sourceUrl.protocol = proxyServerOriginUrl.protocol;
-		sourceUrl.hostname = proxyServerOriginUrl.hostname;
-		sourceUrl.port = proxyServerOriginUrl.port;
-		sourceUrl.pathname = join(proxyServerOriginUrl.pathname, targetUrl.pathname);
-
 		// Basically this can't happen.
 		if (!session) {
 			this._notificationService.error(localize(
@@ -749,20 +762,15 @@ class PositronHelpService extends Disposable implements IPositronHelpService {
 		// Open the help view.
 		await this._viewsService.openView(POSITRON_HELP_VIEW_ID, false);
 
-		// Create the help entry.
-		const helpEntry = this._instantiationService.createInstance(HelpEntry,
+		// Create the help entry. The help entry resolves the proxied source URL
+		// it loads from on its own, when it loads; see resolveSourceUrl.
+		const helpEntry = this.createHelpEntry(
 			this._helpHTML,
 			session.runtimeMetadata.languageId,
 			session.runtimeMetadata.runtimeId,
 			session.runtimeMetadata.languageName,
-			sourceUrl.toString(),
 			targetUrl.toString()
 		);
-
-		// Add the onDidNavigate event handler.
-		this._register(helpEntry.onDidNavigate(url => {
-			this.navigate(helpEntry.sourceUrl, url);
-		}));
 
 		// Add the help entry.
 		this.addHelpEntry(helpEntry);

--- a/src/vs/workbench/contrib/positronHelp/test/browser/helpEntry.vitest.ts
+++ b/src/vs/workbench/contrib/positronHelp/test/browser/helpEntry.vitest.ts
@@ -22,6 +22,7 @@ const LOCALHOST_HELP_URL = 'http://localhost/help/library/graphics/html/plot.htm
 
 describe('HelpEntry', () => {
 	let messages: HelpMessage[];
+	let navigated: string[];
 	let helpEntry: HelpEntry;
 
 	// Emitter used to simulate messages posted from the help webview (e.g. a
@@ -66,8 +67,9 @@ describe('HelpEntry', () => {
 		.stub(IOpenerService, { open })
 		.build();
 
-	function createHelpEntry(sourceUrl: string = LOCALHOST_HELP_URL): void {
+	async function createHelpEntry(sourceUrl: string = LOCALHOST_HELP_URL): Promise<void> {
 		messages = [];
+		navigated = [];
 
 		helpEntry = ctx.disposables.add(ctx.instantiationService.createInstance(
 			HelpEntry,
@@ -75,9 +77,13 @@ describe('HelpEntry', () => {
 			'r',
 			'test-session',
 			'R',
-			sourceUrl,
 			URI.parse(LOCALHOST_HELP_URL).toString(),
+			async () => sourceUrl,
 		));
+
+		// The help service listens for navigation and opens the next help
+		// entry; stand in for it here.
+		ctx.disposables.add(helpEntry.onDidNavigate(toTargetUrl => navigated.push(toTargetUrl)));
 
 		const anchor = document.createElement('div');
 		Object.defineProperty(anchor, 'getBoundingClientRect', {
@@ -85,6 +91,10 @@ describe('HelpEntry', () => {
 		});
 		document.body.appendChild(anchor);
 		helpEntry.showHelpOverlayWebview(anchor);
+
+		// The help entry resolves its source URL as it loads, so let the load
+		// settle before the test posts messages from the webview.
+		await vi.runAllTimersAsync();
 	}
 
 	afterEach(() => {
@@ -95,7 +105,7 @@ describe('HelpEntry', () => {
 	describe('Find navigation', () => {
 		it('advances without moving focus into the Help webview', async () => {
 			vi.useFakeTimers();
-			createHelpEntry();
+			await createHelpEntry();
 
 			helpEntry.find('title', false);
 			await vi.runAllTimersAsync();
@@ -109,7 +119,7 @@ describe('HelpEntry', () => {
 			vi.useFakeTimers();
 			// The welcome page uses a relative source URL ('welcome.html'), which
 			// is not a valid absolute URL. See issue #14810.
-			createHelpEntry('welcome.html');
+			await createHelpEntry('welcome.html');
 
 			onMessageEmitter.fire({
 				message: {
@@ -127,9 +137,7 @@ describe('HelpEntry', () => {
 
 		it('navigates internally for same-origin help links', async () => {
 			vi.useFakeTimers();
-			createHelpEntry();
-			const navigated: string[] = [];
-			ctx.disposables.add(helpEntry.onDidNavigate(url => navigated.push(url.toString())));
+			await createHelpEntry();
 
 			const sameOriginUrl = 'http://localhost/help/library/graphics/html/hist.html';
 			onMessageEmitter.fire({

--- a/src/vs/workbench/contrib/positronHelp/test/browser/helpEntry.vitest.ts
+++ b/src/vs/workbench/contrib/positronHelp/test/browser/helpEntry.vitest.ts
@@ -8,6 +8,7 @@
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
+import { IColorTheme, IThemeService } from '../../../../../platform/theme/common/themeService.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { IOverlayWebview, IWebviewService, WebviewMessageReceivedEvent } from '../../../webview/browser/webview.js';
@@ -18,18 +19,32 @@ type HelpMessage = {
 	readonly findValue?: string;
 };
 
+// The help topic as the runtime's own help server serves it. This is the help
+// entry's stable identity; it outlives an extension host restart.
 const LOCALHOST_HELP_URL = 'http://localhost/help/library/graphics/html/plot.html';
+
+// The same topic as a help proxy server serves it. The proxy server lives in
+// the extension host, so a restart replaces it with one on another port.
+const PROXIED_HELP_URL = 'http://127.0.0.1:5001/help/library/graphics/html/plot.html';
+const RESTARTED_PROXIED_HELP_URL = 'http://127.0.0.1:5999/help/library/graphics/html/plot.html';
 
 describe('HelpEntry', () => {
 	let messages: HelpMessage[];
 	let navigated: string[];
 	let helpEntry: HelpEntry;
 
+	// The source URL the resolver hands back right now. Tests reassign this to
+	// stand in for an extension host restart, which leaves the previously
+	// resolved source URL naming a proxy server that is gone.
+	let sourceUrl: string;
+
 	// Emitter used to simulate messages posted from the help webview (e.g. a
 	// link click). Created at describe scope so the webview stub can hand out
 	// its `.event` reference; fired from individual tests.
 	const onMessageEmitter = new Emitter<WebviewMessageReceivedEvent>();
+	const onDidColorThemeChangeEmitter = new Emitter<IColorTheme>();
 	const open = vi.fn(async () => true);
+	const setHtml = vi.fn((_html: string) => { });
 
 	const overlayWebview = (): IOverlayWebview => stubInterface<IOverlayWebview>({
 		container: document.createElement('div'),
@@ -52,9 +67,11 @@ describe('HelpEntry', () => {
 			messages.push(message as HelpMessage);
 			return true;
 		},
-		setHtml: () => { },
+		setHtml,
 		claim: () => { },
+		release: () => { },
 		setAnchorElement: () => { },
+		hideFind: () => { },
 		dispose: () => { },
 		reload: () => { },
 	});
@@ -65,11 +82,35 @@ describe('HelpEntry', () => {
 			createWebviewOverlay: () => overlayWebview(),
 		})
 		.stub(IOpenerService, { open })
+		.stub(IThemeService, { onDidColorThemeChange: onDidColorThemeChangeEmitter.event })
 		.build();
 
-	async function createHelpEntry(sourceUrl: string = LOCALHOST_HELP_URL): Promise<void> {
+	/**
+	 * Gets the source URL the help overlay webview was last loaded from.
+	 */
+	const loadedSourceUrl = () =>
+		setHtml.mock.lastCall?.[0].match(/<html>(?<sourceUrl>.*)<\/html>/)?.groups?.sourceUrl;
+
+	/**
+	 * Shows the help entry over a fresh anchor element and lets the load settle.
+	 */
+	async function showHelpEntry(): Promise<void> {
+		const anchor = document.createElement('div');
+		Object.defineProperty(anchor, 'getBoundingClientRect', {
+			value: () => ({ x: 0, y: 0, width: 100, height: 100 }),
+		});
+		document.body.appendChild(anchor);
+		helpEntry.showHelpOverlayWebview(anchor);
+
+		// The help entry resolves its source URL as it loads, so let the load
+		// settle before the test posts messages from the webview.
+		await vi.runAllTimersAsync();
+	}
+
+	async function createHelpEntry(initialSourceUrl: string = LOCALHOST_HELP_URL): Promise<void> {
 		messages = [];
 		navigated = [];
+		sourceUrl = initialSourceUrl;
 
 		helpEntry = ctx.disposables.add(ctx.instantiationService.createInstance(
 			HelpEntry,
@@ -85,21 +126,40 @@ describe('HelpEntry', () => {
 		// entry; stand in for it here.
 		ctx.disposables.add(helpEntry.onDidNavigate(toTargetUrl => navigated.push(toTargetUrl)));
 
-		const anchor = document.createElement('div');
-		Object.defineProperty(anchor, 'getBoundingClientRect', {
-			value: () => ({ x: 0, y: 0, width: 100, height: 100 }),
-		});
-		document.body.appendChild(anchor);
-		helpEntry.showHelpOverlayWebview(anchor);
-
-		// The help entry resolves its source URL as it loads, so let the load
-		// settle before the test posts messages from the webview.
-		await vi.runAllTimersAsync();
+		await showHelpEntry();
 	}
 
 	afterEach(() => {
 		helpEntry?.dispose();
 		document.body.replaceChildren();
+	});
+
+	describe('Source URL resolution', () => {
+		it('resolves the source URL again when a hidden entry is shown once more', async () => {
+			vi.useFakeTimers();
+			await createHelpEntry(PROXIED_HELP_URL);
+
+			// Hide the entry long enough for its webview to be disposed, then
+			// bring it back to a proxy server that has moved, as it would have
+			// while the entry was off-screen across an extension host restart.
+			helpEntry.hideHelpOverlayWebview(true);
+			await vi.runAllTimersAsync();
+			sourceUrl = RESTARTED_PROXIED_HELP_URL;
+			await showHelpEntry();
+
+			expect(loadedSourceUrl()).toBe(RESTARTED_PROXIED_HELP_URL);
+		});
+
+		it('resolves the source URL again when the color theme changes', async () => {
+			vi.useFakeTimers();
+			await createHelpEntry(PROXIED_HELP_URL);
+
+			sourceUrl = RESTARTED_PROXIED_HELP_URL;
+			onDidColorThemeChangeEmitter.fire(stubInterface<IColorTheme>());
+			await vi.runAllTimersAsync();
+
+			expect(loadedSourceUrl()).toBe(RESTARTED_PROXIED_HELP_URL);
+		});
 	});
 
 	describe('Find navigation', () => {
@@ -147,6 +207,25 @@ describe('HelpEntry', () => {
 
 			expect(navigated).toEqual([sameOriginUrl]);
 			expect(open).not.toHaveBeenCalled();
+		});
+
+		it('reports a clicked link as a target URL, not the proxied URL', async () => {
+			vi.useFakeTimers();
+			await createHelpEntry(PROXIED_HELP_URL);
+
+			// A link click reaches us as the URL the webview navigated to, which
+			// carries the proxy server's origin. It becomes the next help
+			// entry's target URL, so it has to be converted back to the
+			// runtime's own help server or it can't be proxied again.
+			onMessageEmitter.fire({
+				message: {
+					id: 'positron-help-navigate',
+					url: 'http://127.0.0.1:5001/help/library/graphics/html/hist.html',
+				},
+			});
+			await vi.runAllTimersAsync();
+
+			expect(navigated).toEqual(['http://localhost/help/library/graphics/html/hist.html']);
 		});
 	});
 });

--- a/src/vs/workbench/contrib/positronHelp/test/browser/positronHelpService.vitest.ts
+++ b/src/vs/workbench/contrib/positronHelp/test/browser/positronHelpService.vitest.ts
@@ -1,0 +1,111 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+// The service resolves its bundled HTML with FileAccess.asFileUri, which needs
+// globalThis._VSCODE_FILE_ROOT. A bootstrap entry point normally sets that; a
+// plain Vitest run doesn't go through one, so set it here.
+vi.hoisted(() => {
+	globalThis._VSCODE_FILE_ROOT = new URL('../../../../../../..', import.meta.url).pathname;
+});
+
+import { Event } from '../../../../../base/common/event.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
+import { IThemeService } from '../../../../../platform/theme/common/themeService.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
+import { PositronHelpService } from '../../browser/positronHelpService.js';
+
+const START_PROXY_COMMAND = 'positronProxy.startHelpProxyServer';
+const TARGET_URL = 'http://localhost:1234/library/graphics/html/plot.html';
+
+describe('PositronHelpService', () => {
+	// The origin the extension host's PositronProxy currently reports. Tests
+	// reassign this to stand in for a proxy server that moved, which is what
+	// happens across an extension host restart.
+	let proxyOrigin: string | undefined;
+
+	const executeCommand = vi.fn(async (command: string) =>
+		command === START_PROXY_COMMAND ? proxyOrigin : undefined
+	);
+	const notifyError = vi.fn();
+
+	const ctx = createTestContainer()
+		.withRuntimeServices()
+		.stub(ICommandService, { executeCommand })
+		.stub(INotificationService, { error: notifyError })
+		// The service reads its bundled HTML in the constructor. Rejecting
+		// keeps the welcome page out of these tests; the failure is handled
+		// internally and only affects the HTML the pane would render.
+		.stub(IFileService, { readFile: () => Promise.reject(new Error('not needed')) })
+		.stub(IThemeService, { onDidColorThemeChange: Event.None })
+		.stub(IRuntimeSessionService, { onDidChangeRuntimeState: Event.None })
+		.build();
+
+	const createService = () =>
+		ctx.disposables.add(ctx.instantiationService.createInstance(PositronHelpService));
+
+	beforeEach(() => {
+		proxyOrigin = 'http://127.0.0.1:5001';
+	});
+
+	it('loads a target URL the runtime does not serve as-is', async () => {
+		const sourceUrl = await createService().resolveSourceUrl('welcome.html');
+
+		expect({
+			sourceUrl,
+			askedProxy: executeCommand.mock.calls.some(([c]) => c === START_PROXY_COMMAND),
+		}).toMatchInlineSnapshot(`
+			{
+			  "askedProxy": false,
+			  "sourceUrl": "welcome.html",
+			}
+		`);
+	});
+
+	it('builds the source URL from the proxy origin reported at resolve time', async () => {
+		const sourceUrl = await createService().resolveSourceUrl(TARGET_URL);
+
+		expect(sourceUrl).toMatchInlineSnapshot(`"http://127.0.0.1:5001/library/graphics/html/plot.html"`);
+	});
+
+	it('asks the proxy on every resolve instead of reusing the first origin', async () => {
+		const helpService = createService();
+
+		const first = await helpService.resolveSourceUrl(TARGET_URL);
+		// Stand in for an extension host restart: the old proxy server is gone
+		// and PositronProxy answers with a new one.
+		proxyOrigin = 'http://127.0.0.1:5999';
+		const second = await helpService.resolveSourceUrl(TARGET_URL);
+
+		expect({
+			first,
+			second,
+			proxyCalls: executeCommand.mock.calls.filter(([c]) => c === START_PROXY_COMMAND).length,
+		}).toMatchInlineSnapshot(`
+			{
+			  "first": "http://127.0.0.1:5001/library/graphics/html/plot.html",
+			  "proxyCalls": 2,
+			  "second": "http://127.0.0.1:5999/library/graphics/html/plot.html",
+			}
+		`);
+	});
+
+	it('reports the service as unavailable when no proxy server can be started', async () => {
+		proxyOrigin = undefined;
+
+		const sourceUrl = await createService().resolveSourceUrl(TARGET_URL);
+
+		expect({ sourceUrl, notified: notifyError.mock.calls.length }).toMatchInlineSnapshot(`
+			{
+			  "notified": 1,
+			  "sourceUrl": undefined,
+			}
+		`);
+	});
+});

--- a/src/vs/workbench/contrib/positronHelp/test/browser/positronHelpService.vitest.ts
+++ b/src/vs/workbench/contrib/positronHelp/test/browser/positronHelpService.vitest.ts
@@ -7,9 +7,14 @@
 
 // The service resolves its bundled HTML with FileAccess.asFileUri, which needs
 // globalThis._VSCODE_FILE_ROOT. A bootstrap entry point normally sets that; a
-// plain Vitest run doesn't go through one, so set it here.
+// plain Vitest run doesn't go through one, so set it here. Assigning through
+// Object.assign rather than naming the property keeps this free of editor
+// diagnostics: the declaration lives in src/typings, which the fallback project
+// the editor uses for .vitest.ts files doesn't load.
 vi.hoisted(() => {
-	globalThis._VSCODE_FILE_ROOT = new URL('../../../../../../..', import.meta.url).pathname;
+	Object.assign(globalThis, {
+		_VSCODE_FILE_ROOT: new URL('../../../../../../..', import.meta.url).pathname
+	});
 });
 
 import { Event } from '../../../../../base/common/event.js';


### PR DESCRIPTION
Replaces #15786.

Closes #15726 by completing the fix for cli's `{.help}` and `{.vignette}`
Closes #15776 (best concrete demo of the problem is here)

https://github.com/user-attachments/assets/224861f8-e83b-47fa-8000-cfa281f91761

#15786 stopped `PositronHelpService` from caching proxy origins and styles, which fixes the path that *creates* a help entry. It doesn't reach entries that already exist: their source URLs were resolved before the extension host restart and still name a dead port. Clicking a link on an already-open page, changing the color theme, or returning to an entry that has been off-screen past the 15s `DISPOSE_TIMEOUT` all reload an existing entry, and all of them go blank.

This follows the same advice from @jmcphers that shaped #15757: don't hold a reference to something the extension host owns, because a restart replaces it and anything still holding the old one is talking to a dead object. Hold the stable identifier instead, and look up the live thing at the moment you need it. There that meant `RuntimeSessionService` storing session IDs rather than session objects. Here a help entry stores only its target URL — the identifier that survives the restart — and resolves a source URL each time it loads its webview. Link clicks, theme reloads, and back/forward rebuilds all funnel through that one point, so it covers them together rather than one path at a time.

### What changed

- `HelpEntry` holds only its target URL and resolves a source URL on each load, through a resolver the help service supplies.
- Help entries are identified by target URL rather than source URL.
- A URL the webview navigates to is converted back to the runtime's help server before it becomes the next entry's target URL, so it can be proxied again the next time it loads.
- `PositronHelpService` no longer remembers proxy origins or that it has pushed styles; it asks every time. The extension host already returns the existing proxy server for a target origin, so this costs one command round trip per load.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Help topics and vignettes keep working after an extension host restart. Previously links on already-open pages stopped working and the Help pane went blank until the window was reloaded.

### Validation Steps

See #15776 for explicit repro/validation steps.
