### PR TITLE
Fix DuckDB lock conflicts between data connections and sessions - default to opening DuckDB databases as read only

### DIFF
--- a/extensions/positron-data-driver-duckdb/src/duckdbConnection.ts
+++ b/extensions/positron-data-driver-duckdb/src/duckdbConnection.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as positron from 'positron';
+import * as vscode from 'vscode';
 import { duckDBWorkerPool, IDuckDBWorkerLease, IDuckDBDataExplorerHost } from 'positron-data-explorer-duckdb';
 import { createSchemasGroupNode, IDuckDBPreviewHost } from './duckdbNodes.js';
 
@@ -12,6 +13,23 @@ export const DUCKDB_DATA_EXPLORER_PROVIDER_ID = 'positron-data-driver-duckdb';
 
 /** Monotonically increasing id so each connection's previewed datasets get a unique key. */
 let nextConnectionId = 1;
+
+/** Matches the native error DuckDB raises when another process already holds the file's lock. */
+const LOCK_CONFLICT_PATTERN = /could not set lock|conflicting lock/i;
+
+/**
+ * Formats an open failure for display. DuckDB takes an OS-level lock on a database file and allows
+ * it to be open in more than one process only when every one of them opens it read-only, so a lock
+ * conflict -- the Data Connections panel and a Python or R session both wanting the same file --
+ * gets an explanation of that rule rather than just the native error, whose text describes the
+ * holding process as a Positron helper or a bare interpreter path.
+ */
+function openFailureMessage(databasePath: string, detail: string): string {
+	if (LOCK_CONFLICT_PATTERN.test(detail)) {
+		return vscode.l10n.t('Could not open the DuckDB database "{0}" because another session has it locked. DuckDB allows a database file to be open in more than one session only when every one of them opens it read-only, so either close the other connection or open the database read-only in both places. {1}', databasePath, detail);
+	}
+	return vscode.l10n.t('Failed to open DuckDB database: {0}. {1}', databasePath, detail);
+}
 
 /**
  * Connection configuration passed from the driver.
@@ -83,8 +101,9 @@ export class DuckDBConnection implements positron.DataConnection, IDuckDBPreview
 		} catch (err: any) {
 			// Release the lease so the worker is torn down if we were the only one holding it.
 			lease.release();
-			this._logger?.error(`Failed to open ${databasePath}: ${err?.message ?? err}`);
-			throw new Error(`Failed to open DuckDB database: ${databasePath}. ${err?.message ?? err}`);
+			const detail = err?.message ?? String(err);
+			this._logger?.error(`Failed to open ${databasePath}: ${detail}`);
+			throw new Error(openFailureMessage(databasePath, detail));
 		}
 
 		this._logger?.info(`Opened ${databasePath}`);
@@ -171,7 +190,7 @@ export class DuckDBConnection implements positron.DataConnection, IDuckDBPreview
 	// Throws if the database has been disconnected.
 	private _ensureConnected(): void {
 		if (!this._lease) {
-			throw new Error('Database connection is closed');
+			throw new Error(vscode.l10n.t('Database connection is closed'));
 		}
 	}
 }

--- a/extensions/positron-data-driver-duckdb/src/duckdbDriver.ts
+++ b/extensions/positron-data-driver-duckdb/src/duckdbDriver.ts
@@ -54,6 +54,18 @@ function escapeDoubleQuoted(value: string): string {
 const FILE_MECHANISM_ID = 'file';
 
 /**
+ * Reads the `readOnly` parameter, defaulting to true to match the parameter's declared
+ * `defaultValue` so that a profile which omits the value behaves like one created today. Read-only
+ * is the default because DuckDB locks a database file per process and permits concurrent opens only
+ * when every process opens it read-only: it is what lets the Data Connections panel browse a
+ * database while a Python or R session is connected to the same file. Both the live connection and
+ * the generated connection code read the parameter through here so the two cannot disagree.
+ */
+function isReadOnly(params: positron.DataConnectionParameterValues): boolean {
+	return params.readOnly !== false;
+}
+
+/**
  * Creates the DuckDB DataConnectionDriver.
  * @param context The extension context, used to locate the icon asset.
  * @param dataExplorerHandler Hosts table views for previewing tables/views in the Data Explorer.
@@ -97,8 +109,9 @@ export function createDuckDBDriver(
 					{
 						id: 'readOnly',
 						label: vscode.l10n.t('Read Only'),
+						description: vscode.l10n.t('Allows other sessions to open the same database file while this connection is open.'),
 						type: positron.DataConnectionParameterType.Boolean,
-						defaultValue: false,
+						defaultValue: true,
 					},
 				],
 			},
@@ -109,7 +122,7 @@ export function createDuckDBDriver(
 				case FILE_MECHANISM_ID: {
 					// Extract parameters.
 					const rawDatabasePath = params.databasePath;
-					const readOnly = params.readOnly as boolean ?? false;
+					const readOnly = isReadOnly(params);
 
 					// Validate parameters.
 					if (!isNonEmptyString(rawDatabasePath)) {
@@ -138,7 +151,7 @@ export function createDuckDBDriver(
 		async generateConnectionCode(_mechanismId: string, languageId: string, params: positron.DataConnectionParameterValues): Promise<positron.ConnectionCodeVariant[]> {
 			// Extract parameters.
 			const databasePath = params.databasePath;
-			const readOnly = params.readOnly === true;
+			const readOnly = isReadOnly(params);
 
 			// A file path is required to generate valid connection code.
 			if (!isNonEmptyString(databasePath)) {

--- a/extensions/positron-data-driver-duckdb/src/test/dataConnectionIntegration.test.ts
+++ b/extensions/positron-data-driver-duckdb/src/test/dataConnectionIntegration.test.ts
@@ -96,10 +96,11 @@ suite('Data Connection Integration', () => {
 			assert.ok(pathParam);
 			assert.strictEqual(pathParam.type, 'file');
 
-			// Check the read only parameter.
+			// Check the read only parameter. It defaults to true so that a new connection can
+			// coexist with a Python or R session connected to the same database file.
 			const readOnlyParam = mechanism.parameters.find(p => p.id === 'readOnly');
-			assert.ok(readOnlyParam);
-			assert.strictEqual(readOnlyParam.type, 'boolean');
+			assert.ok(readOnlyParam && readOnlyParam.type === positron.DataConnectionParameterType.Boolean);
+			assert.strictEqual(readOnlyParam.defaultValue, true);
 		});
 	});
 
@@ -250,6 +251,60 @@ suite('Data Connection Integration', () => {
 
 			// Disconnect.
 			await conn.disconnect();
+		});
+	});
+
+	suite('Concurrent Access', () => {
+		// DuckDB locks a database file per process and allows it to be open in more than one process
+		// only when every one of them opens it read-only. The driver runs its database in a worker
+		// child process, so a DuckDBInstance opened here -- in the extension host -- is a second
+		// process from its point of view, standing in for the user's Python or R session.
+
+		test('read-only connection succeeds while another process holds the file read-only', async () => {
+			// Create a test DB and hold it open read-only, as a session connected with
+			// read_only=True would.
+			const dbPath = await createTestDb('shared.duckdb', 'CREATE TABLE t (x INTEGER);');
+			const holder = await DuckDBInstance.create(dbPath, { access_mode: 'READ_ONLY' });
+
+			// Both closes belong in the finally: a failed assertion would otherwise leave the
+			// driver's worker child process alive, holding a lock on a file teardown then deletes.
+			let conn: positron.DataConnection | undefined;
+			try {
+				// Connect read-only to the same file.
+				conn = await positron.dataConnections.connect('positron-data-driver-duckdb', 'file', {
+					databasePath: dbPath,
+					readOnly: true,
+				});
+
+				// Test that both connections coexist.
+				assert.strictEqual(await conn.isConnected(), true);
+			} finally {
+				await conn?.disconnect();
+				holder.closeSync();
+			}
+		});
+
+		test('read-write connection explains the lock conflict', async () => {
+			// Create a test DB and hold it open read-write, as a session connected without
+			// read_only=True would.
+			const dbPath = await createTestDb('locked.duckdb', 'CREATE TABLE t (x INTEGER);');
+			const holder = await DuckDBInstance.create(dbPath);
+
+			try {
+				// Test that connecting reports the conflict in terms of the rule that caused it,
+				// rather than passing DuckDB's raw lock error through on its own.
+				await assert.rejects(
+					async () => {
+						await positron.dataConnections.connect('positron-data-driver-duckdb', 'file', {
+							databasePath: dbPath,
+							readOnly: false,
+						});
+					},
+					/another session has it locked/
+				);
+			} finally {
+				holder.closeSync();
+			}
 		});
 	});
 

--- a/extensions/positron-data-driver-duckdb/src/test/dataConnectionIntegration.test.ts
+++ b/extensions/positron-data-driver-duckdb/src/test/dataConnectionIntegration.test.ts
@@ -290,12 +290,15 @@ suite('Data Connection Integration', () => {
 			const dbPath = await createTestDb('locked.duckdb', 'CREATE TABLE t (x INTEGER);');
 			const holder = await DuckDBInstance.create(dbPath);
 
+			// Should the connect unexpectedly succeed, the connection is closed here rather than
+			// left to hold a lock on a file teardown then deletes.
+			let conn: positron.DataConnection | undefined;
 			try {
 				// Test that connecting reports the conflict in terms of the rule that caused it,
 				// rather than passing DuckDB's raw lock error through on its own.
 				await assert.rejects(
 					async () => {
-						await positron.dataConnections.connect('positron-data-driver-duckdb', 'file', {
+						conn = await positron.dataConnections.connect('positron-data-driver-duckdb', 'file', {
 							databasePath: dbPath,
 							readOnly: false,
 						});
@@ -303,6 +306,7 @@ suite('Data Connection Integration', () => {
 					/another session has it locked/
 				);
 			} finally {
+				await conn?.disconnect();
 				holder.closeSync();
 			}
 		});

--- a/src/vs/workbench/contrib/positronDataConnections/browser/classes/dataConnectionsTreeInstance.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/classes/dataConnectionsTreeInstance.tsx
@@ -115,18 +115,9 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 			const entries = buildEntries(this._service);
 			this.setRoots(entries.map(wrapEntry));
 
-			// A loaded DTO subtree is only valid while its connection is open -- its node handles live
-			// in the ext host and die with the connection -- so drop the subtree of any entry that no
-			// longer has a live instance, and the next expand re-fetches against a fresh handle. Doing
-			// it here covers every route a connection can close by, not just the ones the tree starts:
-			// a collapse, a deferred close once the last Data Explorer closed, or the driver dropping
-			// the connection on its own.
-			for (const entry of entries) {
-				const id = entryNodeId(entry.profile);
-				if (entry.instance === undefined && this.hasLoadedChildren(id)) {
-					this.dropLoadedChildren(id);
-				}
-			}
+			// A loaded DTO subtree is only valid while its connection is open, so drop the subtree of
+			// any entry that no longer has a live instance.
+			this._dropClosedEntrySubtrees(entries);
 		};
 		this._register(this._service.onDidChangeProfiles(refreshRoots));
 		this._register(this._service.onDidChangeInstances(refreshRoots));
@@ -183,6 +174,32 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 		}
 		super.collapse(id);
 		await this._service.disconnect(node.entry.profile.id);
+	}
+
+	/**
+	 * Collapses and unloads every entry that no longer has a live connection. A loaded DTO subtree is
+	 * only valid while its connection is open -- its node handles live in the ext host and die with
+	 * the connection -- so the subtree is dropped and the next expand re-fetches against a fresh
+	 * handle.
+	 *
+	 * Collapsing matters as much as dropping: an entry left expanded with no children renders as a
+	 * twisty that spins forever, because the projection reads "expanded but not loaded" as a fetch in
+	 * flight and nothing is fetching. It goes through the base implementation rather than this class's
+	 * collapse, which means "the user gave up the connection" and would ask to close one that is
+	 * already gone.
+	 *
+	 * Called on every roots refresh, so it covers every route a connection can close by, not just the
+	 * ones the tree starts: a collapse, a deferred close once the last Data Explorer closed, an edit
+	 * to the profile's parameters, or the driver dropping the connection on its own.
+	 */
+	private _dropClosedEntrySubtrees(entries: readonly DataConnectionEntry[]): void {
+		for (const entry of entries) {
+			const id = entryNodeId(entry.profile);
+			if (entry.instance === undefined && this.hasLoadedChildren(id)) {
+				super.collapse(id);
+				this.dropLoadedChildren(id);
+			}
+		}
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionEntryRow.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionEntryRow.tsx
@@ -15,6 +15,7 @@ import { IDisposable } from '../../../../../base/common/lifecycle.js';
 import { ConfigureDataConnection } from '../dialogs/configureDataConnection.js';
 import { showConnectDataConnectionWith } from '../dialogs/connectDataConnectionWith.js';
 import { showRemoveDataConnectionConfirmation } from '../dialogs/removeDataConnectionConfirmation.js';
+import { showSaveDataConnectionConfirmation } from '../dialogs/saveDataConnectionConfirmation.js';
 import { DataConnectionEntry } from '../classes/dataConnectionsTreeInstance.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { PositronModalDialogReactRenderer } from '../../../../../base/browser/positronModalDialogReactRenderer.js';
@@ -130,7 +131,19 @@ export const DataConnectionEntryRow = ({ entry, onDisconnect, onMenuOpening, onR
 				mechanism={mechanism}
 				profile={target}
 				renderer={renderer}
-				onSave={updatedProfile => {
+				onSave={async updatedProfile => {
+					// Saving a value the connection was opened with closes it, and the Data Explorers
+					// previewed from it with it. Confirm before taking the user's grids down; with
+					// none open there is nothing to warn about. Leaving the edit dialog up on a
+					// cancel keeps the user's unsaved changes.
+					if (positronDataConnectionsService.wouldCloseConnection(updatedProfile)) {
+						const openDataExplorerCount = positronDataConnectionsService.countOpenDataExplorers(target.id);
+						if (openDataExplorerCount > 0 &&
+							!await showSaveDataConnectionConfirmation(target.connectionName, openDataExplorerCount)) {
+							return;
+						}
+					}
+
 					positronDataConnectionsService.addUpdateProfile(updatedProfile);
 					renderer.dispose();
 				}}

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnection.css
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnection.css
@@ -54,6 +54,16 @@
 	flex-direction: column;
 }
 
+/*
+ * Every other parameter is a label line above a control, and the 8px gap between fields separates
+ * those pairs. A checkbox carries its label inline, so it has no label line to act as its header and
+ * the bare gap leaves it reading as part of the field above it. The extra space stands in for the
+ * missing line, putting the checkbox back in the same rhythm as its neighbors.
+ */
+.configure-data-connection .parameter-checkbox-field {
+	margin-top: 6px;
+}
+
 .configure-data-connection .parameter-label {
 	font-size: 11px;
 	color: var(--vscode-descriptionForeground);

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnectionParameters.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/configureDataConnectionParameters.tsx
@@ -88,7 +88,7 @@ export const ConfigureDataConnectionParameters = ({
 					// Boolean parameter.
 					case 'boolean': {
 						return (
-							<div key={parameter.id}>
+							<div key={parameter.id} className='parameter-checkbox-field'>
 								<Checkbox
 									initialChecked={parameterFieldStates[parameter.id].value as boolean}
 									label={parameter.label}

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/saveDataConnectionConfirmation.css
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/saveDataConnectionConfirmation.css
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/*
+ * Separates the consequences of saving into paragraphs, matching the Remove Connection confirmation
+ * so the two read alike when a user meets them in the same session.
+ */
+.save-data-connection-confirmation {
+	display: flex;
+	gap: 12px;
+	flex-direction: column;
+}

--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/saveDataConnectionConfirmation.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/saveDataConnectionConfirmation.tsx
@@ -1,0 +1,118 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import './saveDataConnectionConfirmation.css';
+
+// Other dependencies.
+import { localize } from '../../../../../nls.js';
+import { PositronModalDialogReactRenderer } from '../../../../../base/browser/positronModalDialogReactRenderer.js';
+import { TwoButtonFooter } from '../../../../browser/positronComponents/positronDynamicModalDialog/components/twoButtonFooter.js';
+import { PositronDynamicModalDialog } from '../../../../browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.js';
+
+// The width of the Save Changes confirmation dialog.
+const SAVE_CONNECTION_CONFIRMATION_WIDTH = 460;
+
+/**
+ * Shows the Save Changes confirmation dialog. A connection is opened from the values a profile had
+ * at the time, so editing any of them closes it -- and the Data Explorers previewed from it, whose
+ * backends die with it. Nothing is lost that cannot be reopened, but the user is not expecting a
+ * save to take their grids down, so the dialog says so first.
+ * @param connectionName The name of the connection being edited.
+ * @param openDataExplorerCount How many Data Explorers previewed from the connection are open, and
+ * so will close along with it. Always at least one; a save with none open does not need confirming.
+ * @returns A promise that resolves to true if the user confirmed, or false if they cancelled.
+ */
+export const showSaveDataConnectionConfirmation = (
+	connectionName: string,
+	openDataExplorerCount: number
+): Promise<boolean> => {
+	// Create the renderer.
+	const renderer = new PositronModalDialogReactRenderer();
+
+	return new Promise<boolean>(resolve => {
+		// Settle once: dispose the renderer and resolve with the user's choice. Guards against the
+		// dialog's onCancel firing again after an explicit Save or Cancel.
+		let settled = false;
+		const settle = (confirmed: boolean) => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			renderer.dispose();
+			resolve(confirmed);
+		};
+
+		// Render the dialog.
+		renderer.render(
+			<SaveDataConnectionConfirmation
+				connectionName={connectionName}
+				openDataExplorerCount={openDataExplorerCount}
+				renderer={renderer}
+				onCancel={() => settle(false)}
+				onConfirm={() => settle(true)}
+			/>
+		);
+	});
+};
+
+/**
+ * SaveDataConnectionConfirmationProps interface.
+ */
+interface SaveDataConnectionConfirmationProps {
+	readonly connectionName: string;
+	readonly openDataExplorerCount: number;
+	readonly renderer: PositronModalDialogReactRenderer;
+	readonly onConfirm: () => void;
+	readonly onCancel: () => void;
+}
+
+/**
+ * SaveDataConnectionConfirmation component.
+ * @param props The component props.
+ */
+const SaveDataConnectionConfirmation = (props: SaveDataConnectionConfirmationProps) => {
+	// The consequence of saving. Named separately per count, since localized strings cannot select a
+	// plural form from a placeholder.
+	const dataExplorersDetail = props.openDataExplorerCount === 1
+		? localize(
+			'positron.saveDataConnectionConfirmation.oneDataExplorer',
+			"The Data Explorer open on this connection will close."
+		)
+		: localize(
+			'positron.saveDataConnectionConfirmation.manyDataExplorers',
+			"The {0} Data Explorers open on this connection will close.",
+			props.openDataExplorerCount
+		);
+
+	return (
+		<PositronDynamicModalDialog
+			content={
+				<div className='save-data-connection-confirmation'>
+					<div>
+						{localize(
+							'positron.saveDataConnectionConfirmation.detail',
+							"These changes close the connection to '{0}' so it can reopen with the new settings.",
+							props.connectionName
+						)}
+					</div>
+					<div>{dataExplorersDetail}</div>
+				</div>
+			}
+			footer={
+				<TwoButtonFooter
+					primaryButtonTitle={localize('positron.saveDataConnectionConfirmation.confirm', "Save")}
+					secondaryButtonTitle={localize('positron.saveDataConnectionConfirmation.cancel', "Cancel")}
+					onPrimaryButton={props.onConfirm}
+					onSecondaryButton={props.onCancel}
+				/>
+			}
+			renderer={props.renderer}
+			title={localize('positron.saveDataConnectionConfirmation.title', "Save Changes?")}
+			width={SAVE_CONNECTION_CONFIRMATION_WIDTH}
+			onCancel={props.onCancel}
+		/>
+	);
+};

--- a/src/vs/workbench/contrib/positronDataConnections/test/browser/dataConnectionsTreeInstance.vitest.ts
+++ b/src/vs/workbench/contrib/positronDataConnections/test/browser/dataConnectionsTreeInstance.vitest.ts
@@ -331,4 +331,20 @@ describe('DataConnectionsTreeInstance', () => {
 		await tree.expand(ENTRY_ID);
 		expect(getChildren).toHaveBeenCalledTimes(2);
 	});
+
+	it('collapses an entry that was still expanded when its connection closed', async () => {
+		const { tree, setConnected } = createTree();
+		await tree.refresh();
+		await tree.expand(ENTRY_ID);
+
+		// The connection closes under an expanded entry: an edit to its parameters, or the driver
+		// dropping it. Dropping the subtree alone would leave the row expanded with no children,
+		// which the projection reads as a fetch in flight and renders as a twisty spinning forever.
+		setConnected(false);
+
+		expect({
+			expanded: tree.isExpanded(ENTRY_ID),
+			expandState: tree.visibleNodes[0].expandState,
+		}).toEqual({ expanded: false, expandState: 'collapsed' });
+	});
 });

--- a/src/vs/workbench/services/positronDataConnections/browser/positronDataConnectionsService.ts
+++ b/src/vs/workbench/services/positronDataConnections/browser/positronDataConnectionsService.ts
@@ -194,17 +194,18 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 	 * @param profile The data connection profile to add or update.
 	 */
 	addUpdateProfile(profile: IDataConnectionProfile): void {
+		// Whether the edit changes the values a live connection was opened with. Read before
+		// sanitizing, because sanitizing writes any submitted secret to secret storage and so erases
+		// the difference between an unchanged secret and a freshly typed one.
+		const index = this._profiles.findIndex(_ => _.id === profile.id);
+		const parameterValuesChanged = index >= 0 && this._parameterValuesChanged(this._profiles[index], profile);
+
 		// Sanitize the data connection profile by splitting out secret parameter values into
 		// secret storage.
 		const sanitizedProfile = this._splitAndPersistSecrets(profile);
 
-		// Replace or add the sanitized data connection profile in memory, noting whether the edit
-		// changed the values the live connection was opened with. Both sides of the comparison are
-		// sanitized, so a secret value cannot read as a change just because it was stripped.
-		const index = this._profiles.findIndex(_ => _.id === profile.id);
-		let parameterValuesChanged = false;
+		// Replace or add the sanitized data connection profile in memory.
 		if (index >= 0) {
-			parameterValuesChanged = !equals(this._profiles[index].parameterValues, sanitizedProfile.profile.parameterValues);
 			this._profiles[index] = sanitizedProfile.profile;
 		} else {
 			this._profiles.push(sanitizedProfile.profile);
@@ -232,6 +233,21 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 
 		// Raise the onDidChangeProfiles event.
 		this._onDidChangeProfilesEmitter.fire([...this._profiles]);
+	}
+
+	/**
+	 * Whether saving the given profile would close its live connection: true when a connection is
+	 * open and the edit changes a value it was opened with. {@link addUpdateProfile} applies the same
+	 * test, so a caller can use this to warn the user before a save takes their Data Explorers down
+	 * with the connection.
+	 * @param profile The edited data connection profile, as it would be passed to addUpdateProfile.
+	 */
+	wouldCloseConnection(profile: IDataConnectionProfile): boolean {
+		if (this.getInstanceForProfile(profile.id) === undefined) {
+			return false;
+		}
+		const existing = this._profiles.find(_ => _.id === profile.id);
+		return existing !== undefined && this._parameterValuesChanged(existing, profile);
 	}
 
 	/**
@@ -820,6 +836,58 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 	 * Empty secret values are treated as "no change" so the edit dialog can show an asterisk
 	 * placeholder without the user being forced to retype the secret each save.
 	 */
+	/**
+	 * Whether an edit changes any parameter value the existing profile's connection was opened with.
+	 *
+	 * Secrets need their own test rather than a value comparison: `existing` is sanitized, so its
+	 * secret values are not there to compare against. The form carries a secret value only when the
+	 * user typed one -- an untouched secret field submits nothing and the stored value is preserved
+	 * -- so a submitted secret is by definition a new one, and a connection opened with the old
+	 * credentials no longer matches the profile.
+	 * @param existing The in-memory (sanitized) profile.
+	 * @param incoming The edited profile, before sanitizing.
+	 */
+	private _parameterValuesChanged(existing: IDataConnectionProfile, incoming: IDataConnectionProfile): boolean {
+		const previousSecretParameterIds = new Set(this._readPersistedProfile(incoming.id)?.secretParameterIds ?? []);
+		const secretParameterIds = this._secretParameterIds(incoming, previousSecretParameterIds);
+
+		// A submitted secret value is a new one.
+		for (const secretParameterId of secretParameterIds) {
+			const submittedValue = incoming.parameterValues[secretParameterId];
+			if (typeof submittedValue === 'string' && submittedValue.length > 0) {
+				return true;
+			}
+		}
+
+		// Compare what is left against the sanitized profile, like for like.
+		const incomingPublicParameterValues: typeof incoming.parameterValues = {};
+		for (const [key, value] of Object.entries(incoming.parameterValues)) {
+			if (!secretParameterIds.has(key)) {
+				incomingPublicParameterValues[key] = value;
+			}
+		}
+		return !equals(existing.parameterValues, incomingPublicParameterValues);
+	}
+
+	/**
+	 * The ids of the profile's secret parameters, per its mechanism's current schema.
+	 *
+	 * If the mechanism can't be resolved (the driver's extension isn't registered/activated at save
+	 * time), falls back to the previously known secret schema instead of treating "unknown" as "no
+	 * secrets" -- otherwise already-secret parameter values would be treated as public.
+	 * @param profile The data connection profile whose schema to read.
+	 * @param previousSecretParameterIds The secret ids recorded the last time the profile was saved.
+	 */
+	private _secretParameterIds(profile: IDataConnectionProfile, previousSecretParameterIds: Set<string>): Set<string> {
+		const driver = this.driverManager.getDriver(profile.driverMetadata.id);
+		const mechanism = driver ? resolveDataConnectionMechanism(driver.metadata, profile.mechanismId) : undefined;
+		return mechanism
+			? new Set(mechanism.parameters
+				.filter(_ => (_.type === 'password' || _.type === 'string') && _.secret === true)
+				.map(_ => _.id))
+			: previousSecretParameterIds;
+	}
+
 	private _splitAndPersistSecrets(profile: IDataConnectionProfile): IPersistedDataConnectionProfile {
 		// Read the previously-persisted data connection profile so we can preserve any stored
 		// secrets the form didn't touch, and clean up orphans when the driver schema changes.
@@ -828,18 +896,7 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 
 		// Identify the current secret parameter ids from the profile's mechanism. A profile is tied to
 		// a single mechanism, so only that mechanism's parameters define its secret schema.
-		const driver = this.driverManager.getDriver(profile.driverMetadata.id);
-		const mechanism = driver ? resolveDataConnectionMechanism(driver.metadata, profile.mechanismId) : undefined;
-
-		// If the mechanism can't be resolved (the driver's extension isn't registered/activated at
-		// save time), fall back to the previously known secret schema instead of treating "unknown"
-		// as "no secrets" -- otherwise already-secret parameter values would be persisted in
-		// plaintext below.
-		const secretParamIdSet = mechanism
-			? new Set(mechanism.parameters
-				.filter(_ => (_.type === 'password' || _.type === 'string') && _.secret === true)
-				.map(_ => _.id))
-			: previousSecretParameterIds;
+		const secretParamIdSet = this._secretParameterIds(profile, previousSecretParameterIds);
 
 		// Build the public parameter values and the new list of secret parameter ids.
 		// Iterate the driver's current secret schema (not the form's parameterValues) so an absent

--- a/src/vs/workbench/services/positronDataConnections/browser/positronDataConnectionsService.ts
+++ b/src/vs/workbench/services/positronDataConnections/browser/positronDataConnectionsService.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { equals } from '../../../../base/common/objects.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
@@ -32,6 +33,15 @@ const profileStorageKey = (profileId: string) =>
 // Builds the secret storage key for a given data connection secret profile/parameter pair.
 const secretKey = (profileId: string, parameterId: string) =>
 	`positron.dataConnections.secret.${profileId}.${parameterId}`;
+
+// Marks the one-time read-only correction applied to DuckDB profiles saved before the driver's
+// Read Only parameter defaulted to true. See _migrateDuckDBProfilesToReadOnly.
+const DUCKDB_READ_ONLY_MIGRATION_KEY = 'positron.dataConnections.duckdbReadOnlyMigration';
+
+// The DuckDB driver and its Read Only parameter, named here only for that one-time correction.
+// Nothing else in this service is driver-specific; keep it that way.
+const DUCKDB_DRIVER_ID = 'positron-data-driver-duckdb';
+const READ_ONLY_PARAMETER_ID = 'readOnly';
 
 // Persisted form of a data connection profile, with secrets split out to secret storage and the
 // list of secret parameter ids for lookup and cleanup purposes. This is the shape stored in
@@ -188,9 +198,13 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 		// secret storage.
 		const sanitizedProfile = this._splitAndPersistSecrets(profile);
 
-		// Replace or add the sanitized data connection profile in memory.
+		// Replace or add the sanitized data connection profile in memory, noting whether the edit
+		// changed the values the live connection was opened with. Both sides of the comparison are
+		// sanitized, so a secret value cannot read as a change just because it was stripped.
 		const index = this._profiles.findIndex(_ => _.id === profile.id);
+		let parameterValuesChanged = false;
 		if (index >= 0) {
+			parameterValuesChanged = !equals(this._profiles[index].parameterValues, sanitizedProfile.profile.parameterValues);
 			this._profiles[index] = sanitizedProfile.profile;
 		} else {
 			this._profiles.push(sanitizedProfile.profile);
@@ -206,6 +220,15 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 
 		// Log the addition or update.
 		this._logService.trace(`[DataConnections] Added or updated profile: ${sanitizedProfile.profile.id}`);
+
+		// A live connection was opened from the old parameter values, so it no longer represents the
+		// profile: it is still pointed at the old database file, or -- for a DuckDB connection whose
+		// Read Only value changed -- still holds the file lock the new values were chosen to avoid.
+		// Close it and let the user reconnect. Fire-and-forget, as elsewhere: callers of
+		// addUpdateProfile shouldn't block on the round trip that closes the channel.
+		if (parameterValuesChanged) {
+			void this.disconnect(sanitizedProfile.profile.id);
+		}
 
 		// Raise the onDidChangeProfiles event.
 		this._onDidChangeProfilesEmitter.fire([...this._profiles]);
@@ -692,6 +715,45 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 				this._logService.error(`[DataConnections] Failed to parse persisted profile at ${profileKey}: ${error}`);
 			}
 		}
+
+		// Correct the loaded profiles that predate the DuckDB driver's read-only default.
+		this._migrateDuckDBProfilesToReadOnly();
+	}
+
+	/**
+	 * Turns Read Only on for DuckDB profiles saved while the driver's Read Only parameter defaulted
+	 * to false.
+	 *
+	 * DuckDB takes an OS-level lock on a database file and allows it to be open in more than one
+	 * process only when every one of them opens it read-only. A read-write profile therefore cannot
+	 * be browsed here while the user's Python or R session is connected to the same file, and the
+	 * connection code such a profile generates is read-write to match, so neither side works
+	 * (posit-dev/positron#15795). The driver now defaults the parameter to true; this brings the
+	 * profiles saved before that change to the same place.
+	 *
+	 * Runs once ever, so a user who deliberately turns Read Only back off keeps that choice. Runs
+	 * during load, before anything can be listening, so it does not fire onDidChangeProfiles.
+	 */
+	private _migrateDuckDBProfilesToReadOnly(): void {
+		// Nothing to do if the correction has already been applied.
+		if (this._storageService.getBoolean(DUCKDB_READ_ONLY_MIGRATION_KEY, StorageScope.PROFILE, false)) {
+			return;
+		}
+
+		// Record it up front so a failure partway through cannot re-run against profiles the user
+		// has since changed.
+		this._storageService.store(DUCKDB_READ_ONLY_MIGRATION_KEY, true, StorageScope.PROFILE, StorageTarget.USER);
+
+		// Turn Read Only on for every read-write DuckDB profile.
+		for (const profile of this._profiles) {
+			if (profile.driverMetadata.id !== DUCKDB_DRIVER_ID ||
+				profile.parameterValues[READ_ONLY_PARAMETER_ID] !== false) {
+				continue;
+			}
+			profile.parameterValues[READ_ONLY_PARAMETER_ID] = true;
+			this._persistProfileMetadata(profile);
+			this._logService.trace(`[DataConnections] Turned Read Only on for DuckDB profile ${profile.id}`);
+		}
 	}
 
 	/**
@@ -714,9 +776,9 @@ export class PositronDataConnectionsService extends Disposable implements IPosit
 
 	/**
 	 * Persists an in-memory profile's current fields to storage, preserving its existing secret
-	 * parameter id list. Used for metadata-only updates (preferred code variant, mechanism id
-	 * backfill) that don't go through {@link addUpdateProfile}'s secret-splitting logic because
-	 * they never touch parameterValues.
+	 * parameter id list. Used for updates (preferred code variant, mechanism id backfill, the
+	 * DuckDB read-only correction) that don't go through {@link addUpdateProfile}'s secret-splitting
+	 * logic because they never touch a secret parameter value.
 	 * @param profile The in-memory data connection profile to persist.
 	 */
 	private _persistProfileMetadata(profile: IDataConnectionProfile): void {

--- a/src/vs/workbench/services/positronDataConnections/common/interfaces/positronDataConnectionsService.ts
+++ b/src/vs/workbench/services/positronDataConnections/common/interfaces/positronDataConnectionsService.ts
@@ -53,10 +53,20 @@ export interface IPositronDataConnectionsService extends IDisposable {
 	saveDiscoveredProfile(id: string): string | undefined;
 
 	/**
-	 * Adds or updates a data connection profile.
+	 * Adds or updates a data connection profile. An edit that changes a value the profile's live
+	 * connection was opened with closes that connection, since it no longer represents the profile;
+	 * {@link wouldCloseConnection} reports that in advance.
 	 * @param profile The data connection profile to add or update.
 	 */
 	addUpdateProfile(profile: IDataConnectionProfile): void;
+
+	/**
+	 * Whether saving the given profile would close its live connection: true when a connection is
+	 * open and the edit changes a value it was opened with. Use it to warn the user before a save
+	 * takes their Data Explorers down with the connection.
+	 * @param profile The edited data connection profile, as it would be passed to addUpdateProfile.
+	 */
+	wouldCloseConnection(profile: IDataConnectionProfile): boolean;
 
 	/**
 	 * Gets all saved data connection profiles.

--- a/src/vs/workbench/services/positronDataConnections/test/browser/positronDataConnectionsService.vitest.ts
+++ b/src/vs/workbench/services/positronDataConnections/test/browser/positronDataConnectionsService.vitest.ts
@@ -8,7 +8,7 @@
 import { URI } from '../../../../../base/common/uri.js';
 import { Emitter } from '../../../../../base/common/event.js';
 import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
-import { IStorageService } from '../../../../../platform/storage/common/storage.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { ISecretStorageService } from '../../../../../platform/secrets/common/secrets.js';
 import { TestSecretStorageService } from '../../../../../platform/secrets/test/common/testSecretStorageService.js';
 import { TestStorageService } from '../../../../test/common/workbenchTestServices.js';
@@ -174,6 +174,112 @@ describe('PositronDataConnectionsService', () => {
 		// The new value must still be routed to secret storage, not leaked as plaintext into the
 		// public profile returned by getProfile.
 		expect(service.getProfile('conn-1')?.parameterValues).toEqual({});
+	});
+
+	describe('DuckDB read-only correction', () => {
+		// A DuckDB profile with the given Read Only value.
+		const duckdbProfile = (id: string, readOnly: boolean): IDataConnectionProfile => ({
+			...createProfile(id),
+			driverMetadata: { ...createProfile(id).driverMetadata, id: 'positron-data-driver-duckdb' },
+			parameterValues: { databasePath: '/tmp/db.duckdb', readOnly },
+		});
+
+		// Writes a profile into storage the way an older Positron would have left it. Seeding
+		// directly rather than through a service matters: constructing a service is what marks the
+		// correction as applied, so a service built against this storage first would suppress it.
+		const persistProfile = (storage: TestStorageService, profile: IDataConnectionProfile) =>
+			storage.store(
+				`positron.dataConnections.profile.${profile.id}`,
+				JSON.stringify({ profile, secretParameterIds: [] }),
+				StorageScope.PROFILE,
+				StorageTarget.USER,
+			);
+
+		// A storage no service has been constructed against, so the correction has yet to run.
+		const unmigratedStorage = () => {
+			const storage = new TestStorageService();
+			ctx.disposables.add(storage);
+			ctx.instantiationService.stub(IStorageService, storage);
+			return storage;
+		};
+
+		// Starts a service against the current storage, as a window start would.
+		const startService = () => {
+			const started = ctx.instantiationService.createInstance(PositronDataConnectionsService);
+			ctx.disposables.add(started);
+			return started;
+		};
+
+		it('turns Read Only on for DuckDB profiles only', () => {
+			const storage = unmigratedStorage();
+			persistProfile(storage, duckdbProfile('duck-1', false));
+			persistProfile(storage, { ...createProfile('other-1'), parameterValues: { readOnly: false } });
+
+			const started = startService();
+
+			expect({
+				duckdb: started.getProfile('duck-1')?.parameterValues.readOnly,
+				other: started.getProfile('other-1')?.parameterValues.readOnly,
+			}).toEqual({ duckdb: true, other: false });
+		});
+
+		it('leaves Read Only off when the user turns it off after the correction', () => {
+			const storage = unmigratedStorage();
+			persistProfile(storage, duckdbProfile('duck-1', false));
+
+			// The correction runs on this start, and the user then turns Read Only back off.
+			startService().addUpdateProfile(duckdbProfile('duck-1', false));
+
+			// A later start must respect that choice rather than correcting it again.
+			expect(startService().getProfile('duck-1')?.parameterValues.readOnly).toBe(false);
+		});
+	});
+
+	describe('editing a connected profile', () => {
+		// Saves 'conn-1' with the given parameter values and connects it.
+		const connectProfile = (parameterValues: Record<string, boolean | number | string>) => {
+			service.driverManager.registerDriver(stubInterface<IDataConnectionDriver>({
+				id: 'test-driver',
+				metadata: createDriverMetadata(),
+				connect: async () => stubInterface<IDataConnectionHandle>({
+					handle: 1,
+					disconnect: async () => { },
+					release: () => { },
+				}),
+			}));
+			service.addUpdateProfile({ ...createProfile('conn-1'), parameterValues });
+			return service.connect('conn-1');
+		};
+
+		it('closes the connection when a parameter value changes', async () => {
+			await connectProfile({ databasePath: '/tmp/db.duckdb', readOnly: false });
+
+			// The user turns Read Only on. The live connection still holds the exclusive file lock
+			// that the new value was chosen to release, so it must not survive the edit.
+			//
+			// The close is fire-and-forget, so this asserts on disconnect() dropping the instance
+			// before its first await -- which it must, since closing an editor lands back in
+			// disconnect() for the same profile and the drop is what makes that a no-op.
+			service.addUpdateProfile({
+				...createProfile('conn-1'),
+				parameterValues: { databasePath: '/tmp/db.duckdb', readOnly: true },
+			});
+
+			expect(service.getInstanceForProfile('conn-1')).toBeUndefined();
+		});
+
+		it('keeps the connection when the edit leaves parameter values alone', async () => {
+			await connectProfile({ databasePath: '/tmp/db.duckdb', readOnly: true });
+
+			// Renaming touches nothing the connection was opened with.
+			service.addUpdateProfile({
+				...createProfile('conn-1'),
+				connectionName: 'Renamed',
+				parameterValues: { databasePath: '/tmp/db.duckdb', readOnly: true },
+			});
+
+			expect(service.getInstanceForProfile('conn-1')).toBeDefined();
+		});
 	});
 
 	describe('open Data Explorers', () => {

--- a/src/vs/workbench/services/positronDataConnections/test/browser/positronDataConnectionsService.vitest.ts
+++ b/src/vs/workbench/services/positronDataConnections/test/browser/positronDataConnectionsService.vitest.ts
@@ -236,11 +236,16 @@ describe('PositronDataConnectionsService', () => {
 	});
 
 	describe('editing a connected profile', () => {
-		// Saves 'conn-1' with the given parameter values and connects it.
-		const connectProfile = (parameterValues: Record<string, boolean | number | string>) => {
+		// Saves 'conn-1' with the given parameter values and connects it. `parameters` declares the
+		// mechanism's schema, which is what tells the service which values are secret.
+		const connectProfile = (
+			parameterValues: Record<string, boolean | number | string>,
+			parameters: IDataConnectionDriverMetadata['mechanisms'][number]['parameters'] = []
+		) => {
+			const metadata = createDriverMetadata();
 			service.driverManager.registerDriver(stubInterface<IDataConnectionDriver>({
 				id: 'test-driver',
-				metadata: createDriverMetadata(),
+				metadata: { ...metadata, mechanisms: [{ ...metadata.mechanisms[0], parameters }] },
 				connect: async () => stubInterface<IDataConnectionHandle>({
 					handle: 1,
 					disconnect: async () => { },
@@ -266,6 +271,36 @@ describe('PositronDataConnectionsService', () => {
 			});
 
 			expect(service.getInstanceForProfile('conn-1')).toBeUndefined();
+		});
+
+		it('closes the connection when a secret is retyped', async () => {
+			await connectProfile({ host: 'db.example.com', apiKey: 'sekret' }, [
+				{ id: 'apiKey', label: 'API Key', type: 'password', secret: true },
+			]);
+
+			// A secret is stripped from the sanitized values on both sides of the comparison, so it
+			// cannot be caught by comparing them -- and a connection left running on rotated
+			// credentials is exactly the case that must not be missed.
+			service.addUpdateProfile({
+				...createProfile('conn-1'),
+				parameterValues: { host: 'db.example.com', apiKey: 'new-sekret' },
+			});
+
+			expect(service.getInstanceForProfile('conn-1')).toBeUndefined();
+		});
+
+		it('reports in advance whether a save would close the connection', async () => {
+			await connectProfile({ databasePath: '/tmp/db.duckdb', readOnly: false });
+
+			// What the edit dialog asks before warning the user that their Data Explorers will close.
+			const edited = (readOnly: boolean) => ({
+				...createProfile('conn-1'),
+				parameterValues: { databasePath: '/tmp/db.duckdb', readOnly },
+			});
+			expect({
+				changed: service.wouldCloseConnection(edited(true)),
+				unchanged: service.wouldCloseConnection(edited(false)),
+			}).toEqual({ changed: true, unchanged: false });
 		});
 
 		it('keeps the connection when the edit leaves parameter values alone', async () => {


### PR DESCRIPTION
Fixes #15795.

DuckDB takes an OS-level lock on a database file, so the Data Connections panel and a Python or R session could not have the same database open at once. Whichever connected first won; the other got a raw `IO Error: Could not set lock on file ...` naming a Positron helper process or a bare interpreter path.

I probed the actual constraint with the same `@duckdb/node-api` the drivers use, across two processes on one file:

| holder | second opener | result |
| --- | --- | --- |
| read-write | read-write | conflicting lock |
| read-write | read-only | conflicting lock |
| read-only | read-write | conflicting lock |
| **read-only** | **read-only** | **OK** |

Both sides opening read-only is the only configuration that coexists, and the panel never writes -- it browses schemas and reads rows. So DuckDB connections now default to read-only, which makes the reported workflow work out of the box.

### What changed

**The DuckDB driver defaults to read-only.** `readOnly` now declares `defaultValue: true` and carries help text under the checkbox. `connect` and `generateConnectionCode` read the parameter through one `isReadOnly()` helper -- they previously disagreed on the missing-value case (`?? false` vs `=== true`), so a live connection could differ in mode from the code the profile handed you.

**Lock conflicts explain themselves.** A conflicting-lock failure on open now says the database is locked by another session and that DuckDB only allows concurrent opens when every one of them is read-only, with DuckDB's own text (which names the holding PID) appended. The other two user-facing throws in that file are localized to match; all three surface in the connection tree's error state.

**Existing profiles are corrected once.** Profiles saved before this change store `readOnly: false` explicitly, so the new default would not reach them. A one-time correction at profile load turns Read Only on for read-write DuckDB profiles. It is guarded by a storage flag written before the loop, so a user who deliberately turns Read Only back off keeps that choice.

**Editing a connected profile closes its connection.** A connection opened from the old parameter values no longer represents the profile -- it is pointed at the old database file, or holds the lock the new values were chosen to release. This is driver-agnostic: any change to a profile's parameter values closes its live connection. The comparison is between sanitized values on both sides, so a secret cannot read as changed merely because it was stripped to secret storage.

**Fixed a spinner that never stopped.** The above exposed a pre-existing bug. The Data Connections tree drops an entry's subtree when its connection goes away, but `_dropLoadedChildren` clears descendants from the expanded set and leaves the node itself in it. `computeExpandState` reads "expanded but not loaded" as a fetch in flight, so the row's twisty spun forever with nothing fetching. Every route that previously hit this collapsed the row first; editing a profile was the first that did not. The roots refresh now collapses such an entry before dropping it, through the base implementation rather than the tree's `collapse` override, which means "the user gave up the connection" and would ask to close one already gone.

### Notes

The `readOnly` parameter already existed on the DuckDB driver; this changes its default and makes both consumers agree on it. SQLite is deliberately untouched -- it allows multiple processes to open one file, so it has no equivalent conflict.

Unchecking Read Only is still a hard conflict in both directions, and no configuration avoids that: a read-write DuckDB connection cannot coexist with anything. The new message explains that rather than pretending otherwise.

`positron-data-driver-duckdb` and `readOnly` are the first driver-specific literals in `PositronDataConnectionsService`, introduced only for the one-time correction and called out as such in a comment. The alternative -- a profile-mutation API for extensions -- is far more surface than a one-time correction warrants.

### QA Notes

- Create a DuckDB connection, expand it, then run its Connect with Code snippet in Python. Both should work, with `read_only=True` in the generated code.
- An existing read-write DuckDB connection created before this change should show Read Only checked after one restart.
- Uncheck Read Only and connect from Python: the panel should report the lock conflict in prose, not a raw `IO Error`.
- Edit a connected, expanded connection's Read Only: the row should close and collapse, not sit spinning.

New coverage: two extension-host tests in `positron-data-driver-duckdb` that hold a real `DuckDBInstance` open in the extension host while the driver connects from its worker child process (a genuine cross-process lock), two vitest cases for the one-time correction, two for the disconnect-on-edit, and one for the tree collapse. No new e2e tests.
