### PR TITLE
Upstream merge from vscode-server for the Code OSS chat sessions fix

### DIFF
--- a/.github/workflows/test-tag-paths-map.json
+++ b/.github/workflows/test-tag-paths-map.json
@@ -134,6 +134,8 @@
   "src/vs/platform/extensions/": [],
   "src/vs/platform/extensions/common/positronExtensionValidator.ts": ["@:extensions"],
   "src/vs/platform/markers/": ["@:problems"],
+  "src/vs/platform/policy/": [],
+  "src/vs/platform/policy/common/adminPolicyService.ts": ["@:workbench"],
   "src/vs/platform/positronActionBar/": [],
   "src/vs/platform/positronAiProvider/": ["@:assistant"],
   "src/vs/platform/positronDocs/": [],
@@ -172,6 +174,8 @@
   "src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/": ["@:welcome"],
   "src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedPositronNotebookContent.ts": ["@:welcome"],
   "src/vs/workbench/services/actions/": ["@:assistant"],
+  "src/vs/workbench/services/encryption/": [],
+  "src/vs/workbench/services/encryption/browser/browserEncryptionService.ts": ["@:web"],
   "src/vs/workbench/services/notification/": [],
   "src/vs/workbench/services/themes/": [],
   "src/vs/workbench/services/themes/browser/positronColorThemeFilter.ts": []

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLIChatSessions.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLIChatSessions.ts
@@ -386,10 +386,9 @@ export class CopilotCLIChatSessionContentProvider extends Disposable implements 
 		item.timing = session.timing;
 		item.status = session.status ?? vscode.ChatSessionStatus.Completed;
 
-		// `buildChanges` runs `git diff` and is the slow leg of populating an item. Skip it on the
-		// eager pass and let `resolveChatSessionItem` fill it in lazily for visible items.
-		// But if computing changes is easy (cached or the like), then include them right away to avoid a second update pass.
-		if (options?.includeChanges || ((await this.hasCachedChanges(session.id, worktreeProperties)))) {
+		// Building changes is expensive, so defer it to explicit resolve and refresh paths
+		// when lazy loading is enabled. Preserve eager loading when it is disabled.
+		if (options?.includeChanges || !this.configurationService.getConfig(ConfigKey.Advanced.CLIChatLazyLoadSessionItem)) {
 			const changes = await this.buildChanges(session.id, worktreeProperties, workingDirectory, token);
 			if (token.isCancellationRequested) {
 				return item;
@@ -441,17 +440,6 @@ export class CopilotCLIChatSessionContentProvider extends Disposable implements 
 		const badge = new vscode.MarkdownString(`${icon} ${basename(badgeUri)}`);
 		badge.supportThemeIcons = true;
 		return badge;
-	}
-
-	private async hasCachedChanges(sessionId: string, worktreeProperties: Awaited<ReturnType<IChatSessionWorktreeService['getWorktreeProperties']>>): Promise<boolean> {
-		if (!this.configurationService.getConfig(ConfigKey.Advanced.CLIChatLazyLoadSessionItem)) {
-			return true;
-		}
-		const [hasCachedWorktreeChanges, hasCachedWorkspaceChanges] = await Promise.all([
-			this.copilotCLIWorktreeManagerService.hasCachedChanges(sessionId),
-			this._workspaceFolderService.hasCachedChanges(sessionId)
-		]);
-		return hasCachedWorktreeChanges || hasCachedWorkspaceChanges;
 	}
 
 	private async buildChanges(

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLIChatSessionsContribution.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLIChatSessionsContribution.ts
@@ -332,13 +332,10 @@ export class CopilotCLIChatSessionItemProvider extends Disposable implements vsc
 		}
 
 		// Statistics (only returned for trusted workspace/worktree folders).
-		// `getWorktreeChanges`/`getWorkspaceChanges` shell out to `git diff` and dominate the cost
-		// of building an item — defer to `resolveChatSessionItem` for visible items.
-		// `buildChanges` runs `git diff` and is the slow leg of populating an item. Skip it on the
-		// eager pass and let `resolveChatSessionItem` fill it in lazily for visible items.
-		// But if computing changes is easy (cached or the like), then include them right away to avoid a second update pass.
+		// Building changes is expensive, so defer it to explicit resolve and refresh paths
+		// when lazy loading is enabled. Preserve eager loading when it is disabled.
 		let changes: vscode.ChatSessionChangedFile[] | undefined;
-		if (!token.isCancellationRequested && (options?.includeChanges || (await this.hasCachedChanges(session.id, worktreeProperties)))) {
+		if (!token.isCancellationRequested && (options?.includeChanges || !this.configurationService.getConfig(ConfigKey.Advanced.CLIChatLazyLoadSessionItem))) {
 			changes = await this.buildChanges(session.id, worktreeProperties, workingDirectory, token);
 			// We need to get an updated version of worktree properties here because when the
 			// changes are being computed, the worktree properties are also updated with the
@@ -452,18 +449,6 @@ export class CopilotCLIChatSessionItemProvider extends Disposable implements vsc
 			metadata,
 		} satisfies vscode.ChatSessionItem;
 	}
-
-	private async hasCachedChanges(sessionId: string, worktreeProperties: Awaited<ReturnType<IChatSessionWorktreeService['getWorktreeProperties']>>): Promise<boolean> {
-		if (!this.configurationService.getConfig(ConfigKey.Advanced.CLIChatLazyLoadSessionItem)) {
-			return true;
-		}
-		const [hasCachedWorktreeChanges, hasCachedWorkspaceChanges] = await Promise.all([
-			this.worktreeManager.hasCachedChanges(sessionId),
-			this.workspaceFolderService.hasCachedChanges(sessionId)
-		]);
-		return hasCachedWorktreeChanges || hasCachedWorkspaceChanges;
-	}
-
 
 	private async buildChanges(
 		sessionId: string,

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/test/copilotCLIChatSessions.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/test/copilotCLIChatSessions.spec.ts
@@ -98,7 +98,7 @@ class TestWorktreeService extends mock<IChatSessionWorktreeService>() {
 	declare readonly _serviceBrand: undefined;
 	override getWorktreeProperties = vi.fn(async (_sessionId: string | vscode.Uri): Promise<ChatSessionWorktreeProperties | undefined> => undefined);
 	override setWorktreeProperties = vi.fn(async () => { });
-	override getWorktreeChanges = vi.fn(async () => []);
+	override getWorktreeChanges = vi.fn<IChatSessionWorktreeService['getWorktreeChanges']>(async () => []);
 	override hasCachedChanges = vi.fn(async () => false);
 	override onDidChangeWorktreeChanges = Event.None;
 }
@@ -507,6 +507,47 @@ describe('CopilotCLIChatSessionContentProvider (additional)', () => {
 
 		const item = await provider.toChatSessionItem(sessionItem);
 		expect(item.label).toBe('Test Session');
+	});
+
+	it('only includes cached changes when explicitly requested', async () => {
+		const { provider, worktreeService } = createProvider();
+		const sessionItem: ICopilotCLISessionItem = {
+			id: 'session-1',
+			label: 'Test Session',
+			timing: undefined,
+			workingDirectory: undefined,
+		};
+		worktreeService.getWorktreeProperties.mockResolvedValue({
+			version: 1,
+			baseCommit: 'base',
+			branchName: 'branch',
+			repositoryPath: '/repository',
+			worktreePath: '/worktree',
+			autoCommit: true,
+		});
+		worktreeService.hasCachedChanges.mockResolvedValue(true);
+		worktreeService.getWorktreeChanges.mockResolvedValue([
+			{
+				uri: vscodeShim.Uri.file('/repository/file'),
+				originalUri: undefined,
+				modifiedUri: vscodeShim.Uri.file('/repository/file'),
+				insertions: 3,
+				deletions: 1,
+			},
+		]);
+
+		const listedItem = await provider.toChatSessionItem(sessionItem);
+		const resolvedItem = await provider.toChatSessionItem(sessionItem, { includeChanges: true });
+
+		expect({
+			listedChanges: listedItem.changes,
+			resolvedChanges: resolvedItem.changes?.length,
+			buildCount: worktreeService.getWorktreeChanges.mock.calls.length,
+		}).toEqual({
+			listedChanges: undefined,
+			resolvedChanges: 1,
+			buildCount: 1,
+		});
 	});
 
 	it('does not call refreshSession when PR detection finds no update', async () => {

--- a/src/vs/base/common/network.ts
+++ b/src/vs/base/common/network.ts
@@ -262,11 +262,13 @@ class RemoteAuthoritiesImpl {
 		return URI.from({
 			scheme: platform.isWeb ? this._preferredWebSchema : Schemas.vscodeRemoteResource,
 			authority: `${host}:${port}`,
-			// --- Start Positron ---
+			// --- Start PWB ---
 			path: platform.isWeb
-				? (window.location.pathname + '/' + this._remoteResourcesPath).replace(/\/\/+/g, '/')
+				// This module is also type-checked against Node/Worker layers where `window` isn't declared;
+				// `globalThis` resolves to the same object as `window` at runtime in a browser.
+				? ((globalThis as unknown as { location: { pathname: string } }).location.pathname + '/' + this._remoteResourcesPath).replace(/\/\/+/g, '/')
 				: this._remoteResourcesPath,
-			// --- End Positron ---
+			// --- End PWB ---
 			query
 		});
 	}

--- a/src/vs/code/browser/workbench/constants.ts
+++ b/src/vs/code/browser/workbench/constants.ts
@@ -1,4 +1,7 @@
-/* eslint-disable header/header */
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
 
 // port tokens for generating secure URLs
 export const kPortToken = process.env.RS_PORT_TOKEN !== undefined ? process.env.RS_PORT_TOKEN : '';

--- a/src/vs/code/browser/workbench/rsLoginCheck.js
+++ b/src/vs/code/browser/workbench/rsLoginCheck.js
@@ -1,4 +1,7 @@
-/* eslint-disable header/header */
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
 
 /* eslint-disable no-var */
 var sCheckInProgress = false;
@@ -68,11 +71,11 @@ function rs_showSessionDialog(hdr, msg, actionName, actionFunc) {
 function rs_getWorkbenchPrefix() {
 	var path = window.location.pathname;
 	// look for prefix, e.g. /rstudio inserted by a proxy server
-	var prefixEnd = path.indexOf("/s/");
+	var prefixEnd = path.indexOf('/s/');
 	if (prefixEnd > 0) {
 		return path.substring(0, prefixEnd);
 	}
-	return "";
+	return '';
 }
 
 function rs_checkConnectionRequest() {
@@ -118,9 +121,9 @@ function rs_checkConnectionRequest() {
 	var url = '/job_launcher_rpc/session_status';
 	var path = window.location.pathname;
 	// look for prefix, e.g. /rstudio inserted by a proxy server
-	var prefixEnd = path.indexOf("/s/");
+	var prefixEnd = path.indexOf('/s/');
 	if (prefixEnd > 0) {
-		var prefix = prefixEnd == 0 ? "" : path.substring(0, prefixEnd);
+		var prefix = prefixEnd === 0 ? '' : path.substring(0, prefixEnd);
 		path = path.substring(prefixEnd);
 		url = prefix + url;
 	}

--- a/src/vs/code/browser/workbench/urlPorts.ts
+++ b/src/vs/code/browser/workbench/urlPorts.ts
@@ -1,4 +1,7 @@
-/* eslint-disable header/header */
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
 /* This code mimicks rstudio-pro server_core/UriPorts to generate port tokens and obscure ports.
  * Any functionality changes need to be accounted for there. Logic regarding 'server ports' has
  * been removed as requests coming from this extension are always 'session ports'.

--- a/src/vs/platform/extensionResourceLoader/common/extensionResourceLoader.ts
+++ b/src/vs/platform/extensionResourceLoader/common/extensionResourceLoader.ts
@@ -124,7 +124,9 @@ export abstract class AbstractExtensionResourceLoaderService extends Disposable 
 				path: 'extension'
 			}));
 			// --- Start PWB ---
-			return this._isWebExtensionResourceEndPoint(uri) ? URI.joinPath(URI.parse(window.location.href), uri.path) : uri;
+			// This module is also type-checked against Node/Worker layers where `window` isn't declared;
+			// `globalThis` resolves to the same object as `window` at runtime in a browser.
+			return this._isWebExtensionResourceEndPoint(uri) ? URI.joinPath(URI.parse((globalThis as unknown as { location: { href: string } }).location.href), uri.path) : uri;
 			// --- End PWB ---
 		}
 		return undefined;

--- a/src/vs/platform/policy/common/adminPolicyService.ts
+++ b/src/vs/platform/policy/common/adminPolicyService.ts
@@ -3,7 +3,6 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// eslint-disable-next-line header/header
 import { Disposable } from '../../../base/common/lifecycle.js';
 import { isObject } from '../../../base/common/types.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
@@ -22,7 +21,7 @@ export interface IAdminPolicyService {
 
 export interface AdminPolicy {
 	key: string;
-	value: any;
+	value: unknown;
 }
 
 export class AdminPolicyService extends Disposable implements IAdminPolicyService {

--- a/src/vs/server/node/pwbConstants.ts
+++ b/src/vs/server/node/pwbConstants.ts
@@ -5,7 +5,6 @@
 import { existsSync, readFileSync } from 'fs';
 import { dirname, join } from '../../base/common/path.js';
 import { fileURLToPath } from 'url';
-
 export const kProxyRegex = new RegExp('\/proxy\/[0-9]+[^a-zA-Z](\/)?');
 
 // --- Start PWB: session-less static URL prefix for cacheable assets ---
@@ -53,16 +52,41 @@ export const VSCODE_STATIC_PREFIX = `/${resolveProductLabel()}-static`;
 // the part before "/s/" is the deployment prefix, and we prepend it to the absolute-from-root
 // URLs we emit so the front proxy will actually route them to Workbench. Empty string when
 // Workbench is mounted at the origin root or when running outside Workbench.
-function resolveDeploymentPrefix(): string {
-	const sessionUrl = process.env['RS_SESSION_URL'];
+//
+// RS_SESSION_URL is usually just a path, but rserver derives it from the `session_url` the
+// homepage passes at launch, and some deployments hand us a fully qualified URL
+// ("https://host/s/<session-id>/"). The scheme and host must never survive into the prefix:
+// `posix.join('https://host', '/vscode-static', ...)` collapses the "//" and yields
+// "https:/host/vscode-static/...", which a browser resolves against the page origin as a *path*
+// (per the WHATWG URL relative-slash rules), producing https://host/host/vscode-static/... So
+// reduce the value to its path component first, and refuse anything that still isn't a plain
+// rooted path.
+export function computeDeploymentPrefix(sessionUrl: string | undefined): string {
 	if (!sessionUrl) {
 		return '';
 	}
-	const idx = sessionUrl.indexOf('/s/');
-	return idx > 0 ? sessionUrl.substring(0, idx) : '';
+
+	let path = sessionUrl;
+	const schemeEnd = path.indexOf('://');
+	if (schemeEnd !== -1) {
+		path = path.substring(schemeEnd + 3); // strip "<scheme>://"
+		const hostEnd = path.indexOf('/');
+		path = hostEnd === -1 ? '' : path.substring(hostEnd); // strip "<host>[:<port>]"
+	} else if (path.startsWith('//')) {
+		const hostEnd = path.indexOf('/', 2); // protocol-relative "//host/..."
+		path = hostEnd === -1 ? '' : path.substring(hostEnd);
+	}
+
+	const idx = path.indexOf('/s/');
+	if (idx <= 0) {
+		return '';
+	}
+
+	const prefix = path.substring(0, idx);
+	return prefix.startsWith('/') && !prefix.startsWith('//') ? prefix : '';
 }
 
-export const WORKBENCH_DEPLOYMENT_PREFIX = resolveDeploymentPrefix();
+export const WORKBENCH_DEPLOYMENT_PREFIX = computeDeploymentPrefix(process.env['RS_SESSION_URL']);
 // --- End PWB ---
 
 // --- Start PWB: Workbench 2026.05+ ships the nginx route for /<product-label>-static/...; ---

--- a/src/vs/server/node/webClientServer.ts
+++ b/src/vs/server/node/webClientServer.ts
@@ -638,7 +638,14 @@ export class WebClientServer {
 			isEnabledFileUploads: !this._environmentService.args['disable-file-uploads'],
 			// --- End PWB ---
 			// --- Start PWB: serve same origin ---
-			webviewEndpoint: vscodeBase + staticRoute + '/out/vs/workbench/contrib/webview/browser/pre',
+			// Use the session-less static route when under Workbench. The webview iframe registers
+			// `pre/service-worker.js`, and as of VS Code 1.130 that registration is a *module*
+			// service worker (`register(..., { type: 'module' })`). The browser fetches a module
+			// service worker script without the Workbench auth cookie, so a session-scoped URL is
+			// answered with a 302 to /auth-sign-in and no webview ever loads. The session-less route
+			// is served off disk by Workbench's nginx with no auth check, and as a bonus these
+			// assets become cacheable across sessions like the rest of the static bundle.
+			webviewEndpoint: effectiveVsBase + effectiveStaticRoute + '/out/vs/workbench/contrib/webview/browser/pre',
 			// --- End PWB: serve same origin ---
 			_wrapWebWorkerExtHostInIframe,
 			developmentOptions: { enableSmokeTestDriver: this._environmentService.args['enable-smoke-test-driver'] ? true : undefined, logLevel: this._logService.getLevel() },

--- a/src/vs/server/test/node/pwbConstants.vitest.ts
+++ b/src/vs/server/test/node/pwbConstants.vitest.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { computeDeploymentPrefix } from '../../node/pwbConstants.js';
+
+describe('PWB computeDeploymentPrefix', () => {
+
+	it('empty when RS_SESSION_URL is unset', () => {
+		expect(computeDeploymentPrefix(undefined)).toBe('');
+		expect(computeDeploymentPrefix('')).toBe('');
+	});
+
+	it('empty when Workbench is mounted at the origin root', () => {
+		expect(computeDeploymentPrefix('/s/a0b7e3c9ab5a7e6d5aeef/')).toBe('');
+	});
+
+	it('returns the sub-path a front proxy routes to Workbench', () => {
+		expect(computeDeploymentPrefix('/rstudio/s/a0b7e3c9ab5a7e6d5aeef/')).toBe('/rstudio');
+		expect(computeDeploymentPrefix('/a/b/s/a0b7e3c9ab5a7e6d5aeef/')).toBe('/a/b');
+	});
+
+	it('drops scheme and host from a fully qualified session URL', () => {
+		expect(computeDeploymentPrefix('https://helio.local/s/a0b7e3c9ab5a7e6d5aeef/')).toBe('');
+		expect(computeDeploymentPrefix('http://helio.local:8787/s/a0b7e3c9ab5a7e6d5aeef/')).toBe('');
+		expect(computeDeploymentPrefix('https://helio.local/rstudio/s/a0b7e3c9ab5a7e6d5aeef/')).toBe('/rstudio');
+	});
+
+	it('drops the host from a protocol-relative session URL', () => {
+		// Shape seen from rserver's /api/launch_session path (rstudio-pro double-prefixes the
+		// session URL there, which lands in RS_SESSION_URL as "//<host>/s/<session-id>/").
+		expect(computeDeploymentPrefix('//helio.local/s/d5de83c9ab5a7b6ea23ae/')).toBe('');
+		expect(computeDeploymentPrefix('//helio.local/rstudio/s/d5de83c9ab5a7b6ea23ae/')).toBe('/rstudio');
+	});
+
+	it('never returns something that is not a rooted path', () => {
+		// A bare host with no scheme would otherwise be mistaken for a path prefix.
+		expect(computeDeploymentPrefix('helio.local/s/a0b7e3c9ab5a7e6d5aeef/')).toBe('');
+		expect(computeDeploymentPrefix('https://helio.local')).toBe('');
+		expect(computeDeploymentPrefix('not-a-session-url')).toBe('');
+	});
+});

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
@@ -657,7 +657,9 @@ export class AgentSessionsModel extends Disposable implements IAgentSessionsMode
 					icon = session.iconPath ?? Codicon.terminal;
 				}
 
-				const changes = session.changes;
+				// A lazy provider refresh omits changes. Keep only the previous aggregate
+				// summary so cached counts survive without retaining hydrated file arrays.
+				const changes = session.changes ?? getAgentChangesSummary(this._sessions.get(session.resource)?.changes);
 				const normalizedChanges = changes && !(changes instanceof Array)
 					? { files: changes.files, insertions: changes.insertions, deletions: changes.deletions }
 					: changes;
@@ -931,7 +933,7 @@ interface ISerializedAgentSessionState extends IAgentSessionState {
 	readonly resource: UriComponents /* old shape */ | string /* new shape that is more compact */;
 }
 
-class AgentSessionsCache {
+export class AgentSessionsCache {
 
 	private static readonly SESSIONS_STORAGE_KEY = 'agentSessions.model.cache';
 	private static readonly STATE_STORAGE_KEY = 'agentSessions.state.cache';
@@ -960,7 +962,7 @@ class AgentSessionsCache {
 
 			timing: session.timing,
 
-			changes: session.changes,
+			changes: getAgentChangesSummary(session.changes),
 			metadata: session.metadata,
 			legacyResource: session.legacyResource?.toString()
 		} satisfies ISerializedAgentSession));
@@ -997,12 +999,7 @@ class AgentSessionsCache {
 					lastRequestEnded: session.timing.lastRequestEnded,
 				},
 
-				changes: Array.isArray(session.changes) ? session.changes.map((change: IChatSessionFileChange) => ({
-					modifiedUri: URI.revive(change.modifiedUri),
-					originalUri: change.originalUri ? URI.revive(change.originalUri) : undefined,
-					insertions: change.insertions,
-					deletions: change.deletions,
-				})) : session.changes,
+				changes: getAgentChangesSummary(session.changes),
 				metadata: session.metadata,
 				legacyResource: session.legacyResource ? URI.parse(session.legacyResource) : undefined,
 			}));

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionViewModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionViewModel.test.ts
@@ -28,7 +28,7 @@ class StaticChatSessionItemController implements IChatSessionItemController {
 	readonly onDidChangeChatSessionItems = Event.None;
 
 	constructor(
-		private readonly sessionItems: readonly IChatSessionItem[],
+		private sessionItems: readonly IChatSessionItem[],
 	) { }
 
 	get items(): readonly IChatSessionItem[] {
@@ -36,6 +36,10 @@ class StaticChatSessionItemController implements IChatSessionItemController {
 	}
 
 	async refresh(): Promise<void> { }
+
+	setItems(sessionItems: readonly IChatSessionItem[]): void {
+		this.sessionItems = sessionItems;
+	}
 }
 
 
@@ -101,6 +105,47 @@ suite('AgentSessions', () => {
 				assert.strictEqual(viewModel.sessions[0].label, 'Test Session 1');
 				assert.strictEqual(viewModel.sessions[1].resource.toString(), `${chatSessionTestType}://session-2`);
 				assert.strictEqual(viewModel.sessions[1].label, 'Test Session 2');
+			});
+		});
+
+		test('should preserve change summaries when lazy refresh omits changes', async () => {
+			return runWithFakedTimers({}, async () => {
+				const controller = new StaticChatSessionItemController([
+					makeSimpleSessionItem('session-1', {
+						changes: { files: 2, insertions: 8, deletions: 3 },
+					}),
+				]);
+
+				mockChatSessionsService.registerChatSessionItemController(chatSessionTestType, controller);
+				viewModel = createViewModel();
+				await viewModel.resolve(undefined);
+
+				controller.setItems([makeSimpleSessionItem('session-1', { changes: undefined })]);
+				await viewModel.resolve(undefined);
+
+				assert.deepStrictEqual(viewModel.sessions[0].changes, { files: 2, insertions: 8, deletions: 3 });
+			});
+		});
+
+		test('should demote hydrated changes when lazy refresh omits changes', async () => {
+			return runWithFakedTimers({}, async () => {
+				const controller = new StaticChatSessionItemController([
+					makeSimpleSessionItem('session-1', {
+						changes: [
+							{ modifiedUri: URI.file('/first'), insertions: 3, deletions: 1 },
+							{ modifiedUri: URI.file('/second'), insertions: 5, deletions: 2 },
+						],
+					}),
+				]);
+
+				mockChatSessionsService.registerChatSessionItemController(chatSessionTestType, controller);
+				viewModel = createViewModel();
+				await viewModel.resolve(undefined);
+
+				controller.setItems([makeSimpleSessionItem('session-1', { changes: undefined })]);
+				await viewModel.resolve(undefined);
+
+				assert.deepStrictEqual(viewModel.sessions[0].changes, { files: 2, insertions: 8, deletions: 3 });
 			});
 		});
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsModel.test.ts
@@ -1,0 +1,92 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { Codicon } from '../../../../../../base/common/codicons.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { InMemoryStorageService, StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
+import { AgentSessionStatus, AgentSessionsCache } from '../../../browser/agentSessions/agentSessionsModel.js';
+
+suite('AgentSessionsCache', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+	const storageKey = 'agentSessions.model.cache';
+
+	function createCache(): { cache: AgentSessionsCache; storageService: InMemoryStorageService } {
+		const storageService = store.add(new InMemoryStorageService());
+		return { cache: new AgentSessionsCache(storageService), storageService };
+	}
+
+	function createSession(changes: Parameters<AgentSessionsCache['saveCachedSessions']>[0][number]['changes']): Parameters<AgentSessionsCache['saveCachedSessions']>[0][number] {
+		return {
+			providerType: 'test',
+			providerLabel: 'Test',
+			resource: URI.parse('test:/session'),
+			status: AgentSessionStatus.Completed,
+			label: 'Session',
+			icon: Codicon.chatSparkle,
+			timing: { created: 1, lastRequestStarted: undefined, lastRequestEnded: undefined },
+			changes,
+			archived: false,
+		};
+	}
+
+	test('persists file change arrays as summaries', () => {
+		const { cache, storageService } = createCache();
+		cache.saveCachedSessions([createSession([
+			{ modifiedUri: URI.file('/first'), insertions: 3, deletions: 1 },
+			{ modifiedUri: URI.file('/second'), originalUri: URI.file('/old-second'), insertions: 5, deletions: 2 },
+		])]);
+
+		const serialized = JSON.parse(storageService.get(storageKey, StorageScope.WORKSPACE) ?? '[]');
+		assert.deepStrictEqual(serialized[0].changes, { files: 2, insertions: 8, deletions: 3 });
+	});
+
+	test('round-trips summaries without URI revival', () => {
+		const { cache } = createCache();
+		const summary = { files: 2, insertions: 8, deletions: 3 };
+		cache.saveCachedSessions([createSession(summary)]);
+
+		const [loaded] = cache.loadCachedSessions();
+		assert.deepStrictEqual(loaded.changes, summary);
+	});
+
+	test('loads legacy arrays as summaries and revives session resources', () => {
+		const { cache, storageService } = createCache();
+		storageService.store(storageKey, JSON.stringify([{
+			providerType: 'test',
+			providerLabel: 'Test',
+			resource: { scheme: 'test', path: '/session' },
+			legacyResource: 'test:/legacy',
+			status: AgentSessionStatus.Completed,
+			label: 'Session',
+			icon: Codicon.chatSparkle.id,
+			timing: { created: 1 },
+			changes: [{
+				modifiedUri: { scheme: 'file', path: '/first' },
+				originalUri: { scheme: 'file', path: '/old-first' },
+				insertions: 3,
+				deletions: 1,
+			}],
+			archived: false,
+			isRead: true,
+		}]), StorageScope.WORKSPACE, StorageTarget.MACHINE);
+
+		const [loaded] = cache.loadCachedSessions();
+		assert.deepStrictEqual({
+			resource: loaded.resource,
+			legacyResource: loaded.legacyResource,
+			changes: loaded.changes,
+		}, {
+			resource: URI.parse('test:/session'),
+			legacyResource: URI.parse('test:/legacy'),
+			changes: { files: 1, insertions: 3, deletions: 1 },
+		});
+
+		cache.saveCachedSessions([loaded]);
+		const serialized = JSON.parse(storageService.get(storageKey, StorageScope.WORKSPACE) ?? '[]');
+		assert.deepStrictEqual(serialized[0].changes, { files: 1, insertions: 3, deletions: 1 });
+	});
+});

--- a/src/vs/workbench/services/configuration/browser/configurationService.ts
+++ b/src/vs/workbench/services/configuration/browser/configurationService.ts
@@ -133,7 +133,7 @@ export class WorkspaceService extends Disposable implements IWorkbenchConfigurat
 		let adminPolicyService: IAdminPolicyService | undefined;
 		// In native (Electron) environment, admin policies data is passed through window configuration
 		// In web (browser) environment, it's passed through options (IWorkbenchConstructionOptions)
-		const nativeEnv = environmentService as any;
+		const nativeEnv = environmentService as unknown as { configuration?: { adminPoliciesData?: string }; options?: { adminPoliciesData?: string } };
 		const enforcedSettings = nativeEnv.configuration?.adminPoliciesData || nativeEnv.options?.adminPoliciesData;
 		logService.info(`[Browser ConfigService] Checking for adminPoliciesData...`);
 		logService.info(`[Browser ConfigService] nativeEnv.configuration exists: ${!!nativeEnv.configuration}`);

--- a/src/vs/workbench/services/encryption/browser/browserEncryptionService.ts
+++ b/src/vs/workbench/services/encryption/browser/browserEncryptionService.ts
@@ -194,7 +194,7 @@ export class BrowserEncryptionService implements IEncryptionService {
 			);
 
 			// Define PBKDF2 parameters
-			let params: Pbkdf2Params = {
+			const params: Pbkdf2Params = {
 				name: 'PBKDF2',
 				salt: salt as BufferSource,
 				iterations: 100000,

--- a/src/vs/workbench/services/environment/browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/browser/environmentService.ts
@@ -3,6 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+// --- Start PWB ---
+import { mainWindow } from '../../../../base/browser/window.js';
+// --- End PWB ---
 import { Schemas } from '../../../../base/common/network.js';
 import { joinPath } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -317,7 +320,7 @@ export class BrowserWorkbenchEnvironmentService implements IBrowserWorkbenchEnvi
 	@memoize
 	get webviewExternalEndpoint(): string {
 		// --- Start PWB: serve same origin ---
-		const endpoint = (this.options.webviewEndpoint && new URL(this.options.webviewEndpoint, window.location.toString()).toString())
+		const endpoint = (this.options.webviewEndpoint && new URL(this.options.webviewEndpoint, mainWindow.location.toString()).toString())
 			|| this.productService.webviewContentExternalBaseUrlTemplate
 			|| 'https://{{uuid}}.vscode-cdn.net/{{quality}}/{{commit}}/out/vs/workbench/contrib/webview/browser/pre/';
 		// --- End PWB: serve same origin ---


### PR DESCRIPTION
This is a targeted upstream merge from vscode-server. It brings a single upstream commit, `8a3c79f9d9c` ("Upstream Code OSS changes for #329506"), to `main`.

### Summary

The reason for the merge is the Code OSS chat sessions fix, upstream's follow-up to microsoft/vscode#329506:

- `agentSessionsModel.ts` keeps the previous aggregate change summary when a lazy provider refresh omits `changes`, so a session's file and insertion/deletion counts survive a refresh instead of blanking out. The cache now stores that summary rather than a hydrated file array, so it does not retain per-file URIs it never displays.
- The Copilot CLI session providers go back to deferring `git diff` work to the explicit resolve and refresh paths when lazy loading is on, instead of eagerly building changes whenever a cached result happened to be available.

These files are pure upstream, last touched by "Update to Code OSS 1.130.0" (#15243), so nothing Positron authored is changed here.

The same commit also carries a group of PWB server changes, because vscode-server had merged Code OSS ahead of us. The deployment-prefix helper becomes an exported, testable `computeDeploymentPrefix(sessionUrl)` that strips scheme and host from a fully-qualified or protocol-relative `RS_SESSION_URL`, and several browser-layer modules read `location` through a `globalThis` cast instead of `window` so they type-check in the Node and Worker layers. Runtime behaviour there is unchanged.

No `package.json` or `package-lock.json` changes came through, so no dependency work is needed.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed agent session change counts disappearing after the session list refreshes

### Validation Steps

@:workbench @:web @:vscode-settings @:assistant @:extensions

#### Automated tests

```sh
./scripts/test.sh --run src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsModel.test.ts
./scripts/test.sh --run src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionViewModel.test.ts
npx vitest run src/vs/server/test/node/pwbConstants.vitest.ts
```

The first two add upstream's new lazy-refresh cases, which assert that a refresh omitting `changes` preserves the previous aggregate summary rather than clearing it, and that a hydrated file array is demoted to a summary rather than dropped. The Copilot extension change is covered by a new case in `extensions/copilot/src/extension/chatSessions/vscode-node/test/copilotCLIChatSessions.spec.ts`. The Vitest suite is the PWB `computeDeploymentPrefix` coverage, converted from the incoming Mocha suite.

#### Manual check

Open the agent sessions list with a session that has file changes, let it refresh, and confirm the change counts stay put instead of disappearing. In a Posit Workbench session, confirm the workbench loads and its static resources resolve under the session URL prefix.

#### Local results

- `npm run test:positron`: 391 files passed, 4586 tests passed, 0 failing.
- `npm run test:core` (`env -u ELECTRON_RUN_AS_NODE ./scripts/test.sh`): 26705 passing, 0 failing.
- `npm run gulp vscode-darwin-arm64`: succeeds, 3.72 min.
- `npm run precommit`: passes. One pre-existing `no-duplicate-imports` warning at `webClientServer.ts:42`, left alone on purpose -- collapsing the two imports would merge a PWB-marked line and a Positron-marked line, which makes the next upstream merge harder.
- `npm run build-check`: 16 files report errors, all pre-existing on this branch. They are `@anthropic-ai` claude-agent-sdk and Electron typing drift in `.test.ts` / `.spec.ts` files, none touched by this merge, and none reach the release bundle.
- E2E, `test/e2e/tests/assistant/`: 10 passed, 0 failed, 0 flaky. This covers the Copilot AI gating checks, which the merge left intact.
- Extension host tests: 323 passing, 2 failing. Both are `chat.runInTerminal` cases that capture a themed shell prompt as command output. Reproduces on this branch's base and will not appear in CI.

#### If you pull this down

- Run `npm install`. `node_modules` went stale on this branch (`npx eslint` could not resolve `@stylistic/eslint-plugin-ts`). `package-lock.json` is unchanged, so this is a one-time local refresh.
- If your shell exports `ELECTRON_RUN_AS_NODE=1`, unset it before running core tests, or the harness dies with "Cannot read properties of undefined (reading 'setPath')".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
