### PR TITLE
docs: fix typo recived -> received

### DIFF
--- a/extensions/positron-zed/src/positronZedPreview.ts
+++ b/extensions/positron-zed/src/positronZedPreview.ts
@@ -57,7 +57,7 @@ export class ZedPreview {
 	}
 
 	public sendMessage(): void {
-		this.panel.webview.postMessage('Recived message from console.');
+		this.panel.webview.postMessage('Received message from console.');
 	}
 
 	public addRecentCommand(command: string): void {


### PR DESCRIPTION
Corrects the misspelling `recived` -> `received` in `extensions/positron-zed/src/positronZedPreview.ts`.

Documentation only, no behaviour change.