### PR TITLE
assistant: add empty inputSchema for getPlot tool (Closes #15735)

### DIFF
--- a/src/vs/workbench/contrib/positronAssistant/browser/tools/positronAssistantTools.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/tools/positronAssistantTools.ts
@@ -54,6 +54,10 @@ const getPlotToolData: IToolData = {
 	displayName: localize('positron.assistant.tool.getPlot.displayName', "View Active Plot"),
 	userDescription: localize('positron.assistant.tool.getPlot.userDescription', "View the current active plot."),
 	modelDescription: 'View the current active plot if one exists. Don\'t invoke this tool if there are no plots in the session.',
+	inputSchema: {
+		type: 'object',
+		properties: {},
+	},
 };
 
 export class GetPlotTool implements IToolImpl {


### PR DESCRIPTION
### Summary
This PR adds an explicit empty `inputSchema` (`{ type: 'object', properties: {} }`) to `getPlotToolData`.

`getPlot` takes no parameters, but without an explicit `inputSchema`, downstream proxies and endpoints expecting standard tool schemas can produce HTTP 400 errors (as analyzed in #15735). Adding an empty object schema aligns it with the other tools and ensures consistent schema serialization.

Closes #15735

### Release Notes

#### Bug Fixes

- Fixed missing `inputSchema` on the `View Active Plot` assistant tool.

### Validation Steps
- Checked `getPlotToolData` in `src/vs/workbench/contrib/positronAssistant/browser/tools/positronAssistantTools.ts`.
- Verified invocation behavior of `GetPlotTool` is unchanged.

