### PR TITLE
Fix the modal renderer import in the save data connection confirmation dialog

### DIFF
--- a/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/saveDataConnectionConfirmation.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/dialogs/saveDataConnectionConfirmation.tsx
@@ -8,7 +8,7 @@ import './saveDataConnectionConfirmation.css';
 
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
-import { PositronModalDialogReactRenderer } from '../../../../../base/browser/positronModalDialogReactRenderer.js';
+import { PositronModalReactRenderer } from '../../../../../base/browser/positronModalReactRenderer.js';
 import { TwoButtonFooter } from '../../../../browser/positronComponents/positronDynamicModalDialog/components/twoButtonFooter.js';
 import { PositronDynamicModalDialog } from '../../../../browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.js';
 
@@ -30,7 +30,7 @@ export const showSaveDataConnectionConfirmation = (
 	openDataExplorerCount: number
 ): Promise<boolean> => {
 	// Create the renderer.
-	const renderer = new PositronModalDialogReactRenderer();
+	const renderer = new PositronModalReactRenderer();
 
 	return new Promise<boolean>(resolve => {
 		// Settle once: dispose the renderer and resolve with the user's choice. Guards against the
@@ -64,7 +64,7 @@ export const showSaveDataConnectionConfirmation = (
 interface SaveDataConnectionConfirmationProps {
 	readonly connectionName: string;
 	readonly openDataExplorerCount: number;
-	readonly renderer: PositronModalDialogReactRenderer;
+	readonly renderer: PositronModalReactRenderer;
 	readonly onConfirm: () => void;
 	readonly onCancel: () => void;
 }


### PR DESCRIPTION
## Summary

Fix build break caused by not rebasing on main on an all green PR.

#15804 added `saveDataConnectionConfirmation.tsx`, which imported `PositronModalDialogReactRenderer` from `base/browser/positronModalDialogReactRenderer.js`. That module existed when the branch was written, so the PR was green. In the meantime #15679 deleted it, consolidating every Positron dialog onto the single `PositronModalReactRenderer`. Neither diff touches the other's lines, so the merge was clean and `main` stopped compiling.

```
src/vs/workbench/contrib/positronDataConnections/browser/dialogs/saveDataConnectionConfirmation.tsx(11,50): error TS2307: Cannot find module '../../../../../base/browser/positronModalDialogReactRenderer.js' or its corresponding type declarations.
```

The moral of the story is that a green PR is only green against the base it ran on. A new file can't conflict with anything, so nothing warns you when another PR deletes a symbol you import -- rebase on main and let the build re-run before merging.

## Changes

Points the dialog at the surviving renderer: the import path and class name, the `new PositronModalReactRenderer()` construction, and the `renderer` prop type. Three lines, no behavior change. This matches what the other dialogs in `positronDataConnections/browser/dialogs/` already import.

## Release Notes

### New Features

- N/A

### Bug Fixes

- N/A

## QA Notes

Check that `npm run watch-clientd` reports 0 errors. Then edit a saved connection that has Data Explorers open on it and hit Save -- the Save Changes confirmation should still appear and both buttons should behave as before.
