### PR TITLE
Import Data: add more entry points

### DIFF
--- a/src/vs/workbench/browser/positronComponents/editableCodeEditor/editableCodeEditor.tsx
+++ b/src/vs/workbench/browser/positronComponents/editableCodeEditor/editableCodeEditor.tsx
@@ -97,12 +97,24 @@ export const EditableCodeEditor = (props: EditableCodeEditorProps) => {
 		));
 
 		// Create and set the model.
-		editor.setModel(disposableStore.add(services.modelService.createModel(
-			code,
-			services.languageService.createById(languageId),
-			undefined,
-			true
-		)));
+		//
+		// Creating a model in a language is what Positron reads as "a file in that language was
+		// opened", so previewing R code in a window that has never seen R implicitly starts an R
+		// session. Let's suppress that.
+		const suppressed = services.runtimeSessionService.implicitStartupSuppressed;
+		services.runtimeSessionService.implicitStartupSuppressed = true;
+		try {
+			editor.setModel(disposableStore.add(services.modelService.createModel(
+				code,
+				services.languageService.createById(languageId),
+				undefined,
+				true
+			)));
+		} finally {
+			// Restore in a finally: leaving the flag set because model creation threw would disable
+			// auto-start for the rest of the window's life.
+			services.runtimeSessionService.implicitStartupSuppressed = suppressed;
+		}
 
 		// Track the editor instance in a ref for the imperative handle.
 		editorRef.current = editor;

--- a/src/vs/workbench/browser/positronComponents/editableCodeEditor/test/browser/editableCodeEditor.vitest.tsx
+++ b/src/vs/workbench/browser/positronComponents/editableCodeEditor/test/browser/editableCodeEditor.vitest.tsx
@@ -13,6 +13,8 @@ import { IUserInteractionService } from '../../../../../../platform/userInteract
 import { UserInteractionService } from '../../../../../../platform/userInteraction/browser/userInteractionServiceImpl.js';
 import { ICodeEditorService } from '../../../../../../editor/browser/services/codeEditorService.js';
 import { EditorOption } from '../../../../../../editor/common/config/editorOptions.js';
+import { ILanguageService } from '../../../../../../editor/common/languages/language.js';
+import { IRuntimeSessionService } from '../../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { EditableCodeEditor, EditableCodeEditorWidget } from '../../editableCodeEditor.js';
 
 describe('EditableCodeEditor', () => {
@@ -34,13 +36,13 @@ describe('EditableCodeEditor', () => {
 		vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(260);
 	});
 
-	function renderEditor(ariaLabel?: string) {
+	function renderEditor(ariaLabel?: string, languageId = 'python') {
 		rtl.render(
 			<EditableCodeEditor
 				ref={createRef<EditableCodeEditorWidget>()}
 				ariaLabel={ariaLabel}
 				code='import pandas as pd'
-				languageId='python'
+				languageId={languageId}
 			/>
 		);
 	}
@@ -59,5 +61,33 @@ describe('EditableCodeEditor', () => {
 		// and the browser moves focus to the next control.
 		const editor = ctx.get(ICodeEditorService).listCodeEditors()[0];
 		expect(editor.getOption(EditorOption.tabFocusMode)).toBe(true);
+	});
+
+	it('does not let a preview of a language implicitly start a session for it', () => {
+		// Encountering a language is what Positron reads as a document in that language being
+		// opened, which implicitly starts a session. Record whether implicit startup was suppressed
+		// at the moment the preview's language was encountered, which is the state the startup
+		// heuristic reads.
+		const runtimeSessionService = ctx.get(IRuntimeSessionService);
+		const suppressedWhenEncountered: boolean[] = [];
+		ctx.disposables.add(ctx.get(ILanguageService).onDidRequestRichLanguageFeatures(
+			() => suppressedWhenEncountered.push(runtimeSessionService.implicitStartupSuppressed)
+		));
+
+		renderEditor(undefined, 'r');
+
+		// The language is encountered under suppression, and the suppression does not outlive the
+		// model's creation: leaving it on would silently disable auto-start for the whole window.
+		expect({
+			suppressedWhenEncountered,
+			suppressedAfterwards: runtimeSessionService.implicitStartupSuppressed,
+		}).toMatchInlineSnapshot(`
+			{
+			  "suppressedAfterwards": false,
+			  "suppressedWhenEncountered": [
+			    true,
+			  ],
+			}
+		`);
 	});
 });

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
@@ -10,7 +10,7 @@ import { ILocalizedString } from '../../../../platform/action/common/action.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { IsDevelopmentContext, IsWebContext } from '../../../../platform/contextkey/common/contextkeys.js';
-import { RemoteNameContext } from '../../../common/contextkeys.js';
+import { RemoteNameContext, ResourceContextKey } from '../../../common/contextkeys.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { isCodeEditor } from '../../../../editor/browser/editorBrowser.js';
 import { EditorContextKeys } from '../../../../editor/common/editorContextKeys.js';
@@ -33,16 +33,18 @@ import { PositronDataExplorerUri } from '../../../services/positronDataExplorer/
 import { EditorOpenSource } from '../../../../platform/editor/common/editor.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IPathService } from '../../../services/path/common/pathService.js';
-import { extname, toLocalResource } from '../../../../base/common/resources.js';
+import { toLocalResource } from '../../../../base/common/resources.js';
 import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
 import { showConvertToCodeModalDialog } from '../../../browser/positronModalDialogs/convertToCodeModalDialog.js';
 import { showFileOptionsModalDialog } from '../../../browser/positronModalDialogs/fileOptionsModalDialog.js';
-import { showImportDataModalDialog } from '../../../browser/positronModalDialogs/importDataModalDialog.js';
-import { isSessionVisibleFile } from '../../../services/positronDataExplorer/common/importDataFileUri.js';
 import { IPositronDataImporterRegistry } from '../../../services/positronDataExplorer/common/positronDataImporterRegistry.js';
 import { IPositronDataExplorerInstance } from '../../../services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance.js';
 import { CodeSyntaxName } from '../../../services/languageRuntime/common/positronDataExplorerComm.js';
 import { mainWindow } from '../../../../base/browser/window.js';
+import { IImportDataServices, importDataResourceArgument, openFileAndShowImportDataDialog, showImportDataDialogForInstance } from './positronDataExplorerImportData.js';
+import { Schemas } from '../../../../base/common/network.js';
+import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
+import { ExplorerFolderContext } from '../../files/common/files.js';
 
 /**
  * Positron Data Explorer action category.
@@ -77,6 +79,7 @@ export const enum PositronDataExplorerCommandId {
 	ConvertToCodeModalAction = 'workbench.action.positronDataExplorer.convertToCodeModal',
 	FileOptionsAction = 'workbench.action.positronDataExplorer.fileOptions',
 	ImportDataAction = 'workbench.action.positronDataExplorer.importData',
+	ImportDataFromFileAction = 'workbench.action.positronDataExplorer.importDataFromFile',
 	ShowColumnContextMenuAction = 'workbench.action.positronDataExplorer.showColumnContextMenu',
 	ShowRowContextMenuAction = 'workbench.action.positronDataExplorer.showRowContextMenu',
 	ShowCellContextMenuAction = 'workbench.action.positronDataExplorer.showCellContextMenu',
@@ -1170,11 +1173,15 @@ class PositronDataExplorerImportDataAction extends Action2 {
 	 * @param accessor The services accessor.
 	 */
 	async run(accessor: ServicesAccessor): Promise<void> {
-		// Access the services we need.
-		const editorService = accessor.get(IEditorService);
-		const environmentService = accessor.get(IWorkbenchEnvironmentService);
-		const importerRegistry = accessor.get(IPositronDataImporterRegistry);
-		const runtimeSessionService = accessor.get(IRuntimeSessionService);
+		// Access the services we need. An accessor is only valid before the first await.
+		const services: IImportDataServices = {
+			editorService: accessor.get(IEditorService),
+			environmentService: accessor.get(IWorkbenchEnvironmentService),
+			importerRegistry: accessor.get(IPositronDataImporterRegistry),
+			notificationService: accessor.get(INotificationService),
+			positronDataExplorerService: accessor.get(IPositronDataExplorerService),
+			runtimeSessionService: accessor.get(IRuntimeSessionService),
+		};
 
 		// Get the Positron data explorer instance, which is where the file options come from.
 		const positronDataExplorerInstance = await getPositronDataExplorerInstance(accessor);
@@ -1184,32 +1191,111 @@ class PositronDataExplorerImportDataAction extends Action2 {
 
 		// Recover the original file from the positron-data-explorer URI. A kernel-backed explorer
 		// has no backing file, so there is nothing to import.
-		const originalUri = EditorResourceAccessor.getOriginalUri(editorService.activeEditor);
+		const originalUri = EditorResourceAccessor.getOriginalUri(services.editorService.activeEditor);
 		const fileUri = originalUri && PositronDataExplorerUri.backingUri(originalUri);
 		if (!fileUri) {
 			return;
 		}
 
-		// Ask the registry which importers can read this file. This activates contributing
-		// extensions, so it must happen before the dialog opens.
-		//
-		// Offer nothing for a file the runtime session's machine cannot open: the generated code
-		// names fileUri.fsPath, and a path the session cannot resolve is worse than no code at all.
-		// The dialog renders the empty list as its empty state.
-		const importers = isSessionVisibleFile(fileUri, environmentService.remoteAuthority)
-			? await importerRegistry.getImporters(extname(fileUri))
-			: [];
+		await showImportDataDialogForInstance(services, fileUri, positronDataExplorerInstance);
+	}
+}
 
-		showImportDataModalDialog({
-			fileUri,
-			importers,
-			options: {
-				hasHeaderRow: positronDataExplorerInstance.fileHasHeaderRow,
-				// Import the sheet the user is looking at, not the workbook's default one.
-				sheetName: positronDataExplorerInstance.fileSelectedSheet,
+/**
+ * PositronImportDataFromFileAction action.
+ * The global Import Data entry points: the Explorer context menu passes the clicked file's URI;
+ * the File menu (and the Variables pane toolbar button, which executes this command) pass nothing,
+ * which opens a file picker. Either way the file is opened in the Data Explorer first and the
+ * Import Data dialog opens over it, so all entry points share one dialog code path.
+ */
+class PositronImportDataFromFileAction extends Action2 {
+	/**
+	 * Constructor.
+	 */
+	constructor() {
+		// Match the Data Explorer's plaintext set (.csv/.tsv/.xlsx). An .xlsx yields the dialog's
+		// empty state until an XLSX-capable importer registers, which is the designed behavior.
+		// Scheme-gate to files a runtime session could plausibly open; a virtual-filesystem file
+		// names no path on the session's machine, so no menu item is offered for it.
+		const importableFile = ContextKeyExpr.and(
+			ExplorerFolderContext.toNegated(),
+			ContextKeyExpr.regex(ResourceContextKey.Extension.key, /\.(csv|tsv|xlsx)$/i),
+			ContextKeyExpr.or(
+				ResourceContextKey.Scheme.isEqualTo(Schemas.file),
+				ResourceContextKey.Scheme.isEqualTo(Schemas.vscodeRemote)
+			)
+		);
+		super({
+			id: PositronDataExplorerCommandId.ImportDataFromFileAction,
+			title: {
+				value: localize('positronDataExplorer.importDataFromFile', 'Import Data...'),
+				original: 'Import Data...'
 			},
-			preferredLanguageId: runtimeSessionService.foregroundSession?.runtimeMetadata.languageId,
+			category,
+			// Not in the command palette: the palette already offers the Data Explorer variant
+			// when one is active, and two adjacent "Import Data" entries would be confusing.
+			f1: false,
+			menu: [
+				{
+					id: MenuId.ExplorerContext,
+					group: 'navigation',
+					order: 30,
+					when: importableFile
+				},
+				{
+					// The design places this near the Open group: it is where people who think of
+					// importing as a file operation go looking. Always enabled; order 100 puts it
+					// after the Open File/Folder/Recent entries in the group.
+					id: MenuId.MenubarFileMenu,
+					group: '2_open',
+					order: 100
+				}
+			]
 		});
+	}
+
+	/**
+	 * Runs the action.
+	 * @param accessor The services accessor.
+	 * @param resource The file to import, supplied by the Explorer context menu; not a URI when
+	 * invoked from the File menu or the Variables pane, which opens a file picker instead.
+	 */
+	async run(accessor: ServicesAccessor, resource?: unknown): Promise<void> {
+		// Access the services we need. An accessor is only valid before the first await.
+		const fileDialogService = accessor.get(IFileDialogService);
+		const services: IImportDataServices = {
+			editorService: accessor.get(IEditorService),
+			environmentService: accessor.get(IWorkbenchEnvironmentService),
+			importerRegistry: accessor.get(IPositronDataImporterRegistry),
+			notificationService: accessor.get(INotificationService),
+			positronDataExplorerService: accessor.get(IPositronDataExplorerService),
+			runtimeSessionService: accessor.get(IRuntimeSessionService),
+		};
+
+		// Without a resource, ask for one. The picker is scoped to the extensions the Data
+		// Explorer can open for import; it browses the workspace's filesystem, which in a remote
+		// window is the remote machine, so the picked path is one the session can open.
+		let fileUri = importDataResourceArgument(resource);
+		if (!fileUri) {
+			const uris = await fileDialogService.showOpenDialog({
+				title: localize('positronDataExplorer.importDataPickerTitle', "Import Data"),
+				openLabel: localize('positronDataExplorer.importDataPickerLabel', "Import"),
+				canSelectFiles: true,
+				canSelectFolders: false,
+				canSelectMany: false,
+				defaultUri: await fileDialogService.defaultFilePath(),
+				filters: [{
+					name: localize('positronDataExplorer.importDataPickerFilter', "Data Files"),
+					extensions: ['csv', 'tsv', 'xlsx']
+				}]
+			});
+			fileUri = uris?.at(0);
+			if (!fileUri) {
+				return;
+			}
+		}
+
+		await openFileAndShowImportDataDialog(services, fileUri);
 	}
 }
 
@@ -1599,6 +1685,7 @@ export function registerPositronDataExplorerActions() {
 	registerAction2(PositronDataExplorerOpenAsSpreadsheetAction);
 	registerAction2(PositronDataExplorerFileOptionsAction);
 	registerAction2(PositronDataExplorerImportDataAction);
+	registerAction2(PositronImportDataFromFileAction);
 	registerAction2(PositronDataExplorerConvertToCodeAction);
 	registerAction2(PositronDataExplorerConvertToCodeModalAction);
 	registerAction2(PositronDataExplorerShowColumnContextMenuAction);

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts
@@ -102,10 +102,12 @@ class PositronDataExplorerContribution extends Disposable {
 			{
 				singlePerResource: true,
 				canSupportResource: resource => {
-					let fileExt = extname(resource).substring(1);
+					// The registration glob above matches case-insensitively, so compare
+					// case-insensitively here too or DATA.CSV resolves to no editor.
+					let fileExt = extname(resource).substring(1).toLowerCase();
 					if (fileExt === 'gz') {
 						// Strip the .gz and get the actual extension
-						fileExt = posix.extname(resource.path.slice(0, -3)).substring(1);
+						fileExt = posix.extname(resource.path.slice(0, -3)).substring(1).toLowerCase();
 					}
 					return DUCKDB_SUPPORTED_EXTENSIONS.includes(fileExt);
 				}

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerImportData.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerImportData.ts
@@ -1,0 +1,136 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../../nls.js';
+import { URI } from '../../../../base/common/uri.js';
+import { basename, extname, isEqual } from '../../../../base/common/resources.js';
+import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
+import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
+import { IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
+import { IPositronDataExplorerService } from '../../../services/positronDataExplorer/browser/interfaces/positronDataExplorerService.js';
+import { IPositronDataExplorerInstance } from '../../../services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance.js';
+import { IPositronDataImporterRegistry } from '../../../services/positronDataExplorer/common/positronDataImporterRegistry.js';
+import { isSessionVisibleFile } from '../../../services/positronDataExplorer/common/importDataFileUri.js';
+import { PositronDataExplorerUri } from '../../../services/positronDataExplorer/common/positronDataExplorerUri.js';
+import { ImportDataModalDialogOptions, showImportDataModalDialog } from '../../../browser/positronModalDialogs/importDataModalDialog.js';
+import { PositronDataExplorerEditorInput } from './positronDataExplorerEditorInput.js';
+
+/**
+ * The services the import-data flow needs. Callers collect these from a ServicesAccessor before
+ * the first await, because an accessor is only valid synchronously.
+ */
+export interface IImportDataServices {
+	readonly editorService: IEditorService;
+	readonly environmentService: IWorkbenchEnvironmentService;
+	readonly importerRegistry: IPositronDataImporterRegistry;
+	readonly notificationService: INotificationService;
+	readonly positronDataExplorerService: IPositronDataExplorerService;
+	readonly runtimeSessionService: IRuntimeSessionService;
+}
+
+/**
+ * Normalizes the argument a command handler receives into a file URI. The native menubar runs the
+ * command with a `{ from: 'menu' }` payload rather than no argument at all, so a handler that only
+ * checks for a missing argument would treat that payload as a file and fail deep inside the editor
+ * service. Anything that is not a URI means "no file was named": open the file picker instead.
+ * @param arg The first argument passed to the command handler.
+ * @returns The named file, or undefined if the argument does not name one.
+ */
+export function importDataResourceArgument(arg: unknown): URI | undefined {
+	return URI.isUri(arg) ? arg : undefined;
+}
+
+/**
+ * Shows the Import Data dialog for a file that is open in a Data Explorer instance. This is the
+ * single dialog code path shared by every entry point (Data Explorer action bar, Explorer context
+ * menu, Variables pane button, and File menu item).
+ * @param services The workbench services the flow needs.
+ * @param fileUri The original file, not the positron-data-explorer URI.
+ * @param instance The Data Explorer instance showing the file, which supplies the file options.
+ * @param showDialog Injectable for tests; defaults to the real dialog.
+ */
+export async function showImportDataDialogForInstance(
+	services: IImportDataServices,
+	fileUri: URI,
+	instance: IPositronDataExplorerInstance,
+	showDialog: (options: ImportDataModalDialogOptions) => void = showImportDataModalDialog
+): Promise<void> {
+	// Ask the registry which importers can read this file. This activates contributing
+	// extensions, so it must happen before the dialog opens.
+	//
+	// Offer nothing for a file the runtime session's machine cannot open: the generated code
+	// names fileUri.fsPath, and a path the session cannot resolve is worse than no code at all.
+	// The dialog renders the empty list as its empty state.
+	const importers = isSessionVisibleFile(fileUri, services.environmentService.remoteAuthority)
+		? await services.importerRegistry.getImporters(extname(fileUri))
+		: [];
+
+	showDialog({
+		fileUri,
+		importers,
+		options: {
+			hasHeaderRow: instance.fileHasHeaderRow,
+			// Import the sheet the user is looking at, not the workbook's default one.
+			sheetName: instance.fileSelectedSheet,
+		},
+		preferredLanguageId: services.runtimeSessionService.foregroundSession?.runtimeMetadata.languageId,
+	});
+}
+
+/**
+ * Opens a file in the Data Explorer and then shows the Import Data dialog over it. This is the
+ * global entry points' path (Explorer context menu, Variables pane button, File menu item): they
+ * name a file that may not be open yet, so the Data Explorer is opened first and the dialog reads
+ * its state, exactly as if the user had opened the file and clicked Import Data.
+ * @param services The workbench services the flow needs.
+ * @param fileUri The file to import.
+ * @param showDialog Injectable for tests; defaults to the real dialog.
+ */
+export async function openFileAndShowImportDataDialog(
+	services: IImportDataServices,
+	fileUri: URI,
+	showDialog: (options: ImportDataModalDialogOptions) => void = showImportDataModalDialog
+): Promise<void> {
+	const identifier = `duckdb:${fileUri.toString()}`;
+	const explorerUri = PositronDataExplorerUri.generate(identifier);
+
+	// Reuse the Data Explorer already showing this file, if there is one.
+	const explorerEditorIsOpen = services.editorService.editors.some(
+		editor => isEqual(editor.resource, explorerUri)
+	);
+	const openInstance = explorerEditorIsOpen
+		? services.positronDataExplorerService.getInstance(identifier)
+		: undefined;
+	if (openInstance) {
+		await services.editorService.openEditor({ resource: explorerUri });
+		await showImportDataDialogForInstance(services, fileUri, openInstance, showDialog);
+		return;
+	}
+
+	// Open the file with the Data Explorer editor. The editor resolver routes supported data
+	// files through the DuckDB backend and registers an instance keyed on the file URI.
+	await services.editorService.openEditor({
+		resource: fileUri,
+		options: { override: PositronDataExplorerEditorInput.EditorID },
+	});
+
+	// Wait for the instance; a large file can take a moment to register.
+	const instance = await services.positronDataExplorerService.getInstanceAsync(identifier);
+	if (!instance) {
+		services.notificationService.notify({
+			severity: Severity.Error,
+			message: localize(
+				'positron.dataExplorer.importOpenFailed',
+				"Could not open {0} in the Data Explorer.",
+				basename(fileUri)
+			),
+			sticky: false,
+		});
+		return;
+	}
+
+	await showImportDataDialogForInstance(services, fileUri, instance, showDialog);
+}

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/test/browser/positronDataExplorerImportData.vitest.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/test/browser/positronDataExplorerImportData.vitest.ts
@@ -1,0 +1,227 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { URI } from '../../../../../base/common/uri.js';
+import { INotification, INotificationHandle, INotificationService, Severity } from '../../../../../platform/notification/common/notification.js';
+import { IEditorPane } from '../../../../common/editor.js';
+import { EditorInput } from '../../../../common/editor/editorInput.js';
+import { EditorResolution, IResourceEditorInput } from '../../../../../platform/editor/common/editor.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
+import { IWorkbenchEnvironmentService } from '../../../../services/environment/common/environmentService.js';
+import { ILanguageRuntimeMetadata } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
+import { ILanguageRuntimeSession, IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
+import { ImportDataModalDialogOptions } from '../../../../browser/positronModalDialogs/importDataModalDialog.js';
+import { IDataImporter, IPositronDataImporterRegistry } from '../../../../services/positronDataExplorer/common/positronDataImporterRegistry.js';
+import { IPositronDataExplorerService } from '../../../../services/positronDataExplorer/browser/interfaces/positronDataExplorerService.js';
+import { IPositronDataExplorerInstance } from '../../../../services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance.js';
+import { PositronDataExplorerUri } from '../../../../services/positronDataExplorer/common/positronDataExplorerUri.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { PositronDataExplorerEditorInput } from '../../browser/positronDataExplorerEditorInput.js';
+import {
+	IImportDataServices,
+	importDataResourceArgument,
+	openFileAndShowImportDataDialog,
+	showImportDataDialogForInstance,
+} from '../../browser/positronDataExplorerImportData.js';
+
+const csvUri = URI.file('/data/flights.csv');
+
+const pandasImporter = stubInterface<IDataImporter>({
+	languageId: 'python',
+	displayName: 'Python (pandas)',
+	fileExtensions: ['csv', 'tsv'],
+});
+
+function makeInstance(overrides?: Partial<IPositronDataExplorerInstance>): IPositronDataExplorerInstance {
+	return stubInterface<IPositronDataExplorerInstance>({
+		fileHasHeaderRow: true,
+		fileSelectedSheet: undefined,
+		...overrides,
+	});
+}
+
+interface TestHarness {
+	services: IImportDataServices;
+	calls: {
+		// The resource is recorded as a string: URI memoizes its serialized form on first
+		// toString(), so comparing the objects makes the assertion depend on whether the
+		// production code happened to stringify the URI.
+		openedEditors: { resource: string; override?: string | EditorResolution }[];
+		importerLookups: string[];
+		notifications: { severity: Severity; message: string }[];
+	};
+	shownDialogs: ImportDataModalDialogOptions[];
+	showDialog: (options: ImportDataModalDialogOptions) => void;
+}
+
+function makeHarness(opts: {
+	instance?: IPositronDataExplorerInstance;
+	/**
+	 * An instance already registered for the file. The service keeps these registered after
+	 * the editor closes, so `explorerEditorOpen` controls whether one is still live.
+	 */
+	openInstance?: IPositronDataExplorerInstance;
+	/** Whether an editor for the generated positron-data-explorer URI is open. */
+	explorerEditorOpen?: boolean;
+	importers?: IDataImporter[];
+	remoteAuthority?: string;
+	foregroundLanguageId?: string;
+} = {}): TestHarness {
+	const calls: TestHarness['calls'] = { openedEditors: [], importerLookups: [], notifications: [] };
+	const shownDialogs: ImportDataModalDialogOptions[] = [];
+	const services: IImportDataServices = {
+		editorService: stubInterface<IEditorService>({
+			editors: opts.explorerEditorOpen
+				? [stubInterface<EditorInput>({
+					resource: PositronDataExplorerUri.generate(`duckdb:${csvUri.toString()}`),
+				})]
+				: [],
+			// openEditor is overloaded five ways; the flow only ever calls the
+			// IResourceEditorInput one, so the stub implements that signature and is
+			// cast to the full set rather than restating the four it never receives.
+			openEditor: (async (editor: IResourceEditorInput): Promise<IEditorPane | undefined> => {
+				calls.openedEditors.push({ resource: editor.resource.toString(), override: editor.options?.override });
+				return undefined;
+			}) as IEditorService['openEditor'],
+		}),
+		environmentService: stubInterface<IWorkbenchEnvironmentService>({
+			remoteAuthority: opts.remoteAuthority,
+		}),
+		importerRegistry: stubInterface<IPositronDataImporterRegistry>({
+			getImporters: async (fileExtension: string) => {
+				calls.importerLookups.push(fileExtension);
+				return opts.importers ?? [pandasImporter];
+			},
+		}),
+		notificationService: stubInterface<INotificationService>({
+			notify: (notification: INotification): INotificationHandle => {
+				calls.notifications.push({
+					severity: notification.severity,
+					message: String(notification.message),
+				});
+				return stubInterface<INotificationHandle>();
+			},
+		}),
+		positronDataExplorerService: stubInterface<IPositronDataExplorerService>({
+			getInstance: (_identifier: string) => opts.openInstance,
+			getInstanceAsync: async (_identifier: string) => opts.instance,
+		}),
+		runtimeSessionService: stubInterface<IRuntimeSessionService>({
+			foregroundSession: opts.foregroundLanguageId
+				? stubInterface<ILanguageRuntimeSession>({
+					runtimeMetadata: stubInterface<ILanguageRuntimeMetadata>({
+						languageId: opts.foregroundLanguageId,
+					}),
+				})
+				: undefined,
+		}),
+	};
+	return { services, calls, shownDialogs, showDialog: options => shownDialogs.push(options) };
+}
+
+describe('importDataResourceArgument', () => {
+	test('keeps a URI named by the Explorer context menu', () => {
+		expect(importDataResourceArgument(csvUri)).toStrictEqual(csvUri);
+	});
+
+	test('discards the native menubar payload so the file picker opens', () => {
+		// The native menubar runs the command with { from: 'menu' } instead of no argument.
+		expect(importDataResourceArgument({ from: 'menu' })).toStrictEqual(undefined);
+	});
+
+	test('discards a missing argument', () => {
+		expect(importDataResourceArgument(undefined)).toStrictEqual(undefined);
+	});
+});
+
+describe('showImportDataDialogForInstance', () => {
+	test('looks up importers by extension and shows the dialog with instance state', async () => {
+		const harness = makeHarness({ foregroundLanguageId: 'python' });
+		await showImportDataDialogForInstance(
+			harness.services, csvUri, makeInstance(), harness.showDialog
+		);
+		expect(harness.calls.importerLookups).toStrictEqual(['.csv']);
+		expect(harness.shownDialogs).toStrictEqual([{
+			fileUri: csvUri,
+			importers: [pandasImporter],
+			options: { hasHeaderRow: true, sheetName: undefined },
+			preferredLanguageId: 'python',
+		}]);
+	});
+
+	test('offers no importers for a file the session machine cannot see', async () => {
+		// A client-local file:// URI inside a remote window names a path the
+		// runtime session cannot open, so the dialog gets its empty state.
+		const harness = makeHarness({ remoteAuthority: 'ssh-remote+box' });
+		await showImportDataDialogForInstance(
+			harness.services, csvUri, makeInstance(), harness.showDialog
+		);
+		expect(harness.calls.importerLookups).toStrictEqual([]);
+		expect(harness.shownDialogs[0].importers).toStrictEqual([]);
+	});
+});
+
+describe('openFileAndShowImportDataDialog', () => {
+	test('opens the file in the Data Explorer, waits for the instance, shows the dialog', async () => {
+		const harness = makeHarness({ instance: makeInstance({ fileSelectedSheet: undefined }) });
+		await openFileAndShowImportDataDialog(harness.services, csvUri, harness.showDialog);
+		expect(harness.calls.openedEditors).toStrictEqual([{
+			resource: csvUri.toString(),
+			override: PositronDataExplorerEditorInput.EditorID,
+		}]);
+		expect(harness.shownDialogs).toHaveLength(1);
+		expect(harness.shownDialogs[0].fileUri).toStrictEqual(csvUri);
+	});
+
+	test('reuses the Data Explorer already showing the file instead of reopening it', async () => {
+		// Reopening the file URI would build a second DuckDB backend under the same identifier,
+		// so the dialog must read the open instance's worksheet and header-row settings.
+		const harness = makeHarness({
+			explorerEditorOpen: true,
+			openInstance: makeInstance({ fileHasHeaderRow: false, fileSelectedSheet: 'Q3' }),
+			instance: makeInstance({ fileHasHeaderRow: true, fileSelectedSheet: undefined }),
+		});
+		await openFileAndShowImportDataDialog(harness.services, csvUri, harness.showDialog);
+		expect(harness.calls.openedEditors).toStrictEqual([{
+			resource: PositronDataExplorerUri.generate(`duckdb:${csvUri.toString()}`).toString(),
+			override: undefined,
+		}]);
+		expect(harness.shownDialogs).toHaveLength(1);
+		expect(harness.shownDialogs[0].options).toStrictEqual({
+			hasHeaderRow: false,
+			sheetName: 'Q3',
+		});
+	});
+
+	test('opens a fresh backend when the file registered an instance but its editor was closed', async () => {
+		// Closing a DuckDB editor disposes its client but leaves the instance registered, so a
+		// registered instance with no open editor must not be reused - reopening the file URI is
+		// what builds a live backend.
+		const harness = makeHarness({
+			explorerEditorOpen: false,
+			openInstance: makeInstance({ fileHasHeaderRow: false, fileSelectedSheet: 'Q3' }),
+			instance: makeInstance({ fileHasHeaderRow: true, fileSelectedSheet: undefined }),
+		});
+		await openFileAndShowImportDataDialog(harness.services, csvUri, harness.showDialog);
+		expect(harness.calls.openedEditors).toStrictEqual([{
+			resource: csvUri.toString(),
+			override: PositronDataExplorerEditorInput.EditorID,
+		}]);
+		expect(harness.shownDialogs[0].options).toStrictEqual({
+			hasHeaderRow: true,
+			sheetName: undefined,
+		});
+	});
+
+	test('notifies and shows no dialog when no instance appears', async () => {
+		const harness = makeHarness({ instance: undefined });
+		await openFileAndShowImportDataDialog(harness.services, csvUri, harness.showDialog);
+		expect(harness.shownDialogs).toStrictEqual([]);
+		expect(harness.calls.notifications).toHaveLength(1);
+		expect(harness.calls.notifications[0].severity).toStrictEqual(Severity.Error);
+	});
+});

--- a/src/vs/workbench/contrib/positronVariables/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/actionBars.tsx
@@ -12,8 +12,6 @@ import { PropsWithChildren, useEffect, useLayoutEffect, useRef, useState } from 
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
-import { PositronActionBar } from '../../../../../platform/positronActionBar/browser/positronActionBar.js';
-import { ActionBarRegion } from '../../../../../platform/positronActionBar/browser/components/actionBarRegion.js';
 import { ActionBarButton } from '../../../../../platform/positronActionBar/browser/components/actionBarButton.js';
 import { ActionBarFilter, ActionBarFilterHandle } from '../../../../../platform/positronActionBar/browser/components/actionBarFilter.js';
 import { SortingMenuButton } from './sortingMenuButton.js';
@@ -32,10 +30,11 @@ import { PositronDynamicActionBar, DynamicActionBarAction, DEFAULT_ACTION_BAR_BU
 import { PositronDataExplorerCommandId } from '../../../positronDataExplorerEditor/browser/positronDataExplorerActions.js';
 
 // Constants.
-const kSecondaryActionBarGap = 4;
 const kPaddingLeft = 8;
 const kPaddingRight = 8;
 const kFilterTimeout = 800;
+const kFilterWidth = 150;
+const kFilterMinWidth = 60;
 
 /**
  * Localized strings.
@@ -186,29 +185,8 @@ export const ActionBars = (props: PropsWithChildren<{}>) => {
 		},
 		{
 			fixedWidth: DEFAULT_ACTION_BAR_DROPDOWN_BUTTON_WIDTH,
-			separator: true,
-			component: <SortingMenuButton />
-		},
-		{
-			fixedWidth: DEFAULT_ACTION_BAR_BUTTON_WIDTH,
 			separator: false,
-			component: (
-				<ActionBarButton
-					ariaLabel={positronImportData}
-					icon={Codicon.positronImportData}
-					tooltip={positronImportData}
-					onPressed={importDataHandler}
-				/>
-			),
-			overflowContextMenuItem: {
-				commandId: PositronDataExplorerCommandId.ImportDataFromFileAction,
-				icon: 'positron-import-data',
-				label: positronImportData,
-				// The commandId above already runs the import; onSelected is called
-				// AFTER the command executes, so it must be a no-op to avoid a
-				// second invocation (and a second stacked file picker).
-				onSelected: () => { }
-			}
+			component: <SortingMenuButton />
 		},
 	];
 
@@ -220,8 +198,8 @@ export const ActionBars = (props: PropsWithChildren<{}>) => {
 	// left actions + right actions + separators + overflow button + padding.
 	const baseWidth =
 		(DEFAULT_ACTION_BAR_DROPDOWN_BUTTON_WIDTH * 2) + // grouping + sorting
-		(DEFAULT_ACTION_BAR_BUTTON_WIDTH * 3) +          // import + refresh + delete
-		(DEFAULT_ACTION_BAR_SEPARATOR_WIDTH * 2) +        // sorting/import divider + refresh/delete separator
+		(DEFAULT_ACTION_BAR_BUTTON_WIDTH * 2) +          // refresh + delete
+		(DEFAULT_ACTION_BAR_SEPARATOR_WIDTH * 1) +        // separator between refresh and delete
 		DEFAULT_ACTION_BAR_BUTTON_WIDTH +                 // overflow button reserved by DynamicActionBar
 		kPaddingLeft + kPaddingRight;
 
@@ -327,6 +305,53 @@ export const ActionBars = (props: PropsWithChildren<{}>) => {
 		},
 	);
 
+	// Build the secondary action bar. Import Data lives here rather than on the primary bar:
+	// the primary bar's width is shared with the memory usage meter, whose bar shrinks and
+	// then disappears as actions are added, and at common pane widths there is not room for
+	// both. The secondary bar carries only the filter, so the button fits alongside it.
+	const secondaryLeftActions: DynamicActionBarAction[] = [
+		{
+			fixedWidth: DEFAULT_ACTION_BAR_BUTTON_WIDTH,
+			separator: false,
+			component: (
+				<ActionBarButton
+					ariaLabel={positronImportData}
+					icon={Codicon.positronImportData}
+					tooltip={positronImportData}
+					onPressed={importDataHandler}
+				/>
+			),
+			overflowContextMenuItem: {
+				commandId: PositronDataExplorerCommandId.ImportDataFromFileAction,
+				icon: 'positron-import-data',
+				label: positronImportData,
+				// The commandId above already runs the import; onSelected is called
+				// AFTER the command executes, so it must be a no-op to avoid a
+				// second invocation (and a second stacked file picker).
+				onSelected: () => { }
+			}
+		},
+	];
+
+	// The filter is allocated its minimum width and then grows into whatever space is left
+	// over, up to its preferred width. It has no overflow menu entry, so a fixed preferred
+	// width would make DynamicActionBar drop it outright once the pane got narrow enough;
+	// shrinking keeps filtering reachable instead. The component fills the granted cell.
+	const secondaryRightActions: DynamicActionBarAction[] = [
+		{
+			fixedWidth: kFilterMinWidth,
+			maxWidth: kFilterWidth,
+			separator: false,
+			component: (
+				<ActionBarFilter
+					ref={filterRef}
+					initialFilterText={filterText}
+					width='100%'
+					onFilterTextChanged={filterText => setFilterText(filterText)} />
+			)
+		},
+	];
+
 	// Render.
 	return (
 		<PositronActionBarContextProvider {...props}>
@@ -339,20 +364,13 @@ export const ActionBars = (props: PropsWithChildren<{}>) => {
 					paddingRight={kPaddingRight}
 					rightActions={rightActions}
 				/>
-				<PositronActionBar
+				<PositronDynamicActionBar
 					borderBottom={true}
-					gap={kSecondaryActionBarGap}
+					leftActions={secondaryLeftActions}
 					paddingLeft={kPaddingLeft}
 					paddingRight={kPaddingRight}
-				>
-					<ActionBarRegion location='right'>
-						<ActionBarFilter
-							ref={filterRef}
-							initialFilterText={filterText}
-							width={150}
-							onFilterTextChanged={filterText => setFilterText(filterText)} />
-					</ActionBarRegion>
-				</PositronActionBar>
+					rightActions={secondaryRightActions}
+				/>
 			</div>
 		</PositronActionBarContextProvider>
 	);

--- a/src/vs/workbench/contrib/positronVariables/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/actionBars.tsx
@@ -11,6 +11,7 @@ import { PropsWithChildren, useEffect, useLayoutEffect, useRef, useState } from 
 
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
 import { PositronActionBar } from '../../../../../platform/positronActionBar/browser/positronActionBar.js';
 import { ActionBarRegion } from '../../../../../platform/positronActionBar/browser/components/actionBarRegion.js';
 import { ActionBarButton } from '../../../../../platform/positronActionBar/browser/components/actionBarButton.js';
@@ -28,6 +29,7 @@ import { DisposableStore, toDisposable } from '../../../../../base/common/lifecy
 import { IMemoryUsageSnapshot } from '../../../../../platform/positronMemoryUsage/common/positronMemoryUsage.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { PositronDynamicActionBar, DynamicActionBarAction, DEFAULT_ACTION_BAR_BUTTON_WIDTH, DEFAULT_ACTION_BAR_DROPDOWN_BUTTON_WIDTH, DEFAULT_ACTION_BAR_SEPARATOR_WIDTH } from '../../../../../platform/positronActionBar/browser/positronDynamicActionBar.js';
+import { PositronDataExplorerCommandId } from '../../../positronDataExplorerEditor/browser/positronDataExplorerActions.js';
 
 // Constants.
 const kSecondaryActionBarGap = 4;
@@ -40,6 +42,7 @@ const kFilterTimeout = 800;
  */
 const positronRefreshObjects = localize('positronRefreshObjects', "Refresh Objects");
 const positronDeleteAllObjects = localize('positronDeleteAllObjects', "Delete All Objects");
+const positronImportData = localize('positronImportDataFromFile', "Import Data");
 
 /**
  * ActionBars component.
@@ -160,6 +163,14 @@ export const ActionBars = (props: PropsWithChildren<{}>) => {
 		positronVariablesContext.activePositronVariablesInstance?.requestRefresh();
 	};
 
+	/**
+	 * Import data event handler. Runs the global Import Data command, which opens a file picker
+	 * and then the Import Data dialog over the file in the Data Explorer.
+	 */
+	const importDataHandler = () => {
+		services.commandService.executeCommand(PositronDataExplorerCommandId.ImportDataFromFileAction);
+	};
+
 	// If there are no instances, return null.
 	// TODO@softwarenerd - Render something specific for this case. TBD.
 	if (positronVariablesContext.positronVariablesInstances.length === 0) {
@@ -175,8 +186,29 @@ export const ActionBars = (props: PropsWithChildren<{}>) => {
 		},
 		{
 			fixedWidth: DEFAULT_ACTION_BAR_DROPDOWN_BUTTON_WIDTH,
-			separator: false,
+			separator: true,
 			component: <SortingMenuButton />
+		},
+		{
+			fixedWidth: DEFAULT_ACTION_BAR_BUTTON_WIDTH,
+			separator: false,
+			component: (
+				<ActionBarButton
+					ariaLabel={positronImportData}
+					icon={Codicon.positronImportData}
+					tooltip={positronImportData}
+					onPressed={importDataHandler}
+				/>
+			),
+			overflowContextMenuItem: {
+				commandId: PositronDataExplorerCommandId.ImportDataFromFileAction,
+				icon: 'positron-import-data',
+				label: positronImportData,
+				// The commandId above already runs the import; onSelected is called
+				// AFTER the command executes, so it must be a no-op to avoid a
+				// second invocation (and a second stacked file picker).
+				onSelected: () => { }
+			}
 		},
 	];
 
@@ -188,8 +220,8 @@ export const ActionBars = (props: PropsWithChildren<{}>) => {
 	// left actions + right actions + separators + overflow button + padding.
 	const baseWidth =
 		(DEFAULT_ACTION_BAR_DROPDOWN_BUTTON_WIDTH * 2) + // grouping + sorting
-		(DEFAULT_ACTION_BAR_BUTTON_WIDTH * 2) +          // refresh + delete
-		(DEFAULT_ACTION_BAR_SEPARATOR_WIDTH * 1) +        // separator between refresh and delete
+		(DEFAULT_ACTION_BAR_BUTTON_WIDTH * 3) +          // import + refresh + delete
+		(DEFAULT_ACTION_BAR_SEPARATOR_WIDTH * 2) +        // sorting/import divider + refresh/delete separator
 		DEFAULT_ACTION_BAR_BUTTON_WIDTH +                 // overflow button reserved by DynamicActionBar
 		kPaddingLeft + kPaddingRight;
 

--- a/test/e2e/pages/dataExplorer.ts
+++ b/test/e2e/pages/dataExplorer.ts
@@ -1187,6 +1187,10 @@ export class ImportDataModal {
 		await this.workbench.dynamicModals.clickButton('Import');
 	}
 
+	async clickCancel() {
+		await this.workbench.dynamicModals.clickButton('Cancel');
+	}
+
 	// --- Verifications ---
 
 	async expectToBeVisible() {

--- a/test/e2e/pages/quickInput.ts
+++ b/test/e2e/pages/quickInput.ts
@@ -14,8 +14,9 @@ export class QuickInput {
 	private static QUICK_INPUT_RESULT = `${QuickInput.QUICK_INPUT} .quick-input-list .monaco-list-row`;
 	// Note: this only grabs the label and not the description or detail
 	static readonly QUICK_INPUT_ENTRY_LABEL = `${this.QUICK_INPUT_RESULT} .quick-input-list-row > .monaco-icon-label .label-name`;
-	private static QUICKINPUT_OK_BUTTON =
-		'.quick-input-widget .quick-input-action a:has-text(\'OK\')';
+	private static quickInputActionButton(label: string): string {
+		return `.quick-input-widget .quick-input-action a:has-text('${label}')`;
+	}
 	quickInputList: Locator;
 	quickInput: Locator;
 	quickInputTitleBar: Locator;
@@ -257,9 +258,9 @@ export class QuickInput {
 		await this.code.driver.currentPage.mouse.move(0, 0);
 	}
 
-	async clickOkButton(): Promise<void> {
+	async clickOkButton(label: string = 'OK'): Promise<void> {
 		await this.code.driver.currentPage
-			.locator(QuickInput.QUICKINPUT_OK_BUTTON)
+			.locator(QuickInput.quickInputActionButton(label))
 			.click();
 	}
 

--- a/test/e2e/pages/variables.ts
+++ b/test/e2e/pages/variables.ts
@@ -187,6 +187,10 @@ export class Variables {
 		await this.code.driver.currentPage.getByLabel('Delete all objects').click();
 	}
 
+	async clickImportData() {
+		await this.code.driver.currentPage.getByLabel('Import Data', { exact: true }).click();
+	}
+
 	/**
 	 * Verify: Confirm the variable is visible and has the expected value.
 	 * @param variableName the name of the variable to check

--- a/test/e2e/tests/data-explorer/import-data.test.ts
+++ b/test/e2e/tests/data-explorer/import-data.test.ts
@@ -62,4 +62,46 @@ test.describe('Data Explorer - Import Data', {
 		// The file has a header row, 10 data rows, and 10 columns, which is how readr reads it.
 		await variables.expectVariableToBe('small_file', /10 rows x 10 columns/);
 	});
+
+	test('Explorer context menu - Verify Import Data opens the dialog over the file', async function ({ app, python }) {
+		const { contextMenu, dataExplorer, quickaccess } = app.workbench;
+		const page = app.code.driver.currentPage;
+
+		// Reveal data-files/small_file.csv in the Explorer.
+		await quickaccess.runCommand('workbench.view.explorer');
+		const folderRow = page.locator('.explorer-folders-view .monaco-list-row[aria-label="data-files"]');
+		if (await folderRow.getAttribute('aria-expanded') === 'false') {
+			await folderRow.locator('.monaco-tl-twistie').click();
+		}
+		const fileRow = page.locator('.explorer-folders-view .monaco-list-row[aria-label="small_file.csv"]');
+
+		await contextMenu.triggerAndClick({
+			menuTrigger: fileRow,
+			menuItemLabel: 'Import Data...',
+			menuTriggerButton: 'right'
+		});
+
+		// The command opens the file in the Data Explorer with the dialog over it.
+		await dataExplorer.importDataModal.expectToBeVisible();
+		await dataExplorer.importDataModal.expectCodeToContain('small_file');
+
+		// The Python/R tests above already prove the import chain; stop at the dialog.
+		await dataExplorer.importDataModal.clickCancel();
+	});
+
+	test('Variables pane button - Verify Import Data picks a file then opens the dialog', async function ({ app, python }) {
+		const { dataExplorer, quickInput, variables } = app.workbench;
+
+		await variables.clickImportData();
+
+		// files.simpleDialog.enable is on in the e2e fixture settings, so the file picker is the
+		// quick-input simple dialog rather than the OS-native one.
+		await quickInput.waitForQuickInputOpened();
+		await quickInput.type(join(app.workspacePathOrFolder, 'data-files', 'small_file.csv'));
+		await quickInput.clickOkButton('Import');
+
+		await dataExplorer.importDataModal.expectToBeVisible();
+		await dataExplorer.importDataModal.expectCodeToContain('small_file');
+		await dataExplorer.importDataModal.clickCancel();
+	});
 });

--- a/test/e2e/tests/data-explorer/import-data.test.ts
+++ b/test/e2e/tests/data-explorer/import-data.test.ts
@@ -63,6 +63,35 @@ test.describe('Data Explorer - Import Data', {
 		await variables.expectVariableToBe('small_file', /10 rows x 10 columns/);
 	});
 
+	test('Variables pane button - Verify Import Data picks a file then opens the dialog', async function ({ app, python }) {
+		const { dataExplorer, quickInput, variables } = app.workbench;
+
+		await variables.clickImportData();
+
+		// files.simpleDialog.enable is on in the e2e fixture settings, so the file picker is the
+		// quick-input simple dialog rather than the OS-native one.
+		await quickInput.waitForQuickInputOpened();
+		await quickInput.type(join(app.workspacePathOrFolder, 'data-files', 'small_file.csv'));
+		await quickInput.clickOkButton('Import');
+
+		await dataExplorer.importDataModal.expectToBeVisible();
+		await dataExplorer.importDataModal.expectCodeToContain('small_file');
+		await dataExplorer.importDataModal.clickCancel();
+	});
+});
+
+// Electron only, with no WEB tag: right-clicking a file row in the Explorer tree opens no
+// context menu at all in Positron Web, while other web surfaces (the Explorer title, the
+// activity bar, the status bar) open one normally. That is a pre-existing web bug unrelated
+// to Import Data, so the entry point is covered on Electron (Linux and Windows) instead.
+test.describe('Data Explorer - Import Data from the Explorer context menu', {
+	tag: [tags.WIN, tags.DATA_EXPLORER, tags.DUCK_DB]
+}, () => {
+
+	test.afterEach(async function ({ hotKeys }) {
+		await hotKeys.closeAllEditors();
+	});
+
 	test('Explorer context menu - Verify Import Data opens the dialog over the file', async function ({ app, python }) {
 		const { contextMenu, dataExplorer, quickaccess } = app.workbench;
 		const page = app.code.driver.currentPage;
@@ -86,22 +115,6 @@ test.describe('Data Explorer - Import Data', {
 		await dataExplorer.importDataModal.expectCodeToContain('small_file');
 
 		// The Python/R tests above already prove the import chain; stop at the dialog.
-		await dataExplorer.importDataModal.clickCancel();
-	});
-
-	test('Variables pane button - Verify Import Data picks a file then opens the dialog', async function ({ app, python }) {
-		const { dataExplorer, quickInput, variables } = app.workbench;
-
-		await variables.clickImportData();
-
-		// files.simpleDialog.enable is on in the e2e fixture settings, so the file picker is the
-		// quick-input simple dialog rather than the OS-native one.
-		await quickInput.waitForQuickInputOpened();
-		await quickInput.type(join(app.workspacePathOrFolder, 'data-files', 'small_file.csv'));
-		await quickInput.clickOkButton('Import');
-
-		await dataExplorer.importDataModal.expectToBeVisible();
-		await dataExplorer.importDataModal.expectCodeToContain('small_file');
 		await dataExplorer.importDataModal.clickCancel();
 	});
 });


### PR DESCRIPTION
Fixes #15583. (Stacked on #15749.) Adds three more entry points to the Import Data dialog:

- File > Import Data...
- A button in the Variables pane toolbar
- "Import Data..." in the File Explorer context menu, on `.csv` and `.tsv` files

These all call the same new `positronDataExplorer.importDataFromFile` command. The Explorer context menu hands the command the file you clicked. The other two don't name a file, so they open a file picker first. From there every entry point does the same thing: open the file in the Data Explorer, then show the Import Data dialog over it, exactly as if you had opened the file and clicked Import Data yourself. If a Data Explorer is already showing that file, it's reused rather than reopened, so the dialog picks up the header-row and worksheet settings you already chose.

### Screenshots

<img width="278" height="338" alt="image" src="https://github.com/user-attachments/assets/734c6186-6d41-4816-abbc-df61389cc57d" />

<img width="374" height="168" alt="image" src="https://github.com/user-attachments/assets/067f56b6-3a4c-4976-97fe-39f9c0cf08a0" />

<img width="368" height="114" alt="image" src="https://github.com/user-attachments/assets/1ed73341-7891-4dad-a016-42460b70db4e" />


### Release Notes

#### New Features

- Import Data is now available from the File menu, the Variables pane, and the File Explorer context menu, not just the Data Explorer (#15583)

#### Bug Fixes

- N/A

### Validation Steps

@:data-explorer @:duck-db @:variables @:win @:web

1. Right-click a `.csv` in the File Explorer and choose "Import Data...". The file opens in the Data Explorer and the dialog opens over it, with the file's name as the default variable name.
2. Check the menu item shows up for `.tsv` too, and not for a folder or an unrelated file type like `.py`. Check it shows for `DATA.CSV`, and that the file opens in the Data Explorer rather than the text editor.
3. Use File > Import Data... with nothing open. A file picker appears titled "Import Data" with an "Import" button, filtered to data files. Pick a CSV and check the dialog opens over it.
4. Cancel the file picker. Nothing should open, and no error should appear.
5. Click the Import Data button in the Variables pane toolbar. Same picker, same dialog. Narrow the pane until the toolbar overflows, then use Import Data from the overflow menu, and check that only one file picker opens.
6. Open a CSV in the Data Explorer, turn off the header row in File Options, then trigger Import Data from the Explorer context menu for that same file. The dialog must show the code without a header row, and the editor must not be reopened.
7. Close the Data Explorer for a file you already imported, then import it again from the context menu. It should open and work rather than showing a stale or empty grid.
8. Run all of the above once on Windows, where the file picker and the generated paths differ.
