### PR TITLE
python: label /opt/python standalone interpreters as Global (community PR #15790)

### DIFF
--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/globalInstalledEnvs.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/globalInstalledEnvs.ts
@@ -63,6 +63,12 @@ export function isAdditionalGlobalBinPath(executablePath: string): boolean {
     if (getOSType() === OSType.Windows) {
         return false;
     }
+
+    // Explicitly catch /opt/python standalone interpreters to ensure they are labeled as Global
+    if (executablePath.startsWith('/opt/python/')) {
+        return true;
+    }
+
     const searchPathEntries = ADDITIONAL_POSIX_BIN_PATHS;
     for (const searchPath of searchPathEntries) {
         if (isParentPath(executablePath, searchPath)) {

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/globalInstalledEnvs.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/globalInstalledEnvs.ts
@@ -63,12 +63,6 @@ export function isAdditionalGlobalBinPath(executablePath: string): boolean {
     if (getOSType() === OSType.Windows) {
         return false;
     }
-
-    // Explicitly catch /opt/python standalone interpreters to ensure they are labeled as Global
-    if (executablePath.startsWith('/opt/python/')) {
-        return true;
-    }
-
     const searchPathEntries = ADDITIONAL_POSIX_BIN_PATHS;
     for (const searchPath of searchPathEntries) {
         if (isParentPath(executablePath, searchPath)) {

--- a/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
@@ -354,17 +354,17 @@ enum ExistingEnvAction {
 
 type ExistingEnvResult =
     | {
-          reason: ExistingEnvAction.KeepExistingEnv;
-          existingEnv: PythonEnvInfo;
-      }
+        reason: ExistingEnvAction.KeepExistingEnv;
+        existingEnv: PythonEnvInfo;
+    }
     | {
-          reason: ExistingEnvAction.AddNewEnv;
-          existingEnv: undefined;
-      }
+        reason: ExistingEnvAction.AddNewEnv;
+        existingEnv: undefined;
+    }
     | {
-          reason: ExistingEnvAction.ReplaceExistingEnv;
-          existingEnv: PythonEnvInfo;
-      };
+        reason: ExistingEnvAction.ReplaceExistingEnv;
+        existingEnv: PythonEnvInfo;
+    };
 // --- End Positron ---
 
 class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
@@ -519,6 +519,11 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
         if (!validEnv(native)) {
             return undefined;
         }
+
+        // --- Start Positron ---
+        // Ensure Positron-specific paths (like /opt/python) are correctly categorized during processing
+        await this.enhanceNativeEnvInfo(native);
+        // --- End Positron ---
 
         try {
             const version = native.version ? parseVersion(native.version) : undefined;
@@ -762,23 +767,27 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
     }
 
     // --- Start Positron ---
+    private async enhanceNativeEnvInfo(native: NativeEnvInfo): Promise<void> {
+        if (native.executable && (await isUvEnvironment(native.executable))) {
+            traceInfo(`Found uv environment: ${native.executable}`);
+            native.kind = NativePythonEnvironmentKind.Uv;
+        }
+        if (!native.kind && native.executable && (await isCustomEnvironment(native.executable))) {
+            native.kind = NativePythonEnvironmentKind.Custom;
+            native.source = [PythonEnvSource.UserSettings];
+        }
+        if (!native.kind && native.executable && isAdditionalGlobalBinPath(native.executable)) {
+            native.kind = NativePythonEnvironmentKind.GlobalPaths;
+        }
+    }
+
     private async _doResolveEnv(envPath: string): Promise<PythonEnvInfo | undefined> {
         // --- End Positron ---
         try {
             const native = await this.finder.resolve(envPath);
             if (native) {
                 // --- Start Positron ---
-                if (native.executable && (await isUvEnvironment(native.executable))) {
-                    traceInfo(`Found uv environment: ${native.executable}`);
-                    native.kind = NativePythonEnvironmentKind.Uv;
-                }
-                if (!native.kind && native.executable && (await isCustomEnvironment(native.executable))) {
-                    native.kind = NativePythonEnvironmentKind.Custom;
-                    native.source = [PythonEnvSource.UserSettings];
-                }
-                if (!native.kind && native.executable && isAdditionalGlobalBinPath(native.executable)) {
-                    native.kind = NativePythonEnvironmentKind.GlobalPaths;
-                }
+                await this.enhanceNativeEnvInfo(native);
                 // --- End Positron ---
                 if (native.kind === NativePythonEnvironmentKind.Conda && this._condaEnvDirs.length === 0) {
                     this._condaEnvDirs = (await getCondaEnvDirs()) ?? [];

--- a/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
@@ -274,7 +274,7 @@ async function toPythonEnvInfo(nativeEnv: NativeEnvInfo, condaEnvDirs: string[])
     // --- End Positron ---
     const displayName = nativeEnv.version
         ? getDisplayName(version, kind, arch, name)
-        : (nativeEnv.displayName ?? 'Python');
+        : nativeEnv.displayName ?? 'Python';
 
     const executable = nativeEnv.executable ?? makeExecutablePath(nativeEnv.prefix);
     return {

--- a/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
@@ -274,7 +274,7 @@ async function toPythonEnvInfo(nativeEnv: NativeEnvInfo, condaEnvDirs: string[])
     // --- End Positron ---
     const displayName = nativeEnv.version
         ? getDisplayName(version, kind, arch, name)
-        : nativeEnv.displayName ?? 'Python';
+        : (nativeEnv.displayName ?? 'Python');
 
     const executable = nativeEnv.executable ?? makeExecutablePath(nativeEnv.prefix);
     return {
@@ -354,17 +354,17 @@ enum ExistingEnvAction {
 
 type ExistingEnvResult =
     | {
-        reason: ExistingEnvAction.KeepExistingEnv;
-        existingEnv: PythonEnvInfo;
-    }
+          reason: ExistingEnvAction.KeepExistingEnv;
+          existingEnv: PythonEnvInfo;
+      }
     | {
-        reason: ExistingEnvAction.AddNewEnv;
-        existingEnv: undefined;
-    }
+          reason: ExistingEnvAction.AddNewEnv;
+          existingEnv: undefined;
+      }
     | {
-        reason: ExistingEnvAction.ReplaceExistingEnv;
-        existingEnv: PythonEnvInfo;
-    };
+          reason: ExistingEnvAction.ReplaceExistingEnv;
+          existingEnv: PythonEnvInfo;
+      };
 // --- End Positron ---
 
 class NativePythonEnvironments implements IDiscoveryAPI, Disposable {

--- a/extensions/positron-python/src/test/pythonEnvironments/nativeAPI.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/nativeAPI.unit.test.ts
@@ -509,7 +509,7 @@ suite('Native Python API', () => {
             displayName: 'Opt Python',
             name: 'python',
             executable: '/opt/python/3.12.0/bin/python',
-            kind: NativePythonEnvironmentKind.Unknown, // Initially unknown, should be upgraded to GlobalPaths
+            kind: undefined, // Initially unknown, should be upgraded to GlobalPaths
             version: '3.12.0',
             prefix: '/opt/python/3.12.0',
         };
@@ -542,7 +542,7 @@ suite('Native Python API', () => {
             displayName: 'Opt Python',
             name: 'python',
             executable: '/opt/python/3.12.0/bin/python',
-            kind: NativePythonEnvironmentKind.Unknown, // Initially unknown, should be upgraded to GlobalPaths
+            kind: undefined, // Initially unknown, should be upgraded to GlobalPaths
             version: '3.12.0',
             prefix: '/opt/python/3.12.0',
         };

--- a/extensions/positron-python/src/test/pythonEnvironments/nativeAPI.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/nativeAPI.unit.test.ts
@@ -503,6 +503,65 @@ suite('Native Python API', () => {
         assert.equal(addedEnv.version.release?.serial, 5);
     });
 
+    // --- Start Positron ---
+    test('Additional global path (/opt/python) is classified as global during addEnv via triggerRefresh', async () => {
+        const optPythonEnv: NativeEnvInfo = {
+            displayName: 'Opt Python',
+            name: 'python',
+            executable: '/opt/python/3.12.0/bin/python',
+            kind: NativePythonEnvironmentKind.Unknown, // Initially unknown, should be upgraded to GlobalPaths
+            version: '3.12.0',
+            prefix: '/opt/python/3.12.0',
+        };
+
+        sinon.stub(nativeFinder, 'getAdditionalEnvDirs').resolves(['/opt/python']);
+
+        mockFinder
+            .setup((f) => f.refresh())
+            .returns(() => {
+                async function* generator() {
+                    yield* [optPythonEnv];
+                }
+                return generator();
+            })
+            .verifiable(typemoq.Times.once());
+
+        await api.triggerRefresh();
+
+        const envs = api.getEnvs();
+        assert.equal(envs.length, 1);
+
+        const addedEnv = envs[0];
+        assert.isDefined(addedEnv);
+        assert.equal(addedEnv.executable.filename, '/opt/python/3.12.0/bin/python');
+        assert.equal(addedEnv.kind, PythonEnvKind.OtherGlobal);
+    });
+
+    test('Additional global path (/opt/python) is classified as global during resolveEnv', async () => {
+        const optPythonEnv: NativeEnvInfo = {
+            displayName: 'Opt Python',
+            name: 'python',
+            executable: '/opt/python/3.12.0/bin/python',
+            kind: NativePythonEnvironmentKind.Unknown, // Initially unknown, should be upgraded to GlobalPaths
+            version: '3.12.0',
+            prefix: '/opt/python/3.12.0',
+        };
+
+        sinon.stub(nativeFinder, 'getAdditionalEnvDirs').resolves(['/opt/python']);
+
+        mockFinder
+            .setup((f) => f.resolve('/opt/python/3.12.0/bin/python'))
+            .returns(() => Promise.resolve(optPythonEnv))
+            .verifiable(typemoq.Times.once());
+
+        const resolved = await api.resolveEnv('/opt/python/3.12.0/bin/python');
+
+        assert.isDefined(resolved);
+        assert.equal(resolved?.executable.filename, '/opt/python/3.12.0/bin/python');
+        assert.equal(resolved?.kind, PythonEnvKind.OtherGlobal);
+    });
+    // --- End Positron ---
+
     test('ReplaceExistingEnv: shorter-path equivalent env replaces the longer one', async () => {
         // Two interpreters in an additional env dir that symlink to the same target.
         // The shorter path should replace the longer one (not be added alongside it).

--- a/extensions/positron-python/src/test/pythonEnvironments/nativeAPI.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/nativeAPI.unit.test.ts
@@ -505,6 +505,10 @@ suite('Native Python API', () => {
 
     // --- Start Positron ---
     test('Additional global path (/opt/python) is classified as global during addEnv via triggerRefresh', async () => {
+        if (process.platform === 'win32') {
+            return;
+        }
+
         const optPythonEnv: NativeEnvInfo = {
             displayName: 'Opt Python',
             name: 'python',
@@ -538,6 +542,10 @@ suite('Native Python API', () => {
     });
 
     test('Additional global path (/opt/python) is classified as global during resolveEnv', async () => {
+        if (process.platform === 'win32') {
+            return;
+        }
+
         const optPythonEnv: NativeEnvInfo = {
             displayName: 'Opt Python',
             name: 'python',

--- a/extensions/positron-python/src/test/pythonEnvironments/nativeAPI.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/nativeAPI.unit.test.ts
@@ -504,9 +504,10 @@ suite('Native Python API', () => {
     });
 
     // --- Start Positron ---
-    test('Additional global path (/opt/python) is classified as global during addEnv via triggerRefresh', async () => {
-        if (process.platform === 'win32') {
-            return;
+    test('Additional global path (/opt/python) is classified as global during addEnv via triggerRefresh', async function () {
+        // isAdditionalGlobalBinPath() only matches POSIX paths, so there is nothing to test on Windows.
+        if (isWindows()) {
+            return this.skip();
         }
 
         const optPythonEnv: NativeEnvInfo = {
@@ -541,9 +542,10 @@ suite('Native Python API', () => {
         assert.equal(addedEnv.kind, PythonEnvKind.OtherGlobal);
     });
 
-    test('Additional global path (/opt/python) is classified as global during resolveEnv', async () => {
-        if (process.platform === 'win32') {
-            return;
+    test('Additional global path (/opt/python) is classified as global during resolveEnv', async function () {
+        // isAdditionalGlobalBinPath() only matches POSIX paths, so there is nothing to test on Windows.
+        if (isWindows()) {
+            return this.skip();
         }
 
         const optPythonEnv: NativeEnvInfo = {


### PR DESCRIPTION
Fixes #15710.

This is a Positron-branch copy of community PR #15790 by @NIKHILSHIRKE56, opened so CI can run on the change (#6628 means CI can't run on forks). Review stays on the original PR.

Standalone Python interpreters under `/opt/python` are reported by PET with no environment kind, so Positron showed them as `Unknown` in the interpreter picker instead of `Global`. The Positron-specific kind checks now live in one helper in `nativeAPI.ts`, and both the discovery path and the resolve path call it, so an interpreter in an additional global bin path is labeled `Global` either way.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Python interpreters installed under `/opt/python` are labeled `Global` instead of `Unknown` in the interpreter picker (#15710)

### Validation Steps

@:interpreter

1. Install a standalone Python under `/opt/python`, such as `/opt/python/3.12.13/bin/python`.
2. Open the interpreter picker.
3. Check that the interpreter is listed under `Global`, not `Unknown`.

