### PR TITLE
e2e(release-screenshots): wait for suggest widget rows before ArrowDown nav

### DIFF
--- a/.github/workflows/release-screenshots.yml
+++ b/.github/workflows/release-screenshots.yml
@@ -171,6 +171,17 @@ jobs:
           npm exec -- npm-run-all --max-old-space-size=8192 -p compile "electron arm64"
           npm run prelaunch
 
+      # A packaged release build bundles its own Quarto CLI (see build/lib/quarto.ts);
+      # a from-source build has no equivalent packaging step, so the Quarto extension
+      # finds no CLI at all and quarto-hello-python.screenshot.ts times out waiting
+      # for the preview to render. Put one on PATH so the extension's own PATH check
+      # picks it up.
+      - name: Set up Quarto (build_from_source only)
+        if: env.BUILD_FROM_SOURCE == 'true'
+        uses: quarto-dev/quarto-actions/setup@v2
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Pre-warm matplotlib font cache
         run: python -c "import matplotlib.pyplot as plt; plt.figure()"
 

--- a/.github/workflows/release-screenshots.yml
+++ b/.github/workflows/release-screenshots.yml
@@ -166,6 +166,10 @@ jobs:
           npm_config_arch: arm64  # macos-latest-xlarge is Apple silicon
           POSITRON_BUILD_NUMBER: 0
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+          # postinstall downloads PET and ripgrep from the GitHub API; authenticate so we
+          # get the per-repo rate limit instead of the anonymous per-IP one (which the
+          # shared runner IPs routinely exhaust -> HTTP 403).
+          POSITRON_GITHUB_RO_PAT: ${{ github.token }}
         run: |
           npm ci --fetch-timeout 120000
           npm exec -- npm-run-all --max-old-space-size=8192 -p compile "electron arm64"

--- a/test/e2e/pages/suggestWidget.ts
+++ b/test/e2e/pages/suggestWidget.ts
@@ -44,12 +44,17 @@ export class SuggestWidget {
 	 * Trigger the suggest widget via `editor.action.triggerSuggest` (Ctrl+Space).
 	 * Wrapped in toPass so a missed first press (focus not yet in editor) is
 	 * retried. No-op once the widget is already visible.
+	 *
+	 * Waits past the widget's own "Loading..." state (shown while completions
+	 * are still being computed, e.g. by a slow language server under CI load)
+	 * so callers always see at least one rendered row, not just the container.
 	 */
 	async trigger({ timeout = 15_000 }: { timeout?: number } = {}): Promise<void> {
 		await expect(async () => {
 			await this.code.driver.currentPage.keyboard.press('Control+Space');
 			await expect(this.widget).toBeVisible({ timeout: 3_000 });
 		}).toPass({ timeout });
+		await expect(this.widget.locator('.monaco-list-row').first()).toBeVisible({ timeout });
 	}
 
 	/**


### PR DESCRIPTION
### Summary
Fixes a race in the `SuggestWidget` e2e page object where `focusSnippetRow()` polled for a snippet row right after `trigger()` resolved, but `trigger()` only waited for the widget container to appear, not for completions to finish loading. Also fixes two `release-screenshots` workflow gaps hit while validating this against a from-source build.
- `trigger()` now also waits for at least one rendered `.monaco-list-row` before returning
- Fixes the nightly `release-screenshots` failure on `snippets-for-example.png`: under CI load the R language server's completion latency exceeded Monaco's loading-placeholder delay, so the row list was still empty when the ArrowDown loop ran
- Test-only change (`test/e2e/pages/suggestWidget.ts`); no product code touched
- Workflow: install Quarto CLI via `quarto-dev/quarto-actions/setup` when `build_from_source` is used, since a from-source build has no bundled Quarto CLI (unlike a packaged release)
- Workflow: authenticate the from-source build's `npm ci` with `POSITRON_GITHUB_RO_PAT` so ripgrep/PET downloads use the per-repo GitHub API rate limit instead of the shared runner IP's

### QA Notes
Validated with a manual `build_from_source` dispatch: https://github.com/posit-dev/positron/actions/runs/33403725728 (green)
