### PR TITLE
Remove incorrect legal disclaimers from providers modal

### DIFF
--- a/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
@@ -12,7 +12,7 @@ import { EmbeddedLink } from '../../../../../base/browser/ui/positronComponents/
 import { IPositronCustomModel, IPositronLanguageModelConfig, IPositronLanguageModelSource } from '../../common/interfaces/positronAssistantService.js';
 import { AuthMethod, AuthStatus } from '../types.js';
 import { availableAuthMethods, deriveAuthMethod, deriveAuthStatus, deriveConnectAction } from '../providerConnection.js';
-import { getProviderGettingStartedText, getProviderTermsOfServiceText, getProviderUsageDisclaimerText } from '../providerLegalText.js';
+import { getProviderGettingStartedText } from '../providerLegalText.js';
 import { PositronDynamicModalDialog } from '../../../../browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.js';
 import { PositronModalReactRenderer } from '../../../../../base/browser/positronModalReactRenderer.js';
 import { DropDownListBox } from '../../../../browser/positronComponents/dropDownListBox/dropDownListBox.js';
@@ -370,11 +370,10 @@ export const ProviderErrorBanner = (props: { message: string }) => (
 );
 
 export const ProviderNotice = (props: { source: IPositronLanguageModelSource }) => {
-	const text = [
-		getProviderGettingStartedText(props.source.provider),
-		getProviderTermsOfServiceText(props.source.provider),
-		getProviderUsageDisclaimerText(props.source.provider),
-	].filter(Boolean).join('\n\n');
+	const text = getProviderGettingStartedText(props.source.provider);
+	if (!text) {
+		return null;
+	}
 	return (
 		<div className='connect-provider-notice' data-testid='provider-notice'>
 			<EmbeddedLink>{text}</EmbeddedLink>

--- a/src/vs/workbench/contrib/positronAssistant/browser/providerLegalText.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/providerLegalText.ts
@@ -56,7 +56,7 @@ export function getProviderGettingStartedText(provider: IProvider): string | und
 			);
 			return localize(
 				'positron.languageModelConfig.positAI.gettingStartedNote',
-				'Get started with Posit Assistant instantly via a free trial of {0}, a managed service that provides access to frontier LLMs through a single account. Posit AI provides access to both Posit Assistant and Next Edit Suggestions.',
+				'{0} is a managed service that provides access to leading AI models through a single account, with a free trial available. You can use it with both Posit Assistant and Next Edit Suggestions.',
 				positAiHomeLink,
 			);
 		}


### PR DESCRIPTION
Closes #15821

The provider connect/connected modal showed legal disclaimer text (Terms of Service, Privacy Policy, EULA, "at your sole risk" notice) for every provider, and that text is no longer needed. `ProviderNotice` in `connectProviderView.tsx` now only renders the posit-ai getting-started note; every other provider renders nothing. The legacy provider modal (`languageModelConfigComponent.tsx`) still shows the same disclaimer text and was intentionally left unchanged, since it's being removed separately.

Posit Assistant still has a bit of copy:

<img width="610" height="270" alt="image" src="https://github.com/user-attachments/assets/a9b787bf-46fc-44ee-859d-99a352f7548c" />

But all providers no longer have the disclaimer:

<img width="610" height="314" alt="image" src="https://github.com/user-attachments/assets/ca942039-905e-44b9-8a92-696816026044" />

### Release Notes

#### Bug Fixes

- Remove inaccurate legal disclaimer text from the provider connection modal (#15821)

### Validation Steps

@:assistant

Existing unit tests (`connectProviderView.vitest.tsx`, `connectedProviderView.vitest.tsx`) already cover `ProviderNotice` rendering and pass unchanged (48/48).

1. Open the providers modal (Settings > AI Providers, or the command to configure LLM providers) and add/view a non-posit-ai provider (e.g. Anthropic, OpenAI).
2. Confirm no Terms of Service / Privacy Policy / EULA / "at your sole risk" text appears.
3. Open the posit-ai provider and confirm its getting-started note still appears.
