### PR TITLE
e2e: upload Electron crash dumps and fix the interpreter-discovery gate

### DIFF
--- a/.github/workflows/test-e2e-macos-run.yml
+++ b/.github/workflows/test-e2e-macos-run.yml
@@ -382,6 +382,18 @@ jobs:
           retention-days: 3
           if-no-files-found: ignore
 
+      # A native crash leaves a minidump in `.build/crashes` (electron.ts's
+      # `--crash-reporter-directory`); the job used to discard it. `always()`,
+      # not `failure()`: the Playwright step ends in `|| true`.
+      - name: Upload Crash Dumps
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.project }}-macos-crash-dumps-${{ matrix.shard }}
+          path: .build/crashes
+          retention-days: 7
+          if-no-files-found: ignore
+
   merge-reports:
     name: ${{ inputs.display_name }}
     if: ${{ !cancelled() }}

--- a/.github/workflows/test-e2e-ubuntu-run.yml
+++ b/.github/workflows/test-e2e-ubuntu-run.yml
@@ -360,6 +360,18 @@ jobs:
           retention-days: 3
           if-no-files-found: ignore
 
+      # A native crash leaves a minidump in `.build/crashes` (electron.ts's
+      # `--crash-reporter-directory`); the job used to discard it. `always()`,
+      # not `failure()`: the Playwright step ends in `|| true`.
+      - name: Upload Crash Dumps
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.project }}-ubuntu-crash-dumps-${{ matrix.shard }}
+          path: .build/crashes
+          retention-days: 7
+          if-no-files-found: ignore
+
       - name: Upload inspect-ai JSON Responses
         if: ${{ always() && inputs.project == 'inspect-ai' }}
         uses: actions/upload-artifact@v7

--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -683,6 +683,18 @@ jobs:
           path: test-logs
           if-no-files-found: ignore
 
+      # A native crash leaves a minidump in `.build/crashes` (electron.ts's
+      # `--crash-reporter-directory`); the job used to discard it. `always()`,
+      # not `failure()`: the Playwright step ends in `|| true`.
+      - name: Upload Crash Dumps
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-win-crash-dumps-${{ inputs.project }}-${{ matrix.shard }}
+          path: .build/crashes
+          retention-days: 7
+          if-no-files-found: ignore
+
   merge-reports:
     name: ${{ inputs.display_name }}
     timeout-minutes: 10

--- a/test/e2e/fixtures/test-setup/reporting.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/reporting.fixtures.ts
@@ -25,6 +25,11 @@ export interface TracingOptions {
 	testInfo: playwright.TestInfo;
 }
 
+export interface AttachCrashDumpsToReportOptions {
+	crashesPath: string;
+	testInfo: playwright.TestInfo;
+}
+
 export function AttachScreenshotsToReportFixture() {
 	return async (options: AttachScreenshotsToReportOptions, use: (arg0: void) => Promise<void>) => {
 		const { app, testInfo } = options;
@@ -87,6 +92,52 @@ export function AttachLogsToReportFixture() {
 			await attachDockerLogsToReport(logsPath, testInfo);
 		} else {
 			await attachLocalLogsToReport(logsPath, testInfo);
+		}
+	};
+}
+
+/**
+ * Dumps already attached by this worker. `crashesPath` is per worker, so without
+ * this every test after a crash re-attaches the same minidump.
+ */
+const attachedCrashDumps = new Set<string>();
+
+/**
+ * Attach any Electron minidump written during this test to the report, so a
+ * native crash arrives with the failure instead of only in the job's artifacts.
+ *
+ * Deliberately does not wait for a dump: crashpad writes asynchronously, and
+ * polling on every test to catch the rare late write would cost more than it
+ * saves. A dump that lands after teardown is still picked up by the workflow's
+ * `.build/crashes` upload.
+ */
+export function AttachCrashDumpsToReportFixture() {
+	return async (options: AttachCrashDumpsToReportOptions, use: (arg0: void) => Promise<void>) => {
+		const { crashesPath, testInfo } = options;
+
+		await use();
+
+		let dumps: string[];
+		try {
+			dumps = (await fs.promises.readdir(crashesPath, { recursive: true, withFileTypes: true }))
+				.filter(entry => entry.isFile())
+				.map(entry => path.join(entry.parentPath, entry.name))
+				.filter(file => !attachedCrashDumps.has(file));
+		} catch {
+			// No crashes directory means no crash: the common case.
+			return;
+		}
+
+		for (const dump of dumps) {
+			attachedCrashDumps.add(dump);
+			try {
+				await testInfo.attach(`crash-dump-${path.basename(dump)}`, {
+					path: dump,
+					contentType: 'application/octet-stream',
+				});
+			} catch (err) {
+				console.error(`Failed to attach crash dump ${dump}:`, err);
+			}
 		}
 	};
 }

--- a/test/e2e/pages/quickInput.ts
+++ b/test/e2e/pages/quickInput.ts
@@ -115,10 +115,16 @@ export class QuickInput {
 	 * languageRuntimeActions.ts) and lists only the interpreters found so far.
 	 * Selecting during this window races discovery: a version-string match can
 	 * land on a fast-discovered source (e.g. a uv base install) instead of the
-	 * intended interpreter. The placeholder is set synchronously before the
-	 * picker is shown, so this assertion cannot pass vacuously mid-discovery.
+	 * intended interpreter.
+	 *
+	 * Wait for this picker to be on screen before reading the placeholder: the
+	 * quick input widget is a singleton that an earlier picker (e.g. the reuse
+	 * scan's session quick pick) leaves hidden in the DOM carrying no
+	 * placeholder, so asserting the negative straight away passes against that
+	 * stale element while discovery is still running.
 	 */
 	async waitForInterpreterDiscoveryToComplete({ timeout = 30000 }: { timeout?: number } = {}): Promise<void> {
+		await this.waitForQuickInputOpened({ timeout });
 		await expect(
 			this.code.driver.currentPage.locator(QuickInput.QUICK_INPUT_INPUT),
 		).not.toHaveAttribute('placeholder', /Discovering interpreters/i, { timeout });

--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -16,7 +16,7 @@ import { Application, createLogger, TestTags, Sessions, HotKeys, TestTeardown, A
 import { PackageManager } from '../pages/utils/packageManager';
 import {
 	FileOperationsFixture, SettingsFixture, Settings, MetricsFixture,
-	AttachScreenshotsToReportFixture, AttachLogsToReportFixture,
+	AttachScreenshotsToReportFixture, AttachLogsToReportFixture, AttachCrashDumpsToReportFixture,
 	TracingFixture, shouldUseCustomTracing, AppFixture, UserDataDirFixture, OptionsFixture,
 	CustomTestOptions, TEMP_DIR, LOGS_ROOT_PATH, setSpecName, renameTempLogsDir
 } from '../fixtures/test-setup';
@@ -373,6 +373,11 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 		await attachLogsFixture({ suiteId, logsPath, testInfo }, use);
 	}, { auto: true }],
 
+	attachCrashDumpsToReport: [async ({ options }, use, testInfo) => {
+		const attachCrashDumpsFixture = AttachCrashDumpsToReportFixture();
+		await attachCrashDumpsFixture({ crashesPath: options.crashesPath, testInfo }, use);
+	}, { auto: true }],
+
 	tracing: [async ({ app }, use, testInfo) => {
 		const tracingFixture = TracingFixture();
 		await tracingFixture({ app, testInfo }, use);
@@ -640,6 +645,7 @@ export interface TestFixtures {
 	page: playwright.Page;
 	attachScreenshotsToReport: any;
 	attachLogsToReport: any;
+	attachCrashDumpsToReport: any;
 	sessions: Sessions;
 	assistant: Assistant;
 	r: void;


### PR DESCRIPTION
### Summary

A native crash in e2e left no stack to debug: Electron writes a minidump to `.build/crashes` via `--crash-reporter-directory`, but none of the e2e workflows uploaded it. Also fixes an interpreter-discovery wait that could return before the picker was on screen.

- Upload `.build/crashes` from the Windows, Ubuntu, and macOS e2e workflows
- Attach any minidump written during a test to that test in the Playwright report
- Gate that upload on `always()`, not `failure()` -- the Playwright step ends in `|| true`, so `failure()` never fires
- `waitForInterpreterDiscoveryToComplete` now waits for the picker to be visible before reading its placeholder
- That assertion previously resolved against the hidden singleton quick input widget left behind by an earlier picker, returning in ~14ms while discovery was still running

Found while triaging a Windows flake where the extension host exited `0xC0000005` mid-session-start ([run 33211203094](https://github.com/posit-dev/positron/actions/runs/33211203094)); the minidump for it had already been discarded, which is what motivated the upload.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:sessions @:interpreter @:plots @:win

No product code changed. The crash upload and report attachment are only observable when a process actually crashes; `if-no-files-found: ignore` keeps it silent otherwise. The discovery-wait change sits in the session-start path that nearly every suite uses, so the session and interpreter suites are the real blast radius.


### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- The extension host crashed with a Windows access violation (exit code 3221225477 / 0xC0000005) ~1.1s before the first failed assertion and never restarted, so interpreter discovery never completed and the runtime quick pick stayed in its 'Discovering interpreters...' state until the 30s toPass budget expired. Not a plots bug: the failure is in test.beforeAll's sessions.start('python'), which Playwright attributes to the first test in the describe.</summary>

- **Test:** [Plots > Python Plots > Python - Verify basic plot functionality - Dynamic Plot](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Plots%20%3E%20Python%20Plots%20%3E%20Python%20-%20Verify%20basic%20plot%20functionality%20-%20Dynamic%20Plot%7C%7C%7Ctest%2Fe2e%2Ftests%2Fplots%2Fplots.test.ts)
- **Targeted failure:** Error: Select runtime from quick pick -- expect(locator('.quick-input-widget .quick-input-list .monaco-list-row[aria-label*="Python 3.10.10"]').first()).toBeVisible() failed, at test/e2e/pages/sessions.ts:576
- **Signal:** timeline.txt t=1721512 'Extension host (LocalProcess pid: 16600) terminated unexpectedly. Code: 3221225477'; t=1721553 '[Runtime startup] Error starting affiliated runtimes: Canceled'; console digest silent after t=1721563 (no ext-host restart); five Expect-failed retries t=1722662..1736861; teardown screenshots at t=1751905+ still show the quick-pick input placeholder and status bar reading 'Discovering interpreters...' with an unfiltered list.
- **Frequency:** 1/127 runs (0.8%) on main, win/electron
- **Hypothesis:** If the extension host had survived, discovery would have completed and the filter would have applied; a test-side change cannot prevent a native crash, so the actionable outputs are a product issue for the crash and a fail-fast in the session helper so this class stops masquerading as a quick-pick timeout.

</details>

