### PR TITLE
e2e: poll for workbench visibility in reloadWindow instead of a single waitFor task

### DIFF
--- a/test/e2e/pages/hotKeys.ts
+++ b/test/e2e/pages/hotKeys.ts
@@ -267,7 +267,11 @@ export class HotKeys {
 		await this.pressHotKeys('Cmd+B R', 'Reload window');
 		await navigated;
 
-		await page.locator('.monaco-workbench').waitFor({ state: 'visible' });
+		// Use a polling assertion, not a single locator.waitFor task: this gate arms at
+		// the instant the navigation commits, and a waitFor task installed then can bind
+		// to the dying document and never observe the new one (seen on Windows CI). Each
+		// expect poll is an independent call that re-resolves the frame.
+		await expect(page.locator('.monaco-workbench')).toBeVisible({ timeout: 30000 });
 
 		// Wait for the workbench lifecycle to reach Restored (the same positive signal
 		// Application#checkPositronReady gates launch on). External browsers (Posit


### PR DESCRIPTION
### Summary

`hotKeys.reloadWindow` (#15793) arms its `.monaco-workbench` readiness wait in the same millisecond the main frame's reload navigation commits. `locator.waitFor` installs a single injected wait task, and armed at that instant the task can bind to the document being torn down and never observe the new one. The trace from the failing run shows exactly this: the `framenavigated` wait resolves and `Frame.waitForSelector` arms at the same timestamp, the reloaded window boots fully inside the 30s wait (the notebook cell editor is restoring 3.6s before the deadline, and the workbench is present in DOM snapshots throughout), yet the call log never resolves the locator against either document.

This replaces the single wait task with the web-first `toBeVisible` assertion, which re-resolves the frame on every poll, so execution-context churn at the commit instant costs one poll instead of the whole wait. The deterministic ordering from #15793 is unchanged: the gate still arms only after the main frame navigation, and no timeout was increased.

The pattern first appeared 2026-08-31 (two win/electron merge-lane failures, runs 33401068999 and 33406513427), three days after #15793 rewrote this path; the prior 404 main runs in the 14-day lookback had zero occurrences.

### QA Notes

`notebook-untitled-naming.test.ts` passed 9/9 locally on Windows e2e-electron with `--repeat-each=3` (three runs of the reload test). The CI contention that surfaces the race (a loaded runner where the reload takes ~26s) cannot be forced locally, so the trend evidence arrives on the merge lane after this lands.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:positron-notebooks @:sessions @:layouts @:interpreter @:outline @:vscode-settings @:win

Reload-heavy suites that exercise the shared reload helper (the same set #15793 validated with). The notebook untitled-naming suite contains the test this race was failing.

### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- reloadWindow (PR #15793) arms Frame.waitForSelector at the exact millisecond the main frame navigation commits, so the injected wait task binds at the navigation boundary and never observes .monaco-workbench in either the dying old document or the new one - a test-code race in the harness helper, not a product bug and not PR #15791.</summary>

- **Test:** [Positron Notebooks: Untitled naming > Untitled names keep incrementing after a window reload restores a dirty notebook](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Positron%20Notebooks%3A%20Untitled%20naming%20%3E%20Untitled%20names%20keep%20incrementing%20after%20a%20window%20reload%20restores%20a%20dirty%20notebook%7C%7C%7Ctest%2Fe2e%2Ftests%2Fnotebooks-positron%2Fnotebook-untitled-naming.test.ts)
- **Targeted failure:** TimeoutError: locator.waitFor: Timeout 30000ms exceeded. waiting for locator(.monaco-workbench) to be visible, at pages/hotKeys.ts:270 in HotKeys.reloadWindow
- **Signal:** Trace: Page.__waitInfo__ (framenavigated) resolves t=1718261 and Frame.waitForSelector arms the same millisecond; DOM presence shows monaco-workbench in 6 snapshots during the wait; console shows the reloaded window booting inside the wait (Runtime startup starting t=1742588, notebook cell editor restore t=1744636, 3.6s before deadline); call log has no locator-resolved line, so the wait task never matched any element in any document. Onset: 0 failures in 404 main runs over 14 days until today, 2 failures (win/electron only) 3 days after #15793 (2026-08-28) rewrote this exact code path. PR #15791 ruled out: first failing run tested e1c774b384 which predates 10406377b2 (git merge-base confirms not an ancestor), and its diff touches only the memory-metrics workflow and performance tests.
- **Frequency:** 2/118 runs (1.7%) on main, win/electron
- **Hypothesis:** race (test code: harness reload gate)

</details>

