### PR TITLE
Add vscode-reh-web-nls task to generate per-locale core NLS bundles

### DIFF
--- a/build/gulpfile.positron.nls.ts
+++ b/build/gulpfile.positron.nls.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import path from 'path';
+import * as task from './lib/gulp/task.ts';
+import * as util from './lib/util.ts';
+import * as i18n from './lib/i18n.ts';
+import { generateNlsBundles } from './lib/positronNlsBundles.ts';
+
+const REPO_ROOT = path.dirname(import.meta.dirname);
+
+// Same header build/lib/nls.ts stamps on the shipped English nls.messages.js.
+// The bundle content is derived from Microsoft's vscode-loc translations (MIT).
+const NLS_BUNDLE_FILE_HEADER = `/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/`;
+
+/**
+ * Generates per-locale core NLS bundles for the web/server workbench into
+ * `out-build-nls/<locale>/nls.messages.js`.
+ *
+ * Run this AFTER a reh-web build task (e.g. `vscode-reh-web-linux-x64`): it
+ * reads the `out-build/nls.keys.json` + `out-build/nls.messages.json` that the
+ * build compile emits, and the message indices are only valid for that exact
+ * compile. It requires a checkout of https://github.com/microsoft/vscode-loc
+ * as a sibling of the repository root (missing checkout is a hard error).
+ *
+ * The output layout matches the tail of the URL template the server hands the
+ * browser (`${nlsCoreBaseUrl}${commit}/${version}/${locale}/nls.messages.js`,
+ * see src/vs/server/node/webClientServer.ts), so publishing is a recursive
+ * copy of `out-build-nls/` to `<base>/<commit>/<version>/`. Until
+ * `nlsCoreBaseUrl` is set in product.json, nothing consumes these files.
+ *
+ * See build/lib/positronNlsBundles.ts for why this merges English defaults
+ * instead of reusing processCoreBundleFormat.
+ */
+const generateRehWebNlsTask = task.define('vscode-reh-web-nls', task.series(
+	util.rimraf('out-build-nls'),
+	async () => {
+		generateNlsBundles({
+			nlsMetadataPath: path.join(REPO_ROOT, 'out-build'),
+			vscodeLocI18nPath: path.join(REPO_ROOT, '..', 'vscode-loc', 'i18n'),
+			outputPath: path.join(REPO_ROOT, 'out-build-nls'),
+			languages: i18n.defaultLanguages,
+			fileHeader: NLS_BUNDLE_FILE_HEADER,
+		});
+	}
+));
+task.task(generateRehWebNlsTask);

--- a/build/lib/i18n.ts
+++ b/build/lib/i18n.ts
@@ -294,7 +294,12 @@ function sortLanguages(languages: Language[]): Language[] {
 	});
 }
 
-function stripComments(content: string): string {
+// --- Start Positron ---
+// Exported for reuse by positronNlsBundles.ts, which parses the same
+// vscode-loc translation files when generating per-locale reh-web bundles.
+// function stripComments(content: string): string {
+export function stripComments(content: string): string {
+	// --- End Positron ---
 	// Copied from stripComments.js
 	//
 	// First group matches a double quoted string

--- a/build/lib/positronNlsBundles.ts
+++ b/build/lib/positronNlsBundles.ts
@@ -1,0 +1,158 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import path from 'path';
+import fs from 'fs';
+import fancyLog from 'fancy-log';
+import ansiColors from 'ansi-colors';
+import { stripComments, type Language } from './i18n.ts';
+
+/**
+ * Generates per-locale `nls.messages.js` bundles for the web/server workbench
+ * (reh-web). The server points browsers at
+ * `${nlsCoreBaseUrl}${commit}/${version}/${locale}/nls.messages.js`
+ * (see src/vs/server/node/webClientServer.ts), and this module produces the
+ * files that URL template expects, laid out as `<locale>/nls.messages.js` so
+ * publishing is a plain recursive copy under `<commit>/<version>/`.
+ *
+ * This intentionally does NOT reuse `processCoreBundleFormat` from i18n.ts:
+ * that emitter pushes `undefined` for untranslated keys, which is only safe
+ * for the monaco editor build (compiled with `preserveEnglish: true`). The
+ * product build compiles with `preserveEnglish: false`, rewriting
+ * `localize('key', "English")` into `localize(<index>, null)` - the English
+ * fallback is stripped from the shipped code. A `null` bundle entry then makes
+ * `src/vs/nls.ts` THROW (`!!! NLS MISSING !!!`) instead of degrading to
+ * English. Every Positron-specific string (Console, Variables, Data Explorer,
+ * ...) has no vscode-loc translation, so an unmerged bundle would crash the
+ * workbench during construction in every non-English locale.
+ *
+ * The fix is to merge in the English defaults from `nls.messages.json`,
+ * exactly as the desktop language-pack path does in
+ * src/vs/base/node/nls.ts (`moduleTranslations?.[key] || defaults[index]`).
+ */
+
+/**
+ * The parsed shape of `out-build/nls.keys.json`: module IDs with their NLS
+ * keys, in the exact order the compile pass assigned message indices.
+ */
+export type NLSKeysFormat = Array<[string /* module ID */, string[] /* keys */]>;
+
+/**
+ * The `contents` payload of a vscode-loc `main.i18n.json` translation file.
+ */
+export interface I18nTranslations {
+	[moduleId: string]: {
+		[nlsKey: string]: string;
+	};
+}
+
+export interface INlsBundleResult {
+	/** The merged, positional message array for the locale. */
+	readonly messages: string[];
+	/** How many indices received a translation (rest fell back to English). */
+	readonly translatedCount: number;
+}
+
+/**
+ * Flattens `nls.keys.json` module key lists into the shared index space and
+ * resolves each index to its translation, falling back to the English default
+ * for untranslated keys (never `undefined`/`null` - see module doc).
+ *
+ * Throws when the flattened key count does not match the default message
+ * count: the two files are emitted from one compile pass and share one index
+ * space, so a mismatch means the inputs are not from the same build and every
+ * string after the divergence would silently shift.
+ */
+export function mergeTranslationsWithDefaults(nlsKeys: NLSKeysFormat, nlsDefaultMessages: string[], translations: I18nTranslations): INlsBundleResult {
+	const flattenedKeyCount = nlsKeys.reduce((count, [, moduleKeys]) => count + moduleKeys.length, 0);
+	if (flattenedKeyCount !== nlsDefaultMessages.length) {
+		throw new Error(`NLS index misalignment: nls.keys.json flattens to ${flattenedKeyCount} keys but nls.messages.json has ${nlsDefaultMessages.length} messages. The two files must come from the same compile pass.`);
+	}
+
+	const messages: string[] = [];
+	let translatedCount = 0;
+	let nlsIndex = 0;
+	for (const [moduleId, moduleKeys] of nlsKeys) {
+		const moduleTranslations = translations[moduleId];
+		for (const nlsKey of moduleKeys) {
+			// `||` (not `??`) mirrors the desktop merge in
+			// src/vs/base/node/nls.ts: an empty translated string also falls
+			// back to the English default.
+			const translation = moduleTranslations?.[nlsKey];
+			if (translation) {
+				translatedCount++;
+			}
+			messages.push(translation || nlsDefaultMessages[nlsIndex]);
+			nlsIndex++;
+		}
+	}
+
+	return { messages, translatedCount };
+}
+
+/**
+ * Renders the bundle file content, setting both globals the workbench boot
+ * code expects (same shape `processCoreBundleFormat` emits).
+ */
+export function renderNlsBundle(fileHeader: string, messages: string[], languageId: string): string {
+	return `${fileHeader}
+globalThis._VSCODE_NLS_MESSAGES=${JSON.stringify(messages)};
+globalThis._VSCODE_NLS_LANGUAGE=${JSON.stringify(languageId)};`;
+}
+
+export interface IGenerateNlsBundlesOptions {
+	/** Directory containing `nls.keys.json` and `nls.messages.json` (i.e. `out-build`). */
+	readonly nlsMetadataPath: string;
+	/** The `i18n` directory of a `microsoft/vscode-loc` checkout. */
+	readonly vscodeLocI18nPath: string;
+	/** Output directory; one `<locale>/nls.messages.js` is written per language. */
+	readonly outputPath: string;
+	readonly languages: readonly Language[];
+	/** Header prepended to each emitted file. */
+	readonly fileHeader: string;
+}
+
+function log(message: string, ...rest: unknown[]): void {
+	fancyLog(ansiColors.green('[nls-bundles]'), message, ...rest);
+}
+
+/**
+ * Reads the NLS metadata and the vscode-loc translations and writes one
+ * merged `nls.messages.js` per language.
+ *
+ * A missing vscode-loc checkout or language pack is a HARD error: with the
+ * English merge in place, tolerating it would silently emit perfectly valid
+ * all-English bundles - indistinguishable from success in CI, failing only as
+ * a user-visible bug.
+ */
+export function generateNlsBundles(options: IGenerateNlsBundlesOptions): void {
+	if (!fs.existsSync(options.vscodeLocI18nPath)) {
+		throw new Error(`No vscode-loc checkout found at ${path.dirname(options.vscodeLocI18nPath)}. Check out https://github.com/microsoft/vscode-loc as a sibling of the repository root to generate NLS bundles.`);
+	}
+
+	const nlsKeysFile = path.join(options.nlsMetadataPath, 'nls.keys.json');
+	if (!fs.existsSync(nlsKeysFile)) {
+		throw new Error(`No NLS metadata found at ${nlsKeysFile}. Run a build compile first (e.g. the vscode-reh-web-* task), which emits nls.keys.json and nls.messages.json.`);
+	}
+
+	const nlsKeys: NLSKeysFormat = JSON.parse(fs.readFileSync(nlsKeysFile, 'utf8'));
+	const nlsDefaultMessages: string[] = JSON.parse(fs.readFileSync(path.join(options.nlsMetadataPath, 'nls.messages.json'), 'utf8'));
+
+	for (const language of options.languages) {
+		const languageFolderName = language.translationId || language.id;
+		const i18nFile = path.join(options.vscodeLocI18nPath, `vscode-language-pack-${languageFolderName}`, 'translations', 'main.i18n.json');
+		if (!fs.existsSync(i18nFile)) {
+			throw new Error(`No translations found for language '${language.id}' at ${i18nFile}.`);
+		}
+
+		const { contents }: { contents: I18nTranslations } = JSON.parse(stripComments(fs.readFileSync(i18nFile, 'utf8')));
+		const { messages, translatedCount } = mergeTranslationsWithDefaults(nlsKeys, nlsDefaultMessages, contents);
+
+		const outputFile = path.join(options.outputPath, language.id, 'nls.messages.js');
+		fs.mkdirSync(path.dirname(outputFile), { recursive: true });
+		fs.writeFileSync(outputFile, renderNlsBundle(options.fileHeader, messages, language.id));
+		log(`${language.id}: ${translatedCount}/${messages.length} strings translated, rest fall back to English (${path.relative(process.cwd(), outputFile)})`);
+	}
+}

--- a/build/lib/test/positronNlsBundles.test.ts
+++ b/build/lib/test/positronNlsBundles.test.ts
@@ -1,0 +1,183 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { suite, test } from 'node:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { generateNlsBundles, mergeTranslationsWithDefaults, renderNlsBundle, type NLSKeysFormat } from '../positronNlsBundles.ts';
+
+suite('Positron NLS bundles', () => {
+
+	// Mirrors the real shape: an upstream module with vscode-loc coverage and
+	// a Positron-only module that no language pack knows about.
+	const nlsKeys: NLSKeysFormat = [
+		['vs/workbench/upstream/module', ['keyA', 'keyB']],
+		['vs/workbench/contrib/positronConsole/module', ['keyC']]
+	];
+	const nlsDefaultMessages = ['English A', 'English B', 'Positron C'];
+
+	suite('mergeTranslationsWithDefaults', () => {
+
+		test('translated keys resolve by index, untranslated keys fall back to English', () => {
+			const { messages, translatedCount } = mergeTranslationsWithDefaults(nlsKeys, nlsDefaultMessages, {
+				'vs/workbench/upstream/module': { keyA: '翻訳 A' }
+			});
+
+			// Positional: index 0 is the translation, indices 1 and 2 are the
+			// English defaults (keyB untranslated, Positron module unknown to
+			// the language pack). Nothing may be undefined/null - the product
+			// build strips English fallbacks from the shipped code, so a
+			// non-string entry makes src/vs/nls.ts throw at runtime.
+			assert.deepStrictEqual(messages, ['翻訳 A', 'English B', 'Positron C']);
+			assert.strictEqual(translatedCount, 1);
+		});
+
+		test('empty bundle input is all-English (never undefined/null)', () => {
+			const { messages, translatedCount } = mergeTranslationsWithDefaults(nlsKeys, nlsDefaultMessages, {});
+
+			assert.deepStrictEqual(messages, nlsDefaultMessages);
+			assert.strictEqual(translatedCount, 0);
+		});
+
+		test('empty-string translations fall back to English (parity with src/vs/base/node/nls.ts)', () => {
+			const { messages } = mergeTranslationsWithDefaults(nlsKeys, nlsDefaultMessages, {
+				'vs/workbench/upstream/module': { keyA: '' }
+			});
+
+			assert.strictEqual(messages[0], 'English A');
+		});
+
+		test('throws when key count and message count disagree (index misalignment)', () => {
+			// nls.keys.json and nls.messages.json share one index space from a
+			// single compile pass. A silent off-by-one here corrupts every
+			// string after the divergence, so it must be a hard error.
+			assert.throws(() => mergeTranslationsWithDefaults(nlsKeys, ['English A', 'English B'], {}), /misalignment/);
+			assert.throws(() => mergeTranslationsWithDefaults(nlsKeys, [...nlsDefaultMessages, 'Extra'], {}), /misalignment/);
+		});
+	});
+
+	suite('renderNlsBundle', () => {
+
+		test('sets both NLS globals', () => {
+			const content = renderNlsBundle('/* header */', ['a', 'b'], 'ja');
+
+			assert.strictEqual(content, '/* header */\nglobalThis._VSCODE_NLS_MESSAGES=["a","b"];\nglobalThis._VSCODE_NLS_LANGUAGE="ja";');
+		});
+	});
+
+	suite('generateNlsBundles', () => {
+
+		function makeFixture(): { root: string; metadataPath: string; locI18nPath: string; outputPath: string } {
+			const root = fs.mkdtempSync(path.join(os.tmpdir(), 'positron-nls-bundles-test-'));
+			const metadataPath = path.join(root, 'out-build');
+			const locI18nPath = path.join(root, 'vscode-loc', 'i18n');
+			const outputPath = path.join(root, 'out-build-nls');
+
+			fs.mkdirSync(metadataPath, { recursive: true });
+			fs.writeFileSync(path.join(metadataPath, 'nls.keys.json'), JSON.stringify(nlsKeys));
+			fs.writeFileSync(path.join(metadataPath, 'nls.messages.json'), JSON.stringify(nlsDefaultMessages));
+
+			return { root, metadataPath, locI18nPath, outputPath };
+		}
+
+		function writeLanguagePack(locI18nPath: string, folderName: string, contents: Record<string, Record<string, string>>): void {
+			const translationsDir = path.join(locI18nPath, `vscode-language-pack-${folderName}`, 'translations');
+			fs.mkdirSync(translationsDir, { recursive: true });
+			fs.writeFileSync(path.join(translationsDir, 'main.i18n.json'), JSON.stringify({ version: '1.0.0', contents }));
+		}
+
+		function readBundle(outputPath: string, languageId: string): { messages: string[]; language: string } {
+			const content = fs.readFileSync(path.join(outputPath, languageId, 'nls.messages.js'), 'utf8');
+			const match = /_VSCODE_NLS_MESSAGES=(?<messages>\[.*\]);\nglobalThis\._VSCODE_NLS_LANGUAGE=(?<language>"[^"]+");$/s.exec(content);
+			assert.ok(match?.groups, `bundle for ${languageId} does not set both NLS globals:\n${content}`);
+			return { messages: JSON.parse(match.groups.messages), language: JSON.parse(match.groups.language) };
+		}
+
+		test('writes one merged <locale>/nls.messages.js per language, mapping translationId folders', (t) => {
+			const { root, metadataPath, locI18nPath, outputPath } = makeFixture();
+			t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+			writeLanguagePack(locI18nPath, 'ja', { 'vs/workbench/upstream/module': { keyA: '翻訳 A', keyB: '翻訳 B' } });
+			// zh-cn resolves through translationId zh-hans to a differently
+			// named vscode-loc folder - the lookup the Latin-script locales
+			// never exercise.
+			writeLanguagePack(locI18nPath, 'zh-hans', { 'vs/workbench/upstream/module': { keyA: '翻译 A' } });
+
+			generateNlsBundles({
+				nlsMetadataPath: metadataPath,
+				vscodeLocI18nPath: locI18nPath,
+				outputPath,
+				languages: [
+					{ id: 'ja', folderName: 'jpn' },
+					{ id: 'zh-cn', folderName: 'chs', translationId: 'zh-hans' }
+				],
+				fileHeader: '/* header */'
+			});
+
+			const ja = readBundle(outputPath, 'ja');
+			const zhCn = readBundle(outputPath, 'zh-cn');
+
+			// Index alignment across the pipeline: both bundles have exactly
+			// as many entries as nls.keys.json flattens to, and a given index
+			// resolves to the same key's string in every locale (translation
+			// where one exists, English default where not).
+			assert.deepStrictEqual(
+				{ ja, zhCn },
+				{
+					ja: { messages: ['翻訳 A', '翻訳 B', 'Positron C'], language: 'ja' },
+					zhCn: { messages: ['翻译 A', 'English B', 'Positron C'], language: 'zh-cn' }
+				}
+			);
+		});
+
+		test('missing vscode-loc checkout is a hard error, not a warning', (t) => {
+			const { root, metadataPath, locI18nPath, outputPath } = makeFixture();
+			t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+			// With the English merge in place, tolerating a missing checkout
+			// would silently emit valid all-English bundles - looking like
+			// success in CI and failing only as a user-visible bug.
+			assert.throws(() => generateNlsBundles({
+				nlsMetadataPath: metadataPath,
+				vscodeLocI18nPath: locI18nPath,
+				outputPath,
+				languages: [{ id: 'ja', folderName: 'jpn' }],
+				fileHeader: ''
+			}), /vscode-loc/);
+		});
+
+		test('missing language pack for a requested locale is a hard error', (t) => {
+			const { root, metadataPath, locI18nPath, outputPath } = makeFixture();
+			t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+			writeLanguagePack(locI18nPath, 'ja', {});
+
+			assert.throws(() => generateNlsBundles({
+				nlsMetadataPath: metadataPath,
+				vscodeLocI18nPath: locI18nPath,
+				outputPath,
+				languages: [{ id: 'ja', folderName: 'jpn' }, { id: 'ko', folderName: 'kor' }],
+				fileHeader: ''
+			}), /No translations found for language 'ko'/);
+		});
+
+		test('missing NLS metadata is a hard error pointing at the build step', (t) => {
+			const { root, locI18nPath, outputPath } = makeFixture();
+			t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+			writeLanguagePack(locI18nPath, 'ja', {});
+
+			assert.throws(() => generateNlsBundles({
+				nlsMetadataPath: path.join(root, 'does-not-exist'),
+				vscodeLocI18nPath: locI18nPath,
+				outputPath,
+				languages: [{ id: 'ja', folderName: 'jpn' }],
+				fileHeader: ''
+			}), /nls\.keys\.json/);
+		});
+	});
+});


### PR DESCRIPTION
Part of posit-dev/positron-builds#1174 (server-side NLS bundles for the web/server workbench).

### Summary

Adds a `vscode-reh-web-nls` gulp task that generates per-locale core NLS bundles for the web/server workbench: `out-build-nls/<locale>/nls.messages.js` for the 9 `defaultLanguages`, built from `out-build/nls.keys.json` + `out-build/nls.messages.json` and a sibling checkout of `microsoft/vscode-loc`. The output layout matches the `{commit}/{version}/{locale}/nls.messages.js` URL template that `webClientServer.ts` requests from `nlsCoreBaseUrl`, so publishing is a plain recursive copy.

**This PR is inert.** `nlsCoreBaseUrl` stays unset in `product.json` (blocked on the hosting URL), and nothing consumes `out-build-nls`. There is no behavior change until that later one-liner lands.

Why a new emitter (`build/lib/positronNlsBundles.ts`) instead of reusing `processCoreBundleFormat`:

- `processCoreBundleFormat` pushes `undefined` for untranslated keys, which is only safe for the monaco editor build (`preserveEnglish: true`). Product builds strip the English fallbacks from shipped code (`localize('key', "English")` becomes `localize(<index>, null)`), so a `null` bundle entry makes `src/vs/nls.ts` throw (`!!! NLS MISSING !!!`) during workbench construction. Verified live: loading a built workbench in ja against an unmerged bundle throws `!!! NLS MISSING: 427 !!!` and the workbench never constructs.
- The new emitter merges English defaults per index, mirroring the desktop language-pack merge in `src/vs/base/node/nls.ts`, so Positron-only strings (Console, Variables, Data Explorer, Assistant, ...) fall back to English instead of crashing. The monaco path is untouched.
- A missing vscode-loc checkout or language pack is a hard error, not a warning: with the English merge in place, tolerating it would silently ship perfectly valid all-English bundles that look like success in CI.

Also includes a `node:test` suite covering index alignment, the `zh-cn`/`zh-tw` translationId folder mapping, English fallback, and the hard-error paths, plus a minimal Positron-marked export of `stripComments` from `build/lib/i18n.ts` for reuse.

Next steps (separate work): Phase 2 in positron-builds vendors vscode-loc at CI time, runs this task in the reh-web release job, and publishes on promotion; setting `nlsCoreBaseUrl` waits on the hosting URL from P3M.

### Local end-to-end verification

Built `vscode-reh-web-darwin-arm64` locally with vscode-loc as a sibling checkout, ran the task, served `out-build-nls` from a local static host at the `{commit}/{version}/{locale}` layout, and pointed the built server's `nlsCoreBaseUrl` at it (stamped into the built output's product.json copy only):

- Index alignment on real artifacts: flattened `nls.keys.json` count == `nls.messages.json` length == shipped `out/nls.messages.js` array length == every generated bundle length (26291); zero null/undefined entries in all 9 locales; spot checks resolve the same index to "More Actions..."/"その他の操作..." and a Positron-only key to its English text in the ja bundle.
- ja workbench (Playwright, built server): loads the ja bundle from the templated URL; upstream chrome translated; Console, Variables, and Data Explorer all render in English with no crash and zero "NLS MISSING" errors; Data Explorer opens a CSV via duckdb and shows data with working column summaries.
- en control: no request to the external NLS host, English fallback bundle used, English chrome.
- zh-cn / zh-tw: correct per-locale URL injected and served (exercises the translationId folder mapping).
- Counterfactual: swapping in an unmerged (`processCoreBundleFormat`-style) ja bundle crashes the built workbench on load, confirming the English merge is load-bearing.

### Release Notes

#### New Features

- N/A (build infrastructure; user-facing web workbench localization lands once the bundle hosting URL is configured)

#### Bug Fixes

- N/A

### Validation Steps

@:critical

1. Unit tests: `cd build && node --test lib/test/positronNlsBundles.test.ts`
2. Manual (optional, needs a production build): check out `microsoft/vscode-loc` as a sibling of the repo root, run a reh-web build (e.g. `npm run gulp vscode-reh-web-linux-x64`), then `npm run gulp vscode-reh-web-nls`. Verify `out-build-nls/<locale>/nls.messages.js` exists for the 9 default locales and each sets `_VSCODE_NLS_MESSAGES` (same length as the flattened `out-build/nls.keys.json`) and `_VSCODE_NLS_LANGUAGE`.
3. Verify inertness: no `product.json` changes; a normal build does not read `out-build-nls`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
