### PR TITLE
Enable execution of unsaved R and Python scripts

### DIFF
--- a/extensions/positron-python/src/client/terminals/codeExecution/codeExecutionManager.ts
+++ b/extensions/positron-python/src/client/terminals/codeExecution/codeExecutionManager.ts
@@ -11,6 +11,9 @@ import * as positron from 'positron';
 // --- End Positron ---
 
 import * as path from 'path';
+// --- Start Positron ---
+import * as os from 'os';
+// --- End Positron ---
 import { ICommandManager, IDocumentManager } from '../../common/application/types';
 import { Commands } from '../../common/constants';
 import '../../common/extensions';
@@ -28,10 +31,17 @@ import {
 } from '../../pythonEnvironments/creation/createEnvironmentTrigger';
 import { ReplType } from '../../repl/types';
 import { runInDedicatedTerminal, runInTerminal, useEnvExtension } from '../../envExt/api.internal';
+// --- Start Positron ---
+import { UnsavedScriptFiles } from './unsavedScripts';
+// --- End Positron ---
 
 @injectable()
 export class CodeExecutionManager implements ICodeExecutionManager {
     private eventEmitter: EventEmitter<string> = new EventEmitter<string>();
+    // --- Start Positron ---
+    /** Backs the "run file" gesture for unsaved (untitled) Python scripts. */
+    private readonly unsavedScripts = new UnsavedScriptFiles();
+    // --- End Positron ---
     constructor(
         @inject(ICommandManager) private commandManager: ICommandManager,
         @inject(IDocumentManager) private documentManager: IDocumentManager,
@@ -41,6 +51,9 @@ export class CodeExecutionManager implements ICodeExecutionManager {
     ) {}
 
     public registerCommands() {
+        // --- Start Positron ---
+        this.disposableRegistry.push(this.unsavedScripts);
+        // --- End Positron ---
         [Commands.Exec_In_Terminal, Commands.Exec_In_Terminal_Icon, Commands.Exec_In_Separate_Terminal].forEach(
             (cmd) => {
                 this.disposableRegistry.push(
@@ -94,38 +107,37 @@ export class CodeExecutionManager implements ICodeExecutionManager {
         // --- Start Positron ---
         this.disposableRegistry.push(
             this.commandManager.registerCommand(Commands.Exec_In_Console as any, async (resource?: Uri) => {
-                let filePath: string | undefined;
-
-                if (resource) {
-                    // Use the provided resource URI (from editor action bar button)
-                    filePath = resource.fsPath;
-                } else {
-                    // Fall back to active text editor (from command palette or other invocations)
-                    const editor = vscode.window.activeTextEditor;
-                    if (!editor) {
-                        // No editor; nothing to do
-                        return;
-                    }
-                    filePath = editor.document.uri.fsPath;
-                }
-
-                if (!filePath) {
-                    // File is unsaved; show a warning
-                    vscode.window.showWarningMessage('Cannot source unsaved file.');
+                // Resolve the target document from the resource URI (editor
+                // action bar button) or the active editor (command palette).
+                const document = resource
+                    ? await vscode.workspace.openTextDocument(resource)
+                    : vscode.window.activeTextEditor?.document;
+                if (!document) {
+                    // No editor; nothing to do
                     return;
                 }
 
-                // Save the file before sourcing it to ensure that the contents are
-                // up to date with editor buffer.
-                if (resource) {
-                    // Save the specific document
-                    const document = await vscode.workspace.openTextDocument(resource);
+                // Unsaved (untitled) buffers are written to a scratch file so
+                // they can be run without prompting the user to save first. The
+                // scratch file is cleaned up once the run finishes.
+                let filePath: string | undefined;
+                let onFinished: (() => void) | undefined;
+                if (document.isUntitled) {
+                    filePath = await this.unsavedScripts.write(document);
+                    onFinished = () => {
+                        void this.unsavedScripts.finished(filePath!);
+                    };
+                } else {
+                    filePath = document.uri.fsPath;
+                    if (!filePath) {
+                        vscode.window.showWarningMessage('Cannot source unsaved file.');
+                        return;
+                    }
+                    // Save the file before running it so that the contents on
+                    // disk are up to date with the editor buffer.
                     if (document.isDirty) {
                         await document.save();
                     }
-                } else {
-                    // Save the active editor
-                    await vscode.commands.executeCommand('workbench.action.files.save');
                 }
 
                 try {
@@ -133,19 +145,21 @@ export class CodeExecutionManager implements ICodeExecutionManager {
                     // the VS Code file system API.
                     const fsStat = await vscode.workspace.fs.stat(vscode.Uri.file(filePath));
 
-                    // In the future, we will want to shorten the path by making it
-                    // relative to the current directory; doing so, however, will
-                    // require the kernel to alert us to the current working directory,
-                    // or provide a method for asking it to create the `source()`
-                    // command.
-                    //
-                    // For now, just use the full path, passed through JSON encoding
-                    // to ensure that it is properly escaped.
                     if (fsStat) {
+                        const fileUri = vscode.Uri.file(filePath);
+
+                        // Format the path relative to the session's working
+                        // directory when possible, falling back to home-relative
+                        // or absolute. IPython's %run expands ~ and reads the
+                        // file from disk.
+                        const formattedPath = await positron.paths.formatPathForCode(filePath, {
+                            relativeTo: ['session', 'home'],
+                            homeUri: vscode.Uri.file(os.homedir()),
+                        });
+
                         // Use -- to ensure everything after is treated as the path, not flags
                         // This prevents paths with -m (or other dash options) from being misinterpreted
-                        const command = `%run -- ${JSON.stringify(filePath)}`;
-                        const fileUri = vscode.Uri.file(filePath);
+                        const command = `%run -- ${formattedPath}`;
 
                         // Offer to install missing packages before running. The
                         // preflight runs in the Positron frontend and returns
@@ -155,9 +169,11 @@ export class CodeExecutionManager implements ICodeExecutionManager {
                             fileUri,
                         );
                         if (shouldRun === false) {
+                            onFinished?.();
                             return;
                         }
 
+                        const observer = onFinished ? { onFinished } : undefined;
                         positron.runtime.executeCode(
                             'python',
                             command,
@@ -165,12 +181,15 @@ export class CodeExecutionManager implements ICodeExecutionManager {
                             true,
                             undefined,
                             undefined,
-                            undefined,
+                            observer,
                             undefined,
                             fileUri,
                         );
+                    } else {
+                        onFinished?.();
                     }
                 } catch (e) {
+                    onFinished?.();
                     // This is not a valid file path, which isn't an error; it just
                     // means the active editor has something loaded into it that
                     // isn't a file on disk.  In Positron, there is currently a bug

--- a/extensions/positron-python/src/client/terminals/codeExecution/codeExecutionManager.ts
+++ b/extensions/positron-python/src/client/terminals/codeExecution/codeExecutionManager.ts
@@ -124,7 +124,15 @@ export class CodeExecutionManager implements ICodeExecutionManager {
                 let onFinished: (() => void) | undefined;
                 if (document.isUntitled) {
                     filePath = await this.unsavedScripts.write(document);
+                    // Guard so the scratch file's in-flight count is
+                    // decremented once, whether cleanup is driven by the
+                    // observer or the catch below.
+                    let finished = false;
                     onFinished = () => {
+                        if (finished) {
+                            return;
+                        }
+                        finished = true;
                         void this.unsavedScripts.finished(filePath!);
                     };
                 } else {
@@ -175,9 +183,10 @@ export class CodeExecutionManager implements ICodeExecutionManager {
 
                         const observer = onFinished ? { onFinished } : undefined;
                         // Not awaited: the run proceeds asynchronously and the
-                        // observer reports completion. If the call itself rejects
-                        // (e.g. no session can be started), the observer's
-                        // onFinished never fires, so clean up the scratch file here.
+                        // observer reports completion. If the call rejects (e.g.
+                        // no session can be started), clean up here; onFinished
+                        // is idempotent, so a redundant call after the observer
+                        // already fired is a no-op.
                         Promise.resolve(
                             positron.runtime.executeCode(
                                 'python',

--- a/extensions/positron-python/src/client/terminals/codeExecution/codeExecutionManager.ts
+++ b/extensions/positron-python/src/client/terminals/codeExecution/codeExecutionManager.ts
@@ -174,17 +174,23 @@ export class CodeExecutionManager implements ICodeExecutionManager {
                         }
 
                         const observer = onFinished ? { onFinished } : undefined;
-                        positron.runtime.executeCode(
-                            'python',
-                            command,
-                            false,
-                            true,
-                            undefined,
-                            undefined,
-                            observer,
-                            undefined,
-                            fileUri,
-                        );
+                        // Not awaited: the run proceeds asynchronously and the
+                        // observer reports completion. If the call itself rejects
+                        // (e.g. no session can be started), the observer's
+                        // onFinished never fires, so clean up the scratch file here.
+                        Promise.resolve(
+                            positron.runtime.executeCode(
+                                'python',
+                                command,
+                                false,
+                                true,
+                                undefined,
+                                undefined,
+                                observer,
+                                undefined,
+                                fileUri,
+                            ),
+                        ).catch(() => onFinished?.());
                     } else {
                         onFinished?.();
                     }

--- a/extensions/positron-python/src/client/terminals/codeExecution/unsavedScripts.ts
+++ b/extensions/positron-python/src/client/terminals/codeExecution/unsavedScripts.ts
@@ -100,14 +100,24 @@ export class UnsavedScriptFiles implements vscode.Disposable {
 
 /**
  * Resolves the directory scratch files are written to: the configured directory
- * if set, else the workspace root, else the system temporary directory.
+ * if set and writable, else the workspace root, else the system temporary
+ * directory.
  */
 async function resolveScratchDirectory(): Promise<string> {
     const configured = vscode.workspace.getConfiguration('interpreters').get<string>('unsavedScriptsDirectory')?.trim();
     if (configured) {
-        const directory = path.normalize(untildify(configured));
+        // Resolve relative paths against the workspace root (or home when no
+        // workspace is open) so they don't depend on the extension host's
+        // working directory.
+        const expanded = untildify(configured);
+        const directory = path.isAbsolute(expanded)
+            ? path.normalize(expanded)
+            : path.resolve(workspaceRoot() ?? os.homedir(), expanded);
         try {
             await fs.promises.mkdir(directory, { recursive: true });
+            // mkdir succeeds silently on an existing directory without checking
+            // writability, so probe it explicitly before committing.
+            await fs.promises.access(directory, fs.constants.W_OK);
             return canonicalize(directory);
         } catch (error) {
             traceWarn(
@@ -116,8 +126,12 @@ async function resolveScratchDirectory(): Promise<string> {
             return canonicalize(os.tmpdir());
         }
     }
-    const folder = vscode.workspace.workspaceFolders?.find((f) => f.uri.scheme === 'file');
-    return canonicalize(folder ? folder.uri.fsPath : os.tmpdir());
+    return canonicalize(workspaceRoot() ?? os.tmpdir());
+}
+
+/** The first file-scheme workspace folder path, if any. */
+function workspaceRoot(): string | undefined {
+    return vscode.workspace.workspaceFolders?.find((f) => f.uri.scheme === 'file')?.uri.fsPath;
 }
 
 /**

--- a/extensions/positron-python/src/client/terminals/codeExecution/unsavedScripts.ts
+++ b/extensions/positron-python/src/client/terminals/codeExecution/unsavedScripts.ts
@@ -1,0 +1,139 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+import { untildify } from '../../common/helpers';
+import { traceWarn } from '../../logging';
+
+/**
+ * Manages temporary files backing the "run file" gesture for unsaved (untitled)
+ * scripts. The untitled buffer is written to a scratch file on disk so that
+ * IPython's `%run` can read it, then the file is cleaned up.
+ *
+ * Files are deleted when their run finishes (the primary path), when the
+ * originating editor is closed, and when the extension is disposed. In-flight
+ * runs are ref-counted per file so a rapid re-run does not delete a file that a
+ * queued run has not yet read.
+ */
+export class UnsavedScriptFiles implements vscode.Disposable {
+    /** Untitled document URI -> temp file path. */
+    private readonly _files = new Map<string, string>();
+
+    /** Temp file path -> number of runs currently in flight. */
+    private readonly _inFlight = new Map<string, number>();
+
+    private readonly _disposables: vscode.Disposable[] = [];
+
+    constructor() {
+        this._disposables.push(
+            vscode.workspace.onDidCloseTextDocument((document) => {
+                if (document.isUntitled) {
+                    this.onDocumentClosed(document.uri);
+                }
+            }),
+        );
+    }
+
+    /**
+     * Writes the untitled document's contents to a scratch file and registers a
+     * run as in flight. Returns the file path to run.
+     */
+    public async write(document: vscode.TextDocument): Promise<string> {
+        const directory = await resolveScratchDirectory();
+        const filePath = path.join(directory, scratchFileName(document));
+        await fs.promises.writeFile(filePath, document.getText(), 'utf8');
+        this._files.set(document.uri.toString(), filePath);
+        this._inFlight.set(filePath, (this._inFlight.get(filePath) ?? 0) + 1);
+        return filePath;
+    }
+
+    /**
+     * Marks a run of the given scratch file as finished, deleting the file once
+     * no runs remain in flight.
+     */
+    public async finished(filePath: string): Promise<void> {
+        const remaining = (this._inFlight.get(filePath) ?? 1) - 1;
+        if (remaining > 0) {
+            this._inFlight.set(filePath, remaining);
+            return;
+        }
+        this._inFlight.delete(filePath);
+        await deleteQuietly(filePath);
+    }
+
+    private onDocumentClosed(uri: vscode.Uri): void {
+        const filePath = this._files.get(uri.toString());
+        if (!filePath) {
+            return;
+        }
+        this._files.delete(uri.toString());
+        // If a run is still in flight, let finished() delete the file.
+        if (!this._inFlight.has(filePath)) {
+            void deleteQuietly(filePath);
+        }
+    }
+
+    public dispose(): void {
+        this._disposables.forEach((d) => d.dispose());
+        for (const filePath of this._files.values()) {
+            void deleteQuietly(filePath);
+        }
+        this._files.clear();
+        this._inFlight.clear();
+    }
+}
+
+/**
+ * Resolves the directory scratch files are written to: the configured directory
+ * if set, else the workspace root, else the system temporary directory.
+ */
+async function resolveScratchDirectory(): Promise<string> {
+    const configured = vscode.workspace.getConfiguration('interpreters').get<string>('unsavedScriptsDirectory')?.trim();
+    if (configured) {
+        const directory = path.normalize(untildify(configured));
+        try {
+            await fs.promises.mkdir(directory, { recursive: true });
+            return canonicalize(directory);
+        } catch (error) {
+            traceWarn(
+                `Cannot use configured unsaved scripts directory '${directory}': ${error}. Falling back to the system temporary directory.`,
+            );
+            return canonicalize(os.tmpdir());
+        }
+    }
+    const folder = vscode.workspace.workspaceFolders?.find((f) => f.uri.scheme === 'file');
+    return canonicalize(folder ? folder.uri.fsPath : os.tmpdir());
+}
+
+/**
+ * Resolves symlinks in a directory so scratch file paths match the canonical
+ * form the session reports as its working directory (macOS temp dirs and
+ * workspace roots are often symlinked, e.g. /var -> /private/var). Without this,
+ * the path can't be made relative to the working directory.
+ */
+async function canonicalize(directory: string): Promise<string> {
+    try {
+        return await fs.promises.realpath(directory);
+    } catch {
+        return directory;
+    }
+}
+
+/** Builds a stable, hidden scratch file name from an untitled document. */
+function scratchFileName(document: vscode.TextDocument): string {
+    const base = path.basename(document.uri.path).replace(/[^\w.-]/g, '_');
+    return `.positron-${base.toLowerCase()}.py`;
+}
+
+async function deleteQuietly(filePath: string): Promise<void> {
+    try {
+        await fs.promises.rm(filePath, { force: true });
+    } catch (error) {
+        traceWarn(`Cannot delete unsaved script scratch file '${filePath}': ${error}`);
+    }
+}

--- a/extensions/positron-python/src/client/terminals/codeExecution/unsavedScripts.ts
+++ b/extensions/positron-python/src/client/terminals/codeExecution/unsavedScripts.ts
@@ -8,6 +8,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
 import { untildify } from '../../common/helpers';
+import { dispose } from '../../common/utils/resourceLifecycle';
 import { traceWarn } from '../../logging';
 
 /**
@@ -89,7 +90,7 @@ export class UnsavedScriptFiles implements vscode.Disposable {
     }
 
     public dispose(): void {
-        this._disposables.forEach((d) => d.dispose());
+        dispose(this._disposables);
         for (const filePath of this._files.values()) {
             void deleteQuietly(filePath);
         }

--- a/extensions/positron-python/src/client/terminals/codeExecution/unsavedScripts.ts
+++ b/extensions/positron-python/src/client/terminals/codeExecution/unsavedScripts.ts
@@ -136,12 +136,18 @@ function workspaceRoot(): string | undefined {
 }
 
 /**
- * Resolves symlinks in a directory so scratch file paths match the canonical
- * form the session reports as its working directory (macOS temp dirs and
- * workspace roots are often symlinked, e.g. /var -> /private/var). Without this,
- * the path can't be made relative to the working directory.
+ * Puts a directory into the same form the session reports as its working
+ * directory, so scratch file paths can be made relative to it.
+ *
+ * On POSIX, `getcwd()` resolves symlinks (e.g. macOS /var -> /private/var), so
+ * we resolve them too. On Windows, `GetCurrentDirectory` echoes the launch path
+ * verbatim; realpath would instead expand 8.3 short names (RUNNER~1 ->
+ * runneradmin) and make the paths diverge, so leave the path as-is.
  */
 async function canonicalize(directory: string): Promise<string> {
+    if (process.platform === 'win32') {
+        return directory;
+    }
     try {
         return await fs.promises.realpath(directory);
     } catch {

--- a/extensions/positron-python/src/client/terminals/codeExecution/unsavedScripts.ts
+++ b/extensions/positron-python/src/client/terminals/codeExecution/unsavedScripts.ts
@@ -63,7 +63,17 @@ export class UnsavedScriptFiles implements vscode.Disposable {
             return;
         }
         this._inFlight.delete(filePath);
+        this.forgetFile(filePath);
         await deleteQuietly(filePath);
+    }
+
+    /** Drops any untitled-URI mappings that point at the given scratch file. */
+    private forgetFile(filePath: string): void {
+        for (const [uri, mapped] of this._files) {
+            if (mapped === filePath) {
+                this._files.delete(uri);
+            }
+        }
     }
 
     private onDocumentClosed(uri: vscode.Uri): void {

--- a/extensions/positron-python/src/test/terminals/codeExecution/unsavedScripts.unit.test.ts
+++ b/extensions/positron-python/src/test/terminals/codeExecution/unsavedScripts.unit.test.ts
@@ -25,8 +25,7 @@ suite('UnsavedScriptFiles', () => {
 
     // Canonicalize a directory the same way the manager does: resolve symlinks
     // on POSIX, leave the path untouched on Windows.
-    const canonicalize = async (dir: string) =>
-        process.platform === 'win32' ? dir : fs.promises.realpath(dir);
+    const canonicalize = async (dir: string) => (process.platform === 'win32' ? dir : fs.promises.realpath(dir));
 
     setup(async () => {
         tmpDir = await canonicalize(fs.mkdtempSync(path.join(os.tmpdir(), 'positron-unsaved-test-')));

--- a/extensions/positron-python/src/test/terminals/codeExecution/unsavedScripts.unit.test.ts
+++ b/extensions/positron-python/src/test/terminals/codeExecution/unsavedScripts.unit.test.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { UnsavedScriptFiles } from '../../../client/terminals/codeExecution/unsavedScripts';
+
+// vscode.workspace is a ts-mockito instance; sinon.stub won't work on it, so we
+// reassign the members we use and restore them afterward.
+suite('UnsavedScriptFiles', () => {
+    let tmpDir: string;
+    let manager: UnsavedScriptFiles;
+    // Loosely typed so we can install fakes over readonly members (the event).
+    const ws = vscode.workspace as any;
+    let originalGetConfiguration: unknown;
+    let originalOnDidClose: unknown;
+
+    const fakeUntitled = (name: string, text: string) =>
+        ({ uri: { toString: () => `untitled:${name}`, path: name }, isUntitled: true, getText: () => text } as any);
+
+    setup(() => {
+        // Canonicalize: the manager resolves symlinks (e.g. macOS /var -> /private/var).
+        tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'positron-unsaved-test-')));
+        originalGetConfiguration = ws.getConfiguration;
+        originalOnDidClose = ws.onDidCloseTextDocument;
+        ws.getConfiguration = () => ({ get: () => tmpDir });
+        ws.onDidCloseTextDocument = () => ({ dispose: () => undefined });
+        manager = new UnsavedScriptFiles();
+    });
+
+    teardown(() => {
+        manager.dispose();
+        ws.getConfiguration = originalGetConfiguration;
+        ws.onDidCloseTextDocument = originalOnDidClose;
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    test('writes the buffer to a hidden scratch file, then deletes it when the run finishes', async () => {
+        const filePath = await manager.write(fakeUntitled('Untitled-1', 'print("hi")'));
+
+        assert.strictEqual(path.dirname(filePath), tmpDir);
+        assert.strictEqual(path.basename(filePath), '.positron-untitled-1.py');
+        assert.strictEqual(fs.readFileSync(filePath, 'utf8'), 'print("hi")');
+
+        await manager.finished(filePath);
+        assert.ok(!fs.existsSync(filePath));
+    });
+
+    test('keeps the scratch file until every in-flight run finishes', async () => {
+        const doc = fakeUntitled('Untitled-1', 'x');
+        const first = await manager.write(doc);
+        const second = await manager.write(doc);
+        assert.strictEqual(first, second);
+
+        await manager.finished(first);
+        assert.ok(fs.existsSync(first), 'file was removed while a run was still in flight');
+
+        await manager.finished(second);
+        assert.ok(!fs.existsSync(first));
+    });
+});

--- a/extensions/positron-python/src/test/terminals/codeExecution/unsavedScripts.unit.test.ts
+++ b/extensions/positron-python/src/test/terminals/codeExecution/unsavedScripts.unit.test.ts
@@ -23,9 +23,12 @@ suite('UnsavedScriptFiles', () => {
     const fakeUntitled = (name: string, text: string) =>
         ({ uri: { toString: () => `untitled:${name}`, path: name }, isUntitled: true, getText: () => text } as any);
 
-    setup(() => {
-        // Canonicalize: the manager resolves symlinks (e.g. macOS /var -> /private/var).
-        tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'positron-unsaved-test-')));
+    setup(async () => {
+        // Canonicalize the same way the manager does (async realpath). This
+        // resolves symlinks (e.g. macOS /var -> /private/var) and, on Windows,
+        // expands 8.3 short names (RUNNER~1 -> runneradmin) so paths compare
+        // equal; sync and async realpath differ on that expansion.
+        tmpDir = await fs.promises.realpath(fs.mkdtempSync(path.join(os.tmpdir(), 'positron-unsaved-test-')));
         originalGetConfiguration = ws.getConfiguration;
         originalOnDidClose = ws.onDidCloseTextDocument;
         ws.getConfiguration = () => ({ get: () => tmpDir });
@@ -71,7 +74,7 @@ suite('UnsavedScriptFiles', () => {
         ws.getConfiguration = () => ({ get: () => filePath });
 
         const written = await manager.write(fakeUntitled('Untitled-9', 'z'));
-        assert.strictEqual(path.dirname(written), fs.realpathSync(os.tmpdir()));
+        assert.strictEqual(path.dirname(written), await fs.promises.realpath(os.tmpdir()));
         await manager.finished(written);
     });
 });

--- a/extensions/positron-python/src/test/terminals/codeExecution/unsavedScripts.unit.test.ts
+++ b/extensions/positron-python/src/test/terminals/codeExecution/unsavedScripts.unit.test.ts
@@ -23,12 +23,13 @@ suite('UnsavedScriptFiles', () => {
     const fakeUntitled = (name: string, text: string) =>
         ({ uri: { toString: () => `untitled:${name}`, path: name }, isUntitled: true, getText: () => text } as any);
 
+    // Canonicalize a directory the same way the manager does: resolve symlinks
+    // on POSIX, leave the path untouched on Windows.
+    const canonicalize = async (dir: string) =>
+        process.platform === 'win32' ? dir : fs.promises.realpath(dir);
+
     setup(async () => {
-        // Canonicalize the same way the manager does (async realpath). This
-        // resolves symlinks (e.g. macOS /var -> /private/var) and, on Windows,
-        // expands 8.3 short names (RUNNER~1 -> runneradmin) so paths compare
-        // equal; sync and async realpath differ on that expansion.
-        tmpDir = await fs.promises.realpath(fs.mkdtempSync(path.join(os.tmpdir(), 'positron-unsaved-test-')));
+        tmpDir = await canonicalize(fs.mkdtempSync(path.join(os.tmpdir(), 'positron-unsaved-test-')));
         originalGetConfiguration = ws.getConfiguration;
         originalOnDidClose = ws.onDidCloseTextDocument;
         ws.getConfiguration = () => ({ get: () => tmpDir });
@@ -74,7 +75,7 @@ suite('UnsavedScriptFiles', () => {
         ws.getConfiguration = () => ({ get: () => filePath });
 
         const written = await manager.write(fakeUntitled('Untitled-9', 'z'));
-        assert.strictEqual(path.dirname(written), await fs.promises.realpath(os.tmpdir()));
+        assert.strictEqual(path.dirname(written), await canonicalize(os.tmpdir()));
         await manager.finished(written);
     });
 });

--- a/extensions/positron-python/src/test/terminals/codeExecution/unsavedScripts.unit.test.ts
+++ b/extensions/positron-python/src/test/terminals/codeExecution/unsavedScripts.unit.test.ts
@@ -63,4 +63,15 @@ suite('UnsavedScriptFiles', () => {
         await manager.finished(second);
         assert.ok(!fs.existsSync(first));
     });
+
+    test('falls back to the system temp dir when the configured directory cannot be used', async () => {
+        // Point the setting at a regular file so the directory can't be created.
+        const filePath = path.join(tmpDir, 'not-a-dir');
+        fs.writeFileSync(filePath, '');
+        ws.getConfiguration = () => ({ get: () => filePath });
+
+        const written = await manager.write(fakeUntitled('Untitled-9', 'z'));
+        assert.strictEqual(path.dirname(written), fs.realpathSync(os.tmpdir()));
+        await manager.finished(written);
+    });
 });

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -21,8 +21,15 @@ import { onDidDiscoverTestFiles } from './testing/testing';
 import { getEnvironmentHealth, logErrorTo } from './environmentHealth';
 import { LOGGER } from './extension.js';
 import { printInterpreterSettingsInfo } from './interpreter-settings.js';
+import { UnsavedScriptFiles } from './unsavedScripts';
+
+/** Backs the "run file" gesture for unsaved (untitled) R scripts. */
+let unsavedScripts: UnsavedScriptFiles;
 
 export async function registerCommands(context: vscode.ExtensionContext, runtimeManager: RRuntimeManager) {
+
+	unsavedScripts = new UnsavedScriptFiles();
+	context.subscriptions.push(unsavedScripts);
 
 	context.subscriptions.push(
 
@@ -471,31 +478,61 @@ export async function getEditorFilePathForCommand(resource?: vscode.Uri) {
 	return;
 }
 
+/** Resolves the document targeted by a run command, from a URI or the active editor. */
+function targetDocument(resource?: vscode.Uri): vscode.TextDocument | undefined {
+	if (resource) {
+		return vscode.workspace.textDocuments.find(d => d.uri.toString() === resource.toString());
+	}
+	return vscode.window.activeTextEditor?.document;
+}
+
 async function sourceCurrentFile(echo: boolean, resource?: vscode.Uri) {
+	let onFinished: (() => void) | undefined;
 	try {
-		const filePath = await getEditorFilePathForCommand(resource);
-		// In the future, we may want to shorten the path by making it
-		// relative to the current working directory.
+		const document = targetDocument(resource);
+
+		// Unsaved (untitled) buffers are written to a scratch file so they can
+		// be sourced without prompting the user to save first. The scratch file
+		// is cleaned up once the run finishes.
+		let filePath: string | undefined;
+		if (document?.isUntitled) {
+			filePath = await unsavedScripts.write(document);
+			onFinished = () => { void unsavedScripts.finished(filePath!); };
+		} else {
+			filePath = await getEditorFilePathForCommand(resource);
+		}
+
 		if (filePath) {
+			const uri = vscode.Uri.file(filePath);
+
 			// Offer to install missing packages before sourcing the file. The
 			// preflight runs in the Positron frontend and returns whether to
 			// proceed (false only if the user cancels).
-			const uri = resource ?? vscode.window.activeTextEditor?.document.uri;
-			if (uri) {
-				const shouldRun = await vscode.commands.executeCommand<boolean>(
-					'positron.missingPackages.preflight', uri);
-				if (shouldRun === false) {
-					return;
-				}
+			const shouldRun = await vscode.commands.executeCommand<boolean>(
+				'positron.missingPackages.preflight', uri);
+			if (shouldRun === false) {
+				onFinished?.();
+				return;
 			}
 
-			let command = `source(${JSON.stringify(filePath)})`;
+			// Format the path relative to the session's working directory when
+			// possible, falling back to home-relative or absolute. On Windows,
+			// omit homeUri: R's ~ expands to the Documents folder, so a
+			// home-relative path would resolve incorrectly.
+			const formattedPath = await positron.paths.formatPathForCode(filePath, {
+				relativeTo: ['session', 'home'],
+				homeUri: process.platform !== 'win32' ? vscode.Uri.file(os.homedir()) : undefined,
+			});
+			let command = `source(${formattedPath})`;
 			if (echo) {
-				command = `source(${JSON.stringify(filePath)}, echo = TRUE)`;
+				command = `source(${formattedPath}, echo = TRUE)`;
 			}
-			positron.runtime.executeCode('r', command, false);
+			const observer = onFinished ? { onFinished } : undefined;
+			positron.runtime.executeCode('r', command, false, undefined, undefined, undefined, observer, undefined, uri);
 		}
 	} catch (e) {
+		// Clean up the scratch file if we wrote one but never launched the run.
+		onFinished?.();
 		// This is not a valid file path, which isn't an error; it just
 		// means the active editor has something loaded into it that
 		// isn't a file on disk.  In Positron, there is currently a bug

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -528,7 +528,13 @@ async function sourceCurrentFile(echo: boolean, resource?: vscode.Uri) {
 				command = `source(${formattedPath}, echo = TRUE)`;
 			}
 			const observer = onFinished ? { onFinished } : undefined;
-			positron.runtime.executeCode('r', command, false, undefined, undefined, undefined, observer, undefined, uri);
+			// Not awaited: the run proceeds asynchronously and the observer
+			// reports completion. If the call itself rejects (e.g. no session
+			// can be started), the observer's onFinished never fires, so clean
+			// up the scratch file here.
+			Promise.resolve(
+				positron.runtime.executeCode('r', command, false, undefined, undefined, undefined, observer, undefined, uri),
+			).catch(() => onFinished?.());
 		}
 	} catch (e) {
 		// Clean up the scratch file if we wrote one but never launched the run.

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -497,7 +497,17 @@ async function sourceCurrentFile(echo: boolean, resource?: vscode.Uri) {
 		let filePath: string | undefined;
 		if (document?.isUntitled) {
 			filePath = await unsavedScripts.write(document);
-			onFinished = () => { void unsavedScripts.finished(filePath!); };
+			// Guard so the scratch file's in-flight count is decremented
+			// once, whether cleanup is driven by the observer or the catch
+			// below.
+			let finished = false;
+			onFinished = () => {
+				if (finished) {
+					return;
+				}
+				finished = true;
+				void unsavedScripts.finished(filePath!);
+			};
 		} else {
 			filePath = await getEditorFilePathForCommand(resource);
 		}
@@ -529,9 +539,9 @@ async function sourceCurrentFile(echo: boolean, resource?: vscode.Uri) {
 			}
 			const observer = onFinished ? { onFinished } : undefined;
 			// Not awaited: the run proceeds asynchronously and the observer
-			// reports completion. If the call itself rejects (e.g. no session
-			// can be started), the observer's onFinished never fires, so clean
-			// up the scratch file here.
+			// reports completion. If the call rejects (e.g. no session can be
+			// started), clean up here; onFinished is idempotent, so a
+			// redundant call after the observer already fired is a no-op.
 			Promise.resolve(
 				positron.runtime.executeCode('r', command, false, undefined, undefined, undefined, observer, undefined, uri),
 			).catch(() => onFinished?.());

--- a/extensions/positron-r/src/test/unsavedScripts.test.ts
+++ b/extensions/positron-r/src/test/unsavedScripts.test.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/extensions/positron-r/src/test/unsavedScripts.test.ts
+++ b/extensions/positron-r/src/test/unsavedScripts.test.ts
@@ -20,13 +20,18 @@ function fakeUntitled(name: string, text: string): vscode.TextDocument {
 	} as unknown as vscode.TextDocument;
 }
 
+// Canonicalize a directory the same way the manager does: resolve symlinks on
+// POSIX, leave the path untouched on Windows.
+async function canonicalize(dir: string): Promise<string> {
+	return process.platform === 'win32' ? dir : fs.promises.realpath(dir);
+}
+
 suite('UnsavedScriptFiles', () => {
 	let tmpDir: string;
 	let manager: UnsavedScriptFiles;
 
 	suiteSetup(async () => {
-		// Canonicalize: the manager resolves symlinks (e.g. macOS /var -> /private/var).
-		tmpDir = fs.realpathSync(await fs.promises.mkdtemp(path.join(os.tmpdir(), 'positron-unsaved-test-')));
+		tmpDir = await canonicalize(await fs.promises.mkdtemp(path.join(os.tmpdir(), 'positron-unsaved-test-')));
 		await vscode.workspace.getConfiguration('interpreters')
 			.update('unsavedScriptsDirectory', tmpDir, vscode.ConfigurationTarget.Global);
 	});
@@ -72,7 +77,7 @@ suite('UnsavedScriptFiles', () => {
 			.update('unsavedScriptsDirectory', filePath, vscode.ConfigurationTarget.Global);
 		try {
 			const written = await manager.write(fakeUntitled('Untitled-9', 'z'));
-			assert.strictEqual(path.dirname(written), fs.realpathSync(os.tmpdir()));
+			assert.strictEqual(path.dirname(written), await canonicalize(os.tmpdir()));
 			await manager.finished(written);
 		} finally {
 			await vscode.workspace.getConfiguration('interpreters')

--- a/extensions/positron-r/src/test/unsavedScripts.test.ts
+++ b/extensions/positron-r/src/test/unsavedScripts.test.ts
@@ -1,0 +1,76 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import './mocha-setup';
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { UnsavedScriptFiles } from '../unsavedScripts';
+
+function fakeUntitled(name: string, text: string): vscode.TextDocument {
+	return {
+		uri: vscode.Uri.parse(`untitled:${name}`),
+		isUntitled: true,
+		getText: () => text,
+	} as unknown as vscode.TextDocument;
+}
+
+suite('UnsavedScriptFiles', () => {
+	let tmpDir: string;
+	let manager: UnsavedScriptFiles;
+
+	suiteSetup(async () => {
+		// Canonicalize: the manager resolves symlinks (e.g. macOS /var -> /private/var).
+		tmpDir = fs.realpathSync(await fs.promises.mkdtemp(path.join(os.tmpdir(), 'positron-unsaved-test-')));
+		await vscode.workspace.getConfiguration('interpreters')
+			.update('unsavedScriptsDirectory', tmpDir, vscode.ConfigurationTarget.Global);
+	});
+
+	suiteTeardown(async () => {
+		await vscode.workspace.getConfiguration('interpreters')
+			.update('unsavedScriptsDirectory', undefined, vscode.ConfigurationTarget.Global);
+		await fs.promises.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	setup(() => { manager = new UnsavedScriptFiles(); });
+	teardown(() => manager.dispose());
+
+	test('writes the buffer to a hidden scratch file, then deletes it when the run finishes', async () => {
+		const filePath = await manager.write(fakeUntitled('Untitled-1', 'cat("hi")'));
+
+		assert.strictEqual(path.dirname(filePath), tmpDir);
+		assert.strictEqual(path.basename(filePath), '.positron-untitled-1.R');
+		assert.strictEqual(await fs.promises.readFile(filePath, 'utf8'), 'cat("hi")');
+
+		await manager.finished(filePath);
+		assert.ok(!fs.existsSync(filePath));
+	});
+
+	test('keeps the scratch file until every in-flight run finishes', async () => {
+		const doc = fakeUntitled('Untitled-1', 'x');
+		const first = await manager.write(doc);
+		const second = await manager.write(doc);
+		assert.strictEqual(first, second);
+
+		await manager.finished(first);
+		assert.ok(fs.existsSync(first), 'file was removed while a run was still in flight');
+
+		await manager.finished(second);
+		assert.ok(!fs.existsSync(first));
+	});
+
+	test('dispose removes any scratch files still on disk', async () => {
+		const filePath = await manager.write(fakeUntitled('Untitled-2', 'y'));
+		assert.ok(fs.existsSync(filePath));
+
+		manager.dispose();
+		// dispose deletes asynchronously; allow the IO to settle.
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		assert.ok(!fs.existsSync(filePath));
+	});
+});

--- a/extensions/positron-r/src/test/unsavedScripts.test.ts
+++ b/extensions/positron-r/src/test/unsavedScripts.test.ts
@@ -64,6 +64,22 @@ suite('UnsavedScriptFiles', () => {
 		assert.ok(!fs.existsSync(first));
 	});
 
+	test('falls back to the system temp dir when the configured directory cannot be used', async () => {
+		// Point the setting at a regular file so the directory can't be created.
+		const filePath = path.join(tmpDir, 'not-a-dir');
+		await fs.promises.writeFile(filePath, '');
+		await vscode.workspace.getConfiguration('interpreters')
+			.update('unsavedScriptsDirectory', filePath, vscode.ConfigurationTarget.Global);
+		try {
+			const written = await manager.write(fakeUntitled('Untitled-9', 'z'));
+			assert.strictEqual(path.dirname(written), fs.realpathSync(os.tmpdir()));
+			await manager.finished(written);
+		} finally {
+			await vscode.workspace.getConfiguration('interpreters')
+				.update('unsavedScriptsDirectory', tmpDir, vscode.ConfigurationTarget.Global);
+		}
+	});
+
 	test('dispose removes any scratch files still on disk', async () => {
 		const filePath = await manager.write(fakeUntitled('Untitled-2', 'y'));
 		assert.ok(fs.existsSync(filePath));

--- a/extensions/positron-r/src/unsavedScripts.ts
+++ b/extensions/positron-r/src/unsavedScripts.ts
@@ -61,7 +61,17 @@ export class UnsavedScriptFiles implements vscode.Disposable {
 			return;
 		}
 		this._inFlight.delete(filePath);
+		this.forgetFile(filePath);
 		await deleteQuietly(filePath);
+	}
+
+	/** Drops any untitled-URI mappings that point at the given scratch file. */
+	private forgetFile(filePath: string): void {
+		for (const [uri, mapped] of this._files) {
+			if (mapped === filePath) {
+				this._files.delete(uri);
+			}
+		}
 	}
 
 	private onDocumentClosed(uri: vscode.Uri): void {

--- a/extensions/positron-r/src/unsavedScripts.ts
+++ b/extensions/positron-r/src/unsavedScripts.ts
@@ -98,7 +98,8 @@ export class UnsavedScriptFiles implements vscode.Disposable {
 
 /**
  * Resolves the directory scratch files are written to: the configured directory
- * if set, else the workspace root, else the system temporary directory.
+ * if set and writable, else the workspace root, else the system temporary
+ * directory.
  */
 async function resolveScratchDirectory(): Promise<string> {
 	const configured = vscode.workspace
@@ -106,17 +107,30 @@ async function resolveScratchDirectory(): Promise<string> {
 		.get<string>('unsavedScriptsDirectory')
 		?.trim();
 	if (configured) {
-		const directory = normalizeUserPath(configured);
+		// Resolve relative paths against the workspace root (or home when no
+		// workspace is open) so they don't depend on the extension host's
+		// working directory.
+		const normalized = normalizeUserPath(configured);
+		const directory = path.isAbsolute(normalized)
+			? normalized
+			: path.resolve(workspaceRoot() ?? os.homedir(), normalized);
 		try {
 			await fs.promises.mkdir(directory, { recursive: true });
+			// mkdir succeeds silently on an existing directory without checking
+			// writability, so probe it explicitly before committing.
+			await fs.promises.access(directory, fs.constants.W_OK);
 			return canonicalize(directory);
 		} catch (error) {
 			LOGGER.warn(`Cannot use configured unsaved scripts directory '${directory}': ${error}. Falling back to the system temporary directory.`);
 			return canonicalize(os.tmpdir());
 		}
 	}
-	const folder = vscode.workspace.workspaceFolders?.find((f) => f.uri.scheme === 'file');
-	return canonicalize(folder ? folder.uri.fsPath : os.tmpdir());
+	return canonicalize(workspaceRoot() ?? os.tmpdir());
+}
+
+/** The first file-scheme workspace folder path, if any. */
+function workspaceRoot(): string | undefined {
+	return vscode.workspace.workspaceFolders?.find((f) => f.uri.scheme === 'file')?.uri.fsPath;
 }
 
 /**

--- a/extensions/positron-r/src/unsavedScripts.ts
+++ b/extensions/positron-r/src/unsavedScripts.ts
@@ -134,12 +134,18 @@ function workspaceRoot(): string | undefined {
 }
 
 /**
- * Resolves symlinks in a directory so scratch file paths match the canonical
- * form the session reports as its working directory (macOS temp dirs and
- * workspace roots are often symlinked, e.g. /var -> /private/var). Without this,
- * the path can't be made relative to the working directory.
+ * Puts a directory into the same form the session reports as its working
+ * directory, so scratch file paths can be made relative to it.
+ *
+ * On POSIX, `getcwd()` resolves symlinks (e.g. macOS /var -> /private/var), so
+ * we resolve them too. On Windows, `GetCurrentDirectory` echoes the launch path
+ * verbatim; realpath would instead expand 8.3 short names (RUNNER~1 ->
+ * runneradmin) and make the paths diverge, so leave the path as-is.
  */
 async function canonicalize(directory: string): Promise<string> {
+	if (process.platform === 'win32') {
+		return directory;
+	}
 	try {
 		return await fs.promises.realpath(directory);
 	} catch {

--- a/extensions/positron-r/src/unsavedScripts.ts
+++ b/extensions/positron-r/src/unsavedScripts.ts
@@ -1,0 +1,138 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+import { normalizeUserPath } from './path-utils';
+import { LOGGER } from './extension.js';
+
+/**
+ * Manages temporary files backing the "run file" gesture for unsaved (untitled)
+ * scripts. The untitled buffer is written to a scratch file on disk so that R's
+ * `source()` can read it, then the file is cleaned up.
+ *
+ * Files are deleted when their run finishes (the primary path), when the
+ * originating editor is closed, and when the extension is disposed. In-flight
+ * runs are ref-counted per file so a rapid re-run does not delete a file that a
+ * queued run has not yet read.
+ */
+export class UnsavedScriptFiles implements vscode.Disposable {
+	/** Untitled document URI -> temp file path. */
+	private readonly _files = new Map<string, string>();
+	/** Temp file path -> number of runs currently in flight. */
+	private readonly _inFlight = new Map<string, number>();
+	private readonly _disposables: vscode.Disposable[] = [];
+
+	constructor() {
+		this._disposables.push(
+			vscode.workspace.onDidCloseTextDocument((document) => {
+				if (document.isUntitled) {
+					this.onDocumentClosed(document.uri);
+				}
+			})
+		);
+	}
+
+	/**
+	 * Writes the untitled document's contents to a scratch file and registers a
+	 * run as in flight. Returns the file path to `source()`.
+	 */
+	public async write(document: vscode.TextDocument): Promise<string> {
+		const directory = await resolveScratchDirectory();
+		const filePath = path.join(directory, scratchFileName(document));
+		await fs.promises.writeFile(filePath, document.getText(), 'utf8');
+		this._files.set(document.uri.toString(), filePath);
+		this._inFlight.set(filePath, (this._inFlight.get(filePath) ?? 0) + 1);
+		return filePath;
+	}
+
+	/**
+	 * Marks a run of the given scratch file as finished, deleting the file once
+	 * no runs remain in flight.
+	 */
+	public async finished(filePath: string): Promise<void> {
+		const remaining = (this._inFlight.get(filePath) ?? 1) - 1;
+		if (remaining > 0) {
+			this._inFlight.set(filePath, remaining);
+			return;
+		}
+		this._inFlight.delete(filePath);
+		await deleteQuietly(filePath);
+	}
+
+	private onDocumentClosed(uri: vscode.Uri): void {
+		const filePath = this._files.get(uri.toString());
+		if (!filePath) {
+			return;
+		}
+		this._files.delete(uri.toString());
+		// If a run is still in flight, let finished() delete the file.
+		if (!this._inFlight.has(filePath)) {
+			void deleteQuietly(filePath);
+		}
+	}
+
+	public dispose(): void {
+		this._disposables.forEach((d) => d.dispose());
+		for (const filePath of this._files.values()) {
+			void deleteQuietly(filePath);
+		}
+		this._files.clear();
+		this._inFlight.clear();
+	}
+}
+
+/**
+ * Resolves the directory scratch files are written to: the configured directory
+ * if set, else the workspace root, else the system temporary directory.
+ */
+async function resolveScratchDirectory(): Promise<string> {
+	const configured = vscode.workspace
+		.getConfiguration('interpreters')
+		.get<string>('unsavedScriptsDirectory')
+		?.trim();
+	if (configured) {
+		const directory = normalizeUserPath(configured);
+		try {
+			await fs.promises.mkdir(directory, { recursive: true });
+			return canonicalize(directory);
+		} catch (error) {
+			LOGGER.warn(`Cannot use configured unsaved scripts directory '${directory}': ${error}. Falling back to the system temporary directory.`);
+			return canonicalize(os.tmpdir());
+		}
+	}
+	const folder = vscode.workspace.workspaceFolders?.find((f) => f.uri.scheme === 'file');
+	return canonicalize(folder ? folder.uri.fsPath : os.tmpdir());
+}
+
+/**
+ * Resolves symlinks in a directory so scratch file paths match the canonical
+ * form the session reports as its working directory (macOS temp dirs and
+ * workspace roots are often symlinked, e.g. /var -> /private/var). Without this,
+ * the path can't be made relative to the working directory.
+ */
+async function canonicalize(directory: string): Promise<string> {
+	try {
+		return await fs.promises.realpath(directory);
+	} catch {
+		return directory;
+	}
+}
+
+/** Builds a stable, hidden scratch file name from an untitled document. */
+function scratchFileName(document: vscode.TextDocument): string {
+	const base = path.basename(document.uri.path).replace(/[^\w.-]/g, '_');
+	return `.positron-${base.toLowerCase()}.R`;
+}
+
+async function deleteQuietly(filePath: string): Promise<void> {
+	try {
+		await fs.promises.rm(filePath, { force: true });
+	} catch (error) {
+		LOGGER.warn(`Cannot delete unsaved script scratch file '${filePath}': ${error}`);
+	}
+}

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -291,6 +291,15 @@ configurationRegistry.registerConfiguration({
 				"How interpreters are started in new Positron windows."),
 			tags: ['interpreterSettings']
 		},
+		'interpreters.unsavedScriptsDirectory': {
+			scope: ConfigurationScope.MACHINE_OVERRIDABLE,
+			type: 'string',
+			default: '',
+			description: nls.localize(
+				'positron.runtime.unsavedScriptsDirectory',
+				"Directory for temporary files created when running unsaved scripts. When empty, the workspace root is used (or the system temporary directory when no workspace is open)."),
+			tags: ['interpreterSettings']
+		},
 		'interpreters.discoveryCache.enabled': {
 			scope: ConfigurationScope.APPLICATION_MACHINE,
 			type: 'boolean',

--- a/test/e2e/tests/editor/unsaved-script-execution.test.ts
+++ b/test/e2e/tests/editor/unsaved-script-execution.test.ts
@@ -1,0 +1,82 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test, tags } from '../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+interface LanguageConfig {
+	session: 'r' | 'python';
+	newFileCommand: string;
+	code: string;
+	marker: string;
+	// The scratch file path as echoed to the console: a quoted literal beginning
+	// right after the opening quote with ".positron-", i.e. relative to the
+	// working directory (the workspace root here) rather than an absolute path.
+	relativePath: RegExp;
+	tags: string[];
+}
+
+// The marker is assembled at runtime so it is not present verbatim in the
+// source text. R's toolbar run echoes the sourced lines to the console, so a
+// marker that appeared literally in the code would show up twice.
+const languageConfigs: LanguageConfig[] = [
+	{
+		session: 'r',
+		newFileCommand: 'r.createNewFile',
+		code: 'cat(paste0("SCRATCH", "_R_RAN"), "\\n")',
+		marker: 'SCRATCH_R_RAN',
+		relativePath: /"\.positron-untitled-\d+\.R"/,
+		tags: [tags.ARK],
+	},
+	{
+		session: 'python',
+		newFileCommand: 'python.createNewFile',
+		code: 'print("SCRATCH" + "_PY_RAN")',
+		marker: 'SCRATCH_PY_RAN',
+		relativePath: /"\.positron-untitled-\d+\.py"/,
+		tags: [],
+	},
+];
+
+for (const config of languageConfigs) {
+	test.describe('Run Unsaved Script', { tag: [tags.WEB, tags.WIN, tags.EDITOR, tags.CONSOLE, ...config.tags] }, () => {
+
+		test.beforeEach(async ({ sessions }) => {
+			await sessions.start(config.session);
+		});
+
+		test.afterEach(async ({ hotKeys }) => {
+			await hotKeys.closeAllEditors();
+		});
+
+		test(`${config.session === 'r' ? 'R' : 'Python'} - runs an untitled script without a save prompt`, async ({ app, runCommand }) => {
+			const { editor, editors, console: consolePane } = app.workbench;
+
+			await test.step('Create a new untitled script with code', async () => {
+				await runCommand(config.newFileCommand);
+				await editor.type(config.code);
+			});
+
+			await test.step('Run the whole file via the editor toolbar button', async () => {
+				await editor.playButton.click();
+			});
+
+			// The scratch file is run by a path relative to the working
+			// directory, not an ugly absolute path.
+			await consolePane.waitForConsoleContents(config.relativePath);
+
+			// The code actually ran: its marker shows up in the console.
+			await consolePane.waitForConsoleContents(config.marker);
+
+			// No save prompt appeared: the buffer is still an unsaved, untitled
+			// editor. Had a save dialog blocked the run, the marker above would
+			// never have appeared.
+			await editors.waitForActiveTab(/Untitled-\d+/, true);
+		});
+	});
+}


### PR DESCRIPTION
Fixes #12351
Fixes #14639

### Summary

Running an unsaved (untitled) R or Python script no longer prompts you to save first. Previously, clicking the editor's Run button on a new, never-saved buffer either forced a save dialog or silently did nothing on the first try. Now the buffer's contents are written to a temporary scratch file, run via R's `source()` or IPython's `%run`, and the scratch file is cleaned up once the run finishes. 

<img width="593" height="619" alt="image" src="https://github.com/user-attachments/assets/afd16d4e-3b24-47ab-b1d2-fa899210c6ec" />

This matches RStudio's behavior of running unnamed documents, with a few improvements:
- RStudio writes to the home directory (`~/.active-rstudio-document`); we write to the workspace folder by default to avoid cluttering `$HOME`
- Positron's path for these temp files is configurable 
- Positron's file names are more unique to reduce the odds of collisions

The scratch file is referenced by a path relative to the session's working directory when possible (falling back to home-relative, then absolute), so the console echoes a short readable path instead of a long temporary path. Scratch files are ref-counted per run and removed when the run completes, when the originating editor is closed, or when the extension is disposed.

A new setting, `interpreters.unsavedScriptsDirectory`, controls where these temporary files are written. When empty (the default), the workspace root is used, or the system temporary directory when no workspace is open.

### Release Notes

#### New Features

- Unsaved (untitled) R and Python scripts can now be run directly without a save prompt (#12351)

#### Bug Fixes

- Fixed running a new, unsaved R file doing nothing on the first attempt (#14639)

### Validation Steps

@:editor @:console @:ark @:editor-action-bar

1. Run the command **R: New R File** to create a new, unsaved R script.
2. Add some code, e.g. `cat("hello, world\n")`.
3. Click the Run button (triangle) in the editor toolbar.
4. Verify the script runs in the console with no save prompt, and the editor tab  stays an untitled buffer.
5. Repeat with **Python: New Python File** and `print("hello, world")`.
6. Optionally set `interpreters.unsavedScriptsDirectory` and confirm scratch files are written there and cleaned up after the run.
