### PR TITLE
e2e: retry Connect when the providers.json write fails with EPERM

### DIFF
--- a/test/e2e/pages/modelProviderModal.ts
+++ b/test/e2e/pages/modelProviderModal.ts
@@ -37,6 +37,19 @@ const BASEURL_INPUT = '#connect-provider-baseurl-input';
 // addressed by name and value, which come from the AuthMethod enum.
 const AUTH_METHOD_RADIO = (method: 'oauth' | 'apiKey') =>
 	`input[name="connect-provider-auth-method"][value="${method}"]`;
+// The Connect view's error banner. Scoped to the Connect view on purpose: the
+// Connected view renders the same banner component, so an unscoped selector would
+// match both and trip strict mode.
+const CONNECT_ERROR_MESSAGE = `${CONNECT_VIEW} .connect-provider-banner.error .connect-provider-banner-message`;
+// Connect failures worth another click rather than a report. See expectConnectedView
+// for the mechanism, and for when this should be deleted.
+const TRANSIENT_CONNECT_ERROR = /(EPERM|EACCES|EBUSY)[\s\S]*providers\.json/i;
+// Extra Connect clicks to spend on a transient failure, and the shorter window each
+// one gets. A retry settles in well under a second either way -- the write either
+// lands or fails again -- so the first attempt keeps the caller's full timeout while
+// the retries stay cheap enough to fit inside the 2 minute test budget.
+const CONNECT_RETRIES = 2;
+const CONNECT_RETRY_TIMEOUT = 8000;
 
 /**
  * Page object for the "Configure LLM Providers" modal. This is what the
@@ -114,6 +127,64 @@ export class ModelProviderModal {
 			await this.clickCloseButton();
 		} catch {
 			// Already dismissed, or in a state the Close button can't be reached from.
+		}
+	}
+
+	/**
+	 * Waits for the Connected view, re-clicking Connect when the connect handler
+	 * failed on a known-transient Windows filesystem error.
+	 *
+	 * TEMPORARY STOPGAP -- remove once the ai-lib fix lands. This makes CI green while
+	 * the underlying Windows bug is still shipped, so it is not a fix.
+	 *
+	 * `providers.json` is persisted by ai-config's `atomicWrite`: a temp file plus a
+	 * single unretried `fs.rename`. On Windows that rename returns EPERM whenever any
+	 * other handle is open on the destination, and the competing reads are largely
+	 * self-inflicted -- `refreshProviderCatalog` runs after every write, and the config
+	 * watcher schedules a 300ms-debounced re-read. The connect handler then rejects, the
+	 * modal stays on the Connect view rendering the raw error, and the Connected view
+	 * never mounts.
+	 *
+	 * A Playwright-level retry does not help: the condition persists across app
+	 * relaunches within a run, so each attempt fails the same way. The retry has to
+	 * happen here, in place, once startup churn has settled.
+	 *
+	 * Every retry is recorded as a test annotation, so the real rate of the underlying
+	 * product failure stays visible in the report instead of being silently absorbed.
+	 */
+	private async expectConnectedView(provider: ModelProvider, timeout: number, canRetry: boolean) {
+		const connectedView = this.code.driver.currentPage.locator(CONNECTED_VIEW);
+		const errorMessage = this.code.driver.currentPage.locator(CONNECT_ERROR_MESSAGE);
+
+		for (let attempt = 0; ; attempt++) {
+			try {
+				// The first attempt keeps the caller's timeout, so a healthy connect behaves
+				// exactly as it did before this retry existed.
+				await expect(connectedView).toBeVisible({
+					timeout: attempt === 0 ? timeout : CONNECT_RETRY_TIMEOUT,
+				});
+				return;
+			} catch (assertionError) {
+				// The banner is cleared synchronously when Connect is clicked and set again
+				// only on rejection, so by the time the assertion above has given up this
+				// text is settled rather than left over from the previous attempt.
+				const message = (await errorMessage.textContent().catch(() => null))?.trim() ?? '';
+
+				if (canRetry && attempt < CONNECT_RETRIES && TRANSIENT_CONNECT_ERROR.test(message)) {
+					annotateTransientConnect(provider, attempt + 1, message);
+					await this.clickConnectButton();
+					continue;
+				}
+
+				// Report what the modal actually said. The bare assertion failure only says
+				// the Connected view was not found, which hides the reason it was not.
+				if (message) {
+					throw new Error(
+						`Connecting to ${provider} failed: the Connect view reported "${message}" and the Connected view never appeared.`
+					);
+				}
+				throw assertionError;
+			}
 		}
 	}
 
@@ -207,8 +278,12 @@ export class ModelProviderModal {
 						throw new Error(`Unknown authentication type for provider: ${provider}`);
 				}
 
-				// A successful connect auto-transitions to the Connected view.
-				await expect(this.code.driver.currentPage.locator(CONNECTED_VIEW)).toBeVisible({ timeout });
+				// A successful connect auto-transitions to the Connected view. Re-clicking
+				// Connect is only safe for the non-OAuth methods, where the form still holds
+				// the entered values; the OAuth flows would need their device or loopback
+				// dance driven again, so they keep the plain assertion.
+				const canRetryConnect = authType === 'apiKey' || authType === 'aws' || authType === 'none';
+				await this.expectConnectedView(provider, timeout, canRetryConnect);
 				await this.clickCloseButton();
 			});
 		});
@@ -257,5 +332,22 @@ export class ModelProviderModal {
 		await this.toasts.closeAll();
 		await this.modal.clickCloseButton();
 		await this.modal.expectNotToBeVisible({ timeout: 15000 });
+	}
+}
+
+/**
+ * Records a transient-connect retry on the current test so the report still shows that
+ * the underlying product failure happened. Falls back to a log line when there is no
+ * active test to annotate, such as a call from a suite-level hook.
+ *
+ * Part of the same temporary stopgap as `expectConnectedView`.
+ */
+function annotateTransientConnect(provider: ModelProvider, attempt: number, message: string) {
+	const description = `${provider}: retrying Connect (attempt ${attempt}) after a transient config-write failure -- ${message}`;
+	try {
+		test.info().annotations.push({ type: 'transient-connect-retry', description });
+	} catch {
+		// No active test to annotate; the log line is the only record available.
+		console.log(`[modelProviderModal] ${description}`);
 	}
 }


### PR DESCRIPTION
Temporary e2e stopgap for a Windows product bug in the provider connect flow. Not a fix -- see the caveat below.

### Summary

`Posit Assistant Sign-in > anthropic-api - Sign in, send hello, sign out` has been failing win/electron only since 2026-08-25 (12 occurrences, ~9.9% on that platform; every other platform 100% green). The connect does not hang -- it *rejects*, and the modal renders the raw error in the Connect view, so `provider-connected-view` never mounts:

```
EPERM: operation not permitted, rename
'...\.posit\ai\providers.json.tmp.9028' -> '...\.posit\ai\providers.json'
```

ai-config's `atomicWrite` (ai-lib, `packages/ai-config/src/node/mutate-config.ts`) persists `providers.json` as a temp file plus a **single unretried `fs.rename`**. On Windows that rename returns EPERM whenever another handle is open on the destination, and the competing reads are largely self-inflicted: `refreshProviderCatalog` runs after every write, and the config watcher schedules a debounced re-read. `mutateProvidersConfig` holds a lock that serializes writers but not readers. A POSIX rename over an open file simply succeeds, which is why this is Windows-only.

The failing provider is not special -- it is just *first* in the list. The suite shares one app, so only the first test runs while startup churn is still touching that file.

This PR retries the Connect click on that specific error, bounded at 2 retries, and annotates each retry (`transient-connect-retry`) so the underlying failure rate stays visible in the report rather than being silently absorbed. It also reports the banner text when the Connected view never appears, replacing the bare `element(s) not found` that hid the cause entirely.

The retry is scoped to the non-OAuth auth methods, where the form still holds the entered values; the OAuth and loopback flows would need their device dance driven again, so they keep the plain assertion.

**This is a stopgap, not a fix.** The Windows bug is still shipped: a user with a second Positron window open can fail to connect a provider, and because credentials are stored separately, the failure leaves inconsistent state (key saved, provider block not persisted). The same unretried pattern exists in ai-credentials `SingleFileStore.writeStore()`, which writes the credentials file. The real fix is a bounded retry on the rename in ai-lib; it is still absent in `a05f21e9`, the submodule current main points at. Remove this stopgap when that lands.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:assistant @:win

The retry path was verified locally by forcing the failure: hold a read handle open on `~/.posit/ai/providers.json` while the connect runs. An open handle on the *destination* reproduces the EPERM deterministically on Windows (a handle on the temp *source* does not, which rules out antivirus-scans-the-temp-file as the mechanism).

- Handle held throughout: 3 Connect clicks at 15s / 8s / 8s, 2 retry annotations, then the new readable error naming the EPERM.
- Handle released 5s after the temp-file write: exactly 1 retry annotation, the connect recovers, and `providers.json` gains the provider block with a fresh mtime.

Two gotchas if you reproduce this yourself:

1. Remove the provider's block from `providers.json` first. `mutate-config.ts` short-circuits when the mutation produces identical bytes (`if (output === raw) return;`), so with the block already present there is no write, no rename, and no EPERM -- the test just passes and looks like it disproves the bug. CI hits it because its runners start without the block.
2. The temp file is `providers.json.tmp.${process.pid}`, so every retry inside one process reuses the same filename. Don't build trigger logic on seeing distinct temp names.


### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- Connect fails because ai-config's atomicWrite does a single unretried fs.rename of providers.json.tmp.<pid> over providers.json; on Windows that rename returns EPERM whenever another handle is open on the target or source, so the connect handler rejects, the modal stays on the Connect view (rendering the raw EPERM), and provider-connected-view is never mounted.</summary>

- **Test:** [Posit Assistant Sign-in > anthropic-api - Sign in, send hello, sign out](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Posit%20Assistant%20Sign-in%20%3E%20anthropic-api%20-%20Sign%20in%2C%20send%20hello%2C%20sign%20out%7C%7C%7Ctest%2Fe2e%2Ftests%2Fposit-assistant%2Fposit-assistant-signin.test.ts)
- **Targeted failure:** expect(locator('[data-testid="provider-connected-view"]')).toBeVisible() times out with element(s) not found at test/e2e/pages/modelProviderModal.ts:211
- **Signal:** DOM snapshot at failure shows dialog 'Connect to Anthropic' still open containing: EPERM: operation not permitted, rename '...providers.json.tmp.9028' -> '...providers.json'
- **Frequency:** 12/121 runs (9.9%) on main, win/electron
- **Hypothesis:** Windows handle contention on a per-user singleton file. providers.json lives at ~/.posit/ai/ (one per OS user) while playwright.config.ts sets workers: 3, so three Positron apps plus their shared-process/exthost readers and the ai-config directory watcher all touch one file. mutateProvidersConfig holds a proper-lockfile lock that serializes writers but not readers, and atomicWrite has no retry. POSIX rename over an open file succeeds, which is why only win/electron fails (12/12 pattern-A occurrences win/electron; every other platform 100%). anthropic-api is not special: it is the FIRST test in the shared-app file, firing ~800ms after 'Runtime startup Phase changed to complete' while startup migrations and the initial catalog load still touch the same file. The four later providers pass because startup churn has settled.

</details>
