### PR TITLE
viewer: reattach query string to url on web

### DIFF
--- a/src/vs/server/node/webClientServer.ts
+++ b/src/vs/server/node/webClientServer.ts
@@ -313,7 +313,16 @@ export class WebClientServer {
 			return;
 		}
 
-		const path: string = parsedUrl.replace('/proxy/', 'http://0.0.0.0:');
+		let path: string = parsedUrl.replace('/proxy/', 'http://0.0.0.0:');
+
+		// Append query string if it exists. The caller passes only the pathname, so the query
+		// string must be recovered from req.url; websocket apps like marimo require it
+		// (e.g. /ws?session_id=...).
+		const search = url.parse(req.url ?? '').search;
+		if (search) {
+			path = path.concat(search);
+		}
+
 		return this._proxyServer.ws(req, socket, upgradeHead, {
 			ignorePath: true,
 			target: path

--- a/src/vs/server/test/node/webClientServer.vitest.ts
+++ b/src/vs/server/test/node/webClientServer.vitest.ts
@@ -328,6 +328,44 @@ describe('WebClientServer /proxy/ port ownership gate', () => {
 			}
 		});
 
+		it('preserves the query string when proxying a websocket upgrade', async () => {
+			const ownershipCheck: ISocketOwnershipCheck = {
+				getListeningPortUid: vi.fn().mockReturnValue(ourUid),
+				isProxyPortOwnershipEnforced: vi.fn().mockReturnValue(true),
+			};
+			const webClientServer = createWebClientServer(ownershipCheck);
+
+			const backendServer = http.createServer();
+			const upgradeUrl = new Promise<string>(resolve => {
+				backendServer.on('upgrade', (req, backendSocket) => {
+					resolve(req.url!);
+					backendSocket.destroy();
+				});
+			});
+			const { server, socket } = await connectedSocketPair();
+
+			try {
+				await listen(backendServer, 0, '127.0.0.1');
+				const { port: backendPort } = backendServer.address() as net.AddressInfo;
+
+				// The production caller (remoteExtensionHostAgentServer#handleUpgrade) passes only the
+				// pathname as the parsed URL; the query string survives only on req.url. Websocket apps
+				// like marimo cannot connect without it (e.g. /ws?session_id=...).
+				await webClientServer.handleUpgrade(
+					fakeUpgradeRequest(`/proxy/${backendPort}/ws?session_id=abc123`),
+					socket,
+					Buffer.alloc(0),
+					`/proxy/${backendPort}/ws`
+				);
+
+				expect(await upgradeUrl).toBe('/ws?session_id=abc123');
+			} finally {
+				socket.destroy();
+				server.close();
+				backendServer.close();
+			}
+		});
+
 		it('does not destroy the socket when the port is owned by our uid', async () => {
 			const ownershipCheck: ISocketOwnershipCheck = {
 				getListeningPortUid: vi.fn().mockReturnValue(ourUid),


### PR DESCRIPTION
Fixes the `Python - Verify Basic Marimo App` e2e failure on web introduced when marimo support landed in #15723. Related to #11095; complements #15476, which fixed query corruption on Viewer HTTP navigation but not this server-side path.

### Summary

In Positron Web and Posit Workbench, apps in the Viewer are reached through the server's `/proxy/<port>/` route. Any websocket upgrade with query parameters arrived at the app with the query silently dropped.

marimo is the first framework we run whose client websocket requires query parameters (`/ws?session_id=...`), so its apps loaded their HTML fine but never established a session, hanging forever in the Viewer on Web/Workbench. eg, Streamlit was unaffected because its websocket (`/_stcore/stream`) carries no query.

The fix recovers the query string from `req.url` in `WebClientServer#handleUpgrade` and appends it to the websocket proxy target, mirroring what the HTTP branch already does. Desktop (Electron) is unaffected: it does not route Viewer traffic through this proxy.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed query parameters being dropped from proxied websocket connections in Positron on Web and Posit Workbench, which prevented marimo apps from connecting in the Viewer

### Validation Steps

@:apps @:viewer @:web

1. In Positron Web, open `workspaces/python_apps/marimo_example/marimo_example.py` and press play.
2. Verify the app renders in the Viewer ("Hello marimo" heading) instead of hanging — on main the page loads but the websocket session never connects.
3. Unit coverage: `npx vitest run src/vs/server/test/node/webClientServer.vitest.ts` (new test: "preserves the query string when proxying a websocket upgrade").