### PR TITLE
Reduce the default tree indent from 18px to 16px

### DIFF
--- a/src/vs/platform/list/browser/listService.ts
+++ b/src/vs/platform/list/browser/listService.ts
@@ -1418,8 +1418,9 @@ configurationRegistry.registerConfiguration({
 			type: 'number',
 			// --- Start Positron ---
 			// https://github.com/posit-dev/positron/issues/2688
+			// https://github.com/posit-dev/positron/issues/15832
 			// default: 8,
-			default: 18,
+			default: 16,
 			// --- End Positron ---
 			minimum: 4,
 			maximum: 40,


### PR DESCRIPTION
Fixes #15832.

[#2688](https://github.com/posit-dev/positron/issues/2688) observed that VS Code's default `workbench.tree.indent` of 8px made the sidebar tree read as too dense, and [#2705](https://github.com/posit-dev/positron/pull/2705) landed a Positron default of 18px in response. The direction was right -- 8px is genuinely cramped, and the roomier tree has held up as a Positron characteristic -- but 18px overshot by about 2px.

Indent is the one dimension that gets multiplied. The per-level step is paid once for every level of depth, while the panel it's spent from doesn't get any wider. The evidence in #2688 was all Explorer screenshots, and the Explorer is shallow: three to five levels in ordinary use, where 18px is comfortable. Trees that nest deeper spend a much larger share of a fixed-width sidebar on empty space before the label starts, and at 18px that adds up faster than it should.

This PR sets the default to **16px**. That is still double upstream's 8px, so it keeps the intent of #2688 intact while trimming the step every level pays.

The change is one line inside the existing Positron block in `src/vs/platform/list/browser/listService.ts`, which already carries the commented-out upstream default for merge-conflict resolution. Two lines of rationale were added alongside the issue link, since the block previously read as "we chose 18 because of #2688" and now has to explain why it isn't 18 anymore.

<!-- Attach before/after screenshots of the Explorer here -- that's the surface #2688 was arguing about and where this will actually be judged. -->

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Reduced the default tree indentation from 18px to 16px (#15832)

### Validation Steps

@:critical @:variables @:outline @:scm @:search @:test-explorer

`src/vs/platform/list/` is not in `.github/workflows/test-tag-paths-map.json`, so no tags are auto-derived for this change. The tags above are added by hand and cover the tree-based views most likely to notice a change in indentation.

Things worth checking:

- This affects **every tree in the workbench** -- Explorer, Search, Debug, SCM, Testing, and any view built on the workbench tree -- not just one surface. The risk is low per-tree but wide.
- Anyone who has set `workbench.tree.indent` explicitly is unaffected; only the default moves.
- The setting is read live (`listService.ts` subscribes to `onDidChangeConfiguration`), so no window reload is needed to see the change, and setting the value explicitly still overrides it.
- Nothing in the codebase asserts the old default. The only other references are `explorerViewer.ts`, which reads the setting at runtime, and `settingsSync.test.ts`, which uses an unrelated value as test data.
