### PR TITLE
Add an agent command and skill reference for AI provider status

### DIFF
--- a/extensions/positron-skills/templates/positron-settings/SKILL.md
+++ b/extensions/positron-skills/templates/positron-settings/SKILL.md
@@ -7,16 +7,18 @@ description: >
   skill's commands can. Use for: what the user has configured, what a setting
   is set to and where, why a setting they set is not taking effect, which
   features are in preview or experimental and what enables each, whether a
-  setting exists, its default and allowed values. Triggers: "what settings do
-  I have enabled", "which features are in preview", "why isn't this setting
-  working", "what is X set to", "is there a setting for X".
+  setting exists, its default and allowed values, and which AI model
+  providers are enabled, signed in, or failing to authenticate. Triggers:
+  "what settings do I have enabled", "which features are in preview", "why
+  isn't this setting working", "what is X set to", "is there a setting for
+  X", "which providers do I have enabled".
 ---
 
 # Positron settings
 
 These commands read the running Positron's configuration -- what the user has
-set, and what this build's settings registry knows. Two rules frame everything
-in this skill:
+set, what this build's settings registry knows, and which AI model providers
+are set up. Two rules frame everything in this skill:
 
 1. **This is state, not documentation.** The user's configuration is live
    state in this running Positron. Do not fetch a documentation page, do not
@@ -43,9 +45,9 @@ user hasn't given you or that isn't documented.
 - **`not-found`**: the command id isn't present in this Positron build, meaning
   the build is older or newer than this skill expects. Report this plainly; do
   not substitute a similarly named id you're unsure about.
-- Neither command here has a precondition: there is always a configuration,
-  even when the user has set nothing, so a `disabled` failure is unexpected.
-  Report it plainly if it ever appears.
+- No command here has a precondition: there is always an answer, even when the
+  user has set nothing and no provider is configured, so a `disabled` failure
+  is unexpected. Report it plainly if it ever appears.
 
 ## When a result is truncated
 
@@ -67,3 +69,8 @@ set to, why a setting they set is not taking effect, which features are in
 preview or experimental, whether a setting exists, or what a setting's default
 or allowed values are. Also carries the known settings-that-gate-other-settings
 relationships (the AI feature switches), which no single payload can reveal.
+
+**Providers** -- [references/providers.md]({{skill_dir}}/references/providers.md)
+Read when the user asks which AI model providers they have set up, enabled, or
+signed in to, whether a provider is usable, why a provider stopped working, or
+where provider configuration lives.

--- a/extensions/positron-skills/templates/positron-settings/references/providers.md
+++ b/extensions/positron-skills/templates/positron-settings/references/providers.md
@@ -65,8 +65,10 @@ provider) and needs no filtering.
    - `authStateUnavailable: true` means no sign-in state exists in this window
      at all. Report which providers are enabled and say sign-in state is
      unavailable; do not call anything signed out.
-   - `catalogStatus: 'error'` means the catalog could not be read and
-     enablement verdicts are best-effort; say so.
+   - A `catalogStatus` other than `'ready'` means the provider catalog could
+     not be read (or had not loaded yet). Entries then omit `enabled`
+     entirely: report sign-in state, say enablement is unknown, and never
+     read a missing `enabled` as disabled.
 6. `maturity` ('preview' or 'experimental') and `custom` (a provider the user
    defined themselves) are worth a parenthetical when present, not a section.
 
@@ -79,9 +81,10 @@ provider) and needs no filtering.
    [configuration.md]({{skill_dir}}/references/configuration.md) (`ai.enabled`
    and `assistant.enabled` both gate Posit Assistant).
 3. `customizedConnection` naming `baseUrl` or an `aws.*`/`snowflake.*` field
-   is a lead worth mentioning: a customized endpoint that stopped resolving
-   looks like an auth failure. The payload never carries the value; have the
-   user check providers.json.
+   is a lead worth mentioning: it means the user or an administrator changed
+   that field from this build's default (a stock install reports none), and a
+   customized endpoint that stopped resolving looks like an auth failure. The
+   payload never carries the value; have the user check providers.json.
 
 ## When this payload disagrees with another view
 

--- a/extensions/positron-skills/templates/positron-settings/references/providers.md
+++ b/extensions/positron-skills/templates/positron-settings/references/providers.md
@@ -1,0 +1,103 @@
+# Positron AI provider status
+
+Finding out which AI language model providers the user has set up: enabled or
+disabled in the provider catalog, signed in or not, and healthy or failing.
+See [SKILL.md]({{skill_dir}}/SKILL.md) for how to call commands, how to handle
+failures, and how to read a truncated result.
+
+The **Returns** entry below is generated from the running build's command
+metadata, so it always matches this Positron. The surrounding guidance is
+hand-written.
+
+## What "enabled" means here
+
+Users say "enabled" to mean several different facts. The payload keeps them
+separate, and so should the answer:
+
+- **Enabled**: the provider catalog allows this provider (`enabled: true`).
+  Administrator enforcement is already folded in.
+- **Signed in** (`auth: 'signed-in'`): a credential resolves right now.
+- **Usable**: both of the above. This is usually what the user is really
+  asking. A provider that is enabled but `not-signed-in` is offered, not set
+  up; one whose `auth` is `'error'` was set up and is now broken, which is
+  worth calling out even when the user did not ask.
+
+## Anti-patterns
+
+Each row below is a move that was actually observed going wrong. Do not remove
+a row without checking its reason still cannot happen.
+
+| Do not | Because (observed) |
+|---|---|
+| point the user at `~/.posit/assistant/settings.json` for provider configuration | Observed, and factually wrong: that file is Posit Assistant's own settings and holds no provider config. Providers live in the provider catalog (providers.json), and even that file is not the resolved answer -- this command is. |
+| read providers.json, or any file, to answer which providers are enabled | The file's location differs by deployment, administrator-enforced layers overlay it, and no file carries sign-in state. The payload reports the resolved verdict with all of that folded in. |
+| send the user to the model picker or the Configure Providers UI instead of answering | Observed: "finding your configured providers is easy:" followed by click-path directions, in place of the answer. Query, answer, and mention the UI only as the place to change things. |
+| say "I can't directly inspect your settings from here" | Observed, and false once this skill is loaded. |
+| report a provider as signed out because its entry has no `auth` field | Absence means unknown, not signed out. Say sign-in state is unknown for that provider. |
+| guess at a customized base URL or connection value | `customizedConnection` carries field names only, deliberately. If the user needs the value, direct them to open providers.json (the "Open AI Provider Settings (JSON)" command), never invent one. |
+
+## Reading provider status
+
+### `positronAssistant.getProviderStatus`
+
+Reports every provider this window knows, with the catalog's enablement
+verdict and live sign-in state -- the same state the Configure Language Model
+Providers UI renders. No arguments; the payload is small (one entry per
+provider) and needs no filtering.
+
+{{command:positronAssistant.getProviderStatus}}
+
+**Worked flow -- "which providers do I have enabled / set up?":**
+
+1. Call `positronAssistant.getProviderStatus`.
+2. Lead with the usable providers: `enabled: true` and `auth: 'signed-in'`,
+   named by `displayName` (fall back to `id`). Note `completionsOnly`
+   providers separately -- GitHub Copilot serves inline completions, not chat,
+   so it does not answer "which providers can I chat with".
+3. Call out any `auth: 'error'` entry even when the user did not ask: the
+   provider is configured but not working, `authMessage` says why, and
+   re-authenticating (via the Configure Language Model Providers UI) is the
+   fix. The list is already ordered so these come first.
+4. Distinguish the rest honestly: enabled but `not-signed-in` means offered
+   and never set up; `enabled: false` means turned off in the catalog, by the
+   user or by an administrator -- the payload cannot say which.
+5. Check the honesty fields before asserting anything:
+   - `authStateUnavailable: true` means no sign-in state exists in this window
+     at all. Report which providers are enabled and say sign-in state is
+     unavailable; do not call anything signed out.
+   - `catalogStatus: 'error'` means the catalog could not be read and
+     enablement verdicts are best-effort; say so.
+6. `maturity` ('preview' or 'experimental') and `custom` (a provider the user
+   defined themselves) are worth a parenthetical when present, not a section.
+
+**Worked flow -- "why isn't provider X working?":**
+
+1. Find X's entry. `enabled: false` or `auth: 'error'` (with `authMessage`) is
+   usually the whole answer.
+2. If X is enabled and signed in but chat still fails, the problem is not
+   provider status; check the AI feature switches in
+   [configuration.md]({{skill_dir}}/references/configuration.md) (`ai.enabled`
+   and `assistant.enabled` both gate Posit Assistant).
+3. `customizedConnection` naming `baseUrl` or an `aws.*`/`snowflake.*` field
+   is a lead worth mentioning: a customized endpoint that stopped resolving
+   looks like an auth failure. The payload never carries the value; have the
+   user check providers.json.
+
+## When this payload disagrees with another view
+
+An extension (including the Posit Assistant) may resolve providers.json on its
+own and reach a different list -- a stale environment snapshot, a different
+profile. This command's payload is the authoritative view for enablement and
+usability, because only the Positron side sees both the resolved catalog and
+the live credential state. Do not blend the two views; report this payload and
+note the discrepancy if one is visible.
+
+## What this command does not report
+
+- **Models.** It reports providers, not the models each one serves. The model
+  picker (and the Assistant itself) already knows the available models; do not
+  present a provider list as a model list.
+- **Connection values.** Field names only, never URLs, hosts, accounts, or
+  header values.
+- **Who disabled a provider.** `enabled: false` does not distinguish the user
+  from an administrator.

--- a/extensions/positron-skills/templates/positron-settings/references/providers.md
+++ b/extensions/positron-skills/templates/positron-settings/references/providers.md
@@ -17,10 +17,12 @@ separate, and so should the answer:
 - **Enabled**: the provider catalog allows this provider (`enabled: true`).
   Administrator enforcement is already folded in.
 - **Signed in** (`auth: 'signed-in'`): a credential resolves right now.
-- **Usable**: both of the above. This is usually what the user is really
-  asking. A provider that is enabled but `not-signed-in` is offered, not set
-  up; one whose `auth` is `'error'` was set up and is now broken, which is
-  worth calling out even when the user did not ask.
+- **Healthy**: no `problem` field. `problem` means the provider itself
+  reported an issue with its configuration or credentials, whatever its
+  sign-in state, and is worth calling out even when the user did not ask.
+- **Usable**: all three. This is usually what the user is really asking. A
+  provider that is enabled but `not-signed-in` with no `problem` is offered,
+  not set up.
 
 ## Anti-patterns
 
@@ -50,17 +52,23 @@ provider) and needs no filtering.
 **Worked flow -- "which providers do I have enabled / set up?":**
 
 1. Call `positronAssistant.getProviderStatus`.
-2. Lead with the usable providers: `enabled: true` and `auth: 'signed-in'`,
-   named by `displayName` (fall back to `id`). Note `completionsOnly`
-   providers separately -- GitHub Copilot serves inline completions, not chat,
-   so it does not answer "which providers can I chat with".
-3. Call out any `auth: 'error'` entry even when the user did not ask: the
-   provider is configured but not working, `authMessage` says why, and
-   re-authenticating (via the Configure Language Model Providers UI) is the
-   fix. The list is already ordered so these come first.
-4. Distinguish the rest honestly: enabled but `not-signed-in` means offered
-   and never set up; `enabled: false` means turned off in the catalog, by the
-   user or by an administrator -- the payload cannot say which.
+2. Lead with the usable providers: `enabled: true`, `auth: 'signed-in'`, and
+   no `problem`, named by `displayName` (fall back to `id`). An entry with
+   `completionsOnly: true` serves inline completions, not chat, so note it
+   separately from the chat answer -- but decide that from the flag only.
+   Treat every other entry as chat-capable; never demote a provider by name.
+3. Call out any entry carrying `problem` even when the user did not ask: the
+   provider reported an issue with its configuration or credentials, and
+   `problem` is its own words. Read it together with `auth`: `not-signed-in`
+   with a problem like "Authentication expired" means re-authenticating (via
+   the Configure Language Model Providers UI) is the likely fix; `signed-in`
+   with a problem means the credential works and the issue is configuration,
+   so do not send the user to re-authenticate. The list is already ordered so
+   problem entries come first.
+4. Distinguish the rest honestly: enabled but `not-signed-in` means no
+   credential resolves (never set up, or signed out); `enabled: false` means
+   turned off in the catalog, by the user or by an administrator -- the
+   payload cannot say which.
 5. Check the honesty fields before asserting anything:
    - `authStateUnavailable: true` means no sign-in state exists in this window
      at all. Report which providers are enabled and say sign-in state is
@@ -74,10 +82,11 @@ provider) and needs no filtering.
 
 **Worked flow -- "why isn't provider X working?":**
 
-1. Find X's entry. `enabled: false` or `auth: 'error'` (with `authMessage`) is
-   usually the whole answer.
-2. If X is enabled and signed in but chat still fails, the problem is not
-   provider status; check the AI feature switches in
+1. Find X's entry. `enabled: false` or a `problem` field is usually the whole
+   answer -- and `problem` with `not-signed-in` points at credentials, while
+   `problem` with `signed-in` points at configuration.
+2. If X is enabled, signed in, and healthy but chat still fails, the cause is
+   not provider status; check the AI feature switches in
    [configuration.md]({{skill_dir}}/references/configuration.md) (`ai.enabled`
    and `assistant.enabled` both gate Posit Assistant).
 3. `customizedConnection` naming `baseUrl` or an `aws.*`/`snowflake.*` field

--- a/src/vs/platform/positronAiProvider/common/aiProviderCatalog.ts
+++ b/src/vs/platform/positronAiProvider/common/aiProviderCatalog.ts
@@ -69,12 +69,32 @@ export interface IResolvedModelsData {
 	readonly custom?: IResolvedCustomModelData[];
 }
 
-/** Mirrors ai-config's ResolvedProvider (id, enabled, connection, model policy). */
+/**
+ * Mirrors ai-config's ResolvedProvider (id, enabled, connection, model
+ * policy), plus two fields computed node-side rather than mirrored: `custom`
+ * and `customizedConnection` need ai-config's provider registry and built-in
+ * connection defaults, which only the node host can import, while their
+ * consumers live in the renderer.
+ */
 export interface IResolvedProviderData {
 	readonly id: string;
 	readonly enabled: boolean;
 	readonly connection: IResolvedConnectionData;
 	readonly models?: IResolvedModelsData;
+
+	/** Present, and true, only for a provider from a custom providers.json entry. */
+	readonly custom?: boolean;
+
+	/**
+	 * Dotted names of the connection fields whose resolved value differs from
+	 * ai-config's built-in default for this provider, e.g. 'baseUrl' or
+	 * 'aws.profile'. The resolved connection alone cannot answer "did the user
+	 * customize this": ai-config layers built-in defaults (a stock positai
+	 * entry resolves a baseUrl the user never wrote) under the user/enforced
+	 * config, and only the node side can import those defaults to diff
+	 * against. Omitted when nothing differs, so a stock install reports none.
+	 */
+	readonly customizedConnection?: readonly string[];
 }
 
 /** Mirrors ai-config's ProviderCatalogChange. */

--- a/src/vs/platform/positronAiProvider/node/aiProviderCatalog.ts
+++ b/src/vs/platform/positronAiProvider/node/aiProviderCatalog.ts
@@ -8,7 +8,13 @@ import { Emitter, Event } from '../../../base/common/event.js';
 import { Disposable, toDisposable } from '../../../base/common/lifecycle.js';
 import { URI } from '../../../base/common/uri.js';
 import { ILogService } from '../../log/common/log.js';
-import { IAiProviderCatalog, IProviderCatalogChangeData, IResolvedProviderData } from '../common/aiProviderCatalog.js';
+import { IAiProviderCatalog, IProviderCatalogChangeData, IResolvedConnectionData, IResolvedProviderData } from '../common/aiProviderCatalog.js';
+
+/** The slice of the ai-config module {@link toProviderData} needs. */
+interface IProviderMappingContext {
+	isBuiltinProviderId(id: string): boolean;
+	readonly PROVIDER_CONNECTION_DEFAULTS: Readonly<Record<string, IResolvedConnectionData | undefined>>;
+}
 
 /**
  * Owns the ai-config catalog lifecycle node-side: initial load, file/env
@@ -59,8 +65,9 @@ export class AiProviderCatalog extends Disposable implements IAiProviderCatalog 
 	private async startCatalog(): Promise<readonly IResolvedProviderData[]> {
 		const aiConfig = await import('ai-config/node');
 		const opts = this.loadOptions();
+		const map = (provider: ResolvedProvider) => toProviderData(provider, aiConfig);
 		const watcher = aiConfig.watchResolvedProviderCatalog((change: ProviderCatalogChange) => {
-			this._catalog = change.catalog.map(toProviderData);
+			this._catalog = change.catalog.map(map);
 			this._onDidChangeCatalog.fire({
 				catalog: this._catalog,
 				enabledChanged: change.enabledChanged,
@@ -71,7 +78,7 @@ export class AiProviderCatalog extends Disposable implements IAiProviderCatalog 
 		this._register(toDisposable(() => watcher.dispose()));
 		const catalog = await aiConfig.loadResolvedProviderCatalog(opts);
 		// Don't let the stale initial load overwrite a change that raced it.
-		return this._catalog ?? catalog.map(toProviderData);
+		return this._catalog ?? catalog.map(map);
 	}
 
 	getConfigFileUri(): Promise<URI> {
@@ -82,8 +89,9 @@ export class AiProviderCatalog extends Disposable implements IAiProviderCatalog 
 	}
 }
 
-function toProviderData(provider: ResolvedProvider): IResolvedProviderData {
+function toProviderData(provider: ResolvedProvider, aiConfig: IProviderMappingContext): IResolvedProviderData {
 	const connection = provider.connection;
+	const builtin = aiConfig.isBuiltinProviderId(provider.id);
 	return {
 		id: provider.id,
 		enabled: provider.enabled,
@@ -97,5 +105,53 @@ function toProviderData(provider: ResolvedProvider): IResolvedProviderData {
 			databricks: connection.databricks,
 		},
 		models: provider.models,
+		custom: builtin ? undefined : true,
+		customizedConnection: customizedConnectionFields(
+			connection,
+			builtin ? aiConfig.PROVIDER_CONNECTION_DEFAULTS[provider.id] : undefined,
+		),
 	};
+}
+
+/**
+ * The connection fields whose resolved value differs from the provider's
+ * built-in defaults, as dotted names. The resolved connection alone reads as
+ * "customized" on a stock install, because ai-config layers built-in defaults
+ * (positai's baseUrl, ollama's endpoint, google-vertex's location) under the
+ * user/enforced config; diffing against those defaults recovers "set by the
+ * user or an administrator". For a custom provider there are no defaults, so
+ * every set field counts -- accurate, since its whole connection is
+ * user-defined. Names only: no value this function reads reaches its result.
+ * @param connection The provider's resolved connection.
+ * @param defaults ai-config's built-in defaults for the provider, when it has any.
+ */
+export function customizedConnectionFields(
+	connection: IResolvedConnectionData,
+	defaults: IResolvedConnectionData | undefined,
+): string[] | undefined {
+	const fields: string[] = [];
+	if (connection.baseUrl !== undefined && connection.baseUrl !== defaults?.baseUrl) {
+		fields.push('baseUrl');
+	}
+	if (connection.endpoint !== undefined && connection.endpoint !== defaults?.endpoint) {
+		fields.push('endpoint');
+	}
+	// No built-in default carries headers, so any non-empty map is the user's.
+	if (connection.customHeaders && Object.keys(connection.customHeaders).length > 0) {
+		fields.push('customHeaders');
+	}
+	const groups: Record<string, [Record<string, unknown> | undefined, Record<string, unknown> | undefined]> = {
+		aws: [connection.aws, defaults?.aws],
+		googleCloud: [connection.googleCloud, defaults?.googleCloud],
+		snowflake: [connection.snowflake, defaults?.snowflake],
+		databricks: [connection.databricks, defaults?.databricks],
+	};
+	for (const [group, [values, defaultValues]] of Object.entries(groups)) {
+		for (const [name, value] of Object.entries(values ?? {})) {
+			if (value !== undefined && value !== defaultValues?.[name]) {
+				fields.push(`${group}.${name}`);
+			}
+		}
+	}
+	return fields.length > 0 ? fields : undefined;
 }

--- a/src/vs/platform/positronAiProvider/test/node/customizedConnectionFields.vitest.ts
+++ b/src/vs/platform/positronAiProvider/test/node/customizedConnectionFields.vitest.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { customizedConnectionFields } from '../../node/aiProviderCatalog.js';
+
+describe('customizedConnectionFields', () => {
+	it('reports nothing when the resolved connection only carries the built-in defaults', () => {
+		// A stock install: ai-config layers the provider's defaults into the
+		// resolved connection even though the user never wrote them. That must
+		// not read as a customization.
+		expect(customizedConnectionFields(
+			{ baseUrl: 'https://gateway.posit.ai', googleCloud: { location: 'us-central1' } },
+			{ baseUrl: 'https://gateway.posit.ai', googleCloud: { location: 'us-central1' } },
+		)).toBeUndefined();
+	});
+
+	it('reports only the fields that differ from the defaults', () => {
+		expect(customizedConnectionFields(
+			{
+				baseUrl: 'https://gateway.example.corp',
+				googleCloud: { location: 'us-central1', project: 'my-project' },
+			},
+			{ baseUrl: 'https://gateway.posit.ai', googleCloud: { location: 'us-central1' } },
+		)).toEqual(['baseUrl', 'googleCloud.project']);
+	});
+
+	it('reports every set field for a provider with no defaults, e.g. a custom entry', () => {
+		expect(customizedConnectionFields(
+			{
+				baseUrl: 'https://gateway.example.corp',
+				customHeaders: { 'X-Route': 'a' },
+				aws: { profile: 'work', region: undefined },
+			},
+			undefined,
+		)).toEqual(['baseUrl', 'customHeaders', 'aws.profile']);
+	});
+
+	it('treats an empty customHeaders map and an untouched connection as nothing to report', () => {
+		expect(customizedConnectionFields({ customHeaders: {} }, undefined)).toBeUndefined();
+		expect(customizedConnectionFields({}, undefined)).toBeUndefined();
+	});
+});

--- a/src/vs/workbench/contrib/positronAiFeatures/test/browser/agentSkillDrift.vitest.ts
+++ b/src/vs/workbench/contrib/positronAiFeatures/test/browser/agentSkillDrift.vitest.ts
@@ -55,7 +55,7 @@ const CANDIDATE_ID_PATTERN = /^[A-Za-z][A-Za-z0-9]*(?:\.[A-Za-z][A-Za-z0-9]*)+$/
  * `vscode.open`: not every command the skill names is Positron's own, and an
  * upstream rename would break the skill just as surely as a Positron one.
  */
-const ALLOWED_PREFIXES = ['positron.', 'positronPackages.', 'positronSettings.', 'positronVariables.', 'vscode.', 'workbench.'];
+const ALLOWED_PREFIXES = ['positron.', 'positronAssistant.', 'positronPackages.', 'positronSettings.', 'positronVariables.', 'vscode.', 'workbench.'];
 
 /**
  * Command ids referenced by the templates that are registered from extension

--- a/src/vs/workbench/contrib/positronAssistant/browser/positronAssistant.contribution.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/positronAssistant.contribution.ts
@@ -37,6 +37,9 @@ import { AI_ENABLED_KEY } from '../common/positronAIConfiguration.js';
 // `positron.assistant.inlineCompletions.enable` setting to `github.copilot.enable`.
 import './inlineCompletionsMigration.js';
 
+// Register the agent-compatible `positronAssistant.getProviderStatus` command.
+import './providerStatusCommand.js';
+
 // Register the commit message generation feature.
 registerCommitMessageGeneration();
 

--- a/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
@@ -174,6 +174,10 @@ export class PositronAssistantConfigurationService extends Disposable implements
 		return sources;
 	}
 
+	getProviderRegistrations(): IPositronLanguageModelSource[] {
+		return [...this._providerRegistrations.values()];
+	}
+
 	get copilotEnabled(): boolean {
 		return this._copilotEnabled;
 	}

--- a/src/vs/workbench/contrib/positronAssistant/browser/providerStatusCommand.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/providerStatusCommand.ts
@@ -34,10 +34,12 @@ export interface IProviderStatusEntry {
 	enabled: boolean;
 
 	/**
-	 * Present only for an enabled provider that has registered its sign-in
-	 * state with this window. Absent means unknown, never "signed out": a
-	 * disabled provider's sign-in state is moot (the authentication extension
-	 * drops its sessions), and a catalog-only entry has nothing to report.
+	 * Present only for an enabled provider whose sign-in state has actually
+	 * been reported to this window. Absent means unknown, never "signed out":
+	 * a disabled provider's sign-in state is moot (the authentication
+	 * extension drops its sessions), a catalog-only entry has nothing to
+	 * report, and a registration the initial session sweep has not reached
+	 * yet carries no verdict.
 	 */
 	auth?: ProviderAuthState;
 
@@ -127,13 +129,32 @@ function customizedConnectionFields(connection: IResolvedConnectionData): string
  * authentication extension's verdict: 'error' means configured but the
  * credential no longer resolves (e.g. expired), which must not read as a
  * fresh, never-configured provider.
+ *
+ * Returns undefined when the registration carries no verdict yet: the
+ * authentication extension registers providers first and sweeps sessions
+ * afterward, so during activation `signedIn` is still unset. Unknown must not
+ * read as 'not-signed-in' -- that is this payload's own absence-is-not-signed-
+ * out rule, applied to its input.
  * @param source The provider's registered source.
  */
-function authState(source: IPositronLanguageModelSource): ProviderAuthState {
+function authState(source: IPositronLanguageModelSource): ProviderAuthState | undefined {
 	if (source.status === 'error') {
 		return 'error';
 	}
+	if (source.signedIn === undefined) {
+		return undefined;
+	}
 	return source.signedIn ? 'signed-in' : 'not-signed-in';
+}
+
+/**
+ * Whether a registration carries any sign-in verdict at all. The initial
+ * session sweep sets `signedIn` (and `status`) on every registered provider,
+ * so a registration with neither has not been swept yet.
+ * @param source The provider's registered source.
+ */
+function hasAuthState(source: IPositronLanguageModelSource): boolean {
+	return source.signedIn !== undefined || source.status !== undefined;
 }
 
 /**
@@ -209,10 +230,16 @@ export async function getProviderStatus(accessor: ServicesAccessor): Promise<IPr
 				: entry.enabled ? 2 : 3;
 	providers.sort((a, b) => interest(a) - interest(b) || a.id.localeCompare(b.id));
 
+	// Sign-in state is unavailable both when nothing has registered at all
+	// (authentication extension missing) and when registrations exist but none
+	// has been swept yet (extension still activating): in either case no entry
+	// carries an auth verdict, and the caller must not read that as signed out.
+	const authStateUnavailable = !registrations.some(hasAuthState);
+
 	return {
 		catalogStatus: aiProviderService.status,
 		providers,
-		authStateUnavailable: registrations.length === 0 ? true : undefined,
+		authStateUnavailable: authStateUnavailable ? true : undefined,
 	};
 }
 

--- a/src/vs/workbench/contrib/positronAssistant/browser/providerStatusCommand.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/providerStatusCommand.ts
@@ -1,0 +1,247 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../../nls.js';
+import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
+import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { IResolvedConnectionData } from '../../../../platform/positronAiProvider/common/aiProviderCatalog.js';
+import { AiProviderServiceStatus, IAiProviderService } from '../../../services/positronAiProvider/common/aiProviderService.js';
+import { IPositronAssistantConfigurationService, IPositronLanguageModelSource, PositronLanguageModelType } from '../common/interfaces/positronAssistantService.js';
+
+/** How far a provider's sign-in has gotten, as this payload reports it. */
+export type ProviderAuthState = 'signed-in' | 'not-signed-in' | 'error';
+
+/** One AI provider, as the getProviderStatus command reports it. */
+export interface IProviderStatusEntry {
+	/**
+	 * The provider's id in the resolved provider catalog (providers.json), e.g.
+	 * 'anthropic' or 'bedrock'; for a custom provider, the entry name the user
+	 * chose. Falls back to the registration id when the registration declares
+	 * no catalog id.
+	 */
+	id: string;
+
+	/** The name the UI shows, when the provider registered one. */
+	displayName?: string;
+
+	/**
+	 * The catalog's enablement verdict, with administrator-enforced layers
+	 * already folded in. Always carried: it is the core fact of every entry,
+	 * so absence semantics would cost more prose than the byte saves.
+	 */
+	enabled: boolean;
+
+	/**
+	 * Present only for an enabled provider that has registered its sign-in
+	 * state with this window. Absent means unknown, never "signed out": a
+	 * disabled provider's sign-in state is moot (the authentication extension
+	 * drops its sessions), and a catalog-only entry has nothing to report.
+	 */
+	auth?: ProviderAuthState;
+
+	/** The auth failure, e.g. 'Authentication expired'. Present only when auth is 'error'. */
+	authMessage?: string;
+
+	/** Present only for a provider not yet stable: 'preview' or 'experimental'. */
+	maturity?: 'preview' | 'experimental';
+
+	/** Present, and true, only for a provider from a custom providers.json entry. */
+	custom?: boolean;
+
+	/**
+	 * Present, and true, only when the provider serves inline completions
+	 * rather than chat (GitHub Copilot).
+	 */
+	completionsOnly?: boolean;
+
+	/**
+	 * Names of the connection fields customized in the provider catalog, e.g.
+	 * 'baseUrl' or 'aws.profile'. Field names only, never values: this payload
+	 * enters a transcript that leaves the machine unreviewed, and a base URL
+	 * or account name can reveal internal endpoints. The name is enough to
+	 * answer "is my connection customized"; for the value itself, the user
+	 * opens providers.json.
+	 */
+	customizedConnection?: string[];
+}
+
+/** What the getProviderStatus command returns. */
+export interface IProviderStatusResult {
+	/**
+	 * The provider catalog's lifecycle: 'ready' when the resolved catalog has
+	 * been read, 'error' when it could not be, 'initializing' before the first
+	 * fetch attempt completes. On 'error' the catalog is absent, and enablement
+	 * falls back to treating providers the catalog has never heard of as
+	 * enabled, so a caller should hedge enablement claims.
+	 */
+	catalogStatus: AiProviderServiceStatus;
+
+	providers: IProviderStatusEntry[];
+
+	/**
+	 * Present, and true, only when no provider has registered sign-in state
+	 * with this window at all (the authentication extension is missing or has
+	 * not finished activating). Every entry then lacks `auth`, and the safe
+	 * statement is which providers are enabled, not which are signed in.
+	 */
+	authStateUnavailable?: boolean;
+}
+
+/**
+ * The connection fields a catalog entry customizes, flattened to dotted names.
+ * Names only, by construction: no value read here ever reaches the payload, so
+ * this command needs no redaction pass -- there is nothing to redact.
+ * @param connection The provider's resolved connection data.
+ */
+function customizedConnectionFields(connection: IResolvedConnectionData): string[] | undefined {
+	const fields: string[] = [];
+	if (connection.baseUrl !== undefined) {
+		fields.push('baseUrl');
+	}
+	if (connection.endpoint !== undefined) {
+		fields.push('endpoint');
+	}
+	if (connection.customHeaders && Object.keys(connection.customHeaders).length > 0) {
+		fields.push('customHeaders');
+	}
+	const groups: Record<string, Record<string, unknown> | undefined> = {
+		aws: connection.aws,
+		googleCloud: connection.googleCloud,
+		snowflake: connection.snowflake,
+		databricks: connection.databricks,
+	};
+	for (const [group, values] of Object.entries(groups)) {
+		for (const [name, value] of Object.entries(values ?? {})) {
+			if (value !== undefined) {
+				fields.push(`${group}.${name}`);
+			}
+		}
+	}
+	return fields.length > 0 ? fields : undefined;
+}
+
+/**
+ * A registration's sign-in state as the payload's vocabulary. `status` is the
+ * authentication extension's verdict: 'error' means configured but the
+ * credential no longer resolves (e.g. expired), which must not read as a
+ * fresh, never-configured provider.
+ * @param source The provider's registered source.
+ */
+function authState(source: IPositronLanguageModelSource): ProviderAuthState {
+	if (source.status === 'error') {
+		return 'error';
+	}
+	return source.signedIn ? 'signed-in' : 'not-signed-in';
+}
+
+/**
+ * Reports every AI language model provider this window knows: the catalog's
+ * enablement verdict, live sign-in state, and whether the connection is
+ * customized.
+ *
+ * Reads renderer state only, on purpose. Sign-in state is the same
+ * registration data the Configure Language Model Providers modal renders
+ * (pushed by the authentication extension at activation and kept fresh on
+ * every session change), and enablement comes from the warmed catalog
+ * snapshot, so this command answers synchronously once the catalog service
+ * has initialized -- no extension-host round trip, no network, no timeouts.
+ * That also makes this payload authoritative over anything an extension
+ * resolves from providers.json on its own: only the host side sees both the
+ * resolved catalog and the credential state.
+ * @param accessor The command's services accessor.
+ */
+export async function getProviderStatus(accessor: ServicesAccessor): Promise<IProviderStatusResult> {
+	const aiProviderService = accessor.get(IAiProviderService);
+	const assistantConfigurationService = accessor.get(IPositronAssistantConfigurationService);
+
+	// The first catalog fetch attempt; resolves on failure too, never rejects.
+	await aiProviderService.whenInitialized;
+
+	const registrations = assistantConfigurationService.getProviderRegistrations();
+	const providers: IProviderStatusEntry[] = [];
+	const coveredCatalogIds = new Set<string>();
+
+	for (const source of registrations) {
+		// The catalog resolves enablement by this same fallback (a registration
+		// without a declared catalogId is looked up by its own id).
+		const catalogId = source.provider.catalogId ?? source.provider.id;
+		coveredCatalogIds.add(catalogId);
+		const enabled = assistantConfigurationService.isProviderEnabled(source.provider.id);
+		const connection = aiProviderService.getProvider(catalogId)?.connection;
+		providers.push({
+			id: catalogId,
+			displayName: source.provider.displayName,
+			enabled,
+			auth: enabled ? authState(source) : undefined,
+			authMessage: enabled && source.status === 'error' ? source.statusMessage : undefined,
+			maturity: source.provider.status,
+			custom: source.provider.customKind !== undefined ? true : undefined,
+			completionsOnly: source.type === PositronLanguageModelType.Completion ? true : undefined,
+			customizedConnection: connection ? customizedConnectionFields(connection) : undefined,
+		});
+	}
+
+	// Catalog entries nothing has registered a source for: a providers.json
+	// entry for a provider this window does not offer, or any entry when the
+	// authentication extension has not activated. Known to exist and worth
+	// reporting, but with no sign-in state to carry.
+	for (const provider of aiProviderService.getProviders()) {
+		if (coveredCatalogIds.has(provider.id)) {
+			continue;
+		}
+		providers.push({
+			id: provider.id,
+			enabled: provider.enabled,
+			customizedConnection: customizedConnectionFields(provider.connection),
+		});
+	}
+
+	// Most interesting entries first, so a transport that truncates a large
+	// payload by keeping an array's leading elements sheds the boring tail:
+	// auth failures (worth a warning), then the signed-in providers (the
+	// answer to "which providers do I have"), then other enabled providers,
+	// then disabled ones. Alphabetical within each band.
+	const interest = (entry: IProviderStatusEntry): number =>
+		entry.auth === 'error' ? 0
+			: entry.auth === 'signed-in' ? 1
+				: entry.enabled ? 2 : 3;
+	providers.sort((a, b) => interest(a) - interest(b) || a.id.localeCompare(b.id));
+
+	return {
+		catalogStatus: aiProviderService.status,
+		providers,
+		authStateUnavailable: registrations.length === 0 ? true : undefined,
+	};
+}
+
+// The id of the payload command, matching every other agentCompatible command in
+// the workbench: one command per payload, carrying its own return contract.
+export const ASSISTANT_GET_PROVIDER_STATUS_COMMAND_ID = 'positronAssistant.getProviderStatus';
+
+// Registered through CommandsRegistry rather than registerAction2, so it takes no
+// Command Palette slot and has no precondition: it always appears in
+// getAgentAllowedCommands() and never vanishes mid-session. There is no state in
+// which it has nothing to say -- with no catalog and no registrations, saying so
+// IS the payload.
+//
+// Deliberately not gated on the ai.enabled main switch, for the reasons written
+// down at positronPackagesCommands.ts:17-28 and applied to the settings commands
+// before this one: it reports the user's own environment, it does not call a
+// model or surface an AI action, and the callers that matter are themselves
+// gated. With every provider disabled by policy, reporting exactly that is this
+// command doing its job.
+CommandsRegistry.registerCommand({
+	id: ASSISTANT_GET_PROVIDER_STATUS_COMMAND_ID,
+	handler: getProviderStatus,
+	metadata: {
+		description: localize(
+			'positron.assistant.getProviderStatus.description',
+			"Report the AI language model providers this Positron knows: which are enabled in the provider catalog, which the user is signed in to right now, and which are configured but failing to authenticate. Changes nothing and shows the user nothing. Reads live state, not any file, so it is correct on desktop, on the web, over a remote connection, and on Posit Workbench."
+		),
+		// Advertise this command to AI agents (positron.ai.getAgentAllowedCommands).
+		agentCompatible: true,
+		returns: 'An object with catalogStatus, providers, and sometimes authStateUnavailable. catalogStatus is the provider catalog\'s lifecycle: \'ready\' when the resolved catalog (providers.json plus any administrator-enforced layers) has been read, \'error\' when it could not be (enablement then falls back to treating providers the catalog has never heard of as enabled, so hedge enablement claims), \'initializing\' if the first fetch has not completed. providers is one entry per known provider, ordered most-noteworthy first: providers whose auth is \'error\', then signed-in providers, then other enabled providers, then disabled ones. Each entry carries: id, the provider\'s name in the provider catalog, which for a custom provider is the entry name the user chose; displayName, the name the UI shows, when the provider registered one; enabled, the catalog\'s verdict, with administrator-enforced layers already folded in -- false means turned off in providers.json or by an administrator, and sign-in state is then not reported, since a disabled provider is unusable regardless. auth is present only for an enabled provider that has registered its sign-in state with this window: \'signed-in\' means a credential resolves right now and the provider is usable; \'error\' means the provider was configured but its credential no longer resolves, so it is NOT usable until the user re-authenticates, with authMessage carrying the reason (e.g. \'Authentication expired\'); \'not-signed-in\' means offered but never set up. An entry with no auth field has UNKNOWN sign-in state -- absence is not \'signed out\'. maturity is present only for a provider that is not yet stable (\'preview\' or \'experimental\'); custom is present and true only for a provider defined by a custom providers.json entry; completionsOnly is present and true only when the provider serves inline completions rather than chat (GitHub Copilot). customizedConnection lists the names of connection fields customized in the provider catalog (e.g. \'baseUrl\', \'aws.profile\', \'customHeaders\') -- names only, never values, deliberately: if the user needs the actual URL or value, direct them to open providers.json rather than guessing at it. authStateUnavailable is present and true only when NO provider has registered sign-in state in this window (the authentication extension is missing or has not finished activating): every entry then lacks auth, and the safe statement is which providers are enabled, not which are signed in. A provider is usable for chat exactly when enabled is true and auth is \'signed-in\'.',
+	},
+});

--- a/src/vs/workbench/contrib/positronAssistant/browser/providerStatusCommand.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/providerStatusCommand.ts
@@ -10,8 +10,14 @@ import { ServicesAccessor } from '../../../../platform/instantiation/common/inst
 import { AiProviderServiceStatus, IAiProviderService } from '../../../services/positronAiProvider/common/aiProviderService.js';
 import { IPositronAssistantConfigurationService, IPositronLanguageModelSource, PositronLanguageModelType } from '../common/interfaces/positronAssistantService.js';
 
-/** How far a provider's sign-in has gotten, as this payload reports it. */
-export type ProviderAuthState = 'signed-in' | 'not-signed-in' | 'error';
+/**
+ * A provider's sign-in state, as this payload reports it. Sign-in only, on
+ * purpose: provider health is broader than credentials (an unreachable custom
+ * endpoint is a problem for a provider that is signed in), so it travels in
+ * the separate `problem` field rather than being collapsed into a third auth
+ * value that would misread every configuration issue as a credential one.
+ */
+export type ProviderAuthState = 'signed-in' | 'not-signed-in';
 
 /** One AI provider, as the getProviderStatus command reports it. */
 export interface IProviderStatusEntry {
@@ -48,13 +54,18 @@ export interface IProviderStatusEntry {
 	auth?: ProviderAuthState;
 
 	/**
-	 * The auth failure, e.g. 'Authentication expired'. Present only when auth
-	 * is 'error'. Unlike every other field, this is provider-supplied prose
-	 * passed through (first line only, length-capped), not text this command
-	 * constructs -- a credential error can name the endpoint or account it
-	 * failed against, the same text the user's own auth error shows.
+	 * Present when the provider reports a problem with its configuration or
+	 * credentials (its registered status is 'error'), whatever its sign-in
+	 * state: an expired credential reports this alongside 'not-signed-in',
+	 * while a signed-in provider with an unreachable custom endpoint reports
+	 * it alongside 'signed-in'. Carries the provider's own status text (first
+	 * line only, length-capped), or 'unspecified' when it gave none. Unlike
+	 * every other field, the text is provider-supplied prose passed through,
+	 * not constructed by this command -- an error can name the endpoint or
+	 * account it failed against, the same text the user's own error UI shows.
+	 * Omitted for known-disabled providers, whose health is moot.
 	 */
-	authMessage?: string;
+	problem?: string;
 
 	/** Present only for a provider not yet stable: 'preview' or 'experimental'. */
 	maturity?: 'preview' | 'experimental';
@@ -63,8 +74,9 @@ export interface IProviderStatusEntry {
 	custom?: boolean;
 
 	/**
-	 * Present, and true, only when the provider serves inline completions
-	 * rather than chat (GitHub Copilot).
+	 * Present, and true, only when the provider registered as serving inline
+	 * completions rather than chat. Mechanical, from the registration's own
+	 * type: no provider is assumed completion-only by name.
 	 */
 	completionsOnly?: boolean;
 
@@ -113,31 +125,31 @@ export interface IProviderStatusResult {
  */
 const CATALOG_INIT_TIMEOUT_MS = 5000;
 
-/** Cap on the pass-through auth failure text, in characters. */
-const AUTH_MESSAGE_CHAR_CAP = 200;
+/** Cap on the pass-through provider status text, in characters. */
+const PROBLEM_MESSAGE_CHAR_CAP = 200;
 
 /**
- * The auth extension's status text, bounded for a payload: first line only,
+ * The provider's own status text, bounded for a payload: first line only,
  * hard character cap. The text is provider-supplied prose (this command
  * constructs every other field itself), so the bound keeps a chatty SDK error
  * from dumping a stack of detail into the transcript.
  * @param message The registration's statusMessage.
  */
-function summarizeAuthMessage(message: string | undefined): string | undefined {
+function summarizeStatusMessage(message: string | undefined): string | undefined {
 	const firstLine = message?.split('\n', 1)[0].trim();
 	if (!firstLine) {
 		return undefined;
 	}
-	return firstLine.length <= AUTH_MESSAGE_CHAR_CAP
+	return firstLine.length <= PROBLEM_MESSAGE_CHAR_CAP
 		? firstLine
-		: `${firstLine.slice(0, AUTH_MESSAGE_CHAR_CAP - 3).trimEnd()}...`;
+		: `${firstLine.slice(0, PROBLEM_MESSAGE_CHAR_CAP - 3).trimEnd()}...`;
 }
 
 /**
- * A registration's sign-in state as the payload's vocabulary. `status` is the
- * authentication extension's verdict: 'error' means configured but the
- * credential no longer resolves (e.g. expired), which must not read as a
- * fresh, never-configured provider.
+ * A registration's sign-in state as the payload's vocabulary: `signedIn` and
+ * nothing else. The registration's `status` is provider *health* (an expired
+ * credential and an unreachable endpoint both report 'error'), so it feeds
+ * the separate `problem` field rather than this one.
  *
  * Returns undefined when the registration carries no verdict yet: the
  * authentication extension registers providers first and sweeps sessions
@@ -147,9 +159,6 @@ function summarizeAuthMessage(message: string | undefined): string | undefined {
  * @param source The provider's registered source.
  */
 function authState(source: IPositronLanguageModelSource): ProviderAuthState | undefined {
-	if (source.status === 'error') {
-		return 'error';
-	}
 	if (source.signedIn === undefined) {
 		return undefined;
 	}
@@ -210,15 +219,17 @@ export async function getProviderStatus(accessor: ServicesAccessor): Promise<IPr
 		const enabled = catalogKnown
 			? assistantConfigurationService.isProviderEnabled(source.provider.id)
 			: undefined;
-		// Sign-in state is withheld only when the provider is KNOWN disabled;
-		// unknown enablement does not invalidate a live sign-in verdict.
-		const auth = enabled === false ? undefined : authState(source);
+		// Sign-in state and health are withheld only when the provider is
+		// KNOWN disabled; unknown enablement does not invalidate live data.
+		const relevant = enabled !== false;
 		providers.push({
 			id: catalogId,
 			displayName: source.provider.displayName,
 			enabled,
-			auth,
-			authMessage: auth === 'error' ? summarizeAuthMessage(source.statusMessage) : undefined,
+			auth: relevant ? authState(source) : undefined,
+			problem: relevant && source.status === 'error'
+				? (summarizeStatusMessage(source.statusMessage) ?? 'unspecified')
+				: undefined,
 			maturity: source.provider.status,
 			custom: source.provider.customKind !== undefined ? true : undefined,
 			completionsOnly: source.type === PositronLanguageModelType.Completion ? true : undefined,
@@ -246,11 +257,13 @@ export async function getProviderStatus(accessor: ServicesAccessor): Promise<IPr
 
 	// Most interesting entries first, so a transport that truncates a large
 	// payload by keeping an array's leading elements sheds the boring tail:
-	// auth failures (worth a warning), then the signed-in providers (the
-	// answer to "which providers do I have"), then the rest, with
-	// known-disabled ones last. Alphabetical within each band.
+	// providers reporting a problem (worth a warning, whatever their sign-in
+	// state -- the Configure Providers modal groups these as needs-attention
+	// the same way), then the signed-in providers (the answer to "which
+	// providers do I have"), then the rest, with known-disabled ones last.
+	// Alphabetical within each band.
 	const interest = (entry: IProviderStatusEntry): number =>
-		entry.auth === 'error' ? 0
+		entry.problem !== undefined ? 0
 			: entry.auth === 'signed-in' ? 1
 				: entry.enabled !== false ? 2 : 3;
 	providers.sort((a, b) => interest(a) - interest(b) || a.id.localeCompare(b.id));
@@ -294,6 +307,6 @@ CommandsRegistry.registerCommand({
 		),
 		// Advertise this command to AI agents (positron.ai.getAgentAllowedCommands).
 		agentCompatible: true,
-		returns: 'An object with catalogStatus, providers, and sometimes authStateUnavailable. catalogStatus is the provider catalog\'s lifecycle: \'ready\' when the resolved catalog (providers.json plus any administrator-enforced layers) has been read; \'error\' when it could not be; \'initializing\' when the first load had not completed within this command\'s short wait. When catalogStatus is not \'ready\', enablement is unknown: every entry omits enabled rather than guessing, sign-in state is still reported (it comes from live registrations, not the catalog), and the honest phrasing is which providers are signed in, with enablement unknown. providers is one entry per known provider, ordered most-noteworthy first: providers whose auth is \'error\', then signed-in providers, then the rest, with known-disabled ones last. Each entry carries: id, the provider\'s name in the provider catalog, which for a custom provider is the entry name the user chose; displayName, the name the UI shows, when the provider registered one; enabled, the catalog\'s verdict, with administrator-enforced layers already folded in -- false means turned off in providers.json or by an administrator, and sign-in state is then not reported, since a disabled provider is unusable regardless; absent means the catalog could not be read and enablement is unknown, not false. auth is present only for a provider that has registered its sign-in state with this window and is not known-disabled: \'signed-in\' means a credential resolves right now; \'error\' means the provider was configured but its credential no longer resolves, so it is NOT usable until the user re-authenticates, with authMessage carrying the reason (e.g. \'Authentication expired\') -- authMessage is the authentication extension\'s own status text passed through (first line, length-capped), the one field whose wording this command does not construct; \'not-signed-in\' means offered but never set up. An entry with no auth field has UNKNOWN sign-in state -- absence is not \'signed out\'. maturity is present only for a provider that is not yet stable (\'preview\' or \'experimental\'); custom is present and true only for a provider defined by a custom providers.json entry; completionsOnly is present and true only when the provider serves inline completions rather than chat (GitHub Copilot). customizedConnection lists the names of connection fields whose value differs from this build\'s built-in defaults (e.g. \'baseUrl\', \'aws.profile\', \'customHeaders\'), meaning the user or an administrator set them; a stock install reports none, and a provider\'s default endpoint never appears here. Names only, never values, deliberately: if the user needs the actual URL or value, direct them to open providers.json rather than guessing at it. authStateUnavailable is present and true only when NO provider has registered sign-in state in this window (the authentication extension is missing or has not finished activating): every entry then lacks auth, and the safe statement is which providers are enabled, not which are signed in. A provider is usable for chat exactly when enabled is true and auth is \'signed-in\'.',
+		returns: 'An object with catalogStatus, providers, and sometimes authStateUnavailable. catalogStatus is the provider catalog\'s lifecycle: \'ready\' when the resolved catalog (providers.json plus any administrator-enforced layers) has been read; \'error\' when it could not be; \'initializing\' when the first load had not completed within this command\'s short wait. When catalogStatus is not \'ready\', enablement is unknown: every entry omits enabled rather than guessing, sign-in state is still reported (it comes from live registrations, not the catalog), and the honest phrasing is which providers are signed in, with enablement unknown. providers is one entry per known provider, ordered most-noteworthy first: providers reporting a problem, then signed-in providers, then the rest, with known-disabled ones last. Each entry carries: id, the provider\'s name in the provider catalog, which for a custom provider is the entry name the user chose; displayName, the name the UI shows, when the provider registered one; enabled, the catalog\'s verdict, with administrator-enforced layers already folded in -- false means turned off in providers.json or by an administrator, and sign-in state is then not reported, since a disabled provider is unusable regardless; absent means the catalog could not be read and enablement is unknown, not false. auth is present only for a provider that has registered its sign-in state with this window and is not known-disabled: \'signed-in\' means a credential resolves right now; \'not-signed-in\' means no credential resolves (never set up, or signed out). An entry with no auth field has UNKNOWN sign-in state -- absence is not \'signed out\'. problem is present when the provider reports a problem with its configuration or credentials, whatever its sign-in state, carrying the provider\'s own status text (first line, length-capped; \'unspecified\' when it gave none) -- the one field whose wording this command does not construct. Read auth and problem together: \'not-signed-in\' with a problem like \'Authentication expired\' means re-authenticating is the likely fix, while \'signed-in\' with a problem means the credential works and the issue is configuration (e.g. an unreachable custom endpoint), which re-authenticating will not fix -- report the problem text rather than prescribing a remedy the payload does not name. maturity is present only for a provider that is not yet stable (\'preview\' or \'experimental\'); custom is present and true only for a provider defined by a custom providers.json entry; completionsOnly is present and true only when the provider registered as serving inline completions rather than chat -- rely on this flag, never on a provider\'s name, to decide whether it answers a chat question. customizedConnection lists the names of connection fields whose value differs from this build\'s built-in defaults (e.g. \'baseUrl\', \'aws.profile\', \'customHeaders\'), meaning the user or an administrator set them; a stock install reports none, and a provider\'s default endpoint never appears here. Names only, never values, deliberately: if the user needs the actual URL or value, direct them to open providers.json rather than guessing at it. authStateUnavailable is present and true only when NO provider has registered sign-in state in this window (the authentication extension is missing or has not finished activating): every entry then lacks auth, and the safe statement is which providers are enabled, not which are signed in. A provider is usable for chat exactly when enabled is true, auth is \'signed-in\', and no problem is reported.',
 	},
 });

--- a/src/vs/workbench/contrib/positronAssistant/browser/providerStatusCommand.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/providerStatusCommand.ts
@@ -3,10 +3,10 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { raceTimeout } from '../../../../base/common/async.js';
 import { localize } from '../../../../nls.js';
 import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
-import { IResolvedConnectionData } from '../../../../platform/positronAiProvider/common/aiProviderCatalog.js';
 import { AiProviderServiceStatus, IAiProviderService } from '../../../services/positronAiProvider/common/aiProviderService.js';
 import { IPositronAssistantConfigurationService, IPositronLanguageModelSource, PositronLanguageModelType } from '../common/interfaces/positronAssistantService.js';
 
@@ -28,22 +28,32 @@ export interface IProviderStatusEntry {
 
 	/**
 	 * The catalog's enablement verdict, with administrator-enforced layers
-	 * already folded in. Always carried: it is the core fact of every entry,
-	 * so absence semantics would cost more prose than the byte saves.
+	 * already folded in. Absent only when the catalog could not be read
+	 * (catalogStatus is not 'ready'): enablement is then unknown, and
+	 * reporting a guess would be worse than saying so -- the enablement
+	 * fallback treats a provider an unreadable catalog "has never heard of"
+	 * as disabled, the opposite of the documented unknown-means-enabled rule
+	 * for genuinely unlisted providers.
 	 */
-	enabled: boolean;
+	enabled?: boolean;
 
 	/**
-	 * Present only for an enabled provider whose sign-in state has actually
-	 * been reported to this window. Absent means unknown, never "signed out":
-	 * a disabled provider's sign-in state is moot (the authentication
-	 * extension drops its sessions), a catalog-only entry has nothing to
-	 * report, and a registration the initial session sweep has not reached
-	 * yet carries no verdict.
+	 * Present only for a provider whose sign-in state has actually been
+	 * reported to this window and that is not known-disabled. Absent means
+	 * unknown, never "signed out": a disabled provider's sign-in state is
+	 * moot (the authentication extension drops its sessions), a catalog-only
+	 * entry has nothing to report, and a registration the initial session
+	 * sweep has not reached yet carries no verdict.
 	 */
 	auth?: ProviderAuthState;
 
-	/** The auth failure, e.g. 'Authentication expired'. Present only when auth is 'error'. */
+	/**
+	 * The auth failure, e.g. 'Authentication expired'. Present only when auth
+	 * is 'error'. Unlike every other field, this is provider-supplied prose
+	 * passed through (first line only, length-capped), not text this command
+	 * constructs -- a credential error can name the endpoint or account it
+	 * failed against, the same text the user's own auth error shows.
+	 */
 	authMessage?: string;
 
 	/** Present only for a provider not yet stable: 'preview' or 'experimental'. */
@@ -59,24 +69,27 @@ export interface IProviderStatusEntry {
 	completionsOnly?: boolean;
 
 	/**
-	 * Names of the connection fields customized in the provider catalog, e.g.
-	 * 'baseUrl' or 'aws.profile'. Field names only, never values: this payload
-	 * enters a transcript that leaves the machine unreviewed, and a base URL
-	 * or account name can reveal internal endpoints. The name is enough to
-	 * answer "is my connection customized"; for the value itself, the user
-	 * opens providers.json.
+	 * Names of the connection fields whose resolved value differs from this
+	 * build's built-in defaults, e.g. 'baseUrl' or 'aws.profile' -- set by the
+	 * user or an administrator, so a stock install reports none. Computed on
+	 * the node side, which can import the defaults to diff against. Field
+	 * names only, never values: this payload enters a transcript that leaves
+	 * the machine unreviewed, and a base URL or account name can reveal
+	 * internal endpoints. The name is enough to answer "is my connection
+	 * customized"; for the value itself, the user opens providers.json.
 	 */
-	customizedConnection?: string[];
+	customizedConnection?: readonly string[];
 }
 
 /** What the getProviderStatus command returns. */
 export interface IProviderStatusResult {
 	/**
 	 * The provider catalog's lifecycle: 'ready' when the resolved catalog has
-	 * been read, 'error' when it could not be, 'initializing' before the first
-	 * fetch attempt completes. On 'error' the catalog is absent, and enablement
-	 * falls back to treating providers the catalog has never heard of as
-	 * enabled, so a caller should hedge enablement claims.
+	 * been read, 'error' when it could not be, 'initializing' when the first
+	 * load had not completed within this command's bounded wait. When it is
+	 * not 'ready', enablement is unknown and every entry omits `enabled`
+	 * rather than guessing; sign-in state is still reported, since it comes
+	 * from the live registrations, not the catalog.
 	 */
 	catalogStatus: AiProviderServiceStatus;
 
@@ -92,36 +105,32 @@ export interface IProviderStatusResult {
 }
 
 /**
- * The connection fields a catalog entry customizes, flattened to dotted names.
- * Names only, by construction: no value read here ever reaches the payload, so
- * this command needs no redaction pass -- there is nothing to redact.
- * @param connection The provider's resolved connection data.
+ * Bound on the wait for the catalog service's first fetch attempt. Local
+ * catalogs resolve in milliseconds; on a remote connection the fetch rides
+ * the remote-agent channel, and a stalled channel must not leave this command
+ * pending forever. On timeout the service still reads 'initializing', which
+ * the payload reports honestly.
  */
-function customizedConnectionFields(connection: IResolvedConnectionData): string[] | undefined {
-	const fields: string[] = [];
-	if (connection.baseUrl !== undefined) {
-		fields.push('baseUrl');
+const CATALOG_INIT_TIMEOUT_MS = 5000;
+
+/** Cap on the pass-through auth failure text, in characters. */
+const AUTH_MESSAGE_CHAR_CAP = 200;
+
+/**
+ * The auth extension's status text, bounded for a payload: first line only,
+ * hard character cap. The text is provider-supplied prose (this command
+ * constructs every other field itself), so the bound keeps a chatty SDK error
+ * from dumping a stack of detail into the transcript.
+ * @param message The registration's statusMessage.
+ */
+function summarizeAuthMessage(message: string | undefined): string | undefined {
+	const firstLine = message?.split('\n', 1)[0].trim();
+	if (!firstLine) {
+		return undefined;
 	}
-	if (connection.endpoint !== undefined) {
-		fields.push('endpoint');
-	}
-	if (connection.customHeaders && Object.keys(connection.customHeaders).length > 0) {
-		fields.push('customHeaders');
-	}
-	const groups: Record<string, Record<string, unknown> | undefined> = {
-		aws: connection.aws,
-		googleCloud: connection.googleCloud,
-		snowflake: connection.snowflake,
-		databricks: connection.databricks,
-	};
-	for (const [group, values] of Object.entries(groups)) {
-		for (const [name, value] of Object.entries(values ?? {})) {
-			if (value !== undefined) {
-				fields.push(`${group}.${name}`);
-			}
-		}
-	}
-	return fields.length > 0 ? fields : undefined;
+	return firstLine.length <= AUTH_MESSAGE_CHAR_CAP
+		? firstLine
+		: `${firstLine.slice(0, AUTH_MESSAGE_CHAR_CAP - 3).trimEnd()}...`;
 }
 
 /**
@@ -166,11 +175,11 @@ function hasAuthState(source: IPositronLanguageModelSource): boolean {
  * registration data the Configure Language Model Providers modal renders
  * (pushed by the authentication extension at activation and kept fresh on
  * every session change), and enablement comes from the warmed catalog
- * snapshot, so this command answers synchronously once the catalog service
- * has initialized -- no extension-host round trip, no network, no timeouts.
- * That also makes this payload authoritative over anything an extension
- * resolves from providers.json on its own: only the host side sees both the
- * resolved catalog and the credential state.
+ * snapshot, so this command answers from local state -- no extension-host
+ * round trip and no network; the only wait is a bounded one for the catalog
+ * service's first fetch attempt. That also makes this payload authoritative
+ * over anything an extension resolves from providers.json on its own: only
+ * the host side sees both the resolved catalog and the credential state.
  * @param accessor The command's services accessor.
  */
 export async function getProviderStatus(accessor: ServicesAccessor): Promise<IProviderStatusResult> {
@@ -178,7 +187,16 @@ export async function getProviderStatus(accessor: ServicesAccessor): Promise<IPr
 	const assistantConfigurationService = accessor.get(IPositronAssistantConfigurationService);
 
 	// The first catalog fetch attempt; resolves on failure too, never rejects.
-	await aiProviderService.whenInitialized;
+	// Bounded, so a stalled remote-agent channel cannot hang the command.
+	await raceTimeout(aiProviderService.whenInitialized, CATALOG_INIT_TIMEOUT_MS);
+
+	// Enablement verdicts are only real when the catalog was actually read.
+	// When it was not ('error', or 'initializing' after the bounded wait),
+	// isProviderEnabled resolves against an empty snapshot and would report
+	// every catalogId-declaring provider as disabled -- so enablement is
+	// reported as unknown instead, while sign-in state (which comes from the
+	// live registrations, not the catalog) is still carried.
+	const catalogKnown = aiProviderService.status === 'ready';
 
 	const registrations = assistantConfigurationService.getProviderRegistrations();
 	const providers: IProviderStatusEntry[] = [];
@@ -189,25 +207,31 @@ export async function getProviderStatus(accessor: ServicesAccessor): Promise<IPr
 		// without a declared catalogId is looked up by its own id).
 		const catalogId = source.provider.catalogId ?? source.provider.id;
 		coveredCatalogIds.add(catalogId);
-		const enabled = assistantConfigurationService.isProviderEnabled(source.provider.id);
-		const connection = aiProviderService.getProvider(catalogId)?.connection;
+		const enabled = catalogKnown
+			? assistantConfigurationService.isProviderEnabled(source.provider.id)
+			: undefined;
+		// Sign-in state is withheld only when the provider is KNOWN disabled;
+		// unknown enablement does not invalidate a live sign-in verdict.
+		const auth = enabled === false ? undefined : authState(source);
 		providers.push({
 			id: catalogId,
 			displayName: source.provider.displayName,
 			enabled,
-			auth: enabled ? authState(source) : undefined,
-			authMessage: enabled && source.status === 'error' ? source.statusMessage : undefined,
+			auth,
+			authMessage: auth === 'error' ? summarizeAuthMessage(source.statusMessage) : undefined,
 			maturity: source.provider.status,
 			custom: source.provider.customKind !== undefined ? true : undefined,
 			completionsOnly: source.type === PositronLanguageModelType.Completion ? true : undefined,
-			customizedConnection: connection ? customizedConnectionFields(connection) : undefined,
+			customizedConnection: aiProviderService.getProvider(catalogId)?.customizedConnection,
 		});
 	}
 
 	// Catalog entries nothing has registered a source for: a providers.json
 	// entry for a provider this window does not offer, or any entry when the
 	// authentication extension has not activated. Known to exist and worth
-	// reporting, but with no sign-in state to carry.
+	// reporting, but with no sign-in state to carry. (Reached only with a
+	// readable catalog -- an unread one has no entries -- so `enabled` here is
+	// always a real verdict.)
 	for (const provider of aiProviderService.getProviders()) {
 		if (coveredCatalogIds.has(provider.id)) {
 			continue;
@@ -215,19 +239,20 @@ export async function getProviderStatus(accessor: ServicesAccessor): Promise<IPr
 		providers.push({
 			id: provider.id,
 			enabled: provider.enabled,
-			customizedConnection: customizedConnectionFields(provider.connection),
+			custom: provider.custom ? true : undefined,
+			customizedConnection: provider.customizedConnection,
 		});
 	}
 
 	// Most interesting entries first, so a transport that truncates a large
 	// payload by keeping an array's leading elements sheds the boring tail:
 	// auth failures (worth a warning), then the signed-in providers (the
-	// answer to "which providers do I have"), then other enabled providers,
-	// then disabled ones. Alphabetical within each band.
+	// answer to "which providers do I have"), then the rest, with
+	// known-disabled ones last. Alphabetical within each band.
 	const interest = (entry: IProviderStatusEntry): number =>
 		entry.auth === 'error' ? 0
 			: entry.auth === 'signed-in' ? 1
-				: entry.enabled ? 2 : 3;
+				: entry.enabled !== false ? 2 : 3;
 	providers.sort((a, b) => interest(a) - interest(b) || a.id.localeCompare(b.id));
 
 	// Sign-in state is unavailable both when nothing has registered at all
@@ -269,6 +294,6 @@ CommandsRegistry.registerCommand({
 		),
 		// Advertise this command to AI agents (positron.ai.getAgentAllowedCommands).
 		agentCompatible: true,
-		returns: 'An object with catalogStatus, providers, and sometimes authStateUnavailable. catalogStatus is the provider catalog\'s lifecycle: \'ready\' when the resolved catalog (providers.json plus any administrator-enforced layers) has been read, \'error\' when it could not be (enablement then falls back to treating providers the catalog has never heard of as enabled, so hedge enablement claims), \'initializing\' if the first fetch has not completed. providers is one entry per known provider, ordered most-noteworthy first: providers whose auth is \'error\', then signed-in providers, then other enabled providers, then disabled ones. Each entry carries: id, the provider\'s name in the provider catalog, which for a custom provider is the entry name the user chose; displayName, the name the UI shows, when the provider registered one; enabled, the catalog\'s verdict, with administrator-enforced layers already folded in -- false means turned off in providers.json or by an administrator, and sign-in state is then not reported, since a disabled provider is unusable regardless. auth is present only for an enabled provider that has registered its sign-in state with this window: \'signed-in\' means a credential resolves right now and the provider is usable; \'error\' means the provider was configured but its credential no longer resolves, so it is NOT usable until the user re-authenticates, with authMessage carrying the reason (e.g. \'Authentication expired\'); \'not-signed-in\' means offered but never set up. An entry with no auth field has UNKNOWN sign-in state -- absence is not \'signed out\'. maturity is present only for a provider that is not yet stable (\'preview\' or \'experimental\'); custom is present and true only for a provider defined by a custom providers.json entry; completionsOnly is present and true only when the provider serves inline completions rather than chat (GitHub Copilot). customizedConnection lists the names of connection fields customized in the provider catalog (e.g. \'baseUrl\', \'aws.profile\', \'customHeaders\') -- names only, never values, deliberately: if the user needs the actual URL or value, direct them to open providers.json rather than guessing at it. authStateUnavailable is present and true only when NO provider has registered sign-in state in this window (the authentication extension is missing or has not finished activating): every entry then lacks auth, and the safe statement is which providers are enabled, not which are signed in. A provider is usable for chat exactly when enabled is true and auth is \'signed-in\'.',
+		returns: 'An object with catalogStatus, providers, and sometimes authStateUnavailable. catalogStatus is the provider catalog\'s lifecycle: \'ready\' when the resolved catalog (providers.json plus any administrator-enforced layers) has been read; \'error\' when it could not be; \'initializing\' when the first load had not completed within this command\'s short wait. When catalogStatus is not \'ready\', enablement is unknown: every entry omits enabled rather than guessing, sign-in state is still reported (it comes from live registrations, not the catalog), and the honest phrasing is which providers are signed in, with enablement unknown. providers is one entry per known provider, ordered most-noteworthy first: providers whose auth is \'error\', then signed-in providers, then the rest, with known-disabled ones last. Each entry carries: id, the provider\'s name in the provider catalog, which for a custom provider is the entry name the user chose; displayName, the name the UI shows, when the provider registered one; enabled, the catalog\'s verdict, with administrator-enforced layers already folded in -- false means turned off in providers.json or by an administrator, and sign-in state is then not reported, since a disabled provider is unusable regardless; absent means the catalog could not be read and enablement is unknown, not false. auth is present only for a provider that has registered its sign-in state with this window and is not known-disabled: \'signed-in\' means a credential resolves right now; \'error\' means the provider was configured but its credential no longer resolves, so it is NOT usable until the user re-authenticates, with authMessage carrying the reason (e.g. \'Authentication expired\') -- authMessage is the authentication extension\'s own status text passed through (first line, length-capped), the one field whose wording this command does not construct; \'not-signed-in\' means offered but never set up. An entry with no auth field has UNKNOWN sign-in state -- absence is not \'signed out\'. maturity is present only for a provider that is not yet stable (\'preview\' or \'experimental\'); custom is present and true only for a provider defined by a custom providers.json entry; completionsOnly is present and true only when the provider serves inline completions rather than chat (GitHub Copilot). customizedConnection lists the names of connection fields whose value differs from this build\'s built-in defaults (e.g. \'baseUrl\', \'aws.profile\', \'customHeaders\'), meaning the user or an administrator set them; a stock install reports none, and a provider\'s default endpoint never appears here. Names only, never values, deliberately: if the user needs the actual URL or value, direct them to open providers.json rather than guessing at it. authStateUnavailable is present and true only when NO provider has registered sign-in state in this window (the authentication extension is missing or has not finished activating): every entry then lacks auth, and the safe statement is which providers are enabled, not which are signed in. A provider is usable for chat exactly when enabled is true and auth is \'signed-in\'.',
 	},
 });

--- a/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
@@ -304,6 +304,15 @@ export interface IPositronAssistantConfigurationService {
 	getRegisteredSources(): IPositronLanguageModelSource[];
 
 	/**
+	 * Returns every registered provider source, including those whose catalog
+	 * entry is disabled. getRegisteredSources filters to enabled providers,
+	 * which is what the configuration modal wants; a caller reporting provider
+	 * status needs the disabled registrations too, so it can say "configured
+	 * but disabled" instead of omitting the provider entirely.
+	 */
+	getProviderRegistrations(): IPositronLanguageModelSource[];
+
+	/**
 	 * Event that fires when a provider's configuration changes via
 	 * registerProvider, unregisterProvider, or updateProvider.
 	 */

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/positronAssistantConfigurationService.vitest.ts
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/positronAssistantConfigurationService.vitest.ts
@@ -227,6 +227,14 @@ describe('PositronAssistantConfigurationService', () => {
 			expect(service.isProviderEnabled('anthropic')).toBe(false);
 		});
 
+		it('getProviderRegistrations keeps disabled registrations that getRegisteredSources filters out', () => {
+			registerProvider('openAI', true, 'openai');
+			registerProvider('anthropic-api', false, 'anthropic');
+
+			expect(service.getRegisteredSources().map(s => s.provider.id)).toEqual(['openAI']);
+			expect(service.getProviderRegistrations().map(s => s.provider.id)).toEqual(['openAI', 'anthropic-api']);
+		});
+
 		it('onChangeEnabledProviders fires on a catalog enabledChanged event', () => {
 			const listener = vi.fn();
 			ctx.disposables.add(service.onChangeEnabledProviders(listener));

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/providerStatusCommand.vitest.ts
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/providerStatusCommand.vitest.ts
@@ -87,10 +87,11 @@ describe('getProviderStatus', () => {
 		});
 	});
 
-	it('reports a configured-but-broken credential as auth error with the message, never as not-signed-in', async () => {
+	it('pairs an expired credential with its problem text, so it cannot read as a fresh provider', async () => {
 		// The authentication extension reports an expired credential with
-		// signedIn false and status 'error'; without the status check this would
-		// read as a fresh, never-configured provider.
+		// signedIn false and status 'error'. Sign-in state and health are
+		// separate fields: without `problem`, this would read as a
+		// never-configured provider.
 		stubServices({
 			registrations: [registration({ id: 'openai-api', catalogId: 'openai', signedIn: false, status: 'error', statusMessage: 'Authentication expired' })],
 		});
@@ -100,9 +101,38 @@ describe('getProviderStatus', () => {
 			id: 'openai',
 			displayName: 'openai-api',
 			enabled: true,
-			auth: 'error',
-			authMessage: 'Authentication expired',
+			auth: 'not-signed-in',
+			problem: 'Authentication expired',
 		}]);
+	});
+
+	it('keeps a signed-in provider signed in when it reports a configuration problem', async () => {
+		// status is provider health, not auth: a working credential against an
+		// unreachable custom endpoint reports status 'error' while signedIn is
+		// still true. Collapsing that into an auth failure would send the user
+		// to re-authenticate, which fixes nothing.
+		stubServices({
+			registrations: [
+				registration({ id: 'custom-gw', signedIn: true, status: 'error', statusMessage: 'Could not reach the configured endpoint' }),
+				registration({ id: 'anthropic-api', catalogId: 'anthropic', signedIn: true, status: 'ok' }),
+			],
+		});
+
+		const result = await getProviderStatus(ctx.instantiationService);
+		expect(result.providers.map(({ id, auth, problem }) => ({ id, auth, problem }))).toEqual([
+			// The problem entry still leads the ordering, matching the modal's
+			// needs-attention grouping.
+			{ id: 'custom-gw', auth: 'signed-in', problem: 'Could not reach the configured endpoint' },
+			{ id: 'anthropic', auth: 'signed-in', problem: undefined },
+		]);
+	});
+
+	it('reports a problem with no status text as unspecified rather than dropping it', async () => {
+		stubServices({
+			registrations: [registration({ id: 'openai-api', catalogId: 'openai', signedIn: false, status: 'error' })],
+		});
+
+		expect((await getProviderStatus(ctx.instantiationService)).providers[0].problem).toBe('unspecified');
 	});
 
 	it('reports an offered, never-configured provider as not-signed-in', async () => {
@@ -237,7 +267,7 @@ describe('getProviderStatus', () => {
 		expect(serialized).not.toContain('work');
 	});
 
-	it('caps the pass-through auth failure text to its first line', async () => {
+	it('caps the pass-through problem text to its first line', async () => {
 		stubServices({
 			registrations: [registration({
 				id: 'bedrock-auth', catalogId: 'bedrock', signedIn: false, status: 'error',
@@ -245,7 +275,7 @@ describe('getProviderStatus', () => {
 			})],
 		});
 
-		const message = (await getProviderStatus(ctx.instantiationService)).providers[0].authMessage!;
+		const message = (await getProviderStatus(ctx.instantiationService)).providers[0].problem!;
 		expect(message.endsWith('...')).toBe(true);
 		expect(message.length).toBeLessThanOrEqual(200);
 		expect(message).not.toContain('SdkError');
@@ -281,7 +311,7 @@ describe('getProviderStatus', () => {
 		});
 	});
 
-	it('orders entries auth failures first, then signed-in, then enabled, then disabled, alphabetically within each band', async () => {
+	it('orders entries problem reports first, then signed-in, then enabled, then disabled, alphabetically within each band', async () => {
 		stubServices({
 			registrations: [
 				registration({ id: 'zeta', signedIn: true, status: 'ok' }),

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/providerStatusCommand.vitest.ts
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/providerStatusCommand.vitest.ts
@@ -1,0 +1,245 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { IResolvedProviderData } from '../../../../../platform/positronAiProvider/common/aiProviderCatalog.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { AiProviderServiceStatus, IAiProviderService } from '../../../../services/positronAiProvider/common/aiProviderService.js';
+import { getProviderStatus } from '../../browser/providerStatusCommand.js';
+import { IPositronAssistantConfigurationService, IPositronLanguageModelSource, PositronLanguageModelType } from '../../common/interfaces/positronAssistantService.js';
+
+/** A provider registration, as the authentication extension would push it. */
+interface IRegistrationSpec {
+	id: string;
+	catalogId?: string;
+	displayName?: string;
+	signedIn?: boolean;
+	status?: 'ok' | 'error' | null;
+	statusMessage?: string;
+	maturity?: 'preview' | 'experimental';
+	customKind?: string;
+	type?: PositronLanguageModelType;
+}
+
+function registration(spec: IRegistrationSpec): IPositronLanguageModelSource {
+	return {
+		type: spec.type ?? PositronLanguageModelType.Chat,
+		provider: {
+			id: spec.id,
+			displayName: spec.displayName ?? spec.id,
+			catalogId: spec.catalogId,
+			status: spec.maturity,
+			customKind: spec.customKind,
+		},
+		supportedOptions: [],
+		defaults: {},
+		signedIn: spec.signedIn,
+		status: spec.status,
+		statusMessage: spec.statusMessage,
+	};
+}
+
+describe('getProviderStatus', () => {
+	const ctx = createTestContainer().build();
+
+	/** Wires the two services the command reads. */
+	function stubServices(options: {
+		registrations?: IPositronLanguageModelSource[];
+		catalog?: IResolvedProviderData[];
+		catalogStatus?: AiProviderServiceStatus;
+		/** Registration ids considered enabled; every id is enabled when omitted. */
+		enabledIds?: string[];
+	} = {}): void {
+		const { registrations = [], catalog = [], catalogStatus = 'ready', enabledIds } = options;
+		ctx.instantiationService.stub(IAiProviderService, stubInterface<IAiProviderService>({
+			whenInitialized: Promise.resolve(),
+			status: catalogStatus,
+			getProviders: () => catalog,
+			getProvider: (id: string) => catalog.find(provider => provider.id === id),
+		}));
+		ctx.instantiationService.stub(IPositronAssistantConfigurationService, stubInterface<IPositronAssistantConfigurationService>({
+			getProviderRegistrations: () => registrations,
+			isProviderEnabled: (providerId: string) => enabledIds === undefined || enabledIds.includes(providerId),
+		}));
+	}
+
+	it('reports a signed-in enabled provider under its catalog id, with the boring fields omitted', async () => {
+		stubServices({
+			registrations: [registration({ id: 'anthropic-api', catalogId: 'anthropic', displayName: 'Anthropic', signedIn: true, status: 'ok' })],
+			catalog: [{ id: 'anthropic', enabled: true, connection: {} }],
+		});
+
+		expect(await getProviderStatus(ctx.instantiationService)).toEqual({
+			catalogStatus: 'ready',
+			// No registration-less providers and at least one registration, so
+			// authStateUnavailable is omitted rather than false.
+			authStateUnavailable: undefined,
+			providers: [{
+				id: 'anthropic',
+				displayName: 'Anthropic',
+				enabled: true,
+				auth: 'signed-in',
+			}],
+		});
+	});
+
+	it('reports a configured-but-broken credential as auth error with the message, never as not-signed-in', async () => {
+		// The authentication extension reports an expired credential with
+		// signedIn false and status 'error'; without the status check this would
+		// read as a fresh, never-configured provider.
+		stubServices({
+			registrations: [registration({ id: 'openai-api', catalogId: 'openai', signedIn: false, status: 'error', statusMessage: 'Authentication expired' })],
+		});
+
+		const result = await getProviderStatus(ctx.instantiationService);
+		expect(result.providers).toEqual([{
+			id: 'openai',
+			displayName: 'openai-api',
+			enabled: true,
+			auth: 'error',
+			authMessage: 'Authentication expired',
+		}]);
+	});
+
+	it('reports an offered, never-configured provider as not-signed-in', async () => {
+		stubServices({
+			registrations: [registration({ id: 'gemini-api', catalogId: 'gemini', signedIn: false, status: null })],
+		});
+
+		const result = await getProviderStatus(ctx.instantiationService);
+		expect(result.providers[0].auth).toBe('not-signed-in');
+	});
+
+	it('omits auth entirely for a disabled provider, even when a session lingers', async () => {
+		stubServices({
+			registrations: [registration({ id: 'copilot-auth', catalogId: 'copilot', signedIn: true, status: 'ok', type: PositronLanguageModelType.Completion })],
+			enabledIds: [],
+		});
+
+		expect((await getProviderStatus(ctx.instantiationService)).providers).toEqual([{
+			id: 'copilot',
+			displayName: 'copilot-auth',
+			enabled: false,
+			completionsOnly: true,
+		}]);
+	});
+
+	it('carries maturity and custom through from the registration metadata', async () => {
+		stubServices({
+			registrations: [
+				registration({ id: 'snowflake-cortex', maturity: 'preview' }),
+				registration({ id: 'My Gateway', customKind: 'anthropic' }),
+			],
+		});
+
+		const result = await getProviderStatus(ctx.instantiationService);
+		expect(result.providers.map(({ id, maturity, custom }) => ({ id, maturity, custom }))).toEqual([
+			{ id: 'My Gateway', custom: true },
+			{ id: 'snowflake-cortex', maturity: 'preview' },
+		]);
+	});
+
+	it('reports a catalog entry nothing registered, without inventing sign-in state', async () => {
+		stubServices({
+			registrations: [registration({ id: 'anthropic-api', catalogId: 'anthropic', signedIn: true, status: 'ok' })],
+			catalog: [
+				{ id: 'anthropic', enabled: true, connection: {} },
+				{ id: 'positai', enabled: false, connection: {} },
+			],
+		});
+
+		const result = await getProviderStatus(ctx.instantiationService);
+		expect(result.providers.find(provider => provider.id === 'positai')).toEqual({
+			id: 'positai',
+			enabled: false,
+		});
+		// Sign-in state exists for other providers, so the whole-payload flag stays off.
+		expect(result.authStateUnavailable).toBeUndefined();
+	});
+
+	it('sets authStateUnavailable only when no provider registered sign-in state at all', async () => {
+		stubServices({
+			catalog: [{ id: 'anthropic', enabled: true, connection: {} }],
+		});
+
+		expect(await getProviderStatus(ctx.instantiationService)).toEqual({
+			catalogStatus: 'ready',
+			authStateUnavailable: true,
+			providers: [{ id: 'anthropic', enabled: true }],
+		});
+	});
+
+	it('names customized connection fields without ever carrying their values', async () => {
+		stubServices({
+			registrations: [registration({ id: 'bedrock-auth', catalogId: 'bedrock', signedIn: true, status: 'ok' })],
+			catalog: [{
+				id: 'bedrock',
+				enabled: true,
+				connection: {
+					baseUrl: 'https://internal-gateway.example.corp',
+					customHeaders: { 'X-Corp-Auth': 'a-secret-token' },
+					aws: { profile: 'work', region: undefined },
+				},
+			}],
+		});
+
+		const result = await getProviderStatus(ctx.instantiationService);
+		expect(result.providers[0].customizedConnection).toEqual(['baseUrl', 'customHeaders', 'aws.profile']);
+		// Redaction by construction: no connection value may reach the payload,
+		// under any key. The whole serialized result is the honest check.
+		const serialized = JSON.stringify(result);
+		expect(serialized).not.toContain('internal-gateway');
+		expect(serialized).not.toContain('a-secret-token');
+		expect(serialized).not.toContain('X-Corp-Auth');
+		expect(serialized).not.toContain('work');
+	});
+
+	it('omits customizedConnection for an empty customHeaders map and an untouched connection', async () => {
+		stubServices({
+			registrations: [registration({ id: 'anthropic-api', catalogId: 'anthropic', signedIn: true, status: 'ok' })],
+			catalog: [{ id: 'anthropic', enabled: true, connection: { customHeaders: {} } }],
+		});
+
+		expect((await getProviderStatus(ctx.instantiationService)).providers[0].customizedConnection).toBeUndefined();
+	});
+
+	it('joins a registration without a declared catalogId to the catalog by its own id', async () => {
+		stubServices({
+			registrations: [registration({ id: 'databricks', signedIn: true, status: 'ok' })],
+			catalog: [{ id: 'databricks', enabled: true, connection: { databricks: { host: 'corp.cloud.databricks.com' } } }],
+		});
+
+		const result = await getProviderStatus(ctx.instantiationService);
+		// One entry, not a registration entry plus a catalog-only duplicate.
+		expect(result.providers.map(provider => provider.id)).toEqual(['databricks']);
+		expect(result.providers[0].customizedConnection).toEqual(['databricks.host']);
+	});
+
+	it('orders entries auth failures first, then signed-in, then enabled, then disabled, alphabetically within each band', async () => {
+		stubServices({
+			registrations: [
+				registration({ id: 'zeta', signedIn: true, status: 'ok' }),
+				registration({ id: 'alpha', signedIn: false, status: null }),
+				registration({ id: 'broken', signedIn: false, status: 'error', statusMessage: 'Authentication expired' }),
+				registration({ id: 'beta', signedIn: true, status: 'ok' }),
+				registration({ id: 'off', signedIn: false, status: null }),
+			],
+			enabledIds: ['zeta', 'alpha', 'broken', 'beta'],
+		});
+
+		const result = await getProviderStatus(ctx.instantiationService);
+		expect(result.providers.map(provider => provider.id)).toEqual(['broken', 'beta', 'zeta', 'alpha', 'off']);
+	});
+
+	it('passes a catalog fetch failure through as catalogStatus error', async () => {
+		stubServices({ catalogStatus: 'error' });
+
+		const result = await getProviderStatus(ctx.instantiationService);
+		expect(result.catalogStatus).toBe('error');
+		expect(result.providers).toEqual([]);
+	});
+});

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/providerStatusCommand.vitest.ts
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/providerStatusCommand.vitest.ts
@@ -173,6 +173,41 @@ describe('getProviderStatus', () => {
 		});
 	});
 
+	it('omits auth for a registration the session sweep has not reached, instead of calling it not-signed-in', async () => {
+		// During activation, providers are registered before the initial session
+		// sweep sets signedIn/status. That window must read as unknown.
+		stubServices({
+			registrations: [registration({ id: 'anthropic-api', catalogId: 'anthropic' })],
+		});
+
+		expect(await getProviderStatus(ctx.instantiationService)).toEqual({
+			catalogStatus: 'ready',
+			// Registrations exist, but none carries a verdict yet.
+			authStateUnavailable: true,
+			providers: [{
+				id: 'anthropic',
+				displayName: 'anthropic-api',
+				enabled: true,
+			}],
+		});
+	});
+
+	it('keeps authStateUnavailable off when any registration has been swept, while unswept entries still omit auth', async () => {
+		stubServices({
+			registrations: [
+				registration({ id: 'anthropic-api', catalogId: 'anthropic', signedIn: true, status: 'ok' }),
+				registration({ id: 'gemini-api', catalogId: 'gemini' }),
+			],
+		});
+
+		const result = await getProviderStatus(ctx.instantiationService);
+		expect(result.authStateUnavailable).toBeUndefined();
+		expect(result.providers.map(({ id, auth }) => ({ id, auth }))).toEqual([
+			{ id: 'anthropic', auth: 'signed-in' },
+			{ id: 'gemini', auth: undefined },
+		]);
+	});
+
 	it('names customized connection fields without ever carrying their values', async () => {
 		stubServices({
 			registrations: [registration({ id: 'bedrock-auth', catalogId: 'bedrock', signedIn: true, status: 'ok' })],

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/providerStatusCommand.vitest.ts
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/providerStatusCommand.vitest.ts
@@ -208,7 +208,10 @@ describe('getProviderStatus', () => {
 		]);
 	});
 
-	it('names customized connection fields without ever carrying their values', async () => {
+	it('passes through the catalog\'s customized-field names without ever carrying connection values', async () => {
+		// customizedConnection is computed node-side (diffed against ai-config's
+		// built-in defaults); this command must relay the names and never the
+		// raw connection the catalog entry still carries.
 		stubServices({
 			registrations: [registration({ id: 'bedrock-auth', catalogId: 'bedrock', signedIn: true, status: 'ok' })],
 			catalog: [{
@@ -217,8 +220,9 @@ describe('getProviderStatus', () => {
 				connection: {
 					baseUrl: 'https://internal-gateway.example.corp',
 					customHeaders: { 'X-Corp-Auth': 'a-secret-token' },
-					aws: { profile: 'work', region: undefined },
+					aws: { profile: 'work' },
 				},
+				customizedConnection: ['baseUrl', 'customHeaders', 'aws.profile'],
 			}],
 		});
 
@@ -233,25 +237,48 @@ describe('getProviderStatus', () => {
 		expect(serialized).not.toContain('work');
 	});
 
-	it('omits customizedConnection for an empty customHeaders map and an untouched connection', async () => {
+	it('caps the pass-through auth failure text to its first line', async () => {
 		stubServices({
-			registrations: [registration({ id: 'anthropic-api', catalogId: 'anthropic', signedIn: true, status: 'ok' })],
-			catalog: [{ id: 'anthropic', enabled: true, connection: { customHeaders: {} } }],
+			registrations: [registration({
+				id: 'bedrock-auth', catalogId: 'bedrock', signedIn: false, status: 'error',
+				statusMessage: `The security token included in the request is expired (role arn:aws:iam::123456789012:role/x)${'!'.repeat(300)}\n  at SdkError.stack (bundle.js:1:1)`,
+			})],
 		});
 
-		expect((await getProviderStatus(ctx.instantiationService)).providers[0].customizedConnection).toBeUndefined();
+		const message = (await getProviderStatus(ctx.instantiationService)).providers[0].authMessage!;
+		expect(message.endsWith('...')).toBe(true);
+		expect(message.length).toBeLessThanOrEqual(200);
+		expect(message).not.toContain('SdkError');
 	});
 
 	it('joins a registration without a declared catalogId to the catalog by its own id', async () => {
 		stubServices({
 			registrations: [registration({ id: 'databricks', signedIn: true, status: 'ok' })],
-			catalog: [{ id: 'databricks', enabled: true, connection: { databricks: { host: 'corp.cloud.databricks.com' } } }],
+			catalog: [{ id: 'databricks', enabled: true, connection: {}, customizedConnection: ['databricks.host'] }],
 		});
 
 		const result = await getProviderStatus(ctx.instantiationService);
 		// One entry, not a registration entry plus a catalog-only duplicate.
 		expect(result.providers.map(provider => provider.id)).toEqual(['databricks']);
 		expect(result.providers[0].customizedConnection).toEqual(['databricks.host']);
+	});
+
+	it('marks a catalog-only custom entry as custom', async () => {
+		// Reachable when a providers.custom entry exists but nothing registered
+		// a source for it (e.g. an Assistant build without custom-provider
+		// support). The node side computes `custom`, so the entry is not
+		// mistakable for a built-in.
+		stubServices({
+			registrations: [registration({ id: 'anthropic-api', catalogId: 'anthropic', signedIn: true, status: 'ok' })],
+			catalog: [{ id: 'My Gateway', enabled: true, connection: {}, custom: true }],
+		});
+
+		const result = await getProviderStatus(ctx.instantiationService);
+		expect(result.providers.find(provider => provider.id === 'My Gateway')).toEqual({
+			id: 'My Gateway',
+			enabled: true,
+			custom: true,
+		});
 	});
 
 	it('orders entries auth failures first, then signed-in, then enabled, then disabled, alphabetically within each band', async () => {
@@ -276,5 +303,40 @@ describe('getProviderStatus', () => {
 		const result = await getProviderStatus(ctx.instantiationService);
 		expect(result.catalogStatus).toBe('error');
 		expect(result.providers).toEqual([]);
+	});
+
+	it('reports enablement as unknown, not disabled, when the catalog could not be read', async () => {
+		// With an unreadable catalog the enablement snapshot is empty, and
+		// isProviderEnabled would answer false for every catalogId-declaring
+		// provider. The payload must not launder that into "all providers are
+		// disabled": enabled is omitted, and the live sign-in state still shows.
+		stubServices({
+			registrations: [registration({ id: 'anthropic-api', catalogId: 'anthropic', signedIn: true, status: 'ok' })],
+			catalogStatus: 'error',
+			enabledIds: [],
+		});
+
+		expect(await getProviderStatus(ctx.instantiationService)).toEqual({
+			catalogStatus: 'error',
+			authStateUnavailable: undefined,
+			providers: [{
+				id: 'anthropic',
+				displayName: 'anthropic-api',
+				enabled: undefined,
+				auth: 'signed-in',
+			}],
+		});
+	});
+
+	it('treats a catalog still initializing after the bounded wait the same as unreadable', async () => {
+		stubServices({
+			registrations: [registration({ id: 'anthropic-api', catalogId: 'anthropic', signedIn: false, status: null })],
+			catalogStatus: 'initializing',
+		});
+
+		const result = await getProviderStatus(ctx.instantiationService);
+		expect(result.catalogStatus).toBe('initializing');
+		expect(result.providers[0].enabled).toBeUndefined();
+		expect(result.providers[0].auth).toBe('not-signed-in');
 	});
 });

--- a/src/vs/workbench/test/common/positronWorkbenchTestServices.ts
+++ b/src/vs/workbench/test/common/positronWorkbenchTestServices.ts
@@ -308,6 +308,7 @@ export class TestPositronAssistantConfigurationService implements IPositronAssis
 	unregisterProvider(): void { }
 	updateProvider(): void { }
 	getRegisteredSources() { return []; }
+	getProviderRegistrations() { return []; }
 
 	getEnabledProviders(): string[] {
 		return [];


### PR DESCRIPTION
Addresses https://github.com/posit-dev/assistant/issues/1883 (follow-up to #15803, which covered configuration; this PR covers providers, the issue's remaining eval question).

### Summary

Adds `positronAssistant.getProviderStatus`, an agent-compatible command that reports every AI language model provider this window knows: the provider catalog's enablement verdict (administrator enforcement folded in), live sign-in state, provider-reported problems (an expired credential, an unreachable custom endpoint) with the provider's own message, maturity, and whether the connection is customized. The `positron-settings` skill gains `references/providers.md` with the hand-written guidance around the generated command facts, plus a provider line and trigger in its description.

Design notes:

- **Reads renderer state only.** Sign-in state comes from the provider registrations the authentication extension pushes into `IPositronAssistantConfigurationService` (the same data the Configure Language Model Providers modal renders), joined by `catalogId` with `IAiProviderService`'s resolved catalog. No extension-host bridge and no network; the only wait is a bounded one (5s) for the catalog service's first fetch attempt, so a stalled remote channel cannot hang the command. The existing `authentication.getProviderDiagnostics` bridge was not reusable: it returns display labels, not ids.
- **`customizedConnection` means "differs from this build's built-in defaults".** ai-config layers built-in defaults (positai's baseUrl, ollama's endpoint, google-vertex's location) into the resolved connection, so the node side - the one place that can import those defaults - now diffs against them and ships the customized field *names* on the catalog data (`IResolvedProviderData.customizedConnection`, plus a node-computed `custom` flag). A stock install reports none.
- **Connection redaction by construction.** The payload carries connection field names only (`baseUrl`, `aws.profile`, `customHeaders`, ...) - no URL, host, account, or header name/value - and a test asserts the serialized result is clean. The one pass-through text is `problem`, the provider's own status line (e.g. "Authentication expired"), bounded to its first line and length-capped; the command's docs say so rather than claiming it is constructed.
- **Sign-in state and provider health are separate fields.** `auth` is purely `signed-in`/`not-signed-in` (absent = unknown); `problem` carries a provider-reported configuration-or-credentials issue whatever the sign-in state, so a signed-in provider with an unreachable endpoint is not misreported as a credential failure. `completionsOnly` comes from the registration's own type; no provider is classified by name.
- **Honest about what it cannot see.** When the catalog could not be read (`catalogStatus` `'error'`, or `'initializing'` after the bounded wait), entries omit `enabled` instead of laundering an empty enablement snapshot into "all providers are disabled"; sign-in state is still reported. `authStateUnavailable` distinguishes "no sign-in state reported in this window" (auth extension missing or still activating) from "signed out"; an entry without `auth` means unknown, never signed out - including registrations the initial session sweep has not reached yet.
- **Interest-ordered** (auth failures, then signed-in, then the rest, known-disabled last) so the agent transport's truncation sheds the boring tail, matching the settings commands' convention.
- **No model listing**, deliberately: it is the only part that would need network and long timeouts, and the Assistant already knows its own models. The reference file says so.
- Small API addition: `getProviderRegistrations()` on `IPositronAssistantConfigurationService` - unfiltered, unlike `getRegisteredSources()`, so disabled providers keep their display names in the payload.

Nothing changes for a default install: platform skills and the agent command tool are gated on the Assistant's experimental-features setting.

### Release Notes

#### New Features

- Posit Assistant can answer "which providers do I have enabled" from live provider status - enablement, sign-in state, and auth failures - instead of guessing at file paths (requires the Assistant's experimental features setting)

#### Bug Fixes

- N/A

### QA Notes

The command is only reachable through Posit Assistant with `assistant.experimentalFeatures: true`.

### Validation Steps

@:assistant

1. Set `assistant.experimentalFeatures: true` and reload.
2. In Posit Assistant, ask "which providers do I have enabled". Expect the `positron-settings` skill to load and `positronAssistant.getProviderStatus` to run (visible in the transcript); the answer should name the providers actually configured on this machine and distinguish usable (signed in) from merely configured, without citing `~/.posit/assistant/settings.json` or sending you to the UI.
3. Sign out of a provider (or let a credential expire) and ask again: the provider should be called out as configured but failing, with the reason.
4. On a stock providers.json, no provider should be described as having a customized connection.
5. Unit coverage: `npx vitest run src/vs/workbench/contrib/positronAssistant/test/browser/providerStatusCommand.vitest.ts src/vs/platform/positronAiProvider/test/node/customizedConnectionFields.vitest.ts` (payload composition, defaults-vs-customized diffing, redaction-by-construction, ordering, unknown-auth and unreadable-catalog honesty).
