### PR TITLE
e2e: retry the post-reload workbench gate on a bounded probe

### DIFF
--- a/test/e2e/pages/hotKeys.ts
+++ b/test/e2e/pages/hotKeys.ts
@@ -8,6 +8,14 @@ import { Code } from '../infra/code.js';
 import { STARTUP_MESSAGING_SELECTOR, STARTUP_MESSAGING_TIMEOUT } from './utils/startupMessaging.js';
 
 /**
+ * How long a single post-reload probe may wait before it is abandoned and retried.
+ */
+const RELOAD_PROBE_TIMEOUT = 2000;
+
+/** Overall budget for the post-reload workbench gate. */
+const RELOAD_READY_TIMEOUT = 30000;
+
+/**
  * Provides hotkey shortcuts for common operations. References the keybindings defined in `test/e2e/fixtures/keybindings.json`.
  */
 export class HotKeys {
@@ -267,11 +275,19 @@ export class HotKeys {
 		await this.pressHotKeys('Cmd+B R', 'Reload window');
 		await navigated;
 
-		// Use a polling assertion, not a single locator.waitFor task: this gate arms at
-		// the instant the navigation commits, and a waitFor task installed then can bind
-		// to the dying document and never observe the new one (seen on Windows CI). Each
-		// expect poll is an independent call that re-resolves the frame.
-		await expect(page.locator('.monaco-workbench')).toBeVisible({ timeout: 30000 });
+		// Bound each probe and retry, rather than spending the whole budget on one
+		// assertion. Playwright parks a query on the execution-context promise that
+		// existed when the query started, and an Electron reload clears the context
+		// more than once as the renderer is swapped -- each clear installs a fresh
+		// promise and orphans the old one, so a probe that started before the last
+		// clear waits forever on a promise nothing will resolve. That is the Windows
+		// CI failure where the workbench is fully rendered but the assertion reports
+		// "element(s) not found". Abandoning the attempt lets the next one pick up
+		// the current promise. The overall budget is unchanged.
+		await expect(async () => {
+			await expect(page.locator('.monaco-workbench'))
+				.toBeVisible({ timeout: RELOAD_PROBE_TIMEOUT });
+		}).toPass({ timeout: RELOAD_READY_TIMEOUT, intervals: [250] });
 
 		// Wait for the workbench lifecycle to reach Restored (the same positive signal
 		// Application#checkPositronReady gates launch on). External browsers (Posit


### PR DESCRIPTION
### Summary

`reloadWindow` spends its whole 30s budget on one `toBeVisible` probe, which can park forever on a discarded execution-context promise and fail against a workbench that is fully rendered and Restored. Bound each probe and retry instead.

- Playwright's `Frame._setContext` installs a fresh `ManualPromise` on every context clear
- An Electron reload clears more than once as the renderer is swapped, orphaning the earlier promise
- The one-shot probe inside `expect().toBeVisible()` runs with no inner deadline, so it never retries
- Each attempt is now capped and retried, letting the next one re-acquire the current promise
- Overall budget is unchanged; the per-attempt wait is shorter, not longer

Follow-up to #15824, which changed the error text but not the outcome; the behavior change came in with #15793.

### QA Notes

Windows-only failure, so it cannot be reproduced on macOS/Linux. Local macOS runs show no regression only. Touches all 24 `reloadWindow` call sites.

@:win @:quarto @:layouts @:positron-notebooks @:sessions


### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- After an in-place Electron window reload on Windows CI, the post-reload workbench assertion parks on an orphaned execution-context promise. Playwright's Frame._setContext installs a NEW ManualPromise on every context clear; an Electron reload clears more than once as the renderer is swapped, so the promise a probe started waiting on is discarded and never resolved. The one-shot probe inside expect(...).toBeVisible() runs with nullProgress (no inner deadline) and so never retries -- the 30s gate burns down against a workbench that is fully rendered and Restored.</summary>

- **Test:** [Quarto - Inline Output: DataFrame and Interactive HTML > R - Verify DataFrame output persists correctly after window reload](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Quarto%20-%20Inline%20Output%3A%20DataFrame%20and%20Interactive%20HTML%20%3E%20R%20-%20Verify%20DataFrame%20output%20persists%20correctly%20after%20window%20reload%7C%7C%7Ctest%2Fe2e%2Ftests%2Fquarto%2Fquarto-inline-output-dataframe.test.ts)
- **Targeted failure:** expect(page.locator(".monaco-workbench")).toBeVisible({timeout:30000}) at test/e2e/pages/hotKeys.ts:274 fails with "element(s) not found" after hotKeys.reloadWindow(true) at quarto-inline-output-dataframe.test.ts:134. win/electron only, 1.7% on main.
- **Signal:** Both pattern-B occurrences: renderer.log shows the reloaded window reaching lifecycle Restored 21-22s BEFORE the assertion deadline (23:38:52.903 vs deadline 23:39:14.000; 21:48:53.067 vs 21:49:15.448), in the same window id 1 with no BrowserWindow recreation and no window2 dir. Playwright screencast frames arrived inside the wait window at t=1651446 and t=1657298 (5.4s before the deadline), and console lines were delivered at t=1657321 -- proving the CDP session was alive and serving. renderer.log emits continuously from the JS thread through the window (23:38:52.190, .903, 23:38:56.987), proving the renderer was not starved. Transport alive + renderer alive + element in DOM + evaluation returns nothing => stale execution context.
- **Frequency:** 2/119 runs (1.7%) on main, win/electron
- **Hypothesis:** Bounding each probe so a parked attempt is abandoned lets the next attempt re-acquire the current context promise; the win/electron failure rate for reloadWindow-based tests should fall to ~0. Falsified if failures continue with the same signature (rendered+Restored workbench, alive CDP session) after the change.
- **Supersedes:** PR #15824 (8c269d5d45) replaced a single locator.waitFor with a polling expect on the premise that each poll re-resolves the frame. That premise does not hold: the first probe parks on the context promise and never yields to a second poll, so it changed the error text (pattern A -> pattern B) without changing the outcome. PR #15793 (07918e5e58, Aug 28) is the trigger -- arming at framenavigated moved the first query to the earliest possible instant, before the context is bound; the sibling reload test panel-visibility broke Aug 29 with the pattern-A signature.

</details>
