### PR TITLE
python: update where we import theme_table

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_ipkernel.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_ipkernel.py
@@ -276,8 +276,6 @@ def test_console_traceback_ipy9(shell: PositronShell, traceback_result) -> None:
 
     # NOTE (here and below): Ignoring types related to `theme_table` and `ultratb.Token`
     # as they will report undefined in IPython < 9.0.0.
-    # `theme_table` moved out of `ultratb`'s module namespace in IPython 9.17.0 (it's only
-    # imported locally within `ultratb`'s methods now), so import it from where it's defined.
     from IPython.utils.PyColorize import theme_table  # type: ignore
 
     colors = theme_table[shell.colors]  # type: ignore

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_ipkernel.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_ipkernel.py
@@ -276,7 +276,11 @@ def test_console_traceback_ipy9(shell: PositronShell, traceback_result) -> None:
 
     # NOTE (here and below): Ignoring types related to `theme_table` and `ultratb.Token`
     # as they will report undefined in IPython < 9.0.0.
-    colors = ultratb.theme_table[shell.colors]  # type: ignore
+    # `theme_table` moved out of `ultratb`'s module namespace in IPython 9.17.0 (it's only
+    # imported locally within `ultratb`'s methods now), so import it from where it's defined.
+    from IPython.utils.PyColorize import theme_table  # type: ignore
+
+    colors = theme_table[shell.colors]  # type: ignore
 
     # This template matches the beginning of each traceback frame. We don't check each entire frame
     # because syntax highlighted code is full of escape codes. For example, after removing


### PR DESCRIPTION
Closes #15839

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Updates IPython tests to be compatible with new versions #15839


### Validation Steps

green ci for python + nightly