### PR TITLE
Fix REPORT_DIR resolution in e2e-failure-analyzer

### DIFF
--- a/.github/actions/e2e-failure-analyzer/action.yml
+++ b/.github/actions/e2e-failure-analyzer/action.yml
@@ -164,7 +164,11 @@ runs:
           # close awk's stdin mid-pipeline, SIGPIPE upstream printf, and under
           # `set -e -o pipefail` kill the step (manifests as "printf: write error:
           # Broken pipe" on large log payloads).
-          LOGS=$(gh api "repos/$REPO/actions/jobs/$JOB_ID/logs" 2>/dev/null || true)
+          # Job logs contain ANSI color escapes (the step's own colorized echo
+          # output), which gh's terminal-safety check refuses to print by
+          # default -- it exits 1 with "the response contains terminal escape
+          # sequences" and no stdout, silently emptying $LOGS.
+          LOGS=$(gh api --allow-escape-sequences "repos/$REPO/actions/jobs/$JOB_ID/logs" 2>/dev/null || true)
           REPORT_DIR=$(printf '%s' "$LOGS" | awk '
             !/\${/ && !found && match($0, /playwright-report-[A-Za-z0-9_-]+/) {
               found = substr($0, RSTART, RLENGTH)


### PR DESCRIPTION
### Summary
`gh api` was silently returning empty job logs, so REPORT_DIR (and the whole s3-path analyzer) failed on every failed e2e job.
- Job logs contain ANSI color escapes from the workflow's own colorized `echo` steps
- `gh`'s terminal-escape-sequence safety check refuses to print such content and exits 1 with no stdout
- The call swallowed that failure (`2>/dev/null || true`), so `$LOGS` was empty and REPORT_DIR never resolved
- Fix: pass `--allow-escape-sequences` to the `gh api` job-logs call

### QA Notes
Verified live: re-dispatched `analyze-e2e-failures.yml` against a real completed nightly run (posit-dev/positron-builds run 33481552067) with this fix — all 4 previously-failing e2e jobs now resolve `Report URL:` correctly, vs. 100% failure before.