### PR TITLE
Add a method to queue code; use it for rstudioapi

### DIFF
--- a/extensions/positron-r/src/test/rstudioapi.test.ts
+++ b/extensions/positron-r/src/test/rstudioapi.test.ts
@@ -5,12 +5,45 @@
 
 import './mocha-setup';
 
+import * as positron from 'positron';
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as assert from 'assert';
 import * as testKit from './kit';
 
 suite('RStudio API', () => {
+	// https://github.com/posit-dev/positron/issues/15459
+	test('sendToConsole queues code without hanging the session', async () => {
+		await testKit.withDisposables(async (disposables) => {
+			const [ses, sesDisposable] = await testKit.startR();
+			disposables.push(sesDisposable);
+
+			// `sendToConsole` should return as soon as the code is queued. It
+			// runs in the same session that is asking to queue it, so waiting
+			// for the queued code to finish would deadlock: the code can't run
+			// until this call returns and the session goes idle.
+			await testKit.execute(
+				'rstudioapi::sendToConsole("sendToConsole_test_15459 <- 42L")');
+
+			// The queued code should actually run once the session is idle. Until
+			// then the variable is undefined and `evaluateCode` rejects, so treat
+			// any failure as "not yet" and keep polling.
+			await testKit.pollForSuccess(async () => {
+				let value: string;
+				try {
+					const result = await positron.runtime.evaluateCode(
+						'r', 'sendToConsole_test_15459', undefined,
+						ses.metadata.sessionId, positron.RuntimeBusyBehavior.Queue);
+					value = JSON.stringify(result);
+				} catch (err) {
+					value = String(err);
+				}
+				assert.match(value, /42/,
+					`queued code should have set the variable, got: ${value}`);
+			});
+		});
+	});
+
 	// https://github.com/posit-dev/positron/issues/8374
 	test('Navigate to file', async () => {
 		await testKit.withDisposables(async (disposables) => {

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -1778,6 +1778,21 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 	}
 
 	/**
+	 * Queues code for execution and resolves as soon as it has been accepted,
+	 * without waiting for it to finish running. Rejects if the code could not be
+	 * queued (e.g. the interpreter failed to start), so those errors still reach
+	 * the caller.
+	 *
+	 * This is the path behind the `sendToConsole` frontend method: the code runs
+	 * in the same session that requested it, so waiting for completion (as
+	 * `executeCode` does) would deadlock that session, which stays busy until the
+	 * request returns.
+	 */
+	public async queueCode(languageId: string, code: string, extensionId: string, focus: boolean, allowIncomplete?: boolean): Promise<void> {
+		await this._proxy.$executeCode(languageId, extensionId, undefined, code, focus, allowIncomplete);
+	}
+
+	/**
 	 * Evaluate code silently and return a JSON-coerced result.
 	 *
 	 * @param languageId The language ID to evaluate in

--- a/src/vs/workbench/api/common/positron/extHostMethods.ts
+++ b/src/vs/workbench/api/common/positron/extHostMethods.ts
@@ -334,7 +334,13 @@ export class ExtHostMethods implements extHostProtocol.ExtHostMethodsShape {
 	}
 
 	async executeCode(languageId: string, code: string, extensionId: string, focus: boolean, allowIncomplete?: boolean): Promise<Record<string, any>> {
-		return this.runtime.executeCode(languageId, code, extensionId, focus, allowIncomplete);
+		// This is the frontend method behind `sendToConsole`. Queue the code and
+		// return once it has been accepted; don't wait for it to finish running,
+		// since it runs in the same session that requested it and that session
+		// stays busy until this call returns. Errors from queuing (e.g. the
+		// interpreter failed to start) still propagate back to the caller.
+		await this.runtime.queueCode(languageId, code, extensionId, focus, allowIncomplete);
+		return {};
 	}
 
 	async evaluateWhenClause(whenClause: string): Promise<boolean> {


### PR DESCRIPTION
Fixes #15459

`rstudioapi::sendToConsole()` (and the `.ps.ui.executeCode()` frontend method behind it) hung the R session: the code was echoed to the console as `> cars` but never ran, and the session stayed blocked.

The frontend method runs in the same session that asked to queue the code. It waited for the queued code to finish before returning, but that code can't run until the request returns and the session goes idle -- a deadlock. It now returns as soon as the code has been accepted, so the queued code runs once the session is idle. Errors from queuing (for example, an interpreter that fails to start) still propagate back to the caller.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix `rstudioapi::sendToConsole()` hanging the R session (#15459)

### Validation Steps

@:console

1. Start a new R session.
2. Run `rstudioapi::sendToConsole("cars")`.
3. Confirm the code is echoed as `> cars`, runs (the `cars` data frame prints), and the session returns to idle instead of hanging.
