### PR TITLE
chore: bump @midleman/playwright-reporter to ^0.55.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,7 @@
       "devDependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.198",
         "@midleman/github-actions-reporter": "^1.10.1",
-        "@midleman/playwright-reporter": "^0.55.0",
+        "@midleman/playwright-reporter": "^0.55.1",
         "@openai/codex": "0.142.0",
         "@playwright/cli": "^0.1.9",
         "@playwright/test": "^1.62.1",
@@ -5170,9 +5170,9 @@
       }
     },
     "node_modules/@midleman/playwright-reporter": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@midleman/playwright-reporter/-/playwright-reporter-0.55.0.tgz",
-      "integrity": "sha512-f1BclSwJoXihp+j1EgrPzN3bIG/Uz2WtUgLslVccm5eFQ/2yy4bNOl0YsbhCQwWClCMZC9BxuuCNHBfgRrVe/A==",
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/@midleman/playwright-reporter/-/playwright-reporter-0.55.1.tgz",
+      "integrity": "sha512-ytxGHaw38oXSf/eTGVTQG3kwCI3NGmQF4gNl1sBC1L9NhNAI0BYd2ZccX2jzsmCf1M5iKZfdGdYdc/nek8QX8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -235,7 +235,7 @@
     "@anthropic-ai/claude-agent-sdk": "0.3.198",
     "@openai/codex": "0.142.0",
     "@midleman/github-actions-reporter": "^1.10.1",
-    "@midleman/playwright-reporter": "^0.55.0",
+    "@midleman/playwright-reporter": "^0.55.1",
     "@playwright/cli": "^0.1.9",
     "@playwright/test": "^1.62.1",
     "@softwarenerd/deemon-ng": "^1.1.0",


### PR DESCRIPTION
### Summary
Picks up the mid-retry fix released in 0.55.1: the reporter no longer publishes a not-yet-final `failed` row to `data.parquet` during incremental flushes.
- Bumps `devDependencies."@midleman/playwright-reporter"` from `^0.55.0` to `^0.55.1`
- Lockfile updated to match — it pinned `0.55.0`, and `npm install pkg@^0.55.0` does not upgrade an already-satisfying locked version, so CI kept resolving the old build
- Fixes Test Status Bot threads reporting a green run's flaky test as failed, and the dashboard flipping a test failing → flake mid-run

### QA Notes
n/a