### PR TITLE
Register the academic license service before the extension gallery

### DIFF
--- a/src/vs/server/node/serverServices.ts
+++ b/src/vs/server/node/serverServices.ts
@@ -249,6 +249,15 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 
 	services.set(IExtensionGalleryManifestService, new ExtensionGalleryManifestIPCService(socketServer, logService, productService));
 	services.set(IMcpGalleryManifestService, new McpGalleryManifestIPCService(socketServer));
+	// --- Start Positron ---
+	// Registered ahead of the gallery service, which depends on it and is instantiated
+	// eagerly below via NativeLanguagePackService.
+	//
+	// The hash is a separate argument rather than a field on the licensee info because that
+	// object goes out to clients over the remote agent channel and the hash has no business
+	// there; it is only ever read back out by the gallery telemetry in this process.
+	services.set(IPositronAcademicLicenseService, new PositronAcademicLicenseService(positronLicenseeInfo?.academic === true, licenseHash));
+	// --- End Positron ---
 	services.set(IExtensionGalleryService, new SyncDescriptor(ExtensionGalleryServiceWithNoStorageService));
 
 	const downloadChannel = socketServer.getChannel('download', router);
@@ -358,10 +367,6 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 	services.set(IEphemeralStateService, ephemeralStateService);
 	const idleTrackingService = new PositronIdleTrackingService();
 	services.set(IPositronIdleTrackingService, idleTrackingService);
-	// The hash is a separate argument rather than a field on the licensee info because that
-	// object goes out to clients over the remote agent channel and the hash has no business
-	// there; it is only ever read back out by the gallery telemetry in this process.
-	services.set(IPositronAcademicLicenseService, new PositronAcademicLicenseService(positronLicenseeInfo?.academic === true, licenseHash));
 	// --- End Positron ---
 
 	instantiationService.invokeFunction(accessor => {


### PR DESCRIPTION
Fixes #15852

`AbstractExtensionGalleryService` depends on `IPositronAcademicLicenseService`, but `setupServerServices` registered the license service about a hundred lines after `NativeLanguagePackService` had already caused the gallery service to be constructed. The dependency resolved to undefined, and every gallery request threw when it read `isAcademic`, so extension installs failed in server sessions. Registering the license service ahead of the gallery service fixes it.


### Validation Steps

@:extensions @:web @:workbench @:workbench-databricks

Install any extension in a Workbench or web session and confirm it succeeds. Before this change the Window log shows `TypeError: Cannot read properties of undefined (reading 'isAcademic')` and the install fails with "Error while installing '<name>' extension."
