### PR TITLE
14626 data connections maximize horizontal space for tables columns

### DIFF
--- a/src/vs/base/browser/positronReactHooks.tsx
+++ b/src/vs/base/browser/positronReactHooks.tsx
@@ -3,11 +3,73 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { usePositronReactServicesContext } from './positronReactRendererContext.js';
 import { ContextKeyValue, IContextKeyService, RawContextKey } from '../../platform/contextkey/common/contextkey.js';
 import { ExtensionIdentifier } from '../../platform/extensions/common/extensions.js';
 
+
+// How long an operation has to run before it is worth telling the user it is running, and how long
+// the indicator stays once it has appeared. See useBusyIndicator.
+const BUSY_INDICATOR_DELAY = 250;
+const BUSY_INDICATOR_MINIMUM = 400;
+
+/**
+ * useBusyIndicator hook. Gates a busy indicator so that a fast operation shows nothing at all and a
+ * slow one shows an indicator that stays long enough to read.
+ *
+ * Two rules, and both are needed. The indicator does not appear until the operation has run for
+ * `delayMs`, so an operation that finishes before that -- opening a table on a local PostgreSQL,
+ * say -- never swaps the icon and never flashes. Once it has appeared it stays for `minimumMs`, so
+ * an operation that finishes just past the delay doesn't blink the indicator out again.
+ *
+ * A minimum on its own would make the fast case worse rather than better: it turns a 40ms flicker
+ * into a spinner that is guaranteed to run for the full minimum on every single open. The delay is
+ * what removes the flash; the minimum only keeps the boundary from flickering.
+ *
+ * @param busy Whether the operation is running.
+ * @param delayMs How long the operation must run before the indicator appears.
+ * @param minimumMs How long the indicator stays once it has appeared.
+ * @returns Whether the indicator should be shown.
+ */
+export function useBusyIndicator(
+	busy: boolean,
+	delayMs: number = BUSY_INDICATOR_DELAY,
+	minimumMs: number = BUSY_INDICATOR_MINIMUM
+): boolean {
+	const [showing, setShowing] = useState(false);
+
+	// When the indicator went up, for measuring the minimum against. A ref rather than state: it is
+	// read when the operation ends, and writing it should not itself paint.
+	const shownAt = useRef(0);
+
+	useEffect(() => {
+		// Running and nothing shown yet: hold off until the delay is up. If the operation finishes
+		// first this effect is torn down and the timeout never fires, which is the whole point.
+		if (busy && !showing) {
+			const handle = setTimeout(() => {
+				shownAt.current = Date.now();
+				setShowing(true);
+			}, delayMs);
+			return () => clearTimeout(handle);
+		}
+
+		// Finished with the indicator up: take it down, but not before it has had its minimum.
+		if (!busy && showing) {
+			const remaining = minimumMs - (Date.now() - shownAt.current);
+			if (remaining <= 0) {
+				setShowing(false);
+				return undefined;
+			}
+			const handle = setTimeout(() => setShowing(false), remaining);
+			return () => clearTimeout(handle);
+		}
+
+		return undefined;
+	}, [busy, showing, delayMs, minimumMs]);
+
+	return showing;
+}
 
 /**
  * usePositronConfiguration hook.

--- a/src/vs/base/browser/test/positronReactHooks.vitest.tsx
+++ b/src/vs/base/browser/test/positronReactHooks.vitest.tsx
@@ -10,7 +10,7 @@ import { ContextKeyService } from '../../../platform/contextkey/browser/contextK
 import { IContextKeyService, RawContextKey } from '../../../platform/contextkey/common/contextkey.js';
 import { TestConfigurationService } from '../../../platform/configuration/test/common/testConfigurationService.js';
 import { ensureNoLeakedDisposables } from '../../../test/vitest/vitestUtils.js';
-import { useScopedContextKey } from '../positronReactHooks.js';
+import { useBusyIndicator, useScopedContextKey } from '../positronReactHooks.js';
 
 // These tests cover useScopedContextKey, the core shared by useContextKey and
 // useContextKeyFromString. Passing the service explicitly means no React
@@ -71,5 +71,52 @@ describe('useScopedContextKey', () => {
 
 		fromScoped.unmount();
 		fromRoot.unmount();
+	});
+});
+
+// Fake timers throughout: the hook's whole behavior is what happens at the delay and minimum
+// boundaries, so the tests step time rather than wait for it.
+describe('useBusyIndicator', () => {
+	beforeEach(() => vi.useFakeTimers());
+	afterEach(() => vi.useRealTimers());
+
+	it('shows nothing at all for an operation that finishes inside the delay', () => {
+		const { result, rerender, unmount } = renderHook(
+			({ busy }: { busy: boolean }) => useBusyIndicator(busy, 250, 400),
+			{ initialProps: { busy: true } }
+		);
+		expect(result.current).toBe(false);
+
+		// Finished at 100ms, well inside the delay. The pending timeout is torn down with the effect,
+		// so the indicator is never raised and the icon never swaps.
+		act(() => { vi.advanceTimersByTime(100); });
+		rerender({ busy: false });
+		act(() => { vi.advanceTimersByTime(1000); });
+		expect(result.current).toBe(false);
+
+		unmount();
+	});
+
+	it('holds the indicator for its minimum once an operation runs past the delay', () => {
+		const { result, rerender, unmount } = renderHook(
+			({ busy }: { busy: boolean }) => useBusyIndicator(busy, 250, 400),
+			{ initialProps: { busy: true } }
+		);
+
+		// Past the delay, so the indicator goes up.
+		act(() => { vi.advanceTimersByTime(250); });
+		const shownAfterDelay = result.current;
+
+		// Finishing 10ms later would blink it straight back out, so it stays for the rest of its
+		// minimum and no longer.
+		rerender({ busy: false });
+		act(() => { vi.advanceTimersByTime(10); });
+		const shownJustAfterFinishing = result.current;
+		act(() => { vi.advanceTimersByTime(400); });
+
+		expect({ shownAfterDelay, shownJustAfterFinishing, shownAfterMinimum: result.current })
+			.toEqual({ shownAfterDelay: true, shownJustAfterFinishing: true, shownAfterMinimum: false });
+
+		unmount();
 	});
 });

--- a/src/vs/workbench/browser/positronTree/classes/positronTreeInstance.css
+++ b/src/vs/workbench/browser/positronTree/classes/positronTreeInstance.css
@@ -73,8 +73,66 @@
 }
 
 .positron-tree-indent {
+	position: relative;
 	flex: 0 0 auto;
 	height: 100%;
+}
+
+/*
+ * The indent guides: one 1px rule per level the row sits under, painted as a repeating background so
+ * a deep row costs no extra DOM. The instance supplies the tile width, since only it knows the
+ * indent width.
+ *
+ * Drawn on a pseudo-element inset by 11px -- the twisty's 3px gutter plus half its 16px box -- so the
+ * first tile lands on the outermost ancestor's twisty center and the repeat runs rightwards only.
+ * Anchoring the background on the spacer itself with background-position instead would tile in both
+ * directions from that offset, which is correct only while the indent width exceeds the offset: at
+ * an indent of 8 the tiles wrap to 3, 11, 19 and every row grows a spurious rule near its left edge.
+ *
+ * The 11px overhang on the right keeps the last tile -- the one for the row's immediate parent --
+ * from being clipped at narrow indent widths.
+ *
+ * Guides matter more here than in an ordinary tree: a row that holds its children at its own indent
+ * (see TreeNode.flattensChildren) gives up the step that would otherwise show what belongs to what,
+ * and the guide is what carries it instead.
+ */
+.positron-tree-indent::before {
+	content: '';
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: 11px;
+	right: -11px;
+	/*
+	 * The overhang reaches across the twisty beside it, and an absolutely positioned element paints
+	 * over in-flow siblings, so without this the guides would take half of every twisty's clicks.
+	 */
+	pointer-events: none;
+	background-image: linear-gradient(
+		to right,
+		var(--vscode-tree-indentGuidesStroke) 1px,
+		transparent 1px
+	);
+	background-size: var(--positron-tree-indent-width) 100%;
+	background-repeat: repeat-x;
+}
+
+/*
+ * The guide for a parent that gave up its indent step (see VisibleNode.flattenedParentGuide). It has
+ * no step of its own to be drawn in, so it is painted past the spacer's right edge, landing on that
+ * parent's twisty center -- 3px gutter plus half the 16px twisty -- which is where every other guide
+ * sits relative to what it marks.
+ */
+.positron-tree-indent.flattened-parent-guide::after {
+	content: '';
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: calc(100% + 11px);
+	width: 1px;
+	background-color: var(--vscode-tree-indentGuidesStroke);
+	/* Sits over the twisty column, same as the guides above. Decoration only. */
+	pointer-events: none;
 }
 
 .positron-tree-twisty {
@@ -87,7 +145,8 @@
 	background: transparent;
 	border: 0;
 	padding: 0;
-	margin: 0 0 0 4px;
+	/* Gutter matches the icon column's, so the twisty and the icon are two identical 19px columns. */
+	margin: 0 0 0 3px;
 	color: inherit;
 	font: inherit;
 }

--- a/src/vs/workbench/browser/positronTree/classes/positronTreeInstance.css
+++ b/src/vs/workbench/browser/positronTree/classes/positronTreeInstance.css
@@ -13,6 +13,26 @@
 	user-select: none;
 }
 
+/*
+ * The connector joining a folded row to its parent's guide: a short horizontal stub from the last
+ * guide across to the row, the elbow a tree connector would draw. It marks the rows that fold a
+ * level, and attaches them to what they belong to, without the full-height line that would run
+ * through the chevrons of everything beneath.
+ *
+ * It reaches from the parent's guide to the spacer's right edge, so it is only as long as the indent
+ * width leaves room for. Below an indent of 11px there is no room at all and the stub collapses to
+ * nothing, which is the right degradation: at that density the guides are already nearly touching.
+ */
+.positron-tree-fold-connector {
+	position: absolute;
+	top: 50%;
+	left: calc(100% - var(--positron-tree-indent-width) + 11px);
+	right: 0;
+	height: 1px;
+	background-color: var(--vscode-tree-indentGuidesStroke);
+	pointer-events: none;
+}
+
 .positron-tree-row.focused {
 	outline: 1px solid var(--vscode-list-focusOutline);
 	outline-offset: -1px;

--- a/src/vs/workbench/browser/positronTree/classes/positronTreeInstance.tsx
+++ b/src/vs/workbench/browser/positronTree/classes/positronTreeInstance.tsx
@@ -7,7 +7,7 @@
 import './positronTreeInstance.css';
 
 // React.
-import { JSX, ReactNode, MouseEvent as ReactMouseEvent } from 'react';
+import { CSSProperties, JSX, ReactNode, MouseEvent as ReactMouseEvent } from 'react';
 
 // Other dependencies.
 import { Emitter, Event } from '../../../../base/common/event.js';
@@ -17,6 +17,14 @@ import { positronClassNames } from '../../../../base/common/positronUtilities.js
 import { DataGridInstance, MouseSelectionType, RowSelectionState, SelectionCursorOptions, selectionCursorOptions } from '../../positronDataGrid/classes/dataGridInstance.js';
 import { TreeNode, TreeNodeContext, VisibleNode } from './treeNode.js';
 import { buildVisibleNodes, findParentIndex } from './treeProjection.js';
+
+/**
+ * Inline-style shape for a row's indent spacer. Extends CSSProperties with the custom property that
+ * carries the indent width to the stylesheet, so TypeScript accepts the literal without a cast.
+ */
+interface PositronTreeIndentCSSProperties extends CSSProperties {
+	'--positron-tree-indent-width': string;
+}
 
 /**
  * PositronTreeRenderNode type. The consumer-provided function that renders the content area of
@@ -1024,6 +1032,14 @@ export class PositronTreeInstance<T> extends DataGridInstance {
 			? (visible.refreshGeneration % 2 === 0 ? 'recently-refreshed-even' : 'recently-refreshed-odd')
 			: undefined;
 
+		// The spacer's width, plus the indent width the stylesheet tiles the indent guides at. The
+		// guides are drawn on a pseudo-element, which an inline background-size can't reach, so the
+		// width crosses over as a custom property.
+		const indentStyle: PositronTreeIndentCSSProperties = {
+			width: visible.indentLevel * this._indentWidth,
+			'--positron-tree-indent-width': `${this._indentWidth}px`,
+		};
+
 		return (
 			<div
 				className={positronClassNames(
@@ -1034,9 +1050,12 @@ export class PositronTreeInstance<T> extends DataGridInstance {
 				)}
 			>
 				<div
-					className='positron-tree-indent'
+					className={positronClassNames(
+						'positron-tree-indent',
+						{ 'flattened-parent-guide': visible.flattenedParentGuide }
+					)}
 					data-testid='positron-tree-indent'
-					style={{ width: visible.depth * this._indentWidth }}
+					style={indentStyle}
 				/>
 				<button
 					aria-label={twistyDisabled ? undefined : (visible.expandState === 'expanded' ? 'Collapse' : 'Expand')}

--- a/src/vs/workbench/browser/positronTree/classes/positronTreeInstance.tsx
+++ b/src/vs/workbench/browser/positronTree/classes/positronTreeInstance.tsx
@@ -1056,7 +1056,15 @@ export class PositronTreeInstance<T> extends DataGridInstance {
 					)}
 					data-testid='positron-tree-indent'
 					style={indentStyle}
-				/>
+				>
+					{/*
+					  * The connector joining a folded row to its parent's guide. A root row has no
+					  * parent guide to join, so it gets none.
+					  */}
+					{visible.node.foldsLevel === true && visible.indentLevel > 0 &&
+						<div className='positron-tree-fold-connector' />
+					}
+				</div>
 				<button
 					aria-label={twistyDisabled ? undefined : (visible.expandState === 'expanded' ? 'Collapse' : 'Expand')}
 					className={positronClassNames(

--- a/src/vs/workbench/browser/positronTree/classes/positronTreeInstance.tsx
+++ b/src/vs/workbench/browser/positronTree/classes/positronTreeInstance.tsx
@@ -65,8 +65,8 @@ interface PositronTreeBaseOptions<T> {
 	// Row height in pixels.
 	readonly rowHeight: number;
 
-	// Per-level indent width in pixels. Defaults to 12.
-	readonly indentWidth?: number;
+	// Per-level indent width in pixels.
+	readonly indentWidth: number;
 
 	// Whether to apply default focused/selected styling on the row wrapper. Defaults to true.
 	readonly useDefaultStyling?: boolean;
@@ -79,9 +79,6 @@ interface PositronTreeBaseOptions<T> {
  * Enter/Space-to-select are redundant and disallowed.
  */
 export type PositronTreeInstanceOptions<T> = PositronTreeBaseOptions<T> & SelectionCursorOptions;
-
-// Per-level indent width in pixels, used when options.indentWidth is not supplied.
-const DEFAULT_INDENT_WIDTH = 12;
 
 /**
  * How long, in milliseconds, the rows a reload brought in stay marked as recently refreshed. Set
@@ -144,7 +141,7 @@ export class PositronTreeInstance<T> extends DataGridInstance {
 	private readonly _getReloadKey: PositronTreeGetReloadKey<T>;
 
 	// Per-level indent width in pixels and whether to apply default focus/selection styling.
-	private readonly _indentWidth: number;
+	private _indentWidth: number;
 	private readonly _useDefaultStyling: boolean;
 
 	// Structural tree state.
@@ -231,7 +228,7 @@ export class PositronTreeInstance<T> extends DataGridInstance {
 		this._getChildren = options.getChildren;
 		this._renderNode = options.renderNode;
 		this._getReloadKey = options.getReloadKey ?? (node => node.id);
-		this._indentWidth = options.indentWidth ?? DEFAULT_INDENT_WIDTH;
+		this._indentWidth = options.indentWidth;
 		this._useDefaultStyling = options.useDefaultStyling ?? true;
 
 		// Lock the column count to one.
@@ -245,6 +242,13 @@ export class PositronTreeInstance<T> extends DataGridInstance {
 	//#endregion Constructor
 
 	//#region Public Properties
+
+	/**
+	 * The per-level indent width, in pixels. A row at depth n is inset by n times this.
+	 */
+	get indentWidth(): number {
+		return this._indentWidth;
+	}
 
 	get initialLoadCompleted(): boolean {
 		return this._initialLoadCompleted;
@@ -577,6 +581,22 @@ export class PositronTreeInstance<T> extends DataGridInstance {
 	//#endregion Public Methods - Selection / Focus / Activation
 
 	//#region Public Methods - Renderer Update
+
+	/**
+	 * Sets the per-level indent width. Consumers that resolve their indent from a user setting call
+	 * this when it changes. Indent width is presentation only: every row keeps its height and its
+	 * place, so the projection is left alone and the rows are simply repainted at the new width.
+	 *
+	 * @param indentWidth The per-level indent width in pixels.
+	 */
+	setIndentWidth(indentWidth: number): void {
+		if (indentWidth === this._indentWidth) {
+			return;
+		}
+
+		this._indentWidth = indentWidth;
+		this.fireOnDidUpdateEvent();
+	}
 
 	setRenderNode(renderNode: PositronTreeRenderNode<T>): void {
 		this._renderNode = renderNode;
@@ -1015,6 +1035,7 @@ export class PositronTreeInstance<T> extends DataGridInstance {
 			>
 				<div
 					className='positron-tree-indent'
+					data-testid='positron-tree-indent'
 					style={{ width: visible.depth * this._indentWidth }}
 				/>
 				<button

--- a/src/vs/workbench/browser/positronTree/classes/treeNode.ts
+++ b/src/vs/workbench/browser/positronTree/classes/treeNode.ts
@@ -21,6 +21,12 @@ export interface TreeNode<T> {
 	// row is expandable; if getChildren later returns [], the node falls back to a leaf after
 	// expansion. If false, no twisty and expansion is disallowed.
 	readonly hasChildren: boolean;
+
+	// Whether this node's children render at its own indent rather than one step further in. For a
+	// node that names a category rather than a thing -- "Tables", "Columns" -- the extra step buys
+	// nothing: the row above already says what the rows below are. The node keeps its twisty and
+	// its place in the structure; only the indent of what it holds changes. Defaults to false.
+	readonly flattensChildren?: boolean;
 }
 
 /**
@@ -42,7 +48,27 @@ export type TreeExpandState = 'leaf' | 'collapsed' | 'expanded' | 'loading' | 'e
  */
 export interface VisibleNode<T> {
 	readonly node: TreeNode<T>;
+
+	// Structural depth: how many ancestors the node has. Drives navigation (which row is a given
+	// row's parent, which row is its first child) and is what any hierarchy an assistive technology
+	// is told about must be derived from.
 	readonly depth: number;
+
+	// Visual indent step. Equal to depth until some ancestor sets flattensChildren, after which it
+	// trails depth by one step per such ancestor. Only the rendered indent uses this -- keeping it
+	// apart from depth is what lets a category row hold its children at its own indent without the
+	// tree losing track of who is whose parent.
+	readonly indentLevel: number;
+
+	// Whether this row draws an extra indent guide for the parent it shares a step with. A node that
+	// sets flattensChildren gives up the step a guide would normally be drawn in, so without this
+	// there is no line marking what its children belong to.
+	//
+	// Set only when every one of those children is a leaf. A child with a twisty of its own has it at
+	// the same x as the line -- they share an indent step -- and the line would run through the
+	// chevrons instead of beside them.
+	readonly flattenedParentGuide: boolean;
+
 	readonly expandState: TreeExpandState;
 
 	// Whether a reload of this node's subtree is in flight. Deliberately separate from

--- a/src/vs/workbench/browser/positronTree/classes/treeNode.ts
+++ b/src/vs/workbench/browser/positronTree/classes/treeNode.ts
@@ -27,6 +27,13 @@ export interface TreeNode<T> {
 	// nothing: the row above already says what the rows below are. The node keeps its twisty and
 	// its place in the structure; only the indent of what it holds changes. Defaults to false.
 	readonly flattensChildren?: boolean;
+
+	// Whether this row stands in for a level the tree isn't showing, and so is marked with a
+	// connector joining it to its parent's guide. Two different collapses want this -- a node that
+	// holds its children at its own indent, and one the consumer merged with an ancestor into a
+	// single row -- and only the consumer knows about the second, so it is asked rather than derived
+	// from flattensChildren. Defaults to false.
+	readonly foldsLevel?: boolean;
 }
 
 /**

--- a/src/vs/workbench/browser/positronTree/classes/treeProjection.ts
+++ b/src/vs/workbench/browser/positronTree/classes/treeProjection.ts
@@ -50,13 +50,21 @@ export interface TreeProjectionInput<T> {
 export function buildVisibleNodes<T>(input: TreeProjectionInput<T>): readonly VisibleNode<T>[] {
 	const result: VisibleNode<T>[] = [];
 
-	const walk = (siblings: readonly TreeNode<T>[], depth: number, stale: boolean): void => {
+	const walk = (
+		siblings: readonly TreeNode<T>[],
+		depth: number,
+		indentLevel: number,
+		flattenedParentGuide: boolean,
+		stale: boolean
+	): void => {
 		for (const node of siblings) {
 			const expandState = computeExpandState(node, input);
 			const refreshGeneration = input.recentlyRefreshed.get(node.id);
 			result.push({
 				node,
 				depth,
+				indentLevel,
+				flattenedParentGuide,
 				expandState,
 				refreshing: input.refreshing.has(node.id),
 				recentlyRefreshed: refreshGeneration !== undefined,
@@ -67,16 +75,30 @@ export function buildVisibleNodes<T>(input: TreeProjectionInput<T>): readonly Vi
 			if (expandState === 'expanded') {
 				const loaded = input.children.get(node.id);
 				if (loaded !== undefined) {
+					// Depth always advances -- the children really are one level down, and navigation
+					// depends on that. The indent only advances when the node isn't a category row
+					// holding its children at its own step.
+					//
 					// Staleness inherits: everything under a refreshing node is on its way out, so
 					// the flag passes down from wherever it was first set. The refreshing node
 					// itself is not stale -- it is the one being replaced into, not replaced.
-					walk(loaded, depth + 1, stale || input.refreshing.has(node.id));
+					// A flattening node's children carry the guide marking what they belong to, since
+					// the node gave up the step one would normally be drawn in -- but only when they
+					// are all leaves. See VisibleNode.flattenedParentGuide.
+					const flattens = node.flattensChildren === true;
+					walk(
+						loaded,
+						depth + 1,
+						flattens ? indentLevel : indentLevel + 1,
+						flattens && loaded.every(child => !child.hasChildren),
+						stale || input.refreshing.has(node.id)
+					);
 				}
 			}
 		}
 	};
 
-	walk(input.roots, 0, false);
+	walk(input.roots, 0, 0, false, false);
 	return result;
 }
 

--- a/src/vs/workbench/browser/positronTree/test/browser/positronTree.vitest.tsx
+++ b/src/vs/workbench/browser/positronTree/test/browser/positronTree.vitest.tsx
@@ -182,6 +182,78 @@ describe('PositronTreeInstance', () => {
 		expect(tree.rows).toBe(3);
 	});
 
+	it('a node that flattens its children holds them at its own indent without moving them in the structure', async () => {
+		// r0 > category > leaf, where the category flattens: its child renders at the category's own
+		// indent, the way a "Tables" row sits directly over its tables rather than a step out from
+		// them.
+		const instance = new PositronTreeInstance<DemoNode>({
+			rowHeight: ROW_HEIGHT,
+			indentWidth: INDENT_WIDTH,
+			getRoots: async () => [branch('r0')],
+			getChildren: async node => node.id === 'r0'
+				? [{ id: 'category', data: { label: 'category' }, hasChildren: true, flattensChildren: true }]
+				: [leaf('category.0')],
+			renderNode: visible => <span>{visible.node.data.label}</span>,
+		});
+		store.add(instance);
+		await instance.refresh();
+		await instance.expand('r0');
+		await instance.expand('category');
+
+		// Right-arrow steps into each node's first child, then left-arrow comes back out. Both walk
+		// by depth, so they still see the category as the leaf's parent even though the two rows
+		// render at the same indent -- the compaction is presentation, not structure.
+		instance.moveCursorRight();
+		instance.moveCursorRight();
+		const cursorAfterDescending = instance.focusedId;
+		instance.moveCursorLeft();
+
+		expect({
+			rows: instance.visibleNodes.map(visible => ({
+				id: visible.node.id,
+				depth: visible.depth,
+				indentLevel: visible.indentLevel,
+				// The flattened category's leaf child carries the guide standing in for the step the
+				// category gave up; nothing else needs one.
+				guide: visible.flattenedParentGuide,
+			})),
+			cursorAfterDescending,
+			cursorAfterAscending: instance.focusedId,
+		}).toEqual({
+			rows: [
+				{ id: 'r0', depth: 0, indentLevel: 0, guide: false },
+				{ id: 'category', depth: 1, indentLevel: 1, guide: false },
+				{ id: 'category.0', depth: 2, indentLevel: 1, guide: true },
+			],
+			cursorAfterDescending: 'category.0',
+			cursorAfterAscending: 'category',
+		});
+	});
+
+	it('a flattening node whose children are expandable gets no guide, since the line would cross their twisties', async () => {
+		const instance = new PositronTreeInstance<DemoNode>({
+			rowHeight: ROW_HEIGHT,
+			indentWidth: INDENT_WIDTH,
+			getRoots: async () => [{ id: 'category', data: { label: 'category' }, hasChildren: true, flattensChildren: true }],
+			getChildren: async () => [branch('child')],
+			renderNode: visible => <span>{visible.node.data.label}</span>,
+		});
+		store.add(instance);
+		await instance.refresh();
+		await instance.expand('category');
+
+		// The child still gives up its indent step -- flattening is unconditional -- but a child with
+		// a twisty of its own has it at the same x the guide would occupy, so the guide is withheld.
+		expect(instance.visibleNodes.map(visible => ({
+			id: visible.node.id,
+			indentLevel: visible.indentLevel,
+			guide: visible.flattenedParentGuide,
+		}))).toEqual([
+			{ id: 'category', indentLevel: 0, guide: false },
+			{ id: 'child', indentLevel: 0, guide: false },
+		]);
+	});
+
 	it('reload re-fetches an expanded node and restores the expansion beneath it', async () => {
 		// Every branch yields one branch child, so the tree can be opened to any depth.
 		const getChildren = vi.fn(async (node: TreeNode<DemoNode>) => [branch(`${node.id}.0`)]);

--- a/src/vs/workbench/browser/positronTree/test/browser/positronTree.vitest.tsx
+++ b/src/vs/workbench/browser/positronTree/test/browser/positronTree.vitest.tsx
@@ -19,8 +19,9 @@ import { PositronTree } from '../../positronTree.js';
 import { TreeNode } from '../../classes/treeNode.js';
 import { PositronTreeInstance } from '../../classes/positronTreeInstance.js';
 
-// Mirror the gallery harness's row height so virtualization math is concrete.
+// Mirror the gallery harness's row height and indent so virtualization math is concrete.
 const ROW_HEIGHT = 22;
+const INDENT_WIDTH = 16;
 
 // A layout size that produces a scrollable viewport: short enough that 10 rows overflow it.
 const VIEWPORT_WIDTH = 300;
@@ -122,6 +123,7 @@ describe('PositronTreeInstance', () => {
 	async function newTree(rootCount: number, childrenPerNode: number) {
 		const instance = new PositronTreeInstance<DemoNode>({
 			rowHeight: ROW_HEIGHT,
+			indentWidth: INDENT_WIDTH,
 			getRoots: async () => Array.from({ length: rootCount }, (_, i) => branch(`r${i}`)),
 			getChildren: async node => Array.from(
 				{ length: childrenPerNode },
@@ -185,6 +187,7 @@ describe('PositronTreeInstance', () => {
 		const getChildren = vi.fn(async (node: TreeNode<DemoNode>) => [branch(`${node.id}.0`)]);
 		const instance = new PositronTreeInstance<DemoNode>({
 			rowHeight: ROW_HEIGHT,
+			indentWidth: INDENT_WIDTH,
 			getRoots: async () => [branch('r0')],
 			getChildren,
 			renderNode: visible => <span>{visible.node.data.label}</span>,
@@ -229,6 +232,7 @@ describe('PositronTreeInstance', () => {
 		let firstFetch = true;
 		const instance = new PositronTreeInstance<DemoNode>({
 			rowHeight: ROW_HEIGHT,
+			indentWidth: INDENT_WIDTH,
 			getRoots: async () => [branch('r0')],
 			getChildren: async node => {
 				if (node.id !== 'r0') {
@@ -268,6 +272,7 @@ describe('PositronTreeInstance', () => {
 		let fetchSequence = 0;
 		const instance = new PositronTreeInstance<DemoNode>({
 			rowHeight: ROW_HEIGHT,
+			indentWidth: INDENT_WIDTH,
 			getRoots: async () => [branch('r0')],
 			getChildren: async node => {
 				const id = `child@${fetchSequence++}`;
@@ -312,6 +317,7 @@ describe('PositronTreeInstance', () => {
 		let reloading = false;
 		const instance = new PositronTreeInstance<DemoNode>({
 			rowHeight: ROW_HEIGHT,
+			indentWidth: INDENT_WIDTH,
 			getRoots: async () => [branch('r0')],
 			getChildren: async node => reloading ? pending.promise : [leaf(`${node.id}.0`), leaf(`${node.id}.1`)],
 			renderNode: visible => <span>{visible.node.data.label}</span>,
@@ -365,6 +371,7 @@ describe('PositronTreeInstance', () => {
 		let reloading = false;
 		const tree = new DropOnCollapseTree({
 			rowHeight: ROW_HEIGHT,
+			indentWidth: INDENT_WIDTH,
 			getRoots: async () => [branch('r0')],
 			getChildren: async () => reloading ? pending.promise : [leaf('before')],
 			renderNode: visible => <span>{visible.node.data.label}</span>,
@@ -394,6 +401,7 @@ describe('PositronTreeInstance', () => {
 		let peakInFlight = 0;
 		const tree = new PositronTreeInstance<DemoNode>({
 			rowHeight: ROW_HEIGHT,
+			indentWidth: INDENT_WIDTH,
 			getRoots: async () => [branch('r0')],
 			getChildren: async node => {
 				if (node.id === 'r0') {
@@ -431,6 +439,7 @@ describe('PositronTreeInstance', () => {
 		let reloading = false;
 		const tree = new PositronTreeInstance<DemoNode>({
 			rowHeight: ROW_HEIGHT,
+			indentWidth: INDENT_WIDTH,
 			getRoots: async () => [branch('r0'), branch('r1')],
 			getChildren: async node => {
 				if (reloading && node.id === 'r0') {
@@ -478,6 +487,7 @@ describe('PositronTreeInstance', () => {
 		let shouldFail = false;
 		const instance = new PositronTreeInstance<DemoNode>({
 			rowHeight: ROW_HEIGHT,
+			indentWidth: INDENT_WIDTH,
 			getRoots: async () => [branch('r0')],
 			getChildren: async node => {
 				if (shouldFail) {
@@ -556,6 +566,7 @@ describe('PositronTreeInstance', () => {
 		const getChildren = vi.fn(async (node: TreeNode<DemoNode>) => [leaf(`${node.id}.0`)]);
 		const tree = new PositronTreeInstance<DemoNode>({
 			rowHeight: ROW_HEIGHT,
+			indentWidth: INDENT_WIDTH,
 			getRoots,
 			getChildren,
 			renderNode: visible => <span>{visible.node.data.label}</span>,
@@ -588,6 +599,7 @@ describe('PositronTreeInstance', () => {
 			let handle = 0;
 			const tree = new PositronTreeInstance<DemoNode>({
 				rowHeight: ROW_HEIGHT,
+				indentWidth: INDENT_WIDTH,
 				getRoots: async () => [{ id: 'root', data: { label: 'root' }, hasChildren: true }],
 				getChildren: async () => [{ id: `child@${handle++}`, data: { label: 'child' }, hasChildren: false }],
 				getReloadKey: node => node.data.label,
@@ -646,6 +658,7 @@ describe('PositronTreeInstance', () => {
 		});
 		const tree = new PositronTreeInstance<DemoNode>({
 			rowHeight: ROW_HEIGHT,
+			indentWidth: INDENT_WIDTH,
 			getRoots,
 			getChildren,
 			renderNode: visible => <span>{visible.node.data.label}</span>,
@@ -729,6 +742,7 @@ describe('PositronTree keyboard navigation', () => {
 	async function renderFlatTree(leafCount: number, selectionFollowsCursor = false) {
 		const common = {
 			rowHeight: ROW_HEIGHT,
+			indentWidth: INDENT_WIDTH,
 			getRoots: async () => Array.from({ length: leafCount }, (_, i) => leaf(`n${i}`)),
 			getChildren: async () => [],
 			renderNode: (visible: { node: TreeNode<DemoNode> }) => <span>{visible.node.data.label}</span>,
@@ -849,6 +863,7 @@ describe('PositronTree rendering and loading states', () => {
 	): PositronTreeInstance<DemoNode> {
 		const instance = new PositronTreeInstance<DemoNode>({
 			rowHeight: ROW_HEIGHT,
+			indentWidth: INDENT_WIDTH,
 			getRoots,
 			getChildren,
 			renderNode: visible => <span>{visible.node.data.label}</span>,
@@ -870,6 +885,31 @@ describe('PositronTree rendering and loading states', () => {
 		await instance.expand('r0');
 		expect(await screen.findByRole('button', { name: 'Collapse' })).toBeInTheDocument();
 		expect(await screen.findByText('r0.0')).toBeInTheDocument();
+	});
+
+	it('insets each row by its depth and repaints when the indent width changes', async () => {
+		const instance = new PositronTreeInstance<DemoNode>({
+			rowHeight: ROW_HEIGHT,
+			indentWidth: 20,
+			getRoots: async () => [branch('r0')],
+			getChildren: async () => [leaf('r0.0')],
+			renderNode: visible => <span>{visible.node.data.label}</span>,
+		});
+		store.add(instance);
+		await instance.refresh();
+		await instance.expand('r0');
+		rtl.render(<PositronTree instance={instance} />);
+
+		// One spacer per row, in visible order: the root sits at depth 0 and its child at depth 1,
+		// so only the child is inset.
+		const indents = async () =>
+			(await screen.findAllByTestId('positron-tree-indent')).map(el => el.style.width);
+		expect(await indents()).toEqual(['0px', '20px']);
+
+		// Narrowing the indent repaints the existing rows in place -- nothing is re-fetched and the
+		// expansion is untouched, so the child is still on screen at its new inset.
+		instance.setIndentWidth(8);
+		await waitFor(async () => expect(await indents()).toEqual(['0px', '8px']));
 	});
 
 	it('marks the focused cursor row when the tree has focus', async () => {

--- a/src/vs/workbench/contrib/positronControlGallery/browser/galleries/positronTreeGallery.tsx
+++ b/src/vs/workbench/contrib/positronControlGallery/browser/galleries/positronTreeGallery.tsx
@@ -18,6 +18,10 @@ import { controlGalleryRegistry } from '../controlGalleryRegistry.js';
 
 const ROW_HEIGHT = 22;
 
+// A fixed indent for the harness, so the gallery shows the same tree on every machine rather than
+// one whose density depends on the reader's settings.
+const INDENT_WIDTH = 16;
+
 /**
  * Synthetic node payload for the harness. The id is encoded in TreeNode.id; the data field
  * just carries a display label.
@@ -92,6 +96,7 @@ const PositronTreeHarness = () => {
 
 		const tree = new PositronTreeInstance<DemoNode>({
 			rowHeight: ROW_HEIGHT,
+			indentWidth: INDENT_WIDTH,
 			getRoots: async () => {
 				await delay(knobsRef.current.fetchDelayMs);
 				return buildChildrenForPath([], knobsRef.current.fanOut, knobsRef.current.maxDepth);

--- a/src/vs/workbench/contrib/positronDataConnections/browser/classes/dataConnectionsTreeInstance.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/classes/dataConnectionsTreeInstance.tsx
@@ -10,8 +10,10 @@ import { ReactNode } from 'react';
 import { DataConnectionEntryRow } from '../components/dataConnectionEntryRow.js';
 import { DataConnectionNodeRow } from '../components/dataConnectionNodeRow.js';
 import { TreeNode, TreeNodeContext, VisibleNode } from '../../../../browser/positronTree/classes/treeNode.js';
-import { PositronTreeInstance } from '../../../../browser/positronTree/classes/positronTreeInstance.js';
 import { MouseSelectionType } from '../../../../browser/positronDataGrid/classes/dataGridInstance.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { POSITRON_DATA_CONNECTIONS_TREE_INDENT_KEY } from '../positronDataConnectionsConfiguration.js';
+import { PositronTreeInstance } from '../../../../browser/positronTree/classes/positronTreeInstance.js';
 import { IDataConnectionNodeDTO } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDTOs.js';
 import { IDataConnectionInstance } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionInstance.js';
 import { IPositronDataConnectionsService } from '../../../../services/positronDataConnections/common/interfaces/positronDataConnectionsService.js';
@@ -81,6 +83,34 @@ const wrapEntry = (entry: DataConnectionEntry): TreeNode<DataConnectionNode> => 
 	hasChildren: true,
 });
 
+/**
+ * The workbench-wide per-level tree indent setting, in pixels, which this view's own indent falls
+ * back to. listService.ts registers the key and reads it for VS Code's own trees but keeps the
+ * constant private, so it is repeated here rather than making an upstream file export it.
+ */
+const TREE_INDENT_KEY = 'workbench.tree.indent';
+
+/**
+ * Resolves the tree's per-level indent width: this view's own setting when set, and the
+ * workbench-wide tree indent when it is left at the inheriting default of 0. Both keys register
+ * numeric defaults, so both reads are trusted to be numbers -- the same trust explorerViewer.ts
+ * places in the workbench key.
+ *
+ * The view has a knob of its own because it nests far deeper than the trees workbench.tree.indent
+ * was tuned for -- see POSITRON_DATA_CONNECTIONS_TREE_INDENT_KEY -- but it inherits by default so
+ * that a user who turns the workbench setting down doesn't have to discover a second one.
+ *
+ * @param configurationService The configuration service.
+ * @returns The indent width in pixels.
+ */
+const resolveIndentWidth = (configurationService: IConfigurationService): number => {
+	// Zero is this view's "inherit the workbench setting" sentinel rather than a width.
+	const viewIndentWidth = configurationService.getValue<number>(POSITRON_DATA_CONNECTIONS_TREE_INDENT_KEY);
+	return viewIndentWidth > 0
+		? viewIndentWidth
+		: configurationService.getValue<number>(TREE_INDENT_KEY);
+};
+
 const wrapDto = (dto: IDataConnectionNodeDTO, handle: IDataConnectionHandle): TreeNode<DataConnectionNode> => ({
 	id: dtoNodeId(handle, dto),
 	data: { kind: 'dto', dto, handle },
@@ -97,10 +127,13 @@ const wrapDto = (dto: IDataConnectionNodeDTO, handle: IDataConnectionHandle): Tr
  * handle.
  */
 export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnectionNode> {
-	constructor(private readonly _service: IPositronDataConnectionsService) {
+	constructor(
+		private readonly _service: IPositronDataConnectionsService,
+		private readonly _configurationService: IConfigurationService,
+	) {
 		super({
 			rowHeight: ROW_HEIGHT,
-			indentWidth: 16,
+			indentWidth: resolveIndentWidth(_configurationService),
 			getRoots: async () => buildEntries(_service).map(wrapEntry),
 			// Bound to `this` so the closure can reach _service for the connect-on-expand path.
 			getChildren: node => this._fetchChildrenForNode(node),
@@ -122,6 +155,17 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 		this._register(this._service.onDidChangeProfiles(refreshRoots));
 		this._register(this._service.onDidChangeInstances(refreshRoots));
 		this._register(this._service.onDidChangeDiscoveredProfiles(refreshRoots));
+
+		// Track both indent settings live -- the workbench one matters even while this view's own is
+		// set, since clearing the latter back to 0 has to fall through to it. Indent takes effect
+		// without a reload everywhere else in the workbench, and a user dialing it in wants the tree
+		// to answer as they drag.
+		this._register(this._configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(POSITRON_DATA_CONNECTIONS_TREE_INDENT_KEY) ||
+				e.affectsConfiguration(TREE_INDENT_KEY)) {
+				this.setIndentWidth(resolveIndentWidth(this._configurationService));
+			}
+		}));
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronDataConnections/browser/classes/dataConnectionsTreeInstance.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/classes/dataConnectionsTreeInstance.tsx
@@ -12,7 +12,7 @@ import { DataConnectionNodeRow } from '../components/dataConnectionNodeRow.js';
 import { TreeNode, TreeNodeContext, VisibleNode } from '../../../../browser/positronTree/classes/treeNode.js';
 import { MouseSelectionType } from '../../../../browser/positronDataGrid/classes/dataGridInstance.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
-import { POSITRON_DATA_CONNECTIONS_MINIMUM_INDENT_WIDTH, POSITRON_DATA_CONNECTIONS_TREE_HIDE_SINGLE_SCHEMA_KEY, POSITRON_DATA_CONNECTIONS_TREE_INDENT_KEY } from '../positronDataConnectionsConfiguration.js';
+import { POSITRON_DATA_CONNECTIONS_MINIMUM_INDENT_WIDTH, POSITRON_DATA_CONNECTIONS_TREE_INDENT_KEY, POSITRON_DATA_CONNECTIONS_TREE_SHOW_SINGLE_SCHEMA_KEY } from '../positronDataConnectionsConfiguration.js';
 import { CONTAINER_ONLY_KINDS } from '../../../../services/positronDataConnections/common/dataConnectionSchemaSummary.js';
 import { PositronTreeInstance } from '../../../../browser/positronTree/classes/positronTreeInstance.js';
 import { IDataConnectionNodeDTO } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDTOs.js';
@@ -58,9 +58,9 @@ export type DataConnectionNode =
 	};
 
 /**
- * The schemas group kind. Called out on its own because it is the one namespace tier a user can ask
- * to have hidden outright when it holds a single schema -- see
- * POSITRON_DATA_CONNECTIONS_TREE_HIDE_SINGLE_SCHEMA_KEY.
+ * The schemas group kind. Called out on its own because it is the one namespace tier that is hidden
+ * outright when it holds a single schema, rather than breadcrumbed like the rest -- see
+ * POSITRON_DATA_CONNECTIONS_TREE_SHOW_SINGLE_SCHEMA_KEY, the opt-in that brings it back.
  */
 const SCHEMAS_GROUP_KIND = 'group-schemas';
 
@@ -173,9 +173,11 @@ const wrapDto = (
  * handle.
  */
 export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnectionNode> {
-	// Ids of breadcrumbed rows this tree has already opened once, so a row the user then closed is
-	// left closed rather than reopened by the next fetch. See _expandBreadcrumbed.
-	private readonly _autoExpandedBreadcrumbs = new Set<string>();
+	// Children the breadcrumb look-ahead fetched for a namespace group that went on to keep its row,
+	// held until that group is expanded so the user's own expand doesn't repeat the query. Keyed by
+	// the group's node id, which carries the node handle the fetch minted, so an entry can only ever
+	// be read by the row it was fetched for. See _breadcrumbNamespaceGroups and _takeLookAhead.
+	private readonly _lookAheadChildren = new Map<string, readonly IDataConnectionNodeDTO[]>();
 
 	constructor(
 		private readonly _service: IPositronDataConnectionsService,
@@ -216,12 +218,12 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 				this.setIndentWidth(resolveIndentWidth(this._configurationService));
 			}
 
-			// Whether the schema tier is hidden is decided by the fetch, so the rows already on
-			// screen were built under the old answer and a reload is what re-decides them -- the
-			// same re-decision a schema gaining or losing a sibling gets. Without it the setting
-			// would appear to do nothing until the user reloaded the window, which for a display
-			// toggle reads as a bug.
-			if (e.affectsConfiguration(POSITRON_DATA_CONNECTIONS_TREE_HIDE_SINGLE_SCHEMA_KEY)) {
+			// Whether a lone schema is shown is decided by the fetch, so the rows already on screen
+			// were built under the old answer and a reload is what re-decides them -- the same
+			// re-decision a schema gaining or losing a sibling gets. Without it the setting would
+			// appear to do nothing until the user reloaded the window, which for a display toggle
+			// reads as a bug.
+			if (e.affectsConfiguration(POSITRON_DATA_CONNECTIONS_TREE_SHOW_SINGLE_SCHEMA_KEY)) {
 				// Fire and forget, as the panel's own Refresh button does: nothing here can act on
 				// the result, and a failed reload surfaces through the tree's per-node error state.
 				void this.reloadAll();
@@ -246,18 +248,25 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 	 * Reloads a subtree. Breadcrumbing is decided by the fetch, so a reload re-decides it: a schema
 	 * that has gained a sibling comes back as an ordinary "Schemas" group, and one that has lost its
 	 * siblings comes back breadcrumbed.
+	 *
+	 * Deliberately does not auto-open breadcrumbed rows the way a first expand does. The base
+	 * restores the expansion the user had, matching rows to their counterparts by reload key rather
+	 * than by id, so a reload already reopens the breadcrumbed rows that were open and leaves the
+	 * ones the user had closed alone. Running the auto-open on top of that would reopen the closed
+	 * ones, since after a reload they are indistinguishable from rows appearing for the first time.
 	 */
 	override async reload(id: string): Promise<void> {
+		this._lookAheadChildren.clear();
 		await super.reload(id);
-		await this._expandBreadcrumbed();
 	}
 
 	/**
-	 * Reloads every connection. Same breadcrumb re-decision as reload.
+	 * Reloads every connection. Same breadcrumb re-decision, and the same deference to the base's
+	 * expansion restoration, as reload.
 	 */
 	override async reloadAll(): Promise<void> {
+		this._lookAheadChildren.clear();
 		await super.reloadAll();
-		await this._expandBreadcrumbed();
 	}
 
 	/**
@@ -331,6 +340,13 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 			if (entry.instance === undefined && this.hasLoadedChildren(id)) {
 				super.collapse(id);
 				this.dropLoadedChildren(id);
+
+				// The dropped subtree's node handles die with the connection, so anything the
+				// look-ahead is still holding for it is unusable. Cleared wholesale rather than per
+				// connection: the entries are keyed by node id, which cannot be mapped back to a
+				// connection that is already gone, and the cost of clearing is one repeated query
+				// on some other connection's next expand.
+				this._lookAheadChildren.clear();
 			}
 		}
 	}
@@ -341,6 +357,9 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 	 * inside the base class's _fetchChildren means the loading state (twisty spinner) covers
 	 * the connect + getChildren as one continuous operation, and a connect failure surfaces
 	 * through the tree's existing error state.
+	 *
+	 * A namespace group that kept its row is answered from what the look-ahead already fetched for
+	 * it, so opening it costs nothing rather than repeating that query.
 	 */
 	private async _fetchChildrenForNode(
 		node: TreeNode<DataConnectionNode>
@@ -354,10 +373,25 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 				return this._breadcrumbNamespaceGroups(dtos, instance.connectionHandle);
 			}
 			case 'dto': {
-				const dtos = await data.handle.nodeGetChildren(data.dto.nodeHandle);
+				const dtos = this._takeLookAhead(node.id)
+					?? await data.handle.nodeGetChildren(data.dto.nodeHandle);
 				return this._breadcrumbNamespaceGroups(dtos, data.handle);
 			}
 		}
+	}
+
+	/**
+	 * Returns the children the look-ahead fetched for a node, if it has any waiting, and forgets
+	 * them. Taken rather than read: the entry answers exactly one fetch, so a later re-fetch of the
+	 * same node goes to the source and sees anything that has changed since.
+	 *
+	 * @param id The node id to take the look-ahead result for.
+	 * @returns The children, or undefined when the look-ahead has nothing for this node.
+	 */
+	private _takeLookAhead(id: string): readonly IDataConnectionNodeDTO[] | undefined {
+		const children = this._lookAheadChildren.get(id);
+		this._lookAheadChildren.delete(id);
+		return children;
 	}
 
 	/**
@@ -369,9 +403,9 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 	 * Deciding this needs the group's children, so a namespace group costs one extra round trip on
 	 * the level above it, paid whether or not the user goes on to open it.
 	 *
-	 * A lone schema is the one case that can go further than breadcrumbing and disappear altogether,
-	 * when the user asks for that -- see _elideSingleSchema. That is why this returns a level rather
-	 * than a node per DTO: one group can expand into the several rows that stood beneath it.
+	 * A lone schema goes further than breadcrumbing and disappears altogether, unless the user has
+	 * opted to keep it -- see _elideSingleSchema. That is why this returns a level rather than a
+	 * node per DTO: one group can expand into the several rows that stood beneath it.
 	 *
 	 * @param dtos The level's DTOs.
 	 * @param handle The connection handle the DTOs came from.
@@ -398,7 +432,7 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 			}
 
 			if (children.length === 1) {
-				if (dto.kind === SCHEMAS_GROUP_KIND && this._hideSingleSchema()) {
+				if (dto.kind === SCHEMAS_GROUP_KIND && !this._showSingleSchema()) {
 					const contents = await this._elideSingleSchema(children[0], handle);
 					if (contents !== undefined) {
 						return contents;
@@ -407,27 +441,33 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 				return [wrapDto(children[0], handle, dto.name)];
 			}
 
-			// The children are deliberately dropped when the group keeps its row. Handing them to
-			// the tree would save the user's own expand a repeat of this query, but this runs inside
-			// a reload's staged fetch as well, and a reload whose result is discarded (its node
-			// collapsed while it was in flight) would leave those children behind in the live map,
-			// keyed by a node that never arrived and holding ext-host handles nothing can release.
-			return [wrapDto(dto, handle)];
+			// The group keeps its row, and the children the look-ahead just fetched are the ones its
+			// expand would ask for, so they are held for that expand to consume rather than queried
+			// twice. On a warehouse connection that second query is seconds, at every namespace
+			// level, on every reload.
+			//
+			// Held to the side rather than handed straight to the tree with setChildren: that writes
+			// into the live children map, and this also runs inside a reload's staged fetch, whose
+			// result is discarded if its node was collapsed while the fetch was in flight. The
+			// entries would outlive the rows they belong to.
+			const group = wrapDto(dto, handle);
+			this._lookAheadChildren.set(group.id, children);
+			return [group];
 		}));
 
 		return level.flat();
 	}
 
 	/**
-	 * Whether the user has asked for a connection's only schema to be hidden rather than
-	 * breadcrumbed. Read live rather than cached in the constructor, so a toggle takes effect on the
-	 * next fetch; the constructor's change handler reloads to make that immediate. Compared against
-	 * true so that an unset value -- and a configuration service that does not know the key -- reads
-	 * as the registered default of off.
+	 * Whether the user has asked to keep a connection's only schema in the tree, breadcrumbed into
+	 * its group, rather than have it dropped. Read live rather than cached in the constructor, so a
+	 * toggle takes effect on the next fetch; the constructor's change handler reloads to make that
+	 * immediate. Compared against true so that an unset value -- and a configuration service that
+	 * does not know the key -- reads as the registered default of off.
 	 */
-	private _hideSingleSchema(): boolean {
+	private _showSingleSchema(): boolean {
 		return this._configurationService.getValue<boolean>(
-			POSITRON_DATA_CONNECTIONS_TREE_HIDE_SINGLE_SCHEMA_KEY) === true;
+			POSITRON_DATA_CONNECTIONS_TREE_SHOW_SINGLE_SCHEMA_KEY) === true;
 	}
 
 	/**
@@ -437,8 +477,9 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 	 * Tables and Views.
 	 *
 	 * This costs a second look-ahead -- the group's children found the schema, and this fetches the
-	 * schema's -- which is why it is behind a setting that is off by default rather than the
-	 * standing behavior. The result is not wasted: these are the rows the level now holds.
+	 * schema's -- so opening a single-schema connection is three sequential round trips rather than
+	 * two. That is the price of the default; the result is not wasted, since these are the rows the
+	 * level goes on to hold. Turning the setting on takes the second one back off.
 	 *
 	 * Returns undefined when the schema cannot stand aside, leaving the caller to breadcrumb it as
 	 * usual. A schema with no children is one of those cases: eliding it would leave the connection
@@ -483,23 +524,23 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 	 * handed between the two is drained by whichever operation finishes first, against rows another
 	 * one has not inserted yet. The projection is the same answer whoever asks and whenever.
 	 *
-	 * Rows already opened once are recorded, so a row the user then closed stays closed. Node ids
-	 * carry the fetch that minted them, so a reload's replacement rows are new ids and open again.
+	 * A row the user has closed is left closed, and having loaded children is what tells the two
+	 * apart: a row that has never been opened has none, and one the user opened and then closed
+	 * keeps them (a collapse does not drop them). Deliberately not a set of ids the tree has already
+	 * opened -- the extension host mints a fresh node handle every time it serializes a node, so a
+	 * row's id changes on every fetch and such a set would treat every replacement row as unseen.
+	 * The reload path avoids the question entirely by leaving expansion to the base, which matches
+	 * rows by reload key; see reload.
 	 */
 	private async _expandBreadcrumbed(): Promise<void> {
 		const toExpand = this.visibleNodes
 			.filter(visible =>
 				visible.node.data.kind === 'dto' &&
 				visible.node.data.labelPrefix !== undefined &&
-				!this._autoExpandedBreadcrumbs.has(visible.node.id))
+				!this.isExpanded(visible.node.id) &&
+				!this.hasLoadedChildren(visible.node.id))
 			.map(visible => visible.node.id);
-		if (toExpand.length === 0) {
-			return;
-		}
 
-		for (const id of toExpand) {
-			this._autoExpandedBreadcrumbs.add(id);
-		}
 		await Promise.all(toExpand.map(id => this.expand(id)));
 	}
 

--- a/src/vs/workbench/contrib/positronDataConnections/browser/classes/dataConnectionsTreeInstance.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/classes/dataConnectionsTreeInstance.tsx
@@ -12,7 +12,7 @@ import { DataConnectionNodeRow } from '../components/dataConnectionNodeRow.js';
 import { TreeNode, TreeNodeContext, VisibleNode } from '../../../../browser/positronTree/classes/treeNode.js';
 import { MouseSelectionType } from '../../../../browser/positronDataGrid/classes/dataGridInstance.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
-import { POSITRON_DATA_CONNECTIONS_MINIMUM_INDENT_WIDTH, POSITRON_DATA_CONNECTIONS_TREE_INDENT_KEY } from '../positronDataConnectionsConfiguration.js';
+import { POSITRON_DATA_CONNECTIONS_MINIMUM_INDENT_WIDTH, POSITRON_DATA_CONNECTIONS_TREE_HIDE_SINGLE_SCHEMA_KEY, POSITRON_DATA_CONNECTIONS_TREE_INDENT_KEY } from '../positronDataConnectionsConfiguration.js';
 import { CONTAINER_ONLY_KINDS } from '../../../../services/positronDataConnections/common/dataConnectionSchemaSummary.js';
 import { PositronTreeInstance } from '../../../../browser/positronTree/classes/positronTreeInstance.js';
 import { IDataConnectionNodeDTO } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDTOs.js';
@@ -58,6 +58,13 @@ export type DataConnectionNode =
 	};
 
 /**
+ * The schemas group kind. Called out on its own because it is the one namespace tier a user can ask
+ * to have hidden outright when it holds a single schema -- see
+ * POSITRON_DATA_CONNECTIONS_TREE_HIDE_SINGLE_SCHEMA_KEY.
+ */
+const SCHEMAS_GROUP_KIND = 'group-schemas';
+
+/**
  * Group kinds that name a namespace tier -- the levels a connection is organized by, above the
  * objects themselves. A group of these kinds holding exactly one child is breadcrumbed into that
  * child, because it is pure ceremony: "Schemas" over a lone "public" costs a level and a click to
@@ -69,7 +76,7 @@ export type DataConnectionNode =
 const BREADCRUMB_GROUP_KINDS = new Set([
 	'group-databases',
 	'group-catalogs',
-	'group-schemas',
+	SCHEMAS_GROUP_KIND,
 ]);
 
 const entryNodeId = (profile: IDataConnectionProfile): string => `entry:${profile.id}`;
@@ -207,6 +214,17 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 			if (e.affectsConfiguration(POSITRON_DATA_CONNECTIONS_TREE_INDENT_KEY) ||
 				e.affectsConfiguration(TREE_INDENT_KEY)) {
 				this.setIndentWidth(resolveIndentWidth(this._configurationService));
+			}
+
+			// Whether the schema tier is hidden is decided by the fetch, so the rows already on
+			// screen were built under the old answer and a reload is what re-decides them -- the
+			// same re-decision a schema gaining or losing a sibling gets. Without it the setting
+			// would appear to do nothing until the user reloaded the window, which for a display
+			// toggle reads as a bug.
+			if (e.affectsConfiguration(POSITRON_DATA_CONNECTIONS_TREE_HIDE_SINGLE_SCHEMA_KEY)) {
+				// Fire and forget, as the panel's own Refresh button does: nothing here can act on
+				// the result, and a failed reload surfaces through the tree's per-node error state.
+				void this.reloadAll();
 			}
 		}));
 	}
@@ -351,17 +369,22 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 	 * Deciding this needs the group's children, so a namespace group costs one extra round trip on
 	 * the level above it, paid whether or not the user goes on to open it.
 	 *
+	 * A lone schema is the one case that can go further than breadcrumbing and disappear altogether,
+	 * when the user asks for that -- see _elideSingleSchema. That is why this returns a level rather
+	 * than a node per DTO: one group can expand into the several rows that stood beneath it.
+	 *
 	 * @param dtos The level's DTOs.
 	 * @param handle The connection handle the DTOs came from.
-	 * @returns The level's tree nodes, with qualifying groups replaced by their only child.
+	 * @returns The level's tree nodes, with qualifying groups replaced by their only child, or by
+	 * that child's own children when the schema tier is being hidden.
 	 */
 	private async _breadcrumbNamespaceGroups(
 		dtos: readonly IDataConnectionNodeDTO[],
 		handle: IDataConnectionHandle
 	): Promise<readonly TreeNode<DataConnectionNode>[]> {
-		return Promise.all(dtos.map(async dto => {
+		const level = await Promise.all(dtos.map(async dto => {
 			if (!BREADCRUMB_GROUP_KINDS.has(dto.kind) || !dto.hasGetChildren) {
-				return wrapDto(dto, handle);
+				return [wrapDto(dto, handle)];
 			}
 
 			let children: readonly IDataConnectionNodeDTO[];
@@ -371,11 +394,17 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 				// The look-ahead is an optimization, so a failure just leaves the group as an
 				// ordinary row. Expanding it will run the same call again and surface the error
 				// through the tree's own error state, where the user can retry it.
-				return wrapDto(dto, handle);
+				return [wrapDto(dto, handle)];
 			}
 
 			if (children.length === 1) {
-				return wrapDto(children[0], handle, dto.name);
+				if (dto.kind === SCHEMAS_GROUP_KIND && this._hideSingleSchema()) {
+					const contents = await this._elideSingleSchema(children[0], handle);
+					if (contents !== undefined) {
+						return contents;
+					}
+				}
+				return [wrapDto(children[0], handle, dto.name)];
 			}
 
 			// The children are deliberately dropped when the group keeps its row. Handing them to
@@ -383,8 +412,64 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 			// a reload's staged fetch as well, and a reload whose result is discarded (its node
 			// collapsed while it was in flight) would leave those children behind in the live map,
 			// keyed by a node that never arrived and holding ext-host handles nothing can release.
-			return wrapDto(dto, handle);
+			return [wrapDto(dto, handle)];
 		}));
+
+		return level.flat();
+	}
+
+	/**
+	 * Whether the user has asked for a connection's only schema to be hidden rather than
+	 * breadcrumbed. Read live rather than cached in the constructor, so a toggle takes effect on the
+	 * next fetch; the constructor's change handler reloads to make that immediate. Compared against
+	 * true so that an unset value -- and a configuration service that does not know the key -- reads
+	 * as the registered default of off.
+	 */
+	private _hideSingleSchema(): boolean {
+		return this._configurationService.getValue<boolean>(
+			POSITRON_DATA_CONNECTIONS_TREE_HIDE_SINGLE_SCHEMA_KEY) === true;
+	}
+
+	/**
+	 * Drops a lone schema out of the tree, returning the rows that stand in its place: its own
+	 * children, spliced into the level where its "Schemas" group would have been. Two tiers vanish
+	 * at once, so a connection to a single-schema database reads straight from the connection to
+	 * Tables and Views.
+	 *
+	 * This costs a second look-ahead -- the group's children found the schema, and this fetches the
+	 * schema's -- which is why it is behind a setting that is off by default rather than the
+	 * standing behavior. The result is not wasted: these are the rows the level now holds.
+	 *
+	 * Returns undefined when the schema cannot stand aside, leaving the caller to breadcrumb it as
+	 * usual. A schema with no children is one of those cases: eliding it would leave the connection
+	 * looking like it holds nothing, which reads as a failed connection rather than an empty schema.
+	 *
+	 * @param schema The lone schema DTO.
+	 * @param handle The connection handle the DTO came from.
+	 * @returns The schema's children as this level's rows, or undefined to fall back.
+	 */
+	private async _elideSingleSchema(
+		schema: IDataConnectionNodeDTO,
+		handle: IDataConnectionHandle
+	): Promise<readonly TreeNode<DataConnectionNode>[] | undefined> {
+		if (!schema.hasGetChildren) {
+			return undefined;
+		}
+
+		let contents: readonly IDataConnectionNodeDTO[];
+		try {
+			contents = await handle.nodeGetChildren(schema.nodeHandle);
+		} catch {
+			// Same reasoning as the group look-ahead above: a failed optimization falls back to the
+			// visible row, where expanding it runs the call again and surfaces the error.
+			return undefined;
+		}
+
+		if (contents.length === 0) {
+			return undefined;
+		}
+
+		return contents.map(dto => wrapDto(dto, handle));
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronDataConnections/browser/classes/dataConnectionsTreeInstance.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/classes/dataConnectionsTreeInstance.tsx
@@ -13,6 +13,7 @@ import { TreeNode, TreeNodeContext, VisibleNode } from '../../../../browser/posi
 import { MouseSelectionType } from '../../../../browser/positronDataGrid/classes/dataGridInstance.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { POSITRON_DATA_CONNECTIONS_TREE_INDENT_KEY } from '../positronDataConnectionsConfiguration.js';
+import { CONTAINER_ONLY_KINDS } from '../../../../services/positronDataConnections/common/dataConnectionSchemaSummary.js';
 import { PositronTreeInstance } from '../../../../browser/positronTree/classes/positronTreeInstance.js';
 import { IDataConnectionNodeDTO } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDTOs.js';
 import { IDataConnectionInstance } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionInstance.js';
@@ -115,6 +116,11 @@ const wrapDto = (dto: IDataConnectionNodeDTO, handle: IDataConnectionHandle): Tr
 	id: dtoNodeId(handle, dto),
 	data: { kind: 'dto', dto, handle },
 	hasChildren: dto.hasGetChildren,
+	// A group node names a category rather than a thing it holds, so it keeps its children at its
+	// own indent: "Tables" above a list of tables already says what they are, and spending a level
+	// to repeat it is what makes a column sit eight steps in. The same set decides which nodes the
+	// schema summarizer flattens, for the same reason.
+	flattensChildren: CONTAINER_ONLY_KINDS.has(dto.kind),
 });
 
 /**

--- a/src/vs/workbench/contrib/positronDataConnections/browser/classes/dataConnectionsTreeInstance.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/classes/dataConnectionsTreeInstance.tsx
@@ -148,6 +148,10 @@ const wrapDto = (
 	// to repeat it is what makes a column sit eight steps in. The same set decides which nodes the
 	// schema summarizer flattens, for the same reason.
 	flattensChildren: CONTAINER_ONLY_KINDS.has(dto.kind),
+	// Both ways this tree drops a level get marked: a group holding its children at its own indent,
+	// and a row breadcrumbed together with the group above it. They read as one thing to the user --
+	// a row standing where two levels used to be -- however differently they got there.
+	foldsLevel: CONTAINER_ONLY_KINDS.has(dto.kind) || labelPrefix !== undefined,
 });
 
 /**

--- a/src/vs/workbench/contrib/positronDataConnections/browser/classes/dataConnectionsTreeInstance.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/classes/dataConnectionsTreeInstance.tsx
@@ -12,7 +12,7 @@ import { DataConnectionNodeRow } from '../components/dataConnectionNodeRow.js';
 import { TreeNode, TreeNodeContext, VisibleNode } from '../../../../browser/positronTree/classes/treeNode.js';
 import { MouseSelectionType } from '../../../../browser/positronDataGrid/classes/dataGridInstance.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
-import { POSITRON_DATA_CONNECTIONS_TREE_INDENT_KEY } from '../positronDataConnectionsConfiguration.js';
+import { POSITRON_DATA_CONNECTIONS_MINIMUM_INDENT_WIDTH, POSITRON_DATA_CONNECTIONS_TREE_INDENT_KEY } from '../positronDataConnectionsConfiguration.js';
 import { CONTAINER_ONLY_KINDS } from '../../../../services/positronDataConnections/common/dataConnectionSchemaSummary.js';
 import { PositronTreeInstance } from '../../../../browser/positronTree/classes/positronTreeInstance.js';
 import { IDataConnectionNodeDTO } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDTOs.js';
@@ -128,9 +128,11 @@ const TREE_INDENT_KEY = 'workbench.tree.indent';
  * @returns The indent width in pixels.
  */
 const resolveIndentWidth = (configurationService: IConfigurationService): number => {
-	// Zero is this view's "inherit the workbench setting" sentinel rather than a width.
+	// Zero is this view's "inherit the workbench setting" sentinel rather than a width, and anything
+	// under the workbench key's own floor of 4 is treated the same way: a JSON schema can't express
+	// "0, or 4 through 40", and at an indent of 1 or 2 the guides tile into a solid bar.
 	const viewIndentWidth = configurationService.getValue<number>(POSITRON_DATA_CONNECTIONS_TREE_INDENT_KEY);
-	return viewIndentWidth > 0
+	return viewIndentWidth >= POSITRON_DATA_CONNECTIONS_MINIMUM_INDENT_WIDTH
 		? viewIndentWidth
 		: configurationService.getValue<number>(TREE_INDENT_KEY);
 };
@@ -164,10 +166,9 @@ const wrapDto = (
  * handle.
  */
 export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnectionNode> {
-	// Ids of rows the last fetch breadcrumbed, waiting to be expanded. Held here rather than
-	// expanded inline because the base has not inserted them into the tree yet when the fetch that
-	// produced them returns. See _expandBreadcrumbed.
-	private readonly _pendingBreadcrumbExpansions = new Set<string>();
+	// Ids of breadcrumbed rows this tree has already opened once, so a row the user then closed is
+	// left closed rather than reopened by the next fetch. See _expandBreadcrumbed.
+	private readonly _autoExpandedBreadcrumbs = new Set<string>();
 
 	constructor(
 		private readonly _service: IPositronDataConnectionsService,
@@ -238,6 +239,15 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 	 */
 	override async reloadAll(): Promise<void> {
 		await super.reloadAll();
+		await this._expandBreadcrumbed();
+	}
+
+	/**
+	 * Re-fetches a subtree in place. Reaches the same fetch as expand and reload, so it can
+	 * breadcrumb too, and opens whatever it produced.
+	 */
+	override async invalidate(id?: string): Promise<void> {
+		await super.invalidate(id);
 		await this._expandBreadcrumbed();
 	}
 
@@ -335,14 +345,11 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 	/**
 	 * Wraps a level's DTOs, breadcrumbing any namespace group that turned out to hold exactly one
 	 * child: the group is dropped and its child takes its place, labeled with the group's name
-	 * ("Schemas" over a lone "public" becomes "Schemas / public"). The replacement is recorded for
-	 * expansion, so the row opens with its contents showing rather than moving the user's click one
-	 * row down. See BREADCRUMB_GROUP_KINDS for which groups qualify and why.
+	 * ("Schemas" over a lone "public" becomes "Schemas / public"). See BREADCRUMB_GROUP_KINDS for
+	 * which groups qualify and why, and _expandBreadcrumbed for how the replacement comes to be open.
 	 *
 	 * Deciding this needs the group's children, so a namespace group costs one extra round trip on
-	 * the level above it. The result is never wasted: a group that turns out to hold several
-	 * children keeps its row and is handed the children that were just fetched, so the user's own
-	 * expand of it is free rather than a repeat of the same query.
+	 * the level above it, paid whether or not the user goes on to open it.
 	 *
 	 * @param dtos The level's DTOs.
 	 * @param handle The connection handle the DTOs came from.
@@ -368,32 +375,47 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 			}
 
 			if (children.length === 1) {
-				const node = wrapDto(children[0], handle, dto.name);
-				this._pendingBreadcrumbExpansions.add(node.id);
-				return node;
+				return wrapDto(children[0], handle, dto.name);
 			}
 
-			const group = wrapDto(dto, handle);
-			this.setChildren(group.id, children.map(child => wrapDto(child, handle)));
-			return group;
+			// The children are deliberately dropped when the group keeps its row. Handing them to
+			// the tree would save the user's own expand a repeat of this query, but this runs inside
+			// a reload's staged fetch as well, and a reload whose result is discarded (its node
+			// collapsed while it was in flight) would leave those children behind in the live map,
+			// keyed by a node that never arrived and holding ext-host handles nothing can release.
+			return wrapDto(dto, handle);
 		}));
 	}
 
 	/**
-	 * Expands the rows the last fetch breadcrumbed. Their children are already loaded (the fetch
-	 * that found the single child left them in hand), so this costs no round trip. Ids that no
-	 * longer exist -- a subtree dropped between the fetch and here -- are no-ops in the base.
+	 * Opens the breadcrumbed rows that are on screen and still closed. A breadcrumbed row stands in
+	 * for a group the user would have had to expand anyway, so leaving it shut would just move the
+	 * click down a row. Its children were not part of the look-ahead -- that fetched the group's
+	 * children, which is the row itself -- so each one costs a round trip of its own.
+	 *
+	 * Read from the projection rather than from a list built during the fetch. Reloads run
+	 * concurrently (reloadAll fans out across roots) and invalidate reaches the same fetch, so a list
+	 * handed between the two is drained by whichever operation finishes first, against rows another
+	 * one has not inserted yet. The projection is the same answer whoever asks and whenever.
+	 *
+	 * Rows already opened once are recorded, so a row the user then closed stays closed. Node ids
+	 * carry the fetch that minted them, so a reload's replacement rows are new ids and open again.
 	 */
 	private async _expandBreadcrumbed(): Promise<void> {
-		if (this._pendingBreadcrumbExpansions.size === 0) {
+		const toExpand = this.visibleNodes
+			.filter(visible =>
+				visible.node.data.kind === 'dto' &&
+				visible.node.data.labelPrefix !== undefined &&
+				!this._autoExpandedBreadcrumbs.has(visible.node.id))
+			.map(visible => visible.node.id);
+		if (toExpand.length === 0) {
 			return;
 		}
 
-		// Taken and cleared up front: expanding these fetches their own children, which can
-		// breadcrumb again and add to the set, and those are drained by that nested call.
-		const pending = [...this._pendingBreadcrumbExpansions];
-		this._pendingBreadcrumbExpansions.clear();
-		await Promise.all(pending.map(id => this.expand(id)));
+		for (const id of toExpand) {
+			this._autoExpandedBreadcrumbs.add(id);
+		}
+		await Promise.all(toExpand.map(id => this.expand(id)));
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronDataConnections/browser/classes/dataConnectionsTreeInstance.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/classes/dataConnectionsTreeInstance.tsx
@@ -47,7 +47,30 @@ export interface DataConnectionEntry {
  */
 export type DataConnectionNode =
 	| { readonly kind: 'entry'; readonly entry: DataConnectionEntry }
-	| { readonly kind: 'dto'; readonly dto: IDataConnectionNodeDTO; readonly handle: IDataConnectionHandle };
+	| {
+		readonly kind: 'dto';
+		readonly dto: IDataConnectionNodeDTO;
+		readonly handle: IDataConnectionHandle;
+
+		// The name of the namespace group this node was breadcrumbed into, set when the node was
+		// that group's only child. Rendered ahead of the node's own name, as "Schemas / public".
+		readonly labelPrefix?: string;
+	};
+
+/**
+ * Group kinds that name a namespace tier -- the levels a connection is organized by, above the
+ * objects themselves. A group of these kinds holding exactly one child is breadcrumbed into that
+ * child, because it is pure ceremony: "Schemas" over a lone "public" costs a level and a click to
+ * say something the row beneath it already says.
+ *
+ * Deliberately not every container kind. A lone "Tables" or "Columns" group still tells the user
+ * what the single row beneath it is, which the row itself does not.
+ */
+const BREADCRUMB_GROUP_KINDS = new Set([
+	'group-databases',
+	'group-catalogs',
+	'group-schemas',
+]);
 
 const entryNodeId = (profile: IDataConnectionProfile): string => `entry:${profile.id}`;
 
@@ -112,9 +135,13 @@ const resolveIndentWidth = (configurationService: IConfigurationService): number
 		: configurationService.getValue<number>(TREE_INDENT_KEY);
 };
 
-const wrapDto = (dto: IDataConnectionNodeDTO, handle: IDataConnectionHandle): TreeNode<DataConnectionNode> => ({
+const wrapDto = (
+	dto: IDataConnectionNodeDTO,
+	handle: IDataConnectionHandle,
+	labelPrefix?: string
+): TreeNode<DataConnectionNode> => ({
 	id: dtoNodeId(handle, dto),
-	data: { kind: 'dto', dto, handle },
+	data: { kind: 'dto', dto, handle, labelPrefix },
 	hasChildren: dto.hasGetChildren,
 	// A group node names a category rather than a thing it holds, so it keeps its children at its
 	// own indent: "Tables" above a list of tables already says what they are, and spending a level
@@ -133,6 +160,11 @@ const wrapDto = (dto: IDataConnectionNodeDTO, handle: IDataConnectionHandle): Tr
  * handle.
  */
 export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnectionNode> {
+	// Ids of rows the last fetch breadcrumbed, waiting to be expanded. Held here rather than
+	// expanded inline because the base has not inserted them into the tree yet when the fetch that
+	// produced them returns. See _expandBreadcrumbed.
+	private readonly _pendingBreadcrumbExpansions = new Set<string>();
+
 	constructor(
 		private readonly _service: IPositronDataConnectionsService,
 		private readonly _configurationService: IConfigurationService,
@@ -184,6 +216,25 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 			this._service.cancelDisconnectWhenUnused(node.entry.profile.id);
 		}
 		await super.expand(id);
+		await this._expandBreadcrumbed();
+	}
+
+	/**
+	 * Reloads a subtree. Breadcrumbing is decided by the fetch, so a reload re-decides it: a schema
+	 * that has gained a sibling comes back as an ordinary "Schemas" group, and one that has lost its
+	 * siblings comes back breadcrumbed.
+	 */
+	override async reload(id: string): Promise<void> {
+		await super.reload(id);
+		await this._expandBreadcrumbed();
+	}
+
+	/**
+	 * Reloads every connection. Same breadcrumb re-decision as reload.
+	 */
+	override async reloadAll(): Promise<void> {
+		await super.reloadAll();
+		await this._expandBreadcrumbed();
 	}
 
 	/**
@@ -268,13 +319,77 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 				const instance = data.entry.instance
 					?? await this._service.connect(data.entry.profile.id);
 				const dtos = await instance.connectionHandle.getChildren();
-				return dtos.map(dto => wrapDto(dto, instance.connectionHandle));
+				return this._breadcrumbNamespaceGroups(dtos, instance.connectionHandle);
 			}
 			case 'dto': {
 				const dtos = await data.handle.nodeGetChildren(data.dto.nodeHandle);
-				return dtos.map(dto => wrapDto(dto, data.handle));
+				return this._breadcrumbNamespaceGroups(dtos, data.handle);
 			}
 		}
+	}
+
+	/**
+	 * Wraps a level's DTOs, breadcrumbing any namespace group that turned out to hold exactly one
+	 * child: the group is dropped and its child takes its place, labeled with the group's name
+	 * ("Schemas" over a lone "public" becomes "Schemas / public"). The replacement is recorded for
+	 * expansion, so the row opens with its contents showing rather than moving the user's click one
+	 * row down. See BREADCRUMB_GROUP_KINDS for which groups qualify and why.
+	 *
+	 * Deciding this needs the group's children, so a namespace group costs one extra round trip on
+	 * the level above it. The result is never wasted: a group that turns out to hold several
+	 * children keeps its row and is handed the children that were just fetched, so the user's own
+	 * expand of it is free rather than a repeat of the same query.
+	 *
+	 * @param dtos The level's DTOs.
+	 * @param handle The connection handle the DTOs came from.
+	 * @returns The level's tree nodes, with qualifying groups replaced by their only child.
+	 */
+	private async _breadcrumbNamespaceGroups(
+		dtos: readonly IDataConnectionNodeDTO[],
+		handle: IDataConnectionHandle
+	): Promise<readonly TreeNode<DataConnectionNode>[]> {
+		return Promise.all(dtos.map(async dto => {
+			if (!BREADCRUMB_GROUP_KINDS.has(dto.kind) || !dto.hasGetChildren) {
+				return wrapDto(dto, handle);
+			}
+
+			let children: readonly IDataConnectionNodeDTO[];
+			try {
+				children = await handle.nodeGetChildren(dto.nodeHandle);
+			} catch {
+				// The look-ahead is an optimization, so a failure just leaves the group as an
+				// ordinary row. Expanding it will run the same call again and surface the error
+				// through the tree's own error state, where the user can retry it.
+				return wrapDto(dto, handle);
+			}
+
+			if (children.length === 1) {
+				const node = wrapDto(children[0], handle, dto.name);
+				this._pendingBreadcrumbExpansions.add(node.id);
+				return node;
+			}
+
+			const group = wrapDto(dto, handle);
+			this.setChildren(group.id, children.map(child => wrapDto(child, handle)));
+			return group;
+		}));
+	}
+
+	/**
+	 * Expands the rows the last fetch breadcrumbed. Their children are already loaded (the fetch
+	 * that found the single child left them in hand), so this costs no round trip. Ids that no
+	 * longer exist -- a subtree dropped between the fetch and here -- are no-ops in the base.
+	 */
+	private async _expandBreadcrumbed(): Promise<void> {
+		if (this._pendingBreadcrumbExpansions.size === 0) {
+			return;
+		}
+
+		// Taken and cleared up front: expanding these fetches their own children, which can
+		// breadcrumb again and add to the set, and those are drained by that nested call.
+		const pending = [...this._pendingBreadcrumbExpansions];
+		this._pendingBreadcrumbExpansions.clear();
+		await Promise.all(pending.map(id => this.expand(id)));
 	}
 
 	/**
@@ -317,7 +432,7 @@ export class DataConnectionsTreeInstance extends PositronTreeInstance<DataConnec
 				// Entries are roots, so no ancestor can be refreshing them out from under the row.
 				return <DataConnectionEntryRow entry={data.entry} onDisconnect={onDisconnect} onMenuOpening={onMenuOpening} onRefresh={onRefresh} />;
 			case 'dto':
-				return <DataConnectionNodeRow dto={data.dto} handle={data.handle} stale={visible.stale} onMenuOpening={onMenuOpening} onRefresh={onRefresh} />;
+				return <DataConnectionNodeRow dto={data.dto} handle={data.handle} labelPrefix={data.labelPrefix} stale={visible.stale} onMenuOpening={onMenuOpening} onRefresh={onRefresh} />;
 		}
 	}
 

--- a/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionEntryRow.css
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionEntryRow.css
@@ -12,15 +12,19 @@
 	align-items: center;
 }
 
+/* Same column as the node rows' icons, so a connection's label and the labels beneath it align. */
 .data-connection-entry-icon {
-	font-size: 14px;
-	margin: 0 3px 0 2px;
+	flex: 0 0 auto;
+	width: 16px;
+	margin-left: 3px;
 	color: var(--vscode-icon-foreground);
 }
 
+/* Gap before the label sits on the label, matching the node rows -- see dataConnectionNodeRow.css. */
 .data-connection-entry-text {
 	flex: 1;
 	min-width: 0;
+	padding-left: 4px;
 	overflow: hidden;
 	white-space: nowrap;
 	text-overflow: ellipsis;

--- a/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionNodeRow.css
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionNodeRow.css
@@ -12,15 +12,23 @@
 	align-items: center;
 }
 
+/*
+ * The icon sits in a column the same width as the twisty column beside it, so the row is laid out on
+ * one repeating step. The glyph is centered in that box, with air on each side of it, so the twisty,
+ * the icon, and the label read as three set columns rather than two crowded ones and a gap.
+ */
 .data-connection-node-icon {
-	font-size: 14px;
-	margin: 0 3px 0 2px;
+	flex: 0 0 auto;
+	width: 16px;
+	margin-left: 3px;
 	color: var(--vscode-icon-foreground);
 }
 
+/* The gap before the label belongs to the label, so the icon column stays a clean 16px step. */
 .data-connection-node-text {
 	flex: 1;
 	min-width: 0;
+	padding-left: 4px;
 	overflow: hidden;
 	white-space: nowrap;
 	text-overflow: ellipsis;

--- a/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionNodeRow.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionNodeRow.tsx
@@ -12,6 +12,8 @@ import { MouseEvent as ReactMouseEvent, useRef, useState } from 'react';
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
 import { IDisposable } from '../../../../../base/common/lifecycle.js';
+import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
+import { CONTAINER_ONLY_KINDS } from '../../../../services/positronDataConnections/common/dataConnectionSchemaSummary.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { CustomContextMenuItem } from '../../../../browser/positronComponents/customContextMenu/customContextMenuItem.js';
 import { CustomContextMenuSeparator } from '../../../../browser/positronComponents/customContextMenu/customContextMenuSeparator.js';
@@ -131,6 +133,11 @@ interface DataConnectionNodeRowProps {
 export const DataConnectionNodeRow = ({ dto, handle, onMenuOpening, onRefresh, stale }: DataConnectionNodeRowProps) => {
 	const { notificationService, positronDataConnectionsService } = usePositronReactServicesContext();
 	const rowRef = useRef<HTMLDivElement>(null);
+	// A group row labels the rows beneath it rather than naming a thing of its own, and it holds them
+	// at its own indent (see wrapDto). Its plural glyph and the indent guide are what tell it apart
+	// from the entities below it; the class carries no styling of its own yet, and is here as the
+	// seam for a treatment if one is wanted.
+	const isGroup = CONTAINER_ONLY_KINDS.has(dto.kind);
 	// Opening a preview can take a moment (a driver may download data first). Track it so the row can
 	// show a spinner for the duration, matching the tree's busy treatment on expansion.
 	const [opening, setOpening] = useState(false);
@@ -229,7 +236,7 @@ export const DataConnectionNodeRow = ({ dto, handle, onMenuOpening, onRefresh, s
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 		<div
 			ref={rowRef}
-			className='data-connection-node-row'
+			className={positronClassNames('data-connection-node-row', { 'group': isGroup })}
 			onContextMenu={onContextMenu}
 			onDoubleClick={onDoubleClick}
 		>

--- a/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionNodeRow.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionNodeRow.tsx
@@ -14,6 +14,7 @@ import { localize } from '../../../../../nls.js';
 import { IDisposable } from '../../../../../base/common/lifecycle.js';
 import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
 import { CONTAINER_ONLY_KINDS } from '../../../../services/positronDataConnections/common/dataConnectionSchemaSummary.js';
+import { useBusyIndicator } from '../../../../../base/browser/positronReactHooks.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { CustomContextMenuItem } from '../../../../browser/positronComponents/customContextMenu/customContextMenuItem.js';
 import { CustomContextMenuSeparator } from '../../../../browser/positronComponents/customContextMenu/customContextMenuSeparator.js';
@@ -144,8 +145,11 @@ export const DataConnectionNodeRow = ({ dto, handle, labelPrefix, onMenuOpening,
 	// seam for a treatment if one is wanted.
 	const isGroup = CONTAINER_ONLY_KINDS.has(dto.kind);
 	// Opening a preview can take a moment (a driver may download data first). Track it so the row can
-	// show a spinner for the duration, matching the tree's busy treatment on expansion.
+	// show a spinner for the duration, matching the tree's busy treatment on expansion. The spinner
+	// is gated so a fast source -- a local PostgreSQL answers in a few milliseconds -- doesn't swap
+	// the row's icon for a spinner and back again faster than the eye can resolve it.
 	const [opening, setOpening] = useState(false);
+	const showOpeningSpinner = useBusyIndicator(opening);
 
 	const openInDataExplorer = async () => {
 		// Ignore a repeat trigger (double-click or context menu) while a preview is already opening.
@@ -245,7 +249,7 @@ export const DataConnectionNodeRow = ({ dto, handle, labelPrefix, onMenuOpening,
 			onContextMenu={onContextMenu}
 			onDoubleClick={onDoubleClick}
 		>
-			<div className={`codicon ${opening ? 'codicon-loading codicon-modifier-spin' : `codicon-${kindIcon(dto)}`} data-connection-node-icon`} />
+			<div className={`codicon ${showOpeningSpinner ? 'codicon-loading codicon-modifier-spin' : `codicon-${kindIcon(dto)}`} data-connection-node-icon`} />
 			<div className='data-connection-node-text'>
 				{labelPrefix !== undefined && `${labelPrefix} · `}
 				{dto.name}

--- a/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionNodeRow.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionNodeRow.tsx
@@ -111,6 +111,11 @@ interface DataConnectionNodeRowProps {
 	dto: IDataConnectionNodeDTO;
 	handle: IDataConnectionHandle;
 
+	// The name of the namespace group this node was breadcrumbed into, when it was that group's
+	// only child. Shown ahead of the node's own name, matching how a connection row reads its
+	// profile and driver as "Bike Share / PostgreSQL".
+	labelPrefix?: string;
+
 	// Reloads this node's subtree. Supplied by the tree, which binds it to this row's node id.
 	onRefresh: () => void;
 
@@ -130,7 +135,7 @@ interface DataConnectionNodeRowProps {
  * Explorer on double-click or via the "Open in Data Explorer" context-menu action; nodes that
  * can have children offer a "Refresh" action that re-fetches the subtree.
  */
-export const DataConnectionNodeRow = ({ dto, handle, onMenuOpening, onRefresh, stale }: DataConnectionNodeRowProps) => {
+export const DataConnectionNodeRow = ({ dto, handle, labelPrefix, onMenuOpening, onRefresh, stale }: DataConnectionNodeRowProps) => {
 	const { notificationService, positronDataConnectionsService } = usePositronReactServicesContext();
 	const rowRef = useRef<HTMLDivElement>(null);
 	// A group row labels the rows beneath it rather than naming a thing of its own, and it holds them
@@ -241,7 +246,10 @@ export const DataConnectionNodeRow = ({ dto, handle, onMenuOpening, onRefresh, s
 			onDoubleClick={onDoubleClick}
 		>
 			<div className={`codicon ${opening ? 'codicon-loading codicon-modifier-spin' : `codicon-${kindIcon(dto)}`} data-connection-node-icon`} />
-			<div className='data-connection-node-text'>{dto.name}</div>
+			<div className='data-connection-node-text'>
+				{labelPrefix !== undefined && `${labelPrefix} · `}
+				{dto.name}
+			</div>
 			{dto.dataType && (
 				<div className='data-connection-node-type'>{dto.dataType}</div>
 			)}

--- a/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionNodeRow.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionNodeRow.tsx
@@ -251,8 +251,10 @@ export const DataConnectionNodeRow = ({ dto, handle, labelPrefix, onMenuOpening,
 		>
 			<div className={`codicon ${showOpeningSpinner ? 'codicon-loading codicon-modifier-spin' : `codicon-${kindIcon(dto)}`} data-connection-node-icon`} />
 			<div className='data-connection-node-text'>
-				{labelPrefix !== undefined && `${labelPrefix} · `}
-				{dto.name}
+				{labelPrefix !== undefined && (
+					<span className='data-connection-node-prefix'>{labelPrefix}{' · '}</span>
+				)}
+				<span className='data-connection-node-name'>{dto.name}</span>
 			</div>
 			{dto.dataType && (
 				<div className='data-connection-node-type'>{dto.dataType}</div>

--- a/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionsPanel.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionsPanel.tsx
@@ -34,12 +34,12 @@ const kPaddingRight = 8;
  */
 export const DataConnectionsPanel = () => {
 	// Context.
-	const { positronDataConnectionsService } = usePositronReactServicesContext();
+	const { configurationService, positronDataConnectionsService } = usePositronReactServicesContext();
 
 	// Tree instance. Constructed once per mount; the instance subscribes to the service's
 	// onDidChangeInstances / onDidChangeProfiles internally and pushes new roots itself, so
 	// no React effect is needed to keep it in sync.
-	const [treeInstance] = useState(() => new DataConnectionsTreeInstance(positronDataConnectionsService));
+	const [treeInstance] = useState(() => new DataConnectionsTreeInstance(positronDataConnectionsService, configurationService));
 
 	// Dispose the tree instance on unmount.
 	useEffect(() => () => treeInstance.dispose(), [treeInstance]);

--- a/src/vs/workbench/contrib/positronDataConnections/browser/positronDataConnections.contribution.ts
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/positronDataConnections.contribution.ts
@@ -13,7 +13,7 @@ import { registerIcon } from '../../../../platform/theme/common/iconRegistry.js'
 import { ViewPaneContainer } from '../../../browser/parts/views/viewPaneContainer.js';
 import { SyncDescriptor } from '../../../../platform/instantiation/common/descriptors.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { POSITRON_DATA_CONNECTIONS_ENABLED_KEY, POSITRON_DATA_CONNECTIONS_TREE_HIDE_SINGLE_SCHEMA_KEY, POSITRON_DATA_CONNECTIONS_TREE_INDENT_KEY } from './positronDataConnectionsConfiguration.js';
+import { POSITRON_DATA_CONNECTIONS_ENABLED_KEY, POSITRON_DATA_CONNECTIONS_TREE_INDENT_KEY, POSITRON_DATA_CONNECTIONS_TREE_SHOW_SINGLE_SCHEMA_KEY } from './positronDataConnectionsConfiguration.js';
 import { IWorkbenchContribution, WorkbenchPhase, registerWorkbenchContribution2 } from '../../../common/contributions.js';
 import { ViewContainer, IViewContainersRegistry, ViewContainerLocation, Extensions as ViewContainerExtensions, IViewsRegistry } from '../../../common/views.js';
 import { ConfigurationScope, Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
@@ -57,16 +57,17 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			scope: ConfigurationScope.WINDOW,
 			included: true,
 		},
-		[POSITRON_DATA_CONNECTIONS_TREE_HIDE_SINGLE_SCHEMA_KEY]: {
+		[POSITRON_DATA_CONNECTIONS_TREE_SHOW_SINGLE_SCHEMA_KEY]: {
 			type: 'boolean',
-			// Off by default, because it trades information for space: a connection with one schema
-			// stops saying it has schemas at all, and the schema's name goes with it. Worth having
-			// for someone whose databases always have exactly one, where the tier is noise every
-			// time; not worth imposing on someone who would then wonder where `public` went.
+			// Off by default: for the many databases that have exactly one schema, the tier is a
+			// level and a click that tell the user nothing they could have chosen differently. The
+			// setting is here for people who want it named anyway -- someone who works across
+			// databases where the schema is sometimes `public` and sometimes not wants to see which
+			// one they are in, even when there is only the one.
 			default: false,
 			markdownDescription: localize(
-				'positron.dataConnections.tree.hideSingleSchema',
-				"Hide the schema level entirely when a connection has only one schema, showing its tables and views directly under the connection. When disabled, a lone schema is shown folded together with its group on a single row (for example `Schemas · public`)."
+				'positron.dataConnections.tree.showSingleSchema',
+				"Show a connection's schema even when it is the only one, folded together with its group on a single row (for example `Schemas · public`). When disabled, a lone schema is hidden and its tables and views are shown directly under the connection."
 			),
 			tags: ['preview'],
 			scope: ConfigurationScope.WINDOW,

--- a/src/vs/workbench/contrib/positronDataConnections/browser/positronDataConnections.contribution.ts
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/positronDataConnections.contribution.ts
@@ -13,7 +13,7 @@ import { registerIcon } from '../../../../platform/theme/common/iconRegistry.js'
 import { ViewPaneContainer } from '../../../browser/parts/views/viewPaneContainer.js';
 import { SyncDescriptor } from '../../../../platform/instantiation/common/descriptors.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { POSITRON_DATA_CONNECTIONS_ENABLED_KEY } from './positronDataConnectionsConfiguration.js';
+import { POSITRON_DATA_CONNECTIONS_ENABLED_KEY, POSITRON_DATA_CONNECTIONS_TREE_INDENT_KEY } from './positronDataConnectionsConfiguration.js';
 import { IWorkbenchContribution, WorkbenchPhase, registerWorkbenchContribution2 } from '../../../common/contributions.js';
 import { ViewContainer, IViewContainersRegistry, ViewContainerLocation, Extensions as ViewContainerExtensions, IViewsRegistry } from '../../../common/views.js';
 import { ConfigurationScope, Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
@@ -34,6 +34,24 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			markdownDescription: localize(
 				'positron.dataConnections.enabled',
 				'Enable the Data Connections panel. Requires a reload to take effect. Can be set per workspace.'
+			),
+			tags: ['preview'],
+			scope: ConfigurationScope.WINDOW,
+			included: true,
+		},
+		[POSITRON_DATA_CONNECTIONS_TREE_INDENT_KEY]: {
+			type: 'number',
+			// Zero inherits workbench.tree.indent, following editor.suggestFontSize, which uses the
+			// same sentinel to fall back to editor.fontSize. Inheriting by default matters here:
+			// someone who finds this tree too wide reaches for the workbench setting first, because
+			// that is the one the Settings editor surfaces for "tree indent", and a view that
+			// quietly ignored it would read as a bug.
+			default: 0,
+			minimum: 0,
+			maximum: 40,
+			markdownDescription: localize(
+				'positron.dataConnections.tree.indent',
+				"Controls tree indentation in the Data Connections view, in pixels. When set to `0`, the value of `#workbench.tree.indent#` is used."
 			),
 			tags: ['preview'],
 			scope: ConfigurationScope.WINDOW,

--- a/src/vs/workbench/contrib/positronDataConnections/browser/positronDataConnections.contribution.ts
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/positronDataConnections.contribution.ts
@@ -13,7 +13,7 @@ import { registerIcon } from '../../../../platform/theme/common/iconRegistry.js'
 import { ViewPaneContainer } from '../../../browser/parts/views/viewPaneContainer.js';
 import { SyncDescriptor } from '../../../../platform/instantiation/common/descriptors.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { POSITRON_DATA_CONNECTIONS_ENABLED_KEY, POSITRON_DATA_CONNECTIONS_TREE_INDENT_KEY } from './positronDataConnectionsConfiguration.js';
+import { POSITRON_DATA_CONNECTIONS_ENABLED_KEY, POSITRON_DATA_CONNECTIONS_TREE_HIDE_SINGLE_SCHEMA_KEY, POSITRON_DATA_CONNECTIONS_TREE_INDENT_KEY } from './positronDataConnectionsConfiguration.js';
 import { IWorkbenchContribution, WorkbenchPhase, registerWorkbenchContribution2 } from '../../../common/contributions.js';
 import { ViewContainer, IViewContainersRegistry, ViewContainerLocation, Extensions as ViewContainerExtensions, IViewsRegistry } from '../../../common/views.js';
 import { ConfigurationScope, Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
@@ -52,6 +52,21 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			markdownDescription: localize(
 				'positron.dataConnections.tree.indent',
 				"Controls tree indentation in the Data Connections view, in pixels. When set to `0`, the value of `#workbench.tree.indent#` is used."
+			),
+			tags: ['preview'],
+			scope: ConfigurationScope.WINDOW,
+			included: true,
+		},
+		[POSITRON_DATA_CONNECTIONS_TREE_HIDE_SINGLE_SCHEMA_KEY]: {
+			type: 'boolean',
+			// Off by default, because it trades information for space: a connection with one schema
+			// stops saying it has schemas at all, and the schema's name goes with it. Worth having
+			// for someone whose databases always have exactly one, where the tier is noise every
+			// time; not worth imposing on someone who would then wonder where `public` went.
+			default: false,
+			markdownDescription: localize(
+				'positron.dataConnections.tree.hideSingleSchema',
+				"Hide the schema level entirely when a connection has only one schema, showing its tables and views directly under the connection. When disabled, a lone schema is shown folded together with its group on a single row (for example `Schemas · public`)."
 			),
 			tags: ['preview'],
 			scope: ConfigurationScope.WINDOW,

--- a/src/vs/workbench/contrib/positronDataConnections/browser/positronDataConnectionsConfiguration.ts
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/positronDataConnectionsConfiguration.ts
@@ -9,3 +9,13 @@
 // commands stay registered and Assistant-side feature-detection is a simple getCommands() check),
 // and positronDataConnectionsInspectActions.ts (the Command Palette entries' precondition).
 export const POSITRON_DATA_CONNECTIONS_ENABLED_KEY = 'dataConnections.enabled';
+
+// Configuration key for the Data Connections tree's per-level indent, in pixels. Zero means "follow
+// workbench.tree.indent" -- see resolveIndentWidth in dataConnectionsTreeInstance.tsx, which reads
+// it, and positronDataConnections.contribution.ts, which registers it.
+//
+// This view gets a knob of its own because it nests far deeper than the trees workbench.tree.indent
+// was tuned for: a column sits up to eight levels down (connection > Catalogs > catalog > Schemas >
+// schema > Tables > table > Columns > column), so every pixel of the per-level step costs eight
+// pixels of the panel's width before the name is reached.
+export const POSITRON_DATA_CONNECTIONS_TREE_INDENT_KEY = 'dataConnections.tree.indent';

--- a/src/vs/workbench/contrib/positronDataConnections/browser/positronDataConnectionsConfiguration.ts
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/positronDataConnectionsConfiguration.ts
@@ -20,6 +20,19 @@ export const POSITRON_DATA_CONNECTIONS_ENABLED_KEY = 'dataConnections.enabled';
 // pixels of the panel's width before the name is reached.
 export const POSITRON_DATA_CONNECTIONS_TREE_INDENT_KEY = 'dataConnections.tree.indent';
 
+// Configuration key controlling whether a connection with exactly one schema drops the schema tier
+// from the tree entirely -- no "Schemas" group and no schema row, with the schema's contents
+// (Tables, Views, and so on) standing directly under the connection or database that holds it.
+// Off by default, so the tier stays visible: by default a lone schema is folded together with its
+// group into one "Schemas · public" row, which still says the schema is there and what it is called.
+// Read by _breadcrumbNamespaceGroups in dataConnectionsTreeInstance.tsx and registered in
+// positronDataConnections.contribution.ts.
+//
+// Schemas only, unlike the folding this replaces (see BREADCRUMB_GROUP_KINDS). Hiding a lone
+// database or catalog would take the connection's own identity with it, and a name the user typed
+// into the connection dialog is not ceremony the tree can decide to drop.
+export const POSITRON_DATA_CONNECTIONS_TREE_HIDE_SINGLE_SCHEMA_KEY = 'dataConnections.tree.hideSingleSchema';
+
 // The narrowest indent this view will render, matching the floor workbench.tree.indent declares for
 // itself. The setting's own minimum has to be 0 to leave room for the inherit sentinel, so this is
 // what keeps 1, 2, and 3 out: at those widths the indent guides tile into a solid bar.

--- a/src/vs/workbench/contrib/positronDataConnections/browser/positronDataConnectionsConfiguration.ts
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/positronDataConnectionsConfiguration.ts
@@ -20,18 +20,17 @@ export const POSITRON_DATA_CONNECTIONS_ENABLED_KEY = 'dataConnections.enabled';
 // pixels of the panel's width before the name is reached.
 export const POSITRON_DATA_CONNECTIONS_TREE_INDENT_KEY = 'dataConnections.tree.indent';
 
-// Configuration key controlling whether a connection with exactly one schema drops the schema tier
-// from the tree entirely -- no "Schemas" group and no schema row, with the schema's contents
-// (Tables, Views, and so on) standing directly under the connection or database that holds it.
-// Off by default, so the tier stays visible: by default a lone schema is folded together with its
-// group into one "Schemas · public" row, which still says the schema is there and what it is called.
-// Read by _breadcrumbNamespaceGroups in dataConnectionsTreeInstance.tsx and registered in
-// positronDataConnections.contribution.ts.
+// Configuration key controlling whether a connection's only schema is shown at all. Off by default:
+// a schema with no siblings is dropped from the tree entirely -- no "Schemas" group and no schema
+// row -- and its contents (Tables, Views, and so on) stand directly under the connection or database
+// that holds it. Turning it on brings the schema back, folded together with its group into one
+// "Schemas · public" row rather than costing two levels. Read by _breadcrumbNamespaceGroups in
+// dataConnectionsTreeInstance.tsx and registered in positronDataConnections.contribution.ts.
 //
-// Schemas only, unlike the folding this replaces (see BREADCRUMB_GROUP_KINDS). Hiding a lone
-// database or catalog would take the connection's own identity with it, and a name the user typed
-// into the connection dialog is not ceremony the tree can decide to drop.
-export const POSITRON_DATA_CONNECTIONS_TREE_HIDE_SINGLE_SCHEMA_KEY = 'dataConnections.tree.hideSingleSchema';
+// Schemas only, unlike the folding it builds on (see BREADCRUMB_GROUP_KINDS). Hiding a lone database
+// or catalog would take the connection's own identity with it, and a name the user typed into the
+// connection dialog is not ceremony the tree can decide to drop.
+export const POSITRON_DATA_CONNECTIONS_TREE_SHOW_SINGLE_SCHEMA_KEY = 'dataConnections.tree.showSingleSchema';
 
 // The narrowest indent this view will render, matching the floor workbench.tree.indent declares for
 // itself. The setting's own minimum has to be 0 to leave room for the inherit sentinel, so this is

--- a/src/vs/workbench/contrib/positronDataConnections/browser/positronDataConnectionsConfiguration.ts
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/positronDataConnectionsConfiguration.ts
@@ -19,3 +19,8 @@ export const POSITRON_DATA_CONNECTIONS_ENABLED_KEY = 'dataConnections.enabled';
 // schema > Tables > table > Columns > column), so every pixel of the per-level step costs eight
 // pixels of the panel's width before the name is reached.
 export const POSITRON_DATA_CONNECTIONS_TREE_INDENT_KEY = 'dataConnections.tree.indent';
+
+// The narrowest indent this view will render, matching the floor workbench.tree.indent declares for
+// itself. The setting's own minimum has to be 0 to leave room for the inherit sentinel, so this is
+// what keeps 1, 2, and 3 out: at those widths the indent guides tile into a solid bar.
+export const POSITRON_DATA_CONNECTIONS_MINIMUM_INDENT_WIDTH = 4;

--- a/src/vs/workbench/contrib/positronDataConnections/test/browser/dataConnectionsTreeInstance.vitest.ts
+++ b/src/vs/workbench/contrib/positronDataConnections/test/browser/dataConnectionsTreeInstance.vitest.ts
@@ -8,6 +8,8 @@
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { IConfigurationChangeEvent } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { DataConnectionNode, DataConnectionsTreeInstance, reloadKey } from '../../browser/classes/dataConnectionsTreeInstance.js';
 import { IDataConnectionNodeDTO } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionDTOs.js';
 import { IDataConnectionInstance } from '../../../../services/positronDataConnections/common/interfaces/dataConnectionInstance.js';
@@ -170,7 +172,16 @@ describe('DataConnectionsTreeInstance', () => {
 	 * flips the profile's live state and notifies the tree, standing in for the service connecting or
 	 * disconnecting it.
 	 */
-	function createTree(connected = true, discoveredProfiles: IDataConnectionProfile[] = []) {
+	function createTree(
+		connected = true,
+		discoveredProfiles: IDataConnectionProfile[] = [],
+		// Seeded with the indent keys the tree reads, since the real configuration service always
+		// has them: both are registered with numeric defaults.
+		configurationService = new TestConfigurationService({
+			'workbench.tree.indent': 16,
+			'dataConnections.tree.indent': 0,
+		})
+	) {
 		// One leaf under the connection, so a test has a real non-entry node to act on. Its node id is
 		// DTO_ID below.
 		const getChildren = vi.fn(async () => [{
@@ -205,7 +216,7 @@ describe('DataConnectionsTreeInstance', () => {
 			cancelDisconnectWhenUnused: vi.fn(),
 		});
 
-		const tree = new DataConnectionsTreeInstance(service);
+		const tree = new DataConnectionsTreeInstance(service, configurationService);
 		ctx.disposables.add(tree);
 
 		const setConnected = (nowConnected: boolean) => {
@@ -215,6 +226,45 @@ describe('DataConnectionsTreeInstance', () => {
 
 		return { tree, service, getChildren, setConnected, disconnect, disconnectWhenUnused };
 	}
+
+	it('inherits the workbench tree indent until its own setting overrides it, and follows both live', async () => {
+		// The view's own indent at its inheriting default of 0.
+		const configurationService = new TestConfigurationService({
+			'workbench.tree.indent': 16,
+			'dataConnections.tree.indent': 0,
+		});
+		const { tree } = createTree(true, [], configurationService);
+
+		// Changes reach the tree without a window reload: a user dialing either setting in wants the
+		// tree to answer as they drag it.
+		const change = async (key: string, value: number) => {
+			await configurationService.setUserConfiguration(key, value);
+			configurationService.onDidChangeConfigurationEmitter.fire(
+				stubInterface<IConfigurationChangeEvent>({
+					affectsConfiguration: (affected: string) => affected === key,
+				})
+			);
+			return tree.indentWidth;
+		};
+
+		expect({
+			inherited: tree.indentWidth,
+			// The workbench setting still drives the tree while this view's own is unset.
+			workbenchChanged: await change('workbench.tree.indent', 8),
+			// Setting the view's own indent takes over from it.
+			overridden: await change('dataConnections.tree.indent', 12),
+			// The workbench setting no longer reaches the tree while the override stands.
+			workbenchIgnored: await change('workbench.tree.indent', 16),
+			// Clearing the override back to 0 falls through to the workbench setting again.
+			clearedBackToInherit: await change('dataConnections.tree.indent', 0),
+		}).toEqual({
+			inherited: 16,
+			workbenchChanged: 8,
+			overridden: 12,
+			workbenchIgnored: 12,
+			clearedBackToInherit: 16,
+		});
+	});
 
 	it('lists discovered connections after the saved ones', async () => {
 		const discovered = createProfile({

--- a/src/vs/workbench/contrib/positronDataConnections/test/browser/dataConnectionsTreeInstance.vitest.ts
+++ b/src/vs/workbench/contrib/positronDataConnections/test/browser/dataConnectionsTreeInstance.vitest.ts
@@ -234,26 +234,33 @@ describe('DataConnectionsTreeInstance', () => {
 	 */
 	function createTreeOverNodes(
 		rootDtos: IDataConnectionNodeDTO[],
-		childrenOf: (nodeHandle: number) => IDataConnectionNodeDTO[]
+		childrenOf: (nodeHandle: number) => IDataConnectionNodeDTO[],
+		profiles: IDataConnectionProfile[] = [profile]
 	) {
 		const nodeGetChildren = vi.fn(async (nodeHandle: number) => childrenOf(nodeHandle));
-		const instance = stubInterface<IDataConnectionInstance>({
-			id: 'instance-1',
-			profileId: profile.id,
-			connectionHandle: stubInterface<IDataConnectionHandle>({
-				handle: 1,
-				getChildren: async () => rootDtos,
-				nodeGetChildren,
+
+		// One instance per profile, each with its own connection handle, so node ids stay distinct
+		// across connections the way they do in the real service.
+		const instances = new Map(profiles.map((forProfile, index) => [
+			forProfile.id,
+			stubInterface<IDataConnectionInstance>({
+				id: `instance-${index + 1}`,
+				profileId: forProfile.id,
+				connectionHandle: stubInterface<IDataConnectionHandle>({
+					handle: index + 1,
+					getChildren: async () => rootDtos,
+					nodeGetChildren,
+				}),
 			}),
-		});
+		]));
 		const service = stubInterface<IPositronDataConnectionsService>({
 			onDidChangeProfiles: Event.None,
 			onDidChangeInstances: onDidChangeInstances.event,
 			onDidChangeDiscoveredProfiles: Event.None,
-			getProfiles: () => [profile],
+			getProfiles: () => profiles,
 			getDiscoveredProfiles: () => [],
-			getInstanceForProfile: () => instance,
-			connect: async () => instance,
+			getInstanceForProfile: (profileId: string) => instances.get(profileId),
+			connect: async (profileId: string) => instances.get(profileId)!,
 			cancelDisconnectWhenUnused: vi.fn(),
 		});
 
@@ -301,7 +308,7 @@ describe('DataConnectionsTreeInstance', () => {
 		]);
 	});
 
-	it('leaves a namespace group with several children alone, and hands it the children it already fetched', async () => {
+	it('leaves a namespace group with several children alone, and re-fetches them when it is expanded', async () => {
 		const { tree, nodeGetChildren } = createTreeOverNodes(
 			[nodeDto({ nodeHandle: 1, name: 'Schemas', kind: 'group-schemas' })],
 			nodeHandle => nodeHandle === 1
@@ -314,8 +321,9 @@ describe('DataConnectionsTreeInstance', () => {
 		await tree.refresh();
 		await tree.expand(ENTRY_ID);
 
-		// The look-ahead that counted the schemas already has them, so expanding the group costs
-		// nothing further -- the count of nodeGetChildren calls doesn't move.
+		// The look-ahead that counted the schemas discards them rather than handing them to the tree,
+		// so expanding the group queries again. The alternative leaves children behind in the live
+		// map when a reload's staged fetch is discarded -- see _breadcrumbNamespaceGroups.
 		const callsBeforeExpanding = nodeGetChildren.mock.calls.length;
 		await tree.expand('dto:1:1');
 
@@ -331,8 +339,50 @@ describe('DataConnectionsTreeInstance', () => {
 				{ name: 'staging', prefix: undefined, expanded: false },
 			],
 			callsBeforeExpanding: 1,
-			callsAfterExpanding: 1,
+			callsAfterExpanding: 2,
 		});
+	});
+
+	it('opens breadcrumbed rows under every connection when several reload at once', async () => {
+		// Two profiles, so Refresh All fans reload out across both roots concurrently. Breadcrumbed
+		// rows used to be collected into one instance-wide list, which whichever reload finished
+		// first drained -- against rows the other had not inserted yet, leaving them shut.
+		const second = createProfile({ id: 'conn-2', connectionName: 'Second Connection' });
+		const { tree } = createTreeOverNodes(
+			[nodeDto({ nodeHandle: 1, name: 'Schemas', kind: 'group-schemas' })],
+			nodeHandle => nodeHandle === 1
+				? [nodeDto({ nodeHandle: 2, name: 'public', kind: 'schema' })]
+				: [],
+			[profile, second]
+		);
+		await tree.refresh();
+		await Promise.all([tree.expand(ENTRY_ID), tree.expand('entry:conn-2')]);
+		await tree.reloadAll();
+
+		expect(rows(tree)).toEqual([
+			{ name: 'connection', prefix: undefined, expanded: true },
+			{ name: 'public', prefix: 'Schemas', expanded: true },
+			{ name: 'connection', prefix: undefined, expanded: true },
+			{ name: 'public', prefix: 'Schemas', expanded: true },
+		]);
+	});
+
+	it('leaves a breadcrumbed row the user closed closed, rather than reopening it on the next fetch', async () => {
+		const { tree } = createTreeOverNodes(
+			[nodeDto({ nodeHandle: 1, name: 'Schemas', kind: 'group-schemas' })],
+			nodeHandle => nodeHandle === 1
+				? [nodeDto({ nodeHandle: 2, name: 'public', kind: 'schema' })]
+				: []
+		);
+		await tree.refresh();
+		await tree.expand(ENTRY_ID);
+		tree.collapse('dto:1:2');
+
+		// Any later fetch runs the auto-expand again. It opens a breadcrumbed row once and records
+		// that it did, so a row the user closed since is left alone.
+		await tree.invalidate(ENTRY_ID);
+
+		expect(tree.isExpanded('dto:1:2')).toBe(false);
 	});
 
 	it('does not breadcrumb an object group, however few children it has', async () => {

--- a/src/vs/workbench/contrib/positronDataConnections/test/browser/dataConnectionsTreeInstance.vitest.ts
+++ b/src/vs/workbench/contrib/positronDataConnections/test/browser/dataConnectionsTreeInstance.vitest.ts
@@ -235,7 +235,10 @@ describe('DataConnectionsTreeInstance', () => {
 	function createTreeOverNodes(
 		rootDtos: IDataConnectionNodeDTO[],
 		childrenOf: (nodeHandle: number) => IDataConnectionNodeDTO[],
-		profiles: IDataConnectionProfile[] = [profile]
+		profiles: IDataConnectionProfile[] = [profile],
+		// Defaulted to the setting's own default, so a test that says nothing gets what a user gets:
+		// a lone schema dropped from the tree. The breadcrumb tests below opt in explicitly.
+		showSingleSchema = false
 	) {
 		const nodeGetChildren = vi.fn(async (nodeHandle: number) => childrenOf(nodeHandle));
 
@@ -267,6 +270,7 @@ describe('DataConnectionsTreeInstance', () => {
 		const tree = new DataConnectionsTreeInstance(service, new TestConfigurationService({
 			'workbench.tree.indent': 16,
 			'dataConnections.tree.indent': 0,
+			'dataConnections.tree.showSingleSchema': showSingleSchema,
 		}));
 		ctx.disposables.add(tree);
 		return { tree, nodeGetChildren };
@@ -287,14 +291,18 @@ describe('DataConnectionsTreeInstance', () => {
 	}
 
 	it('breadcrumbs a namespace group holding one child into that child, and opens it', async () => {
-		// connection > Schemas > public > Tables. Only one schema, so "Schemas" is ceremony.
+		// connection > Schemas > public > Tables. Only one schema, so "Schemas" is ceremony. Opted
+		// into showing that schema, since the tree drops it entirely by default -- see the elide
+		// test below.
 		const { tree } = createTreeOverNodes(
 			[nodeDto({ nodeHandle: 1, name: 'Schemas', kind: 'group-schemas' })],
 			nodeHandle => nodeHandle === 1
 				? [nodeDto({ nodeHandle: 2, name: 'public', kind: 'schema' })]
 				: nodeHandle === 2
 					? [nodeDto({ nodeHandle: 3, name: 'Tables', kind: 'group-tables' })]
-					: []
+					: [],
+			[profile],
+			true
 		);
 		await tree.refresh();
 		await tree.expand(ENTRY_ID);
@@ -308,7 +316,52 @@ describe('DataConnectionsTreeInstance', () => {
 		]);
 	});
 
-	it('leaves a namespace group with several children alone, and re-fetches them when it is expanded', async () => {
+	it('drops a lone schema out of the tree by default, standing its contents where it stood', async () => {
+		// connection > Schemas > public > Tables, Views. With one schema there is nothing to choose
+		// between, so both tiers go and the objects they held move up to the connection.
+		const { tree } = createTreeOverNodes(
+			[nodeDto({ nodeHandle: 1, name: 'Schemas', kind: 'group-schemas' })],
+			nodeHandle => nodeHandle === 1
+				? [nodeDto({ nodeHandle: 2, name: 'public', kind: 'schema' })]
+				: nodeHandle === 2
+					? [
+						nodeDto({ nodeHandle: 3, name: 'Tables', kind: 'group-tables' }),
+						nodeDto({ nodeHandle: 4, name: 'Views', kind: 'group-views' }),
+					]
+					: []
+		);
+		await tree.refresh();
+		await tree.expand(ENTRY_ID);
+
+		// Neither tier left a row behind, and nothing wears a breadcrumb: the schema is not folded
+		// into anything here, it is simply gone.
+		expect(rows(tree)).toEqual([
+			{ name: 'connection', prefix: undefined, expanded: true },
+			{ name: 'Tables', prefix: undefined, expanded: false },
+			{ name: 'Views', prefix: undefined, expanded: false },
+		]);
+	});
+
+	it('keeps a lone schema that holds nothing, rather than leaving the connection looking empty', async () => {
+		// Same single schema, but with no tables or views under it. Eliding it would leave the
+		// connection with no rows at all, which reads as a connection that failed rather than as a
+		// schema with nothing in it, so it falls back to the breadcrumbed row.
+		const { tree } = createTreeOverNodes(
+			[nodeDto({ nodeHandle: 1, name: 'Schemas', kind: 'group-schemas' })],
+			nodeHandle => nodeHandle === 1
+				? [nodeDto({ nodeHandle: 2, name: 'public', kind: 'schema' })]
+				: []
+		);
+		await tree.refresh();
+		await tree.expand(ENTRY_ID);
+
+		expect(rows(tree)).toEqual([
+			{ name: 'connection', prefix: undefined, expanded: true },
+			{ name: 'public', prefix: 'Schemas', expanded: true },
+		]);
+	});
+
+	it('leaves a namespace group with several children alone, and opens it without querying again', async () => {
 		const { tree, nodeGetChildren } = createTreeOverNodes(
 			[nodeDto({ nodeHandle: 1, name: 'Schemas', kind: 'group-schemas' })],
 			nodeHandle => nodeHandle === 1
@@ -321,9 +374,9 @@ describe('DataConnectionsTreeInstance', () => {
 		await tree.refresh();
 		await tree.expand(ENTRY_ID);
 
-		// The look-ahead that counted the schemas discards them rather than handing them to the tree,
-		// so expanding the group queries again. The alternative leaves children behind in the live
-		// map when a reload's staged fetch is discarded -- see _breadcrumbNamespaceGroups.
+		// The look-ahead that counted the schemas holds them for the expand rather than throwing them
+		// away, so opening the group adds no query of its own. On a warehouse connection that saved
+		// query is seconds, at every namespace level, on every reload.
 		const callsBeforeExpanding = nodeGetChildren.mock.calls.length;
 		await tree.expand('dto:1:1');
 
@@ -339,21 +392,23 @@ describe('DataConnectionsTreeInstance', () => {
 				{ name: 'staging', prefix: undefined, expanded: false },
 			],
 			callsBeforeExpanding: 1,
-			callsAfterExpanding: 2,
+			callsAfterExpanding: 1,
 		});
 	});
 
-	it('opens breadcrumbed rows under every connection when several reload at once', async () => {
-		// Two profiles, so Refresh All fans reload out across both roots concurrently. Breadcrumbed
-		// rows used to be collected into one instance-wide list, which whichever reload finished
-		// first drained -- against rows the other had not inserted yet, leaving them shut.
+	it('keeps breadcrumbed rows open under every connection when several reload at once', async () => {
+		// Two profiles, so Refresh All fans reload out across both roots concurrently. A breadcrumbed
+		// row that was open has to come back open on both, which the base does by matching rows to
+		// their counterparts by reload key -- the auto-open deliberately sits out the reload path, so
+		// nothing else is holding these open. See reload in DataConnectionsTreeInstance.
 		const second = createProfile({ id: 'conn-2', connectionName: 'Second Connection' });
 		const { tree } = createTreeOverNodes(
 			[nodeDto({ nodeHandle: 1, name: 'Schemas', kind: 'group-schemas' })],
 			nodeHandle => nodeHandle === 1
 				? [nodeDto({ nodeHandle: 2, name: 'public', kind: 'schema' })]
 				: [],
-			[profile, second]
+			[profile, second],
+			true
 		);
 		await tree.refresh();
 		await Promise.all([tree.expand(ENTRY_ID), tree.expand('entry:conn-2')]);
@@ -367,22 +422,32 @@ describe('DataConnectionsTreeInstance', () => {
 		]);
 	});
 
-	it('leaves a breadcrumbed row the user closed closed, rather than reopening it on the next fetch', async () => {
+	it('leaves a breadcrumbed row the user closed closed when the tree is refreshed', async () => {
+		// The extension host mints a fresh node handle every time it serializes a node, so the rows a
+		// refresh brings back carry different ids from the ones they replace. Modelled here: with a
+		// stub that returned fixed handles, an "already opened these ids" set would look like it
+		// worked, and the row would reopen in the product.
+		let nextSchemaHandle = 10;
 		const { tree } = createTreeOverNodes(
 			[nodeDto({ nodeHandle: 1, name: 'Schemas', kind: 'group-schemas' })],
 			nodeHandle => nodeHandle === 1
-				? [nodeDto({ nodeHandle: 2, name: 'public', kind: 'schema' })]
-				: []
+				? [nodeDto({ nodeHandle: nextSchemaHandle++, name: 'public', kind: 'schema' })]
+				: [],
+			[profile],
+			true
 		);
 		await tree.refresh();
 		await tree.expand(ENTRY_ID);
-		tree.collapse('dto:1:2');
 
-		// Any later fetch runs the auto-expand again. It opens a breadcrumbed row once and records
-		// that it did, so a row the user closed since is left alone.
-		await tree.invalidate(ENTRY_ID);
+		// Closed by the user, then refreshed the way the row's own Refresh action does it. The base
+		// restores expansion by reload key, so the replacement row comes back closed too.
+		tree.collapse(tree.visibleNodes.find(visible => visible.node.data.kind === 'dto')!.node.id);
+		await tree.reload(ENTRY_ID);
 
-		expect(tree.isExpanded('dto:1:2')).toBe(false);
+		expect(rows(tree)).toEqual([
+			{ name: 'connection', prefix: undefined, expanded: true },
+			{ name: 'public', prefix: 'Schemas', expanded: false },
+		]);
 	});
 
 	it('does not breadcrumb an object group, however few children it has', async () => {

--- a/src/vs/workbench/contrib/positronDataConnections/test/browser/dataConnectionsTreeInstance.vitest.ts
+++ b/src/vs/workbench/contrib/positronDataConnections/test/browser/dataConnectionsTreeInstance.vitest.ts
@@ -227,6 +227,131 @@ describe('DataConnectionsTreeInstance', () => {
 		return { tree, service, getChildren, setConnected, disconnect, disconnectWhenUnused };
 	}
 
+	/**
+	 * Builds a tree whose connection returns `rootDtos`, with `nodeGetChildren` answering for the
+	 * levels below. Separate from createTree, which pins one flat table: breadcrumbing is decided by
+	 * what a level's children turn out to be, so these tests need to shape the whole subtree.
+	 */
+	function createTreeOverNodes(
+		rootDtos: IDataConnectionNodeDTO[],
+		childrenOf: (nodeHandle: number) => IDataConnectionNodeDTO[]
+	) {
+		const nodeGetChildren = vi.fn(async (nodeHandle: number) => childrenOf(nodeHandle));
+		const instance = stubInterface<IDataConnectionInstance>({
+			id: 'instance-1',
+			profileId: profile.id,
+			connectionHandle: stubInterface<IDataConnectionHandle>({
+				handle: 1,
+				getChildren: async () => rootDtos,
+				nodeGetChildren,
+			}),
+		});
+		const service = stubInterface<IPositronDataConnectionsService>({
+			onDidChangeProfiles: Event.None,
+			onDidChangeInstances: onDidChangeInstances.event,
+			onDidChangeDiscoveredProfiles: Event.None,
+			getProfiles: () => [profile],
+			getDiscoveredProfiles: () => [],
+			getInstanceForProfile: () => instance,
+			connect: async () => instance,
+			cancelDisconnectWhenUnused: vi.fn(),
+		});
+
+		const tree = new DataConnectionsTreeInstance(service, new TestConfigurationService({
+			'workbench.tree.indent': 16,
+			'dataConnections.tree.indent': 0,
+		}));
+		ctx.disposables.add(tree);
+		return { tree, nodeGetChildren };
+	}
+
+	/** A node DTO, defaulting to an expandable, non-previewable one. */
+	function nodeDto(overrides: Partial<IDataConnectionNodeDTO> & Pick<IDataConnectionNodeDTO, 'nodeHandle' | 'name' | 'kind'>): IDataConnectionNodeDTO {
+		return { hasGetChildren: true, hasPreview: false, ...overrides };
+	}
+
+	/** The visible rows as name / breadcrumb prefix / expanded triples. */
+	function rows(tree: DataConnectionsTreeInstance) {
+		return tree.visibleNodes.map(visible => ({
+			name: visible.node.data.kind === 'dto' ? visible.node.data.dto.name : 'connection',
+			prefix: visible.node.data.kind === 'dto' ? visible.node.data.labelPrefix : undefined,
+			expanded: tree.isExpanded(visible.node.id),
+		}));
+	}
+
+	it('breadcrumbs a namespace group holding one child into that child, and opens it', async () => {
+		// connection > Schemas > public > Tables. Only one schema, so "Schemas" is ceremony.
+		const { tree } = createTreeOverNodes(
+			[nodeDto({ nodeHandle: 1, name: 'Schemas', kind: 'group-schemas' })],
+			nodeHandle => nodeHandle === 1
+				? [nodeDto({ nodeHandle: 2, name: 'public', kind: 'schema' })]
+				: nodeHandle === 2
+					? [nodeDto({ nodeHandle: 3, name: 'Tables', kind: 'group-tables' })]
+					: []
+		);
+		await tree.refresh();
+		await tree.expand(ENTRY_ID);
+
+		// The Schemas row is gone; public wears its name and is already open, so the Tables group the
+		// user was heading for is on screen without the two clicks that used to stand in front of it.
+		expect(rows(tree)).toEqual([
+			{ name: 'connection', prefix: undefined, expanded: true },
+			{ name: 'public', prefix: 'Schemas', expanded: true },
+			{ name: 'Tables', prefix: undefined, expanded: false },
+		]);
+	});
+
+	it('leaves a namespace group with several children alone, and hands it the children it already fetched', async () => {
+		const { tree, nodeGetChildren } = createTreeOverNodes(
+			[nodeDto({ nodeHandle: 1, name: 'Schemas', kind: 'group-schemas' })],
+			nodeHandle => nodeHandle === 1
+				? [
+					nodeDto({ nodeHandle: 2, name: 'public', kind: 'schema' }),
+					nodeDto({ nodeHandle: 3, name: 'staging', kind: 'schema' }),
+				]
+				: []
+		);
+		await tree.refresh();
+		await tree.expand(ENTRY_ID);
+
+		// The look-ahead that counted the schemas already has them, so expanding the group costs
+		// nothing further -- the count of nodeGetChildren calls doesn't move.
+		const callsBeforeExpanding = nodeGetChildren.mock.calls.length;
+		await tree.expand('dto:1:1');
+
+		expect({
+			rows: rows(tree),
+			callsBeforeExpanding,
+			callsAfterExpanding: nodeGetChildren.mock.calls.length,
+		}).toEqual({
+			rows: [
+				{ name: 'connection', prefix: undefined, expanded: true },
+				{ name: 'Schemas', prefix: undefined, expanded: true },
+				{ name: 'public', prefix: undefined, expanded: false },
+				{ name: 'staging', prefix: undefined, expanded: false },
+			],
+			callsBeforeExpanding: 1,
+			callsAfterExpanding: 1,
+		});
+	});
+
+	it('does not breadcrumb an object group, however few children it has', async () => {
+		// "Tables" over a lone table still says what that row is, so it keeps its own row.
+		const { tree } = createTreeOverNodes(
+			[nodeDto({ nodeHandle: 1, name: 'Tables', kind: 'group-tables' })],
+			nodeHandle => nodeHandle === 1
+				? [nodeDto({ nodeHandle: 2, name: 'flights', kind: 'table', hasGetChildren: false, hasPreview: true })]
+				: []
+		);
+		await tree.refresh();
+		await tree.expand(ENTRY_ID);
+
+		expect(rows(tree)).toEqual([
+			{ name: 'connection', prefix: undefined, expanded: true },
+			{ name: 'Tables', prefix: undefined, expanded: false },
+		]);
+	});
+
 	it('inherits the workbench tree indent until its own setting overrides it, and follows both live', async () => {
 		// The view's own indent at its inheriting default of 0.
 		const configurationService = new TestConfigurationService({

--- a/src/vs/workbench/services/positronDataConnections/common/dataConnectionSchemaSummary.ts
+++ b/src/vs/workbench/services/positronDataConnections/common/dataConnectionSchemaSummary.ts
@@ -16,7 +16,7 @@ const DEFAULT_MAX_TOTAL_NODES = 500;
 // "Tables", "Views") and carry no schema information of their own. IDataConnectionNodeDTO.kind
 // crosses the RPC wire as a plain string (see dataConnectionDTOs.ts), so these are compared as
 // string literals rather than imported from the ext-host-only DataConnectionNodeKind enum.
-const CONTAINER_ONLY_KINDS = new Set([
+export const CONTAINER_ONLY_KINDS = new Set([
 	'group-databases',
 	'group-catalogs',
 	'group-schemas',

--- a/test/e2e/tests/data-connections/duckdb.test.ts
+++ b/test/e2e/tests/data-connections/duckdb.test.ts
@@ -65,7 +65,8 @@ test.describe('Data Connections - DuckDB', {
 
 		await test.step('Expand the tree down to tables and views', async () => {
 			await dataConnections.expandConnection(connectionName);
-			await dataConnections.expectNodeVisible('main', 'schema');
+			// The database has a single schema, which the tree hides by default, so Tables and Views
+			// sit directly under the connection and there is no 'Schemas' or 'main' row to expand.
 			await dataConnections.expandNode('Tables');
 			await dataConnections.expandNode('Views');
 		});

--- a/test/e2e/tests/data-connections/duckdb.test.ts
+++ b/test/e2e/tests/data-connections/duckdb.test.ts
@@ -65,9 +65,6 @@ test.describe('Data Connections - DuckDB', {
 
 		await test.step('Expand the tree down to tables and views', async () => {
 			await dataConnections.expandConnection(connectionName);
-			// The database has a single schema, so the 'Schemas' group is breadcrumbed into it:
-			// 'main' takes the group's place already expanded, and there is no 'Schemas' row of
-			// its own left to expand.
 			await dataConnections.expectNodeVisible('main', 'schema');
 			await dataConnections.expandNode('Tables');
 			await dataConnections.expandNode('Views');

--- a/test/e2e/tests/data-connections/duckdb.test.ts
+++ b/test/e2e/tests/data-connections/duckdb.test.ts
@@ -65,8 +65,10 @@ test.describe('Data Connections - DuckDB', {
 
 		await test.step('Expand the tree down to tables and views', async () => {
 			await dataConnections.expandConnection(connectionName);
-			await dataConnections.expandNode('Schemas');
-			await dataConnections.expandNode('main');
+			// The database has a single schema, so the 'Schemas' group is breadcrumbed into it:
+			// 'main' takes the group's place already expanded, and there is no 'Schemas' row of
+			// its own left to expand.
+			await dataConnections.expectNodeVisible('main', 'schema');
 			await dataConnections.expandNode('Tables');
 			await dataConnections.expandNode('Views');
 		});

--- a/test/e2e/tests/data-connections/postgres.test.ts
+++ b/test/e2e/tests/data-connections/postgres.test.ts
@@ -74,7 +74,8 @@ test.describe('Data Connections - Postgres', {
 
 		await test.step('Expand the tree down to tables and views', async () => {
 			await dataConnections.expandConnection(connectionName);
-			await dataConnections.expectNodeVisible('public', 'schema');
+			// dvdrental has a single schema, which the tree hides by default, so Tables and Views sit
+			// directly under the connection and there is no 'Schemas' or 'public' row to expand.
 			await dataConnections.expandNode('Tables');
 			await dataConnections.expandNode('Views');
 		});

--- a/test/e2e/tests/data-connections/postgres.test.ts
+++ b/test/e2e/tests/data-connections/postgres.test.ts
@@ -74,9 +74,6 @@ test.describe('Data Connections - Postgres', {
 
 		await test.step('Expand the tree down to tables and views', async () => {
 			await dataConnections.expandConnection(connectionName);
-			// pagila has a single schema, so the 'Schemas' group is breadcrumbed into it: 'public'
-			// takes the group's place already expanded, and there is no 'Schemas' row of its own
-			// left to expand.
 			await dataConnections.expectNodeVisible('public', 'schema');
 			await dataConnections.expandNode('Tables');
 			await dataConnections.expandNode('Views');

--- a/test/e2e/tests/data-connections/postgres.test.ts
+++ b/test/e2e/tests/data-connections/postgres.test.ts
@@ -74,8 +74,10 @@ test.describe('Data Connections - Postgres', {
 
 		await test.step('Expand the tree down to tables and views', async () => {
 			await dataConnections.expandConnection(connectionName);
-			await dataConnections.expandNode('Schemas');
-			await dataConnections.expandNode('public');
+			// pagila has a single schema, so the 'Schemas' group is breadcrumbed into it: 'public'
+			// takes the group's place already expanded, and there is no 'Schemas' row of its own
+			// left to expand.
+			await dataConnections.expectNodeVisible('public', 'schema');
 			await dataConnections.expandNode('Tables');
 			await dataConnections.expandNode('Views');
 		});


### PR DESCRIPTION
Fixes #14626.

The Data Connections tree spent most of a narrow sidebar on indentation before it got to a name. A column sat six levels deep -- `connection > Schemas > public > Tables > bikes > Columns > column` -- and four of those six levels were category rows that carry no information of their own. At the default indent that was well over a third of a 300px panel gone before the first character of a column name.

This PR attacks the depth rather than the indent width, and adds a setting for the width on top. A column now sits three indent steps in instead of six, and reaching a table takes two expands instead of four.

Screenshots:
<p>
<img width="336" height="1081" alt="image" src="https://github.com/user-attachments/assets/36527a7a-acd6-45cc-96e2-b252f72d900d" />
<span>&nbsp;&nbsp;&nbsp;</span>
<img width="336" height="1081" alt="connector-stub-light-2" src="https://github.com/user-attachments/assets/33089b05-2c1e-4599-a9a4-8ea0bb37b3ea" />
<p/>

### What changed

**Group rows stop consuming a level.** `Tables`, `Views`, `Columns`, and `Indexes` keep their row and their twisty but hold their children at their own indent. This is a rendering change only: `VisibleNode` now carries `indentLevel` alongside `depth`, and `depth` is untouched. Keeping them apart matters -- `findParentIndex` and `moveCursorRight` both navigate by depth, so flattening the depth itself would have silently broken left- and right-arrow navigation with no type error and no failing test.

**Single-child namespace groups are breadcrumbed.** Expanding a connection with one schema now gives `Schemas · public`, already open, instead of two rows the user has to click through. Only `group-schemas`, `group-databases`, and `group-catalogs` qualify: a lone `Tables` group still tells you what the row beneath it is, but `Schemas` over a lone `public` does not. The schema name is deliberately kept rather than hidden -- one schema does not imply the *default* schema, and a user writing an unqualified query against a lone `analytics` schema would get an error with nothing on screen to explain it.

**Indent guides.** 1px rules drawn as a repeating background on the indent spacer, so a deep row costs no extra DOM. These do real work here: a row that holds its children at its own indent gives up the step that would otherwise show what belongs to what, and the guide carries it instead.

**A connector stub** marks the rows that fold a level away -- a short horizontal tick joining the row back to its parent's indent guide.

**`dataConnections.tree.indent`**, a number defaulting to `0`, which inherits `workbench.tree.indent`. Modelled on `editor.suggestFontSize`, which uses the same sentinel to fall back to `editor.fontSize`. Inheriting by default matters: someone who finds this tree too wide reaches for the workbench setting first, and a view that quietly ignored it would read as a bug.

**Row alignment.** The twisty and icon columns are now identical 19px steps (3px gutter + 16px box), which is what lets each level's twisty sit centered under its parent's icon.

### Release Notes

#### New Features

- Added `dataConnections.tree.indent` for controlling indentation in the Data Connections view, inheriting `workbench.tree.indent` when unset (#14626)

#### Bug Fixes

- Reduced the depth of the Data Connections tree so table and column names get more of the panel's width (#14626)

### QA Notes

Tags auto-derive to `@:connections` -- `positronDataConnections`, `positronTree`, and the data connections service all map to it in `test-tag-paths-map.json`.

Worth exercising by hand:

- A Postgres connection with one schema (breadcrumbs to `Schemas · public`) and one with several (keeps an ordinary `Schemas` group). Redshift in database mode hits both shapes in the same tree, since one database can have a single schema while its sibling has two.
- Both themes. Group rows are distinguished by their plural glyph and the guides, with no colour or size treatment -- earlier attempts at a muted foreground read as *disabled* in light mode rather than quiet.
- `dataConnections.tree.indent` at 4, 16, and 40, and `workbench.tree.indent` changed with this view's setting left at `0`. Both apply live with no reload.
- Clicking a twisty on a deeply nested row. The guides overhang the twisty column, so they carry `pointer-events: none`; without it they take half of every twisty's clicks.
- Keyboard navigation into and out of a flattened group. Left-arrow from a table lands on `Tables` even though the two render at the same indent.

Known and deliberate, not worth blocking on:

- Indent guides are always drawn and do not consult workbench.tree.renderIndentGuides (default onHover). They carry structure here rather than decoration, but this does diverge from other workbench trees.
- `Tables` and `Views` get no connector guide running down their children, only the stub. A flattened child's twisty sits at the same x as such a line would, so it ran through the chevrons.
- `group-stages` is absent from `CONTAINER_ONLY_KINDS`, asserted by an existing test, so a Stages group still indents while every other group flattens.
- The framework twisty gutter went 4px to 3px, so the control gallery tree shifts by a pixel too.
