### PR TITLE
Import Data: add parquet and xlsx support

### DIFF
--- a/extensions/positron-python/src/client/positron/dataImport/pandasCodeGenerator.ts
+++ b/extensions/positron-python/src/client/positron/dataImport/pandasCodeGenerator.ts
@@ -23,6 +23,9 @@ export interface PandasImportRequest {
     /** Whether the first row holds column names. Treated as true when absent. */
     hasHeaderRow?: boolean;
 
+    /** The worksheet to read, for formats that have sheets. Omitted means the first sheet. */
+    sheetName?: string;
+
     /** The Data Explorer view (filters and sorts) to reproduce after the load, if requested. */
     view?: DataImportView;
 }
@@ -103,9 +106,25 @@ export const PYTHON_KEYWORDS = new Set([
     'yield',
 ]);
 
-/** Whether a path names a tab-separated file, which pandas needs told explicitly. */
-function isTabSeparated(filePath: string): boolean {
-    return filePath.toLowerCase().endsWith('.tsv');
+/** The file formats the generator can write a load call for, keyed off the path's extension. */
+type FileFormat = 'csv' | 'tsv' | 'xlsx' | 'parquet';
+
+/**
+ * Detects the format from the path's extension. An unrecognized extension falls back to CSV,
+ * preserving the generator's existing behavior for paths the registry should not have sent it.
+ */
+function detectFileFormat(filePath: string): FileFormat {
+    const lower = filePath.toLowerCase();
+    if (lower.endsWith('.tsv')) {
+        return 'tsv';
+    }
+    if (lower.endsWith('.xlsx')) {
+        return 'xlsx';
+    }
+    if (lower.endsWith('.parquet') || lower.endsWith('.parq')) {
+        return 'parquet';
+    }
+    return 'csv';
 }
 
 /** Display types whose stringified values are emitted as bare numeric literals. */
@@ -295,24 +314,49 @@ function translateView(
  * describes, and it names the variable so a script that accumulates several imports stays readable.
  */
 export function generatePandasImportCode(request: PandasImportRequest): PandasImportResult {
+    const format = detectFileFormat(request.filePath);
     const args = [`"${escapePythonString(request.filePath)}"`];
-    if (isTabSeparated(request.filePath)) {
-        args.push('sep="\\t"');
-    }
-    if (request.hasHeaderRow === false) {
-        args.push('header=None');
+
+    let readFunction: string;
+    switch (format) {
+        case 'parquet':
+            // Parquet always carries column names and has no sheets, so the header and
+            // sheet options do not apply, whatever the options bag says.
+            readFunction = 'read_parquet';
+            break;
+        case 'xlsx':
+            readFunction = 'read_excel';
+            if (request.sheetName !== undefined) {
+                args.push(`sheet_name="${escapePythonString(request.sheetName)}"`);
+            }
+            if (request.hasHeaderRow === false) {
+                args.push('header=None');
+            }
+            break;
+        case 'tsv':
+        case 'csv':
+            readFunction = 'read_csv';
+            if (format === 'tsv') {
+                args.push('sep="\\t"');
+            }
+            if (request.hasHeaderRow === false) {
+                args.push('header=None');
+            }
+            break;
     }
 
     const lines = [
         'import pandas as pd',
         '',
         `# Load ${request.variableName} data`,
-        `${request.variableName} = pd.read_csv(${args.join(', ')})`,
+        `${request.variableName} = pd.${readFunction}(${args.join(', ')})`,
     ];
 
     const unsupported: string[] = [];
     if (request.view) {
-        const statements = translateView(request.variableName, request.view, request.hasHeaderRow, unsupported);
+        // Parquet columns are always named, so the headerless-columns guard never applies.
+        const headerForView = format === 'parquet' ? undefined : request.hasHeaderRow;
+        const statements = translateView(request.variableName, request.view, headerForView, unsupported);
         if (statements.length > 0) {
             lines.push('', '# Filter and sort as shown in the Data Explorer', ...statements);
         }

--- a/extensions/positron-python/src/client/positron/dataImport/pandasImporter.ts
+++ b/extensions/positron-python/src/client/positron/dataImport/pandasImporter.ts
@@ -9,23 +9,28 @@ import * as positron from 'positron';
 import { generatePandasImportCode, PYTHON_KEYWORDS } from './pandasCodeGenerator';
 
 /**
- * Registers the pandas data importer, which generates the code that loads a delimited file into a
- * dataframe. Generation is pure TypeScript; no Python runtime is involved.
+ * Builds the pandas data importer, which generates the code that loads a delimited file, Excel
+ * workbook, or Parquet file into a dataframe. Generation is pure TypeScript; no Python runtime is
+ * involved, so the importer can be built and exercised without registering it.
  */
-export function registerPandasDataImporter(disposables: vscode.Disposable[]): void {
-    const importer: positron.DataImporter = {
+export function createPandasDataImporter(): positron.DataImporter {
+    return {
         languageId: 'python',
         displayName: 'Python (pandas)',
-        fileExtensions: ['csv', 'tsv'],
+        fileExtensions: ['csv', 'tsv', 'xlsx', 'parquet', 'parq'],
         reservedNames: [...PYTHON_KEYWORDS],
         generateCode: (request: positron.DataImportRequest): positron.DataImportResult =>
             generatePandasImportCode({
                 filePath: request.fileUri.fsPath,
                 variableName: request.variableName,
                 hasHeaderRow: request.options.hasHeaderRow,
+                sheetName: request.options.sheetName,
                 view: request.view,
             }),
     };
+}
 
-    disposables.push(positron.dataExplorer.registerDataImporter(importer));
+/** Registers the pandas data importer with the Data Explorer. */
+export function registerPandasDataImporter(disposables: vscode.Disposable[]): void {
+    disposables.push(positron.dataExplorer.registerDataImporter(createPandasDataImporter()));
 }

--- a/extensions/positron-python/src/test/positron/pandasCodeGenerator.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/pandasCodeGenerator.unit.test.ts
@@ -92,6 +92,120 @@ suite('pandasCodeGenerator Tests', () => {
 
             expect(code.code).to.contain('pd.read_csv("C:\\\\Users\\\\austin\\\\data\\\\flights.csv")');
         });
+
+        test('generates a read_excel call for an xlsx file', () => {
+            const code = generatePandasImportCode({
+                filePath: '/data/flights.xlsx',
+                variableName: 'flights',
+                hasHeaderRow: true,
+            });
+
+            expect(code.code).to.equal(
+                'import pandas as pd\n' +
+                    '\n' +
+                    '# Load flights data\n' +
+                    'flights = pd.read_excel("/data/flights.xlsx")\n',
+            );
+        });
+
+        test('emits sheet_name when a sheet is selected', () => {
+            const code = generatePandasImportCode({
+                filePath: '/data/flights.xlsx',
+                variableName: 'flights',
+                sheetName: 'Sheet 2',
+            });
+
+            expect(code.code).to.contain('pd.read_excel("/data/flights.xlsx", sheet_name="Sheet 2")');
+        });
+
+        test('escapes the sheet name like any other string literal', () => {
+            const code = generatePandasImportCode({
+                filePath: '/data/flights.xlsx',
+                variableName: 'flights',
+                sheetName: 'say "hi"',
+            });
+
+            expect(code.code).to.contain('sheet_name="say \\"hi\\""');
+        });
+
+        test('adds header=None to read_excel when the header row is off', () => {
+            const code = generatePandasImportCode({
+                filePath: '/data/flights.xlsx',
+                variableName: 'flights',
+                hasHeaderRow: false,
+                sheetName: 'Sheet 2',
+            });
+
+            expect(code.code).to.contain('pd.read_excel("/data/flights.xlsx", sheet_name="Sheet 2", header=None)');
+        });
+
+        test('generates a read_parquet call for a parquet file', () => {
+            const code = generatePandasImportCode({
+                filePath: '/data/flights.parquet',
+                variableName: 'flights',
+            });
+
+            expect(code.code).to.equal(
+                'import pandas as pd\n' +
+                    '\n' +
+                    '# Load flights data\n' +
+                    'flights = pd.read_parquet("/data/flights.parquet")\n',
+            );
+        });
+
+        test('treats .parq as parquet', () => {
+            const code = generatePandasImportCode({
+                filePath: '/data/flights.parq',
+                variableName: 'flights',
+            });
+
+            expect(code.code).to.contain('pd.read_parquet("/data/flights.parq")');
+        });
+
+        test('parquet ignores header row and sheet options', () => {
+            const code = generatePandasImportCode({
+                filePath: '/data/flights.parquet',
+                variableName: 'flights',
+                hasHeaderRow: false,
+                sheetName: 'Sheet 1',
+            });
+
+            expect(code.code).to.contain('pd.read_parquet("/data/flights.parquet")');
+            expect(code.code).to.not.contain('header');
+            expect(code.code).to.not.contain('sheet_name');
+        });
+
+        test('parquet with header row off still translates the view', () => {
+            // Parquet always has column names, so the "no header row" unsupported
+            // branch must not fire even when the options bag says the header is off.
+            const code = generatePandasImportCode({
+                filePath: '/data/flights.parquet',
+                variableName: 'flights',
+                hasHeaderRow: false,
+                view: {
+                    rowFilters: [],
+                    sortKeys: [{ columnName: 'delay', ascending: false }],
+                },
+            });
+
+            expect(code.code).to.contain('flights.sort_values("delay", ascending=False)');
+            expect(code.unsupported).to.deep.equal([]);
+        });
+
+        test('xlsx with header row off reports filters and sorts as unsupported', () => {
+            const code = generatePandasImportCode({
+                filePath: '/data/flights.xlsx',
+                variableName: 'flights',
+                hasHeaderRow: false,
+                view: {
+                    rowFilters: [],
+                    sortKeys: [{ columnName: 'delay', ascending: true }],
+                },
+            });
+
+            expect(code.code).to.not.contain('sort_values');
+            expect(code.unsupported).to.have.lengthOf(1);
+        });
     });
 
     suite('view translation', () => {

--- a/extensions/positron-python/src/test/positron/pandasImporter.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/pandasImporter.unit.test.ts
@@ -1,0 +1,76 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import { expect } from 'chai';
+import * as vscode from 'vscode';
+// eslint-disable-next-line import/no-unresolved
+import * as positron from 'positron';
+import { createPandasDataImporter } from '../../client/positron/dataImport/pandasImporter';
+
+/** Runs the importer's generateCode over a file with the given name and options. */
+function generate(
+    fileName: string,
+    options: positron.DataImportOptions = {},
+    view?: positron.DataImportView,
+): positron.DataImportResult {
+    const importer = createPandasDataImporter();
+    const request: positron.DataImportRequest = {
+        fileUri: vscode.Uri.file(`/data/${fileName}`),
+        variableName: 'flights',
+        options,
+        view,
+    };
+    return importer.generateCode(request) as positron.DataImportResult;
+}
+
+suite('pandasImporter Tests', () => {
+    test('registers python and the extensions the entry points offer', () => {
+        const importer = createPandasDataImporter();
+
+        expect(importer.languageId).to.equal('python');
+        expect(importer.fileExtensions).to.deep.equal(['csv', 'tsv', 'xlsx', 'parquet', 'parq']);
+        expect(importer.reservedNames).to.include('class');
+    });
+
+    // The registered extension list and the generator's own format detection are separate
+    // pieces of code, so an extension added to one and not the other would fall silently into
+    // the CSV branch. This pins every registered extension to the read function it should get.
+    const readFunctions: [string, string][] = [
+        ['csv', 'pd.read_csv'],
+        ['tsv', 'pd.read_csv'],
+        ['xlsx', 'pd.read_excel'],
+        ['parquet', 'pd.read_parquet'],
+        ['parq', 'pd.read_parquet'],
+    ];
+    readFunctions.forEach(([extension, readFunction]) => {
+        test(`reads a .${extension} file with ${readFunction}`, () => {
+            expect(generate(`flights.${extension}`).code).to.contain(readFunction);
+        });
+    });
+
+    test('forwards the selected worksheet to read_excel', () => {
+        expect(generate('flights.xlsx', { sheetName: 'Male' }).code).to.contain('sheet_name="Male"');
+    });
+
+    test('forwards a header row that is off', () => {
+        expect(generate('flights.xlsx', { hasHeaderRow: false }).code).to.contain('header=None');
+    });
+
+    test('forwards the view so its filters and sorts are translated', () => {
+        const result = generate(
+            'flights.csv',
+            {},
+            {
+                rowFilters: [],
+                sortKeys: [{ columnName: 'delay', ascending: false }],
+            },
+        );
+
+        expect(result.code).to.contain('flights.sort_values("delay", ascending=False)');
+        expect(result.unsupported).to.deep.equal([]);
+    });
+});

--- a/extensions/positron-r/src/data-import.ts
+++ b/extensions/positron-r/src/data-import.ts
@@ -22,7 +22,7 @@ export interface ReadrImportRequest {
 }
 
 /** The generated code plus anything in the view it does not reproduce. */
-export interface ReadrImportResult {
+export interface RImportResult {
 	code: string;
 	unsupported: string[];
 }
@@ -245,36 +245,34 @@ function translateView(
 }
 
 /**
- * Generates the readr code that loads a file into a data frame.
- *
- * The comment sits directly above the call rather than above library(), so it labels the thing it
- * describes, and it names the variable so a script that accumulates several imports stays
- * readable.
+ * Assembles the generated R code: the library() line(s), the labelled load call, and the piped
+ * dplyr verbs reproducing the view, if any. Shared by every R generator, because only the load
+ * call differs between packages.
  */
-export function generateReadrImportCode(request: ReadrImportRequest): ReadrImportResult {
-	const args = [`"${escapeRString(request.filePath)}"`];
-	if (request.hasHeaderRow === false) {
-		args.push('col_names = FALSE');
-	}
-	const readFunction = isTabSeparated(request.filePath) ? 'read_tsv' : 'read_csv';
-
+function assembleRImportCode(
+	libraryName: string,
+	loadCall: string,
+	variableName: string,
+	view: positron.DataImportView | undefined,
+	hasHeaderRowForView: boolean | undefined,
+): RImportResult {
 	const unsupported: string[] = [];
-	const verbs = request.view ? translateView(request.view, request.hasHeaderRow, unsupported) : [];
+	const verbs = view ? translateView(view, hasHeaderRowForView, unsupported) : [];
 
-	const lines = ['library(readr)'];
+	const lines = [`library(${libraryName})`];
 	if (verbs.length > 0) {
 		lines.push('library(dplyr)');
 	}
 	lines.push(
 		'',
-		`# Load ${request.variableName} data`,
-		`${request.variableName} <- ${readFunction}(${args.join(', ')})`,
+		`# Load ${variableName} data`,
+		`${variableName} <- ${loadCall}`,
 	);
 	if (verbs.length > 0) {
 		lines.push(
 			'',
 			'# Filter and sort as shown in the Data Explorer',
-			`${request.variableName} <- ${request.variableName} |>`,
+			`${variableName} <- ${variableName} |>`,
 			...verbs.map((verb, index) => `  ${verb}${index < verbs.length - 1 ? ' |>' : ''}`),
 		);
 	}
@@ -284,21 +282,143 @@ export function generateReadrImportCode(request: ReadrImportRequest): ReadrImpor
 }
 
 /**
- * Registers the readr data importer, which generates the code that loads a delimited file into a
- * data frame. Generation is pure TypeScript; no R runtime is involved.
+ * Generates the readr code that loads a file into a data frame.
+ *
+ * The comment sits directly above the call rather than above library(), so it labels the thing it
+ * describes, and it names the variable so a script that accumulates several imports stays
+ * readable.
  */
+export function generateReadrImportCode(request: ReadrImportRequest): RImportResult {
+	const args = [`"${escapeRString(request.filePath)}"`];
+	if (request.hasHeaderRow === false) {
+		args.push('col_names = FALSE');
+	}
+	const readFunction = isTabSeparated(request.filePath) ? 'read_tsv' : 'read_csv';
+	return assembleRImportCode(
+		'readr',
+		`${readFunction}(${args.join(', ')})`,
+		request.variableName,
+		request.view,
+		request.hasHeaderRow,
+	);
+}
+
+/** A request to generate a readxl load statement. */
+export interface ReadxlImportRequest {
+	/** The absolute path of the workbook to load. */
+	filePath: string;
+
+	/** The target variable name. */
+	variableName: string;
+
+	/** Whether the first row holds column names. Treated as true when absent. */
+	hasHeaderRow?: boolean;
+
+	/** The worksheet to read. Omitted means the first sheet. */
+	sheetName?: string;
+
+	/** The Data Explorer view (filters and sorts) to reproduce after the load, if requested. */
+	view?: positron.DataImportView;
+}
+
+/** Generates the readxl code that loads an Excel workbook into a data frame. */
+export function generateReadxlImportCode(request: ReadxlImportRequest): RImportResult {
+	const args = [`"${escapeRString(request.filePath)}"`];
+	if (request.sheetName !== undefined) {
+		args.push(`sheet = "${escapeRString(request.sheetName)}"`);
+	}
+	if (request.hasHeaderRow === false) {
+		args.push('col_names = FALSE');
+	}
+	return assembleRImportCode(
+		'readxl',
+		`read_excel(${args.join(', ')})`,
+		request.variableName,
+		request.view,
+		request.hasHeaderRow,
+	);
+}
+
+/** A request to generate a nanoparquet load statement. */
+export interface NanoparquetImportRequest {
+	/** The absolute path of the file to load. */
+	filePath: string;
+
+	/** The target variable name. */
+	variableName: string;
+
+	/** The Data Explorer view (filters and sorts) to reproduce after the load, if requested. */
+	view?: positron.DataImportView;
+}
+
+/**
+ * Generates the nanoparquet code that loads a Parquet file into a data frame. Parquet has no
+ * header-row or sheet concept, so the request carries neither; the view translation always runs
+ * with named columns, because Parquet files always carry column names.
+ */
+export function generateNanoparquetImportCode(request: NanoparquetImportRequest): RImportResult {
+	return assembleRImportCode(
+		'nanoparquet',
+		`read_parquet("${escapeRString(request.filePath)}")`,
+		request.variableName,
+		request.view,
+		undefined,
+	);
+}
+
+/**
+ * Builds the readr, readxl, and nanoparquet data importers, which generate the code that loads
+ * a delimited file, Excel workbook, or Parquet file into a data frame. Generation is pure
+ * TypeScript; no R runtime is involved, so the importers can be built and exercised without
+ * registering them.
+ */
+export function createRDataImporters(): positron.DataImporter[] {
+	return [
+		{
+			languageId: 'r',
+			displayName: 'R (readr)',
+			fileExtensions: ['csv', 'tsv'],
+			reservedNames: R_RESERVED_NAMES,
+			generateCode: (request: positron.DataImportRequest): positron.DataImportResult =>
+				generateReadrImportCode({
+					filePath: request.fileUri.fsPath,
+					variableName: request.variableName,
+					hasHeaderRow: request.options.hasHeaderRow,
+					view: request.view,
+				}),
+		},
+		{
+			languageId: 'r',
+			displayName: 'R (readxl)',
+			fileExtensions: ['xlsx'],
+			reservedNames: R_RESERVED_NAMES,
+			generateCode: (request: positron.DataImportRequest): positron.DataImportResult =>
+				generateReadxlImportCode({
+					filePath: request.fileUri.fsPath,
+					variableName: request.variableName,
+					hasHeaderRow: request.options.hasHeaderRow,
+					sheetName: request.options.sheetName,
+					view: request.view,
+				}),
+		},
+		{
+			languageId: 'r',
+			displayName: 'R (nanoparquet)',
+			fileExtensions: ['parquet', 'parq'],
+			reservedNames: R_RESERVED_NAMES,
+			generateCode: (request: positron.DataImportRequest): positron.DataImportResult =>
+				generateNanoparquetImportCode({
+					filePath: request.fileUri.fsPath,
+					variableName: request.variableName,
+					view: request.view,
+				}),
+		},
+	];
+}
+
+/** Registers the readr, readxl, and nanoparquet data importers with the Data Explorer. */
 export function registerRDataImporter(context: vscode.ExtensionContext): void {
-	context.subscriptions.push(positron.dataExplorer.registerDataImporter({
-		languageId: 'r',
-		displayName: 'R (readr)',
-		fileExtensions: ['csv', 'tsv'],
-		reservedNames: R_RESERVED_NAMES,
-		generateCode: (request: positron.DataImportRequest): positron.DataImportResult =>
-			generateReadrImportCode({
-				filePath: request.fileUri.fsPath,
-				variableName: request.variableName,
-				hasHeaderRow: request.options.hasHeaderRow,
-				view: request.view,
-			}),
-	}));
+	for (const importer of createRDataImporters()) {
+		context.subscriptions.push(positron.dataExplorer.registerDataImporter(importer));
+	}
 }

--- a/extensions/positron-r/src/test/data-import.unit.test.ts
+++ b/extensions/positron-r/src/test/data-import.unit.test.ts
@@ -6,7 +6,16 @@
 import './mocha-setup';
 
 import * as assert from 'assert';
-import { escapeRString, generateReadrImportCode, R_RESERVED_NAMES } from '../data-import';
+import * as vscode from 'vscode';
+import * as positron from 'positron';
+import {
+	createRDataImporters,
+	escapeRString,
+	generateNanoparquetImportCode,
+	generateReadrImportCode,
+	generateReadxlImportCode,
+	R_RESERVED_NAMES,
+} from '../data-import';
 
 suite('generateReadrImportCode', () => {
 	test('generates a read_csv call with the comment directly above it', () => {
@@ -238,5 +247,180 @@ suite('R_RESERVED_NAMES', () => {
 	test('leaves T and F out, which are ordinary variables in R', () => {
 		assert.ok(!R_RESERVED_NAMES.includes('T'));
 		assert.ok(!R_RESERVED_NAMES.includes('F'));
+	});
+});
+
+suite('generateReadxlImportCode', () => {
+	test('generates a read_excel call with the comment directly above it', () => {
+		assert.strictEqual(
+			generateReadxlImportCode({
+				filePath: '/data/flights.xlsx',
+				variableName: 'flights',
+				hasHeaderRow: true,
+			}).code,
+			[
+				'library(readxl)',
+				'',
+				'# Load flights data',
+				'flights <- read_excel("/data/flights.xlsx")',
+				'',
+			].join('\n')
+		);
+	});
+
+	test('emits the sheet argument when a sheet is selected', () => {
+		const code = generateReadxlImportCode({
+			filePath: '/data/flights.xlsx',
+			variableName: 'flights',
+			sheetName: 'Sheet 2',
+		}).code;
+		assert.ok(code.includes('read_excel("/data/flights.xlsx", sheet = "Sheet 2")'));
+	});
+
+	test('escapes the sheet name like any other string literal', () => {
+		const code = generateReadxlImportCode({
+			filePath: '/data/flights.xlsx',
+			variableName: 'flights',
+			sheetName: 'say "hi"',
+		}).code;
+		assert.ok(code.includes('sheet = "say \\"hi\\""'));
+	});
+
+	test('adds col_names = FALSE when the header row is off', () => {
+		const code = generateReadxlImportCode({
+			filePath: '/data/flights.xlsx',
+			variableName: 'flights',
+			hasHeaderRow: false,
+			sheetName: 'Sheet 2',
+		}).code;
+		assert.ok(code.includes('read_excel("/data/flights.xlsx", sheet = "Sheet 2", col_names = FALSE)'));
+	});
+
+	test('translates the view into dplyr verbs after the load', () => {
+		const result = generateReadxlImportCode({
+			filePath: '/data/flights.xlsx',
+			variableName: 'flights',
+			view: {
+				rowFilters: [],
+				sortKeys: [{ columnName: 'delay', ascending: false }],
+			},
+		});
+		assert.ok(result.code.includes('library(dplyr)'));
+		assert.ok(result.code.includes('arrange(desc(delay))'));
+		assert.deepStrictEqual(result.unsupported, []);
+	});
+
+	test('header row off reports filters and sorts as unsupported', () => {
+		const result = generateReadxlImportCode({
+			filePath: '/data/flights.xlsx',
+			variableName: 'flights',
+			hasHeaderRow: false,
+			view: {
+				rowFilters: [],
+				sortKeys: [{ columnName: 'delay', ascending: true }],
+			},
+		});
+		assert.ok(!result.code.includes('arrange'));
+		assert.strictEqual(result.unsupported.length, 1);
+	});
+});
+
+suite('generateNanoparquetImportCode', () => {
+	test('generates a read_parquet call with the comment directly above it', () => {
+		assert.strictEqual(
+			generateNanoparquetImportCode({
+				filePath: '/data/flights.parquet',
+				variableName: 'flights',
+			}).code,
+			[
+				'library(nanoparquet)',
+				'',
+				'# Load flights data',
+				'flights <- read_parquet("/data/flights.parquet")',
+				'',
+			].join('\n')
+		);
+	});
+
+	test('translates the view even though the options bag may say no header row', () => {
+		// Parquet always has column names, so the headerless-columns guard never applies.
+		const result = generateNanoparquetImportCode({
+			filePath: '/data/flights.parquet',
+			variableName: 'flights',
+			view: {
+				rowFilters: [],
+				sortKeys: [{ columnName: 'delay', ascending: false }],
+			},
+		});
+		assert.ok(result.code.includes('arrange(desc(delay))'));
+		assert.deepStrictEqual(result.unsupported, []);
+	});
+
+	test('escapes the path like any other string literal', () => {
+		const code = generateNanoparquetImportCode({ filePath: 'C:\\data\\a"b.parquet', variableName: 'x' }).code;
+		assert.ok(code.includes('read_parquet("C:\\\\data\\\\a\\"b.parquet")'));
+	});
+});
+
+suite('createRDataImporters', () => {
+	/** Runs the importer registered for a file's extension over that file. */
+	function generate(
+		fileName: string,
+		options: positron.DataImportOptions = {},
+		view?: positron.DataImportView,
+	): positron.DataImportResult {
+		const extension = fileName.split('.').pop()!;
+		const importer = createRDataImporters().find(candidate => candidate.fileExtensions.includes(extension));
+		assert.ok(importer, `no importer registered for .${extension}`);
+		const request: positron.DataImportRequest = {
+			fileUri: vscode.Uri.file(`/data/${fileName}`),
+			variableName: 'flights',
+			options,
+			view,
+		};
+		return importer.generateCode(request) as positron.DataImportResult;
+	}
+
+	test('registers one r importer per package, covering the offered extensions', () => {
+		assert.deepStrictEqual(
+			createRDataImporters().map(importer => [importer.languageId, importer.displayName, importer.fileExtensions]),
+			[
+				['r', 'R (readr)', ['csv', 'tsv']],
+				['r', 'R (readxl)', ['xlsx']],
+				['r', 'R (nanoparquet)', ['parquet', 'parq']],
+			]
+		);
+	});
+
+	// The extension each importer registers and the read call it generates are separate pieces
+	// of code; this pins every registered extension to the call it should produce.
+	const readCalls: [string, string][] = [
+		['csv', 'read_csv('],
+		['tsv', 'read_tsv('],
+		['xlsx', 'read_excel('],
+		['parquet', 'read_parquet('],
+		['parq', 'read_parquet('],
+	];
+	for (const [extension, readCall] of readCalls) {
+		test(`reads a .${extension} file with ${readCall})`, () => {
+			assert.ok(generate(`flights.${extension}`).code.includes(readCall));
+		});
+	}
+
+	test('forwards the selected worksheet to read_excel', () => {
+		assert.ok(generate('flights.xlsx', { sheetName: 'Male' }).code.includes('sheet = "Male"'));
+	});
+
+	test('forwards a header row that is off', () => {
+		assert.ok(generate('flights.xlsx', { hasHeaderRow: false }).code.includes('col_names = FALSE'));
+	});
+
+	test('forwards the view so its sorts are translated', () => {
+		const result = generate('flights.parquet', {}, {
+			rowFilters: [],
+			sortKeys: [{ columnName: 'delay', ascending: false }],
+		});
+		assert.ok(result.code.includes('arrange(desc(delay))'));
+		assert.deepStrictEqual(result.unsupported, []);
 	});
 });

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
@@ -1213,13 +1213,14 @@ class PositronImportDataFromFileAction extends Action2 {
 	 * Constructor.
 	 */
 	constructor() {
-		// Match the Data Explorer's plaintext set (.csv/.tsv/.xlsx). An .xlsx yields the dialog's
-		// empty state until an XLSX-capable importer registers, which is the designed behavior.
+		// Match the file types the Data Explorer opens and an importer can read (.csv/.tsv/.xlsx/
+		// .parquet/.parq). Compressed files (.gz) are deliberately absent: the importer registry
+		// matches only the final extension, so gzip support is its own change.
 		// Scheme-gate to files a runtime session could plausibly open; a virtual-filesystem file
 		// names no path on the session's machine, so no menu item is offered for it.
 		const importableFile = ContextKeyExpr.and(
 			ExplorerFolderContext.toNegated(),
-			ContextKeyExpr.regex(ResourceContextKey.Extension.key, /\.(csv|tsv|xlsx)$/i),
+			ContextKeyExpr.regex(ResourceContextKey.Extension.key, /\.(csv|tsv|xlsx|parquet|parq)$/i),
 			ContextKeyExpr.or(
 				ResourceContextKey.Scheme.isEqualTo(Schemas.file),
 				ResourceContextKey.Scheme.isEqualTo(Schemas.vscodeRemote)
@@ -1286,7 +1287,7 @@ class PositronImportDataFromFileAction extends Action2 {
 				defaultUri: await fileDialogService.defaultFilePath(),
 				filters: [{
 					name: localize('positronDataExplorer.importDataPickerFilter', "Data Files"),
-					extensions: ['csv', 'tsv', 'xlsx']
+					extensions: ['csv', 'tsv', 'xlsx', 'parquet', 'parq']
 				}]
 			});
 			fileUri = uris?.at(0);

--- a/test/e2e/test-files/DESCRIPTION
+++ b/test/e2e/test-files/DESCRIPTION
@@ -5,6 +5,7 @@ Type: TestAssets
 Description: Not really a package. This file is just to enable installing dependencies.
 Imports: 
     arrow,
+    nanoparquet,
     readxl,
     connections,
     tidyverse,

--- a/test/e2e/tests/data-explorer/import-data.test.ts
+++ b/test/e2e/tests/data-explorer/import-data.test.ts
@@ -63,6 +63,79 @@ test.describe('Data Explorer - Import Data', {
 		await variables.expectVariableToBe('small_file', /10 rows x 10 columns/);
 	});
 
+	test('Python Pandas - Verify importing an XLSX honors the selected sheet', async function ({ app, openDataFile, python }) {
+		const { dataExplorer, variables } = app.workbench;
+
+		await openDataFile(join('data-files', 'ap-math-enrollment', 'ap-math-enrollment.xlsx'));
+		await dataExplorer.waitForIdle();
+
+		// Import must load the sheet the Data Explorer is showing, not the workbook's first.
+		await dataExplorer.editorActionBar.selectWorksheet('Male');
+		await dataExplorer.waitForIdle();
+
+		await dataExplorer.editorActionBar.clickButton('Import Data');
+		await dataExplorer.importDataModal.expectToBeVisible();
+
+		// The sheet argument proves the backend's sheet state reached the generator; the variable
+		// below proves real pandas accepted it. (Code assertions avoid spaces: Monaco renders
+		// them as NBSP.)
+		await dataExplorer.importDataModal.expectCodeToContain('pd.read_excel');
+		await dataExplorer.importDataModal.expectCodeToContain('sheet_name="Male"');
+
+		await dataExplorer.importDataModal.clickImport();
+
+		// A dataframe named after the workbook appears, so real pandas accepted the generated
+		// call. Which sheet it read is pinned by the sheet_name assertion above, not here: all
+		// three sheets have the same shape, so the row count cannot tell them apart.
+		await variables.expectVariableToBe('ap_math_enrollment', /\d+ rows/);
+	});
+
+	test('R readxl - Verify importing an XLSX honors the selected sheet', async function ({ app, openDataFile, r }) {
+		const { dataExplorer, variables } = app.workbench;
+
+		await openDataFile(join('data-files', 'ap-math-enrollment', 'ap-math-enrollment.xlsx'));
+		await dataExplorer.waitForIdle();
+
+		// Import must load the sheet the Data Explorer is showing, not the workbook's first.
+		await dataExplorer.editorActionBar.selectWorksheet('Male');
+		await dataExplorer.waitForIdle();
+
+		await dataExplorer.editorActionBar.clickButton('Import Data');
+		await dataExplorer.importDataModal.expectToBeVisible();
+		await dataExplorer.importDataModal.selectPackage('R (readxl)');
+
+		// The sheet argument proves the backend's sheet state reached the generator; the variable
+		// below proves real readxl accepted it. (The regex spans the spaces around '=' because
+		// Monaco renders them as NBSP.)
+		await dataExplorer.importDataModal.expectCodeToContain('library(readxl)');
+		await dataExplorer.importDataModal.expectCodeToContain(/read_excel\(.*sheet\s*=\s*"Male"\)/);
+
+		await dataExplorer.importDataModal.clickImport();
+
+		// readxl reads the sheet as 61 rows and 23 columns. Which sheet it read is pinned by the
+		// sheet assertion above, not here: all three sheets have the same shape.
+		await variables.expectVariableToBe('ap_math_enrollment', /61 rows x 23 columns/);
+	});
+
+	test('R nanoparquet - Verify importing a Parquet file creates a dataframe in the session', async function ({ app, openDataFile, r }) {
+		const { dataExplorer, variables } = app.workbench;
+
+		await openDataFile(join('data-files', 'misc-parquet', 'decimal_types.parquet'));
+		await dataExplorer.waitForIdle();
+
+		await dataExplorer.editorActionBar.clickButton('Import Data');
+		await dataExplorer.importDataModal.expectToBeVisible();
+		await dataExplorer.importDataModal.selectPackage('R (nanoparquet)');
+
+		await dataExplorer.importDataModal.expectCodeToContain('library(nanoparquet)');
+		await dataExplorer.importDataModal.expectCodeToContain('read_parquet');
+
+		await dataExplorer.importDataModal.clickImport();
+
+		// The file holds 4 rows and 4 decimal columns, which nanoparquet reads as doubles.
+		await variables.expectVariableToBe('decimal_types', /4 rows x 4 columns/);
+	});
+
 	test('Variables pane button - Verify Import Data picks a file then opens the dialog', async function ({ app, python }) {
 		const { dataExplorer, quickInput, variables } = app.workbench;
 

--- a/test/e2e/tests/data-explorer/import-data.test.ts
+++ b/test/e2e/tests/data-explorer/import-data.test.ts
@@ -117,7 +117,8 @@ test.describe('Data Explorer - Import Data', {
 		await variables.expectVariableToBe('ap_math_enrollment', /61 rows x 23 columns/);
 	});
 
-	test('R nanoparquet - Verify importing a Parquet file creates a dataframe in the session', async function ({ app, openDataFile, r }) {
+	// need to merge this PR and rebuild the CI images first
+	test.skip('R nanoparquet - Verify importing a Parquet file creates a dataframe in the session', async function ({ app, openDataFile, r }) {
 		const { dataExplorer, variables } = app.workbench;
 
 		await openDataFile(join('data-files', 'misc-parquet', 'decimal_types.parquet'));


### PR DESCRIPTION
Fixes #15585. Fixes #14414. Fixes #5515!!! 

Import Data now handles the other two formats the Data Explorer can already open: Excel workbooks and Parquet files.

For Python, the pandas importer picks its read function from the file's extension: `read_csv`, `read_excel`, or `read_parquet`. For R, readr is joined by two more importers, so the package selector offers the package that can actually read the file you opened:

| File | Python | R |
|---|---|---|
| `.csv`, `.tsv` | pandas `read_csv` | readr `read_csv` / `read_tsv` |
| `.xlsx` | pandas `read_excel` | readxl `read_excel` |
| `.parquet`, `.parq` | pandas `read_parquet` | nanoparquet `read_parquet` |

For a workbook, the sheet you're looking at in the Data Explorer is the sheet the generated code reads. The sheet name flows through the import options into the load call as `sheet_name=` or `sheet =`:

```r
library(readxl)

# Load ap_math_enrollment data
ap_math_enrollment <- read_excel("/data/ap-math-enrollment.xlsx", sheet = "Male")
```

The Explorer context menu and the file picker behind the Variables pane button now accept `.parquet` and `.parq` alongside `.csv`, `.tsv`, and `.xlsx`. Compressed files are still absent (#15860).

### Screenshots

<img width="796" height="485" alt="image" src="https://github.com/user-attachments/assets/badd30c5-dadb-4063-985b-51674a7ab3d3" />

<img width="794" height="483" alt="image" src="https://github.com/user-attachments/assets/09690975-322b-414e-976f-ba175b59e364" />


### Release Notes

#### New Features

- Import Data supports Excel workbooks and Parquet files, in Python with pandas and in R with readxl and nanoparquet (#14414)

#### Bug Fixes

- N/A

### Validation Steps

@:data-explorer @:duck-db @:variables @:win @:web

Python needs `pyarrow` (or `fastparquet`) for `read_parquet`; R needs `readxl` and `nanoparquet`.

1. Open `test/e2e/test-files/data-files/ap-math-enrollment/ap-math-enrollment.xlsx` in the Data Explorer and click Import Data. The preview should use `pd.read_excel`. Run it and check the dataframe lands in the Variables pane.
2. Switch the worksheet in the action bar to `Male`, then reopen Import Data. The preview should gain `sheet_name="Male"`. Run it and spot-check a value against the grid.
3. Do the same in an R session with `R (readxl)` selected. The code should be `library(readxl)` plus `read_excel(..., sheet = "Male")`, and it should run.
4. Open a Parquet file, for example `test/e2e/test-files/data-files/misc-parquet/decimal_types.parquet`. Import Data should offer `Python (pandas)` and `R (nanoparquet)` and no longer show the empty state. Run both.
5. Apply a filter and a sort to the Parquet file, then check the box to include them. The generated code should carry the filter and sort.
6. Uncheck "First row contains column names" on an XLSX, add a sort, and import. You should still get the warning that filters and sorts weren't included.
7. Right-click a `.parquet` file in the Explorer. "Import Data..." should be in the menu. Same for the file picker the Variables pane button opens.
8. Run through this on Windows, where the generated paths differ.
