### PR TITLE
Add command for fetching specific package metadata

### DIFF
--- a/extensions/positron-skills/templates/positron-commands/references/packages.md
+++ b/extensions/positron-skills/templates/positron-commands/references/packages.md
@@ -11,29 +11,48 @@ guidance is hand-written.
 ## Read the environment, never probe it
 
 To find out what is installed, what version it is, or whether something newer
-is available, call `positronPackages.getPackages`. **Do not run code to find
-out.** Writing `import pandas` in a try/except, calling `pip list`,
+is available, call `positronPackages.getAllPackages` (the whole environment) or
+`positronPackages.getPackages` (specific packages, by name). **Do not run code
+to find out.** Writing `import pandas` in a try/except, calling `pip list`,
 `installed.packages()`, `importlib.metadata.version()`, or anything similar
 through `executeCode` is the wrong move every time: it runs code the user did
 not ask for, it can have side effects (an import executes module-level code),
 it only answers for the one package you thought to test, and it tells you
 nothing about whether a newer version exists.
 
-`getPackages` has none of those problems. It changes nothing, shows the user
-nothing, needs no pane open, and answers for every installed package at once.
-Reach for it before any package operation, and before answering any question
-about what the session has.
+These commands have none of those problems. They change nothing, show the user
+nothing, and need no pane open. Reach for one before any package operation, and
+before answering any question about what the session has.
+
+**Which of the two to call:**
+
+- To size up the environment, or list what is installed, call
+  `getAllPackages`. It returns a compact entry per package, built to fit
+  hundreds of packages at once.
+- To look a package (or a few) up by name -- its full detail, its security
+  vulnerabilities, or simply *whether it is installed at all* -- call
+  `getPackages` with the names. A named package that is missing comes back in
+  `notFound`, which is a definitive "not installed"; the compact list can be
+  large, so do not conclude a package is absent just because you did not spot
+  it there.
 
 ## Reading what's installed
 
-### `positronPackages.getPackages`
+### `positronPackages.getAllPackages`
 
-Reports the packages installed in the foreground session, each with its
-installed version and whether a newer one is available. Read-only and quiet.
+Reports every package installed in the foreground session, each with its
+installed version and whether a newer one is available. A **compact** list: the
+`description` is shortened to 256 characters (suffixed with `...` when cut), and
+security vulnerabilities and the per-package detail fields (license, author,
+source repository, publication date) are left out entirely to keep the whole
+environment inside the token budget. When you need the full description, the
+detail fields, or the vulnerabilities for a package, call `getPackages` with its
+name.
 
-Unlike the write commands below, this has **no precondition** -- it is always
-callable, and tells you in its payload when it has nothing to say. So a
-`disabled` failure from a write command does not mean you cannot read.
+Read-only and quiet. Unlike the write commands below, this has **no
+precondition** -- it is always callable, and tells you in its payload when it
+has nothing to say. So a `disabled` failure from a write command does not mean
+you cannot read.
 
 **Reading the payload:**
 
@@ -61,13 +80,36 @@ callable, and tells you in its payload when it has nothing to say. So a
   available?" is answered by the package appearing in the list at all;
   `attached` only says whether it is on the search path right now.
 
+{{command:positronPackages.getAllPackages}}
+
+### `positronPackages.getPackages`
+
+Reports **full detail** on the packages you name: the full description plus the
+detail fields (license, author, source repository, publication date) and the
+security vulnerabilities that `getAllPackages` leaves out. Pass an array of
+names (matching is case-insensitive). Use it to look a package up rather than
+scanning the whole list, and to answer "is X installed?" reliably.
+
+**Reading the payload:**
+
+- `packages` holds the named packages that **are** installed, with full detail.
+- `notFound` holds the names that are **not** installed. A name here is a
+  definitive "not installed" -- that is the reason to name packages rather than
+  to search the compact list, which can be large.
+- `metadataStatus` and `vulnerabilityStatus` mean the same as elsewhere (see
+  above and the advisories section below).
+- The same `available: false` reasons apply. In addition, if you call it
+  without any names it returns `reason: 'no-names'` -- pass the package names.
+
 {{command:positronPackages.getPackages}}
 
 ## Security advisories
 
-The same payload carries known security advisories against each installed
-version, so a question about vulnerable packages is answered by `getPackages`
-too -- not by a web search, and not by running an auditing tool.
+`getPackages` carries known security advisories against each named package's
+installed version, so a question about whether a package is vulnerable is
+answered by `getPackages` -- not by a web search, and not by running an auditing
+tool. (`getAllPackages` omits advisories to stay compact, so name the packages
+you care about and call `getPackages`.)
 
 **The three states of `vulnerabilities` are all meaningful, and conflating
 them is the easiest mistake to make here:**
@@ -134,8 +176,8 @@ the plotting one", ask which.
 Installs a package that is not there yet. If the package is **already
 installed, this does nothing at all**, whatever `version` says -- it will not
 move an installed package to a different version. Use `updatePackage` for
-that. So check `getPackages` first: it tells you which of the two commands the
-user actually needs.
+that. So look the package up with `getPackages` first: it tells you whether it
+is installed, and so which of the two commands the user actually needs.
 
 Base R installs ignore `version` entirely and always take the current release
 from the repository. Do not promise a specific version on an R session using
@@ -171,7 +213,7 @@ Refreshes the Packages pane's list. Use when a package was installed or
 removed outside Positron (from a terminal, say) and the pane looks stale.
 
 This is for the *pane*. To read the installed list yourself, use
-`getPackages`, which reads live and does not need this first.
+`getAllPackages`, which reads live and does not need this first.
 
 {{command:positronPackages.refreshPackages}}
 
@@ -186,8 +228,8 @@ That last clause is the one to watch. A `disabled` failure does not
 necessarily mean the feature is off or the session is missing -- it may simply
 mean an install or update is in flight. Wait and tell the user an operation is
 already running; do not retry in a loop, and do not conclude packages are
-unavailable. `getPackages` still works while an operation runs, so use it to
-tell the cases apart.
+unavailable. `getAllPackages` and `getPackages` still work while an operation
+runs, so use one to tell the cases apart.
 
 ## After installing or updating
 

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesCommands.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesCommands.ts
@@ -12,12 +12,12 @@ import { RuntimeState } from '../../../services/languageRuntime/common/languageR
 import { ILanguageRuntimePackage, ILanguageRuntimeSession, IPackageVulnerability } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { IPositronPackagesService } from './interfaces/positronPackagesService.js';
 import { severityBand, VulnerabilitySeverityBand } from './packageVulnerabilities.js';
-import { IPackagesSnapshot, PackagesMetadataStatus, PackagesVulnerabilityStatus } from './positronPackagesInstance.js';
+import { IPackagesSnapshot, IPositronPackagesInstance, PackagesMetadataStatus, PackagesVulnerabilityStatus } from './positronPackagesInstance.js';
 import { PACKAGES_ENABLED_KEY, PACKAGES_ENABLED_LEGACY_KEY } from './positronPackagesContextKeys.js';
 
 /**
- * Whether the packages command should produce a payload at all: it goes quiet
- * when the Packages pane is turned off. The command stays registered either
+ * Whether the packages commands should produce a payload at all: they go quiet
+ * when the Packages pane is turned off. The commands stay registered either
  * way, so Assistant-side feature detection is a simple getCommands() check.
  *
  * Deliberately not gated on the ai.enabled main switch. This reports the
@@ -35,61 +35,29 @@ function isPackagesCommandEnabled(configurationService: IConfigurationService): 
 }
 
 /**
- * A single installed package, as the getPackages command reports it.
- *
- * Only the fields a session's package *list* actually carries are here.
- * License, publication date, author and source repository are served one
- * package at a time by the detail RPC (that's what the package editor opens
- * for), so including them would cost a round trip per package and, in
- * practice, be absent from every entry.
+ * Hard cap on a description's length in the getAllPackages payload. That command
+ * lists a whole environment -- hundreds of packages -- for an agent to size up
+ * at once, so a single package with a long description must not crowd the rest
+ * out of the token budget. The full description, and the fields left out of the
+ * list entirely, are served per package by getPackages.
  */
-export interface IPackagesCommandPackage {
-	name: string;
+const MAX_LIST_DESCRIPTION_LENGTH = 256;
 
-	/** The installed version. */
-	version: string;
-
-	/**
-	 * The newest version available to the session. Absent when nothing newer
-	 * exists, or when outdated state could not be obtained -- see
-	 * {@link IPackagesCommandResult.metadataStatus}.
-	 */
-	latestVersion?: string;
-
-	/** Whether the installed version is older than `latestVersion`. */
-	outdated?: boolean;
-
-	/**
-	 * Whether the package is on the session's search path: attached with
-	 * `library()` in R, bound to a name in the user namespace in Python.
-	 * Distinct from installed, and from loaded as a transitive dependency.
-	 */
-	attached?: boolean;
-
-	/** One-line summary, when the session's package list carries one. */
-	description?: string;
-
-	/** The package's primary external URL (homepage, falling back to repository). */
-	url?: string;
-
-	/**
-	 * Known security advisories affecting *this* installed version, worst-scored
-	 * first.
-	 *
-	 * Three states, all meaningful:
-	 * - a non-empty array: the installed version is affected.
-	 * - an empty array: the repository knows this version and reports nothing
-	 *   against it -- an all-clear, not a missing answer.
-	 * - absent: no advisory data for this package, so nothing can be concluded
-	 *   either way. See {@link IPackagesCommandResult.vulnerabilityStatus}.
-	 */
-	vulnerabilities?: IPackagesCommandVulnerability[];
+/**
+ * Truncates a description to {@link MAX_LIST_DESCRIPTION_LENGTH}, marking a cut
+ * one so a reader can tell it was shortened rather than being this brief.
+ * @param text The description as the session reported it.
+ */
+function truncateDescription(text: string): string {
+	return text.length > MAX_LIST_DESCRIPTION_LENGTH
+		? `${text.slice(0, MAX_LIST_DESCRIPTION_LENGTH).trimEnd()}...`
+		: text;
 }
 
 /**
  * A single security advisory affecting an installed package version, as the
- * getPackages command reports it. Mirrors {@link IPackageVulnerability} with
- * the severity band the pane renders resolved for the caller.
+ * package commands report it. Mirrors {@link IPackageVulnerability} with the
+ * severity band the pane renders resolved for the caller.
  */
 export interface IPackagesCommandVulnerability {
 	/** Preferred display id: the CVE when one exists, otherwise the OSV id. */
@@ -133,7 +101,7 @@ export interface IPackagesCommandVulnerability {
 }
 
 /**
- * The Package Manager instance that served the advisories in the payload, and
+ * The Package Manager instance that served the advisories in a payload, and
  * when -- so a caller can say where the advisory data came from and how old it
  * is, rather than presenting it as timeless fact.
  */
@@ -146,7 +114,7 @@ export interface IPackagesCommandVulnerabilitySource {
 }
 
 /**
- * The session the payload describes. Named rather than implied so a caller
+ * The session a payload describes. Named rather than implied so a caller
  * holding several sessions can tell which environment it just read, and so a
  * stale answer is recognizable as one.
  */
@@ -160,9 +128,120 @@ export interface IPackagesCommandSession {
 }
 
 /**
- * The getPackages payload: what is installed in the foreground session.
+ * A single installed package in the getAllPackages list: the compact shape,
+ * sized so a whole environment fits an agent's token budget.
+ *
+ * Deliberately lean. Security advisories and the detail fields (license,
+ * publication date, author, source repository, title) are left out; the
+ * description is capped. All of them are served per package by getPackages.
  */
-export interface IPackagesCommandResult {
+export interface IAllPackagesCommandPackage {
+	name: string;
+
+	/** The installed version. */
+	version: string;
+
+	/**
+	 * The newest version available to the session. Absent when nothing newer
+	 * exists, or when outdated state could not be obtained -- see
+	 * {@link IAllPackagesCommandResult.metadataStatus}.
+	 */
+	latestVersion?: string;
+
+	/** Whether the installed version is older than `latestVersion`. */
+	outdated?: boolean;
+
+	/**
+	 * Whether the package is on the session's search path: attached with
+	 * `library()` in R, bound to a name in the user namespace in Python.
+	 * Distinct from installed, and from loaded as a transitive dependency.
+	 */
+	attached?: boolean;
+
+	/**
+	 * One-line summary, when the session's package list carries one, capped at
+	 * {@link MAX_LIST_DESCRIPTION_LENGTH} and suffixed with "..." when cut. Call
+	 * getPackages for the full text.
+	 */
+	description?: string;
+
+	/** The package's primary external URL (homepage, falling back to repository). */
+	url?: string;
+}
+
+/**
+ * A single package in the getPackages payload: the full per-package shape, with
+ * the detail fields and security advisories the list omits.
+ */
+export interface IPackageCommandPackage {
+	name: string;
+
+	/** The installed version. */
+	version: string;
+
+	/** The newest version available to the session, when known. */
+	latestVersion?: string;
+
+	/** Whether the installed version is older than `latestVersion`. */
+	outdated?: boolean;
+
+	/** Whether the package is on the session's search path. */
+	attached?: boolean;
+
+	/** Full one-line summary (uncapped, unlike the list). */
+	description?: string;
+
+	/** The package's primary external URL (homepage, falling back to repository). */
+	url?: string;
+
+	/** License information, from the detail lookup. */
+	license?: string;
+
+	/** Display-ready author/maintainer string, from the detail lookup. */
+	author?: string;
+
+	/** Source repository label or URL (e.g. "CRAN"), from the detail lookup. */
+	sourceRepository?: string;
+
+	/** Publication/release date, from the detail lookup. */
+	publishedDate?: string;
+
+	/** One-line title/summary, richer than `description`, from the detail lookup. */
+	title?: string;
+
+	/**
+	 * Known security advisories affecting *this* installed version, worst-scored
+	 * first.
+	 *
+	 * Three states, all meaningful:
+	 * - a non-empty array: the installed version is affected.
+	 * - an empty array: the repository knows this version and reports nothing
+	 *   against it -- an all-clear, not a missing answer.
+	 * - absent: no advisory data for this package, so nothing can be concluded
+	 *   either way. See {@link IPackageCommandResult.vulnerabilityStatus}.
+	 */
+	vulnerabilities?: IPackagesCommandVulnerability[];
+}
+
+/**
+ * The getAllPackages payload: the compact list of what is installed in the
+ * foreground session.
+ */
+export interface IAllPackagesCommandResult {
+	available: true;
+
+	session: IPackagesCommandSession;
+
+	/** How far the `outdated` state below can be trusted. */
+	metadataStatus: PackagesMetadataStatus;
+
+	packages: IAllPackagesCommandPackage[];
+}
+
+/**
+ * The getPackages payload: full detail on the packages the caller named.
+ */
+export interface IPackageCommandResult {
 	available: true;
 
 	session: IPackagesCommandSession;
@@ -184,13 +263,22 @@ export interface IPackagesCommandResult {
 	 */
 	vulnerabilitySource?: IPackagesCommandVulnerabilitySource;
 
-	packages: IPackagesCommandPackage[];
+	/** The named packages that are installed, with full detail. */
+	packages: IPackageCommandPackage[];
+
+	/**
+	 * The named packages that are not installed in the session. Empty when every
+	 * requested package was found. A name here is a definitive "not installed",
+	 * not a truncated-away answer -- which is the whole point of naming packages
+	 * rather than scanning the list.
+	 */
+	notFound: string[];
 }
 
 /**
- * Why getPackages produced no payload. Distinguishing these is the point: each
- * calls for a different next step, and a caller can't read the log line that
- * says which happened.
+ * Why a package command produced no payload. Distinguishing these is the point:
+ * each calls for a different next step, and a caller can't read the log line
+ * that says which happened.
  *
  * - `disabled`: the Packages pane is turned off in settings.
  * - `no-session`: no interpreter session is running, so there is no
@@ -208,8 +296,8 @@ export type PackagesUnavailableReason =
 	| 'failed';
 
 /**
- * What getPackages returns in place of a payload. `available: false` is the
- * discriminant against {@link IPackagesCommandResult}.
+ * What a package command returns in place of a payload. `available: false` is
+ * the discriminant against the available results.
  */
 export interface IPackagesCommandUnavailableResult {
 	available: false;
@@ -221,10 +309,21 @@ export interface IPackagesCommandUnavailableResult {
 }
 
 /**
- * What getPackages resolves to: the packages, or the reason there are none to
- * report.
+ * What getPackages returns when the caller named no packages. Its own
+ * discriminant (`reason: 'no-names'`), kept apart from the environment reasons
+ * above because it is a bad call, not a state of the session.
  */
-export type PackagesCommandResult = IPackagesCommandResult | IPackagesCommandUnavailableResult;
+export interface IPackageNoNamesResult {
+	available: false;
+
+	reason: 'no-names';
+}
+
+/** What getAllPackages resolves to. */
+export type AllPackagesCommandResult = IAllPackagesCommandResult | IPackagesCommandUnavailableResult;
+
+/** What getPackages resolves to. */
+export type PackageCommandResult = IPackageCommandResult | IPackagesCommandUnavailableResult | IPackageNoNamesResult;
 
 /**
  * The runtime states in which a session can answer a package query. Mirrors
@@ -286,13 +385,12 @@ function describeVulnerabilities(vulnerabilities: readonly IPackageVulnerability
 }
 
 /**
- * Maps a package to its payload shape. Explicit rather than a spread so the
- * agent-facing contract doesn't quietly grow whichever fields the runtime
+ * Maps a package to its compact list shape. Explicit rather than a spread so
+ * the agent-facing contract doesn't quietly grow whichever fields the runtime
  * interface gains next.
  * @param pkg The package as the session reported it.
- * @param includeVulnerabilities Whether advisory data may be reported at all.
  */
-function describePackage(pkg: ILanguageRuntimePackage, includeVulnerabilities: boolean): IPackagesCommandPackage {
+function describeListPackage(pkg: ILanguageRuntimePackage): IAllPackagesCommandPackage {
 	return {
 		name: pkg.name,
 		version: pkg.version,
@@ -302,11 +400,34 @@ function describePackage(pkg: ILanguageRuntimePackage, includeVulnerabilities: b
 		// Python's package list sends an empty string for a package with no
 		// summary; an absent field says "unknown" without the caller having to
 		// treat '' as a special case.
+		description: pkg.description ? truncateDescription(pkg.description) : undefined,
+		url: pkg.url,
+	};
+}
+
+/**
+ * Maps a package to its full detail shape, with the detail fields and
+ * advisories the list omits.
+ * @param pkg The package, with its detail fields already merged over the list entry.
+ * @param includeVulnerabilities Whether advisory data may be reported at all.
+ */
+function describePackage(pkg: ILanguageRuntimePackage, includeVulnerabilities: boolean): IPackageCommandPackage {
+	return {
+		name: pkg.name,
+		version: pkg.version,
+		latestVersion: pkg.latestVersion,
+		outdated: pkg.outdated,
+		attached: pkg.attached,
 		description: pkg.description || undefined,
 		url: pkg.url,
-		// Unlike the fields above, an empty array is kept rather than
-		// normalized away: it is the all-clear, and collapsing it to undefined
-		// would report "checked, nothing found" as "not checked".
+		license: pkg.license,
+		author: pkg.author,
+		sourceRepository: pkg.sourceRepository,
+		publishedDate: pkg.publishedDate,
+		title: pkg.title,
+		// Unlike the fields above, an empty array is kept rather than normalized
+		// away: it is the all-clear, and collapsing it to undefined would report
+		// "checked, nothing found" as "not checked".
 		vulnerabilities: includeVulnerabilities && pkg.vulnerabilities
 			? describeVulnerabilities(pkg.vulnerabilities)
 			: undefined,
@@ -329,63 +450,155 @@ function describeVulnerabilitySource(
 }
 
 /**
- * Builds the getPackages payload: the packages installed in the foreground
- * session, each with its installed version, whether something newer is
- * available, and any known security advisories against the installed version,
- * for Assistant to reason about the environment it is working in.
- *
- * Read-only and quiet -- no progress notification, no pane required. Never
- * throws: every way this can come up empty is reported as a reason the caller
- * can act on (see {@link PackagesUnavailableReason}).
- * @param accessor The services accessor.
+ * The active session's package snapshot, or the reason there is none to read.
+ * Shared by both commands: everything up to and including the snapshot read is
+ * identical; only how the packages are projected differs. `ok` discriminates.
  */
-export async function getPackages(accessor: ServicesAccessor): Promise<PackagesCommandResult> {
-	// Everything is resolved before the first await: a ServicesAccessor stops
-	// being valid once the handler yields.
+type SnapshotResolution =
+	| { ok: true; session: ILanguageRuntimeSession; instance: IPositronPackagesInstance; snapshot: IPackagesSnapshot }
+	| { ok: false; result: IPackagesCommandUnavailableResult };
+
+/**
+ * Reads the foreground session's package snapshot, mapping every way it can come
+ * up empty to a reason the caller can act on. Never throws.
+ * @param accessor The services accessor. Resolve it before the first await: a
+ * ServicesAccessor stops being valid once the handler yields.
+ * @param includeVulnerabilities Whether the snapshot should run the (slower)
+ * advisory lookup. The list command opts out; the detail command needs it.
+ */
+async function resolveSnapshot(
+	accessor: ServicesAccessor,
+	includeVulnerabilities: boolean,
+): Promise<SnapshotResolution> {
 	const configurationService = accessor.get(IConfigurationService);
 	const packagesService = accessor.get(IPositronPackagesService);
 	const logService = accessor.get(ILogService);
 
-	// The command has no precondition (see its registration below), so this is
+	// The commands have no precondition (see registration below), so this is
 	// how a caller learns the feature is off: a reason it can act on, rather
 	// than an empty list indistinguishable from an empty environment.
 	if (!isPackagesCommandEnabled(configurationService)) {
-		return { available: false, reason: 'disabled' };
+		return { ok: false, result: { available: false, reason: 'disabled' } };
 	}
 
 	const instance = packagesService.activePackagesInstance;
 	if (!instance) {
-		return { available: false, reason: 'no-session' };
+		return { ok: false, result: { available: false, reason: 'no-session' } };
 	}
 
 	const session = instance.session;
 	if (!READABLE_RUNTIME_STATES.includes(session.getRuntimeState())) {
 		logService.debug(`[Packages] getPackages: session ${session.sessionId} is ${session.getRuntimeState()}.`);
-		return { available: false, reason: 'session-not-ready' };
+		return { ok: false, result: { available: false, reason: 'session-not-ready' } };
 	}
 
 	let snapshot: IPackagesSnapshot;
 	try {
-		snapshot = await instance.getPackagesSnapshot();
+		snapshot = await instance.getPackagesSnapshot(undefined, { includeVulnerabilities });
 	} catch (err) {
 		logService.warn(`[Packages] getPackages: failed to read packages for ${session.sessionId}: ${err}`);
 		return {
-			available: false,
-			reason: 'failed',
-			message: err instanceof Error ? err.message : String(err),
+			ok: false,
+			result: {
+				available: false,
+				reason: 'failed',
+				message: err instanceof Error ? err.message : String(err),
+			},
 		};
 	}
 
 	// A runtime with no package manager reports no packages, which on its own
 	// reads as an empty environment; the reason keeps the two apart.
 	if (snapshot.metadataStatus === 'unsupported' && snapshot.packages.length === 0) {
-		return { available: false, reason: 'unsupported' };
+		return { ok: false, result: { available: false, reason: 'unsupported' } };
 	}
 
-	// The snapshot reports 'disabled' from the same setting, but the packages
-	// still carry whatever the cache holds: the status describes the read, this
-	// drops the data it says isn't there.
+	return { ok: true, session, instance, snapshot };
+}
+
+/**
+ * Builds the getAllPackages payload: the compact list of packages installed in
+ * the foreground session, each with its installed version and whether something
+ * newer is available, for Assistant to size up the environment it is working in.
+ *
+ * Read-only and quiet -- no progress notification, no pane required. Never
+ * throws: every way this can come up empty is reported as a reason the caller
+ * can act on (see {@link PackagesUnavailableReason}).
+ * @param accessor The services accessor.
+ */
+export async function getAllPackages(accessor: ServicesAccessor): Promise<AllPackagesCommandResult> {
+	// The list never carries advisories, so it skips the advisory lookup rather
+	// than paying for a whole-environment fetch on every call.
+	const resolved = await resolveSnapshot(accessor, false);
+	if (!resolved.ok) {
+		return resolved.result;
+	}
+
+	return {
+		available: true,
+		session: describeSession(resolved.session),
+		metadataStatus: resolved.snapshot.metadataStatus,
+		packages: resolved.snapshot.packages.map(describeListPackage),
+	};
+}
+
+/**
+ * Builds the getPackages payload: full detail on each named package that is
+ * installed in the foreground session -- its detail fields (license,
+ * publication date, author, source repository) and any known security
+ * advisories against the installed version -- plus the names that are not
+ * installed. For looking one package up rather than reading the whole list.
+ *
+ * Read-only and quiet. Never throws: every way this can come up empty is a
+ * reason the caller can act on.
+ * @param accessor The services accessor.
+ * @param args The package names to look up, as a string, an array of strings,
+ * or several string arguments.
+ */
+export async function getPackages(accessor: ServicesAccessor, ...args: unknown[]): Promise<PackageCommandResult> {
+	const names = normalizeNames(args);
+	if (names.length === 0) {
+		return { available: false, reason: 'no-names' };
+	}
+
+	const resolved = await resolveSnapshot(accessor, true);
+	if (!resolved.ok) {
+		return resolved.result;
+	}
+
+	const { instance, session, snapshot } = resolved;
 	const vulnerabilitiesEnabled = snapshot.vulnerabilityStatus !== 'disabled';
+
+	// Match requested names against the installed list case-insensitively (a
+	// repository asked about 'Matrix' has been asked about 'matrix'), keeping
+	// the caller's order. A name with no match is definitively not installed.
+	const byName = new Map<string, ILanguageRuntimePackage>();
+	for (const pkg of snapshot.packages) {
+		const key = pkg.name.toLowerCase();
+		if (!byName.has(key)) {
+			byName.set(key, pkg);
+		}
+	}
+
+	const found: ILanguageRuntimePackage[] = [];
+	const notFound: string[] = [];
+	for (const name of names) {
+		const pkg = byName.get(name.toLowerCase());
+		if (pkg) {
+			found.push(pkg);
+		} else {
+			notFound.push(name);
+		}
+	}
+
+	// The detail fields (license, author, source repository, published date) are
+	// a per-package RPC, run only for the handful the caller named -- the reason
+	// this command exists rather than the list carrying them for everything.
+	// The advisories already rode in with the snapshot above.
+	const packages = await Promise.all(found.map(async (pkg) => {
+		const detail = await instance.getPackageDetail(pkg.name).catch(() => undefined);
+		return describePackage({ ...pkg, ...detail }, vulnerabilitiesEnabled);
+	}));
 
 	return {
 		available: true,
@@ -393,38 +606,87 @@ export async function getPackages(accessor: ServicesAccessor): Promise<PackagesC
 		metadataStatus: snapshot.metadataStatus,
 		vulnerabilityStatus: snapshot.vulnerabilityStatus,
 		vulnerabilitySource: describeVulnerabilitySource(snapshot.vulnerabilitySource),
-		packages: snapshot.packages.map((pkg) => describePackage(pkg, vulnerabilitiesEnabled)),
+		packages,
+		notFound,
 	};
 }
 
-// The id of the payload command. One command per payload, matching every other
-// agentCompatible command in the workbench, so it carries its own return
-// contract and shows up on its own in the positron-commands skill's reference
-// file (#15344).
+/**
+ * Collects the package names from a command's arguments, accepting a single
+ * string, an array of strings, or several string arguments. Trims each, drops
+ * blanks, and deduplicates case-insensitively while keeping the first spelling.
+ * @param args The raw command arguments.
+ */
+function normalizeNames(args: unknown[]): string[] {
+	const seen = new Set<string>();
+	const names: string[] = [];
+	const add = (value: unknown): void => {
+		if (typeof value !== 'string') {
+			return;
+		}
+		const name = value.trim();
+		const key = name.toLowerCase();
+		if (name && !seen.has(key)) {
+			seen.add(key);
+			names.push(name);
+		}
+	};
+	for (const arg of args) {
+		if (Array.isArray(arg)) {
+			arg.forEach(add);
+		} else {
+			add(arg);
+		}
+	}
+	return names;
+}
+
+// The ids of the payload commands. One command per payload, matching every
+// other agentCompatible command in the workbench, so each carries its own
+// return contract and shows up on its own in the positron-commands skill's
+// reference file (#15344).
+export const PACKAGES_GET_ALL_PACKAGES_COMMAND_ID = 'positronPackages.getAllPackages';
 export const PACKAGES_GET_PACKAGES_COMMAND_ID = 'positronPackages.getPackages';
 
 // Registered through CommandsRegistry rather than registerAction2, so the
-// payload command takes no Command Palette slot: running it would show the
+// payload commands take no Command Palette slot: running one would show the
 // user nothing, since the return value is for a programmatic caller. The
-// Command Palette entry that displays this payload lives in
+// Command Palette entry that displays a payload lives in
 // positronPackagesInspectActions.ts.
 //
-// That also means it has no precondition -- registerAction2 only records one in
-// MenuRegistry when f1 is set, and MenuRegistry is the only place the agent
+// That also means they have no precondition -- registerAction2 only records one
+// in MenuRegistry when f1 is set, and MenuRegistry is the only place the agent
 // path reads preconditions from. This is the always-registered pattern the
-// payload wants: Assistant discovers the command once, and learns the feature
+// payloads want: Assistant discovers the commands once, and learns the feature
 // is off from the payload itself (reason 'disabled') rather than by the command
 // vanishing from getAgentAllowedCommands() mid-session.
+CommandsRegistry.registerCommand({
+	id: PACKAGES_GET_ALL_PACKAGES_COMMAND_ID,
+	handler: getAllPackages,
+	metadata: {
+		description: localize(
+			'positron.packages.getAllPackages.description',
+			"Read the packages installed in the running interpreter session, each with its version and whether a newer version is available. A compact list built to fit a whole environment at once: descriptions are shortened and security vulnerabilities and per-package detail (license, author, source repository, publication date) are left out. To get those, or the full description, call positronPackages.getPackages with the package names. Changes nothing and shows the user nothing: unlike Refresh Packages, it can be called at any time, including before the Packages pane has ever been opened."
+		),
+		// Advertise this command to AI agents (positron.ai.getAgentAllowedCommands).
+		agentCompatible: true,
+		returns: 'An object with available: true, the session the packages belong to, the installed packages (name, version, latestVersion, outdated, attached, description, url) -- where description is shortened to 256 characters and suffixed with "..." when cut -- and metadataStatus saying how the outdated state was obtained: \'fresh\' (repositories queried now), \'cached\' (as of the last fetch), \'unsupported\' (this runtime reports no outdated state, so no package has it), \'timed-out\' (the list is complete but outdated state may be missing), or \'fetch-failed\' (the repository query errored; the list is complete, outdated state is whatever an earlier fetch cached). This list carries no security vulnerabilities and no per-package detail; call positronPackages.getPackages for those. When there are no packages to report, an object with available: false and a reason of \'disabled\', \'no-session\', \'session-not-ready\', \'unsupported\', or \'failed\' -- the last of which also carries a message.',
+	},
+});
+
 CommandsRegistry.registerCommand({
 	id: PACKAGES_GET_PACKAGES_COMMAND_ID,
 	handler: getPackages,
 	metadata: {
 		description: localize(
 			'positron.packages.getPackages.description',
-			"Read the packages installed in the running interpreter session, with the version of each, whether a newer version is available, and any known security vulnerabilities affecting the installed version. Changes nothing and shows the user nothing: unlike Refresh Packages, it can be called at any time, including before the Packages pane has ever been opened."
+			"Read full detail on specific packages in the running interpreter session: the version, whether a newer version is available, the full description, the detail fields (license, author, source repository, publication date), and any known security vulnerabilities affecting the installed version. Use this to look a package up by name -- including to check whether it is installed at all -- rather than reading the whole environment with positronPackages.getAllPackages. Changes nothing and shows the user nothing."
 		),
 		// Advertise this command to AI agents (positron.ai.getAgentAllowedCommands).
 		agentCompatible: true,
-		returns: 'An object with available: true, the session the packages belong to, the installed packages (name, version, latestVersion, outdated, attached, description, url, vulnerabilities), and metadataStatus saying how the outdated state was obtained: \'fresh\' (repositories queried now), \'cached\' (as of the last fetch), \'unsupported\' (this runtime reports no outdated state, so no package has it), \'timed-out\' (the list is complete but outdated state may be missing), or \'fetch-failed\' (the repository query errored; the list is complete, outdated state is whatever an earlier fetch cached). Each package\'s vulnerabilities are the security advisories against its installed version, worst first (id, osvId, score, scoreVersion, severity of \'critical\'/\'high\'/\'medium\'/\'low\'/\'unscored\', summary, fixedIn, published, url); an empty array means the repository was asked and reports nothing against that version, which is an all-clear, while an absent field means there is no advisory data for that package at all, which is not. vulnerabilityStatus says how the advisories were obtained: \'fresh\' (Package Manager queried now for every package), \'cached\' (the cached advisories were still current, so only packages with none were queried now), \'disabled\' (advisory lookups are turned off in settings), \'unavailable\' (a lookup ran and produced nothing: either no Package Manager here reports advisories or the lookup failed, and neither is worth retrying), or \'timed-out\' (the lookup ran out of time partway: the package list is complete, the advisories fetched before time ran out are included, and the packages never reached carry whatever was cached, possibly nothing). A package with no advisory data is looked up automatically, so after \'fresh\' or \'cached\' there is no reason to call this command again for advisories; after \'timed-out\', calling again continues where the lookup stopped and fills the remaining gaps. vulnerabilitySource names the Package Manager host that served them and when it answered. When there are no packages to report, an object with available: false and a reason of \'disabled\', \'no-session\', \'session-not-ready\', \'unsupported\', or \'failed\' -- the last of which also carries a message.',
+		args: [
+			{ name: 'names', description: 'The package names to look up, as the package repository knows them (for example: dplyr, pandas). Pass an array of names, or a single name. Matching is case-insensitive.', schema: { type: 'array', items: { type: 'string' } } },
+		],
+		returns: 'An object with available: true, the session the packages belong to, packages (the named packages that are installed, with full detail), notFound (the named packages that are not installed -- a name here is a definitive "not installed", not a truncated-away answer), metadataStatus (how the outdated state was obtained: \'fresh\', \'cached\', \'unsupported\', \'timed-out\', or \'fetch-failed\'), and vulnerabilityStatus (how advisories were obtained). Each installed package carries name, version, latestVersion, outdated, attached, description, url, license, author, sourceRepository, publishedDate, title, and vulnerabilities. vulnerabilities are the security advisories against the installed version, worst first (id, osvId, score, scoreVersion, severity of \'critical\'/\'high\'/\'medium\'/\'low\'/\'unscored\', summary, fixedIn, published, url); an empty array means the repository was asked and reports nothing against that version, which is an all-clear, while an absent field means there is no advisory data for that package at all, which is not. vulnerabilityStatus says how the advisories were obtained: \'fresh\' (Package Manager queried now), \'cached\' (the cached advisories were still current), \'disabled\' (advisory lookups are turned off in settings), \'unavailable\' (a lookup ran and produced nothing, which is not worth retrying), or \'timed-out\' (the lookup ran out of time partway). vulnerabilitySource names the Package Manager host that served them and when it answered. When no packages are named, an object with available: false and reason \'no-names\'. When there are no packages to report at all, an object with available: false and a reason of \'disabled\', \'no-session\', \'session-not-ready\', \'unsupported\', or \'failed\' -- the last of which also carries a message.',
 	},
 });

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesInspectActions.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesInspectActions.ts
@@ -10,19 +10,19 @@ import { Action2, registerAction2 } from '../../../../platform/actions/common/ac
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IProgressService, ProgressLocation } from '../../../../platform/progress/common/progress.js';
 import { POSITRON_PACKAGES_ENABLED } from './positronPackagesContextKeys.js';
-import { getPackages } from './positronPackagesCommands.js';
+import { getAllPackages } from './positronPackagesCommands.js';
 
 /**
- * Command Palette entry that shows the positronPackages.getPackages payload --
- * the same JSON Assistant reads -- in an untitled editor. Unlike the command it
- * wraps, this ships rather than being development-only, so the payload can be
- * inspected in a release build.
+ * Command Palette entry that shows the positronPackages.getAllPackages payload
+ * -- the same compact JSON Assistant reads -- in an untitled editor. Unlike the
+ * command it wraps, this ships rather than being development-only, so the
+ * payload can be inspected in a release build.
  *
  * Wrapped in progress because the command fills its own gaps: on a cold cache
- * it queries the repositories for outdated state and Package Manager for
- * security advisories before answering, which takes seconds. A palette entry
- * that sat silent for that long would read as a hang, and the delay only shows
- * up on exactly the runs a developer reaches for this to inspect.
+ * it queries the repositories for outdated state before answering, which takes
+ * seconds. A palette entry that sat silent for that long would read as a hang,
+ * and the delay only shows up on exactly the runs a developer reaches for this
+ * to inspect.
  *
  * Exported so tests can construct it and call run() directly.
  */
@@ -39,11 +39,11 @@ export class ShowPackagesAction extends Action2 {
 
 	override async run(accessor: ServicesAccessor): Promise<void> {
 		// The accessor stops being valid at the first await, so the services are
-		// resolved up front and getPackages is called before anything is awaited
-		// (it resolves the services it needs synchronously).
+		// resolved up front and getAllPackages is called before anything is
+		// awaited (it resolves the services it needs synchronously).
 		const editorService = accessor.get(IEditorService);
 		const progressService = accessor.get(IProgressService);
-		const packagesPromise = getPackages(accessor);
+		const packagesPromise = getAllPackages(accessor);
 
 		const packages = await progressService.withProgress({
 			title: localize('positron.packages.showPackages.reading', "Reading packages..."),

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesInstance.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesInstance.ts
@@ -96,6 +96,14 @@ export interface IPackagesSnapshotOptions {
 	metadataTimeoutMs?: number;
 	/** Budget for the advisory lookup, when one is run. */
 	vulnerabilityTimeoutMs?: number;
+	/**
+	 * Whether to run the advisory lookup at all. Defaults to true. A caller that
+	 * won't report advisories (the compact getAllPackages list) sets this false
+	 * to skip a whole-environment fetch it would only throw away; the resulting
+	 * snapshot carries no advisories, and its `vulnerabilityStatus` is not a
+	 * lookup result.
+	 */
+	includeVulnerabilities?: boolean;
 }
 
 /**
@@ -189,7 +197,7 @@ export interface IPositronPackagesInstance {
 	/**
 	 * Reads the installed packages together with their outdated state, for a
 	 * caller that needs an answer rather than a rendered pane -- notably the
-	 * positronPackages.getPackages command.
+	 * positronPackages.getAllPackages and getPackages commands.
 	 *
 	 * Differs from {@link refreshPackages} in the two ways that matter to such
 	 * a caller: it reads the installed list live on every call (an agent can
@@ -204,7 +212,8 @@ export interface IPositronPackagesInstance {
 	 * package with no cached advisory data is looked up now, and a cache still
 	 * inside its freshness window is reported as-is. So a caller never has to
 	 * ask twice to find out whether its packages have advisories, and a warm
-	 * cache still costs nothing.
+	 * cache still costs nothing. A caller that won't report advisories can skip
+	 * the lookup entirely with `options.includeVulnerabilities: false`.
 	 */
 	getPackagesSnapshot(token?: CancellationToken, options?: IPackagesSnapshotOptions): Promise<IPackagesSnapshot>;
 
@@ -989,14 +998,20 @@ export class PositronPackagesInstance extends Disposable implements IPositronPac
 			outdatedSupported
 				? this._snapshotOutdatedStage(packageManager, visiblePackages, versionByName, token, metadataDeadline, fetchAll)
 				: Promise.resolve<PackagesMetadataStatus>('unsupported'),
-			this._snapshotVulnerabilityStage(
-				packageManager,
-				visiblePackages,
-				versionByName,
-				token,
-				options.vulnerabilityTimeoutMs ?? PACKAGES_SNAPSHOT_VULNERABILITY_TIMEOUT_MS,
-				fetchAll,
-			),
+			// A caller that won't report advisories skips the lookup: it is the
+			// slow stage, and running it only to drop the result would defeat the
+			// point of the compact list. The packages then carry no advisories,
+			// so 'cached' here means "not looked up", not "as of the last fetch".
+			options.includeVulnerabilities === false
+				? Promise.resolve<PackagesVulnerabilityStatus>(this._vulnerabilityStatus('cached'))
+				: this._snapshotVulnerabilityStage(
+					packageManager,
+					visiblePackages,
+					versionByName,
+					token,
+					options.vulnerabilityTimeoutMs ?? PACKAGES_SNAPSHOT_VULNERABILITY_TIMEOUT_MS,
+					fetchAll,
+				),
 		]);
 
 		return this._snapshotResult(this.packages, metadataStatus, vulnerabilityStatus);

--- a/src/vs/workbench/contrib/positronPackages/test/browser/positronPackagesCommands.vitest.ts
+++ b/src/vs/workbench/contrib/positronPackages/test/browser/positronPackagesCommands.vitest.ts
@@ -14,7 +14,7 @@ import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { ILanguageRuntimeMetadata, ILanguageRuntimeSessionState, RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimePackage, ILanguageRuntimeSession, IPackageVulnerability } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { IPositronPackagesService } from '../../browser/interfaces/positronPackagesService.js';
-import { PACKAGES_GET_PACKAGES_COMMAND_ID, getPackages } from '../../browser/positronPackagesCommands.js';
+import { PACKAGES_GET_ALL_PACKAGES_COMMAND_ID, PACKAGES_GET_PACKAGES_COMMAND_ID, getAllPackages, getPackages } from '../../browser/positronPackagesCommands.js';
 import { IPackagesSnapshot, IPositronPackagesInstance } from '../../browser/positronPackagesInstance.js';
 
 /** An installed package as a session's package list reports it. */
@@ -39,11 +39,13 @@ function createSession(runtimeState: RuntimeState = RuntimeState.Idle): ILanguag
 
 /**
  * A packages instance whose snapshot is `snapshot`, or that fails the read when
- * given an error.
+ * given an error. `details` supplies what getPackageDetail returns per package
+ * (keyed by lowercased name), for the getPackages detail merge.
  */
 function createInstance(
 	snapshot: SnapshotStub | Error,
 	session: ILanguageRuntimeSession = createSession(),
+	details: Record<string, Partial<ILanguageRuntimePackage>> = {},
 ): IPositronPackagesInstance {
 	return stubInterface<IPositronPackagesInstance>({
 		session,
@@ -55,6 +57,7 @@ function createInstance(
 			// refresh reports, so only the tests about advisories mention them.
 			return { vulnerabilityStatus: 'cached' as const, ...snapshot };
 		}),
+		getPackageDetail: vi.fn(async (name: string) => details[name.toLowerCase()]),
 	});
 }
 
@@ -81,7 +84,7 @@ function advisory(id: string, score?: number): IPackageVulnerability {
 	};
 }
 
-describe('getPackages', () => {
+describe('getAllPackages', () => {
 	const ctx = createTestContainer().build();
 
 	/**
@@ -106,7 +109,7 @@ describe('getPackages', () => {
 			{ 'packages.enabled': false, 'positron.packages.enable': true },
 		);
 
-		const result = await getPackages(ctx.instantiationService);
+		const result = await getAllPackages(ctx.instantiationService);
 
 		expect(result).toEqual({ available: false, reason: 'disabled' });
 		expect(getPackagesSnapshot).not.toHaveBeenCalled();
@@ -118,14 +121,13 @@ describe('getPackages', () => {
 			{ 'packages.enabled': true, 'positron.packages.enable': false },
 		);
 
-		const result = await getPackages(ctx.instantiationService);
+		const result = await getAllPackages(ctx.instantiationService);
 
 		expect(result).toEqual({ available: false, reason: 'disabled' });
 	});
 
 	// ai.enabled is deliberately not a gate: this payload is the user's own environment, not an AI
-	// feature, and the other agentCompatible package commands don't gate on it either. A stray check
-	// here would take the inspect action away from a user who turned AI off.
+	// feature, and the other agentCompatible package commands don't gate on it either.
 	it('reports packages even when ai.enabled is off', async () => {
 		stubServices(createInstance({ packages: [pkg('numpy', '2.1.0')], metadataStatus: 'fresh' }), {
 			'packages.enabled': true,
@@ -133,7 +135,7 @@ describe('getPackages', () => {
 			'ai.enabled': false,
 		});
 
-		const result = await getPackages(ctx.instantiationService);
+		const result = await getAllPackages(ctx.instantiationService);
 
 		expect(result).toMatchObject({ available: true, packages: [{ name: 'numpy' }] });
 	});
@@ -141,7 +143,7 @@ describe('getPackages', () => {
 	it('reports no-session when no interpreter session is active', async () => {
 		stubServices(undefined);
 
-		const result = await getPackages(ctx.instantiationService);
+		const result = await getAllPackages(ctx.instantiationService);
 
 		expect(result).toEqual({ available: false, reason: 'no-session' });
 	});
@@ -153,7 +155,7 @@ describe('getPackages', () => {
 			getPackagesSnapshot,
 		}));
 
-		const result = await getPackages(ctx.instantiationService);
+		const result = await getAllPackages(ctx.instantiationService);
 
 		// Asking a kernel that isn't listening yet would hang rather than answer.
 		expect(result).toEqual({ available: false, reason: 'session-not-ready' });
@@ -163,7 +165,7 @@ describe('getPackages', () => {
 	it('reports unsupported for a runtime that does not manage packages', async () => {
 		stubServices(createInstance({ packages: [], metadataStatus: 'unsupported' }));
 
-		const result = await getPackages(ctx.instantiationService);
+		const result = await getAllPackages(ctx.instantiationService);
 
 		expect(result).toEqual({ available: false, reason: 'unsupported' });
 	});
@@ -171,7 +173,7 @@ describe('getPackages', () => {
 	it('reports failed with the error message when the read fails', async () => {
 		stubServices(createInstance(new Error('Timed out reading the installed packages.')));
 
-		const result = await getPackages(ctx.instantiationService);
+		const result = await getAllPackages(ctx.instantiationService);
 
 		expect(result).toEqual({
 			available: false,
@@ -180,17 +182,30 @@ describe('getPackages', () => {
 		});
 	});
 
-	it('returns the session, its packages, and how fresh their outdated state is', async () => {
+	it('reads the snapshot without the advisory lookup', async () => {
+		const instance = createInstance({ packages: [pkg('numpy', '2.1.0')], metadataStatus: 'fresh' });
+		stubServices(instance);
+
+		await getAllPackages(ctx.instantiationService);
+
+		// The compact list carries no advisories, so it opts out of the fetch.
+		expect(instance.getPackagesSnapshot).toHaveBeenCalledWith(undefined, { includeVulnerabilities: false });
+	});
+
+	it('returns the session, its packages, and how fresh their outdated state is -- but no advisories', async () => {
 		stubServices(createInstance({
 			metadataStatus: 'cached',
+			// A snapshot may still carry advisories; the compact list drops them.
+			vulnerabilityStatus: 'fresh',
+			vulnerabilitySource: VULNERABILITY_SOURCE,
 			packages: [
-				{ ...pkg('pandas', '2.2.1'), outdated: true, latestVersion: '2.3.0', attached: true, description: 'Data analysis', url: 'https://pandas.pydata.org' },
+				{ ...pkg('pandas', '2.2.1'), outdated: true, latestVersion: '2.3.0', attached: true, description: 'Data analysis', url: 'https://pandas.pydata.org', vulnerabilities: [advisory('CVE-2026-1000', 9.8)] },
 				// No summary: Python's package list sends '' rather than omitting it.
 				{ ...pkg('numpy', '2.1.0'), outdated: false, description: '' },
 			],
 		}));
 
-		const result = await getPackages(ctx.instantiationService);
+		const result = await getAllPackages(ctx.instantiationService);
 
 		expect(result).toMatchInlineSnapshot(`
 			{
@@ -205,7 +220,6 @@ describe('getPackages', () => {
 			      "outdated": true,
 			      "url": "https://pandas.pydata.org",
 			      "version": "2.2.1",
-			      "vulnerabilities": undefined,
 			    },
 			    {
 			      "attached": undefined,
@@ -215,7 +229,6 @@ describe('getPackages', () => {
 			      "outdated": false,
 			      "url": undefined,
 			      "version": "2.1.0",
-			      "vulnerabilities": undefined,
 			    },
 			  ],
 			  "session": {
@@ -226,77 +239,111 @@ describe('getPackages', () => {
 			    "sessionId": "session-1",
 			    "sessionName": "Python 3.12.4",
 			  },
-			  "vulnerabilitySource": undefined,
-			  "vulnerabilityStatus": "cached",
 			}
 		`);
 	});
 
-	it('reports each package\'s advisories worst first, with the source that served them', async () => {
+	it('caps a long description and marks it truncated', async () => {
+		const longDescription = 'x'.repeat(300);
 		stubServices(createInstance({
 			metadataStatus: 'fresh',
-			vulnerabilityStatus: 'fresh',
-			vulnerabilitySource: VULNERABILITY_SOURCE,
-			packages: [
-				// Deliberately out of order, and mixing scored with unscored:
-				// the payload leads with the advisory the pane leads with.
-				{
-					...pkg('pandas', '2.2.1'),
-					vulnerabilities: [advisory('CVE-2026-2000', 5.4), advisory('RSEC-2026-1'), advisory('CVE-2026-1000', 9.8)],
-				},
-				// Asked about and reported clean: an empty array, not undefined.
-				{ ...pkg('numpy', '2.1.0'), vulnerabilities: [] },
-				// No advisory data at all, so nothing can be concluded.
-				pkg('polars', '1.9.0'),
-			],
+			packages: [{ ...pkg('pandas', '2.2.1'), description: longDescription }],
 		}));
 
-		const result = await getPackages(ctx.instantiationService);
+		const result = await getAllPackages(ctx.instantiationService);
 
-		expect(result).toMatchObject({
-			available: true,
-			vulnerabilityStatus: 'fresh',
-			// Epoch ms in the snapshot, ISO 8601 in the payload.
-			vulnerabilitySource: { host: VULNERABILITY_SOURCE.host, fetchedAt: '2026-08-19T10:00:00.000Z' },
-			packages: [
-				{
-					name: 'pandas',
-					vulnerabilities: [
-						{ id: 'CVE-2026-1000', score: 9.8, severity: 'critical' },
-						{ id: 'CVE-2026-2000', score: 5.4, severity: 'medium' },
-						// Unscored sorts last but is still reported: known
-						// vulnerable, severity unknown.
-						{ id: 'RSEC-2026-1', score: undefined, severity: 'unscored' },
-					],
-				},
-				{ name: 'numpy', vulnerabilities: [] },
-				{ name: 'polars', vulnerabilities: undefined },
-			],
-		});
+		const description = (result as { packages: { description: string }[] }).packages[0].description;
+		expect(description).toBe(`${'x'.repeat(256)}...`);
 	});
 
-	it('maps every advisory field the lookup carries', async () => {
-		stubServices(createInstance({
-			metadataStatus: 'fresh',
-			vulnerabilityStatus: 'fresh',
-			vulnerabilitySource: VULNERABILITY_SOURCE,
-			packages: [{ ...pkg('pandas', '2.2.1'), vulnerabilities: [advisory('CVE-2026-1000', 7.5)] }],
+	it('is registered as an agent-compatible command', async () => {
+		const command = CommandsRegistry.getCommand(PACKAGES_GET_ALL_PACKAGES_COMMAND_ID);
+
+		expect(command?.metadata?.agentCompatible).toBe(true);
+	});
+});
+
+describe('getPackages', () => {
+	const ctx = createTestContainer().build();
+
+	function stubServices(
+		instance: IPositronPackagesInstance | undefined,
+		configuration: Record<string, boolean> = { 'packages.enabled': true, 'positron.packages.enable': true },
+	): void {
+		ctx.instantiationService.stub(IConfigurationService, new TestConfigurationService(configuration));
+		ctx.instantiationService.stub(ILogService, new NullLogService());
+		ctx.instantiationService.stub(IPositronPackagesService, stubInterface<IPositronPackagesService>({
+			activePackagesInstance: instance,
 		}));
+	}
+
+	it('reports no-names when called without any package names', async () => {
+		const getPackagesSnapshot = vi.fn<IPositronPackagesInstance['getPackagesSnapshot']>();
+		stubServices(stubInterface<IPositronPackagesInstance>({ getPackagesSnapshot }));
 
 		const result = await getPackages(ctx.instantiationService);
+
+		expect(result).toEqual({ available: false, reason: 'no-names' });
+		// A bad call, not a state of the session, so the session is never read.
+		expect(getPackagesSnapshot).not.toHaveBeenCalled();
+	});
+
+	it('reports the environment reasons a read can fail with', async () => {
+		stubServices(undefined);
+
+		const result = await getPackages(ctx.instantiationService, 'pandas');
+
+		expect(result).toEqual({ available: false, reason: 'no-session' });
+	});
+
+	it('reads the snapshot with the advisory lookup', async () => {
+		const instance = createInstance({ packages: [pkg('numpy', '2.1.0')], metadataStatus: 'fresh' });
+		stubServices(instance);
+
+		await getPackages(ctx.instantiationService, 'numpy');
+
+		expect(instance.getPackagesSnapshot).toHaveBeenCalledWith(undefined, { includeVulnerabilities: true });
+	});
+
+	it('returns full detail for the named packages and lists the rest as not found', async () => {
+		stubServices(createInstance(
+			{
+				metadataStatus: 'fresh',
+				vulnerabilityStatus: 'fresh',
+				vulnerabilitySource: VULNERABILITY_SOURCE,
+				packages: [
+					{ ...pkg('pandas', '2.2.1'), outdated: true, latestVersion: '2.3.0', description: 'Data analysis', url: 'https://pandas.pydata.org', vulnerabilities: [advisory('CVE-2026-1000', 9.8)] },
+					pkg('numpy', '2.1.0'),
+				],
+			},
+			createSession(),
+			// getPackageDetail merges these over the list entry.
+			{ pandas: { license: 'BSD-3-Clause', author: 'The pandas team', sourceRepository: 'PyPI', publishedDate: '2026-02-01', title: 'Powerful data structures' } },
+		));
+
+		// Case-insensitive, and a name that is not installed lands in notFound.
+		const result = await getPackages(ctx.instantiationService, ['Pandas', 'scikit-learn']);
 
 		expect(result).toMatchInlineSnapshot(`
 			{
 			  "available": true,
 			  "metadataStatus": "fresh",
+			  "notFound": [
+			    "scikit-learn",
+			  ],
 			  "packages": [
 			    {
 			      "attached": undefined,
-			      "description": undefined,
-			      "latestVersion": undefined,
+			      "author": "The pandas team",
+			      "description": "Data analysis",
+			      "latestVersion": "2.3.0",
+			      "license": "BSD-3-Clause",
 			      "name": "pandas",
-			      "outdated": undefined,
-			      "url": undefined,
+			      "outdated": true,
+			      "publishedDate": "2026-02-01",
+			      "sourceRepository": "PyPI",
+			      "title": "Powerful data structures",
+			      "url": "https://pandas.pydata.org",
 			      "version": "2.2.1",
 			      "vulnerabilities": [
 			        {
@@ -304,9 +351,9 @@ describe('getPackages', () => {
 			          "id": "CVE-2026-1000",
 			          "osvId": "PYSEC-CVE-2026-1000",
 			          "published": "2026-05-01T00:00:00Z",
-			          "score": 7.5,
+			          "score": 9.8,
 			          "scoreVersion": "v3",
-			          "severity": "high",
+			          "severity": "critical",
 			          "summary": "CVE-2026-1000 summary",
 			          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-1000",
 			        },
@@ -330,49 +377,55 @@ describe('getPackages', () => {
 		`);
 	});
 
+	it('reports a named package\'s advisories worst first', async () => {
+		stubServices(createInstance({
+			metadataStatus: 'fresh',
+			vulnerabilityStatus: 'fresh',
+			vulnerabilitySource: VULNERABILITY_SOURCE,
+			packages: [{
+				...pkg('pandas', '2.2.1'),
+				// Deliberately out of order, mixing scored with unscored.
+				vulnerabilities: [advisory('CVE-2026-2000', 5.4), advisory('RSEC-2026-1'), advisory('CVE-2026-1000', 9.8)],
+			}],
+		}));
+
+		const result = await getPackages(ctx.instantiationService, 'pandas');
+
+		expect(result).toMatchObject({
+			available: true,
+			packages: [{
+				name: 'pandas',
+				vulnerabilities: [
+					{ id: 'CVE-2026-1000', score: 9.8, severity: 'critical' },
+					{ id: 'CVE-2026-2000', score: 5.4, severity: 'medium' },
+					// Unscored sorts last but is still reported.
+					{ id: 'RSEC-2026-1', score: undefined, severity: 'unscored' },
+				],
+			}],
+		});
+	});
+
 	it('drops the advisories the cache still holds when lookups are turned off', async () => {
-		// The snapshot reports 'disabled' from the setting but still merges
-		// whatever the cache kept from before it was turned off. The payload
-		// must not report data its own status says isn't there.
 		stubServices(createInstance({
 			metadataStatus: 'fresh',
 			vulnerabilityStatus: 'disabled',
 			packages: [{ ...pkg('pandas', '2.2.1'), vulnerabilities: [advisory('CVE-2026-1000', 9.8)] }],
 		}));
 
-		const result = await getPackages(ctx.instantiationService);
+		const result = await getPackages(ctx.instantiationService, 'pandas');
 
 		expect(result).toMatchObject({
 			available: true,
 			vulnerabilityStatus: 'disabled',
-			// Nothing to attribute, so no source is named either.
 			vulnerabilitySource: undefined,
 			packages: [{ name: 'pandas', vulnerabilities: undefined }],
 		});
 	});
 
-	it('passes the advisory status through rather than deriving its own', async () => {
-		// Only the snapshot knows whether a lookup ran, so the payload reports
-		// what it was told -- including 'unavailable', which says a lookup
-		// happened and found nothing, not that one is still owed.
-		stubServices(createInstance({
-			metadataStatus: 'fresh',
-			vulnerabilityStatus: 'unavailable',
-			packages: [pkg('pandas', '2.2.1')],
-		}));
-
-		const result = await getPackages(ctx.instantiationService);
-
-		expect(result).toMatchObject({
-			available: true,
-			vulnerabilityStatus: 'unavailable',
-			vulnerabilitySource: undefined,
-		});
-	});
-
-	it('is registered as an agent-compatible command', async () => {
+	it('is registered as an agent-compatible command that takes names', async () => {
 		const command = CommandsRegistry.getCommand(PACKAGES_GET_PACKAGES_COMMAND_ID);
 
 		expect(command?.metadata?.agentCompatible).toBe(true);
+		expect(command?.metadata?.args?.[0].name).toBe('names');
 	});
 });

--- a/src/vs/workbench/contrib/positronPackages/test/browser/positronPackagesInspectActions.vitest.ts
+++ b/src/vs/workbench/contrib/positronPackages/test/browser/positronPackagesInspectActions.vitest.ts
@@ -19,7 +19,7 @@ import { IEditorService } from '../../../../services/editor/common/editorService
 import { ILanguageRuntimeMetadata, ILanguageRuntimeSessionState, RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { IPositronPackagesService } from '../../browser/interfaces/positronPackagesService.js';
-import { PACKAGES_GET_PACKAGES_COMMAND_ID } from '../../browser/positronPackagesCommands.js';
+import { PACKAGES_GET_ALL_PACKAGES_COMMAND_ID } from '../../browser/positronPackagesCommands.js';
 import { IPackagesSnapshot, IPositronPackagesInstance } from '../../browser/positronPackagesInstance.js';
 import { ShowPackagesAction } from '../../browser/positronPackagesInspectActions.js';
 
@@ -36,8 +36,9 @@ const ANSWERED_SNAPSHOT: IPackagesSnapshot = {
 	packages: [NUMPY],
 };
 
-// The payload both the action and a programmatic caller should see: one installed package in a
-// session that can answer.
+// The payload both the action and a programmatic caller should see: the compact
+// getAllPackages list, one installed package in a session that can answer. The
+// list omits advisories, so the snapshot's advisory fields don't appear here.
 const PACKAGES_PAYLOAD = {
 	available: true,
 	session: {
@@ -49,8 +50,6 @@ const PACKAGES_PAYLOAD = {
 		runtimeName: 'Python 3.12.4 (.venv)',
 	},
 	metadataStatus: 'fresh',
-	vulnerabilityStatus: 'cached',
-	vulnerabilitySource: { host: 'ppm.example.com', fetchedAt: '2026-08-19T10:00:00.000Z' },
 	packages: [{
 		name: 'numpy',
 		version: '2.1.0',
@@ -59,7 +58,6 @@ const PACKAGES_PAYLOAD = {
 		attached: undefined,
 		description: undefined,
 		url: undefined,
-		vulnerabilities: undefined,
 	}],
 };
 
@@ -120,11 +118,6 @@ describe('packages inspect action', () => {
 		await ctx.instantiationService.invokeFunction(accessor => new ShowPackagesAction().run(accessor));
 	}
 
-	/** The JSON the action opened, parsed back. */
-	function shownPayload(): { vulnerabilityStatus: string } {
-		return JSON.parse(openEditor.mock.calls[0][0].contents!);
-	}
-
 	// The JSON contents are the whole point of the action: they're what a developer reads to see
 	// exactly what Assistant gets from the command it wraps.
 	it('shows the packages payload as JSON', async () => {
@@ -153,16 +146,6 @@ describe('packages inspect action', () => {
 		);
 	});
 
-	it('shows the payload even when no advisories could be obtained', async () => {
-		// 'unavailable' is an answer, not a failure: the packages and their
-		// outdated state are still what the developer opened this to read.
-		snapshot = { ...ANSWERED_SNAPSHOT, vulnerabilityStatus: 'unavailable', vulnerabilitySource: undefined };
-
-		await runAction();
-
-		expect(shownPayload().vulnerabilityStatus).toBe('unavailable');
-	});
-
 	it('is offered in the Command Palette only while the Packages pane is enabled', () => {
 		const item = MenuRegistry.getMenuItems(MenuId.CommandPalette)
 			.filter(isIMenuItem)
@@ -177,7 +160,7 @@ describe('packages inspect action', () => {
 	// registerAction2 never sets, so the guard is that nobody adds it by hand later.
 	it('is not advertised to AI agents, unlike the payload command it wraps', () => {
 		expect(CommandsRegistry.getCommand('positronPackages.showPackages')?.metadata?.agentCompatible).toBeFalsy();
-		expect(CommandsRegistry.getCommand(PACKAGES_GET_PACKAGES_COMMAND_ID)?.metadata?.agentCompatible).toBe(true);
+		expect(CommandsRegistry.getCommand(PACKAGES_GET_ALL_PACKAGES_COMMAND_ID)?.metadata?.agentCompatible).toBe(true);
 	});
 
 	// The property Assistant depends on: executing the payload command hands the JSON back to the
@@ -187,7 +170,7 @@ describe('packages inspect action', () => {
 	it('returns the payload to a programmatic caller without opening an editor', async () => {
 		// The registry types every handler as returning void; this one returns its payload, which is
 		// what executeCommand passes back to the caller.
-		const handler = CommandsRegistry.getCommand(PACKAGES_GET_PACKAGES_COMMAND_ID)?.handler as
+		const handler = CommandsRegistry.getCommand(PACKAGES_GET_ALL_PACKAGES_COMMAND_ID)?.handler as
 			((accessor: ServicesAccessor) => Promise<unknown>) | undefined;
 
 		const result = await ctx.instantiationService.invokeFunction(accessor => handler!(accessor));

--- a/src/vs/workbench/contrib/positronSettings/browser/positronSettingsCommands.ts
+++ b/src/vs/workbench/contrib/positronSettings/browser/positronSettingsCommands.ts
@@ -487,7 +487,7 @@ export const SETTINGS_GET_CONFIGURED_SETTINGS_COMMAND_ID = 'positronSettings.get
 // say, since there is always a configuration even when the user has set nothing.
 //
 // Deliberately not gated on the ai.enabled main switch, for the reasons already
-// written down at positronPackagesCommands.ts:17-28: it reports the user's own
+// written down on isPackagesCommandEnabled in positronPackagesCommands.ts: it reports the user's own
 // environment, it does not call a model or surface an AI action, and Assistant is
 // itself gated on ai.enabled. Gating here would only take the payload away from
 // non-AI callers.


### PR DESCRIPTION
Fixes #15744

Splits the single `positronPackages.getPackages` command into two, so Assistant can survey a whole environment cheaply and still look individual packages up in full.

Previously one command returned every field for every installed package, including security vulnerabilities. In environments with hundreds of packages the payload was large enough to be truncated, which also made single-package questions ("is pandas installed?") unreliable: the package you asked about might be the one that got cut, and a truncated answer looks the same as "not found".

Now there are two commands:

- `getPackages` takes a list of names and returns full detail for each: the complete description, license, author, source repository, publication date, and security vulnerabilities. Names that are not installed come back in a `notFound` list, which is a definitive answer rather than a maybe-truncated one.

<img width="479" height="481" alt="image" src="https://github.com/user-attachments/assets/01b9b139-14fd-4110-a21a-97baf8d61c25" />

- `getAllPackages` returns a compact entry per package (name, version, whether an update is available), built to fit a whole environment at once. Descriptions are capped at 256 characters, and vulnerabilities and the heavier detail fields are left out. It also skips the security-advisory lookup entirely, so it is cheaper as well as smaller.

<img width="486" height="491" alt="image" src="https://github.com/user-attachments/assets/45b780c9-a66a-44d4-9b92-0b7b18abf510" />

The Assistant skill and the "Show Packages as JSON" command were updated to match.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Package information given to Positron Assistant is no longer truncated in environments with many packages, and looking a single package up now gives a reliable installed/not-installed answer (#15744)

### Validation Steps

@:packages-pane

1. Start a Python or R session and install a large set of packages.
2. Run "Packages: Show Packages as JSON" from the Command Palette and confirm the list is compact: each package shows name/version/update info, descriptions are shortened, and no vulnerabilities are included.
3. Confirm the existing Packages pane still lists packages, shows outdated state, and reports vulnerabilities as before (the pane's data path is shared and unchanged).

