### PR TITLE
Apply ai-config policy to headless LLM service

### DIFF
--- a/src/vs/code/electron-utility/sharedProcess/sharedProcessMain.ts
+++ b/src/vs/code/electron-utility/sharedProcess/sharedProcessMain.ts
@@ -509,16 +509,18 @@ class SharedProcessMain extends Disposable implements IClientConnectionFilter {
 		this.server.registerChannel('customEndpointTelemetry', customEndpointTelemetryChannel);
 
 		// --- Start Positron ---
-		// Headless Language Model engine: local-desktop egress runs here in the
-		// shared process; the workbench reaches it over this channel.
-		const headlessLmEngine = new HeadlessLanguageModelEngine(accessor.get(ILogService));
-		this.server.registerChannel(HEADLESS_LM_ENGINE_CHANNEL, new HeadlessLanguageModelEngineChannel(headlessLmEngine));
-
 		// AI provider catalog: resolves providers.json + enforced/default env
 		// fragments where they live (this process's HOME/env); the workbench
 		// reads it over this channel.
 		const aiProviderCatalog = this._store.add(new AiProviderCatalog(accessor.get(ILogService)));
 		this.server.registerChannel(POSITRON_AI_PROVIDER_CHANNEL, new AiProviderCatalogChannel(aiProviderCatalog));
+
+		// Headless Language Model engine: local-desktop egress runs here in the
+		// shared process; the workbench reaches it over this channel. The engine
+		// applies the catalog's model policy so a listing never offers a model
+		// providers.json excludes.
+		const headlessLmEngine = new HeadlessLanguageModelEngine(accessor.get(ILogService), aiProviderCatalog);
+		this.server.registerChannel(HEADLESS_LM_ENGINE_CHANNEL, new HeadlessLanguageModelEngineChannel(headlessLmEngine));
 		// --- End Positron ---
 
 		const userDataSyncAccountChannel = new UserDataSyncAccountServiceChannel(accessor.get(IUserDataSyncAccountService));

--- a/src/vs/platform/positronAiProvider/common/aiProviderCatalog.ts
+++ b/src/vs/platform/positronAiProvider/common/aiProviderCatalog.ts
@@ -23,11 +23,58 @@ export interface IResolvedConnectionData {
 	readonly databricks?: { readonly host?: string };
 }
 
-/** Mirrors ai-config's ResolvedProvider (id, enabled, connection). */
+/** Mirrors ai-config's Protocol union. */
+export type IResolvedProtocol =
+	| 'anthropic-messages'
+	| 'openai-chat'
+	| 'openai-responses'
+	| 'mlflow-responses'
+	| 'bedrock-converse'
+	| 'google-generative';
+
+/** Mirrors ai-config's ModelOverride as plain IPC-marshalable data. */
+export interface IResolvedModelOverrideData {
+	readonly name?: string;
+	readonly family?: string;
+	readonly maxContextLength?: number;
+	readonly maxInputTokens?: number;
+	readonly maxOutputTokens?: number;
+	readonly protocol?: IResolvedProtocol;
+	readonly baseUrl?: string;
+	readonly supportsTools?: boolean;
+	readonly supportsImages?: boolean;
+	readonly supportsToolResultImages?: boolean;
+	readonly supportedInputMediaTypes?: string[];
+	readonly supportsWebSearch?: boolean;
+	readonly thinkingEffortLevels?: string[];
+}
+
+/** Mirrors ai-config's CustomModel as plain IPC-marshalable data. */
+export interface IResolvedCustomModelData extends IResolvedModelOverrideData {
+	readonly id: string;
+	readonly name: string;
+	readonly maxContextLength: number;
+	readonly supportsTools: boolean;
+	readonly supportsImages: boolean;
+	readonly supportsToolResultImages: boolean;
+	readonly supportsWebSearch: boolean;
+}
+
+/** Mirrors ai-config's ModelsBlock as plain IPC-marshalable data. */
+export interface IResolvedModelsData {
+	readonly discovery?: 'auto' | 'off';
+	readonly allow?: string[];
+	readonly deny?: string[];
+	readonly overrides?: Record<string, IResolvedModelOverrideData>;
+	readonly custom?: IResolvedCustomModelData[];
+}
+
+/** Mirrors ai-config's ResolvedProvider (id, enabled, connection, model policy). */
 export interface IResolvedProviderData {
 	readonly id: string;
 	readonly enabled: boolean;
 	readonly connection: IResolvedConnectionData;
+	readonly models?: IResolvedModelsData;
 }
 
 /** Mirrors ai-config's ProviderCatalogChange. */

--- a/src/vs/platform/positronAiProvider/node/aiProviderCatalog.ts
+++ b/src/vs/platform/positronAiProvider/node/aiProviderCatalog.ts
@@ -96,5 +96,6 @@ function toProviderData(provider: ResolvedProvider): IResolvedProviderData {
 			snowflake: connection.snowflake,
 			databricks: connection.databricks,
 		},
+		models: provider.models,
 	};
 }

--- a/src/vs/platform/positronAiProvider/test/node/aiProviderCatalog.vitest.ts
+++ b/src/vs/platform/positronAiProvider/test/node/aiProviderCatalog.vitest.ts
@@ -44,6 +44,37 @@ describe('AiProviderCatalog', () => {
 			.toEqual({ enabled: false, baseUrl: 'https://proxy.example/v1' });
 	});
 
+	it('reads model policy from the file and emits model-policy change events', async () => {
+		const configPath = join(dir, 'providers.json');
+		fs.writeFileSync(configPath, JSON.stringify({
+			version: 1,
+			providers: { anthropic: { models: { allow: ['claude-opus-5'] } } },
+		}));
+		catalog = new AiProviderCatalog(new NullLogService(), { configPath, envVars: {} });
+		const initialAnthropic = (await catalog.getCatalog()).find(p => p.id === 'anthropic')!;
+		expect(initialAnthropic.models).toEqual({ allow: ['claude-opus-5'] });
+
+		const changed = new Promise<void>(resolve => {
+			const d = catalog.onDidChangeCatalog(e => {
+				const anthropic = e.catalog.find(p => p.id === 'anthropic')!;
+				expect({
+					modelsChanged: e.modelsChanged,
+					models: anthropic.models,
+				}).toEqual({
+					modelsChanged: true,
+					models: { deny: ['claude-sonnet-5'] },
+				});
+				d.dispose();
+				resolve();
+			});
+		});
+		fs.writeFileSync(configPath, JSON.stringify({
+			version: 1,
+			providers: { anthropic: { models: { deny: ['claude-sonnet-5'] } } },
+		}));
+		await changed;
+	}, 10_000);
+
 	it('emits a change event when the file changes', async () => {
 		const configPath = join(dir, 'providers.json');
 		fs.writeFileSync(configPath, JSON.stringify({ version: 1, providers: {} }));

--- a/src/vs/platform/positronAiProvider/test/node/aiProviderCatalogShapeGuard.vitest.ts
+++ b/src/vs/platform/positronAiProvider/test/node/aiProviderCatalogShapeGuard.vitest.ts
@@ -6,7 +6,7 @@
 /// <reference types="vitest/globals" />
 
 import type { ProviderCatalogChange, ResolvedConnection, ResolvedProvider } from 'ai-config/node';
-import type { IProviderCatalogChangeData, IResolvedConnectionData, IResolvedProviderData } from '../../common/aiProviderCatalog.js';
+import type { IProviderCatalogChangeData, IResolvedConnectionData, IResolvedModelsData, IResolvedProviderData } from '../../common/aiProviderCatalog.js';
 
 // Compile-time guard that the hand-mirrored IPC types stay assignable from the
 // ai-config types they mirror at the pinned commit. One-directional: the mirror
@@ -26,6 +26,15 @@ const _provider = (p: ResolvedProvider): IResolvedProviderData => ({
 	id: p.id,
 	enabled: p.enabled,
 	connection: _connection(p.connection),
+	models: p.models && _models(p.models),
+});
+
+const _models = (m: NonNullable<ResolvedProvider['models']>): IResolvedModelsData => ({
+	discovery: m.discovery,
+	allow: m.allow,
+	deny: m.deny,
+	overrides: m.overrides,
+	custom: m.custom,
 });
 
 const _change = (change: ProviderCatalogChange): Omit<IProviderCatalogChangeData, 'catalog'> => ({
@@ -36,6 +45,6 @@ const _change = (change: ProviderCatalogChange): Omit<IProviderCatalogChangeData
 
 describe('aiProviderCatalog shape guard', () => {
 	it('mirrors ai-config types (compile-time assertion)', () => {
-		expect([_connection, _provider, _change]).toHaveLength(3);
+		expect([_connection, _provider, _models, _change]).toHaveLength(4);
 	});
 });

--- a/src/vs/platform/positronAiProvider/test/node/aiProviderCatalogShapeGuard.vitest.ts
+++ b/src/vs/platform/positronAiProvider/test/node/aiProviderCatalogShapeGuard.vitest.ts
@@ -12,6 +12,11 @@ import type { IProviderCatalogChangeData, IResolvedConnectionData, IResolvedMode
 // ai-config types they mirror at the pinned commit. One-directional: the mirror
 // is a deliberate reduced view, so a rename/retype of a mirrored field fails the
 // typecheck rather than drifting silently.
+//
+// Drift in an all-optional field (ModelOverride) is not detectable this way:
+// optional-only types stay mutually assignable whatever their field names, and
+// excess-property checking applies only to fresh literals. Required fields are
+// what this guard actually pins, which covers CustomModel and the change flags.
 
 const _connection = (c: ResolvedConnection): IResolvedConnectionData => ({
 	baseUrl: c.baseUrl,

--- a/src/vs/platform/positronHeadlessLanguageModel/node/headlessLanguageModelEngine.ts
+++ b/src/vs/platform/positronHeadlessLanguageModel/node/headlessLanguageModelEngine.ts
@@ -3,19 +3,25 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { Logger, ModelInfo, ModelMessage, ProviderId, ProviderRegistry } from 'ai-provider-bridge';
+import type { ModelInfoLike } from 'ai-config';
+import type { Logger, ModelMessage, ProviderId, ProviderRegistry } from 'ai-provider-bridge';
 import { AsyncIterableObject } from '../../../base/common/async.js';
 import { CancellationToken } from '../../../base/common/cancellation.js';
 import { SelfHealingLazyPromise } from '../../../base/common/positron/async.js';
 import { ILogService } from '../../log/common/log.js';
+import { IAiProviderCatalog } from '../../positronAiProvider/common/aiProviderCatalog.js';
 import { ICredentials, IEngineChatRequest, IHeadlessLanguageModelEngine, IModelDescriptor, IProviderMapping } from '../common/engine.js';
 
 /**
  * The Node-side egress engine: the one place that touches the provider bridge
- * and the network. It is intentionally thin -- it holds no policy. Selection,
- * priority, credentials, and availability all live in the workbench facade;
- * this just lists models and streams text for an already-chosen provider/model,
- * and adapts the service-owned port types to the bridge.
+ * and the network. Intentionally thin -- selection, priority, credentials, and
+ * availability all live in the workbench facade; this lists models and streams
+ * text for an already-chosen provider/model, and adapts the service-owned port
+ * types to the bridge.
+ *
+ * The one policy it does apply is the catalog's model policy, because a model
+ * providers.json excludes must never reach a consumer: filtering here covers
+ * every caller of the channel at the point discovery happens.
  *
  * Runs in the shared process (desktop) or the remote server (Remote SSH / web)
  * and is reached over an IPC channel.
@@ -26,7 +32,7 @@ export class HeadlessLanguageModelEngine implements IHeadlessLanguageModelEngine
 	/** Self-healing so a transient first-use failure (e.g. a deferred bridge import error) retries on the next call. */
 	private readonly _registry = new SelfHealingLazyPromise(() => this.createRegistry());
 
-	constructor(logService: ILogService) {
+	constructor(logService: ILogService, private readonly _catalog: IAiProviderCatalog) {
 		this._logger = {
 			info: (m: string, ...a: unknown[]) => logService.info(m, ...a),
 			warn: (m: string, ...a: unknown[]) => logService.warn(m, ...a),
@@ -63,7 +69,7 @@ export class HeadlessLanguageModelEngine implements IHeadlessLanguageModelEngine
 	async listModels(providerId: string, credentials: ICredentials): Promise<IModelDescriptor[]> {
 		const registry = await this._registry.get();
 		const models = await registry.getModelsForProvider(providerId, credentials);
-		return models.map((model: ModelInfo) => ({ id: model.id, name: model.name, vendor: model.vendor, providerId }));
+		return applyModelPolicy(this._catalog, providerId, models);
 	}
 
 	streamChat(request: IEngineChatRequest, token: CancellationToken): AsyncIterable<string> {
@@ -119,4 +125,34 @@ export class HeadlessLanguageModelEngine implements IHeadlessLanguageModelEngine
 		});
 		return registry;
 	}
+}
+
+/** A model as discovery reports it: ai-config's resolution input plus the display vendor. */
+type IDiscoveredModel = ModelInfoLike & { readonly vendor: string };
+
+/**
+ * Resolve a listing against the catalog's model policy (`discovery`, `custom`,
+ * `allow`, `deny`). Declared `custom` models participate even when discovery
+ * never reported them, carrying the metadata from their declaration.
+ *
+ * Fails open when the provider has no policy, so a catalog read failure cannot
+ * blank a picker.
+ */
+export async function applyModelPolicy(
+	catalog: IAiProviderCatalog,
+	providerId: string,
+	models: readonly IDiscoveredModel[],
+): Promise<IModelDescriptor[]> {
+	const providers = await catalog.getCatalog();
+	const policy = providers.find(provider => provider.id === providerId)?.models;
+	if (!policy) {
+		return models.map(model => describe(model, model.vendor, providerId));
+	}
+	const { resolveModels } = await import('ai-config');
+	const vendors = new Map(models.map(model => [model.id, model.vendor]));
+	return resolveModels(policy, models).map(model => describe(model, vendors.get(model.id), providerId));
+}
+
+function describe(model: { id: string; name: string }, vendor: string | undefined, providerId: string): IModelDescriptor {
+	return { id: model.id, name: model.name, vendor: vendor ?? providerId, providerId };
 }

--- a/src/vs/platform/positronHeadlessLanguageModel/test/node/headlessLanguageModelEnginePolicy.vitest.ts
+++ b/src/vs/platform/positronHeadlessLanguageModel/test/node/headlessLanguageModelEnginePolicy.vitest.ts
@@ -1,0 +1,104 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { Event } from '../../../../base/common/event.js';
+import { URI } from '../../../../base/common/uri.js';
+import { IAiProviderCatalog, IResolvedModelsData, IResolvedProviderData } from '../../../positronAiProvider/common/aiProviderCatalog.js';
+import { applyModelPolicy } from '../../node/headlessLanguageModelEngine.js';
+
+/** A discovered model as the bridge reports it: identity plus the capabilities ai-config resolves against. */
+function model(id: string, name: string, vendor = 'Anthropic') {
+	return {
+		id,
+		name,
+		vendor,
+		maxContextLength: 200000,
+		supportsTools: true,
+		supportsImages: true,
+		supportsToolResultImages: false,
+		supportsWebSearch: false,
+	};
+}
+
+function catalog(models: IResolvedModelsData | undefined, id = 'anthropic'): IAiProviderCatalog {
+	const provider: IResolvedProviderData = { id, enabled: true, connection: {}, models };
+	return {
+		onDidChangeCatalog: Event.None,
+		getCatalog: () => Promise.resolve([provider]),
+		getConfigFileUri: () => Promise.resolve(URI.file('/providers.json')),
+	};
+}
+
+describe('applyModelPolicy', () => {
+	const discovered = [
+		model('claude-opus-5', 'Claude Opus 5'),
+		model('claude-sonnet-5', 'Claude Sonnet 5'),
+		model('claude-haiku-5', 'Claude Haiku 5'),
+	];
+
+	it('applies allow and deny, with deny winning', async () => {
+		const resolved = await applyModelPolicy(
+			catalog({ allow: ['claude-opus-5', 'claude-sonnet-5'], deny: ['claude-sonnet-5'] }),
+			'anthropic',
+			discovered,
+		);
+
+		expect(resolved.map(m => m.id)).toEqual(['claude-opus-5']);
+	});
+
+	it('drops every discovered model when discovery is off', async () => {
+		const resolved = await applyModelPolicy(catalog({ discovery: 'off' }), 'anthropic', discovered);
+
+		expect(resolved).toEqual([]);
+	});
+
+	it('materializes a custom model discovery never returned', async () => {
+		const resolved = await applyModelPolicy(
+			catalog({
+				custom: [{
+					id: 'claude-custom',
+					name: 'Claude Custom',
+					maxContextLength: 100000,
+					supportsTools: true,
+					supportsImages: true,
+					supportsToolResultImages: false,
+					supportsWebSearch: false,
+				}],
+			}),
+			'anthropic',
+			[],
+		);
+
+		expect(resolved).toEqual([{
+			id: 'claude-custom',
+			name: 'Claude Custom',
+			vendor: 'anthropic',
+			providerId: 'anthropic',
+		}]);
+	});
+
+	it('keeps a discovered model\'s vendor while dropping its denied siblings', async () => {
+		const resolved = await applyModelPolicy(catalog({ deny: ['claude-haiku-5'] }), 'anthropic', discovered);
+
+		expect(resolved).toEqual([
+			{ id: 'claude-opus-5', name: 'Claude Opus 5', vendor: 'Anthropic', providerId: 'anthropic' },
+			{ id: 'claude-sonnet-5', name: 'Claude Sonnet 5', vendor: 'Anthropic', providerId: 'anthropic' },
+		]);
+	});
+
+	it('passes models through when the provider has no policy', async () => {
+		const resolved = await applyModelPolicy(catalog(undefined), 'anthropic', discovered);
+
+		expect(resolved.map(m => m.id)).toEqual(['claude-opus-5', 'claude-sonnet-5', 'claude-haiku-5']);
+	});
+
+	it('passes models through for a provider the catalog does not list', async () => {
+		const resolved = await applyModelPolicy(catalog({ deny: ['claude-opus-5'] }, 'openai'), 'anthropic', discovered);
+
+		expect(resolved.map(m => m.id)).toEqual(['claude-opus-5', 'claude-sonnet-5', 'claude-haiku-5']);
+	});
+});

--- a/src/vs/server/node/serverServices.ts
+++ b/src/vs/server/node/serverServices.ts
@@ -410,16 +410,18 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 		const idleTrackingChannel = new PositronIdleTrackingChannel(accessor.get(IPositronIdleTrackingService));
 		socketServer.registerChannel(POSITRON_IDLE_TRACKING_CHANNEL_NAME, idleTrackingChannel);
 
-		// Headless Language Model engine: in Remote SSH / web, model API calls
-		// originate from this remote host; the workbench reaches it here.
-		const headlessLmEngine = new HeadlessLanguageModelEngine(logService);
-		socketServer.registerChannel(HEADLESS_LM_ENGINE_CHANNEL, new HeadlessLanguageModelEngineChannel(headlessLmEngine));
-
 		// AI provider catalog: resolves providers.json + enforced/default env
 		// fragments where they live (this remote host's HOME/env); the
 		// workbench reaches it over this channel.
 		const aiProviderCatalog = disposables.add(new AiProviderCatalog(logService));
 		socketServer.registerChannel(POSITRON_AI_PROVIDER_CHANNEL, new AiProviderCatalogChannel(aiProviderCatalog));
+
+		// Headless Language Model engine: in Remote SSH / web, model API calls
+		// originate from this remote host; the workbench reaches it here. The
+		// engine applies the catalog's model policy so a listing never offers a
+		// model providers.json excludes.
+		const headlessLmEngine = new HeadlessLanguageModelEngine(logService, aiProviderCatalog);
+		socketServer.registerChannel(HEADLESS_LM_ENGINE_CHANNEL, new HeadlessLanguageModelEngineChannel(headlessLmEngine));
 		// --- End Positron ---
 		// clean up extensions folder
 		remoteExtensionsScanner.whenExtensionsReady().then(() => extensionManagementService.cleanUp());

--- a/src/vs/workbench/services/positronHeadlessLanguageModel/browser/abstractHeadlessLanguageModelService.ts
+++ b/src/vs/workbench/services/positronHeadlessLanguageModel/browser/abstractHeadlessLanguageModelService.ts
@@ -30,10 +30,10 @@ import { type CredentialConfig, shapeCredentials } from 'ai-provider-bridge/cred
 interface IResolvedState {
 	readonly models: readonly IModelDescriptor[];
 	/**
-	 * Every model each provider returned, before the cross-provider de-duplication
-	 * that produces {@link models}. Kept for diagnostics: a provider whose models
-	 * all lost the dedupe contributes nothing to `models`, which otherwise looks
-	 * identical to the provider having returned nothing at all.
+	 * Every policy-enabled model each provider returned, before the cross-provider
+	 * de-duplication that produces {@link models}. Kept for diagnostics: a
+	 * provider whose models all lost the dedupe contributes nothing to `models`,
+	 * which otherwise looks identical to the provider having returned nothing at all.
 	 */
 	readonly allModels: readonly IModelDescriptor[];
 	/** Providers actually queried this listing, whether or not they returned models. */
@@ -121,11 +121,9 @@ export abstract class AbstractHeadlessLanguageModelService extends Disposable im
 
 		// Availability also depends on the resolved provider catalog the credential
 		// shaping reads (base URLs, custom headers, AWS region/profile, Snowflake
-		// host/account) and on each provider's enabled state. A change to either
-		// can flip a provider's availability or the listed models, so drop the
-		// cached state.
+		// host/account), on each provider's enabled state, and on model policy.
 		this._register(this._aiProviderService.onDidChangeProviders(e => {
-			if (e.enabledChanged || e.connectionChanged) {
+			if (e.enabledChanged || e.connectionChanged || e.modelsChanged) {
 				this._invalidate();
 			}
 		}));

--- a/src/vs/workbench/services/positronHeadlessLanguageModel/test/browser/headlessLanguageModelService.vitest.ts
+++ b/src/vs/workbench/services/positronHeadlessLanguageModel/test/browser/headlessLanguageModelService.vitest.ts
@@ -55,19 +55,25 @@ function fakeEngine(options: {
 	models?: Record<string, IModelDescriptor[]>;
 	mappings?: IProviderMapping[];
 	getProviderMappings?: () => Promise<IProviderMapping[]>;
+	listModels?: (providerId: string) => Promise<IModelDescriptor[]>;
 	stream?: (request: IEngineChatRequest) => AsyncIterable<string>;
 } = {}): IHeadlessLanguageModelEngine {
 	return {
 		getProviderMappings: options.getProviderMappings ?? (async () => options.mappings ?? TEST_MAPPINGS),
-		listModels: async (providerId: string) => options.models?.[providerId] ?? [],
+		listModels: options.listModels ?? (async (providerId: string) => options.models?.[providerId] ?? []),
 		streamChat: (request: IEngineChatRequest) =>
 			options.stream ? options.stream(request) : AsyncIterableObject.fromArray(['ok']),
 	};
 }
 
-/** A resolved-catalog provider entry with an optional connection (enabled by default). */
-function provider(id: string, connection: IResolvedProviderData['connection'] = {}, enabled = true): IResolvedProviderData {
-	return { id, enabled, connection };
+/** A resolved-catalog provider entry with optional connection/model policy (enabled by default). */
+function provider(
+	id: string,
+	connection: IResolvedProviderData['connection'] = {},
+	enabled = true,
+	models?: IResolvedProviderData['models'],
+): IResolvedProviderData {
+	return { id, enabled, connection, models };
 }
 
 /** A catalog change event carrying the given flags; the catalog field is unused by the facade. */
@@ -520,15 +526,33 @@ describe('HeadlessLanguageModelService', () => {
 			expect(getSessions.mock.calls.length).toBeGreaterThan(before);
 		});
 
-		it('a catalog change that touches neither enablement nor connections does not invalidate', async () => {
+		it('a catalog change that touches neither enablement, connections, nor model policy does not invalidate', async () => {
 			signedInAuthProviders.add('anthropic-api');
 			const service = createService(fakeEngine({ models: { anthropic: [model('claude-haiku', 'Claude Haiku', 'anthropic')] } }));
 			await service.getAvailableModels();
 			const fired = vi.fn();
 			ctx.disposables.add(service.onDidChangeAvailableModels(fired));
 
-			catalogChangeEmitter.fire(catalogChange({ modelsChanged: true }));
+			catalogChangeEmitter.fire(catalogChange({}));
 			expect(fired).not.toHaveBeenCalled();
+		});
+
+		// The engine applies the policy (see applyModelPolicy); the service's job is
+		// to drop its cache so the next listing re-queries.
+		it('a catalog model policy change invalidates the cached model list', async () => {
+			signedInAuthProviders.add('anthropic-api');
+			const listModels = vi.fn().mockResolvedValue([model('claude-opus-5', 'Claude Opus 5', 'anthropic')]);
+			const service = createService(fakeEngine({ listModels }));
+			await service.getAvailableModels();
+			expect(listModels).toHaveBeenCalledTimes(1);
+			const fired = vi.fn();
+			ctx.disposables.add(service.onDidChangeAvailableModels(fired));
+
+			catalogSnapshot.set('anthropic', provider('anthropic', {}, true, { allow: ['claude-opus-5'] }));
+			catalogChangeEmitter.fire(catalogChange({ modelsChanged: true }));
+			expect(fired).toHaveBeenCalledTimes(1);
+			await service.getAvailableModels();
+			expect(listModels).toHaveBeenCalledTimes(2);
 		});
 
 		it('registering a mapped auth provider invalidates the cache and recomputes', async () => {


### PR DESCRIPTION
Fixes #15417

`providers.<id>.models.allow` and `.deny` reached Posit Assistant's model menu but features managed by the headless service (git suggestions, notebook suggestions, ghost cells)

- The headless language model engine resolves a listing against the catalog before returning it, so every caller of the channel gets the same filtered set. This also covers a model pinned into a feature's setting before the administrator excluded it.
- Resolution goes through ai-config's `resolveModels`, so declared custom models keep the metadata from their declaration and overrides still apply.
- The remote server built an engine without a catalog, which left Remote SSH and web unfiltered. The catalog is now a required engine dependency.

## Validation

We can set `POSIT_AI_PROVIDERS_ENFORCED` in a desktop build of Positron to test the proof of concept.

```
POSIT_AI_PROVIDERS_ENFORCED='{"providers":{"default":{"enabled":false},"anthropic":{"enabled":true,"models":{"allow":["claude-opus-5"]}}}}'
```

| Case                                                   | Result                                                                    |
| ------------------------------------------------------ | ------------------------------------------------------------------------- |
| `allow` restricted to one model                        | All four quick-picks offer only Claude Opus 5; the assistant menu agrees  |
| `allow` two models, `deny` one of them                 | Opus only, Sonnet dropped despite being allowed                           |
| Policy set in providers.json rather than the environment | Same filtering                                                            |

On Posit Workbench, I tested with the Databricks configuration from positron-builds: https://github.com/posit-dev/positron-builds/tree/main/dev/workbench#databricks-integration
Set it through the `ai-providers-enforced` profile key rather than the environment directly:

```
# /etc/rstudio/profiles
ai-providers-enforced = /etc/rstudio/ai-providers-enforced/default.json
```

```json
{"providers":{"databricks":{"enabled":true,"models":{"allow":["databricks-claude-sonnet-5","databricks-claude-opus-5"]}},"snowflake-cortex":{"enabled":false}}}
```

Unit tests cover allow/deny precedence, `discovery: "off"`, custom model materialization, vendor preservation, and the fail-open paths when a provider has no policy or is absent from the catalog.

```
npx vitest run src/vs/platform/positronHeadlessLanguageModel/ src/vs/platform/positronAiProvider/ src/vs/workbench/services/positronHeadlessLanguageModel/
```

@:assistant
