### PR TITLE
Consolidate Download URL settings for remote extensions

### DIFF
--- a/.claude/rules/vitest-tests.md
+++ b/.claude/rules/vitest-tests.md
@@ -1,13 +1,17 @@
 ---
 paths:
   - src/**/*.vitest.{ts,tsx}
+  - extensions/**/*.vitest.{ts,tsx}
   - vitest.config.ts
+  - vitest.tsconfig.json
   - src/vs/test/vitest/**
 ---
 
 # Positron Vitest Tests
 
-Vitest tests for Positron code (`*.vitest.ts` / `*.vitest.tsx` in `src/vs/`) run directly on your source files -- no build daemons, no compilation step, no waiting. Run `npx vitest <file>` for watch mode (re-runs on save) or `npx vitest run <file>` for a single pass.
+Vitest tests for Positron code (`*.vitest.ts` / `*.vitest.tsx`) run directly on your source files -- no build daemons, no compilation step, no waiting. Run `npx vitest <file>` for watch mode (re-runs on save) or `npx vitest run <file>` for a single pass.
+
+Most live in `src/vs/`. Tests under `extensions/` are also collected, with extra setup -- see [Tests inside `extensions/`](#tests-inside-extensions).
 
 ## Quick Start
 
@@ -48,6 +52,50 @@ Read [`vitest-rtl.md`](vitest-rtl.md) for query priority, jest-dom matcher selec
 - File extension: `.vitest.ts` (or `.vitest.tsx` for React components)
 - `/// <reference types="vitest/globals" />` after the copyright header (required for IDE intellisense)
 - Tabs for indentation
+
+### Tests inside `extensions/`
+
+Vitest collects `extensions/**/*.vitest.{ts,tsx}` too. Four things differ from `src/vs/`.
+
+**1. Exclude the tests from that extension's build, in the same change that adds the first one.** Add this to `extensions/<name>/tsconfig.json`:
+
+```json
+"exclude": [
+	"src/**/*.vitest.ts",
+	"src/**/*.vitest.tsx"
+]
+```
+
+Without it, the test is compiled into `out/` and ships inside the extension, where its `vitest` import cannot resolve at runtime. Nothing else catches this: `compile-extension` runs tsgo straight off the extension's tsconfig and bypasses the gulp pipeline, `.vscodeignore` excludes `src/**` but not `out/**`, and the `.vitest.` filter in `build/lib/compilation.ts` applies only to the core `src` build. Each extension has to opt out for itself.
+
+Confirm with a command, not by eye -- this fails silently:
+
+```bash
+npx tsc -p extensions/<name> --listFilesOnly | grep vitest   # expect no output
+ls extensions/<name>/out | grep vitest                       # expect no output
+```
+
+Don't rely on a comment in `tsconfig.json` to explain the exclude. Those files get reformatted and the comments can be dropped; this section is the durable home for the reason.
+
+**2. `vscode` is not a real package.** The extension host injects it at runtime, so nothing resolves it under Vitest. Importing it anywhere in the module graph fails the whole file before any test runs:
+
+```
+Failed to resolve import "vscode" from "<your test>". Does the file exist?
+```
+
+`vi.mock('vscode', () => ({ ... }))` does **not** fix this on its own -- resolution happens before mocking, so you get the identical error. Making it importable needs a `resolve.alias` in `vitest.config.ts` pointing `vscode` at a stub module. **No such alias exists today**, so as things stand a module that imports `vscode` cannot be unit tested here at all.
+
+Prefer not to need one. Keep the logic worth testing in a plain module that imports nothing from `vscode`, and leave the configuration reads and API calls to its caller. `extensions/open-remote-ssh/src/serverDownloadUrl.ts` is the pattern: it declares a local interface for the one shape it needs instead of importing the `vscode` type, and its callers pass in the `inspect()` results. That seam is usually the better design anyway -- if a module can't be reached without `vscode`, the logic and the API access generally want separating.
+
+Adding the alias is a shared-config change affecting every extension test, so agree on the stub's shape first rather than growing it ad hoc per test.
+
+**3. To read files from the test, use `__dirname`.** `import.meta.url` reads better but does not survive the CommonJS type check in `vitest.tsconfig.json` (`TS1470`). `process.cwd()` is not the repo root: Vitest resolves `root` for module resolution but never changes the working directory, so a test using it passes from the repo root and fails from anywhere else.
+
+**4. Type checking covers these files, but with core's compiler options.** `npm run test:positron:check-ts` picks them up through the `extensions/**/*.vitest.{ts,tsx}` entries in `vitest.tsconfig.json` -- both the test and any source it imports. Confirm with `npx tsc -p vitest.tsconfig.json --listFilesOnly | grep /extensions/`.
+
+Those options come from `src/tsconfig.json`, not from the extension's own. The program checks at `strict: true, target: es2024`, while, for example, `positron-dev-containers` builds at `strict: false, target: es2018`. A green `check-ts` therefore does not prove the file would compile under the extension's tsconfig -- which is fine, because step 1 excludes it from that build on purpose. Just don't read it as coverage of the extension's real build settings.
+
+Sharing code across extensions isn't possible (each compiles under its own tsconfig), so a helper needed by several is copied per extension. When that happens, add a guard that the copies stay identical -- see `extensions/serverDownloadUrl-copies.vitest.ts`.
 
 ## The Builder
 

--- a/.claude/rules/vitest-tests.md
+++ b/.claude/rules/vitest-tests.md
@@ -68,7 +68,9 @@ Vitest collects `extensions/**/*.vitest.{ts,tsx}` too. Four things differ from `
 
 Without it, the test is compiled into `out/` and ships inside the extension, where its `vitest` import cannot resolve at runtime. Nothing else catches this: `compile-extension` runs tsgo straight off the extension's tsconfig and bypasses the gulp pipeline, `.vscodeignore` excludes `src/**` but not `out/**`, and the `.vitest.` filter in `build/lib/compilation.ts` applies only to the core `src` build. Each extension has to opt out for itself.
 
-Confirm with a command, not by eye -- this fails silently:
+`extensions/noVitestFilesInBuilds.vitest.ts` guards this for every extension automatically: it resolves each extension's tsconfig the same way its real build does and fails if a `.vitest.` file would be included. A forgotten exclude fails that test instead of shipping silently.
+
+To confirm by hand instead, use a command, not eye inspection -- this fails silently:
 
 ```bash
 npx tsc -p extensions/<name> --listFilesOnly | grep vitest   # expect no output

--- a/.claude/skills/author-vitest-tests/SKILL.md
+++ b/.claude/skills/author-vitest-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: author-vitest-tests
-description: Use when writing or adding Vitest tests for Positron src/vs/ code, checking a branch/PR for test-coverage gaps, or testing React components with RTL.
+description: Use when writing or adding Vitest tests for Positron src/vs/ or extensions/ code, checking a branch/PR for test-coverage gaps, or testing React components with RTL.
 ---
 
 # Positron Vitest Test Authoring
@@ -146,15 +146,17 @@ For each approved item:
    - If setup exceeds ~20 lines of stubs, extract a helper function.
    - Minimize imports: if you're importing 5+ service identifiers just for `.stub()` calls, extract a helper.
 
-2. **Run the test:** `npx vitest run <path-to-test-file>`. Iterate on missing stubs per the "start low, let errors guide you up" pattern in the rules file's Builder section.
+2. **If the test lives under `extensions/`, exclude it from that extension's build** before moving on. Add `"src/**/*.vitest.ts"` and `"src/**/*.vitest.tsx"` to `exclude` in `extensions/<name>/tsconfig.json`, then confirm with `npx tsc -p extensions/<name> --listFilesOnly | grep vitest` (expect no output). Skipping this ships the test file inside the extension with an unresolvable `vitest` import, and no other check catches it. See "Tests inside `extensions/`" in [`vitest-tests.md`](../../rules/vitest-tests.md) for why, plus the `vscode`-import and `__dirname` constraints that apply there.
 
-3. **Type-check the file:** `npm run test:positron:check-ts 2>&1 | grep '<test-file-name>.vitest.ts'`. This surfaces strict TypeScript errors (overload compatibility, missing properties on stubs, etc.) that `npx vitest run` does NOT catch — the output matches what the VS Code Problems pane shows. The file must be clean before considering it done.
+3. **Run the test:** `npx vitest run <path-to-test-file>`. Iterate on missing stubs per the "start low, let errors guide you up" pattern in the rules file's Builder section.
 
-4. **Check coverage** for React component tests: `npx vitest run --coverage --coverage.include='**/sourceFile.tsx' <path-to-test-file>`
+4. **Type-check the file:** `npm run test:positron:check-ts 2>&1 | grep '<test-file-name>.vitest.ts'`. This surfaces strict TypeScript errors (overload compatibility, missing properties on stubs, etc.) that `npx vitest run` does NOT catch — the output matches what the VS Code Problems pane shows. The file must be clean before considering it done.
 
-5. **For React tests**, run `npx eslint <file>` before considering it done -- `eslint-plugin-testing-library` enforces most of the RTL conventions.
+5. **Check coverage** for React component tests: `npx vitest run --coverage --coverage.include='**/sourceFile.tsx' <path-to-test-file>`
 
-6. Move to the next file. Do NOT ask the dev after each file.
+6. **For React tests**, run `npx eslint <file>` before considering it done -- `eslint-plugin-testing-library` enforces most of the RTL conventions.
+
+7. Move to the next file. Do NOT ask the dev after each file.
 
 Don't run the full suite here -- it runs exactly once, after Phase 3 fixes land (see below). Running it now just duplicates that pass.
 

--- a/.github/workflows/test-tag-paths-map.json
+++ b/.github/workflows/test-tag-paths-map.json
@@ -82,6 +82,8 @@
   "src/vs/workbench/services/positronWebviewPreloads/": ["@:positron-notebooks"],
   "src/vs/workbench/services/positronLicense/": [],
 
+  "extensions/open-remote-ssh/": ["@:remote-ssh"],
+  "extensions/open-remote-wsl/": ["@:remote-wsl"],
   "extensions/positron-catalog-explorer/": ["@:catalog-explorer"],
   "extensions/positron-code-cells/": [],
   "extensions/positron-data-driver-databricks/": ["@:connections"],
@@ -168,6 +170,8 @@
   "src/vs/workbench/contrib/inlineChat/browser/positronNotebookUtils.ts": ["@:positron-notebooks", "@:assistant"],
   "src/vs/workbench/contrib/preferences/": [],
   "src/vs/workbench/contrib/preferences/common/positronSettingBadges.ts": ["@:vscode-settings"],
+  "src/vs/workbench/contrib/remote/": [],
+  "src/vs/workbench/contrib/remote/common/positronRemoteConfiguration.ts": ["@:remote-ssh", "@:remote-wsl"],
   "src/vs/workbench/contrib/update/": [],
   "src/vs/workbench/contrib/welcomeGettingStarted/": [],
   "src/vs/workbench/contrib/welcomeGettingStarted/browser/media/positronGettingStarted.css": ["@:welcome"],

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,8 @@ Positron has three test categories:
 
 **Don't create new `.test.ts` in `src/vs/` for Positron code** -- use Vitest. Core Mocha rows are for maintaining existing upstream tests.
 
+**Vitest also collects `extensions/**/*.vitest.{ts,tsx}`**, for plain modules that don't import `vscode`. Prefer it over an extension host test when the logic can be reached without the `vscode` API. Adding the first one to an extension means excluding it from that extension's build, or it ships inside the extension -- see [Tests inside `extensions/`](.claude/rules/vitest-tests.md#tests-inside-extensions).
+
 ### Running tests
 
 - **Vitest** (`*.vitest.ts` / `*.vitest.tsx`, **no build daemons needed**):

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -208,6 +208,8 @@ export default defineConfig(
 		files: [
 			'src/vs/**/*.vitest.ts',
 			'src/vs/**/*.vitest.tsx',
+			'extensions/**/*.vitest.ts',
+			'extensions/**/*.vitest.tsx',
 		],
 		plugins: {
 			'testing-library': pluginTestingLibrary,
@@ -3176,6 +3178,8 @@ export default defineConfig(
 		files: [
 			'src/vs/**/*.vitest.ts',
 			'src/vs/**/*.vitest.tsx',
+			'extensions/**/*.vitest.ts',
+			'extensions/**/*.vitest.tsx',
 		],
 		rules: {
 			// Manual type assertions (as any, as T) hide bugs in tests the same

--- a/extensions/noVitestFilesInBuilds.vitest.ts
+++ b/extensions/noVitestFilesInBuilds.vitest.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import * as fs from 'fs';
+import * as path from 'path';
+import ts from 'typescript';
+
+/**
+ * Vitest collects `extensions/**\/*.vitest.{ts,tsx}`, and an extension's own build compiles
+ * `src/**` too. Without a `.vitest.` exclude in that extension's tsconfig, the test compiles
+ * into `out/` and ships inside the extension, where its `vitest` import cannot resolve at
+ * runtime. Nothing else catches this: `compile-extension` runs tsgo straight off the
+ * extension's tsconfig and bypasses the gulp pipeline, `.vscodeignore` excludes `src/**` but
+ * not `out/**`, and the `.vitest.` filter in `build/lib/compilation.ts` applies only to the
+ * core `src` build. The build stays green either way, so this has to be a test rather than a
+ * compiler error. See `.claude/rules/vitest-tests.md#tests-inside-extensions`.
+ *
+ * This resolves each extension's tsconfig the same way its real build does, and fails if a
+ * `.vitest.` file would be included in the result.
+ */
+function resolvedFileNames(tsconfigPath: string): string[] {
+	const { config, error } = ts.readConfigFile(tsconfigPath, ts.sys.readFile);
+	if (error) {
+		throw new Error(`Cannot parse ${tsconfigPath}: ${error.messageText}`);
+	}
+	return ts.parseJsonConfigFileContent(config, ts.sys, path.dirname(tsconfigPath)).fileNames;
+}
+
+// `__dirname` is this file's own directory (`extensions/`), so the path holds wherever Vitest
+// is started from. See vitest-tests.md on why `process.cwd()` and `import.meta.url` don't.
+const extensionNames = fs.readdirSync(__dirname)
+	.filter(name => fs.existsSync(path.join(__dirname, name, 'tsconfig.json')));
+
+describe('extension builds exclude vitest files', () => {
+	it.each(extensionNames)('%s', name => {
+		const tsconfigPath = path.join(__dirname, name, 'tsconfig.json');
+		const includedVitestFiles = resolvedFileNames(tsconfigPath).filter(f => f.includes('.vitest.'));
+
+		expect(includedVitestFiles).toEqual([]);
+	});
+});

--- a/extensions/open-remote-ssh/package.json
+++ b/extensions/open-remote-ssh/package.json
@@ -71,6 +71,7 @@
 				"remoteSSH.serverDownloadUrlTemplate": {
 					"type": "string",
 					"description": "The URL from where the Positron server will be downloaded. You can use the following variables and they will be replaced dynamically:\n- ${quality}: Positron server quality, e.g. stable or insiders\n- ${version}: Positron server version, e.g. 2024.10.0-123\n- ${commit}: Positron server release commit\n- ${arch}: Positron server arch, e.g. x64, armhf, arm64\n- ${arch-long}: Positron server arch in long format, e.g. x86_64, arm64",
+					"markdownDeprecationMessage": "Use `#remote.serverDownloadUrlTemplate#` instead, which applies to SSH, WSL, and dev containers. This setting still works, and it takes precedence when both are set.",
 					"scope": "application",
 					"default": "https://cdn.posit.co/positron/${quality}/reh/${arch-long}/positron-reh-${os}-${arch}-${version}.tar.gz"
 				},

--- a/extensions/open-remote-ssh/src/authResolver.ts
+++ b/extensions/open-remote-ssh/src/authResolver.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -23,6 +23,7 @@ import { untildify, exists as fileExists } from './common/files';
 import { findRandomPort } from './common/ports';
 import { disposeAll } from './common/disposable';
 import { installCodeServer, ServerInstallError } from './serverSetup';
+import { pickConfiguredDownloadUrlTemplate, UNIFIED_DOWNLOAD_URL_KEY, UNIFIED_DOWNLOAD_URL_SECTION } from './serverDownloadUrl';
 import { isWindows } from './common/platform';
 import * as os from 'os';
 
@@ -89,7 +90,10 @@ export class RemoteSSHResolver implements vscode.RemoteAuthorityResolver, vscode
 		const remoteSSHconfig = vscode.workspace.getConfiguration('remoteSSH');
 		const enableDynamicForwarding = remoteSSHconfig.get<boolean>('enableDynamicForwarding', true)!;
 		const enableAgentForwarding = remoteSSHconfig.get<boolean>('enableAgentForwarding', true)!;
-		const serverDownloadUrlTemplate = remoteSSHconfig.get<string>('serverDownloadUrlTemplate');
+		const serverDownloadUrlTemplate = pickConfiguredDownloadUrlTemplate(
+			remoteSSHconfig.inspect<string>('serverDownloadUrlTemplate'),
+			vscode.workspace.getConfiguration(UNIFIED_DOWNLOAD_URL_SECTION).inspect<string>(UNIFIED_DOWNLOAD_URL_KEY)
+		);
 		const defaultExtensions = remoteSSHconfig.get<string[]>('defaultExtensions', []);
 		const remotePlatformMap = remoteSSHconfig.get<Record<string, string>>('remotePlatform', {});
 		const remoteServerListenOnSocket = remoteSSHconfig.get<boolean>('remoteServerListenOnSocket', false)!;

--- a/extensions/open-remote-ssh/src/serverDownloadUrl.ts
+++ b/extensions/open-remote-ssh/src/serverDownloadUrl.ts
@@ -1,0 +1,68 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * The section and key of the unified server download URL setting,
+ * `remote.serverDownloadUrlTemplate`.
+ *
+ * It is registered in core, in
+ * `src/vs/workbench/contrib/remote/common/positronRemoteConfiguration.ts`, rather than by
+ * any one remote extension, so that it is present whether or not this extension is enabled.
+ */
+export const UNIFIED_DOWNLOAD_URL_SECTION = 'remote';
+export const UNIFIED_DOWNLOAD_URL_KEY = 'serverDownloadUrlTemplate';
+
+/**
+ * The part of `vscode.WorkspaceConfiguration.inspect()` that matters here.
+ *
+ * Declared locally so that this module imports nothing. That keeps it directly unit
+ * testable, since a test does not have to stand up the `vscode` module to load it.
+ *
+ * `defaultValue` is deliberately absent. The extension host fills that field from
+ * `config.policy?.value ?? config.default?.value` (see `extHostConfiguration.ts`), so it
+ * blends an administrator-enforced value together with the value the manifest ships, and it
+ * exposes no `policyValue` that would separate them. Reading it would mean treating the
+ * shipped CDN default as a deliberate choice, which is the thing this function exists to
+ * avoid. Enforced settings reach Positron through `POSITRON_ENFORCED_SETTINGS`, which is a
+ * Posit Workbench mechanism, and all three remote extensions are `"extensionKind": ["ui"]`
+ * desktop-only features that a Workbench session never runs. So there is no enforced value
+ * to lose here. Please do not "fix" this by folding `defaultValue` into the chain.
+ */
+export interface IInspectedValue {
+	globalValue?: string;
+	workspaceValue?: string;
+	workspaceFolderValue?: string;
+}
+
+/**
+ * Picks the server download URL template the user configured, or `undefined` when they
+ * configured neither setting.
+ *
+ * The deprecated setting (`remoteSSH.serverDownloadUrlTemplate`) comes first, so that anyone who
+ * already set it keeps the behavior they chose.
+ *
+ * Both settings are read with `inspect()` rather than `get()` because the deprecated one
+ * ships a non-empty default: `get()` cannot tell "the user asked for the CDN URL" apart from
+ * "the user asked for nothing", and only the second case may fall through to `product.json`,
+ * which is how a local or dev build downloads a server that matches it.
+ *
+ * Returning `undefined` leaves the caller's existing fall-through to `product.json` and then
+ * to a hardcoded default in place.
+ */
+export function pickConfiguredDownloadUrlTemplate(
+	legacy: IInspectedValue | undefined,
+	unified: IInspectedValue | undefined
+): string | undefined {
+	return chosenByUser(legacy) || chosenByUser(unified) || undefined;
+}
+
+/**
+ * Returns the value the user set for a setting, most specific scope first, matching how VS
+ * Code itself resolves one. Both settings are application scoped today, so in practice only
+ * `globalValue` is ever set.
+ */
+function chosenByUser(inspected: IInspectedValue | undefined): string | undefined {
+	return inspected?.workspaceFolderValue || inspected?.workspaceValue || inspected?.globalValue || undefined;
+}

--- a/extensions/open-remote-ssh/src/serverDownloadUrl.vitest.ts
+++ b/extensions/open-remote-ssh/src/serverDownloadUrl.vitest.ts
@@ -1,0 +1,77 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { pickConfiguredDownloadUrlTemplate } from './serverDownloadUrl';
+
+const LEGACY_URL = 'https://example.test/legacy/positron-reh-${os}-${arch}-${version}.tar.gz';
+const UNIFIED_URL = 'https://example.test/unified/positron-reh-${os}-${arch}-${version}.tar.gz';
+
+/**
+ * What an untouched setting looks like. `inspect()` reports no scope values at all, and the
+ * shipped default arrives in a `defaultValue` field this code deliberately does not read.
+ */
+const UNSET = {};
+
+describe('pickConfiguredDownloadUrlTemplate', () => {
+	describe('when the user set the deprecated setting', () => {
+		it('returns the deprecated value even when the unified setting is also set', () => {
+			const result = pickConfiguredDownloadUrlTemplate(
+				{ globalValue: LEGACY_URL }, { globalValue: UNIFIED_URL });
+			expect(result).toBe(LEGACY_URL);
+		});
+
+		it('prefers the folder scope over the workspace and global scopes', () => {
+			const result = pickConfiguredDownloadUrlTemplate({
+				globalValue: 'https://example.test/global.tar.gz',
+				workspaceValue: 'https://example.test/workspace.tar.gz',
+				workspaceFolderValue: 'https://example.test/folder.tar.gz'
+			}, UNSET);
+			expect(result).toBe('https://example.test/folder.tar.gz');
+		});
+
+		it('prefers the workspace scope over the global scope', () => {
+			const result = pickConfiguredDownloadUrlTemplate({
+				globalValue: 'https://example.test/global.tar.gz',
+				workspaceValue: 'https://example.test/workspace.tar.gz'
+			}, UNSET);
+			expect(result).toBe('https://example.test/workspace.tar.gz');
+		});
+
+		it('falls through an empty deprecated value to the unified setting', () => {
+			const result = pickConfiguredDownloadUrlTemplate(
+				{ globalValue: '' }, { globalValue: UNIFIED_URL });
+			expect(result).toBe(UNIFIED_URL);
+		});
+	});
+
+	describe('when the user set only the unified setting', () => {
+		it('returns the unified value', () => {
+			const result = pickConfiguredDownloadUrlTemplate(UNSET, { globalValue: UNIFIED_URL });
+			expect(result).toBe(UNIFIED_URL);
+		});
+	});
+
+	describe('when the user set neither setting', () => {
+		// The reason both settings are read with `inspect()` rather than `get()`. The
+		// deprecated setting ships a non-empty default, so `get()` would report the CDN URL
+		// here and the caller would never reach its product.json fallback.
+		it('returns undefined, so the caller falls back to product.json', () => {
+			const result = pickConfiguredDownloadUrlTemplate(UNSET, UNSET);
+			expect(result).toBeUndefined();
+		});
+
+		it('returns undefined when neither setting reports anything at all', () => {
+			const result = pickConfiguredDownloadUrlTemplate(undefined, undefined);
+			expect(result).toBeUndefined();
+		});
+
+		it('returns undefined when the unified setting holds its empty default', () => {
+			const result = pickConfiguredDownloadUrlTemplate(UNSET, { globalValue: '' });
+			expect(result).toBeUndefined();
+		});
+	});
+});

--- a/extensions/open-remote-ssh/src/serverSetup.ts
+++ b/extensions/open-remote-ssh/src/serverSetup.ts
@@ -44,7 +44,7 @@ export class ServerInstallError extends Error {
 	}
 }
 
-const DEFAULT_DOWNLOAD_URL_TEMPLATE = 'https://cdn.posit.co/positron/dailies/reh/${arch-long}/positron-reh-${os}-${arch}-${version}.tar.gz';
+const DEFAULT_DOWNLOAD_URL_TEMPLATE = 'https://cdn.posit.co/positron/${quality}/reh/${arch-long}/positron-reh-${os}-${arch}-${version}.tar.gz';
 
 /**
  * Converts a wildcard pattern to a regular expression.

--- a/extensions/open-remote-ssh/tsconfig.json
+++ b/extensions/open-remote-ssh/tsconfig.json
@@ -21,6 +21,10 @@
 			"node"
 		]
 	},
+	"exclude": [
+		"src/**/*.vitest.ts",
+		"src/**/*.vitest.tsx"
+	],
 	"include": [
 		"*.d.ts",
 		"src/**/*",

--- a/extensions/open-remote-wsl/package.json
+++ b/extensions/open-remote-wsl/package.json
@@ -42,6 +42,7 @@
         "remote.WSL.serverDownloadUrlTemplate": {
           "type": "string",
           "description": "%configuration.remote.WSL.serverDownloadUrlTemplate.description%",
+          "markdownDeprecationMessage": "%configuration.remote.WSL.serverDownloadUrlTemplate.deprecationMessage%",
           "scope": "application",
           "default": "https://cdn.posit.co/positron/${quality}/reh/${arch-long}/positron-reh-${os}-${arch}-${version}.tar.gz"
         }

--- a/extensions/open-remote-wsl/package.nls.json
+++ b/extensions/open-remote-wsl/package.nls.json
@@ -3,6 +3,7 @@
 	"description": "Open any folder in the Windows Subsystem for Linux (WSL).",
 	"configuration.title": "WSL",
 	"configuration.remote.WSL.serverDownloadUrlTemplate.description": "The URL from where the Positron server will be downloaded. You can use the following variables and they will be replaced dynamically:\n- ${quality}: Positron server quality, e.g. stable or insiders\n- ${version}: Positron server version, e.g. 2024.10.0-123\n- ${commit}: Positron server release commit\n- ${arch}: Positron server arch, e.g. x64, armhf, arm64\n- ${arch-long}: Positron server arch in long format, e.g. x86_64, arm64",
+	"configuration.remote.WSL.serverDownloadUrlTemplate.deprecationMessage": "Use `#remote.serverDownloadUrlTemplate#` instead, which applies to SSH, WSL, and dev containers. This setting still works, and it takes precedence when both are set.",
 	"views.remote.wslTargets.name": "WSL Targets",
 	"command.openremotewsl.category": "Remote-WSL",
 	"command.openremotewsl.connect.title": "Connect to WSL",

--- a/extensions/open-remote-wsl/src/authResolver.ts
+++ b/extensions/open-remote-wsl/src/authResolver.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -9,6 +9,7 @@
 import * as vscode from 'vscode';
 import Log from './common/logger';
 import { installCodeServer, ServerInstallError } from './serverSetup';
+import { pickConfiguredDownloadUrlTemplate, UNIFIED_DOWNLOAD_URL_KEY, UNIFIED_DOWNLOAD_URL_SECTION } from './serverDownloadUrl';
 import { WSLManager } from './wsl/wslManager';
 
 export const REMOTE_WSL_AUTHORITY = 'wsl';
@@ -57,8 +58,11 @@ export class RemoteWSLResolver implements vscode.RemoteAuthorityResolver, vscode
 
 		// It looks like default values are not loaded yet when resolving a remote,
 		// so let's hardcode the default values here
-		const remoteSSHconfig = vscode.workspace.getConfiguration('remote.WSL');
-		const serverDownloadUrlTemplate = remoteSSHconfig.get<string>('serverDownloadUrlTemplate');
+		const remoteWSLconfig = vscode.workspace.getConfiguration('remote.WSL');
+		const serverDownloadUrlTemplate = pickConfiguredDownloadUrlTemplate(
+			remoteWSLconfig.inspect<string>('serverDownloadUrlTemplate'),
+			vscode.workspace.getConfiguration(UNIFIED_DOWNLOAD_URL_SECTION).inspect<string>(UNIFIED_DOWNLOAD_URL_KEY)
+		);
 
 		return vscode.window.withProgress({
 			title: `Setting up WSL Distro: ${distroName}`,

--- a/extensions/open-remote-wsl/src/serverDownloadUrl.ts
+++ b/extensions/open-remote-wsl/src/serverDownloadUrl.ts
@@ -1,0 +1,68 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * The section and key of the unified server download URL setting,
+ * `remote.serverDownloadUrlTemplate`.
+ *
+ * It is registered in core, in
+ * `src/vs/workbench/contrib/remote/common/positronRemoteConfiguration.ts`, rather than by
+ * any one remote extension, so that it is present whether or not this extension is enabled.
+ */
+export const UNIFIED_DOWNLOAD_URL_SECTION = 'remote';
+export const UNIFIED_DOWNLOAD_URL_KEY = 'serverDownloadUrlTemplate';
+
+/**
+ * The part of `vscode.WorkspaceConfiguration.inspect()` that matters here.
+ *
+ * Declared locally so that this module imports nothing. That keeps it directly unit
+ * testable, since a test does not have to stand up the `vscode` module to load it.
+ *
+ * `defaultValue` is deliberately absent. The extension host fills that field from
+ * `config.policy?.value ?? config.default?.value` (see `extHostConfiguration.ts`), so it
+ * blends an administrator-enforced value together with the value the manifest ships, and it
+ * exposes no `policyValue` that would separate them. Reading it would mean treating the
+ * shipped CDN default as a deliberate choice, which is the thing this function exists to
+ * avoid. Enforced settings reach Positron through `POSITRON_ENFORCED_SETTINGS`, which is a
+ * Posit Workbench mechanism, and all three remote extensions are `"extensionKind": ["ui"]`
+ * desktop-only features that a Workbench session never runs. So there is no enforced value
+ * to lose here. Please do not "fix" this by folding `defaultValue` into the chain.
+ */
+export interface IInspectedValue {
+	globalValue?: string;
+	workspaceValue?: string;
+	workspaceFolderValue?: string;
+}
+
+/**
+ * Picks the server download URL template the user configured, or `undefined` when they
+ * configured neither setting.
+ *
+ * The deprecated setting (`remote.WSL.serverDownloadUrlTemplate`) comes first, so that anyone who
+ * already set it keeps the behavior they chose.
+ *
+ * Both settings are read with `inspect()` rather than `get()` because the deprecated one
+ * ships a non-empty default: `get()` cannot tell "the user asked for the CDN URL" apart from
+ * "the user asked for nothing", and only the second case may fall through to `product.json`,
+ * which is how a local or dev build downloads a server that matches it.
+ *
+ * Returning `undefined` leaves the caller's existing fall-through to `product.json` and then
+ * to a hardcoded default in place.
+ */
+export function pickConfiguredDownloadUrlTemplate(
+	legacy: IInspectedValue | undefined,
+	unified: IInspectedValue | undefined
+): string | undefined {
+	return chosenByUser(legacy) || chosenByUser(unified) || undefined;
+}
+
+/**
+ * Returns the value the user set for a setting, most specific scope first, matching how VS
+ * Code itself resolves one. Both settings are application scoped today, so in practice only
+ * `globalValue` is ever set.
+ */
+function chosenByUser(inspected: IInspectedValue | undefined): string | undefined {
+	return inspected?.workspaceFolderValue || inspected?.workspaceValue || inspected?.globalValue || undefined;
+}

--- a/extensions/open-remote-wsl/src/serverSetup.ts
+++ b/extensions/open-remote-wsl/src/serverSetup.ts
@@ -42,7 +42,7 @@ export class ServerInstallError extends Error {
 	}
 }
 
-const DEFAULT_DOWNLOAD_URL_TEMPLATE = 'https://cdn.posit.co/positron/dailies/reh/${arch-long}/positron-reh-${os}-${arch}-${version}.tar.gz';
+const DEFAULT_DOWNLOAD_URL_TEMPLATE = 'https://cdn.posit.co/positron/${quality}/reh/${arch-long}/positron-reh-${os}-${arch}-${version}.tar.gz';
 
 export async function installCodeServer(wslManager: WSLManager, distroName: string, serverDownloadUrlTemplate: string | undefined, extensionIds: string[], envVariables: string[], logger: Log): Promise<ServerInstallResult> {
 	const scriptId = crypto.randomBytes(12).toString('hex');

--- a/extensions/open-remote-wsl/tsconfig.json
+++ b/extensions/open-remote-wsl/tsconfig.json
@@ -20,6 +20,10 @@
 			"node"
 		]
 	},
+	"exclude": [
+		"src/**/*.vitest.ts",
+		"src/**/*.vitest.tsx"
+	],
 	"include": [
 		"*.d.ts",
 		"src/**/*",

--- a/extensions/positron-dev-containers/package.json
+++ b/extensions/positron-dev-containers/package.json
@@ -126,7 +126,8 @@
           "scope": "application",
           "type": "string",
           "default": "https://cdn.posit.co/positron/${quality}/reh/${arch-long}/positron-reh-${os}-${arch}-${version}.tar.gz",
-          "markdownDescription": "The URL from where the Positron server will be downloaded. You can use the following variables and they will be replaced dynamically:\n- `${quality}`: Positron server quality, e.g. stable or insiders\n- `${version}`: Positron server version, e.g. 2024.10.0-123\n- `${commit}`: Positron server release commit\n- `${os}`: Positron server OS, e.g. linux, darwin, win32\n- `${arch}`: Positron server arch, e.g. x64, arm64\n- `${arch-long}`: Positron server arch in long format, e.g. x86_64, arm64"
+          "markdownDescription": "The URL from where the Positron server will be downloaded. You can use the following variables and they will be replaced dynamically:\n- `${quality}`: Positron server quality, e.g. stable or insiders\n- `${version}`: Positron server version, e.g. 2024.10.0-123\n- `${commit}`: Positron server release commit\n- `${os}`: Positron server OS, e.g. linux, darwin, win32\n- `${arch}`: Positron server arch, e.g. x64, arm64\n- `${arch-long}`: Positron server arch in long format, e.g. x86_64, arm64",
+          "markdownDeprecationMessage": "Use `#remote.serverDownloadUrlTemplate#` instead, which applies to SSH, WSL, and dev containers. This setting still works, and it takes precedence when both are set."
         }
       }
     },

--- a/extensions/positron-dev-containers/src/server/serverConfig.ts
+++ b/extensions/positron-dev-containers/src/server/serverConfig.ts
@@ -9,6 +9,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
 import { getLogger } from '../common/logger';
+import { pickConfiguredDownloadUrlTemplate, UNIFIED_DOWNLOAD_URL_KEY, UNIFIED_DOWNLOAD_URL_SECTION } from './serverDownloadUrl';
 
 /**
  * Server platform information
@@ -207,6 +208,28 @@ export class ServerConfigProvider {
 	}
 
 	/**
+	 * Get the server download URL template that this build was published with, from
+	 * product.json. This is what gives a local or dev build a server that matches it,
+	 * and it is the fallback when the user has configured no download URL of their own.
+	 */
+	private getProductDownloadUrlTemplate(): string | undefined {
+		try {
+			const appRoot = vscode.env.appRoot;
+			const productPath = path.join(appRoot, 'product.json');
+
+			const productJson = fs.readFileSync(productPath, 'utf8');
+			const product = JSON.parse(productJson);
+			if (product.serverDownloadUrlTemplate) {
+				return product.serverDownloadUrlTemplate;
+			}
+		} catch (error) {
+			this.logger.error(`Failed to read serverDownloadUrlTemplate from product.json: ${error}`);
+		}
+
+		return undefined;
+	}
+
+	/**
 	 * Get platform information for the host
 	 */
 	private getPlatformInfo(): ServerPlatform {
@@ -269,9 +292,13 @@ export class ServerConfigProvider {
 	 * @param platform Platform information
 	 */
 	private getDownloadUrl(version: string, commit: string, quality: string, platform: ServerPlatform): string {
-		// Get the URL template from configuration or use default
-		const config = vscode.workspace.getConfiguration('dev.containers');
-		const urlTemplate = config.get<string>('serverDownloadUrlTemplate') || DEFAULT_DOWNLOAD_URL_TEMPLATE;
+		// Prefer whatever the user configured, then what this build was published with,
+		// then the hardcoded default.
+		const configured = pickConfiguredDownloadUrlTemplate(
+			vscode.workspace.getConfiguration('dev.containers').inspect<string>('serverDownloadUrlTemplate'),
+			vscode.workspace.getConfiguration(UNIFIED_DOWNLOAD_URL_SECTION).inspect<string>(UNIFIED_DOWNLOAD_URL_KEY)
+		);
+		const urlTemplate = configured || this.getProductDownloadUrlTemplate() || DEFAULT_DOWNLOAD_URL_TEMPLATE;
 
 		// Get the long-form architecture name (e.g., x86_64 instead of x64)
 		const archLong = this.getArchLong(platform.arch);

--- a/extensions/positron-dev-containers/src/server/serverDownloadUrl.ts
+++ b/extensions/positron-dev-containers/src/server/serverDownloadUrl.ts
@@ -1,0 +1,68 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * The section and key of the unified server download URL setting,
+ * `remote.serverDownloadUrlTemplate`.
+ *
+ * It is registered in core, in
+ * `src/vs/workbench/contrib/remote/common/positronRemoteConfiguration.ts`, rather than by
+ * any one remote extension, so that it is present whether or not this extension is enabled.
+ */
+export const UNIFIED_DOWNLOAD_URL_SECTION = 'remote';
+export const UNIFIED_DOWNLOAD_URL_KEY = 'serverDownloadUrlTemplate';
+
+/**
+ * The part of `vscode.WorkspaceConfiguration.inspect()` that matters here.
+ *
+ * Declared locally so that this module imports nothing. That keeps it directly unit
+ * testable, since a test does not have to stand up the `vscode` module to load it.
+ *
+ * `defaultValue` is deliberately absent. The extension host fills that field from
+ * `config.policy?.value ?? config.default?.value` (see `extHostConfiguration.ts`), so it
+ * blends an administrator-enforced value together with the value the manifest ships, and it
+ * exposes no `policyValue` that would separate them. Reading it would mean treating the
+ * shipped CDN default as a deliberate choice, which is the thing this function exists to
+ * avoid. Enforced settings reach Positron through `POSITRON_ENFORCED_SETTINGS`, which is a
+ * Posit Workbench mechanism, and all three remote extensions are `"extensionKind": ["ui"]`
+ * desktop-only features that a Workbench session never runs. So there is no enforced value
+ * to lose here. Please do not "fix" this by folding `defaultValue` into the chain.
+ */
+export interface IInspectedValue {
+	globalValue?: string;
+	workspaceValue?: string;
+	workspaceFolderValue?: string;
+}
+
+/**
+ * Picks the server download URL template the user configured, or `undefined` when they
+ * configured neither setting.
+ *
+ * The deprecated setting (`dev.containers.serverDownloadUrlTemplate`) comes first, so that anyone who
+ * already set it keeps the behavior they chose.
+ *
+ * Both settings are read with `inspect()` rather than `get()` because the deprecated one
+ * ships a non-empty default: `get()` cannot tell "the user asked for the CDN URL" apart from
+ * "the user asked for nothing", and only the second case may fall through to `product.json`,
+ * which is how a local or dev build downloads a server that matches it.
+ *
+ * Returning `undefined` leaves the caller's existing fall-through to `product.json` and then
+ * to a hardcoded default in place.
+ */
+export function pickConfiguredDownloadUrlTemplate(
+	legacy: IInspectedValue | undefined,
+	unified: IInspectedValue | undefined
+): string | undefined {
+	return chosenByUser(legacy) || chosenByUser(unified) || undefined;
+}
+
+/**
+ * Returns the value the user set for a setting, most specific scope first, matching how VS
+ * Code itself resolves one. Both settings are application scoped today, so in practice only
+ * `globalValue` is ever set.
+ */
+function chosenByUser(inspected: IInspectedValue | undefined): string | undefined {
+	return inspected?.workspaceFolderValue || inspected?.workspaceValue || inspected?.globalValue || undefined;
+}

--- a/extensions/positron-dev-containers/tsconfig.json
+++ b/extensions/positron-dev-containers/tsconfig.json
@@ -34,7 +34,9 @@
 		"dist",
 		"tmp",
 		"src/spec/test/**/*",
-		"src/cli-0.80.1/**/*"
+		"src/cli-0.80.1/**/*",
+		"src/**/*.vitest.ts",
+		"src/**/*.vitest.tsx"
 	],
 	"include": [
 		"src/**/*",

--- a/extensions/serverDownloadUrl-copies.vitest.ts
+++ b/extensions/serverDownloadUrl-copies.vitest.ts
@@ -1,0 +1,79 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { UNIFIED_DOWNLOAD_URL_KEY, UNIFIED_DOWNLOAD_URL_SECTION } from './open-remote-ssh/src/serverDownloadUrl';
+
+/**
+ * `serverDownloadUrl.ts` exists once per remote extension, because each extension compiles
+ * under its own tsconfig and cannot import from another extension or from `src/vs`. The
+ * copies have to stay in step: correcting the resolution order in one of them and
+ * forgetting the others would leave two remotes honoring the wrong setting.
+ *
+ * Only the open-remote-ssh copy has behavioral tests, in `serverDownloadUrl.vitest.ts`.
+ * This guard is what lets those tests speak for all three.
+ */
+const COPIES = [
+	{
+		file: 'open-remote-ssh/src/serverDownloadUrl.ts',
+		settingKey: 'remoteSSH.serverDownloadUrlTemplate'
+	},
+	{
+		file: 'open-remote-wsl/src/serverDownloadUrl.ts',
+		settingKey: 'remote.WSL.serverDownloadUrlTemplate'
+	},
+	{
+		file: 'positron-dev-containers/src/server/serverDownloadUrl.ts',
+		settingKey: 'dev.containers.serverDownloadUrlTemplate'
+	},
+] as const;
+
+// `__dirname` is this file's own directory, so the paths hold wherever Vitest is started
+// from. `process.cwd()` does not: Vitest resolves `root` for module resolution but never
+// changes the working directory. `import.meta.url` would read better still, but it does not
+// survive the CommonJS type check in vitest.tsconfig.json.
+function read(relativePath: string): string {
+	return fs.readFileSync(path.join(__dirname, relativePath), 'utf8');
+}
+
+/**
+ * Reads one copy and masks the only thing that legitimately differs between them: the doc
+ * comments naming that extension's own deprecated setting.
+ */
+function readNormalized(copy: typeof COPIES[number]): string {
+	return read(copy.file).replaceAll(copy.settingKey, '<deprecated setting>');
+}
+
+describe('serverDownloadUrl copies', () => {
+	const [ssh, wsl, devContainers] = COPIES;
+
+	it('keeps the WSL copy in step with the SSH copy', () => {
+		expect(readNormalized(wsl)).toBe(readNormalized(ssh));
+	});
+
+	it('keeps the Dev Containers copy in step with the SSH copy', () => {
+		expect(readNormalized(devContainers)).toBe(readNormalized(ssh));
+	});
+});
+
+/**
+ * The extensions cannot import from `src/vs`, so they spell the unified setting's section and
+ * key out again rather than using the exported constant. Nothing else connects the two: rename
+ * the setting in core and the workbench still compiles, the copies above still match, and all
+ * three extensions quietly read a key that no longer exists, sending every configured URL to
+ * the product.json fallback instead.
+ */
+describe('the unified setting key', () => {
+	it('matches the key that core registers', () => {
+		const core = read('../src/vs/workbench/contrib/remote/common/positronRemoteConfiguration.ts');
+		const registered = /REMOTE_SERVER_DOWNLOAD_URL_TEMPLATE_KEY = '([^']+)'/.exec(core)?.[1];
+
+		expect(`${UNIFIED_DOWNLOAD_URL_SECTION}.${UNIFIED_DOWNLOAD_URL_KEY}`).toBe(registered);
+	});
+});
+

--- a/src/vs/workbench/contrib/remote/common/positronRemoteConfiguration.ts
+++ b/src/vs/workbench/contrib/remote/common/positronRemoteConfiguration.ts
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../../nls.js';
+import { ConfigurationScope, Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
+import { Registry } from '../../../../platform/registry/common/platform.js';
+
+/**
+ * The unified setting key for the URL that the Positron server (reh) is downloaded from.
+ *
+ * The remote extensions (SSH, WSL, and Dev Containers) each declared their own copy of
+ * this setting. Those copies are deprecated but still honored. This key is registered in
+ * core rather than in one of those extensions so that it exists even when a given remote
+ * extension is disabled or not installed.
+ *
+ * The default is deliberately empty. An empty value means "not set", which is what lets
+ * the extensions fall through to `serverDownloadUrlTemplate` in `product.json`. Defaulting
+ * to the CDN URL instead would make an unset setting indistinguishable from a deliberate
+ * choice, and local and dev builds would lose their own default.
+ */
+export const REMOTE_SERVER_DOWNLOAD_URL_TEMPLATE_KEY = 'remote.serverDownloadUrlTemplate';
+
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
+	.registerConfiguration({
+		id: 'remote',
+		title: localize('positron.remote', "Remote"),
+		type: 'object',
+		properties: {
+			[REMOTE_SERVER_DOWNLOAD_URL_TEMPLATE_KEY]: {
+				type: 'string',
+				default: '',
+				scope: ConfigurationScope.APPLICATION,
+				markdownDescription: localize('positron.remote.serverDownloadUrlTemplate', "The URL that the Positron server is downloaded from when you connect to a remote over SSH, WSL, or a dev container. Leave this empty to use the URL that this build was published with. These variables are replaced when the URL is built:\n- `${quality}`: server quality, for example `stable` or `dailies`\n- `${version}`: server version, for example `2024.10.0-123`\n- `${commit}`: server release commit\n- `${os}`: server operating system, for example `linux`, `darwin`, or `win32`\n- `${arch}`: server architecture, for example `x64`, `armhf`, or `arm64`\n- `${arch-long}`: server architecture in long form, for example `x86_64` or `arm64`")
+			}
+		}
+	});

--- a/src/vs/workbench/contrib/remote/common/positronRemoteConfiguration.ts
+++ b/src/vs/workbench/contrib/remote/common/positronRemoteConfiguration.ts
@@ -32,7 +32,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 				type: 'string',
 				default: '',
 				scope: ConfigurationScope.APPLICATION,
-				markdownDescription: localize('positron.remote.serverDownloadUrlTemplate', "The URL that the Positron server is downloaded from when you connect to a remote over SSH, WSL, or a dev container. Leave this empty to use the URL that this build was published with. These variables are replaced when the URL is built:\n- `${quality}`: server quality, for example `stable` or `dailies`\n- `${version}`: server version, for example `2024.10.0-123`\n- `${commit}`: server release commit\n- `${os}`: server operating system, for example `linux`, `darwin`, or `win32`\n- `${arch}`: server architecture, for example `x64`, `armhf`, or `arm64`\n- `${arch-long}`: server architecture in long form, for example `x86_64` or `arm64`")
+				markdownDescription: localize('positron.remote.serverDownloadUrlTemplate', "The URL that the Positron server is downloaded from when you connect to a remote over SSH, WSL, or a dev container. Leave this empty to use the URL that this build was published with, for example, `https://cdn.posit.co/positron/${quality}/reh/${arch-long}/positron-reh-${os}-${arch}-${version}.tar.gz`. These variables are replaced when the URL is built:\n- `${quality}`: server quality, for example `stable` or `dailies`\n- `${version}`: server version, for example `2024.10.0-123`\n- `${commit}`: server release commit\n- `${os}`: server operating system, for example `linux`, `darwin`, or `win32`\n- `${arch}`: server architecture, for example `x64`, `armhf`, or `arm64`\n- `${arch-long}`: server architecture in long form, for example `x86_64` or `arm64`")
 			}
 		}
 	});

--- a/src/vs/workbench/contrib/remote/common/remote.contribution.ts
+++ b/src/vs/workbench/contrib/remote/common/remote.contribution.ts
@@ -28,6 +28,9 @@ import { DownloadServiceChannel } from '../../../../platform/download/common/dow
 import { RemoteLoggerChannelClient } from '../../../../platform/log/common/logIpc.js';
 import { REMOTE_DEFAULT_IF_LOCAL_EXTENSIONS } from '../../../../platform/remote/common/remote.js';
 import product from '../../../../platform/product/common/product.js';
+// --- Start Positron ---
+import './positronRemoteConfiguration.js';
+// --- End Positron ---
 
 
 const EXTENSION_IDENTIFIER_PATTERN = '([a-z0-9A-Z][a-z0-9-A-Z]*)\\.([a-z0-9A-Z][a-z0-9-A-Z]*)$';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,8 @@ export default defineConfig({
 		include: [
 			'src/vs/**/*.vitest.{ts,tsx}',
 			'src/*.vitest.{ts,tsx}',
-			'test/e2e/**/*.vitest.{ts,tsx}'
+			'test/e2e/**/*.vitest.{ts,tsx}',
+			'extensions/**/*.vitest.{ts,tsx}'
 		],
 		environment: 'happy-dom',
 		globals: true,

--- a/vitest.tsconfig.json
+++ b/vitest.tsconfig.json
@@ -27,6 +27,10 @@
 		// plain TypeScript with no workbench dependencies. Without these the
 		// type check silently skips them.
 		"test/e2e/**/*.vitest.ts",
+		// Vitest tests for built-in extension modules. Like the e2e helpers, these
+		// cover plain TypeScript with no workbench and no `vscode` dependencies.
+		"extensions/**/*.vitest.ts",
+		"extensions/**/*.vitest.tsx",
 		// Add files from the base tsconfig that we need for Vitest tests
 		"src/typings",
 		"src/positron-dts/positron.d.ts",


### PR DESCRIPTION
There's no rush on this; it's fine to wait to review/merge until after we branch.

Fixes #11020

The SSH, WSL, and Dev Containers extensions each declared their own "Download URL" setting. All three had the same purpose and the same default, which also duplicated `serverDownloadUrlTemplate` in `product.json`. Typing "Download URL" in the Settings editor showed three entries, and it was easy to set the wrong one.

This adds a single setting, `remote.serverDownloadUrlTemplate`, and reads it from all three extensions. It is registered in core rather than by one of the extensions, so it exists whether or not a given remote extension is enabled. The key sits in the `remote.*` namespace, so the Settings editor groups it with the other remote settings:

<img width="931" height="716" alt="Screenshot 2026-09-01 at 3 17 19 PM" src="https://github.com/user-attachments/assets/9def5618-f219-4728-af8c-4a1c73acafe9" />

Its default is the empty string, not the CDN URL. An empty value means "not set", which is what lets a local or dev build fall through to `product.json` and download a server that matches it.

The three per-extension settings are deprecated but still work, and take precedence when set, so nobody loses the behavior they configured:

<img width="914" height="495" alt="Screenshot 2026-09-01 at 3 46 18 PM" src="https://github.com/user-attachments/assets/52978289-113f-452f-a524-16832d10661b" />

The Settings editor hides a deprecated setting until it has a value, so a fresh profile now shows one entry instead of three.

Two implementation notes:

- Both settings are read with `inspect()` rather than `get()`. The deprecated settings ship a non-empty default, so `get()` cannot tell "the user asked for the CDN URL" apart from "the user asked for nothing", and only the second case may fall through to `product.json`.
- That fall-through was unreachable before this change. `get()` always returned the manifest default, so for SSH and WSL neither `product.json` nor `DEFAULT_DOWNLOAD_URL_TEMPLATE` was ever consulted. Both are reachable now, which is why `serverSetup.ts` is touched. Those two hardcoded defaults pinned the quality to `dailies`, and they now match the manifest defaults they stand in for. Dev Containers gains the `product.json` step, which it never had.

The extensions cannot import from each other or from `src/vs`, so the resolution helper is copied into each one. A test asserts the copies stay identical and that the key they spell out still matches the one core registers.

This branch also enables Vitest for `extensions/**`, which is what makes the helper testable at all, in a separate commit. Adding a test inside an extension requires excluding it from that extension's build, or it ships inside the extension with an unresolvable `vitest` import. That is documented in `.claude/rules/vitest-tests.md` and in the author-vitest-tests skill.

### Release Notes

#### New Features

- Added a single Download URL setting, `remote.serverDownloadUrlTemplate`, shared by the SSH, WSL, and Dev Containers extensions. The three per-extension settings are deprecated, and still take precedence where they are already set. (#11020)

#### Bug Fixes

- N/A

### Validation Steps

@:remote-ssh @:remote-wsl

The WSL suite already sets the deprecated `remote.WSL.serverDownloadUrlTemplate`, so it exercises the precedence rule directly. Dev Containers has no e2e tag, so that call site is covered by unit tests and manual checks only.

#### Manual validation with a local Docker container

This verifies which URL is actually requested. A dev build is the right harness, because its `product.json` has no `quality` or `commit`, so the default URL is unreachable. That is the problem this setting exists to solve!

1. Build the image and start a container, from a checkout of `positron-builds`:

    ```bash
    docker build -t remotessh -f dev/remote-ssh/Dockerfile --build-arg NODE_VERSION=$(cat ../positron/.nvmrc) .
    docker run -d --name remotessh -p 3456:22 remotessh
    ```

2. Install your public key. Use `docker cp` rather than `ssh-copy-id` to skip the password prompts, then fix the owner, because `docker cp` keeps your host UID and sshd refuses a file it does not own:

    ```bash
    docker exec remotessh mkdir -p /root/.ssh
    docker cp ~/.ssh/id_ed25519.pub remotessh:/root/.ssh/authorized_keys
    docker exec remotessh chown -R root:root /root/.ssh
    docker exec remotessh chmod 600 /root/.ssh/authorized_keys
    ```

    Add a `dock` host to your `~/.ssh/config` (`User root`, `Hostname localhost`, `Port 3456`), then confirm `ssh dock` works. If you have used this container before, clear the stale host keys first with `ssh-keygen -R "[localhost]:3456"`.

3. Make sure `~/.positron-server` does not exist in the container, so a download is attempted:

    ```bash
    docker exec remotessh ls -d /root/.positron-server   # expect "No such file or directory"
    ```

4. Log the requested URL. The extension writes the install script to the **Remote - SSH** output channel, which is UI only, so a shim in the container gives a record you can read directly:

    ```bash
    docker exec remotessh sh -c 'mv /usr/bin/wget /usr/bin/wget.real; \
      printf "#!/bin/sh\nprintf \"%%s\\\\n\" \"\$*\" >> /tmp/download-urls.log\nexec /usr/bin/wget.real \"\$@\"\n" > /usr/bin/wget; \
      chmod +x /usr/bin/wget'
    ```

5. Run each case below in a dev build. Both keys are application-scoped, so they go in the dev build's user settings (`~/.vscode-oss-dev/User/settings.json`), not workspace settings. For each one, run _Remote-SSH: Connect to Host..._ and choose `dock`, then read `/tmp/download-urls.log` with `docker exec remotessh cat /tmp/download-urls.log`.

| Case | Settings | Expected URL |
|---|---|---|
| 1 | neither key set | `https://cdn.posit.co/positron/undefined/reh/arm64/positron-reh-linux-arm64-<version>.tar.gz` |
| 2 | `remote.serverDownloadUrlTemplate` only | `https://unified.test/linux-arm64.tar.gz` |
| 3 | both, with distinct hosts | `https://legacy.test/linux-arm64.tar.gz` |
| 4 | deprecated key removed, unified set to `""` | the case 1 URL again |

Use `https://unified.test/${os}-${arch}.tar.gz` and `https://legacy.test/${os}-${arch}.tar.gz` as the values, so you can tell which key won and so the template variables are visibly substituted.

What to expect:

- The literal `undefined` in the case 1 URL is correct, not a typo. A dev build has no `quality` in `product.json`. 
- Every case fails to connect, with `There is no available Positron server with version <version> for linux aarch64`. That is expected here! The download is after the part under test, and the message reports the version rather than the URL, so it looks identical in all four cases. Read the log, and don't be worried about the error.
- Case 3 needs the deprecated key typed into `settings.json` by hand, because it is now hidden in the Settings editor until it has a value. That behavior is worth confirming while you are there, along with the strikethrough and the deprecation notice once it is set.

Tear down with `docker rm -f remotessh`.
