### PR TITLE
Stop the Redshift suite expanding a schema level the tree now hides

### DIFF
--- a/test/e2e/tests/data-connections/redshift.test.ts
+++ b/test/e2e/tests/data-connections/redshift.test.ts
@@ -105,8 +105,9 @@ test.describe('Data Connections - Redshift', {
 			await dataConnections.expandConnection(connectionName);
 			await dataConnections.expandNode('Databases');
 			await dataConnections.expandNode(detailDatabase, 'database');
-			await dataConnections.expandNode('Schemas');
-			await dataConnections.expandNode('public');
+			// The flights database has a single schema, which the tree hides by default, so Tables
+			// and Views sit directly under the database and there is no 'Schemas' or 'public' row to
+			// expand. The Databases group above keeps its row, since dev is there alongside flights.
 			await dataConnections.expandNode('Tables');
 			await dataConnections.expandNode('Views');
 		});


### PR DESCRIPTION
Follow-up to #15859, which is merged. That PR changed the Data Connections tree to hide a connection's schema level when there is only one schema, behind the `dataConnections.tree.showSingleSchema` opt-in. It updated the DuckDB and Postgres e2e specs for the new default but missed the Redshift one, which failed on the next run.

The Redshift suite's `beforeAll` walked `Databases > flights > Schemas > public > Tables > Views`. The test cluster's `flights` database holds a single `public` schema (the driver filters `pg_catalog`, `information_schema`, and friends out of the schema list), so both the `Schemas` group row and the `public` row are now gone, and `expandNode('Schemas')` timed out looking for a row the tree no longer renders. The failure surfaced on `Displays the table, columns, and their types in the tree`, but the broken step was the shared setup, so every test in the suite was affected.

This is a test-only change: the two `expandNode` calls come out and `Tables` is expanded directly under the `flights` database. No product code is touched.

The `Databases` group above it is deliberately left alone. It holds `dev` alongside `flights`, so it has more than one child and keeps its own row.

I checked the other two schema-bearing cloud specs and neither needs the same change:

- **Snowflake** runs `SHOW TERSE SCHEMAS IN DATABASE` with no filtering, and lists `INFORMATION_SCHEMA` along with everything else, so `FINANCIAL__ECONOMIC_ESSENTIALS` has two schemas and the group survives.
- **Databricks** browses the read-only `samples` catalog, which carries several schemas (`accuweather`, `nyctaxi`, `tpch`, and its Unity Catalog `information_schema`).

`sqlite` and the ODBC-backed connections have no schema tier to hide, and `pins-remote` navigates `owner` and `pin` kinds, which are not breadcrumb kinds.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

@:connections

The tag has to be added by hand here. `test-tag-paths-map.json` maps source directories to tags, not `test/e2e/tests/`, so a PR that only edits a spec file derives no tags and would otherwise run none of these tests.

The Redshift suite skips itself when `REDSHIFT_TEST_HOST` is unset, so this can only be verified on a rig with the cluster credentials. Worth confirming the whole `@:connections` set is green rather than just Redshift, since the same default is what the DuckDB and Postgres specs were already updated for.
