### PR TITLE
e2e: drop the schema tier from the Redshift connections test

### DIFF
--- a/test/e2e/tests/data-connections/redshift.test.ts
+++ b/test/e2e/tests/data-connections/redshift.test.ts
@@ -105,8 +105,8 @@ test.describe('Data Connections - Redshift', {
 			await dataConnections.expandConnection(connectionName);
 			await dataConnections.expandNode('Databases');
 			await dataConnections.expandNode(detailDatabase, 'database');
-			await dataConnections.expandNode('Schemas');
-			await dataConnections.expandNode('public');
+			// The flights database has a single schema, which the tree hides by default, so Tables and
+			// Views sit directly under the database and there is no 'Schemas' or 'public' row to expand.
 			await dataConnections.expandNode('Tables');
 			await dataConnections.expandNode('Views');
 		});


### PR DESCRIPTION
Fixes the `Data Connections - Redshift` e2e suite, which has been failing in the daily build since #15859.

#15859 intentionally removed the lone-schema tier from the Data Connections tree: with `dataConnections.tree.showSingleSchema` off (the default), a schema with no siblings is dropped entirely -- no `Schemas` group row and no schema row -- and its `Tables` and `Views` stand directly under the database that holds it. The test cluster's `flights` database has a single `public` schema, so the suite's `beforeAll` fails at `expandNode('Schemas')` with "element(s) not found" and takes all three tests down with it.

That PR updated the two suites it could run in PR CI (postgres, duckdb) and missed this one. Redshift needs a Tailscale-reachable serverless workgroup plus the `REDSHIFT_TEST_*` secrets, so it only runs in the daily build -- see [the 2026-09-02 daily run](https://github.com/posit-dev/positron-builds/actions/runs/33603021424). Snowflake and Databricks keep their `Schemas` expands on purpose; those clusters have several schemas, so the group row stays.

Test-only change: the two `expandNode` calls for `Schemas` and `public` are replaced with a comment matching the wording already used in the postgres and duckdb suites.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A (test-only change)

### Validation Steps

@:connections

This suite skips itself unless `REDSHIFT_TEST_HOST` is set, and the endpoint is only reachable over Tailscale, so it will not exercise the fix in ordinary PR CI. To confirm it locally with `.env.e2e` populated and Tailscale up:

```bash
npx playwright test test/e2e/tests/data-connections/redshift.test.ts --project e2e-electron
```

Expect all three tests to pass, with the tree expanding `redshift > Databases > flights > Tables` without a schema row in between.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
