### PR TITLE
Add large-package-library tests for the Packages pane (#12994)

### DIFF
--- a/src/vs/test/vitest/stubGridLayout.ts
+++ b/src/vs/test/vitest/stubGridLayout.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { stubInterface } from './stubInterface.js';
+
+/**
+ * The Positron data grid (and everything built on it: PositronList, PositronTree,
+ * the packages pane) sizes itself from the DOM via requestAnimationFrame +
+ * ResizeObserver. Neither produces a real layout in happy-dom, so neutralize
+ * them and drive the size explicitly with `instance.setSize`. Stubbing rAF to a
+ * no-op also stops a late frame from resetting that size to 0.
+ *
+ * Callers must pair this with `vi.unstubAllGlobals()` in `afterEach`.
+ */
+export function stubGridLayout(): void {
+	vi.stubGlobal('requestAnimationFrame', () => 0);
+	vi.stubGlobal('ResizeObserver', class {
+		observe() { }
+		unobserve() { }
+		disconnect() { }
+	});
+}
+
+/**
+ * Like {@link stubGridLayout}, but for tests that assert on rendered rows rather
+ * than instance state: the data grid only paints the rows that fit its *local*
+ * height, which it learns from the DOM. happy-dom reports 0 for every
+ * measurement, so this gives elements a real offset size and hands that size to
+ * the grid synchronously via a ResizeObserver that fires on observe(), so the
+ * rows paint during render.
+ *
+ * @returns A restore function for the offset overrides; callers must invoke it
+ * (typically in `afterEach`) and also call `vi.unstubAllGlobals()`.
+ */
+export function stubGridLayoutWithSize(width: number, height: number): () => void {
+	const offsetWidthDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth');
+	const offsetHeightDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight');
+	Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { configurable: true, get: () => width });
+	Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, get: () => height });
+
+	// rAF stays a no-op; the size instead arrives from the ResizeObserver below.
+	vi.stubGlobal('requestAnimationFrame', () => 0);
+	vi.stubGlobal('ResizeObserver', class {
+		private readonly _callback: ResizeObserverCallback;
+		constructor(callback: ResizeObserverCallback) { this._callback = callback; }
+		observe() {
+			// Report the stubbed size immediately so the grid sizes itself during render. The grid
+			// only reads contentRect, so the rest of the entry throws if it is ever read.
+			const entry = stubInterface<ResizeObserverEntry>({
+				contentRect: stubInterface<DOMRectReadOnly>({ width, height }),
+			});
+			this._callback([entry], this);
+		}
+		unobserve() { }
+		disconnect() { }
+	});
+
+	return () => {
+		Object.defineProperty(HTMLElement.prototype, 'offsetWidth', offsetWidthDescriptor!);
+		Object.defineProperty(HTMLElement.prototype, 'offsetHeight', offsetHeightDescriptor!);
+	};
+}

--- a/src/vs/workbench/browser/positronDataGrid/test/browser/positronDataGrid.vitest.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/test/browser/positronDataGrid.vitest.tsx
@@ -9,9 +9,9 @@
 import { act, screen } from '@testing-library/react';
 
 // Other dependencies.
-import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubGridLayoutWithSize } from '../../../../../test/vitest/stubGridLayout.js';
 import { PositronDataGrid } from '../../positronDataGrid.js';
 import { DataGridInstance } from '../../classes/dataGridInstance.js';
 
@@ -32,42 +32,6 @@ const HORIZONTAL_SCROLL_OFFSET = 150;
 
 // Scrolls the unpinned rows so that row 2 lands at top: 10, 10px inside a one-row (20px) band.
 const VERTICAL_SCROLL_OFFSET = 30;
-
-/**
- * The data grid sizes itself from the DOM via requestAnimationFrame + ResizeObserver. Neither
- * produces a real layout in happy-dom, and the grid only paints the rows and columns that fit its
- * *local* size, so this gives elements a real offset size and hands that size to the grid
- * synchronously via a ResizeObserver that fires on observe(). Returns a restore function for the
- * offset overrides; callers must also call vi.unstubAllGlobals().
- */
-function stubGridLayoutWithSize(width: number, height: number): () => void {
-	const offsetWidthDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth');
-	const offsetHeightDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight');
-	Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { configurable: true, get: () => width });
-	Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, get: () => height });
-
-	// rAF stays a no-op; the size instead arrives from the ResizeObserver below.
-	vi.stubGlobal('requestAnimationFrame', () => 0);
-	vi.stubGlobal('ResizeObserver', class {
-		private readonly _callback: ResizeObserverCallback;
-		constructor(callback: ResizeObserverCallback) { this._callback = callback; }
-		observe() {
-			// Report the stubbed size immediately so the grid sizes itself during render. The grid
-			// only reads contentRect, so the rest of the entry throws if it is ever read.
-			const entry = stubInterface<ResizeObserverEntry>({
-				contentRect: stubInterface<DOMRectReadOnly>({ width, height }),
-			});
-			this._callback([entry], this);
-		}
-		unobserve() { }
-		disconnect() { }
-	});
-
-	return () => {
-		Object.defineProperty(HTMLElement.prototype, 'offsetWidth', offsetWidthDescriptor!);
-		Object.defineProperty(HTMLElement.prototype, 'offsetHeight', offsetHeightDescriptor!);
-	};
-}
 
 /**
  * A minimal concrete data grid instance. Column and row pinning are enabled, and headers are off so

--- a/src/vs/workbench/browser/positronList/test/browser/positronList.vitest.tsx
+++ b/src/vs/workbench/browser/positronList/test/browser/positronList.vitest.tsx
@@ -15,6 +15,7 @@ import { isMacintosh } from '../../../../../base/common/platform.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubGridLayout, stubGridLayoutWithSize } from '../../../../../test/vitest/stubGridLayout.js';
 import { PositronList } from '../../positronList.js';
 import { ListEntry, PositronListInstance } from '../../classes/positronListInstance.js';
 
@@ -28,55 +29,6 @@ const VIEWPORT_HEIGHT = 100;
 
 // A viewport tall enough to render a handful of rows at once, for the rendering assertions.
 const TALL_VIEWPORT_HEIGHT = 400;
-
-/**
- * The data grid sizes itself from the DOM via requestAnimationFrame + ResizeObserver. Neither
- * produces a real layout in happy-dom, so neutralize them and drive the size explicitly with
- * instance.setSize. Stubbing rAF to a no-op also stops a late frame from resetting that size to 0.
- * Callers must pair this with vi.unstubAllGlobals() in afterEach.
- */
-function stubGridLayout() {
-	vi.stubGlobal('requestAnimationFrame', () => 0);
-	vi.stubGlobal('ResizeObserver', class {
-		observe() { }
-		unobserve() { }
-		disconnect() { }
-	});
-}
-
-/**
- * Like stubGridLayout, but for tests that assert on rendered rows rather than instance state:
- * the data grid only paints the rows that fit its *local* height, which it learns from the DOM.
- * happy-dom reports 0 for every measurement, so this gives elements a real offset size and hands
- * that size to the grid synchronously via a ResizeObserver that fires on observe(). Returns a
- * restore function for the offset overrides; callers must also call vi.unstubAllGlobals().
- */
-function stubGridLayoutWithSize(width: number, height: number): () => void {
-	const offsetWidthDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth');
-	const offsetHeightDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight');
-	Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { configurable: true, get: () => width });
-	Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, get: () => height });
-
-	// rAF stays a no-op; the size instead arrives from the ResizeObserver below.
-	vi.stubGlobal('requestAnimationFrame', () => 0);
-	vi.stubGlobal('ResizeObserver', class {
-		private readonly _callback: ResizeObserverCallback;
-		constructor(callback: ResizeObserverCallback) { this._callback = callback; }
-		observe() {
-			// Report the stubbed size immediately so the grid sizes itself during render.
-			// Minimal entry: the grid only reads contentRect's width/height.
-			const entry = { contentRect: { width, height } };
-			this._callback([entry] as unknown as ResizeObserverEntry[], this as unknown as ResizeObserver);
-		}
-		unobserve() { }
-		disconnect() { }
-	});
-
-	return () => {
-		Object.defineProperty(HTMLElement.prototype, 'offsetWidth', offsetWidthDescriptor!);
-		Object.defineProperty(HTMLElement.prototype, 'offsetHeight', offsetHeightDescriptor!);
-	};
-}
 
 /**
  * Builds a flat list of item entries (no sections), matching the gallery harness's flat mode.

--- a/src/vs/workbench/browser/positronTree/test/browser/positronTree.vitest.tsx
+++ b/src/vs/workbench/browser/positronTree/test/browser/positronTree.vitest.tsx
@@ -15,6 +15,7 @@ import { isMacintosh } from '../../../../../base/common/platform.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubGridLayout, stubGridLayoutWithSize } from '../../../../../test/vitest/stubGridLayout.js';
 import { PositronTree } from '../../positronTree.js';
 import { TreeNode } from '../../classes/treeNode.js';
 import { PositronTreeInstance } from '../../classes/positronTreeInstance.js';
@@ -48,51 +49,6 @@ function branch(id: string): TreeNode<DemoNode> {
  */
 function jumpChord(key: 'Home' | 'End'): string {
 	return isMacintosh ? `{Meta>}{${key}}{/Meta}` : `{Control>}{${key}}{/Control}`;
-}
-
-/**
- * Neutralizes the data grid's DOM-driven sizing for tests that assert on instance state (not
- * rendered rows): happy-dom produces no real layout, so the size is driven explicitly with
- * instance.setSize instead. Pair with vi.unstubAllGlobals() in afterEach.
- */
-function stubGridLayout() {
-	vi.stubGlobal('requestAnimationFrame', () => 0);
-	vi.stubGlobal('ResizeObserver', class {
-		observe() { }
-		unobserve() { }
-		disconnect() { }
-	});
-}
-
-/**
- * Like stubGridLayout, but for tests that assert on rendered rows: the data grid only paints the
- * rows that fit its *local* height, which it learns from the DOM. This gives elements a real
- * offset size and hands it to the grid synchronously via a ResizeObserver that fires on observe().
- * Returns a restore function for the offset overrides; callers must also call vi.unstubAllGlobals().
- */
-function stubGridLayoutWithSize(width: number, height: number): () => void {
-	const offsetWidthDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth');
-	const offsetHeightDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight');
-	Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { configurable: true, get: () => width });
-	Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, get: () => height });
-
-	vi.stubGlobal('requestAnimationFrame', () => 0);
-	vi.stubGlobal('ResizeObserver', class {
-		private readonly _callback: ResizeObserverCallback;
-		constructor(callback: ResizeObserverCallback) { this._callback = callback; }
-		observe() {
-			// Minimal entry: the grid only reads contentRect's width/height.
-			const entry = { contentRect: { width, height } };
-			this._callback([entry] as unknown as ResizeObserverEntry[], this as unknown as ResizeObserver);
-		}
-		unobserve() { }
-		disconnect() { }
-	});
-
-	return () => {
-		Object.defineProperty(HTMLElement.prototype, 'offsetWidth', offsetWidthDescriptor!);
-		Object.defineProperty(HTMLElement.prototype, 'offsetHeight', offsetHeightDescriptor!);
-	};
 }
 
 // A viewport tall enough to render a handful of rows at once, for the rendering assertions.

--- a/src/vs/workbench/contrib/positronPackages/test/browser/listPackages.vitest.tsx
+++ b/src/vs/workbench/contrib/positronPackages/test/browser/listPackages.vitest.tsx
@@ -5,12 +5,9 @@
 
 /// <reference types="vitest/globals" />
 
-// React.
-import React from 'react';
-
 // Testing libraries.
 import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { userEvent } from '@testing-library/user-event';
 
 // Other dependencies.
 import { Emitter, Event } from '../../../../../base/common/event.js';
@@ -19,6 +16,7 @@ import { IReactComponentContainer } from '../../../../../base/browser/positronRe
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubGridLayoutWithSize } from '../../../../../test/vitest/stubGridLayout.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { IContextMenuService } from '../../../../../platform/contextview/browser/contextView.js';
 import { ILanguageRuntimePackage } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
@@ -44,37 +42,6 @@ const pkg = (name: string, version: string): ILanguageRuntimePackage => ({
 	displayName: name,
 	version,
 });
-
-/**
- * The data grid sizes itself from the DOM via requestAnimationFrame + ResizeObserver, neither of
- * which produces a real layout in happy-dom. Give elements a concrete offset size and hand that
- * size to the grid synchronously through a ResizeObserver that fires on observe(), so the rows
- * paint during render. Mirrors the helper in positronList.vitest.tsx. Returns a restore function
- * for the offset overrides; callers must also call vi.unstubAllGlobals().
- */
-function stubGridLayoutWithSize(width: number, height: number): () => void {
-	const offsetWidthDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth');
-	const offsetHeightDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight');
-	Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { configurable: true, get: () => width });
-	Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, get: () => height });
-
-	vi.stubGlobal('requestAnimationFrame', () => 0);
-	vi.stubGlobal('ResizeObserver', class {
-		private readonly _callback: ResizeObserverCallback;
-		constructor(callback: ResizeObserverCallback) { this._callback = callback; }
-		observe() {
-			const entry = { contentRect: { width, height } };
-			this._callback([entry] as unknown as ResizeObserverEntry[], this as unknown as ResizeObserver);
-		}
-		unobserve() { }
-		disconnect() { }
-	});
-
-	return () => {
-		Object.defineProperty(HTMLElement.prototype, 'offsetWidth', offsetWidthDescriptor!);
-		Object.defineProperty(HTMLElement.prototype, 'offsetHeight', offsetHeightDescriptor!);
-	};
-}
 
 describe('ListPackages', () => {
 	// Emitters live at describe scope so the .stub() below captures their .event during build();

--- a/src/vs/workbench/contrib/positronPackages/test/browser/listPackagesLargeLibrary.vitest.tsx
+++ b/src/vs/workbench/contrib/positronPackages/test/browser/listPackagesLargeLibrary.vitest.tsx
@@ -1,0 +1,146 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+// Testing libraries.
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+
+// Other dependencies.
+import { Event } from '../../../../../base/common/event.js';
+import { isMacintosh } from '../../../../../base/common/platform.js';
+import { IReactComponentContainer } from '../../../../../base/browser/positronReactRenderer.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubGridLayoutWithSize } from '../../../../../test/vitest/stubGridLayout.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { ILanguageRuntimePackage } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
+import { ListPackages } from '../../browser/components/listPackages.js';
+import { PositronPackagesContextProvider } from '../../browser/positronPackagesContext.js';
+import { IPositronPackagesService } from '../../browser/interfaces/positronPackagesService.js';
+import { IPositronPackagesInstance } from '../../browser/positronPackagesInstance.js';
+
+// A large library on the scale the packages pane has to stay usable at
+// (posit-dev/positron#12994): a base R install plus Bioconductor, or a heavyweight
+// Python environment, lands in the low thousands.
+const PACKAGE_COUNT = 5000;
+
+const VIEWPORT_WIDTH = 300;
+const VIEWPORT_HEIGHT = 400;
+
+// Matches ROW_ITEM_HEIGHT in listPackages.tsx: the harness renders in 'row' mode,
+// so a correct virtualization mounts about VIEWPORT_HEIGHT / 26 rows plus overscan.
+const ROW_ITEM_HEIGHT = 26;
+
+// Generous ceiling for "the DOM stays bounded": several times the visible window,
+// far below the full library. A virtualization regression mounts thousands.
+const MOUNTED_ROW_CEILING = 100;
+
+/**
+ * `pkg-0000` ... `pkg-4999`. Zero-padded so a filter query can target exactly one
+ * package, and so the name regex below can't match a version string.
+ */
+const largeLibrary: ILanguageRuntimePackage[] = Array.from({ length: PACKAGE_COUNT }, (_, i) => {
+	const name = `pkg-${String(i).padStart(4, '0')}`;
+	return { id: name, name, displayName: name, version: '1.0.0' };
+});
+
+const FIRST_PACKAGE = 'pkg-0000';
+const LAST_PACKAGE = `pkg-${String(PACKAGE_COUNT - 1).padStart(4, '0')}`;
+
+/** Every mounted package row, identified by its unique name text. */
+const mountedNames = () => screen.getAllByText(/^pkg-\d{4}$/).map(el => el.textContent);
+
+describe('ListPackages with a large library', () => {
+	// These tests never push a refresh or change event; the static 5,000-package
+	// list is the whole scenario.
+	const fakeInstance = stubInterface<IPositronPackagesInstance>({
+		packages: largeLibrary,
+		attachRuntime: () => { },
+		detachRuntime: () => { },
+		onDidRefreshPackagesInstance: Event.None,
+		onDidChangePackages: Event.None,
+	});
+
+	const ctx = createTestContainer()
+		.withReactServices()
+		.stub(IPositronPackagesService, {
+			activePackagesInstance: fakeInstance,
+			onDidChangeActivePackagesInstance: Event.None,
+			// Row mode: the densest layout, so the viewport shows the most rows a
+			// virtualization bound has to allow for.
+			itemSize: 'row',
+			onDidChangeItemSize: Event.None,
+			setSelectedPackage: vi.fn(),
+		})
+		// Selecting a package fires the (fire-and-forget) 'positronPackages.openPackage'
+		// command; stub it so row selection doesn't emit unhandled rejections.
+		.stub(ICommandService, { executeCommand: vi.fn() })
+		.build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
+
+	const reactComponentContainer = stubInterface<IReactComponentContainer>({});
+
+	let restoreLayout: (() => void) | undefined;
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		restoreLayout?.();
+		restoreLayout = undefined;
+	});
+
+	async function renderList() {
+		restoreLayout = stubGridLayoutWithSize(VIEWPORT_WIDTH, VIEWPORT_HEIGHT);
+		rtl.render(
+			<PositronPackagesContextProvider reactComponentContainer={reactComponentContainer}>
+				<ListPackages height={VIEWPORT_HEIGHT} reactComponentContainer={reactComponentContainer} width={VIEWPORT_WIDTH} />
+			</PositronPackagesContextProvider>
+		);
+		expect(await screen.findByText(FIRST_PACKAGE)).toBeInTheDocument();
+	}
+
+	it('mounts only the visible window of rows, not the whole library', async () => {
+		await renderList();
+
+		const names = mountedNames();
+		// The window is filled: at 26px rows a 400px viewport shows ~15 packages.
+		expect(names.length).toBeGreaterThanOrEqual(Math.floor(VIEWPORT_HEIGHT / ROW_ITEM_HEIGHT));
+		// ...and bounded: mounting anywhere near PACKAGE_COUNT rows is the
+		// regression this file exists to catch.
+		expect(names.length).toBeLessThan(MOUNTED_ROW_CEILING);
+		expect(screen.queryByText(LAST_PACKAGE)).not.toBeInTheDocument();
+	});
+
+	it('Cmd/Ctrl+End reaches and renders the last package', async () => {
+		await renderList();
+
+		// The jump chord is Cmd on macOS and Ctrl elsewhere (see dataGridWaffle.tsx).
+		// eslint-disable-next-line testing-library/prefer-user-event -- user.keyboard targets document.activeElement, and the virtualized grid takes no real DOM focus in happy-dom; the keydown bubbles from the row to the grid's handler, as it does in listPackages.vitest.tsx.
+		fireEvent.keyDown(screen.getByText(FIRST_PACKAGE), {
+			key: 'End',
+			code: 'End',
+			metaKey: isMacintosh,
+			ctrlKey: !isMacintosh,
+		});
+
+		// The window slid to the end of the library: the last package is mounted,
+		// the first is not, and the DOM stayed bounded through the jump.
+		await waitFor(() => expect(screen.getByText(LAST_PACKAGE)).toBeInTheDocument());
+		expect(screen.queryByText(FIRST_PACKAGE)).not.toBeInTheDocument();
+		expect(mountedNames().length).toBeLessThan(MOUNTED_ROW_CEILING);
+	});
+
+	it('filters the library down to the matching row', async () => {
+		const user = userEvent.setup();
+		await renderList();
+
+		// Targets exactly one of the 5,000 names (300ms debounce before it applies).
+		await user.type(screen.getByPlaceholderText('Filter packages'), LAST_PACKAGE);
+
+		await waitFor(() => expect(screen.getByText(LAST_PACKAGE)).toBeInTheDocument());
+		expect(mountedNames()).toEqual([LAST_PACKAGE]);
+	});
+});

--- a/src/vs/workbench/contrib/positronPackages/test/browser/packageDetail.vitest.tsx
+++ b/src/vs/workbench/contrib/positronPackages/test/browser/packageDetail.vitest.tsx
@@ -5,9 +5,8 @@
 
 /// <reference types="vitest/globals" />
 
-import React from 'react';
 import { act, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { userEvent } from '@testing-library/user-event';
 import { Emitter } from '../../../../../base/common/event.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { ILanguageRuntimePackage, IRuntimeSessionMetadata, ILanguageRuntimeSession } from '../../../../services/runtimeSession/common/runtimeSessionService.js';

--- a/src/vs/workbench/contrib/positronPackages/test/browser/positronPackagesInstance.vitest.ts
+++ b/src/vs/workbench/contrib/positronPackages/test/browser/positronPackagesInstance.vitest.ts
@@ -233,6 +233,74 @@ describe('PositronPackagesInstance disk-cache integration', () => {
 		});
 	});
 
+	it('serves a second session of the same interpreter from the shared cache without refetching metadata', async () => {
+		// Both sources answer fully in the first session's round, so every entry
+		// is covered: outdated state plus an advisory answer for each package.
+		getVulnerabilities.mockResolvedValue(lookupResult([['numpy', [ADVISORY]], ['pandas', []]]));
+
+		const first = makeInstance();
+		const firstFires = waitForEvents(first.onDidRefreshPackagesInstance, 2);
+		await first.refreshPackages();
+		await firstFires;
+
+		// A second console for the same interpreter: a new session id but the same
+		// runtime id and the same shared cache (the packages service threads one
+		// cache into every instance). The per-console cost #12994 worries about
+		// is the repository round trip; the kernel-side list stays per-session.
+		const session2 = stubInterface<ILanguageRuntimeSession>({
+			sessionId: 'session-2',
+			runtimeMetadata: stubInterface<ILanguageRuntimeMetadata>({ runtimeId: RUNTIME_ID, languageId: 'python' }),
+			getRuntimeState: () => RuntimeState.Uninitialized,
+			onDidChangeRuntimeState: Event.None,
+			getPackageManager: () => packageManager,
+		});
+		const second = disposables.add(new PositronPackagesInstance(session2, new NullLogService(), cache, vulnerabilityLookup));
+		const secondFires = waitForEvents(second.onDidRefreshPackagesInstance, 2);
+		await second.refreshPackages();
+		const [stage1] = await secondFires;
+
+		// Give a microtask for any (incorrectly issued) refetch to run.
+		await new Promise(resolve => setTimeout(resolve, 10));
+
+		// The kernel list is read once per session; the metadata round trips
+		// happened once per interpreter.
+		expect(getPackages).toHaveBeenCalledTimes(2);
+		expect(getPackageMetadata).toHaveBeenCalledTimes(1);
+		expect(getVulnerabilities).toHaveBeenCalledTimes(1);
+		// And the second console renders the shared metadata immediately, in its
+		// very first (Stage 1) push.
+		expect(stage1.find(p => p.name === 'numpy')).toMatchObject({
+			outdated: true,
+			latestVersion: '2.1.0',
+			vulnerabilities: [ADVISORY],
+		});
+	});
+
+	it('fetches metadata for a large library in one batched call per source', async () => {
+		// #12994 scale: thousands of installed packages. The instance must hand
+		// each source the whole list at once -- one kernel metadata call and one
+		// lookup invocation -- rather than degrading to per-package calls.
+		const largeLibrary = Array.from({ length: 5000 }, (_, i) => pkg(`pkg-${i}`, '1.0.0'));
+		getPackages.mockResolvedValue(largeLibrary);
+		getPackageMetadata.mockImplementation(async (names) =>
+			new Map(names.map((name): [string, Partial<ILanguageRuntimePackage>] => [name, { outdated: true, latestVersion: '2.0.0' }])));
+		getVulnerabilities.mockResolvedValue(lookupResult(largeLibrary.map((p): [string, []] => [p.name, []])));
+
+		const instance = makeInstance();
+		const fires = waitForEvents(instance.onDidRefreshPackagesInstance, 2);
+		await instance.refreshPackages();
+		const [, stage2] = await fires;
+
+		expect(getPackageMetadata).toHaveBeenCalledTimes(1);
+		expect(getPackageMetadata.mock.calls[0][0]).toHaveLength(5000);
+		expect(getVulnerabilities).toHaveBeenCalledTimes(1);
+		expect(getVulnerabilities.mock.calls[0][2]).toHaveLength(5000);
+		// The merge covers the whole library, first row to last...
+		expect(stage2[4999]).toMatchObject({ name: 'pkg-4999', outdated: true, latestVersion: '2.0.0', vulnerabilities: [] });
+		// ...and the whole set persists, so the next session starts warm.
+		expect(Object.keys(cache.get(RUNTIME_ID)?.packages ?? {})).toHaveLength(5000);
+	});
+
 	it('merges both sources into one entry, and persists the advisory source', async () => {
 		// numpy is vulnerable; pandas is affirmatively clean ([]); a package the
 		// repository doesn't know at its installed version is absent from the

--- a/test/e2e/tests/packages-pane/packages-pane-large-library.test.ts
+++ b/test/e2e/tests/packages-pane/packages-pane-large-library.test.ts
@@ -1,0 +1,171 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { test as base, tags } from '../_test.setup';
+
+/**
+ * Packages pane with a large library (posit-dev/positron#12994).
+ *
+ * Rather than installing thousands of real packages, each test generates a
+ * synthetic library on disk and puts it on the session's package search path:
+ * both kernels discover packages from the filesystem, so everything downstream
+ * of the fixture -- kernel enumeration, the comm, the packages service, the
+ * virtualized pane -- is the real product code under a real 1,500-package load.
+ *
+ * - Python lists via `importlib.metadata.distributions()` (see ui.py), which
+ *   walks `sys.path`: a directory of minimal `*.dist-info` folders prepended to
+ *   `sys.path` reads as 1,500 installed distributions.
+ * - R lists via ark's `pkg_list` over `.libPaths()`: a library of stub packages
+ *   (DESCRIPTION plus a Meta/package.rds cloned from a real base package and
+ *   patched, so whatever fields the lister reads are present) prepended with
+ *   `.libPaths()` reads as 1,500 installed packages.
+ *
+ * The fixtures live only in this session's search path and a temp dir removed
+ * in afterAll, so nothing leaks into the machine's interpreters.
+ */
+
+const PACKAGE_COUNT = 1500;
+// pyfakepkg0000 .. / rfakepkg0000 ..; the names are prefixed per language so an
+// assertion can only be satisfied by its own session's library, and the *last*
+// one proves the full set traversed kernel -> comm -> service -> pane.
+const LAST_PY_PACKAGE = `pyfakepkg${String(PACKAGE_COUNT - 1).padStart(4, '0')}`;
+const LAST_R_PACKAGE = `rfakepkg${String(PACKAGE_COUNT - 1).padStart(4, '0')}`;
+// Printed by both generator scripts; the tests wait for it in the console
+// before refreshing the pane. executeCode can return before the submitted code
+// has started running (its ready-prompt check races the code submission), and a
+// refresh issued in that window lists the library as it was *before* the
+// fixtures existed.
+const READY_MARKER = 'biglib-ready';
+
+const test = base.extend<{}, {}>({
+	beforeApp: [
+		async ({ settingsFile }, use) => {
+			await settingsFile.append({ 'packages.enabled': true });
+			await use();
+		},
+		{ scope: 'worker' }
+	],
+});
+
+test.use({
+	suiteId: __filename
+});
+
+/** Writes the generator scripts for both languages; returns their paths. */
+function writeGeneratorScripts(fixtureDir: string): { pyScript: string; rScript: string } {
+	// Forward slashes work for both languages on every platform and avoid
+	// escaping trouble on Windows.
+	const dir = fixtureDir.replace(/\\/g, '/');
+
+	const pyScript = path.join(fixtureDir, 'generate-py-lib.py');
+	fs.writeFileSync(pyScript, [
+		'import os, sys',
+		`root = os.path.join("${dir}", "py-lib")`,
+		'os.makedirs(root, exist_ok=True)',
+		`for i in range(${PACKAGE_COUNT}):`,
+		'    name = "pyfakepkg%04d" % i',
+		'    d = os.path.join(root, "%s-1.0.0.dist-info" % name)',
+		'    os.makedirs(d, exist_ok=True)',
+		'    with open(os.path.join(d, "METADATA"), "w") as f:',
+		'        f.write("Metadata-Version: 2.1\\nName: %s\\nVersion: 1.0.0\\nSummary: Synthetic package for Positron e2e tests\\n" % name)',
+		'    with open(os.path.join(d, "RECORD"), "w") as f:',
+		'        pass',
+		'sys.path.insert(0, root)',
+		`print("${READY_MARKER}")`,
+		'',
+	].join('\n'));
+
+	const rScript = path.join(fixtureDir, 'generate-r-lib.R');
+	fs.writeFileSync(rScript, [
+		`root <- file.path("${dir}", "r-lib")`,
+		'dir.create(root, recursive = TRUE, showWarnings = FALSE)',
+		'# Clone a real installed package\'s Meta so every field the lister reads is present.',
+		'meta <- readRDS(file.path(find.package("stats"), "Meta", "package.rds"))',
+		`for (i in seq_len(${PACKAGE_COUNT}) - 1L) {`,
+		'  name <- sprintf("rfakepkg%04d", i)',
+		'  meta_dir <- file.path(root, name, "Meta")',
+		'  dir.create(meta_dir, recursive = TRUE, showWarnings = FALSE)',
+		'  desc <- c(Package = name, Version = "1.0.0",',
+		'            Title = "Synthetic package for Positron e2e tests",',
+		'            Description = "Generated fixture for positron issue 12994.",',
+		'            License = "MIT",',
+		'            Built = paste0("R ", getRversion(), "; ; ", format(Sys.time(), "%Y-%m-%d %H:%M:%S UTC"), "; unix"))',
+		'  writeLines(paste0(names(desc), ": ", desc), file.path(root, name, "DESCRIPTION"))',
+		'  pkg_meta <- meta',
+		'  pkg_meta$DESCRIPTION <- desc',
+		'  saveRDS(pkg_meta, file.path(meta_dir, "package.rds"))',
+		'}',
+		'.libPaths(c(root, .libPaths()))',
+		`cat("${READY_MARKER}\\n")`,
+		'',
+	].join('\n'));
+
+	return { pyScript, rScript };
+}
+
+test.describe('Packages Pane - Large Library', {
+	tag: [tags.PACKAGES_PANE, tags.WEB]
+}, () => {
+
+	let fixtureDir: string;
+	let pyScript: string;
+	let rScript: string;
+
+	test.beforeAll(async () => {
+		fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'positron-e2e-biglib-'));
+		({ pyScript, rScript } = writeGeneratorScripts(fixtureDir));
+	});
+
+	test.afterAll(async () => {
+		fs.rmSync(fixtureDir, { recursive: true, force: true });
+	});
+
+	test.afterEach(async function ({ app }) {
+		await app.workbench.packages.clearFilter();
+		await app.workbench.packages.closePackagesPane();
+	});
+
+	test('Python - Packages pane loads and filters a 1,500-package library',
+		async function ({ app, python: _python, executeCode }) {
+			const { console, packages } = app.workbench;
+
+			await executeCode('Python', `exec(open(${JSON.stringify(pyScript.replace(/\\/g, '/'))}).read())`);
+			// Only the generator's own output proves the fixtures exist; see READY_MARKER.
+			await console.waitForConsoleContents(READY_MARKER);
+
+			await packages.verifyPackagesList();
+			await packages.clickRefreshPackagesButton();
+
+			// The last synthetic package is reachable through the filter: the whole
+			// set made it from the kernel to the (virtualized) pane.
+			await packages.searchPackages(LAST_PY_PACKAGE);
+			await packages.expectPackageInList(LAST_PY_PACKAGE);
+
+			// And clearing the filter re-renders the full library.
+			await packages.clearFilter();
+			await packages.expectPackagesListPopulated();
+		});
+
+	test('R - Packages pane loads and filters a 1,500-package library',
+		async function ({ app, r: _r, executeCode }) {
+			const { console, packages } = app.workbench;
+
+			await executeCode('R', `source(${JSON.stringify(rScript.replace(/\\/g, '/'))})`);
+			// Only the generator's own output proves the fixtures exist; see READY_MARKER.
+			await console.waitForConsoleContents(READY_MARKER);
+
+			await packages.verifyPackagesList();
+			await packages.clickRefreshPackagesButton();
+
+			await packages.searchPackages(LAST_R_PACKAGE);
+			await packages.expectPackageInList(LAST_R_PACKAGE);
+
+			await packages.clearFilter();
+			await packages.expectPackagesListPopulated();
+		});
+});


### PR DESCRIPTION
Closes #12994. The one deliberately-uncovered angle (kernel-side enumeration blocking a session on a slow filesystem/NFS) is recorded in a closing comment on the issue for future reference.

### Summary

Adds tests at two levels for packages-pane behavior with 1,000+ installed packages:

**Vitest**
- New `listPackagesLargeLibrary.vitest.tsx`: with a 5,000-package library, the list mounts only the visible window of rows (virtualization guard), Cmd/Ctrl+End reaches and renders the last package, and filtering narrows to the matching row.
- `positronPackagesInstance.vitest.ts` (+2): a second session of the same interpreter is served from the shared metadata cache without refetching (the per-console-cost concern in the issue), and a 5,000-package refresh issues one batched metadata call per source, not per-package calls.
- Extracts the five verbatim copies of `stubGridLayoutWithSize` into a shared `src/vs/test/vitest/stubGridLayout.ts` and fixes pre-existing strict-TS errors (default `userEvent` import, unused React import) in two sibling test files.

**E2E**
- New `packages-pane-large-library.test.ts`: generates 1,500 synthetic packages in-session -- minimal `*.dist-info` dirs prepended to `sys.path` for Python; `DESCRIPTION` + `Meta/package.rds` stubs prepended with `.libPaths()` for R -- so the real kernel enumeration, comm, service, and virtualized pane all run under real load with no mocking and no machine pollution (fixtures live in a temp dir removed in `afterAll`). Each test loads the pane, filters to the last synthetic package, and clears the filter.
- The generator scripts print a `biglib-ready` marker the tests wait for in the console before refreshing: `executeCode` can return before the submitted code runs (its ready-prompt check races the code submission), and a refresh issued in that window lists the library as it was before the fixtures existed.

Deliberately no wall-clock perf assertions -- the DOM-mount bounds, batched-call counts, and default assertion timeouts are the CI-stable proxies.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

@:packages-pane

- `npx vitest run src/vs/workbench/contrib/positronPackages/test/browser/` (and the positronList/positronTree/positronDataGrid test files touched by the helper extraction)
- `npx playwright test test/e2e/tests/packages-pane/packages-pane-large-library.test.ts --project e2e-electron` -- locally green 6/6 across three runs (Python ~23s, R ~5s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
