### PR TITLE
Import Data: make the error dialog skinnier

### DIFF
--- a/src/vs/workbench/browser/positronModalDialogs/importDataModalDialog.tsx
+++ b/src/vs/workbench/browser/positronModalDialogs/importDataModalDialog.tsx
@@ -32,6 +32,10 @@ import { IDataImporter, IDataImportOptions, IDataImportResult, IDataImportView }
 // package sidebar plus code preview layout.
 const IMPORT_DATA_DIALOG_WIDTH = 800;
 
+// The width of the Import Data dialog in the empty state, which holds a single line of text instead
+// of the sidebar and code preview.
+const IMPORT_DATA_DIALOG_EMPTY_WIDTH = 450;
+
 /**
  * Options for showing the Import Data dialog.
  */
@@ -267,6 +271,7 @@ export const ImportDataModalDialog = (props: ImportDataModalDialogProps) => {
 	// state, a generation still in flight, and an importer that declined or threw.
 	const code = result?.code ?? '';
 	const canRun = code.length > 0;
+	const isEmpty = props.importers.length === 0;
 
 	// The importers are packages (the install unit in both R and Python) so "Package" is
 	// correct for every language.
@@ -276,7 +281,7 @@ export const ImportDataModalDialog = (props: ImportDataModalDialogProps) => {
 		<PositronDynamicModalDialog
 			content={
 				<div className='import-data'>
-					{props.importers.length === 0
+					{isEmpty
 						? <div className='empty-state'>
 							{localize(
 								'positron.importData.noImporters',
@@ -368,7 +373,7 @@ export const ImportDataModalDialog = (props: ImportDataModalDialogProps) => {
 			}
 			renderer={props.renderer}
 			title={localize('positron.importData.title', "Import {0}", fileName)}
-			width={IMPORT_DATA_DIALOG_WIDTH}
+			width={isEmpty ? IMPORT_DATA_DIALOG_EMPTY_WIDTH : IMPORT_DATA_DIALOG_WIDTH}
 			onCancel={cancelHandler}
 		/>
 	);

--- a/src/vs/workbench/browser/positronModalDialogs/test/browser/importDataModalDialog.vitest.tsx
+++ b/src/vs/workbench/browser/positronModalDialogs/test/browser/importDataModalDialog.vitest.tsx
@@ -325,6 +325,18 @@ describe('ImportDataModalDialog', () => {
 		expect(screen.getByRole('button', { name: 'Import' })).toBeDisabled();
 	});
 
+	it('narrows the dialog for the empty state', () => {
+		renderDialog([]);
+
+		expect(screen.getByRole('dialog')).toHaveStyle({ width: '450px' });
+	});
+
+	it('keeps the dialog wide when an importer can read the file', () => {
+		renderDialog([createImporter()]);
+
+		expect(screen.getByRole('dialog')).toHaveStyle({ width: '800px' });
+	});
+
 	it('warns about anything the importer could not translate', async () => {
 		renderDialog([createImporter({
 			generateCode: async () => ({ code: 'x = 1\n', unsupported: ['Filter on column "dep_delay"'] }),


### PR DESCRIPTION
Fixes #15836.

The Import Data dialog now opens at 450px when no extension can import the file, and keeps 800px otherwise.

### Screenshots


https://github.com/user-attachments/assets/05f79844-a50c-47e3-8ac6-6ea49cb4d451



### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:data-explorer

A gzipped CSV reaches the empty state. The Data Explorer opens it, because DuckDB decompresses it transparently, but the importers only claim `csv` and `tsv`, so nothing matches the `gz` extension.

1. Compress a CSV: `gzip -k flights.csv`, which leaves `flights.csv.gz` next to it.
2. Open `flights.csv.gz`. The Data Explorer shows the data as usual.
3. Press Import Data. The dialog is narrow and reads "No extension can generate code to import this file."
4. Open `flights.csv` and press Import Data. The wide layout is back, with the package list and the code preview.
